### PR TITLE
fix(install): MLX installer aborted when MERIDIAN_OO_AUTH unset

### DIFF
--- a/services/scripts/install-mlx-server-daemon.sh
+++ b/services/scripts/install-mlx-server-daemon.sh
@@ -70,8 +70,11 @@ fi
 MERIDIAN_OO_AUTH=""
 MERIDIAN_OTLP_ENDPOINT=""
 if [[ -f "${REPO_ROOT}/.env" ]]; then
-    MERIDIAN_OO_AUTH=$(grep -E '^MERIDIAN_OO_AUTH=' "${REPO_ROOT}/.env" | tail -1 | cut -d= -f2-)
-    MERIDIAN_OTLP_ENDPOINT=$(grep -E '^MERIDIAN_OTLP_ENDPOINT=' "${REPO_ROOT}/.env" | tail -1 | cut -d= -f2-)
+    # `|| true`: grep exits non-zero when the key is absent, which under
+    # `set -o pipefail` + `set -e` would abort the whole installer. These vars
+    # are optional (telemetry off when unset), so never let a missing key fail.
+    MERIDIAN_OO_AUTH=$(grep -E '^MERIDIAN_OO_AUTH=' "${REPO_ROOT}/.env" | tail -1 | cut -d= -f2- || true)
+    MERIDIAN_OTLP_ENDPOINT=$(grep -E '^MERIDIAN_OTLP_ENDPOINT=' "${REPO_ROOT}/.env" | tail -1 | cut -d= -f2- || true)
 fi
 
 mkdir -p "${HOME}/.meridian/logs"

--- a/services/scripts/install-mlx-server-daemon.sh
+++ b/services/scripts/install-mlx-server-daemon.sh
@@ -98,7 +98,19 @@ fi
 
 echo "→ bootout ${LABEL} (if loaded)"
 launchctl bootout "${GUI_TARGET}/${LABEL}" 2>/dev/null || true
-sleep 1
+# bootout is async. A fixed sleep is unreliable — when the prior MLX process
+# still holds the ~9 GB model in memory it takes seconds to exit, and
+# bootstrapping before the domain entry is gone fails with EIO (errno 5).
+# Wait until launchd confirms the service is actually gone.
+_bootout_wait=0
+while launchctl print "${GUI_TARGET}/${LABEL}" >/dev/null 2>&1; do
+    sleep 1
+    _bootout_wait=$(( _bootout_wait + 1 ))
+    if [[ "${_bootout_wait}" -ge 20 ]]; then
+        echo "⚠ ${LABEL} still in launchd domain after 20s — proceeding anyway" >&2
+        break
+    fi
+done
 
 echo "→ bootstrap ${LABEL}"
 launchctl enable "${GUI_TARGET}/${LABEL}" 2>/dev/null || true


### PR DESCRIPTION
When OpenObserve isn't configured (no `MERIDIAN_OO_AUTH` in `.env`), `grep` exits non-zero → `set -o pipefail` + `set -e` aborted `install-mlx-server-daemon.sh` **before writing the MLX plist**, which silently killed the rest of `install.sh` (Rust daemon, UI, and the `meridian` CLI symlink never installed). Added `|| true` to the optional OTel-credential reads — same safe pattern `install-daemon.sh` already uses. Verified: installer now exits 0 and installs the MLX plist with OO unset.