### PR TITLE
fix(intelligence): enforce Python 3.11 venv when extracting pre-built tarball

### DIFF
--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -304,9 +304,21 @@ if [[ -f "${VENV_TARBALL}" ]]; then
     else
         info "Extracting pre-built Python venv ($(du -sh "${VENV_TARBALL}" | cut -f1) — no PyPI download required)…"
         rm -rf "${VENV}"
-        # Create a fresh venv with correct local paths (pyvenv.cfg points to
-        # PYTHON_BIN, which install-mlx-server-daemon.sh reads for BASE_PYTHON).
-        "${UV_BIN}" venv --python "${PYTHON_BIN}" "${VENV}" 2>/dev/null
+        # The tarball is compiled for Python 3.11 (package-release.sh enforces this).
+        # The venv MUST use exactly Python 3.11 or compiled extensions (.so files with
+        # cpython-311 ABI tags) will fail to import on any other interpreter version.
+        # Prefer the system python3.11, then uv-managed 3.11, then install it via uv.
+        _tarball_python=""
+        if command -v python3.11 >/dev/null 2>&1; then
+            _tarball_python="$(command -v python3.11)"
+        elif "${UV_BIN}" python find 3.11 >/dev/null 2>&1; then
+            _tarball_python="$("${UV_BIN}" python find 3.11)"
+        else
+            info "Installing Python 3.11 (pre-built venv requires it — one-time download)…"
+            "${UV_BIN}" python install 3.11
+            _tarball_python="$("${UV_BIN}" python find 3.11)"
+        fi
+        "${UV_BIN}" venv --python "${_tarball_python}" "${VENV}" 2>/dev/null
         # Determine the Python version subdirectory (e.g. python3.11).
         _py_dir="$(ls "${VENV}/lib/" | grep '^python' | head -1)"
         mkdir -p "${VENV}/lib/${_py_dir}/site-packages"


### PR DESCRIPTION
## Summary

- The venv tarball is compiled for Python 3.11 (CI enforces this). Extracting it into a Python 3.13 venv causes all compiled extensions (pydantic_core, mlx, apple_fm_sdk) to fail with `ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'` — the `.so` files have cpython-311 ABI tags and can't load in Python 3.13.
- Fix: in the tarball extraction path, always use Python 3.11 — prefer system python3.11, then uv-managed 3.11, then auto-install via `uv python install 3.11`. The dev/uv-sync path is unaffected (builds extensions from source with the active Python version).

## Test plan

- [ ] Machine without python3.11: `meridian update` → installs Python 3.11 via uv → extracts tarball → server starts
- [ ] Machine with python3.11: `meridian update` → uses existing python3.11 → no download
- [ ] Server starts with `source=apple_fm` on macOS 26+

🤖 Generated with [Claude Code](https://claude.com/claude-code)