### PR TITLE
fix(ui): gate standalone output to production so dev server boots

### DIFF
--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -20,7 +20,12 @@ const nextConfig: NextConfig = {
   // crash-loops the standalone server. So package-release.sh packs the standalone
   // into `ui.tar.gz` (tar preserves symlinks; npm ships it as one opaque file) and
   // install-from-bundle.sh extracts it on the user's machine — keeping Turbopack.
-  output: 'standalone',
+  // Only emit the standalone server bundle for production builds. Applying
+  // `output: 'standalone'` in dev makes Next 16's Turbopack mis-resolve the
+  // distDir relative to the pinned `outputFileTracingRoot`, crashing
+  // `next dev --turbopack` with "Invalid distDirRoot". Production builds set
+  // NODE_ENV=production, so the shipped standalone bundle is unaffected.
+  output: process.env.NODE_ENV === 'production' ? 'standalone' : undefined,
   // Pin the standalone file-tracing root to this `ui/` dir. The repo root also
   // has a package-lock.json, so Next otherwise infers the monorepo root and
   // nests the output as `.next/standalone/ui/server.js` — which breaks the


### PR DESCRIPTION
## Problem
`next dev --turbopack` crashes on startup with:

```
TurbopackInternalError: Invalid distDirRoot: ".next". distDirRoot should not navigate out of the projectPath.
```

`ui/next.config.ts` sets `output: 'standalone'` unconditionally. Combined with the pinned `outputFileTracingRoot` / `turbopack.root` (both `ui/`), Next 16.2's Turbopack mis-resolves the dev `distDir` and aborts. This blocks the local hot-reload dev server (`dev-start.sh` window #3 and `cd ui && npm run dev`).

## Fix
Gate `output: 'standalone'` on `NODE_ENV === 'production'`. Standalone output is purely a production/packaging concern; it has no purpose in dev.

```ts
output: process.env.NODE_ENV === 'production' ? 'standalone' : undefined,
```

## Why this is safe
- `npm run build` runs with `NODE_ENV=production` → standalone bundle still emitted exactly as before. `package-release.sh` / `install-from-bundle.sh` are unaffected.
- `next dev` runs with `NODE_ENV=development` → no standalone tracing → Turbopack boots clean.

## Verification
- `next dev --turbopack` → `✓ Ready` and serves (was a hard crash before).
- `output: 'standalone'` still active for production builds (NODE_ENV gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)