### PR TITLE
fix(ui): cache the read-only SQLite handle in production

### DIFF
--- a/ui/lib/db.ts
+++ b/ui/lib/db.ts
@@ -18,7 +18,12 @@ function expandTilde(filePath: string): string {
 }
 
 function getDb(): Database.Database {
-  if (process.env.NODE_ENV !== 'production' && globalThis.__meridian_db__) {
+  // Cache the connection in ALL environments. In a long-running production
+  // server, opening a fresh connection per request would leak file descriptors
+  // (db + -wal + -shm) and page-cache memory until GC finalizes each handle —
+  // the source of the unbounded RSS growth seen under request load. The
+  // single read-only handle is safe to share across concurrent requests.
+  if (globalThis.__meridian_db__) {
     return globalThis.__meridian_db__
   }
 
@@ -32,9 +37,7 @@ function getDb(): Database.Database {
 
   db.pragma('busy_timeout = 5000')
 
-  if (process.env.NODE_ENV !== 'production') {
-    globalThis.__meridian_db__ = db
-  }
+  globalThis.__meridian_db__ = db
 
   return db
 }


### PR DESCRIPTION
## Problem

\`getDb()\` gated its connection cache behind \`process.env.NODE_ENV !== 'production'\`. In the production dashboard (\`meridian start\`) that meant **every API request opened a brand-new \`better-sqlite3\` connection and never closed it**. Each handle holds three file descriptors (\`db\` + \`-wal\` + \`-shm\`) plus prepared-statement and page-cache memory, accumulating until GC finalized them — unbounded RSS growth under request load.

## Fix

Cache the single read-only handle in **all** environments, mirroring the unconditional cache already used by \`getWriteDb()\` in \`db-write.ts\`. The read-only handle is safe to share across concurrent requests.

## Verified

Production server (\`next start\`), 80 requests each across five routes:

| | baseline | after \`api/tasks\` | final (400 req) | open meridian.db fds |
|---|---|---|---|---|
| **before** | 169 MB | 753 MB | 760 MB | 4 → 42 → 93 |
| **after** | 170 MB | 229 MB | 231 MB | 4 (constant) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)