### PR TITLE
fix(ci): pin Python 3.11 in venv build — fixes MLX server crash on startup

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -67,9 +67,12 @@ echo "→ Python venv (pre-built site-packages — avoids PyPI at install time)"
 # by PEP 668 (externally-managed-environment). Install via Homebrew instead.
 command -v uv >/dev/null 2>&1 || brew install uv
 # Build the venv from the committed uv.lock (exact pinned set, no resolution).
-uv sync --project services --extra mlx --frozen
-# Determine the Python version subdirectory (e.g. python3.11).
-_py_dir="$(ls services/.venv/lib/ | grep '^python' | head -1)"
+# Pin Python 3.11 explicitly: the macos-26 runner defaults to Python 3.14 which
+# produces cpython-314-darwin.so extensions that Python 3.11 on user machines
+# cannot load (ImportError at startup). uv installs Python 3.11 automatically.
+uv sync --project services --extra mlx --frozen --python 3.11
+# Python version subdir is always python3.11 (we pin above).
+_py_dir="python3.11"
 if [[ -z "${_py_dir}" ]]; then
     echo "✗ could not find python lib dir under services/.venv/lib/" >&2
     exit 1


### PR DESCRIPTION
## Bug

The pre-built venv (shipped in `services-venv.tar.gz`) was built with Python 3.14 on the `macos-26` CI runner. All native extensions were compiled as `cpython-314-darwin.so`. Users run Python 3.11 — Python 3.11 cannot load `cpython-314` extensions, causing the MLX server to crash immediately at startup:

```
ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'
```

Confirmed: all `.so` files in the tarball are `cpython-314-darwin.so`.

## Fix

Pass `--python 3.11` to `uv sync` in `package-release.sh`. uv installs Python 3.11 automatically on the runner if absent, and builds `cpython-311-darwin.so` extensions that match user machines.

Also hardcode `_py_dir=python3.11` instead of auto-detecting — prevents a future Python version bump on the runner from silently shipping the wrong `.so` files again.

## Workaround for users on 1.17.1

```bash
rm -rf ~/.meridian/app/services/.venv
cd ~/.meridian/app/services && uv sync --extra mlx --frozen --python python3.11
bash ~/.meridian/app/services/scripts/install-mlx-server-daemon.sh --port 7823
```

🤖 Generated with Claude Code