### PR TITLE
fix(classifier): remove category prior, lean recent context, raise OCR cap, untracked-first skill

### DIFF
--- a/services/agents/_prompts.py
+++ b/services/agents/_prompts.py
@@ -51,10 +51,12 @@ def _format_session(session: dict) -> str:
         parts.append(f"time: {time_range}{dur_str}")
     elif dur is not None:
         parts.append(f"duration: {_fmt_dur(dur)}")
-    cat = session.get("category")
-    cat_conf = session.get("confidence")
-    if cat:
-        parts.append(f"category: {cat} (confidence {round(cat_conf or 0.0, 2)})")
+    # NOTE: the rule-based ETL category is intentionally NOT included here. It is
+    # a cheap heuristic derived from the SAME app/window/OCR signals the LLM
+    # already sees, so feeding it in only injects a correlated prior — when the
+    # heuristic is wrong (e.g. background-window OCR bleed), it biases the LLM
+    # toward the same mistake. The classifier re-derives category from the raw
+    # evidence and its output overwrites the rule-based value anyway.
     titles = session.get("window_titles") or []
     if titles:
         parts.append("top windows:")
@@ -116,7 +118,6 @@ def _format_recent_sessions(sessions: list[dict]) -> str:
         dur_str = _fmt_dur(s.get("duration_s") or 0)
         task_key = s.get("task_key")
         routing = s.get("task_routing")  # None means unclassified
-        category = (s.get("category") or "").strip()
         if task_key:
             target = f"→ {task_key}"
         elif routing == "untracked":
@@ -126,8 +127,10 @@ def _format_recent_sessions(sessions: list[dict]) -> str:
             target = "→ [pending]"
         else:
             target = "→ [overhead]"
-        cat_tag = f"  [{category}]" if category else ""
-        rows.append(f"  {time_str}  {app:<14}  {dur_str:<7}  {target}{cat_tag}")
+        # Category is intentionally omitted — recent-context is a task-continuity
+        # signal only; carrying the (rule-based or prior-LLM) category tag would
+        # feed a category prior back into classification.
+        rows.append(f"  {time_str}  {app:<14}  {dur_str:<7}  {target}")
     return "\n".join(rows)
 
 

--- a/services/agents/_prompts.py
+++ b/services/agents/_prompts.py
@@ -11,12 +11,17 @@ _VSCODE_BANNER_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
-# Max chars of session_text included in the prompt. Default 2500 (~625 tokens at
-# 4 chars/token) — enough to identify files, ticket keys, and recent activity
-# without inflating context in production. Override via SESSION_TEXT_CAP env var
-# for eval experiments; set to 0 to disable truncation entirely (caller is then
-# responsible for not blowing the model's context window).
-SESSION_TEXT_CAP = int(os.environ.get("SESSION_TEXT_CAP", "2500"))
+# Max chars of session_text included in the prompt. Default 10000 (~2500 tokens
+# at 4 chars/token). The old 2500 cap kept only the FIRST frames of a multi-frame
+# OCR capture, so when a session spanned more than one window/app the later
+# (often foreground) activity was silently dropped — e.g. a session whose head
+# showed an IDE but whose tail showed the user had moved to a different app/
+# project got misclassified on the stale head. The classifier model has a 128K
+# context window, so 2500 was far too conservative; 10000 comfortably holds a
+# full multi-frame session while staying trivial for the model. Override via
+# SESSION_TEXT_CAP env var; set to 0 to disable truncation entirely (caller is
+# then responsible for not blowing the model's context window).
+SESSION_TEXT_CAP = int(os.environ.get("SESSION_TEXT_CAP", "10000"))
 
 
 def _fmt_dur(duration_s: int | float) -> str:

