### PR TITLE
fix(github): guard against null nodes in ProjectV2 GraphQL response

### DIFF
--- a/src/intelligence/providers/github.rs
+++ b/src/intelligence/providers/github.rs
@@ -46,7 +46,7 @@ struct ProjectNode {
 struct ProjectItemConnection {
     #[serde(rename = "pageInfo")]
     page_info: PageInfo,
-    nodes: Vec<ProjectItem>,
+    nodes: Vec<Option<ProjectItem>>,
 }
 
 #[derive(Deserialize)]
@@ -96,7 +96,7 @@ struct Repo {
 
 #[derive(Deserialize)]
 struct AssigneeConnection {
-    nodes: Vec<LoginNode>,
+    nodes: Vec<Option<LoginNode>>,
 }
 
 #[derive(Deserialize)]
@@ -243,7 +243,7 @@ async fn fetch_project_items(
             }
         };
 
-        for item in &project.items.nodes {
+        for item in project.items.nodes.iter().flatten() {
             if item.item_type.as_deref() != Some("ISSUE") {
                 continue;
             }
@@ -264,6 +264,7 @@ async fn fetch_project_items(
                 .assignees
                 .nodes
                 .iter()
+                .flatten()
                 .any(|a| a.login.eq_ignore_ascii_case(viewer_login))
             {
                 continue;


### PR DESCRIPTION
## Summary

- `ProjectV2ItemConnection.nodes` and `UserConnection.nodes` are typed `[T]` in GitHub's GraphQL schema — both the list and individual elements can be `null`
- The Rust structs had them as `Vec<T>` (non-optional elements), so a null element would cause a serde deserialization failure and silently drop the entire project's tasks
- Changed both to `Vec<Option<T>>` and added `.flatten()` at the two iteration sites

## Test plan

- [ ] Verify `cargo clippy` passes (no warnings)
- [ ] Trigger a GitHub sync and confirm tasks from all configured projects are fetched correctly
- [ ] Confirm behaviour is unchanged when no null elements are present (normal case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)