### PR TITLE
fix(ci): use brew install uv in package-release.sh (PEP 668 fix)

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -63,8 +63,9 @@ tar cf - \
   -C services . | tar xf - -C "${DEST}/services"
 
 echo "→ Python venv (pre-built site-packages — avoids PyPI at install time)"
-# uv must be available on the CI runner; install via pip if absent.
-command -v uv >/dev/null 2>&1 || pip3 install --quiet uv
+# uv must be available on the CI runner. pip3 install is blocked on macOS 26
+# by PEP 668 (externally-managed-environment). Install via Homebrew instead.
+command -v uv >/dev/null 2>&1 || brew install uv
 # Build the venv from the committed uv.lock (exact pinned set, no resolution).
 uv sync --project services --extra mlx --frozen
 # Determine the Python version subdirectory (e.g. python3.11).


### PR DESCRIPTION
## Bug

The `package-release.sh` step introduced in #132 calls `pip3 install uv` when uv is absent. On the macOS 26 CI runner, Homebrew's Python blocks system-wide pip installs (PEP 668 "externally-managed-environment"), causing the release build to fail.

## Fix

Replace `pip3 install --quiet uv` with `brew install uv`. Homebrew is always present on the macOS runner and is the correct way to install uv on macOS without touching the system Python.

Fixes the `v1.15.0` release failure.

🤖 Generated with Claude Code