### PR TITLE
feat(worklog): Linear & GitHub worklog providers alongside Jira

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,15 +33,21 @@
 # JIRA_PROJECT_KEYS=KAN,ENG          # optional — comma-separated; empty = all projects
 
 # ---------------------------------------------------------------------------
-# PM worklog (Stage 4) — Jira worklogs from classified sessions.
+# PM worklog (Stage 4) — worklogs from classified sessions, for whichever
+# tracker is configured above (Jira, Linear, or GitHub).
 # Runs inside the Rust daemon: one hour-driven worklog per task per hour,
 # synthesised via the MLX server's /synthesise_worklog endpoint. Requires the
 # MLX server (it hosts the synth agent).
+#
+# How each tracker records a worklog:
+#   Jira   — native worklog API (time spent + comment).
+#   Linear — a structured comment on the issue (Linear has no time-tracking API).
+#   GitHub — a structured comment on the issue (GitHub has no time tracking).
 # ---------------------------------------------------------------------------
 
-# Nothing posts to Jira automatically. The daemon DRAFTS worklogs every hour;
-# you review, edit, and approve each one in the dashboard (Worklogs view), and
-# the daemon posts approved worklogs within ~60s. Approval is the only gate —
+# Nothing posts to your tracker automatically. The daemon DRAFTS worklogs every
+# hour; you review, edit, and approve each one in the dashboard (Worklogs view),
+# and the daemon posts approved worklogs within ~60s. Approval is the only gate —
 # there is no auto-post switch.
 
 # Driver cadence in hours (clamped to a 60s floor). Default 1.0.
@@ -62,19 +68,29 @@
 # PM_WORKLOG_SYNTH_TIMEOUT_S=300
 
 # ---------------------------------------------------------------------------
-# GitHub (both required to enable the GitHub connector)
+# GitHub (GITHUB_TOKEN + GITHUB_ORG required to enable the GitHub connector)
+# Syncs the OPEN issues assigned to you under GITHUB_ORG; logs worklogs as
+# structured issue comments (GitHub has no native time tracking).
+# Token: Settings > Developer settings > Personal access tokens. A classic token
+# with the `repo` scope is simplest (works for personal + org issues); a
+# fine-grained token needs Issues: Read and write on the relevant repos.
+# GITHUB_ORG is the issue owner — an org slug OR your own username.
 # ---------------------------------------------------------------------------
 
 # GITHUB_TOKEN=ghp_your_personal_access_token
 # GITHUB_ORG=your-org
-# GITHUB_REPOS=your-org/api,your-org/web  # optional — comma-separated; empty = all org repos
+# GITHUB_REPOS=your-org/api,your-org/web  # optional — comma-separated owner/repo; empty = all repos under the owner
 
 # ---------------------------------------------------------------------------
-# Linear (required to enable the Linear connector)
+# Linear (LINEAR_API_KEY required to enable the Linear connector)
+# Syncs the issues assigned to you; logs worklogs as structured issue comments
+# (Linear has no native time-tracking API).
+# Key: linear.app > Settings > Account > Security & access > Personal API keys.
+# Sent raw in the Authorization header (no "Bearer" prefix).
 # ---------------------------------------------------------------------------
 
 # LINEAR_API_KEY=lin_api_your_key_here
-# LINEAR_TEAM_IDS=TEAM1,TEAM2        # optional — comma-separated; empty = all teams
+# LINEAR_TEAM_IDS=ENG,DESIGN          # optional — comma-separated team KEY or id; empty = all teams
 
 # ---------------------------------------------------------------------------
 # Python LLM backend — cloud fallback for the coding-agent summariser (Claude/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "meridian"
-version = "1.4.1"
+version = "1.4.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/SETUP.md
+++ b/SETUP.md
@@ -41,25 +41,49 @@ After granting, run `meridian restart`.
 
 ---
 
-## 3. Connect Jira (optional, but it's the point)
+## 3. Connect your issue tracker (optional, but it's the point)
 
-Meridian drafts worklogs against your Jira tickets. To enable:
+Meridian drafts worklogs against the tickets you're assigned. It supports **Jira, Linear, and GitHub** — pick the one you use (you can configure more than one, but most people use a single tracker). Open the config with `meridian config edit` and add the block for your tracker, then `meridian restart`.
+
+### Jira
 
 1. Create an API token at **https://id.atlassian.com/manage-profile/security/api-tokens**.
-2. Open the config and add three lines:
-   ```bash
-   meridian config edit
-   ```
+2. Add:
    ```dotenv
    JIRA_BASE_URL=https://your-org.atlassian.net
    JIRA_EMAIL=you@your-org.com
    JIRA_API_TOKEN=your-api-token
+   # JIRA_PROJECT_KEYS=KAN,ENG   # optional filter; empty = all projects
    ```
-3. Restart: `meridian restart`.
 
-> GitHub and Linear are also supported (`GITHUB_TOKEN`/`GITHUB_ORG`, `LINEAR_API_KEY`/`LINEAR_TEAM_IDS`) — same file.
+Meridian syncs the issues assigned to you (`assignee = currentUser()`, not Done) and logs time via Jira's native **worklog** API (time spent + a comment), the way Jira time tracking is meant to work.
 
-**Nothing posts to Jira automatically.** Meridian *drafts* a worklog for each task/hour; you review, edit, and approve each one in the dashboard's **Worklogs** view, and the daemon posts approved worklogs within ~60s. Approval is the only gate — there is no auto-post switch. Check the day's drafts any time with `meridian worklog-status`.
+### Linear
+
+1. Create a **personal API key** at **https://linear.app/settings/account/security** → *Personal API keys*.
+2. Add:
+   ```dotenv
+   LINEAR_API_KEY=lin_api_your_key_here
+   # LINEAR_TEAM_IDS=ENG,DESIGN   # optional filter by team key or id; empty = all teams
+   ```
+
+Meridian syncs the issues assigned to you. **Linear has no native time-tracking API**, so a worklog is posted as a structured comment on the issue — a "⏱ Worklog — 1h 30m" line plus the synthesised narrative — which is Linear's only first-class, per-issue, timestamped record.
+
+### GitHub
+
+1. Create a token at **Settings → Developer settings → Personal access tokens**. A classic token with the **`repo`** scope is the simplest and works for both personal and org issues. (Fine-grained tokens work too: grant **Issues: Read and write** on the repos you care about.)
+2. Add:
+   ```dotenv
+   GITHUB_TOKEN=ghp_your_token
+   GITHUB_ORG=your-org          # the owner whose issues to track (org or your username)
+   # GITHUB_REPOS=your-org/api,your-org/web   # optional filter; empty = all repos under the owner
+   ```
+
+Meridian syncs the open issues assigned to you under that owner. **GitHub has no native time tracking**, so a worklog is posted as a structured comment on the issue (an append-only "⏱ Worklog" ledger entry), which is visible on the issue and on any Project board it belongs to.
+
+---
+
+**Nothing posts automatically — for any tracker.** Meridian *drafts* a worklog for each task/hour; you review, edit, and approve each one in the dashboard's **Worklogs** view, and the daemon posts approved worklogs within ~60s. Approval is the only gate — there is no auto-post switch. Check the day's drafts any time with `meridian worklog-status`.
 
 ---
 
@@ -99,7 +123,7 @@ meridian uninstall   # stop services + remove the CLI (your data in ~/.meridian/
 
 ## Privacy
 
-Everything runs **on your machine**. screenpipe records your screen locally into `~/.screenpipe/` (audio capture is disabled); Meridian reads that and writes to `~/.meridian/meridian.db`. There is no telemetry by default and no outbound network — the **only** thing that ever leaves your Mac is a Jira worklog, and only one you explicitly approved in the dashboard.
+Everything runs **on your machine**. screenpipe records your screen locally into `~/.screenpipe/` (audio capture is disabled); Meridian reads that and writes to `~/.meridian/meridian.db`. There is no telemetry by default and no outbound network — the **only** thing that ever leaves your Mac is a worklog (to Jira, Linear, or GitHub), and only one you explicitly approved in the dashboard.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -644,9 +644,10 @@ if [[ "${NO_DAEMON}" -eq 0 ]]; then
     info "Installing Rust daemon launchd agent..."
     run bash "${REPO_ROOT}/scripts/install-daemon.sh"
     ok "Rust daemon launchd agent installed"
-    # Jira worklogs (Stage 4) and coding-agent ingest both run INSIDE the Rust
+    # Worklogs (Stage 4) and coding-agent ingest both run INSIDE the Rust
     # daemon — no separate launchd agents. Worklogs are only DRAFTED; they post
-    # to Jira only after you approve them in the dashboard (Worklogs view).
+    # to your tracker (Jira/Linear/GitHub) only after you approve them in the
+    # dashboard (Worklogs view).
 
     info "Installing Claude Code coding-agent SessionEnd hook..."
     if ! run bash "${REPO_ROOT}/services/scripts/install-claude-hook.sh"; then
@@ -688,8 +689,9 @@ echo "Required before Jira/GitHub/Linear sync:"
 echo "  <repo>/.env                  # one backend env for the Rust daemon AND Python services"
 echo "  ui/.env.local                # Next.js UI"
 echo ""
-echo "Jira worklogs are DRAFTED only — review, edit, and approve them in the"
-echo "dashboard (Worklogs view); the daemon posts approved worklogs within ~60s."
+echo "Worklogs (Jira/Linear/GitHub) are DRAFTED only — review, edit, and approve"
+echo "them in the dashboard (Worklogs view); the daemon posts approved worklogs"
+echo "within ~60s of approval."
 
 case ":${PATH}:" in
     *":${BIN_DIR}:"*) ;;

--- a/src/intelligence/providers/github.rs
+++ b/src/intelligence/providers/github.rs
@@ -1,14 +1,378 @@
 // meridian — normalises screenpipe activity into structured app sessions
