### PR TITLE
feat(ui): daily "today's plan" page with declared working set

### DIFF
--- a/src/migrations/041_daily_plan.sql
+++ b/src/migrations/041_daily_plan.sql
@@ -1,0 +1,34 @@
+-- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+--
+-- Daily plan — the developer's declared "what I'm working on today" set. This is
+-- the Tier-1 priority signal for classification: tasks the dev commits to in the
+-- morning lead the candidate list and are labelled as today's focus. It is a
+-- *boost*, never a filter — every non-excluded board ticket still flows through
+-- as a candidate, so a mid-day pivot to an undeclared task is still matchable.
+--
+-- Only EXPLICIT dev intent is stored here (committed rows). Suggestions are
+-- computed on the fly from board signals (in-progress / carried-over / recent /
+-- due-soon) and are never persisted until the dev acts. `daily_plan_meta` records
+-- whether the dev confirmed (or skipped) the ritual for a given day, which is what
+-- decides "show suggestions" vs "use the committed set / evidence fallback".
+
+CREATE TABLE IF NOT EXISTS daily_plan (
+    plan_date  TEXT    NOT NULL,                 -- local calendar day, 'YYYY-MM-DD'
+    task_key   TEXT    NOT NULL,                 -- references pm_tasks.task_key (loose, not FK — provider tickets churn)
+    position   INTEGER NOT NULL DEFAULT 0,       -- drag order within the day (ascending)
+    origin     TEXT    NOT NULL DEFAULT 'manual', -- carryover | in_progress | recent | due_soon | manual
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    PRIMARY KEY (plan_date, task_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_daily_plan_date ON daily_plan (plan_date);
+
+-- One row per planned day. Presence of a row = the dev acted that day.
+CREATE TABLE IF NOT EXISTS daily_plan_meta (
+    plan_date    TEXT    NOT NULL PRIMARY KEY,   -- local calendar day, 'YYYY-MM-DD'
+    confirmed_at TEXT,                            -- set when the dev confirms (or skips)
+    skipped      INTEGER NOT NULL DEFAULT 0,      -- 1 = dev dismissed the ritual; evidence fallback drives Tier-1
+    created_at   TEXT    NOT NULL,
+    updated_at   TEXT    NOT NULL
+);

--- a/src/migrations/041_daily_plan.sql
+++ b/src/migrations/041_daily_plan.sql
@@ -22,7 +22,8 @@ CREATE TABLE IF NOT EXISTS daily_plan (
     PRIMARY KEY (plan_date, task_key)
 );
 
-CREATE INDEX IF NOT EXISTS idx_daily_plan_date ON daily_plan (plan_date);
+-- No separate index on plan_date: it's the leftmost column of the primary key,
+-- so `WHERE plan_date = ?` already uses the PK index.
 
 -- One row per planned day. Presence of a row = the dev acted that day.
 CREATE TABLE IF NOT EXISTS daily_plan_meta (

--- a/ui/app/(dashboard)/plan/page.tsx
+++ b/ui/app/(dashboard)/plan/page.tsx
@@ -1,0 +1,6 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import PlanView from '@/components/views/PlanView'
+
+export default function PlanPage() {
+  return <PlanView />
+}

--- a/ui/app/api/plan/route.ts
+++ b/ui/app/api/plan/route.ts
@@ -1,0 +1,167 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// GET  /api/plan?date=YYYY-MM-DD  → the day's committed plan + ranked suggestions
+//                                    + the full scored board (for the "add" panel).
+// POST /api/plan  { action, date?, task_key?, task_keys? }
+//        confirm  — replace the day's committed set with task_keys (ordered) + stamp confirmed
+//        add      — append one task to the day's plan
+//        remove   — drop one task from the day's plan
+//        reorder  — set positions from the given ordered task_keys
+//        skip     — mark the day skipped (evidence fallback drives Tier-1)
+//        reopen   — clear confirmed/skipped so suggestions return (keeps committed rows)
+//
+// Like the triage flow, the UI records intent in meridian.db; nothing is pushed to
+// a tracker here. All writes are idempotent UPSERT/DELETE on the daily_plan tables.
+
+import { NextResponse } from 'next/server'
+import { getWriteDb } from '@/lib/db-write'
+import { buildPlanResponse, buildAvailable, todayString } from '@/lib/daily-plan'
+
+export const dynamic = 'force-dynamic'
+
+function nowIso(): string {
+  return new Date().toISOString().replace(/\.\d+Z$/, 'Z')
+}
+
+function validDate(d: unknown): string {
+  return typeof d === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(d) ? d : todayString()
+}
+
+export async function GET(req: Request) {
+  try {
+    const url = new URL(req.url)
+    const date = validDate(url.searchParams.get('date'))
+    return NextResponse.json(buildPlanResponse(date))
+  } catch (e) {
+    console.error('plan api GET error:', e)
+    return NextResponse.json(
+      { date: todayString(), has_table: false, confirmed: false, skipped: false, plan: [], suggestions: [], available: [] },
+      { status: 200 },
+    )
+  }
+}
+
+interface Body {
+  action?: unknown
+  date?: unknown
+  task_key?: unknown
+  task_keys?: unknown
+}
+
+export async function POST(req: Request) {
+  let body: Body
+  try { body = await req.json() } catch { return NextResponse.json({ error: 'bad json' }, { status: 400 }) }
+
+  const action = body.action
+  if (typeof action !== 'string') {
+    return NextResponse.json({ error: 'action required' }, { status: 400 })
+  }
+  const date = validDate(body.date)
+
+  try {
+    const db = getWriteDb()
+    // Schema is owned by Rust migration 041; if the daemon hasn't applied it yet,
+    // fail clearly rather than silently dropping the dev's plan.
+    const ready = db.prepare(
+      "SELECT 1 FROM sqlite_master WHERE type='table' AND name='daily_plan'",
+    ).get()
+    if (!ready) {
+      return NextResponse.json({ error: 'plan storage not ready — restart the meridian daemon' }, { status: 503 })
+    }
+
+    const now = nowIso()
+    // origin lookup uses the scored board so a committed task keeps a meaningful
+    // origin label ("carried over" / "in progress" / …) instead of bare "manual".
+    const originFor = (() => {
+      let map: Map<string, string> | null = null
+      return (key: string): string => {
+        if (!map) map = new Map(buildAvailable(db, date).map(a => [a.key, a.origin]))
+        return map.get(key) ?? 'manual'
+      }
+    })()
+
+    const upsertMeta = (confirmedAt: string | null, skipped: number) => {
+      db.prepare(`
+        INSERT INTO daily_plan_meta (plan_date, confirmed_at, skipped, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(plan_date) DO UPDATE SET
+          confirmed_at = excluded.confirmed_at,
+          skipped      = excluded.skipped,
+          updated_at   = excluded.updated_at
+      `).run(date, confirmedAt, skipped, now, now)
+    }
+
+    // Replace the day's committed set with `ordered` (idempotent UPSERT + prune).
+    const replacePlan = db.transaction((ordered: string[]) => {
+      const keep = new Set(ordered)
+      const existing = db.prepare('SELECT task_key FROM daily_plan WHERE plan_date = ?').all(date) as Array<{ task_key: string }>
+      for (const row of existing) {
+        if (!keep.has(row.task_key)) {
+          db.prepare('DELETE FROM daily_plan WHERE plan_date = ? AND task_key = ?').run(date, row.task_key)
+        }
+      }
+      ordered.forEach((key, i) => {
+        db.prepare(`
+          INSERT INTO daily_plan (plan_date, task_key, position, origin, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?)
+          ON CONFLICT(plan_date, task_key) DO UPDATE SET position = excluded.position, updated_at = excluded.updated_at
+        `).run(date, key, i, originFor(key), now, now)
+      })
+    })
+    const keysFromBody = () => Array.isArray(body.task_keys) ? body.task_keys.filter((k): k is string => typeof k === 'string') : []
+
+    switch (action) {
+      case 'confirm': {
+        const keys = keysFromBody()
+        db.transaction(() => { replacePlan(keys); upsertMeta(now, 0) })()
+        break
+      }
+      case 'set': {
+        // Live edit while already confirmed — replace rows, leave meta untouched.
+        replacePlan(keysFromBody())
+        break
+      }
+      case 'add': {
+        const key = body.task_key
+        if (typeof key !== 'string' || !key) return NextResponse.json({ error: 'task_key required' }, { status: 400 })
+        const max = db.prepare('SELECT COALESCE(MAX(position), -1) AS m FROM daily_plan WHERE plan_date = ?').get(date) as { m: number }
+        db.prepare(`
+          INSERT INTO daily_plan (plan_date, task_key, position, origin, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?)
+          ON CONFLICT(plan_date, task_key) DO NOTHING
+        `).run(date, key, max.m + 1, originFor(key), now, now)
+        break
+      }
+      case 'remove': {
+        const key = body.task_key
+        if (typeof key !== 'string' || !key) return NextResponse.json({ error: 'task_key required' }, { status: 400 })
+        db.prepare('DELETE FROM daily_plan WHERE plan_date = ? AND task_key = ?').run(date, key)
+        break
+      }
+      case 'reorder': {
+        const keys = Array.isArray(body.task_keys) ? body.task_keys.filter((k): k is string => typeof k === 'string') : []
+        const repos = db.transaction((ordered: string[]) => {
+          ordered.forEach((key, i) => {
+            db.prepare('UPDATE daily_plan SET position = ?, updated_at = ? WHERE plan_date = ? AND task_key = ?').run(i, now, date, key)
+          })
+        })
+        repos(keys)
+        break
+      }
+      case 'skip':
+        upsertMeta(now, 1)
+        break
+      case 'reopen':
+        upsertMeta(null, 0)
+        break
+      default:
+        return NextResponse.json({ error: `unknown action: ${action}` }, { status: 400 })
+    }
+
+    // Return the fresh state so the client can reconcile against the server.
+    return NextResponse.json(buildPlanResponse(date))
+  } catch (e) {
+    console.error('plan api POST error:', e)
+    return NextResponse.json({ error: 'write failed' }, { status: 500 })
+  }
+}

--- a/ui/app/api/plan/route.ts
+++ b/ui/app/api/plan/route.ts
@@ -23,21 +23,30 @@ function nowIso(): string {
   return new Date().toISOString().replace(/\.\d+Z$/, 'Z')
 }
 
-function validDate(d: unknown): string {
-  return typeof d === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(d) ? d : todayString()
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+// GET: an absent/garbage date harmlessly falls back to today (read-only).
+function readDate(d: unknown): string {
+  return typeof d === 'string' && DATE_RE.test(d) ? d : todayString()
+}
+
+// Writes: an explicitly-supplied date MUST be valid — defaulting a malformed
+// date to today would silently mutate the WRONG day's plan. Absent → today.
+function writeDate(d: unknown): string | null {
+  if (d === undefined || d === null) return todayString()
+  return typeof d === 'string' && DATE_RE.test(d) ? d : null
 }
 
 export async function GET(req: Request) {
   try {
     const url = new URL(req.url)
-    const date = validDate(url.searchParams.get('date'))
+    const date = readDate(url.searchParams.get('date'))
     return NextResponse.json(buildPlanResponse(date))
   } catch (e) {
+    // Surface backend failure as 500 — a DB/read error must NOT render as a
+    // valid empty day (the client can't tell those apart otherwise).
     console.error('plan api GET error:', e)
-    return NextResponse.json(
-      { date: todayString(), has_table: false, confirmed: false, skipped: false, plan: [], suggestions: [], available: [] },
-      { status: 200 },
-    )
+    return NextResponse.json({ error: 'failed to load plan' }, { status: 500 })
   }
 }
 
@@ -56,7 +65,10 @@ export async function POST(req: Request) {
   if (typeof action !== 'string') {
     return NextResponse.json({ error: 'action required' }, { status: 400 })
   }
-  const date = validDate(body.date)
+  const date = writeDate(body.date)
+  if (date === null) {
+    return NextResponse.json({ error: 'invalid date (expected YYYY-MM-DD)' }, { status: 400 })
+  }
 
   try {
     const db = getWriteDb()
@@ -70,15 +82,13 @@ export async function POST(req: Request) {
     }
 
     const now = nowIso()
+    // Score the board ONCE per request and reuse it for both the origin lookup
+    // and the response payload below (buildPlanResponse would otherwise re-score).
+    const available = buildAvailable(db, date)
     // origin lookup uses the scored board so a committed task keeps a meaningful
     // origin label ("carried over" / "in progress" / …) instead of bare "manual".
-    const originFor = (() => {
-      let map: Map<string, string> | null = null
-      return (key: string): string => {
-        if (!map) map = new Map(buildAvailable(db, date).map(a => [a.key, a.origin]))
-        return map.get(key) ?? 'manual'
-      }
-    })()
+    const originMap = new Map(available.map(a => [a.key, a.origin]))
+    const originFor = (key: string): string => originMap.get(key) ?? 'manual'
 
     const upsertMeta = (confirmedAt: string | null, skipped: number) => {
       db.prepare(`
@@ -112,12 +122,20 @@ export async function POST(req: Request) {
 
     switch (action) {
       case 'confirm': {
+        // task_keys MUST be an array — an explicit [] means "clear the plan",
+        // but a missing/malformed body must 400, not wipe the day silently.
+        if (!Array.isArray(body.task_keys)) {
+          return NextResponse.json({ error: 'task_keys array required' }, { status: 400 })
+        }
         const keys = keysFromBody()
         db.transaction(() => { replacePlan(keys); upsertMeta(now, 0) })()
         break
       }
       case 'set': {
         // Live edit while already confirmed — replace rows, leave meta untouched.
+        if (!Array.isArray(body.task_keys)) {
+          return NextResponse.json({ error: 'task_keys array required' }, { status: 400 })
+        }
         replacePlan(keysFromBody())
         break
       }
@@ -159,7 +177,8 @@ export async function POST(req: Request) {
     }
 
     // Return the fresh state so the client can reconcile against the server.
-    return NextResponse.json(buildPlanResponse(date))
+    // Reuse the board scored above (plan writes don't change pm_tasks scoring).
+    return NextResponse.json(buildPlanResponse(date, db, available))
   } catch (e) {
     console.error('plan api POST error:', e)
     return NextResponse.json({ error: 'write failed' }, { status: 500 })

--- a/ui/app/api/plan/task/route.ts
+++ b/ui/app/api/plan/task/route.ts
@@ -1,0 +1,79 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// GET /api/plan/task?key=KAN-123 — full detail for one board ticket, for the
+// plan page's task dialog. Returns the FULL description + acceptance criteria
+// (the list payload only carries a short excerpt), plus all display meta.
+
+import { NextResponse } from 'next/server'
+import getDb from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+export interface TaskDetail {
+  key: string
+  title: string
+  provider: string
+  url: string
+  status: string
+  is_terminal: boolean
+  issue_type: string
+  epic: string | null
+  priority: string | null
+  story_points: string | null
+  due_date: string | null
+  due_days: number | null
+  start_date: string | null
+  description: string
+  acceptance_criteria: string | null
+}
+
+function dueDaysFrom(due: string | null): number | null {
+  if (!due) return null
+  const d = new Date(due.length <= 10 ? `${due}T00:00:00` : due)
+  if (isNaN(d.getTime())) return null
+  const now = new Date()
+  const a = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const b = new Date(d.getFullYear(), d.getMonth(), d.getDate())
+  return Math.round((b.getTime() - a.getTime()) / 86400000)
+}
+
+export async function GET(req: Request) {
+  try {
+    const key = new URL(req.url).searchParams.get('key')
+    if (!key) return NextResponse.json({ error: 'key required' }, { status: 400 })
+
+    const db = getDb()
+    const r = db.prepare(`
+      SELECT task_key, title, provider, url,
+             COALESCE(status_raw,'') AS status_raw, COALESCE(is_terminal,0) AS is_terminal,
+             COALESCE(issue_type,'') AS issue_type, epic_title, parent_key,
+             priority, story_points, due_date, start_date,
+             COALESCE(description_text,'') AS description_text, acceptance_criteria
+      FROM pm_tasks WHERE task_key = ?
+    `).get(key) as Record<string, unknown> | undefined
+
+    if (!r) return NextResponse.json({ error: 'not found' }, { status: 404 })
+
+    const detail: TaskDetail = {
+      key: r.task_key as string,
+      title: (r.title as string) ?? (r.task_key as string),
+      provider: (r.provider as string) || 'jira',
+      url: (r.url as string) || '',
+      status: (r.status_raw as string) || '',
+      is_terminal: !!(r.is_terminal as number),
+      issue_type: (r.issue_type as string) || '',
+      epic: ((r.epic_title as string)?.trim() || (r.parent_key as string)?.trim() || null) ?? null,
+      priority: (r.priority as string)?.trim() || null,
+      story_points: (r.story_points as string)?.trim() || null,
+      due_date: (r.due_date as string | null) ?? null,
+      due_days: dueDaysFrom((r.due_date as string | null) ?? null),
+      start_date: (r.start_date as string | null) ?? null,
+      description: (r.description_text as string) || '',
+      acceptance_criteria: (r.acceptance_criteria as string)?.trim() || null,
+    }
+    return NextResponse.json(detail)
+  } catch (e) {
+    console.error('plan task detail error:', e)
+    return NextResponse.json({ error: 'failed' }, { status: 500 })
+  }
+}

--- a/ui/app/api/plan/task/route.ts
+++ b/ui/app/api/plan/task/route.ts
@@ -6,6 +6,7 @@
 
 import { NextResponse } from 'next/server'
 import getDb from '@/lib/db'
+import { dueDaysFrom } from '@/lib/daily-plan'
 
 export const dynamic = 'force-dynamic'
 
@@ -25,16 +26,6 @@ export interface TaskDetail {
   start_date: string | null
   description: string
   acceptance_criteria: string | null
-}
-
-function dueDaysFrom(due: string | null): number | null {
-  if (!due) return null
-  const d = new Date(due.length <= 10 ? `${due}T00:00:00` : due)
-  if (isNaN(d.getTime())) return null
-  const now = new Date()
-  const a = new Date(now.getFullYear(), now.getMonth(), now.getDate())
-  const b = new Date(d.getFullYear(), d.getMonth(), d.getDate())
-  return Math.round((b.getTime() - a.getTime()) / 86400000)
 }
 
 export async function GET(req: Request) {
@@ -66,7 +57,7 @@ export async function GET(req: Request) {
       priority: (r.priority as string)?.trim() || null,
       story_points: (r.story_points as string)?.trim() || null,
       due_date: (r.due_date as string | null) ?? null,
-      due_days: dueDaysFrom((r.due_date as string | null) ?? null),
+      due_days: dueDaysFrom((r.due_date as string | null) ?? null, new Date()),
       start_date: (r.start_date as string | null) ?? null,
       description: (r.description_text as string) || '',
       acceptance_criteria: (r.acceptance_criteria as string)?.trim() || null,

--- a/ui/components/CommandBar.tsx
+++ b/ui/components/CommandBar.tsx
@@ -26,6 +26,7 @@ export default function CommandBar({ onClose }: Props) {
 
   const views: CmdItem[] = [
     { kind: 'view', label: 'Go to Today',    route: '/today' },
+    { kind: 'view', label: "Go to Today's plan", route: '/plan' },
     { kind: 'view', label: 'Go to Tasks',    route: '/tasks' },
     { kind: 'view', label: 'Go to Worklogs', route: '/worklogs' },
     { kind: 'view', label: 'Go to Sessions', route: '/sessions' },

--- a/ui/components/DashboardShell.tsx
+++ b/ui/components/DashboardShell.tsx
@@ -12,7 +12,7 @@ import MustFixBanner from '@/components/MustFixBanner'
 const KEY_ROUTES: Record<string, string> = {
   '1': '/today', '2': '/tasks', '3': '/worklogs',
   '4': '/sessions', '5': '/week', '6': '/settings',
-  '7': '/cleanup',
+  '7': '/cleanup', '8': '/plan',
 }
 
 export default function DashboardShell({ children }: { children: React.ReactNode }) {
@@ -42,26 +42,43 @@ export default function DashboardShell({ children }: { children: React.ReactNode
     weekday: 'long', month: 'long', day: 'numeric', year: 'numeric',
   })
 
+  // App-like pages bind to the viewport and scroll their own inner regions
+  // (no page-level scrollbar, no footer). Document-flow pages keep the classic
+  // scroll-the-whole-page layout. Keyed on route so non-app pages are unchanged.
+  const appLike = pathname === '/plan'
+
   return (
-    <div className="min-h-screen flex flex-col" style={{ background: 'var(--paper)' }}>
+    <div
+      className={`flex flex-col ${appLike ? 'h-[100svh] overflow-hidden' : 'min-h-screen'}`}
+      style={{ background: 'var(--paper)' }}
+    >
       <HealthBanner />
       <MustFixBanner />
-      <div className="flex flex-1">
+      <div className={`flex flex-1 ${appLike ? 'min-h-0' : ''}`}>
         <Sidebar onOpenCmd={() => setCmdOpen(true)} />
-        <main className="flex-1 min-w-0" data-screen-label={pathname.slice(1)}>
-          <div className="max-w-[1080px] mx-auto px-10 py-14">
-            {children}
-            <footer
-              className="mt-24 pt-8 rule-t flex items-center justify-between text-[11px]"
-              style={{ borderTopColor: 'var(--rule)', color: 'var(--ink-4)' }}
-            >
-              <span>Meridian · local · {todayDate}</span>
-              <span className="font-mono tnum">
-                <span className="kbd">⌘</span> <span className="kbd">K</span> to jump ·{' '}
-                <span className="kbd">1</span>–<span className="kbd">6</span> to switch view
-              </span>
-            </footer>
-          </div>
+        <main
+          className={`flex-1 min-w-0 ${appLike ? 'flex flex-col overflow-hidden' : ''}`}
+          data-screen-label={pathname.slice(1)}
+        >
+          {appLike ? (
+            <div className="flex-1 min-h-0 flex flex-col w-full max-w-[1080px] mx-auto px-10 py-10">
+              {children}
+            </div>
+          ) : (
+            <div className="max-w-[1080px] mx-auto px-10 py-14">
+              {children}
+              <footer
+                className="mt-24 pt-8 rule-t flex items-center justify-between text-[11px]"
+                style={{ borderTopColor: 'var(--rule)', color: 'var(--ink-4)' }}
+              >
+                <span>Meridian · local · {todayDate}</span>
+                <span className="font-mono tnum">
+                  <span className="kbd">⌘</span> <span className="kbd">K</span> to jump ·{' '}
+                  <span className="kbd">1</span>–<span className="kbd">6</span> to switch view
+                </span>
+              </footer>
+            </div>
+          )}
         </main>
         {cmdOpen && (
           <CommandBar onClose={() => setCmdOpen(false)} />

--- a/ui/components/DashboardShell.tsx
+++ b/ui/components/DashboardShell.tsx
@@ -10,9 +10,9 @@ import HealthBanner from '@/components/HealthBanner'
 import MustFixBanner from '@/components/MustFixBanner'
 
 const KEY_ROUTES: Record<string, string> = {
-  '1': '/today', '2': '/tasks', '3': '/worklogs',
-  '4': '/sessions', '5': '/week', '6': '/settings',
-  '7': '/cleanup', '8': '/plan',
+  '1': '/today', '2': '/plan', '3': '/tasks',
+  '4': '/worklogs', '5': '/sessions', '6': '/week',
+  '7': '/cleanup', '8': '/settings',
 }
 
 export default function DashboardShell({ children }: { children: React.ReactNode }) {
@@ -74,7 +74,7 @@ export default function DashboardShell({ children }: { children: React.ReactNode
                 <span>Meridian · local · {todayDate}</span>
                 <span className="font-mono tnum">
                   <span className="kbd">⌘</span> <span className="kbd">K</span> to jump ·{' '}
-                  <span className="kbd">1</span>–<span className="kbd">6</span> to switch view
+                  <span className="kbd">1</span>–<span className="kbd">8</span> to switch view
                 </span>
               </footer>
             </div>

--- a/ui/components/Sidebar.tsx
+++ b/ui/components/Sidebar.tsx
@@ -75,6 +75,7 @@ export default function Sidebar({ onOpenCmd }: Props) {
 
   const items: Array<{ route: string; label: string; kbd: string }> = [
     { route: '/today',    label: 'Today',    kbd: '1' },
+    { route: '/plan',     label: 'Plan',     kbd: '8' },
     { route: '/tasks',    label: 'Tasks',    kbd: '2' },
     { route: '/worklogs', label: 'Worklogs', kbd: '3' },
     { route: '/sessions', label: 'Sessions', kbd: '4' },

--- a/ui/components/Sidebar.tsx
+++ b/ui/components/Sidebar.tsx
@@ -75,11 +75,11 @@ export default function Sidebar({ onOpenCmd }: Props) {
 
   const items: Array<{ route: string; label: string; kbd: string }> = [
     { route: '/today',    label: 'Today',    kbd: '1' },
-    { route: '/plan',     label: 'Plan',     kbd: '8' },
-    { route: '/tasks',    label: 'Tasks',    kbd: '2' },
-    { route: '/worklogs', label: 'Worklogs', kbd: '3' },
-    { route: '/sessions', label: 'Sessions', kbd: '4' },
-    { route: '/week',     label: 'Week',     kbd: '5' },
+    { route: '/plan',     label: 'Plan',     kbd: '2' },
+    { route: '/tasks',    label: 'Tasks',    kbd: '3' },
+    { route: '/worklogs', label: 'Worklogs', kbd: '4' },
+    { route: '/sessions', label: 'Sessions', kbd: '5' },
+    { route: '/week',     label: 'Week',     kbd: '6' },
     { route: '/cleanup',  label: 'Clean-up', kbd: '7' },
   ]
 
@@ -163,7 +163,7 @@ export default function Sidebar({ onOpenCmd }: Props) {
             <path d="M8 1v1.5M8 13.5V15M1 8h1.5M13.5 8H15M3.05 3.05l1.06 1.06M11.89 11.89l1.06 1.06M3.05 12.95l1.06-1.06M11.89 4.11l1.06-1.06"/>
           </svg>
           <span className="text-[13px]">Settings</span>
-          <span className="kbd ml-auto">6</span>
+          <span className="kbd ml-auto">8</span>
         </button>
       </div>
 

--- a/ui/components/plan/TaskCard.tsx
+++ b/ui/components/plan/TaskCard.tsx
@@ -1,0 +1,83 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+'use client'
+
+import { ProviderGlyph, TaskKey } from '@/components/atoms'
+import { DuePill, OriginChip, StatusChip, EpicChip, PriorityTag, MetaChip } from '@/components/plan/parts'
+
+export interface CardTask {
+  key: string
+  title: string
+  provider: string
+  url: string
+  due_days: number | null
+  reason: string
+  origin: string
+  is_terminal?: boolean
+  description?: string
+  epic?: string | null
+  status?: string
+  priority?: string | null
+  issue_type?: string
+  story_points?: string | null
+}
+
+/** Presentational card body shared by the Today (compact) and board (detailed)
+ *  columns. `lead` is the drag handle, `trail` the action controls; the central
+ *  content opens the detail dialog via `onOpen`. When `detail` is set (the board)
+ *  it also shows the description excerpt, priority and story points. */
+export function TaskCardBody({
+  task, lead, trail, detail = false, onOpen,
+}: {
+  task: CardTask
+  lead?: React.ReactNode
+  trail?: React.ReactNode
+  detail?: boolean
+  onOpen?: () => void
+}) {
+  const showType = task.issue_type && !/^task$/i.test(task.issue_type)
+  // The origin chip only adds value for signals the status/due chips DON'T already
+  // show — otherwise it duplicates them ("In progress" beside an "In Progress"
+  // status, "Due 2d" beside the due pill). Keep it for carried-over / worked-recently.
+  const showOrigin = (task.origin === 'carryover' || task.origin === 'recent') && !!task.reason
+
+  return (
+    <div className="px-3 py-2.5 flex items-start gap-2.5">
+      {lead}
+      <div
+        role={onOpen ? 'button' : undefined} tabIndex={onOpen ? 0 : undefined}
+        onClick={onOpen}
+        onKeyDown={onOpen ? e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpen() } } : undefined}
+        aria-label={onOpen ? `Open ${task.key} details` : undefined}
+        className={`min-w-0 flex-1 rounded ${onOpen ? 'cursor-pointer' : ''}`}>
+        <div className="flex items-center gap-2 min-w-0">
+          <ProviderGlyph provider={task.provider} size={16} />
+          <TaskKey keyId={task.key} />
+          {showType && <MetaChip>{task.issue_type}</MetaChip>}
+          <span className="text-[13px] truncate"
+            style={{ color: 'var(--ink)', textDecoration: task.is_terminal ? 'line-through' : 'none' }}>
+            {task.title}
+          </span>
+        </div>
+
+        {detail && task.description && (
+          <p className="text-[12px] mt-1.5 leading-snug truncate" style={{ color: 'var(--ink-3)' }}>
+            {task.description}
+          </p>
+        )}
+
+        <div className="flex items-center gap-1.5 mt-1.5 flex-wrap">
+          {showOrigin && <OriginChip reason={task.reason} origin={task.origin} />}
+          <StatusChip status={task.status} />
+          <EpicChip epic={task.epic} />
+          <DuePill days={task.due_days} />
+          {detail && <PriorityTag priority={task.priority} />}
+          {detail && task.story_points && <MetaChip>{task.story_points} pts</MetaChip>}
+          {task.is_terminal && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded-md" style={{ color: 'var(--success)', background: 'var(--surface-2)' }}>Done</span>
+          )}
+        </div>
+      </div>
+      {trail}
+    </div>
+  )
+}

--- a/ui/components/plan/TaskDialog.tsx
+++ b/ui/components/plan/TaskDialog.tsx
@@ -1,0 +1,179 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+'use client'
+
+import { useEffect, useState } from 'react'
+import { TaskKey, ProviderGlyph, StatusPill } from '@/components/atoms'
+import { MetaChip } from '@/components/plan/parts'
+import type { CardTask } from '@/components/plan/TaskCard'
+import type { TaskDetail } from '@/app/api/plan/task/route'
+
+// Full-ticket dialog opened from a plan card. Shows the complete description and
+// acceptance criteria (the list only carries an excerpt) and lets the dev add the
+// task to / remove it from today, or open it in the tracker.
+export default function TaskDialog({
+  task, inToday, canEdit = true, onClose, onAdd, onRemove,
+}: {
+  task: CardTask
+  inToday: boolean
+  canEdit?: boolean
+  onClose: () => void
+  onAdd: () => void
+  onRemove: () => void
+}) {
+  const [detail, setDetail] = useState<TaskDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    // Lock background scroll while the dialog is open.
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      window.removeEventListener('keydown', onKey)
+      document.body.style.overflow = prevOverflow
+    }
+  }, [onClose])
+
+  useEffect(() => {
+    let alive = true
+    setLoading(true)
+    fetch(`/api/plan/task?key=${encodeURIComponent(task.key)}`)
+      .then(r => r.ok ? r.json() : null)
+      .then((d: TaskDetail | null) => { if (alive) { setDetail(d); setLoading(false) } })
+      .catch(() => { if (alive) setLoading(false) })
+    return () => { alive = false }
+  }, [task.key])
+
+  // Fall back to the card's data while the full detail loads.
+  const d = detail
+  const title = d?.title ?? task.title
+  const status = d?.status ?? task.status ?? ''
+  const isTerminal = d?.is_terminal ?? task.is_terminal ?? false
+  const epic = d?.epic ?? task.epic ?? null
+  const priority = d?.priority ?? task.priority ?? null
+  const points = d?.story_points ?? task.story_points ?? null
+  const issueType = d?.issue_type ?? task.issue_type ?? ''
+  const dueDays = d?.due_days ?? task.due_days ?? null
+  const dueDate = d?.due_date ?? null
+  const startDate = d?.start_date ?? null
+  const url = d?.url || task.url
+  const description = d?.description ?? task.description ?? ''
+  const acceptance = d?.acceptance_criteria ?? null
+
+  const dueLabel = dueDays === null ? null
+    : dueDays < 0 ? `overdue ${-dueDays}d`
+      : dueDays === 0 ? 'today' : dueDays === 1 ? 'tomorrow' : `in ${dueDays}d`
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 rise"
+      style={{ background: 'rgba(20,16,10,0.45)', backdropFilter: 'blur(3px)' }} onClick={onClose}>
+      <div className="w-full max-w-2xl rounded-[20px] overflow-hidden flex flex-col max-h-[88vh]"
+        style={{ background: 'var(--paper)', border: '1px solid var(--rule)', boxShadow: '0 24px 60px -12px rgba(20,16,10,0.35)' }}
+        onClick={e => e.stopPropagation()}>
+        <div style={{ height: 3, background: 'linear-gradient(90deg, var(--accent), #60A5FA)' }} />
+
+        {/* Header */}
+        <div className="px-7 pt-6 pb-5" style={{ background: 'var(--tint)', borderBottom: '1px solid var(--rule)' }}>
+          <div className="flex items-center gap-2.5 mb-3">
+            <ProviderGlyph provider={task.provider} size={18} />
+            <TaskKey keyId={task.key} />
+            <StatusPill status={status} isTerminal={isTerminal} />
+            {issueType && !/^task$/i.test(issueType) && <MetaChip>{issueType}</MetaChip>}
+            <button onClick={onClose} aria-label="Close"
+              className="ml-auto inline-flex items-center justify-center rounded-full transition-colors"
+              style={{ width: 28, height: 28, color: 'var(--ink-3)', background: 'var(--surface)', border: '1px solid var(--rule)' }}>
+              <span className="text-[16px] leading-none">×</span>
+            </button>
+          </div>
+          <h2 className="type-heading leading-snug" style={{ color: 'var(--ink)' }}>{title}</h2>
+          <dl className="mt-4 grid grid-cols-[auto_1fr] gap-x-5 gap-y-2 text-[12px]">
+            {epic && <MetaRow label="Epic"><span style={{ color: 'var(--ink-2)' }}>{epic}</span></MetaRow>}
+            {dueDate && (
+              <MetaRow label="Due">
+                <span style={{ color: dueDays !== null && dueDays <= 1 ? 'var(--warn)' : 'var(--ink-2)' }}>
+                  {fmtDate(dueDate)}{dueLabel ? ` · ${dueLabel}` : ''}
+                </span>
+              </MetaRow>
+            )}
+            {startDate && <MetaRow label="Start"><span style={{ color: 'var(--ink-2)' }}>{fmtDate(startDate)}</span></MetaRow>}
+            {priority && <MetaRow label="Priority"><span style={{ color: 'var(--ink-2)' }}>{priority}</span></MetaRow>}
+            {points && <MetaRow label="Points"><span style={{ color: 'var(--ink-2)' }}>{points}</span></MetaRow>}
+          </dl>
+        </div>
+
+        {/* Body */}
+        <div className="px-7 py-6 overflow-auto" style={{ background: 'var(--paper)' }}>
+          {loading && !d ? (
+            <p className="text-[13px]" style={{ color: 'var(--ink-3)' }}>Loading…</p>
+          ) : (
+            <>
+              <Section label="Description">
+                {description.trim()
+                  ? <p className="text-[13px] leading-relaxed whitespace-pre-wrap" style={{ color: 'var(--ink-2)' }}>{description}</p>
+                  : <p className="text-[13px] italic" style={{ color: 'var(--ink-4)' }}>No description on this ticket.</p>}
+              </Section>
+              {acceptance && (
+                <Section label="Acceptance criteria">
+                  <p className="text-[13px] leading-relaxed whitespace-pre-wrap" style={{ color: 'var(--ink-2)' }}>{acceptance}</p>
+                </Section>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Footer actions */}
+        <div className="px-7 py-4 flex items-center gap-3" style={{ borderTop: '1px solid var(--rule)', background: 'var(--surface)' }}>
+          {canEdit ? (inToday ? (
+            <button onClick={() => { onRemove(); onClose() }}
+              className="text-[13px] px-4 py-2 rounded-lg border font-medium transition-colors"
+              style={{ borderColor: 'var(--rule)', color: 'var(--ink-2)', background: 'var(--paper)' }}>
+              Remove from today
+            </button>
+          ) : (
+            <button onClick={() => { onAdd(); onClose() }}
+              className="text-[13px] px-4 py-2 rounded-lg font-medium transition-colors"
+              style={{ background: 'var(--ink)', color: 'var(--paper)' }}>
+              + Add to today
+            </button>
+          )) : (
+            inToday && <span className="text-[12px]" style={{ color: 'var(--ink-3)' }}>In today’s plan</span>
+          )}
+          {url && (
+            <a href={url} target="_blank" rel="noopener noreferrer"
+              className="ml-auto text-[12px] px-3.5 py-2 rounded-lg border transition-colors"
+              style={{ borderColor: 'var(--rule)', color: 'var(--ink-2)', background: 'var(--paper)' }}>
+              Open in tracker ↗
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="mb-5 last:mb-0">
+      <p className="text-[10px] uppercase tracking-[0.16em] mb-2" style={{ color: 'var(--ink-3)' }}>{label}</p>
+      {children}
+    </div>
+  )
+}
+
+// One label/value pair in the header definition list. dt/dd are direct grid items.
+function MetaRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <>
+      <dt className="text-[10px] uppercase tracking-[0.12em] pt-0.5 whitespace-nowrap" style={{ color: 'var(--ink-4)' }}>{label}</dt>
+      <dd className="min-w-0">{children}</dd>
+    </>
+  )
+}
+
+/** Format a due/start value (date-only or full timestamp) as "Jun 26". */
+function fmtDate(s: string): string {
+  const d = new Date(s.length <= 10 ? `${s}T00:00:00` : s)
+  if (isNaN(d.getTime())) return s
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}

--- a/ui/components/plan/parts.tsx
+++ b/ui/components/plan/parts.tsx
@@ -1,0 +1,119 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+'use client'
+
+// Small presentational helpers shared by the daily-plan columns. Due date is
+// given visual weight here (urgency → colour), matching its weight in scoring.
+
+/** A due-date pill coloured by urgency. Renders nothing when there's no date. */
+export function DuePill({ days }: { days: number | null }) {
+  if (days === null) return null
+
+  let label: string
+  let color: string
+  let bg: string
+  if (days < 0) { label = `Overdue ${-days}d`; color = 'var(--warn)'; bg = 'rgba(220,38,38,0.12)' }
+  else if (days === 0) { label = 'Due today'; color = 'var(--warn)'; bg = 'rgba(220,38,38,0.12)' }
+  else if (days === 1) { label = 'Due tomorrow'; color = 'var(--accent)'; bg = 'var(--accent-soft)' }
+  else if (days <= 14) { label = `Due ${days}d`; color = 'var(--accent)'; bg = 'var(--accent-soft)' }
+  else if (days <= 30) { label = `Due ${days}d`; color = 'var(--ink-3)'; bg = 'var(--surface-2)' }
+  else { label = `Due ${Math.round(days / 7)}w`; color = 'var(--ink-4)'; bg = 'var(--surface-2)' }
+
+  return (
+    <span className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-md whitespace-nowrap"
+      style={{ color, background: bg }}>
+      <svg width="9" height="9" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6">
+        <rect x="2.5" y="3.5" width="11" height="10" rx="1.5" />
+        <path d="M2.5 6.5h11M5.5 1.5v2M10.5 1.5v2" />
+      </svg>
+      {label}
+    </span>
+  )
+}
+
+/** The lead "why this is here" chip (carried over / in progress / worked recently). */
+export function OriginChip({ reason, origin }: { reason: string; origin: string }) {
+  const strong = origin === 'carryover' || origin === 'in_progress'
+  return (
+    <span className="text-[10px] px-1.5 py-0.5 rounded-md whitespace-nowrap"
+      style={{
+        color: strong ? 'var(--accent)' : 'var(--ink-3)',
+        background: strong ? 'var(--accent-soft)' : 'var(--surface-2)',
+      }}>
+      {reason}
+    </span>
+  )
+}
+
+/** Status / column chip. Accent-tinted when the column reads "in progress". */
+export function StatusChip({ status }: { status?: string }) {
+  const s = (status || '').trim()
+  if (!s) return null
+  const active = /progress|doing|review|qa|testing|dev|implement|active|building/i.test(s)
+  return (
+    <span className="text-[10px] px-1.5 py-0.5 rounded-md whitespace-nowrap"
+      style={{ color: active ? 'var(--accent)' : 'var(--ink-3)', background: active ? 'var(--accent-soft)' : 'var(--surface-2)' }}>
+      {s}
+    </span>
+  )
+}
+
+/** Epic / parent chip. */
+export function EpicChip({ epic }: { epic?: string | null }) {
+  if (!epic) return null
+  const label = epic.length > 22 ? epic.slice(0, 21) + '…' : epic
+  return (
+    <span className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-md whitespace-nowrap"
+      style={{ color: 'var(--ink-3)', background: 'var(--surface-2)' }} title={epic}>
+      <svg width="8" height="8" viewBox="0 0 16 16" fill="currentColor" aria-hidden><rect x="2" y="2" width="5" height="5" rx="1" /><rect x="9" y="2" width="5" height="5" rx="1" /><rect x="2" y="9" width="5" height="5" rx="1" /><rect x="9" y="9" width="5" height="5" rx="1" /></svg>
+      {label}
+    </span>
+  )
+}
+
+/** Priority dot + label, coloured by urgency. Provider-agnostic string match. */
+export function PriorityTag({ priority }: { priority?: string | null }) {
+  if (!priority) return null
+  const p = priority.toLowerCase()
+  const color = /highest|critical|blocker|p1|urgent/.test(p) ? 'var(--warn)'
+    : /high|p2/.test(p) ? 'var(--accent)'
+      : /low|minor|p4|p5|trivial/.test(p) ? 'var(--ink-4)'
+        : 'var(--ink-3)'
+  return (
+    <span className="inline-flex items-center gap-1 text-[10px] whitespace-nowrap" style={{ color: 'var(--ink-3)' }} title={`Priority: ${priority}`}>
+      <span className="w-1.5 h-1.5 rounded-full" style={{ background: color }} />
+      {priority}
+    </span>
+  )
+}
+
+/** Tiny generic chip (e.g. story points, issue type). */
+export function MetaChip({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="text-[10px] px-1.5 py-0.5 rounded-md whitespace-nowrap"
+      style={{ color: 'var(--ink-3)', background: 'var(--surface-2)' }}>
+      {children}
+    </span>
+  )
+}
+
+/** External "open in tracker" link. */
+export function OpenLink({ url }: { url?: string }) {
+  if (!url) return null
+  return (
+    <a href={url} target="_blank" rel="noopener noreferrer" onPointerDown={e => e.stopPropagation()}
+      className="text-[10px] whitespace-nowrap hover:underline" style={{ color: 'var(--ink-4)' }}>
+      Open ↗
+    </a>
+  )
+}
+
+/** Drag-handle glyph. */
+export function GripHandle() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+      <circle cx="6" cy="4" r="1.1" /><circle cx="10" cy="4" r="1.1" />
+      <circle cx="6" cy="8" r="1.1" /><circle cx="10" cy="8" r="1.1" />
+      <circle cx="6" cy="12" r="1.1" /><circle cx="10" cy="12" r="1.1" />
+    </svg>
+  )
+}

--- a/ui/components/views/PlanView.tsx
+++ b/ui/components/views/PlanView.tsx
@@ -1,0 +1,430 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  DragDropContext, Droppable, Draggable,
+  type DropResult, type DraggableProvided, type DraggableStateSnapshot,
+} from '@hello-pangea/dnd'
+import { Card } from '@/components/atoms'
+import { GripHandle } from '@/components/plan/parts'
+import { TaskCardBody, type CardTask } from '@/components/plan/TaskCard'
+import TaskDialog from '@/components/plan/TaskDialog'
+import type { PlanResponse, AvailableTask, PlanItem } from '@/lib/daily-plan'
+
+// ── normalisation ────────────────────────────────────────────────────────────
+function fromAvailable(a: AvailableTask): CardTask {
+  return {
+    key: a.key, title: a.title, provider: a.provider, url: a.url, due_days: a.due_days,
+    reason: a.reason, origin: a.origin, is_terminal: a.is_terminal,
+    description: a.description, epic: a.epic, status: a.status, priority: a.priority,
+    issue_type: a.issue_type, story_points: a.story_points,
+  }
+}
+const REASON: Record<string, string> = {
+  carryover: 'Carried over', in_progress: 'In progress', due_soon: 'Due soon', recent: 'Worked recently', manual: 'Added',
+}
+function fromPlan(p: PlanItem, avail: Map<string, AvailableTask>): CardTask {
+  const a = avail.get(p.task_key)
+  return {
+    key: p.task_key, title: p.title, provider: p.provider, url: p.url,
+    due_days: p.due_days, origin: p.origin,
+    reason: a?.reason ?? REASON[p.origin] ?? 'Added',
+    is_terminal: p.is_terminal,
+    description: p.description, epic: p.epic, status: p.status, priority: p.priority,
+    issue_type: p.issue_type, story_points: p.story_points,
+  }
+}
+
+const FOCUS = 'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2'
+
+// White & blue theme, scoped to the plan page — overrides the app's warm accent
+// for all `var(--accent)` / `var(--accent-soft)` / `var(--tint)` usages below
+// (and the dialog, which is a descendant). `--warn` → red so urgency isn't orange.
+const BLUE_THEME = {
+  '--accent': '#2563EB',
+  '--accent-soft': '#E8F0FE',
+  '--tint': 'rgba(37,99,235,0.06)',
+  '--warn': '#DC2626',
+} as React.CSSProperties
+
+// A card body that's draggable when `draggable` is set (a grip handle appears and
+// the row can be dragged) + caller-supplied trailing controls. When locked
+// (`draggable=false`) the handle is hidden and the row can't be dragged. Shared by
+// both columns.
+function DraggableCard({
+  task, index, trail, detail = false, onOpen, draggable = true,
+}: { task: CardTask; index: number; trail?: React.ReactNode; detail?: boolean; onOpen?: () => void; draggable?: boolean }) {
+  return (
+    <Draggable draggableId={task.key} index={index} isDragDisabled={!draggable}>
+      {(provided: DraggableProvided, snapshot: DraggableStateSnapshot) => (
+        <div ref={provided.innerRef} {...provided.draggableProps}
+          style={{
+            ...provided.draggableProps.style,
+            borderColor: 'var(--rule)',
+            background: 'var(--surface)',
+            boxShadow: snapshot.isDragging ? '0 10px 30px rgba(0,0,0,0.18)' : 'none',
+          }}
+          className="rounded-lg border">
+          <TaskCardBody task={task} detail={detail} onOpen={onOpen}
+            lead={draggable
+              ? (
+                <span {...provided.dragHandleProps} aria-label={`Drag ${task.key}`}
+                  className={`shrink-0 cursor-grab active:cursor-grabbing -ml-1 px-0.5 rounded inline-flex items-center ${FOCUS}`}
+                  style={{ color: 'var(--ink-4)' }}>
+                  <GripHandle />
+                </span>
+              )
+              : undefined}
+            trail={trail}
+          />
+        </div>
+      )}
+    </Draggable>
+  )
+}
+
+// ── main view ────────────────────────────────────────────────────────────────
+export default function PlanView() {
+  const [data, setData] = useState<PlanResponse | null>(null)
+  const [loadFailed, setLoadFailed] = useState(false)
+  const [today, setToday] = useState<CardTask[]>([])
+  const [confirmedMode, setConfirmedMode] = useState(false)
+  const [editing, setEditing] = useState(false)
+  const [skipped, setSkipped] = useState(false)
+  const [search, setSearch] = useState('')
+  const [sortMode, setSortMode] = useState<'top' | 'due' | 'az'>('top')
+  const [saveError, setSaveError] = useState(false)
+  const [openTask, setOpenTask] = useState<CardTask | null>(null)
+  const draggingRef = useRef(false)
+
+  const derive = useCallback((d: PlanResponse) => {
+    const isConfirmed = d.confirmed && !d.skipped
+    setConfirmedMode(isConfirmed)
+    setEditing(false)   // re-deriving from the server always returns to the locked/clean state
+    setSkipped(d.skipped)
+    const avail = new Map(d.available.map(a => [a.key, a]))
+    if (isConfirmed || d.plan.length > 0) setToday(d.plan.map(p => fromPlan(p, avail)))
+    else if (!d.skipped) setToday(d.suggestions.map(fromAvailable))
+    else setToday([])
+  }, [])
+
+  // `initial` (mount / error-rollback) re-seeds the Today list from the server.
+  // A background poll passes initial=false: it refreshes the board (so a PM sync's
+  // new/changed tickets appear) WITHOUT re-deriving Today, so it never clobbers the
+  // user's in-progress edits. Skipped entirely during an active drag.
+  const load = useCallback((initial = false) => {
+    if (!initial && draggingRef.current) return
+    fetch('/api/plan').then(r => r.json()).then((d: PlanResponse) => {
+      setData(d); setLoadFailed(false)
+      if (initial) derive(d)
+    }).catch(() => { if (initial) setLoadFailed(true) })
+  }, [derive])
+
+  useEffect(() => {
+    load(true)
+    const id = setInterval(() => load(false), 30_000)
+    return () => clearInterval(id)
+  }, [load])
+
+  // Persist a Today ordering (live mode only); roll back to server truth on error.
+  const persist = useCallback((keys: string[]) => {
+    fetch('/api/plan', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'set', task_keys: keys }) })
+      .then(r => { if (!r.ok) { setSaveError(true); load(true) } else setSaveError(false) })   // rollback to server truth
+      .catch(() => { setSaveError(true); load(true) })
+  }, [load])
+
+  const metaAction = useCallback((action: string, keys: string[]) => {
+    fetch('/api/plan', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action, task_keys: keys }) })
+      .then(async r => {
+        if (!r.ok) { setSaveError(true); return }
+        setSaveError(false)
+        const d: PlanResponse = await r.json(); setData(d); derive(d)
+      })
+      .catch(() => setSaveError(true))
+  }, [derive])
+
+  // Local edit only — both the proposed draft and the "Edit plan" session keep
+  // changes in `today` until the dev explicitly Confirms / Saves. No silent writes.
+  const commit = useCallback((next: CardTask[]) => {
+    setToday(next)
+  }, [])
+
+  // editable = the dev can drag / add / remove right now: either the pre-confirm
+  // draft, or an unlocked "Edit plan" session. A confirmed-but-locked plan is read-only.
+  const proposed = !confirmedMode && !skipped
+  const editable = proposed || editing
+
+  const saveEdits = useCallback(() => {
+    persist(today.map(t => t.key))
+    setEditing(false)
+  }, [persist, today])
+
+  const cancelEdits = useCallback(() => {
+    setEditing(false)
+    load(true)   // discard local changes, restore the committed plan from the server
+  }, [load])
+
+  // ── derived board + key map ─────────────────────────────────────────────────
+  const byKey = useMemo(() => {
+    const m = new Map<string, CardTask>()
+    ;(data?.available ?? []).forEach(a => m.set(a.key, fromAvailable(a)))
+    today.forEach(t => m.set(t.key, t))
+    return m
+  }, [data, today])
+
+  const board = useMemo(() => {
+    const todayKeys = new Set(today.map(t => t.key))
+    let items = (data?.available ?? []).filter(a => !todayKeys.has(a.key))
+    const q = search.trim().toLowerCase()
+    if (q) items = items.filter(a => a.key.toLowerCase().includes(q) || a.title.toLowerCase().includes(q))
+    const sorted = [...items]
+    if (sortMode === 'due') sorted.sort((a, b) => (a.due_days ?? 9e9) - (b.due_days ?? 9e9) || b.score - a.score || a.key.localeCompare(b.key))
+    else if (sortMode === 'az') sorted.sort((a, b) => a.title.localeCompare(b.title) || a.key.localeCompare(b.key))
+    return sorted.map(fromAvailable)
+  }, [data, today, search, sortMode])
+
+  // ── single onDragEnd for both lists (@hello-pangea/dnd DropResult) ──────────
+  const onDragEnd = useCallback((result: DropResult) => {
+    draggingRef.current = false
+    if (!editable) return                                      // plan is locked — ignore stray drags
+    const { source, destination, draggableId } = result
+    if (!destination) return                                   // dropped outside any list
+    const from = source.droppableId
+    const to = destination.droppableId
+
+    if (from === 'today' && to === 'today') {                  // reorder within Today
+      if (source.index === destination.index) return
+      const next = [...today]
+      const [moved] = next.splice(source.index, 1)
+      next.splice(destination.index, 0, moved)
+      commit(next)
+      return
+    }
+    if (from === 'board' && to === 'today') {                  // add at the drop position
+      const task = byKey.get(draggableId)
+      if (!task || today.some(t => t.key === draggableId)) return
+      const next = [...today]
+      next.splice(destination.index, 0, task)
+      commit(next)
+      return
+    }
+    if (from === 'today' && to === 'board') {                  // drag out → remove
+      commit(today.filter(t => t.key !== draggableId))
+      return
+    }
+    // board → board: it's a sorted source list, leave order to the sort control.
+  }, [today, byKey, commit, editable])
+
+  // ── render ──────────────────────────────────────────────────────────────────
+  if (!data) {
+    return (
+      <div className="space-y-8">
+        <header className="rise"><h1 className="type-title" style={{ color: 'var(--ink)' }}>Today&apos;s plan</h1></header>
+        {loadFailed
+          ? <button onClick={() => load(true)} className="text-[13px] px-3 py-2 rounded-md" style={{ background: 'var(--accent)', color: '#fff' }}>Couldn’t load — retry</button>
+          : <p className="text-[13px]" style={{ color: 'var(--ink-3)' }}>Loading…</p>}
+      </div>
+    )
+  }
+
+  const dateLabel = new Date(`${data.date}T00:00:00`).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })
+  const boardEmpty = (data.available?.length ?? 0) === 0 && today.length === 0
+
+  return (
+    <div style={BLUE_THEME} className="h-full flex flex-col min-h-0">
+    <DragDropContext onDragStart={() => { draggingRef.current = true }} onDragEnd={onDragEnd}>
+      <div className="flex-1 min-h-0 flex flex-col gap-8">
+        <header className="rise shrink-0 flex items-end justify-between gap-4">
+          <div>
+            <p className="text-[11px] uppercase tracking-[0.2em]" style={{ color: 'var(--ink-3)' }}>{dateLabel}</p>
+            <h1 className="type-title mt-1" style={{ color: 'var(--ink)' }}>What are you working on today?</h1>
+          </div>
+          <div className="text-right shrink-0">
+            {confirmedMode
+              ? (editing
+                ? <p className="text-[12px]" style={{ color: 'var(--accent)' }}>Editing · unsaved changes</p>
+                : <p className="text-[12px]" style={{ color: 'var(--success)' }}>Confirmed · {today.length} task{today.length === 1 ? '' : 's'}</p>)
+              : skipped
+                ? <p className="text-[12px]" style={{ color: 'var(--ink-3)' }}>Skipped for today</p>
+                : <p className="text-[12px]" style={{ color: 'var(--ink-3)' }}>Pick your focus, then confirm</p>}
+            {saveError && <p className="text-[11px] mt-0.5" style={{ color: 'var(--warn)' }}>Couldn’t save — is the daemon running?</p>}
+          </div>
+        </header>
+
+        {boardEmpty ? (
+          <div className="py-16 text-center rounded-xl border" style={{ borderColor: 'var(--rule)', background: 'var(--surface)' }}>
+            <p className="type-empty" style={{ color: 'var(--ink-2)' }}>No tasks on your board yet.</p>
+            <p className="text-[12px] mt-2" style={{ color: 'var(--ink-3)' }}>Connect a tracker in Settings and your tickets will appear here.</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-stretch flex-1 min-h-0">
+            {/* ── LEFT: Today ──────────────────────────────────────────────── */}
+            <Card className="p-5 flex flex-col min-h-0">
+              <div className="flex items-center justify-between mb-1">
+                <p className="text-[10px] uppercase tracking-[0.18em]" style={{ color: 'var(--ink-3)' }}>Today · {today.length}</p>
+                {proposed && today.length > 0 && (
+                  <span className="text-[10px] px-1.5 py-0.5 rounded-md" style={{ color: 'var(--accent)', background: 'var(--accent-soft)' }}>Suggested</span>
+                )}
+              </div>
+              <p className="text-[12px] mb-2" style={{ color: 'var(--ink-3)' }}>
+                {proposed
+                  ? 'We pre-filled what looks active. Drag to reorder, drag a card out to remove, or add from your board — then confirm.'
+                  : editing
+                    ? 'Reorder, add, or remove — then Save to update today’s plan, or Cancel to discard.'
+                    : confirmedMode
+                      ? 'Your plan is locked in. Hit Edit plan to make changes.'
+                      : 'Plan your day below.'}
+              </p>
+              {editable && today.length > 5 && (
+                <p className="text-[11px] mb-3 flex items-center gap-1.5" style={{ color: 'var(--warn)' }}>
+                  <span>⚠</span> That&apos;s a full plate — most focused days land on 1–3 tasks.
+                </p>
+              )}
+
+              <Droppable droppableId="today">
+                {(provided, snapshot) => (
+                  <div ref={provided.innerRef} {...provided.droppableProps}
+                    className="rounded-xl transition-colors flex-1 min-h-0 overflow-y-auto p-2 space-y-2"
+                    style={{ background: snapshot.isDraggingOver ? 'var(--accent-soft)' : 'var(--surface-2)', outline: snapshot.isDraggingOver ? '1.5px dashed var(--accent)' : '1.5px dashed transparent', outlineOffset: 2 }}>
+                    {today.map((t, i) => (
+                      <DraggableCard key={t.key} task={t} index={i} draggable={editable} onOpen={() => setOpenTask(t)}
+                        trail={
+                          <div className="flex items-center gap-1 shrink-0">
+                            <span aria-hidden className="font-mono tnum text-[11px] mr-1" style={{ color: 'var(--ink-4)' }}>{i + 1}</span>
+                            {editable && (
+                              <button onClick={() => commit(today.filter(x => x.key !== t.key))} aria-label={`Remove ${t.key} from today`}
+                                className={`w-6 h-6 rounded-md flex items-center justify-center transition-colors hover:bg-[var(--rule)] ${FOCUS}`}
+                                style={{ color: 'var(--ink-4)' }}>
+                                <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6"><path d="M4 4l8 8M12 4l-8 8" /></svg>
+                              </button>
+                            )}
+                          </div>
+                        }
+                      />
+                    ))}
+                    {provided.placeholder}
+                    {today.length === 0 && !snapshot.isDraggingOver && (
+                      <div className="py-9 text-center">
+                        <p className="text-[12px]" style={{ color: 'var(--ink-4)' }}>
+                          {editable
+                            ? <>Drag tasks here, or tap <span style={{ color: 'var(--accent)' }}>+ Add</span> from your board.</>
+                            : 'No tasks in today’s plan.'}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </Droppable>
+
+              <div className="mt-5 pt-4 rule-t shrink-0 flex items-center gap-3" style={{ borderTopColor: 'var(--rule)' }}>
+                {proposed ? (
+                  <>
+                    <button onClick={() => metaAction('confirm', today.map(t => t.key))}
+                      className={`px-4 py-2 rounded-md text-[13px] font-medium transition-colors ${FOCUS}`}
+                      style={{ background: 'var(--accent)', color: '#fff' }}>
+                      Confirm {today.length > 0 ? `${today.length} task${today.length === 1 ? '' : 's'}` : 'plan'} →
+                    </button>
+                    <button onClick={() => metaAction('skip', [])} className={`text-[12px] px-2 py-1.5 rounded-md ml-auto ${FOCUS}`} style={{ color: 'var(--ink-4)' }}>
+                      Skip today
+                    </button>
+                  </>
+                ) : skipped ? (
+                  <button onClick={() => metaAction('reopen', [])}
+                    className={`px-4 py-2 rounded-md text-[13px] font-medium transition-colors ${FOCUS}`}
+                    style={{ background: 'var(--accent)', color: '#fff' }}>
+                    Plan today →
+                  </button>
+                ) : editing ? (
+                  <>
+                    <button onClick={saveEdits}
+                      className={`px-4 py-2 rounded-md text-[13px] font-medium transition-colors ${FOCUS}`}
+                      style={{ background: 'var(--accent)', color: '#fff' }}>
+                      Save changes
+                    </button>
+                    <button onClick={cancelEdits} className={`text-[12px] px-2 py-1.5 rounded-md ${FOCUS}`} style={{ color: 'var(--ink-4)' }}>
+                      Cancel
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <button onClick={() => setEditing(true)}
+                      className={`px-4 py-2 rounded-md text-[13px] font-medium border transition-colors ${FOCUS}`}
+                      style={{ borderColor: 'var(--rule)', color: 'var(--ink-2)', background: 'var(--paper)' }}>
+                      Edit plan
+                    </button>
+                    <span className="text-[12px] ml-auto" style={{ color: 'var(--ink-4)' }}>These lead today’s task matching.</span>
+                  </>
+                )}
+              </div>
+            </Card>
+
+            {/* ── RIGHT: Your tasks (board) ─────────────────────────────────── */}
+            <Card className="p-5 flex flex-col min-h-0">
+              <p className="text-[10px] uppercase tracking-[0.18em] mb-3 shrink-0" style={{ color: 'var(--ink-3)' }}>
+                Your tasks{search ? ` · ${board.length} match${board.length === 1 ? '' : 'es'}` : ` · ${board.length}`}
+              </p>
+              <div className="flex items-center gap-2 mb-4 shrink-0">
+                <input
+                  value={search} onChange={e => setSearch(e.target.value)} aria-label="Search your tasks"
+                  placeholder="Search tasks…"
+                  className={`flex-1 text-[13px] px-3 py-2 rounded-md ${FOCUS}`}
+                  style={{ background: 'var(--surface-2)', color: 'var(--ink)', border: '1px solid var(--rule)' }}
+                />
+                <div role="radiogroup" aria-label="Sort tasks" className="flex rounded-md overflow-hidden" style={{ border: '1px solid var(--rule)' }}>
+                  {(['top', 'due', 'az'] as const).map(m => (
+                    <button key={m} role="radio" aria-checked={sortMode === m} onClick={() => setSortMode(m)}
+                      className={`text-[11px] px-2.5 py-2 transition-colors ${FOCUS}`}
+                      style={{ background: sortMode === m ? 'var(--surface-2)' : 'var(--surface)', color: sortMode === m ? 'var(--ink)' : 'var(--ink-3)' }}>
+                      {m === 'top' ? 'Top' : m === 'due' ? 'Due' : 'A–Z'}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <Droppable droppableId="board">
+                {(provided, snapshot) => (
+                  <div ref={provided.innerRef} {...provided.droppableProps}
+                    className="space-y-2 flex-1 min-h-0 overflow-y-auto rounded-xl transition-colors p-1 pr-1.5"
+                    style={{ outline: snapshot.isDraggingOver ? '1.5px dashed var(--rule-2)' : '1.5px dashed transparent', outlineOffset: 2 }}>
+                    {board.map((t, i) => (
+                      <DraggableCard key={t.key} task={t} index={i} detail draggable={editable} onOpen={() => setOpenTask(t)}
+                        trail={editable
+                          ? (
+                            <button onClick={() => commit([...today, t])} aria-label={`Add ${t.key} to today`}
+                              className={`shrink-0 px-3 py-1.5 rounded-md text-[12px] font-medium transition-colors hover:opacity-80 ${FOCUS}`}
+                              style={{ background: 'var(--accent-soft)', color: 'var(--accent)' }}>
+                              + Add
+                            </button>
+                          )
+                          : undefined}
+                      />
+                    ))}
+                    {provided.placeholder}
+                    {board.length === 0 && (
+                      <p className="py-8 text-center text-[12px]" style={{ color: 'var(--ink-4)' }}>
+                        {search ? 'No tasks match your search.' : 'Everything is in today’s plan. Drag a card here to remove it.'}
+                      </p>
+                    )}
+                  </div>
+                )}
+              </Droppable>
+            </Card>
+          </div>
+        )}
+      </div>
+
+      {openTask && (
+        <TaskDialog
+          task={openTask}
+          inToday={today.some(t => t.key === openTask.key)}
+          canEdit={editable}
+          onClose={() => setOpenTask(null)}
+          onAdd={() => commit([...today, openTask])}
+          onRemove={() => commit(today.filter(t => t.key !== openTask.key))}
+        />
+      )}
+    </DragDropContext>
+    </div>
+  )
+}

--- a/ui/components/views/PlanView.tsx
+++ b/ui/components/views/PlanView.tsx
@@ -115,7 +115,10 @@ export default function PlanView() {
   // user's in-progress edits. Skipped entirely during an active drag.
   const load = useCallback((initial = false) => {
     if (!initial && draggingRef.current) return
-    fetch('/api/plan').then(r => r.json()).then((d: PlanResponse) => {
+    fetch('/api/plan').then(r => {
+      if (!r.ok) throw new Error(`plan load failed: ${r.status}`)  // 500 = real backend error, not an empty day
+      return r.json()
+    }).then((d: PlanResponse) => {
       setData(d); setLoadFailed(false)
       if (initial) derive(d)
     }).catch(() => { if (initial) setLoadFailed(true) })

--- a/ui/lib/daily-plan.ts
+++ b/ui/lib/daily-plan.ts
@@ -1,0 +1,334 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Server-side data + scoring for the daily plan ("Today's tasks"). Pure board
+// signals — no LLM. Builds three things the /api/plan route serves:
+//   • plan        — the dev's committed task_keys for the day (joined w/ pm_tasks)
+//   • available   — every non-excluded, open board ticket, scored & sorted so the
+//                   most-likely-today tasks float to the top (easy to drag/add)
+//   • suggestions — the top few not-yet-committed tasks to pre-fill the morning
+//
+// Scoring is additive across signals, with DUE DATE weighted prominently (a
+// near/overdue ticket should surface even if nothing else flags it). Node runtime
+// only (uses better-sqlite3 via lib/db).
+
+import type Database from 'better-sqlite3'
+import getDb from '@/lib/db'
+import { localDayBounds, todayString } from '@/lib/date-utils'
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+// Shared ticket context shown on a card so a dev can recognise / decide.
+export interface TaskMeta {
+  description: string       // short excerpt of description_text
+  epic: string | null       // epic_title, else parent_key
+  priority: string | null
+  issue_type: string
+  story_points: string | null
+}
+
+export interface PlanItem extends TaskMeta {
+  task_key: string
+  position: number
+  origin: string
+  title: string
+  provider: string
+  url: string
+  status: string
+  is_terminal: boolean
+  due_date: string | null
+  due_days: number | null   // whole days until due (negative = overdue), null if no/again unparseable date
+}
+
+export interface AvailableTask extends TaskMeta {
+  key: string
+  title: string
+  provider: string
+  url: string
+  status: string
+  is_terminal: boolean
+  due_date: string | null
+  due_days: number | null
+  started: boolean          // status reads as in-progress
+  carryover: boolean        // was in the most recent prior day's plan
+  worked_recently: boolean  // appeared in app_sessions in the last few days
+  score: number
+  origin: string            // primary contributing signal (for storage on add)
+  reason: string            // short friendly label for the UI
+}
+
+/** Short single-line excerpt of a description for card display. */
+function excerpt(s: string | null | undefined, n = 130): string {
+  const t = (s ?? '').replace(/\s+/g, ' ').trim()
+  return t.length > n ? t.slice(0, n - 1).trimEnd() + '…' : t
+}
+
+export interface PlanResponse {
+  date: string
+  has_table: boolean
+  confirmed: boolean
+  skipped: boolean
+  plan: PlanItem[]
+  suggestions: AvailableTask[]
+  available: AvailableTask[]
+}
+
+// ── Tunables ─────────────────────────────────────────────────────────────────
+
+const RECENT_WORK_DAYS = 3      // "worked recently" lookback
+const DUE_SOON_DAYS = 14        // due within this counts as a soon signal
+const SUGGESTION_CAP = 5        // how many tasks to pre-fill in the morning
+
+// ── Small helpers ────────────────────────────────────────────────────────────
+
+function tableExists(db: Database.Database, name: string): boolean {
+  return !!db.prepare(
+    "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+  ).get(name)
+}
+
+// Lightweight in-progress heuristic for scoring only (NOT a correctness gate —
+// the Rust triage engine owns the authoritative startedness). Word-ish contains.
+const STARTED_HINTS = [
+  'progress', 'doing', 'wip', 'review', 'qa', 'testing', 'dev',
+  'implement', 'active', 'building', 'ongoing', 'started',
+]
+function looksStarted(status: string): boolean {
+  const s = (status || '').toLowerCase()
+  return STARTED_HINTS.some(h => s.includes(h))
+}
+
+/** Whole days until a due date (date-only). Negative = overdue. null if absent/bad. */
+function dueDaysFrom(due: string | null, now: Date): number | null {
+  if (!due) return null
+  const d = new Date(due.length <= 10 ? `${due}T00:00:00` : due)
+  if (isNaN(d.getTime())) return null
+  const a = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const b = new Date(d.getFullYear(), d.getMonth(), d.getDate())
+  return Math.round((b.getTime() - a.getTime()) / 86400000)
+}
+
+// ── Scoring ──────────────────────────────────────────────────────────────────
+
+function dueComponent(dueDays: number | null): number {
+  if (dueDays === null) return 0
+  if (dueDays < 0) return 400        // overdue — strongest due signal
+  if (dueDays <= 2) return 350
+  if (dueDays <= 7) return 250
+  if (dueDays <= DUE_SOON_DAYS) return 120
+  if (dueDays <= 30) return 40
+  return 0                            // far-future / planned — not today's work
+}
+
+function dueReason(dueDays: number | null): string | null {
+  if (dueDays === null) return null
+  if (dueDays < 0) return `Overdue ${-dueDays}d`
+  if (dueDays === 0) return 'Due today'
+  if (dueDays === 1) return 'Due tomorrow'
+  if (dueDays <= DUE_SOON_DAYS) return `Due in ${dueDays}d`
+  return null
+}
+
+// ── Loaders ──────────────────────────────────────────────────────────────────
+
+interface MetaRow { confirmed_at: string | null; skipped: number }
+
+/** Committed plan rows joined with their live pm_tasks state. Reads pm_tasks
+ *  directly (not the scored `available` map) so a committed task that has since
+ *  gone terminal still shows its real title / Done state. */
+function loadPlan(db: Database.Database, date: string, now: Date): PlanItem[] {
+  if (!tableExists(db, 'daily_plan')) return []
+  const rows = db.prepare(`
+    SELECT p.task_key, p.position, p.origin,
+           t.title, t.provider, t.url,
+           COALESCE(t.status_raw,'') AS status_raw,
+           COALESCE(t.is_terminal,0) AS is_terminal,
+           t.due_date, t.description_text, t.epic_title, t.parent_key,
+           t.priority, t.issue_type, t.story_points
+    FROM daily_plan p
+    LEFT JOIN pm_tasks t ON t.task_key = p.task_key
+    WHERE p.plan_date = ?
+    ORDER BY p.position ASC, p.task_key ASC
+  `).all(date) as Array<{
+    task_key: string; position: number; origin: string
+    title: string | null; provider: string | null; url: string | null
+    status_raw: string; is_terminal: number; due_date: string | null
+    description_text: string | null; epic_title: string | null; parent_key: string | null
+    priority: string | null; issue_type: string | null; story_points: string | null
+  }>
+  return rows.map(r => ({
+    task_key: r.task_key,
+    position: r.position,
+    origin: r.origin,
+    title: r.title ?? r.task_key,
+    provider: r.provider ?? 'jira',
+    url: r.url ?? '',
+    status: r.status_raw,
+    is_terminal: !!r.is_terminal,
+    due_date: r.due_date ?? null,
+    due_days: dueDaysFrom(r.due_date ?? null, now),
+    description: excerpt(r.description_text),
+    epic: (r.epic_title?.trim() || r.parent_key?.trim() || null) ?? null,
+    priority: r.priority?.trim() || null,
+    issue_type: r.issue_type?.trim() || '',
+    story_points: r.story_points?.trim() || null,
+  }))
+}
+
+function loadMeta(db: Database.Database, date: string): MetaRow {
+  if (!tableExists(db, 'daily_plan_meta')) return { confirmed_at: null, skipped: 0 }
+  const row = db.prepare(
+    'SELECT confirmed_at, skipped FROM daily_plan_meta WHERE plan_date = ?',
+  ).get(date) as MetaRow | undefined
+  return row ?? { confirmed_at: null, skipped: 0 }
+}
+
+/** task_keys committed on the most recent planned day before `date`. */
+function carryoverKeys(db: Database.Database, date: string): Set<string> {
+  if (!tableExists(db, 'daily_plan')) return new Set()
+  const prior = db.prepare(
+    'SELECT MAX(plan_date) AS d FROM daily_plan WHERE plan_date < ?',
+  ).get(date) as { d: string | null }
+  if (!prior?.d) return new Set()
+  const rows = db.prepare(
+    'SELECT task_key FROM daily_plan WHERE plan_date = ?',
+  ).all(prior.d) as Array<{ task_key: string }>
+  return new Set(rows.map(r => r.task_key))
+}
+
+/** task_key → most recent worked timestamp within the lookback window. */
+function recentWorkedKeys(db: Database.Database): Map<string, string> {
+  const since = new Date(Date.now() - RECENT_WORK_DAYS * 86400000)
+  const { start } = localDayBounds(since.toLocaleDateString('en-CA'))
+  const rows = db.prepare(`
+    SELECT task_key, MAX(started_at) AS last_at
+    FROM app_sessions
+    WHERE task_key IS NOT NULL AND task_session_type = 'task' AND started_at >= ?
+    GROUP BY task_key
+  `).all(start) as Array<{ task_key: string; last_at: string }>
+  return new Map(rows.map(r => [r.task_key, r.last_at]))
+}
+
+interface BoardRow {
+  task_key: string; title: string; provider: string | null; url: string | null
+  status_raw: string | null; is_terminal: number; due_date: string | null
+  decision: string | null; updated_at: string | null
+  description_text: string | null; epic_title: string | null; parent_key: string | null
+  priority: string | null; issue_type: string | null; story_points: string | null
+}
+
+/** Every candidate board ticket (non-excluded), scored and sorted top-first. */
+export function buildAvailable(db: Database.Database, date: string): AvailableTask[] {
+  const hasCuration = tableExists(db, 'pm_task_curation')
+  const rows = db.prepare(`
+    SELECT t.task_key, t.title, t.provider, t.url,
+           COALESCE(t.status_raw,'') AS status_raw,
+           COALESCE(t.is_terminal,0) AS is_terminal,
+           t.due_date, t.updated_at,
+           t.description_text, t.epic_title, t.parent_key,
+           t.priority, t.issue_type, t.story_points,
+           ${hasCuration ? 'c.decision' : 'NULL'} AS decision
+    FROM pm_tasks t
+    ${hasCuration ? 'LEFT JOIN pm_task_curation c ON c.task_key = t.task_key' : ''}
+  `).all() as BoardRow[]
+
+  const carry = carryoverKeys(db, date)
+  const worked = recentWorkedKeys(db)
+  const now = new Date()
+  const nowMs = now.getTime()
+
+  const items: AvailableTask[] = []
+  for (const r of rows) {
+    if (r.decision === 'excluded') continue          // honour board cleanup
+    const isTerminal = !!r.is_terminal
+    if (isTerminal) continue                          // done tickets aren't today's work
+    const dueDays = dueDaysFrom(r.due_date, now)
+    const started = looksStarted(r.status_raw ?? '')
+    const carryover = carry.has(r.task_key)
+    const workedAt = worked.get(r.task_key) ?? null
+    const workedRecently = workedAt !== null
+
+    // recency-of-work component
+    let recentComp = 0
+    if (workedAt) {
+      const ageDays = (nowMs - new Date(workedAt).getTime()) / 86400000
+      recentComp = ageDays < 1 ? 200 : ageDays < 2 ? 150 : 80
+    }
+    // small updated_at tiebreaker (0..30)
+    let updComp = 0
+    if (r.updated_at) {
+      const ageDays = (nowMs - new Date(r.updated_at).getTime()) / 86400000
+      if (!isNaN(ageDays)) updComp = Math.max(0, 30 - Math.min(30, Math.floor(ageDays)))
+    }
+
+    const score =
+      (carryover ? 500 : 0) +
+      (started ? 300 : 0) +
+      dueComponent(dueDays) +
+      recentComp +
+      updComp
+
+    // primary origin + friendly reason (highest-weight signal wins)
+    let origin = 'manual'
+    let reason = 'On your board'
+    const dr = dueReason(dueDays)
+    if (carryover) { origin = 'carryover'; reason = 'Carried over' }
+    else if (started) { origin = 'in_progress'; reason = 'In progress' }
+    else if (dr) { origin = 'due_soon'; reason = dr }
+    else if (workedRecently) { origin = 'recent'; reason = recentComp >= 150 ? 'Worked recently' : 'Worked this week' }
+    // Always surface a due pill reason as secondary even when origin differs —
+    // the UI reads due_days directly, so `reason` is just the lead label.
+
+    items.push({
+      key: r.task_key,
+      title: r.title,
+      provider: r.provider || 'jira',
+      url: r.url || '',
+      status: r.status_raw || '',
+      is_terminal: isTerminal,
+      due_date: r.due_date ?? null,
+      due_days: dueDays,
+      started,
+      carryover,
+      worked_recently: workedRecently,
+      score,
+      origin,
+      reason,
+      description: excerpt(r.description_text),
+      epic: (r.epic_title?.trim() || r.parent_key?.trim() || null) ?? null,
+      priority: r.priority?.trim() || null,
+      issue_type: r.issue_type?.trim() || '',
+      story_points: r.story_points?.trim() || null,
+    })
+  }
+
+  // Highest score first; stable tiebreak on key so order is deterministic.
+  items.sort((a, b) => (b.score - a.score) || a.key.localeCompare(b.key))
+  return items
+}
+
+/** Full plan payload for a day. */
+export function buildPlanResponse(date: string): PlanResponse {
+  const db = getDb()
+  const now = new Date()
+  const hasTable = tableExists(db, 'daily_plan')
+  const meta = loadMeta(db, date)
+  const available = buildAvailable(db, date)
+
+  const plan = loadPlan(db, date, now)
+  const committed = new Set(plan.map(p => p.task_key))
+  const suggestions = available
+    .filter(a => !committed.has(a.key) && a.score > 0)
+    .slice(0, SUGGESTION_CAP)
+
+  return {
+    date,
+    has_table: hasTable,
+    confirmed: meta.confirmed_at !== null,
+    skipped: meta.skipped === 1,
+    plan,
+    suggestions,
+    available,
+  }
+}
+
+export { todayString }

--- a/ui/lib/daily-plan.ts
+++ b/ui/lib/daily-plan.ts
@@ -98,7 +98,7 @@ function looksStarted(status: string): boolean {
 }
 
 /** Whole days until a due date (date-only). Negative = overdue. null if absent/bad. */
-function dueDaysFrom(due: string | null, now: Date): number | null {
+export function dueDaysFrom(due: string | null, now: Date): number | null {
   if (!due) return null
   const d = new Date(due.length <= 10 ? `${due}T00:00:00` : due)
   if (isNaN(d.getTime())) return null
@@ -306,13 +306,17 @@ export function buildAvailable(db: Database.Database, date: string): AvailableTa
   return items
 }
 
-/** Full plan payload for a day. */
-export function buildPlanResponse(date: string): PlanResponse {
-  const db = getDb()
+/** Full plan payload for a day. `db` and `available` may be supplied by a write
+ *  handler that has already opened the DB and scored the board, so a POST scores
+ *  the board once instead of twice. */
+export function buildPlanResponse(
+  date: string,
+  db: Database.Database = getDb(),
+  available: AvailableTask[] = buildAvailable(db, date),
+): PlanResponse {
   const now = new Date()
   const hasTable = tableExists(db, 'daily_plan')
   const meta = loadMeta(db, date)
-  const available = buildAvailable(db, date)
 
   const plan = loadPlan(db, date, now)
   const committed = new Set(plan.map(p => p.task_key))

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "meridian-ui",
-  "version": "1.40.1",
+  "version": "1.52.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meridian-ui",
-      "version": "1.40.1",
+      "version": "1.52.6",
       "dependencies": {
+        "@hello-pangea/dnd": "^18.0.1",
         "@opentelemetry/api": "1.9",
         "@opentelemetry/exporter-trace-otlp-http": "0.217",
         "@opentelemetry/sdk-node": "0.217",
@@ -136,6 +137,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@hello-pangea/dnd": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-18.0.1.tgz",
+      "integrity": "sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "css-box-model": "^1.2.1",
+        "raf-schd": "^4.0.3",
+        "react-redux": "^9.2.0",
+        "redux": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@img/colour": {
@@ -2437,6 +2455,12 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2671,6 +2695,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -3680,6 +3713,12 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+      "license": "MIT"
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -3721,6 +3760,29 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -3876,6 +3938,12 @@
       "dependencies": {
         "decimal.js-light": "^2.4.1"
       }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -4283,6 +4351,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@hello-pangea/dnd": "^18.0.1",
     "@opentelemetry/api": "1.9",
     "@opentelemetry/exporter-trace-otlp-http": "0.217",
     "@opentelemetry/sdk-node": "0.217",


### PR DESCRIPTION
## What

A new **Plan** page (`/plan`, nav key `8`) where a developer declares their daily working set each morning via a drag-and-drop two-column UI:

- **Today** — a pre-filled, scored column of what looks active (carryover / in-progress / due-soon, due-date weighted). Drag to reorder, drag out to remove.
- **Your tasks** — a searchable, sortable board of assigned tickets; drag or **+ Add** into Today.

Click any card to open a full-ticket dialog (description, acceptance criteria, epic, due/start date, priority, points, open-in-tracker).

## Flow

`Suggested → Confirm → (locked) → Edit plan → Save / Cancel → (locked)`

Confirm **locks** the plan (no accidental drags); an explicit **Edit plan** unlocks it, with **Save changes** / **Cancel**. No silent writes.

## Implementation

- **Migration 041** — `daily_plan` + `daily_plan_meta` tables. Intent only, local `meridian.db`; nothing is pushed to a tracker.
- **`/api/plan`** — `confirm`/`set`/`add`/`remove`/`reorder`/`skip`/`reopen`, all idempotent UPSERT/DELETE (same pattern as triage).
- **`/api/plan/task`** — full ticket detail for the dialog.
- **`lib/daily-plan.ts`** — server-side candidate **scoring/ranking only** (no classification).
- White & blue theme scoped to the page; app-like layout (no page-level scrollbar); 30s background poll refreshes the board without clobbering local edits or an active drag.
- Uses `@hello-pangea/dnd`.

## Follow-up (not in this PR)

The committed plan is **intended to lead the classifier's candidate set** as today's declared focus — a **boost, never a filter**, so recall isn't compromised. That `run_task_linker_mlx.py` wiring lands in a separate PR.

## Test

`npm run build` ✓ compiled clean. Pre-push suite (fmt + clippy + cargo test + UI build + UI tests) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)