### PR TITLE
fix(db): self-heal migration checksums instead of crash-looping

### DIFF
--- a/src/db/meridian.rs
+++ b/src/db/meridian.rs
@@ -107,12 +107,86 @@ pub async fn setup_db(uri: &str) -> anyhow::Result<SqlitePool> {
         .await
         .with_context(|| format!("failed to open SQLite at {uri}"))?;
 
-    sqlx::migrate!("src/migrations")
+    let migrator = sqlx::migrate!("src/migrations");
+    reconcile_migration_checksums(&pool, &migrator).await?;
+    migrator
         .run(&pool)
         .await
         .context("failed to run migrations")?;
 
     Ok(pool)
+}
+
+/// Realign `_sqlx_migrations` checksums with the embedded migration files.
+///
+/// sqlx records a SHA-384 checksum of every applied migration and refuses to
+/// start ("migration N was previously applied but has been modified") if a
+/// migration file later differs. A comment/header-only edit to a shipped
+/// migration is enough to trip this and crash-loop the daemon on the next
+/// upgrade — the executable SQL is unchanged, but the bytes (hence the hash)
+/// are not. Rather than freeze migration bytes forever, we reconcile: for each
+/// already-applied migration whose stored checksum differs from the embedded
+/// one, rewrite the stored checksum (with a warning) so `run()` proceeds.
+///
+/// Only applied migrations present in `_sqlx_migrations` are touched; new or
+/// unapplied migrations are left for `run()` to apply normally, and a fresh DB
+/// (no `_sqlx_migrations` table yet) is a no-op. The trade-off is that a genuine
+/// SQL edit to a shipped migration is silently accepted rather than blocked —
+/// the warning log is the audit trail, and the "never edit a shipped migration"
+/// rule still stands.
+async fn reconcile_migration_checksums(
+    pool: &SqlitePool,
+    migrator: &sqlx::migrate::Migrator,
+) -> anyhow::Result<()> {
+    // `_sqlx_migrations` is created by the migrator on first run; on a brand-new
+    // database it does not exist yet, so there is nothing applied to reconcile.
+    let table_exists: i64 = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+         WHERE type = 'table' AND name = '_sqlx_migrations')",
+    )
+    .fetch_one(pool)
+    .await
+    .context("checking for _sqlx_migrations table")?;
+    if table_exists == 0 {
+        return Ok(());
+    }
+
+    for migration in migrator.iter() {
+        let stored: Option<Vec<u8>> =
+            sqlx::query_scalar("SELECT checksum FROM _sqlx_migrations WHERE version = ?")
+                .bind(migration.version)
+                .fetch_optional(pool)
+                .await
+                .with_context(|| {
+                    format!(
+                        "reading stored checksum for migration {}",
+                        migration.version
+                    )
+                })?;
+
+        // Not applied yet, or already aligned → nothing to do.
+        let Some(stored) = stored else { continue };
+        if stored.as_slice() == migration.checksum.as_ref() {
+            continue;
+        }
+
+        sqlx::query("UPDATE _sqlx_migrations SET checksum = ? WHERE version = ?")
+            .bind(migration.checksum.as_ref())
+            .bind(migration.version)
+            .execute(pool)
+            .await
+            .with_context(|| format!("repairing checksum for migration {}", migration.version))?;
+
+        tracing::warn!(
+            version = migration.version,
+            description = %migration.description,
+            "migration checksum drifted from the embedded file — repaired in \
+             _sqlx_migrations (expected only for comment/header-only edits to a \
+             shipped migration)"
+        );
+    }
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -453,4 +527,62 @@ pub async fn insert_gap(
     .await
     .context("insert_gap failed")?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    /// A header/comment-only edit to a shipped migration changes its checksum and
+    /// makes sqlx refuse to start ("migration N … has been modified"). Reconcile
+    /// must realign the stored checksum so the daemon boots again.
+    #[tokio::test]
+    async fn reconcile_repairs_drifted_checksum() {
+        // max_connections(1) keeps a single shared in-memory DB for the pool.
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("open in-memory db");
+
+        let migrator = sqlx::migrate!("src/migrations");
+        migrator.run(&pool).await.expect("initial migrate");
+
+        // Simulate a #250-style header edit: the stored checksum no longer matches
+        // the embedded migration's bytes.
+        sqlx::query("UPDATE _sqlx_migrations SET checksum = X'00' WHERE version = 1")
+            .execute(&pool)
+            .await
+            .expect("corrupt stored checksum");
+
+        // This is the crash-loop the daemon hits on upgrade.
+        assert!(
+            migrator.run(&pool).await.is_err(),
+            "a drifted checksum must make sqlx run() fail"
+        );
+
+        // After reconcile, run() succeeds again.
+        reconcile_migration_checksums(&pool, &migrator)
+            .await
+            .expect("reconcile");
+        migrator
+            .run(&pool)
+            .await
+            .expect("migrate after reconcile must succeed");
+    }
+
+    /// A fresh database (no `_sqlx_migrations` table yet) is a clean no-op.
+    #[tokio::test]
+    async fn reconcile_is_noop_on_fresh_db() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("open in-memory db");
+        let migrator = sqlx::migrate!("src/migrations");
+        reconcile_migration_checksums(&pool, &migrator)
+            .await
+            .expect("reconcile on fresh db must be a no-op");
+    }
 }


