### PR TITLE
fix(bootstrap): use prefix ownership to detect root-owned npm

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -45,13 +45,18 @@ ok "Node $(node --version)"
 # `meridian update`) just work without sudo.
 npm_global_writable() {
     local prefix; prefix="$(npm config get prefix 2>/dev/null || true)"
-    [[ -n "$prefix" && -w "${prefix}/lib/node_modules" ]]
+    [[ -n "$prefix" ]] || return 1
+    # Use ownership of the prefix itself — more reliable than -w on the
+    # node_modules dir. -w returns true even when ACLs or missing @scope
+    # subdirs prevent mkdir, as seen on /usr/local with system Node.
+    local owner; owner="$(stat -f '%Su' "${prefix}" 2>/dev/null || true)"
+    [[ -n "$owner" && "$owner" == "$(id -un)" ]]
 }
 
 NPM_GLOBAL="${HOME}/.npm-global"
 
 if npm_global_writable; then
-    ok "npm prefix already user-writable — no fix needed"
+    ok "npm prefix ($(npm config get prefix)) is user-writable — no fix needed"
 else
     _old_prefix="$(npm config get prefix 2>/dev/null || true)"
     info "npm prefix (${_old_prefix}) is root-owned — redirecting to ${NPM_GLOBAL}…"


### PR DESCRIPTION
## Bug

`-w "${prefix}/lib/node_modules"` returned `true` for `/usr/local` even though `npm install -g` failed with EACCES. The `node_modules` directory has permissive modes from prior `sudo npm install` runs, but creating new `@scope` subdirs is still denied.

## Fix

Check `stat -f %Su "${prefix}"` — if the owner is not the current user, the prefix is root-controlled and the `~/.npm-global` redirect applies.

```
prefix=/usr/local  owner=root  → fix now correctly triggers
prefix=/opt/homebrew  owner=<user>  → no fix needed
```

Fixes the EACCES failure seen when running the bootstrap one-liner on a system Node install.

## Test plan

- [ ] Run bootstrap on system Node (`/usr/local`) — should see "ROOT-OWNED — redirecting to ~/.npm-global" then successful install
- [ ] Run bootstrap on Homebrew Node (`/opt/homebrew`) — should see "user-writable — no fix needed"

🤖 Generated with Claude Code