### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/scripts/refresh_pm_tasks.py
+++ b/scripts/refresh_pm_tasks.py
@@ -179,9 +179,8 @@ def main() -> int:
     base_url = os.environ.get("JIRA_BASE_URL", os.environ.get("JIRA_URL", "")).rstrip("/")
     email = os.environ.get("JIRA_EMAIL", "")
     token = os.environ.get("JIRA_API_TOKEN", "")
-    missing = [k for k, v in (("JIRA_BASE_URL or JIRA_URL", base_url), ("JIRA_EMAIL", email), ("JIRA_API_TOKEN", token)) if not v]
-    if missing:
-        log.error("missing env: %s", ", ".join(missing))
+    if not (base_url and email and token):
+        log.error("missing required Jira credentials/configuration in environment")
         return 2
 
     log.info("jira: %s  jql=%r  limit=%d", base_url, args.jql, args.limit)


### PR DESCRIPTION
Potential fix for [https://github.com/Meridiona/meridian/security/code-scanning/2](https://github.com/Meridiona/meridian/security/code-scanning/2)

General fix: never include sensitive values (or sensitive-field identifiers) in error logs for auth/config failures. Log a generic message and keep detailed diagnostics out of logs.

Best targeted fix in `scripts/refresh_pm_tasks.py`:
- Replace the computed `missing` list of specific env var names with a simple boolean check for required values.
- Replace `log.error("missing env: %s", ", ".join(missing))` with a generic non-sensitive error string.
- Keep return code and control flow unchanged.

This preserves functionality (still fails fast when required env vars are absent) while removing sensitive/config-identifying log content that triggered CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
