### PR TITLE
fix(npm): meridian setup parity — credential prompts + no CLI shadow

### DIFF
--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -109,8 +109,21 @@ ok "config at ${ENV_FILE} (dashboard port ${UI_PORT})"
 # ── 3. Binary + CLI symlinks ─────────────────────────────────────────────────
 mkdir -p "${HOME}/.local/bin"
 ln -sfn "${APP_ROOT}/bin/meridian"        "${HOME}/.local/bin/meridian-daemon"
-ln -sfn "${APP_ROOT}/scripts/meridian-cli.sh" "${HOME}/.local/bin/meridian"
-ok "meridian-daemon + meridian → ~/.local/bin"
+# Do NOT shadow the npm launcher with a second `meridian` on PATH. When installed
+# via npm, /usr/local/bin/meridian (the launcher) owns `setup`/`update` and
+# delegates start/stop/doctor to this bundle's CLI by its real path. ~/.local/bin
+# usually precedes /usr/local/bin on PATH, so a ~/.local/bin/meridian symlink
+# would hide `meridian setup` / `meridian update` (it can't reach the launcher).
+# Only create the CLI symlink as a fallback when no launcher is present (e.g. a
+# standalone bundle install); when the launcher exists, remove any stale shadow
+# so `meridian update` self-heals an install made by an older bundle.
+if [[ -e /usr/local/bin/meridian ]]; then
+    rm -f "${HOME}/.local/bin/meridian"
+    ok "meridian-daemon → ~/.local/bin  (meridian CLI = npm launcher at /usr/local/bin/meridian)"
+else
+    ln -sfn "${APP_ROOT}/scripts/meridian-cli.sh" "${HOME}/.local/bin/meridian"
+    ok "meridian-daemon + meridian → ~/.local/bin"
+fi
 
 # ── 4. Python venv + MLX deps (the one install-time download) ────────────────
 info "Setting up Python venv + MLX inference deps (downloads ~ a few hundred MB)…"


### PR DESCRIPTION
Two fixes to the npm `meridian setup` flow, both in `scripts/install-from-bundle.sh`, found during a real npm install test. Theme: make npm `setup` a proper first-run, equivalent to the dev `install.sh`.

## 1. Stop the bundle CLI shadowing the npm launcher
After `meridian setup`, running `meridian setup`/`meridian update` again failed with **`✗ unknown command: setup`**.

- `/usr/local/bin/meridian` = npm **launcher** (owns `setup`/`update`, delegates the rest)
- `~/.local/bin/meridian` = bundle CLI (start/stop/doctor, **no** `setup`), created by the installer
- `~/.local/bin` precedes `/usr/local/bin` on PATH → the bundle CLI **shadowed** the launcher.

**Fix:** only create `~/.local/bin/meridian` as a fallback when no launcher exists; when `/usr/local/bin/meridian` is present, skip it and remove any stale shadow (so `meridian update` self-heals older installs). `meridian-daemon` (no name collision) unchanged.

## 2. Collect Jira/GitHub/Linear credentials in `meridian setup`
The npm path only copied `.env.example` and said *"add your Jira creds later"* — so users finished setup with **no tracker configured** and an empty dashboard, unlike `install.sh` which prompts interactively.

**Fix:** port the credential walkthrough into the bundle installer. Prompts for **Jira / GitHub / Linear** right after `.env` is created.
- Each prompt **self-skips when already set** (idempotent).
- Gated on `SKIP_PERMISSIONS=0` + a **TTY**, so a fresh `meridian setup` collects creds while `meridian update` (passes `--skip-permissions`, preserves `.env`) and non-interactive/CI runs never prompt.
- `JIRA_URL` (Python) kept in sync with `JIRA_BASE_URL` (Rust). OpenObserve omitted (bundle runs no OO server).

## Safety / scope
- **Dev path unaffected:** `install.sh` has its own credential walkthrough + its own `~/.local/bin/meridian`, and never calls `install-from-bundle.sh`.
- **Single source of truth:** `npm/meridian-darwin-arm64/scripts/` is gitignored and regenerated from `scripts/` by `package-release.sh`.
- `bash -n` clean; pre-commit (fmt + clippy) green.

🤖 Generated with Claude Code