### PR TITLE
chore(screenpipe): bump pin to 0.4.6 and enable PII removal

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ USE_MLX=1   # MLX inference server is the only backend (powers classify + PM-wor
 MLX_PORT=7823
 # Pinned screenpipe version — the launchd plist expects this exact build
 # (`screenpipe record`). Installed via npm only when screenpipe is absent.
-SCREENPIPE_VERSION="0.3.350"
+SCREENPIPE_VERSION="0.4.6"
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/scripts/com.meridiona.screenpipe.plist
+++ b/scripts/com.meridiona.screenpipe.plist
@@ -23,7 +23,7 @@
     <array>
         <string>/bin/sh</string>
         <string>-c</string>
-        <string>exec {{SCREENPIPE_BIN}} record --disable-audio</string>
+        <string>exec {{SCREENPIPE_BIN}} record --disable-audio --use-pii-removal</string>
     </array>
 
     <key>EnvironmentVariables</key>

--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -10,7 +10,7 @@
 set -euo pipefail
 
 APP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SCREENPIPE_VERSION="0.3.350"
+SCREENPIPE_VERSION="0.4.6"
 MLX_PORT="${MLX_PORT:-7823}"
 UI_PORT="${MERIDIAN_UI_PORT:-3939}"   # dashboard port (override via MERIDIAN_UI_PORT)
 SKIP_PERMISSIONS=0


### PR DESCRIPTION
## Summary

- Bumps `SCREENPIPE_VERSION` from `0.3.350` → `0.4.6` in `install.sh` and `install-from-bundle.sh`
- Adds `--use-pii-removal` to the screenpipe launchd plist (`com.meridiona.screenpipe.plist`)
- Retention stays at screenpipe's default 14 days (intentional)

## Verification

Diff between `0.3.350` and `0.4.6` native binaries (`record --help`) is additive only:
- `--pii-redaction-labels` flag added (new, opt-in)
- `--disable-keyboard-capture` flag added (new, opt-in)
- `rfdetr_v8` → `rfdetr_v11` for image PII model (unused by us)
- `screenpipe record --disable-audio` command: **identical behavior, no breaking changes**

## Test plan

- [ ] `bash install.sh --dry-run` shows `screenpipe@0.4.6` in install prompt
- [ ] `screenpipe record --disable-audio --use-pii-removal` runs without error on a machine with 0.4.6
- [ ] `meridian doctor` passes after re-installing screenpipe at the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)