### PR TITLE
feat(KAN-97): dynamic LLM selection, settings UI, task linker, and observability

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,3 +7,18 @@ echo "Running cargo fmt check..."
 cargo fmt --check || { echo "Run 'cargo fmt' before committing"; exit 1; }
 echo "Running cargo clippy..."
 cargo clippy -- -D warnings || { echo "Fix clippy warnings before committing"; exit 1; }
+
+# Security audit — staged files only, blocks commit on HIGH/CRITICAL findings
+STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(rs|ts|tsx|py)$' || true)
+if [ -n "$STAGED" ] && command -v claude &>/dev/null; then
+  echo "Running security audit on staged files..."
+  FINDINGS=$(claude --print "Security audit of staged changes in the Meridian project. Files: $STAGED. Check only: SQL injection, command injection, path traversal, hardcoded credentials, missing input validation at API boundaries, unsafe subprocess calls (shell=True, unvalidated exec paths). Report only HIGH and CRITICAL severity findings as a compact bulleted list with file:line. If none found, output exactly: NO_HIGH_FINDINGS" 2>/dev/null || echo "NO_HIGH_FINDINGS")
+  if echo "$FINDINGS" | grep -qE "HIGH|CRITICAL"; then
+    echo ""
+    echo "Security audit findings:"
+    echo "$FINDINGS"
+    echo ""
+    echo "Fix HIGH/CRITICAL issues before committing, or run: git commit --no-verify to skip."
+    exit 1
+  fi
+fi

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -9,7 +9,7 @@ chmod +x .githooks/pre-push
 
 echo "Git hooks installed:"
 echo "  commit-msg  — conventional commits format check"
-echo "  pre-commit  — cargo fmt + clippy"
+echo "  pre-commit  — cargo fmt + clippy + security audit on staged files (requires claude CLI)"
 echo "  pre-push    — cargo fmt + clippy + cargo test + UI build + UI tests"
 echo ""
 echo "Commit format: feat|fix|docs|refactor|perf|chore|ci(scope): description"

--- a/services/agents/llm_selector.py
+++ b/services/agents/llm_selector.py
@@ -135,7 +135,14 @@ def discover_running_servers() -> list[RunningServer]:
                     if models:
                         found.append(RunningServer(
                             "ollama", "http://127.0.0.1:11434/v1", models, models[0]))
-                        log.info("llm_selector: Ollama loaded=%s", models)
+                        log.info("llm_selector: Ollama running loaded=%s", models)
+                        span.add_event("ollama_found", {"models": str(models)})
+                    else:
+                        log.debug("llm_selector: Ollama on :11434 — no models loaded")
+                else:
+                    log.debug("llm_selector: port 11434 open but not Ollama (no version endpoint)")
+            else:
+                log.debug("llm_selector: Ollama not running (port 11434 closed)")
 
             # 2. LM Studio — use native /api/v0/models (has state field) to distinguish
             #    in-memory models from installed-only ones. /v1/models omits state entirely.
@@ -144,14 +151,21 @@ def discover_running_servers() -> list[RunningServer]:
                 if native_status == 200 and native:
                     models = [m["id"] for m in native.get("data", [])
                               if m.get("state") == "loaded"]
+                    log.debug("llm_selector: LM Studio /api/v0/models loaded=%s", models)
                 else:
                     # Older LM Studio — fall back to /v1/models, take all listed models
                     data, status = _get_json("http://127.0.0.1:1234/v1/models")
                     models = [m["id"] for m in (data or {}).get("data", [])] if status == 200 else []
+                    log.debug("llm_selector: LM Studio /v1/models fallback models=%s", models)
                 if models:
                     found.append(RunningServer(
                         "lmstudio", "http://127.0.0.1:1234/v1", models, models[0]))
-                    log.info("llm_selector: LM Studio loaded=%s", models)
+                    log.info("llm_selector: LM Studio running loaded=%s", models)
+                    span.add_event("lmstudio_found", {"models": str(models)})
+                else:
+                    log.debug("llm_selector: LM Studio on :1234 — no models loaded")
+            else:
+                log.debug("llm_selector: LM Studio not running (port 1234 closed)")
 
             # 3. Port 8080 — llama.cpp or mlx_lm; /props 200 = llama.cpp, 404 = mlx_lm
             if _tcp_open("127.0.0.1", 8080):
@@ -162,7 +176,10 @@ def discover_running_servers() -> list[RunningServer]:
                     if models:
                         found.append(RunningServer(
                             "llamacpp", "http://127.0.0.1:8080/v1", models, models[0]))
-                        log.info("llm_selector: llama.cpp loaded=%s", models)
+                        log.info("llm_selector: llama.cpp running loaded=%s", models)
+                        span.add_event("llamacpp_found", {"models": str(models)})
+                    else:
+                        log.debug("llm_selector: llama.cpp on :8080 — no models loaded")
                 else:
                     data, status = _get_json("http://127.0.0.1:8080/v1/models")
                     if status == 200 and data:
@@ -170,7 +187,12 @@ def discover_running_servers() -> list[RunningServer]:
                         if models:
                             found.append(RunningServer(
                                 "mlxlm", "http://127.0.0.1:8080/v1", models, models[0]))
-                            log.info("llm_selector: mlx_lm server loaded=%s", models)
+                            log.info("llm_selector: mlx_lm on :8080 running loaded=%s", models)
+                            span.add_event("mlxlm_found", {"models": str(models)})
+                        else:
+                            log.debug("llm_selector: mlx_lm on :8080 — no models loaded")
+            else:
+                log.debug("llm_selector: no server on port 8080")
 
             # 4. Apple FoundationModels — in-process, no port, macOS 26+
             try:
@@ -179,6 +201,7 @@ def discover_running_servers() -> list[RunningServer]:
                     found.append(RunningServer(
                         "apple_fm", "", ["apple-intelligence"], "apple-intelligence"))
                     log.info("llm_selector: Apple Intelligence available")
+                    span.add_event("apple_fm_found")
             except ImportError:
                 pass
 
@@ -235,15 +258,23 @@ _MANAGED_SERVER_PORT = 8765
 _MANAGED_SERVER_PID_FILE = Path.home() / ".meridian" / "mlx_lm_server.pid"
 
 
-def _metal_headroom_gb() -> float:
-    """Primary memory signal — headroom within Metal's recommended working set."""
+def _metal_headroom_gb() -> tuple[float, str]:
+    """Primary memory signal — headroom within Metal's recommended working set.
+
+    Returns (headroom_gb, source) where source is 'mlx' or 'vm_stat'.
+    """
     try:
         import mlx.core as mx  # type: ignore[import]
         info    = mx.device_info()
         ceiling = info["max_recommended_working_set_size"]
         active  = mx.get_active_memory()
         cached  = mx.get_cache_memory()
-        return (ceiling - active - cached) / (1 << 30)
+        gb = (ceiling - active - cached) / (1 << 30)
+        log.debug(
+            "llm_selector: metal headroom=%.1f GB (ceiling=%.1f active=%.1f cached=%.1f) source=mlx",
+            gb, ceiling / (1 << 30), active / (1 << 30), cached / (1 << 30),
+        )
+        return gb, "mlx"
     except Exception:
         pass
     # Fallback: vm_stat free+inactive (less accurate, always available)
@@ -254,9 +285,11 @@ def _metal_headroom_gb() -> float:
         def pg(label: str) -> int:
             m = re.search(rf"{label}:\s+(\d+)", out)
             return int(m.group(1)) if m else 0
-        return (pg("Pages free") + pg("Pages inactive")) * page_size / (1 << 30)
+        gb = (pg("Pages free") + pg("Pages inactive")) * page_size / (1 << 30)
+        log.debug("llm_selector: metal headroom=%.1f GB source=vm_stat (mlx unavailable)", gb)
+        return gb, "vm_stat"
     except Exception:
-        return 0.0
+        return 0.0, "unknown"
 
 
 def _thermal_level() -> int:
@@ -299,18 +332,31 @@ def probe_compute() -> ComputeSnapshot:
             brand = _sysctl("machdep.cpu.brand_string") or ""
             key   = re.sub(r"\s+", " ", brand).lower()
             _, mem_bw = _CHIP_SPECS.get(key, (None, 0))
+            headroom_gb, headroom_source = _metal_headroom_gb()
+            thermal = _thermal_level()
+            cpu_pct = psutil.cpu_percent(interval=0.5)
+            locked  = _screen_locked()
             snap = ComputeSnapshot(
-                metal_headroom_gb=_metal_headroom_gb(),
-                thermal_level=_thermal_level(),
-                cpu_pct=psutil.cpu_percent(interval=0.5),
-                screen_locked=_screen_locked(),
+                metal_headroom_gb=headroom_gb,
+                thermal_level=thermal,
+                cpu_pct=cpu_pct,
+                screen_locked=locked,
                 chip_name=brand,
                 mem_bw_gbs=mem_bw or 0,
             )
-            span.set_attribute("compute.headroom_pct", snap.metal_headroom_gb)
-            span.set_attribute("compute.thermal_ok", snap.thermal_level < 2)
-            span.set_attribute("compute.chip", snap.chip_name)
-            span.set_attribute("compute.screen_locked", snap.screen_locked)
+            span.set_attribute("compute.headroom_gb",    round(headroom_gb, 2))
+            span.set_attribute("compute.headroom_source", headroom_source)
+            span.set_attribute("compute.thermal_level",  thermal)
+            span.set_attribute("compute.thermal_ok",     thermal < 2)
+            span.set_attribute("compute.cpu_pct",        round(cpu_pct, 1))
+            span.set_attribute("compute.screen_locked",  locked)
+            span.set_attribute("compute.chip",           brand)
+            span.set_attribute("compute.mem_bw_gbs",     mem_bw or 0)
+            log.info(
+                "llm_selector: compute headroom=%.1f GB thermal=%d cpu=%.0f%% "
+                "locked=%s chip=%s mem_bw=%d GB/s source=%s",
+                headroom_gb, thermal, cpu_pct, locked, brand, mem_bw or 0, headroom_source,
+            )
             return snap
         except Exception as exc:
             span.record_exception(exc)
