### PR TITLE
feat(classifier): boost today's declared plan as Tier-1 candidates

### DIFF
--- a/services/agents/_prompts.py
+++ b/services/agents/_prompts.py
@@ -106,8 +106,11 @@ def _format_candidates(tasks: list[dict]) -> str:
             desc = desc[:240] + "…"
         meta_parts = [p for p in [issue_type, f"Epic: {epic_title}" if epic_title else "", sprint_name, f"tags: {tags}" if tags else ""] if p]
         meta = "  [" + " · ".join(meta_parts) + "]" if meta_parts else ""
+        # The dev declared this ticket as today's focus on the plan page. It's a
+        # tie-breaking prior, not a forced answer — only matches if the evidence fits.
+        focus = " ★ TODAY'S FOCUS" if task.get("is_today_focus") else ""
         rows.append(
-            f"{i}. {task['task_key']}{meta}\n"
+            f"{i}. {task['task_key']}{focus}{meta}\n"
             f"   title: {title}\n"
             f"   description: {desc or '(empty)'}"
         )
@@ -152,12 +155,21 @@ def build_user_message(
         f"{_format_recent_sessions(sessions)}\n"
         "\n"
     ) if has_any_task_key else ""
+    # When the dev declared a focus for the day, name it in the header so the model
+    # treats ★ rows as a prior — preferred when the evidence plausibly fits, but
+    # never forced. Recall is preserved: every candidate is still listed.
+    has_focus = any(c.get("is_today_focus") for c in candidates)
+    candidate_header = (
+        "CANDIDATE TICKETS (★ = the dev declared this as a task they're working on "
+        "today; prefer a ★ ticket when the session plausibly matches it, but only "
+        "if the evidence fits — never force a match):\n"
+    ) if has_focus else "CANDIDATE TICKETS:\n"
     return (
         f"{recent_block}"
         "SESSION:\n"
         f"{_format_session(session)}\n"
         "\n"
-        "CANDIDATE TICKETS:\n"
+        f"{candidate_header}"
         f"{_format_candidates(candidates)}"
     )
 

