### PR TITLE
fix(bundle): ship the OpenObserve installer + plist so the dashboard toggle works on installs

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -187,10 +187,17 @@ cp scripts/install-daemon.sh scripts/uninstall-daemon.sh \
    scripts/install-ui-daemon.sh scripts/uninstall-ui-daemon.sh \
    scripts/install-screenpipe-daemon.sh scripts/uninstall-screenpipe-daemon.sh \
    scripts/install-a11y-helper-daemon.sh "${DEST}/scripts/"
+# OpenObserve installer + plist: required at runtime by the dashboard's
+# "OpenObserve Export" toggle, which bootstraps OO on demand via
+# POST /api/openobserve → scripts/install-openobserve-daemon.sh. Without these
+# in the bundle the toggle errors "OpenObserve installer not found".
+cp scripts/install-openobserve-daemon.sh scripts/uninstall-openobserve-daemon.sh \
+   "${DEST}/scripts/"
 cp scripts/com.meridiona.daemon.plist \
    scripts/com.meridiona.screenpipe.plist \
    scripts/com.meridiona.a11y-helper.plist \
    scripts/com.meridiona.ui.plist \
+   scripts/com.meridiona.openobserve.plist \
    scripts/com.meridiona.tray.plist "${DEST}/scripts/"
 cp scripts/install-tray-daemon.sh scripts/uninstall-tray-daemon.sh "${DEST}/scripts/"
 


### PR DESCRIPTION
## Bug
On a **bundle install**, enabling "OpenObserve Export" in the dashboard fails with:
> OpenObserve installer not found (scripts/install-openobserve-daemon.sh)

`POST /api/openobserve` bootstraps OpenObserve on a fresh machine by running `~/.meridian/app/scripts/install-openobserve-daemon.sh`, but `package-release.sh` copies an explicit script allowlist into the bundle that **omitted** that script (along with its plist and uninstaller). So the file is never present in an installed bundle — only in source checkouts. Confirmed against a live install: no `*openobserve*` files in `~/.meridian/app/scripts/`.

This shipped in 1.52.0 (the bootstrap-on-enable feature landed without the script being bundled).

## Fix
Add to `package-release.sh`'s copy list:
- `scripts/install-openobserve-daemon.sh`
- `scripts/uninstall-openobserve-daemon.sh`
- `scripts/com.meridiona.openobserve.plist` (the installer substitutes this template; it must sit beside the script)

## Verified
- The new `cp` lines copy all three (dry-run into a temp dir ✓)
- The route resolves exactly `~/.meridian/app/scripts/install-openobserve-daemon.sh` (route.ts:91), which the bundle will now contain
- The installer finds its plist via `SCRIPT_DIR` (same dir) and reads creds from `settings.json` — both satisfied once shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)