### PR TITLE
fix(openobserve): correct memory config units (MB not bytes) to prevent startup panic

### DIFF
--- a/scripts/install-openobserve-daemon.sh
+++ b/scripts/install-openobserve-daemon.sh
@@ -154,8 +154,8 @@ else
 fi
 export RUST_LOG
 
-export ZO_MEMORY_CACHE_MAX_SIZE=2147483648   # 2 GB (cache layer)
-export ZO_DATAFUSION_POOL_SIZE=4294967296    # 4 GB (query engine)
+export ZO_MEMORY_CACHE_MAX_SIZE=512          # 512 MB (unit is MB in v0.15+; bytes caused panic)
+export ZO_DATAFUSION_POOL_SIZE=4096          # 4 GB  (unit is MB in v0.15+)
 
 exec "${HOME}/.openobserve/openobserve"
 RUNEOF


### PR DESCRIPTION
## Summary
- `ZO_MEMORY_CACHE_MAX_SIZE` and `ZO_DATAFUSION_POOL_SIZE` in the OpenObserve launcher are interpreted in **MB** by OpenObserve v0.15+, not bytes
- Old values (`2147483648` / `4294967296`) were read as ~2 PB and ~4 PB, causing a hard panic at startup: `memory cache config error: ZO_MEMORY_CACHE_MAX_SIZE is larger than total memory`
- Fixed to `512` (512 MB) and `4096` (4 GB)

## Test plan
- [ ] Run `./scripts/install-openobserve-daemon.sh` and confirm OpenObserve starts without panic
- [ ] Check `~/.meridian/logs/openobserve-error.log` has no new panic entries
- [ ] Check `~/.meridian/logs/openobserve.log` shows normal startup output

🤖 Generated with [Claude Code](https://claude.com/claude-code)