### PR TITLE
fix(mlx-server): guard /classify against Apple FM sentinel + restart server on py-src change

### DIFF
--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -523,9 +523,17 @@ fi
 info "Installing screenpipe launchd agent…"
 bash "${APP_ROOT}/scripts/install-screenpipe-daemon.sh" || warn "screenpipe agent install failed"
 
-# MLX: skip restart + model-load wait when server was already healthy and the
-# Python services/venv didn't change — saves ~9 s on every non-Python update.
-if [[ "${_mlx_was_healthy}" -eq 1 && "${_venv_changed}" -eq 0 ]]; then
+# MLX: skip restart + model-load wait when server was already healthy and
+# neither the venv nor the Python source files changed.
+_PY_SRC_STAMP="${HOME}/.meridian/py-src.sha256"
+_py_src_hash="$(find "${APP_ROOT}/services/agents" -name '*.py' | sort | xargs shasum -a 256 2>/dev/null | shasum -a 256 | cut -d' ' -f1 || true)"
+_py_src_changed=1
+if [[ -f "${_PY_SRC_STAMP}" && "$(cat "${_PY_SRC_STAMP}")" == "${_py_src_hash}" ]]; then
+    _py_src_changed=0
+fi
+echo "${_py_src_hash}" > "${_PY_SRC_STAMP}"
+
+if [[ "${_mlx_was_healthy}" -eq 1 && "${_venv_changed}" -eq 0 && "${_py_src_changed}" -eq 0 ]]; then
     ok "Python services unchanged — MLX server kept running"
 else
     info "Installing MLX inference server launchd agent…"

--- a/services/agents/server.py
+++ b/services/agents/server.py
@@ -193,22 +193,27 @@ async def classify(req: ClassifyRequest) -> ClassifyResponse:
     from outlines.inputs import Chat
     from mlx_lm.sample_utils import make_sampler
 
+    from agents.llm_selector import APPLE_INTELLIGENCE_ID
+
     m = _app_state["mlx_module"]
-    model = m._get_model()
     messages = [
         {"role": "system", "content": m._SYSTEM_PROMPT},
         {"role": "user",   "content": req.input},
     ]
     t0 = _time.time()
     try:
-        raw = model(
-            Chat(messages),
-            output_type=m.SessionClassification,
-            max_tokens=m._MAX_TOKENS,
-            sampler=make_sampler(temp=m._TEMPERATURE),
-            verbose=False,
-        )
-        result = m.SessionClassification.model_validate_json(raw)
+        if m._resolve_model_id() == APPLE_INTELLIGENCE_ID:
+            result = m._classify_apple_fm(messages)
+        else:
+            model = m._get_model()
+            raw = model(
+                Chat(messages),
+                output_type=m.SessionClassification,
+                max_tokens=m._MAX_TOKENS,
+                sampler=make_sampler(temp=m._TEMPERATURE),
+                verbose=False,
+            )
+            result = m.SessionClassification.model_validate_json(raw)
     except Exception as exc:
         log.warning("classify: inference error: %s", exc)
         raise HTTPException(status_code=500, detail=str(exc)) from exc


### PR DESCRIPTION
## Summary

Two follow-up fixes to #168 (Apple FM routing), caught by the post-update smoke test on M1 Air 8 GB.

**1. `/classify` missing Apple FM guard**
The `/classify` endpoint called `_get_model()` directly without checking for the `apple-intelligence` sentinel — same bug that was fixed in `/v1/chat/completions` and `/summarise` in #168. Now routes through `m._classify_apple_fm()` when Apple FM is selected (same function used by `/classify_sessions`).

**2. MLX server not restarted when Python source changes**
`install-from-bundle.sh` kept the MLX server running when only the venv/uv.lock hash was unchanged — it didn't check whether Python source files (e.g. `server.py`) had changed. So after `meridian update`, the process had new files on disk but old code in memory.

Fix: hash all `services/agents/**/*.py` files and stamp at `~/.meridian/py-src.sha256`. If the hash changes (source updated), restart the server even when the venv is identical.

## Test plan

- [x] All pre-push checks pass (fmt, clippy, ui build, cargo test)
- [ ] After merge + `meridian update` on M1 Air: smoke test `/classify` should pass with Apple FM

🤖 Generated with [Claude Code](https://claude.com/claude-code)