### PR TITLE
feat(ui): show absolute time on hover in Shape of Day activity breakdown

### DIFF
--- a/ui/components/ShapeOfDay.tsx
+++ b/ui/components/ShapeOfDay.tsx
@@ -137,7 +137,7 @@ export default function ShapeOfDay({ data }: { data: TodayResponse }) {
                     </span>
                   </div>
                   <span className="text-[12px] font-mono tnum font-semibold" style={{ color: isHov ? 'var(--ink)' : 'var(--ink-3)' }}>
-                    {item.percentage.toFixed(0)}%
+                    {isHov ? fmtDur(item.seconds) : `${item.percentage.toFixed(0)}%`}
                   </span>
                 </div>
               )


### PR DESCRIPTION
## Summary

- Category rows in the Shape of Day card show percentage by default (e.g. `45%`)
- Hovering a category row now swaps the value to the actual duration (e.g. `2h 15m`) so users can see how much time they actually spent without cluttering the default view

No new state needed — uses the existing `hoveredCat` state and `item.seconds` already in the data.

## Test plan

- [ ] Go to Today view
- [ ] Hover each category row in the Activity patterns card — value should switch from `%` to duration
- [ ] Mouse out — value should return to `%`

🤖 Generated with [Claude Code](https://claude.com/claude-code)