### PR TITLE
fix(mlx-server): handle uv pyvenv.cfg format in BASE_PYTHON resolution

### DIFF
--- a/services/scripts/install-mlx-server-daemon.sh
+++ b/services/scripts/install-mlx-server-daemon.sh
@@ -52,9 +52,22 @@ fi
 # than through the venv wrapper. The wrapper shebang causes Python to read
 # pyvenv.cfg at startup, which EPERM-fails when launchd launches the process
 # on macOS 15 (launchd inherits no TCC Documents permission).
+#
+# pyvenv.cfg format differs by creator:
+#   python -m venv  → "executable = /path/to/python3.11"
+#   uv sync         → "home = /path/to/bin"  (no `executable` key)
+# Try `executable` first, fall back to `home` + python3.11/python3/python.
 BASE_PYTHON=$(grep '^executable' "${VENV_CFG}" | awk '{print $3}')
+if [[ -z "${BASE_PYTHON}" || ! -x "${BASE_PYTHON}" ]]; then
+    _home=$(grep '^home ' "${VENV_CFG}" | awk '{print $3}')
+    if [[ -n "${_home}" ]]; then
+        for _py in python3.11 python3 python; do
+            if [[ -x "${_home}/${_py}" ]]; then BASE_PYTHON="${_home}/${_py}"; break; fi
+        done
+    fi
+fi
 if [[ ! -x "${BASE_PYTHON}" ]]; then
-    echo "✗ base Python not found at ${BASE_PYTHON} (from ${VENV_CFG})" >&2
+    echo "✗ base Python not found (checked pyvenv.cfg executable + home keys in ${VENV_CFG})" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Bug

After switching to \`uv sync\` (PR #127), the MLX daemon installer failed on every fresh install with \`⚠ MLX agent install failed\`.

**Root cause:** \`install-mlx-server-daemon.sh\` resolves the base Python by grepping \`pyvenv.cfg\` for \`^executable\`. This key exists in venvs created by \`python -m venv\` but **not** in venvs created by \`uv sync\`, which writes \`home = /path/to/bin\` instead. Result: \`BASE_PYTHON\` was empty → script exited 1 → MLX daemon never started → 300s wait timeout on every setup.

## Fix

Try \`executable\` first (regular venv), fall back to \`home + python3.11/python3/python\` (uv venv).

```
# uv pyvenv.cfg:
home = /Users/adityaharish/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin
# → resolves to: .../bin/python3.11  ✓
```

Verified against live install: \`BASE_PYTHON\` correctly resolves, \`[[ -x ]]\` passes.

## Test plan

- [ ] Fresh \`meridian setup\` — MLX installer should succeed, no "MLX agent install failed"
- [ ] \`curl http://127.0.0.1:7823/health\` returns 200 after setup

🤖 Generated with Claude Code