### PR TITLE
fix(ui): restore page.tsx after bad merge, remove stale field refs, add UI build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,18 @@ jobs:
 
       - name: build
         run: cargo build --release
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: ui/package-lock.json
+
+      - name: UI install
+        run: npm ci
+        working-directory: ui
+
+      - name: UI build
+        run: npm run build
+        working-directory: ui

--- a/services/.env.example
+++ b/services/.env.example
@@ -29,6 +29,15 @@ OLLAMA_API_KEY=
 # HERMES_BASE_URL=http://localhost:1234/v1
 
 # ──────────────────────────────────────────────────────────────────────────────
+# Observability (OpenObserve OTLP exporter)
+# ──────────────────────────────────────────────────────────────────────────────
+# Base64-encoded "user:password" for the OpenObserve OTLP endpoint.
+# Required by install-tagger-daemon.sh — launchd must inject this directly
+# because observability.py initialises the exporter before dotenv is loaded.
+# Generate with: echo -n "user@example.com:password" | base64
+MERIDIAN_OO_AUTH=
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Jira (used by the Jira Keeper agent only — leave empty to skip Jira sync)
 # ──────────────────────────────────────────────────────────────────────────────
 # Atlassian Cloud URL, e.g. https://yourorg.atlassian.net

--- a/services/scripts/com.meridiona.tagger-daemon.plist
+++ b/services/scripts/com.meridiona.tagger-daemon.plist
@@ -51,9 +51,12 @@
         <string>1</string>
         <key>STAGE3_ENABLED</key>
         <string>1</string>
-        <!-- Stage 3 (LLM) credentials are read from .env files inside config.py;
-             the launchd context still loads them since we set MERIDIAN_HOME and
-             agents/config.py walks ~/.hermes/.env automatically. -->
+        <!-- OTLP auth for OpenObserve — must be set here (not just .env) because
+             observability.py initialises the exporter before config.py loads dotenv.
+             The install script reads MERIDIAN_OO_AUTH from services/.env and
+             substitutes the {{MERIDIAN_OO_AUTH}} placeholder below. -->
+        <key>MERIDIAN_OO_AUTH</key>
+        <string>{{MERIDIAN_OO_AUTH}}</string>
     </dict>
 
     <key>StandardOutPath</key>

--- a/services/scripts/install-tagger-daemon.sh
+++ b/services/scripts/install-tagger-daemon.sh
@@ -35,10 +35,24 @@ fi
 mkdir -p "${HOME}/.meridian/logs"
 mkdir -p "${LAUNCH_AGENTS}"
 
+# Read MERIDIAN_OO_AUTH from services/.env (required — observability.py
+# initialises before dotenv is loaded, so launchd must inject it directly).
+ENV_FILE="${SERVICES_DIR}/.env"
+MERIDIAN_OO_AUTH=""
+if [[ -f "${ENV_FILE}" ]]; then
+    MERIDIAN_OO_AUTH="$(grep -E '^MERIDIAN_OO_AUTH=' "${ENV_FILE}" | cut -d= -f2- | tr -d '[:space:]')"
+fi
+if [[ -z "${MERIDIAN_OO_AUTH}" ]]; then
+    echo "✗ MERIDIAN_OO_AUTH not found in ${ENV_FILE}" >&2
+    echo "  Add:  MERIDIAN_OO_AUTH=<base64-encoded user:password>" >&2
+    exit 1
+fi
+
 echo "→ writing ${PLIST_DEST}"
 sed \
     -e "s|{{REPO_ROOT}}|${REPO_ROOT}|g" \
     -e "s|{{HOME}}|${HOME}|g" \
+    -e "s|{{MERIDIAN_OO_AUTH}}|${MERIDIAN_OO_AUTH}|g" \
     "${TEMPLATE}" > "${PLIST_DEST}"
 
 # Validate the plist before loading.

