### PR TITLE
feat(pm-worklog): human-in-the-loop posting — draft-only driver + approved-poster (backend)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -99,13 +99,12 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    // `meridian pm-worklog [--day YYYY-MM-DD] [--dry-run]` — one-shot Stage 4:
-    // walk the day's hours and draft (or, when posting is enabled, post) one Jira
-    // worklog per task per ready hour. Opens via setup_db so migrations (incl. the
-    // pm_worklog tables) are applied even when run standalone.
+    // `meridian pm-worklog [--day YYYY-MM-DD]` — one-shot Stage 4: walk the day's
+    // hours and DRAFT one worklog per task per ready hour (never posts — posting
+    // is approval-gated). Opens via setup_db so migrations (incl. the pm_worklog
+    // tables) are applied even when run standalone.
     if std::env::args().nth(1).as_deref() == Some("pm-worklog") {
         let args: Vec<String> = std::env::args().collect();
-        let dry_run = args.iter().any(|a| a == "--dry-run");
         let day = args
             .iter()
             .position(|a| a == "--day")
@@ -113,10 +112,25 @@ async fn main() -> Result<()> {
         let cfg = Config::from_env();
         match setup_db(&cfg.meridian_db_uri()).await {
             Ok(pool) => {
-                meridian::pm_worklog::cli_run(&pool, day.as_deref(), dry_run).await;
+                meridian::pm_worklog::cli_run(&pool, day.as_deref()).await;
                 pool.close().await;
             }
             Err(e) => eprintln!("pm-worklog: open db: {e}"),
+        }
+        return Ok(());
+    }
+
+    // `meridian worklog-post-approved` — post every worklog the user approved in
+    // the dashboard to Jira now (the same sweep the daemon runs every ~60s). This
+    // is the only path that writes to real Jira.
+    if std::env::args().nth(1).as_deref() == Some("worklog-post-approved") {
+        let cfg = Config::from_env();
+        match setup_db(&cfg.meridian_db_uri()).await {
+            Ok(pool) => {
+                meridian::pm_worklog::cli_post_approved(&pool).await;
+                pool.close().await;
+            }
+            Err(e) => eprintln!("worklog-post-approved: open db: {e}"),
         }
         return Ok(());
     }
@@ -277,15 +291,26 @@ async fn main() -> Result<()> {
         });
     }
 
-    // 7d. PM-worklog driver (Stage 4): the hour-driven loop that writes one Jira
-    //     worklog per task per settled hour. Gated on the global LLM gate and on
-    //     PM_WORKLOG_POST_ENABLED (defaults to dry-run so it never posts to real
-    //     Jira unattended). Independent of the ETL tick.
+    // 7d. PM-worklog driver (Stage 4): the hour-driven loop that DRAFTS one Jira
+    //     worklog per task per settled hour. Never posts — drafted worklogs wait
+    //     for a human to approve them in the dashboard. Independent of the ETL tick.
     {
         let pool_pm = meridian.clone();
         let rx_pm = shutdown_rx.clone();
         tokio::spawn(async move {
             meridian::pm_worklog::run_loop(pool_pm, rx_pm).await;
+        });
+    }
+
+    // 7e. PM-worklog approved-poster: the ~60s sweep that posts worklogs the user
+    //     approved in the dashboard to Jira. This is the SOLE path to real Jira
+    //     (there is no unattended auto-post). Gated on the global LLM gate's
+    //     siblings only — posting itself is a plain HTTP call, not an LLM hop.
+    {
+        let pool_post = meridian.clone();
+        let rx_post = shutdown_rx.clone();
+        tokio::spawn(async move {
+            meridian::pm_worklog::run_post_loop(pool_post, rx_post).await;
         });
     }
 

--- a/src/migrations/030_pm_worklog_approval.sql
+++ b/src/migrations/030_pm_worklog_approval.sql
@@ -1,0 +1,18 @@
+-- meridian — normalises screenpipe activity into structured app sessions
+--
+-- pm-worklog UI approval flow. Worklogs are now never auto-posted: the daemon
+-- only ever DRAFTS them, and a human approves (and optionally edits) each one in
+-- the dashboard. The `state` column is free text, so the new 'approved' state
+-- needs no DDL — these columns just carry the approval/edit audit trail and the
+-- last post error so the UI can show why a post is stuck.
+--
+-- Flow:  drafted ──(UI edit)──▶ drafted ──(UI approve)──▶ approved
+--                                              │ daemon sweep
+--                                              ▼
+--                                           posted   (or stays 'approved' with
+--                                                     last_post_error on failure)
+
+ALTER TABLE pm_worklogs ADD COLUMN approved_at        TEXT;
+ALTER TABLE pm_worklogs ADD COLUMN edited_at          TEXT;
+ALTER TABLE pm_worklogs ADD COLUMN last_post_error    TEXT;
+ALTER TABLE pm_worklogs ADD COLUMN post_attempt_count INTEGER NOT NULL DEFAULT 0;

