### PR TITLE
feat(coding-agent): port indexer + summariser into the Rust daemon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,13 +267,22 @@ The dataset's value lives in **what it discriminates**, not how many cases it ha
 
 ---
 
+## Coding-agent pipeline (`src/coding_agent/`)
+
+The coding-agent indexer + summariser now run **inside the Rust daemon** (`src/coding_agent/`), spawned as gated tokio tasks from `main.rs`. They turn Claude Code / Codex JSONLs into segmented `app_sessions` rows, summarise sealed segments (Claude for Claude sessions, Codex for Codex; MLX as fallback), and hand them to the classifier on their summary. Lifecycle is the `task_method` column: `coding_agent_live → pending_summariser → pending_classifier → mlx_direct`.
+
+- **Indexer** (`indexer.rs`): polls `~/.claude/projects` + `~/.codex/sessions`, parses (`jsonl.rs`) + segments (`segment.rs`, 1h time-box split at a user-prompt boundary), upserts/seals (`db.rs`). Backfill is today-only on startup. `meridian coding-agent-hook` is the SessionEnd entry (seals one session).
+- **Summariser** (`summariser/`): `claude.rs`/`codex.rs` subprocesses (2 attempts) → `mlx.rs` fallback (`/summarise`); writes `session_summary` + `summary_source` and flips `task_method` to `pending_classifier`. CLI: `meridian coding-agent-summarise`.
+- **Classify trigger** (`src/intelligence/task_linker/`): a non-cursor branch classifies `pending_classifier` rows on the **summary** (not the transcript), preserving the summariser's summary. CLI: `meridian coding-agent-classify`.
+
+The Python `services/coding_agent_indexer/` + `coding_agent_summariser/` are the **reference / parity** implementations (parsers kept byte-for-byte in sync, enforced by tests); their daemons are retired. Change both parsers together.
+
 ## Python agent service (`services/`)
 
-Three Python services run alongside the Rust daemon:
+These Python services still run alongside the Rust daemon:
 
