### PR TITLE
fix(ui): per-task time = your time + autonomous agent (numbers that add up)

### DIFF
--- a/ui/app/api/tasks/route.ts
+++ b/ui/app/api/tasks/route.ts
@@ -3,7 +3,7 @@
 import { NextResponse } from 'next/server'
 import getDb from '@/lib/db'
 import { localDayBounds, todayString } from '@/lib/date-utils'
-import { sessionInterval, unionSeconds } from '@/lib/intervals'
+import { sessionInterval, unionSeconds, intersectSeconds, mergeIntervals, type Interval } from '@/lib/intervals'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,6 +15,7 @@ export interface TaskSummary {
   provider: string
   url: string
   today_s: number
+  today_autonomous_s: number  // agent time on the task that ran while you were away
   week_s: number
   session_count: number
   cats: Record<string, number>
@@ -43,57 +44,67 @@ export async function GET() {
       ORDER BY task_key DESC
     `).all() as Array<Record<string, unknown>>
 
-    // Per-task time is the UNION of every session linked to the task, across
-    // BOTH recording streams — foreground screen capture AND the coding-agent
-    // transcript overlay. The two streams record the same wall-clock from two
-    // angles, so SUMMING duration_s double-counts every overlapping second
-    // (and lets a parked-open agent window inflate a task to impossible hours).
-    // `sessionInterval` caps agent rows to their engaged duration; `unionSeconds`
-    // then counts overlapping time once and agent-only time still counts.
+    // A task's time = YOUR hands-on time on it + the agent time that ran while
+    // you were AWAY (autonomous). Agent time alongside you (supervised) is not
+    // added — that wall-clock is already your presence, and adding it would
+    // double-count the day and inflate a task past your Focus. So we need your
+    // full presence (every foreground session, task or not) to tell autonomous
+    // from supervised agent time.
     interface SessionRow { started_at: string; ended_at: string; duration_s: number; claude_session_uuid: string | null; category: string | null; task_key: string }
 
-    const todaySessions = db.prepare(`
-      SELECT s.started_at, s.ended_at, s.duration_s, s.claude_session_uuid, s.category, s.task_key
-      FROM app_sessions s
-      WHERE s.started_at >= ? AND s.started_at < ?
-        AND s.task_session_type = 'task'
-        AND s.task_key IS NOT NULL
-    `).all(todayStart, todayEnd) as SessionRow[]
+    const fgPresenceRows = (start: string, end: string) =>
+      (db.prepare(`
+        SELECT s.started_at, s.ended_at, s.duration_s, s.claude_session_uuid, s.category, s.task_key
+        FROM app_sessions s
+        WHERE s.started_at >= ? AND s.started_at < ? AND s.claude_session_uuid IS NULL
+      `).all(start, end) as SessionRow[])
+        .map(r => ({ started_at: r.started_at, ended_at: r.ended_at }))
 
-    const weekSessions = db.prepare(`
-      SELECT s.started_at, s.ended_at, s.duration_s, s.claude_session_uuid, s.task_key
-      FROM app_sessions s
-      WHERE s.started_at >= ? AND s.started_at < ?
-        AND s.task_session_type = 'task'
-        AND s.task_key IS NOT NULL
-    `).all(ws, todayEnd) as SessionRow[]
+    const todayPresence = mergeIntervals(fgPresenceRows(todayStart, todayEnd))
+    const weekPresence = mergeIntervals(fgPresenceRows(ws, todayEnd))
 
-    // group rows by task, then union each group's intervals
+    const taskSessions = (start: string, end: string) =>
+      db.prepare(`
+        SELECT s.started_at, s.ended_at, s.duration_s, s.claude_session_uuid, s.category, s.task_key
+        FROM app_sessions s
+        WHERE s.started_at >= ? AND s.started_at < ?
+          AND s.task_session_type = 'task'
+          AND s.task_key IS NOT NULL
+      `).all(start, end) as SessionRow[]
+
+    const todaySessions = taskSessions(todayStart, todayEnd)
+    const weekSessions = taskSessions(ws, todayEnd)
+
+    // your time on the task + autonomous agent time (agent intervals outside presence)
+    const taskTime = (rows: SessionRow[], presence: Interval[]) => {
+      const fg = rows.filter(r => r.claude_session_uuid == null).map(sessionInterval)
+      const agent = rows.filter(r => r.claude_session_uuid != null).map(sessionInterval)
+      const your_s = unionSeconds(fg)
+      const autonomous_s = Math.max(0, unionSeconds(agent) - intersectSeconds(agent, presence))
+      return { your_s, autonomous_s, total_s: your_s + autonomous_s }
+    }
+
     const todayRowsByTask: Record<string, SessionRow[]> = {}
     todaySessions.forEach(s => { (todayRowsByTask[s.task_key] ??= []).push(s) })
     const weekRowsByTask: Record<string, SessionRow[]> = {}
     weekSessions.forEach(s => { (weekRowsByTask[s.task_key] ??= []).push(s) })
 
-    const todayByTask: Record<string, { dur: number; sessions: number; cats: Record<string, number> }> = {}
+    const todayByTask: Record<string, { dur: number; autonomous_s: number; sessions: number; cats: Record<string, number> }> = {}
     for (const [k, rows] of Object.entries(todayRowsByTask)) {
-      // Category split is the FOREGROUND share only — the agent overlay is the
-      // same work from a second angle, so folding its raw duration in here would
-      // re-introduce the double-count the union exists to prevent.
+      // Category split is the FOREGROUND share only — proportions for the bar.
+      const fgRows = rows.filter(r => r.claude_session_uuid == null)
       const cats: Record<string, number> = {}
-      rows.filter(r => r.claude_session_uuid == null).forEach(r => {
+      fgRows.forEach(r => {
         const cat = r.category || 'idle_personal'
         cats[cat] = (cats[cat] ?? 0) + r.duration_s
       })
-      todayByTask[k] = {
-        dur: unionSeconds(rows.map(sessionInterval)),
-        sessions: rows.length,
-        cats,
-      }
+      const t = taskTime(rows, todayPresence)
+      todayByTask[k] = { dur: t.total_s, autonomous_s: t.autonomous_s, sessions: fgRows.length, cats }
     }
 
     const weekByTask: Record<string, number> = {}
     for (const [k, rows] of Object.entries(weekRowsByTask)) {
-      weekByTask[k] = unionSeconds(rows.map(sessionInterval))
+      weekByTask[k] = taskTime(rows, weekPresence).total_s
     }
 
     // unassigned today
@@ -115,6 +126,7 @@ export async function GET() {
         provider: (t.provider as string) || 'jira',
         url: (t.url as string) || '',
         today_s: agg?.dur ?? 0,
+        today_autonomous_s: agg?.autonomous_s ?? 0,
         week_s: weekByTask[k] ?? 0,
         session_count: agg?.sessions ?? 0,
         cats: agg?.cats ?? {},

--- a/ui/app/api/today/route.ts
+++ b/ui/app/api/today/route.ts
@@ -78,6 +78,10 @@ export interface TodayResponse {
   // capped coding-agent overlay). This is the authoritative per-task figure the
   // "By task" buckets and the Tasks page both render, so the two views agree.
   task_totals: Record<string, number>
+  // task_key → autonomous agent time on the task (agent ran while you were away).
+  // This is the slice that lifts a task above your own hands-on time; surfaced as
+  // "+ Xm agent while you were away", and only when there is some.
+  task_autonomous_s: Record<string, number>
   // engaged_s: focus_s + autonomous agent time — the denominator for the per-task
   // "% of day" so a task carrying autonomous agent work never exceeds 100%.
   engaged_s: number
@@ -228,22 +232,38 @@ export async function GET() {
       SWITCH_MIN_DURATION_S,
     )
 
-    // ── Per-task union totals (foreground + capped agent overlay) ──────────────
-    // Built from allRows (both streams) so a task's figure matches the Tasks page
-    // exactly. Same filter as /api/tasks: a real task link, session_type = 'task'.
-    const taskIntervals: Record<string, Interval[]> = {}
+    // ── Per-task time = YOUR hands-on time + AUTONOMOUS agent time ─────────────
+    // A task's total is the time it genuinely consumed: your foreground time on
+    // it, PLUS the coding-agent's time that ran while you were away (autonomous).
+    // Agent time that ran while you were active (supervised) is NOT added — that
+    // wall-clock is already your presence, so adding it would double-count the
+    // day and push a single task past your Focus. With this split, per-task
+    // totals + overhead + untracked sum to engaged time, and the only thing that
+    // lifts a task above your own time is autonomous AI — which we surface.
+    const taskFgIntervals: Record<string, Interval[]> = {}
+    const taskAgentIntervals: Record<string, Interval[]> = {}
     allRows.forEach(r => {
       if (r.task_key == null || r.session_type !== 'task') return
       const k = r.task_key as string
-      ;(taskIntervals[k] ??= []).push(sessionInterval({
+      const iv = sessionInterval({
         started_at: r.started_at as string,
         ended_at: r.ended_at as string,
         duration_s: (r.duration_s as number) ?? 0,
         claude_session_uuid: (r.claude_session_uuid as string) ?? null,
-      }))
+      })
+      if (r.claude_session_uuid == null) (taskFgIntervals[k] ??= []).push(iv)
+      else (taskAgentIntervals[k] ??= []).push(iv)
     })
     const task_totals: Record<string, number> = {}
-    for (const [k, ivs] of Object.entries(taskIntervals)) task_totals[k] = unionSeconds(ivs)
+    const task_autonomous_s: Record<string, number> = {}
+    const taskKeys = new Set([...Object.keys(taskFgIntervals), ...Object.keys(taskAgentIntervals)])
+    for (const k of taskKeys) {
+      const yourS = unionSeconds(taskFgIntervals[k] ?? [])
+      const agentIv = taskAgentIntervals[k] ?? []
+      const autoS = Math.max(0, unionSeconds(agentIv) - intersectSeconds(agentIv, presence_segments))
+      task_totals[k] = yourS + autoS
+      task_autonomous_s[k] = autoS
+    }
     const engaged_s = focus_s + autonomous_s
 
     const resp: TodayResponse = {
@@ -261,6 +281,7 @@ export async function GET() {
       session_count: sessions.length + (active ? 1 : 0),
       switch_count,
       task_totals,
+      task_autonomous_s,
       engaged_s,
     }
 
@@ -272,7 +293,7 @@ export async function GET() {
       focus_s: 0, idle_s: 0, agent_s: 0, supervised_s: 0, autonomous_s: 0,
       presence_segments: [], agent_segments: [],
       session_count: 0, switch_count: 0,
-      task_totals: {}, engaged_s: 0,
+      task_totals: {}, task_autonomous_s: {}, engaged_s: 0,
     } satisfies TodayResponse)
   }
 }

--- a/ui/components/views/TasksView.tsx
+++ b/ui/components/views/TasksView.tsx
@@ -141,6 +141,12 @@ function TaskDetail({ task, sessions }: { task: TaskSummary; sessions: TodayResp
         <div className="px-5 py-4">
           <p className="text-[10px] uppercase tracking-[0.16em] mb-2" style={{ color: 'var(--ink-3)' }}>Today</p>
           <p className="font-mono tnum text-[22px] leading-none" style={{ color: 'var(--ink)' }}>{fmtDur(task.today_s)}</p>
+          {task.today_autonomous_s >= 60 && (
+            <p className="text-[10px] mt-1.5" style={{ color: 'var(--live)' }}
+              title="Of today's total, the agent ran on its own while you were away — the part that adds time beyond your own.">
+              +{fmtDur(task.today_autonomous_s)} agent while away
+            </p>
+          )}
         </div>
         <div className="px-5 py-4 rule-l" style={{ borderLeftColor: 'var(--rule)' }}>
           <p className="text-[10px] uppercase tracking-[0.16em] mb-2" style={{ color: 'var(--ink-3)' }}>This week</p>

--- a/ui/components/views/TodayView.tsx
+++ b/ui/components/views/TodayView.tsx
@@ -32,6 +32,7 @@ interface Bucket {
   title: string
   sessions: BucketSession[]
   total_s: number
+  autonomous_s: number  // agent time that ran while you were away (0 for non-task buckets)
   cats: Set<string>
   day_total_s: number
   isOverhead: boolean
@@ -205,7 +206,15 @@ function BucketRow({ bucket }: { bucket: Bucket }) {
         </div>
         <div className="text-right">
           <p className="font-mono tnum text-[18px] leading-none" style={{ color: 'var(--ink)' }}>{fmtDur(bucket.total_s)}</p>
-          <p className="text-[11px] mt-1.5" style={{ color: 'var(--ink-3)' }}>{pct}% of day</p>
+          <p className="text-[11px] mt-1.5" style={{ color: 'var(--ink-3)' }}>
+            {pct}% of day
+            {bucket.autonomous_s >= 60 && (
+              <span style={{ color: 'var(--live)' }}
+                title="Of this total, the agent ran on its own while you were away from the keyboard — the part that adds time beyond your own.">
+                {' · +'}{fmtDur(bucket.autonomous_s)} agent while away
+              </span>
+            )}
+          </p>
         </div>
       </button>
 
@@ -247,13 +256,15 @@ function buildStory(data: TodayResponse): string | null {
   const { sessions, active } = data
   if (sessions.length === 0 && !active) return null
 
-  const taskMap = new Map<string, { dur: number; cats: string[] }>()
+  // Durations come from task_totals (your time + autonomous agent) so the
+  // narrative matches the "By task" buckets exactly; categories come from the
+  // foreground sessions for the verb choice.
+  const taskMap = new Map<string, { dur: number; auto: number; cats: string[] }>()
   sessions.forEach(s => {
     const key = s.task_key
     if (!key) return
-    if (!taskMap.has(key)) taskMap.set(key, { dur: 0, cats: [] })
+    if (!taskMap.has(key)) taskMap.set(key, { dur: data.task_totals[key] ?? 0, auto: data.task_autonomous_s[key] ?? 0, cats: [] })
     const e = taskMap.get(key)!
-    e.dur += s.dur
     if (!e.cats.includes(s.cat)) e.cats.push(s.cat)
   })
 
@@ -288,7 +299,9 @@ function buildStory(data: TodayResponse): string | null {
   const clauses: string[] = []
   tasks.forEach(([key, info], i) => {
     const dur = fmtDur(info.dur)
-    if (i === 0) clauses.push(`${verbFor(info.cats, info.dur)} ${key} for ${dur}`)
+    // Call out autonomous agent help on the lead task — the standout insight.
+    const aside = i === 0 && info.auto >= 600 ? ` (${fmtDur(info.auto)} of it the agent, solo)` : ''
+    if (i === 0) clauses.push(`${verbFor(info.cats, info.dur)} ${key} for ${dur}${aside}`)
     else clauses.push(`${dur} on ${key}`)
   })
 
@@ -357,7 +370,7 @@ export default function TodayView({ onNavigate }: { onNavigate?: (v: string, key
 
   function pushToBucket(key: string, session: BucketSession) {
     if (!bucketMap.has(key)) {
-      bucketMap.set(key, { key, title: '', sessions: [], total_s: 0, cats: new Set(), day_total_s: total_s, isOverhead: false, isUntracked: false, isQueue: false })
+      bucketMap.set(key, { key, title: '', sessions: [], total_s: 0, autonomous_s: 0, cats: new Set(), day_total_s: total_s, isOverhead: false, isUntracked: false, isQueue: false })
     }
     const b = bucketMap.get(key)!
     b.sessions.push(session)
@@ -388,9 +401,11 @@ export default function TodayView({ onNavigate }: { onNavigate?: (v: string, key
     // foreground session durs above only filled `b.total_s` as a fallback.
     const isTask = !b.key.startsWith('_')
     const total = isTask ? (data.task_totals[b.key] ?? b.total_s) : b.total_s
+    const autonomous_s = isTask ? (data.task_autonomous_s[b.key] ?? 0) : 0
     return {
       ...b,
       total_s: total,
+      autonomous_s,
       isOverhead: b.key === '_overhead',
       isUntracked: b.key === '_untracked',
       isQueue: b.key === '_queue',


### PR DESCRIPTION
Follow-up to #100.

## Problem
The union total from #100 double-counted agent time that overlapped your work on **other** tasks. Symptoms:
- **KAN-142 read 6h 44m while Focus was only 6h 12m** — a single task appeared larger than your whole focused day.
- The "By task" **percentages summed past 100%** (≈128%).
- The home **"story" line disagreed with the buckets** (2h 38m vs 6h 44m for the same task).
- The "incl. agent" label lumped in supervised time, so it didn't explain what actually *increased* the number.

## Fix — per-task time = your time + autonomous agent
A task's time is what it genuinely consumed: **your foreground time** on it **plus the agent time that ran while you were away** (autonomous). Supervised agent time (alongside you) is *not* added — that wall-clock is already your presence, so adding it double-counts the day.

Result (verified against the live DB):

| Task | Total (you + autonomous) | Label | % of day |
|---|---|---|---|
| KAN-142 | **4h 56m** (was 6h 44m) | +2h 16m agent while away | 55% |
| KAN-64 | 0h 50m | +8m agent while away | 9% |
| KAN-67 | 0h 10m | +3m agent while away | 1% |
| KAN-65 | 0h 03m | +3m agent while away | — |
| KAN-109/134/135 | 6m/3m/1m | *(no label — no autonomous AI)* | — |

- Task totals + overhead + untracked now **sum to engaged time** (~100%, no overflow).
- A task can **no longer exceed Focus** from supervised overlap.
- The only lift above your own time is **autonomous AI**, surfaced as **"+Xm agent while away"** — shown **only** when there is autonomous work, never a blanket "incl. agent".
- The home **story line and the buckets render the same totals**.

## API
- `/api/today` → `task_totals` (your + autonomous) and `task_autonomous_s` (renamed from `task_agent_s`).
- `/api/tasks` → `today_s` (your + autonomous) and `today_autonomous_s`, computed against your day/week presence.

## Checks
- `npm run build` (UI typecheck) ✅
- Full pre-push suite (fmt + clippy + cargo test + UI build + UI tests + security audit) ✅
- Verified live: both endpoints return identical per-task totals; sums reconcile to engaged time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)