### PR TITLE
feat: add PM update workflow and session summaries

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -11,6 +11,10 @@
       "args": [
         "/Users/akarshhegde/.screenpipe/mcp/dist/index.js"
       ]
+    },
+    "agno-docs": {
+      "type": "http",
+      "url": "https://docs.agno.com/mcp"
     }
   }
 }

--- a/services/agents/pm_update/__init__.py
+++ b/services/agents/pm_update/__init__.py
@@ -1,0 +1,9 @@
+"""pm_update — agno-powered PM update synthesis for Meridian.
+
+Generates Jira-ready comments + status proposals + worklog entries from
+classified `app_sessions` rows. Designed as a standalone module: it can be
+run from the CLI (`python -m agents.pm_update.cli`) before being stitched
+into `jira_updater_daemon` for the 1-hour cadence (see PM_UPDATE_INTERVAL_HOURS).
+
+Architecture: see `services/agents/pm_update/workflow.py`.
+"""

--- a/services/agents/pm_update/agents.py
+++ b/services/agents/pm_update/agents.py
@@ -1,0 +1,124 @@
+"""Agent definitions for the pm_update workflow.
+
+A single Synthesise agent reads the session bundle, calls reasoning +
+evidence-fetching tools, and produces a strict JiraUpdate. With the
+local MLX model's 262K context, no chunked / map-reduce path is needed
+— even heavy bundles fit comfortably in one call.
+
+Lazy imports of agno keep this module importable without the optional
+dependency.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from agents.pm_update import config, tools
+from agents.pm_update.hooks import (
+    ProjectSecretGuard,
+    SessionBundleSizeGuard,
+    evidence_ref_validator,
+    time_spent_sanity_check,
+)
+from agents.pm_update.models import JiraUpdate
+
+if TYPE_CHECKING:
+    from agno.agent import Agent
+
+log = logging.getLogger(__name__)
+
+_SYNTH_NAME = "pm_update_synthesiser"
+
+
+def _load_skill_prompt(name: str) -> str:
+    """Read a skill's SKILL.md from the configured skills paths.
+
+    Re-uses the existing `agents.config.load_skill` helper so we don't
+    duplicate path search logic.
+    """
+    from agents.config import load_skill
+    raw = load_skill(name)
+    if not raw:
+        raise RuntimeError(
+            f"skill '{name}' not found in SKILLS_SEARCH_PATHS — "
+            "check services/skills/activity/ exists"
+        )
+    return raw
+
+
+def _local_model(*, max_tokens: int, temperature: float):
+    """Build an OpenAILike pointing at the local MLX server."""
+    from agno.models.openai.like import OpenAILike
+    return OpenAILike(
+        id=config.MLX_SERVER_MODEL,
+        base_url=f"http://{config.MLX_SERVER_HOST}:{config.MLX_SERVER_PORT}/v1",
+        api_key="local",
+        max_tokens=max_tokens,
+        temperature=temperature,
+        request_params={"timeout": config.PM_UPDATE_REQUEST_TIMEOUT_S},
+    )
+
+
+def build_synth_agent(
+    *, db, learning, debug_mode: bool = False, debug_level: int = 1,
+) -> "Agent":
+    """Build the headline Synthesise agent.
+
+    Arguments are injected so `workflow.py` controls the shared
+    `SqliteDb` and `LearningMachine` instances.
+
+    Args:
+        db: An `agno.db.sqlite.SqliteDb` pointing at meridian.db.
+        learning: A `LearningMachine` instance from `learning.py`.
+        debug_mode: Forward to the underlying `Agent` — prints prompts,
+            tool calls, and model responses to stderr.
+        debug_level: 1 or 2 (verbose).
+
+    Returns:
+        Configured `Agent` ready to plug into a Workflow `Step`.
+    """
+    from agno.agent import Agent
+    from agno.guardrails import PIIDetectionGuardrail
+    from agno.tools.reasoning import ReasoningTools
+
+    return Agent(
+        name=_SYNTH_NAME,
+        debug_mode=debug_mode,
+        debug_level=debug_level,
+        description=(
+            "Reads a window of classified work sessions for one Jira "
+            "ticket and produces a professional, evidence-grounded "
+            "JiraUpdate ready to post as a comment."
+        ),
+        model=_local_model(
+            max_tokens=config.PM_UPDATE_SYNTH_MAX_TOKENS,
+            temperature=config.PM_UPDATE_TEMP_SYNTH,
+        ),
+        db=db,
+        learning=learning,
+        instructions=_load_skill_prompt("pm-update-synth"),
+        tools=[
+            ReasoningTools(add_instructions=True),
+            tools.get_session_evidence,
+            tools.check_pm_task_status,
+            tools.get_earlier_today_summaries,
+            tools.get_feedback_examples,
+        ],
+        pre_hooks=[
+            PIIDetectionGuardrail(),
+            ProjectSecretGuard(),
+            SessionBundleSizeGuard(max_tokens=120_000),
+        ],
+        post_hooks=[
+            evidence_ref_validator,
+            time_spent_sanity_check,
+        ],
+        output_schema=JiraUpdate,
+        use_json_mode=True,                     # safest for local 9B
+        tool_call_limit=12,
+        add_datetime_to_context=True,
+        add_history_to_context=False,           # workflow session_state replaces this
+        markdown=False,                         # we want pure JSON
+    )
+
+

--- a/services/agents/pm_update/cli.py
+++ b/services/agents/pm_update/cli.py
@@ -1,0 +1,156 @@
+"""CLI entry point for the pm_update workflow.
+
+Run a single PM-update cycle for one ticket from the command line:
+
+    cd services
+    .venv313/bin/python -m agents.pm_update.cli \\
+        --task KAN-64 \\
+        --window-start 2026-05-28T09:00:00Z \\
+        --window-end   2026-05-28T12:00:00Z
+
+Defaults:
+
+    --window-end   = now (UTC)
+    --window-start = (now - PM_UPDATE_INTERVAL_HOURS)
+    --cycle-index  = 0
+    --dry-run      = true (no Jira post)
+
+This is the only blessed way to exercise the workflow until it's
+stitched into the daemon. Returns exit code 0 on success, 1 on
+internal failure, 2 on "skipped" (e.g. window too quiet).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from datetime import datetime, timedelta, timezone
+
+from agents import observability
+from agents.pm_update import config
+from agents.pm_update.models import UpdateState
+
+log = logging.getLogger(__name__)
+
+
+def _parse_iso(s: str) -> datetime:
+    """Parse an ISO-8601 string, defaulting to UTC if naive."""
+    cleaned = s.replace("Z", "+00:00")
+    dt = datetime.fromisoformat(cleaned)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="agents.pm_update.cli",
+        description="Run one PM-update cycle for one Jira ticket against meridian.db",
+    )
+    p.add_argument("--task", required=True, help="Jira ticket key, e.g. KAN-64")
+    p.add_argument(
+        "--window-start",
+        type=_parse_iso,
+        default=None,
+        help="ISO-8601 UTC start of the window. Default: now - PM_UPDATE_INTERVAL_HOURS",
+    )
+    p.add_argument(
+        "--window-end",
+        type=_parse_iso,
+        default=None,
+        help="ISO-8601 UTC end of the window. Default: now",
+    )
+    p.add_argument(
+        "--cycle-index",
+        type=int,
+        default=0,
+        help="Nth cycle of the day for this ticket (0-indexed). Default: 0",
+    )
+    p.add_argument(
+        "--post",
+        action="store_true",
+        help="Actually post the worklog to Jira (default: dry-run, only writes to "
+             "pm_updates table). Skips automatically if real_seconds < 60.",
+    )
+    p.add_argument(
+        "--json",
+        dest="emit_json",
+        action="store_true",
+        help="Emit only the RouteOutcome JSON on stdout (suppresses human-readable summary).",
+    )
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Turn on agno debug_mode for the workflow + all agents (shows prompts, "
+             "tool calls, model responses). Equivalent to AGNO_DEBUG=True.",
+    )
+    p.add_argument(
+        "--debug-verbose",
+        action="store_true",
+        help="As --debug, plus debug_level=2 (much more detail; spammy).",
+    )
+    return p
+
+
+def _resolve_window(args: argparse.Namespace) -> tuple[datetime, datetime]:
+    end = args.window_end or datetime.now(timezone.utc)
+    start = args.window_start or (
+        end - timedelta(hours=config.PM_UPDATE_INTERVAL_HOURS)
+    )
+    if start >= end:
+        raise SystemExit(f"window-start ({start}) must be earlier than window-end ({end})")
+    return start, end
+
+
+def main(argv: list[str] | None = None) -> int:
+    # Late import so `--help` works even when agno isn't installed.
+    from agents.pm_update.workflow import run_cycle
+
+    observability.setup("meridian-pm-update")
+    args = build_parser().parse_args(argv)
+    start, end = _resolve_window(args)
+
+    log.info(
+        "pm_update CLI: task=%s window=%s→%s cycle=%d post=%s",
+        args.task, start.isoformat(), end.isoformat(), args.cycle_index, args.post,
+    )
+
+    debug_mode  = args.debug or args.debug_verbose
+    debug_level = 2 if args.debug_verbose else 1
+
+    try:
+        outcome = run_cycle(
+            task_key=args.task,
+            window_start=start,
+            window_end=end,
+            cycle_index=args.cycle_index,
+            dry_run=not args.post,
+            debug_mode=debug_mode,
+            debug_level=debug_level,
+        )
+    except Exception as exc:                            # noqa: BLE001 — CLI top level
+        log.exception("pm_update cycle failed: %s", exc)
+        observability.shutdown()
+        return 1
+
+    if args.emit_json:
+        sys.stdout.write(outcome.model_dump_json() + "\n")
+    else:
+        sys.stdout.write(
+            f"\n=== PM update outcome ===\n"
+            f"  state:        {outcome.state.value}\n"
+            f"  pm_update_id: {outcome.pm_update_id}\n"
+            f"  reason:       {outcome.reason}\n"
+        )
+
+    observability.shutdown()
+    if outcome.state == UpdateState.FAILED:
+        return 1
+    if outcome.state == UpdateState.SKIPPED:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/agents/pm_update/config.py
+++ b/services/agents/pm_update/config.py
@@ -1,0 +1,61 @@
+"""Config for the pm_update workflow.
+
+All tunables are read from the environment (loaded by the parent
+`agents.config` module). This file exposes them as typed constants so the
+rest of the package can `from agents.pm_update.config import X`.
+
+The defaults are chosen for a single-user laptop setup with the local 9B
+MLX server on :7823 and the user's screen-capture history in
+`~/.meridian/meridian.db`.
+"""
+from __future__ import annotations
+
+import os
+
+# Re-export the shared paths so callers don't have to know about the parent
+# config module.
+from agents.config import LOG_DIR, MERIDIAN_DB, MERIDIAN_HOME  # noqa: F401
+
+# ── Cadence ───────────────────────────────────────────────────────────────────
+# How often the daemon should fire a new PM update cycle, in hours.
+# 3h is the recommended default — enough material to summarise, infrequent
+# enough not to spam the ticket.
+PM_UPDATE_INTERVAL_HOURS = float(os.environ.get("PM_UPDATE_INTERVAL_HOURS", "1"))
+
+# ── Model / inference ─────────────────────────────────────────────────────────
+# The local MLX server is OpenAI-compatible; we point agno at it via
+# OpenAILike. The port is the same one the classifier uses.
+MLX_SERVER_HOST   = os.environ.get("MLX_SERVER_HOST", "127.0.0.1")
+MLX_SERVER_PORT   = int(os.environ.get("MLX_SERVER_PORT", "7823"))
+MLX_SERVER_MODEL  = os.environ.get("MLX_SERVER_MODEL", "qwen3.5-9b-instruct")
+
+# Token caps. The MLX model exposes 128-262K context — a single Synthesise
+# call comfortably swallows even the heaviest hour of work.
+PM_UPDATE_SYNTH_MAX_TOKENS  = int(os.environ.get("PM_UPDATE_SYNTH_MAX_TOKENS",  "8000"))
+PM_UPDATE_REQUEST_TIMEOUT_S = int(os.environ.get("PM_UPDATE_REQUEST_TIMEOUT_S", "300"))
+
+# Temperature tuned for each step. Lower = more deterministic.
+PM_UPDATE_TEMP_COLLECT = 0.0
+PM_UPDATE_TEMP_SYNTH   = float(os.environ.get("PM_UPDATE_TEMP_SYNTH",   "0.3"))
+PM_UPDATE_TEMP_COMPOSE = float(os.environ.get("PM_UPDATE_TEMP_COMPOSE", "0.5"))
+
+# ── Routing / posting thresholds ──────────────────────────────────────────────
+# Coverage = fraction of generated bullets that have at least one
+# evidence_ref pointing into the source session bundle. Below this, the
+# update is held back from auto-post.
+PM_UPDATE_MIN_COVERAGE   = float(os.environ.get("PM_UPDATE_MIN_COVERAGE",   "0.80"))
+PM_UPDATE_MIN_CONFIDENCE = float(os.environ.get("PM_UPDATE_MIN_CONFIDENCE", "0.65"))
+
+# Above this fraction of duration in `idle_frame_count`, mark the cycle as
+# probably idle (lunch / meeting in the background) and shrink time_spent.
+PM_UPDATE_IDLE_DISCOUNT_THRESHOLD = float(
+    os.environ.get("PM_UPDATE_IDLE_DISCOUNT_THRESHOLD", "0.50")
+)
+
+# ── Heavy-path signal (informational only) ────────────────────────────────────
+# `SessionBundle.is_heavy` is still computed and stored on the row for
+# observability and possible future optimisation, but the workflow no
+# longer branches on it — every bundle flows through a single Synthesise.
+PM_UPDATE_HEAVY_SESSION_COUNT = int(os.environ.get("PM_UPDATE_HEAVY_SESSION_COUNT", "60"))
+PM_UPDATE_HEAVY_TEXT_BYTES    = int(os.environ.get("PM_UPDATE_HEAVY_TEXT_BYTES",    "400000"))
+

