### PR TITLE
feat(setup): bootstrap.sh — no-sudo first install

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# meridian — normalises screenpipe activity into structured app sessions
+#
+# Bootstrap installer. Fixes the npm global prefix when it is root-owned (the
+# most common reason `npm install -g` fails with EACCES on a stock macOS Node
+# install), installs @meridiona/meridian, then hands off to `meridian setup`.
+#
+# One-liner usage (download + inspect first if you prefer):
+#   curl -fsSL https://raw.githubusercontent.com/Meridiona/meridian/main/scripts/bootstrap.sh | bash
+#
+# Or run directly from a clone:
+#   bash scripts/bootstrap.sh
+#
+# Re-running is safe — all steps are idempotent.
+
+set -euo pipefail
+
+info() { printf '→ %s\n'   "$*"; }
+ok()   { printf '  ✓ %s\n' "$*"; }
+warn() { printf '  ⚠ %s\n' "$*" >&2; }
+err()  { printf '✗ %s\n'   "$*" >&2; exit 1; }
+
+# ── 0. Platform + safety guards ──────────────────────────────────────────────
+[[ "$(uname -s)" == "Darwin" ]] || err "Meridian requires macOS."
+[[ "$(uname -m)" == "arm64"  ]] || err "Meridian requires Apple Silicon (arm64)."
+[[ "$(id -u)" -ne 0          ]] || err "Do not run as root / with sudo. Re-run as your normal user."
+
+# ── 1. Homebrew ───────────────────────────────────────────────────────────────
+command -v brew >/dev/null 2>&1 \
+    || err "Homebrew is required. Install it from https://brew.sh then re-run."
+ok "Homebrew"
+
+# ── 2. Node.js ────────────────────────────────────────────────────────────────
+if ! command -v node >/dev/null 2>&1; then
+    info "Installing Node.js via Homebrew…"
+    brew install node
+fi
+ok "Node $(node --version)"
+
+# ── 3. npm global prefix — ensure it is user-writable ─────────────────────
+# A system Node install (/usr/local) has a root-owned prefix; npm install -g
+# fails with EACCES. Fix: redirect the prefix to ~/.npm-global (user-owned)
+# and add ~/.npm-global/bin to PATH in the user's shell profile. This is a
+# permanent, one-time change — subsequent `npm install -g` commands (including
+# `meridian update`) just work without sudo.
+npm_global_writable() {
+    local prefix; prefix="$(npm config get prefix 2>/dev/null || true)"
+    [[ -n "$prefix" && -w "${prefix}/lib/node_modules" ]]
+}
+
+NPM_GLOBAL="${HOME}/.npm-global"
+
+if npm_global_writable; then
+    ok "npm prefix already user-writable — no fix needed"
+else
+    _old_prefix="$(npm config get prefix 2>/dev/null || true)"
+    info "npm prefix (${_old_prefix}) is root-owned — redirecting to ${NPM_GLOBAL}…"
+    mkdir -p "${NPM_GLOBAL}"
+    npm config set prefix "${NPM_GLOBAL}"
+
+    # Patch the user's shell profile so the fix survives new terminals.
+    _profile=""
+    case "${SHELL:-}" in
+        */zsh)  _profile="${ZDOTDIR:-${HOME}}/.zshrc" ;;
+        */bash) _profile="${HOME}/.bash_profile" ;;
+    esac
+    _export='export PATH="${HOME}/.npm-global/bin:${PATH}"'
+    if [[ -n "${_profile}" ]] && ! grep -qF '.npm-global/bin' "${_profile}" 2>/dev/null; then
+        {
+            printf '\n# Added by meridian bootstrap — npm global prefix\n'
+            printf '%s\n' "${_export}"
+        } >> "${_profile}"
+        ok "Added ~/.npm-global/bin to PATH in ${_profile}"
+        warn "Open a new terminal (or run: source ${_profile}) after setup to pick up PATH."
+    fi
+
+    # Apply for this session so meridian is immediately on PATH after install.
+    export PATH="${NPM_GLOBAL}/bin:${PATH}"
+    ok "npm prefix → ${NPM_GLOBAL} (user-writable, no sudo needed)"
+fi
+
+# ── 4. Install @meridiona/meridian ───────────────────────────────────────────
+info "Installing @meridiona/meridian@latest…"
+npm install -g @meridiona/meridian@latest
+ok "meridian installed ($(meridian --version 2>/dev/null || echo 'version unknown'))"
+
+# ── 5. Hand off to meridian setup ────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  meridian is installed. Running setup now…"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# When run interactively (direct bash invocation), exec meridian setup so it
+# owns the terminal for the permission walkthrough. When piped (curl | bash)
+# there is no TTY for interactive prompts — skip permissions and print a
+# reminder; the user runs `meridian setup` once they have a full terminal.
+if [[ -t 0 && -t 1 ]]; then
+    exec meridian setup
+else
+    meridian setup --skip-permissions
+    echo ""
+    echo "  Next step: open a new terminal and run:"
+    echo ""
+    echo "    meridian setup"
+    echo ""
+    echo "  This grants macOS Screen Recording + Accessibility to screenpipe"
+    echo "  and collects your Jira / GitHub / Linear credentials."
+fi

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -63,7 +63,8 @@ tar cf - \
   -C services . | tar xf - -C "${DEST}/services"
 
 echo "→ scripts + plists + CLI"