--- a/ui/app/api/active/route.ts
+++ b/ui/app/api/active/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: Request) {
       const db = getDb()
       const row = db.prepare(`
         SELECT app_name, started_at, last_seen_at,
-               window_titles, ocr_samples, audio_snippets, signals, frame_count,
+               window_titles, audio_snippets, signals, frame_count,
                category, confidence
         FROM active_session WHERE id = 1
       `).get() as Record<string, unknown> | undefined
@@ -30,7 +30,6 @@ export async function GET(request: Request) {
         started_at: row.started_at as string,
         last_seen_at: row.last_seen_at as string,
         window_titles: JSON.parse((row.window_titles as string) || '[]'),
-        ocr_samples: row.ocr_samples ? JSON.parse(row.ocr_samples as string) : null,
         audio_snippets: row.audio_snippets ? JSON.parse(row.audio_snippets as string) : null,
         signals: row.signals ? JSON.parse(row.signals as string) : null,
         frame_count: row.frame_count as number,

--- a/ui/app/api/sessions/[id]/route.ts
+++ b/ui/app/api/sessions/[id]/route.ts
@@ -41,8 +41,6 @@ function parseRow(r: Record<string, unknown>): SessionRow {
     ended_at: r.ended_at as string,
     duration_s: r.duration_s as number,
     window_titles: JSON.parse((r.window_titles as string) || '[]'),
-    ocr_samples: r.ocr_samples ? JSON.parse(r.ocr_samples as string) : null,
-    elements_samples: r.elements_samples ? JSON.parse(r.elements_samples as string) : null,
     audio_snippets: r.audio_snippets ? JSON.parse(r.audio_snippets as string) : null,
     signals: r.signals ? JSON.parse(r.signals as string) : null,
     frame_count: r.frame_count as number,
@@ -75,8 +73,7 @@ export async function GET(
 
     const sessionRow = db.prepare(`
       SELECT s.id, s.app_name, s.started_at, s.ended_at, s.duration_s,
-             s.window_titles, s.ocr_samples, s.elements_samples,
-             s.audio_snippets, s.signals, s.frame_count, s.etl_run_id,
+             s.window_titles, s.audio_snippets, s.signals, s.frame_count, s.etl_run_id,
              s.category, s.confidence,
              tl.task_key       AS task_key,
              tl.session_type   AS session_type,

--- a/ui/app/api/sessions/route.ts
+++ b/ui/app/api/sessions/route.ts
@@ -73,8 +73,7 @@ export async function GET(request: Request) {
     // a session-only query in the catch below.
     const rows = db.prepare(`
       SELECT s.id, s.app_name, s.started_at, s.ended_at, s.duration_s,
-             s.window_titles, s.ocr_samples, s.elements_samples,
-             s.audio_snippets, s.signals, s.frame_count, s.etl_run_id,
+             s.window_titles, s.audio_snippets, s.signals, s.frame_count, s.etl_run_id,
              s.category, s.confidence,
              tl.task_key       AS task_key,
              tl.session_type   AS session_type,

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -1,19 +1,11 @@
 // meridian — normalises screenpipe activity into structured app sessions
 'use client'
 
-import getDb from '@/lib/db'
-import { localDayBounds, todayString } from '@/lib/date-utils'
-import { formatDateLabel } from '@/lib/format'
-import ActiveSessionCard from '@/components/ActiveSessionCard'
-import DayTimeline from '@/components/DayTimeline'
-import StatsRow from '@/components/StatsRow'
-import SessionCard from '@/components/SessionCard'
-import RefreshTrigger from '@/components/RefreshTrigger'
-import CategoryBreakdown from '@/components/CategoryBreakdown'
-import TicketBreakdown from '@/components/TicketBreakdown'
-import type {
-  ActiveSessionRow, StatsResponse, TimelineResponse, SessionRow, GapRow
-} from '@/lib/types'
+import { useEffect, useState, useCallback } from 'react'
+import dynamic from 'next/dynamic'
+import Sidebar from '@/components/Sidebar'
+import CommandBar from '@/components/CommandBar'
+import TweaksPanel from '@/components/TweaksPanel'
 
 // Lazy-load heavy views
 const TodayView    = dynamic(() => import('@/components/views/TodayView'),    { ssr: false })
@@ -22,93 +14,7 @@ const QueueView    = dynamic(() => import('@/components/views/QueueView'),    { 
 const SessionsView = dynamic(() => import('@/components/views/SessionsView'), { ssr: false })
 const WeekView     = dynamic(() => import('@/components/views/WeekView'),     { ssr: false })
 
-function parseSession(r: Record<string, unknown>): SessionRow {
-  return {
-    id: r.id as number,
-    app_name: r.app_name as string,
-    started_at: r.started_at as string,
-    ended_at: r.ended_at as string,
-    duration_s: r.duration_s as number,
-    window_titles: JSON.parse((r.window_titles as string) || '[]'),
-    audio_snippets: r.audio_snippets ? JSON.parse(r.audio_snippets as string) : null,
-    signals: r.signals ? JSON.parse(r.signals as string) : null,
-    frame_count: r.frame_count as number,
-    etl_run_id: r.etl_run_id as number,
-    category: (r.category as string) || 'idle_personal',
-    confidence: (r.confidence as number) || 0,
-    task_key:        (r.task_key as string | null) ?? null,
-    task_title:      (r.task_title as string | null) ?? null,
-    task_url:        (r.task_url as string | null) ?? null,
-    task_provider:   (r.task_provider as string | null) ?? null,
-    session_type:    (r.session_type as string | null) ?? null,
-    routing:         (r.routing as string | null) ?? null,
-    link_confidence: (r.link_confidence as number | null) ?? null,
-    link_method:     (r.link_method as string | null) ?? null,
-  }
-}
-
-function getActiveSession(): ActiveSessionRow | null {
-  try {
-    const db = getDb()
-    const row = db.prepare(`
-      SELECT app_name, started_at, last_seen_at,
-             window_titles, audio_snippets, frame_count,
-             category, confidence
-      FROM active_session WHERE id = 1
-    `).get() as Record<string, unknown> | undefined
-    if (!row) return null
-    return {
-      app_name: row.app_name as string,
-      started_at: row.started_at as string,
-      last_seen_at: row.last_seen_at as string,
-      window_titles: JSON.parse((row.window_titles as string) || '[]'),
-      audio_snippets: row.audio_snippets ? JSON.parse(row.audio_snippets as string) : null,
-      signals: null,
-      frame_count: row.frame_count as number,
-      elapsed_s: Math.floor((Date.now() - new Date(row.started_at as string).getTime()) / 1000),
-      category: (row.category as string) || 'idle_personal',
-      confidence: (row.confidence as number) || 0,
-    }
-  } catch { return null }
-}
-
-function getStats(date: string): StatsResponse {
-  const empty: StatsResponse = { date, focus_s: 0, user_idle_s: 0, away_s: 0, session_count: 0, top_apps: [], category_breakdown: [] }
-  try {
-    const db = getDb()
-    const { start, end } = localDayBounds(date)
-    const t = db.prepare(`
-      SELECT
-        SUM(duration_s) AS focus_s,
-        COUNT(*) AS session_count
-      FROM app_sessions WHERE started_at >= ? AND started_at < ?
-    `).get(start, end) as { focus_s: number | null; session_count: number }
-    const topApps = db.prepare(`
-      SELECT app_name, SUM(duration_s) AS duration_s, COUNT(*) AS session_count
-      FROM app_sessions WHERE started_at >= ? AND started_at < ?
-      GROUP BY app_name ORDER BY duration_s DESC LIMIT 8
-    `).all(start, end) as StatsResponse['top_apps']
-    let user_idle_s = 0
-    let away_s = 0
-    try {
-      const gapStats = db.prepare(`
-        SELECT
-          SUM(CASE WHEN kind = 'user_idle'    THEN duration_s ELSE 0 END) AS user_idle_s,
-          SUM(CASE WHEN kind = 'system_sleep' THEN duration_s ELSE 0 END) AS away_s
-        FROM gaps
-        WHERE started_at >= ? AND started_at < ?
-      `).get(start, end) as { user_idle_s: number | null; away_s: number | null } | null
-      user_idle_s = gapStats?.user_idle_s ?? 0
-      away_s = gapStats?.away_s ?? 0
-    } catch { /* gaps table not yet created by ETL */ }
-    const categoryBreakdown = db.prepare(`
-      SELECT category, SUM(duration_s) AS duration_s
-      FROM app_sessions WHERE started_at >= ? AND started_at < ?
-      GROUP BY category ORDER BY duration_s DESC
-    `).all(start, end) as StatsResponse['category_breakdown']
-    return { date, focus_s: t.focus_s ?? 0, user_idle_s, away_s, session_count: t.session_count, top_apps: topApps, category_breakdown: categoryBreakdown }
-  } catch { return empty }
-}
+type View = 'today' | 'tasks' | 'queue' | 'sessions' | 'week'
 
 export default function DashboardPage() {
   const [view, setView] = useState<View>('today')
@@ -151,156 +57,34 @@ export default function DashboardPage() {
     return () => window.removeEventListener('keydown', onKey)
   }, [cmdOpen, navigate])
 
-interface TicketsBundle {
-  tasks: Array<{
-    task_key: string
-    title: string | null
-    url: string | null
-    provider: string | null
-    duration_s: number
-    session_count: number
-  }>
-  overhead_s: number
-  untagged_s: number
-}
-
-function getTickets(date: string): TicketsBundle {
-  try {
-    const db = getDb()
-    const { start, end } = localDayBounds(date)
-    const tasks = db.prepare(`
-      SELECT tl.task_key                                AS task_key,
-             pt.title                                   AS title,
-             pt.url                                     AS url,
-             pt.provider                                AS provider,
-             SUM(s.duration_s)                          AS duration_s,
-             COUNT(*)                                   AS session_count
-        FROM app_sessions s
-        JOIN ticket_links tl ON tl.session_id = s.id AND tl.session_type = 'task'
-        LEFT JOIN pm_tasks pt ON pt.task_key  = tl.task_key
-       WHERE s.started_at >= ? AND s.started_at < ?
-         AND tl.task_key IS NOT NULL
-       GROUP BY tl.task_key
-       ORDER BY duration_s DESC
-    `).all(start, end) as Array<Record<string, unknown>>
-
-    const overhead = (db.prepare(`
-      SELECT COALESCE(SUM(s.duration_s), 0) AS s
-        FROM app_sessions s
-        JOIN ticket_links tl ON tl.session_id = s.id
-       WHERE s.started_at >= ? AND s.started_at < ?
-         AND tl.session_type = 'overhead'
-    `).get(start, end) as { s: number }).s
-
-    const untagged = (db.prepare(`
-      SELECT COALESCE(SUM(s.duration_s), 0) AS s
-        FROM app_sessions s
-        LEFT JOIN ticket_links tl ON tl.session_id = s.id
-       WHERE s.started_at >= ? AND s.started_at < ?
-         AND tl.session_id IS NULL
-    `).get(start, end) as { s: number }).s
-
-    return {
-      tasks: tasks.map(r => ({
-        task_key: r.task_key as string,
-        title: (r.title as string | null) ?? null,
-        url:   (r.url as string | null) ?? null,
-        provider: (r.provider as string | null) ?? null,
-        duration_s: Number(r.duration_s ?? 0),
-        session_count: Number(r.session_count ?? 0),
-      })),
-      overhead_s: Number(overhead ?? 0),
-      untagged_s: Number(untagged ?? 0),
-    }
-  } catch {
-    return { tasks: [], overhead_s: 0, untagged_s: 0 }
-  }
-}
-
-function getRecentSessions(date: string): SessionRow[] {
-  try {
-    const db = getDb()
-    const { start, end } = localDayBounds(date)
-    const rows = db.prepare(`
-      SELECT s.id, s.app_name, s.started_at, s.ended_at, s.duration_s,
-             s.window_titles, s.ocr_samples, s.elements_samples,
-             s.audio_snippets, s.signals, s.frame_count, s.etl_run_id,
-             s.category, s.confidence,
-             tl.task_key       AS task_key,
-             tl.session_type   AS session_type,
-             tl.routing        AS routing,
-             tl.confidence     AS link_confidence,
-             tl.method         AS link_method,
-             pt.title          AS task_title,
-             pt.url            AS task_url,
-             pt.provider       AS task_provider
-        FROM app_sessions s
-        LEFT JOIN ticket_links tl ON tl.session_id = s.id
-        LEFT JOIN pm_tasks    pt ON pt.task_key   = tl.task_key
-       WHERE s.started_at >= ? AND s.started_at < ?
-       ORDER BY s.started_at DESC LIMIT 8
-    `).all(start, end) as Array<Record<string, unknown>>
-    return rows.map(parseSession)
-  } catch { return [] }
-}
-
-export default function DashboardPage() {
-  const today = todayString()
-  const active = getActiveSession()
-  const stats = getStats(today)
-  const timeline = getTimeline(today)
-  const recent = getRecentSessions(today)
-  const tickets = getTickets(today)
+  const todayDate = new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })
 
   return (
-    <div className="space-y-6">
-      <RefreshTrigger intervalMs={30_000} />
+    <div className="min-h-screen flex" style={{ background: 'var(--paper)' }}>
+      <Sidebar
+        view={view}
+        onNavigate={navigate}
+        onOpenCmd={() => setCmdOpen(true)}
+        queueCount={queueCount}
+      />
 
-      {/* Header */}
-      <div className="flex items-baseline justify-between">
-        <h1 className="text-2xl font-semibold tracking-tight">{formatDateLabel(today)}</h1>
-        {stats.session_count > 0 && (
-          <span className="text-sm text-[#9B9A97]">{stats.session_count} sessions</span>
-        )}
-      </div>
+      <main className="flex-1 min-w-0" data-screen-label={view}>
+        <div className="max-w-[1080px] mx-auto px-10 py-14">
+          {view === 'today'    && <TodayView    onNavigate={(v, k) => navigate(v as View, k)} />}
+          {view === 'tasks'    && <TasksView    focusKey={focusKey} />}
+          {view === 'queue'    && <QueueView    />}
+          {view === 'sessions' && <SessionsView />}
+          {view === 'week'     && <WeekView     />}
 
-      {/* Active session */}
-      <ActiveSessionCard session={active} />
-
-      {/* Day timeline */}
-      {timeline.sessions.length > 0 && (
-        <section>
-          <p className="text-[10px] uppercase tracking-widest text-[#C8C6C1] mb-3">Timeline</p>
-          <DayTimeline data={timeline} activeSession={active} />
-        </section>
-      )}
-
-      {/* Stats */}
-      {stats.session_count > 0 && <StatsRow stats={stats} />}
-
-      {/* Today's tickets */}
-      {(tickets.tasks.length > 0 || tickets.overhead_s > 0 || tickets.untagged_s > 0) && (
-        <section>
-          <p className="text-[10px] uppercase tracking-widest text-[#C8C6C1] mb-3">Today&rsquo;s Tickets</p>
-          <div className="rounded-2xl border border-[#E8E6E1] bg-white p-5">
-            <TicketBreakdown
-              tasks={tickets.tasks}
-              overhead_s={tickets.overhead_s}
-              untagged_s={tickets.untagged_s}
-            />
-          </div>
-        </section>
-      )}
-
-      {/* Category breakdown */}
-      {stats.category_breakdown && stats.category_breakdown.length > 0 && (
-        <section>
-          <p className="text-[10px] uppercase tracking-widest text-[#C8C6C1] mb-3">By Category</p>
-          <div className="rounded-2xl border border-[#E8E6E1] bg-white p-5">
-            <CategoryBreakdown stats={stats.category_breakdown} />
-          </div>
-        </section>
-      )}
+          <footer className="mt-24 pt-8 rule-t flex items-center justify-between text-[11px]"
+            style={{ borderTopColor: 'var(--rule)', color: 'var(--ink-4)' }}>
+            <span>Meridian · local · {todayDate}</span>
+            <span className="font-mono tnum">
+              <span className="kbd">⌘</span> <span className="kbd">K</span> to jump · <span className="kbd">1</span>–<span className="kbd">5</span> to switch view
+            </span>
+          </footer>
+        </div>
+      </main>
 
       {cmdOpen && (
         <CommandBar

--- a/ui/app/sessions/[id]/page.tsx
+++ b/ui/app/sessions/[id]/page.tsx
@@ -47,8 +47,6 @@ function parseRow(r: Record<string, unknown>): SessionRow {
     ended_at: r.ended_at as string,
     duration_s: r.duration_s as number,
     window_titles: JSON.parse((r.window_titles as string) || '[]'),
-    ocr_samples: r.ocr_samples ? JSON.parse(r.ocr_samples as string) : null,
-    elements_samples: r.elements_samples ? JSON.parse(r.elements_samples as string) : null,
     audio_snippets: r.audio_snippets ? JSON.parse(r.audio_snippets as string) : null,
     signals: r.signals ? JSON.parse(r.signals as string) : null,
     frame_count: r.frame_count as number,
@@ -71,8 +69,7 @@ function loadSession(id: number): PageData | null {
     const db = getDb()
     const sessionRow = db.prepare(`
       SELECT s.id, s.app_name, s.started_at, s.ended_at, s.duration_s,
-             s.window_titles, s.ocr_samples, s.elements_samples,
-             s.audio_snippets, s.signals, s.frame_count, s.etl_run_id,
+             s.window_titles, s.audio_snippets, s.signals, s.frame_count, s.etl_run_id,
              s.category, s.confidence,
              tl.task_key       AS task_key,
              tl.session_type   AS session_type,
@@ -295,23 +292,6 @@ export default async function SessionDetailPage({
                 </li>
               ))}
             </ul>
-          </div>
-        </section>
-      )}
-
-      {/* OCR */}
-      {session.ocr_samples && session.ocr_samples.length > 0 && (
-        <section>
-          <p className="text-[10px] uppercase tracking-widest text-[#C8C6C1] mb-3">Screen Text</p>
-          <div className="rounded-2xl border border-[#E8E6E1] bg-white p-5 space-y-3">
-            {session.ocr_samples.slice(0, 20).map((o, i) => (
-              <div key={i} className="text-xs">
-                {o.window_name && (
-                  <p className="text-[10px] text-[#C8C6C1] mb-0.5">· {o.window_name}</p>
-                )}
-                <p className="text-[#6B6A67] leading-relaxed line-clamp-4 whitespace-pre-wrap">{o.text}</p>
-              </div>
-            ))}
           </div>
         </section>
       )}


### PR DESCRIPTION
## Summary

- **Broken `app/page.tsx`** — a bad merge left the file with two `export default function DashboardPage()` declarations: the old server-rendered dashboard was concatenated after the new client-side navigation shell, causing a Turbopack parse error (`'export' cannot be used outside of module code`). Restored the correct navigation shell version.
- **Stale `ocr_samples` / `elements_samples` refs** — these fields were removed from `SessionRow` and `ActiveSessionRow` types in a prior cleanup commit, but four files still referenced them causing TypeScript type errors: `api/active/route.ts`, `api/sessions/route.ts`, `api/sessions/[id]/route.ts`, and `app/sessions/[id]/page.tsx`.
- **UI build in CI** — added `npm ci` + `npm run build` steps to `.github/workflows/ci.yml` so build failures are caught before merge.
- **Credential in plist** — `MERIDIAN_OO_AUTH` was hardcoded in `com.meridiona.tagger-daemon.plist` (a tracked file). Replaced with a `{{MERIDIAN_OO_AUTH}}` placeholder following the existing `{{HOME}}`/`{{REPO_ROOT}}` pattern; `install-tagger-daemon.sh` now reads the value from `services/.env` at install time and fails loudly if missing. Documented in `services/.env.example`.

## Test plan

- [x] `npm run build` in `ui/` passes with no type errors
- [x] Dashboard loads and view switching (Today / Tasks / Queue / Sessions / Week) works
- [x] `./services/scripts/install-tagger-daemon.sh` installs the daemon correctly with `MERIDIAN_OO_AUTH` injected from `.env`
- [ ] CI workflow runs `npm run build` on push/PR to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)