### PR TITLE
feat(ui): in-dashboard update notification + one-click update

### DIFF
--- a/ui/app/api/update/route.ts
+++ b/ui/app/api/update/route.ts
@@ -1,0 +1,58 @@
+// meridian — normalises screenpipe activity into structured app sessions
+
+import { NextResponse } from 'next/server'
+import { spawn } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { logger, withSpan } from '@/lib/observability'
+
+export const dynamic = 'force-dynamic'
+
+// The command a user runs to update. `meridian update` self-elevates only the
+// npm step, preserves creds + venv, and restarts the daemons.
+const UPDATE_CMD = 'meridian update'
+
+/**
+ * Launch `meridian update` in a visible Terminal window. We do NOT run the
+ * update from this server process: the update restarts the daemons (and may
+ * prompt for a password on a root-owned npm prefix), so it must run in an
+ * interactive terminal the user can see — not silently inside the dashboard.
+ *
+ * Mechanism: write a tiny .command script and `open -a Terminal` it. This uses
+ * LaunchServices (no AppleEvents/Automation permission prompt, unlike osascript)
+ * and runs in an interactive login shell so `meridian` is on PATH. The response
+ * also returns the raw command so the UI can show a copyable fallback if the
+ * user's environment blocks launching Terminal.
+ */
+export async function POST(request: Request) {
+  const url = new URL(request.url)
+  return withSpan('api.update', { route: url.pathname }, async () => {
+    const script = [
+      '#!/bin/bash',
+      'echo "→ Updating Meridian…"',
+      'echo',
+      UPDATE_CMD,
+      'status=$?',
+      'echo',
+      'if [ $status -eq 0 ]; then echo "✓ Update complete — you can close this window."; else echo "✗ Update failed (exit $status). See output above."; fi',
+      '',
+    ].join('\n')
+
+    const scriptPath = path.join(os.tmpdir(), 'meridian-update.command')
+    try {
+      fs.writeFileSync(scriptPath, script, { mode: 0o755 })
+      const child = spawn('open', ['-a', 'Terminal', scriptPath], {
+        detached: true,
+        stdio: 'ignore',
+      })
+      child.unref()
+      logger.info({ scriptPath }, 'launched meridian update in Terminal')
+      return NextResponse.json({ launched: true, command: UPDATE_CMD })
+    } catch (err) {
+      // Couldn't launch Terminal — the UI falls back to showing the command.
+      logger.warn({ err: String(err) }, 'could not launch Terminal for update')
+      return NextResponse.json({ launched: false, command: UPDATE_CMD }, { status: 200 })
+    }
+  })
+}

