### PR TITLE
fix(release): build on macOS 26 SDK, complete FFI stub, fetch tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,11 @@ name: Release
 # (@meridiona/meridian + @meridiona/meridian-darwin-arm64), creates the GitHub
 # release + tag + CHANGELOG, and commits the version bump back to main.
 #
-# Runs on macos-14 (arm64) because the prepare step compiles the Metal/MLX
-# daemon + the dashboard for that target.
+# Runs on macos-26 (arm64) because the prepare step compiles the Swift
+# Foundation Models bridge — which needs the macOS 26 SDK — plus the
+# Metal/MLX daemon and the dashboard. The bridge is weak-linked, so the
+# resulting binary still launches on older macOS (Foundation Models simply
+# reports unavailable there).
 
 on:
   push:
@@ -25,13 +28,14 @@ concurrency:
 
 jobs:
   release:
-    runs-on: macos-14
+    runs-on: macos-26
     env:
       SQLX_OFFLINE: "true"
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0          # full history — semantic-release needs tags + commits
+          fetch-depth: 0          # full history — semantic-release needs commits
+          fetch-tags: true        # explicitly fetch tags so the v0.0.0 baseline is seen
           persist-credentials: false
 
       - name: Install Rust 1.93.1

--- a/build.rs
+++ b/build.rs
@@ -119,6 +119,9 @@ void fm_free_string(char* p) { if(p) free(p); }
 int fm_generate_text(const char* i, const char* p, char** t, char** e) {
     if(e) *e=ms("Apple Intelligence not available"); if(t) *t=0; return -1;
 }
+int fm_generate_category_json(const char* i, const char* p, char** j, char** e) {
+    if(e) *e=ms("Apple Intelligence not available"); if(j) *j=0; return -1;
+}
 int fm_prewarm(void) { return -1; }
 "#,
     )


### PR DESCRIPTION
Fixes the two failures in the first release run ([run 26738377401](https://github.com/Meridiona/meridian/actions/runs/26738377401)).

## 1. Build failure (the blocker)
The `macos-14` runner has no macOS 26 SDK, so `build.rs` took the Foundation Models **stub** path — but the stub was missing `fm_generate_category_json` (added to the FFI after the stub was written). Linking failed:
```
Undefined symbols for architecture arm64: "_fm_generate_category_json"
```
- **Runner → `macos-26`** so the real Swift bridge compiles. It's weak-linked (`-weak_framework`), so the binary still launches on older macOS (Foundation Models just reports unavailable there). This also keeps the **default** `LLM_BACKEND=foundation` working in the shipped artifact.
- **Stub completed** with `fm_generate_category_json` so non-SDK builds link too.

## 2. Wrong version (1.0.0 instead of 0.1.0)
`checkout` didn't fetch the `v0.0.0` baseline tag, so semantic-release treated this as a first release (→1.0.0). Added `fetch-tags: true` → the baseline is seen → first release computes as **0.1.0**.

## After merge
Re-triggers `release.yml` on `macos-26` → builds the full bridge → publishes `@meridiona/meridian@0.1.0` + `@meridiona/meridian-darwin-arm64@0.1.0` → tag `v0.1.0` + GitHub release + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)