### PR TITLE
feat(ui): insight-first Today dashboard (presence + agent overlay, progressive disclosure)

### DIFF
--- a/ui/__tests__/intervals.test.ts
+++ b/ui/__tests__/intervals.test.ts
@@ -1,6 +1,6 @@
 // meridian — normalises screenpipe activity into structured app sessions
 import { describe, it, expect } from 'bun:test'
-import { unionSeconds, countSwitches } from '../lib/intervals'
+import { unionSeconds, countSwitches, mergeIntervals, intersectSeconds } from '../lib/intervals'
 
 // ISO helper: minutes-past-midnight UTC → ISO string, keeps cases readable.
 const at = (min: number) => new Date(Date.UTC(2026, 0, 1, 0, min, 0)).toISOString()
@@ -81,5 +81,69 @@ describe('countSwitches', () => {
 
   it('orders by start time before counting', () => {
     expect(countSwitches([s('Chrome', 20, 600), s('Code', 0, 600)], 15)).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// mergeIntervals — disjoint bands for the timeline
+// ---------------------------------------------------------------------------
+
+describe('mergeIntervals', () => {
+  it('returns an empty list for no intervals', () => {
+    expect(mergeIntervals([])).toEqual([])
+  })
+
+  it('leaves disjoint intervals untouched (count + span)', () => {
+    const m = mergeIntervals([iv(0, 10), iv(20, 25)])
+    expect(m.length).toBe(2)
+    expect(unionSeconds(m)).toBe(900)
+  })
+
+  it('collapses overlapping intervals into one band', () => {
+    const m = mergeIntervals([iv(0, 30), iv(10, 40)])
+    expect(m.length).toBe(1)
+    expect(unionSeconds(m)).toBe(2400)
+  })
+
+  it('merges touching intervals into one', () => {
+    expect(mergeIntervals([iv(0, 10), iv(10, 20)]).length).toBe(1)
+  })
+
+  it('drops corrupt intervals before merging', () => {
+    const m = mergeIntervals([iv(0, 10), { started_at: at(30), ended_at: at(5) }])
+    expect(m.length).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// intersectSeconds — agent ∩ active (supervised) vs outside (autonomous)
+// ---------------------------------------------------------------------------
+
+describe('intersectSeconds', () => {
+  it('returns 0 when sets do not overlap', () => {
+    expect(intersectSeconds([iv(0, 10)], [iv(20, 30)])).toBe(0)
+  })
+
+  it('returns the overlapping span of two intervals', () => {
+    // agent 10–40 over active 0–30 → supervised = 10–30 = 20 min
+    expect(intersectSeconds([iv(10, 40)], [iv(0, 30)])).toBe(1200)
+  })
+
+  it('is symmetric', () => {
+    expect(intersectSeconds([iv(10, 40)], [iv(0, 30)])).toBe(intersectSeconds([iv(0, 30)], [iv(10, 40)]))
+  })
+
+  it('sums overlap across multiple disjoint blocks', () => {
+    // active in two blocks 0–10 and 20–30; agent spans 5–25 → overlaps 5–10 (5m) + 20–25 (5m)
+    expect(intersectSeconds([iv(5, 25)], [iv(0, 10), iv(20, 30)])).toBe(600)
+  })
+
+  it('never exceeds either set (autonomous = agent − supervised ≥ 0)', () => {
+    const agent = [iv(0, 60)]
+    const active = [iv(10, 30), iv(40, 50)]
+    const supervised = intersectSeconds(agent, active)
+    const agentTotal = unionSeconds(agent)
+    expect(agentTotal - supervised).toBeGreaterThanOrEqual(0)
+    expect(supervised).toBe(1800) // 20m + 10m
   })
 })

--- a/ui/app/api/today/route.ts
+++ b/ui/app/api/today/route.ts
@@ -3,7 +3,7 @@
 import { NextResponse } from 'next/server'
 import getDb from '@/lib/db'
 import { localDayBounds, todayString } from '@/lib/date-utils'
-import { unionSeconds, countSwitches } from '@/lib/intervals'
+import { unionSeconds, intersectSeconds, mergeIntervals, countSwitches, type Interval } from '@/lib/intervals'
 
 export const dynamic = 'force-dynamic'
 
@@ -12,6 +12,12 @@ export const dynamic = 'force-dynamic'
  * screenpipe, not real context switches — excluded from the switch count.
  */
 const SWITCH_MIN_DURATION_S = 15
+
+/** ISO timestamp `secs` seconds after `iso` — caps an agent transcript span to
+ * its engaged `duration_s` so parked-open sessions don't masquerade as activity. */
+function addSeconds(iso: string, secs: number): string {
+  return new Date(new Date(iso).getTime() + Math.max(0, secs) * 1000).toISOString()
+}
 
 interface TodaySession {
   id: number
@@ -54,11 +60,19 @@ export interface TodayResponse {
   sessions: TodaySession[]
   active: TodayActive | null
   gaps: TodayGap[]
-  focus_s: number       // union of all activity (foreground ∪ coding-agent), overlap counted once
-  coding_s: number      // union of coding-agent overlay — a SUBSET of focus_s, not additive
-  idle_s: number
-  session_count: number // foreground sessions only
-  switch_count: number  // genuine context switches in the foreground stream
+  // ── Presence (mutually exclusive: you were either active or idle) ──────────
+  focus_s: number        // ACTIVE presence — union of foreground sessions you were engaged in
+  idle_s: number         // away from keyboard (user_idle gaps)
+  // ── Agent overlay (a layer ON TOP of presence, never additive to focus) ────
+  agent_s: number        // engaged coding-agent time (capped to duration_s, unioned)
+  supervised_s: number   // agent time that ran WHILE you were active (AI-assisted) — subset of focus_s
+  autonomous_s: number   // agent time that ran while you were away (agent_s − supervised_s)
+  // ── Timeline bands ─────────────────────────────────────────────────────────
+  presence_segments: Interval[] // merged active blocks (foreground), for the day timeline
+  agent_segments: Interval[]    // merged engaged-agent blocks, drawn as an overlay band
+  // ── Counts ───────────────────────────────────────────────────────────────
+  session_count: number  // foreground sessions only
+  switch_count: number   // genuine context switches in the foreground stream
 }
 
 export async function GET() {
@@ -173,18 +187,33 @@ export async function GET() {
       }))
     } catch { /* gaps table might not exist */ }
 
-    // Focus = real wall-clock covered by ANY activity, overlap counted once.
-    // Summing durations double-counts every second where the coding-agent
-    // overlay runs concurrently with the foreground capture, so we union the
-    // raw intervals of both streams plus the live session instead.
     const nowIso = new Date().toISOString()
-    const focus_s = unionSeconds([
-      ...allRows.map(r => ({ started_at: r.started_at as string, ended_at: r.ended_at as string })),
+
+    // ── Presence (the foreground stream — where you were demonstrably active) ──
+    // Foreground sessions never overlap each other, but merging is still the
+    // honest way to get contiguous timeline bands and the active total.
+    const presenceRaw: Interval[] = [
+      ...rows.map(r => ({ started_at: r.started_at as string, ended_at: r.ended_at as string })),
       ...(active ? [{ started_at: active.started_at, ended_at: nowIso }] : []),
-    ])
-    const coding_s = unionSeconds(
-      codingRows.map(r => ({ started_at: r.started_at as string, ended_at: r.ended_at as string })),
-    )
+    ]
+    const presence_segments = mergeIntervals(presenceRaw)
+    const focus_s = unionSeconds(presence_segments)
+
+    // ── Agent overlay (the coding-agent stream, an OVERLAY on top of presence) ─
+    // Cap each transcript to its engaged `duration_s` (anchored at its start) so
+    // a parked-open Claude window doesn't masquerade as activity. The capped
+    // intervals are then split against presence: time spent alongside you is
+    // "supervised" (AI-assisted, a subset of focus); time while you were away is
+    // "autonomous". Autonomous is NEVER added to focus — it's its own track.
+    const agentRaw: Interval[] = codingRows.map(r => ({
+      started_at: r.started_at as string,
+      ended_at: addSeconds(r.started_at as string, (r.duration_s as number) ?? 0),
+    }))
+    const agent_segments = mergeIntervals(agentRaw)
+    const agent_s = unionSeconds(agent_segments)
+    const supervised_s = intersectSeconds(agent_segments, presence_segments)
+    const autonomous_s = Math.max(0, agent_s - supervised_s)
+
     const idle_s = gaps.filter(g => g.kind === 'user_idle').reduce((a, g) => a + g.dur, 0)
     const switch_count = countSwitches(
       sessions.map(s => ({ app: s.app, started_at: s.started_at, dur: s.dur })),
@@ -197,8 +226,12 @@ export async function GET() {
       active,
       gaps,
       focus_s,
-      coding_s,
       idle_s,
+      agent_s,
+      supervised_s,
+      autonomous_s,
+      presence_segments,
+      agent_segments,
       session_count: sessions.length + (active ? 1 : 0),
       switch_count,
     }
@@ -208,7 +241,9 @@ export async function GET() {
     console.error('today api error:', e)
     return NextResponse.json({
       date, sessions: [], active: null, gaps: [],
-      focus_s: 0, coding_s: 0, idle_s: 0, session_count: 0, switch_count: 0,
+      focus_s: 0, idle_s: 0, agent_s: 0, supervised_s: 0, autonomous_s: 0,
+      presence_segments: [], agent_segments: [],
+      session_count: 0, switch_count: 0,
     } satisfies TodayResponse)
   }
 }

--- a/ui/components/DayTimeline.tsx
+++ b/ui/components/DayTimeline.tsx
@@ -1,237 +1,125 @@
-// meridian — AI activity intelligence by Meridiona
-
+// meridian — normalises screenpipe activity into structured app sessions
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
-import type { SessionRow, ActiveSessionRow, TimelineResponse, GapRow } from '@/lib/types'
-import { getCategoryMeta } from '@/lib/category-colors'
-import { formatDuration, formatTime } from '@/lib/format'
+import { useMemo, useState } from 'react'
+import { fmtDur } from '@/components/atoms'
+import type { TodayResponse } from '@/app/api/today/route'
 
-const HOUR_LABELS = [6, 9, 12, 15, 18, 21]
+// The hero visual of the Today view. Two aligned tracks tell the whole story at
+// a glance, with overlap shown rather than summed:
+//   • Presence — solid where you were active, faint where you were idle/away.
+//   • Agent    — a band beneath presence, solid where Claude/Codex was engaged.
+// Where the agent band sits under an IDLE stretch of the presence track, that is
+// autonomous work (agent running while you were away) — visible by alignment, no
+// number needed. Hover any block for its exact span.
 
-function toEpochS(iso: string): number {
-  const t = Math.floor(new Date(iso).getTime() / 1000)
-  return isFinite(t) ? t : 0
+type Band = { startMs: number; endMs: number; label: string; kind: 'active' | 'idle' | 'agent' }
+
+const COLOR = {
+  active: 'var(--ink)',
+  idle: 'var(--rule-2)',
+  agent: '#3B6FE0', // matches the `coding` category hue used across the app
 }
 
-interface Segment {
-  id: number
-  app_name: string
-  started_at: string
-  ended_at?: string
-  duration_s: number
-  window_titles: SessionRow['window_titles']
-  isActive: boolean
-  isGap: boolean
-  gapKind?: GapRow['kind']
-  category?: string
-}
+const ms = (iso: string) => new Date(iso).getTime()
 
-interface TooltipState {
-  segment: Segment
-  x: number
-  y: number
-}
+export default function DayTimeline({ data }: { data: TodayResponse }) {
+  const [hover, setHover] = useState<Band | null>(null)
 
-interface DayTimelineProps {
-  data: TimelineResponse
-  activeSession?: ActiveSessionRow | null
-}
+  const model = useMemo(() => {
+    const active: Band[] = data.presence_segments.map(s => ({
+      startMs: ms(s.started_at), endMs: ms(s.ended_at), kind: 'active' as const, label: 'Active',
+    }))
+    const idle: Band[] = data.gaps
+      .filter(g => g.kind === 'user_idle')
+      .map(g => ({ startMs: ms(g.started_at), endMs: ms(g.ended_at), kind: 'idle' as const, label: 'Idle' }))
+    const agent: Band[] = data.agent_segments.map(s => ({
+      startMs: ms(s.started_at), endMs: ms(s.ended_at), kind: 'agent' as const, label: 'Claude / Codex',
+    }))
 
-const GAP_COLORS: Record<GapRow['kind'], string> = {
-  user_idle: '#D4D1CB',
-  system_sleep: '#C8C6C1',
-}
+    const all = [...active, ...idle, ...agent].filter(b => Number.isFinite(b.startMs) && b.endMs > b.startMs)
+    if (all.length === 0) return null
 
-export default function DayTimeline({ data, activeSession }: DayTimelineProps) {
-  const { sessions, gaps, day_start_s, day_end_s } = data
-  const spanS = Math.max(day_end_s - day_start_s, 1)
-  const containerRef = useRef<HTMLDivElement>(null)
+    // Window: floor to the hour before the first event, ceil to the hour after
+    // the last — so bands never touch the edges and hour ticks line up.
+    const HOUR = 3_600_000
+    const lo = Math.floor(Math.min(...all.map(b => b.startMs)) / HOUR) * HOUR
+    const hi = Math.ceil(Math.max(...all.map(b => b.endMs)) / HOUR) * HOUR
+    const span = Math.max(HOUR, hi - lo)
 
-  // Initialize to 0 on both server and client to avoid hydration mismatch.
-  // useEffect sets the real value after first paint.
-  const [nowS, setNowS] = useState(0)
-  const [tooltip, setTooltip] = useState<TooltipState | null>(null)
+    const ticks: { left: number; label: string }[] = []
+    for (let t = lo; t <= hi; t += HOUR) {
+      ticks.push({ left: ((t - lo) / span) * 100, label: new Date(t).getHours().toString().padStart(2, '0') })
+    }
+    const pos = (b: Band) => ({
+      left: ((b.startMs - lo) / span) * 100,
+      width: Math.max(0.4, ((b.endMs - b.startMs) / span) * 100),
+    })
+    return { active, idle, agent, ticks, pos }
+  }, [data])
 
-  useEffect(() => {
-    setNowS(Math.floor(Date.now() / 1000))
-    const id = setInterval(() => setNowS(Math.floor(Date.now() / 1000)), 1000)
-    return () => clearInterval(id)
-  }, [])
+  if (!model) return null
 
-  const sessionSegments: Segment[] = [
-    ...sessions.map(s => ({
-      id: s.id,
-      app_name: s.app_name,
-      started_at: s.started_at,
-      ended_at: s.ended_at,
-      duration_s: s.duration_s,
-      window_titles: s.window_titles,
-      isActive: false,
-      isGap: false,
-      category: s.category,
-    })),
-    ...(activeSession ? [{
-      id: -1,
-      app_name: activeSession.app_name,
-      started_at: activeSession.started_at,
-      ended_at: undefined,
-      duration_s: Math.max(0, nowS - toEpochS(activeSession.started_at)),
-      window_titles: activeSession.window_titles,
-      isActive: true,
-      isGap: false,
-      category: activeSession.category,
-    }] : []),
-  ]
-
-  const gapSegments: Segment[] = (gaps ?? []).map(g => ({
-    id: g.id * -1000,  // avoid id collisions with session ids
-    app_name: g.kind === 'user_idle' ? 'Idle' : 'Away',
-    started_at: g.started_at,
-    ended_at: g.ended_at,
-    duration_s: g.duration_s,
-    window_titles: [],
-    isActive: false,
-    isGap: true,
-    gapKind: g.kind,
-  }))
-
-  const segments: Segment[] = [...sessionSegments, ...gapSegments]
-
-  function getLeft(startS: number): number {
-    const v = ((startS - day_start_s) / spanS) * 100
-    return isFinite(v) ? Math.max(0, v) : 0
+  const tip = () => {
+    if (!hover) return null
+    const fmt = (t: number) => new Date(t).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    return (
+      <div className="text-[11px] font-mono tnum px-2 py-1 rounded-md inline-flex gap-2 items-center"
+        style={{ background: 'var(--ink)', color: 'var(--paper)' }}>
+        <span style={{ opacity: 0.7 }}>{hover.label}</span>
+        <span>{fmt(hover.startMs)}–{fmt(hover.endMs)}</span>
+        <span style={{ opacity: 0.7 }}>· {fmtDur(Math.round((hover.endMs - hover.startMs) / 1000))}</span>
+      </div>
+    )
   }
 
-  function getWidth(durationS: number): number {
-    const v = (durationS / spanS) * 100
-    return isFinite(v) ? Math.max(0, v) : 0
+  const block = (b: Band, top: number, height: number, color: string, rounded = false) => {
+    const { left, width } = model.pos(b)
+    return (
+      <div
+        key={`${b.kind}-${b.startMs}`}
+        onMouseEnter={() => setHover(b)}
+        onMouseLeave={() => setHover(h => (h === b ? null : h))}
+        className="absolute cursor-pointer transition-opacity"
+        style={{
+          left: `${left}%`, width: `${width}%`, top, height,
+          background: color, borderRadius: rounded ? 3 : 2,
+          opacity: hover && hover !== b ? 0.4 : 1,
+        }}
+      />
+    )
   }
-
-  function handleMouseEnter(e: React.MouseEvent, segment: Segment) {
-    const rect = containerRef.current?.getBoundingClientRect()
-    if (!rect) return
-    const x = e.clientX - rect.left
-    const y = e.clientY - rect.top
-    if (!isFinite(x) || !isFinite(y)) return
-    setTooltip({ segment, x, y })
-  }
-
-  function handleMouseMove(e: React.MouseEvent) {
-    if (!tooltip) return
-    const rect = containerRef.current?.getBoundingClientRect()
-    if (!rect) return
-    setTooltip(t => t ? { ...t, x: e.clientX - rect.left, y: e.clientY - rect.top } : null)
-  }
-
-  const totalSessions = sessions.length
-  const hasData = totalSessions > 0 || !!activeSession
 
   return (
-    <div className="flex flex-col gap-3">
-      {/* Hour axis */}
-      <div className="relative h-4 select-none" aria-hidden>
-        {HOUR_LABELS.map(h => (
-          <span
-            key={h}
-            className="absolute text-[10px] font-mono text-[#C8C6C1] -translate-x-1/2 tabular-nums"
-            style={{ left: `${(h / 24) * 100}%` }}
-          >
-            {h < 12 ? `${h}am` : h === 12 ? '12pm' : `${h - 12}pm`}
-          </span>
+    <div className="select-none">
+      {/* tooltip rail keeps height stable whether or not something is hovered */}
+      <div className="h-6 mb-1 flex items-end">{tip()}</div>
+
+      <div className="relative" style={{ height: 54 }}>
+        {/* hour gridlines */}
+        {model.ticks.map((t, i) => (
+          <div key={`g${i}`} className="absolute top-0" style={{ left: `${t.left}%`, height: 40, width: 1, background: 'var(--rule)' }} />
+        ))}
+        {/* presence track: idle baseline first, active on top */}
+        {model.idle.map(b => block(b, 6, 18, COLOR.idle))}
+        {model.active.map(b => block(b, 6, 18, COLOR.active))}
+        {/* agent overlay track, aligned beneath presence */}
+        {model.agent.map(b => block(b, 27, 11, COLOR.agent, true))}
+        {/* hour labels */}
+        {model.ticks.map((t, i) => (
+          <div key={`l${i}`} className="absolute font-mono text-[9px]"
+            style={{ left: `${t.left}%`, top: 42, color: 'var(--ink-4)', transform: 'translateX(-50%)' }}>
+            {t.label}
+          </div>
         ))}
       </div>
 
-      {/* Timeline bar */}
-      <div
-        ref={containerRef}
-        className="relative h-12 rounded-xl overflow-hidden bg-[#E8E6E1] cursor-default"
-        role="img"
-        aria-label={`Activity timeline — ${totalSessions} sessions`}
-        onMouseLeave={() => setTooltip(null)}
-        onMouseMove={handleMouseMove}
-      >
-        {/* Hour grid */}
-        {Array.from({ length: 25 }, (_, i) => (
-          <div
-            key={i}
-            aria-hidden
-            className="absolute top-0 bottom-0 w-px bg-[#F8F7F4]/30 pointer-events-none"
-            style={{ left: `${(i / 24) * 100}%` }}
-          />
-        ))}
-
-        {!hasData && (
-          <div className="absolute inset-0 flex items-center justify-center">
-            <span className="text-xs text-[#C8C6C1] font-mono">no activity</span>
-          </div>
-        )}
-
-        {segments.map(seg => {
-          const startS = toEpochS(seg.started_at)
-          const left = getLeft(startS)
-          const width = getWidth(seg.duration_s)
-          const color = seg.isGap
-            ? GAP_COLORS[seg.gapKind!]
-            : seg.isActive
-              ? getCategoryMeta(seg.category ?? 'idle_personal').color
-              : getCategoryMeta(seg.category ?? 'idle_personal').color
-
-          return (
-            <div
-              key={seg.id}
-              role={seg.isGap ? undefined : 'button'}
-              tabIndex={seg.isGap ? -1 : 0}
-              aria-label={seg.isGap ? undefined : `${seg.app_name}: ${formatDuration(seg.duration_s)}`}
-              aria-hidden={seg.isGap ? true : undefined}
-              className={[
-                'absolute top-0 h-full transition-filter',
-                !seg.isGap && 'hover:brightness-110 cursor-pointer',
-                seg.isActive && 'animate-meridian-pulse',
-              ].filter(Boolean).join(' ')}
-              style={{
-                left: `max(0%, ${left}%)`,
-                width: `max(2px, ${width}%)`,
-                backgroundColor: color,
-              }}
-              onMouseEnter={e => !seg.isGap && handleMouseEnter(e, seg)}
-              onFocus={e => !seg.isGap && handleMouseEnter(e as unknown as React.MouseEvent, seg)}
-              onBlur={() => setTooltip(null)}
-            />
-          )
-        })}
-
-        {/* Tooltip */}
-        {tooltip && (
-          <div
-            className="absolute z-50 pointer-events-none"
-            style={{
-              left: Math.min(tooltip.x + 12, containerRef.current ? containerRef.current.offsetWidth - 200 : tooltip.x),
-              top: -8,
-              transform: 'translateY(-100%)',
-            }}
-          >
-            <div className="bg-[#141414] text-white rounded-xl px-3 py-2.5 shadow-xl text-left min-w-[160px] max-w-[220px]">
-              <p className="font-semibold text-sm leading-tight">{tooltip.segment.app_name}</p>
-              {!tooltip.segment.isGap && tooltip.segment.category && (
-                <p className="text-[11px] mt-1" style={{ color: getCategoryMeta(tooltip.segment.category).color }}>
-                  {getCategoryMeta(tooltip.segment.category).label}
-                </p>
-              )}
-              <p className="font-mono text-[#9B9A97] text-xs mt-0.5">
-                {formatDuration(tooltip.segment.duration_s)}
-                {' · '}
-                {formatTime(tooltip.segment.started_at)}
-                {tooltip.segment.isActive ? ' → now' : tooltip.segment.ended_at ? ` → ${formatTime(tooltip.segment.ended_at)}` : ''}
-              </p>
-              {tooltip.segment.window_titles.slice(0, 2).map(w => (
-                <p key={w.window_name} className="text-[11px] text-[#6B6A67] mt-1 truncate">
-                  {w.window_name}
-                </p>
-              ))}
-            </div>
-          </div>
-        )}
+      {/* legend */}
+      <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px]" style={{ color: 'var(--ink-3)' }}>
+        <span className="inline-flex items-center gap-1.5"><i style={{ width: 10, height: 10, background: COLOR.active, borderRadius: 2, display: 'inline-block' }} /> Active</span>
+        <span className="inline-flex items-center gap-1.5"><i style={{ width: 10, height: 10, background: COLOR.idle, borderRadius: 2, display: 'inline-block' }} /> Idle</span>
+        <span className="inline-flex items-center gap-1.5"><i style={{ width: 10, height: 6, background: COLOR.agent, borderRadius: 2, display: 'inline-block' }} /> Claude / Codex</span>
+        <span style={{ color: 'var(--ink-4)' }}>· agent under an idle stretch = autonomous</span>
       </div>
     </div>
   )

--- a/ui/components/TodayMetrics.tsx
+++ b/ui/components/TodayMetrics.tsx
@@ -1,0 +1,110 @@
+// meridian — normalises screenpipe activity into structured app sessions
+'use client'
+
+import { useState } from 'react'
+import { fmtDur } from '@/components/atoms'
+
+// Layer 2 + 3 of the Today view (Shneiderman: zoom, then details-on-demand).
+// A calm row of three headline numbers — Focus, AI-assisted, Switches — each a
+// button that expands one detail panel below. The fuller breakdown (Active vs
+// Idle, Supervised vs Autonomous) stays hidden until asked for, so the default
+// view never clogs.
+
+interface Props {
+  focus_s: number
+  idle_s: number
+  agent_s: number
+  supervised_s: number
+  autonomous_s: number
+  switch_count: number
+}
+
+type Key = 'focus' | 'ai' | 'switches'
+
+const pct = (part: number, whole: number) => (whole > 0 ? Math.round((part / whole) * 100) : 0)
+
+function DetailRow({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4 py-2">
+      <div className="min-w-0">
+        <span className="text-[13px]" style={{ color: 'var(--ink)' }}>{label}</span>
+        {hint && <span className="text-[11px] ml-2" style={{ color: 'var(--ink-3)' }}>{hint}</span>}
+      </div>
+      <span className="font-mono tnum text-[14px] whitespace-nowrap" style={{ color: 'var(--ink)' }}>{value}</span>
+    </div>
+  )
+}
+
+export default function TodayMetrics(props: Props) {
+  const { focus_s, idle_s, agent_s, supervised_s, autonomous_s, switch_count } = props
+  const [open, setOpen] = useState<Key | null>(null)
+
+  const tiles: { key: Key; label: string; value: string; note: string }[] = [
+    { key: 'focus', label: 'Focus', value: fmtDur(focus_s), note: 'active' },
+    { key: 'ai', label: 'AI-assisted', value: `${pct(supervised_s, focus_s)}%`, note: 'of focus' },
+    { key: 'switches', label: 'Switches', value: String(switch_count), note: 'context switches' },
+  ]
+
+  const detail = (key: Key) => {
+    switch (key) {
+      case 'focus':
+        return (
+          <>
+            <DetailRow label="Active" value={fmtDur(focus_s)} hint="you, at the keyboard" />
+            <DetailRow label="Idle / away" value={fmtDur(idle_s)} hint="no input detected" />
+            <DetailRow label="AI-assisted" value={`${fmtDur(supervised_s)} · ${pct(supervised_s, focus_s)}%`} hint="of your active time" />
+          </>
+        )
+      case 'ai':
+        return (
+          <>
+            <DetailRow label="Supervised" value={fmtDur(supervised_s)} hint="agent ran while you were active" />
+            <DetailRow label="Autonomous" value={fmtDur(autonomous_s)} hint="agent ran while you were away" />
+            <DetailRow label="Agent total" value={fmtDur(agent_s)} hint="engaged Claude / Codex time" />
+          </>
+        )
+      case 'switches':
+        return (
+          <>
+            <DetailRow label="Context switches" value={String(switch_count)} hint="foreground app changes over 15s" />
+            <p className="text-[12px] leading-relaxed pt-1" style={{ color: 'var(--ink-3)' }}>
+              Lower is deeper. Brief sub-15s window flicker is filtered out so this
+              reflects real context shifts, not capture noise.
+            </p>
+          </>
+        )
+    }
+  }
+
+  return (
+    <div className="rule-t rule-b" style={{ borderColor: 'var(--rule)' }}>
+      <div className="grid grid-cols-3">
+        {tiles.map((t, i) => {
+          const isOpen = open === t.key
+          return (
+            <button
+              key={t.key}
+              onClick={() => setOpen(isOpen ? null : t.key)}
+              className={`text-left py-4 px-5 transition-colors ${i > 0 ? 'rule-l' : ''}`}
+              style={{ borderColor: 'var(--rule)', background: isOpen ? 'var(--tint)' : 'transparent' }}
+              aria-expanded={isOpen}
+            >
+              <p className="text-[10px] uppercase tracking-[0.16em] mb-2 flex items-center gap-1.5" style={{ color: 'var(--ink-3)' }}>
+                {t.label}
+                <span className="text-[9px]" style={{ color: 'var(--ink-4)', transform: isOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s' }}>▾</span>
+              </p>
+              <p className="font-mono tnum text-[20px] leading-none" style={{ color: 'var(--ink)' }}>{t.value}</p>
+              <p className="text-[11px] mt-1.5" style={{ color: 'var(--ink-3)' }}>{t.note}</p>
+            </button>
+          )
+        })}
+      </div>
+
+      {open && (
+        <div className="px-5 py-3 rule-t" style={{ borderTopColor: 'var(--rule)', background: 'var(--surface)' }}>
+          <div className="max-w-md">{detail(open)}</div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/components/views/TodayView.tsx
+++ b/ui/components/views/TodayView.tsx
@@ -9,6 +9,8 @@ import {
 } from '@/components/atoms'
 import TaskBadge from '@/components/TaskBadge'
 import ShapeOfDay from '@/components/ShapeOfDay'
+import DayTimeline from '@/components/DayTimeline'
+import TodayMetrics from '@/components/TodayMetrics'
 import type { TodayResponse } from '@/app/api/today/route'
 
 interface BucketSession {
@@ -143,29 +145,24 @@ function ActiveSessionCard({ active, taskKey }: { active: NonNullable<TodayRespo
   )
 }
 
-// ── Totals strip ─────────────────────────────────────────────────────────────
-function TotalsStrip({ focus_s, idle_s, coding_s, switch_count }: { focus_s: number; idle_s: number; coding_s: number; switch_count: number }) {
-  // Coding-agent time is a SUBSET of focus (the AI-assisted slice), never an
-  // additive total — surface it as a share of focus so the four tiles can't be
-  // read as summing to more wall-clock than actually elapsed.
-  const codingPct = focus_s > 0 ? Math.round((coding_s / focus_s) * 100) : 0
-  const items = [
-    { k: 'Focus',        v: fmtDur(focus_s),       note: 'active' },
-    { k: 'Idle',         v: fmtDur(idle_s),        note: 'away from keyboard' },
-    { k: 'Coding agent', v: fmtDur(coding_s),      note: `${codingPct}% of focus · AI-assisted` },
-    { k: 'Switches',     v: String(switch_count),  note: 'context switches' },
-  ]
-  return (
-    <div className="grid grid-cols-4 rule-t rule-b" style={{ borderColor: 'var(--rule)' }}>
-      {items.map((it, i) => (
-        <div key={it.k} className={`py-4 px-5 ${i > 0 ? 'rule-l' : ''}`} style={{ borderColor: 'var(--rule)' }}>
-          <p className="text-[10px] uppercase tracking-[0.16em] mb-2" style={{ color: 'var(--ink-3)' }}>{it.k}</p>
-          <p className="font-mono tnum text-[20px] leading-none" style={{ color: 'var(--ink)' }}>{it.v}</p>
-          <p className="text-[11px] mt-1.5" style={{ color: 'var(--ink-3)' }}>{it.note}</p>
-        </div>
-      ))}
-    </div>
-  )
+// ── At-a-glance insight (Layer 1) ────────────────────────────────────────────
+// One pre-computed takeaway, in the Oura "tell me the meaning, not the data"
+// spirit: lead with active focus + how much was AI-assisted, and only mention
+// autonomous agent work or a fragmented day when they're actually notable.
+function buildInsight(data: TodayResponse): string | null {
+  const { focus_s, supervised_s, autonomous_s, switch_count, active } = data
+  if (focus_s < 300 && !active) return null
+
+  const aiPct = focus_s > 0 ? Math.round((supervised_s / focus_s) * 100) : 0
+  let lead = `${fmtDur(focus_s)} focused`
+  if (aiPct >= 5) lead += `, ${aiPct}% of it alongside Claude`
+
+  const extra: string[] = []
+  if (autonomous_s >= 600) extra.push(`plus ${fmtDur(autonomous_s)} of autonomous agent work while you were away`)
+  const focusMin = focus_s / 60
+  if (focusMin > 60 && switch_count > focusMin / 4) extra.push(`a fragmented day — ${switch_count} context switches`)
+
+  return extra.length ? `${lead} — ${extra.join('; ')}.` : `${lead}.`
 }
 
 // ── Task bucket row ──────────────────────────────────────────────────────────
@@ -402,19 +399,40 @@ export default function TodayView({ onNavigate }: { onNavigate?: (v: string, key
         <h1 className="font-serif text-[88px] leading-[0.95] tracking-tight" style={{ color: 'var(--ink)' }}>Today</h1>
       </header>
 
+      {/* Layer 1 — the glance: one insight + the day timeline (overlap shown, not summed) */}
       {(() => {
+        const insight = buildInsight(data)
         const story = buildStory(data)
-        return story ? (
-          <section className="rise">
-            <p className="text-[11px] uppercase tracking-[0.18em] mb-3" style={{ color: 'var(--ink-3)' }}>The story so far</p>
-            <p className="font-serif text-[26px] leading-[1.2]" style={{ color: 'var(--ink)', textWrap: 'pretty' } as React.CSSProperties}>{story}</p>
+        if (!insight && !(data.sessions.length > 0 || data.active)) return null
+        return (
+          <section className="rise space-y-5">
+            {insight && (
+              <div>
+                <p className="text-[11px] uppercase tracking-[0.18em] mb-3" style={{ color: 'var(--ink-3)' }}>Today at a glance</p>
+                <p className="font-serif text-[32px] leading-[1.15]" style={{ color: 'var(--ink)', textWrap: 'pretty' } as React.CSSProperties}>{insight}</p>
+              </div>
+            )}
+            {(data.sessions.length > 0 || data.active) && (
+              <Card className="p-6"><DayTimeline data={data} /></Card>
+            )}
+            {story && (
+              <p className="text-[14px] leading-relaxed" style={{ color: 'var(--ink-2)', textWrap: 'pretty' } as React.CSSProperties}>{story}</p>
+            )}
           </section>
-        ) : null
+        )
       })()}
 
       {data.active && <ActiveSessionCard active={data.active} taskKey={data.sessions.filter(s => s.task_key).at(-1)?.task_key} />}
 
-      <TotalsStrip focus_s={data.focus_s} idle_s={data.idle_s} coding_s={data.coding_s} switch_count={data.switch_count} />
+      {/* Layer 2 + 3 — zoom row with details-on-demand */}
+      <TodayMetrics
+        focus_s={data.focus_s}
+        idle_s={data.idle_s}
+        agent_s={data.agent_s}
+        supervised_s={data.supervised_s}
+        autonomous_s={data.autonomous_s}
+        switch_count={data.switch_count}
+      />
 
       {buckets.length > 0 && (
         <section>

--- a/ui/lib/intervals.ts
+++ b/ui/lib/intervals.ts
@@ -12,31 +12,71 @@ export interface Interval {
   ended_at: string
 }
 
+type Pair = [number, number] // [startMs, endMs]
+
 /**
- * Total wall-clock seconds covered by a set of intervals, with overlap counted
- * once. Intervals where `ended_at <= started_at` (including corrupt rows whose
- * end precedes their start) are discarded rather than contributing negative or
- * zero time.
+ * Parse, drop invalid intervals (`end <= start`, including corrupt rows whose
+ * end precedes their start, and unparseable timestamps), sort by start, and
+ * merge overlapping/touching intervals into a disjoint, ascending set.
  */
-export function unionSeconds(intervals: Interval[]): number {
+function normalize(intervals: Interval[]): Pair[] {
   const ivs = intervals
-    .map(r => [new Date(r.started_at).getTime(), new Date(r.ended_at).getTime()] as [number, number])
+    .map(r => [new Date(r.started_at).getTime(), new Date(r.ended_at).getTime()] as Pair)
     .filter(([s, e]) => Number.isFinite(s) && Number.isFinite(e) && e > s)
     .sort((a, b) => a[0] - b[0])
 
-  let total = 0
-  let curStart = -1
-  let curEnd = -1
+  const out: Pair[] = []
   for (const [s, e] of ivs) {
-    if (s > curEnd) {
-      if (curEnd > curStart) total += curEnd - curStart
-      curStart = s
-      curEnd = e
-    } else if (e > curEnd) {
-      curEnd = e
-    }
+    const last = out[out.length - 1]
+    if (last && s <= last[1]) last[1] = Math.max(last[1], e)
+    else out.push([s, e])
   }
-  if (curEnd > curStart) total += curEnd - curStart
+  return out
+}
+
+/**
+ * Total wall-clock seconds covered by a set of intervals, with overlap counted
+ * once. Invalid/corrupt intervals contribute nothing.
+ */
+export function unionSeconds(intervals: Interval[]): number {
+  const merged = normalize(intervals)
+  let total = 0
+  for (const [s, e] of merged) total += e - s
+  return Math.round(total / 1000)
+}
+
+/**
+ * Merge a set of intervals into a disjoint, ascending list — the timeline's
+ * presence/agent bands are drawn from these so overlapping rows render as one
+ * continuous block rather than stacked duplicates.
+ */
+export function mergeIntervals(intervals: Interval[]): Interval[] {
+  return normalize(intervals).map(([s, e]) => ({
+    started_at: new Date(s).toISOString(),
+    ended_at: new Date(e).toISOString(),
+  }))
+}
+
+/**
+ * Total seconds where set `a` and set `b` overlap — e.g. agent time that fell
+ * inside foreground-active time (supervised / "AI-assisted") vs outside it
+ * (autonomous). Both sides are normalized first, then swept together in linear
+ * time.
+ */
+export function intersectSeconds(a: Interval[], b: Interval[]): number {
+  const A = normalize(a)
+  const B = normalize(b)
+  let i = 0
+  let j = 0
+  let total = 0
+  while (i < A.length && j < B.length) {
+    const lo = Math.max(A[i][0], B[j][0])
+    const hi = Math.min(A[i][1], B[j][1])
+    if (hi > lo) total += hi - lo
+    // advance whichever interval ends first
+    if (A[i][1] < B[j][1]) i++
+    else j++
+  }
   return Math.round(total / 1000)
 }
 


### PR DESCRIPTION
Re-targets the insight-dashboard work to **main**. It was previously merged into the (already-merged) #80 branch as a stacked PR (#83), so it never reached main — this lands it.

Builds on #80 (the double-count fix, already in main). Single commit `92ca7fb`, 6 files.

## What
Reworks the Today view into three layers (Shneiderman: overview → zoom → details-on-demand) and separates two kinds of time that must never be summed: **human presence** vs **coding-agent activity**.

- **Presence** (mutually exclusive): **Active** (foreground) · **Idle/away**.
- **Agent overlay** (a layer on top of presence, never added to focus):
  - **Supervised** — agent ran while you were active (AI-assisted)
  - **Autonomous** — agent ran while you were away
- Each transcript is capped to its engaged `duration_s` so a parked-open Claude window stops inflating time.

## UI (3 layers)
- **Glance:** one insight headline + **DayTimeline** (presence track + aligned agent band; agent under an idle stretch reads as autonomous by alignment).
- **Zoom + details:** `TodayMetrics` — Focus · AI-assisted % · Switches; tap any to expand its breakdown. Default view stays uncluttered.

## API (`/api/today`)
`focus_s` = Active presence (foreground union). Adds `agent_s`, `supervised_s`, `autonomous_s`, `presence_segments`, `agent_segments`. **Conservation holds:** `supervised + autonomous = agent`, `supervised ⊆ focus`.

## Verification (no inflation / no deflation)
Cross-checked against the live DB — all invariants pass: `focus ≤ 24h`, `supervised ⊆ active`, `autonomous ≥ 0`, `supervised + autonomous = agent`, capped agent ≤ raw span, focus = foreground union exactly.

## Known caveat (separate, pre-existing)
`idle_s` counts overnight/away-for-hours as idle — needs a "within a working window" bound on the Rust gap side. Focus/agent unaffected.

## Testing
`bun test` 105 pass (25 for intervals) · `npm run build` clean · `tsc` clean · no merge conflicts vs main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)