### PR TITLE
fix(install): make meridian update atomic — stage and swap instead of rm-rf in place

### DIFF
--- a/scripts/meridian-npm-setup.sh
+++ b/scripts/meridian-npm-setup.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 # meridian — normalises screenpipe activity into structured app sessions
 #
-# Bridge from the npm install to the real install. Copies the prebuilt bundle
+# Bridge from the npm install to the real install. Assembles the prebuilt bundle
 # (the @meridiona/meridian-darwin-arm64 package contents) into ~/.meridian/app
 # and runs the bundle installer there — so the daemons run from a stable
 # location, not npm's volatile global node_modules.
+#
+# ATOMIC UPDATE: the new app tree is assembled COMPLETELY in a staging dir on
+# the same filesystem, then swapped into place with two renames. The live app
+# dir is never in a partial state — a crash anywhere during assembly leaves the
+# old version untouched and running. (The previous rm-rf-then-rebuild-in-place
+# flow shipped a 1.39.0 update that crashed mid-install and left machines with
+# no dashboard at all.)
 #
 #   meridian-npm-setup.sh <bundle_dir> [--skip-permissions]
 set -euo pipefail
@@ -12,63 +19,82 @@ set -euo pipefail
 BUNDLE="${1:?usage: meridian-npm-setup.sh <bundle_dir> [args…]}"
 shift || true
 APP="${HOME}/.meridian/app"
+STAGE="${HOME}/.meridian/.app-staging"
+OLD="${HOME}/.meridian/.app-old"
 
 [[ -x "${BUNDLE}/bin/meridian" ]] || { echo "✗ bundle at ${BUNDLE} is missing bin/meridian" >&2; exit 1; }
 
 mkdir -p "$(dirname "${APP}")"
+
+# Recover from a crash between the two swap renames of a previous run (app
+# already moved aside, staging not yet moved in). Microsecond window, but free
+# to handle: put the old version back before assembling the new one.
+if [[ ! -d "${APP}" && -d "${OLD}" ]]; then mv "${OLD}" "${APP}"; fi
+rm -rf "${STAGE}" "${OLD}"
+
+# APFS clonefile copy — instant and no extra disk on the same volume; plain
+# copy elsewhere. The live tree is always CLONED into staging, never moved, so
+# ~/.meridian/app stays complete until the swap.
+clone_dir() { # <src> <dst>
+    if ! cp -Rc "$1" "$2" 2>/dev/null; then
+        rm -rf "$2"
+        cp -R "$1" "$2"
+    fi
+}
+
+mkdir -p "${STAGE}"
+# Copy the prebuilt payload (bin/ ui.tar.gz services/ scripts/ .env.example VERSION).
+cp -R "${BUNDLE}/." "${STAGE}/"
+# Drop npm-package metadata that isn't part of the app.
+rm -f "${STAGE}/package.json" "${STAGE}/README.md" "${STAGE}/.gitignore" "${STAGE}/.npmignore"
+
 # Preserve an existing .env across re-installs/updates.
-keep=""
-if [[ -f "${APP}/.env" ]]; then keep="$(mktemp)"; cp "${APP}/.env" "${keep}"; fi
+[[ -f "${APP}/.env" ]] && cp "${APP}/.env" "${STAGE}/.env"
 
 # Preserve the Python venv across updates. The venv is built from PyPI via
 # uv sync at install time; preserving it means install-from-bundle.sh only
-# re-syncs when uv.lock actually changed. Kept in a sibling dir under
-# ~/.meridian so the move is an instant rename (same filesystem), never a
-# cross-volume copy.
-venv_keep="${HOME}/.meridian/.venv-update-keep"
-rm -rf "${venv_keep}"
-if [[ -d "${APP}/services/.venv" ]]; then mv "${APP}/services/.venv" "${venv_keep}"; fi
+# re-syncs when uv.lock actually changed.
+if [[ -d "${APP}/services/.venv" ]]; then
+    mkdir -p "${STAGE}/services"
+    rm -rf "${STAGE}/services/.venv"
+    clone_dir "${APP}/services/.venv" "${STAGE}/services/.venv"
+fi
 
-# Preserve the UI dir when the new ui.tar.gz hash matches the installed one.
-# install-from-bundle.sh detects the absent tarball + present ui/ dir and skips
-# re-extraction and the daemon restart, making non-UI updates instant.
+# UI. Two cases, mirroring install-from-bundle.sh's contract:
+#   * unchanged (tarball hash matches the recorded one, or no tarball shipped):
+#     clone the existing ui/ and drop the tarball — the installer reads
+#     "no tarball + ui/ present" as unchanged and skips re-extraction.
+#   * changed: pre-extract the tarball into staging AND keep the tarball. The
+#     stage is then complete BEFORE the swap, so an installer crash after the
+#     swap still leaves a runnable dashboard; the installer's own extraction
+#     (which records the new hash) re-does only a few seconds of work.
 _hash_file="${HOME}/.meridian/.component-hashes"
-_ui_keep="${HOME}/.meridian/.ui-update-keep"
-rm -rf "${_ui_keep}"
+_ui_preserved=0
 if [[ -d "${APP}/ui" ]]; then
-    if [[ -f "${BUNDLE}/ui.tar.gz" ]] && [[ -f "${_hash_file}" ]]; then
-        # Tarball present: preserve existing ui/ only when hash matches (unchanged build).
+    if [[ -f "${STAGE}/ui.tar.gz" ]] && [[ -f "${_hash_file}" ]]; then
         _old_ui_hash="$(grep '^ui_tarball=' "${_hash_file}" 2>/dev/null | cut -d= -f2 || true)"
