### PR TITLE
feat(ui): Worklogs review view — approve worklogs before they post (UI)

### DIFF
--- a/ui/app/api/worklogs/[id]/route.ts
+++ b/ui/app/api/worklogs/[id]/route.ts
@@ -1,0 +1,120 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Worklog mutations — the human-in-the-loop write path. The UI never posts to
+// Jira itself; it only records intent in the DB and the daemon's approved-sweep
+// (~60s) posts. A POSTED worklog is immutable here.
+//
+//   PATCH /api/worklogs/:id   { summary }                  → edit the comment
+//   POST  /api/worklogs/:id    { action: approve|reject|unapprove }
+//
+//     approve   drafted/skipped → approved   (daemon will post it)
+//     reject    drafted/approved → skipped   (dismiss; won't post)
+//     unapprove approved → drafted           (pull back before the sweep)
+
+import { NextResponse } from 'next/server'
+import { getWriteDb } from '@/lib/db-write'
+
+export const dynamic = 'force-dynamic'
+
+type Ctx = { params: Promise<{ id: string }> }
+
+function nowIso(): string {
+  return new Date().toISOString().replace(/\.\d+Z$/, 'Z')
+}
+
+function parseId(raw: string): number | null {
+  const id = Number(raw)
+  return Number.isInteger(id) && id > 0 ? id : null
+}
+
+interface StateRow { state: string; payload_json: string }
+
+// ── Edit the Jira comment (the payload `summary`) ──────────────────────────
+export async function PATCH(req: Request, ctx: Ctx) {
+  const id = parseId((await ctx.params).id)
+  if (id == null) return NextResponse.json({ error: 'bad id' }, { status: 400 })
+
+  let body: { summary?: unknown }
+  try { body = await req.json() } catch { return NextResponse.json({ error: 'bad json' }, { status: 400 }) }
+  if (typeof body.summary !== 'string') {
+    return NextResponse.json({ error: 'summary must be a string' }, { status: 400 })
+  }
+  const summary = body.summary
+
+  try {
+    const db = getWriteDb()
+    const row = db.prepare('SELECT state, payload_json FROM pm_worklogs WHERE id = ?').get(id) as StateRow | undefined
+    if (!row) return NextResponse.json({ error: 'not found' }, { status: 404 })
+    if (row.state === 'posted') {
+      return NextResponse.json({ error: 'worklog already posted to Jira — cannot edit' }, { status: 409 })
+    }
+
+    let original = ''
+    try { original = (JSON.parse(row.payload_json)?.summary as string) ?? '' } catch { /* ignore */ }
+
+    // Editing an approved row pulls it back to drafted — content changed, so it
+    // must be re-approved before it posts.
+    const nextState = row.state === 'approved' ? 'drafted' : row.state
+
+    const tx = db.transaction(() => {
+      db.prepare(`
+        UPDATE pm_worklogs
+        SET payload_json = json_set(payload_json, '$.summary', ?),
+            state = ?, edited_at = ?, last_post_error = NULL
+        WHERE id = ?
+      `).run(summary, nextState, nowIso(), id)
+
+      db.prepare(`
+        INSERT INTO pm_worklog_feedback (pm_worklog_id, feedback_kind, original_text, edited_text)
+        VALUES (?, 'edit', ?, ?)
+      `).run(id, original, summary)
+    })
+    tx()
+
+    return NextResponse.json({ ok: true, id, state: nextState })
+  } catch (e) {
+    console.error('worklog edit error:', e)
+    return NextResponse.json({ error: 'edit failed' }, { status: 500 })
+  }
+}
+
+// ── State transitions (approve / reject / unapprove) ───────────────────────
+export async function POST(req: Request, ctx: Ctx) {
+  const id = parseId((await ctx.params).id)
+  if (id == null) return NextResponse.json({ error: 'bad id' }, { status: 400 })
+
+  let body: { action?: unknown }
+  try { body = await req.json() } catch { return NextResponse.json({ error: 'bad json' }, { status: 400 }) }
+  const action = body.action
+  if (action !== 'approve' && action !== 'reject' && action !== 'unapprove') {
+    return NextResponse.json({ error: 'action must be approve|reject|unapprove' }, { status: 400 })
+  }
+
+  try {
+    const db = getWriteDb()
+    const row = db.prepare('SELECT state FROM pm_worklogs WHERE id = ?').get(id) as { state: string } | undefined
+    if (!row) return NextResponse.json({ error: 'not found' }, { status: 404 })
+    if (row.state === 'posted') {
+      return NextResponse.json({ error: 'worklog already posted to Jira' }, { status: 409 })
+    }
+
+    let next: string
+    if (action === 'approve') {
+      next = 'approved'
+      db.prepare(`
+        UPDATE pm_worklogs SET state = 'approved', approved_at = ?, last_post_error = NULL WHERE id = ?
+      `).run(nowIso(), id)
+    } else if (action === 'reject') {
+      next = 'skipped'
+      db.prepare(`UPDATE pm_worklogs SET state = 'skipped' WHERE id = ?`).run(id)
+    } else {
+      next = 'drafted'
+      db.prepare(`UPDATE pm_worklogs SET state = 'drafted', approved_at = NULL WHERE id = ?`).run(id)
+    }
+
+    return NextResponse.json({ ok: true, id, state: next })
+  } catch (e) {
+    console.error('worklog action error:', e)
+    return NextResponse.json({ error: 'action failed' }, { status: 500 })
+  }
+}

