### PR TITLE
fix(migrations): revert #250 header edits that broke sqlx checksums

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@ SQL migration files use the SQL comment form:
 -- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 ```
 
+> **Migrations are exempt from retroactive header changes.** This header applies to a migration only when it is *first created*. Once a migration has shipped, its bytes are frozen — sqlx records a checksum of each applied migration and refuses to start the daemon if the file later differs (`migration N was previously applied but has been modified`). NEVER reformat, re-header, or otherwise edit an already-merged migration; doing so bricks every existing install on its next upgrade. Pre-existing migrations keep whatever first-line comment they shipped with.
+
 The `commit-msg` hook enforces conventional commit format. The `pre-commit` hook enforces `cargo fmt` and `cargo clippy`. The `pre-push` hook runs the full suite: fmt + clippy + `cargo test` + UI build + UI tests.
 
 ---

--- a/src/migrations/001_initial.sql
+++ b/src/migrations/001_initial.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 -- https://github.com/meridiona/meridian
 
 -- Completed app sessions (append-only, never updated after insert)

--- a/src/migrations/002_gaps.sql
+++ b/src/migrations/002_gaps.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 -- https://github.com/meridiona/meridian
 
 CREATE TABLE IF NOT EXISTS gaps (

--- a/src/migrations/003_intelligence.sql
+++ b/src/migrations/003_intelligence.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- Cached PM tasks fetched from Jira / GitHub / Linear.
 -- Re-fetched periodically; expires_at controls staleness.

--- a/src/migrations/004_categories.sql
+++ b/src/migrations/004_categories.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- Add activity category and confidence score to every closed session.
 -- Populated inline during ETL at the moment each session closes.

--- a/src/migrations/005_agents.sql
+++ b/src/migrations/005_agents.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- ---------------------------------------------------------------------------
 -- Schema for the meridian-agents Python service.

--- a/src/migrations/006_category_method.sql
+++ b/src/migrations/006_category_method.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- Track whether the category was assigned by the rule-based ETL or re-classified
 -- by Foundation Models post-ETL.  'rule_based' is the default for all existing rows.

--- a/src/migrations/007_session_dimensions.sql
+++ b/src/migrations/007_session_dimensions.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- ---------------------------------------------------------------------------
 -- session_dimensions — multi-label tagging table.

--- a/src/migrations/008_session_embeddings.sql
+++ b/src/migrations/008_session_embeddings.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- ---------------------------------------------------------------------------
 -- Stage-2 vector index for the agent-side tagger.

--- a/src/migrations/009_multi_sample_embeddings.sql
+++ b/src/migrations/009_multi_sample_embeddings.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- ---------------------------------------------------------------------------
 -- Multi-sample (multi-vector) session embeddings.

--- a/src/migrations/010_traceparent.sql
+++ b/src/migrations/010_traceparent.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- W3C trace-context propagation across process boundaries.
 -- Rust ETL writes the active span's `traceparent` when it closes a session;

--- a/src/migrations/011_deduplicate_gaps.sql
+++ b/src/migrations/011_deduplicate_gaps.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- Remove gap rows that are exact duplicates of an earlier row for the same
 -- time window. Duplicates arise when an ETL run is aborted mid-way and

--- a/src/migrations/012_add_session_text.sql
+++ b/src/migrations/012_add_session_text.sql
@@ -1,3 +1,3 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 ALTER TABLE app_sessions   ADD COLUMN session_text TEXT;
 ALTER TABLE active_session ADD COLUMN session_text TEXT;

--- a/src/migrations/013_add_category_explanation.sql
+++ b/src/migrations/013_add_category_explanation.sql
@@ -1,3 +1,3 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 ALTER TABLE app_sessions ADD COLUMN category_explanation TEXT;

--- a/src/migrations/014_drop_ocr_elements.sql
+++ b/src/migrations/014_drop_ocr_elements.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 -- Remove ocr_samples and elements_samples columns.
 -- Uses ALTER TABLE DROP COLUMN (SQLite 3.35+) to avoid recreating the table,
 -- which would require disabling FK constraints (sqlx enables them by default).

--- a/src/migrations/015_jira_updates.sql
+++ b/src/migrations/015_jira_updates.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 CREATE TABLE IF NOT EXISTS jira_update_log (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,
     task_key      TEXT    NOT NULL,

--- a/src/migrations/016_category_settler_cursor.sql
+++ b/src/migrations/016_category_settler_cursor.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- High-water mark for the Foundation Models category settler. Prevents the
 -- settler from re-processing sessions that existed before the daemon started.

--- a/src/migrations/017_ticket_links_reasoning.sql
+++ b/src/migrations/017_ticket_links_reasoning.sql
@@ -1,2 +1,2 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 ALTER TABLE ticket_links ADD COLUMN reasoning TEXT;

--- a/src/migrations/018_merge_ticket_links.sql
+++ b/src/migrations/018_merge_ticket_links.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- Merge ticket_links into app_sessions so every session row carries its task
 -- classification inline. task_method IS NULL means not yet classified.

--- a/src/migrations/019_pm_tasks_hierarchy.sql
+++ b/src/migrations/019_pm_tasks_hierarchy.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- Add hierarchy and context columns to pm_tasks so the classifier can
 -- reason about epic context, sprint membership, and task ownership.

--- a/src/migrations/020_session_text_source.sql
+++ b/src/migrations/020_session_text_source.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- Track the source of session_text per session so the LLM can calibrate
 -- confidence: accessibility tree text is clean/structured, OCR is noisier.

--- a/src/migrations/021_remove_subtasks.sql
+++ b/src/migrations/021_remove_subtasks.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- Remove all subtasks from pm_tasks, keeping only top-level tasks and features.
 -- Subtasks will be filtered out at fetch time with type != Subtask in the JQL.

--- a/src/migrations/022_drop_status_keep_category.sql
+++ b/src/migrations/022_drop_status_keep_category.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- Remove redundant status column; status_category is the normalized form used for all logic.
 -- status_category values: 'todo', 'in_progress', 'done'

--- a/src/migrations/023_pm_sync_state.sql
+++ b/src/migrations/023_pm_sync_state.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- Replace per-row expires_at TTL with a single last_synced_at timestamp per
 -- provider. This decouples "when to re-fetch" from task data and prevents a

--- a/src/migrations/024_session_summary.sql
+++ b/src/migrations/024_session_summary.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 --
 -- Add a `session_summary` column to `app_sessions` so the classifier can
 -- emit a 10-40 sentence factual summary of the user's activity in the

--- a/src/migrations/025_app_sessions_claude_uuid.sql
+++ b/src/migrations/025_app_sessions_claude_uuid.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 --
 -- Add `claude_session_uuid` to `app_sessions` so the coding_agent_indexer
 -- can register ended Claude Code / Codex sessions as first-class

--- a/src/migrations/026_app_sessions_day_utc.sql
+++ b/src/migrations/026_app_sessions_day_utc.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 --
 -- Per-day chunking for Claude / Codex rows.
 --

--- a/src/migrations/027_app_sessions_segments.sql
+++ b/src/migrations/027_app_sessions_segments.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 --
 -- Segment-based chunking + sealing for Claude / Codex coding-agent rows.
 --

--- a/src/migrations/028_drop_day_utc.sql
+++ b/src/migrations/028_drop_day_utc.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 -- Drop the redundant day_utc column from app_sessions.
 -- The date is already encoded in started_at; callers use substr(started_at,1,10).
 ALTER TABLE app_sessions DROP COLUMN day_utc;

--- a/src/migrations/029_pm_worklog.sql
+++ b/src/migrations/029_pm_worklog.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 --
 -- pm-worklog stage (Stage 4). Adds the hour ledger (new) and brings the worklog
 -- tables under Rust's DDL ownership. The pm_worklogs / pm_worklog_evidence /

--- a/src/migrations/030_pm_worklog_approval.sql
+++ b/src/migrations/030_pm_worklog_approval.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 --
 -- pm-worklog UI approval flow. Worklogs are now never auto-posted: the daemon
 -- only ever DRAFTS them, and a human approves (and optionally edits) each one in

--- a/src/migrations/031_pm_worklog_provider.sql
+++ b/src/migrations/031_pm_worklog_provider.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 --
 -- Multi-provider worklog support. A worklog must remember WHICH tracker it
 -- belongs to so the approved-poster can route it to the right backend (Jira's

--- a/src/migrations/032_worklog_reject_attribution.sql
+++ b/src/migrations/032_worklog_reject_attribution.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 --
 -- Worklog-reject attribution capture. When a reviewer dismisses a worklog they
 -- can now say where the time *should* have gone: a different ticket, or

--- a/src/migrations/033_pm_sync_state_error.sql
+++ b/src/migrations/033_pm_sync_state_error.sql
@@ -1,4 +1,4 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 
 -- Surface sync errors (e.g. 401/403 from provider APIs) so the UI can flag them.
 ALTER TABLE pm_sync_state ADD COLUMN last_error TEXT;

--- a/src/migrations/034_pm_tasks_tags.sql
+++ b/src/migrations/034_pm_tasks_tags.sql
@@ -1,2 +1,2 @@
--- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- meridian — normalises screenpipe activity into structured app sessions
 ALTER TABLE pm_tasks ADD COLUMN tags TEXT;


### PR DESCRIPTION
## The bug

**Every existing user's daemon crash-loops on upgrade** to any build containing #250, with:

```
Caused by:
    migration 1 was previously applied but has been modified