@@ -473,51 +519,109 @@ def _wait_for_port_free(port: int, timeout: float = 5.0) -> None:
 
 
 def _ensure_mlx_server(model_id: str, port: int = _MANAGED_SERVER_PORT) -> bool:
-    pid_file = _MANAGED_SERVER_PID_FILE
-    if pid_file.exists():
-        try:
-            meta = json.loads(pid_file.read_text())
-            pid, existing_model, existing_port = meta["pid"], meta["model"], meta["port"]
+    with _tracer.start_as_current_span("llm_selector.ensure_server") as span:
+        span.set_attribute("server.model",      model_id)
+        span.set_attribute("server.port",       port)
+        t0 = time.monotonic()
+
+        pid_file = _MANAGED_SERVER_PID_FILE
+        if pid_file.exists():
             try:
-                os.kill(pid, 0)
-                alive = True
-            except OSError:
-                alive = False
-            if alive and existing_model == model_id and existing_port == port:
+                meta = json.loads(pid_file.read_text())
+                pid, existing_model, existing_port = meta["pid"], meta["model"], meta["port"]
+                try:
+                    os.kill(pid, 0)
+                    alive = True
+                except OSError:
+                    alive = False
+
+                if alive and existing_model == model_id and existing_port == port:
+                    log.info(
+                        "llm_selector: managed server already running model=%s pid=%d port=%d",
+                        model_id, pid, port,
+                    )
+                    span.set_attribute("server.action", "reused")
+                    span.set_attribute("server.pid",    pid)
+                    span.add_event("server_reused", {"pid": pid, "model": model_id})
+                    return True
+
+                if alive:
+                    log.info(
+                        "llm_selector: model switch %s → %s — stopping pid=%d",
+                        existing_model, model_id, pid,
+                    )
+                    span.set_attribute("server.previous_model", existing_model)
+                    span.add_event("model_switch", {
+                        "from_model": existing_model,
+                        "to_model":   model_id,
+                        "pid":        pid,
+                    })
+                    os.kill(pid, signal.SIGTERM)
+                    _wait_for_process_exit(pid)
+                    _wait_for_port_free(port)
+                    stop_ms = int((time.monotonic() - t0) * 1000)
+                    log.info(
+                        "llm_selector: stopped old managed server pid=%d model=%s elapsed_ms=%d",
+                        pid, existing_model, stop_ms,
+                    )
+                    span.add_event("old_server_stopped", {"elapsed_ms": stop_ms})
+                else:
+                    log.debug("llm_selector: stale pid file (pid=%d dead) — starting fresh", pid)
+                    span.add_event("stale_pid_file", {"pid": pid})
+            except Exception:
+                pass
+
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "mlx_lm.server",
+             "--model", model_id, "--port", str(port), "--max-tokens", "4096"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        pid_file.parent.mkdir(parents=True, exist_ok=True)
+        pid_file.write_text(json.dumps({"pid": proc.pid, "model": model_id, "port": port}))
+        log.info(
+            "llm_selector: started mlx_lm.server model=%s pid=%d port=%d — waiting for ready",
+            model_id, proc.pid, port,
+        )
+        span.set_attribute("server.action", "started")
+        span.set_attribute("server.pid",    proc.pid)
+        span.add_event("server_started", {"pid": proc.pid, "model": model_id})
+
+        url = f"http://127.0.0.1:{port}/v1/models"
+        deadline = time.monotonic() + 90.0
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                elapsed_ms = int((time.monotonic() - t0) * 1000)
+                log.warning(
+                    "llm_selector: mlx_lm.server exited early exit=%d model=%s elapsed_ms=%d"
+                    " — is mlx_lm installed?",
+                    proc.returncode, model_id, elapsed_ms,
+                )
+                span.set_attribute("server.action",     "failed")
+                span.set_attribute("server.exit_code",  proc.returncode)
+                span.add_event("server_exited_early", {"exit_code": proc.returncode})
+                pid_file.unlink(missing_ok=True)
+                return False
+            _, status = _get_json(url, timeout=1.0)
+            if status == 200:
+                elapsed_ms = int((time.monotonic() - t0) * 1000)
+                log.info(
+                    "llm_selector: mlx_lm.server ready model=%s port=%d startup_ms=%d",
+                    model_id, port, elapsed_ms,
+                )
+                span.set_attribute("server.startup_ms", elapsed_ms)
+                span.add_event("server_ready", {"startup_ms": elapsed_ms})
                 return True
-            if alive:
-                os.kill(pid, signal.SIGTERM)
-                _wait_for_process_exit(pid)
-                _wait_for_port_free(port)
-                log.info("llm_selector: stopped old managed server pid=%d model=%s",
-                         pid, existing_model)
-        except Exception:
-            pass
+            time.sleep(1)
 
-    proc = subprocess.Popen(
-        [sys.executable, "-m", "mlx_lm.server",
-         "--model", model_id, "--port", str(port), "--max-tokens", "4096"],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-        start_new_session=True,
-    )
-    pid_file.parent.mkdir(parents=True, exist_ok=True)
-    pid_file.write_text(json.dumps({"pid": proc.pid, "model": model_id, "port": port}))
-
-    url = f"http://127.0.0.1:{port}/v1/models"
-    deadline = time.monotonic() + 90.0
-    while time.monotonic() < deadline:
-        if proc.poll() is not None:
-            log.warning("llm_selector: mlx_lm.server exited early (exit=%d) — is mlx_lm installed?",
-                        proc.returncode)
-            pid_file.unlink(missing_ok=True)
-            return False
-        _, status = _get_json(url, timeout=1.0)
-        if status == 200:
-            log.info("llm_selector: mlx_lm.server ready model=%s port=%d", model_id, port)
-            return True
-        time.sleep(1)
-    log.warning("llm_selector: mlx_lm.server startup timeout model=%s", model_id)
-    return False
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        log.warning(
+            "llm_selector: mlx_lm.server startup timeout model=%s elapsed_ms=%d",
+            model_id, elapsed_ms,
+        )
+        span.set_attribute("server.action",  "timeout")
+        span.add_event("server_timeout", {"elapsed_ms": elapsed_ms})
+        return False
 
 
 def select_model_for_hermes(budget_pct: Optional[float] = None) -> Optional[LocalModelEndpoint]:
