### PR TITLE
fix(prompts): multi-provider language and prompt accuracy fixes

### DIFF
--- a/services/agents/_system_context.py
+++ b/services/agents/_system_context.py
@@ -33,15 +33,16 @@ Meridian monitors a developer's screen and builds a structured record of their w
 
 CURRENT CAPABILITY — session classification
   Given a work session (app, duration, screen content, recent history, open tickets), decide:
-  · which Jira ticket the session belongs to ("task"), or
+  · which tracked ticket the session belongs to ("task"), or
   · that it is overhead or untracked work.
+  Tickets may come from Jira, Linear, GitHub, Trello, or Azure DevOps — treat them uniformly.
   Use the task-classifier skill when asked to classify. Session data and candidate tickets are
   passed directly in the message — no need to query unless verifying a detail.
   Always return a single bare JSON object. No preamble, no markdown fences, no explanation.
 
-PLANNED CAPABILITY — PM task updates
-  Given classified sessions, create, update, comment on, and transition Jira tickets to keep
-  the project board current without manual developer input.
+CURRENT CAPABILITY — PM worklog updates
+  Given classified sessions, writes a verified worklog comment and posts it to the
+  connected PM tool (Jira, Linear, GitHub, etc.) without manual developer input.
 
 DATABASE (for verification and ad-hoc queries)
   Path:  {_DB_PATH}

--- a/services/agents/pm_worklog_update/workflow.py
+++ b/services/agents/pm_worklog_update/workflow.py
@@ -111,11 +111,9 @@ def _coerce_jira(raw) -> JiraUpdate | None:
 
 
 def _decide_state(update: JiraUpdate, coverage: float, bundle: SessionBundle) -> UpdateState:
-    """Apply the routing matrix that picks the final UpdateState."""
+    """All worklogs are DRAFTED until a human approves via the UI — never auto-posted."""
     if not update.summary.strip():
         return UpdateState.SKIPPED
-    if update.confidence < config.PM_WORKLOG_MIN_CONFIDENCE:
-        return UpdateState.DRAFTED
     return UpdateState.DRAFTED
 
 