--- a/services/agents/pm_update/db.py
+++ b/services/agents/pm_update/db.py
@@ -1,0 +1,607 @@
+"""SQLite read/write layer for the pm_update workflow.
+
+Read paths point at the existing tables owned by the Rust ETL
+(`app_sessions`) and the intelligence module (`pm_tasks`). Write paths
+own the three pm_update tables defined in `schema.sql`.
+
+Connection model: short-lived `sqlite3.Connection` per call, mirroring
+the pattern used by `run_task_linker_mlx`. SQLite WAL mode handles
+concurrency between Rust and Python without explicit pooling.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterator, Optional
+
+from agents.pm_update import config
+from agents.pm_update.models import (
+    BulletWithEvidence,
+    JiraUpdate,
+    SessionBundle,
+    SessionDigest,
+    UpdateState,
+)
+
+log = logging.getLogger(__name__)
+
+# Cap for the per-session excerpt that travels into the LLM prompt. Full
+# session_text is always available on demand via get_session_evidence.
+EXCERPT_CAP_BYTES = 2_000
+
+
+# ──────────────────────── Connection helper ────────────────────────────────────
+
+
+@contextmanager
+def connect(db_path: Path = config.MERIDIAN_DB, *, readonly: bool = False) -> Iterator[sqlite3.Connection]:
+    """Open a short-lived connection with row_factory + WAL + busy_timeout.
+
+    Read-only mode uses the URI form so we can never accidentally write
+    when the caller only meant to read.
+    """
+    if readonly:
+        # The URI form lets sqlite3 enforce read-only at the driver layer.
+        uri = f"file:{db_path}?mode=ro"
+        conn = sqlite3.connect(uri, uri=True, timeout=10)
+    else:
+        conn = sqlite3.connect(db_path, timeout=10)
+        conn.execute("PRAGMA journal_mode=WAL")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout=5000")
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+# ──────────────────────── Schema bootstrap ─────────────────────────────────────
+
+
+def init_schema(db_path: Path = config.MERIDIAN_DB) -> None:
+    """Apply schema.sql idempotently. Safe to call on every CLI invocation.
+
+    Also performs additive column migrations for databases that were
+    created before a column existed. SQLite has no `ADD COLUMN IF NOT
+    EXISTS`, so we probe `PRAGMA table_info` and only ALTER when
+    missing.
+    """
+    ddl = (Path(__file__).parent / "schema.sql").read_text()
+    with connect(db_path) as con:
+        con.executescript(ddl)
+
+        # Backfill column for DBs that pre-date posted_worklog_id. This
+        # one stays here because pm_updates is Python-owned (no Rust
+        # migration manages it).
+        cols = {row["name"] for row in con.execute("PRAGMA table_info(pm_updates)")}
+        if "posted_worklog_id" not in cols:
+            con.execute("ALTER TABLE pm_updates ADD COLUMN posted_worklog_id TEXT")
+            log.info("added posted_worklog_id column to pm_updates")
+
+        # NOTE: `session_summary` on app_sessions is owned by the Rust
+        # migration `024_session_summary.sql`. Adding it from Python here
+        # would race the migration runner and trip "duplicate column" on
+        # daemon startup — don't.
+
+        # Worklog idempotency: at most one POSTED worklog per (task, window).
+        # Created after the ALTER above so the column always exists.
+        con.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_pm_updates_worklog_window
+                ON pm_updates (task_key, window_start, window_end)
+                WHERE posted_worklog_id IS NOT NULL
+            """
+        )
+
+        con.commit()
+    log.debug("pm_update schema applied to %s", db_path)
+
+
+# ──────────────────────── Read paths ───────────────────────────────────────────
+
+
+def fetch_session_bundle(
+    task_key: str,
+    window_start: datetime,
+    window_end: datetime,
+    cycle_index: int = 0,
+    *,
+    db_path: Path = config.MERIDIAN_DB,
+) -> SessionBundle:
+    """Build a `SessionBundle` for one (task_key, window).
+
+    Includes only sessions where `task_key` matches and `started_at` falls
+    inside the window. Drops sessions whose `session_text` is empty since
+    those carry no narrative signal.
+    """
+    start_iso = _utc_iso(window_start)
+    end_iso = _utc_iso(window_end)
+
+    with connect(db_path, readonly=True) as con:
+        # Ticket metadata for context-aware prompts. Missing pm_task is
+        # acceptable — the PM cache may not have refreshed yet.
+        task_row = con.execute(
+            """
+            SELECT title, status_category, assignee_name
+            FROM pm_tasks
+            WHERE task_key = ?
+            """,
+            (task_key,),
+        ).fetchone()
+
+        rows = con.execute(
+            """
+            SELECT id, app_name, started_at, ended_at, duration_s,
+                   idle_frame_count, frame_count, window_titles,
+                   session_text, session_text_source, category,
+                   session_summary,
+                   COALESCE(task_session_type, '') AS task_session_type
+            FROM app_sessions
+            WHERE task_key = ?
+              AND started_at >= ?
+              AND started_at <  ?
+              AND COALESCE(task_session_type, '') = 'task'
+            ORDER BY id ASC
+            """,
+            (task_key, start_iso, end_iso),
+        ).fetchall()
+
+        dim_rows = con.execute(
+            """
+            SELECT session_id, dimension, value
+            FROM session_dimensions
+            WHERE session_id IN (
+                SELECT id FROM app_sessions
+                WHERE task_key = ? AND started_at >= ? AND started_at < ?
+            )
+            """,
+            (task_key, start_iso, end_iso),
+        ).fetchall()
+
+    # Group dimensions by session_id → {dimension: [values]}
+    dims_by_session: dict[int, dict[str, list[str]]] = {}
+    for r in dim_rows:
+        s = dims_by_session.setdefault(r["session_id"], {})
+        s.setdefault(r["dimension"], []).append(r["value"])
+
+    digests: list[SessionDigest] = []
+    raw_bytes = 0
+    total_s = 0
+    real_s = 0
+    for r in rows:
+        text = r["session_text"] or ""
+        summary = (r["session_summary"] or "").strip()
+
+        # Skip rows that have neither a classifier summary nor raw text.
+        # The summary is the primary PM-update signal; falling back to the
+        # 2KB raw excerpt only matters for legacy rows (pre-migration 024).
+        if not summary and not text.strip():
+            continue
+
+        # Idle discount per session: scale duration by the non-idle frame
+        # ratio. frame_count == 0 shouldn't happen for a real session, but
+        # we guard against div-by-zero anyway.
+        fc = r["frame_count"] or 0
+        ifc = r["idle_frame_count"] or 0
+        idle_share = (ifc / fc) if fc > 0 else 0.0
+        real_session_s = int(round(r["duration_s"] * (1.0 - idle_share)))
+
+        # Prefer the classifier-written prose summary over the OCR excerpt:
+        #   - present:  use the full summary, no truncation (it's already
+        #               sized to the PM-update budget by the classifier
+        #               schema's max_length=8000).
+        #   - missing:  fall back to the legacy 2KB OCR excerpt so old
+        #               sessions still work end-to-end.
+        digest_excerpt = summary if summary else text[:EXCERPT_CAP_BYTES]
+
+        digests.append(
+            SessionDigest(
+                id=r["id"],
+                app_name=r["app_name"],
+                started_at=r["started_at"],
+                ended_at=r["ended_at"],
+                duration_s=r["duration_s"],
+                idle_frame_s=int(round(r["duration_s"] * idle_share)),
+                top_titles=_parse_top_titles(r["window_titles"]),
+                dimensions=dims_by_session.get(r["id"], {}),
+                excerpt=digest_excerpt,
+                category=r["category"],
+                text_source="summary" if summary else r["session_text_source"],
+            )
+        )
+        # raw_bytes still measures the raw_text footprint (drives is_heavy);
+        # the synth prompt size is dominated by `digest_excerpt`.
+        raw_bytes += len(text)
+        total_s += r["duration_s"]
+        real_s += real_session_s
+
+    is_heavy = (
+        len(digests) > config.PM_UPDATE_HEAVY_SESSION_COUNT
+        or raw_bytes > config.PM_UPDATE_HEAVY_TEXT_BYTES
+    )
+
+    return SessionBundle(
+        task_key=task_key,
+        window_start=start_iso,
+        window_end=end_iso,
+        cycle_index=cycle_index,
+        sessions=digests,
+        total_seconds=total_s,
+        real_seconds=real_s,
+        raw_text_bytes=raw_bytes,
+        is_heavy=is_heavy,
+        pm_task_status=task_row["status_category"] if task_row else None,
+        pm_task_title=task_row["title"] if task_row else None,
+        assignee_name=task_row["assignee_name"] if task_row else None,
+        earlier_today_summaries=_fetch_earlier_today_summaries(
+            task_key, window_start, db_path=db_path
+        ),
+    )
+
+
+def fetch_session_text(session_id: int, *, db_path: Path = config.MERIDIAN_DB) -> str:
+    """Return full session_text for one session_id, or empty string if absent.
+
+    Used by the `get_session_evidence` agno tool so the LLM can pull the
+    raw OCR/audio excerpt when its 2KB digest preview isn't enough.
+    """
+    with connect(db_path, readonly=True) as con:
+        row = con.execute(
+            "SELECT session_text FROM app_sessions WHERE id = ?", (session_id,),
+        ).fetchone()
+    if row is None:
+        return ""
+    return row["session_text"] or ""
+
+
+def fetch_pm_task(task_key: str, *, db_path: Path = config.MERIDIAN_DB) -> Optional[dict]:
+    """Current cached state of a Jira ticket from `pm_tasks`."""
+    with connect(db_path, readonly=True) as con:
+        row = con.execute(
+            """
+            SELECT task_key, provider, title, description_text, status_category,
+                   issue_type, project_key, url, parent_key, epic_title,
+                   sprint_name, assignee_name, fetched_at
+            FROM pm_tasks WHERE task_key = ?
+            """,
+            (task_key,),
+        ).fetchone()
+    return dict(row) if row else None
+
+
+def _fetch_earlier_today_summaries(
+    task_key: str,
+    window_start: datetime,
+    *,
+    db_path: Path,
+) -> list[str]:
+    """Headlines of earlier-today cycles, oldest → newest.
+
+    Used by the Synth prompt to avoid repeating what was already posted.
+    """
+    day = window_start.astimezone(timezone.utc).strftime("%Y-%m-%d")
+    with connect(db_path, readonly=True) as con:
+        rows = con.execute(
+            """
+            SELECT payload_json
+            FROM pm_updates
+            WHERE task_key = ? AND day_utc = ? AND state = ?
+            ORDER BY cycle_index ASC
+            """,
+            (task_key, day, UpdateState.POSTED.value),
+        ).fetchall()
+    summaries: list[str] = []
+    for r in rows:
+        try:
+            payload = json.loads(r["payload_json"])
+            if summary := payload.get("summary"):
+                summaries.append(summary)
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return summaries
+
+
+# ──────────────────────── Write paths ──────────────────────────────────────────
+
+
+def upsert_pm_update(
+    update: JiraUpdate,
+    *,
+    state: UpdateState,
+    coverage: float,
+    workflow_run_id: Optional[str] = None,
+    session_id_min: Optional[int] = None,
+    session_id_max: Optional[int] = None,
+    db_path: Path = config.MERIDIAN_DB,
+) -> int:
+    """Insert or update the pm_updates row for this (task, day, cycle).
+
+    Returns the row's `id`. Idempotent on `(task_key, day_utc, cycle_index)`.
+    """
+    day = _day_utc(update.window_start)
+    payload = update.model_dump_json()
+
+    with connect(db_path) as con:
+        cur = con.execute(
+            """
+            INSERT INTO pm_updates (
+                task_key, day_utc, cycle_index, window_start, window_end,
+                state, confidence, coverage, time_spent_seconds,
+                payload_json, session_id_min, session_id_max, workflow_run_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (task_key, day_utc, cycle_index)
+            DO UPDATE SET
+                state              = excluded.state,
+                confidence         = excluded.confidence,
+                coverage           = excluded.coverage,
+                time_spent_seconds = excluded.time_spent_seconds,
+                payload_json       = excluded.payload_json,
+                workflow_run_id    = excluded.workflow_run_id
+            RETURNING id
+            """,
+            (
+                update.task_key,
+                day,
+                update.cycle_index,
+                update.window_start,
+                update.window_end,
+                state.value,
+                update.confidence,
+                coverage,
+                update.time_spent_seconds,
+                payload,
+                session_id_min,
+                session_id_max,
+                workflow_run_id,
+            ),
+        )
+        row = cur.fetchone()
+        pm_update_id = row["id"] if row else cur.lastrowid
+
+        # Refresh evidence table — drop old refs, insert fresh.
+        con.execute("DELETE FROM pm_update_evidence WHERE pm_update_id = ?", (pm_update_id,))
+        for kind, bullets in (
+            ("shipped",     update.what_shipped),
+            ("in_progress", update.in_progress),
+            ("blocker",     update.blockers),
+            ("decision",    update.decisions),
+        ):
+            for idx, b in enumerate(bullets):
+                _insert_evidence(con, pm_update_id, kind, idx, b)
+        con.commit()
+    return pm_update_id
+
+
+def mark_posted(
+    pm_update_id: int,
+    posted_comment_id: str,
+    *,
+    db_path: Path = config.MERIDIAN_DB,
+) -> None:
+    """Stamp the row with a Jira comment id once the post lands."""
+    with connect(db_path) as con:
+        con.execute(
+            """
+            UPDATE pm_updates
+            SET state = ?, posted_comment_id = ?, posted_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+            WHERE id = ?
+            """,
+            (UpdateState.POSTED.value, posted_comment_id, pm_update_id),
+        )
+        con.commit()
+
+
+def mark_worklog_posted(
+    pm_update_id: int,
+    posted_worklog_id: str,
+    *,
+    db_path: Path = config.MERIDIAN_DB,
+) -> None:
+    """Stamp the row with the Jira worklog id once the post lands.
+
+    Separate from `mark_posted` because worklog and comment are
+    independent phases — phase 1 ships only worklog. Setting either
+    one's id is enough to flip `state` to POSTED.
+    """
+    with connect(db_path) as con:
+        con.execute(
+            """
+            UPDATE pm_updates
+            SET state = ?,
+                posted_worklog_id = ?,
+                posted_at = COALESCE(posted_at, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+            WHERE id = ?
+            """,
+            (UpdateState.POSTED.value, posted_worklog_id, pm_update_id),
+        )
+        con.commit()
+
+
+def find_existing_worklog(
+    task_key: str,
+    window_start: str,
+    window_end: str,
+    *,
+    db_path: Path = config.MERIDIAN_DB,
+) -> Optional[tuple[int, str]]:
+    """Look up any prior worklog post for this exact (task, window).
+
+    Returns (pm_update_id, posted_worklog_id) or None. Used by the
+    Route step to short-circuit duplicate posts after daemon restarts
+    or backfill replays.
+    """
+    with connect(db_path, readonly=True) as con:
+        row = con.execute(
+            """
+            SELECT id, posted_worklog_id FROM pm_updates
+            WHERE task_key = ?
+              AND window_start = ?
+              AND window_end   = ?
+              AND posted_worklog_id IS NOT NULL
+            LIMIT 1
+            """,
+            (task_key, window_start, window_end),
+        ).fetchone()
+    if row is None:
+        return None
+    return row["id"], row["posted_worklog_id"]
+
+
+def record_feedback(
+    pm_update_id: int,
+    *,
+    feedback_kind: str,
+    original_text: Optional[str] = None,
+    edited_text: Optional[str] = None,
+    note: Optional[str] = None,
+    db_path: Path = config.MERIDIAN_DB,
+) -> int:
+    """Record an admin edit / rejection / approval. Fuels self-learning."""
+    if feedback_kind not in ("edit", "reject", "approve"):
+        raise ValueError(f"unknown feedback_kind: {feedback_kind}")
+    with connect(db_path) as con:
+        cur = con.execute(
+            """
+            INSERT INTO pm_update_feedback
+                (pm_update_id, feedback_kind, original_text, edited_text, note)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (pm_update_id, feedback_kind, original_text, edited_text, note),
+        )
+        con.commit()
+        return cur.lastrowid
+
+
+def fetch_recent_feedback(
+    task_key: str,
+    *,
+    limit: int = 5,
+    db_path: Path = config.MERIDIAN_DB,
+) -> list[dict]:
+    """Recent feedback rows for one ticket, newest first.
+
+    Synth pre_hook injects these as few-shot guidance — that's the
+    closing loop on self-improvement.
+    """
+    with connect(db_path, readonly=True) as con:
+        rows = con.execute(
+            """
+            SELECT f.id, f.feedback_kind, f.original_text, f.edited_text,
+                   f.note, f.created_at
+            FROM pm_update_feedback f
+            JOIN pm_updates u ON u.id = f.pm_update_id
+            WHERE u.task_key = ?
+            ORDER BY f.created_at DESC
+            LIMIT ?
+            """,
+            (task_key, limit),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+# ──────────────────────── Helpers ──────────────────────────────────────────────
+
+
+def _utc_iso(dt: datetime) -> str:
+    """ISO-8601 UTC with 'Z' suffix, matching the rest of meridian.db."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _day_utc(iso_ts: str) -> str:
+    """Strip an ISO timestamp to YYYY-MM-DD in UTC."""
+    # Tolerant of both '...Z' and '+00:00' suffixes.
+    cleaned = iso_ts.replace("Z", "+00:00")
+    return datetime.fromisoformat(cleaned).astimezone(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _parse_top_titles(raw: Optional[str], *, n: int = 3) -> list[str]:
+    """Extract the n most common window titles from the JSON column."""
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(parsed, list):
+        return []
+    # Each element is {"title": str, "count": int}; sort desc by count.
+    titles = sorted(
+        (p for p in parsed if isinstance(p, dict) and p.get("title")),
+        key=lambda p: p.get("count", 0),
+        reverse=True,
+    )
+    return [p["title"] for p in titles[:n]]
+
+
+def _insert_evidence(
+    con: sqlite3.Connection,
+    pm_update_id: int,
+    bullet_kind: str,
+    bullet_index: int,
+    bullet: BulletWithEvidence,
+) -> None:
+    for session_id in bullet.evidence_refs:
+        con.execute(
+            """
+            INSERT OR IGNORE INTO pm_update_evidence
+                (pm_update_id, bullet_kind, bullet_index, session_id, excerpt)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (pm_update_id, bullet_kind, bullet_index, session_id, bullet.text[:400]),
+        )
+
+
+def last_posted_window_end(
+    task_key: str,
+    *,
+    db_path: Path = config.MERIDIAN_DB,
+) -> Optional[datetime]:
+    """When was the most recent successful post for this ticket?
+
+    Used by the daemon (later) to pick the next window's start. Returns
+    None if no post has ever landed.
+    """
+    with connect(db_path, readonly=True) as con:
+        row = con.execute(
+            """
+            SELECT window_end FROM pm_updates
+            WHERE task_key = ? AND state = ?
+            ORDER BY window_end DESC LIMIT 1
+            """,
+            (task_key, UpdateState.POSTED.value),
+        ).fetchone()
+    if row is None:
+        return None
+    cleaned = row["window_end"].replace("Z", "+00:00")
+    return datetime.fromisoformat(cleaned)
+
+
+def has_recent_classified_work(
+    task_key: str,
+    since: datetime,
+    *,
+    db_path: Path = config.MERIDIAN_DB,
+) -> bool:
+    """True if any classified session for `task_key` was written after `since`.
+
+    Lets the daemon skip ticks where nothing has happened.
+    """
+    since_iso = _utc_iso(since)
+    with connect(db_path, readonly=True) as con:
+        row = con.execute(
+            """
+            SELECT 1 FROM app_sessions
+            WHERE task_key = ? AND ended_at > ?
+              AND COALESCE(task_session_type, '') = 'task'
+            LIMIT 1
+            """,
+            (task_key, since_iso),
+        ).fetchone()
+    return row is not None

--- a/services/agents/pm_update/hooks.py
+++ b/services/agents/pm_update/hooks.py
@@ -1,0 +1,293 @@
+"""Pre-hooks, post-hooks, and custom guardrails for the Synth agent.
+
+Layout:
+
+  * `SessionBundleSizeGuard`   — pre-hook: reject inputs that don't fit
+                                  the model's effective context window
+  * `EvidenceRefValidator`     — post-hook: drop bullets without
+                                  evidence_refs and recompute coverage
+  * `TimeSpentSanityCheck`     — post-hook: clamp time_spent_seconds to
+                                  the cycle window
+  * `RiskFlagger`              — post-hook: surface low-confidence /
+                                  ticket-closed / assignee-mismatch flags
+
+All guardrails extend `agno.guardrails.BaseGuardrail` (when agno is
+installed). The classes are written so that if agno is not yet on the
+PYTHONPATH, this module still imports cleanly — useful for the unit test
+that exercises `EvidenceRefValidator` without the agno runtime.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+try:
+    from agno.exceptions import CheckTrigger, InputCheckError, OutputCheckError
+    from agno.guardrails import BaseGuardrail
+    from agno.run.agent import RunInput, RunOutput
+    _AGNO_AVAILABLE = True
+except ImportError:                                     # pragma: no cover
+    # Allow this module to import when agno isn't installed yet. The
+    # guardrail classes still work as plain callables in that case.
+    _AGNO_AVAILABLE = False
+
+    class BaseGuardrail:                                # type: ignore[no-redef]
+        def check(self, run_input):  # noqa: D401
+            ...
+        async def async_check(self, run_input):
+            self.check(run_input)
+
+    class InputCheckError(Exception):                   # type: ignore[no-redef]
+        def __init__(self, msg: str, check_trigger: Any = None):
+            super().__init__(msg)
+            self.check_trigger = check_trigger
+
+    class OutputCheckError(Exception):                  # type: ignore[no-redef]
+        def __init__(self, msg: str, check_trigger: Any = None):
+            super().__init__(msg)
+            self.check_trigger = check_trigger
+
+    class CheckTrigger:                                 # type: ignore[no-redef]
+        INPUT_NOT_ALLOWED  = "INPUT_NOT_ALLOWED"
+        OUTPUT_NOT_ALLOWED = "OUTPUT_NOT_ALLOWED"
+
+    RunInput  = Any                                     # type: ignore[misc]
+    RunOutput = Any                                     # type: ignore[misc]
+
+from agents.pm_update.models import (
+    BulletWithEvidence,
+    GroundedNarrative,
+    JiraUpdate,
+    RiskFlag,
+    SessionBundle,
+)
+from agents.pm_update import config
+
+log = logging.getLogger(__name__)
+
+# Conservative token estimate: 4 bytes per token for ASCII-heavy text.
+# Errs on the side of "this is bigger than it looks".
+_BYTES_PER_TOKEN = 4
+
+
+# ──────────────────────── Pre-hooks ────────────────────────────────────────────
+
+
+class SessionBundleSizeGuard(BaseGuardrail):
+    """Pre-hook: refuse to call the LLM if the bundle exceeds the budget.
+
+    With a 9B local MLX model the effective good-quality window is
+    8K-16K tokens. We let bundles up to 120K-token-equivalents through —
+    above that, the Collect step should have routed via the heavy path.
+    Hitting this guardrail means a bug in the heavy-path threshold.
+    """
+
+    def __init__(self, max_tokens: int = 120_000) -> None:
+        self.max_tokens = max_tokens
+
+    def check(self, run_input: RunInput) -> None:
+        content = getattr(run_input, "input_content", run_input)
+        size_bytes = len(content if isinstance(content, str) else str(content))
+        approx_tokens = size_bytes // _BYTES_PER_TOKEN
+        if approx_tokens > self.max_tokens:
+            raise InputCheckError(
+                f"session bundle ~{approx_tokens} tokens exceeds budget "
+                f"{self.max_tokens} — route via heavy path",
+                check_trigger=CheckTrigger.INPUT_NOT_ALLOWED,
+            )
+
+    async def async_check(self, run_input: RunInput) -> None:
+        self.check(run_input)
+
+
+# ──────────────────────── Post-hooks (plain functions, not BaseGuardrail) ──────
+#
+# Agno post-hooks can be plain callables; we use that form so they can
+# manipulate the `RunOutput` (BaseGuardrail is for pure validation).
+
+
+def evidence_ref_validator(run_output: RunOutput) -> None:
+    """Post-hook: drop bullets without evidence_refs; recompute coverage.
+
+    Mutates `run_output.content` in place. Raises if the resulting
+    grounded output would be empty — that means the model returned nothing
+    we can prove, which is worse than no comment at all.
+    """
+    upd = _coerce_to_jira_update(run_output)
+    if upd is None:
+        return  # nothing to validate
+
+    dropped: list[str] = []
+    for attr in ("what_shipped", "in_progress", "blockers", "decisions"):
+        kept: list[BulletWithEvidence] = []
+        for b in getattr(upd, attr):
+            if not b.evidence_refs:
+                dropped.append(f"{attr}: {b.text[:80]}")
+                continue
+            kept.append(b)
+        setattr(upd, attr, kept)
+
+    total = sum(len(getattr(upd, a)) for a in
+                ("what_shipped", "in_progress", "blockers", "decisions"))
+    if total == 0:
+        # Don't raise — let downstream router decide. Set a flag so the
+        # router skips this update.
+        if RiskFlag.LOW_EVIDENCE not in upd.risk_flags:
+            upd.risk_flags.append(RiskFlag.LOW_EVIDENCE)
+        upd.confidence = 0.0
+
+    if dropped:
+        log.info("evidence_ref_validator dropped %d un-grounded bullets: %s",
+                 len(dropped), dropped[:3])
+
+    _write_back(run_output, upd)
+
+
+def time_spent_sanity_check(run_output: RunOutput, *, window_seconds: int = 3600) -> None:
+    """Post-hook: clamp `time_spent_seconds` to a physically possible range.
+
+    A 1-hour cycle window can spend at most 1 hour. The LLM occasionally
+    hallucinates 28800s (8h) — we clamp.
+    """
+    upd = _coerce_to_jira_update(run_output)
+    if upd is None:
+        return
+    if upd.time_spent_seconds > window_seconds:
+        log.info(
+            "time_spent_sanity_check clamping %ds → %ds for %s",
+            upd.time_spent_seconds, window_seconds, upd.task_key,
+        )
+        upd.time_spent_seconds = window_seconds
+    _write_back(run_output, upd)
+
+
+def risk_flagger(run_output: RunOutput, *, bundle: SessionBundle) -> None:
+    """Post-hook: surface routing-relevant signals.
+
+    Looks at the JiraUpdate + the original SessionBundle and appends
+    `RiskFlag` entries for the Router step to consult.
+    """
+    upd = _coerce_to_jira_update(run_output)
+    if upd is None:
+        return
+
+    flags = set(upd.risk_flags)
+
+    if upd.confidence < config.PM_UPDATE_MIN_CONFIDENCE:
+        flags.add(RiskFlag.LOW_CONFIDENCE)
+
+    if bundle.pm_task_status == "done":
+        flags.add(RiskFlag.TICKET_CLOSED)
+
+    # Cross-ticket leak: any bullet that references a session_id which
+    # ISN'T in the bundle — should be impossible after EvidenceRefValidator,
+    # but we double-check.
+    bundle_ids = {s.id for s in bundle.sessions}
+    for b in upd.bullets:
+        if any(ref not in bundle_ids for ref in b.evidence_refs):
+            flags.add(RiskFlag.CROSS_TICKET_LEAK)
+            break
+
+    upd.risk_flags = sorted(flags, key=lambda f: f.value)
+    _write_back(run_output, upd)
+
+
+# ──────────────────────── PII helpers ──────────────────────────────────────────
+#
+# We compose Agno's built-in PIIDetectionGuardrail in the agent assembly,
+# but we add one extra regex pass here for things its default ruleset
+# might miss (project-scoped tokens like Jira API keys).
+
+_EXTRA_PII_PATTERNS = (
+    re.compile(r"\bsk-[a-zA-Z0-9]{20,}\b"),                # OpenAI / openrouter style keys
+    re.compile(r"\bATATT3[A-Za-z0-9_-]{20,}\b"),           # Atlassian API tokens
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b"),         # GitHub tokens
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),                   # AWS access keys
+)
+
+
+class ProjectSecretGuard(BaseGuardrail):
+    """Pre-hook: refuse inputs containing API-style tokens.
+
+    Sits alongside Agno's `PIIDetectionGuardrail` — that one catches
+    standard PII (emails, phone, SSN, credit cards). This one catches
+    project-scoped secrets we are paranoid about leaking to Jira.
+    """
+
+    def check(self, run_input: RunInput) -> None:
+        content = getattr(run_input, "input_content", run_input)
+        if not isinstance(content, str):
+            return
+        for pat in _EXTRA_PII_PATTERNS:
+            if pat.search(content):
+                raise InputCheckError(
+                    f"input contains a token matching {pat.pattern!r}; refusing to send to LLM",
+                    check_trigger=CheckTrigger.INPUT_NOT_ALLOWED,
+                )
+
+    async def async_check(self, run_input: RunInput) -> None:
+        self.check(run_input)
+
+
+# ──────────────────────── Coverage helper ──────────────────────────────────────
+
+
+def compute_coverage(update: JiraUpdate) -> float:
+    """Coverage = (bullets with ≥1 evidence_ref) / (total bullets).
+
+    This is the headline metric the Ground step writes into the
+    `pm_updates.coverage` column.
+    """
+    bullets = update.bullets
+    if not bullets:
+        return 0.0
+    grounded = sum(1 for b in bullets if b.evidence_refs)
+    return grounded / len(bullets)
+
+
+def build_grounded_narrative(update: JiraUpdate) -> GroundedNarrative:
+    """Apply the evidence filter and return a GroundedNarrative.
+
+    Idempotent: callable multiple times without changing the result.
+    """
+    dropped: list[str] = []
+    for attr in ("what_shipped", "in_progress", "blockers", "decisions"):
+        kept: list[BulletWithEvidence] = []
+        for b in getattr(update, attr):
+            if b.evidence_refs:
+                kept.append(b)
+            else:
+                dropped.append(f"{attr}: {b.text[:80]}")
+        setattr(update, attr, kept)
+    return GroundedNarrative(
+        update=update,
+        coverage=compute_coverage(update),
+        dropped_bullets=dropped,
+    )
+
+
+# ──────────────────────── Internals ────────────────────────────────────────────
+
+
+def _coerce_to_jira_update(run_output: Any) -> JiraUpdate | None:
+    """Extract a JiraUpdate from a RunOutput-like object.
+
+    Works for: a real `RunOutput` with `.content` set to a JiraUpdate,
+    a bare JiraUpdate instance, or a dict.
+    """
+    candidate = getattr(run_output, "content", run_output)
+    if isinstance(candidate, JiraUpdate):
+        return candidate
+    if isinstance(candidate, dict):
+        try:
+            return JiraUpdate.model_validate(candidate)
+        except Exception as exc:                        # pragma: no cover
+            log.warning("could not coerce dict → JiraUpdate: %s", exc)
+            return None
+    return None
+
+
+def _write_back(run_output: Any, update: JiraUpdate) -> None:
+    if hasattr(run_output, "content"):
+        run_output.content = update

--- a/services/agents/pm_update/inspect.py
+++ b/services/agents/pm_update/inspect.py
@@ -1,0 +1,218 @@
+"""Inspector — show the SessionBundle for one ticket × one window.
+
+Read-only CLI for eyeballing what the Synth would see. Boots no agno,
+no LLM, no Jira — just runs the same query that `run_cycle` uses and
+pretty-prints the bundle.
+
+Usage:
+
+    cd services
+    .venv313/bin/python -m agents.pm_update.inspect --task KAN-64
+
+    # explicit window
+    .venv313/bin/python -m agents.pm_update.inspect --task KAN-64 \\
+        --window-start 2026-05-28T09:00:00Z \\
+        --window-end   2026-05-28T10:00:00Z
+
+    # dump full session_text excerpts (helpful when debugging the prompt)
+    .venv313/bin/python -m agents.pm_update.inspect --task KAN-64 --full-text
+
+    # machine-readable JSON for piping into jq
+    .venv313/bin/python -m agents.pm_update.inspect --task KAN-64 --json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+
+from agents.pm_update import config, db
+
+
+# ──────────────────────── CLI ──────────────────────────────────────────────────
+
+
+def _parse_iso(s: str) -> datetime:
+    cleaned = s.replace("Z", "+00:00")
+    dt = datetime.fromisoformat(cleaned)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="agents.pm_update.inspect",
+        description="Show classified-session data for one Jira ticket in a window.",
+    )
+    p.add_argument("--task", required=True, help="Jira ticket key, e.g. KAN-64")
+    p.add_argument(
+        "--window-start",
+        type=_parse_iso,
+        default=None,
+        help="ISO-8601 UTC start. Default: now - PM_UPDATE_INTERVAL_HOURS",
+    )
+    p.add_argument(
+        "--window-end",
+        type=_parse_iso,
+        default=None,
+        help="ISO-8601 UTC end. Default: now",
+    )
+    p.add_argument(
+        "--full-text",
+        action="store_true",
+        help="Dump each session's full excerpt (2KB cap from db.py).",
+    )
+    p.add_argument(
+        "--json",
+        dest="emit_json",
+        action="store_true",
+        help="Emit the SessionBundle as JSON on stdout instead of the human view.",
+    )
+    return p
+
+
+# ──────────────────────── Formatting helpers ───────────────────────────────────
+
+
+def _fmt_secs(s: int) -> str:
+    """Format seconds as a compact h/m/s string."""
+    if s < 60:
+        return f"{s}s"
+    if s < 3600:
+        return f"{s // 60}m {s % 60}s"
+    h, rem = divmod(s, 3600)
+    m, _ = divmod(rem, 60)
+    return f"{h}h {m}m"
+
+
+def _fmt_local(iso_utc: str) -> str:
+    """Render a UTC ISO timestamp as the host TZ in HH:MM:SS for readability."""
+    cleaned = iso_utc.replace("Z", "+00:00")
+    dt = datetime.fromisoformat(cleaned).astimezone()
+    return dt.strftime("%H:%M:%S")
+
+
+# ──────────────────────── Human view ───────────────────────────────────────────
+
+
+def render_human(bundle, *, full_text: bool) -> str:
+    out: list[str] = []
+    line = "─" * 78
+
+    out.append(line)
+    out.append(f" Ticket : {bundle.task_key}")
+    if bundle.pm_task_title:
+        out.append(f" Title  : {bundle.pm_task_title}")
+    if bundle.pm_task_status:
+        out.append(f" Status : {bundle.pm_task_status}")
+    if bundle.assignee_name:
+        out.append(f" Assignee: {bundle.assignee_name}")
+    out.append(f" Window : {bundle.window_start}  →  {bundle.window_end}")
+    out.append(f" Cycle  : {bundle.cycle_index}")
+    out.append(line)
+
+    out.append(
+        f" Sessions     : {len(bundle.sessions)}"
+        f"   (total {_fmt_secs(bundle.total_seconds)},"
+        f" real {_fmt_secs(bundle.real_seconds)})"
+    )
+    out.append(
+        f" Raw text     : {bundle.raw_text_bytes:,} bytes"
+        f"   (heavy: {bundle.is_heavy})"
+    )
+    if bundle.earlier_today_summaries:
+        out.append(" Earlier today:")
+        for s in bundle.earlier_today_summaries:
+            out.append(f"   - {s}")
+
+    # Aggregate dimensions across all sessions in the window
+    dim_counts: dict[str, Counter] = {}
+    app_secs: Counter = Counter()
+    for s in bundle.sessions:
+        app_secs[s.app_name] += s.duration_s
+        for dim, vals in s.dimensions.items():
+            dim_counts.setdefault(dim, Counter()).update(vals)
+
+    if app_secs:
+        out.append("")
+        out.append(" Apps (by time):")
+        for name, secs in sorted(app_secs.items(), key=lambda kv: -kv[1])[:8]:
+            out.append(f"   {name:<24} {_fmt_secs(secs):>10}")
+
+    if dim_counts:
+        out.append("")
+        out.append(" Dimensions (top values):")
+        for dim, counts in sorted(dim_counts.items()):
+            tops = ", ".join(f"{v}×{n}" for v, n in counts.most_common(5))
+            out.append(f"   {dim:<12} {tops}")
+
+    out.append("")
+    out.append(line)
+    out.append(f" Per-session breakdown ({len(bundle.sessions)} rows)")
+    out.append(line)
+
+    if not bundle.sessions:
+        out.append(" (no classified sessions in this window)")
+    else:
+        out.append(
+            f" {'id':>6}  {'started':>8}  {'dur':>9}  {'real':>9}  "
+            f"{'app':<18}  top_title"
+        )
+        out.append(" " + ("─" * 76))
+        for s in bundle.sessions:
+            real = s.duration_s - s.idle_frame_s
+            top = (s.top_titles or [""])[0][:30]
+            out.append(
+                f" {s.id:>6}  {_fmt_local(s.started_at):>8}  "
+                f"{_fmt_secs(s.duration_s):>9}  {_fmt_secs(real):>9}  "
+                f"{s.app_name[:18]:<18}  {top}"
+            )
+
+    if full_text:
+        out.append("")
+        out.append(line)
+        out.append(" Full session excerpts (capped at 2KB each in the bundle)")
+        out.append(line)
+        for s in bundle.sessions:
+            out.append("")
+            out.append(f" === session {s.id} — {s.app_name} — {_fmt_secs(s.duration_s)} ===")
+            if s.top_titles:
+                out.append(f" top_titles: {s.top_titles}")
+            if s.dimensions:
+                out.append(f" dimensions: {s.dimensions}")
+            out.append("")
+            out.append(s.excerpt or "(no text)")
+    return "\n".join(out)
+
+
+# ──────────────────────── Entry point ──────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    end = args.window_end or datetime.now(timezone.utc)
+    start = args.window_start or (end - timedelta(hours=config.PM_UPDATE_INTERVAL_HOURS))
+    if start >= end:
+        sys.stderr.write(f"window-start ({start}) must be earlier than window-end ({end})\n")
+        return 2
+
+    db.init_schema()
+    bundle = db.fetch_session_bundle(
+        task_key=args.task,
+        window_start=start,
+        window_end=end,
+        cycle_index=0,
+    )
+
+    if args.emit_json:
+        sys.stdout.write(bundle.model_dump_json(indent=2) + "\n")
+    else:
+        sys.stdout.write(render_human(bundle, full_text=args.full_text) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/agents/pm_update/jira_poster.py
+++ b/services/agents/pm_update/jira_poster.py
@@ -1,0 +1,353 @@
+"""Jira worklog poster — phase 1.
+
+Single responsibility: turn a (task_key, time_spent_seconds, started_utc,
+comment) into a successful `jira_add_worklog` call on the user's Jira
+instance via the `mcp-atlassian` MCP server, returning the new worklog id.
+
+Why MCP and not a direct REST call?
+
+  * Auth + URL are already wired into the user's `services/.env` for
+    mcp-atlassian; we'd otherwise duplicate that config.
+  * mcp-atlassian's `jira_add_worklog` handles the Atlassian Document
+    Format conversion of the Markdown comment for us — Jira Cloud
+    doesn't accept plain Markdown over its raw API.
+  * Future phases (comments, transitions) reuse the same boot, so the
+    incremental cost is zero.
+
+Lifecycle: one `uvx mcp-atlassian --transport=stdio` subprocess per
+post. That's deliberately cheap-and-disposable rather than long-lived
+— a stuck child is the worst kind of bug in a 1-hour cron, so we keep
+the failure surface a single subprocess we own.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+from zoneinfo import ZoneInfo
+
+from agents.pm_update import config
+
+log = logging.getLogger(__name__)
+
+# Names mcp-atlassian expects in its env. Our .env uses JIRA_EMAIL for
+# the human's address — mcp-atlassian wants JIRA_USERNAME. Map at boot.
+_JIRA_ENV_KEYS = ("JIRA_URL", "JIRA_USERNAME", "JIRA_API_TOKEN")
+
+# How long we'll wait for the MCP child to handshake + answer one tool call.
+# 30s is generous — even a cold uvx download has finished by then.
+_SUBPROCESS_TIMEOUT_S = int(os.environ.get("JIRA_MCP_TIMEOUT_S", "60"))
+
+
+# ──────────────────────── Errors ───────────────────────────────────────────────
+
+
+class JiraPostError(RuntimeError):
+    """Anything that prevents a worklog from landing in Jira.
+
+    Caller decides whether to retry or downgrade to DRAFTED. We never
+    silently swallow — the row in `pm_updates` reflects reality.
+    """
+
+
+class JiraConfigError(JiraPostError):
+    """Missing or malformed Jira env vars. Permanent until env fixed."""
+
+
+# ──────────────────────── Public API ───────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class WorklogPostResult:
+    worklog_id:        str
+    issue_key:         str
+    time_spent_jira:   str
+    time_spent_seconds: int
+    started_iso:       str
+    raw_response:      dict[str, Any]
+
+
+def post_worklog(
+    *,
+    task_key: str,
+    time_spent_seconds: int,
+    started_utc: datetime,
+    comment: Optional[str] = None,
+    timezone_name: Optional[str] = None,
+) -> WorklogPostResult:
+    """Post one worklog entry to Jira.
+
+    Args:
+        task_key: Jira issue key, e.g. "KAN-64". Validated by the MCP
+            server with a `^[A-Z][A-Z0-9_]+-\\d+$` pattern.
+        time_spent_seconds: Real (idle-discounted) seconds for this
+            window. Must be >= 60 — Jira rejects shorter entries.
+        started_utc: Window-start moment in UTC. Will be rendered to
+            the local TZ in the Jira-expected format.
+        comment: Optional Markdown comment (≤ a few sentences in phase
+            1 — the worklog tab in Jira shows this in-line).
+        timezone_name: Override for the started-time TZ. Defaults to
+            `MERIDIAN_TZ` env var, then the host's `datetime.now()`
+            tzinfo, then `Asia/Kolkata`.
+
+    Returns:
+        `WorklogPostResult` with the new worklog id.
+
+    Raises:
+        JiraConfigError on missing creds.
+        JiraPostError on any MCP / Jira API failure.
+    """
+    if time_spent_seconds < 60:
+        raise JiraPostError(
+            f"time_spent_seconds={time_spent_seconds} below Jira's 60s minimum"
+        )
+
+    started_local = render_started_local(started_utc, tz_name=timezone_name)
+    jira_time = seconds_to_jira_time(time_spent_seconds)
+
+    env = _build_env()
+    args: dict[str, Any] = {
+        "issue_key":  task_key,
+        "time_spent": jira_time,
+        "started":    started_local,
+    }
+    if comment:
+        args["comment"] = comment
+
+    log.info(
+        "jira_add_worklog: task=%s time_spent=%s started=%s comment_len=%d",
+        task_key, jira_time, started_local, len(comment or ""),
+    )
+    raw = _call_mcp_tool("jira_add_worklog", args, env=env)
+    worklog_id = _extract_worklog_id(raw)
+    return WorklogPostResult(
+        worklog_id=worklog_id,
+        issue_key=task_key,
+        time_spent_jira=jira_time,
+        time_spent_seconds=time_spent_seconds,
+        started_iso=started_local,
+        raw_response=raw,
+    )
+
+
+# ──────────────────────── Helpers (importable, unit-tested in isolation) ───────
+
+
+def seconds_to_jira_time(seconds: int) -> str:
+    """Convert seconds → Jira's time-spent string (e.g. '1h 30m').
+
+    Jira accepts a small grammar: `Nw`, `Nd`, `Nh`, `Nm`. We emit
+    hours+minutes because PM updates land at sub-day granularity.
+    Anything under a minute rounds up — Jira rejects fractional minutes
+    on the worklog API.
+    """
+    if seconds < 60:
+        raise ValueError(f"seconds must be ≥ 60 for Jira worklog (got {seconds})")
+    minutes_total = (seconds + 30) // 60        # round-to-nearest
+    hours, minutes = divmod(minutes_total, 60)
+    if hours and minutes:
+        return f"{hours}h {minutes}m"
+    if hours:
+        return f"{hours}h"
+    return f"{minutes}m"
+
+
+def render_started_local(when_utc: datetime, *, tz_name: Optional[str] = None) -> str:
+    """Render a UTC moment in the Jira worklog `started` format.
+
+    Format: `YYYY-MM-DDTHH:MM:SS.mmm+ZZZZ` — milliseconds + ±HHMM offset,
+    no colon in the offset. This is what mcp-atlassian's example string
+    uses (`2023-08-01T12:00:00.000+0000`) and what the underlying Jira
+    REST API expects.
+    """
+    if when_utc.tzinfo is None:
+        when_utc = when_utc.replace(tzinfo=timezone.utc)
+
+    tz = _resolve_tz(tz_name)
+    local = when_utc.astimezone(tz)
+    millis = f"{local.microsecond // 1000:03d}"
+    # `%z` gives `+HHMM` on all modern Python versions — no colon, good.
+    return local.strftime(f"%Y-%m-%dT%H:%M:%S.{millis}%z")
+
+
+# ──────────────────────── Internals ────────────────────────────────────────────
+
+
+def _resolve_tz(explicit: Optional[str]) -> ZoneInfo:
+    """Pick the TZ for `started`: explicit > MERIDIAN_TZ > host > Asia/Kolkata."""
+    candidates = [
+        explicit,
+        os.environ.get("MERIDIAN_TZ"),
+    ]
+    for name in candidates:
+        if name:
+            try:
+                return ZoneInfo(name)
+            except Exception as exc:                    # noqa: BLE001 — invalid TZ string
+                log.warning("invalid TZ %r: %s", name, exc)
+
+    host_tz = datetime.now().astimezone().tzinfo
+    if host_tz is not None:
+        # tzinfo from astimezone() is a fixed offset on some platforms;
+        # but it always has tzname() so this is enough for strftime("%z").
+        return host_tz                                  # type: ignore[return-value]
+
+    return ZoneInfo("Asia/Kolkata")
+
+
+def _build_env() -> dict[str, str]:
+    """Inherit the process env, then re-key JIRA_EMAIL → JIRA_USERNAME.
+
+    mcp-atlassian fails loudly if the trio isn't set, so we pre-check
+    and raise a clearer error before spawning.
+    """
+    env = os.environ.copy()
+    if "JIRA_EMAIL" in env and "JIRA_USERNAME" not in env:
+        env["JIRA_USERNAME"] = env["JIRA_EMAIL"]
+
+    missing = [k for k in _JIRA_ENV_KEYS if not env.get(k)]
+    if missing:
+        raise JiraConfigError(
+            f"mcp-atlassian needs {missing} in env "
+            f"(services/.env defines JIRA_URL/JIRA_EMAIL/JIRA_API_TOKEN)"
+        )
+    return env
+
+
+def _call_mcp_tool(
+    name: str,
+    arguments: dict[str, Any],
+    *,
+    env: dict[str, str],
+) -> dict[str, Any]:
+    """Run one MCP tool call and return its `result` payload.
+
+    Boots `uvx mcp-atlassian --transport=stdio`, performs the
+    initialize handshake, calls the tool, then terminates the child.
+    Exceptions surface to the caller — never silently retried.
+    """
+    cmd = ["uvx", "mcp-atlassian", "--transport=stdio"]
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    try:
+        _send(proc, {
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities":     {},
+                "clientInfo":       {"name": "meridian-pm-update", "version": "1.0"},
+            },
+        })
+        _recv(proc)                                     # init reply (discarded)
+        _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+
+        _send(proc, {
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        })
+        reply = _recv(proc)
+    except subprocess.TimeoutExpired as exc:
+        raise JiraPostError(f"mcp-atlassian timed out: {exc}") from exc
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    if "error" in reply:
+        raise JiraPostError(f"jira_add_worklog returned error: {reply['error']}")
+
+    result = reply.get("result")
+    if not result:
+        raise JiraPostError(f"jira_add_worklog returned no result: {reply}")
+
+    # Tools return content as a list of typed parts. We always expect a
+    # single text/JSON blob from jira_add_worklog.
+    return _flatten_tool_result(result)
+
+
+def _send(proc: subprocess.Popen, msg: dict[str, Any]) -> None:
+    if proc.stdin is None:
+        raise JiraPostError("mcp-atlassian subprocess has no stdin")
+    proc.stdin.write(json.dumps(msg) + "\n")
+    proc.stdin.flush()
+
+
+def _recv(proc: subprocess.Popen) -> dict[str, Any]:
+    """Read one JSON-RPC reply, bounded by SUBPROCESS_TIMEOUT.
+
+    mcp-atlassian emits banner lines to *stderr* — those don't matter
+    here. stdout is strictly newline-delimited JSON-RPC frames.
+    """
+    if proc.stdout is None:
+        raise JiraPostError("mcp-atlassian subprocess has no stdout")
+
+    # Python's readline has no timeout. Use communicate-like polling
+    # via select to bound the wait per frame.
+    import select
+    deadline = _SUBPROCESS_TIMEOUT_S
+    buf: list[str] = []
+    while True:
+        ready, _, _ = select.select([proc.stdout], [], [], deadline)
+        if not ready:
+            raise subprocess.TimeoutExpired(proc.args, deadline)
+        chunk = proc.stdout.readline()
+        if not chunk:
+            stderr = proc.stderr.read() if proc.stderr else ""
+            raise JiraPostError(f"mcp-atlassian closed stdout — stderr: {stderr[:500]}")
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        try:
+            return json.loads(chunk)
+        except json.JSONDecodeError:
+            # Some MCP servers leak a banner line through stdout; tolerate.
+            buf.append(chunk)
+            if len(buf) > 5:
+                raise JiraPostError(f"mcp-atlassian sent non-JSON: {buf!r}")
+
+
+def _flatten_tool_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Pull the structured JSON out of a tools/call result envelope.
+
+    MCP tools return `{"content": [{"type":"text","text": "<json>"}, ...]}`.
+    `jira_add_worklog` always returns a single JSON-encoded text block.
+    """
+    content = result.get("content") or []
+    for part in content:
+        if part.get("type") == "text" and "text" in part:
+            try:
+                return json.loads(part["text"])
+            except json.JSONDecodeError:
+                # Server returned plain text — pass it back verbatim.
+                return {"_raw_text": part["text"]}
+    # Result with no content list — return the raw envelope.
+    return result
+
+
+def _extract_worklog_id(raw: dict[str, Any]) -> str:
+    """Find the worklog id in mcp-atlassian's response.
+
+    The server returns the Jira REST envelope shape. We probe the few
+    locations Jira's API uses for the id, fail loudly if none match.
+    """
+    for key in ("id", "worklog_id", "worklogId"):
+        if key in raw and raw[key]:
+            return str(raw[key])
+    nested = raw.get("worklog") or raw.get("data") or {}
+    for key in ("id", "worklog_id", "worklogId"):
+        if key in nested and nested[key]:
+            return str(nested[key])
+    raise JiraPostError(f"could not find worklog id in response: {raw!r}")

--- a/services/agents/pm_update/learning.py
+++ b/services/agents/pm_update/learning.py
@@ -1,0 +1,89 @@
+"""Self-learning configuration for the pm_update workflow.
+
+Agno exposes a `LearningMachine` that wires up five complementary stores:
+
+  * **User Profile**     — structured facts about the human user
+  * **User Memory**      — unstructured observations from runs
+  * **Session Context**  — within-run goals/progress
+  * **Entity Memory**    — facts about external entities (here: tickets)
+  * **Learned Knowledge** — cross-run insights to transfer between users
+  * **Decision Log**     — every routing/posting decision + outcome
+
+For Meridian, the entities we want to remember are **Jira tickets** —
+not "users" in the conversational sense. So we use `user_id=task_key`
+as the identity key: each ticket gets its own memory pile.
+
+This gives the agent:
+  - **Entity Memory** for KAN-64: themes, files, blockers seen
+  - **Decision Log** of every cycle: what was posted, was it edited,
+    did the routing gate fire
+  - **Learned Knowledge** in Propose mode: the agent suggests
+    generalisations ("user prefers terse bullets") that we accept
+    explicitly via the feedback table
+
+Combined with the `pm_update_feedback` table (read by the
+`get_feedback_examples` tool), this closes the loop: every admin edit
+becomes a few-shot hint for the next cycle.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from agents.pm_update import config
+
+if TYPE_CHECKING:
+    from agno.learn import LearningMachine
+
+log = logging.getLogger(__name__)
+
+
+def build_learning_machine() -> "LearningMachine":
+    """Return the LearningMachine instance wired for PM updates.
+
+    The defaults are deliberately conservative:
+      * `user_profile=False`  — we have one human user, no need to
+        extract structured facts about them
+      * `user_memory=True` (ALWAYS) — accumulate ticket-scoped notes
+      * `entity_memory=True` (ALWAYS) — per-ticket facts
+      * `learned_knowledge=True` (AGENTIC) — agent saves
+        generalisations on its own; cheap because we cap tool calls
+      * `decision_log=True` (AGENTIC) — only logged when the agent
+        decides a decision is worth recording, avoiding spam
+
+    Returns:
+        A configured `LearningMachine` ready to pass to `Agent(learning=)`.
+    """
+    from agno.learn import (
+        DecisionLogConfig,
+        EntityMemoryConfig,
+        LearnedKnowledgeConfig,
+        LearningMachine,
+        LearningMode,
+        UserMemoryConfig,
+    )
+
+    return LearningMachine(
+        user_profile=False,
+        user_memory=UserMemoryConfig(mode=LearningMode.ALWAYS),
+        entity_memory=EntityMemoryConfig(mode=LearningMode.ALWAYS),
+        learned_knowledge=LearnedKnowledgeConfig(mode=LearningMode.AGENTIC),
+        decision_log=DecisionLogConfig(mode=LearningMode.AGENTIC),
+    )
+
+
+def prune_old_memories(*, max_age_days: int = 90) -> None:
+    """Call from a weekly cron to keep the memory store healthy.
+
+    Memory growth is the #1 cost trap agno calls out in their
+    production-best-practices doc — at 200+ memories per entity the
+    per-LLM-call cost balloons.
+    """
+    from agno.db.sqlite import SqliteDb
+    from agno.learn import LearningMachine
+
+    db = SqliteDb(db_file=str(config.MERIDIAN_DB))
+    lm = LearningMachine(db=db)  # type: ignore[call-arg]
+    lm.curator.prune(max_age_days=max_age_days)
+    lm.curator.deduplicate()
+    log.info("pruned pm_update memories older than %d days", max_age_days)

--- a/services/agents/pm_update/models.py
+++ b/services/agents/pm_update/models.py
@@ -1,0 +1,180 @@
+"""Pydantic models for the pm_update workflow.
+
+These models serve three purposes:
+
+  1. **`output_schema` for agno Agents** — the Synthesise + Compose agents
+     emit `JiraUpdate` instances; agno's structured-output path validates
+     the LLM response against this schema.
+  2. **Step-to-step data flow** — `SessionBundle` and `WorkNarrative` are
+     passed between workflow steps via `StepOutput.content`.
+  3. **DB row contract** — `JiraUpdate` is what we serialise into the
+     `pm_updates.payload_json` column.
+
+The anti-hallucination contract lives here: every `BulletWithEvidence`
+must carry at least one `session_id` evidence ref. The `EvidenceRefValidator`
+post-hook hard-rejects bullets that violate this.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+# ──────────────────────── Enums ────────────────────────────────────────────────
+
+
+class RiskFlag(str, Enum):
+    """Risk signals surfaced to the reviewer.
+
+    Each flag means "this update should not auto-post without a human look".
+    """
+    PII_REDACTED        = "pii_redacted"
+    LOW_EVIDENCE        = "low_evidence"
+    CROSS_TICKET_LEAK   = "cross_ticket_leak"
+    TESTS_FAILING       = "tests_failing"
+    LOW_CONFIDENCE      = "low_confidence"
+    TICKET_CLOSED       = "ticket_closed_upstream"
+    ASSIGNEE_MISMATCH   = "assignee_mismatch"
+    STALE_PM_TASK_CACHE = "stale_pm_task_cache"
+
+
+class UpdateState(str, Enum):
+    """Lifecycle state of a row in `pm_updates`."""
+    DRAFTED  = "drafted"   # workflow produced the row, not yet routed
+    QUEUED   = "queued"    # held for human review
+    POSTED   = "posted"    # comment + worklog landed on Jira
+    SKIPPED  = "skipped"   # gate rejected (e.g. low work, already-done ticket)
+    REJECTED = "rejected"  # admin explicitly declined this update
+    FAILED   = "failed"    # post attempt failed; safe to retry
+
+
+# ──────────────────────── Building blocks ──────────────────────────────────────
+
+
+class SessionDigest(BaseModel):
+    """Compact, LLM-friendly representation of one `app_sessions` row.
+
+    Raw `session_text` (which can be 80KB+) is NOT included by default —
+    the digest carries an `excerpt` capped at 2KB. Full text is fetched on
+    demand via the `get_session_evidence` tool.
+    """
+    model_config = ConfigDict(frozen=True)
+
+    id:             int
+    app_name:       str
+    started_at:     str            # ISO-8601 UTC
+    ended_at:       str
+    duration_s:     int
+    idle_frame_s:   int = 0
+    top_titles:     list[str] = Field(default_factory=list, max_length=3)
+    dimensions:     dict[str, list[str]] = Field(default_factory=dict)
+    excerpt:        str = Field(default="", description="Up to 2KB of session_text")
+    category:       Optional[str] = None
+    text_source:    Optional[str] = None
+
+
+class SessionBundle(BaseModel):
+    """All sessions for one (task_key, window) — the workflow input.
+
+    `is_heavy` is computed in the Collect step and drives the Condition
+    branch downstream.
+    """
+    model_config = ConfigDict(frozen=True)
+
+    task_key:        str
+    window_start:    str
+    window_end:      str
+    cycle_index:     int = Field(default=0, description="Nth cycle today for this task, 0-indexed")
+    sessions:        list[SessionDigest]
+    total_seconds:   int
+    real_seconds:    int = Field(description="duration minus idle, used for time_spent")
+    raw_text_bytes:  int = 0
+    is_heavy:        bool = False
+    pm_task_status:  Optional[str] = None
+    pm_task_title:   Optional[str] = None
+    assignee_name:   Optional[str] = None
+    earlier_today_summaries: list[str] = Field(default_factory=list)
+
+
+# ──────────────────────── Output schema (Synthesise → Jira) ────────────────────
+
+
+class BulletWithEvidence(BaseModel):
+    """One factual claim plus the session_ids it is grounded in.
+
+    The `EvidenceRefValidator` post-hook drops any bullet with an empty
+    `evidence_refs` list, because every claim must be traceable back to a
+    captured session.
+    """
+    text:           str  = Field(min_length=4, max_length=400)
+    evidence_refs:  list[int] = Field(default_factory=list, min_length=1)
+
+    @model_validator(mode="after")
+    def _refs_must_be_non_empty(self) -> "BulletWithEvidence":
+        if not self.evidence_refs:
+            raise ValueError("bullet must reference at least one session_id")
+        return self
+
+
+class JiraUpdate(BaseModel):
+    """The contract the Synthesise agent must produce.
+
+    This is what gets persisted to `pm_updates.payload_json` and rendered
+    into a Jira comment by the Compose step.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    task_key:           str
+    window_start:       str
+    window_end:         str
+    cycle_index:        int = 0
+    time_spent_seconds: int = Field(ge=0)
+
+    summary:            str = Field(max_length=80, description="≤80 char headline")
+    what_shipped:       list[BulletWithEvidence] = Field(default_factory=list)
+    in_progress:        list[BulletWithEvidence] = Field(default_factory=list)
+    blockers:           list[BulletWithEvidence] = Field(default_factory=list)
+    decisions:          list[BulletWithEvidence] = Field(default_factory=list)
+    next_steps:         list[str] = Field(default_factory=list, max_length=5)
+
+    risk_flags:          list[RiskFlag] = Field(default_factory=list)
+
+    confidence:         float = Field(ge=0.0, le=1.0, default=0.0)
+    reasoning:          str = Field(default="", description="Synth's brief justification")
+
+    @property
+    def bullets(self) -> list[BulletWithEvidence]:
+        """All evidence-bearing bullets in deterministic order."""
+        return [
+            *self.what_shipped,
+            *self.in_progress,
+            *self.blockers,
+            *self.decisions,
+        ]
+
+
+# ──────────────────────── Grounded narrative (post-Ground step) ────────────────
+
+
+class GroundedNarrative(BaseModel):
+    """The `JiraUpdate` after the Ground step has filtered un-evidenced bullets."""
+    model_config = ConfigDict(frozen=False)
+
+    update:           JiraUpdate
+    coverage:         float = Field(ge=0.0, le=1.0)
+    dropped_bullets:  list[str] = Field(default_factory=list)
+
+
+# ──────────────────────── Routing outcome ──────────────────────────────────────
+
+
+class RouteOutcome(BaseModel):
+    """What the Router step decided. Final workflow output."""
+    state:           UpdateState
+    pm_update_id:    Optional[int] = None
+    posted_comment_id: Optional[str] = None
+    reason:          str = ""
+    timestamp:       datetime = Field(default_factory=datetime.utcnow)

--- a/services/agents/pm_update/schema.sql
+++ b/services/agents/pm_update/schema.sql
@@ -1,0 +1,72 @@
+-- meridian — pm_update tables
+--
+-- These tables live alongside the rest of meridian.db. They are owned by
+-- the Python pm_update package — Rust does not write to them. When this
+-- module is eventually stitched into the daemon, the DDL here will be
+-- migrated into src/migrations/02X_pm_updates.sql; until then,
+-- `db.init_schema()` applies it idempotently.
+
+-- One row per workflow run. Uniqueness over (task_key, day_utc, cycle_index)
+-- prevents the daemon from double-posting after a restart. Backfill mode
+-- writes rows with cycle_index = -1 so it never collides with live cycles.
+CREATE TABLE IF NOT EXISTS pm_updates (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_key             TEXT    NOT NULL,
+    day_utc              TEXT    NOT NULL,                       -- 'YYYY-MM-DD'
+    cycle_index          INTEGER NOT NULL DEFAULT 0,             -- nth cycle that day; -1 = backfill
+    window_start         TEXT    NOT NULL,                       -- ISO-8601 UTC
+    window_end           TEXT    NOT NULL,
+    state                TEXT    NOT NULL,                       -- UpdateState enum value
+    confidence           REAL    NOT NULL DEFAULT 0.0,
+    coverage             REAL    NOT NULL DEFAULT 0.0,
+    time_spent_seconds   INTEGER NOT NULL DEFAULT 0,
+    payload_json         TEXT    NOT NULL,                       -- serialised JiraUpdate
+    session_id_min       INTEGER,
+    session_id_max       INTEGER,
+    workflow_run_id      TEXT,                                   -- agno workflow run id
+    posted_comment_id    TEXT,                                   -- Jira comment id (phase 2)
+    posted_worklog_id    TEXT,                                   -- Jira worklog id (phase 1)
+    created_at           TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    posted_at            TEXT,
+    UNIQUE (task_key, day_utc, cycle_index)
+);
+
+-- NOTE: the worklog idempotency index `uq_pm_updates_worklog_window`
+-- is created in db.init_schema() so it can run AFTER the additive
+-- column migration adds posted_worklog_id to legacy tables.
+
+CREATE INDEX IF NOT EXISTS idx_pm_updates_task_day
+    ON pm_updates (task_key, day_utc);
+
+CREATE INDEX IF NOT EXISTS idx_pm_updates_state
+    ON pm_updates (state);
+
+-- One row per bullet — flat shape lets the UI render an evidence panel
+-- without parsing the payload JSON.
+CREATE TABLE IF NOT EXISTS pm_update_evidence (
+    pm_update_id  INTEGER NOT NULL REFERENCES pm_updates(id) ON DELETE CASCADE,
+    bullet_kind   TEXT    NOT NULL,                              -- 'shipped'|'in_progress'|'blocker'|'decision'
+    bullet_index  INTEGER NOT NULL,
+    session_id    INTEGER NOT NULL REFERENCES app_sessions(id),
+    excerpt       TEXT    NOT NULL DEFAULT '',
+    PRIMARY KEY (pm_update_id, bullet_kind, bullet_index, session_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pm_update_evidence_session
+    ON pm_update_evidence (session_id);
+
+-- Self-learning signal: every admin edit / rejection becomes a feedback
+-- row. The Synth agent's pre_hook injects recent feedback as few-shot
+-- guidance, so the system improves without us manually retuning prompts.
+CREATE TABLE IF NOT EXISTS pm_update_feedback (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    pm_update_id   INTEGER NOT NULL REFERENCES pm_updates(id) ON DELETE CASCADE,
+    feedback_kind  TEXT    NOT NULL,                             -- 'edit'|'reject'|'approve'
+    original_text  TEXT,                                         -- the synth-generated comment
+    edited_text    TEXT,                                         -- the human-edited final, if any
+    note           TEXT,                                         -- optional admin note
+    created_at     TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_pm_update_feedback_task
+    ON pm_update_feedback (pm_update_id);

--- a/services/agents/pm_update/tools.py
+++ b/services/agents/pm_update/tools.py
@@ -1,0 +1,187 @@
+"""Function tools exposed to the Synth agent.
+
+agno introspects each function's name, signature and docstring to build
+the tool spec the LLM sees. So the docstrings here matter — they're the
+LLM-facing documentation. Keep them imperative and specific.
+
+We deliberately do NOT expose raw SQL to the model. Every tool below is a
+typed, narrow accessor. If we ever want richer querying, we'll add more
+narrow tools — never a generic SQL endpoint, since "replace the dev's PM
+work" means the surface area must stay auditable.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from agents.pm_update import db
+from agents.pm_update.config import MERIDIAN_DB
+
+log = logging.getLogger(__name__)
+
+# Cap evidence excerpts shown to the model so a 50KB OCR blob doesn't
+# blow past a single tool-result token budget.
+EVIDENCE_CHAR_CAP = 4_000
+
+
+def get_session_evidence(session_id: int, max_chars: int = EVIDENCE_CHAR_CAP) -> str:
+    """Return the raw OCR/text excerpt for one session as proof of activity.
+
+    Use this when you need more detail than the 2KB excerpt in the digest —
+    for example, to verify whether a specific file was edited or to quote
+    a commit message. The session_id MUST appear in the bundle you were
+    given; using it outside the bundle is a hallucination.
+
+    Args:
+        session_id: The `app_sessions.id` to fetch.
+        max_chars: Cap on returned text size (default 4000).
+
+    Returns:
+        The session_text, truncated to `max_chars`. Empty string if the
+        session has no captured text.
+    """
+    text = db.fetch_session_text(session_id, db_path=MERIDIAN_DB)
+    if len(text) > max_chars:
+        return text[:max_chars] + "\n…[truncated]"
+    return text
+
+
+def check_pm_task_status(task_key: str) -> dict[str, Any]:
+    """Look up the current cached Jira state of a ticket.
+
+    Use this BEFORE proposing a status transition or writing a comment
+    that depends on the ticket's lifecycle phase. Returns a dict with:
+        status_category : 'todo' | 'in_progress' | 'done'
+        issue_type      : 'Story' | 'Bug' | 'Task' | …
+        title           : human-readable summary
+        epic_title      : parent epic if any
+        sprint_name     : active sprint if any
+        assignee_name   : current assignee
+        fetched_at      : when meridian last refreshed this row
+
+    If the cache is older than 30 minutes, treat the data as stale and
+    say so in your `reasoning` field.
+
+    Args:
+        task_key: Jira ticket key, e.g. "KAN-64".
+
+    Returns:
+        Dict of ticket fields, or {"error": "not_found"} if the ticket is
+        not in the local cache.
+    """
+    row = db.fetch_pm_task(task_key, db_path=MERIDIAN_DB)
+    if row is None:
+        return {"error": "not_found", "task_key": task_key}
+    # Drop the description_text — it can be huge and is rarely useful in
+    # a tool result (we already have it in the bundle context).
+    row.pop("description_text", None)
+    if row.get("fetched_at"):
+        try:
+            fetched = datetime.fromisoformat(row["fetched_at"].replace("Z", "+00:00"))
+            age = datetime.now(timezone.utc) - fetched
+            row["cache_age_minutes"] = int(age.total_seconds() // 60)
+            row["cache_is_stale"] = age > timedelta(minutes=30)
+        except (ValueError, TypeError):
+            pass
+    return row
+
+
+def get_earlier_today_summaries(task_key: str) -> list[str]:
+    """Headlines of earlier posts on this ticket today (oldest first).
+
+    Use this to avoid repeating yourself across the day's cycles. If you
+    see "Wired migration 022" in this list, you don't need to say that
+    again in cycle 3 — focus on what's new.
+
+    Args:
+        task_key: Jira ticket key.
+
+    Returns:
+        Ordered list of summary headlines, oldest first. Empty list if
+        this is the first cycle of the day.
+    """
+    from datetime import datetime as _dt
+    return db._fetch_earlier_today_summaries(
+        task_key, _dt.now(timezone.utc), db_path=MERIDIAN_DB
+    )
+
+
+def get_feedback_examples(task_key: str, limit: int = 3) -> list[dict[str, str]]:
+    """Recent admin edits/rejections — use them to match the user's style.
+
+    Each item is `{kind, original, edited, note}`. The Synth agent should
+    treat `edited` versions as positive examples (this is how the user
+    wants comments worded) and `reject` entries as negative examples
+    (avoid this shape).
+
+    Args:
+        task_key: Jira ticket key.
+        limit: Max number of items.
+
+    Returns:
+        List ordered newest first.
+    """
+    rows = db.fetch_recent_feedback(task_key, limit=limit, db_path=MERIDIAN_DB)
+    examples: list[dict[str, str]] = []
+    for r in rows:
+        examples.append({
+            "kind":     r["feedback_kind"],
+            "original": (r.get("original_text") or "")[:600],
+            "edited":   (r.get("edited_text") or "")[:600],
+            "note":     (r.get("note") or "")[:200],
+        })
+    return examples
+
+
+def render_jira_comment_markdown(
+    summary: str,
+    what_shipped: list[str],
+    in_progress: list[str],
+    blockers: list[str],
+    decisions: list[str],
+    next_steps: list[str],
+    time_spent_seconds: int,
+) -> str:
+    """Render the final Jira-flavoured Markdown comment.
+
+    This is a deterministic Python function — not an LLM call — because
+    the structure of the comment must be stable across cycles. The Synth
+    agent fills the `JiraUpdate` model; this helper serialises it.
+
+    Args:
+        summary: ≤80-char headline.
+        what_shipped: Bullets for completed work.
+        in_progress: Bullets for ongoing work.
+        blockers: Bullets for current blockers.
+        decisions: Bullets for design/tech decisions.
+        next_steps: Short list of next actions.
+        time_spent_seconds: For the "time spent" footer.
+
+    Returns:
+        Markdown string ready to POST to Jira.
+    """
+    def _bullets(items: list[str]) -> str:
+        return "\n".join(f"* {i}" for i in items) if items else "_(none)_"
+
+    minutes = max(1, time_spent_seconds // 60)
+    parts: list[str] = [
+        f"**{summary}**",
+        "",
+        f"_Meridian PM update — time spent: ~{minutes} min_",
+        "",
+        "### What shipped",
+        _bullets(what_shipped),
+        "",
+        "### In progress",
+        _bullets(in_progress),
+    ]
+    if blockers:
+        parts += ["", "### Blockers", _bullets(blockers)]
+    if decisions:
+        parts += ["", "### Decisions", _bullets(decisions)]
+    if next_steps:
+        parts += ["", "### Next", _bullets(next_steps)]
+    return "\n".join(parts)

--- a/services/agents/pm_update/workflow.py
+++ b/services/agents/pm_update/workflow.py
@@ -1,0 +1,486 @@
+"""The pm_update_cycle Workflow.
+
+This is the spine of the package. It wires the steps described in the
+architecture doc:
+
+  Collect → Condition(heavy/light) → Synthesise → Ground → Route
+
+Designed to be invoked one of two ways:
+
+  1. **CLI / standalone** — `cli.py` calls `run_cycle()` directly.
+  2. **Daemon** (later)   — `jira_updater_daemon` will import
+     `run_cycle_async()` and fire it on the hourly cron.
+
+The Workflow's `session_state` carries cross-cycle context (earlier
+posts today, the high-water mark of the last posted session) so the
+synth has continuity without re-querying the DB.
+
+No status-transition logic: this workflow only generates Jira comments.
+Status changes stay a human decision.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Optional
+
+from agents.pm_update import agents as pm_agents
+from agents.pm_update import config, db
+from agents.pm_update.hooks import build_grounded_narrative, risk_flagger
+from agents.pm_update.learning import build_learning_machine
+from agents.pm_update.models import (
+    BulletWithEvidence,
+    GroundedNarrative,
+    JiraUpdate,
+    RiskFlag,
+    RouteOutcome,
+    SessionBundle,
+    UpdateState,
+)
+
+if TYPE_CHECKING:
+    from agno.workflow.workflow import Workflow
+
+log = logging.getLogger(__name__)
+
+
+# ──────────────────────── Workflow factory ─────────────────────────────────────
+
+
+def build_workflow(*, debug_mode: bool = False, debug_level: int = 1) -> "Workflow":
+    """Construct the Workflow object once per process.
+
+    Heavy imports (agno) live inside this function — the module itself
+    stays importable without the optional dependency.
+
+    Args:
+        debug_mode: Pass through to Workflow + every Agent's `debug_mode`.
+        debug_level: 1 (default) or 2 (verbose) — only honoured when
+            debug_mode is True.
+    """
+    from agno.db.sqlite import SqliteDb
+    from agno.workflow.step import Step
+    from agno.workflow.workflow import Workflow
+
+    agno_db = SqliteDb(
+        db_file=str(config.MERIDIAN_DB),
+        session_table="agno_workflow_sessions",
+        memory_table="agno_pm_memories",
+        metrics_table="agno_pm_metrics",
+        eval_table="agno_pm_eval_runs",
+        approvals_table="agno_pm_approvals",
+    )
+
+    learning = build_learning_machine()
+
+    synth = pm_agents.build_synth_agent(
+        db=agno_db, learning=learning,
+        debug_mode=debug_mode, debug_level=debug_level,
+    )
+
+    workflow = Workflow(
+        name="pm_update_cycle",
+        description="Hourly Jira worklog update from classified sessions",
+        db=agno_db,
+        store_executor_outputs=True,           # full audit per step
+        debug_mode=debug_mode,
+        debug_level=debug_level,
+        steps=[
+            Step(name="collect",    executor=_step_collect),
+            Step(name="synthesise", agent=synth),
+            Step(name="ground",     executor=_step_ground),
+            Step(name="route",      executor=_step_route),
+        ],
+        session_state={
+            "task_key": None,
+            "earlier_today_summaries": [],
+            "last_posted_session_id": None,
+        },
+    )
+    return workflow
+
+
+# ──────────────────────── Public entry points ──────────────────────────────────
+
+
+def run_cycle(
+    *,
+    task_key: str,
+    window_start: datetime,
+    window_end: datetime,
+    cycle_index: int = 0,
+    dry_run: bool = True,
+    debug_mode: bool = False,
+    debug_level: int = 1,
+) -> RouteOutcome:
+    """Synchronous one-shot — used by the CLI.
+
+    Boots the schema, builds the workflow, runs one cycle, and returns
+    the routing outcome. `dry_run=True` (the default) prevents any
+    side-effect on Jira even if the routing gate would otherwise post.
+
+    `debug_mode=True` turns on agno's `debug_mode` on the Workflow and
+    every Agent — prompts, model responses, and tool calls are printed.
+    `debug_level=2` is even more verbose.
+    """
+    db.init_schema()
+    workflow = build_workflow(debug_mode=debug_mode, debug_level=debug_level)
+    bundle = db.fetch_session_bundle(
+        task_key=task_key,
+        window_start=window_start,
+        window_end=window_end,
+        cycle_index=cycle_index,
+    )
+    log.info(
+        "pm_update cycle starting — task=%s sessions=%d total_s=%d real_s=%d heavy=%s",
+        task_key, len(bundle.sessions), bundle.total_seconds, bundle.real_seconds, bundle.is_heavy,
+    )
+
+    response = workflow.run(
+        input=_render_workflow_input(bundle),
+        additional_data={
+            "task_key":      task_key,
+            "window_start":  bundle.window_start,
+            "window_end":    bundle.window_end,
+            "cycle_index":   cycle_index,
+            "dry_run":       dry_run,
+            "bundle":        bundle.model_dump(),
+        },
+    )
+    outcome = _extract_outcome(response)
+    log.info("pm_update cycle done — state=%s reason=%s", outcome.state.value, outcome.reason)
+    return outcome
+
+
+async def run_cycle_async(**kwargs) -> RouteOutcome:
+    """Async variant for the daemon path (later)."""
+    db.init_schema()
+    workflow = build_workflow(
+        debug_mode=kwargs.get("debug_mode", False),
+        debug_level=kwargs.get("debug_level", 1),
+    )
+    bundle = db.fetch_session_bundle(
+        task_key=kwargs["task_key"],
+        window_start=kwargs["window_start"],
+        window_end=kwargs["window_end"],
+        cycle_index=kwargs.get("cycle_index", 0),
+    )
+    response = await workflow.arun(
+        input=_render_workflow_input(bundle),
+        additional_data={
+            "task_key":     kwargs["task_key"],
+            "window_start": bundle.window_start,
+            "window_end":   bundle.window_end,
+            "cycle_index":  kwargs.get("cycle_index", 0),
+            "dry_run":      kwargs.get("dry_run", True),
+            "bundle":       bundle.model_dump(),
+        },
+    )
+    return _extract_outcome(response)
+
+
+# ──────────────────────── Step executors ───────────────────────────────────────
+
+
+def _step_collect(step_input, run_context=None):
+    """Unpack the SessionBundle and stash cross-step context in session_state.
+
+    The bundle was already assembled by `run_cycle()` before the workflow
+    started; this step just hydrates it from `additional_data` and seeds
+    session_state. Every window is processed regardless of activity level.
+    """
+    from agno.workflow.types import StepOutput
+
+    data = step_input.additional_data or {}
+    bundle = SessionBundle.model_validate(data["bundle"])
+
+    if run_context is not None and run_context.session_state is not None:
+        run_context.session_state["task_key"] = bundle.task_key
+        run_context.session_state["earlier_today_summaries"] = list(
+            bundle.earlier_today_summaries
+        )
+
+    log.info(
+        "collect: task=%s sessions=%d real_s=%d heavy=%s",
+        bundle.task_key, len(bundle.sessions), bundle.real_seconds, bundle.is_heavy,
+    )
+    return StepOutput(content=bundle.model_dump_json())
+
+
+
+def _step_ground(step_input, run_context=None):
+    """Drop un-grounded bullets, compute coverage, attach risk flags."""
+    from agno.workflow.types import StepOutput
+
+    update = _extract_jira_update(step_input)
+    if update is None:
+        return StepOutput(
+            content=RouteOutcome(
+                state=UpdateState.FAILED,
+                reason="ground: no JiraUpdate produced upstream",
+            ).model_dump_json(),
+            stop=True,
+        )
+
+    bundle = SessionBundle.model_validate((step_input.additional_data or {})["bundle"])
+    grounded = build_grounded_narrative(update)
+    risk_flagger(grounded, bundle=bundle)
+    log.info(
+        "ground: coverage=%.2f dropped=%d task=%s",
+        grounded.coverage, len(grounded.dropped_bullets), update.task_key,
+    )
+    return StepOutput(content=grounded.model_dump_json())
+
+
+def _step_route(step_input, run_context=None):
+    """Final gate: persist the row, optionally post the Jira worklog.
+
+    Posting policy (phase 1 — worklog only):
+      * dry_run=True  → always DRAFTED, no Jira call
+      * dry_run=False AND bullets/ticket sane AND real_seconds >= 60
+          → call jira_poster.post_worklog, stamp the row POSTED
+      * any Jira failure → leave the row DRAFTED with a reason; the
+        next cycle will retry the same window because of the
+        uq_pm_updates_worklog_window index (only "posted" rows are
+        unique-constrained, so DRAFTED rows can be replaced).
+    """
+    from datetime import datetime as _dt
+
+    from agno.workflow.types import StepOutput
+
+    grounded = _extract_grounded(step_input)
+    if grounded is None:
+        return StepOutput(
+            content=RouteOutcome(state=UpdateState.FAILED, reason="route: no grounded").model_dump_json(),
+            stop=True,
+        )
+
+    extras = step_input.additional_data or {}
+    bundle = SessionBundle.model_validate(extras["bundle"])
+    update = grounded.update
+    dry_run = extras.get("dry_run", True)
+
+    # First-pass decision matrix (might still flip below after a real post).
+    state = _decide_state(update, grounded.coverage, bundle)
+    pm_update_id = db.upsert_pm_update(
+        update,
+        state=state,
+        coverage=grounded.coverage,
+        session_id_min=min((s.id for s in bundle.sessions), default=None),
+        session_id_max=max((s.id for s in bundle.sessions), default=None),
+    )
+    reason = _state_reason(state, update, grounded.coverage)
+    posted_worklog_id: Optional[str] = None
+
+    if dry_run:
+        log.info("route: dry_run=True — skipping Jira post")
+    else:
+        post_decision = _evaluate_post_eligibility(state, bundle, update)
+        if post_decision is None:
+            log.info("route: post eligible — attempting jira worklog")
+            try:
+                posted_worklog_id = _post_worklog(bundle, update)
+            except Exception as exc:                    # noqa: BLE001 — log + keep DRAFTED
+                log.exception("route: jira post failed; row remains %s", state.value)
+                reason = f"{reason}; jira post failed: {exc}"
+            else:
+                db.mark_worklog_posted(pm_update_id, posted_worklog_id)
+                state = UpdateState.POSTED
+                reason = f"worklog {posted_worklog_id} posted"
+        else:
+            log.info("route: post NOT eligible — %s", post_decision)
+            reason = f"{reason}; post skipped: {post_decision}"
+
+    outcome = RouteOutcome(
+        state=state,
+        pm_update_id=pm_update_id,
+        posted_comment_id=posted_worklog_id,            # piggyback on field for now
+        reason=reason,
+    )
+    log.info(
+        "route: state=%s pm_update_id=%d worklog_id=%s reason=%s",
+        state.value, pm_update_id, posted_worklog_id or "-", reason,
+    )
+    return StepOutput(content=outcome.model_dump_json())
+
+
+# ──────────────────────── Posting helpers ──────────────────────────────────────
+
+
+def _evaluate_post_eligibility(
+    state: UpdateState, bundle: SessionBundle, update: JiraUpdate,
+) -> Optional[str]:
+    """Return None if eligible to post; otherwise a one-line reason.
+
+    Ticket-closed is intentionally NOT a gate — we keep logging time
+    against tickets even after they're marked done upstream.
+    """
+    if state == UpdateState.SKIPPED:
+        return "row marked SKIPPED upstream"
+    if state == UpdateState.FAILED:
+        return "row marked FAILED upstream"
+    if bundle.real_seconds < 60:
+        return f"real_seconds={bundle.real_seconds} below Jira's 60s minimum"
+    return None
+
+
+def _post_worklog(bundle: SessionBundle, update: JiraUpdate) -> str:
+    """Post (or recover) a Jira worklog for this (task, window).
+
+    Idempotency: if `pm_updates` already has a row for the same
+    (task, window) with a worklog id, we short-circuit and return that
+    id without calling Jira again. This is what makes daemon restarts
+    and backfill safe.
+    """
+    from agents.pm_update import jira_poster
+
+    existing = db.find_existing_worklog(
+        task_key=bundle.task_key,
+        window_start=bundle.window_start,
+        window_end=bundle.window_end,
+    )
+    if existing is not None:
+        prior_id, worklog_id = existing
+        log.info(
+            "route: worklog already posted for %s [%s→%s] as %s (row %d) — skipping",
+            bundle.task_key, bundle.window_start, bundle.window_end, worklog_id, prior_id,
+        )
+        return worklog_id
+
+    started_utc = _parse_iso_utc(bundle.window_start)
+    comment = (update.summary or "").strip() or None
+    result = jira_poster.post_worklog(
+        task_key=bundle.task_key,
+        time_spent_seconds=bundle.real_seconds,
+        started_utc=started_utc,
+        comment=comment,
+    )
+    return result.worklog_id
+
+
+def _parse_iso_utc(iso: str):
+    """Parse our canonical 'YYYY-MM-DDTHH:MM:SSZ' back into an aware datetime."""
+    from datetime import datetime as _dt
+    return _dt.fromisoformat(iso.replace("Z", "+00:00"))
+
+
+# ──────────────────────── Helpers ──────────────────────────────────────────────
+
+
+def _render_workflow_input(bundle: SessionBundle) -> str:
+    """Compose the user-message blob fed to the Synthesise agent."""
+    lines: list[str] = []
+    lines.append(f"# TICKET: {bundle.task_key}")
+    if bundle.pm_task_title:
+        lines.append(f"title: {bundle.pm_task_title}")
+    if bundle.pm_task_status:
+        lines.append(f"status: {bundle.pm_task_status}")
+    if bundle.assignee_name:
+        lines.append(f"assignee: {bundle.assignee_name}")
+    lines.append("")
+    lines.append(f"# WINDOW: {bundle.window_start} → {bundle.window_end}")
+    lines.append(f"cycle_index: {bundle.cycle_index}")
+    lines.append(f"total_seconds: {bundle.total_seconds}")
+    lines.append(f"real_seconds: {bundle.real_seconds}")
+    lines.append("")
+    if bundle.earlier_today_summaries:
+        lines.append("# EARLIER TODAY")
+        for s in bundle.earlier_today_summaries:
+            lines.append(f"- {s}")
+        lines.append("")
+    lines.append(f"# SESSIONS ({len(bundle.sessions)})")
+    for s in bundle.sessions:
+        lines.append(f"## session {s.id} — {s.app_name} — {s.duration_s}s")
+        if s.top_titles:
+            lines.append(f"top_titles: {s.top_titles}")
+        if s.dimensions:
+            lines.append(f"dimensions: {s.dimensions}")
+        if s.excerpt:
+            lines.append(f"excerpt:\n{s.excerpt}\n")
+    return "\n".join(lines)
+
+
+def _extract_jira_update(step_input) -> JiraUpdate | None:
+    """Pull the JiraUpdate produced by the Synthesise step out of step_input."""
+    raw = step_input.get_step_content("synthesise") or step_input.previous_step_content
+    return _coerce_jira(raw)
+
+
+def _extract_grounded(step_input) -> GroundedNarrative | None:
+    raw = step_input.get_step_content("ground") or step_input.previous_step_content
+    if isinstance(raw, GroundedNarrative):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return GroundedNarrative.model_validate_json(raw)
+        except Exception:
+            return None
+    if isinstance(raw, dict):
+        try:
+            return GroundedNarrative.model_validate(raw)
+        except Exception:
+            return None
+    return None
+
+
+def _coerce_jira(raw) -> JiraUpdate | None:
+    if isinstance(raw, JiraUpdate):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return JiraUpdate.model_validate_json(raw)
+        except Exception:
+            return None
+    if isinstance(raw, dict):
+        try:
+            return JiraUpdate.model_validate(raw)
+        except Exception:
+            return None
+    return None
+
+
+def _extract_outcome(workflow_response) -> RouteOutcome:
+    """Pull the RouteOutcome from the workflow's final response."""
+    raw = getattr(workflow_response, "content", workflow_response)
+    if isinstance(raw, RouteOutcome):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return RouteOutcome.model_validate_json(raw)
+        except Exception:
+            pass
+    if isinstance(raw, dict):
+        try:
+            return RouteOutcome.model_validate(raw)
+        except Exception:
+            pass
+    return RouteOutcome(state=UpdateState.FAILED, reason="could not parse workflow output")
+
+
+def _decide_state(update: JiraUpdate, coverage: float, bundle: SessionBundle) -> UpdateState:
+    """Apply the routing matrix that picks the final UpdateState.
+
+    Ticket-closed is NOT a routing input — worklogs land regardless.
+    The flag is still surfaced on the row for the UI, just not acted on.
+    """
+    if not update.bullets:
+        return UpdateState.SKIPPED
+    if (coverage < config.PM_UPDATE_MIN_COVERAGE
+            or update.confidence < config.PM_UPDATE_MIN_CONFIDENCE):
+        return UpdateState.DRAFTED  # held for review; no review UI yet
+    # If we had a Jira poster wired up, this is where POSTED would happen.
+    # For now, mark DRAFTED — the row sits in the DB awaiting future stitch.
+    return UpdateState.DRAFTED
+
+
+def _state_reason(state: UpdateState, update: JiraUpdate, coverage: float) -> str:
+    if state == UpdateState.SKIPPED:
+        if not update.bullets:
+            return "no grounded bullets"
+        return "skipped"
+    if state == UpdateState.DRAFTED:
+        return (
+            f"drafted (coverage={coverage:.2f}, confidence={update.confidence:.2f}); "
+            "Jira posting not yet wired"
+        )
+    return state.value

--- a/services/agents/run_task_linker_mlx.py
+++ b/services/agents/run_task_linker_mlx.py
@@ -85,7 +85,7 @@ class SessionClassification(BaseModel):
         ),
     )
     reasoning: str = Field(
-        ..., max_length=500,
+        ..., max_length=300,
         description="1–4 sentences citing window titles, OCR text, or context clues.",
     )
     dimensions: dict[str, list[str]] = Field(
@@ -94,6 +94,30 @@ class SessionClassification(BaseModel):
             "Inferred activity tags. Keys: activity, intent, engagement, "
             "collaboration, tool, topic, practice. "
             "Values: lowercase snake_case lists. Omit keys with no evidence."
+        ),
+    )
+    session_summary: str = Field(
+        ..., min_length=100, max_length=1000,
+        description=(
+            "A factual prose summary of EVERYTHING the user did in this "
+            "session, written for downstream project-management updates. "
+            "Length is adaptive: aim for ~10 sentences for short trivial "
+            "sessions and up to ~40-80 sentences for content-rich sessions; "
+            "match depth to the evidence. Past tense, third person. "
+            "PRESERVE every SDLC-relevant signal: "
+            "(1) specific files, paths, modules touched; "
+            "(2) commands, scripts, queries run + their outcome; "
+            "(3) errors hit, stack traces, failing tests; "
+            "(4) technical decisions made and the alternative considered; "
+            "(5) tests written or run + pass/fail; "
+            "(6) commits, branches, PRs opened/merged; "
+            "(7) blockers and unanswered questions; "
+            "(8) external research / docs / Stack Overflow / Claude advice consulted; "
+            "(9) validations, manual QA, screenshots reviewed; "
+            "(10) design choices, schema changes, migrations. "
+            "DO NOT write marketing language, vague claims, or speculation "
+            "about future work. Cite the evidence you saw in the session_text — "
+            "this is the single source of truth the PM updater will compose from."
         ),
     )
 
