### PR TITLE
fix(ui): spawn native meridian binary, not the node wrapper, under launchd

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,7 @@ Read `VISION.md` first.
 - Use `better-sqlite3` (synchronous) in the MCP server — it runs in a single-threaded Node process
 - UI API routes live in `ui/app/api/`; keep them thin — query, transform, return JSON
 - No `any` types unless unavoidable and justified with a comment
+- **Spawning the `meridian` binary from a UI route: ALWAYS use `selectMeridianBinary(meridianCandidates())` from `@/lib/meridian-bin`.** Never spawn a bare `'meridian'` (relies on `$PATH`), and never hand-roll a candidate list. The dashboard runs under **launchd**, whose PATH lacks Homebrew's `node`, so the `#!/usr/bin/env node` wrapper at `~/.local/bin/meridian` dies with `env: node: No such file or directory`. The helper probes the **native binary first** (`~/.meridian/app/bin/meridian`, no runtime deps → works under launchd), so it behaves identically in dev and installed. This bug is invisible in `dev-start` (dev installs a bash wrapper, not a node one) — it only surfaces on bundle/npm installs. `__tests__/meridian-bin.test.ts` guards the ordering. The one sanctioned exception is launching `meridian` in a user Terminal (`open -a Terminal …`, e.g. `api/update`), where an interactive login shell *does* have node/PATH.
 
 ### SQL migrations
 
@@ -286,6 +287,7 @@ Read `VISION.md` first.
 1. Create `ui/app/api/<name>/route.ts`
 2. Query `meridian.db` using `better-sqlite3` (see existing routes for the pattern)
 3. Return a typed JSON response; define the response type inline
+4. If the route shells out to the `meridian` binary, resolve it with `selectMeridianBinary(meridianCandidates())` from `@/lib/meridian-bin` — never a bare `'meridian'` or an ad-hoc candidate list (see the launchd/node-wrapper note under Coding Conventions → TypeScript / Next.js)
 
 ### Add a new MCP tool
 

--- a/ui/__tests__/meridian-bin.test.ts
+++ b/ui/__tests__/meridian-bin.test.ts
@@ -1,0 +1,66 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import { describe, it, expect } from 'bun:test'
+import { meridianCandidates, selectMeridianBinary } from '../lib/meridian-bin'
+
+// ---------------------------------------------------------------------------
+// Candidate ordering — the native binary must outrank the node wrapper.
+//
+// Regression guard for the dashboard "Sync failed: env: node: No such file or
+// directory" bug: under launchd's stripped PATH the `#!/usr/bin/env node`
+// wrapper at ~/.local/bin/meridian can't resolve node, while the native
+// Mach-O binary at ~/.meridian/app/bin/meridian has no runtime deps. If the
+// ordering ever regresses so the wrapper is probed first, this test fails.
+// ---------------------------------------------------------------------------
+
+const HOME = '/home/u'
+const native = `${HOME}/.meridian/app/bin/meridian`
+const systemNative = '/usr/local/bin/meridian'
+const nodeWrapper = `${HOME}/.local/bin/meridian`
+
+describe('meridianCandidates', () => {
+  it('lists the native binary before the node wrapper', () => {
+    const list = meridianCandidates(HOME)
+    expect(list.indexOf(native)).toBeLessThan(list.indexOf(nodeWrapper))
+  })
+
+  it('lists the node wrapper last', () => {
+    const list = meridianCandidates(HOME)
+    expect(list[list.length - 1]).toBe(nodeWrapper)
+  })
+
+  it('expands HOME into every home-relative candidate', () => {
+    const list = meridianCandidates(HOME)
+    expect(list).toContain(native)
+    expect(list).toContain(nodeWrapper)
+    expect(list.some(p => p.includes('undefined'))).toBe(false)
+  })
+})
+
+describe('selectMeridianBinary', () => {
+  const candidates = meridianCandidates(HOME)
+
+  it('prefers the native binary when both native and wrapper are executable', () => {
+    // Everything executable (the real dev-machine case that masked the bug).
+    const bin = selectMeridianBinary(candidates, () => true)
+    expect(bin).toBe(native)
+  })
+
+  it('falls back to the node wrapper when only the wrapper exists', () => {
+    const bin = selectMeridianBinary(candidates, p => p === nodeWrapper)
+    expect(bin).toBe(nodeWrapper)
+  })
+
+  it('skips the absent native binary and takes the next executable native path', () => {
+    const bin = selectMeridianBinary(candidates, p => p === systemNative || p === nodeWrapper)
+    expect(bin).toBe(systemNative)
+  })
+
+  it('returns the first candidate when nothing is executable (meaningful ENOENT, not undefined)', () => {
+    const bin = selectMeridianBinary(candidates, () => false)
+    expect(bin).toBe(native)
+  })
+
+  it('never returns undefined', () => {
+    expect(selectMeridianBinary(candidates, () => false)).toBeDefined()
+  })
+})

--- a/ui/app/api/auth/oauth/start/route.ts
+++ b/ui/app/api/auth/oauth/start/route.ts
@@ -15,16 +15,9 @@ import { spawn } from 'child_process'
 import path from 'path'
 import os from 'os'
 import fs from 'fs'
