### PR TITLE
feat(coding-agent): add install-skill command and health check for session-summary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "meridian"
-version = "1.6.0"
+version = "1.24.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -648,7 +648,7 @@ case "$CMD" in
     uninstall)        cmd_uninstall ;;
     permissions)      cmd_permissions ;;
     version|--version|-v) cat "${REPO_ROOT}/VERSION" 2>/dev/null || echo "unknown" ;;
-    worklog-status|pm-worklog|coding-agent-hook|coding-agent-summarise|coding-agent-classify) cmd_daemon_passthrough "$CMD" "$@" ;;
+    worklog-status|pm-worklog|coding-agent-hook|coding-agent-summarise|coding-agent-classify|coding-agent-install-skill) cmd_daemon_passthrough "$CMD" "$@" ;;
     --help|-h|help|"") cmd_help ;;
     *) err "unknown command: ${CMD}"; echo; cmd_help; exit 1 ;;
 esac

--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -372,11 +372,10 @@ pub async fn run_loop(
     tracing::info!("coding-agent summariser stopped");
 }
 
-/// One drain pass: summarise today's pending rows, oldest-first. Returns true if
+/// One drain pass: summarise pending rows (all days), oldest-first. Returns true if
 /// we should back off (primary rate-limited AND MLX also failed).
 async fn drain(pool: &SqlitePool, cfg: &SummariserConfig) -> bool {
-    let today = Local::now().format("%Y-%m-%d").to_string();
-    let rows = match db::fetch_pending(pool, cfg, cfg.batch_per_tick, Some(&today)).await {
+    let rows = match db::fetch_pending(pool, cfg, cfg.batch_per_tick, None).await {
         Ok(r) => r,
         Err(e) => {
             tracing::warn!(error = %e, "summariser: fetch_pending failed");

--- a/src/health/codingagent.rs
+++ b/src/health/codingagent.rs
@@ -14,12 +14,37 @@ pub fn checks(_cfg: &Config) -> Vec<Check> {
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("."));
 
+    let claude_present = which("claude").is_some();
+    let skill_path = home.join(".claude/commands/session-summary.md");
+
     let mut out = vec![
         cli("claude", "Claude Code"),
         cli("codex", "Codex"),
         dir(&home.join(".claude/projects"), "claude sessions dir"),
         dir(&home.join(".codex/sessions"), "codex sessions dir"),
     ];
+
+    // The session-summary skill must exist for `claude -p /session-summary` to
+    // work. Without it the command returns "Unknown command" and every Claude
+    // Code session silently falls through to the local MLX model instead.
+    if claude_present {
+        if skill_path.exists() {
+            out.push(Check::ok(
+                "session-summary skill",
+                "L2",
+                "~/.claude/commands/session-summary.md present",
+            ));
+        } else {
+            out.push(
+                Check::warn(
+                    "session-summary skill",
+                    "L2",
+                    "~/.claude/commands/session-summary.md missing — claude summariser falls back to MLX for every session",
+                )
+                .with_remedy("meridian doctor --fix  (or: meridian coding-agent-install-skill)"),
+            );
+        }
+    }
 
     // The Cursor gap: Cursor stores agent sessions outside the ingested paths, so
     // its work is only captured via OCR/a11y, never the rich transcript path.

--- a/src/health/diagnose.rs
+++ b/src/health/diagnose.rs
@@ -59,6 +59,13 @@ pub fn root_causes(report: &Report) -> Vec<Diagnosis> {
             ]),
             action: "Start it (`meridian start`), then `meridian doctor --fix` to drain the backlog.".into(),
         });
+    } else if bad("coding-agent", "session-summary skill") {
+        out.push(Diagnosis {
+            title: "session-summary Claude Code command is missing".into(),
+            cause: "The `claude -p /session-summary` invocation that produces transcript summaries returns 'Unknown command' because ~/.claude/commands/session-summary.md doesn't exist. Every Claude Code session silently falls back to the local MLX model instead of the subscription claude CLI.".into(),
+            contributing: contributing(&[("coding-agent", "session-summary skill")]),
+            action: "`meridian doctor --fix`  (or: `meridian coding-agent-install-skill`)".into(),
+        });
     } else if bad("meridian daemon", "summariser queue") {
         out.push(Diagnosis {
             title: "Coding-agent summariser is stalled".into(),

--- a/src/health/fix.rs
+++ b/src/health/fix.rs
@@ -62,6 +62,11 @@ pub fn fix_for(c: &Check) -> Option<FixAction> {
         ("jira", name) if name.contains("ticket sync") => {
             guided("refresh the Jira ticket cache", &["meridian", "restart"])
         }
+        // Missing session-summary skill → write the file (safe, idempotent).
+        ("coding-agent", name) if name.contains("session-summary skill") => auto(
+            "install the session-summary Claude Code command",
+            &["meridian", "coding-agent-install-skill"],
+        ),
         // Summariser backlog → drain it (mutates data → guided).
         ("meridian daemon", name) if name.contains("summariser queue") => guided(
             "drain the summariser queue",

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,50 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    // `meridian coding-agent-install-skill` — write the session-summary Claude
+    // Code command file so `claude -p /session-summary` works. Idempotent; safe
+    // to run any number of times. Also called by `meridian doctor --fix`.
+    if std::env::args().nth(1).as_deref() == Some("coding-agent-install-skill") {
+        let home = std::env::var_os("HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        let commands_dir = home.join(".claude/commands");
+        let skill_path = commands_dir.join("session-summary.md");
+        // Keep rules in sync with src/coding_agent_session_ingest/summariser/prompts.rs
+        let content = concat!(
+            "---\n",
+            "description: Summarise a coding-agent session transcript for a Jira work-log.\n",
+            "---\n\n",
+            "You summarise ONE work-burst of a developer's coding-agent session for a Jira ",
+            "work-log. The transcript is timestamped as `[<ISO ts>] [role] <message>`. Write ",
+            "a factual prose summary of 10-40 sentences: name the files edited, commands run, ",
+            "errors hit, decisions made, tests/validations performed, and any rework or ",
+            "blockers (an approach abandoned, a failed build/test, something deleted and ",
+            "rebuilt). State ONLY what is in the transcript — never invent files, tickets, ",
+            "commands, or outcomes. No preamble, no markdown headings, no bullet lists — just ",
+            "clear paragraphs. If an 'EARLIER IN THIS SESSION' section is present, do not ",
+            "repeat it; summarise only this burst.\n\n",
+            "Return JSON with `summary` (the prose) and `blockers` (a list of distinct ",
+            "blockers / failures / rework, possibly empty).\n"
+        );
+        if let Err(e) = std::fs::create_dir_all(&commands_dir) {
+            eprintln!("coding-agent-install-skill: create dir: {e}");
+            return Ok(());
+        }
+        if skill_path.exists() {
+            println!(
+                "coding-agent-install-skill: already present at {}",
+                skill_path.display()
+            );
+        } else {
+            match std::fs::write(&skill_path, content) {
+                Ok(()) => println!("coding-agent-install-skill: wrote {}", skill_path.display()),
+                Err(e) => eprintln!("coding-agent-install-skill: write: {e}"),
+            }
+        }
+        return Ok(());
+    }
+
     // `meridian pm-worklog [--day YYYY-MM-DD]` — one-shot Stage 4: walk the day's
     // hours and DRAFT one worklog per task per ready hour (never posts — posting
     // is approval-gated). Opens via setup_db so migrations (incl. the pm_worklog


### PR DESCRIPTION
## Summary

- Adds `meridian coding-agent-install-skill` subcommand that writes `~/.claude/commands/session-summary.md` so `claude -p /session-summary` resolves correctly — without it, every Claude Code session silently falls back to the local MLX model instead of the subscription claude CLI
- Wires the missing skill into the health/diagnose/fix pipeline: `meridian doctor` now warns, explains, and auto-fixes with `--fix`
- Registers the new subcommand in the CLI passthrough (`meridian-cli.sh`)
- Fixes the summariser drain to process all pending days (not today-only)

## Test plan

- [ ] `meridian coding-agent-install-skill` writes `~/.claude/commands/session-summary.md` on a clean machine
- [ ] Running it a second time prints "already present" and does not overwrite
- [ ] `meridian doctor` shows a warning when the skill file is absent and claude is installed
- [ ] `meridian doctor --fix` auto-runs install-skill and re-checks to green
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)