### PR TITLE
release-fix: rewrite main to ship 1.52.0 (minor) instead of 2.0.0 — apply via force-update, NOT merge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -188,8 +188,9 @@
 # structured log ingestion into a local OpenObserve instance)
 # ---------------------------------------------------------------------------
 
-# base64(email:password) for your local OpenObserve instance.
-# When unset, OTLP export is silently skipped — logs still go to .jsonl files.
+# DEPRECATED — the Rust daemon ignores this; set OpenObserve credentials in
+# the dashboard Settings instead (stored in settings.json). Still read by the
+# Python services' exporter and as an installer fallback for old setups.
 # Generate: echo -n "you@your-org.com:yourpassword" | base64
 # MERIDIAN_OO_AUTH=base64encodedcredentials
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ There are no JS/TS test suites yet. When adding them, place them under `ui/__tes
 | `RUST_LOG` | `meridian=info` | Tracing filter |
 | `SQLX_OFFLINE` | `true` (via `.cargo/config.toml`) | Prevents sqlx from hitting the DB at compile time |
 | `MERIDIAN_OTLP_ENDPOINT` | (unset → no export) | OpenObserve OTLP/HTTP traces endpoint (loaded from `.env`) |
-| `MERIDIAN_OO_AUTH` | (unset → no auth) | Base64 `user:password` for OpenObserve OTLP auth |
+| `MERIDIAN_OO_AUTH` | DEPRECATED — ignored by the daemon | OO credentials live in `settings.json` (`oo_email`/`oo_password`, set via dashboard Settings); env var still read by Python services + installer fallback |
 | `MLX_SERVER_URL` | (unset → in-process load) | URL of a running MLX classifier server (eval pipeline) |
 | `EVAL_DATASET_PATH` | `services/tests/evals/data/generated/goldens_real.json` | Override Goldens file for the eval pipeline |
 | `SESSION_TEXT_CAP` | `2500` (chars) | Per-session OCR/a11y excerpt cap in the classifier prompt. Set to `0` to disable truncation for eval experiments (caller is then responsible for not blowing the model's context window — phi-4 = 16k tokens). |

--- a/scripts/com.meridiona.daemon.plist
+++ b/scripts/com.meridiona.daemon.plist
@@ -43,14 +43,14 @@
         <string>{{HOME}}/.meridian/meridian.db</string>
         <key>POLL_INTERVAL_SECS</key>
         <string>60</string>
-        <key>RUST_LOG</key>
-        <string>meridian=info</string>
-        <!-- OTLP auth for OpenObserve — must be set here (not just .env)
-             because the Rust binary reads env vars before dotenv is loaded.
-             The install script reads MERIDIAN_OO_AUTH from the repo-root .env and
-             substitutes the {{MERIDIAN_OO_AUTH}} placeholder below. -->
-        <key>MERIDIAN_OO_AUTH</key>
-        <string>{{MERIDIAN_OO_AUTH}}</string>
+        <!-- RUST_LOG is intentionally NOT set here. The daemon derives its log
+             filter from settings.log_level (dashboard Settings → Log Level) and
+             hot-reloads it on the next poll tick; pinning RUST_LOG would make
+             reload_log_level() a no-op and silently defeat the UI control. A
+             power user can still export RUST_LOG to override. -->
+        <!-- MERIDIAN_OO_AUTH is deprecated and ignored by the daemon — OpenObserve
+             credentials come from settings.json (dashboard Settings). The key is
+             left out of this plist on purpose. -->
         <key>MERIDIAN_OTLP_ENDPOINT</key>
         <string>{{MERIDIAN_OTLP_ENDPOINT}}</string>
     </dict>

--- a/scripts/install-openobserve-daemon.sh
+++ b/scripts/install-openobserve-daemon.sh
@@ -175,13 +175,34 @@ while launchctl print "${GUI_TARGET}/${LABEL}" >/dev/null 2>&1; do
     fi
 done
 
-echo "→ bootstrap ${LABEL}"
-launchctl bootstrap "${GUI_TARGET}" "${PLIST_DEST}"
-launchctl enable "${GUI_TARGET}/${LABEL}"
-launchctl kickstart -k "${GUI_TARGET}/${LABEL}"
+# Respect the runtime toggle: the service runs only when "OpenObserve Export"
+# is enabled in Settings. The plist is always installed so the UI's toggle
+# (POST /api/openobserve) can start/stop the service on demand; here we only
+# decide the INITIAL state. No settings.json anywhere → off (matches
+# RuntimeSettings::default and the UI default).
+_otlp_enabled() {
+    local f
+    for f in "${HOME}/.meridian/settings.json" "$(cd "${SCRIPT_DIR}/.." && pwd)/settings.json"; do
+        [[ -f "$f" ]] || continue
+        grep -q '"otlp_enabled"[[:space:]]*:[[:space:]]*true' "$f" && return 0
+        return 1
+    done
+    return 1
+}
 
-echo
-echo "✓ OpenObserve installed and started"
+if _otlp_enabled; then
+    echo "→ bootstrap ${LABEL} (OpenObserve Export is enabled in settings)"
+    launchctl bootstrap "${GUI_TARGET}" "${PLIST_DEST}"
+    launchctl enable "${GUI_TARGET}/${LABEL}"
+    launchctl kickstart -k "${GUI_TARGET}/${LABEL}"
+    echo
+    echo "✓ OpenObserve installed and started"
+else
+    launchctl disable "${GUI_TARGET}/${LABEL}" 2>/dev/null || true
+    echo
+    echo "✓ OpenObserve installed (service left stopped — OpenObserve Export is"
+    echo "  disabled in Settings; enable the toggle in the dashboard to start it)"
+fi
 echo
 echo "  open  http://localhost:5080                           # the UI"
 echo "  tail -f ~/.meridian/logs/openobserve.log              # live stdout"

--- a/scripts/install-openobserve-daemon.sh
+++ b/scripts/install-openobserve-daemon.sh
@@ -8,7 +8,10 @@
 # Re-running is safe — it bootouts the existing agent first, rewrites the
 # plist with current credentials, and reloads it.
 #
-# Requires MERIDIAN_OO_AUTH=<base64(email:password)> in <repo>/.env.
+# Credentials come from settings.json (oo_email/oo_password, set in the
+# dashboard Settings). MERIDIAN_OO_AUTH in <repo>/.env is DEPRECATED and used
+# only as a fallback; with no credentials anywhere the agent is installed
+# stopped and the dashboard toggle starts it once credentials are set.
 #
 # Uninstall:
 #   ./scripts/uninstall-openobserve-daemon.sh
@@ -62,30 +65,54 @@ if [[ -z "${OO_BIN}" ]]; then
     fi
 fi
 
-# Read MERIDIAN_OO_AUTH from the repo-root .env and decode it.
-ENV_FILE="$(cd "${SCRIPT_DIR}/.." && pwd)/.env"
-OO_AUTH=""
-if [[ -f "${ENV_FILE}" ]]; then
-    OO_AUTH="$(grep -E '^MERIDIAN_OO_AUTH=' "${ENV_FILE}" | cut -d= -f2- | tr -d '[:space:]')" || true
-fi
-
-if [[ -z "${OO_AUTH}" ]]; then
-    echo "✗ MERIDIAN_OO_AUTH not set in ${ENV_FILE}" >&2
-    echo "  Add it:  MERIDIAN_OO_AUTH=\$(printf 'email:password' | base64)" >&2
-    exit 1
-fi
-
-OO_CREDENTIALS=""
-OO_CREDENTIALS="$(printf '%s' "${OO_AUTH}" | base64 --decode 2>/dev/null)" || {
-    echo "✗ MERIDIAN_OO_AUTH is not valid base64" >&2
-    exit 1
+# Resolve OpenObserve root credentials. settings.json (written by the dashboard
+# Settings page) is the canonical source; MERIDIAN_OO_AUTH in <repo>/.env is
+# DEPRECATED and honoured only as a fallback for not-yet-migrated installs.
+# With no credentials anywhere, the plist is written with placeholders and the
+# service is left stopped — enabling OpenObserve Export in the dashboard
+# patches real credentials into the plist (POST /api/openobserve) before the
+# service's first start, which is when OpenObserve creates its root account.
+_get_setting() {
+    python3 -c "import json,sys;print(json.load(open(sys.argv[1])).get(sys.argv[2]) or '')" "$1" "$2" 2>/dev/null || true
 }
-OO_EMAIL="${OO_CREDENTIALS%%:*}"
-OO_PASSWORD="${OO_CREDENTIALS#*:}"
 
-if [[ -z "${OO_EMAIL}" || -z "${OO_PASSWORD}" || "${OO_EMAIL}" == "${OO_CREDENTIALS}" ]]; then
-    echo "✗ MERIDIAN_OO_AUTH decoded to '${OO_CREDENTIALS}' — expected 'email:password'" >&2
-    exit 1
+OO_EMAIL=""
+OO_PASSWORD=""
+for _settings in "${HOME}/.meridian/settings.json" "$(cd "${SCRIPT_DIR}/.." && pwd)/settings.json"; do
+    [[ -f "${_settings}" ]] || continue
+    OO_EMAIL="$(_get_setting "${_settings}" oo_email)"
+    OO_PASSWORD="$(_get_setting "${_settings}" oo_password)"
+    if [[ -n "${OO_EMAIL}" && -n "${OO_PASSWORD}" ]]; then
+        echo "→ using OpenObserve credentials from ${_settings}"
+        break
+    fi
+    OO_EMAIL=""; OO_PASSWORD=""
+done
+
+if [[ -z "${OO_EMAIL}" ]]; then
+    ENV_FILE="$(cd "${SCRIPT_DIR}/.." && pwd)/.env"
+    OO_AUTH=""
+    if [[ -f "${ENV_FILE}" ]]; then
+        OO_AUTH="$(grep -E '^MERIDIAN_OO_AUTH=' "${ENV_FILE}" | cut -d= -f2- | tr -d '[:space:]')" || true
+    fi
+    if [[ -n "${OO_AUTH}" ]]; then
+        echo "  ⚠ MERIDIAN_OO_AUTH is DEPRECATED — set OpenObserve credentials in the dashboard Settings instead" >&2
+        OO_CREDENTIALS="$(printf '%s' "${OO_AUTH}" | base64 --decode 2>/dev/null)" || OO_CREDENTIALS=""
+        OO_EMAIL="${OO_CREDENTIALS%%:*}"
+        OO_PASSWORD="${OO_CREDENTIALS#*:}"
+        if [[ -z "${OO_EMAIL}" || -z "${OO_PASSWORD}" || "${OO_EMAIL}" == "${OO_CREDENTIALS}" ]]; then
+            OO_EMAIL=""; OO_PASSWORD=""
+        fi
+    fi
+fi
+
+_no_creds=0
+if [[ -z "${OO_EMAIL}" || -z "${OO_PASSWORD}" ]]; then
+    _no_creds=1
+    OO_EMAIL="setup-pending@meridian.local"
+    OO_PASSWORD="setup-pending"
+    echo "→ no OpenObserve credentials yet — installing the agent stopped; enable"
+    echo "  OpenObserve Export in the dashboard Settings to set them and start it"
 fi
 
 mkdir -p "${HOME}/.meridian/logs"
@@ -190,7 +217,7 @@ _otlp_enabled() {
     return 1
 }
 
-if _otlp_enabled; then
+if [[ "${_no_creds}" -eq 0 ]] && _otlp_enabled; then
     echo "→ bootstrap ${LABEL} (OpenObserve Export is enabled in settings)"
     launchctl bootstrap "${GUI_TARGET}" "${PLIST_DEST}"
     launchctl enable "${GUI_TARGET}/${LABEL}"

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,7 +44,9 @@ impl Default for RuntimeSettings {
             llm_budget_pct: 0.5,
             poll_interval_secs: 60,
             jira_update_enabled: true,
-            otlp_enabled: true,
+            // OpenObserve export is opt-in — off until enabled in Settings (UI
+            // default in ui/lib/settings.ts must match this).
+            otlp_enabled: false,
             otlp_endpoint: None,
             oo_email: None,
             oo_password: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,8 @@ pub struct RuntimeSettings {
     pub poll_interval_secs: u64,
     pub jira_update_enabled: bool,
     // OpenObserve OTLP export — all three must be non-empty for export to activate.
-    // Takes precedence over MERIDIAN_OTLP_ENDPOINT / MERIDIAN_OO_AUTH env vars.
+    // settings.json is the ONLY credential source (MERIDIAN_OO_AUTH is deprecated
+    // and ignored); otlp_endpoint still falls back to MERIDIAN_OTLP_ENDPOINT.
     pub otlp_enabled: bool,
     pub otlp_endpoint: Option<String>,
     pub oo_email: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,11 +4,12 @@
 use std::path::PathBuf;
 
 // ---------------------------------------------------------------------------
-// RuntimeSettings — hot-reloadable subset of config (repo-local settings.json)
+// RuntimeSettings — hot-reloadable subset of config (~/.meridian/settings.json)
 // ---------------------------------------------------------------------------
 
-/// Settings that can be changed at runtime by editing the repo-local `settings.json`.
-/// The daemon re-reads this file on every poll tick; no restart required.
+/// Settings that can be changed at runtime by editing `settings.json` (resolved by
+/// [`settings_json_path`]). The daemon re-reads this file on every poll tick; no
+/// restart required.
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(default)]
 pub struct RuntimeSettings {
@@ -51,13 +52,49 @@ impl Default for RuntimeSettings {
     }
 }
 
-/// Return the path to the repo-local `settings.json`, resolved against the
-/// process working directory (the daemon runs with cwd = repo root). Kept inside
-/// the repo so nothing is read from outside it; absent → built-in defaults.
+/// Resolve the path to `settings.json` — the hot-reloadable runtime settings the
+/// UI writes and the daemon reads. Both sides MUST agree on this path or the UI's
+/// "Apply" never reaches the daemon.
+///
+/// The daemon's working directory depends on the install type (repo root under
+/// `cargo run`, `~/.meridian/app` for a bundle install), so resolving relative to
+/// cwd makes the UI and daemon disagree on anything but a source checkout. Instead
+/// we resolve to a fixed, install-independent location. Resolution order:
+///   1. `MERIDIAN_SETTINGS_PATH` — explicit override (tests, non-standard installs)
+///   2. `~/.meridian/settings.json` — canonical home, next to `meridian.db`; this
+///      is what the UI writes (see `ui/lib/settings.ts`)
+///   3. `<cwd>/settings.json` — legacy fallback, honoured only when the canonical
+///      file is absent (a source checkout still keeping settings in the repo). The
+///      canonical path takes precedence so a UI write always wins once it exists.
 fn settings_json_path() -> std::path::PathBuf {
-    std::env::current_dir()
-        .unwrap_or_else(|_| std::path::PathBuf::from("."))
-        .join("settings.json")
+    if let Ok(p) = std::env::var("MERIDIAN_SETTINGS_PATH") {
+        if !p.is_empty() {
+            return PathBuf::from(shellexpand::tilde(&p).into_owned());
+        }
+    }
+
+    let canonical = std::env::var("HOME")
+        .ok()
+        .map(|home| PathBuf::from(home).join(".meridian").join("settings.json"));
+
+    if let Some(path) = &canonical {
+        if path.exists() {
+            return path.clone();
+        }
+    }
+
+    // Legacy: a source checkout may still carry settings.json in the repo root
+    // (the daemon's cwd). Honoured only when the canonical file does not exist.
+    let cwd_path = std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join("settings.json");
+    if cwd_path.exists() {
+        return cwd_path;
+    }
+
+    // Neither exists yet — default to the canonical path so a first write lands
+    // in the right, install-independent place.
+    canonical.unwrap_or(cwd_path)
 }
 
 /// Load the repo-local `settings.json`, falling back to defaults if the file is
@@ -232,8 +269,14 @@ fn parse_jira() -> Option<PmProviderConfig> {
         .unwrap_or_default()
         .trim()
         .to_owned();
-    let email = std::env::var("JIRA_EMAIL").unwrap_or_default().trim().to_owned();
-    let api_token = std::env::var("JIRA_API_TOKEN").unwrap_or_default().trim().to_owned();
+    let email = std::env::var("JIRA_EMAIL")
+        .unwrap_or_default()
+        .trim()
+        .to_owned();
+    let api_token = std::env::var("JIRA_API_TOKEN")
+        .unwrap_or_default()
+        .trim()
+        .to_owned();
 
     // Configured if EITHER auth path is viable:
     //   * browser OAuth — the user has run `meridian oauth-login jira`, so a token

--- a/src/health/observability.rs
+++ b/src/health/observability.rs
@@ -3,7 +3,8 @@
 // Observability sink health. If OpenObserve is down, traces/logs silently drop
 // — which blinds the very fault-attribution this layer depends on, so it is
 // worth a check of its own. Export is gated on credentials being present in
-// settings.json or MERIDIAN_OO_AUTH (resolved by observability::resolve_otlp_target).
+// settings.json (resolved by observability::resolve_otlp_target; the old
+// MERIDIAN_OO_AUTH env fallback is deprecated and ignored).
 
 use crate::config::Config;
 use crate::health::Check;
@@ -15,7 +16,7 @@ pub async fn checks(_cfg: &Config) -> Vec<Check> {
         return vec![Check::info(
             "openobserve",
             "obs",
-            "OTLP export disabled (no credentials in settings or MERIDIAN_OO_AUTH) — telemetry not collected",
+            "OTLP export disabled (no credentials in Settings) — telemetry not collected",
         )];
     }
     let endpoint = crate::observability::resolve_otlp_endpoint()

--- a/src/intelligence/providers/github.rs
+++ b/src/intelligence/providers/github.rs
@@ -432,7 +432,8 @@ pub async fn refresh_if_stale(
         Ok(l) => l,
         Err(e) => {
             tracing::warn!(error = %e, "github viewer fetch failed — keeping stale cache");
-            let _ = super::stamp_sync_error(pool, "github", &format!("GitHub auth failed — {e}")).await;
+            let _ =
+                super::stamp_sync_error(pool, "github", &format!("GitHub auth failed — {e}")).await;
             return Ok(None);
         }
     };
@@ -468,7 +469,12 @@ pub async fn refresh_if_stale(
 
     if !any_ok {
         tracing::warn!("all github project fetches failed — keeping stale cache");
-        let _ = super::stamp_sync_error(pool, "github", "GitHub sync failed — all project fetches failed").await;
+        let _ = super::stamp_sync_error(
+            pool,
+            "github",
+            "GitHub sync failed — all project fetches failed",
+        )
+        .await;
         return Ok(None);
     }
 

--- a/src/intelligence/providers/jira.rs
+++ b/src/intelligence/providers/jira.rs
@@ -84,14 +84,20 @@ async fn discover_start_date_field(ctx: &JiraReqCtx) -> Option<String> {
     let fields: Vec<JiraFieldMeta> = resp.json().await.ok()?;
 
     // Priority 1: exact match
-    if let Some(f) = fields.iter().find(|f| f.name.eq_ignore_ascii_case("start date")) {
+    if let Some(f) = fields
+        .iter()
+        .find(|f| f.name.eq_ignore_ascii_case("start date"))
+    {
         return Some(f.id.clone());
     }
     // Priority 2: name contains both "start" and "date"
-    fields.iter().find(|f| {
-        let n = f.name.to_lowercase();
-        n.contains("start") && n.contains("date")
-    }).map(|f| f.id.clone())
+    fields
+        .iter()
+        .find(|f| {
+            let n = f.name.to_lowercase();
+            n.contains("start") && n.contains("date")
+        })
+        .map(|f| f.id.clone())
 }
 
 #[derive(Deserialize)]
@@ -197,8 +203,17 @@ async fn fetch(ctx: &JiraReqCtx, start_date_field: Option<&str>) -> Result<Vec<J
     let url = ctx.api_url("/rest/api/3/search/jql");
 
     let mut fields = vec![
-        "summary", "description", "issuetype", "project", "updated",
-        "parent", "status", "duedate", "assignee", "labels", "customfield_10020",
+        "summary",
+        "description",
+        "issuetype",
+        "project",
+        "updated",
+        "parent",
+        "status",
+        "duedate",
+        "assignee",
+        "labels",
+        "customfield_10020",
     ];
     if let Some(id) = start_date_field {
         fields.push(id);
@@ -300,7 +315,12 @@ async fn upsert(
             .and_then(|s| s.name.clone());
 
         let start_date: Option<String> = start_date_field.and_then(|field_id| {
-            issue.fields.extra.get(field_id)?.as_str().map(str::to_owned)
+            issue
+                .fields
+                .extra
+                .get(field_id)?
+                .as_str()
+                .map(str::to_owned)
         });
 
         let upsert_result = sqlx::query(
@@ -359,7 +379,10 @@ async fn upsert(
         }
     }
     if !issues.is_empty() && ok_count == 0 {
-        anyhow::bail!("all {} jira task upserts failed — DB write errors above", issues.len());
+        anyhow::bail!(
+            "all {} jira task upserts failed — DB write errors above",
+            issues.len()
+        );
     }
     Ok(())
 }
@@ -447,7 +470,11 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
             return Ok(None);
         }
     };
-    let auth_method = if jira.api_token.is_empty() { "oauth" } else { "api_token" };
+    let auth_method = if jira.api_token.is_empty() {
+        "oauth"
+    } else {
+        "api_token"
+    };
     tracing::debug!(auth_method, "jira auth resolved");
 
     let start_date_field = discover_start_date_field(&ctx).await;
@@ -459,7 +486,10 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
         Ok(issues) => {
             let keys: Vec<String> = issues.iter().map(|i| i.key.clone()).collect();
             let n = keys.len();
-            let project_key = issues.first().map(|i| i.fields.project.key.as_str()).unwrap_or("-");
+            let project_key = issues
+                .first()
+                .map(|i| i.fields.project.key.as_str())
+                .unwrap_or("-");
             let terminal_count = issues
                 .iter()
                 .filter(|i| native_terminal(&i.fields.status.status_category.key) == Some(true))

--- a/src/intelligence/providers/linear.rs
+++ b/src/intelligence/providers/linear.rs
@@ -397,7 +397,8 @@ pub async fn refresh_if_stale(
         }
         Err(e) => {
             tracing::warn!(error = %e, "linear fetch failed — keeping stale cache");
-            let _ = super::stamp_sync_error(pool, "linear", &format!("Linear sync failed — {e}")).await;
+            let _ =
+                super::stamp_sync_error(pool, "linear", &format!("Linear sync failed — {e}")).await;
             Ok(None)
         }
     }

--- a/src/intelligence/providers/mod.rs
+++ b/src/intelligence/providers/mod.rs
@@ -25,12 +25,21 @@ pub async fn stamp_sync_error(pool: &SqlitePool, provider: &str, error: &str) ->
     .await?;
 
     let (title, remedy): (&str, Option<&str>) = match provider {
-        "jira"         => ("Jira sync failing",        Some("Set JIRA_API_TOKEN and JIRA_BASE_URL in .env")),
-        "linear"       => ("Linear sync failing",       Some("Set LINEAR_API_KEY in .env")),
-        "trello"       => ("Trello sync failing",       Some("Run: meridian oauth-login trello")),
-        "github"       => ("GitHub sync failing",       Some("Set GITHUB_TOKEN in .env")),
-        "azure_devops" => ("Azure DevOps sync failing", Some("Set AZURE_DEVOPS_PAT in .env")),
-        _              => ("PM sync failing",            None),
+        "jira" => (
+            "Jira sync failing",
+            Some("Set JIRA_API_TOKEN and JIRA_BASE_URL in .env"),
+        ),
+        "linear" => ("Linear sync failing", Some("Set LINEAR_API_KEY in .env")),
+        "trello" => (
+            "Trello sync failing",
+            Some("Run: meridian oauth-login trello"),
+        ),
+        "github" => ("GitHub sync failing", Some("Set GITHUB_TOKEN in .env")),
+        "azure_devops" => (
+            "Azure DevOps sync failing",
+            Some("Set AZURE_DEVOPS_PAT in .env"),
+        ),
+        _ => ("PM sync failing", None),
     };
     let _ = crate::notices::raise(
         pool,
@@ -46,12 +55,10 @@ pub async fn stamp_sync_error(pool: &SqlitePool, provider: &str, error: &str) ->
 
 /// Clear the last error for a provider after a successful sync.
 pub async fn clear_sync_error(pool: &SqlitePool, provider: &str) -> Result<()> {
-    sqlx::query(
-        "UPDATE pm_sync_state SET last_error = NULL WHERE provider = ?",
-    )
-    .bind(provider)
-    .execute(pool)
-    .await?;
+    sqlx::query("UPDATE pm_sync_state SET last_error = NULL WHERE provider = ?")
+        .bind(provider)
+        .execute(pool)
+        .await?;
     let _ = crate::notices::clear(pool, &format!("pm.{provider}")).await;
     Ok(())
 }

--- a/src/intelligence/providers/trello.rs
+++ b/src/intelligence/providers/trello.rs
@@ -275,7 +275,8 @@ pub async fn refresh_if_stale(
         }
         Err(e) => {
             tracing::warn!(error = %e, "trello fetch failed — keeping stale cache");
-            let _ = super::stamp_sync_error(pool, "trello", &format!("Trello sync failed — {e}")).await;
+            let _ =
+                super::stamp_sync_error(pool, "trello", &format!("Trello sync failed — {e}")).await;
             Ok(None)
         }
     }

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -10,13 +10,15 @@
 //      (log events carry trace_id/span_id so they correlate with traces in OO)
 //
 // Environment variables read at init time:
-//   MERIDIAN_OTLP_ENDPOINT  — OTLP/HTTP traces endpoint
+//   MERIDIAN_OTLP_ENDPOINT  — OTLP/HTTP traces endpoint override
 //                              (default: http://localhost:5080/api/default/v1/traces)
-//   MERIDIAN_OO_AUTH        — base64(email:password); when empty, OTLP export
-//                              is skipped (e.g. in tests or when OO is offline)
 //   MERIDIAN_LOG_DIR        — log directory (default: ~/.meridian/logs)
 //   RUST_LOG                — standard env-filter; default
 //                              "meridian=info,meridian::etl=debug,sqlx=warn"
+//
+// OpenObserve credentials come from settings.json (oo_email/oo_password, set in
+// the dashboard Settings). The MERIDIAN_OO_AUTH env var is DEPRECATED and
+// ignored; export is skipped when settings carry no credentials.
 //
 // `init` returns an `ObservabilityGuard` whose `Drop` flushes the file writer.
 // Call `ObservabilityGuard::shutdown().await` before tearing down the tokio
@@ -211,12 +213,13 @@ pub fn is_otlp_configured() -> bool {
     if !settings.otlp_enabled {
         return false;
     }
-    let has_settings_creds = settings.oo_email.as_deref().is_some_and(|e| !e.is_empty())
+    // settings.json is the single source for OO credentials — the old
+    // MERIDIAN_OO_AUTH env fallback is deprecated and ignored.
+    settings.oo_email.as_deref().is_some_and(|e| !e.is_empty())
         && settings
             .oo_password
             .as_deref()
-            .is_some_and(|p| !p.is_empty());
-    has_settings_creds || std::env::var("MERIDIAN_OO_AUTH").is_ok_and(|v| !v.is_empty())
+            .is_some_and(|p| !p.is_empty())
 }
 
 /// Resolve the configured OTLP endpoint URL (without assembling credentials).
@@ -247,7 +250,10 @@ pub fn resolve_otlp_target() -> Option<OtlpTarget> {
         return None;
     }
 
-    // Auth: settings email+password → env var MERIDIAN_OO_AUTH → disabled.
+    // Auth: settings email+password only. The MERIDIAN_OO_AUTH env fallback is
+    // DEPRECATED and ignored — a dual credential store (env + settings) meant
+    // the UI could show creds while the daemon used different ones (or none).
+    // Credentials are set in the dashboard Settings and read from settings.json.
     let auth = match (&settings.oo_email, &settings.oo_password) {
         (Some(email), Some(pass)) if !email.is_empty() && !pass.is_empty() => {
             // Guard against HTTP header injection and malformed user:password splits.
@@ -259,10 +265,15 @@ pub fn resolve_otlp_target() -> Option<OtlpTarget> {
             }
             STANDARD.encode(format!("{email}:{pass}"))
         }
-        _ => match std::env::var("MERIDIAN_OO_AUTH") {
-            Ok(v) if !v.is_empty() => v,
-            _ => return None,
-        },
+        _ => {
+            if std::env::var("MERIDIAN_OO_AUTH").is_ok_and(|v| !v.is_empty()) {
+                tracing::warn!(
+                    "MERIDIAN_OO_AUTH is set but deprecated and ignored — \
+                     set OpenObserve credentials in the dashboard Settings instead"
+                );
+            }
+            return None;
+        }
     };
 
     let endpoint = settings

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -233,7 +233,11 @@ pub fn resolve_otlp_endpoint() -> Option<String> {
         settings
             .otlp_endpoint
             .filter(|s| !s.is_empty())
-            .or_else(|| std::env::var("MERIDIAN_OTLP_ENDPOINT").ok())
+            .or_else(|| {
+                std::env::var("MERIDIAN_OTLP_ENDPOINT")
+                    .ok()
+                    .filter(|s| !s.is_empty())
+            })
             .unwrap_or_else(|| DEFAULT_OTLP_ENDPOINT.to_string()),
     )
 }
@@ -279,7 +283,11 @@ pub fn resolve_otlp_target() -> Option<OtlpTarget> {
     let endpoint = settings
         .otlp_endpoint
         .filter(|s| !s.is_empty())
-        .or_else(|| std::env::var("MERIDIAN_OTLP_ENDPOINT").ok())
+        .or_else(|| {
+            std::env::var("MERIDIAN_OTLP_ENDPOINT")
+                .ok()
+                .filter(|s| !s.is_empty())
+        })
         .unwrap_or_else(|| DEFAULT_OTLP_ENDPOINT.to_string());
 
     // Validate scheme — only http/https are valid OTLP transports.

--- a/tests/log_level_reload.rs
+++ b/tests/log_level_reload.rs
@@ -1,0 +1,72 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Verifies the Settings "Log Level" control actually works: the daemon builds
+// its tracing filter from settings.log_level and hot-reloads it at runtime
+// (the poll loop calls observability::reload_log_level when the value changes,
+// no restart). This drives the real reload handle and asserts the file sink's
+// verbosity changes accordingly.
+
+use std::time::Duration;
+
+#[test]
+fn log_level_hot_reload_changes_verbosity() {
+    // Isolate from the dev machine: a temp settings.json (export off so init
+    // builds no OTLP exporter) + temp log dir, and no RUST_LOG (an explicit
+    // override would correctly disable the settings-driven filter).
+    std::env::remove_var("RUST_LOG");
+    let tmp = std::env::temp_dir().join(format!("meridian-loglevel-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let settings = tmp.join("settings.json");
+    std::fs::write(&settings, r#"{"log_level":"INFO","otlp_enabled":false}"#).unwrap();
+    std::env::set_var("MERIDIAN_SETTINGS_PATH", &settings);
+    std::env::set_var("MERIDIAN_LOG_DIR", &tmp);
+
+    let guard = meridian::observability::init("loglevel-test").expect("init observability");
+
+    // Default level is INFO → a debug event on the `meridian` target is dropped.
+    tracing::debug!(target: "meridian", "DBG_BEFORE_RELOAD");
+    tracing::info!(target: "meridian", "INFO_SANITY");
+
+    // Flip to DEBUG at runtime — this is exactly what the poll loop does when
+    // the user changes Log Level in Settings. Returns true when applied.
+    assert!(
+        meridian::observability::reload_log_level("DEBUG"),
+        "reload_log_level should apply when RUST_LOG is unset and the handle is initialised",
+    );
+    tracing::debug!(target: "meridian", "DBG_AFTER_RELOAD");
+
+    // Flush the non-blocking file writer, then read the daily-rolled jsonl.
+    drop(guard);
+    std::thread::sleep(Duration::from_millis(300));
+
+    let body = std::fs::read_dir(&tmp)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("loglevel-test.jsonl"))
+        })
+        .map(|p| std::fs::read_to_string(p).unwrap_or_default())
+        .collect::<String>();
+
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    // INFO sanity line is always present.
+    assert!(
+        body.contains("INFO_SANITY"),
+        "INFO event should be logged at the INFO default"
+    );
+    // Debug emitted BEFORE the reload (while at INFO) must be filtered out.
+    assert!(
+        !body.contains("DBG_BEFORE_RELOAD"),
+        "a debug event at the INFO default must be filtered out",
+    );
+    // Debug emitted AFTER reloading to DEBUG must now appear — proving the
+    // hot-reload took effect without a restart.
+    assert!(
+        body.contains("DBG_AFTER_RELOAD"),
+        "a debug event after reloading to DEBUG must be logged",
+    );
+}

--- a/ui/app/api/openobserve/route.ts
+++ b/ui/app/api/openobserve/route.ts
@@ -50,14 +50,21 @@ export async function POST(req: Request) {
       )
     }
     // Sync the UI-entered credentials into the plist's ZO_ROOT_USER_* env vars
-    // BEFORE the service starts. OpenObserve creates its root account from
-    // these on its FIRST boot (no user store yet) — this is what lets a
-    // first-time user simply pick an email/password in Settings and have it
-    // become their OpenObserve login. On an already-initialised instance the
-    // env vars are ignored, so this is harmless. The service must be stopped
-    // when the plist changes, so patch → (re)bootstrap, not patch-while-running.
+    // BEFORE the service's first start. OpenObserve creates its root account
+    // from these on its FIRST boot only (no user store yet) — this is what
+    // lets a first-time user simply pick an email/password in Settings and
+    // have it become their OpenObserve login. Once the instance is
+    // initialised the env vars are ignored, so we skip the patch AND the
+    // bootout/bootstrap cycle it requires — if OO is already running,
+    // enabling must not bounce it (the restart window reads as "Apply didn't
+    // work" to anyone who clicks "Open OpenObserve" right away).
+    const dataDir = path.join(/*turbopackIgnore: true*/ os.homedir(), '.openobserve', 'data')
+    let initialised = false
+    try {
+      initialised = fs.readdirSync(/*turbopackIgnore: true*/ dataDir).length > 0
+    } catch { /* no data dir yet — first boot */ }
     const { oo_email, oo_password } = readSettings()
-    if (oo_email && oo_password) {
+    if (!initialised && oo_email && oo_password) {
       await launchctl('bootout', target) // ensure next bootstrap reads the fresh plist
       // launchd tears the entry down asynchronously; bootstrap fails with EIO
       // while it lingers. Poll until gone (max ~5 s) — same guard as the

--- a/ui/app/api/openobserve/route.ts
+++ b/ui/app/api/openobserve/route.ts
@@ -1,0 +1,66 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// POST /api/openobserve — start or stop the local OpenObserve launchd service
+// (com.meridiona.openobserve) to match the "OpenObserve Export" toggle.
+//
+// The toggle gates the SERVICE, not just the daemon's exporters: with export
+// disabled there is no idle OpenObserve server holding :5080 and its memory
+// caps. Disable also persists across logins (launchctl disable), so RunAtLoad
+// cannot resurrect the service after a reboot.
+
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+export const dynamic = 'force-dynamic'
+
+const execFileP = promisify(execFile)
+const LABEL = 'com.meridiona.openobserve'
+
+async function launchctl(...args: string[]): Promise<{ ok: boolean; err?: string }> {
+  try {
+    await execFileP('launchctl', args)
+    return { ok: true }
+  } catch (e) {
+    return { ok: false, err: e instanceof Error ? e.message : String(e) }
+  }
+}
+
+export async function POST(req: Request) {
+  const body = await req.json() as { enabled?: unknown }
+  if (typeof body.enabled !== 'boolean') {
+    return Response.json({ error: 'enabled must be a boolean' }, { status: 400 })
+  }
+  const uid = process.getuid?.()
+  if (uid === undefined) {
+    return Response.json({ error: 'cannot determine uid' }, { status: 500 })
+  }
+  const domain = `gui/${uid}`
+  const target = `${domain}/${LABEL}`
+  const plist = path.join(/*turbopackIgnore: true*/ os.homedir(), 'Library', 'LaunchAgents', `${LABEL}.plist`)
+
+  if (body.enabled) {
+    if (!fs.existsSync(/*turbopackIgnore: true*/ plist)) {
+      return Response.json(
+        { error: 'OpenObserve agent not installed — run scripts/install-openobserve-daemon.sh' },
+        { status: 409 },
+      )
+    }
+    // enable first: bootstrap fails with EIO on a disabled service.
+    await launchctl('enable', target)
+    await launchctl('bootstrap', domain, plist) // "already bootstrapped" is fine
+    await launchctl('kickstart', target)        // start now if not running
+    const up = (await launchctl('print', target)).ok
+    if (!up) {
+      return Response.json({ error: 'OpenObserve failed to start — check ~/.meridian/logs/openobserve-error.log' }, { status: 500 })
+    }
+    return Response.json({ ok: true, running: true })
+  }
+
+  // Stop, and disable so RunAtLoad does not restart it at next login.
+  await launchctl('bootout', target) // "not loaded" is fine
+  await launchctl('disable', target)
+  return Response.json({ ok: true, running: false })
+}

--- a/ui/app/api/openobserve/route.ts
+++ b/ui/app/api/openobserve/route.ts
@@ -1,14 +1,21 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 //
-// POST /api/openobserve — start or stop the local OpenObserve launchd service
-// (com.meridiona.openobserve) to match the "OpenObserve Export" toggle.
+// OpenObserve service control for the "OpenObserve Export" toggle.
+//
+//   POST { enabled: true }
+//     - agent already installed → start it (cred-sync on first boot, then
+//       enable/bootstrap/kickstart) and confirm it is actually serving
+//     - agent NOT installed (fresh machine) → kick off install-openobserve-
+//       daemon.sh in the background (downloads the binary, writes the plist,
+//       reads creds from settings.json, starts the service) and return
+//       { installing: true }; the client polls GET until it is reachable
+//   POST { enabled: false } → stop + disable (persists across logins)
+//   GET → { installed, running, reachable, installing, failed, error }
 //
 // The toggle gates the SERVICE, not just the daemon's exporters: with export
-// disabled there is no idle OpenObserve server holding :5080 and its memory
-// caps. Disable also persists across logins (launchctl disable), so RunAtLoad
-// cannot resurrect the service after a reboot.
+// off there is no idle OpenObserve server holding :5080 and its memory caps.
 
-import { execFile } from 'child_process'
+import { execFile, spawn } from 'child_process'
 import { promisify } from 'util'
 import fs from 'fs'
 import os from 'os'
@@ -19,6 +26,16 @@ export const dynamic = 'force-dynamic'
 
 const execFileP = promisify(execFile)
 const LABEL = 'com.meridiona.openobserve'
+const HEALTHZ = 'http://localhost:5080/healthz'
+// Status file written by the background installer wrapper: "installing" while
+// it runs, then "exit:<code>" when done. Lives outside any app dir so it
+// survives bundle re-installs.
+const STATUS_FILE = path.join(os.homedir(), '.meridian', '.oo-install.status')
+const INSTALL_LOG = path.join(os.homedir(), '.meridian', 'logs', 'openobserve-install.log')
+
+function plistPath(): string {
+  return path.join(/*turbopackIgnore: true*/ os.homedir(), 'Library', 'LaunchAgents', `${LABEL}.plist`)
+}
 
 async function launchctl(...args: string[]): Promise<{ ok: boolean; err?: string }> {
   try {
@@ -27,6 +44,73 @@ async function launchctl(...args: string[]): Promise<{ ok: boolean; err?: string
   } catch (e) {
     return { ok: false, err: e instanceof Error ? e.message : String(e) }
   }
+}
+
+async function reachable(): Promise<boolean> {
+  try {
+    const r = await fetch(HEALTHZ, { signal: AbortSignal.timeout(1000) })
+    return r.ok
+  } catch {
+    return false
+  }
+}
+
+// Resolve install-openobserve-daemon.sh across install types: bundle first
+// (~/.meridian/app), then walk up from cwd for a source checkout.
+function resolveInstaller(): string | null {
+  const candidates = [
+    path.join(/*turbopackIgnore: true*/ os.homedir(), '.meridian', 'app', 'scripts', 'install-openobserve-daemon.sh'),
+  ]
+  let dir = process.cwd()
+  for (let i = 0; i < 6; i++) {
+    candidates.push(path.join(/*turbopackIgnore: true*/ dir, 'scripts', 'install-openobserve-daemon.sh'))
+    const parent = path.dirname(/*turbopackIgnore: true*/ dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return candidates.find(p => fs.existsSync(/*turbopackIgnore: true*/ p)) ?? null
+}
+
+// POSIX single-quote escape for safe interpolation into a bash -c string.
+function sq(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+function startBackgroundInstall(script: string): { ok: boolean; error?: string } {
+  try {
+    fs.mkdirSync(/*turbopackIgnore: true*/ path.dirname(INSTALL_LOG), { recursive: true })
+    fs.writeFileSync(/*turbopackIgnore: true*/ STATUS_FILE, 'installing')
+    // Wrapper runs the installer, tees output to the log, and records the exit
+    // code in the status file. Detached + unref so it outlives this request.
+    const cmd = `${sq(script)} >> ${sq(INSTALL_LOG)} 2>&1; printf 'exit:%s' "$?" > ${sq(STATUS_FILE)}`
+    const child = spawn('bash', ['-c', cmd], { detached: true, stdio: 'ignore' })
+    child.unref()
+    return { ok: true }
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) }
+  }
+}
+
+function readStatus(): string | null {
+  try {
+    return fs.readFileSync(/*turbopackIgnore: true*/ STATUS_FILE, 'utf-8').trim()
+  } catch {
+    return null
+  }
+}
+
+export async function GET() {
+  const installed = fs.existsSync(/*turbopackIgnore: true*/ plistPath())
+  const status = readStatus()
+  const installing = status === 'installing'
+  const up = await reachable()
+  let failed = false
+  let error: string | undefined
+  if (status && status.startsWith('exit:') && status !== 'exit:0' && !up) {
+    failed = true
+    error = `OpenObserve install failed (code ${status.slice('exit:'.length)}) — see ${INSTALL_LOG}`
+  }
+  return Response.json({ installed, installing, reachable: up, failed, error })
 }
 
 export async function POST(req: Request) {
@@ -40,24 +124,34 @@ export async function POST(req: Request) {
   }
   const domain = `gui/${uid}`
   const target = `${domain}/${LABEL}`
-  const plist = path.join(/*turbopackIgnore: true*/ os.homedir(), 'Library', 'LaunchAgents', `${LABEL}.plist`)
+  const plist = plistPath()
 
   if (body.enabled) {
+    // Fresh machine: no launchd agent yet. Bootstrap from zero — the installer
+    // downloads the binary, writes the plist, reads creds from settings.json
+    // (the UI saved them just before calling this), and starts the service.
+    // It is slow (binary download), so run it in the background and let the
+    // client poll GET for readiness.
     if (!fs.existsSync(/*turbopackIgnore: true*/ plist)) {
-      return Response.json(
-        { error: 'OpenObserve agent not installed — run scripts/install-openobserve-daemon.sh' },
-        { status: 409 },
-      )
+      const script = resolveInstaller()
+      if (!script) {
+        return Response.json(
+          { error: 'OpenObserve installer not found (scripts/install-openobserve-daemon.sh)' },
+          { status: 500 },
+        )
+      }
+      const started = startBackgroundInstall(script)
+      if (!started.ok) {
+        return Response.json({ error: started.error ?? 'failed to start installer' }, { status: 500 })
+      }
+      return Response.json({ ok: true, installing: true })
     }
+
     // Sync the UI-entered credentials into the plist's ZO_ROOT_USER_* env vars
     // BEFORE the service's first start. OpenObserve creates its root account
-    // from these on its FIRST boot only (no user store yet) — this is what
-    // lets a first-time user simply pick an email/password in Settings and
-    // have it become their OpenObserve login. Once the instance is
-    // initialised the env vars are ignored, so we skip the patch AND the
-    // bootout/bootstrap cycle it requires — if OO is already running,
-    // enabling must not bounce it (the restart window reads as "Apply didn't
-    // work" to anyone who clicks "Open OpenObserve" right away).
+    // from these on its FIRST boot only — once the data dir is populated they
+    // are ignored, so we skip the patch (and the restart it requires) to avoid
+    // bouncing an already-running instance.
     const dataDir = path.join(/*turbopackIgnore: true*/ os.homedir(), '.openobserve', 'data')
     let initialised = false
     try {
@@ -67,8 +161,7 @@ export async function POST(req: Request) {
     if (!initialised && oo_email && oo_password) {
       await launchctl('bootout', target) // ensure next bootstrap reads the fresh plist
       // launchd tears the entry down asynchronously; bootstrap fails with EIO
-      // while it lingers. Poll until gone (max ~5 s) — same guard as the
-      // install script's bootout wait loop.
+      // while it lingers. Poll until gone (max ~5 s).
       for (let i = 0; i < 10; i++) {
         if (!(await launchctl('print', target)).ok) break
         await new Promise(r => setTimeout(r, 500))
@@ -85,9 +178,18 @@ export async function POST(req: Request) {
     await launchctl('enable', target)
     await launchctl('bootstrap', domain, plist) // "already bootstrapped" is fine
     await launchctl('kickstart', target)        // start now if not running
-    const up = (await launchctl('print', target)).ok
+    // Confirm OO is actually SERVING, not merely loaded — launchctl reports a
+    // job as present the moment it is bootstrapped, well before it binds :5080.
+    let up = false
+    for (let i = 0; i < 20; i++) {
+      if (await reachable()) { up = true; break }
+      await new Promise(r => setTimeout(r, 500))
+    }
     if (!up) {
-      return Response.json({ error: 'OpenObserve failed to start — check ~/.meridian/logs/openobserve-error.log' }, { status: 500 })
+      return Response.json(
+        { error: 'OpenObserve did not become reachable — see ~/.meridian/logs/openobserve-error.log' },
+        { status: 500 },
+      )
     }
     return Response.json({ ok: true, running: true })
   }

--- a/ui/app/api/openobserve/route.ts
+++ b/ui/app/api/openobserve/route.ts
@@ -13,6 +13,7 @@ import { promisify } from 'util'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
+import { readSettings } from '@/lib/settings'
 
 export const dynamic = 'force-dynamic'
 
@@ -47,6 +48,31 @@ export async function POST(req: Request) {
         { error: 'OpenObserve agent not installed — run scripts/install-openobserve-daemon.sh' },
         { status: 409 },
       )
+    }
+    // Sync the UI-entered credentials into the plist's ZO_ROOT_USER_* env vars
+    // BEFORE the service starts. OpenObserve creates its root account from
+    // these on its FIRST boot (no user store yet) — this is what lets a
+    // first-time user simply pick an email/password in Settings and have it
+    // become their OpenObserve login. On an already-initialised instance the
+    // env vars are ignored, so this is harmless. The service must be stopped
+    // when the plist changes, so patch → (re)bootstrap, not patch-while-running.
+    const { oo_email, oo_password } = readSettings()
+    if (oo_email && oo_password) {
+      await launchctl('bootout', target) // ensure next bootstrap reads the fresh plist
+      // launchd tears the entry down asynchronously; bootstrap fails with EIO
+      // while it lingers. Poll until gone (max ~5 s) — same guard as the
+      // install script's bootout wait loop.
+      for (let i = 0; i < 10; i++) {
+        if (!(await launchctl('print', target)).ok) break
+        await new Promise(r => setTimeout(r, 500))
+      }
+      const patch = async (key: string, value: string) => {
+        try {
+          await execFileP('plutil', ['-replace', `EnvironmentVariables.${key}`, '-string', value, plist])
+        } catch { /* plist without EnvironmentVariables dict — leave as installed */ }
+      }
+      await patch('ZO_ROOT_USER_EMAIL', oo_email)
+      await patch('ZO_ROOT_USER_PASSWORD', oo_password)
     }
     // enable first: bootstrap fails with EIO on a disabled service.
     await launchctl('enable', target)

--- a/ui/app/api/openobserve/route.ts
+++ b/ui/app/api/openobserve/route.ts
@@ -55,6 +55,35 @@ async function reachable(): Promise<boolean> {
   }
 }
 
+// The configured OTLP traces URL (settings override → local default). Used as
+// the authenticated probe target below.
+function tracesUrl(): string {
+  const { otlp_endpoint } = readSettings()
+  return otlp_endpoint && otlp_endpoint.trim()
+    ? otlp_endpoint
+    : 'http://localhost:5080/api/default/v1/traces'
+}
+
+// Do the given credentials actually authenticate against the running
+// OpenObserve? Good auth → 200, wrong auth → 401/403. Lets us catch the case
+// where OO was already initialised with a different root account (changing the
+// password in Settings after first boot is a no-op — OO only reads
+// ZO_ROOT_USER_* on first boot — so the new creds would silently not work).
+async function authOk(email: string, password: string): Promise<boolean> {
+  try {
+    const auth = Buffer.from(`${email}:${password}`).toString('base64')
+    const r = await fetch(tracesUrl(), {
+      method: 'POST',
+      headers: { Authorization: `Basic ${auth}`, 'Content-Type': 'application/x-protobuf' },
+      body: new Uint8Array(),
+      signal: AbortSignal.timeout(2000),
+    })
+    return r.status !== 401 && r.status !== 403
+  } catch {
+    return false
+  }
+}
+
 // Resolve install-openobserve-daemon.sh across install types: bundle first
 // (~/.meridian/app), then walk up from cwd for a source checkout.
 function resolveInstaller(): string | null {
@@ -189,6 +218,20 @@ export async function POST(req: Request) {
       return Response.json(
         { error: 'OpenObserve did not become reachable — see ~/.meridian/logs/openobserve-error.log' },
         { status: 500 },
+      )
+    }
+    // Already-initialised instance: verify the credentials in Settings actually
+    // log in. If they don't, the user almost certainly changed email/password
+    // after OO's first boot — which OO ignores — so fail loudly instead of
+    // reporting success while export silently 401s.
+    if (initialised && oo_email && oo_password && !(await authOk(oo_email, oo_password))) {
+      return Response.json(
+        {
+          error:
+            'OpenObserve is already initialised with a different login. Enter the existing ' +
+            'OpenObserve credentials, or reset ~/.openobserve/data to start over with new ones.',
+        },
+        { status: 409 },
       )
     }
     return Response.json({ ok: true, running: true })

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -288,3 +288,24 @@ html.density-comfy   .density-pad { padding-top: 1.25rem; padding-bottom: 1.25re
   -webkit-font-smoothing: auto;
   -moz-osx-font-smoothing: auto;
 }
+
+/* ── Radix Switch — iOS-style pill ────────────────────────────────────────────
+   Restored: these styles were added in 706364e (Apple-style Radix controls)
+   and silently dropped when globals.css was rewritten for the type scale.
+   Switch.tsx renders className="meridian-switch" and relies on this block —
+   without it every toggle's track is transparent (invisible). */
+.meridian-switch {
+  background: rgba(120, 120, 128, 0.28);
+  transition: background 0.22s ease;
+}
+.meridian-switch[data-state="checked"] {
+  background: var(--accent);
+}
+.meridian-switch-thumb {
+  transform: translateX(2px);
+  transition: transform 0.22s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+              box-shadow 0.15s ease;
+}
+.meridian-switch-thumb[data-state="checked"] {
+  transform: translateX(20px);
+}

--- a/ui/components/views/SettingsView.tsx
+++ b/ui/components/views/SettingsView.tsx
@@ -223,7 +223,7 @@ export default function SettingsView() {
         <FieldRow label="OpenObserve Export" description="Send traces and logs to the local OpenObserve instance. Off by default; enabling reveals the connection fields. Takes effect after a daemon restart.">
           <Switch checked={settings.otlp_enabled} onCheckedChange={v => patch({ otlp_enabled: v })} />
         </FieldRow>
-        <FieldRow label="Log Level" description="Controls verbosity of traces and logs (OpenObserve and local log files). DEBUG exports everything; WARNING/ERROR suppress info spans. Takes effect after a daemon restart.">
+        <FieldRow label="Log Level" description="Verbosity of daemon logs — always applies to the local log files, and to OpenObserve export when enabled. DEBUG logs everything; WARNING/ERROR suppress info. Hot-reloads on the next daemon tick.">
           <Select
             value={settings.log_level}
             onValueChange={v => patch({ log_level: v as RuntimeSettings['log_level'] })}

--- a/ui/components/views/SettingsView.tsx
+++ b/ui/components/views/SettingsView.tsx
@@ -149,15 +149,24 @@ export default function SettingsView() {
 
     // The toggle gates the OpenObserve SERVICE itself, not just the exporters:
     // enabled → start the launchd agent; disabled → stop it (and keep it off
-    // across logins). Failure here is surfaced but doesn't block the daemon
-    // reload — the daemon tolerates a missing OTLP backend.
+    // across logins). A failed start is a real error the user must see —
+    // otherwise "Apply" reports success while OpenObserve is down.
     try {
-      await fetch('/api/openobserve', {
+      const ooRes = await fetch('/api/openobserve', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ enabled: settings.otlp_enabled }),
       })
-    } catch { /* non-fatal — surfaced via the OO health card */ }
+      if (!ooRes.ok) {
+        setReloadStatus('error')
+        setTimeout(() => setReloadStatus('idle'), 3000)
+        return
+      }
+    } catch {
+      setReloadStatus('error')
+      setTimeout(() => setReloadStatus('idle'), 3000)
+      return
+    }
 
     setReloadStatus('reloading')
     const reloadRes = await fetch('/api/daemon/reload', { method: 'POST' })
@@ -220,7 +229,7 @@ export default function SettingsView() {
         <SectionHeader>Observability</SectionHeader>
         {/* Master switch first: when off, OpenObserve is disabled by default and
             the connection fields stay hidden — they appear only once enabled. */}
-        <FieldRow label="OpenObserve Export" description="Send traces and logs to the local OpenObserve instance. Off by default; enabling reveals the connection fields. Takes effect after a daemon restart.">
+        <FieldRow label="OpenObserve Export" description="Send traces and logs to the local OpenObserve instance. Off by default; enabling reveals the connection fields. Apply starts/stops OpenObserve and restarts the daemon for you.">
           <Switch checked={settings.otlp_enabled} onCheckedChange={v => patch({ otlp_enabled: v })} />
         </FieldRow>
         <FieldRow label="Log Level" description="Verbosity of daemon logs — always applies to the local log files, and to OpenObserve export when enabled. DEBUG logs everything; WARNING/ERROR suppress info. Hot-reloads on the next daemon tick.">
@@ -285,7 +294,7 @@ export default function SettingsView() {
           {reloadStatus === 'done' && <span style={{ fontSize: '12px', color: 'var(--success)' }}>Active</span>}
           {reloadStatus === 'error' && <span style={{ fontSize: '12px', color: 'var(--warn)' }}>Failed</span>}
           <span style={{ fontSize: '11px', color: 'var(--ink-3)' }}>
-            {reloadStatus === 'reloading' ? 'Restarting daemon…' : 'Log level applies next tick · endpoint/credentials require restart'}
+            {reloadStatus === 'reloading' ? 'Restarting daemon…' : 'Apply handles everything — starts/stops OpenObserve and restarts the daemon'}
           </span>
           {settings.otlp_enabled && (
             <button

--- a/ui/components/views/SettingsView.tsx
+++ b/ui/components/views/SettingsView.tsx
@@ -9,7 +9,22 @@ import { TextInput } from '@/components/ui/TextInput'
 import type { RuntimeSettings } from '@/lib/settings'
 
 type SaveStatus = 'idle' | 'saved' | 'error'
-type ReloadStatus = 'idle' | 'saving' | 'reloading' | 'done' | 'error'
+type ReloadStatus = 'idle' | 'saving' | 'installing' | 'reloading' | 'done' | 'error'
+
+// Poll GET /api/openobserve until OpenObserve is reachable or the background
+// install fails. Returns true when reachable. Up to ~90 s (binary download).
+async function pollOpenObserveReady(): Promise<boolean> {
+  for (let i = 0; i < 60; i++) {
+    try {
+      const r = await fetch('/api/openobserve')
+      const s = await r.json() as { reachable?: boolean; failed?: boolean }
+      if (s.reachable) return true
+      if (s.failed) return false
+    } catch { /* keep polling */ }
+    await new Promise(res => setTimeout(res, 1500))
+  }
+  return false
+}
 
 function SectionCard({ children }: { children: React.ReactNode }) {
   return (
@@ -148,9 +163,10 @@ export default function SettingsView() {
     }
 
     // The toggle gates the OpenObserve SERVICE itself, not just the exporters:
-    // enabled → start the launchd agent; disabled → stop it (and keep it off
-    // across logins). A failed start is a real error the user must see —
-    // otherwise "Apply" reports success while OpenObserve is down.
+    // enabled → start the launchd agent (installing it first on a fresh
+    // machine); disabled → stop it (and keep it off across logins). A failed
+    // start is a real error the user must see — otherwise "Apply" reports
+    // success while OpenObserve is down.
     try {
       const ooRes = await fetch('/api/openobserve', {
         method: 'POST',
@@ -161,6 +177,19 @@ export default function SettingsView() {
         setReloadStatus('error')
         setTimeout(() => setReloadStatus('idle'), 3000)
         return
+      }
+      // Fresh machine: the server is downloading + installing OpenObserve in
+      // the background. Poll until it is reachable (binary download can take
+      // ~30 s) before continuing to the daemon reload.
+      const ooBody = await ooRes.json() as { installing?: boolean }
+      if (ooBody.installing) {
+        setReloadStatus('installing')
+        const ready = await pollOpenObserveReady()
+        if (!ready) {
+          setReloadStatus('error')
+          setTimeout(() => setReloadStatus('idle'), 4000)
+          return
+        }
       }
     } catch {
       setReloadStatus('error')
@@ -275,7 +304,7 @@ export default function SettingsView() {
           <button
             type="button"
             onClick={applyObservability}
-            disabled={reloadStatus === 'saving' || reloadStatus === 'reloading'}
+            disabled={reloadStatus === 'saving' || reloadStatus === 'installing' || reloadStatus === 'reloading'}
             style={{
               background: 'var(--accent)',
               color: '#fff',
@@ -284,17 +313,22 @@ export default function SettingsView() {
               padding: '5px 14px',
               borderRadius: '6px',
               border: 'none',
-              cursor: reloadStatus === 'saving' || reloadStatus === 'reloading' ? 'not-allowed' : 'default',
-              opacity: reloadStatus === 'saving' || reloadStatus === 'reloading' ? 0.7 : 1,
+              cursor: reloadStatus === 'saving' || reloadStatus === 'installing' || reloadStatus === 'reloading' ? 'not-allowed' : 'default',
+              opacity: reloadStatus === 'saving' || reloadStatus === 'installing' || reloadStatus === 'reloading' ? 0.7 : 1,
               boxShadow: '0 1px 3px rgba(0,0,0,0.15)',
             }}
           >
-            {reloadStatus === 'saving' ? 'Saving…' : reloadStatus === 'reloading' ? 'Reloading…' : 'Apply'}
+            {reloadStatus === 'saving' ? 'Saving…'
+              : reloadStatus === 'installing' ? 'Installing…'
+              : reloadStatus === 'reloading' ? 'Reloading…'
+              : 'Apply'}
           </button>
           {reloadStatus === 'done' && <span style={{ fontSize: '12px', color: 'var(--success)' }}>Active</span>}
           {reloadStatus === 'error' && <span style={{ fontSize: '12px', color: 'var(--warn)' }}>Failed</span>}
           <span style={{ fontSize: '11px', color: 'var(--ink-3)' }}>
-            {reloadStatus === 'reloading' ? 'Restarting daemon…' : 'Apply handles everything — starts/stops OpenObserve and restarts the daemon'}
+            {reloadStatus === 'installing' ? 'Downloading & installing OpenObserve (first time only)…'
+              : reloadStatus === 'reloading' ? 'Restarting daemon…'
+              : 'Apply handles everything — installs/starts/stops OpenObserve and restarts the daemon'}
           </span>
           {settings.otlp_enabled && (
             <button

--- a/ui/components/views/SettingsView.tsx
+++ b/ui/components/views/SettingsView.tsx
@@ -198,43 +198,51 @@ export default function SettingsView() {
       {/* Observability */}
       <SectionCard>
         <SectionHeader>Observability</SectionHeader>
-        <FieldRow label="Log Level" description="Controls verbosity of traces and logs sent to OpenObserve. DEBUG exports everything; WARNING/ERROR suppress info spans. Takes effect after a daemon restart.">
+        {/* Master switch first: when off, OpenObserve is disabled by default and
+            the connection fields stay hidden — they appear only once enabled. */}
+        <FieldRow label="OpenObserve Export" description="Send traces and logs to the local OpenObserve instance. Off by default; enabling reveals the connection fields. Takes effect after a daemon restart.">
+          <Switch checked={settings.otlp_enabled} onCheckedChange={v => patch({ otlp_enabled: v })} />
+        </FieldRow>
+        <FieldRow label="Log Level" description="Controls verbosity of traces and logs (OpenObserve and local log files). DEBUG exports everything; WARNING/ERROR suppress info spans. Takes effect after a daemon restart.">
           <Select
             value={settings.log_level}
             onValueChange={v => patch({ log_level: v as RuntimeSettings['log_level'] })}
             options={LOG_LEVEL_OPTIONS}
           />
         </FieldRow>
-        <FieldRow label="OpenObserve Export" description="Send traces and logs to the local OpenObserve instance. Requires credentials below; takes effect after a daemon restart.">
-          <Switch checked={settings.otlp_enabled} onCheckedChange={v => patch({ otlp_enabled: v })} />
-        </FieldRow>
-        <FieldRow label="OTLP Endpoint" description="Leave blank to use the default (localhost:5080).">
-          <TextInput
-            value={settings.otlp_endpoint}
-            onChange={v => patch({ otlp_endpoint: v })}
-            placeholder="http://localhost:5080/api/default/v1/traces"
-          />
-        </FieldRow>
-        <FieldRow label="Email">
-          <TextInput
-            type="email"
-            value={settings.oo_email}
-            onChange={v => patch({ oo_email: v })}
-            placeholder="admin@example.com"
-          />
-        </FieldRow>
-        <FieldRow label="Password">
-          <TextInput
-            type="password"
-            value={settings.oo_password}
-            onChange={v => patch({ oo_password: v })}
-            placeholder="••••••••"
-          />
-        </FieldRow>
+        {settings.otlp_enabled && (
+          <>
+            <FieldRow label="OTLP Endpoint" description="Leave blank to use the default (localhost:5080).">
+              <TextInput
+                value={settings.otlp_endpoint}
+                onChange={v => patch({ otlp_endpoint: v })}
+                placeholder="http://localhost:5080/api/default/v1/traces"
+              />
+            </FieldRow>
+            <FieldRow label="Email">
+              <TextInput
+                type="email"
+                value={settings.oo_email}
+                onChange={v => patch({ oo_email: v })}
+                placeholder="admin@example.com"
+              />
+            </FieldRow>
+            <FieldRow label="Password">
+              <TextInput
+                type="password"
+                value={settings.oo_password}
+                onChange={v => patch({ oo_password: v })}
+                placeholder="••••••••"
+              />
+            </FieldRow>
+          </>
+        )}
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px', paddingTop: '8px', borderTop: '1px solid var(--rule)' }}>
           {/* Log Level → hot-reloaded in-process (no restart). All other OTel
-              fields require the daemon to restart to rebuild the exporters —
-              "Apply" saves settings then sends SIGHUP; launchd restarts it. */}
+              fields require the daemon to rebuild its exporters — "Apply" saves
+              settings then sends SIGHUP to ONLY the daemon PID; launchd's
+              KeepAlive relaunches that single service, leaving screenpipe / MLX /
+              UI untouched. */}
           <button
             type="button"
             onClick={applyObservability}
@@ -259,29 +267,31 @@ export default function SettingsView() {
           <span style={{ fontSize: '11px', color: 'var(--ink-3)' }}>
             {reloadStatus === 'reloading' ? 'Restarting daemon…' : 'Log level applies next tick · endpoint/credentials require restart'}
           </span>
-          <button
-            type="button"
-            onClick={() => {
-              let base = 'http://localhost:5080'
-              try {
-                if (settings.otlp_endpoint) base = new URL(settings.otlp_endpoint).origin
-              } catch { /* keep default */ }
-              window.open(base, '_blank', 'noopener,noreferrer')
-            }}
-            style={{
-              background: 'transparent',
-              color: 'var(--accent)',
-              fontSize: '12px',
-              fontWeight: 500,
-              padding: '5px 14px',
-              borderRadius: '6px',
-              border: '1px solid var(--accent)',
-              cursor: 'default',
-              marginLeft: 'auto',
-            }}
-          >
-            Open OpenObserve
-          </button>
+          {settings.otlp_enabled && (
+            <button
+              type="button"
+              onClick={() => {
+                let base = 'http://localhost:5080'
+                try {
+                  if (settings.otlp_endpoint) base = new URL(settings.otlp_endpoint).origin
+                } catch { /* keep default */ }
+                window.open(base, '_blank', 'noopener,noreferrer')
+              }}
+              style={{
+                background: 'transparent',
+                color: 'var(--accent)',
+                fontSize: '12px',
+                fontWeight: 500,
+                padding: '5px 14px',
+                borderRadius: '6px',
+                border: '1px solid var(--accent)',
+                cursor: 'default',
+                marginLeft: 'auto',
+              }}
+            >
+              Open OpenObserve
+            </button>
+          )}
         </div>
       </SectionCard>
 

--- a/ui/components/views/SettingsView.tsx
+++ b/ui/components/views/SettingsView.tsx
@@ -97,6 +97,7 @@ const LOG_LEVEL_OPTIONS = [
 export default function SettingsView() {
   const [settings, setSettings] = useState<RuntimeSettings | null>(null)
   const [reloadStatus, setReloadStatus] = useState<ReloadStatus>('idle')
+  const [reloadMsg, setReloadMsg] = useState<string | null>(null)
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const [etlStatus, setEtlStatus] = useState<SaveStatus>('idle')
   const [classificationStatus, setClassificationStatus] = useState<SaveStatus>('idle')
@@ -140,6 +141,7 @@ export default function SettingsView() {
   // needed); this button handles the credential/toggle/endpoint case.
   const applyObservability = useCallback(async () => {
     if (!settings) return
+    setReloadMsg(null)
     setReloadStatus('saving')
     try {
       const res = await fetch('/api/settings', {
@@ -174,8 +176,10 @@ export default function SettingsView() {
         body: JSON.stringify({ enabled: settings.otlp_enabled }),
       })
       if (!ooRes.ok) {
+        const b = await ooRes.json().catch(() => ({})) as { error?: string }
+        setReloadMsg(b.error ?? 'OpenObserve start failed')
         setReloadStatus('error')
-        setTimeout(() => setReloadStatus('idle'), 3000)
+        setTimeout(() => { setReloadStatus('idle'); setReloadMsg(null) }, 8000)
         return
       }
       // Fresh machine: the server is downloading + installing OpenObserve in
@@ -324,7 +328,7 @@ export default function SettingsView() {
               : 'Apply'}
           </button>
           {reloadStatus === 'done' && <span style={{ fontSize: '12px', color: 'var(--success)' }}>Active</span>}
-          {reloadStatus === 'error' && <span style={{ fontSize: '12px', color: 'var(--warn)' }}>Failed</span>}
+          {reloadStatus === 'error' && <span style={{ fontSize: '12px', color: 'var(--warn)' }}>{reloadMsg ?? 'Failed'}</span>}
           <span style={{ fontSize: '11px', color: 'var(--ink-3)' }}>
             {reloadStatus === 'installing' ? 'Downloading & installing OpenObserve (first time only)…'
               : reloadStatus === 'reloading' ? 'Restarting daemon…'

--- a/ui/components/views/SettingsView.tsx
+++ b/ui/components/views/SettingsView.tsx
@@ -232,27 +232,27 @@ export default function SettingsView() {
         </FieldRow>
         {settings.otlp_enabled && (
           <>
-            <FieldRow label="OTLP Endpoint" description="Leave blank to use the default (localhost:5080).">
-              <TextInput
-                value={settings.otlp_endpoint}
-                onChange={v => patch({ otlp_endpoint: v })}
-                placeholder="http://localhost:5080/api/default/v1/traces"
-              />
-            </FieldRow>
-            <FieldRow label="Email">
+            <FieldRow label="Email" description="Your OpenObserve login. First time? Just pick an email and password here — they become the OpenObserve root account when the service first starts. Already using OpenObserve? Enter the credentials you log in with.">
               <TextInput
                 type="email"
                 value={settings.oo_email}
                 onChange={v => patch({ oo_email: v })}
-                placeholder="admin@example.com"
+                placeholder="you@example.com"
               />
             </FieldRow>
-            <FieldRow label="Password">
+            <FieldRow label="Password" description="Stored locally; used to log in at localhost:5080 and as auth for trace/log export.">
               <TextInput
                 type="password"
                 value={settings.oo_password}
                 onChange={v => patch({ oo_password: v })}
                 placeholder="••••••••"
+              />
+            </FieldRow>
+            <FieldRow label="OTLP Endpoint (optional)" description="Advanced — leave blank for the local OpenObserve instance. Only set this to export to a remote collector.">
+              <TextInput
+                value={settings.otlp_endpoint}
+                onChange={v => patch({ otlp_endpoint: v })}
+                placeholder="http://localhost:5080/api/default/v1/traces"
               />
             </FieldRow>
           </>

--- a/ui/components/views/SettingsView.tsx
+++ b/ui/components/views/SettingsView.tsx
@@ -119,9 +119,10 @@ export default function SettingsView() {
     }
   }
 
-  // Save observability settings then send SIGHUP so the daemon restarts and
-  // picks up the new OTLP config. Log-level changes are hot-reloaded in-process
-  // (no restart needed); this button handles the credential/toggle/endpoint case.
+  // Save observability settings, start/stop the OpenObserve service to match
+  // the toggle, then send SIGHUP so the daemon restarts and picks up the new
+  // OTLP config. Log-level changes are hot-reloaded in-process (no restart
+  // needed); this button handles the credential/toggle/endpoint case.
   const applyObservability = useCallback(async () => {
     if (!settings) return
     setReloadStatus('saving')
@@ -146,8 +147,27 @@ export default function SettingsView() {
       return
     }
 
+    // The toggle gates the OpenObserve SERVICE itself, not just the exporters:
+    // enabled → start the launchd agent; disabled → stop it (and keep it off
+    // across logins). Failure here is surfaced but doesn't block the daemon
+    // reload — the daemon tolerates a missing OTLP backend.
+    try {
+      await fetch('/api/openobserve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: settings.otlp_enabled }),
+      })
+    } catch { /* non-fatal — surfaced via the OO health card */ }
+
     setReloadStatus('reloading')
     const reloadRes = await fetch('/api/daemon/reload', { method: 'POST' })
+    if (reloadRes.status === 503) {
+      // Daemon not running (e.g. dev session with the stack down) — settings
+      // are saved and will be read at the next daemon start. Not an error.
+      setReloadStatus('done')
+      setTimeout(() => setReloadStatus('idle'), 3000)
+      return
+    }
     if (!reloadRes.ok) {
       setReloadStatus('error')
       setTimeout(() => setReloadStatus('idle'), 3000)

--- a/ui/lib/settings.ts
+++ b/ui/lib/settings.ts
@@ -27,7 +27,8 @@ export interface RuntimeSettings {
 
 export const SETTINGS_DEFAULTS: RuntimeSettings = {
   log_level: 'INFO',
-  otlp_enabled: true,
+  // OpenObserve export is opt-in: off until the user enables it in Settings.
+  otlp_enabled: false,
   otlp_endpoint: '',
   oo_email: '',
   oo_password: '',

--- a/ui/lib/settings.ts
+++ b/ui/lib/settings.ts
@@ -42,10 +42,9 @@ export const SETTINGS_DEFAULTS: RuntimeSettings = {
   jira_update_enabled: true,
 }
 
-// The daemon reads the repo-local settings.json (cwd = repo root). The UI must
-// write the SAME file or its toggles never reach the daemon. The UI runs with
-// cwd = <repo>/ui (launchd WorkingDirectory and `next dev`/`start`), so the repo
-// root is the nearest ancestor containing Cargo.toml.
+// repoRoot finds the source-checkout root (nearest ancestor with Cargo.toml).
+// Used only for the legacy read fallback below — the UI writes to the canonical
+// ~/.meridian/settings.json, not here.
 function repoRoot(): string {
   let dir = process.cwd()
   for (let i = 0; i < 6; i++) {
@@ -60,16 +59,32 @@ function repoRoot(): string {
 
 // Lazy getters to avoid tracing filesystem ops at build time (Turbopack NFT issue).
 // These are only called at runtime when API routes execute.
+//
+// Canonical settings path — MUST match the daemon's resolution in
+// src/config.rs::settings_json_path(). The daemon's cwd varies by install type
+// (repo root under `cargo run`, ~/.meridian/app for a bundle), so neither side
+// resolves settings.json relative to cwd; both use ~/.meridian/settings.json
+// (next to meridian.db), overridable via MERIDIAN_SETTINGS_PATH. The repo-local
+// settings.json survives only as a read-time migration fallback.
 function getSettingsPath(): string {
-  return path.join(/*turbopackIgnore: true*/ repoRoot(), 'settings.json')
-}
-
-function getLegacySettingsPath(): string {
+  const override = process.env.MERIDIAN_SETTINGS_PATH
+  if (override && override.trim()) {
+    const expanded = override.startsWith('~/')
+      ? path.join(/*turbopackIgnore: true*/ os.homedir(), override.slice(2))
+      : override
+    return expanded
+  }
   return path.join(/*turbopackIgnore: true*/ os.homedir(), '.meridian', 'settings.json')
 }
 
+// Legacy location: a source checkout may still carry settings.json in the repo
+// root. Read-only fallback so existing dev configs migrate on first write.
+function getRepoSettingsPath(): string {
+  return path.join(/*turbopackIgnore: true*/ repoRoot(), 'settings.json')
+}
+
 export function readSettings(): RuntimeSettings {
-  for (const p of [getSettingsPath(), getLegacySettingsPath()]) {
+  for (const p of [getSettingsPath(), getRepoSettingsPath()]) {
     try {
       const raw = fs.readFileSync(/*turbopackIgnore: true*/ p, 'utf-8')
       const parsed = JSON.parse(raw)


### PR DESCRIPTION
## ⚠️ Do NOT click "Merge" — this is a history correction, applied by force-updating `main`

A normal merge cannot fix the problem: semantic-release computes the version from every commit message since the last tag (`v1.51.0`), and the `BREAKING CHANGE` footer is baked into the already-merged commit `3b4ff4d`. Merging this branch forward would leave that footer in range → it would still cut **2.0.0**. The footer can only be removed by replacing `main`'s history.

## What happened
- #271 merged, and its `feat(observability)!: deprecate MERIDIAN_OO_AUTH` commit (`!` + `BREAKING CHANGE:` footer) made semantic-release bump **major → 2.0.0**.
- The release then died on `git push --tags` (a transient GitHub HTTP 500), so **nothing shipped** — no `v2.0.0` tag, no npm publish, no GitHub release. Only the `chore(release): 2.0.0` commit (`0deb06f`) landed on `main`.
- The deprecation is real but **not worth a major** for this tool → it should be a minor (1.52.0).

## What this branch is
The exact 12 commits of #271, rebuilt linearly on `v1.51.0` (`40bd410`), with:
- the deprecation commit **reworded** to a plain `feat(observability):` (dropped `!` and the `BREAKING CHANGE:` footer) — **code unchanged**
- the `chore(release): 2.0.0` commit **dropped** (manifests + CHANGELOG back at 1.51.0)

**Verification:** `git diff <this-branch> ce88c17` is empty — the tree is byte-identical to the merged code that already passed CI + a full 362-test local run. Only commit messages/SHAs changed.

## How to apply (maintainer, from a clone)
```bash
git fetch origin
git push --force-with-lease=main:0deb06fff2c63e2a8730b44268c38fcc8baff6c3 \
  origin origin/fix/release-history-1.52:main
```
`--force-with-lease` aborts unless `main` is still at the broken `0deb06f`, so it can't clobber a newer push. After it lands, the push (no `[skip ci]`) triggers the release workflow → semantic-release sees only `feat`/`fix` since `v1.51.0` → ships **1.52.0**.

Backup of the current (broken) `main` is kept locally as `backup/main-pre-relfix` → `0deb06f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)