### PR TITLE
feat(KAN-108): Jira update agent — slot-based progress comments from Meridian activity

### DIFF
--- a/packages/meridian-mcp/src/index.ts
+++ b/packages/meridian-mcp/src/index.ts
@@ -723,14 +723,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
 
         // Fetch all dimension tags for these sessions in one query
-        const sessionIds = rows.map(r => r.id);
-        const placeholders = sessionIds.map(() => "?").join(",");
         const dimRows = dbAll(db, `
-          SELECT session_id, dimension, value, confidence
-          FROM session_dimensions
-          WHERE session_id IN (${placeholders})
-          ORDER BY session_id, confidence DESC
-        `, sessionIds as SqlVal[]) as Array<{
+          SELECT sd.session_id, sd.dimension, sd.value, sd.confidence
+          FROM session_dimensions sd
+          WHERE sd.session_id IN (
+            SELECT s.id
+            FROM app_sessions s
+            JOIN ticket_links tl ON s.id = tl.session_id
+            WHERE tl.task_key = ? AND ${tw.cond}
+          )
+          ORDER BY sd.session_id, sd.confidence DESC
+        `, [taskKey, ...tw.params] as SqlVal[]) as Array<{
           session_id: number; dimension: string; value: string; confidence: number;
         }>;
 
@@ -972,6 +975,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           topTitle ? `Window: ${topTitle}` : "",
           "",
         ].filter(l => l !== "");
+
+        if (elapsed > 120) {
+          lines.push(`⚠ Session data is ${Math.round(elapsed / 60)}min old — Meridian daemon may not be running`);
+        }
 
         const taskKey = ctx?.jira_key ?? recent?.task_key ?? null;
 

--- a/packages/meridian-mcp/src/index.ts
+++ b/packages/meridian-mcp/src/index.ts
@@ -89,6 +89,63 @@ function parseJsonColumn<T>(val: string | null | undefined): T | null {
   try { return JSON.parse(val) as T; } catch { return null; }
 }
 
+interface TimeWindow {
+  fromTs: string;
+  untilTs: string | null;
+  cond: string;       // s.started_at-qualified, for queries with a JOIN alias
+  plainCond: string;  // unqualified, for single-table queries
+  params: SqlVal[];
+  label: string;
+}
+
+// Priority order: from_time/to_time > since_hours > date (defaults to today)
+function buildTimeWindow({ sinceHours, date, fromTime, toTime }: {
+  sinceHours?: number;
+  date?: string;
+  fromTime?: string;  // ISO 8601 UTC — exact window start
+  toTime?: string;    // ISO 8601 UTC — exact window end (optional)
+}): TimeWindow {
+  if (fromTime) {
+    const fromTs = new Date(fromTime).toISOString();
+    const toTs = toTime ? new Date(toTime).toISOString() : null;
+    const label = toTs
+      ? `${fromTs.slice(0, 16).replace("T", " ")}–${toTs.slice(11, 16)} UTC`
+      : `from ${fromTs.slice(0, 16).replace("T", " ")} UTC`;
+    return {
+      fromTs, untilTs: toTs,
+      cond: toTs ? "s.started_at >= ? AND s.started_at < ?" : "s.started_at >= ?",
+      plainCond: toTs ? "started_at >= ? AND started_at < ?" : "started_at >= ?",
+      params: toTs ? [fromTs, toTs] : [fromTs],
+      label,
+    };
+  }
+  if (sinceHours != null) {
+    const h = Math.min(168, Math.max(0.5, sinceHours));
+    const fromTs = new Date(Date.now() - h * 3600 * 1000).toISOString();
+    return {
+      fromTs, untilTs: null,
+      cond: "s.started_at >= ?",
+      plainCond: "started_at >= ?",
+      params: [fromTs],
+      label: `last ${h}h`,
+    };
+  }
+  const d = date ?? todayString();
+  const { start, end } = localDayBounds(d);
+  return {
+    fromTs: start, untilTs: end,
+    cond: "s.started_at >= ? AND s.started_at < ?",
+    plainCond: "started_at >= ? AND started_at < ?",
+    params: [start, end],
+    label: d,
+  };
+}
+
+function fmtDuration(seconds: number): string {
+  const m = Math.round(seconds / 60);
+  return m >= 60 ? `${Math.floor(m / 60)}h ${m % 60}m` : `${m}m`;
+}
+
 const PKG_VERSION = "1.0.0";
 
 const server = new Server(
@@ -197,6 +254,75 @@ const TOOLS: Tool[] = [
     },
   },
   {
+    name: "get-task-sessions",
+    description:
+      "Get all sessions linked to a specific Jira task key by the AI tagger pipeline (via ticket_links). " +
+      "More precise than search-sessions: uses the tagger's semantic + rule-based classification, not just text search. " +
+      "Optionally filter to a recent time window. " +
+      "Use for: 'what did I do on KAN-108 today?', 'show all work on KAN-108 in the last 4 hours', " +
+      "'how long have I spent on this ticket?', 'what was I actually doing on this task?'. " +
+      "Set include_content=true to also return OCR and audio text from each session.",
+    annotations: { title: "Get Task Sessions", readOnlyHint: true, openWorldHint: false, idempotentHint: true },
+    inputSchema: {
+      type: "object",
+      properties: {
+        task_key: { type: "string", description: "Jira task key, e.g. 'KAN-108'." },
+        from_time: { type: "string", description: "Exact window start as ISO 8601 UTC, e.g. '2026-05-13T09:00:00Z'. Takes priority over since_hours and date." },
+        to_time: { type: "string", description: "Exact window end as ISO 8601 UTC, e.g. '2026-05-13T13:00:00Z'. Used with from_time." },
+        since_hours: { type: "number", description: "Return sessions from the last N hours (max 48). Overrides date when set." },
+        date: { type: "string", description: "Limit to a specific date (YYYY-MM-DD). Defaults to today if no other time param is set." },
+        include_content: { type: "boolean", description: "If true, include screen content (OCR + audio text) per session. Default false.", default: false },
+      },
+      required: ["task_key"],
+    },
+  },
+  {
+    name: "get-recent-sessions",
+    description:
+      "Get sessions from the last N hours across all apps, with any linked Jira task shown alongside each session. " +
+      "Unlike get-sessions (which is date-based), this uses a sliding time window. " +
+      "Use for: 'what did I do in the last 2 hours?', 'what was I working on since lunch?', " +
+      "'give me a quick summary of recent activity', 'what task am I currently focused on?'.",
+    annotations: { title: "Get Recent Sessions", readOnlyHint: true, openWorldHint: false, idempotentHint: true },
+    inputSchema: {
+      type: "object",
+      properties: {
+        hours: { type: "number", description: "Look-back window in hours. Default 4. Max 48.", default: 4 },
+        app: { type: "string", description: "Filter by app name (case-sensitive, exact match)." },
+        limit: { type: "integer", description: "Max sessions to return. Default 20.", default: 20 },
+      },
+    },
+  },
+  {
+    name: "get-task-breakdown",
+    description:
+      "For a given date or recent time window, show total time spent grouped by linked Jira task. " +
+      "Includes task title, status, URL, session count, and percentage of total focus time. " +
+      "Use for: 'how much time per ticket today?', 'give me a work breakdown for today', " +
+      "'what tasks did I work on this week?', 'how was my time split across Jira tickets?'. " +
+      "Requires the AI tagger to have linked sessions to tickets (ticket_links table).",
+    annotations: { title: "Get Task Breakdown", readOnlyHint: true, openWorldHint: false, idempotentHint: true },
+    inputSchema: {
+      type: "object",
+      properties: {
+        from_time: { type: "string", description: "Exact window start as ISO 8601 UTC, e.g. '2026-05-13T09:00:00Z'. Takes priority over since_hours and date." },
+        to_time: { type: "string", description: "Exact window end as ISO 8601 UTC, e.g. '2026-05-13T17:00:00Z'. Used with from_time." },
+        date: { type: "string", description: "Date (YYYY-MM-DD). Defaults to today. Ignored if from_time or since_hours is set." },
+        since_hours: { type: "number", description: "Look-back window in hours (max 168 = 1 week). Overrides date when set." },
+      },
+    },
+  },
+  {
+    name: "get-active-task",
+    description:
+      "Get the Jira ticket currently being worked on, combining the active app session with the AI tagger's classification. " +
+      "Checks the tagger's inferred context first, then falls back to the most recently linked session for the same app. " +
+      "Use for: 'what Jira ticket am I working on right now?', 'what is my current task?', 'what should I log time against?'. " +
+      "Returns the active app, elapsed time, task key, title, status, and confidence.",
+    annotations: { title: "Get Active Task", readOnlyHint: true, openWorldHint: false, idempotentHint: true },
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
     name: "health-check",
     description:
       "Check if the Meridian daemon is running and the DB is accessible. " +
@@ -259,7 +385,7 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
         mimeType: "text/markdown",
         text: `# Meridian Usage Guide
 
-Meridian tracks your app usage by reading screenpipe's ambient recordings and normalising them into structured app sessions.
+Meridian tracks your app usage by reading screenpipe's ambient recordings and normalising them into structured app sessions. The AI tagger links sessions to Jira tickets and tags each session with activity/tool/topic dimensions.
 
 ## Tool Selection
 
@@ -269,17 +395,31 @@ Meridian tracks your app usage by reading screenpipe's ambient recordings and no
 | "How productive was I?" | get-stats |
 | "Which apps did I use?" | get-sessions |
 | "What am I doing right now?" | get-active-session |
+| "What did I do in the last 2 hours?" | get-recent-sessions with hours=2 |
+| "What did I work on per Jira ticket today?" | get-task-breakdown |
+| "What did I do on KAN-108?" | get-task-sessions with task_key=KAN-108 |
+| "What Jira ticket am I working on right now?" | get-active-task |
 | "When did I work on X?" | search-sessions with q=X |
 | "Full content of a session?" | get-session-detail with id |
 | "All-time app usage?" | get-apps |
 
+## Task-linked tools (require the AI tagger to be running)
+
+- **get-active-task** — current app + the Jira ticket the tagger infers you're working on. Falls back to the most recently linked session for the same app. Best for "what should I be logging time to right now?".
+- **get-task-sessions** — sessions for a specific Jira ticket key via the tagger's ticket_links classification (more accurate than text search). Supports exact time windows via from_time/to_time or a sliding hour window. Set include_content=true for OCR/audio text. Includes AI dimension tags (activity, tool, topic, intent) per session.
+- **get-recent-sessions** — last N hours of sessions with any linked Jira task shown alongside. Best for "what have I been doing lately?".
+- **get-task-breakdown** — time per Jira ticket for a date or exact time window, with percentages of total focus time. Best for standups and Jira progress updates. Supports from_time/to_time for precise slot queries.
+
 ## Tips
 
 - **Dates** are local calendar dates (YYYY-MM-DD). Today is the default when omitted.
+- **from_time / to_time** on get-task-sessions and get-task-breakdown accept ISO 8601 UTC timestamps for exact slot queries (e.g. "2026-05-13T09:00:00Z" to "2026-05-13T13:00:00Z"). Takes priority over since_hours and date.
+- **since_hours** on get-task-sessions, get-recent-sessions, and get-task-breakdown uses a sliding window from now — good for "last N hours" without caring about exact clock time.
 - **App names** are case-sensitive exact strings — use values from session results (e.g. "code.visualstudio.com").
-- **search-sessions** searches window titles, OCR screen text, and audio transcriptions.
+- **search-sessions** searches window titles, OCR screen text, and audio transcriptions — useful when you don't know the ticket key.
+- **get-task-sessions** uses the tagger's ticket_links table (semantic + rule-based) — prefer it over search-sessions when you know the ticket key.
 - **get-timeline** includes idle and sleep gaps for a full picture of the day.
-- **get-session-detail** returns the full OCR text, audio, and accessibility content for a session.
+- **get-session-detail** returns the full OCR text, audio, and accessibility content for a single session.
 - The Meridian daemon runs every 60 seconds — data may be up to 60s stale.
 `,
       }],
@@ -538,6 +678,327 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         });
 
         return { content: [{ type: "text", text: `Found ${rows.length} session(s) matching "${q}":\n\n${formatted.join("\n---\n")}` }] };
+      }
+
+      case "get-task-sessions": {
+        const taskKey = args?.task_key as string;
+        if (!taskKey) {
+          return { content: [{ type: "text", text: "Error: task_key is required" }] };
+        }
+        const tw = buildTimeWindow({
+          fromTime: args?.from_time as string | undefined,
+          toTime: args?.to_time as string | undefined,
+          sinceHours: args?.since_hours as number | undefined,
+          date: args?.date as string | undefined,
+        });
+        const includeContent = (args?.include_content as boolean) ?? false;
+
+        const taskMeta = dbGet(db, `
+          SELECT title, url, status FROM pm_tasks WHERE task_key = ?
+        `, [taskKey]) as { title: string; url: string; status: string } | undefined;
+
+        const rows = dbAll(db, `
+          SELECT
+            s.id, s.app_name, s.started_at, s.ended_at, s.duration_s,
+            s.window_titles, s.session_text,
+            tl.confidence, tl.method, tl.session_type
+          FROM app_sessions s
+          JOIN ticket_links tl ON s.id = tl.session_id
+          WHERE tl.task_key = ? AND ${tw.cond}
+          ORDER BY s.started_at ASC
+        `, [taskKey, ...tw.params]) as Array<{
+          id: number; app_name: string; started_at: string; ended_at: string;
+          duration_s: number; window_titles: string; session_text: string | null;
+          confidence: number; method: string; session_type: string;
+        }>;
+
+        if (rows.length === 0) {
+          return {
+            content: [{
+              type: "text",
+              text: `No sessions linked to ${taskKey} in ${tw.label}.\n` +
+                "(The tagger may not have run yet, or no sessions were matched to this ticket.)",
+            }],
+          };
+        }
+
+        // Fetch all dimension tags for these sessions in one query
+        const sessionIds = rows.map(r => r.id);
+        const placeholders = sessionIds.map(() => "?").join(",");
+        const dimRows = dbAll(db, `
+          SELECT session_id, dimension, value, confidence
+          FROM session_dimensions
+          WHERE session_id IN (${placeholders})
+          ORDER BY session_id, confidence DESC
+        `, sessionIds as SqlVal[]) as Array<{
+          session_id: number; dimension: string; value: string; confidence: number;
+        }>;
+
+        const dimsBySession = new Map<number, Map<string, string[]>>();
+        for (const d of dimRows) {
+          if (!dimsBySession.has(d.session_id)) dimsBySession.set(d.session_id, new Map());
+          const byDim = dimsBySession.get(d.session_id)!;
+          if (!byDim.has(d.dimension)) byDim.set(d.dimension, []);
+          byDim.get(d.dimension)!.push(d.value);
+        }
+
+        const totalS = rows.reduce((sum, r) => sum + r.duration_s, 0);
+
+        const lines: string[] = [
+          `${taskKey}${taskMeta?.title ? ` — ${taskMeta.title}` : ""}`,
+          ...(taskMeta?.status ? [`Status: ${taskMeta.status}`] : []),
+          ...(taskMeta?.url ? [`URL: ${taskMeta.url}`] : []),
+          "",
+          `Sessions in ${tw.label}: ${rows.length} session${rows.length === 1 ? "" : "s"}, ${fmtDuration(totalS)} total`,
+          "",
+        ];
+
+        for (const r of rows) {
+          const durMin = Math.round(r.duration_s / 60);
+          const tStart = r.started_at.slice(11, 16);
+          const tEnd = r.ended_at.slice(11, 16);
+          const conf = r.confidence != null ? ` · confidence: ${(r.confidence as number).toFixed(2)}` : "";
+          const method = r.method ? ` · ${r.method}` : "";
+
+          lines.push(`[#${r.id}] ${r.app_name} | ${tStart}–${tEnd} UTC (${durMin}min)${conf}${method}`);
+
+          const titles = parseJsonColumn<Array<{ window_name: string; count: number }>>(r.window_titles);
+          if (titles?.length) {
+            const top = titles.slice(0, 5).map(t => `${t.window_name} ×${t.count}`).join(", ");
+            lines.push(`  Windows: ${top}`);
+          }
+
+          const byDim = dimsBySession.get(r.id);
+          if (byDim && byDim.size > 0) {
+            const dimStr = Array.from(byDim.entries())
+              .map(([dim, vals]) => `${dim}: ${vals.join(", ")}`)
+              .join(" · ");
+            lines.push(`  Tags: ${dimStr}`);
+          }
+
+          if (includeContent && r.session_text) {
+            const excerpt = r.session_text.slice(0, 1500).replace(/\n/g, "\n  ");
+            lines.push(`  Content: ${excerpt}`);
+            if (r.session_text.length > 1500) {
+              lines.push(`  ... (${r.session_text.length - 1500} more chars)`);
+            }
+          }
+
+          lines.push("");
+        }
+
+        return { content: [{ type: "text", text: lines.join("\n").trimEnd() }] };
+      }
+
+      case "get-recent-sessions": {
+        const hours = Math.min(48, Math.max(0.5, (args?.hours as number) ?? 4));
+        const appFilter = args?.app as string | undefined;
+        const limit = Math.min(50, (args?.limit as number) ?? 20);
+        const sinceTs = new Date(Date.now() - hours * 3600 * 1000).toISOString();
+
+        const appCond = appFilter ? "AND s.app_name = ?" : "";
+        const params: SqlVal[] = [sinceTs];
+        if (appFilter) params.push(appFilter);
+        params.push(limit);
+
+        const rows = dbAll(db, `
+          SELECT
+            s.id, s.app_name, s.started_at, s.ended_at, s.duration_s, s.window_titles,
+            tl.task_key, tl.session_type,
+            pt.title AS task_title
+          FROM app_sessions s
+          LEFT JOIN ticket_links tl ON s.id = tl.session_id
+          LEFT JOIN pm_tasks pt ON tl.task_key = pt.task_key
+          WHERE s.started_at >= ? ${appCond}
+          ORDER BY s.started_at DESC
+          LIMIT ?
+        `, params) as Array<{
+          id: number; app_name: string; started_at: string; ended_at: string;
+          duration_s: number; window_titles: string;
+          task_key: string | null; session_type: string | null; task_title: string | null;
+        }>;
+
+        if (rows.length === 0) {
+          return { content: [{ type: "text", text: `No sessions in the last ${hours}h.` }] };
+        }
+
+        const totalS = rows.reduce((sum, r) => sum + r.duration_s, 0);
+        const lines: string[] = [
+          `Recent sessions (last ${hours}h)${appFilter ? ` · ${appFilter}` : ""}: ${rows.length} session${rows.length === 1 ? "" : "s"}, ${fmtDuration(totalS)} total`,
+          "",
+        ];
+
+        for (const r of rows) {
+          const durMin = Math.round(r.duration_s / 60);
+          const tStart = r.started_at.slice(11, 16);
+          const tEnd = r.ended_at.slice(11, 16);
+
+          let taskTag = "";
+          if (r.task_key && r.session_type !== "overhead") {
+            const title = r.task_title ? `: ${r.task_title.slice(0, 60)}` : "";
+            taskTag = ` → ${r.task_key}${title}`;
+          } else if (r.session_type === "overhead") {
+            taskTag = " → (overhead)";
+          }
+
+          lines.push(`${tStart}–${tEnd} UTC · ${r.app_name} (${durMin}min)${taskTag}`);
+
+          const titles = parseJsonColumn<Array<{ window_name: string; count: number }>>(r.window_titles);
+          if (titles?.length) {
+            const top = titles.slice(0, 3).map(t => t.window_name).filter(Boolean).join(", ");
+            if (top) lines.push(`  Windows: ${top}`);
+          }
+
+          lines.push("");
+        }
+
+        return { content: [{ type: "text", text: lines.join("\n").trimEnd() }] };
+      }
+
+      case "get-task-breakdown": {
+        const tw = buildTimeWindow({
+          fromTime: args?.from_time as string | undefined,
+          toTime: args?.to_time as string | undefined,
+          sinceHours: args?.since_hours as number | undefined,
+          date: args?.date as string | undefined,
+        });
+
+        const taskRows = dbAll(db, `
+          SELECT
+            tl.task_key,
+            pt.title,
+            pt.url,
+            pt.status,
+            SUM(s.duration_s) AS total_s,
+            COUNT(*) AS session_count
+          FROM app_sessions s
+          JOIN ticket_links tl ON s.id = tl.session_id
+          LEFT JOIN pm_tasks pt ON tl.task_key = pt.task_key
+          WHERE tl.task_key IS NOT NULL AND tl.session_type != 'overhead' AND ${tw.cond}
+          GROUP BY tl.task_key, pt.title, pt.url, pt.status
+          ORDER BY total_s DESC
+        `, tw.params) as Array<{
+          task_key: string; title: string | null; url: string | null;
+          status: string | null; total_s: number; session_count: number;
+        }>;
+
+        const overheadRow = dbGet(db, `
+          SELECT COALESCE(SUM(s.duration_s), 0) AS s, COUNT(*) AS n
+          FROM app_sessions s
+          LEFT JOIN ticket_links tl ON s.id = tl.session_id
+          WHERE (tl.task_key IS NULL OR tl.session_type = 'overhead') AND ${tw.cond}
+        `, tw.params) as { s: number; n: number } | undefined;
+
+        const focusRow = dbGet(db, `
+          SELECT COALESCE(SUM(duration_s), 0) AS s FROM app_sessions WHERE ${tw.plainCond}
+        `, tw.params) as { s: number } | undefined;
+
+        const totalS = focusRow?.s ?? 0;
+
+        const lines: string[] = [
+          `Task breakdown — ${tw.label}`,
+          `Total focus time: ${fmtDuration(totalS)}`,
+          "",
+        ];
+
+        if (taskRows.length === 0 && (overheadRow?.s ?? 0) === 0) {
+          lines.push("No sessions found for this period.");
+          return { content: [{ type: "text", text: lines.join("\n") }] };
+        }
+
+        if (taskRows.length === 0) {
+          lines.push("No sessions linked to Jira tickets yet.");
+          lines.push("(Run the tagger daemon to link sessions to tickets.)");
+          lines.push("");
+        }
+
+        for (const r of taskRows) {
+          const pct = totalS > 0 ? Math.round((r.total_s / totalS) * 100) : 0;
+          lines.push(`${r.task_key}${r.title ? ` — ${r.title}` : ""}${r.status ? ` (${r.status})` : ""}`);
+          lines.push(`  ${fmtDuration(r.total_s)} · ${r.session_count} session${r.session_count === 1 ? "" : "s"} · ${pct}% of focus time`);
+          if (r.url) lines.push(`  ${r.url}`);
+          lines.push("");
+        }
+
+        const ovS = overheadRow?.s ?? 0;
+        const ovN = overheadRow?.n ?? 0;
+        if (ovS > 0) {
+          const ovPct = totalS > 0 ? Math.round((ovS / totalS) * 100) : 0;
+          lines.push(`Overhead / untagged: ${fmtDuration(ovS)} · ${ovN} session${ovN === 1 ? "" : "s"} · ${ovPct}% of focus time`);
+        }
+
+        return { content: [{ type: "text", text: lines.join("\n").trimEnd() }] };
+      }
+
+      case "get-active-task": {
+        const active = dbGet(db, `
+          SELECT app_name, started_at, last_seen_at, window_titles, frame_count
+          FROM active_session WHERE id = 1
+        `) as { app_name: string; started_at: string; last_seen_at: string; window_titles: string; frame_count: number } | undefined;
+
+        if (!active) {
+          return { content: [{ type: "text", text: "No active session. The Meridian daemon may not have run recently." }] };
+        }
+
+        // 1. Check tagger's inferred current task (written to activity_context by the tagger daemon)
+        const ctx = dbGet(db, `
+          SELECT jira_key, inferred_task, confidence, updated_at
+          FROM activity_context WHERE id = 1
+        `) as { jira_key: string | null; inferred_task: string | null; confidence: number; updated_at: string } | undefined;
+
+        // 2. Fallback: most recently linked completed session for the same app
+        const recent = dbGet(db, `
+          SELECT tl.task_key, tl.confidence, tl.method,
+                 pt.title, pt.url, pt.status,
+                 s.ended_at
+          FROM app_sessions s
+          JOIN ticket_links tl ON s.id = tl.session_id
+          LEFT JOIN pm_tasks pt ON tl.task_key = pt.task_key
+          WHERE s.app_name = ? AND tl.task_key IS NOT NULL AND tl.session_type != 'overhead'
+          ORDER BY s.ended_at DESC
+          LIMIT 1
+        `, [active.app_name]) as {
+          task_key: string; confidence: number; method: string;
+          title: string | null; url: string | null; status: string | null; ended_at: string;
+        } | undefined;
+
+        const elapsed = Math.round((Date.now() - new Date(active.last_seen_at).getTime()) / 1000);
+        const durationSoFar = Math.round((Date.now() - new Date(active.started_at).getTime()) / 1000 / 60);
+        const titles = parseJsonColumn<Array<{ window_name: string }>>(active.window_titles);
+        const topTitle = titles?.[0]?.window_name ?? "";
+
+        const lines: string[] = [
+          `Active: ${active.app_name} (${durationSoFar}min so far, last seen ${elapsed}s ago)`,
+          topTitle ? `Window: ${topTitle}` : "",
+          "",
+        ].filter(l => l !== "");
+
+        const taskKey = ctx?.jira_key ?? recent?.task_key ?? null;
+
+        if (taskKey) {
+          const meta = dbGet(db, `
+            SELECT title, url, status FROM pm_tasks WHERE task_key = ?
+          `, [taskKey]) as { title: string; url: string; status: string } | undefined;
+
+          const fromCtx = !!ctx?.jira_key;
+          const confidence = fromCtx ? ctx!.confidence : recent?.confidence;
+          const title = meta?.title ?? (fromCtx ? ctx?.inferred_task : recent?.title) ?? null;
+
+          lines.push(`Current task: ${taskKey}${title ? ` — ${title}` : ""}`);
+          if (meta?.status ?? recent?.status) lines.push(`Status: ${meta?.status ?? recent?.status}`);
+          if (meta?.url ?? recent?.url) lines.push(`URL: ${meta?.url ?? recent?.url}`);
+          if (confidence != null) lines.push(`Confidence: ${confidence.toFixed(2)}`);
+          if (!fromCtx && recent) {
+            lines.push(`(Inferred from last completed ${active.app_name} session at ${recent.ended_at.slice(11, 16)} UTC — active session not yet classified)`);
+          } else if (fromCtx && ctx?.updated_at) {
+            lines.push(`(Inferred by tagger at ${ctx.updated_at.slice(11, 16)} UTC)`);
+          }
+        } else {
+          lines.push("No task linked yet.");
+          lines.push("(Active sessions are classified after they close; the tagger may not have run yet.)");
+        }
+
+        return { content: [{ type: "text", text: lines.join("\n") }] };
       }
 
       case "get-session-detail": {

--- a/services/README.md
+++ b/services/README.md
@@ -133,6 +133,77 @@ If you launch the daemon with an explicit `--stage 1,2`, the stage set is frozen
 
 ---
 
+## Jira updater
+
+Fetches in-progress Jira tasks (via `mcp-atlassian`), queries Meridian MCP for session data on each task, generates a bullet-point summary via hermes, and posts as timed comments to Jira. All updates are logged to `jira_update_log` for idempotent deduplication per (task_key, period_start, period_end) slot.
+
+Default schedule: fires at 1 PM and 5 PM within office hours (9–17), looking back over the preceding interval window (default: 4 hours).
+
+### Prerequisites
+
+Set these in `services/.env`:
+
+```bash
+JIRA_URL=https://your-instance.atlassian.net
+JIRA_EMAIL=your-email@example.com
+JIRA_API_TOKEN=your-api-token
+```
+
+Meridian MCP must be built first:
+
+```bash
+cd packages/meridian-mcp
+npm run build
+```
+
+### Quick command reference
+
+```bash
+# One-shot update all in-progress tasks (use current 4-hour window)
+python -m agents.jira_updater_daemon --trigger-now
+
+# One-shot update a single task
+python -m agents.jira_updater_daemon --task KAN-87
+
+# Preview (print comments without posting to Jira)
+python -m agents.jira_updater_daemon --dry-run
+
+# Custom look-back window in hours
+python -m agents.jira_updater_daemon --interval 2
+
+# Long-running daemon (sleeps until next scheduled slot)
+python -m agents.jira_updater_daemon
+```
+
+### Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `UPDATE_INTERVAL_HOURS` | `4` | Hours between scheduled slots (e.g. 4 → slots at 13:00, 17:00 within office hours). |
+| `OFFICE_START_HOUR` | `9` | Office start hour (UTC). |
+| `OFFICE_END_HOUR` | `17` | Office end hour (UTC). |
+| `JIRA_POST_NO_ACTIVITY` | `1` | Post comment even if no sessions found in the slot (set to `0` to skip posting no-activity slots). |
+| `MERIDIAN_MCP_PATH` | Auto-detected | Path to the compiled MCP server (`packages/meridian-mcp/dist/index.js`). |
+| `JIRA_URL` | — | Jira Cloud instance URL. |
+| `JIRA_EMAIL` | — | Email address for Jira API token auth. |
+| `JIRA_API_TOKEN` | — | API token for Jira REST API. |
+
+### Install / uninstall the launchd daemon
+
+```bash
+# Installs plist → ~/Library/LaunchAgents/, starts the service
+./scripts/install-jira-updater-daemon.sh
+
+# Stops and removes the plist
+./scripts/uninstall-jira-updater-daemon.sh
+
+# Status and logs
+launchctl print gui/$(id -u)/com.meridiona.jira-updater-daemon
+tail -f ~/.meridian/logs/jira-updater.log
+```
+
+---
+
 ## Dev mode (hermes source)
 
 By default the pipeline imports `run_agent` and related modules from the installed `hermes-agent` package. To step into hermes internals instead:

--- a/services/agents/config.py
+++ b/services/agents/config.py
@@ -237,10 +237,6 @@ UPDATE_INTERVAL_HOURS = float(os.environ.get("UPDATE_INTERVAL_HOURS", "4"))
 OFFICE_START_HOUR     = int(os.environ.get("OFFICE_START_HOUR", "9"))
 OFFICE_END_HOUR       = int(os.environ.get("OFFICE_END_HOUR", "17"))
 JIRA_POST_NO_ACTIVITY = _env_bool("JIRA_POST_NO_ACTIVITY", True)
-UPDATER_CONFIG_FILE   = Path(os.environ.get(
-    "UPDATER_CONFIG_FILE",
-    str(MERIDIAN_HOME / "updater.config.json"),
-))
 MERIDIAN_MCP_PATH     = Path(os.environ.get(
     "MERIDIAN_MCP_PATH",
     str(REPO_ROOT.parent / "packages" / "meridian-mcp" / "dist" / "index.js"),

--- a/services/agents/config.py
+++ b/services/agents/config.py
@@ -231,3 +231,17 @@ API_KEY  = os.environ.get("OLLAMA_API_KEY", "")
 # to sys.path so the local source checkout shadows the installed hermes-agent
 # package. Set HERMES_DEV_MODE=1 in your .env for breakpoint debugging.
 HERMES_DEV_MODE = os.environ.get("HERMES_DEV_MODE", "0") == "1"
+
+# ── Jira updater ──────────────────────────────────────────────────────────────
+UPDATE_INTERVAL_HOURS = float(os.environ.get("UPDATE_INTERVAL_HOURS", "4"))
+OFFICE_START_HOUR     = int(os.environ.get("OFFICE_START_HOUR", "9"))
+OFFICE_END_HOUR       = int(os.environ.get("OFFICE_END_HOUR", "17"))
+JIRA_POST_NO_ACTIVITY = _env_bool("JIRA_POST_NO_ACTIVITY", True)
+UPDATER_CONFIG_FILE   = Path(os.environ.get(
+    "UPDATER_CONFIG_FILE",
+    str(MERIDIAN_HOME / "updater.config.json"),
+))
+MERIDIAN_MCP_PATH     = Path(os.environ.get(
+    "MERIDIAN_MCP_PATH",
+    str(REPO_ROOT.parent / "packages" / "meridian-mcp" / "dist" / "index.js"),
+))

--- a/services/agents/db.py
+++ b/services/agents/db.py
@@ -667,3 +667,86 @@ def clear_session_dimensions(conn: sqlite3.Connection, session_id: int) -> int:
 def session_id_max(sessions: Iterable[dict]) -> int:
     """Return the largest id in a session bundle, or 0 if empty."""
     return max((int(s["id"]) for s in sessions), default=0)
+
+
+# ── jira_update_log ────────────────────────────────────────────────────────────
+def log_jira_update(
+    conn: sqlite3.Connection,
+    *,
+    task_key: str,
+    period_start: str,
+    period_end: str,
+    session_count: int,
+    duration_s: int,
+    had_activity: bool,
+    comment_body: str,
+) -> int:
+    """Insert a pending jira_update_log row. Returns the new row id.
+    On conflict (same task+slot already exists) returns the existing id."""
+    cur = conn.execute(
+        """
+        INSERT INTO jira_update_log
+            (task_key, period_start, period_end, session_count, duration_s,
+             had_activity, comment_body, state)
+        VALUES (?, ?, ?, ?, ?, ?, ?, 'pending')
+        ON CONFLICT(task_key, period_start, period_end) DO UPDATE SET
+            comment_body = excluded.comment_body,
+            session_count = excluded.session_count,
+            duration_s = excluded.duration_s,
+            had_activity = excluded.had_activity
+        """,
+        (task_key, period_start, period_end, session_count, duration_s,
+         int(had_activity), comment_body),
+    )
+    conn.commit()
+    return cur.lastrowid or _get_update_id(conn, task_key, period_start, period_end)
+
+
+def _get_update_id(conn: sqlite3.Connection, task_key: str, period_start: str, period_end: str) -> int:
+    row = conn.execute(
+        "SELECT id FROM jira_update_log WHERE task_key=? AND period_start=? AND period_end=?",
+        (task_key, period_start, period_end),
+    ).fetchone()
+    return row[0] if row else 0
+
+
+def get_last_update(
+    conn: sqlite3.Connection,
+    task_key: str,
+    period_start: str,
+    period_end: str,
+) -> dict | None:
+    """Return the log row for (task, slot) if state='sent', else None."""
+    row = conn.execute(
+        """
+        SELECT id, state, comment_id, posted_at
+        FROM jira_update_log
+        WHERE task_key=? AND period_start=? AND period_end=? AND state='sent'
+        """,
+        (task_key, period_start, period_end),
+    ).fetchone()
+    if not row:
+        return None
+    return {"id": row[0], "state": row[1], "comment_id": row[2], "posted_at": row[3]}
+
+
+def mark_update_sent(conn: sqlite3.Connection, update_id: int, comment_id: str) -> None:
+    """Set state='sent', comment_id, posted_at=now."""
+    conn.execute(
+        """
+        UPDATE jira_update_log
+        SET state='sent', comment_id=?, posted_at=strftime('%Y-%m-%dT%H:%M:%SZ','now')
+        WHERE id=?
+        """,
+        (comment_id, update_id),
+    )
+    conn.commit()
+
+
+def mark_update_failed(conn: sqlite3.Connection, update_id: int, error: str) -> None:
+    """Set state='failed', error (capped at 1000 chars)."""
+    conn.execute(
+        "UPDATE jira_update_log SET state='failed', error=? WHERE id=?",
+        (error[:1000], update_id),
+    )
+    conn.commit()

--- a/services/agents/db.py
+++ b/services/agents/db.py
@@ -743,6 +743,8 @@ def mark_update_sent(conn: sqlite3.Connection, update_id: int, comment_id: str) 
         (comment_id, update_id),
     )
     conn.commit()
+    if conn.execute("SELECT changes()").fetchone()[0] == 0:
+        log.warning("mark_update_sent: no row matched id=%d", update_id)
 
 
 def mark_update_failed(conn: sqlite3.Connection, update_id: int, error: str) -> None:
@@ -752,3 +754,5 @@ def mark_update_failed(conn: sqlite3.Connection, update_id: int, error: str) -> 
         (error[:1000], update_id),
     )
     conn.commit()
+    if conn.execute("SELECT changes()").fetchone()[0] == 0:
+        log.warning("mark_update_failed: no row matched id=%d", update_id)

--- a/services/agents/db.py
+++ b/services/agents/db.py
@@ -699,7 +699,9 @@ def log_jira_update(
          int(had_activity), comment_body),
     )
     conn.commit()
