### PR TITLE
feat(agents): dynamically select the MLX server model via llm_selector

### DIFF
--- a/services/agents/llm_selector.py
+++ b/services/agents/llm_selector.py
@@ -79,6 +79,7 @@ _MODELS = [
     ("phi-4",           "mlx",  8.5, 80, "mlx-community/phi-4-4bit"),
     ("r1-14b",          "mlx",  8.5, 78, "mlx-community/DeepSeek-R1-Distill-Qwen-14B-4bit"),
     ("gemma3-12b",      "mlx",  7.0, 75, "mlx-community/gemma-3-12b-it-qat-4bit"),
+    ("qwen3.5-9b-optiq","mlx",  6.5, 74, "mlx-community/Qwen3.5-9B-OptiQ-4bit"),  # eval-tuned classifier default
     ("qwen3.5-4b",      "mlx",  2.5, 65, "mlx-community/Qwen3.5-4B-MLX-4bit"),
     ("llama3.2-3b",     "mlx",  1.8, 62, "mlx-community/Llama-3.2-3B-Instruct-4bit"),
     ("apple-intelligence", "apple_fm", 0.0, 60, None),
@@ -801,6 +802,156 @@ def select_model_for_hermes(budget_pct: Optional[float] = None) -> Optional[Loca
             raise
 
 
+def _hf_model_cached(hf_id: "str | None") -> bool:
+    """True when a HuggingFace repo's weights are already in the local cache.
+
+    A best-effort filesystem check so dynamic selection never picks a catalog
+    model that would trigger a multi-GB ``snapshot_download`` (online) or raise
+    (offline) inside ``mlx_lm.load`` at server startup. Honours HF_HUB_CACHE /
+    HF_HOME, falling back to ~/.cache/huggingface/hub. Mirrors the
+    "best among what's present" philosophy of discover_running_servers().
+    """
+    if not hf_id:
+        return False
+    hf_home = os.environ.get("HF_HOME")
+    cache = (
+        os.environ.get("HF_HUB_CACHE")
+        or (os.path.join(hf_home, "hub") if hf_home else None)
+        or str(Path.home() / ".cache" / "huggingface" / "hub")
+    )
+    snapshots = Path(cache) / ("models--" + hf_id.replace("/", "--")) / "snapshots"
+    if not snapshots.is_dir():
+        return False
+    # A revision directory that actually contains files (not just an empty shell).
+    for rev in snapshots.iterdir():
+        if rev.is_dir() and any(rev.iterdir()):
+            return True
+    return False
+
+
+def select_mlx_model_id(
+    preferred_hf_id: "str | None" = None,
+    preferred_min_ram_gb: float = 0.0,
+    budget_pct: "float | None" = None,
+) -> "str | None":
+    """Pick the best **in-process** MLX model id for this machine.
+
+    Selection-only sibling of select_model_for_hermes(): returns a HuggingFace
+    repo id the caller loads directly via mlx_lm + outlines (FSM-constrained
+    decoding). It deliberately does NOT discover external servers
+    (Ollama / LM Studio / Apple Intelligence give no constrained decoding) and
+    does NOT spawn a managed mlx_lm.server — the MLX classifier server loads the
+    chosen model in-process and is the single LLM host for every stage.
+
+    Priority:
+      1. ``preferred_hf_id`` when it fits the Metal headroom budget — the
+         eval-tuned classifier model. Keep it on capable machines; degrade only
+         when it physically won't fit, so a generic catalog ``quality_score``
+         never silently swaps out the tuned model on a big box.
+      2. The largest catalog model that fits (``_select_mlx_entry``).
+      3. ``preferred_hf_id`` as a best-effort fallback when nothing in the
+         catalog fits — let ``mlx_lm.load`` try rather than returning None and
+         breaking the load.
+
+    Returns None only when no ``preferred_hf_id`` is given and nothing fits.
+    """
+    if budget_pct is None:
+        try:
+            from agents.config import LLM_BUDGET_PCT
+            budget_pct = LLM_BUDGET_PCT
+        except Exception:
+            budget_pct = 0.5
+
+    with _tracer.start_as_current_span("llm_selector.select_mlx_model_id") as span:
+        span.set_attribute("llm.preferred_hf_id", preferred_hf_id or "")
+        span.set_attribute("llm.preferred_min_ram_gb", preferred_min_ram_gb)
+        span.set_attribute("llm.budget_pct", budget_pct)
+
+        # Non-Apple-Silicon: no MLX runtime — return the preferred default so the
+        # caller's behaviour is unchanged (the load path no-ops/fails as before).
+        if platform.system() != "Darwin":
+            span.set_attribute("llm.reason", "not_darwin")
+            span.set_attribute("llm.selected_model", preferred_hf_id or "")
+            return preferred_hf_id
+        brand = _sysctl("machdep.cpu.brand_string") or ""
+        if not brand.startswith("Apple M"):
+            span.set_attribute("llm.reason", "not_apple_silicon")
+            span.set_attribute("llm.selected_model", preferred_hf_id or "")
+            return preferred_hf_id
+
+        try:
+            snap = probe_compute()
+        except Exception as exc:  # noqa: BLE001
+            span.record_exception(exc)
+            span.set_attribute("llm.reason", "compute_probe_failed")
+            span.set_attribute("llm.selected_model", preferred_hf_id or "")
+            log.warning("llm_selector: compute probe failed (%s) — using %s",
+                        exc, preferred_hf_id)
+            return preferred_hf_id
+
+        # Relax the budget when the screen is locked — the user won't feel the
+        # latency — and mirror _select_mlx_entry's heavy-throttle cap so the
+        # preferred-fit check sees the same budget the catalog ladder does.
+        effective_pct = (
+            min(0.8, budget_pct * 1.5) if snap.screen_locked else budget_pct
+        )
+        budget = snap.metal_headroom_gb * effective_pct
+        if snap.thermal_level >= 2:
+            budget = min(budget, 9.0)
+
+        span.set_attribute("llm.headroom_gb",   round(snap.metal_headroom_gb, 2))
+        span.set_attribute("llm.effective_pct", round(effective_pct, 3))
+        span.set_attribute("llm.budget_gb",     round(budget, 2))
+        span.set_attribute("llm.thermal_level", snap.thermal_level)
+        span.set_attribute("llm.screen_locked", snap.screen_locked)
+
+        # 1. Keep the tuned classifier model when it fits.
+        if preferred_hf_id and preferred_min_ram_gb <= budget:
+            span.set_attribute("llm.reason", "preferred_fits")
+            span.set_attribute("llm.selected_model", preferred_hf_id)
+            log.info(
+                "llm_selector: MLX in-process model=%s (preferred — min_ram=%.1f GB "
+                "fits budget=%.1f GB)",
+                preferred_hf_id, preferred_min_ram_gb, budget,
+            )
+            return preferred_hf_id
+
+        # 2. Largest catalog model that BOTH fits the budget AND is already in
+        #    the HF cache. Gating on the cache keeps "dynamic" meaning "best
+        #    among what's present" — never a surprise multi-GB download (or an
+        #    offline load failure that would kill server startup) on exactly the
+        #    constrained machines this degradation path targets. The `budget`
+        #    here is already thermal-capped, matching _select_mlx_entry.
+        for model_id, backend, min_ram, quality, hf_id in _MODELS:
+            if backend != "mlx" or min_ram > budget:
+                continue
+            if not _hf_model_cached(hf_id):
+                log.debug(
+                    "llm_selector: skip %s — fits budget=%.1f GB but not in HF cache",
+                    hf_id, budget,
+                )
+                continue
+            span.set_attribute("llm.reason", "catalog_fit_cached")
+            span.set_attribute("llm.selected_model", hf_id)
+            log.info(
+                "llm_selector: MLX in-process model=%s hf=%s min_ram=%.1f GB "
+                "quality=%d cached (preferred=%s did not fit budget=%.1f GB)",
+                model_id, hf_id, min_ram, quality, preferred_hf_id, budget,
+            )
+            return hf_id
+
+        # 3. Nothing cached fits the budget — best effort with the preferred id.
+        #    (Loading preferred-when-absent is the pre-existing single-model
+        #    behaviour, not a regression introduced by dynamic selection.)
+        span.set_attribute("llm.reason", "nothing_cached_fits_use_preferred")
+        span.set_attribute("llm.selected_model", preferred_hf_id or "")
+        log.warning(
+            "llm_selector: no cached MLX model fits budget=%.1f GB — falling back to %s",
+            budget, preferred_hf_id,
+        )
+        return preferred_hf_id
+
+
 def resolve_model(name: str) -> "dict | None":
     """Resolve a short name ('phi-4') or HF ID to its catalog entry.
 
@@ -837,7 +988,8 @@ def discover_mlx_eval_server(port: int = 7823) -> "str | None":
 
 __all__ = ["local_infer", "discover_running_servers", "probe_compute",
            "RunningServer", "ComputeSnapshot", "LocalModelEndpoint",
-           "select_model_for_hermes", "shutdown_managed_server",
+           "select_model_for_hermes", "select_mlx_model_id",
+           "shutdown_managed_server",
            "resolve_model", "discover_mlx_eval_server"]
 
 # Public alias (no underscore) for external callers

--- a/services/agents/run_task_linker_mlx.py
+++ b/services/agents/run_task_linker_mlx.py
@@ -50,9 +50,63 @@ _CONTEXT_WINDOW = 5
 _MAX_TOKENS = 1024
 _TEMPERATURE = 0.0  # greedy decoding — deterministic classification
 
-_MLX_MODEL_ID = os.environ.get(
-    "MLX_MODEL_ID", "mlx-community/Qwen3.5-9B-OptiQ-4bit"
-)
+# The eval-tuned default classifier model. It lives in the llm_selector catalog
+# (_MODELS) as "qwen3.5-9b-optiq"; llm_selector keeps it on machines where it
+# fits and degrades only when Metal headroom can't accommodate it. The catalog
+# is the single source of truth for its working-set footprint — the constant
+# below is only the fallback used if the lookup ever fails (~5-6 GB resident for
+# the 9B-4bit weights, plus KV cache at our 1024-token generation budget).
+_DEFAULT_MLX_MODEL_ID = "mlx-community/Qwen3.5-9B-OptiQ-4bit"
+_DEFAULT_MLX_MODEL_MIN_RAM_GB = 6.5
+
+# Explicit pin — set MLX_MODEL_ID to bypass dynamic selection entirely (eval
+# experiments, reproducible benchmarks). When unset, the model is chosen at
+# runtime by llm_selector.select_mlx_model_id() based on available compute.
+_MLX_MODEL_ID_PIN = os.environ.get("MLX_MODEL_ID")
+
+# Resolved lazily and cached for the process lifetime by _resolve_model_id().
+# Kept as a module attribute (not just a function return) so /info, /v1/models,
+# and the llm_inference span all report the same, truthful id.
+_MLX_MODEL_ID: str | None = None
+
+
+def _resolve_model_id() -> str:
+    """Resolve the MLX model id for this process — once, then cached.
+
+    Order: explicit MLX_MODEL_ID pin → dynamic selection via llm_selector →
+    the hardcoded eval-tuned default on any failure. Never returns None so the
+    in-process load always has a concrete id to hand mlx_lm.load.
+    """
+    global _MLX_MODEL_ID
+    if _MLX_MODEL_ID is not None:
+        return _MLX_MODEL_ID
+
+    if _MLX_MODEL_ID_PIN:
+        _MLX_MODEL_ID = _MLX_MODEL_ID_PIN
+        log.info("run_task_linker_mlx: model pinned via MLX_MODEL_ID=%s", _MLX_MODEL_ID)
+        return _MLX_MODEL_ID
+
+    try:
+        from agents.llm_selector import resolve_model, select_mlx_model_id
+        entry = resolve_model(_DEFAULT_MLX_MODEL_ID)
+        preferred_min_ram = (
+            entry["min_ram_gb"] if entry else _DEFAULT_MLX_MODEL_MIN_RAM_GB
+        )
+        _MLX_MODEL_ID = select_mlx_model_id(
+            preferred_hf_id=_DEFAULT_MLX_MODEL_ID,
+            preferred_min_ram_gb=preferred_min_ram,
+        ) or _DEFAULT_MLX_MODEL_ID
+    except Exception as exc:  # noqa: BLE001
+        log.warning(
+            "run_task_linker_mlx: dynamic model selection failed (%s) — "
+            "using default %s", exc, _DEFAULT_MLX_MODEL_ID,
+        )
+        _MLX_MODEL_ID = _DEFAULT_MLX_MODEL_ID
+
+    log.info("run_task_linker_mlx: resolved MLX model=%s", _MLX_MODEL_ID)
+    return _MLX_MODEL_ID
+
+
 _SKILL_PATH = (
     _SERVICES_DIR / "skills" / "activity" / "task-classifier" / "SKILL.md"
 )
@@ -185,8 +239,9 @@ _model_cache: dict[str, Any] = {}
 
 def _get_model() -> Any:
     """Return an outlines-wrapped model, loading from disk on the first call."""
-    if _MLX_MODEL_ID in _model_cache:
-        return _model_cache[_MLX_MODEL_ID]
+    model_id = _resolve_model_id()
+    if model_id in _model_cache:
+        return _model_cache[model_id]
 
     try:
         import mlx_lm
@@ -198,17 +253,17 @@ def _get_model() -> Any:
         ) from exc
 
     log.info(
-        "run_task_linker_mlx: loading %s (first call this process)", _MLX_MODEL_ID
+        "run_task_linker_mlx: loading %s (first call this process)", model_id
     )
     t0 = time.time()
     mlx_model, tokenizer = mlx_lm.load(
-        _MLX_MODEL_ID,
+        model_id,
         tokenizer_config={"trust_remote_code": True},
     )
     outlines_model = outlines.from_mlxlm(mlx_model, tokenizer)
     log.info("run_task_linker_mlx: model loaded in %.1fs", time.time() - t0)
 
-    _model_cache[_MLX_MODEL_ID] = outlines_model
+    _model_cache[model_id] = outlines_model
     return outlines_model
 
 
@@ -369,7 +424,7 @@ def _classify_one(
     # ── llm_inference ─────────────────────────────────────────────────────────
     t0 = time.time()
     with tracer.start_as_current_span("llm_inference") as llm_span:
-        llm_span.set_attribute("model", _MLX_MODEL_ID)
+        llm_span.set_attribute("model", _resolve_model_id())
         llm_span.set_attribute("max_tokens", _MAX_TOKENS)
         llm_span.set_attribute("temperature", _TEMPERATURE)
         llm_span.add_event("inference_started", {"session_id": session_id})

--- a/services/agents/server.py
+++ b/services/agents/server.py
@@ -95,7 +95,7 @@ async def info() -> dict:
     m = _app_state.get("mlx_module")
     return {
         "backend":   _app_state.get("backend", "hermes"),
-        "model_id":  m._MLX_MODEL_ID if m else None,
+        "model_id":  m._resolve_model_id() if m else None,
         "loaded_at": _app_state.get("loaded_at"),
     }
 
@@ -646,8 +646,8 @@ async def openai_models_list() -> dict:
     model_id = "qwen3.5-9b-instruct"
     if _app_state.get("backend") == "mlx":
         m = _app_state.get("mlx_module")
-        if m is not None and hasattr(m, "_MLX_MODEL_ID"):
-            model_id = m._MLX_MODEL_ID
+        if m is not None and hasattr(m, "_resolve_model_id"):
+            model_id = m._resolve_model_id()
     return {
         "object": "list",
         "data": [


### PR DESCRIPTION
## What

The MLX server (`server.py --backend mlx`) loaded **one hardcoded model** (`Qwen3.5-9B-OptiQ-4bit`) at startup via `run_task_linker_mlx._MLX_MODEL_ID` and served it to every stage — `/classify_sessions`, `/summarise`, `/v1/chat/completions`, `/synthesise_worklog`. This wires the existing `llm_selector` into that single load point so the model is chosen at runtime from available Metal headroom, while keeping the eval-tuned default on machines that can run it.

## How

- **`llm_selector.py` — `select_mlx_model_id()`**: a new **MLX-in-process** selector. Deliberately does *not* reuse `select_model_for_hermes`/`local_infer` (which prefer external Ollama/LM Studio/Apple FM servers with no FSM-constrained decoding, and spawn a separate managed `mlx_lm.server` that would collide on the port). Priority: tuned model when it fits the budget → largest catalog model that **both fits and is already in the HF cache** → tuned model best-effort.
- **`_hf_model_cached()`**: gates catalog picks to weights already on disk, so dynamic selection never triggers a surprise multi-GB download (online) or an offline startup failure inside `mlx_lm.load` — on exactly the constrained machines this degradation path targets.
- **Catalog entry**: added `Qwen3.5-9B-OptiQ-4bit` to `_MODELS` at its 6.5 GB size slot (between `gemma3-12b` and `qwen3.5-4b`), so `resolve_model()` and the Hermes oscillation guard resolve it.
- **`run_task_linker_mlx.py`**: `_MLX_MODEL_ID` is resolved lazily/cached by `_resolve_model_id()` — explicit `MLX_MODEL_ID` pin **>** dynamic selection **>** hardcoded default (never returns `None`). Catalog is the single source of truth for the preferred model's footprint.
- **`server.py`**: `/info` and `/v1/models` report the *resolved* id, so the eval pipeline (which reads `/info`) stays truthful.

## Why prefer-then-degrade

`OptiQ` is the eval-tuned classifier; the catalog's generic `quality_score` would otherwise silently swap it for `llama3.3-70b` on a big box. So capable Macs keep `OptiQ`; only RAM-constrained Macs degrade — and only to a model already present.

## Testing

Verified end-to-end on an M4 Max (production server on :7823 untouched, test server on :7824):
- **Dynamic**: selector logged `preferred fits budget=14.0 GB` → loaded OptiQ; `/classify_sessions` (real session → KAN-141, coding, mlx_direct) and `/summarise` (clean FSM summary, no CoT leak) round-tripped; `/info` + `/v1/models` reported the selected model.
- **Pin**: `MLX_MODEL_ID=Qwen3.5-4B` bypassed selection; `/info` reflected the pin.
- **Cache-gated degradation** (forced headroom): 5 GB → Qwen3.5-4B (cached); 4 GB → falls back to OptiQ (only budget-fitting catalog model was uncached) — no download; thermal-throttle cap honored.

`MLX_MODEL_ID` env still pins a specific model for eval reproducibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)