### PR TITLE
fix(ui): per-task time = union of total time, consistent across views

### DIFF
--- a/ui/app/api/tasks/route.ts
+++ b/ui/app/api/tasks/route.ts
@@ -3,6 +3,7 @@
 import { NextResponse } from 'next/server'
 import getDb from '@/lib/db'
 import { localDayBounds, todayString } from '@/lib/date-utils'
+import { sessionInterval, unionSeconds } from '@/lib/intervals'
 
 export const dynamic = 'force-dynamic'
 
@@ -42,40 +43,58 @@ export async function GET() {
       ORDER BY task_key DESC
     `).all() as Array<Record<string, unknown>>
 
-    // today session + task associations
+    // Per-task time is the UNION of every session linked to the task, across
+    // BOTH recording streams — foreground screen capture AND the coding-agent
+    // transcript overlay. The two streams record the same wall-clock from two
+    // angles, so SUMMING duration_s double-counts every overlapping second
+    // (and lets a parked-open agent window inflate a task to impossible hours).
+    // `sessionInterval` caps agent rows to their engaged duration; `unionSeconds`
+    // then counts overlapping time once and agent-only time still counts.
+    interface SessionRow { started_at: string; ended_at: string; duration_s: number; claude_session_uuid: string | null; category: string | null; task_key: string }
+
     const todaySessions = db.prepare(`
-      SELECT s.id, s.duration_s, s.category, s.task_key
+      SELECT s.started_at, s.ended_at, s.duration_s, s.claude_session_uuid, s.category, s.task_key
       FROM app_sessions s
       WHERE s.started_at >= ? AND s.started_at < ?
         AND s.task_session_type = 'task'
         AND s.task_key IS NOT NULL
-    `).all(todayStart, todayEnd) as Array<Record<string, unknown>>
+    `).all(todayStart, todayEnd) as SessionRow[]
 
-    // week sessions
     const weekSessions = db.prepare(`
-      SELECT s.duration_s, s.task_key
+      SELECT s.started_at, s.ended_at, s.duration_s, s.claude_session_uuid, s.task_key
       FROM app_sessions s
       WHERE s.started_at >= ? AND s.started_at < ?
         AND s.task_session_type = 'task'
         AND s.task_key IS NOT NULL
-    `).all(ws, todayEnd) as Array<Record<string, unknown>>
+    `).all(ws, todayEnd) as SessionRow[]
 
-    // build aggregations
+    // group rows by task, then union each group's intervals
+    const todayRowsByTask: Record<string, SessionRow[]> = {}
+    todaySessions.forEach(s => { (todayRowsByTask[s.task_key] ??= []).push(s) })
+    const weekRowsByTask: Record<string, SessionRow[]> = {}
+    weekSessions.forEach(s => { (weekRowsByTask[s.task_key] ??= []).push(s) })
+
     const todayByTask: Record<string, { dur: number; sessions: number; cats: Record<string, number> }> = {}
-    todaySessions.forEach(s => {
-      const k = s.task_key as string
-      if (!todayByTask[k]) todayByTask[k] = { dur: 0, sessions: 0, cats: {} }
-      todayByTask[k].dur += s.duration_s as number
-      todayByTask[k].sessions++
-      const cat = (s.category as string) || 'idle_personal'
-      todayByTask[k].cats[cat] = (todayByTask[k].cats[cat] ?? 0) + (s.duration_s as number)
-    })
+    for (const [k, rows] of Object.entries(todayRowsByTask)) {
+      // Category split is the FOREGROUND share only — the agent overlay is the
+      // same work from a second angle, so folding its raw duration in here would
+      // re-introduce the double-count the union exists to prevent.
+      const cats: Record<string, number> = {}
+      rows.filter(r => r.claude_session_uuid == null).forEach(r => {
+        const cat = r.category || 'idle_personal'
+        cats[cat] = (cats[cat] ?? 0) + r.duration_s
+      })
+      todayByTask[k] = {
+        dur: unionSeconds(rows.map(sessionInterval)),
+        sessions: rows.length,
+        cats,
+      }
+    }
 
     const weekByTask: Record<string, number> = {}
-    weekSessions.forEach(s => {
-      const k = s.task_key as string
-      weekByTask[k] = (weekByTask[k] ?? 0) + (s.duration_s as number)
-    })
+    for (const [k, rows] of Object.entries(weekRowsByTask)) {
+      weekByTask[k] = unionSeconds(rows.map(sessionInterval))
+    }
 
     // unassigned today
     const unassigned = db.prepare(`

--- a/ui/app/api/today/route.ts
+++ b/ui/app/api/today/route.ts
@@ -3,7 +3,7 @@
 import { NextResponse } from 'next/server'
 import getDb from '@/lib/db'
 import { localDayBounds, todayString } from '@/lib/date-utils'