--- a/ui/app/api/worklogs/route.ts
+++ b/ui/app/api/worklogs/route.ts
@@ -1,0 +1,130 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// GET /api/worklogs?day=YYYY-MM-DD — the day's drafted/approved/posted worklogs
+// for review. Returns the editable Jira comment (the payload `summary`), the
+// supporting bullets/next-steps for context, confidence, risk flags, and the
+// post status (incl. any last error). Read-only; mutations live in [id]/route.ts.
+
+import { NextResponse } from 'next/server'
+import getDb from '@/lib/db'
+import { todayString } from '@/lib/date-utils'
+
+export const dynamic = 'force-dynamic'
+
+export interface WorklogBullet {
+  kind: string
+  text: string
+}
+
+export interface WorklogItem {
+  id: number
+  task_key: string
+  window_start: string
+  state: string
+  confidence: number
+  coverage: number
+  time_spent_seconds: number
+  summary: string
+  bullets: WorklogBullet[]
+  next_steps: string[]
+  risk_flags: string[]
+  reasoning: string
+  posted_worklog_id: string | null
+  last_post_error: string | null
+  edited: boolean
+}
+
+export interface WorklogsResponse {
+  day: string
+  items: WorklogItem[]
+  counts: Record<string, number>
+}
+
+interface RawRow {
+  id: number
+  task_key: string
+  window_start: string
+  state: string
+  confidence: number
+  coverage: number
+  time_spent_seconds: number
+  payload_json: string
+  posted_worklog_id: string | null
+  last_post_error: string | null
+  edited_at: string | null
+}
+
+interface RawBullet { text?: string }
+interface RawPayload {
+  summary?: string
+  what_shipped?: RawBullet[]
+  in_progress?: RawBullet[]
+  blockers?: RawBullet[]
+  decisions?: RawBullet[]
+  next_steps?: string[]
+  risk_flags?: string[]
+  reasoning?: string
+}
+
+const BULLET_GROUPS: Array<[keyof RawPayload, string]> = [
+  ['what_shipped', 'shipped'],
+  ['in_progress', 'in progress'],
+  ['blockers', 'blocker'],
+  ['decisions', 'decision'],
+]
+
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const day = url.searchParams.get('day') || todayString()
+
+  try {
+    const db = getDb()
+    const rows = db.prepare(`
+      SELECT id, task_key, window_start, state, confidence, coverage,
+             time_spent_seconds, payload_json, posted_worklog_id,
+             last_post_error, edited_at
+      FROM pm_worklogs
+      WHERE day_utc = ?
+      ORDER BY window_start, task_key
+    `).all(day) as RawRow[]
+
+    const counts: Record<string, number> = {}
+    const items: WorklogItem[] = rows.map(r => {
+      counts[r.state] = (counts[r.state] ?? 0) + 1
+
+      let p: RawPayload = {}
+      try { p = JSON.parse(r.payload_json) as RawPayload } catch { /* leave empty */ }
+
+      const bullets: WorklogBullet[] = []
+      for (const [field, kind] of BULLET_GROUPS) {
+        const arr = (p[field] as RawBullet[] | undefined) ?? []
+        for (const b of arr) {
+          if (b?.text) bullets.push({ kind, text: b.text })
+        }
+      }
+
+      return {
+        id: r.id,
+        task_key: r.task_key,
+        window_start: r.window_start,
+        state: r.state,
+        confidence: r.confidence ?? 0,
+        coverage: r.coverage ?? 0,
+        time_spent_seconds: r.time_spent_seconds ?? 0,
+        summary: p.summary ?? '',
+        bullets,
+        next_steps: p.next_steps ?? [],
+        risk_flags: p.risk_flags ?? [],
+        reasoning: p.reasoning ?? '',
+        posted_worklog_id: r.posted_worklog_id,
+        last_post_error: r.last_post_error,
+        edited: r.edited_at != null,
+      }
+    })
+
+    return NextResponse.json({ day, items, counts } satisfies WorklogsResponse)
+  } catch (e) {
+    console.error('worklogs api error:', e)
+    return NextResponse.json({ day, items: [], counts: {} } satisfies WorklogsResponse)
+  }
+}

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -11,11 +11,12 @@ import TweaksPanel from '@/components/TweaksPanel'
 const TodayView    = dynamic(() => import('@/components/views/TodayView'),    { ssr: false })
 const TasksView    = dynamic(() => import('@/components/views/TasksView'),    { ssr: false })
 const QueueView    = dynamic(() => import('@/components/views/QueueView'),    { ssr: false })
