### PR TITLE
feat(azure-devops): surface PAT permission errors in the UI

### DIFF
--- a/src/intelligence/providers/azure_devops.rs
+++ b/src/intelligence/providers/azure_devops.rs
@@ -125,7 +125,12 @@ async fn run_wiql(client: &reqwest::Client, cfg: &AzureDevOpsConfig) -> Result<V
     let status = resp.status();
     if !status.is_success() {
         let text = resp.text().await.unwrap_or_default();
-        anyhow::bail!("Azure DevOps WIQL returned {status}: {text}");
+        let msg = match status.as_u16() {
+            401 => "permission_error: PAT is invalid or expired — regenerate it in Azure DevOps User settings → Personal access tokens".to_string(),
+            403 => "permission_error: PAT lacks required scope — create a token with Work Items → Read & write scope".to_string(),
+            _ => format!("sync_error: HTTP {status}: {text}"),
+        };
+        anyhow::bail!("{msg}");
     }
     let wiql: WiqlResponse = resp.json().await.context("parsing WIQL response")?;
     Ok(wiql.work_items.iter().map(|w| w.id).collect())
@@ -247,7 +252,14 @@ pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result
         .context("building HTTP client")?;
 
     // 1. WIQL: all work items assigned to me.
-    let all_ids = run_wiql(&client, cfg).await?;
+    let all_ids = match run_wiql(&client, cfg).await {
+        Ok(ids) => ids,
+        Err(e) => {
+            let msg = e.to_string();
+            stamp_error(pool, &msg).await?;
+            return Err(e);
+        }
+    };
     tracing::debug!(count = all_ids.len(), "azure_devops: WIQL returned IDs");
 
     if all_ids.is_empty() {
@@ -406,14 +418,31 @@ async fn prune(pool: &SqlitePool, kept_keys: &[String]) -> Result<()> {
 async fn stamp_sync(pool: &SqlitePool) -> Result<()> {
     let now = chrono::Utc::now().to_rfc3339();
     sqlx::query(
-        "INSERT INTO pm_sync_state (provider, last_synced_at)
-         VALUES ('azure_devops', ?)
-         ON CONFLICT(provider) DO UPDATE SET last_synced_at = excluded.last_synced_at",
+        "INSERT INTO pm_sync_state (provider, last_synced_at, last_error)
+         VALUES ('azure_devops', ?, NULL)
+         ON CONFLICT(provider) DO UPDATE SET
+           last_synced_at = excluded.last_synced_at,
+           last_error     = NULL",
     )
     .bind(&now)
     .execute(pool)
     .await
     .context("updating azure_devops sync state")?;
+    Ok(())
+}
+
+async fn stamp_error(pool: &SqlitePool, error: &str) -> Result<()> {
+    let now = chrono::Utc::now().to_rfc3339();
+    sqlx::query(
+        "INSERT INTO pm_sync_state (provider, last_synced_at, last_error)
+         VALUES ('azure_devops', ?, ?)
+         ON CONFLICT(provider) DO UPDATE SET last_error = excluded.last_error",
+    )
+    .bind(&now)
+    .bind(error)
+    .execute(pool)
+    .await
+    .context("recording azure_devops sync error")?;
     Ok(())
 }
 

--- a/src/migrations/033_pm_sync_state_error.sql
+++ b/src/migrations/033_pm_sync_state_error.sql
@@ -1,0 +1,4 @@
+-- meridian — normalises screenpipe activity into structured app sessions
+
+-- Surface sync errors (e.g. 401/403 from provider APIs) so the UI can flag them.
+ALTER TABLE pm_sync_state ADD COLUMN last_error TEXT;

--- a/ui/app/api/integrations/azure-devops/discover/route.ts
+++ b/ui/app/api/integrations/azure-devops/discover/route.ts
@@ -1,0 +1,86 @@
+// meridian — normalises screenpipe activity into structured app sessions
+
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+function basicAuth(pat: string): string {
+  return 'Basic ' + Buffer.from(`:${pat}`).toString('base64')
+}
+
+async function fetchJson<T>(url: string, pat: string): Promise<{ data: T | null; status: number; error?: string }> {
+  try {
+    const resp = await fetch(url, {
+      headers: { Authorization: basicAuth(pat), Accept: 'application/json' },
+    })
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => '')
+      return { data: null, status: resp.status, error: text }
+    }
+    const data = await resp.json() as T
+    return { data, status: resp.status }
+  } catch (e) {
+    return { data: null, status: 0, error: String(e) }
+  }
+}
+
+interface ProfileResponse { id: string }
+interface AccountsResponse { value: Array<{ accountName: string }> }
+interface ProjectsResponse { value: Array<{ name: string }> }
+
+// POST { pat } → { orgs: string[] }
+// POST { pat, org } → { projects: string[] }
+export async function POST(request: Request) {
+  let body: Record<string, string>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON' }, { status: 400 })
+  }
+
+  const { pat, org } = body
+  if (!pat) return NextResponse.json({ error: 'pat is required' }, { status: 400 })
+
+  if (org) {
+    // Step 2: list projects for the chosen org
+    const { data, status, error } = await fetchJson<ProjectsResponse>(
+      `https://dev.azure.com/${encodeURIComponent(org)}/_apis/projects?api-version=7.1`,
+      pat,
+    )
+    if (!data) {
+      const msg = status === 401 || status === 403
+        ? 'PAT is invalid or lacks Work Items → Read & write scope'
+        : `Azure DevOps returned HTTP ${status}`
+      return NextResponse.json({ error: msg, detail: error }, { status: 502 })
+    }
+    const projects = data.value.map(p => p.name).sort((a, b) => a.localeCompare(b))
+    return NextResponse.json({ projects })
+  }
+
+  // Step 1: look up the PAT owner's member ID, then list their orgs
+  const profile = await fetchJson<ProfileResponse>(
+    'https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=6.0',
+    pat,
+  )
+  if (!profile.data) {
+    const msg = profile.status === 401 || profile.status === 403
+      ? 'PAT is invalid or expired — check it and try again'
+      : `Azure DevOps profile API returned HTTP ${profile.status}`
+    return NextResponse.json({ error: msg, detail: profile.error }, { status: 502 })
+  }
+
+  const memberId = profile.data.id
+  const accounts = await fetchJson<AccountsResponse>(
+    `https://app.vssps.visualstudio.com/_apis/accounts?memberId=${encodeURIComponent(memberId)}&api-version=6.0`,
+    pat,
+  )
+  if (!accounts.data) {
+    return NextResponse.json(
+      { error: `Could not list organizations (HTTP ${accounts.status})`, detail: accounts.error },
+      { status: 502 },
+    )
+  }
+
+  const orgs = accounts.data.value.map(a => a.accountName).sort((a, b) => a.localeCompare(b))
+  return NextResponse.json({ orgs })
+}

