### PR TITLE
fix(setup): ship agno in the venv so /synthesise_worklog stops 500ing

### DIFF
--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -319,10 +319,14 @@ if [[ -f "${VENV_TARBALL}" ]]; then
     fi
 else
     # Dev / source install — no pre-built tarball. Resolve from uv.lock.
-    info "Installing Python + MLX deps (mlx-lm/outlines/fastapi; first run may download a few hundred MB)…"
+    # Both extras: mlx (classifier + server) AND pm_worklog_update (agno) — the
+    # one MLX server process serves /classify_sessions AND /synthesise_worklog,
+    # so the venv needs agno or worklog synthesis 500s with ModuleNotFoundError.
+    info "Installing Python + MLX deps (mlx-lm/outlines/fastapi/agno; first run may download a few hundred MB)…"
     if "${UV_BIN}" sync \
             --project "${APP_ROOT}/services" \
             --extra mlx \
+            --extra pm_worklog_update \
             --frozen \
             --python "${PYTHON_BIN}"; then
         ok "Python services ready ($(${VENV}/bin/python --version 2>&1))"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -63,15 +63,18 @@ tar cf - \
   -C services . | tar xf - -C "${DEST}/services"
 
 echo "→ Python venv (pre-built site-packages)"
-# Only rebuild and ship the venv tarball when services/uv.lock has changed since
-# the previous git tag. Shipping it on every release forces all users to download
-# ~160 MB even when only the Rust binary or UI changed. When uv.lock is unchanged
-# the installer falls back to `uv sync --frozen` which is a 3ms no-op from the
-# warm uv cache on updates, and downloads from PyPI only on a fresh machine.
+# Only rebuild and ship the venv tarball when the venv's contents could have
+# changed since the previous git tag — i.e. when services/uv.lock OR this script
+# changed. The extras installed (--extra mlx --extra pm_worklog_update) live in
+# THIS script, so a change to which extras ship must force a rebuild even when
+# uv.lock is untouched — otherwise an extras fix would ship a stale tarball.
+# Shipping on every release would force all users to download ~160 MB even when
+# only the Rust binary or UI changed; when neither input changed the installer
+# falls back to `uv sync --frozen` (a no-op from the warm uv cache on updates).
 _prev_tag="$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)"
 _lock_changed=1
 if [[ -n "${_prev_tag}" ]]; then
-    if git diff --quiet "${_prev_tag}" HEAD -- services/uv.lock 2>/dev/null; then
+    if git diff --quiet "${_prev_tag}" HEAD -- services/uv.lock scripts/package-release.sh 2>/dev/null; then
         _lock_changed=0
     fi
 fi
@@ -83,7 +86,10 @@ if [[ "${_lock_changed}" -eq 1 ]]; then
     command -v uv >/dev/null 2>&1 || brew install uv
     # Pin Python 3.11: macos-26 defaults to Python 3.14 which produces
     # cpython-314-darwin.so that Python 3.11 on user machines cannot load.
-    uv sync --project services --extra mlx --frozen --python 3.11
+    # Both extras: mlx (classifier) AND pm_worklog_update (agno) — the shipped
+    # MLX server serves /synthesise_worklog too, which imports agno; without it
+    # worklog synthesis 500s with ModuleNotFoundError on every install.
+    uv sync --project services --extra mlx --extra pm_worklog_update --frozen --python 3.11
     # Validate the venv is actually Python 3.11.
     _py_dir="$(ls -d services/.venv/lib/python* 2>/dev/null | head -1 | xargs basename 2>/dev/null || true)"
     if [[ -z "${_py_dir}" ]]; then

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -53,7 +53,9 @@ meridian-server = "agents.server:main"
 
 [tool.uv]
 # Lock all extras so `uv lock` produces a complete, reproducible uv.lock.
-# install-from-bundle.sh installs the mlx extra via `uv sync --extra mlx --frozen`.
+# The shipped venv installs BOTH server-side extras — `uv sync --extra mlx
+# --extra pm_worklog_update` — because the one MLX server serves
+# /classify_sessions (mlx) AND /synthesise_worklog (agno, pm_worklog_update).
 constraint-dependencies = []
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Symptom

Every drafted worklog failed in the daemon log:
```
WARN meridian::pm_worklog::scheduler: worklog cycle errored
  task=KAN-142 error=/synthesise_worklog returned 500 Internal Server Error
```

## Root cause (packaging, not synth logic)

The MLX server serves **`/synthesise_worklog`** (worklog drafting) in the *same* process as `/classify_sessions`. That endpoint imports `agno`:
```
ModuleNotFoundError: No module named 'agno'
  File ".../services/agents/server.py", line 595, in synthesise_worklog
```
`agno` lives in the **`pm_worklog_update`** extra, but the venv was built with **`--extra mlx`** only — in both `package-release.sh` (the prebuilt tarball) and `install-from-bundle.sh` (the dev/source fallback). So the shipped venv never had agno, and worklog synthesis 500'd on every install.

This is **not** the same as the readiness gate (#146) — these 500s fired for tasks that already exist; the tracker was working. Pure missing-dependency.

## Fix

Build the venv with **both** server-side extras wherever it's built:
- `package-release.sh` → `uv sync --extra mlx --extra pm_worklog_update`
- `install-from-bundle.sh` (fallback) → same

`agno` was already in `uv.lock`, so the "rebuild the tarball only when `uv.lock` changed" guard would **not** have shipped a fresh tarball for this fix (stale tarball, still no agno). Extended that guard to also rebuild when `package-release.sh` changes — the `--extra` flags live there, so a change to *which* extras ship now forces a rebuild. The no-redundant-download optimization still holds for releases that touch neither input.

## Verification

- `uv sync --extra mlx --extra pm_worklog_update --frozen --python 3.11` installs **agno 2.6.10**.
- The endpoint's full import chain resolves: `from agents.pm_worklog_update import workflow` + `.models import JiraUpdate, SessionBundle`.
- Both scripts pass `bash -n`.

## Immediate fix for an already-installed machine

```bash
uv pip install --python ~/.meridian/app/services/.venv/bin/python "agno>=2.6,<3" "sqlalchemy>=2.0,<3" "aiosqlite>=0.20,<1"
meridian restart
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)