### PR TITLE
fix(summariser): log primary-engine failure on MLX fallback

### DIFF
--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -221,10 +221,26 @@ pub async fn summarise_one(
             }
             Err(SummariserError::RateLimited(m)) => {
                 rate_limited = true;
+                // Log the primary failure even though MLX will likely save the row
+                // — otherwise a degraded-to-MLX state is invisible (this is exactly
+                // how the missing-PATH outage hid: every row silently became mlx).
+                tracing::warn!(
+                    row_id = row.id,
+                    engine = primary_source.as_str(),
+                    error = %m,
+                    "primary summariser rate-limited — falling back to MLX"
+                );
                 errors.push(format!("{} rate-limited: {m}", primary_source.as_str()));
                 break; // retrying a limit is pointless → fall through to MLX
             }
             Err(SummariserError::Failed(m)) => {
+                tracing::warn!(
+                    row_id = row.id,
+                    engine = primary_source.as_str(),
+                    attempt,
+                    error = %m,
+                    "primary summariser attempt failed"
+                );
                 errors.push(format!(
                     "{} attempt {attempt} failed: {m}",
                     primary_source.as_str()
@@ -237,6 +253,11 @@ pub async fn summarise_one(
     if summary.is_none() {
         match mlx::run_mlx(&stdin_text, cfg).await {
             Ok(s) => {
+                tracing::warn!(
+                    row_id = row.id,
+                    primary = primary_source.as_str(),
+                    "summarised via MLX fallback — primary engine unavailable"
+                );
                 summary = Some(s);
                 source = Source::Mlx;
             }


### PR DESCRIPTION
## Problem

When the primary engine (Claude/Codex) failed but the MLX fallback succeeded, the row was written as `source="mlx"` and the primary failure was **discarded** (`outcome.error` is only set on total failure). A degraded-to-MLX state passed silently as success — exactly how the missing-PATH outage stayed invisible: every coding session quietly became `mlx`, with nothing in `daemon-error.log`.

## Fix

Emit `warn!` (→ `daemon-error.log`) at each primary failure point in `summarise_one`:
- primary attempt failed → engine, attempt, error
- primary rate-limited → engine, error
- fell back to MLX → primary engine + row id

Normal operation stays quiet — these only fire when a primary actually fails, so a fallback is always visible.

## Context

Part of the logging audit: confirmed `daemon.log` (stdout) captures all INFO+ and `daemon-error.log` (stderr) captures WARN+ERROR; every stage already routes errors through `warn!`/`error!`. This closes the one remaining blind spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)