### PR TITLE
fix(release): add --prefix to better-sqlite3 Node 22 build so binary is findable

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -92,7 +92,8 @@ if [[ "${_ui_changed}" -eq 1 ]]; then
     echo "  · building better-sqlite3@${_bs_version} for Node 22 (ABI 127)…"
     _bs_tmp="$(mktemp -d)"
     HOME="${_bs_tmp}" "${_NODE22_BIN}" "${_NODE22_NPM_CLI}" install \
-        --no-save --prefer-offline=false "better-sqlite3@${_bs_version}" 2>&1 | tail -5 || true
+        --prefix "${_bs_tmp}" \
+        --no-save --prefer-offline=false "better-sqlite3@${_bs_version}" 2>&1 | tail -20 || true
     _bs_node="$(find "${_bs_tmp}" -name "better_sqlite3.node" -path "*/Release/*" 2>/dev/null | head -1)"
     [[ -n "${_bs_node}" && -f "${_bs_node}" ]] || {
         echo "✗ better-sqlite3@${_bs_version} Node 22 build produced no binary" >&2


### PR DESCRIPTION
## Root cause

`npm install` without `--prefix` installs packages into the **current working directory's `node_modules/`** (`${REPO_ROOT}/node_modules/`). Setting `HOME="${_bs_tmp}"` only redirects npm's config/cache reads — it does not change where packages are installed.

The subsequent `find "${_bs_tmp}" -name "better_sqlite3.node"` then searched the temp dir, which was empty, so the binary was never found and the release always failed with:

```
✗ better-sqlite3@12.2.0 Node 22 build produced no binary
```

## Fix

Add `--prefix "${_bs_tmp}"` so npm installs better-sqlite3 into `${_bs_tmp}/node_modules/`, which is exactly where `find "${_bs_tmp}"` already looks.

Also bumps `tail -5 → tail -20` for more context on future build failures.

## Test plan

- [ ] Trigger a release (or run `scripts/package-release.sh` locally after `cargo build --release` + UI build) — the better-sqlite3 Node 22 binary should be found and the `ABI 127 ✓` line should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)