### PR TITLE
fix(smoke): raise classify timeout to 180s for M1 machines

### DIFF
--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -315,8 +315,8 @@ cmd_smoke() {
     mlx_port="$(_smoke_read_env MLX_SERVER_PORT)"
     mlx_port="${mlx_port:-7823}"
     local base="http://127.0.0.1:${mlx_port}"
-    local classify_timeout=60
-    [[ $classify_only -eq 1 ]] && classify_timeout=30
+    local classify_timeout=180
+    [[ $classify_only -eq 1 ]] && classify_timeout=180
     local all_ok=1
 
     if [[ -t 1 ]]; then


### PR DESCRIPTION
## Summary
- M1 (68 GB/s memory bandwidth) takes ~120s per `/classify` call
- Previous limits were 60s (full smoke) and 30s (classify-only), causing false-positive `✗ classification` failures even when the model returns correct results
- Raised both to 180s to cover M1 with headroom

## Test plan
- [ ] Run `meridian smoke` on M1 — should now show `✓ classification` instead of `✗`
- [ ] Run `meridian doctor` — smoke section should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)