### PR TITLE
fix(intelligence): install apple-fm-sdk in npm bundle path on macOS 26+

### DIFF
--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -335,6 +335,25 @@ else
     fi
 fi
 
+# On macOS 26+, install apple-fm-sdk so Apple Intelligence is used instead of
+# downloading a large MLX model. This runs after both venv paths (tarball or uv
+# sync) so the package is available regardless of how the venv was built.
+# apple-fm-sdk only installs on macOS 26+ (links against system frameworks);
+# on older macOS pip will fail gracefully and MLX is used as the fallback.
+_macos_major="$(sw_vers -productVersion 2>/dev/null | cut -d. -f1)"
+if [[ "${_macos_major:-0}" -ge 26 ]]; then
+    if "${VENV}/bin/python" -c "import apple_fm_sdk" 2>/dev/null; then
+        ok "apple-fm-sdk already installed — Apple Intelligence will be used"
+    else
+        info "macOS ${_macos_major} detected — installing apple-fm-sdk for Apple Intelligence (no MLX model download needed)…"
+        if "${VENV}/bin/pip" install --quiet "apple-fm-sdk" 2>/dev/null; then
+            ok "apple-fm-sdk installed — Apple Intelligence will be used"
+        else
+            warn "apple-fm-sdk install failed — MLX model download will be used instead"
+        fi
+    fi
+fi
+
 # ── 5. macOS permissions for screenpipe (manual — can't be automated) ────────
 if [[ "${SKIP_PERMISSIONS}" -eq 0 ]]; then
     echo "→ screenpipe needs 2 macOS permissions: Screen Recording and Accessibility."


### PR DESCRIPTION
## Summary

- On macOS 26+, `meridian setup` was loading a full MLX model (~6 GB) instead of using Apple Intelligence
- Root cause: `apple-fm-sdk` was never installed in the pre-built venv tarball (it's not in `pyproject.toml`), so `_apple_intelligence_available()` failed its `import apple_fm_sdk` check and fell back to MLX
- Fix: after the venv is ready (both the tarball-extract and `uv sync` paths in `install-from-bundle.sh`), pip install `apple-fm-sdk` on macOS 26+ — idempotent, skips if already present, warns gracefully on failure and falls back to MLX

## Test plan

- [ ] On macOS 26+: `meridian setup` or `meridian update` → shows `✓ apple-fm-sdk installed` (or `already installed`) → `meridian logs mlx-server -f` shows `source=apple_fm` not `source=mlx`
- [ ] On macOS 15.x: step is skipped entirely, MLX path unchanged
- [ ] Re-run `meridian update` on macOS 26+: shows `already installed` (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)