### PR TITLE
fix(install): fall back to system node when bundled node-runtime absent

### DIFF
--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -114,8 +114,15 @@ LAUNCH_AGENTS="${HOME}/Library/LaunchAgents"
 install_ui_standalone() {
     local label="com.meridiona.ui"
     local plist="${LAUNCH_AGENTS}/${label}.plist"
+    # Prefer a bundled Node runtime (ABI-matched to the better-sqlite3 addon in
+    # ui.tar.gz). Fall back to system/Homebrew Node when not included in this package.
     local node_bin="${APP_ROOT}/bin/node-runtime"
-    [[ -x "${node_bin}" ]] || { err "bundled node runtime missing — re-install: npm install -g @meridiona/meridian"; return 1; }
+    if [[ ! -x "${node_bin}" ]]; then
+        for _n in /opt/homebrew/bin/node /usr/local/bin/node /usr/bin/node; do
+            [[ -x "${_n}" ]] && { node_bin="${_n}"; break; }
+        done
+    fi
+    [[ -x "${node_bin}" ]] || { err "node not found — install Node.js: brew install node"; return 1; }
     local start_script="${APP_ROOT}/scripts/ui-start.sh"
     chmod +x "${start_script}" 2>/dev/null || true
     mkdir -p "${HOME}/.meridian/logs" "${LAUNCH_AGENTS}"


### PR DESCRIPTION
## Summary

- `install_ui_standalone` hard-errored when `bin/node-runtime` was absent, with a misleading "re-install" message
- In release bundles this is fine (`package-release.sh` always ships `node-runtime`), but in dev/source installs the binary isn't built, so the UI daemon install would fail
- Fall back through `/opt/homebrew/bin/node → /usr/local/bin/node → /usr/bin/node` when the bundled runtime isn't present — the same lookup `ui-start.sh` already does at daemon startup

## Test plan

- [ ] `meridian setup` from a release bundle (node-runtime present) — should use bundled runtime as before
- [ ] `bash scripts/install-from-bundle.sh` from a source checkout (no node-runtime) — should fall back to Homebrew node and succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)