### PR TITLE
fix(tasks): sort task sessions descending

### DIFF
--- a/ui/components/views/TasksView.tsx
+++ b/ui/components/views/TasksView.tsx
@@ -327,7 +327,7 @@ function TaskRow({ task, selected, onSelect, epicColor: eColor, showProvider }: 
 }
 
 function TaskDetail({ task, sessions }: { task: TaskSummary; sessions: TodayResponse['sessions'] }) {
-  const sortedSessions = [...sessions].sort((a, b) => a.started_at.localeCompare(b.started_at))
+  const sortedSessions = [...sessions].sort((a, b) => b.started_at.localeCompare(a.started_at))
   const providerMeta = PROVIDER_META[task.provider]
   const eColor = epicColor(task.epic_title)
 


### PR DESCRIPTION
## Summary
- Sessions listed under each task in the Tasks page now appear most-recent first (descending by `started_at`)

## Change
Single-line sort flip in `TaskDetail` (`TasksView.tsx:330`): `a.localeCompare(b)` → `b.localeCompare(a)`

## Test plan
- [ ] Open Tasks page, click a task with multiple sessions today — most recent session appears at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)