### PR TITLE
feat(intelligence): gate task-linking + worklog on a working pipeline

### DIFF
--- a/src/intelligence/mod.rs
+++ b/src/intelligence/mod.rs
@@ -11,8 +11,67 @@ pub use task_linker::{
 
 use anyhow::Result;
 use sqlx::SqlitePool;
+use std::time::Duration;
 
 use crate::config::{Config, PmProviderConfig};
+
+/// True once at least one PM task is cached. Rows only land in `pm_tasks` after a
+/// provider authenticated and fetched successfully, so a non-zero count is proof
+/// a tracker actually WORKS (not merely that keys are present — bad creds 401 and
+/// leave the table empty). A DB error is treated as "not present" (fail closed).
+pub async fn pm_tasks_present(pool: &SqlitePool) -> bool {
+    match sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM pm_tasks")
+        .fetch_one(pool)
+        .await
+    {
+        Ok(n) => n > 0,
+        Err(e) => {
+            tracing::warn!(error = %e, "pm_tasks count failed — treating tracker as not ready");
+            false
+        }
+    }
+}
+
+/// True when the MLX classifier is actually WORKING: reachable AND, if it reports
+/// model-load status, the model is loaded. This is a POSITIVE readiness probe
+/// (short timeout) — never inferred from a failed classify call, and never the
+/// 120 s startup wait of `check_classification_ready`. Safe to call every cycle.
+pub async fn mlx_ready(cfg: &Config) -> bool {
+    let base = format!("http://127.0.0.1:{}", cfg.mlx_server_port);
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(3))
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    // Liveness: the port must answer /health.
+    if client.get(format!("{base}/health")).send().await.is_err() {
+        return false;
+    }
+    // Readiness: /info reports `loaded_at`. If this build exposes it, require the
+    // model to be loaded; if /info is absent (older build), liveness is enough.
+    match client.get(format!("{base}/info")).send().await {
+        Ok(resp) => match resp.json::<serde_json::Value>().await {
+            Ok(body) => match body.get("loaded_at") {
+                Some(v) => !v.is_null(),
+                None => true,
+            },
+            Err(_) => true,
+        },
+        Err(_) => true,
+    }
+}
+
+/// The gate for the whole task-linking + worklog pipeline: BOTH halves must be
+/// working before any session is classified or any worklog drafted — the LLM
+/// classifier loaded AND a PM tracker that has synced tasks. Either side failing
+/// pauses the pipeline; it resumes automatically once both recover, because the
+/// driving loops re-check each cycle and the classification cursor is held while
+/// paused (so the backlog links retroactively rather than being skipped).
+pub async fn pipeline_ready(pool: &SqlitePool, cfg: &Config) -> bool {
+    mlx_ready(cfg).await && pm_tasks_present(pool).await
+}
 
 /// Refreshes PM task caches from all configured providers.
 #[tracing::instrument(skip_all)]

--- a/src/intelligence/task_linker/mod.rs
+++ b/src/intelligence/task_linker/mod.rs
@@ -343,6 +343,24 @@ pub async fn run_task_linking(pool: &SqlitePool, cfg: &Config) -> Result<TaskLin
         return Ok(TaskLinkOutcome::Classified);
     }
 
+    // Gate: a classifiable session reaches the LLM only when the whole pipeline
+    // is WORKING — the MLX classifier loaded AND a PM tracker that has synced
+    // tasks. If either is down we pause WITHOUT advancing the cursor, so this
+    // session (and any that accumulate behind it) is classified retroactively the
+    // moment both recover, rather than being skipped. Placed after the trivial/
+    // short prefilter so those local no-LLM paths still run while paused. Trivial
+    // sessions never reach here (BATCH_LIMIT = 1 → this batch is one classifiable
+    // session), so the held cursor cannot strand a sibling.
+    if !super::pipeline_ready(pool, cfg).await {
+        span.record("outcome", "paused_not_ready");
+        info!(
+            "task linking paused — the MLX classifier and a synced PM tracker must \
+             both be working; the backlog will drain automatically once they are"
+        );
+        complete_agent_run(pool, run_id, "success", trivial_count, trivial_count).await?;
+        return Ok(TaskLinkOutcome::NoPendingWork);
+    }
+
     // Refresh the PM task cache before classifying so the candidate ticket list
     // the classifier matches against is current. Gated by SYNC_INTERVAL_MINS, so
     // the one-session-per-tick drain loop does not fetch Jira per session. A

