### PR TITLE
fix(setup): pin MLX Python deps with a lockfile for reproducible installs

### DIFF
--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -265,7 +265,15 @@ fi
 # fresh venv was created or the hash differs (a release that bumped Python deps).
 VENV="${APP_ROOT}/services/.venv"
 DEPS_STAMP="${VENV}/.meridian-deps-hash"
-deps_hash() { shasum -a 256 "${APP_ROOT}/services/pyproject.toml" 2>/dev/null | cut -d' ' -f1; }
+# Reproducible runtime: install the exact pinned set from requirements-mlx.lock,
+# not the [mlx] extra resolved fresh from PyPI within version ranges (where a new
+# upstream release could break a fresh install). Hash the lock (its source of
+# truth) so a changed lock re-pips; fall back to pyproject when no lock shipped.
+MLX_LOCK="${APP_ROOT}/services/requirements-mlx.lock"
+deps_hash() {
+    local f="${MLX_LOCK}"; [[ -f "$f" ]] || f="${APP_ROOT}/services/pyproject.toml"
+    shasum -a 256 "$f" 2>/dev/null | cut -d' ' -f1
+}
 want_hash="$(deps_hash)"
 
 fresh_venv=0
@@ -282,7 +290,17 @@ have_hash=""
 if [[ "${fresh_venv}" -eq 1 || "${want_hash}" != "${have_hash}" || -z "${want_hash}" ]]; then
     info "Installing Python + MLX deps (mlx-lm/outlines/fastapi; downloads ~ a few hundred MB on first run)…"
     "${VENV}/bin/pip" install --quiet --upgrade pip
-    if "${VENV}/bin/pip" install --quiet -e "${APP_ROOT}/services[mlx]"; then
+    _deps_ok=0
+    if [[ -f "${MLX_LOCK}" ]]; then
+        # Pinned lock + the local package WITHOUT re-resolving its deps.
+        "${VENV}/bin/pip" install --quiet -r "${MLX_LOCK}" \
+            && "${VENV}/bin/pip" install --quiet --no-deps -e "${APP_ROOT}/services" \
+            && _deps_ok=1
+    else
+        warn "no requirements-mlx.lock in bundle — resolving [mlx] from version ranges (not pinned)"
+        "${VENV}/bin/pip" install --quiet -e "${APP_ROOT}/services[mlx]" && _deps_ok=1
+    fi
+    if [[ "${_deps_ok}" -eq 1 ]]; then
         [[ -n "${want_hash}" ]] && printf '%s\n' "${want_hash}" > "${DEPS_STAMP}"
         ok "Python services ready"
     else

