### PR TITLE
feat(install): dashboard on port 3939 (overridable) + disable screenpipe audio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@
 # MLX_SERVER_HOST=127.0.0.1
 # MLX_SERVER_PORT=7823
 
+# Dashboard (Next.js UI) port. Defaults to 3939 (off the common 3000 to avoid
+# clashes with other dev servers). Change this and re-run `meridian setup` to
+# move the dashboard.
+# MERIDIAN_UI_PORT=3939
+
 # ---------------------------------------------------------------------------
 # Jira (all three required to enable the Jira connector)
 # ---------------------------------------------------------------------------

--- a/scripts/com.meridiona.screenpipe.plist
+++ b/scripts/com.meridiona.screenpipe.plist
@@ -23,7 +23,7 @@
     <array>
         <string>/bin/sh</string>
         <string>-c</string>
-        <string>exec {{SCREENPIPE_BIN}} record</string>
+        <string>exec {{SCREENPIPE_BIN}} record --disable-audio</string>
     </array>
 
     <key>EnvironmentVariables</key>

--- a/scripts/com.meridiona.ui.plist
+++ b/scripts/com.meridiona.ui.plist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     com.meridiona.ui — runs the Next.js dashboard (built by ./install.sh) as
-    a background launchd LaunchAgent. Serves on http://localhost:3000.
+    a background launchd LaunchAgent. Serves on http://localhost:3939.
 
     Install via scripts/install-ui-daemon.sh which copies this file into
     ~/Library/LaunchAgents/ with absolute paths substituted in, then
@@ -39,7 +39,7 @@
         <key>MERIDIAN_DB</key>
         <string>{{HOME}}/.meridian/meridian.db</string>
         <key>PORT</key>
-        <string>3000</string>
+        <string>3939</string>
         <key>NODE_ENV</key>
         <string>production</string>
     </dict>

--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 APP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCREENPIPE_VERSION="0.3.350"
 MLX_PORT="${MLX_PORT:-7823}"
+UI_PORT="${MERIDIAN_UI_PORT:-3939}"   # dashboard port; off the common 3000 to avoid clashes
 SKIP_PERMISSIONS=0
 [[ "${1:-}" == "--skip-permissions" ]] && SKIP_PERMISSIONS=1
 