--- a/src/pm_worklog/scheduler.rs
+++ b/src/pm_worklog/scheduler.rs
@@ -202,8 +202,21 @@ enum Scope {
 /// first (gated — a no-op within the sync window).
 async fn run_pass(pool: &SqlitePool, cfg: &PmWorklogConfig, scope: Scope) {
     let config = Config::from_env();
+    // Sync first so a newly-configured tracker populates pm_tasks and the gate
+    // below can open without a daemon restart (run_pm_sync is interval-gated).
     if let Err(e) = crate::intelligence::run_pm_sync(pool, &config).await {
         tracing::warn!(error = %e, "pm_tasks refresh before worklog pass failed — using cached tasks");
+    }
+
+    // Gate: only draft worklogs when the whole pipeline is WORKING — the MLX
+    // synthesiser loaded AND a PM tracker that has synced tasks. With no tracker
+    // there is nothing to draft against; with the LLM down every /synthesise call
+    // would just 500. Skipping leaves the day pending — the next pass retries.
+    if !crate::intelligence::pipeline_ready(pool, &config).await {
+        tracing::debug!(
+            "pm-worklog pass skipped — the MLX synthesiser and a synced PM tracker must both be working"
+        );
+        return;
     }
 
     let today = Local::now().date_naive();

--- a/tests/task_linker_smoke.rs
+++ b/tests/task_linker_smoke.rs
@@ -247,6 +247,53 @@ async fn real_classification_does_not_reprocess_classified_session() {
     );
 }
 
+/// A classifiable session must NOT be classified while the pipeline is paused —
+/// i.e. when no PM tracker has synced tasks (and/or the MLX server is down). The
+/// cursor must stay put so the session links retroactively once both work. Runs
+/// in CI without an MLX server: no pm_tasks are seeded, so the readiness gate
+/// trips regardless of whether a classifier is reachable.
+#[tokio::test]
+#[serial]
+async fn classifiable_session_paused_until_pipeline_ready() {
+    let (_tmp, pool, db_path) = make_file_db().await;
+
+    // A real, classifiable session (non-empty text, over the duration floor).
+    let id = seed_session(
+        &pool,
+        "Cursor",
+        120,
+        "Editing src/etl/runner.rs — gap detection across ETL run boundaries.",
+    )
+    .await;
+
+    // No pm_tasks seeded → pm_tasks_present() is false → pipeline is paused.
+    let cfg = make_cfg(&db_path);
+    run_task_linking(&pool, &cfg).await.unwrap();
+
+    // Session must remain unclassified (task_method still NULL).
+    let method: Option<String> =
+        sqlx::query_scalar("SELECT task_method FROM app_sessions WHERE id = ?")
+            .bind(id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        method.is_none(),
+        "session must not be classified while the pipeline is paused"
+    );
+
+    // Cursor must NOT have advanced past the paused session — it drains later.
+    let cursor: Option<(i64,)> =
+        sqlx::query_as("SELECT last_session_id FROM agent_cursor WHERE id = 1")
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+    assert!(
+        cursor.map(|c| c.0).unwrap_or(0) < id,
+        "cursor must not advance past a session held by the readiness gate"
+    );
+}
+
 /// A session below the minimum duration threshold is not sent to the MLX server.
 /// This does not require the server — verifies the prefilter without any LLM.
 #[tokio::test]


### PR DESCRIPTION
Task classification and worklog drafting now run only when BOTH halves of the pipeline actually WORK (not merely configured):

  * the MLX classifier is reachable and the model is loaded (positive /health
    + /info readiness probe, short timeout — never the 120s startup wait), and
  * a PM tracker has synced tasks (pm_tasks count > 0 — rows only land there after a provider authenticates and fetches, so bad creds keep it paused).

When either side is down the pipeline pauses. In run_task_linking the gate sits after the trivial/short prefilter and BEFORE the LLM call, returning without advancing the cursor — so a classifiable session (and any that accumulate behind it) is classified retroactively the moment both recover, rather than being skipped. BATCH_LIMIT = 1 guarantees the held cursor never strands a sibling. The worklog driver skips its draft pass under the same gate (after the task sync, so a newly-configured tracker still populates pm_tasks and the gate self-opens without a restart).

Note: because the MLX classifier sets `category` and `task_key` in one call, pausing classification also pauses session categorization — while paused, the activity timeline shows uncategorized sessions until both halves work, then they categorize retroactively.

Adds a CI test: a classifiable session with no synced tasks stays unclassified with the cursor held. All 176 lib tests + integration suites pass.