### PR TITLE
fix(ui): pin Turbopack workspace root to ui/

### DIFF
--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -1,6 +1,14 @@
 import type { NextConfig } from 'next'
+import path from 'path'
 
 const nextConfig: NextConfig = {
+  // Pin the Turbopack workspace root to this `ui/` directory. The repo root
+  // also has a package-lock.json, so Turbopack otherwise infers the monorepo
+  // root and tries to watch the whole tree — including the 22 GB Rust
+  // `target/` dir — which hangs the dev compile and balloons memory.
+  turbopack: {
+    root: path.join(__dirname),
+  },
   // Emit a self-contained server bundle (`.next/standalone/`) so the dashboard
   // ships prebuilt in the release tarball and runs with `node server.js` — no
   // `npm ci` / native rebuild of better-sqlite3 on the user's machine.


### PR DESCRIPTION
## Problem

Running \`npm run dev\` left the dashboard stuck at \`○ Compiling / ...\` and never opened, while the dev-server memory climbed into the GBs.

Root cause: the repo root has its own \`package-lock.json\` alongside \`ui/package-lock.json\`, so Turbopack inferred the **monorepo root** as its workspace and tried to watch the entire tree — including the **22 GB Rust \`target/\` directory**.

```
⚠ We detected multiple lockfiles and selected the directory of
  .../meridian/package-lock.json as the root directory.
```

## Fix

Pin \`turbopack.root\` to the \`ui/\` directory in \`next.config.ts\` so the watcher is scoped to the dashboard.

## Verified

| | before | after |
|---|---|---|
| first compile | hangs | ~2 s |
| dev-server RSS | 665 MB → 2.4 GB | ~75 MB |
| homepage | never loads | `200` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)