### PR TITLE
fix(hooks): fix claude hook idempotency and add coding-agent CLI passthrough

### DIFF
--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -483,7 +483,7 @@ case "$CMD" in
     uninstall)        cmd_uninstall ;;
     permissions)      cmd_permissions ;;
     version|--version|-v) cat "${REPO_ROOT}/VERSION" 2>/dev/null || echo "unknown" ;;
-    worklog-status|pm-worklog) cmd_daemon_passthrough "$CMD" "$@" ;;
+    worklog-status|pm-worklog|coding-agent-hook|coding-agent-summarise|coding-agent-classify) cmd_daemon_passthrough "$CMD" "$@" ;;
     --help|-h|help|"") cmd_help ;;
     *) err "unknown command: ${CMD}"; echo; cmd_help; exit 1 ;;
 esac

--- a/services/scripts/install-claude-hook.sh
+++ b/services/scripts/install-claude-hook.sh
@@ -66,36 +66,32 @@ with open(settings_path) as f:
 hooks = settings.setdefault("hooks", {})
 session_end = hooks.setdefault("SessionEnd", [])
 
-# SessionEnd doesn't support `matcher` — each entry is just a list of
-# hooks. We use an unmatched group whose first command carries our
-# marker as a comment so we can find + replace it later.
 new_entry = {
     "hooks": [
         {
             "type":    "command",
             "command": hook_cmd,
-            # Claude Code reads `timeout` in milliseconds (matching the
-            # existing entries already in this settings.json). 30s ceiling
+            # Claude Code reads `timeout` in milliseconds. 30s ceiling
             # — the hook itself returns in <100 ms.
             "timeout": 30000,
-            # Comment field that Claude Code preserves but doesn't act on
-            # — gives us a robust idempotency / uninstall handle.
-            "_meridian": marker,
         }
     ]
 }
 
-# Replace any prior meridian entry, leave all others untouched.
+# Replace any prior meridian entry by matching on the command substring
+# "coding-agent-hook". Claude Code strips unknown JSON fields (like the
+# former "_meridian" marker) on every save, so command-string matching
+# is the only reliable idempotency mechanism.
 filtered = []
 removed = 0
 for group in session_end:
-    is_ours = False
-    for h in group.get("hooks", []):
-        if h.get("_meridian") == marker:
-            is_ours = True
-            removed += 1
-            break
-    if not is_ours:
+    is_ours = any(
+        "coding-agent-hook" in h.get("command", "")
+        for h in group.get("hooks", [])
+    )
+    if is_ours:
+        removed += 1
+    else:
         filtered.append(group)
 
 filtered.append(new_entry)


### PR DESCRIPTION
## Summary

- **`install-claude-hook.sh`**: replace `_meridian` JSON field idempotency check with command-string matching (`"coding-agent-hook" in command`). Claude Code was stripping unknown JSON fields on every `settings.json` save, so each re-run of the install script couldn't find the prior entry and appended a new one — leaving up to 5 duplicate/broken hook entries.
- **`meridian-cli.sh`**: add `coding-agent-hook|coding-agent-summarise|coding-agent-classify` to the `cmd_daemon_passthrough` case so `meridian coding-agent-hook` works via `~/.local/bin/meridian` (the CLI wrapper), not just the raw daemon binary path.

## Background

`~/.claude/settings.json` had accumulated 5 `SessionEnd` entries for `coding-agent-hook`:
- 2 working (both pointing to `target/release/meridian` — duplicate)
- 1 dead (`/usr/local/bin/meridian` — binary doesn't exist)
- 2 broken (`~/.npm-global/bin/meridian` — Node.js shim that hit the `unknown command` fallthrough in `meridian-cli.sh`)

The settings were cleaned up manually; this PR prevents re-accumulation.

## Test plan
- [ ] Run `./services/scripts/install-claude-hook.sh` twice; verify `settings.json` has exactly one `coding-agent-hook` entry after both runs
- [ ] `meridian coding-agent-hook` (via the CLI wrapper) no longer returns "unknown command"

🤖 Generated with [Claude Code](https://claude.com/claude-code)