### PR TITLE
chore(task-linker): tag classifier dimensions as mlx, not hermes

### DIFF
--- a/src/intelligence/task_linker/db_write.rs
+++ b/src/intelligence/task_linker/db_write.rs
@@ -43,7 +43,7 @@ pub(super) async fn update_session_overhead(pool: &SqlitePool, session_id: i64) 
     Ok(())
 }
 
-/// Persist a hermes classification result into `app_sessions`.
+/// Persist an MLX classification result into `app_sessions`.
 pub(super) async fn update_session_task(
     pool: &SqlitePool,
     r: &SessionClassification,
@@ -136,7 +136,7 @@ pub(super) async fn write_dimensions(
             sqlx::query(
                 "INSERT OR IGNORE INTO session_dimensions \
                  (session_id, dimension, value, confidence, source) \
-                 VALUES (?, ?, ?, 0.75, 'hermes_standalone')",
+                 VALUES (?, ?, ?, 0.75, 'mlx_standalone')",
             )
             .bind(session_id)
             .bind(dimension)


### PR DESCRIPTION
## What

The live classifier write path (`write_dimensions` in `task_linker/db_write.rs`) stamped every `session_dimensions` row with `source = 'hermes_standalone'` — a stale label left over from the removed Hermes backend. MLX has been the **only** classifier since #94, so this provenance tag was misleading on every new row (10k+ already written this way).

This renames the write-time tag to `'mlx_standalone'` and fixes the matching doc comment on `update_session_task`.

## Why it's safe

The tag is **write-only** — `grep` across `src/`, `ui/`, and `packages/` confirms nothing reads or filters on `'hermes_standalone'`. So this is a pure provenance correction with **zero consumer impact**.

## Scope

- Existing rows keep their old `'hermes_standalone'` tag (harmless; a data backfill is intentionally **out of scope** to keep this change minimal and reversible).
- The remaining `hermes` references in the tree are either the legacy Python files deliberately kept on disk, or test fixtures — neither is in the live daemon path, so they're left untouched here.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` (129+ tests) ✅
- Full pre-push suite (fmt + clippy + cargo test + UI build + UI tests + security audit) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)