### PR TITLE
fix(daemon): create meridian.db before the MLX preflight and survive MLX being down

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -343,18 +343,35 @@ async fn main() -> Result<()> {
         "meridian daemon starting"
     );
 
-    // 4b. Preflight: verify classification stack is ready before starting the daemon.
-    //     Fails fast with a clear message rather than silently erroring every tick.
+    // 4b. Open / create meridian pool and run migrations FIRST — before any
+    //     preflight that can block or fail. The UI and MCP server read this DB
+    //     directly, so it must exist even when an optional component (MLX
+    //     server, screenpipe) is down; ordering it after the MLX preflight left
+    //     machines with a broken MLX install running a daemon that never
+    //     created its own database.
+    let meridian = setup_db(&initial_cfg.meridian_db_uri()).await?;
+
+    // 4c. Preflight: verify the classification stack. NON-FATAL — classification
+    //     is an enhancement layer; ETL must keep recording sessions while the
+    //     MLX server is down. Unclassified sessions stay pending and the task
+    //     linker's 5-minute fallback drains them once the server is reachable.
+    //     (Exiting here put launchd in a 120s-wait → exit → respawn loop on any
+    //     machine where the MLX server could not start.)
     if let Err(e) = check_classification_ready(&initial_cfg) {
-        tracing::error!("{}", e);
-        eprintln!("\nERROR: {}\n", e);
-        std::process::exit(1);
+        tracing::error!(
+            error = %e,
+            "classification preflight failed — continuing with classification degraded"
+        );
+        eprintln!(
+            "\nWARNING: {e}\n\
+             Sessions will be recorded but not classified until the MLX server is reachable.\n"
+        );
     }
 
-    // 4. Open screenpipe pool (read-only)
+    // 4d. Open screenpipe pool (read-only)
     let screenpipe = open_screenpipe(&initial_cfg.screenpipe_db_uri()).await?;
 
-    // 4c. Capture-layer (L1) preflight: surface degraded screen capture (revoked
+    // 4e. Capture-layer (L1) preflight: surface degraded screen capture (revoked
     //     Screen Recording / Accessibility permission, dead screenpipe, stale
     //     frames) before the poll loop. Non-fatal — the daemon still runs; we log
     //     the fault so misclassifications aren't blamed on the model.
@@ -362,9 +379,6 @@ async fn main() -> Result<()> {
         meridian::health::capture::checks(&initial_cfg, Some(&screenpipe)).await,
     )
     .log("startup");
-
-    // 5. Open / create meridian pool and run migrations
-    let meridian = setup_db(&initial_cfg.meridian_db_uri()).await?;
 
     // 5b. Unix domain socket — health endpoint for the tray / UI.
     //     ~/.meridian/daemon.sock: connecting succeeds = daemon is running.


### PR DESCRIPTION
## Symptom (two user machines so far)

`meridian doctor` shows the daemon **running** (stable pid) yet:

```
✗  meridian DB     meridian.db not readable (missing, locked, or not yet created)
✗  ui db access    Database not found — start the daemon: launchctl load …
```

The remedy text is a dead end — the daemon is already "running". The dashboard has no database to read, ETL never records a session, and the machine looks healthy on every liveness check.

## Root cause

Startup ordering in `main.rs`:

1. `check_classification_ready()` — blocks up to **120 s** retrying a TCP connect to the MLX server, then **`exit(1)`** if it's still down
2. `open_screenpipe()`
3. `setup_db()` — **only here** is `meridian.db` created and migrated

On any machine where the MLX server cannot start (broken venv, unsupported arch — e.g. x86_64 Python where `mlx` ships no wheel — failed model download, port conflict), launchd's `KeepAlive` + 30 s `ThrottleInterval` produce a permanent slow crash-loop: **120 s alive → exit(1) → 30 s throttle → respawn**. The daemon shows a live pid ~80 % of any given moment, so `meridian restart` and `doctor` both see it "running" — but step 3 is never reached and `meridian.db` is never created.

One broken *optional* component (classification) prevents the *core* pipeline from creating its own database and takes the dashboard down with it.

## Fix

Both changes in `main.rs`, no behaviour change on healthy machines:

1. **`setup_db()` runs first** — before the MLX preflight and the screenpipe open. The UI and MCP server read this DB directly; it must exist regardless of optional components.
2. **The MLX preflight is non-fatal.** Classification is an enhancement layer, and the runtime already tolerates the MLX server dying mid-run (task-linker retries, 5-minute fallback, `subprocess_error` sentinels after 3 consecutive failures). Exiting at startup was strictly worse than the degraded mode the daemon already supports: now it logs the failure loudly (`tracing::error!` + stderr WARNING) and continues — sessions are recorded and stay pending until the server is reachable. The 120 s retry window is kept so a legitimately slow first model load still gets waited for.

## Testing

- `cargo fmt --check`, `cargo clippy -- -D warnings` — clean
- `cargo test` — 251 unit + all integration suites pass

## Follow-ups (separate)

- `meridian doctor`: detect the "daemon running + DB missing" state explicitly and point at the daemon log instead of "start the daemon once"
- installer: preflight `platform.machine() == arm64` before `uv sync` so a broken MLX venv is reported as unsupported-hardware instead of being discovered at daemon startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)