### PR TITLE
feat(ui): ship Turbopack standalone via symlink-preserving tarball (keep Turbopack in prod)

### DIFF
--- a/npm/meridian-darwin-arm64/package.json
+++ b/npm/meridian-darwin-arm64/package.json
@@ -16,7 +16,7 @@
   ],
   "files": [
     "bin/",
-    "ui/",
+    "ui.tar.gz",
     "services/",
     "scripts/",
     ".env.example",

--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -259,6 +259,20 @@ fi
 # this, screenpipe falls back to OCR for those editors instead of their a11y tree.
 configure_editor_accessibility
 
+# ── 5b. Unpack the dashboard (Turbopack standalone, shipped as a tarball) ─────
+# The UI ships as ui.tar.gz rather than an expanded ui/ dir so that Turbopack's
+# relative symlinks under .next/node_modules (serverExternalPackages: better-
+# sqlite3, pino, @opentelemetry/*) survive `npm publish`, which strips symlinks.
+# Extract the exact built tree into place before the UI agent starts.
+if [[ -f "${APP_ROOT}/ui.tar.gz" ]]; then
+    info "Unpacking dashboard…"
+    rm -rf "${APP_ROOT}/ui"
+    mkdir -p "${APP_ROOT}/ui"
+    tar -xzf "${APP_ROOT}/ui.tar.gz" -C "${APP_ROOT}/ui"
+    rm -f "${APP_ROOT}/ui.tar.gz"
+    ok "dashboard unpacked ($(find "${APP_ROOT}/ui/.next/node_modules" -type l 2>/dev/null | wc -l | tr -d ' ') external symlink(s) restored)"
+fi
+
 # ── 6. Daemons (reuse the hardened installers; UI runs the standalone server) ─
 info "Installing screenpipe launchd agent…"
 bash "${APP_ROOT}/scripts/install-screenpipe-daemon.sh" || warn "screenpipe agent install failed"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -33,11 +33,25 @@ echo "→ daemon binary"
 cp "${DAEMON_BIN}" "${DEST}/bin/meridian"
 chmod +x "${DEST}/bin/meridian"
 
-echo "→ UI (Next.js standalone)"
-cp -R "${UI_STANDALONE}/." "${DEST}/ui/"
-mkdir -p "${DEST}/ui/.next"
-cp -R "ui/.next/static" "${DEST}/ui/.next/static"
-[[ -d "ui/public" ]] && cp -R "ui/public" "${DEST}/ui/public"
+echo "→ UI (Next.js standalone, packed as a tarball)"
+# Assemble the runnable standalone tree (server + static + public), then pack it
+# into a single tarball. WHY a tarball and not a plain ui/ dir: the Turbopack
+# production build references serverExternalPackages (better-sqlite3, pino,
+# @opentelemetry/*) via relative SYMLINKS under .next/node_modules. `npm publish`
+# strips symlinks, which crash-loops the standalone server on the user's machine
+# (vercel/next.js#87737, #93849). tar preserves symlinks and npm ships the .tgz
+# as one opaque file, so the exact built tree round-trips intact;
+# install-from-bundle.sh extracts it back into ~/.meridian/app/ui. This is what
+# lets the production build stay on Turbopack despite our npm distribution.
+_ui_stage="${DEST}/ui"
+cp -R "${UI_STANDALONE}/." "${_ui_stage}/"        # cp -R preserves symlinks (BSD/macOS default)
+mkdir -p "${_ui_stage}/.next"
+cp -R "ui/.next/static" "${_ui_stage}/.next/static"
+[[ -d "ui/public" ]] && cp -R "ui/public" "${_ui_stage}/public"
+# Pack (preserving symlinks — no -h) and drop the expanded dir so npm ships only the tarball.
+tar -czf "${DEST}/ui.tar.gz" -C "${_ui_stage}" .
+rm -rf "${_ui_stage}"
+echo "  · ui.tar.gz ($(du -h "${DEST}/ui.tar.gz" | cut -f1), symlinks preserved)"
 
 echo "→ Python services (source — venv is created at install)"
 mkdir -p "${DEST}/services"

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -1,22 +1,6 @@
 import type { NextConfig } from 'next'
 import path from 'path'
 
-// ─────────────────────────────────────────────────────────────────────────────
-// BUNDLER: dev uses Turbopack (`next dev --turbopack`); the PRODUCTION build uses
-// WEBPACK (`next build --webpack`, see package.json). This is deliberate, not a
-// leftover. Turbopack's `output: 'standalone'` references serverExternalPackages
-// (better-sqlite3, pino, @opentelemetry/*) via hashed symlink aliases under
-// `.next/node_modules` (e.g. `better-sqlite3-<hash> -> ../../node_modules/...`).
-// Those symlinks are stripped by `npm publish` (our prebuilt bundle ships via the
-// @meridiona/meridian-darwin-arm64 npm package), and the hashed alias can fail to
-// resolve at runtime even on Vercel — open upstream bugs:
-//   https://github.com/vercel/next.js/issues/87737
-//   https://github.com/vercel/next.js/issues/93849
-// Result was a crash-loop: "Failed to load external module better-sqlite3-<hash>".
-// Webpack emits a plain `require("better-sqlite3")` with no symlink indirection,
-// which survives npm pack/extract (validated end-to-end). Revert package.json
-// `build` to plain `next build` (Turbopack) once those issues close upstream.
-// ─────────────────────────────────────────────────────────────────────────────
 const nextConfig: NextConfig = {
   // Pin the Turbopack workspace root to this `ui/` directory. The repo root
   // also has a package-lock.json, so Turbopack otherwise infers the monorepo

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -10,14 +10,22 @@ const nextConfig: NextConfig = {
     root: path.join(__dirname),
   },
   // Emit a self-contained server bundle (`.next/standalone/`) so the dashboard
-  // ships prebuilt in the release tarball and runs with `node server.js` — no
-  // `npm ci` / native rebuild of better-sqlite3 on the user's machine.
+  // ships prebuilt and runs with `node server.js` — no `npm ci` / native rebuild
+  // of better-sqlite3 on the user's machine.
+  //
+  // NOTE on distribution: the production build uses Turbopack (the Next 16
+  // default). Turbopack references serverExternalPackages (better-sqlite3, pino,
+  // @opentelemetry/*) via relative SYMLINKS under `.next/node_modules`. Those
+  // symlinks are stripped by `npm publish` (vercel/next.js#87737, #93849), which
+  // crash-loops the standalone server. So package-release.sh packs the standalone
+  // into `ui.tar.gz` (tar preserves symlinks; npm ships it as one opaque file) and
+  // install-from-bundle.sh extracts it on the user's machine — keeping Turbopack.
   output: 'standalone',
   // Pin the standalone file-tracing root to this `ui/` dir. The repo root also
   // has a package-lock.json, so Next otherwise infers the monorepo root and
   // nests the output as `.next/standalone/ui/server.js` — which breaks the
   // launchd plist + package-release.sh (both expect `ui/server.js` at the top).
-  // Mirrors the `turbopack.root` pin above for the webpack production build.
+  // Mirrors the `turbopack.root` pin above.
   outputFileTracingRoot: path.join(__dirname),
   serverExternalPackages: [
     'better-sqlite3',

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 3939",
-    "build": "next build --webpack",
+    "build": "next build",
     "start": "next start -p 3939",
     "lint": "next lint",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
## Goal
Keep **Turbopack for the production build** (the Next 16 default) — reverting the webpack opt-out from #118 — while still shipping a working prebuilt dashboard via npm.

## The real constraint
Turbopack production builds are fine; **`npm publish` is what breaks them.** Turbopack references `serverExternalPackages` (better-sqlite3, pino, @opentelemetry/*) via **relative symlinks** under `.next/node_modules`, and `npm publish` **strips symlinks** → the standalone server crash-loops with *"Failed to load external module better-sqlite3-<hash>"* ([#87737](https://github.com/vercel/next.js/issues/87737), [#93849](https://github.com/vercel/next.js/issues/93849)).

## Fix — solve it at the distribution layer, not the bundler
Ship the standalone as an **opaque tarball** so symlinks survive:
- **`package-release.sh`** packs the assembled tree (server + `.next/static` + `public`) into **`ui.tar.gz`** (`tar` preserves symlinks; npm ships one opaque file).
- **`install-from-bundle.sh`** extracts `ui.tar.gz` → `~/.meridian/app/ui` on the user's machine (relative symlinks stay valid).
- arch package `files` ships `ui.tar.gz` instead of an expanded `ui/`.
- `ui/package.json` `build` → `next build` (Turbopack); `next.config.ts` documents the rationale + the open upstream issues.

## Validated end-to-end on macOS arm64 (real publish path)
1. Turbopack `next build` ✓
2. `package-release.sh` → `ui.tar.gz` (13 MB), no expanded `ui/` ✓
3. `npm pack` → tarball contains **`ui.tar.gz` (1), loose `ui/` files (0)** ✓
4. extract published pkg → install-extract `ui.tar.gz` → **7 external symlinks restored**, `server.js` + better-sqlite3 native `.node` present ✓
5. `node server.js` → **`GET /api/today` = HTTP 200 with real session data** (0.29s) ✓

## Notes
- **Supersedes #118's bundler choice** (webpack → back to Turbopack). #121 (webpack rationale doc) becomes moot — closing it.
- Dev was already Turbopack; now prod is too. No `--webpack` anywhere.

🤖 Generated with Claude Code