### PR TITLE
feat(pm-worklog): 'meridian worklog-status' — monitor worklogs without SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,12 @@ The server loads the model once at startup (~30 s on first run while the model d
 ```bash
 meridian start          # bring up all daemons (screenpipe + daemon + mlx-server + ui)
 meridian status         # check what's running
+meridian worklog-status # today's PM worklogs: done/pending + per-ticket comments
 meridian doctor         # diagnose missing config / services / permissions
 meridian permissions    # re-run the screenpipe permissions walkthrough
 ```
+
+`meridian worklog-status [--day YYYY-MM-DD]` prints a no-SQL summary of the PM-worklog stage: hours done/pending/stuck, worklogs by state (drafted/posted/skipped/failed), and a per-ticket table with the synthesised Jira comment — plus a "flagged" list of low-confidence or risk-flagged worklogs to inspect before enabling Jira posting.
 
 ### Logs
 

--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -44,6 +44,8 @@ Commands:
     -f               Follow (stream)
     -n N             Last N lines (default 100)
   doctor             Run environment health checks
+  worklog-status     Show today's PM worklogs (done/pending/drafted/posted + comments)
+                     [--day YYYY-MM-DD]
   config edit        Open the repo-root .env in $EDITOR
   permissions        Open macOS permission panes for screenpipe
   uninstall          Stop daemons and remove CLI symlinks
@@ -355,6 +357,17 @@ cmd_permissions() {
 CMD="${1:-}"
 shift || true
 
+# Subcommands implemented by the daemon binary itself (not the launchd manager).
+# Forward these straight through to `meridian-daemon <cmd> [args]`.
+cmd_daemon_passthrough() {
+    local bin=""
+    for p in /usr/local/bin/meridian-daemon "${HOME}/.local/bin/meridian-daemon"; do
+        [[ -x "$p" ]] && bin="$p" && break
+    done
+    [[ -n "$bin" ]] || { err "meridian-daemon binary not found — run ./install.sh"; exit 1; }
+    exec "$bin" "$@"
+}
+
 case "$CMD" in
     start)            cmd_start ;;
     stop)             cmd_stop ;;
@@ -365,6 +378,7 @@ case "$CMD" in
     config)           cmd_config "$@" ;;
     uninstall)        cmd_uninstall ;;
     permissions)      cmd_permissions ;;
+    worklog-status|pm-worklog) cmd_daemon_passthrough "$CMD" "$@" ;;
     --help|-h|help|"") cmd_help ;;
     *) err "unknown command: ${CMD}"; echo; cmd_help; exit 1 ;;
 esac

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,26 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    // `meridian worklog-status [--day YYYY-MM-DD]` — a human-readable report of
+    // the day's worklogs (hours done/pending/stuck, rows by state, per-ticket
+    // comments + flagged ones). Read-only; no daemon init.
+    if std::env::args().nth(1).as_deref() == Some("worklog-status") {
+        let args: Vec<String> = std::env::args().collect();
+        let day = args
+            .iter()
+            .position(|a| a == "--day")
+            .and_then(|i| args.get(i + 1).cloned());
+        let cfg = Config::from_env();
+        match setup_db(&cfg.meridian_db_uri()).await {
+            Ok(pool) => {
+                meridian::pm_worklog::cli_status(&pool, day.as_deref()).await;
+                pool.close().await;
+            }
+            Err(e) => eprintln!("worklog-status: open db: {e}"),
+        }
+        return Ok(());
+    }
+
     // 2. Tracing — layered subscriber (stdout + JSONL file + OTLP to OpenObserve).
     //    Guard must outlive the program; we shut it down explicitly at the end
     //    so OTel's blocking flush doesn't run inside tokio's drop path.

--- a/src/pm_worklog/mod.rs
+++ b/src/pm_worklog/mod.rs
@@ -20,7 +20,9 @@ pub mod ledger;
 pub mod models;
 pub mod route;
 pub mod scheduler;
+pub mod status;
 pub mod synth;
 
 pub use config::PmWorklogConfig;
 pub use scheduler::{cli_run, run_driver, run_loop, DriverSummary};
+pub use status::cli_status;