@@ -210,14 +234,15 @@ def _error_result(
     session_id: int, reason: str, elapsed: float, method: str
 ) -> dict[str, Any]:
     return {
-        "session_id":   session_id,
-        "task_key":     None,
-        "confidence":   0.0,
-        "session_type": "overhead",
-        "reasoning":    reason,
-        "method":       method,
-        "dimensions":   {},
-        "elapsed_s":    elapsed,
+        "session_id":      session_id,
+        "task_key":        None,
+        "confidence":      0.0,
+        "session_type":    "overhead",
+        "reasoning":       reason,
+        "method":          method,
+        "dimensions":      {},
+        "session_summary": "",
+        "elapsed_s":       elapsed,
     }
 
 
@@ -405,14 +430,15 @@ def _classify_one(
         })
 
     return {
-        "session_id":   session_id,
-        "task_key":     task_key,
-        "confidence":   confidence,
-        "session_type": result.session_type,
-        "reasoning":    result.reasoning,
-        "method":       "mlx_direct",
-        "dimensions":   result.dimensions,
-        "elapsed_s":    elapsed,
+        "session_id":      session_id,
+        "task_key":        task_key,
+        "confidence":      confidence,
+        "session_type":    result.session_type,
+        "reasoning":       result.reasoning,
+        "method":          "mlx_direct",
+        "dimensions":      result.dimensions,
+        "session_summary": result.session_summary,
+        "elapsed_s":       elapsed,
     }
 
 