-import { unionSeconds, intersectSeconds, mergeIntervals, countSwitches, type Interval } from '@/lib/intervals'
+import { unionSeconds, intersectSeconds, mergeIntervals, countSwitches, sessionInterval, type Interval } from '@/lib/intervals'
 
 export const dynamic = 'force-dynamic'
 
@@ -73,6 +73,14 @@ export interface TodayResponse {
   // ── Counts ───────────────────────────────────────────────────────────────
   session_count: number  // foreground sessions only
   switch_count: number   // genuine context switches in the foreground stream
+  // ── Per-task totals ────────────────────────────────────────────────────────
+  // task_key → UNION of total time on the task across BOTH streams (foreground +
+  // capped coding-agent overlay). This is the authoritative per-task figure the
+  // "By task" buckets and the Tasks page both render, so the two views agree.
+  task_totals: Record<string, number>
+  // engaged_s: focus_s + autonomous agent time — the denominator for the per-task
+  // "% of day" so a task carrying autonomous agent work never exceeds 100%.
+  engaged_s: number
 }
 
 export async function GET() {
@@ -220,6 +228,24 @@ export async function GET() {
       SWITCH_MIN_DURATION_S,
     )
 
+    // ── Per-task union totals (foreground + capped agent overlay) ──────────────
+    // Built from allRows (both streams) so a task's figure matches the Tasks page
+    // exactly. Same filter as /api/tasks: a real task link, session_type = 'task'.
+    const taskIntervals: Record<string, Interval[]> = {}
+    allRows.forEach(r => {
+      if (r.task_key == null || r.session_type !== 'task') return
+      const k = r.task_key as string
+      ;(taskIntervals[k] ??= []).push(sessionInterval({
+        started_at: r.started_at as string,
+        ended_at: r.ended_at as string,
+        duration_s: (r.duration_s as number) ?? 0,
+        claude_session_uuid: (r.claude_session_uuid as string) ?? null,
+      }))
+    })
+    const task_totals: Record<string, number> = {}
+    for (const [k, ivs] of Object.entries(taskIntervals)) task_totals[k] = unionSeconds(ivs)
+    const engaged_s = focus_s + autonomous_s
+
     const resp: TodayResponse = {
       date,
       sessions,
@@ -234,6 +260,8 @@ export async function GET() {
       agent_segments,
       session_count: sessions.length + (active ? 1 : 0),
       switch_count,
+      task_totals,
+      engaged_s,
     }
 
     return NextResponse.json(resp)
@@ -244,6 +272,7 @@ export async function GET() {
       focus_s: 0, idle_s: 0, agent_s: 0, supervised_s: 0, autonomous_s: 0,
       presence_segments: [], agent_segments: [],
       session_count: 0, switch_count: 0,
+      task_totals: {}, engaged_s: 0,
     } satisfies TodayResponse)
   }
 }

