### PR TITLE
feat(dev): hot-reload dev environment with dev-start.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,36 +1,34 @@
 # Contributing to Meridian
 
-Thanks for your interest in Meridian! Contributions of all kinds are welcome — bug reports, fixes, documentation, and features. This guide gets you from a clone to a passing pull request.
+Thanks for your interest in contributing. This guide gets you from a clone to a passing pull request.
 
-By participating, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+By participating you agree to our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ---
 
 ## Ways to contribute
 
 - **Report a bug** — open a [bug report](https://github.com/Meridiona/meridian/issues/new?template=bug_report.yml). Include your macOS version, what you expected, and what happened.
-- **Request a feature** — open a [feature request](https://github.com/Meridiona/meridian/issues/new?template=feature_request.yml). Tell us the problem first, the solution second.
-- **Improve docs** — typos, unclear steps, missing context. Docs PRs are always welcome and easy to review.
-- **Fix or build** — grab an open issue (look for `good first issue`), or open one to discuss before large changes.
+- **Request a feature** — open a [feature request](https://github.com/Meridiona/meridian/issues/new?template=feature_request.yml). Describe the problem first, the solution second.
+- **Improve docs** — typos, unclear steps, missing context. Always welcome.
+- **Fix or build** — grab a `good first issue`, or open one to align on approach before large changes.
 
-For anything beyond a small fix, **open an issue first** so we can align on the approach before you invest time.
+For anything beyond a small fix, **open an issue first**.
 
 ---
 
 ## Project layout
 
-Meridian is a monorepo. The major pieces:
-
 | Path | What it is |
 |---|---|
-| `src/` | The Rust daemon — ETL pipeline, classification, coding-agent ingest, worklog drafting |
-| `ui/` | The Next.js dashboard |
-| `packages/meridian-mcp/` | The TypeScript MCP server |
-| `tray/` | The Tauri menu-bar app |
-| `services/` | Python services — the on-device MLX model server and the worklog synthesiser |
+| `src/` | Rust daemon — ETL pipeline, coding-agent ingest, classification, worklog drafting |
+| `ui/` | Next.js dashboard |
+| `packages/meridian-mcp/` | TypeScript MCP server |
+| `tray/` | Tauri menu-bar app |
+| `services/` | Python services — MLX model server and worklog synthesiser |
 | `tests/` | Rust integration tests |
 
-See **[CLAUDE.md](CLAUDE.md)** for the full architecture, the ETL state machine, and per-task recipes. It's the canonical engineering reference.
+See **[CLAUDE.md](CLAUDE.md)** for the full architecture and per-task recipes.
 
 ---
 
@@ -38,65 +36,101 @@ See **[CLAUDE.md](CLAUDE.md)** for the full architecture, the ETL state machine,
 
 **Requirements:** macOS on Apple Silicon (M1+), Rust 1.93.1 (pinned via `rust-toolchain.toml`), Node 20+, Python 3.11.
 
+### First-time setup
+
 ```bash
 git clone https://github.com/Meridiona/meridian
 cd meridian
 cp .env.example .env
-./install.sh
-bash scripts/setup-hooks.sh   # install the git hooks — do this before your first commit
+bash install-dev.sh          # builds deps, registers screenpipe + a11y-helper launchd agents
+cargo install cargo-watch    # Rust file watcher (one-time)
+bash scripts/setup-hooks.sh  # install git hooks — do this before your first commit
 ```
 
-`./install.sh` builds the daemon and dashboard and registers the local services. For the iterative dev loop (`meridian dev`, hot-reload, rebuilding individual services), see [SETUP.md → Development](SETUP.md#development).
+`install-dev.sh` installs everything but does **not** register the Rust daemon or MLX server as launchd agents — those run in watch mode instead.
 
-> **Install the git hooks.** `scripts/setup-hooks.sh` wires up the checks below. Without them your PR will fail CI on something the hooks would have caught locally.
+### Starting the dev environment
+
+```bash
+bash dev-start.sh
+```
+
+This opens 4 Terminal windows, one per service:
+
+| Window | Command | Triggers on |
+|---|---|---|
+| Rust daemon | `cargo watch -x 'run --bin meridian'` | any `.rs` save |
+| MLX server | `uvicorn --reload --reload-dir services/agents/` | any `.py` save in `services/agents/` |
+| Next.js UI | `npm run dev` | any `.ts`/`.tsx` save |
+| Tauri tray | `npm run tauri dev` | any Rust or JS/CSS save |
+
+screenpipe and a11y-helper run via launchd and restart automatically — you don't need to touch them.
+
+### Stopping the dev environment
+
+- **Ctrl-C** in each Terminal window to stop the watch processes
+- `meridian stop` to stop the launchd agents (screenpipe, a11y-helper)
+
+### Installed package vs dev mode
+
+These are two distinct setups — do not mix them:
+
+| | Installed package (`curl … | bash`) | Dev mode (`install-dev.sh`) |
+|---|---|---|
+| Rust daemon | launchd agent, release binary | `cargo watch` in terminal |
+| MLX server | launchd agent | `uvicorn --reload` in terminal |
+| Next.js UI | launchd agent, production build | `npm run dev` in terminal |
+| Tauri tray | launchd agent, production build | `npm run tauri dev` in terminal |
+| screenpipe | launchd agent | launchd agent |
+| a11y-helper | launchd agent | launchd agent |
 
 ---
 
 ## Before you open a pull request
 
-Run the same checks CI runs. All must pass:
+Run the same checks CI runs — all must pass:
 
 ```bash
-cargo fmt                       # format (CI checks --check)
-cargo clippy -- -D warnings     # lint — warnings are errors
-cargo test                      # Rust unit + integration tests
-cargo build --release           # the daemon builds
+cargo fmt                          # format
+cargo clippy -- -D warnings        # lint — warnings are errors
+cargo test                         # Rust unit + integration tests
+cargo build --release              # verify release build
 
-cd ui && npm ci && npm run build   # the dashboard builds
+cd ui && npm ci && npm run build   # dashboard builds
 ```
 
-The git hooks enforce most of this for you:
+The git hooks enforce most of this automatically:
 
 - **pre-commit** — `cargo fmt --check` + `cargo clippy -- -D warnings`
 - **commit-msg** — Conventional Commits format
-- **pre-push** — the full suite: fmt + clippy + `cargo test` + UI build + UI tests
+- **pre-push** — full suite: fmt + clippy + `cargo test` + UI build + UI tests
 
-**Never bypass the hooks** (`--no-verify`). If a hook fails, fix the cause — don't skip it.
+**Never bypass the hooks** (`--no-verify`). Fix the cause, don't skip it.
 
-### Touching the ETL pipeline, DB schema, or migrations?
+### Touching ETL, DB schema, or migrations?
 
-Read **[TESTING.md](TESTING.md)** first. The integration tests in `tests/integration_etl.rs` encode invariants (session boundaries, gap detection, cursor advancement) that must keep passing. Add a test for any new behaviour.
+Read **[TESTING.md](TESTING.md)** first. The integration tests in `tests/integration_etl.rs` encode invariants (session boundaries, gap detection, cursor advancement). Add a test for any new behaviour.
 
 ---
 
 ## Commit and branch conventions
 
-- **Branch per change.** Name it `type/short-description` — e.g. `feat/linear-sync`, `fix/timeline-gap`, `docs/setup-clarify`.
-- **Conventional Commits** for messages: `type(scope): summary`. Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `style`.
-  - e.g. `fix(etl): detect sleep gaps that span ETL run boundaries`
+- **One branch per change.** Format: `type/short-description` — e.g. `feat/linear-sync`, `fix/timeline-gap`.
+- **Conventional Commits:** `type(scope): summary` — e.g. `fix(etl): detect sleep gaps that span ETL run boundaries`.
+  - Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`.
 - **Never push to `main` directly.** Open a PR from your branch.
 
-Releases are automated by release-please from the commit history, so accurate commit types matter.
+Releases are automated by release-please from the commit history, so accurate types matter.
 
 ### File-header convention
 
-Every `.rs`, `.ts`, and `.tsx` file starts with this exact first line:
+Every `.rs`, `.ts`, and `.tsx` file must start with:
 
 ```
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 ```
 
-SQL migrations use the `--` comment form. Python files in `services/agents/` use a `"""…"""` module docstring instead. The hooks expect these.
+SQL migrations use the `--` comment form. Python files in `services/agents/` use a `"""…"""` module docstring. The hooks expect these.
 
 ---
 
@@ -105,23 +139,23 @@ SQL migrations use the `--` comment form. Python files in `services/agents/` use
 1. Push your branch and open a PR against `main`.
 2. Fill out the PR template — what changed, why, and how you tested it.
 3. Make sure CI is green.
-4. A maintainer will review. We may ask for changes; that's normal and not personal.
+4. A maintainer will review. We may ask for changes.
 
-We **never** merge our own PRs without review, and we leave the final merge to a maintainer.
+Maintainers never merge their own PRs. Leave the final merge to a reviewer.
 
 ---
 
-## Coding conventions (quick reference)
+## Coding conventions
 
-- **Rust** — `anyhow::Result` with `.context("…")` on DB calls; `tracing` with structured fields, not format strings; avoid `unwrap()` outside tests.
+- **Rust** — `anyhow::Result` with `.context("…")` on every DB call; `tracing` with structured fields; avoid `unwrap()` outside tests.
 - **TypeScript** — no `any` unless justified with a comment; keep UI API routes thin (query, transform, return JSON).
 - **SQL** — add a new numbered migration; never edit an existing one.
 - **Keep files under ~500 lines** — split when they grow past that.
 
-The deeper rationale for each lives in [CLAUDE.md](CLAUDE.md).
+Full rationale in [CLAUDE.md](CLAUDE.md).
 
 ---
 
 ## Questions?
 
-Open a [discussion or issue](https://github.com/Meridiona/meridian/issues), or reach out to **akarsh@meridiona.com**. We're happy to help you land your first contribution.
+Open a [discussion or issue](https://github.com/Meridiona/meridian/issues) or email **akarsh@meridiona.com**.

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+# Start all Meridian services in watch/hot-reload mode for local development.
+#
+# Prereqs (run once):
+#   bash install-dev.sh          # installs deps, screenpipe + a11y-helper launchd agents
+#   cargo install cargo-watch    # Rust file watcher
+#
+# What this opens (4 Terminal windows):
+#   1. Rust daemon   — cargo watch, rebuilds + restarts on every .rs save
+#   2. MLX server    — uvicorn --reload, reloads on every .py save in services/agents/
+#   3. Next.js UI    — npm run dev, hot reload at http://localhost:3939
+#   4. Tauri tray    — npm run tauri dev, hot reload
+#
+# screenpipe + a11y-helper run via launchd and do not need restarting.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Pre-flight checks
+# ---------------------------------------------------------------------------
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "✗ cargo not found — install Rust: https://rustup.rs" >&2
+    exit 1
+fi
+
+if ! cargo watch --version >/dev/null 2>&1; then
+    echo "→ cargo-watch not found — installing..."
+    cargo install cargo-watch
+    echo "  ✓ cargo-watch installed"
+fi
+
+if [[ ! -d "${REPO_ROOT}/services/.venv" ]]; then
+    echo "✗ services/.venv not found — run: bash install-dev.sh" >&2
+    exit 1
+fi
+
+if [[ ! -d "${REPO_ROOT}/ui/node_modules" ]]; then
+    echo "✗ ui/node_modules not found — run: bash install-dev.sh" >&2
+    exit 1
+fi
+
+if [[ ! -d "${REPO_ROOT}/tray/node_modules" ]]; then
+    echo "✗ tray/node_modules not found — run: bash install-dev.sh" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Launch each service in its own Terminal window
+# ---------------------------------------------------------------------------
+
+osascript <<APPLESCRIPT
+tell application "Terminal"
+    activate
+
+    -- 1. Rust daemon (cargo watch)
+    do script "echo '=== Rust daemon (cargo watch) ===' && cd '${REPO_ROOT}' && cargo watch -x 'run --bin meridian'"
+
+    -- 2. MLX server (uvicorn --reload, watches services/agents/ only)
+    do script "echo '=== MLX server (uvicorn --reload) ===' && cd '${REPO_ROOT}/services' && .venv/bin/uvicorn agents.server:app --reload --reload-dir '${REPO_ROOT}/services/agents' --host 127.0.0.1 --port 7823"
+
+    -- 3. Next.js UI (hot reload)
+    do script "echo '=== Next.js UI ===' && cd '${REPO_ROOT}/ui' && npm run dev"
+
+    -- 4. Tauri tray (hot reload)
+    do script "echo '=== Tauri tray ===' && cd '${REPO_ROOT}/tray' && npm run tauri dev"
+end tell
+APPLESCRIPT
+
+echo ""
+echo "✓ Dev services starting in 4 Terminal windows:"
+echo ""
+echo "  1. Rust daemon   — rebuilds automatically on .rs save"
+echo "  2. MLX server    — reloads on .py changes in services/agents/"
+echo "  3. Next.js UI    — http://localhost:3939 (hot reload)"
+echo "  4. Tauri tray    — hot reload"
+echo ""
+echo "  screenpipe + a11y-helper running via launchd (no restarts needed)."
+echo ""
+echo "  To stop: Ctrl-C in each window + meridian stop (for launchd services)"

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -1,30 +1,37 @@
 #!/usr/bin/env bash
 # ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
-# Dev-mode install: debug Rust binary, no Next.js production build, no tray build.
-# Background services (screenpipe, MLX server, Rust daemon) still register as launchd agents.
-# UI:  cd ui && npm run dev
-# Tray: automatically starts in a new terminal via npm run tauri dev
+# Dev-mode install: build deps and register only the infrastructure launchd agents
+# (screenpipe, a11y-helper). The Rust daemon and MLX server are NOT registered
+# as launchd agents — run them in watch mode via: bash dev-start.sh
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Run main install with --dev flag
-bash "${REPO_ROOT}/install.sh" --dev "$@"
+# Run main install: builds Rust (debug), installs UI/tray deps, sets up Python
+# venv + MLX. --no-daemon skips all launchd registration so we can selectively
+# register only screenpipe and a11y-helper below.
+bash "${REPO_ROOT}/install.sh" --dev --no-daemon "$@"
 
-# Start tray app in a new Terminal window
+# Register only the infrastructure agents that we don't actively develop.
+# The Rust daemon and MLX server are intentionally excluded — dev-start.sh
+# runs them with hot-reload instead.
 echo ""
-echo "→ Starting tray app in a new Terminal window..."
-osascript <<APPLESCRIPT
-tell application "Terminal"
-    activate
-    do script "cd '${REPO_ROOT}/tray' && npm run tauri dev"
-end tell
-APPLESCRIPT
+echo "→ Installing infrastructure launchd agents (screenpipe + a11y-helper)..."
+bash "${REPO_ROOT}/scripts/install-screenpipe-daemon.sh"
+bash "${REPO_ROOT}/scripts/install-a11y-helper-daemon.sh"
+echo "  ✓ screenpipe + a11y-helper registered"
 
-echo "  ✓ Tray app starting — it will open in a new Terminal window"
 echo ""
-echo "You can now:"
-echo "  cd ui && npm run dev          # start Next.js dashboard (separate terminal)"
-echo "  tail -f ~/.meridian/logs/*.log # monitor background services"
-
+echo "✓ Dev environment ready."
+echo ""
+echo "Start all services with hot-reload:"
+echo "  bash dev-start.sh"
+echo ""
+echo "What dev-start.sh opens (4 Terminal windows):"
+echo "  1. Rust daemon   — cargo watch, rebuilds on every .rs save"
+echo "  2. MLX server    — uvicorn --reload, reloads on .py changes"
+echo "  3. Next.js UI    — http://localhost:3939 (hot reload)"
+echo "  4. Tauri tray    — hot reload"
+echo ""
+echo "screenpipe + a11y-helper run via launchd and restart automatically."


### PR DESCRIPTION
## Summary

- Add `dev-start.sh`: single command that opens 4 Terminal windows — `cargo watch` for the Rust daemon, `uvicorn --reload` for the MLX server, `npm run dev` for the UI, and `npm run tauri dev` for the tray. Every service rebuilds/reloads automatically on file save.
- Update `install-dev.sh`: no longer registers the Rust daemon or MLX server as launchd agents. Only screenpipe + a11y-helper are registered (infrastructure dependencies we don't actively develop).
- Rewrite `CONTRIBUTING.md`: documents the installed-package vs dev-mode distinction, `dev-start.sh` as the canonical dev entry point, and updated first-time setup steps.

## Test plan

- [ ] `bash install-dev.sh` completes without errors, registers only screenpipe + a11y-helper launchd agents
- [ ] `bash dev-start.sh` opens 4 Terminal windows, each starting the correct service
- [ ] Editing a `.rs` file triggers a cargo rebuild and daemon restart
- [ ] Editing a `.py` file in `services/agents/` triggers a uvicorn reload
- [ ] Editing a UI file triggers Next.js hot reload
- [ ] `meridian stop` + Ctrl-C in each window cleanly stops everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)