### PR TITLE
fix(update): re-exec new launcher to self-heal old launchers in one step

### DIFF
--- a/npm/meridian/bin/meridian.js
+++ b/npm/meridian/bin/meridian.js
@@ -85,15 +85,34 @@ if (typeof process.getuid === 'function' && process.getuid() === 0) {
 if (cmd === 'setup' || cmd === 'install') {
   const bundle = resolveBundle();
   run('bash', [path.join(bundle, 'scripts', 'meridian-npm-setup.sh'), bundle, ...rest]);
-} else if (cmd === 'update') {
-  console.log('meridian update: downloading latest release…');
-  console.log('  The package includes a pre-built Python venv (~160 MB).');
-  console.log('  First update after 1.15.0 will take ~1-3 min; subsequent updates are faster.');
-  const _updateStart = Date.now();
-  const up = npmInstallLatest();
-  if (up.status) process.exit(up.status);
-  const _elapsed = Math.round((Date.now() - _updateStart) / 1000);
-  console.log(`  Downloaded in ${_elapsed}s`);
+} else if (cmd === 'update' || cmd === '_update-continue') {
+  if (cmd === 'update') {
+    // Step 1: update the thin launcher only. The current process runs the OLD
+    // launcher in memory — fixes to also install darwin-arm64 may only be in the
+    // NEW launcher on disk. Re-exec the newly installed launcher so step 2 always
+    // uses the latest code, even when invoked by an old launcher.
+    console.log('meridian update: downloading latest release…');
+    console.log('  The package includes a pre-built Python venv (~160 MB).');
+    console.log('  First update after 1.15.0 will take ~1-3 min; subsequent updates are faster.');
+    const _start = Date.now();
+    const up = spawnSync('npm', ['install', '-g', '@meridiona/meridian@latest'], { stdio: 'inherit' });
+    if (up.status) process.exit(up.status);
+    console.log(`  Launcher updated in ${Math.round((Date.now() - _start) / 1000)}s`);
+    // Re-exec the freshly installed launcher to continue with the correct code.
+    const npmRoot = (spawnSync('npm', ['root', '-g'], { encoding: 'utf8' }).stdout || '').trim();
+    const newLauncher = path.join(npmRoot, '@meridiona', 'meridian', 'bin', 'meridian.js');
+    if (fs.existsSync(newLauncher)) {
+      const r = spawnSync(process.execPath, [newLauncher, '_update-continue'], { stdio: 'inherit' });
+      process.exit(r.status ?? 1);
+    }
+    // Fallback: new launcher not found, continue in this process.
+  }
+  // Step 2 (runs in new launcher): install bundle + run setup.
+  const _bundleStart = Date.now();
+  const bup = spawnSync('npm', ['install', '-g', '@meridiona/meridian-darwin-arm64@latest'],
+    { stdio: 'inherit', env: { ...process.env } });
+  if (bup.status) process.exit(bup.status);
+  console.log(`  Bundle downloaded in ${Math.round((Date.now() - _bundleStart) / 1000)}s`);
   const bundle = resolveBundle();
   run('bash', [path.join(bundle, 'scripts', 'meridian-npm-setup.sh'), bundle, '--skip-permissions']);
 } else {


### PR DESCRIPTION
## Problem

Old launchers run in-memory during `meridian update`. When step 1 installs `@meridiona/meridian@latest` (the new launcher), the current process keeps executing the OLD code — meaning any fix in the new launcher (e.g. explicitly installing `darwin-arm64`) doesn't take effect until the NEXT `meridian update`.

Users needed to run `meridian update` twice.

## Fix

After step 1 (install new thin launcher), re-exec the freshly installed `meridian.js` with `_update-continue`. The new launcher then runs step 2 (install `darwin-arm64@latest` + setup) with the correct code.

```
meridian update (old launcher)
  → npm install @meridiona/meridian@latest     ← step 1: new launcher on disk
  → node <new launcher> _update-continue       ← re-exec
      → npm install @meridiona/meridian-darwin-arm64@latest  ← step 2
      → meridian-npm-setup.sh --skip-permissions
```

Old launchers self-heal in **one** `meridian update`.

🤖 Generated with Claude Code