### PR TITLE
fix(screenpipe): launch the real Mach-O so macOS grants attach to screenpipe, not node

### DIFF
--- a/scripts/install-screenpipe-daemon.sh
+++ b/scripts/install-screenpipe-daemon.sh
@@ -31,11 +31,30 @@ if [[ ! -f "${TEMPLATE}" ]]; then
     exit 1
 fi
 
-# Locate the screenpipe binary.
+# Locate the screenpipe binary. The npm package ships a Node *wrapper* at
+# `command -v screenpipe` (a cli.js shim) that spawns the real arm64 Mach-O. If
+# the launchd agent launches that wrapper, macOS attributes Screen Recording /
+# Accessibility to `node` (the responsible process) — a broad, fragile grant
+# (breaks on node upgrades) that also shows a scary "node wants to record your
+# screen" prompt. Resolve the real Mach-O and launch it directly so the grant
+# attaches to a stable binary named `screenpipe` (and survives reinstalls of the
+# same version, since its path is fixed). Falls back to whatever `command -v`
+# found when screenpipe is a native binary (Homebrew) rather than the npm shim.
 SCREENPIPE_BIN="$(command -v screenpipe)" || true
 if [[ -z "${SCREENPIPE_BIN}" ]]; then
     echo "✗ screenpipe binary not found in PATH — install with: npm install -g screenpipe" >&2
     exit 1
+fi
+_npm_root="$(npm root -g 2>/dev/null || true)"
+if [[ -n "${_npm_root}" && -d "${_npm_root}/screenpipe" ]]; then
+    _real=""
+    while IFS= read -r _cand; do
+        if file "${_cand}" 2>/dev/null | grep -q "Mach-O"; then _real="${_cand}"; break; fi
+    done < <(find "${_npm_root}/screenpipe" -type f -name screenpipe -perm +0111 2>/dev/null)
+    if [[ -n "${_real}" ]]; then
+        SCREENPIPE_BIN="${_real}"
+        echo "→ using the real screenpipe binary (not the node wrapper): ${SCREENPIPE_BIN}"
+    fi
 fi
 
 mkdir -p "${HOME}/.meridian/logs"


### PR DESCRIPTION
## Finding (last one from the npm install test)

When granting macOS permissions during setup, the prompt said **"node wants to record your screen"** instead of screenpipe. Root cause: the npm `screenpipe` package is a **Node wrapper** (`command -v screenpipe` → a `cli.js` shim) that spawns the real arm64 Mach-O. The launchd agent ran the *wrapper*, so macOS attributed Screen Recording / Accessibility to the **responsible process — `node`**.

Why that's bad:
- **Scary UX:** "node wants to record your screen."
- **Too broad:** the grant covers *any* Node program.
- **Fragile:** a Node upgrade changes the binary → the grant silently breaks → a11y/screen capture drops to OCR-only with no error. (This is the same class of silent regression PR #117's doctor check now detects.)

## Fix
In `install-screenpipe-daemon.sh`, resolve the **real Mach-O** behind the wrapper (via `npm root -g` → the screenpipe package's bundled `@screenpipe/cli-darwin-arm64/bin/screenpipe`) and point the plist at it. The grant then attaches to a stable binary named `screenpipe`, and — because its path is fixed — **survives same-version reinstalls**. Falls back to `command -v screenpipe` when it's a native binary (Homebrew) rather than the npm shim.

## Verification (live npm install)
```
wrapper:           /usr/local/bin/screenpipe          (node cli.js shim)
resolved Mach-O:   …/screenpipe/node_modules/@screenpipe/cli-darwin-arm64/bin/screenpipe
file:              Mach-O 64-bit executable arm64
```
`bash -n` clean. The plist's `exec <bin> record --disable-audio` works the same against the real binary (the shim just locates+execs it).

## Note
After this ships, the next setup/reinstall will prompt to grant **screenpipe** (not node) once — the desired end state. PR #117's doctor check surfaces `accessibility=false` until granted.

This closes the last finding from the full `npm install → meridian setup` dry run.

🤖 Generated with Claude Code