+//
+// GitHub task connector. Pulls the OPEN issues assigned to the authenticated
+// user into `pm_tasks` so the classifier can link sessions to them and the
+// worklog driver can draft against them. Mirrors the Jira/Linear connectors:
+// fetch → filter → upsert → prune, gated by `pm_sync_state`.
+//
+// We use the REST search API (`GET /search/issues?q=assignee:@me is:issue
+// is:open`) which returns the user's assigned issues across every repo they can
+// see, then scope in Rust to the configured org (or the explicit repo list) by
+// parsing each item's `repository_url`. This sidesteps the org-vs-user search
+// qualifier ambiguity (a configured owner may be a personal account or an org).
+//
+// task_key is `owner/repo#number` — the worklog poster parses it back to hit the
+// issue-comments endpoint. GitHub issues have no native time tracking, so a
+// "worklog" is posted as a structured issue comment (see pm_worklog/github.rs).
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use serde::Deserialize;
 use sqlx::SqlitePool;
 
 use crate::config::GitHubConfig;
 
+const SEARCH_URL: &str = "https://api.github.com/search/issues";
+const MAX_RESULTS: usize = 100;
+const SYNC_INTERVAL_MINS: i64 = 5;
+
+// ---------------------------------------------------------------------------
+// REST search response shapes
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct SearchResponse {
+    items: Vec<SearchItem>,
+}
+
+#[derive(Deserialize)]
+struct SearchItem {
+    number: u64,
+    title: String,
+    #[serde(default)]
+    body: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    html_url: Option<String>,
+    repository_url: String,
+    updated_at: String,
+    #[serde(default)]
+    assignee: Option<GhUser>,
+    /// Present only on pull requests — used to skip PRs defensively.
+    #[serde(default)]
+    pull_request: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct GhUser {
+    #[serde(default)]
+    login: Option<String>,
+}
+
+/// One normalised, in-scope issue ready to upsert.
+struct GhTask {
+    task_key: String,
+    repo_slug: String,
+    title: String,
+    body: String,
+    status: &'static str,
+    url: String,
+    updated_at: String,
+    assignee: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Extract `owner/repo` from a `https://api.github.com/repos/owner/repo` URL.
+fn repo_slug_from_url(repository_url: &str) -> Option<String> {
+    let tail = repository_url.split("/repos/").nth(1)?;
+    let mut parts = tail.split('/');
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
+}
+
+/// Decide whether an in-scope item belongs to this connector's configuration.
+/// If explicit repos are configured, the slug must be one of them; otherwise the
+/// repo owner must equal the configured org/user.
+fn in_scope(repo_slug: &str, github: &GitHubConfig) -> bool {
+    if !github.repos.is_empty() {
+        return github.repos.iter().any(|r| r == repo_slug);
+    }
+    repo_slug
+        .split_once('/')
+        .map(|(owner, _)| owner.eq_ignore_ascii_case(&github.org))
+        .unwrap_or(false)
+}
+
+/// Map a GitHub issue state to meridian's status_category. Issues are open or
+/// closed; finer status only exists inside a Project board (not modelled here).
+fn map_state(state: Option<&str>) -> &'static str {
+    match state {
+        Some("closed") => "done",
+        _ => "todo",
+    }
+}
+
+/// Normalise a raw search item into a `GhTask`, or `None` if it is a PR / out of
+/// scope / malformed.
+fn normalise(item: &SearchItem, github: &GitHubConfig) -> Option<GhTask> {
+    if item.pull_request.is_some() {
+        return None; // PRs are not tasks
+    }
+    let repo_slug = repo_slug_from_url(&item.repository_url)?;
+    if !in_scope(&repo_slug, github) {
+        return None;
+    }
+    Some(GhTask {
+        task_key: format!("{repo_slug}#{}", item.number),
+        repo_slug: repo_slug.clone(),
+        title: item.title.clone(),
+        body: item.body.clone().unwrap_or_default(),
+        status: map_state(item.state.as_deref()),
+        url: item
+            .html_url
+            .clone()
+            .unwrap_or_else(|| format!("https://github.com/{repo_slug}/issues/{}", item.number)),
+        updated_at: item.updated_at.clone(),
+        assignee: item.assignee.as_ref().and_then(|u| u.login.clone()),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Fetch
+// ---------------------------------------------------------------------------
+
+#[tracing::instrument(
+    skip(github),
+    fields(provider = "github", status_code = tracing::field::Empty)
+)]
+async fn fetch(github: &GitHubConfig) -> Result<Vec<SearchItem>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(SEARCH_URL)
+        .query(&[
+            ("q", "assignee:@me is:issue is:open archived:false"),
+            ("per_page", "100"),
+            ("sort", "updated"),
+            ("order", "desc"),
+        ])
+        .header("Authorization", format!("Bearer {}", github.token))
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "meridian")
+        .send()
+        .await
+        .context("GET /search/issues")?;
+
+    let status = resp.status();
+    tracing::Span::current().record("status_code", status.as_u16() as i64);
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        anyhow::bail!("GitHub /search/issues → {}: {}", status, text);
+    }
+    let parsed: SearchResponse =
+        serde_json::from_str(&text).context("deserialising GitHub search")?;
+    tracing::debug!(count = parsed.items.len(), "parsed GitHub search response");
+    Ok(parsed.items)
+}
+
+// ---------------------------------------------------------------------------
+// Upsert
+// ---------------------------------------------------------------------------
+
+async fn upsert(pool: &SqlitePool, tasks: &[GhTask]) -> Result<()> {
+    for t in tasks {
+        sqlx::query(
+            "INSERT INTO pm_tasks
+               (task_key, provider, title, description_text, status_category,
+                issue_type, project_key, url, assignee_name, updated_at, fetched_at)
+             VALUES (?, 'github', ?, ?, ?, 'Issue', ?, ?, ?, ?,
+                     strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+             ON CONFLICT(task_key) DO UPDATE SET
+               provider         = 'github',
+               title            = excluded.title,
+               description_text = excluded.description_text,
+               status_category  = excluded.status_category,
+               project_key      = excluded.project_key,
+               url              = excluded.url,
+               assignee_name    = excluded.assignee_name,
+               updated_at       = excluded.updated_at,
+               fetched_at       = excluded.fetched_at",
+        )
+        .bind(&t.task_key)
+        .bind(&t.title)
+        .bind(&t.body)
+        .bind(t.status)
+        .bind(&t.repo_slug)
+        .bind(&t.url)
+        .bind(&t.assignee)
+        .bind(&t.updated_at)
+        .execute(pool)
+        .await
+        .with_context(|| format!("upserting {}", t.task_key))?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Prune (scoped to provider = 'github')
+// ---------------------------------------------------------------------------
+
+async fn prune(pool: &SqlitePool, fetched_keys: &[String]) -> Result<usize> {
+    let placeholders = fetched_keys
+        .iter()
+        .map(|_| "?")
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let emb_sql = format!(
+        "DELETE FROM pm_task_embeddings WHERE task_key IN \
+         (SELECT task_key FROM pm_tasks WHERE provider = 'github' AND task_key NOT IN ({placeholders}))"
+    );
+    let mut q = sqlx::query(&emb_sql);
+    for key in fetched_keys {
+        q = q.bind(key.as_str());
+    }
+    q.execute(pool)
+        .await
+        .context("pruning github pm_task_embeddings")?;
+
+    let task_sql = format!(
+        "DELETE FROM pm_tasks WHERE provider = 'github' AND task_key NOT IN ({placeholders})"
+    );
+    let mut q = sqlx::query(&task_sql);
+    for key in fetched_keys {
+        q = q.bind(key.as_str());
+    }
+    let result = q.execute(pool).await.context("pruning github pm_tasks")?;
+    Ok(result.rows_affected() as usize)
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+#[tracing::instrument(skip(pool, github))]
 pub async fn refresh_if_stale(
-    _pool: &SqlitePool,
-    _github: &GitHubConfig,
+    pool: &SqlitePool,
+    github: &GitHubConfig,
 ) -> Result<Option<Vec<String>>> {
-    // TODO: implement GitHub Issues connector
-    Ok(None)
+    let threshold = format!("-{SYNC_INTERVAL_MINS} minutes");
+    let (is_fresh,): (i64,) = sqlx::query_as(
+        "SELECT EXISTS(
+             SELECT 1 FROM pm_sync_state
+             WHERE provider = 'github'
+               AND last_synced_at > strftime('%Y-%m-%dT%H:%M:%SZ', 'now', ?)
+         )",
+    )
+    .bind(&threshold)
+    .fetch_one(pool)
+    .await
+    .context("checking github sync state")?;
+
+    if is_fresh != 0 {
+        return Ok(None);
+    }
+
+    match fetch(github).await {
+        Ok(items) => {
+            let raw_count = items.len();
+            let tasks: Vec<GhTask> = items.iter().filter_map(|i| normalise(i, github)).collect();
+            let keys: Vec<String> = tasks.iter().map(|t| t.task_key.clone()).collect();
+            upsert(pool, &tasks).await?;
+            sqlx::query(
+                "INSERT INTO pm_sync_state (provider, last_synced_at)
+                 VALUES ('github', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+                 ON CONFLICT(provider) DO UPDATE SET last_synced_at = excluded.last_synced_at",
+            )
+            .execute(pool)
+            .await
+            .context("updating github sync state")?;
+
+            if raw_count < MAX_RESULTS {
+                if !keys.is_empty() {
+                    match prune(pool, &keys).await {
+                        Ok(0) => {}
+                        Ok(p) => tracing::info!(pruned_count = p, "pruned stale github tasks"),
+                        Err(e) => tracing::warn!(error = %e, "github prune failed"),
+                    }
+                } else if let Err(e) = sqlx::query("DELETE FROM pm_tasks WHERE provider = 'github'")
+                    .execute(pool)
+                    .await
+                {
+                    tracing::warn!(error = %e, "github full-clear failed");
+                }
+            }
+            tracing::info!(upserted_count = keys.len(), "github tasks refreshed");
+            Ok(Some(keys))
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "github fetch failed — keeping stale cache");
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(org: &str, repos: &[&str]) -> GitHubConfig {
+        GitHubConfig {
+            token: "x".into(),
+            org: org.into(),
+            repos: repos.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn slug_parsing() {
+        assert_eq!(
+            repo_slug_from_url("https://api.github.com/repos/acme/api").as_deref(),
+            Some("acme/api")
+        );
+        assert_eq!(
+            repo_slug_from_url("https://api.github.com/repos/acme").as_deref(),
+            None
+        );
+        assert_eq!(repo_slug_from_url("garbage").as_deref(), None);
+    }
+
+    #[test]
+    fn scope_by_org_case_insensitive() {
+        assert!(in_scope("Acme/api", &cfg("acme", &[])));
+        assert!(!in_scope("other/api", &cfg("acme", &[])));
+    }
+
+    #[test]
+    fn scope_by_explicit_repos() {
+        let c = cfg("acme", &["acme/api", "acme/web"]);
+        assert!(in_scope("acme/api", &c));
+        assert!(!in_scope("acme/infra", &c)); // not in the list, even though same org
+    }
+
+    #[test]
+    fn state_mapping() {
+        assert_eq!(map_state(Some("open")), "todo");
+        assert_eq!(map_state(Some("closed")), "done");
+        assert_eq!(map_state(None), "todo");
+    }
+
+    #[test]
+    fn normalise_builds_task_key_and_skips_prs() {
+        let item: SearchItem = serde_json::from_str(
+            r#"{"number":42,"title":"Fix it","body":"do x","state":"open",
+                "html_url":"https://github.com/acme/api/issues/42",
+                "repository_url":"https://api.github.com/repos/acme/api",
+                "updated_at":"2026-06-01T00:00:00Z","assignee":{"login":"sam"}}"#,
+        )
+        .unwrap();
+        let t = normalise(&item, &cfg("acme", &[])).unwrap();
+        assert_eq!(t.task_key, "acme/api#42");
+        assert_eq!(t.repo_slug, "acme/api");
+        assert_eq!(t.assignee.as_deref(), Some("sam"));
+
+        let pr: SearchItem = serde_json::from_str(
+            r#"{"number":7,"title":"PR","repository_url":"https://api.github.com/repos/acme/api",
+                "updated_at":"2026-06-01T00:00:00Z","pull_request":{"url":"x"}}"#,
+        )
+        .unwrap();
+        assert!(normalise(&pr, &cfg("acme", &[])).is_none());
+    }
 }

--- a/src/intelligence/providers/linear.rs
+++ b/src/intelligence/providers/linear.rs
@@ -1,14 +1,419 @@
 // meridian — normalises screenpipe activity into structured app sessions
+//
+// Linear task connector. Pulls the issues assigned to the authenticated user
+// (the API key's owner) into `pm_tasks` so the classifier can link sessions to
+// them and the worklog driver can draft against them. Mirrors the Jira connector
+// (`jira.rs`): fetch → filter → upsert → prune, gated by `pm_sync_state`.
+//
+// Linear's API is GraphQL-only (https://api.linear.app/graphql). The personal
+// API key is sent RAW in the `Authorization` header (no `Bearer` prefix). We
+// fetch the viewer's assigned issues and drop completed/canceled ones in Rust
+// (mirrors Jira's `statusCategory != Done`) rather than guessing the server-side
+// IssueFilter shape — the task_key we store is the human identifier (`ENG-123`).
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use serde::Deserialize;
 use sqlx::SqlitePool;
 
 use crate::config::LinearConfig;
 
+const LINEAR_GRAPHQL_URL: &str = "https://api.linear.app/graphql";
+const MAX_RESULTS: usize = 100;
+const SYNC_INTERVAL_MINS: i64 = 5;
+
+// ---------------------------------------------------------------------------
+// GraphQL response shapes
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct GqlResponse {
+    data: Option<ViewerData>,
+    errors: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct ViewerData {
+    viewer: Option<Viewer>,
+}
+
+#[derive(Deserialize)]
+struct Viewer {
+    #[serde(rename = "assignedIssues")]
+    assigned_issues: IssueConnection,
+}
+
+#[derive(Deserialize)]
+struct IssueConnection {
+    nodes: Vec<LinearIssue>,
+}
+
+#[derive(Deserialize)]
+struct LinearIssue {
+    identifier: String,
+    title: String,
+    description: Option<String>,
+    #[serde(rename = "updatedAt")]
+    updated_at: String,
+    url: Option<String>,
+    state: Option<WorkflowState>,
+    team: Option<Team>,
+    parent: Option<Parent>,
+    assignee: Option<NamedUser>,
+}
+
+#[derive(Deserialize)]
+struct WorkflowState {
+    #[serde(rename = "type")]
+    type_: String,
+}
+
+#[derive(Deserialize)]
+struct Team {
+    id: String,
+    key: String,
+}
+
+#[derive(Deserialize)]
+struct Parent {
+    identifier: String,
+    title: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct NamedUser {
+    name: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Map a Linear workflow-state type to meridian's status_category. State types:
+/// backlog | unstarted | started | completed | canceled | triage.
+fn map_state_type(type_: &str) -> &'static str {
+    match type_ {
+        "completed" | "canceled" => "done",
+        "started" => "in_progress",
+        _ => "todo",
+    }
+}
+
+/// True if this issue should be dropped (already finished). Mirrors Jira's
+/// `statusCategory != Done` exclusion so the candidate list stays actionable.
+fn is_finished(issue: &LinearIssue) -> bool {
+    issue
+        .state
+        .as_ref()
+        .map(|s| matches!(s.type_.as_str(), "completed" | "canceled"))
+        .unwrap_or(false)
+}
+
+/// Apply the optional team filter. `team_ids` is matched against BOTH the team
+/// UUID and the team key (e.g. "ENG") so a user can configure either.
+fn team_allowed(issue: &LinearIssue, team_ids: &[String]) -> bool {
+    if team_ids.is_empty() {
+        return true;
+    }
+    match &issue.team {
+        Some(t) => team_ids.iter().any(|w| w == &t.id || w == &t.key),
+        None => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fetch
+// ---------------------------------------------------------------------------
+
+#[tracing::instrument(
+    skip(linear),
+    fields(provider = "linear", status_code = tracing::field::Empty)
+)]
+async fn fetch(linear: &LinearConfig) -> Result<Vec<LinearIssue>> {
+    let query = format!(
+        "query {{ viewer {{ assignedIssues(first: {MAX_RESULTS}) {{ nodes {{ \
+           identifier title description updatedAt url \
+           state {{ type }} team {{ id key }} \
+           parent {{ identifier title }} assignee {{ name }} \
+         }} }} }} }}"
+    );
+    let body = serde_json::json!({ "query": query });
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(LINEAR_GRAPHQL_URL)
+        .header("Authorization", &linear.api_key)
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .context("POST Linear GraphQL")?;
+
+    let status = resp.status();
+    tracing::Span::current().record("status_code", status.as_u16() as i64);
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        anyhow::bail!("Linear GraphQL → {}: {}", status, text);
+    }
+
+    let parsed: GqlResponse =
+        serde_json::from_str(&text).context("deserialising Linear response")?;
+    if let Some(errors) = &parsed.errors {
+        anyhow::bail!("Linear GraphQL errors: {errors}");
+    }
+    let issues = parsed
+        .data
+        .and_then(|d| d.viewer)
+        .map(|v| v.assigned_issues.nodes)
+        .unwrap_or_default();
+    tracing::debug!(count = issues.len(), "parsed Linear response");
+    Ok(issues)
+}
+
+// ---------------------------------------------------------------------------
+// Upsert
+// ---------------------------------------------------------------------------
+
+async fn upsert(
+    pool: &SqlitePool,
+    issues: &[LinearIssue],
+    linear: &LinearConfig,
+) -> Result<Vec<String>> {
+    let mut kept: Vec<String> = Vec::new();
+    for issue in issues {
+        if is_finished(issue) || !team_allowed(issue, &linear.team_ids) {
+            continue;
+        }
+        let status = issue
+            .state
+            .as_ref()
+            .map(|s| map_state_type(&s.type_))
+            .unwrap_or("todo");
+        let description = issue.description.clone().unwrap_or_default();
+        let url = issue.url.clone().unwrap_or_default();
+        let project_key = issue
+            .team
+            .as_ref()
+            .map(|t| t.key.clone())
+            .unwrap_or_default();
+        let (parent_key, epic_title) = issue
+            .parent
+            .as_ref()
+            .map(|p| {
+                (
+                    Some(p.identifier.as_str()),
+                    p.title.clone().unwrap_or_default(),
+                )
+            })
+            .unwrap_or((None, String::new()));
+        let assignee = issue.assignee.as_ref().and_then(|a| a.name.clone());
+
+        sqlx::query(
+            "INSERT INTO pm_tasks
+               (task_key, provider, title, description_text, status_category,
+                issue_type, project_key, url, parent_key, epic_title, assignee_name,
+                updated_at, fetched_at)
+             VALUES (?, 'linear', ?, ?, ?, '', ?, ?, ?, ?, ?, ?,
+                     strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+             ON CONFLICT(task_key) DO UPDATE SET
+               provider         = 'linear',
+               title            = excluded.title,
+               description_text = excluded.description_text,
+               status_category  = excluded.status_category,
+               project_key      = excluded.project_key,
+               url              = excluded.url,
+               parent_key       = excluded.parent_key,
+               epic_title       = excluded.epic_title,
+               assignee_name    = excluded.assignee_name,
+               updated_at       = excluded.updated_at,
+               fetched_at       = excluded.fetched_at",
+        )
+        .bind(&issue.identifier)
+        .bind(&issue.title)
+        .bind(&description)
+        .bind(status)
+        .bind(&project_key)
+        .bind(&url)
+        .bind(parent_key)
+        .bind(if epic_title.is_empty() {
+            None
+        } else {
+            Some(epic_title)
+        })
+        .bind(assignee)
+        .bind(&issue.updated_at)
+        .execute(pool)
+        .await
+        .with_context(|| format!("upserting {}", issue.identifier))?;
+
+        kept.push(issue.identifier.clone());
+    }
+    Ok(kept)
+}
+
+// ---------------------------------------------------------------------------
+// Prune (identical shape to the Jira connector, scoped to provider = 'linear')
+// ---------------------------------------------------------------------------
+
+async fn prune(pool: &SqlitePool, fetched_keys: &[String]) -> Result<usize> {
+    let placeholders = fetched_keys
+        .iter()
+        .map(|_| "?")
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let emb_sql = format!(
+        "DELETE FROM pm_task_embeddings WHERE task_key IN \
+         (SELECT task_key FROM pm_tasks WHERE provider = 'linear' AND task_key NOT IN ({placeholders}))"
+    );
+    let mut q = sqlx::query(&emb_sql);
+    for key in fetched_keys {
+        q = q.bind(key.as_str());
+    }
+    q.execute(pool)
+        .await
+        .context("pruning linear pm_task_embeddings")?;
+
+    let task_sql = format!(
+        "DELETE FROM pm_tasks WHERE provider = 'linear' AND task_key NOT IN ({placeholders})"
+    );
+    let mut q = sqlx::query(&task_sql);
+    for key in fetched_keys {
+        q = q.bind(key.as_str());
+    }
+    let result = q.execute(pool).await.context("pruning linear pm_tasks")?;
+    Ok(result.rows_affected() as usize)
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+#[tracing::instrument(skip(pool, linear))]
 pub async fn refresh_if_stale(
-    _pool: &SqlitePool,
-    _linear: &LinearConfig,
+    pool: &SqlitePool,
+    linear: &LinearConfig,
 ) -> Result<Option<Vec<String>>> {
-    // TODO: implement Linear connector
-    Ok(None)
+    let threshold = format!("-{SYNC_INTERVAL_MINS} minutes");
+    let (is_fresh,): (i64,) = sqlx::query_as(
+        "SELECT EXISTS(
+             SELECT 1 FROM pm_sync_state
+             WHERE provider = 'linear'
+               AND last_synced_at > strftime('%Y-%m-%dT%H:%M:%SZ', 'now', ?)
+         )",
+    )
+    .bind(&threshold)
+    .fetch_one(pool)
+    .await
+    .context("checking linear sync state")?;
+
+    if is_fresh != 0 {
+        return Ok(None);
+    }
+
+    match fetch(linear).await {
+        Ok(issues) => {
+            let raw_count = issues.len();
+            let kept = upsert(pool, &issues, linear).await?;
+            let n = kept.len();
+            sqlx::query(
+                "INSERT INTO pm_sync_state (provider, last_synced_at)
+                 VALUES ('linear', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+                 ON CONFLICT(provider) DO UPDATE SET last_synced_at = excluded.last_synced_at",
+            )
+            .execute(pool)
+            .await
+            .context("updating linear sync state")?;
+
+            // Only prune when the response was not truncated — otherwise tasks
+            // beyond the first page would be wrongly deleted.
+            if raw_count < MAX_RESULTS {
+                if !kept.is_empty() {
+                    match prune(pool, &kept).await {
+                        Ok(0) => {}
+                        Ok(p) => tracing::info!(pruned_count = p, "pruned stale linear tasks"),
+                        Err(e) => tracing::warn!(error = %e, "linear prune failed"),
+                    }
+                } else {
+                    // No live tasks at all → delete every linear row.
+                    if let Err(e) = sqlx::query("DELETE FROM pm_tasks WHERE provider = 'linear'")
+                        .execute(pool)
+                        .await
+                    {
+                        tracing::warn!(error = %e, "linear full-clear failed");
+                    }
+                }
+            }
+            tracing::info!(upserted_count = n, "linear tasks refreshed");
+            Ok(Some(kept))
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "linear fetch failed — keeping stale cache");
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_mapping() {
+        assert_eq!(map_state_type("started"), "in_progress");
+        assert_eq!(map_state_type("completed"), "done");
+        assert_eq!(map_state_type("canceled"), "done");
+        assert_eq!(map_state_type("backlog"), "todo");
+        assert_eq!(map_state_type("triage"), "todo");
+    }
+
+    fn issue_with(team_id: &str, team_key: &str, state: &str) -> LinearIssue {
+        LinearIssue {
+            identifier: "ENG-1".into(),
+            title: "t".into(),
+            description: None,
+            updated_at: "2026-06-01T00:00:00.000Z".into(),
+            url: None,
+            state: Some(WorkflowState {
+                type_: state.into(),
+            }),
+            team: Some(Team {
+                id: team_id.into(),
+                key: team_key.into(),
+            }),
+            parent: None,
+            assignee: None,
+        }
+    }
+
+    #[test]
+    fn finished_issues_detected() {
+        assert!(is_finished(&issue_with("u", "ENG", "completed")));
+        assert!(is_finished(&issue_with("u", "ENG", "canceled")));
+        assert!(!is_finished(&issue_with("u", "ENG", "started")));
+    }
+
+    #[test]
+    fn team_filter_matches_id_or_key() {
+        let i = issue_with("uuid-123", "ENG", "started");
+        assert!(team_allowed(&i, &[])); // empty = all
+        assert!(team_allowed(&i, &["uuid-123".into()])); // by id
+        assert!(team_allowed(&i, &["ENG".into()])); // by key
+        assert!(!team_allowed(&i, &["OTHER".into()]));
+    }
+
+    #[test]
+    fn parses_assigned_issues_response() {
+        let raw = r#"{"data":{"viewer":{"assignedIssues":{"nodes":[
+            {"identifier":"ENG-12","title":"Fix bug","description":"d","updatedAt":"2026-06-01T00:00:00.000Z",
+             "url":"https://linear.app/x/issue/ENG-12","state":{"type":"started"},
+             "team":{"id":"t1","key":"ENG"},"project":{"name":"P"},
+             "parent":{"identifier":"ENG-1","title":"Epic"},"assignee":{"name":"Sam"}}
+        ]}}}}"#;
+        let parsed: GqlResponse = serde_json::from_str(raw).unwrap();
+        let nodes = parsed.data.unwrap().viewer.unwrap().assigned_issues.nodes;
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].identifier, "ENG-12");
+        assert_eq!(nodes[0].state.as_ref().unwrap().type_, "started");
+        assert_eq!(nodes[0].parent.as_ref().unwrap().identifier, "ENG-1");
+    }
 }

--- a/src/migrations/031_pm_worklog_provider.sql
+++ b/src/migrations/031_pm_worklog_provider.sql
@@ -1,0 +1,14 @@
+-- meridian — normalises screenpipe activity into structured app sessions
+--
+-- Multi-provider worklog support. A worklog must remember WHICH tracker it
+-- belongs to so the approved-poster can route it to the right backend (Jira's
+-- native worklog API, a Linear comment, or a GitHub issue comment) even after
+-- the originating pm_tasks row has been pruned (a closed ticket is removed on
+-- the next sync). We snapshot the provider onto the worklog row at draft time.
+--
+-- Default 'jira' keeps every pre-existing row valid — before this migration the
+-- poster only ever spoke to Jira, so that is the correct historical value.
+
+ALTER TABLE pm_worklogs ADD COLUMN provider TEXT NOT NULL DEFAULT 'jira';
+
+CREATE INDEX IF NOT EXISTS idx_pm_worklogs_provider ON pm_worklogs (provider);

--- a/src/pm_worklog/comment.rs
+++ b/src/pm_worklog/comment.rs
@@ -1,0 +1,123 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Shared worklog-comment helpers for the trackers that have NO native worklog
+// API (Linear, GitHub). Neither exposes a "log N hours" primitive — verified
+// against Linear's full GraphQL schema (zero worklog/timeEntry/custom-field) and
+// GitHub's docs (time tracking is an open feature request). So for those two we
+// mirror a Jira worklog row as a structured comment on the issue: a human-readable
+// time line + the synthesised narrative, plus a machine marker carrying the exact
+// window and seconds so an entry can be reconstructed/deduplicated programmatically.
+//
+// Jira does NOT use this — it has a real worklog endpoint (see `jira.rs`).
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Local, NaiveDateTime, Utc};
+
+/// Provider-neutral result of a worklog post. `id` is the backend's identifier
+/// for the created entry (a Jira worklog id, or a Linear/GitHub comment id) and
+/// is stored in `pm_worklogs.posted_worklog_id`. `label` is a short human string
+/// for logs (e.g. the time-spent "1h 30m").
+#[derive(Debug, Clone)]
+pub struct PostedWorklog {
+    pub id: String,
+    pub label: String,
+}
+
+/// Convert seconds → a human "1h 30m" / "45m" / "2h" label, rounding to the
+/// nearest minute. Worklogs below 60s are never posted (the min-post floor), so
+/// the minute is always the smallest unit shown.
+pub fn seconds_to_human(seconds: i64) -> String {
+    let minutes_total = ((seconds.max(0) + 30) / 60).max(1);
+    let hours = minutes_total / 60;
+    let minutes = minutes_total % 60;
+    match (hours, minutes) {
+        (h, m) if h > 0 && m > 0 => format!("{h}h {m}m"),
+        (h, _) if h > 0 => format!("{h}h"),
+        (_, m) => format!("{m}m"),
+    }
+}
+
+/// Render a UTC ISO instant as a local "YYYY-MM-DD HH:MM" label for display in a
+/// comment. Falls back to the raw string if it cannot be parsed.
+pub fn local_label(utc_iso: &str) -> String {
+    match parse_iso_utc(utc_iso) {
+        Ok(utc) => utc
+            .with_timezone(&Local)
+            .format("%Y-%m-%d %H:%M")
+            .to_string(),
+        Err(_) => utc_iso.to_string(),
+    }
+}
+
+/// Build the Markdown body for a worklog comment posted to Linear or GitHub.
+///
+/// The trailing HTML comment is a stable machine marker: callers (and future
+/// readers) can grep `meridian-worklog` to find/parse logged entries and recover
+/// the window + seconds even though neither tracker stores them as structured time.
+pub fn format_worklog_comment(
+    summary: &str,
+    time_spent_seconds: i64,
+    window_start_iso: &str,
+    window_end_iso: &str,
+) -> String {
+    let human = seconds_to_human(time_spent_seconds);
+    let when = local_label(window_start_iso);
+    format!(
+        "**⏱ Worklog — {human}** · {when}\n\n{summary}\n\n\
+         <!-- meridian-worklog v1 window={window_start_iso}/{window_end_iso} seconds={time_spent_seconds} -->",
+        summary = summary.trim()
+    )
+}
+
+/// Parse a `YYYY-MM-DDTHH:MM:SSZ` / RFC3339 / naive-UTC instant into a UTC datetime.
+pub(crate) fn parse_iso_utc(iso: &str) -> Result<DateTime<Utc>> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(&iso.replace('Z', "+00:00")) {
+        return Ok(dt.with_timezone(&Utc));
+    }
+    let naive = NaiveDateTime::parse_from_str(iso.trim_end_matches('Z'), "%Y-%m-%dT%H:%M:%S")
+        .context("unrecognised timestamp format")?;
+    Ok(DateTime::from_naive_utc_and_offset(naive, Utc))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn human_time_rounds_and_floors() {
+        assert_eq!(seconds_to_human(60), "1m");
+        assert_eq!(seconds_to_human(89), "1m"); // 1.48 → 1
+        assert_eq!(seconds_to_human(90), "2m"); // 1.5 → 2
+        assert_eq!(seconds_to_human(3600), "1h");
+        assert_eq!(seconds_to_human(5400), "1h 30m");
+        assert_eq!(seconds_to_human(0), "1m"); // floored to a visible minute
+    }
+
+    #[test]
+    fn comment_carries_marker_and_summary() {
+        let body = format_worklog_comment(
+            "Did the thing.",
+            5400,
+            "2026-06-01T09:00:00Z",
+            "2026-06-01T10:00:00Z",
+        );
+        assert!(body.contains("Did the thing."));
+        assert!(body.contains("1h 30m"));
+        assert!(body.contains(
+            "meridian-worklog v1 window=2026-06-01T09:00:00Z/2026-06-01T10:00:00Z seconds=5400"
+        ));
+    }
+
+    #[test]
+    fn local_label_parses_utc() {
+        // Just assert it produces a "YYYY-MM-DD HH:MM"-shaped string, not the raw input.
+        let s = local_label("2026-06-01T09:00:00Z");
+        assert_eq!(s.len(), 16, "expected 'YYYY-MM-DD HH:MM': {s}");
+        assert!(s.contains('-') && s.contains(':'));
+    }
+
+    #[test]
+    fn local_label_passthrough_on_garbage() {
+        assert_eq!(local_label("not-a-date"), "not-a-date");
+    }
+}