-cp scripts/meridian-cli.sh scripts/install-from-bundle.sh scripts/meridian-npm-setup.sh "${DEST}/scripts/"
+cp scripts/meridian-cli.sh scripts/install-from-bundle.sh scripts/meridian-npm-setup.sh \
+   scripts/bootstrap.sh "${DEST}/scripts/"
 cp scripts/install-daemon.sh scripts/uninstall-daemon.sh \
    scripts/install-ui-daemon.sh scripts/uninstall-ui-daemon.sh \
    scripts/install-screenpipe-daemon.sh scripts/uninstall-screenpipe-daemon.sh \


### PR DESCRIPTION
## Problem

Users on a stock macOS Node install (`/usr/local`) hit EACCES when running `npm install -g @meridiona/meridian` because the global prefix is root-owned. The only current workaround is `sudo npm install -g`, which then breaks `meridian setup` (launchd refuses root).

## Solution

`scripts/bootstrap.sh` — a single curl-pipeable script that:

1. Detects whether the npm global prefix is user-writable
2. If not: redirects it to `~/.npm-global`, patches `~/.zshrc` / `~/.bash_profile`
3. Runs `npm install -g @meridiona/meridian@latest` (no sudo in either case)
4. Hands off to `meridian setup`

**Install one-liner:**
```bash
curl -fsSL https://raw.githubusercontent.com/Meridiona/meridian/main/scripts/bootstrap.sh | bash
```

## Behaviour

| Situation | Outcome |
|-----------|---------|
| Homebrew Node (`/opt/homebrew`, writable) | No prefix change; straight to npm install |
| System Node (`/usr/local`, root-owned) | Prefix → `~/.npm-global`; PATH patched in shell profile |
| Interactive run (direct bash) | `exec meridian setup` — full interactive walkthrough |
| Piped run (curl \| bash, no TTY) | `meridian setup --skip-permissions`; prints reminder to run `meridian setup` in a new terminal |

All steps are idempotent — re-running is safe.

## Test plan

- [ ] Run on a machine with Homebrew Node — prefix check passes, no changes to npm config
- [ ] Run on a machine with system Node (`npm config get prefix` = `/usr/local`) — prefix redirected, shell profile patched
- [ ] `curl ... | bash` — installs without hanging on interactive prompts
- [ ] Direct `bash scripts/bootstrap.sh` — hands off to `meridian setup` interactive flow

🤖 Generated with Claude Code