-    return cur.lastrowid or _get_update_id(conn, task_key, period_start, period_end)
+    # lastrowid is unreliable on the UPSERT conflict path across SQLite versions;
+    # always resolve via SELECT to guarantee correctness.
+    return _get_update_id(conn, task_key, period_start, period_end)
 
 
 def _get_update_id(conn: sqlite3.Connection, task_key: str, period_start: str, period_end: str) -> int:

--- a/services/agents/jira_updater.py
+++ b/services/agents/jira_updater.py
@@ -54,8 +54,7 @@ class UpdateResult:
 
 # ── Atlassian MCP client ───────────────────────────────────────────────────────
 class _AtlassianMCPClient:
-    """Wraps uvx mcp-atlassian. Holds one subprocess open for the lifetime of
-    the object so the FastMCP banner only prints once per run_update call."""
+    """Wraps uvx mcp-atlassian; each method call starts and tears down its own subprocess."""
 
     def __init__(self) -> None:
         self.url = os.environ.get("JIRA_URL", "")
@@ -92,37 +91,32 @@ class _AtlassianMCPClient:
             },
         )
 
-    async def _run(self, calls: list[tuple[str, dict]]) -> list[str]:
-        """Open one subprocess and execute all calls sequentially."""
+    async def _call(self, tool: str, args: dict) -> str:
         from mcp import ClientSession
         from mcp.client.stdio import stdio_client
 
