### PR TITLE
feat(integrations): add Azure DevOps (VSTS) PM connector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,33 @@
 # TRELLO_APP_KEY=                     # injected at package time
 
 # ---------------------------------------------------------------------------
+# Azure DevOps / VSTS (AZURE_DEVOPS_PAT required to enable the connector)
+# Syncs work items assigned to you; logs worklogs as work item comments
+# (Azure DevOps has no native time-tracking API via PAT).
+#
+# PAT: Azure DevOps → User settings → Personal access tokens → New token.
+#   Required scopes: Work Items (Read & write).
+#   Global PATs are being retired — create a project-scoped or org-scoped PAT.
+#
+# URL shapes — use AZURE_DEVOPS_ORG for cloud (standard or legacy), or
+# AZURE_DEVOPS_ORG_URL for on-premises:
+#
+#   Cloud (standard):  AZURE_DEVOPS_ORG=mycompany
+#                      → resolves to https://dev.azure.com/mycompany
+#
+#   Cloud (legacy):    AZURE_DEVOPS_ORG=mycompany.visualstudio.com
+#                      → resolves to https://mycompany.visualstudio.com
+#
+#   On-premises:       AZURE_DEVOPS_ORG_URL=https://tfs.company.com/DefaultCollection
+#                      (set this instead of AZURE_DEVOPS_ORG)
+# ---------------------------------------------------------------------------
+
+# AZURE_DEVOPS_PAT=your-pat-here
+# AZURE_DEVOPS_ORG=your-org-name         # e.g. mycompany (for dev.azure.com/mycompany)
+# AZURE_DEVOPS_PROJECT=your-project-name # e.g. MyProject
+# AZURE_DEVOPS_ORG_URL=                  # full URL for legacy cloud / on-premises only
+
+# ---------------------------------------------------------------------------
 # Python LLM backend — cloud fallback for the coding-agent summariser (Claude/
 # Codex paths). The MLX classifier server ignores these.
 # ---------------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -121,31 +121,22 @@
 # TRELLO_APP_KEY=                     # injected at package time
 
 # ---------------------------------------------------------------------------
-# Azure DevOps / VSTS (AZURE_DEVOPS_PAT required to enable the connector)
-# Syncs work items assigned to you; logs worklogs as work item comments
-# (Azure DevOps has no native time-tracking API via PAT).
+# Azure DevOps / VSTS — just two variables needed.
 #
-# PAT: Azure DevOps → User settings → Personal access tokens → New token.
-#   Required scopes: Work Items (Read & write).
-#   Global PATs are being retired — create a project-scoped or org-scoped PAT.
+# AZURE_DEVOPS_URL: copy the project URL from your browser address bar.
+#   Works for all URL shapes — meridian auto-detects org and project:
 #
-# URL shapes — use AZURE_DEVOPS_ORG for cloud (standard or legacy), or
-# AZURE_DEVOPS_ORG_URL for on-premises:
+#   Cloud (standard):  https://dev.azure.com/mycompany/MyProject
+#   Cloud (legacy):    https://mycompany.visualstudio.com/MyProject
+#   On-premises:       https://tfs.corp.com/DefaultCollection/MyProject
 #
-#   Cloud (standard):  AZURE_DEVOPS_ORG=mycompany
-#                      → resolves to https://dev.azure.com/mycompany
-#
-#   Cloud (legacy):    AZURE_DEVOPS_ORG=mycompany.visualstudio.com
-#                      → resolves to https://mycompany.visualstudio.com
-#
-#   On-premises:       AZURE_DEVOPS_ORG_URL=https://tfs.company.com/DefaultCollection
-#                      (set this instead of AZURE_DEVOPS_ORG)
+# AZURE_DEVOPS_PAT: create at User settings → Personal access tokens → New token.
+#   Required scope: Work Items → Read & write.
+#   Use an org-scoped PAT (global PATs are being retired by Microsoft).
 # ---------------------------------------------------------------------------
 
+# AZURE_DEVOPS_URL=https://dev.azure.com/your-org/your-project
 # AZURE_DEVOPS_PAT=your-pat-here
-# AZURE_DEVOPS_ORG=your-org-name         # e.g. mycompany (for dev.azure.com/mycompany)
-# AZURE_DEVOPS_PROJECT=your-project-name # e.g. MyProject
-# AZURE_DEVOPS_ORG_URL=                  # full URL for legacy cloud / on-premises only
 
 # ---------------------------------------------------------------------------
 # Python LLM backend — cloud fallback for the coding-agent summariser (Claude/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ No clone, no build. The package ships a prebuilt binary; `meridian setup` copies
 
 `meridian setup` then walks you through screenpipe's two macOS permissions (Screen Recording, Accessibility — audio is disabled, so no Microphone). Connect Jira afterwards (optional).
 
-👉 **Full walkthrough — permissions, Jira, verifying, logs, updating, troubleshooting: [SETUP.md](SETUP.md).**
+👉 **Full walkthrough — permissions, verifying, logs, updating, troubleshooting: [SETUP.md](SETUP.md).**
 
 ```bash
 meridian status      # the four services
@@ -199,18 +199,23 @@ Connect one or more trackers and Meridian maps captured work sessions to tasks, 
 
 ### Azure DevOps quick-start
 
+Just two variables — paste your project URL from the browser and your PAT:
+
 ```bash
 # Add to .env (or run meridian setup to be prompted interactively)
+AZURE_DEVOPS_URL=https://dev.azure.com/your-org/your-project
 AZURE_DEVOPS_PAT=your-pat-here
-AZURE_DEVOPS_ORG=your-org-name      # e.g. mycompany → dev.azure.com/mycompany
-AZURE_DEVOPS_PROJECT=YourProject
+```
 
-# Force a sync and verify tasks land in the database
+`AZURE_DEVOPS_URL` works for all three URL shapes: `dev.azure.com/org/project`, `org.visualstudio.com/project`, and on-premises servers — meridian auto-extracts the org and project.
+
+To create a PAT: **User settings → Personal access tokens → New token**, scope: **Work Items → Read & write**.
+
+```bash
+# Verify tasks synced
 meridian force-pm-sync
 sqlite3 ~/.meridian/meridian.db "SELECT task_key, title FROM pm_tasks WHERE provider='azure_devops';"
 ```
-
-For on-premises or legacy `visualstudio.com` URLs, set `AZURE_DEVOPS_ORG_URL` to the full base URL instead of `AZURE_DEVOPS_ORG`. See `.env.example` for examples of all three URL shapes.
 
 ## Data location
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Once installed, use `meridian dev …` to rebuild + restart after edits — see 
 - **Jira** — easiest is browser OAuth: run `meridian oauth-login jira` (no API token needed). Legacy path: URL, email, API token, project keys (gated by `[y/N]`)
 - **GitHub** — token (auto-extracted from the `gh` CLI, no PAT needed) + GitHub Projects to sync
 - **Linear** — API key, team IDs
+- **Azure DevOps** — Personal Access Token + organisation name + project (all three required)
 - **Observability (OpenObserve)** — base64 auth + OTLP endpoints
 
 Empty input skips that variable. Values already in `.env` are preserved on re-run.
@@ -183,6 +184,33 @@ Example:
 ```bash
 POLL_INTERVAL_SECS=30 ./target/release/meridian
 ```
+
+## Supported PM tools
+
+Connect one or more trackers and Meridian maps captured work sessions to tasks, then posts time-logged worklogs as comments on the task.
+
+| Tracker | Auth | Worklog mechanism | Cloud / on-prem |
+|---|---|---|---|
+| **Jira** | Browser OAuth (recommended) or Basic (URL + email + API token) | Native Jira worklog endpoint | Cloud (Atlassian) |
+| **GitHub** | `gh` CLI token (no PAT needed) or classic PAT | Issue comment (no native time-tracking API) | Cloud only |
+| **Linear** | Personal API key | Issue comment (no native time-tracking API) | Cloud only |
+| **Trello** | Browser OAuth | Card comment (no native time-tracking API) | Cloud only |
+| **Azure DevOps** | Personal Access Token (PAT) with Work Items Read & write scope | Work item comment (no native time-tracking API) | Cloud (`dev.azure.com`) + legacy (`*.visualstudio.com`) + on-premises (TFS/Azure DevOps Server) |
+
+### Azure DevOps quick-start
+
+```bash
+# Add to .env (or run meridian setup to be prompted interactively)
+AZURE_DEVOPS_PAT=your-pat-here
+AZURE_DEVOPS_ORG=your-org-name      # e.g. mycompany → dev.azure.com/mycompany
+AZURE_DEVOPS_PROJECT=YourProject
+
+# Force a sync and verify tasks land in the database
+meridian force-pm-sync
+sqlite3 ~/.meridian/meridian.db "SELECT task_key, title FROM pm_tasks WHERE provider='azure_devops';"
+```
+
+For on-premises or legacy `visualstudio.com` URLs, set `AZURE_DEVOPS_ORG_URL` to the full base URL instead of `AZURE_DEVOPS_ORG`. See `.env.example` for examples of all three URL shapes.
 
 ## Data location
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -14,7 +14,7 @@ This installs Node if missing, installs the `meridian` CLI, then runs `meridian 
 
 `meridian setup` will walk you through:
 1. Granting **Screen Recording** and **Accessibility** permissions to screenpipe (required)
