### PR TITLE
fix(ui): build standalone with webpack (Turbopack ships unresolvable better-sqlite3 external)

### DIFF
--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -13,6 +13,12 @@ const nextConfig: NextConfig = {
   // ships prebuilt in the release tarball and runs with `node server.js` — no
   // `npm ci` / native rebuild of better-sqlite3 on the user's machine.
   output: 'standalone',
+  // Pin the standalone file-tracing root to this `ui/` dir. The repo root also
+  // has a package-lock.json, so Next otherwise infers the monorepo root and
+  // nests the output as `.next/standalone/ui/server.js` — which breaks the
+  // launchd plist + package-release.sh (both expect `ui/server.js` at the top).
+  // Mirrors the `turbopack.root` pin above for the webpack production build.
+  outputFileTracingRoot: path.join(__dirname),
   serverExternalPackages: [
     'better-sqlite3',
     '@opentelemetry/sdk-node',

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 3939",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start -p 3939",
     "lint": "next lint",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
## Bug (GA blocker — found during npm install test)

The npm-shipped dashboard **crash-loops on startup** and the UI sits on **"Loading…"** forever:
```
⨯ Failed to load external module better-sqlite3-90e2652d1716b047: Cannot find module 'better-sqlite3-90e2652d1716b047'
```

### Root cause
Next 16 defaults `next build` to **Turbopack**. Turbopack's `output: 'standalone'` emits `serverExternalPackages` under a **content-hashed alias** (`better-sqlite3-<hash>`) that the standalone runtime can't `require` — even though `better-sqlite3` is correctly present in `ui/node_modules` and listed in `serverExternalPackages` (vercel/next.js [#88844](https://github.com/vercel/next.js/issues/88844), [#87737](https://github.com/vercel/next.js/issues/87737)). Every DB-backed API route (`/api/today`, `/api/week`, …) throws → blank dashboard.

## Fix
- `ui/package.json`: `build` → **`next build --webpack`**. Webpack's externals handling is mature: it emits a plain `require("better-sqlite3")` and copies the native module into `.next/standalone/node_modules`. `dev` keeps `--turbopack` for speed.
- `ui/next.config.ts`: pin **`outputFileTracingRoot`** to `ui/` so webpack roots the standalone at `ui/` (`server.js` at the top, not nested under `ui/ui/`) — matching the launchd plist + `package-release.sh`. Mirrors the existing `turbopack.root` pin.

## Validated locally (the only way to be sure the standalone serves)
- webpack standalone build → `node .next/standalone/server.js` → `GET /api/today` → **HTTP 200 with real session data** (0.6s)
- compiled output contains plain `require("better-sqlite3")`, **no** hashed alias
- native module present at `.next/standalone/node_modules/better-sqlite3/build/Release/better_sqlite3.node`
- `server.js` at standalone top level (not nested)

🤖 Generated with Claude Code