### PR TITLE
feat(health): comprehensive multi-daemon meridian doctor (+ settings-path fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ data/memory/
 .claude/memory.db
 .claude/settings.json
 
+# Repo-local runtime settings (hot-reloaded by the daemon, written by the UI) —
+# user/machine specific, must never be committed.
+/settings.json
+
 # Python virtual environments (.venv313 merged into .venv via --mlx extra)
 services/.venv/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Meridian is a single-process Rust daemon that reads screenpipe's SQLite database
 - Keep files under 500 lines; split when a file grows beyond that
 - Validate all input at system boundaries (config load, DB open, frame parsing)
 - NEVER run `git reset`, `git push --force`, or delete local code — other agents may be working on the codebase in parallel
+- NEVER merge a PR automatically — open/update PRs as needed, but leave the actual merge to a human reviewer
 
 ---
 

--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -228,11 +228,17 @@ _daemon_bin() {
 cmd_doctor() {
     local bin
     if bin="$(_daemon_bin)"; then
-        # Guard with a perl alarm so a stale binary (one that predates `doctor`
-        # and would fall through to starting the daemon) can never hang the
-        # terminal. The Rust report colourises itself when stdout is a tty.
         set +e
-        perl -e 'alarm shift @ARGV; exec @ARGV' 30 "$bin" doctor
+        if [[ "$*" == *--fix* ]]; then
+            # --fix has interactive guided prompts — the user is present, so run
+            # without the alarm (which would kill a prompt waiting for input).
+            "$bin" doctor "$@"
+        else
+            # Guard with a perl alarm so a stale binary (one that predates
+            # `doctor` and would fall through to starting the daemon) can never
+            # hang the terminal. The Rust report colourises itself on a tty.
+            perl -e 'alarm shift @ARGV; exec @ARGV' 30 "$bin" doctor "$@"
+        fi
         local rc=$?
         set -e
         # 0 = healthy, 1 = critical issues found — both are real doctor runs.
@@ -470,7 +476,7 @@ case "$CMD" in
     restart)          cmd_restart ;;
     status)           cmd_status ;;
     logs)             cmd_logs "$@" ;;
-    doctor)           cmd_doctor ;;
+    doctor)           cmd_doctor "$@" ;;
     config)           cmd_config "$@" ;;
     dev)              cmd_dev "$@" ;;
     uninstall)        cmd_uninstall ;;

--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -190,14 +190,52 @@ cmd_logs() {
 }
 
 # --- doctor ---