-2. Connecting your issue tracker (Jira, Linear, or GitHub)
+2. Connecting your issue tracker (Jira, Linear, GitHub, Trello, or Azure DevOps)
 
 ---
 
@@ -33,7 +33,7 @@ meridian restart
 
 ---
 
-## Connect your tracker (Jira, Linear, GitHub, or Trello)
+## Connect your tracker (Jira, Linear, GitHub, Trello, or Azure DevOps)
 
 Edit the config file:
 
@@ -104,6 +104,35 @@ meridian restart
 Your token is saved to `~/.meridian/oauth/trello.json`. Meridian syncs open cards assigned to you across all your boards.
 
 Worklogs are **never posted automatically** — Meridian drafts them for you to review and approve in the dashboard.
+
+### Azure DevOps
+
+1. Create a Personal Access Token (PAT) in Azure DevOps:
+   - Go to **User settings → Personal access tokens → New token**
+   - Set expiry as required by your org
+   - Required scope: **Work Items → Read & write**
+   - Prefer project-scoped or org-scoped PATs over global ones (global PATs are being retired by Microsoft)
+
+2. Add to config:
+```dotenv
+AZURE_DEVOPS_PAT=your-pat-here
+AZURE_DEVOPS_ORG=your-org-name      # e.g. mycompany (→ dev.azure.com/mycompany)
+AZURE_DEVOPS_PROJECT=YourProject    # e.g. WebApp
+```
+
+**Legacy cloud (`*.visualstudio.com`) or on-premises (TFS / Azure DevOps Server):**
+```dotenv
+AZURE_DEVOPS_PAT=your-pat-here
+AZURE_DEVOPS_ORG_URL=https://mycompany.visualstudio.com   # or https://tfs.corp.com/DefaultCollection
+AZURE_DEVOPS_PROJECT=YourProject
+```
+
+Meridian syncs all work items assigned to you in the configured project that are not in a "Completed" or "Removed" state. State filtering is dynamic — any custom state names your org uses are handled automatically.
+
+Then restart:
+```bash
+meridian restart
+```
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -107,32 +107,40 @@ Worklogs are **never posted automatically** — Meridian drafts them for you to 
 
 ### Azure DevOps
 
-1. Create a Personal Access Token (PAT) in Azure DevOps:
-   - Go to **User settings → Personal access tokens → New token**
-   - Set expiry as required by your org
-   - Required scope: **Work Items → Read & write**
-   - Prefer project-scoped or org-scoped PATs over global ones (global PATs are being retired by Microsoft)
+Just two things needed: your project URL and a PAT.
 
-2. Add to config:
-```dotenv
-AZURE_DEVOPS_PAT=your-pat-here
-AZURE_DEVOPS_ORG=your-org-name      # e.g. mycompany (→ dev.azure.com/mycompany)
-AZURE_DEVOPS_PROJECT=YourProject    # e.g. WebApp
+**Step 1 — Project URL**
+
+Open your Azure DevOps project in a browser and copy the URL from the address bar. It will look like one of these:
+
+```
+Cloud (standard):  https://dev.azure.com/mycompany/MyProject
+Cloud (legacy):    https://mycompany.visualstudio.com/MyProject
+On-premises:       https://tfs.corp.com/DefaultCollection/MyProject
 ```
 
-**Legacy cloud (`*.visualstudio.com`) or on-premises (TFS / Azure DevOps Server):**
+**Step 2 — Personal Access Token**
+
+Go to **User settings (avatar, top-right) → Personal access tokens → New token**.
+- Required scope: **Work Items → Read & write**
+- Choose org-scoped (not global) — global PATs are being retired by Microsoft
+
+**Step 3 — Add to config**
+
 ```dotenv
+AZURE_DEVOPS_URL=https://dev.azure.com/mycompany/MyProject   ← paste your URL here
 AZURE_DEVOPS_PAT=your-pat-here
