### PR TITLE
fix(ci): restore GH_TOKEN in Stage 1 to trigger Stage 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Analyze commits and create draft release
         env:
-          # Stage 1 never pushes back to main (no @semantic-release/git), so
-          # the auto-provisioned GITHUB_TOKEN is sufficient — no PAT needed.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT required: GITHUB_TOKEN cannot trigger other workflows, so the
+          # tag push that fires Stage 2 (release-publish.yml) must use GH_TOKEN.
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary

Reverts the GITHUB_TOKEN-only change from #247.

`GITHUB_TOKEN` cannot trigger other GitHub Actions workflows (GitHub blocks cross-workflow events from the auto token to prevent loops). Stage 2 (`release-publish.yml`) only fires if the tag push in Stage 1 uses a PAT (`GH_TOKEN`).

The original 401 in Stage 1's first run was not caused by an invalid PAT — the token is valid and was used recently. The 401 may have been a transient GitHub API error on the first run of the new workflow.

## Test plan

- [ ] Merge — Stage 1 should create tag + draft release using GH_TOKEN
- [ ] Stage 2 should auto-trigger from the tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)