### PR TITLE
fix(uninstall): tear down orphaned OpenObserve + legacy crash-loop agents

### DIFF
--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -499,6 +499,7 @@ cmd_uninstall() {
     bash "${REPO_ROOT}/scripts/uninstall-daemon.sh" 2>/dev/null
     bash "${REPO_ROOT}/scripts/uninstall-screenpipe-daemon.sh" 2>/dev/null
     bash "${REPO_ROOT}/scripts/uninstall-tray-daemon.sh" 2>/dev/null
+    bash "${REPO_ROOT}/scripts/uninstall-openobserve-daemon.sh" 2>/dev/null
     # a11y-helper plist
     launchctl bootout "${GUI_TARGET}/com.meridiona.a11y-helper" 2>/dev/null || true
     rm -f "${HOME}/Library/LaunchAgents/com.meridiona.a11y-helper.plist"

--- a/scripts/uninstall-daemon.sh
+++ b/scripts/uninstall-daemon.sh
@@ -17,3 +17,20 @@ if [[ -f "${PLIST}" ]]; then
 else
     echo "(not installed) ${PLIST}"
 fi
+
+# Legacy agents: the Jira updater and coding-agent indexer used to run as their
+# own standalone Python launchd daemons. They were ported into this Rust daemon
+# (the Python modules were deleted), but a pre-port install leaves the old
+# KeepAlive agents behind — they then crash-loop every ~10s against the missing
+# modules and spam ~MB/min into their logs. Boot out + disable + remove them so
+# an upgrade-then-uninstall leaves nothing orphaned. Idempotent: no-ops when the
+# agents aren't present.
+for legacy in com.meridiona.jira-updater com.meridiona.coding-agent-indexer; do
+    legacy_plist="${HOME}/Library/LaunchAgents/${legacy}.plist"
+    if launchctl print "${GUI_TARGET}/${legacy}" >/dev/null 2>&1; then
+        launchctl disable "${GUI_TARGET}/${legacy}" 2>/dev/null || true
+        launchctl bootout "${GUI_TARGET}/${legacy}" 2>/dev/null || true
+        echo "✓ removed legacy agent ${legacy}"
+    fi
+    rm -f "${legacy_plist}"
+done


### PR DESCRIPTION
## Problem

`meridian uninstall` (`cmd_uninstall` in `scripts/meridian-cli.sh`) tears down ui / mlx-server / daemon / screenpipe / tray / a11y-helper, but leaves two classes of agent orphaned:

1. **OpenObserve** (`com.meridiona.openobserve`) — installed by `install.sh` / `install-dev.sh` but never removed on uninstall, so the process keeps listening on port 5080 and the plist stays in `~/Library/LaunchAgents/`.
2. **Legacy Python agents** (`com.meridiona.jira-updater`, `com.meridiona.coding-agent-indexer`) — these used to run as standalone Python launchd daemons, then were ported into the Rust daemon and their Python modules deleted. A pre-port install leaves the old `KeepAlive` agents behind; they then **crash-loop every ~10s** against the missing modules and spam ~MB/min into their logs. No current install script registers these labels, so the teardown is pure orphan cleanup.

## Fix

- **`scripts/meridian-cli.sh`** — `cmd_uninstall` now also runs `scripts/uninstall-openobserve-daemon.sh` (the script already exists and is already shipped in the release bundle; it just was never wired in).
- **`scripts/uninstall-daemon.sh`** — boots out, disables, and removes the legacy `jira-updater` / `coding-agent-indexer` plists. Idempotent — no-ops when the agents aren't present.

Both fixes are idempotent and preserve data: OpenObserve trace data at `~/.openobserve/data/` is left intact.

## Relationship to #158

This **supersedes the still-relevant half of #158**, rebased onto current `main`. The other two hunks in #158 are now redundant/obsolete and are intentionally dropped:

- `package-release.sh` already ships `install-openobserve-daemon.sh` + `uninstall-openobserve-daemon.sh` + the plist (added by later openobserve work).
- The README "Utility Scripts" table #158 edited no longer exists — the README was cut 337 → 151 lines and that content moved to `SETUP.md`.

#158 should be closed in favour of this PR.

## Verification

- `bash -n scripts/meridian-cli.sh` and `bash -n scripts/uninstall-daemon.sh` both clean.
- `uninstall-openobserve-daemon.sh` exists on `main` and is the same script `cmd_uninstall` now invokes.
- The legacy block guards every action behind `launchctl print … >/dev/null` and `rm -f`, so re-running on a clean machine is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)