### PR TITLE
feat: npm distribution (@meridiona/meridian) + semantic-release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,5 +1,11 @@
 name: Release Please
 
+# Maintains the product version from conventional commits: opens/updates a
+# "release PR" that bumps the version (Cargo.toml + ui/mcp package.json +
+# pyproject.toml in lockstep) and updates CHANGELOG.md. Merging that PR tags
+# vX.Y.Z and publishes a GitHub Release — which triggers release.yml to build
+# and attach the macOS arm64 artifacts.
+
 on:
   push:
     branches: [main]
@@ -12,42 +18,12 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name:        ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
-        id: release
         with:
-          # Use a PAT so the action can open PRs when org-level GITHUB_TOKEN
-          # PR creation is restricted. Create a classic token with `repo` scope
-          # and add it as repository secret RELEASE_PLEASE_TOKEN.
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # A PAT (classic, `repo` scope) added as repo secret RELEASE_PLEASE_TOKEN
+          # so the action can open PRs when org GITHUB_TOKEN PR-creation is
+          # restricted. Falls back to GITHUB_TOKEN if the secret is absent.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  # Build release binaries only when release-please actually cut a release.
-  build-release:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
-    runs-on: ubuntu-latest
-    env:
-      SQLX_OFFLINE: "true"
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust 1.93.1
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.93.1"
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Build release binary
-        run: cargo build --release
-
-      - name: Upload binary to GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.release-please.outputs.tag_name }}
-          files: target/release/meridian

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release Build
+
+# When release-please publishes a GitHub Release (tag vX.Y.Z), build the
+# prebuilt macOS arm64 bundle and attach it. The installer downloads this
+# tarball — no cargo/npm build on the user's machine.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-bundle:
+    runs-on: macos-14          # Apple Silicon (arm64) — MLX/Metal target
+    env:
+      SQLX_OFFLINE: "true"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Install Rust 1.93.1
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.93.1"
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build daemon (release)
+        run: cargo build --release
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Build UI (standalone)
+        working-directory: ui
+        run: |
+          npm ci
+          npm run build
+
+      - name: Assemble release bundle
+        run: bash scripts/package-release.sh "${{ github.event.release.tag_name }}" dist
+
+      - name: Checksum
+        working-directory: dist
+        run: shasum -a 256 *.tar.gz > SHA256SUMS
+
+      - name: Attach artifacts to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: |
+            dist/*.tar.gz
+            dist/SHA256SUMS

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ services/tests/evals/results/
 # Python bytecode
 __pycache__/
 *.pyc
+dist/

--- a/README.md
+++ b/README.md
@@ -36,33 +36,36 @@ to `app_sessions`:
 
 ## Getting started
 
-### Prerequisites
+**Requirements:** macOS on **Apple Silicon** (M1+). That's it — the installer brings the rest.
 
-- macOS 13+
-- Internet connection (for Homebrew + dependency downloads)
-
-`install.sh` handles everything else — Homebrew, Rust, Node 18+, Python 3.11+, and screenpipe itself.
-
-### Install
+### Install (one command)
 
 ```bash
-git clone https://github.com/meridiona/meridian
+curl -fsSL https://raw.githubusercontent.com/Meridiona/meridian/main/bootstrap.sh | bash
+```
+
+No clone, no build. This downloads the latest prebuilt release to `~/.meridian/app`, installs any missing prerequisites (Homebrew packages, Node, Python 3.11, screenpipe, ffmpeg), sets up the on-device model, and registers four auto-starting services — **screenpipe** (capture), the **daemon** (pipeline), the **MLX server** (on-device model), and the **dashboard** at http://localhost:3000.
+
+Then grant screenpipe its three macOS permissions when prompted (Screen Recording, Accessibility, Microphone), and optionally connect Jira.
+
+👉 **Full walkthrough — permissions, Jira, verifying, logs, updating, troubleshooting: [SETUP.md](SETUP.md).**
+
+```bash
+meridian status      # the four services
+meridian logs -f     # watch the pipeline
+meridian config edit # add your Jira credentials
+meridian update      # update to the latest release
+```
+
+### Build from source (contributors)
+
+```bash
+git clone https://github.com/Meridiona/meridian
 cd meridian
 ./install.sh
 ```
 
-The installer detects and offers to install each missing prerequisite, then builds the Rust daemon, the MCP server, the Next.js UI, sets up the Python services (including the MLX inference server), walks you through granting screenpipe its three macOS permissions (Screen Recording, Accessibility, Microphone), and registers four launchd LaunchAgents: `com.meridiona.screenpipe`, `com.meridiona.daemon`, `com.meridiona.mlx-server`, and `com.meridiona.ui` (the dashboard at http://localhost:3000). All four start automatically once installed.
-
-The **MLX inference server** (Qwen3.5-9B, Apple Silicon) is installed by default — it powers both session classification and the PM-worklog synthesiser. `./install.sh` sets up the Python venv and the `[mlx]` extras for you; no manual steps needed.
-
-Useful flags:
-
-- `./install.sh --no-ui` — skip the dashboard build
-- `./install.sh --dry-run` — preview actions without executing
-- `./install.sh --no-daemon` — build only; don't register launchd agents
-- `./install.sh --skip-permissions` — skip the macOS permissions walkthrough
-- `./install.sh --skip-env` — skip the credential walkthrough
-- `./install.sh --no-mlx` — skip the MLX server and use the hermes LLM-selector backend (PM-worklog synthesis is then unavailable)
+Builds the daemon + UI from source and registers the same services. Flags: `--no-ui`, `--dry-run`, `--no-daemon`, `--skip-permissions`, `--skip-env`, `--no-mlx` (use the hermes LLM-selector backend instead of the MLX server).
 
 ### Configure
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,129 @@
+# Setting up Meridian
+
+Meridian installs with **one command** — no repo to clone, no compiler to set up. It downloads a prebuilt release, installs the four background services, and starts them.
+
+> **Platform:** macOS on **Apple Silicon** (M1 or later). The on-device model needs Metal; Intel Macs aren't supported.
+
+---
+
+## 1. Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Meridiona/meridian/main/bootstrap.sh | bash
+```
+
+This downloads the latest release to `~/.meridian/app`, installs prerequisites it's missing (Homebrew packages, Node, Python 3.11, screenpipe, ffmpeg), creates the Python environment + the on-device model deps, and registers four launchd agents that start automatically:
+
+| Service | Role |
+|---|---|
+| **screenpipe** | captures screen + audio (the data source) |
+| **meridian daemon** | the pipeline — ETL, classification, coding-agent ingest, PM-worklog |
+| **MLX server** | the on-device model (classification + worklog synthesis) |
+| **dashboard** | the web UI at http://localhost:3000 |
+
+> First install downloads the ~6 GB model on first MLX start — give it a few minutes (`meridian logs mlx-server -f` shows progress).
+
+Pin a specific version with `MERIDIAN_VERSION=v0.3.0 curl … | bash`.
+
+---
+
+## 2. Grant macOS permissions (required, manual)
+
+screenpipe needs three permissions macOS will only let **you** grant. The installer opens each pane; for each:
+
+1. **Screen Recording** — System Settings → Privacy & Security → Screen Recording → click **+**, add the screenpipe binary, toggle ON.
+2. **Accessibility** — same, under Accessibility.
+3. **Microphone** — screenpipe appears here after it first tries the mic; toggle ON.
+
+After granting, run `meridian restart`.
+
+---
+
+## 3. Connect Jira (optional, but it's the point)
+
+Meridian drafts worklogs against your Jira tickets. To enable:
+
+1. Create an API token at **https://id.atlassian.com/manage-profile/security/api-tokens**.
+2. Open the config and add three lines:
+   ```bash
+   meridian config edit
+   ```
+   ```dotenv
+   JIRA_BASE_URL=https://your-org.atlassian.net
+   JIRA_EMAIL=you@your-org.com
+   JIRA_API_TOKEN=your-api-token
+   ```
+3. Restart: `meridian restart`.
+
+> GitHub and Linear are also supported (`GITHUB_TOKEN`/`GITHUB_ORG`, `LINEAR_API_KEY`/`LINEAR_TEAM_IDS`) — same file.
+
+**Worklog posting is OFF by default** — Meridian *drafts* worklogs but never writes to Jira until you opt in:
+```dotenv
+PM_WORKLOG_POST_ENABLED=true
+```
+Review the drafts first (`meridian worklog-status`), then enable when you're ready.
+
+---
+
+## 4. Verify it's running
+
+```bash
+meridian status          # all four services
+meridian doctor          # diagnose config / services / permissions
+meridian logs -f         # watch the pipeline live
+open http://localhost:3000
+```
+
+---
+
+## Where everything lives
+
+| | Path |
+|---|---|
+| App (prebuilt bundle) | `~/.meridian/app` |
+| Config | `~/.meridian/app/.env` (the one backend config) |
+| Database | `~/.meridian/meridian.db` (yours — plain SQLite) |
+| Logs | `~/.meridian/logs/` (per service: `daemon.log`, `mlx-server.log`, `screenpipe.log`, `ui.log`, plus `*-error.log`) |
+| Services (launchd) | `~/Library/LaunchAgents/com.meridiona.*.plist` |
+
+**Logs:** `meridian logs <target> [-f]` — targets: `daemon`, `daemon-error`, `mlx-server`, `mlx-server-error`, `screenpipe`, `ui`. The `-error` variants show only warnings/errors.
+
+---
+
+## Update / uninstall
+
+```bash
+meridian update      # fetch + install the latest release (keeps your .env)
+meridian uninstall   # stop services + remove the CLI (your data in ~/.meridian/ is kept)
+```
+
+---
+
+## Privacy
+
+Everything runs **on your machine**. screenpipe records your screen and audio locally into `~/.screenpipe/`; Meridian reads that and writes to `~/.meridian/meridian.db`. There is no telemetry by default and no outbound network — the **only** thing that ever leaves your Mac is a Jira worklog, and only after you set `PM_WORKLOG_POST_ENABLED=true`.
+
+---
+
+## Troubleshooting
+
+- **Dashboard not loading** — give it ~15 s after start; check `meridian logs ui-error -n 50`.
+- **No worklogs / classifications** — confirm the model is up: `meridian logs mlx-server -f` should show `MLX model ready`; `curl -s localhost:7823/health`.
+- **`meridian: command not found`** — ensure `~/.local/bin` is on your `PATH`.
+- **Gatekeeper blocks the binary** (unsigned builds) — `xattr -dr com.apple.quarantine ~/.meridian/app`, then `meridian restart`.
+- **Moved the install?** — the services point at `~/.meridian/app`; don't move it. Re-run the installer if you must relocate.
+
+---
+
+## Build from source (contributors)
+
+Developers working on Meridian itself clone and build instead:
+
+```bash
+git clone https://github.com/Meridiona/meridian
+cd meridian
+./install.sh          # builds the daemon + UI, sets up services
+bash scripts/setup-hooks.sh   # pre-commit/pre-push hooks
+```
+
+`./install.sh --no-mlx` uses the hermes LLM-selector backend instead of the MLX server.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# meridian — normalises screenpipe activity into structured app sessions
+#
+# One-command installer. Downloads the latest prebuilt macOS arm64 release,
+# unpacks it to ~/.meridian/app, and runs the bundle installer. No git clone,
+# no cargo/npm build.
+#
+#   curl -fsSL https://raw.githubusercontent.com/Meridiona/meridian/main/bootstrap.sh | bash
+#
+# Options (env):
+#   MERIDIAN_VERSION=v0.3.0   install a specific tag instead of latest
+#   MERIDIAN_SKIP_PERMISSIONS=1   skip the macOS permissions walkthrough
+set -euo pipefail
+
+REPO="Meridiona/meridian"
+APP="${HOME}/.meridian/app"
+
+err() { echo "✗ $*" >&2; exit 1; }
+
+[[ "$(uname -s)" == "Darwin" ]] || err "Meridian requires macOS."
+[[ "$(uname -m)" == "arm64" ]]  || err "Meridian requires Apple Silicon (arm64)."
+command -v curl >/dev/null 2>&1 || err "curl is required."
+
+# Resolve the release + the macOS-arm64 asset URL (unauthenticated GitHub API).
+if [[ -n "${MERIDIAN_VERSION:-}" ]]; then
+    api="https://api.github.com/repos/${REPO}/releases/tags/${MERIDIAN_VERSION}"
+else
+    api="https://api.github.com/repos/${REPO}/releases/latest"
+fi
+echo "→ Finding the latest Meridian release…"
+meta="$(curl -fsSL "${api}")" || err "could not reach the GitHub releases API for ${REPO}."
+asset_url="$(printf '%s' "${meta}" \
+    | grep -oE '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*macos-arm64\.tar\.gz"' \
+    | head -1 | sed -E 's/.*"(https[^"]+)"/\1/')"
+[[ -n "${asset_url}" ]] || err "no macOS-arm64 release asset found. Has a release been published yet?"
+tag="$(printf '%s' "${meta}" | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*"([^"]+)"$/\1/')"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+echo "→ Downloading ${tag:-release} …"
+curl -fSL "${asset_url}" -o "${tmp}/meridian.tar.gz" || err "download failed."
+tar xzf "${tmp}/meridian.tar.gz" -C "${tmp}" || err "could not unpack the release tarball."
+src="$(find "${tmp}" -maxdepth 1 -type d -name 'meridian-*-macos-arm64' | head -1)"
+[[ -n "${src}" ]] || err "unexpected tarball layout."
+
+echo "→ Installing to ${APP} …"
+mkdir -p "$(dirname "${APP}")"
+# Preserve the user's .env across re-installs.
+[[ -f "${APP}/.env" ]] && cp "${APP}/.env" "${tmp}/.env.keep"
+rm -rf "${APP}"
+mv "${src}" "${APP}"
+[[ -f "${tmp}/.env.keep" ]] && cp "${tmp}/.env.keep" "${APP}/.env"
+
+args=()
+[[ "${MERIDIAN_SKIP_PERMISSIONS:-0}" == "1" ]] && args+=(--skip-permissions)
+exec bash "${APP}/scripts/install-from-bundle.sh" "${args[@]}"

--- a/packages/meridian-mcp/package.json
+++ b/packages/meridian-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meridian-mcp",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "MCP server for Meridian — query app sessions, focus time, and activity data",
   "main": "dist/index.js",
   "bin": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,9 +1,16 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
+  "include-v-in-tag": true,
   "packages": {
     ".": {
       "release-type": "rust",
       "package-name": "meridian",
+      "extra-files": [
+        { "type": "json", "path": "ui/package.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "packages/meridian-mcp/package.json", "jsonpath": "$.version" },
+        { "type": "toml", "path": "services/pyproject.toml", "jsonpath": "$.project.version" }
+      ],
       "changelog-sections": [
         { "type": "feat",     "section": "Features" },
         { "type": "fix",      "section": "Bug Fixes" },

--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# meridian — normalises screenpipe activity into structured app sessions
+#
+# Install a PREBUILT release bundle (no cargo/npm build). Run from inside an
+# unpacked bundle at ~/.meridian/app — bootstrap.sh downloads + unpacks the
+# release tarball and execs this. Installs prerequisites, the Python venv + MLX
+# deps, and registers the four launchd daemons pointing at this bundle.
+#
+#   bash ~/.meridian/app/scripts/install-from-bundle.sh [--skip-permissions]
+set -euo pipefail
+
+APP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCREENPIPE_VERSION="0.3.350"
+MLX_PORT="${MLX_PORT:-7823}"
+SKIP_PERMISSIONS=0
+[[ "${1:-}" == "--skip-permissions" ]] && SKIP_PERMISSIONS=1
+
+info() { echo "→ $*" >&2; }
+ok()   { echo "  ✓ $*" >&2; }
+warn() { echo "  ⚠ $*" >&2; }
+err()  { echo "✗ $*" >&2; }
+
+GUI_TARGET="gui/$(id -u)"
+LAUNCH_AGENTS="${HOME}/Library/LaunchAgents"
+
+# Register the dashboard as a launchd agent that runs the prebuilt Next.js
+# standalone server (`node ui/server.js`) — no `npm start`, no node_modules
+# install. Mirrors the EIO-safe bootout/bootstrap pattern of the other agents.
+install_ui_standalone() {
+    local label="com.meridiona.ui"
+    local plist="${LAUNCH_AGENTS}/${label}.plist"
+    local node_bin; node_bin="$(command -v node)"
+    mkdir -p "${HOME}/.meridian/logs" "${LAUNCH_AGENTS}"
+    cat > "${plist}" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>${label}</string>
+  <key>ProgramArguments</key>
+  <array><string>/bin/sh</string><string>-c</string>
+    <string>exec '${node_bin}' '${APP_ROOT}/ui/server.js'</string></array>
+  <key>WorkingDirectory</key><string>${APP_ROOT}/ui</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PORT</key><string>3000</string>
+    <key>HOSTNAME</key><string>127.0.0.1</string>
+    <key>MERIDIAN_DB</key><string>${HOME}/.meridian/meridian.db</string>
+  </dict>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>${HOME}/.meridian/logs/ui.log</string>
+  <key>StandardErrorPath</key><string>${HOME}/.meridian/logs/ui-error.log</string>
+  <key>ProcessType</key><string>Background</string>
+</dict></plist>
+PLIST
+    plutil -lint "${plist}" >/dev/null 2>&1 || { warn "ui plist failed lint"; return 1; }
+    launchctl bootout "${GUI_TARGET}/${label}" 2>/dev/null || true
+    local w=0
+    while launchctl print "${GUI_TARGET}/${label}" >/dev/null 2>&1; do
+        sleep 1; w=$((w+1)); [[ $w -ge 15 ]] && break
+    done
+    launchctl enable "${GUI_TARGET}/${label}" 2>/dev/null || true
+    launchctl bootstrap "${GUI_TARGET}" "${plist}"
+    launchctl kickstart -k "${GUI_TARGET}/${label}" 2>/dev/null || true
+}
+
+# ── 0. Platform gate ────────────────────────────────────────────────────────
+[[ "$(uname -s)" == "Darwin" ]]  || { err "Meridian requires macOS."; exit 1; }
+[[ "$(uname -m)" == "arm64" ]]   || { err "Meridian requires Apple Silicon (arm64). This bundle is macOS-arm64 only."; exit 1; }
+
+echo "→ Installing Meridian $(cat "${APP_ROOT}/VERSION" 2>/dev/null || echo '?') from ${APP_ROOT}"
+
+# ── 1. Prerequisites (no Rust/Node-build toolchain — artifacts are prebuilt) ──
+if ! command -v brew >/dev/null 2>&1; then
+    err "Homebrew required — install from https://brew.sh and re-run."; exit 1
+fi
+command -v node >/dev/null 2>&1 || { info "Installing Node.js…"; brew install node; }
+PYTHON_BIN=""
+for p in python3.11 python3; do command -v "$p" >/dev/null 2>&1 && { PYTHON_BIN="$(command -v "$p")"; break; }; done
+[[ -n "${PYTHON_BIN}" ]] || { info "Installing Python 3.11…"; brew install python@3.11; PYTHON_BIN="$(command -v python3.11)"; }
+ok "node + python ($(${PYTHON_BIN} --version 2>&1))"
+
+if ! command -v screenpipe >/dev/null 2>&1; then
+    info "Installing screenpipe ${SCREENPIPE_VERSION} via npm…"
+    npm install -g "screenpipe@${SCREENPIPE_VERSION}"
+fi
+ok "screenpipe"
+if ! command -v ffmpeg >/dev/null 2>&1; then info "Installing ffmpeg…"; brew install ffmpeg; fi
+ok "ffmpeg"
+
+# ── 2. Config: single repo-local .env ────────────────────────────────────────
+ENV_FILE="${APP_ROOT}/.env"
+if [[ ! -f "${ENV_FILE}" ]]; then
+    cp "${APP_ROOT}/.env.example" "${ENV_FILE}"
+    info "created ${ENV_FILE} from template — add your Jira creds later: meridian config edit"
+fi
+# MLX is the default backend.
+grep -q '^CLASSIFIER_BACKEND=' "${ENV_FILE}" || echo "CLASSIFIER_BACKEND=mlx" >> "${ENV_FILE}"
+grep -q '^MLX_SERVER_PORT='    "${ENV_FILE}" || echo "MLX_SERVER_PORT=${MLX_PORT}" >> "${ENV_FILE}"
+ok "config at ${ENV_FILE}"
+
+# ── 3. Binary + CLI symlinks ─────────────────────────────────────────────────
+mkdir -p "${HOME}/.local/bin"
+ln -sfn "${APP_ROOT}/bin/meridian"        "${HOME}/.local/bin/meridian-daemon"
+ln -sfn "${APP_ROOT}/scripts/meridian-cli.sh" "${HOME}/.local/bin/meridian"
+ok "meridian-daemon + meridian → ~/.local/bin"
+
+# ── 4. Python venv + MLX deps (the one install-time download) ────────────────
+info "Setting up Python venv + MLX inference deps (downloads ~ a few hundred MB)…"
+VENV="${APP_ROOT}/services/.venv"
+[[ -d "${VENV}" ]] || "${PYTHON_BIN}" -m venv "${VENV}"
+"${VENV}/bin/pip" install --quiet --upgrade pip
+"${VENV}/bin/pip" install --quiet -e "${APP_ROOT}/services[mlx]"
+ok "Python services ready"
+
+# ── 5. macOS permissions for screenpipe (manual — can't be automated) ────────
+if [[ "${SKIP_PERMISSIONS}" -eq 0 ]]; then
+    echo "→ screenpipe needs 3 macOS permissions: Screen Recording, Accessibility, Microphone."
+    read -r -p "  Press Enter to open Screen Recording settings… " _ || true
+    open "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture" 2>/dev/null || true
+    read -r -p "  Press Enter to open Accessibility settings… " _ || true
+    open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility" 2>/dev/null || true
+    read -r -p "  Press Enter once both are granted (Microphone is requested on first run)… " _ || true
+fi
+
+# ── 6. Daemons (reuse the hardened installers; UI runs the standalone server) ─
+info "Installing screenpipe launchd agent…"
+bash "${APP_ROOT}/scripts/install-screenpipe-daemon.sh" || warn "screenpipe agent install failed"
+
+info "Installing MLX inference server launchd agent…"
+bash "${APP_ROOT}/services/scripts/install-mlx-server-daemon.sh" --port "${MLX_PORT}" || warn "MLX agent install failed"
+
+# Wait for MLX to answer before starting the daemon (it hard-exits if MLX is down).
+info "Waiting for the MLX server to load the model…"
+_w=0
+until curl -sf "http://127.0.0.1:${MLX_PORT}/health" >/dev/null 2>&1; do
+    sleep 3; _w=$((_w+3)); [[ $_w -ge 300 ]] && { warn "MLX not ready after 300s — check: meridian logs mlx-server"; break; }
+done
+curl -sf "http://127.0.0.1:${MLX_PORT}/health" >/dev/null 2>&1 && ok "MLX server ready (${_w}s)"
+
+info "Installing Rust daemon launchd agent…"
+bash "${APP_ROOT}/scripts/install-daemon.sh" || warn "daemon agent install failed"
+
+info "Installing the dashboard (UI) launchd agent…"
+install_ui_standalone
+
+ok "all daemons installed"
+
+echo ""
+echo "✓ Meridian installed at ${APP_ROOT}"
+echo "  meridian status            # check the daemons"
+echo "  meridian logs -f           # watch the pipeline"
+echo "  meridian config edit       # add Jira creds"
+echo "  open http://localhost:3000 # the dashboard"
+echo ""
+echo "Jira worklog posting is OFF by default — set PM_WORKLOG_POST_ENABLED=true"
+echo "in ${ENV_FILE} when you're ready to write worklogs."

--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -44,6 +44,8 @@ Commands:
     -f               Follow (stream)
     -n N             Last N lines (default 100)
   doctor             Run environment health checks
+  worklog-status     Show today's PM worklogs (done/pending/drafted/posted + comments)
+                     [--day YYYY-MM-DD]
   config edit        Open the repo-root .env in $EDITOR
   permissions        Open macOS permission panes for screenpipe
   uninstall          Stop daemons and remove CLI symlinks
@@ -355,6 +357,17 @@ cmd_permissions() {
 CMD="${1:-}"
 shift || true
 
+# Subcommands implemented by the daemon binary itself (not the launchd manager).
+# Forward these straight through to `meridian-daemon <cmd> [args]`.
+cmd_daemon_passthrough() {
+    local bin=""
+    for p in /usr/local/bin/meridian-daemon "${HOME}/.local/bin/meridian-daemon"; do
+        [[ -x "$p" ]] && bin="$p" && break
+    done
+    [[ -n "$bin" ]] || { err "meridian-daemon binary not found — run ./install.sh"; exit 1; }
+    exec "$bin" "$@"
+}
+
 case "$CMD" in
     start)            cmd_start ;;
     stop)             cmd_stop ;;
@@ -365,6 +378,7 @@ case "$CMD" in
     config)           cmd_config "$@" ;;
     uninstall)        cmd_uninstall ;;
     permissions)      cmd_permissions ;;
+    worklog-status|pm-worklog) cmd_daemon_passthrough "$CMD" "$@" ;;
     --help|-h|help|"") cmd_help ;;
     *) err "unknown command: ${CMD}"; echo; cmd_help; exit 1 ;;
 esac

--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -47,6 +47,7 @@ Commands:
   worklog-status     Show today's PM worklogs (done/pending/drafted/posted + comments)
                      [--day YYYY-MM-DD]
   config edit        Open the repo-root .env in $EDITOR
+  update             Update to the latest release (bundle) or pull+rebuild (source)
   permissions        Open macOS permission panes for screenpipe
   uninstall          Stop daemons and remove CLI symlinks
   --help | -h        Show this help
@@ -353,6 +354,23 @@ cmd_permissions() {
     echo "    meridian restart"
 }
 
+# --- update ---
+# Bundle install: re-run the one-line bootstrap (downloads the latest release).
+# Source checkout: git pull + rebuild + restart.
+cmd_update() {
+    if [[ -d "${REPO_ROOT}/.git" ]]; then
+        info "source checkout — pulling + rebuilding"
+        git -C "${REPO_ROOT}" pull --ff-only
+        ( cd "${REPO_ROOT}" && cargo build --release )
+        ( cd "${REPO_ROOT}/ui" && npm ci && npm run build )
+        cmd_restart
+    else
+        info "fetching the latest release…"
+        curl -fsSL "https://raw.githubusercontent.com/Meridiona/meridian/main/bootstrap.sh" \
+            | MERIDIAN_SKIP_PERMISSIONS=1 bash
+    fi
+}
+
 # --- dispatch ---
 CMD="${1:-}"
 shift || true
@@ -376,6 +394,7 @@ case "$CMD" in
     logs)             cmd_logs "$@" ;;
     doctor)           cmd_doctor ;;
     config)           cmd_config "$@" ;;
+    update)           cmd_update ;;
     uninstall)        cmd_uninstall ;;
     permissions)      cmd_permissions ;;
     worklog-status|pm-worklog) cmd_daemon_passthrough "$CMD" "$@" ;;

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# meridian — normalises screenpipe activity into structured app sessions
+#
+# Assemble a prebuilt release bundle from an already-built repo, into a single
+# tarball the installer downloads and unpacks to ~/.meridian/app. Run by
+# release.yml on a macOS arm64 runner; also runnable locally to validate.
+#
+#   scripts/package-release.sh <version> [out_dir]
+#
+# Prerequisites (must already be built before calling):
+#   * target/release/meridian          (cargo build --release)
+#   * ui/.next/standalone              (npm run build, with output:'standalone')
+#
+# Produces: <out_dir>/meridian-<version>-macos-arm64.tar.gz
+set -euo pipefail
+
+VERSION="${1:?usage: package-release.sh <version> [out_dir]}"
+VERSION="${VERSION#v}"                       # tolerate a leading v
+OUT_DIR="${2:-dist}"
+ARCH="macos-arm64"
+NAME="meridian-${VERSION}-${ARCH}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+DAEMON_BIN="target/release/meridian"
+UI_STANDALONE="ui/.next/standalone"
+[[ -x "${DAEMON_BIN}" ]]    || { echo "✗ ${DAEMON_BIN} not found — run: cargo build --release" >&2; exit 1; }
+[[ -d "${UI_STANDALONE}" ]] || { echo "✗ ${UI_STANDALONE} not found — run: (cd ui && npm ci && npm run build)" >&2; exit 1; }
+
+STAGE="${OUT_DIR}/${NAME}"
+rm -rf "${STAGE}"
+mkdir -p "${STAGE}/bin" "${STAGE}/ui" "${STAGE}/scripts"
+
+echo "→ daemon binary"
+cp "${DAEMON_BIN}" "${STAGE}/bin/meridian"
+chmod +x "${STAGE}/bin/meridian"
+
+echo "→ UI (Next.js standalone)"
+# standalone/ holds server.js + traced node_modules (incl. the native
+# better-sqlite3 .node). static + public are copied in alongside, per Next docs.
+cp -R "${UI_STANDALONE}/." "${STAGE}/ui/"
+mkdir -p "${STAGE}/ui/.next"
+cp -R "ui/.next/static" "${STAGE}/ui/.next/static"
+[[ -d "ui/public" ]] && cp -R "ui/public" "${STAGE}/ui/public"
+
+echo "→ Python services (source — venv is created at install)"
+# Source only; the venv + MLX wheels are installed on the user's machine.
+mkdir -p "${STAGE}/services"
+tar cf - \
+  --exclude='.venv' --exclude='.venv*' --exclude='__pycache__' --exclude='*.pyc' \
+  --exclude='logs' --exclude='.hermes' --exclude='.pytest_cache' --exclude='tests/evals/results' \
+  -C services . | tar xf - -C "${STAGE}/services"
+
+echo "→ skills"
+[[ -d "services/skills" ]] || echo "  ⚠ services/skills not found (summariser/classifier prompts)"
+
+echo "→ scripts + plists + CLI"
+cp scripts/meridian-cli.sh "${STAGE}/scripts/"
+cp scripts/install-from-bundle.sh "${STAGE}/scripts/"
+cp scripts/install-daemon.sh scripts/uninstall-daemon.sh \
+   scripts/install-ui-daemon.sh scripts/uninstall-ui-daemon.sh \
+   scripts/install-screenpipe-daemon.sh scripts/uninstall-screenpipe-daemon.sh \
+   scripts/com.meridiona.daemon.plist scripts/com.meridiona.screenpipe.plist \
+   scripts/com.meridiona.ui.plist "${STAGE}/scripts/" 2>/dev/null || true
+
+echo "→ config template + version stamp"
+cp .env.example "${STAGE}/.env.example"
+printf '%s\n' "${VERSION}" > "${STAGE}/VERSION"
+
+echo "→ tarball"
+mkdir -p "${OUT_DIR}"
+tar czf "${OUT_DIR}/${NAME}.tar.gz" -C "${OUT_DIR}" "${NAME}"
+rm -rf "${STAGE}"
+
+echo "✓ ${OUT_DIR}/${NAME}.tar.gz"
+du -h "${OUT_DIR}/${NAME}.tar.gz" | awk '{print "  size:", $1}'

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -1,6 +1,10 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
+  // Emit a self-contained server bundle (`.next/standalone/`) so the dashboard
+  // ships prebuilt in the release tarball and runs with `node server.js` — no
+  // `npm ci` / native rebuild of better-sqlite3 on the user's machine.
+  output: 'standalone',
   serverExternalPackages: [
     'better-sqlite3',
     '@opentelemetry/sdk-node',


### PR DESCRIPTION
Ships Meridian via **npm**, like screenpipe — `npm install -g @meridiona/meridian && meridian setup` — with **semantic-release** driving versioning/changelog/publishing from conventional commits.

## Versioning — semantic-release (replaces release-please)
- `.releaserc.json`: commit-analyzer + release-notes + changelog + **exec** (build) + **npm** (publish main) + github + git (version-bump commit).
- `scripts/set-version.sh` syncs the version across Cargo.toml, pyproject.toml, ui/mcp package.json, and both npm packages in lockstep.
- Root `package.json` (private) holds the semantic-release toolchain.

## Distribution — npm, like screenpipe
- **`@meridiona/meridian`** — thin launcher; its bin resolves the per-arch package and delegates (start/stop/logs/…), or runs `setup`/`update`.
- **`@meridiona/meridian-darwin-arm64`** — prebuilt payload: daemon binary + Next.js standalone UI + Python source + scripts.
- `meridian setup` copies the bundle to `~/.meridian/app`, installs prereqs + the Python/MLX venv, and registers the four launchd daemons (UI via the standalone node server).

## Release pipeline (`release.yml`, macos-14 arm64)
On push to main: `npx semantic-release` → analyze commits → `set-version` + `cargo build --release` + UI standalone build + populate the arch package → publish **both** npm packages → GitHub release + tag + CHANGELOG → version-bump commit.

## Tested locally
- Both packages `npm pack` cleanly (arch payload ~58 MB: daemon + UI + services).
- **End-to-end shim test** (isolated install): `meridian --help` resolves the arch package + delegates; `meridian setup` reaches the installer + passes prereq checks.
- set-version idempotent; all shell/JSON/YAML lint clean; pre-push suite green.

## You must provide (external)
- **npm org `meridiona`** + an **NPM automation token** → repo secret `NPM_TOKEN`.
- A **`GH_TOKEN` PAT** (repo scope, able to push the version commit past branch protection).
- (Repo can stay private — npm distribution is independent of repo visibility.)

## Notes
- **First semantic-release version is `1.0.0`** by default. To start at 0.x, tag `v0.1.0` on main before the first run.
- **Unsigned v1** — SETUP.md documents the Gatekeeper bypass; Developer-ID signing is a fast-follow (screenpipe-style codesign+notarize).
- Supersedes the earlier release-please/curl-bootstrap commits on this same branch (squash-merge for a clean history).