### PR TITLE
fix(packaging): include lib-trello-setup.sh in release bundle

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -181,7 +181,7 @@ tar cf - \
 echo "→ scripts + plists + CLI"
 cp scripts/meridian-cli.sh scripts/install-from-bundle.sh scripts/meridian-npm-setup.sh \
    scripts/bootstrap.sh scripts/ui-start.sh scripts/lib-github-setup.sh \
-   scripts/lib-jira-setup.sh "${DEST}/scripts/"
+   scripts/lib-jira-setup.sh scripts/lib-trello-setup.sh "${DEST}/scripts/"
 cp scripts/install-daemon.sh scripts/uninstall-daemon.sh \
    scripts/install-ui-daemon.sh scripts/uninstall-ui-daemon.sh \
    scripts/install-screenpipe-daemon.sh scripts/uninstall-screenpipe-daemon.sh \


### PR DESCRIPTION
## Summary

- `package-release.sh` has an explicit allowlist of scripts copied into the bundle; `lib-trello-setup.sh` was missing from it
- `install-from-bundle.sh` sources it at line 118, so fresh installs were failing with: `lib-trello-setup.sh: No such file or directory`

## Root cause

Every new `scripts/lib-*.sh` file must be manually added to the `cp` list in `package-release.sh`. This was missed when the Trello integration was shipped.

## Test plan

- [ ] Run `package-release.sh` and verify `lib-trello-setup.sh` exists in the bundle's `scripts/` directory
- [ ] Fresh curl install completes without the "No such file or directory" error