-_check() {
-    local desc="$1" pass="$2" reason="${3:-}"
-    if [[ "$pass" == "1" ]]; then
-        ok "$desc"
+# --- table-style doctor output, grouped by daemon ---
+_group() { printf "\n  ── %s ─────────────────────────────────────────────\n" "$1"; }
+
+_row() {  # status check detail
+    local status="$1" check="$2" detail="${3:-}" glyph
+    case "$status" in
+        ok)   glyph="✓" ;;
+        warn) glyph="⊘" ;;
+        info) glyph="·" ;;
+        *)    glyph="✗"; DOCTOR_FAILURES=$(( DOCTOR_FAILURES + 1 )) ;;
+    esac
+    printf "  %s %-26s %s\n" "$glyph" "$check" "$detail"
+}
+
+_plist_row() {  # label check-label
+    local plist="${LAUNCH_AGENTS}/$1.plist"
+    if [[ -f "$plist" ]] && plutil -lint "$plist" >/dev/null 2>&1; then
+        _row ok "$2" ""
     else
-        err "$desc${reason:+ — ${reason}}"
-        DOCTOR_FAILURES=$(( DOCTOR_FAILURES + 1 ))
+        _row fail "$2" "run ./install.sh"
     fi
+}
+
+# Fold the daemon binary's machine-readable L1 capture checks into the table.
+# Guarded by a perl alarm so a stale binary (one that doesn't know `doctor` and
+# would otherwise start the daemon) can never hang the report.
+_capture_rows() {  # daemon-binary-path
+    local bin="$1" out
+    if [[ ! -x "$bin" ]]; then _row info "capture (L1)" "daemon binary missing"; return; fi
+    set +e
+    out="$(perl -e 'alarm shift @ARGV; exec @ARGV' 8 "$bin" doctor --porcelain 2>/dev/null)"
+    set -e
+    if [[ -z "$out" ]]; then
+        _row info "capture (L1)" "unavailable — run: cargo build --release"
+        return
+    fi
+    # status \t name \t detail \t remedy
+    while IFS=$'\t' read -r st name detail remedy; do
+        [[ -z "$name" ]] && continue
+        # binary/DB presence is already shown by the screenpipe rows above.
+        case "$name" in screenpipe.installed|screenpipe.db_present) continue ;; esac
+        _row "$st" "${name#screenpipe.}" "$detail"
+        if [[ -n "$remedy" && "$st" != "ok" && "$st" != "info" ]]; then
+            printf "       → %s\n" "$remedy"
+        fi
+    done <<< "$out"
 }
 
 _pid_from_print() {
@@ -213,90 +251,56 @@ _pid_from_print() {
 
 cmd_doctor() {
     DOCTOR_FAILURES=0
+    printf "\n  Meridian doctor — health by daemon\n"
+    printf "  ════════════════════════════════════════════════════════\n"
 
-    # 1. macOS
-    _check "macOS" "$([[ "$(uname -s)" == "Darwin" ]] && echo 1 || echo 0)" "run on macOS"
+    # ---- System ----
+    _group "system"
+    _row "$([[ "$(uname -s)" == "Darwin" ]] && echo ok || echo fail)" "macOS" ""
 
-    # 2. daemon binary
-    local bin_ok=0
+    # ---- meridian daemon ----
+    _group "meridian daemon"
+    local binpath=""
     for p in /usr/local/bin/meridian-daemon "${HOME}/.local/bin/meridian-daemon"; do
-        [[ -x "$p" ]] && bin_ok=1 && break
+        [[ -x "$p" ]] && binpath="$p" && break
     done
-    _check "daemon binary exists and is executable" "$bin_ok" "run ./install.sh"
-
-    # 3. daemon plist lints
-    local dplist="${LAUNCH_AGENTS}/${LABEL_DAEMON}.plist"
-    if [[ -f "$dplist" ]]; then
-        set +e; plutil -lint "$dplist" >/dev/null 2>&1; local pl=$?; set -e
-        _check "daemon plist installed and valid" "$([[ $pl -eq 0 ]] && echo 1 || echo 0)" "plutil -lint ${dplist}"
-    else
-        _check "daemon plist installed and valid" "0" "run ./install.sh"
-    fi
-
-    # 4. daemon running
+    _row "$([[ -n "$binpath" ]] && echo ok || echo fail)" "binary installed" "$binpath"
+    _plist_row "$LABEL_DAEMON" "plist valid"
     local dpid; dpid="$(_pid_from_print "$LABEL_DAEMON" 2>/dev/null)" || dpid=""
-    _check "daemon running (pid ${dpid:-?})" "$([[ -n "$dpid" ]] && echo 1 || echo 0)" "meridian start"
+    _row "$([[ -n "$dpid" ]] && echo ok || echo fail)" "running" "${dpid:+pid $dpid}"
+    _row "$([[ -f "${REPO_ROOT}/.env" ]] && echo ok || echo fail)" "config (.env)" ""
+    _row "$([[ -f "${HOME}/.meridian/meridian.db" ]] && echo ok || echo warn)" "meridian DB" ""
 
-    # 5. user config
-    _check "user config <repo>/.env exists" "$([[ -f "${REPO_ROOT}/.env" ]] && echo 1 || echo 0)" "run ./install.sh"
+    # ---- screenpipe (launchd/process + L1 capture from the daemon binary) ----
+    _group "screenpipe"
+    _plist_row "$LABEL_SCREENPIPE" "plist valid"
+    _row "$(command -v screenpipe >/dev/null 2>&1 && echo ok || echo fail)" "binary in PATH" ""
+    _row "$(pgrep -x screenpipe >/dev/null 2>&1 && echo ok || echo fail)" "running" ""
+    _capture_rows "$binpath"
 
-    # 6. screenpipe plist lints
-    local spplist="${LAUNCH_AGENTS}/${LABEL_SCREENPIPE}.plist"
-    if [[ -f "$spplist" ]]; then
-        set +e; plutil -lint "$spplist" >/dev/null 2>&1; local spl=$?; set -e
-        _check "screenpipe plist installed and valid" "$([[ $spl -eq 0 ]] && echo 1 || echo 0)" "plutil -lint ${spplist}"
-    else
-        _check "screenpipe plist installed and valid" "0" "run ./install.sh"
-    fi
+    # ---- mlx-server ----
+    _group "mlx-server"
+    _plist_row "$LABEL_MLX" "plist valid"
+    local venv_py="${REPO_ROOT}/services/.venv/bin/python" venv_ok=0
+    if [[ -x "$venv_py" ]] && "$venv_py" -c "import run_agent" >/dev/null 2>&1; then venv_ok=1; fi
+    _row "$([[ $venv_ok -eq 1 ]] && echo ok || echo fail)" "python venv + run_agent" ""
 
-    # 7. screenpipe binary in PATH
-    set +e; command -v screenpipe >/dev/null 2>&1; local spbin=$?; set -e
-    _check "screenpipe binary in PATH" "$([[ $spbin -eq 0 ]] && echo 1 || echo 0)" "install screenpipe (npm install -g screenpipe)"
+    # ---- MCP server ----
+    _group "mcp server"
+    _row "$([[ -f "${REPO_ROOT}/packages/meridian-mcp/dist/index.js" ]] && echo ok || echo fail)" "built" ""
 
-    # 8. screenpipe DB
-    _check "screenpipe DB exists" "$([[ -f "${HOME}/.screenpipe/db.sqlite" ]] && echo 1 || echo 0)" "install and run screenpipe"
-
-    # 9. screenpipe running
-    set +e; pgrep -x screenpipe >/dev/null 2>&1; local sp=$?; set -e
-    _check "screenpipe running" "$([[ $sp -eq 0 ]] && echo 1 || echo 0)" "start screenpipe"
-
-    # 10. meridian DB
-    if [[ -f "${HOME}/.meridian/meridian.db" ]]; then
-        ok "meridian DB exists"
-    else
-        warn "meridian DB not yet created (will be on first run)"
-    fi
-
-    # 11. Python venv
-    local venv_py="${REPO_ROOT}/services/.venv/bin/python"
-    local venv_ok=0
-    if [[ -x "$venv_py" ]]; then
-        set +e; "$venv_py" -c "import run_agent" 2>/dev/null; local vi=$?; set -e
-        [[ $vi -eq 0 ]] && venv_ok=1
-    fi
-    _check "Python venv and run_agent importable" "$venv_ok" "bash scripts/setup-services.sh"
-
-    # 12. MCP server built
-    _check "MCP server built" "$([[ -f "${REPO_ROOT}/packages/meridian-mcp/dist/index.js" ]] && echo 1 || echo 0)" "cd packages/meridian-mcp && npm run build"
-
-    # 13. UI plist lints
-    local uiplist="${LAUNCH_AGENTS}/${LABEL_UI}.plist"
-    if [[ -f "$uiplist" ]]; then
-        set +e; plutil -lint "$uiplist" >/dev/null 2>&1; local uil=$?; set -e
-        _check "UI plist installed and valid" "$([[ $uil -eq 0 ]] && echo 1 || echo 0)" "plutil -lint ${uiplist}"
-    else
-        _check "UI plist installed and valid" "0" "run ./install.sh"
-    fi
-
-    # 14. UI built
-    _check "UI built (ui/.next exists)" "$([[ -d "${REPO_ROOT}/ui/.next" ]] && echo 1 || echo 0)" "cd ui && npm ci && npm run build"
+    # ---- UI ----
+    _group "ui"
+    _plist_row "$LABEL_UI" "plist valid"
+    _row "$([[ -d "${REPO_ROOT}/ui/.next" ]] && echo ok || echo fail)" "built (.next)" ""
 
     echo
     if [[ $DOCTOR_FAILURES -eq 0 ]]; then
-        ok "all checks passed"
+        printf "  ✓ all checks passed\n\n"
     else
-        printf "  %d check%s failed\n" "$DOCTOR_FAILURES" "$([[ $DOCTOR_FAILURES -ne 1 ]] && echo s || true)"
+        printf "  ✗ %d check(s) failed\n\n" "$DOCTOR_FAILURES"
     fi
+    [[ $DOCTOR_FAILURES -eq 0 ]]
 }
 
 # --- config ---

--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -190,7 +190,11 @@ cmd_logs() {
 }
 
 # --- doctor ---
-# --- table-style doctor output, grouped by daemon ---
+# The daemon binary owns the comprehensive, colourised, by-daemon health table
+# (system, meridian daemon, screenpipe, mlx-server, jira, ui, mcp). The wrapper
+# just delegates to it; if that binary is missing or stale, a minimal bash-only
+# fallback runs so `meridian doctor` always produces something useful.
+
 _group() { printf "\n  ── %s ─────────────────────────────────────────────\n" "$1"; }
 
 _row() {  # status check detail
@@ -213,93 +217,49 @@ _plist_row() {  # label check-label
     fi
 }
 
-# Fold the daemon binary's machine-readable L1 capture checks into the table.
-# Guarded by a perl alarm so a stale binary (one that doesn't know `doctor` and
-# would otherwise start the daemon) can never hang the report.
-_capture_rows() {  # daemon-binary-path
-    local bin="$1" out
-    if [[ ! -x "$bin" ]]; then _row info "capture (L1)" "daemon binary missing"; return; fi
-    set +e
-    out="$(perl -e 'alarm shift @ARGV; exec @ARGV' 8 "$bin" doctor --porcelain 2>/dev/null)"
-    set -e
-    if [[ -z "$out" ]]; then
-        _row info "capture (L1)" "unavailable — run: cargo build --release"
-        return
-    fi
-    # status \t name \t detail \t remedy
-    while IFS=$'\t' read -r st name detail remedy; do
-        [[ -z "$name" ]] && continue
-        # binary/DB presence is already shown by the screenpipe rows above.
-        case "$name" in screenpipe.installed|screenpipe.db_present) continue ;; esac
-        _row "$st" "${name#screenpipe.}" "$detail"
-        if [[ -n "$remedy" && "$st" != "ok" && "$st" != "info" ]]; then
-            printf "       → %s\n" "$remedy"
-        fi
-    done <<< "$out"
-}
-
-_pid_from_print() {
-    local label="$1"
-    local output
-    set +e
-    output="$(launchctl print "${GUI_TARGET}/${label}" 2>/dev/null)"
-    local rc=$?
-    set -e
-    [[ $rc -ne 0 ]] && return 1
-    printf '%s\n' "$output" | grep -E '^\s+pid\s*=' | grep -oE '[0-9]+' | head -1
+_daemon_bin() {
+    local p
+    for p in /usr/local/bin/meridian-daemon "${HOME}/.local/bin/meridian-daemon"; do
+        [[ -x "$p" ]] && { printf '%s\n' "$p"; return 0; }
+    done
+    return 1
 }
 
 cmd_doctor() {
-    DOCTOR_FAILURES=0
-    printf "\n  Meridian doctor — health by daemon\n"
-    printf "  ════════════════════════════════════════════════════════\n"
+    local bin
+    if bin="$(_daemon_bin)"; then
+        # Guard with a perl alarm so a stale binary (one that predates `doctor`
+        # and would fall through to starting the daemon) can never hang the
+        # terminal. The Rust report colourises itself when stdout is a tty.
+        set +e
+        perl -e 'alarm shift @ARGV; exec @ARGV' 30 "$bin" doctor
+        local rc=$?
+        set -e
+        # 0 = healthy, 1 = critical issues found — both are real doctor runs.
+        if [[ $rc -eq 0 || $rc -eq 1 ]]; then return $rc; fi
+        warn "health engine timed out or is stale — rebuild: cargo build --release"
+    fi
+    _doctor_fallback
+}
 
-    # ---- System ----
+# Minimal bash-only checks for when the daemon binary is unavailable.
+_doctor_fallback() {
+    DOCTOR_FAILURES=0
+    printf "\n  Meridian doctor (fallback — daemon binary unavailable)\n"
+    printf "  ════════════════════════════════════════════════════════\n"
     _group "system"
     _row "$([[ "$(uname -s)" == "Darwin" ]] && echo ok || echo fail)" "macOS" ""
-
-    # ---- meridian daemon ----
-    _group "meridian daemon"
-    local binpath=""
-    for p in /usr/local/bin/meridian-daemon "${HOME}/.local/bin/meridian-daemon"; do
-        [[ -x "$p" ]] && binpath="$p" && break
-    done
-    _row "$([[ -n "$binpath" ]] && echo ok || echo fail)" "binary installed" "$binpath"
-    _plist_row "$LABEL_DAEMON" "plist valid"
-    local dpid; dpid="$(_pid_from_print "$LABEL_DAEMON" 2>/dev/null)" || dpid=""
-    _row "$([[ -n "$dpid" ]] && echo ok || echo fail)" "running" "${dpid:+pid $dpid}"
     _row "$([[ -f "${REPO_ROOT}/.env" ]] && echo ok || echo fail)" "config (.env)" ""
-    _row "$([[ -f "${HOME}/.meridian/meridian.db" ]] && echo ok || echo warn)" "meridian DB" ""
-
-    # ---- screenpipe (launchd/process + L1 capture from the daemon binary) ----
-    _group "screenpipe"
-    _plist_row "$LABEL_SCREENPIPE" "plist valid"
-    _row "$(command -v screenpipe >/dev/null 2>&1 && echo ok || echo fail)" "binary in PATH" ""
-    _row "$(pgrep -x screenpipe >/dev/null 2>&1 && echo ok || echo fail)" "running" ""
-    _capture_rows "$binpath"
-
-    # ---- mlx-server ----
-    _group "mlx-server"
-    _plist_row "$LABEL_MLX" "plist valid"
-    local venv_py="${REPO_ROOT}/services/.venv/bin/python" venv_ok=0
-    if [[ -x "$venv_py" ]] && "$venv_py" -c "import run_agent" >/dev/null 2>&1; then venv_ok=1; fi
-    _row "$([[ $venv_ok -eq 1 ]] && echo ok || echo fail)" "python venv + run_agent" ""
-
-    # ---- MCP server ----
-    _group "mcp server"
-    _row "$([[ -f "${REPO_ROOT}/packages/meridian-mcp/dist/index.js" ]] && echo ok || echo fail)" "built" ""
-
-    # ---- UI ----
-    _group "ui"
-    _plist_row "$LABEL_UI" "plist valid"
-    _row "$([[ -d "${REPO_ROOT}/ui/.next" ]] && echo ok || echo fail)" "built (.next)" ""
-
+    _group "services (plists)"
+    _plist_row "$LABEL_DAEMON" "daemon plist"
+    _plist_row "$LABEL_SCREENPIPE" "screenpipe plist"
+    _plist_row "$LABEL_MLX" "mlx plist"
+    _plist_row "$LABEL_UI" "ui plist"
+    _group "builds"
+    _row "$([[ -f "${REPO_ROOT}/packages/meridian-mcp/dist/index.js" ]] && echo ok || echo fail)" "mcp built" ""
+    _row "$([[ -d "${REPO_ROOT}/ui/.next" ]] && echo ok || echo fail)" "ui built" ""
     echo
-    if [[ $DOCTOR_FAILURES -eq 0 ]]; then
-        printf "  ✓ all checks passed\n\n"
-    else
-        printf "  ✗ %d check(s) failed\n\n" "$DOCTOR_FAILURES"
-    fi
+    _row info "next step" "cargo build --release && meridian doctor"
     [[ $DOCTOR_FAILURES -eq 0 ]]
 }
 

--- a/src/health/capture.rs
+++ b/src/health/capture.rs
@@ -240,6 +240,25 @@ const A11Y_HEALTHY_PCT: f64 = 30.0;
 const A11Y_MIN_APP_FRAMES: i64 = 20;
 const A11Y_RECENT_WINDOW: i64 = 2000;
 const A11Y_MAX_APPS_SHOWN: usize = 8;
+/// (a) Degraded-capture note: an app at/under this a11y share is OCR-dominant.
+const A11Y_OCR_DOMINANT_PCT: f64 = 20.0;
+/// ...and needs this many frames in the window to count as high-usage (you
+/// actually spend time there, so its OCR-only sessions matter).
+const A11Y_SIGNIFICANT_FRAMES: i64 = 50;
+/// (b) Regression: baseline window of older frames to compare the recent one to.
+const A11Y_BASELINE_WINDOW: i64 = 30000;
+/// An app whose a11y was at least this healthy in the baseline...
+const A11Y_BASELINE_HEALTHY_PCT: f64 = 50.0;
+/// ...but has fallen under this recently ⇒ a regression worth a warning.
+const A11Y_REGRESSED_PCT: f64 = 20.0;
+
+fn share_pct(n: i64, a11y: i64) -> f64 {
+    if n > 0 {
+        100.0 * a11y as f64 / n as f64
+    } else {
+        0.0
+    }
+}
 
 async fn accessibility_checks(pool: &SqlitePool) -> Vec<Check> {
     let rows = sqlx::query_as::<_, (String, i64, i64)>(
@@ -330,7 +349,99 @@ async fn accessibility_checks(pool: &SqlitePool) -> Vec<Check> {
         format!("{}{}", parts.join(" · "), suffix),
     );
 
-    vec![verdict, per_app]
+    // (a) Degraded-capture note: high-usage apps that are OCR-dominant. Info,
+    // not a fault — it's expected — but it tells you which sessions feed the
+    // classifier lower-fidelity input (relevant when attributing a miss).
+    let degraded = degraded_apps(&rows);
+    let degraded_check = if degraded.is_empty() {
+        Check::ok(
+            "screenpipe.a11y_degraded",
+            "L1",
+            "active apps yield usable text",
+        )
+    } else {
+        Check::info(
+            "screenpipe.a11y_degraded",
+            "L1",
+            format!("OCR-only (degraded input): {}", degraded.join(" · ")),
+        )
+    };
+
+    // (b) Regression: an app that *used to* yield a11y but recently dropped to
+    // OCR-only — a real change (capture broke / app updated), unlike an
+    // always-low app. Needs the baseline window, so it queries again.
+    let regression = a11y_regression(pool, A11Y_RECENT_WINDOW, A11Y_BASELINE_WINDOW).await;
+
+    vec![verdict, per_app, degraded_check, regression]
+}
+
+/// High-usage apps whose recent capture is OCR-dominant. Returns "App pct%".
+fn degraded_apps(rows: &[(String, i64, i64)]) -> Vec<String> {
+    rows.iter()
+        .filter(|(_, n, a)| {
+            *n >= A11Y_SIGNIFICANT_FRAMES && share_pct(*n, *a) < A11Y_OCR_DOMINANT_PCT
+        })
+        .map(|(app, n, a)| format!("{app} {:.0}%", share_pct(*n, *a)))
+        .collect()
+}
+
+/// Compare each app's a11y share in the recent window against an older baseline;
+/// flag apps that were healthy then but OCR-only now. `recent_window`/
+/// `base_window` are frame counts (parameterised for testing).
+async fn a11y_regression(pool: &SqlitePool, recent_window: i64, base_window: i64) -> Check {
+    let max_id = sqlx::query_scalar::<_, i64>("SELECT COALESCE(MAX(id), 0) FROM frames")
+        .fetch_one(pool)
+        .await
+        .unwrap_or(0);
+    let recent_start = max_id - recent_window;
+    let base_start = max_id - recent_window - base_window;
+
+    let rows = sqlx::query_as::<_, (String, i64, i64, i64, i64)>(
+        "SELECT app_name,
+                SUM(CASE WHEN id > ?1 THEN 1 ELSE 0 END) AS recent_n,
+                SUM(CASE WHEN id > ?1 AND COALESCE(text_source,'')='accessibility' THEN 1 ELSE 0 END) AS recent_a,
+                SUM(CASE WHEN id <= ?1 THEN 1 ELSE 0 END) AS base_n,
+                SUM(CASE WHEN id <= ?1 AND COALESCE(text_source,'')='accessibility' THEN 1 ELSE 0 END) AS base_a
+         FROM frames
+         WHERE id > ?2 AND app_name IS NOT NULL AND app_name != ''
+         GROUP BY app_name
+         HAVING recent_n >= ?3 AND base_n >= 50",
+    )
+    .bind(recent_start)
+    .bind(base_start)
+    .bind(A11Y_MIN_APP_FRAMES)
+    .fetch_all(pool)
+    .await;
+
+    let rows = match rows {
+        Ok(r) => r,
+        Err(e) => {
+            return Check::info(
+                "screenpipe.a11y_regression",
+                "L1",
+                format!("not available ({e})"),
+            )
+        }
+    };
+    let regressed: Vec<String> = rows
+        .iter()
+        .filter_map(|(app, rn, ra, bn, ba)| {
+            let recent = share_pct(*rn, *ra);
+            let base = share_pct(*bn, *ba);
+            (base >= A11Y_BASELINE_HEALTHY_PCT && recent < A11Y_REGRESSED_PCT)
+                .then(|| format!("{app} {base:.0}%→{recent:.0}%"))
+        })
+        .collect();
+    if regressed.is_empty() {
+        Check::ok("screenpipe.a11y_regression", "L1", "no a11y regressions")
+    } else {
+        Check::warn(
+            "screenpipe.a11y_regression",
+            "L1",
+            format!("a11y dropped for: {}", regressed.join(" · ")),
+        )
+        .with_remedy("restart screenpipe to re-establish a11y capture; if the app updated it may have dropped a11y support")
+    }
 }
 
 /// screenpipe's WAL file size. An unbounded WAL (stalled checkpoint) means disk
@@ -469,5 +580,38 @@ mod tests {
         let c = permissions_unverified();
         assert_eq!(c.severity, Severity::Warn);
         assert!(c.remedy.is_some());
+    }
+
+    #[test]
+    fn degraded_apps_flags_high_usage_ocr_only() {
+        let rows = vec![
+            ("Code".to_string(), 100, 95),  // 95% a11y → not degraded
+            ("DBeaver".to_string(), 80, 8), // 10% a11y, high usage → degraded
+            ("Quick".to_string(), 10, 0),   // 0% but < 50 frames → excluded
+        ];
+        let d = degraded_apps(&rows);
+        assert_eq!(d.len(), 1);
+        assert!(d[0].contains("DBeaver"));
+    }
+
+    #[tokio::test]
+    async fn a11y_regression_flags_a_drop_from_baseline() {
+        let pool = mem_pool().await;
+        // 60 older frames with a11y, then 30 recent frames OCR-only — same app.
+        insert(&pool, "Code", None, Some("tree"), "accessibility", 60).await;
+        insert(&pool, "Code", Some("pixels"), None, "ocr", 30).await;
+        // small windows so the recent 30 vs older 60 split cleanly
+        let c = a11y_regression(&pool, 30, 60).await;
+        assert_eq!(c.severity, Severity::Warn);
+        assert!(c.remedy.is_some());
+    }
+
+    #[tokio::test]
+    async fn a11y_regression_quiet_when_stable() {
+        let pool = mem_pool().await;
+        insert(&pool, "Code", None, Some("tree"), "accessibility", 60).await;
+        insert(&pool, "Code", None, Some("tree"), "accessibility", 30).await;
+        let c = a11y_regression(&pool, 30, 60).await;
+        assert_eq!(c.severity, Severity::Ok);
     }
 }

--- a/src/health/capture.rs
+++ b/src/health/capture.rs
@@ -35,7 +35,7 @@ pub async fn run(cfg: &Config, pool: Option<&SqlitePool>) -> Report {
                 // proxies (blank rate → Screen Recording, a11y share → Accessibility).
                 checks.push(frame_freshness(p).await);
                 checks.push(blank_text_rate(p).await);
-                checks.push(accessibility_share(p).await);
+                checks.extend(accessibility_checks(p).await);
             } else {
                 // Fresh install / nothing captured: the runtime proxies are blind,
                 // so surface the permission prerequisite explicitly.
@@ -226,44 +226,111 @@ async fn blank_text_rate(pool: &SqlitePool) -> Check {
     }
 }
 
-/// Share of recent frames whose text came from the accessibility tree. A near-
-/// zero share is the content-free proxy for Accessibility permission off (or an
-/// Electron-heavy workload, e.g. Cursor/VS Code, that returns an empty a11y
-/// tree). Warn only — OCR-only capture is degraded, not dead.
-async fn accessibility_share(pool: &SqlitePool) -> Check {
-    let row = sqlx::query_as::<_, (i64, i64)>(
-        "SELECT COUNT(*),
+/// Per-app accessibility-tree yield. Accessibility *permission* is global (all
+/// apps lose a11y if it is off), but a11y *yield* is per-app — some apps simply
+/// expose little tree even with permission granted. A single blended average
+/// conflates the two: an app-mix heavy in low-yield apps reads as "permission
+/// off". So we split it:
+///   - permission verdict = "is ANY well-sampled app yielding healthy a11y?"
+///     (a robust oracle, immune to app mix); critical only if none is.
+///   - a per-app breakdown (Info) so the operator sees which apps are OCR-only
+///     — that is itself a fault-attribution signal (those sessions are degraded
+///     input to the classifier, not model errors).
+const A11Y_HEALTHY_PCT: f64 = 30.0;
+const A11Y_MIN_APP_FRAMES: i64 = 20;
+const A11Y_RECENT_WINDOW: i64 = 2000;
+const A11Y_MAX_APPS_SHOWN: usize = 8;
+
+async fn accessibility_checks(pool: &SqlitePool) -> Vec<Check> {
+    let rows = sqlx::query_as::<_, (String, i64, i64)>(
+        "SELECT app_name, COUNT(*) AS n,
                 COALESCE(SUM(CASE WHEN COALESCE(text_source, '') = 'accessibility'
-                                  THEN 1 ELSE 0 END), 0)
-         FROM (SELECT text_source FROM frames ORDER BY id DESC LIMIT ?1)",
+                                  THEN 1 ELSE 0 END), 0) AS a11y
+         FROM (SELECT app_name, text_source FROM frames ORDER BY id DESC LIMIT ?1)
+         WHERE app_name IS NOT NULL AND app_name != ''
+         GROUP BY app_name
+         HAVING n >= ?2
+         ORDER BY n DESC",
     )
-    .bind(RECENT_SAMPLE)
-    .fetch_one(pool)
+    .bind(A11Y_RECENT_WINDOW)
+    .bind(A11Y_MIN_APP_FRAMES)
+    .fetch_all(pool)
     .await;
-    match row {
-        Ok((0, _)) => Check::ok("screenpipe.a11y_tree", "L1", "no recent frames sampled"),
-        Ok((total, a11y)) => {
-            let pct = 100.0 * a11y as f64 / total as f64;
-            let detail = format!("{a11y}/{total} recent frames via a11y ({pct:.0}%)");
-            if pct < 5.0 {
-                Check::warn(
-                    "screenpipe.a11y_tree",
-                    "L1",
-                    format!("{detail} — Accessibility permission off or Electron-heavy apps"),
-                )
-                .with_remedy(
-                    "grant Accessibility to screenpipe (expected to be low for Electron apps like Cursor/VS Code)",
-                )
-            } else {
-                Check::ok("screenpipe.a11y_tree", "L1", detail)
-            }
+
+    let rows = match rows {
+        Ok(r) => r,
+        Err(e) => {
+            return vec![Check::warn(
+                "screenpipe.a11y",
+                "L1",
+                format!("could not sample per-app a11y ({e})"),
+            )]
         }
-        Err(e) => Check::warn(
-            "screenpipe.a11y_tree",
+    };
+    if rows.is_empty() {
+        return vec![Check::ok(
+            "screenpipe.a11y",
             "L1",
-            format!("could not sample text_source ({e})"),
-        ),
+            "no app with a meaningful recent sample",
+        )];
     }
+
+    let share = |n: i64, a11y: i64| {
+        if n > 0 {
+            100.0 * a11y as f64 / n as f64
+        } else {
+            0.0
+        }
+    };
+    let (best_app, best_pct) = rows
+        .iter()
+        .map(|(app, n, a)| (app.as_str(), share(*n, *a)))
+        .fold(("", 0.0_f64), |acc, x| if x.1 > acc.1 { x } else { acc });
+
+    // Permission verdict: driven by the best-yielding app, not the average.
+    let verdict = if best_pct >= A11Y_HEALTHY_PCT {
+        Check::ok(
+            "screenpipe.a11y_permission",
+            "L1",
+            format!("Accessibility granted — best: {best_app} {best_pct:.0}%"),
+        )
+    } else if best_pct > 0.0 {
+        Check::warn(
+            "screenpipe.a11y_permission",
+            "L1",
+            format!("weak a11y across all apps (best {best_app} {best_pct:.0}%) — Accessibility may be off"),
+        )
+        .with_remedy("grant Accessibility to screenpipe in System Settings, then restart it")
+    } else {
+        Check::critical(
+            "screenpipe.a11y_permission",
+            "L1",
+            "no app is yielding any a11y — Accessibility permission likely off",
+        )
+        .with_remedy(
+            "System Settings ▸ Privacy & Security ▸ Accessibility ▸ enable screenpipe, then restart it",
+        )
+    };
+
+    // Per-app breakdown (most-used first) — diagnostic, never a fault.
+    let parts: Vec<String> = rows
+        .iter()
+        .take(A11Y_MAX_APPS_SHOWN)
+        .map(|(app, n, a)| format!("{app} {:.0}%", share(*n, *a)))
+        .collect();
+    let more = rows.len().saturating_sub(A11Y_MAX_APPS_SHOWN);
+    let suffix = if more > 0 {
+        format!(" (+{more} more)")
+    } else {
+        String::new()
+    };
+    let per_app = Check::info(
+        "screenpipe.a11y_per_app",
+        "L1",
+        format!("{}{}", parts.join(" · "), suffix),
+    );
+
+    vec![verdict, per_app]
 }
 
 /// screenpipe's WAL file size. An unbounded WAL (stalled checkpoint) means disk
@@ -315,6 +382,7 @@ mod tests {
 
     async fn insert(
         pool: &SqlitePool,
+        app: &str,
         full: Option<&str>,
         a11y: Option<&str>,
         src: &str,
@@ -323,8 +391,9 @@ mod tests {
         for _ in 0..n {
             sqlx::query(
                 "INSERT INTO frames(app_name, timestamp, full_text, accessibility_text, text_source)
-                 VALUES('A', strftime('%Y-%m-%dT%H:%M:%SZ','now'), ?1, ?2, ?3)",
+                 VALUES(?1, strftime('%Y-%m-%dT%H:%M:%SZ','now'), ?2, ?3, ?4)",
             )
+            .bind(app)
             .bind(full)
             .bind(a11y)
             .bind(src)
@@ -343,20 +412,49 @@ mod tests {
     #[tokio::test]
     async fn all_blank_flags_screen_recording() {
         let pool = mem_pool().await;
-        insert(&pool, Some(""), Some(""), "ocr", 20).await;
+        insert(&pool, "A", Some(""), Some(""), "ocr", 20).await;
         assert_eq!(blank_text_rate(&pool).await.severity, Severity::Critical);
-        // 0% a11y share → warn (perm off or Electron-heavy).
-        assert_eq!(accessibility_share(&pool).await.severity, Severity::Warn);
     }
 
     #[tokio::test]
     async fn healthy_a11y_capture_is_ok() {
         let pool = mem_pool().await;
-        insert(&pool, None, Some("button: Save"), "accessibility", 20).await;
+        insert(&pool, "A", None, Some("button: Save"), "accessibility", 20).await;
         assert_eq!(frames_present(&pool).await.severity, Severity::Ok);
         assert_eq!(blank_text_rate(&pool).await.severity, Severity::Ok);
-        assert_eq!(accessibility_share(&pool).await.severity, Severity::Ok);
         assert_eq!(frame_freshness(&pool).await.severity, Severity::Ok);
+        let checks = accessibility_checks(&pool).await;
+        assert_eq!(checks[0].severity, Severity::Ok); // permission verdict
+    }
+
+    #[tokio::test]
+    async fn permission_ok_when_any_app_has_a11y() {
+        // The whole point of per-app: a low-a11y app (Chrome) must NOT trigger a
+        // false "permission off" when another app (Code) clearly has a11y.
+        let pool = mem_pool().await;
+        insert(
+            &pool,
+            "Code",
+            None,
+            Some("editor tree"),
+            "accessibility",
+            30,
+        )
+        .await;
+        insert(&pool, "Chrome", Some("page text"), None, "ocr", 30).await;
+        let checks = accessibility_checks(&pool).await;
+        assert_eq!(checks[0].severity, Severity::Ok); // best app drives the verdict
+        assert!(checks.iter().any(|c| c.name == "screenpipe.a11y_per_app"));
+    }
+
+    #[tokio::test]
+    async fn no_app_with_a11y_flags_permission_off() {
+        let pool = mem_pool().await;
+        insert(&pool, "Code", Some("text"), None, "ocr", 30).await;
+        insert(&pool, "Chrome", Some("text"), None, "ocr", 30).await;
+        let checks = accessibility_checks(&pool).await;
+        assert_eq!(checks[0].severity, Severity::Critical);
+        assert!(checks[0].remedy.is_some());
     }
 
     #[test]

--- a/src/health/capture.rs
+++ b/src/health/capture.rs
@@ -8,7 +8,7 @@
 // timestamps, and text *presence* — never the captured text itself.
 
 use crate::config::Config;
-use crate::health::{Check, Report};
+use crate::health::Check;
 use sqlx::SqlitePool;
 
 /// Newest frame older than this ⇒ capture likely stopped (or the machine is
@@ -21,7 +21,7 @@ const RECENT_SAMPLE: i64 = 500;
 /// Run all L1 capture checks. `pool` is `None` when the screenpipe DB could not
 /// be opened read-only — the file-level check still runs and the rest report
 /// the open failure.
-pub async fn run(cfg: &Config, pool: Option<&SqlitePool>) -> Report {
+pub async fn checks(cfg: &Config, pool: Option<&SqlitePool>) -> Vec<Check> {
     // Prerequisites first (can capture run at all?), then runtime health.
     let mut checks = vec![screenpipe_installed(), db_present(cfg)];
     match pool {
@@ -54,7 +54,7 @@ pub async fn run(cfg: &Config, pool: Option<&SqlitePool>) -> Report {
             ),
         ),
     }
-    Report { checks }
+    checks
 }
 
 /// Prerequisite: the screenpipe binary is installed (on PATH). Without it there

--- a/src/health/capture.rs
+++ b/src/health/capture.rs
@@ -1,0 +1,307 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// L1 capture-layer health checks. Meridian reads screenpipe's frames read-only;
+// if capture is broken (screen-recording permission revoked → blank frames,
+// accessibility permission off → empty a11y tree, screenpipe dead → stale
+// frames), the classifier receives garbage and gets blamed for it. These probes
+// surface that as an L1 fault. All probes are content-free: they read counts,
+// timestamps, and text *presence* — never the captured text itself.
+
+use crate::config::Config;
+use crate::health::{Check, Report};
+use sqlx::SqlitePool;
+
+/// Newest frame older than this ⇒ capture likely stopped (or the machine is
+/// asleep). Warn, not critical — a sleeping machine is a legitimate cause.
+const STALE_FRAMES_SECS: f64 = 600.0;
+/// Sample size for the most-recent-frames ratio checks. By id (not wall-clock)
+/// so the checks still work when the machine has been idle/asleep.
+const RECENT_SAMPLE: i64 = 500;
+
+/// Run all L1 capture checks. `pool` is `None` when the screenpipe DB could not
+/// be opened read-only — the file-level check still runs and the rest report
+/// the open failure.
+pub async fn run(cfg: &Config, pool: Option<&SqlitePool>) -> Report {
+    let mut checks = vec![db_present(cfg)];
+    match pool {
+        Some(p) => {
+            let frames = frames_present(p).await;
+            // The ratio checks are only meaningful once frames exist.
+            let have_frames = frames.severity != crate::health::Severity::Critical;
+            checks.push(frames);
+            if have_frames {
+                checks.push(frame_freshness(p).await);
+                checks.push(blank_text_rate(p).await);
+                checks.push(accessibility_share(p).await);
+            }
+            checks.push(wal_size(cfg));
+        }
+        None => checks.push(Check::critical(
+            "screenpipe.pool",
+            "L1",
+            "could not open screenpipe DB read-only (path wrong, locked, or corrupt)",
+        )),
+    }
+    Report { checks }
+}
+
+/// The screenpipe DB file exists and is non-empty. File-stat only — no pool.
+fn db_present(cfg: &Config) -> Check {
+    let path = &cfg.screenpipe_db;
+    match std::fs::metadata(path) {
+        Ok(m) if m.len() > 0 => Check::ok(
+            "screenpipe.db_present",
+            "L1",
+            format!("{path} ({} KB)", m.len() / 1024),
+        ),
+        Ok(_) => Check::critical(
+            "screenpipe.db_present",
+            "L1",
+            format!("{path} exists but is empty — screenpipe never captured"),
+        ),
+        Err(e) => Check::critical(
+            "screenpipe.db_present",
+            "L1",
+            format!("{path} not found ({e}) — is screenpipe installed/running?"),
+        ),
+    }
+}
+
+/// The `frames` table is readable and non-empty. An unreadable table means
+/// screenpipe schema drift (renamed/missing table), which breaks every ETL tick.
+async fn frames_present(pool: &SqlitePool) -> Check {
+    match sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM frames")
+        .fetch_one(pool)
+        .await
+    {
+        Ok(0) => Check::critical(
+            "screenpipe.frames",
+            "L1",
+            "frames table is empty — screenpipe has captured nothing",
+        ),
+        Ok(n) => Check::ok("screenpipe.frames", "L1", format!("{n} frames total")),
+        Err(e) => Check::critical(
+            "screenpipe.frames",
+            "L1",
+            format!("frames table unreadable ({e}) — screenpipe schema drift?"),
+        ),
+    }
+}
+
+/// Age of the newest frame. Uses julianday() arithmetic (not string compare) so
+/// it is robust to the timestamp format/timezone. A future timestamp surfaces
+/// clock/timezone skew rather than hiding it.
+async fn frame_freshness(pool: &SqlitePool) -> Check {
+    let age = sqlx::query_scalar::<_, Option<f64>>(
+        "SELECT (julianday('now') - julianday(MAX(timestamp))) * 86400.0 FROM frames",
+    )
+    .fetch_one(pool)
+    .await;
+    match age {
+        Ok(Some(secs)) if secs < -60.0 => Check::warn(
+            "screenpipe.freshness",
+            "L1",
+            format!(
+                "newest frame is {:.0}s in the future — clock/timezone skew",
+                -secs
+            ),
+        ),
+        Ok(Some(secs)) if secs > STALE_FRAMES_SECS => Check::warn(
+            "screenpipe.freshness",
+            "L1",
+            format!(
+                "newest frame is {:.0}s old (> {:.0}s) — capture stopped or machine asleep",
+                secs, STALE_FRAMES_SECS
+            ),
+        ),
+        Ok(Some(secs)) => Check::ok(
+            "screenpipe.freshness",
+            "L1",
+            format!("newest frame {:.0}s ago", secs.max(0.0)),
+        ),
+        Ok(None) => Check::warn(
+            "screenpipe.freshness",
+            "L1",
+            "no frame timestamps to measure",
+        ),
+        Err(e) => Check::warn(
+            "screenpipe.freshness",
+            "L1",
+            format!("could not read frame freshness ({e})"),
+        ),
+    }
+}
+
+/// Fraction of the most-recent frames with no extractable text. A high blank
+/// rate is the content-free proxy for Screen-Recording permission revoked
+/// (screenpipe captures black frames → OCR yields nothing).
+async fn blank_text_rate(pool: &SqlitePool) -> Check {
+    let row = sqlx::query_as::<_, (i64, i64)>(
+        "SELECT COUNT(*),
+                COALESCE(SUM(CASE WHEN COALESCE(full_text, accessibility_text) IS NULL
+                                   OR COALESCE(full_text, accessibility_text) = ''
+                                  THEN 1 ELSE 0 END), 0)
+         FROM (SELECT full_text, accessibility_text FROM frames ORDER BY id DESC LIMIT ?1)",
+    )
+    .bind(RECENT_SAMPLE)
+    .fetch_one(pool)
+    .await;
+    match row {
+        Ok((0, _)) => Check::ok("screenpipe.text_present", "L1", "no recent frames sampled"),
+        Ok((total, blank)) => {
+            let pct = 100.0 * blank as f64 / total as f64;
+            let detail = format!("{blank}/{total} recent frames blank ({pct:.0}%)");
+            if pct >= 90.0 {
+                Check::critical(
+                    "screenpipe.text_present",
+                    "L1",
+                    format!("{detail} — Screen Recording permission likely revoked"),
+                )
+            } else if pct >= 50.0 {
+                Check::warn(
+                    "screenpipe.text_present",
+                    "L1",
+                    format!("{detail} — degraded OCR/capture"),
+                )
+            } else {
+                Check::ok("screenpipe.text_present", "L1", detail)
+            }
+        }
+        Err(e) => Check::warn(
+            "screenpipe.text_present",
+            "L1",
+            format!("could not sample frame text ({e})"),
+        ),
+    }
+}
+
+/// Share of recent frames whose text came from the accessibility tree. A near-
+/// zero share is the content-free proxy for Accessibility permission off (or an
+/// Electron-heavy workload, e.g. Cursor/VS Code, that returns an empty a11y
+/// tree). Warn only — OCR-only capture is degraded, not dead.
+async fn accessibility_share(pool: &SqlitePool) -> Check {
+    let row = sqlx::query_as::<_, (i64, i64)>(
+        "SELECT COUNT(*),
+                COALESCE(SUM(CASE WHEN COALESCE(text_source, '') = 'accessibility'
+                                  THEN 1 ELSE 0 END), 0)
+         FROM (SELECT text_source FROM frames ORDER BY id DESC LIMIT ?1)",
+    )
+    .bind(RECENT_SAMPLE)
+    .fetch_one(pool)
+    .await;
+    match row {
+        Ok((0, _)) => Check::ok("screenpipe.a11y_tree", "L1", "no recent frames sampled"),
+        Ok((total, a11y)) => {
+            let pct = 100.0 * a11y as f64 / total as f64;
+            let detail = format!("{a11y}/{total} recent frames via a11y ({pct:.0}%)");
+            if pct < 5.0 {
+                Check::warn(
+                    "screenpipe.a11y_tree",
+                    "L1",
+                    format!("{detail} — Accessibility permission off or Electron-heavy apps"),
+                )
+            } else {
+                Check::ok("screenpipe.a11y_tree", "L1", detail)
+            }
+        }
+        Err(e) => Check::warn(
+            "screenpipe.a11y_tree",
+            "L1",
+            format!("could not sample text_source ({e})"),
+        ),
+    }
+}
+
+/// screenpipe's WAL file size. An unbounded WAL (stalled checkpoint) means disk
+/// pressure and slow reads. Absent WAL is healthy (checkpointed).
+fn wal_size(cfg: &Config) -> Check {
+    let wal = format!("{}-wal", cfg.screenpipe_db);
+    match std::fs::metadata(&wal) {
+        Ok(m) => {
+            let mb = m.len() / 1_048_576;
+            if mb > 1024 {
+                Check::warn(
+                    "screenpipe.wal",
+                    "L1",
+                    format!("WAL is {mb} MB — checkpoint may be stalled"),
+                )
+            } else {
+                Check::ok("screenpipe.wal", "L1", format!("WAL {mb} MB"))
+            }
+        }
+        Err(_) => Check::ok("screenpipe.wal", "L1", "no WAL (checkpointed)"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::health::Severity;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    /// In-memory screenpipe-shaped DB. max_connections(1) keeps the one
+    /// in-memory database alive across queries.
+    async fn mem_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE frames(
+                id INTEGER PRIMARY KEY,
+                app_name TEXT, timestamp TEXT,
+                full_text TEXT, accessibility_text TEXT, text_source TEXT)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    async fn insert(
+        pool: &SqlitePool,
+        full: Option<&str>,
+        a11y: Option<&str>,
+        src: &str,
+        n: usize,
+    ) {
+        for _ in 0..n {
+            sqlx::query(
+                "INSERT INTO frames(app_name, timestamp, full_text, accessibility_text, text_source)
+                 VALUES('A', strftime('%Y-%m-%dT%H:%M:%SZ','now'), ?1, ?2, ?3)",
+            )
+            .bind(full)
+            .bind(a11y)
+            .bind(src)
+            .execute(pool)
+            .await
+            .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_frames_is_critical() {
+        let pool = mem_pool().await;
+        assert_eq!(frames_present(&pool).await.severity, Severity::Critical);
+    }
+
+    #[tokio::test]
+    async fn all_blank_flags_screen_recording() {
+        let pool = mem_pool().await;
+        insert(&pool, Some(""), Some(""), "ocr", 20).await;
+        assert_eq!(blank_text_rate(&pool).await.severity, Severity::Critical);
+        // 0% a11y share → warn (perm off or Electron-heavy).
+        assert_eq!(accessibility_share(&pool).await.severity, Severity::Warn);
+    }
+
+    #[tokio::test]
+    async fn healthy_a11y_capture_is_ok() {
+        let pool = mem_pool().await;
+        insert(&pool, None, Some("button: Save"), "accessibility", 20).await;
+        assert_eq!(frames_present(&pool).await.severity, Severity::Ok);
+        assert_eq!(blank_text_rate(&pool).await.severity, Severity::Ok);
+        assert_eq!(accessibility_share(&pool).await.severity, Severity::Ok);
+        assert_eq!(frame_freshness(&pool).await.severity, Severity::Ok);
+    }
+}

--- a/src/health/capture.rs
+++ b/src/health/capture.rs
@@ -22,7 +22,8 @@ const RECENT_SAMPLE: i64 = 500;
 /// be opened read-only — the file-level check still runs and the rest report
 /// the open failure.
 pub async fn run(cfg: &Config, pool: Option<&SqlitePool>) -> Report {
-    let mut checks = vec![db_present(cfg)];
+    // Prerequisites first (can capture run at all?), then runtime health.
+    let mut checks = vec![screenpipe_installed(), db_present(cfg)];
     match pool {
         Some(p) => {
             let frames = frames_present(p).await;
@@ -30,19 +31,64 @@ pub async fn run(cfg: &Config, pool: Option<&SqlitePool>) -> Report {
             let have_frames = frames.severity != crate::health::Severity::Critical;
             checks.push(frames);
             if have_frames {
+                // Runtime capture quality — these also serve as the permission
+                // proxies (blank rate → Screen Recording, a11y share → Accessibility).
                 checks.push(frame_freshness(p).await);
                 checks.push(blank_text_rate(p).await);
                 checks.push(accessibility_share(p).await);
+            } else {
+                // Fresh install / nothing captured: the runtime proxies are blind,
+                // so surface the permission prerequisite explicitly.
+                checks.push(permissions_unverified());
             }
             checks.push(wal_size(cfg));
         }
-        None => checks.push(Check::critical(
-            "screenpipe.pool",
-            "L1",
-            "could not open screenpipe DB read-only (path wrong, locked, or corrupt)",
-        )),
+        None => checks.push(
+            Check::critical(
+                "screenpipe.pool",
+                "L1",
+                "could not open screenpipe DB read-only (path wrong, locked, or corrupt)",
+            )
+            .with_remedy(
+                "check SCREENPIPE_DB points at ~/.screenpipe/db.sqlite and screenpipe is running",
+            ),
+        ),
     }
     Report { checks }
+}
+
+/// Prerequisite: the screenpipe binary is installed (on PATH). Without it there
+/// is no capture at all. Content-free — a filesystem lookup only.
+fn screenpipe_installed() -> Check {
+    match which("screenpipe") {
+        Some(path) => Check::ok("screenpipe.installed", "L1", format!("{}", path.display())),
+        None => Check::critical("screenpipe.installed", "L1", "not found on PATH").with_remedy(
+            "install screenpipe (e.g. brew install screenpipe) and load its launchd service",
+        ),
+    }
+}
+
+/// Find an executable on PATH without pulling in the `which` crate.
+fn which(bin: &str) -> Option<std::path::PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(bin))
+        .find(|cand| cand.is_file())
+}
+
+/// Prerequisite for the fresh-install / no-frames case, where the runtime
+/// blank/a11y proxies cannot run. macOS TCC permission state isn't cleanly
+/// readable from here, so this is an explicit "unverified — grant and re-run"
+/// prompt rather than a false pass.
+fn permissions_unverified() -> Check {
+    Check::warn(
+        "screenpipe.permissions",
+        "L1",
+        "no frames captured yet — Screen Recording / Accessibility may not be granted",
+    )
+    .with_remedy(
+        "System Settings ▸ Privacy & Security ▸ grant Screen Recording AND Accessibility to screenpipe, then restart it and re-run doctor",
+    )
 }
 
 /// The screenpipe DB file exists and is non-empty. File-stat only — no pool.
@@ -58,12 +104,14 @@ fn db_present(cfg: &Config) -> Check {
             "screenpipe.db_present",
             "L1",
             format!("{path} exists but is empty — screenpipe never captured"),
-        ),
+        )
+        .with_remedy("start screenpipe and grant it Screen Recording, then re-run doctor"),
         Err(e) => Check::critical(
             "screenpipe.db_present",
             "L1",
             format!("{path} not found ({e}) — is screenpipe installed/running?"),
-        ),
+        )
+        .with_remedy("install + start screenpipe so it creates ~/.screenpipe/db.sqlite"),
     }
 }
 
@@ -157,6 +205,9 @@ async fn blank_text_rate(pool: &SqlitePool) -> Check {
                     "L1",
                     format!("{detail} — Screen Recording permission likely revoked"),
                 )
+                .with_remedy(
+                    "re-grant Screen Recording to screenpipe in System Settings, then restart it",
+                )
             } else if pct >= 50.0 {
                 Check::warn(
                     "screenpipe.text_present",
@@ -199,6 +250,9 @@ async fn accessibility_share(pool: &SqlitePool) -> Check {
                     "screenpipe.a11y_tree",
                     "L1",
                     format!("{detail} — Accessibility permission off or Electron-heavy apps"),
+                )
+                .with_remedy(
+                    "grant Accessibility to screenpipe (expected to be low for Electron apps like Cursor/VS Code)",
                 )
             } else {
                 Check::ok("screenpipe.a11y_tree", "L1", detail)
@@ -303,5 +357,19 @@ mod tests {
         assert_eq!(blank_text_rate(&pool).await.severity, Severity::Ok);
         assert_eq!(accessibility_share(&pool).await.severity, Severity::Ok);
         assert_eq!(frame_freshness(&pool).await.severity, Severity::Ok);
+    }
+
+    #[test]
+    fn which_resolves_real_and_missing() {
+        assert!(which("sh").is_some());
+        assert!(which("definitely_not_a_real_binary_xyz123").is_none());
+    }
+
+    #[test]
+    fn permissions_prompt_is_actionable() {
+        // The no-frames prerequisite must carry a remedy, not a silent pass.
+        let c = permissions_unverified();
+        assert_eq!(c.severity, Severity::Warn);
+        assert!(c.remedy.is_some());
     }
 }

--- a/src/health/codingagent.rs
+++ b/src/health/codingagent.rs
@@ -1,0 +1,56 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Coding-agent ingest health: whether the Claude Code / Codex CLIs and their
+// JSONL session dirs are present (the inputs that gate the indexer + summariser
+// into a rich transcript path), and a note about the Cursor blind spot.
+
+use crate::config::Config;
+use crate::health::platform::which;
+use crate::health::Check;
+use std::path::PathBuf;
+
+pub fn checks(_cfg: &Config) -> Vec<Check> {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    let mut out = vec![
+        cli("claude", "Claude Code"),
+        cli("codex", "Codex"),
+        dir(&home.join(".claude/projects"), "claude sessions dir"),
+        dir(&home.join(".codex/sessions"), "codex sessions dir"),
+    ];
+
+    // The Cursor gap: Cursor stores agent sessions outside the ingested paths, so
+    // its work is only captured via OCR/a11y, never the rich transcript path.
+    let cursor_present =
+        which("cursor").is_some() || home.join("Library/Application Support/Cursor").is_dir();
+    if cursor_present {
+        out.push(Check::info(
+            "cursor",
+            "L1",
+            "detected — captured via OCR/a11y only (no transcript ingest)",
+        ));
+    }
+    out
+}
+
+fn cli(bin: &str, label: &'static str) -> Check {
+    if which(bin).is_some() {
+        Check::ok(label, "L2", format!("{bin} on PATH"))
+    } else {
+        Check::info(
+            label,
+            "L2",
+            format!("{bin} not on PATH — those sessions fall back to MLX summaries"),
+        )
+    }
+}
+
+fn dir(path: &std::path::Path, label: &'static str) -> Check {
+    if path.is_dir() {
+        Check::ok(label, "L1", "present")
+    } else {
+        Check::info(label, "L1", "none yet")
+    }
+}

--- a/src/health/contracts.rs
+++ b/src/health/contracts.rs
@@ -1,0 +1,93 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Cross-process config contracts: values multiple processes must agree on, where
+// a silent mismatch masquerades as an AI/runtime fault. Verified against the
+// code: the UI reads MERIDIAN_DB_PATH (not MERIDIAN_DB), and the daemon reads
+// <repo>/settings.json (not the UI's ~/.meridian/settings.json).
+
+use crate::config::Config;
+use crate::health::platform::repo_root;
+use crate::health::Check;
+use std::path::PathBuf;
+
+fn home() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn expand(p: &str) -> String {
+    p.strip_prefix("~/")
+        .map(|rest| home().join(rest).display().to_string())
+        .unwrap_or_else(|| p.to_string())
+}
+
+pub fn checks(cfg: &Config) -> Vec<Check> {
+    vec![db_path_contract(cfg), settings_contract(), dead_poll_env()]
+}
+
+/// C1 — the daemon/MCP/MLX open MERIDIAN_DB; the UI opens MERIDIAN_DB_PATH. If
+/// they diverge the dashboard silently reads a different (stale/empty) database.
+fn db_path_contract(cfg: &Config) -> Check {
+    let daemon_db = cfg.meridian_db.clone(); // already tilde-expanded by Config
+    let ui_db = expand(
+        &std::env::var("MERIDIAN_DB_PATH")
+            .unwrap_or_else(|_| "~/.meridian/meridian.db".to_string()),
+    );
+    if daemon_db == ui_db {
+        Check::ok("db path", "config", "daemon + UI agree")
+    } else {
+        Check::warn(
+            "db path",
+            "config",
+            format!("daemon writes {daemon_db}; UI reads {ui_db}"),
+        )
+        .with_remedy("set MERIDIAN_DB_PATH (UI) equal to MERIDIAN_DB, or unset both")
+    }
+}
+
+/// C7 — the daemon reads `<repo>/settings.json`; the dashboard writes
+/// `~/.meridian/settings.json`. If only the latter exists, toggles in the UI
+/// never reach the daemon.
+fn settings_contract() -> Check {
+    let daemon_exists = repo_root()
+        .map(|r| r.join("settings.json").is_file())
+        .unwrap_or(false);
+    let ui_settings = home().join(".meridian/settings.json");
+    if ui_settings.is_file() && !daemon_exists {
+        Check::warn(
+            "settings file",
+            "config",
+            "~/.meridian/settings.json is not read by the daemon",
+        )
+        .with_remedy("the daemon reads <repo>/settings.json — align them")
+    } else {
+        Check::ok("settings file", "config", "no split-brain")
+    }
+}
+
+/// Dead env var: POLL_INTERVAL_SECS is documented but ignored (the daemon takes
+/// the interval from settings.json). Flag if someone set it expecting an effect.
+fn dead_poll_env() -> Check {
+    if std::env::var("POLL_INTERVAL_SECS").is_ok() {
+        Check::info(
+            "poll interval",
+            "config",
+            "POLL_INTERVAL_SECS is set but ignored — the daemon uses settings.json",
+        )
+    } else {
+        Check::ok("poll interval", "config", "from settings.json")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expand;
+
+    #[test]
+    fn expand_handles_tilde_and_absolute() {
+        assert!(expand("~/x").ends_with("/x"));
+        assert!(!expand("~/x").starts_with('~'));
+        assert_eq!(expand("/abs/path"), "/abs/path");
+    }
+}

--- a/src/health/daemon.rs
+++ b/src/health/daemon.rs
@@ -1,0 +1,145 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// meridian-daemon health: ETL liveness, frame-cursor progress, classification
+// queue depth, and the subprocess-error sentinel. All content-free (statuses,
+// counts, timestamps from meridian.db, opened read-only).
+
+use crate::config::Config;
+use crate::health::Check;
+use sqlx::sqlite::SqliteConnectOptions;
+use sqlx::SqlitePool;
+use std::str::FromStr;
+
+/// No ETL run in this long ⇒ the poll loop is probably stalled.
+const STALE_RUN_SECS: f64 = 1800.0;
+/// A pending_* queue this deep ⇒ a downstream stage is wedged.
+const QUEUE_WARN: i64 = 50;
+
+/// Open meridian.db read-only for inspection. Returns None if it cannot be
+/// opened (missing / not yet created / corrupt) — the caller surfaces that.
+pub async fn open_meridian_ro(cfg: &Config) -> Option<SqlitePool> {
+    let opts = SqliteConnectOptions::from_str(&cfg.meridian_db_uri())
+        .ok()?
+        .read_only(true);
+    SqlitePool::connect_with(opts).await.ok()
+}
+
+pub async fn checks(_cfg: &Config, pool: Option<&SqlitePool>) -> Vec<Check> {
+    let p = match pool {
+        Some(p) => p,
+        None => {
+            return vec![Check::critical(
+                "meridian DB",
+                "L1",
+                "meridian.db not readable (missing, locked, or not yet created)",
+            )
+            .with_remedy("start the daemon once to create ~/.meridian/meridian.db")]
+        }
+    };
+    vec![
+        Check::ok("meridian DB", "L1", "readable"),
+        etl_last_run(p).await,
+        etl_freshness(p).await,
+        etl_cursor(p).await,
+        queue_depth(p, "pending_summariser", "summariser queue").await,
+        queue_depth(p, "pending_classifier", "classifier queue").await,
+        subprocess_errors(p).await,
+    ]
+}
+
+async fn etl_last_run(pool: &SqlitePool) -> Check {
+    match sqlx::query_as::<_, (String, Option<String>)>(
+        "SELECT status, error FROM etl_runs ORDER BY id DESC LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await
+    {
+        Ok(Some((status, err))) => match status.as_str() {
+            "success" | "skipped" => Check::ok("etl last run", "L1", format!("status: {status}")),
+            "running" => Check::info("etl last run", "L1", "a run is in progress"),
+            "failed" => Check::critical(
+                "etl last run",
+                "L1",
+                format!("failed: {}", err.unwrap_or_default()),
+            )
+            .with_remedy("check ~/.meridian/logs — usually a screenpipe read error"),
+            other => Check::warn("etl last run", "L1", format!("status: {other}")),
+        },
+        Ok(None) => Check::info("etl last run", "L1", "no ETL runs yet"),
+        Err(e) => Check::warn(
+            "etl last run",
+            "L1",
+            format!("could not read etl_runs ({e})"),
+        ),
+    }
+}
+
+async fn etl_freshness(pool: &SqlitePool) -> Check {
+    match sqlx::query_scalar::<_, Option<f64>>(
+        "SELECT (julianday('now') - julianday(MAX(started_at))) * 86400.0 FROM etl_runs",
+    )
+    .fetch_one(pool)
+    .await
+    {
+        Ok(Some(age)) if age > STALE_RUN_SECS => Check::warn(
+            "etl freshness",
+            "L1",
+            format!("last run {:.0}m ago — poll loop may be stalled", age / 60.0),
+        )
+        .with_remedy("meridian restart"),
+        Ok(Some(age)) => Check::ok(
+            "etl freshness",
+            "L1",
+            format!("last run {:.0}s ago", age.max(0.0)),
+        ),
+        Ok(None) => Check::info("etl freshness", "L1", "no runs yet"),
+        Err(e) => Check::warn(
+            "etl freshness",
+            "L1",
+            format!("could not read run time ({e})"),
+        ),
+    }
+}
+
+async fn etl_cursor(pool: &SqlitePool) -> Check {
+    match sqlx::query_scalar::<_, i64>("SELECT last_frame_id FROM etl_cursor WHERE id = 1")
+        .fetch_optional(pool)
+        .await
+    {
+        Ok(Some(id)) => Check::ok("etl cursor", "L1", format!("at frame {id}")),
+        Ok(None) => Check::info("etl cursor", "L1", "not initialised yet"),
+        Err(e) => Check::warn("etl cursor", "L1", format!("could not read cursor ({e})")),
+    }
+}
+
+async fn queue_depth(pool: &SqlitePool, method: &str, label: &'static str) -> Check {
+    match sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM app_sessions WHERE task_method = ?1")
+        .bind(method)
+        .fetch_one(pool)
+        .await
+    {
+        Ok(0) => Check::ok(label, "L2", "empty"),
+        Ok(n) if n >= QUEUE_WARN => Check::warn(label, "L2", format!("{n} sessions backed up"))
+            .with_remedy("check the MLX server / claude+codex CLIs are reachable"),
+        Ok(n) => Check::info(label, "L2", format!("{n} pending")),
+        Err(e) => Check::warn(label, "L2", format!("could not read queue ({e})")),
+    }
+}
+
+async fn subprocess_errors(pool: &SqlitePool) -> Check {
+    match sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM app_sessions WHERE task_method = 'subprocess_error'",
+    )
+    .fetch_one(pool)
+    .await
+    {
+        Ok(0) => Check::ok("classify errors", "L2", "no sentinel errors"),
+        Ok(n) => Check::warn(
+            "classify errors",
+            "L2",
+            format!("{n} sessions sentinelled — usually a sustained MLX outage, not the model"),
+        )
+        .with_remedy("verify the MLX server, then re-classify those sessions"),
+        Err(e) => Check::warn("classify errors", "L2", format!("could not read ({e})")),
+    }
+}

--- a/src/health/diagnose.rs
+++ b/src/health/diagnose.rs
@@ -113,7 +113,17 @@ pub fn root_causes(report: &Report) -> Vec<Diagnosis> {
         });
     }
 
-    // 5. Settings split-brain (standalone config issue).
+    // 5. Dashboard serving a broken build — up but blank.
+    if crit("ui", "ui assets") || crit("ui", "ui serve mode") {
+        out.push(Diagnosis {
+            title: "Dashboard is serving a broken build".into(),
+            cause: "The UI process is up and `/` returns 200, but its _next/static assets 404/500 — usually a stale build or an output:'standalone' build served with `next start`. The page loads blank.".into(),
+            contributing: contributing(&[("ui", "ui assets"), ("ui", "ui serve mode")]),
+            action: "Rebuild the UI (cd ui && npm run build) and restart; if standalone, serve via `node .next/standalone/server.js`.".into(),
+        });
+    }
+
+    // 6. Settings split-brain (standalone config issue).
     if bad("config", "settings file") {
         out.push(Diagnosis {
             title: "UI settings aren't reaching the daemon".into(),

--- a/src/health/diagnose.rs
+++ b/src/health/diagnose.rs
@@ -113,6 +113,16 @@ pub fn root_causes(report: &Report) -> Vec<Diagnosis> {
         });
     }
 
+    // 4b. a11y capture regressed for specific apps.
+    if bad("screenpipe", "a11y_regression") {
+        out.push(Diagnosis {
+            title: "Accessibility capture regressed for some apps".into(),
+            cause: "Apps that used to yield structured a11y text dropped to OCR-only — capture broke for them, or the app updated and stopped exposing a tree. Their sessions now feed the classifier lower-fidelity input.".into(),
+            contributing: contributing(&[("screenpipe", "a11y_regression")]),
+            action: "Restart screenpipe; if it persists, the app changed its a11y support.".into(),
+        });
+    }
+
     // 5. Dashboard serving a broken build — up but blank.
     if crit("ui", "ui assets") || crit("ui", "ui serve mode") {
         out.push(Diagnosis {

--- a/src/health/diagnose.rs
+++ b/src/health/diagnose.rs
@@ -1,0 +1,222 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Root-cause diagnosis. Correlates failing checks into the underlying cause so
+// the operator sees "the summariser stalled (which is why hours are stuck and
+// sessions sentinelled)" instead of three disconnected warnings. Rule-based
+// over the check set, plus the escalation footer for the plain `doctor`.
+
+use crate::health::{Report, Severity};
+
+pub struct Diagnosis {
+    /// The root cause, one line.
+    pub title: String,
+    /// Why it produces the symptoms below.
+    pub cause: String,
+    /// The failing checks this cause explains (group › name).
+    pub contributing: Vec<String>,
+    /// What to do about it.
+    pub action: String,
+}
+
+/// Correlate the report's failing checks into root causes (most-specific first).
+pub fn root_causes(report: &Report) -> Vec<Diagnosis> {
+    let crit = |group: &str, needle: &str| {
+        report.checks.iter().any(|c| {
+            c.severity == Severity::Critical && c.group == group && c.name.contains(needle)
+        })
+    };
+    let bad = |group: &str, needle: &str| {
+        report
+            .checks
+            .iter()
+            .any(|c| c.severity >= Severity::Warn && c.group == group && c.name.contains(needle))
+    };
+    let contributing = |pairs: &[(&str, &str)]| -> Vec<String> {
+        report
+            .checks
+            .iter()
+            .filter(|c| {
+                c.severity >= Severity::Warn
+                    && pairs
+                        .iter()
+                        .any(|(g, n)| c.group == *g && c.name.contains(n))
+            })
+            .map(|c| format!("{} › {}", c.group, c.name))
+            .collect()
+    };
+
+    let mut out = Vec::new();
+
+    // 1. MLX server down — the whole classify/summarise cascade.
+    if crit("mlx-server", "reachable") {
+        out.push(Diagnosis {
+            title: "MLX classifier server is down".into(),
+            cause: "All classification and summarisation run through the MLX server. With it down, sealed sessions pile up, eventually get sentinelled, and worklog hours stall behind them.".into(),
+            contributing: contributing(&[
+                ("meridian daemon", "queue"),
+                ("meridian daemon", "classify errors"),
+                ("worklog", "hour ledger"),
+            ]),
+            action: "Start it (`meridian start`), then `meridian doctor --fix` to drain the backlog.".into(),
+        });
+    } else if bad("meridian daemon", "summariser queue") {
+        out.push(Diagnosis {
+            title: "Coding-agent summariser is stalled".into(),
+            cause: "Sealed sessions aren't being summarised, so they never reach the classifier and the worklog hour-ledger backs up behind them.".into(),
+            contributing: contributing(&[
+                ("meridian daemon", "summariser queue"),
+                ("meridian daemon", "classify errors"),
+                ("worklog", "hour ledger"),
+            ]),
+            action: "The claude/codex CLI or MLX /summarise is likely failing — inspect with `meridian coding-agent-summarise --dry-run`, or run `meridian doctor --fix`.".into(),
+        });
+    }
+
+    // 2. Jira: a rejected token vs a merely-stale cache.
+    if crit("jira", "auth") {
+        out.push(Diagnosis {
+            title: "Jira token rejected".into(),
+            cause: "The API token is expired or lacks scope, so the ticket cache can't refresh and the candidate set goes stale or empty.".into(),
+            contributing: contributing(&[("jira", "ticket sync"), ("jira", "candidate")]),
+            action: "Regenerate the Jira API token, update JIRA_API_TOKEN in .env, then `meridian restart`.".into(),
+        });
+    } else if bad("jira", "ticket sync") {
+        out.push(Diagnosis {
+            title: "Jira cache is stale (auth OK)".into(),
+            cause: "Auth works and the daemon refreshes every 30 min, so this usually means the daemon was down recently and it will self-heal — unless the fetch itself is erroring.".into(),
+            contributing: contributing(&[("jira", "ticket sync")]),
+            action: "If it persists past 30 min of healthy uptime, force a refresh via `meridian doctor --fix`.".into(),
+        });
+    }
+
+    // 3. Daemon down — broad staleness.
+    if crit("meridian daemon", "running") {
+        out.push(Diagnosis {
+            title: "The meridian daemon isn't running".into(),
+            cause: "Nothing advances while it is down — ETL, classification, sync, and worklogs all stall.".into(),
+            contributing: contributing(&[
+                ("meridian daemon", "etl"),
+                ("jira", "ticket sync"),
+                ("worklog", "hour ledger"),
+            ]),
+            action: "`meridian start` (or `meridian doctor --fix`).".into(),
+        });
+    }
+
+    // 4. Capture degraded — garbage-in for the classifier.
+    if crit("screenpipe", "text_present") || crit("screenpipe", "service") {
+        out.push(Diagnosis {
+            title: "Screen capture is degraded".into(),
+            cause: "screenpipe isn't producing usable text, so every session feeds the classifier blank/garbage input — misclassifications here are L1 capture faults, not the model.".into(),
+            contributing: contributing(&[("screenpipe", "text_present"), ("screenpipe", "service")]),
+            action: "Check Screen-Recording permission for screenpipe and that it is running.".into(),
+        });
+    }
+
+    // 5. Settings split-brain (standalone config issue).
+    if bad("config", "settings file") {
+        out.push(Diagnosis {
+            title: "UI settings aren't reaching the daemon".into(),
+            cause: "The dashboard writes ~/.meridian/settings.json but the daemon reads <repo>/settings.json, so toggles made in the UI have no effect.".into(),
+            contributing: contributing(&[("config", "settings file")]),
+            action: "Align the two files — `meridian doctor --fix` can link them.".into(),
+        });
+    }
+
+    out
+}
+
+/// The "Diagnosis" section for the plain `doctor` report.
+pub fn render(dx: &[Diagnosis], color: bool) -> String {
+    if dx.is_empty() {
+        return String::new();
+    }
+    let paint = |code: &str, s: &str| {
+        if color {
+            format!("{code}{s}\x1b[0m")
+        } else {
+            s.to_string()
+        }
+    };
+    let bold = |s: &str| paint("\x1b[1m", s);
+    let dim = |s: &str| paint("\x1b[2m", s);
+
+    let mut out = format!("\n  {}\n", bold("Diagnosis"));
+    for d in dx {
+        out.push_str(&format!(
+            "  {} {}\n",
+            paint("\x1b[33m", "●"),
+            bold(&d.title)
+        ));
+        out.push_str(&format!("      {}\n", dim(&d.cause)));
+        if !d.contributing.is_empty() {
+            out.push_str(&format!(
+                "      {} {}\n",
+                dim("from:"),
+                dim(&d.contributing.join(", "))
+            ));
+        }
+        out.push_str(&format!(
+            "      {} {}\n",
+            paint("\x1b[36m", "fix:"),
+            d.action
+        ));
+    }
+    out
+}
+
+/// The escalation footer shown whenever the report has any warning/critical.
+pub fn escalation_hint(color: bool) -> String {
+    let paint = |code: &str, s: &str| {
+        if color {
+            format!("{code}{s}\x1b[0m")
+        } else {
+            s.to_string()
+        }
+    };
+    let bold = |s: &str| paint("\x1b[1m", s);
+    let dim = |s: &str| paint("\x1b[2m", s);
+    format!(
+        "\n  {}\n    • {}  {}\n    • {}\n",
+        bold("Still stuck?"),
+        "meridian doctor --fix",
+        dim("attempt automatic + guided repair"),
+        dim("share this output with the team, or run: claude \"debug my meridian doctor output\""),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::health::Check;
+
+    #[test]
+    fn summariser_backlog_chains_to_one_root_cause() {
+        let report = Report::new(vec![
+            Check::warn("summariser queue", "L2", "293 backed up").in_group("meridian daemon"),
+            Check::warn("hour ledger", "L4", "5 stuck").in_group("worklog"),
+            Check::ok("reachable", "L2", "ok").in_group("mlx-server"),
+        ]);
+        let dx = root_causes(&report);
+        assert_eq!(dx.len(), 1);
+        assert!(dx[0].title.contains("summariser"));
+        // both symptoms attributed to the one cause
+        assert_eq!(dx[0].contributing.len(), 2);
+    }
+
+    #[test]
+    fn mlx_down_supersedes_the_queue_symptom() {
+        let report = Report::new(vec![
+            Check::critical("reachable", "L2", "down").in_group("mlx-server"),
+            Check::warn("summariser queue", "L2", "293").in_group("meridian daemon"),
+        ]);
+        let dx = root_causes(&report);
+        assert!(dx[0].title.contains("MLX"));
+    }
+
+    #[test]
+    fn healthy_report_has_no_diagnosis() {
+        let report = Report::new(vec![Check::ok("x", "L1", "fine").in_group("system")]);
+        assert!(root_causes(&report).is_empty());
+    }
+}

--- a/src/health/fix.rs
+++ b/src/health/fix.rs
@@ -1,0 +1,266 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// `meridian doctor --fix`: attempt to repair the warnings/criticals the sweep
+// found. Fixes are tiered by risk —
+//   Auto   : safe + idempotent, run silently (restart a dead service)
+//   Guided : run, but show the command and ask y/N first (drain a queue)
+//   Manual : only a human can (regenerate a token) — print the remedy
+// Anything still failing after a pass is escalated: a content-free bundle is
+// written for the team / a `claude` hand-off. `--dry-run` plans without acting.
+
+use crate::config::Config;
+use crate::health::platform::repo_root;
+use crate::health::{Check, Report, Severity};
+use std::io::{BufRead, IsTerminal, Write};
+use std::process::Command;
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum Tier {
+    Auto,
+    Guided,
+    Manual,
+}
+
+pub struct FixAction {
+    pub tier: Tier,
+    pub label: String,
+    /// argv to execute (empty for Manual). Run in the repo root.
+    pub command: Vec<String>,
+}
+
+/// Map a failing check to a repair, if one exists.
+pub fn fix_for(c: &Check) -> Option<FixAction> {
+    let (g, n) = (c.group, c.name.as_str());
+    let auto = |label: &str, cmd: &[&str]| {
+        Some(FixAction {
+            tier: Tier::Auto,
+            label: label.into(),
+            command: cmd.iter().map(|s| s.to_string()).collect(),
+        })
+    };
+    let guided = |label: &str, cmd: &[&str]| {
+        Some(FixAction {
+            tier: Tier::Guided,
+            label: label.into(),
+            command: cmd.iter().map(|s| s.to_string()).collect(),
+        })
+    };
+    let manual = |label: &str| {
+        Some(FixAction {
+            tier: Tier::Manual,
+            label: label.into(),
+            command: Vec::new(),
+        })
+    };
+
+    match (g, n) {
+        // A dead launchd service → bring the stack up (safe, idempotent).
+        (_, name) if name.contains("running") || name.contains("service") => {
+            auto("restart the daemons", &["meridian", "start"])
+        }
+        // Stale Jira cache → force a refresh.
+        ("jira", name) if name.contains("ticket sync") => {
+            guided("refresh the Jira ticket cache", &["meridian", "restart"])
+        }
+        // Summariser backlog → drain it (mutates data → guided).
+        ("meridian daemon", name) if name.contains("summariser queue") => guided(
+            "drain the summariser queue",
+            &["meridian", "coding-agent-summarise"],
+        ),
+        // Sentinelled sessions → re-run classification (guided).
+        ("meridian daemon", name) if name.contains("classify errors") => guided(
+            "re-classify sentinelled sessions",
+            &["meridian", "coding-agent-classify"],
+        ),
+        // UI not built → build it.
+        ("ui", name) if name.contains("built") => guided(
+            "build the UI",
+            &["bash", "-lc", "cd ui && npm ci && npm run build"],
+        ),
+        // Token/permission/config — a human must act.
+        ("jira", name) if name.contains("auth") => {
+            manual("regenerate the Jira API token and update JIRA_API_TOKEN in .env")
+        }
+        ("config", name) if name.contains("settings") => {
+            manual("align <repo>/settings.json with ~/.meridian/settings.json")
+        }
+        _ => None,
+    }
+}
+
+/// Run the repair pass over a report. Returns true if anything still needs a
+/// human (so the caller can exit non-zero).
+pub fn run(_cfg: &Config, report: &Report, dry_run: bool) -> bool {
+    let failing: Vec<&Check> = report
+        .checks
+        .iter()
+        .filter(|c| c.severity >= Severity::Warn)
+        .collect();
+
+    if failing.is_empty() {
+        println!("\n  ✓ nothing to fix — all checks pass\n");
+        return false;
+    }
+
+    println!(
+        "\n  Meridian doctor --fix{}",
+        if dry_run {
+            "  (dry run — nothing will be executed)"
+        } else {
+            ""
+        }
+    );
+    println!("  ════════════════════════════════════════════════════════");
+
+    let mut planned: Vec<FixAction> = Vec::new();
+    let mut residual = false;
+
+    for c in &failing {
+        let Some(action) = fix_for(c) else {
+            println!("  ·  {} › {} — no automatic fix", c.group, c.name);
+            residual = true;
+            continue;
+        };
+        // De-dupe: many dead services map to one `meridian start`.
+        if planned
+            .iter()
+            .any(|p| p.command == action.command && p.label == action.label)
+        {
+            continue;
+        }
+        match action.tier {
+            Tier::Manual => {
+                println!("  ⚠  manual: {}", action.label);
+                residual = true;
+            }
+            Tier::Auto => {
+                if dry_run {
+                    println!(
+                        "  →  auto: {}  [{}]",
+                        action.label,
+                        action.command.join(" ")
+                    );
+                } else {
+                    print!("  →  auto: {} … ", action.label);
+                    let _ = std::io::stdout().flush();
+                    let ok = exec(&action.command);
+                    println!("{}", if ok { "done" } else { "FAILED" });
+                    residual |= !ok;
+                }
+            }
+            Tier::Guided => {
+                if dry_run {
+                    println!(
+                        "  ?  guided: {}  [{}]",
+                        action.label,
+                        action.command.join(" ")
+                    );
+                } else if confirm(&action.label, &action.command) {
+                    print!("     running … ");
+                    let _ = std::io::stdout().flush();
+                    let ok = exec(&action.command);
+                    println!("{}", if ok { "done" } else { "FAILED" });
+                    residual |= !ok;
+                } else {
+                    println!("     skipped — run later: {}", action.command.join(" "));
+                    residual = true;
+                }
+            }
+        }
+        planned.push(action);
+    }
+
+    if residual && !dry_run {
+        match write_bundle(report) {
+            Some(path) => println!(
+                "\n  Some items still need attention. Diagnostic bundle saved:\n    {}\n    Share it with the team, or run: claude \"debug this meridian doctor bundle\"\n",
+                path
+            ),
+            None => println!("\n  Some items still need attention — share `meridian doctor` output with the team.\n"),
+        }
+    } else if !residual && !dry_run {
+        println!("\n  ✓ applied fixes — re-run `meridian doctor` to confirm\n");
+    } else {
+        println!();
+    }
+    residual
+}
+
+fn exec(argv: &[String]) -> bool {
+    let Some((bin, args)) = argv.split_first() else {
+        return false;
+    };
+    let mut cmd = Command::new(bin);
+    cmd.args(args);
+    if let Some(root) = repo_root() {
+        cmd.current_dir(root);
+    }
+    cmd.status().map(|s| s.success()).unwrap_or(false)
+}
+
+/// y/N prompt. Non-interactive (piped) input defaults to No so `--fix` never
+/// auto-runs a guided action without a human.
+fn confirm(label: &str, argv: &[String]) -> bool {
+    if !std::io::stdin().is_terminal() {
+        println!(
+            "  ?  guided: {} [{}] — skipped (non-interactive)",
+            label,
+            argv.join(" ")
+        );
+        return false;
+    }
+    print!("  ?  {} — run `{}`? [y/N] ", label, argv.join(" "));
+    let _ = std::io::stdout().flush();
+    let mut line = String::new();
+    if std::io::stdin().lock().read_line(&mut line).is_err() {
+        return false;
+    }
+    matches!(line.trim(), "y" | "Y" | "yes")
+}
+
+/// Write a content-free diagnostic bundle (the porcelain report) for handoff.
+fn write_bundle(report: &Report) -> Option<String> {
+    let dir = std::env::var_os("HOME")
+        .map(std::path::PathBuf::from)?
+        .join(".meridian");
+    let _ = std::fs::create_dir_all(&dir);
+    let path = dir.join("doctor-bundle.txt");
+    let mut body = String::from("meridian doctor diagnostic bundle\n\n");
+    body.push_str(&report.render(false));
+    let dx = crate::health::diagnose::root_causes(report);
+    body.push_str(&crate::health::diagnose::render(&dx, false));
+    std::fs::write(&path, body).ok()?;
+    Some(path.display().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dead_service_maps_to_auto_restart() {
+        let c =
+            Check::critical("daemon running", "system", "not loaded").in_group("meridian daemon");
+        let f = fix_for(&c).unwrap();
+        assert_eq!(f.tier, Tier::Auto);
+        assert_eq!(f.command, vec!["meridian", "start"]);
+    }
+
+    #[test]
+    fn summariser_backlog_is_guided() {
+        let c = Check::warn("summariser queue", "L2", "293").in_group("meridian daemon");
+        assert_eq!(fix_for(&c).unwrap().tier, Tier::Guided);
+    }
+
+    #[test]
+    fn jira_auth_is_manual() {
+        let c = Check::critical("auth", "L2", "401").in_group("jira");
+        assert_eq!(fix_for(&c).unwrap().tier, Tier::Manual);
+    }
+
+    #[test]
+    fn unknown_check_has_no_fix() {
+        let c = Check::warn("a11y_per_app", "L1", "x").in_group("screenpipe");
+        assert!(fix_for(&c).is_none());
+    }
+}

--- a/src/health/fix.rs
+++ b/src/health/fix.rs
@@ -77,6 +77,14 @@ pub fn fix_for(c: &Check) -> Option<FixAction> {
             "build the UI",
             &["bash", "-lc", "cd ui && npm ci && npm run build"],
         ),
+        // a11y regression — re-establishing capture often fixes it (guided).
+        ("screenpipe", name) if name.contains("a11y_regression") => {
+            guided("restart screenpipe to re-establish a11y capture", &["meridian", "restart"])
+        }
+        // a11y permission off — a human must grant it in System Settings.
+        ("screenpipe", name) if name.contains("a11y_permission") => manual(
+            "System Settings ▸ Privacy & Security ▸ Accessibility ▸ enable screenpipe, then restart it",
+        ),
         // Token/permission/config — a human must act.
         ("jira", name) if name.contains("auth") => {
             manual("regenerate the Jira API token and update JIRA_API_TOKEN in .env")

--- a/src/health/jira.rs
+++ b/src/health/jira.rs
@@ -1,0 +1,134 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Jira integration health (L2/L3). The auth probe (/myself) is the only thing
+// that distinguishes an expired token from a transient blip — today the daemon
+// collapses both into a silent warn. Sync freshness + candidate count come from
+// meridian.db (content-free). Creds are read from the env (loaded via dotenv at
+// startup), so this works without reaching into Config internals.
+
+use crate::config::Config;
+use crate::health::Check;
+use sqlx::SqlitePool;
+use std::time::Duration;
+
+/// Cache older than this (2× the 30-min sync interval) ⇒ fetch likely failing.
+const SYNC_STALE_SECS: f64 = 3600.0;
+
+pub async fn checks(_cfg: &Config, pool: Option<&SqlitePool>) -> Vec<Check> {
+    let mut out = Vec::new();
+
+    let base = std::env::var("JIRA_BASE_URL")
+        .or_else(|_| std::env::var("JIRA_URL"))
+        .ok()
+        .filter(|s| !s.is_empty());
+    let email = std::env::var("JIRA_EMAIL").ok().filter(|s| !s.is_empty());
+    let token = std::env::var("JIRA_API_TOKEN")
+        .ok()
+        .filter(|s| !s.is_empty());
+
+    match (base, email, token) {
+        (Some(b), Some(e), Some(t)) => out.push(auth(&b, &e, &t).await),
+        _ => out.push(Check::info(
+            "auth",
+            "L2",
+            "Jira not configured (no JIRA_BASE_URL / EMAIL / API_TOKEN)",
+        )),
+    }
+
+    if let Some(p) = pool {
+        out.push(sync_freshness(p).await);
+        out.push(candidate_count(p).await);
+    }
+    out
+}
+
+async fn auth(base: &str, email: &str, token: &str) -> Check {
+    let url = format!("{}/rest/api/3/myself", base.trim_end_matches('/'));
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(6))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => return Check::warn("auth", "L2", format!("http client error ({e})")),
+    };
+    match client.get(&url).basic_auth(email, Some(token)).send().await {
+        Err(_) => Check::critical("auth", "L2", "Jira API unreachable")
+            .with_remedy("check network connectivity and JIRA_BASE_URL"),
+        Ok(resp) => match resp.status().as_u16() {
+            200 => {
+                let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+                let who = body
+                    .get("emailAddress")
+                    .and_then(|v| v.as_str())
+                    .or_else(|| body.get("displayName").and_then(|v| v.as_str()))
+                    .unwrap_or("ok");
+                Check::ok("auth", "L2", format!("token valid ({who})"))
+            }
+            401 => Check::critical("auth", "L2", "401 — API token expired or invalid")
+                .with_remedy("regenerate the Jira API token and update JIRA_API_TOKEN in .env"),
+            403 => Check::critical("auth", "L2", "403 — token lacks required scope")
+                .with_remedy("grant the token read:jira-work (and write:jira-work for worklogs)"),
+            429 => {
+                Check::warn("auth", "L2", "429 — rate limited").with_remedy("back off and retry")
+            }
+            s => Check::warn("auth", "L2", format!("unexpected HTTP {s}")),
+        },
+    }
+}
+
+async fn sync_freshness(pool: &SqlitePool) -> Check {
+    match sqlx::query_scalar::<_, Option<f64>>(
+        "SELECT (julianday('now') - julianday(MAX(last_synced_at))) * 86400.0
+         FROM pm_sync_state WHERE provider = 'jira'",
+    )
+    .fetch_one(pool)
+    .await
+    {
+        Ok(Some(age)) if age > SYNC_STALE_SECS => Check::warn(
+            "ticket sync",
+            "L3",
+            format!(
+                "cache {:.0}m stale — fetch may be failing silently",
+                age / 60.0
+            ),
+        )
+        .with_remedy("check the auth row above; the daemon refreshes every 30m"),
+        Ok(Some(age)) => Check::ok(
+            "ticket sync",
+            "L3",
+            format!("fresh ({:.0}m ago)", age / 60.0),
+        ),
+        Ok(None) => Check::info("ticket sync", "L3", "no Jira sync recorded yet"),
+        Err(e) => Check::warn(
+            "ticket sync",
+            "L3",
+            format!("could not read sync state ({e})"),
+        ),
+    }
+}
+
+async fn candidate_count(pool: &SqlitePool) -> Check {
+    match sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM pm_tasks WHERE provider = 'jira'")
+        .fetch_one(pool)
+        .await
+    {
+        Ok(0) => Check::warn(
+            "candidate tickets",
+            "L3",
+            "0 candidates — classifier can only return untracked/overhead",
+        )
+        .with_remedy("check the JQL / JIRA_PROJECT_KEYS; ensure assigned open issues exist"),
+        Ok(n) if n >= 100 => Check::warn(
+            "candidate tickets",
+            "L3",
+            format!("{n} (at the 100-result cap) — tickets beyond it are invisible"),
+        )
+        .with_remedy("the JQL fetch caps at 100; narrow it or add pagination"),
+        Ok(n) => Check::ok("candidate tickets", "L3", format!("{n} open tickets")),
+        Err(e) => Check::warn(
+            "candidate tickets",
+            "L3",
+            format!("could not count pm_tasks ({e})"),
+        ),
+    }
+}

--- a/src/health/mlx.rs
+++ b/src/health/mlx.rs
@@ -1,0 +1,88 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// MLX classifier server health (L2). Distinguishes liveness (port open) from
+// readiness (model actually loaded) — the latter is the gap the Rust preflight
+// historically missed. Content-free: only status codes and model metadata.
+
+use crate::config::Config;
+use crate::health::Check;
+use std::time::Duration;
+
+pub async fn checks(cfg: &Config) -> Vec<Check> {
+    let base = format!("http://127.0.0.1:{}", cfg.mlx_server_port);
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(3))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return vec![Check::warn(
+                "mlx client",
+                "L2",
+                format!("http client error ({e})"),
+            )]
+        }
+    };
+
+    let mut out = Vec::new();
+
+    // 1. liveness + backend via /health
+    match client.get(format!("{base}/health")).send().await {
+        Err(_) => {
+            out.push(
+                Check::critical("reachable", "L2", format!("MLX server down at {base}"))
+                    .with_remedy("meridian start (or check the mlx-server launchd agent / port)"),
+            );
+            return out; // nothing else to probe if it is down
+        }
+        Ok(resp) => {
+            let status = resp.status();
+            let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+            out.push(Check::ok(
+                "reachable",
+                "L2",
+                format!("/health {}", status.as_u16()),
+            ));
+            let backend = body.get("backend").and_then(|v| v.as_str()).unwrap_or("");
+            if backend == "mlx" {
+                out.push(Check::ok("backend", "L2", "mlx"));
+            } else {
+                out.push(
+                    Check::warn(
+                        "backend",
+                        "L2",
+                        format!("'{backend}' (expected mlx) — /classify_sessions will 503"),
+                    )
+                    .with_remedy("start the server with --backend mlx"),
+                );
+            }
+        }
+    }
+
+    // 2. readiness via /info — model actually loaded, not just port open
+    match client.get(format!("{base}/info")).send().await {
+        Ok(resp) => {
+            let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+            let model = body.get("model_id").and_then(|v| v.as_str());
+            let loaded = body.get("loaded_at").map(|v| !v.is_null()).unwrap_or(false);
+            match (model, loaded) {
+                (Some(m), true) => out.push(Check::ok("model loaded", "L2", m.to_string())),
+                (Some(m), false) => out.push(
+                    Check::warn("model loaded", "L2", format!("{m} still loading"))
+                        .with_remedy("wait for the model load to finish, then re-run"),
+                ),
+                (None, _) => out.push(
+                    Check::warn("model loaded", "L2", "model not reported as loaded").with_remedy(
+                        "restart the mlx-server; check its logs for an OOM/load error",
+                    ),
+                ),
+            }
+        }
+        Err(_) => out.push(Check::info(
+            "model loaded",
+            "L2",
+            "/info not exposed by this build",
+        )),
+    }
+    out
+}

--- a/src/health/mod.rs
+++ b/src/health/mod.rs
@@ -1,16 +1,24 @@
 // meridian — normalises screenpipe activity into structured app sessions
 //
 // System-health / fault-attribution layer. Each check is a content-free probe
-// (counts, timestamps, booleans — never screen content) that attributes a
-// degraded pipeline to the layer that broke (the fault ladder L1..L4), so a
-// misclassification is never silently blamed on the model when the real cause
-// was broken capture, a dead integration, or bad config.
+// (counts, timestamps, booleans, reachability — never screen content) that
+// attributes a degraded pipeline to the layer that broke (the fault ladder
+// L1..L4), so a problem is never silently blamed on the model when the real
+// cause was broken capture, a dead integration, bad config, or a missing
+// dependency.
 //
 // This module hosts the boot preflight and the `meridian doctor` on-demand
-// sweep. L1 (screen capture) checks live in `capture`; further layers are added
-// incrementally.
+// sweep. Checks are grouped by the daemon/subsystem they belong to and rendered
+// as a table; `run_all` is the comprehensive sweep the CLI wrapper delegates to.
 
 pub mod capture;
+pub mod daemon;
+pub mod jira;
+pub mod mlx;
+pub mod platform;
+
+use crate::config::Config;
+use crate::db::screenpipe::open_screenpipe;
 
 /// Severity of a single check. Ordered Ok < Info < Warn < Critical. `Info` is a
 /// non-actionable diagnostic line (e.g. a per-app breakdown) — it never trips a
@@ -27,71 +35,81 @@ impl Severity {
     /// Fixed-width glyph for the doctor report.
     fn glyph(self) -> &'static str {
         match self {
-            Severity::Ok => " ok ",
+            Severity::Ok => "✓",
+            Severity::Info => "·",
+            Severity::Warn => "⊘",
+            Severity::Critical => "✗",
+        }
+    }
+
+    /// ANSI colour code (no reset) for the glyph when stdout is a terminal.
+    fn color(self) -> &'static str {
+        match self {
+            Severity::Ok => "\x1b[32m",       // green
+            Severity::Info => "\x1b[2m",      // dim
+            Severity::Warn => "\x1b[33m",     // yellow
+            Severity::Critical => "\x1b[31m", // red
+        }
+    }
+
+    /// Porcelain status token consumed by the CLI wrapper.
+    fn token(self) -> &'static str {
+        match self {
+            Severity::Ok => "ok",
             Severity::Info => "info",
             Severity::Warn => "warn",
-            Severity::Critical => "FAIL",
+            Severity::Critical => "fail",
         }
     }
 }
 
-/// One probe result. `layer` is the fault-ladder rung (e.g. "L1") this check
-/// attributes a failure to.
+/// One probe result. `group` is the daemon/subsystem this check belongs to (the
+/// table section); `layer` is the fault-ladder rung (e.g. "L1") a failure is
+/// attributed to.
 #[derive(Debug, Clone)]
 pub struct Check {
+    pub group: &'static str,
+    pub layer: &'static str,
     pub name: String,
     pub severity: Severity,
     pub detail: String,
-    pub layer: &'static str,
-    /// The human action that fixes this check, shown as a `→` line in the doctor
-    /// report. Set on prerequisites and actionable faults; `None` otherwise.
+    /// The human action that fixes this check, shown as a `→` line under a
+    /// failing check. Set on prerequisites and actionable faults; `None` else.
     pub remedy: Option<String>,
 }
 
 impl Check {
-    pub fn ok(name: impl Into<String>, layer: &'static str, detail: impl Into<String>) -> Self {
-        Check {
-            name: name.into(),
-            severity: Severity::Ok,
-            detail: detail.into(),
-            layer,
-            remedy: None,
-        }
-    }
-
-    pub fn warn(name: impl Into<String>, layer: &'static str, detail: impl Into<String>) -> Self {
-        Check {
-            name: name.into(),
-            severity: Severity::Warn,
-            detail: detail.into(),
-            layer,
-            remedy: None,
-        }
-    }
-
-    pub fn critical(
+    fn make(
+        severity: Severity,
         name: impl Into<String>,
         layer: &'static str,
         detail: impl Into<String>,
     ) -> Self {
         Check {
-            name: name.into(),
-            severity: Severity::Critical,
-            detail: detail.into(),
+            group: "",
             layer,
+            name: name.into(),
+            severity,
+            detail: detail.into(),
             remedy: None,
         }
     }
 
-    /// A non-actionable diagnostic line (e.g. a per-app breakdown). Never a fault.
+    pub fn ok(name: impl Into<String>, layer: &'static str, detail: impl Into<String>) -> Self {
+        Check::make(Severity::Ok, name, layer, detail)
+    }
     pub fn info(name: impl Into<String>, layer: &'static str, detail: impl Into<String>) -> Self {
-        Check {
-            name: name.into(),
-            severity: Severity::Info,
-            detail: detail.into(),
-            layer,
-            remedy: None,
-        }
+        Check::make(Severity::Info, name, layer, detail)
+    }
+    pub fn warn(name: impl Into<String>, layer: &'static str, detail: impl Into<String>) -> Self {
+        Check::make(Severity::Warn, name, layer, detail)
+    }
+    pub fn critical(
+        name: impl Into<String>,
+        layer: &'static str,
+        detail: impl Into<String>,
+    ) -> Self {
+        Check::make(Severity::Critical, name, layer, detail)
     }
 
     /// Attach the remedy (the fix-it action) shown under a failing check.
@@ -99,14 +117,29 @@ impl Check {
         self.remedy = Some(remedy.into());
         self
     }
+
+    /// Assign this check to a daemon/subsystem group (the table section).
+    pub fn in_group(mut self, group: &'static str) -> Self {
+        self.group = group;
+        self
+    }
 }
 
-/// A group of checks under one subsystem.
+/// Tag every check in a module's output with its daemon group in one call.
+pub fn tag(group: &'static str, checks: Vec<Check>) -> Vec<Check> {
+    checks.into_iter().map(|c| c.in_group(group)).collect()
+}
+
+/// A collection of checks, rendered grouped by daemon.
 pub struct Report {
     pub checks: Vec<Check>,
 }
 
 impl Report {
+    pub fn new(checks: Vec<Check>) -> Self {
+        Report { checks }
+    }
+
     /// The worst severity across all checks (Ok if empty).
     pub fn worst(&self) -> Severity {
         self.checks
@@ -116,49 +149,99 @@ impl Report {
             .unwrap_or(Severity::Ok)
     }
 
-    /// Human-readable report for `meridian doctor`.
-    pub fn render_titled(&self, title: &str) -> String {
-        let rule = "─".repeat(58);
-        let mut s = format!("\n  Meridian doctor — {title}\n  {rule}\n");
+    /// (ok, info, warn, critical) counts.
+    pub fn counts(&self) -> (usize, usize, usize, usize) {
+        let mut c = (0, 0, 0, 0);
+        for chk in &self.checks {
+            match chk.severity {
+                Severity::Ok => c.0 += 1,
+                Severity::Info => c.1 += 1,
+                Severity::Warn => c.2 += 1,
+                Severity::Critical => c.3 += 1,
+            }
+        }
+        c
+    }
+
+    /// Distinct groups in first-appearance order.
+    fn groups(&self) -> Vec<&'static str> {
+        let mut seen = Vec::new();
         for c in &self.checks {
-            s.push_str(&format!(
-                "  [{}] {:<7} {:<26} {}\n",
-                c.severity.glyph(),
-                c.layer,
-                c.name,
-                c.detail
+            if !seen.contains(&c.group) {
+                seen.push(c.group);
+            }
+        }
+        seen
+    }
+
+    /// Rich, optionally-coloured table grouped by daemon. `color` should reflect
+    /// whether stdout is a terminal.
+    pub fn render(&self, color: bool) -> String {
+        let paint = |code: &str, s: &str| -> String {
+            if color {
+                format!("{code}{s}\x1b[0m")
+            } else {
+                s.to_string()
+            }
+        };
+        let dim = |s: &str| paint("\x1b[2m", s);
+        let bold = |s: &str| paint("\x1b[1m", s);
+
+        let mut out = String::new();
+        out.push_str(&format!(
+            "\n  {}\n",
+            bold("Meridian doctor — health by daemon")
+        ));
+        out.push_str(&format!("  {}\n", dim(&"═".repeat(56))));
+
+        for group in self.groups() {
+            let label = if group.is_empty() { "general" } else { group };
+            out.push_str(&format!(
+                "\n  {}\n",
+                paint("\x1b[36m", &format!("▸ {label}"))
             ));
-            // Show the fix-it action under any non-passing check that has one.
-            if c.severity != Severity::Ok {
-                if let Some(remedy) = &c.remedy {
-                    s.push_str(&format!("         → {remedy}\n"));
+            for c in self.checks.iter().filter(|c| c.group == group) {
+                let glyph = paint(c.severity.color(), c.severity.glyph());
+                // Drop a redundant "<group>." prefix from the check name.
+                let name = c.name.strip_prefix(&format!("{group}.")).unwrap_or(&c.name);
+                out.push_str(&format!("    {glyph}  {name:<26} {}\n", dim(&c.detail)));
+                if c.severity >= Severity::Warn {
+                    if let Some(r) = &c.remedy {
+                        out.push_str(&format!("       {} {}\n", dim("→"), dim(r)));
+                    }
                 }
             }
         }
-        let summary = match self.worst() {
-            Severity::Ok | Severity::Info => "all checks passed",
-            Severity::Warn => "completed with warnings",
-            Severity::Critical => "CRITICAL issues found",
+
+        let (ok, info, warn, crit) = self.counts();
+        out.push_str(&format!("\n  {}\n", dim(&"═".repeat(56))));
+        let summary = format!(
+            "{}  {}  {}  {}",
+            paint("\x1b[32m", &format!("✓ {ok} ok")),
+            dim(&format!("· {info} info")),
+            paint("\x1b[33m", &format!("⊘ {warn} warn")),
+            paint("\x1b[31m", &format!("✗ {crit} fail")),
+        );
+        out.push_str(&format!("  {summary}\n"));
+        let verdict = match self.worst() {
+            Severity::Critical => paint("\x1b[31m", "  ✗ critical issues — see remedies above"),
+            Severity::Warn => paint("\x1b[33m", "  ⊘ healthy with warnings"),
+            _ => paint("\x1b[32m", "  ✓ all systems healthy"),
         };
-        s.push_str(&format!("  {rule}\n  {summary}\n"));
-        s
+        out.push_str(&format!("{verdict}\n"));
+        out
     }
 
     /// Machine-readable output for the `meridian` CLI wrapper to ingest and fold
     /// into its by-daemon table. One TSV line per check:
-    /// `status<TAB>name<TAB>detail<TAB>remedy` (status ∈ ok|info|warn|fail).
+    /// `status<TAB>group<TAB>name<TAB>detail<TAB>remedy`.
     pub fn render_porcelain(&self) -> String {
         let mut s = String::new();
         for c in &self.checks {
-            let status = match c.severity {
-                Severity::Ok => "ok",
-                Severity::Info => "info",
-                Severity::Warn => "warn",
-                Severity::Critical => "fail",
-            };
             s.push_str(&format!(
-                "{}\t{}\t{}\t{}\n",
-                status,
+                "{}\t{}\t{}\t{}\t{}\n",
+                c.severity.token(),
+                c.group,
                 c.name,
                 c.detail,
                 c.remedy.as_deref().unwrap_or("")
@@ -173,27 +256,67 @@ impl Report {
         for c in &self.checks {
             match c.severity {
                 Severity::Ok | Severity::Info => tracing::debug!(
-                    stage = stage,
-                    check = %c.name,
-                    layer = c.layer,
-                    detail = %c.detail,
-                    "health check"
+                    stage = stage, check = %c.name, group = c.group, layer = c.layer,
+                    detail = %c.detail, "health check"
                 ),
                 Severity::Warn => tracing::warn!(
-                    stage = stage,
-                    check = %c.name,
-                    layer = c.layer,
-                    detail = %c.detail,
-                    "health check degraded"
+                    stage = stage, check = %c.name, group = c.group, layer = c.layer,
+                    detail = %c.detail, "health check degraded"
                 ),
                 Severity::Critical => tracing::error!(
-                    stage = stage,
-                    check = %c.name,
-                    layer = c.layer,
-                    detail = %c.detail,
-                    "health check failed"
+                    stage = stage, check = %c.name, group = c.group, layer = c.layer,
+                    detail = %c.detail, "health check failed"
                 ),
             }
         }
     }
+}
+
+/// The comprehensive sweep behind `meridian doctor`. Opens what each subsystem
+/// needs (read-only), runs every check module, and returns one grouped report.
+/// Best-effort: a module that cannot open its dependency reports that as a
+/// failing check rather than aborting the sweep.
+pub async fn run_all(cfg: &Config) -> Report {
+    let mut checks: Vec<Check> = Vec::new();
+
+    // system — OS, config, disk, toolchains.
+    checks.extend(tag("system", platform::system_checks(cfg)));
+
+    // meridian daemon — service (binary/plist/process) + ETL liveness/queues.
+    let md = daemon::open_meridian_ro(cfg).await;
+    {
+        let mut g = platform::daemon_service();
+        g.extend(daemon::checks(cfg, md.as_ref()).await);
+        checks.extend(tag("meridian daemon", g));
+    }
+
+    // screenpipe — service + L1 capture content (screenpipe DB, read-only).
+    {
+        let sp = open_screenpipe(&cfg.screenpipe_db_uri()).await.ok();
+        let mut g = platform::screenpipe_service();
+        g.extend(capture::checks(cfg, sp.as_ref()).await);
+        checks.extend(tag("screenpipe", g));
+        if let Some(p) = sp {
+            p.close().await;
+        }
+    }
+
+    // mlx-server — service + HTTP readiness probes.
+    {
+        let mut g = platform::mlx_service(cfg);
+        g.extend(mlx::checks(cfg).await);
+        checks.extend(tag("mlx-server", g));
+    }
+
+    // jira — auth, sync freshness, candidate completeness.
+    checks.extend(tag("jira", jira::checks(cfg, md.as_ref()).await));
+    if let Some(p) = md {
+        p.close().await;
+    }
+
+    // ui + mcp — build/service state.
+    checks.extend(tag("ui", platform::ui_service()));
+    checks.extend(tag("mcp", platform::mcp_service()));
+
+    Report::new(checks)
 }

--- a/src/health/mod.rs
+++ b/src/health/mod.rs
@@ -1,0 +1,143 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// System-health / fault-attribution layer. Each check is a content-free probe
+// (counts, timestamps, booleans — never screen content) that attributes a
+// degraded pipeline to the layer that broke (the fault ladder L1..L4), so a
+// misclassification is never silently blamed on the model when the real cause
+// was broken capture, a dead integration, or bad config.
+//
+// This module hosts the boot preflight and the `meridian doctor` on-demand
+// sweep. L1 (screen capture) checks live in `capture`; further layers are added
+// incrementally.
+
+pub mod capture;
+
+/// Severity of a single check. Ordered Ok < Warn < Critical.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Severity {
+    Ok,
+    Warn,
+    Critical,
+}
+
+impl Severity {
+    /// Fixed-width glyph for the doctor report.
+    fn glyph(self) -> &'static str {
+        match self {
+            Severity::Ok => " ok ",
+            Severity::Warn => "warn",
+            Severity::Critical => "FAIL",
+        }
+    }
+}
+
+/// One probe result. `layer` is the fault-ladder rung (e.g. "L1") this check
+/// attributes a failure to.
+#[derive(Debug, Clone)]
+pub struct Check {
+    pub name: String,
+    pub severity: Severity,
+    pub detail: String,
+    pub layer: &'static str,
+}
+
+impl Check {
+    pub fn ok(name: impl Into<String>, layer: &'static str, detail: impl Into<String>) -> Self {
+        Check {
+            name: name.into(),
+            severity: Severity::Ok,
+            detail: detail.into(),
+            layer,
+        }
+    }
+
+    pub fn warn(name: impl Into<String>, layer: &'static str, detail: impl Into<String>) -> Self {
+        Check {
+            name: name.into(),
+            severity: Severity::Warn,
+            detail: detail.into(),
+            layer,
+        }
+    }
+
+    pub fn critical(
+        name: impl Into<String>,
+        layer: &'static str,
+        detail: impl Into<String>,
+    ) -> Self {
+        Check {
+            name: name.into(),
+            severity: Severity::Critical,
+            detail: detail.into(),
+            layer,
+        }
+    }
+}
+
+/// A group of checks under one subsystem.
+pub struct Report {
+    pub checks: Vec<Check>,
+}
+
+impl Report {
+    /// The worst severity across all checks (Ok if empty).
+    pub fn worst(&self) -> Severity {
+        self.checks
+            .iter()
+            .map(|c| c.severity)
+            .max()
+            .unwrap_or(Severity::Ok)
+    }
+
+    /// Human-readable report for `meridian doctor`.
+    pub fn render_titled(&self, title: &str) -> String {
+        let rule = "─".repeat(58);
+        let mut s = format!("\n  Meridian doctor — {title}\n  {rule}\n");
+        for c in &self.checks {
+            s.push_str(&format!(
+                "  [{}] {:<7} {:<26} {}\n",
+                c.severity.glyph(),
+                c.layer,
+                c.name,
+                c.detail
+            ));
+        }
+        let summary = match self.worst() {
+            Severity::Ok => "all checks passed",
+            Severity::Warn => "completed with warnings",
+            Severity::Critical => "CRITICAL issues found",
+        };
+        s.push_str(&format!("  {rule}\n  {summary}\n"));
+        s
+    }
+
+    /// Emit each check to tracing at a level matching its severity. Used by the
+    /// boot preflight (non-fatal — the daemon still runs; we surface the fault).
+    pub fn log(&self, stage: &str) {
+        for c in &self.checks {
+            match c.severity {
+                Severity::Ok => tracing::debug!(
+                    stage = stage,
+                    check = %c.name,
+                    layer = c.layer,
+                    detail = %c.detail,
+                    "health check"
+                ),
+                Severity::Warn => tracing::warn!(
+                    stage = stage,
+                    check = %c.name,
+                    layer = c.layer,
+                    detail = %c.detail,
+                    "health check degraded"
+                ),
+                Severity::Critical => tracing::error!(
+                    stage = stage,
+                    check = %c.name,
+                    layer = c.layer,
+                    detail = %c.detail,
+                    "health check failed"
+                ),
+            }
+        }
+    }
+}

--- a/src/health/mod.rs
+++ b/src/health/mod.rs
@@ -144,6 +144,29 @@ impl Report {
         s
     }
 
+    /// Machine-readable output for the `meridian` CLI wrapper to ingest and fold
+    /// into its by-daemon table. One TSV line per check:
+    /// `status<TAB>name<TAB>detail<TAB>remedy` (status ∈ ok|info|warn|fail).
+    pub fn render_porcelain(&self) -> String {
+        let mut s = String::new();
+        for c in &self.checks {
+            let status = match c.severity {
+                Severity::Ok => "ok",
+                Severity::Info => "info",
+                Severity::Warn => "warn",
+                Severity::Critical => "fail",
+            };
+            s.push_str(&format!(
+                "{}\t{}\t{}\t{}\n",
+                status,
+                c.name,
+                c.detail,
+                c.remedy.as_deref().unwrap_or("")
+            ));
+        }
+        s
+    }
+
     /// Emit each check to tracing at a level matching its severity. Used by the
     /// boot preflight (non-fatal — the daemon still runs; we surface the fault).
     pub fn log(&self, stage: &str) {

--- a/src/health/mod.rs
+++ b/src/health/mod.rs
@@ -12,10 +12,13 @@
 
 pub mod capture;
 
-/// Severity of a single check. Ordered Ok < Warn < Critical.
+/// Severity of a single check. Ordered Ok < Info < Warn < Critical. `Info` is a
+/// non-actionable diagnostic line (e.g. a per-app breakdown) — it never trips a
+/// warning or a non-zero exit.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Severity {
     Ok,
+    Info,
     Warn,
     Critical,
 }
@@ -25,6 +28,7 @@ impl Severity {
     fn glyph(self) -> &'static str {
         match self {
             Severity::Ok => " ok ",
+            Severity::Info => "info",
             Severity::Warn => "warn",
             Severity::Critical => "FAIL",
         }
@@ -79,6 +83,17 @@ impl Check {
         }
     }
 
+    /// A non-actionable diagnostic line (e.g. a per-app breakdown). Never a fault.
+    pub fn info(name: impl Into<String>, layer: &'static str, detail: impl Into<String>) -> Self {
+        Check {
+            name: name.into(),
+            severity: Severity::Info,
+            detail: detail.into(),
+            layer,
+            remedy: None,
+        }
+    }
+
     /// Attach the remedy (the fix-it action) shown under a failing check.
     pub fn with_remedy(mut self, remedy: impl Into<String>) -> Self {
         self.remedy = Some(remedy.into());
@@ -121,7 +136,7 @@ impl Report {
             }
         }
         let summary = match self.worst() {
-            Severity::Ok => "all checks passed",
+            Severity::Ok | Severity::Info => "all checks passed",
             Severity::Warn => "completed with warnings",
             Severity::Critical => "CRITICAL issues found",
         };
@@ -134,7 +149,7 @@ impl Report {
     pub fn log(&self, stage: &str) {
         for c in &self.checks {
             match c.severity {
-                Severity::Ok => tracing::debug!(
+                Severity::Ok | Severity::Info => tracing::debug!(
                     stage = stage,
                     check = %c.name,
                     layer = c.layer,

--- a/src/health/mod.rs
+++ b/src/health/mod.rs
@@ -12,10 +12,13 @@
 // as a table; `run_all` is the comprehensive sweep the CLI wrapper delegates to.
 
 pub mod capture;
+pub mod codingagent;
 pub mod daemon;
 pub mod jira;
 pub mod mlx;
+pub mod observability;
 pub mod platform;
+pub mod worklog;
 
 use crate::config::Config;
 use crate::db::screenpipe::open_screenpipe;
@@ -310,13 +313,75 @@ pub async fn run_all(cfg: &Config) -> Report {
 
     // jira — auth, sync freshness, candidate completeness.
     checks.extend(tag("jira", jira::checks(cfg, md.as_ref()).await));
+
+    // worklog — drafts awaiting review, stuck hours, Jira post failures.
+    checks.extend(tag("worklog", worklog::checks(cfg, md.as_ref()).await));
     if let Some(p) = md {
         p.close().await;
     }
+
+    // coding-agent — Claude/Codex CLI + ingest dirs (and the Cursor gap).
+    checks.extend(tag("coding-agent", codingagent::checks(cfg)));
 
     // ui + mcp — build/service state.
     checks.extend(tag("ui", platform::ui_service()));
     checks.extend(tag("mcp", platform::mcp_service()));
 
+    // observability — OpenObserve sink (the health layer's own eyes).
+    checks.extend(tag("observability", observability::checks(cfg).await));
+
     Report::new(checks)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Report {
+        Report::new(vec![
+            Check::ok("screenpipe.frames", "L1", "100").in_group("screenpipe"),
+            Check::warn("queue", "L2", "deep")
+                .with_remedy("fix it")
+                .in_group("meridian daemon"),
+            Check::info("a11y", "L1", "x").in_group("screenpipe"),
+            Check::critical("auth", "L2", "401").in_group("jira"),
+        ])
+    }
+
+    #[test]
+    fn counts_and_worst() {
+        let r = sample();
+        assert_eq!(r.counts(), (1, 1, 1, 1));
+        assert_eq!(r.worst(), Severity::Critical);
+    }
+
+    #[test]
+    fn porcelain_is_five_tab_columns_with_group() {
+        let out = sample().render_porcelain();
+        let cols: Vec<&str> = out.lines().next().unwrap().split('\t').collect();
+        assert_eq!(cols.len(), 5);
+        assert_eq!(cols[0], "ok"); // status
+        assert_eq!(cols[1], "screenpipe"); // group
+        assert_eq!(cols[2], "screenpipe.frames"); // name (full, not stripped)
+    }
+
+    #[test]
+    fn render_groups_strips_prefix_and_shows_remedy() {
+        let out = sample().render(false);
+        assert!(out.contains("▸ screenpipe"));
+        assert!(out.contains("▸ meridian daemon"));
+        // group prefix stripped in the table
+        assert!(out.contains(" frames "));
+        assert!(!out.contains("screenpipe.frames"));
+        // remedy under the warn
+        assert!(out.contains("→ fix it"));
+        // counts summary present
+        assert!(out.contains("1 ok"));
+    }
+
+    #[test]
+    fn color_flag_gates_ansi() {
+        assert!(!sample().render(false).contains('\x1b'));
+        assert!(sample().render(true).contains('\x1b'));
+    }
 }

--- a/src/health/mod.rs
+++ b/src/health/mod.rs
@@ -21,6 +21,7 @@ pub mod jira;
 pub mod mlx;
 pub mod observability;
 pub mod platform;
+pub mod ui;
 pub mod worklog;
 
 use crate::config::Config;
@@ -339,8 +340,12 @@ pub async fn run_all(cfg: &Config) -> Report {
     // coding-agent — Claude/Codex CLI + ingest dirs (and the Cursor gap).
     checks.extend(tag("coding-agent", codingagent::checks(cfg)));
 
-    // ui + mcp — build/service state.
-    checks.extend(tag("ui", platform::ui_service()));
+    // ui — service/build presence + functional serve-health (assets actually load).
+    {
+        let mut g = platform::ui_service();
+        g.extend(ui::checks(cfg).await);
+        checks.extend(tag("ui", g));
+    }
     checks.extend(tag("mcp", platform::mcp_service()));
 
     // observability — OpenObserve sink (the health layer's own eyes).

--- a/src/health/mod.rs
+++ b/src/health/mod.rs
@@ -13,6 +13,7 @@
 
 pub mod capture;
 pub mod codingagent;
+pub mod contracts;
 pub mod daemon;
 pub mod jira;
 pub mod mlx;
@@ -197,6 +198,19 @@ impl Report {
         ));
         out.push_str(&format!("  {}\n", dim(&"═".repeat(56))));
 
+        // Surface the problem count up front so issues aren't missed in a long
+        // mostly-green table.
+        let (_, _, warn_n, crit_n) = self.counts();
+        if warn_n + crit_n > 0 {
+            out.push_str(&format!(
+                "  {}\n",
+                paint(
+                    "\x1b[33m",
+                    &format!("⚠ {} item(s) need attention", warn_n + crit_n)
+                )
+            ));
+        }
+
         for group in self.groups() {
             let label = if group.is_empty() { "general" } else { group };
             out.push_str(&format!(
@@ -329,6 +343,9 @@ pub async fn run_all(cfg: &Config) -> Report {
 
     // observability — OpenObserve sink (the health layer's own eyes).
     checks.extend(tag("observability", observability::checks(cfg).await));
+
+    // config — cross-process contracts (DB path, settings file, dead env).
+    checks.extend(tag("config", contracts::checks(cfg)));
 
     Report::new(checks)
 }

--- a/src/health/mod.rs
+++ b/src/health/mod.rs
@@ -16,6 +16,7 @@ pub mod codingagent;
 pub mod contracts;
 pub mod daemon;
 pub mod diagnose;
+pub mod fix;
 pub mod jira;
 pub mod mlx;
 pub mod observability;

--- a/src/health/mod.rs
+++ b/src/health/mod.rs
@@ -15,6 +15,7 @@ pub mod capture;
 pub mod codingagent;
 pub mod contracts;
 pub mod daemon;
+pub mod diagnose;
 pub mod jira;
 pub mod mlx;
 pub mod observability;

--- a/src/health/mod.rs
+++ b/src/health/mod.rs
@@ -39,6 +39,9 @@ pub struct Check {
     pub severity: Severity,
     pub detail: String,
     pub layer: &'static str,
+    /// The human action that fixes this check, shown as a `→` line in the doctor
+    /// report. Set on prerequisites and actionable faults; `None` otherwise.
+    pub remedy: Option<String>,
 }
 
 impl Check {
@@ -48,6 +51,7 @@ impl Check {
             severity: Severity::Ok,
             detail: detail.into(),
             layer,
+            remedy: None,
         }
     }
 
@@ -57,6 +61,7 @@ impl Check {
             severity: Severity::Warn,
             detail: detail.into(),
             layer,
+            remedy: None,
         }
     }
 
@@ -70,7 +75,14 @@ impl Check {
             severity: Severity::Critical,
             detail: detail.into(),
             layer,
+            remedy: None,
         }
+    }
+
+    /// Attach the remedy (the fix-it action) shown under a failing check.
+    pub fn with_remedy(mut self, remedy: impl Into<String>) -> Self {
+        self.remedy = Some(remedy.into());
+        self
     }
 }
 
@@ -101,6 +113,12 @@ impl Report {
                 c.name,
                 c.detail
             ));
+            // Show the fix-it action under any non-passing check that has one.
+            if c.severity != Severity::Ok {
+                if let Some(remedy) = &c.remedy {
+                    s.push_str(&format!("         → {remedy}\n"));
+                }
+            }
         }
         let summary = match self.worst() {
             Severity::Ok => "all checks passed",

--- a/src/health/observability.rs
+++ b/src/health/observability.rs
@@ -1,0 +1,82 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Observability sink health. If OpenObserve is down, traces/logs silently drop
+// — which blinds the very fault-attribution this layer depends on, so it is
+// worth a check of its own. Export is gated on MERIDIAN_OO_AUTH being set.
+
+use crate::config::Config;
+use crate::health::Check;
+use std::time::Duration;
+
+pub async fn checks(_cfg: &Config) -> Vec<Check> {
+    let auth_set = std::env::var("MERIDIAN_OO_AUTH")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    if !auth_set {
+        return vec![Check::info(
+            "openobserve",
+            "obs",
+            "OTLP export disabled (no MERIDIAN_OO_AUTH) — telemetry not collected",
+        )];
+    }
+
+    let endpoint = std::env::var("MERIDIAN_OTLP_ENDPOINT")
+        .unwrap_or_else(|_| "http://localhost:5080/api/default/v1/traces".to_string());
+    let healthz = derive_healthz(&endpoint);
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(3))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return vec![Check::info(
+                "openobserve",
+                "obs",
+                format!("client error ({e})"),
+            )]
+        }
+    };
+
+    vec![match client.get(&healthz).send().await {
+        Ok(resp) if resp.status().is_success() => Check::ok("openobserve", "obs", "reachable"),
+        Ok(resp) => Check::warn(
+            "openobserve",
+            "obs",
+            format!(
+                "HTTP {} — traces/logs may be dropping",
+                resp.status().as_u16()
+            ),
+        )
+        .with_remedy("check the openobserve launchd agent (port 5080)"),
+        Err(_) => Check::warn("openobserve", "obs", "not reachable — traces/logs dropping")
+            .with_remedy("start OpenObserve (port 5080)"),
+    }]
+}
+
+/// `http://host:port/api/...` → `http://host:port/healthz`.
+fn derive_healthz(endpoint: &str) -> String {
+    if let Some(scheme_end) = endpoint.find("://") {
+        let rest = &endpoint[scheme_end + 3..];
+        let host_port = rest.split('/').next().unwrap_or(rest);
+        return format!("{}://{}/healthz", &endpoint[..scheme_end], host_port);
+    }
+    "http://localhost:5080/healthz".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::derive_healthz;
+
+    #[test]
+    fn healthz_derived_from_otlp_endpoint() {
+        assert_eq!(
+            derive_healthz("http://localhost:5080/api/default/v1/traces"),
+            "http://localhost:5080/healthz"
+        );
+        assert_eq!(
+            derive_healthz("https://127.0.0.1:9000/x"),
+            "https://127.0.0.1:9000/healthz"
+        );
+        assert_eq!(derive_healthz("garbage"), "http://localhost:5080/healthz");
+    }
+}

--- a/src/health/platform.rs
+++ b/src/health/platform.rs
@@ -1,0 +1,267 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Platform / prerequisite checks: launchd agents, plist validity, process
+// liveness, installed binaries, build artifacts, toolchains, and disk. These
+// are the "is the environment set up to run at all" rungs, distributed into
+// each daemon's table group. Shelling out to launchctl/plutil/pgrep/df/node.
+
+use crate::config::Config;
+use crate::health::Check;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const LABEL_DAEMON: &str = "com.meridiona.daemon";
+const LABEL_SCREENPIPE: &str = "com.meridiona.screenpipe";
+const LABEL_UI: &str = "com.meridiona.ui";
+const LABEL_MLX: &str = "com.meridiona.mlx-server";
+
+// ── shared helpers ──────────────────────────────────────────────────────────
+
+fn home() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn is_exec(p: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(p)
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+/// Repo root via the running binary (the CLI wrapper may run from anywhere, so
+/// cwd is unreliable). Resolves the symlink then walks up to the Cargo.toml.
+pub fn repo_root() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let exe = std::fs::canonicalize(&exe).unwrap_or(exe);
+    exe.ancestors()
+        .find(|a| a.join("Cargo.toml").is_file())
+        .map(|a| a.to_path_buf())
+}
+
+/// Find an executable on PATH (no `which` crate).
+pub fn which(bin: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(bin))
+        .find(|c| c.is_file())
+}
+
+fn launchd_pid(label: &str) -> Option<i64> {
+    let out = Command::new("launchctl")
+        .args(["list", label])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    for line in String::from_utf8_lossy(&out.stdout).lines() {
+        if let Some(rest) = line.trim().strip_prefix("\"PID\" = ") {
+            return rest.trim_end_matches(';').trim().parse().ok();
+        }
+    }
+    None
+}
+
+fn plist_valid(label: &str) -> bool {
+    let p = home()
+        .join("Library/LaunchAgents")
+        .join(format!("{label}.plist"));
+    p.is_file()
+        && Command::new("plutil")
+            .arg("-lint")
+            .arg(&p)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+}
+
+fn process_running(name: &str) -> bool {
+    Command::new("pgrep")
+        .args(["-x", name])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn cmd_output(bin: &str, args: &[&str]) -> Option<String> {
+    let out = Command::new(bin).args(args).output().ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn disk_free_gb(path: &Path) -> Option<f64> {
+    let out = Command::new("df").arg("-Pk").arg(path).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout);
+    let avail_kb: f64 = s.lines().nth(1)?.split_whitespace().nth(3)?.parse().ok()?;
+    Some(avail_kb / 1_048_576.0)
+}
+
+fn plist_check(label: &str, name: &'static str) -> Check {
+    if plist_valid(label) {
+        Check::ok(name, "system", "installed + valid")
+    } else {
+        Check::critical(name, "system", "missing or invalid").with_remedy("run ./install.sh")
+    }
+}
+
+// ── per-daemon service checks ───────────────────────────────────────────────
+
+pub fn daemon_service() -> Vec<Check> {
+    let bin = [
+        PathBuf::from("/usr/local/bin/meridian-daemon"),
+        home().join(".local/bin/meridian-daemon"),
+    ]
+    .into_iter()
+    .find(|p| is_exec(p));
+    let bin_check = match bin {
+        Some(p) => Check::ok("daemon binary", "system", p.display().to_string()),
+        None => Check::critical("daemon binary", "system", "not installed")
+            .with_remedy("run ./install.sh"),
+    };
+    let run_check = match launchd_pid(LABEL_DAEMON) {
+        Some(pid) => Check::ok("daemon running", "system", format!("pid {pid}")),
+        None => {
+            Check::critical("daemon running", "system", "not loaded").with_remedy("meridian start")
+        }
+    };
+    vec![
+        bin_check,
+        plist_check(LABEL_DAEMON, "daemon plist"),
+        run_check,
+    ]
+}
+
+pub fn screenpipe_service() -> Vec<Check> {
+    let run = if process_running("screenpipe") {
+        Check::ok("screenpipe service", "L1", "process alive")
+    } else {
+        Check::critical("screenpipe service", "L1", "not running").with_remedy("meridian start")
+    };
+    vec![plist_check(LABEL_SCREENPIPE, "screenpipe plist"), run]
+}
+
+pub fn mlx_service(_cfg: &Config) -> Vec<Check> {
+    let run = match launchd_pid(LABEL_MLX) {
+        Some(pid) => Check::ok("mlx service", "L2", format!("pid {pid}")),
+        None => Check::warn("mlx service", "L2", "launchd agent not loaded")
+            .with_remedy("meridian start"),
+    };
+    vec![plist_check(LABEL_MLX, "mlx plist"), run, venv_check()]
+}
+
+fn venv_check() -> Check {
+    let py = match repo_root() {
+        Some(r) => r.join("services/.venv/bin/python"),
+        None => return Check::info("python venv", "system", "repo root not found"),
+    };
+    if !is_exec(&py) {
+        return Check::critical("python venv", "system", ".venv missing")
+            .with_remedy("bash scripts/setup-services.sh");
+    }
+    let ok = Command::new(&py)
+        .args(["-c", "import run_agent"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if ok {
+        Check::ok("python venv", "system", "run_agent importable")
+    } else {
+        Check::critical("python venv", "system", "run_agent import failed")
+            .with_remedy("bash scripts/setup-services.sh")
+    }
+}
+
+pub fn ui_service() -> Vec<Check> {
+    let run = match launchd_pid(LABEL_UI) {
+        Some(pid) => Check::ok("ui service", "system", format!("pid {pid}")),
+        None => Check::warn("ui service", "system", "not loaded — dashboard unavailable")
+            .with_remedy("meridian start"),
+    };
+    let built = repo_root()
+        .map(|r| r.join("ui/.next").is_dir())
+        .unwrap_or(false);
+    let build_check = if built {
+        Check::ok("ui built", "system", ".next present")
+    } else {
+        Check::warn("ui built", "system", "not built")
+            .with_remedy("cd ui && npm ci && npm run build")
+    };
+    vec![plist_check(LABEL_UI, "ui plist"), run, build_check]
+}
+
+pub fn mcp_service() -> Vec<Check> {
+    let built = repo_root()
+        .map(|r| r.join("packages/meridian-mcp/dist/index.js").is_file())
+        .unwrap_or(false);
+    vec![if built {
+        Check::ok("mcp built", "system", "dist/index.js present")
+    } else {
+        Check::warn("mcp built", "system", "not built")
+            .with_remedy("cd packages/meridian-mcp && npm run build")
+    }]
+}
+
+// ── system / toolchain ──────────────────────────────────────────────────────
+
+pub fn system_checks(_cfg: &Config) -> Vec<Check> {
+    let os = if cfg!(target_os = "macos") {
+        Check::ok("os", "system", "macOS")
+    } else {
+        Check::warn(
+            "os",
+            "system",
+            "not macOS — the capture stack is macOS-only",
+        )
+    };
+    let env_ok = repo_root()
+        .map(|r| r.join(".env").is_file())
+        .unwrap_or(false);
+    let env_check = if env_ok {
+        Check::ok("config (.env)", "system", "present")
+    } else {
+        Check::warn("config (.env)", "system", "missing").with_remedy("run ./install.sh")
+    };
+    vec![
+        os,
+        env_check,
+        node_check(),
+        disk_check("disk (screenpipe)", &home().join(".screenpipe")),
+        disk_check("disk (meridian)", &home().join(".meridian")),
+    ]
+}
+
+fn node_check() -> Check {
+    match cmd_output("node", &["--version"]) {
+        Some(v) => {
+            let major: u32 = v
+                .trim_start_matches('v')
+                .split('.')
+                .next()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
+            if major >= 18 {
+                Check::ok("node", "system", v)
+            } else {
+                Check::warn("node", "system", format!("{v} (< 18; Next.js needs ≥18)"))
+                    .with_remedy("upgrade Node to 18+")
+            }
+        }
+        None => Check::warn("node", "system", "not found on PATH")
+            .with_remedy("install Node 18+ for the UI"),
+    }
+}
+
+fn disk_check(name: &'static str, path: &Path) -> Check {
+    match disk_free_gb(path) {
+        Some(gb) if gb < 2.0 => Check::warn(name, "system", format!("{gb:.1} GB free — low"))
+            .with_remedy("free disk space"),
+        Some(gb) => Check::ok(name, "system", format!("{gb:.0} GB free")),
+        None => Check::info(name, "system", "usage unknown"),
+    }
+}

--- a/src/health/ui.rs
+++ b/src/health/ui.rs
@@ -1,0 +1,189 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// UI *readiness* — not just liveness. `ui service` (a launchd PID) and `ui
+// built` (`.next` exists) both pass for a running-but-broken dashboard: a stale
+// build or an output:'standalone' / `next start` mismatch serves HTML whose
+// _next/static assets 404/500, blanking the page. So we functionally probe what
+// is actually served, and flag the serve-mode mismatch that causes it.
+
+use crate::config::Config;
+use crate::health::platform::repo_root;
+use crate::health::Check;
+use std::path::PathBuf;
+use std::time::Duration;
+
+fn home() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn ui_port() -> u16 {
+    std::env::var("MERIDIAN_UI_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(3939)
+}
+
+pub async fn checks(_cfg: &Config) -> Vec<Check> {
+    let mut out = vec![serve_mode_check()];
+    out.extend(serve_health(ui_port()).await);
+    out
+}
+
+/// Static config contract: an `output: 'standalone'` build must be served with
+/// `node .next/standalone/server.js`, NOT `next start` — the latter serves a
+/// manifest pointing at assets that aren't where `next start` looks for them.
+fn serve_mode_check() -> Check {
+    let Some(root) = repo_root() else {
+        return Check::info("ui serve mode", "ui", "repo root not found");
+    };
+    let standalone = ["ts", "js", "mjs"].iter().any(|ext| {
+        std::fs::read_to_string(root.join(format!("ui/next.config.{ext}")))
+            .map(|s| s.contains("standalone"))
+            .unwrap_or(false)
+    });
+    if !standalone {
+        return Check::ok("ui serve mode", "ui", "not standalone");
+    }
+    let plist = home().join("Library/LaunchAgents/com.meridiona.ui.plist");
+    let runs_next_start = std::fs::read_to_string(&plist)
+        .map(|s| s.contains("next start") || s.contains("<string>start</string>"))
+        .unwrap_or(false);
+    if runs_next_start {
+        Check::critical(
+            "ui serve mode",
+            "ui",
+            "output:'standalone' build but the service runs `next start`",
+        )
+        .with_remedy("serve via `node .next/standalone/server.js` in com.meridiona.ui.plist")
+    } else {
+        Check::ok("ui serve mode", "ui", "standalone, served correctly")
+    }
+}
+
+/// Functional probe: GET `/`, then fetch a `_next/static` asset the HTML
+/// references. The asset fetch is the real signal — a stale/broken build returns
+/// 200 on `/` but 404/500 on its chunks, which is what blanks the dashboard.
+async fn serve_health(port: u16) -> Vec<Check> {
+    let base = format!("http://localhost:{port}");
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(4))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return vec![Check::warn(
+                "ui serving",
+                "ui",
+                format!("http client error ({e})"),
+            )]
+        }
+    };
+
+    let html = match client.get(&base).send().await {
+        Err(_) => {
+            return vec![
+                Check::warn("ui serving", "ui", format!("not reachable at {base}"))
+                    .with_remedy("meridian start"),
+            ]
+        }
+        Ok(resp) if !resp.status().is_success() => {
+            return vec![Check::critical(
+                "ui serving",
+                "ui",
+                format!("/ returned HTTP {}", resp.status().as_u16()),
+            )
+            .with_remedy("rebuild + restart the UI (cd ui && npm run build)")]
+        }
+        Ok(resp) => resp.text().await.unwrap_or_default(),
+    };
+
+    vec![
+        Check::ok("ui serving", "ui", "/ → 200"),
+        asset_check(&client, &base, &html).await,
+    ]
+}
+
+async fn asset_check(client: &reqwest::Client, base: &str, html: &str) -> Check {
+    let Some(asset) = first_asset(html) else {
+        return Check::info("ui assets", "ui", "no static asset referenced (unusual)");
+    };
+    match client.get(format!("{base}{asset}")).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            Check::ok("ui assets", "ui", "static assets load")
+        }
+        Ok(resp) => Check::critical(
+            "ui assets",
+            "ui",
+            format!(
+                "{} → HTTP {} — stale/broken build",
+                short(&asset),
+                resp.status().as_u16()
+            ),
+        )
+        .with_remedy("rebuild + restart the UI; check output:'standalone' vs `next start`"),
+        Err(_) => Check::warn("ui assets", "ui", "could not fetch a static asset"),
+    }
+}
+
+/// First `/_next/static/...` asset URL in the HTML, preferring CSS then JS.
+fn first_asset(html: &str) -> Option<String> {
+    [".css", ".js"]
+        .into_iter()
+        .find_map(|ext| find_asset_with_ext(html, ext))
+}
+
+fn find_asset_with_ext(html: &str, ext: &str) -> Option<String> {
+    const NEEDLE: &str = "/_next/static/";
+    let mut from = 0;
+    while let Some(rel) = html[from..].find(NEEDLE) {
+        let i = from + rel;
+        let rest = &html[i..];
+        let end = rest.find(['"', '\'', '>', ' ']).unwrap_or(rest.len());
+        let url = &rest[..end];
+        if url.ends_with(ext) {
+            return Some(url.to_string());
+        }
+        from = i + NEEDLE.len();
+    }
+    None
+}
+
+/// Tail of an asset path for compact display.
+fn short(url: &str) -> String {
+    url.rsplit('/').next().unwrap_or(url).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_css_asset_then_js() {
+        let html = r#"<link rel="stylesheet" href="/_next/static/chunks/a1b2.css"/><script src="/_next/static/chunks/main.js"></script>"#;
+        assert_eq!(
+            first_asset(html).as_deref(),
+            Some("/_next/static/chunks/a1b2.css")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_js_when_no_css() {
+        let html = r#"<script src="/_next/static/chunks/main-xyz.js"></script>"#;
+        assert_eq!(
+            first_asset(html).as_deref(),
+            Some("/_next/static/chunks/main-xyz.js")
+        );
+    }
+
+    #[test]
+    fn no_asset_when_absent() {
+        assert!(first_asset("<html><body>hi</body></html>").is_none());
+    }
+
+    #[test]
+    fn short_takes_basename() {
+        assert_eq!(short("/_next/static/chunks/a.css"), "a.css");
+    }
+}

--- a/src/health/worklog.rs
+++ b/src/health/worklog.rs
@@ -1,0 +1,78 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// PM-worklog health: drafts awaiting human review, hours stuck unprocessed, and
+// worklogs failing to post to Jira (the retry-forever case the daemon never
+// surfaces). Content-free — counts and timestamps from meridian.db.
+
+use crate::config::Config;
+use crate::health::Check;
+use sqlx::SqlitePool;
+
+/// A pending hour older than this (minutes) is wedged, not just settling.
+const STUCK_HOUR_MIN: f64 = 90.0;
+
+pub async fn checks(_cfg: &Config, pool: Option<&SqlitePool>) -> Vec<Check> {
+    let p = match pool {
+        Some(p) => p,
+        None => return Vec::new(),
+    };
+    vec![
+        drafts_pending(p).await,
+        stuck_hours(p).await,
+        post_failures(p).await,
+    ]
+}
+
+async fn drafts_pending(pool: &SqlitePool) -> Check {
+    match sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM pm_worklogs WHERE state = 'drafted'")
+        .fetch_one(pool)
+        .await
+    {
+        Ok(0) => Check::ok("drafts", "L4", "none awaiting review"),
+        Ok(n) => Check::info(
+            "drafts",
+            "L4",
+            format!("{n} awaiting review in the dashboard"),
+        ),
+        Err(e) => Check::info("drafts", "L4", format!("not available ({e})")),
+    }
+}
+
+async fn stuck_hours(pool: &SqlitePool) -> Check {
+    match sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM pm_worklog_hours
+         WHERE status = 'pending'
+           AND (julianday('now') - julianday(hour_end)) * 1440.0 > ?1",
+    )
+    .bind(STUCK_HOUR_MIN)
+    .fetch_one(pool)
+    .await
+    {
+        Ok(0) => Check::ok("hour ledger", "L4", "no stuck hours"),
+        Ok(n) => Check::warn("hour ledger", "L4", format!("{n} hours stuck unprocessed"))
+            .with_remedy("a summariser/classifier stall upstream — check those queues"),
+        Err(e) => Check::info("hour ledger", "L4", format!("not available ({e})")),
+    }
+}
+
+async fn post_failures(pool: &SqlitePool) -> Check {
+    match sqlx::query_as::<_, (i64, Option<i64>)>(
+        "SELECT COUNT(*), MAX(post_attempt_count) FROM pm_worklogs
+         WHERE last_post_error IS NOT NULL AND state = 'approved'",
+    )
+    .fetch_one(pool)
+    .await
+    {
+        Ok((0, _)) => Check::ok("jira posting", "L2", "no post failures"),
+        Ok((n, attempts)) => Check::warn(
+            "jira posting",
+            "L2",
+            format!(
+                "{n} approved worklogs failing to post (≤{} attempts each)",
+                attempts.unwrap_or(0)
+            ),
+        )
+        .with_remedy("check jira.auth and the worklog's last_post_error in the dashboard"),
+        Err(e) => Check::info("jira posting", "L2", format!("not available ({e})")),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod coding_agent_session_ingest;
 pub mod config;
 pub mod db;
 pub mod etl;
+pub mod health;
 pub mod intelligence;
 pub mod llm_gate;
 pub mod observability;

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,22 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    // `meridian doctor` — content-free system-health sweep. Read-only, no daemon
+    // init. Surfaces broken capture/config so a misclassification isn't blamed on
+    // the model. Currently covers L1 screenpipe capture; more layers TBD. Exits
+    // non-zero if any check is critical.
+    if std::env::args().nth(1).as_deref() == Some("doctor") {
+        let cfg = Config::from_env();
+        let screenpipe = open_screenpipe(&cfg.screenpipe_db_uri()).await.ok();
+        let report = meridian::health::capture::run(&cfg, screenpipe.as_ref()).await;
+        println!("{}", report.render_titled("screenpipe capture (L1)"));
+        if let Some(pool) = screenpipe {
+            pool.close().await;
+        }
+        let critical = report.worst() == meridian::health::Severity::Critical;
+        std::process::exit(if critical { 1 } else { 0 });
+    }
+
     // 2. Tracing — layered subscriber (stdout + JSONL file + OTLP to OpenObserve).
     //    Guard must outlive the program; we shut it down explicitly at the end
     //    so OTel's blocking flush doesn't run inside tokio's drop path.
@@ -183,6 +199,14 @@ async fn main() -> Result<()> {
 
     // 4. Open screenpipe pool (read-only)
     let screenpipe = open_screenpipe(&initial_cfg.screenpipe_db_uri()).await?;
+
+    // 4c. Capture-layer (L1) preflight: surface degraded screen capture (revoked
+    //     Screen Recording / Accessibility permission, dead screenpipe, stale
+    //     frames) before the poll loop. Non-fatal — the daemon still runs; we log
+    //     the fault so misclassifications aren't blamed on the model.
+    meridian::health::capture::run(&initial_cfg, Some(&screenpipe))
+        .await
+        .log("startup");
 
     // 5. Open / create meridian pool and run migrations
     let meridian = setup_db(&initial_cfg.meridian_db_uri()).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,19 +160,16 @@ async fn main() -> Result<()> {
     // the model. Currently covers L1 screenpipe capture; more layers TBD. Exits
     // non-zero if any check is critical.
     if std::env::args().nth(1).as_deref() == Some("doctor") {
-        // `--porcelain` emits TSV rows for the `meridian` CLI wrapper to fold into
-        // its by-daemon table; otherwise a human-readable report.
+        // `--porcelain` emits TSV rows for machine ingestion; otherwise a rich,
+        // colour-when-a-tty, by-daemon table. Read-only comprehensive sweep.
         let porcelain = std::env::args().any(|a| a == "--porcelain");
         let cfg = Config::from_env();
-        let screenpipe = open_screenpipe(&cfg.screenpipe_db_uri()).await.ok();
-        let report = meridian::health::capture::run(&cfg, screenpipe.as_ref()).await;
+        let report = meridian::health::run_all(&cfg).await;
         if porcelain {
             print!("{}", report.render_porcelain());
         } else {
-            println!("{}", report.render_titled("screenpipe capture (L1)"));
-        }
-        if let Some(pool) = screenpipe {
-            pool.close().await;
+            use std::io::IsTerminal;
+            print!("{}", report.render(std::io::stdout().is_terminal()));
         }
         let critical = report.worst() == meridian::health::Severity::Critical;
         std::process::exit(if critical { 1 } else { 0 });
@@ -211,9 +208,10 @@ async fn main() -> Result<()> {
     //     Screen Recording / Accessibility permission, dead screenpipe, stale
     //     frames) before the poll loop. Non-fatal — the daemon still runs; we log
     //     the fault so misclassifications aren't blamed on the model.
-    meridian::health::capture::run(&initial_cfg, Some(&screenpipe))
-        .await
-        .log("startup");
+    meridian::health::Report::new(
+        meridian::health::capture::checks(&initial_cfg, Some(&screenpipe)).await,
+    )
+    .log("startup");
 
     // 5. Open / create meridian pool and run migrations
     let meridian = setup_db(&initial_cfg.meridian_db_uri()).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,10 +160,17 @@ async fn main() -> Result<()> {
     // the model. Currently covers L1 screenpipe capture; more layers TBD. Exits
     // non-zero if any check is critical.
     if std::env::args().nth(1).as_deref() == Some("doctor") {
+        // `--porcelain` emits TSV rows for the `meridian` CLI wrapper to fold into
+        // its by-daemon table; otherwise a human-readable report.
+        let porcelain = std::env::args().any(|a| a == "--porcelain");
         let cfg = Config::from_env();
         let screenpipe = open_screenpipe(&cfg.screenpipe_db_uri()).await.ok();
         let report = meridian::health::capture::run(&cfg, screenpipe.as_ref()).await;
-        println!("{}", report.render_titled("screenpipe capture (L1)"));
+        if porcelain {
+            print!("{}", report.render_porcelain());
+        } else {
+            println!("{}", report.render_titled("screenpipe capture (L1)"));
+        }
         if let Some(pool) = screenpipe {
             pool.close().await;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,8 +163,16 @@ async fn main() -> Result<()> {
         // `--porcelain` emits TSV rows for machine ingestion; otherwise a rich,
         // colour-when-a-tty, by-daemon table. Read-only comprehensive sweep.
         let porcelain = std::env::args().any(|a| a == "--porcelain");
+        let fix = std::env::args().any(|a| a == "--fix");
+        let dry_run = std::env::args().any(|a| a == "--dry-run");
         let cfg = Config::from_env();
         let report = meridian::health::run_all(&cfg).await;
+        if fix {
+            // Attempt repair (auto silently, guided with confirm); exit non-zero
+            // if anything still needs a human.
+            let residual = meridian::health::fix::run(&cfg, &report, dry_run);
+            std::process::exit(if residual { 1 } else { 0 });
+        }
         if porcelain {
             print!("{}", report.render_porcelain());
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,7 +169,15 @@ async fn main() -> Result<()> {
             print!("{}", report.render_porcelain());
         } else {
             use std::io::IsTerminal;
-            print!("{}", report.render(std::io::stdout().is_terminal()));
+            let color = std::io::stdout().is_terminal();
+            print!("{}", report.render(color));
+            // Diagnose + escalate: chain the warnings into root causes, then
+            // point at `--fix` / support / claude.
+            let dx = meridian::health::diagnose::root_causes(&report);
+            print!("{}", meridian::health::diagnose::render(&dx, color));
+            if report.worst() >= meridian::health::Severity::Warn {
+                print!("{}", meridian::health::diagnose::escalation_hint(color));
+            }
         }
         let critical = report.worst() == meridian::health::Severity::Critical;
         std::process::exit(if critical { 1 } else { 0 });

--- a/ui/lib/settings.ts
+++ b/ui/lib/settings.ts
@@ -34,15 +34,37 @@ export const SETTINGS_DEFAULTS: RuntimeSettings = {
   jira_update_enabled: true,
 }
 
-const SETTINGS_PATH = path.join(os.homedir(), '.meridian', 'settings.json')
+// The daemon reads the repo-local settings.json (cwd = repo root). The UI must
+// write the SAME file or its toggles never reach the daemon. The UI runs with
+// cwd = <repo>/ui (launchd WorkingDirectory and `next dev`/`start`), so the repo
+// root is the nearest ancestor containing Cargo.toml.
+function repoRoot(): string {
+  let dir = process.cwd()
+  for (let i = 0; i < 6; i++) {
+    if (fs.existsSync(path.join(dir, 'Cargo.toml'))) return dir
+    const parent = path.dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  // Fallback: cwd is typically <repo>/ui, so the repo root is its parent.
+  return path.basename(process.cwd()) === 'ui' ? path.dirname(process.cwd()) : process.cwd()
+}
+
+const SETTINGS_PATH = path.join(repoRoot(), 'settings.json')
+// Pre-fix location — read as a fallback so existing settings aren't lost; the
+// next write migrates them to SETTINGS_PATH.
+const LEGACY_SETTINGS_PATH = path.join(os.homedir(), '.meridian', 'settings.json')
 
 export function readSettings(): RuntimeSettings {
-  try {
-    const raw = fs.readFileSync(SETTINGS_PATH, 'utf-8')
-    return { ...SETTINGS_DEFAULTS, ...JSON.parse(raw) }
-  } catch {
-    return { ...SETTINGS_DEFAULTS }
+  for (const p of [SETTINGS_PATH, LEGACY_SETTINGS_PATH]) {
+    try {
+      const raw = fs.readFileSync(p, 'utf-8')
+      return { ...SETTINGS_DEFAULTS, ...JSON.parse(raw) }
+    } catch {
+      // not at this location — try the next
+    }
   }
+  return { ...SETTINGS_DEFAULTS }
 }
 
 export function writeSettings(settings: RuntimeSettings): void {


### PR DESCRIPTION
## Summary

Comprehensive multi-daemon `meridian doctor` system-health command, plus a UI settings-path fix. **Eval-feedback / worklog-reject-attribution work has been split out** into #107 and the KAN-141 deepeval work stays on its own branch — this PR is health-tooling only.

Replaces #106 (same health commits, with the worklog/eval-feedback commit removed at the source).

## Changes

- **`meridian doctor`** (9 commits): multi-daemon health checks with rich by-daemon table rendering; L1 screenpipe capture preflight; per-app a11y checks; config-contract group; worklog / coding-agent / observability groups; root-cause diagnosis + escalation; and `--fix` tiered auto/guided/manual repair. New module tree under `src/health/`.
- **`fix(settings)`**: UI writes the repo-local `settings.json` so the daemon (cwd = repo root) actually reads the UI's toggles.

## Not included (split out)

- Worklog review-action + reject-attribution capture → **#107**
- KAN-141 deepeval-on-golden-dataset → `KAN-141-run-deepeval-on-the-golden-dataset` branch

## Test plan

- [ ] `cargo test` (168 passed locally)
- [ ] `cd ui && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
