### PR TITLE
docs(readme): state why Apple Silicon is required and what is unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ A local dashboard at **http://localhost:3939** shows your day as a timeline and 
 
 **Requirements:** macOS on Apple Silicon (M1+).
 
+> The on-device model runs on [MLX](https://github.com/ml-explore/mlx) (Metal-based, arm64-only), so **Intel Macs are not supported** — the installer checks the hardware and refuses cleanly. **Windows and Linux are not supported** either: the capture and service stack is macOS-only. Rosetta toolchains (x86_64 terminal, Homebrew, or Python) on an Apple Silicon Mac are fine — Python services are built from a pinned, uv-managed arm64 interpreter regardless of what's on your `PATH`.
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Meridiona/meridian/main/scripts/bootstrap.sh | bash
 ```

--- a/src/pm_worklog/azure_devops.rs
+++ b/src/pm_worklog/azure_devops.rs
@@ -55,7 +55,12 @@ pub async fn post_worklog(
         bail!("time_spent_seconds={time_spent_seconds} below the 60s worklog minimum");
     }
     let item = parse_task_key(task_key)?;
-    let body = format_worklog_comment(comment, time_spent_seconds, window_start_iso, window_end_iso);
+    let body = format_worklog_comment(
+        comment,
+        time_spent_seconds,
+        window_start_iso,
+        window_end_iso,
+    );
 
     // The Comments endpoint is a preview API; use the -preview.4 suffix as
     // documented for Azure DevOps Services (cloud). On-premises TFS may require


### PR DESCRIPTION
Follow-up to #228 — the README requirement note missed that PR's merge window, and main's README was rewritten by #227 in the meantime, so this ports it onto the current landing page.

Adds a short note under the existing `**Requirements:** macOS on Apple Silicon (M1+).` line (kept verbatim) in the Install section:

- **Intel Macs are not supported** — MLX is Metal-based and ships arm64-only wheels; the installer checks the hardware and refuses cleanly (#228)
- **Windows and Linux are not supported** — the capture and service stack (screenpipe permissions, launchd agents, a11y helper) is macOS-only
- **Rosetta toolchains on Apple Silicon are fine** — installers detect hardware via `sysctl` and build Python services from a pinned uv-managed arm64 interpreter regardless of `PATH`

Also carries the one-file `cargo fmt` drift in `src/pm_worklog/azure_devops.rs` from the Azure DevOps merge — pure formatter output, no logic change. `main` currently fails its own fmt gate, so the commit/push hooks refuse any commit without it (same situation #223 documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)