--- a/ui/app/api/version/route.ts
+++ b/ui/app/api/version/route.ts
@@ -1,0 +1,86 @@
+// meridian — normalises screenpipe activity into structured app sessions
+
+import { NextResponse } from 'next/server'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { logger, withSpan } from '@/lib/observability'
+
+export const dynamic = 'force-dynamic'
+
+const NPM_PKG = '@meridiona/meridian'
+// Package-root endpoint with the abbreviated-metadata accept header (below):
+// returns dist-tags without the full per-version payload — light and correct.
+// (The /<pkg>/latest endpoint 406s with the abbreviated header.)
+const NPM_PKG_URL = `https://registry.npmjs.org/${NPM_PKG}`
+const CHECK_TTL_MS = 60 * 60 * 1000 // re-check npm at most hourly
+
+// In-memory cache of the npm result — persists across requests in the same
+// server process, so a dashboard left open doesn't hammer the registry.
+let cache: { latest: string | null; checkedAt: number } | null = null
+
+interface VersionInfo {
+  current: string
+  latest: string | null
+  updateAvailable: boolean
+  checkedAt: string | null
+}
+
+/** Installed bundle version from ~/.meridian/app/VERSION; 'dev' when absent. */
+function readCurrentVersion(): string {
+  try {
+    const v = fs.readFileSync(path.join(os.homedir(), '.meridian', 'app', 'VERSION'), 'utf8').trim()
+    if (v) return v
+  } catch {
+    /* not installed via bundle (e.g. dev) — fall through */
+  }
+  return process.env.MERIDIAN_VERSION?.trim() || 'dev'
+}
+
+/** Compare dotted numeric versions. Returns true if `latest` > `current`. */
+function isNewer(latest: string, current: string): boolean {
+  if (current === 'dev') return false
+  const norm = (v: string) => v.replace(/^v/, '').split('-')[0].split('.').map((n) => parseInt(n, 10) || 0)
+  const a = norm(latest)
+  const b = norm(current)
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const d = (a[i] ?? 0) - (b[i] ?? 0)
+    if (d !== 0) return d > 0
+  }
+  return false
+}
+
+/** Fetch the latest published version from npm, cached for CHECK_TTL_MS. */
+async function fetchLatest(): Promise<{ latest: string | null; checkedAt: number }> {
+  if (cache && Date.now() - cache.checkedAt < CHECK_TTL_MS) return cache
+  try {
+    const res = await fetch(NPM_PKG_URL, {
+      headers: { accept: 'application/vnd.npm.install-v1+json' },
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!res.ok) throw new Error(`npm registry ${res.status}`)
+    const body = (await res.json()) as { 'dist-tags'?: { latest?: string } }
+    cache = { latest: body['dist-tags']?.latest ?? null, checkedAt: Date.now() }
+  } catch (err) {
+    // Network/offline/registry error — keep any prior result, else null. Never
+    // throw: an update check must not break the dashboard.
+    logger.warn({ err: String(err) }, 'version check: npm registry unreachable')
+    cache = cache ?? { latest: null, checkedAt: Date.now() }
+  }
+  return cache
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  return withSpan('api.version', { route: url.pathname }, async () => {
+    const current = readCurrentVersion()
+    const { latest, checkedAt } = await fetchLatest()
+    const info: VersionInfo = {
+      current,
+      latest,
+      updateAvailable: latest != null && isNewer(latest, current),
+      checkedAt: checkedAt ? new Date(checkedAt).toISOString() : null,
+    }
+    return NextResponse.json(info)
+  })
+}

--- a/ui/components/Sidebar.tsx
+++ b/ui/components/Sidebar.tsx
@@ -42,8 +42,16 @@ function ActiveSessionPill({ info, onClick }: { info: ActiveInfo; onClick: () =>
   )
 }
 
+interface VersionInfo {
+  current: string
+  latest: string | null
+  updateAvailable: boolean
+}
+
 export default function Sidebar({ view, onNavigate, onOpenCmd, queueCount }: Props) {
   const [active, setActive] = useState<ActiveInfo | null>(null)
+  const [ver, setVer] = useState<VersionInfo | null>(null)
+  const [updating, setUpdating] = useState(false)
 
   useEffect(() => {
     function load() {
@@ -53,6 +61,19 @@ export default function Sidebar({ view, onNavigate, onOpenCmd, queueCount }: Pro
     const id = setInterval(load, 30_000)
     return () => clearInterval(id)
   }, [])
+
+  useEffect(() => {
+    fetch('/api/version').then(r => r.json()).then((d: VersionInfo) => setVer(d)).catch(() => {})
+  }, [])
+
+  async function runUpdate() {
+    setUpdating(true)
+    try {
+      await fetch('/api/update', { method: 'POST' })
+    } catch {
+      /* ignore — banner keeps the copyable command as fallback */
+    }
+  }
 
   const items: Array<{ id: View; label: string; kbd: string; badge?: number }> = [
     { id: 'today',    label: 'Today',    kbd: '1' },
@@ -72,8 +93,36 @@ export default function Sidebar({ view, onNavigate, onOpenCmd, queueCount }: Pro
           <span className="inline-block w-2.5 h-2.5 rounded-full live-dot" style={{ background: 'var(--accent)' }} />
           <span className="font-serif italic text-[22px] leading-none tracking-tight" style={{ color: 'var(--ink)' }}>meridian</span>
         </div>
-        <p className="text-[10px] uppercase tracking-[0.2em] mt-2" style={{ color: 'var(--ink-3)' }}>local · v0.3</p>
+        <p className="text-[10px] uppercase tracking-[0.2em] mt-2" style={{ color: 'var(--ink-3)' }}>
+          local · v{ver?.current ?? '…'}
+        </p>
       </div>
+
+      {/* Update-available banner — notify + one-click (opens Terminal running `meridian update`) */}
+      {ver?.updateAvailable && ver.latest && (
+        <div className="mx-3 mb-1 p-3 rounded-lg"
+          style={{ background: 'var(--surface)', border: '1px solid var(--accent)' }}>
+          <div className="flex items-center gap-2">
+            <span className="text-[12px]" style={{ color: 'var(--accent)' }}>↑</span>
+            <span className="text-[11px]" style={{ color: 'var(--ink)' }}>
+              Update available
+            </span>
+            <span className="ml-auto font-mono tnum text-[10px]" style={{ color: 'var(--ink-3)' }}>
+              v{ver.current} → v{ver.latest}
+            </span>
+          </div>
+          <button onClick={runUpdate} disabled={updating}
+            className="w-full mt-2 px-2 py-1.5 rounded-md text-[11px] transition-colors"
+            style={{ background: 'var(--accent)', color: 'var(--paper)', opacity: updating ? 0.6 : 1 }}>
+            {updating ? 'Opening Terminal…' : 'Update now'}
+          </button>
+          {updating && (
+            <p className="text-[10px] mt-1.5 font-mono" style={{ color: 'var(--ink-3)' }}>
+              or run <span style={{ color: 'var(--ink-2)' }}>meridian update</span>
+            </p>
+          )}
+        </div>
+      )}
 
       {/* Nav */}
       <nav className="flex-1 px-3">


### PR DESCRIPTION
Adds an in-dashboard "update available" banner with a one-click update (the **notify + one-click** UX). No more guessing whether a new release shipped; no terminal required.

## What
- **`/api/version`** — reads the installed version from `~/.meridian/app/VERSION` and the latest published version from npm (registry package-root + `dist-tags`, 1h in-memory cache, 5s timeout, **never throws** — an offline check just shows no banner). Also replaces the **hardcoded `v0.3`** sidebar badge with the real version.
- **`/api/update`** — launches `meridian update` in a visible Terminal via a `.command` file + `open -a Terminal` (LaunchServices — no AppleEvents/Automation prompt; interactive login shell so the launcher is on PATH). The update is **not** run inside the server (it restarts daemons and may prompt for a password — must be visible + user-driven). Returns the raw command for a copyable fallback.
- **Sidebar** — shows an "Update available vX → vY" banner with an **Update now** button only when a newer version exists.

## Why this shape (the chosen UX)
No stored credentials · no silent daemon restart · works on a `/usr/local` npm prefix today · user stays in control of a screen-capture daemon.

## Validated live (against the running install)
- `/api/version` → `{current:"1.10.0", latest:"1.11.0", updateAvailable:true}` (semver compare correct; real 1.11.0 detected)
- `/api/update` → `{launched:true, command:"meridian update"}` and opens Terminal
- Turbopack build clean; typecheck errors are pre-existing `bun:test` files only

🤖 Generated with Claude Code