--- a/ui/app/api/integrations/route.ts
+++ b/ui/app/api/integrations/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import getDb from '@/lib/db'
 
 export const dynamic = 'force-dynamic'
 
@@ -12,6 +13,7 @@ export interface IntegrationsResponse {
   github: boolean
   trello: boolean
   azure_devops: boolean
+  sync_errors: Partial<Record<string, string>>
 }
 
 function repoRoot(): string {
@@ -119,6 +121,19 @@ export async function GET() {
     github: isSet(env, 'GITHUB_TOKEN'),
     trello: trelloOAuth,
     azure_devops: isSet(env, 'AZURE_DEVOPS_PAT') && (isSet(env, 'AZURE_DEVOPS_URL') || isSet(env, 'AZURE_DEVOPS_ORG') || isSet(env, 'AZURE_DEVOPS_ORG_URL')),
+    sync_errors: {},
+  }
+
+  try {
+    const db = getDb()
+    const rows = db.prepare(
+      "SELECT provider, last_error FROM pm_sync_state WHERE last_error IS NOT NULL"
+    ).all() as Array<{ provider: string; last_error: string }>
+    for (const row of rows) {
+      result.sync_errors[row.provider] = row.last_error
+    }
+  } catch {
+    // DB not available (e.g. daemon not yet initialised) — omit errors silently
   }
 
   return NextResponse.json(result)

--- a/ui/components/views/TasksView.tsx
+++ b/ui/components/views/TasksView.tsx
@@ -442,6 +442,7 @@ function ConnectTrackers({ integrations, onDisconnect }: { integrations: Integra
       <div className="mt-5 rounded-xl border overflow-hidden" style={{ borderColor: 'var(--rule)' }}>
         {TRACKERS.map((t, i) => {
           const connected = !!integrations?.[t.id]
+          const syncError = integrations?.sync_errors?.[t.id]
           const isOpen = open === t.id
           return (
             <div key={t.id} className={i > 0 ? 'rule-t' : ''} style={{ borderTopColor: 'var(--rule)' }}>
@@ -458,9 +459,9 @@ function ConnectTrackers({ integrations, onDisconnect }: { integrations: Integra
                 </span>
                 <span className="text-[13px]" style={{ color: 'var(--ink)' }}>{t.name}</span>
                 {connected ? (
-                  <span className="ml-auto inline-flex items-center gap-1.5 text-[11px]" style={{ color: 'var(--ink-2)' }}>
-                    <span className="inline-block w-1.5 h-1.5 rounded-full" style={{ background: 'var(--success)' }} />
-                    Connected
+                  <span className="ml-auto inline-flex items-center gap-1.5 text-[11px]" style={{ color: syncError ? '#d97706' : 'var(--ink-2)' }}>
+                    <span className="inline-block w-1.5 h-1.5 rounded-full" style={{ background: syncError ? '#d97706' : 'var(--success)' }} />
+                    {syncError ? 'Sync error' : 'Connected'}
                     <span className="inline-block transition-transform" style={{ transform: isOpen ? 'rotate(90deg)' : 'none', color: 'var(--ink-4)' }}>›</span>
                   </span>
                 ) : (
@@ -472,6 +473,16 @@ function ConnectTrackers({ integrations, onDisconnect }: { integrations: Integra
               </button>
               {isOpen && connected && (
                 <div className="px-4 pb-4 pt-2" style={{ background: 'var(--surface-2)' }}>
+                  {syncError && (
+                    <div className="mb-3 rounded-md px-3 py-2 text-[12px] leading-relaxed" style={{ background: '#fef3c7', color: '#92400e', border: '1px solid #fcd34d' }}>
+                      <strong>Sync failed:</strong>{' '}
+                      {syncError.startsWith('permission_error: ')
+                        ? syncError.slice('permission_error: '.length)
+                        : syncError.startsWith('sync_error: ')
+                          ? syncError.slice('sync_error: '.length)
+                          : syncError}
+                    </div>
+                  )}
                   <p className="text-[12px] leading-relaxed mb-3" style={{ color: 'var(--ink-3)' }}>
                     After disconnecting, run <CodeChip text="meridian restart" /> for the change to take effect.
                   </p>

--- a/ui/components/views/TasksView.tsx
+++ b/ui/components/views/TasksView.tsx
@@ -506,9 +506,185 @@ function ConnectTrackers({ integrations, onDisconnect }: { integrations: Integra
 }
 
 function TrackerSetup({ tracker }: { tracker: (typeof TRACKERS)[number] }) {
-  // Browser-OAuth trackers (Jira) get the one-command flow; everyone else gets
-  // the get-a-token / paste-env / restart flow.
-  return tracker.oauth ? <OAuthSetup oauth={tracker.oauth} /> : <TokenSetup tracker={tracker} />
+  if (tracker.oauth) return <OAuthSetup oauth={tracker.oauth} />
+  if (tracker.id === 'azure_devops') return <AzureDevOpsSetup tracker={tracker} />
+  return <TokenSetup tracker={tracker} />
+}
+
+function AzureDevOpsSetup({ tracker }: { tracker: (typeof TRACKERS)[number] }) {
+  const [pat, setPat] = useState('')
+  const [orgs, setOrgs] = useState<string[] | null>(null)
+  const [selectedOrg, setSelectedOrg] = useState('')
+  const [projects, setProjects] = useState<string[] | null>(null)
+  const [selectedProject, setSelectedProject] = useState('')
+  const [loading, setLoading] = useState<'orgs' | 'projects' | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const lookupOrgs = async () => {
+    if (!pat.trim()) return
+    setLoading('orgs')
+    setError(null)
+    setOrgs(null)
+    setSelectedOrg('')
+    setProjects(null)
+    setSelectedProject('')
+    try {
+      const r = await fetch('/api/integrations/azure-devops/discover', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pat: pat.trim() }),
+      })
+      const json = await r.json()
+      if (!r.ok) { setError(json.error ?? 'Failed to fetch organisations'); return }
+      setOrgs(json.orgs ?? [])
+      if ((json.orgs ?? []).length === 1) setSelectedOrg(json.orgs[0])
+    } catch {
+      setError('Network error — check your connection')
+    } finally {
+      setLoading(null)
+    }
+  }
+
+  const lookupProjects = async (org: string) => {
+    if (!org) return
+    setLoading('projects')
+    setError(null)
+    setProjects(null)
+    setSelectedProject('')
+    try {
+      const r = await fetch('/api/integrations/azure-devops/discover', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pat: pat.trim(), org }),
+      })
+      const json = await r.json()
+      if (!r.ok) { setError(json.error ?? 'Failed to fetch projects'); return }
+      setProjects(json.projects ?? [])
+      if ((json.projects ?? []).length === 1) setSelectedProject(json.projects[0])
+    } catch {
+      setError('Network error — check your connection')
+    } finally {
+      setLoading(null)
+    }
+  }
+
+  const handleOrgChange = (org: string) => {
+    setSelectedOrg(org)
+    if (org) lookupProjects(org)
+  }
+
+  const envBlock = selectedOrg && selectedProject
+    ? `AZURE_DEVOPS_URL=https://dev.azure.com/${selectedOrg}/${selectedProject}\nAZURE_DEVOPS_PAT=${pat.trim()}`
+    : tracker.env ?? ''
+
+  return (
+    <div className="px-4 pb-4 pt-1" style={{ background: 'var(--surface-2)' }}>
+      <ol className="space-y-3">
+        <li className="flex gap-3">
+          <StepNum n={1} />
+          <div className="min-w-0 flex-1">
+            <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-2)' }}>
+              Go to User settings → Personal access tokens → New token. Set scope to{' '}
+              <strong>Work Items → Read &amp; write</strong>.{' '}
+              <a href="https://dev.azure.com" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)' }}>
+                Open ↗
+              </a>
+            </p>
+            <div className="mt-2 flex gap-2">
+              <input
+                type="password"
+                value={pat}
+                onChange={e => setPat(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && lookupOrgs()}
+                placeholder="Paste your PAT here"
+                className="flex-1 font-mono text-[11px] px-2 py-1.5 rounded-md border"
+                style={{ color: 'var(--ink)', background: 'var(--surface)', borderColor: 'var(--rule)', outline: 'none' }}
+              />
+              <button
+                onClick={lookupOrgs}
+                disabled={!pat.trim() || loading === 'orgs'}
+                className="text-[11px] px-3 py-1.5 rounded-md transition-opacity shrink-0"
+                style={{
+                  background: 'var(--accent)', color: '#fff',
+                  opacity: (!pat.trim() || loading === 'orgs') ? 0.5 : 1,
+                  cursor: (!pat.trim() || loading === 'orgs') ? 'default' : 'pointer',
+                }}
+              >
+                {loading === 'orgs' ? 'Looking up…' : 'Look up orgs'}
+              </button>
+            </div>
+            {error && (
+              <p className="mt-1.5 text-[11px]" style={{ color: '#e53e3e' }}>{error}</p>
+            )}
+          </div>
+        </li>
+
+        {orgs !== null && (
+          <li className="flex gap-3">
+            <StepNum n={2} />
+            <div className="min-w-0 flex-1">
+              <p className="text-[12px] mb-1.5" style={{ color: 'var(--ink-2)' }}>
+                {orgs.length === 0 ? 'No organisations found for this PAT.' : 'Choose your organisation:'}
+              </p>
+              {orgs.length > 0 && (
+                <select
+                  value={selectedOrg}
+                  onChange={e => handleOrgChange(e.target.value)}
+                  className="w-full text-[12px] px-2 py-1.5 rounded-md border"
+                  style={{ color: 'var(--ink)', background: 'var(--surface)', borderColor: 'var(--rule)' }}
+                >
+                  <option value="">— select org —</option>
+                  {orgs.map(o => <option key={o} value={o}>{o}</option>)}
+                </select>
+              )}
+            </div>
+          </li>
+        )}
+
+        {projects !== null && selectedOrg && (
+          <li className="flex gap-3">
+            <StepNum n={3} />
+            <div className="min-w-0 flex-1">
+              <p className="text-[12px] mb-1.5" style={{ color: 'var(--ink-2)' }}>
+                {projects.length === 0 ? 'No projects found in this organisation.' : 'Choose your project:'}
+              </p>
+              {loading === 'projects' && (
+                <p className="text-[11px]" style={{ color: 'var(--ink-3)' }}>Loading projects…</p>
+              )}
+              {projects.length > 0 && (
+                <select
+                  value={selectedProject}
+                  onChange={e => setSelectedProject(e.target.value)}
+                  className="w-full text-[12px] px-2 py-1.5 rounded-md border"
+                  style={{ color: 'var(--ink)', background: 'var(--surface)', borderColor: 'var(--rule)' }}
+                >
+                  <option value="">— select project —</option>
+                  {projects.map(p => <option key={p} value={p}>{p}</option>)}
+                </select>
+              )}
+            </div>
+          </li>
+        )}
+
+        <li className="flex gap-3">
+          <StepNum n={selectedOrg && selectedProject ? (projects !== null ? 4 : 3) : (orgs !== null ? 3 : 2)} />
+          <div className="min-w-0 flex-1">
+            <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-2)' }}>
+              Run <CodeChip text="meridian config edit" /> and add:
+            </p>
+            <CopyBlock text={envBlock} />
+          </div>
+        </li>
+
+        <li className="flex gap-3">
+          <StepNum n={selectedOrg && selectedProject ? (projects !== null ? 5 : 4) : (orgs !== null ? 4 : 3)} />
+          <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-2)' }}>
+            Save, then run <CodeChip text="meridian restart" />. Your tasks appear here within a minute.
+          </p>
+        </li>
+      </ol>
+    </div>
+  )
 }
 
 function OAuthSetup({ oauth }: { oauth: { command: string; hint: string } }) {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meridian-ui",
-  "version": "1.34.4",
+  "version": "1.40.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meridian-ui",
-      "version": "1.34.4",
+      "version": "1.40.1",
       "dependencies": {
         "@opentelemetry/api": "1.9",
         "@opentelemetry/exporter-trace-otlp-http": "0.217",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- When the Azure DevOps WIQL request returns 401 or 403, the sync now writes a descriptive error message to `pm_sync_state.last_error` instead of silently failing
- The `/api/integrations` route reads `last_error` from the DB and includes it in the response
- The Tasks UI shows an amber "Sync error" badge on the connected tracker row and a warning banner with the human-readable error when expanded

## Changes

- `src/migrations/033_pm_sync_state_error.sql` — adds `last_error TEXT` column to `pm_sync_state`
- `src/intelligence/providers/azure_devops.rs` — 401 → "PAT is invalid or expired", 403 → "PAT lacks required scope — Work Items → Read & write"; clears error on success
- `ui/app/api/integrations/route.ts` — queries `pm_sync_state` for errors and adds `sync_errors` to the response type
- `ui/components/views/TasksView.tsx` — renders amber badge + banner when `sync_errors[provider]` is set

## Test plan

- [ ] Connect Azure DevOps with a PAT that has no Work Items scope → sync → Tasks view shows "Sync error" badge and "PAT lacks required scope" message
- [ ] Connect with an expired/invalid PAT → shows "PAT is invalid or expired" message
- [ ] Connect with a valid PAT → badge shows green "Connected", no banner
- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes

https://claude.ai/code/session_01FXVJmZjFdNeRjyQKNzS2ja
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXVJmZjFdNeRjyQKNzS2ja)_