### PR TITLE
fix(mlx-server): use fresh OS thread for Apple FM to escape anyio event loop

### DIFF
--- a/services/agents/run_task_linker_mlx.py
+++ b/services/agents/run_task_linker_mlx.py
@@ -415,7 +415,25 @@ def _classify_apple_fm(messages: list[dict[str, str]]) -> "SessionClassification
         data = json.loads(text)
         return SessionClassification.model_validate(_coerce_apple_fm_result(data))
 
-    raw = asyncio.run(_run(user_with_hint))
+    def _call_apple_fm(prompt: str) -> str:
+        # anyio (used by FastAPI's run_in_threadpool) sets up its own event loop
+        # machinery in its worker threads. asyncio.run() raises
+        # "cannot be called from a running event loop" even inside a threadpool
+        # thread. Spawning a genuinely fresh OS thread with its own event loop
+        # avoids anyio's loop entirely.
+        import concurrent.futures
+        def _in_fresh_thread() -> str:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                return loop.run_until_complete(_run(prompt))
+            finally:
+                loop.close()
+                asyncio.set_event_loop(None)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+            return ex.submit(_in_fresh_thread).result(timeout=60)
+
+    raw = _call_apple_fm(user_with_hint)
     try:
         return _parse(raw)
     except Exception:
@@ -425,7 +443,7 @@ def _classify_apple_fm(messages: list[dict[str, str]]) -> "SessionClassification
             "(category, category_confidence, category_explanation, session_summary). "
             "Return a complete JSON with ALL fields from the schema:\n" + raw
         )
-        raw2 = asyncio.run(_run(fix_prompt))
+        raw2 = _call_apple_fm(fix_prompt)
         return _parse(raw2)
 
 


### PR DESCRIPTION
## Summary

`run_in_threadpool` (anyio) sets up its own event loop machinery in its worker threads. Even though `/classify` now wraps the call in `run_in_threadpool` (PR #172), `asyncio.run()` inside `_classify_apple_fm` still sees a running event loop and raises `"asyncio.run() cannot be called from a running event loop"`.

Fix: `_call_apple_fm()` inside `_classify_apple_fm` spawns a genuinely fresh OS thread via `ThreadPoolExecutor(max_workers=1)`, creates a new event loop explicitly (`asyncio.new_event_loop()`), and closes it after the coroutine completes. This escapes anyio's thread-pool loop context entirely.

## Root cause

anyio attaches loop state to threads in its pool for portal-based async-from-sync bridging. `asyncio.run()` calls `asyncio.get_running_loop()` which finds anyio's attached loop and raises. A fresh `ThreadPoolExecutor` thread has no such state.

## Test plan

- [x] Confirmed error on M1 Air 8 GB after v1.24.4: `{"detail":"asyncio.run() cannot be called from a running event loop"}`
- [x] Confirmed `run_in_threadpool` count = 11 in installed server.py (PR #172 was there but not sufficient)

🤖 Generated with [Claude Code](https://claude.com/claude-code)