### PR TITLE
feat(ui): show coding-agent time in the totals strip

### DIFF
--- a/ui/app/api/coding-agents/route.ts
+++ b/ui/app/api/coding-agents/route.ts
@@ -1,0 +1,74 @@
+// meridian — normalises screenpipe activity into structured app sessions
+
+import { NextResponse } from 'next/server'
+import getDb from '@/lib/db'
+import { todayString } from '@/lib/date-utils'
+
+export const dynamic = 'force-dynamic'
+
+interface AgentTotal {
+  app: string
+  total_s: number
+}
+
+export interface CodingAgentsResponse {
+  date: string
+  total_s: number          // union across ALL coding-agent sessions (overlap deduped)
+  agents: AgentTotal[]      // per-agent union, descending
+}
+
+const CODING_AGENTS = ['Claude Code', 'Codex']
+
+/** Union of [start,end] wall intervals, in seconds — dedups parallel overlap. */
+function unionSeconds(rows: Array<{ started_at: string; ended_at: string }>): number {
+  const ivs = rows
+    .map(r => [new Date(r.started_at).getTime(), new Date(r.ended_at).getTime()] as [number, number])
+    .filter(([s, e]) => e > s)
+    .sort((a, b) => a[0] - b[0])
+  let total = 0
+  let curStart = -1
+  let curEnd = -1
+  for (const [s, e] of ivs) {
+    if (s > curEnd) {
+      if (curEnd > curStart) total += curEnd - curStart
+      curStart = s
+      curEnd = e
+    } else if (e > curEnd) {
+      curEnd = e
+    }
+  }
+  if (curEnd > curStart) total += curEnd - curStart
+  return Math.round(total / 1000)
+}
+
+export async function GET() {
+  const date = todayString()
+  try {
+    const db = getDb()
+    // Coding-agent rows carry claude_session_uuid and a local-day bucket.
+    const rows = db.prepare(`
+      SELECT app_name, started_at, ended_at
+      FROM app_sessions
+      WHERE claude_session_uuid IS NOT NULL
+        AND substr(started_at, 1, 10) = ?
+        AND app_name IN ('Claude Code', 'Codex')
+    `).all(date) as Array<{ app_name: string; started_at: string; ended_at: string }>
+
+    const agents: AgentTotal[] = CODING_AGENTS
+      .map(app => ({
+        app,
+        total_s: unionSeconds(rows.filter(r => r.app_name === app)),
+      }))
+      .filter(a => a.total_s > 0)
+      .sort((a, b) => b.total_s - a.total_s)
+
+    return NextResponse.json({
+      date,
+      total_s: unionSeconds(rows),
+      agents,
+    } satisfies CodingAgentsResponse)
+  } catch (e) {
+    console.error('coding-agents api error:', e)
+    return NextResponse.json({ date, total_s: 0, agents: [] } satisfies CodingAgentsResponse)
+  }
+}

--- a/ui/components/views/TodayView.tsx
+++ b/ui/components/views/TodayView.tsx
@@ -144,12 +144,12 @@ function ActiveSessionCard({ active, taskKey }: { active: NonNullable<TodayRespo
 }
 
 // ── Totals strip ─────────────────────────────────────────────────────────────
-function TotalsStrip({ focus_s, idle_s, session_count }: { focus_s: number; idle_s: number; session_count: number }) {
+function TotalsStrip({ focus_s, idle_s, coding_s, session_count }: { focus_s: number; idle_s: number; coding_s: number; session_count: number }) {
   const items = [
-    { k: 'Focus',    v: fmtDur(focus_s),                            note: 'active' },
-    { k: 'Idle',     v: fmtDur(idle_s),                             note: 'away from keyboard' },
-    { k: 'Sessions', v: String(session_count),                      note: 'captured today' },
-    { k: 'Switches', v: String(Math.max(0, session_count - 1)),     note: 'context switches' },
+    { k: 'Focus',        v: fmtDur(focus_s),                        note: 'active' },
+    { k: 'Idle',         v: fmtDur(idle_s),                         note: 'away from keyboard' },
+    { k: 'Coding agent', v: fmtDur(coding_s),                       note: 'Claude Code · Codex' },
+    { k: 'Switches',     v: String(Math.max(0, session_count - 1)), note: 'context switches' },
   ]
   return (
     <div className="grid grid-cols-4 rule-t rule-b" style={{ borderColor: 'var(--rule)' }}>
@@ -322,10 +322,18 @@ function QueuePreviewRow({ session }: { session: { id: number | string; app: str
 // ── Today page ───────────────────────────────────────────────────────────────
 export default function TodayView({ onNavigate }: { onNavigate?: (v: string, key?: string) => void }) {
   const [data, setData] = useState<TodayResponse | null>(null)
+  const [codingS, setCodingS] = useState(0)
 
   useEffect(() => {
     fetch('/api/today').then(r => r.json()).then(setData).catch(() => {})
     const id = setInterval(() => fetch('/api/today').then(r => r.json()).then(setData).catch(() => {}), 30_000)
+    return () => clearInterval(id)
+  }, [])
+
+  useEffect(() => {
+    const load = () => fetch('/api/coding-agents').then(r => r.json()).then(d => setCodingS(d?.total_s ?? 0)).catch(() => {})
+    load()
+    const id = setInterval(load, 30_000)
     return () => clearInterval(id)
   }, [])
 
@@ -410,7 +418,7 @@ export default function TodayView({ onNavigate }: { onNavigate?: (v: string, key
 
       {data.active && <ActiveSessionCard active={data.active} taskKey={data.sessions.filter(s => s.task_key).at(-1)?.task_key} />}
 
-      <TotalsStrip focus_s={data.focus_s} idle_s={data.idle_s} session_count={data.session_count} />
+      <TotalsStrip focus_s={data.focus_s} idle_s={data.idle_s} coding_s={codingS} session_count={data.session_count} />
 
       {buckets.length > 0 && (
         <section>


### PR DESCRIPTION
## What

Replaces the **Sessions** tile in the Today totals strip with **Coding agent** time, so it sits next to **Focus** and **Idle** at the top of the view instead of as a separate card below.

| Before | After |
|---|---|
| Focus · Idle · Sessions · Switches | Focus · Idle · **Coding agent** · Switches |

- Value = overlap-deduped union of today's Claude Code / Codex sessions (`/api/coding-agents` → `total_s`), refreshed on the same 30 s cadence as the rest of the view.
- The standalone `CodingAgentsStat` card is folded into the strip (the component was never committed; only the API route + `TodayView` change ship here).

## Files
- `ui/app/api/coding-agents/route.ts` — the data source the strip reads (was untracked; required for the tile to work).
- `ui/components/views/TodayView.tsx` — strip tile + fetch wiring.

## Verification
- `npm run build` ✓ (compiles, types clean)
- pre-push suite ✓ (fmt · ui build · clippy · ui tests · security audit · cargo test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)