### PR TITLE
fix(azure-devops): correct pm_tasks column names in upsert query

### DIFF
--- a/src/intelligence/providers/azure_devops.rs
+++ b/src/intelligence/providers/azure_devops.rs
@@ -306,16 +306,16 @@ pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result
         sqlx::query(
             "INSERT INTO pm_tasks
                (task_key, provider, title, description_text, status_category,
-                issue_type, source_url, updated_at_remote)
+                issue_type, url, updated_at)
              VALUES (?, 'azure_devops', ?, ?, ?, ?, ?, ?)
              ON CONFLICT(task_key) DO UPDATE SET
-               provider          = 'azure_devops',
-               title             = excluded.title,
-               description_text  = excluded.description_text,
-               status_category   = excluded.status_category,
-               issue_type        = excluded.issue_type,
-               source_url        = excluded.source_url,
-               updated_at_remote = excluded.updated_at_remote",
+               provider         = 'azure_devops',
+               title            = excluded.title,
+               description_text = excluded.description_text,
+               status_category  = excluded.status_category,
+               issue_type       = excluded.issue_type,
+               url              = excluded.url,
+               updated_at       = excluded.updated_at",
         )
         .bind(&task_key)
         .bind(&u.detail.fields.title)


### PR DESCRIPTION
## Summary

- The Azure DevOps provider used `source_url` and `updated_at_remote` in the `pm_tasks` INSERT/ON CONFLICT query
- Neither column exists — the schema uses `url` and `updated_at` (consistent with all other providers: Jira, Linear, GitHub, Trello)
- This caused every sync attempt to fail silently: `provider refresh failed provider="azure_devops" error=upserting Azure DevOps work item N`
- Azure DevOps tasks never appeared in the dashboard despite credentials being valid and work items being fetched successfully

## Test plan

- [ ] Run `meridian tasks-sync` with valid `AZURE_DEVOPS_PAT` + `AZURE_DEVOPS_URL` — should print `azure_devops: synced N task(s)`
- [ ] Azure DevOps tasks appear in the Tasks view
- [ ] No `upserting Azure DevOps work item` errors in `meridian logs daemon-error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)