### PR TITLE
fix(dev): resolve meridian binary to repo build in dev to stop migration drift

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,10 @@ async fn main() -> Result<()> {
                 pool.close().await;
             }
             Err(e) => {
-                eprintln!("tasks-sync: open db: {e}");
+                // `{e:#}` prints the full anyhow source chain (e.g. the sqlx
+                // "migration N was previously applied / missing" cause) instead
+                // of just the top-level "failed to run migrations" context.
+                eprintln!("tasks-sync: open db: {e:#}");
                 std::process::exit(1);
             }
         }

--- a/ui/__tests__/meridian-bin.test.ts
+++ b/ui/__tests__/meridian-bin.test.ts
@@ -36,8 +36,33 @@ describe('meridianCandidates', () => {
   })
 })
 
+describe('meridianCandidates in development', () => {
+  // `npm run dev` runs with cwd = <repo>/ui, so the repo root is one level up.
+  const list = meridianCandidates(HOME, 'development', '/work/meridian/ui')
+
+  it('prepends the repo build (target/debug) ahead of the installed binaries', () => {
+    expect(list[0]).toBe('/work/meridian/target/debug/meridian')
+    expect(list.indexOf('/work/meridian/target/debug/meridian')).toBeLessThan(list.indexOf(native))
+  })
+
+  it('keeps a release build as a fallback after debug but before installed', () => {
+    const debug = list.indexOf('/work/meridian/target/debug/meridian')
+    const release = list.indexOf('/work/meridian/target/release/meridian')
+    expect(debug).toBeLessThan(release)
+    expect(release).toBeLessThan(list.indexOf(native))
+  })
+
+  it('still lists the node wrapper last (launchd-parity ordering preserved)', () => {
+    expect(list[list.length - 1]).toBe(nodeWrapper)
+  })
+
+  it('does not prepend repo builds outside development', () => {
+    expect(meridianCandidates(HOME, 'production', '/work/meridian/ui')[0]).toBe(native)
+  })
+})
+
 describe('selectMeridianBinary', () => {
-  const candidates = meridianCandidates(HOME)
+  const candidates = meridianCandidates(HOME, 'production')
 
   it('prefers the native binary when both native and wrapper are executable', () => {
     // Everything executable (the real dev-machine case that masked the bug).

--- a/ui/lib/meridian-bin.ts
+++ b/ui/lib/meridian-bin.ts
@@ -1,6 +1,7 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 
 import { accessSync, constants } from 'fs'
+import { resolve } from 'path'
 
 /**
  * Candidate paths for the meridian binary, in PREFERENCE order.
@@ -13,12 +14,37 @@ import { accessSync, constants } from 'fs'
  * the wrapper was probed first, the installed dashboard's task sync failed with
  * `env: node: No such file or directory` while dev worked fine — a dev/prod
  * parity gap. Preferring the native binary closes it: same behaviour in both.
+ *
+ * In LOCAL DEVELOPMENT (`NODE_ENV === 'development'`, i.e. `npm run dev`) the
+ * repo build is prepended ahead of the installed paths. dev-start.sh runs the
+ * daemon as `cargo watch -x 'run --bin meridian'` → `target/debug/meridian`,
+ * which is rebuilt on every save and advances `meridian.db` as new migrations
+ * land. The installed binary under ~/.meridian is a SEPARATE artifact that does
+ * NOT track the repo, so the moment a migration is added the daemon migrates the
+ * DB forward while the installed CLI stays behind — and sqlx aborts task-sync
+ * with the opaque "failed to run migrations" (it refuses to open a DB whose
+ * applied migrations the binary doesn't know about). Preferring the repo build
+ * in dev makes the UI shell out to the SAME binary the daemon runs, so they can
+ * never drift. Production is unchanged: `env !== 'development'` → installed-only.
  */
-export function meridianCandidates(home: string = process.env.HOME ?? ''): string[] {
-  return [
+export function meridianCandidates(
+  home: string = process.env.HOME ?? '',
+  env: string | undefined = process.env.NODE_ENV,
+  cwd: string = process.cwd(),
+): string[] {
+  const installed = [
     `${home}/.meridian/app/bin/meridian`, // native, no runtime deps — works under launchd
     '/usr/local/bin/meridian', // native, system-wide install
     `${home}/.local/bin/meridian`, // node wrapper — needs `node` on PATH, so last
+  ]
+  if (env !== 'development') return installed
+
+  // `next dev` runs with cwd = <repo>/ui, so the repo root is one level up.
+  const repoRoot = resolve(cwd, '..')
+  return [
+    `${repoRoot}/target/debug/meridian`, // cargo watch (dev-start.sh) builds here
+    `${repoRoot}/target/release/meridian`, // fallback if only a release build exists
+    ...installed,
   ]
 }
 


### PR DESCRIPTION
## Problem

In local dev, the **Tasks → Sync** button failed with `Sync failed: tasks-sync: open db: failed to run migrations`.

Root cause is a dev-only binary mismatch:
- `dev-start.sh` runs the daemon as `cargo watch -x 'run --bin meridian'` → `target/debug/meridian`. That build is rebuilt on every save and migrates `meridian.db` forward as new migrations land.
- UI route handlers (`/api/tasks/sync`, OAuth, triage) resolved a **separately-installed** binary under `~/.meridian/app/bin/meridian` via `selectMeridianBinary(meridianCandidates())`. That artifact does **not** track the repo.

So the instant a migration was added, the daemon advanced the DB while the installed CLI stayed behind, and sqlx refused to open the ahead-of-it DB — surfacing as the opaque "failed to run migrations".

## Fix

Make `meridianCandidates()` environment-aware:
- **`NODE_ENV === 'development'`** (`npm run dev`): prepend `<repo>/target/debug/meridian` then `target/release/meridian` ahead of the installed paths (`next dev` runs with cwd = `<repo>/ui`, so repo root is one level up). The UI now shells out to the **same** binary the daemon runs — they can't drift.
- **Production** (`NODE_ENV !== 'development'`): unchanged — installed-only, native-first, preserving the launchd PATH-parity guarantee from the original `env: node: No such file or directory` fix.

Also: print the full anyhow source chain (`{e:#}`) on `tasks-sync` open-db failure so the real sqlx cause is visible next time instead of the top-level context (`src/main.rs`).

## Tests

- Added dev-mode coverage in `ui/__tests__/meridian-bin.test.ts`: repo build prepended, debug-before-release, node wrapper still last, production no-op.
- Pinned the existing `selectMeridianBinary` tests to `'production'` for determinism.
- `bun test` → 12 pass / 0 fail; UI build clean; full pre-push suite passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)