--- a/services/agents/run_task_linker_mlx.py
+++ b/services/agents/run_task_linker_mlx.py
@@ -232,9 +232,13 @@ def _fetch_session(
 def _fetch_recent_sessions(
     con: _sqlite3.Connection, before_id: int
 ) -> list[dict[str, Any]]:
+    # Recent context is a task-continuity signal only: app, time, duration and
+    # which ticket each recent session mapped to. We deliberately do NOT select
+    # session_text/excerpt or category — recent OCR is noise here and a category
+    # tag would feed a prior back into classification. (session_text is still
+    # referenced in WHERE only to skip empty-capture rows.)
     rows = con.execute(
-        "SELECT app_name, started_at, duration_s, task_key, task_routing, category,"
-        "       COALESCE(SUBSTR(session_text, 1, 200), '') AS text_excerpt"
+        "SELECT app_name, started_at, duration_s, task_key, task_routing"
         " FROM app_sessions"
         " WHERE id < ? AND duration_s > 1 AND COALESCE(session_text,'') != ''"
         " ORDER BY id DESC LIMIT ?",

--- a/services/agents/run_task_linker_mlx.py
+++ b/services/agents/run_task_linker_mlx.py
@@ -83,10 +83,10 @@ class SessionClassification(BaseModel):
     ] = Field(
         ...,
         description=(
-            "The single best activity category for this session. A rule-based "
-            "guess is supplied in the input — confirm it or correct it from the "
-            "evidence. Declared early in the schema so FSM decoding always emits "
-            "it before the long session_summary field."
+            "The single best activity category for this session. Derive it from "
+            "the evidence (app, window titles, screen content); no category is "
+            "supplied in the input. Declared early in the schema so FSM decoding "
+            "always emits it before the long session_summary field."
         ),
     )
     category_confidence: float = Field(

--- a/services/skills/activity/task-classifier/SKILL.md
+++ b/services/skills/activity/task-classifier/SKILL.md
@@ -24,7 +24,7 @@ The task classifier sits at the center of Meridian's workflow understanding:
 
 ## Classification Decision Tree
 
-For each session, you must decide:
+For each session, decide in this order. **Core principle: do NOT try to fit every session to an existing ticket. Assign a `task_key` only when the session's OWN evidence clearly matches that specific ticket's scope. Most real work that isn't an obvious match is `untracked`, not a forced link.**
 
 ### 1. Is this overhead?
 If the session is **idle, music, system settings,or clearly personal/unrelated activity** → return:
@@ -33,27 +33,29 @@ If the session is **idle, music, system settings,or clearly personal/unrelated a
 ```
 **overhead is a hard discard.** These sessions are thrown away — never surfaced, never used for inference, never create tasks. When in doubt between overhead and untracked, ask: *"Would a manager care that this happened?"* If no, it's overhead.
 
-### 2. Is this work-related?
-If the session shows **any real work signal** (coding, research, meetings, writing, debugging, reviewing, learning) but **no Jira candidate matches** → mark as **untracked** and return:
+### 2. Is this real work that ISN'T clearly one of the candidate tickets? → untracked
+If the session shows **any real work signal** (coding, research, meetings, writing, debugging, reviewing, learning) but it does **not clearly match the scope of a candidate ticket** → mark as **untracked**:
 ```json
 {"task_key": null, "confidence": 0.6-0.8, "session_type": "untracked", "routing": "queue"}
 ```
-**untracked sessions are kept and used downstream** — for workload analysis, capacity reporting, and automatic new-task creation. Mark dimensions to capture *what* the work was. Examples that must be `untracked` (not `overhead`): standups, retros, code reviews on untracked PRs, config/infra housekeeping, general repo exploration, internal tool usage.
+**This is the important, common case — and it is what `untracked` MEANS: the user genuinely did this work, but there is no Jira ticket for it yet.** Downstream, Meridian uses untracked sessions to **create or update** the matching Jira task. So it is critical that you do **not** shoehorn this work into an unrelated existing ticket just because it is the only candidate available, or because recent sessions were on it. **A wrong task link is worse than `untracked`** — it pollutes a real ticket's worklog and hides the genuine untracked work that should have spawned its own ticket. When the evidence doesn't clearly fit a candidate, choose `untracked`.
 
-### 3. Can it map to an open Jira ticket?
-If the session evidence **directly or contextually matches** an open ticket → return:
+`untracked` sessions are kept and used downstream (workload analysis, capacity reporting, new-task creation). Mark dimensions to capture *what* the work was. Examples that must be `untracked` (not `overhead`): standups, retros, code reviews on untracked PRs, config/infra housekeeping, general repo exploration, general research, **and any work on a feature/bug/chore that has no matching candidate ticket**.
+
+### 3. Does it CLEARLY map to one specific candidate ticket? → task
+Assign a `task_key` **only** when the session's own evidence (window titles, OCR, file/branch names, an explicit ticket-key mention) directly matches the **scope described in that ticket's title/description** → return:
 ```json
 {"task_key": "KEY-123", "confidence": 0.50-0.90, "session_type": "task", "routing": "auto"}
 ```
-Cite the evidence (window title, OCR snippet, context from previous sessions) and infer activity dimensions.
+Recent-session continuity may *support* a match, but **continuity alone is never enough** — the current session must carry its own evidence that fits the ticket. If the active app/window shows the user is now on something else (a different project, a meeting, another repo, a doc for another team), classify by **that**, not by what they were doing minutes ago. Cite the specific evidence, and infer activity dimensions.
 
 ## Your inputs
 
 The user message contains:
 
-- **SESSION** — app, category (with confidence), duration, top window titles, and counts of OCR/audio captures.
+- **SESSION** — app, duration, top window titles, and the screen content (OCR / a11y). Decide the category yourself from this evidence; no category is provided.
 - **CANDIDATE TICKETS** — all open Jira tickets. These are the only tickets you may choose from.
-- **RECENT SESSIONS** (previous 5) — context to help disambiguate. Example: *"User was on KAN-42 (coding) 5 minutes ago, then Slack, now back in VS Code."* → likely same task, even if Slack doesn't directly match KAN-42.
+- **RECENT SESSIONS** (previous 5) — app / time / duration / which ticket each mapped to (no screen text). A **weak disambiguation hint only**: it can support a match when the current session ALSO has matching evidence, but it must never override what the current session itself shows. Recent activity on a ticket does not make the current session that ticket.
 
 ## Available capabilities
 
@@ -98,7 +100,7 @@ Reply with ONE valid JSON object — no preamble, no markdown fences, no follow-
 ### Field rules
 - `task_key` — must be one of the supplied candidates, or `null`. Never invent a key.
 - `confidence` — see Scoring heuristics section for exact ranges per outcome type.
-- `category` — the single best activity category (see taxonomy below). The input carries a rule-based guess; confirm it or correct it from the evidence.
+- `category` — the single best activity category (see taxonomy below). Derive it yourself from the evidence (app, window titles, screen content); no category is provided in the input.
 - `category_confidence` — how certain you are about `category`, `0.0`–`1.0`.
 - `category_explanation` — ONE concise sentence justifying the category, citing the app / window titles / OCR evidence. Shown in the dashboard next to the category.
 - `session_type` — `"task"` links to Jira; `"overhead"` is thrown away; `"untracked"` is kept for workload analysis.
@@ -199,7 +201,7 @@ You have access to **the previous 5 sessions** to disambiguate the current sessi
 - Session 2 (3 min ago): Slack, discussing PR review for KAN-42 → **if related to same work**, task_key: KAN-42, confidence: 0.75 (work mention + prior context)
 - Session 3 (now): VS Code, editing same file → task_key: KAN-42, confidence: 0.85 (context continuity)
 
-**Decision:** If Session 2 (Slack) content shows it's about the same work (discussing the work or searching about it), classify it to **KAN-42** using context from Session 1. If Slack is generic work discussion with no connection to the prior task, return `null` with `session_type: "untracked"`.
+**Decision:** Only link Session 2 to KAN-42 if Session 2's **own content** shows it is about that work (the OCR/window discusses or searches the KAN-42 work). If Session 2 is generic, OR shows the user has moved to *different* work (another project, another team's doc, an unrelated meeting), return `null` with `session_type: "untracked"` (or a different ticket if its own evidence matches one) — **do not inherit KAN-42 just because it was the recent task.** Continuity is a tie-breaker between plausible matches, never a substitute for current-session evidence.
 
 Example reasoning for Session 2 (if task-related): `"Slack discusses PR review for KAN-42 implementation mentioned in prior VS Code session; linked via work context."`
 
@@ -208,7 +210,7 @@ Example reasoning for Session 2 (if task-related): `"Slack discusses PR review f
 **When task_key is not null (matched to a ticket):**
 - **Task key + work alignment**  — `confidence ≥ 0.90`, `session_type: "task"`
 - **Work description alignment**  — `0.75–0.85`, `session_type: "task"`
-- **Context continuity**  — `0.75–0.85`, `session_type: "task"`
+- **Context continuity (current session ALSO has matching evidence)**  — `0.75–0.85`, `session_type: "task"`. Continuity with no current-session evidence is **not** a task — use `untracked`.
 - **Generic project-level match**  — `0.50–0.65`, `session_type: "task"`
 - **Task key only**  — `0.60–0.75`, `session_type: "task"` (lower than key+alignment because work intent unclear)
 


### PR DESCRIPTION
Improves the task classifier's **inputs** so it stops mis-attributing sessions. Found by tracing a real misclassification (a mostly-coding Chrome session) through the exact prompt the model receives.

## Changes
1. **Drop the category prior** (`_prompts.py`) — the SESSION block carried the rule-based ETL `category (confidence)` and recent lines carried `[category]` tags. Both derive from the same app/window/OCR the LLM already sees, so they injected a *correlated* prior that reinforced the rule-based mistake. The classifier emits its own category anyway.
2. **Raise `SESSION_TEXT_CAP` 2500 → 10000** (`_prompts.py`) — the old cap kept only the first frames of a multi-frame OCR capture, silently dropping later (often foreground) activity. The model has a 128K context; 2500 was far too conservative.
3. **Lean recent context** (`run_task_linker_mlx.py`) — `_fetch_recent_sessions` no longer selects the (unused) 200-char session_text excerpt or category. Recent context is task-continuity only: app / time / duration / → ticket. No recent session text reaches the model.
4. **Untracked-first skill** (`SKILL.md`) — `untracked` now explicitly means *real work with no Jira ticket yet* (used downstream to create/update tasks). The model must not force-fit a session into an existing candidate; assign a `task_key` only when the **current session's own evidence** matches that ticket's scope — recent continuity can support but never substitute for it. Removed the now-stale category-input references.

## Validation
A read-only dry-run tool (`classify_session.py`, separate PR) reproduces the exact `_classify_one` path. The full classifier eval (re-rendered goldens, exact-match on task_key + session_type) is being run; results to follow. No Rust/UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)