### PR TITLE
fix(classifier): stop outlines truncating task reasoning at 300 chars

### DIFF
--- a/services/agents/run_task_linker_mlx.py
+++ b/services/agents/run_task_linker_mlx.py
@@ -85,8 +85,13 @@ class SessionClassification(BaseModel):
         ),
     )
     reasoning: str = Field(
-        ..., max_length=300,
-        description="1–4 sentences citing window titles, OCR text, or context clues.",
+        ...,
+        description=(
+            "Concise justification citing window titles, OCR text, or context "
+            "clues. No hard length cap — outlines must not truncate this field; "
+            "the only ceiling is the server-side _MAX_TOKENS generation budget. "
+            "Store whatever the model produces verbatim."
+        ),
     )
     dimensions: dict[str, list[str]] = Field(
         default_factory=dict,


### PR DESCRIPTION
## Problem

A real `app_sessions` row had its `task_reasoning` cut off mid-sentence at exactly **300 characters** (`"...the broader PM-1"`). The cause: `SessionClassification.reasoning` (`run_task_linker_mlx.py`) carried `max_length=300`. The MLX classifier generates this via **outlines FSM-constrained decoding**, which guarantees output matches the Pydantic schema — so the 300-char cap force-closed the reasoning string mid-word and the truncated text was persisted as valid JSON (no error surfaced).

The earlier `task_key` / `confidence` / `session_type` fields were intact because they precede `reasoning` in the schema; only the long trailing field hit the wall.

## Fix

Remove `max_length=300` from the `reasoning` field. The model now writes reasoning to its natural end, bounded only by the server-side `_MAX_TOKENS` generation budget (the intended ceiling). The Rust write path (`db_write.rs`) and the `TEXT` column never capped this — so whatever the model emits is now stored verbatim.

## Notes

- This is a classifier **schema** change. Per `CLAUDE.md`, removing the length bound can shift model behavior (reasonings may get longer), so it's worth a pass through the eval pipeline (`services/tests/evals/`) before considering it settled.
- A sibling latent issue (not changed here): the same schema's `session_summary` has `max_length=1000`, which contradicts its own "40-80 sentences" instruction and truncates the classifier-generated summary the same way — but coding-agent rows keep the summariser's summary, so it only bites direct-MLX-classified sessions. Left for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)