-        results = []
         async with stdio_client(self._server_params()) as (r, w):
             async with ClientSession(r, w) as session:
                 await session.initialize()
-                for tool, args in calls:
-                    result = await session.call_tool(tool, args)
-                    if not result.content:
-                        results.append("{}")
-                        continue
-                    first = result.content[0]
-                    results.append(getattr(first, "text", str(first)) or "{}")
-        return results
+                result = await session.call_tool(tool, args)
+                if not result.content:
+                    return "{}"
+                first = result.content[0]
+                return getattr(first, "text", str(first)) or "{}"
 
     def fetch_in_progress(self) -> list[dict]:
         log.info("fetching in-progress tasks (JQL: %s)", _IN_PROGRESS_JQL)
         raw = asyncio.run(
-            self._run([("jira_search", {"jql": _IN_PROGRESS_JQL, "limit": 50})])
-        )[0]
+            self._call("jira_search", {"jql": _IN_PROGRESS_JQL, "limit": 50})
+        )
         issues = _parse_search_result(raw)
         return [_normalise_issue(i, self.url) for i in issues]
 
     def add_comment(self, task_key: str, body: str) -> str:
         log.info("posting comment to %s", task_key)
         raw = asyncio.run(
-            self._run([("jira_add_comment", {"issue_key": task_key, "body": body})])
-        )[0]
+            self._call("jira_add_comment", {"issue_key": task_key, "body": body})
+        )
         try:
             data = json.loads(raw)
             if isinstance(data, dict):
@@ -172,7 +166,11 @@ def _normalise_issue(issue: dict, base_url: str) -> dict:
 
 # ── Meridian MCP client ────────────────────────────────────────────────────────
 class _MeridianMCPClient:
-    """Wraps the local Node.js meridian-mcp server."""
+    """Wraps the local Node.js meridian-mcp server.
+
+    Use get_task_sessions_batch() to query multiple tasks in a single
+    subprocess, avoiding per-task Node.js startup overhead.
+    """
 
     def __init__(self) -> None:
         self.mcp_path = Path(MERIDIAN_MCP_PATH)
