### PR TITLE
feat(cli): meridian dev commands + dev-workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ cd meridian
 
 Builds the daemon + UI from source and registers the same services. Flags: `--no-ui`, `--dry-run`, `--no-daemon`, `--skip-permissions`, `--skip-env`, `--no-mlx` (use the hermes LLM-selector backend instead of the MLX server).
 
+Once installed, use `meridian dev …` to rebuild + restart after edits — see [Development](#development).
+
 ### Configure
 
 `./install.sh` walks you through credential prompts grouped by category:
@@ -220,18 +222,36 @@ python3 scripts/refresh_pm_tasks.py --db /path/to/meridian.db
 
 ## Development
 
+After cloning + `./install.sh`, the four services run under launchd (see [Run](#run)). When you change code, rebuild and restart **only what changed** with `meridian dev` — these build from your checkout (the daemon's launchd agent runs `target/release/meridian` via a symlink, so a release build is picked up in place). They are only available in a source checkout.
+
 ```bash
-# Format
-cargo fmt
+meridian dev daemon     # rebuild Rust + restart the daemon          ← backend loop
+meridian dev ui-watch   # Next.js hot-reload dev server (foreground) ← UI loop
+meridian dev ui         # rebuild prod bundle + restart dashboard (:3939)
+meridian dev mlx        # restart only the MLX server (reloads the model, ~30s)
+meridian dev            # build daemon + UI, restart them, start MLX/screenpipe if down
+meridian dev build      # build daemon + UI, no restart
+```
 
-# Lint (warnings are errors)
-cargo clippy -- -D warnings
+`meridian dev` and `meridian dev daemon` **leave the MLX model loaded** (fast). Only `meridian dev mlx` and `meridian restart` reload it — avoid `meridian restart` in a tight loop. Migrations apply automatically on daemon start.
 
-# Tests
-cargo test
+To test one stage without the background daemon (hits the same `~/.meridian/meridian.db`):
 
-# Install git hooks (runs fmt + clippy before each commit)
-bash scripts/setup-hooks.sh
+```bash
+cargo run --release -- worklog-status          # inspect the day's worklogs
+cargo run --release -- pm-worklog --day DATE    # draft worklogs for a day
+cargo run --release -- worklog-post-approved    # post approved worklogs now
+```
+
+> Don't run `cargo run` while the launchd daemon is up — two processes writing the DB. Stop it first (`meridian stop`) or just use `meridian dev daemon`.
+
+### Quality checks (enforced by git hooks)
+
+```bash
+cargo fmt                       # format (pre-commit checks --check)
+cargo clippy -- -D warnings     # lint — warnings are errors (pre-commit)
+meridian dev build && cargo test   # build everything + run tests (pre-push runs the full suite)
+bash scripts/setup-hooks.sh     # install the hooks after cloning
 ```
 
 ## Architecture

--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -51,6 +51,20 @@ Commands:
   uninstall          Stop daemons and remove CLI symlinks
   --help | -h        Show this help
 EOF
+    # Dev commands only make sense (and only work) in a source checkout.
+    if [[ -f "${REPO_ROOT}/Cargo.toml" ]]; then
+        cat <<'EOF'
+
+Dev (source checkout — builds from this repo, MLX stays loaded):
+  dev                Build daemon + UI, restart them, start MLX/screenpipe if down
+  dev daemon         Rebuild Rust + restart only the daemon   ← main backend loop
+  dev ui             Rebuild UI + restart the dashboard (:3939)
+  dev ui-watch       Next.js hot-reload dev server (foreground)  ← main UI loop
+  dev mlx            Restart only the MLX server (reloads the model)
+  dev screenpipe     Restart only screenpipe
+  dev build          Build daemon + UI, no restart
+EOF
+    fi
 }
 
 # --- start ---
@@ -368,6 +382,73 @@ cmd_daemon_passthrough() {
     exec "$bin" "$@"
 }
 
+# --- dev (source checkout only) ---
+# Build from THIS repo and restart only what changed. The daemon's launchd plist
+# runs ~/.local/bin/meridian-daemon -> target/release/meridian, so a release
+# build is picked up in place. Gated on Cargo.toml: a prebuilt install (bundle at
+# ~/.meridian/app) has no source, so these are hidden/disabled there.
+_is_source_checkout() { [[ -f "${REPO_ROOT}/Cargo.toml" ]]; }
+
+# Restart a service to pick up a new build (no-op-with-warning if not running).
+_dev_kick() {
+    local label="$1"
+    if launchctl kickstart -k "${GUI_TARGET}/${label}" 2>/dev/null; then
+        ok "restarted ${label}"
+    else
+        warn "${label} not running — 'meridian start' or ./install.sh first"
+    fi
+}
+
+# Start a service ONLY if it isn't already up — never reloads a live process
+# (so the ~6 GB MLX model isn't reloaded when it's already serving).
+_dev_ensure() {
+    local label="$1"
+    if launchctl print "${GUI_TARGET}/${label}" >/dev/null 2>&1; then
+        ok "${label} already up (left as-is)"
+    elif [[ -f "${LAUNCH_AGENTS}/${label}.plist" ]]; then
+        set +e
+        launchctl enable "${GUI_TARGET}/${label}" 2>/dev/null
+        launchctl bootstrap "${GUI_TARGET}" "${LAUNCH_AGENTS}/${label}.plist" 2>/dev/null
+        set -e
+        info "started ${label}"
+    else
+        warn "${label} not installed — run ./install.sh"
+    fi
+}
+
+_dev_build_daemon() { info "building daemon (cargo --release)…"; ( cd "${REPO_ROOT}" && cargo build --release ); }
+_dev_build_ui()     { info "building UI (npm run build)…";       ( cd "${REPO_ROOT}/ui" && npm run build ); }
+
+cmd_dev() {
+    if ! _is_source_checkout; then
+        err "'meridian dev' needs a source checkout (no Cargo.toml at ${REPO_ROOT})."
+        err "This is a prebuilt install — use start / stop / restart / status / logs."
+        exit 1
+    fi
+    local target="${1:-all}"
+    case "$target" in
+        all)
+            # Build everything + bring up: rebuild & restart the cheap services,
+            # start MLX/screenpipe only if down (don't reload a live model).
+            _dev_build_daemon; _dev_build_ui
+            _dev_ensure "${LABEL_SCREENPIPE}"
+            _dev_ensure "${LABEL_MLX}"
+            _dev_kick   "${LABEL_DAEMON}"
+            _dev_kick   "${LABEL_UI}"
+            echo; info "dev up (MLX left loaded if it was already running)"; echo
+            cmd_status
+            ;;
+        build)      _dev_build_daemon; _dev_build_ui; ok "built (no restart)" ;;
+        daemon)     _dev_build_daemon; _dev_kick "${LABEL_DAEMON}" ;;
+        ui)         _dev_build_ui;     _dev_kick "${LABEL_UI}" ;;
+        ui-watch)   info "Next.js hot reload (Ctrl-C to stop)…"; ( cd "${REPO_ROOT}/ui" && exec npm run dev ) ;;
+        mlx)        _dev_kick "${LABEL_MLX}" ;;          # python — restart reloads the model
+        screenpipe) _dev_kick "${LABEL_SCREENPIPE}" ;;
+        *) err "unknown dev target: ${target}";
+           echo "  targets: all | build | daemon | ui | ui-watch | mlx | screenpipe"; exit 1 ;;
+    esac
+}
+
 case "$CMD" in
     start)            cmd_start ;;
     stop)             cmd_stop ;;