+import { meridianCandidates, selectMeridianBinary } from '@/lib/meridian-bin'
 
 const ALLOWED = new Set(['jira', 'trello'])
-
-function findMeridianBin(): string {
-  // Installed binary takes precedence; fall back to cargo run for dev
-  const installed = path.join(os.homedir(), '.meridian', 'app', 'meridian')
-  if (fs.existsSync(installed)) return installed
-  // Try PATH
-  return 'meridian'
-}
 
 export async function POST(request: Request) {
   const { searchParams } = new URL(request.url)
@@ -33,7 +26,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: `Unknown provider: ${provider}` }, { status: 400 })
   }
 
-  const bin = findMeridianBin()
+  const bin = selectMeridianBinary(meridianCandidates())
   const logDir = process.env.MERIDIAN_LOG_DIR ?? path.join(os.homedir(), '.meridian', 'logs')
 
   try {

--- a/ui/app/api/tasks/sync/route.ts
+++ b/ui/app/api/tasks/sync/route.ts
@@ -2,23 +2,15 @@
 
 import { NextResponse } from 'next/server'
 import { spawn } from 'child_process'
+import { meridianCandidates, selectMeridianBinary } from '@/lib/meridian-bin'
 
 export const dynamic = 'force-dynamic'
 
-// Candidate paths for the meridian binary. The shell-script wrapper at
-// ~/.local/bin/meridian delegates to the daemon via cmd_daemon_passthrough,
-// which is what we need. Launchd's PATH lacks ~/.local/bin, so we probe
-// candidate locations rather than relying on $PATH.
-const MERIDIAN_CANDIDATES = [
-  `${process.env.HOME}/.local/bin/meridian`,
-  '/usr/local/bin/meridian',
-  `${process.env.HOME}/.meridian/app/bin/meridian`,
-]
-
 function runTasksSync(): Promise<{ ok: boolean; stdout: string; stderr: string }> {
-  const bin = MERIDIAN_CANDIDATES.find(p => {
-    try { require('fs').accessSync(p, require('fs').constants.X_OK); return true } catch { return false }
-  }) ?? MERIDIAN_CANDIDATES[0]
+  // Prefer the native binary over the node wrapper: launchd's PATH lacks `node`,
+  // so probing the wrapper first broke sync on installed dashboards. See
+  // lib/meridian-bin.ts for the ordering rationale.
+  const bin = selectMeridianBinary(meridianCandidates())
 
   return new Promise(resolve => {
     const child = spawn(bin, ['tasks-sync'], {

--- a/ui/app/api/triage/apply/route.ts
+++ b/ui/app/api/triage/apply/route.ts
@@ -11,28 +11,9 @@
 
 import { NextResponse } from 'next/server'
 import { spawn } from 'child_process'
-import fs from 'fs'
+import { meridianCandidates, selectMeridianBinary } from '@/lib/meridian-bin'
 
 export const dynamic = 'force-dynamic'
-
-const MERIDIAN_CANDIDATES = [
-  `${process.env.HOME}/.local/bin/meridian`,
-  '/usr/local/bin/meridian',
-  `${process.env.HOME}/.meridian/app/bin/meridian`,
-]
-
-function meridianBin(): string {
-  return (
-    MERIDIAN_CANDIDATES.find(p => {
-      try {
-        fs.accessSync(p, fs.constants.X_OK)
-        return true
-      } catch {
-        return false
-      }
-    }) ?? MERIDIAN_CANDIDATES[0]
-  )
-}
 
 interface ApplyOutput {
   status: 'applied' | 'redirected'
@@ -51,7 +32,7 @@ function runUpdate(
 ): Promise<{ ok: boolean; out?: ApplyOutput; error?: string }> {
   return new Promise(resolve => {
     const args = ['ticket-update', '--provider', provider, '--key', key, '--field', field, '--value', value]
-    const child = spawn(meridianBin(), args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    const child = spawn(selectMeridianBinary(meridianCandidates()), args, { stdio: ['ignore', 'pipe', 'pipe'] })
 
     let stdout = ''
     let stderr = ''

--- a/ui/app/api/triage/parents/route.ts
+++ b/ui/app/api/triage/parents/route.ts
@@ -10,23 +10,9 @@
 
 import { NextResponse } from 'next/server'
 import { spawn } from 'child_process'
-import fs from 'fs'
+import { meridianCandidates, selectMeridianBinary } from '@/lib/meridian-bin'
 
 export const dynamic = 'force-dynamic'
-
-const MERIDIAN_CANDIDATES = [
-  `${process.env.HOME}/.local/bin/meridian`,
-  '/usr/local/bin/meridian',
-  `${process.env.HOME}/.meridian/app/bin/meridian`,
-]
-
-function meridianBin(): string {
-  return (
-    MERIDIAN_CANDIDATES.find(p => {
-      try { fs.accessSync(p, fs.constants.X_OK); return true } catch { return false }
-    }) ?? MERIDIAN_CANDIDATES[0]
-  )
-}
 
 interface ParentsOutput {
   parents: Array<{ key: string; title: string }>
@@ -36,7 +22,7 @@ interface ParentsOutput {
 
 function runParents(provider: string, key: string): Promise<{ ok: boolean; out?: ParentsOutput; error?: string }> {
   return new Promise(resolve => {
-    const child = spawn(meridianBin(), ['ticket-parents', '--provider', provider, '--key', key], {
+    const child = spawn(selectMeridianBinary(meridianCandidates()), ['ticket-parents', '--provider', provider, '--key', key], {
       stdio: ['ignore', 'pipe', 'pipe'],
     })
     let stdout = ''

--- a/ui/lib/meridian-bin.ts
+++ b/ui/lib/meridian-bin.ts
@@ -1,0 +1,46 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+
+import { accessSync, constants } from 'fs'
+
+/**
+ * Candidate paths for the meridian binary, in PREFERENCE order.
+ *
+ * The native Mach-O binary is listed FIRST on purpose: it has no runtime
+ * dependencies, so it runs under launchd's stripped PATH. The
+ * `~/.local/bin/meridian` wrapper is a `#!/usr/bin/env node` script, so it only
+ * works when `node` is resolvable on PATH — true in a dev shell, but NOT under
+ * the launchd-managed dashboard (launchd's PATH lacks Homebrew's bin dir). When
+ * the wrapper was probed first, the installed dashboard's task sync failed with
+ * `env: node: No such file or directory` while dev worked fine — a dev/prod
+ * parity gap. Preferring the native binary closes it: same behaviour in both.
+ */
+export function meridianCandidates(home: string = process.env.HOME ?? ''): string[] {
+  return [
+    `${home}/.meridian/app/bin/meridian`, // native, no runtime deps — works under launchd
+    '/usr/local/bin/meridian', // native, system-wide install
+    `${home}/.local/bin/meridian`, // node wrapper — needs `node` on PATH, so last
+  ]
+}
+
+/** Default executability probe — X_OK against the real filesystem. */
+export function isExecutable(path: string): boolean {
+  try {
+    accessSync(path, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Pick the first executable candidate. Falls back to the first candidate when
+ * none are executable, so the caller spawns a real path and surfaces a
+ * meaningful ENOENT rather than spawning `undefined`. `probe` is injectable so
+ * the selection order can be unit-tested without touching the filesystem.
+ */
+export function selectMeridianBinary(
+  candidates: string[],
+  probe: (path: string) => boolean = isExecutable,
+): string {
+  return candidates.find(probe) ?? candidates[0]
+}


### PR DESCRIPTION
## Problem

Dashboard **Tasks → Sync** failed with `Sync failed: env: node: No such file or directory`.

The dashboard runs as a **launchd agent**, whose PATH lacks Homebrew's `node`. The UI routes that shell out to the `meridian` binary probed `~/.local/bin/meridian` **first** — which on a bundle/npm install is a `#!/usr/bin/env node` wrapper. With no `node` on launchd's PATH, `env` can't launch it. The self-contained native Rust binary (`~/.meridian/app/bin/meridian`) was listed last and never reached.

This was **invisible in `dev-start`**: the dev installer symlinks a `#!/usr/bin/env bash` wrapper at the same path, and bash is always resolvable — so it only ever broke on bundle/npm (`curl … bootstrap.sh | bash`) installs.

## Fix

New `ui/lib/meridian-bin.ts` centralizes binary resolution and probes the **native binary first** (no runtime deps → works identically under launchd and in dev). Applied to **all four** routes that spawn `meridian`:

| Route | Command | Was |
|---|---|---|
| `api/tasks/sync` | `tasks-sync` | node-wrapper-first list |
| `api/triage/apply` | `ticket-update` | duplicated node-first list |
| `api/triage/parents` | `ticket-parents` | duplicated node-first list |
| `api/auth/oauth/start` | `oauth-login` | wrong path `~/.meridian/app/meridian` + bare-name PATH fallback |

Four copies of the logic collapsed into one shared helper.

## Sweep

Checked the whole surface — no other instances:
- `api/update` uses bare `meridian update` **deliberately** via `open -a Terminal` (interactive login shell has node/PATH) — the one sanctioned exception.
- `api/openobserve` spawns `bash`/`launchctl`/`plutil` (system binaries).
- tray spawns only `launchctl`/`id`; MCP server is node-by-design (run by node-aware clients, reads the DB directly).

## Tests & docs

- `ui/__tests__/meridian-bin.test.ts` — 8 cases guarding the native-first ordering and fallback behavior.
- Full suite: **127 pass / 0 fail**.
- Live-verified in dev: sync returns 200 (synced 3 GitHub tasks).
- `CLAUDE.md` updated (Coding Conventions + "Add a new UI API route") to require the shared helper going forward.

## Follow-up (separate ticket)

The native-first fix sidesteps the root mismatch, but dev ships a bash wrapper while npm/bundle ships a node launcher. A future change could make `install.sh`/npm ship a bash wrapper too, for true dev/prod parity. Also: this is dev-verified only — worth confirming under a real launchd bundle install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)