### PR TITLE
fix(bundle): include lib-azure-setup.sh in release package

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -181,7 +181,8 @@ tar cf - \
 echo "→ scripts + plists + CLI"
 cp scripts/meridian-cli.sh scripts/install-from-bundle.sh scripts/meridian-npm-setup.sh \
    scripts/bootstrap.sh scripts/ui-start.sh scripts/lib-github-setup.sh \
-   scripts/lib-jira-setup.sh scripts/lib-trello-setup.sh "${DEST}/scripts/"
+   scripts/lib-jira-setup.sh scripts/lib-trello-setup.sh \
+   scripts/lib-azure-setup.sh "${DEST}/scripts/"
 cp scripts/install-daemon.sh scripts/uninstall-daemon.sh \
    scripts/install-ui-daemon.sh scripts/uninstall-ui-daemon.sh \
    scripts/install-screenpipe-daemon.sh scripts/uninstall-screenpipe-daemon.sh \

--- a/src/pm_worklog/azure_devops.rs
+++ b/src/pm_worklog/azure_devops.rs
@@ -55,7 +55,12 @@ pub async fn post_worklog(
         bail!("time_spent_seconds={time_spent_seconds} below the 60s worklog minimum");
     }
     let item = parse_task_key(task_key)?;
-    let body = format_worklog_comment(comment, time_spent_seconds, window_start_iso, window_end_iso);
+    let body = format_worklog_comment(
+        comment,
+        time_spent_seconds,
+        window_start_iso,
+        window_end_iso,
+    );
 
     // The Comments endpoint is a preview API; use the -preview.4 suffix as
     // documented for Azure DevOps Services (cloud). On-premises TFS may require


### PR DESCRIPTION
## Summary

- `scripts/lib-azure-setup.sh` was sourced by `install-from-bundle.sh` (line 122) but not copied into the bundle by `package-release.sh`
- This caused `meridian update` to fail with: `/scripts/lib-azure-setup.sh: No such file or directory`
- Fixed by adding `lib-azure-setup.sh` to the same `cp` command that already includes `lib-github-setup.sh`, `lib-jira-setup.sh`, and `lib-trello-setup.sh`

## Test plan

- [ ] Run `scripts/package-release.sh <version>` and verify `scripts/lib-azure-setup.sh` appears in the output bundle
- [ ] Run `meridian update` on an installed instance and confirm no "No such file or directory" error
- [ ] Verify `meridian setup` → Azure DevOps path completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)