### PR TITLE
feat(update): preserve Python venv across meridian update (seconds, not minutes)

### DIFF
--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -257,13 +257,40 @@ else
     ok "meridian-daemon + meridian → ~/.local/bin"
 fi
 
-# ── 4. Python venv + MLX deps (the one install-time download) ────────────────
-info "Setting up Python venv + MLX inference deps (downloads ~ a few hundred MB)…"
+# ── 4. Python venv + MLX deps ────────────────────────────────────────────────
+# meridian-npm-setup.sh preserves an existing venv across updates, so on a normal
+# update the venv is already here. The pip install (mlx-lm/outlines/fastapi) costs
+# minutes, so we skip it when the dependency spec is unchanged: hash the parts of
+# pyproject.toml that define the deps and stamp it in the venv. Re-pip only when a
+# fresh venv was created or the hash differs (a release that bumped Python deps).
 VENV="${APP_ROOT}/services/.venv"
-[[ -d "${VENV}" ]] || "${PYTHON_BIN}" -m venv "${VENV}"
-"${VENV}/bin/pip" install --quiet --upgrade pip
-"${VENV}/bin/pip" install --quiet -e "${APP_ROOT}/services[mlx]"
-ok "Python services ready"
+DEPS_STAMP="${VENV}/.meridian-deps-hash"
+deps_hash() { shasum -a 256 "${APP_ROOT}/services/pyproject.toml" 2>/dev/null | cut -d' ' -f1; }
+want_hash="$(deps_hash)"
+
+fresh_venv=0
+if [[ ! -x "${VENV}/bin/python" ]]; then
+    info "Creating Python venv…"
+    rm -rf "${VENV}"
+    "${PYTHON_BIN}" -m venv "${VENV}"
+    fresh_venv=1
+fi
+
+have_hash=""
+[[ -f "${DEPS_STAMP}" ]] && have_hash="$(cat "${DEPS_STAMP}" 2>/dev/null)"
+
+if [[ "${fresh_venv}" -eq 1 || "${want_hash}" != "${have_hash}" || -z "${want_hash}" ]]; then
+    info "Installing Python + MLX deps (mlx-lm/outlines/fastapi; downloads ~ a few hundred MB on first run)…"
+    "${VENV}/bin/pip" install --quiet --upgrade pip
+    if "${VENV}/bin/pip" install --quiet -e "${APP_ROOT}/services[mlx]"; then
+        [[ -n "${want_hash}" ]] && printf '%s\n' "${want_hash}" > "${DEPS_STAMP}"
+        ok "Python services ready"
+    else
+        warn "pip install failed — leaving venv as-is; re-run 'meridian setup' to retry"
+    fi
+else
+    ok "Python deps unchanged — reusing existing venv (skipped pip install)"
+fi
 
 # ── 5. macOS permissions for screenpipe (manual — can't be automated) ────────
 if [[ "${SKIP_PERMISSIONS}" -eq 0 ]]; then

--- a/scripts/meridian-npm-setup.sh
+++ b/scripts/meridian-npm-setup.sh
@@ -20,13 +20,29 @@ mkdir -p "$(dirname "${APP}")"
 keep=""
 if [[ -f "${APP}/.env" ]]; then keep="$(mktemp)"; cp "${APP}/.env" "${keep}"; fi
 
+# Preserve the Python venv across updates. Rebuilding it (python -m venv + pip
+# install mlx-lm/outlines/…) costs minutes; most releases don't change Python
+# deps, so move it aside and restore it to the SAME absolute path (its baked-in
+# shebangs stay valid). install-from-bundle.sh then only re-pips when the deps
+# hash actually changes. Kept in a sibling dir under ~/.meridian so the move is
+# an instant rename (same filesystem), never a cross-volume copy.
+venv_keep="${HOME}/.meridian/.venv-update-keep"
+rm -rf "${venv_keep}"
+if [[ -d "${APP}/services/.venv" ]]; then mv "${APP}/services/.venv" "${venv_keep}"; fi
+
 rm -rf "${APP}"
 mkdir -p "${APP}"
-# Copy the prebuilt payload (bin/ ui/ services/ scripts/ .env.example VERSION).
+# Copy the prebuilt payload (bin/ ui.tar.gz services/ scripts/ .env.example VERSION).
 cp -R "${BUNDLE}/." "${APP}/"
 # Drop npm-package metadata that isn't part of the app.
 rm -f "${APP}/package.json" "${APP}/README.md" "${APP}/.gitignore" "${APP}/.npmignore"
 
 [[ -n "${keep}" ]] && { cp "${keep}" "${APP}/.env"; rm -f "${keep}"; }
+# Restore the preserved venv (the bundle ships services/ source but no venv).
+if [[ -d "${venv_keep}" ]]; then
+    mkdir -p "${APP}/services"
+    rm -rf "${APP}/services/.venv"
+    mv "${venv_keep}" "${APP}/services/.venv"
+fi
 
 exec bash "${APP}/scripts/install-from-bundle.sh" "$@"


### PR DESCRIPTION
## Problem
`meridian update` is the one-command update path, but it felt heavy: it re-lays the bundle and **rebuilt the Python venv every time** — `python -m venv` + `pip install -e services[mlx]` (mlx-lm/outlines/fastapi, a few hundred MB) — costing minutes even when no Python dependency changed.

## Fix — make a no-Python-change update near-instant
- **`meridian-npm-setup.sh`**: before wiping `~/.meridian/app`, move `services/.venv` aside (instant same-filesystem rename under `~/.meridian`) and restore it to the **same absolute path** afterward, so baked-in shebangs + the editable-install link stay valid.
- **`install-from-bundle.sh`**: stamp a hash of `services/pyproject.toml` inside the venv; only re-pip when a fresh venv was created or the hash differs. Because the install is **editable (`-e`)**, first-party code changes are picked up live from the re-copied source with no re-pip — so skipping is *correct*, not just faster.
- A failed `pip install` leaves the venv intact and warns (re-run `meridian setup`), rather than half-tearing-down a working environment.

## Validated
- venv survives the aside/restore move: `python` runs, editable import works (same abs path)
- warm path, unchanged `pyproject.toml` hash → **pip skipped**
- fresh venv → installs; bumped hash → reinstalls (all three branches verified)

## Result
`meridian update` for a typical release (no Python dep change) drops from **minutes → seconds**. Pairs naturally with future uv/lockfile work (B3).

🤖 Generated with Claude Code