### PR TITLE
fix(ui): don't load OpenTelemetry at boot — fixes dashboard 500 in standalone install

### DIFF
--- a/ui/instrumentation.ts
+++ b/ui/instrumentation.ts
@@ -1,8 +1,28 @@
 // meridian — normalises screenpipe activity into structured app sessions
 
 export async function register(): Promise<void> {
-  if (process.env.NEXT_RUNTIME === "nodejs" && process.env.NODE_ENV === "production") {
+  // Only the Node.js server runtime in production can host the OTel SDK.
+  if (process.env.NEXT_RUNTIME !== "nodejs" || process.env.NODE_ENV !== "production") {
+    return;
+  }
+  // Telemetry is OFF by default. Gate the *import* — not just initOtel() — on the
+  // opt-in flag: ./lib/observability statically imports @opentelemetry/sdk-node,
+  // which is a serverExternalPackage that may be absent from the standalone
+  // bundle. Importing it unconditionally throws "Cannot find module
+  // @opentelemetry/sdk-node", crashing the instrumentation hook and 500-ing every
+  // route — even when tracing is disabled. So when it's off we never load OTel at
+  // all; when it's on we fail soft so the dashboard still serves if OTel is broken.
+  const enabled = process.env.MERIDIAN_OTEL_ENABLED;
+  if (enabled !== "1" && enabled !== "true") {
+    return;
+  }
+  try {
     const mod = await import("./lib/observability");
     mod.initOtel();
+  } catch (err) {
+    console.error(
+      "meridian-ui: OpenTelemetry instrumentation unavailable — serving without tracing:",
+      err,
+    );
   }
 }


### PR DESCRIPTION
## Bug (P0 — found during the npm install test)

A fresh `npm install -g @meridiona/meridian && meridian setup` brought up screenpipe, MLX, the daemon, classification — everything — **except the dashboard returned HTTP 500 on every route**.

### Root cause
`ui/instrumentation.ts` imported `./lib/observability` in production **unconditionally**, and that module has **top-level static imports** of `@opentelemetry/sdk-node` (a `serverExternalPackage`). Those OTel packages aren't present in the Next.js **standalone** bundle, so the import threw:

```
Error: loading instrumentation hook: Failed to load external module
@opentelemetry/sdk-node-…: Cannot find module '@opentelemetry/sdk-node-…'
```

That crashed the instrumentation hook → **every request 500'd**, even though UI tracing is **off by default**. The `MERIDIAN_OTEL_ENABLED` guard inside `initOtel()` ran too late — the static imports had already failed at module load.

## Fix
Gate the **dynamic import itself** on `MERIDIAN_OTEL_ENABLED` (not just `initOtel()`):
- Tracing **off** (default) → `./lib/observability` is never imported → OTel can't crash the dashboard.
- Tracing **on** → wrapped in try/catch, so a missing/broken OTel bundle disables tracing but still serves the dashboard.

## Verification
Built the standalone bundle and booted `node server.js` (`NODE_ENV=production`, telemetry off, like a fresh install):
- before: `/` → **500**, boot log shows the `@opentelemetry/sdk-node` crash
- after: `/` → **HTTP 200**, no instrumentation/opentelemetry error in the boot log

## Follow-up (separate, lower priority)
When a user *opts into* tracing (`MERIDIAN_OTEL_ENABLED=1`), the OTel packages still need to be present in the standalone bundle (`outputFileTracingIncludes` or have `package-release.sh` copy `node_modules/@opentelemetry`). This PR makes the dashboard robust regardless; that follow-up makes opt-in tracing actually functional.

🤖 Generated with Claude Code