### PR TITLE
feat(pm-worklog): event-driven worklog drafting + fix backfill timer starvation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "meridian"
-version = "1.4.5"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,6 +223,12 @@ async fn main() -> Result<()> {
     let etl_tick_span: Arc<std::sync::Mutex<Option<tracing::Span>>> =
         Arc::new(std::sync::Mutex::new(None));
 
+    // Wakes the PM-worklog driver the moment the classifier settles a session: an
+    // hour becomes draftable exactly when its last in-flight session is classified,
+    // so the driver reacts in seconds instead of waiting up to a full interval. The
+    // driver's interval timer is kept as a fallback (aging escape + day rollover).
+    let worklog_notify: Arc<Notify> = Arc::new(Notify::new());
+
     // 7c. Run ETL once immediately before entering the loop.
     //     Re-read config so that any settings.json present at startup takes effect.
     {
@@ -283,8 +289,9 @@ async fn main() -> Result<()> {
     {
         let pool_pm = meridian.clone();
         let rx_pm = shutdown_rx.clone();
+        let notify_pm = worklog_notify.clone();
         tokio::spawn(async move {
-            meridian::pm_worklog::run_loop(pool_pm, rx_pm).await;
+            meridian::pm_worklog::run_loop(pool_pm, rx_pm, notify_pm).await;
         });
     }
 
@@ -305,6 +312,7 @@ async fn main() -> Result<()> {
         let meridian_linker = meridian.clone();
         let notify_linker = etl_notify.clone();
         let tick_span_linker = etl_tick_span.clone();
+        let notify_worklog = worklog_notify.clone();
         tokio::spawn(async move {
             // Tracks consecutive subprocess failures per session_id.
             // Reset to zero whenever any session is successfully classified.
@@ -324,6 +332,10 @@ async fn main() -> Result<()> {
                     _ = tokio::time::sleep(Duration::from_secs(300)) => tracing::Span::none(),
                 };
 
+                // Whether this wake settled at least one session — if so, wake the
+                // PM-worklog driver afterwards so a now-complete hour drafts at once.
+                let mut classified_any = false;
+
                 // Drain: classify oldest-first until nothing is left or a failure stops us.
                 loop {
                     let cfg = Config::from_env();
@@ -337,6 +349,7 @@ async fn main() -> Result<()> {
                     {
                         Ok(TaskLinkOutcome::Classified) => {
                             failure_counts.clear();
+                            classified_any = true;
                             // Loop immediately — more sessions may be waiting.
                         }
                         Ok(TaskLinkOutcome::NoPendingWork) => {
@@ -350,6 +363,7 @@ async fn main() -> Result<()> {
                                 {
                                     Ok(0) => break,
                                     Ok(n) => {
+                                        classified_any = true;
                                         tracing::info!(
                                             classified = n,
                                             "coding-agent rows classified"
@@ -407,6 +421,13 @@ async fn main() -> Result<()> {
                             break;
                         }
                     }
+                }
+
+                // This wake settled at least one session — nudge the PM-worklog
+                // driver so an hour that just became complete drafts immediately
+                // instead of waiting for the next interval tick.
+                if classified_any {
+                    notify_worklog.notify_one();
                 }
             }
             tracing::info!("task linker loop stopped");

--- a/src/pm_worklog/scheduler.rs
+++ b/src/pm_worklog/scheduler.rs
@@ -10,10 +10,12 @@
 // The driver NEVER posts to Jira. Drafted worklogs wait for a human to approve
 // them in the dashboard; the `post` sweep then posts approved rows. See `mod.rs`.
 
+use std::sync::Arc;
+
 use anyhow::Result;
 use chrono::{Duration, Local, NaiveDate, TimeZone, Utc};
 use sqlx::SqlitePool;
-use tokio::sync::watch;
+use tokio::sync::{watch, Notify};
 
 use crate::config::Config;
 
@@ -134,50 +136,98 @@ pub async fn run_driver(
     Ok(summary)
 }
 
-/// Daemon task: run the driver on the configured interval until shutdown. Drafts
-/// only — posting is handled separately by the approved-poster (`post::run_post_loop`).
-pub async fn run_loop(pool: SqlitePool, mut shutdown_rx: watch::Receiver<bool>) {
+/// Daemon task: run the driver until shutdown. Drafts only — posting is handled
+/// separately by the approved-poster (`post::run_post_loop`).
+///
+/// Woken by EITHER `classify_notify` (the classifier fires it after settling a
+/// session, so an hour drafts the instant its last in-flight session is
+/// classified) OR the interval timer (the fallback that still covers the aging
+/// escape and the midnight day-rollover, which are inherently time-based).
+pub async fn run_loop(
+    pool: SqlitePool,
+    mut shutdown_rx: watch::Receiver<bool>,
+    classify_notify: Arc<Notify>,
+) {
     let cfg = PmWorklogConfig::from_env();
     let interval = std::time::Duration::from_secs((cfg.interval_hours * 3600.0).max(60.0) as u64);
     tracing::info!(
         interval_s = interval.as_secs(),
-        "pm-worklog driver starting (drafts only — posting is approval-gated)"
+        "pm-worklog driver starting (drafts only — posting is approval-gated; \
+         wakes on classifier notify or interval)"
     );
 
+    // Startup catch-up: a full bounded backfill (yesterday-leftover + today) so a
+    // restart re-drafts any hour that settled while the daemon was down.
+    run_pass(&pool, &cfg, Scope::Backfill).await;
+
+    // The backfill cadence is a PERSISTENT interval, not a fresh `sleep` per loop
+    // iteration: a `sleep` future is recreated (and thus reset) every time the
+    // select wakes, so frequent classify events would perpetually starve it and
+    // the periodic safety net would only ever run at startup. An `Interval` keeps
+    // its own deadline across select cancellations, so it fires on a fixed cadence
+    // regardless of how often the event path wakes us. Delay (not Burst) missed-
+    // tick behaviour avoids a catch-up storm after a long-running pass.
+    let mut backfill_timer = tokio::time::interval(interval);
+    backfill_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    backfill_timer.tick().await; // consume the immediate first tick (startup backfill already ran)
+
     loop {
-        // Process yesterday AND today every pass. Yesterday's done hours skip
-        // instantly via the ledger; this closes the day-rollover gap where the
-        // previous day's last hours would otherwise strand at midnight.
-        // Refresh the PM task cache before drafting so worklog prose reflects
-        // current ticket metadata (title/status/assignee). Gated — a no-op if a
-        // classification pass already refreshed it within SYNC_INTERVAL_MINS.
-        let config = Config::from_env();
-        if let Err(e) = crate::intelligence::run_pm_sync(&pool, &config).await {
-            tracing::warn!(error = %e, "pm_tasks refresh before worklog pass failed — using cached tasks");
-        }
-
-        let today = Local::now().date_naive();
-        let days: Vec<Option<NaiveDate>> = vec![today.pred_opt(), Some(today)];
-        let min_duration_s = config.min_classification_duration_s;
-        for day in days.into_iter().flatten() {
-            match run_driver(&pool, &cfg, min_duration_s, Some(day)).await {
-                Ok(s) => tracing::info!(
-                    day = %day,
-                    hours_processed = s.hours_processed,
-                    drafted = s.worklogs_drafted,
-                    not_ready = s.hours_not_ready,
-                    "pm-worklog driver pass complete"
-                ),
-                Err(e) => tracing::error!(day = %day, error = %e, "pm-worklog driver pass failed"),
-            }
-        }
-
-        tokio::select! {
+        let scope = tokio::select! {
             _ = shutdown_rx.changed() => break,
-            _ = tokio::time::sleep(interval) => {}
-        }
+            // Event path: the classifier just settled a session, so an hour may
+            // have just become complete. Draft TODAY's now-ready hours at once.
+            // Today only — live work is always today, so we skip re-scanning
+            // yesterday on every classify wake (that's the backfill's job).
+            _ = classify_notify.notified() => Scope::Today,
+            // Bounded same-day backfill + rollover safety net: retries hours that
+            // didn't draft on the event path (LLM down, daemon down, aged-out)
+            // across yesterday-leftover + today. Time-based, so timer-driven.
+            _ = backfill_timer.tick() => Scope::Backfill,
+        };
+        run_pass(&pool, &cfg, scope).await;
     }
     tracing::info!("pm-worklog driver stopped");
+}
+
+/// Which days a driver pass covers.
+#[derive(Clone, Copy, PartialEq)]
+enum Scope {
+    /// Live/event path — today only.
+    Today,
+    /// Recovery path — yesterday-leftover + today (bounded; never older).
+    Backfill,
+}
+
+/// Run one driver pass over the days in `scope`. Refreshes the PM task cache
+/// first (gated — a no-op within the sync window).
+async fn run_pass(pool: &SqlitePool, cfg: &PmWorklogConfig, scope: Scope) {
+    let config = Config::from_env();
+    if let Err(e) = crate::intelligence::run_pm_sync(pool, &config).await {
+        tracing::warn!(error = %e, "pm_tasks refresh before worklog pass failed — using cached tasks");
+    }
+
+    let today = Local::now().date_naive();
+    let days: Vec<NaiveDate> = match scope {
+        Scope::Today => vec![today],
+        Scope::Backfill => vec![today.pred_opt(), Some(today)]
+            .into_iter()
+            .flatten()
+            .collect(),
+    };
+    let min_duration_s = config.min_classification_duration_s;
+    for day in days {
+        match run_driver(pool, cfg, min_duration_s, Some(day)).await {
+            Ok(s) => tracing::info!(
+                day = %day,
+                hours_processed = s.hours_processed,
+                drafted = s.worklogs_drafted,
+                not_ready = s.hours_not_ready,
+                scope = if scope == Scope::Backfill { "backfill" } else { "event" },
+                "pm-worklog driver pass complete"
+            ),
+            Err(e) => tracing::error!(day = %day, error = %e, "pm-worklog driver pass failed"),
+        }
+    }
 }
 
 /// One-shot CLI entry: `meridian pm-worklog [--day YYYY-MM-DD]`. Drafts worklogs;


### PR DESCRIPTION
## What

Make the PM-worklog driver **event-driven** instead of purely interval-driven, and fix a starvation bug introduced in that loop.

### Event-driven drafting
The task-linker now fires a `tokio::sync::Notify` the instant it settles (classifies) any session. The worklog driver wakes on that notify and drafts **today's** now-ready hours immediately, rather than waiting up to the 1-hour interval. An hour drafts the moment its last in-flight session is classified.

### Interval retained as bounded backfill
The interval timer is kept as a **same-day backfill** (yesterday-leftover + today) — the recovery path for the aging escape, LLM-down, daemon-down, and day rollover. Event passes are today-only (live work is always today), so we no longer re-scan yesterday on every classify wake.

### Bug fix: backfill timer starvation
The first cut of the loop used a fresh `tokio::time::sleep(interval)` inside `tokio::select!` **per loop iteration** — which is recreated (reset) every time the select wakes. With frequent classify events the 1-hour backfill timer never elapsed, so the periodic safety net only ever ran at startup. Replaced with a **persistent `tokio::time::interval`** (`MissedTickBehavior::Delay`) whose deadline survives select cancellation, so it fires on a fixed cadence regardless of event frequency.

### Cargo.lock
Synced the `meridian` package version to `1.6.0` to match the already-committed `Cargo.toml` (the lock had lagged at `1.4.5`).

## Testing

- `cargo clippy -- -D warnings` and release build: clean
- **148 tests pass** (no regressions)
- Verified live on the running daemon:
  - startup `scope="backfill"` covers both days ✓
  - `scope="event"` passes are today-only, fired by the classifier notify ✓
  - main ETL loop unaffected (independent of the worklog driver) ✓

## Files
- `src/main.rs` — `worklog_notify` wiring; fire it after the task-linker settles any session
- `src/pm_worklog/scheduler.rs` — `Scope` enum, `run_pass`, event/backfill select, persistent interval
- `Cargo.lock` — version sync

🤖 Generated with Claude Code