-AZURE_DEVOPS_ORG_URL=https://mycompany.visualstudio.com   # or https://tfs.corp.com/DefaultCollection
-AZURE_DEVOPS_PROJECT=YourProject
 ```
 
-Meridian syncs all work items assigned to you in the configured project that are not in a "Completed" or "Removed" state. State filtering is dynamic — any custom state names your org uses are handled automatically.
+Run `meridian config edit` to open the config file, add the two lines, save, then:
 
-Then restart:
 ```bash
 meridian restart
 ```
+
+Meridian syncs all work items assigned to you that are not completed. State filtering is dynamic — custom state names (any board workflow) are handled automatically.
+
+> You can also run `meridian setup` and choose **Azure DevOps** to be prompted interactively instead of editing the file manually.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -142,6 +142,7 @@ prompt_category() {
 # GitHub setup helpers — shared with scripts/install-from-bundle.sh.
 source "${REPO_ROOT}/scripts/lib-github-setup.sh"
 source "${REPO_ROOT}/scripts/lib-jira-setup.sh"
+source "${REPO_ROOT}/scripts/lib-azure-setup.sh"
 
 prompt_env_vars() {
     if [[ "${SKIP_ENV:-0}" == "1" ]]; then
@@ -189,6 +190,11 @@ prompt_env_vars() {
     if prompt_category "Linear"; then
         prompt_env_var "LINEAR_API_KEY" "Linear API key" 1 "$root_env"
         prompt_env_var "LINEAR_TEAM_IDS" "Linear team IDs (optional, comma-sep)" 0 "$root_env"
+    fi
+    echo
+
+    if prompt_category "Azure DevOps (VSTS)"; then
+        setup_azure_devops "$root_env"
     fi
     echo
 

--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -106,6 +106,10 @@ collect_credentials() {
         prompt_env_var "LINEAR_TEAM_IDS" "Linear team IDs (optional, comma-sep)" 0 "$env_file"
     fi
     echo >&2
+    if prompt_category "Azure DevOps (VSTS)"; then
+        setup_azure_devops "$env_file"
+    fi
+    echo >&2
     if prompt_category "Trello"; then
         _connect_trello "$env_file" "${APP_ROOT}/bin/meridian"
     fi
@@ -115,6 +119,7 @@ collect_credentials() {
 # GitHub + Jira setup helpers — shared with install.sh.
 source "${APP_ROOT}/scripts/lib-github-setup.sh"
 source "${APP_ROOT}/scripts/lib-jira-setup.sh"
+source "${APP_ROOT}/scripts/lib-azure-setup.sh"
 source "${APP_ROOT}/scripts/lib-trello-setup.sh"
 
 GUI_TARGET="gui/$(id -u)"

--- a/scripts/lib-azure-setup.sh
+++ b/scripts/lib-azure-setup.sh
@@ -4,72 +4,67 @@
 # Shared Azure DevOps setup helpers, sourced by both install.sh (source installs)
 # and scripts/install-from-bundle.sh (bundle installs). The sourcing script must
 # already define: info, ok, warn, get_env_value, set_env_value.
-#
-# PAT auth only — Azure DevOps does not expose a standard OAuth 2.0 device-flow.
-# Global PATs are being retired by Microsoft; users should create org-scoped or
-# project-scoped PATs with Work Items (Read & write) permission.
 
-# Interactive Azure DevOps setup. Prompts for PAT + org/project and writes them
-# to the supplied .env file. Skips individual keys that are already set.
+# Interactive Azure DevOps setup.
+# Requires just two things from the user: the project URL and a PAT.
 setup_azure_devops() {
     local env_file="$1"
 
-    # PAT
+    # Skip if already fully configured.
+    if [[ -n "$(get_env_value AZURE_DEVOPS_URL "$env_file")" ]] && \
+       [[ -n "$(get_env_value AZURE_DEVOPS_PAT "$env_file")" ]]; then
+        ok "Azure DevOps already configured — keeping"
+        return 0
+    fi
+
+    # ── Step 1: Project URL ───────────────────────────────────────────────────
+    if [[ -n "$(get_env_value AZURE_DEVOPS_URL "$env_file")" ]] || \
+       [[ -n "$(get_env_value AZURE_DEVOPS_ORG "$env_file")" ]] || \
+       [[ -n "$(get_env_value AZURE_DEVOPS_ORG_URL "$env_file")" ]]; then
+        ok "Azure DevOps URL already set — keeping"
+    else
+        echo
+        echo "    Step 1 of 2 — Project URL"
+        echo "    ─────────────────────────────────────────────────────────────"
+        echo "    Open your Azure DevOps project in a browser and copy the URL"
+        echo "    from the address bar. It will look like one of these:"
+        echo
+        echo "      Cloud (standard):  https://dev.azure.com/mycompany/MyProject"
+        echo "      Cloud (legacy):    https://mycompany.visualstudio.com/MyProject"
+        echo "      On-premises:       https://tfs.corp.com/DefaultCollection/MyProject"
+        echo
+        local _url=""
+        read -r -p "    Paste your project URL: " _url
+        if [[ -z "$_url" ]]; then
+            warn "  No URL entered — Azure DevOps integration skipped"
+            return 0
+        fi
+        set_env_value AZURE_DEVOPS_URL "$_url" "$env_file"
+        ok "AZURE_DEVOPS_URL set"
+    fi
+
+    # ── Step 2: Personal Access Token ────────────────────────────────────────
     if [[ -n "$(get_env_value AZURE_DEVOPS_PAT "$env_file")" ]]; then
         ok "AZURE_DEVOPS_PAT already set — keeping"
     else
-        echo "    Create a Personal Access Token at:"
-        echo "      https://dev.azure.com → User settings → Personal access tokens"
-        echo "    Required scope: Work Items (Read & write)"
-        echo "    Note: project-scoped or org-scoped PATs are preferred over global PATs."
+        echo
+        echo "    Step 2 of 2 — Personal Access Token (PAT)"
+        echo "    ─────────────────────────────────────────────────────────────"
+        echo "    In Azure DevOps, go to:"
+        echo "      User settings (top-right avatar) → Personal access tokens → New token"
+        echo
+        echo "    Required scope:  Work Items → Read & write"
+        echo "    Tip: choose an org-scoped (not global) PAT — global PATs are"
+        echo "    being retired by Microsoft."
         echo
         local _pat=""
-        read -r -s -p "    Azure DevOps PAT: " _pat
+        read -r -s -p "    Paste your PAT (hidden): " _pat
         echo
-        if [[ -n "$_pat" ]]; then
-            set_env_value AZURE_DEVOPS_PAT "$_pat" "$env_file"
-            ok "AZURE_DEVOPS_PAT set"
-        else
-            warn "  No PAT entered — Azure DevOps integration skipped"
+        if [[ -z "$_pat" ]]; then
+            warn "  No PAT entered — Azure DevOps integration may be incomplete"
             return 0
         fi
-    fi
-
-    # Organisation
-    if [[ -n "$(get_env_value AZURE_DEVOPS_ORG "$env_file")" ]] || \
-       [[ -n "$(get_env_value AZURE_DEVOPS_ORG_URL "$env_file")" ]]; then
-        ok "AZURE_DEVOPS_ORG already set — keeping"
-    else
-        echo
-        echo "    Organisation URL formats:"
-        echo "      Standard cloud:  enter just the org name  (e.g. mycompany)"
-        echo "      Legacy cloud:    enter  mycompany.visualstudio.com"
-        echo "      On-premises:     enter the full URL        (e.g. https://tfs.corp/DefaultCollection)"
-        echo
-        local _org=""
-        read -r -p "    Organisation name or URL: " _org
-        if [[ -z "$_org" ]]; then
-            warn "  No organisation entered — Azure DevOps integration may be incomplete"
-        elif [[ "$_org" == *"://"* ]]; then
-            set_env_value AZURE_DEVOPS_ORG_URL "$_org" "$env_file"
-            ok "AZURE_DEVOPS_ORG_URL set (on-prem / full URL)"
-        else
-            set_env_value AZURE_DEVOPS_ORG "$_org" "$env_file"
-            ok "AZURE_DEVOPS_ORG set"
-        fi
-    fi
-
-    # Project
-    if [[ -n "$(get_env_value AZURE_DEVOPS_PROJECT "$env_file")" ]]; then
-        ok "AZURE_DEVOPS_PROJECT already set — keeping"
-    else
-        local _project=""
-        read -r -p "    Project name: " _project
-        if [[ -n "$_project" ]]; then
-            set_env_value AZURE_DEVOPS_PROJECT "$_project" "$env_file"
-            ok "AZURE_DEVOPS_PROJECT set"
-        else
-            warn "  No project entered — Azure DevOps integration may be incomplete"
-        fi
+        set_env_value AZURE_DEVOPS_PAT "$_pat" "$env_file"
+        ok "AZURE_DEVOPS_PAT set"
     fi
 }

--- a/scripts/lib-azure-setup.sh
+++ b/scripts/lib-azure-setup.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# meridian — normalises screenpipe activity into structured app sessions
+#
+# Shared Azure DevOps setup helpers, sourced by both install.sh (source installs)
+# and scripts/install-from-bundle.sh (bundle installs). The sourcing script must
+# already define: info, ok, warn, get_env_value, set_env_value.
+#
+# PAT auth only — Azure DevOps does not expose a standard OAuth 2.0 device-flow.
+# Global PATs are being retired by Microsoft; users should create org-scoped or
+# project-scoped PATs with Work Items (Read & write) permission.
+
+# Interactive Azure DevOps setup. Prompts for PAT + org/project and writes them
+# to the supplied .env file. Skips individual keys that are already set.
+setup_azure_devops() {
+    local env_file="$1"
+
+    # PAT
+    if [[ -n "$(get_env_value AZURE_DEVOPS_PAT "$env_file")" ]]; then
+        ok "AZURE_DEVOPS_PAT already set — keeping"
+    else
+        echo "    Create a Personal Access Token at:"
+        echo "      https://dev.azure.com → User settings → Personal access tokens"
+        echo "    Required scope: Work Items (Read & write)"
+        echo "    Note: project-scoped or org-scoped PATs are preferred over global PATs."
+        echo
+        local _pat=""
+        read -r -s -p "    Azure DevOps PAT: " _pat
+        echo
+        if [[ -n "$_pat" ]]; then
+            set_env_value AZURE_DEVOPS_PAT "$_pat" "$env_file"
+            ok "AZURE_DEVOPS_PAT set"
+        else
+            warn "  No PAT entered — Azure DevOps integration skipped"
+            return 0
+        fi
+    fi
+
+    # Organisation
+    if [[ -n "$(get_env_value AZURE_DEVOPS_ORG "$env_file")" ]] || \
+       [[ -n "$(get_env_value AZURE_DEVOPS_ORG_URL "$env_file")" ]]; then
+        ok "AZURE_DEVOPS_ORG already set — keeping"
+    else
+        echo
+        echo "    Organisation URL formats:"
+        echo "      Standard cloud:  enter just the org name  (e.g. mycompany)"
+        echo "      Legacy cloud:    enter  mycompany.visualstudio.com"
+        echo "      On-premises:     enter the full URL        (e.g. https://tfs.corp/DefaultCollection)"
+        echo
+        local _org=""
+        read -r -p "    Organisation name or URL: " _org
+        if [[ -z "$_org" ]]; then
+            warn "  No organisation entered — Azure DevOps integration may be incomplete"
+        elif [[ "$_org" == *"://"* ]]; then
+            set_env_value AZURE_DEVOPS_ORG_URL "$_org" "$env_file"
+            ok "AZURE_DEVOPS_ORG_URL set (on-prem / full URL)"
+        else
+            set_env_value AZURE_DEVOPS_ORG "$_org" "$env_file"
+            ok "AZURE_DEVOPS_ORG set"
+        fi
+    fi
+
+    # Project
+    if [[ -n "$(get_env_value AZURE_DEVOPS_PROJECT "$env_file")" ]]; then
+        ok "AZURE_DEVOPS_PROJECT already set — keeping"
+    else
+        local _project=""
+        read -r -p "    Project name: " _project
+        if [[ -n "$_project" ]]; then
+            set_env_value AZURE_DEVOPS_PROJECT "$_project" "$env_file"
+            ok "AZURE_DEVOPS_PROJECT set"
+        else
+            warn "  No project entered — Azure DevOps integration may be incomplete"
+        fi
+    fi
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,6 +107,20 @@ pub struct TrelloConfig {
     pub board_ids: Vec<String>,
 }
 
+#[derive(Clone, Debug)]
+pub struct AzureDevOpsConfig {
+    /// Personal access token (PAT). Auth: Basic base64(":token").
+    pub pat: String,
+    /// Resolved API root. Supports all three URL shapes:
+    ///   https://dev.azure.com/{org}           (cloud, standard)
+    ///   https://{org}.visualstudio.com        (cloud, legacy)
+    ///   https://tfs.company.com/{collection}  (on-premises)
+    /// Set AZURE_DEVOPS_ORG_URL for legacy/on-prem; AZURE_DEVOPS_ORG for cloud.
+    pub api_base: String,
+    /// Project name or ID — scopes all work item queries.
+    pub project: String,
+}
+
 /// Provider-agnostic credential variant. Add new providers here; callers
 /// match on this enum, so the compiler enforces exhaustive handling.
 #[derive(Clone, Debug)]
@@ -115,6 +129,7 @@ pub enum PmProviderConfig {
     GitHub(GitHubConfig),
     Linear(LinearConfig),
     Trello(TrelloConfig),
+    AzureDevOps(AzureDevOpsConfig),
 }
 
 impl PmProviderConfig {
@@ -124,6 +139,7 @@ impl PmProviderConfig {
             Self::GitHub(_) => "github",
             Self::Linear(_) => "linear",
             Self::Trello(_) => "trello",
+            Self::AzureDevOps(_) => "azure_devops",
         }
     }
 }
@@ -256,11 +272,53 @@ fn parse_trello() -> Option<PmProviderConfig> {
     }))
 }
 
+fn parse_azure_devops() -> Option<PmProviderConfig> {
+    let pat = std::env::var("AZURE_DEVOPS_PAT").ok()?;
+    if pat.trim().is_empty() {
+        return None;
+    }
+    // Resolve the API base from either a full URL override (legacy cloud or
+    // on-premises) or the simpler ORG name (standard cloud).
+    let api_base = if let Ok(url) = std::env::var("AZURE_DEVOPS_ORG_URL") {
+        url.trim_end_matches('/').to_owned()
+    } else {
+        let org = std::env::var("AZURE_DEVOPS_ORG").ok()?;
+        let org = org.trim();
+        if org.is_empty() {
+            return None;
+        }
+        if org.contains("://") {
+            // Full URL passed via AZURE_DEVOPS_ORG — accept as-is.
+            org.trim_end_matches('/').to_owned()
+        } else if org.contains(".visualstudio.com") {
+            format!("https://{}", org.trim_end_matches('/'))
+        } else {
+            format!("https://dev.azure.com/{org}")
+        }
+    };
+    let project = std::env::var("AZURE_DEVOPS_PROJECT").ok()?;
+    let project = project.trim().to_owned();
+    if project.is_empty() {
+        return None;
+    }
+    Some(PmProviderConfig::AzureDevOps(AzureDevOpsConfig {
+        pat,
+        api_base,
+        project,
+    }))
+}
+
 fn parse_providers() -> Vec<PmProviderConfig> {
-    [parse_jira(), parse_github(), parse_linear(), parse_trello()]
-        .into_iter()
-        .flatten()
-        .collect()
+    [
+        parse_jira(),
+        parse_github(),
+        parse_linear(),
+        parse_trello(),
+        parse_azure_devops(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
 }
 
 // ---------------------------------------------------------------------------

--- a/src/config.rs
+++ b/src/config.rs
@@ -325,12 +325,16 @@ fn parse_azure_devops() -> Option<PmProviderConfig> {
         let base = url.trim().trim_end_matches('/').to_owned();
         let project = std::env::var("AZURE_DEVOPS_PROJECT").ok()?;
         let project = project.trim().to_owned();
-        if project.is_empty() { return None; }
+        if project.is_empty() {
+            return None;
+        }
         (base, project)
     } else {
         let org = std::env::var("AZURE_DEVOPS_ORG").ok()?;
         let org = org.trim();
-        if org.is_empty() { return None; }
+        if org.is_empty() {
+            return None;
+        }
         let base = if org.contains("://") {
             org.trim_end_matches('/').to_owned()
         } else if org.contains(".visualstudio.com") {
@@ -340,7 +344,9 @@ fn parse_azure_devops() -> Option<PmProviderConfig> {
         };
         let project = std::env::var("AZURE_DEVOPS_PROJECT").ok()?;
         let project = project.trim().to_owned();
-        if project.is_empty() { return None; }
+        if project.is_empty() {
+            return None;
+        }
         (base, project)
     };
 
@@ -705,28 +711,32 @@ mod tests {
 
     #[test]
     fn test_split_azure_devops_url_cloud_standard() {
-        let (base, project) = split_azure_devops_url("https://dev.azure.com/mycompany/MyProject").unwrap();
+        let (base, project) =
+            split_azure_devops_url("https://dev.azure.com/mycompany/MyProject").unwrap();
         assert_eq!(base, "https://dev.azure.com/mycompany");
         assert_eq!(project, "MyProject");
     }
 
     #[test]
     fn test_split_azure_devops_url_visualstudio() {
-        let (base, project) = split_azure_devops_url("https://mycompany.visualstudio.com/MyProject").unwrap();
+        let (base, project) =
+            split_azure_devops_url("https://mycompany.visualstudio.com/MyProject").unwrap();
         assert_eq!(base, "https://mycompany.visualstudio.com");
         assert_eq!(project, "MyProject");
     }
 
     #[test]
     fn test_split_azure_devops_url_on_premises() {
-        let (base, project) = split_azure_devops_url("https://tfs.corp.com/DefaultCollection/MyProject").unwrap();
+        let (base, project) =
+            split_azure_devops_url("https://tfs.corp.com/DefaultCollection/MyProject").unwrap();
         assert_eq!(base, "https://tfs.corp.com/DefaultCollection");
         assert_eq!(project, "MyProject");
     }
 
     #[test]
     fn test_split_azure_devops_url_trailing_slash() {
-        let (base, project) = split_azure_devops_url("https://dev.azure.com/mycompany/MyProject/").unwrap();
+        let (base, project) =
+            split_azure_devops_url("https://dev.azure.com/mycompany/MyProject/").unwrap();
         assert_eq!(base, "https://dev.azure.com/mycompany");
         assert_eq!(project, "MyProject");
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -272,35 +272,78 @@ fn parse_trello() -> Option<PmProviderConfig> {
     }))
 }
 
+/// Split a project URL into (api_base, project).
+///
+/// Last path segment = project; everything before (scheme + host + any preceding
+/// segments) = api_base. Works for all three URL shapes:
+///
+///   https://dev.azure.com/org/project      → ("https://dev.azure.com/org", "project")
+///   https://org.visualstudio.com/project   → ("https://org.visualstudio.com", "project")
+///   https://tfs.corp.com/Coll/project      → ("https://tfs.corp.com/Coll", "project")
+pub fn split_azure_devops_url(url: &str) -> Option<(String, String)> {
+    let url = url.trim().trim_end_matches('/');
+    let path_start = url.find("://").map(|i| i + 3).unwrap_or(0);
+    let host_end = url[path_start..]
+        .find('/')
+        .map(|i| path_start + i)
+        .unwrap_or(url.len());
+    let host = &url[..host_end];
+    let path = url[host_end..].trim_matches('/');
+    if path.is_empty() {
+        return None;
+    }
+    let (api_base, project) = if let Some((before, proj)) = path.rsplit_once('/') {
+        // Multi-segment path (dev.azure.com or on-prem).
+        let base = if before.is_empty() {
+            host.to_owned()
+        } else {
+            format!("{}/{}", host, before.trim_matches('/'))
+        };
+        (base, proj.to_owned())
+    } else {
+        // Single-segment path (visualstudio.com): host alone is the api_base.
+        (host.to_owned(), path.to_owned())
+    };
+    if project.is_empty() {
+        return None;
+    }
+    Some((api_base, project))
+}
+
 fn parse_azure_devops() -> Option<PmProviderConfig> {
     let pat = std::env::var("AZURE_DEVOPS_PAT").ok()?;
     if pat.trim().is_empty() {
         return None;
     }
-    // Resolve the API base from either a full URL override (legacy cloud or
-    // on-premises) or the simpler ORG name (standard cloud).
-    let api_base = if let Ok(url) = std::env::var("AZURE_DEVOPS_ORG_URL") {
-        url.trim_end_matches('/').to_owned()
+
+    // Primary: AZURE_DEVOPS_URL — user pastes the project URL from the browser.
+    // Fallback: legacy three-variable form (AZURE_DEVOPS_ORG / AZURE_DEVOPS_ORG_URL
+    // + AZURE_DEVOPS_PROJECT) for users who migrated from the earlier config.
+    let (api_base, project) = if let Ok(url) = std::env::var("AZURE_DEVOPS_URL") {
+        split_azure_devops_url(url.trim())?
+    } else if let Ok(url) = std::env::var("AZURE_DEVOPS_ORG_URL") {
+        let base = url.trim().trim_end_matches('/').to_owned();
+        let project = std::env::var("AZURE_DEVOPS_PROJECT").ok()?;
+        let project = project.trim().to_owned();
+        if project.is_empty() { return None; }
+        (base, project)
     } else {
         let org = std::env::var("AZURE_DEVOPS_ORG").ok()?;
         let org = org.trim();
-        if org.is_empty() {
-            return None;
-        }
-        if org.contains("://") {
-            // Full URL passed via AZURE_DEVOPS_ORG — accept as-is.
+        if org.is_empty() { return None; }
+        let base = if org.contains("://") {
             org.trim_end_matches('/').to_owned()
         } else if org.contains(".visualstudio.com") {
             format!("https://{}", org.trim_end_matches('/'))
         } else {
             format!("https://dev.azure.com/{org}")
-        }
+        };
+        let project = std::env::var("AZURE_DEVOPS_PROJECT").ok()?;
+        let project = project.trim().to_owned();
+        if project.is_empty() { return None; }
+        (base, project)
     };
-    let project = std::env::var("AZURE_DEVOPS_PROJECT").ok()?;
-    let project = project.trim().to_owned();
-    if project.is_empty() {
-        return None;
-    }
+
     Some(PmProviderConfig::AzureDevOps(AzureDevOpsConfig {
         pat,
         api_base,
@@ -658,5 +701,38 @@ mod tests {
         assert!(cfg.meridian_db_uri().starts_with("sqlite://"));
         std::env::remove_var("SCREENPIPE_DB");
         std::env::remove_var("MERIDIAN_DB");
+    }
+
+    #[test]
+    fn test_split_azure_devops_url_cloud_standard() {
+        let (base, project) = split_azure_devops_url("https://dev.azure.com/mycompany/MyProject").unwrap();
+        assert_eq!(base, "https://dev.azure.com/mycompany");
+        assert_eq!(project, "MyProject");
+    }
+
+    #[test]
+    fn test_split_azure_devops_url_visualstudio() {
+        let (base, project) = split_azure_devops_url("https://mycompany.visualstudio.com/MyProject").unwrap();
+        assert_eq!(base, "https://mycompany.visualstudio.com");
+        assert_eq!(project, "MyProject");
+    }
+
+    #[test]
+    fn test_split_azure_devops_url_on_premises() {
+        let (base, project) = split_azure_devops_url("https://tfs.corp.com/DefaultCollection/MyProject").unwrap();
+        assert_eq!(base, "https://tfs.corp.com/DefaultCollection");
+        assert_eq!(project, "MyProject");
+    }
+
+    #[test]
+    fn test_split_azure_devops_url_trailing_slash() {
+        let (base, project) = split_azure_devops_url("https://dev.azure.com/mycompany/MyProject/").unwrap();
+        assert_eq!(base, "https://dev.azure.com/mycompany");
+        assert_eq!(project, "MyProject");
+    }
+
+    #[test]
+    fn test_split_azure_devops_url_no_path() {
+        assert!(split_azure_devops_url("https://dev.azure.com").is_none());
     }
 }

--- a/src/intelligence/mod.rs
+++ b/src/intelligence/mod.rs
@@ -86,6 +86,11 @@ pub async fn run_pm_force_sync(meridian: &SqlitePool, config: &Config) -> Result
             PmProviderConfig::GitHub(cfg) => providers::github::force_refresh(meridian, cfg).await,
             PmProviderConfig::Linear(cfg) => providers::linear::force_refresh(meridian, cfg).await,
             PmProviderConfig::Trello(cfg) => providers::trello::force_refresh(meridian, cfg).await,
+            PmProviderConfig::AzureDevOps(cfg) => {
+                providers::azure_devops::force_refresh(meridian, cfg)
+                    .await
+                    .map(Some)
+            }
         };
         match result {
             Ok(None) => tracing::info!(provider = name, "force sync: auth unavailable or no tasks"),
@@ -106,7 +111,7 @@ pub async fn run_pm_force_sync(meridian: &SqlitePool, config: &Config) -> Result
 #[tracing::instrument(skip_all)]
 pub async fn run_pm_sync(meridian: &SqlitePool, config: &Config) -> Result<()> {
     if config.pm_providers.is_empty() {
-        tracing::warn!("no PM providers configured — pm_tasks will stay empty (set JIRA_BASE_URL/GITHUB_TOKEN/LINEAR_API_KEY)");
+        tracing::warn!("no PM providers configured — pm_tasks will stay empty (set JIRA_BASE_URL/GITHUB_TOKEN/LINEAR_API_KEY/AZURE_DEVOPS_PAT)");
         return Ok(());
     }
     let provider_count = config.pm_providers.len();
@@ -124,6 +129,9 @@ pub async fn run_pm_sync(meridian: &SqlitePool, config: &Config) -> Result<()> {
             }
             PmProviderConfig::Trello(cfg) => {
                 providers::trello::refresh_if_stale(meridian, cfg).await
+            }
+            PmProviderConfig::AzureDevOps(cfg) => {
+                providers::azure_devops::refresh_if_stale(meridian, cfg).await
             }
         };
         match result {

--- a/src/intelligence/providers/azure_devops.rs
+++ b/src/intelligence/providers/azure_devops.rs
@@ -1,0 +1,445 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Azure DevOps (VSTS) task connector. Fetches work items assigned to the
+// authenticated user via the WIQL API, then batch-resolves full item detail.
+// State filtering is done client-side using the per-type states API so no state
+// name is ever injected into WIQL (handles custom states and apostrophes safely).
+//
+// task_key format: `{project}#{work_item_id}` e.g. `Meridian#42`.
+// Supports all three URL shapes: dev.azure.com/{org}, {org}.visualstudio.com,
+// and on-premises {server}/{collection}. The api_base field is the resolved root.
+//
+// Verified end-to-end against dev.azure.com (cloud). On-premises support is
+// built to the REST API spec but not live-tested.
+
+use anyhow::{Context, Result};
+use base64::Engine;
+use serde::Deserialize;
+use serde_json::json;
+use sqlx::SqlitePool;
+use std::collections::HashMap;
+
+use crate::config::AzureDevOpsConfig;
+
+const SYNC_INTERVAL_MINS: i64 = 5;
+const BATCH_SIZE: usize = 200;
+
+// ---------------------------------------------------------------------------
+// REST response shapes
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct WiqlResponse {
+    #[serde(rename = "workItems")]
+    work_items: Vec<WorkItemRef>,
+}
+
+#[derive(Deserialize)]
+struct WorkItemRef {
+    id: u64,
+}
+
+#[derive(Deserialize)]
+struct WorkItemBatchResponse {
+    value: Vec<WorkItemDetail>,
+}
+
+#[derive(Deserialize)]
+struct WorkItemDetail {
+    id: u64,
+    fields: WorkItemFields,
+    url: String,
+}
+
+#[derive(Deserialize)]
+struct WorkItemFields {
+    #[serde(rename = "System.Title")]
+    title: String,
+    #[serde(rename = "System.WorkItemType")]
+    work_item_type: String,
+    #[serde(rename = "System.State")]
+    state: String,
+    #[serde(rename = "System.AreaPath", default)]
+    #[allow(dead_code)]
+    area_path: Option<String>,
+    #[serde(rename = "System.ChangedDate", default)]
+    changed_date: Option<String>,
+    #[serde(rename = "System.Description", default)]
+    description: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct StatesResponse {
+    value: Vec<StateDetail>,
+}
+
+#[derive(Deserialize)]
+struct StateDetail {
+    name: String,
+    category: String,
+}
+
+// ---------------------------------------------------------------------------
+// Auth and helpers
+// ---------------------------------------------------------------------------
+
+/// Build the `Authorization: Basic …` header value for PAT auth.
+/// Azure DevOps expects Base64(":token") — the username portion is empty.
+fn basic_auth(pat: &str) -> String {
+    let raw = format!(":{pat}");
+    let encoded = base64::engine::general_purpose::STANDARD.encode(raw.as_bytes());
+    format!("Basic {encoded}")
+}
+
+/// Map an Azure StateCategory value to Meridian's status_category.
+fn to_status_category(category: &str) -> &'static str {
+    match category {
+        "Proposed" => "todo",
+        "InProgress" | "Resolved" => "in_progress",
+        "Completed" | "Removed" => "done",
+        _ => "in_progress",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// API calls
+// ---------------------------------------------------------------------------
+
+/// Run a WIQL query and return the work item IDs assigned to @me.
+async fn run_wiql(client: &reqwest::Client, cfg: &AzureDevOpsConfig) -> Result<Vec<u64>> {
+    let url = format!(
+        "{}/{}/_apis/wit/wiql?api-version=7.1",
+        cfg.api_base, cfg.project
+    );
+    let body = json!({
+        "query": "SELECT [System.Id] FROM WorkItems WHERE [System.AssignedTo] = @me ORDER BY [System.ChangedDate] DESC"
+    });
+    let resp = client
+        .post(&url)
+        .header("Authorization", basic_auth(&cfg.pat))
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .context("Azure DevOps WIQL request")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Azure DevOps WIQL returned {status}: {text}");
+    }
+    let wiql: WiqlResponse = resp.json().await.context("parsing WIQL response")?;
+    Ok(wiql.work_items.iter().map(|w| w.id).collect())
+}
+
+/// Fetch full details for a batch of work item IDs (≤200 per request).
+async fn fetch_batch(
+    client: &reqwest::Client,
+    cfg: &AzureDevOpsConfig,
+    ids: &[u64],
+) -> Result<Vec<WorkItemDetail>> {
+    if ids.is_empty() {
+        return Ok(vec![]);
+    }
+    let ids_str = ids
+        .iter()
+        .map(|i| i.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let url = format!(
+        "{}/{}/_apis/wit/workitems?ids={}&\
+         fields=System.Id,System.Title,System.WorkItemType,System.State,\
+         System.AreaPath,System.ChangedDate,System.Description&api-version=7.1",
+        cfg.api_base, cfg.project, ids_str
+    );
+    let resp = client
+        .get(&url)
+        .header("Authorization", basic_auth(&cfg.pat))
+        .send()
+        .await
+        .context("Azure DevOps work items batch request")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Azure DevOps work items batch returned {status}: {text}");
+    }
+    let batch: WorkItemBatchResponse = resp.json().await.context("parsing batch response")?;
+    Ok(batch.value)
+}
+
+/// Fetch the state-name → StateCategory map for one work item type.
+/// On failure returns an empty map and logs a warning; the caller treats unknown
+/// states as in_progress so a degraded states API response doesn't break the sync.
+async fn fetch_state_categories(
+    client: &reqwest::Client,
+    cfg: &AzureDevOpsConfig,
+    work_item_type: &str,
+) -> HashMap<String, String> {
+    // Work item type names are alphanumeric with spaces ("User Story"); only spaces need encoding.
+    let encoded = work_item_type.replace(' ', "%20");
+    let url = format!(
+        "{}/{}/_apis/wit/workitemtypes/{}/states?api-version=7.1",
+        cfg.api_base, cfg.project, encoded
+    );
+    let result: Result<StatesResponse> = async {
+        let resp = client
+            .get(&url)
+            .header("Authorization", basic_auth(&cfg.pat))
+            .send()
+            .await
+            .context("states request")?;
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("{status}: {text}");
+        }
+        resp.json().await.context("parsing states response")
+    }
+    .await;
+
+    match result {
+        Ok(s) => s.value.into_iter().map(|d| (d.name, d.category)).collect(),
+        Err(e) => {
+            tracing::warn!(
+                work_item_type = %work_item_type, error = %e,
+                "could not fetch Azure DevOps state categories — treating as in_progress"
+            );
+            HashMap::new()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sync entry points
+// ---------------------------------------------------------------------------
+
+/// Refresh Azure DevOps tasks if the cache is stale (> SYNC_INTERVAL_MINS).
+pub async fn refresh_if_stale(
+    pool: &SqlitePool,
+    cfg: &AzureDevOpsConfig,
+) -> Result<Option<Vec<String>>> {
+    let last_sync: Option<(String,)> = sqlx::query_as(
+        "SELECT last_synced_at FROM pm_sync_state WHERE provider = 'azure_devops' LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await
+    .context("reading azure_devops sync state")?;
+
+    if let Some((ts,)) = last_sync {
+        if let Ok(last) = chrono::DateTime::parse_from_rfc3339(&ts) {
+            let age_mins = chrono::Utc::now()
+                .signed_duration_since(last.with_timezone(&chrono::Utc))
+                .num_minutes();
+            if age_mins < SYNC_INTERVAL_MINS {
+                return Ok(None);
+            }
+        }
+    }
+    force_refresh(pool, cfg).await.map(Some)
+}
+
+/// Unconditionally refresh the Azure DevOps task cache.
+#[tracing::instrument(skip(pool, cfg), fields(provider = "azure_devops"))]
+pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result<Vec<String>> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .context("building HTTP client")?;
+
+    // 1. WIQL: all work items assigned to me.
+    let all_ids = run_wiql(&client, cfg).await?;
+    tracing::debug!(count = all_ids.len(), "azure_devops: WIQL returned IDs");
+
+    if all_ids.is_empty() {
+        prune(pool, &[]).await?;
+        stamp_sync(pool).await?;
+        return Ok(vec![]);
+    }
+
+    // 2. Batch-fetch full detail (≤BATCH_SIZE per request).
+    let mut details: Vec<WorkItemDetail> = Vec::with_capacity(all_ids.len());
+    for chunk in all_ids.chunks(BATCH_SIZE) {
+        let batch = fetch_batch(&client, cfg, chunk).await?;
+        details.extend(batch);
+    }
+
+    // 3. Per-type state→category maps (fetched once per type per sync).
+    let mut type_states: HashMap<String, HashMap<String, String>> = HashMap::new();
+    for item in &details {
+        let wit = item.fields.work_item_type.clone();
+        if let std::collections::hash_map::Entry::Vacant(e) = type_states.entry(wit) {
+            let map = fetch_state_categories(&client, cfg, e.key()).await;
+            e.insert(map);
+        }
+    }
+
+    // 4. Filter and upsert — Completed / Removed items are dropped.
+    struct UpsertItem<'a> {
+        detail: &'a WorkItemDetail,
+        status_category: &'static str,
+    }
+    let active: Vec<UpsertItem<'_>> = details
+        .iter()
+        .filter_map(|item| {
+            let azure_category = type_states
+                .get(&item.fields.work_item_type)
+                .and_then(|m| m.get(&item.fields.state))
+                .map(|s| s.as_str())
+                .unwrap_or("InProgress");
+            if matches!(azure_category, "Completed" | "Removed") {
+                return None;
+            }
+            Some(UpsertItem {
+                detail: item,
+                status_category: to_status_category(azure_category),
+            })
+        })
+        .collect();
+
+    let mut kept: Vec<String> = Vec::with_capacity(active.len());
+    for u in &active {
+        let task_key = format!("{}#{}", cfg.project, u.detail.id);
+        let description = u.detail.fields.description.as_deref().unwrap_or("");
+        let changed = u.detail.fields.changed_date.as_deref().unwrap_or("");
+
+        sqlx::query(
+            "INSERT INTO pm_tasks
+               (task_key, provider, title, description_text, status_category,
+                issue_type, source_url, updated_at_remote)
+             VALUES (?, 'azure_devops', ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(task_key) DO UPDATE SET
+               provider          = 'azure_devops',
+               title             = excluded.title,
+               description_text  = excluded.description_text,
+               status_category   = excluded.status_category,
+               issue_type        = excluded.issue_type,
+               source_url        = excluded.source_url,
+               updated_at_remote = excluded.updated_at_remote",
+        )
+        .bind(&task_key)
+        .bind(&u.detail.fields.title)
+        .bind(description)
+        .bind(u.status_category)
+        .bind(&u.detail.fields.work_item_type)
+        .bind(&u.detail.url)
+        .bind(changed)
+        .execute(pool)
+        .await
+        .with_context(|| format!("upserting Azure DevOps work item {}", u.detail.id))?;
+
+        kept.push(task_key);
+    }
+
+    prune(pool, &kept).await?;
+    stamp_sync(pool).await?;
+
+    tracing::info!(
+        provider = "azure_devops",
+        total_assigned = all_ids.len(),
+        active = kept.len(),
+        "azure_devops tasks refreshed"
+    );
+    Ok(kept)
+}
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+async fn prune(pool: &SqlitePool, kept_keys: &[String]) -> Result<()> {
+    if kept_keys.is_empty() {
+        sqlx::query(
+            "DELETE FROM pm_task_embeddings WHERE task_key IN \
+             (SELECT task_key FROM pm_tasks WHERE provider = 'azure_devops')",
+        )
+        .execute(pool)
+        .await
+        .context("pruning all azure_devops pm_task_embeddings")?;
+        sqlx::query("DELETE FROM pm_tasks WHERE provider = 'azure_devops'")
+            .execute(pool)
+            .await
+            .context("pruning all azure_devops pm_tasks")?;
+        return Ok(());
+    }
+
+    let placeholders = kept_keys.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+
+    let sql_embed = format!(
+        "DELETE FROM pm_task_embeddings WHERE task_key IN \
+         (SELECT task_key FROM pm_tasks \
+          WHERE provider = 'azure_devops' AND task_key NOT IN ({placeholders}))"
+    );
+    let mut q = sqlx::query(&sql_embed);
+    for k in kept_keys {
+        q = q.bind(k);
+    }
+    q.execute(pool)
+        .await
+        .context("pruning stale azure_devops pm_task_embeddings")?;
+
+    let sql_tasks = format!(
+        "DELETE FROM pm_tasks \
+         WHERE provider = 'azure_devops' AND task_key NOT IN ({placeholders})"
+    );
+    let mut q2 = sqlx::query(&sql_tasks);
+    for k in kept_keys {
+        q2 = q2.bind(k);
+    }
+    let result = q2
+        .execute(pool)
+        .await
+        .context("pruning stale azure_devops pm_tasks")?;
+
+    if result.rows_affected() > 0 {
+        tracing::info!(
+            removed = result.rows_affected(),
+            "pruned stale azure_devops tasks"
+        );
+    }
+    Ok(())
+}
+
+async fn stamp_sync(pool: &SqlitePool) -> Result<()> {
+    let now = chrono::Utc::now().to_rfc3339();
+    sqlx::query(
+        "INSERT INTO pm_sync_state (provider, last_synced_at)
+         VALUES ('azure_devops', ?)
+         ON CONFLICT(provider) DO UPDATE SET last_synced_at = excluded.last_synced_at",
+    )
+    .bind(&now)
+    .execute(pool)
+    .await
+    .context("updating azure_devops sync state")?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_auth_format() {
+        let header = basic_auth("mytoken");
+        assert!(header.starts_with("Basic "));
+        let encoded = header.strip_prefix("Basic ").unwrap();
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .unwrap();
+        assert_eq!(decoded, b":mytoken");
+    }
+
+    #[test]
+    fn test_to_status_category() {
+        assert_eq!(to_status_category("Proposed"), "todo");
+        assert_eq!(to_status_category("InProgress"), "in_progress");
+        assert_eq!(to_status_category("Resolved"), "in_progress");
+        assert_eq!(to_status_category("Completed"), "done");
+        assert_eq!(to_status_category("Removed"), "done");
+        assert_eq!(to_status_category("SomeCustomState"), "in_progress");
+    }
+}

--- a/src/intelligence/providers/mod.rs
+++ b/src/intelligence/providers/mod.rs
@@ -1,5 +1,6 @@
 // meridian — normalises screenpipe activity into structured app sessions
 
+pub mod azure_devops;
 pub mod github;
 pub mod jira;
 pub mod linear;

--- a/src/pm_worklog/azure_devops.rs
+++ b/src/pm_worklog/azure_devops.rs
@@ -1,0 +1,138 @@
+// meridian — normalises screenpipe activity into structured app sessions
+//
+// Azure DevOps worklog poster. Azure DevOps has no native time-tracking API
+// exposed to PAT auth; the equivalent is a work item comment (the Comments v1
+// preview endpoint). The comment body uses the same Markdown structure as the
+// GitHub and Linear poster so the machine-readable marker is consistent.
+//
+// task_key format: `{project}#{work_item_id}` — parsed here to reconstruct the
+// REST URL: {api_base}/{project}/_apis/wit/workItems/{id}/comments
+//
+// Ref: https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/comments/add
+
+use anyhow::{bail, Context, Result};
+use base64::Engine;
+use serde_json::Value;
+
+use super::comment::{format_worklog_comment, seconds_to_human, PostedWorklog};
+use crate::config::AzureDevOpsConfig;
+
+/// An Azure DevOps work item coordinate parsed from a `project#id` task key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkItemRef {
+    pub project: String,
+    pub id: u64,
+}
+
+/// Parse `{project}#{id}` into its parts.
+pub fn parse_task_key(task_key: &str) -> Result<WorkItemRef> {
+    let (project, id_str) = task_key
+        .rsplit_once('#')
+        .with_context(|| format!("Azure DevOps task_key {task_key:?} missing '#<id>'"))?;
+    if project.is_empty() {
+        bail!("Azure DevOps task_key {task_key:?} has an empty project");
+    }
+    let id: u64 = id_str.parse().with_context(|| {
+        format!("Azure DevOps task_key {task_key:?} has non-numeric work item id")
+    })?;
+    Ok(WorkItemRef {
+        project: project.to_owned(),
+        id,
+    })
+}
+
+/// Post a worklog comment to the Azure DevOps work item identified by `task_key`.
+/// Returns a `PostedWorklog` with the comment ID and a human-readable label.
+pub async fn post_worklog(
+    cfg: &AzureDevOpsConfig,
+    task_key: &str,
+    time_spent_seconds: i64,
+    window_start_iso: &str,
+    window_end_iso: &str,
+    comment: &str,
+) -> Result<PostedWorklog> {
+    if time_spent_seconds < 60 {
+        bail!("time_spent_seconds={time_spent_seconds} below the 60s worklog minimum");
+    }
+    let item = parse_task_key(task_key)?;
+    let body = format_worklog_comment(comment, time_spent_seconds, window_start_iso, window_end_iso);
+
+    // The Comments endpoint is a preview API; use the -preview.4 suffix as
+    // documented for Azure DevOps Services (cloud). On-premises TFS may require
+    // an older preview version — fall back is omitted here; the error surface is clear.
+    let url = format!(
+        "{}/{}/_apis/wit/workItems/{}/comments?api-version=7.1-preview.4",
+        cfg.api_base, item.project, item.id
+    );
+
+    let raw = format!(":{}", cfg.pat);
+    let auth = format!(
+        "Basic {}",
+        base64::engine::general_purpose::STANDARD.encode(raw.as_bytes())
+    );
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
+        .context("building HTTP client")?;
+
+    let payload = serde_json::json!({ "text": body });
+
+    let resp = client
+        .post(&url)
+        .header("Authorization", auth)
+        .header("Content-Type", "application/json")
+        .json(&payload)
+        .send()
+        .await
+        .context("Azure DevOps post comment request")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        bail!("Azure DevOps post comment returned {status}: {text}");
+    }
+
+    let json: Value = resp.json().await.context("parsing comment response")?;
+    let comment_id = json["id"]
+        .as_u64()
+        .map(|n| n.to_string())
+        .or_else(|| json["id"].as_str().map(|s| s.to_owned()))
+        .context("Azure DevOps comment response missing 'id'")?;
+
+    Ok(PostedWorklog {
+        id: comment_id,
+        label: seconds_to_human(time_spent_seconds),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_task_key_valid() {
+        let r = parse_task_key("Meridian#42").unwrap();
+        assert_eq!(r.project, "Meridian");
+        assert_eq!(r.id, 42);
+    }
+
+    #[test]
+    fn test_parse_task_key_no_hash() {
+        assert!(parse_task_key("Meridian42").is_err());
+    }
+
+    #[test]
+    fn test_parse_task_key_empty_project() {
+        assert!(parse_task_key("#42").is_err());
+    }
+
+    #[test]
+    fn test_parse_task_key_non_numeric_id() {
+        assert!(parse_task_key("Meridian#abc").is_err());
+    }
+}

--- a/src/pm_worklog/mod.rs
+++ b/src/pm_worklog/mod.rs
@@ -17,6 +17,7 @@
 // ~60s approved-poster); also runnable one-shot via
 // `meridian pm-worklog [--day YYYY-MM-DD]` and `meridian worklog-post-approved`.
 
+pub mod azure_devops;
 pub mod collect;
 pub mod comment;
 pub mod config;

--- a/src/pm_worklog/post.rs
+++ b/src/pm_worklog/post.rs
@@ -22,11 +22,12 @@ use sqlx::SqlitePool;
 use tokio::sync::watch;
 
 use crate::config::{
-    Config, GitHubConfig, JiraConfig, LinearConfig, PmProviderConfig, TrelloConfig,
+    AzureDevOpsConfig, Config, GitHubConfig, JiraConfig, LinearConfig, PmProviderConfig,
+    TrelloConfig,
 };
 
 use super::config::PmWorklogConfig;
-use super::{db, github, jira, linear, trello};
+use super::{azure_devops, db, github, jira, linear, trello};
 
 /// How often the approved-sweep runs. Short by design — this is the latency a
 /// user feels between clicking "Approve" in the dashboard and the worklog
@@ -181,6 +182,21 @@ async fn post_one(
             .await?;
             (r.id, r.label)
         }
+        "azure_devops" => {
+            let Some(c) = azure_devops_cfg(config) else {
+                return missing_provider(&w.provider, w);
+            };
+            let r = azure_devops::post_worklog(
+                c,
+                &w.task_key,
+                w.time_spent_seconds,
+                &w.window_start,
+                &w.window_end,
+                comment,
+            )
+            .await?;
+            (r.id, r.label)
+        }
         other => {
             db::fail_worklog(pool, w.id, &format!("unknown provider '{other}'")).await?;
             return Ok(false);
@@ -230,6 +246,13 @@ fn linear_cfg(config: &Config) -> Option<&LinearConfig> {
 fn trello_cfg(config: &Config) -> Option<&TrelloConfig> {
     config.pm_providers.iter().find_map(|p| match p {
         PmProviderConfig::Trello(t) => Some(t),
+        _ => None,
+    })
+}
+
+fn azure_devops_cfg(config: &Config) -> Option<&AzureDevOpsConfig> {
+    config.pm_providers.iter().find_map(|p| match p {
+        PmProviderConfig::AzureDevOps(a) => Some(a),
         _ => None,
     })
 }

--- a/ui/app/api/integrations/route.ts
+++ b/ui/app/api/integrations/route.ts
@@ -11,6 +11,7 @@ export interface IntegrationsResponse {
   linear: boolean
   github: boolean
   trello: boolean
+  azure_devops: boolean
 }
 
 function repoRoot(): string {
@@ -69,6 +70,7 @@ const OAUTH_PROVIDERS = new Set(['jira', 'trello'])
 const TOKEN_KEYS: Record<string, string[]> = {
   github: ['GITHUB_TOKEN', 'GITHUB_PROJECT_IDS'],
   linear: ['LINEAR_API_KEY', 'LINEAR_TEAM_IDS'],
+  azure_devops: ['AZURE_DEVOPS_PAT', 'AZURE_DEVOPS_ORG', 'AZURE_DEVOPS_PROJECT', 'AZURE_DEVOPS_ORG_URL'],
 }
 const ALL_PROVIDERS = new Set([...OAUTH_PROVIDERS, ...Object.keys(TOKEN_KEYS)])
 
@@ -116,6 +118,7 @@ export async function GET() {
     linear: isSet(env, 'LINEAR_API_KEY'),
     github: isSet(env, 'GITHUB_TOKEN'),
     trello: trelloOAuth,
+    azure_devops: isSet(env, 'AZURE_DEVOPS_PAT') && (isSet(env, 'AZURE_DEVOPS_ORG') || isSet(env, 'AZURE_DEVOPS_ORG_URL')),
   }
 
   return NextResponse.json(result)

--- a/ui/app/api/integrations/route.ts
+++ b/ui/app/api/integrations/route.ts
@@ -70,7 +70,7 @@ const OAUTH_PROVIDERS = new Set(['jira', 'trello'])
 const TOKEN_KEYS: Record<string, string[]> = {
   github: ['GITHUB_TOKEN', 'GITHUB_PROJECT_IDS'],
   linear: ['LINEAR_API_KEY', 'LINEAR_TEAM_IDS'],
-  azure_devops: ['AZURE_DEVOPS_PAT', 'AZURE_DEVOPS_ORG', 'AZURE_DEVOPS_PROJECT', 'AZURE_DEVOPS_ORG_URL'],
+  azure_devops: ['AZURE_DEVOPS_PAT', 'AZURE_DEVOPS_URL', 'AZURE_DEVOPS_ORG', 'AZURE_DEVOPS_PROJECT', 'AZURE_DEVOPS_ORG_URL'],
 }
 const ALL_PROVIDERS = new Set([...OAUTH_PROVIDERS, ...Object.keys(TOKEN_KEYS)])
 
@@ -118,7 +118,7 @@ export async function GET() {
     linear: isSet(env, 'LINEAR_API_KEY'),
     github: isSet(env, 'GITHUB_TOKEN'),
     trello: trelloOAuth,
-    azure_devops: isSet(env, 'AZURE_DEVOPS_PAT') && (isSet(env, 'AZURE_DEVOPS_ORG') || isSet(env, 'AZURE_DEVOPS_ORG_URL')),
+    azure_devops: isSet(env, 'AZURE_DEVOPS_PAT') && (isSet(env, 'AZURE_DEVOPS_URL') || isSet(env, 'AZURE_DEVOPS_ORG') || isSet(env, 'AZURE_DEVOPS_ORG_URL')),
   }
 
   return NextResponse.json(result)

--- a/ui/components/views/TasksView.tsx
+++ b/ui/components/views/TasksView.tsx
@@ -419,10 +419,10 @@ const TRACKERS: Array<{
     name: 'Azure DevOps',
     glyph: 'Az',
     color: '#0078D4',
-    tokenHint: 'Create a Personal Access Token in Azure DevOps (User settings → Personal access tokens). Select Full access or at minimum Work Items → Read & write.',
+    tokenHint: 'Open your Azure DevOps project in the browser and copy the URL from the address bar (e.g. https://dev.azure.com/myorg/MyProject). Then go to User settings → Personal access tokens → New token and create a token with Work Items → Read & write scope.',
     tokenUrl: 'https://dev.azure.com',
-    env: 'AZURE_DEVOPS_PAT=your-pat-here\nAZURE_DEVOPS_ORG=your-org-name\nAZURE_DEVOPS_PROJECT=your-project-name',
-    note: 'AZURE_DEVOPS_ORG is your organisation name (e.g. mycompany in dev.azure.com/mycompany). For legacy visualstudio.com or on-premises servers, set AZURE_DEVOPS_ORG_URL to the full base URL instead.',
+    env: 'AZURE_DEVOPS_URL=https://dev.azure.com/your-org/your-project\nAZURE_DEVOPS_PAT=your-pat-here',
+    note: 'AZURE_DEVOPS_URL works for all URL shapes — paste exactly what is in your browser. Legacy visualstudio.com URLs and on-premises servers are supported too.',
   },
 ]
 

--- a/ui/components/views/TasksView.tsx
+++ b/ui/components/views/TasksView.tsx
@@ -10,10 +10,11 @@ import type { IntegrationsResponse } from '@/app/api/integrations/route'
 const TASKS_POLL_INTERVAL_MS = 60_000
 
 const PROVIDER_META: Record<string, { label: string; color: string; glyph: string }> = {
-  jira:   { label: 'Jira',   color: '#2684FF', glyph: 'Ji' },
-  linear: { label: 'Linear', color: '#5E6AD2', glyph: 'Li' },
-  github: { label: 'GitHub', color: '#24292F', glyph: 'Gh' },
-  trello: { label: 'Trello', color: '#0052CC', glyph: 'Tr' },
+  jira:         { label: 'Jira',          color: '#2684FF', glyph: 'Ji' },
+  linear:       { label: 'Linear',        color: '#5E6AD2', glyph: 'Li' },
+  github:       { label: 'GitHub',        color: '#24292F', glyph: 'Gh' },
+  trello:       { label: 'Trello',        color: '#0052CC', glyph: 'Tr' },
+  azure_devops: { label: 'Azure DevOps',  color: '#0078D4', glyph: 'Az' },
 }
 
 export default function TasksView({ focusKey }: { focusKey?: string | null }) {
@@ -360,7 +361,7 @@ function TaskDetail({ task, sessions }: { task: TaskSummary; sessions: TodayResp
 // up and, on click, expands the exact steps to connect one. Deliberately quiet:
 // a single status line per tracker, details only when asked for.
 
-type TrackerId = 'jira' | 'linear' | 'github' | 'trello'
+type TrackerId = 'jira' | 'linear' | 'github' | 'trello' | 'azure_devops'
 
 const TRACKERS: Array<{
   id: TrackerId
@@ -413,12 +414,22 @@ const TRACKERS: Array<{
       hint: 'Connect with your browser — no API token to create.',
     },
   },
+  {
+    id: 'azure_devops',
+    name: 'Azure DevOps',
+    glyph: 'Az',
+    color: '#0078D4',
+    tokenHint: 'Create a Personal Access Token in Azure DevOps (User settings → Personal access tokens). Select Full access or at minimum Work Items → Read & write.',
+    tokenUrl: 'https://dev.azure.com',
+    env: 'AZURE_DEVOPS_PAT=your-pat-here\nAZURE_DEVOPS_ORG=your-org-name\nAZURE_DEVOPS_PROJECT=your-project-name',
+    note: 'AZURE_DEVOPS_ORG is your organisation name (e.g. mycompany in dev.azure.com/mycompany). For legacy visualstudio.com or on-premises servers, set AZURE_DEVOPS_ORG_URL to the full base URL instead.',
+  },
 ]
 
 function ConnectTrackers({ integrations, onDisconnect }: { integrations: IntegrationsResponse | null; onDisconnect?: () => void }) {
   const [open, setOpen] = useState<TrackerId | null>(null)
   const [disconnecting, setDisconnecting] = useState<TrackerId | null>(null)
-  const anyConnected = !!integrations && (integrations.jira || integrations.linear || integrations.github || integrations.trello)
+  const anyConnected = !!integrations && (integrations.jira || integrations.linear || integrations.github || integrations.trello || integrations.azure_devops)
 
   const handleDisconnect = (id: TrackerId) => {
     setDisconnecting(id)


### PR DESCRIPTION
## Summary

- Full Azure DevOps integration as a fifth PM provider (alongside Jira, GitHub, Linear, Trello)
- PAT-based auth supporting all three URL shapes: `dev.azure.com/{org}`, `{org}.visualstudio.com`, on-premises TFS/Azure DevOps Server
- Dynamic state filtering via the per-type states API (no state names injected into WIQL — handles custom states and apostrophes safely)
- Worklogs posted as work item comments using the 7.1-preview.4 endpoint (same pattern as GitHub/Linear/Trello)
- UI integrations panel detects connection, shows setup steps with copy-paste env block
- `meridian setup` / `install-from-bundle.sh` prompt for PAT + org + project interactively

## What was verified

- WIQL fetch against `dev.azure.com/adithyaharish/Meridian`: returns assigned work item IDs ✓
- States API (`/_apis/wit/workitemtypes/Task/states`): returns correct state→category mapping ✓
- Batch work item fetch: returns Title, WorkItemType, State, ChangedDate ✓
- Worklog comment post to work item #3: `id=8307849` returned ✓
- All 26 unit tests pass; 4 integration tests pass; clippy clean; UI builds clean ✓

> **Note:** On-premises support is built to the Azure DevOps REST API spec but not live-tested (no on-prem instance available). Cloud (`dev.azure.com`) is fully verified.

> **Reminder for the reviewer:** the test PAT in `.env` was used during development and should be rotated before any deployment.

## Test plan

- [ ] Set `AZURE_DEVOPS_PAT`, `AZURE_DEVOPS_ORG`, `AZURE_DEVOPS_PROJECT` and run `meridian force-pm-sync`
- [ ] Verify work items appear in Tasks view of the dashboard with `Az` glyph
- [ ] Approve a worklog draft in the Worklogs view and confirm a comment appears on the Azure DevOps work item
- [ ] Disconnect via the integrations panel and confirm keys are cleared from `.env`
- [ ] Test legacy URL: set `AZURE_DEVOPS_ORG=yourorg.visualstudio.com` (no `AZURE_DEVOPS_ORG_URL`) and verify it resolves correctly