### PR TITLE
feat(ui): show task title and PM-tool link on worklog cards

### DIFF
--- a/ui/app/api/worklogs/route.ts
+++ b/ui/app/api/worklogs/route.ts
@@ -19,6 +19,8 @@ export interface WorklogBullet {
 export interface WorklogItem {
   id: number
   task_key: string
+  task_title: string | null
+  task_url: string | null
   provider: string
   window_start: string
   state: string
@@ -44,6 +46,8 @@ export interface WorklogsResponse {
 interface RawRow {
   id: number
   task_key: string
+  task_title: string | null
+  task_url: string | null
   provider: string
   window_start: string
   state: string
@@ -82,13 +86,15 @@ export async function GET(req: Request) {
   try {
     const db = getDb()
     const rows = db.prepare(`
-      SELECT id, task_key, COALESCE(provider, 'jira') AS provider, window_start,
-             state, confidence, coverage,
-             time_spent_seconds, payload_json, posted_worklog_id,
-             last_post_error, edited_at
-      FROM pm_worklogs
-      WHERE day_utc = ?
-      ORDER BY window_start, task_key
+      SELECT w.id, w.task_key, t.title AS task_title, t.url AS task_url,
+             COALESCE(w.provider, 'jira') AS provider, w.window_start,
+             w.state, w.confidence, w.coverage,
+             w.time_spent_seconds, w.payload_json, w.posted_worklog_id,
+             w.last_post_error, w.edited_at
+      FROM pm_worklogs w
+      LEFT JOIN pm_tasks t ON t.task_key = w.task_key
+      WHERE w.day_utc = ?
+      ORDER BY w.window_start, w.task_key
     `).all(day) as RawRow[]
 
     const counts: Record<string, number> = {}
@@ -109,6 +115,8 @@ export async function GET(req: Request) {
       return {
         id: r.id,
         task_key: r.task_key,
+        task_title: r.task_title,
+        task_url: r.task_url,
         provider: r.provider ?? 'jira',
         window_start: r.window_start,
         state: r.state,

--- a/ui/app/api/worklogs/route.ts
+++ b/ui/app/api/worklogs/route.ts
@@ -116,7 +116,7 @@ export async function GET(req: Request) {
         id: r.id,
         task_key: r.task_key,
         task_title: r.task_title,
-        task_url: r.task_url,
+        task_url: r.task_url?.startsWith('https://') ? r.task_url : null,
         provider: r.provider ?? 'jira',
         window_start: r.window_start,
         state: r.state,

--- a/ui/components/views/WorklogsView.tsx
+++ b/ui/components/views/WorklogsView.tsx
@@ -226,9 +226,27 @@ function WorklogCard({ w, busy, onApprove, onReject, onUnapprove, onSave }: {
     <div className="rounded-xl border overflow-hidden" style={{ borderColor: 'var(--rule)', background: 'var(--surface)' }}>
       <div className="px-5 py-4">
         {/* meta row */}
-        <div className="flex items-center gap-3">
-          <TaskKey keyId={w.task_key} />
-          <span className="text-[10px] uppercase tracking-[0.12em]" style={{ color: 'var(--ink-4)' }}>{providerLabel(w.provider)}</span>
+        <div className="flex items-center gap-3 min-w-0">
+          {w.task_url ? (
+            <a href={w.task_url} target="_blank" rel="noreferrer" title={`Open ${w.task_key} in ${providerLabel(w.provider)}`}
+              className="flex items-center gap-2 min-w-0 group">
+              <TaskKey keyId={w.task_key} />
+              {w.task_title && (
+                <span className="text-[12px] truncate group-hover:underline" style={{ color: 'var(--ink-2)' }}>
+                  {w.task_title}
+                </span>
+              )}
+              <span className="text-[10px] shrink-0" style={{ color: 'var(--ink-4)' }}>↗</span>
+            </a>
+          ) : (
+            <span className="flex items-center gap-2 min-w-0">
+              <TaskKey keyId={w.task_key} />
+              {w.task_title && (
+                <span className="text-[12px] truncate" style={{ color: 'var(--ink-2)' }}>{w.task_title}</span>
+              )}
+            </span>
+          )}
+          <span className="text-[10px] uppercase tracking-[0.12em] shrink-0" style={{ color: 'var(--ink-4)' }}>{providerLabel(w.provider)}</span>
           <span className="font-mono tnum text-[11px]" style={{ color: 'var(--ink-3)' }}>{fmtClock(w.window_start)}</span>
           <span className="text-[11px]" style={{ color: 'var(--ink-4)' }}>·</span>
           <span className="font-mono tnum text-[11px]" style={{ color: 'var(--ink-3)' }}>{fmtDur(w.time_spent_seconds)}</span>

--- a/ui/components/views/WorklogsView.tsx
+++ b/ui/components/views/WorklogsView.tsx
@@ -228,7 +228,7 @@ function WorklogCard({ w, busy, onApprove, onReject, onUnapprove, onSave }: {
         {/* meta row */}
         <div className="flex items-center gap-3 min-w-0">
           {w.task_url ? (
-            <a href={w.task_url} target="_blank" rel="noreferrer" title={`Open ${w.task_key} in ${providerLabel(w.provider)}`}
+            <a href={w.task_url} target="_blank" rel="noopener noreferrer" title={`Open ${w.task_key} in ${providerLabel(w.provider)}`}
               className="flex items-center gap-2 min-w-0 group">
               <TaskKey keyId={w.task_key} />
               {w.task_title && (


### PR DESCRIPTION
## Summary
- Worklog review cards previously showed only the ticket key (e.g. `KAN-157`) with no indication of what the task actually is.
- The worklogs API (`GET /api/worklogs`) now LEFT JOINs `pm_tasks` on `task_key`, exposing `task_title` and `task_url` on each `WorklogItem`.
- The card meta row renders the title next to the key (truncated for long titles). When the task has a URL, key + title link out to the ticket in the tracker (new tab, ↗ indicator, hover underline). Worklogs whose ticket isn't in `pm_tasks` degrade gracefully to plain key with no link.

## Test plan
- [x] `tsc --noEmit` — no new errors (only pre-existing `bun:test` resolution issues in test files)
- [x] Verified the join against a live `meridian.db`: drafts return full title + `https://…atlassian.net/browse/KAN-…` URL
- [ ] Visual check on the Worklogs page: title visible, link opens the ticket in Jira

🤖 Generated with [Claude Code](https://claude.com/claude-code)