### PR TITLE
fix(install): pin Python services to a uv-managed arm64 interpreter

### DIFF
--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -287,7 +287,10 @@ configure_editor_accessibility() {
 
 # ── 0. Platform gate ────────────────────────────────────────────────────────
 [[ "$(uname -s)" == "Darwin" ]]  || { err "Meridian requires macOS."; exit 1; }
-[[ "$(uname -m)" == "arm64" ]]   || { err "Meridian requires Apple Silicon (arm64). This bundle is macOS-arm64 only."; exit 1; }
+# hw.optional.arm64 reports the HARDWARE: it stays 1 in a Rosetta (x86_64)
+# shell on Apple Silicon, where uname -m would lie and wrongly refuse.
+[[ "$(sysctl -n hw.optional.arm64 2>/dev/null || echo 0)" == "1" ]] \
+    || { err "Meridian requires Apple Silicon (arm64). This bundle is macOS-arm64 only."; exit 1; }
 
 # Refuse root: this installs per-user launchd agents (gui/$(id -u)) and writes
 # ~/.meridian. As root, launchd bootstrap fails and files end up root-owned. The
@@ -438,31 +441,51 @@ curl -sf "http://127.0.0.1:${MLX_PORT}/health" >/dev/null 2>&1 && _mlx_was_healt
 
 # ── 4. Python venv + MLX deps ────────────────────────────────────────────────
 # Installed from PyPI via uv sync at install time — no pre-built venv shipped.
-# PyPI MLX wheels are tagged macosx_13_0_arm64 / macosx_14_0_arm64 so pip's
-# platform tag filter guarantees the correct ABI for the user's macOS version.
-# Differential skip: if uv.lock hasn't changed and mlx.core imports cleanly,
-# the venv is already correct — no network round-trip needed.
+# PyPI MLX wheels are arm64-only (mlx is Metal-based), so the venv interpreter
+# MUST be a native arm64 CPython. PATH python3 is NOT trustworthy here: user
+# machines often carry x86_64 builds running under Rosetta (Intel Homebrew,
+# pyenv), which fail the mlx resolve outright — or worse, leave a
+# mixed-architecture venv behind. So the venv is built from a uv-MANAGED
+# interpreter pinned by full build key: deterministic on every machine,
+# independent of whatever python3 (or uv binary arch) the user has.
+# Differential skip: if uv.lock + interpreter build are unchanged, the venv
+# python is really arm64, and mlx.core imports cleanly — no network round-trip.
+MERIDIAN_PY_BUILD="cpython-3.11-macos-aarch64-none"
 VENV="${APP_ROOT}/services/.venv"
 VENV_STAMP="${VENV}/.meridian-venv-hash"
 _LOCK_HASH="$(shasum -a 256 "${APP_ROOT}/services/uv.lock" 2>/dev/null | cut -d' ' -f1 || true)"
+# Stamp records lock hash + interpreter build — bumping either rebuilds the venv.
+_WANT_STAMP="${_LOCK_HASH} ${MERIDIAN_PY_BUILD}"
 
 _venv_changed=1
-_have_hash=""; [[ -f "${VENV_STAMP}" ]] && _have_hash="$(cat "${VENV_STAMP}" 2>/dev/null)"
+_have_stamp=""; [[ -f "${VENV_STAMP}" ]] && _have_stamp="$(cat "${VENV_STAMP}" 2>/dev/null)"
+_venv_arch=""
+[[ -x "${VENV}/bin/python" ]] \
+    && _venv_arch="$("${VENV}/bin/python" -c 'import platform; print(platform.machine())' 2>/dev/null || true)"
 
-if [[ -n "${_LOCK_HASH}" && "${_LOCK_HASH}" == "${_have_hash}" && -x "${VENV}/bin/python" ]] \
+if [[ -n "${_LOCK_HASH}" && "${_WANT_STAMP}" == "${_have_stamp}" && "${_venv_arch}" == "arm64" ]] \
    && "${VENV}/bin/python" -c "import mlx.core" 2>/dev/null; then
     ok "Python deps unchanged — skipping uv sync"
     _venv_changed=0
 else
+    # Self-heal: a venv whose interpreter is not arm64 (built by a Rosetta
+    # python3 before this pin existed) can never be fixed in place — wipe it.
+    if [[ -d "${VENV}" && -n "${_venv_arch}" && "${_venv_arch}" != "arm64" ]]; then
+        warn "venv interpreter is ${_venv_arch}, not arm64 (mixed-architecture venv) — rebuilding from scratch"
+        rm -rf "${VENV}"
+    fi
+    "${UV_BIN}" python install "${MERIDIAN_PY_BUILD}" \
+        || warn "managed Python pre-install failed — uv sync retries the download"
     info "Installing Python services from PyPI (mlx-lm/outlines/fastapi/agno; first run ~40–120s)…"
     if "${UV_BIN}" sync \
             --project "${APP_ROOT}/services" \
             --extra mlx \
             --extra pm_worklog_update \
             --frozen \
-            --python 3.11; then
-        [[ -n "${_LOCK_HASH}" ]] && printf '%s\n' "${_LOCK_HASH}" > "${VENV_STAMP}"
-        ok "Python services ready ($(${VENV}/bin/python --version 2>&1))"
+            --python "${MERIDIAN_PY_BUILD}" \
+            --python-preference only-managed; then
+        [[ -n "${_LOCK_HASH}" ]] && printf '%s\n' "${_WANT_STAMP}" > "${VENV_STAMP}"
+        ok "Python services ready ($("${VENV}/bin/python" --version 2>&1), $("${VENV}/bin/python" -c 'import platform; print(platform.machine())' 2>/dev/null))"
     else
         warn "uv sync failed — leaving venv as-is; re-run 'meridian setup' to retry"
     fi

--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -328,6 +328,14 @@ cmd_smoke() {
         printf "  %s\n" "════════════════════════════════════════════════════════"
     fi
 
+    # Hardware that can never run MLX (recorded by the installers): skip the
+    # probe instead of failing with a remedy that cannot work.
+    if grep -q '^mlx=unsupported_intel_hardware$' "${HOME}/.meridian/capabilities" 2>/dev/null; then
+        _smoke_row "·" "2" "mlx" "unsupported on this hardware (Intel Mac) — smoke skipped"
+        echo ""
+        return 0
+    fi
+
     # Quick reachability probe — if the server isn't up, nothing else can run.
     local reach_ok=0
     set +e

--- a/scripts/setup-services.sh
+++ b/scripts/setup-services.sh
@@ -19,6 +19,32 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SERVICES_DIR="${REPO_ROOT}/services"
 
+# MLX needs a native arm64 CPython: mlx ships arm64-only wheels (Metal), and a
+# Rosetta/Intel python3 from PATH either fails the resolve or leaves a
+# mixed-architecture venv. So on Apple Silicon the venv is built from a
+# uv-MANAGED interpreter pinned by full build key — never the PATH python.
+MERIDIAN_PY_BUILD="cpython-3.11-macos-aarch64-none"
+
+# Hardware probe: hw.optional.arm64 stays 1 in a Rosetta (x86_64) shell on
+# Apple Silicon, where uname -m reports the process arch and lies.
+APPLE_SILICON=0
+if [[ "$(uname -s)" == "Darwin" \
+      && "$(sysctl -n hw.optional.arm64 2>/dev/null || echo 0)" == "1" ]]; then
+    APPLE_SILICON=1
+fi
+
+# Record MLX capability for `meridian doctor`: on unsupported hardware it
+# reports "unsupported" with the degradation story instead of an unfixable
+# "server down → meridian start" loop.
+mkdir -p "${HOME}/.meridian"
+CAPABILITIES_FILE="${HOME}/.meridian/capabilities"
+_mlx_cap="supported"
+if [[ "$(uname -s)" == "Darwin" && "${APPLE_SILICON}" -eq 0 ]]; then
+    _mlx_cap="unsupported_intel_hardware"
+fi
+{ grep -v '^mlx=' "${CAPABILITIES_FILE}" 2>/dev/null || true; echo "mlx=${_mlx_cap}"; } \
+    > "${CAPABILITIES_FILE}.tmp" && mv "${CAPABILITIES_FILE}.tmp" "${CAPABILITIES_FILE}"
+
 USE_MLX=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -49,13 +75,16 @@ echo "  ✓ uv $("${UV_BIN}" --version | awk '{print $2}')"
 #    This venv is for interactive dev use (terminal, evals, scripts).
 #    The launchd daemon uses ~/.meridian/mlx-server-venv instead (see above).
 if [[ "${USE_MLX}" -eq 1 ]]; then
-    if [[ "$(uname -s)" != "Darwin" || "$(uname -m)" != "arm64" ]]; then
-        echo "✗ --mlx requires Apple Silicon (arm64 macOS)" >&2
+    if [[ "${APPLE_SILICON}" -ne 1 ]]; then
+        echo "✗ --mlx requires Apple Silicon hardware (mlx has no x86_64 wheels)" >&2
+        echo "  Summaries still work via the agent CLIs; re-run without --mlx." >&2
         exit 1
     fi
     echo "Installing Python services (mlx + pm_worklog_update) to services/.venv..."
+    "${UV_BIN}" python install "${MERIDIAN_PY_BUILD}"
     "${UV_BIN}" sync --project "${SERVICES_DIR}" \
-        --extra mlx --extra pm_worklog_update --python 3.11
+        --extra mlx --extra pm_worklog_update \
+        --python "${MERIDIAN_PY_BUILD}" --python-preference only-managed
     echo "  ✓ mlx + pm_worklog_update extras installed"
 
     if ! "${UV_BIN}" run --no-sync --project "${SERVICES_DIR}" \
@@ -66,10 +95,16 @@ if [[ "${USE_MLX}" -eq 1 ]]; then
     echo "  ✓ meridian-server script available"
 else
     echo "Installing Python services to services/.venv..."
-    "${UV_BIN}" sync --project "${SERVICES_DIR}" --python 3.11
+    if [[ "${APPLE_SILICON}" -eq 1 ]]; then
+        "${UV_BIN}" python install "${MERIDIAN_PY_BUILD}"
+        "${UV_BIN}" sync --project "${SERVICES_DIR}" \
+            --python "${MERIDIAN_PY_BUILD}" --python-preference only-managed
+    else
+        "${UV_BIN}" sync --project "${SERVICES_DIR}" --python 3.11
+    fi
     echo "  ✓ core dependencies installed"
 
-    if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
+    if [[ "${APPLE_SILICON}" -eq 1 ]]; then
         echo "Apple Silicon detected — installing mlx-lm for local inference..."
         "${UV_BIN}" pip install --python "${SERVICES_DIR}/.venv/bin/python" "mlx-lm>=0.22,<1"
         echo "  ✓ mlx-lm installed"

--- a/services/scripts/install-mlx-server-daemon.sh
+++ b/services/scripts/install-mlx-server-daemon.sh
@@ -40,6 +40,15 @@ if [[ ! -f "${TEMPLATE}" ]]; then
     exit 1
 fi
 
+# MLX requires Apple Silicon — mlx ships arm64-only wheels (Metal). Probe the
+# HARDWARE via sysctl: hw.optional.arm64 stays 1 in a Rosetta (x86_64) shell,
+# where uname -m would lie. Installing the agent anyway would just crash-loop.
+if [[ "$(sysctl -n hw.optional.arm64 2>/dev/null || echo 0)" != "1" ]]; then
+    echo "✗ MLX requires Apple Silicon — not installing the MLX server agent on this Mac." >&2
+    echo "  Coding-agent summaries still work via the agent CLIs (claude/codex)." >&2
+    exit 1
+fi
+
 # Find the uv binary.
 UV_BIN=""
 for _uv_candidate in "${HOME}/.local/bin/uv" /opt/homebrew/bin/uv /usr/local/bin/uv; do
@@ -63,6 +72,20 @@ if [[ ! -d "${SERVICES_VENV}" ]]; then
     fi
     echo "✗ venv not found at ${SERVICES_VENV}" >&2
     echo "  Run:  bash scripts/setup-services.sh --mlx" >&2
+    exit 1
+fi
+
+# Refuse a mixed-architecture venv (built by a Rosetta/Intel python3 before the
+# interpreter was pinned to a uv-managed arm64 build) — the server would only
+# crash-loop on native-extension imports.
+_venv_arch="$("${SERVICES_VENV}/bin/python" -c 'import platform; print(platform.machine())' 2>/dev/null || true)"
+if [[ "${_venv_arch}" != "arm64" ]]; then
+    echo "✗ venv python at ${SERVICES_VENV} is '${_venv_arch:-unknown}', need arm64 (mixed-architecture venv)." >&2
+    if [[ "${SERVICES_DIR}" == "${HOME}/.meridian/"* ]]; then
+        echo "  Rebuild it:  meridian update" >&2
+    else
+        echo "  Rebuild it:  rm -rf ${SERVICES_VENV} && bash scripts/setup-services.sh --mlx" >&2
+    fi
     exit 1
 fi
 

--- a/src/health/mod.rs
+++ b/src/health/mod.rs
@@ -321,11 +321,24 @@ pub async fn run_all(cfg: &Config) -> Report {
         }
     }
 
-    // mlx-server — service + HTTP readiness probes.
+    // mlx-server — service + HTTP readiness probes. Hardware that can never
+    // run MLX (Intel Macs — mlx ships arm64-only wheels) is recorded by the
+    // installers; report that as fact instead of an unfixable "server down".
     {
-        let mut g = platform::mlx_service(cfg);
-        g.extend(mlx::checks(cfg).await);
-        checks.extend(tag("mlx-server", g));
+        if platform::mlx_unsupported() {
+            checks.extend(tag(
+                "mlx-server",
+                vec![Check::info(
+                    "mlx",
+                    "L2",
+                    "unsupported on this hardware (Intel Mac) — summaries use the agent CLIs; local classification is unavailable",
+                )],
+            ));
+        } else {
+            let mut g = platform::mlx_service(cfg);
+            g.extend(mlx::checks(cfg).await);
+            checks.extend(tag("mlx-server", g));
+        }
     }
 
     // jira — auth, sync freshness, candidate completeness.

--- a/src/health/platform.rs
+++ b/src/health/platform.rs
@@ -146,6 +146,19 @@ pub fn screenpipe_service() -> Vec<Check> {
     vec![plist_check(LABEL_SCREENPIPE, "screenpipe plist"), run]
 }
 
+/// MLX capability recorded by the installers in `~/.meridian/capabilities`.
+/// `mlx=unsupported_intel_hardware` means this Mac can never run MLX (mlx
+/// ships arm64-only wheels) — doctor reports that as fact, not as a failure
+/// with an unfollowable remedy.
+pub fn mlx_unsupported() -> bool {
+    std::fs::read_to_string(home().join(".meridian/capabilities"))
+        .map(|s| {
+            s.lines()
+                .any(|l| l.trim() == "mlx=unsupported_intel_hardware")
+        })
+        .unwrap_or(false)
+}
+
 pub fn mlx_service(_cfg: &Config) -> Vec<Check> {
     let run = match launchd_pid(LABEL_MLX) {
         Some(pid) => Check::ok("mlx service", "L2", format!("pid {pid}")),
@@ -156,24 +169,56 @@ pub fn mlx_service(_cfg: &Config) -> Vec<Check> {
 }
 
 fn venv_check() -> Check {
-    let py = match repo_root() {
-        Some(r) => r.join("services/.venv/bin/python"),
-        None => return Check::info("python venv", "system", "repo root not found"),
+    // Source checkout: <repo>/services/.venv. Bundle install: the venv lives
+    // under ~/.meridian/app (no Cargo.toml, so repo_root() is None).
+    let (py, remedy) = match repo_root() {
+        Some(r) => (
+            r.join("services/.venv/bin/python"),
+            "bash scripts/setup-services.sh",
+        ),
+        None => (
+            home().join(".meridian/app/services/.venv/bin/python"),
+            "meridian update",
+        ),
     };
     if !is_exec(&py) {
-        return Check::critical("python venv", "system", ".venv missing")
-            .with_remedy("bash scripts/setup-services.sh");
+        return Check::critical("python venv", "system", ".venv missing").with_remedy(remedy);
     }
+    // A venv built by a Rosetta/Intel python3 carries x86_64 native extensions
+    // an arm64 interpreter can never import — rebuilding is the only fix.
+    let arch = Command::new(&py)
+        .args(["-c", "import platform; print(platform.machine())"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+    match arch.as_deref() {
+        Some("arm64") => {}
+        Some(other) => {
+            return Check::critical(
+                "python venv",
+                "system",
+                format!("venv python is {other}, not arm64 — mixed-architecture venv"),
+            )
+            .with_remedy(remedy)
+        }
+        None => {
+            return Check::critical("python venv", "system", "venv python failed to run")
+                .with_remedy(remedy)
+        }
+    }
+    // Import the module the launchd agent actually execs (`python -m
+    // agents.server`) — pulls in pydantic/fastapi/mlx, so it catches broken or
+    // mixed-architecture native extensions, not just a present venv dir.
     let ok = Command::new(&py)
-        .args(["-c", "import run_agent"])
+        .args(["-c", "import agents.server"])
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false);
     if ok {
-        Check::ok("python venv", "system", "run_agent importable")
+        Check::ok("python venv", "system", "agents.server importable")
     } else {
-        Check::critical("python venv", "system", "run_agent import failed")
-            .with_remedy("bash scripts/setup-services.sh")
+        Check::critical("python venv", "system", "agents.server import failed").with_remedy(remedy)
     }
 }
 


### PR DESCRIPTION
## Symptom (seen in the field)

On a fresh user machine, `meridian setup` failed at the Python services step:

```
error: Distribution `mlx==0.31.2` can't be installed because it doesn't have a
source distribution or wheel for the current platform
hint: You're on macOS (macosx_26_0_x86_64), but mlx only has wheels for … arm64
ImportError: …pydantic_core….so (mach-o file, but is an incompatible
architecture (have 'arm64', need 'x86_64'))
```

The MLX server then stays permanently down, and `meridian doctor` advises `meridian start` — a remedy that can never work.

## Root cause

The venv was built from whatever `python3` was on PATH. On user machines that is frequently an **x86_64 build running under Rosetta** (Intel Homebrew, pyenv) — and `mlx` ships arm64-only wheels (it's Metal-based). Depending on timing this either fails the resolve outright or leaves a **mixed-architecture venv** whose native extensions (`pydantic_core`, `mlx.core`) can never import. Both states were unrecoverable in place, and doctor couldn't see why.

## Fix — remove the environment from the equation instead of validating it harder

- **`install-from-bundle.sh`**: build the venv from the uv-managed `cpython-3.11-macos-aarch64-none` interpreter (`--python <full build key> --python-preference only-managed`). Deterministic on every machine — immune to PATH pythons, Rosetta, and even a Rosetta uv (the full build key pins os+arch explicitly). The venv stamp now records lock hash **+ interpreter build**; a venv whose interpreter is not arm64 is wiped and rebuilt, so **already-broken machines self-heal on their next `meridian update`**. The platform gate now probes `sysctl hw.optional.arm64` (truthful in Rosetta shells, unlike `uname -m`, which wrongly refused Apple Silicon Macs with an Intel terminal).
- **`setup-services.sh`** (source installs): same managed-interpreter pin; hardware probe via sysctl; records `mlx=supported|unsupported_intel_hardware` in `~/.meridian/capabilities`.
- **`install-mlx-server-daemon.sh`**: refuses to register the launchd agent on Intel hardware or against a non-arm64 venv (it would only crash-loop), with a remedy that actually rebuilds.
- **doctor**: on recorded-unsupported hardware, the mlx-server group and the CLI smoke probe report `unsupported on this hardware — summaries use the agent CLIs` as **info** instead of an unfixable critical. The venv check now also covers bundle installs (`~/.meridian/app/services/.venv` — previously "repo root not found"), verifies the interpreter is arm64, and imports `agents.server` — the module the launchd agent actually execs, which exercises the exact native imports that broke in the field. (The old probe imported `run_agent`, a legacy module no current installer provides — it would have failed on every fresh install.)

## Testing

- 4-case behavioural harness against the extracted installer section (stubbed uv): fresh machine → managed install + pinned sync; up-to-date arm64 venv → skip with zero uv calls; **mixed-arch x86_64 venv → wiped and rebuilt**; stale lock on healthy venv → resync without wipe. All pass.
- Intel hardware simulated via a `sysctl` shim: bundle-installer gate, `setup-services.sh --mlx`, and the MLX agent installer all refuse with actionable messages; capability file records `unsupported_intel_hardware`; doctor + smoke report it as info.
- Real-world end-to-end on Apple Silicon: `setup-services.sh --mlx` rebuilt the repo venv onto the managed `cpython-3.11.15-macos-aarch64-none` interpreter; `mlx.core` imports; the MLX launchd agent reinstalled against it and `/health` returns 200 with the model loaded.
- `bash -n` clean on all four scripts; `cargo fmt` + `clippy -D warnings` + full test suite (240 unit + integration) green; pre-push gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)