### PR TITLE
fix(ui): gate standalone output on build phase so dev server boots

### DIFF
--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from 'next'
+import { PHASE_PRODUCTION_BUILD } from 'next/constants'
 import path from 'path'
 
-const nextConfig: NextConfig = {
+const nextConfig = (phase: string): NextConfig => ({
   // Pin the Turbopack workspace root to this `ui/` directory. The repo root
   // also has a package-lock.json, so Turbopack otherwise infers the monorepo
   // root and tries to watch the whole tree — including the 22 GB Rust
@@ -20,7 +21,12 @@ const nextConfig: NextConfig = {
   // crash-loops the standalone server. So package-release.sh packs the standalone
   // into `ui.tar.gz` (tar preserves symlinks; npm ships it as one opaque file) and
   // install-from-bundle.sh extracts it on the user's machine — keeping Turbopack.
-  output: 'standalone',
+  //
+  // Gate on the build phase, NOT process.env.NODE_ENV: a stray NODE_ENV=production
+  // in the shell otherwise enables standalone during `next dev`, which double-joins
+  // the dev distDir (`.next/dev/dev`) and panics Turbopack with
+  // "Invalid distDirRoot: .next" (vercel/next.js#87881).
+  output: phase === PHASE_PRODUCTION_BUILD ? 'standalone' : undefined,
   // Pin the standalone file-tracing root to this `ui/` dir. The repo root also
   // has a package-lock.json, so Next otherwise infers the monorepo root and
   // nests the output as `.next/standalone/ui/server.js` — which breaks the
@@ -44,6 +50,6 @@ const nextConfig: NextConfig = {
   logging: {
     fetches: { fullUrl: false },
   },
-}
+})
 
 export default nextConfig

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "version": "1.52.2",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack -p 3939",
+    "dev": "env -u NODE_ENV next dev --turbopack -p 3939",
     "build": "next build && cp -r .next/static .next/standalone/.next/static",
     "start": "next start -p 3939",
     "lint": "next lint",


### PR DESCRIPTION
## Problem
`next dev --turbopack` crashes on startup with:

```
TurbopackInternalError: Invalid distDirRoot: ".next". distDirRoot should not navigate out of the projectPath.
```

`ui/next.config.ts` sets `output: 'standalone'` unconditionally. Combined with the pinned `outputFileTracingRoot` / `turbopack.root` (both `ui/`), Next 16.2's Turbopack mis-resolves the dev `distDir` and aborts. This blocks the local hot-reload dev server (`dev-start.sh` window #3 and `cd ui && npm run dev`).

## Fix
Gate `output: 'standalone'` on the **build phase** (`PHASE_PRODUCTION_BUILD`), not `process.env.NODE_ENV`:

```ts
const nextConfig = (phase: string): NextConfig => ({
  ...
  output: phase === PHASE_PRODUCTION_BUILD ? 'standalone' : undefined,
  ...
})
```

Plus a second line of defence on the dev script:

```jsonc
"dev": "env -u NODE_ENV next dev --turbopack -p 3939"
```

### Why phase, not `NODE_ENV`
The actual upstream of the panic is running `next dev` with a non-standard `NODE_ENV` (including `production`) exported in the shell — that double-joins the dev distDir (`.next/dev/dev`) and corrupts the Turbopack cache (vercel/next.js#87881). A `process.env.NODE_ENV === 'production'` gate would *still* emit standalone in exactly that scenario and keep crashing. `PHASE_PRODUCTION_BUILD` is true **only** during `next build`, so it's immune; `env -u NODE_ENV` strips a stray value so the corruption can't happen at all.

> Supersedes #274, which used the weaker `NODE_ENV` gate.

## Why this is safe
- `npm run build` runs under `PHASE_PRODUCTION_BUILD` → standalone bundle still emitted exactly as before. `package-release.sh` / `install-from-bundle.sh` are unaffected.
- `next dev` runs under `PHASE_DEVELOPMENT_SERVER` → no standalone tracing → Turbopack boots clean.

## Verification
- `npm run build` → succeeds, `.next/standalone/server.js` emitted (standalone still active for production).
- Config compiles as a phase function; no type errors in `next.config.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)