@@ -543,11 +647,15 @@ def select_model_for_hermes(budget_pct: Optional[float] = None) -> Optional[Loca
                 span.set_attribute("llm.is_local", False)
                 return None
 
-            for server in discover_running_servers():
+            servers = discover_running_servers()
+            if not servers:
+                log.debug("llm_selector: no external servers found — will compute budget")
+
+            for server in servers:
                 if server.runtime == "apple_fm":
                     continue
                 _shutdown_managed_server()
-                log.info("llm_selector: hermes endpoint reusing %s model=%s",
+                log.info("llm_selector: using external server runtime=%s model=%s",
                          server.runtime, server.best_model)
                 result = LocalModelEndpoint(
                     model=server.best_model,
@@ -557,16 +665,30 @@ def select_model_for_hermes(budget_pct: Optional[float] = None) -> Optional[Loca
                 )
                 break
 
+            _reason = "cloud_fallback"
+            _headroom_gb = 0.0
+            _adj_headroom_gb = 0.0
+            _budget_gb = 0.0
+            _thermal = 0
+            _screen_locked_val = False
+            _effective_pct = budget_pct
+
             if result is None:
                 try:
                     snap = probe_compute()
                 except Exception as exc:
                     log.warning("llm_selector: compute probe failed: %s", exc)
-                    span.set_attribute("llm.budget_pct", budget_pct)
-                    span.set_attribute("llm.selected_model", "cloud_fallback")
+                    _reason = "compute_probe_failed"
+                    span.set_attribute("llm.budget_pct",       budget_pct)
+                    span.set_attribute("llm.selected_model",   "cloud_fallback")
                     span.set_attribute("llm.selected_runtime", "cloud")
-                    span.set_attribute("llm.is_local", False)
+                    span.set_attribute("llm.is_local",         False)
+                    span.set_attribute("llm.reason",           _reason)
                     return None
+
+                _headroom_gb      = snap.metal_headroom_gb
+                _thermal          = snap.thermal_level
+                _screen_locked_val = snap.screen_locked
 
                 # If a managed server is already running, its model weight is
                 # included in Metal's "used" accounting, which shrinks headroom.
@@ -574,7 +696,7 @@ def select_model_for_hermes(budget_pct: Optional[float] = None) -> Optional[Loca
                 # budget rather than headroom-minus-current-model.  Without this
                 # the selected model changes on every tick as headroom shifts,
                 # causing an oscillation loop (Qwen3.5 → phi-4 → gemma → …).
-                headroom = snap.metal_headroom_gb
+                _adj_headroom_gb = _headroom_gb
                 if _MANAGED_SERVER_PID_FILE.exists():
                     try:
                         meta = json.loads(_MANAGED_SERVER_PID_FILE.read_text())
@@ -584,37 +706,86 @@ def select_model_for_hermes(budget_pct: Optional[float] = None) -> Optional[Loca
                              if hf == meta["model"]),
                             0.0,
                         )
-                        headroom = snap.metal_headroom_gb + current_ram
-                        log.debug(
-                            "llm_selector: adjusted headroom %.1f→%.1f GB "
-                            "(adding managed model=%s %.1f GB)",
-                            snap.metal_headroom_gb, headroom,
+                        _adj_headroom_gb = _headroom_gb + current_ram
+                        log.info(
+                            "llm_selector: headroom adjusted %.1f→%.1f GB "
+                            "(managed model=%s uses %.1f GB)",
+                            _headroom_gb, _adj_headroom_gb,
                             meta["model"], current_ram,
                         )
                     except (OSError, Exception):
                         pass
 
-                effective_pct = min(0.8, budget_pct * 1.5) if snap.screen_locked else budget_pct
-                entry = _select_mlx_entry(headroom, effective_pct,
+                _effective_pct = min(0.8, budget_pct * 1.5) if snap.screen_locked else budget_pct
+                _budget_gb = _adj_headroom_gb * _effective_pct
+
+                entry = _select_mlx_entry(_adj_headroom_gb, _effective_pct,
                                           snap.thermal_level, apple_intelligence=False)
                 if entry is None:
-                    log.info("llm_selector: no local model fits budget headroom=%.1f GB pct=%.2f",
-                             headroom, effective_pct)
+                    _reason = "no_model_fits"
+                    log.info(
+                        "llm_selector: no local model fits "
+                        "headroom=%.1f GB adj=%.1f GB budget=%.1f GB pct=%.2f → cloud fallback",
+                        _headroom_gb, _adj_headroom_gb, _budget_gb, _effective_pct,
+                    )
                 else:
-                    model_id, _, _, _, hf_id = entry
-                    log.info("llm_selector: hermes will use mlx_managed model=%s hf=%s", model_id, hf_id)
+                    model_id, _, min_ram, quality, hf_id = entry
+                    log.info(
+                        "llm_selector: selected model=%s hf=%s min_ram=%.1f GB quality=%d "
+                        "headroom=%.1f GB adj=%.1f GB budget=%.1f GB pct=%.2f",
+                        model_id, hf_id, min_ram, quality,
+                        _headroom_gb, _adj_headroom_gb, _budget_gb, _effective_pct,
+                    )
                     if _ensure_mlx_server(hf_id, _MANAGED_SERVER_PORT):
+                        _reason = "mlx_managed"
                         result = LocalModelEndpoint(
                             model=hf_id,
                             base_url=f"http://127.0.0.1:{_MANAGED_SERVER_PORT}/v1",
                             api_key="local",
                             runtime="mlx_managed",
                         )
+                    else:
+                        _reason = "mlx_server_failed"
+                        log.warning(
+                            "llm_selector: mlx_lm.server failed to start for model=%s — cloud fallback",
+                            hf_id,
+                        )
+            else:
+                _reason = result.runtime
 
-            span.set_attribute("llm.budget_pct", budget_pct)
-            span.set_attribute("llm.selected_model", result.model if result else "cloud_fallback")
-            span.set_attribute("llm.selected_runtime", result.runtime if result else "cloud")
-            span.set_attribute("llm.is_local", result is not None)
+            _selected_model   = result.model   if result else "cloud_fallback"
+            _selected_runtime = result.runtime if result else "cloud"
+            _is_local         = result is not None
+
+            span.set_attribute("llm.budget_pct",         budget_pct)
+            span.set_attribute("llm.effective_pct",      round(_effective_pct, 3))
+            span.set_attribute("llm.headroom_gb",        round(_headroom_gb, 2))
+            span.set_attribute("llm.adj_headroom_gb",    round(_adj_headroom_gb, 2))
+            span.set_attribute("llm.budget_gb",          round(_budget_gb, 2))
+            span.set_attribute("llm.thermal_level",      _thermal)
+            span.set_attribute("llm.screen_locked",      _screen_locked_val)
+            span.set_attribute("llm.reason",             _reason)
+            span.set_attribute("llm.selected_model",     _selected_model)
+            span.set_attribute("llm.selected_runtime",   _selected_runtime)
+            span.set_attribute("llm.is_local",           _is_local)
+
+            log.info(
+                "llm_selector: decision reason=%s model=%s runtime=%s "
+                "budget_pct=%.2f headroom_gb=%.1f budget_gb=%.1f thermal=%d",
+                _reason, _selected_model, _selected_runtime,
+                budget_pct, _adj_headroom_gb, _budget_gb, _thermal,
+                extra={
+                    "llm_selector_reason":       _reason,
+                    "llm_selector_model":        _selected_model,
+                    "llm_selector_runtime":      _selected_runtime,
+                    "llm_selector_budget_pct":   budget_pct,
+                    "llm_selector_headroom_gb":  round(_adj_headroom_gb, 2),
+                    "llm_selector_budget_gb":    round(_budget_gb, 2),
+                    "llm_selector_thermal":      _thermal,
+                    "llm_selector_screen_locked": _screen_locked_val,
+                    "llm_selector_is_local":     _is_local,
+                },
+            )
             return result
         except Exception as exc:
             span.record_exception(exc)

--- a/services/agents/llm_selector.py
+++ b/services/agents/llm_selector.py
@@ -447,6 +447,31 @@ def _shutdown_managed_server() -> None:
     pid_file.unlink(missing_ok=True)
 
 
+def _wait_for_process_exit(pid: int, timeout: float = 10.0) -> None:
+    """Wait for a process to exit; SIGKILL after timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return  # dead
+        time.sleep(0.3)
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except OSError:
+        pass
+    time.sleep(0.5)
+
+
+def _wait_for_port_free(port: int, timeout: float = 5.0) -> None:
+    """Wait until a local TCP port stops accepting connections."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _tcp_open("127.0.0.1", port, timeout=0.3):
+            return
+        time.sleep(0.3)
+
+
 def _ensure_mlx_server(model_id: str, port: int = _MANAGED_SERVER_PORT) -> bool:
     pid_file = _MANAGED_SERVER_PID_FILE
     if pid_file.exists():
@@ -462,7 +487,10 @@ def _ensure_mlx_server(model_id: str, port: int = _MANAGED_SERVER_PORT) -> bool:
                 return True
             if alive:
                 os.kill(pid, signal.SIGTERM)
-                time.sleep(3)
+                _wait_for_process_exit(pid)
+                _wait_for_port_free(port)
+                log.info("llm_selector: stopped old managed server pid=%d model=%s",
+                         pid, existing_model)
         except Exception:
             pass
 

--- a/services/agents/llm_selector.py
+++ b/services/agents/llm_selector.py
@@ -568,12 +568,38 @@ def select_model_for_hermes(budget_pct: Optional[float] = None) -> Optional[Loca
                     span.set_attribute("llm.is_local", False)
                     return None
 
+                # If a managed server is already running, its model weight is
+                # included in Metal's "used" accounting, which shrinks headroom.
+                # Add that weight back so the selection sees the true system-wide
+                # budget rather than headroom-minus-current-model.  Without this
+                # the selected model changes on every tick as headroom shifts,
+                # causing an oscillation loop (Qwen3.5 → phi-4 → gemma → …).
+                headroom = snap.metal_headroom_gb
+                if _MANAGED_SERVER_PID_FILE.exists():
+                    try:
+                        meta = json.loads(_MANAGED_SERVER_PID_FILE.read_text())
+                        os.kill(meta["pid"], 0)  # raises OSError if dead
+                        current_ram = next(
+                            (min_ram for _, _, min_ram, _, hf in _MODELS
+                             if hf == meta["model"]),
+                            0.0,
+                        )
+                        headroom = snap.metal_headroom_gb + current_ram
+                        log.debug(
+                            "llm_selector: adjusted headroom %.1f→%.1f GB "
+                            "(adding managed model=%s %.1f GB)",
+                            snap.metal_headroom_gb, headroom,
+                            meta["model"], current_ram,
+                        )
+                    except (OSError, Exception):
+                        pass
+
                 effective_pct = min(0.8, budget_pct * 1.5) if snap.screen_locked else budget_pct
-                entry = _select_mlx_entry(snap.metal_headroom_gb, effective_pct,
+                entry = _select_mlx_entry(headroom, effective_pct,
                                           snap.thermal_level, apple_intelligence=False)
                 if entry is None:
                     log.info("llm_selector: no local model fits budget headroom=%.1f GB pct=%.2f",
-                             snap.metal_headroom_gb, effective_pct)
+                             headroom, effective_pct)
                 else:
                     model_id, _, _, _, hf_id = entry
                     log.info("llm_selector: hermes will use mlx_managed model=%s hf=%s", model_id, hf_id)

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 .env.local
 *.db
+next-env.d.ts

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -166,8 +166,45 @@ html.density-comfy  .density-pad  { padding-top: 1.25rem; padding-bottom: 1.25re
 .stepper-input::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; }
 .stepper-input { -moz-appearance: textfield; }
 
-/* ── Radix Select trigger focus ───────────────────────────────────────────── */
+/* ── Radix Select ─────────────────────────────────────────────────────────── */
 .select-trigger:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+.select-item[data-highlighted] {
+  background: var(--accent);
+  color: #fff;
+  outline: none;
+}
+.select-item[data-highlighted] .select-check {
+  color: #fff;
+}
+
+/* ── Radix Switch — iOS-style pill ────────────────────────────────────────── */
+.meridian-switch {
+  background: rgba(120, 120, 128, 0.28);
+  transition: background 0.22s ease;
+}
+.meridian-switch[data-state="checked"] {
+  background: var(--accent);
+}
+.meridian-switch-thumb {
+  transform: translateX(2px);
+  transition: transform 0.22s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+              box-shadow 0.15s ease;
+}
+.meridian-switch-thumb[data-state="checked"] {
+  transform: translateX(20px);
+}
+
+/* ── Number stepper buttons ───────────────────────────────────────────────── */
+.stepper-btn {
+  background: transparent;
+  transition: background 0.1s ease;
+}
+.stepper-btn:hover:not(:disabled) {
+  background: var(--surface-2);
+}
+.stepper-btn:active:not(:disabled) {
+  background: var(--rule);
 }

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -160,3 +160,14 @@ button:focus-visible, a:focus-visible, [tabindex]:focus-visible {
 /* ── Density ──────────────────────────────────────────────────────────────── */
 html.density-compact .density-pad { padding-top: .5rem; padding-bottom: .5rem; }
 html.density-comfy  .density-pad  { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+
+/* ── Number stepper — hide native spin buttons ────────────────────────────── */
+.stepper-input::-webkit-inner-spin-button,
+.stepper-input::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; }
+.stepper-input { -moz-appearance: textfield; }
+
+/* ── Radix Select trigger focus ───────────────────────────────────────────── */
+.select-trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}

--- a/ui/components/ui/NumberStepper.tsx
+++ b/ui/components/ui/NumberStepper.tsx
@@ -1,0 +1,90 @@
+// meridian — normalises screenpipe activity into structured app sessions
+'use client'
+
+import { useRef } from 'react'
+import { Minus, Plus } from 'lucide-react'
+
+interface NumberStepperProps {
+  value: number
+  onChange: (v: number) => void
+  min?: number
+  max?: number
+  step?: number
+}
+
+export function NumberStepper({ value, onChange, min, max, step = 1 }: NumberStepperProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const atMin = min !== undefined && value <= min
+  const atMax = max !== undefined && value >= max
+
+  function clamp(n: number) {
+    if (min !== undefined && n < min) return min
+    if (max !== undefined && n > max) return max
+    return n
+  }
+
+  const btnStyle = (disabled: boolean): React.CSSProperties => ({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '30px',
+    height: '30px',
+    border: 'none',
+    background: 'transparent',
+    color: disabled ? 'var(--ink-4)' : 'var(--ink-2)',
+    cursor: disabled ? 'not-allowed' : 'default',
+    flexShrink: 0,
+    transition: 'color 0.1s',
+  })
+
+  return (
+    <div style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      height: '30px',
+      borderRadius: '7px',
+      border: '1px solid var(--rule-2)',
+      background: 'var(--surface)',
+      overflow: 'hidden',
+      boxShadow: '0 1px 2px rgba(0,0,0,0.06)',
+    }}>
+      <button type="button" disabled={atMin} onClick={() => onChange(clamp(value - step))} style={btnStyle(atMin)}>
+        <Minus size={11} strokeWidth={2.5} />
+      </button>
+
+      <div style={{ width: '1px', height: '16px', background: 'var(--rule)', flexShrink: 0 }} />
+
+      <input
+        ref={inputRef}
+        type="number"
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+        onChange={e => {
+          const n = Number(e.target.value)
+          if (!isNaN(n)) onChange(clamp(n))
+        }}
+        style={{
+          width: '52px',
+          height: '100%',
+          border: 'none',
+          background: 'transparent',
+          textAlign: 'center',
+          fontSize: '13px',
+          color: 'var(--ink)',
+          outline: 'none',
+          padding: '0 2px',
+          // spinner hidden via globals.css
+        }}
+        className="stepper-input"
+      />
+
+      <div style={{ width: '1px', height: '16px', background: 'var(--rule)', flexShrink: 0 }} />
+
+      <button type="button" disabled={atMax} onClick={() => onChange(clamp(value + step))} style={btnStyle(atMax)}>
+        <Plus size={11} strokeWidth={2.5} />
+      </button>
+    </div>
+  )
+}

--- a/ui/components/ui/NumberStepper.tsx
+++ b/ui/components/ui/NumberStepper.tsx
@@ -1,7 +1,6 @@
 // meridian — normalises screenpipe activity into structured app sessions
 'use client'
 
-import { useRef } from 'react'
 import { Minus, Plus } from 'lucide-react'
 
 interface NumberStepperProps {
@@ -13,49 +12,53 @@ interface NumberStepperProps {
 }
 
 export function NumberStepper({ value, onChange, min, max, step = 1 }: NumberStepperProps) {
-  const inputRef = useRef<HTMLInputElement>(null)
   const atMin = min !== undefined && value <= min
   const atMax = max !== undefined && value >= max
 
   function clamp(n: number) {
-    if (min !== undefined && n < min) return min
-    if (max !== undefined && n > max) return max
-    return n
+    let v = n
+    if (min !== undefined && v < min) v = min
+    if (max !== undefined && v > max) v = max
+    return v
   }
-
-  const btnStyle = (disabled: boolean): React.CSSProperties => ({
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '30px',
-    height: '30px',
-    border: 'none',
-    background: 'transparent',
-    color: disabled ? 'var(--ink-4)' : 'var(--ink-2)',
-    cursor: disabled ? 'not-allowed' : 'default',
-    flexShrink: 0,
-    transition: 'color 0.1s',
-  })
 
   return (
     <div style={{
       display: 'inline-flex',
-      alignItems: 'center',
+      alignItems: 'stretch',
       height: '30px',
       borderRadius: '7px',
       border: '1px solid var(--rule-2)',
       background: 'var(--surface)',
       overflow: 'hidden',
-      boxShadow: '0 1px 2px rgba(0,0,0,0.06)',
+      boxShadow: '0 1px 2px rgba(0,0,0,0.07)',
     }}>
-      <button type="button" disabled={atMin} onClick={() => onChange(clamp(value - step))} style={btnStyle(atMin)}>
+      {/* Decrement */}
+      <button
+        type="button"
+        disabled={atMin}
+        onClick={() => onChange(clamp(value - step))}
+        className="stepper-btn"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '30px',
+          border: 'none',
+          cursor: atMin ? 'not-allowed' : 'default',
+          color: atMin ? 'var(--ink-4)' : 'var(--ink-2)',
+          flexShrink: 0,
+        }}
+        aria-label="Decrease"
+      >
         <Minus size={11} strokeWidth={2.5} />
       </button>
 
-      <div style={{ width: '1px', height: '16px', background: 'var(--rule)', flexShrink: 0 }} />
+      {/* Divider */}
+      <div style={{ width: '1px', background: 'var(--rule)', flexShrink: 0, alignSelf: 'stretch' }} />
 
+      {/* Value input */}
       <input
-        ref={inputRef}
         type="number"
         value={value}
         min={min}
@@ -65,9 +68,9 @@ export function NumberStepper({ value, onChange, min, max, step = 1 }: NumberSte
           const n = Number(e.target.value)
           if (!isNaN(n)) onChange(clamp(n))
         }}
+        className="stepper-input"
         style={{
           width: '52px',
-          height: '100%',
           border: 'none',
           background: 'transparent',
           textAlign: 'center',
@@ -75,14 +78,30 @@ export function NumberStepper({ value, onChange, min, max, step = 1 }: NumberSte
           color: 'var(--ink)',
           outline: 'none',
           padding: '0 2px',
-          // spinner hidden via globals.css
         }}
-        className="stepper-input"
       />
 
-      <div style={{ width: '1px', height: '16px', background: 'var(--rule)', flexShrink: 0 }} />
+      {/* Divider */}
+      <div style={{ width: '1px', background: 'var(--rule)', flexShrink: 0, alignSelf: 'stretch' }} />
 
-      <button type="button" disabled={atMax} onClick={() => onChange(clamp(value + step))} style={btnStyle(atMax)}>
+      {/* Increment */}
+      <button
+        type="button"
+        disabled={atMax}
+        onClick={() => onChange(clamp(value + step))}
+        className="stepper-btn"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '30px',
+          border: 'none',
+          cursor: atMax ? 'not-allowed' : 'default',
+          color: atMax ? 'var(--ink-4)' : 'var(--ink-2)',
+          flexShrink: 0,
+        }}
+        aria-label="Increase"
+      >
         <Plus size={11} strokeWidth={2.5} />
       </button>
     </div>

--- a/ui/components/ui/NumberStepper.tsx
+++ b/ui/components/ui/NumberStepper.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { Minus, Plus } from 'lucide-react'
+import { useState, useEffect } from 'react'
 
 interface NumberStepperProps {
   value: number
@@ -12,6 +13,14 @@ interface NumberStepperProps {
 }
 
 export function NumberStepper({ value, onChange, min, max, step = 1 }: NumberStepperProps) {
+  const [inputVal, setInputVal] = useState(String(value))
+  const [focused, setFocused] = useState(false)
+
+  // Keep display in sync when value changes externally (e.g. stepper buttons)
+  useEffect(() => {
+    if (!focused) setInputVal(String(value))
+  }, [value, focused])
+
   const atMin = min !== undefined && value <= min
   const atMax = max !== undefined && value >= max
 
@@ -20,6 +29,16 @@ export function NumberStepper({ value, onChange, min, max, step = 1 }: NumberSte
     if (min !== undefined && v < min) v = min
     if (max !== undefined && v > max) v = max
     return v
+  }
+
+  function commit(raw: string) {
+    const n = Number(raw)
+    if (!isNaN(n) && raw.trim() !== '') {
+      onChange(clamp(n))
+    } else {
+      // revert display to last valid value
+      setInputVal(String(value))
+    }
   }
 
   return (
@@ -57,17 +76,17 @@ export function NumberStepper({ value, onChange, min, max, step = 1 }: NumberSte
       {/* Divider */}
       <div style={{ width: '1px', background: 'var(--rule)', flexShrink: 0, alignSelf: 'stretch' }} />
 
-      {/* Value input */}
+      {/* Value input — local string state so partial edits aren't clamped mid-type */}
       <input
         type="number"
-        value={value}
+        value={inputVal}
         min={min}
         max={max}
         step={step}
-        onChange={e => {
-          const n = Number(e.target.value)
-          if (!isNaN(n)) onChange(clamp(n))
-        }}
+        onChange={e => setInputVal(e.target.value)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => { setFocused(false); commit(inputVal) }}
+        onKeyDown={e => { if (e.key === 'Enter') commit(inputVal) }}
         className="stepper-input"
         style={{
           width: '52px',

--- a/ui/components/ui/Select.tsx
+++ b/ui/components/ui/Select.tsx
@@ -2,13 +2,22 @@
 'use client'
 
 import * as RadixSelect from '@radix-ui/react-select'
-import { ChevronDown, ChevronUp, Check } from 'lucide-react'
+import { Check } from 'lucide-react'
 
 interface SelectProps {
   value: string
   onValueChange: (v: string) => void
   options: { value: string; label: string }[]
   placeholder?: string
+}
+
+// Up/down double-chevron — the macOS native select badge icon
+function SelectChevrons() {
+  return (
+    <svg viewBox="0 0 10 16" width="8" height="11" fill="white" aria-hidden>
+      <path d="M5 4L1 8h8L5 4zm0 8L1 8h8l-4 4z" />
+    </svg>
+  )
 }
 
 export function Select({ value, onValueChange, options, placeholder }: SelectProps) {
@@ -19,49 +28,60 @@ export function Select({ value, onValueChange, options, placeholder }: SelectPro
         style={{
           display: 'inline-flex',
           alignItems: 'center',
-          justifyContent: 'space-between',
-          gap: '8px',
-          minWidth: '120px',
-          padding: '6px 10px',
-          borderRadius: '7px',
+          gap: 0,
+          borderRadius: '6px',
           border: '1px solid var(--rule-2)',
           background: 'var(--surface)',
-          color: 'var(--ink)',
           fontSize: '13px',
+          color: 'var(--ink)',
           cursor: 'default',
           outline: 'none',
-          boxShadow: '0 1px 2px rgba(0,0,0,0.06)',
+          overflow: 'hidden',
+          boxShadow: '0 1px 2px rgba(0,0,0,0.07)',
+          minWidth: '120px',
         }}
       >
-        <RadixSelect.Value placeholder={placeholder} />
-        <RadixSelect.Icon style={{ color: 'var(--ink-3)', flexShrink: 0 }}>
-          <ChevronDown size={13} strokeWidth={2} />
+        {/* Label area */}
+        <span style={{ flex: 1, padding: '6px 8px 6px 10px', textAlign: 'left' }}>
+          <RadixSelect.Value placeholder={placeholder} />
+        </span>
+
+        {/* macOS accent badge with up/down chevrons */}
+        <RadixSelect.Icon asChild>
+          <span style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: '24px',
+            alignSelf: 'stretch',
+            background: 'var(--accent)',
+            flexShrink: 0,
+          }}>
+            <SelectChevrons />
+          </span>
         </RadixSelect.Icon>
       </RadixSelect.Trigger>
 
       <RadixSelect.Portal>
         <RadixSelect.Content
           position="popper"
-          sideOffset={4}
+          sideOffset={5}
           style={{
             background: 'var(--surface)',
             border: '1px solid var(--rule)',
             borderRadius: '9px',
-            boxShadow: '0 8px 24px rgba(0,0,0,0.12), 0 2px 6px rgba(0,0,0,0.07)',
+            boxShadow: '0 8px 32px rgba(0,0,0,0.14), 0 2px 8px rgba(0,0,0,0.08)',
             overflow: 'hidden',
             zIndex: 9999,
             minWidth: 'var(--radix-select-trigger-width)',
           }}
         >
-          <RadixSelect.ScrollUpButton style={{ display: 'flex', justifyContent: 'center', padding: '4px', color: 'var(--ink-3)' }}>
-            <ChevronUp size={12} />
-          </RadixSelect.ScrollUpButton>
-
           <RadixSelect.Viewport style={{ padding: '4px' }}>
             {options.map(opt => (
               <RadixSelect.Item
                 key={opt.value}
                 value={opt.value}
+                className="select-item"
                 style={{
                   display: 'flex',
                   alignItems: 'center',
@@ -69,27 +89,19 @@ export function Select({ value, onValueChange, options, placeholder }: SelectPro
                   padding: '6px 10px',
                   borderRadius: '5px',
                   fontSize: '13px',
-                  color: 'var(--ink)',
                   cursor: 'default',
                   outline: 'none',
                   userSelect: 'none',
+                  color: 'var(--ink)',
                 }}
-                onMouseEnter={e => (e.currentTarget.style.background = 'var(--surface-2)')}
-                onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
-                onFocus={e => (e.currentTarget.style.background = 'var(--surface-2)')}
-                onBlur={e => (e.currentTarget.style.background = 'transparent')}
               >
                 <RadixSelect.ItemText>{opt.label}</RadixSelect.ItemText>
-                <RadixSelect.ItemIndicator style={{ color: 'var(--accent)' }}>
+                <RadixSelect.ItemIndicator className="select-check" style={{ color: 'var(--accent)', marginLeft: '8px' }}>
                   <Check size={12} strokeWidth={2.5} />
                 </RadixSelect.ItemIndicator>
               </RadixSelect.Item>
             ))}
           </RadixSelect.Viewport>
-
-          <RadixSelect.ScrollDownButton style={{ display: 'flex', justifyContent: 'center', padding: '4px', color: 'var(--ink-3)' }}>
-            <ChevronDown size={12} />
-          </RadixSelect.ScrollDownButton>
         </RadixSelect.Content>
       </RadixSelect.Portal>
     </RadixSelect.Root>

--- a/ui/components/ui/Select.tsx
+++ b/ui/components/ui/Select.tsx
@@ -1,0 +1,97 @@
+// meridian — normalises screenpipe activity into structured app sessions
+'use client'
+
+import * as RadixSelect from '@radix-ui/react-select'
+import { ChevronDown, ChevronUp, Check } from 'lucide-react'
+
+interface SelectProps {
+  value: string
+  onValueChange: (v: string) => void
+  options: { value: string; label: string }[]
+  placeholder?: string
+}
+
+export function Select({ value, onValueChange, options, placeholder }: SelectProps) {
+  return (
+    <RadixSelect.Root value={value} onValueChange={onValueChange}>
+      <RadixSelect.Trigger
+        className="select-trigger"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: '8px',
+          minWidth: '120px',
+          padding: '6px 10px',
+          borderRadius: '7px',
+          border: '1px solid var(--rule-2)',
+          background: 'var(--surface)',
+          color: 'var(--ink)',
+          fontSize: '13px',
+          cursor: 'default',
+          outline: 'none',
+          boxShadow: '0 1px 2px rgba(0,0,0,0.06)',
+        }}
+      >
+        <RadixSelect.Value placeholder={placeholder} />
+        <RadixSelect.Icon style={{ color: 'var(--ink-3)', flexShrink: 0 }}>
+          <ChevronDown size={13} strokeWidth={2} />
+        </RadixSelect.Icon>
+      </RadixSelect.Trigger>
+
+      <RadixSelect.Portal>
+        <RadixSelect.Content
+          position="popper"
+          sideOffset={4}
+          style={{
+            background: 'var(--surface)',
+            border: '1px solid var(--rule)',
+            borderRadius: '9px',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.12), 0 2px 6px rgba(0,0,0,0.07)',
+            overflow: 'hidden',
+            zIndex: 9999,
+            minWidth: 'var(--radix-select-trigger-width)',
+          }}
+        >
+          <RadixSelect.ScrollUpButton style={{ display: 'flex', justifyContent: 'center', padding: '4px', color: 'var(--ink-3)' }}>
+            <ChevronUp size={12} />
+          </RadixSelect.ScrollUpButton>
+
+          <RadixSelect.Viewport style={{ padding: '4px' }}>
+            {options.map(opt => (
+              <RadixSelect.Item
+                key={opt.value}
+                value={opt.value}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  padding: '6px 10px',
+                  borderRadius: '5px',
+                  fontSize: '13px',
+                  color: 'var(--ink)',
+                  cursor: 'default',
+                  outline: 'none',
+                  userSelect: 'none',
+                }}
+                onMouseEnter={e => (e.currentTarget.style.background = 'var(--surface-2)')}
+                onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+                onFocus={e => (e.currentTarget.style.background = 'var(--surface-2)')}
+                onBlur={e => (e.currentTarget.style.background = 'transparent')}
+              >
+                <RadixSelect.ItemText>{opt.label}</RadixSelect.ItemText>
+                <RadixSelect.ItemIndicator style={{ color: 'var(--accent)' }}>
+                  <Check size={12} strokeWidth={2.5} />
+                </RadixSelect.ItemIndicator>
+              </RadixSelect.Item>
+            ))}
+          </RadixSelect.Viewport>
+
+          <RadixSelect.ScrollDownButton style={{ display: 'flex', justifyContent: 'center', padding: '4px', color: 'var(--ink-3)' }}>
+            <ChevronDown size={12} />
+          </RadixSelect.ScrollDownButton>
+        </RadixSelect.Content>
+      </RadixSelect.Portal>
+    </RadixSelect.Root>
+  )
+}

--- a/ui/components/ui/Switch.tsx
+++ b/ui/components/ui/Switch.tsx
@@ -1,0 +1,49 @@
+// meridian — normalises screenpipe activity into structured app sessions
+'use client'
+
+import * as RadixSwitch from '@radix-ui/react-switch'
+
+interface SwitchProps {
+  checked: boolean
+  onCheckedChange: (v: boolean) => void
+  id?: string
+}
+
+export function Switch({ checked, onCheckedChange, id }: SwitchProps) {
+  return (
+    <RadixSwitch.Root
+      id={id}
+      checked={checked}
+      onCheckedChange={onCheckedChange}
+      style={{
+        width: '42px',
+        height: '24px',
+        borderRadius: '12px',
+        border: 'none',
+        padding: 0,
+        cursor: 'default',
+        flexShrink: 0,
+        background: checked ? 'var(--accent)' : 'var(--rule-2)',
+        transition: 'background 0.2s ease',
+        position: 'relative',
+        outline: 'none',
+      }}
+    >
+      <RadixSwitch.Thumb
+        style={{
+          display: 'block',
+          width: '20px',
+          height: '20px',
+          borderRadius: '50%',
+          background: '#fff',
+          boxShadow: '0 1px 4px rgba(0,0,0,0.22)',
+          position: 'absolute',
+          top: '2px',
+          left: checked ? '20px' : '2px',
+          transition: 'left 0.18s cubic-bezier(0.25,0.46,0.45,0.94)',
+          willChange: 'left',
+        }}
+      />
+    </RadixSwitch.Root>
+  )
+}

--- a/ui/components/ui/Switch.tsx
+++ b/ui/components/ui/Switch.tsx
@@ -15,6 +15,8 @@ export function Switch({ checked, onCheckedChange, id }: SwitchProps) {
       id={id}
       checked={checked}
       onCheckedChange={onCheckedChange}
+      // data-state="checked"|"unchecked" set by Radix — CSS in globals.css handles colors + animation
+      className="meridian-switch"
       style={{
         width: '42px',
         height: '24px',
@@ -23,25 +25,23 @@ export function Switch({ checked, onCheckedChange, id }: SwitchProps) {
         padding: 0,
         cursor: 'default',
         flexShrink: 0,
-        background: checked ? 'var(--accent)' : 'var(--rule-2)',
-        transition: 'background 0.2s ease',
         position: 'relative',
         outline: 'none',
       }}
     >
       <RadixSwitch.Thumb
+        className="meridian-switch-thumb"
         style={{
           display: 'block',
           width: '20px',
           height: '20px',
           borderRadius: '50%',
           background: '#fff',
-          boxShadow: '0 1px 4px rgba(0,0,0,0.22)',
+          // layered shadow: first layer is the ambient drop, second is the key light
+          boxShadow: '0 2px 4px rgba(0,0,0,0.24), 0 0.5px 1px rgba(0,0,0,0.12)',
           position: 'absolute',
           top: '2px',
-          left: checked ? '20px' : '2px',
-          transition: 'left 0.18s cubic-bezier(0.25,0.46,0.45,0.94)',
-          willChange: 'left',
+          willChange: 'transform',
         }}
       />
     </RadixSwitch.Root>

--- a/ui/components/views/SettingsView.tsx
+++ b/ui/components/views/SettingsView.tsx
@@ -2,201 +2,13 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { Select } from '@/components/ui/Select'
+import { Switch } from '@/components/ui/Switch'
+import { NumberStepper } from '@/components/ui/NumberStepper'
 import type { RuntimeSettings } from '@/lib/settings'
 
 type SaveStatus = 'idle' | 'saved' | 'error'
 
-// ── Apple-style Toggle ───────────────────────────────────────────────────────
-function Toggle({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      onClick={() => onChange(!checked)}
-      style={{
-        position: 'relative',
-        display: 'inline-flex',
-        height: '22px',
-        width: '40px',
-        flexShrink: 0,
-        cursor: 'default',
-        borderRadius: '11px',
-        border: 'none',
-        transition: 'background 0.25s',
-        background: checked ? 'var(--accent)' : 'rgba(120,120,128,0.32)',
-        boxShadow: '0 1px 3px rgba(0,0,0,0.18) inset',
-      }}
-    >
-      <span style={{
-        pointerEvents: 'none',
-        position: 'absolute',
-        top: '2px',
-        left: checked ? '20px' : '2px',
-        width: '18px',
-        height: '18px',
-        borderRadius: '50%',
-        background: '#fff',
-        boxShadow: '0 1px 4px rgba(0,0,0,0.25)',
-        transition: 'left 0.2s cubic-bezier(0.25,0.46,0.45,0.94)',
-      }} />
-    </button>
-  )
-}
-
-// ── Apple macOS-style Select ─────────────────────────────────────────────────
-function SelectInput({ value, onChange, options }: { value: string; onChange: (v: string) => void; options: string[] }) {
-  const [focused, setFocused] = useState(false)
-  return (
-    <div style={{
-      display: 'inline-block',
-      position: 'relative',
-      borderRadius: '5px',
-      border: focused ? '1px solid var(--accent)' : '1px solid rgba(0,0,0,0.14)',
-      boxShadow: focused
-        ? '0 0 0 3px rgba(0,122,255,0.25)'
-        : '0 0.5px 2px rgba(0,0,0,0.12)',
-      background: 'var(--surface)',
-      transition: 'box-shadow 0.15s, border-color 0.15s',
-    }}>
-      <select
-        value={value}
-        onChange={e => onChange(e.target.value)}
-        onFocus={() => setFocused(true)}
-        onBlur={() => setFocused(false)}
-        style={{
-          WebkitAppearance: 'none',
-          appearance: 'none',
-          background: 'transparent',
-          border: 'none',
-          outline: 'none',
-          borderRadius: '5px',
-          padding: '5px 30px 5px 9px',
-          fontSize: '13px',
-          color: 'var(--ink)',
-          cursor: 'default',
-          minWidth: '100px',
-        }}
-      >
-        {options.map(o => <option key={o} value={o}>{o}</option>)}
-      </select>
-      {/* macOS-style blue badge with up/down chevron */}
-      <span style={{
-        position: 'absolute',
-        right: 0,
-        top: 0,
-        bottom: 0,
-        width: '22px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        background: 'var(--accent)',
-        borderRadius: '0 4px 4px 0',
-        pointerEvents: 'none',
-      }}>
-        <svg viewBox="0 0 10 16" width="8" height="12" fill="white">
-          <path d="M5 4L1 8h8L5 4zm0 8L1 8h8l-4 4z" />
-        </svg>
-      </span>
-    </div>
-  )
-}
-
-// ── Apple macOS-style Stepper ────────────────────────────────────────────────
-function NumberInput({ value, onChange, min, max, step }: {
-  value: number; onChange: (v: number) => void; min?: number; max?: number; step?: number
-}) {
-  const s = step ?? 1
-  const atMin = min !== undefined && value <= min
-  const atMax = max !== undefined && value >= max
-
-  function dec() { onChange(min !== undefined ? Math.max(min, value - s) : value - s) }
-  function inc() { onChange(max !== undefined ? Math.min(max, value + s) : value + s) }
-
-  const btnBase: React.CSSProperties = {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '28px',
-    height: '28px',
-    border: 'none',
-    background: 'transparent',
-    cursor: 'default',
-    transition: 'background 0.1s',
-    flexShrink: 0,
-  }
-
-  return (
-    <div style={{
-      display: 'inline-flex',
-      alignItems: 'stretch',
-      border: '1px solid rgba(0,0,0,0.14)',
-      borderRadius: '5px',
-      boxShadow: '0 0.5px 2px rgba(0,0,0,0.12)',
-      overflow: 'hidden',
-      background: 'var(--surface)',
-      height: '28px',
-    }}>
-      <button
-        type="button"
-        disabled={atMin}
-        onClick={dec}
-        style={{ ...btnBase, opacity: atMin ? 0.3 : 1, color: 'var(--ink)' }}
-      >
-        <svg viewBox="0 0 10 2" width="10" height="2">
-          <line x1="1" y1="1" x2="9" y2="1" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-        </svg>
-      </button>
-
-      <span style={{ width: '1px', background: 'rgba(0,0,0,0.1)', flexShrink: 0 }} />
-
-      <input
-        type="number"
-        value={value}
-        min={min}
-        max={max}
-        step={s}
-        onChange={e => {
-          const n = Number(e.target.value)
-          if (isNaN(n)) return
-          const clamped = min !== undefined && max !== undefined
-            ? Math.min(max, Math.max(min, n))
-            : min !== undefined ? Math.max(min, n)
-            : max !== undefined ? Math.min(max, n) : n
-          onChange(clamped)
-        }}
-        className="mac-stepper-input"
-        style={{
-          border: 'none',
-          background: 'transparent',
-          outline: 'none',
-          fontSize: '13px',
-          color: 'var(--ink)',
-          textAlign: 'center',
-          width: '52px',
-          padding: '0',
-          height: '100%',
-        }}
-      />
-
-      <span style={{ width: '1px', background: 'rgba(0,0,0,0.1)', flexShrink: 0 }} />
-
-      <button
-        type="button"
-        disabled={atMax}
-        onClick={inc}
-        style={{ ...btnBase, opacity: atMax ? 0.3 : 1, color: 'var(--ink)' }}
-      >
-        <svg viewBox="0 0 10 10" width="10" height="10">
-          <line x1="5" y1="1" x2="5" y2="9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-          <line x1="1" y1="5" x2="9" y2="5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-        </svg>
-      </button>
-    </div>
-  )
-}
-
-// ── Layout helpers ────────────────────────────────────────────────────────────
 function SectionCard({ children }: { children: React.ReactNode }) {
   return (
     <div style={{
@@ -228,7 +40,7 @@ function FieldRow({ label, description, children }: { label: string; description
         <p style={{ fontSize: '13px', fontWeight: 500, color: 'var(--ink)' }}>{label}</p>
         {description && <p style={{ fontSize: '11px', color: 'var(--ink-3)', marginTop: '2px' }}>{description}</p>}
       </div>
-      <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: '6px' }}>{children}</div>
+      <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: '8px' }}>{children}</div>
     </div>
   )
 }
@@ -245,10 +57,10 @@ function SaveButton({ onClick, status }: { onClick: () => void; status: SaveStat
           fontSize: '12px',
           fontWeight: 500,
           padding: '5px 14px',
-          borderRadius: '5px',
+          borderRadius: '6px',
           border: 'none',
           cursor: 'default',
-          boxShadow: '0 0.5px 2px rgba(0,0,0,0.18)',
+          boxShadow: '0 1px 3px rgba(0,0,0,0.15)',
         }}
       >
         Save
@@ -259,7 +71,13 @@ function SaveButton({ onClick, status }: { onClick: () => void; status: SaveStat
   )
 }
 
-// ── Main view ────────────────────────────────────────────────────────────────
+const LOG_LEVEL_OPTIONS = [
+  { value: 'DEBUG',   label: 'DEBUG' },
+  { value: 'INFO',    label: 'INFO' },
+  { value: 'WARNING', label: 'WARNING' },
+  { value: 'ERROR',   label: 'ERROR' },
+]
+
 export default function SettingsView() {
   const [settings, setSettings] = useState<RuntimeSettings | null>(null)
   const [observabilityStatus, setObservabilityStatus] = useState<SaveStatus>('idle')
@@ -310,95 +128,90 @@ export default function SettingsView() {
   }
 
   return (
-    <>
-      {/* Hide native number spinners */}
-      <style>{`.mac-stepper-input::-webkit-inner-spin-button,.mac-stepper-input::-webkit-outer-spin-button{-webkit-appearance:none;margin:0}.mac-stepper-input{-moz-appearance:textfield}`}</style>
-
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
-        <div>
-          <h1 style={{ fontSize: '22px', fontWeight: 600, letterSpacing: '-0.02em', color: 'var(--ink)' }}>Settings</h1>
-          <p style={{ fontSize: '12px', color: 'var(--ink-3)', marginTop: '4px' }}>Runtime configuration — changes take effect on the next daemon tick.</p>
-        </div>
-
-        {/* Observability */}
-        <SectionCard>
-          <SectionHeader>Observability</SectionHeader>
-          <FieldRow label="Log Level" description="Python agent log verbosity. DEBUG includes raw LLM prompts and rule hits.">
-            <SelectInput
-              value={settings.log_level}
-              onChange={v => patch({ log_level: v as RuntimeSettings['log_level'] })}
-              options={['DEBUG', 'INFO', 'WARNING', 'ERROR']}
-            />
-          </FieldRow>
-          <SaveButton status={observabilityStatus} onClick={() => save({ log_level: settings.log_level }, setObservabilityStatus)} />
-        </SectionCard>
-
-        {/* ETL Pipeline */}
-        <SectionCard>
-          <SectionHeader>ETL Pipeline</SectionHeader>
-          <FieldRow label="Poll Interval" description="How often the ETL pipeline runs. Takes effect on the next tick.">
-            <NumberInput value={settings.poll_interval_secs} onChange={v => patch({ poll_interval_secs: v })} min={10} max={3600} step={10} />
-            <span style={{ fontSize: '11px', color: 'var(--ink-3)' }}>sec</span>
-          </FieldRow>
-          <SaveButton status={etlStatus} onClick={() => save({ poll_interval_secs: settings.poll_interval_secs }, setEtlStatus)} />
-        </SectionCard>
-
-        {/* Session Classification */}
-        <SectionCard>
-          <SectionHeader>Session Classification</SectionHeader>
-          <FieldRow label="Classification Enabled">
-            <Toggle checked={settings.classification_enabled} onChange={v => patch({ classification_enabled: v })} />
-          </FieldRow>
-          <FieldRow label="Min Session Duration" description="Sessions shorter than this are skipped by the classifier.">
-            <NumberInput value={settings.min_classification_duration_s} onChange={v => patch({ min_classification_duration_s: v })} min={1} />
-            <span style={{ fontSize: '11px', color: 'var(--ink-3)' }}>sec</span>
-          </FieldRow>
-          <FieldRow label="Classification Timeout" description="Maximum time allowed per classification request.">
-            <NumberInput value={settings.classification_timeout_s} onChange={v => patch({ classification_timeout_s: v })} min={5} max={600} step={5} />
-            <span style={{ fontSize: '11px', color: 'var(--ink-3)' }}>sec</span>
-          </FieldRow>
-          <FieldRow label="Auto-route Floor" description="Confidence above this → auto-link to task.">
-            <NumberInput value={settings.agent_auto_floor} onChange={v => patch({ agent_auto_floor: v })} min={0} max={1} step={0.05} />
-          </FieldRow>
-          <FieldRow label="Queue Floor" description="Confidence above this → queue for review.">
-            <NumberInput value={settings.agent_queue_floor} onChange={v => patch({ agent_queue_floor: v })} min={0} max={1} step={0.05} />
-          </FieldRow>
-          <SaveButton
-            status={classificationStatus}
-            onClick={() => save({
-              classification_enabled: settings.classification_enabled,
-              min_classification_duration_s: settings.min_classification_duration_s,
-              classification_timeout_s: settings.classification_timeout_s,
-              agent_auto_floor: settings.agent_auto_floor,
-              agent_queue_floor: settings.agent_queue_floor,
-            }, setClassificationStatus)}
-          />
-        </SectionCard>
-
-        {/* LLM */}
-        <SectionCard>
-          <SectionHeader>LLM</SectionHeader>
-          <FieldRow label="Prefer Local Model" description="Use Apple Silicon MLX or local LM Studio when available.">
-            <Toggle checked={settings.llm_prefer_local} onChange={v => patch({ llm_prefer_local: v })} />
-          </FieldRow>
-          <FieldRow label="Local Budget" description="Fraction of GPU headroom to allow.">
-            <NumberInput value={settings.llm_budget_pct} onChange={v => patch({ llm_budget_pct: v })} min={0} max={1} step={0.05} />
-          </FieldRow>
-          <SaveButton
-            status={llmStatus}
-            onClick={() => save({ llm_prefer_local: settings.llm_prefer_local, llm_budget_pct: settings.llm_budget_pct }, setLlmStatus)}
-          />
-        </SectionCard>
-
-        {/* Jira Updater */}
-        <SectionCard>
-          <SectionHeader>Jira Updater</SectionHeader>
-          <FieldRow label="Jira Updates Enabled">
-            <Toggle checked={settings.jira_update_enabled} onChange={v => patch({ jira_update_enabled: v })} />
-          </FieldRow>
-          <SaveButton status={jiraStatus} onClick={() => save({ jira_update_enabled: settings.jira_update_enabled }, setJiraStatus)} />
-        </SectionCard>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
+      <div>
+        <h1 style={{ fontSize: '22px', fontWeight: 600, letterSpacing: '-0.02em', color: 'var(--ink)' }}>Settings</h1>
+        <p style={{ fontSize: '12px', color: 'var(--ink-3)', marginTop: '4px' }}>Runtime configuration — changes take effect on the next daemon tick.</p>
       </div>
-    </>
+
+      {/* Observability */}
+      <SectionCard>
+        <SectionHeader>Observability</SectionHeader>
+        <FieldRow label="Log Level" description="Python agent log verbosity. DEBUG includes raw LLM prompts and rule hits.">
+          <Select
+            value={settings.log_level}
+            onValueChange={v => patch({ log_level: v as RuntimeSettings['log_level'] })}
+            options={LOG_LEVEL_OPTIONS}
+          />
+        </FieldRow>
+        <SaveButton status={observabilityStatus} onClick={() => save({ log_level: settings.log_level }, setObservabilityStatus)} />
+      </SectionCard>
+
+      {/* ETL Pipeline */}
+      <SectionCard>
+        <SectionHeader>ETL Pipeline</SectionHeader>
+        <FieldRow label="Poll Interval" description="How often the ETL pipeline runs. Takes effect on the next tick.">
+          <NumberStepper value={settings.poll_interval_secs} onChange={v => patch({ poll_interval_secs: v })} min={10} max={3600} step={10} />
+          <span style={{ fontSize: '11px', color: 'var(--ink-3)' }}>sec</span>
+        </FieldRow>
+        <SaveButton status={etlStatus} onClick={() => save({ poll_interval_secs: settings.poll_interval_secs }, setEtlStatus)} />
+      </SectionCard>
+
+      {/* Session Classification */}
+      <SectionCard>
+        <SectionHeader>Session Classification</SectionHeader>
+        <FieldRow label="Classification Enabled">
+          <Switch checked={settings.classification_enabled} onCheckedChange={v => patch({ classification_enabled: v })} />
+        </FieldRow>
+        <FieldRow label="Min Session Duration" description="Sessions shorter than this are skipped by the classifier.">
+          <NumberStepper value={settings.min_classification_duration_s} onChange={v => patch({ min_classification_duration_s: v })} min={1} />
+          <span style={{ fontSize: '11px', color: 'var(--ink-3)' }}>sec</span>
+        </FieldRow>
+        <FieldRow label="Classification Timeout" description="Maximum time allowed per classification request.">
+          <NumberStepper value={settings.classification_timeout_s} onChange={v => patch({ classification_timeout_s: v })} min={5} max={600} step={5} />
+          <span style={{ fontSize: '11px', color: 'var(--ink-3)' }}>sec</span>
+        </FieldRow>
+        <FieldRow label="Auto-route Floor" description="Confidence above this → auto-link to task.">
+          <NumberStepper value={settings.agent_auto_floor} onChange={v => patch({ agent_auto_floor: v })} min={0} max={1} step={0.05} />
+        </FieldRow>
+        <FieldRow label="Queue Floor" description="Confidence above this → queue for review.">
+          <NumberStepper value={settings.agent_queue_floor} onChange={v => patch({ agent_queue_floor: v })} min={0} max={1} step={0.05} />
+        </FieldRow>
+        <SaveButton
+          status={classificationStatus}
+          onClick={() => save({
+            classification_enabled: settings.classification_enabled,
+            min_classification_duration_s: settings.min_classification_duration_s,
+            classification_timeout_s: settings.classification_timeout_s,
+            agent_auto_floor: settings.agent_auto_floor,
+            agent_queue_floor: settings.agent_queue_floor,
+          }, setClassificationStatus)}
+        />
+      </SectionCard>
+
+      {/* LLM */}
+      <SectionCard>
+        <SectionHeader>LLM</SectionHeader>
+        <FieldRow label="Prefer Local Model" description="Use Apple Silicon MLX or local LM Studio when available.">
+          <Switch checked={settings.llm_prefer_local} onCheckedChange={v => patch({ llm_prefer_local: v })} />
+        </FieldRow>
+        <FieldRow label="Local Budget" description="Fraction of GPU headroom to allow.">
+          <NumberStepper value={settings.llm_budget_pct} onChange={v => patch({ llm_budget_pct: v })} min={0} max={1} step={0.05} />
+        </FieldRow>
+        <SaveButton
+          status={llmStatus}
+          onClick={() => save({ llm_prefer_local: settings.llm_prefer_local, llm_budget_pct: settings.llm_budget_pct }, setLlmStatus)}
+        />
+      </SectionCard>
+
+      {/* Jira Updater */}
+      <SectionCard>
+        <SectionHeader>Jira Updater</SectionHeader>
+        <FieldRow label="Jira Updates Enabled">
+          <Switch checked={settings.jira_update_enabled} onCheckedChange={v => patch({ jira_update_enabled: v })} />
+        </FieldRow>
+        <SaveButton status={jiraStatus} onClick={() => save({ jira_update_enabled: settings.jira_update_enabled }, setJiraStatus)} />
+      </SectionCard>
+    </div>
   )
 }

--- a/ui/next-env.d.ts
+++ b/ui/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -14,6 +14,8 @@
         "@opentelemetry/sdk-node": "0.55",
         "@opentelemetry/semantic-conventions": "1.28",
         "@radix-ui/react-collapsible": "1.1.11",
+        "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tooltip": "1.2.8",
         "better-sqlite3": "12.2.0",
         "clsx": "2.1.1",
@@ -1336,6 +1338,12 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -1401,6 +1409,32 @@
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -1431,6 +1465,21 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-dismissable-layer": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
@@ -1442,6 +1491,46 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1579,6 +1668,49 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -1593,6 +1725,35 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -1729,6 +1890,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2247,6 +2423,18 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -2618,6 +2806,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -2736,6 +2930,15 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/github-from-package": {
@@ -3549,6 +3752,53 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-smooth": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
@@ -3562,6 +3812,28 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-transition-group": {
@@ -4039,6 +4311,49 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.11.1.tgz",
       "integrity": "sha512-mIDEX2ek50x0OlRgxryxsenE5XaQD4on5U2inY7RApK3SOJpofyw7uW2AyfMKkhAxXIceo2DeWGVGwyvng1GNQ==",
       "license": "MIT"
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,32 +10,34 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "next": "16.2.5",
-    "react": "19.2.0",
-    "react-dom": "19.2.0",
-    "better-sqlite3": "12.2.0",
-    "date-fns": "4.1.0",
-    "recharts": "2.15.3",
-    "geist": "1.3.1",
-    "lucide-react": "0.514.0",
-    "clsx": "2.1.1",
-    "tailwind-merge": "3.3.0",
-    "@radix-ui/react-tooltip": "1.2.8",
-    "@radix-ui/react-collapsible": "1.1.11",
     "@opentelemetry/api": "1.9",
     "@opentelemetry/exporter-trace-otlp-http": "0.55",
     "@opentelemetry/resources": "1.28",
     "@opentelemetry/sdk-node": "0.55",
     "@opentelemetry/semantic-conventions": "1.28",
-    "pino": "9"
+    "@radix-ui/react-collapsible": "1.1.11",
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-tooltip": "1.2.8",
+    "better-sqlite3": "12.2.0",
+    "clsx": "2.1.1",
+    "date-fns": "4.1.0",
+    "geist": "1.3.1",
+    "lucide-react": "0.514.0",
+    "next": "16.2.5",
+    "pino": "9",
+    "react": "19.2.0",
+    "react-dom": "19.2.0",
+    "recharts": "2.15.3",
+    "tailwind-merge": "3.3.0"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "4.1.4",
+    "@types/better-sqlite3": "7.6.13",
     "@types/node": "22.0.0",
     "@types/react": "19.2.0",
     "@types/react-dom": "19.2.0",
-    "@types/better-sqlite3": "7.6.13",
-    "typescript": "5.8.2",
     "tailwindcss": "4.1.4",
-    "@tailwindcss/postcss": "4.1.4"
+    "typescript": "5.8.2"
   }
 }


### PR DESCRIPTION
## Summary

This PR lands the KAN-97 epic: **dynamic LLM selection based on machine specs** for the task-classification agent, along with a runtime settings UI, a refactored task-linker pipeline, and end-to-end distributed tracing.

---

## What's in this PR

### Dynamic LLM selection (`services/agents/llm_selector.py`)
- Detects available compute at startup: MLX on Apple Silicon, LM Studio with a loaded model, or falls back to the configured remote endpoint (e.g. Anthropic Claude).
- Manages a long-running `mlx_lm.server` child process when no external server is found; respects `LLM_BUDGET_PCT` to leave headroom for macOS.
- Auto-unloads the managed MLX server when an external server is detected mid-run, and waits for the old process to fully exit before launching a replacement.
- Comprehensive structured logging + tracing spans (`llm.model`, `llm.runtime`, `llm.is_local`) on every selection decision.

### Runtime settings UI (`ui/app/settings/`, `ui/components/views/SettingsView.tsx`)
- New `/settings` SPA view embedded in the dashboard (no page reload).
- Backed by `~/.meridian/settings.json` via a new `GET /api/settings` + `POST /api/settings` route.
- Radix UI primitives (Switch, Select, NumberStepper) styled to Apple HIG feel.
- NumberStepper allows free typing without clamping mid-edit; clamps only on blur/enter.

### Task linker refactor (`src/intelligence/task_linker/`)
- Merged `ticket_links` into `app_sessions` (migration 018) — eliminates the join for every UI query.
- Split monolithic `db.rs` into `db.rs` (reads) + `db_write.rs` (writes).
- Added startup preflight check that fast-fails on a missing classification stack.
- Reduced daemon batch to 1 session per tick to prevent blocking the poll loop.
- Hermes reasoning text now stored alongside the ticket link.

### Intelligence pipeline simplification (`services/agents/`)
- Removed stages 1/2/3 (rules + embeddings + agent tiebreak); replaced with a single hermes `AIAgent` call per session — simpler, more accurate, same latency budget.
- Renamed `agent_tiebreaker` → `task_classifier_agent` throughout.
- Consolidated DB connections (`services/agents/db/`) into typed sub-modules (sessions, context, dispatch, agent_runs, jira_updates).
- Backfill binaries (`src/bin/backfill_session_categories.rs`, `backfill_task_classification.rs`) for historical data.

### Observability (`services/agents/observability.py`, Rust `intelligence/`)
- End-to-end distributed tracing into OpenObserve via OTLP.
- `llm.model`, `llm.runtime`, `llm.is_local` attributes on every span and log record.

### Tests & docs
- Replaced stub smoke tests with real hermes integration tests for the task linker.
- New test suites: `test_parser.py`, `test_run_task_linker.py`, `test_llm_selector.py`.
- Rewrote `services/README.md` and `services/agents/README.md` to match the actual codebase.
- Added `scripts/setup-services.sh` for co-dev onboarding.
- `chore(ui)`: added `next-env.d.ts` to `.gitignore` — auto-generated by Next.js on each build.

---

## Migrations

| # | File | Change |
|---|---|---|
| 016 | `016_category_settler_cursor.sql` | Category settler cursor |
| 017 | `017_ticket_links_reasoning.sql` | Reasoning column on ticket_links |
| 018 | `018_merge_ticket_links.sql` | Merge ticket_links into app_sessions |
| 019 | `019_pm_tasks_hierarchy.sql` | PM task hierarchy |
| 020 | `020_session_text_source.sql` | Session text source tracking |

---

## Test plan

- [ ] `cargo test` passes (integration tests cover ETL, category settler, task linker smoke)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cd ui && npm run build` succeeds
- [ ] Python tests: `cd services && pytest` (test_llm_selector, test_parser, test_run_task_linker)
- [ ] Settings UI: open `/settings`, toggle a switch, verify `~/.meridian/settings.json` persists
- [ ] LLM selector: run `python -m agents.tagger --session <ID>` and confirm model selection log lines
- [ ] Backfill: run `cargo run --bin backfill_task_classification` against a populated DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)