--- a/src/pm_worklog/config.rs
+++ b/src/pm_worklog/config.rs
@@ -29,12 +29,6 @@ pub struct PmWorklogConfig {
     /// Jira's hard minimum — worklogs below this many real seconds are not
     /// posted (Jira rejects < 60s).
     pub min_post_seconds: i64,
-
-    /// Master safety switch for the daemon driver. Default `false`: the driver
-    /// runs in dry-run (drafts worklog rows but never POSTs to real Jira) until
-    /// a human flips `PM_WORKLOG_POST_ENABLED=true`. The CLI `--dry-run` flag is
-    /// independent of this.
-    pub post_enabled: bool,
 }
 
 fn env_str(key: &str, default: &str) -> String {
@@ -59,9 +53,6 @@ impl PmWorklogConfig {
             min_coverage: env_parse("PM_WORKLOG_MIN_COVERAGE", 0.80),
             readiness_aging_minutes: env_parse("PM_WORKLOG_READINESS_AGING_MIN", 90),
             min_post_seconds: env_parse("PM_WORKLOG_MIN_POST_SECONDS", 60),
-            post_enabled: std::env::var("PM_WORKLOG_POST_ENABLED")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false),
         }
     }
 }

--- a/src/pm_worklog/db.rs
+++ b/src/pm_worklog/db.rs
@@ -25,6 +25,12 @@ pub async fn upsert_pm_worklog(
     let update = &grounded.update;
     let payload_json = serde_json::to_string(update).context("serialise JiraUpdate payload")?;
 
+    // The DO UPDATE guard is the safety net for the human-in-the-loop flow: once
+    // a row is `approved` or `posted`, a later driver re-run (backfill, aging
+    // retry, manual `meridian pm-worklog --day …`) MUST NOT overwrite the user's
+    // edit/approval back to a fresh draft. When the guard blocks the update the
+    // conflict becomes a no-op and `RETURNING` yields nothing, so we fall back to
+    // reading the existing id.
     let row = sqlx::query(
         "INSERT INTO pm_worklogs (\
              task_key, day_utc, cycle_index, window_start, window_end, \
@@ -39,6 +45,7 @@ pub async fn upsert_pm_worklog(
              payload_json       = excluded.payload_json, \
              session_id_min     = excluded.session_id_min, \
              session_id_max     = excluded.session_id_max \
+         WHERE pm_worklogs.state NOT IN ('approved', 'posted') \
          RETURNING id",
     )
     .bind(&update.task_key)
@@ -53,11 +60,34 @@ pub async fn upsert_pm_worklog(
     .bind(&payload_json)
     .bind(session_id_min)
     .bind(session_id_max)
-    .fetch_one(pool)
+    .fetch_optional(pool)
     .await
     .context("upsert pm_worklogs row")?;
 
-    let pm_worklog_id: i64 = row.get("id");
+    let pm_worklog_id: i64 = match row {
+        Some(r) => r.get("id"),
+        None => {
+            // Guard blocked the update — the row is approved/posted and immutable.
+            // Return its id without touching it (and skip the evidence rewrite).
+            let existing = sqlx::query(
+                "SELECT id FROM pm_worklogs \
+                 WHERE task_key = ? AND day_utc = ? AND cycle_index = ?",
+            )
+            .bind(&update.task_key)
+            .bind(day_utc)
+            .bind(update.cycle_index)
+            .fetch_one(pool)
+            .await
+            .context("read existing approved/posted worklog id")?;
+            let id: i64 = existing.get("id");
+            tracing::debug!(
+                pm_worklog_id = id,
+                task_key = %update.task_key,
+                "worklog already approved/posted — draft re-run left it untouched"
+            );
+            return Ok(id);
+        }
+    };
 
     // Rewrite evidence rows for this worklog.
     sqlx::query("DELETE FROM pm_worklog_evidence WHERE pm_worklog_id = ?")
@@ -98,7 +128,7 @@ pub async fn mark_worklog_posted(
 ) -> Result<()> {
     sqlx::query(
         "UPDATE pm_worklogs \
-         SET state = 'posted', posted_worklog_id = ?, \
+         SET state = 'posted', posted_worklog_id = ?, last_post_error = NULL, \
              posted_at = COALESCE(posted_at, strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) \
          WHERE id = ?",
     )
@@ -142,4 +172,82 @@ pub async fn find_existing_worklog(
 /// Convenience: serialise the payload for logging/dry-run.
 pub fn payload_preview(update: &JiraUpdate) -> String {
     serde_json::to_string_pretty(update).unwrap_or_else(|_| "<unserialisable>".to_string())
+}
+
+/// One worklog the user has approved in the dashboard, ready to post to Jira.
+/// `comment` is the (possibly user-edited) summary lifted from `payload_json`.
+#[derive(Debug, Clone)]
+pub struct ApprovedWorklog {
+    pub id: i64,
+    pub task_key: String,
+    pub window_start: String,
+    pub window_end: String,
+    pub time_spent_seconds: i64,
+    pub comment: String,
+}
+
+/// All worklogs awaiting a post (`state = 'approved'`), oldest window first.
+/// The summary text is read straight from the stored payload so any UI edit is
+/// honoured. Rows with an empty summary are skipped — there is nothing to post.
+pub async fn fetch_approved_worklogs(pool: &SqlitePool) -> Result<Vec<ApprovedWorklog>> {
+    let rows = sqlx::query(
+        "SELECT id, task_key, window_start, window_end, time_spent_seconds, payload_json \
+         FROM pm_worklogs WHERE state = 'approved' ORDER BY window_start, task_key",
+    )
+    .fetch_all(pool)
+    .await
+    .context("fetch approved worklogs")?;
+
+    let mut out = Vec::with_capacity(rows.len());
+    for r in rows {
+        let payload: String = r.get("payload_json");
+        let comment = serde_json::from_str::<JiraUpdate>(&payload)
+            .map(|u| u.summary)
+            .unwrap_or_default();
+        out.push(ApprovedWorklog {
+            id: r.get("id"),
+            task_key: r.get("task_key"),
+            window_start: r.get("window_start"),
+            window_end: r.get("window_end"),
+            time_spent_seconds: r.try_get("time_spent_seconds").unwrap_or(0),
+            comment,
+        });
+    }
+    Ok(out)
+}
+
+/// Record a TRANSIENT failed post attempt (network/5xx): bump the counter and
+/// stash the error for the UI. The row stays `approved` so the next sweep retries.
+pub async fn mark_post_failed(pool: &SqlitePool, pm_worklog_id: i64, error: &str) -> Result<()> {
+    let truncated: String = error.chars().take(500).collect();
+    sqlx::query(
+        "UPDATE pm_worklogs \
+         SET post_attempt_count = post_attempt_count + 1, last_post_error = ? \
+         WHERE id = ?",
+    )
+    .bind(&truncated)
+    .bind(pm_worklog_id)
+    .execute(pool)
+    .await
+    .context("mark worklog post failed")?;
+    Ok(())
+}
+
+/// Record a TERMINAL post failure (empty comment, below Jira's minimum): flip the
+/// row to `failed` so the sweep stops retrying. The user can edit + re-approve or
+/// dismiss it in the dashboard.
+pub async fn fail_worklog(pool: &SqlitePool, pm_worklog_id: i64, error: &str) -> Result<()> {
+    let truncated: String = error.chars().take(500).collect();
+    sqlx::query(
+        "UPDATE pm_worklogs \
+         SET state = 'failed', last_post_error = ?, \
+             post_attempt_count = post_attempt_count + 1 \
+         WHERE id = ?",
+    )
+    .bind(&truncated)
+    .bind(pm_worklog_id)
+    .execute(pool)
+    .await
+    .context("mark worklog terminally failed")?;
+    Ok(())
 }

--- a/src/pm_worklog/mod.rs
+++ b/src/pm_worklog/mod.rs
@@ -6,10 +6,16 @@
 // through the global LLM gate). The hour-driven driver walks each day's hours,
 // processing every hour whose upstream stages have settled.
 //
-//   collect → synthesise (gated LLM) → ground → route (persist + post)
+//   collect → synthesise (gated LLM) → ground → DRAFT
 //
-// Spawned as a gated tokio task from `main.rs`; also runnable one-shot via
-// `meridian pm-worklog [--day YYYY-MM-DD] [--dry-run]`.
+// The driver NEVER posts. Every worklog lands as a `drafted` row for a human to
+// review, edit, and approve in the dashboard; approval flips it to `approved`,
+// and the `post` sweep (the only path to real Jira) posts it. This is the sole
+// post gate — there is no unattended auto-post.
+//
+// Spawned as two gated tokio tasks from `main.rs` (the hourly driver + the
+// ~60s approved-poster); also runnable one-shot via
+// `meridian pm-worklog [--day YYYY-MM-DD]` and `meridian worklog-post-approved`.
 
 pub mod collect;
 pub mod config;
@@ -18,11 +24,13 @@ pub mod ground;
 pub mod jira;
 pub mod ledger;
 pub mod models;
+pub mod post;
 pub mod route;
 pub mod scheduler;
 pub mod status;
 pub mod synth;
 
 pub use config::PmWorklogConfig;
+pub use post::{cli_post_approved, post_approved, run_post_loop};
 pub use scheduler::{cli_run, run_driver, run_loop, DriverSummary};
 pub use status::cli_status;

--- a/src/pm_worklog/models.rs
+++ b/src/pm_worklog/models.rs
@@ -140,10 +140,16 @@ pub struct GroundedNarrative {
     pub dropped_bullets: Vec<String>,
 }
 
-/// Lifecycle state of a worklog row (mirrors Python `UpdateState`).
+/// Lifecycle state of a worklog row.
+///
+///   drafted ──(UI edit)──▶ drafted ──(UI approve)──▶ approved ──(daemon)──▶ posted
+///
+/// `Approved` is set by the dashboard, never by the daemon: the driver only ever
+/// drafts, and the approved-sweep is the sole path that posts to Jira.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpdateState {
     Drafted,
+    Approved,
     Posted,
     Skipped,
     Failed,
@@ -153,6 +159,7 @@ impl UpdateState {
     pub fn as_str(self) -> &'static str {
         match self {
             UpdateState::Drafted => "drafted",
+            UpdateState::Approved => "approved",
             UpdateState::Posted => "posted",
             UpdateState::Skipped => "skipped",
             UpdateState::Failed => "failed",

--- a/src/pm_worklog/post.rs
+++ b/src/pm_worklog/post.rs
@@ -1,0 +1,191 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// The approved-worklog poster. This is the ONLY path that writes to real Jira.
+// The hour-driven driver (`scheduler.rs`) only ever DRAFTS; a human reviews,
+// optionally edits, and approves each worklog in the dashboard (which flips the
+// row to `approved`). This sweep then picks approved rows up and posts them via
+// `jira.rs`, on a fast cadence independent of the hourly driver so "approve in
+// the UI" feels close to immediate.
+//
+// Idempotent: a window already POSTED short-circuits (the `find_existing_worklog`
+// backstop), so a restart mid-sweep can never double-post. A post failure leaves
+// the row `approved` with `last_post_error` recorded, and the next sweep retries.
+
+use anyhow::Result;
+use sqlx::SqlitePool;
+use tokio::sync::watch;
+
+use crate::config::{Config, JiraConfig, PmProviderConfig};
+
+use super::config::PmWorklogConfig;
+use super::{db, jira};
+
+/// How often the approved-sweep runs. Short by design — this is the latency a
+/// user feels between clicking "Approve" in the dashboard and the worklog
+/// landing in Jira.
+const POST_SWEEP_INTERVAL_SECS: u64 = 60;
+
+/// Outcome of one approved-sweep pass.
+#[derive(Debug, Default, Clone)]
+pub struct PostSweepSummary {
+    pub approved_seen: u32,
+    pub posted: u32,
+    pub failed: u32,
+}
+
+/// Post every approved worklog. `jira` is `None` when no Jira provider is
+/// configured — then approved rows are left in place (nothing to post to) and a
+/// warning is logged once per pass.
+pub async fn post_approved(
+    pool: &SqlitePool,
+    jira: Option<&JiraConfig>,
+    cfg: &PmWorklogConfig,
+) -> Result<PostSweepSummary> {
+    let approved = db::fetch_approved_worklogs(pool).await?;
+    let mut summary = PostSweepSummary {
+        approved_seen: approved.len() as u32,
+        ..Default::default()
+    };
+    if approved.is_empty() {
+        return Ok(summary);
+    }
+
+    let Some(jira) = jira else {
+        tracing::warn!(
+            approved = approved.len(),
+            "approved worklogs waiting but no Jira provider configured — not posting"
+        );
+        return Ok(summary);
+    };
+
+    for w in approved {
+        match post_one(pool, jira, cfg, &w).await {
+            Ok(true) => summary.posted += 1,
+            Ok(false) => {} // ineligible/skipped — already recorded
+            Err(e) => {
+                summary.failed += 1;
+                tracing::warn!(
+                    pm_worklog_id = w.id, task = %w.task_key, error = %e,
+                    "approved worklog post failed — left approved for retry"
+                );
+                db::mark_post_failed(pool, w.id, &format!("{e:#}")).await?;
+            }
+        }
+    }
+    Ok(summary)
+}
+
+/// Post one approved worklog. Returns `Ok(true)` if it was posted, `Ok(false)` if
+/// it was skipped as ineligible (too short — recorded as a non-retryable error),
+/// or `Err` on a transient failure the caller should record for retry.
+async fn post_one(
+    pool: &SqlitePool,
+    jira: &JiraConfig,
+    cfg: &PmWorklogConfig,
+    w: &db::ApprovedWorklog,
+) -> Result<bool> {
+    if w.comment.trim().is_empty() {
+        // Nothing to post — the user approved an empty draft. Terminal: editing
+        // the worklog re-drafts it, so don't keep retrying.
+        db::fail_worklog(pool, w.id, "approved worklog has an empty comment").await?;
+        return Ok(false);
+    }
+    if w.time_spent_seconds < cfg.min_post_seconds {
+        // Below Jira's hard floor — terminal; nothing the sweep can do.
+        db::fail_worklog(
+            pool,
+            w.id,
+            &format!(
+                "time_spent={}s below Jira's {}s minimum",
+                w.time_spent_seconds, cfg.min_post_seconds
+            ),
+        )
+        .await?;
+        return Ok(false);
+    }
+
+    // Idempotency backstop: if this exact (task, window) was already posted,
+    // adopt that worklog id instead of posting again.
+    if let Some((_, worklog_id)) =
+        db::find_existing_worklog(pool, &w.task_key, &w.window_start, &w.window_end).await?
+    {
+        tracing::info!(
+            pm_worklog_id = w.id, task = %w.task_key, %worklog_id,
+            "window already posted — adopting existing worklog id"
+        );
+        db::mark_worklog_posted(pool, w.id, &worklog_id).await?;
+        return Ok(true);
+    }
+
+    let result = jira::post_worklog(
+        jira,
+        &w.task_key,
+        w.time_spent_seconds,
+        &w.window_start,
+        w.comment.trim(),
+    )
+    .await?;
+    db::mark_worklog_posted(pool, w.id, &result.worklog_id).await?;
+    tracing::info!(
+        pm_worklog_id = w.id, task = %w.task_key, worklog_id = %result.worklog_id,
+        time_spent = %result.time_spent_jira, "approved worklog posted to Jira"
+    );
+    Ok(true)
+}
+
+/// First Jira provider in the daemon config, if any.
+fn jira_from_config(config: &Config) -> Option<JiraConfig> {
+    config.pm_providers.iter().find_map(|p| match p {
+        PmProviderConfig::Jira(j) => Some(j.clone()),
+        _ => None,
+    })
+}
+
+/// Daemon task: post approved worklogs on a short cadence until shutdown.
+pub async fn run_post_loop(pool: SqlitePool, mut shutdown_rx: watch::Receiver<bool>) {
+    let cfg = PmWorklogConfig::from_env();
+    let interval = std::time::Duration::from_secs(POST_SWEEP_INTERVAL_SECS);
+    tracing::info!(
+        interval_s = interval.as_secs(),
+        "pm-worklog approved-poster starting (approval is the only post gate)"
+    );
+
+    loop {
+        let config = Config::from_env();
+        let jira = jira_from_config(&config);
+        match post_approved(&pool, jira.as_ref(), &cfg).await {
+            Ok(s) if s.posted > 0 || s.failed > 0 => tracing::info!(
+                approved = s.approved_seen,
+                posted = s.posted,
+                failed = s.failed,
+                "approved-poster pass complete"
+            ),
+            Ok(_) => {}
+            Err(e) => tracing::error!(error = %e, "approved-poster pass failed"),
+        }
+
+        tokio::select! {
+            _ = shutdown_rx.changed() => break,
+            _ = tokio::time::sleep(interval) => {}
+        }
+    }
+    tracing::info!("pm-worklog approved-poster stopped");
+}
+
+/// One-shot CLI: `meridian worklog-post-approved` — post every approved worklog
+/// now (the same sweep the daemon runs, for manual/testing use).
+pub async fn cli_post_approved(pool: &SqlitePool) {
+    let cfg = PmWorklogConfig::from_env();
+    let config = Config::from_env();
+    let jira = jira_from_config(&config);
+    match post_approved(pool, jira.as_ref(), &cfg).await {
+        Ok(s) => println!(
+            "worklog-post-approved: approved={} posted={} failed={} (jira={})",
+            s.approved_seen,
+            s.posted,
+            s.failed,
+            jira.is_some(),
+        ),
+        Err(e) => eprintln!("worklog-post-approved: sweep failed: {e:#}"),
+    }
+}

--- a/src/pm_worklog/route.rs
+++ b/src/pm_worklog/route.rs
@@ -1,20 +1,18 @@
 // meridian — normalises screenpipe activity into structured app sessions
 //
 // Route: process ONE (task, hour) — collect the bundle, synthesise (the single
-// LLM hop), ground it, persist the worklog row, and (unless dry-run) post it to
-// Jira. Idempotent: a window already posted short-circuits, and the row UPSERT
-// keyed on (task, day, cycle) means a re-run replaces a DRAFTED row but never a
-// POSTED one. Port of the Collect→Synth→Ground→Route spine in
-// `pm_worklog_update/workflow.py`, minus the LLM (which lives in the endpoint).
+// LLM hop), ground it, and persist a DRAFTED worklog row. This stage never posts
+// to Jira: every worklog waits in `drafted` for a human to review/edit/approve
+// in the dashboard, after which the `post` sweep is the sole path to real Jira.
+// Idempotent: the row UPSERT keyed on (task, day, cycle) replaces a still-DRAFTED
+// row on a re-run but leaves an `approved`/`posted` row untouched (see `db.rs`).
 
 use anyhow::Result;
 use sqlx::SqlitePool;
 
-use crate::config::JiraConfig;
-
 use super::config::PmWorklogConfig;
 use super::models::UpdateState;
-use super::{collect, db, ground, jira, synth};
+use super::{collect, db, ground, synth};
 
 /// One worklog covers exactly one hour, so time logged is capped here.
 const WINDOW_SECONDS: i64 = 3600;
@@ -26,23 +24,19 @@ pub struct TaskOutcome {
     pub state: UpdateState,
     pub reason: String,
     pub pm_worklog_id: Option<i64>,
-    pub posted_worklog_id: Option<String>,
 }
 
-/// Process one task's worklog for one hour window. `jira` is `None` when no Jira
-/// provider is configured (then we only ever DRAFT). `dry_run` persists the
-/// drafted row but never posts.
-#[allow(clippy::too_many_arguments)]
+/// Collect → synthesise → ground → draft one task's worklog for one hour window.
+/// A synth failure leaves nothing persisted — the next driver pass retries this
+/// hour/task. The drafted row is what the dashboard shows for approval.
 pub async fn process_task(
     pool: &SqlitePool,
-    jira: Option<&JiraConfig>,
     cfg: &PmWorklogConfig,
     task_key: &str,
     hour_start_iso: &str,
     hour_end_iso: &str,
     day_utc: &str,
     cycle_index: i64,
-    dry_run: bool,
 ) -> Result<TaskOutcome> {
     // 1. Collect.
     let bundle = collect::fetch_session_bundle(
@@ -61,12 +55,10 @@ pub async fn process_task(
             state: UpdateState::Skipped,
             reason: "no classified task sessions in window".to_string(),
             pm_worklog_id: None,
-            posted_worklog_id: None,
         });
     }
 
-    // 2. Synthesise (gated LLM hop). A synth failure leaves nothing persisted —
-    // the next driver pass retries this hour/task.
+    // 2. Synthesise (gated LLM hop).
     let mut update = synth::synthesise(&bundle, cfg).await?;
 
     // Authoritative scalars from the bundle — never trust the LLM for these.
@@ -76,15 +68,14 @@ pub async fn process_task(
     update.cycle_index = cycle_index;
     // time_spent = idle-discounted real_seconds, but capped at the window length:
     // overlapping coding-agent + screen sessions can sum past the hour, and you
-    // cannot log more than one real hour in a one-hour window (the Python
-    // time_spent_sanity_check, applied authoritatively here).
+    // cannot log more than one real hour in a one-hour window.
     update.time_spent_seconds = bundle.real_seconds.min(WINDOW_SECONDS);
 
     // 3. Ground.
     let grounded = ground::ground(update, &bundle, cfg.min_confidence);
 
-    // 4. Decide initial state.
-    let mut state = if grounded.update.summary.trim().is_empty() {
+    // 4. Decide state: an empty summary is unactionable, so skip; else draft.
+    let state = if grounded.update.summary.trim().is_empty() {
         UpdateState::Skipped
     } else {
         UpdateState::Drafted
@@ -94,95 +85,18 @@ pub async fn process_task(
     let pm_worklog_id =
         db::upsert_pm_worklog(pool, &grounded, state, day_utc, id_min, id_max).await?;
 
-    let mut reason = format!(
-        "drafted (conf={:.2}, coverage={:.2}, real_s={})",
-        grounded.update.confidence, grounded.coverage, bundle.real_seconds
-    );
-    let mut posted_worklog_id: Option<String> = None;
-
-    // 5. Post (unless dry-run / ineligible).
-    if dry_run {
-        reason = format!("{reason}; dry_run — not posted");
-    } else if let Some(skip) = post_ineligibility(state, &bundle, cfg) {
-        reason = format!("{reason}; post skipped: {skip}");
-    } else if let Some(jira_cfg) = jira {
-        match post_or_recover(pool, jira_cfg, &bundle, &grounded.update.summary).await {
-            Ok(wid) => {
-                db::mark_worklog_posted(pool, pm_worklog_id, &wid).await?;
-                state = UpdateState::Posted;
-                posted_worklog_id = Some(wid.clone());
-                reason = format!("worklog {wid} posted");
-            }
-            Err(e) => {
-                reason = format!("{reason}; jira post failed: {e}");
-                tracing::warn!(task_key, error = %e, "jira worklog post failed — left DRAFTED");
-            }
-        }
-    } else {
-        reason = format!("{reason}; no Jira provider configured");
-    }
+    let reason = match state {
+        UpdateState::Skipped => "skipped (empty summary after grounding)".to_string(),
+        _ => format!(
+            "drafted (conf={:.2}, coverage={:.2}, real_s={}) — awaiting UI approval",
+            grounded.update.confidence, grounded.coverage, bundle.real_seconds
+        ),
+    };
 
     Ok(TaskOutcome {
         task_key: task_key.to_string(),
         state,
         reason,
         pm_worklog_id: Some(pm_worklog_id),
-        posted_worklog_id,
     })
-}
-
-/// Return `Some(reason)` if this row must not post; `None` if eligible.
-/// Ticket-closed is intentionally NOT a gate (we keep logging time after done).
-fn post_ineligibility(
-    state: UpdateState,
-    bundle: &super::models::SessionBundle,
-    cfg: &PmWorklogConfig,
-) -> Option<String> {
-    if state == UpdateState::Skipped {
-        return Some("row marked SKIPPED".to_string());
-    }
-    if bundle.real_seconds < cfg.min_post_seconds {
-        return Some(format!(
-            "real_seconds={} below Jira's {}s minimum",
-            bundle.real_seconds, cfg.min_post_seconds
-        ));
-    }
-    None
-}
-
-/// Post a worklog, or recover the id if this window was already posted (the
-/// idempotency short-circuit that makes restarts/backfill safe).
-async fn post_or_recover(
-    pool: &SqlitePool,
-    jira: &JiraConfig,
-    bundle: &super::models::SessionBundle,
-    summary: &str,
-) -> Result<String> {
-    if let Some((prior_id, worklog_id)) = db::find_existing_worklog(
-        pool,
-        &bundle.task_key,
-        &bundle.window_start,
-        &bundle.window_end,
-    )
-    .await?
-    {
-        tracing::info!(
-            task_key = %bundle.task_key,
-            worklog_id = %worklog_id,
-            row = prior_id,
-            "worklog already posted for this window — skipping re-post"
-        );
-        return Ok(worklog_id);
-    }
-
-    let comment = summary.trim();
-    let result = jira::post_worklog(
-        jira,
-        &bundle.task_key,
-        bundle.real_seconds,
-        &bundle.window_start,
-        comment,
-    )
-    .await?;
-    Ok(result.worklog_id)
 }

--- a/src/pm_worklog/scheduler.rs
+++ b/src/pm_worklog/scheduler.rs
@@ -1,18 +1,21 @@
 // meridian — normalises screenpipe activity into structured app sessions
 //
 // The hour-driven driver. Walk hours from local-midnight → now; for each hour
-// that is READY, write one worklog per task that had classified work in it, then
+// that is READY, DRAFT one worklog per task that had classified work in it, then
 // mark the hour done. Hours are independent — a not-ready hour is left for the
 // next pass and does NOT block later hours, so a single stuck classification can
 // never freeze the day. The aging escape (config) bounds how long we wait for an
 // hour to settle before processing it best-effort.
+//
+// The driver NEVER posts to Jira. Drafted worklogs wait for a human to approve
+// them in the dashboard; the `post` sweep then posts approved rows. See `mod.rs`.
 
 use anyhow::Result;
 use chrono::{Duration, Local, NaiveDate, TimeZone, Utc};
 use sqlx::SqlitePool;
 use tokio::sync::watch;
 
-use crate::config::{Config, PmProviderConfig};
+use crate::config::Config;
 
 use super::config::PmWorklogConfig;
 use super::models::UpdateState;
@@ -30,19 +33,16 @@ pub struct DriverSummary {
     pub hours_processed: u32,
     pub hours_not_ready: u32,
     pub worklogs_drafted: u32,
-    pub worklogs_posted: u32,
     pub worklogs_skipped: u32,
 }
 
-/// Run one full pass over a day's hours. `day` defaults to today (local).
-/// `dry_run` drafts rows but never POSTs.
+/// Run one full pass over a day's hours, drafting worklogs. `day` defaults to
+/// today (local). Never posts — drafted rows await UI approval.
 pub async fn run_driver(
     pool: &SqlitePool,
-    jira: Option<&crate::config::JiraConfig>,
     cfg: &PmWorklogConfig,
     min_duration_s: i64,
     day: Option<NaiveDate>,
-    dry_run: bool,
 ) -> Result<DriverSummary> {
     let now = Local::now();
     let day = day.unwrap_or_else(|| now.date_naive());
@@ -93,37 +93,21 @@ pub async fn run_driver(
             continue;
         }
 
-        // READY — write one worklog per task with classified work this hour.
+        // READY — draft one worklog per task with classified work this hour.
         let tasks = ledger::tasks_in_hour(pool, &hs, &he).await?;
-        tracing::info!(
-            hour = %hs, tasks = tasks.len(), aged_out, dry_run,
-            "processing ready hour"
-        );
+        tracing::info!(hour = %hs, tasks = tasks.len(), aged_out, "processing ready hour");
 
         let mut hour_had_error = false;
         for task_key in &tasks {
-            match route::process_task(
-                pool,
-                jira,
-                cfg,
-                task_key,
-                &hs,
-                &he,
-                &day_utc,
-                cycle_index,
-                dry_run,
-            )
-            .await
-            {
+            match route::process_task(pool, cfg, task_key, &hs, &he, &day_utc, cycle_index).await {
                 Ok(outcome) => {
                     match outcome.state {
-                        UpdateState::Posted => summary.worklogs_posted += 1,
                         UpdateState::Drafted => summary.worklogs_drafted += 1,
-                        UpdateState::Skipped | UpdateState::Failed => summary.worklogs_skipped += 1,
+                        _ => summary.worklogs_skipped += 1,
                     }
                     tracing::info!(
                         task = %task_key, state = outcome.state.as_str(),
-                        reason = %outcome.reason, "worklog cycle done"
+                        reason = %outcome.reason, "worklog drafted"
                     );
                 }
                 Err(e) => {
@@ -150,52 +134,29 @@ pub async fn run_driver(
     Ok(summary)
 }
 
-/// First Jira provider in the daemon config, if any (worklogs only post to Jira).
-fn jira_from_config(config: &Config) -> Option<crate::config::JiraConfig> {
-    config.pm_providers.iter().find_map(|p| match p {
-        PmProviderConfig::Jira(j) => Some(j.clone()),
-        _ => None,
-    })
-}
-
-/// Daemon task: run the driver on the configured interval until shutdown.
-/// Posts only when `PM_WORKLOG_POST_ENABLED` is set — otherwise dry-run.
+/// Daemon task: run the driver on the configured interval until shutdown. Drafts
+/// only — posting is handled separately by the approved-poster (`post::run_post_loop`).
 pub async fn run_loop(pool: SqlitePool, mut shutdown_rx: watch::Receiver<bool>) {
     let cfg = PmWorklogConfig::from_env();
     let interval = std::time::Duration::from_secs((cfg.interval_hours * 3600.0).max(60.0) as u64);
     tracing::info!(
         interval_s = interval.as_secs(),
-        post_enabled = cfg.post_enabled,
-        "pm-worklog driver starting"
+        "pm-worklog driver starting (drafts only — posting is approval-gated)"
     );
 
     loop {
-        let config = Config::from_env();
-        let jira = jira_from_config(&config);
-        let dry_run = !cfg.post_enabled || jira.is_none();
-
         // Process yesterday AND today every pass. Yesterday's done hours skip
         // instantly via the ledger; this closes the day-rollover gap where the
         // previous day's last hours would otherwise strand at midnight.
         let today = Local::now().date_naive();
         let days: Vec<Option<NaiveDate>> = vec![today.pred_opt(), Some(today)];
-        let min_duration_s = config.min_classification_duration_s;
+        let min_duration_s = Config::from_env().min_classification_duration_s;
         for day in days.into_iter().flatten() {
-            match run_driver(
-                &pool,
-                jira.as_ref(),
-                &cfg,
-                min_duration_s,
-                Some(day),
-                dry_run,
-            )
-            .await
-            {
+            match run_driver(&pool, &cfg, min_duration_s, Some(day)).await {
                 Ok(s) => tracing::info!(
                     day = %day,
                     hours_processed = s.hours_processed,
                     drafted = s.worklogs_drafted,
-                    posted = s.worklogs_posted,
                     not_ready = s.hours_not_ready,
                     "pm-worklog driver pass complete"
                 ),
@@ -211,12 +172,11 @@ pub async fn run_loop(pool: SqlitePool, mut shutdown_rx: watch::Receiver<bool>) 
     tracing::info!("pm-worklog driver stopped");
 }
 
-/// One-shot CLI entry: `meridian pm-worklog [--day YYYY-MM-DD] [--dry-run]`.
-pub async fn cli_run(pool: &SqlitePool, day: Option<&str>, dry_run: bool) {
+/// One-shot CLI entry: `meridian pm-worklog [--day YYYY-MM-DD]`. Drafts worklogs;
+/// posting happens only via approval (`meridian worklog-post-approved` / the UI).
+pub async fn cli_run(pool: &SqlitePool, day: Option<&str>) {
     let cfg = PmWorklogConfig::from_env();
     let config = Config::from_env();
-    let jira = jira_from_config(&config);
-    let effective_dry = dry_run || !cfg.post_enabled || jira.is_none();
 
     let parsed_day = match day {
         Some(d) => match NaiveDate::parse_from_str(d, "%Y-%m-%d") {
@@ -230,29 +190,20 @@ pub async fn cli_run(pool: &SqlitePool, day: Option<&str>, dry_run: bool) {
     };
 
     println!(
-        "pm-worklog: day={} dry_run={} (post_enabled={}, jira={})",
+        "pm-worklog: day={} (drafts only — approve in the dashboard to post)",
         parsed_day
             .map(|d| d.to_string())
             .unwrap_or_else(|| "today".into()),
-        effective_dry,
-        cfg.post_enabled,
-        jira.is_some(),
     );
 
-    match run_driver(
-        pool,
-        jira.as_ref(),
-        &cfg,
-        config.min_classification_duration_s,
-        parsed_day,
-        effective_dry,
-    )
-    .await
-    {
+    match run_driver(pool, &cfg, config.min_classification_duration_s, parsed_day).await {
         Ok(s) => println!(
-            "pm-worklog: hours seen={} processed={} not_ready={} | worklogs drafted={} posted={} skipped={}",
-            s.hours_seen, s.hours_processed, s.hours_not_ready,
-            s.worklogs_drafted, s.worklogs_posted, s.worklogs_skipped,
+            "pm-worklog: hours seen={} processed={} not_ready={} | worklogs drafted={} skipped={}",
+            s.hours_seen,
+            s.hours_processed,
+            s.hours_not_ready,
+            s.worklogs_drafted,
+            s.worklogs_skipped,
         ),
         Err(e) => eprintln!("pm-worklog: driver failed: {e}"),
     }

--- a/src/pm_worklog/status.rs
+++ b/src/pm_worklog/status.rs
@@ -88,7 +88,8 @@ async fn print_status(pool: &SqlitePool, day_utc: &str) -> Result<()> {
     .await
     .context("read pm_worklogs")?;
 
-    let (mut drafted, mut posted, mut skipped, mut failed) = (0u32, 0u32, 0u32, 0u32);
+    let (mut drafted, mut approved, mut posted, mut skipped, mut failed) =
+        (0u32, 0u32, 0u32, 0u32, 0u32);
     let mut total_secs: i64 = 0;
     struct Line {
         hour: String,
@@ -104,6 +105,7 @@ async fn print_status(pool: &SqlitePool, day_utc: &str) -> Result<()> {
         let state: String = r.get("state");
         match state.as_str() {
             "posted" => posted += 1,
+            "approved" => approved += 1,
             "drafted" => drafted += 1,
             "skipped" => skipped += 1,
             "failed" => failed += 1,
@@ -128,11 +130,6 @@ async fn print_status(pool: &SqlitePool, day_utc: &str) -> Result<()> {
     }
 
     // ── Header ─────────────────────────────────────────────────────────────
-    let posting = if cfg.post_enabled {
-        "ON (posts to Jira)"
-    } else {
-        "OFF (dry-run — drafts only)"
-    };
     println!();
     println!("  PM Worklog Status — {day_utc} (times shown in local tz)");
     println!("  ─────────────────────────────────────────────────────────────");
@@ -143,10 +140,13 @@ async fn print_status(pool: &SqlitePool, day_utc: &str) -> Result<()> {
     };
     println!("  Hours:    {done} done · {pending} pending{stuck_note}");
     println!(
-        "  Worklogs: {drafted} drafted · {posted} posted · {skipped} skipped · {failed} failed   ({} total)",
+        "  Worklogs: {drafted} drafted · {approved} approved · {posted} posted · {skipped} skipped · {failed} failed   ({} total)",
         fmt_secs(total_secs)
     );
-    println!("  Posting:  {posting}");
+    println!("  Posting:  approval-gated — review & approve in the dashboard to post to Jira");
+    if approved > 0 {
+        println!("            ({approved} approved, awaiting the next post sweep ~60s)");
+    }
 
     if lines.is_empty() {
         println!();


### PR DESCRIPTION
## What

Stops the daemon from ever auto-posting worklogs to Jira. The hourly driver now **only drafts**; a separate ~60s sweep posts **only** the worklogs a human approved in the dashboard. Approval is the sole gate to real Jira — the old \`PM_WORKLOG_POST_ENABLED\` switch is removed.

```
drafted ──(UI approve)──▶ approved ──(post sweep ~60s)──▶ posted
                             │  terminal (empty / <60s)
                             └──▶ failed
```

## Changes (Rust only)
- **migration 030** — `approved` state + `approved_at`, `edited_at`, `last_post_error`, `post_attempt_count`.
- **`db.rs`** — draft UPSERT now guards `approved`/`posted` rows (a driver re-run/backfill can never clobber a human decision); `fetch_approved_worklogs` + `mark_post_failed` / `fail_worklog`.
- **`route.rs` / `scheduler.rs` / `config.rs`** — driver drafts only; auto-post path + `PM_WORKLOG_POST_ENABLED` deleted.
- **`post.rs` (new)** — the approved-poster sweep: posts approved rows via the existing `jira.rs`, idempotently. Transient errors retry; terminal ones go to `failed`.
- **`main.rs`** — spawns the sweep; adds `meridian worklog-post-approved`. `status.rs` reports the new `approved` count.

## Companion PRs
- **UI** (the Worklogs review/approve surface) — follow-up PR.
- **Docs** (approval-flow documentation) — follow-up PR.

The UI PR needs this merged + migration applied at runtime, but each PR builds independently.

## Tests
`cargo test` (incl. migration 030 via integration tests), `cargo clippy -D warnings`, full pre-push suite — all green.