### PR TITLE
fix(setup,doctor): harden a11y-tree capture for VS Code-family editors

### DIFF
--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -65,6 +65,40 @@ PLIST
     launchctl kickstart -k "${GUI_TARGET}/${label}" 2>/dev/null || true
 }
 
+# Enable accessibility mode in VS Code / Cursor / Antigravity so screenpipe
+# captures their a11y tree instead of falling back to OCR. Chromium/Electron
+# editors only expose their AX tree when editor.accessibilitySupport = "on"
+# (the force-renderer-accessibility argv switch is Linux-only on macOS).
+# Idempotent + JSONC-safe (preserves existing keys/comments). Without this, npm
+# users' editors silently OCR-only until they discover the setting by hand.
+configure_editor_accessibility() {
+    local support_root="${HOME}/Library/Application Support"
+    local editors=("Code" "Cursor" "Antigravity IDE")
+    local any=0 ed dir settings
+    for ed in "${editors[@]}"; do
+        dir="${support_root}/${ed}"
+        [[ -d "$dir" ]] || continue           # editor not installed → skip
+        any=1
+        settings="${dir}/User/settings.json"
+        if [[ -f "$settings" ]] && grep -q '"editor.accessibilitySupport"' "$settings"; then
+            ok "${ed}: editor.accessibilitySupport already set — keeping"
+            continue
+        fi
+        mkdir -p "${dir}/User"
+        if [[ ! -s "$settings" ]]; then
+            printf '{\n\t"editor.accessibilitySupport": "on"\n}\n' > "$settings"
+        else
+            cp "$settings" "${settings}.meridian-bak"
+            # Insert the key after the first `{`. VS Code-family parsers are
+            # JSONC-tolerant, so this preserves existing keys/comments/formatting.
+            perl -0777 -i -pe 's/\{/\{\n\t"editor.accessibilitySupport": "on",/ unless $done++' "$settings"
+        fi
+        ok "${ed}: enabled editor.accessibilitySupport = on (restart the editor)"
+    done
+    [[ "$any" -eq 0 ]] && info "No VS Code / Cursor / Antigravity install found — skipping editor a11y setup"
+    return 0
+}
+
 # ── 0. Platform gate ────────────────────────────────────────────────────────
 [[ "$(uname -s)" == "Darwin" ]]  || { err "Meridian requires macOS."; exit 1; }
 [[ "$(uname -m)" == "arm64" ]]   || { err "Meridian requires Apple Silicon (arm64). This bundle is macOS-arm64 only."; exit 1; }
@@ -143,6 +177,10 @@ if [[ "${SKIP_PERMISSIONS}" -eq 0 ]]; then
     open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility" 2>/dev/null || true
     read -r -p "  Press Enter once both are granted… " _ || true
 fi
+
+# Enable a11y mode in installed VS Code-family editors (idempotent). Without
+# this, screenpipe falls back to OCR for those editors instead of their a11y tree.
+configure_editor_accessibility
 
 # ── 6. Daemons (reuse the hardened installers; UI runs the standalone server) ─
 info "Installing screenpipe launchd agent…"