@@ -42,7 +43,7 @@ install_ui_standalone() {
   <key>WorkingDirectory</key><string>${APP_ROOT}/ui</string>
   <key>EnvironmentVariables</key>
   <dict>
-    <key>PORT</key><string>3000</string>
+    <key>PORT</key><string>${UI_PORT}</string>
     <key>HOSTNAME</key><string>127.0.0.1</string>
     <key>MERIDIAN_DB</key><string>${HOME}/.meridian/meridian.db</string>
   </dict>
@@ -97,7 +98,13 @@ fi
 # MLX is the default backend.
 grep -q '^CLASSIFIER_BACKEND=' "${ENV_FILE}" || echo "CLASSIFIER_BACKEND=mlx" >> "${ENV_FILE}"
 grep -q '^MLX_SERVER_PORT='    "${ENV_FILE}" || echo "MLX_SERVER_PORT=${MLX_PORT}" >> "${ENV_FILE}"
-ok "config at ${ENV_FILE}"
+# Dashboard port — honour an existing .env value, otherwise record the default.
+if grep -q '^MERIDIAN_UI_PORT=' "${ENV_FILE}"; then
+    UI_PORT="$(grep '^MERIDIAN_UI_PORT=' "${ENV_FILE}" | tail -n1 | cut -d= -f2 | tr -d '[:space:]')"
+else
+    echo "MERIDIAN_UI_PORT=${UI_PORT}" >> "${ENV_FILE}"
+fi
+ok "config at ${ENV_FILE} (dashboard port ${UI_PORT})"
 
 # ── 3. Binary + CLI symlinks ─────────────────────────────────────────────────
 mkdir -p "${HOME}/.local/bin"
@@ -115,12 +122,13 @@ ok "Python services ready"
 
 # ── 5. macOS permissions for screenpipe (manual — can't be automated) ────────
 if [[ "${SKIP_PERMISSIONS}" -eq 0 ]]; then
-    echo "→ screenpipe needs 3 macOS permissions: Screen Recording, Accessibility, Microphone."
+    echo "→ screenpipe needs 2 macOS permissions: Screen Recording and Accessibility."
+    echo "  (Audio capture is disabled, so no Microphone permission is required.)"
     read -r -p "  Press Enter to open Screen Recording settings… " _ || true
     open "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture" 2>/dev/null || true
     read -r -p "  Press Enter to open Accessibility settings… " _ || true
     open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility" 2>/dev/null || true
-    read -r -p "  Press Enter once both are granted (Microphone is requested on first run)… " _ || true
+    read -r -p "  Press Enter once both are granted… " _ || true
 fi
 
 # ── 6. Daemons (reuse the hardened installers; UI runs the standalone server) ─
@@ -151,7 +159,7 @@ echo "✓ Meridian installed at ${APP_ROOT}"
 echo "  meridian status            # check the daemons"
 echo "  meridian logs -f           # watch the pipeline"
 echo "  meridian config edit       # add Jira creds"
-echo "  open http://localhost:3000 # the dashboard"
+echo "  open http://localhost:${UI_PORT} # the dashboard"
 echo ""
 echo "Jira worklog posting is OFF by default — set PM_WORKLOG_POST_ENABLED=true"
 echo "in ${ENV_FILE} when you're ready to write worklogs."

--- a/scripts/install-screenpipe-daemon.sh
+++ b/scripts/install-screenpipe-daemon.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # meridian — normalises screenpipe activity into structured app sessions
 # Install screenpipe as a launchd LaunchAgent under the current user.
-# screenpipe runs continuously, recording screen and audio on its default
-# port 3030 with data stored in ~/.screenpipe.
+# screenpipe runs continuously, recording the screen (audio disabled via
+# --disable-audio) on its default port 3030 with data stored in ~/.screenpipe.
 #
 #   ./scripts/install-screenpipe-daemon.sh
 #

--- a/scripts/install-ui-daemon.sh
+++ b/scripts/install-ui-daemon.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # meridian — normalises screenpipe activity into structured app sessions
 # Install the meridian Next.js dashboard as a launchd LaunchAgent under the
-# current user. Serves on http://localhost:3000. Built artifact must exist
+# current user. Serves on http://localhost:3939. Built artifact must exist
 # at ui/.next/ before this script runs (install.sh handles that).
 #
 #   ./scripts/install-ui-daemon.sh
@@ -79,7 +79,7 @@ launchctl kickstart -k "${GUI_TARGET}/${LABEL}"
 echo
 echo "✓ UI installed and started"
 echo
-echo "  open  http://localhost:3000                # the dashboard"
+echo "  open  http://localhost:3939                # the dashboard"
 echo "  tail -f ~/.meridian/logs/ui.log            # live stdout"
 echo "  tail -f ~/.meridian/logs/ui-error.log      # live stderr"
 echo "  ${SCRIPT_DIR}/uninstall-ui-daemon.sh       # remove"


### PR DESCRIPTION
## UI port
- Dashboard default **3000 → 3939** (off the common 3000 to avoid clashes), **overridable via `MERIDIAN_UI_PORT`** in `.env`.
- `install-from-bundle.sh` (npm path): honours an existing `.env` value, else records the default, and bakes it into the UI launchd plist `PORT`. Install summary + `.env.example` updated.
- Dev path (`com.meridiona.ui.plist`, `install-ui-daemon.sh`) moved to 3939 too.

## screenpipe audio
- Launch `screenpipe record **--disable-audio**` → no microphone capture, and the install walkthrough no longer asks for Microphone permission (only Screen Recording + Accessibility).

Ships in the next release (**1.1.0** — `feat:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)