### PR TITLE
docs: dashboard on port 3939 + screenpipe audio disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ npm install -g @meridiona/meridian
 meridian setup
 ```
 
-No clone, no build. The package ships a prebuilt binary; `meridian setup` copies the app to `~/.meridian/app`, installs any missing prerequisites (Homebrew packages, Node, Python 3.11, screenpipe, ffmpeg), sets up the on-device model, and registers four auto-starting services — **screenpipe** (capture), the **daemon** (pipeline), the **MLX server** (on-device model), and the **dashboard** at http://localhost:3000.
+No clone, no build. The package ships a prebuilt binary; `meridian setup` copies the app to `~/.meridian/app`, installs any missing prerequisites (Homebrew packages, Node, Python 3.11, screenpipe, ffmpeg), sets up the on-device model, and registers four auto-starting services — **screenpipe** (capture), the **daemon** (pipeline), the **MLX server** (on-device model), and the **dashboard** at http://localhost:3939.
 
-`meridian setup` then walks you through screenpipe's three macOS permissions (Screen Recording, Accessibility, Microphone). Connect Jira afterwards (optional).
+`meridian setup` then walks you through screenpipe's two macOS permissions (Screen Recording, Accessibility — audio is disabled, so no Microphone). Connect Jira afterwards (optional).
 
 👉 **Full walkthrough — permissions, Jira, verifying, logs, updating, troubleshooting: [SETUP.md](SETUP.md).**
 
@@ -154,7 +154,7 @@ meridian logs screenpipe -f       # capture layer
 
 Targets: `daemon` · `daemon-error` · `mlx-server` · `mlx-server-error` · `ui` · `ui-error` · `screenpipe` · `screenpipe-error`. The Rust daemon also writes structured JSON to `~/.meridian/logs/meridian-rust.jsonl.<date>` for grepping.
 
-Once started, the dashboard is at **http://localhost:3000**. Stop with `meridian stop`. Remove everything with `meridian uninstall`.
+Once started, the dashboard is at **http://localhost:3939** (set `MERIDIAN_UI_PORT` in `~/.meridian/app/.env` to change it). Stop with `meridian stop`. Remove everything with `meridian uninstall`.
 
 On startup the daemon TCP-connects to the MLX server to verify it is reachable before entering the poll loop. If the server is not running it exits immediately with a clear error message. Stop the daemon with `Ctrl-C` or `SIGTERM`.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -17,10 +17,10 @@ meridian setup
 
 | Service | Role |
 |---|---|
-| **screenpipe** | captures screen + audio (the data source) |
+| **screenpipe** | captures the screen (the data source; audio disabled) |
 | **meridian daemon** | the pipeline — ETL, classification, coding-agent ingest, PM-worklog |
 | **MLX server** | the on-device model (classification + worklog synthesis) |
-| **dashboard** | the web UI at http://localhost:3000 |
+| **dashboard** | the web UI at http://localhost:3939 (override via `MERIDIAN_UI_PORT`) |
 
 > First setup downloads the ~6 GB model on first MLX start — give it a few minutes (`meridian logs mlx-server -f` shows progress).
 
@@ -30,11 +30,12 @@ Pin a specific version with `npm install -g @meridiona/meridian@0.3.0`.
 
 ## 2. Grant macOS permissions (required, manual)
 
-screenpipe needs three permissions macOS will only let **you** grant. The installer opens each pane; for each:
+screenpipe needs two permissions macOS will only let **you** grant. The installer opens each pane; for each:
 
 1. **Screen Recording** — System Settings → Privacy & Security → Screen Recording → click **+**, add the screenpipe binary, toggle ON.
 2. **Accessibility** — same, under Accessibility.
-3. **Microphone** — screenpipe appears here after it first tries the mic; toggle ON.
+
+(Audio capture is disabled, so no Microphone permission is needed.)
 
 After granting, run `meridian restart`.
 
@@ -72,7 +73,7 @@ Review the drafts first (`meridian worklog-status`), then enable when you're rea
 meridian status          # all four services
 meridian doctor          # diagnose config / services / permissions
 meridian logs -f         # watch the pipeline live
-open http://localhost:3000
+open http://localhost:3939
 ```
 
 ---
@@ -102,7 +103,7 @@ meridian uninstall   # stop services + remove the CLI (your data in ~/.meridian/
 
 ## Privacy
 
-Everything runs **on your machine**. screenpipe records your screen and audio locally into `~/.screenpipe/`; Meridian reads that and writes to `~/.meridian/meridian.db`. There is no telemetry by default and no outbound network — the **only** thing that ever leaves your Mac is a Jira worklog, and only after you set `PM_WORKLOG_POST_ENABLED=true`.
+Everything runs **on your machine**. screenpipe records your screen locally into `~/.screenpipe/` (audio capture is disabled); Meridian reads that and writes to `~/.meridian/meridian.db`. There is no telemetry by default and no outbound network — the **only** thing that ever leaves your Mac is a Jira worklog, and only after you set `PM_WORKLOG_POST_ENABLED=true`.
 
 ---
 


### PR DESCRIPTION
README + SETUP still referenced port **3000** and a **Microphone** permission. Brings the docs in line with what 1.1.0+ actually ships:
- dashboard → **http://localhost:3939** (+ `MERIDIAN_UI_PORT` override noted)
- **two** macOS permissions (Screen Recording, Accessibility) — audio disabled via `--disable-audio`, no mic prompt
- privacy/data-source prose no longer claims audio capture

Docs-only — no release triggered (the behavior already shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)