--- a/services/requirements-mlx.lock
+++ b/services/requirements-mlx.lock
@@ -1,0 +1,112 @@
+# meridian — pinned dependency lock for the MLX inference server (services[mlx]).
+#
+# The exact, verified runtime set for the FastAPI MLX classifier/summariser.
+# The installer installs from THIS file so every install is identical, instead
+# of re-resolving mlx-lm/outlines/fastapi from PyPI within version ranges (which
+# could pull an untested/broken upstream release into a fresh install).
+#
+# Regenerate after an intentional dep bump, from a known-good venv:
+#   uv pip compile services/pyproject.toml --extra mlx -o services/requirements-mlx.lock
+#   (or: python3.11 -m venv /tmp/le && /tmp/le/bin/pip install -e 'services[mlx]' \
+#         && /tmp/le/bin/pip freeze --exclude-editable > services/requirements-mlx.lock)
+#
+# Pinned from the verified arm64 venv on 2026-06-02 (mlx 0.31.2 / mlx-lm 0.31.3 /
+# outlines 1.3.0 / fastapi 0.136.3). Not hashed yet — version pins first.
+
+aiohappyeyeballs==2.6.2
+aiohttp==3.14.0
+aiosignal==1.4.0
+annotated-doc==0.0.4
+annotated-types==0.7.0
+anyio==4.13.0
+attrs==26.1.0
+certifi==2026.5.20
+cffi==2.0.0
+charset-normalizer==3.4.7
+click==8.4.1
+cloudpickle==3.1.2
+cryptography==48.0.0
+datasets==4.8.5
+dill==0.4.1
+diskcache==5.6.3
+distro==1.9.0
+fastapi==0.136.3
+filelock==3.29.0
+frozenlist==1.8.0
+fsspec==2026.2.0
+genson==1.3.0
+googleapis-common-protos==1.75.0
+h11==0.16.0
+hf-xet==1.5.0
+httpcore==1.0.9
+httpx==0.28.1
+httpx-sse==0.4.3
+huggingface_hub==1.17.0
+idna==3.17
+Jinja2==3.1.6
+jiter==0.15.0
+jsonpath-ng==1.8.0
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
+markdown-it-py==4.2.0
+MarkupSafe==3.0.3
+mcp==1.27.2
+mdurl==0.1.2
+mlx==0.31.2
+mlx-lm==0.31.3
+mlx-metal==0.31.2
+multidict==6.7.1
+multiprocess==0.70.19
+numpy==2.4.6
+openai==2.40.0
+opentelemetry-api==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-proto==1.42.1
+opentelemetry-sdk==1.42.1
+opentelemetry-semantic-conventions==0.63b1
+outlines==1.3.0
+outlines_core==0.2.14
+packaging==26.2
+pandas==3.0.3
+pillow==12.2.0
+propcache==0.5.2
+protobuf==6.33.6
+psutil==6.1.1
+pyarrow==24.0.0
+pycparser==3.0
+pydantic==2.13.4
+pydantic-settings==2.14.1
+pydantic_core==2.46.4
+Pygments==2.20.0
+PyJWT==2.13.0
+python-dateutil==2.9.0.post0
+python-dotenv==1.2.2
+python-json-logger==2.0.7
+python-multipart==0.0.30
+PyYAML==6.0.3
+referencing==0.37.0
+regex==2026.5.9
+requests==2.34.2
+rich==15.0.0
+rpds-py==2026.5.1
+safetensors==0.7.0
+sentencepiece==0.2.1
+shellingham==1.5.4
+six==1.17.0
+sniffio==1.3.1
+sse-starlette==3.4.4
+starlette==1.2.1
+tokenizers==0.22.2
+tqdm==4.67.3
+transformers==5.9.0
+typer==0.25.1
+typing-inspection==0.4.2
+typing_extensions==4.15.0
+urllib3==2.7.0
+uvicorn==0.48.0
+wrapt==2.2.1
+xxhash==3.7.0
+yarl==1.24.2


### PR DESCRIPTION
## Why
The bundle installs the MLX server's Python deps via `pip install -e services[mlx]`, which **resolves `mlx-lm`/`outlines`/`fastapi` fresh from PyPI within version ranges** on every install. So two installs at different times can get different versions, and a bad upstream release can silently break a fresh install. An end-user runtime should be **reproducible**.

## What
- **New `services/requirements-mlx.lock`** — the exact, verified runtime set (97 pkgs: `mlx 0.31.2` / `mlx-lm 0.31.3` / `outlines 1.3.0` / `fastapi 0.136.3` …), frozen from a known-good arm64 venv. Header documents regeneration (`uv pip compile` or `pip freeze`).
- **`install-from-bundle.sh`** — install from the lock, then the local `services` package with `--no-deps` (don't re-resolve). Preserves the existing deps-hash caching (skip re-pip when unchanged) and now hashes the **lock** so a lock change re-pips. Falls back to the `[mlx]` extra for older bundles without a lock.

This is the **must-have reproducibility foundation**. It uses only `pip` — **no new runtime dependency**. The dev path (`setup-services.sh` / `requirements.txt`, which pulls eval-only `hermes-agent`/`deepeval`) is intentionally left loose.

## Validation
- Lock generated from the live, working venv (`pip freeze --exclude-editable`), so it's exactly what's proven to run.
- `pip install --dry-run -r services/requirements-mlx.lock` against the working venv → all "already satisfied" (parses + resolves consistently).
- `bash -n` clean.

## Follow-up (separate)
Adopt **`uv`** for the venv step — drops the "user must have Python 3.11" requirement (uv can provide the interpreter) and is much faster. This lock is the prerequisite for that.

🤖 Generated with Claude Code