### PR TITLE
feat(observability): system notices fault bus, log viewer UI, and UI auth for all providers

### DIFF
--- a/services/agents/pm_worklog_update/agents.py
+++ b/services/agents/pm_worklog_update/agents.py
@@ -62,7 +62,7 @@ def build_synth_agent(
         debug_level: 1 or 2 (verbose).
     """
     from agno.agent import Agent
-    # from agno.guardrails import PIIDetectionGuardrail
+    from agno.guardrails import PIIDetectionGuardrail
     from agno.skills import LocalSkills, Skills
 
     return Agent(
@@ -98,10 +98,7 @@ def build_synth_agent(
             SessionBundleSizeGuard(max_tokens=80_000),
         ],
         post_hooks=[
-            # PIIDetectionGuardrail disabled — was falsely blocking on session input
-            # (OCR/window titles contain names/emails). Re-enable on post_hooks once
-            # we confirm the output Jira comment doesn't reproduce raw PII.
-            # PIIDetectionGuardrail(),
+            PIIDetectionGuardrail(),
             time_spent_sanity_check,
         ],
         output_schema=JiraUpdate,

--- a/services/agents/pm_worklog_update/agents.py
+++ b/services/agents/pm_worklog_update/agents.py
@@ -62,7 +62,7 @@ def build_synth_agent(
         debug_level: 1 or 2 (verbose).
     """
     from agno.agent import Agent
-    from agno.guardrails import PIIDetectionGuardrail
+    # from agno.guardrails import PIIDetectionGuardrail
     from agno.skills import LocalSkills, Skills
 
     return Agent(
@@ -94,11 +94,14 @@ def build_synth_agent(
         #     tools.get_earlier_today_summaries,
         # ],
         pre_hooks=[
-            PIIDetectionGuardrail(),
             ProjectSecretGuard(),
             SessionBundleSizeGuard(max_tokens=80_000),
         ],
         post_hooks=[
+            # PIIDetectionGuardrail disabled — was falsely blocking on session input
+            # (OCR/window titles contain names/emails). Re-enable on post_hooks once
+            # we confirm the output Jira comment doesn't reproduce raw PII.
+            # PIIDetectionGuardrail(),
             time_spent_sanity_check,
         ],
         output_schema=JiraUpdate,

--- a/services/agents/server.py
+++ b/services/agents/server.py
@@ -603,15 +603,19 @@ async def synthesise_worklog(req: _SynthWorklogRequest) -> dict:
         try:
             response = await run_in_threadpool(_run)
         except Exception as exc:  # noqa: BLE001 — never crash the shared server
-            last_detail = f"agent run failed: {exc}"
+            last_detail = f"agent run raised {type(exc).__name__}: {exc}"
             log.warning("synthesise_worklog: attempt %d %s", attempt, last_detail)
             continue
         raw = getattr(response, "content", response)
+        if raw is None:
+            last_detail = "agent returned no content (guardrail likely blocked the run)"
+            log.warning("synthesise_worklog: attempt %d %s", attempt, last_detail)
+            continue
         update = pm_workflow._coerce_jira(raw)
         if update is not None:
             break
-        last_detail = "agent output did not parse into a JiraUpdate"
-        log.warning("synthesise_worklog: attempt %d %s", attempt, last_detail)
+        last_detail = f"agent output did not parse into a JiraUpdate (raw type={type(raw).__name__})"
+        log.warning("synthesise_worklog: attempt %d %s | raw=%.200s", attempt, last_detail, str(raw))
 
     if update is None:
         raise HTTPException(

--- a/src/coding_agent_session_ingest/indexer.rs
+++ b/src/coding_agent_session_ingest/indexer.rs
@@ -255,6 +255,9 @@ pub async fn run_tick(pool: &SqlitePool, cfg: &IndexerConfig, now: DateTime<Utc>
     let candidates = candidate_jsonls(pool, cfg, now).await;
     let mut wrote = 0_u64;
     let mut failed = 0_u64;
+    for path in &candidates {
+        tracing::debug!(source = "jsonl", path = %path.display(), "registering agent session file");
+    }
     for path in candidates {
         match register_session(pool, &path, false, now).await {
             Outcome::Inserted => wrote += 1,
@@ -431,8 +434,17 @@ async fn candidate_jsonls(
                         .with_timezone(&Local)
                         .date_naive();
                     if mdate != today {
+                        tracing::debug!(
+                            path = %path.display(),
+                            file_date = %mdate,
+                            "backfill skipped — file not touched today"
+                        );
                         continue;
                     }
+                    tracing::debug!(
+                        path = %path.display(),
+                        "new agent session file discovered"
+                    );
                 }
             }
             candidates.push((mtime_epoch, path));

--- a/src/config.rs
+++ b/src/config.rs
@@ -229,9 +229,11 @@ fn env_list(key: &str) -> Vec<String> {
 fn parse_jira() -> Option<PmProviderConfig> {
     let base_url = std::env::var("JIRA_URL")
         .or_else(|_| std::env::var("JIRA_BASE_URL"))
-        .unwrap_or_default();
-    let email = std::env::var("JIRA_EMAIL").unwrap_or_default();
-    let api_token = std::env::var("JIRA_API_TOKEN").unwrap_or_default();
+        .unwrap_or_default()
+        .trim()
+        .to_owned();
+    let email = std::env::var("JIRA_EMAIL").unwrap_or_default().trim().to_owned();
+    let api_token = std::env::var("JIRA_API_TOKEN").unwrap_or_default().trim().to_owned();
 
     // Configured if EITHER auth path is viable:
     //   * browser OAuth — the user has run `meridian oauth-login jira`, so a token

--- a/src/config.rs
+++ b/src/config.rs
@@ -481,11 +481,23 @@ impl Config {
             .and_then(|v| v.parse::<u16>().ok())
             .unwrap_or(7823);
 
+        let pm_providers = parse_providers();
+        let provider_names: Vec<&str> = pm_providers.iter().map(|p| p.provider_name()).collect();
+
+        tracing::info!(
+            screenpipe_db = %screenpipe_db,
+            meridian_db = %meridian_db,
+            poll_interval_secs,
+            classification_enabled,
+            pm_providers = ?provider_names,
+            "config loaded"
+        );
+
         Self {
             screenpipe_db,
             meridian_db,
             poll_interval_secs,
-            pm_providers: parse_providers(),
+            pm_providers,
             classification_enabled,
             classification_timeout_s,
             min_classification_duration_s,

--- a/src/etl/runner.rs
+++ b/src/etl/runner.rs
@@ -134,8 +134,19 @@ pub async fn run_etl(screenpipe: &SqlitePool, meridian: &SqlitePool) -> Result<V
 
     let result: Result<()> = async {
         let mut batch = first_batch;
+        let mut batch_count: usize = 0;
 
         loop {
+            batch_count += 1;
+            let batch_min = batch.first().map(|f| f.id).unwrap_or(0);
+            let batch_max = batch.last().map(|f| f.id).unwrap_or(0);
+            debug!(
+                batch = batch_count,
+                frame_id_min = batch_min,
+                frame_id_max = batch_max,
+                frame_count = batch.len(),
+                "ETL batch starting"
+            );
             for frame in &batch {
                 let app = frame.app_name.trim();
                 let window = frame
@@ -225,6 +236,13 @@ pub async fn run_etl(screenpipe: &SqlitePool, meridian: &SqlitePool) -> Result<V
                                 },
                             )
                             .await?;
+                            info!(
+                                session_id = sid,
+                                app_name = closing_app,
+                                frame_count = block_frame_count,
+                                reason = "pre-gap close",
+                                "session closed into app_sessions"
+                            );
                             new_session_ids.push(sid);
                             sessions_closed += cnt;
                         }
@@ -301,6 +319,13 @@ pub async fn run_etl(screenpipe: &SqlitePool, meridian: &SqlitePool) -> Result<V
                             },
                         )
                         .await?;
+                        info!(
+                            session_id = sid,
+                            app_name = old_app,
+                            frame_count = block_frame_count,
+                            reason = "app switch",
+                            "session closed into app_sessions"
+                        );
                         new_session_ids.push(sid);
                         sessions_closed += cnt;
 
@@ -329,6 +354,7 @@ pub async fn run_etl(screenpipe: &SqlitePool, meridian: &SqlitePool) -> Result<V
         // Upsert the still-open block into active_session.
         if let Some(ref open_app) = current_app {
             if block_frame_count > 0 {
+                debug!(app_name = open_app, frame_count = block_frame_count, "upserting open block into active_session");
                 sessions_closed += upsert_open_block(
                     screenpipe,
                     meridian,
@@ -360,6 +386,7 @@ pub async fn run_etl(screenpipe: &SqlitePool, meridian: &SqlitePool) -> Result<V
     }
 
     update_cursor(meridian, last_processed_id, run_id).await?;
+    debug!(cursor = last_processed_id, run_id, "ETL cursor advanced");
     complete_etl_run(meridian, run_id, sessions_closed, None).await?;
 
     tracing::Span::current().record("sessions_closed", sessions_closed);

--- a/src/intelligence/mod.rs
+++ b/src/intelligence/mod.rs
@@ -145,9 +145,12 @@ pub async fn run_pm_sync(meridian: &SqlitePool, config: &Config) -> Result<()> {
                     ?keys,
                     "provider cache was stale — refreshed"
                 );
+                // Clear any lingering notice — provider just refreshed successfully
+                let _ = providers::clear_sync_error(meridian, name).await;
             }
             Err(e) => {
                 tracing::warn!(provider = name, error = %e, "provider refresh failed");
+                let _ = providers::stamp_sync_error(meridian, name, &e.to_string()).await;
             }
         }
     }

--- a/src/intelligence/oauth/jira.rs
+++ b/src/intelligence/oauth/jira.rs
@@ -274,20 +274,26 @@ impl JiraReqCtx {
 
 /// Decide how to authenticate Jira requests: prefer OAuth when a token store
 /// exists (the user has logged in), otherwise fall back to the static API token.
+/// API token beats stored OAuth — a set JIRA_API_TOKEN always wins.
+/// This mirrors the industry standard (gh, Vercel CLI, Stripe CLI all follow
+/// env-var-first) and lets developers use a stable PAT in .env without being
+/// blocked by a stale OAuth session stored in ~/.meridian/oauth/jira.json.
 pub async fn resolve(jira: &JiraConfig) -> Result<JiraReqCtx> {
+    if !jira.base_url.is_empty() && !jira.email.is_empty() && !jira.api_token.is_empty() {
+        tracing::debug!(auth_method = "api_token", "resolving Jira auth");
+        return Ok(JiraReqCtx::Basic {
+            base_url: jira.base_url.clone(),
+            email: jira.email.clone(),
+            api_token: jira.api_token.clone(),
+        });
+    }
     if store::exists("jira") {
+        tracing::debug!(auth_method = "oauth", "resolving Jira auth");
         let t = ensure_fresh().await?;
         return Ok(JiraReqCtx::OAuth {
             token: t.access_token,
             cloud_id: t.cloud_id,
             site_url: t.site_url,
-        });
-    }
-    if !jira.base_url.is_empty() && !jira.email.is_empty() && !jira.api_token.is_empty() {
-        return Ok(JiraReqCtx::Basic {
-            base_url: jira.base_url.clone(),
-            email: jira.email.clone(),
-            api_token: jira.api_token.clone(),
         });
     }
     bail!(

--- a/src/intelligence/providers/azure_devops.rs
+++ b/src/intelligence/providers/azure_devops.rs
@@ -581,6 +581,7 @@ async fn stamp_sync(pool: &SqlitePool) -> Result<()> {
     .execute(pool)
     .await
     .context("updating azure_devops sync state")?;
+    let _ = crate::notices::clear(pool, "pm.azure_devops").await;
     Ok(())
 }
 
@@ -596,6 +597,15 @@ async fn stamp_error(pool: &SqlitePool, error: &str) -> Result<()> {
     .execute(pool)
     .await
     .context("recording azure_devops sync error")?;
+    let _ = crate::notices::raise(
+        pool,
+        "pm.azure_devops",
+        "error",
+        "Azure DevOps sync failing",
+        error,
+        Some("Set AZURE_DEVOPS_PAT in .env"),
+    )
+    .await;
     Ok(())
 }
 

--- a/src/intelligence/providers/azure_devops.rs
+++ b/src/intelligence/providers/azure_devops.rs
@@ -51,6 +51,12 @@ struct WorkItemDetail {
 }
 
 #[derive(Deserialize)]
+struct AzureIdentity {
+    #[serde(rename = "displayName")]
+    display_name: String,
+}
+
+#[derive(Deserialize)]
 struct WorkItemFields {
     #[serde(rename = "System.Title")]
     title: String,
@@ -74,6 +80,17 @@ struct WorkItemFields {
     /// Full iteration path e.g. `MyProject\Sprint 14`. Last segment = sprint name.
     #[serde(rename = "System.IterationPath", default)]
     iteration_path: Option<String>,
+    #[serde(rename = "System.TeamProject", default)]
+    team_project: Option<String>,
+    #[serde(rename = "System.AssignedTo", default)]
+    assigned_to: Option<AzureIdentity>,
+    /// Start date — present on all process types (Scheduling namespace).
+    #[serde(rename = "Microsoft.VSTS.Scheduling.StartDate", default)]
+    start_date: Option<String>,
+    /// Target date — cross-process equivalent of due date (TargetDate, not DueDate
+    /// which is Agile-process-only).
+    #[serde(rename = "Microsoft.VSTS.Scheduling.TargetDate", default)]
+    target_date: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -224,8 +241,11 @@ async fn fetch_batch(
         "{}/{}/_apis/wit/workitems?ids={}&\
          fields=System.Id,System.Title,System.WorkItemType,System.State,\
          System.ChangedDate,System.Description,System.Tags,System.IterationPath,\
+         System.TeamProject,System.AssignedTo,\
          Microsoft.VSTS.Common.AcceptanceCriteria,\
-         Microsoft.VSTS.TCM.ReproSteps&api-version=7.1",
+         Microsoft.VSTS.TCM.ReproSteps,\
+         Microsoft.VSTS.Scheduling.StartDate,\
+         Microsoft.VSTS.Scheduling.TargetDate&api-version=7.1",
         cfg.api_base, cfg.project, ids_str
     );
     let resp = client
@@ -433,12 +453,15 @@ pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result
             "{}/{}/_workitems/edit/{}",
             cfg.api_base, cfg.project, u.detail.id
         );
+        let project_key = f.team_project.as_deref();
+        let assignee_name = f.assigned_to.as_ref().map(|a| a.display_name.as_str());
 
         sqlx::query(
             "INSERT INTO pm_tasks
                (task_key, provider, title, description_text, status_raw, is_terminal,
-                issue_type, url, updated_at, sprint_name, tags)
-             VALUES (?, 'azure_devops', ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                issue_type, project_key, url, updated_at, sprint_name, tags,
+                assignee_name, start_date, due_date)
+             VALUES (?, 'azure_devops', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(task_key) DO UPDATE SET
                provider         = 'azure_devops',
                title            = excluded.title,
@@ -446,10 +469,14 @@ pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result
                status_raw       = excluded.status_raw,
                is_terminal      = excluded.is_terminal,
                issue_type       = excluded.issue_type,
+               project_key      = excluded.project_key,
                url              = excluded.url,
                updated_at       = excluded.updated_at,
                sprint_name      = excluded.sprint_name,
-               tags             = excluded.tags",
+               tags             = excluded.tags,
+               assignee_name    = excluded.assignee_name,
+               start_date       = excluded.start_date,
+               due_date         = excluded.due_date",
         )
         .bind(&task_key)
         .bind(&f.title)
@@ -457,10 +484,14 @@ pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result
         .bind(&u.status.raw)
         .bind(u.status.is_terminal)
         .bind(&f.work_item_type)
+        .bind(project_key)
         .bind(&browser_url)
         .bind(changed)
         .bind(sprint.as_deref())
         .bind(tags.as_deref())
+        .bind(assignee_name)
+        .bind(f.start_date.as_deref())
+        .bind(f.target_date.as_deref())
         .execute(pool)
         .await
         .with_context(|| format!("upserting Azure DevOps work item {}", u.detail.id))?;

--- a/src/intelligence/providers/github.rs
+++ b/src/intelligence/providers/github.rs
@@ -432,6 +432,7 @@ pub async fn refresh_if_stale(
         Ok(l) => l,
         Err(e) => {
             tracing::warn!(error = %e, "github viewer fetch failed — keeping stale cache");
+            let _ = super::stamp_sync_error(pool, "github", &format!("GitHub auth failed — {e}")).await;
             return Ok(None);
         }
     };
@@ -467,6 +468,7 @@ pub async fn refresh_if_stale(
 
     if !any_ok {
         tracing::warn!("all github project fetches failed — keeping stale cache");
+        let _ = super::stamp_sync_error(pool, "github", "GitHub sync failed — all project fetches failed").await;
         return Ok(None);
     }
 
@@ -504,6 +506,7 @@ pub async fn refresh_if_stale(
     }
 
     tracing::info!(upserted_count = keys.len(), "github tasks refreshed");
+    let _ = super::clear_sync_error(pool, "github").await;
     Ok(Some(keys))
 }
 

--- a/src/intelligence/providers/github.rs
+++ b/src/intelligence/providers/github.rs
@@ -86,6 +86,8 @@ struct IssueContent {
     updated_at: String,
     repository: Repo,
     assignees: AssigneeConnection,
+    #[serde(default)]
+    labels: GhLabelConnection,
 }
 
 #[derive(Deserialize)]
@@ -104,6 +106,16 @@ struct LoginNode {
     login: String,
 }
 
+#[derive(Deserialize, Default)]
+struct GhLabelConnection {
+    nodes: Vec<GhLabel>,
+}
+
+#[derive(Deserialize)]
+struct GhLabel {
+    name: String,
+}
+
 /// One normalised issue ready to upsert.
 struct GhTask {
     task_key: String,
@@ -120,6 +132,7 @@ struct GhTask {
     url: String,
     updated_at: String,
     assignee: String,
+    tags: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -196,6 +209,7 @@ const PROJECT_ITEMS_QUERY: &str = "query($id: ID!, $cursor: String) {
               number title body state url updatedAt
               repository { nameWithOwner }
               assignees(first: 10) { nodes { login } }
+              labels(first: 10) { nodes { name } }
             }
           }
         }
@@ -272,6 +286,18 @@ async fn fetch_project_items(
                 &extract_status_raw(&item.field_values.nodes),
                 None,
             );
+            let label_names: Vec<&str> = content
+                .labels
+                .nodes
+                .iter()
+                .map(|l| l.name.as_str())
+                .filter(|s| !s.is_empty())
+                .collect();
+            let tags = if label_names.is_empty() {
+                None
+            } else {
+                Some(label_names.join(", "))
+            };
             tasks.push(GhTask {
                 task_key: format!("{}#{}", content.repository.name_with_owner, content.number),
                 repo_slug: content.repository.name_with_owner.clone(),
@@ -282,6 +308,7 @@ async fn fetch_project_items(
                 url: content.url.clone(),
                 updated_at: content.updated_at.clone(),
                 assignee: viewer_login.to_string(),
+                tags,
             });
         }
 
@@ -303,8 +330,8 @@ async fn upsert(pool: &SqlitePool, tasks: &[GhTask]) -> Result<()> {
         sqlx::query(
             "INSERT INTO pm_tasks
                (task_key, provider, title, description_text, status_raw, is_terminal,
-                issue_type, project_key, url, assignee_name, updated_at, fetched_at)
-             VALUES (?, 'github', ?, ?, ?, ?, 'Issue', ?, ?, ?, ?,
+                issue_type, project_key, url, assignee_name, tags, updated_at, fetched_at)
+             VALUES (?, 'github', ?, ?, ?, ?, 'Issue', ?, ?, ?, ?, ?,
                      strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
              ON CONFLICT(task_key) DO UPDATE SET
                provider         = 'github',
@@ -315,6 +342,7 @@ async fn upsert(pool: &SqlitePool, tasks: &[GhTask]) -> Result<()> {
                project_key      = excluded.project_key,
                url              = excluded.url,
                assignee_name    = excluded.assignee_name,
+               tags             = excluded.tags,
                updated_at       = excluded.updated_at,
                fetched_at       = excluded.fetched_at",
         )
@@ -326,6 +354,7 @@ async fn upsert(pool: &SqlitePool, tasks: &[GhTask]) -> Result<()> {
         .bind(&t.repo_slug)
         .bind(&t.url)
         .bind(&t.assignee)
+        .bind(t.tags.as_deref())
         .bind(&t.updated_at)
         .execute(pool)
         .await

--- a/src/intelligence/providers/jira.rs
+++ b/src/intelligence/providers/jira.rs
@@ -3,6 +3,7 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use sqlx::SqlitePool;
+use std::collections::HashMap;
 
 use crate::config::JiraConfig;
 use crate::intelligence::oauth::jira::JiraReqCtx;
@@ -34,6 +35,62 @@ struct JiraFields {
     parent: Option<JiraParent>,
     #[serde(default)]
     duedate: Option<String>,
+    #[serde(default)]
+    assignee: Option<JiraUser>,
+    #[serde(default)]
+    labels: Vec<String>,
+    // Sprint custom field — Cloud standard; value is an array of sprint objects.
+    #[serde(rename = "customfield_10020", default)]
+    sprint: Option<Vec<JiraSprint>>,
+    // Remaining fields captured for dynamic start-date extraction.
+    #[serde(flatten)]
+    extra: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct JiraUser {
+    #[serde(rename = "displayName")]
+    display_name: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct JiraSprint {
+    name: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Field discovery
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct JiraFieldMeta {
+    id: String,
+    name: String,
+}
+
+/// Call /rest/api/3/field and return the ID of the field whose name best
+/// matches "start date":
+///   1. exact case-insensitive match on "start date"
+///   2. name contains both "start" and "date" (case-insensitive)
+/// Returns None if no match or if the request fails.
+async fn discover_start_date_field(ctx: &JiraReqCtx) -> Option<String> {
+    let client = reqwest::Client::new();
+    let url = ctx.api_url("/rest/api/3/field");
+    let resp = ctx.apply(client.get(&url)).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let fields: Vec<JiraFieldMeta> = resp.json().await.ok()?;
+
+    // Priority 1: exact match
+    if let Some(f) = fields.iter().find(|f| f.name.eq_ignore_ascii_case("start date")) {
+        return Some(f.id.clone());
+    }
+    // Priority 2: name contains both "start" and "date"
+    fields.iter().find(|f| {
+        let n = f.name.to_lowercase();
+        n.contains("start") && n.contains("date")
+    }).map(|f| f.id.clone())
 }
 
 #[derive(Deserialize)]
@@ -134,14 +191,22 @@ const SYNC_INTERVAL_MINS: i64 = 5;
         status_code = tracing::field::Empty,
     )
 )]
-async fn fetch(ctx: &JiraReqCtx) -> Result<Vec<JiraIssue>> {
+async fn fetch(ctx: &JiraReqCtx, start_date_field: Option<&str>) -> Result<Vec<JiraIssue>> {
     let client = reqwest::Client::new();
     let url = ctx.api_url("/rest/api/3/search/jql");
+
+    let mut fields = vec![
+        "summary", "description", "issuetype", "project", "updated",
+        "parent", "status", "duedate", "assignee", "labels", "customfield_10020",
+    ];
+    if let Some(id) = start_date_field {
+        fields.push(id);
+    }
 
     let body = serde_json::json!({
         "jql": "assignee = currentUser() AND statusCategory != Done AND type IN (Task, Feature) ORDER BY updated DESC",
         "maxResults": MAX_RESULTS,
-        "fields": ["summary", "description", "issuetype", "project", "updated", "parent", "status", "duedate"]
+        "fields": fields,
     });
 
     let start = std::time::Instant::now();
@@ -178,6 +243,7 @@ async fn upsert(
     issues: &[JiraIssue],
     jira: &JiraConfig,
     ctx: &JiraReqCtx,
+    start_date_field: Option<&str>,
 ) -> Result<()> {
     for issue in issues {
         if !jira.project_keys.is_empty() && !jira.project_keys.contains(&issue.fields.project.key) {
@@ -212,11 +278,35 @@ async fn upsert(
             })
             .unwrap_or((None, ""));
 
+        let assignee_name = issue
+            .fields
+            .assignee
+            .as_ref()
+            .and_then(|a| a.display_name.clone());
+
+        let tags: Option<String> = if issue.fields.labels.is_empty() {
+            None
+        } else {
+            Some(issue.fields.labels.join(", "))
+        };
+
+        let sprint_name = issue
+            .fields
+            .sprint
+            .as_deref()
+            .and_then(|sprints| sprints.first())
+            .and_then(|s| s.name.clone());
+
+        let start_date: Option<String> = start_date_field.and_then(|field_id| {
+            issue.fields.extra.get(field_id)?.as_str().map(str::to_owned)
+        });
+
         sqlx::query(
             "INSERT INTO pm_tasks
                (task_key, provider, title, description_text, status_raw, is_terminal,
-                issue_type, project_key, url, parent_key, epic_title, due_date, updated_at, fetched_at)
-             VALUES (?, 'jira', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                issue_type, project_key, url, parent_key, epic_title, due_date,
+                assignee_name, tags, sprint_name, start_date, updated_at, fetched_at)
+             VALUES (?, 'jira', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                      strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
              ON CONFLICT(task_key) DO UPDATE SET
                title            = excluded.title,
@@ -229,6 +319,10 @@ async fn upsert(
                parent_key       = excluded.parent_key,
                epic_title       = excluded.epic_title,
                due_date         = excluded.due_date,
+               assignee_name    = excluded.assignee_name,
+               tags             = excluded.tags,
+               sprint_name      = excluded.sprint_name,
+               start_date       = excluded.start_date,
                updated_at       = excluded.updated_at,
                fetched_at       = excluded.fetched_at",
         )
@@ -247,6 +341,10 @@ async fn upsert(
             Some(epic_title)
         })
         .bind(&issue.fields.duedate)
+        .bind(assignee_name)
+        .bind(tags)
+        .bind(sprint_name)
+        .bind(start_date)
         .bind(&issue.fields.updated)
         .execute(pool)
         .await
@@ -337,12 +435,17 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
         }
     };
 
-    match fetch(&ctx).await {
+    let start_date_field = discover_start_date_field(&ctx).await;
+    if let Some(ref id) = start_date_field {
+        tracing::debug!(field_id = %id, "discovered jira start date field");
+    }
+
+    match fetch(&ctx, start_date_field.as_deref()).await {
         Ok(issues) => {
             let keys: Vec<String> = issues.iter().map(|i| i.key.clone()).collect();
             let n = keys.len();
             tracing::debug!(fetched_count = n, "jira fetch completed");
-            upsert(pool, &issues, jira, &ctx).await?;
+            upsert(pool, &issues, jira, &ctx, start_date_field.as_deref()).await?;
             sqlx::query(
                 "INSERT INTO pm_sync_state (provider, last_synced_at)
                  VALUES ('jira', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))

--- a/src/intelligence/providers/jira.rs
+++ b/src/intelligence/providers/jira.rs
@@ -72,6 +72,7 @@ struct JiraFieldMeta {
 /// matches "start date":
 ///   1. exact case-insensitive match on "start date"
 ///   2. name contains both "start" and "date" (case-insensitive)
+///
 /// Returns None if no match or if the request fails.
 async fn discover_start_date_field(ctx: &JiraReqCtx) -> Option<String> {
     let client = reqwest::Client::new();
@@ -431,9 +432,13 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
         Ok(ctx) => ctx,
         Err(e) => {
             tracing::warn!(error = %e, "jira auth unavailable — keeping stale cache");
+            let msg = format!("Jira auth failed — {e}");
+            let _ = super::stamp_sync_error(pool, "jira", &msg).await;
             return Ok(None);
         }
     };
+    let auth_method = if jira.api_token.is_empty() { "oauth" } else { "api_token" };
+    tracing::debug!(auth_method, "jira auth resolved");
 
     let start_date_field = discover_start_date_field(&ctx).await;
     if let Some(ref id) = start_date_field {
@@ -444,7 +449,20 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
         Ok(issues) => {
             let keys: Vec<String> = issues.iter().map(|i| i.key.clone()).collect();
             let n = keys.len();
+            let project_key = issues.first().map(|i| i.fields.project.key.as_str()).unwrap_or("-");
+            let terminal_count = issues
+                .iter()
+                .filter(|i| native_terminal(&i.fields.status.status_category.key) == Some(true))
+                .count();
             tracing::debug!(fetched_count = n, "jira fetch completed");
+            tracing::info!(
+                issue_count = n,
+                project_key,
+                upserted = n,
+                terminal_skipped = terminal_count,
+                auth_method,
+                "jira issues fetched"
+            );
             upsert(pool, &issues, jira, &ctx, start_date_field.as_deref()).await?;
             sqlx::query(
                 "INSERT INTO pm_sync_state (provider, last_synced_at)
@@ -468,10 +486,13 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
                 );
             }
             tracing::info!(upserted_count = n, "jira tasks refreshed");
+            let _ = super::clear_sync_error(pool, "jira").await;
             Ok(Some(keys))
         }
         Err(e) => {
             tracing::warn!(error = %e, "jira fetch failed — keeping stale cache");
+            let msg = format!("Jira sync failed — {e}");
+            let _ = super::stamp_sync_error(pool, "jira", &msg).await;
             Ok(None)
         }
     }

--- a/src/intelligence/providers/jira.rs
+++ b/src/intelligence/providers/jira.rs
@@ -302,12 +302,12 @@ async fn upsert(
             issue.fields.extra.get(field_id)?.as_str().map(str::to_owned)
         });
 
-        sqlx::query(
+        let upsert_result = sqlx::query(
             "INSERT INTO pm_tasks
                (task_key, provider, title, description_text, status_raw, is_terminal,
                 issue_type, project_key, url, parent_key, epic_title, due_date,
                 assignee_name, tags, sprint_name, start_date, updated_at, fetched_at)
-             VALUES (?, 'jira', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+             VALUES (?, 'jira', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                      strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
              ON CONFLICT(task_key) DO UPDATE SET
                title            = excluded.title,
@@ -349,7 +349,11 @@ async fn upsert(
         .bind(&issue.fields.updated)
         .execute(pool)
         .await
-        .with_context(|| format!("upserting {}", issue.key))?;
+        .with_context(|| format!("upserting {}", issue.key));
+        if let Err(ref upsert_err) = upsert_result {
+            // Log full error chain so the root cause is visible in /logs
+            tracing::warn!(task_key = %issue.key, error = ?upsert_err, "jira task upsert failed — skipping");
+        }
     }
     Ok(())
 }

--- a/src/intelligence/providers/jira.rs
+++ b/src/intelligence/providers/jira.rs
@@ -246,6 +246,7 @@ async fn upsert(
     ctx: &JiraReqCtx,
     start_date_field: Option<&str>,
 ) -> Result<()> {
+    let mut ok_count: usize = 0;
     for issue in issues {
         if !jira.project_keys.is_empty() && !jira.project_keys.contains(&issue.fields.project.key) {
             continue;
@@ -350,10 +351,15 @@ async fn upsert(
         .execute(pool)
         .await
         .with_context(|| format!("upserting {}", issue.key));
-        if let Err(ref upsert_err) = upsert_result {
-            // Log full error chain so the root cause is visible in /logs
-            tracing::warn!(task_key = %issue.key, error = ?upsert_err, "jira task upsert failed — skipping");
+        match upsert_result {
+            Ok(_) => ok_count += 1,
+            Err(ref upsert_err) => {
+                tracing::warn!(task_key = %issue.key, error = ?upsert_err, "jira task upsert failed — skipping");
+            }
         }
+    }
+    if !issues.is_empty() && ok_count == 0 {
+        anyhow::bail!("all {} jira task upserts failed — DB write errors above", issues.len());
     }
     Ok(())
 }

--- a/src/intelligence/providers/linear.rs
+++ b/src/intelligence/providers/linear.rs
@@ -392,10 +392,12 @@ pub async fn refresh_if_stale(
                 }
             }
             tracing::info!(upserted_count = n, "linear tasks refreshed");
+            let _ = super::clear_sync_error(pool, "linear").await;
             Ok(Some(kept))
         }
         Err(e) => {
             tracing::warn!(error = %e, "linear fetch failed — keeping stale cache");
+            let _ = super::stamp_sync_error(pool, "linear", &format!("Linear sync failed — {e}")).await;
             Ok(None)
         }
     }

--- a/src/intelligence/providers/linear.rs
+++ b/src/intelligence/providers/linear.rs
@@ -61,6 +61,12 @@ struct LinearIssue {
     assignee: Option<NamedUser>,
     #[serde(rename = "dueDate", default)]
     due_date: Option<String>,
+    #[serde(rename = "startedAt", default)]
+    started_at: Option<String>,
+    #[serde(default)]
+    labels: Option<LabelConnection>,
+    #[serde(default)]
+    cycle: Option<Cycle>,
 }
 
 #[derive(Deserialize)]
@@ -87,6 +93,21 @@ struct Parent {
 
 #[derive(Deserialize)]
 struct NamedUser {
+    name: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct LabelConnection {
+    nodes: Vec<LabelNode>,
+}
+
+#[derive(Deserialize)]
+struct LabelNode {
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct Cycle {
     name: Option<String>,
 }
 
@@ -137,7 +158,7 @@ async fn fetch(linear: &LinearConfig) -> Result<Vec<LinearIssue>> {
            identifier title description updatedAt url \
            state {{ name type }} team {{ id key }} \
            parent {{ identifier title }} assignee {{ name }} \
-           dueDate \
+           dueDate startedAt labels {{ nodes {{ name }} }} cycle {{ name }} \
          }} }} }} }}"
     );
     let body = serde_json::json!({ "query": query });
@@ -209,13 +230,26 @@ async fn upsert(
             })
             .unwrap_or((None, String::new()));
         let assignee = issue.assignee.as_ref().and_then(|a| a.name.clone());
+        let tags: Option<String> = issue.labels.as_ref().map(|lc| {
+            lc.nodes
+                .iter()
+                .map(|l| l.name.as_str())
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+                .join(", ")
+        });
+        let sprint_name: Option<String> = issue
+            .cycle
+            .as_ref()
+            .and_then(|c| c.name.clone())
+            .filter(|s| !s.is_empty());
 
         sqlx::query(
             "INSERT INTO pm_tasks
                (task_key, provider, title, description_text, status_raw, is_terminal,
                 issue_type, project_key, url, parent_key, epic_title, assignee_name,
-                due_date, updated_at, fetched_at)
-             VALUES (?, 'linear', ?, ?, ?, ?, '', ?, ?, ?, ?, ?, ?, ?,
+                due_date, start_date, tags, sprint_name, updated_at, fetched_at)
+             VALUES (?, 'linear', ?, ?, ?, ?, '', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                      strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
              ON CONFLICT(task_key) DO UPDATE SET
                provider         = 'linear',
@@ -230,6 +264,9 @@ async fn upsert(
                epic_title       = excluded.epic_title,
                assignee_name    = excluded.assignee_name,
                due_date         = excluded.due_date,
+               start_date       = excluded.start_date,
+               tags             = excluded.tags,
+               sprint_name      = excluded.sprint_name,
                updated_at       = excluded.updated_at,
                fetched_at       = excluded.fetched_at",
         )
@@ -248,6 +285,9 @@ async fn upsert(
         })
         .bind(assignee)
         .bind(&issue.due_date)
+        .bind(&issue.started_at)
+        .bind(tags.as_deref())
+        .bind(sprint_name.as_deref())
         .bind(&issue.updated_at)
         .execute(pool)
         .await
@@ -405,6 +445,9 @@ mod tests {
             parent: None,
             assignee: None,
             due_date: None,
+            started_at: None,
+            labels: None,
+            cycle: None,
         }
     }
 

--- a/src/intelligence/providers/mod.rs
+++ b/src/intelligence/providers/mod.rs
@@ -6,3 +6,52 @@ pub mod jira;
 pub mod linear;
 pub mod status;
 pub mod trello;
+
+use anyhow::Result;
+use sqlx::SqlitePool;
+
+/// Write a sync error for a provider. Writes to both `pm_sync_state.last_error`
+/// (for the connect-status indicators) and `system_notices` (for the global
+/// UI fault bus that surfaces banners on every page).
+pub async fn stamp_sync_error(pool: &SqlitePool, provider: &str, error: &str) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO pm_sync_state (provider, last_synced_at, last_error)
+         VALUES (?, '1970-01-01T00:00:00Z', ?)
+         ON CONFLICT(provider) DO UPDATE SET last_error = excluded.last_error",
+    )
+    .bind(provider)
+    .bind(error)
+    .execute(pool)
+    .await?;
+
+    let (title, remedy): (&str, Option<&str>) = match provider {
+        "jira"         => ("Jira sync failing",        Some("Set JIRA_API_TOKEN and JIRA_BASE_URL in .env")),
+        "linear"       => ("Linear sync failing",       Some("Set LINEAR_API_KEY in .env")),
+        "trello"       => ("Trello sync failing",       Some("Run: meridian oauth-login trello")),
+        "github"       => ("GitHub sync failing",       Some("Set GITHUB_TOKEN in .env")),
+        "azure_devops" => ("Azure DevOps sync failing", Some("Set AZURE_DEVOPS_PAT in .env")),
+        _              => ("PM sync failing",            None),
+    };
+    let _ = crate::notices::raise(
+        pool,
+        &format!("pm.{provider}"),
+        "error",
+        title,
+        error,
+        remedy,
+    )
+    .await;
+    Ok(())
+}
+
+/// Clear the last error for a provider after a successful sync.
+pub async fn clear_sync_error(pool: &SqlitePool, provider: &str) -> Result<()> {
+    sqlx::query(
+        "UPDATE pm_sync_state SET last_error = NULL WHERE provider = ?",
+    )
+    .bind(provider)
+    .execute(pool)
+    .await?;
+    let _ = crate::notices::clear(pool, &format!("pm.{provider}")).await;
+    Ok(())
+}

--- a/src/intelligence/providers/trello.rs
+++ b/src/intelligence/providers/trello.rs
@@ -270,10 +270,12 @@ pub async fn refresh_if_stale(
                 }
             }
             tracing::info!(upserted_count = n, "trello tasks refreshed");
+            let _ = super::clear_sync_error(pool, "trello").await;
             Ok(Some(kept))
         }
         Err(e) => {
             tracing::warn!(error = %e, "trello fetch failed — keeping stale cache");
+            let _ = super::stamp_sync_error(pool, "trello", &format!("Trello sync failed — {e}")).await;
             Ok(None)
         }
     }

--- a/src/intelligence/providers/trello.rs
+++ b/src/intelligence/providers/trello.rs
@@ -24,6 +24,18 @@ const SYNC_INTERVAL_MINS: i64 = 5;
 // ---------------------------------------------------------------------------
 
 #[derive(Deserialize)]
+struct TrelloLabel {
+    #[serde(default)]
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct TrelloMember {
+    #[serde(rename = "fullName", default)]
+    full_name: String,
+}
+
+#[derive(Deserialize)]
 struct TrelloCard {
     #[serde(rename = "shortLink")]
     short_link: String,
@@ -38,6 +50,12 @@ struct TrelloCard {
     short_url: String,
     #[serde(default)]
     closed: bool,
+    #[serde(default)]
+    due: Option<String>,
+    #[serde(default)]
+    labels: Vec<TrelloLabel>,
+    #[serde(default)]
+    members: Vec<TrelloMember>,
 }
 
 // ---------------------------------------------------------------------------
@@ -64,7 +82,8 @@ async fn fetch(trello: &TrelloConfig) -> Result<Vec<TrelloCard>> {
     let url = format!(
         "{TRELLO_BASE}/members/me/cards\
          ?filter=open\
-         &fields=shortLink,name,desc,idBoard,dateLastActivity,shortUrl,closed\
+         &fields=shortLink,name,desc,idBoard,dateLastActivity,shortUrl,closed,due,labels\
+         &members=true&member_fields=fullName\
          &limit={MAX_RESULTS}\
          &key={}&token={}",
         trello.app_key, token,
@@ -108,12 +127,28 @@ async fn upsert(
         // Trello cards have no status/list name in the connector's current fetch,
         // and closed cards are filtered out above — so every kept card is open
         // (is_terminal = 0) with an empty status_raw.
+        let tags: Option<String> = {
+            let names: Vec<&str> = card
+                .labels
+                .iter()
+                .map(|l| l.name.as_str())
+                .filter(|s| !s.is_empty())
+                .collect();
+            if names.is_empty() {
+                None
+            } else {
+                Some(names.join(", "))
+            }
+        };
+        let assignee_name: Option<&str> = card.members.first().map(|m| m.full_name.as_str());
+
         sqlx::query(
             "INSERT INTO pm_tasks
                (task_key, provider, title, description_text, status_raw, is_terminal,
-                issue_type, project_key, url, updated_at, fetched_at)
+                issue_type, project_key, url, due_date, tags, assignee_name,
+                updated_at, fetched_at)
              VALUES (?, 'trello', ?, ?, '', 0, 'Card', ?, ?,
-                     ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+                     ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
              ON CONFLICT(task_key) DO UPDATE SET
                provider         = 'trello',
                title            = excluded.title,
@@ -122,6 +157,9 @@ async fn upsert(
                is_terminal      = excluded.is_terminal,
                project_key      = excluded.project_key,
                url              = excluded.url,
+               due_date         = excluded.due_date,
+               tags             = excluded.tags,
+               assignee_name    = excluded.assignee_name,
                updated_at       = excluded.updated_at,
                fetched_at       = excluded.fetched_at",
         )
@@ -130,6 +168,9 @@ async fn upsert(
         .bind(&card.desc)
         .bind(&card.id_board)
         .bind(&card.short_url)
+        .bind(card.due.as_deref())
+        .bind(tags.as_deref())
+        .bind(assignee_name)
         .bind(&card.date_last_activity)
         .execute(pool)
         .await
@@ -264,6 +305,9 @@ mod tests {
             date_last_activity: String::new(),
             short_url: String::new(),
             closed: false,
+            due: None,
+            labels: vec![],
+            members: vec![],
         };
         assert!(board_allowed(&card, &[]));
     }
@@ -278,6 +322,9 @@ mod tests {
             date_last_activity: String::new(),
             short_url: String::new(),
             closed: false,
+            due: None,
+            labels: vec![],
+            members: vec![],
         };
         assert!(board_allowed(&card, &["board1".to_string()]));
         assert!(!board_allowed(&card, &["board2".to_string()]));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,6 @@ pub mod etl;
 pub mod health;
 pub mod intelligence;
 pub mod llm_gate;
+pub mod notices;
 pub mod observability;
 pub mod pm_worklog;

--- a/src/main.rs
+++ b/src/main.rs
@@ -468,7 +468,15 @@ async fn main() -> Result<()> {
         let _guard = startup_tick.enter();
         tracing::info!("running initial ETL pass");
         if let Err(e) = run_etl(&screenpipe, &meridian).await {
-            tracing::error!("ETL run failed: {}", e);
+            tracing::error!(error = %e, "ETL run failed");
+            let _ = meridian::notices::raise(
+                &meridian, "etl.failed", "error",
+                "Activity capture pipeline failed",
+                &e.to_string(),
+                Some("Open /logs in the dashboard to see details"),
+            ).await;
+        } else {
+            let _ = meridian::notices::clear(&meridian, "etl.failed").await;
         }
         etl_notify.notify_one();
         if let Err(e) = run_pm_sync(&meridian, &cfg).await {
@@ -580,6 +588,7 @@ async fn main() -> Result<()> {
                         Ok(TaskLinkOutcome::Classified) => {
                             failure_counts.clear();
                             classified_any = true;
+                            let _ = meridian::notices::clear(&meridian_linker, "mlx.down").await;
                             // Loop immediately — more sessions may be waiting.
                         }
                         Ok(TaskLinkOutcome::NoPendingWork) => {
@@ -622,6 +631,14 @@ async fn main() -> Result<()> {
                                     "max consecutive failures — writing subprocess_error sentinel \
                                  and advancing cursor"
                                 );
+                                let _ = meridian::notices::raise(
+                                    &meridian_linker,
+                                    "mlx.down",
+                                    "error",
+                                    "MLX classifier is not responding",
+                                    &format!("Failed to classify session {session_id} after {count} attempts — classification is paused"),
+                                    Some("Start MLX server: cd services && .venv313/bin/meridian-server --backend mlx"),
+                                ).await;
                                 if let Err(e) =
                                     mark_session_subprocess_error(&meridian_linker, session_id)
                                         .await
@@ -703,7 +720,15 @@ async fn main() -> Result<()> {
                 let _guard = poll_tick.enter();
                 tracing::debug!("starting ETL tick");
                 if let Err(e) = run_etl(&screenpipe, &meridian).await {
-                    tracing::error!("ETL run failed: {}", e);
+                    tracing::error!(error = %e, "ETL run failed");
+                    let _ = meridian::notices::raise(
+                        &meridian, "etl.failed", "error",
+                        "Activity capture pipeline failed",
+                        &e.to_string(),
+                        Some("Open /logs in the dashboard to see details"),
+                    ).await;
+                } else {
+                    let _ = meridian::notices::clear(&meridian, "etl.failed").await;
                 }
                 // Wake the background task linker to drain newly-created sessions.
                 etl_notify.notify_one();

--- a/src/migrations/037_system_notices.sql
+++ b/src/migrations/037_system_notices.sql
@@ -1,0 +1,13 @@
+-- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+
+-- Centralised fault bus. Daemon raises named notices when something breaks and
+-- clears them on recovery. The UI polls this table via SSE and surfaces notices
+-- as banners on every page — no user has to check terminal logs.
+CREATE TABLE system_notices (
+    notice_id  TEXT PRIMARY KEY,
+    severity   TEXT NOT NULL CHECK (severity IN ('error', 'warning')),
+    title      TEXT NOT NULL,
+    detail     TEXT NOT NULL,
+    remedy     TEXT,
+    raised_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);

--- a/src/notices.rs
+++ b/src/notices.rs
@@ -1,0 +1,55 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Centralised fault bus. The daemon calls `raise` when something breaks and
+// `clear` when it recovers. The UI reads `system_notices` via the SSE stream
+// and surfaces banners on every page — users never have to check terminal logs.
+//
+// Notice IDs follow the pattern `<subsystem>.<fault>`, e.g.:
+//   pm.jira       — Jira sync failing
+//   pm.linear     — Linear sync failing
+//   etl.failed    — ETL pipeline error
+//   mlx.down      — MLX classifier unreachable
+
+use anyhow::{Context, Result};
+use sqlx::SqlitePool;
+
+/// Raise (or refresh) a named notice. Idempotent — upserts so repeated calls
+/// from the poll loop don't accumulate duplicate rows.
+pub async fn raise(
+    pool: &SqlitePool,
+    id: &str,
+    severity: &str,
+    title: &str,
+    detail: &str,
+    remedy: Option<&str>,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO system_notices (notice_id, severity, title, detail, remedy)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(notice_id) DO UPDATE SET
+           severity  = excluded.severity,
+           title     = excluded.title,
+           detail    = excluded.detail,
+           remedy    = excluded.remedy,
+           raised_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')",
+    )
+    .bind(id)
+    .bind(severity)
+    .bind(title)
+    .bind(detail)
+    .bind(remedy)
+    .execute(pool)
+    .await
+    .context("raising system notice")?;
+    Ok(())
+}
+
+/// Clear a notice — called when the daemon recovers from a fault.
+pub async fn clear(pool: &SqlitePool, id: &str) -> Result<()> {
+    sqlx::query("DELETE FROM system_notices WHERE notice_id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context("clearing system notice")?;
+    Ok(())
+}

--- a/ui/app/(dashboard)/tasks/page.tsx
+++ b/ui/app/(dashboard)/tasks/page.tsx
@@ -7,7 +7,12 @@ import TasksView from '@/components/views/TasksView'
 
 function TasksContent() {
   const params = useSearchParams()
-  return <TasksView focusKey={params.get('focus')} />
+  return (
+    <TasksView
+      focusKey={params.get('focus')}
+      openIntegrations={params.get('integrations') === '1'}
+    />
+  )
 }
 
 export default function TasksPage() {

--- a/ui/app/api/auth/oauth/start/route.ts
+++ b/ui/app/api/auth/oauth/start/route.ts
@@ -1,0 +1,57 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// POST /api/auth/oauth/start?provider=jira|trello
+//
+// Spawns `meridian oauth-login <provider>` as a background process.
+// The command opens the user's browser to the provider's OAuth page,
+// handles the callback on a local port, and writes the token to
+// ~/.meridian/oauth/<provider>.json.
+//
+// Returns immediately with { started: true }. The UI polls
+// /api/integrations until the provider shows connected.
+
+import { NextResponse } from 'next/server'
+import { spawn } from 'child_process'
+import path from 'path'
+import os from 'os'
+import fs from 'fs'
+
+const ALLOWED = new Set(['jira', 'trello'])
+
+function findMeridianBin(): string {
+  // Installed binary takes precedence; fall back to cargo run for dev
+  const installed = path.join(os.homedir(), '.meridian', 'app', 'meridian')
+  if (fs.existsSync(installed)) return installed
+  // Try PATH
+  return 'meridian'
+}
+
+export async function POST(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const provider = searchParams.get('provider') ?? ''
+  if (!ALLOWED.has(provider)) {
+    return NextResponse.json({ error: `Unknown provider: ${provider}` }, { status: 400 })
+  }
+
+  const bin = findMeridianBin()
+  const logDir = process.env.MERIDIAN_LOG_DIR ?? path.join(os.homedir(), '.meridian', 'logs')
+
+  try {
+    // Detached so it survives if Next.js process restarts
+    const child = spawn(bin, ['oauth-login', provider], {
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env },
+    })
+
+    // Capture output to a temp log for debugging
+    const outLog = fs.createWriteStream(path.join(logDir, `oauth-${provider}.log`), { flags: 'a' })
+    child.stdout?.pipe(outLog)
+    child.stderr?.pipe(outLog)
+    child.unref()
+
+    return NextResponse.json({ started: true, provider })
+  } catch (e) {
+    return NextResponse.json({ error: `Could not start OAuth flow: ${e}` }, { status: 500 })
+  }
+}

--- a/ui/app/api/auth/token/route.ts
+++ b/ui/app/api/auth/token/route.ts
@@ -91,9 +91,8 @@ export async function POST(request: Request) {
   // Build env var updates from submitted fields
   const updates: Record<string, string> = {}
   for (const [fieldName, envKey] of Object.entries(fieldMap)) {
-    if (fields[fieldName]?.trim()) {
-      updates[envKey] = fields[fieldName].trim()
-    }
+    const v = fields[fieldName]?.trim().replace(/[\r\n]/g, '')
+    if (v) updates[envKey] = v
   }
 
   if (Object.keys(updates).length === 0) {
@@ -101,7 +100,6 @@ export async function POST(request: Request) {
   }
 
   // Validate required fields per provider
-  const keys = PROVIDER_KEYS[provider]!
   const required: Record<string, string[]> = {
     jira:   ['JIRA_BASE_URL', 'JIRA_EMAIL', 'JIRA_API_TOKEN'],
     linear: ['LINEAR_API_KEY'],

--- a/ui/app/api/auth/token/route.ts
+++ b/ui/app/api/auth/token/route.ts
@@ -1,0 +1,131 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// POST /api/auth/token — write API credentials to .env and reload the daemon.
+// Body: { provider: "jira"|"linear"|"github", ...fields }
+//
+// Jira fields:   { base_url, email, api_token }
+// Linear fields: { api_key, team_ids? }
+// GitHub fields: { token, project_ids? }
+//
+// Writes the relevant KEY=value lines to the active .env, then signals
+// the daemon to reload so the new credentials take effect immediately.
+
+import { NextResponse } from 'next/server'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import net from 'net'
+
+function activeEnvPath(): string {
+  return process.env.NODE_ENV === 'production'
+    ? path.join(os.homedir(), '.meridian', 'app', '.env')
+    : (() => {
+        let dir = process.cwd()
+        for (let i = 0; i < 6; i++) {
+          if (fs.existsSync(path.join(dir, 'Cargo.toml'))) return path.join(dir, '.env')
+          const parent = path.dirname(dir)
+          if (parent === dir) break
+          dir = parent
+        }
+        return path.join(process.cwd(), '.env')
+      })()
+}
+
+const PROVIDER_KEYS: Record<string, string[]> = {
+  jira:    ['JIRA_BASE_URL', 'JIRA_EMAIL', 'JIRA_API_TOKEN'],
+  linear:  ['LINEAR_API_KEY', 'LINEAR_TEAM_IDS'],
+  github:  ['GITHUB_TOKEN', 'GITHUB_PROJECT_IDS'],
+}
+
+const FIELD_MAP: Record<string, Record<string, string>> = {
+  jira:   { base_url: 'JIRA_BASE_URL', email: 'JIRA_EMAIL', api_token: 'JIRA_API_TOKEN' },
+  linear: { api_key: 'LINEAR_API_KEY', team_ids: 'LINEAR_TEAM_IDS' },
+  github: { token: 'GITHUB_TOKEN', project_ids: 'GITHUB_PROJECT_IDS' },
+}
+
+function upsertEnv(envPath: string, updates: Record<string, string>): void {
+  const existing = fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf-8') : ''
+  const lines = existing.split('\n')
+  const keysToUpdate = new Set(Object.keys(updates))
+
+  // Replace existing lines
+  const updated = lines.map(line => {
+    const key = line.split('=')[0].trim()
+    if (keysToUpdate.has(key)) {
+      keysToUpdate.delete(key)
+      return `${key}=${updates[key]}`
+    }
+    return line
+  })
+
+  // Append any keys not already present
+  for (const key of keysToUpdate) {
+    if (updates[key]) updated.push(`${key}=${updates[key]}`)
+  }
+
+  fs.writeFileSync(envPath, updated.join('\n'), 'utf-8')
+}
+
+function reloadDaemon(): Promise<void> {
+  return new Promise((resolve) => {
+    const sockPath = path.join(os.homedir(), '.meridian', 'daemon.sock')
+    const socket = net.connect(sockPath)
+    socket.on('connect', () => { socket.destroy(); resolve() })
+    socket.on('error', () => resolve()) // daemon not running — no-op
+    setTimeout(() => { socket.destroy(); resolve() }, 500)
+  })
+}
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null)
+  if (!body || typeof body.provider !== 'string') {
+    return NextResponse.json({ error: 'Missing provider' }, { status: 400 })
+  }
+
+  const { provider, ...fields } = body as Record<string, string>
+  const fieldMap = FIELD_MAP[provider]
+  if (!fieldMap) {
+    return NextResponse.json({ error: `Unknown provider: ${provider}` }, { status: 400 })
+  }
+
+  // Build env var updates from submitted fields
+  const updates: Record<string, string> = {}
+  for (const [fieldName, envKey] of Object.entries(fieldMap)) {
+    if (fields[fieldName]?.trim()) {
+      updates[envKey] = fields[fieldName].trim()
+    }
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'No fields provided' }, { status: 400 })
+  }
+
+  // Validate required fields per provider
+  const keys = PROVIDER_KEYS[provider]!
+  const required: Record<string, string[]> = {
+    jira:   ['JIRA_BASE_URL', 'JIRA_EMAIL', 'JIRA_API_TOKEN'],
+    linear: ['LINEAR_API_KEY'],
+    github: ['GITHUB_TOKEN'],
+  }
+  const missing = (required[provider] ?? []).filter(k => !updates[k])
+  if (missing.length > 0) {
+    return NextResponse.json({ error: `Missing: ${missing.join(', ')}` }, { status: 400 })
+  }
+
+  // Remove old OAuth token for Jira (API token should take priority, but cleaner to remove)
+  if (provider === 'jira') {
+    const oauthPath = path.join(os.homedir(), '.meridian', 'oauth', 'jira.json')
+    try { fs.unlinkSync(oauthPath) } catch { /* not present */ }
+  }
+
+  try {
+    upsertEnv(activeEnvPath(), updates)
+  } catch (e) {
+    return NextResponse.json({ error: `Could not write .env: ${e}` }, { status: 500 })
+  }
+
+  // Signal daemon to reload (non-fatal if not running)
+  await reloadDaemon()
+
+  return NextResponse.json({ ok: true, updated: Object.keys(updates) })
+}

--- a/ui/app/api/auth/token/route.ts
+++ b/ui/app/api/auth/token/route.ts
@@ -31,12 +31,6 @@ function activeEnvPath(): string {
       })()
 }
 
-const PROVIDER_KEYS: Record<string, string[]> = {
-  jira:    ['JIRA_BASE_URL', 'JIRA_EMAIL', 'JIRA_API_TOKEN'],
-  linear:  ['LINEAR_API_KEY', 'LINEAR_TEAM_IDS'],
-  github:  ['GITHUB_TOKEN', 'GITHUB_PROJECT_IDS'],
-}
-
 const FIELD_MAP: Record<string, Record<string, string>> = {
   jira:   { base_url: 'JIRA_BASE_URL', email: 'JIRA_EMAIL', api_token: 'JIRA_API_TOKEN' },
   linear: { api_key: 'LINEAR_API_KEY', team_ids: 'LINEAR_TEAM_IDS' },

--- a/ui/app/api/logs/route.ts
+++ b/ui/app/api/logs/route.ts
@@ -1,0 +1,16 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Returns the last N log entries from the daemon's JSONL file. Used to
+// populate the initial log view before the SSE tail takes over.
+
+import { NextResponse } from 'next/server'
+import { readRecentLines } from '@/lib/log-tail'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const limit = Math.min(parseInt(searchParams.get('limit') ?? '200', 10), 1000)
+  const entries = await readRecentLines(limit)
+  return NextResponse.json(entries)
+}

--- a/ui/app/api/logs/stream/route.ts
+++ b/ui/app/api/logs/stream/route.ts
@@ -1,0 +1,32 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// SSE endpoint that tails the daemon's JSONL log file. Uses kqueue/inotify
+// via fs.watch() — reliable for append-only files. N open tabs share one
+// watcher and one file position; no per-connection polling overhead.
+
+import { subscribeToTail, unsubscribeFromTail } from '@/lib/log-tail'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  let ctrl: ReadableStreamDefaultController<Uint8Array>
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      ctrl = controller
+      subscribeToTail(ctrl)
+    },
+    cancel() {
+      unsubscribeFromTail(ctrl)
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  })
+}

--- a/ui/app/api/notices/[id]/route.ts
+++ b/ui/app/api/notices/[id]/route.ts
@@ -1,0 +1,29 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// DELETE /api/notices/:id — clear a notice from system_notices immediately.
+// Called by the UI when a provider successfully connects so the error banner
+// disappears without waiting for the next ETL poll cycle.
+
+import { NextResponse } from 'next/server'
+import getDb from '@/lib/db'
+import { refresh } from '@/lib/notices-store'
+
+export const dynamic = 'force-dynamic'
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: { id: string } },
+) {
+  const noticeId = params.id
+  if (!noticeId) {
+    return NextResponse.json({ error: 'Missing notice id' }, { status: 400 })
+  }
+  try {
+    const db = getDb()
+    db.prepare('DELETE FROM system_notices WHERE notice_id = ?').run(noticeId)
+    refresh() // push empty/updated list to all open SSE connections immediately
+    return NextResponse.json({ ok: true })
+  } catch (e) {
+    return NextResponse.json({ error: String(e) }, { status: 500 })
+  }
+}

--- a/ui/app/api/notices/[id]/route.ts
+++ b/ui/app/api/notices/[id]/route.ts
@@ -12,9 +12,9 @@ export const dynamic = 'force-dynamic'
 
 export async function DELETE(
   _request: Request,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const noticeId = params.id
+  const { id: noticeId } = await params
   if (!noticeId) {
     return NextResponse.json({ error: 'Missing notice id' }, { status: 400 })
   }

--- a/ui/app/api/notices/stream/route.ts
+++ b/ui/app/api/notices/stream/route.ts
@@ -1,0 +1,36 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// SSE endpoint for the global fault bus. The browser opens one persistent
+// EventSource connection; this route registers a controller with the shared
+// notices-store singleton and keeps the stream open until the tab closes.
+//
+// One shared setInterval (in notices-store.ts) polls the DB every 30s and
+// broadcasts only when the notice set changes — so N open tabs cost one DB
+// query per interval, not N.
+
+import { subscribe, unsubscribe } from '@/lib/notices-store'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  let ctrl: ReadableStreamDefaultController<Uint8Array>
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      ctrl = controller
+      subscribe(ctrl)
+    },
+    cancel() {
+      unsubscribe(ctrl)
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  })
+}

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -6,6 +6,7 @@ import { GeistMono } from 'geist/font/mono'
 import { Instrument_Serif } from 'next/font/google'
 import './globals.css'
 import { ThemeProvider } from '@/lib/theme-context'
+import NoticeBar from '@/components/NoticeBar'
 
 const instrumentSerif = Instrument_Serif({
   weight: '400',
@@ -25,6 +26,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable} ${instrumentSerif.variable}`}>
       <body className="min-h-screen font-sans">
         <ThemeProvider>
+          <NoticeBar />
           {children}
         </ThemeProvider>
       </body>

--- a/ui/app/logs/page.tsx
+++ b/ui/app/logs/page.tsx
@@ -1,0 +1,9 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+
+import LogsView from '@/components/views/LogsView'
+
+export const metadata = { title: 'Meridian — Logs' }
+
+export default function LogsPage() {
+  return <LogsView />
+}

--- a/ui/components/Nav.tsx
+++ b/ui/components/Nav.tsx
@@ -10,6 +10,7 @@ const links = [
   { href: '/', label: 'Today' },
   { href: '/sessions', label: 'Sessions' },
   { href: '/apps', label: 'Apps' },
+  { href: '/logs', label: 'Logs' },
   { href: '/settings', label: 'Settings' },
 ]
 

--- a/ui/components/NoticeBar.tsx
+++ b/ui/components/NoticeBar.tsx
@@ -98,6 +98,26 @@ export default function NoticeBar() {
                 </div>
               )}
             </div>
+            {n.notice_id.startsWith('pm.') && (
+              <a
+                href="/tasks?integrations=1"
+                style={{
+                  flexShrink: 0,
+                  fontSize: 11,
+                  fontWeight: 600,
+                  color: s.text,
+                  background: 'rgba(0,0,0,0.07)',
+                  border: `1px solid ${s.border}`,
+                  borderRadius: 5,
+                  padding: '3px 8px',
+                  textDecoration: 'none',
+                  whiteSpace: 'nowrap',
+                  alignSelf: 'center',
+                }}
+              >
+                Fix in Tasks →
+              </a>
+            )}
           </div>
         )
       })}

--- a/ui/components/NoticeBar.tsx
+++ b/ui/components/NoticeBar.tsx
@@ -1,0 +1,106 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Global fault banner. Opens one SSE connection to /api/notices/stream and
+// renders a banner for each active system notice. Banners auto-disappear when
+// the daemon clears the fault — no manual dismiss needed. Placed in the root
+// layout so it appears on every page.
+
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import type { Notice } from '@/lib/notices-store'
+
+const SEVERITY_STYLES: Record<string, { bg: string; border: string; text: string; dot: string }> = {
+  error: {
+    bg: '#fff5f5',
+    border: '#feb2b2',
+    text: '#c53030',
+    dot: '#e53e3e',
+  },
+  warning: {
+    bg: '#fffbeb',
+    border: '#fcd34d',
+    text: '#92400e',
+    dot: '#d97706',
+  },
+}
+
+export default function NoticeBar() {
+  const [notices, setNotices] = useState<Notice[]>([])
+  const esRef = useRef<EventSource | null>(null)
+
+  useEffect(() => {
+    function connect() {
+      const es = new EventSource('/api/notices/stream')
+      esRef.current = es
+
+      es.onmessage = (e) => {
+        try {
+          setNotices(JSON.parse(e.data) as Notice[])
+        } catch {
+          // malformed frame — ignore
+        }
+      }
+
+      es.onerror = () => {
+        // Connection dropped — close and reconnect after 5s
+        es.close()
+        esRef.current = null
+        setTimeout(connect, 5_000)
+      }
+    }
+
+    connect()
+    return () => {
+      esRef.current?.close()
+    }
+  }, [])
+
+  if (notices.length === 0) return null
+
+  return (
+    <div style={{ position: 'sticky', top: 0, zIndex: 50 }}>
+      {notices.map((n) => {
+        const s = SEVERITY_STYLES[n.severity] ?? SEVERITY_STYLES.error
+        return (
+          <div
+            key={n.notice_id}
+            style={{
+              background: s.bg,
+              borderBottom: `1px solid ${s.border}`,
+              padding: '10px 16px',
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: 10,
+            }}
+          >
+            <span
+              style={{
+                display: 'inline-block',
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                background: s.dot,
+                flexShrink: 0,
+                marginTop: 5,
+              }}
+            />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <span style={{ fontSize: 13, fontWeight: 600, color: s.text }}>
+                {n.title}
+              </span>
+              <span style={{ fontSize: 12, color: s.text, marginLeft: 8, opacity: 0.85 }}>
+                {n.detail}
+              </span>
+              {n.remedy && (
+                <div style={{ marginTop: 2, fontSize: 11, color: s.text, opacity: 0.7 }}>
+                  Fix: <code style={{ fontFamily: 'var(--font-geist-mono)', background: 'rgba(0,0,0,0.06)', padding: '1px 4px', borderRadius: 3 }}>{n.remedy}</code>
+                </div>
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/ui/components/views/LogsView.tsx
+++ b/ui/components/views/LogsView.tsx
@@ -1,0 +1,201 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Live log viewer. Loads recent entries on mount, then tails new ones via SSE.
+// Filterable by level. Auto-scrolls to bottom unless the user has scrolled up.
+
+'use client'
+
+import { useEffect, useRef, useState, useCallback } from 'react'
+import type { LogEntry } from '@/lib/log-tail'
+
+const LEVEL_STYLES: Record<string, { bg: string; color: string; label: string }> = {
+  ERROR: { bg: '#fee2e2', color: '#b91c1c', label: 'ERR' },
+  WARN:  { bg: '#fef3c7', color: '#92400e', label: 'WRN' },
+  INFO:  { bg: '#dbeafe', color: '#1e40af', label: 'INF' },
+  DEBUG: { bg: '#f3f4f6', color: '#6b7280', label: 'DBG' },
+  TRACE: { bg: '#f3f4f6', color: '#9ca3af', label: 'TRC' },
+}
+
+const FILTERS = ['ALL', 'ERROR', 'WARN', 'INFO', 'DEBUG'] as const
+type Filter = (typeof FILTERS)[number]
+
+function shortTarget(target: string): string {
+  const parts = target.split('::')
+  return parts.length > 2 ? parts.slice(-2).join('::') : target
+}
+
+function relativeTime(iso: string): string {
+  const delta = Date.now() - new Date(iso).getTime()
+  if (delta < 60_000) return `${Math.floor(delta / 1000)}s ago`
+  if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m ago`
+  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
+
+function levelOrder(level: string): number {
+  return { ERROR: 0, WARN: 1, INFO: 2, DEBUG: 3, TRACE: 4 }[level] ?? 5
+}
+
+export default function LogsView() {
+  const [entries, setEntries] = useState<LogEntry[]>([])
+  const [filter, setFilter] = useState<Filter>('ALL')
+  const [expanded, setExpanded] = useState<Set<number>>(new Set())
+  const [paused, setPaused] = useState(false)
+  const bottomRef = useRef<HTMLDivElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const pausedRef = useRef(false)
+  pausedRef.current = paused
+
+  // Auto-scroll: only when user hasn't scrolled up
+  const shouldAutoScroll = useRef(true)
+  const onScroll = useCallback(() => {
+    const el = containerRef.current
+    if (!el) return
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80
+    shouldAutoScroll.current = atBottom
+  }, [])
+
+  useEffect(() => {
+    // Load last 200 entries on mount
+    fetch('/api/logs?limit=200')
+      .then(r => r.json())
+      .then((data: LogEntry[]) => setEntries(data))
+      .catch(() => {})
+
+    // Tail new entries via SSE
+    const es = new EventSource('/api/logs/stream')
+    es.onmessage = (e) => {
+      if (pausedRef.current) return
+      try {
+        const incoming: LogEntry[] = JSON.parse(e.data)
+        setEntries(prev => {
+          const next = [...prev, ...incoming].slice(-2000) // cap at 2000
+          return next
+        })
+      } catch { /* ignore */ }
+    }
+    return () => es.close()
+  }, [])
+
+  useEffect(() => {
+    if (shouldAutoScroll.current) {
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [entries])
+
+  const visible = filter === 'ALL'
+    ? entries
+    : entries.filter(e => levelOrder(e.level) <= levelOrder(filter))
+
+  const toggleExpand = (idx: number) => {
+    setExpanded(prev => {
+      const next = new Set(prev)
+      if (next.has(idx)) next.delete(idx); else next.add(idx)
+      return next
+    })
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
+      {/* Toolbar */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 12,
+        padding: '12px 16px', borderBottom: '1px solid var(--rule)', flexShrink: 0,
+      }}>
+        <p style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.15em', color: 'var(--ink-3)' }}>
+          Daemon Logs
+        </p>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 6, alignItems: 'center' }}>
+          {FILTERS.map(f => (
+            <button
+              key={f}
+              onClick={() => setFilter(f)}
+              style={{
+                fontSize: 11, padding: '2px 8px', borderRadius: 4, cursor: 'pointer',
+                border: `1px solid ${filter === f ? 'var(--ink-3)' : 'var(--rule)'}`,
+                background: filter === f ? 'var(--ink)' : 'transparent',
+                color: filter === f ? 'var(--canvas)' : 'var(--ink-3)',
+              }}
+            >
+              {f}
+            </button>
+          ))}
+          <button
+            onClick={() => setPaused(p => !p)}
+            style={{
+              fontSize: 11, padding: '2px 8px', borderRadius: 4, cursor: 'pointer',
+              border: `1px solid ${paused ? '#fcd34d' : 'var(--rule)'}`,
+              background: paused ? '#fef3c7' : 'transparent',
+              color: paused ? '#92400e' : 'var(--ink-3)',
+            }}
+          >
+            {paused ? '▶ Resume' : '⏸ Pause'}
+          </button>
+        </div>
+      </div>
+
+      {/* Log list */}
+      <div
+        ref={containerRef}
+        onScroll={onScroll}
+        style={{
+          flex: 1, overflowY: 'auto', fontFamily: 'var(--font-geist-mono)',
+          fontSize: 12, lineHeight: 1.6,
+        }}
+      >
+        {visible.length === 0 && (
+          <p style={{ padding: 24, color: 'var(--ink-4)', fontSize: 13 }}>
+            No log entries — ensure the daemon is running.
+          </p>
+        )}
+        {visible.map((entry, idx) => {
+          const style = LEVEL_STYLES[entry.level] ?? LEVEL_STYLES.DEBUG
+          const hasFields = Object.keys(entry.fields).length > 0
+          const isExpanded = expanded.has(idx)
+          return (
+            <div
+              key={idx}
+              onClick={() => hasFields && toggleExpand(idx)}
+              style={{
+                display: 'flex', gap: 10, padding: '3px 16px',
+                borderBottom: '1px solid var(--rule)',
+                cursor: hasFields ? 'pointer' : 'default',
+                background: isExpanded ? 'var(--canvas-2)' : 'transparent',
+              }}
+            >
+              <span style={{ color: 'var(--ink-4)', flexShrink: 0, width: 60, fontSize: 11 }}>
+                {relativeTime(entry.timestamp)}
+              </span>
+              <span style={{
+                flexShrink: 0, width: 28, fontSize: 10, fontWeight: 700,
+                padding: '0 3px', borderRadius: 3,
+                background: style.bg, color: style.color,
+                display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+              }}>
+                {style.label}
+              </span>
+              <span style={{ color: 'var(--ink-4)', flexShrink: 0, width: 180, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 11 }}>
+                {shortTarget(entry.target)}
+                {entry.span ? ` › ${entry.span}` : ''}
+              </span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <span style={{ color: 'var(--ink)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                  {entry.message}
+                </span>
+                {isExpanded && hasFields && (
+                  <pre style={{
+                    marginTop: 4, padding: '6px 10px', borderRadius: 4,
+                    background: 'var(--canvas-3)', color: 'var(--ink-2)',
+                    fontSize: 11, whiteSpace: 'pre-wrap', wordBreak: 'break-all',
+                  }}>
+                    {JSON.stringify(entry.fields, null, 2)}
+                  </pre>
+                )}
+              </div>
+            </div>
+          )
+        })}
+        <div ref={bottomRef} />
+      </div>
+    </div>
+  )
+}

--- a/ui/components/views/TasksView.tsx
+++ b/ui/components/views/TasksView.tsx
@@ -491,6 +491,9 @@ const TRACKERS: Array<{
       command: 'meridian oauth-login jira',
       hint: 'Connect with your browser — no API token to create.',
     },
+    tokenHint: 'Go to Atlassian account security and create an API token with "All Jira" or "Read" scope.',
+    tokenUrl: 'https://id.atlassian.com/manage-profile/security/api-tokens',
+    env: 'JIRA_BASE_URL=https://yourorg.atlassian.net\nJIRA_EMAIL=you@yourorg.com\nJIRA_API_TOKEN=ATATT3x…',
   },
   {
     id: 'linear',
@@ -533,23 +536,6 @@ const TRACKERS: Array<{
   },
 ]
 
-// Field definitions for token-based setup forms
-type FieldDef = { name: string; label: string; placeholder: string; secret?: boolean; required: boolean }
-const TOKEN_FIELDS: Record<string, FieldDef[]> = {
-  jira: [
-    { name: 'base_url',    label: 'Jira URL',    placeholder: 'https://yourorg.atlassian.net', required: true },
-    { name: 'email',       label: 'Email',        placeholder: 'you@yourorg.com',               required: true },
-    { name: 'api_token',   label: 'API Token',    placeholder: 'ATATT3x…',                      required: true, secret: true },
-  ],
-  linear: [
-    { name: 'api_key',  label: 'API Key',    placeholder: 'lin_api_…', required: true, secret: true },
-    { name: 'team_ids', label: 'Team IDs',   placeholder: 'ENG (optional — leave blank for all)', required: false },
-  ],
-  github: [
-    { name: 'token',       label: 'Personal Access Token', placeholder: 'ghp_…',          required: true, secret: true },
-    { name: 'project_ids', label: 'Project IDs',           placeholder: 'PVT_… (optional — leave blank for all)', required: false },
-  ],
-}
 
 function ConnectTrackers({ integrations, onDisconnect }: { integrations: IntegrationsResponse | null; onDisconnect?: () => void }) {
   const [open, setOpen] = useState<TrackerId | null>(null)
@@ -946,76 +932,75 @@ function OAuthSetup({ tracker }: { tracker: (typeof TRACKERS)[number] }) {
 }
 
 function TokenSetup({ tracker }: { tracker: (typeof TRACKERS)[number] }) {
-  const fields = TOKEN_FIELDS[tracker.id] ?? []
-  const [values, setValues] = useState<Record<string, string>>({})
-  const [status, setStatus] = useState<'idle' | 'saving' | 'done' | 'error'>('idle')
-  const [error, setError] = useState<string | null>(null)
+  const [connected, setConnected] = useState(false)
+  const [checking, setChecking] = useState(false)
 
-  const requiredFields = fields.filter(f => f.required)
-  const allFilled = requiredFields.every(f => values[f.name]?.trim())
-
-  const save = async () => {
-    setStatus('saving'); setError(null)
+  const checkConnection = async () => {
+    setChecking(true)
     try {
-      const r = await fetch('/api/auth/token', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ provider: tracker.id, ...values }),
-      })
-      const body = await r.json()
-      if (!r.ok) { setError(body.error ?? 'Save failed'); setStatus('error'); return }
-      setStatus('done')
-    } catch (e) { setError(String(e)); setStatus('error') }
-  }
-
-  if (status === 'done') {
-    return (
-      <div className="px-4 pb-4 pt-2" style={{ background: 'var(--surface-2)' }}>
-        <p className="text-[12px]" style={{ color: 'var(--success)' }}>✓ Saved! Your tasks will appear within a minute.</p>
-      </div>
-    )
+      const r = await fetch('/api/integrations')
+      if (r.ok) {
+        const data = await r.json()
+        setConnected(!!data[tracker.id])
+      }
+    } catch { /* ignore */ }
+    finally { setChecking(false) }
   }
 
   return (
-    <div className="px-4 pb-4 pt-2" style={{ background: 'var(--surface-2)' }}>
-      {tracker.tokenHint && (
-        <p className="text-[12px] leading-relaxed mb-3" style={{ color: 'var(--ink-2)' }}>
-          {tracker.tokenHint}{' '}
-          {tracker.tokenUrl && (
-            <a href={tracker.tokenUrl} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)' }}>Open ↗</a>
-          )}
-        </p>
-      )}
-      <div className="space-y-2">
-        {fields.map(f => (
-          <div key={f.name}>
-            <label className="block text-[11px] mb-0.5" style={{ color: 'var(--ink-3)' }}>
-              {f.label}{f.required ? '' : ' (optional)'}
-            </label>
-            <input
-              type={f.secret ? 'password' : 'text'}
-              value={values[f.name] ?? ''}
-              onChange={e => setValues(v => ({ ...v, [f.name]: e.target.value }))}
-              placeholder={f.placeholder}
-              className="w-full font-mono text-[11px] px-2 py-1.5 rounded-md border"
-              style={{ color: 'var(--ink)', background: 'var(--surface)', borderColor: 'var(--rule)', outline: 'none' }}
-            />
+    <div className="px-4 pb-4 pt-1" style={{ background: 'var(--surface-2)' }}>
+      <ol className="space-y-3">
+        <li className="flex gap-3">
+          <StepNum n={1} />
+          <div className="min-w-0 flex-1">
+            <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-2)' }}>
+              {tracker.tokenHint}{' '}
+              {tracker.tokenUrl && (
+                <a href={tracker.tokenUrl} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)' }}>
+                  Open ↗
+                </a>
+              )}
+            </p>
           </div>
-        ))}
-      </div>
-      {error && <p className="mt-2 text-[11px]" style={{ color: '#e53e3e' }}>{error}</p>}
-      <button
-        onClick={save}
-        disabled={!allFilled || status === 'saving'}
-        className="mt-3 text-[12px] px-4 py-2 rounded-md font-medium transition-opacity"
-        style={{
-          background: 'var(--accent)', color: '#fff',
-          opacity: (!allFilled || status === 'saving') ? 0.5 : 1,
-          cursor: (!allFilled || status === 'saving') ? 'not-allowed' : 'pointer',
-        }}
-      >
-        {status === 'saving' ? 'Saving…' : `Connect ${tracker.name}`}
-      </button>
+        </li>
+        <li className="flex gap-3">
+          <StepNum n={2} />
+          <div className="min-w-0 flex-1">
+            <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-2)' }}>
+              Run <CodeChip text="meridian config edit" /> and add:
+            </p>
+            {tracker.env && <CopyBlock text={tracker.env} />}
+          </div>
+        </li>
+        <li className="flex gap-3">
+          <StepNum n={3} />
+          <div className="min-w-0 flex-1">
+            <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-2)' }}>
+              Save, then run <CodeChip text="meridian restart" />
+            </p>
+            <button
+              onClick={checkConnection}
+              disabled={checking}
+              className="mt-2 text-[11px] px-3 py-1.5 rounded-md transition-opacity"
+              style={{
+                background: 'var(--tint)',
+                color: connected ? 'var(--success)' : 'var(--ink-2)',
+                border: `1px solid ${connected ? 'var(--success)' : 'var(--rule)'}`,
+                opacity: checking ? 0.6 : 1,
+                cursor: checking ? 'not-allowed' : 'pointer',
+              }}
+            >
+              {checking ? 'Checking…' : connected ? '✓ Connected!' : 'Check connection'}
+            </button>
+          </div>
+        </li>
+        {tracker.note && (
+          <li className="flex gap-3">
+            <span className="shrink-0 w-[18px]" />
+            <p className="text-[11px] leading-relaxed" style={{ color: 'var(--ink-4)' }}>{tracker.note}</p>
+          </li>
+        )}
+      </ol>
     </div>
   )
 }

--- a/ui/components/views/TasksView.tsx
+++ b/ui/components/views/TasksView.tsx
@@ -616,6 +616,7 @@ function ConnectedPanel({
   onDisconnect: () => void
 }) {
   const [reauthorizing, setReauthorizing] = useState(false)
+  const exitReauth = () => setReauthorizing(false)
   const cleanError = syncError
     ? syncError.replace(/^permission_error: |^sync_error: /, '')
     : null
@@ -641,8 +642,8 @@ function ConnectedPanel({
           <p className="text-[12px] mb-2" style={{ color: 'var(--ink-2)' }}>
             Re-authorize {tracker.name}:
           </p>
-          <TrackerSetup tracker={tracker} reauthorize />
-          <button onClick={() => setReauthorizing(false)} className="mt-2 text-[11px]" style={{ color: 'var(--ink-4)', cursor: 'pointer' }}>
+          <TrackerSetup tracker={tracker} reauthorize onSuccess={exitReauth} />
+          <button onClick={exitReauth} className="mt-2 text-[11px]" style={{ color: 'var(--ink-4)', cursor: 'pointer' }}>
             Cancel
           </button>
         </div>
@@ -666,8 +667,8 @@ function ConnectedPanel({
   )
 }
 
-function TrackerSetup({ tracker, reauthorize }: { tracker: (typeof TRACKERS)[number]; reauthorize?: boolean }) {
-  // Jira supports both OAuth and API token — show a chooser (or force API token on reauth)
+function TrackerSetup({ tracker, reauthorize, onSuccess }: { tracker: (typeof TRACKERS)[number]; reauthorize?: boolean; onSuccess?: () => void }) {
+  // Jira supports both OAuth and API token — show a chooser (or force token on reauth)
   const [jiraMode, setJiraMode] = useState<'oauth' | 'token'>(reauthorize ? 'token' : 'oauth')
   if (tracker.id === 'jira') {
     return (
@@ -685,11 +686,11 @@ function TrackerSetup({ tracker, reauthorize }: { tracker: (typeof TRACKERS)[num
             style={{ background: jiraMode === 'token' ? 'var(--accent)' : 'var(--tint)', color: jiraMode === 'token' ? '#fff' : 'var(--ink-3)', cursor: 'pointer' }}
           >API Token</button>
         </div>
-        {jiraMode === 'oauth' ? <OAuthSetup tracker={tracker} /> : <TokenSetup tracker={tracker} />}
+        {jiraMode === 'oauth' ? <OAuthSetup tracker={tracker} onSuccess={onSuccess} /> : <TokenSetup tracker={tracker} />}
       </div>
     )
   }
-  if (tracker.oauth) return <OAuthSetup tracker={tracker} />
+  if (tracker.oauth) return <OAuthSetup tracker={tracker} onSuccess={onSuccess} />
   if (tracker.id === 'azure_devops') return <AzureDevOpsSetup tracker={tracker} />
   return <TokenSetup tracker={tracker} />
 }
@@ -870,7 +871,7 @@ function AzureDevOpsSetup({ tracker }: { tracker: (typeof TRACKERS)[number] }) {
   )
 }
 
-function OAuthSetup({ tracker }: { tracker: (typeof TRACKERS)[number] }) {
+function OAuthSetup({ tracker, onSuccess }: { tracker: (typeof TRACKERS)[number]; onSuccess?: () => void }) {
   const [status, setStatus] = useState<'idle' | 'waiting' | 'done' | 'error'>('idle')
   const [error, setError] = useState<string | null>(null)
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -883,21 +884,31 @@ function OAuthSetup({ tracker }: { tracker: (typeof TRACKERS)[number] }) {
     try {
       const r = await fetch(`/api/auth/oauth/start?provider=${tracker.id}`, { method: 'POST' })
       if (!r.ok) { const b = await r.json(); setError(b.error ?? 'Failed to start'); setStatus('error'); return }
-      // Poll until connected (up to 3 minutes)
+      // Poll until connected (up to 3 minutes).
+      // `stopped` prevents two async invocations of the same callback from both
+      // resolving — e.g. tick N suspended at await while tick N+1 hits the deadline.
       const deadline = Date.now() + 180_000
-      pollRef.current = setInterval(async () => {
-        if (Date.now() > deadline) { clearInterval(pollRef.current!); pollRef.current = null; setStatus('error'); setError('Timed out — try again'); return }
+      let stopped = false
+      const id = setInterval(async () => {
+        if (stopped) return
+        if (Date.now() > deadline) {
+          stopped = true; clearInterval(id); pollRef.current = null
+          setStatus('error'); setError('Timed out — try again'); return
+        }
         const ir = await fetch('/api/integrations').catch(() => null)
+        if (stopped) return  // re-check after await — timeout may have fired
         if (!ir?.ok) return
         const data = await ir.json()
+        if (stopped) return
         if (data[tracker.id]) {
-          clearInterval(pollRef.current!)
-          pollRef.current = null
+          stopped = true; clearInterval(id); pollRef.current = null
           setStatus('done')
           // Clear the provider's error notice immediately — don't wait for next ETL poll
           fetch(`/api/notices/pm.${tracker.id}`, { method: 'DELETE' }).catch(() => {})
+          onSuccess?.()
         }
       }, 2_000)
+      pollRef.current = id
     } catch (e) {
       setError(String(e)); setStatus('error')
     }

--- a/ui/components/views/TasksView.tsx
+++ b/ui/components/views/TasksView.tsx
@@ -1,7 +1,7 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { fmtDur, fmtClock, AppGlyph, CatDot, TaskKey, StatusPill, SectionHead, Card, CATS, PROVIDER_META } from '@/components/atoms'
 import type { TaskSummary, TasksResponse } from '@/app/api/tasks/route'
 import type { TodayResponse } from '@/app/api/today/route'
@@ -873,6 +873,9 @@ function AzureDevOpsSetup({ tracker }: { tracker: (typeof TRACKERS)[number] }) {
 function OAuthSetup({ tracker }: { tracker: (typeof TRACKERS)[number] }) {
   const [status, setStatus] = useState<'idle' | 'waiting' | 'done' | 'error'>('idle')
   const [error, setError] = useState<string | null>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  useEffect(() => () => { if (pollRef.current != null) clearInterval(pollRef.current) }, [])
 
   const startOAuth = async () => {
     setStatus('waiting')
@@ -882,13 +885,14 @@ function OAuthSetup({ tracker }: { tracker: (typeof TRACKERS)[number] }) {
       if (!r.ok) { const b = await r.json(); setError(b.error ?? 'Failed to start'); setStatus('error'); return }
       // Poll until connected (up to 3 minutes)
       const deadline = Date.now() + 180_000
-      const poll = setInterval(async () => {
-        if (Date.now() > deadline) { clearInterval(poll); setStatus('error'); setError('Timed out — try again'); return }
+      pollRef.current = setInterval(async () => {
+        if (Date.now() > deadline) { clearInterval(pollRef.current!); pollRef.current = null; setStatus('error'); setError('Timed out — try again'); return }
         const ir = await fetch('/api/integrations').catch(() => null)
         if (!ir?.ok) return
         const data = await ir.json()
         if (data[tracker.id]) {
-          clearInterval(poll)
+          clearInterval(pollRef.current!)
+          pollRef.current = null
           setStatus('done')
           // Clear the provider's error notice immediately — don't wait for next ETL poll
           fetch(`/api/notices/pm.${tracker.id}`, { method: 'DELETE' }).catch(() => {})

--- a/ui/components/views/TasksView.tsx
+++ b/ui/components/views/TasksView.tsx
@@ -887,7 +887,12 @@ function OAuthSetup({ tracker }: { tracker: (typeof TRACKERS)[number] }) {
         const ir = await fetch('/api/integrations').catch(() => null)
         if (!ir?.ok) return
         const data = await ir.json()
-        if (data[tracker.id]) { clearInterval(poll); setStatus('done') }
+        if (data[tracker.id]) {
+          clearInterval(poll)
+          setStatus('done')
+          // Clear the provider's error notice immediately — don't wait for next ETL poll
+          fetch(`/api/notices/pm.${tracker.id}`, { method: 'DELETE' }).catch(() => {})
+        }
       }, 2_000)
     } catch (e) {
       setError(String(e)); setStatus('error')
@@ -941,7 +946,12 @@ function TokenSetup({ tracker }: { tracker: (typeof TRACKERS)[number] }) {
       const r = await fetch('/api/integrations')
       if (r.ok) {
         const data = await r.json()
-        setConnected(!!data[tracker.id])
+        const isConnected = !!data[tracker.id]
+        setConnected(isConnected)
+        if (isConnected) {
+          // Clear the provider's error notice immediately
+          fetch(`/api/notices/pm.${tracker.id}`, { method: 'DELETE' }).catch(() => {})
+        }
       }
     } catch { /* ignore */ }
     finally { setChecking(false) }

--- a/ui/components/views/TasksView.tsx
+++ b/ui/components/views/TasksView.tsx
@@ -41,6 +41,7 @@ export default function TasksView({ focusKey }: { focusKey?: string | null }) {
   const [selected, setSelected] = useState<string | null>(focusKey ?? null)
   const [syncing, setSyncing] = useState(false)
   const [lastSynced, setLastSynced] = useState<Date | null>(null)
+  const [syncError, setSyncError] = useState<string | null>(null)
   const [providerFilter, setProviderFilter] = useState<string>('all')
   const [showIntegrations, setShowIntegrations] = useState(false)
   const [collapsedEpics, setCollapsedEpics] = useState<Set<string>>(new Set())
@@ -64,13 +65,19 @@ export default function TasksView({ focusKey }: { focusKey?: string | null }) {
   const handleSync = () => {
     if (syncing) return
     setSyncing(true)
+    setSyncError(null)
     fetch('/api/tasks/sync', { method: 'POST' })
-      .then(() => fetchTasks())
-      .catch(() => {})
-      .finally(() => {
-        setSyncing(false)
-        setLastSynced(new Date())
+      .then(async r => {
+        const body = await r.json().catch(() => ({}))
+        if (!r.ok || body.ok === false) {
+          setSyncError(body.error ?? 'Sync failed — check daemon logs')
+        } else {
+          setLastSynced(new Date())
+          fetchTasks()
+        }
       })
+      .catch(() => setSyncError('Could not reach the daemon — is it running?'))
+      .finally(() => setSyncing(false))
   }
 
   useEffect(() => {
@@ -81,7 +88,7 @@ export default function TasksView({ focusKey }: { focusKey?: string | null }) {
     fetchIntegrations()
 
     const timer = setInterval(fetchTasks, TASKS_POLL_INTERVAL_MS)
-    return () => clearInterval(timer)
+    return () => { clearInterval(timer) }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!data) {
@@ -152,21 +159,30 @@ export default function TasksView({ focusKey }: { focusKey?: string | null }) {
           <p className="text-[12px]" style={{ color: 'var(--ink-3)' }}>
             <span className="font-mono tnum">{touched}</span> touched today
           </p>
-          <button
-            onClick={handleSync}
-            disabled={syncing}
-            className="flex items-center gap-1.5 text-[12px] px-3 py-1.5 rounded-md transition-colors"
-            style={{
-              color: syncing ? 'var(--ink-4)' : 'var(--ink-3)',
-              background: 'var(--surface)',
-              border: '1px solid var(--rule)',
-              cursor: syncing ? 'not-allowed' : 'pointer',
-            }}
-            title={lastSynced ? `Last synced ${lastSynced.toLocaleTimeString()}` : 'Sync tasks from Jira / Linear / GitHub'}
-          >
-            <span style={{ display: 'inline-block', animation: syncing ? 'spin 1s linear infinite' : 'none' }}>↻</span>
-            {syncing ? 'Syncing…' : 'Sync'}
-          </button>
+          <div className="flex flex-col items-end gap-1">
+            <button
+              onClick={handleSync}
+              disabled={syncing}
+              className="flex items-center gap-1.5 text-[12px] px-3 py-1.5 rounded-md transition-colors"
+              style={{
+                color: syncing ? 'var(--ink-4)' : syncError ? '#e53e3e' : 'var(--ink-3)',
+                background: 'var(--surface)',
+                border: `1px solid ${syncError ? '#e53e3e' : 'var(--rule)'}`,
+                cursor: syncing ? 'not-allowed' : 'pointer',
+              }}
+              title={lastSynced ? `Last synced ${lastSynced.toLocaleTimeString()}` : 'Sync tasks from Jira / Linear / GitHub'}
+            >
+              <span style={{ display: 'inline-block', animation: syncing ? 'spin 1s linear infinite' : 'none' }}>
+                {syncError ? '⚠' : '↻'}
+              </span>
+              {syncing ? 'Syncing…' : syncError ? 'Sync failed' : 'Sync'}
+            </button>
+            {syncError && (
+              <p className="text-[11px] max-w-[280px] text-right" style={{ color: '#e53e3e' }}>
+                {syncError}
+              </p>
+            )}
+          </div>
           <button
             onClick={() => setShowIntegrations(s => !s)}
             className="flex items-center gap-1.5 text-[12px] px-3 py-1.5 rounded-md transition-colors"
@@ -517,6 +533,24 @@ const TRACKERS: Array<{
   },
 ]
 
+// Field definitions for token-based setup forms
+type FieldDef = { name: string; label: string; placeholder: string; secret?: boolean; required: boolean }
+const TOKEN_FIELDS: Record<string, FieldDef[]> = {
+  jira: [
+    { name: 'base_url',    label: 'Jira URL',    placeholder: 'https://yourorg.atlassian.net', required: true },
+    { name: 'email',       label: 'Email',        placeholder: 'you@yourorg.com',               required: true },
+    { name: 'api_token',   label: 'API Token',    placeholder: 'ATATT3x…',                      required: true, secret: true },
+  ],
+  linear: [
+    { name: 'api_key',  label: 'API Key',    placeholder: 'lin_api_…', required: true, secret: true },
+    { name: 'team_ids', label: 'Team IDs',   placeholder: 'ENG (optional — leave blank for all)', required: false },
+  ],
+  github: [
+    { name: 'token',       label: 'Personal Access Token', placeholder: 'ghp_…',          required: true, secret: true },
+    { name: 'project_ids', label: 'Project IDs',           placeholder: 'PVT_… (optional — leave blank for all)', required: false },
+  ],
+}
+
 function ConnectTrackers({ integrations, onDisconnect }: { integrations: IntegrationsResponse | null; onDisconnect?: () => void }) {
   const [open, setOpen] = useState<TrackerId | null>(null)
   const [disconnecting, setDisconnecting] = useState<TrackerId | null>(null)
@@ -571,29 +605,12 @@ function ConnectTrackers({ integrations, onDisconnect }: { integrations: Integra
                 )}
               </button>
               {isOpen && connected && (
-                <div className="px-4 pb-4 pt-2" style={{ background: 'var(--surface-2)' }}>
-                  {syncError && (
-                    <div className="mb-3 rounded-md px-3 py-2 text-[12px] leading-relaxed" style={{ background: '#fef3c7', color: '#92400e', border: '1px solid #fcd34d' }}>
-                      <strong>Sync failed:</strong>{' '}
-                      {syncError.startsWith('permission_error: ')
-                        ? syncError.slice('permission_error: '.length)
-                        : syncError.startsWith('sync_error: ')
-                          ? syncError.slice('sync_error: '.length)
-                          : syncError}
-                    </div>
-                  )}
-                  <p className="text-[12px] leading-relaxed mb-3" style={{ color: 'var(--ink-3)' }}>
-                    After disconnecting, run <CodeChip text="meridian restart" /> for the change to take effect.
-                  </p>
-                  <button
-                    onClick={() => handleDisconnect(t.id)}
-                    disabled={disconnecting === t.id}
-                    className="text-[12px] px-3 py-1.5 rounded-md transition-opacity"
-                    style={{ color: '#e53e3e', border: '1px solid #e53e3e', opacity: disconnecting === t.id ? 0.5 : 1, cursor: disconnecting === t.id ? 'not-allowed' : 'pointer', background: 'transparent' }}
-                  >
-                    {disconnecting === t.id ? 'Disconnecting…' : `Disconnect ${t.name}`}
-                  </button>
-                </div>
+                <ConnectedPanel
+                  tracker={t}
+                  syncError={syncError}
+                  disconnecting={disconnecting === t.id}
+                  onDisconnect={() => handleDisconnect(t.id)}
+                />
               )}
               {isOpen && !connected && <TrackerSetup tracker={t} />}
             </div>
@@ -604,8 +621,89 @@ function ConnectTrackers({ integrations, onDisconnect }: { integrations: Integra
   )
 }
 
-function TrackerSetup({ tracker }: { tracker: (typeof TRACKERS)[number] }) {
-  if (tracker.oauth) return <OAuthSetup oauth={tracker.oauth} />
+function ConnectedPanel({
+  tracker, syncError, disconnecting, onDisconnect,
+}: {
+  tracker: (typeof TRACKERS)[number]
+  syncError?: string
+  disconnecting: boolean
+  onDisconnect: () => void
+}) {
+  const [reauthorizing, setReauthorizing] = useState(false)
+  const cleanError = syncError
+    ? syncError.replace(/^permission_error: |^sync_error: /, '')
+    : null
+
+  return (
+    <div className="px-4 pb-4 pt-2" style={{ background: 'var(--surface-2)' }}>
+      {cleanError && !reauthorizing && (
+        <div className="mb-3 rounded-md px-3 py-2" style={{ background: '#fef3c7', border: '1px solid #fcd34d' }}>
+          <p className="text-[12px] leading-relaxed" style={{ color: '#92400e' }}>
+            <strong>Sync failed:</strong> {cleanError}
+          </p>
+          <button
+            onClick={() => setReauthorizing(true)}
+            className="mt-2 text-[11px] px-3 py-1 rounded-md"
+            style={{ background: '#92400e', color: '#fff', cursor: 'pointer' }}
+          >
+            Fix: Re-authorize {tracker.name}
+          </button>
+        </div>
+      )}
+      {reauthorizing && (
+        <div className="mb-3">
+          <p className="text-[12px] mb-2" style={{ color: 'var(--ink-2)' }}>
+            Re-authorize {tracker.name}:
+          </p>
+          <TrackerSetup tracker={tracker} reauthorize />
+          <button onClick={() => setReauthorizing(false)} className="mt-2 text-[11px]" style={{ color: 'var(--ink-4)', cursor: 'pointer' }}>
+            Cancel
+          </button>
+        </div>
+      )}
+      {!reauthorizing && (
+        <>
+          <p className="text-[12px] leading-relaxed mb-3" style={{ color: 'var(--ink-3)' }}>
+            Disconnect removes the stored credentials. The daemon reloads automatically.
+          </p>
+          <button
+            onClick={onDisconnect}
+            disabled={disconnecting}
+            className="text-[12px] px-3 py-1.5 rounded-md transition-opacity"
+            style={{ color: '#e53e3e', border: '1px solid #e53e3e', opacity: disconnecting ? 0.5 : 1, cursor: disconnecting ? 'not-allowed' : 'pointer', background: 'transparent' }}
+          >
+            {disconnecting ? 'Disconnecting…' : `Disconnect ${tracker.name}`}
+          </button>
+        </>
+      )}
+    </div>
+  )
+}
+
+function TrackerSetup({ tracker, reauthorize }: { tracker: (typeof TRACKERS)[number]; reauthorize?: boolean }) {
+  // Jira supports both OAuth and API token — show a chooser (or force API token on reauth)
+  const [jiraMode, setJiraMode] = useState<'oauth' | 'token'>(reauthorize ? 'token' : 'oauth')
+  if (tracker.id === 'jira') {
+    return (
+      <div style={{ background: 'var(--surface-2)' }}>
+        {/* Mode toggle */}
+        <div className="px-4 pt-2 pb-1 flex gap-2">
+          <button
+            onClick={() => setJiraMode('oauth')}
+            className="text-[11px] px-3 py-1 rounded-md"
+            style={{ background: jiraMode === 'oauth' ? 'var(--accent)' : 'var(--tint)', color: jiraMode === 'oauth' ? '#fff' : 'var(--ink-3)', cursor: 'pointer' }}
+          >Browser OAuth</button>
+          <button
+            onClick={() => setJiraMode('token')}
+            className="text-[11px] px-3 py-1 rounded-md"
+            style={{ background: jiraMode === 'token' ? 'var(--accent)' : 'var(--tint)', color: jiraMode === 'token' ? '#fff' : 'var(--ink-3)', cursor: 'pointer' }}
+          >API Token</button>
+        </div>
+        {jiraMode === 'oauth' ? <OAuthSetup tracker={tracker} /> : <TokenSetup tracker={tracker} />}
+      </div>
+    )
+  }
+  if (tracker.oauth) return <OAuthSetup tracker={tracker} />
   if (tracker.id === 'azure_devops') return <AzureDevOpsSetup tracker={tracker} />
   return <TokenSetup tracker={tracker} />
 }
@@ -786,67 +884,138 @@ function AzureDevOpsSetup({ tracker }: { tracker: (typeof TRACKERS)[number] }) {
   )
 }
 
-function OAuthSetup({ oauth }: { oauth: { command: string; hint: string } }) {
+function OAuthSetup({ tracker }: { tracker: (typeof TRACKERS)[number] }) {
+  const [status, setStatus] = useState<'idle' | 'waiting' | 'done' | 'error'>('idle')
+  const [error, setError] = useState<string | null>(null)
+
+  const startOAuth = async () => {
+    setStatus('waiting')
+    setError(null)
+    try {
+      const r = await fetch(`/api/auth/oauth/start?provider=${tracker.id}`, { method: 'POST' })
+      if (!r.ok) { const b = await r.json(); setError(b.error ?? 'Failed to start'); setStatus('error'); return }
+      // Poll until connected (up to 3 minutes)
+      const deadline = Date.now() + 180_000
+      const poll = setInterval(async () => {
+        if (Date.now() > deadline) { clearInterval(poll); setStatus('error'); setError('Timed out — try again'); return }
+        const ir = await fetch('/api/integrations').catch(() => null)
+        if (!ir?.ok) return
+        const data = await ir.json()
+        if (data[tracker.id]) { clearInterval(poll); setStatus('done') }
+      }, 2_000)
+    } catch (e) {
+      setError(String(e)); setStatus('error')
+    }
+  }
+
   return (
-    <div className="px-4 pb-4 pt-1" style={{ background: 'var(--surface-2)' }}>
-      <ol className="space-y-3">
-        <li className="flex gap-3">
-          <StepNum n={1} />
-          <div className="min-w-0 flex-1">
-            <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-2)' }}>
-              {oauth.hint} In a terminal, run:
-            </p>
-            <CopyBlock text={oauth.command} />
-            <p className="mt-2 text-[11px] leading-relaxed" style={{ color: 'var(--ink-3)' }}>
-              Your browser opens — pick your site and click Accept.
-            </p>
-          </div>
-        </li>
-        <li className="flex gap-3">
-          <StepNum n={2} />
+    <div className="px-4 pb-4 pt-2" style={{ background: 'var(--surface-2)' }}>
+      {status === 'idle' && (
+        <div className="space-y-3">
           <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-2)' }}>
-            Run <CodeChip text="meridian restart" />. Your tasks appear here within a minute.
+            {tracker.oauth?.hint}
           </p>
-        </li>
-      </ol>
+          <button
+            onClick={startOAuth}
+            className="text-[12px] px-4 py-2 rounded-md font-medium transition-opacity"
+            style={{ background: 'var(--accent)', color: '#fff', cursor: 'pointer' }}
+          >
+            Connect {tracker.name} →
+          </button>
+        </div>
+      )}
+      {status === 'waiting' && (
+        <div className="space-y-2">
+          <p className="text-[12px]" style={{ color: 'var(--ink-2)' }}>
+            Your browser should have opened. Authorize the app, then come back here.
+          </p>
+          <p className="text-[11px]" style={{ color: 'var(--ink-4)' }}>Waiting for authorization…</p>
+        </div>
+      )}
+      {status === 'done' && (
+        <p className="text-[12px]" style={{ color: 'var(--success)' }}>✓ Connected! Your tasks will appear shortly.</p>
+      )}
+      {status === 'error' && (
+        <div className="space-y-2">
+          <p className="text-[12px]" style={{ color: '#e53e3e' }}>{error ?? 'OAuth failed.'}</p>
+          <button onClick={() => setStatus('idle')} className="text-[11px]" style={{ color: 'var(--accent)', cursor: 'pointer' }}>Try again</button>
+        </div>
+      )}
     </div>
   )
 }
 
 function TokenSetup({ tracker }: { tracker: (typeof TRACKERS)[number] }) {
+  const fields = TOKEN_FIELDS[tracker.id] ?? []
+  const [values, setValues] = useState<Record<string, string>>({})
+  const [status, setStatus] = useState<'idle' | 'saving' | 'done' | 'error'>('idle')
+  const [error, setError] = useState<string | null>(null)
+
+  const requiredFields = fields.filter(f => f.required)
+  const allFilled = requiredFields.every(f => values[f.name]?.trim())
+
+  const save = async () => {
+    setStatus('saving'); setError(null)
+    try {
+      const r = await fetch('/api/auth/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider: tracker.id, ...values }),
+      })
+      const body = await r.json()
+      if (!r.ok) { setError(body.error ?? 'Save failed'); setStatus('error'); return }
+      setStatus('done')
+    } catch (e) { setError(String(e)); setStatus('error') }
+  }
+
+  if (status === 'done') {
+    return (
+      <div className="px-4 pb-4 pt-2" style={{ background: 'var(--surface-2)' }}>
+        <p className="text-[12px]" style={{ color: 'var(--success)' }}>✓ Saved! Your tasks will appear within a minute.</p>
+      </div>
+    )
+  }
+
   return (
-    <div className="px-4 pb-4 pt-1" style={{ background: 'var(--surface-2)' }}>
-      <ol className="space-y-3">
-        <li className="flex gap-3">
-          <StepNum n={1} />
-          <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-2)' }}>
-            {tracker.tokenHint}{' '}
-            <a href={tracker.tokenUrl} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)' }}>
-              Open ↗
-            </a>
-          </p>
-        </li>
-        <li className="flex gap-3">
-          <StepNum n={2} />
-          <div className="min-w-0 flex-1">
-            <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-2)' }}>
-              In a terminal, run <CodeChip text="meridian config edit" /> and add:
-            </p>
-            <CopyBlock text={tracker.env ?? ''} />
-            {tracker.note && (
-              <p className="mt-2 text-[11px] leading-relaxed" style={{ color: 'var(--ink-3)' }}>
-                {tracker.note}
-              </p>
-            )}
+    <div className="px-4 pb-4 pt-2" style={{ background: 'var(--surface-2)' }}>
+      {tracker.tokenHint && (
+        <p className="text-[12px] leading-relaxed mb-3" style={{ color: 'var(--ink-2)' }}>
+          {tracker.tokenHint}{' '}
+          {tracker.tokenUrl && (
+            <a href={tracker.tokenUrl} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)' }}>Open ↗</a>
+          )}
+        </p>
+      )}
+      <div className="space-y-2">
+        {fields.map(f => (
+          <div key={f.name}>
+            <label className="block text-[11px] mb-0.5" style={{ color: 'var(--ink-3)' }}>
+              {f.label}{f.required ? '' : ' (optional)'}
+            </label>
+            <input
+              type={f.secret ? 'password' : 'text'}
+              value={values[f.name] ?? ''}
+              onChange={e => setValues(v => ({ ...v, [f.name]: e.target.value }))}
+              placeholder={f.placeholder}
+              className="w-full font-mono text-[11px] px-2 py-1.5 rounded-md border"
+              style={{ color: 'var(--ink)', background: 'var(--surface)', borderColor: 'var(--rule)', outline: 'none' }}
+            />
           </div>
-        </li>
-        <li className="flex gap-3">
-          <StepNum n={3} />
-          <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-2)' }}>
-            Save, then run <CodeChip text="meridian restart" />. Your tasks appear here within a minute.
-          </p>
-        </li>
-      </ol>
+        ))}
+      </div>
+      {error && <p className="mt-2 text-[11px]" style={{ color: '#e53e3e' }}>{error}</p>}
+      <button
+        onClick={save}
+        disabled={!allFilled || status === 'saving'}
+        className="mt-3 text-[12px] px-4 py-2 rounded-md font-medium transition-opacity"
+        style={{
+          background: 'var(--accent)', color: '#fff',
+          opacity: (!allFilled || status === 'saving') ? 0.5 : 1,
+          cursor: (!allFilled || status === 'saving') ? 'not-allowed' : 'pointer',
+        }}
+      >
+        {status === 'saving' ? 'Saving…' : `Connect ${tracker.name}`}
+      </button>
     </div>
   )
 }

--- a/ui/components/views/TasksView.tsx
+++ b/ui/components/views/TasksView.tsx
@@ -34,7 +34,7 @@ function epicColor(epicKey: string | null): string {
   return EPIC_PALETTE[h % EPIC_PALETTE.length]
 }
 
-export default function TasksView({ focusKey }: { focusKey?: string | null }) {
+export default function TasksView({ focusKey, openIntegrations }: { focusKey?: string | null; openIntegrations?: boolean }) {
   const [data, setData] = useState<TasksResponse | null>(null)
   const [todaySessions, setTodaySessions] = useState<TodayResponse['sessions']>([])
   const [integrations, setIntegrations] = useState<IntegrationsResponse | null>(null)
@@ -43,7 +43,7 @@ export default function TasksView({ focusKey }: { focusKey?: string | null }) {
   const [lastSynced, setLastSynced] = useState<Date | null>(null)
   const [syncError, setSyncError] = useState<string | null>(null)
   const [providerFilter, setProviderFilter] = useState<string>('all')
-  const [showIntegrations, setShowIntegrations] = useState(false)
+  const [showIntegrations, setShowIntegrations] = useState(openIntegrations ?? false)
   const [collapsedEpics, setCollapsedEpics] = useState<Set<string>>(new Set())
 
   const fetchTasks = () => {

--- a/ui/lib/log-tail.ts
+++ b/ui/lib/log-tail.ts
@@ -26,9 +26,20 @@ type Controller = ReadableStreamDefaultController<Uint8Array>
 const encoder = new TextEncoder()
 const controllers = new Set<Controller>()
 
-let watcherStarted = false
-let currentLogPath = ''
-let filePosition = 0
+// Store watcher handle on globalThis so Next.js HMR module re-evaluation
+// doesn't spawn a second watcher while the first keeps running.
+const g = globalThis as typeof globalThis & {
+  _meridianWatcher?: fs.FSWatcher
+  _meridianLogPath?: string
+  _meridianFilePos?: number
+}
+
+function watcherStarted(): boolean { return !!g._meridianWatcher }
+function setWatcher(w: fs.FSWatcher | undefined) { g._meridianWatcher = w }
+function getCurrentLogPath(): string { return g._meridianLogPath ?? '' }
+function setCurrentLogPath(p: string) { g._meridianLogPath = p }
+function getFilePosition(): number { return g._meridianFilePos ?? 0 }
+function setFilePosition(n: number) { g._meridianFilePos = n }
 
 function logDir(): string {
   return process.env.MERIDIAN_LOG_DIR ?? path.join(os.homedir(), '.meridian', 'logs')
@@ -75,19 +86,19 @@ function readNewLines() {
   const logPath = todayLogPath()
 
   // If the date rolled over, reset position for the new file
-  if (logPath !== currentLogPath) {
-    currentLogPath = logPath
-    filePosition = 0
+  if (logPath !== getCurrentLogPath()) {
+    setCurrentLogPath(logPath)
+    setFilePosition(0)
   }
 
   try {
     const stat = fs.statSync(logPath)
-    if (stat.size <= filePosition) return
+    if (stat.size <= getFilePosition()) return
     const fd = fs.openSync(logPath, 'r')
-    const buf = Buffer.alloc(stat.size - filePosition)
-    fs.readSync(fd, buf as unknown as Uint8Array, 0, buf.length, filePosition)
+    const buf = Buffer.alloc(stat.size - getFilePosition())
+    fs.readSync(fd, buf as unknown as Uint8Array, 0, buf.length, getFilePosition())
     fs.closeSync(fd)
-    filePosition = stat.size
+    setFilePosition(stat.size)
 
     const lines = buf.toString('utf8').split('\n').filter(Boolean)
     const entries = lines.map(parseLine).filter((e): e is LogEntry => e !== null)
@@ -98,18 +109,17 @@ function readNewLines() {
 }
 
 function ensureWatcher() {
-  if (watcherStarted) return
-  watcherStarted = true
-  currentLogPath = todayLogPath()
+  if (watcherStarted()) return
+  setCurrentLogPath(todayLogPath())
 
   // Watch the directory so we catch both writes to today's file and the moment
   // a new dated file appears at midnight
   try {
-    fs.watch(logDir(), { persistent: false }, (_event, filename) => {
+    setWatcher(fs.watch(logDir(), { persistent: false }, (_event, filename) => {
       if (filename?.startsWith('meridian-rust.jsonl')) {
         readNewLines()
       }
-    })
+    }))
   } catch {
     // Log dir not yet created — fall back to polling until it appears
     const poll = setInterval(() => {
@@ -145,8 +155,8 @@ export function readRecentLines(n: number): Promise<LogEntry[]> {
     })
     rl.on('close', () => {
       // Set position so the SSE watcher picks up from here
-      try { filePosition = fs.statSync(logPath).size } catch { /* ignore */ }
-      currentLogPath = logPath
+      try { setFilePosition(fs.statSync(logPath).size) } catch { /* ignore */ }
+      setCurrentLogPath(logPath)
       resolve(entries.slice(-n))
     })
     rl.on('error', () => resolve([]))

--- a/ui/lib/log-tail.ts
+++ b/ui/lib/log-tail.ts
@@ -1,0 +1,163 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Singleton that tails the daemon's JSONL log file and broadcasts new entries
+// to all open SSE connections. Uses fs.watch() (kqueue/inotify) on the log
+// directory — reliable for append-only files unlike SQLite WAL.
+//
+// One watcher per process lifetime. N open browser tabs share one watcher and
+// one file position — zero extra CPU per additional tab.
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import readline from 'readline'
+
+export interface LogEntry {
+  timestamp: string
+  level: string
+  message: string
+  target: string
+  fields: Record<string, unknown>
+  span?: string
+}
+
+type Controller = ReadableStreamDefaultController<Uint8Array>
+
+const encoder = new TextEncoder()
+const controllers = new Set<Controller>()
+
+let watcherStarted = false
+let currentLogPath = ''
+let filePosition = 0
+
+function logDir(): string {
+  return process.env.MERIDIAN_LOG_DIR ?? path.join(os.homedir(), '.meridian', 'logs')
+}
+
+function todayLogPath(): string {
+  const date = new Date().toISOString().slice(0, 10)
+  return path.join(logDir(), `meridian-rust.jsonl.${date}`)
+}
+
+function parseLine(raw: string): LogEntry | null {
+  try {
+    const obj = JSON.parse(raw)
+    return {
+      timestamp: obj.timestamp ?? '',
+      level: (obj.level ?? 'INFO').toUpperCase(),
+      message: obj.fields?.message ?? obj.message ?? '',
+      target: obj.target ?? '',
+      span: obj.span?.name,
+      fields: obj.fields ? (() => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { message: _m, scope: _s, ...rest } = obj.fields
+        return rest
+      })() : {},
+    }
+  } catch {
+    return null
+  }
+}
+
+function broadcast(entries: LogEntry[]) {
+  if (entries.length === 0 || controllers.size === 0) return
+  const payload = encoder.encode(`data: ${JSON.stringify(entries)}\n\n`)
+  for (const ctrl of controllers) {
+    try {
+      ctrl.enqueue(payload)
+    } catch {
+      controllers.delete(ctrl)
+    }
+  }
+}
+
+function readNewLines() {
+  const logPath = todayLogPath()
+
+  // If the date rolled over, reset position for the new file
+  if (logPath !== currentLogPath) {
+    currentLogPath = logPath
+    filePosition = 0
+  }
+
+  try {
+    const stat = fs.statSync(logPath)
+    if (stat.size <= filePosition) return
+    const fd = fs.openSync(logPath, 'r')
+    const buf = Buffer.alloc(stat.size - filePosition)
+    fs.readSync(fd, buf as unknown as Uint8Array, 0, buf.length, filePosition)
+    fs.closeSync(fd)
+    filePosition = stat.size
+
+    const lines = buf.toString('utf8').split('\n').filter(Boolean)
+    const entries = lines.map(parseLine).filter((e): e is LogEntry => e !== null)
+    broadcast(entries)
+  } catch {
+    // Log file not yet created (daemon not started today) — ignore
+  }
+}
+
+function ensureWatcher() {
+  if (watcherStarted) return
+  watcherStarted = true
+  currentLogPath = todayLogPath()
+
+  // Watch the directory so we catch both writes to today's file and the moment
+  // a new dated file appears at midnight
+  try {
+    fs.watch(logDir(), { persistent: false }, (_event, filename) => {
+      if (filename?.startsWith('meridian-rust.jsonl')) {
+        readNewLines()
+      }
+    })
+  } catch {
+    // Log dir not yet created — fall back to polling until it appears
+    const poll = setInterval(() => {
+      try {
+        if (fs.existsSync(logDir())) {
+          clearInterval(poll)
+          ensureWatcher()
+        }
+      } catch { /* ignore */ }
+    }, 5_000)
+  }
+}
+
+/** Read the last `n` lines from the current or most-recent log file. */
+export function readRecentLines(n: number): Promise<LogEntry[]> {
+  return new Promise((resolve) => {
+    // Try today's file first, fall back to yesterday's if today doesn't exist yet
+    const candidates = [todayLogPath()]
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10)
+    candidates.push(path.join(logDir(), `meridian-rust.jsonl.${yesterday}`))
+
+    let logPath = ''
+    for (const p of candidates) {
+      if (fs.existsSync(p)) { logPath = p; break }
+    }
+    if (!logPath) return resolve([])
+
+    const entries: LogEntry[] = []
+    const rl = readline.createInterface({ input: fs.createReadStream(logPath) })
+    rl.on('line', (line) => {
+      const e = parseLine(line)
+      if (e) entries.push(e)
+    })
+    rl.on('close', () => {
+      // Set position so the SSE watcher picks up from here
+      try { filePosition = fs.statSync(logPath).size } catch { /* ignore */ }
+      currentLogPath = logPath
+      resolve(entries.slice(-n))
+    })
+    rl.on('error', () => resolve([]))
+  })
+}
+
+export function subscribeToTail(ctrl: Controller) {
+  controllers.add(ctrl)
+  ensureWatcher()
+}
+
+export function unsubscribeFromTail(ctrl: Controller) {
+  controllers.delete(ctrl)
+}

--- a/ui/lib/notices-store.ts
+++ b/ui/lib/notices-store.ts
@@ -71,3 +71,10 @@ export function subscribe(ctrl: Controller): void {
 export function unsubscribe(ctrl: Controller): void {
   controllers.delete(ctrl)
 }
+
+// Force an immediate re-read and broadcast — call after writing to system_notices
+// from an API route (e.g. after clearing a notice on successful auth).
+export function refresh(): void {
+  lastSnapshot = '' // invalidate snapshot so broadcast always pushes
+  broadcast()
+}

--- a/ui/lib/notices-store.ts
+++ b/ui/lib/notices-store.ts
@@ -4,6 +4,9 @@
 // cache keeps this alive for the lifetime of the process — one shared
 // setInterval, one Set of open SSE controllers. Adding more browser tabs adds
 // controllers to the Set but does NOT create more DB queries or more timers.
+//
+// State is stored on globalThis so Next.js HMR module re-evaluation doesn't
+// spawn a second broadcast loop while the first keeps running.
 
 import getDb from '@/lib/db'
 
@@ -18,10 +21,19 @@ export interface Notice {
 
 type Controller = ReadableStreamDefaultController<Uint8Array>
 
-const controllers = new Set<Controller>()
+// Store all mutable singleton state on globalThis to survive HMR re-evaluation.
+const g = globalThis as typeof globalThis & {
+  _meridianNoticesControllers?: Set<Controller>
+  _meridianNoticesInterval?: ReturnType<typeof setInterval>
+  _meridianNoticesSnapshot?: string
+}
+if (!g._meridianNoticesControllers) g._meridianNoticesControllers = new Set()
+
 const encoder = new TextEncoder()
-let lastSnapshot = ''
-let intervalStarted = false
+
+function controllers(): Set<Controller> { return g._meridianNoticesControllers! }
+function getSnapshot(): string { return g._meridianNoticesSnapshot ?? '' }
+function setSnapshot(s: string) { g._meridianNoticesSnapshot = s }
 
 function queryNotices(): Notice[] {
   try {
@@ -37,44 +49,48 @@ function queryNotices(): Notice[] {
 }
 
 function broadcast() {
+  const ctrls = controllers()
+  if (ctrls.size === 0) return
   const notices = queryNotices()
   const snapshot = JSON.stringify(notices)
-  if (snapshot === lastSnapshot) return
-  lastSnapshot = snapshot
+  if (snapshot === getSnapshot()) return
+  setSnapshot(snapshot)
   const payload = encoder.encode(`data: ${snapshot}\n\n`)
-  for (const ctrl of controllers) {
+  for (const ctrl of ctrls) {
     try {
       ctrl.enqueue(payload)
     } catch {
       // Controller closed — remove it
-      controllers.delete(ctrl)
+      ctrls.delete(ctrl)
     }
   }
 }
 
 function ensureInterval() {
-  if (intervalStarted) return
-  intervalStarted = true
+  if (g._meridianNoticesInterval != null) return
   // One shared interval — 30s is right for error banners (they persist until fixed)
-  setInterval(broadcast, 30_000)
+  g._meridianNoticesInterval = setInterval(broadcast, 30_000)
 }
 
 export function subscribe(ctrl: Controller): void {
-  controllers.add(ctrl)
+  controllers().add(ctrl)
   ensureInterval()
-  // Send current state immediately on connect so the browser doesn't wait 30s
+  // Send current state immediately on connect so the browser doesn't wait 30s.
+  // Set lastSnapshot BEFORE enqueueing so a concurrent refresh() sees the
+  // up-to-date snapshot and doesn't overwrite it with a stale value.
   const notices = queryNotices()
-  lastSnapshot = JSON.stringify(notices)
-  ctrl.enqueue(encoder.encode(`data: ${JSON.stringify(notices)}\n\n`))
+  const snapshot = JSON.stringify(notices)
+  setSnapshot(snapshot)
+  ctrl.enqueue(encoder.encode(`data: ${snapshot}\n\n`))
 }
 
 export function unsubscribe(ctrl: Controller): void {
-  controllers.delete(ctrl)
+  controllers().delete(ctrl)
 }
 
 // Force an immediate re-read and broadcast — call after writing to system_notices
 // from an API route (e.g. after clearing a notice on successful auth).
 export function refresh(): void {
-  lastSnapshot = '' // invalidate snapshot so broadcast always pushes
+  setSnapshot('') // invalidate snapshot so broadcast always pushes
   broadcast()
 }

--- a/ui/lib/notices-store.ts
+++ b/ui/lib/notices-store.ts
@@ -1,0 +1,73 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Module-level singleton that owns the SSE broadcast state. Node.js module
+// cache keeps this alive for the lifetime of the process — one shared
+// setInterval, one Set of open SSE controllers. Adding more browser tabs adds
+// controllers to the Set but does NOT create more DB queries or more timers.
+
+import getDb from '@/lib/db'
+
+export interface Notice {
+  notice_id: string
+  severity: 'error' | 'warning'
+  title: string
+  detail: string
+  remedy: string | null
+  raised_at: string
+}
+
+type Controller = ReadableStreamDefaultController<Uint8Array>
+
+const controllers = new Set<Controller>()
+const encoder = new TextEncoder()
+let lastSnapshot = ''
+let intervalStarted = false
+
+function queryNotices(): Notice[] {
+  try {
+    const db = getDb()
+    return db
+      .prepare(
+        'SELECT notice_id, severity, title, detail, remedy, raised_at FROM system_notices ORDER BY raised_at DESC',
+      )
+      .all() as Notice[]
+  } catch {
+    return []
+  }
+}
+
+function broadcast() {
+  const notices = queryNotices()
+  const snapshot = JSON.stringify(notices)
+  if (snapshot === lastSnapshot) return
+  lastSnapshot = snapshot
+  const payload = encoder.encode(`data: ${snapshot}\n\n`)
+  for (const ctrl of controllers) {
+    try {
+      ctrl.enqueue(payload)
+    } catch {
+      // Controller closed — remove it
+      controllers.delete(ctrl)
+    }
+  }
+}
+
+function ensureInterval() {
+  if (intervalStarted) return
+  intervalStarted = true
+  // One shared interval — 30s is right for error banners (they persist until fixed)
+  setInterval(broadcast, 30_000)
+}
+
+export function subscribe(ctrl: Controller): void {
+  controllers.add(ctrl)
+  ensureInterval()
+  // Send current state immediately on connect so the browser doesn't wait 30s
+  const notices = queryNotices()
+  lastSnapshot = JSON.stringify(notices)
+  ctrl.enqueue(encoder.encode(`data: ${JSON.stringify(notices)}\n\n`))
+}
+
+export function unsubscribe(ctrl: Controller): void {
+  controllers.delete(ctrl)
+}


### PR DESCRIPTION
## Summary

- **System notices fault bus** — `system_notices` SQLite table (migration 037) + `src/notices.rs` with centralized `raise`/`clear` helpers. ETL failures, MLX failures, and all five PM provider sync errors write to it; on recovery each calls `clear`.
- **SSE notice stream** — `NoticeBar` in root layout subscribes to `/api/notices/stream`. One shared `setInterval(30s)` per server process — N browser tabs costs 1 DB query, not N. Banners show severity + remedy as inline code chip.
- **Jira auth priority fix** — `JIRA_API_TOKEN` env var now beats stale OAuth token in `~/.meridian/oauth/jira.json` (mirrors gh/Vercel/Stripe CLI behaviour). Added `tracing::debug!(auth_method)` at resolution.
- **Structured logging** — `tracing::info!/debug!/warn!/error!` with structured fields added to ETL batch loop, session close, active_session upsert, config load, coding-agent indexer, and all five PM providers.
- **Log viewer at `/logs`** — 200-entry initial load, SSE tail via `fs.watch()` (zero CPU between events), level filter (ALL/ERROR/WARN/INFO/DEBUG), Pause/Resume, click-to-expand JSON fields, 2000-entry cap, auto-scroll.
- **UI auth forms in Tasks page** — OAuth flow + API token forms for Jira, Linear, GitHub. No terminal needed. `/api/auth/token` writes to `.env` and signals daemon to reload via `daemon.sock`. `/api/auth/oauth/start` spawns `meridian oauth-login <provider>` as a detached background process.
- **PM provider missing fields** — `start_date`, `due_date`, `tags`, `assignee_name`, `sprint_name` re-applied across linear.rs, trello.rs, github.rs, azure_devops.rs.

## Test plan

- [ ] Fresh install: blank Tasks page shows TrackerSetup with OAuth + API token tabs for Jira; other providers show token form
- [ ] Submit valid Jira API token: banner disappears, tasks load
- [ ] Submit bad token: sync error notice appears in NoticeBar on next poll cycle
- [ ] Kill MLX server: `mlx.down` notice appears within 30s
- [ ] ETL failure (bad DB path): `etl.failed` notice appears; fix path and it clears
- [ ] `/logs` page: entries stream in live, level filter works, expand a row shows full JSON fields
- [ ] Open 3 tabs — only 1 DB query per 30s interval (verify via RUST_LOG=debug)
- [ ] `JIRA_API_TOKEN` set + stale `~/.meridian/oauth/jira.json` present → API token wins (auth_method=api_token in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)