### PR TITLE
feat(setup): auto-install + sign in to gh when configuring GitHub (no PAT)

### DIFF
--- a/scripts/lib-github-setup.sh
+++ b/scripts/lib-github-setup.sh
@@ -10,15 +10,42 @@
 # scopes: `repo` (post worklog / task-update issue comments) and `read:project`
 # (read Projects v2 via GraphQL). gh's default web-login grants repo + read:org
 # but not read:project, so add whatever is missing through the same browser flow,
-# then write the OAuth token to GITHUB_TOKEN. Returns non-zero if gh is missing,
-# unauthenticated, or the scope refresh fails, so the caller can fall back to a
-# manual PAT prompt. An existing GITHUB_TOKEN is kept untouched.
+# then write the OAuth token to GITHUB_TOKEN.
+#
+# Since the user has opted into GitHub, drive the whole no-PAT path for them:
+# install gh via Homebrew if it's missing (the installer already brew-installs
+# node/ffmpeg/uv the same way) and run gh's browser sign-in if they're not
+# authenticated. Returns non-zero only if gh can't be installed, the sign-in
+# fails, or the scope refresh fails, so the caller can fall back to a manual PAT
+# prompt. An existing GITHUB_TOKEN is kept untouched.
 _try_gh_token() {
     local env_file="$1"
     [[ -n "$(get_env_value GITHUB_TOKEN "$env_file")" ]] && {
         ok "GITHUB_TOKEN already set — keeping"; return 0
     }
+
+    # gh missing → install it (best-effort). Without Homebrew we can't, so fall
+    # back to the PAT prompt.
+    if ! command -v gh >/dev/null 2>&1; then
+        if command -v brew >/dev/null 2>&1; then
+            info "  Installing GitHub CLI (gh) for no-PAT sign-in…"
+            brew install gh >&2 || { warn "  gh install failed — use a personal access token instead"; return 1; }
+        else
+            warn "  GitHub CLI (gh) not installed and Homebrew unavailable — use a personal access token"
+            return 1
+        fi
+    fi
     command -v gh >/dev/null 2>&1 || return 1
+
+    # Not signed in → run gh's interactive browser login, requesting meridian's
+    # scopes up front so the refresh step below is usually a no-op.
+    if ! gh auth status >/dev/null 2>&1; then
+        info "  Signing in to GitHub (opens a browser)…"
+        gh auth login -h github.com -p https -w -s "repo,read:project" >&2 || {
+            warn "  GitHub sign-in failed — use a personal access token instead"
+            return 1
+        }
+    fi
     gh auth status >/dev/null 2>&1 || return 1
 
     # Add any missing scope through gh's browser flow. `project` (write) satisfies

--- a/src/intelligence/oauth/flow.rs
+++ b/src/intelligence/oauth/flow.rs
@@ -300,25 +300,18 @@ async fn accept_fragment_relay(listener: &TcpListener) -> Result<String> {
 
         if target.starts_with("/capture") {
             // Second request: JS relayed the token as ?t=TOKEN
-            let token = target
-                .split('?')
-                .nth(1)
-                .and_then(|q| {
-                    q.split('&').find_map(|pair| {
-                        let mut it = pair.splitn(2, '=');
-                        match (it.next(), it.next()) {
-                            (Some("t"), Some(v)) => Some(decode(v)),
-                            _ => None,
-                        }
-                    })
-                });
+            let token = target.split('?').nth(1).and_then(|q| {
+                q.split('&').find_map(|pair| {
+                    let mut it = pair.splitn(2, '=');
+                    match (it.next(), it.next()) {
+                        (Some("t"), Some(v)) => Some(decode(v)),
+                        _ => None,
+                    }
+                })
+            });
             match token {
                 Some(t) if !t.is_empty() => {
-                    let _ = respond(
-                        &mut socket,
-                        "Trello connected! You can close this tab.",
-                    )
-                    .await;
+                    let _ = respond(&mut socket, "Trello connected! You can close this tab.").await;
                     return Ok(t);
                 }
                 _ => {

--- a/src/intelligence/providers/trello.rs
+++ b/src/intelligence/providers/trello.rs
@@ -166,10 +166,7 @@ async fn prune(pool: &SqlitePool, fetched_keys: &[String]) -> Result<usize> {
     for key in fetched_keys {
         q = q.bind(key.as_str());
     }
-    let result = q
-        .execute(pool)
-        .await
-        .context("pruning trello pm_tasks")?;
+    let result = q.execute(pool).await.context("pruning trello pm_tasks")?;
     Ok(result.rows_affected() as usize)
 }
 
@@ -221,8 +218,8 @@ pub async fn refresh_if_stale(
                         Err(e) => tracing::warn!(error = %e, "trello prune failed"),
                     }
                 } else if let Err(e) = sqlx::query("DELETE FROM pm_tasks WHERE provider = 'trello'")
-                        .execute(pool)
-                        .await
+                    .execute(pool)
+                    .await
                 {
                     tracing::warn!(error = %e, "trello full-clear failed");
                 }

--- a/src/pm_worklog/post.rs
+++ b/src/pm_worklog/post.rs
@@ -21,7 +21,9 @@ use anyhow::Result;
 use sqlx::SqlitePool;
 use tokio::sync::watch;
 
-use crate::config::{Config, GitHubConfig, JiraConfig, LinearConfig, PmProviderConfig, TrelloConfig};
+use crate::config::{
+    Config, GitHubConfig, JiraConfig, LinearConfig, PmProviderConfig, TrelloConfig,
+};
 
 use super::config::PmWorklogConfig;
 use super::{db, github, jira, linear, trello};

--- a/src/pm_worklog/trello.rs
+++ b/src/pm_worklog/trello.rs
@@ -32,7 +32,12 @@ pub async fn post_worklog(
 
     let token = oauth_trello::load_token().context("loading Trello OAuth token")?;
     let short_link = parse_short_link(task_key)?;
-    let body = format_worklog_comment(comment, time_spent_seconds, window_start_iso, window_end_iso);
+    let body = format_worklog_comment(
+        comment,
+        time_spent_seconds,
+        window_start_iso,
+        window_end_iso,
+    );
 
     let url = format!(
         "{TRELLO_BASE}/cards/{short_link}/actions/comments\


### PR DESCRIPTION
## Problem

Choosing **`Configure GitHub? y`** in `meridian setup` is supposed to be a no-PAT flow via the `gh` CLI (`_try_gh_token`). But the helper hard-bailed the instant `gh` was missing or unauthenticated:

```bash
command -v gh >/dev/null 2>&1 || return 1
gh auth status >/dev/null 2>&1 || return 1
```

→ the user was dropped straight to a manual **personal access token** prompt. On a fresh machine without `gh` (e.g. the reporter's), that's *every* time — so the no-PAT path effectively never triggered.

## Fix

When the user has opted into GitHub, `_try_gh_token` now drives the whole no-PAT path:

1. **`gh` missing → `brew install gh`** (the installer already brew-installs node/ffmpeg/uv the same way).
2. **Not signed in → `gh auth login`** (web flow, requesting `repo,read:project` up front so the existing scope-refresh step is a no-op).
3. Then writes `GITHUB_TOKEN` from `gh auth token` as before.

Falls back to the PAT prompt only if Homebrew is unavailable or the install/sign-in genuinely fails. An existing `GITHUB_TOKEN` is still left untouched.

## Gated behind the GitHub opt-in

`gh` is installed **only when the user chooses to configure GitHub** — `_try_gh_token` is called exclusively inside `if prompt_category "GitHub"` (`Configure GitHub? [y/N]`, true only on `y`/`Y`) in **both** entry points:

- `scripts/install-from-bundle.sh:92` (bundle install)
- `install.sh:176` (source install)

Users who don't choose GitHub never get `gh` touched.

## Testing

- `bash -n scripts/lib-github-setup.sh` clean; full pre-push suite passes.
- The interactive `brew install` / `gh auth login` flow can't be exercised headlessly; logic is best-effort with a preserved PAT fallback on every failure branch.

## Note on the first commit

`9c17c87 style(fmt)` is **not part of this feature** — it's the same pre-existing `cargo fmt` drift from the Trello merge that blocks the commit/push hooks on a clean `main` (also carried by the UI-fix PR #223). Pure formatter output, no logic change. **`main` currently fails its own fmt gate** and should be fixed at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)