### PR TITLE
fix(ui): bundle Node 22 runtime — permanent fix for better-sqlite3 ABI mismatch

### DIFF
--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -114,7 +114,8 @@ LAUNCH_AGENTS="${HOME}/Library/LaunchAgents"
 install_ui_standalone() {
     local label="com.meridiona.ui"
     local plist="${LAUNCH_AGENTS}/${label}.plist"
-    local node_bin; node_bin="$(command -v node)"
+    local node_bin="${APP_ROOT}/bin/node-runtime"
+    [[ -x "${node_bin}" ]] || { err "bundled node runtime missing — re-install: npm install -g @meridiona/meridian"; return 1; }
     local start_script="${APP_ROOT}/scripts/ui-start.sh"
     chmod +x "${start_script}" 2>/dev/null || true
     mkdir -p "${HOME}/.meridian/logs" "${LAUNCH_AGENTS}"
@@ -425,35 +426,6 @@ elif [[ -d "${APP_ROOT}/ui" ]]; then
     # ui/ was preserved by meridian-npm-setup.sh — hash matched, no re-extraction needed
     ok "dashboard unchanged — reusing existing build"
     _ui_changed=0
-fi
-
-# Re-fetch the correct better-sqlite3 binary when the pre-built addon ABI
-# doesn't match the local Node.js. The Next.js standalone strips source files
-# (binding.gyp is absent), so `npm rebuild` can't compile from source — instead
-# we install the same version into a temp dir (which runs prebuild-install and
-# downloads the right binary from GitHub) then copy just the .node file across.
-# ui-start.sh runs the same check at every daemon startup as a safety net.
-_sqlite3_dir="${APP_ROOT}/ui/node_modules/better-sqlite3"
-_node_bin="$(command -v node 2>/dev/null || true)"
-_npm_bin="${_node_bin%node}npm"; [[ -x "${_npm_bin}" ]] || _npm_bin="$(command -v npm 2>/dev/null || true)"
-if [[ -n "${_node_bin}" ]] && [[ -d "${_sqlite3_dir}" ]] && ! "${_node_bin}" -e "require('${_sqlite3_dir}')" 2>/dev/null; then
-    info "Re-fetching better-sqlite3 binary for Node $("${_node_bin}" --version) (ABI mismatch with CI build)…"
-    _bsv="$("${_node_bin}" -e "process.stdout.write(require('${_sqlite3_dir}/package.json').version)" 2>/dev/null || echo "")"
-    _bstmp="$(mktemp -d)"
-    _bsok=0
-    if [[ -n "${_bsv}" ]] && [[ -x "${_npm_bin:-}" ]] && \
-       (cd "${_bstmp}" && "${_npm_bin}" install --no-save "better-sqlite3@${_bsv}" 2>/dev/null) && \
-       [[ -f "${_bstmp}/node_modules/better-sqlite3/build/Release/better_sqlite3.node" ]]; then
-        cp "${_bstmp}/node_modules/better-sqlite3/build/Release/better_sqlite3.node" \
-           "${_sqlite3_dir}/build/Release/better_sqlite3.node"
-        _bsok=1
-    fi
-    rm -rf "${_bstmp}"
-    if [[ "${_bsok}" -eq 1 ]]; then
-        ok "better-sqlite3 binary updated for Node $("${_node_bin}" --version)"
-    else
-        warn "better-sqlite3 binary update failed — ui-start.sh will retry on first launch"
-    fi
 fi
 
 # ── 6. Daemons — restart only what changed ───────────────────────────────────

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -36,6 +36,31 @@ echo "→ daemon binary"
 cp "${DAEMON_BIN}" "${DEST}/bin/meridian"
 chmod +x "${DEST}/bin/meridian"
 
+echo "→ Node.js 22 LTS runtime (bundled — UI daemon uses this, not system node)"
+# Download the official Node 22 LTS binary and verify its SHA-256.
+# This binary is later exec'd by ui-start.sh (via MERIDIAN_NODE_BIN in the
+# launchd plist). Because the better-sqlite3 addon is also built against this
+# exact Node version below, ABI is always correct regardless of what node
+# the user has installed.
+_NODE22_VERSION="22.22.3"
+_NODE22_SHA="0da7ff74ef8611328c8212f17943368713a2ad953fb7d89a8c8a0eae87c23207"
+_node22_tmp="$(mktemp -d)"
+curl -fsSL --retry 3 \
+    "https://nodejs.org/dist/v${_NODE22_VERSION}/node-v${_NODE22_VERSION}-darwin-arm64.tar.gz" \
+    -o "${_node22_tmp}/node22.tar.gz"
+_actual_sha="$(shasum -a 256 "${_node22_tmp}/node22.tar.gz" | cut -d' ' -f1)"
+if [[ "${_actual_sha}" != "${_NODE22_SHA}" ]]; then
+    echo "✗ node-v${_NODE22_VERSION} SHA-256 mismatch" >&2
+    echo "  expected: ${_NODE22_SHA}" >&2
+    echo "  got:      ${_actual_sha}" >&2
+    rm -rf "${_node22_tmp}"; exit 1
+fi
+tar -xzf "${_node22_tmp}/node22.tar.gz" -C "${_node22_tmp}"
+_NODE22_DIR="${_node22_tmp}/node-v${_NODE22_VERSION}-darwin-arm64"
+_NODE22_BIN="${_NODE22_DIR}/bin/node"
+_NODE22_NPM_CLI="${_NODE22_DIR}/lib/node_modules/npm/bin/npm-cli.js"
+echo "  · $("${_NODE22_BIN}" --version) — ABI $("${_NODE22_BIN}" -e 'process.stdout.write(String(process.versions.modules))') ✓"
+
 echo "→ UI (Next.js standalone, packed as a tarball)"
 # Only rebuild and ship the UI tarball when the dashboard has actually changed
 # since the previous release tag. Most releases change only the Rust binary or
@@ -48,7 +73,7 @@ echo "→ UI (Next.js standalone, packed as a tarball)"
 # the server (vercel/next.js#87737, #93849); tar preserves them intact.
 _ui_changed=1
 if [[ -n "${_prev_tag}" ]]; then
-    if git diff --quiet "${_prev_tag}" HEAD -- ui/ 2>/dev/null; then
+    if git diff --quiet "${_prev_tag}" HEAD -- ui/ scripts/package-release.sh 2>/dev/null; then
         _ui_changed=0
     fi
 fi
@@ -59,6 +84,50 @@ if [[ "${_ui_changed}" -eq 1 ]]; then
     mkdir -p "${_ui_stage}/.next"
     cp -R "ui/.next/static" "${_ui_stage}/.next/static"
     [[ -d "ui/public" ]] && cp -R "ui/public" "${_ui_stage}/public"
+    # Swap the better-sqlite3 native addon for one built against Node 22 (ABI 127).
+    # CI runs with Node 24 (ABI 137) for semantic-release/npm OIDC; the binary
+    # produced by `npm ci && npm run build` loads only on Node 24. The bundled
+    # node-runtime is Node 22, so we must ship a matching binary.
+    _bs_version="$("${_NODE22_BIN}" -e "process.stdout.write(require('./ui/node_modules/better-sqlite3/package.json').version)")"
+    echo "  · building better-sqlite3@${_bs_version} for Node 22 (ABI 127)…"
+    _bs_tmp="$(mktemp -d)"
+    HOME="${_bs_tmp}" "${_NODE22_BIN}" "${_NODE22_NPM_CLI}" install \
+        --no-save --prefer-offline=false "better-sqlite3@${_bs_version}" 2>&1 | tail -5 || true
+    _bs_node="$(find "${_bs_tmp}" -name "better_sqlite3.node" -path "*/Release/*" 2>/dev/null | head -1)"
+    [[ -n "${_bs_node}" && -f "${_bs_node}" ]] || {
+        echo "✗ better-sqlite3@${_bs_version} Node 22 build produced no binary" >&2
+        rm -rf "${_bs_tmp}" "${_node22_tmp}"; exit 1
+    }
+    # Confirm the staged tree has exactly one .node file, then replace it.
+    _staged_nodes="$(find "${_ui_stage}" -name "better_sqlite3.node" 2>/dev/null)"
+    _staged_count="$(echo "${_staged_nodes}" | grep -c 'better_sqlite3' 2>/dev/null || echo 0)"
+    [[ "${_staged_count}" -eq 1 ]] || {
+        echo "✗ expected 1 better_sqlite3.node in staged tree, found ${_staged_count}:" >&2
+        echo "${_staged_nodes}" >&2
+        rm -rf "${_bs_tmp}" "${_node22_tmp}"; exit 1
+    }
+    cp "${_bs_node}" "${_staged_nodes}"
+    rm -rf "${_bs_tmp}"
+    # Positive check: Node 22 must load the replaced binary.
+    _staged_pkg="$(dirname "$(dirname "$(dirname "${_staged_nodes}")")")"
+    "${_NODE22_BIN}" -e "require('${_staged_pkg}')" 2>/dev/null || {
+        echo "✗ Node 22 failed to load rebuilt better-sqlite3 — aborting" >&2
+        rm -rf "${_node22_tmp}"; exit 1
+    }
+    # Negative check: system node (CI = Node 24, ABI 137) must NOT load it.
+    _sys_node="$(command -v node 2>/dev/null || true)"
+    if [[ -x "${_sys_node}" ]]; then
+        _sys_abi="$("${_sys_node}" -e 'process.stdout.write(String(process.versions.modules))' 2>/dev/null || echo 0)"
+        if [[ "${_sys_abi}" != "127" ]]; then
+            "${_sys_node}" -e "require('${_staged_pkg}')" 2>/dev/null && {
+                echo "✗ system node (ABI ${_sys_abi}) loaded the Node 22 binary — swap did not take effect" >&2
+                rm -rf "${_node22_tmp}"; exit 1
+            }
+            echo "  · ABI isolation: $(${_sys_node} --version) (ABI ${_sys_abi}) correctly rejects binary ✓"
+        fi
+    fi
+    echo "  · better-sqlite3 → Node 22 ABI 127 ($(du -h "${_staged_nodes}" | cut -f1)) ✓"
+
     # Pack (preserving symlinks — no -h) and drop the expanded dir so npm ships only the tarball.
     tar -czf "${DEST}/ui.tar.gz" -C "${_ui_stage}" .
     rm -rf "${_ui_stage}"
@@ -66,6 +135,14 @@ if [[ "${_ui_changed}" -eq 1 ]]; then
 else
     echo "  UI unchanged since ${_prev_tag} — skipping UI tarball (~10 MB saved per update)"
 fi
+
+# Copy the bundled node binary into the package — always, regardless of whether
+# the UI tarball was skipped. Every release must include bin/node-runtime so
+# ui-start.sh never falls back to a user-installed node with a different ABI.
+cp "${_NODE22_BIN}" "${DEST}/bin/node-runtime"
+chmod +x "${DEST}/bin/node-runtime"
+rm -rf "${_node22_tmp}"
+echo "  · node-runtime bundled ($(du -h "${DEST}/bin/node-runtime" | cut -f1))"
 
 echo "→ Python services (source + pre-built site-packages)"
 mkdir -p "${DEST}/services"

--- a/scripts/ui-start.sh
+++ b/scripts/ui-start.sh
@@ -3,19 +3,13 @@
 #
 # Startup wrapper for the Next.js UI daemon.
 #
-# Checks that better-sqlite3's native addon matches the current Node.js ABI
-# before starting the server. If the ABI doesn't match (e.g. CI built with
-# Node 24 but the user has Node 22 or 23), downloads the correct pre-built
-# binary from GitHub via prebuild-install, then execs the server.
-#
-# Runs at every UI daemon start — check is fast (<200ms) when the binary is
-# already correct (just a require() probe). The slow path (npm install) only
-# executes on mismatch, which should only happen once.
+# MERIDIAN_NODE_BIN is set by the launchd plist to the bundled Node 22 runtime
+# at APP_ROOT/bin/node-runtime. That binary was used in CI to build the
+# better-sqlite3 addon shipped in ui.tar.gz, so ABI is always correct.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_ROOT="$(dirname "${SCRIPT_DIR}")"
-SQLITE3_DIR="${APP_ROOT}/ui/node_modules/better-sqlite3"
 
 # Resolve node: prefer the path baked in at install time (MERIDIAN_NODE_BIN),
 # fall back to well-known Homebrew / system locations. launchd agents don't
@@ -27,31 +21,5 @@ if [[ -z "${NODE}" ]] || [[ ! -x "${NODE}" ]]; then
     done
 fi
 [[ -x "${NODE:-}" ]] || { echo "[meridian-ui] node not found — cannot start UI server" >&2; exit 1; }
-
-# npm lives alongside node in the same bin directory.
-NPM="${NODE%node}npm"
-[[ -x "${NPM}" ]] || NPM="$(command -v npm 2>/dev/null || true)"
-
-if [[ -d "${SQLITE3_DIR}" ]] && ! "${NODE}" -e "require('${SQLITE3_DIR}')" 2>/dev/null; then
-    echo "[meridian-ui] better-sqlite3 ABI mismatch for Node $("${NODE}" -v) — fetching correct binary…" >&2
-    _bsv="$("${NODE}" -e "process.stdout.write(require('${SQLITE3_DIR}/package.json').version)" 2>/dev/null || true)"
-    _bsok=0
-    if [[ -n "${_bsv}" ]] && [[ -x "${NPM:-}" ]]; then
-        _bstmp="$(mktemp -d)"
-        if (cd "${_bstmp}" && "${NPM}" install --no-save "better-sqlite3@${_bsv}" >/dev/null 2>&1) && \
-           [[ -f "${_bstmp}/node_modules/better-sqlite3/build/Release/better_sqlite3.node" ]]; then
-            cp "${_bstmp}/node_modules/better-sqlite3/build/Release/better_sqlite3.node" \
-               "${SQLITE3_DIR}/build/Release/better_sqlite3.node"
-            _bsok=1
-        fi
-        rm -rf "${_bstmp}"
-    fi
-    if [[ "${_bsok}" -eq 1 ]]; then
-        echo "[meridian-ui] better-sqlite3 fixed for Node $("${NODE}" -v)" >&2
-    else
-        echo "[meridian-ui] WARNING: could not fix better-sqlite3 — dashboard will show empty data" >&2
-        echo "[meridian-ui]   fix: meridian update  (or: npm install -g @meridiona/meridian)" >&2
-    fi
-fi
 
 exec "${NODE}" "${APP_ROOT}/ui/server.js"


### PR DESCRIPTION
## Problem

CI builds `better-sqlite3` against Node 24 (ABI 137) because semantic-release requires Node ≥22.14/≥24.10 with npm 11.x for OIDC publishing. Any machine with a different Node major (22 → ABI 127, 23 → ABI 131) gets a `NODE_MODULE_VERSION` mismatch and a blank dashboard.

The existing self-heal (`npm install better-sqlite3` in a temp dir) was unreliable:
- `prebuild-install` isn't on PATH in a launchd environment
- Source files are stripped from the installed package (`binding.gyp` missing)
- The binary landed at the wrong path and was silently ignored

## Fix

Ship the Node 22.22.3 binary (`bin/node-runtime`) inside every npm release and always exec the UI server with it.

**`scripts/package-release.sh`** (CI packaging step):
1. Downloads `node-v22.22.3-darwin-arm64.tar.gz`, verifies SHA-256 (`0da7ff74…`)
2. Uses Node 22's own npm to `npm install better-sqlite3@12.2.0` → downloads the `node-v127-darwin-arm64` prebuilt from GitHub Releases
3. Confirms exactly one `.node` file in the staged tree, swaps it
4. **Positive check**: Node 22 must load the new binary (exit 0)
5. **Negative check**: system node (Node 24, ABI 137) must NOT load it — catches a no-op swap
6. Packs `ui.tar.gz` with the correct binary inside
7. Copies `bin/node` → `${DEST}/bin/node-runtime` (included in `files[]`, shipped every release)

**`scripts/install-from-bundle.sh`**:
- `install_ui_standalone()` now sets `node_bin="${APP_ROOT}/bin/node-runtime"` (the bundled binary) instead of `command -v node`
- Removed the ABI self-heal block (dead code — binary is correct on install)

**`scripts/ui-start.sh`**:
- Removed ABI probe + npm-install recovery (dead code)
- `MERIDIAN_NODE_BIN` (set by launchd plist to bundled `node-runtime`) is always correct; system-node fallback is kept for manual invocations

**Migration**: `scripts/package-release.sh` is now included in the `_ui_changed` git-diff check, so this release forces a UI tarball rebuild even if `ui/` source is unchanged — the tarball must be rebuilt to contain the Node 22 binary.

## Test plan

- [ ] CI passes (pre-push hooks: fmt, clippy, cargo test, ui build, ui tests)
- [ ] `scripts/package-release.sh` runs end-to-end on a CI build: Node 22 download → SHA verification → better-sqlite3 build → positive/negative ABI checks → `ui.tar.gz` packed → `bin/node-runtime` present
- [ ] `npm/meridian-darwin-arm64/bin/node-runtime -e "process.versions.modules"` prints `127`
- [ ] Installing the package and starting the UI daemon on a machine with any Node version (or no Node) serves `/api/today` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)