--- a/services/agents/server.py
+++ b/services/agents/server.py
@@ -302,6 +302,160 @@ async def classify_sessions(req: ClassifySessionsRequest) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# OpenAI-compatible chat completions
+# ---------------------------------------------------------------------------
+#
+# A minimal `/v1/chat/completions` endpoint that lets agno, the openai
+# python SDK, and anything else expecting OpenAI's wire format talk to
+# our already-loaded MLX model. Free-form generation only (no FSM /
+# structured-output decoding); callers that need JSON shape inject it
+# into the system prompt.
+#
+# Only available with --backend mlx. The hermes backend keeps using
+# /chat for its conversational path.
+
+
+class _OAIMessage(BaseModel):
+    role: str
+    content: str | list | None = None
+
+
+class _OAIChatRequest(BaseModel):
+    model: str | None = None
+    messages: list[_OAIMessage]
+    temperature: float | None = None
+    max_tokens: int | None = None
+    top_p: float | None = None
+    stop: list[str] | str | None = None
+    stream: bool = False
+    # Tolerate unknown fields agno / openai-python may add.
+    response_format: dict | None = None
+
+
+def _flatten_message_content(content: Any) -> str:
+    """OpenAI allows `content` to be a list of typed parts; we flatten to text."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        out: list[str] = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                out.append(part.get("text", ""))
+            elif isinstance(part, str):
+                out.append(part)
+        return "\n".join(out)
+    return str(content)
+
+
+@app.post("/v1/chat/completions")
+async def openai_chat_completions(req: _OAIChatRequest) -> dict:
+    """OpenAI ChatCompletions-shaped wrapper around the MLX model.
+
+    Streaming is rejected for now — agno's structured-output path uses
+    non-streaming for JSON mode, so this covers our use case.
+    """
+    import time as _time
+    import uuid as _uuid
+
+    from fastapi.concurrency import run_in_threadpool
+
+    if _app_state.get("backend") != "mlx":
+        raise HTTPException(
+            status_code=503,
+            detail="/v1/chat/completions is only available with --backend mlx",
+        )
+    if req.stream:
+        raise HTTPException(status_code=400, detail="streaming not supported")
+
+    m = _app_state.get("mlx_module")
+    if m is None:
+        raise HTTPException(status_code=503, detail="MLX model is still loading")
+
+    from mlx_lm.sample_utils import make_sampler
+    from outlines.inputs import Chat
+
+    # Normalise messages — OpenAI tolerates list-of-parts; outlines wants strings.
+    msgs = [
+        {"role": msg.role, "content": _flatten_message_content(msg.content)}
+        for msg in req.messages
+    ]
+
+    temperature = req.temperature if req.temperature is not None else 0.3
+    max_tokens  = req.max_tokens if req.max_tokens else 2048
+
+    def _generate() -> str:
+        model = m._get_model()
+        return model(
+            Chat(msgs),
+            max_tokens=max_tokens,
+            sampler=make_sampler(temp=temperature),
+            verbose=False,
+        )
+
+    t0 = _time.time()
+    try:
+        text = await run_in_threadpool(_generate)
+    except Exception as exc:                            # noqa: BLE001
+        log.warning("openai_chat_completions: inference error: %s", exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    elapsed = _time.time() - t0
+
+    completion_id = f"chatcmpl-{_uuid.uuid4().hex[:24]}"
+    # Token counts are approximations — outlines doesn't expose exact
+    # counts without re-tokenising; 4 bytes/token is the OpenAI convention.
+    prompt_chars = sum(len(msg["content"]) for msg in msgs)
+    prompt_tokens = max(1, prompt_chars // 4)
+    completion_tokens = max(1, len(text) // 4)
+
+    log.info(
+        "openai_chat_completions: msgs=%d max_tokens=%d temp=%.2f elapsed=%.2fs out_chars=%d",
+        len(msgs), max_tokens, temperature, elapsed, len(text),
+    )
+
+    return {
+        "id":      completion_id,
+        "object":  "chat.completion",
+        "created": int(_time.time()),
+        "model":   req.model or "qwen3.5-9b-instruct",
+        "choices": [
+            {
+                "index":         0,
+                "message":       {"role": "assistant", "content": text},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens":     prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens":      prompt_tokens + completion_tokens,
+        },
+    }
+
+
+@app.get("/v1/models")
+async def openai_models_list() -> dict:
+    """OpenAI-style models listing — agno/openai-python probe this on first use."""
+    model_id = "qwen3.5-9b-instruct"
+    if _app_state.get("backend") == "mlx":
+        m = _app_state.get("mlx_module")
+        if m is not None and hasattr(m, "_MLX_MODEL_ID"):
+            model_id = m._MLX_MODEL_ID
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id":       model_id,
+                "object":   "model",
+                "created":  0,
+                "owned_by": "meridian-local",
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -36,6 +36,16 @@ mlx = [
     "uvicorn>=0.30,<1",
 ]
 
+# Agno-based PM update workflow — install with: pip install -e ".[pm_update]"
+# Pulls in agno (Workflow/Agent/LearningMachine). No RAG: the synth has the
+# session bundle + tools, no vector DB.
+pm_update = [
+    "agno>=2.1,<3",
+    "pydantic>=2.10,<3",
+    "sqlalchemy>=2.0,<3",
+    "aiosqlite>=0.20,<1",
+]
+
 [project.scripts]
 meridian-server = "agents.server:main"
 

--- a/services/scripts/count_classifier_tokens.py
+++ b/services/scripts/count_classifier_tokens.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Count input + output tokens for each session in a classifier JSONL log.
+
+Reads `services/logs/mlx/server_*.jsonl` produced by the FastAPI MLX
+server's `/classify_sessions` endpoint and prints a per-session token
+table using the same tokenizer the classifier itself loads.
+
+Usage:
+    cd services
+    .venv313/bin/python scripts/count_classifier_tokens.py
+    .venv313/bin/python scripts/count_classifier_tokens.py logs/mlx/server_20260528T175639.jsonl
+    .venv313/bin/python scripts/count_classifier_tokens.py --top 20
+
+Designed to be read-only — no daemon restart, no behavioural change.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+LOG_DIR = Path(__file__).resolve().parent.parent / "logs" / "mlx"
+DEFAULT_MODEL_ID = "mlx-community/Qwen3.5-9B-OptiQ-4bit"
+
+
+def _latest_log() -> Path:
+    files = sorted(LOG_DIR.glob("server_*.jsonl"))
+    if not files:
+        sys.exit(f"no log files found under {LOG_DIR}")
+    return files[-1]
+
+
+def _read_records(path: Path) -> list[dict]:
+    """Parse JSONL, drop blank / malformed lines, drop pre-result records."""
+    out: list[dict] = []
+    for line_no, line in enumerate(path.read_text().splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError as exc:
+            print(f"  skip line {line_no}: {exc}", file=sys.stderr)
+            continue
+        if "result" in rec and rec["result"].get("session_id"):
+            out.append(rec)
+    return out
+
+
+def _format_messages(rec: dict) -> list[dict]:
+    """Reconstruct the exact messages outlines saw at inference time."""
+    return [
+        {"role": "system", "content": rec.get("system_prompt", "") or ""},
+        {"role": "user",   "content": rec.get("user_message", "") or ""},
+    ]
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="count_classifier_tokens")
+    parser.add_argument(
+        "path", nargs="?", default=None,
+        help="JSONL log path. Defaults to the most recent under services/logs/mlx/",
+    )
+    parser.add_argument(
+        "--model-id", default=DEFAULT_MODEL_ID,
+        help="HuggingFace model id (must match the classifier's _MLX_MODEL_ID)",
+    )
+    parser.add_argument(
+        "--top", type=int, default=0,
+        help="Show only the top-N slowest sessions (by elapsed_s). 0 = all.",
+    )
+    parser.add_argument(
+        "--csv", action="store_true",
+        help="Emit machine-readable CSV instead of the human table",
+    )
+    args = parser.parse_args(argv[1:])
+
+    log_path = Path(args.path) if args.path else _latest_log()
+    if not log_path.exists():
+        sys.exit(f"log file {log_path} does not exist")
+
+    records = _read_records(log_path)
+    if not records:
+        sys.exit(f"no usable records in {log_path}")
+
+    print(f"reading {log_path}  ({len(records)} records)", file=sys.stderr)
+    print(f"loading tokenizer for {args.model_id}…", file=sys.stderr)
+    import mlx_lm                       # local import — heavy dep
+    _, tok = mlx_lm.load(args.model_id)
+
+    rows: list[dict] = []
+    for rec in records:
+        result = rec["result"] or {}
+        messages = _format_messages(rec)
+        prompt = tok.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+        in_tok = len(tok.encode(prompt))
+
+        result_json = json.dumps(result, ensure_ascii=False)
+        out_tok = len(tok.encode(result_json))
+
+        rows.append({
+            "session_id":  result["session_id"],
+            "task_key":    result.get("task_key") or "-",
+            "in_tok":      in_tok,
+            "out_tok":     out_tok,
+            "elapsed_s":   float(result.get("elapsed_s", 0.0)),
+            "tok_per_sec": out_tok / float(result.get("elapsed_s", 1.0) or 1.0),
+        })
+
+    if args.top:
+        rows.sort(key=lambda r: r["elapsed_s"], reverse=True)
+        rows = rows[: args.top]
+
+    if args.csv:
+        writer_cols = ["session_id", "task_key", "in_tok", "out_tok",
+                       "elapsed_s", "tok_per_sec"]
+        sys.stdout.write(",".join(writer_cols) + "\n")
+        for r in rows:
+            sys.stdout.write(",".join(str(r[c]) for c in writer_cols) + "\n")
+        return 0
+
+    # Human-readable table
+    hdr = (
+        f"{'session_id':>11} {'task_key':>9} {'in_tok':>7} "
+        f"{'out_tok':>7} {'elapsed_s':>10} {'tok/s':>7}"
+    )
+    print()
+    print(hdr)
+    print("-" * len(hdr))
+    for r in rows:
+        print(
+            f"{r['session_id']:>11} "
+            f"{r['task_key']:>9} "
+            f"{r['in_tok']:>7} "
+            f"{r['out_tok']:>7} "
+            f"{r['elapsed_s']:>10.2f} "
+            f"{r['tok_per_sec']:>7.1f}"
+        )
+
+    # Aggregate row
+    if rows:
+        n = len(rows)
+        avg_in = sum(r["in_tok"] for r in rows) / n
+        avg_out = sum(r["out_tok"] for r in rows) / n
+        avg_elapsed = sum(r["elapsed_s"] for r in rows) / n
+        total_out = sum(r["out_tok"] for r in rows)
+        total_elapsed = sum(r["elapsed_s"] for r in rows)
+        avg_tok_per_sec = total_out / total_elapsed if total_elapsed else 0
+        print("-" * len(hdr))
+        print(
+            f"{'avg':>11} {'(' + str(n) + ')':>9} "
+            f"{avg_in:>7.0f} {avg_out:>7.0f} "
+            f"{avg_elapsed:>10.2f} {avg_tok_per_sec:>7.1f}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/services/skills/activity/pm-update-synth/SKILL.md
+++ b/services/skills/activity/pm-update-synth/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: pm-update-synth
+description: Synthesise a professional Jira update from one window of classified work sessions. Output a strict JiraUpdate JSON with evidence_refs grounded in the session bundle.
+license: MIT
+metadata:
+  version: "1.0.0"
+  meridian:
+    role: synth
+    tags: [pm-update, jira, sdlc]
+---
+
+# PM Update Synthesiser
+
+You are Meridian's PM update writer. Your job is to read the user's
+captured work for one Jira ticket over the last hour, and produce the
+kind of professional progress update a senior engineer would post.
+
+You are **replacing the developer's manual Jira update**. The bar is
+"would a tech lead reading this know what happened, what's left, and
+whether the ticket needs help?"
+
+## Inputs
+
+The user message contains:
+
+- **TICKET** — title, status, epic, sprint, current assignee
+- **SESSION BUNDLE** — every classified session in this window. **Each
+  session arrives with a pre-computed `excerpt` that is a factual
+  10-40 sentence summary written by the upstream classifier.** This
+  summary is your primary signal — it already names files touched,
+  commands run, errors hit, decisions made, tests, blockers, etc. You
+  should rarely need raw OCR. Each session also carries:
+  - `id`, `app_name`, `duration_s`, `idle_frame_s`
+  - top window titles
+  - activity / intent / tool dimension tags
+- **EARLIER TODAY** — headlines of comments already posted today on this
+  ticket. **Do not repeat what they already say** — focus on what's new.
+- **RECENT FEEDBACK** — recent admin edits/rejections (if any) showing
+  how the user prefers updates to be worded. Treat `edited` versions as
+  positive examples to match. Treat `reject` items as negative examples
+  to avoid.
+
+A small fraction of sessions (pre-migration-024 legacy rows) may arrive
+with a raw OCR excerpt instead of a summary — you can tell because the
+text looks like screen contents rather than a coherent narrative. For
+those, call `get_session_evidence(session_id)` to pull more raw text if
+needed.
+
+## Hard rules
+
+1. **Every claim must cite evidence.** A bullet without `evidence_refs`
+   (session_id list) will be silently dropped by the validator. Only put
+   things in `what_shipped` / `in_progress` / `blockers` / `decisions`
+   that you can back with at least one session_id from the bundle.
+2. **`next_steps` may be empty** — only fill it when the bundle shows
+   real next-action signal (a TODO comment, an unfinished test, an
+   error visible in terminal). Do not speculate.
+3. **No invented facts.** Stay inside what the session summaries say. The
+   summaries are factual and reliable; trust them. Only call
+   `get_session_evidence` when you need to disambiguate or verify a
+   specific detail before posting it.
+4. **Do not propose Jira status changes.** This workflow only writes
+   comments. Leaving the ticket in its current status is always the
+   right answer.
+5. **Stay focused on this ticket.** If the bundle contains incidental
+   cross-ticket activity, ignore it. Cross-ticket leakage is the most
+   common failure mode.
+6. **Match the user's voice.** If `RECENT FEEDBACK` shows the user
+   prefers terse, lowercased bullets — match that. Do not adopt a
+   marketing tone.
+
+## Process (think before you write)
+
+Use the `think()` tool to work through these in order, then produce the
+final JSON.
+
+### Step 1 — Read the bundle
+
+Each session's `excerpt` is a factual prose summary from the classifier.
+Read them in order. Build a mental timeline:
+- Group consecutive sessions by what they were *about* (often a single
+  narrative arc spans 3-10 sessions across Code + Terminal flips)
+- Note the dominant intent (`implementation`, `debugging`, `research`,
+  `verification`) from dimensions
+- Identify any "arc" — a sequence that ends in commit/test/PR mentioned
+  in one of the summaries
+
+### Step 2 — Identify what shipped
+
+A "shipped" item must be one the session summary explicitly states as
+complete:
+- A commit landed (summary says "committed X" or shows a git output)
+- A test passed (summary says "ran tests, all passed")
+- A file was finished (summary describes a closed edit)
+- A PR was opened or merged (summary says so)
+
+Do NOT mark something as "shipped" just because the user touched a file.
+That goes in `in_progress`.
+
+### Step 3 — Identify in-progress threads
+
+Anything actively being edited but not yet completed. One bullet per
+distinct thread. If the user is mid-debug in three different files,
+that's three bullets, not one vague "investigating issues".
+
+### Step 4 — Surface blockers and decisions
+
+- **Blockers**: explicit "stuck" signals — error messages, failing
+  tests they couldn't get past, missing dependencies, unanswered
+  questions in Slack.
+- **Decisions**: design or technical choices made — picked one library
+  over another, chose a schema shape, decided to defer a refactor.
+
+### Step 5 — Time accounting
+
+`time_spent_seconds` = sum of `duration_s` minus idle. The bundle
+already pre-computes a `real_seconds` value — use that. Never invent
+time beyond the window length.
+
+### Step 6 — Confidence calibration
+
+- 0.85+ : every bullet has clear evidence and the narrative arc is
+  unambiguous
+- 0.65-0.85 : narrative is solid but some inference; safe to auto-post
+- 0.40-0.65 : enough doubt that a human should look at this
+- < 0.40 : just don't post; let it fall through to skip
+
+### Step 7 — Self-check before emitting
+
+- [ ] No bullet is missing evidence_refs
+- [ ] No transition_proposal without git signal
+- [ ] summary ≤ 80 chars and is actually a summary, not a placeholder
+- [ ] Nothing repeats what `EARLIER TODAY` already said
+- [ ] If `RECENT FEEDBACK` shows a stylistic preference, you matched it
+
+## Output format
+
+Reply with ONE valid `JiraUpdate` object — no preamble, no markdown
+fences, no follow-up text. The schema enforces this; deviation will
+cause a parser failure.
+
+## Examples (style only — do not copy verbatim)
+
+### Good summary lines
+- `KAN-64 — finished migration 022, blocked on FK cleanup`
+- `KAN-109 — drafted ax-sidecar app detection patch`
+
+### Bad summary lines (don't do this)
+- `Made progress on KAN-64` (vague)
+- `Worked on stuff` (no signal)
+- `KAN-64 update for cycle 3 of the day` (meta-noise)
+
+### Good shipped bullet
+- `Merged PR #38 fixing FK constraint in pm_task_embeddings (evidence_refs: [10231, 10235])`
+
+### Bad shipped bullet
+- `Did some database work` (no evidence, no specificity, no refs)

--- a/services/skills/activity/pm-update-synth/references/jira-comment-style.md
+++ b/services/skills/activity/pm-update-synth/references/jira-comment-style.md
@@ -1,0 +1,63 @@
+# Jira Comment Style Reference
+
+Tone and structure conventions for Meridian-generated PM updates.
+Loaded on-demand by the agent via `get_skill_reference`.
+
+## Voice
+
+- **Engineer-to-engineer**, not status-report-to-manager
+- Past tense for shipped, present continuous for in-progress
+- Lower-case bullets unless the first word is a proper noun
+- One sentence per bullet, max ~25 words
+
+## Bullet shape
+
+```
+<verb in past/present> <specific object> <evidence ref in parens>
+```
+
+Examples that match the house style:
+
+- `wired the OS process-tree detection for ax-sidecar host app (s10212)`
+- `debugging FK cleanup in migration 022 — sqlite refuses DROP+RECREATE in same tx`
+- `picked process-tree over osascript for host detection: works when window not focused`
+
+Anti-patterns:
+
+- `I worked on…` (avoid first-person)
+- `Successfully implemented…` (no marketing verbs)
+- `Made some changes` (no specificity)
+- `Need to do more work` (no signal)
+
+## Section ordering
+
+The schema enforces this order. Don't try to reorder by importance —
+consistency is more useful than dramatic structure for a daily log.
+
+1. summary (1 line)
+2. what_shipped
+3. in_progress
+4. blockers (omit section if empty)
+5. decisions (omit section if empty)
+6. next_steps (≤ 5 items, omit if empty)
+
+## Evidence ref format
+
+Each bullet's `evidence_refs` is a list of `session_id` integers from
+the bundle. The renderer turns them into a small parenthetical:
+`(s10212)` for one ref, `(s10212, s10231)` for many, `(s10212+3)` when
+more than three.
+
+## When to mention tools / files
+
+Yes — when the bundle's `top_titles` clearly identifies the file. Eg.
+`edited ax_sidecar.py to add process-tree detection (s10212)`.
+
+No — when only the app name is known. Don't write `worked in VS Code`;
+that's noise.
+
+## When to mention time
+
+The footer auto-includes `~N min`. Don't repeat time spent inside the
+bullets unless it's narratively important (`spent 40 min on one
+flaky test before finding the race condition`).

--- a/services/skills/activity/task-classifier/SKILL.md
+++ b/services/skills/activity/task-classifier/SKILL.md
@@ -87,7 +87,8 @@ Reply with ONE valid JSON object — no preamble, no markdown fences, no follow-
   "confidence": 0.85,
   "session_type": "task",
   "reasoning": "Editing run_watcher.py with KAN-86 ticket open in adjacent tab; matches the migration task described.",
-  "dimensions": {"activity": ["coding"], "intent": ["implementation"], "tool": ["vscode"]}
+  "dimensions": {"activity": ["coding"], "intent": ["implementation"], "tool": ["vscode"]},
+  "session_summary": "Opened run_watcher.py in VS Code and rewrote the inotify polling loop to use the new ETLConfig path; introduced a 250 ms debounce window and removed the obsolete `_last_tick` global. Ran `cargo check` twice — second attempt clean. Reviewed migration 023 in DBeaver to confirm the pm_sync_state schema matches what the watcher expects. Briefly read the openobserve docs tab for OTLP retry semantics before deciding to defer the retry change to a follow-up. No tests written this session — they are queued behind the watcher refactor."
 }
 ```
 
@@ -97,6 +98,72 @@ Reply with ONE valid JSON object — no preamble, no markdown fences, no follow-
 - `session_type` — `"task"` links to Jira; `"overhead"` is thrown away; `"untracked"` is kept for workload analysis.
 - `reasoning` — must cite specific window titles, OCR snippets, or context clues.
 - `dimensions` — omit keys with no evidence; return `{}` if no clear signals.
+- `session_summary` — see the dedicated section below. This is the SINGLE most important field for downstream PM updates.
+
+## session_summary — THE PM-update payload
+
+This field is what the PM-update workflow consumes to write Jira worklog comments. It REPLACES the raw OCR text downstream — the PM agent will not see the original session_text unless it explicitly asks. So **every SDLC-relevant detail you observe must be captured here, written so a tech-lead reading it understands exactly what happened.**
+
+### Length
+
+**Adaptive to the content.** Match depth to evidence:
+
+| Session shape | Target length |
+|---|---|
+| 12-second session, one terminal command, screen mostly static | ~5-10 sentences, factual |
+| 1-3 minute session, single file edited, no errors | ~10-20 sentences |
+| Content-rich session: multiple files, tests, errors, decisions, research | ~25-80 sentences |
+| Long session (5+ min) with a clear narrative arc — debug → fix → verify | up to ~80 sentences |
+
+Do not pad. If a session was genuinely uninteresting, write the truth in a few sentences. If a session was rich, give the full picture.
+
+### Voice
+
+- Past tense, third person ("edited", "ran", "reviewed", "decided") — never "I" or "you"
+- Concrete, file-name-specific — `"edited services/agents/run_task_linker_mlx.py"`, not `"worked on the classifier"`
+- Cite exact commands, error messages, function names when visible
+- No marketing language ("successfully implemented", "made great progress")
+- No speculation about future work ("will need to…", "next step is…")
+
+### What MUST be in the summary (SDLC checklist)
+
+Capture every category the session shows evidence of:
+
+1. **Files / paths / modules touched** — full paths or recognisable basenames
+2. **Commands / scripts / queries run** — and their outcome (success, error message, exit code)
+3. **Errors hit** — exception names, stack-trace snippets, failing assertions
+4. **Tests** — written, run, passed, failed; specific test names
+5. **Technical decisions** — choice made, alternative considered, reason ("picked process-tree over osascript because…")
+6. **Schema / DB changes** — migrations applied, columns added, queries run in DBeaver
+7. **Commits / branches / PRs** — visible in terminal output or VS Code source control panel
+8. **Blockers / open questions** — explicit "stuck on…", unanswered prompts, missing deps
+9. **External research** — docs read, Stack Overflow visited, Claude/ChatGPT consulted (and which question)
+10. **Validations** — manual smoke tests, UI inspections, screenshot reviews, log tailing
+11. **Design discussions** — architecture sketches, ADR notes, conversations with Claude/Codex about approach
+12. **Time-on-subtask hints** — when the session has clearly distinct phases ("first 2 min reading docs, then 6 min editing")
+
+### What NEVER goes in the summary
+
+- "Worked on KAN-XXX" (vague — say what *specifically*)
+- "Successfully implemented X" (drop "successfully"; just say what was done)
+- "Will continue tomorrow" (no speculation)
+- "User seems frustrated" (no interpretation of mood)
+- "This is important because…" (no editorialising)
+- Repeated content from `reasoning` — `reasoning` is for *why* the session matches the ticket; `session_summary` is for *what happened*
+
+### Examples
+
+**Good — short trivial session (~6 sentences):**
+> Ran `git status` and `git diff` in the meridian repo terminal to review pending edits. Output showed three modified files in `services/agents/pm_update/`. No commands executed beyond the status review. No errors. No tests. The session ended when focus shifted to the VS Code window.
+
+**Good — content-rich session (~30-80 sentences):**
+> Edited `services/agents/pm_update/workflow.py` to remove the chunked-summariser heavy-path; deleted the `_is_heavy_bundle` evaluator, the `Parallel(*chunk_summarisers)` block, and the `merge_chunks` step. Workflow now linear: collect → synthesise → ground → route. Then removed `build_chunk_agent` and `build_merger_agent` from `agents.py` along with their `_CHUNK_NAME` / `_MERGER_NAME` constants. Cleaned up `config.py` — dropped `PM_UPDATE_CHUNK_MAX_TOKENS`, `PM_UPDATE_MERGE_MAX_TOKENS`, `PM_UPDATE_CHUNK_PARALLELISM`, `PM_UPDATE_KNOWLEDGE_DIR`. Decision: removed the heavy path entirely instead of just disabling parallelism, because the 9B model's 262K context fits all bundles comfortably. Ran `python -c "from agents.pm_update.workflow import build_workflow; print([s.name for s in build_workflow().steps])"` to verify; output was `['collect','synthesise','ground','route']`. No new tests written. Confirmed via `rm -rf __pycache__` then re-import that no stale references remain. Briefly considered keeping the chunk/merger factories dormant for future use but chose to delete since the 9B context window makes them strictly unnecessary.
+
+**Bad — too vague:**
+> Made changes to the workflow file. Removed some unused code. Cleaned things up. Ran the workflow and it worked.
+
+**Bad — speculative + marketing:**
+> Successfully refactored the workflow to be more efficient. The new linear design will be much faster. Next steps include adding the worklog poster and testing end-to-end on Jira.
 
 ## Using Context from Previous Sessions
 

--- a/src/intelligence/task_linker/db.rs
+++ b/src/intelligence/task_linker/db.rs
@@ -302,6 +302,7 @@ mod tests {
             reasoning: "test".to_string(),
             method: "hermes_aiagent".to_string(),
             dimensions: HashMap::new(),
+            session_summary: String::new(),
             elapsed_s: 0.5,
         };
         update_session_task(&pool, &r).await.unwrap();
@@ -333,6 +334,7 @@ mod tests {
             reasoning: "test".to_string(),
             method: "hermes_aiagent".to_string(),
             dimensions: HashMap::new(),
+            session_summary: String::new(),
             elapsed_s: 0.2,
         };
         update_session_task(&pool, &r).await.unwrap();
@@ -360,6 +362,7 @@ mod tests {
             reasoning: "test".to_string(),
             method: "hermes_aiagent".to_string(),
             dimensions: HashMap::new(),
+            session_summary: String::new(),
             elapsed_s: 0.1,
         };
         update_session_task(&pool, &r).await.unwrap();

--- a/src/intelligence/task_linker/db_write.rs
+++ b/src/intelligence/task_linker/db_write.rs
@@ -53,10 +53,19 @@ pub(super) async fn update_session_task(
     } else {
         Some(&r.reasoning)
     };
+    // The classifier's per-session prose summary feeds the PM-update
+    // workflow downstream. Empty string → NULL so the PM layer's
+    // COALESCE fallback to session_text still works on edge cases.
+    let summary = if r.session_summary.is_empty() {
+        None
+    } else {
+        Some(&r.session_summary)
+    };
     sqlx::query(
         "UPDATE app_sessions
          SET task_key = ?, task_confidence = ?, task_routing = ?,
-             task_method = ?, task_reasoning = ?, task_session_type = ?
+             task_method = ?, task_reasoning = ?, task_session_type = ?,
+             session_summary = ?
          WHERE id = ?",
     )
     .bind(&r.task_key)
@@ -65,6 +74,7 @@ pub(super) async fn update_session_task(
     .bind(&r.method)
     .bind(reasoning)
     .bind(&r.session_type)
+    .bind(summary)
     .bind(r.session_id)
     .execute(pool)
     .await

--- a/src/intelligence/task_linker/mod.rs
+++ b/src/intelligence/task_linker/mod.rs
@@ -77,15 +77,29 @@ pub fn check_classification_ready(cfg: &Config) -> Result<()> {
     let addr: std::net::SocketAddr = format!("127.0.0.1:{port}")
         .parse()
         .context("invalid MLX server address")?;
-    std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_secs(5)).with_context(
-        || {
-            format!(
-                "MLX server not running on port {port}\n\
-                 Fix: cd services && .venv313/bin/meridian-server --backend mlx --port {port}"
-            )
-        },
-    )?;
-    Ok(())
+
+    // The MLX server loads a large model in its lifespan startup before it
+    // accepts connections. Retry for up to 120 s to cover first-load time.
+    let timeout = std::time::Duration::from_secs(2);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(120);
+    loop {
+        match std::net::TcpStream::connect_timeout(&addr, timeout) {
+            Ok(_) => return Ok(()),
+            Err(_) if std::time::Instant::now() < deadline => {
+                warn!(
+                    port,
+                    "MLX server not yet ready — waiting for model to load (up to 120 s total)"
+                );
+                std::thread::sleep(std::time::Duration::from_secs(5));
+            }
+            Err(_) => {
+                anyhow::bail!(
+                    "MLX server not running on port {port}\n\
+                     Fix: cd services && .venv313/bin/meridian-server --backend mlx --port {port}"
+                );
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -131,6 +145,11 @@ pub(super) struct SessionClassification {
     pub(super) method: String,
     #[serde(default)]
     pub(super) dimensions: HashMap<String, Vec<String>>,
+    /// Factual prose summary of the session (10-40 sentences, adaptive to
+    /// content). Persisted to `app_sessions.session_summary` and consumed
+    /// by the PM-update workflow as its primary signal.
+    #[serde(default)]
+    pub(super) session_summary: String,
     #[allow(dead_code)]
     pub(super) elapsed_s: f64,
 }

--- a/src/migrations/022_drop_status_keep_category.sql
+++ b/src/migrations/022_drop_status_keep_category.sql
@@ -4,7 +4,6 @@
 -- status_category values: 'todo', 'in_progress', 'done'
 -- Note: SQLite doesn't support DROP COLUMN IF EXISTS, so we use a workaround.
 -- Create a new table without the status column, copy data, and swap names.
--- pm_task_embeddings has a FK to pm_tasks so it must be dropped and recreated.
 
 CREATE TABLE pm_tasks_new (
     id               INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -31,30 +30,8 @@ SELECT id, task_key, provider, title, description_text, status_category,
        parent_key, epic_title, sprint_name, assignee_name
 FROM pm_tasks;
 
--- Preserve embeddings before dropping the parent table.
-CREATE TABLE pm_task_embeddings_save AS SELECT * FROM pm_task_embeddings;
-DROP TABLE pm_task_embeddings;
-
 DROP TABLE pm_tasks;
 ALTER TABLE pm_tasks_new RENAME TO pm_tasks;
 
 CREATE INDEX IF NOT EXISTS idx_pm_tasks_provider   ON pm_tasks (provider);
 CREATE INDEX IF NOT EXISTS idx_pm_tasks_expires_at ON pm_tasks (expires_at);
-
--- Recreate pm_task_embeddings with FK pointing at the renamed table.
-CREATE TABLE pm_task_embeddings (
-    task_key       TEXT    NOT NULL REFERENCES pm_tasks(task_key),
-    model          TEXT    NOT NULL,
-    dim            INTEGER NOT NULL,
-    embedding      BLOB    NOT NULL,
-    text_hash      TEXT    NOT NULL,
-    pm_updated_at  TEXT    NOT NULL,
-    expected_dims  TEXT,
-    created_at     TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-    PRIMARY KEY (task_key, model)
-);
-
-CREATE INDEX IF NOT EXISTS idx_pm_task_embeddings_model ON pm_task_embeddings (model);
-
-INSERT INTO pm_task_embeddings SELECT * FROM pm_task_embeddings_save;
-DROP TABLE pm_task_embeddings_save;

--- a/src/migrations/024_session_summary.sql
+++ b/src/migrations/024_session_summary.sql
@@ -1,0 +1,13 @@
+-- meridian — normalises screenpipe activity into structured app sessions
+--
+-- Add a `session_summary` column to `app_sessions` so the classifier can
+-- emit a 10-40 sentence factual summary of the user's activity in the
+-- session. The PM-update workflow reads this column instead of the raw
+-- 2KB session_text excerpt — it's pre-digested, much smaller, and
+-- preserves SDLC-relevant signal (files touched, commands run, errors
+-- hit, decisions, tests, blockers, validations, commits, research).
+--
+-- Nullable: old rows stay NULL until re-classified. The PM-update layer
+-- falls back to session_text excerpts for rows where this is NULL.
+
+ALTER TABLE app_sessions ADD COLUMN session_summary TEXT;


### PR DESCRIPTION
## Summary
- add the new agno-based PM update workflow package and CLI
- persist classifier-written session summaries for downstream PM updates
- add OpenAI-compatible local MLX chat completions and supporting classifier updates
- add supporting migrations and tooling for session-summary storage

## Validation
- python3 -m compileall services/agents/pm_update services/agents/server.py services/agents/run_task_linker_mlx.py services/scripts/count_classifier_tokens.py
- repo pre-commit hook passed during commit
- repo pre-push checks passed: cargo fmt --check, cargo clippy, cargo test, ui build, ui tests