### PR TITLE
perf(release): conditional UI tarball — skip ~10 MB download when dashboard unchanged

### DIFF
--- a/npm/meridian/bin/meridian.js
+++ b/npm/meridian/bin/meridian.js
@@ -92,7 +92,7 @@ if (cmd === 'setup' || cmd === 'install') {
     // NEW launcher on disk. Re-exec the newly installed launcher so step 2 always
     // uses the latest code, even when invoked by an old launcher.
     console.log('meridian update: downloading latest release…');
-    console.log('  The package includes a pre-built Python venv (~160 MB) — expect ~1-3 min.');
+    console.log('  Size varies: ~5 MB (binary-only) → ~165 MB (Python deps changed). May take 1-3 min if large.');
     const _start = Date.now();
     const up = spawnSync('npm', ['install', '-g', '@meridiona/meridian@latest'], { stdio: 'inherit' });
     if (up.status) process.exit(up.status);

--- a/scripts/meridian-npm-setup.sh
+++ b/scripts/meridian-npm-setup.sh
@@ -36,10 +36,16 @@ if [[ -d "${APP}/services/.venv" ]]; then mv "${APP}/services/.venv" "${venv_kee
 _hash_file="${HOME}/.meridian/.component-hashes"
 _ui_keep="${HOME}/.meridian/.ui-update-keep"
 rm -rf "${_ui_keep}"
-if [[ -f "${BUNDLE}/ui.tar.gz" ]] && [[ -d "${APP}/ui" ]] && [[ -f "${_hash_file}" ]]; then
-    _old_ui_hash="$(grep '^ui_tarball=' "${_hash_file}" 2>/dev/null | cut -d= -f2 || true)"
-    _new_ui_hash="$(shasum -a 256 "${BUNDLE}/ui.tar.gz" | cut -d' ' -f1)"
-    if [[ -n "${_old_ui_hash}" && "${_new_ui_hash}" == "${_old_ui_hash}" ]]; then
+if [[ -d "${APP}/ui" ]]; then
+    if [[ -f "${BUNDLE}/ui.tar.gz" ]] && [[ -f "${_hash_file}" ]]; then
+        # Tarball present: preserve existing ui/ only when hash matches (unchanged build).
+        _old_ui_hash="$(grep '^ui_tarball=' "${_hash_file}" 2>/dev/null | cut -d= -f2 || true)"
+        _new_ui_hash="$(shasum -a 256 "${BUNDLE}/ui.tar.gz" | cut -d' ' -f1)"
+        if [[ -n "${_old_ui_hash}" && "${_new_ui_hash}" == "${_old_ui_hash}" ]]; then
+            mv "${APP}/ui" "${_ui_keep}"
+        fi
+    elif [[ ! -f "${BUNDLE}/ui.tar.gz" ]]; then
+        # No tarball in bundle = UI unchanged since last release; keep existing build.
         mv "${APP}/ui" "${_ui_keep}"
     fi
 fi

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -27,31 +27,45 @@ UI_STANDALONE="ui/.next/standalone"
 DEST="npm/meridian-darwin-arm64"
 echo "→ populating ${DEST} (v${VERSION})"
 rm -rf "${DEST}/bin" "${DEST}/ui" "${DEST}/services" "${DEST}/scripts" "${DEST}/.env.example" "${DEST}/VERSION"
-mkdir -p "${DEST}/bin" "${DEST}/ui" "${DEST}/scripts"
+mkdir -p "${DEST}/bin" "${DEST}/scripts"
+
+# Compute _prev_tag once — used by both the UI and venv conditional-ship logic.
+_prev_tag="$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)"
 
 echo "→ daemon binary"
 cp "${DAEMON_BIN}" "${DEST}/bin/meridian"
 chmod +x "${DEST}/bin/meridian"
 
 echo "→ UI (Next.js standalone, packed as a tarball)"
-# Assemble the runnable standalone tree (server + static + public), then pack it
-# into a single tarball. WHY a tarball and not a plain ui/ dir: the Turbopack
-# production build references serverExternalPackages (better-sqlite3, pino,
-# @opentelemetry/*) via relative SYMLINKS under .next/node_modules. `npm publish`
-# strips symlinks, which crash-loops the standalone server on the user's machine
-# (vercel/next.js#87737, #93849). tar preserves symlinks and npm ships the .tgz
-# as one opaque file, so the exact built tree round-trips intact;
-# install-from-bundle.sh extracts it back into ~/.meridian/app/ui. This is what
-# lets the production build stay on Turbopack despite our npm distribution.
-_ui_stage="${DEST}/ui"
-cp -R "${UI_STANDALONE}/." "${_ui_stage}/"        # cp -R preserves symlinks (BSD/macOS default)
-mkdir -p "${_ui_stage}/.next"
-cp -R "ui/.next/static" "${_ui_stage}/.next/static"
-[[ -d "ui/public" ]] && cp -R "ui/public" "${_ui_stage}/public"
-# Pack (preserving symlinks — no -h) and drop the expanded dir so npm ships only the tarball.
-tar -czf "${DEST}/ui.tar.gz" -C "${_ui_stage}" .
-rm -rf "${_ui_stage}"
-echo "  · ui.tar.gz ($(du -h "${DEST}/ui.tar.gz" | cut -f1), symlinks preserved)"
+# Only rebuild and ship the UI tarball when the dashboard has actually changed
+# since the previous release tag. Most releases change only the Rust binary or
+# Python services; skipping the tarball saves ~10 MB per update download for
+# those users. When absent, meridian-npm-setup.sh preserves the existing ui/ dir
+# and install-from-bundle.sh skips extraction + UI daemon restart entirely.
+# WHY a tarball (not a plain ui/ dir): Turbopack's production build references
+# serverExternalPackages (better-sqlite3, pino, @opentelemetry/*) via relative
+# SYMLINKS under .next/node_modules. npm publish strips symlinks which crash-loops
+# the server (vercel/next.js#87737, #93849); tar preserves them intact.
+_ui_changed=1
+if [[ -n "${_prev_tag}" ]]; then
+    if git diff --quiet "${_prev_tag}" HEAD -- ui/ 2>/dev/null; then
+        _ui_changed=0
+    fi
+fi
+if [[ "${_ui_changed}" -eq 1 ]]; then
+    mkdir -p "${DEST}/ui"
+    _ui_stage="${DEST}/ui"
+    cp -R "${UI_STANDALONE}/." "${_ui_stage}/"        # cp -R preserves symlinks (BSD/macOS default)
+    mkdir -p "${_ui_stage}/.next"
+    cp -R "ui/.next/static" "${_ui_stage}/.next/static"
+    [[ -d "ui/public" ]] && cp -R "ui/public" "${_ui_stage}/public"
+    # Pack (preserving symlinks — no -h) and drop the expanded dir so npm ships only the tarball.
+    tar -czf "${DEST}/ui.tar.gz" -C "${_ui_stage}" .
+    rm -rf "${_ui_stage}"
+    echo "  · ui.tar.gz ($(du -h "${DEST}/ui.tar.gz" | cut -f1), symlinks preserved)"
+else
+    echo "  UI unchanged since ${_prev_tag} — skipping UI tarball (~10 MB saved per update)"
+fi
 
 echo "→ Python services (source + pre-built site-packages)"
 mkdir -p "${DEST}/services"
@@ -71,7 +85,6 @@ echo "→ Python venv (pre-built site-packages)"
 # Shipping on every release would force all users to download ~160 MB even when
 # only the Rust binary or UI changed; when neither input changed the installer
 # falls back to `uv sync --frozen` (a no-op from the warm uv cache on updates).
-_prev_tag="$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)"
 _lock_changed=1
 if [[ -n "${_prev_tag}" ]]; then
     if git diff --quiet "${_prev_tag}" HEAD -- services/uv.lock scripts/package-release.sh 2>/dev/null; then


### PR DESCRIPTION
## Summary

- **`package-release.sh`**: only build and ship `ui.tar.gz` when `ui/` changed since the previous release tag (same pattern as the existing venv tarball gate). Binary-only or Python-only releases no longer include the UI tarball.
- **`meridian-npm-setup.sh`**: preserve existing `ui/` dir when `ui.tar.gz` is absent from the bundle (absent = UI unchanged), in addition to the existing hash-match path. `install-from-bundle.sh` already treats a missing tarball + present `ui/` as `_ui_changed=0` and skips the daemon restart.
- **`meridian.js`**: replace static "~160 MB" warning with an accurate size range so the update message reflects reality for small releases.

## Typical update sizes after this change

| What changed | Before | After |
|---|---|---|
| Binary only | ~15 MB | **~5 MB** |
| UI only | ~10 MB | ~10 MB |
| Python deps | ~165 MB | ~165 MB |

## Test plan

- [ ] Binary-only release: verify `ui.tar.gz` is absent from the npm package; `meridian update` preserves the existing dashboard and skips UI restart
- [ ] UI-changed release: verify `ui.tar.gz` is present and dashboard is updated
- [ ] First install (no `_prev_tag`): `_ui_changed=1` so tarball is always built

🤖 Generated with [Claude Code](https://claude.com/claude-code)