### PR DESCRIPTION
## The bug

Every existing user's daemon **crash-loops on upgrade** to any build containing #250:

```
Caused by:
    migration 1 was previously applied but has been modified
Error: failed to run migrations
```

(Reported live by a user on 1.43.0 → 1.46.0 — `meridian status` showed "loaded but not running" while the log repeated `meridian daemon starting` every ~30 s as launchd restarted it.)

## Root cause

sqlx records a **SHA-384 checksum of each migration's bytes** in `_sqlx_migrations` when it's applied, and re-validates **every** applied migration on startup. #250 ("update file headers… tagline") rewrote line 1 of all 34 shipped migrations — only a comment, **no schema** — but sqlx hashes the whole file, so every checksum changed. Existing DBs hold the old checksums; the new binary ships the new files → mismatch → `run()` aborts → daemon panics before the poll loop.

(The error names "migration 1" only because it's the first mismatch checked; all 34 are broken — so reverting a single file just moves the error to migration 2.)

## Fix — repair forward, don't freeze the bytes

This keeps #250's headers. Before running migrations, `setup_db` now calls `reconcile_migration_checksums()`, which:

1. No-ops on a fresh DB (no `_sqlx_migrations` table yet).
2. For each **already-applied** migration whose stored checksum differs from the **embedded** file's checksum (`migrator.iter()`), rewrites the stored checksum to match and logs a `warn!` naming the version.
3. Lets `run()` proceed and apply any genuinely new migrations as normal.

Every stuck install self-heals on its next daemon start — no revert, no user action, no `migrate-db` dance — and it's forward-proof against any future accidental reformat.

**Trade-off (called out honestly):** this weakens sqlx's tamper-detection — a genuine *SQL* change to a shipped migration is now accepted with a warning rather than blocked. The `warn!` is the audit trail, and the "never edit a shipped migration" rule remains the real guard.

## Tests

- `reconcile_repairs_drifted_checksum`: applies migrations, corrupts a stored checksum, asserts `run()` then **fails** (reproducing the crash), runs reconcile, asserts `run()` **succeeds**.
- `reconcile_is_noop_on_fresh_db`: reconcile on a DB with no `_sqlx_migrations` table is a clean no-op.

Full suite green: 256 lib tests + integration, `clippy -D warnings` and `fmt` clean.

## Relationship to other PRs

Supersedes the closed #260 (which reverted the headers). This is the "keep the tagline, fix the checksums" approach instead.

https://claude.ai/code/session_013mv3epyceLahz9Cue1mtPj

---
_Generated by [Claude Code](https://claude.ai/code/session_013mv3epyceLahz9Cue1mtPj)_