-        _new_ui_hash="$(shasum -a 256 "${BUNDLE}/ui.tar.gz" | cut -d' ' -f1)"
+        _new_ui_hash="$(shasum -a 256 "${STAGE}/ui.tar.gz" | cut -d' ' -f1)"
         if [[ -n "${_old_ui_hash}" && "${_new_ui_hash}" == "${_old_ui_hash}" ]]; then
-            mv "${APP}/ui" "${_ui_keep}"
+            clone_dir "${APP}/ui" "${STAGE}/ui"
+            rm -f "${STAGE}/ui.tar.gz"
+            _ui_preserved=1
         fi
-    elif [[ ! -f "${BUNDLE}/ui.tar.gz" ]]; then
+    elif [[ ! -f "${STAGE}/ui.tar.gz" ]]; then
         # No tarball in bundle = UI unchanged since last release; keep existing build.
-        mv "${APP}/ui" "${_ui_keep}"
+        clone_dir "${APP}/ui" "${STAGE}/ui"
+        _ui_preserved=1
     fi
 fi
-
-rm -rf "${APP}"
-mkdir -p "${APP}"
-# Copy the prebuilt payload (bin/ ui.tar.gz services/ scripts/ .env.example VERSION).
-cp -R "${BUNDLE}/." "${APP}/"
-# Drop npm-package metadata that isn't part of the app.
-rm -f "${APP}/package.json" "${APP}/README.md" "${APP}/.gitignore" "${APP}/.npmignore"
-
-[[ -n "${keep}" ]] && { cp "${keep}" "${APP}/.env"; rm -f "${keep}"; }
-# Restore the preserved venv (the bundle ships services/ source but no venv).
-if [[ -d "${venv_keep}" ]]; then
-    mkdir -p "${APP}/services"
-    rm -rf "${APP}/services/.venv"
-    mv "${venv_keep}" "${APP}/services/.venv"
+if [[ "${_ui_preserved}" -eq 0 && -f "${STAGE}/ui.tar.gz" ]]; then
+    mkdir -p "${STAGE}/ui"
+    tar -xzf "${STAGE}/ui.tar.gz" -C "${STAGE}/ui"
 fi
-# Restore the preserved UI dir; delete the new tarball so install-from-bundle.sh
-# skips extraction and the daemon restart.
-if [[ -d "${_ui_keep}" ]]; then
-    rm -rf "${APP}/ui"
-    mv "${_ui_keep}" "${APP}/ui"
-    rm -f "${APP}/ui.tar.gz"
-fi
+
+# The swap: two renames on one filesystem. Running daemons keep their open
+# inodes from the old tree until they restart; the installer (exec'd next)
+# reloads them against the new tree.
+if [[ -d "${APP}" ]]; then mv "${APP}" "${OLD}"; fi
+mv "${STAGE}" "${APP}"
+rm -rf "${OLD}"
 
 exec bash "${APP}/scripts/install-from-bundle.sh" "$@"


### PR DESCRIPTION
## The problem this kills

`meridian-npm-setup.sh` updated in place: **`rm -rf ~/.meridian/app`** → copy new bundle → exec `install-from-bundle.sh` (UI extraction, venv sync, daemon reloads). Anything that dies between the `rm -rf` and the end of the installer leaves a half-installed machine with no self-repair.

This isn't theoretical — **1.39.0 demonstrated it at fleet scale**: its installer crashed deterministically (`source lib-azure-setup.sh` on a file the package didn't ship, fixed in #233) *after* the `rm -rf`, so every machine that updated was left with no `ui/` directory and a dead dashboard, exit-78 looping in launchd. Diagnosed live on a dev machine today.

## The new flow

Assemble the **complete** new tree in `~/.meridian/.app-staging` (same filesystem), then swap:

1. Copy the bundle into staging; drop npm metadata
2. Preserve `.env` (copy) and the Python venv (**APFS clonefile** — `cp -Rc`, instant + no extra disk; plain-copy fallback)
3. UI, mirroring the installer's existing contract:
   - **unchanged** (tarball hash matches recorded): clone existing `ui/`, drop the tarball → installer takes its skip-extraction path
   - **changed**: **pre-extract** `ui.tar.gz` into staging *and keep the tarball* → staging is runnable before the swap; the installer re-extracts (a few seconds) and records the new hash as before
4. Swap: `mv app .app-old && mv .app-staging app && rm -rf .app-old`
5. exec `install-from-bundle.sh` (unchanged — zero changes needed there)

## Failure analysis

| Crash point | Before | After |
|---|---|---|
| during assembly | app already deleted — dead dashboard | live app untouched, old version keeps running |
| between the two renames | n/a | microsecond window; next run restores `.app-old` automatically |
| inside the installer | possibly no `ui/` yet — dead dashboard | swapped-in app already complete + runnable; installer idempotent on re-run |

Key design shift: preservation moves from *move-aside-and-restore* (which mutates the live tree before the new one exists) to *clone-into-staging* (live tree never touched until the swap).

## Testing

Harness simulating the full lifecycle against a fake bundle + stub installer:

- fresh install (no existing app) — UI pre-extracted, tarball kept, installer exec'd
- unchanged-UI update — existing `ui/` cloned not re-extracted, tarball dropped, `.env` + venv preserved
- changed-UI update — new build extracted, `.env` preserved
- **mid-assembly crash (the 1.39.0 scenario)** — script fails, old app fully intact, installer never ran
- swap-window recovery — `.app-old` restored and update completes

**18/18 pass.** `bash -n` clean.

## Scope notes

- `install-from-bundle.sh` untouched — its tarball-presence contract is preserved exactly.
- The installer's *own* post-swap steps (extraction, plist reloads) remain non-transactional, but after the swap the app dir is always complete, so the worst post-swap outcome is "re-run `meridian update`", never "no dashboard".

🤖 Generated with [Claude Code](https://claude.com/claude-code)