### PR TITLE
fix(release): publish arch package by path (./), not npm owner/repo shorthand

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,7 +7,7 @@
     ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
     ["@semantic-release/exec", {
       "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && cargo build --release && (cd ui && npm ci && npm run build) && bash scripts/package-release.sh ${nextRelease.version}",
-      "publishCmd": "npm publish npm/meridian-darwin-arm64 --access public"
+      "publishCmd": "npm publish ./npm/meridian-darwin-arm64 --access public"
     }],
     ["@semantic-release/npm", { "pkgRoot": "npm/meridian" }],
     ["@semantic-release/github", {}],


### PR DESCRIPTION
The first release got all the way to publishing and failed on the **arch package**:

```
npm publish npm/meridian-darwin-arm64 → git ls-remote ssh://git@github.com/npm/meridian-darwin-arm64.git
→ Permission denied (publickey)
```

npm parsed `npm/meridian-darwin-arm64` as a GitHub **`owner/repo` shorthand** and tried to SSH-clone it, instead of publishing the local folder. Fix: prefix with `./` → `npm publish ./npm/meridian-darwin-arm64`.

Everything else worked: macos-26 build ✓, version computed as **0.1.0** ✓, main-package prepare ✓. Only this hop was broken — nothing published to npm yet (both packages still 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)