### PR TITLE
fix(scripts): chain coding-agent-indexer daemon and Claude hook into install scripts

### DIFF
--- a/services/scripts/install-coding-agent-indexer.sh
+++ b/services/scripts/install-coding-agent-indexer.sh
@@ -78,3 +78,7 @@ echo "    \"SELECT id, started_at, duration_s, frame_count, claude_session_uuid 
 echo "       FROM app_sessions WHERE claude_session_uuid IS NOT NULL \\"
 echo "       ORDER BY id DESC LIMIT 5;\""
 echo "  ${SCRIPT_DIR}/uninstall-coding-agent-indexer.sh             # remove"
+
+echo
+echo "→ installing Claude Code SessionEnd hook …"
+bash "${SCRIPT_DIR}/install-claude-hook.sh"

--- a/services/scripts/install-mlx-server-daemon.sh
+++ b/services/scripts/install-mlx-server-daemon.sh
@@ -114,3 +114,7 @@ echo "  ${SCRIPT_DIR}/uninstall-mlx-server-daemon.sh          # remove"
 echo
 echo "Set CLASSIFIER_BACKEND=mlx and MLX_SERVER_PORT=${MLX_SERVER_PORT} in your .env"
 echo "then restart the Rust daemon."
+
+echo
+echo "→ installing coding-agent-indexer daemon + Claude Code hook …"
+bash "${SCRIPT_DIR}/install-coding-agent-indexer.sh"


### PR DESCRIPTION
## Summary

- `install-mlx-server-daemon.sh` now calls `install-coding-agent-indexer.sh` at the end
- `install-coding-agent-indexer.sh` now calls `install-claude-hook.sh` at the end
- Running either install script brings up the full session-capture stack (MLX server → daemon → Claude hook)

## Test plan

- [ ] Run `./services/scripts/install-mlx-server-daemon.sh` and confirm all three services install and start (MLX server, coding-agent-indexer daemon, Claude Code SessionEnd hook)
- [ ] Run `./services/scripts/install-coding-agent-indexer.sh` standalone and confirm the daemon + hook install without installing the MLX server
- [ ] Verify hook entry appears in `~/.claude/settings.json` under `SessionEnd`
- [ ] Verify `launchctl print gui/$(id -u)/com.meridiona.coding-agent-indexer` shows the daemon running

🤖 Generated with [Claude Code](https://claude.com/claude-code)