+const WorklogsView = dynamic(() => import('@/components/views/WorklogsView'), { ssr: false })
 const SessionsView = dynamic(() => import('@/components/views/SessionsView'), { ssr: false })
 const WeekView     = dynamic(() => import('@/components/views/WeekView'),     { ssr: false })
 const SettingsView = dynamic(() => import('@/components/views/SettingsView'), { ssr: false })
 
-type View = 'today' | 'tasks' | 'queue' | 'sessions' | 'week' | 'settings'
+type View = 'today' | 'tasks' | 'queue' | 'worklogs' | 'sessions' | 'week' | 'settings'
 
 export default function DashboardPage() {
   const [view, setView] = useState<View>('today')
@@ -52,9 +53,10 @@ export default function DashboardPage() {
       if (e.key === '1') navigate('today')
       else if (e.key === '2') navigate('tasks')
       else if (e.key === '3') navigate('queue')
-      else if (e.key === '4') navigate('sessions')
-      else if (e.key === '5') navigate('week')
-      else if (e.key === '6') navigate('settings')
+      else if (e.key === '4') navigate('worklogs')
+      else if (e.key === '5') navigate('sessions')
+      else if (e.key === '6') navigate('week')
+      else if (e.key === '7') navigate('settings')
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
@@ -76,6 +78,7 @@ export default function DashboardPage() {
           {view === 'today'    && <TodayView    onNavigate={(v, k) => navigate(v as View, k)} />}
           {view === 'tasks'    && <TasksView    focusKey={focusKey} />}
           {view === 'queue'    && <QueueView    />}
+          {view === 'worklogs' && <WorklogsView />}
           {view === 'sessions' && <SessionsView />}
           {view === 'week'     && <WeekView     />}
           {view === 'settings' && <SettingsView />}
@@ -84,7 +87,7 @@ export default function DashboardPage() {
             style={{ borderTopColor: 'var(--rule)', color: 'var(--ink-4)' }}>
             <span>Meridian · local · {todayDate}</span>
             <span className="font-mono tnum">
-              <span className="kbd">⌘</span> <span className="kbd">K</span> to jump · <span className="kbd">1</span>–<span className="kbd">6</span> to switch view
+              <span className="kbd">⌘</span> <span className="kbd">K</span> to jump · <span className="kbd">1</span>–<span className="kbd">7</span> to switch view
             </span>
           </footer>
         </div>

--- a/ui/components/CommandBar.tsx
+++ b/ui/components/CommandBar.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { TaskKey, StatusPill } from '@/components/atoms'
 
-type View = 'today' | 'tasks' | 'queue' | 'sessions' | 'week'
+type View = 'today' | 'tasks' | 'queue' | 'worklogs' | 'sessions' | 'week'
 
 interface Props {
   onClose: () => void
@@ -29,6 +29,7 @@ export default function CommandBar({ onClose, onNavigate }: Props) {
     { kind: 'view', label: 'Go to Today',        v: 'today' },
     { kind: 'view', label: 'Go to Tasks',        v: 'tasks' },
     { kind: 'view', label: 'Go to Review queue', v: 'queue' },
+    { kind: 'view', label: 'Go to Worklogs',     v: 'worklogs' },
     { kind: 'view', label: 'Go to Sessions',     v: 'sessions' },
     { kind: 'view', label: 'Go to Week',         v: 'week' },
   ]

--- a/ui/components/Sidebar.tsx
+++ b/ui/components/Sidebar.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState } from 'react'
 import { fmtDurDecimal, AppGlyph, TaskKey, LiveDot, useTick } from '@/components/atoms'
 
-type View = 'today' | 'tasks' | 'queue' | 'sessions' | 'week' | 'settings'
+type View = 'today' | 'tasks' | 'queue' | 'worklogs' | 'sessions' | 'week' | 'settings'
 
 interface Props {
   view: View
@@ -58,8 +58,9 @@ export default function Sidebar({ view, onNavigate, onOpenCmd, queueCount }: Pro
     { id: 'today',    label: 'Today',    kbd: '1' },
     { id: 'tasks',    label: 'Tasks',    kbd: '2' },
     { id: 'queue',    label: 'Queue',    kbd: '3', badge: queueCount || undefined },
-    { id: 'sessions', label: 'Sessions', kbd: '4' },
-    { id: 'week',     label: 'Week',     kbd: '5' },
+    { id: 'worklogs', label: 'Worklogs', kbd: '4' },
+    { id: 'sessions', label: 'Sessions', kbd: '5' },
+    { id: 'week',     label: 'Week',     kbd: '6' },
   ]
 
   return (
@@ -118,7 +119,7 @@ export default function Sidebar({ view, onNavigate, onOpenCmd, queueCount }: Pro
             <path d="M8 1v1.5M8 13.5V15M1 8h1.5M13.5 8H15M3.05 3.05l1.06 1.06M11.89 11.89l1.06 1.06M3.05 12.95l1.06-1.06M11.89 4.11l1.06-1.06"/>
           </svg>
           <span className="text-[13px]">Settings</span>
-          <span className="kbd ml-auto">6</span>
+          <span className="kbd ml-auto">7</span>
         </button>
       </div>
 

--- a/ui/components/views/WorklogsView.tsx
+++ b/ui/components/views/WorklogsView.tsx
@@ -1,0 +1,283 @@
+// meridian — normalises screenpipe activity into structured app sessions
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { fmtDur, fmtClock, TaskKey, ConfidenceRing } from '@/components/atoms'
+import type { WorklogItem, WorklogsResponse } from '@/app/api/worklogs/route'
+
+// Local YYYY-MM-DD for `d` days from today (negative = past).
+function dayString(offsetDays = 0): string {
+  const d = new Date()
+  d.setDate(d.getDate() + offsetDays)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+const STATE_STYLE: Record<string, { label: string; color: string }> = {
+  drafted:  { label: 'Draft',    color: 'var(--ink-3)' },
+  approved: { label: 'Approved', color: 'var(--accent)' },
+  posted:   { label: 'Posted',   color: '#2F9E44' },
+  skipped:  { label: 'Dismissed', color: 'var(--ink-4)' },
+  failed:   { label: 'Failed',   color: '#E03131' },
+}
+
+export default function WorklogsView() {
+  const [day, setDay] = useState<string>(dayString(0))
+  const [items, setItems] = useState<WorklogItem[]>([])
+  const [counts, setCounts] = useState<Record<string, number>>({})
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState<number | null>(null)
+
+  const load = useCallback((d: string) => {
+    fetch(`/api/worklogs?day=${d}`)
+      .then(r => r.json())
+      .then((res: WorklogsResponse) => { setItems(res.items ?? []); setCounts(res.counts ?? {}); setLoading(false) })
+      .catch(() => setLoading(false))
+  }, [])
+
+  useEffect(() => {
+    setLoading(true)
+    load(day)
+    // Poll so approved → posted transitions (driven by the daemon sweep) show up.
+    const id = setInterval(() => load(day), 30_000)
+    return () => clearInterval(id)
+  }, [day, load])
+
+  async function mutate(id: number, fn: () => Promise<Response>) {
+    setBusy(id)
+    try {
+      const res = await fn()
+      if (!res.ok) {
+        const e = await res.json().catch(() => ({}))
+        alert(e.error ?? 'Action failed')
+      }
+    } finally {
+      setBusy(null)
+      load(day)
+    }
+  }
+
+  const act = (id: number, action: 'approve' | 'reject' | 'unapprove') =>
+    mutate(id, () => fetch(`/api/worklogs/${id}`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action }),
+    }))
+
+  const saveEdit = (id: number, summary: string) =>
+    mutate(id, () => fetch(`/api/worklogs/${id}`, {
+      method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ summary }),
+    }))
+
+  const draftedIds = items.filter(i => i.state === 'drafted' && i.summary.trim()).map(i => i.id)
+  async function approveAll() {
+    setBusy(-1)
+    try { await Promise.all(draftedIds.map(id => fetch(`/api/worklogs/${id}`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'approve' }),
+    }))) } finally { setBusy(null); load(day) }
+  }
+
+  const isToday = day === dayString(0)
+
+  return (
+    <div className="space-y-8">
+      <header className="rise flex items-end justify-between gap-4">
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.2em]" style={{ color: 'var(--ink-3)' }}>Worklog review</p>
+          <h1 className="font-serif text-[56px] leading-[1] tracking-tight mt-1" style={{ color: 'var(--ink)' }}>
+            Approve before it posts
+          </h1>
+          <p className="mt-3 text-[14px] max-w-prose" style={{ color: 'var(--ink-2)' }}>
+            Nothing reaches Jira until you approve it. Edit the comment if it&apos;s off, then approve —
+            the daemon posts approved worklogs within a minute.
+          </p>
+        </div>
+        <div className="text-right shrink-0">
+          <div className="flex items-center gap-1 justify-end">
+            <button onClick={() => setDay(d => shiftDay(d, -1))}
+              className="px-2 py-1 rounded-md text-[13px]" style={{ color: 'var(--ink-3)', border: '1px solid var(--rule-2)' }}>←</button>
+            <span className="font-mono tnum text-[12px] px-2" style={{ color: 'var(--ink-2)' }}>{isToday ? 'Today' : day}</span>
+            <button onClick={() => setDay(d => shiftDay(d, 1))} disabled={isToday}
+              className="px-2 py-1 rounded-md text-[13px]" style={{ color: isToday ? 'var(--ink-4)' : 'var(--ink-3)', border: '1px solid var(--rule-2)' }}>→</button>
+          </div>
+          <p className="text-[11px] mt-2" style={{ color: 'var(--ink-3)' }}>
+            {(counts.drafted ?? 0)} draft · {(counts.approved ?? 0)} approved · {(counts.posted ?? 0)} posted
+          </p>
+        </div>
+      </header>
+
+      {draftedIds.length > 0 && (
+        <div className="flex items-center gap-3">
+          <button onClick={approveAll} disabled={busy === -1}
+            className="px-3 py-1.5 rounded-md text-[12px] transition-colors"
+            style={{ background: 'var(--accent)', color: 'var(--paper)' }}>
+            {busy === -1 ? 'Approving…' : `Approve all ${draftedIds.length} drafts`}
+          </button>
+          <span className="text-[11px]" style={{ color: 'var(--ink-4)' }}>posts everything you haven&apos;t edited away</span>
+        </div>
+      )}
+
+      {loading ? (
+        <p className="text-[13px]" style={{ color: 'var(--ink-3)' }}>Loading…</p>
+      ) : items.length === 0 ? (
+        <div className="py-16 text-center rounded-xl border" style={{ borderColor: 'var(--rule)', background: 'var(--surface)' }}>
+          <p className="font-serif italic text-[24px]" style={{ color: 'var(--ink-2)' }}>No worklogs {isToday ? 'yet today' : 'this day'}.</p>
+          <p className="text-[12px] mt-2" style={{ color: 'var(--ink-3)' }}>
+            They appear here as the daemon drafts them, hour by hour.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {items.map(w => (
+            <WorklogCard key={w.id} w={w} busy={busy === w.id}
+              onApprove={() => act(w.id, 'approve')}
+              onReject={() => act(w.id, 'reject')}
+              onUnapprove={() => act(w.id, 'unapprove')}
+              onSave={(s) => saveEdit(w.id, s)} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function shiftDay(d: string, by: number): string {
+  const dt = new Date(`${d}T12:00:00`)
+  dt.setDate(dt.getDate() + by)
+  const today = new Date(); today.setHours(12, 0, 0, 0)
+  if (dt > today) return d // never go past today
+  const y = dt.getFullYear(); const m = String(dt.getMonth() + 1).padStart(2, '0'); const day = String(dt.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function WorklogCard({ w, busy, onApprove, onReject, onUnapprove, onSave }: {
+  w: WorklogItem
+  busy: boolean
+  onApprove: () => void
+  onReject: () => void
+  onUnapprove: () => void
+  onSave: (summary: string) => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(w.summary)
+  const [showEvidence, setShowEvidence] = useState(false)
+  const st = STATE_STYLE[w.state] ?? { label: w.state, color: 'var(--ink-3)' }
+  const posted = w.state === 'posted'
+
+  useEffect(() => { setDraft(w.summary) }, [w.summary])
+
+  return (
+    <div className="rounded-xl border overflow-hidden" style={{ borderColor: 'var(--rule)', background: 'var(--surface)' }}>
+      <div className="px-5 py-4">
+        {/* meta row */}
+        <div className="flex items-center gap-3">
+          <TaskKey keyId={w.task_key} />
+          <span className="font-mono tnum text-[11px]" style={{ color: 'var(--ink-3)' }}>{fmtClock(w.window_start)}</span>
+          <span className="text-[11px]" style={{ color: 'var(--ink-4)' }}>·</span>
+          <span className="font-mono tnum text-[11px]" style={{ color: 'var(--ink-3)' }}>{fmtDur(w.time_spent_seconds)}</span>
+          <ConfidenceRing value={w.confidence} />
+          {w.edited && <span className="text-[10px] uppercase tracking-[0.12em]" style={{ color: 'var(--ink-4)' }}>edited</span>}
+          <span className="ml-auto text-[10px] uppercase tracking-[0.14em] px-2 py-0.5 rounded"
+            style={{ color: st.color, border: `1px solid ${st.color}` }}>{st.label}</span>
+        </div>
+
+        {/* risk flags */}
+        {w.risk_flags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mt-2">
+            {w.risk_flags.map(f => (
+              <span key={f} className="text-[10px] px-1.5 py-0.5 rounded font-mono"
+                style={{ background: 'var(--tint)', color: '#B45309', border: '1px solid var(--rule-2)' }}>⚑ {f}</span>
+            ))}
+          </div>
+        )}
+
+        {/* comment — editable */}
+        <div className="mt-3">
+          {editing && !posted ? (
+            <div>
+              <textarea value={draft} onChange={e => setDraft(e.target.value)} rows={4}
+                className="w-full px-3 py-2 rounded-md text-[13px] leading-relaxed"
+                style={{ background: 'var(--surface-2)', border: '1px solid var(--rule-2)', color: 'var(--ink)', outline: 'none', resize: 'vertical' }} />
+              <div className="flex items-center gap-2 mt-2">
+                <button onClick={() => { onSave(draft); setEditing(false) }} disabled={busy}
+                  className="px-3 py-1 rounded-md text-[12px]" style={{ background: 'var(--ink)', color: 'var(--paper)' }}>Save</button>
+                <button onClick={() => { setDraft(w.summary); setEditing(false) }}
+                  className="px-3 py-1 rounded-md text-[12px]" style={{ color: 'var(--ink-3)', border: '1px solid var(--rule-2)' }}>Cancel</button>
+                <span className="text-[10px]" style={{ color: 'var(--ink-4)' }}>saving re-drafts an approved worklog</span>
+              </div>
+            </div>
+          ) : (
+            <p className="text-[13px] leading-relaxed whitespace-pre-wrap" style={{ color: w.summary ? 'var(--ink)' : 'var(--ink-4)' }}>
+              {w.summary || '(empty — nothing to post; edit to add a comment)'}
+            </p>
+          )}
+        </div>
+
+        {/* post error */}
+        {w.last_post_error && (
+          <p className="text-[11px] mt-2 font-mono" style={{ color: '#E03131' }}>post error: {w.last_post_error}</p>
+        )}
+        {posted && w.posted_worklog_id && (
+          <p className="text-[11px] mt-2" style={{ color: '#2F9E44' }}>✓ posted to Jira · worklog {w.posted_worklog_id}</p>
+        )}
+
+        {/* evidence toggle */}
+        {(w.bullets.length > 0 || w.next_steps.length > 0) && (
+          <button onClick={() => setShowEvidence(v => !v)} className="text-[11px] mt-3" style={{ color: 'var(--ink-3)' }}>
+            {showEvidence ? '− hide' : '+ show'} supporting detail
+          </button>
+        )}
+        {showEvidence && (
+          <div className="mt-2 pl-3 border-l space-y-1" style={{ borderColor: 'var(--rule-2)' }}>
+            {w.bullets.map((b, i) => (
+              <p key={i} className="text-[12px]" style={{ color: 'var(--ink-2)' }}>
+                <span className="text-[10px] uppercase tracking-[0.1em] mr-1.5" style={{ color: 'var(--ink-4)' }}>{b.kind}</span>
+                {b.text}
+              </p>
+            ))}
+            {w.next_steps.length > 0 && (
+              <p className="text-[12px] pt-1" style={{ color: 'var(--ink-3)' }}>
+                <span className="text-[10px] uppercase tracking-[0.1em] mr-1.5" style={{ color: 'var(--ink-4)' }}>next</span>
+                {w.next_steps.join(' · ')}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* actions */}
+        {!posted && (
+          <div className="flex items-center gap-2 mt-4">
+            {w.state !== 'approved' ? (
+              <button onClick={onApprove} disabled={busy || !w.summary.trim()}
+                className="px-3 py-1.5 rounded-md text-[12px] transition-colors"
+                style={{ background: w.summary.trim() ? 'var(--accent)' : 'var(--rule-2)', color: 'var(--paper)' }}>
+                Approve → post
+              </button>
+            ) : (
+              <button onClick={onUnapprove} disabled={busy}
+                className="px-3 py-1.5 rounded-md text-[12px]"
+                style={{ color: 'var(--ink-2)', border: '1px solid var(--rule-2)' }}>
+                Hold (un-approve)
+              </button>
+            )}
+            {!editing && (
+              <button onClick={() => setEditing(true)} disabled={busy}
+                className="px-3 py-1.5 rounded-md text-[12px]" style={{ color: 'var(--ink-2)', border: '1px solid var(--rule-2)' }}>
+                Edit
+              </button>
+            )}
+            {w.state !== 'skipped' && (
+              <button onClick={onReject} disabled={busy}
+                className="px-3 py-1.5 rounded-md text-[12px] ml-auto" style={{ color: 'var(--ink-3)' }}>
+                Dismiss
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/ui/lib/db-write.ts
+++ b/ui/lib/db-write.ts
@@ -1,0 +1,41 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Writable meridian.db handle — used ONLY by the worklog approval mutations
+// (edit / approve / reject). Everything else reads through the read-only handle
+// in `db.ts`. The daemon also writes this DB (sqlx, WAL), so concurrent access
+// is expected: WAL serialises writers and `busy_timeout` rides out the daemon's
+// short write transactions. IMPORTANT: Node.js runtime only (API routes).
+
+import Database from 'better-sqlite3'
+import path from 'path'
+import os from 'os'
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __meridian_write_db__: Database.Database | undefined
+}
+
+function expandTilde(filePath: string): string {
+  if (filePath.startsWith('~/') || filePath === '~') {
+    return path.join(os.homedir(), filePath.slice(2))
+  }
+  return filePath
+}
+
+export function getWriteDb(): Database.Database {
+  if (globalThis.__meridian_write_db__) {
+    return globalThis.__meridian_write_db__
+  }
+
+  const rawPath = process.env.MERIDIAN_DB_PATH ?? '~/.meridian/meridian.db'
+  const db = new Database(expandTilde(rawPath), {
+    readonly: false,
+    fileMustExist: true,
+  })
+
+  db.pragma('journal_mode = WAL')
+  db.pragma('busy_timeout = 5000')
+
+  globalThis.__meridian_write_db__ = db
+  return db
+}


### PR DESCRIPTION
## What

The dashboard surface for the human-in-the-loop worklog flow. A new **Worklogs** view lets you review every drafted worklog, edit the Jira comment, and **approve** it — only then does the daemon post it (see companion backend PR).

The UI **never calls Jira itself** — it only records intent in the DB (`drafted → approved`/`skipped`, or edits the comment). The daemon's sweep does the posting.

## Changes (UI only)
- **`ui/lib/db-write.ts`** — a writable better-sqlite3 handle (the existing one is read-only).
- **`/api/worklogs`** — `GET ?day=` (list), `PATCH :id` (edit comment), `POST :id` (approve/reject/unapprove). Validates at the boundary; a POSTED worklog is immutable.
- **`WorklogsView`** — per-ticket cards grouped by day: confidence, risk flags, editable comment, supporting detail, Approve/Edit/Dismiss + "approve all drafts". Day stepper. Polls so `approved → posted` shows up live.
- Wired into the sidebar (slot 4), command bar, and keyboard shortcuts.

## Depends on
The backend PR (approval state + `post` sweep + migration 030). This PR builds independently, but the flow only works end-to-end once both are merged and migration 030 is applied.

## Tests
`npm run build`, `bun test` (80 pass), full pre-push suite — all green.