### PR TITLE
feat(ui): SSE health banner replaces 30s polling

### DIFF
--- a/ui/app/api/health/stream/route.ts
+++ b/ui/app/api/health/stream/route.ts
@@ -1,0 +1,133 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// SSE endpoint for real-time health status. Uses fs.watch (FSEvents on macOS)
+// to detect DB and a11y-helper log changes — no polling, instant notification.
+// ReadableStream.start() runs after the Response is returned, so getHealth()
+// never blocks the caller.
+
+import { watch } from 'fs'
+import { access, constants, readFile } from 'fs/promises'
+import { exec } from 'child_process'
+import path from 'path'
+import os from 'os'
+
+export const dynamic = 'force-dynamic'
+
+interface HealthStatus {
+  a11y_helper_trusted?: boolean
+  database_ready?: boolean
+  error?: string
+}
+
+function dbPath(): string {
+  return process.env.MERIDIAN_DB_PATH ?? path.join(os.homedir(), '.meridian', 'meridian.db')
+}
+
+function logsDir(): string {
+  return path.join(os.homedir(), '.meridian', 'logs')
+}
+
+async function checkDatabase(): Promise<{ ready: boolean; error?: string }> {
+  try {
+    await access(dbPath(), constants.R_OK)
+    return { ready: true }
+  } catch {
+    return {
+      ready: false,
+      error: 'Database not found — start the daemon: launchctl load ~/Library/LaunchAgents/com.meridiona.daemon.plist',
+    }
+  }
+}
+
+async function checkA11yFromLog(): Promise<boolean | undefined> {
+  const logFile = path.join(logsDir(), 'a11y-helper.log')
+  try {
+    const raw = await readFile(logFile, 'utf8')
+    const lines = raw.trimEnd().split('\n')
+    for (let i = lines.length - 1; i >= Math.max(0, lines.length - 200); i--) {
+      const l = lines[i]
+      if (l.includes('trusted: true') || l.includes('[trusted]')) return true
+      if (l.includes('trusted: false') || l.includes('[untrusted]')) return false
+    }
+    return undefined
+  } catch {
+    return undefined
+  }
+}
+
+function launchctlA11yTrusted(): Promise<boolean | undefined> {
+  return new Promise((resolve) => {
+    const uid = process.getuid?.() ?? 501
+    exec(`launchctl print gui/${uid}/com.meridiona.a11y-helper`, { timeout: 3000 }, (_err, stdout) => {
+      if (!stdout) { resolve(undefined); return }
+      if (stdout.includes('a11y_trusted = 1')) resolve(true)
+      else if (stdout.includes('a11y_trusted = 0')) resolve(false)
+      else resolve(undefined)
+    })
+  })
+}
+
+async function getHealth(): Promise<HealthStatus> {
+  const [db, logTrust] = await Promise.all([checkDatabase(), checkA11yFromLog()])
+  const trusted = logTrust !== undefined ? logTrust : await launchctlA11yTrusted()
+  return {
+    database_ready: db.ready,
+    ...(db.error ? { error: db.error } : {}),
+    ...(trusted !== undefined ? { a11y_helper_trusted: trusted } : {}),
+  }
+}
+
+export async function GET(request: Request) {
+  const encoder = new TextEncoder()
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const enqueue = (data: HealthStatus) => {
+        try { controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`)) } catch { /* closed */ }
+      }
+      const ping = () => {
+        try { controller.enqueue(encoder.encode(': ping\n\n')) } catch { /* closed */ }
+      }
+
+      // Initial health push — runs after the Response has been returned.
+      enqueue(await getHealth())
+
+      // Coalesce rapid fs.watch events.
+      let debounce: ReturnType<typeof setTimeout> | null = null
+      const onChange = () => {
+        if (debounce) clearTimeout(debounce)
+        debounce = setTimeout(() => { getHealth().then(enqueue) }, 300)
+      }
+
+      const watchers: ReturnType<typeof watch>[] = []
+      const meridianDir = path.dirname(dbPath())
+      const dbFile = path.basename(dbPath())
+      try {
+        watchers.push(watch(meridianDir, (_, filename) => { if (filename === dbFile) onChange() }))
+      } catch { /* dir absent */ }
+      try {
+        watchers.push(watch(logsDir(), (_, filename) => { if (filename === 'a11y-helper.log') onChange() }))
+      } catch { /* logs dir absent */ }
+
+      const heartbeatTimer = setInterval(ping, 25_000)
+
+      const cleanup = () => {
+        if (debounce) clearTimeout(debounce)
+        clearInterval(heartbeatTimer)
+        watchers.forEach((w) => { try { w.close() } catch { /* already closed */ } })
+        try { controller.close() } catch { /* already closed */ }
+      }
+
+      request.signal.addEventListener('abort', cleanup)
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  })
+}

--- a/ui/components/HealthBanner.tsx
+++ b/ui/components/HealthBanner.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState } from 'react'
 
 interface HealthStatus {
-  a11y_helper_trusted: boolean
+  a11y_helper_trusted?: boolean
   database_ready?: boolean
   error?: string
 }
@@ -14,21 +14,18 @@ export default function HealthBanner() {
   const [dismissed, setDismissed] = useState(false)
 
   useEffect(() => {
-    // Fetch health status on mount and every 30 seconds
-    const fetchHealth = async () => {
+    const source = new EventSource('/api/health/stream')
+    source.onmessage = (e) => {
       try {
-        const res = await fetch('/api/health')
-        const data = await res.json()
-        setHealth(data)
-      } catch (e) {
-        // Silently fail if health check unavailable
-      }
+        const data = JSON.parse(e.data) as HealthStatus
+        // Ignore empty objects ({}) sent on first call before data arrives
+        if (Object.keys(data).length > 0) setHealth(data)
+      } catch { /* malformed event */ }
     }
-
-    fetchHealth()
-    const interval = setInterval(fetchHealth, 30000)
-
-    return () => clearInterval(interval)
+    source.onerror = () => {
+      // SSE auto-reconnects on error; no action needed
+    }
+    return () => source.close()
   }, [])
 
   // Show banner if database is not ready (critical), or a11y-helper is not trusted, and not dismissed


### PR DESCRIPTION
## Summary

- Add `/api/health/stream` — a Server-Sent Events endpoint that pushes health status changes in real-time using `fs.watch` (FSEvents on macOS), with a 25 s keepalive ping and automatic cleanup on disconnect
- Replace `fetch + setInterval(30 000)` in `HealthBanner.tsx` with `EventSource` — the banner now updates within ~300 ms of the database appearing, disappearing, or the a11y-helper trust state changing
- Use the `ReadableStream.start()` pattern so the initial `getHealth()` runs *after* the Response is returned — the handler never blocks the caller (fix for the hanging-connection issue with the TransformStream approach)

## Why SSE over polling

Polling at 30 s meant a fresh install could show a stale "DB not found" banner for half a minute after the daemon started. SSE replaces the timer entirely: `fs.watch` fires instantly on macOS via FSEvents, the debouncer coalesces rapid events to one check, and the client reconnects automatically if the connection drops.

## Test plan

- [ ] Open the dashboard on a machine where the daemon is stopped — banner shows "Database not found"
- [ ] Start the daemon (`meridian start`) — banner disappears within ~1 s
- [ ] Stop the daemon — banner reappears within ~1 s
- [ ] Toggle Accessibility permission for a11y-helper off and on — banner reflects the change quickly
- [ ] Leave the page open for > 30 s — no repeated fetch calls in Network tab, only the single EventSource connection with periodic `: ping` frames
- [ ] Close the tab — confirm no lingering fs.watch handles (server log should show no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)