### PR TITLE
feat(installer): stream MLX server logs during model load wait

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -86,8 +86,8 @@ fi
 
 # ── 4. Install @meridiona/meridian ───────────────────────────────────────────
 info "Installing @meridiona/meridian@latest…"
-info "  The npm package is small; the Python venv + Node runtime (~200 MB) download"
-info "  once during 'meridian setup' below. Budget 2–4 min on a typical connection."
+info "  The npm package is small; Python deps + Node runtime download once during"
+info "  'meridian setup' below. Budget 2–4 min on a typical connection."
 npm install -g @meridiona/meridian@latest
 ok "meridian installed ($(meridian --version 2>/dev/null || echo 'version unknown'))"
 

--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -568,10 +568,42 @@ else
     info "Installing MLX inference server launchd agent…"
     bash "${APP_ROOT}/services/scripts/install-mlx-server-daemon.sh" --port "${MLX_PORT}" || warn "MLX agent install failed"
     info "Waiting for the MLX server to load the model…"
+    _MLX_LOG="${HOME}/.meridian/logs/mlx-server.log"
+    _MLX_ERR="${HOME}/.meridian/logs/mlx-server-error.log"
     _w=0
+
+    # Stream both log files while polling so the user can see which model is
+    # loading and whether a download is in progress.
+    # mlx-server.log  — JSON structured logs: model selection, readiness
+    # mlx-server-error.log — raw stderr: huggingface_hub download progress
+    # tail -F follows by name and retries if the file doesn't exist yet.
+    (tail -F "${_MLX_LOG}" 2>/dev/null | python3 -u -c '
+import sys, json
+for line in sys.stdin:
+    line = line.rstrip()
+    if not line:
+        continue
+    try:
+        d = json.loads(line)
+        lvl = d.get("level", "INFO")
+        msg = d.get("message", line)
+        prefix = "  ⚠ " if lvl in ("WARNING", "ERROR") else "  · "
+        print(prefix + msg, flush=True)
+    except Exception:
+        print("  " + line, flush=True)
+') &
+    _log_pid=$!
+    (tail -F "${_MLX_ERR}" 2>/dev/null | while IFS= read -r _eline; do
+        printf '  %s\n' "${_eline}"
+    done) &
+    _err_pid=$!
+
     until curl -sf "http://127.0.0.1:${MLX_PORT}/health" >/dev/null 2>&1; do
-        sleep 3; _w=$((_w+3)); [[ $_w -ge 300 ]] && { warn "MLX not ready after 300s — check: meridian logs mlx-server"; break; }
+        sleep 3; _w=$((_w+3))
+        [[ $_w -ge 300 ]] && { warn "MLX not ready after 300s — check: meridian logs mlx-server"; break; }
     done
+    { kill "${_log_pid}" "${_err_pid}" 2>/dev/null; wait "${_log_pid}" "${_err_pid}" 2>/dev/null; } || true
+
     # Only stamp after confirmed ready — prevents stale stamp on a failed restart.
     if curl -sf "http://127.0.0.1:${MLX_PORT}/health" >/dev/null 2>&1; then
         ok "MLX server ready (${_w}s)"

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "meridian-agents"
 version = "1.32.1"
-description = "Meridian agents — hermes task linking and Jira progress updates for meridian.db"
+description = "Meridian agents — MLX classifier server and Jira worklog synthesis for meridian.db"
 requires-python = ">=3.11"
 authors = [{ name = "Meridiona" }]
 license = { text = "MIT" }
@@ -53,9 +53,9 @@ meridian-server = "agents.server:main"
 
 [tool.uv]
 # Lock all extras so `uv lock` produces a complete, reproducible uv.lock.
-# The shipped venv installs BOTH server-side extras — `uv sync --extra mlx
-# --extra pm_worklog_update` — because the one MLX server serves
-# /classify_sessions (mlx) AND /synthesise_worklog (agno, pm_worklog_update).
+# At install time both extras are synced — `uv sync --extra mlx --extra
+# pm_worklog_update` — because the one MLX server serves /classify_sessions
+# (mlx) AND /synthesise_worklog (agno, pm_worklog_update).
 constraint-dependencies = []
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Problem

After `→ Installing MLX inference server launchd agent…` the installer went silent for up to 5 minutes. Users had no idea which model was being loaded, whether a large download was happening, or how long to wait.

## Changes

**`install-from-bundle.sh`** — tail both MLX log files while health-check polling:
- `mlx-server.log` (JSON structured logs) — parsed with Python to extract the `message` field, shown with `·` / `⚠` prefixes
- `mlx-server-error.log` (raw stderr) — passed through directly so huggingface_hub tqdm download bars render with file name, size, transfer speed, and ETA

Both tail processes are killed cleanly once the health check passes or times out.

**`bootstrap.sh`** — remove stale "Python venv + Node runtime (~200 MB)" text (venv is no longer shipped; Python deps install from PyPI at setup time per #201).

**`services/pyproject.toml`** — update package description (hermes removed) and `[tool.uv]` comment (no longer references "shipped venv").

## What users will see

```
→ Waiting for the MLX server to load the model…
  · llm_selector: selecting mlx-community/Qwen3-5B-4bit (will download)
  · run_task_linker_mlx: loading mlx-community/Qwen3-5B-4bit
  Fetching 8 files: 100%|████████████| 8/8 [00:42<00:00]
  Downloading: 100%|████████████| 2.4G/2.4G [01:23<00:00, 28.7MB/s]
  · run_task_linker_mlx: model loaded in 12.3s
  ✓ MLX server ready (97s)
```

## Test plan

- [ ] `bash -n scripts/install-from-bundle.sh` passes ✓
- [ ] Fresh install: confirm model name + download progress visible in terminal
- [ ] Re-install (model cached): confirm fast path shows "model loaded" without download bars
- [ ] Timeout path: confirm tail processes are killed cleanly on 300s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)