### PR TITLE
fix(ui): stop the dashboard crash-looping under a mismatched Node after `meridian update`

### DIFF
--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -671,13 +671,18 @@ if command -v cursor >/dev/null 2>&1 || [[ -d "${HOME}/Library/Application Suppo
     fi
 fi
 
-# UI: skip daemon restart when the build didn't change (tarball hash matched).
+# UI: even when the build is unchanged we ALWAYS re-pin the Node runtime and
+# reload the launchd job. The better-sqlite3 addon is ABI-locked to one Node
+# version; skipping this reload is how a stale UI job survives `update` and ends
+# up running a mismatched system Node (NODE_MODULE_VERSION crash-loop). The
+# expensive re-extraction is already skipped above when unchanged, so this is
+# cheap — resolve_node_runtime hits the cache, then bootout/bootstrap reloads.
 if [[ "${_ui_changed}" -eq 0 ]]; then
-    ok "Dashboard unchanged — skipping restart"
+    info "Dashboard build unchanged — re-pinning Node runtime and reloading UI agent…"
 else
     info "Installing the dashboard (UI) launchd agent…"
-    install_ui_standalone
 fi
+install_ui_standalone
 
 # Persist component hashes for the next update's differential check.
 # Write to a temp file and rename atomically so a crash mid-write never leaves

--- a/scripts/ui-start.sh
+++ b/scripts/ui-start.sh
@@ -3,24 +3,66 @@
 #
 # Startup wrapper for the Next.js UI daemon.
 #
-# MERIDIAN_NODE_BIN is set by the launchd plist to the ABI-matched Node 22 runtime
-# that install-from-bundle.sh downloaded and cached under ~/.meridian/node-runtime.
-# That is the exact Node version CI built the better-sqlite3 addon in ui.tar.gz
-# against, so the ABI always matches. Fall back to system node only if unset.
+# The dashboard's better-sqlite3 native addon is ABI-locked to ONE exact Node
+# version — the one CI built it against, recorded in bin/node-runtime.meta as
+# NODE_RUNTIME_VERSION. Running any other Node major triggers a
+# NODE_MODULE_VERSION (ABI) mismatch and the dashboard crash-loops. So on a
+# bundle install we resolve the cached, version-matched runtime under
+# ~/.meridian/node-runtime ourselves — we do NOT trust a stale MERIDIAN_NODE_BIN
+# or system node that a `meridian update` may have left behind (that is exactly
+# how the UI ended up on a mismatched Node). If the matched runtime is missing we
+# fail LOUD with remediation rather than silently crash-looping under the wrong
+# Node. (A source/dev install has no meta file: there better-sqlite3 was compiled
+# against the local node, so we prefer MERIDIAN_NODE_BIN then system node.)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_ROOT="$(dirname "${SCRIPT_DIR}")"
+META="${APP_ROOT}/bin/node-runtime.meta"
 
-# Resolve node: prefer the path baked in at install time (MERIDIAN_NODE_BIN),
-# fall back to well-known Homebrew / system locations. launchd agents don't
-# inherit the user's PATH, so we can't rely on `command -v node`.
-NODE="${MERIDIAN_NODE_BIN:-}"
-if [[ -z "${NODE}" ]] || [[ ! -x "${NODE}" ]]; then
-    for _n in /opt/homebrew/bin/node /usr/local/bin/node /usr/bin/node; do
-        if [[ -x "${_n}" ]]; then NODE="${_n}"; break; fi
-    done
+log() { echo "[meridian-ui] $*" >&2; }
+
+# `node -v` → bare version (strip the leading "v"); empty if it can't run.
+node_version() { "${1}" -v 2>/dev/null | sed 's/^v//'; }
+
+# The exact Node version the shipped addon was built against (bundle install
+# only). `|| true` so a malformed/lineless meta doesn't trip `set -e`.
+REQUIRED_VER=""
+if [[ -f "${META}" ]]; then
+    REQUIRED_VER="$(grep '^NODE_RUNTIME_VERSION=' "${META}" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]' || true)"
 fi
-[[ -x "${NODE:-}" ]] || { echo "[meridian-ui] node not found — cannot start UI server" >&2; exit 1; }
+
+NODE=""
+if [[ -n "${REQUIRED_VER}" ]]; then
+    # Bundle install: enforce the ABI-matched runtime. The cached runtime that
+    # install-from-bundle.sh downloaded for this exact version is the source of
+    # truth; accept MERIDIAN_NODE_BIN only if it actually IS that version.
+    cached="${HOME}/.meridian/node-runtime/v${REQUIRED_VER}/bin/node"
+    if [[ -x "${cached}" ]] && [[ "$(node_version "${cached}")" == "${REQUIRED_VER}" ]]; then
+        NODE="${cached}"
+    elif [[ -n "${MERIDIAN_NODE_BIN:-}" ]] && [[ -x "${MERIDIAN_NODE_BIN}" ]] \
+         && [[ "$(node_version "${MERIDIAN_NODE_BIN}")" == "${REQUIRED_VER}" ]]; then
+        NODE="${MERIDIAN_NODE_BIN}"
+    else
+        log "dashboard requires Node ${REQUIRED_VER} (better-sqlite3 ABI), but the"
+        log "cached runtime at ${cached} is missing or wrong-versioned."
+        log "Fetch it: run 'meridian update' with a connection, or reinstall:"
+        log "  curl -fsSL https://raw.githubusercontent.com/Meridiona/meridian/main/scripts/bootstrap.sh | bash"
+        # EX_CONFIG: refuse to start under a mismatched Node. KeepAlive will retry,
+        # but the log now states the exact cause instead of a cryptic ERR_DLOPEN.
+        exit 78
+    fi
+else
+    # Source/dev install (no meta): better-sqlite3 was compiled against the local
+    # node, so prefer MERIDIAN_NODE_BIN then system node — ABI matches by build.
+    # launchd agents don't inherit the user's PATH, so probe known locations.
+    NODE="${MERIDIAN_NODE_BIN:-}"
+    if [[ -z "${NODE}" ]] || [[ ! -x "${NODE}" ]]; then
+        for _n in /opt/homebrew/bin/node /usr/local/bin/node /usr/bin/node; do
+            if [[ -x "${_n}" ]]; then NODE="${_n}"; break; fi
+        done
+    fi
+    [[ -x "${NODE:-}" ]] || { log "node not found — cannot start UI server"; exit 1; }
+fi
 
 exec "${NODE}" "${APP_ROOT}/ui/server.js"

--- a/src/intelligence/oauth/flow.rs
+++ b/src/intelligence/oauth/flow.rs
@@ -300,25 +300,18 @@ async fn accept_fragment_relay(listener: &TcpListener) -> Result<String> {
 
         if target.starts_with("/capture") {
             // Second request: JS relayed the token as ?t=TOKEN
-            let token = target
-                .split('?')
-                .nth(1)
-                .and_then(|q| {
-                    q.split('&').find_map(|pair| {
-                        let mut it = pair.splitn(2, '=');
-                        match (it.next(), it.next()) {
-                            (Some("t"), Some(v)) => Some(decode(v)),
-                            _ => None,
-                        }
-                    })
-                });
+            let token = target.split('?').nth(1).and_then(|q| {
+                q.split('&').find_map(|pair| {
+                    let mut it = pair.splitn(2, '=');
+                    match (it.next(), it.next()) {
+                        (Some("t"), Some(v)) => Some(decode(v)),
+                        _ => None,
+                    }
+                })
+            });
             match token {
                 Some(t) if !t.is_empty() => {
-                    let _ = respond(
-                        &mut socket,
-                        "Trello connected! You can close this tab.",
-                    )
-                    .await;
+                    let _ = respond(&mut socket, "Trello connected! You can close this tab.").await;
                     return Ok(t);
                 }
                 _ => {

--- a/src/intelligence/providers/trello.rs
+++ b/src/intelligence/providers/trello.rs
@@ -166,10 +166,7 @@ async fn prune(pool: &SqlitePool, fetched_keys: &[String]) -> Result<usize> {
     for key in fetched_keys {
         q = q.bind(key.as_str());
     }
-    let result = q
-        .execute(pool)
-        .await
-        .context("pruning trello pm_tasks")?;
+    let result = q.execute(pool).await.context("pruning trello pm_tasks")?;
     Ok(result.rows_affected() as usize)
 }
 
@@ -221,8 +218,8 @@ pub async fn refresh_if_stale(
                         Err(e) => tracing::warn!(error = %e, "trello prune failed"),
                     }
                 } else if let Err(e) = sqlx::query("DELETE FROM pm_tasks WHERE provider = 'trello'")
-                        .execute(pool)
-                        .await
+                    .execute(pool)
+                    .await
                 {
                     tracing::warn!(error = %e, "trello full-clear failed");
                 }

--- a/src/pm_worklog/post.rs
+++ b/src/pm_worklog/post.rs
@@ -21,7 +21,9 @@ use anyhow::Result;
 use sqlx::SqlitePool;
 use tokio::sync::watch;
 
-use crate::config::{Config, GitHubConfig, JiraConfig, LinearConfig, PmProviderConfig, TrelloConfig};
+use crate::config::{
+    Config, GitHubConfig, JiraConfig, LinearConfig, PmProviderConfig, TrelloConfig,
+};
 
 use super::config::PmWorklogConfig;
 use super::{db, github, jira, linear, trello};

--- a/src/pm_worklog/trello.rs
+++ b/src/pm_worklog/trello.rs
@@ -32,7 +32,12 @@ pub async fn post_worklog(
 
     let token = oauth_trello::load_token().context("loading Trello OAuth token")?;
     let short_link = parse_short_link(task_key)?;
-    let body = format_worklog_comment(comment, time_spent_seconds, window_start_iso, window_end_iso);
+    let body = format_worklog_comment(
+        comment,
+        time_spent_seconds,
+        window_start_iso,
+        window_end_iso,
+    );
 
     let url = format!(
         "{TRELLO_BASE}/cards/{short_link}/actions/comments\


### PR DESCRIPTION
## Symptom

After `meridian update`, the dashboard goes down and stays down. `meridian doctor` shows the UI `loaded but not running`; `~/.meridian/logs/ui-error.log` is full of:

```
better_sqlite3.node was compiled against NODE_MODULE_VERSION 127 … requires 141
code: 'ERR_DLOPEN_FAILED'
```

The UI launchd job (`exit 78`) crash-loops via `KeepAlive`. `meridian restart` doesn't fix it.

## Root cause

The dashboard's `better-sqlite3` native addon is **ABI-locked to one exact Node version**. CI (Node 24) deliberately swaps in the official prebuilt for **Node 22.22.3 (ABI 127)** and records it in `bin/node-runtime.meta` (`NODE_RUNTIME_VERSION=22.22.3`); `install_ui_standalone()` downloads that runtime, pins it via `MERIDIAN_NODE_BIN`, and reloads the launchd job. **127 = Node 22, 141 = Node 25.** So the addon is correct — the UI was just *running under the wrong Node* (system Node 25). Two code paths combined to cause that:

1. **`install-from-bundle.sh` skipped the reload on update.** When the UI tarball hash was unchanged (`_ui_changed -eq 0`), it skipped `install_ui_standalone` entirely — the only thing that re-pins the Node runtime and reloads the job. So a **stale UI launchd job survived `update`**, still resolving Node via system PATH.
2. **`ui-start.sh` silently fell back to system Node.** With `MERIDIAN_NODE_BIN` unset/stale, it used `/opt/homebrew/bin/node` (Node 25) → ABI mismatch with the Node-22 addon → `ERR_DLOPEN_FAILED` → crash-loop with an opaque error.

The trigger is common: a user upgrades system Node (or `update` leaves a stale job), and the UI lands on a Node whose ABI doesn't match the shipped addon.

## Fix (two parts)

**1. `ui-start.sh` — derive the Node from the contract, fail loud on mismatch** *(the durable guarantee)*
- Reads `NODE_RUNTIME_VERSION` from `node-runtime.meta` and, on a bundle install, runs **only** the cached version-matched runtime under `~/.meridian/node-runtime`. `MERIDIAN_NODE_BIN` is accepted **only if it actually is that version**.
- If no matching runtime exists, it **exits 78 (EX_CONFIG) with a clear remediation message** instead of crash-looping under the wrong Node.
- Because the wrapper is re-read from disk on every (re)start, this **self-heals a stale launchd job**.
- Source/dev installs (no meta) keep the prior prefer-`MERIDIAN_NODE_BIN`-then-system behaviour (there the addon is compiled against local node).

**2. `install-from-bundle.sh` — always reload the UI agent on update** *(the root-cause fix)*
- Stop skipping `install_ui_standalone` when the build is unchanged. The expensive re-extraction is still skipped; `resolve_node_runtime` hits the cache, so this is just a fast `bootout`/`bootstrap` — cheap insurance against a stale, ABI-mismatched job.

## Testing

Exercised all four `ui-start.sh` resolution branches with a fake bundle layout:

| Case | Result |
|---|---|
| meta + cached runtime matches version | ✅ runs cached node, starts server |
| meta + no cache + `MERIDIAN_NODE_BIN` wrong version | ✅ **exits 78, refuses system node** (the bug scenario) |
| meta + `MERIDIAN_NODE_BIN` is the required version | ✅ uses it |
| no meta (source install) | ✅ falls back to `MERIDIAN_NODE_BIN` |

`bash -n` clean on both scripts; full pre-push suite (fmt + clippy + UI tests + cargo test) passes. (The bundle/update path can't be exercised on a source checkout — the in-product version-match + loud-fail is the safety net.)

## Note on the first commit

`b3e38a6 style(fmt)` is **not part of this fix** — it's pre-existing `cargo fmt` drift from the Trello merge (`flow.rs`, `providers/trello.rs`, `pm_worklog/{post,trello}.rs`) that landed on `main` un-formatted, so `cargo fmt --check` (and the commit/push hooks) fail on a clean `main`. Pure formatter output, no logic change; included so this branch can pass the format gate. **`main` currently fails its own fmt gate** — worth a look independently.

## Not covered

This fixes *future* updates. An already-broken machine needs a **one-time** clean reload/reinstall (`bootstrap.sh`) to lay down the corrected `ui-start.sh` and reload the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)