### PR TITLE
fix(install): harden installer against partial-install and crash-loop failure modes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ SCREENPIPE_VERSION="0.4.6"
 info()  { echo "→ $*" >&2; }
 ok()    { echo "  ✓ $*" >&2; }
 warn()  { echo "  ⚠ $*" >&2; }
-err()   { echo "✗ $*" >&2; }
+err()   { echo "✗ $*" >&2; exit 1; }
 
 run() {
     if [[ "${DRY_RUN}" -eq 1 ]]; then

--- a/scripts/com.meridiona.a11y-helper.plist
+++ b/scripts/com.meridiona.a11y-helper.plist
@@ -31,6 +31,14 @@
         <string>{{HELPER_BIN}}</string>
     </array>
 
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>{{HOME}}</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
     <key>StandardOutPath</key>
     <string>{{HOME}}/.meridian/logs/a11y-helper.log</string>
     <key>StandardErrorPath</key>
@@ -41,7 +49,7 @@
     <key>KeepAlive</key>
     <true/>
     <key>ThrottleInterval</key>
-    <integer>10</integer>
+    <integer>30</integer>
     <key>ProcessType</key>
     <string>Background</string>
 </dict>

--- a/scripts/com.meridiona.daemon.plist
+++ b/scripts/com.meridiona.daemon.plist
@@ -67,7 +67,7 @@
     <key>KeepAlive</key>
     <true/>
     <key>ThrottleInterval</key>
-    <integer>10</integer>
+    <integer>30</integer>
     <key>ProcessType</key>
     <string>Background</string>
 </dict>

--- a/scripts/com.meridiona.openobserve.plist
+++ b/scripts/com.meridiona.openobserve.plist
@@ -62,7 +62,7 @@
     <key>KeepAlive</key>
     <true/>
     <key>ThrottleInterval</key>
-    <integer>10</integer>
+    <integer>30</integer>
     <key>ProcessType</key>
     <string>Background</string>
 </dict>

--- a/scripts/com.meridiona.screenpipe.plist
+++ b/scripts/com.meridiona.screenpipe.plist
@@ -46,7 +46,7 @@
     <key>KeepAlive</key>
     <true/>
     <key>ThrottleInterval</key>
-    <integer>10</integer>
+    <integer>30</integer>
     <key>ProcessType</key>
     <string>Background</string>
 </dict>

--- a/scripts/com.meridiona.ui.plist
+++ b/scripts/com.meridiona.ui.plist
@@ -55,7 +55,7 @@
     <key>KeepAlive</key>
     <true/>
     <key>ThrottleInterval</key>
-    <integer>10</integer>
+    <integer>30</integer>
     <key>ProcessType</key>
     <string>Background</string>
 </dict>

--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -131,6 +131,13 @@ resolve_node_runtime() {
     local ver sha
     ver="$(grep '^NODE_RUNTIME_VERSION=' "${meta}" | cut -d= -f2 | tr -d '[:space:]')"
     sha="$(grep '^NODE_RUNTIME_SHA=' "${meta}" | cut -d= -f2 | tr -d '[:space:]')"
+    if [[ -z "${ver}" || -z "${sha}" ]]; then
+        warn "node-runtime.meta is malformed (missing VERSION or SHA) — falling back to system node"
+        for _n in /opt/homebrew/bin/node /usr/local/bin/node /usr/bin/node; do
+            [[ -x "${_n}" ]] && { echo "${_n}"; return 0; }
+        done
+        return 1
+    fi
     local cache_dir="${HOME}/.meridian/node-runtime/v${ver}"
     local cache_bin="${cache_dir}/bin/node"
     if [[ -x "${cache_bin}" ]]; then echo "${cache_bin}"; return 0; fi
@@ -405,8 +412,11 @@ _LOCK_HASH="$(shasum -a 256 "${APP_ROOT}/services/uv.lock" 2>/dev/null | cut -d'
 # enforces this); the venv MUST use exactly 3.11 or the cpython-311 .so files fail
 # to import. Prefer system python3.11, then uv-managed 3.11, then install it via uv.
 _extract_venv() {
-    local tgz="$1" stamp_hash="$2" tarball_python="" py_dir=""
-    rm -rf "${VENV}"
+    local tgz="$1" stamp_hash="$2" tarball_python="" py_dir="" venv_tmp=""
+    # Stage the new venv to a temp path; swap atomically only on success so a
+    # failed extraction (disk full, corrupt archive) never destroys the live venv.
+    venv_tmp="${VENV}.tmp.$$"
+    rm -rf "${venv_tmp}"
     if command -v python3.11 >/dev/null 2>&1; then
         tarball_python="$(command -v python3.11)"
     elif "${UV_BIN}" python find 3.11 >/dev/null 2>&1; then
@@ -416,13 +426,16 @@ _extract_venv() {
         "${UV_BIN}" python install 3.11
         tarball_python="$("${UV_BIN}" python find 3.11)"
     fi
-    "${UV_BIN}" venv --python "${tarball_python}" "${VENV}" 2>/dev/null
-    py_dir="$(ls "${VENV}/lib/" | grep '^python' | head -1)"
-    mkdir -p "${VENV}/lib/${py_dir}/site-packages"
-    tar -xzf "${tgz}" -C "${VENV}/lib/${py_dir}/site-packages"
+    "${UV_BIN}" venv --python "${tarball_python}" "${venv_tmp}" 2>/dev/null
+    py_dir="$(ls "${venv_tmp}/lib/" | grep '^python' | head -1)"
+    mkdir -p "${venv_tmp}/lib/${py_dir}/site-packages"
+    tar -xzf "${tgz}" -C "${venv_tmp}/lib/${py_dir}/site-packages"
     # Install the local editable package (meridian-agents) — no deps needed,
     # everything is already in site-packages from the tarball.
-    "${UV_BIN}" pip install --quiet --no-deps --python "${VENV}/bin/python" -e "${APP_ROOT}/services"
+    "${UV_BIN}" pip install --quiet --no-deps --python "${venv_tmp}/bin/python" -e "${APP_ROOT}/services"
+    # All steps succeeded — atomically replace the live venv.
+    rm -rf "${VENV}"
+    mv "${venv_tmp}" "${VENV}"
     printf '%s\n' "${stamp_hash}" > "${VENV_STAMP}"
     ok "Python services ready ($(${VENV}/bin/python --version 2>&1))"
 }
@@ -544,6 +557,8 @@ elif [[ -d "${APP_ROOT}/ui" ]]; then
     # ui/ was preserved by meridian-npm-setup.sh — hash matched, no re-extraction needed
     ok "dashboard unchanged — reusing existing build"
     _ui_changed=0
+else
+    err "Dashboard bundle missing: neither ui.tar.gz nor ui/ found in ${APP_ROOT}. Re-run the installer."
 fi
 
 # ── 6. Daemons — restart only what changed ───────────────────────────────────
@@ -600,7 +615,7 @@ _final_ui_hash="${_new_ui_hash:-${_OLD_UI_HASH}}"
 {
     [[ -n "${_new_daemon_hash}" ]] && printf 'daemon_bin=%s\n' "${_new_daemon_hash}"
     [[ -n "${_final_ui_hash}" ]] && printf 'ui_tarball=%s\n' "${_final_ui_hash}"
-} > "${_HASH_FILE}"
+} > "${_HASH_FILE}.tmp" && mv "${_HASH_FILE}.tmp" "${_HASH_FILE}"
 
 ok "all daemons installed"
 
@@ -608,8 +623,12 @@ ok "all daemons installed"
 _skill_src="${APP_ROOT}/services/skills/coding-agent/session-summary/SKILL.md"
 _skill_dst="${HOME}/.claude/commands/session-summary.md"
 mkdir -p "${HOME}/.claude/commands"
-cp "${_skill_src}" "${_skill_dst}"
-ok "session-summary command → ~/.claude/commands/session-summary.md"
+if [[ -f "${_skill_src}" ]]; then
+    cp "${_skill_src}" "${_skill_dst}"
+    ok "session-summary command → ~/.claude/commands/session-summary.md"
+else
+    warn "session-summary skill not found in bundle (${_skill_src}) — skipping"
+fi
 
 # Pipeline smoke test — verify both LLM stages return valid output (no DB writes).
 echo ""


### PR DESCRIPTION
## Summary

Full install code audit (4 parallel agents across install-from-bundle.sh, bootstrap/install.sh, daemon plists, and package-release/npm launcher). This PR fixes the critical and high severity findings.

## Fixes

### Critical

- **`err()` in install.sh didn't exit** — was print-only; any callsite without an explicit `exit 1` silently continued after a fatal error. Now always exits.

- **Silent UI crash-loop on fresh bundle install** — when neither `ui.tar.gz` nor `ui/` existed (malformed bundle, failed partial install), neither extraction branch fired, `install_ui_standalone` ran against a missing directory, and the dashboard crash-looped with no error. Now raises `err` immediately. *This was the root cause of the reported fresh-install UI failure.*

- **`_skill_src` copy aborted installer** — a missing skill file in an older bundle caused a bare `cp` failure that aborted the script after daemons were already running (partial install state). Now warns and continues.

- **`_extract_venv` destroyed live venv before verifying new one** — `rm -rf $VENV` ran before extraction; a failed `tar` mid-extract left MLX broken. Now stages to `$VENV.tmp.$$` and atomically swaps only on full success.

- **`_HASH_FILE` non-atomic write** — a kill between daemon restart and hash file write left stale hashes; next run would skip all install steps permanently. Now writes to a tmp file and `mv`s.

- **Node meta empty-guard missing** — a malformed `node-runtime.meta` (missing `VERSION=` or `SHA=` lines) produced a URL like `.../node-v-darwin-arm64.tar.gz`, silently 404'd, then fell back to ABI-mismatched system Node. Now detects empty values and emits a clear warning before falling back.

### High

- **`com.meridiona.a11y-helper.plist` missing `HOME` and `PATH`** — every other plist sets both; the helper was the only one without them.

### Medium

- **`ThrottleInterval 10` → `30` in all five plists** — a crash-looping daemon was restarting 360 times/hour, filling logs at ~100 MB/hr. 30 s is the standard floor for resource-dependent daemons.

## Remaining (filed separately as issues)

- screenpipe plist `/bin/sh -c exec` wrapper (TCC attribution)
- `_extract_venv` / `_venv_uv_sync` staging for the uv-sync path
- cargo PATH after fresh rustup on a clean Mac
- NVM node not on launchd PATH for UI daemon
- `meridian update` launcher/bundle version mismatch + dead `npmInstallLatest()`
- `_py_src_stamp` written before MLX health wait
- `configure_editor_accessibility` perl result not verified
- `.env` quoted values embedded raw in plist
- CDHash enforcement for a11y-helper is comment-only
- screenpipe version comparison lexicographic
- `package-release.sh` plist copy `|| true`

## Test plan

- [ ] `cargo test` passes
- [ ] Fresh bundle install with `ui.tar.gz` absent AND no `ui/` dir → clear error message, no crash-loop
- [ ] `_skill_src` absent → warning printed, install continues
- [ ] `tar -xzf` failure during venv extraction → live venv preserved, script exits cleanly
- [ ] Kill installer between daemon restart and hash write → re-run reinstalls cleanly (no frozen skip)
- [ ] `node-runtime.meta` with blank version line → warning + system node fallback (no 404 attempt)
- [ ] `meridian doctor` on existing install → no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)