--- a/src/pm_worklog/db.rs
+++ b/src/pm_worklog/db.rs
@@ -31,12 +31,16 @@ pub async fn upsert_pm_worklog(
     // edit/approval back to a fresh draft. When the guard blocks the update the
     // conflict becomes a no-op and `RETURNING` yields nothing, so we fall back to
     // reading the existing id.
+    // `provider` is snapshotted from pm_tasks so the poster can route this
+    // worklog to the right backend even if the ticket is later pruned. Falls
+    // back to 'jira' for safety (the only provider before multi-provider support).
     let row = sqlx::query(
         "INSERT INTO pm_worklogs (\
              task_key, day_utc, cycle_index, window_start, window_end, \
              state, confidence, coverage, time_spent_seconds, \
-             payload_json, session_id_min, session_id_max) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+             payload_json, session_id_min, session_id_max, provider) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, \
+                 COALESCE((SELECT provider FROM pm_tasks WHERE task_key = ?), 'jira')) \
          ON CONFLICT (task_key, day_utc, cycle_index) DO UPDATE SET \
              state              = excluded.state, \
              confidence         = excluded.confidence, \
@@ -44,7 +48,8 @@ pub async fn upsert_pm_worklog(
              time_spent_seconds = excluded.time_spent_seconds, \
              payload_json       = excluded.payload_json, \
              session_id_min     = excluded.session_id_min, \
-             session_id_max     = excluded.session_id_max \
+             session_id_max     = excluded.session_id_max, \
+             provider           = excluded.provider \
          WHERE pm_worklogs.state NOT IN ('approved', 'posted') \
          RETURNING id",
     )
@@ -60,6 +65,7 @@ pub async fn upsert_pm_worklog(
     .bind(&payload_json)
     .bind(session_id_min)
     .bind(session_id_max)
+    .bind(&update.task_key)
     .fetch_optional(pool)
     .await
     .context("upsert pm_worklogs row")?;
@@ -184,6 +190,8 @@ pub struct ApprovedWorklog {
     pub window_end: String,
     pub time_spent_seconds: i64,
     pub comment: String,
+    /// Which tracker this worklog posts to ('jira' | 'github' | 'linear').
+    pub provider: String,
 }
 
 /// All worklogs awaiting a post (`state = 'approved'`), oldest window first.
@@ -191,7 +199,8 @@ pub struct ApprovedWorklog {
 /// honoured. Rows with an empty summary are skipped — there is nothing to post.
 pub async fn fetch_approved_worklogs(pool: &SqlitePool) -> Result<Vec<ApprovedWorklog>> {
     let rows = sqlx::query(
-        "SELECT id, task_key, window_start, window_end, time_spent_seconds, payload_json \
+        "SELECT id, task_key, window_start, window_end, time_spent_seconds, payload_json, \
+                COALESCE(provider, 'jira') AS provider \
          FROM pm_worklogs WHERE state = 'approved' ORDER BY window_start, task_key",
     )
     .fetch_all(pool)
@@ -211,6 +220,7 @@ pub async fn fetch_approved_worklogs(pool: &SqlitePool) -> Result<Vec<ApprovedWo
             window_end: r.get("window_end"),
             time_spent_seconds: r.try_get("time_spent_seconds").unwrap_or(0),
             comment,
+            provider: r.try_get("provider").unwrap_or_else(|_| "jira".to_string()),
         });
     }
     Ok(out)

--- a/src/pm_worklog/github.rs
+++ b/src/pm_worklog/github.rs
@@ -1,0 +1,171 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// GitHub worklog poster. GitHub has NO native time tracking (it's a long-standing
+// open feature request — neither the Issues API nor Projects v2 exposes a
+// time-spent / worklog field). The robust, universally-available analog to a Jira
+// worklog row is an issue comment: append-only, timestamped by GitHub, attributed
+// to the authenticated user, and visible on the card whether or not the issue is
+// in a Project. So a "worklog" on GitHub is a structured Markdown comment posted
+// to the issue via the REST API (see `comment.rs` for the body + machine marker).
+//
+// We deliberately do NOT write a Projects v2 custom "Time Spent" Number field:
+// fields can't be created via the API (a manual board setup step), fine-grained
+// PATs have a documented gap for user-owned projects, and it needs project/item/
+// field-id juggling — all of which hurt smooth onboarding. The issue comment is
+// what every GitHub user has. (A Project Number-field running total is a possible
+// future enhancement layered on top.)
+//
+// task_key is `owner/repo#123`; we parse it for the REST path. Auth: a PAT in the
+// `Authorization: Bearer` header with the standard GitHub headers (User-Agent is
+// required by the API).
+
+use anyhow::{bail, Context, Result};
+use serde_json::{json, Value};
+
+use super::comment::{format_worklog_comment, seconds_to_human, PostedWorklog};
+use crate::config::GitHubConfig;
+
+/// A GitHub issue coordinate parsed from a `owner/repo#number` task key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueRef {
+    pub owner: String,
+    pub repo: String,
+    pub number: u64,
+}
+
+/// Parse `owner/repo#123` into its parts. Returns an error for any other shape.
+pub fn parse_task_key(task_key: &str) -> Result<IssueRef> {
+    let (repo_path, num) = task_key
+        .rsplit_once('#')
+        .with_context(|| format!("GitHub task_key {task_key:?} missing '#<number>'"))?;
+    let number: u64 = num
+        .parse()
+        .with_context(|| format!("GitHub task_key {task_key:?} has non-numeric issue number"))?;
+    let (owner, repo) = repo_path
+        .split_once('/')
+        .with_context(|| format!("GitHub task_key {task_key:?} missing 'owner/repo'"))?;
+    if owner.is_empty() || repo.is_empty() {
+        bail!("GitHub task_key {task_key:?} has an empty owner or repo");
+    }
+    Ok(IssueRef {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        number,
+    })
+}
+
+/// Post a worklog comment to the GitHub issue identified by `task_key`
+/// (`owner/repo#123`). Returns the created comment's id.
+pub async fn post_worklog(
+    github: &GitHubConfig,
+    task_key: &str,
+    time_spent_seconds: i64,
+    window_start_iso: &str,
+    window_end_iso: &str,
+    comment: &str,
+) -> Result<PostedWorklog> {
+    if time_spent_seconds < 60 {
+        bail!("time_spent_seconds={time_spent_seconds} below the 60s worklog minimum");
+    }
+    let issue = parse_task_key(task_key)?;
+    let body = format_worklog_comment(
+        comment,
+        time_spent_seconds,
+        window_start_iso,
+        window_end_iso,
+    );
+
+    let url = format!(
+        "https://api.github.com/repos/{}/{}/issues/{}/comments",
+        issue.owner, issue.repo, issue.number
+    );
+
+    tracing::info!(
+        task_key,
+        time_spent = %seconds_to_human(time_spent_seconds),
+        comment_len = body.len(),
+        "github worklog comment POST"
+    );
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&url)
+        .header("Authorization", format!("Bearer {}", github.token))
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "meridian")
+        .json(&json!({ "body": body }))
+        .send()
+        .await
+        .with_context(|| format!("network error reaching GitHub at {url}"))?;
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        bail!("GitHub comment POST for {task_key} returned {status}: {text}");
+    }
+    let value: Value = serde_json::from_str(&text).context("parsing GitHub comment response")?;
+    let comment_id = comment_id_from_response(&value)
+        .with_context(|| format!("GitHub comment response for {task_key} missing `id`"))?;
+
+    Ok(PostedWorklog {
+        id: comment_id,
+        label: seconds_to_human(time_spent_seconds),
+    })
+}
+
+/// GitHub returns the comment `id` as a JSON number; normalise it to a string.
+fn comment_id_from_response(value: &Value) -> Option<String> {
+    match value.get("id")? {
+        Value::Number(n) => Some(n.to_string()),
+        Value::String(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_owner_repo_number() {
+        let r = parse_task_key("acme/api#42").unwrap();
+        assert_eq!(
+            r,
+            IssueRef {
+                owner: "acme".into(),
+                repo: "api".into(),
+                number: 42
+            }
+        );
+    }
+
+    #[test]
+    fn parses_repo_names_with_dots_and_dashes() {
+        let r = parse_task_key("my-org/web.client#1007").unwrap();
+        assert_eq!(r.owner, "my-org");
+        assert_eq!(r.repo, "web.client");
+        assert_eq!(r.number, 1007);
+    }
+
+    #[test]
+    fn rejects_malformed_keys() {
+        assert!(parse_task_key("KAN-123").is_err()); // jira-style
+        assert!(parse_task_key("acme/api").is_err()); // no number
+        assert!(parse_task_key("acme#42").is_err()); // no repo
+        assert!(parse_task_key("acme/api#nope").is_err()); // non-numeric
+    }
+
+    #[test]
+    fn normalises_numeric_id() {
+        assert_eq!(
+            comment_id_from_response(&json!({ "id": 123456 })).as_deref(),
+            Some("123456")
+        );
+        assert_eq!(
+            comment_id_from_response(&json!({ "id": "abc" })).as_deref(),
+            Some("abc")
+        );
+        assert_eq!(comment_id_from_response(&json!({})), None);
+    }
+}

--- a/src/pm_worklog/linear.rs
+++ b/src/pm_worklog/linear.rs
@@ -1,0 +1,161 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Linear worklog poster. Linear has NO native worklog / time-logging API — its
+// full GraphQL schema exposes no worklog, timeEntry, "time spent" field, or
+// custom-field write (verified against the published schema). The only
+// first-class, per-issue, per-user, timestamped write it offers is a comment.
+// So a "worklog" on Linear is a structured Markdown comment created via the
+// `commentCreate` mutation, carrying the time spent + the synthesised narrative
+// (see `comment.rs` for the body format and machine marker).
+//
+// Auth: a personal API key passed RAW in the `Authorization` header — Linear
+// does NOT use a `Bearer` prefix for API keys (it does for OAuth tokens; we use
+// keys). Endpoint: a single GraphQL POST to https://api.linear.app/graphql.
+//
+// `commentCreate.issueId` wants the issue UUID, not the human identifier
+// (`ENG-123`). We carry the identifier as the task_key, so we first resolve the
+// UUID via `issue(id: "ENG-123") { id }` (Linear's `issue` query accepts the
+// identifier as a lookup key), then create the comment.
+
+use anyhow::{bail, Context, Result};
+use serde_json::{json, Value};
+
+use super::comment::{format_worklog_comment, seconds_to_human, PostedWorklog};
+use crate::config::LinearConfig;
+
+const LINEAR_GRAPHQL_URL: &str = "https://api.linear.app/graphql";
+
+/// Post a worklog comment to the Linear issue identified by `task_key`
+/// (e.g. `ENG-123`). Returns the created comment's id.
+pub async fn post_worklog(
+    linear: &LinearConfig,
+    task_key: &str,
+    time_spent_seconds: i64,
+    window_start_iso: &str,
+    window_end_iso: &str,
+    comment: &str,
+) -> Result<PostedWorklog> {
+    if time_spent_seconds < 60 {
+        bail!("time_spent_seconds={time_spent_seconds} below the 60s worklog minimum");
+    }
+    let body = format_worklog_comment(
+        comment,
+        time_spent_seconds,
+        window_start_iso,
+        window_end_iso,
+    );
+
+    let client = reqwest::Client::new();
+    let issue_uuid = resolve_issue_uuid(&client, linear, task_key).await?;
+
+    let mutation = "mutation CreateWorklogComment($issueId: String!, $body: String!) {\n  \
+        commentCreate(input: { issueId: $issueId, body: $body }) {\n    \
+        success\n    comment { id url }\n  }\n}";
+    let payload = json!({
+        "query": mutation,
+        "variables": { "issueId": issue_uuid, "body": body },
+    });
+
+    tracing::info!(
+        task_key,
+        time_spent = %seconds_to_human(time_spent_seconds),
+        comment_len = body.len(),
+        "linear worklog comment create"
+    );
+
+    let data = graphql(&client, linear, &payload)
+        .await
+        .with_context(|| format!("creating Linear worklog comment for {task_key}"))?;
+
+    let created = &data["commentCreate"];
+    if created["success"].as_bool() != Some(true) {
+        bail!("Linear commentCreate for {task_key} did not report success: {created}");
+    }
+    let comment_id = created["comment"]["id"]
+        .as_str()
+        .context("Linear commentCreate response missing comment.id")?
+        .to_string();
+
+    Ok(PostedWorklog {
+        id: comment_id,
+        label: seconds_to_human(time_spent_seconds),
+    })
+}
+
+/// Resolve a Linear issue's UUID from its human identifier (`ENG-123`).
+async fn resolve_issue_uuid(
+    client: &reqwest::Client,
+    linear: &LinearConfig,
+    identifier: &str,
+) -> Result<String> {
+    let query = "query ResolveIssue($id: String!) { issue(id: $id) { id identifier } }";
+    let payload = json!({ "query": query, "variables": { "id": identifier } });
+    let data = graphql(client, linear, &payload)
+        .await
+        .with_context(|| format!("resolving Linear issue {identifier}"))?;
+    data["issue"]["id"]
+        .as_str()
+        .map(|s| s.to_string())
+        .with_context(|| format!("Linear issue {identifier} not found (no id in response)"))
+}
+
+/// Execute one GraphQL request and return its `data` object, surfacing GraphQL
+/// `errors` (which Linear returns with HTTP 200) as a hard error.
+async fn graphql(
+    client: &reqwest::Client,
+    linear: &LinearConfig,
+    payload: &Value,
+) -> Result<Value> {
+    let resp = client
+        .post(LINEAR_GRAPHQL_URL)
+        .header("Authorization", &linear.api_key)
+        .header("Content-Type", "application/json")
+        .json(payload)
+        .send()
+        .await
+        .context("network error reaching Linear GraphQL API")?;
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        bail!("Linear GraphQL returned {status}: {text}");
+    }
+    let value: Value = serde_json::from_str(&text).context("parsing Linear GraphQL response")?;
+    if let Some(errors) = value.get("errors").and_then(Value::as_array) {
+        if !errors.is_empty() {
+            bail!("Linear GraphQL errors: {}", value["errors"]);
+        }
+    }
+    value
+        .get("data")
+        .cloned()
+        .context("Linear GraphQL response missing `data`")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn comment_body_is_well_formed() {
+        let body = format_worklog_comment(
+            "Shipped X.",
+            3600,
+            "2026-06-01T09:00:00Z",
+            "2026-06-01T10:00:00Z",
+        );
+        assert!(body.contains("Shipped X."));
+        assert!(body.contains("1h"));
+        assert!(body.contains("meridian-worklog"));
+    }
+
+    #[test]
+    fn extracts_comment_id_from_success_response() {
+        // Shape mirrors a real commentCreate `data` payload.
+        let data = json!({
+            "commentCreate": { "success": true, "comment": { "id": "cmt_abc", "url": "https://linear.app/x" } }
+        });
+        assert_eq!(data["commentCreate"]["comment"]["id"], "cmt_abc");
+        assert_eq!(data["commentCreate"]["success"], true);
+    }
+}

--- a/src/pm_worklog/mod.rs
+++ b/src/pm_worklog/mod.rs
@@ -18,11 +18,14 @@
 // `meridian pm-worklog [--day YYYY-MM-DD]` and `meridian worklog-post-approved`.
 
 pub mod collect;
+pub mod comment;
 pub mod config;
 pub mod db;
+pub mod github;
 pub mod ground;
 pub mod jira;
 pub mod ledger;
+pub mod linear;
 pub mod models;
 pub mod post;
 pub mod route;

--- a/src/pm_worklog/post.rs
+++ b/src/pm_worklog/post.rs
@@ -1,11 +1,17 @@
 // meridian — normalises screenpipe activity into structured app sessions
 //
-// The approved-worklog poster. This is the ONLY path that writes to real Jira.
-// The hour-driven driver (`scheduler.rs`) only ever DRAFTS; a human reviews,
-// optionally edits, and approves each worklog in the dashboard (which flips the
-// row to `approved`). This sweep then picks approved rows up and posts them via
-// `jira.rs`, on a fast cadence independent of the hourly driver so "approve in
-// the UI" feels close to immediate.
+// The approved-worklog poster. This is the ONLY path that writes to a real
+// tracker. The hour-driven driver (`scheduler.rs`) only ever DRAFTS; a human
+// reviews, optionally edits, and approves each worklog in the dashboard (which
+// flips the row to `approved`). This sweep then picks approved rows up and posts
+// them to whichever tracker the row belongs to (`pm_worklogs.provider`):
+//
+//   jira   → native worklog endpoint        (`jira.rs`)
+//   linear → structured `commentCreate`      (`linear.rs`)  — no native worklog API
+//   github → structured issue comment (REST) (`github.rs`)  — no native time tracking
+//
+// The sweep runs on a fast cadence independent of the hourly driver so "approve
+// in the UI" feels close to immediate.
 //
 // Idempotent: a window already POSTED short-circuits (the `find_existing_worklog`
 // backstop), so a restart mid-sweep can never double-post. A post failure leaves
@@ -15,14 +21,14 @@ use anyhow::Result;
 use sqlx::SqlitePool;
 use tokio::sync::watch;
 
-use crate::config::{Config, JiraConfig, PmProviderConfig};
+use crate::config::{Config, GitHubConfig, JiraConfig, LinearConfig, PmProviderConfig};
 
 use super::config::PmWorklogConfig;
-use super::{db, jira};
+use super::{db, github, jira, linear};
 
 /// How often the approved-sweep runs. Short by design — this is the latency a
 /// user feels between clicking "Approve" in the dashboard and the worklog
-/// landing in Jira.
+/// landing in their tracker.
 const POST_SWEEP_INTERVAL_SECS: u64 = 60;
 
 /// Outcome of one approved-sweep pass.
@@ -33,12 +39,12 @@ pub struct PostSweepSummary {
     pub failed: u32,
 }
 
-/// Post every approved worklog. `jira` is `None` when no Jira provider is
-/// configured — then approved rows are left in place (nothing to post to) and a
-/// warning is logged once per pass.
+/// Post every approved worklog, routing each to its provider. Rows whose
+/// provider is not configured on this daemon are left in place (nothing to post
+/// to) with a warning — the same forgiving behaviour the Jira-only poster had.
 pub async fn post_approved(
     pool: &SqlitePool,
-    jira: Option<&JiraConfig>,
+    config: &Config,
     cfg: &PmWorklogConfig,
 ) -> Result<PostSweepSummary> {
     let approved = db::fetch_approved_worklogs(pool).await?;
@@ -50,22 +56,14 @@ pub async fn post_approved(
         return Ok(summary);
     }
 
-    let Some(jira) = jira else {
-        tracing::warn!(
-            approved = approved.len(),
-            "approved worklogs waiting but no Jira provider configured — not posting"
-        );
-        return Ok(summary);
-    };
-
     for w in approved {
-        match post_one(pool, jira, cfg, &w).await {
+        match post_one(pool, config, cfg, &w).await {
             Ok(true) => summary.posted += 1,
             Ok(false) => {} // ineligible/skipped — already recorded
             Err(e) => {
                 summary.failed += 1;
                 tracing::warn!(
-                    pm_worklog_id = w.id, task = %w.task_key, error = %e,
+                    pm_worklog_id = w.id, task = %w.task_key, provider = %w.provider, error = %e,
                     "approved worklog post failed — left approved for retry"
                 );
                 db::mark_post_failed(pool, w.id, &format!("{e:#}")).await?;
@@ -76,11 +74,11 @@ pub async fn post_approved(
 }
 
 /// Post one approved worklog. Returns `Ok(true)` if it was posted, `Ok(false)` if
-/// it was skipped as ineligible (too short — recorded as a non-retryable error),
-/// or `Err` on a transient failure the caller should record for retry.
+/// it was skipped as ineligible (too short / empty / no matching provider — each
+/// recorded), or `Err` on a transient failure the caller should record for retry.
 async fn post_one(
     pool: &SqlitePool,
-    jira: &JiraConfig,
+    config: &Config,
     cfg: &PmWorklogConfig,
     w: &db::ApprovedWorklog,
 ) -> Result<bool> {
@@ -91,12 +89,12 @@ async fn post_one(
         return Ok(false);
     }
     if w.time_spent_seconds < cfg.min_post_seconds {
-        // Below Jira's hard floor — terminal; nothing the sweep can do.
+        // Below the worklog floor — terminal; nothing the sweep can do.
         db::fail_worklog(
             pool,
             w.id,
             &format!(
-                "time_spent={}s below Jira's {}s minimum",
+                "time_spent={}s below the {}s minimum",
                 w.time_spent_seconds, cfg.min_post_seconds
             ),
         )
@@ -105,7 +103,7 @@ async fn post_one(
     }
 
     // Idempotency backstop: if this exact (task, window) was already posted,
-    // adopt that worklog id instead of posting again.
+    // adopt that worklog/comment id instead of posting again.
     if let Some((_, worklog_id)) =
         db::find_existing_worklog(pool, &w.task_key, &w.window_start, &w.window_end).await?
     {
@@ -117,26 +115,97 @@ async fn post_one(
         return Ok(true);
     }
 
-    let result = jira::post_worklog(
-        jira,
-        &w.task_key,
-        w.time_spent_seconds,
-        &w.window_start,
-        w.comment.trim(),
-    )
-    .await?;
-    db::mark_worklog_posted(pool, w.id, &result.worklog_id).await?;
+    // Route to the provider this worklog was drafted against. A missing provider
+    // config (e.g. the row is for Linear but only Jira is configured here) is not
+    // a failure — leave it approved and warn, so it posts once configured.
+    let comment = w.comment.trim();
+    let (worklog_id, label) = match w.provider.as_str() {
+        "jira" => {
+            let Some(c) = jira_cfg(config) else {
+                return missing_provider(&w.provider, w);
+            };
+            let r = jira::post_worklog(
+                c,
+                &w.task_key,
+                w.time_spent_seconds,
+                &w.window_start,
+                comment,
+            )
+            .await?;
+            (r.worklog_id, r.time_spent_jira)
+        }
+        "linear" => {
+            let Some(c) = linear_cfg(config) else {
+                return missing_provider(&w.provider, w);
+            };
+            let r = linear::post_worklog(
+                c,
+                &w.task_key,
+                w.time_spent_seconds,
+                &w.window_start,
+                &w.window_end,
+                comment,
+            )
+            .await?;
+            (r.id, r.label)
+        }
+        "github" => {
+            let Some(c) = github_cfg(config) else {
+                return missing_provider(&w.provider, w);
+            };
+            let r = github::post_worklog(
+                c,
+                &w.task_key,
+                w.time_spent_seconds,
+                &w.window_start,
+                &w.window_end,
+                comment,
+            )
+            .await?;
+            (r.id, r.label)
+        }
+        other => {
+            db::fail_worklog(pool, w.id, &format!("unknown provider '{other}'")).await?;
+            return Ok(false);
+        }
+    };
+
+    db::mark_worklog_posted(pool, w.id, &worklog_id).await?;
     tracing::info!(
-        pm_worklog_id = w.id, task = %w.task_key, worklog_id = %result.worklog_id,
-        time_spent = %result.time_spent_jira, "approved worklog posted to Jira"
+        pm_worklog_id = w.id, task = %w.task_key, provider = %w.provider,
+        worklog_id = %worklog_id, time_spent = %label, "approved worklog posted"
     );
     Ok(true)
 }
 
-/// First Jira provider in the daemon config, if any.
-fn jira_from_config(config: &Config) -> Option<JiraConfig> {
+/// The worklog's provider is not configured on this daemon: leave it approved
+/// (nothing to post to) and warn once. Returns `Ok(false)` (not posted, not a
+/// hard error — it will post when the provider is configured).
+fn missing_provider(provider: &str, w: &db::ApprovedWorklog) -> Result<bool> {
+    tracing::warn!(
+        pm_worklog_id = w.id, task = %w.task_key, %provider,
+        "approved worklog waiting but its provider is not configured — not posting"
+    );
+    Ok(false)
+}
+
+fn jira_cfg(config: &Config) -> Option<&JiraConfig> {
     config.pm_providers.iter().find_map(|p| match p {
-        PmProviderConfig::Jira(j) => Some(j.clone()),
+        PmProviderConfig::Jira(j) => Some(j),
+        _ => None,
+    })
+}
+
+fn github_cfg(config: &Config) -> Option<&GitHubConfig> {
+    config.pm_providers.iter().find_map(|p| match p {
+        PmProviderConfig::GitHub(g) => Some(g),
+        _ => None,
+    })
+}
+
+fn linear_cfg(config: &Config) -> Option<&LinearConfig> {
+    config.pm_providers.iter().find_map(|p| match p {
+        PmProviderConfig::Linear(l) => Some(l),
         _ => None,
     })
 }
@@ -152,8 +221,7 @@ pub async fn run_post_loop(pool: SqlitePool, mut shutdown_rx: watch::Receiver<bo
 
     loop {
         let config = Config::from_env();
-        let jira = jira_from_config(&config);
-        match post_approved(&pool, jira.as_ref(), &cfg).await {
+        match post_approved(&pool, &config, &cfg).await {
             Ok(s) if s.posted > 0 || s.failed > 0 => tracing::info!(
                 approved = s.approved_seen,
                 posted = s.posted,
@@ -177,14 +245,15 @@ pub async fn run_post_loop(pool: SqlitePool, mut shutdown_rx: watch::Receiver<bo
 pub async fn cli_post_approved(pool: &SqlitePool) {
     let cfg = PmWorklogConfig::from_env();
     let config = Config::from_env();
-    let jira = jira_from_config(&config);
-    match post_approved(pool, jira.as_ref(), &cfg).await {
+    let providers: Vec<&str> = config
+        .pm_providers
+        .iter()
+        .map(|p| p.provider_name())
+        .collect();
+    match post_approved(pool, &config, &cfg).await {
         Ok(s) => println!(
-            "worklog-post-approved: approved={} posted={} failed={} (jira={})",
-            s.approved_seen,
-            s.posted,
-            s.failed,
-            jira.is_some(),
+            "worklog-post-approved: approved={} posted={} failed={} (providers={:?})",
+            s.approved_seen, s.posted, s.failed, providers,
         ),
         Err(e) => eprintln!("worklog-post-approved: sweep failed: {e:#}"),
     }

--- a/tests/worklog_provider.rs
+++ b/tests/worklog_provider.rs
@@ -1,0 +1,133 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Runtime coverage for the multi-provider worklog write path: that
+// `upsert_pm_worklog` snapshots the provider from `pm_tasks` onto the worklog
+// row, defaults to 'jira' when the task is absent, and that
+// `fetch_approved_worklogs` surfaces the provider for the approved-poster to
+// route on. These exercise the real SQL (bind counts + the COALESCE sub-select),
+// which the in-module unit tests do not.
+
+use meridian::pm_worklog::db::{fetch_approved_worklogs, upsert_pm_worklog};
+use meridian::pm_worklog::models::{GroundedNarrative, JiraUpdate, UpdateState};
+use sqlx::sqlite::SqliteConnectOptions;
+use sqlx::{Row, SqlitePool};
+use std::str::FromStr;
+
+async fn make_db() -> SqlitePool {
+    let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+        .unwrap()
+        .create_if_missing(true);
+    let pool = SqlitePool::connect_with(opts).await.unwrap();
+    sqlx::migrate!("src/migrations").run(&pool).await.unwrap();
+    pool
+}
+
+async fn insert_task(pool: &SqlitePool, task_key: &str, provider: &str) {
+    sqlx::query(
+        "INSERT INTO pm_tasks
+           (task_key, provider, title, description_text, status_category,
+            issue_type, project_key, url, updated_at, fetched_at)
+         VALUES (?, ?, 'T', '', 'in_progress', 'Issue', 'acme/api', '',
+                 strftime('%Y-%m-%dT%H:%M:%SZ', 'now'),
+                 strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))",
+    )
+    .bind(task_key)
+    .bind(provider)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+fn narrative(task_key: &str) -> GroundedNarrative {
+    GroundedNarrative {
+        update: JiraUpdate {
+            task_key: task_key.to_string(),
+            window_start: "2026-06-01T09:00:00+00:00".to_string(),
+            window_end: "2026-06-01T10:00:00+00:00".to_string(),
+            cycle_index: 9,
+            time_spent_seconds: 1800,
+            summary: "Did work".to_string(),
+            what_shipped: vec![],
+            in_progress: vec![],
+            blockers: vec![],
+            decisions: vec![],
+            next_steps: vec![],
+            risk_flags: vec![],
+            confidence: 0.9,
+            reasoning: String::new(),
+        },
+        coverage: 1.0,
+        dropped_bullets: vec![],
+    }
+}
+
+async fn provider_of(pool: &SqlitePool, id: i64) -> String {
+    let row = sqlx::query("SELECT provider FROM pm_worklogs WHERE id = ?")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    row.get::<String, _>("provider")
+}
+
+#[tokio::test]
+async fn snapshots_provider_from_pm_tasks() {
+    let pool = make_db().await;
+    insert_task(&pool, "acme/api#1", "github").await;
+
+    let id = upsert_pm_worklog(
+        &pool,
+        &narrative("acme/api#1"),
+        UpdateState::Drafted,
+        "2026-06-01",
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(provider_of(&pool, id).await, "github");
+}
+
+#[tokio::test]
+async fn defaults_to_jira_when_task_absent() {
+    let pool = make_db().await;
+    // No pm_tasks row for this key — the COALESCE must fall back to 'jira'.
+    let id = upsert_pm_worklog(
+        &pool,
+        &narrative("KAN-1"),
+        UpdateState::Drafted,
+        "2026-06-01",
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(provider_of(&pool, id).await, "jira");
+}
+
+#[tokio::test]
+async fn approved_worklogs_carry_provider_for_routing() {
+    let pool = make_db().await;
+    insert_task(&pool, "ENG-7", "linear").await;
+
+    // Insert straight as approved (what the dashboard's approve action produces).
+    upsert_pm_worklog(
+        &pool,
+        &narrative("ENG-7"),
+        UpdateState::Approved,
+        "2026-06-01",
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let approved = fetch_approved_worklogs(&pool).await.unwrap();
+    assert_eq!(approved.len(), 1);
+    assert_eq!(approved[0].provider, "linear");
+    assert_eq!(approved[0].task_key, "ENG-7");
+    assert_eq!(approved[0].comment, "Did work");
+    assert_eq!(approved[0].time_spent_seconds, 1800);
+}

--- a/ui/app/api/worklogs/route.ts
+++ b/ui/app/api/worklogs/route.ts
@@ -19,6 +19,7 @@ export interface WorklogBullet {
 export interface WorklogItem {
   id: number
   task_key: string
+  provider: string
   window_start: string
   state: string
   confidence: number
@@ -43,6 +44,7 @@ export interface WorklogsResponse {
 interface RawRow {
   id: number
   task_key: string
+  provider: string
   window_start: string
   state: string
   confidence: number
@@ -80,7 +82,8 @@ export async function GET(req: Request) {
   try {
     const db = getDb()
     const rows = db.prepare(`
-      SELECT id, task_key, window_start, state, confidence, coverage,
+      SELECT id, task_key, COALESCE(provider, 'jira') AS provider, window_start,
+             state, confidence, coverage,
              time_spent_seconds, payload_json, posted_worklog_id,
              last_post_error, edited_at
       FROM pm_worklogs
@@ -106,6 +109,7 @@ export async function GET(req: Request) {
       return {
         id: r.id,
         task_key: r.task_key,
+        provider: r.provider ?? 'jira',
         window_start: r.window_start,
         state: r.state,
         confidence: r.confidence ?? 0,

--- a/ui/components/views/WorklogsView.tsx
+++ b/ui/components/views/WorklogsView.tsx
@@ -15,6 +15,16 @@ function dayString(offsetDays = 0): string {
   return `${y}-${m}-${day}`
 }
 
+// Human label for a worklog's tracker (provider snapshot on the row).
+function providerLabel(provider: string): string {
+  switch (provider) {
+    case 'jira': return 'Jira'
+    case 'linear': return 'Linear'
+    case 'github': return 'GitHub'
+    default: return provider || 'Jira'
+  }
+}
+
 const STATE_STYLE: Record<string, { label: string; color: string }> = {
   drafted:  { label: 'Draft',    color: 'var(--ink-3)' },
   approved: { label: 'Approved', color: 'var(--accent)' },
@@ -91,7 +101,7 @@ export default function WorklogsView() {
             Approve before it posts
           </h1>
           <p className="mt-3 text-[14px] max-w-prose" style={{ color: 'var(--ink-2)' }}>
-            Nothing reaches Jira until you approve it. Edit the comment if it&apos;s off, then approve —
+            Nothing reaches your tracker until you approve it. Edit the comment if it&apos;s off, then approve —
             the daemon posts approved worklogs within a minute.
           </p>
         </div>
@@ -175,6 +185,7 @@ function WorklogCard({ w, busy, onApprove, onReject, onUnapprove, onSave }: {
         {/* meta row */}
         <div className="flex items-center gap-3">
           <TaskKey keyId={w.task_key} />
+          <span className="text-[10px] uppercase tracking-[0.12em]" style={{ color: 'var(--ink-4)' }}>{providerLabel(w.provider)}</span>
           <span className="font-mono tnum text-[11px]" style={{ color: 'var(--ink-3)' }}>{fmtClock(w.window_start)}</span>
           <span className="text-[11px]" style={{ color: 'var(--ink-4)' }}>·</span>
           <span className="font-mono tnum text-[11px]" style={{ color: 'var(--ink-3)' }}>{fmtDur(w.time_spent_seconds)}</span>
@@ -221,7 +232,7 @@ function WorklogCard({ w, busy, onApprove, onReject, onUnapprove, onSave }: {
           <p className="text-[11px] mt-2 font-mono" style={{ color: '#E03131' }}>post error: {w.last_post_error}</p>
         )}
         {posted && w.posted_worklog_id && (
-          <p className="text-[11px] mt-2" style={{ color: '#2F9E44' }}>✓ posted to Jira · worklog {w.posted_worklog_id}</p>
+          <p className="text-[11px] mt-2" style={{ color: '#2F9E44' }}>✓ posted to {providerLabel(w.provider)} · {w.posted_worklog_id}</p>
         )}
 
         {/* evidence toggle */}


### PR DESCRIPTION
## What

Adds **Linear** and **GitHub** as first-class worklog targets alongside Jira. A user can connect any one of the three; the whole draft → approve → post pipeline, idempotency, and dashboard flow are identical across providers — only the final post hop differs.

## The decision: how to log time on Linear & GitHub

Verified against the official APIs: **neither Linear nor GitHub has a native worklog / "log hours" endpoint.** Linear's full GraphQL schema has zero worklog/timeEntry/time-spent/custom-field write; GitHub has no time tracking in Issues or Projects v2 (it's an open feature request). So:

| Tracker | Task sync | Worklog mechanism |
|---|---|---|
| **Jira** | assigned issues (JQL) — unchanged | native worklog API (time + ADF comment) |
| **Linear** | `viewer.assignedIssues` (GraphQL) | structured comment via `commentCreate` — the only first-class per-issue timestamped write |
| **GitHub** | open assigned issues (REST `/search/issues`, owner-scoped) | structured issue comment (REST) — append-only "⏱ Worklog" ledger entry |

GitHub worklogs go on the **issue** (universally available, simple `repo`-scope auth) rather than a Projects v2 custom Number field (can't be created via API, fine-grained-PAT gaps, id juggling) — keeps onboarding smooth. A Project Number-field total is a clean future enhancement.

## How

- `pm_worklog/{linear,github}.rs` — the two posters; `comment.rs` — shared worklog-comment formatter + machine marker for idempotent readback.
- `providers/{linear,github}.rs` — the task connectors that were stubbed.
- Migration 031 snapshots `provider` onto each `pm_worklogs` row at draft time (default `jira`, so existing rows stay valid); `post.rs` routes the approved-poster on it.
- Provider-aware worklogs UI label; onboarding docs (`SETUP.md`, `.env.example`, `install.sh`) cover all three + where to get each credential.

## Testing

`cargo fmt` ✓, `clippy -D warnings` ✓, **202 tests pass / 0 fail**. Unit tests cover payload shapes, response parsing, `owner/repo#123` parsing, state→category mapping, scoping, comment formatting/marker. Integration test (`tests/worklog_provider.rs`) exercises the real SQL: provider snapshot, jira default, approved-routing.

⚠️ **Not yet live-tested against real Jira/Linear/GitHub APIs** (no credentials in this environment). The HTTP calls are thin tails over the tested pure functions — recommend one real approve-and-post per provider before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)