### PR TITLE
ci: enforce append-only migrations server-side + harden pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,14 +3,15 @@
 # Note: run `chmod +x .githooks/pre-commit` after cloning to make this executable
 set -e
 
-# Block modifications to already-committed migration files.
+# Block modifications, renames, or deletions of already-committed migration files.
 # Editing an existing migration changes its checksum and breaks any DB that has
-# already applied it — add a new numbered migration instead.
+# already applied it — add a new numbered migration instead. (M = modified,
+# D = deleted, R = renamed; $2 is the old path for all three.)
 modified_migrations=$(git diff --cached --name-status \
-    | awk '$1 == "M" { print $2 }' \
+    | awk '$1 ~ /^(M|D|R)/ { print $2 }' \
     | grep -E '^src/migrations/[0-9]+_.*\.sql$' || true)
 if [[ -n "$modified_migrations" ]]; then
-    echo "ERROR: modifying existing migration files is not allowed:" >&2
+    echo "ERROR: modifying, renaming, or deleting existing migration files is not allowed:" >&2
     echo "$modified_migrations" | sed 's/^/  /' >&2
     echo "" >&2
     echo "  Add a new src/migrations/<next>_<description>.sql instead." >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,29 @@ jobs:
       - name: UI build
         run: npm run build
         working-directory: ui
+
+  # Shipped migrations are immutable: sqlx records a checksum of every applied
+  # migration and the daemon refuses to start if a migration file later differs.
+  # A pre-commit hook also guards this, but hooks are opt-in and bypassable, so
+  # enforce it server-side where it cannot be skipped.
+  migration-guard:
+    name: Migrations append-only
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Reject modified, renamed, or deleted migrations
+        run: |
+          base='${{ github.event.pull_request.base.sha }}'
+          violations=$(git diff --name-status "$base"...HEAD -- src/migrations \
+            | grep -E '^(M|D|R)' || true)
+          if [ -n "$violations" ]; then
+            echo "::error::Shipped migrations are immutable. Add a NEW numbered migration in src/migrations/ — never modify, rename, or delete an existing one (it changes the sqlx checksum and breaks every database that already applied it)."
+            echo "Offending changes:"
+            echo "$violations"
+            exit 1
+          fi
+          echo "OK — no existing migrations were modified, renamed, or deleted."


### PR DESCRIPTION
## Why

#250 edited the header of all 34 shipped migrations, which changed their sqlx checksums and **crash-looped the daemon on every existing install** (`migration N was previously applied but has been modified`). #261 added a self-heal so the daemon recovers — but that's a safety net, not prevention. This PR closes the prevention gap.

A pre-commit hook *already* blocked modifying migrations… but it was added **by #250 itself**, and pre-commit hooks are:
- **opt-in** — only active if the dev ran `setup-hooks.sh` (which sets `core.hooksPath`), and
- **bypassable** — `git commit --no-verify` skips them.

So nothing enforced it where it counts. That's why #250 sailed through.

## What

1. **`migration-guard` CI job** (`ci.yml`) — on every PR, fails if the diff **modifies, renames, or deletes** any `src/migrations/*.sql` file. Adding a new numbered migration (`A`) is allowed. Runs server-side, so it can't be skipped with `--no-verify`:

   ```bash
   git diff --name-status "$base"...HEAD -- src/migrations | grep -E '^(M|D|R)'
   ```

2. **Hardened pre-commit hook** — the existing check only caught modifications (`M`); now it also catches deletes (`D`) and renames (`R`), which break checksums/ordering just as badly.

## Verification

- `ci.yml` parses as valid YAML; the hook passes `bash -n`.
- Detection logic checked against sample `--name-status` output: `M`/`D`/`R` on a migration are caught (rename reports the old path), while a new migration (`A`) and non-migration edits are ignored.

## Note

Scoped to the modification guard you asked about. A *second*, distinct migration footgun also surfaced today — two branches each adding a `035_*` file (duplicate version → `UNIQUE constraint failed: _sqlx_migrations.version`, which broke #257's CI after the #258 merge). I can add a duplicate-version check to the same CI job as a follow-up if you want it.

https://claude.ai/code/session_013mv3epyceLahz9Cue1mtPj

---
_Generated by [Claude Code](https://claude.ai/code/session_013mv3epyceLahz9Cue1mtPj)_