--- a/ui/components/views/TodayView.tsx
+++ b/ui/components/views/TodayView.tsx
@@ -349,8 +349,10 @@ export default function TodayView({ onNavigate }: { onNavigate?: (v: string, key
     )
   }
 
-  // Build buckets
-  const total_s = data.focus_s
+  // Build buckets. The "% of day" denominator is total ENGAGED time (your
+  // foreground presence + autonomous agent time), so a task carrying agent work
+  // never exceeds 100%. Falls back to focus_s on older API responses.
+  const total_s = data.engaged_s || data.focus_s
   const bucketMap = new Map<string, Bucket>()
 
   function pushToBucket(key: string, session: BucketSession) {
@@ -379,18 +381,27 @@ export default function TodayView({ onNavigate }: { onNavigate?: (v: string, key
     pushToBucket('_active', ab)
   }
 
-  const buckets = Array.from(bucketMap.values()).map(b => ({
-    ...b,
-    isOverhead: b.key === '_overhead',
-    isUntracked: b.key === '_untracked',
-    isQueue: b.key === '_queue',
-    title: b.key === '_overhead'  ? 'Overhead — comms, mail, planning'
-         : b.key === '_untracked' ? 'Untracked — personal, idle, unclassified'
-         : b.key === '_queue'     ? 'Sessions waiting to be assigned'
-         : b.key === '_active'    ? 'Current session'
-         : b.key,
-    day_total_s: total_s,
-  })).sort((a, b) => {
+  const buckets = Array.from(bucketMap.values()).map(b => {
+    // For a real task bucket, the headline time is the UNION of total time on
+    // the task (foreground + capped agent overlay) computed server-side — the
+    // same figure the Tasks page shows, so the two views always agree. Pushing
+    // foreground session durs above only filled `b.total_s` as a fallback.
+    const isTask = !b.key.startsWith('_')
+    const total = isTask ? (data.task_totals[b.key] ?? b.total_s) : b.total_s
+    return {
+      ...b,
+      total_s: total,
+      isOverhead: b.key === '_overhead',
+      isUntracked: b.key === '_untracked',
+      isQueue: b.key === '_queue',
+      title: b.key === '_overhead'  ? 'Overhead — comms, mail, planning'
+           : b.key === '_untracked' ? 'Untracked — personal, idle, unclassified'
+           : b.key === '_queue'     ? 'Sessions waiting to be assigned'
+           : b.key === '_active'    ? 'Current session'
+           : b.key,
+      day_total_s: total_s,
+    }
+  }).sort((a, b) => {
     const ord = (k: string) =>
       k === '_queue' ? 10 : k === '_untracked' ? 9 : k === '_overhead' ? 8 : k === '_active' ? -1 : 0
     return (ord(a.key) - ord(b.key)) || (b.total_s - a.total_s)

--- a/ui/lib/intervals.ts
+++ b/ui/lib/intervals.ts
@@ -46,6 +46,31 @@ export function unionSeconds(intervals: Interval[]): number {
 }
 
 /**
+ * Wall-clock interval for one `app_sessions` row, normalised across the two
+ * recording streams. A foreground screen-capture row (`claude_session_uuid`
+ * IS NULL) uses its real `[started_at, ended_at]` span. A coding-agent
+ * transcript row is capped to its engaged `duration_s` anchored at the start,
+ * so a parked-open Claude/Codex window can't masquerade as hours of activity.
+ *
+ * Feeding a task's rows from BOTH streams through this and then `unionSeconds`
+ * yields the honest "total time spent on the task" — overlapping foreground and
+ * agent time counted once, agent-only time still counted.
+ */
+export function sessionInterval(row: {
+  started_at: string
+  ended_at: string
+  duration_s: number
+  claude_session_uuid: string | null
+}): Interval {
+  if (row.claude_session_uuid != null) {
+    const startMs = new Date(row.started_at).getTime()
+    const endMs = startMs + Math.max(0, row.duration_s ?? 0) * 1000
+    return { started_at: row.started_at, ended_at: new Date(endMs).toISOString() }
+  }
+  return { started_at: row.started_at, ended_at: row.ended_at }
+}
+
+/**
  * Merge a set of intervals into a disjoint, ascending list — the timeline's
  * presence/agent bands are drawn from these so overlapping rows render as one
  * continuous block rather than stacked duplicates.


### PR DESCRIPTION
## The bug

The home **"By task / Where your time went"** and the Tasks page **"What you're working on"** showed *different* per-task time — sometimes by hours. E.g. **KAN-142 showed ~9h** on the Tasks page (impossible in the day) while the home view showed ~2h, and agent-only tasks like **KAN-65 appeared on the Tasks page but vanished from home**.

## Root cause

`app_sessions` interleaves two recordings of the **same wall-clock**:
- foreground screen-capture (`claude_session_uuid IS NULL`)
- coding-agent transcript overlay — Claude Code / Codex (`claude_session_uuid IS NOT NULL`)

`/api/tasks` **summed** `duration_s` across both streams → double-counted every overlapping second (and a parked-open agent window inflated tasks to impossible totals). `/api/today` **excluded** the overlay entirely → undercounted, and agent-only tasks disappeared.

## Fix — one shared definition

Per-task time is now the **UNION of total time on the task across both streams**: overlapping time counted once, agent-only time still counted.

- New `sessionInterval()` helper in `lib/intervals.ts` caps agent rows to their engaged `duration_s`; `unionSeconds()` merges.
- `/api/tasks`: `today_s` / `week_s` are interval unions, not sums.
- `/api/today`: exposes `task_totals` (the same per-task union) + `engaged_s` (focus + autonomous agent time).
- `TodayView`: "By task" buckets render `task_totals`; "% of day" is measured against `engaged_s` so a task carrying autonomous agent work never exceeds 100%.

## Verified against the live DB

Both endpoints now return **identical** per-task figures:

| Task | Tasks page | Home `task_totals` |
|---|---|---|
| KAN-142 | 23,440 | 23,440 ✅ |
| KAN-64 | 3,947 | 3,947 ✅ |
| KAN-67 | 2,440 | 2,440 ✅ |
| KAN-65 | 1,730 | 1,730 ✅ (no longer phantom) |
| KAN-109 / 134 / 135 | 387 / 191 / 117 | 387 / 191 / 117 ✅ |

KAN-142's impossible ~9h collapses to its true ~6.5h union.

## Checks
- `npm run build` (UI typecheck) ✅
- Full pre-push suite: fmt + clippy + cargo test + UI build + UI tests + security audit ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)