### PR TITLE
ci(release): release the main tip, not the trigger commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # Release the current tip of the default branch, NOT the commit that
+          # triggered this run. With the concurrency group serialising runs
+          # (cancel-in-progress: false), a burst of merges otherwise has each
+          # run pinned to its own (stale) trigger SHA: the older run releases a
+          # stale snapshot and its `git push HEAD:main` is rejected once a newer
+          # commit lands ("fetch first"). Checking out the tip means the first
+          # queued run releases everything on main and later runs find nothing
+          # new to release (clean no-op) — no failures, npm always == main.
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0          # full history — semantic-release needs commits
           fetch-tags: true        # explicitly fetch tags so the v0.0.0 baseline is seen
           persist-credentials: false


### PR DESCRIPTION
## Problem

Merging several PRs back-to-back spawned one Release run per merge. The concurrency group already serialises them (`cancel-in-progress: false`), but the checkout had no `ref`, so each run was pinned to **its own trigger SHA**. An older run released a stale snapshot and its `git push HEAD:main` was rejected once a newer commit had landed:

```
! [rejected]  HEAD -> main (fetch first)
```

That's the failed Release run for #96. (It was harmless — semantic-release pushes in `prepare`, before `npm publish`, so a stale run aborts before publishing, and the last run on the fresh tip published `v1.4.3` with everything. But the red runs are confusing.)

## Fix

Check out the **default-branch tip** instead of the trigger commit:

```yaml
- uses: actions/checkout@v4
  with:
    ref: ${{ github.event.repository.default_branch }}
    fetch-depth: 0
    fetch-tags: true
```

With runs serialised, the first queued run releases everything on `main` and pushes cleanly; later runs check out a `main` that already has the release commit and find nothing new → clean no-op. No spurious failures, and **npm always matches `main`**.

## Why not `cancel-in-progress: true`

semantic-release pushes the tag/commit in `prepare` **before** `npm publish` in `publish`. Cancelling mid-run could leave a `vX.Y.Z` tag on `main` with no published package — stranding npm behind the tag. Serialise + release-the-tip avoids both the race and that hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)