--- a/src/health/capture.rs
+++ b/src/health/capture.rs
@@ -24,6 +24,12 @@ const RECENT_SAMPLE: i64 = 500;
 pub async fn checks(cfg: &Config, pool: Option<&SqlitePool>) -> Vec<Check> {
     // Prerequisites first (can capture run at all?), then runtime health.
     let mut checks = vec![screenpipe_installed(), db_present(cfg)];
+    // Direct Accessibility-grant probe from screenpipe's own log (ground truth,
+    // unlike the DB a11y-yield proxy below). Catches a grant silently dropped by
+    // a reinstall/update before it shows up as OCR-only sessions.
+    if let Some(c) = screenpipe_accessibility_permission(cfg) {
+        checks.push(c);
+    }
     match pool {
         Some(p) => {
             let frames = frames_present(p).await;
@@ -89,6 +95,68 @@ fn permissions_unverified() -> Check {
     .with_remedy(
         "System Settings ▸ Privacy & Security ▸ grant Screen Recording AND Accessibility to screenpipe, then restart it and re-run doctor",
     )
+}
+
+/// Direct Accessibility-permission probe from screenpipe's own log. macOS TCC
+/// state isn't readable from our process, but screenpipe logs
+/// `permission monitor started … accessibility=true|false` on every (re)start,
+/// and that line is ground truth. A reinstall/update can silently drop the grant
+/// (it attaches to a binary path/signature that changes), flipping a11y capture
+/// to OCR-only with no other symptom — this surfaces it loudly. Returns `None`
+/// when the log or the line can't be found (nothing to assert).
+fn screenpipe_accessibility_permission(cfg: &Config) -> Option<Check> {
+    let dir = std::path::Path::new(&cfg.screenpipe_db).parent()?;
+    // Newest screenpipe.<date>.N.log by mtime — that's the live one.
+    let mut newest: Option<(std::time::SystemTime, std::path::PathBuf)> = None;
+    for entry in std::fs::read_dir(dir).ok()?.flatten() {
+        let p = entry.path();
+        let is_sp_log = p
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.starts_with("screenpipe.") && n.ends_with(".log"))
+            .unwrap_or(false);
+        if !is_sp_log {
+            continue;
+        }
+        if let Ok(m) = entry.metadata().and_then(|md| md.modified()) {
+            if newest.as_ref().is_none_or(|(t, _)| m > *t) {
+                newest = Some((m, p));
+            }
+        }
+    }
+    let log_path = newest?.1;
+    let content = std::fs::read_to_string(&log_path).ok()?;
+    accessibility_verdict_from_log(&content)
+}
+
+/// Pure verdict from screenpipe log text: scan for the LAST `permission monitor
+/// started …` line (the current state after the most recent restart) and report
+/// the Accessibility grant. Split out from the file I/O so it is unit-testable.
+fn accessibility_verdict_from_log(content: &str) -> Option<Check> {
+    let last = content
+        .lines()
+        .rfind(|l| l.contains("permission monitor started"))?;
+
+    if last.contains("accessibility=false") {
+        Some(
+            Check::critical(
+                "screenpipe.accessibility_grant",
+                "L1",
+                "screenpipe reports accessibility=false — a11y tree capture is OFF (OCR-only); the grant was likely dropped by a reinstall/update",
+            )
+            .with_remedy(
+                "System Settings ▸ Privacy & Security ▸ Accessibility ▸ enable screenpipe, then restart it (meridian restart)",
+            ),
+        )
+    } else if last.contains("accessibility=true") {
+        Some(Check::ok(
+            "screenpipe.accessibility_grant",
+            "L1",
+            "screenpipe reports accessibility=true (a11y capture enabled)",
+        ))
+    } else {
+        None
+    }
 }
 
 /// The screenpipe DB file exists and is non-empty. File-stat only — no pool.
@@ -612,6 +680,27 @@ mod tests {
         insert(&pool, "Code", None, Some("tree"), "accessibility", 60).await;
         insert(&pool, "Code", None, Some("tree"), "accessibility", 30).await;
         let c = a11y_regression(&pool, 30, 60).await;
+        assert_eq!(c.severity, Severity::Ok);
+    }
+
+    #[test]
+    fn accessibility_log_verdict_latest_line_wins() {
+        // No permission-monitor line at all → nothing to assert.
+        assert!(accessibility_verdict_from_log("nothing relevant here").is_none());
+
+        // accessibility=false → critical, with a remedy.
+        let c = accessibility_verdict_from_log(
+            "startup\npermission monitor started screen=true mic=false accessibility=false keychain=true\n",
+        )
+        .expect("verdict");
+        assert_eq!(c.severity, Severity::Critical);
+        assert!(c.remedy.is_some());
+
+        // A later true overrides an earlier false — the most-recent restart wins.
+        let c = accessibility_verdict_from_log(
+            "permission monitor started accessibility=false\nnoise\npermission monitor started accessibility=true\n",
+        )
+        .expect("verdict");
         assert_eq!(c.severity, Severity::Ok);
     }
 }


### PR DESCRIPTION
Two gaps surfaced during the npm install test — both make screenpipe silently fall back to **OCR** (losing the a11y tree) for editors like **Cursor / Antigravity IDE**.

## 1. Bundle setup never configured editor accessibility
The dev `install.sh` sets `editor.accessibilitySupport: "on"` for Code/Cursor/Antigravity (Chromium editors only expose their AX tree in that mode — the `force-renderer-accessibility` argv switch is Linux-only on macOS), but **`install-from-bundle.sh` (the npm path) didn't**. So every npm user's VS Code forks were OCR-only until they discovered the setting by hand — exactly what happened in testing.

→ Ported the idempotent, JSONC-safe `configure_editor_accessibility` into the bundle installer; runs right after the permissions walkthrough.

## 2. `meridian doctor` couldn't see a dropped Accessibility grant
A reinstall/update can silently flip screenpipe's Accessibility permission **off** (it attaches to a binary path/signature that changes on reinstall) → a11y capture goes OCR-only with no other symptom. Observed live: screenpipe logged `accessibility=false` right after the `meridian update` reinstall.

→ Added a direct probe that reads screenpipe's own `permission monitor started … accessibility=true|false` log line (ground truth, unlike the existing DB a11y-yield proxy) and reports **critical + remedy** when false. Latest line wins (most-recent restart). The verdict parser is split into a pure helper and **unit-tested** (false→critical, none→skip, later-true-overrides-earlier-false).

## Testing
- `cargo clippy -- -D warnings`: clean
- **176 tests pass** (added `accessibility_log_verdict_latest_line_wins`)
- `bash -n scripts/install-from-bundle.sh`: clean

## Context
Found alongside the already-merged CLI-shadow (#113) and UI-500 (#115) fixes during a full `npm install → meridian setup` dry run. Remaining open finding from that run: the `sudo meridian update` footgun (npm prefix needs root, launchd needs the user) — tracked separately.

🤖 Generated with Claude Code