### PR TITLE
fix(uninstall): clean up OpenObserve + legacy crash-looping agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,17 @@ sqlite3 ~/.meridian/meridian.db \
 |---|---|
 | `services/scripts/install-mlx-server-daemon.sh` | Install the MLX server as a launchd daemon (KeepAlive, auto-restart). |
 | `services/scripts/uninstall-mlx-server-daemon.sh` | Stop and remove the MLX server daemon. |
+| `scripts/install-openobserve-daemon.sh` | Install the OpenObserve trace backend as a launchd daemon (source-checkout / observability only). |
+| `scripts/uninstall-openobserve-daemon.sh` | Stop and remove the OpenObserve daemon (run by `meridian uninstall`; trace data at `~/.openobserve/data/` is preserved). |
 | `scripts/refresh_pm_tasks.py` | Force-refresh `pm_tasks` from Jira without restarting the daemon. |
 | `scripts/setup-hooks.sh` | Install git hooks (fmt + clippy pre-commit, full suite pre-push). |
 
 ```bash
 # Install MLX server as a background daemon
 bash services/scripts/install-mlx-server-daemon.sh [--port 7823]
+
+# Install / restart the OpenObserve trace backend (source checkout)
+bash scripts/install-openobserve-daemon.sh
 
 # MLX server logs
 tail -f ~/.meridian/logs/mlx-server.log

--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -299,6 +299,7 @@ cmd_uninstall() {
     bash "${REPO_ROOT}/services/scripts/uninstall-mlx-server-daemon.sh" 2>/dev/null
     bash "${REPO_ROOT}/scripts/uninstall-daemon.sh" 2>/dev/null
     bash "${REPO_ROOT}/scripts/uninstall-screenpipe-daemon.sh" 2>/dev/null
+    bash "${REPO_ROOT}/scripts/uninstall-openobserve-daemon.sh" 2>/dev/null
     pkill -f "mlx_lm.server" 2>/dev/null || true
     rm -f /usr/local/bin/meridian /usr/local/bin/meridian-daemon \
           "${HOME}/.local/bin/meridian" "${HOME}/.local/bin/meridian-daemon"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -112,6 +112,7 @@ cp scripts/meridian-cli.sh scripts/install-from-bundle.sh scripts/meridian-npm-s
 cp scripts/install-daemon.sh scripts/uninstall-daemon.sh \
    scripts/install-ui-daemon.sh scripts/uninstall-ui-daemon.sh \
    scripts/install-screenpipe-daemon.sh scripts/uninstall-screenpipe-daemon.sh \
+   scripts/uninstall-openobserve-daemon.sh \
    scripts/com.meridiona.daemon.plist scripts/com.meridiona.screenpipe.plist \
    scripts/com.meridiona.ui.plist "${DEST}/scripts/" 2>/dev/null || true
 

--- a/scripts/uninstall-daemon.sh
+++ b/scripts/uninstall-daemon.sh
@@ -17,3 +17,19 @@ if [[ -f "${PLIST}" ]]; then
 else
     echo "(not installed) ${PLIST}"
 fi
+
+# Legacy agents: the Jira updater and coding-agent indexer used to run as their
+# own standalone Python launchd daemons. They were ported into this Rust daemon
+# (the Python modules were deleted), but a pre-port install leaves the old
+# KeepAlive agents behind — they then crash-loop every ~10s against the missing
+# modules and spam ~MB/min into their logs. Boot out + disable + remove them so
+# an upgrade-then-uninstall leaves nothing orphaned.
+for legacy in com.meridiona.jira-updater com.meridiona.coding-agent-indexer; do
+    legacy_plist="${HOME}/Library/LaunchAgents/${legacy}.plist"
+    if launchctl print "${GUI_TARGET}/${legacy}" >/dev/null 2>&1; then
+        launchctl disable "${GUI_TARGET}/${legacy}" 2>/dev/null || true
+        launchctl bootout "${GUI_TARGET}/${legacy}" 2>/dev/null || true
+        echo "✓ removed legacy agent ${legacy}"
+    fi
+    rm -f "${legacy_plist}"
+done


### PR DESCRIPTION
## Problem

`meridian uninstall` (`cmd_uninstall` in `scripts/meridian-cli.sh`) only tore down the four *currently-managed* launchd agents (screenpipe, daemon, ui, mlx-server). It left two classes of agent orphaned:

1. **OpenObserve** (`com.meridiona.openobserve`) — kept running after uninstall (process still listening on port 5080, plist left in `~/Library/LaunchAgents/`).
2. **Legacy Python agents** (`com.meridiona.jira-updater`, `com.meridiona.coding-agent-indexer`) — these used to run as standalone Python daemons, then were **ported into the Rust daemon and their Python modules deleted**. A pre-port install leaves the old `KeepAlive` agents behind; they then **crash-loop every ~10s** against the missing modules (`ModuleNotFoundError`) and spam ~MB/min into their logs (found one machine with 11 MB + 9 MB of pure crash spam).

Both were found while auditing running Meridian services on a dev machine.

## Fix

- **`scripts/meridian-cli.sh`** — `cmd_uninstall` now also calls `scripts/uninstall-openobserve-daemon.sh`.
- **`scripts/uninstall-daemon.sh`** — boots out, disables, and removes the legacy `jira-updater` / `coding-agent-indexer` plists (the daemon's uninstaller is the natural home, since both jobs now live inside the Rust daemon). Idempotent — no-ops when the agents aren't present.
- **`scripts/package-release.sh`** — ship `uninstall-openobserve-daemon.sh` in the release bundle's `scripts/` copy-list, so npm-installed users have the script the new line invokes (otherwise it would silently no-op on the `2>/dev/null`).
- **`README.md`** — document the OpenObserve install/uninstall scripts, with a `bash scripts/install-openobserve-daemon.sh` example to bring the trace backend back after uninstall.

All uninstall scripts are idempotent and preserve data: OpenObserve trace data at `~/.openobserve/data/` is left intact.

## Verification

On a machine where all three orphans were live:

- ✓ OpenObserve: agent unloaded, plist removed, port 5080 freed, no process, `~/.openobserve/data/` preserved
- ✓ Legacy agents: both booted out + `disable`d (persists across reboot), plists removed, no Python processes, ~20 MB of crash-loop logs reclaimed
- ✓ `uninstall-daemon.sh` re-run on a clean machine exits 0 (legacy block no-ops)
- ✓ All touched shell scripts pass `bash -n`

## Notes / out of scope

OpenObserve is still **not installed** by the npm flow and is absent from the `LABELS` array used by `start`/`stop`/`status` — it stays dev-only observability; this PR only cleans it up on uninstall and documents reinstall. A follow-up could extend `meridian doctor` to warn on any `com.meridiona.*` agent not in the managed `LABELS` set — that would have surfaced these orphans immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)