-1. **`coding_agent_indexer`** — polls Claude Code (`~/.claude/projects/`) and Codex (`~/.codex/sessions/`) JSONLs and writes them as `app_sessions` rows. Also triggered in real-time by Claude Code's SessionEnd hook.
-2. **MLX classifier** (`run_task_linker_mlx.py`) — called by the Rust intelligence module via HTTP POST to classify `app_sessions` into Jira tasks. Runs as a persistent FastAPI server (`com.meridiona.mlx-server.plist`).
-3. **Jira updater** (`agents/pm_update/`) — agno-powered synthesis workflow that generates Jira comments + worklogs from classified sessions. Runs on an office-hours slot schedule (`com.meridiona.jira-updater.plist`).
+1. **MLX classifier + summariser** (`agents/server.py`, `run_task_linker_mlx.py`) — the persistent FastAPI model server (`com.meridiona.mlx-server.plist`). Exposes `/classify_sessions` (Rust calls it to classify) and `/summarise` (the coding-agent summariser's MLX fallback). The one Python piece the pipeline can't replace (outlines + mlx-lm are Python-only).
+2. **Jira updater** (`agents/pm_worklog_update/`) — agno-powered synthesis workflow that generates Jira comments + worklogs from classified sessions. Runs on an office-hours slot schedule.
 
 For the deep technical reference (classification logic, scoring formulas, recipes for tuning prompts / debugging misclassifications), see `services/agents/README.md`.
 
@@ -281,7 +290,7 @@ For the deep technical reference (classification logic, scoring formulas, recipe
 
 - **Every `.py` file in `services/agents/` must start with a `"""…"""` module docstring** describing its purpose. The Rust/TS file-header convention does not apply — Python uses docstrings. Match the prose style of existing modules (terse, opinionated).
 - **`ticket_links` and `session_dimensions` writes must be idempotent.** Both tables have UNIQUE / composite-PK constraints with explicit `ON CONFLICT … DO UPDATE` policies. New writers must use the same UPSERT pattern. Never `DELETE` then `INSERT` from the daemon path.
-- **`coding_agent_indexer` cursor monotonicity:** the `(claude_session_uuid, day_utc)` unique index is the idempotency key. The UPSERT updates mutable fields (timestamps, duration, transcript) but never touches classifier-owned fields (`task_method`, `task_key`, `session_summary`).
+- **Coding-agent segment idempotency:** the `(claude_session_uuid, segment_started_at)` unique index is the key (migration 027; `day_utc` was dropped in 028). The UPSERT refreshes a LIVE row but carries `WHERE sealed_at IS NULL`, so a SEALED row is immutable — the summariser/classifier only ever read sealed rows.
 
 ### Quick command reference
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ to `app_sessions`:
 - macOS with Apple Silicon (the MLX inference server requires Metal)
 - [screenpipe](https://screenpi.pe) running and recording
 - Rust 1.93.1 — install via `rustup` or `rust-toolchain.toml` is picked up automatically
-- Python 3.13 — install via `brew install python@3.13` or `pyenv install 3.13`
+- Python 3.11 — install via `brew install python@3.11` or `pyenv install 3.11` (outlines/MLX require ≤ 3.13; 3.11 is the supported floor)
 
 ## Getting started
 
@@ -74,11 +74,11 @@ Task classification uses a persistent MLX inference server (Qwen3.5-9B). Set it 
 ```bash
 cd services
 
-# Create a Python 3.13 virtual environment
-python3.13 -m venv .venv313
+# Create a Python 3.11 virtual environment
+python3.11 -m venv .venv
 
 # Install core dependencies + MLX inference extras
-.venv313/bin/pip install -e ".[local-llm]"
+.venv/bin/pip install -e ".[mlx]"
 ```
 
 ### Configure
@@ -151,7 +151,7 @@ tail -f ~/.meridian/logs/mlx-server.log
 
 ```bash
 cd services
-.venv313/bin/meridian-server --backend mlx --port 7823
+.venv/bin/meridian-server --backend mlx --port 7823
 ```
 
 The server loads the model once at startup (~30 s on first run while the model downloads). Subsequent starts from cache are ~5 s. You will see `server: MLX model ready` in the log when it is ready.
@@ -270,6 +270,28 @@ screenpipe.db (read-only)
 ```
 
 The MLX server is a long-running FastAPI process managed by launchd. It loads the model once at startup — no cold-load penalty per session. The Rust daemon HTTP-calls it and writes the classification results back to `meridian.db`.
+
+### Coding-agent pipeline
+
+On machines that run a terminal coding agent (Claude Code / Codex), the **same Rust daemon** also turns those sessions into `app_sessions` rows and runs them through summarise → classify. It's gated — dormant if neither agent is present.
+
+```
+~/.claude/projects/*.jsonl                indexer task (≈10 min poll + SessionEnd hook)
+~/.codex/sessions/**/*.jsonl  ──────────► parse → segment (1h time-box, split at a
+                                          user-prompt boundary) → upsert app_sessions
+                                                     │
+                          coding_agent_live ─seal→ pending_summariser
+                                                     │
+   summariser task ──► claude -p / codex exec (2 tries) ─fail→ MLX /summarise ──► session_summary
+                                                     │                            (source: claude|codex|mlx)
+                                          pending_summariser → pending_classifier
+                                                     │
+   classifier (MLX drain) ──► /classify_sessions on the SUMMARY ──► task_key + dimensions
+                                                     │
+                                          pending_classifier → mlx_direct  (terminal)
+```
+
+Each session is sliced into ~1-hour segments (split at a real user-prompt boundary for continuity), sealed, summarised by its own agent (Claude for Claude sessions, Codex for Codex; MLX as the local fallback), then classified against your Jira tasks using the concise summary. The lifecycle is the `task_method` column: `coding_agent_live → pending_summariser → pending_classifier → mlx_direct`. The SessionEnd hook (`meridian coding-agent-hook`) seals a session immediately on `/clear` or stop; the 1-hour idle sweep is the backstop. Manual one-shots: `meridian coding-agent-summarise [--dry-run] [--day D]` and `meridian coding-agent-classify`.
 
 ## MCP Server
 

--- a/examples/ca_parse.rs
+++ b/examples/ca_parse.rs
@@ -1,0 +1,33 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Parity harness: prints the segmentation fingerprint of one coding-agent JSONL
+// so it can be diffed against the Python implementation. Critical fields
+// (segment count, boundaries, turn counts, active-time) must match exactly;
+// `tlen` (transcript char-length) is reported for an approximate transcript
+// comparison. Run: cargo run --example ca_parse -- <path.jsonl>
+
+use std::path::Path;
+
+use meridian::coding_agent::{parse_session_segments, SegmentParams};
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: ca_parse <path.jsonl>");
+    let (meta, segs) = parse_session_segments(Path::new(&path), &SegmentParams::default());
+    println!("AGENT {}", meta.agent);
+    println!("NSEG {}", segs.len());
+    for (i, s) in segs.iter().enumerate() {
+        println!(
+            "SEG {} start={} end={} u={} a={} active={} tlen={} last={}",
+            i,
+            s.segment_started_at,
+            s.ended_at,
+            s.user_turns,
+            s.assistant_turns,
+            s.active_seconds,
+            s.transcript.chars().count(),
+            s.is_last,
+        );
+    }
+}

--- a/services/README.md
+++ b/services/README.md
@@ -4,6 +4,8 @@ Python service that runs alongside the Rust daemon. It classifies completed `app
 
 The Rust daemon owns all DDL; this service only does SELECT/INSERT/UPDATE on its agent-side tables.
 
+> **Note:** the coding-agent indexer + summariser now run **inside the Rust daemon** (`src/coding_agent/`). The Python `coding_agent_indexer/` and `coding_agent_summariser/` packages here are kept as the **reference / parity** implementations (their parsers are held byte-for-byte in sync with the Rust ones via tests); their standalone daemons are retired. The MLX server (`agents/server.py`) stays — it serves both `/classify_sessions` and the summariser's `/summarise` fallback.
+
 For the deep technical reference (classification logic, schema, recipes), see [`agents/README.md`](agents/README.md).
 
 ---
@@ -30,16 +32,16 @@ Rust writes ticket_links + session_dimensions → meridian.db
 
 ## Installation
 
-Requires Python 3.13 and Apple Silicon.
+Requires Python 3.11 and Apple Silicon. (outlines/MLX require ≤ 3.13; 3.11 is the supported floor.)
 
 ```bash
 cd services/
 
-# Create a Python 3.13 virtual environment
-python3.13 -m venv .venv313
+# Create a Python 3.11 virtual environment
+python3.11 -m venv .venv
 
 # Install core + MLX inference dependencies
-.venv313/bin/pip install -e ".[local-llm]"
+.venv/bin/pip install -e ".[mlx]"
 ```
 
 The `hermes-agent` package is fetched from GitHub at the pinned tag; an internet connection is needed on first install.
@@ -68,7 +70,7 @@ bash scripts/uninstall-mlx-server-daemon.sh
 
 ```bash
 RUST_LOG=meridian=debug CLASSIFIER_BACKEND=mlx cargo run --bin meridian
-.venv313/bin/meridian-server --backend mlx --port 7823
+.venv/bin/meridian-server --backend mlx --port 7823
 python -m agents.server --backend mlx --port 7823
 ```
 

--- a/services/agents/run_task_linker_mlx.py
+++ b/services/agents/run_task_linker_mlx.py
@@ -19,7 +19,7 @@ OTel span hierarchy (when invoked as a script via main()):
 When imported by server.py the same child spans are emitted under whatever
 parent span the server establishes (propagated via contextvars).
 
-Requires: outlines[mlxlm]>=1.3, mlx-lm>=0.22 (installed in .venv313).
+Requires: outlines[mlxlm]>=1.3, mlx-lm>=0.22 (installed in .venv).
 Method tag in results: "mlx_direct".
 """
 from __future__ import annotations
@@ -189,7 +189,8 @@ def _fetch_session(
 ) -> dict[str, Any] | None:
     row = con.execute(
         "SELECT id, app_name, started_at, ended_at, duration_s, session_text,"
-        "       session_text_source, window_titles, category, confidence"
+        "       session_text_source, window_titles, category, confidence,"
+        "       session_summary, claude_session_uuid"
         " FROM app_sessions WHERE id = ?",
         (session_id,),
     ).fetchone()
@@ -269,6 +270,12 @@ def _classify_one(
         db_span.set_attribute("recent_sessions_count", len(recent))
 
         session_text = session_raw.get("session_text") or ""
+        # Coding-agent rows (Claude Code / Codex) carry the full transcript in
+        # session_text and a concise, high-quality prose summary in
+        # session_summary. Classify on the summary, not the multi-MB transcript:
+        # cheaper, faster, and it's already the distilled "what was done".
+        if session_raw.get("claude_session_uuid") and (session_raw.get("session_summary") or "").strip():
+            session_text = session_raw["session_summary"]
         db_span.add_event("session_loaded", {
             "app_name":           str(session_raw.get("app_name") or ""),
             "duration_s":         float(session_raw.get("duration_s") or 0.0),

--- a/services/agents/server.py
+++ b/services/agents/server.py
@@ -434,6 +434,78 @@ async def openai_chat_completions(req: _OAIChatRequest) -> dict:
     }
 
 
+class _SummariseRequest(BaseModel):
+    transcript: str
+    system: str | None = None
+    max_tokens: int = 2048
+    temperature: float = 0.2
+
+
+class _SummariseResponse(BaseModel):
+    summary: str
+    blockers: list[str] = []
+
+
+class _SummarySchema(BaseModel):
+    """Outlines FSM-constrains generation to this shape, so a reasoning model
+    physically cannot emit chain-of-thought — only the JSON object."""
+    summary: str
+    blockers: list[str] = []
+
+
+_SUMMARISE_DEFAULT_SYSTEM = (
+    "Summarise the coding-session transcript into a factual prose work-log "
+    "summary. Name files edited, commands run, errors hit, decisions made, "
+    "tests/validations, and any rework or blockers. State ONLY what is in the "
+    "transcript — never invent files, commands, or outcomes."
+)
+
+
+@app.post("/summarise", response_model=_SummariseResponse)
+async def summarise(req: _SummariseRequest) -> _SummariseResponse:
+    """Schema-constrained session summary (MLX backend only).
+
+    Unlike /v1/chat/completions, this forces the {summary, blockers} schema via
+    outlines — the fix for reasoning models leaking chain-of-thought into the
+    summary. Used by the coding_agent_summariser's MLX fallback path.
+    """
+    from fastapi.concurrency import run_in_threadpool
+
+    if _app_state.get("backend") != "mlx":
+        raise HTTPException(status_code=503, detail="/summarise requires --backend mlx")
+    m = _app_state.get("mlx_module")
+    if m is None:
+        raise HTTPException(status_code=503, detail="MLX model is still loading")
+
+    from mlx_lm.sample_utils import make_sampler
+    from outlines.inputs import Chat
+
+    messages = [
+        {"role": "system", "content": req.system or _SUMMARISE_DEFAULT_SYSTEM},
+        {"role": "user", "content": req.transcript},
+    ]
+
+    def _generate() -> str:
+        model = m._get_model()
+        return model(
+            Chat(messages),
+            output_type=_SummarySchema,
+            max_tokens=req.max_tokens,
+            sampler=make_sampler(temp=req.temperature),
+            verbose=False,
+        )
+
+    try:
+        raw = await run_in_threadpool(_generate)
+        obj = _SummarySchema.model_validate_json(raw)
+    except Exception as exc:                            # noqa: BLE001
+        log.warning("summarise: inference/parse error: %s", exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    log.info("summarise: out_chars=%d blockers=%d", len(obj.summary), len(obj.blockers))
+    return _SummariseResponse(summary=obj.summary.strip(), blockers=obj.blockers)
+
+
 @app.get("/v1/models")
 async def openai_models_list() -> dict:
     """OpenAI-style models listing — agno/openai-python probe this on first use."""

--- a/services/coding_agent_indexer/cli.py
+++ b/services/coding_agent_indexer/cli.py
@@ -12,8 +12,8 @@ Four modes:
     python -m coding_agent_indexer.cli --scan-once
 
     # Wipe all indexer-owned rows and re-register from disk under the
-    # current schema (used once after migration 026 to split legacy
-    # per-(uuid, started_at) rows into per-(uuid, day_utc) rows)
+    # current schema (used after migration 027 to re-split legacy day rows
+    # into per-segment (idle-gap) rows)
     python -m coding_agent_indexer.cli --reseed
 
 All modes except --reseed are idempotent against the DB unique
@@ -26,6 +26,7 @@ import json
 import logging
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -48,8 +49,8 @@ def build_parser() -> argparse.ArgumentParser:
                    help="Do one daemon-style poll sweep, register everything ready, exit.")
     g.add_argument("--reseed", action="store_true",
                    help="Wipe all indexer-owned app_sessions rows then re-scan from disk. "
-                        "Use after migration 026 to split legacy per-(uuid, started_at) "
-                        "rows into per-(uuid, day_utc) rows. Destructive (rows are recreated).")
+                        "Use after migration 027 to re-split legacy day rows into "
+                        "per-segment (idle-gap) rows. Destructive (rows are recreated).")
     p.add_argument("--json", dest="emit_json", action="store_true",
                    help="Emit machine-readable JSON for each result.")
     return p
@@ -84,7 +85,9 @@ def _do_one(jsonl_path: Path, *, emit_json: bool) -> int:
     if not jsonl_path.exists():
         print(f"file not found: {jsonl_path}", file=sys.stderr)
         return 2
-    result = register.register_ended_session(jsonl_path)
+    # Poll-like: don't force-seal a possibly-active session. register() still
+    # seals the last segment if it has already idled out (>1h since last msg).
+    result = register.register_ended_session(jsonl_path, session_ended=False)
     _print_result(result, jsonl_path, emit_json=emit_json)
     return 0 if result.outcome != register.RegisterOutcome.FAILED else 1
 
@@ -92,8 +95,8 @@ def _do_one(jsonl_path: Path, *, emit_json: bool) -> int:
 def _do_reseed(*, emit_json: bool) -> int:
     """Wipe all indexer-owned rows, then re-scan from disk.
 
-    Destructive: rows are recreated. Use once after migration 026 to
-    split legacy per-(uuid, started_at) rows into per-(uuid, day_utc).
+    Destructive: rows are recreated. Use after migration 027 to re-split
+    legacy day rows into per-segment (idle-gap) rows.
     """
     deleted = db.delete_claude_session_rows()
     log.info("reseed: deleted %d existing rows; re-scanning…", deleted)
@@ -103,10 +106,21 @@ def _do_reseed(*, emit_json: bool) -> int:
 
 
 def _do_scan(*, emit_json: bool) -> int:
+    """One poll sweep, identical to the daemon's tick: seal settled live rows,
+    then register changed files (poll path → session_ended=False)."""
     fork_skip = _load_fork_skip()
+    now_dt = datetime.now(timezone.utc)
+    now_iso = now_dt.strftime("%Y-%m-%dT%H:%M:%S.%f+00:00")   # canonical (jsonl_meta.iso_utc)
+
+    sealed = db.seal_stale_open_rows(now_iso=now_iso, idle_seconds=config.SEAL_IDLE_SECONDS)
+    if sealed and not emit_json:
+        print(f"sealed {sealed} settled open row(s)")
+
     wrote = skipped = failed = 0
     for jsonl in _candidate_jsonls(now=time.time()):
-        result = register.register_ended_session(jsonl, fork_skip_list=fork_skip)
+        result = register.register_ended_session(
+            jsonl, session_ended=False, fork_skip_list=fork_skip, now=now_dt,
+        )
         _print_result(result, jsonl, emit_json=emit_json)
         if result.outcome == register.RegisterOutcome.INSERTED:
             wrote += 1
@@ -115,7 +129,7 @@ def _do_scan(*, emit_json: bool) -> int:
         else:
             skipped += 1
     if not emit_json:
-        print(f"\n=== scan complete: wrote={wrote} skipped={skipped} failed={failed} ===")
+        print(f"\n=== scan complete: sealed={sealed} wrote={wrote} skipped={skipped} failed={failed} ===")
     return 0 if failed == 0 else 1
 
 
@@ -149,6 +163,7 @@ def _print_result(result, jsonl_path: Path, *, emit_json: bool) -> None:
             "session_uuid": result.session_uuid,
             "jsonl_path":   str(jsonl_path),
             "row_ids":      list(result.row_ids),
+            "sealed_ids":   list(result.sealed_ids),
             "host_app":     result.host_app,
             "user_turns":   result.meta.user_turns      if result.meta else None,
             "asst_turns":   result.meta.assistant_turns if result.meta else None,

--- a/services/coding_agent_indexer/config.py
+++ b/services/coding_agent_indexer/config.py
@@ -36,9 +36,7 @@ def _resolve_local_tz() -> tzinfo:
     return timezone.utc
 
 
-# Days for `app_sessions.day_utc` are bucketed in this TZ. A continuous
-# coding session that crosses midnight produces two rows split on this
-# TZ's calendar boundary.
+# Sessions that cross midnight produce two rows split on this TZ's calendar boundary.
 LOCAL_TZ = _resolve_local_tz()
 
 # ── Source dirs to watch ──────────────────────────────────────────────────────
@@ -71,10 +69,48 @@ POLL_INTERVAL_SECONDS = int(os.environ.get("INDEXER_POLL_INTERVAL_S", "600"))   
 # overnight, day off) don't contribute — the user wasn't actively
 # engaged during them.
 #
-# 5 min is the sweet spot: short enough that a coffee break stops
-# counting, long enough that a slow Claude response or a moment of
-# thinking still counts as active time.
-ACTIVE_TIME_GAP_CAP_SECONDS = int(os.environ.get("INDEXER_ACTIVE_GAP_CAP_S", "300"))
+# During AI-assisted coding, active work emits records frequently (prompts,
+# the agent's streamed tool round-trips). A gap with NO record for >2 min
+# almost always means the user stepped away — so capping each gap at 2 min
+# credits the brief transition/think and discards the idle remainder.
+# (Measured: dropping 5min→2min removed mostly genuine 5–60min idle gaps,
+# not real activity.) Env-tunable; raise it if you want longer no-record
+# reading stretches to count in full.
+ACTIVE_TIME_GAP_CAP_SECONDS = int(os.environ.get("INDEXER_ACTIVE_GAP_CAP_S", "120"))
+
+# ── Segmentation + sealing ────────────────────────────────────────────────────
+#
+# A coding-agent session is sliced into SEGMENTS split on idle gaps larger
+# than this between consecutive messages. A new burst of activity after a
+# gap this long becomes a NEW app_sessions row (same claude_session_uuid,
+# later segment_started_at), and the prior segment is sealed.
+#
+# Distinct from ACTIVE_TIME_GAP_CAP_SECONDS: that caps each gap when summing
+# *active* duration_s (so a 50-min think within a segment doesn't inflate
+# work time); this decides where one row ends and the next begins.
+#
+# The threshold is STRICTLY exceeded to split: a gap of exactly
+# SEGMENT_GAP_SECONDS stays in the same segment (mirrors the Rust ETL's
+# "> threshold" gap convention).
+SEGMENT_GAP_SECONDS = int(os.environ.get("INDEXER_SEGMENT_GAP_S", "3600"))      # 1 hour
+
+# A live (unsealed) segment whose last message is older than this is
+# considered settled and gets sealed by the poll sweep — even if its JSONL
+# never changes again (crash, force-quit, macOS sleep, file deleted). Kept
+# equal to SEGMENT_GAP_SECONDS so "settled" and "would start a new segment"
+# mean the same elapsed idleness.
+SEAL_IDLE_SECONDS = int(os.environ.get("INDEXER_SEAL_IDLE_S", str(SEGMENT_GAP_SECONDS)))
+
+# ── Time-box ──────────────────────────────────────────────────────────────────
+#
+# A long CONTINUOUS session (no >1h gap, never ended) would otherwise stay one
+# live row indefinitely — its summary, and the Jira update that depends on it,
+# would wait unpredictably. So we also split a segment once its span reaches
+# this many seconds: the prior chunk immediately becomes a non-last (→ sealed →
+# summarisable) row, giving a fresh Jira-ready summary on a predictable cadence.
+# Boundaries are deterministic (start, start+box, start+2·box, …) so re-parses
+# stay idempotent. Set to 0 to disable time-boxing (gap/end sealing only).
+MAX_SEGMENT_SECONDS = int(os.environ.get("INDEXER_MAX_SEGMENT_S", "3600"))      # 1 hour
 
 # ── Fork skip list ────────────────────────────────────────────────────────────
 #

--- a/services/coding_agent_indexer/daemon.py
+++ b/services/coding_agent_indexer/daemon.py
@@ -25,7 +25,7 @@ import logging
 import signal
 import threading
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator, Optional
 
@@ -77,12 +77,32 @@ def main() -> int:
 
 
 def _tick(fork_skip: set[str]) -> None:
-    """One sweep — register anything changed since last tick."""
-    now = time.time()
-    wrote = skipped = failed = 0
+    """One sweep: (1) seal settled live rows, (2) register changed files.
 
-    for jsonl in _candidate_jsonls(now=now):
-        result = register.register_ended_session(jsonl, fork_skip_list=fork_skip)
+    Step 1 is the robust backstop that seals rows whose JSONL will never be
+    re-parsed (crash, force-quit, macOS sleep, file deleted) — it touches
+    only the DB. Step 2 re-parses files that grew and refreshes their live
+    last segment (`session_ended=False`, so an actively-growing session
+    stays live until it idles out or its SessionEnd hook fires).
+    """
+    now_epoch = time.time()
+    now_dt = datetime.now(timezone.utc)
+    now_iso = now_dt.strftime("%Y-%m-%dT%H:%M:%S.%f+00:00")   # canonical (jsonl_meta.iso_utc)
+
+    try:
+        sealed = db.seal_stale_open_rows(
+            now_iso=now_iso, idle_seconds=config.SEAL_IDLE_SECONDS,
+        )
+        if sealed:
+            log.info("tick: sealed %d settled open row(s)", sealed)
+    except Exception:                                       # noqa: BLE001
+        log.exception("tick: seal sweep failed")
+
+    wrote = skipped = failed = 0
+    for jsonl in _candidate_jsonls(now=now_epoch):
+        result = register.register_ended_session(
+            jsonl, session_ended=False, fork_skip_list=fork_skip, now=now_dt,
+        )
         if result.outcome == register.RegisterOutcome.INSERTED:
             wrote += 1
         elif result.outcome == register.RegisterOutcome.FAILED:

--- a/services/coding_agent_indexer/db.py
+++ b/services/coding_agent_indexer/db.py
@@ -1,9 +1,17 @@
 """SQLite read/write layer for coding_agent_indexer.
 
 Owns inserts to `app_sessions` for Claude / Codex sessions (rows carry a
-non-NULL `claude_session_uuid`). Per-day chunking: a session spanning
-multiple local days produces one row per day, keyed on
-`(claude_session_uuid, day_utc)`.
+non-NULL `claude_session_uuid`). Segment chunking: a session is sliced
+into work bursts split on >1h idle gaps, one row per burst, keyed on
+`(claude_session_uuid, segment_started_at)`.
+
+Lifecycle of a coding-agent row:
+  * LIVE   — `sealed_at IS NULL`, `task_method = 'coding_agent_live'`.
+             Re-UPSERTed each poll while the burst is still growing.
+  * SEALED — `sealed_at` set, `task_method = 'pending_summariser'`.
+             Immutable: the UPSERT carries `WHERE sealed_at IS NULL`, so a
+             sealed row is never mutated again. This is the downstream
+             contract — summariser/classifier only read sealed rows.
 
 Connection model: short-lived `sqlite3.Connection` per call. WAL mode is
 set once at DB creation by the Rust ETL — we only set busy_timeout per
@@ -18,7 +26,7 @@ from pathlib import Path
 from typing import Iterator, Optional
 
 from coding_agent_indexer import config
-from coding_agent_indexer.jsonl_meta import DaySlice
+from coding_agent_indexer.jsonl_meta import Segment
 
 log = logging.getLogger(__name__)
 
@@ -31,18 +39,23 @@ _EMPTY_JSON_LIST = "[]"
 _CATEGORY        = "coding"                # we are sure: this IS coding work
 _CATEGORY_METHOD = "coding_agent_indexer"
 
-# `task_method` is set non-NULL on insert so the Rust MLX classifier
-# skips these rows — its query is `WHERE task_method IS NULL`. The
-# summariser (phase 2, Claude API) picks them up by querying
-# `WHERE task_method = 'pending_summariser'`.
-_TASK_METHOD_PENDING = "pending_summariser"
+# `task_method` is set non-NULL in BOTH states so the Rust MLX classifier
+# (which selects `WHERE task_method IS NULL`) skips these rows whether live
+# or sealed. The summariser's queue is `WHERE task_method = 'pending_summariser'`
+# — which only sealed rows carry.
+TASK_METHOD_LIVE    = "coding_agent_live"
+TASK_METHOD_PENDING = "pending_summariser"
 
-# Map agent flavour → app_name. We use the agent's product name, not
-# the host terminal/IDE: a Claude Code session is `Claude Code` whether
-# you ran it inside VS Code, iTerm2, or any other terminal.
+# Map agent flavour → app_name / session_text_source. We use the agent's
+# product name, not the host terminal/IDE: a Claude Code session is
+# `Claude Code` whether run inside VS Code, iTerm2, or any other terminal.
 _APP_NAME_BY_AGENT = {
     "claude_code": "Claude Code",
     "codex":       "Codex",
+}
+_TEXT_SOURCE_BY_AGENT = {
+    "claude_code": "claude_jsonl",
+    "codex":       "codex_jsonl",
 }
 
 _BUSY_TIMEOUT_MS = 5000
@@ -77,63 +90,57 @@ def connect(
 # ──────────────────────── Write paths ──────────────────────────────────────────
 
 
-def upsert_session_day_slice(
-    slice_: DaySlice,
+def upsert_segment(
+    segment: Segment,
     *,
+    sealed: bool,
+    sealed_at: Optional[str] = None,
     db_path: Optional[Path] = None,
 ) -> Optional[int]:
-    """INSERT or UPDATE one (uuid, day) row for a coding-agent session.
+    """INSERT or UPDATE one (uuid, segment_started_at) row.
 
-    Per-day rows: a long-running session that spans multiple calendar
-    days produces one row per local day, so PM-update window queries
-    (`WHERE started_at BETWEEN ?...`) correctly attribute time to the
-    day the work actually happened.
+    `sealed=False` writes/refreshes a LIVE row (mutable, re-UPSERTed each
+    poll). `sealed=True` writes/seals the row — `task_method` flips to
+    `pending_summariser` and `sealed_at` is stamped.
 
-    Live-tracking semantics: each tick can re-call this with a fresh
-    slice; mutable fields (started_at, ended_at, duration_s,
-    frame_count, session_text) get refreshed; classifier-owned fields
-    (task_method, task_key, session_summary, …) are deliberately NOT
-    touched on UPDATE so the summariser's work isn't clobbered.
+    The UPDATE branch carries `WHERE sealed_at IS NULL`, so once a row is
+    sealed it is immutable: subsequent UPSERTs for the same key (e.g. a
+    redundant re-scan) are no-ops. Combined with the parser's sealed
+    high-water boundary, this guarantees a sealed row never changes and
+    new content always lands in a fresh segment.
 
-    Idempotent under hook + poller races via the partial unique index
-    on `(claude_session_uuid, day_utc)`.
-
-    Args:
-        slice_: parsed DaySlice (one day's slice of a session).
-        db_path: target meridian.db; defaults to config.MERIDIAN_DB.
-
-    Returns:
-        The row's id (whether INSERTed or UPDATEd), or None if the
-        slice was rejected as invalid (e.g. no turns).
+    Returns the row id, or None if the segment was rejected as invalid.
     """
-    if not slice_.is_valid:
+    if not segment.is_valid:
         log.info(
-            "skip upsert: slice invalid (uuid=%s day=%s user=%d asst=%d started=%r ended=%r)",
-            slice_.session_uuid, slice_.day_utc, slice_.user_turns,
-            slice_.assistant_turns, slice_.started_at, slice_.ended_at,
+            "skip upsert: segment invalid (uuid=%s seg_start=%s user=%d asst=%d ended=%r)",
+            segment.session_uuid, segment.segment_started_at, segment.user_turns,
+            segment.assistant_turns, segment.ended_at,
         )
         return None
 
-    app_name     = _APP_NAME_BY_AGENT.get(slice_.agent, "Claude Code")
-    transcript   = slice_.transcript
+    app_name     = _APP_NAME_BY_AGENT.get(segment.agent, "Claude Code")
+    transcript   = segment.transcript
     session_text = transcript if transcript else None
-    text_source  = "claude_jsonl" if transcript else None
-    frame_count  = slice_.user_turns + slice_.assistant_turns
+    text_source  = _TEXT_SOURCE_BY_AGENT.get(segment.agent) if transcript else None
+    frame_count  = segment.user_turns + segment.assistant_turns
+    task_method  = TASK_METHOD_PENDING if sealed else TASK_METHOD_LIVE
+    sealed_stamp = sealed_at if sealed else None
 
     with connect(db_path) as con:
         con.execute(
             """
             INSERT INTO app_sessions (
-                app_name, started_at, ended_at, duration_s, day_utc,
+                app_name, started_at, ended_at, duration_s,
                 window_titles, min_frame_id, max_frame_id, frame_count,
                 etl_run_id, idle_frame_count,
                 category, confidence, category_method,
                 session_text, session_text_source,
                 task_method,
-                claude_session_uuid
+                claude_session_uuid, segment_started_at, sealed_at
             )
-            VALUES (?, ?, ?, ?, ?,  ?, ?, ?, ?,  ?, ?,  ?, ?, ?,  ?, ?,  ?,  ?)
-            ON CONFLICT (claude_session_uuid, day_utc)
+            VALUES (?, ?, ?, ?,  ?, ?, ?, ?,  ?, ?,  ?, ?, ?,  ?, ?,  ?,  ?, ?, ?)
+            ON CONFLICT (claude_session_uuid, segment_started_at)
             WHERE claude_session_uuid IS NOT NULL
             DO UPDATE SET
                 started_at          = excluded.started_at,
@@ -141,14 +148,16 @@ def upsert_session_day_slice(
                 duration_s          = excluded.duration_s,
                 frame_count         = excluded.frame_count,
                 session_text        = excluded.session_text,
-                session_text_source = excluded.session_text_source
+                session_text_source = excluded.session_text_source,
+                task_method         = excluded.task_method,
+                sealed_at           = excluded.sealed_at
+            WHERE app_sessions.sealed_at IS NULL
             """,
             (
                 app_name,
-                slice_.started_at,
-                slice_.ended_at,
-                slice_.active_seconds,
-                slice_.day_utc,
+                segment.started_at,
+                segment.ended_at,
+                segment.active_seconds,
                 _EMPTY_JSON_LIST,
                 0,                                         # min_frame_id (sentinel)
                 0,                                         # max_frame_id (sentinel)
@@ -160,29 +169,59 @@ def upsert_session_day_slice(
                 _CATEGORY_METHOD,
                 session_text,
                 text_source,
-                _TASK_METHOD_PENDING,
-                slice_.session_uuid,
+                task_method,
+                segment.session_uuid,
+                segment.segment_started_at,
+                sealed_stamp,
             ),
         )
         row = con.execute(
             "SELECT id FROM app_sessions "
-            "WHERE claude_session_uuid = ? AND day_utc = ?",
-            (slice_.session_uuid, slice_.day_utc),
+            "WHERE claude_session_uuid = ? AND segment_started_at = ?",
+            (segment.session_uuid, segment.segment_started_at),
         ).fetchone()
         con.commit()
         return row["id"] if row else None
 
 
+def seal_stale_open_rows(
+    *,
+    now_iso: str,
+    idle_seconds: int,
+    db_path: Optional[Path] = None,
+) -> int:
+    """Seal every LIVE coding-agent row whose last activity is > idle_seconds old.
+
+    This is the robust backstop that does NOT require re-parsing the JSONL:
+    it seals rows left open by crashes, force-quits, macOS sleep, or a file
+    that was deleted after the session ended. Idempotent — already-sealed
+    rows are excluded by `sealed_at IS NULL`.
+
+    Returns the number of rows sealed.
+    """
+    cutoff = _shift_iso(now_iso, -idle_seconds)
+    with connect(db_path) as con:
+        cur = con.execute(
+            """
+            UPDATE app_sessions
+            SET    sealed_at = ?, task_method = ?
+            WHERE  claude_session_uuid IS NOT NULL
+              AND  sealed_at IS NULL
+              AND  ended_at < ?
+            """,
+            (now_iso, TASK_METHOD_PENDING, cutoff),
+        )
+        con.commit()
+        return cur.rowcount or 0
+
+
 def delete_claude_session_rows(*, db_path: Optional[Path] = None) -> int:
     """Delete every Claude/Codex-owned app_sessions row.
 
-    Used by the CLI `--reseed` flag to wipe stale per-(uuid, started_at)
-    rows from a pre-migration-026 install so the next `--scan-once`
-    re-registers them under the new per-day scheme. Only touches rows
-    the indexer owns (`claude_session_uuid IS NOT NULL`); never touches
-    screen-frame rows.
-
-    Returns the number of rows deleted.
+    Used by the CLI `--reseed` flag to wipe legacy per-(uuid, day) rows so
+    the next scan re-registers them under the per-segment scheme. Only
+    touches rows the indexer owns (`claude_session_uuid IS NOT NULL`);
+    never touches screen-frame rows. Returns rows deleted.
     """
     with connect(db_path) as con:
         cur = con.execute(
@@ -192,12 +231,14 @@ def delete_claude_session_rows(*, db_path: Optional[Path] = None) -> int:
         return cur.rowcount or 0
 
 
-def fetch_session_endpoints(*, db_path: Optional[Path] = None) -> dict[str, str]:
-    """Return {claude_session_uuid: latest_ended_at_iso} for every registered row.
+# ──────────────────────── Read paths ────────────────────────────────────────────
 
-    Used by the daemon's change-detection (skip parsing a JSONL whose
-    mtime hasn't moved past the stored `ended_at`). Cheap — uses the
-    `idx_app_sessions_claude_uuid` partial index.
+
+def fetch_session_endpoints(*, db_path: Optional[Path] = None) -> dict[str, str]:
+    """Return {claude_session_uuid: latest_ended_at_iso} across all its segments.
+
+    Used by the daemon's change-detection: skip parsing a JSONL whose mtime
+    hasn't moved past the latest stored `ended_at`.
     """
     with connect(db_path, readonly=True) as con:
         rows = con.execute(
@@ -207,3 +248,39 @@ def fetch_session_endpoints(*, db_path: Optional[Path] = None) -> dict[str, str]
             "GROUP  BY claude_session_uuid"
         ).fetchall()
     return {r["claude_session_uuid"]: r["ended_at"] for r in rows if r["claude_session_uuid"]}
+
+
+def sealed_high_water(uuid: str, *, db_path: Optional[Path] = None) -> Optional[str]:
+    """Latest `ended_at` among this session's SEALED segments, or None.
+
+    Passed to the parser as `start_after_ts` so already-sealed content is
+    excluded and any newer record opens a fresh segment — the invariant that
+    makes a post-SessionEnd resume safe.
+    """
+    with connect(db_path, readonly=True) as con:
+        row = con.execute(
+            "SELECT MAX(ended_at) AS hwm FROM app_sessions "
+            "WHERE claude_session_uuid = ? AND sealed_at IS NOT NULL",
+            (uuid,),
+        ).fetchone()
+    return row["hwm"] if row and row["hwm"] else None
+
+
+# ──────────────────────── Helpers ──────────────────────────────────────────────
+
+
+def _shift_iso(iso: str, delta_seconds: int) -> str:
+    """Return `iso` shifted by delta_seconds, in the canonical µs+'+00:00' UTC format.
+
+    Used to compute the seal cutoff. Lexicographic comparison of two
+    same-format UTC ISO strings is a valid chronological comparison, so the
+    sweep's `ended_at < cutoff` works as a plain string compare.
+    """
+    from datetime import datetime, timedelta, timezone
+    dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    shifted = dt.astimezone(timezone.utc) + timedelta(seconds=delta_seconds)
+    # Canonical µs+'+00:00' shape (see jsonl_meta.iso_utc): the same fixed-width
+    # UTC form every row stores, so the sweep's string compare stays chronological.
+    return shifted.strftime("%Y-%m-%dT%H:%M:%S.%f+00:00")

--- a/services/coding_agent_indexer/jsonl_meta.py
+++ b/services/coding_agent_indexer/jsonl_meta.py
@@ -1,29 +1,33 @@
-"""Parse a coding-agent JSONL once and return per-day session slices.
+"""Parse a coding-agent JSONL once and return idle-gap session segments.
 
 A Claude Code or Codex session writes its conversation as an append-only
-.jsonl file that can span many calendar days. We slice it by the user's
-local calendar day so PM-update windowing (`WHERE started_at BETWEEN
-?...`) attributes time correctly — yesterday's work shows up under
-yesterday, today's work under today, etc.
+.jsonl file. A single file can hold several distinct work bursts separated by
+long idle gaps (lunch, a meeting, picking the session back up the next morning
+via `claude --continue` / `codex resume`). We slice the file into SEGMENTS
+split on idle gaps larger than `config.SEGMENT_GAP_SECONDS` (default 1h): each
+continuous burst becomes one `app_sessions` row.
+
+Claude and Codex use different on-disk event schemas, so each record is first
+normalised to a common `_NormRecord` (timestamp, cwd, is_turn, is_user, body).
+Everything downstream — segmentation, active-time, the timestamped transcript —
+is agent-agnostic.
+
+Timestamps are stored as the JSONL's own UTC ISO-8601 (`...Z`); callers derive
+is bucketed in the user's local TZ (for PM-update windowing).
 
 Public surface:
+  * `parse_session_segments()` — single pass; returns the overall `SessionMeta`
+    plus a list of `Segment` (one per work burst). The indexer UPSERTs one row
+    per segment and seals settled ones.
 
-  * `parse_session_slices()` — single pass; returns the overall
-    `SessionMeta` plus a list of `DaySlice` (one per local day that has
-    at least one record). The indexer's UPSERT loops over the slices.
+`start_after_ts` excludes content already captured by a sealed segment: any
+record at or before it is ignored and the first record after it begins a fresh
+segment regardless of gap — the "sealed content is immutable; newer is a new
+segment" invariant.
 
-Deliberately ignored (despite being present on every record):
-  * gitBranch — by product decision
-  * version, parentUuid — not useful for indexing
-  * UI-state types (mode, ai-title, permission-mode, last-prompt,
-    pr-link, file-history-snapshot, attachment, system,
-    queue-operation) — not conversation, would just bloat the
-    transcript
-
-Tolerant: malformed lines, missing fields, files truncated mid-write,
-files with zero meaningful records all degrade gracefully — slices'
-`is_valid` flag tells the caller whether registration should proceed;
-the renderer returns an empty string on a broken file.
+Tolerant: malformed lines, missing fields, files truncated mid-write, and files
+with zero meaningful records all degrade gracefully — each segment's `is_valid`
+flag tells the caller whether to register it.
 """
 from __future__ import annotations
 
@@ -36,34 +40,28 @@ from typing import Iterator, List, Optional, Tuple
 
 log = logging.getLogger(__name__)
 
-# Record types we *count* as conversational turns. Everything else
-# (mode, ai-title, permission-mode, last-prompt, pr-link, etc.) is
-# ignored for the turn count — it's UI state, not conversation.
-_TURN_TYPES_USER      = frozenset({"user"})
-_TURN_TYPES_ASSISTANT = frozenset({"assistant"})
-
-# Truncation for noisy tool_result bodies (file dumps, large search
-# outputs). Keeps the rendered transcript bounded.
+# Truncation for noisy tool_result bodies (file dumps, large search outputs).
 _TOOL_RESULT_CAP = 800
-_ASSISTANT_LABEL = "claude-code"
+_CLAUDE_ASSISTANT_LABEL = "claude-code"
+_CODEX_ASSISTANT_LABEL = "codex"
 
 
 @dataclass(frozen=True)
 class SessionMeta:
     """Overall metadata for a JSONL — useful for daemon-level cursors.
 
-    For the per-day rows written to app_sessions, use `DaySlice` below.
+    For the per-segment rows written to app_sessions, use `Segment` below.
     """
-    session_uuid:    str             # filename stem; also `sessionId` in every record
+    session_uuid:    str
     agent:           str             # 'claude_code' | 'codex'
-    cwd:             Optional[str]   # working directory the session was launched from
-    started_at:      str             # ISO-8601 UTC; first record's timestamp
-    ended_at:        str             # ISO-8601 UTC; last record's timestamp
-    user_turns:      int             # total non-meta, non-sidechain user messages
-    assistant_turns: int             # total non-meta, non-sidechain assistant messages
-    total_records:   int             # all parseable records (including UI state)
-    jsonl_bytes:     int             # source-file size at parse time
-    active_seconds:  int             # gap-capped active engagement time across ALL days
+    cwd:             Optional[str]
+    started_at:      str
+    ended_at:        str
+    user_turns:      int
+    assistant_turns: int
+    total_records:   int
+    jsonl_bytes:     int
+    active_seconds:  int
 
     @property
     def is_valid(self) -> bool:
@@ -76,30 +74,30 @@ class SessionMeta:
 
 
 @dataclass(frozen=True)
-class DaySlice:
-    """One calendar-day slice of a session, in the user's local TZ.
+class Segment:
+    """One continuous work burst of a session (gaps < SEGMENT_GAP_SECONDS).
 
-    The indexer writes one app_sessions row per slice — `day_utc` is
-    the (local) calendar day key; `started_at` / `ended_at` are the
-    first / last record timestamps WITHIN that day (still emitted as
-    UTC ISO strings because the rest of meridian.db stores UTC).
+    One app_sessions row per segment, keyed on (claude_session_uuid,
+    segment_started_at). `is_last` marks the final segment — the only one that
+    may still be live (unsealed).
     """
-    session_uuid:    str
-    agent:           str
-    cwd:             Optional[str]
-    day_utc:         str             # YYYY-MM-DD in the user's local TZ
-    started_at:      str             # first record ts that fell into this day (ISO UTC)
-    ended_at:        str             # last record ts that fell into this day  (ISO UTC)
-    user_turns:      int             # turns within this day only
-    assistant_turns: int
-    active_seconds:  int             # gap-capped active time, credited to this day
-    transcript:      str             # rendered transcript of just this day's records
+    session_uuid:       str
+    agent:              str
+    cwd:                Optional[str]
+    segment_started_at: str          # first record ts in this segment (ISO UTC) — the key
+    started_at:         str          # == segment_started_at
+    ended_at:           str          # last record ts in this segment (ISO UTC)
+    user_turns:         int
+    assistant_turns:    int
+    active_seconds:     int
+    transcript:         str
+    is_last:            bool
 
     @property
     def is_valid(self) -> bool:
         return (
             self.user_turns + self.assistant_turns > 0
-            and bool(self.started_at)
+            and bool(self.segment_started_at)
             and bool(self.ended_at)
         )
 
@@ -107,30 +105,36 @@ class DaySlice:
 # ──────────────────────── Public API ───────────────────────────────────────────
 
 
-def parse_session_slices(
+def parse_session_segments(
     jsonl_path: Path,
     *,
     agent: Optional[str] = None,
     active_gap_cap_seconds: Optional[int] = None,
+    segment_gap_seconds: Optional[int] = None,
+    max_segment_seconds: Optional[int] = None,
     local_tz: Optional[tzinfo] = None,
-) -> Tuple[SessionMeta, List[DaySlice]]:
-    """Single pass over the JSONL; returns (overall SessionMeta, sorted DaySlice list).
-
-    `agent` defaults to inferring from the path (claude_code vs codex).
-    `active_gap_cap_seconds` clamps each inter-record gap before adding
-    it to that record's day-bucket active total. Gaps that straddle a
-    day boundary are credited to the day of the LATER record.
-    `local_tz` defaults to `config.LOCAL_TZ` (user's machine TZ).
-    """
-    # Lazy import to avoid circular dep at module load
+    start_after_ts: Optional[str] = None,
+) -> Tuple[SessionMeta, List[Segment]]:
+    """Single pass over the JSONL; returns (overall SessionMeta, Segment list)."""
     from coding_agent_indexer import config
 
     if agent is None:
         agent = _infer_agent(jsonl_path)
     if active_gap_cap_seconds is None:
         active_gap_cap_seconds = config.ACTIVE_TIME_GAP_CAP_SECONDS
+    if segment_gap_seconds is None:
+        segment_gap_seconds = config.SEGMENT_GAP_SECONDS
+    if max_segment_seconds is None:
+        max_segment_seconds = config.MAX_SEGMENT_SECONDS
     if local_tz is None:
         local_tz = config.LOCAL_TZ
+
+    start_after_dt: Optional[datetime] = None
+    if start_after_ts:
+        try:
+            start_after_dt = _parse_iso(start_after_ts)
+        except (ValueError, TypeError):
+            start_after_dt = None
 
     session_uuid = jsonl_path.stem
     cwd: Optional[str] = None
@@ -139,123 +143,161 @@ def parse_session_slices(
     user_turns_overall = 0
     assistant_turns_overall = 0
     total_records = 0
-    prev_dt: Optional[datetime] = None
-    days: dict[str, _DayBuilder] = {}
+    prev_dt: Optional[datetime] = None          # ts of previous KEPT record (gap calc)
+    seg_start_dt: Optional[datetime] = None      # start ts of the current segment (time-box)
+    segments_b: List[_SegBuilder] = []
+    cur: Optional[_SegBuilder] = None
 
     try:
         jsonl_bytes = jsonl_path.stat().st_size
     except OSError:
         jsonl_bytes = 0
 
-    for record in _iter_records(jsonl_path):
+    for rec in _iter_normalised(jsonl_path, agent=agent):
         total_records += 1
-        ts = record.get("timestamp")
-        cur_dt: Optional[datetime] = None
-        cur_day: Optional[str] = None
+        ts = rec.timestamp
+        if cwd is None and rec.cwd:
+            cwd = rec.cwd
 
+        cur_dt: Optional[datetime] = None
         if isinstance(ts, str):
+            try:
+                cur_dt = _parse_iso(ts)
+            except (ValueError, TypeError):
+                cur_dt = None
+
+        # Already-sealed content is immutable history — skip it and reset the
+        # gap anchor so the first kept record opens a fresh segment.
+        if cur_dt is not None and start_after_dt is not None and cur_dt <= start_after_dt:
+            prev_dt = None
+            continue
+
+        if cur_dt is not None:
             if started_overall is None:
                 started_overall = ts
             ended_overall = ts
-            try:
-                cur_dt = _parse_iso(ts)
-                cur_day = cur_dt.astimezone(local_tz).strftime("%Y-%m-%d")
-            except (ValueError, TypeError):
-                pass
 
-        if cwd is None and isinstance(record.get("cwd"), str):
-            cwd = record["cwd"]
+        # Records with no usable timestamp can't anchor a segment; attach to the
+        # current one if it exists (so a body isn't lost), else drop.
+        if cur_dt is None:
+            if cur is not None and rec.is_turn:
+                _add_turn(cur, ts, rec)
+            continue
 
-        # Each record lands in exactly one day bucket.
-        slot: Optional[_DayBuilder] = None
-        if cur_day is not None:
-            slot = days.get(cur_day)
-            if slot is None:
-                slot = _DayBuilder(day_utc=cur_day)
-                days[cur_day] = slot
-            if slot.started_at is None and isinstance(ts, str):
-                slot.started_at = ts
-            if isinstance(ts, str):
-                slot.ended_at = ts
-
-        # Active-time accumulation: cap each inter-record gap at
-        # active_gap_cap_seconds. Gap is credited to the day of the
-        # LATER record (cur_day) — so a gap that straddles midnight
-        # gets clamped and assigned to the new day.
-        if cur_dt is not None and prev_dt is not None and slot is not None:
+        start_new = (
+            cur is None
+            or prev_dt is None
+            or (cur_dt - prev_dt).total_seconds() > segment_gap_seconds
+            # Time-box: once a segment has run for max_segment_seconds, split — but
+            # only AT THE NEXT REAL USER PROMPT, so the prior row ends on a complete
+            # assistant turn and the new row opens on a user message (continuity).
+            # Tool-result `user` records don't count (is_user_prompt is False).
+            or (
+                max_segment_seconds > 0
+                and seg_start_dt is not None
+                and (cur_dt - seg_start_dt).total_seconds() >= max_segment_seconds
+                and rec.is_user_prompt
+            )
+        )
+        if start_new:
+            cur = _SegBuilder(
+                segment_started_at=ts,
+            )
+            segments_b.append(cur)
+            seg_start_dt = cur_dt
+        else:
             gap = (cur_dt - prev_dt).total_seconds()
             if gap > 0:
-                slot.active_seconds += min(gap, active_gap_cap_seconds)
-        if cur_dt is not None:
-            prev_dt = cur_dt
+                cur.active_seconds += min(gap, active_gap_cap_seconds)
 
-        # Turn counting + transcript building — only real conversational
-        # records (no sidechain sub-agents, no meta local-command echoes).
-        if record.get("isSidechain") or record.get("isMeta"):
-            continue
-        rtype = record.get("type")
-        if rtype not in ("user", "assistant"):
-            continue
-        if slot is None:
-            continue                                       # record had no usable timestamp
+        cur.ended_at = ts
+        prev_dt = cur_dt
 
-        if rtype == "user":
-            slot.user_turns += 1
-            user_turns_overall += 1
-        else:
-            slot.assistant_turns += 1
-            assistant_turns_overall += 1
-        slot.records.append(record)
+        if rec.is_turn:
+            _add_turn(cur, ts, rec)
+            if rec.is_user:
+                user_turns_overall += 1
+            else:
+                assistant_turns_overall += 1
 
-    # Render transcripts per slice (sorted by day for stable output).
-    slices: List[DaySlice] = []
-    for day_utc in sorted(days):
-        b = days[day_utc]
-        slices.append(DaySlice(
-            session_uuid    = session_uuid,
-            agent           = agent,
-            cwd             = cwd,
-            day_utc         = day_utc,
-            started_at      = b.started_at or "",
-            ended_at        = b.ended_at or "",
-            user_turns      = b.user_turns,
-            assistant_turns = b.assistant_turns,
-            active_seconds  = int(b.active_seconds),
-            transcript      = _render_records(b.records),
+    segments: List[Segment] = []
+    for i, b in enumerate(segments_b):
+        segments.append(Segment(
+            session_uuid       = session_uuid,
+            agent              = agent,
+            cwd                = cwd,
+            segment_started_at = norm_iso(b.segment_started_at),
+            started_at         = norm_iso(b.segment_started_at),
+            ended_at           = norm_iso(b.ended_at or b.segment_started_at),
+            user_turns         = b.user_turns,
+            assistant_turns    = b.assistant_turns,
+            active_seconds     = int(b.active_seconds),
+            transcript         = _render_records(b.records),
+            is_last            = (i == len(segments_b) - 1),
         ))
 
     meta = SessionMeta(
         session_uuid    = session_uuid,
         agent           = agent,
         cwd             = cwd,
-        started_at      = started_overall or "",
-        ended_at        = ended_overall or "",
+        started_at      = norm_iso(started_overall) if started_overall else "",
+        ended_at        = norm_iso(ended_overall) if ended_overall else "",
         user_turns      = user_turns_overall,
         assistant_turns = assistant_turns_overall,
         total_records   = total_records,
         jsonl_bytes     = jsonl_bytes,
-        active_seconds  = sum(s.active_seconds for s in slices),
+        active_seconds  = sum(s.active_seconds for s in segments),
     )
-    return meta, slices
+    return meta, segments
 
 
-# ──────────────────────── Internals ────────────────────────────────────────────
+# ──────────────────────── Canonical record ─────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _NormRecord:
+    """One raw JSONL record normalised across Claude and Codex schemas."""
+    timestamp:  Optional[str]
+    cwd:        Optional[str]
+    is_turn:    bool
+    is_user:    bool
+    role_label: Optional[str]
+    body:       str
+    # True only for a REAL human prompt (text), not a tool-result (Claude logs
+    # tool outputs as type:user too). The time-box split aligns to this so a
+    # segment begins on a genuine user message.
+    is_user_prompt: bool = False
+
+
+def _is_real_user_prompt(content) -> bool:
+    """A genuine prompt (has text) vs a tool-result-only user message."""
+    if isinstance(content, str):
+        return bool(content.strip())
+    if isinstance(content, list):
+        return any(isinstance(b, dict) and b.get("type") == "text" for b in content)
+    return False
 
 
 @dataclass
-class _DayBuilder:
-    """Mutable accumulator while parsing — converted into a frozen DaySlice at the end."""
-    day_utc:         str
-    started_at:      Optional[str] = None
-    ended_at:        Optional[str] = None
-    user_turns:      int           = 0
-    assistant_turns: int           = 0
-    active_seconds:  float         = 0.0
-    records:         List[dict]    = field(default_factory=list)
+class _SegBuilder:
+    """Mutable accumulator while parsing — frozen into a Segment at the end."""
+    segment_started_at: str
+    ended_at:           Optional[str] = None
+    user_turns:         int           = 0
+    assistant_turns:    int           = 0
+    active_seconds:     float         = 0.0
+    records:            List[Tuple[Optional[str], _NormRecord]] = field(default_factory=list)
+
+
+def _add_turn(builder: _SegBuilder, ts: Optional[str], rec: _NormRecord) -> None:
+    if rec.is_user:
+        builder.user_turns += 1
+    else:
+        builder.assistant_turns += 1
+    builder.records.append((ts, rec))
 
 
 def _infer_agent(jsonl_path: Path) -> str:
-    """Heuristic: which agent wrote this JSONL?"""
     parts = {p.name for p in jsonl_path.parents}
     if "projects" in parts and ".claude" in parts:
         return "claude_code"
@@ -270,7 +312,7 @@ def _infer_agent(jsonl_path: Path) -> str:
 
 
 def _iter_records(path: Path) -> Iterator[dict]:
-    """Yield each well-formed JSON record. Silent on partial writes / IO errors."""
+    """Yield each well-formed JSON object. Silent on partial writes / IO errors."""
     try:
         fh = path.open("rb")
     except (FileNotFoundError, PermissionError, OSError) as exc:
@@ -279,9 +321,11 @@ def _iter_records(path: Path) -> Iterator[dict]:
     try:
         for raw in fh:
             try:
-                yield json.loads(raw)
+                obj = json.loads(raw)
             except Exception:
                 continue
+            if isinstance(obj, dict):
+                yield obj
     except OSError as exc:
         log.debug("read error on %s: %s", path, exc)
         return
@@ -292,33 +336,109 @@ def _iter_records(path: Path) -> Iterator[dict]:
             pass
 
 
+def _iter_normalised(path: Path, *, agent: str) -> Iterator[_NormRecord]:
+    """Yield canonical records for one source JSONL (agent-aware)."""
+    if agent == "codex":
+        yield from _iter_codex(path)
+    else:
+        yield from _iter_claude(path)
+
+
+def _iter_claude(path: Path) -> Iterator[_NormRecord]:
+    """Normalise Claude Code records. Sidechain/meta carry a timestamp (so they
+    participate in gap/segment accounting) but are not conversational turns."""
+    for raw in _iter_records(path):
+        ts = raw.get("timestamp") if isinstance(raw.get("timestamp"), str) else None
+        cwd = raw.get("cwd") if isinstance(raw.get("cwd"), str) else None
+        rtype = raw.get("type")
+
+        if raw.get("isSidechain") or raw.get("isMeta") or rtype not in ("user", "assistant"):
+            yield _NormRecord(ts, cwd, is_turn=False, is_user=False, role_label=None, body="")
+            continue
+
+        msg = raw.get("message") or {}
+        role_raw = msg.get("role") or rtype
+        is_user = role_raw == "user"
+        label = role_raw if is_user else _CLAUDE_ASSISTANT_LABEL
+        content = msg.get("content", "")
+        yield _NormRecord(
+            ts, cwd, is_turn=True, is_user=is_user, role_label=label,
+            body=_format_claude_content(content),
+            is_user_prompt=is_user and _is_real_user_prompt(content),
+        )
+
+
+def _iter_codex(path: Path) -> Iterator[_NormRecord]:
+    """Normalise Codex rollout records. Conversational turns are the
+    `event_msg` `user_message` / `agent_message` events; everything else
+    (session_meta, response_item, turn_context, token_count, …) is non-turn
+    but still carries a timestamp for gap/segment accounting."""
+    for raw in _iter_records(path):
+        ts = raw.get("timestamp") if isinstance(raw.get("timestamp"), str) else None
+        payload = raw.get("payload") if isinstance(raw.get("payload"), dict) else {}
+        cwd = payload.get("cwd") if isinstance(payload.get("cwd"), str) else None
+
+        if raw.get("type") != "event_msg":
+            yield _NormRecord(ts, cwd, is_turn=False, is_user=False, role_label=None, body="")
+            continue
+
+        sub = payload.get("type")
+        if sub == "user_message":
+            yield _NormRecord(ts, cwd, is_turn=True, is_user=True, role_label="user",
+                              body=_format_codex_message(payload.get("message", "")),
+                              is_user_prompt=True)
+        elif sub == "agent_message":
+            yield _NormRecord(ts, cwd, is_turn=True, is_user=False, role_label=_CODEX_ASSISTANT_LABEL,
+                              body=_format_codex_message(payload.get("message", "")))
+        else:
+            yield _NormRecord(ts, cwd, is_turn=False, is_user=False, role_label=None, body="")
+
+
 def _parse_iso(ts: str) -> datetime:
-    """Parse the JSONL's ISO-8601 timestamp (with 'Z' suffix) into an aware datetime."""
     dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     return dt
 
 
+def iso_utc(dt: datetime) -> str:
+    """Canonical app_sessions timestamp: ISO-8601 UTC, microseconds, '+00:00'.
+
+    Matches the Rust ETL's chrono RFC3339 output so every started_at / ended_at /
+    segment_started_at in the table shares one lexical shape. A UTC offset string
+    is fixed-width, so plain string comparison stays chronological.
+    """
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f+00:00")
+
+
+def norm_iso(ts: str) -> str:
+    """Normalise any ISO string (…Z / …±offset, any precision) to iso_utc().
+
+    Falls back to the input unchanged if it can't be parsed, so a malformed
+    source timestamp is never silently dropped.
+    """
+    try:
+        return iso_utc(_parse_iso(ts))
+    except (ValueError, TypeError):
+        return ts
+
+
 # ──────────────────────── Transcript rendering ─────────────────────────────────
 
 
-def _render_records(records: List[dict]) -> str:
-    """Flatten a pre-filtered list of user/assistant records to a transcript."""
+def _render_records(records: List[Tuple[Optional[str], _NormRecord]]) -> str:
+    """Flatten (timestamp, record) pairs to a timestamped transcript:
+    `[<ISO ts>] [role] body` per turn, so the summariser can reason about time."""
     blocks: List[str] = []
-    for rec in records:
-        msg = rec.get("message") or {}
-        rtype = rec.get("type")
-        role_raw = msg.get("role") or rtype
-        label = _ASSISTANT_LABEL if role_raw == "assistant" else role_raw
-        body = _format_message_content(msg.get("content", ""))
-        if body.strip():
-            blocks.append(f"[{label}] {body}")
+    for ts, rec in records:
+        if rec.body.strip():
+            prefix = f"[{ts}] " if ts else ""
+            blocks.append(f"{prefix}[{rec.role_label or 'user'}] {rec.body}")
     return "\n\n".join(blocks)
 
 
-def _format_message_content(content) -> str:
-    """Render a single `message.content` (string or list of typed blocks) to text."""
+def _format_claude_content(content) -> str:
+    """Render Claude `message.content` (string or typed blocks) to text."""
     if isinstance(content, str):
         return content
     if not isinstance(content, list):
@@ -340,8 +460,7 @@ def _format_message_content(content) -> str:
             tr = block.get("content", "")
             if isinstance(tr, list):
                 tr = "\n".join(
-                    p.get("text", "") if isinstance(p, dict) else str(p)
-                    for p in tr
+                    p.get("text", "") if isinstance(p, dict) else str(p) for p in tr
                 )
             tr_str = str(tr).strip()
             if len(tr_str) > _TOOL_RESULT_CAP:
@@ -351,4 +470,25 @@ def _format_message_content(content) -> str:
             t = block.get("thinking", "")
             if t:
                 parts.append(f"[thinking] {t}")
+    return "\n".join(p for p in parts if p)
+
+
+def _format_codex_message(content) -> str:
+    """Render a Codex event_msg message payload into plain transcript text."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: List[str] = []
+    for block in content:
+        if isinstance(block, dict):
+            text = block.get("text")
+            if isinstance(text, str) and text:
+                parts.append(text)
+                continue
+            nested = block.get("content")
+            if isinstance(nested, str) and nested:
+                parts.append(nested)
+        elif isinstance(block, str):
+            parts.append(block)
     return "\n".join(p for p in parts if p)

--- a/services/coding_agent_indexer/register.py
+++ b/services/coding_agent_indexer/register.py
@@ -1,38 +1,53 @@
 """The single entry point both the hook and the daemon use.
 
-`register_ended_session(jsonl_path)` parses the JSONL into per-day
-slices, resolves the host terminal/IDE once, and UPSERTs one
-`app_sessions` row per slice. Idempotent at the DB layer — duplicate
-calls update mutable fields in place, never raise.
+`register_ended_session(jsonl_path)` parses the JSONL into idle-gap
+segments, resolves the host terminal/IDE once, and UPSERTs one
+`app_sessions` row per segment — sealing the settled ones. Idempotent at
+the DB layer: duplicate calls refresh live rows in place and no-op on
+sealed rows, never raise.
 
-A long-running session that spans multiple calendar days produces
-multiple rows here, one per local day, so PM-update windowing
-attributes time to the day the work actually happened.
+Seal decision per segment:
+  * Every segment EXCEPT the last is sealed — a later segment exists, so
+    the >1h gap that ended it already happened.
+  * The LAST segment is sealed iff the caller says the session ended
+    (`session_ended=True`, the SessionEnd-hook path) OR its last message
+    is already older than `config.SEGMENT_GAP_SECONDS` (settled by idle).
+    Otherwise it stays LIVE and is refreshed on the next poll.
 
-This module deliberately knows nothing about how it was invoked: the
-hook process passes a path it got from Claude Code's SessionEnd payload;
-the poller passes a path it found by scanning. Both go through here.
+Before parsing, we fetch the session's sealed high-water mark and pass it
+as `start_after_ts`, so already-sealed content is excluded and any newer
+record opens a fresh segment — the invariant that keeps a session safe to
+resume shortly after its SessionEnd hook fired.
+
+Timestamps are UTC (ISO-8601 `...Z`), matching what the JSONLs store.
+
+This module knows nothing about how it was invoked: the hook passes a path
+from Claude Code's SessionEnd payload (session_ended defaults True); the
+poller passes a path it scanned (session_ended=False).
 """
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import List, Optional
 
-from coding_agent_indexer import db, host_app
+from coding_agent_indexer import config, db, host_app
 from coding_agent_indexer.jsonl_meta import (
+    Segment,
     SessionMeta,
-    parse_session_slices,
+    iso_utc,
+    parse_session_segments,
 )
 
 log = logging.getLogger(__name__)
 
 
 class RegisterOutcome(str, Enum):
-    INSERTED      = "inserted"        # at least one slice written (INSERT or UPDATE)
-    SKIPPED_EMPTY = "skipped_empty"   # session has zero turns / no timestamps / no slices
+    INSERTED      = "inserted"        # at least one segment written (INSERT or UPDATE)
+    SKIPPED_EMPTY = "skipped_empty"   # no turns / no timestamps / no segments / all sealed
     SKIPPED_FORK  = "skipped_fork"    # this is one of our summariser forks
     FAILED        = "failed"          # unexpected exception
 
@@ -43,7 +58,8 @@ class RegisterResult:
     session_uuid: str
     host_app:     str
     meta:         Optional[SessionMeta]                    # overall session metadata
-    row_ids:      List[int] = field(default_factory=list)  # one id per day slice written
+    row_ids:      List[int] = field(default_factory=list)  # one id per segment written
+    sealed_ids:   List[int] = field(default_factory=list)  # subset of row_ids that were sealed
     error:        Optional[str] = None
 
     @property
@@ -55,74 +71,113 @@ class RegisterResult:
 def register_ended_session(
     jsonl_path: Path,
     *,
+    session_ended: bool = True,
     fork_skip_list: Optional[set[str]] = None,
+    now: Optional[datetime] = None,
 ) -> RegisterResult:
-    """Parse → resolve host → UPSERT one row per day slice.
+    """Parse → resolve host → UPSERT one row per segment, sealing settled ones.
 
     Idempotent. Always returns a result; never raises.
 
     Args:
         jsonl_path: Path to the session's JSONL file.
-        fork_skip_list: Optional set of session_uuids the caller already
-            knows are summariser forks (don't re-register them as user
-            sessions). The daemon passes its in-memory skip-list here.
+        session_ended: True when the caller knows the session ended (the
+            SessionEnd-hook path; default) → the last segment seals
+            immediately. The poller passes False so an actively-growing
+            last segment stays live until it idles out.
+        fork_skip_list: session_uuids known to be summariser forks — skip.
+        now: reference time for the idle/seal check (default: utcnow).
 
     Returns:
-        `RegisterResult` describing the outcome. `row_ids` contains the
-        id of every (uuid, day) row written or refreshed.
+        `RegisterResult`; `row_ids` = every segment row written/refreshed,
+        `sealed_ids` = the subset that are now sealed.
     """
     session_uuid = jsonl_path.stem
 
     if fork_skip_list and session_uuid in fork_skip_list:
         return _result(RegisterOutcome.SKIPPED_FORK, session_uuid, "", None)
 
+    now_dt = now or datetime.now(timezone.utc)
+    now_iso = _utc_iso(now_dt)
+
     try:
-        meta, slices = parse_session_slices(jsonl_path)
+        start_after = db.sealed_high_water(session_uuid)
+        meta, segments = parse_session_segments(jsonl_path, start_after_ts=start_after)
     except Exception as exc:                                 # noqa: BLE001
         log.exception("parse failed for %s", jsonl_path)
         return _result(RegisterOutcome.FAILED, session_uuid, "", None, error=str(exc))
 
-    if not meta.is_valid or not slices:
-        # Empty / metadata-only JSONLs are normal, especially for Codex
-        # rollout artifacts. Keep this at DEBUG so the daemon log stays
-        # high-signal; operators still get per-tick skipped counts.
+    valid = [s for s in segments if s.is_valid]
+    if not valid:
+        # Empty / metadata-only / fully-sealed-already JSONLs are normal.
+        # DEBUG keeps the daemon log high-signal; per-tick counts still show.
         log.debug(
-            "skip empty session: uuid=%s user_turns=%d asst_turns=%d slices=%d started=%r ended=%r",
+            "skip empty session: uuid=%s user=%d asst=%d segments=%d started=%r ended=%r",
             session_uuid, meta.user_turns, meta.assistant_turns,
-            len(slices), meta.started_at, meta.ended_at,
+            len(segments), meta.started_at, meta.ended_at,
         )
         return _result(RegisterOutcome.SKIPPED_EMPTY, session_uuid, "", meta)
 
     resolved_host = host_app.detect_host_app()
 
-    # One UPSERT per day slice. Per-slice failures don't abort the rest —
-    # we want partial progress on a session even if one day's slice is
-    # malformed. Aggregate written ids for the result.
+    # One UPSERT per segment. Per-segment failures don't abort the rest.
     row_ids: List[int] = []
-    for slice_ in slices:
+    sealed_ids: List[int] = []
+    for seg in valid:
+        sealed = _should_seal(seg, session_ended=session_ended, now_dt=now_dt)
         try:
-            row_id = db.upsert_session_day_slice(slice_)
-        except Exception:                                    # noqa: BLE001
-            log.exception("upsert failed for %s day=%s", session_uuid, slice_.day_utc)
-            continue
-        if row_id is not None:
-            row_ids.append(row_id)
-            log.info(
-                "registered: agent=%s uuid=%s day=%s host=%s started=%s ended=%s "
-                "active=%ds turns=%d/%d transcript_bytes=%d row_id=%d",
-                slice_.agent, slice_.session_uuid, slice_.day_utc, resolved_host,
-                slice_.started_at, slice_.ended_at, slice_.active_seconds,
-                slice_.user_turns, slice_.assistant_turns,
-                len(slice_.transcript), row_id,
+            row_id = db.upsert_segment(
+                seg, sealed=sealed, sealed_at=now_iso if sealed else None,
             )
+        except Exception:                                    # noqa: BLE001
+            log.exception("upsert failed for %s seg=%s", session_uuid, seg.segment_started_at)
+            continue
+        if row_id is None:
+            continue
+        row_ids.append(row_id)
+        if sealed:
+            sealed_ids.append(row_id)
+        log.info(
+            "registered: agent=%s uuid=%s seg=%s host=%s ended=%s "
+            "active=%ds turns=%d/%d bytes=%d sealed=%s row_id=%d",
+            seg.agent, seg.session_uuid, seg.segment_started_at,
+            resolved_host, seg.ended_at, seg.active_seconds,
+            seg.user_turns, seg.assistant_turns, len(seg.transcript),
+            sealed, row_id,
+        )
 
     if not row_ids:
-        # All slices invalid OR all upserts failed — treat as no-op.
+        # Everything we tried was a no-op (e.g. all keys hit already-sealed rows).
         return _result(RegisterOutcome.SKIPPED_EMPTY, session_uuid, resolved_host, meta)
 
     return _result(
-        RegisterOutcome.INSERTED, session_uuid, resolved_host, meta, row_ids=row_ids,
+        RegisterOutcome.INSERTED, session_uuid, resolved_host, meta,
+        row_ids=row_ids, sealed_ids=sealed_ids,
     )
+
+
+# ──────────────────────── Internals ────────────────────────────────────────────
+
+
+def _should_seal(seg: Segment, *, session_ended: bool, now_dt: datetime) -> bool:
+    """A non-last segment is always sealed; the last seals on end-or-idle."""
+    if not seg.is_last:
+        return True
+    if session_ended:
+        return True
+    try:
+        ended = datetime.fromisoformat(seg.ended_at.replace("Z", "+00:00"))
+        if ended.tzinfo is None:
+            ended = ended.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return False                                         # can't determine idleness → keep live
+    idle = (now_dt - ended).total_seconds()
+    return idle > config.SEGMENT_GAP_SECONDS
+
+
+def _utc_iso(dt: datetime) -> str:
+    """Canonical UTC timestamp (microseconds + '+00:00'); see jsonl_meta.iso_utc."""
+    return iso_utc(dt)
 
 
 def _result(
@@ -132,6 +187,7 @@ def _result(
     meta:           Optional[SessionMeta],
     *,
     row_ids:        Optional[List[int]] = None,
+    sealed_ids:     Optional[List[int]] = None,
     error:          Optional[str] = None,
 ) -> RegisterResult:
     return RegisterResult(
@@ -140,5 +196,6 @@ def _result(
         host_app     = host_app_name,
         meta         = meta,
         row_ids      = list(row_ids) if row_ids else [],
+        sealed_ids   = list(sealed_ids) if sealed_ids else [],
         error        = error,
     )

--- a/services/coding_agent_indexer/tests/test_segmentation.py
+++ b/services/coding_agent_indexer/tests/test_segmentation.py
@@ -1,0 +1,349 @@
+"""Edge-case tests for coding_agent_indexer segmentation + sealing.
+
+These cover the invariants the product depends on:
+  * segments split on >1h idle gaps (strictly greater)
+  * a non-last segment is always sealed; the last seals on end-or-idle
+  * the poll seal-sweep settles open rows without re-parsing
+  * a SEALED row is immutable; content after the sealed high-water always
+    lands in a NEW segment (the resume-after-SessionEnd case)
+  * idempotent re-registration (hook + poll races)
+  * active_seconds is gap-capped; transcript carries timestamps
+
+Run:
+    cd services
+    .venv/bin/python -m pytest coding_agent_indexer/tests/test_segmentation.py -v
+"""
+from __future__ import annotations
+
+import glob
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from coding_agent_indexer import config, db, register
+from coding_agent_indexer.jsonl_meta import iso_utc, parse_session_segments
+
+BASE = datetime(2026, 5, 20, 8, 0, 0, tzinfo=timezone.utc)
+_MIGRATIONS = Path(__file__).resolve().parents[3] / "src" / "migrations"
+
+
+def _iso(dt: datetime) -> str:
+    """Source 'ms + Z' shape that Claude/Codex JSONLs actually write — used to
+    build input records. The parser normalises this to the canonical iso_utc()
+    ('µs + +00:00') for storage, which is what output assertions compare against.
+    """
+    u = dt.astimezone(timezone.utc)
+    return u.strftime("%Y-%m-%dT%H:%M:%S.") + f"{u.microsecond // 1000:03d}Z"
+
+
+def _rec(offset_s: int, role: str, text: str) -> dict:
+    """One Claude Code JSONL record `offset_s` seconds after BASE."""
+    return {
+        "type": role,                       # 'user' | 'assistant'
+        "timestamp": _iso(BASE + timedelta(seconds=offset_s)),
+        "cwd": "/work/proj",
+        "message": {"role": role, "content": text},
+    }
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+
+def _make_db(tmp_path: Path) -> Path:
+    """Build a real meridian.db by applying every migration in order."""
+    dbp = tmp_path / "meridian.db"
+    con = sqlite3.connect(dbp)
+    for m in sorted(glob.glob(str(_MIGRATIONS / "*.sql"))):
+        con.executescript(Path(m).read_text())
+    con.commit()
+    con.close()
+    return dbp
+
+
+@pytest.fixture
+def live_db(tmp_path, monkeypatch):
+    """Point the indexer at a fresh migrated DB and stub host detection."""
+    dbp = _make_db(tmp_path)
+    monkeypatch.setattr(config, "MERIDIAN_DB", dbp)
+    monkeypatch.setattr(
+        "coding_agent_indexer.host_app.detect_host_app", lambda: "TestHost"
+    )
+    return dbp
+
+
+def _claude_jsonl(tmp_path: Path, uuid: str, records: list[dict]) -> Path:
+    """Place a JSONL under a .claude/projects layout so agent inference works."""
+    d = tmp_path / ".claude" / "projects" / "-work-proj"
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"{uuid}.jsonl"
+    _write_jsonl(p, records)
+    return p
+
+
+def _rows(dbp: Path, uuid: str) -> list[sqlite3.Row]:
+    con = sqlite3.connect(dbp)
+    con.row_factory = sqlite3.Row
+    rows = con.execute(
+        "SELECT * FROM app_sessions WHERE claude_session_uuid=? ORDER BY segment_started_at",
+        (uuid,),
+    ).fetchall()
+    con.close()
+    return rows
+
+
+# ──────────────────────── Parser-level segmentation ─────────────────────────────
+
+
+def test_single_continuous_segment(tmp_path):
+    p = _claude_jsonl(tmp_path, "u1", [
+        _rec(0, "user", "hi"),
+        _rec(60, "assistant", "working"),
+        _rec(120, "user", "thanks"),
+    ])
+    _meta, segs = parse_session_segments(p)
+    assert len(segs) == 1
+    assert segs[0].user_turns == 2 and segs[0].assistant_turns == 1
+    assert segs[0].is_last is True
+    assert segs[0].segment_started_at == iso_utc(BASE)
+
+
+def test_split_on_gap_over_threshold(tmp_path):
+    # 2h gap (7200s > 3600s) → two segments.
+    p = _claude_jsonl(tmp_path, "u2", [
+        _rec(0, "user", "morning work"),
+        _rec(60, "assistant", "done"),
+        _rec(60 + 7200, "user", "afternoon work"),
+        _rec(60 + 7200 + 30, "assistant", "done2"),
+    ])
+    _meta, segs = parse_session_segments(p)
+    assert len(segs) == 2
+    assert segs[0].is_last is False and segs[1].is_last is True
+    assert segs[0].segment_started_at == iso_utc(BASE)
+    assert segs[1].segment_started_at == iso_utc(BASE + timedelta(seconds=7260))
+
+
+def test_no_split_at_exact_threshold(tmp_path):
+    # Gap of EXACTLY 3600s must NOT gap-split (strictly greater splits).
+    # Disable the time-box here so we test the gap rule in isolation.
+    p = _claude_jsonl(tmp_path, "u3", [
+        _rec(0, "user", "a"),
+        _rec(3600, "assistant", "b"),
+    ])
+    _meta, segs = parse_session_segments(p, max_segment_seconds=0)
+    assert len(segs) == 1
+
+
+def test_time_box_splits_continuous_session(tmp_path):
+    # Records every 10 min for 2.5h — NO >1h idle gap, so only the 1h time-box
+    # splits it. Long continuous sessions become predictable hourly chunks.
+    recs = [_rec(i * 600, "user" if i % 2 == 0 else "assistant", f"m{i}") for i in range(16)]
+    p = _claude_jsonl(tmp_path, "tb", recs)
+    _meta, segs = parse_session_segments(p, segment_gap_seconds=3600, max_segment_seconds=3600)
+    assert len(segs) == 3                                    # 0–1h, 1–2h, 2–2.5h
+    for s in segs:
+        span = (datetime.fromisoformat(s.ended_at.replace("Z", "+00:00"))
+                - datetime.fromisoformat(s.started_at.replace("Z", "+00:00"))).total_seconds()
+        assert span < 3600                                   # no chunk exceeds the box
+    assert segs[0].is_last is False and segs[-1].is_last is True
+
+
+def test_time_box_disabled_keeps_one_segment(tmp_path):
+    recs = [_rec(i * 600, "user", f"m{i}") for i in range(16)]
+    p = _claude_jsonl(tmp_path, "tb0", recs)
+    _meta, segs = parse_session_segments(p, segment_gap_seconds=3600, max_segment_seconds=0)
+    assert len(segs) == 1                                    # box off → one continuous segment
+
+
+def test_active_seconds_capped(tmp_path):
+    # One 50-min gap (<1h, same segment) must be capped at 300s, not counted whole.
+    p = _claude_jsonl(tmp_path, "u4", [
+        _rec(0, "user", "a"),
+        _rec(3000, "assistant", "b"),   # 50 min later
+    ])
+    _meta, segs = parse_session_segments(p)
+    assert len(segs) == 1
+    assert segs[0].active_seconds == config.ACTIVE_TIME_GAP_CAP_SECONDS  # 300, not 3000
+
+
+def test_timestamps_in_transcript(tmp_path):
+    p = _claude_jsonl(tmp_path, "u5", [_rec(0, "user", "hello world")])
+    _meta, segs = parse_session_segments(p)
+    assert _iso(BASE) in segs[0].transcript
+    assert "[user] hello world" in segs[0].transcript
+
+
+def test_empty_file_has_no_segments(tmp_path):
+    p = _claude_jsonl(tmp_path, "u6", [])
+    meta, segs = parse_session_segments(p)
+    assert segs == [] and meta.is_valid is False
+
+
+# ──────────────────────── Codex schema parsing ─────────────────────────────────
+
+
+def _codex_jsonl(tmp_path, uuid, records):
+    d = tmp_path / ".codex" / "sessions" / "2026" / "05" / "20"
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"rollout-{uuid}.jsonl"
+    _write_jsonl(p, records)
+    return p
+
+
+def _cx(offset_s, rtype, payload):
+    return {"type": rtype, "timestamp": _iso(BASE + timedelta(seconds=offset_s)), "payload": payload}
+
+
+def test_codex_records_parse_to_turns(tmp_path):
+    p = _codex_jsonl(tmp_path, "cx1", [
+        _cx(0,  "session_meta", {"id": "cx1", "cwd": "/work/proj"}),
+        _cx(1,  "event_msg",    {"type": "user_message", "message": "add a test"}),
+        _cx(5,  "response_item", {"type": "reasoning"}),                      # non-turn, still ticks time
+        _cx(8,  "event_msg",    {"type": "agent_message", "message": "wrote test_x.py"}),
+        _cx(60, "event_msg",    {"type": "user_message", "message": "run it"}),
+        _cx(63, "event_msg",    {"type": "agent_message", "message": "3 passed"}),
+    ])
+    meta, segs = parse_session_segments(p, agent="codex")
+    assert meta.user_turns == 2 and meta.assistant_turns == 2
+    assert len(segs) == 1 and segs[0].cwd == "/work/proj"
+    assert "[codex] wrote test_x.py" in segs[0].transcript
+    assert _iso(BASE + timedelta(seconds=1)) in segs[0].transcript     # timestamped
+
+
+def test_codex_splits_on_gap(tmp_path):
+    p = _codex_jsonl(tmp_path, "cx2", [
+        _cx(0,        "event_msg", {"type": "user_message", "message": "morning"}),
+        _cx(30,       "event_msg", {"type": "agent_message", "message": "done"}),
+        _cx(30 + 7200, "event_msg", {"type": "user_message", "message": "afternoon"}),   # >1h gap
+        _cx(30 + 7230, "event_msg", {"type": "agent_message", "message": "done2"}),
+    ])
+    _meta, segs = parse_session_segments(p, agent="codex")
+    assert len(segs) == 2
+
+
+# ──────────────────────── Registration + sealing (DB) ───────────────────────────
+
+
+def test_last_segment_live_until_idle_or_ended(live_db):
+    p = _claude_jsonl(live_db.parent, "s1", [
+        _rec(0, "user", "a"), _rec(60, "assistant", "b"),
+    ])
+    # Poll path, only 5 min elapsed → last segment stays LIVE.
+    res = register.register_ended_session(
+        p, session_ended=False, now=BASE + timedelta(minutes=5),
+    )
+    assert res.outcome == register.RegisterOutcome.INSERTED
+    rows = _rows(live_db, "s1")
+    assert len(rows) == 1
+    assert rows[0]["sealed_at"] is None
+    assert rows[0]["task_method"] == db.TASK_METHOD_LIVE
+
+
+def test_session_ended_seals_last(live_db):
+    p = _claude_jsonl(live_db.parent, "s2", [
+        _rec(0, "user", "a"), _rec(60, "assistant", "b"),
+    ])
+    res = register.register_ended_session(
+        p, session_ended=True, now=BASE + timedelta(minutes=5),
+    )
+    rows = _rows(live_db, "s2")
+    assert len(rows) == 1
+    assert rows[0]["sealed_at"] is not None
+    assert rows[0]["task_method"] == db.TASK_METHOD_PENDING
+    assert res.sealed_ids == [rows[0]["id"]]
+
+
+def test_last_segment_seals_on_idle(live_db):
+    p = _claude_jsonl(live_db.parent, "s3", [
+        _rec(0, "user", "a"), _rec(60, "assistant", "b"),
+    ])
+    # 2h after last message, not explicitly ended → idle seal.
+    register.register_ended_session(p, session_ended=False, now=BASE + timedelta(hours=2))
+    rows = _rows(live_db, "s3")
+    assert rows[0]["sealed_at"] is not None
+    assert rows[0]["task_method"] == db.TASK_METHOD_PENDING
+
+
+def test_seal_sweep_settles_open_row(live_db):
+    p = _claude_jsonl(live_db.parent, "s4", [
+        _rec(0, "user", "a"), _rec(60, "assistant", "b"),
+    ])
+    register.register_ended_session(p, session_ended=False, now=BASE + timedelta(minutes=5))
+    assert _rows(live_db, "s4")[0]["sealed_at"] is None       # still live
+    # Sweep 2h later seals it without re-parsing.
+    n = db.seal_stale_open_rows(now_iso=_iso(BASE + timedelta(hours=2)), idle_seconds=3600)
+    assert n == 1
+    row = _rows(live_db, "s4")[0]
+    assert row["sealed_at"] is not None
+    assert row["task_method"] == db.TASK_METHOD_PENDING
+
+
+def test_resume_after_seal_creates_new_segment(live_db):
+    """The critical edge: SessionEnd seals, user resumes <1h later → new row,
+    sealed row untouched, nothing lost."""
+    p = _claude_jsonl(live_db.parent, "s5", [
+        _rec(0, "user", "first"), _rec(60, "assistant", "done"),
+    ])
+    register.register_ended_session(p, session_ended=True, now=BASE + timedelta(minutes=2))
+    sealed_row = _rows(live_db, "s5")[0]
+    assert sealed_row["sealed_at"] is not None
+
+    # Resume only 29 min after the sealed segment's end (gap < 1h).
+    _write_jsonl(p, [
+        _rec(0, "user", "first"), _rec(60, "assistant", "done"),
+        _rec(60 + 1740, "user", "resumed"), _rec(60 + 1740 + 30, "assistant", "more"),
+    ])
+    register.register_ended_session(p, session_ended=False, now=BASE + timedelta(minutes=40))
+
+    rows = _rows(live_db, "s5")
+    assert len(rows) == 2, "resume must create a NEW segment, not mutate the sealed one"
+    # Original sealed row is unchanged (still ends at the original last msg).
+    assert rows[0]["sealed_at"] == sealed_row["sealed_at"]
+    assert rows[0]["ended_at"] == sealed_row["ended_at"]
+    # New row covers only the resumed turns, and is live.
+    assert rows[1]["segment_started_at"] == iso_utc(BASE + timedelta(seconds=1800))
+    assert rows[1]["sealed_at"] is None
+    assert "resumed" in rows[1]["session_text"]
+    assert "first" not in rows[1]["session_text"]            # no duplication of sealed content
+
+
+def test_idempotent_reregister_live(live_db):
+    """Two poll re-scans of an unchanged LIVE session → same row, no duplicate."""
+    p = _claude_jsonl(live_db.parent, "s6", [
+        _rec(0, "user", "a"), _rec(60, "assistant", "b"),
+    ])
+    r1 = register.register_ended_session(p, session_ended=False, now=BASE + timedelta(minutes=5))
+    r2 = register.register_ended_session(p, session_ended=False, now=BASE + timedelta(minutes=6))
+    assert r1.row_ids == r2.row_ids == [_rows(live_db, "s6")[0]["id"]]
+    assert len(_rows(live_db, "s6")) == 1
+
+
+def test_reregister_sealed_is_noop(live_db):
+    """Re-registering an already-sealed session finds nothing new (high-water
+    excludes all sealed content) and creates no duplicate."""
+    p = _claude_jsonl(live_db.parent, "s6b", [
+        _rec(0, "user", "a"), _rec(60, "assistant", "b"),
+    ])
+    register.register_ended_session(p, session_ended=True, now=BASE + timedelta(minutes=5))
+    r2 = register.register_ended_session(p, session_ended=True, now=BASE + timedelta(minutes=6))
+    assert r2.outcome == register.RegisterOutcome.SKIPPED_EMPTY
+    assert len(_rows(live_db, "s6b")) == 1
+
+
+def test_sealed_row_not_mutated_by_later_register(live_db):
+    p = _claude_jsonl(live_db.parent, "s7", [
+        _rec(0, "user", "a"), _rec(60, "assistant", "b"),
+    ])
+    register.register_ended_session(p, session_ended=True, now=BASE + timedelta(minutes=5))
+    before = _rows(live_db, "s7")[0]
+    # A poll re-scan of the unchanged file must not touch the sealed row.
+    register.register_ended_session(p, session_ended=False, now=BASE + timedelta(hours=3))
+    after = _rows(live_db, "s7")[0]
+    assert dict(after) == dict(before)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/services/coding_agent_summariser/__init__.py
+++ b/services/coding_agent_summariser/__init__.py
@@ -1,0 +1,29 @@
+"""coding_agent_summariser — fills `session_summary` for sealed coding rows.
+
+Phase 2 of the coding-agent pipeline. The `coding_agent_indexer` writes sealed,
+immutable `app_sessions` rows for each Claude Code work-burst (see
+[[project_indexer_segmentation]]) with `task_method='pending_summariser'`. This
+package turns each into a factual prose `session_summary` that the PM-update
+workflow consumes.
+
+How it summarises (decided empirically — see [[project_coding_session_summariser]]):
+  * Pipe the already-rendered `session_text` transcript to `claude -p` running
+    the native `session-summary` skill with `--json-schema`, using the user's
+    Claude subscription (no API-key billing). A prior burst's summary is passed
+    as context so continued sessions read coherently.
+  * On rate/usage limit (or no `claude` CLI), fall back to the local MLX server's
+    OpenAI-compatible `/v1/chat/completions`.
+
+Guarantees:
+  * **Idempotent** — only sealed rows with `session_summary IS NULL` are picked;
+    the write is `WHERE session_summary IS NULL` so concurrent runs / restarts
+    never double-write or clobber.
+  * **Crash-safe** — the summary is written only on success; an interrupted row
+    stays NULL and is retried next tick. No cursor, no lost work.
+  * **Bounded** — one transcript in memory at a time, sequential calls, a cap
+    per tick, and a subprocess timeout; the daemon is idle (event-wait) between
+    ticks. Cheap on CPU and memory.
+
+Scope: Claude Code sessions only. Does NOT link sessions to Jira tickets — that
+is the next phase.
+"""

--- a/services/coding_agent_summariser/claude_runner.py
+++ b/services/coding_agent_summariser/claude_runner.py
@@ -1,0 +1,108 @@
+"""Run `claude -p` with the session-summary skill and structured output.
+
+Returns the validated `{summary, blockers}` dict, or raises:
+  * `RateLimited`     — subscription usage/rate limit hit (caller falls back to MLX)
+  * `SummariserError` — anything else (missing CLI, timeout, bad output);
+                        caller leaves the row NULL and retries next tick.
+
+Auth: uses the user's Claude subscription. We explicitly drop ANTHROPIC_API_KEY
+from the child env so a stray key can't silently switch us to metered API
+billing, and set MERIDIAN_SUMMARISER=1 so the indexer's SessionEnd hook can
+ignore the throwaway session this call spawns. `--no-session-persistence` means
+no JSONL is written for it either.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from typing import Optional
+
+from coding_agent_summariser import config
+from coding_agent_summariser.prompts import (
+    SUMMARY_SCHEMA,
+    first_line,
+    looks_rate_limited,
+)
+
+log = logging.getLogger(__name__)
+
+
+class SummariserError(RuntimeError):
+    """Recoverable failure — leave the row unsummarised and retry later."""
+
+
+class RateLimited(SummariserError):
+    """Subscription rate/usage limit — switch to the MLX fallback."""
+
+
+def run_claude(
+    stdin_text: str,
+    *,
+    model: Optional[str] = None,
+    skill: Optional[str] = None,
+    timeout: Optional[int] = None,
+) -> dict:
+    """Invoke `claude -p /<skill>` over stdin; return {summary, blockers}."""
+    model = model or config.CLAUDE_MODEL
+    skill = skill or config.SKILL_NAME
+    timeout = timeout or config.CLAUDE_TIMEOUT_S
+
+    cmd = [
+        "claude", "-p",
+        f"/{skill} Summarise the coding-session transcript provided on stdin.",
+        "--output-format", "json",
+        "--json-schema", json.dumps(SUMMARY_SCHEMA),
+        "--model", model,
+        "--no-session-persistence",
+        "--strict-mcp-config",          # drop MCP overhead; keeps skills working
+    ]
+
+    env = os.environ.copy()
+    env.pop("ANTHROPIC_API_KEY", None)  # force subscription auth, never metered API
+    env["MERIDIAN_SUMMARISER"] = "1"    # let the indexer hook skip our spawned session
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=str(config.MERIDIAN_HOME),   # neutral cwd — no project CLAUDE.md to load
+            env=env,
+        )
+    except FileNotFoundError as exc:
+        raise SummariserError("claude CLI not found on PATH") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise SummariserError(f"claude -p timed out after {timeout}s") from exc
+
+    if proc.returncode != 0:
+        blob = f"{proc.stderr}\n{proc.stdout}"
+        if looks_rate_limited(blob):
+            raise RateLimited(first_line(proc.stderr) or "rate/usage limit")
+        raise SummariserError(
+            f"claude exited {proc.returncode}: {first_line(proc.stderr) or first_line(proc.stdout)}"
+        )
+
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise SummariserError(f"claude output not JSON: {proc.stdout[:200]!r}") from exc
+
+    # Even on exit 0 the result envelope can report an error (e.g. mid-run limit).
+    if payload.get("is_error") or payload.get("subtype") not in (None, "success"):
+        detail = str(payload.get("result") or payload.get("subtype") or "error")
+        if looks_rate_limited(detail):
+            raise RateLimited(detail[:200])
+        raise SummariserError(f"claude result error: {detail[:200]}")
+
+    structured = payload.get("structured_output")
+    if not isinstance(structured, dict) or not (structured.get("summary") or "").strip():
+        raise SummariserError("claude returned no usable structured summary")
+
+    return {
+        "summary": structured["summary"].strip(),
+        "blockers": [b for b in structured.get("blockers", []) if isinstance(b, str)],
+    }

--- a/services/coding_agent_summariser/cli.py
+++ b/services/coding_agent_summariser/cli.py
@@ -1,0 +1,104 @@
+"""Debug / one-shot CLI for the summariser.
+
+    # Drain one batch (same as a daemon tick), write to DB
+    python -m coding_agent_summariser.cli --once
+
+    # Summarise one session's pending segments
+    python -m coding_agent_summariser.cli --session <uuid>
+
+    # Eyeball output without writing (any mode)
+    python -m coding_agent_summariser.cli --session <uuid> --dry-run
+    python -m coding_agent_summariser.cli --row <id> --dry-run
+
+All modes are idempotent against the DB (write is `WHERE session_summary IS
+NULL`); `--dry-run` never writes.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from typing import List, Optional
+
+from agents import observability
+from coding_agent_summariser import config, db, summariser
+from coding_agent_summariser.db import PendingRow
+
+log = logging.getLogger(__name__)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="coding_agent_summariser.cli",
+        description="Generate session_summary for sealed coding-agent segments.",
+    )
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--once", action="store_true",
+                   help="Summarise one batch for a single day (default today), like a daemon tick.")
+    g.add_argument("--session", metavar="UUID", help="Summarise this session's pending segments.")
+    g.add_argument("--row", type=int, metavar="ID", help="Summarise one app_sessions row by id.")
+    p.add_argument("--day", metavar="YYYY-MM-DD",
+                   help="Day to backfill with --once (default: today). Backfills only that day.")
+    p.add_argument("--limit", type=int, default=config.BATCH_PER_TICK,
+                   help=f"Max rows to process (default {config.BATCH_PER_TICK}).")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Generate but do not write; print the summary.")
+    return p
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    observability.setup("meridian-coding-agent-summariser-cli")
+    db.ensure_schema()
+    args = build_parser().parse_args(argv)
+
+    if args.row is not None:
+        row = db.fetch_by_id(args.row)
+        rows: List[PendingRow] = [row] if row else []
+        if not rows:
+            print(f"no coding-agent row with id {args.row}", file=sys.stderr)
+            observability.shutdown()
+            return 2
+    elif args.session:
+        rows = db.fetch_pending(args.limit, session_uuid=args.session)
+    else:  # --once — scoped to a single day (today unless --day given)
+        day = args.day or config.today_local()
+        print(f"backfilling day {day}")
+        rows = db.fetch_pending(args.limit, day=day)
+
+    if not rows:
+        print("nothing to summarise (queue empty for this selection)")
+        observability.shutdown()
+        return 0
+
+    wrote = failed = 0
+    for row in rows:
+        outcome = summariser.summarise_one(row, write=not args.dry_run)
+        _print(row, outcome, dry_run=args.dry_run)
+        if outcome.written:
+            wrote += 1
+        elif outcome.error:
+            failed += 1
+        if outcome.rate_limited and not outcome.written:
+            print("  (rate-limited — stopping)", file=sys.stderr)
+            break
+
+    if not args.dry_run:
+        print(f"\n=== done: wrote={wrote} failed={failed} of {len(rows)} ===")
+    observability.shutdown()
+    return 1 if failed and not wrote else 0
+
+
+def _print(row: PendingRow, outcome, *, dry_run: bool) -> None:
+    head = (f"row {row.id} · {row.session_uuid[:8]} · seg {row.segment_started_at} "
+            f"· {row.duration_s}s · {row.text_bytes}B")
+    if outcome.error:
+        print(f"✗ {head}\n  error: {outcome.error}")
+        return
+    tag = "[dry-run]" if dry_run else ("[wrote]" if outcome.written else "[noop]")
+    print(f"✓ {tag} {head}  via {outcome.source.value}")
+    if dry_run and outcome.summary:
+        print("  " + outcome.summary.replace("\n", "\n  "))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/coding_agent_summariser/codex_runner.py
+++ b/services/coding_agent_summariser/codex_runner.py
@@ -1,0 +1,121 @@
+"""Run `codex exec` to summarise a Codex session (symmetry with claude_runner).
+
+Codex sessions are summarised with the user's own Codex CLI / auth, just as
+Claude sessions use `claude -p`. Returns the validated `{summary, blockers}`
+dict, or raises `RateLimited` (Codex usage limit → caller falls back to MLX) /
+`SummariserError` (anything else → retry later).
+
+Flags chosen for a safe, side-effect-free, non-interactive run:
+  * `-s read-only`            — the agent may not edit anything
+  * `--skip-git-repo-check`   — we run from ~/.meridian, not a git repo
+  * `--ephemeral`             — no session file written → indexer won't re-pick it
+  * `--output-schema FILE`    — final message conforms to SUMMARY_SCHEMA
+  * `-o FILE`                 — capture that final message cleanly
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional, Tuple
+
+from coding_agent_summariser import config
+from coding_agent_summariser.claude_runner import RateLimited, SummariserError
+from coding_agent_summariser.prompts import (
+    SUMMARY_INSTRUCTION,
+    SUMMARY_SCHEMA,
+    first_line,
+    looks_rate_limited,
+)
+
+log = logging.getLogger(__name__)
+
+_PROMPT = SUMMARY_INSTRUCTION + " Summarise the coding-session transcript provided on stdin."
+
+
+def run_codex(
+    stdin_text: str,
+    *,
+    model: Optional[str] = None,
+    timeout: Optional[int] = None,
+) -> dict:
+    """Invoke `codex exec`, feeding the transcript on stdin; return {summary, blockers}."""
+    model = model if model is not None else config.CODEX_MODEL
+    timeout = timeout or config.CODEX_TIMEOUT_S
+
+    with tempfile.TemporaryDirectory(prefix="codex_summ_") as td:
+        schema_path = Path(td) / "schema.json"
+        out_path = Path(td) / "last_message.txt"
+        schema_path.write_text(json.dumps(SUMMARY_SCHEMA))
+
+        cmd = [
+            "codex", "exec", _PROMPT,
+            "-s", "read-only",
+            "--skip-git-repo-check",
+            "--ephemeral",
+            "--output-schema", str(schema_path),
+            "-o", str(out_path),
+            "-C", str(config.MERIDIAN_HOME),
+        ]
+        if model:
+            cmd += ["-m", model]
+
+        env = os.environ.copy()
+        env["MERIDIAN_SUMMARISER"] = "1"   # marker for the indexer hook (defensive)
+
+        try:
+            proc = subprocess.run(
+                cmd, input=stdin_text, capture_output=True, text=True,
+                timeout=timeout, cwd=str(config.MERIDIAN_HOME), env=env,
+            )
+        except FileNotFoundError as exc:
+            raise SummariserError("codex CLI not found on PATH") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise SummariserError(f"codex exec timed out after {timeout}s") from exc
+
+        if proc.returncode != 0:
+            blob = f"{proc.stderr}\n{proc.stdout}"
+            if looks_rate_limited(blob):
+                raise RateLimited(first_line(proc.stderr) or "codex usage limit")
+            raise SummariserError(f"codex exited {proc.returncode}: {first_line(proc.stderr)}")
+
+        text = out_path.read_text().strip() if out_path.exists() else ""
+        if not text:
+            raise SummariserError("codex produced no output")
+
+        summary, blockers = _extract(text)
+        if not summary:
+            raise SummariserError("codex output had no usable summary")
+        return {"summary": summary, "blockers": blockers}
+
+
+def _extract(text: str) -> Tuple[str, list]:
+    """Pull (summary, blockers) from codex's final message.
+
+    With --output-schema the message should be a JSON object; if codex returns
+    prose instead, fall back to treating the whole text as the summary.
+    """
+    obj = _try_json_object(text)
+    if isinstance(obj, dict) and isinstance(obj.get("summary"), str):
+        return (
+            obj["summary"].strip(),
+            [b for b in obj.get("blockers", []) if isinstance(b, str)],
+        )
+    return text.strip(), []
+
+
+def _try_json_object(text: str):
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        # Tolerate a JSON object embedded in surrounding prose.
+        start, end = text.find("{"), text.rfind("}")
+        if 0 <= start < end:
+            try:
+                return json.loads(text[start:end + 1])
+            except json.JSONDecodeError:
+                return None
+    return None

--- a/services/coding_agent_summariser/config.py
+++ b/services/coding_agent_summariser/config.py
@@ -1,0 +1,77 @@
+"""Config for coding_agent_summariser — all env-driven.
+
+Defaults suit a single-user laptop on a Claude Max subscription with the local
+MLX server on :7823 as the fallback judge.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+from agents.config import LOG_DIR, MERIDIAN_DB, MERIDIAN_HOME  # noqa: F401
+from coding_agent_indexer.config import LOCAL_TZ
+
+
+def today_local() -> str:
+    """Current local calendar day as 'YYYY-MM-DD', matching substr(started_at,1,10)."""
+    return datetime.now(LOCAL_TZ).strftime("%Y-%m-%d")
+
+# ── Cadence / batching ────────────────────────────────────────────────────────
+#
+# Summarisation is not latency-critical (it feeds periodic PM updates), so we
+# poll infrequently and process a bounded batch per tick. Sequential, never
+# parallel — that keeps memory flat (one transcript at a time) and avoids
+# tripping the subscription's rate limit with a burst.
+POLL_INTERVAL_SECONDS = int(os.environ.get("SUMMARISER_POLL_INTERVAL_S", "300"))   # 5 min
+BATCH_PER_TICK        = int(os.environ.get("SUMMARISER_BATCH_PER_TICK", "8"))
+
+# ── Model / invocation ────────────────────────────────────────────────────────
+#
+# Haiku by default: ~2.5x lighter on Max usage limits and ~3x faster than Sonnet,
+# with the skill prompt hardened to still capture blockers/rework. Override to a
+# Sonnet/Opus id for richer summaries.
+CLAUDE_MODEL      = os.environ.get("SUMMARISER_MODEL", "claude-haiku-4-5-20251001")
+SKILL_NAME        = os.environ.get("SUMMARISER_SKILL", "session-summary")
+CLAUDE_TIMEOUT_S  = int(os.environ.get("SUMMARISER_CLAUDE_TIMEOUT_S", "240"))
+
+# Codex-flavoured sessions are summarised via `codex exec` using the user's
+# Codex auth (symmetry with Claude). Empty model → codex's configured default.
+CODEX_MODEL       = os.environ.get("SUMMARISER_CODEX_MODEL", "")
+CODEX_TIMEOUT_S   = int(os.environ.get("SUMMARISER_CODEX_TIMEOUT_S", "240"))
+
+# Transcript hard cap (chars) fed to the model. Most bursts are well under this;
+# the cap bounds memory + token cost for a pathological 1 MB+ transcript. We keep
+# the HEAD and TAIL (where the task and the outcome live) and elide the middle.
+TRANSCRIPT_CAP_CHARS = int(os.environ.get("SUMMARISER_TRANSCRIPT_CAP", "500000"))
+
+# ── Fallback (local MLX) ──────────────────────────────────────────────────────
+MLX_HOST          = os.environ.get("MLX_SERVER_HOST", "127.0.0.1")
+MLX_PORT          = int(os.environ.get("MLX_SERVER_PORT", "7823"))
+MLX_TIMEOUT_S     = int(os.environ.get("SUMMARISER_MLX_TIMEOUT_S", "180"))
+MLX_MAX_TOKENS    = int(os.environ.get("SUMMARISER_MLX_MAX_TOKENS", "2048"))   # output cap
+
+# MLX INPUT cap (MLX-only — Claude/Codex always get the full transcript). The
+# local model receives just the TAIL (most recent activity / outcome) of the
+# transcript, bounded to ~this many tokens. Token count is approximated by
+# chars (no tokenizer in this lightweight process): cap_chars = tokens × ratio.
+MLX_INPUT_MAX_TOKENS  = int(os.environ.get("SUMMARISER_MLX_INPUT_TOKENS", "5000"))
+MLX_CHARS_PER_TOKEN   = int(os.environ.get("SUMMARISER_MLX_CHARS_PER_TOKEN", "4"))
+
+# ── Backoff ───────────────────────────────────────────────────────────────────
+#
+# When BOTH Claude (rate-limited) and MLX (down) fail, sleep this long before the
+# next tick instead of hammering. Rows stay NULL and are retried later.
+RATE_LIMIT_BACKOFF_SECONDS = int(os.environ.get("SUMMARISER_BACKOFF_S", "1800"))   # 30 min
+
+# ── Noise filter ──────────────────────────────────────────────────────────────
+#
+# Skip trivial / empty-work segments (rate-limit blips, accidental opens, an
+# imported-session marker). A row must clear BOTH bars to be worth a summary —
+# at least this many turns AND this much rendered transcript.
+MIN_TURNS         = int(os.environ.get("SUMMARISER_MIN_TURNS", "2"))
+MIN_TEXT_BYTES    = int(os.environ.get("SUMMARISER_MIN_TEXT_BYTES", "800"))
+
+# task_method transitions (mirrors db.py constants in coding_agent_indexer)
+TASK_METHOD_PENDING    = "pending_summariser"   # queue marker the indexer sets
+TASK_METHOD_SUMMARISED = "summarised"           # terminal marker we set on success
+SESSION_TEXT_SOURCE    = "summary"              # so downstream knows it's prose, not OCR

--- a/services/coding_agent_summariser/daemon.py
+++ b/services/coding_agent_summariser/daemon.py
@@ -1,0 +1,90 @@
+"""Low-frequency daemon that drains the summariser queue.
+
+Each tick: fetch a bounded batch of sealed, unsummarised coding segments and
+summarise them sequentially (one transcript in memory at a time — flat memory,
+no CPU burst, no rate-limit storm). If Claude reports a usage/rate limit, stop
+the tick early and sleep a longer backoff instead of hammering the subscription;
+the unfinished rows stay NULL and are retried later.
+
+Idle between ticks via `threading.Event.wait`, so the process uses ~no CPU when
+there's nothing to do. SIGTERM/SIGINT wake it immediately and it stops after the
+in-flight summary.
+"""
+from __future__ import annotations
+
+import logging
+import signal
+import threading
+
+from agents import observability
+from coding_agent_summariser import config, db, summariser
+
+log = logging.getLogger(__name__)
+
+_SHUTDOWN = threading.Event()
+
+
+def main() -> int:
+    observability.setup("meridian-coding-agent-summariser")
+    db.ensure_schema()
+    log.info(
+        "starting coding_agent_summariser — model=%s poll=%ds batch=%d",
+        config.CLAUDE_MODEL, config.POLL_INTERVAL_SECONDS, config.BATCH_PER_TICK,
+    )
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+
+    while not _SHUTDOWN.is_set():
+        backoff = False
+        try:
+            backoff = _tick()
+        except Exception as exc:                            # noqa: BLE001 — never die on a bad tick
+            log.exception("tick failed: %s", exc)
+        wait = config.RATE_LIMIT_BACKOFF_SECONDS if backoff else config.POLL_INTERVAL_SECONDS
+        if backoff:
+            log.warning("rate-limited — backing off %ds", wait)
+        _SHUTDOWN.wait(timeout=wait)
+
+    log.info("coding_agent_summariser stopped")
+    observability.shutdown()
+    return 0
+
+
+def _tick() -> bool:
+    """Summarise up to BATCH_PER_TICK of TODAY's rows. Returns True on rate limit.
+
+    Scoped to the current local day so the daemon never tries to drain all of
+    history in one go — past days are backfilled explicitly via the CLI's --day.
+    """
+    day = config.today_local()
+    rows = db.fetch_pending(config.BATCH_PER_TICK, day=day)
+    if not rows:
+        log.debug("tick: queue empty for %s", day)
+        return False
+
+    wrote = failed = 0
+    for row in rows:
+        if _SHUTDOWN.is_set():
+            break
+        outcome = summariser.summarise_one(row)
+        if outcome.rate_limited and not outcome.written:
+            # Claude is limited and MLX didn't cover it — stop now, back off.
+            log.warning("rate-limited on row_id=%d; ending tick (wrote=%d)", row.id, wrote)
+            return True
+        if outcome.written:
+            wrote += 1
+        elif outcome.error:
+            failed += 1
+            log.warning("row_id=%d not summarised: %s", row.id, outcome.error)
+
+    log.info("tick: wrote=%d failed=%d of %d candidate(s)", wrote, failed, len(rows))
+    return False
+
+
+def _stop(signum, frame) -> None:                           # noqa: ARG001
+    log.info("signal %d received — stopping after current summary", signum)
+    _SHUTDOWN.set()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/coding_agent_summariser/db.py
+++ b/services/coding_agent_summariser/db.py
@@ -1,0 +1,207 @@
+"""SQLite layer for the summariser — read the queue, write the summary.
+
+Read paths use URI read-only mode. The single write path is idempotent:
+`UPDATE ... WHERE session_summary IS NULL`, so concurrent runs, restarts, and
+retries can never double-write or clobber a summary that already landed.
+
+Connection model: short-lived `sqlite3.Connection` per call (mirrors the
+indexer). We never hold a transcript longer than the call that uses it.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, List, Optional
+
+from coding_agent_summariser import config
+
+log = logging.getLogger(__name__)
+
+_BUSY_TIMEOUT_MS = 5000
+
+
+@dataclass(frozen=True)
+class PendingRow:
+    """A sealed coding-agent segment awaiting a summary (metadata only).
+
+    `session_text` is fetched separately, one at a time, to keep memory flat.
+    """
+    id:                 int
+    session_uuid:       str
+    agent:              str
+    segment_started_at: str
+    started_at:         str
+    ended_at:           str
+    duration_s:         int
+    text_bytes:         int
+
+
+@contextmanager
+def connect(
+    db_path: Optional[Path] = None, *, readonly: bool = False,
+) -> Iterator[sqlite3.Connection]:
+    target = Path(db_path) if db_path is not None else config.MERIDIAN_DB
+    if readonly:
+        conn = sqlite3.connect(f"file:{target}?mode=ro", uri=True, timeout=10)
+    else:
+        conn = sqlite3.connect(target, timeout=10)
+    conn.row_factory = sqlite3.Row
+    conn.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def ensure_schema(*, db_path: Optional[Path] = None) -> None:
+    """Idempotently add the `summary_source` column to app_sessions.
+
+    app_sessions is Rust-owned, but `summary_source` is a summariser-only field
+    not managed by any Rust migration — so we add it from Python (the same
+    pattern pm_update uses for its own additive columns). Rust ignores the extra
+    column; no Rust migration / recompile needed. Safe to call on every startup.
+    """
+    with connect(db_path) as con:
+        cols = {r["name"] for r in con.execute("PRAGMA table_info(app_sessions)")}
+        if "summary_source" not in cols:
+            con.execute("ALTER TABLE app_sessions ADD COLUMN summary_source TEXT")
+            con.commit()
+            log.info("added summary_source column to app_sessions")
+
+
+def _to_row(r: sqlite3.Row) -> PendingRow:
+    return PendingRow(
+        id=r["id"],
+        session_uuid=r["claude_session_uuid"],
+        agent=r["app_name"],
+        segment_started_at=r["segment_started_at"],
+        started_at=r["started_at"],
+        ended_at=r["ended_at"],
+        duration_s=r["duration_s"],
+        text_bytes=r["text_bytes"] or 0,
+    )
+
+
+_ROW_COLS = """
+    id, claude_session_uuid, app_name, segment_started_at,
+    started_at, ended_at, duration_s,
+    length(session_text) AS text_bytes
+"""
+
+
+def fetch_pending(
+    limit: int,
+    *,
+    day: Optional[str] = None,
+    session_uuid: Optional[str] = None,
+    db_path: Optional[Path] = None,
+) -> List[PendingRow]:
+    """Sealed coding segments needing a summary, oldest-ended first.
+
+    `day` (a `YYYY-MM-DD` day_utc) scopes the queue to a single calendar day —
+    the daemon always passes today, so it never drains all history at once; the
+    CLI passes a chosen day to backfill just that day. `session_uuid` restricts
+    to one session. Oldest-first ordering means a session's earlier bursts are
+    summarised before its later ones (prior-burst context — `fetch_prior_summary`).
+    """
+    # Noise filter: trivial/empty-work segments are never worth a summary.
+    clauses = ""
+    params: tuple = (config.TASK_METHOD_PENDING, config.MIN_TURNS, config.MIN_TEXT_BYTES)
+    if day:
+        clauses += " AND substr(started_at, 1, 10) = ?"
+        params += (day,)
+    if session_uuid:
+        clauses += " AND claude_session_uuid = ?"
+        params += (session_uuid,)
+    params += (limit,)
+    with connect(db_path, readonly=True) as con:
+        rows = con.execute(
+            f"""
+            SELECT {_ROW_COLS}
+            FROM   app_sessions
+            WHERE  claude_session_uuid IS NOT NULL
+              AND  sealed_at IS NOT NULL
+              AND  task_method = ?
+              AND  session_summary IS NULL
+              AND  session_text IS NOT NULL
+              AND  session_text <> ''
+              AND  frame_count >= ?
+              AND  length(session_text) >= ?
+              {clauses}
+            ORDER BY ended_at ASC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+    return [_to_row(r) for r in rows]
+
+
+def fetch_by_id(row_id: int, *, db_path: Optional[Path] = None) -> Optional[PendingRow]:
+    """One row by id, regardless of summary/seal state — for CLI --row dry-runs."""
+    with connect(db_path, readonly=True) as con:
+        r = con.execute(
+            f"SELECT {_ROW_COLS} FROM app_sessions WHERE id = ? AND claude_session_uuid IS NOT NULL",
+            (row_id,),
+        ).fetchone()
+    return _to_row(r) if r else None
+
+
+def fetch_transcript(row_id: int, *, db_path: Optional[Path] = None) -> str:
+    """Full `session_text` for one row. Fetched per-row to bound memory."""
+    with connect(db_path, readonly=True) as con:
+        row = con.execute(
+            "SELECT session_text FROM app_sessions WHERE id = ?", (row_id,),
+        ).fetchone()
+    return (row["session_text"] if row else "") or ""
+
+
+def fetch_prior_summary(
+    session_uuid: str,
+    segment_started_at: str,
+    *,
+    db_path: Optional[Path] = None,
+) -> Optional[str]:
+    """The summary of this session's most recent EARLIER burst, if any.
+
+    Passed to the model as continuation context so a resumed session reads as
+    one coherent story instead of repeating itself.
+    """
+    with connect(db_path, readonly=True) as con:
+        row = con.execute(
+            """
+            SELECT session_summary
+            FROM   app_sessions
+            WHERE  claude_session_uuid = ?
+              AND  segment_started_at < ?
+              AND  session_summary IS NOT NULL
+            ORDER BY segment_started_at DESC
+            LIMIT 1
+            """,
+            (session_uuid, segment_started_at),
+        ).fetchone()
+    return row["session_summary"] if row and row["session_summary"] else None
+
+
+def write_summary(
+    row_id: int, summary: str, *, source: Optional[str] = None, db_path: Optional[Path] = None,
+) -> bool:
+    """Persist the summary + engine source + flip task_method. Idempotent.
+
+    `source` is the engine that produced it ('claude' | 'codex' | 'mlx'),
+    stored in `summary_source`. Returns True if this call wrote the row, False
+    if it was already summarised (another worker won the race / retry).
+    """
+    with connect(db_path) as con:
+        cur = con.execute(
+            """
+            UPDATE app_sessions
+            SET    session_summary = ?, task_method = ?, summary_source = ?
+            WHERE  id = ? AND session_summary IS NULL
+            """,
+            (summary, config.TASK_METHOD_SUMMARISED, source, row_id),
+        )
+        con.commit()
+        return (cur.rowcount or 0) > 0

--- a/services/coding_agent_summariser/mlx_fallback.py
+++ b/services/coding_agent_summariser/mlx_fallback.py
@@ -1,0 +1,130 @@
+"""Fallback summariser — the local MLX server's OpenAI-compatible endpoint.
+
+Used only when `claude -p` is rate-limited or unavailable. The local model is
+the degraded path: we ask for plain prose (no structured-output / schema, which
+the MLX endpoint doesn't enforce) and store that. Uses stdlib `urllib` so the
+summariser carries no extra dependency.
+
+Raises `SummariserError` on any failure so the caller leaves the row NULL and
+retries later (next tick may have Claude back).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+
+import re
+
+from coding_agent_summariser import config
+from coding_agent_summariser.claude_runner import SummariserError
+from coding_agent_summariser.prompts import SUMMARY_RULES
+
+log = logging.getLogger(__name__)
+
+# /summarise enforces the {summary} schema via outlines, so the system message
+# only needs the content rules (no output-format clause).
+_SYSTEM = SUMMARY_RULES
+
+
+def summarise(stdin_text: str) -> str:
+    """Return a prose summary from the local MLX server, or raise SummariserError.
+
+    Uses the schema-constrained `/summarise` endpoint (outlines FSM forces the
+    {summary} shape), which is what stops this reasoning model from leaking its
+    chain-of-thought. The `_clean`/reasoning gate below is kept as cheap defence.
+    """
+    url = f"http://{config.MLX_HOST}:{config.MLX_PORT}/summarise"
+    body = json.dumps({
+        "transcript": _tail_cap(stdin_text),     # MLX-only: tail of the session
+        "system": _SYSTEM,
+        "max_tokens": config.MLX_MAX_TOKENS,
+        "temperature": 0.2,
+    }).encode("utf-8")
+
+    req = urllib.request.Request(
+        url, data=body, headers={"Content-Type": "application/json"}, method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=config.MLX_TIMEOUT_S) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise SummariserError(f"MLX fallback unreachable: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise SummariserError(f"MLX fallback bad JSON: {exc}") from exc
+
+    text = _clean((payload.get("summary") or "").strip())
+    if not text:
+        raise SummariserError("MLX fallback returned empty summary")
+    if _looks_like_reasoning(text):
+        # The local model leaked its chain-of-thought instead of a clean
+        # summary. Reject rather than store garbage — the row stays NULL and
+        # gets a proper summary later from claude/codex (or a future
+        # constrained-MLX path).
+        raise SummariserError("MLX output looks like leaked reasoning — rejected")
+    return text
+
+
+def _tail_cap(text: str) -> str:
+    """Keep only the TAIL (~MLX_INPUT_MAX_TOKENS) of the transcript for MLX.
+
+    The bottom of a session holds the most recent activity / outcome, which is
+    what we want the local model to summarise. Claude/Codex are unaffected —
+    this trims only the MLX request. Token count is approximated by chars.
+    """
+    max_chars = config.MLX_INPUT_MAX_TOKENS * config.MLX_CHARS_PER_TOKEN
+    if len(text) <= max_chars:
+        return text
+    return "…[earlier session truncated — most recent activity below]…\n\n" + text[-max_chars:]
+
+
+_REASONING_MARKERS = (
+    "thinking process",
+    "analyze the request",
+    "**analyze",
+    "constraint:",
+    "decision:",
+    "re-evaluation",
+    "let me think",
+    "i must follow",
+    "the transcript is",
+)
+
+
+def _looks_like_reasoning(text: str) -> bool:
+    low = text.lower()
+    if low.lstrip().startswith(("thinking process", "1.", "1)", "**analyze")):
+        return True
+    return sum(1 for m in _REASONING_MARKERS if m in low) >= 2
+
+
+def _clean(text: str) -> str:
+    """Defensively strip a reasoning model's leakage to leave just the prose.
+
+    The prose-only system prompt usually suffices, but local reasoners can still
+    emit `<think>…</think>`, a "Thinking Process:" preamble, or a JSON object.
+    Order matters: drop think-tags, prefer an embedded `{"summary": …}`, then
+    drop a leading reasoning preamble.
+    """
+    # 1. Remove <think>…</think> (and stray closing tags).
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL | re.IGNORECASE).strip()
+    text = re.sub(r"</?think>", "", text, flags=re.IGNORECASE).strip()
+
+    # 2. If it emitted JSON anyway, take the summary field.
+    start, end = text.find("{"), text.rfind("}")
+    if 0 <= start < end:
+        try:
+            obj = json.loads(text[start:end + 1])
+            if isinstance(obj, dict) and isinstance(obj.get("summary"), str) and obj["summary"].strip():
+                return obj["summary"].strip()
+        except json.JSONDecodeError:
+            pass
+
+    # 3. Drop a leading reasoning preamble ("Thinking Process:", "Reasoning:", …)
+    #    up to the first blank line that precedes ordinary prose.
+    m = re.match(r"^\s*(thinking process|reasoning|analysis|let me think)\b.*?\n\s*\n",
+                 text, flags=re.IGNORECASE | re.DOTALL)
+    if m:
+        text = text[m.end():].strip()
+    return text.strip()

--- a/services/coding_agent_summariser/prompts.py
+++ b/services/coding_agent_summariser/prompts.py
@@ -1,0 +1,79 @@
+"""Shared summary contract — the rules, the schema, and limit detection.
+
+Lives in one place so the three engines stay consistent:
+  * Claude loads the `session-summary` skill (same rules, authored in SKILL.md).
+  * Codex and MLX get `SUMMARY_INSTRUCTION` as their prompt / system message.
+All three target `SUMMARY_SCHEMA`.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+# The shared rules, without an output-format clause (engines append their own).
+SUMMARY_RULES = (
+    "You summarise ONE work-burst of a developer's coding-agent session for a "
+    "Jira work-log. The transcript (provided on stdin) is timestamped as "
+    "`[<ISO ts>] [role] <message>`. Write a factual prose summary of 10-40 "
+    "sentences: name the files edited, commands run, errors hit, decisions "
+    "made, tests/validations performed, and any rework or blockers (an approach "
+    "abandoned, a failed build/test, something deleted and rebuilt). State ONLY "
+    "what is in the transcript — never invent files, tickets, commands, or "
+    "outcomes. No preamble, no markdown headings, no bullet lists — just clear "
+    "paragraphs. If an 'EARLIER IN THIS SESSION' section is present, do not "
+    "repeat it; summarise only this burst."
+)
+
+# For schema-enforced engines (Codex `--output-schema`): ask for JSON.
+SUMMARY_INSTRUCTION = (
+    SUMMARY_RULES + " Return JSON matching the schema: `summary` (the prose) "
+    "and `blockers` (a list of distinct blockers / failures / rework, possibly empty)."
+)
+
+# For the MLX fallback (no schema enforcement, and the local model is a reasoner):
+# demand ONLY the prose, no thinking/JSON, so it doesn't leak its reasoning.
+MLX_PROSE_INSTRUCTION = (
+    SUMMARY_RULES + " Output ONLY the final prose summary itself — do NOT show "
+    "your reasoning or thinking, do NOT wrap it in JSON, do NOT add any preamble "
+    "or labels. Begin directly with the first sentence of the summary."
+)
+
+# Structured-output contract. `summary` is the prose we store; `blockers`
+# forces the model to surface rework/failures (the bit weaker models drop).
+SUMMARY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "summary":  {"type": "string", "minLength": 1},
+        "blockers": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["summary"],
+}
+
+# Substrings that mark a subscription usage/rate limit in CLI stderr/output —
+# for Claude (`claude -p`) and Codex (`codex exec`) alike.
+RATE_LIMIT_MARKERS = (
+    "usage limit",
+    "rate limit",
+    "rate_limit",
+    "429",
+    "overloaded",
+    "exceeded your",
+    "quota",
+    "resets at",
+    "try again at",
+    "upgrade to plus",
+)
+
+
+def looks_rate_limited(text: str) -> bool:
+    low = (text or "").lower()
+    return any(m in low for m in RATE_LIMIT_MARKERS)
+
+
+def first_line(text: Optional[str]) -> str:
+    if not text:
+        return ""
+    for line in text.splitlines():
+        line = line.strip()
+        if line:
+            return line[:200]
+    return ""

--- a/services/coding_agent_summariser/skill/session-summary/SKILL.md
+++ b/services/coding_agent_summariser/skill/session-summary/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: session-summary
+description: Summarise a developer's Claude Code / Codex coding-session transcript into a factual SDLC work-log summary. Use whenever asked to summarise a coding session or transcript.
+---
+
+# Coding session summariser
+
+You are summarising ONE work-burst of a developer's coding-agent session for a
+Jira work-log. The transcript (provided on stdin) is timestamped, in the form
+`[<ISO ts>] [role] <message>`. It may include `[tool_use: ...]`,
+`[tool_result: ...]` and `[thinking] ...` blocks.
+
+Produce a **factual** summary of what the developer and the agent actually did.
+Write for an engineering manager skimming a ticket — concrete, not generic.
+
+## Hard rules
+
+- **Only state what is in the transcript.** Never invent files, tickets,
+  commands, or outcomes. If something is unclear, omit it.
+- **Be specific:** name the files edited, the commands run, the errors hit, the
+  decisions made, the tests/validations performed, the commit/PR if any.
+- **Capture rework and blockers explicitly.** If an approach was tried and
+  abandoned, a build/test failed, something was deleted and rebuilt, or the
+  developer was blocked — say so. This is the most valuable signal and the
+  easiest to omit; do not skip it.
+- **Length:** 10–40 sentences of prose. No preamble, no markdown headings, no
+  bullet lists in `summary` — just clear paragraphs.
+- If "earlier in this session" context is provided, do NOT repeat it; summarise
+  only THIS burst and note how it continued the prior work in one clause.
+
+## Output
+
+Return structured JSON matching the provided schema:
+- `summary` — the prose summary (the rules above).
+- `blockers` — a list of distinct blockers / failures / rework moments (may be
+  empty). Each one short (≤140 chars). These must also be reflected in `summary`.

--- a/services/coding_agent_summariser/summariser.py
+++ b/services/coding_agent_summariser/summariser.py
@@ -1,0 +1,126 @@
+"""Summarise one sealed coding-agent segment: Claude → MLX fallback → write.
+
+`summarise_one` is the single unit of work, shared by the daemon and the CLI.
+It never raises — it returns an `Outcome` describing what happened, so callers
+(loops) stay simple and a bad row can't kill the process.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+from coding_agent_summariser import claude_runner, codex_runner, config, db, mlx_fallback
+from coding_agent_summariser.claude_runner import RateLimited, SummariserError
+from coding_agent_summariser.db import PendingRow
+
+log = logging.getLogger(__name__)
+
+
+class Source(str, Enum):
+    CLAUDE = "claude"
+    CODEX  = "codex"
+    MLX    = "mlx"
+    NONE   = "none"
+
+
+def _primary_engine(agent: str):
+    """Pick the per-agent engine: Codex sessions → codex, else → claude."""
+    if (agent or "").strip().lower() == "codex":
+        return codex_runner.run_codex, Source.CODEX
+    return claude_runner.run_claude, Source.CLAUDE
+
+
+@dataclass(frozen=True)
+class Outcome:
+    row_id:       int
+    written:      bool                  # summary persisted this call
+    source:       Source                # which engine produced it
+    rate_limited: bool = False          # Claude hit a usage/rate limit (→ daemon backs off)
+    error:        Optional[str] = None
+    summary:      Optional[str] = None  # the generated text (always set on success; for --dry-run)
+
+
+def summarise_one(row: PendingRow, *, write: bool = True, db_path: Optional[Path] = None) -> Outcome:
+    """Produce (and by default persist) a summary for one segment. Never raises.
+
+    `write=False` generates the summary but does not touch the DB — used by the
+    CLI's `--dry-run` to eyeball output.
+    """
+    transcript = db.fetch_transcript(row.id, db_path=db_path)
+    if not transcript.strip():
+        # Sealed-but-empty shouldn't reach the queue (it filters on non-empty
+        # session_text), but guard anyway rather than send an empty prompt.
+        return Outcome(row.id, False, Source.NONE, error="empty transcript")
+
+    prior = db.fetch_prior_summary(row.session_uuid, row.segment_started_at, db_path=db_path)
+    stdin_text = _build_prompt(transcript, prior)
+
+    summary: Optional[str] = None
+    source = Source.NONE
+    rate_limited = False
+    errors: list[str] = []
+
+    # 1. Primary: the session's own agent (Codex → codex exec, else claude -p),
+    #    on the user's subscription for that tool.
+    primary_fn, primary_source = _primary_engine(row.agent)
+    try:
+        summary = primary_fn(stdin_text)["summary"]
+        source = primary_source
+    except RateLimited as exc:
+        rate_limited = True
+        errors.append(f"{primary_source.value} rate-limited: {exc}")
+    except SummariserError as exc:
+        errors.append(f"{primary_source.value} failed: {exc}")
+
+    # 2. Fallback: local MLX (on any primary failure).
+    if summary is None:
+        try:
+            summary = mlx_fallback.summarise(stdin_text)
+            source = Source.MLX
+        except SummariserError as exc:
+            errors.append(f"mlx failed: {exc}")
+
+    if summary is None:
+        return Outcome(row.id, False, Source.NONE, rate_limited=rate_limited,
+                       error="; ".join(errors))
+
+    wrote = db.write_summary(row.id, summary, source=source.value, db_path=db_path) if write else False
+    log.info(
+        "summarised: row_id=%d uuid=%s seg=%s source=%s wrote=%s chars=%d",
+        row.id, row.session_uuid[:8], row.segment_started_at, source.value, wrote, len(summary),
+    )
+    return Outcome(row.id, wrote, source, rate_limited=rate_limited, summary=summary)
+
+
+# ──────────────────────── Prompt assembly ──────────────────────────────────────
+
+
+def _build_prompt(transcript: str, prior_summary: Optional[str]) -> str:
+    """stdin for the model: optional prior-burst context + (capped) transcript."""
+    parts: list[str] = []
+    if prior_summary:
+        parts.append("## EARLIER IN THIS SESSION (context — do not repeat)\n" + prior_summary)
+    parts.append("## TRANSCRIPT\n" + _cap_transcript(transcript))
+    return "\n\n".join(parts)
+
+
+def _cap_transcript(transcript: str, cap: Optional[int] = None) -> str:
+    """Bound transcript size: keep the head (task setup) and tail (outcome).
+
+    A pathological multi-MB transcript would otherwise blow token cost / memory.
+    Most bursts are well under the cap and pass through untouched.
+    """
+    cap = cap or config.TRANSCRIPT_CAP_CHARS
+    if len(transcript) <= cap:
+        return transcript
+    head_len = cap * 7 // 10
+    tail_len = cap - head_len
+    elided = len(transcript) - cap
+    return (
+        transcript[:head_len]
+        + f"\n\n…[{elided} chars elided — long autonomous stretch omitted]…\n\n"
+        + transcript[-tail_len:]
+    )

--- a/services/coding_agent_summariser/tests/test_summariser.py
+++ b/services/coding_agent_summariser/tests/test_summariser.py
@@ -1,0 +1,234 @@
+"""Edge-case tests for the summariser. Claude + MLX are mocked — no live calls.
+
+Covers the contract the daemon relies on:
+  * success writes the prose + flips task_method to 'summarised'
+  * idempotent / crash-safe write (WHERE session_summary IS NULL)
+  * rate-limit → MLX fallback (and the rate_limited flag for daemon backoff)
+  * non-rate Claude failure also falls back to MLX
+  * both engines failing leaves the row NULL (retried later)
+  * prior-burst summary is fed as context (chaining)
+  * transcript is capped; queue filters to sealed/unsummarised/non-empty
+  * --dry-run never writes
+
+Run:
+    cd services
+    .venv/bin/python -m pytest coding_agent_summariser/tests/test_summariser.py -v
+"""
+from __future__ import annotations
+
+import glob
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from coding_agent_summariser import claude_runner, codex_runner, config, db, mlx_fallback, summariser
+from coding_agent_summariser.claude_runner import RateLimited, SummariserError
+
+_MIGRATIONS = Path(__file__).resolve().parents[3] / "src" / "migrations"
+
+
+def _make_db(tmp_path: Path) -> Path:
+    dbp = tmp_path / "meridian.db"
+    con = sqlite3.connect(dbp)
+    for m in sorted(glob.glob(str(_MIGRATIONS / "*.sql"))):
+        con.executescript(Path(m).read_text())
+    con.commit(); con.close()
+    return dbp
+
+
+def _insert(dbp: Path, *, uuid: str, seg_start: str, ended: str, text: str,
+            sealed: bool = True, summary=None, task_method="pending_summariser",
+            app: str = "Claude Code", day: str = "2026-05-20", frames: int = 5) -> int:
+    con = sqlite3.connect(dbp)
+    cur = con.execute(
+        """
+        INSERT INTO app_sessions (
+            app_name, started_at, ended_at, duration_s,
+            window_titles, min_frame_id, max_frame_id, frame_count, etl_run_id,
+            idle_frame_count, category, confidence, category_method,
+            session_text, session_text_source, task_method, session_summary,
+            claude_session_uuid, segment_started_at, sealed_at
+        ) VALUES (?,?,?,?, ?,?,?,?,?, ?,?,?,?, ?,?,?,?, ?,?,?)
+        """,
+        (app, seg_start, ended, 100,
+         "[]", 0, 0, frames, 0,
+         0, "coding", 1.0, "coding_agent_indexer",
+         text, "claude_jsonl", task_method, summary,
+         uuid, seg_start, (ended if sealed else None)),
+    )
+    con.commit(); rid = cur.lastrowid; con.close()
+    return rid
+
+
+@pytest.fixture
+def dbp(tmp_path, monkeypatch):
+    p = _make_db(tmp_path)
+    monkeypatch.setattr(config, "MERIDIAN_DB", p)
+    db.ensure_schema(db_path=p)          # add summary_source (not in the Rust migrations)
+    # Neutralise the noise filter for routing/idempotency tests (they use tiny
+    # text on purpose); the threshold itself is exercised by its own test.
+    monkeypatch.setattr(config, "MIN_TURNS", 0)
+    monkeypatch.setattr(config, "MIN_TEXT_BYTES", 0)
+    return p
+
+
+def _only_row(dbp, rid):
+    con = sqlite3.connect(dbp); con.row_factory = sqlite3.Row
+    r = con.execute("SELECT session_summary, task_method, summary_source FROM app_sessions WHERE id=?", (rid,)).fetchone()
+    con.close(); return r
+
+
+# ──────────────────────── DB queue / write ─────────────────────────────────────
+
+
+def test_queue_filters(dbp):
+    good = _insert(dbp, uuid="a", seg_start="2026-05-20T08:00:00Z", ended="2026-05-20T08:10:00Z", text="work")
+    _insert(dbp, uuid="b", seg_start="2026-05-20T09:00:00Z", ended="2026-05-20T09:05:00Z", text="x", sealed=False)        # unsealed
+    _insert(dbp, uuid="c", seg_start="2026-05-20T10:00:00Z", ended="2026-05-20T10:05:00Z", text="x", summary="done")       # already summarised
+    _insert(dbp, uuid="d", seg_start="2026-05-20T11:00:00Z", ended="2026-05-20T11:05:00Z", text="")                        # empty text
+    rows = db.fetch_pending(50, db_path=dbp)
+    assert [r.id for r in rows] == [good]
+
+
+def test_day_scopes_the_queue(dbp):
+    a = _insert(dbp, uuid="a", seg_start="2026-05-20T08:00:00Z", ended="2026-05-20T08:10:00Z",
+                text="day20", day="2026-05-20")
+    _insert(dbp, uuid="b", seg_start="2026-05-21T08:00:00Z", ended="2026-05-21T08:10:00Z",
+            text="day21", day="2026-05-21")
+    assert [r.id for r in db.fetch_pending(50, day="2026-05-20", db_path=dbp)] == [a]
+    assert len(db.fetch_pending(50, day="2026-05-21", db_path=dbp)) == 1
+    assert len(db.fetch_pending(50, db_path=dbp)) == 2          # no day → all (CLI/daemon always pass one)
+
+
+def test_skips_trivial_sessions(dbp, monkeypatch):
+    monkeypatch.setattr(config, "MIN_TURNS", 2)
+    monkeypatch.setattr(config, "MIN_TEXT_BYTES", 800)
+    real = _insert(dbp, uuid="big", seg_start="2026-05-20T08:00:00Z", ended="2026-05-20T08:30:00Z",
+                   text="x" * 1000, frames=8)
+    _insert(dbp, uuid="tiny", seg_start="2026-05-20T09:00:00Z", ended="2026-05-20T09:01:00Z",
+            text="You've hit your limit", frames=2)             # < 800 bytes → noise
+    _insert(dbp, uuid="fewturns", seg_start="2026-05-20T10:00:00Z", ended="2026-05-20T10:05:00Z",
+            text="x" * 1000, frames=1)                           # < 2 turns → noise
+    assert [r.id for r in db.fetch_pending(50, db_path=dbp)] == [real]
+
+
+def test_write_is_idempotent(dbp):
+    rid = _insert(dbp, uuid="a", seg_start="2026-05-20T08:00:00Z", ended="2026-05-20T08:10:00Z", text="w")
+    assert db.write_summary(rid, "first", db_path=dbp) is True
+    assert db.write_summary(rid, "second", db_path=dbp) is False     # already set → noop
+    assert _only_row(dbp, rid)["session_summary"] == "first"
+
+
+# ──────────────────────── summarise_one engine routing ─────────────────────────
+
+
+def test_success_writes_and_flips_method(dbp, monkeypatch):
+    rid = _insert(dbp, uuid="a", seg_start="2026-05-20T08:00:00Z", ended="2026-05-20T08:10:00Z", text="fixed a bug")
+    monkeypatch.setattr(claude_runner, "run_claude", lambda *_a, **_k: {"summary": "Fixed the bug.", "blockers": []})
+    out = summariser.summarise_one(db.fetch_pending(1, db_path=dbp)[0], db_path=dbp)
+    assert out.written and out.source.value == "claude"
+    row = _only_row(dbp, rid)
+    assert row["session_summary"] == "Fixed the bug."
+    assert row["task_method"] == config.TASK_METHOD_SUMMARISED
+    assert row["summary_source"] == "claude"        # engine recorded in DB
+
+
+def test_rate_limit_falls_back_to_mlx(dbp, monkeypatch):
+    rid = _insert(dbp, uuid="a", seg_start="2026-05-20T08:00:00Z", ended="2026-05-20T08:10:00Z", text="w")
+    def boom(*_a, **_k): raise RateLimited("usage limit")
+    monkeypatch.setattr(claude_runner, "run_claude", boom)
+    monkeypatch.setattr(mlx_fallback, "summarise", lambda *_a, **_k: "MLX summary.")
+    out = summariser.summarise_one(db.fetch_pending(1, db_path=dbp)[0], db_path=dbp)
+    assert out.written and out.source.value == "mlx" and out.rate_limited is True
+    row = _only_row(dbp, rid)
+    assert row["session_summary"] == "MLX summary." and row["summary_source"] == "mlx"
+
+
+def test_claude_error_falls_back_to_mlx(dbp, monkeypatch):
+    _insert(dbp, uuid="a", seg_start="2026-05-20T08:00:00Z", ended="2026-05-20T08:10:00Z", text="w")
+    def boom(*_a, **_k): raise SummariserError("timed out")
+    monkeypatch.setattr(claude_runner, "run_claude", boom)
+    monkeypatch.setattr(mlx_fallback, "summarise", lambda *_a, **_k: "MLX summary.")
+    out = summariser.summarise_one(db.fetch_pending(1, db_path=dbp)[0], db_path=dbp)
+    assert out.written and out.source.value == "mlx" and out.rate_limited is False
+
+
+def test_both_fail_leaves_null(dbp, monkeypatch):
+    rid = _insert(dbp, uuid="a", seg_start="2026-05-20T08:00:00Z", ended="2026-05-20T08:10:00Z", text="w")
+    monkeypatch.setattr(claude_runner, "run_claude", lambda *_a, **_k: (_ for _ in ()).throw(RateLimited("limit")))
+    monkeypatch.setattr(mlx_fallback, "summarise", lambda *_a, **_k: (_ for _ in ()).throw(SummariserError("mlx down")))
+    out = summariser.summarise_one(db.fetch_pending(1, db_path=dbp)[0], db_path=dbp)
+    assert out.written is False and out.rate_limited is True and out.error
+    assert _only_row(dbp, rid)["session_summary"] is None        # retried next tick
+
+
+def test_dry_run_does_not_write(dbp, monkeypatch):
+    rid = _insert(dbp, uuid="a", seg_start="2026-05-20T08:00:00Z", ended="2026-05-20T08:10:00Z", text="w")
+    monkeypatch.setattr(claude_runner, "run_claude", lambda *_a, **_k: {"summary": "S", "blockers": []})
+    out = summariser.summarise_one(db.fetch_pending(1, db_path=dbp)[0], write=False, db_path=dbp)
+    assert out.written is False and out.summary == "S"
+    assert _only_row(dbp, rid)["session_summary"] is None
+
+
+# ──────────────────────── chaining + capping ───────────────────────────────────
+
+
+def test_prior_summary_is_passed_as_context(dbp, monkeypatch):
+    _insert(dbp, uuid="a", seg_start="2026-05-20T08:00:00Z", ended="2026-05-20T08:10:00Z",
+            text="burst1", summary="Earlier burst summary.")          # already summarised, earlier
+    later = _insert(dbp, uuid="a", seg_start="2026-05-20T12:00:00Z", ended="2026-05-20T12:10:00Z", text="burst2")
+    captured = {}
+    def spy(stdin_text, **_k):
+        captured["stdin"] = stdin_text
+        return {"summary": "Second burst.", "blockers": []}
+    monkeypatch.setattr(claude_runner, "run_claude", spy)
+    row = next(r for r in db.fetch_pending(10, db_path=dbp) if r.id == later)
+    summariser.summarise_one(row, db_path=dbp)
+    assert "EARLIER IN THIS SESSION" in captured["stdin"]
+    assert "Earlier burst summary." in captured["stdin"]
+
+
+def test_codex_session_routes_to_codex(dbp, monkeypatch):
+    rid = _insert(dbp, uuid="a", seg_start="2026-05-20T08:00:00Z", ended="2026-05-20T08:10:00Z",
+                  text="codex work", app="Codex")
+    # claude must NOT be called for a Codex session
+    monkeypatch.setattr(claude_runner, "run_claude",
+                        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("claude used for codex")))
+    monkeypatch.setattr(codex_runner, "run_codex", lambda *_a, **_k: {"summary": "Codex did it.", "blockers": []})
+    out = summariser.summarise_one(db.fetch_pending(1, db_path=dbp)[0], db_path=dbp)
+    assert out.written and out.source.value == "codex"
+    row = _only_row(dbp, rid)
+    assert row["session_summary"] == "Codex did it." and row["summary_source"] == "codex"
+
+
+def test_codex_rate_limited_falls_back_to_mlx(dbp, monkeypatch):
+    _insert(dbp, uuid="a", seg_start="2026-05-20T08:00:00Z", ended="2026-05-20T08:10:00Z",
+            text="codex work", app="Codex")
+    monkeypatch.setattr(codex_runner, "run_codex",
+                        lambda *_a, **_k: (_ for _ in ()).throw(RateLimited("usage limit")))
+    monkeypatch.setattr(mlx_fallback, "summarise", lambda *_a, **_k: "MLX covered codex.")
+    out = summariser.summarise_one(db.fetch_pending(1, db_path=dbp)[0], db_path=dbp)
+    assert out.written and out.source.value == "mlx" and out.rate_limited is True
+
+
+def test_mlx_tail_caps_from_the_bottom(monkeypatch):
+    monkeypatch.setattr(config, "MLX_INPUT_MAX_TOKENS", 10)
+    monkeypatch.setattr(config, "MLX_CHARS_PER_TOKEN", 4)        # 40-char cap
+    assert mlx_fallback._tail_cap("short") == "short"            # under cap → unchanged
+    long = "TOP_HEAD" + "x" * 200 + "BOTTOM_END"
+    out = mlx_fallback._tail_cap(long)
+    assert out.endswith("BOTTOM_END")                            # kept the bottom
+    assert "TOP_HEAD" not in out                                 # dropped the top
+    assert "truncated" in out
+
+
+def test_transcript_is_capped():
+    big = "x" * (config.TRANSCRIPT_CAP_CHARS + 50_000)
+    out = summariser._cap_transcript(big)
+    assert len(out) < len(big)
+    assert "elided" in out
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/src/coding_agent/db.rs
+++ b/src/coding_agent/db.rs
@@ -1,0 +1,453 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// SQLite read/write layer for coding-agent rows (app_sessions rows carrying a
+// non-NULL claude_session_uuid). One row per segment, keyed on
+// (claude_session_uuid, segment_started_at).
+//
+// Lifecycle:
+//   * LIVE   — sealed_at IS NULL, task_method = 'coding_agent_live'.
+//              Re-UPSERTed each poll while the burst is still growing.
+//   * SEALED — sealed_at set, task_method = 'pending_summariser'.
+//              Immutable: the UPSERT carries `WHERE sealed_at IS NULL`, so a
+//              sealed row is never mutated again. Downstream (summariser /
+//              classifier) only ever reads sealed rows.
+//
+// Faithful port of services/coding_agent_indexer/db.py. Uses the daemon's
+// shared meridian RW pool (sqlx) instead of short-lived sqlite3 connections.
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use chrono::Duration;
+use sqlx::SqlitePool;
+
+use super::segment::{iso_utc, parse_iso, Segment};
+
+// Sentinel for rows we own — not produced by any ETL run.
+const INDEXER_ETL_RUN_ID: i64 = 0;
+
+const EMPTY_JSON_LIST: &str = "[]";
+const CATEGORY: &str = "coding"; // we are sure: this IS coding work
+const CATEGORY_METHOD: &str = "coding_agent_indexer";
+
+/// `task_method` is non-NULL in BOTH states so the MLX classifier (which
+/// selects `WHERE task_method IS NULL`) skips these rows whether live or
+/// sealed. The summariser queue is `WHERE task_method = 'pending_summariser'`.
+pub const TASK_METHOD_LIVE: &str = "coding_agent_live";
+pub const TASK_METHOD_PENDING: &str = "pending_summariser";
+
+/// Agent flavour → app_name. We use the agent's product name, not the host
+/// terminal/IDE: a Claude Code session is `Claude Code` whether run inside VS
+/// Code, iTerm2, or any other terminal.
+fn app_name_for(agent: &str) -> &'static str {
+    match agent {
+        "codex" => "Codex",
+        _ => "Claude Code",
+    }
+}
+
+fn text_source_for(agent: &str) -> Option<&'static str> {
+    match agent {
+        "claude_code" => Some("claude_jsonl"),
+        "codex" => Some("codex_jsonl"),
+        _ => None,
+    }
+}
+
+// ──────────────────────── Write paths ──────────────────────────────────────
+
+/// INSERT or UPDATE one (uuid, segment_started_at) row.
+///
+/// `sealed=false` writes/refreshes a LIVE row (mutable, re-UPSERTed each poll).
+/// `sealed=true` seals the row — `task_method` flips to `pending_summariser`
+/// and `sealed_at` is stamped. The UPDATE branch carries `WHERE sealed_at IS
+/// NULL`, so once sealed a row is immutable: subsequent UPSERTs for the same
+/// key are no-ops.
+///
+/// Returns the row id, or None if the segment was rejected as invalid.
+pub async fn upsert_segment(
+    pool: &SqlitePool,
+    segment: &Segment,
+    sealed: bool,
+    sealed_at: Option<&str>,
+) -> Result<Option<i64>> {
+    if !segment.is_valid() {
+        tracing::info!(
+            uuid = %segment.session_uuid,
+            seg_start = %segment.segment_started_at,
+            user = segment.user_turns,
+            asst = segment.assistant_turns,
+            "skip upsert: segment invalid",
+        );
+        return Ok(None);
+    }
+
+    let app_name = app_name_for(&segment.agent);
+    let has_text = !segment.transcript.is_empty();
+    let session_text: Option<&str> = if has_text {
+        Some(&segment.transcript)
+    } else {
+        None
+    };
+    let text_source: Option<&str> = if has_text {
+        text_source_for(&segment.agent)
+    } else {
+        None
+    };
+    let frame_count: i64 = segment.user_turns as i64 + segment.assistant_turns as i64;
+    let task_method = if sealed {
+        TASK_METHOD_PENDING
+    } else {
+        TASK_METHOD_LIVE
+    };
+    let sealed_stamp: Option<&str> = if sealed { sealed_at } else { None };
+
+    sqlx::query(
+        r#"
+        INSERT INTO app_sessions (
+            app_name, started_at, ended_at, duration_s,
+            window_titles, min_frame_id, max_frame_id, frame_count,
+            etl_run_id, idle_frame_count,
+            category, confidence, category_method,
+            session_text, session_text_source,
+            task_method,
+            claude_session_uuid, segment_started_at, sealed_at
+        )
+        VALUES (?, ?, ?, ?,  ?, ?, ?, ?,  ?, ?,  ?, ?, ?,  ?, ?,  ?,  ?, ?, ?)
+        ON CONFLICT (claude_session_uuid, segment_started_at)
+        WHERE claude_session_uuid IS NOT NULL
+        DO UPDATE SET
+            started_at          = excluded.started_at,
+            ended_at            = excluded.ended_at,
+            duration_s          = excluded.duration_s,
+            frame_count         = excluded.frame_count,
+            session_text        = excluded.session_text,
+            session_text_source = excluded.session_text_source,
+            task_method         = excluded.task_method,
+            sealed_at           = excluded.sealed_at
+        WHERE app_sessions.sealed_at IS NULL
+        "#,
+    )
+    .bind(app_name)
+    .bind(&segment.started_at)
+    .bind(&segment.ended_at)
+    .bind(segment.active_seconds)
+    .bind(EMPTY_JSON_LIST)
+    .bind(0_i64) // min_frame_id (sentinel)
+    .bind(0_i64) // max_frame_id (sentinel)
+    .bind(frame_count)
+    .bind(INDEXER_ETL_RUN_ID)
+    .bind(0_i64) // idle_frame_count
+    .bind(CATEGORY)
+    .bind(1.0_f64) // confidence
+    .bind(CATEGORY_METHOD)
+    .bind(session_text)
+    .bind(text_source)
+    .bind(task_method)
+    .bind(&segment.session_uuid)
+    .bind(&segment.segment_started_at)
+    .bind(sealed_stamp)
+    .execute(pool)
+    .await
+    .context("upsert coding-agent segment")?;
+
+    let id: Option<i64> = sqlx::query_scalar(
+        "SELECT id FROM app_sessions WHERE claude_session_uuid = ? AND segment_started_at = ?",
+    )
+    .bind(&segment.session_uuid)
+    .bind(&segment.segment_started_at)
+    .fetch_optional(pool)
+    .await
+    .context("fetch upserted segment id")?;
+
+    Ok(id)
+}
+
+/// Seal every LIVE coding-agent row whose last activity is > `idle_seconds`
+/// old. The robust backstop that does NOT require re-parsing the JSONL: seals
+/// rows left open by crashes, force-quits, macOS sleep, or a deleted file.
+/// Idempotent (already-sealed rows excluded). Returns rows sealed.
+pub async fn seal_stale_open_rows(
+    pool: &SqlitePool,
+    now_iso: &str,
+    idle_seconds: i64,
+) -> Result<u64> {
+    let cutoff = shift_iso(now_iso, -idle_seconds);
+    let res = sqlx::query(
+        r#"
+        UPDATE app_sessions
+        SET    sealed_at = ?, task_method = ?
+        WHERE  claude_session_uuid IS NOT NULL
+          AND  sealed_at IS NULL
+          AND  ended_at < ?
+        "#,
+    )
+    .bind(now_iso)
+    .bind(TASK_METHOD_PENDING)
+    .bind(&cutoff)
+    .execute(pool)
+    .await
+    .context("seal stale open coding-agent rows")?;
+    Ok(res.rows_affected())
+}
+
+/// Delete every Claude/Codex-owned app_sessions row (reseed). Only touches rows
+/// the indexer owns (`claude_session_uuid IS NOT NULL`); never screen-frame
+/// rows. Returns rows deleted.
+pub async fn delete_claude_session_rows(pool: &SqlitePool) -> Result<u64> {
+    let res = sqlx::query("DELETE FROM app_sessions WHERE claude_session_uuid IS NOT NULL")
+        .execute(pool)
+        .await
+        .context("delete coding-agent rows")?;
+    Ok(res.rows_affected())
+}
+
+// ──────────────────────── Read paths ────────────────────────────────────────
+
+/// Return {claude_session_uuid: latest_ended_at} across all its segments.
+/// Used by the daemon's change-detection: skip parsing a JSONL whose mtime
+/// hasn't moved past the latest stored `ended_at`.
+pub async fn fetch_session_endpoints(pool: &SqlitePool) -> Result<HashMap<String, String>> {
+    let rows: Vec<(String, String)> = sqlx::query_as(
+        r#"
+        SELECT claude_session_uuid, MAX(ended_at) AS ended_at
+        FROM   app_sessions
+        WHERE  claude_session_uuid IS NOT NULL
+        GROUP  BY claude_session_uuid
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    .context("fetch coding-agent session endpoints")?;
+    Ok(rows.into_iter().collect())
+}
+
+/// Latest `ended_at` among this session's SEALED segments, or None. Passed to
+/// the parser as `start_after_ts` so already-sealed content is excluded and any
+/// newer record opens a fresh segment (makes a post-SessionEnd resume safe).
+pub async fn sealed_high_water(pool: &SqlitePool, uuid: &str) -> Result<Option<String>> {
+    let hwm: Option<String> = sqlx::query_scalar(
+        "SELECT MAX(ended_at) FROM app_sessions \
+         WHERE claude_session_uuid = ? AND sealed_at IS NOT NULL",
+    )
+    .bind(uuid)
+    .fetch_one(pool)
+    .await
+    .context("fetch sealed high-water mark")?;
+    Ok(hwm.filter(|s| !s.is_empty()))
+}
+
+// ──────────────────────── Helpers ──────────────────────────────────────────
+
+/// Shift an ISO timestamp by `delta_seconds`, in the canonical µs+'+00:00' UTC
+/// format. Lexicographic comparison of two same-format UTC strings is a valid
+/// chronological comparison, so the seal sweep's `ended_at < cutoff` works as a
+/// plain string compare.
+fn shift_iso(iso: &str, delta_seconds: i64) -> String {
+    match parse_iso(iso) {
+        Some(dt) => iso_utc(dt + Duration::seconds(delta_seconds)),
+        None => iso.to_string(),
+    }
+}
+
+// ──────────────────────── Tests ─────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coding_agent::segment::Segment;
+    use sqlx::sqlite::SqliteConnectOptions;
+    use std::str::FromStr;
+
+    async fn fresh_db() -> SqlitePool {
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+            .unwrap()
+            .create_if_missing(true);
+        let pool = SqlitePool::connect_with(opts).await.unwrap();
+        sqlx::migrate!("src/migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    fn seg(uuid: &str, seg_start: &str, ended: &str, turns: u32) -> Segment {
+        Segment {
+            session_uuid: uuid.to_string(),
+            agent: "claude_code".to_string(),
+            cwd: Some("/repo".to_string()),
+            segment_started_at: seg_start.to_string(),
+            started_at: seg_start.to_string(),
+            ended_at: ended.to_string(),
+            user_turns: turns,
+            assistant_turns: turns,
+            active_seconds: 100,
+            transcript: "[user] hi\n\n[claude-code] yo".to_string(),
+            is_last: true,
+        }
+    }
+
+    async fn row_fields(pool: &SqlitePool, id: i64) -> (Option<String>, String) {
+        sqlx::query_as::<_, (Option<String>, String)>(
+            "SELECT sealed_at, task_method FROM app_sessions WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn upsert_live_then_seal_then_immutable() {
+        let pool = fresh_db().await;
+        let s = seg(
+            "u1",
+            "2026-05-20T08:00:00.000000+00:00",
+            "2026-05-20T08:10:00.000000+00:00",
+            2,
+        );
+
+        // Live insert.
+        let id = upsert_segment(&pool, &s, false, None)
+            .await
+            .unwrap()
+            .unwrap();
+        let (sealed, method) = row_fields(&pool, id).await;
+        assert!(sealed.is_none());
+        assert_eq!(method, TASK_METHOD_LIVE);
+
+        // Live re-upsert updates the same row (ended_at grows).
+        let mut s2 = s.clone();
+        s2.ended_at = "2026-05-20T08:20:00.000000+00:00".to_string();
+        let id2 = upsert_segment(&pool, &s2, false, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(id, id2, "same key → same row updated, not duplicated");
+
+        // Seal it.
+        let id3 = upsert_segment(&pool, &s2, true, Some("2026-05-20T09:00:00.000000+00:00"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(id, id3);
+        let (sealed, method) = row_fields(&pool, id).await;
+        assert_eq!(sealed.as_deref(), Some("2026-05-20T09:00:00.000000+00:00"));
+        assert_eq!(method, TASK_METHOD_PENDING);
+
+        // Immutability: a re-upsert after sealing is a no-op (ended_at frozen).
+        let mut s3 = s2.clone();
+        s3.ended_at = "2026-05-20T08:55:00.000000+00:00".to_string();
+        upsert_segment(&pool, &s3, false, None).await.unwrap();
+        let frozen: String = sqlx::query_scalar("SELECT ended_at FROM app_sessions WHERE id = ?")
+            .bind(id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            frozen, "2026-05-20T08:20:00.000000+00:00",
+            "sealed row must not mutate"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_segment_returns_none() {
+        let pool = fresh_db().await;
+        let mut s = seg(
+            "u2",
+            "2026-05-20T08:00:00.000000+00:00",
+            "2026-05-20T08:10:00.000000+00:00",
+            0,
+        );
+        s.user_turns = 0;
+        s.assistant_turns = 0; // no turns → invalid
+        assert!(upsert_segment(&pool, &s, false, None)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn seal_stale_seals_old_live_only() {
+        let pool = fresh_db().await;
+        // Old live row (ended 3h before now) → should seal.
+        let old = seg(
+            "old",
+            "2026-05-20T05:00:00.000000+00:00",
+            "2026-05-20T05:30:00.000000+00:00",
+            2,
+        );
+        let old_id = upsert_segment(&pool, &old, false, None)
+            .await
+            .unwrap()
+            .unwrap();
+        // Recent live row (ended 10 min before now) → should NOT seal.
+        let recent = seg(
+            "recent",
+            "2026-05-20T07:50:00.000000+00:00",
+            "2026-05-20T07:50:00.000000+00:00",
+            2,
+        );
+        let recent_id = upsert_segment(&pool, &recent, false, None)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let now = "2026-05-20T08:00:00.000000+00:00";
+        let n = seal_stale_open_rows(&pool, now, 3600).await.unwrap();
+        assert_eq!(n, 1);
+        assert!(
+            row_fields(&pool, old_id).await.0.is_some(),
+            "old row sealed"
+        );
+        assert!(
+            row_fields(&pool, recent_id).await.0.is_none(),
+            "recent row stays live"
+        );
+    }
+
+    #[tokio::test]
+    async fn sealed_high_water_and_endpoints() {
+        let pool = fresh_db().await;
+        let a1 = seg(
+            "a",
+            "2026-05-20T08:00:00.000000+00:00",
+            "2026-05-20T08:30:00.000000+00:00",
+            2,
+        );
+        upsert_segment(&pool, &a1, true, Some("2026-05-20T09:00:00.000000+00:00"))
+            .await
+            .unwrap();
+        let a2 = seg(
+            "a",
+            "2026-05-20T10:00:00.000000+00:00",
+            "2026-05-20T10:30:00.000000+00:00",
+            2,
+        );
+        upsert_segment(&pool, &a2, false, None).await.unwrap(); // live, not sealed
+
+        // High-water = latest SEALED ended_at (ignores the live a2).
+        let hwm = sealed_high_water(&pool, "a").await.unwrap();
+        assert_eq!(hwm.as_deref(), Some("2026-05-20T08:30:00.000000+00:00"));
+
+        // Endpoints = latest ended_at across ALL segments (includes live a2).
+        let eps = fetch_session_endpoints(&pool).await.unwrap();
+        assert_eq!(
+            eps.get("a").map(String::as_str),
+            Some("2026-05-20T10:30:00.000000+00:00")
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_reseed_clears_only_coding_rows() {
+        let pool = fresh_db().await;
+        let s = seg(
+            "z",
+            "2026-05-20T08:00:00.000000+00:00",
+            "2026-05-20T08:10:00.000000+00:00",
+            2,
+        );
+        upsert_segment(&pool, &s, false, None).await.unwrap();
+        let n = delete_claude_session_rows(&pool).await.unwrap();
+        assert_eq!(n, 1);
+        let eps = fetch_session_endpoints(&pool).await.unwrap();
+        assert!(eps.is_empty());
+    }
+}

--- a/src/coding_agent/hook.rs
+++ b/src/coding_agent/hook.rs
@@ -1,0 +1,113 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// `meridian coding-agent-hook` — the Claude Code SessionEnd hook entry point.
+// Claude Code invokes it with a JSON payload on stdin describing the event;
+// for SessionEnd that payload carries the transcript path. We register that one
+// session immediately (sealing it), then exit 0 — a SessionEnd hook must never
+// block Claude, so every failure path still returns cleanly.
+//
+// Port of services/coding_agent_indexer/hook.py. One-shot: opens its own
+// short-lived pool against MERIDIAN_DB (the daemon already created + migrated
+// it), registers, closes.
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use chrono::Utc;
+use serde_json::Value;
+use sqlx::sqlite::SqliteConnectOptions;
+use sqlx::SqlitePool;
+
+use super::indexer::register_session;
+
+/// Run the hook. Always returns (never errors out): a SessionEnd hook that
+/// returned non-zero or panicked could disrupt Claude, so we swallow every
+/// failure to stderr and let the caller exit 0.
+pub async fn run_hook() {
+    let mut raw = String::new();
+    let _ = std::io::stdin().read_to_string(&mut raw);
+    let payload: Value = serde_json::from_str(raw.trim()).unwrap_or(Value::Null);
+
+    let jsonl_path = match extract_jsonl_path(&payload) {
+        Some(p) => p,
+        None => {
+            eprintln!("coding-agent-hook: could not determine JSONL path from payload");
+            return;
+        }
+    };
+    if !jsonl_path.exists() {
+        eprintln!(
+            "coding-agent-hook: transcript not found: {}",
+            jsonl_path.display()
+        );
+        return;
+    }
+
+    let db_path = meridian_db_path();
+    let uri = format!("sqlite://{}", db_path.display());
+    let opts = match SqliteConnectOptions::from_str(&uri) {
+        Ok(o) => o.create_if_missing(false),
+        Err(e) => {
+            eprintln!("coding-agent-hook: bad db uri {}: {}", uri, e);
+            return;
+        }
+    };
+    let pool = match SqlitePool::connect_with(opts).await {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "coding-agent-hook: open {} failed: {}",
+                db_path.display(),
+                e
+            );
+            return;
+        }
+    };
+
+    let outcome = register_session(&pool, &jsonl_path, true, Utc::now()).await;
+    pool.close().await;
+    eprintln!(
+        "coding-agent-hook: {:?} for {}",
+        outcome,
+        jsonl_path.display()
+    );
+}
+
+/// Tease the JSONL path out of the payload (mirrors `_extract_jsonl_path`):
+/// `transcript_path` / `jsonl_path` directly, else construct from
+/// `session_id` + `cwd` via Claude's project-dir convention.
+fn extract_jsonl_path(payload: &Value) -> Option<PathBuf> {
+    let direct = payload
+        .get("jsonl_path")
+        .or_else(|| payload.get("transcript_path"))
+        .and_then(|v| v.as_str());
+    if let Some(p) = direct {
+        return Some(expand(p));
+    }
+
+    let session_id = payload
+        .get("session_id")
+        .or_else(|| payload.get("sessionId"))
+        .and_then(|v| v.as_str());
+    let cwd = payload
+        .get("cwd")
+        .or_else(|| payload.get("project_cwd"))
+        .and_then(|v| v.as_str());
+    if let (Some(sid), Some(cwd)) = (session_id, cwd) {
+        let sanitized = format!("-{}", cwd.replace('/', "-"));
+        let base = expand("~/.claude/projects");
+        return Some(base.join(sanitized).join(format!("{}.jsonl", sid)));
+    }
+    None
+}
+
+fn meridian_db_path() -> PathBuf {
+    let raw =
+        std::env::var("MERIDIAN_DB").unwrap_or_else(|_| "~/.meridian/meridian.db".to_string());
+    expand(&raw)
+}
+
+fn expand(p: &str) -> PathBuf {
+    PathBuf::from(shellexpand::tilde(p).into_owned())
+}

--- a/src/coding_agent/indexer.rs
+++ b/src/coding_agent/indexer.rs
@@ -1,0 +1,491 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// The coding-agent indexer task: a low-frequency tokio loop that turns Claude
+// Code / Codex JSONLs into app_sessions segment rows. Port of
+// services/coding_agent_indexer/{register,daemon}.py.
+//
+// Per tick: (1) seal settled live rows (the JSONL-free backstop for crashes /
+// force-quits / sleep), then (2) re-parse changed files and refresh their live
+// last segment. A never-seen file is only backfilled if it was touched TODAY
+// (local) — so a fresh DB / post-downtime start does not re-index weeks of
+// history. The whole task stays dormant unless a terminal coding agent is
+// present (device gate).
+//
+// Dropped vs the Python original: the fork-skip list (we summarise via
+// `claude -p` stdin, not `--fork-session`, so no throwaway JSONLs to skip) and
+// host_app resolution (it was only logged, never stored).
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use chrono::{DateTime, Local, Utc};
+use sqlx::SqlitePool;
+use tokio::sync::{watch, Notify};
+
+use super::db;
+use super::segment::{
+    iso_utc, parse_iso, parse_session_segments, Segment, SegmentParams, SEGMENT_GAP_SECONDS,
+};
+
+const DEFAULT_POLL_INTERVAL_S: u64 = 600;
+const DEFAULT_SEAL_IDLE_S: i64 = 3600;
+/// Slack (s) on the mtime-vs-stored-ended_at change check: absorbs clock skew
+/// and ISO truncation so an unchanged file isn't needlessly re-parsed.
+const CHANGE_SLACK_SECS: f64 = 5.0;
+
+/// Resolved paths + cadence for the indexer (env-driven, mirrors the Python
+/// config + the retired launchd plist).
+pub struct IndexerConfig {
+    pub claude_projects_dir: PathBuf,
+    pub codex_sessions_dir: PathBuf,
+    pub poll_interval_secs: u64,
+    pub seal_idle_seconds: i64,
+}
+
+impl IndexerConfig {
+    pub fn from_env() -> Self {
+        let expand = |env: &str, default: &str| -> PathBuf {
+            let raw = std::env::var(env).unwrap_or_else(|_| default.to_string());
+            PathBuf::from(shellexpand::tilde(&raw).into_owned())
+        };
+        fn parse_env<T: std::str::FromStr>(env: &str) -> Option<T> {
+            std::env::var(env).ok().and_then(|v| v.parse().ok())
+        }
+        Self {
+            claude_projects_dir: expand("CLAUDE_PROJECTS_DIR", "~/.claude/projects"),
+            codex_sessions_dir: expand("CODEX_SESSIONS_DIR", "~/.codex/sessions"),
+            poll_interval_secs: parse_env("INDEXER_POLL_INTERVAL_S")
+                .unwrap_or(DEFAULT_POLL_INTERVAL_S),
+            seal_idle_seconds: parse_env("INDEXER_SEAL_IDLE_S").unwrap_or(DEFAULT_SEAL_IDLE_S),
+        }
+    }
+}
+
+/// Device gate: a terminal coding agent is present iff its data dir exists OR
+/// its binary resolves on PATH. When false, the indexer task stays dormant.
+pub fn coding_agents_present(cfg: &IndexerConfig) -> bool {
+    cfg.claude_projects_dir.exists()
+        || cfg.codex_sessions_dir.exists()
+        || binary_on_path("claude")
+        || binary_on_path("codex")
+}
+
+fn binary_on_path(bin: &str) -> bool {
+    std::env::var_os("PATH")
+        .map(|p| std::env::split_paths(&p).any(|dir| dir.join(bin).is_file()))
+        .unwrap_or(false)
+}
+
+/// Outcome of registering one JSONL (mirrors `RegisterOutcome`, trimmed).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    Inserted,
+    SkippedEmpty,
+    Failed,
+}
+
+// ──────────────────────── Register one session ──────────────────────────────
+
+/// Parse one JSONL into segments and UPSERT one row each, sealing settled ones.
+/// Idempotent; never panics. `session_ended=true` (the SessionEnd-hook path)
+/// seals the last segment immediately; `false` (the poller) leaves an
+/// actively-growing last segment live until it idles out.
+pub async fn register_session(
+    pool: &SqlitePool,
+    jsonl_path: &Path,
+    session_ended: bool,
+    now: DateTime<Utc>,
+) -> Outcome {
+    let uuid = match jsonl_path.file_stem().and_then(|s| s.to_str()) {
+        Some(u) => u.to_string(),
+        None => return Outcome::SkippedEmpty,
+    };
+    let now_iso = iso_utc(now);
+
+    // Exclude already-sealed content so any newer record opens a fresh segment.
+    let start_after = match db::sealed_high_water(pool, &uuid).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(uuid = %uuid, error = %e, "sealed_high_water failed");
+            return Outcome::Failed;
+        }
+    };
+
+    // Heavy work (file read + parse) off the async runtime.
+    let params = SegmentParams {
+        start_after_ts: start_after,
+        ..Default::default()
+    };
+    let path_owned = jsonl_path.to_path_buf();
+    let segments: Vec<Segment> = match tokio::task::spawn_blocking(move || {
+        let (_meta, segs) = parse_session_segments(&path_owned, &params);
+        segs
+    })
+    .await
+    {
+        Ok(segs) => segs,
+        Err(e) => {
+            tracing::warn!(uuid = %uuid, error = %e, "parse task panicked");
+            return Outcome::Failed;
+        }
+    };
+
+    let valid: Vec<&Segment> = segments.iter().filter(|s| s.is_valid()).collect();
+    if valid.is_empty() {
+        return Outcome::SkippedEmpty;
+    }
+
+    let mut wrote = 0_u32;
+    for seg in valid {
+        let sealed = should_seal(seg, session_ended, now);
+        let stamp = if sealed { Some(now_iso.as_str()) } else { None };
+        match db::upsert_segment(pool, seg, sealed, stamp).await {
+            Ok(Some(row_id)) => {
+                wrote += 1;
+                tracing::info!(
+                    agent = %seg.agent, uuid = %seg.session_uuid,
+                    seg = %seg.segment_started_at, ended = %seg.ended_at,
+                    active_s = seg.active_seconds, turns = seg.user_turns + seg.assistant_turns,
+                    sealed, row_id, "registered coding-agent segment",
+                );
+            }
+            Ok(None) => {} // invalid, or hit an already-sealed row (no-op)
+            Err(e) => {
+                tracing::warn!(uuid = %seg.session_uuid, seg = %seg.segment_started_at, error = %e, "upsert failed");
+            }
+        }
+    }
+
+    if wrote == 0 {
+        Outcome::SkippedEmpty
+    } else {
+        Outcome::Inserted
+    }
+}
+
+/// A non-last segment is always sealed (its >1h gap already happened). The last
+/// segment seals iff the caller says the session ended, or its last message is
+/// already older than the segment gap (settled by idle).
+fn should_seal(seg: &Segment, session_ended: bool, now: DateTime<Utc>) -> bool {
+    if !seg.is_last || session_ended {
+        return true;
+    }
+    match parse_iso(&seg.ended_at) {
+        Some(ended) => {
+            let idle = (now - ended).num_milliseconds() as f64 / 1000.0;
+            idle > SEGMENT_GAP_SECONDS as f64
+        }
+        None => false, // can't determine idleness → keep live
+    }
+}
+
+// ──────────────────────── One tick ──────────────────────────────────────────
+
+/// One poll sweep: seal settled live rows, then register changed files. Returns
+/// (rows sealed, files written).
+pub async fn run_tick(pool: &SqlitePool, cfg: &IndexerConfig, now: DateTime<Utc>) -> (u64, u64) {
+    let now_iso = iso_utc(now);
+
+    let sealed = match db::seal_stale_open_rows(pool, &now_iso, cfg.seal_idle_seconds).await {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::warn!(error = %e, "seal sweep failed");
+            0
+        }
+    };
+
+    let candidates = candidate_jsonls(pool, cfg, now).await;
+    let mut wrote = 0_u64;
+    let mut failed = 0_u64;
+    for path in candidates {
+        match register_session(pool, &path, false, now).await {
+            Outcome::Inserted => wrote += 1,
+            Outcome::Failed => failed += 1,
+            Outcome::SkippedEmpty => {}
+        }
+    }
+
+    if sealed > 0 || wrote > 0 || failed > 0 {
+        tracing::info!(sealed, wrote, failed, "coding-agent indexer tick");
+    }
+    (sealed, wrote)
+}
+
+/// Files whose mtime moved past their stored `ended_at` (+slack). A never-seen
+/// file is included only if it was touched TODAY (local) — the backfill-only-
+/// today rule. Returned oldest-changed first.
+async fn candidate_jsonls(
+    pool: &SqlitePool,
+    cfg: &IndexerConfig,
+    now: DateTime<Utc>,
+) -> Vec<PathBuf> {
+    let endpoints = db::fetch_session_endpoints(pool).await.unwrap_or_default();
+    let dirs = iter_project_dirs(cfg);
+    let today = now.with_timezone(&Local).date_naive();
+
+    let mut candidates: Vec<(f64, PathBuf)> = Vec::new();
+    for dir in dirs {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let mtime = match entry.metadata().and_then(|m| m.modified()) {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            let mtime_epoch = system_time_epoch(mtime);
+            let stem = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string();
+
+            match endpoints.get(&stem) {
+                Some(end_iso) => {
+                    if let Some(end_epoch) = iso_to_epoch(end_iso) {
+                        if mtime_epoch <= end_epoch + CHANGE_SLACK_SECS {
+                            continue; // nothing new since last register
+                        }
+                    }
+                }
+                None => {
+                    // Never indexed → backfill only if touched today.
+                    let mdate = DateTime::<Utc>::from(mtime)
+                        .with_timezone(&Local)
+                        .date_naive();
+                    if mdate != today {
+                        continue;
+                    }
+                }
+            }
+            candidates.push((mtime_epoch, path));
+        }
+    }
+    candidates.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    candidates.into_iter().map(|(_, p)| p).collect()
+}
+
+/// All Claude project dirs (children of CLAUDE_PROJECTS_DIR) + Codex day dirs
+/// (`<sessions>/<YYYY>/<MM>/<DD>`).
+fn iter_project_dirs(cfg: &IndexerConfig) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+
+    if let Ok(entries) = std::fs::read_dir(&cfg.claude_projects_dir) {
+        for e in entries.flatten() {
+            if e.path().is_dir() {
+                dirs.push(e.path());
+            }
+        }
+    }
+
+    // Codex layout: <sessions>/<YYYY>/<MM>/<DD>/rollout-*.jsonl
+    if let Ok(years) = std::fs::read_dir(&cfg.codex_sessions_dir) {
+        for y in years.flatten().filter(|y| y.path().is_dir()) {
+            if let Ok(months) = std::fs::read_dir(y.path()) {
+                for m in months.flatten().filter(|m| m.path().is_dir()) {
+                    if let Ok(days) = std::fs::read_dir(m.path()) {
+                        for d in days.flatten().filter(|d| d.path().is_dir()) {
+                            dirs.push(d.path());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    dirs
+}
+
+// ──────────────────────── Loop ──────────────────────────────────────────────
+
+/// The indexer task: gate, an immediate backfill-today tick, then poll until
+/// shutdown. Returns immediately (dormant) if no coding agent is present.
+/// Notifies `summariser_notify` whenever a tick seals or writes rows, so the
+/// summariser wakes near-instantly on the indexer's own seals.
+pub async fn run_loop(
+    pool: SqlitePool,
+    summariser_notify: Arc<Notify>,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    let cfg = IndexerConfig::from_env();
+    if !coding_agents_present(&cfg) {
+        tracing::info!("coding-agent indexer dormant — no claude/codex detected");
+        return;
+    }
+    tracing::info!(
+        claude = %cfg.claude_projects_dir.display(),
+        codex = %cfg.codex_sessions_dir.display(),
+        poll_s = cfg.poll_interval_secs,
+        "coding-agent indexer starting",
+    );
+
+    let notify_if_work = |sealed: u64, wrote: u64| {
+        if sealed > 0 || wrote > 0 {
+            summariser_notify.notify_one();
+        }
+    };
+
+    let (sealed, wrote) = run_tick(&pool, &cfg, Utc::now()).await; // backfill-today on startup
+    notify_if_work(sealed, wrote);
+
+    loop {
+        tokio::select! {
+            _ = shutdown_rx.changed() => break,
+            _ = tokio::time::sleep(Duration::from_secs(cfg.poll_interval_secs)) => {
+                let (sealed, wrote) = run_tick(&pool, &cfg, Utc::now()).await;
+                notify_if_work(sealed, wrote);
+            }
+        }
+    }
+    tracing::info!("coding-agent indexer stopped");
+}
+
+// ──────────────────────── Helpers ──────────────────────────────────────────
+
+fn system_time_epoch(t: SystemTime) -> f64 {
+    t.duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+fn iso_to_epoch(iso: &str) -> Option<f64> {
+    parse_iso(iso).map(|dt| dt.timestamp_millis() as f64 / 1000.0)
+}
+
+// ──────────────────────── Tests ─────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration as ChronoDuration, TimeZone};
+    use sqlx::sqlite::SqliteConnectOptions;
+    use std::io::Write;
+    use std::str::FromStr;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    async fn fresh_db() -> SqlitePool {
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+            .unwrap()
+            .create_if_missing(true);
+        let pool = SqlitePool::connect_with(opts).await.unwrap();
+        sqlx::migrate!("src/migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    fn tmpdir() -> PathBuf {
+        static C: AtomicU64 = AtomicU64::new(0);
+        let mut d = std::env::temp_dir();
+        d.push(format!(
+            "meridian_idx_test_{}",
+            C.fetch_add(1, Ordering::SeqCst)
+        ));
+        let proj = d.join(".claude").join("projects").join("proj");
+        std::fs::create_dir_all(&proj).unwrap();
+        proj
+    }
+
+    fn base() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 20, 8, 0, 0).unwrap()
+    }
+
+    fn rec(offset_s: i64, role: &str, text: &str) -> String {
+        let ts = (base() + ChronoDuration::seconds(offset_s))
+            .format("%Y-%m-%dT%H:%M:%S.%3fZ")
+            .to_string();
+        serde_json::json!({
+            "type": role, "timestamp": ts, "cwd": "/repo",
+            "message": { "role": role, "content": text }
+        })
+        .to_string()
+    }
+
+    fn write_jsonl(dir: &Path, uuid: &str, lines: &[String]) -> PathBuf {
+        let p = dir.join(format!("{}.jsonl", uuid));
+        let mut f = std::fs::File::create(&p).unwrap();
+        for l in lines {
+            writeln!(f, "{}", l).unwrap();
+        }
+        p
+    }
+
+    #[tokio::test]
+    async fn register_seals_non_last_keeps_last_live() {
+        let pool = fresh_db().await;
+        let dir = tmpdir();
+        // Two bursts split by a 2h gap → seg0 (sealed), seg1 (last).
+        let p = write_jsonl(
+            &dir,
+            "s1",
+            &[
+                rec(0, "user", "morning"),
+                rec(60, "assistant", "ok"),
+                rec(60 + 7200, "user", "afternoon"),
+                rec(60 + 7200 + 30, "assistant", "ok2"),
+            ],
+        );
+        // now = just after the last message → last segment is recent (not idle).
+        let now = base() + ChronoDuration::seconds(60 + 7200 + 90);
+        let outcome = register_session(&pool, &p, false, now).await;
+        assert_eq!(outcome, Outcome::Inserted);
+
+        let rows: Vec<(String, Option<String>, String)> = sqlx::query_as(
+            "SELECT segment_started_at, sealed_at, task_method FROM app_sessions \
+             WHERE claude_session_uuid='s1' ORDER BY segment_started_at",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(rows[0].1.is_some(), "non-last segment sealed");
+        assert_eq!(rows[0].2, db::TASK_METHOD_PENDING);
+        assert!(rows[1].1.is_none(), "last segment stays live");
+        assert_eq!(rows[1].2, db::TASK_METHOD_LIVE);
+    }
+
+    #[tokio::test]
+    async fn session_ended_seals_last_segment() {
+        let pool = fresh_db().await;
+        let dir = tmpdir();
+        let p = write_jsonl(
+            &dir,
+            "s2",
+            &[rec(0, "user", "hi"), rec(30, "assistant", "yo")],
+        );
+        let now = base() + ChronoDuration::seconds(120);
+        // Hook path: session_ended=true → the single (last) segment seals now.
+        register_session(&pool, &p, true, now).await;
+        let sealed: Option<String> =
+            sqlx::query_scalar("SELECT sealed_at FROM app_sessions WHERE claude_session_uuid='s2'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(sealed.is_some());
+    }
+
+    #[tokio::test]
+    async fn device_gate_detects_data_dir() {
+        let dir = tmpdir(); // creates .../.claude/projects/proj
+        let cfg = IndexerConfig {
+            claude_projects_dir: dir.clone(),
+            codex_sessions_dir: dir.join("nonexistent-codex"),
+            poll_interval_secs: 600,
+            seal_idle_seconds: 3600,
+        };
+        assert!(coding_agents_present(&cfg));
+
+        let cfg_absent = IndexerConfig {
+            claude_projects_dir: dir.join("nope-claude"),
+            codex_sessions_dir: dir.join("nope-codex"),
+            poll_interval_secs: 600,
+            seal_idle_seconds: 3600,
+        };
+        // Only false if neither dir exists AND no binary on PATH; binaries may be
+        // installed on the dev box, so just assert the dir-absence branch is wired.
+        let _ = coding_agents_present(&cfg_absent);
+    }
+}

--- a/src/coding_agent/jsonl.rs
+++ b/src/coding_agent/jsonl.rs
@@ -1,0 +1,430 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// JSONL normalisation layer for coding-agent sessions. Claude Code and Codex
+// write different on-disk event schemas; each record is normalised to a common
+// `NormRecord` (timestamp, cwd, is_turn, is_user, body) so everything
+// downstream (segmentation, active-time, transcript) is agent-agnostic.
+//
+// This is a faithful port of services/coding_agent_indexer/jsonl_meta.py
+// (the `_iter_claude` / `_iter_codex` / `_format_*` helpers). Parity with that
+// module is enforced by tests; change both together.
+
+use std::fs::File;
+use std::io::{self, BufRead, BufReader};
+use std::path::Path;
+
+use serde::Serialize;
+use serde_json::ser::Formatter;
+use serde_json::Value;
+
+/// Truncation for noisy tool_result bodies (file dumps, large search outputs).
+const TOOL_RESULT_CAP: usize = 800;
+const CLAUDE_ASSISTANT_LABEL: &str = "claude-code";
+const CODEX_ASSISTANT_LABEL: &str = "codex";
+
+/// One raw JSONL record normalised across Claude and Codex schemas.
+#[derive(Debug, Clone)]
+pub struct NormRecord {
+    pub timestamp: Option<String>,
+    pub cwd: Option<String>,
+    pub is_turn: bool,
+    pub is_user: bool,
+    /// True only for a REAL human prompt (text), not a tool-result. Claude
+    /// records tool outputs as `type:user` too, so `is_user` alone can't anchor
+    /// a conversation boundary — `is_user_prompt` is what the time-box split
+    /// aligns to so a segment begins at a genuine user message.
+    pub is_user_prompt: bool,
+    pub role_label: Option<String>,
+    pub body: String,
+}
+
+/// Is this user `content` a genuine prompt (has text), vs a tool-result-only
+/// message? A real prompt is a non-empty string or a block list containing a
+/// `text` block; a tool-result message carries only `tool_result` blocks.
+fn is_real_user_prompt(content: &Value) -> bool {
+    if let Some(s) = content.as_str() {
+        return !s.trim().is_empty();
+    }
+    if let Some(arr) = content.as_array() {
+        return arr.iter().any(|b| {
+            b.as_object()
+                .and_then(|o| o.get("type"))
+                .and_then(|t| t.as_str())
+                == Some("text")
+        });
+    }
+    false
+}
+
+/// Infer the agent from a JSONL path (mirrors `_infer_agent`).
+pub fn infer_agent(path: &Path) -> String {
+    let names: Vec<String> = path
+        .ancestors()
+        .filter_map(|p| p.file_name())
+        .map(|n| n.to_string_lossy().into_owned())
+        .collect();
+    let has = |n: &str| names.iter().any(|x| x == n);
+    if has("projects") && has(".claude") {
+        return "claude_code".to_string();
+    }
+    if has("sessions") && has(".codex") {
+        return "codex".to_string();
+    }
+    let s = path.to_string_lossy();
+    if s.contains("/.claude/") {
+        return "claude_code".to_string();
+    }
+    if s.contains("/.codex/") {
+        return "codex".to_string();
+    }
+    "unknown".to_string()
+}
+
+/// Read each well-formed JSON object from the file. Tolerant of partial writes,
+/// malformed lines, and IO errors — they are silently skipped (mirrors
+/// `_iter_records`).
+fn iter_records(path: &Path) -> Vec<Value> {
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
+    };
+    let reader = BufReader::new(file);
+    let mut out = Vec::new();
+    for line in reader.lines() {
+        let raw = match line {
+            Ok(l) => l,
+            Err(_) => break, // read/IO error — stop, like the Python OSError path
+        };
+        if raw.trim().is_empty() {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<Value>(&raw) {
+            if v.is_object() {
+                out.push(v);
+            }
+        }
+    }
+    out
+}
+
+/// Yield canonical records for one source JSONL (agent-aware).
+pub fn iter_normalised(path: &Path, agent: &str) -> Vec<NormRecord> {
+    let records = iter_records(path);
+    if agent == "codex" {
+        records.iter().map(norm_codex).collect()
+    } else {
+        records.iter().map(norm_claude).collect()
+    }
+}
+
+fn str_field<'a>(v: &'a Value, key: &str) -> Option<&'a str> {
+    v.get(key).and_then(|x| x.as_str())
+}
+
+/// Normalise one Claude Code record (mirrors `_iter_claude`).
+fn norm_claude(raw: &Value) -> NormRecord {
+    let ts = str_field(raw, "timestamp").map(|s| s.to_string());
+    let cwd = str_field(raw, "cwd").map(|s| s.to_string());
+    let rtype = str_field(raw, "type");
+
+    let is_sidechain = raw
+        .get("isSidechain")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let is_meta = raw.get("isMeta").and_then(|v| v.as_bool()).unwrap_or(false);
+    let is_conv = matches!(rtype, Some("user") | Some("assistant"));
+
+    if is_sidechain || is_meta || !is_conv {
+        return NormRecord {
+            timestamp: ts,
+            cwd,
+            is_turn: false,
+            is_user: false,
+            is_user_prompt: false,
+            role_label: None,
+            body: String::new(),
+        };
+    }
+
+    let msg = raw.get("message").cloned().unwrap_or(Value::Null);
+    let role_raw = str_field(&msg, "role")
+        .or(rtype)
+        .unwrap_or("user")
+        .to_string();
+    let is_user = role_raw == "user";
+    let label = if is_user {
+        role_raw.clone()
+    } else {
+        CLAUDE_ASSISTANT_LABEL.to_string()
+    };
+    let content = msg
+        .get("content")
+        .cloned()
+        .unwrap_or(Value::String(String::new()));
+    let is_user_prompt = is_user && is_real_user_prompt(&content);
+    NormRecord {
+        timestamp: ts,
+        cwd,
+        is_turn: true,
+        is_user,
+        is_user_prompt,
+        role_label: Some(label),
+        body: format_claude_content(&content),
+    }
+}
+
+/// Normalise one Codex rollout record (mirrors `_iter_codex`).
+fn norm_codex(raw: &Value) -> NormRecord {
+    let ts = str_field(raw, "timestamp").map(|s| s.to_string());
+    let payload = raw.get("payload").cloned().unwrap_or(Value::Null);
+    let cwd = str_field(&payload, "cwd").map(|s| s.to_string());
+
+    if str_field(raw, "type") != Some("event_msg") {
+        return NormRecord {
+            timestamp: ts,
+            cwd,
+            is_turn: false,
+            is_user: false,
+            is_user_prompt: false,
+            role_label: None,
+            body: String::new(),
+        };
+    }
+
+    let sub = str_field(&payload, "type");
+    let message = payload
+        .get("message")
+        .cloned()
+        .unwrap_or(Value::String(String::new()));
+    match sub {
+        Some("user_message") => NormRecord {
+            timestamp: ts,
+            cwd,
+            is_turn: true,
+            is_user: true,
+            is_user_prompt: true, // codex user_message is always a real prompt
+            role_label: Some("user".to_string()),
+            body: format_codex_message(&message),
+        },
+        Some("agent_message") => NormRecord {
+            timestamp: ts,
+            cwd,
+            is_turn: true,
+            is_user: false,
+            is_user_prompt: false,
+            role_label: Some(CODEX_ASSISTANT_LABEL.to_string()),
+            body: format_codex_message(&message),
+        },
+        _ => NormRecord {
+            timestamp: ts,
+            cwd,
+            is_turn: false,
+            is_user: false,
+            is_user_prompt: false,
+            role_label: None,
+            body: String::new(),
+        },
+    }
+}
+
+/// First `n` chars (Unicode scalar values), matching Python str slicing.
+fn take_chars(s: &str, n: usize) -> String {
+    s.chars().take(n).collect()
+}
+
+fn char_count(s: &str) -> usize {
+    s.chars().count()
+}
+
+/// Python truthiness for a JSON value (`if inp:`).
+fn is_truthy(v: &Value) -> bool {
+    match v {
+        Value::Null => false,
+        Value::Bool(b) => *b,
+        Value::Number(n) => n.as_f64().map(|f| f != 0.0).unwrap_or(true),
+        Value::String(s) => !s.is_empty(),
+        Value::Array(a) => !a.is_empty(),
+        Value::Object(o) => !o.is_empty(),
+    }
+}
+
+/// Formatter matching CPython `json.dumps` default separators (`", "` / `": "`),
+/// so tool_use input rendering matches the Python indexer char-for-char. (Object
+/// key order still differs — serde_json sorts, CPython preserves insertion order
+/// — but that's reordering of identical content: same length, cosmetic.)
+struct PyFormatter;
+
+impl Formatter for PyFormatter {
+    fn begin_array_value<W: ?Sized + io::Write>(
+        &mut self,
+        w: &mut W,
+        first: bool,
+    ) -> io::Result<()> {
+        if first {
+            Ok(())
+        } else {
+            w.write_all(b", ")
+        }
+    }
+    fn begin_object_key<W: ?Sized + io::Write>(
+        &mut self,
+        w: &mut W,
+        first: bool,
+    ) -> io::Result<()> {
+        if first {
+            Ok(())
+        } else {
+            w.write_all(b", ")
+        }
+    }
+    fn begin_object_value<W: ?Sized + io::Write>(&mut self, w: &mut W) -> io::Result<()> {
+        w.write_all(b": ")
+    }
+}
+
+/// Serialize a JSON value with CPython's `json.dumps(..., ensure_ascii=False)`
+/// spelling (spaced separators, raw UTF-8).
+fn py_json(v: &Value) -> String {
+    let mut buf = Vec::new();
+    let mut ser = serde_json::Serializer::with_formatter(&mut buf, PyFormatter);
+    if v.serialize(&mut ser).is_err() {
+        return String::new();
+    }
+    String::from_utf8(buf).unwrap_or_default()
+}
+
+/// Best-effort `str(value)` for the rare non-text branches (mirrors Python's
+/// `str(block)` / `str(p)` / `str(tr)`). Exact for str/bool/number/null;
+/// compact JSON for arrays/objects (a documented minor divergence from CPython
+/// repr, only hit by malformed/exotic content blocks).
+fn py_str(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Bool(b) => {
+            if *b {
+                "True".into()
+            } else {
+                "False".into()
+            }
+        }
+        Value::Null => "None".into(),
+        Value::Number(n) => n.to_string(),
+        _ => serde_json::to_string(v).unwrap_or_default(),
+    }
+}
+
+/// Render Claude `message.content` (string or typed blocks) to text
+/// (mirrors `_format_claude_content`).
+fn format_claude_content(content: &Value) -> String {
+    if let Some(s) = content.as_str() {
+        return s.to_string();
+    }
+    let arr = match content.as_array() {
+        Some(a) => a,
+        None => return String::new(),
+    };
+    let mut parts: Vec<String> = Vec::new();
+    for block in arr {
+        let obj = match block.as_object() {
+            Some(o) => o,
+            None => {
+                parts.push(py_str(block));
+                continue;
+            }
+        };
+        match obj.get("type").and_then(|v| v.as_str()) {
+            Some("text") => {
+                parts.push(
+                    obj.get("text")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                );
+            }
+            Some("tool_use") => {
+                let name = obj.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+                let inp_repr = match obj.get("input") {
+                    Some(v) if is_truthy(v) => take_chars(&py_json(v), 400),
+                    _ => String::new(),
+                };
+                let s = format!("[tool_use: {} {}]", name, inp_repr);
+                parts.push(s.trim_end().to_string());
+            }
+            Some("tool_result") => {
+                let tr = obj
+                    .get("content")
+                    .cloned()
+                    .unwrap_or(Value::String(String::new()));
+                let tr_str = if let Some(list) = tr.as_array() {
+                    list.iter()
+                        .map(|p| match p.as_object() {
+                            Some(o) => o
+                                .get("text")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string(),
+                            None => py_str(p),
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                } else {
+                    py_str(&tr)
+                };
+                let tr_str = tr_str.trim().to_string();
+                let capped = if char_count(&tr_str) > TOOL_RESULT_CAP {
+                    format!("{}…[truncated]", take_chars(&tr_str, TOOL_RESULT_CAP))
+                } else {
+                    tr_str
+                };
+                parts.push(format!("[tool_result: {}]", capped));
+            }
+            Some("thinking") => {
+                let t = obj.get("thinking").and_then(|v| v.as_str()).unwrap_or("");
+                if !t.is_empty() {
+                    parts.push(format!("[thinking] {}", t));
+                }
+            }
+            _ => {}
+        }
+    }
+    parts
+        .into_iter()
+        .filter(|p| !p.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Render a Codex event_msg message payload into plain text
+/// (mirrors `_format_codex_message`).
+fn format_codex_message(content: &Value) -> String {
+    if let Some(s) = content.as_str() {
+        return s.to_string();
+    }
+    let arr = match content.as_array() {
+        Some(a) => a,
+        None => return String::new(),
+    };
+    let mut parts: Vec<String> = Vec::new();
+    for block in arr {
+        if let Some(o) = block.as_object() {
+            if let Some(text) = o.get("text").and_then(|v| v.as_str()) {
+                if !text.is_empty() {
+                    parts.push(text.to_string());
+                    continue;
+                }
+            }
+            if let Some(nested) = o.get("content").and_then(|v| v.as_str()) {
+                if !nested.is_empty() {
+                    parts.push(nested.to_string());
+                }
+            }
+        } else if let Some(s) = block.as_str() {
+            parts.push(s.to_string());
+        }
+    }
+    parts
+        .into_iter()
+        .filter(|p| !p.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/src/coding_agent/mod.rs
+++ b/src/coding_agent/mod.rs
@@ -1,0 +1,39 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Coding-agent indexer + summariser, ported from the Python services
+// (services/coding_agent_indexer, services/coding_agent_summariser) into the
+// daemon. Spawned as gated tokio tasks from main.rs: the indexer turns
+// Claude/Codex JSONLs into app_sessions segment rows; the summariser turns
+// sealed segments into prose summaries; both stay dormant without a coding
+// agent present. CLI subcommands (`coding-agent-hook`, `coding-agent-summarise`)
+// run one-shot against the same DB.
+
+pub mod db;
+pub mod hook;
+pub mod indexer;
+pub mod jsonl;
+pub mod segment;
+pub mod summariser;
+
+use std::path::PathBuf;
+use std::str::FromStr;
+
+pub use segment::{
+    iso_utc, norm_iso, parse_iso, parse_session_segments, Segment, SegmentParams, SessionMeta,
+};
+
+/// Path to the meridian DB (MERIDIAN_DB env, default `~/.meridian/meridian.db`).
+pub fn meridian_db_path() -> PathBuf {
+    let raw =
+        std::env::var("MERIDIAN_DB").unwrap_or_else(|_| "~/.meridian/meridian.db".to_string());
+    PathBuf::from(shellexpand::tilde(&raw).into_owned())
+}
+
+/// Open a short-lived pool against the meridian DB (the daemon already created +
+/// migrated it; we never migrate here). Used by the one-shot CLI subcommands.
+pub async fn open_meridian_pool() -> anyhow::Result<sqlx::SqlitePool> {
+    let path = meridian_db_path();
+    let uri = format!("sqlite://{}", path.display());
+    let opts = sqlx::sqlite::SqliteConnectOptions::from_str(&uri)?.create_if_missing(false);
+    Ok(sqlx::SqlitePool::connect_with(opts).await?)
+}

--- a/src/coding_agent/segment.rs
+++ b/src/coding_agent/segment.rs
@@ -1,0 +1,615 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Segmentation: a single coding-agent JSONL is sliced into SEGMENTS split on
+// idle gaps > `segment_gap_seconds` (default 1h) AND on a `max_segment_seconds`
+// time-box (default 1h), so a long continuous burst still seals on a
+// predictable cadence. One `app_sessions` row per segment, keyed on
+// (claude_session_uuid, segment_started_at).
+//
+// Faithful port of services/coding_agent_indexer/jsonl_meta.py
+// `parse_session_segments`. Parity is enforced by the tests below; the Python
+// `tests/test_segmentation.py` cases are mirrored here. Change both together.
+
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+
+use super::jsonl::{infer_agent, iter_normalised, NormRecord};
+
+// Defaults mirror services/coding_agent_indexer/config.py.
+pub const ACTIVE_TIME_GAP_CAP_SECONDS: i64 = 120;
+pub const SEGMENT_GAP_SECONDS: i64 = 3600;
+pub const MAX_SEGMENT_SECONDS: i64 = 3600;
+
+/// Tunables for one parse pass (mirrors the keyword args of the Python fn).
+#[derive(Debug, Clone)]
+pub struct SegmentParams {
+    pub agent: Option<String>,
+    pub active_gap_cap_seconds: i64,
+    pub segment_gap_seconds: i64,
+    pub max_segment_seconds: i64,
+    pub start_after_ts: Option<String>,
+}
+
+impl Default for SegmentParams {
+    fn default() -> Self {
+        Self {
+            agent: None,
+            active_gap_cap_seconds: ACTIVE_TIME_GAP_CAP_SECONDS,
+            segment_gap_seconds: SEGMENT_GAP_SECONDS,
+            max_segment_seconds: MAX_SEGMENT_SECONDS,
+            start_after_ts: None,
+        }
+    }
+}
+
+/// One continuous work burst of a session. One app_sessions row per segment,
+/// keyed on (session_uuid, segment_started_at). `is_last` marks the final
+/// segment — the only one that may still be live (unsealed).
+#[derive(Debug, Clone)]
+pub struct Segment {
+    pub session_uuid: String,
+    pub agent: String,
+    pub cwd: Option<String>,
+    pub segment_started_at: String,
+    pub started_at: String,
+    pub ended_at: String,
+    pub user_turns: u32,
+    pub assistant_turns: u32,
+    pub active_seconds: i64,
+    pub transcript: String,
+    pub is_last: bool,
+}
+
+impl Segment {
+    pub fn is_valid(&self) -> bool {
+        self.user_turns + self.assistant_turns > 0
+            && !self.segment_started_at.is_empty()
+            && !self.ended_at.is_empty()
+    }
+}
+
+/// Overall metadata for a JSONL — useful for daemon-level cursors.
+#[derive(Debug, Clone)]
+pub struct SessionMeta {
+    pub session_uuid: String,
+    pub agent: String,
+    pub cwd: Option<String>,
+    pub started_at: String,
+    pub ended_at: String,
+    pub user_turns: u32,
+    pub assistant_turns: u32,
+    pub total_records: u64,
+    pub jsonl_bytes: u64,
+    pub active_seconds: i64,
+}
+
+impl SessionMeta {
+    pub fn is_valid(&self) -> bool {
+        self.user_turns + self.assistant_turns > 0
+            && !self.started_at.is_empty()
+            && !self.ended_at.is_empty()
+            && self.started_at <= self.ended_at
+    }
+}
+
+// ──────────────────────── Time helpers ─────────────────────────────────────
+
+/// Parse any ISO-8601 string (…Z / …±offset) to UTC (mirrors `_parse_iso`).
+pub fn parse_iso(ts: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(ts)
+        .ok()
+        .map(|d| d.with_timezone(&Utc))
+}
+
+/// Canonical app_sessions timestamp: ISO-8601 UTC, microseconds, `+00:00`
+/// (mirrors `iso_utc`). `%6f` matches CPython's `%f` (6-digit microseconds).
+pub fn iso_utc(dt: DateTime<Utc>) -> String {
+    dt.format("%Y-%m-%dT%H:%M:%S.%6f+00:00").to_string()
+}
+
+/// Normalise any ISO string to `iso_utc`; fall back to the input unchanged if
+/// it can't be parsed (mirrors `norm_iso`).
+pub fn norm_iso(ts: &str) -> String {
+    match parse_iso(ts) {
+        Some(dt) => iso_utc(dt),
+        None => ts.to_string(),
+    }
+}
+
+/// Signed seconds between two instants as float, preserving sub-second
+/// precision — matches Python's `(a - b).total_seconds()` so gap/time-box
+/// boundary comparisons are byte-for-byte equivalent.
+fn delta_secs(a: DateTime<Utc>, b: DateTime<Utc>) -> f64 {
+    (a - b).num_milliseconds() as f64 / 1000.0
+}
+
+// ──────────────────────── Builder ──────────────────────────────────────────
+
+struct SegBuilder {
+    segment_started_at: String,
+    ended_at: Option<String>,
+    user_turns: u32,
+    assistant_turns: u32,
+    active_seconds: f64,
+    records: Vec<(Option<String>, NormRecord)>,
+}
+
+impl SegBuilder {
+    fn new(segment_started_at: String) -> Self {
+        Self {
+            segment_started_at,
+            ended_at: None,
+            user_turns: 0,
+            assistant_turns: 0,
+            active_seconds: 0.0,
+            records: Vec::new(),
+        }
+    }
+
+    fn add_turn(&mut self, ts: Option<String>, rec: NormRecord) {
+        if rec.is_user {
+            self.user_turns += 1;
+        } else {
+            self.assistant_turns += 1;
+        }
+        self.records.push((ts, rec));
+    }
+}
+
+// ──────────────────────── Public API ───────────────────────────────────────
+
+/// Single pass over the JSONL; returns (overall SessionMeta, Segment list).
+pub fn parse_session_segments(path: &Path, params: &SegmentParams) -> (SessionMeta, Vec<Segment>) {
+    let agent = params.agent.clone().unwrap_or_else(|| infer_agent(path));
+
+    let start_after_dt: Option<DateTime<Utc>> =
+        params.start_after_ts.as_deref().and_then(parse_iso);
+
+    let session_uuid = path
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let jsonl_bytes = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+
+    let mut cwd: Option<String> = None;
+    let mut started_overall: Option<String> = None;
+    let mut ended_overall: Option<String> = None;
+    let mut user_turns_overall: u32 = 0;
+    let mut assistant_turns_overall: u32 = 0;
+    let mut total_records: u64 = 0;
+    let mut prev_dt: Option<DateTime<Utc>> = None; // ts of previous KEPT record (gap calc)
+    let mut seg_start_dt: Option<DateTime<Utc>> = None; // start ts of current segment (time-box)
+    let mut builders: Vec<SegBuilder> = Vec::new();
+    let mut cur: Option<usize> = None; // index into `builders`
+
+    for rec in iter_normalised(path, &agent) {
+        total_records += 1;
+        let ts = rec.timestamp.clone();
+        if cwd.is_none() {
+            if let Some(c) = &rec.cwd {
+                cwd = Some(c.clone());
+            }
+        }
+
+        let cur_dt: Option<DateTime<Utc>> = ts.as_deref().and_then(parse_iso);
+
+        // Already-sealed content is immutable history — skip it and reset the
+        // gap anchor so the first kept record opens a fresh segment.
+        if let (Some(c), Some(sa)) = (cur_dt, start_after_dt) {
+            if c <= sa {
+                prev_dt = None;
+                continue;
+            }
+        }
+
+        if cur_dt.is_some() {
+            if started_overall.is_none() {
+                started_overall = ts.clone();
+            }
+            ended_overall = ts.clone();
+        }
+
+        // Records with no usable timestamp can't anchor a segment; attach to the
+        // current one if it exists (so a body isn't lost), else drop.
+        let cur_dt = match cur_dt {
+            Some(d) => d,
+            None => {
+                if let Some(ci) = cur {
+                    if rec.is_turn {
+                        builders[ci].add_turn(ts, rec);
+                    }
+                }
+                continue;
+            }
+        };
+
+        // Time-box: once a segment has run for max_segment_seconds, it should
+        // split — but only AT THE NEXT REAL USER PROMPT, so the prior row ends on
+        // a complete assistant turn and the new row opens on a user message
+        // (continuity). Splitting on raw time would cut mid-exchange. Tool-result
+        // `user` records don't count (is_user_prompt is false for them). If the
+        // agent runs autonomously past the box with no new prompt, the segment
+        // simply extends until the next prompt (or a >1h gap closes it).
+        let time_box_due = params.max_segment_seconds > 0
+            && seg_start_dt.is_some()
+            && delta_secs(cur_dt, seg_start_dt.unwrap()) >= params.max_segment_seconds as f64;
+        let start_new = cur.is_none()
+            || prev_dt.is_none()
+            || delta_secs(cur_dt, prev_dt.unwrap()) > params.segment_gap_seconds as f64
+            || (time_box_due && rec.is_user_prompt);
+
+        if start_new {
+            builders.push(SegBuilder::new(ts.clone().unwrap_or_default()));
+            cur = Some(builders.len() - 1);
+            seg_start_dt = Some(cur_dt);
+        } else {
+            let gap = delta_secs(cur_dt, prev_dt.unwrap());
+            if gap > 0.0 {
+                let ci = cur.unwrap();
+                builders[ci].active_seconds += gap.min(params.active_gap_cap_seconds as f64);
+            }
+        }
+
+        let ci = cur.unwrap();
+        builders[ci].ended_at = ts.clone();
+        prev_dt = Some(cur_dt);
+
+        if rec.is_turn {
+            let is_user = rec.is_user;
+            builders[ci].add_turn(ts, rec);
+            if is_user {
+                user_turns_overall += 1;
+            } else {
+                assistant_turns_overall += 1;
+            }
+        }
+    }
+
+    let n = builders.len();
+    let mut segments: Vec<Segment> = Vec::with_capacity(n);
+    let mut active_total: i64 = 0;
+    for (i, b) in builders.into_iter().enumerate() {
+        let active = b.active_seconds as i64; // int() truncation toward zero
+        active_total += active;
+        let seg_start = norm_iso(&b.segment_started_at);
+        let ended = norm_iso(b.ended_at.as_deref().unwrap_or(&b.segment_started_at));
+        segments.push(Segment {
+            session_uuid: session_uuid.clone(),
+            agent: agent.clone(),
+            cwd: cwd.clone(),
+            segment_started_at: seg_start.clone(),
+            started_at: seg_start,
+            ended_at: ended,
+            user_turns: b.user_turns,
+            assistant_turns: b.assistant_turns,
+            active_seconds: active,
+            transcript: render_records(&b.records),
+            is_last: i == n - 1,
+        });
+    }
+
+    let meta = SessionMeta {
+        session_uuid,
+        agent,
+        cwd,
+        started_at: started_overall.as_deref().map(norm_iso).unwrap_or_default(),
+        ended_at: ended_overall.as_deref().map(norm_iso).unwrap_or_default(),
+        user_turns: user_turns_overall,
+        assistant_turns: assistant_turns_overall,
+        total_records,
+        jsonl_bytes,
+        active_seconds: active_total,
+    };
+    (meta, segments)
+}
+
+/// Flatten (timestamp, record) pairs to a timestamped transcript:
+/// `[<raw ts>] [role] body` per turn (mirrors `_render_records`). The timestamp
+/// prefix is the RAW JSONL ts (not normalised), matching the Python behaviour.
+fn render_records(records: &[(Option<String>, NormRecord)]) -> String {
+    let mut blocks: Vec<String> = Vec::new();
+    for (ts, rec) in records {
+        if !rec.body.trim().is_empty() {
+            let prefix = match ts {
+                Some(t) => format!("[{}] ", t),
+                None => String::new(),
+            };
+            let role = rec.role_label.as_deref().unwrap_or("user");
+            blocks.push(format!("{}[{}] {}", prefix, role, rec.body));
+        }
+    }
+    blocks.join("\n\n")
+}
+
+// ──────────────────────── Tests (parity with test_segmentation.py) ──────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, TimeZone};
+    use std::io::Write;
+
+    fn base() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 20, 8, 0, 0).unwrap()
+    }
+
+    /// Source 'ms + Z' shape that real Claude JSONLs write (mirrors test `_iso`).
+    fn iso_z(dt: DateTime<Utc>) -> String {
+        dt.format("%Y-%m-%dT%H:%M:%S.%3fZ").to_string()
+    }
+
+    /// One Claude Code JSONL record `offset_s` after BASE.
+    fn rec(offset_s: i64, role: &str, text: &str) -> String {
+        let ts = iso_z(base() + Duration::seconds(offset_s));
+        serde_json::json!({
+            "type": role,
+            "timestamp": ts,
+            "cwd": "/repo",
+            "message": { "role": role, "content": text }
+        })
+        .to_string()
+    }
+
+    /// A Claude `type:user` record that is a TOOL RESULT (not a human prompt) —
+    /// content is a tool_result block, so is_user_prompt must be false.
+    fn rec_tool_result(offset_s: i64) -> String {
+        let ts = iso_z(base() + Duration::seconds(offset_s));
+        serde_json::json!({
+            "type": "user",
+            "timestamp": ts,
+            "cwd": "/repo",
+            "message": { "role": "user", "content": [{"type": "tool_result", "content": "output"}] }
+        })
+        .to_string()
+    }
+
+    fn write_claude_jsonl(dir: &Path, uuid: &str, lines: &[String]) -> std::path::PathBuf {
+        // Path must look like ~/.claude/projects/<proj>/<uuid>.jsonl for agent inference.
+        let proj = dir.join(".claude").join("projects").join("proj");
+        std::fs::create_dir_all(&proj).unwrap();
+        let p = proj.join(format!("{}.jsonl", uuid));
+        let mut f = std::fs::File::create(&p).unwrap();
+        for l in lines {
+            writeln!(f, "{}", l).unwrap();
+        }
+        p
+    }
+
+    fn tmp() -> std::path::PathBuf {
+        let mut d = std::env::temp_dir();
+        // unique-ish dir without Math.random/time: use a static counter
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static C: AtomicU64 = AtomicU64::new(0);
+        d.push(format!(
+            "meridian_seg_test_{}",
+            C.fetch_add(1, Ordering::SeqCst)
+        ));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn single_segment_no_split() {
+        let d = tmp();
+        let p = write_claude_jsonl(
+            &d,
+            "u1",
+            &[
+                rec(0, "user", "first"),
+                rec(60, "assistant", "working"),
+                rec(120, "user", "thanks"),
+            ],
+        );
+        let (_m, segs) = parse_session_segments(&p, &SegmentParams::default());
+        assert_eq!(segs.len(), 1);
+        assert_eq!(segs[0].user_turns, 2);
+        assert_eq!(segs[0].assistant_turns, 1);
+        assert!(segs[0].is_last);
+        assert_eq!(segs[0].segment_started_at, iso_utc(base()));
+    }
+
+    #[test]
+    fn split_on_gap_over_threshold() {
+        let d = tmp();
+        // 2h gap (7200s > 3600s) → two segments.
+        let p = write_claude_jsonl(
+            &d,
+            "u2",
+            &[
+                rec(0, "user", "morning work"),
+                rec(60, "assistant", "done"),
+                rec(60 + 7200, "user", "afternoon work"),
+                rec(60 + 7200 + 30, "assistant", "done2"),
+            ],
+        );
+        let (_m, segs) = parse_session_segments(&p, &SegmentParams::default());
+        assert_eq!(segs.len(), 2);
+        assert!(!segs[0].is_last);
+        assert!(segs[1].is_last);
+        assert_eq!(segs[0].segment_started_at, iso_utc(base()));
+        assert_eq!(
+            segs[1].segment_started_at,
+            iso_utc(base() + Duration::seconds(7260))
+        );
+    }
+
+    #[test]
+    fn no_split_at_exact_threshold() {
+        let d = tmp();
+        // Exactly 3600s gap, time-box disabled → stays one segment (strict >).
+        let p = write_claude_jsonl(
+            &d,
+            "u3",
+            &[rec(0, "user", "a"), rec(3600, "assistant", "b")],
+        );
+        let params = SegmentParams {
+            max_segment_seconds: 0,
+            ..Default::default()
+        };
+        let (_m, segs) = parse_session_segments(&p, &params);
+        assert_eq!(segs.len(), 1);
+    }
+
+    #[test]
+    fn time_box_splits_continuous_session() {
+        let d = tmp();
+        // 16 records, 10 min apart = 150 min continuous, no >1h gap.
+        // Time-box at 3600s → boundaries at 0, 3600, 7200 → 3 segments.
+        let mut lines = Vec::new();
+        for i in 0..16 {
+            let role = if i % 2 == 0 { "user" } else { "assistant" };
+            lines.push(rec(i * 600, role, &format!("turn {}", i)));
+        }
+        let p = write_claude_jsonl(&d, "u4", &lines);
+        let (_m, segs) = parse_session_segments(&p, &SegmentParams::default());
+        assert_eq!(
+            segs.len(),
+            3,
+            "150min continuous should time-box into 3 hourly chunks"
+        );
+        // No segment spans >= 1h.
+        for s in &segs {
+            let span = delta_secs(
+                parse_iso(&s.ended_at).unwrap(),
+                parse_iso(&s.started_at).unwrap(),
+            );
+            assert!(span < 3600.0, "segment span {} must be < time-box", span);
+        }
+    }
+
+    #[test]
+    fn time_box_splits_at_user_prompt_not_mid_exchange() {
+        let d = tmp();
+        // seg starts at 0; time-box boundary = 3600. After the boundary the agent
+        // is mid-work (assistant turns + a tool_result), and the next REAL user
+        // prompt is at 4000 → the split must land there, not at the raw boundary.
+        let p = write_claude_jsonl(
+            &d,
+            "u",
+            &[
+                rec(0, "user", "do the task"),
+                rec(100, "assistant", "working"),
+                rec(3500, "assistant", "still working"), // before boundary
+                rec(3700, "assistant", "ran a tool"),    // after boundary, not a prompt
+                rec_tool_result(3750),                   // tool_result user → not a prompt
+                rec(3800, "assistant", "more work"),     // last assistant before the prompt
+                rec(4000, "user", "next request"),       // real prompt after boundary → SPLIT
+                rec(4100, "assistant", "on it"),
+            ],
+        );
+        let (_m, segs) = parse_session_segments(&p, &SegmentParams::default());
+        assert_eq!(segs.len(), 2, "exactly one split, at the user prompt");
+
+        // Prior row ends on the complete assistant turn (3800), keeps the in-flight
+        // exchange, and does NOT contain the next prompt.
+        assert_eq!(segs[0].ended_at, iso_utc(base() + Duration::seconds(3800)));
+        assert!(segs[0].transcript.contains("more work"));
+        assert!(!segs[0].transcript.contains("next request"));
+
+        // New row opens AT the user prompt.
+        assert_eq!(
+            segs[1].segment_started_at,
+            iso_utc(base() + Duration::seconds(4000))
+        );
+        assert!(segs[1].transcript.contains("[user] next request"));
+        assert!(!segs[1].transcript.contains("more work"));
+    }
+
+    #[test]
+    fn time_box_extends_when_no_user_prompt_after_boundary() {
+        let d = tmp();
+        // Agent runs autonomously ~3h past the box with no new prompt and no >1h
+        // gap → stays ONE segment (continuity beats a mid-stream cut).
+        let mut lines = vec![rec(0, "user", "go")];
+        for i in 1..20 {
+            lines.push(rec(i * 600, "assistant", &format!("step {i}")));
+        }
+        let p = write_claude_jsonl(&d, "u", &lines);
+        let (_m, segs) = parse_session_segments(&p, &SegmentParams::default());
+        assert_eq!(segs.len(), 1, "no user prompt after the box → no split");
+    }
+
+    #[test]
+    fn time_box_disabled_keeps_one_segment() {
+        let d = tmp();
+        let mut lines = Vec::new();
+        for i in 0..16 {
+            let role = if i % 2 == 0 { "user" } else { "assistant" };
+            lines.push(rec(i * 600, role, &format!("turn {}", i)));
+        }
+        let p = write_claude_jsonl(&d, "u5", &lines);
+        let params = SegmentParams {
+            max_segment_seconds: 0,
+            ..Default::default()
+        };
+        let (_m, segs) = parse_session_segments(&p, &params);
+        assert_eq!(segs.len(), 1);
+    }
+
+    #[test]
+    fn timestamps_normalised_to_canonical_plus0000() {
+        let d = tmp();
+        let p = write_claude_jsonl(
+            &d,
+            "u6",
+            &[rec(0, "user", "hi"), rec(30, "assistant", "yo")],
+        );
+        let (_m, segs) = parse_session_segments(&p, &SegmentParams::default());
+        // Input was '...Z' (ms); output must be '...+00:00' (µs).
+        assert!(segs[0].started_at.ends_with("+00:00"));
+        assert!(!segs[0].started_at.contains('Z'));
+        assert_eq!(segs[0].started_at, "2026-05-20T08:00:00.000000+00:00");
+    }
+
+    #[test]
+    fn transcript_has_timestamped_turns_with_full_body() {
+        let d = tmp();
+        let long_body = "x".repeat(5000);
+        let p = write_claude_jsonl(
+            &d,
+            "u7",
+            &[
+                rec(0, "user", "please fix the bug"),
+                rec(30, "assistant", &long_body),
+            ],
+        );
+        let (_m, segs) = parse_session_segments(&p, &SegmentParams::default());
+        let t = &segs[0].transcript;
+        assert!(t.contains("[user] please fix the bug"));
+        assert!(t.contains("[claude-code]"));
+        // "full text, not half": a 5000-char message body is preserved in full.
+        assert!(
+            t.contains(&long_body),
+            "assistant body must be stored in full"
+        );
+    }
+
+    #[test]
+    fn start_after_ts_excludes_sealed_content() {
+        let d = tmp();
+        let p = write_claude_jsonl(
+            &d,
+            "u8",
+            &[
+                rec(0, "user", "sealed already"),
+                rec(60, "assistant", "sealed reply"),
+                rec(120, "user", "fresh turn"),
+            ],
+        );
+        // Seal everything up to and including the 60s record.
+        let cutoff = iso_z(base() + Duration::seconds(60));
+        let params = SegmentParams {
+            start_after_ts: Some(cutoff),
+            ..Default::default()
+        };
+        let (_m, segs) = parse_session_segments(&p, &params);
+        assert_eq!(segs.len(), 1);
+        assert!(segs[0].transcript.contains("fresh turn"));
+        assert!(!segs[0].transcript.contains("sealed"));
+        assert_eq!(
+            segs[0].segment_started_at,
+            iso_utc(base() + Duration::seconds(120))
+        );
+    }
+}

--- a/src/coding_agent/summariser/claude.rs
+++ b/src/coding_agent/summariser/claude.rs
@@ -1,0 +1,127 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Run `claude -p` with the session-summary skill + structured output. Returns
+// the validated {summary, blockers}, or RateLimited (→ MLX fallback) /
+// Failed (→ retry). Port of services/coding_agent_summariser/claude_runner.py.
+//
+// Auth: the user's Claude subscription. We drop ANTHROPIC_API_KEY from the child
+// env so a stray key can't silently switch to metered API billing, and set
+// MERIDIAN_SUMMARISER=1 so the indexer hook ignores the throwaway session this
+// spawns. `--no-session-persistence` means no JSONL is written for it either.
+// NOTE: the inherited env must carry HOME/PATH/USER/LOGNAME for the login
+// keychain to unlock (see the auth spike) — the daemon's launchd plist owns that.
+
+use serde_json::Value;
+
+use super::config::SummariserConfig;
+use super::prompts;
+use super::{run_capture, EngineOutput, SummariserError};
+
+pub async fn run_claude(
+    stdin_text: &str,
+    cfg: &SummariserConfig,
+) -> Result<EngineOutput, SummariserError> {
+    let prompt = format!(
+        "/{} Summarise the coding-session transcript provided on stdin.",
+        cfg.skill_name
+    );
+    let args: Vec<String> = vec![
+        "-p".into(),
+        prompt,
+        "--output-format".into(),
+        "json".into(),
+        "--json-schema".into(),
+        prompts::summary_schema_json(),
+        "--model".into(),
+        cfg.claude_model.clone(),
+        "--no-session-persistence".into(),
+        "--strict-mcp-config".into(), // drop MCP overhead; keeps skills working
+    ];
+
+    let cap = run_capture(
+        "claude",
+        &args,
+        stdin_text,
+        &cfg.meridian_home,
+        cfg.claude_timeout_s,
+        &[("MERIDIAN_SUMMARISER", "1")],
+        &["ANTHROPIC_API_KEY"],
+    )
+    .await?;
+
+    if !cap.success {
+        let blob = format!("{}\n{}", cap.stderr, cap.stdout);
+        if prompts::looks_rate_limited(&blob) {
+            let msg = prompts::first_line(&cap.stderr);
+            return Err(SummariserError::RateLimited(if msg.is_empty() {
+                "rate/usage limit".into()
+            } else {
+                msg
+            }));
+        }
+        let detail = {
+            let s = prompts::first_line(&cap.stderr);
+            if s.is_empty() {
+                prompts::first_line(&cap.stdout)
+            } else {
+                s
+            }
+        };
+        return Err(SummariserError::Failed(format!(
+            "claude exited {:?}: {}",
+            cap.code, detail
+        )));
+    }
+
+    let payload: Value = serde_json::from_str(&cap.stdout).map_err(|e| {
+        let head: String = cap.stdout.chars().take(200).collect();
+        SummariserError::Failed(format!("claude output not JSON ({e}): {head:?}"))
+    })?;
+
+    // Even on exit 0 the envelope can report an error (e.g. a mid-run limit).
+    let is_error = payload
+        .get("is_error")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let subtype = payload.get("subtype").and_then(Value::as_str);
+    if is_error || !matches!(subtype, None | Some("success")) {
+        let detail: String = payload
+            .get("result")
+            .and_then(Value::as_str)
+            .or(subtype)
+            .unwrap_or("error")
+            .chars()
+            .take(200)
+            .collect();
+        if prompts::looks_rate_limited(&detail) {
+            return Err(SummariserError::RateLimited(detail));
+        }
+        return Err(SummariserError::Failed(format!(
+            "claude result error: {detail}"
+        )));
+    }
+
+    let structured = payload.get("structured_output");
+    let summary = structured
+        .and_then(|s| s.get("summary"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if summary.is_empty() {
+        return Err(SummariserError::Failed(
+            "claude returned no usable structured summary".into(),
+        ));
+    }
+    let blockers = structured
+        .and_then(|s| s.get("blockers"))
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|b| b.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(EngineOutput { summary, blockers })
+}

--- a/src/coding_agent/summariser/codex.rs
+++ b/src/coding_agent/summariser/codex.rs
@@ -1,0 +1,148 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Run `codex exec` to summarise a Codex session (symmetry with claude.rs). Safe,
+// side-effect-free, non-interactive: `-s read-only`, `--skip-git-repo-check`,
+// `--ephemeral` (no session file → indexer won't re-pick it), `--output-schema`
+// + `-o FILE` to capture the structured final message. Port of
+// services/coding_agent_summariser/codex_runner.py.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde_json::Value;
+
+use super::config::SummariserConfig;
+use super::prompts;
+use super::{run_capture, EngineOutput, SummariserError};
+
+pub async fn run_codex(
+    stdin_text: &str,
+    cfg: &SummariserConfig,
+) -> Result<EngineOutput, SummariserError> {
+    let prompt = format!(
+        "{} Summarise the coding-session transcript provided on stdin.",
+        prompts::summary_instruction()
+    );
+
+    // Unique scratch dir for the schema + captured final message. Avoids the
+    // time/random APIs (banned in some contexts) via pid + a static counter.
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let td = std::env::temp_dir().join(format!(
+        "codex_summ_{}_{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::SeqCst)
+    ));
+    if let Err(e) = std::fs::create_dir_all(&td) {
+        return Err(SummariserError::Failed(format!("codex: temp dir: {e}")));
+    }
+    let _guard = TempDirGuard(td.clone());
+    let schema_path = td.join("schema.json");
+    let out_path = td.join("last_message.txt");
+    if let Err(e) = std::fs::write(&schema_path, prompts::summary_schema_json()) {
+        return Err(SummariserError::Failed(format!("codex: write schema: {e}")));
+    }
+
+    let home = cfg.meridian_home.display().to_string();
+    let mut args: Vec<String> = vec![
+        "exec".into(),
+        prompt,
+        "-s".into(),
+        "read-only".into(),
+        "--skip-git-repo-check".into(),
+        "--ephemeral".into(),
+        "--output-schema".into(),
+        schema_path.display().to_string(),
+        "-o".into(),
+        out_path.display().to_string(),
+        "-C".into(),
+        home,
+    ];
+    if !cfg.codex_model.is_empty() {
+        args.push("-m".into());
+        args.push(cfg.codex_model.clone());
+    }
+
+    let cap = run_capture(
+        "codex",
+        &args,
+        stdin_text,
+        &cfg.meridian_home,
+        cfg.codex_timeout_s,
+        &[("MERIDIAN_SUMMARISER", "1")],
+        &[],
+    )
+    .await?;
+
+    if !cap.success {
+        let blob = format!("{}\n{}", cap.stderr, cap.stdout);
+        if prompts::looks_rate_limited(&blob) {
+            let msg = prompts::first_line(&cap.stderr);
+            return Err(SummariserError::RateLimited(if msg.is_empty() {
+                "codex usage limit".into()
+            } else {
+                msg
+            }));
+        }
+        return Err(SummariserError::Failed(format!(
+            "codex exited {:?}: {}",
+            cap.code,
+            prompts::first_line(&cap.stderr)
+        )));
+    }
+
+    let text = std::fs::read_to_string(&out_path).unwrap_or_default();
+    let text = text.trim();
+    if text.is_empty() {
+        return Err(SummariserError::Failed("codex produced no output".into()));
+    }
+
+    let (summary, blockers) = extract(text);
+    if summary.is_empty() {
+        return Err(SummariserError::Failed(
+            "codex output had no usable summary".into(),
+        ));
+    }
+    Ok(EngineOutput { summary, blockers })
+}
+
+/// Pull (summary, blockers) from codex's final message. With --output-schema it
+/// should be a JSON object; if codex returns prose, treat the whole text as the
+/// summary.
+fn extract(text: &str) -> (String, Vec<String>) {
+    if let Some(obj) = try_json_object(text) {
+        if let Some(summary) = obj.get("summary").and_then(Value::as_str) {
+            let blockers = obj
+                .get("blockers")
+                .and_then(Value::as_array)
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|b| b.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+            return (summary.trim().to_string(), blockers);
+        }
+    }
+    (text.trim().to_string(), Vec::new())
+}
+
+fn try_json_object(text: &str) -> Option<Value> {
+    if let Ok(v) = serde_json::from_str::<Value>(text) {
+        return Some(v);
+    }
+    // Tolerate a JSON object embedded in surrounding prose.
+    let (start, end) = (text.find('{')?, text.rfind('}')?);
+    if start < end {
+        serde_json::from_str::<Value>(&text[start..=end]).ok()
+    } else {
+        None
+    }
+}
+
+/// Best-effort recursive cleanup of the scratch dir on scope exit.
+struct TempDirGuard(PathBuf);
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}

--- a/src/coding_agent/summariser/config.rs
+++ b/src/coding_agent/summariser/config.rs
@@ -1,0 +1,84 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Env-driven config for the summariser. Defaults match
+// services/coding_agent_summariser/config.py; cadence is adapted to the
+// in-daemon model (notify + short sweep instead of a 5-min standalone poll).
+
+use std::path::PathBuf;
+
+pub struct SummariserConfig {
+    /// Catch-up sweep cadence (s). The indexer also notifies on its own seals
+    /// (near-instant); this covers hook-sealed rows the daemon didn't seal.
+    pub sweep_interval_secs: u64,
+    /// Max rows summarised per drain pass (sequential — flat memory, no burst).
+    pub batch_per_tick: i64,
+
+    pub claude_model: String,
+    pub skill_name: String,
+    pub claude_timeout_s: u64,
+
+    /// Empty → codex's configured default model.
+    pub codex_model: String,
+    pub codex_timeout_s: u64,
+
+    /// How many times to attempt the primary engine before falling back to MLX
+    /// (the user's "try 2 times, then MLX" rule). Rate-limit short-circuits.
+    pub primary_attempts: u32,
+
+    pub transcript_cap_chars: usize,
+
+    pub mlx_host: String,
+    pub mlx_port: u16,
+    pub mlx_timeout_s: u64,
+    pub mlx_max_tokens: u32,
+    pub mlx_input_max_tokens: usize,
+    pub mlx_chars_per_token: usize,
+
+    /// Noise filter — a row must clear BOTH to be worth a summary.
+    pub min_turns: i64,
+    pub min_text_bytes: i64,
+
+    /// When BOTH primary and MLX fail (rate-limited + down), back off this long.
+    pub rate_limit_backoff_secs: u64,
+
+    /// Neutral cwd for the agent subprocesses (no project CLAUDE.md to load).
+    pub meridian_home: PathBuf,
+}
+
+impl SummariserConfig {
+    pub fn from_env() -> Self {
+        fn s(env: &str, default: &str) -> String {
+            std::env::var(env).unwrap_or_else(|_| default.to_string())
+        }
+        fn n<T: std::str::FromStr>(env: &str, default: T) -> T {
+            std::env::var(env)
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(default)
+        }
+        let home = std::env::var("MERIDIAN_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(shellexpand::tilde("~/.meridian").into_owned()));
+        Self {
+            sweep_interval_secs: n("SUMMARISER_SWEEP_S", 30),
+            batch_per_tick: n("SUMMARISER_BATCH_PER_TICK", 8),
+            claude_model: s("SUMMARISER_MODEL", "claude-haiku-4-5-20251001"),
+            skill_name: s("SUMMARISER_SKILL", "session-summary"),
+            claude_timeout_s: n("SUMMARISER_CLAUDE_TIMEOUT_S", 240),
+            codex_model: s("SUMMARISER_CODEX_MODEL", ""),
+            codex_timeout_s: n("SUMMARISER_CODEX_TIMEOUT_S", 240),
+            primary_attempts: n("SUMMARISER_PRIMARY_ATTEMPTS", 2),
+            transcript_cap_chars: n("SUMMARISER_TRANSCRIPT_CAP", 500_000),
+            mlx_host: s("MLX_SERVER_HOST", "127.0.0.1"),
+            mlx_port: n("MLX_SERVER_PORT", 7823),
+            mlx_timeout_s: n("SUMMARISER_MLX_TIMEOUT_S", 180),
+            mlx_max_tokens: n("SUMMARISER_MLX_MAX_TOKENS", 2048),
+            mlx_input_max_tokens: n("SUMMARISER_MLX_INPUT_TOKENS", 5000),
+            mlx_chars_per_token: n("SUMMARISER_MLX_CHARS_PER_TOKEN", 4),
+            min_turns: n("SUMMARISER_MIN_TURNS", 2),
+            min_text_bytes: n("SUMMARISER_MIN_TEXT_BYTES", 800),
+            rate_limit_backoff_secs: n("SUMMARISER_BACKOFF_S", 1800),
+            meridian_home: home,
+        }
+    }
+}

--- a/src/coding_agent/summariser/db.rs
+++ b/src/coding_agent/summariser/db.rs
@@ -1,0 +1,307 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// SQLite layer for the summariser — read the queue, write the summary. The
+// single write path is idempotent (`UPDATE ... WHERE session_summary IS NULL`),
+// so retries / concurrent runs can never double-write. Port of
+// services/coding_agent_summariser/db.py.
+
+use anyhow::{Context, Result};
+use sqlx::SqlitePool;
+
+use super::config::SummariserConfig;
+
+/// task_method the indexer sets on a sealed row awaiting summary.
+pub const TASK_METHOD_PENDING: &str = "pending_summariser";
+/// task_method we set after summarising — the classifier's queue (P3). NOT the
+/// Python terminal 'summarised': summarising is no longer the end of the line.
+pub const TASK_METHOD_PENDING_CLASSIFIER: &str = "pending_classifier";
+
+/// A sealed coding-agent segment awaiting a summary (metadata only;
+/// `session_text` is fetched separately, one at a time, to keep memory flat).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct PendingRow {
+    pub id: i64,
+    #[sqlx(rename = "claude_session_uuid")]
+    pub session_uuid: String,
+    #[sqlx(rename = "app_name")]
+    pub agent: String,
+    pub segment_started_at: String,
+    pub started_at: String,
+    pub ended_at: String,
+    pub duration_s: i64,
+}
+
+/// Idempotently add the `summary_source` column to app_sessions.
+///
+/// app_sessions is migration-owned, but `summary_source` was historically added
+/// out-of-band (the Python summariser's `ensure_schema`), so the live DB already
+/// has it while a freshly-migrated DB does not — a static ADD COLUMN migration
+/// would fail on the live DB. This runtime guard works for both. Safe to call on
+/// every startup / before tests.
+pub async fn ensure_summary_source_column(pool: &SqlitePool) -> Result<()> {
+    let has: bool = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('app_sessions') WHERE name = 'summary_source'",
+    )
+    .fetch_one(pool)
+    .await
+    .map(|n: i64| n > 0)
+    .context("check summary_source column")?;
+    if !has {
+        sqlx::query("ALTER TABLE app_sessions ADD COLUMN summary_source TEXT")
+            .execute(pool)
+            .await
+            .context("add summary_source column")?;
+        tracing::info!("added summary_source column to app_sessions");
+    }
+    Ok(())
+}
+
+const ROW_COLS: &str = "id, claude_session_uuid, app_name, segment_started_at, \
+                        started_at, ended_at, duration_s";
+
+/// Sealed coding segments needing a summary, oldest-ended first. `day`
+/// (`YYYY-MM-DD`, matched against `substr(started_at,1,10)`) scopes the queue to
+/// one calendar day so a tick never drains all history at once. Oldest-first so
+/// a session's earlier bursts summarise before later ones (prior-burst context).
+pub async fn fetch_pending(
+    pool: &SqlitePool,
+    cfg: &SummariserConfig,
+    limit: i64,
+    day: Option<&str>,
+) -> Result<Vec<PendingRow>> {
+    let day_clause = if day.is_some() {
+        "AND substr(started_at, 1, 10) = ?"
+    } else {
+        ""
+    };
+    let sql = format!(
+        "SELECT {cols}
+         FROM   app_sessions
+         WHERE  claude_session_uuid IS NOT NULL
+           AND  sealed_at IS NOT NULL
+           AND  task_method = ?
+           AND  session_summary IS NULL
+           AND  session_text IS NOT NULL
+           AND  session_text <> ''
+           AND  frame_count >= ?
+           AND  length(session_text) >= ?
+           {day}
+         ORDER BY ended_at ASC
+         LIMIT ?",
+        cols = ROW_COLS,
+        day = day_clause,
+    );
+
+    let mut q = sqlx::query_as::<_, PendingRow>(&sql)
+        .bind(TASK_METHOD_PENDING)
+        .bind(cfg.min_turns)
+        .bind(cfg.min_text_bytes);
+    if let Some(d) = day {
+        q = q.bind(d);
+    }
+    q = q.bind(limit);
+    q.fetch_all(pool).await.context("fetch pending summaries")
+}
+
+/// Full `session_text` for one row (fetched per-row to bound memory).
+pub async fn fetch_transcript(pool: &SqlitePool, row_id: i64) -> Result<String> {
+    let text: Option<String> =
+        sqlx::query_scalar("SELECT session_text FROM app_sessions WHERE id = ?")
+            .bind(row_id)
+            .fetch_optional(pool)
+            .await
+            .context("fetch transcript")?
+            .flatten();
+    Ok(text.unwrap_or_default())
+}
+
+/// The summary of this session's most recent EARLIER burst, if any — passed to
+/// the model as continuation context so a resumed session reads as one story.
+pub async fn fetch_prior_summary(
+    pool: &SqlitePool,
+    session_uuid: &str,
+    segment_started_at: &str,
+) -> Result<Option<String>> {
+    let s: Option<String> = sqlx::query_scalar(
+        "SELECT session_summary FROM app_sessions
+         WHERE claude_session_uuid = ?
+           AND segment_started_at < ?
+           AND session_summary IS NOT NULL
+         ORDER BY segment_started_at DESC
+         LIMIT 1",
+    )
+    .bind(session_uuid)
+    .bind(segment_started_at)
+    .fetch_optional(pool)
+    .await
+    .context("fetch prior summary")?
+    .flatten();
+    Ok(s.filter(|x| !x.is_empty()))
+}
+
+/// Persist summary + engine source + flip task_method to the classifier queue.
+/// Idempotent: returns true if this call wrote the row, false if already
+/// summarised (another worker / retry won the race).
+pub async fn write_summary(
+    pool: &SqlitePool,
+    row_id: i64,
+    summary: &str,
+    source: &str,
+) -> Result<bool> {
+    let res = sqlx::query(
+        "UPDATE app_sessions
+         SET    session_summary = ?, task_method = ?, summary_source = ?
+         WHERE  id = ? AND session_summary IS NULL",
+    )
+    .bind(summary)
+    .bind(TASK_METHOD_PENDING_CLASSIFIER)
+    .bind(source)
+    .bind(row_id)
+    .execute(pool)
+    .await
+    .context("write summary")?;
+    Ok(res.rows_affected() > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coding_agent::db as cdb;
+    use crate::coding_agent::segment::Segment;
+    use crate::coding_agent::summariser::config::SummariserConfig;
+    use sqlx::sqlite::SqliteConnectOptions;
+    use std::str::FromStr;
+
+    async fn fresh_db() -> SqlitePool {
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+            .unwrap()
+            .create_if_missing(true);
+        let pool = SqlitePool::connect_with(opts).await.unwrap();
+        sqlx::migrate!("src/migrations").run(&pool).await.unwrap();
+        ensure_summary_source_column(&pool).await.unwrap();
+        pool
+    }
+
+    /// A sealed, pending, summary-worthy segment (clears MIN_TURNS + MIN_TEXT_BYTES).
+    fn pending_seg(uuid: &str, seg_start: &str, ended: &str) -> Segment {
+        Segment {
+            session_uuid: uuid.into(),
+            agent: "claude_code".into(),
+            cwd: Some("/repo".into()),
+            segment_started_at: seg_start.into(),
+            started_at: seg_start.into(),
+            ended_at: ended.into(),
+            user_turns: 2,
+            assistant_turns: 2,
+            active_seconds: 300,
+            transcript: "x".repeat(900), // > MIN_TEXT_BYTES
+            is_last: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_pending_then_write_flips_to_classifier_queue() {
+        let pool = fresh_db().await;
+        let cfg = SummariserConfig::from_env();
+        let s = pending_seg(
+            "u1",
+            "2026-05-20T08:00:00.000000+00:00",
+            "2026-05-20T08:30:00.000000+00:00",
+        );
+        let id = cdb::upsert_segment(&pool, &s, true, Some("2026-05-20T09:00:00.000000+00:00"))
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Appears in the queue (day-scoped to its started_at date).
+        let rows = fetch_pending(&pool, &cfg, 10, Some("2026-05-20"))
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, id);
+        assert_eq!(rows[0].agent, "Claude Code"); // app_name
+
+        // Write summary → row leaves the summariser queue for the classifier queue.
+        assert!(write_summary(&pool, id, "did the work", "claude")
+            .await
+            .unwrap());
+        let (method, src, summ): (String, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT task_method, summary_source, session_summary FROM app_sessions WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(method, TASK_METHOD_PENDING_CLASSIFIER);
+        assert_eq!(src.as_deref(), Some("claude"));
+        assert_eq!(summ.as_deref(), Some("did the work"));
+
+        // No longer pending; second write is a no-op (idempotent).
+        assert!(fetch_pending(&pool, &cfg, 10, None)
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(!write_summary(&pool, id, "again", "mlx").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn fetch_pending_excludes_live_and_thin_rows() {
+        let pool = fresh_db().await;
+        let cfg = SummariserConfig::from_env();
+
+        // Live (unsealed) row → not in queue.
+        let live = pending_seg(
+            "live",
+            "2026-05-20T08:00:00.000000+00:00",
+            "2026-05-20T08:30:00.000000+00:00",
+        );
+        cdb::upsert_segment(&pool, &live, false, None)
+            .await
+            .unwrap();
+
+        // Sealed but too little text → not in queue.
+        let mut thin = pending_seg(
+            "thin",
+            "2026-05-20T10:00:00.000000+00:00",
+            "2026-05-20T10:05:00.000000+00:00",
+        );
+        thin.transcript = "tiny".into();
+        cdb::upsert_segment(&pool, &thin, true, Some("2026-05-20T11:00:00.000000+00:00"))
+            .await
+            .unwrap();
+
+        assert!(fetch_pending(&pool, &cfg, 10, None)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn prior_summary_is_the_latest_earlier_burst() {
+        let pool = fresh_db().await;
+        // Seg A (earlier) summarised, Seg B (later) not yet.
+        let a = pending_seg(
+            "s",
+            "2026-05-20T08:00:00.000000+00:00",
+            "2026-05-20T08:30:00.000000+00:00",
+        );
+        let aid = cdb::upsert_segment(&pool, &a, true, Some("2026-05-20T09:00:00.000000+00:00"))
+            .await
+            .unwrap()
+            .unwrap();
+        write_summary(&pool, aid, "burst A summary", "claude")
+            .await
+            .unwrap();
+
+        let prior = fetch_prior_summary(&pool, "s", "2026-05-20T10:00:00.000000+00:00")
+            .await
+            .unwrap();
+        assert_eq!(prior.as_deref(), Some("burst A summary"));
+
+        // For the earliest burst there is no prior.
+        let none = fetch_prior_summary(&pool, "s", "2026-05-20T08:00:00.000000+00:00")
+            .await
+            .unwrap();
+        assert!(none.is_none());
+    }
+}

--- a/src/coding_agent/summariser/mlx.rs
+++ b/src/coding_agent/summariser/mlx.rs
@@ -1,0 +1,162 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Fallback summariser — the local MLX server's schema-constrained /summarise
+// endpoint (the ONLY remaining Python hop). Used when claude/codex are
+// rate-limited or fail. The local model is a reasoner, so we (1) feed it only
+// the TAIL of the transcript (most recent activity / outcome) and (2) keep a
+// cheap reasoning-leak filter as defence even though the endpoint's outlines FSM
+// already forces the {summary} shape. Port of
+// services/coding_agent_summariser/mlx_fallback.py.
+
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+use super::config::SummariserConfig;
+use super::prompts;
+use super::SummariserError;
+
+pub async fn run_mlx(stdin_text: &str, cfg: &SummariserConfig) -> Result<String, SummariserError> {
+    let url = format!("http://{}:{}/summarise", cfg.mlx_host, cfg.mlx_port);
+    let body = json!({
+        "transcript": tail_cap(stdin_text, cfg),  // MLX-only: tail of the session
+        "system": prompts::SUMMARY_RULES,
+        "max_tokens": cfg.mlx_max_tokens,
+        "temperature": 0.2,
+    });
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(cfg.mlx_timeout_s))
+        .build()
+        .map_err(|e| SummariserError::Failed(format!("MLX client: {e}")))?;
+
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| SummariserError::Failed(format!("MLX fallback unreachable: {e}")))?;
+    let payload: Value = resp
+        .json()
+        .await
+        .map_err(|e| SummariserError::Failed(format!("MLX fallback bad JSON: {e}")))?;
+
+    let raw = payload
+        .get("summary")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim();
+    let text = clean(raw);
+    if text.is_empty() {
+        return Err(SummariserError::Failed(
+            "MLX fallback returned empty summary".into(),
+        ));
+    }
+    if looks_like_reasoning(&text) {
+        // Local model leaked its chain-of-thought instead of a clean summary.
+        // Reject rather than store garbage — the row stays NULL for a later
+        // claude/codex pass.
+        return Err(SummariserError::Failed(
+            "MLX output looks like leaked reasoning — rejected".into(),
+        ));
+    }
+    Ok(text)
+}
+
+/// Keep only the TAIL (~mlx_input_max_tokens) of the transcript for MLX. The
+/// bottom of a session holds the most recent activity / outcome. Char-counted.
+fn tail_cap(text: &str, cfg: &SummariserConfig) -> String {
+    let max_chars = cfg.mlx_input_max_tokens * cfg.mlx_chars_per_token;
+    let chars: Vec<char> = text.chars().collect();
+    if chars.len() <= max_chars {
+        return text.to_string();
+    }
+    let tail: String = chars[chars.len() - max_chars..].iter().collect();
+    format!("…[earlier session truncated — most recent activity below]…\n\n{tail}")
+}
+
+const REASONING_MARKERS: &[&str] = &[
+    "thinking process",
+    "analyze the request",
+    "**analyze",
+    "constraint:",
+    "decision:",
+    "re-evaluation",
+    "let me think",
+    "i must follow",
+    "the transcript is",
+];
+
+fn looks_like_reasoning(text: &str) -> bool {
+    let low = text.to_lowercase();
+    let lstripped = low.trim_start();
+    if lstripped.starts_with("thinking process")
+        || lstripped.starts_with("1.")
+        || lstripped.starts_with("1)")
+        || lstripped.starts_with("**analyze")
+    {
+        return true;
+    }
+    REASONING_MARKERS
+        .iter()
+        .filter(|m| low.contains(*m))
+        .count()
+        >= 2
+}
+
+/// Defensively strip a reasoner's leakage to leave just the prose: drop
+/// `<think>…</think>`, prefer an embedded `{"summary": …}`, then drop a leading
+/// reasoning preamble. String-based (no regex dependency).
+fn clean(text: &str) -> String {
+    let mut t = strip_think_tags(text).trim().to_string();
+
+    // If it emitted JSON anyway, take the summary field.
+    if let (Some(start), Some(end)) = (t.find('{'), t.rfind('}')) {
+        if start < end {
+            if let Ok(obj) = serde_json::from_str::<Value>(&t[start..=end]) {
+                if let Some(s) = obj.get("summary").and_then(Value::as_str) {
+                    if !s.trim().is_empty() {
+                        return s.trim().to_string();
+                    }
+                }
+            }
+        }
+    }
+
+    // Drop a leading reasoning preamble up to the first blank line.
+    let low = t.to_lowercase();
+    let lead = low.trim_start();
+    const PREAMBLES: &[&str] = &["thinking process", "reasoning", "analysis", "let me think"];
+    if PREAMBLES.iter().any(|p| lead.starts_with(p)) {
+        if let Some(idx) = t.find("\n\n") {
+            t = t[idx + 2..].trim().to_string();
+        }
+    }
+    t.trim().to_string()
+}
+
+/// Remove `<think>…</think>` blocks and stray think tags, case-insensitively.
+fn strip_think_tags(text: &str) -> String {
+    let lower = text.to_lowercase();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0usize;
+    let bytes_open = "<think>";
+    let bytes_close = "</think>";
+    while i < text.len() {
+        if lower[i..].starts_with(bytes_open) {
+            // Skip to the matching close tag (or end of string).
+            match lower[i..].find(bytes_close) {
+                Some(rel) => i += rel + bytes_close.len(),
+                None => i = text.len(),
+            }
+        } else if lower[i..].starts_with(bytes_close) {
+            i += bytes_close.len(); // stray closing tag
+        } else {
+            // Copy one char (respecting UTF-8 boundaries).
+            let ch = text[i..].chars().next().unwrap();
+            out.push(ch);
+            i += ch.len_utf8();
+        }
+    }
+    out
+}

--- a/src/coding_agent/summariser/mod.rs
+++ b/src/coding_agent/summariser/mod.rs
@@ -1,0 +1,470 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Summariser: turn each sealed coding-agent segment into a factual prose summary
+// for the PM work-log, then hand it to the classifier (task_method →
+// 'pending_classifier'). Port of services/coding_agent_summariser.
+//
+// Engine routing per segment: Codex sessions → `codex exec`, else → `claude -p`
+// (both Rust subprocesses on the user's subscription). Each primary engine is
+// tried up to `primary_attempts` times; a rate-limit short-circuits straight to
+// the local MLX server (`/summarise`, the only remaining Python hop). Sequential
+// (one transcript in flight) keeps memory flat and avoids bursting rate limits.
+//
+// Cadence: woken in-process by the indexer's own seals (near-instant) plus a
+// short catch-up sweep for hook-sealed rows — no listener (local-only rule).
+
+pub mod claude;
+pub mod codex;
+pub mod config;
+pub mod db;
+pub mod mlx;
+pub mod prompts;
+
+use std::fmt;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Local;
+use sqlx::SqlitePool;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+use tokio::sync::{watch, Notify};
+
+use config::SummariserConfig;
+use db::PendingRow;
+
+// ──────────────────────── Errors / engine output ────────────────────────────
+
+/// A summariser engine failure. `RateLimited` means switch to MLX now;
+/// `Failed` is anything else (retry the primary, then MLX).
+#[derive(Debug, Clone)]
+pub enum SummariserError {
+    RateLimited(String),
+    Failed(String),
+}
+
+impl fmt::Display for SummariserError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SummariserError::RateLimited(m) => write!(f, "rate-limited: {m}"),
+            SummariserError::Failed(m) => write!(f, "{m}"),
+        }
+    }
+}
+impl std::error::Error for SummariserError {}
+
+/// The validated output of a primary (claude/codex) engine.
+pub struct EngineOutput {
+    pub summary: String,
+    pub blockers: Vec<String>,
+}
+
+/// Captured result of a subprocess run.
+pub(super) struct Capture {
+    pub success: bool,
+    pub code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Spawn `program args`, feed `stdin_text`, capture stdout/stderr with a hard
+/// timeout. `kill_on_drop` guarantees a timed-out child is reaped (no leak);
+/// stdin is written from a concurrent task so a large prompt can't deadlock the
+/// pipe. Summariser stdout is small (a JSON envelope), so no read-side deadlock.
+pub(super) async fn run_capture(
+    program: &str,
+    args: &[String],
+    stdin_text: &str,
+    cwd: &Path,
+    timeout_s: u64,
+    extra_env: &[(&str, &str)],
+    remove_env: &[&str],
+) -> Result<Capture, SummariserError> {
+    let mut cmd = Command::new(program);
+    cmd.args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .current_dir(cwd)
+        .kill_on_drop(true);
+    for k in remove_env {
+        cmd.env_remove(k);
+    }
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+
+    let mut child = cmd.spawn().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            SummariserError::Failed(format!("{program} CLI not found on PATH"))
+        } else {
+            SummariserError::Failed(format!("{program} spawn failed: {e}"))
+        }
+    })?;
+
+    if let Some(mut sin) = child.stdin.take() {
+        let input = stdin_text.to_string();
+        tokio::spawn(async move {
+            let _ = sin.write_all(input.as_bytes()).await;
+            let _ = sin.shutdown().await;
+        });
+    }
+
+    let output = match tokio::time::timeout(
+        Duration::from_secs(timeout_s),
+        child.wait_with_output(),
+    )
+    .await
+    {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => return Err(SummariserError::Failed(format!("{program}: {e}"))),
+        Err(_) => {
+            return Err(SummariserError::Failed(format!(
+                "{program} timed out after {timeout_s}s"
+            )))
+        }
+    };
+
+    Ok(Capture {
+        success: output.status.success(),
+        code: output.status.code(),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+}
+
+// ──────────────────────── One unit of work ──────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    Claude,
+    Codex,
+    Mlx,
+    None,
+}
+
+impl Source {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Source::Claude => "claude",
+            Source::Codex => "codex",
+            Source::Mlx => "mlx",
+            Source::None => "none",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Outcome {
+    pub row_id: i64,
+    pub written: bool,
+    pub source: Source,
+    pub rate_limited: bool,
+    pub error: Option<String>,
+    pub summary: Option<String>,
+}
+
+/// Produce (and by default persist) a summary for one segment. Never panics —
+/// returns an Outcome so a bad row can't kill the drain loop.
+pub async fn summarise_one(
+    pool: &SqlitePool,
+    row: &PendingRow,
+    cfg: &SummariserConfig,
+    write: bool,
+) -> Outcome {
+    let err = |row_id, e: String| Outcome {
+        row_id,
+        written: false,
+        source: Source::None,
+        rate_limited: false,
+        error: Some(e),
+        summary: None,
+    };
+
+    let transcript = match db::fetch_transcript(pool, row.id).await {
+        Ok(t) => t,
+        Err(e) => return err(row.id, format!("fetch transcript: {e}")),
+    };
+    if transcript.trim().is_empty() {
+        return err(row.id, "empty transcript".into());
+    }
+    let prior = db::fetch_prior_summary(pool, &row.session_uuid, &row.segment_started_at)
+        .await
+        .unwrap_or(None);
+    let stdin_text = build_prompt(&transcript, prior.as_deref(), cfg.transcript_cap_chars);
+
+    let mut summary: Option<String> = None;
+    let mut source = Source::None;
+    let mut rate_limited = false;
+    let mut errors: Vec<String> = Vec::new();
+
+    // 1. Primary: the session's own agent, up to `primary_attempts` tries.
+    let is_codex = row.agent.trim().eq_ignore_ascii_case("codex");
+    let primary_source = if is_codex {
+        Source::Codex
+    } else {
+        Source::Claude
+    };
+    for attempt in 1..=cfg.primary_attempts.max(1) {
+        let res = if is_codex {
+            codex::run_codex(&stdin_text, cfg).await
+        } else {
+            claude::run_claude(&stdin_text, cfg).await
+        };
+        match res {
+            Ok(out) => {
+                summary = Some(out.summary);
+                source = primary_source;
+                break;
+            }
+            Err(SummariserError::RateLimited(m)) => {
+                rate_limited = true;
+                errors.push(format!("{} rate-limited: {m}", primary_source.as_str()));
+                break; // retrying a limit is pointless → fall through to MLX
+            }
+            Err(SummariserError::Failed(m)) => {
+                errors.push(format!(
+                    "{} attempt {attempt} failed: {m}",
+                    primary_source.as_str()
+                ));
+            }
+        }
+    }
+
+    // 2. Fallback: local MLX (on any primary failure).
+    if summary.is_none() {
+        match mlx::run_mlx(&stdin_text, cfg).await {
+            Ok(s) => {
+                summary = Some(s);
+                source = Source::Mlx;
+            }
+            Err(e) => errors.push(format!("mlx failed: {e}")),
+        }
+    }
+
+    let summary = match summary {
+        Some(s) => s,
+        None => {
+            return Outcome {
+                row_id: row.id,
+                written: false,
+                source: Source::None,
+                rate_limited,
+                error: Some(errors.join("; ")),
+                summary: None,
+            }
+        }
+    };
+
+    let written = if write {
+        db::write_summary(pool, row.id, &summary, source.as_str())
+            .await
+            .unwrap_or(false)
+    } else {
+        false
+    };
+    let uuid_short: String = row.session_uuid.chars().take(8).collect();
+    tracing::info!(
+        row_id = row.id, uuid = %uuid_short, source = source.as_str(),
+        written, chars = summary.len(), "summarised coding-agent segment",
+    );
+    Outcome {
+        row_id: row.id,
+        written,
+        source,
+        rate_limited,
+        error: None,
+        summary: Some(summary),
+    }
+}
+
+/// stdin for the model: optional prior-burst context + (capped) transcript.
+fn build_prompt(transcript: &str, prior: Option<&str>, cap: usize) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(p) = prior {
+        parts.push(format!(
+            "## EARLIER IN THIS SESSION (context — do not repeat)\n{p}"
+        ));
+    }
+    parts.push(format!(
+        "## TRANSCRIPT\n{}",
+        cap_transcript(transcript, cap)
+    ));
+    parts.join("\n\n")
+}
+
+/// Bound transcript size: keep the head (task setup) and tail (outcome). Most
+/// bursts pass through untouched. Char-counted to match the Python original.
+fn cap_transcript(transcript: &str, cap: usize) -> String {
+    let chars: Vec<char> = transcript.chars().collect();
+    if chars.len() <= cap {
+        return transcript.to_string();
+    }
+    let head_len = cap * 7 / 10;
+    let tail_len = cap - head_len;
+    let elided = chars.len() - cap;
+    let head: String = chars[..head_len].iter().collect();
+    let tail: String = chars[chars.len() - tail_len..].iter().collect();
+    format!("{head}\n\n…[{elided} chars elided — long autonomous stretch omitted]…\n\n{tail}")
+}
+
+// ──────────────────────── Loop ──────────────────────────────────────────────
+
+/// The summariser task: drain the queue, then wait for an indexer notify or the
+/// catch-up sweep. Dormant if no coding agent is present. Backs off when both
+/// the primary engine and MLX are unavailable.
+pub async fn run_loop(
+    pool: SqlitePool,
+    notify: Arc<Notify>,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    use super::indexer::{coding_agents_present, IndexerConfig};
+    if !coding_agents_present(&IndexerConfig::from_env()) {
+        tracing::info!("coding-agent summariser dormant — no claude/codex detected");
+        return;
+    }
+    let cfg = SummariserConfig::from_env();
+    if let Err(e) = db::ensure_summary_source_column(&pool).await {
+        tracing::warn!(error = %e, "summariser: could not ensure summary_source column");
+    }
+    tracing::info!(
+        sweep_s = cfg.sweep_interval_secs,
+        batch = cfg.batch_per_tick,
+        "coding-agent summariser starting"
+    );
+
+    loop {
+        let backoff = drain(&pool, &cfg).await;
+        let wait = if backoff {
+            cfg.rate_limit_backoff_secs
+        } else {
+            cfg.sweep_interval_secs
+        };
+        tokio::select! {
+            _ = shutdown_rx.changed() => break,
+            _ = notify.notified() => {}
+            _ = tokio::time::sleep(Duration::from_secs(wait)) => {}
+        }
+    }
+    tracing::info!("coding-agent summariser stopped");
+}
+
+/// One drain pass: summarise today's pending rows, oldest-first. Returns true if
+/// we should back off (primary rate-limited AND MLX also failed).
+async fn drain(pool: &SqlitePool, cfg: &SummariserConfig) -> bool {
+    let today = Local::now().format("%Y-%m-%d").to_string();
+    let rows = match db::fetch_pending(pool, cfg, cfg.batch_per_tick, Some(&today)).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, "summariser: fetch_pending failed");
+            return false;
+        }
+    };
+    let mut summarised = 0u32;
+    for row in rows {
+        let outcome = summarise_one(pool, &row, cfg, true).await;
+        if outcome.written {
+            summarised += 1;
+        } else if outcome.rate_limited {
+            // Primary rate-limited AND MLX failed → stop draining, back off.
+            tracing::warn!(
+                row_id = outcome.row_id,
+                "summariser backing off (rate-limited + MLX down)"
+            );
+            if summarised > 0 {
+                tracing::info!(summarised, "summariser drain (partial)");
+            }
+            return true;
+        } else {
+            // Transient failure (primary failed all attempts + MLX failed/down,
+            // or empty/unreadable transcript). Leave the row NULL for a later
+            // retry — but log WHY so it isn't a silent stall.
+            tracing::warn!(
+                row_id = outcome.row_id,
+                error = outcome.error.as_deref().unwrap_or("unknown"),
+                "summarise failed — leaving pending for retry"
+            );
+        }
+    }
+    if summarised > 0 {
+        tracing::info!(summarised, "summariser drain");
+    }
+    false
+}
+
+/// One-shot CLI: `meridian coding-agent-summarise [--dry-run] [--day D] [--limit N]`.
+/// Summarise (or dry-run) the pending queue for a day — manual backfill / eval.
+pub async fn cli_summarise(pool: &SqlitePool, dry_run: bool, day: Option<&str>, limit: i64) {
+    let cfg = SummariserConfig::from_env();
+    if let Err(e) = db::ensure_summary_source_column(pool).await {
+        eprintln!("summarise: ensure column: {e}");
+        return;
+    }
+    let day = day
+        .map(str::to_string)
+        .unwrap_or_else(|| Local::now().format("%Y-%m-%d").to_string());
+    let rows = match db::fetch_pending(pool, &cfg, limit, Some(&day)).await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("summarise: fetch_pending: {e}");
+            return;
+        }
+    };
+    println!(
+        "summarise: {} pending row(s) for {day} (dry_run={dry_run})",
+        rows.len()
+    );
+    for row in rows {
+        let o = summarise_one(pool, &row, &cfg, !dry_run).await;
+        match (&o.summary, &o.error) {
+            (Some(s), _) => {
+                let preview: String = s.chars().take(160).collect();
+                println!(
+                    "  row {} [{}] written={} chars={}: {preview}",
+                    o.row_id,
+                    o.source.as_str(),
+                    o.written,
+                    s.len(),
+                );
+            }
+            (None, Some(e)) => println!("  row {} FAILED: {e}", o.row_id),
+            (None, None) => {}
+        }
+    }
+}
+
+// ──────────────────────── Tests ─────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cap_transcript_passes_short_through() {
+        let t = "short transcript";
+        assert_eq!(cap_transcript(t, 1000), t);
+    }
+
+    #[test]
+    fn cap_transcript_keeps_head_and_tail() {
+        let t: String = "A".repeat(500) + &"B".repeat(500); // 1000 chars
+        let capped = cap_transcript(&t, 100);
+        assert!(capped.starts_with(&"A".repeat(70)), "70% head kept");
+        assert!(capped.ends_with(&"B".repeat(30)), "30% tail kept");
+        assert!(capped.contains("chars elided"));
+    }
+
+    #[test]
+    fn build_prompt_includes_prior_context() {
+        let p = build_prompt("the work", Some("earlier summary"), 1000);
+        assert!(p.contains("EARLIER IN THIS SESSION"));
+        assert!(p.contains("earlier summary"));
+        assert!(p.contains("## TRANSCRIPT"));
+        assert!(p.contains("the work"));
+
+        let p2 = build_prompt("just work", None, 1000);
+        assert!(!p2.contains("EARLIER IN THIS SESSION"));
+    }
+}

--- a/src/coding_agent/summariser/prompts.rs
+++ b/src/coding_agent/summariser/prompts.rs
@@ -1,0 +1,78 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Shared summary contract — the rules, the schema, and limit detection. Lives in
+// one place so the three engines stay consistent: Claude loads the
+// `session-summary` skill (same rules, in SKILL.md); Codex gets
+// SUMMARY_INSTRUCTION as its prompt; MLX gets SUMMARY_RULES as its system
+// message. All three target SUMMARY_SCHEMA. Port of
+// services/coding_agent_summariser/prompts.py.
+
+use serde_json::json;
+
+/// The shared rules, without an output-format clause (engines append their own).
+pub const SUMMARY_RULES: &str =
+    "You summarise ONE work-burst of a developer's coding-agent session for a \
+Jira work-log. The transcript (provided on stdin) is timestamped as \
+`[<ISO ts>] [role] <message>`. Write a factual prose summary of 10-40 \
+sentences: name the files edited, commands run, errors hit, decisions \
+made, tests/validations performed, and any rework or blockers (an approach \
+abandoned, a failed build/test, something deleted and rebuilt). State ONLY \
+what is in the transcript — never invent files, tickets, commands, or \
+outcomes. No preamble, no markdown headings, no bullet lists — just clear \
+paragraphs. If an 'EARLIER IN THIS SESSION' section is present, do not \
+repeat it; summarise only this burst.";
+
+/// For schema-enforced engines (Codex `--output-schema`): ask for JSON.
+pub fn summary_instruction() -> String {
+    format!(
+        "{} Return JSON matching the schema: `summary` (the prose) and \
+         `blockers` (a list of distinct blockers / failures / rework, possibly empty).",
+        SUMMARY_RULES
+    )
+}
+
+/// Structured-output contract, serialized for `claude --json-schema` /
+/// `codex --output-schema`. `summary` is the prose we store; `blockers` forces
+/// the model to surface rework/failures (the bit weaker models drop).
+pub fn summary_schema_json() -> String {
+    json!({
+        "type": "object",
+        "properties": {
+            "summary":  {"type": "string", "minLength": 1},
+            "blockers": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["summary"],
+    })
+    .to_string()
+}
+
+/// Substrings that mark a subscription usage/rate limit in CLI stderr/output —
+/// for Claude (`claude -p`) and Codex (`codex exec`) alike.
+const RATE_LIMIT_MARKERS: &[&str] = &[
+    "usage limit",
+    "rate limit",
+    "rate_limit",
+    "429",
+    "overloaded",
+    "exceeded your",
+    "quota",
+    "resets at",
+    "try again at",
+    "upgrade to plus",
+];
+
+pub fn looks_rate_limited(text: &str) -> bool {
+    let low = text.to_lowercase();
+    RATE_LIMIT_MARKERS.iter().any(|m| low.contains(m))
+}
+
+/// First non-empty line, capped to 200 chars (for compact error messages).
+pub fn first_line(text: &str) -> String {
+    for line in text.lines() {
+        let line = line.trim();
+        if !line.is_empty() {
+            return line.chars().take(200).collect();
+        }
+    }
+    String::new()
+}

--- a/src/intelligence/mod.rs
+++ b/src/intelligence/mod.rs
@@ -7,8 +7,8 @@ pub mod session_categorizer;
 pub mod task_linker;
 
 pub use task_linker::{
-    check_classification_ready, link_range, mark_session_subprocess_error, run_task_linking,
-    TaskLinkOutcome,
+    check_classification_ready, link_range, mark_session_subprocess_error,
+    run_coding_agent_classification, run_task_linking, TaskLinkOutcome,
 };
 
 use anyhow::Result;

--- a/src/intelligence/task_linker/db.rs
+++ b/src/intelligence/task_linker/db.rs
@@ -24,6 +24,29 @@ pub(super) async fn count_pending_sessions(
     Ok(row.0)
 }
 
+/// Fetch up to `limit` sealed coding-agent rows that have been summarised and
+/// are awaiting classification (`task_method = 'pending_classifier'`). This is a
+/// NON-cursor queue: coding-agent rows have low ids the cursor has long passed,
+/// so they are classified by summarised-state, not id order. Oldest-ended first.
+pub(super) async fn fetch_pending_classifier_sessions(
+    pool: &SqlitePool,
+    limit: i64,
+) -> Result<Vec<i64>> {
+    let ids: Vec<i64> = sqlx::query_scalar(
+        "SELECT id FROM app_sessions
+         WHERE claude_session_uuid IS NOT NULL
+           AND session_summary IS NOT NULL
+           AND task_method = 'pending_classifier'
+         ORDER BY ended_at ASC
+         LIMIT ?",
+    )
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+    .context("fetching pending_classifier coding-agent sessions")?;
+    Ok(ids)
+}
+
 /// Returns the max `id` in `app_sessions`, or `None` if the table is empty.
 pub(super) async fn get_max_session_id(pool: &SqlitePool) -> Result<Option<i64>> {
     let row = sqlx::query_as::<_, (Option<i64>,)>("SELECT MAX(id) FROM app_sessions")
@@ -186,8 +209,8 @@ pub(super) async fn fetch_sessions_in_range(
 mod tests {
     use super::*;
     use crate::intelligence::task_linker::db_write::{
-        advance_agent_cursor, complete_agent_run, start_agent_run, update_session_overhead,
-        update_session_task, write_dimensions,
+        advance_agent_cursor, complete_agent_run, start_agent_run, update_coding_agent_task,
+        update_session_overhead, update_session_task, write_dimensions,
     };
     use crate::intelligence::task_linker::SessionClassification;
     use sqlx::{sqlite::SqliteConnectOptions, SqlitePool};
@@ -223,6 +246,110 @@ mod tests {
         .await
         .unwrap()
         .last_insert_rowid()
+    }
+
+    /// Insert a sealed, summarised coding-agent row awaiting classification.
+    async fn seed_pending_classifier(pool: &SqlitePool, uuid: &str, summary: &str) -> i64 {
+        sqlx::query(
+            "INSERT INTO etl_runs (started_at, from_frame_id, to_frame_id, status)
+             VALUES ('t', 0, 0, 'success')",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO app_sessions (
+                app_name, started_at, ended_at, duration_s,
+                window_titles, audio_snippets, signals,
+                min_frame_id, max_frame_id, frame_count, idle_frame_count, etl_run_id,
+                claude_session_uuid, segment_started_at, sealed_at,
+                session_summary, task_method
+             ) VALUES ('Claude Code',
+                '2026-05-20T08:00:00.000000+00:00', '2026-05-20T08:30:00.000000+00:00', 300,
+                '[]', '[]', '{}', 0, 0, 4, 0, 1,
+                ?, '2026-05-20T08:00:00.000000+00:00', '2026-05-20T09:00:00.000000+00:00',
+                ?, 'pending_classifier')",
+        )
+        .bind(uuid)
+        .bind(summary)
+        .execute(pool)
+        .await
+        .unwrap()
+        .last_insert_rowid()
+    }
+
+    fn classification(session_id: i64) -> SessionClassification {
+        SessionClassification {
+            session_id,
+            task_key: Some("KAN-1".into()),
+            confidence: 0.9,
+            routing: "queue".into(),
+            session_type: "task".into(),
+            reasoning: "did the work".into(),
+            method: "mlx_direct".into(),
+            dimensions: HashMap::new(),
+            session_summary: "CLASSIFIER SUMMARY — must NOT overwrite".into(),
+            elapsed_s: 1.0,
+        }
+    }
+
+    #[tokio::test]
+    async fn pending_classifier_queue_then_classify_preserves_summary() {
+        let pool = fresh_db().await;
+        let id = seed_pending_classifier(&pool, "u1", "GOOD SUMMARISER SUMMARY").await;
+
+        // The non-cursor queue picks it up (independent of agent_cursor).
+        assert_eq!(
+            fetch_pending_classifier_sessions(&pool, 8).await.unwrap(),
+            vec![id]
+        );
+
+        // Classify it — task fields land, session_summary is PRESERVED.
+        update_coding_agent_task(&pool, &classification(id))
+            .await
+            .unwrap();
+        let (method, task_key, summary): (String, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT task_method, task_key, session_summary FROM app_sessions WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(method, "mlx_direct"); // terminal — leaves the queue
+        assert_eq!(task_key.as_deref(), Some("KAN-1"));
+        assert_eq!(
+            summary.as_deref(),
+            Some("GOOD SUMMARISER SUMMARY"),
+            "summary must survive classify"
+        );
+
+        // Drained.
+        assert!(fetch_pending_classifier_sessions(&pool, 8)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn pending_classifier_excludes_unsummarised_rows() {
+        let pool = fresh_db().await;
+        // A coding row still awaiting summary (pending_summariser) → not in this queue.
+        sqlx::query(
+            "INSERT INTO etl_runs (started_at, from_frame_id, to_frame_id, status) VALUES ('t',0,0,'success')",
+        ).execute(&pool).await.unwrap();
+        sqlx::query(
+            "INSERT INTO app_sessions (
+                app_name, started_at, ended_at, duration_s, window_titles, audio_snippets, signals,
+                min_frame_id, max_frame_id, frame_count, idle_frame_count, etl_run_id,
+                claude_session_uuid, segment_started_at, sealed_at, task_method
+             ) VALUES ('Claude Code','2026-05-20T08:00:00.000000+00:00','2026-05-20T08:30:00.000000+00:00',
+                300,'[]','[]','{}',0,0,4,0,1,'u2','2026-05-20T08:00:00.000000+00:00',
+                '2026-05-20T09:00:00.000000+00:00','pending_summariser')",
+        ).execute(&pool).await.unwrap();
+        assert!(fetch_pending_classifier_sessions(&pool, 8)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     // ── cursor ────────────────────────────────────────────────────────────

--- a/src/intelligence/task_linker/db_write.rs
+++ b/src/intelligence/task_linker/db_write.rs
@@ -82,6 +82,38 @@ pub(super) async fn update_session_task(
     Ok(())
 }
 
+/// Persist a classification result for a coding-agent row. Identical to
+/// `update_session_task` EXCEPT it does NOT touch `session_summary`: that column
+/// already holds the summariser's high-quality prose, and the classifier's own
+/// summary (built from that same text) must not clobber it.
+pub(super) async fn update_coding_agent_task(
+    pool: &SqlitePool,
+    r: &SessionClassification,
+) -> Result<()> {
+    let reasoning = if r.reasoning.is_empty() {
+        None
+    } else {
+        Some(&r.reasoning)
+    };
+    sqlx::query(
+        "UPDATE app_sessions
+         SET task_key = ?, task_confidence = ?, task_routing = ?,
+             task_method = ?, task_reasoning = ?, task_session_type = ?
+         WHERE id = ?",
+    )
+    .bind(&r.task_key)
+    .bind(r.confidence)
+    .bind(&r.routing)
+    .bind(&r.method)
+    .bind(reasoning)
+    .bind(&r.session_type)
+    .bind(r.session_id)
+    .execute(pool)
+    .await
+    .with_context(|| format!("updating coding-agent task for session {}", r.session_id))?;
+    Ok(())
+}
+
 /// Persist multi-label dimension tags returned by Python.
 pub(super) async fn write_dimensions(
     pool: &SqlitePool,

--- a/src/intelligence/task_linker/mod.rs
+++ b/src/intelligence/task_linker/mod.rs
@@ -14,12 +14,12 @@ use crate::config::Config;
 use tracing::field;
 
 use db::{
-    count_pending_sessions, fetch_sessions_in_range, fetch_unclassified_sessions, get_agent_cursor,
-    get_max_session_id,
+    count_pending_sessions, fetch_pending_classifier_sessions, fetch_sessions_in_range,
+    fetch_unclassified_sessions, get_agent_cursor, get_max_session_id,
 };
 use db_write::{
-    advance_agent_cursor, complete_agent_run, start_agent_run, update_session_overhead,
-    update_session_task, write_dimensions, write_error_sentinel,
+    advance_agent_cursor, complete_agent_run, start_agent_run, update_coding_agent_task,
+    update_session_overhead, update_session_task, write_dimensions, write_error_sentinel,
 };
 
 // ---------------------------------------------------------------------------
@@ -46,6 +46,11 @@ pub enum TaskLinkOutcome {
 // One session per daemon tick — at 30-60s cadence there is typically one new
 // session. The backfill binary handles bulk catch-up after downtime.
 pub(super) const BATCH_LIMIT: i64 = 1;
+
+// Coding-agent rows are classified in small batches from their (non-cursor)
+// pending_classifier queue. The MLX server classifies the whole batch in one
+// call; the drain loop repeats until the queue is empty.
+const CODING_CLASSIFY_BATCH: i64 = 8;
 
 // ---------------------------------------------------------------------------
 // Sentinel helper
@@ -407,6 +412,50 @@ pub async fn run_task_linking(pool: &SqlitePool, cfg: &Config) -> Result<TaskLin
 
     complete_agent_run(pool, run_id, "success", total_sessions, links_written).await?;
     Ok(TaskLinkOutcome::Classified)
+}
+
+// ---------------------------------------------------------------------------
+// Coding-agent classify trigger — the seal→summarise→classify chain's last link
+// ---------------------------------------------------------------------------
+
+/// Classify up to `CODING_CLASSIFY_BATCH` summarised coding-agent rows (the
+/// `pending_classifier` queue). NON-cursor: selected by summarised-state, not id
+/// order, so it never collides with the screen-capture cursor. The MLX server
+/// reasons over each row's `session_summary` (not the transcript); we persist
+/// the task fields WITHOUT touching `session_summary`. Returns rows classified.
+pub async fn run_coding_agent_classification(pool: &SqlitePool, cfg: &Config) -> Result<usize> {
+    if !cfg.classification_enabled {
+        return Ok(0);
+    }
+
+    let ids = fetch_pending_classifier_sessions(pool, CODING_CLASSIFY_BATCH).await?;
+    if ids.is_empty() {
+        return Ok(0);
+    }
+
+    info!(session_ids = ?ids, "classifying summarised coding-agent rows");
+    let input = ClassifyInput {
+        session_ids: ids,
+        meridian_db: cfg.meridian_db.clone(),
+        traceparent: crate::observability::current_traceparent(),
+    };
+
+    let out = call_mlx_server(&input, cfg.mlx_server_port, cfg.classification_timeout_s).await?;
+
+    let mut n = 0usize;
+    for r in &out.results {
+        update_coding_agent_task(pool, r).await?;
+        write_dimensions(pool, r.session_id, &r.dimensions).await?;
+        info!(
+            session_id = r.session_id,
+            task_key = ?r.task_key,
+            session_type = %r.session_type,
+            method = %r.method,
+            "coding-agent session classified",
+        );
+        n += 1;
+    }
+    Ok(n)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // meridian — normalises screenpipe activity into structured app sessions
 // https://github.com/meridiona/meridian
 
+pub mod coding_agent;
 pub mod config;
 pub mod db;
 pub mod etl;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,8 @@ use meridian::db::meridian::{cleanup_incomplete_runs, setup_db};
 use meridian::db::screenpipe::open_screenpipe;
 use meridian::etl::run_etl;
 use meridian::intelligence::{
-    check_classification_ready, mark_session_subprocess_error, run_fm_categorization, run_pm_sync,
-    run_task_linking, TaskLinkOutcome,
+    check_classification_ready, mark_session_subprocess_error, run_coding_agent_classification,
+    run_fm_categorization, run_pm_sync, run_task_linking, TaskLinkOutcome,
 };
 use meridian::observability;
 use tokio::signal::unix::{signal, SignalKind};
@@ -35,6 +35,72 @@ async fn main() -> Result<()> {
     }
     // Override so cwd .env beats any empty values injected by launchd plist.
     let _ = dotenvy::dotenv_override();
+
+    // 1b. Subcommand dispatch. `meridian coding-agent-hook` is the Claude Code
+    //     SessionEnd hook entry point: one-shot, reads a JSON payload on stdin,
+    //     seals that session, exits 0. It must stay light (no daemon init, no
+    //     OTLP) and must never block Claude, so it always exits 0.
+    if std::env::args().nth(1).as_deref() == Some("coding-agent-hook") {
+        meridian::coding_agent::hook::run_hook().await;
+        return Ok(());
+    }
+
+    // `meridian coding-agent-summarise [--dry-run] [--day YYYY-MM-DD] [--limit N]`
+    // — one-shot manual backfill / eval of the summariser queue for one day.
+    if std::env::args().nth(1).as_deref() == Some("coding-agent-summarise") {
+        let args: Vec<String> = std::env::args().collect();
+        let flag = |name: &str| -> Option<String> {
+            args.iter()
+                .position(|a| a == name)
+                .and_then(|i| args.get(i + 1).cloned())
+        };
+        let dry_run = args.iter().any(|a| a == "--dry-run");
+        let day = flag("--day");
+        let limit: i64 = flag("--limit").and_then(|v| v.parse().ok()).unwrap_or(8);
+        match meridian::coding_agent::open_meridian_pool().await {
+            Ok(pool) => {
+                meridian::coding_agent::summariser::cli_summarise(
+                    &pool,
+                    dry_run,
+                    day.as_deref(),
+                    limit,
+                )
+                .await;
+                pool.close().await;
+            }
+            Err(e) => eprintln!("coding-agent-summarise: open db: {e}"),
+        }
+        return Ok(());
+    }
+
+    // `meridian coding-agent-classify` — one-shot: classify every summarised
+    // coding-agent row (the pending_classifier queue) via the MLX server. Manual
+    // backfill of the last link in seal→summarise→classify.
+    if std::env::args().nth(1).as_deref() == Some("coding-agent-classify") {
+        let cfg = Config::from_env();
+        match meridian::coding_agent::open_meridian_pool().await {
+            Ok(pool) => {
+                let mut total = 0usize;
+                loop {
+                    match run_coding_agent_classification(&pool, &cfg).await {
+                        Ok(0) => break,
+                        Ok(n) => {
+                            total += n;
+                            println!("classified {n} (total {total})");
+                        }
+                        Err(e) => {
+                            eprintln!("coding-agent-classify: {e}");
+                            break;
+                        }
+                    }
+                }
+                println!("coding-agent-classify: {total} classified");
+                pool.close().await;
+            }
+            Err(e) => eprintln!("coding-agent-classify: open db: {e}"),
+        }
+        return Ok(());
+    }
 
     // 2. Tracing — layered subscriber (stdout + JSONL file + OTLP to OpenObserve).
     //    Guard must outlive the program; we shut it down explicitly at the end
@@ -146,6 +212,28 @@ async fn main() -> Result<()> {
     //       - Permanent failure  → sentinel written after MAX_CONSECUTIVE_FAILURES,
     //                              cursor advances, drain continues
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+    // 8a-bis. Coding-agent tasks (both gated — dormant if neither agent is
+    //         present). The indexer turns Claude Code / Codex JSONLs into
+    //         app_sessions segment rows; the summariser turns sealed segments
+    //         into prose summaries. They share a Notify so the summariser wakes
+    //         near-instantly on the indexer's own seals (plus its own sweep for
+    //         hook-sealed rows). Decoupled from the ETL tick.
+    {
+        let ca_notify: Arc<Notify> = Arc::new(Notify::new());
+        let pool_idx = meridian.clone();
+        let notify_idx = ca_notify.clone();
+        let rx_idx = shutdown_rx.clone();
+        tokio::spawn(async move {
+            meridian::coding_agent::indexer::run_loop(pool_idx, notify_idx, rx_idx).await;
+        });
+        let pool_sum = meridian.clone();
+        let rx_sum = shutdown_rx.clone();
+        tokio::spawn(async move {
+            meridian::coding_agent::summariser::run_loop(pool_sum, ca_notify, rx_sum).await;
+        });
+    }
+
     if mlx_mode {
         let mut shutdown_rx = shutdown_rx;
         let meridian_linker = meridian.clone();
@@ -186,6 +274,27 @@ async fn main() -> Result<()> {
                             // Loop immediately — more sessions may be waiting.
                         }
                         Ok(TaskLinkOutcome::NoPendingWork) => {
+                            // Cursor work is caught up — now drain the coding-agent
+                            // classify queue (summarised rows → task linking), the
+                            // last link of seal→summarise→classify. Repeat until empty.
+                            loop {
+                                match run_coding_agent_classification(&meridian_linker, &cfg)
+                                    .instrument(parent_span.clone())
+                                    .await
+                                {
+                                    Ok(0) => break,
+                                    Ok(n) => {
+                                        tracing::info!(
+                                            classified = n,
+                                            "coding-agent rows classified"
+                                        )
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(error = %e, "coding-agent classification failed");
+                                        break;
+                                    }
+                                }
+                            }
                             break; // Caught up — go back to waiting for next notify.
                         }
                         Ok(TaskLinkOutcome::SubprocessFailed {

--- a/src/migrations/027_app_sessions_segments.sql
+++ b/src/migrations/027_app_sessions_segments.sql
@@ -1,0 +1,70 @@
+-- meridian — normalises screenpipe activity into structured app sessions
+--
+-- Segment-based chunking + sealing for Claude / Codex coding-agent rows.
+--
+-- WHY: the previous scheme (migration 026) keyed coding-agent rows on
+-- (claude_session_uuid, day_utc) and live-tracked them — every poll tick
+-- re-UPSERTed the same row with fresh ended_at / duration / transcript.
+-- That makes the row a moving target: a downstream summary taken mid-flight
+-- goes stale the moment more turns append. It also violated the
+-- app_sessions invariant ("append-only, never updated after insert").
+--
+-- WHAT: we now slice a session into SEGMENTS split on >1h idle gaps between
+-- messages (config.SEGMENT_GAP_SECONDS), and SEAL each segment once it is
+-- settled. A sealed row is immutable forever; downstream only ever reads
+-- sealed rows, so it never sees a moving target.
+--
+--   * `segment_started_at` — the first message timestamp of the segment
+--     (ISO-8601 UTC). This is the segment's stable identity. A single
+--     session that the user resumes after a >1h break produces a SECOND
+--     row with a later segment_started_at, same claude_session_uuid.
+--
+--   * `sealed_at` — NULL while the segment is live (still being appended
+--     to / last activity <1h ago). Set to an ISO-8601 UTC timestamp once
+--     the segment settles (last message >1h ago, OR the SessionEnd hook
+--     fired). The indexer's UPSERT carries `WHERE sealed_at IS NULL`, so a
+--     sealed row is never mutated again.
+--
+-- The summariser queue is exactly: sealed rows with task_method =
+-- 'pending_summariser'. Live (unsealed) rows carry task_method =
+-- 'coding_agent_live' — non-NULL either way, so the MLX classifier (which
+-- selects `WHERE task_method IS NULL`) skips them in both states.
+
+ALTER TABLE app_sessions ADD COLUMN segment_started_at TEXT;
+ALTER TABLE app_sessions ADD COLUMN sealed_at TEXT;
+
+-- Backfill existing coding-agent rows so they remain valid under the new
+-- unique key without waiting for a reseed. Each legacy (uuid, day) row
+-- becomes a single sealed segment keyed on its own started_at.
+UPDATE app_sessions
+SET    segment_started_at = started_at
+WHERE  claude_session_uuid IS NOT NULL
+  AND  segment_started_at IS NULL;
+
+-- Legacy rows are historical (their sessions ended long ago) — mark them
+-- sealed so they are immutable and immediately eligible for the summariser.
+UPDATE app_sessions
+SET    sealed_at = ended_at
+WHERE  claude_session_uuid IS NOT NULL
+  AND  sealed_at IS NULL;
+
+-- Replace per-day uniqueness with per-segment uniqueness.
+DROP INDEX IF EXISTS uq_app_sessions_claude_day;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_app_sessions_claude_segment
+    ON app_sessions (claude_session_uuid, segment_started_at)
+    WHERE claude_session_uuid IS NOT NULL;
+
+-- Partial index for the seal sweep + summariser queue (open / sealed scans).
+CREATE INDEX IF NOT EXISTS idx_app_sessions_seal
+    ON app_sessions (sealed_at, ended_at)
+    WHERE claude_session_uuid IS NOT NULL;
+
+-- After applying this migration, re-split legacy day-rows into true
+-- gap-based segments by re-registering from the JSONLs on disk:
+--
+--     cd services
+--     .venv313/bin/python -m coding_agent_indexer.cli --reseed
+--
+-- Reseed is safe: nothing is summarised yet, so deleting + recreating the
+-- indexer-owned rows loses no downstream work.

--- a/src/migrations/028_drop_day_utc.sql
+++ b/src/migrations/028_drop_day_utc.sql
@@ -1,0 +1,4 @@
+-- meridian — normalises screenpipe activity into structured app sessions
+-- Drop the redundant day_utc column from app_sessions.
+-- The date is already encoded in started_at; callers use substr(started_at,1,10).
+ALTER TABLE app_sessions DROP COLUMN day_utc;


### PR DESCRIPTION
## What

Folds the Claude Code / Codex **coding-agent pipeline** out of standalone Python daemons and **into the single Rust daemon** as gated tokio tasks, closing the **seal → summarise → classify** chain in-process. Dormant when no coding agent is present.

```
JSONLs ─► indexer (segment + seal) ─► summariser (claude/codex, MLX fallback) ─► classifier (on the summary)
         coding_agent_live → pending_summariser → pending_classifier → mlx_direct
```

## Changes

- **Indexer** (`src/coding_agent/{jsonl,segment,indexer,db,hook}.rs`): parse + segment JSONLs; **1h time-box split aligned to a real user-prompt boundary** (a row ends on a complete assistant turn; the next opens on a user message); upsert/seal `app_sessions`; backfill-today; `meridian coding-agent-hook` SessionEnd entry.
- **Summariser** (`src/coding_agent/summariser/`): `claude -p` / `codex exec` (2 attempts) → MLX `/summarise` fallback; writes `session_summary` + `summary_source`, flips `task_method` to `pending_classifier`.
- **Classify trigger** (`src/intelligence/task_linker/`): non-cursor branch classifies `pending_classifier` rows on the **summary** (not the transcript) and **preserves** the summariser's summary. Python classifier reasons over `session_summary` for coding rows.
- **Migrations**: `027` (segment key + seal index) and `028` (drop `day_utc`).
- **CLIs**: `coding-agent-hook` / `coding-agent-summarise` / `coding-agent-classify`.
- Python `coding_agent_indexer` / `coding_agent_summariser` kept as **byte-for-byte parity reference** (enforced by tests); standalone daemons retired. The MLX server (`/classify_sessions` + `/summarise`) stays.

## Testing

- **109 Rust lib tests** (parser parity, seal/immutability, queue, summary-preserved-through-classify); fmt + clippy clean; pre-push (incl. UI build + `cargo test` + security audit) green.
- **Rust ↔ Python parser parity** validated on real session files.
- Full **seal → summarise → classify** chain validated live (real `claude` + real MLX).

## Scope

Pipeline only — deliberately excludes unrelated in-flight work (UI stat, `pm_worklog` rename, `pyproject.toml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)