@@ -191,31 +189,45 @@ class _MeridianMCPClient:
             env={**os.environ, "MERIDIAN_DB": str(MERIDIAN_DB)},
         )
 
-    async def _call(self, tool: str, args: dict) -> str:
+    async def _call_many(self, calls: list[tuple[str, dict]]) -> list[str]:
         from mcp import ClientSession
         from mcp.client.stdio import stdio_client
 
+        results: list[str] = []
         async with stdio_client(self._server_params()) as (r, w):
             async with ClientSession(r, w) as session:
                 await session.initialize()
-                result = await session.call_tool(tool, args)
-                if not result.content:
-                    return ""
-                first = result.content[0]
-                return getattr(first, "text", str(first)) or ""
+                for tool, args in calls:
+                    result = await session.call_tool(tool, args)
+                    if not result.content:
+                        results.append("")
+                    else:
+                        first = result.content[0]
+                        results.append(getattr(first, "text", str(first)) or "")
+        return results
 
-    def get_task_sessions(self, task_key: str, from_time: str, to_time: str) -> str:
-        return asyncio.run(
-            self._call(
+    def get_task_sessions_batch(
+        self,
+        tasks: list[tuple[str, str, str]],
+    ) -> list[str]:
+        """Fetch sessions for multiple tasks in a single subprocess.
+
+        tasks: list of (task_key, from_time, to_time)
+        Returns response strings in the same order.
+        """
+        calls = [
+            (
                 "get-task-sessions",
                 {
-                    "task_key": task_key,
-                    "from_time": from_time,
-                    "to_time": to_time,
+                    "task_key": tk,
+                    "from_time": ft,
+                    "to_time": tt,
                     "include_content": True,
                 },
             )
-        )
+            for tk, ft, tt in tasks
+        ]
+        return asyncio.run(self._call_many(calls))
 
 
 # ── Hermes summary generator ───────────────────────────────────────────────────
@@ -262,7 +274,8 @@ def _parse_mcp_summary(mcp_text: str) -> tuple[bool, int, int]:
         return False, 0, 0
     m = _SUMMARY_RE.search(mcp_text)
     if not m:
-        return True, 1, 0
+        log.warning("could not parse session summary from MCP response: %s", mcp_text[:200])
+        return True, 0, 0
     count = int(m.group(1))
     hours = int(m.group(2) or 0)
     minutes = int(m.group(3))
@@ -339,7 +352,7 @@ def run_update(
     task_filter: str | None = None,
     dry_run: bool = False,
 ) -> list[UpdateResult]:
-    """Main entry point — safe to call from a thread (via run_in_executor)."""
+    """Main entry point called by daemon and CLI."""
     conn = sqlite3.connect(str(MERIDIAN_DB))
     conn.row_factory = sqlite3.Row
     try:
@@ -347,23 +360,20 @@ def run_update(
         meridian = _MeridianMCPClient()
 
         tasks = jira.fetch_in_progress()
-        log.info("found %d in-progress task(s): %s", len(tasks), [t["task_key"] for t in tasks])
         if task_filter:
             tasks = [t for t in tasks if t["task_key"] == task_filter]
-            if not tasks:
-                log.warning(
-                    "task %s not found in in-progress tasks — check its status in Jira",
-                    task_filter,
-                )
-                return []
         if not tasks:
             log.info("no in-progress tasks found")
             return []
 
+        mcp_results = meridian.get_task_sessions_batch(
+            [(t["task_key"], from_time, to_time) for t in tasks]
+        )
+
         results: list[UpdateResult] = []
-        for task in tasks:
+        for task, mcp_text in zip(tasks, mcp_results):
             result = _process_task(
-                conn, jira, meridian, task, task["task_key"], from_time, to_time, dry_run
+                conn, jira, task, task["task_key"], from_time, to_time, dry_run, mcp_text
             )
             results.append(result)
         return results
@@ -374,12 +384,12 @@ def run_update(
 def _process_task(
     conn: sqlite3.Connection,
     jira: _AtlassianMCPClient,
-    meridian: _MeridianMCPClient,
     task: dict,
     task_key: str,
     from_time: str,
     to_time: str,
     dry_run: bool,
+    mcp_text: str,
 ) -> UpdateResult:
     if db.get_last_update(conn, task_key, from_time, to_time):
         log.info("skipping %s: already posted for this slot", task_key)
@@ -388,7 +398,6 @@ def _process_task(
             session_count=0, comment_body="", comment_id=None, state="skipped",
         )
 
-    mcp_text = meridian.get_task_sessions(task_key, from_time, to_time)
     had_activity, session_count, duration_s = _parse_mcp_summary(mcp_text)
 
     if had_activity:

--- a/services/agents/jira_updater.py
+++ b/services/agents/jira_updater.py
@@ -1,0 +1,451 @@
+"""Jira progress updater — posts timed activity summaries to in-progress Jira issues.
+
+Fetches in-progress tickets via mcp-atlassian, pulls session data for each ticket
+from the local Meridian MCP server, generates a bullet-point summary via hermes,
+and posts the comment back to Jira. All updates are logged in jira_update_log for
+idempotent deduplication per (task_key, period_start, period_end) slot.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from agents import db
+from agents._hermes_setup import ensure_hermes_importable
+from agents.config import (
+    API_KEY,
+    BASE_URL,
+    JIRA_POST_NO_ACTIVITY,
+    MERIDIAN_DB,
+    MERIDIAN_MCP_PATH,
+    MODEL,
+    REPO_ROOT,
+    load_skill,
+)
+
+log = logging.getLogger("agents.jira_updater")
+
+_IN_PROGRESS_JQL = (
+    "assignee = currentUser() AND statusCategory = indeterminate ORDER BY updated DESC"
+)
+
+
+# ── Result type ────────────────────────────────────────────────────────────────
+@dataclass
+class UpdateResult:
+    task_key: str
+    had_activity: bool
+    duration_s: int
+    session_count: int
+    comment_body: str
+    comment_id: str | None
+    state: str  # 'sent' | 'failed' | 'skipped' | 'dry_run' | 'no_activity_skipped'
+    error: str | None = None
+
+
+# ── Atlassian MCP client ───────────────────────────────────────────────────────
+class _AtlassianMCPClient:
+    """Wraps uvx mcp-atlassian. Holds one subprocess open for the lifetime of
+    the object so the FastMCP banner only prints once per run_update call."""
+
+    def __init__(self) -> None:
+        self.url = os.environ.get("JIRA_URL", "")
+        self.email = os.environ.get("JIRA_EMAIL", "")
+        self.token = os.environ.get("JIRA_API_TOKEN", "")
+        missing = [
+            k
+            for k, v in (
+                ("JIRA_URL", self.url),
+                ("JIRA_EMAIL", self.email),
+                ("JIRA_API_TOKEN", self.token),
+            )
+            if not v
+        ]
+        if missing:
+            raise RuntimeError(
+                f"Atlassian MCP unavailable — missing env: {', '.join(missing)}"
+            )
+
+    def _server_params(self):
+        from mcp import StdioServerParameters
+
+        return StdioServerParameters(
+            command="uvx",
+            args=["mcp-atlassian", "--jira-url", self.url],
+            env={
+                **os.environ,
+                "JIRA_URL": self.url,
+                "JIRA_USERNAME": self.email,
+                "JIRA_API_TOKEN": self.token,
+                # Suppress FastMCP startup banner and toolset warning.
+                "FASTMCP_BANNER": "0",
+                "TOOLSETS": "all",
+            },
+        )
+
+    async def _run(self, calls: list[tuple[str, dict]]) -> list[str]:
+        """Open one subprocess and execute all calls sequentially."""
+        from mcp import ClientSession
+        from mcp.client.stdio import stdio_client
+
+        results = []
+        async with stdio_client(self._server_params()) as (r, w):
+            async with ClientSession(r, w) as session:
+                await session.initialize()
+                for tool, args in calls:
+                    result = await session.call_tool(tool, args)
+                    if not result.content:
+                        results.append("{}")
+                        continue
+                    first = result.content[0]
+                    results.append(getattr(first, "text", str(first)) or "{}")
+        return results
+
+    def fetch_in_progress(self) -> list[dict]:
+        log.info("fetching in-progress tasks (JQL: %s)", _IN_PROGRESS_JQL)
+        raw = asyncio.run(
+            self._run([("jira_search", {"jql": _IN_PROGRESS_JQL, "limit": 50})])
+        )[0]
+        issues = _parse_search_result(raw)
+        return [_normalise_issue(i, self.url) for i in issues]
+
+    def add_comment(self, task_key: str, body: str) -> str:
+        log.info("posting comment to %s", task_key)
+        raw = asyncio.run(
+            self._run([("jira_add_comment", {"issue_key": task_key, "body": body})])
+        )[0]
+        try:
+            data = json.loads(raw)
+            if isinstance(data, dict):
+                return str(data.get("id") or data.get("comment_id") or "")
+        except (json.JSONDecodeError, TypeError):
+            pass
+        return ""
+
+
+def _parse_search_result(raw: str) -> list[dict]:
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        match = re.search(r"\{.*\}|\[.*\]", raw, re.DOTALL)
+        if not match:
+            log.warning("atlassian mcp: response was not JSON: %s", raw[:200])
+            return []
+        try:
+            data = json.loads(match.group())
+        except json.JSONDecodeError:
+            return []
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for key in ("issues", "results", "items"):
+            if isinstance(data.get(key), list):
+                return data[key]
+    log.warning("atlassian mcp: unexpected response shape: %s", str(data)[:200])
+    return []
+
+
+def _normalise_issue(issue: dict, base_url: str) -> dict:
+    # mcp-atlassian returns a flat structure (key, summary, status at top level)
+    # not the nested Jira REST API format (fields.summary, fields.status.name).
+    status = issue.get("status") or {}
+    if isinstance(status, dict):
+        status_name = status.get("name") or ""
+    else:
+        status_name = str(status)
+    return {
+        "task_key": issue.get("key", ""),
+        "title": issue.get("summary") or "",
+        "status": status_name,
+        "url": f"{base_url.rstrip('/')}/browse/{issue.get('key', '')}",
+    }
+
+
+# ── Meridian MCP client ────────────────────────────────────────────────────────
+class _MeridianMCPClient:
+    """Wraps the local Node.js meridian-mcp server."""
+
+    def __init__(self) -> None:
+        self.mcp_path = Path(MERIDIAN_MCP_PATH)
+        if not self.mcp_path.exists():
+            raise RuntimeError(
+                f"Meridian MCP not found at {self.mcp_path}. "
+                "Run `npm run build` in packages/meridian-mcp/."
+            )
+
+    def _server_params(self):
+        from mcp import StdioServerParameters
+
+        return StdioServerParameters(
+            command="node",
+            args=[str(self.mcp_path)],
+            env={**os.environ, "MERIDIAN_DB": str(MERIDIAN_DB)},
+        )
+
+    async def _call(self, tool: str, args: dict) -> str:
+        from mcp import ClientSession
+        from mcp.client.stdio import stdio_client
+
+        async with stdio_client(self._server_params()) as (r, w):
+            async with ClientSession(r, w) as session:
+                await session.initialize()
+                result = await session.call_tool(tool, args)
+                if not result.content:
+                    return ""
+                first = result.content[0]
+                return getattr(first, "text", str(first)) or ""
+
+    def get_task_sessions(self, task_key: str, from_time: str, to_time: str) -> str:
+        return asyncio.run(
+            self._call(
+                "get-task-sessions",
+                {
+                    "task_key": task_key,
+                    "from_time": from_time,
+                    "to_time": to_time,
+                    "include_content": True,
+                },
+            )
+        )
+
+
+# ── Hermes summary generator ───────────────────────────────────────────────────
+class _HermesUpdater:
+    """Single-shot hermes AIAgent call — no tools, one iteration."""
+
+    def generate(self, user_message: str) -> str:
+        ensure_hermes_importable()
+        # Force services/.env after hermes's own dotenv loading which may
+        # override OLLAMA_* vars with stale values from ~/.hermes/.env.
+        load_dotenv(REPO_ROOT / ".env", override=True)
+        from run_agent import AIAgent
+
+        model    = os.environ.get("OLLAMA_MODEL",   MODEL)
+        base_url = os.environ.get("OLLAMA_HOST",    BASE_URL)
+        api_key  = os.environ.get("OLLAMA_API_KEY", API_KEY)
+
+        agent = AIAgent(
+            model=model,
+            base_url=base_url,
+            api_key=api_key or "none",
+            ephemeral_system_prompt=load_skill("jira-updater"),
+            enabled_toolsets=[],
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            load_soul_identity=False,
+            max_iterations=1,
+            max_tokens=1500,
+        )
+        result = agent.run_conversation(user_message)
+        return result.get("final_response", "").strip()
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+_SUMMARY_RE = re.compile(
+    r"(\d+)\s+session\(s\),\s*(?:(\d+)h\s*)?(\d+)m\s+total", re.IGNORECASE
+)
+
+
+def _parse_mcp_summary(mcp_text: str) -> tuple[bool, int, int]:
+    """Returns (had_activity, session_count, duration_s)."""
+    if "No sessions linked" in mcp_text:
+        return False, 0, 0
+    m = _SUMMARY_RE.search(mcp_text)
+    if not m:
+        return True, 1, 0
+    count = int(m.group(1))
+    hours = int(m.group(2) or 0)
+    minutes = int(m.group(3))
+    return True, count, hours * 3600 + minutes * 60
+
+
+def _fmt_time(iso: str) -> str:
+    """Parse ISO 8601 UTC and return HH:MM."""
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        return dt.strftime("%H:%M")
+    except ValueError:
+        return iso
+
+
+def _fmt_date(iso: str) -> str:
+    """Parse ISO 8601 UTC and return 'Month Day' (e.g. 'May 14')."""
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        return dt.strftime("%B %-d")
+    except ValueError:
+        return iso
+
+
+def _fmt_duration(duration_s: int) -> str:
+    hours, rem = divmod(duration_s, 3600)
+    minutes = rem // 60
+    if hours:
+        return f"{hours}h {minutes}m"
+    return f"{minutes}m"
+
+
+def _build_user_message(
+    task: dict, mcp_text: str, from_time: str, to_time: str
+) -> str:
+    return (
+        f"TASK: {task['task_key']} — {task['title']}\n"
+        f"Status: {task['status']}\n"
+        f"Period: {_fmt_time(from_time)}–{_fmt_time(to_time)} UTC\n"
+        "\n"
+        "ACTIVITY DATA:\n"
+        f"{mcp_text}\n"
+        "\n"
+        "Write 3–5 bullet points summarising what was accomplished. "
+        "Bullet points only, no preamble."
+    )
+
+
+def _format_comment(
+    task: dict,
+    summary: str,
+    from_time: str,
+    to_time: str,
+    duration_s: int,
+    session_count: int,
+) -> str:
+    header = (
+        f"📊 *Progress Update* — {_fmt_time(from_time)}–{_fmt_time(to_time)}, "
+        f"{_fmt_date(from_time)}"
+    )
+    if duration_s == 0 and session_count == 0:
+        return f"{header}\n\nNo activity recorded in this period."
+    footer = (
+        f"_⏱ {_fmt_duration(duration_s)} active · "
+        f"{session_count} session(s) · Via Meridian_"
+    )
+    return f"{header}\n\n{summary}\n\n{footer}"
+
+
+# ── Public entry point ─────────────────────────────────────────────────────────
+def run_update(
+    from_time: str,
+    to_time: str,
+    task_filter: str | None = None,
+    dry_run: bool = False,
+) -> list[UpdateResult]:
+    """Main entry point called by daemon and CLI."""
+    conn = sqlite3.connect(str(MERIDIAN_DB))
+    conn.row_factory = sqlite3.Row
+    jira = _AtlassianMCPClient()
+    meridian = _MeridianMCPClient()
+
+    tasks = jira.fetch_in_progress()
+    log.info("found %d in-progress task(s): %s", len(tasks), [t["task_key"] for t in tasks])
+    if task_filter:
+        tasks = [t for t in tasks if t["task_key"] == task_filter]
+        if not tasks:
+            log.warning("task %s is not in your in-progress tasks — check its status in Jira", task_filter)
+            conn.close()
+            return []
+    if not tasks:
+        log.info("no in-progress tasks found")
+        conn.close()
+        return []
+
+    results: list[UpdateResult] = []
+    for task in tasks:
+        task_key = task["task_key"]
+        result = _process_task(
+            conn, jira, meridian, task, task_key, from_time, to_time, dry_run
+        )
+        results.append(result)
+
+    conn.close()
+    return results
+
+
+def _process_task(
+    conn: sqlite3.Connection,
+    jira: _AtlassianMCPClient,
+    meridian: _MeridianMCPClient,
+    task: dict,
+    task_key: str,
+    from_time: str,
+    to_time: str,
+    dry_run: bool,
+) -> UpdateResult:
+    if db.get_last_update(conn, task_key, from_time, to_time):
+        log.info("skipping %s: already posted for this slot", task_key)
+        return UpdateResult(
+            task_key=task_key, had_activity=False, duration_s=0,
+            session_count=0, comment_body="", comment_id=None, state="skipped",
+        )
+
+    mcp_text = meridian.get_task_sessions(task_key, from_time, to_time)
+    had_activity, session_count, duration_s = _parse_mcp_summary(mcp_text)
+
+    if had_activity:
+        user_msg = _build_user_message(task, mcp_text, from_time, to_time)
+        try:
+            summary = _HermesUpdater().generate(user_msg)
+        except Exception as exc:
+            log.error("hermes failed for %s: %s", task_key, exc)
+            summary = "Could not generate summary."
+    else:
+        summary = "No activity recorded in this period."
+
+    if not had_activity and not JIRA_POST_NO_ACTIVITY:
+        return UpdateResult(
+            task_key=task_key, had_activity=False, duration_s=0,
+            session_count=0, comment_body="", comment_id=None,
+            state="no_activity_skipped",
+        )
+
+    comment_body = _format_comment(
+        task, summary, from_time, to_time, duration_s, session_count
+    )
+    update_id = db.log_jira_update(
+        conn,
+        task_key=task_key,
+        period_start=from_time,
+        period_end=to_time,
+        session_count=session_count,
+        duration_s=duration_s,
+        had_activity=had_activity,
+        comment_body=comment_body,
+    )
+
+    if dry_run:
+        print(f"\n{'=' * 60}\n{task_key}\n{'=' * 60}\n{comment_body}\n")
+        return UpdateResult(
+            task_key=task_key, had_activity=had_activity, duration_s=duration_s,
+            session_count=session_count, comment_body=comment_body,
+            comment_id=None, state="dry_run",
+        )
+
+    try:
+        comment_id = jira.add_comment(task_key, comment_body)
+        db.mark_update_sent(conn, update_id, comment_id)
+        log.info("posted update for %s (comment_id=%s)", task_key, comment_id)
+        return UpdateResult(
+            task_key=task_key, had_activity=had_activity, duration_s=duration_s,
+            session_count=session_count, comment_body=comment_body,
+            comment_id=comment_id, state="sent",
+        )
+    except Exception as exc:
+        db.mark_update_failed(conn, update_id, str(exc))
+        log.error("failed to post for %s: %s", task_key, exc)
+        return UpdateResult(
+            task_key=task_key, had_activity=had_activity, duration_s=duration_s,
+            session_count=session_count, comment_body=comment_body,
+            comment_id=None, state="failed", error=str(exc),
+        )
+
+
+__all__ = ["UpdateResult", "run_update"]

--- a/services/agents/jira_updater.py
+++ b/services/agents/jira_updater.py
@@ -339,35 +339,36 @@ def run_update(
     task_filter: str | None = None,
     dry_run: bool = False,
 ) -> list[UpdateResult]:
-    """Main entry point called by daemon and CLI."""
+    """Main entry point — safe to call from a thread (via run_in_executor)."""
     conn = sqlite3.connect(str(MERIDIAN_DB))
     conn.row_factory = sqlite3.Row
-    jira = _AtlassianMCPClient()
-    meridian = _MeridianMCPClient()
+    try:
+        jira = _AtlassianMCPClient()
+        meridian = _MeridianMCPClient()
 
-    tasks = jira.fetch_in_progress()
-    log.info("found %d in-progress task(s): %s", len(tasks), [t["task_key"] for t in tasks])
-    if task_filter:
-        tasks = [t for t in tasks if t["task_key"] == task_filter]
+        tasks = jira.fetch_in_progress()
+        log.info("found %d in-progress task(s): %s", len(tasks), [t["task_key"] for t in tasks])
+        if task_filter:
+            tasks = [t for t in tasks if t["task_key"] == task_filter]
+            if not tasks:
+                log.warning(
+                    "task %s not found in in-progress tasks — check its status in Jira",
+                    task_filter,
+                )
+                return []
         if not tasks:
-            log.warning("task %s is not in your in-progress tasks — check its status in Jira", task_filter)
-            conn.close()
+            log.info("no in-progress tasks found")
             return []
-    if not tasks:
-        log.info("no in-progress tasks found")
+
+        results: list[UpdateResult] = []
+        for task in tasks:
+            result = _process_task(
+                conn, jira, meridian, task, task["task_key"], from_time, to_time, dry_run
+            )
+            results.append(result)
+        return results
+    finally:
         conn.close()
-        return []
-
-    results: list[UpdateResult] = []
-    for task in tasks:
-        task_key = task["task_key"]
-        result = _process_task(
-            conn, jira, meridian, task, task_key, from_time, to_time, dry_run
-        )
-        results.append(result)
-
-    conn.close()
-    return results
 
 
 def _process_task(

--- a/services/agents/jira_updater_daemon.py
+++ b/services/agents/jira_updater_daemon.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import functools
 import logging
 import signal
 import sys
@@ -43,6 +44,11 @@ def compute_slots(office_start: int, office_end: int, interval_h: float) -> list
     while t <= office_end:
         slots.append(round(t))
         t += interval_h
+    if not slots:
+        raise ValueError(
+            f"No update slots fit interval {interval_h}h within office hours "
+            f"{office_start}–{office_end}"
+        )
     return slots
 
 
@@ -61,6 +67,8 @@ def slot_window(slot_hour: int, interval_h: float) -> tuple[str, str]:
 
 def next_slot_dt(slots: list[int]) -> datetime:
     """Return datetime of the next scheduled slot (may be tomorrow)."""
+    if not slots:
+        raise ValueError("slots must be non-empty")
     now = datetime.now().astimezone()
     midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
     for h in sorted(slots):
@@ -105,7 +113,6 @@ async def daemon_loop(dry_run: bool = False) -> None:
     calls (MCP stdio clients) don't conflict with the running event loop.
     """
     from agents.jira_updater import run_update
-    import functools
 
     slots = compute_slots(OFFICE_START_HOUR, OFFICE_END_HOUR, UPDATE_INTERVAL_HOURS)
     log.info(

--- a/services/agents/jira_updater_daemon.py
+++ b/services/agents/jira_updater_daemon.py
@@ -99,8 +99,13 @@ def _run_one_shot(
 # ── Daemon loop ───────────────────────────────────────────────────────────────
 
 async def daemon_loop(dry_run: bool = False) -> None:
-    """Async daemon loop — sleeps until the next slot, then fires run_update."""
+    """Async daemon loop — sleeps until the next slot, then fires run_update.
+
+    run_update is dispatched via run_in_executor so its internal asyncio.run()
+    calls (MCP stdio clients) don't conflict with the running event loop.
+    """
     from agents.jira_updater import run_update
+    import functools
 
     slots = compute_slots(OFFICE_START_HOUR, OFFICE_END_HOUR, UPDATE_INTERVAL_HOURS)
     log.info(
@@ -118,19 +123,28 @@ async def daemon_loop(dry_run: bool = False) -> None:
         sleep_s = max(0.0, (nxt - datetime.now().astimezone()).total_seconds())
         log.info("next update at %s (%.0fs)", nxt.strftime("%H:%M"), sleep_s)
 
+        # Wait for the next slot, waking early if stop is signalled.
+        # Using wait_for on the coroutine directly avoids the orphaned-task
+        # accumulation of the asyncio.shield(ensure_future(...)) pattern.
         try:
-            await asyncio.wait_for(
-                asyncio.shield(asyncio.ensure_future(stop.wait())),
-                timeout=sleep_s,
-            )
-            break
+            await asyncio.wait_for(stop.wait(), timeout=sleep_s)
+            break  # stop was set — exit cleanly
         except asyncio.TimeoutError:
             pass
+
+        if stop.is_set():
+            break
 
         from_time, to_time = slot_window(nxt.hour, UPDATE_INTERVAL_HOURS)
         log.info("running update window %s → %s", from_time, to_time)
         try:
-            results = run_update(from_time=from_time, to_time=to_time, dry_run=dry_run)
+            # run_update is synchronous and uses asyncio.run() internally.
+            # Dispatch to a thread so those nested event loops don't conflict
+            # with this one, and so SIGTERM is not blocked during the update.
+            fn = functools.partial(
+                run_update, from_time=from_time, to_time=to_time, dry_run=dry_run
+            )
+            results = await loop.run_in_executor(None, fn)
             for r in results:
                 log.info(
                     "task=%s state=%s duration=%ds had_activity=%s",

--- a/services/agents/jira_updater_daemon.py
+++ b/services/agents/jira_updater_daemon.py
@@ -1,0 +1,204 @@
+"""Jira updater daemon.
+
+Fires `run_update` once per scheduled slot within office hours.  Slots are
+computed from OFFICE_START_HOUR, OFFICE_END_HOUR, and UPDATE_INTERVAL_HOURS
+(e.g. 9–17 with a 4 h interval → slots at 13:00 and 17:00).
+
+Designed to be supervised by launchd — see scripts/install-jira-updater-daemon.sh.
+Run manually:
+    cd services/
+    python -m agents.jira_updater_daemon                 # daemon (blocks)
+    python -m agents.jira_updater_daemon --trigger-now   # one-shot all tasks
+    python -m agents.jira_updater_daemon --task KAN-87   # one-shot single task
+    python -m agents.jira_updater_daemon --dry-run       # print only
+    python -m agents.jira_updater_daemon --interval 2    # custom look-back hours
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import signal
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from agents.config import (
+    LOG_DIR,
+    MERIDIAN_DB,
+    OFFICE_END_HOUR,
+    OFFICE_START_HOUR,
+    UPDATE_INTERVAL_HOURS,
+)
+
+log = logging.getLogger("jira_updater_daemon")
+
+
+# ── Slot helpers ──────────────────────────────────────────────────────────────
+
+def compute_slots(office_start: int, office_end: int, interval_h: float) -> list[int]:
+    """Hours at which updates fire. E.g. [13, 17] for 9–17 with 4h interval."""
+    slots: list[int] = []
+    t = office_start + interval_h
+    while t <= office_end:
+        slots.append(round(t))
+        t += interval_h
+    return slots
+
+
+def slot_window(slot_hour: int, interval_h: float) -> tuple[str, str]:
+    """Return (from_time, to_time) as ISO 8601 UTC for today's slot_hour."""
+    now_local = datetime.now().astimezone()
+    midnight = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    to_local = midnight + timedelta(hours=slot_hour)
+    from_local = to_local - timedelta(hours=interval_h)
+    fmt = "%Y-%m-%dT%H:%M:%SZ"
+    return (
+        from_local.astimezone(timezone.utc).strftime(fmt),
+        to_local.astimezone(timezone.utc).strftime(fmt),
+    )
+
+
+def next_slot_dt(slots: list[int]) -> datetime:
+    """Return datetime of the next scheduled slot (may be tomorrow)."""
+    now = datetime.now().astimezone()
+    midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    for h in sorted(slots):
+        dt = midnight + timedelta(hours=h)
+        if dt > now:
+            return dt
+    return midnight + timedelta(days=1, hours=slots[0])
+
+
+# ── One-shot helper ───────────────────────────────────────────────────────────
+
+def _run_one_shot(
+    *,
+    interval_h: float,
+    task_key: str | None,
+    dry_run: bool,
+) -> None:
+    from agents.jira_updater import run_update
+
+    now_utc = datetime.now(tz=timezone.utc)
+    to_time = now_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+    from_time = (now_utc - timedelta(hours=interval_h)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    log.info("one-shot window %s → %s task=%s dry_run=%s",
+             from_time, to_time, task_key or "all", dry_run)
+    results = run_update(
+        from_time=from_time,
+        to_time=to_time,
+        dry_run=dry_run,
+        task_filter=task_key,
+    )
+    for r in results:
+        log.info("task=%s state=%s duration=%ds had_activity=%s",
+                 r.task_key, r.state, r.duration_s, r.had_activity)
+
+
+# ── Daemon loop ───────────────────────────────────────────────────────────────
+
+async def daemon_loop(dry_run: bool = False) -> None:
+    """Async daemon loop — sleeps until the next slot, then fires run_update."""
+    from agents.jira_updater import run_update
+
+    slots = compute_slots(OFFICE_START_HOUR, OFFICE_END_HOUR, UPDATE_INTERVAL_HOURS)
+    log.info(
+        "jira-updater starting: office=%d–%d slots=%s interval=%.1fh",
+        OFFICE_START_HOUR, OFFICE_END_HOUR, slots, UPDATE_INTERVAL_HOURS,
+    )
+
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, stop.set)
+
+    while not stop.is_set():
+        nxt = next_slot_dt(slots)
+        sleep_s = max(0.0, (nxt - datetime.now().astimezone()).total_seconds())
+        log.info("next update at %s (%.0fs)", nxt.strftime("%H:%M"), sleep_s)
+
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(asyncio.ensure_future(stop.wait())),
+                timeout=sleep_s,
+            )
+            break
+        except asyncio.TimeoutError:
+            pass
+
+        from_time, to_time = slot_window(nxt.hour, UPDATE_INTERVAL_HOURS)
+        log.info("running update window %s → %s", from_time, to_time)
+        try:
+            results = run_update(from_time=from_time, to_time=to_time, dry_run=dry_run)
+            for r in results:
+                log.info(
+                    "task=%s state=%s duration=%ds had_activity=%s",
+                    r.task_key, r.state, r.duration_s, r.had_activity,
+                )
+        except Exception:
+            log.exception("update run failed")
+
+    log.info("jira-updater stopped")
+
+
+# ── Logging setup ─────────────────────────────────────────────────────────────
+
+def _configure_logging() -> None:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    log_file = LOG_DIR / "jira-updater.log"
+
+    fmt = logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+
+    sh = logging.StreamHandler(sys.stderr)
+    sh.setFormatter(fmt)
+    root.addHandler(sh)
+
+    fh = logging.FileHandler(log_file)
+    fh.setFormatter(fmt)
+    root.addHandler(fh)
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Jira updater daemon — fires run_update on a slot schedule within office hours."
+    )
+    parser.add_argument(
+        "--trigger-now", action="store_true",
+        help="Run a one-shot update immediately (all tasks) then exit.",
+    )
+    parser.add_argument(
+        "--task", metavar="KEY",
+        help="One-shot update for a single Jira task key (e.g. KAN-87), then exit.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print what would be posted to Jira without writing anything.",
+    )
+    parser.add_argument(
+        "--interval", type=float, default=UPDATE_INTERVAL_HOURS, metavar="HOURS",
+        help=f"Look-back window in hours for one-shot runs (default: {UPDATE_INTERVAL_HOURS}).",
+    )
+    args = parser.parse_args()
+
+    _configure_logging()
+
+    if args.trigger_now or args.task:
+        _run_one_shot(
+            interval_h=args.interval,
+            task_key=args.task,
+            dry_run=args.dry_run,
+        )
+        return
+
+    asyncio.run(daemon_loop(dry_run=args.dry_run))
+
+
+# Both `python -m agents.jira_updater_daemon` and `python -m agents.jira_updater`
+# (if __main__.py is added there) resolve to this entry point.
+if __name__ == "__main__":
+    main()

--- a/services/agents/tests/test_jira_updater.py
+++ b/services/agents/tests/test_jira_updater.py
@@ -1,0 +1,528 @@
+# meridian — normalises screenpipe activity into structured app sessions
+"""Unit tests for jira_updater and jira_updater_daemon helper functions.
+
+Covers pure-logic helpers (_parse_search_result, _normalise_issue,
+_parse_mcp_summary, _format_comment, _build_user_message), daemon slot
+helpers (compute_slots, slot_window), and the four jira_update_log db
+functions (log_jira_update, get_last_update, mark_update_sent,
+mark_update_failed).
+
+All external calls (Atlassian MCP, Meridian MCP, hermes) are never
+invoked — tested functions are pure or operate against in-memory SQLite.
+"""
+from __future__ import annotations
+
+import re
+import sqlite3
+
+import pytest
+
+from agents import jira_updater
+from agents.jira_updater import (
+    _build_user_message,
+    _format_comment,
+    _normalise_issue,
+    _parse_mcp_summary,
+    _parse_search_result,
+)
+from agents.jira_updater_daemon import compute_slots, slot_window
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────────
+
+MIGRATION_SQL = """\
+CREATE TABLE IF NOT EXISTS jira_update_log (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_key      TEXT    NOT NULL,
+    period_start  TEXT    NOT NULL,
+    period_end    TEXT    NOT NULL,
+    session_count INTEGER DEFAULT 0,
+    duration_s    INTEGER DEFAULT 0,
+    had_activity  INTEGER DEFAULT 0,
+    comment_body  TEXT,
+    comment_id    TEXT,
+    state         TEXT    DEFAULT 'pending',
+    error         TEXT,
+    posted_at     TEXT,
+    created_at    TEXT    DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_jira_update_log_dedup
+    ON jira_update_log(task_key, period_start, period_end);
+"""
+
+
+@pytest.fixture
+def conn():
+    """In-memory SQLite connection with the jira_update_log table created."""
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.executescript(MIGRATION_SQL)
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def sample_task():
+    return {
+        "task_key": "KAN-87",
+        "title": "Implement OAuth flow",
+        "status": "In Progress",
+        "url": "https://example.atlassian.net/browse/KAN-87",
+    }
+
+
+_FROM = "2026-05-14T09:00:00Z"
+_TO   = "2026-05-14T13:00:00Z"
+
+
+# ── _parse_search_result ────────────────────────────────────────────────────────
+
+def test_parse_search_result_plain_list():
+    """A JSON array is returned as-is."""
+    raw = '[{"key": "KAN-1"}, {"key": "KAN-2"}]'
+    result = _parse_search_result(raw)
+    assert len(result) == 2
+    assert result[0]["key"] == "KAN-1"
+
+
+def test_parse_search_result_issues_key():
+    """A dict with an 'issues' list is unwrapped."""
+    raw = '{"issues": [{"key": "KAN-3"}], "total": 1}'
+    result = _parse_search_result(raw)
+    assert len(result) == 1
+    assert result[0]["key"] == "KAN-3"
+
+
+def test_parse_search_result_results_key():
+    """A dict with a 'results' list is unwrapped."""
+    raw = '{"results": [{"key": "KAN-4"}]}'
+    result = _parse_search_result(raw)
+    assert result[0]["key"] == "KAN-4"
+
+
+def test_parse_search_result_empty_string():
+    """Empty input returns an empty list without raising."""
+    result = _parse_search_result("")
+    assert result == []
+
+
+def test_parse_search_result_non_json_text():
+    """Plain prose (no JSON) returns an empty list."""
+    result = _parse_search_result("Server error: connection refused")
+    assert result == []
+
+
+def test_parse_search_result_malformed_json():
+    """Unparseable JSON returns an empty list."""
+    result = _parse_search_result("{key: 'no quotes'}")
+    assert result == []
+
+
+def test_parse_search_result_unexpected_shape():
+    """A dict with no recognised list key returns an empty list."""
+    raw = '{"total": 0, "startAt": 0}'
+    result = _parse_search_result(raw)
+    assert result == []
+
+
+def test_parse_search_result_json_embedded_in_prose():
+    """JSON object embedded in surrounding text is extracted and parsed."""
+    raw = 'FastMCP ready.\n{"issues": [{"key": "KAN-5"}]}\nDone.'
+    result = _parse_search_result(raw)
+    assert result[0]["key"] == "KAN-5"
+
+
+# ── _normalise_issue ────────────────────────────────────────────────────────────
+
+def test_normalise_issue_flat_mcp_format():
+    """mcp-atlassian flat structure is correctly mapped."""
+    issue = {
+        "key": "KAN-10",
+        "summary": "Fix login bug",
+        "status": {"name": "In Progress", "category": "indeterminate"},
+    }
+    result = _normalise_issue(issue, "https://example.atlassian.net")
+    assert result["task_key"] == "KAN-10"
+    assert result["title"] == "Fix login bug"
+    assert result["status"] == "In Progress"
+    assert result["url"] == "https://example.atlassian.net/browse/KAN-10"
+
+
+def test_normalise_issue_string_status():
+    """A string status (non-dict) is coerced to a string."""
+    issue = {"key": "KAN-11", "summary": "Refactor DB", "status": "Done"}
+    result = _normalise_issue(issue, "https://example.atlassian.net")
+    assert result["status"] == "Done"
+
+
+def test_normalise_issue_missing_fields_give_empty_strings():
+    """Missing key/summary/status fields default to empty strings."""
+    result = _normalise_issue({}, "https://example.atlassian.net")
+    assert result["task_key"] == ""
+    assert result["title"] == ""
+    assert result["status"] == ""
+
+
+def test_normalise_issue_url_trailing_slash_stripped():
+    """Trailing slash on base_url is stripped before /browse/."""
+    issue = {"key": "KAN-12", "summary": "Edge", "status": {}}
+    result = _normalise_issue(issue, "https://example.atlassian.net/")
+    assert result["url"] == "https://example.atlassian.net/browse/KAN-12"
+
+
+# ── _parse_mcp_summary ──────────────────────────────────────────────────────────
+
+def test_parse_mcp_summary_no_sessions_linked():
+    """'No sessions linked' sentinel returns (False, 0, 0)."""
+    had, count, dur = _parse_mcp_summary("No sessions linked to KAN-87.")
+    assert had is False
+    assert count == 0
+    assert dur == 0
+
+
+def test_parse_mcp_summary_hours_and_minutes():
+    """'3 session(s), 2h 15m total' → (True, 3, 8100 s)."""
+    had, count, dur = _parse_mcp_summary("3 session(s), 2h 15m total")
+    assert had is True
+    assert count == 3
+    assert dur == 2 * 3600 + 15 * 60
+
+
+def test_parse_mcp_summary_minutes_only():
+    """'1 session(s), 45m total' → (True, 1, 2700 s)."""
+    had, count, dur = _parse_mcp_summary("1 session(s), 45m total")
+    assert had is True
+    assert count == 1
+    assert dur == 45 * 60
+
+
+def test_parse_mcp_summary_exact_one_hour():
+    """'2 session(s), 1h 0m total' → (True, 2, 3600 s)."""
+    had, count, dur = _parse_mcp_summary("2 session(s), 1h 0m total")
+    assert had is True
+    assert count == 2
+    assert dur == 3600
+
+
+def test_parse_mcp_summary_unrecognised_format_treated_as_activity():
+    """Unrecognised text that lacks the sentinel → (True, 1, 0) defensive default."""
+    had, count, dur = _parse_mcp_summary("Some unexpected MCP output.")
+    assert had is True
+    assert count == 1
+    assert dur == 0
+
+
+# ── _format_comment ─────────────────────────────────────────────────────────────
+
+def test_format_comment_with_activity(sample_task):
+    """Non-zero duration/session_count includes the footer line."""
+    body = _format_comment(
+        task=sample_task,
+        summary="• Implemented OAuth\n• Added tests",
+        from_time=_FROM,
+        to_time=_TO,
+        duration_s=3600,
+        session_count=2,
+    )
+    assert "09:00" in body
+    assert "13:00" in body
+    assert "• Implemented OAuth" in body
+    assert "1h 0m" in body
+    assert "2 session(s)" in body
+    assert "Via Meridian" in body
+
+
+def test_format_comment_no_activity(sample_task):
+    """duration_s=0 and session_count=0 → no-activity message, no footer."""
+    body = _format_comment(
+        task=sample_task,
+        summary="No activity recorded in this period.",
+        from_time=_FROM,
+        to_time=_TO,
+        duration_s=0,
+        session_count=0,
+    )
+    assert "No activity recorded in this period." in body
+    assert "Via Meridian" not in body
+
+
+def test_format_comment_header_contains_date(sample_task):
+    """The header includes the formatted date from from_time."""
+    body = _format_comment(
+        task=sample_task,
+        summary="• Did work",
+        from_time=_FROM,
+        to_time=_TO,
+        duration_s=900,
+        session_count=1,
+    )
+    # from_time is 2026-05-14 → "May 14"
+    assert "May 14" in body
+
+
+# ── _build_user_message ─────────────────────────────────────────────────────────
+
+def test_build_user_message_contains_task_section(sample_task):
+    """Output contains the TASK key and title."""
+    msg = _build_user_message(sample_task, "3 session(s), 2h 0m total", _FROM, _TO)
+    assert "KAN-87" in msg
+    assert "Implement OAuth flow" in msg
+
+
+def test_build_user_message_contains_period_section(sample_task):
+    """Output contains the Period line with formatted HH:MM times."""
+    msg = _build_user_message(sample_task, "some data", _FROM, _TO)
+    assert "Period:" in msg
+    assert "09:00" in msg
+    assert "13:00" in msg
+
+
+def test_build_user_message_contains_activity_data_section(sample_task):
+    """ACTIVITY DATA section is present and contains the mcp_text."""
+    mcp = "3 session(s), 2h 15m total\n- cursor.so: 45m"
+    msg = _build_user_message(sample_task, mcp, _FROM, _TO)
+    assert "ACTIVITY DATA:" in msg
+    assert "cursor.so" in msg
+
+
+def test_build_user_message_instruction_line_present(sample_task):
+    """The summarisation instruction is present in the message."""
+    msg = _build_user_message(sample_task, "data", _FROM, _TO)
+    assert "bullet point" in msg.lower()
+
+
+# ── compute_slots ───────────────────────────────────────────────────────────────
+
+def test_compute_slots_4h_interval():
+    """9–17 with 4h interval → [13, 17]."""
+    assert compute_slots(9, 17, 4) == [13, 17]
+
+
+def test_compute_slots_8h_interval():
+    """9–17 with 8h interval → [17]."""
+    assert compute_slots(9, 17, 8) == [17]
+
+
+def test_compute_slots_2h_interval():
+    """9–17 with 2h interval → [11, 13, 15, 17]."""
+    assert compute_slots(9, 17, 2) == [11, 13, 15, 17]
+
+
+def test_compute_slots_interval_exceeds_window():
+    """Interval longer than office window → empty list."""
+    assert compute_slots(9, 10, 8) == []
+
+
+def test_compute_slots_tight_window():
+    """Exactly one interval fits at end → one slot."""
+    assert compute_slots(9, 11, 2) == [11]
+
+
+# ── slot_window ──────────────────────────────────────────────────────────────────
+
+_ISO_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"
+)
+
+
+def test_slot_window_returns_valid_iso_strings():
+    """Both returned strings are valid ISO 8601 UTC timestamps."""
+    from_t, to_t = slot_window(13, 4)
+    assert _ISO_RE.match(from_t), f"from_time not ISO 8601: {from_t}"
+    assert _ISO_RE.match(to_t), f"to_time not ISO 8601: {to_t}"
+
+
+def test_slot_window_to_time_hour_matches_slot():
+    """The to_time hour (in UTC) matches slot_hour when local offset is accounted for."""
+    # We cannot assume a fixed local timezone, so we verify the window width instead.
+    from datetime import datetime, timezone
+
+    from_t, to_t = slot_window(17, 4)
+    dt_from = datetime.fromisoformat(from_t.replace("Z", "+00:00"))
+    dt_to   = datetime.fromisoformat(to_t.replace("Z", "+00:00"))
+    delta_h = (dt_to - dt_from).total_seconds() / 3600
+    assert delta_h == pytest.approx(4.0)
+
+
+def test_slot_window_from_is_before_to():
+    """from_time is always strictly before to_time."""
+    from datetime import datetime
+
+    from_t, to_t = slot_window(13, 4)
+    dt_from = datetime.fromisoformat(from_t.replace("Z", "+00:00"))
+    dt_to   = datetime.fromisoformat(to_t.replace("Z", "+00:00"))
+    assert dt_from < dt_to
+
+
+# ── db: log_jira_update ─────────────────────────────────────────────────────────
+
+def test_log_jira_update_inserts_row(conn):
+    """Inserting a new update returns a positive id and stores the row."""
+    from agents.db import log_jira_update
+
+    uid = log_jira_update(
+        conn,
+        task_key="KAN-87",
+        period_start=_FROM,
+        period_end=_TO,
+        session_count=3,
+        duration_s=7200,
+        had_activity=True,
+        comment_body="• did stuff",
+    )
+    assert uid > 0
+    row = conn.execute("SELECT * FROM jira_update_log WHERE id=?", (uid,)).fetchone()
+    assert row["task_key"] == "KAN-87"
+    assert row["state"] == "pending"
+    assert row["had_activity"] == 1
+    assert row["session_count"] == 3
+
+
+def test_log_jira_update_upsert_on_conflict(conn):
+    """Duplicate (task, start, end) upserts rather than raising."""
+    from agents.db import log_jira_update
+
+    uid1 = log_jira_update(
+        conn,
+        task_key="KAN-87",
+        period_start=_FROM,
+        period_end=_TO,
+        session_count=1,
+        duration_s=3600,
+        had_activity=True,
+        comment_body="first",
+    )
+    uid2 = log_jira_update(
+        conn,
+        task_key="KAN-87",
+        period_start=_FROM,
+        period_end=_TO,
+        session_count=2,
+        duration_s=7200,
+        had_activity=True,
+        comment_body="updated",
+    )
+    # Only one row should exist.
+    count = conn.execute("SELECT COUNT(*) FROM jira_update_log").fetchone()[0]
+    assert count == 1
+    row = conn.execute("SELECT comment_body FROM jira_update_log WHERE id=?", (uid2,)).fetchone()
+    assert row["comment_body"] == "updated"
+
+
+# ── db: get_last_update ─────────────────────────────────────────────────────────
+
+def test_get_last_update_returns_none_when_pending(conn):
+    """Pending row is not returned by get_last_update."""
+    from agents.db import get_last_update, log_jira_update
+
+    log_jira_update(
+        conn,
+        task_key="KAN-88",
+        period_start=_FROM,
+        period_end=_TO,
+        session_count=1,
+        duration_s=1800,
+        had_activity=True,
+        comment_body="body",
+    )
+    assert get_last_update(conn, "KAN-88", _FROM, _TO) is None
+
+
+def test_get_last_update_returns_row_when_sent(conn):
+    """get_last_update returns the row only after mark_update_sent."""
+    from agents.db import get_last_update, log_jira_update, mark_update_sent
+
+    uid = log_jira_update(
+        conn,
+        task_key="KAN-88",
+        period_start=_FROM,
+        period_end=_TO,
+        session_count=1,
+        duration_s=1800,
+        had_activity=True,
+        comment_body="body",
+    )
+    mark_update_sent(conn, uid, "comment-abc")
+    result = get_last_update(conn, "KAN-88", _FROM, _TO)
+    assert result is not None
+    assert result["state"] == "sent"
+    assert result["comment_id"] == "comment-abc"
+
+
+def test_get_last_update_returns_none_for_unknown_slot(conn):
+    """Querying a non-existent (task, slot) pair returns None."""
+    from agents.db import get_last_update
+
+    assert get_last_update(conn, "KAN-99", _FROM, _TO) is None
+
+
+# ── db: mark_update_sent ────────────────────────────────────────────────────────
+
+def test_mark_update_sent_sets_state_and_comment_id(conn):
+    """mark_update_sent transitions state to 'sent' and persists comment_id."""
+    from agents.db import log_jira_update, mark_update_sent
+
+    uid = log_jira_update(
+        conn,
+        task_key="KAN-89",
+        period_start=_FROM,
+        period_end=_TO,
+        session_count=2,
+        duration_s=5400,
+        had_activity=True,
+        comment_body="comment",
+    )
+    mark_update_sent(conn, uid, "cid-999")
+    row = conn.execute(
+        "SELECT state, comment_id, posted_at FROM jira_update_log WHERE id=?", (uid,)
+    ).fetchone()
+    assert row["state"] == "sent"
+    assert row["comment_id"] == "cid-999"
+    assert row["posted_at"] is not None
+
+
+# ── db: mark_update_failed ──────────────────────────────────────────────────────
+
+def test_mark_update_failed_sets_state_and_error(conn):
+    """mark_update_failed transitions state to 'failed' and stores the error."""
+    from agents.db import log_jira_update, mark_update_failed
+
+    uid = log_jira_update(
+        conn,
+        task_key="KAN-90",
+        period_start=_FROM,
+        period_end=_TO,
+        session_count=0,
+        duration_s=0,
+        had_activity=False,
+        comment_body="",
+    )
+    mark_update_failed(conn, uid, "connection timeout")
+    row = conn.execute(
+        "SELECT state, error FROM jira_update_log WHERE id=?", (uid,)
+    ).fetchone()
+    assert row["state"] == "failed"
+    assert row["error"] == "connection timeout"
+
+
+def test_mark_update_failed_truncates_long_error(conn):
+    """Errors longer than 1000 chars are truncated to 1000 chars."""
+    from agents.db import log_jira_update, mark_update_failed
+
+    uid = log_jira_update(
+        conn,
+        task_key="KAN-91",
+        period_start=_FROM,
+        period_end=_TO,
+        session_count=0,
+        duration_s=0,
+        had_activity=False,
+        comment_body="",
+    )
+    long_error = "x" * 2000
+    mark_update_failed(conn, uid, long_error)
+    row = conn.execute(
+        "SELECT error FROM jira_update_log WHERE id=?", (uid,)
+    ).fetchone()
+    assert len(row["error"]) == 1000

--- a/services/agents/tests/test_jira_updater.py
+++ b/services/agents/tests/test_jira_updater.py
@@ -1,4 +1,3 @@
-# meridian — normalises screenpipe activity into structured app sessions
 """Unit tests for jira_updater and jira_updater_daemon helper functions.
 
 Covers pure-logic helpers (_parse_search_result, _normalise_issue,
@@ -25,7 +24,7 @@ from agents.jira_updater import (
     _parse_mcp_summary,
     _parse_search_result,
 )
-from agents.jira_updater_daemon import compute_slots, slot_window
+from agents.jira_updater_daemon import compute_slots, next_slot_dt, slot_window
 
 
 # ── Fixtures ────────────────────────────────────────────────────────────────────
@@ -206,10 +205,10 @@ def test_parse_mcp_summary_exact_one_hour():
 
 
 def test_parse_mcp_summary_unrecognised_format_treated_as_activity():
-    """Unrecognised text that lacks the sentinel → (True, 1, 0) defensive default."""
+    """Unrecognised text that lacks the sentinel → (True, 0, 0): activity present but counts unknown."""
     had, count, dur = _parse_mcp_summary("Some unexpected MCP output.")
     assert had is True
-    assert count == 1
+    assert count == 0
     assert dur == 0
 
 
@@ -310,13 +309,20 @@ def test_compute_slots_2h_interval():
 
 
 def test_compute_slots_interval_exceeds_window():
-    """Interval longer than office window → empty list."""
-    assert compute_slots(9, 10, 8) == []
+    """Interval longer than office window → ValueError (no valid slots)."""
+    with pytest.raises(ValueError, match="No update slots fit"):
+        compute_slots(9, 10, 8)
 
 
 def test_compute_slots_tight_window():
     """Exactly one interval fits at end → one slot."""
     assert compute_slots(9, 11, 2) == [11]
+
+
+def test_next_slot_dt_raises_on_empty_slots():
+    """next_slot_dt with an empty list raises ValueError, not IndexError."""
+    with pytest.raises(ValueError, match="slots must be non-empty"):
+        next_slot_dt([])
 
 
 # ── slot_window ──────────────────────────────────────────────────────────────────

--- a/services/scripts/com.meridiona.jira-updater.plist
+++ b/services/scripts/com.meridiona.jira-updater.plist
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    com.meridiona.jira-updater — slot-based Jira update daemon.
+
+    Install via services/scripts/install-jira-updater-daemon.sh which copies
+    this file into ~/Library/LaunchAgents/ with absolute paths substituted in,
+    then bootstraps it under launchd. The plist below uses {{HOME}} +
+    {{REPO_ROOT}} placeholders that the install script replaces.
+
+    Uninstall:
+        services/scripts/uninstall-jira-updater-daemon.sh
+    Or manually:
+        launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.meridiona.jira-updater.plist
+        rm ~/Library/LaunchAgents/com.meridiona.jira-updater.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.meridiona.jira-updater</string>
+
+    <key>WorkingDirectory</key>
+    <string>{{REPO_ROOT}}/services</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{REPO_ROOT}}/services/.venv/bin/python</string>
+        <string>-m</string>
+        <string>agents.jira_updater_daemon</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>MERIDIAN_DB</key>
+        <string>{{HOME}}/.meridian/meridian.db</string>
+        <key>MERIDIAN_HOME</key>
+        <string>{{HOME}}/.meridian</string>
+        <key>LOG_LEVEL</key>
+        <string>INFO</string>
+        <key>PYTHONUNBUFFERED</key>
+        <string>1</string>
+        <!-- Slot schedule tunables. Slots fire at OFFICE_START_HOUR +
+             UPDATE_INTERVAL_HOURS, then every UPDATE_INTERVAL_HOURS until
+             OFFICE_END_HOUR. E.g. 9–17 @ 4h → slots at 13 and 17. -->
+        <key>UPDATE_INTERVAL_HOURS</key>
+        <string>4</string>
+        <key>OFFICE_START_HOUR</key>
+        <string>9</string>
+        <key>OFFICE_END_HOUR</key>
+        <string>17</string>
+        <!-- Set JIRA_POST_NO_ACTIVITY=0 to suppress updates for tasks with
+             zero recorded activity in the window. -->
+        <key>JIRA_POST_NO_ACTIVITY</key>
+        <string>1</string>
+        <!-- OTLP auth for OpenObserve — must be set here (not just .env)
+             because observability.py initialises before dotenv is loaded.
+             The install script reads MERIDIAN_OO_AUTH from services/.env and
+             substitutes the {{MERIDIAN_OO_AUTH}} placeholder below. -->
+        <key>MERIDIAN_OO_AUTH</key>
+        <string>{{MERIDIAN_OO_AUTH}}</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.meridian/logs/jira-updater.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.meridian/logs/jira-updater-error.log</string>
+
+    <!-- RunAtLoad false: slot-based scheduling is handled by the daemon
+         itself — it is not meant to fire immediately on every login. -->
+    <key>RunAtLoad</key>
+    <false/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/services/scripts/install-jira-updater-daemon.sh
+++ b/services/scripts/install-jira-updater-daemon.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Install the meridian jira-updater as a launchd LaunchAgent under the
+# current user. Slot-based schedule is managed by the daemon itself
+# (RunAtLoad false — it does not fire on every login).
+#
+#   ./services/scripts/install-jira-updater-daemon.sh
+#
+# Re-running this script is safe — it bootouts the existing agent first,
+# rewrites the plist with current paths, and reloads it.
+#
+# Uninstall:
+#   ./services/scripts/uninstall-jira-updater-daemon.sh
+#   Or manually:
+#     launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.meridiona.jira-updater.plist
+#     rm ~/Library/LaunchAgents/com.meridiona.jira-updater.plist
+
+set -euo pipefail
+
+LABEL="com.meridiona.jira-updater"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVICES_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${SERVICES_DIR}/.." && pwd)"
+TEMPLATE="${SCRIPT_DIR}/${LABEL}.plist"
+
+LAUNCH_AGENTS="${HOME}/Library/LaunchAgents"
+PLIST_DEST="${LAUNCH_AGENTS}/${LABEL}.plist"
+
+GUI_TARGET="gui/$(id -u)"
+
+if [[ ! -f "${TEMPLATE}" ]]; then
+    echo "✗ template not found: ${TEMPLATE}" >&2
+    exit 1
+fi
+
+VENV_PYTHON="${SERVICES_DIR}/.venv/bin/python"
+if [[ ! -x "${VENV_PYTHON}" ]]; then
+    echo "✗ python venv not found at ${VENV_PYTHON}" >&2
+    echo "  Run:  cd services && python3.11 -m venv .venv && source .venv/bin/activate && pip install -e ." >&2
+    exit 1
+fi
+
+mkdir -p "${HOME}/.meridian/logs"
+mkdir -p "${LAUNCH_AGENTS}"
+
+# Read MERIDIAN_OO_AUTH from services/.env (required — observability.py
+# initialises before dotenv is loaded, so launchd must inject it directly).
+ENV_FILE="${SERVICES_DIR}/.env"
+MERIDIAN_OO_AUTH=""
+if [[ -f "${ENV_FILE}" ]]; then
+    MERIDIAN_OO_AUTH="$(grep -E '^MERIDIAN_OO_AUTH=' "${ENV_FILE}" | cut -d= -f2- | tr -d '[:space:]')"
+fi
+if [[ -z "${MERIDIAN_OO_AUTH}" ]]; then
+    echo "✗ MERIDIAN_OO_AUTH not found in ${ENV_FILE}" >&2
+    echo "  Add:  MERIDIAN_OO_AUTH=<base64-encoded user:password>" >&2
+    exit 1
+fi
+
+echo "→ writing ${PLIST_DEST}"
+sed \
+    -e "s|{{REPO_ROOT}}|${REPO_ROOT}|g" \
+    -e "s|{{HOME}}|${HOME}|g" \
+    -e "s|{{MERIDIAN_OO_AUTH}}|${MERIDIAN_OO_AUTH}|g" \
+    "${TEMPLATE}" > "${PLIST_DEST}"
+
+# Validate the plist before loading.
+if ! plutil -lint "${PLIST_DEST}" >/dev/null; then
+    echo "✗ plist failed validation" >&2
+    exit 1
+fi
+
+# Bootout if previously loaded (idempotent — ignore if not loaded).
+if launchctl print "${GUI_TARGET}/${LABEL}" >/dev/null 2>&1; then
+    echo "→ bootout existing ${LABEL}"
+    launchctl bootout "${GUI_TARGET}" "${PLIST_DEST}" || true
+fi
+
+echo "→ bootstrap ${LABEL}"
+launchctl bootstrap "${GUI_TARGET}" "${PLIST_DEST}"
+launchctl enable "${GUI_TARGET}/${LABEL}"
+launchctl kickstart -k "${GUI_TARGET}/${LABEL}"
+
+echo
+echo "✓ jira-updater installed and started"
+echo
+echo "Useful follow-ups:"
+echo "  launchctl print  ${GUI_TARGET}/${LABEL}           # status"
+echo "  tail -f ~/.meridian/logs/jira-updater.log         # live logs"
+echo "  ${SCRIPT_DIR}/uninstall-jira-updater-daemon.sh    # remove"
+echo
+echo "One-shot trigger without restarting:"
+echo "  cd services && python -m agents.jira_updater_daemon --trigger-now"
+
+# Note: make this script executable after cloning:
+#   chmod +x services/scripts/install-jira-updater-daemon.sh

--- a/services/scripts/uninstall-jira-updater-daemon.sh
+++ b/services/scripts/uninstall-jira-updater-daemon.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Stop and remove the meridian jira-updater launchd agent.
+set -euo pipefail
+
+LABEL="com.meridiona.jira-updater"
+PLIST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+GUI_TARGET="gui/$(id -u)"
+
+if [[ -f "${PLIST}" ]]; then
+    if launchctl print "${GUI_TARGET}/${LABEL}" >/dev/null 2>&1; then
+        echo "→ bootout ${LABEL}"
+        launchctl bootout "${GUI_TARGET}" "${PLIST}" || true
+    fi
+    rm -f "${PLIST}"
+    echo "✓ removed ${PLIST}"
+else
+    echo "(not installed) ${PLIST}"
+fi

--- a/services/skills/activity/jira-updater/SKILL.md
+++ b/services/skills/activity/jira-updater/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: jira-updater
+description: Summarise a period of Meridian-tracked activity for a Jira ticket into 3–5 factual bullet points suitable for a progress comment or standup.
+version: 0.1.0
+metadata:
+  hermes:
+    tags: [jira, summary, activity, progress]
+---
+
+# Jira Updater — Activity Summariser
+
+You receive structured activity data for a specific Jira ticket and time window. Your job is to produce 3–5 bullet points that accurately describe what was accomplished.
+
+## Your inputs
+
+The user message contains, in this order:
+
+- **TASK** — Jira ticket key, title, current status, and URL.
+- **PERIOD** — the from/to timestamps covering this summary (e.g. "09:00–13:00, May 14").
+- **ACTIVITY DATA** — verbatim output from the `get-task-sessions` MCP tool: one block per session, each with app name, timestamps, duration, window titles with counts, dimension tags (activity, tool, intent, topic), and an OCR/content snippet.
+
+## Your job
+
+Write 3–5 bullet points summarising what was accomplished during the period.
+
+Use window titles, file names, module names, and content snippets as the primary evidence. Use Tags to infer the nature of work: `activity: coding` + `tool: rust` means "wrote Rust code"; `activity: learning` means "researched" or "reviewed documentation".
+
+## Output format
+
+Plain bullet list only — no preamble, no heading, no trailing text:
+
+```
+- Implemented OtelExporter trait in meridian.rs to forward spans to OpenObserve
+- Resolved async span context propagation issue across ETL batch boundaries
+- Pinned opentelemetry-otlp to 0.17 in Cargo.toml to fix breaking API change
+- Reviewed OpenTelemetry Rust SDK documentation for the tracing subscriber setup
+```
+
+Each bullet is one sentence, max 20 words. Start with a past-tense verb (Implemented, Fixed, Reviewed, Added, Resolved, Refactored, Investigated, etc.).
+
+## Hard rules
+
+- Be specific: name the files, modules, or libraries visible in the session data.
+- Do NOT mention Meridian, screenpipe, or data collection.
+- Do NOT say "based on the data" or any other meta-commentary.
+- Do NOT invent details absent from the session data.
+- Do NOT produce more than 5 bullets or fewer than 3.
+- Professional tone. No emojis.
+- Output bullets only — nothing before the first `-`, nothing after the last bullet.

--- a/src/migrations/015_jira_updates.sql
+++ b/src/migrations/015_jira_updates.sql
@@ -1,0 +1,19 @@
+-- meridian — normalises screenpipe activity into structured app sessions
+CREATE TABLE IF NOT EXISTS jira_update_log (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_key      TEXT    NOT NULL,
+    period_start  TEXT    NOT NULL,
+    period_end    TEXT    NOT NULL,
+    session_count INTEGER DEFAULT 0,
+    duration_s    INTEGER DEFAULT 0,
+    had_activity  INTEGER DEFAULT 0,
+    comment_body  TEXT,
+    comment_id    TEXT,
+    state         TEXT    DEFAULT 'pending',
+    error         TEXT,
+    posted_at     TEXT,
+    created_at    TEXT    DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_jira_update_log_dedup
+    ON jira_update_log(task_key, period_start, period_end);


### PR DESCRIPTION
## Summary

- **Jira updater agent**: fetches in-progress tasks via mcp-atlassian, pulls session data per task from the new Meridian MCP `get-task-sessions` tool, generates 3–5 bullet-point summaries via hermes AIAgent, and posts timed progress comments back to Jira
- **Slot-based scheduler daemon**: fires at configurable office-hour slots (default: 1pm and 5pm for 9–17 window with 4h interval); SIGTERM-safe via `run_in_executor` + `asyncio.Event`
- **Meridian MCP enhancements**: 4 new tools — `get-task-sessions` (AI-classified ticket links + session dimensions tags), `get-recent-sessions`, `get-task-breakdown`, `get-active-task` — all with `from_time`/`to_time` ISO 8601 range support
- **Dedup**: `jira_update_log` table (migration 015) with UNIQUE index on `(task_key, period_start, period_end)` prevents double-posting on daemon restart

## Architecture

```
mcp-atlassian → fetch in-progress tasks
Meridian MCP  → get-task-sessions (ticket_links JOIN + session_dimensions tags)
hermes        → one-shot AIAgent bullet-point generation (no tools, max_iterations=1)
mcp-atlassian → jira_add_comment (body param, Markdown)
jira_update_log → dedup + audit (state: pending → sent/failed)
```

## Critical fixes applied (from code review)

1. `run_update()` dispatched via `run_in_executor` so its `asyncio.run()` calls (MCP stdio clients) don't conflict with the daemon's event loop — without this every scheduled slot would crash
2. DB connection wrapped in `try/finally` — previously leaked on MCP subprocess failure
3. `_get_update_id()` called unconditionally after UPSERT — `lastrowid` is unreliable on the conflict path across SQLite versions
4. `wait_for(stop.wait())` replaces `shield(ensure_future(...))` — eliminates orphaned task accumulation each slot

## Test plan

- [x] 40 pytest tests passing — parse functions, db helpers, slot logic, comment formatting (no network/subprocess)
- [x] Dry-run verified end-to-end: `python -m agents.jira_updater_daemon --task KAN-108 --dry-run`
- [x] Live comment posted to KAN-108 and visible in Jira
- [x] `jira_update_log` dedup confirmed — second `--trigger-now` on same window skips re-post

## CLI reference

```bash
# One-shot (all in-progress tasks)
python -m agents.jira_updater_daemon --trigger-now

# Single task
python -m agents.jira_updater_daemon --task KAN-108

# Dry run
python -m agents.jira_updater_daemon --task KAN-108 --dry-run

# Daemon (blocks, fires on schedule)
python -m agents.jira_updater_daemon
```

## Environment variables required in `services/.env`

```
JIRA_URL=https://your-org.atlassian.net
JIRA_EMAIL=you@example.com
JIRA_API_TOKEN=...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)