### PR TITLE
fix(hooks): fix uninstall-claude-hook.sh idempotency detection

### DIFF
--- a/services/scripts/uninstall-claude-hook.sh
+++ b/services/scripts/uninstall-claude-hook.sh
@@ -25,13 +25,13 @@ session_end = settings.get("hooks", {}).get("SessionEnd", []) or []
 filtered = []
 removed = 0
 for group in session_end:
-    is_ours = False
-    for h in group.get("hooks", []):
-        if h.get("_meridian") == marker:
-            is_ours = True
-            removed += 1
-            break
-    if not is_ours:
+    is_ours = any(
+        "coding-agent-hook" in h.get("command", "")
+        for h in group.get("hooks", [])
+    )
+    if is_ours:
+        removed += 1
+    else:
         filtered.append(group)
 
 if removed == 0:


### PR DESCRIPTION
## Summary

- Fixes the same `_meridian` JSON field detection bug in `uninstall-claude-hook.sh` that was fixed in `install-claude-hook.sh` in #150.
- Claude Code strips unknown JSON fields on every `settings.json` save, so the `_meridian` marker was never present at uninstall time — the uninstall script would silently find nothing and leave the hook entry in place.
- Fix: match by command substring (`"coding-agent-hook" in command`) instead of the stripped field.

## Test plan
- [ ] Install the hook, then run `./services/scripts/uninstall-claude-hook.sh` — verify the entry is removed from `~/.claude/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)