### PR TITLE
fix(install): preserve screenpipe plist path on update to avoid TCC grant invalidation

### DIFF
--- a/scripts/install-screenpipe-daemon.sh
+++ b/scripts/install-screenpipe-daemon.sh
@@ -42,12 +42,32 @@ fi
 # found when screenpipe is a native binary (Homebrew) rather than the npm shim.
 STAGED_BIN="${HOME}/.meridian/bin/screenpipe"
 
-# Prefer the already-staged stable binary (written by install-from-bundle.sh).
-# On a standalone re-run of this script (e.g. `meridian repair`) resolve the
-# real Mach-O from the npm tree and stage it so the launchd plist is immune to
-# nvm version changes — the npm shim path under ~/.nvm is version-specific and
-# breaks silently when the user runs `nvm use` or upgrades Node.
-if [[ -x "${STAGED_BIN}" ]] && file "${STAGED_BIN}" 2>/dev/null | grep -q "Mach-O"; then
+# Determine the binary path to write into the plist.
+#
+# Priority order — chosen to avoid invalidating existing TCC grants:
+#
+# 1. Existing plist path is still a valid Mach-O → keep it.
+#    macOS TCC grants are per absolute path. Changing the path silently
+#    revokes the grant and breaks screenpipe on the next start. Preserve
+#    the old path on updates so working installs stay working.
+#
+# 2. Already-staged stable binary exists → use it.
+#    Covers fresh installs and repairs where no old plist exists.
+#
+# 3. Resolve the real Mach-O from the npm tree → stage it → use it.
+#    Handles new installs where neither a plist nor a staged binary exists.
+#    nvm users get a version-specific path under ~/.nvm that breaks on
+#    `nvm use` or Node upgrades, so we always copy to the stable
+#    ~/.meridian/bin/screenpipe location.
+_old_plist_bin=""
+if [[ -f "${PLIST_DEST}" ]]; then
+    _old_plist_bin="$(plutil -extract ProgramArguments.0 raw "${PLIST_DEST}" 2>/dev/null || true)"
+fi
+
+if [[ -n "${_old_plist_bin}" ]] && [[ -x "${_old_plist_bin}" ]] && file "${_old_plist_bin}" 2>/dev/null | grep -q "Mach-O"; then
+    SCREENPIPE_BIN="${_old_plist_bin}"
+    echo "→ keeping existing screenpipe binary (preserves TCC grant): ${SCREENPIPE_BIN}"
+elif [[ -x "${STAGED_BIN}" ]] && file "${STAGED_BIN}" 2>/dev/null | grep -q "Mach-O"; then
     SCREENPIPE_BIN="${STAGED_BIN}"
     echo "→ using staged screenpipe binary: ${SCREENPIPE_BIN}"
 else


### PR DESCRIPTION
## Problem

PR #209 staged the screenpipe binary to `~/.meridian/bin/screenpipe` and updated the launchd plist to point there. But changing the plist path on an existing install silently revokes the macOS TCC grant — Screen Recording and Accessibility grants are per absolute path. Every user running `meridian update` would have screenpipe crash on next start even if it was working before.

## Fix

New priority order in `install-screenpipe-daemon.sh`:

1. **Existing plist path still a valid Mach-O** → keep it. Preserves TCC grant on updates — working installs stay working.
2. **Already-staged `~/.meridian/bin/screenpipe` exists** → use it. Covers fresh installs and repairs with no old plist.
3. **Resolve from npm tree + stage** → new installs where neither a plist nor a staged binary exists. nvm users get the stable `~/.meridian/bin/` path from day one.

## Behaviour by scenario

| Scenario | Before | After |
|----------|--------|-------|
| Existing working install, `meridian update` | Path changes → TCC revoked → screenpipe crashes | Path preserved → TCC intact → screenpipe keeps running |
| Fresh install (nvm user) | nvm path in plist → breaks on `nvm use` | `~/.meridian/bin/screenpipe` in plist → stable |
| Fresh install (Homebrew Node) | npm-global path in plist | `~/.meridian/bin/screenpipe` in plist → stable |
| Broken install (no plist) | — | Stages + uses `~/.meridian/bin/screenpipe` |

## Test plan

- [ ] `meridian update` on a working install — screenpipe stays running, plist path unchanged
- [ ] Fresh install — plist points to `~/.meridian/bin/screenpipe`
- [ ] nvm user fresh install — same stable path, not the nvm tree path

🤖 Generated with [Claude Code](https://claude.com/claude-code)