### PR TITLE
ci(release): add workflow_dispatch for manual re-trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch: {}   # manual re-trigger (e.g. after fixing a secret) without a dummy commit
 
 permissions:
   contents: write       # tags, release, the version-bump commit


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to `release.yml` so the release can be re-run from the Actions tab (or `gh workflow run release.yml`) without pushing a dummy commit — needed now to re-trigger the release after the `NPM_TOKEN` swap, and useful for any future transient publish failure.

**Merge order (important):** only merge this **after** `NPM_TOKEN` is replaced with a Classic Automation token and the phantom `v1.0.0` tag is deleted. Merging it is what re-triggers the release → publishes **1.0.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)