### PR TITLE
fix(ci): use GITHUB_TOKEN directly in Stage 1 — no PAT needed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,5 +51,7 @@ jobs:
 
       - name: Analyze commits and create draft release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          # Stage 1 never pushes back to main (no @semantic-release/git), so
+          # the auto-provisioned GITHUB_TOKEN is sufficient — no PAT needed.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary

- Removes `secrets.GH_TOKEN ||` from the `GITHUB_TOKEN` env in Stage 1's semantic-release step
- Stage 1 has no `@semantic-release/git`, so it never pushes commits back to main — no PAT required

## Why it was failing (401)

`${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}` only falls back if `GH_TOKEN` is falsy. If `GH_TOKEN` is set but expired, it's non-empty (truthy) so the expression returns it, and the GitHub API rejects it with 401.

Stage 2 (`release-publish.yml`) still uses `secrets.GH_TOKEN || secrets.GITHUB_TOKEN` for the version-bump push to main, where a PAT may be needed to bypass branch protection.

## Test plan

- [ ] Merge this PR — Stage 1 should create the `v1.44.0` tag and draft release cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)