--- a/services/agents/run_task_linker_mlx.py
+++ b/services/agents/run_task_linker_mlx.py
@@ -24,6 +24,7 @@ Method tag in results: "mlx_direct".
 """
 from __future__ import annotations
 
+import datetime as _dt
 import json
 import logging
 import os
@@ -483,7 +484,53 @@ def _fetch_recent_sessions(
     return result
 
 
-def _fetch_pm_tasks(con: _sqlite3.Connection) -> list[dict[str, Any]]:
+def _local_day(started_at: str) -> str:
+    """The local calendar day (YYYY-MM-DD) of a session's UTC `started_at`.
+
+    `daily_plan.plan_date` is the dev's *local* day (the dashboard stamps it from
+    the browser's local date), but `app_sessions.started_at` is stored UTC. We
+    convert UTC → local here so a session is matched to the plan the dev actually
+    declared for that day. Returns "" on an unparseable timestamp (→ no boost).
+    """
+    if not started_at:
+        return ""
+    try:
+        # `astimezone()` with no arg converts an aware datetime to the host's
+        # local zone — the same zone the dashboard used to compute plan_date.
+        return _dt.datetime.fromisoformat(started_at).astimezone().date().isoformat()
+    except ValueError:
+        return ""
+
+
+def _fetch_plan_focus(con: _sqlite3.Connection, plan_date: str) -> list[str]:
+    """Ordered task_keys the dev CONFIRMED as their focus for `plan_date`.
+
+    Empty (→ no boost, classification proceeds exactly as before) when the day is
+    unconfirmed, explicitly skipped, has no plan rows, or the plan tables don't
+    exist yet (pre-migration-041 DB). This is a ranking signal only — never a
+    filter — so an empty result can only ever cost the boost, never recall.
+    """
+    if not plan_date:
+        return []
+    try:
+        meta = con.execute(
+            "SELECT confirmed_at, skipped FROM daily_plan_meta WHERE plan_date = ?",
+            (plan_date,),
+        ).fetchone()
+        if meta is None or meta["skipped"] or not meta["confirmed_at"]:
+            return []
+        rows = con.execute(
+            "SELECT task_key FROM daily_plan WHERE plan_date = ? ORDER BY position",
+            (plan_date,),
+        ).fetchall()
+        return [r["task_key"] for r in rows]
+    except _sqlite3.OperationalError:
+        return []
+
+
+def _fetch_pm_tasks(
+    con: _sqlite3.Connection, focus_keys: list[str] | None = None
+) -> list[dict[str, Any]]:
     # Candidate set for classification. Tickets the user explicitly EXCLUDED during
     # onboarding board-cleanup (pm_task_curation.decision = 'excluded') are dropped
     # so a cleaned-up dead ticket can never be a classification target. Everything
@@ -512,7 +559,20 @@ def _fetch_pm_tasks(con: _sqlite3.Connection) -> list[dict[str, Any]]:
         # Pre-migration-038 DB (no pm_task_curation): degrade to the unfiltered
         # candidate set rather than crashing the whole /classify_sessions call.
         rows = con.execute(base_cols).fetchall()
-    return [dict(r) for r in rows]
+    tasks = [dict(r) for r in rows]
+
+    # Today's-focus boost: tag the tickets the dev declared for the day and float
+    # them to the top of the candidate list, in their declared order. This is a
+    # BOOST, never a filter — every other candidate still follows, so recall is
+    # untouched. A focus key that isn't in `tasks` (e.g. excluded by curation)
+    # simply has no effect; we never resurrect a filtered-out ticket.
+    focus = focus_keys or []
+    if focus:
+        order = {key: i for i, key in enumerate(focus)}
+        for t in tasks:
+            t["is_today_focus"] = t["task_key"] in order
+        tasks.sort(key=lambda t: (0, order[t["task_key"]]) if t.get("is_today_focus") else (1, 0))
+    return tasks
 
 
 # ---------------------------------------------------------------------------
@@ -555,10 +615,13 @@ def _classify_one(
                 session_id, f"session {session_id} not found in DB", 0.0, "mlx_error"
             )
 
-        pm_tasks = _fetch_pm_tasks(con)
-        recent   = _fetch_recent_sessions(con, session_id)
+        plan_date  = _local_day(session_raw.get("started_at") or "")
+        focus_keys = _fetch_plan_focus(con, plan_date)
+        pm_tasks   = _fetch_pm_tasks(con, focus_keys)
+        recent     = _fetch_recent_sessions(con, session_id)
 
         db_span.set_attribute("pm_tasks_count", len(pm_tasks))
+        db_span.set_attribute("today_focus_count", len(focus_keys))
         db_span.set_attribute("recent_sessions_count", len(recent))
 
         session_text = session_raw.get("session_text") or ""
@@ -785,7 +848,8 @@ def _classify_one_logged(
     """Classify one session and append a full record to the run log."""
     # Gather inputs before classification so we can log them even on error.
     session_raw = _fetch_session(con, session_id)
-    pm_tasks = _fetch_pm_tasks(con) if session_raw else []
+    focus_keys = _fetch_plan_focus(con, _local_day(session_raw.get("started_at") or "")) if session_raw else []
+    pm_tasks = _fetch_pm_tasks(con, focus_keys) if session_raw else []
     recent = _fetch_recent_sessions(con, session_id) if session_raw else []
 
     if session_raw:


### PR DESCRIPTION
**Stacked on #288** (base = `feat/daily-plan-today-tasks`). Retarget to `main` once #288 merges.

## What

Closes the loop on the Plan page: when a developer **confirms** their daily plan, those tickets become the **leading candidates** when classifying that day's sessions.

## How

- **`_local_day()`** — maps a session's UTC `started_at` to the dev's *local* calendar day, matching `daily_plan.plan_date` (stamped from the dashboard's local date). So a session is matched to the plan the dev actually declared for **that day** — backfilled / cross-midnight sessions use their own day's plan, not "now".
- **`_fetch_plan_focus()`** — ordered `task_keys` the dev **confirmed** for the day. Empty (→ no boost) when the day is unconfirmed, skipped, has no rows, or the DB predates migration 041 (`OperationalError` guard).
- **`_fetch_pm_tasks(focus_keys)`** — tags matched candidates `is_today_focus` and floats them to the top in the dev's declared order.
- **Prompt** — `★ TODAY'S FOCUS` marker on those rows + a header note: *prefer a ★ ticket when the session plausibly matches, but only if the evidence fits — never force a match.*

## Boost, never a filter

Every other candidate still flows through unchanged, so **recall is untouched**. An empty/skipped plan behaves exactly as today. A focus key that was excluded by curation simply has no effect (we never resurrect a filtered-out ticket).

## Verified against the live DB

- `_local_day('2026-06-15T14:01:26+00:00')` → `2026-06-15`
- confirmed day → `['KAN-230','KAN-109']`; unconfirmed day → `[]`
- candidate ordering: the 2 focus tickets lead (marked), other 21 follow — all 23 present
- no-focus path sets no `is_today_focus` key → prompt header byte-identical to before (fully backward compatible)
- rendered prompt shows the header note + `★ TODAY'S FOCUS` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)