--- a/services/agents/run_task_linker_mlx.py
+++ b/services/agents/run_task_linker_mlx.py
@@ -187,7 +187,7 @@ class SessionClassification(BaseModel):
         ),
     )
     session_summary: str = Field(
-        ..., min_length=100, max_length=1000,
+        ..., min_length=100,
         description=(
             "A factual prose summary of EVERYTHING the user did in this "
             "session, written for downstream project-management updates. "
@@ -342,7 +342,7 @@ def _coerce_apple_fm_result(data: dict) -> dict:
     if not data.get("reasoning"):
         data["reasoning"] = "Classified via Apple Foundation Models."
 
-    # session_summary: must be 100-1000 chars
+    # session_summary: must be at least 100 chars
     summary = str(data.get("session_summary", ""))
     if len(summary) < 100:
         # Pad from reasoning
@@ -350,7 +350,7 @@ def _coerce_apple_fm_result(data: dict) -> dict:
         summary = (summary + " " + reasoning).strip()
     if len(summary) < 100:
         summary = summary + " The session was processed by Apple Foundation Models."
-    data["session_summary"] = summary[:1000]
+    data["session_summary"] = summary
 
     # dimensions: must be dict[str, list[str]]
     dims = data.get("dimensions", {})

--- a/services/skills/activity/pm-worklog-synth/SKILL.md
+++ b/services/skills/activity/pm-worklog-synth/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: pm-worklog-synth
-description: Verify classified work sessions belong to a Jira ticket and write a brief worklog comment.
+description: Verify classified work sessions belong to a tracked ticket and write a brief worklog comment.
 license: MIT
 metadata:
   version: "2.0.0"
   meridian:
     role: synth
-    tags: [pm-worklog, jira, sdlc]
+    tags: [pm-worklog, sdlc]
 ---
 
 # PM Worklog Synthesiser
 
 You are Meridian's worklog writer. Your job is to look at a window of screen-capture sessions
-that were automatically classified to a Jira ticket, verify they actually belong, and write
-a brief, honest Jira worklog comment summarising what was done.
+that were automatically classified to a tracked ticket, verify they actually belong, and write
+a brief, honest worklog comment summarising what was done.
 
-You are **writing the developer's Jira time log entry**. The bar is: would the ticket owner
+You are **writing the developer's work log entry**. The bar is: would the ticket owner
 reading this understand what work happened, how long it took, and whether it genuinely
 relates to this ticket?
 
@@ -77,7 +77,7 @@ your `confidence`.
 ### Step 3 — Write the worklog comment
 
 From the verified sessions, write a **2-4 line worklog comment** in `summary`. This is what
-gets posted to Jira. Rules:
+gets posted to the ticket tracker. Rules:
 
 - Be factual and specific — mention the actual files, functions, commands, or outcomes visible
   in the session summaries. No vague claims like "made progress" or "worked on the feature".
@@ -108,7 +108,7 @@ gets posted to Jira. Rules:
 
 ## Output format
 
-Reply with ONE valid `JiraUpdate` JSON object. No preamble, no markdown fences, no follow-up
+Reply with ONE valid `WorklogUpdate` JSON object. No preamble, no markdown fences, no follow-up
 text. The primary fields that matter are `summary`, `time_spent_seconds`, and `confidence`.
 The bullet arrays (`what_shipped`, `in_progress`, `blockers`, `decisions`) are optional —
 leave them empty unless you have a very clear signal worth surfacing.

--- a/services/skills/activity/task-classifier/SKILL.applefm.md
+++ b/services/skills/activity/task-classifier/SKILL.applefm.md
@@ -10,7 +10,7 @@ metadata:
 # Session Task Classifier — Apple Intelligence tier (compact)
 
 You are Meridian's session classifier. Classify ONE work session captured from the
-user's screen against the open Jira tickets, and return a single JSON object.
+user's screen against the open tracked tickets (Jira, Linear, GitHub, Trello, Azure DevOps), and return a single JSON object.
 
 ## Decide in order
 1. **Overhead** — idle, music, system settings, clearly personal/unrelated browsing →

--- a/services/skills/activity/task-classifier/SKILL.md
+++ b/services/skills/activity/task-classifier/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-classifier
-description: Classify a user work session against open Jira tickets — pick the best match (or null) using session evidence, and infer dimension tags.
+description: Classify a user work session against open tracked tickets — pick the best match (or null) using session evidence, and infer dimension tags.
 version: 2.0.0
 metadata:
   meridian:
@@ -9,7 +9,7 @@ metadata:
 
 # Session Task Classifier
 
-You are Meridian's AI classifier. Your job is to classify work sessions captured from the user's screen and match them to open Jira tickets when appropriate and return response in strcutured json output.
+You are Meridian's AI classifier. Your job is to classify work sessions captured from the user's screen and match them to open tracked tickets (Jira, Linear, GitHub, Trello, Azure DevOps) when appropriate and return response in structured json output.
 
 ## Purpose
 
@@ -19,8 +19,8 @@ The task classifier sits at the center of Meridian's workflow understanding:
 2. **Sessions** → **task classification** (you classify each session)
 3. **Classification outcome** dictates downstream usage:
    - Sessions marked as **overhead** → completely discarded. Never surfaced in the UI, never used for inference, never used to create tasks. Treat as throwaway. Examples:  music players, system settings, idle browsing, etc.
-   - Sessions marked as **untracked** → retained and used downstream. Fed into workload analysis, task inference, and new-task creation pipelines. These are real work signals the user performed that just didn't match an open ticket. Examples: standup meetings, config housekeeping, repo exploration, general research.
-   - Sessions with **task matches** → linked to Jira tickets, routing=auto for time-tracking and progress.
+   - Sessions marked as **untracked** → retained and used downstream. Fed into workload analysis and task inference. These are real work signals the user performed that just didn't match an open ticket. Examples: standup meetings, config housekeeping, repo exploration, general research.
+   - Sessions with **task matches** → linked to the matched ticket, routing=auto for time-tracking and progress.
 
 ## Classification Decision Tree
 
@@ -38,9 +38,9 @@ If the session shows **any real work signal** (coding, research, meetings, writi
 ```json
 {"task_key": null, "confidence": 0.6-0.8, "session_type": "untracked", "routing": "queue"}
 ```
-**This is the important, common case — and it is what `untracked` MEANS: the user genuinely did this work, but there is no Jira ticket for it yet.** Downstream, Meridian uses untracked sessions to **create or update** the matching Jira task. So it is critical that you do **not** shoehorn this work into an unrelated existing ticket just because it is the only candidate available, or because recent sessions were on it. **A wrong task link is worse than `untracked`** — it pollutes a real ticket's worklog and hides the genuine untracked work that should have spawned its own ticket. When the evidence doesn't clearly fit a candidate, choose `untracked`.
+**This is the important, common case — and it is what `untracked` MEANS: the user genuinely did this work, but there is no tracked ticket for it.** It is critical that you do **not** shoehorn this work into an unrelated existing ticket just because it is the only candidate available, or because recent sessions were on it. **A wrong task link is worse than `untracked`** — it pollutes a real ticket's worklog and hides the genuine untracked work. When the evidence doesn't clearly fit a candidate, choose `untracked`.
 
-`untracked` sessions are kept and used downstream (workload analysis, capacity reporting, new-task creation). Mark dimensions to capture *what* the work was. Examples that must be `untracked` (not `overhead`): standups, retros, code reviews on untracked PRs, config/infra housekeeping, general repo exploration, general research, **and any work on a feature/bug/chore that has no matching candidate ticket**.
+`untracked` sessions are kept and used downstream (workload analysis, capacity reporting). Mark dimensions to capture *what* the work was. Examples that must be `untracked` (not `overhead`): standups, retros, code reviews on untracked PRs, config/infra housekeeping, general repo exploration, general research, **and any work on a feature/bug/chore that has no matching candidate ticket**.
 
 ### 3. Does it CLEARLY map to one specific candidate ticket? → task
 Assign a `task_key` **only** when the session's own evidence (window titles, OCR, file/branch names, an explicit ticket-key mention) directly matches the **scope described in that ticket's title/description** → return:
@@ -54,7 +54,7 @@ Recent-session continuity may *support* a match, but **continuity alone is never
 The user message contains:
 
 - **SESSION** — app, duration, top window titles, and the screen content (OCR / a11y). Decide the category yourself from this evidence; no category is provided.
-- **CANDIDATE TICKETS** — all open Jira tickets. These are the only tickets you may choose from.
+- **CANDIDATE TICKETS** — all open tracked tickets (Jira, Linear, GitHub, Trello, Azure DevOps). These are the only tickets you may choose from.
 - **RECENT SESSIONS** (previous 5) — app / time / duration / which ticket each mapped to (no screen text). A **weak disambiguation hint only**: it can support a match when the current session ALSO has matching evidence, but it must never override what the current session itself shows. Recent activity on a ticket does not make the current session that ticket.
 
 ## Available capabilities
@@ -66,7 +66,7 @@ sqlite3 "~/.meridian/meridian.db" "<SQL>"
 
 Available tables:
 - `app_sessions` — all captured work sessions (id, app_name, duration_s, session_text, task_key, task_routing, etc.)
-- `pm_tasks` — open Jira tickets (task_key, title, description_text, issue_type, status, epic_title, sprint_name)
+- `pm_tasks` — open tracked tickets (task_key, provider, title, description_text, issue_type, status, epic_title, sprint_name, tags)
 
 Use database queries sparingly — session data and candidate tickets are already provided in the message. Only query if you need to verify a detail or look up historical context not included in the current inputs.
 
@@ -103,7 +103,7 @@ Reply with ONE valid JSON object — no preamble, no markdown fences, no follow-
 - `category` — the single best activity category (see taxonomy below). Derive it yourself from the evidence (app, window titles, screen content); no category is provided in the input.
 - `category_confidence` — how certain you are about `category`, `0.0`–`1.0`.
 - `category_explanation` — ONE concise sentence justifying the category, citing the app / window titles / OCR evidence. Shown in the dashboard next to the category.
-- `session_type` — `"task"` links to Jira; `"overhead"` is thrown away; `"untracked"` is kept for workload analysis.
+- `session_type` — `"task"` links to the matched ticket; `"overhead"` is thrown away; `"untracked"` is kept for workload analysis.
 - `reasoning` — must cite specific window titles, OCR snippets, or context clues.
 - `dimensions` — omit keys with no evidence; return `{}` if no clear signals.
 - `session_summary` — see the dedicated section below. This is the SINGLE most important field for downstream PM updates.
@@ -129,7 +129,7 @@ Choose exactly ONE `category` from this fixed set. Pick the dominant activity by
 
 ## session_summary — THE PM-update payload
 
-This field is what the PM-update workflow consumes to write Jira worklog comments. It REPLACES the raw OCR text downstream — the PM agent will not see the original session_text unless it explicitly asks. So **every SDLC-relevant detail you observe must be captured here, written so a tech-lead reading it understands exactly what happened.**
+This field is what the PM-update workflow consumes to write worklog comments. It REPLACES the raw OCR text downstream — the PM agent will not see the original session_text unless it explicitly asks. So **every SDLC-relevant detail you observe must be captured here, written so a tech-lead reading it understands exactly what happened.**
 
 ### Length
 


### PR DESCRIPTION
- Replace 'Jira ticket' → 'tracked ticket' throughout classifier and worklog skills; list all supported providers where helpful
- Remove max_length=1000 FSM cap on session_summary — was silently truncating rich SDLC signal before it reached the worklog synth
- Remove 1000-char truncation in Apple FM session_summary fallback path
- Mark PM worklog capability as CURRENT (not PLANNED) in system context
- Remove dead confidence gate in _decide_state — worklog is always DRAFTED until human approval via UI; add clarifying comment

## What does this PR do?

<!-- One paragraph. Why is this change needed? What does it do? -->

## How was it tested?

<!-- What did you run? Paste relevant output, screenshots, or test results. -->

- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo fmt --check` passes
- [ ] UI builds (`cd ui && npm run build`)
- [ ] Manually tested the relevant flow

## Checklist

- [ ] Branch named `type/short-description`
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] New `.rs`/`.ts`/`.tsx` files start with the file-header comment (see CLAUDE.md)
- [ ] New migrations are numbered and don't modify existing ones
- [ ] No secrets, credentials, or `.env` files committed

## Related issues

<!-- Closes #NNN -->
