### PR TITLE
fix(setup): ship services-venv.tar.gz in npm; fix MLX grep set -e exit

### DIFF
--- a/npm/meridian-darwin-arm64/package.json
+++ b/npm/meridian-darwin-arm64/package.json
@@ -18,6 +18,7 @@
     "bin/",
     "ui.tar.gz",
     "services/",
+    "services-venv.tar.gz",
     "scripts/",
     ".env.example",
     "VERSION"

--- a/services/scripts/install-mlx-server-daemon.sh
+++ b/services/scripts/install-mlx-server-daemon.sh
@@ -57,9 +57,10 @@ fi
 #   python -m venv  → "executable = /path/to/python3.11"
 #   uv sync         → "home = /path/to/bin"  (no `executable` key)
 # Try `executable` first, fall back to `home` + python3.11/python3/python.
-BASE_PYTHON=$(grep '^executable' "${VENV_CFG}" | awk '{print $3}')
+# `|| true` prevents set -e from exiting when grep finds no match (exit 1).
+BASE_PYTHON=$(grep '^executable' "${VENV_CFG}" 2>/dev/null | awk '{print $3}' || true)
 if [[ -z "${BASE_PYTHON}" || ! -x "${BASE_PYTHON}" ]]; then
-    _home=$(grep '^home ' "${VENV_CFG}" | awk '{print $3}')
+    _home=$(grep '^home ' "${VENV_CFG}" 2>/dev/null | awk '{print $3}' || true)
     if [[ -n "${_home}" ]]; then
         for _py in python3.11 python3 python; do
             if [[ -x "${_home}/${_py}" ]]; then BASE_PYTHON="${_home}/${_py}"; break; fi


### PR DESCRIPTION
## Two bugs in 1.15.0

### 1. `services-venv.tar.gz` not shipped in npm package

Not listed in `files` array of `npm/meridian-darwin-arm64/package.json` — npm strips unlisted files on publish. Installer fell back to `uv sync` (warm cache made it fast, but pre-build was wasted).

**Fix:** add `"services-venv.tar.gz"` to the `files` array.

### 2. MLX installer aborts before the `home` fallback (`set -e` + grep)

With `set -euo pipefail`, `grep '^executable'` exits 1 when no match → bash aborts before the `home` fallback from #131 runs → `BASE_PYTHON` empty → "MLX agent install failed".

**Fix:** add `|| true` to both grep calls.

**Verified locally:** `BASE_PYTHON` resolves correctly from the `home` key.

## Test plan
- [ ] `meridian setup` — "→ Extracting pre-built Python venv" (not "downloading…")
- [ ] No "MLX agent install failed"
- [ ] `curl http://127.0.0.1:7823/health` → 200

🤖 Generated with Claude Code