### PR TITLE
refactor(coding-agent): unify session-title cleaning into one helper

### DIFF
--- a/src/coding_agent_session_ingest/indexer.rs
+++ b/src/coding_agent_session_ingest/indexer.rs
@@ -25,7 +25,8 @@ use tokio::sync::{watch, Notify};
 
 use super::db;
 use super::segment::{
-    iso_utc, parse_iso, parse_session_segments, Segment, SegmentParams, SEGMENT_GAP_SECONDS,
+    clean_title, iso_utc, parse_iso, parse_session_segments, Segment, SegmentParams,
+    SEGMENT_GAP_SECONDS,
 };
 
 const DEFAULT_POLL_INTERVAL_S: u64 = 600;
@@ -141,12 +142,7 @@ pub async fn register_session(
 /// app_sessions row; all rows of a conversation share its name). Trimmed and
 /// capped so a runaway store value can't bloat the row.
 fn stamp_title(segments: &mut [Segment], title: Option<&str>) {
-    const TITLE_CAP: usize = 200;
-    let cleaned = title
-        .map(str::trim)
-        .filter(|t| !t.is_empty())
-        .map(|t| t.chars().take(TITLE_CAP).collect::<String>());
-    if let Some(t) = cleaned {
+    if let Some(t) = title.and_then(clean_title) {
         for seg in segments.iter_mut() {
             seg.title = Some(t.clone());
         }

--- a/src/coding_agent_session_ingest/segment.rs
+++ b/src/coding_agent_session_ingest/segment.rs
@@ -175,14 +175,25 @@ pub fn parse_session_segments(path: &Path, params: &SegmentParams) -> (SessionMe
     let (records, title) = iter_normalised_with_title(path, &agent);
     let (meta, mut segments) = segment_records(records, &session_uuid, &agent, jsonl_bytes, params);
     // Stamp the session's own name on every segment (one read produced both).
-    if let Some(t) = title {
-        const TITLE_CAP: usize = 200;
-        let cleaned = t.chars().take(TITLE_CAP).collect::<String>();
+    if let Some(t) = title.as_deref().and_then(clean_title) {
         for seg in segments.iter_mut() {
-            seg.title = Some(cleaned.clone());
+            seg.title = Some(t.clone());
         }
     }
     (meta, segments)
+}
+
+/// Normalise a raw session title for storage: trim, drop when empty, cap length.
+/// Shared by both title-stamping sites — `parse_session_segments` (the Claude
+/// JSONL path) and `indexer::stamp_title` (the source-adapter path) — so the two
+/// cannot diverge on trimming, empty-filtering, or the length cap.
+pub(crate) fn clean_title(raw: &str) -> Option<String> {
+    const TITLE_CAP: usize = 200;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.chars().take(TITLE_CAP).collect())
 }
 
 /// Segment an already-normalised record stream — the source-agnostic core of
@@ -358,6 +369,19 @@ mod tests {
     use super::*;
     use chrono::{Duration, TimeZone};
     use std::io::Write;
+
+    #[test]
+    fn clean_title_trims_filters_and_caps() {
+        assert_eq!(clean_title("  hello  ").as_deref(), Some("hello"));
+        assert_eq!(clean_title("   ").as_deref(), None);
+        assert_eq!(clean_title("").as_deref(), None);
+        // Capped at 200 chars (counts chars, not bytes).
+        let long = "x".repeat(250);
+        assert_eq!(clean_title(&long).map(|t| t.chars().count()), Some(200));
+        // Multibyte stays char-correct (no panic on a byte boundary).
+        let emoji = "🚀".repeat(250);
+        assert_eq!(clean_title(&emoji).map(|t| t.chars().count()), Some(200));
+    }
 
     fn base() -> DateTime<Utc> {
         Utc.with_ymd_and_hms(2026, 5, 20, 8, 0, 0).unwrap()


### PR DESCRIPTION
## Summary

Maintenance finding from the [PR #198 review](https://github.com/Meridiona/meridian/pull/198): the two title-stamping sites had diverged.

- `indexer::stamp_title` — trimmed, dropped empty, capped at 200
- `segment::parse_session_segments` — only capped

A future change to the cap or filtering rules would silently apply to only one path.

## Change

Extract `segment::clean_title(raw) -> Option<String>` (trim → drop-if-empty → cap 200 chars, char-safe) and call it from **both** sites. The only behavioural change is that the Claude-JSONL path now also trims and drops blank titles (previously cap-only) — which matches the source-adapter path's existing behaviour.

Unit-tested (`clean_title_trims_filters_and_caps`, incl. multibyte cap safety).

> Surfaced while addressing #198's review; it lives in `main`'s coding-agent code, not in #198's changes, so it's split out here.

## Test plan
- [x] `cargo test` (clean_title + existing title tests pass)
- [x] `cargo clippy -- -D warnings`, `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)