### PR TITLE
feat(logs): split errors into a separate command (daemon + MLX) + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,24 @@ The server loads the model once at startup (~30 s on first run while the model d
 ```bash
 meridian start          # bring up all daemons (screenpipe + daemon + mlx-server + ui)
 meridian status         # check what's running
-meridian logs           # tail the Rust daemon log
-meridian logs ui        # tail the dashboard log
-meridian logs mlx-server # tail the MLX server log
 meridian doctor         # diagnose missing config / services / permissions
 meridian permissions    # re-run the screenpipe permissions walkthrough
 ```
+
+### Logs
+
+`meridian logs [target] [-f]` tails a log; add `-f` to stream live. Each component has a normal log (everything) and an `-error` log (WARN/ERROR only):
+
+```bash
+meridian logs -f                  # Rust daemon — the whole pipeline (default)
+meridian logs daemon-error -f     # Rust daemon — problems only
+meridian logs mlx-server -f       # MLX inference server — classify/synth requests
+meridian logs mlx-server-error -f # MLX server — problems only
+meridian logs ui -f               # dashboard
+meridian logs screenpipe -f       # capture layer
+```
+
+Targets: `daemon` · `daemon-error` · `mlx-server` · `mlx-server-error` · `ui` · `ui-error` · `screenpipe` · `screenpipe-error`. The Rust daemon also writes structured JSON to `~/.meridian/logs/meridian-rust.jsonl.<date>` for grepping.
 
 Once started, the dashboard is at **http://localhost:3000**. Stop with `meridian stop`. Remove everything with `meridian uninstall`.
 

--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -40,7 +40,7 @@ Commands:
   restart            Stop, wait 1s, start
   status             Show running state of all daemons
   logs [target]      Tail log files
-                     target: daemon|daemon-error|screenpipe|screenpipe-error|ui|ui-error|mlx-server
+                     target: daemon|daemon-error|screenpipe|screenpipe-error|ui|ui-error|mlx-server|mlx-server-error
     -f               Follow (stream)
     -n N             Last N lines (default 100)
   doctor             Run environment health checks
@@ -158,7 +158,8 @@ cmd_logs() {
         ui)                log_file="${LOG_DIR}/ui.log" ;;
         ui-error)          log_file="${LOG_DIR}/ui-error.log" ;;
         mlx-server)        log_file="${LOG_DIR}/mlx-server.log" ;;
-        *) err "unknown log target: ${target} (daemon|daemon-error|screenpipe|screenpipe-error|ui|ui-error|mlx-server)"; exit 1 ;;
+        mlx-server-error)  log_file="${LOG_DIR}/mlx-server-error.log" ;;
+        *) err "unknown log target: ${target} (daemon|daemon-error|screenpipe|screenpipe-error|ui|ui-error|mlx-server|mlx-server-error)"; exit 1 ;;
     esac
 
     if [[ ! -f "$log_file" ]]; then

--- a/services/agents/observability.py
+++ b/services/agents/observability.py
@@ -183,9 +183,18 @@ def _configure_logging(agent_name: str) -> None:
     file_h.setFormatter(formatter)
     file_h.addFilter(_ServiceFilter())
 
-    stream_h = logging.StreamHandler(sys.stderr)
-    stream_h.setFormatter(formatter)
-    stream_h.addFilter(_ServiceFilter())
+    # Split streams by level so the launchd plist can route them to separate
+    # files: INFO/DEBUG → stdout (mlx-server.log), WARNING+ → stderr
+    # (mlx-server-error.log). Errors still appear in the file/JSONL handler too.
+    stdout_h = logging.StreamHandler(sys.stdout)
+    stdout_h.setFormatter(formatter)
+    stdout_h.addFilter(_ServiceFilter())
+    stdout_h.addFilter(lambda r: r.levelno < logging.WARNING)  # below WARNING only
+
+    stderr_h = logging.StreamHandler(sys.stderr)
+    stderr_h.setFormatter(formatter)
+    stderr_h.addFilter(_ServiceFilter())
+    stderr_h.setLevel(logging.WARNING)  # WARNING / ERROR / CRITICAL only
 
     root = logging.getLogger()
     # Clear any pre-existing handlers — long-running daemons that import
@@ -193,7 +202,8 @@ def _configure_logging(agent_name: str) -> None:
     # behind that would duplicate every line.
     root.handlers.clear()
     root.addHandler(file_h)
-    root.addHandler(stream_h)
+    root.addHandler(stdout_h)
+    root.addHandler(stderr_h)
     root.setLevel(level)
 
     for noisy in _NOISY_LOGGERS:

--- a/services/scripts/com.meridiona.mlx-server.plist
+++ b/services/scripts/com.meridiona.mlx-server.plist
@@ -57,7 +57,7 @@
     <key>StandardOutPath</key>
     <string>{{HOME}}/.meridian/logs/mlx-server.log</string>
     <key>StandardErrorPath</key>
-    <string>{{HOME}}/.meridian/logs/mlx-server.log</string>
+    <string>{{HOME}}/.meridian/logs/mlx-server-error.log</string>
 
     <!-- Start immediately when loaded and after every crash. -->
     <key>RunAtLoad</key>

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -86,10 +86,20 @@ pub fn init(service_name: &str) -> Result<ObservabilityGuard> {
     let env_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT_ENV_FILTER));
 
+    // stdout: everything (INFO+). This is what `meridian logs` / daemon.log shows.
     let fmt_stdout = tracing_subscriber::fmt::layer()
         .with_target(true)
         .with_writer(std::io::stdout)
         .compact();
+    // stderr: WARN+ERROR only — a filtered view so `meridian logs daemon-error`
+    // surfaces just the problems. Errors still appear in stdout/daemon.log too.
+    use tracing_subscriber::filter::LevelFilter;
+    use tracing_subscriber::Layer as _;
+    let fmt_stderr = tracing_subscriber::fmt::layer()
+        .with_target(true)
+        .with_writer(std::io::stderr)
+        .compact()
+        .with_filter(LevelFilter::WARN);
     let fmt_file = tracing_subscriber::fmt::layer()
         .with_target(true)
         .with_writer(file_writer)
@@ -111,6 +121,7 @@ pub fn init(service_name: &str) -> Result<ObservabilityGuard> {
             tracing_subscriber::registry()
                 .with(env_filter)
                 .with(fmt_stdout)
+                .with(fmt_stderr)
                 .with(fmt_file)
                 .with(trace_layer)
                 .with(log_layer)
@@ -122,6 +133,7 @@ pub fn init(service_name: &str) -> Result<ObservabilityGuard> {
             tracing_subscriber::registry()
                 .with(env_filter)
                 .with(fmt_stdout)
+                .with(fmt_stderr)
                 .with(fmt_file)
                 .init();
             (false, None)
@@ -131,6 +143,7 @@ pub fn init(service_name: &str) -> Result<ObservabilityGuard> {
             tracing_subscriber::registry()
                 .with(env_filter)
                 .with(fmt_stdout)
+                .with(fmt_stderr)
                 .with(fmt_file)
                 .init();
             (false, None)


### PR DESCRIPTION
Follow-up to #67 (these commits were pushed after #67 was merged, so they're not on main yet).

- **Rust daemon:** WARN/ERROR-only stderr layer → `daemon-error.log` carries just the problems; `daemon.log` still has everything.
- **MLX server:** split Python logging (INFO→stdout, WARNING+→stderr) + separate `StandardErrorPath` in the plist + new `meridian logs mlx-server-error` target.
- **README:** documents all `meridian logs` targets including the `-error` variants.

Already verified live: `daemon-error.log` has 0 INFO lines, only WARN/ERROR.