--- a/src/pm_worklog/status.rs
+++ b/src/pm_worklog/status.rs
@@ -1,0 +1,200 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// `meridian worklog-status` — a human-readable PM-worklog report, no SQL needed.
+// For a day it prints: the hour ledger (done / pending / stuck), worklogs by
+// state, and a per-ticket table with the synthesised Jira comment. Reads
+// pm_worklog_hours (driver progress) + pm_worklogs (output rows).
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Local};
+use sqlx::{Row, SqlitePool};
+
+use super::config::PmWorklogConfig;
+use super::models::JiraUpdate;
+
+/// Aging window (minutes) past hour_end after which a still-`pending` hour is
+/// considered genuinely stuck rather than merely settling. Mirrors the driver's
+/// default `PM_WORKLOG_READINESS_AGING_MIN`.
+const STUCK_AFTER_MIN: f64 = 90.0;
+
+/// Render `window_start` (`...+00:00`) as a local `HH:MM`, or the raw string if
+/// it can't be parsed.
+fn local_hhmm(iso: &str) -> String {
+    match DateTime::parse_from_rfc3339(iso) {
+        Ok(dt) => dt.with_timezone(&Local).format("%H:%M").to_string(),
+        Err(_) => iso.chars().take(5).collect(),
+    }
+}
+
+fn fmt_secs(s: i64) -> String {
+    let m = s / 60;
+    if m >= 60 {
+        format!("{}h{:02}m", m / 60, m % 60)
+    } else {
+        format!("{m}m")
+    }
+}
+
+/// One-shot CLI: `meridian worklog-status [--day YYYY-MM-DD]`.
+/// `day` defaults to the local current date (matches how rows are stamped for
+/// daytime hours; late-night hours may fall under the previous UTC date).
+pub async fn cli_status(pool: &SqlitePool, day: Option<&str>) {
+    let day_utc = match day {
+        Some(d) => d.to_string(),
+        None => Local::now().format("%Y-%m-%d").to_string(),
+    };
+    if let Err(e) = print_status(pool, &day_utc).await {
+        eprintln!("worklog-status: {e:#}");
+    }
+}
+
+async fn print_status(pool: &SqlitePool, day_utc: &str) -> Result<()> {
+    let cfg = PmWorklogConfig::from_env();
+
+    // ── Hour ledger ────────────────────────────────────────────────────────
+    let hour_rows = sqlx::query("SELECT status, hour_end FROM pm_worklog_hours WHERE day_utc = ?")
+        .bind(day_utc)
+        .fetch_all(pool)
+        .await
+        .context("read pm_worklog_hours")?;
+
+    let now = Local::now();
+    let (mut done, mut pending, mut stuck) = (0u32, 0u32, 0u32);
+    for r in &hour_rows {
+        let status: String = r.get("status");
+        if status == "done" {
+            done += 1;
+            continue;
+        }
+        pending += 1;
+        let hour_end: String = r.get("hour_end");
+        if let Ok(he) = DateTime::parse_from_rfc3339(&hour_end) {
+            let mins_over =
+                (now.signed_duration_since(he.with_timezone(&Local))).num_minutes() as f64;
+            if mins_over > STUCK_AFTER_MIN {
+                stuck += 1;
+            }
+        }
+    }
+
+    // ── Worklog rows ───────────────────────────────────────────────────────
+    let wl_rows = sqlx::query(
+        "SELECT task_key, window_start, state, confidence, time_spent_seconds, \
+                posted_worklog_id, payload_json \
+         FROM pm_worklogs WHERE day_utc = ? ORDER BY window_start, task_key",
+    )
+    .bind(day_utc)
+    .fetch_all(pool)
+    .await
+    .context("read pm_worklogs")?;
+
+    let (mut drafted, mut posted, mut skipped, mut failed) = (0u32, 0u32, 0u32, 0u32);
+    let mut total_secs: i64 = 0;
+    struct Line {
+        hour: String,
+        task: String,
+        state: String,
+        conf: f64,
+        secs: i64,
+        comment: String,
+        flags: Vec<String>,
+    }
+    let mut lines: Vec<Line> = Vec::with_capacity(wl_rows.len());
+    for r in &wl_rows {
+        let state: String = r.get("state");
+        match state.as_str() {
+            "posted" => posted += 1,
+            "drafted" => drafted += 1,
+            "skipped" => skipped += 1,
+            "failed" => failed += 1,
+            _ => {}
+        }
+        let secs: i64 = r.try_get("time_spent_seconds").unwrap_or(0);
+        total_secs += secs;
+        let payload: String = r.get("payload_json");
+        let (comment, flags) = match serde_json::from_str::<JiraUpdate>(&payload) {
+            Ok(u) => (u.summary, u.risk_flags),
+            Err(_) => ("(unparseable payload)".to_string(), vec![]),
+        };
+        lines.push(Line {
+            hour: local_hhmm(&r.get::<String, _>("window_start")),
+            task: r.get("task_key"),
+            state,
+            conf: r.try_get("confidence").unwrap_or(0.0),
+            secs,
+            comment,
+            flags,
+        });
+    }
+
+    // ── Header ─────────────────────────────────────────────────────────────
+    let posting = if cfg.post_enabled {
+        "ON (posts to Jira)"
+    } else {
+        "OFF (dry-run — drafts only)"
+    };
+    println!();
+    println!("  PM Worklog Status — {day_utc} (times shown in local tz)");
+    println!("  ─────────────────────────────────────────────────────────────");
+    let stuck_note = if stuck > 0 {
+        format!("  ⚠ {stuck} STUCK (>{STUCK_AFTER_MIN:.0}m overdue)")
+    } else {
+        String::new()
+    };
+    println!("  Hours:    {done} done · {pending} pending{stuck_note}");
+    println!(
+        "  Worklogs: {drafted} drafted · {posted} posted · {skipped} skipped · {failed} failed   ({} total)",
+        fmt_secs(total_secs)
+    );
+    println!("  Posting:  {posting}");
+
+    if lines.is_empty() {
+        println!();
+        println!("  (no worklogs for this day)");
+        return Ok(());
+    }
+
+    // ── Per-ticket table ───────────────────────────────────────────────────
+    println!();
+    println!(
+        "  {:<6}  {:<9}  {:<8}  {:>4}  {:>6}  comment",
+        "hour", "ticket", "state", "conf", "time"
+    );
+    for l in &lines {
+        let flag = if l.flags.is_empty() { "" } else { " ⚑" };
+        let comment: String = l.comment.chars().take(64).collect();
+        println!(
+            "  {:<6}  {:<9}  {:<8}  {:>4.2}  {:>6}  {comment}{flag}",
+            l.hour,
+            l.task,
+            l.state,
+            l.conf,
+            fmt_secs(l.secs)
+        );
+    }
+
+    // ── Flagged (weak/leaky) worklogs ──────────────────────────────────────
+    let flagged: Vec<&Line> = lines
+        .iter()
+        .filter(|l| l.conf < cfg.min_confidence || !l.flags.is_empty())
+        .collect();
+    if !flagged.is_empty() {
+        println!();
+        println!(
+            "  ⚑ {} worklog(s) below conf {:.2} or with risk flags — inspect before posting:",
+            flagged.len(),
+            cfg.min_confidence
+        );
+        for l in flagged {
+            let fl = if l.flags.is_empty() {
+                "low_confidence".to_string()
+            } else {
+                l.flags.join(",")
+            };
+            println!("      {} {} (conf {:.2}) — {}", l.hour, l.task, l.conf, fl);
+        }
+    }
+
+    println!();
+    Ok(())
+}


### PR DESCRIPTION
Adds `meridian worklog-status [--day YYYY-MM-DD]` — a human-readable report of the PM-worklog stage, so you can monitor it without writing SQL or opening a DB GUI.

**Prints:**
- **Hour ledger**: done / pending / stuck (pending >90 min past hour end).
- **Worklogs by state**: drafted / posted / skipped / failed + total time + posting on/off.
- **Per-ticket table**: hour (local tz), ticket, state, confidence, time, synthesised Jira comment.
- **Flagged list**: worklogs below `PM_WORKLOG_MIN_CONFIDENCE` or carrying risk flags (low_evidence, cross_ticket_leak, …) — inspect before enabling Jira posting.

`src/pm_worklog/status.rs` (read-only over `pm_worklogs` + `pm_worklog_hours`), wired as a daemon subcommand and forwarded through the `meridian` CLI wrapper. README updated.