### PR TITLE
fix(daemon): add PATH to launchd plist so claude/codex resolve

### DIFF
--- a/scripts/com.meridiona.daemon.plist
+++ b/scripts/com.meridiona.daemon.plist
@@ -30,6 +30,13 @@
 
     <key>EnvironmentVariables</key>
     <dict>
+        <!-- launchd gives agents a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin).
+             The coding-agent summariser shells out to `claude` (~/.local/bin) and
+             `codex` (/opt/homebrew/bin); without them on PATH every primary
+             summary silently falls back to MLX. Keep ~/.local/bin and Homebrew
+             ahead of the system defaults. -->
+        <key>PATH</key>
+        <string>{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         <key>SCREENPIPE_DB</key>
         <string>{{HOME}}/.screenpipe/db.sqlite</string>
         <key>MERIDIAN_DB</key>


### PR DESCRIPTION
## Problem

The daemon runs under launchd with the minimal default `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`). The coding-agent summariser shells out to `claude` (`~/.local/bin`) and `codex` (`/opt/homebrew/bin`) — neither on that PATH — so `Command::new("claude")` failed with "not found" and **every primary summary silently fell back to MLX**. Coding sessions were never summarised by their own agent.

It was invisible in logs because a primary failure is only surfaced when MLX *also* fails (addressed separately by the summariser-logging PR).

## Fix

Add a `PATH` to the daemon plist's `EnvironmentVariables`, putting `~/.local/bin` and Homebrew ahead of the system defaults:

```
{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
```

Both install paths render this one template through `install-daemon.sh` (source `install.sh` directly; the npm bundle via `install-from-bundle.sh`), so the fix ships to every install.

## Verified live

After patching the live plist and reloading, the daemon summarises Claude sessions with `summary_source=claude` (keychain auth works with the launchd-provided HOME/USER/LOGNAME). A clean-env `claude -p` returned `success`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)