### PR TITLE
docs(ui): explain why the production build uses webpack (Turbopack standalone externals bug)

### DIFF
--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -1,6 +1,22 @@
 import type { NextConfig } from 'next'
 import path from 'path'
 
+// ─────────────────────────────────────────────────────────────────────────────
+// BUNDLER: dev uses Turbopack (`next dev --turbopack`); the PRODUCTION build uses
+// WEBPACK (`next build --webpack`, see package.json). This is deliberate, not a
+// leftover. Turbopack's `output: 'standalone'` references serverExternalPackages
+// (better-sqlite3, pino, @opentelemetry/*) via hashed symlink aliases under
+// `.next/node_modules` (e.g. `better-sqlite3-<hash> -> ../../node_modules/...`).
+// Those symlinks are stripped by `npm publish` (our prebuilt bundle ships via the
+// @meridiona/meridian-darwin-arm64 npm package), and the hashed alias can fail to
+// resolve at runtime even on Vercel — open upstream bugs:
+//   https://github.com/vercel/next.js/issues/87737
+//   https://github.com/vercel/next.js/issues/93849
+// Result was a crash-loop: "Failed to load external module better-sqlite3-<hash>".
+// Webpack emits a plain `require("better-sqlite3")` with no symlink indirection,
+// which survives npm pack/extract (validated end-to-end). Revert package.json
+// `build` to plain `next build` (Turbopack) once those issues close upstream.
+// ─────────────────────────────────────────────────────────────────────────────
 const nextConfig: NextConfig = {
   // Pin the Turbopack workspace root to this `ui/` directory. The repo root
   // also has a package-lock.json, so Turbopack otherwise infers the monorepo


### PR DESCRIPTION
Follow-up to #118 (which switched the production standalone build to `next build --webpack`). Adds a top-of-file rationale in `ui/next.config.ts` so the bundler split isn't mysterious to future maintainers.

## Why webpack for the production build (not Turbopack)
- `dev` keeps **Turbopack** (`next dev --turbopack`) — fast HMR, unchanged.
- The **production standalone** build uses **webpack** because Turbopack's `output: 'standalone'` references `serverExternalPackages` (better-sqlite3, pino, @opentelemetry/*) via **hashed symlink aliases** under `.next/node_modules`. Those symlinks are **stripped by `npm publish`** (we ship the prebuilt bundle as `@meridiona/meridian-darwin-arm64`), and the hashed alias can fail to resolve at runtime **even on Vercel** — open upstream bugs [#87737](https://github.com/vercel/next.js/issues/87737) and [#93849](https://github.com/vercel/next.js/issues/93849) (the latter is literally our `pino` external).
- Webpack emits a plain `require("better-sqlite3")` with no symlink indirection → survives `npm pack`/extract.

## Evidence (validated end-to-end)
- webpack standalone: **0 symlinks**, plain `require("better-sqlite3")`, no hashed alias
- full `package-release.sh` → `npm pack` → extract → `node server.js` → **`GET /api/today` = HTTP 200** with real data

## Revert condition
Flip `package.json` `build` back to plain `next build` (Turbopack) once #87737 / #93849 close upstream. The comment documents this so it gets revisited.

🤖 Generated with Claude Code