### PR TITLE
fix(ui): render display serif in Georgia to match design

### DIFF
--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -9,7 +9,7 @@
   /* Fonts */
   --font-sans:  var(--font-geist-sans);
   --font-mono:  var(--font-geist-mono);
-  --font-serif: 'Iowan Old Style', Georgia, serif;
+  --font-serif: Georgia, 'Times New Roman', serif;
 
   /* Colors → Tailwind utilities (text-*, bg-*, border-*) */
   --color-paper:       var(--paper);
@@ -84,7 +84,7 @@ body, .font-sans {
 }
 
 .font-serif {
-  font-family: 'Iowan Old Style', Georgia, serif;
+  font-family: Georgia, 'Times New Roman', serif;
   font-feature-settings: 'liga', 'dlig';
 }
 
@@ -198,7 +198,7 @@ html.density-comfy   .density-pad { padding-top: 1.25rem; padding-bottom: 1.25re
 
 /* 72px — hero: Today page main heading */
 .type-hero {
-  font-family: 'Iowan Old Style', Georgia, serif;
+  font-family: Georgia, 'Times New Roman', serif;
   font-size: 72px;
   line-height: 0.95;
   letter-spacing: -0.025em;
@@ -207,7 +207,7 @@ html.density-comfy   .density-pad { padding-top: 1.25rem; padding-bottom: 1.25re
 
 /* 56px — page title: main heading on every page */
 .type-title {
-  font-family: 'Iowan Old Style', Georgia, serif;
+  font-family: Georgia, 'Times New Roman', serif;
   font-size: 56px;
   line-height: 1;
   letter-spacing: -0.025em;
@@ -216,7 +216,7 @@ html.density-comfy   .density-pad { padding-top: 1.25rem; padding-bottom: 1.25re
 
 /* 36px — section heading: task detail title, sub-section heads */
 .type-heading {
-  font-family: 'Iowan Old Style', Georgia, serif;
+  font-family: Georgia, 'Times New Roman', serif;
   font-size: 36px;
   line-height: 1.1;
   letter-spacing: -0.025em;
@@ -225,7 +225,7 @@ html.density-comfy   .density-pad { padding-top: 1.25rem; padding-bottom: 1.25re
 
 /* 26px — stat: insight callout / narrative text */
 .type-stat {
-  font-family: 'Iowan Old Style', Georgia, serif;
+  font-family: Georgia, 'Times New Roman', serif;
   font-size: 26px;
   line-height: 1.2;
   letter-spacing: -0.01em;
@@ -234,7 +234,7 @@ html.density-comfy   .density-pad { padding-top: 1.25rem; padding-bottom: 1.25re
 
 /* 28px italic — active: "You're on · task name" live heading */
 .type-active {
-  font-family: 'Iowan Old Style', Georgia, serif;
+  font-family: Georgia, 'Times New Roman', serif;
   font-size: 28px;
   line-height: 1;
   font-style: italic;
@@ -244,7 +244,7 @@ html.density-comfy   .density-pad { padding-top: 1.25rem; padding-bottom: 1.25re
 
 /* 24px italic — empty: empty state messages */
 .type-empty {
-  font-family: 'Iowan Old Style', Georgia, serif;
+  font-family: Georgia, 'Times New Roman', serif;
   font-size: 24px;
   line-height: 1.2;
   font-style: italic;
@@ -254,7 +254,7 @@ html.density-comfy   .density-pad { padding-top: 1.25rem; padding-bottom: 1.25re
 
 /* 22px — callout: insight card headline */
 .type-callout {
-  font-family: 'Iowan Old Style', Georgia, serif;
+  font-family: Georgia, 'Times New Roman', serif;
   font-size: 22px;
   line-height: 1.2;
   letter-spacing: 0;
@@ -263,7 +263,7 @@ html.density-comfy   .density-pad { padding-top: 1.25rem; padding-bottom: 1.25re
 
 /* 22px italic — wordmark: "meridian" in sidebar — slight tracking is intentional */
 .type-wordmark {
-  font-family: 'Iowan Old Style', Georgia, serif;
+  font-family: Georgia, 'Times New Roman', serif;
   font-size: 22px;
   line-height: 1;
   font-style: italic;

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -9,7 +9,7 @@
   /* Fonts */
   --font-sans:  var(--font-geist-sans);
   --font-mono:  var(--font-geist-mono);
-  --font-serif: var(--font-instrument-serif);
+  --font-serif: 'Iowan Old Style', Georgia, serif;
 
   /* Colors → Tailwind utilities (text-*, bg-*, border-*) */
   --color-paper:       var(--paper);
@@ -73,8 +73,6 @@ html, body {
 }
 
 * { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-/* Serif glyphs rely on fine strokes — subpixel rendering preserves them better */
-.font-serif { -webkit-font-smoothing: auto; -moz-osx-font-smoothing: auto; }
 
 body, .font-sans {
   font-feature-settings: 'ss01', 'cv11';
@@ -86,7 +84,7 @@ body, .font-sans {
 }
 
 .font-serif {
-  font-family: var(--font-instrument-serif), 'Instrument Serif', Georgia, serif;
+  font-family: 'Iowan Old Style', Georgia, serif;
   font-feature-settings: 'liga', 'dlig';
 }
 
@@ -200,91 +198,75 @@ html.density-comfy   .density-pad { padding-top: 1.25rem; padding-bottom: 1.25re
 
 /* 72px — hero: Today page main heading */
 .type-hero {
-  font-family: var(--font-instrument-serif), 'Instrument Serif', Georgia, serif;
+  font-family: 'Iowan Old Style', Georgia, serif;
   font-size: 72px;
   line-height: 0.95;
   letter-spacing: -0.025em;
   font-feature-settings: 'liga', 'dlig';
-  -webkit-font-smoothing: auto;
-  -moz-osx-font-smoothing: auto;
 }
 
 /* 56px — page title: main heading on every page */
 .type-title {
-  font-family: var(--font-instrument-serif), 'Instrument Serif', Georgia, serif;
+  font-family: 'Iowan Old Style', Georgia, serif;
   font-size: 56px;
   line-height: 1;
   letter-spacing: -0.025em;
   font-feature-settings: 'liga', 'dlig';
-  -webkit-font-smoothing: auto;
-  -moz-osx-font-smoothing: auto;
 }
 
 /* 36px — section heading: task detail title, sub-section heads */
 .type-heading {
-  font-family: var(--font-instrument-serif), 'Instrument Serif', Georgia, serif;
+  font-family: 'Iowan Old Style', Georgia, serif;
   font-size: 36px;
   line-height: 1.1;
   letter-spacing: -0.025em;
   font-feature-settings: 'liga', 'dlig';
-  -webkit-font-smoothing: auto;
-  -moz-osx-font-smoothing: auto;
 }
 
 /* 26px — stat: insight callout / narrative text */
 .type-stat {
-  font-family: var(--font-instrument-serif), 'Instrument Serif', Georgia, serif;
+  font-family: 'Iowan Old Style', Georgia, serif;
   font-size: 26px;
   line-height: 1.2;
   letter-spacing: -0.01em;
   font-feature-settings: 'liga', 'dlig';
-  -webkit-font-smoothing: auto;
-  -moz-osx-font-smoothing: auto;
 }
 
 /* 28px italic — active: "You're on · task name" live heading */
 .type-active {
-  font-family: var(--font-instrument-serif), 'Instrument Serif', Georgia, serif;
+  font-family: 'Iowan Old Style', Georgia, serif;
   font-size: 28px;
   line-height: 1;
   font-style: italic;
   letter-spacing: 0;
   font-feature-settings: 'liga', 'dlig';
-  -webkit-font-smoothing: auto;
-  -moz-osx-font-smoothing: auto;
 }
 
 /* 24px italic — empty: empty state messages */
 .type-empty {
-  font-family: var(--font-instrument-serif), 'Instrument Serif', Georgia, serif;
+  font-family: 'Iowan Old Style', Georgia, serif;
   font-size: 24px;
   line-height: 1.2;
   font-style: italic;
   letter-spacing: 0;
   font-feature-settings: 'liga', 'dlig';
-  -webkit-font-smoothing: auto;
-  -moz-osx-font-smoothing: auto;
 }
 
 /* 22px — callout: insight card headline */
 .type-callout {
-  font-family: var(--font-instrument-serif), 'Instrument Serif', Georgia, serif;
+  font-family: 'Iowan Old Style', Georgia, serif;
   font-size: 22px;
   line-height: 1.2;
   letter-spacing: 0;
   font-feature-settings: 'liga', 'dlig';
-  -webkit-font-smoothing: auto;
-  -moz-osx-font-smoothing: auto;
 }
 
 /* 22px italic — wordmark: "meridian" in sidebar — slight tracking is intentional */
 .type-wordmark {
-  font-family: var(--font-instrument-serif), 'Instrument Serif', Georgia, serif;
+  font-family: 'Iowan Old Style', Georgia, serif;
   font-size: 22px;
   line-height: 1;
   font-style: italic;
   letter-spacing: -0.02em;
   font-feature-settings: 'liga', 'dlig';
-  -webkit-font-smoothing: auto;
-  -moz-osx-font-smoothing: auto;
 }

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -3,18 +3,9 @@
 import type { Metadata } from 'next'
 import { GeistSans } from 'geist/font/sans'
 import { GeistMono } from 'geist/font/mono'
-import { Instrument_Serif } from 'next/font/google'
 import './globals.css'
 import { ThemeProvider } from '@/lib/theme-context'
 import NoticeBar from '@/components/NoticeBar'
-
-const instrumentSerif = Instrument_Serif({
-  weight: '400',
-  style: ['normal', 'italic'],
-  subsets: ['latin'],
-  variable: '--font-instrument-serif',
-  display: 'swap',
-})
 
 export const metadata: Metadata = {
   title: 'Meridian',
@@ -23,7 +14,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable} ${instrumentSerif.variable}`}>
+    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`}>
       <body className="min-h-screen font-sans">
         <ThemeProvider>
           <NoticeBar />


### PR DESCRIPTION
## Summary

The design mocks (claude.ai artifacts) were rendered in a sandboxed environment where Google Fonts are blocked, so the serif stack fell back to a system font. The UI, meanwhile, loaded the real **Instrument Serif** — a deliberately condensed hairline display face — which is why large headings looked thinner and squeezed compared to the design.

Pixel forensics against the design screenshot identified the actual rendered fallback as **Georgia**: the design's narrative digits (KAN-70, KAN-67) are old-style figures that dip below the baseline — Georgia's signature; Iowan Old Style and New York render lining figures. Line widths match Georgia glyph-for-glyph. (The artifact preview pane also scales the design ~50%, which is why naive size comparisons were misleading — the mock really is 72px type.)

- Set all display serif type (`.type-hero`, `.type-title`, `.type-heading`, `.type-stat`, `.type-active`, `.type-empty`, `.type-callout`, `.type-wordmark`, `.font-serif`) to `Georgia, 'Times New Roman', serif`
- Drop the unused Instrument Serif Google Font load from `layout.tsx`
- Remove the per-class `-webkit-font-smoothing: auto` subpixel overrides — the design renders with the global antialiased setting (supersedes #269)

## Test plan

- [x] `npm run build` passes
- [x] `bun test` — 119 pass, 0 fail
- [x] Headless-Chrome scaled side-by-side of design crop vs new `/today`: letterforms, stroke weight, and old-style digits match
- [ ] Owner visual sign-off (PR stays draft until then)

🤖 Generated with [Claude Code](https://claude.com/claude-code)