### PR TITLE
fix(ui): stop double-counting coding-agent time in dashboard totals

### DIFF
--- a/ui/__tests__/intervals.test.ts
+++ b/ui/__tests__/intervals.test.ts
@@ -1,0 +1,85 @@
+// meridian — normalises screenpipe activity into structured app sessions
+import { describe, it, expect } from 'bun:test'
+import { unionSeconds, countSwitches } from '../lib/intervals'
+
+// ISO helper: minutes-past-midnight UTC → ISO string, keeps cases readable.
+const at = (min: number) => new Date(Date.UTC(2026, 0, 1, 0, min, 0)).toISOString()
+const iv = (startMin: number, endMin: number) => ({ started_at: at(startMin), ended_at: at(endMin) })
+
+// ---------------------------------------------------------------------------
+// unionSeconds — the anti-double-count core
+// ---------------------------------------------------------------------------
+
+describe('unionSeconds', () => {
+  it('returns 0 for no intervals', () => {
+    expect(unionSeconds([])).toBe(0)
+  })
+
+  it('returns the span of a single interval', () => {
+    expect(unionSeconds([iv(0, 10)])).toBe(600) // 10 min
+  })
+
+  it('sums two disjoint intervals', () => {
+    expect(unionSeconds([iv(0, 10), iv(20, 25)])).toBe(900) // 10 + 5 min
+  })
+
+  it('counts overlapping intervals once (the double-count bug)', () => {
+    // foreground 0–30, coding-agent overlay 10–40 → union is 0–40 = 40 min,
+    // NOT 30 + 30 = 60 min.
+    expect(unionSeconds([iv(0, 30), iv(10, 40)])).toBe(2400)
+  })
+
+  it('counts a fully nested interval once', () => {
+    expect(unionSeconds([iv(0, 60), iv(20, 30)])).toBe(3600)
+  })
+
+  it('merges touching intervals without gaps or overlap', () => {
+    expect(unionSeconds([iv(0, 10), iv(10, 20)])).toBe(1200)
+  })
+
+  it('is order-independent', () => {
+    expect(unionSeconds([iv(20, 40), iv(0, 30), iv(35, 50)])).toBe(unionSeconds([iv(0, 30), iv(20, 40), iv(35, 50)]))
+  })
+
+  it('discards corrupt intervals where end precedes start', () => {
+    // a segmentation bug (ended_at < started_at) must not subtract time.
+    expect(unionSeconds([iv(0, 10), { started_at: at(30), ended_at: at(5) }])).toBe(600)
+  })
+
+  it('discards zero-length and unparseable intervals', () => {
+    expect(unionSeconds([iv(5, 5), { started_at: 'nope', ended_at: 'nope' }, iv(0, 10)])).toBe(600)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// countSwitches — real context switches, not capture jitter
+// ---------------------------------------------------------------------------
+
+const s = (app: string, startMin: number, dur: number) => ({ app, started_at: at(startMin), dur })
+
+describe('countSwitches', () => {
+  it('returns 0 for an empty stream', () => {
+    expect(countSwitches([], 15)).toBe(0)
+  })
+
+  it('returns 0 for a single session', () => {
+    expect(countSwitches([s('Code', 0, 600)], 15)).toBe(0)
+  })
+
+  it('does not count consecutive sessions of the same app', () => {
+    expect(countSwitches([s('Code', 0, 600), s('Code', 10, 600)], 15)).toBe(2 - 2) // 0
+  })
+
+  it('counts each app change between consecutive sessions', () => {
+    expect(countSwitches([s('Code', 0, 600), s('Chrome', 10, 600), s('Code', 20, 600)], 15)).toBe(2)
+  })
+
+  it('ignores sub-floor flicker sessions (capture noise)', () => {
+    // 2s Chrome flicker between two Code sessions is jitter, not a switch.
+    expect(countSwitches([s('Code', 0, 600), s('Chrome', 10, 2), s('Code', 11, 600)], 15)).toBe(0)
+  })
+
+  it('orders by start time before counting', () => {
+    expect(countSwitches([s('Chrome', 20, 600), s('Code', 0, 600)], 15)).toBe(1)
+  })
+})

--- a/ui/app/api/coding-agents/route.ts
+++ b/ui/app/api/coding-agents/route.ts
@@ -3,6 +3,7 @@
 import { NextResponse } from 'next/server'
 import getDb from '@/lib/db'
 import { todayString } from '@/lib/date-utils'
+import { unionSeconds } from '@/lib/intervals'
 
 export const dynamic = 'force-dynamic'
 
@@ -18,28 +19,6 @@ export interface CodingAgentsResponse {
 }
 
 const CODING_AGENTS = ['Claude Code', 'Codex']
-
-/** Union of [start,end] wall intervals, in seconds — dedups parallel overlap. */
-function unionSeconds(rows: Array<{ started_at: string; ended_at: string }>): number {
-  const ivs = rows
-    .map(r => [new Date(r.started_at).getTime(), new Date(r.ended_at).getTime()] as [number, number])
-    .filter(([s, e]) => e > s)
-    .sort((a, b) => a[0] - b[0])
-  let total = 0
-  let curStart = -1
-  let curEnd = -1
-  for (const [s, e] of ivs) {
-    if (s > curEnd) {
-      if (curEnd > curStart) total += curEnd - curStart
-      curStart = s
-      curEnd = e
-    } else if (e > curEnd) {
-      curEnd = e
-    }
-  }
-  if (curEnd > curStart) total += curEnd - curStart
-  return Math.round(total / 1000)
-}
 
 export async function GET() {
   const date = todayString()

--- a/ui/app/api/today/route.ts
+++ b/ui/app/api/today/route.ts
@@ -3,8 +3,15 @@
 import { NextResponse } from 'next/server'
 import getDb from '@/lib/db'
 import { localDayBounds, todayString } from '@/lib/date-utils'
+import { unionSeconds, countSwitches } from '@/lib/intervals'
 
 export const dynamic = 'force-dynamic'
+
+/**
+ * Foreground sessions shorter than this are sub-second focus jitter from
+ * screenpipe, not real context switches — excluded from the switch count.
+ */
+const SWITCH_MIN_DURATION_S = 15
 
 interface TodaySession {
   id: number
@@ -47,9 +54,11 @@ export interface TodayResponse {
   sessions: TodaySession[]
   active: TodayActive | null
   gaps: TodayGap[]
-  focus_s: number
+  focus_s: number       // union of all activity (foreground ∪ coding-agent), overlap counted once
+  coding_s: number      // union of coding-agent overlay — a SUBSET of focus_s, not additive
   idle_s: number
-  session_count: number
+  session_count: number // foreground sessions only
+  switch_count: number  // genuine context switches in the foreground stream
 }
 
 export async function GET() {
@@ -68,7 +77,9 @@ export async function GET() {
         s.id,
         s.app_name,
         s.started_at,
+        s.ended_at,
         s.duration_s,
+        s.claude_session_uuid,
         s.category,
         s.confidence,
         s.category_method,
@@ -83,7 +94,16 @@ export async function GET() {
       WHERE s.started_at >= ? AND s.started_at < ?
       ORDER BY s.started_at ASC
     `
-    const rows = db.prepare(sql).all(start, end) as Array<Record<string, unknown>>
+    const allRows = db.prepare(sql).all(start, end) as Array<Record<string, unknown>>
+
+    // Two streams share app_sessions: the foreground screen-capture stream
+    // (claude_session_uuid IS NULL) and the coding-agent transcript overlay
+    // (claude_session_uuid IS NOT NULL). The overlay records the same wall-clock
+    // time from a second angle, so it must NOT appear as its own foreground
+    // session — it drives the unioned focus figure and the coding-agent tile,
+    // never the per-task buckets, timeline, or switch count.
+    const rows = allRows.filter(r => r.claude_session_uuid == null)
+    const codingRows = allRows.filter(r => r.claude_session_uuid != null)
 
     const sessions: TodaySession[] = rows.map(r => {
       const titles: Array<{ window_name?: string; title?: string; count: number }> =
@@ -153,8 +173,23 @@ export async function GET() {
       }))
     } catch { /* gaps table might not exist */ }
 
-    const focus_s = sessions.reduce((a, s) => a + s.dur, 0) + (active?.elapsed_s ?? 0)
+    // Focus = real wall-clock covered by ANY activity, overlap counted once.
+    // Summing durations double-counts every second where the coding-agent
+    // overlay runs concurrently with the foreground capture, so we union the
+    // raw intervals of both streams plus the live session instead.
+    const nowIso = new Date().toISOString()
+    const focus_s = unionSeconds([
+      ...allRows.map(r => ({ started_at: r.started_at as string, ended_at: r.ended_at as string })),
+      ...(active ? [{ started_at: active.started_at, ended_at: nowIso }] : []),
+    ])
+    const coding_s = unionSeconds(
+      codingRows.map(r => ({ started_at: r.started_at as string, ended_at: r.ended_at as string })),
+    )
     const idle_s = gaps.filter(g => g.kind === 'user_idle').reduce((a, g) => a + g.dur, 0)
+    const switch_count = countSwitches(
+      sessions.map(s => ({ app: s.app, started_at: s.started_at, dur: s.dur })),
+      SWITCH_MIN_DURATION_S,
+    )
 
     const resp: TodayResponse = {
       date,
@@ -162,8 +197,10 @@ export async function GET() {
       active,
       gaps,
       focus_s,
+      coding_s,
       idle_s,
       session_count: sessions.length + (active ? 1 : 0),
+      switch_count,
     }
 
     return NextResponse.json(resp)
@@ -171,7 +208,7 @@ export async function GET() {
     console.error('today api error:', e)
     return NextResponse.json({
       date, sessions: [], active: null, gaps: [],
-      focus_s: 0, idle_s: 0, session_count: 0,
-    })
+      focus_s: 0, coding_s: 0, idle_s: 0, session_count: 0, switch_count: 0,
+    } satisfies TodayResponse)
   }
 }

--- a/ui/app/api/week/route.ts
+++ b/ui/app/api/week/route.ts
@@ -39,10 +39,16 @@ export async function GET() {
       const mmdd = d.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' })
       const { start, end } = localDayRange(dateStr)
 
+      // Foreground stream only. The coding-agent transcript overlay
+      // (claude_session_uuid IS NOT NULL) records the same wall-clock time a
+      // second time, so including it would double-count each day's total and
+      // inflate the `coding` band. Foreground sessions never overlap each other,
+      // so SUM here already equals the day's true union.
       const rows = db.prepare(`
         SELECT category, SUM(duration_s) AS dur_s
         FROM app_sessions
         WHERE started_at >= ? AND started_at < ?
+          AND claude_session_uuid IS NULL
         GROUP BY category
       `).all(start, end) as Array<{ category: string; dur_s: number }>
 

--- a/ui/components/views/TodayView.tsx
+++ b/ui/components/views/TodayView.tsx
@@ -144,12 +144,16 @@ function ActiveSessionCard({ active, taskKey }: { active: NonNullable<TodayRespo
 }
 
 // ── Totals strip ─────────────────────────────────────────────────────────────
-function TotalsStrip({ focus_s, idle_s, coding_s, session_count }: { focus_s: number; idle_s: number; coding_s: number; session_count: number }) {
+function TotalsStrip({ focus_s, idle_s, coding_s, switch_count }: { focus_s: number; idle_s: number; coding_s: number; switch_count: number }) {
+  // Coding-agent time is a SUBSET of focus (the AI-assisted slice), never an
+  // additive total — surface it as a share of focus so the four tiles can't be
+  // read as summing to more wall-clock than actually elapsed.
+  const codingPct = focus_s > 0 ? Math.round((coding_s / focus_s) * 100) : 0
   const items = [
-    { k: 'Focus',        v: fmtDur(focus_s),                        note: 'active' },
-    { k: 'Idle',         v: fmtDur(idle_s),                         note: 'away from keyboard' },
-    { k: 'Coding agent', v: fmtDur(coding_s),                       note: 'Claude Code · Codex' },
-    { k: 'Switches',     v: String(Math.max(0, session_count - 1)), note: 'context switches' },
+    { k: 'Focus',        v: fmtDur(focus_s),       note: 'active' },
+    { k: 'Idle',         v: fmtDur(idle_s),        note: 'away from keyboard' },
+    { k: 'Coding agent', v: fmtDur(coding_s),      note: `${codingPct}% of focus · AI-assisted` },
+    { k: 'Switches',     v: String(switch_count),  note: 'context switches' },
   ]
   return (
     <div className="grid grid-cols-4 rule-t rule-b" style={{ borderColor: 'var(--rule)' }}>
@@ -322,18 +326,10 @@ function QueuePreviewRow({ session }: { session: { id: number | string; app: str
 // ── Today page ───────────────────────────────────────────────────────────────
 export default function TodayView({ onNavigate }: { onNavigate?: (v: string, key?: string) => void }) {
   const [data, setData] = useState<TodayResponse | null>(null)
-  const [codingS, setCodingS] = useState(0)
 
   useEffect(() => {
     fetch('/api/today').then(r => r.json()).then(setData).catch(() => {})
     const id = setInterval(() => fetch('/api/today').then(r => r.json()).then(setData).catch(() => {}), 30_000)
-    return () => clearInterval(id)
-  }, [])
-
-  useEffect(() => {
-    const load = () => fetch('/api/coding-agents').then(r => r.json()).then(d => setCodingS(d?.total_s ?? 0)).catch(() => {})
-    load()
-    const id = setInterval(load, 30_000)
     return () => clearInterval(id)
   }, [])
 
@@ -418,7 +414,7 @@ export default function TodayView({ onNavigate }: { onNavigate?: (v: string, key
 
       {data.active && <ActiveSessionCard active={data.active} taskKey={data.sessions.filter(s => s.task_key).at(-1)?.task_key} />}
 
-      <TotalsStrip focus_s={data.focus_s} idle_s={data.idle_s} coding_s={codingS} session_count={data.session_count} />
+      <TotalsStrip focus_s={data.focus_s} idle_s={data.idle_s} coding_s={data.coding_s} switch_count={data.switch_count} />
 
       {buckets.length > 0 && (
         <section>

--- a/ui/lib/intervals.ts
+++ b/ui/lib/intervals.ts
@@ -1,0 +1,63 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Wall-clock interval math shared across the dashboard. Meridian stores two
+// overlapping recordings of the same time in `app_sessions`: the screen-capture
+// stream (foreground app) and the coding-agent transcript stream (Claude Code /
+// Codex). SUMMING their durations double-counts every overlapping second, so any
+// "total time" figure must UNION intervals instead. These helpers are the single
+// source of that math — used by the Today and coding-agents routes.
+
+export interface Interval {
+  started_at: string
+  ended_at: string
+}
+
+/**
+ * Total wall-clock seconds covered by a set of intervals, with overlap counted
+ * once. Intervals where `ended_at <= started_at` (including corrupt rows whose
+ * end precedes their start) are discarded rather than contributing negative or
+ * zero time.
+ */
+export function unionSeconds(intervals: Interval[]): number {
+  const ivs = intervals
+    .map(r => [new Date(r.started_at).getTime(), new Date(r.ended_at).getTime()] as [number, number])
+    .filter(([s, e]) => Number.isFinite(s) && Number.isFinite(e) && e > s)
+    .sort((a, b) => a[0] - b[0])
+
+  let total = 0
+  let curStart = -1
+  let curEnd = -1
+  for (const [s, e] of ivs) {
+    if (s > curEnd) {
+      if (curEnd > curStart) total += curEnd - curStart
+      curStart = s
+      curEnd = e
+    } else if (e > curEnd) {
+      curEnd = e
+    }
+  }
+  if (curEnd > curStart) total += curEnd - curStart
+  return Math.round(total / 1000)
+}
+
+/**
+ * Count genuine context switches in a time-ordered foreground stream: the number
+ * of times the active app changes between consecutive sessions. Sessions shorter
+ * than `minDurationS` are dropped first, so the sub-second foreground flicker
+ * screenpipe emits (rapid Finder↔Chrome focus jitter) is not mistaken for the
+ * user actually switching contexts.
+ */
+export function countSwitches(
+  sessions: Array<{ app: string; started_at: string; dur: number }>,
+  minDurationS: number,
+): number {
+  const ordered = sessions
+    .filter(s => s.dur >= minDurationS)
+    .sort((a, b) => new Date(a.started_at).getTime() - new Date(b.started_at).getTime())
+
+  let switches = 0
+  for (let i = 1; i < ordered.length; i++) {
+    if (ordered[i].app !== ordered[i - 1].app) switches++
+  }
+  return switches
+}


### PR DESCRIPTION
## Problem

The Today dashboard's **Focus** tile was reporting roughly **double** the real
wall-clock time, because Meridian stores two overlapping recordings of the same
time in \`app_sessions\`:

| Stream | Rows | Source |
|---|---|---|
| Screen-capture (foreground) | \`claude_session_uuid IS NULL\` | screenpipe's foreground app |
| Coding-agent overlay | \`claude_session_uuid IS NOT NULL\` | Claude Code / Codex transcripts |

When you run a coding agent in your IDE, **both fire for the same minutes**.
\`focus_s\` was a naive \`SUM(duration_s)\`, so every concurrent second was counted
twice — and the "Coding agent" tile then showed that slice a *third* time as its
own additive number. **Switches** counted every row boundary, so sub-second
foreground flicker (rapid Finder↔Chrome focus jitter) inflated it into the
hundreds.

Verified against the live DB:

| | Old (sum) | New (union) |
|---|---|---|
| Focus (a full day) | **20h35m** | **10h36m** (6h03m, 57%, AI-assisted) |
| Focus (partial day) | 5h36m | 3h40m (80% AI-assisted) |
| Switches (full day) | 811 | 76 |

## Fix

Treat the coding-agent stream as an **overlay/subset of focus**, never additive
(the agreed product model), and compute time as a **union of intervals**, not a sum.

- **`lib/intervals.ts`** (new, tested): `unionSeconds()` counts overlap once and
  discards corrupt rows (`ended_at < started_at`); `countSwitches()` counts
  foreground app changes above a 15s floor.
- **`/api/today`**: `focus_s` = union of all activity; `coding_s` = unioned
  overlay (a subset); `switch_count` = foreground switches. The foreground stream
  alone drives `sessions` (buckets, timeline, Sessions/Tasks views) so per-task
  percentages stay consistent.
- **`/api/coding-agents`**: reuses the shared `unionSeconds()`.
- **`/api/week`**: counts the foreground stream only, so daily totals and the
  `coding` band aren't inflated by the overlay.
- **`TodayView`**: Coding-agent tile now reads "N% of focus · AI-assisted";
  Switches uses `switch_count`. Drops the redundant second fetch.

## Behaviour change worth noting

`/api/today`'s `sessions` array is now foreground-only, so the general Sessions
and Tasks views show the foreground stream. Coding-agent work remains surfaced
via its own tile / `/api/coding-agents` and the PM-worklog pipeline — this is the
intended "overlay, not a foreground session" model.

## Follow-up (separate, not in this PR)

A corrupt coding-agent segment row (`ended_at` before `started_at`) was observed,
pointing at a segmentation bug in `src/coding_agent_session_ingest/segment.rs`.
The union math now tolerates it, but it should be guarded at write time on its
own branch.

## Testing

- \`bun test\`: 95 pass (15 new for intervals).
- \`npm run build\`: clean.
- Numbers verified end-to-end against \`~/.meridian/meridian.db\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)