### PR TITLE
feat(trello): inject app key at package time, document setup flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,15 @@
 # LINEAR_TEAM_IDS=ENG,DESIGN          # optional — comma-separated team KEY or id; empty = all teams
 
 # ---------------------------------------------------------------------------
+# Trello — browser OAuth (`meridian oauth-login trello`).
+# TRELLO_APP_KEY is Meridian's Power-Up identity key (like an OAuth client_id).
+# It is injected into the bundle .env by package-release.sh — never commit the
+# real key to source. Users connect with their own Trello account via OAuth;
+# their personal token lands in ~/.meridian/oauth/trello.json.
+# ---------------------------------------------------------------------------
+# TRELLO_APP_KEY=                     # injected at package time
+
+# ---------------------------------------------------------------------------
 # Python LLM backend — cloud fallback for the coding-agent summariser (Claude/
 # Codex paths). The MLX classifier server ignores these.
 # ---------------------------------------------------------------------------

--- a/SETUP.md
+++ b/SETUP.md
@@ -33,7 +33,7 @@ meridian restart
 
 ---
 
-## Connect your tracker (Jira, Linear, or GitHub)
+## Connect your tracker (Jira, Linear, GitHub, or Trello)
 
 Edit the config file:
 
@@ -91,6 +91,17 @@ GITHUB_PROJECT_IDS=PVT_xxx,PVT_yyy
 ```
 
 To find your project node ID: `gh api graphql -f query='{ viewer { projectsV2(first: 10) { nodes { id title } } } }'`
+
+### Trello
+
+The installer offers Trello browser sign-in during `meridian setup`. To connect manually or re-connect:
+
+```bash
+meridian oauth-login trello    # opens your browser → click Allow
+meridian restart
+```
+
+Your token is saved to `~/.meridian/oauth/trello.json`. Meridian syncs open cards assigned to you across all your boards.
 
 Worklogs are **never posted automatically** — Meridian drafts them for you to review and approve in the dashboard.
 

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -203,6 +203,21 @@ cp scripts/a11y-helper/meridian-a11y-helper "${DEST}/scripts/a11y-helper/"
 
 echo "→ config template + version stamp"
 cp .env.example "${DEST}/.env.example"
+
+# Inject the Trello Power-Up app key into the bundle .env so the daemon can
+# run `meridian oauth-login trello` without the user setting anything manually.
+# Read from the repo .env (gitignored); skip silently if not set.
+_trello_key=""
+if [[ -f ".env" ]]; then
+    _trello_key="$(grep -E '^TRELLO_APP_KEY=' .env | cut -d= -f2- | tr -d '[:space:]')" || true
+fi
+if [[ -n "${_trello_key}" ]]; then
+    echo "  injecting TRELLO_APP_KEY into bundle .env.example"
+    sed -i '' "s|^# TRELLO_APP_KEY=.*|TRELLO_APP_KEY=${_trello_key}|" "${DEST}/.env.example"
+else
+    echo "  ⚠ TRELLO_APP_KEY not set in .env — Trello OAuth will not work in this bundle"
+fi
+
 printf '%s\n' "${VERSION}" > "${DEST}/VERSION"
 
 echo "✓ ${DEST} populated"

--- a/src/intelligence/oauth/flow.rs
+++ b/src/intelligence/oauth/flow.rs
@@ -300,25 +300,18 @@ async fn accept_fragment_relay(listener: &TcpListener) -> Result<String> {
 
         if target.starts_with("/capture") {
             // Second request: JS relayed the token as ?t=TOKEN
-            let token = target
-                .split('?')
-                .nth(1)
-                .and_then(|q| {
-                    q.split('&').find_map(|pair| {
-                        let mut it = pair.splitn(2, '=');
-                        match (it.next(), it.next()) {
-                            (Some("t"), Some(v)) => Some(decode(v)),
-                            _ => None,
-                        }
-                    })
-                });
+            let token = target.split('?').nth(1).and_then(|q| {
+                q.split('&').find_map(|pair| {
+                    let mut it = pair.splitn(2, '=');
+                    match (it.next(), it.next()) {
+                        (Some("t"), Some(v)) => Some(decode(v)),
+                        _ => None,
+                    }
+                })
+            });
             match token {
                 Some(t) if !t.is_empty() => {
-                    let _ = respond(
-                        &mut socket,
-                        "Trello connected! You can close this tab.",
-                    )
-                    .await;
+                    let _ = respond(&mut socket, "Trello connected! You can close this tab.").await;
                     return Ok(t);
                 }
                 _ => {

--- a/src/intelligence/providers/trello.rs
+++ b/src/intelligence/providers/trello.rs
@@ -166,10 +166,7 @@ async fn prune(pool: &SqlitePool, fetched_keys: &[String]) -> Result<usize> {
     for key in fetched_keys {
         q = q.bind(key.as_str());
     }
-    let result = q
-        .execute(pool)
-        .await
-        .context("pruning trello pm_tasks")?;
+    let result = q.execute(pool).await.context("pruning trello pm_tasks")?;
     Ok(result.rows_affected() as usize)
 }
 
@@ -221,8 +218,8 @@ pub async fn refresh_if_stale(
                         Err(e) => tracing::warn!(error = %e, "trello prune failed"),
                     }
                 } else if let Err(e) = sqlx::query("DELETE FROM pm_tasks WHERE provider = 'trello'")
-                        .execute(pool)
-                        .await
+                    .execute(pool)
+                    .await
                 {
                     tracing::warn!(error = %e, "trello full-clear failed");
                 }

--- a/src/pm_worklog/post.rs
+++ b/src/pm_worklog/post.rs
@@ -21,7 +21,9 @@ use anyhow::Result;
 use sqlx::SqlitePool;
 use tokio::sync::watch;
 
-use crate::config::{Config, GitHubConfig, JiraConfig, LinearConfig, PmProviderConfig, TrelloConfig};
+use crate::config::{
+    Config, GitHubConfig, JiraConfig, LinearConfig, PmProviderConfig, TrelloConfig,
+};
 
 use super::config::PmWorklogConfig;
 use super::{db, github, jira, linear, trello};

--- a/src/pm_worklog/trello.rs
+++ b/src/pm_worklog/trello.rs
@@ -32,7 +32,12 @@ pub async fn post_worklog(
 
     let token = oauth_trello::load_token().context("loading Trello OAuth token")?;
     let short_link = parse_short_link(task_key)?;
-    let body = format_worklog_comment(comment, time_spent_seconds, window_start_iso, window_end_iso);
+    let body = format_worklog_comment(
+        comment,
+        time_spent_seconds,
+        window_start_iso,
+        window_end_iso,
+    );
 
     let url = format!(
         "{TRELLO_BASE}/cards/{short_link}/actions/comments\


### PR DESCRIPTION
## Summary

- `package-release.sh` now reads `TRELLO_APP_KEY` from the repo `.env` (gitignored) and injects it into the bundle `.env.example` at package time — users get Trello OAuth working out of the box after install
- `.env.example` gains a Trello section explaining the key's purpose and that it's injected at build time (never committed)
- `SETUP.md` updated: tracker section heading includes Trello, new Trello subsection with `meridian oauth-login trello` instructions

## Test plan

- [ ] Run `package-release.sh` with `TRELLO_APP_KEY` set in repo `.env` — verify bundle `.env.example` has the key uncommented
- [ ] Run `package-release.sh` without `TRELLO_APP_KEY` — verify warning is printed and key stays commented
- [ ] On a fresh install from the bundle, verify `meridian oauth-login trello` opens the browser without needing manual `.env` edits