### PR TITLE
chore: purge localhost:3000 references; default dev server to 3939

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,8 @@
 # MLX_SERVER_HOST=127.0.0.1
 # MLX_SERVER_PORT=7823
 
-# Dashboard (Next.js UI) port. Defaults to 3939 (off the common 3000 to avoid
-# clashes with other dev servers). Change this and re-run `meridian setup` to
-# move the dashboard.
+# Dashboard (Next.js UI) port. Defaults to 3939. Change this and re-run
+# `meridian setup` to move the dashboard.
 # MERIDIAN_UI_PORT=3939
 
 # ---------------------------------------------------------------------------

--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 APP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCREENPIPE_VERSION="0.3.350"
 MLX_PORT="${MLX_PORT:-7823}"
-UI_PORT="${MERIDIAN_UI_PORT:-3939}"   # dashboard port; off the common 3000 to avoid clashes
+UI_PORT="${MERIDIAN_UI_PORT:-3939}"   # dashboard port (override via MERIDIAN_UI_PORT)
 SKIP_PERMISSIONS=0
 [[ "${1:-}" == "--skip-permissions" ]] && SKIP_PERMISSIONS=1
 

--- a/src/db/screenpipe.rs
+++ b/src/db/screenpipe.rs
@@ -151,8 +151,8 @@ pub async fn get_window_titles(
 ) -> Result<Vec<WindowTitleCount>> {
     let rows = if is_browser_app(app_name) {
         // Fetch raw URLs grouped by full URL, then aggregate by domain in Rust.
-        // SQLite has no URL-parsing functions, and we want localhost:3000/ and
-        // localhost:3000/sessions to count as one entry, not two.
+        // SQLite has no URL-parsing functions, and we want localhost:3939/ and
+        // localhost:3939/sessions to count as one entry, not two.
         let raw = sqlx::query_as::<_, (String, i64)>(
             "SELECT COALESCE(browser_url, window_name) as context, COUNT(*) as count
              FROM frames

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,9 +3,9 @@
   "version": "1.2.1",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack -p 3939",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 3939",
     "lint": "next lint",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
Removes the "off the common 3000" phrasing and lingering `localhost:3000` mentions now that the dashboard is on 3939:
- `.env.example` + `install-from-bundle.sh`: drop the justification, just state the 3939 default + `MERIDIAN_UI_PORT` override
- `ui/package.json`: `dev` + `start` bind `-p 3939` so local dev no longer comes up on 3000
- `screenpipe.rs`: URL-dedup comment example uses `localhost:3939`

**Not touched (by design):**
- `.claude/skills/meridian-ui/SKILL.md` — agent skill file; blocked from self-modification (still says 3000 on the dev-server line). Easy manual one-liner if wanted.
- `services/tests/evals/data/seeds/sessions_{a,b}_generic.json` — these are simulated screen-capture **test fixtures**; their `localhost:3000` represents a developer's own app under test (realistically the Next.js default), not the Meridian dashboard. Changing them would reduce test realism and require a goldens re-render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)