Error: failed to run migrations
```

(Reported live by a user upgrading 1.43.0 → 1.46.0 — the daemon showed "loaded but not running" and the log repeated `meridian daemon starting` every ~30s as launchd restarted it.)

## Root cause

sqlx records a **SHA-384 checksum of each migration's bytes** in `_sqlx_migrations` when it's applied, and re-validates every checksum on startup — this is its tamper-detection for already-applied migrations.

PR **#250 ("chore: update file headers… tagline", `64a9aa3`)** rewrote **line 1 of all 34 shipped migrations** (`001`–`034`):

```diff
--- meridian — normalises screenpipe activity into structured app sessions
+-- ambient dev tool that watches what you do and updates your PM tickets… productivity
```

Only a comment changed — **no schema** — but sqlx hashes the whole file, so the checksum of every migration changed. Existing DBs recorded the *old* checksums; the new binary ships the *new* files → mismatch → migrations abort → daemon panics before the poll loop → crash-loop. This hits **everyone**, not one machine.

## Fix

Restore migrations `001`–`034` to their **exact pre-#250 bytes** (verified header-line-only: each file is `1+/1-`, zero schema bytes touched) so they match what every existing database recorded. Keep #250's `.rs`/`.ts`/`.sh` header changes — those aren't checksum-validated, so they're harmless.

Also add a **CLAUDE.md carve-out** so the file-header rule and sqlx immutability stop colliding: the header applies to a migration **only at creation**; shipped migrations are frozen and must never be re-headered.

## Why reverting is safe (not the same mistake in reverse)

The restored bytes are the ones stable across **all releases 1.0–1.45** — i.e. what virtually every existing DB checksummed. #250 landed only hours before this, so the cohort that recorded the *new* checksums (a fresh install of a post-#250 build) is essentially empty; for any such case the same checksum-repair applies.

## Verification

- `git diff --numstat` on all 34 files: every change is exactly `1+/1-` (header line only).
- Restored line 1 confirmed back to `-- meridian — normalises screenpipe activity into structured app sessions`.
- No schema, no SQL statements altered.

## Immediate user remediation (until this ships)

For a user already stuck, the schema is intact, so realign the stored checksums (back up `meridian.db` first), then restart the daemon — or, as a last resort, move `meridian.db` aside and let it rebuild from screenpipe.

https://claude.ai/code/session_013mv3epyceLahz9Cue1mtPj

---
_Generated by [Claude Code](https://claude.ai/code/session_013mv3epyceLahz9Cue1mtPj)_