### PR TITLE
chore(hooks): run security audit and cargo test in parallel on pre-push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,6 +6,10 @@ export SQLX_OFFLINE=true
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 FAIL=0
 
+# Consume stdin immediately — git passes push info here and it must be read
+# before any background subshells start (they can't read stdin after forking).
+PUSH_INFO=$(cat)
+
 run_check() {
   local label="$1"; shift
   local log; log=$(mktemp)
@@ -60,17 +64,17 @@ if [[ $FAIL -ne 0 ]]; then
   exit 1
 fi
 
-# ── Wave 3: security audit (files changed in commits being pushed) ──────────
+# ── Wave 3: security audit + cargo test (parallel) ──────────────────────────
 echo ""
-echo "[wave 3/4] security audit"
+echo "[wave 3/3] security audit  +  cargo test"
+
+AUDIT_LOG=$(mktemp)
+AUDIT_PID=""
 
 if command -v claude &>/dev/null; then
-  # Read the remote/branch from pre-push stdin (format: <local-ref> <local-sha> <remote-ref> <remote-sha>)
-  PUSH_INFO=$(cat)
   REMOTE_SHA=$(echo "$PUSH_INFO" | awk '{print $4}')
   LOCAL_SHA=$(echo "$PUSH_INFO" | awk '{print $2}')
 
-  # Fall back to comparing against remote HEAD if we can't parse stdin
   if [ -z "$REMOTE_SHA" ] || [ "$REMOTE_SHA" = "0000000000000000000000000000000000000000" ]; then
     CHANGED=$(git diff --name-only HEAD~1..HEAD 2>/dev/null | grep -E '\.(rs|ts|tsx|py)$' || true)
   else
@@ -79,17 +83,8 @@ if command -v claude &>/dev/null; then
 
   if [ -n "$CHANGED" ]; then
     echo "  Running security audit on pushed files..."
-    FINDINGS=$(claude --print "Security audit of changes in the Meridian project. Files: $CHANGED. Check only: SQL injection, command injection, path traversal, hardcoded credentials, missing input validation at API boundaries, unsafe subprocess calls (shell=True, unvalidated exec paths). Report only HIGH and CRITICAL severity findings as a compact bulleted list with file:line. If none found, output exactly: NO_HIGH_FINDINGS" 2>/dev/null || echo "NO_HIGH_FINDINGS")
-    if echo "$FINDINGS" | grep -qE '\*\*(HIGH|CRITICAL)'; then
-      echo ""
-      echo "  Security audit findings:"
-      echo "$FINDINGS"
-      echo ""
-      echo "  Fix HIGH/CRITICAL issues before pushing, or run: git push --no-verify to skip."
-      exit 1
-    else
-      echo "  ✓ security audit"
-    fi
+    claude --print "Security audit of changes in the Meridian project. Files: $CHANGED. Check only: SQL injection, command injection, path traversal, hardcoded credentials, missing input validation at API boundaries, unsafe subprocess calls (shell=True, unvalidated exec paths). Report only HIGH and CRITICAL severity findings as a compact bulleted list with file:line. If none found, output exactly: NO_HIGH_FINDINGS" >"$AUDIT_LOG" 2>/dev/null &
+    AUDIT_PID=$!
   else
     echo "  ✓ security audit (no auditable files changed)"
   fi
@@ -97,15 +92,31 @@ else
   echo "  - security audit skipped (claude CLI not found)"
 fi
 
-# ── Wave 4: cargo test (sequential after clippy — reuses build artifacts) ───
-echo ""
-echo "[wave 4/4] cargo test"
+run_check "cargo test" cargo test &
+W3_TEST=$!
 
-run_check "cargo test" cargo test
+wait $W3_TEST
+
+if [ -n "$AUDIT_PID" ]; then
+  wait "$AUDIT_PID" || true
+  FINDINGS=$(cat "$AUDIT_LOG")
+  if echo "$FINDINGS" | grep -qE '\*\*(HIGH|CRITICAL)'; then
+    echo ""
+    echo "  Security audit findings:"
+    echo "$FINDINGS"
+    echo ""
+    echo "  Fix HIGH/CRITICAL issues before pushing, or run: git push --no-verify to skip."
+    rm -f "$AUDIT_LOG"
+    exit 1
+  else
+    echo "  ✓ security audit"
+  fi
+fi
+rm -f "$AUDIT_LOG"
 
 if [[ $FAIL -ne 0 ]]; then
   echo ""
-  echo "Wave 4 failed — fix Rust test errors before pushing."
+  echo "Wave 3 failed — fix Rust test errors before pushing."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Security audit (`claude --print`) and `cargo test` previously ran sequentially in waves 3 and 4, adding ~20-30s of serial API wait time to every push
- Both are fully independent so they now run concurrently as a single wave 3/3
- `PUSH_INFO=$(cat)` moved to the top of the script — stdin must be consumed before any background subshells are forked, otherwise they race on it

## Test plan

- [x] Pre-push hook ran successfully during this push (all 3 waves passed)
- [ ] Verify on a push with changed `.rs`/`.ts`/`.py` files to confirm audit fires in the background correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)