### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/Meridiona/meridian/security/code-scanning/1](https://github.com/Meridiona/meridian/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (best here since there is one job and all steps share the same minimal needs). Set:

- `contents: read`

This preserves current behavior (checkout and reads still work) while ensuring the token cannot write unless later explicitly granted.  
Change location: `.github/workflows/ci.yml`, insert the block after the `on:` section (before `concurrency:`), or equivalently near top-level keys.

No imports, methods, or dependencies are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
