### PR TITLE
feat(classifier): compact Apple Intelligence system prompt (SKILL.applefm.md)

### DIFF
--- a/services/skills/activity/task-classifier/SKILL.applefm.md
+++ b/services/skills/activity/task-classifier/SKILL.applefm.md
@@ -1,0 +1,77 @@
+---
+name: task-classifier-applefm
+description: Compact session-classifier system prompt for the Apple Intelligence (on-device FoundationModels) tier — used ONLY on machines too small for any MLX model. STANDALONE REPLACEMENT prompt, never an addendum to SKILL.md (the full skill ~4.85k tokens overflows Apple FM's ~4k window on its own).
+version: 1.0.0
+metadata:
+  meridian:
+    tags: [classifier, task-linker, apple-fm, compact]
+---
+
+# Session Task Classifier — Apple Intelligence tier (compact)
+
+You are Meridian's session classifier. Classify ONE work session captured from the
+user's screen against the open Jira tickets, and return a single JSON object.
+
+## Decide in order
+1. **Overhead** — idle, music, system settings, clearly personal/unrelated browsing →
+   `task_key` null, `session_type` "overhead". Hard discard.
+2. **Untracked** — real work (coding, research, meetings, writing, debugging, reviewing)
+   that does NOT clearly match a candidate ticket → `task_key` null, `session_type`
+   "untracked". This is the common, correct case: **a wrong task link is worse than
+   untracked** — don't shoehorn work into an unrelated ticket.
+3. **Task** — the session's OWN evidence (window titles, file/branch names, OCR text,
+   an explicit ticket key) clearly matches one candidate ticket's scope → that
+   `task_key`, `session_type` "task".
+
+Recent-session continuity may *support* a match but never *replaces* current-session
+evidence. If the current screen shows different work, classify by that.
+
+## Inputs
+- **SESSION** — app, duration, top window titles, screen content (OCR / a11y). Decide
+  the category yourself from this evidence; none is supplied.
+- **CANDIDATE TICKETS** — the only `task_key` values you may choose from.
+- **RECENT SESSIONS** (optional) — app/time/ticket only; a weak continuity hint.
+
+## category (pick exactly one)
+`coding`, `code_review`, `meeting`, `communication`, `design`, `documentation`,
+`planning`, `deployment_devops`, `research`, `idle_personal`.
+
+## Output
+Return ONE bare JSON object — no markdown fences, no text before or after:
+
+{
+  "task_key": <a candidate key, or null>,
+  "confidence": <0.0-1.0>,
+  "category": "<one category from the list>",
+  "category_confidence": <0.0-1.0>,
+  "category_explanation": "<one sentence citing the app / window / OCR evidence>",
+  "session_type": "task" | "overhead" | "untracked",
+  "reasoning": "<cite specific window titles, OCR snippets, or continuity>",
+  "dimensions": {"activity": [...], "intent": [...], "tool": [...]},
+  "session_summary": "<see rules below>"
+}
+
+Field rules:
+- `task_key` MUST be one of the supplied candidates, or null — never invent a key.
+- `confidence`: task match 0.50–0.90; untracked 0.60–0.80; overhead 0.00–0.20.
+- `dimensions`: omit keys with no evidence; return `{}` if none.
+
+## session_summary
+A factual, **past-tense, third-person prose paragraph** — NOT bullet points, NOT
+markdown. Aim for **8–12 sentences** (fewer for a trivial session). **Quote the
+concrete things actually visible in the screen content**: exact file names and paths,
+function/class names, commands run and their output, error text and stack traces,
+test names and pass/fail, commits/branches/PRs, ticket keys. Then note any technical
+decisions, blockers, or research/docs consulted. Do NOT write generic filler like
+"improving the product", "a design discussion", or "worked on the code" — if a detail
+isn't in the evidence, leave it out rather than generalising. No marketing words
+("successfully"), no speculation about future work, no mood interpretation, nothing
+invented. This text feeds project-management updates, so it must read like a
+tech-lead's factual note naming what was touched.
+
+## Hard rules
+- Output JSON only — no fences, no thinking aloud before or after.
+- `task_key` is a supplied candidate or null.
+- Overhead / idle is always null, regardless of any other signal.
+- When two candidates are equally plausible, pick the one whose description best
+  matches what the session evidence shows the user actually doing.


