### PR TITLE
fix(npm): stop `sudo meridian update` breaking launchd; elevate only the npm step

### DIFF
--- a/npm/meridian/bin/meridian.js
+++ b/npm/meridian/bin/meridian.js
@@ -35,14 +35,56 @@ function run(file, args) {
   process.exit(r.status == null ? 1 : r.status);
 }
 
+// Is the global npm prefix writable without root? `npm i -g` installs into
+// <prefix>/lib/node_modules; on a /usr/local prefix that needs sudo, on a
+// Homebrew/user prefix it doesn't.
+function npmGlobalWritable() {
+  const r = spawnSync('npm', ['config', 'get', 'prefix'], { encoding: 'utf8' });
+  const prefix = (r.stdout || '').trim();
+  if (!prefix) return true; // unknown — let npm decide
+  try {
+    fs.accessSync(path.join(prefix, 'lib', 'node_modules'), fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Update the global package, elevating ONLY this step when the prefix needs
+// root. The rest of `update` (setup: per-user launchd agents, venv) must NOT run
+// as root, so we never sudo the whole command — just this one install.
+function npmInstallLatest() {
+  const args = ['install', '-g', '@meridiona/meridian@latest'];
+  if (npmGlobalWritable()) {
+    return spawnSync('npm', args, { stdio: 'inherit' });
+  }
+  console.error('meridian update: the global npm prefix needs root — elevating just the');
+  console.error('  package install (you may be prompted for your password)…');
+  return spawnSync('sudo', ['npm', ...args], { stdio: 'inherit' });
+}
+
 const cmd = process.argv[2];
 const rest = process.argv.slice(3);
+
+// Every Meridian command is per-user: launchd agents live under gui/$UID and
+// state under ~/.meridian. Running as root (e.g. `sudo meridian update`) makes
+// launchd bootstrap fail ("Domain does not support specified action") and leaves
+// root-owned files behind. Refuse up front — the one step that genuinely needs
+// root (`npm install -g` during `update`) is elevated on its own below.
+if (typeof process.getuid === 'function' && process.getuid() === 0) {
+  console.error('meridian: do not run as root / with sudo.');
+  console.error('  Meridian runs per-user (launchd agents under gui/$UID, files in ~/.meridian);');
+  console.error('  as root, launchd fails and ~/.meridian fills with root-owned files.');
+  console.error(`  Run it as your normal user:  meridian ${cmd || '<command>'}`);
+  console.error('  (`meridian update` elevates just the npm install step if your prefix needs root.)');
+  process.exit(1);
+}
 
 if (cmd === 'setup' || cmd === 'install') {
   const bundle = resolveBundle();
   run('bash', [path.join(bundle, 'scripts', 'meridian-npm-setup.sh'), bundle, ...rest]);
 } else if (cmd === 'update') {
-  const up = spawnSync('npm', ['install', '-g', '@meridiona/meridian@latest'], { stdio: 'inherit' });
+  const up = npmInstallLatest();
   if (up.status) process.exit(up.status);
   const bundle = resolveBundle();
   run('bash', [path.join(bundle, 'scripts', 'meridian-npm-setup.sh'), bundle, '--skip-permissions']);

--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -21,6 +21,14 @@ ok()   { echo "  ✓ $*" >&2; }
 warn() { echo "  ⚠ $*" >&2; }
 err()  { echo "✗ $*" >&2; }
 
+# True when `npm i -g` can write the global prefix without root (Homebrew/user
+# prefix). On a root-owned prefix (e.g. /usr/local) the one npm step is elevated
+# on its own, rather than running this whole script as root.
+npm_global_writable() {
+    local prefix; prefix="$(npm config get prefix 2>/dev/null)"
+    [[ -n "$prefix" && -w "${prefix}/lib/node_modules" ]]
+}
+
 GUI_TARGET="gui/$(id -u)"
 LAUNCH_AGENTS="${HOME}/Library/LaunchAgents"
 
@@ -103,6 +111,14 @@ configure_editor_accessibility() {
 [[ "$(uname -s)" == "Darwin" ]]  || { err "Meridian requires macOS."; exit 1; }
 [[ "$(uname -m)" == "arm64" ]]   || { err "Meridian requires Apple Silicon (arm64). This bundle is macOS-arm64 only."; exit 1; }
 
+# Refuse root: this installs per-user launchd agents (gui/$(id -u)) and writes
+# ~/.meridian. As root, launchd bootstrap fails and files end up root-owned. The
+# npm launcher elevates only the steps that need root; the rest stays per-user.
+if [[ "$(id -u)" -eq 0 ]]; then
+    err "Do not run as root / with sudo — run 'meridian setup' as your normal user."
+    exit 1
+fi
+
 echo "→ Installing Meridian $(cat "${APP_ROOT}/VERSION" 2>/dev/null || echo '?') from ${APP_ROOT}"
 
 # ── 1. Prerequisites (no Rust/Node-build toolchain — artifacts are prebuilt) ──
@@ -117,7 +133,12 @@ ok "node + python ($(${PYTHON_BIN} --version 2>&1))"
 
 if ! command -v screenpipe >/dev/null 2>&1; then
     info "Installing screenpipe ${SCREENPIPE_VERSION} via npm…"
-    npm install -g "screenpipe@${SCREENPIPE_VERSION}"
+    if npm_global_writable; then
+        npm install -g "screenpipe@${SCREENPIPE_VERSION}"
+    else
+        warn "global npm prefix needs root — elevating just this install (you may be prompted)…"
+        sudo npm install -g "screenpipe@${SCREENPIPE_VERSION}"
+    fi
 fi
 ok "screenpipe"
 if ! command -v ffmpeg >/dev/null 2>&1; then info "Installing ffmpeg…"; brew install ffmpeg; fi


### PR DESCRIPTION
## Bug (found during the npm install test)

`meridian update` install per-user launchd agents (`gui/$UID`) and write `~/.meridian` — they must run **as the user**. But `update` also runs `npm install -g`, which needs **root** on a `/usr/local` npm prefix. So users reach for `sudo meridian update`, which runs the *whole* thing as root:
- launchd bootstrap fails: `Bootstrap failed: 125: Domain does not support specified action`
- pip can't use the user cache
- `~/.meridian` fills with **root-owned files** → broken, half-installed state (exactly what happened in testing)

## Fix — never run setup/update as root; elevate only the step that needs it
- **`bin/meridian.js` (launcher):** refuse to run as root (any command) with a clear, actionable message — every Meridian command is per-user. In `update`, install the global package via plain `npm` when the prefix is user-writable, else via `sudo npm install -g` for **just that step** (one password prompt), then run setup as the user so launchd succeeds.
- **`install-from-bundle.sh`:** refuse root as a safety net (direct invocation), and elevate the lone `npm install -g screenpipe` step the same way — so a **no-sudo fresh install** still works on a `/usr/local` prefix.

## Verification
- `node --check` + `bash -n`: clean
- Simulated `getuid()===0` → launcher prints the refusal and **exits 1** instead of proceeding (no more broken half-install).

## Note
The remaining open finding from the install test is #4 (screenpipe launched via the node-wrapper, so macOS attaches Screen Recording to `node` instead of `screenpipe`). Tracked separately.

🤖 Generated with Claude Code