### PR TITLE
fix(llm-selector): correct Apple FoundationModels SDK API usage

### DIFF
--- a/services/agents/llm_selector.py
+++ b/services/agents/llm_selector.py
@@ -203,16 +203,23 @@ def discover_running_servers() -> list[RunningServer]:
             else:
                 log.debug("llm_selector: no server on port 8080")
 
-            # 4. Apple FoundationModels — in-process, no port, macOS 26+
+            # 4. Apple FoundationModels — in-process, no port, macOS 26+.
+            #    is_available() is an INSTANCE method returning (bool, reason).
+            #    Catch broadly (not just ImportError): an absent OR API-skewed
+            #    apple_fm_sdk must degrade to "not found", never crash the whole
+            #    discovery sweep (which would push every caller to cloud).
             try:
                 from apple_fm_sdk import SystemLanguageModel  # type: ignore[import]
-                if SystemLanguageModel.default.is_available()[0]:
+                available, reason = SystemLanguageModel().is_available()
+                if available:
                     found.append(RunningServer(
                         "apple_fm", "", ["apple-intelligence"], "apple-intelligence"))
                     log.info("llm_selector: Apple Intelligence available")
                     span.add_event("apple_fm_found")
-            except ImportError:
-                pass
+                else:
+                    log.debug("llm_selector: Apple Intelligence unavailable: %s", reason)
+            except Exception as exc:  # noqa: BLE001 — SDK absent or version-skewed
+                log.debug("llm_selector: Apple FM probe skipped: %s", exc)
 
             span.set_attribute("servers.found", len(found))
             span.set_attribute("servers.names", str([s.runtime for s in found]))
@@ -457,9 +464,13 @@ def _infer_apple_intelligence(system: str, user: str, max_tokens: int) -> Option
         import asyncio
         from apple_fm_sdk import LanguageModelSession  # type: ignore[import]
         async def _run() -> str:
-            session = LanguageModelSession(system_prompt=system)
-            r = await session.respond(prompt=user)
-            return r.content
+            # Constructor kwarg is `instructions` (the system prompt). respond()
+            # is a coroutine; in free-form mode it resolves to a plain str, while
+            # guided modes return a GeneratedContent with a .content attr — handle
+            # both. (max_tokens is governed by the SDK's own GenerationOptions.)
+            session = LanguageModelSession(instructions=system)
+            r = await session.respond(user)
+            return getattr(r, "content", r)
         return asyncio.run(_run())
     except Exception as exc:
         log.warning("llm_selector: apple_fm failed: %s", exc)


### PR DESCRIPTION
## What

The `apple_fm_sdk` integration in `llm_selector.py` was written against an API the real PyPI package (`apple_fm_sdk` 0.1.x) doesn't expose. The Apple Intelligence path **could never have worked** — and once the SDK is installed it actively breaks discovery. Found while testing the foundation-model path on macOS 26.5 (Apple Intelligence *is* available on the machine; the hardware works — only the code was wrong).

## Three bugs fixed

| Location | Was | Real SDK 0.1.x |
|---|---|---|
| `discover_running_servers` | `SystemLanguageModel.default.is_available()[0]` | no `.default`; `is_available()` is an **instance** method returning `(bool, reason)` |
| `discover_running_servers` | `except ImportError:` only | the above raised `AttributeError`, which escaped the handler and **crashed the whole discovery sweep** — silently forcing every caller (Hermes, `local_infer`) to cloud fallback. Now catches broadly so an absent/skewed SDK degrades to "not found" |
| `_infer_apple_intelligence` | `LanguageModelSession(system_prompt=…)` then `r.content` | constructor kwarg is `instructions=`; free-form `respond()` resolves to a plain `str`, so `r.content` would `AttributeError`. Now `instructions=` + `getattr(r, "content", r)` |

## Validation

Against `apple_fm_sdk` 0.1.x on macOS 26.5 (SDK temp-installed for the test, then removed — it is not a declared dependency):
- `discover_running_servers()` lists `apple_fm` **without crashing**.
- `_infer_apple_intelligence(...)` returns the model's text (`'M1, M1 Pro, M1 Max.'`).

## Scope / non-goals

This is a **correctness fix only**. Apple FM remains **excluded from the FSM-constrained classifier/summariser path** by design (it needs `outlines` structured decoding; the selector passes `apple_intelligence=False` and the Hermes path skips `apple_fm`). After this fix, Apple FM is correctly *detectable* and usable for **free-form** inference via `local_infer()` — it is not wired into classification. Actually routing the classifier through Apple FM's native `json_schema`/`Generable` structured output is a separate feature (feasibility gated on its ~4k context window + guardrails; quality gated on the eval goldens) — likely a KAN-97 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)