### PR TITLE
fix(intelligence): use uv pip instead of pip binary for apple-fm-sdk install

### DIFF
--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -346,7 +346,7 @@ if [[ "${_macos_major:-0}" -ge 26 ]]; then
         ok "apple-fm-sdk already installed — Apple Intelligence will be used"
     else
         info "macOS ${_macos_major} detected — installing apple-fm-sdk for Apple Intelligence (no MLX model download needed)…"
-        if "${VENV}/bin/pip" install --quiet "apple-fm-sdk" 2>/dev/null; then
+        if "${UV_BIN}" pip install --python "${VENV}/bin/python" --quiet "apple-fm-sdk" 2>/dev/null; then
             ok "apple-fm-sdk installed — Apple Intelligence will be used"
         else
             warn "apple-fm-sdk install failed — MLX model download will be used instead"

--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -335,6 +335,25 @@ else
     fi
 fi
 
+# On macOS 26+, install apple-fm-sdk so Apple Intelligence is used instead of
+# downloading a large MLX model. This runs after both venv paths (tarball or uv
+# sync) so the package is available regardless of how the venv was built.
+# apple-fm-sdk only installs on macOS 26+ (links against system frameworks);
+# on older macOS pip will fail gracefully and MLX is used as the fallback.
+_macos_major="$(sw_vers -productVersion 2>/dev/null | cut -d. -f1)"
+if [[ "${_macos_major:-0}" -ge 26 ]]; then
+    if "${VENV}/bin/python" -c "import apple_fm_sdk" 2>/dev/null; then
+        ok "apple-fm-sdk already installed — Apple Intelligence will be used"
+    else
+        info "macOS ${_macos_major} detected — installing apple-fm-sdk for Apple Intelligence (no MLX model download needed)…"
+        if "${VENV}/bin/pip" install --quiet "apple-fm-sdk" 2>/dev/null; then
+            ok "apple-fm-sdk installed — Apple Intelligence will be used"
+        else
+            warn "apple-fm-sdk install failed — MLX model download will be used instead"
+        fi
+    fi
+fi
+
 # ── 5. macOS permissions for screenpipe (manual — can't be automated) ────────
 if [[ "${SKIP_PERMISSIONS}" -eq 0 ]]; then
     echo "→ screenpipe needs 2 macOS permissions: Screen Recording and Accessibility."

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -98,6 +98,15 @@ if [[ "${_lock_changed}" -eq 1 ]]; then
     if [[ "${_py_dir}" != "python3.11" ]]; then
         echo "✗ venv was built with ${_py_dir} but must be python3.11" >&2; exit 1
     fi
+    # On macOS 26+, install apple-fm-sdk into the venv so end users get Apple
+    # Intelligence without needing Xcode. The CI runner (macos-26) has Xcode;
+    # the package is source-only (no PyPI wheels) so must be compiled here.
+    _pkg_macos_major="$(sw_vers -productVersion 2>/dev/null | cut -d. -f1)"
+    if [[ "${_pkg_macos_major:-0}" -ge 26 ]]; then
+        echo "  macOS ${_pkg_macos_major}: compiling apple-fm-sdk for Apple Intelligence…"
+        uv pip install --python "services/.venv/bin/python" "apple-fm-sdk"
+        echo "  · apple-fm-sdk compiled and included in bundle"
+    fi
     tar -czf "${DEST}/services-venv.tar.gz" \
         -C "services/.venv/lib/${_py_dir}/site-packages" .
     echo "  · $(du -sh "${DEST}/services-venv.tar.gz" | cut -f1) compressed — included in bundle"


### PR DESCRIPTION
## Summary

- Follow-up to #157: the apple-fm-sdk install step used `${VENV}/bin/pip` but the venv is built with `uv venv` which does not include a `pip` binary
- This caused the install to fail with "no such file" on every macOS 26+ install, silently falling back to MLX
- Fix: use `uv pip install --python ${VENV}/bin/python` which works correctly for uv-managed venvs

## Test plan

- [ ] On macOS 26+: `meridian update` shows `✓ apple-fm-sdk installed` (not `⚠ install failed`)
- [ ] `meridian logs mlx-server -f` shows `source=apple_fm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)