### PR TITLE
fix(install): stage screenpipe binary to ~/.meridian/bin for stable TCC path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -238,13 +238,12 @@ prompt_permissions() {
         info "Skipping permissions walkthrough (--skip-permissions)"
         return 0
     fi
-    local sp_bin
-    sp_bin="$(command -v screenpipe 2>/dev/null || echo "/opt/homebrew/bin/screenpipe")"
+    local sp_bin="${HOME}/.meridian/bin/screenpipe"
     info "screenpipe needs three macOS permissions to record activity"
     echo "    binary path: ${sp_bin}"
     echo
-    echo "    Screen Recording + Accessibility panes: click '+', navigate to the"
-    echo "    binary path above, add it to the list, and toggle it ON."
+    echo "    Screen Recording + Accessibility panes: click '+' → ⌘⇧G → paste"
+    echo "    the path above → Open → toggle ON."
     echo "    Microphone pane has no '+'. screenpipe will appear there only after"
     echo "    it tries to use the mic — then toggle it ON. If it isn't listed yet,"
     echo "    grant Screen Recording first and screenpipe will request mic access."
@@ -521,6 +520,23 @@ else
     fi
 fi
 ok "screenpipe"
+# Stage the real screenpipe Mach-O to ~/.meridian/bin/screenpipe — stable path
+# independent of npm prefix (nvm users have a version-specific path that breaks
+# on `nvm use` and is too deep to navigate in System Settings).
+mkdir -p "${HOME}/.meridian/bin"
+_sp_npm_root="$(npm root -g 2>/dev/null || true)"
+_sp_real=""
+if [[ -n "${_sp_npm_root}" && -d "${_sp_npm_root}/screenpipe" ]]; then
+    while IFS= read -r _sp_cand; do
+        if file "${_sp_cand}" 2>/dev/null | grep -q "Mach-O"; then _sp_real="${_sp_cand}"; break; fi
+    done < <(find "${_sp_npm_root}/screenpipe" -type f -name screenpipe -perm +0111 2>/dev/null)
+fi
+if [[ -n "${_sp_real}" ]]; then
+    cmp -s "${_sp_real}" "${HOME}/.meridian/bin/screenpipe" 2>/dev/null \
+        || cp "${_sp_real}" "${HOME}/.meridian/bin/screenpipe"
+    chmod +x "${HOME}/.meridian/bin/screenpipe"
+    ok "screenpipe staged → ${HOME}/.meridian/bin/screenpipe"
+fi
 
 if ! command -v ffmpeg >/dev/null 2>&1 || [[ ! -x /opt/homebrew/bin/ffmpeg && ! -x /usr/local/bin/ffmpeg ]]; then
     warn "ffmpeg not found on the launchd PATH (screenpipe can't auto-install it from a daemon context)."

--- a/scripts/install-screenpipe-daemon.sh
+++ b/scripts/install-screenpipe-daemon.sh
@@ -40,21 +40,37 @@ fi
 # attaches to a stable binary named `screenpipe` (and survives reinstalls of the
 # same version, since its path is fixed). Falls back to whatever `command -v`
 # found when screenpipe is a native binary (Homebrew) rather than the npm shim.
-SCREENPIPE_BIN="$(command -v screenpipe)" || true
-if [[ -z "${SCREENPIPE_BIN}" ]]; then
-    echo "✗ screenpipe binary not found in PATH — install with: npm install -g screenpipe" >&2
-    exit 1
-fi
-_npm_root="$(npm root -g 2>/dev/null || true)"
-if [[ -n "${_npm_root}" && -d "${_npm_root}/screenpipe" ]]; then
-    _real=""
-    while IFS= read -r _cand; do
-        if file "${_cand}" 2>/dev/null | grep -q "Mach-O"; then _real="${_cand}"; break; fi
-    done < <(find "${_npm_root}/screenpipe" -type f -name screenpipe -perm +0111 2>/dev/null)
-    if [[ -n "${_real}" ]]; then
-        SCREENPIPE_BIN="${_real}"
-        echo "→ using the real screenpipe binary (not the node wrapper): ${SCREENPIPE_BIN}"
+STAGED_BIN="${HOME}/.meridian/bin/screenpipe"
+
+# Prefer the already-staged stable binary (written by install-from-bundle.sh).
+# On a standalone re-run of this script (e.g. `meridian repair`) resolve the
+# real Mach-O from the npm tree and stage it so the launchd plist is immune to
+# nvm version changes — the npm shim path under ~/.nvm is version-specific and
+# breaks silently when the user runs `nvm use` or upgrades Node.
+if [[ -x "${STAGED_BIN}" ]] && file "${STAGED_BIN}" 2>/dev/null | grep -q "Mach-O"; then
+    SCREENPIPE_BIN="${STAGED_BIN}"
+    echo "→ using staged screenpipe binary: ${SCREENPIPE_BIN}"
+else
+    SCREENPIPE_BIN="$(command -v screenpipe 2>/dev/null || true)"
+    if [[ -z "${SCREENPIPE_BIN}" ]]; then
+        echo "✗ screenpipe not found in PATH — install with: npm install -g screenpipe" >&2
+        exit 1
     fi
+    _npm_root="$(npm root -g 2>/dev/null || true)"
+    if [[ -n "${_npm_root}" && -d "${_npm_root}/screenpipe" ]]; then
+        _real=""
+        while IFS= read -r _cand; do
+            if file "${_cand}" 2>/dev/null | grep -q "Mach-O"; then _real="${_cand}"; break; fi
+        done < <(find "${_npm_root}/screenpipe" -type f -name screenpipe -perm +0111 2>/dev/null)
+        if [[ -n "${_real}" ]]; then
+            SCREENPIPE_BIN="${_real}"
+        fi
+    fi
+    mkdir -p "${HOME}/.meridian/bin"
+    cp "${SCREENPIPE_BIN}" "${STAGED_BIN}"
+    chmod +x "${STAGED_BIN}"
+    SCREENPIPE_BIN="${STAGED_BIN}"
+    echo "→ staged screenpipe binary: ${SCREENPIPE_BIN}"
 fi
 
 mkdir -p "${HOME}/.meridian/logs"

--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -498,13 +498,12 @@ cmd_uninstall() {
 
 # --- permissions ---
 cmd_permissions() {
-    local sp_bin
-    sp_bin="$(command -v screenpipe 2>/dev/null || echo "/opt/homebrew/bin/screenpipe")"
+    local sp_bin="${HOME}/.meridian/bin/screenpipe"
     info "screenpipe needs three macOS permissions to record activity"
     echo "    binary path: ${sp_bin}"
     echo
-    echo "    Screen Recording + Accessibility panes: click '+', navigate to the"
-    echo "    binary path above, add it to the list, and toggle it ON."
+    echo "    Screen Recording + Accessibility panes: click '+' → ⌘⇧G → paste"
+    echo "    the path above → Open → toggle ON."
     echo "    Microphone pane has no '+'. screenpipe will appear there only after"
     echo "    it tries to use the mic — then toggle it ON. If it isn't listed yet,"
     echo "    grant Screen Recording first and screenpipe will request mic access."


### PR DESCRIPTION
## Summary

- **Root cause**: nvm users had screenpipe installed at `~/.nvm/versions/node/<version>/lib/node_modules/...` — a version-specific, hidden path that (1) breaks silently when the user runs `nvm use` or upgrades Node, and (2) is too deeply nested for System Settings to navigate when manually adding to Accessibility/Screen Recording
- **Fix**: after installing screenpipe via npm, resolve the real Mach-O binary from the npm tree and copy it to `~/.meridian/bin/screenpipe` — the same stable, user-visible location already used for `meridian-a11y-helper`. The launchd plist and TCC grants are always written against this stable path

## Files changed

- **`scripts/install-screenpipe-daemon.sh`**: prefer already-staged `~/.meridian/bin/screenpipe`; falls back to resolve + stage on standalone re-runs (e.g. `meridian repair`)
- **`install.sh`**: same staging logic for dev/source installs; `cmd_permissions` now prints the stable path
- **`scripts/meridian-cli.sh`**: `meridian permissions` now shows `~/.meridian/bin/screenpipe` instead of `which screenpipe`

Note: `install-from-bundle.sh` staging was already on main from a prior session.

## Test plan

- [ ] Fresh install with nvm Node — confirm `~/.meridian/bin/screenpipe` exists after setup
- [ ] `meridian status` shows screenpipe running
- [ ] `meridian permissions` prints `~/.meridian/bin/screenpipe`
- [ ] System Settings Accessibility pane accepts `~/.meridian/bin/screenpipe` via `⌘⇧G`
- [ ] Switching Node version via `nvm use` does not break screenpipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)