### PR TITLE
fix(intelligence): always ship venv tarball on macOS 26+ to preserve apple-fm-sdk

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -79,6 +79,16 @@ if [[ -n "${_prev_tag}" ]]; then
     fi
 fi
 
+# On macOS 26+, always ship the tarball regardless of lock changes.
+# apple-fm-sdk (Apple Intelligence) is source-only on PyPI — it can only be
+# compiled here (CI has full Xcode). If we skip the tarball, the installer falls
+# back to `uv sync --frozen` which removes apple-fm-sdk (not in the lockfile),
+# breaking Apple Intelligence for every update where only non-Python files changed.
+_ci_macos_major="$(sw_vers -productVersion 2>/dev/null | cut -d. -f1)"
+if [[ "${_ci_macos_major:-0}" -ge 26 ]]; then
+    _lock_changed=1
+fi
+
 if [[ "${_lock_changed}" -eq 1 ]]; then
     echo "  uv.lock changed since ${_prev_tag:-beginning} — building and shipping venv tarball (~160 MB)"
     # uv must be available on the CI runner. pip3 install is blocked on macOS 26


### PR DESCRIPTION
## Summary

- **Root cause**: When only non-Python files change between releases (e.g. installer scripts, Rust daemon, UI), `package-release.sh` skips building `services-venv.tar.gz`. The installer then falls back to `uv sync --frozen`, which removes packages not in `uv.lock` — including `apple-fm-sdk`. The post-sync reinstall of `apple-fm-sdk` silently fails on user machines (source-only PyPI package, requires full Xcode to compile). Result: Apple Intelligence breaks and MLX loads instead.
- **Fix**: Force `_lock_changed=1` on macOS 26+ CI so `services-venv.tar.gz` is rebuilt and shipped in every release, always containing the pre-compiled `apple-fm-sdk`. The tradeoff is a ~160 MB download on every `meridian update` for macOS 26 users, but those users already benefit from Apple Intelligence (no 4+ GB MLX model), making this acceptable.

## Test plan

- [ ] After this merges and releases, `meridian update` on the M1 Air should print `✓ apple-fm-sdk already installed — Apple Intelligence will be used` and the MLX server should show `resolved MLX model=apple-intelligence`
- [ ] On a release where only the Rust daemon changes, the tarball is still shipped and apple-fm-sdk is present after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)