### PR TITLE
feat(ui): group Today task buckets by integration, show titles & time-chunked summaries

### DIFF
--- a/ui/__tests__/redesign.test.ts
+++ b/ui/__tests__/redesign.test.ts
@@ -40,6 +40,20 @@ function fmtClock(isoOrHours: string | number): string {
   return `${hh}:${String(mn).padStart(2, '0')} ${period}`
 }
 
+function shortTaskKey(keyId: string, max = 12): string {
+  if (keyId.length <= max) return keyId
+  const slash = keyId.indexOf('/')
+  const k = slash >= 0 ? keyId.slice(slash + 1) : keyId
+  if (k.length <= max) return k
+  const hash = k.lastIndexOf('#')
+  if (hash > 0) {
+    const tail = k.slice(hash)
+    const head = k.slice(0, Math.max(1, max - tail.length - 1))
+    return `${head}…${tail}`
+  }
+  return `${k.slice(0, max - 1)}…`
+}
+
 function hexA(hex: string, a: number): string {
   const h = hex.replace('#', '')
   const r = parseInt(h.substring(0, 2), 16)
@@ -47,6 +61,32 @@ function hexA(hex: string, a: number): string {
   const b = parseInt(h.substring(4, 6), 16)
   return `rgba(${r},${g},${b},${a})`
 }
+
+// ── shortTaskKey ─────────────────────────────────────────────────────────────
+describe('shortTaskKey (redesign atoms)', () => {
+  it('leaves short keys untouched', () => {
+    expect(shortTaskKey('KAN-157')).toBe('KAN-157')
+    expect(shortTaskKey('ENG-1234')).toBe('ENG-1234')
+  })
+
+  it('drops the owner from a GitHub key that then fits', () => {
+    expect(shortTaskKey('Meridiona/meridian#194')).toBe('meridian#194')
+  })
+
+  it('ellipsizes a long repo but always keeps the issue number', () => {
+    expect(shortTaskKey('Meridiona/screenpipe-integration#1234')).toBe('screen…#1234')
+  })
+
+  it('keeps the full issue number even when the tail is long', () => {
+    const out = shortTaskKey('org/repository-name#1234567890')
+    expect(out.endsWith('#1234567890')).toBe(true)
+    expect(out).toContain('…')
+  })
+
+  it('tail-ellipsizes long keys with no issue number', () => {
+    expect(shortTaskKey('a-very-long-task-key-without-hash')).toBe('a-very-long…')
+  })
+})
 
 // ── fmtDur ───────────────────────────────────────────────────────────────────
 describe('fmtDur (redesign atoms)', () => {

--- a/ui/app/api/today/route.ts
+++ b/ui/app/api/today/route.ts
@@ -35,6 +35,19 @@ interface TodaySession {
   method: string
   link_method: string | null
   link_confidence: number | null
+  summary: string | null
+}
+
+export interface TaskMeta {
+  title: string
+  provider: string
+  url: string
+}
+
+export interface AgentSummary {
+  started_at: string
+  dur: number
+  summary: string
 }
 
 interface TodayActive {
@@ -85,6 +98,14 @@ export interface TodayResponse {
   // engaged_s: focus_s + autonomous agent time — the denominator for the per-task
   // "% of day" so a task carrying autonomous agent work never exceeds 100%.
   engaged_s: number
+  // task_key → tracker metadata from pm_tasks (title, provider, url) so the UI
+  // can show the human task title and group buckets by integration. A key may be
+  // missing if the originating ticket closed and was pruned on the next sync.
+  task_meta: Record<string, TaskMeta>
+  // task_key → coding-agent session summaries for today. Agent transcript rows
+  // are excluded from `sessions` (they're an overlay, not foreground activity)
+  // but they carry the summariser's digest — the per-task summary blocks need it.
+  task_agent_summaries: Record<string, AgentSummary[]>
 }
 
 export async function GET() {
@@ -98,6 +119,10 @@ export async function GET() {
     let hasExplanation = false
     try { db.prepare('SELECT category_explanation FROM app_sessions LIMIT 0').run(); hasExplanation = true } catch { /* pre-009 */ }
 
+    // session_summary was added in migration 024 — check gracefully
+    let hasSummary = false
+    try { db.prepare('SELECT session_summary FROM app_sessions LIMIT 0').run(); hasSummary = true } catch { /* pre-024 */ }
+
     const sql = `
       SELECT
         s.id,
@@ -110,6 +135,7 @@ export async function GET() {
         s.confidence,
         s.category_method,
         ${hasExplanation ? 's.category_explanation,' : "NULL AS category_explanation,"}
+        ${hasSummary ? 's.session_summary,' : "NULL AS session_summary,"}
         s.window_titles,
         s.task_key,
         s.task_routing      AS routing,
@@ -155,6 +181,7 @@ export async function GET() {
         method: (r.category_method as string) || 'rule_based',
         link_method: (r.link_method as string) || null,
         link_confidence: typeof r.link_confidence === 'number' ? r.link_confidence : null,
+        summary: (r.session_summary as string) || null,
       }
     })
 
@@ -266,6 +293,37 @@ export async function GET() {
     }
     const engaged_s = focus_s + autonomous_s
 
+    // ── Task metadata (title / provider / url) for keys touched today ──────────
+    const task_meta: Record<string, TaskMeta> = {}
+    try {
+      const todayKeys = new Set(allRows.map(r => r.task_key as string | null).filter(Boolean))
+      const tRows = db.prepare(`
+        SELECT task_key, title, provider, url FROM pm_tasks
+      `).all() as Array<Record<string, unknown>>
+      tRows.forEach(t => {
+        const k = t.task_key as string
+        if (!todayKeys.has(k)) return
+        task_meta[k] = {
+          title: (t.title as string) || k,
+          provider: (t.provider as string) || 'jira',
+          url: (t.url as string) || '',
+        }
+      })
+    } catch { /* pm_tasks table might not exist */ }
+
+    // ── Coding-agent summaries per task ─────────────────────────────────────────
+    const task_agent_summaries: Record<string, AgentSummary[]> = {}
+    codingRows.forEach(r => {
+      const k = r.task_key as string | null
+      const summary = (r.session_summary as string) || null
+      if (!k || !summary) return
+      ;(task_agent_summaries[k] ??= []).push({
+        started_at: r.started_at as string,
+        dur: (r.duration_s as number) ?? 0,
+        summary,
+      })
+    })
+
     const resp: TodayResponse = {
       date,
       sessions,
@@ -283,6 +341,8 @@ export async function GET() {
       task_totals,
       task_autonomous_s,
       engaged_s,
+      task_meta,
+      task_agent_summaries,
     }
 
     return NextResponse.json(resp)
@@ -294,6 +354,7 @@ export async function GET() {
       presence_segments: [], agent_segments: [],
       session_count: 0, switch_count: 0,
       task_totals: {}, task_autonomous_s: {}, engaged_s: 0,
+      task_meta: {}, task_agent_summaries: {},
     } satisfies TodayResponse)
   }
 }

--- a/ui/components/TaskBadge.tsx
+++ b/ui/components/TaskBadge.tsx
@@ -4,6 +4,7 @@
 import { ExternalLink } from 'lucide-react'
 import { clsx } from 'clsx'
 import * as Tooltip from '@radix-ui/react-tooltip'
+import { shortTaskKey } from '@/components/atoms'
 
 interface TaskBadgeProps {
   taskKey: string | null
@@ -158,7 +159,7 @@ export default function TaskBadge({
   if (sessionType === 'task' && routing === 'auto' && taskKey) {
     const inner = (
       <>
-        <span className="font-mono">{taskKey}</span>
+        <span className="font-mono whitespace-nowrap">{shortTaskKey(taskKey)}</span>
         {taskUrl && <ExternalLink className="w-2.5 h-2.5 opacity-60" />}
       </>
     )
@@ -197,7 +198,7 @@ export default function TaskBadge({
           'bg-[#FEF9EC] text-[#92400E] border border-[#FDE68A]',
           sizeClass,
         )}>
-          <span className="font-mono">{taskKey ?? 'queued'}</span>
+          <span className="font-mono whitespace-nowrap">{taskKey ? shortTaskKey(taskKey) : 'queued'}</span>
           <span className="opacity-60">?</span>
         </span>
       </WithTooltip>

--- a/ui/components/atoms.tsx
+++ b/ui/components/atoms.tsx
@@ -156,14 +156,36 @@ export function AppGlyph({ app, size = 24, withName = false }: { app: string | n
   )
 }
 
+/**
+ * Compact display form for a task key. GitHub keys (`owner/repo#123`) overflow
+ * the fixed-width key columns, so drop the owner and, if the rest is still too
+ * long, ellipsize the repo while always preserving the `#123` issue number.
+ * Callers showing the short form should keep the full key in a tooltip.
+ */
+export function shortTaskKey(keyId: string, max = 12): string {
+  if (keyId.length <= max) return keyId
+  const slash = keyId.indexOf('/')
+  const k = slash >= 0 ? keyId.slice(slash + 1) : keyId
+  if (k.length <= max) return k
+  const hash = k.lastIndexOf('#')
+  if (hash > 0) {
+    const tail = k.slice(hash)
+    const head = k.slice(0, Math.max(1, max - tail.length - 1))
+    return `${head}…${tail}`
+  }
+  return `${k.slice(0, max - 1)}…`
+}
+
 export function TaskKey({ keyId, big = false }: { keyId?: string | null; big?: boolean }) {
   if (!keyId) return null
+  const display = shortTaskKey(keyId)
   return (
     <span
-      className={`font-mono tracking-tight ${big ? 'text-[12px]' : 'text-[11px]'} px-1.5 py-px rounded-[4px] tnum`}
+      title={display === keyId ? undefined : keyId}
+      className={`font-mono tracking-tight whitespace-nowrap ${big ? 'text-[12px]' : 'text-[11px]'} px-1.5 py-px rounded-[4px] tnum`}
       style={{ color: 'var(--ink)', background: 'var(--tint)', borderBottom: '1px solid var(--rule-2)' }}
     >
-      {keyId}
+      {display}
     </span>
   )
 }

--- a/ui/components/atoms.tsx
+++ b/ui/components/atoms.tsx
@@ -51,6 +51,33 @@ export const CATS: Record<string, { label: string; short: string }> = {
   idle_personal:     { label: 'Idle',        short: 'Idle'   },
 }
 
+// ── Tracker (integration) metadata ───────────────────────────────────────────
+export const PROVIDER_META: Record<string, { label: string; color: string; glyph: string }> = {
+  jira:         { label: 'Jira',          color: '#2684FF', glyph: 'Ji' },
+  linear:       { label: 'Linear',        color: '#5E6AD2', glyph: 'Li' },
+  github:       { label: 'GitHub',        color: '#24292F', glyph: 'Gh' },
+  trello:       { label: 'Trello',        color: '#0052CC', glyph: 'Tr' },
+  azure_devops: { label: 'Azure DevOps',  color: '#0078D4', glyph: 'Az' },
+}
+
+export function ProviderGlyph({ provider, size = 16 }: { provider: string; size?: number }) {
+  const meta = PROVIDER_META[provider]
+  return (
+    <span
+      className="inline-flex items-center justify-center rounded shrink-0 font-mono"
+      style={{
+        width: size, height: size,
+        fontSize: Math.max(7, size * 0.56), fontWeight: 700,
+        background: (meta?.color ?? '#888') + '1A',
+        color: meta?.color ?? '#888',
+      }}
+      aria-label={meta?.label ?? provider}
+    >
+      {meta?.glyph ?? provider[0]?.toUpperCase() ?? '?'}
+    </span>
+  )
+}
+
 // ── App glyph metadata ───────────────────────────────────────────────────────
 const APP_META: Record<string, { mono: string; color: string }> = {
   'Antigravity':    { mono: 'Aᴳ', color: '#7C3AED' },

--- a/ui/components/views/TasksView.tsx
+++ b/ui/components/views/TasksView.tsx
@@ -2,20 +2,12 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { fmtDur, fmtClock, AppGlyph, CatDot, TaskKey, StatusPill, SegBar, SectionHead, Card, CATS } from '@/components/atoms'
+import { fmtDur, fmtClock, AppGlyph, CatDot, TaskKey, StatusPill, SegBar, SectionHead, Card, CATS, PROVIDER_META } from '@/components/atoms'
 import type { TaskSummary, TasksResponse } from '@/app/api/tasks/route'
 import type { TodayResponse } from '@/app/api/today/route'
 import type { IntegrationsResponse } from '@/app/api/integrations/route'
 
 const TASKS_POLL_INTERVAL_MS = 60_000
-
-const PROVIDER_META: Record<string, { label: string; color: string; glyph: string }> = {
-  jira:         { label: 'Jira',          color: '#2684FF', glyph: 'Ji' },
-  linear:       { label: 'Linear',        color: '#5E6AD2', glyph: 'Li' },
-  github:       { label: 'GitHub',        color: '#24292F', glyph: 'Gh' },
-  trello:       { label: 'Trello',        color: '#0052CC', glyph: 'Tr' },
-  azure_devops: { label: 'Azure DevOps',  color: '#0078D4', glyph: 'Az' },
-}
 
 export default function TasksView({ focusKey }: { focusKey?: string | null }) {
   const [data, setData] = useState<TasksResponse | null>(null)

--- a/ui/components/views/TodayView.tsx
+++ b/ui/components/views/TodayView.tsx
@@ -252,7 +252,7 @@ function BucketRow({ bucket, agentSummaries = [] }: { bucket: Bucket; agentSumma
         className="w-full text-left grid grid-cols-[auto_1fr_200px_auto] items-center gap-5 px-5 py-4 transition-colors"
         style={{ background: open ? 'var(--surface-2)' : 'var(--surface)' }}
       >
-        <span className="font-mono tnum text-[12px] w-[72px]" style={{ color: 'var(--ink-2)' }}>
+        <span className="font-mono tnum text-[12px] w-[92px] shrink-0" style={{ color: 'var(--ink-2)' }}>
           {!bucket.isOverhead && !bucket.isUntracked && !bucket.isQueue
             ? <TaskKey keyId={bucket.key} />
             : <span style={{ color: 'var(--ink-3)' }}>

--- a/ui/components/views/TodayView.tsx
+++ b/ui/components/views/TodayView.tsx
@@ -1,18 +1,18 @@
 // meridian — normalises screenpipe activity into structured app sessions
 'use client'
 
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo, useEffect, Fragment } from 'react'
 import { useRouter } from 'next/navigation'
 import {
   fmtDur, fmtDurDecimal, fmtClock,
-  CATS, AppGlyph, CatDot, LiveDot,
+  CATS, AppGlyph, CatDot, LiveDot, ProviderGlyph, PROVIDER_META,
   TaskKey, ConfidenceRing, SegBar, SectionHead, Card, useTick,
 } from '@/components/atoms'
 import TaskBadge from '@/components/TaskBadge'
 import ShapeOfDay from '@/components/ShapeOfDay'
 import DayTimeline from '@/components/DayTimeline'
 import TodayMetrics from '@/components/TodayMetrics'
-import type { TodayResponse } from '@/app/api/today/route'
+import type { TodayResponse, AgentSummary } from '@/app/api/today/route'
 
 interface BucketSession {
   id: number | string
@@ -26,6 +26,7 @@ interface BucketSession {
   link_method: string | null
   link_confidence: number | null
   routing: string | null
+  summary: string | null
 }
 
 interface Bucket {
@@ -168,14 +169,77 @@ function buildInsight(data: TodayResponse): string | null {
   return extra.length ? `${lead} — ${extra.join('; ')}.` : `${lead}.`
 }
 
+// ── Per-task summary chunks ──────────────────────────────────────────────────
+// Sessions on a task (foreground + coding-agent) are clustered into rolling
+// windows of at most CHUNK_MAX_SPAN_S, broken early on a CHUNK_MAX_GAP_S lull —
+// one digest line per stretch of work rather than one per session, so an
+// expanded task reads as a short narrative instead of a wall of text.
+const CHUNK_MAX_SPAN_S = 2 * 3600
+const CHUNK_MAX_GAP_S = 30 * 60
+
+interface SummaryChunk {
+  start: string
+  end: string
+  text: string
+}
+
+/** First sentence of a session summary, capped — summaries run 10-40 sentences. */
+function summaryLead(text: string): string {
+  const t = text.trim()
+  const m = t.match(/^[^.!?]*[.!?]/)
+  const s = (m ? m[0] : t).trim()
+  return s.length > 240 ? s.slice(0, 237).trimEnd() + '…' : s
+}
+
+function buildSummaryChunks(sessions: BucketSession[], agentSummaries: AgentSummary[]): SummaryChunk[] {
+  const entries = [
+    ...sessions.filter(s => s.summary).map(s => ({ started_at: s.started_at, dur: s.dur, summary: s.summary! })),
+    ...agentSummaries,
+  ].sort((a, b) => new Date(a.started_at).getTime() - new Date(b.started_at).getTime())
+
+  const chunks: Array<{ startMs: number; endMs: number; leads: string[] }> = []
+  for (const e of entries) {
+    const startMs = new Date(e.started_at).getTime()
+    const endMs = startMs + Math.max(0, e.dur) * 1000
+    const lead = summaryLead(e.summary)
+    const cur = chunks[chunks.length - 1]
+    if (cur && startMs - cur.startMs <= CHUNK_MAX_SPAN_S * 1000 && startMs - cur.endMs <= CHUNK_MAX_GAP_S * 1000) {
+      cur.endMs = Math.max(cur.endMs, endMs)
+      if (lead && !cur.leads.includes(lead)) cur.leads.push(lead)
+    } else {
+      chunks.push({ startMs, endMs, leads: lead ? [lead] : [] })
+    }
+  }
+
+  // Newest stretch first, matching the session list below it.
+  return chunks
+    .filter(c => c.leads.length > 0)
+    .map(c => ({
+      start: new Date(c.startMs).toISOString(),
+      end: new Date(c.endMs).toISOString(),
+      text: c.leads.join(' '),
+    }))
+    .reverse()
+}
+
 // ── Task bucket row ──────────────────────────────────────────────────────────
-function BucketRow({ bucket }: { bucket: Bucket }) {
+function BucketRow({ bucket, agentSummaries = [] }: { bucket: Bucket; agentSummaries?: AgentSummary[] }) {
   const [open, setOpen] = useState(false)
   const segs = useMemo(() => {
     const byCat: Record<string, number> = {}
     bucket.sessions.forEach(s => { byCat[s.cat] = (byCat[s.cat] ?? 0) + s.dur })
     return Object.entries(byCat).map(([cat, value]) => ({ cat, value }))
   }, [bucket.sessions])
+
+  // Latest work on top — both the digest chunks and the raw session list.
+  const recentFirst = useMemo(
+    () => [...bucket.sessions].sort((a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime()),
+    [bucket.sessions],
+  )
+  const chunks = useMemo(
+    () => buildSummaryChunks(bucket.sessions, agentSummaries),
+    [bucket.sessions, agentSummaries],
+  )
 
   const pct = bucket.day_total_s > 0
     ? ((bucket.total_s / bucket.day_total_s) * 100).toFixed(0)
@@ -221,8 +285,24 @@ function BucketRow({ bucket }: { bucket: Bucket }) {
 
       {open && (
         <div className="px-5 pb-4 pt-1 rule-t" style={{ borderTopColor: 'var(--rule)' }}>
+          {chunks.length > 0 && (
+            <div className="py-3 space-y-2.5">
+              <p className="text-[10px] uppercase tracking-[0.16em]" style={{ color: 'var(--ink-3)' }}>Summary</p>
+              {chunks.map(c => (
+                <div key={c.start} className="grid grid-cols-[auto_1fr] gap-3">
+                  <span className="font-mono tnum text-[11px] pt-px whitespace-nowrap" style={{ color: 'var(--ink-3)' }}>
+                    {fmtClock(c.start)}–{fmtClock(c.end)}
+                  </span>
+                  <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-2)', textWrap: 'pretty' } as React.CSSProperties}>
+                    {c.text}
+                  </p>
+                </div>
+              ))}
+              <p className="text-[10px] uppercase tracking-[0.16em] pt-1" style={{ color: 'var(--ink-3)' }}>Sessions</p>
+            </div>
+          )}
           <div className="grid grid-cols-1 gap-px" style={{ background: 'var(--rule)' }}>
-            {bucket.sessions.map(s => (
+            {recentFirst.map(s => (
               <div key={s.id} className="grid grid-cols-[auto_1fr_auto_auto] items-center gap-4 py-2.5 px-3"
                 style={{ background: 'var(--surface)' }}>
                 <AppGlyph app={s.app} size={20} />
@@ -248,6 +328,20 @@ function BucketRow({ bucket }: { bucket: Bucket }) {
           </div>
         </div>
       )}
+    </div>
+  )
+}
+
+// ── Integration group header ─────────────────────────────────────────────────
+function GroupHead({ provider, label, total_s }: { provider?: string; label?: string; total_s: number }) {
+  const meta = provider ? PROVIDER_META[provider] : undefined
+  return (
+    <div className="flex items-center gap-2 px-5 py-2" style={{ background: 'var(--surface-2)' }}>
+      {provider && meta && <ProviderGlyph provider={provider} size={16} />}
+      <span className="text-[10px] uppercase tracking-[0.15em]" style={{ color: 'var(--ink-3)' }}>
+        {label ?? meta?.label ?? provider}
+      </span>
+      <span className="ml-auto font-mono tnum text-[10px]" style={{ color: 'var(--ink-4)' }}>{fmtDur(total_s)}</span>
     </div>
   )
 }
@@ -381,7 +475,7 @@ export default function TodayView() {
   }
 
   data.sessions.forEach(s => {
-    const bs: BucketSession = { id: s.id, app: s.app, started_at: s.started_at, dur: s.dur, cat: s.cat, titles: s.titles, task_key: s.task_key, session_type: s.session_type, link_method: s.link_method, link_confidence: s.link_confidence, routing: s.routing }
+    const bs: BucketSession = { id: s.id, app: s.app, started_at: s.started_at, dur: s.dur, cat: s.cat, titles: s.titles, task_key: s.task_key, session_type: s.session_type, link_method: s.link_method, link_confidence: s.link_confidence, routing: s.routing, summary: s.summary }
     if (s.task_key) pushToBucket(s.task_key, bs)
     else if (s.routing === 'queue') pushToBucket('_queue', bs)
     // session_type ('task' | 'overhead' | 'unknown') is the classifier's own
@@ -392,7 +486,7 @@ export default function TodayView() {
   })
 
   if (data.active) {
-    const ab: BucketSession = { id: 'active', app: data.active.app, started_at: data.active.started_at, dur: data.active.elapsed_s, cat: data.active.cat, titles: data.active.titles, task_key: null, session_type: null, link_method: null, link_confidence: null, routing: null }
+    const ab: BucketSession = { id: 'active', app: data.active.app, started_at: data.active.started_at, dur: data.active.elapsed_s, cat: data.active.cat, titles: data.active.titles, task_key: null, session_type: null, link_method: null, link_confidence: null, routing: null, summary: null }
     pushToBucket('_active', ab)
   }
 
@@ -415,7 +509,10 @@ export default function TodayView() {
            : b.key === '_untracked' ? 'Untracked — personal, idle, unclassified'
            : b.key === '_queue'     ? 'Sessions waiting to be assigned'
            : b.key === '_active'    ? 'Current session'
-           : b.key,
+           // The human-readable ticket title; the key itself stays visible as
+           // the small mono badge in the row's left column. Falls back to the
+           // key when the ticket was pruned from pm_tasks (closed + re-synced).
+           : data.task_meta?.[b.key]?.title ?? b.key,
       day_total_s: total_s,
     }
   }).sort((a, b) => {
@@ -423,6 +520,24 @@ export default function TodayView() {
       k === '_queue' ? 10 : k === '_untracked' ? 9 : k === '_overhead' ? 8 : k === '_active' ? -1 : 0
     return (ord(a.key) - ord(b.key)) || (b.total_s - a.total_s)
   })
+
+  // ── Group task buckets by integration ──────────────────────────────────────
+  // The active block leads, then one group per tracker (largest first), then
+  // the off-ticket buckets (overhead / untracked / queue) at the bottom.
+  const activeBucket = buckets.find(b => b.key === '_active')
+  const taskBuckets = buckets.filter(b => !b.key.startsWith('_'))
+  const offTicketBuckets = buckets.filter(b => b.key.startsWith('_') && b.key !== '_active')
+
+  const byProvider = new Map<string, Bucket[]>()
+  taskBuckets.forEach(b => {
+    const provider = data.task_meta?.[b.key]?.provider ?? 'other'
+    if (!byProvider.has(provider)) byProvider.set(provider, [])
+    byProvider.get(provider)!.push(b)
+  })
+  const providerGroups = Array.from(byProvider.entries())
+    .map(([provider, group]) => ({ provider, group, total_s: group.reduce((a, g) => a + g.total_s, 0) }))
+    .sort((a, b) => b.total_s - a.total_s)
+  const offTicketTotal = offTicketBuckets.reduce((a, b) => a + b.total_s, 0)
 
   const queueCount = data.sessions.filter(s => s.routing === 'queue').length
 
@@ -483,7 +598,23 @@ export default function TodayView() {
             right={<button onClick={() => router.push('/tasks')} className="text-[12px]" style={{ color: 'var(--ink-3)' }}>Open Tasks →</button>}
           />
           <div className="space-y-px rule rounded-xl overflow-hidden border" style={{ borderColor: 'var(--rule)' }}>
-            {buckets.map(b => <BucketRow key={b.key} bucket={b} />)}
+            {activeBucket && <BucketRow bucket={activeBucket} />}
+            {providerGroups.map(g => (
+              <Fragment key={g.provider}>
+                <GroupHead provider={g.provider} label={g.provider === 'other' ? 'Other tasks' : undefined} total_s={g.total_s} />
+                {g.group.map(b => (
+                  <BucketRow key={b.key} bucket={b} agentSummaries={data.task_agent_summaries?.[b.key] ?? []} />
+                ))}
+              </Fragment>
+            ))}
+            {offTicketBuckets.length > 0 && (
+              <Fragment>
+                {(activeBucket || providerGroups.length > 0) && (
+                  <GroupHead label="Off-ticket" total_s={offTicketTotal} />
+                )}
+                {offTicketBuckets.map(b => <BucketRow key={b.key} bucket={b} />)}
+              </Fragment>
+            )}
           </div>
         </section>
       )}


### PR DESCRIPTION
## What

Reworks the **Today** page's "By task" section:

- **Grouped by integration** — task buckets now sit under a header per tracker (Jira / Linear / GitHub / Trello / Azure DevOps), largest group first, with the group's total time on the right. Tasks whose ticket was pruned from `pm_tasks` fall into an *Other tasks* group; overhead / untracked / queue buckets trail under *Off-ticket*.
- **Task title as the headline** — each bucket row now shows the human ticket title (from `pm_tasks.title`) instead of repeating the task id; the id stays visible as the existing small mono badge in the left column, so the row doesn't get more crowded.
- **Sessions newest-first** — the expanded session list inside a task is now reverse-chronological.
- **Per-task summary** — an expanded task shows a *Summary* block: sessions are clustered into rolling windows of at most 2 h (broken early on a 30 min lull), one digest line per stretch built from the first sentence of each session's `session_summary`. Coding-agent transcript rows (excluded from the foreground session list by design) contribute their summariser digests too.

## API

`/api/today` additionally returns:
- `summary` per session (`session_summary`, migration 024 — gracefully NULL on older DBs)
- `task_meta`: task_key → { title, provider, url } for keys touched today
- `task_agent_summaries`: task_key → coding-agent session digests for today

## Refactor

`PROVIDER_META` + new `ProviderGlyph` moved into shared `atoms.tsx`; `TasksView` imports them instead of holding its own copy.

## Verified

- `bun test` — 105 pass
- `npm run build` — clean
- Manual check against the live `meridian.db` (dev server + screenshots): Jira and GitHub groups render with correct totals, titles, newest-first sessions, and 2-hour summary chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)