@@ -376,6 +457,7 @@ case "$CMD" in
     logs)             cmd_logs "$@" ;;
     doctor)           cmd_doctor ;;
     config)           cmd_config "$@" ;;
+    dev)              cmd_dev "$@" ;;
     uninstall)        cmd_uninstall ;;
     permissions)      cmd_permissions ;;
     worklog-status|pm-worklog) cmd_daemon_passthrough "$CMD" "$@" ;;


### PR DESCRIPTION
## What

Adds a `meridian dev` command group so source contributors build + restart from the `meridian` CLI they already use — no separate Makefile/justfile.

```bash
meridian dev daemon     # rebuild Rust + restart the daemon          ← backend loop
meridian dev ui-watch   # Next.js hot reload (foreground)            ← UI loop
meridian dev ui         # rebuild prod bundle + restart dashboard (:3939)
meridian dev mlx        # restart only MLX (reloads the model)
meridian dev            # build daemon + UI, restart them, start MLX/screenpipe if down
meridian dev build      # build everything, no restart
```

## Why it's safe in the shipped CLI
`scripts/meridian-cli.sh` ships to npm users (prebuilt bundle, no source). The dev commands are **gated on `Cargo.toml`** next to the install — the bundle has none, so they're hidden from `--help` and refuse to run there. Installed users only ever see `start/stop/restart/status/logs`.

## Key behaviors
- `dev` / `dev daemon` **leave the MLX model loaded** (fast) — only `dev mlx` / `meridian restart` reload it. The daemon's launchd agent runs `target/release/meridian` via symlink, so `cargo build --release` is picked up in place.
- `dev` starts MLX/screenpipe **only if down** (never reloads a live model).

## Docs
README `## Development` rewritten: the dev loop, the MLX-reload caveat, one-shot stage CLIs (`worklog-status`/`pm-worklog`/`worklog-post-approved`), and quality checks framed as the git-hook gates.

Replaces the throwaway Makefile from earlier exploration (consolidated into the CLI per review).