### PR TITLE
fix(azure-devops): store browser URL instead of REST API URL

### DIFF
--- a/src/intelligence/providers/azure_devops.rs
+++ b/src/intelligence/providers/azure_devops.rs
@@ -306,16 +306,16 @@ pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result
         sqlx::query(
             "INSERT INTO pm_tasks
                (task_key, provider, title, description_text, status_category,
-                issue_type, source_url, updated_at_remote)
+                issue_type, url, updated_at)
              VALUES (?, 'azure_devops', ?, ?, ?, ?, ?, ?)
              ON CONFLICT(task_key) DO UPDATE SET
-               provider          = 'azure_devops',
-               title             = excluded.title,
-               description_text  = excluded.description_text,
-               status_category   = excluded.status_category,
-               issue_type        = excluded.issue_type,
-               source_url        = excluded.source_url,
-               updated_at_remote = excluded.updated_at_remote",
+               provider         = 'azure_devops',
+               title            = excluded.title,
+               description_text = excluded.description_text,
+               status_category  = excluded.status_category,
+               issue_type       = excluded.issue_type,
+               url              = excluded.url,
+               updated_at       = excluded.updated_at",
         )
         .bind(&task_key)
         .bind(&u.detail.fields.title)

--- a/src/intelligence/providers/azure_devops.rs
+++ b/src/intelligence/providers/azure_devops.rs
@@ -48,7 +48,6 @@ struct WorkItemBatchResponse {
 struct WorkItemDetail {
     id: u64,
     fields: WorkItemFields,
-    url: String,
 }
 
 #[derive(Deserialize)]
@@ -302,6 +301,10 @@ pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result
         let task_key = format!("{}#{}", cfg.project, u.detail.id);
         let description = u.detail.fields.description.as_deref().unwrap_or("");
         let changed = u.detail.fields.changed_date.as_deref().unwrap_or("");
+        let browser_url = format!(
+            "{}/{}/_workitems/edit/{}",
+            cfg.api_base, cfg.project, u.detail.id
+        );
 
         sqlx::query(
             "INSERT INTO pm_tasks
@@ -322,7 +325,7 @@ pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result
         .bind(description)
         .bind(u.status_category)
         .bind(&u.detail.fields.work_item_type)
-        .bind(&u.detail.url)
+        .bind(&browser_url)
         .bind(changed)
         .execute(pool)
         .await


### PR DESCRIPTION
## Summary

- Work items were storing the REST API URL (`_apis/wit/workItems/{id}`) in the `url` column instead of the browser URL
- The Open button in the Tasks view navigated to the API endpoint instead of `dev.azure.com/{org}/{project}/_workitems/edit/{id}`
- Fixed by constructing the browser URL from `cfg.api_base` + `cfg.project` + work item id
- Also removed the now-unused `url` field from `WorkItemDetail` (was the API URL deserialized from the response)

## Test plan

- [ ] Run `meridian tasks-sync` to re-sync work items with correct URLs
- [ ] Click Open on an Azure DevOps task in the Tasks view — should open the work item in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)