### PR TITLE
fix(dev): suppress update-available banner in dev mode

### DIFF
--- a/install-dev.sh
+++ b/install-dev.sh
@@ -13,6 +13,12 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # register only screenpipe and a11y-helper below.
 bash "${REPO_ROOT}/install.sh" --dev --no-daemon "$@"
 
+# Write 'dev' into ~/.meridian/app/VERSION so the UI update-available banner
+# never shows in dev mode (the version check returns false when current='dev').
+mkdir -p "${HOME}/.meridian/app"
+echo "dev" > "${HOME}/.meridian/app/VERSION"
+echo "  ✓ ~/.meridian/app/VERSION set to 'dev' (suppresses update banner)"
+
 # Register only the infrastructure agents that we don't actively develop.
 # The Rust daemon and MLX server are intentionally excluded — dev-start.sh
 # runs them with hot-reload instead.


### PR DESCRIPTION
## Summary

- `install-dev.sh` now writes `dev` to `~/.meridian/app/VERSION` during setup.
- The UI version check already handles this: `isNewer()` returns `false` when `current === 'dev'`, so the update banner never shows.
- Without this fix, a leftover `VERSION` file from a prior `curl | bash` install causes the banner to display a stale version comparison in dev mode.

## Test plan

- [ ] Run `bash install-dev.sh` — verify `~/.meridian/app/VERSION` contains `dev`
- [ ] Open the dashboard — update-available banner should not appear
- [ ] Install via `curl | bash` — banner still works correctly for real installs (VERSION contains a real semver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)