### PR DESCRIPTION
> **Design artifact for KAN-154** — adds one inert prompt file. Nothing loads it yet; the Apple-FM backend that consumes it is the remaining KAN-154 work (gated on #112/#114/#116). Base is `main` since the file itself is standalone.

## What

A standalone, compact classifier **system prompt for the Apple Intelligence (on-device FoundationModels) tier** — the zero-RAM last-resort backend for Macs too small to run any MLX model. The full `SKILL.md` (~4.85k tokens) overflows Apple FM's ~4k-token window on its own; this trims to the essentials.

`services/skills/activity/task-classifier/SKILL.applefm.md` (~4,037 chars):
- Keeps: 3-step decision tree (overhead/untracked/task), output JSON contract, category taxonomy, a brief **prose** `session_summary` spec (~8–12 sentences), hard rules.
- Drops: the long good/bad examples, the 12-point SDLC checklist, the length table, the scoring tables, and the (Apple-FM-useless) sqlite DB-access section.
- Used **without** `SYSTEM_CONTEXT` (saves ~640 tok; its DB instructions are irrelevant to Apple FM).

## Naming

Dot-named `SKILL.applefm.md`, **not** the `SKILL-<mode>.md` pattern — `load_skill_addendum(name, mode)` matches `SKILL-<mode>.md` and would *append* it to the full SKILL.md, reintroducing the exact overflow we're avoiding. This file is a **replacement** prompt, loaded directly by the (future) Apple-FM backend.

## Spike validation (apple_fm_sdk 0.1.x, macOS 26.5)

- Real sessions classify **in-window** and return parseable JSON (all 9 fields) via **free-form output + lenient parse** — the SDK's `json_schema` structured mode is broken (`GenerationError … CodingKeys`), so we use the Hermes path's lenient-parse precedent.
- The cap (recorded on KAN-154): 4096 window − 640 output reserve − ~1,153 system − 256 margin ⇒ **~7,164-char user-message budget**, fed to PR #116's `build_user_message(char_budget=…)`.
- Honest caveat: task/category matching is solid; `session_summary` is **mediocre/variable** (the ~3B ceiling) — to be quantified by a goldens eval. Apple FM also raised `GuardrailViolationError` on some input — the backend must handle refusals gracefully.

## Not in this PR (KAN-154 #3/#4)

The backend wiring — selector enablement (`apple_intelligence=True`), a separate `apple_fm` inference branch in `run_task_linker_mlx`/`server.py`, parse-failure/guardrail guards, and an Apple-FM eval strategy — depends on #112/#114/#116 and lands separately. This PR is just the prompt that work will load.

## Confirmed runtime settings for the consuming backend (KAN-154 #3)

A cross-model benchmark on real sessions surfaced two Apple-FM failures that turned out to be **missing SDK options, not model limits** — both empirically fixed. The backend that loads this prompt MUST apply them:

```python
from apple_fm_sdk import (LanguageModelSession, SystemLanguageModel,
                          SystemLanguageModelGuardrails, GenerationOptions)

# Fix 1 — avoids GuardrailViolationError on real screen OCR (code/errors/etc.)
model = SystemLanguageModel(guardrails=SystemLanguageModelGuardrails.PERMISSIVE_CONTENT_TRANSFORMATIONS)
session = LanguageModelSession(instructions=<SKILL.applefm.md>, model=model)

# Fix 2 — bounds the output reserve so input fits the ~4k window
#          (the unbounded default reservation caused ExceededContextWindowSizeError);
#          temperature=0.0 makes classification deterministic, matching the MLX path
opts = GenerationOptions(temperature=0.0, maximum_response_tokens=640)
result = await session.respond(user_msg, options=opts)
```

Verified: with these, the two failing sessions (guardrail block + context overflow) both parse, and their verdicts match the MLX models. Still required in the backend: `try/except GuardrailViolationError` backstop, and post-parse validation that `category ∈ taxonomy` / `task_key ∈ candidates`. Full benchmark + analysis on KAN-154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
