### PR TITLE
feat(classifier): whole-prompt token budget fit to the selected model

### DIFF
--- a/services/agents/_prompts.py
+++ b/services/agents/_prompts.py
@@ -23,6 +23,18 @@ _VSCODE_BANNER_RE = re.compile(
 # then responsible for not blowing the model's context window).
 SESSION_TEXT_CAP = int(os.environ.get("SESSION_TEXT_CAP", "10000"))
 
+# Floors for the whole-prompt token budget (see build_user_message). When the
+# selected model's context window is tight enough to force truncation, neither
+# the session evidence nor the candidate-ticket list is starved below these
+# char floors — the candidate list is what the model matches task_key against,
+# the session text is the evidence it matches on, so both must survive.
+_SESSION_TEXT_FLOOR = 500
+_CANDIDATES_FLOOR = 800
+# The "screen content [src]:" header + truncation tail that _format_session adds
+# around session_text but that the empty-text skeleton measurement omits. Held
+# as a small fixed reserve so the budget over-counts overhead rather than under.
+_SCREEN_BLOCK_OVERHEAD = 64
+
 
 def _fmt_dur(duration_s: int | float) -> str:
     secs = int(duration_s or 0)
@@ -39,7 +51,8 @@ def _fmt_time(ts: str) -> str:
         return ts[:5] if len(ts) >= 5 else ts
 
 
-def _format_session(session: dict) -> str:
+def _format_session(session: dict, session_text_cap: int | None = None) -> str:
+    cap = SESSION_TEXT_CAP if session_text_cap is None else session_text_cap
     parts: list[str] = []
     parts.append(f"app: {session.get('app_name') or '?'}")
     started = (session.get("started_at") or "").strip()
@@ -79,9 +92,9 @@ def _format_session(session: dict) -> str:
     if session_text_val:
         source = (session.get("session_text_source") or "unknown").strip().lower()
         total = len(session_text_val)
-        if SESSION_TEXT_CAP > 0 and total > SESSION_TEXT_CAP:
-            excerpt = session_text_val[:SESSION_TEXT_CAP]
-            tail = f"\n  … ({total - SESSION_TEXT_CAP} more chars)"
+        if cap > 0 and total > cap:
+            excerpt = session_text_val[:cap]
+            tail = f"\n  … ({total - cap} more chars)"
         else:
             excerpt = session_text_val
             tail = ""
@@ -93,24 +106,54 @@ def _format_session(session: dict) -> str:
     return "\n".join(parts)
 
 
+def _format_one_candidate(i: int, task: dict) -> str:
+    title       = (task.get("title") or "").strip()
+    desc        = (task.get("description_text") or "").strip()
+    issue_type  = (task.get("issue_type") or "").strip()
+    epic_title  = (task.get("epic_title") or "").strip()
+    sprint_name = (task.get("sprint_name") or "").strip()
+    if len(desc) > 240:
+        desc = desc[:240] + "…"
+    meta_parts = [p for p in [issue_type, f"Epic: {epic_title}" if epic_title else "", sprint_name] if p]
+    meta = "  [" + " · ".join(meta_parts) + "]" if meta_parts else ""
+    return (
+        f"{i}. {task['task_key']}{meta}\n"
+        f"   title: {title}\n"
+        f"   description: {desc or '(empty)'}"
+    )
+
+
 def _format_candidates(tasks: list[dict]) -> str:
-    rows: list[str] = []
-    for i, task in enumerate(tasks, start=1):
-        title       = (task.get("title") or "").strip()
-        desc        = (task.get("description_text") or "").strip()
-        issue_type  = (task.get("issue_type") or "").strip()
-        epic_title  = (task.get("epic_title") or "").strip()
-        sprint_name = (task.get("sprint_name") or "").strip()
-        if len(desc) > 240:
-            desc = desc[:240] + "…"
-        meta_parts = [p for p in [issue_type, f"Epic: {epic_title}" if epic_title else "", sprint_name] if p]
-        meta = "  [" + " · ".join(meta_parts) + "]" if meta_parts else ""
-        rows.append(
-            f"{i}. {task['task_key']}{meta}\n"
-            f"   title: {title}\n"
-            f"   description: {desc or '(empty)'}"
-        )
+    rows = [_format_one_candidate(i, t) for i, t in enumerate(tasks, start=1)]
     return "\n\n".join(rows) if rows else "(no candidates)"
+
+
+def _fit_candidates(tasks: list[dict], char_budget: int) -> str:
+    """Format candidate tickets, dropping whole tickets from the end to fit.
+
+    Always keeps at least the first ticket (the model needs a non-empty answer
+    space), and appends an explicit note when any are omitted so a partial list
+    is visible to the model rather than silently truncated.
+    """
+    if not tasks:
+        return "(no candidates)"
+    rows: list[str] = []
+    used = 0
+    for i, task in enumerate(tasks, start=1):
+        row = _format_one_candidate(i, task)
+        add = len(row) + (2 if rows else 0)  # "\n\n" separator between rows
+        if rows and used + add > char_budget:
+            break
+        rows.append(row)
+        used += add
+    omitted = len(tasks) - len(rows)
+    block = "\n\n".join(rows)
+    if omitted > 0:
+        block += (
+            f"\n\n… ({omitted} more candidate ticket(s) omitted to fit the "
+            "model's context window)"
+        )
+    return block
 
 
 def _format_recent_sessions(sessions: list[dict]) -> str:
@@ -143,7 +186,21 @@ def build_user_message(
     session: dict,
     candidates: list[dict],
     recent_sessions: list[dict] | None = None,
+    *,
+    char_budget: int | None = None,
 ) -> str:
+    """Assemble the classifier user message.
+
+    char_budget (chars) caps the WHOLE user message so system + this message +
+    output reserve fit the selected model's context window. When None (eval with
+    an explicit SESSION_TEXT_CAP, non-MLX callers), the legacy static path runs:
+    session_text capped by SESSION_TEXT_CAP, candidate list uncapped.
+
+    With a budget, session_text keeps its normal cap and the (otherwise uncapped)
+    candidate list absorbs overflow first — only when the candidate floor still
+    won't fit does session_text shrink toward its floor. In the common case of a
+    roomy window the output is byte-identical to the static path.
+    """
     sessions = recent_sessions or []
     has_any_task_key = any(s.get("task_key") for s in sessions)
     recent_block = (
@@ -151,13 +208,45 @@ def build_user_message(
         f"{_format_recent_sessions(sessions)}\n"
         "\n"
     ) if has_any_task_key else ""
+
+    if char_budget is None:
+        return (
+            f"{recent_block}"
+            "SESSION:\n"
+            f"{_format_session(session)}\n"
+            "\n"
+            "CANDIDATE TICKETS:\n"
+            f"{_format_candidates(candidates)}"
+        )
+
+    # Fixed overhead = everything except the two truncatable inputs (session_text
+    # and the candidate block). Measure it by rendering the session scaffold with
+    # the text removed, plus a small reserve for the screen-content header/tail.
+    scaffold = _format_session({**session, "session_text": ""})
+    overhead = (
+        len(recent_block)
+        + len("SESSION:\n") + len(scaffold) + len("\n\nCANDIDATE TICKETS:\n")
+        + _SCREEN_BLOCK_OVERHEAD
+    )
+    avail = max(0, char_budget - overhead)
+
+    session_text = (session.get("session_text") or "").strip()
+    default_cap = SESSION_TEXT_CAP if SESSION_TEXT_CAP > 0 else len(session_text)
+    session_text_used = min(default_cap, len(session_text))
+
+    cand_budget = avail - session_text_used
+    if cand_budget < _CANDIDATES_FLOOR:
+        # Candidates would be starved — claw session_text back toward its floor.
+        session_text_used = max(_SESSION_TEXT_FLOOR, avail - _CANDIDATES_FLOOR)
+        cand_budget = max(_CANDIDATES_FLOOR, avail - session_text_used)
+
     return (
         f"{recent_block}"
         "SESSION:\n"
-        f"{_format_session(session)}\n"
+        f"{_format_session(session, session_text_cap=session_text_used)}\n"
         "\n"
         "CANDIDATE TICKETS:\n"
-        f"{_format_candidates(candidates)}"
+        f"{_fit_candidates(candidates, cand_budget)}"
     )
 
 

--- a/services/agents/run_task_linker_mlx.py
+++ b/services/agents/run_task_linker_mlx.py
@@ -50,6 +50,21 @@ _CONTEXT_WINDOW = 5
 _MAX_TOKENS = 1024
 _TEMPERATURE = 0.0  # greedy decoding — deterministic classification
 
+# ── Whole-prompt context budget ────────────────────────────────────────────
+# The full prompt (system + session evidence + candidate tickets + recent
+# context) must fit the SELECTED model's context window minus the output
+# reserve. _user_message_char_budget() derives a char budget for the user
+# message from the loaded model's context length; build_user_message() then
+# truncates session_text and the candidate list to fit. Conservative by design:
+# a low chars-per-token estimate truncates slightly early rather than risking
+# the hard ExceededContextWindow error (asymmetric failure — overflow is fatal,
+# under-fill is a mild quality cost).
+_CTX_WINDOW_FLOOR = 4096
+_CTX_WINDOW_CEILING = 131072
+_CTX_WINDOW_FALLBACK = 8192          # used only when config.json can't be read
+_PROMPT_SAFETY_MARGIN_TOKENS = 512   # chat-template markers, role tokens, fudge
+_CHARS_PER_TOKEN = 3.5               # dense code/OCR/JSON skews low — bias safe
+
 # The eval-tuned default classifier model. It lives in the llm_selector catalog
 # (_MODELS) as "qwen3.5-9b-optiq"; llm_selector keeps it on machines where it
 # fits and degrades only when Metal headroom can't accommodate it. The catalog
@@ -235,6 +250,10 @@ _SYSTEM_PROMPT = (
 # ---------------------------------------------------------------------------
 
 _model_cache: dict[str, Any] = {}
+# Raw mlx_lm tokenizer per model — kept so _count_tokens() can measure the
+# system prompt against the real vocabulary (the dominant, constant term in the
+# context budget) instead of a char estimate.
+_tokenizer_cache: dict[str, Any] = {}
 
 
 def _get_model() -> Any:
@@ -264,7 +283,124 @@ def _get_model() -> Any:
     log.info("run_task_linker_mlx: model loaded in %.1fs", time.time() - t0)
 
     _model_cache[model_id] = outlines_model
+    _tokenizer_cache[model_id] = tokenizer
     return outlines_model
+
+
+# ---------------------------------------------------------------------------
+# Context budget — derive a per-model char budget for the user message so the
+# whole prompt fits the selected model's context window (see build_user_message
+# in _prompts.py). Resolved lazily and cached for the process lifetime.
+# ---------------------------------------------------------------------------
+
+_ctx_window_tokens: int | None = None
+_user_msg_char_budget: int | None = None
+_user_msg_budget_resolved = False
+
+
+def _hf_snapshot_dir(hf_id: str) -> "Path | None":
+    """Locate the on-disk HF snapshot dir holding a model's config.json."""
+    hf_home = os.environ.get("HF_HOME")
+    cache = (
+        os.environ.get("HF_HUB_CACHE")
+        or (os.path.join(hf_home, "hub") if hf_home else None)
+        or str(Path.home() / ".cache" / "huggingface" / "hub")
+    )
+    snaps = Path(cache) / ("models--" + hf_id.replace("/", "--")) / "snapshots"
+    if not snaps.is_dir():
+        return None
+    for rev in sorted(snaps.iterdir()):
+        if rev.is_dir() and (rev / "config.json").exists():
+            return rev
+    return None
+
+
+def _context_window_tokens() -> int:
+    """Read the selected model's context length from its config.json.
+
+    Reads max_position_embeddings (the authoritative context length) from the
+    model's config; falls back to a conservative default and clamps to sane
+    bounds. Read from disk rather than a hand-maintained map so it can't drift.
+    """
+    global _ctx_window_tokens
+    if _ctx_window_tokens is not None:
+        return _ctx_window_tokens
+    ctx: Any = None
+    try:
+        model_id = _resolve_model_id()
+        snap = _hf_snapshot_dir(model_id) if "/" in model_id else None
+        cfg_path = (snap / "config.json") if snap else (Path(model_id) / "config.json")
+        if cfg_path.exists():
+            cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+            ctx = cfg.get("max_position_embeddings")
+            if ctx is None and isinstance(cfg.get("text_config"), dict):
+                ctx = cfg["text_config"].get("max_position_embeddings")
+    except Exception as exc:  # noqa: BLE001
+        log.debug("run_task_linker_mlx: context-window probe failed: %s", exc)
+    if not isinstance(ctx, int) or ctx <= 0:
+        log.info(
+            "run_task_linker_mlx: context window unknown — using fallback %d",
+            _CTX_WINDOW_FALLBACK,
+        )
+        ctx = _CTX_WINDOW_FALLBACK
+    ctx = max(_CTX_WINDOW_FLOOR, min(_CTX_WINDOW_CEILING, ctx))
+    _ctx_window_tokens = ctx
+    log.info("run_task_linker_mlx: model context window = %d tokens", ctx)
+    return ctx
+
+
+def _count_tokens(text: str) -> int:
+    """Token count via the loaded tokenizer; conservative char estimate if absent.
+
+    The tokenizer is only cached after _get_model() runs. On the server it is
+    preloaded at startup, so the system-prompt measurement is exact; on the CLI
+    first call it falls back to chars/_CHARS_PER_TOKEN (an over-estimate, which
+    is the safe direction for a budget).
+    """
+    tok = _tokenizer_cache.get(_resolve_model_id())
+    if tok is not None:
+        try:
+            return len(tok.encode(text))
+        except Exception:  # noqa: BLE001
+            pass
+    return int(len(text) / _CHARS_PER_TOKEN) + 1
+
+
+def _user_message_char_budget() -> "int | None":
+    """Char budget for the classifier user message, or None to use the static cap.
+
+    Precedence (mirrors _resolve_model_id): an explicit SESSION_TEXT_CAP env
+    (including 0) pins the legacy static behaviour and disables this dynamic
+    budget — eval reproducibility and caller-owns-fit. Otherwise derive it from
+    the model's context window minus the system prompt and output reserve.
+    """
+    global _user_msg_char_budget, _user_msg_budget_resolved
+    if _user_msg_budget_resolved:
+        return _user_msg_char_budget
+    _user_msg_budget_resolved = True
+
+    if os.environ.get("SESSION_TEXT_CAP") is not None:
+        log.info("run_task_linker_mlx: SESSION_TEXT_CAP pinned — dynamic prompt budget off")
+        _user_msg_char_budget = None
+        return None
+
+    try:
+        ctx = _context_window_tokens()
+        system_tokens = _count_tokens(_SYSTEM_PROMPT)
+        user_tokens = ctx - _MAX_TOKENS - system_tokens - _PROMPT_SAFETY_MARGIN_TOKENS
+        _user_msg_char_budget = max(0, int(user_tokens * _CHARS_PER_TOKEN))
+        log.info(
+            "run_task_linker_mlx: user-message char budget=%d "
+            "(ctx=%d system_tok=%d output=%d margin=%d)",
+            _user_msg_char_budget, ctx, system_tokens, _MAX_TOKENS,
+            _PROMPT_SAFETY_MARGIN_TOKENS,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.warning(
+            "run_task_linker_mlx: char-budget calc failed (%s) — static cap", exc
+        )
+        _user_msg_char_budget = None
+    return _user_msg_char_budget
 
 
 # ---------------------------------------------------------------------------
@@ -404,7 +540,11 @@ def _classify_one(
     with tracer.start_as_current_span("build_prompt") as bp_span:
         bp_span.set_attribute("pm_tasks_count", len(pm_tasks))
         bp_span.set_attribute("recent_sessions_count", len(recent))
-        user_message = build_user_message(session, pm_tasks, recent_sessions=recent)
+        char_budget = _user_message_char_budget()
+        bp_span.set_attribute("char_budget", char_budget if char_budget is not None else -1)
+        user_message = build_user_message(
+            session, pm_tasks, recent_sessions=recent, char_budget=char_budget,
+        )
         bp_span.set_attribute("prompt_chars", len(user_message))
         recent_with_task = sum(1 for r in recent if r.get("task_key"))
         bp_span.add_event("prompt_assembled", {
@@ -591,6 +731,7 @@ def _classify_one_logged(
             },
             pm_tasks,
             recent_sessions=recent,
+            char_budget=_user_message_char_budget(),
         )
     else:
         user_message = ""


### PR DESCRIPTION
> **Stacked on #112** (`feat/mlx-dynamic-model-selection`). Base is that branch, not `main` — merge after #112. Both edit `run_task_linker_mlx.py`; stacking avoids the conflict.

## TL;DR — read this first

**This is a no-op for every model the classifier can select today.** OptiQ has a 128k window (→ ~436k-char budget) and every selectable MLX model is ≥16k, so nothing truncates and the rendered prompt is **byte-identical to the current static path** (verified). No production inputs change → **no eval cycle required**.

What it delivers is **principled hardening + insurance**, not a behavior change:
- the previously **uncapped candidate-ticket list is now bounded** (with a visible "N omitted" note);
- the prompt is now **model-aware** (fits whatever window the loaded model has, vs a fixed char cap);
- insurance for a future sub-16k catalog model or a pathological huge-ticket deployment.

It does **not** fix Apple FM for the classifier — its system prompt alone (~4.85k tok) overflows a ~4k window regardless of user-message budgeting (deferred KAN-97 work).

## What changed

- **`run_task_linker_mlx`**: read the model's `max_position_embeddings` from its `config.json` (authoritative, can't drift like a hand-kept map; clamped + conservative fallback), measure the fixed system prompt with the **real loaded tokenizer** (dominant constant term), and derive `user_message_char_budget = (ctx − output_reserve − system − margin) × chars_per_token`. Conservative chars/token biases toward truncating slightly early (overflow is fatal; under-fill is a mild quality cost).
- **`_prompts.build_user_message(…, char_budget=…)`**: keep `session_text` at its normal cap; absorb overflow by truncating the **candidate list first**; only shrink `session_text` toward a floor when even the candidate floor won't fit. Both floored.
- **Precedence** mirrors `_resolve_model_id`: an explicit `SESSION_TEXT_CAP` env (incl. `0`) pins the legacy static behaviour and disables the dynamic budget (eval reproducibility). `char_budget=None` preserves exact prior behaviour for non-MLX callers.

## Verification

- OptiQ (128k) budget → rendered prompt **byte-identical** to static; production has 8 `pm_tasks` (~1.3k chars), nowhere near the ~436k budget → no-op deployment-wide.
- Tight budgets (8k/3k/1.5k) → in-bounds prompts with graceful candidate→session truncation.
- Live `/classify_sessions` round-trips; budget log shows the tokenizer-measured system prompt (4790 tok).
- No new unit-test failures (`char_budget=None` default is backward-compatible).

Caveat: "guaranteed fit" holds except in a ~5–5.5k-token window band too small to host the classifier at all — academic; no selectable model lives there.

## Follow-up (not here)

A true small-window path for the classifier (Apple FM etc.) needs a SKILL.md/system-prompt redesign — separate, eval-gated, KAN-97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)