### PR TITLE
fix(install): point ~/.local/bin/meridian at the launcher (follow-up to #144)

### DIFF
--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -251,22 +251,23 @@ fi
 # ── 3. Binary + CLI symlinks ─────────────────────────────────────────────────
 mkdir -p "${HOME}/.local/bin"
 ln -sfn "${APP_ROOT}/bin/meridian"        "${HOME}/.local/bin/meridian-daemon"
-# Do NOT shadow the npm launcher with a second `meridian` on PATH. When installed
-# via npm, the launcher (`meridian.js`) owns `setup`/`update` and delegates
-# start/stop/doctor to this bundle's CLI by its real path. ~/.local/bin usually
-# precedes the npm bin dir on PATH, so a ~/.local/bin/meridian symlink would hide
-# `meridian setup` / `meridian update` (it can't reach the launcher).
+# Put a single `meridian` on PATH that owns every command. The npm launcher
+# (`meridian.js`) owns `setup`/`update` and delegates start/stop/doctor to this
+# bundle's CLI; the CLI alone does NOT know `setup`/`update`. So we point
+# ~/.local/bin/meridian AT the launcher (not the CLI) whenever a launcher exists.
 #
-# The launcher's location depends on the npm prefix: /usr/local/bin on a default
-# prefix, but ~/.npm-global/bin when the EACCES bootstrap redirected the prefix to
-# a user-writable dir. Resolve the prefix from npm rather than assuming
-# /usr/local — otherwise the launcher is missed and the CLI shadow hides `update`.
-# Only create the CLI symlink as a fallback when no launcher is present (e.g. a
-# standalone bundle install); when the launcher exists, remove any stale shadow
-# so `meridian update` self-heals an install made by an older bundle.
+# Why ~/.local/bin and not rely on the npm bin dir being on PATH: the launcher's
+# own bin dir depends on the npm prefix (/usr/local/bin by default, but
+# ~/.npm-global/bin when the EACCES bootstrap redirected the prefix). That dir is
+# only added to PATH via a shell-rc patch, which doesn't apply to already-open
+# shells and may never apply for bash users. ~/.local/bin is a standard user bin
+# dir that is reliably on PATH already, so pointing it at the launcher makes
+# `meridian update` work in every shell immediately — no rc reload required, no
+# CLI shadow hiding `update`. Fall back to the CLI only for a standalone bundle
+# install where no npm launcher is present.
 _launcher=""
 _npm_prefix="$(npm config get prefix 2>/dev/null || true)"
-for _cand in "/usr/local/bin/meridian" ${_npm_prefix:+"${_npm_prefix}/bin/meridian"}; do
+for _cand in ${_npm_prefix:+"${_npm_prefix}/bin/meridian"} "/usr/local/bin/meridian"; do
     [[ -e "${_cand}" ]] || continue
     # Distinguish the launcher (node shim) from a self-referential CLI symlink:
     # the launcher never resolves to meridian-cli.sh.
@@ -275,11 +276,11 @@ for _cand in "/usr/local/bin/meridian" ${_npm_prefix:+"${_npm_prefix}/bin/meridi
     fi
 done
 if [[ -n "${_launcher}" ]]; then
-    rm -f "${HOME}/.local/bin/meridian"
-    ok "meridian-daemon → ~/.local/bin  (meridian CLI = npm launcher at ${_launcher})"
+    ln -sfn "${_launcher}" "${HOME}/.local/bin/meridian"
+    ok "meridian-daemon + meridian → ~/.local/bin  (meridian → npm launcher at ${_launcher})"
 else
     ln -sfn "${APP_ROOT}/scripts/meridian-cli.sh" "${HOME}/.local/bin/meridian"
-    ok "meridian-daemon + meridian → ~/.local/bin"
+    ok "meridian-daemon + meridian → ~/.local/bin  (CLI; no npm launcher found)"
 fi
 
 # ── 4. Python venv + MLX deps ────────────────────────────────────────────────

--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -252,16 +252,31 @@ fi
 mkdir -p "${HOME}/.local/bin"
 ln -sfn "${APP_ROOT}/bin/meridian"        "${HOME}/.local/bin/meridian-daemon"
 # Do NOT shadow the npm launcher with a second `meridian` on PATH. When installed
-# via npm, /usr/local/bin/meridian (the launcher) owns `setup`/`update` and
-# delegates start/stop/doctor to this bundle's CLI by its real path. ~/.local/bin
-# usually precedes /usr/local/bin on PATH, so a ~/.local/bin/meridian symlink
-# would hide `meridian setup` / `meridian update` (it can't reach the launcher).
+# via npm, the launcher (`meridian.js`) owns `setup`/`update` and delegates
+# start/stop/doctor to this bundle's CLI by its real path. ~/.local/bin usually
+# precedes the npm bin dir on PATH, so a ~/.local/bin/meridian symlink would hide
+# `meridian setup` / `meridian update` (it can't reach the launcher).
+#
+# The launcher's location depends on the npm prefix: /usr/local/bin on a default
+# prefix, but ~/.npm-global/bin when the EACCES bootstrap redirected the prefix to
+# a user-writable dir. Resolve the prefix from npm rather than assuming
+# /usr/local — otherwise the launcher is missed and the CLI shadow hides `update`.
 # Only create the CLI symlink as a fallback when no launcher is present (e.g. a
 # standalone bundle install); when the launcher exists, remove any stale shadow
 # so `meridian update` self-heals an install made by an older bundle.
-if [[ -e /usr/local/bin/meridian ]]; then
+_launcher=""
+_npm_prefix="$(npm config get prefix 2>/dev/null || true)"
+for _cand in "/usr/local/bin/meridian" ${_npm_prefix:+"${_npm_prefix}/bin/meridian"}; do
+    [[ -e "${_cand}" ]] || continue
+    # Distinguish the launcher (node shim) from a self-referential CLI symlink:
+    # the launcher never resolves to meridian-cli.sh.
+    if [[ "$(readlink "${_cand}" 2>/dev/null || echo "${_cand}")" != *meridian-cli.sh ]]; then
+        _launcher="${_cand}"; break
+    fi
+done
+if [[ -n "${_launcher}" ]]; then
     rm -f "${HOME}/.local/bin/meridian"
-    ok "meridian-daemon → ~/.local/bin  (meridian CLI = npm launcher at /usr/local/bin/meridian)"
+    ok "meridian-daemon → ~/.local/bin  (meridian CLI = npm launcher at ${_launcher})"
 else
     ln -sfn "${APP_ROOT}/scripts/meridian-cli.sh" "${HOME}/.local/bin/meridian"
     ok "meridian-daemon + meridian → ~/.local/bin"


### PR DESCRIPTION
Follow-up to **#144**, which merged before its second commit landed — so main currently has the weaker *remove-the-shadow* logic. This PR completes the fix with *point-at-launcher*.

## Why remove-shadow (what's on main now) isn't enough

#144 removed the `~/.local/bin/meridian → meridian-cli.sh` shadow when an npm launcher exists, relying on the launcher's own bin dir being on PATH. But that dir (`~/.npm-global/bin` under the EACCES bootstrap) is only added to PATH by a shell-rc patch that **doesn't apply to already-open shells** and may never apply for bash users.

Observed live: after the shadow was removed, `which meridian` → `meridian not found`, because `~/.npm-global/bin` wasn't on the running shell's PATH.

## Fix

Point `~/.local/bin/meridian` **at the launcher** instead of removing it. `~/.local/bin` is a standard user bin dir reliably on PATH already (it was on PATH even in the broken shell), and the launcher delegates non-`setup`/`update` commands to the CLI — so one entry serves every command, in every shell, with no rc reload. Launcher located via `npm config get prefix` (checking `<prefix>/bin` then `/usr/local/bin`), skipping a self-referential `meridian-cli.sh` symlink.

## Verification

- `bash -n` parses clean; conflict with main resolved (net diff is only the comment + loop order + `ln` vs `rm`).
- **Empirically confirmed** the double-symlink resolves the bundle: `~/.local/bin → ~/.npm-global/bin/meridian → meridian.js` ran `meridian status` with no "prebuilt package not installed" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)