### PR TITLE
style(lint): clear three pre-existing clippy --all-targets errors in tests

### DIFF
--- a/src/coding_agent_session_ingest/sources/mod.rs
+++ b/src/coding_agent_session_ingest/sources/mod.rs
@@ -255,6 +255,53 @@ fn has_new_turns(records: &[NormRecord], stored_end: Option<&str>) -> bool {
     }
 }
 
+// ──────────────────────── Shared helpers ───────────────────────────────────
+
+/// The JSONL indexer's change-detection rule, reusable by any source with a
+/// change timestamp: changed iff it moved past the stored `ended_at` (+slack);
+/// a never-seen session is a candidate only if touched TODAY (local) — so a
+/// fresh DB does not re-index weeks of history.
+pub(crate) fn file_is_candidate(
+    mtime: SystemTime,
+    stored_end: Option<&str>,
+    now: DateTime<Utc>,
+) -> bool {
+    let mtime_epoch = mtime
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0);
+    epoch_is_candidate(mtime_epoch, stored_end, now)
+}
+
+/// Epoch-seconds flavour of `file_is_candidate` (Cursor's lastUpdatedAt is
+/// epoch milliseconds, not a file mtime).
+pub(crate) fn epoch_is_candidate(
+    changed_epoch: f64,
+    stored_end: Option<&str>,
+    now: DateTime<Utc>,
+) -> bool {
+    match stored_end {
+        Some(end_iso) => match parse_iso(end_iso) {
+            Some(end) => {
+                let end_epoch = end.timestamp_millis() as f64 / 1000.0;
+                changed_epoch > end_epoch + CHANGE_SLACK_SECS
+            }
+            None => true, // unparseable endpoint → re-register to repair
+        },
+        None => {
+            let secs = changed_epoch as i64;
+            let nanos = ((changed_epoch - secs as f64) * 1e9) as u32;
+            match DateTime::<Utc>::from_timestamp(secs, nanos) {
+                Some(changed) => {
+                    changed.with_timezone(&Local).date_naive()
+                        == now.with_timezone(&Local).date_naive()
+                }
+                None => false,
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -354,52 +401,5 @@ mod tests {
         // Ordinary sessions pass through.
         assert!(!is_summariser_artifact(&[prompt_rec("fix the login bug")]));
         assert!(!is_summariser_artifact(&[]));
-    }
-}
-
-// ──────────────────────── Shared helpers ───────────────────────────────────
-
-/// The JSONL indexer's change-detection rule, reusable by any source with a
-/// change timestamp: changed iff it moved past the stored `ended_at` (+slack);
-/// a never-seen session is a candidate only if touched TODAY (local) — so a
-/// fresh DB does not re-index weeks of history.
-pub(crate) fn file_is_candidate(
-    mtime: SystemTime,
-    stored_end: Option<&str>,
-    now: DateTime<Utc>,
-) -> bool {
-    let mtime_epoch = mtime
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs_f64())
-        .unwrap_or(0.0);
-    epoch_is_candidate(mtime_epoch, stored_end, now)
-}
-
-/// Epoch-seconds flavour of `file_is_candidate` (Cursor's lastUpdatedAt is
-/// epoch milliseconds, not a file mtime).
-pub(crate) fn epoch_is_candidate(
-    changed_epoch: f64,
-    stored_end: Option<&str>,
-    now: DateTime<Utc>,
-) -> bool {
-    match stored_end {
-        Some(end_iso) => match parse_iso(end_iso) {
-            Some(end) => {
-                let end_epoch = end.timestamp_millis() as f64 / 1000.0;
-                changed_epoch > end_epoch + CHANGE_SLACK_SECS
-            }
-            None => true, // unparseable endpoint → re-register to repair
-        },
-        None => {
-            let secs = changed_epoch as i64;
-            let nanos = ((changed_epoch - secs as f64) * 1e9) as u32;
-            match DateTime::<Utc>::from_timestamp(secs, nanos) {
-                Some(changed) => {
-                    changed.with_timezone(&Local).date_naive()
-                        == now.with_timezone(&Local).date_naive()
-                }
-                None => false,
-            }
-        }
     }
 }

--- a/src/intelligence/providers/jira.rs
+++ b/src/intelligence/providers/jira.rs
@@ -540,12 +540,8 @@ mod tests {
         insert_jira_task(&pool, "KAN-30").await;
 
         // An empty IN-list is syntactically invalid in SQLite; callers must
-        // gate on non-empty fetched_keys before calling prune. This test
-        // confirms the empty case is safe when guarded.
-        if ![""; 0].is_empty() {
-            // unreachable: satisfies the borrow-checker while documenting intent
-            run_prune_sql(&pool, &[]).await;
-        }
+        // gate on non-empty fetched_keys before calling prune — so prune is
+        // intentionally NOT called here. The task must survive untouched.
 
         // Task must still be present — no prune was called.
         assert_eq!(

--- a/tests/task_linker_smoke.rs
+++ b/tests/task_linker_smoke.rs
@@ -174,10 +174,7 @@ async fn real_classification_writes_task_and_advances_cursor() {
     );
     // task_key may be None if classified as overhead — that is valid
     let confidence = row.get::<Option<f64>, _>(3).unwrap_or(0.0);
-    assert!(
-        confidence >= 0.0 && confidence <= 1.0,
-        "confidence out of range"
-    );
+    assert!((0.0..=1.0).contains(&confidence), "confidence out of range");
 
     // cursor advanced to this session
     let cursor: (i64,) = sqlx::query_as("SELECT last_session_id FROM agent_cursor WHERE id = 1")


### PR DESCRIPTION
## Summary

Three test-only clippy lints fail `cargo clippy --all-targets -- -D warnings` but slip through the git hooks (plain `cargo clippy` skips test code). All pre-existing on `main`, unrelated to any feature — pure lint hygiene, **no behaviour change**.

| File | Lint | Fix |
|---|---|---|
| `src/intelligence/providers/jira.rs` | `const_is_empty` | Drop the always-false `![""; 0].is_empty()` guard; the "empty IN-list → no prune" intent stays in the comment, and `run_prune_sql` is still exercised by the other prune tests |
| `tests/task_linker_smoke.rs` | `manual_range_contains` | `(0.0..=1.0).contains(&confidence)` |
| `src/coding_agent_session_ingest/sources/mod.rs` | `items_after_test_module` | Move `#[cfg(test)] mod tests` below the shared-helper fns so it's the last item |

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt --check`, `cargo test`, UI build/tests, security audit (pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)