### PR TITLE
feat: land notification system + classifier plan-boost onto main

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -260,6 +260,24 @@ prompt_permissions() {
     run open "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
     read -r -p "  Press Enter when Microphone is granted (or skip if screenpipe isn't listed yet)… " _
     ok "Microphone acknowledged"
+
+    # Notifications: the tray surfaces desktop toasts (plan nudges, worklog
+    # drafts, faults). macOS HIDES all notifications while the screen is being
+    # shared/recorded unless this is on — and screenpipe records continuously, so
+    # without it every Meridian toast is silently suppressed. There is no API to
+    # set this toggle and no prompt for it, so we can only walk the user there.
+    echo
+    echo "    Meridian's menu-bar tray shows desktop notifications. Because"
+    echo "    screenpipe records the screen, macOS hides notifications during"
+    echo "    screen sharing unless you explicitly allow them."
+    read -r -p "  Press Enter to open the Notifications pane… " _
+    run open "x-apple.systempreferences:com.apple.Notifications-Settings.extension"
+    echo "    → Scroll to the bottom and turn ON"
+    echo "      'Allow notifications when mirroring or sharing the display'."
+    echo "    → When 'Meridian Tray' appears in the app list, make sure its"
+    echo "      notifications are allowed (style Banners or Alerts, not None)."
+    read -r -p "  Press Enter when done… " _
+    ok "Notifications acknowledged"
 }
 
 # Check if a11y-helper has accessibility permission granted by reading its log

--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -540,6 +540,21 @@ if [[ "${SKIP_PERMISSIONS}" -eq 0 ]]; then
     echo "      ${HOME}/.meridian/bin/meridian-a11y-helper"
     echo "  Without the a11y helper, Electron apps (Claude, Codex, Slack, …) stay invisible to capture."
     read -r -p "  Press Enter once all are granted… " _ || true
+
+    # Notifications: the tray surfaces desktop toasts (plan nudges, worklog
+    # drafts, faults). macOS hides ALL notifications while the screen is being
+    # recorded/shared unless this is on — and screenpipe records continuously, so
+    # without it every Meridian toast is silently suppressed. No API/prompt exists
+    # for this toggle, so we can only walk the user to it.
+    echo "→ Meridian's tray shows desktop notifications. Because screenpipe records"
+    echo "  the screen, macOS hides notifications during screen sharing unless allowed."
+    read -r -p "  Press Enter to open Notifications settings… " _ || true
+    open "x-apple.systempreferences:com.apple.Notifications-Settings.extension" 2>/dev/null || true
+    echo "  → Scroll to the bottom and turn ON"
+    echo "    'Allow notifications when mirroring or sharing the display'."
+    echo "  → When 'Meridian Tray' appears, ensure its notifications are allowed"
+    echo "    (style Banners or Alerts, not None)."
+    read -r -p "  Press Enter when done… " _ || true
 fi
 
 # Enable a11y mode in installed VS Code-family editors (idempotent). Without

--- a/services/agents/_prompts.py
+++ b/services/agents/_prompts.py
@@ -106,8 +106,11 @@ def _format_candidates(tasks: list[dict]) -> str:
             desc = desc[:240] + "…"
         meta_parts = [p for p in [issue_type, f"Epic: {epic_title}" if epic_title else "", sprint_name, f"tags: {tags}" if tags else ""] if p]
         meta = "  [" + " · ".join(meta_parts) + "]" if meta_parts else ""
+        # The dev declared this ticket as today's focus on the plan page. It's a
+        # tie-breaking prior, not a forced answer — only matches if the evidence fits.
+        focus = " ★ TODAY'S FOCUS" if task.get("is_today_focus") else ""
         rows.append(
-            f"{i}. {task['task_key']}{meta}\n"
+            f"{i}. {task['task_key']}{focus}{meta}\n"
             f"   title: {title}\n"
             f"   description: {desc or '(empty)'}"
         )
@@ -152,12 +155,21 @@ def build_user_message(
         f"{_format_recent_sessions(sessions)}\n"
         "\n"
     ) if has_any_task_key else ""
+    # When the dev declared a focus for the day, name it in the header so the model
+    # treats ★ rows as a prior — preferred when the evidence plausibly fits, but
+    # never forced. Recall is preserved: every candidate is still listed.
+    has_focus = any(c.get("is_today_focus") for c in candidates)
+    candidate_header = (
+        "CANDIDATE TICKETS (★ = the dev declared this as a task they're working on "
+        "today; prefer a ★ ticket when the session plausibly matches it, but only "
+        "if the evidence fits — never force a match):\n"
+    ) if has_focus else "CANDIDATE TICKETS:\n"
     return (
         f"{recent_block}"
         "SESSION:\n"
         f"{_format_session(session)}\n"
         "\n"
-        "CANDIDATE TICKETS:\n"
+        f"{candidate_header}"
         f"{_format_candidates(candidates)}"
     )
 

--- a/services/agents/run_task_linker_mlx.py
+++ b/services/agents/run_task_linker_mlx.py
@@ -24,6 +24,7 @@ Method tag in results: "mlx_direct".
 """
 from __future__ import annotations
 
+import datetime as _dt
 import json
 import logging
 import os
@@ -483,7 +484,53 @@ def _fetch_recent_sessions(
     return result
 
 
-def _fetch_pm_tasks(con: _sqlite3.Connection) -> list[dict[str, Any]]:
+def _local_day(started_at: str) -> str:
+    """The local calendar day (YYYY-MM-DD) of a session's UTC `started_at`.
+
+    `daily_plan.plan_date` is the dev's *local* day (the dashboard stamps it from
+    the browser's local date), but `app_sessions.started_at` is stored UTC. We
+    convert UTC → local here so a session is matched to the plan the dev actually
+    declared for that day. Returns "" on an unparseable timestamp (→ no boost).
+    """
+    if not started_at:
+        return ""
+    try:
+        # `astimezone()` with no arg converts an aware datetime to the host's
+        # local zone — the same zone the dashboard used to compute plan_date.
+        return _dt.datetime.fromisoformat(started_at).astimezone().date().isoformat()
+    except ValueError:
+        return ""
+
+
+def _fetch_plan_focus(con: _sqlite3.Connection, plan_date: str) -> list[str]:
+    """Ordered task_keys the dev CONFIRMED as their focus for `plan_date`.
+
+    Empty (→ no boost, classification proceeds exactly as before) when the day is
+    unconfirmed, explicitly skipped, has no plan rows, or the plan tables don't
+    exist yet (pre-migration-041 DB). This is a ranking signal only — never a
+    filter — so an empty result can only ever cost the boost, never recall.
+    """
+    if not plan_date:
+        return []
+    try:
+        meta = con.execute(
+            "SELECT confirmed_at, skipped FROM daily_plan_meta WHERE plan_date = ?",
+            (plan_date,),
+        ).fetchone()
+        if meta is None or meta["skipped"] or not meta["confirmed_at"]:
+            return []
+        rows = con.execute(
+            "SELECT task_key FROM daily_plan WHERE plan_date = ? ORDER BY position",
+            (plan_date,),
+        ).fetchall()
+        return [r["task_key"] for r in rows]
+    except _sqlite3.OperationalError:
+        return []
+
+
+def _fetch_pm_tasks(
+    con: _sqlite3.Connection, focus_keys: list[str] | None = None
+) -> list[dict[str, Any]]:
     # Candidate set for classification. Tickets the user explicitly EXCLUDED during
     # onboarding board-cleanup (pm_task_curation.decision = 'excluded') are dropped
     # so a cleaned-up dead ticket can never be a classification target. Everything
@@ -512,7 +559,20 @@ def _fetch_pm_tasks(con: _sqlite3.Connection) -> list[dict[str, Any]]:
         # Pre-migration-038 DB (no pm_task_curation): degrade to the unfiltered
         # candidate set rather than crashing the whole /classify_sessions call.
         rows = con.execute(base_cols).fetchall()
-    return [dict(r) for r in rows]
+    tasks = [dict(r) for r in rows]
+
+    # Today's-focus boost: tag the tickets the dev declared for the day and float
+    # them to the top of the candidate list, in their declared order. This is a
+    # BOOST, never a filter — every other candidate still follows, so recall is
+    # untouched. A focus key that isn't in `tasks` (e.g. excluded by curation)
+    # simply has no effect; we never resurrect a filtered-out ticket.
+    focus = focus_keys or []
+    if focus:
+        order = {key: i for i, key in enumerate(focus)}
+        for t in tasks:
+            t["is_today_focus"] = t["task_key"] in order
+        tasks.sort(key=lambda t: (0, order[t["task_key"]]) if t.get("is_today_focus") else (1, 0))
+    return tasks
 
 
 # ---------------------------------------------------------------------------
@@ -555,10 +615,13 @@ def _classify_one(
                 session_id, f"session {session_id} not found in DB", 0.0, "mlx_error"
             )
 
-        pm_tasks = _fetch_pm_tasks(con)
-        recent   = _fetch_recent_sessions(con, session_id)
+        plan_date  = _local_day(session_raw.get("started_at") or "")
+        focus_keys = _fetch_plan_focus(con, plan_date)
+        pm_tasks   = _fetch_pm_tasks(con, focus_keys)
+        recent     = _fetch_recent_sessions(con, session_id)
 
         db_span.set_attribute("pm_tasks_count", len(pm_tasks))
+        db_span.set_attribute("today_focus_count", len(focus_keys))
         db_span.set_attribute("recent_sessions_count", len(recent))
 
         session_text = session_raw.get("session_text") or ""
@@ -785,7 +848,8 @@ def _classify_one_logged(
     """Classify one session and append a full record to the run log."""
     # Gather inputs before classification so we can log them even on error.
     session_raw = _fetch_session(con, session_id)
-    pm_tasks = _fetch_pm_tasks(con) if session_raw else []
+    focus_keys = _fetch_plan_focus(con, _local_day(session_raw.get("started_at") or "")) if session_raw else []
+    pm_tasks = _fetch_pm_tasks(con, focus_keys) if session_raw else []
     recent = _fetch_recent_sessions(con, session_id) if session_raw else []
 
     if session_raw:

--- a/src/daily_plan.rs
+++ b/src/daily_plan.rs
@@ -1,0 +1,67 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Morning "plan your day" nudge. Once per local day, when the dev has neither
+// confirmed nor skipped today's plan and there are open tickets to plan against,
+// enqueue a `plan.nudge` notification. Idempotent via the outbox dedup key, so
+// the poll loop can call this every tick without spamming.
+
+use anyhow::Result;
+use chrono::{Local, Timelike};
+use sqlx::{Row, SqlitePool};
+
+use crate::notifications::{self, NewNotification};
+
+// Only nudge during working hours — a first poll at 3am shouldn't ping. The
+// once-per-day dedup means the nudge lands on the first tick after the start hour.
+const NUDGE_FROM_HOUR: u32 = 8;
+const NUDGE_UNTIL_HOUR: u32 = 18;
+
+/// Enqueue today's plan nudge if it's due and not already actioned. Best-effort:
+/// any DB error (e.g. a pre-migration-041 database with no `daily_plan` tables)
+/// is surfaced to the caller, which logs-and-ignores.
+pub async fn maybe_nudge(pool: &SqlitePool) -> Result<()> {
+    let now = Local::now();
+    let hour = now.hour();
+    if !(NUDGE_FROM_HOUR..NUDGE_UNTIL_HOUR).contains(&hour) {
+        return Ok(());
+    }
+    let today = now.format("%Y-%m-%d").to_string();
+
+    // Already confirmed or skipped today? Nothing to nudge.
+    if let Some(row) =
+        sqlx::query("SELECT confirmed_at, skipped FROM daily_plan_meta WHERE plan_date = ?")
+            .bind(&today)
+            .fetch_optional(pool)
+            .await?
+    {
+        let confirmed: Option<String> = row.try_get("confirmed_at").unwrap_or(None);
+        let skipped: i64 = row.try_get("skipped").unwrap_or(0);
+        if confirmed.is_some() || skipped != 0 {
+            return Ok(());
+        }
+    }
+
+    // Nothing on the board to plan against → no nudge.
+    let has_open_tasks: i64 = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM pm_tasks WHERE COALESCE(is_terminal, 0) = 0)",
+    )
+    .fetch_one(pool)
+    .await
+    .unwrap_or(0);
+    if has_open_tasks == 0 {
+        return Ok(());
+    }
+
+    let dedup = format!("plan.nudge:{today}");
+    notifications::enqueue(
+        pool,
+        NewNotification::event(
+            &dedup,
+            "plan.nudge",
+            "Plan your day",
+            "Pick what you're working on today so Meridian can match your work to the right tickets.",
+        )
+        .link("/plan"),
+    )
+    .await
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,13 @@
 
 pub mod coding_agent_session_ingest;
 pub mod config;
+pub mod daily_plan;
 pub mod db;
 pub mod etl;
 pub mod health;
 pub mod intelligence;
 pub mod llm_gate;
 pub mod notices;
+pub mod notifications;
 pub mod observability;
 pub mod pm_worklog;

--- a/src/main.rs
+++ b/src/main.rs
@@ -713,7 +713,7 @@ async fn main() -> Result<()> {
                                 let _ = meridian::notices::raise(
                                     &meridian_linker,
                                     "mlx.down",
-                                    "error",
+                                    "warning",
                                     "MLX classifier is not responding",
                                     &format!("Failed to classify session {session_id} after {count} attempts — classification is paused"),
                                     Some("Start MLX server: cd services && .venv313/bin/meridian-server --backend mlx"),
@@ -811,6 +811,30 @@ async fn main() -> Result<()> {
                 }
                 // Wake the background task linker to drain newly-created sessions.
                 etl_notify.notify_one();
+
+                // Morning plan nudge — idempotent per day, gated to working hours.
+                if let Err(e) = meridian::daily_plan::maybe_nudge(&meridian).await {
+                    tracing::debug!(error = %e, "plan nudge check skipped");
+                }
+
+                // Proactive classifier health probe. Detect a down/wedged MLX
+                // server every tick via a fast /health check (NOT reactively, only
+                // when a classify happens to fail) so the fault surfaces promptly
+                // on the dashboard banner AND — via the notices→outbox bridge — as
+                // a desktop toast + in-app banner. Auto-clears when it recovers.
+                if meridian::intelligence::mlx_ready(&cfg).await {
+                    let _ = meridian::notices::clear(&meridian, "mlx.down").await;
+                } else {
+                    let _ = meridian::notices::raise(
+                        &meridian,
+                        "mlx.down",
+                        "warning",
+                        "Classifier offline",
+                        "The MLX classifier server isn't responding — new sessions are recorded but won't be tagged until it's back.",
+                        Some("Restart it: cd services && .venv313/bin/meridian-server --backend mlx"),
+                    )
+                    .await;
+                }
                 // pm_tasks is refreshed on demand at its read boundaries
                 // (classification in run_task_linking, drafting in the worklog
                 // driver), so no timer-driven refresh is needed here.

--- a/src/migrations/042_notifications.sql
+++ b/src/migrations/042_notifications.sql
@@ -1,0 +1,40 @@
+-- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+
+-- Notification outbox. Distinct from `system_notices` (a stateful fault bus that
+-- is raised/cleared): this is a transactional outbox of DISCRETE notification
+-- events (plan nudge, worklog ready, a fault promoted to an OS toast). The daemon
+-- enqueues a row; consumers drain it and stamp a per-channel delivered/dismissed
+-- timestamp. At-least-once delivery with idempotency on `dedup_key`.
+--
+-- event_key  — type for preference lookup, e.g. 'plan.nudge', 'worklog.ready',
+--              'system.fault'. dedup_key — the once-only key, usually
+--              '<event_key>:<scope>' e.g. 'plan.nudge:2026-06-15'. Re-enqueuing
+--              the same dedup_key is a no-op (the event fires exactly once).
+-- channels   — CSV of delivery channels: 'native' (macOS toast via the tray),
+--              'banner' (in-dashboard banner). Either or both.
+CREATE TABLE notifications (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    dedup_key           TEXT NOT NULL UNIQUE,
+    event_key           TEXT NOT NULL,
+    severity            TEXT NOT NULL DEFAULT 'info'
+                          CHECK (severity IN ('info', 'warning', 'error')),
+    title               TEXT NOT NULL,
+    body                TEXT NOT NULL DEFAULT '',
+    deep_link           TEXT,
+    channels            TEXT NOT NULL DEFAULT 'native',
+    scheduled_for       TEXT,
+    expires_at          TEXT,
+    delivered_native_at TEXT,
+    banner_dismissed_at TEXT,
+    attempts            INTEGER NOT NULL DEFAULT 0,
+    created_at          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+-- Drains the native channel: undelivered, due, unexpired rows whose channel set
+-- includes 'native'. ORDER BY id keeps delivery FIFO.
+CREATE INDEX idx_notifications_native_pending
+    ON notifications (delivered_native_at, scheduled_for);
+
+-- Drains the banner channel: undismissed, unexpired rows.
+CREATE INDEX idx_notifications_banner_active
+    ON notifications (banner_dismissed_at, expires_at);

--- a/src/notices.rs
+++ b/src/notices.rs
@@ -41,6 +41,33 @@ pub async fn raise(
     .execute(pool)
     .await
     .context("raising system notice")?;
+
+    // Promote the fault to an OS-level toast (the dashboard banner already comes
+    // from this table, so the notification is native-only to avoid a double
+    // banner). Deduped on the notice id → one toast per fault, cleared below when
+    // the fault recovers so a later re-occurrence toasts again. Best-effort:
+    // never let notification delivery break the fault-bus write.
+    let dedup = format!("system.fault:{id}");
+    let link = if id.starts_with("pm.") {
+        Some("/tasks?integrations=1")
+    } else {
+        Some("/logs")
+    };
+    let _ = crate::notifications::enqueue(
+        pool,
+        crate::notifications::NewNotification {
+            dedup_key: &dedup,
+            event_key: "system.fault",
+            severity,
+            title,
+            body: detail,
+            deep_link: link,
+            channels: crate::notifications::CHANNEL_NATIVE,
+            scheduled_for: None,
+            expires_at: None,
+        },
+    )
+    .await;
     Ok(())
 }
 
@@ -51,5 +78,8 @@ pub async fn clear(pool: &SqlitePool, id: &str) -> Result<()> {
         .execute(pool)
         .await
         .context("clearing system notice")?;
+    // Retract the paired toast so a future re-occurrence of this fault notifies
+    // again instead of being deduped away.
+    let _ = crate::notifications::retract(pool, &format!("system.fault:{id}")).await;
     Ok(())
 }

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -1,0 +1,119 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Notification outbox — the single emit point for discrete, user-facing
+// notification events (plan nudge, worklog ready, a fault promoted to an OS
+// toast). Mirrors the `notices` fault-bus shape but with different semantics:
+//
+//   notices       — STATEFUL conditions, raised then cleared; shown as a banner
+//                    while active. Use for faults that come and go.
+//   notifications — DISCRETE events delivered once per `dedup_key`, drained by
+//                    the tray (native macOS toast) and/or the dashboard (banner).
+//
+// Features call `enqueue` with a `dedup_key` that encodes the once-only scope
+// (e.g. `plan.nudge:2026-06-15`); re-enqueuing the same key is a no-op, so the
+// event fires exactly once no matter how often the producing loop runs. Delivery
+// state (per channel) and preference/quiet-hours filtering live with the
+// consumers (the UI API routes and the tray relay), keeping this a thin,
+// centralised write surface.
+
+use anyhow::{Context, Result};
+use sqlx::SqlitePool;
+
+/// macOS desktop toast, delivered by the tray relay.
+pub const CHANNEL_NATIVE: &str = "native";
+/// In-dashboard banner, surfaced by the UI.
+pub const CHANNEL_BANNER: &str = "banner";
+/// Both channels — the redundant default for important events.
+pub const CHANNELS_BOTH: &str = "native,banner";
+
+/// A notification to enqueue. Grouped into a struct so producers read clearly and
+/// to stay under clippy's argument limit.
+pub struct NewNotification<'a> {
+    /// Once-only key — usually `<event_key>:<scope>`. Re-enqueuing is a no-op.
+    pub dedup_key: &'a str,
+    /// Event type, used for preference lookup (e.g. `plan.nudge`).
+    pub event_key: &'a str,
+    /// `info` | `warning` | `error`.
+    pub severity: &'a str,
+    pub title: &'a str,
+    pub body: &'a str,
+    /// Optional dashboard route to open on click (e.g. `/plan`).
+    pub deep_link: Option<&'a str>,
+    /// CSV of [`CHANNEL_NATIVE`] / [`CHANNEL_BANNER`].
+    pub channels: &'a str,
+    /// ISO8601 UTC; the notification is withheld until this time (NULL = now).
+    pub scheduled_for: Option<&'a str>,
+    /// ISO8601 UTC; the notification is suppressed after this time (NULL = never).
+    pub expires_at: Option<&'a str>,
+}
+
+impl<'a> NewNotification<'a> {
+    /// A simple info-level event delivered on both channels immediately.
+    pub fn event(dedup_key: &'a str, event_key: &'a str, title: &'a str, body: &'a str) -> Self {
+        Self {
+            dedup_key,
+            event_key,
+            severity: "info",
+            title,
+            body,
+            deep_link: None,
+            channels: CHANNELS_BOTH,
+            scheduled_for: None,
+            expires_at: None,
+        }
+    }
+
+    /// Set the click-through deep link (builder style).
+    pub fn link(mut self, deep_link: &'a str) -> Self {
+        self.deep_link = Some(deep_link);
+        self
+    }
+
+    /// Restrict delivery to specific channels (builder style).
+    pub fn via(mut self, channels: &'a str) -> Self {
+        self.channels = channels;
+        self
+    }
+
+    /// Set the expiry (builder style).
+    pub fn expiring(mut self, expires_at: &'a str) -> Self {
+        self.expires_at = Some(expires_at);
+        self
+    }
+}
+
+/// Enqueue a notification. Idempotent on `dedup_key` — repeated calls are
+/// no-ops, so a producing loop can call this every tick without spamming.
+pub async fn enqueue(pool: &SqlitePool, n: NewNotification<'_>) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO notifications
+            (dedup_key, event_key, severity, title, body, deep_link, channels, scheduled_for, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(dedup_key) DO NOTHING",
+    )
+    .bind(n.dedup_key)
+    .bind(n.event_key)
+    .bind(n.severity)
+    .bind(n.title)
+    .bind(n.body)
+    .bind(n.deep_link)
+    .bind(n.channels)
+    .bind(n.scheduled_for)
+    .bind(n.expires_at)
+    .execute(pool)
+    .await
+    .context("enqueueing notification")?;
+    Ok(())
+}
+
+/// Drop any pending notification with this `dedup_key`. Used when a stateful
+/// condition recovers (e.g. a fault clears), so a later re-occurrence of the same
+/// condition re-enqueues and notifies again instead of being deduped away.
+pub async fn retract(pool: &SqlitePool, dedup_key: &str) -> Result<()> {
+    sqlx::query("DELETE FROM notifications WHERE dedup_key = ?")
+        .bind(dedup_key)
+        .execute(pool)
+        .await
+        .context("retracting notification")?;
+    Ok(())
+}

--- a/src/pm_worklog/scheduler.rs
+++ b/src/pm_worklog/scheduler.rs
@@ -228,17 +228,45 @@ async fn run_pass(pool: &SqlitePool, cfg: &PmWorklogConfig, scope: Scope) {
             .collect(),
     };
     let min_duration_s = config.min_classification_duration_s;
+    let mut drafted_total = 0u32;
     for day in days {
         match run_driver(pool, cfg, min_duration_s, Some(day)).await {
-            Ok(s) => tracing::info!(
-                day = %day,
-                hours_processed = s.hours_processed,
-                drafted = s.worklogs_drafted,
-                not_ready = s.hours_not_ready,
-                scope = if scope == Scope::Backfill { "backfill" } else { "event" },
-                "pm-worklog driver pass complete"
-            ),
+            Ok(s) => {
+                drafted_total += s.worklogs_drafted;
+                tracing::info!(
+                    day = %day,
+                    hours_processed = s.hours_processed,
+                    drafted = s.worklogs_drafted,
+                    not_ready = s.hours_not_ready,
+                    scope = if scope == Scope::Backfill { "backfill" } else { "event" },
+                    "pm-worklog driver pass complete"
+                )
+            }
             Err(e) => tracing::error!(day = %day, error = %e, "pm-worklog driver pass failed"),
+        }
+    }
+
+    // One "drafts ready" notification per local day — deduped by the outbox so a
+    // pass that drafts hour-by-hour through the day only pings once. The tray
+    // tooltip/badge tracks the live count separately.
+    if drafted_total > 0 {
+        let dedup = format!("worklog.ready:{}", Local::now().format("%Y-%m-%d"));
+        if let Err(e) = crate::notifications::enqueue(
+            pool,
+            crate::notifications::NewNotification::event(
+                &dedup,
+                "worklog.ready",
+                "Worklog drafts ready",
+                "Drafts are ready to review and approve.",
+            )
+            .link("/worklogs"),
+        )
+        .await
+        {
+            // Mirror the plan-nudge site: a swallowed enqueue failure means the
+            // tray/banner stays silent while drafts read "ready" in the dashboard,
+            // with nothing to diagnose. Surface it.
+            tracing::warn!(error = %e, "worklog-ready notification enqueue failed");
         }
     }
 }

--- a/tray/src-tauri/src/commands.rs
+++ b/tray/src-tauri/src/commands.rs
@@ -20,7 +20,7 @@ pub fn get_status(state: State<'_, Arc<Mutex<AppState>>>) -> Result<StatusPayloa
 #[tauri::command]
 pub async fn open_dashboard(app: tauri::AppHandle) -> Result<(), String> {
     app.opener()
-        .open_url(&ui_base(), None::<&str>)
+        .open_url(ui_base(), None::<&str>)
         .map_err(|e| e.to_string())
 }
 
@@ -72,7 +72,11 @@ pub async fn toggle_daemon(app: tauri::AppHandle, is_running: bool) -> Result<()
         } else {
             ("Resumed", "Meridian is back tracking.")
         };
-        notify_user(&app, title, body);
+        // Honor the user's notification prefs (master switch + quiet hours) for
+        // this direct toast, same policy as the outbox notifications.
+        if crate::poll::notifications_allowed("system.pause").await {
+            notify_user(&app, title, body);
+        }
         Ok(())
     } else {
         Err(format!(

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -25,6 +25,17 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             app.set_activation_policy(tauri::ActivationPolicy::Accessory);
 
+            // Request OS notification authorization up front. Without this,
+            // `.show()` is a silent no-op on macOS until the app has prompted at
+            // least once — the reason the health/pause toasts never appeared.
+            {
+                use tauri_plugin_notification::{NotificationExt, PermissionState};
+                let notifier = app.notification();
+                if !matches!(notifier.permission_state(), Ok(PermissionState::Granted)) {
+                    let _ = notifier.request_permission();
+                }
+            }
+
             let toggle_item =
                 MenuItemBuilder::with_id("toggle_daemon", "Connected ●").build(app)?;
             let open_item =

--- a/tray/src-tauri/src/poll.rs
+++ b/tray/src-tauri/src/poll.rs
@@ -42,6 +42,13 @@ struct WorklogsResp {
     items: Vec<WorklogItem>,
 }
 
+#[derive(Deserialize)]
+struct PendingNotif {
+    id: i64,
+    title: String,
+    body: String,
+}
+
 pub async fn run_poll_loop(app: tauri::AppHandle, state: Arc<Mutex<AppState>>) {
     let client = Client::builder()
         .timeout(Duration::from_secs(5))
@@ -65,8 +72,13 @@ pub async fn run_poll_loop(app: tauri::AppHandle, state: Arc<Mutex<AppState>>) {
             refresh_today(&client, &state).await;
         }
         if do_worklogs {
-            refresh_worklogs(&app, &client, &state).await;
+            refresh_worklogs(&client, &state).await;
         }
+        // Drain the daemon's notification outbox every tick — this is the single
+        // delivery path for all daemon-originated notifications (plan nudge,
+        // worklog ready, promoted faults). The tray is a dumb delivery agent;
+        // preference + quiet-hours filtering already happened server-side.
+        drain_notifications(&app, &client).await;
 
         {
             let mut s = state.lock().unwrap();
@@ -143,10 +155,42 @@ async fn refresh_health(app: &tauri::AppHandle, client: &Client, state: &Arc<Mut
         (notify_down, notify_back)
     };
 
-    if notify_down {
+    if notify_down && notifications_allowed("system.health").await {
         notify(app, "Meridian went quiet.", "Tap to check what happened.");
-    } else if notify_back {
+    } else if notify_back && notifications_allowed("system.health").await {
         notify(app, "Back online.", "Picking up where you left off.");
+    }
+}
+
+/// Ask the dashboard whether a notification for `event_key` may fire right now,
+/// honoring the user's master switch + quiet hours. The tray's direct health/
+/// pause toasts don't flow through the outbox (the daemon can't enqueue while
+/// it's down), so they consult the same server-side policy here. Defaults to
+/// `true` when the dashboard is unreachable — an operational alert (e.g. "went
+/// quiet") must not be lost just because the preference check itself failed.
+pub(crate) async fn notifications_allowed(event_key: &str) -> bool {
+    #[derive(Deserialize)]
+    struct Allowed {
+        allowed: bool,
+    }
+    let client = match Client::builder().timeout(Duration::from_secs(3)).build() {
+        Ok(c) => c,
+        Err(_) => return true,
+    };
+    let resp = client
+        .get(format!(
+            "{}/api/notifications/allowed?event={}",
+            ui_base(),
+            event_key
+        ))
+        .send()
+        .await
+        .ok();
+    match resp {
+        Some(r) if r.status().is_success() => {
+            r.json::<Allowed>().await.map(|a| a.allowed).unwrap_or(true)
+        }
+        _ => true,
     }
 }
 
@@ -195,7 +239,10 @@ async fn refresh_today(client: &Client, state: &Arc<Mutex<AppState>>) {
     }
 }
 
-async fn refresh_worklogs(app: &tauri::AppHandle, client: &Client, state: &Arc<Mutex<AppState>>) {
+// Tracks the draft count for the tray tooltip/badge only. The "worklog ready"
+// notification itself is emitted by the daemon's worklog scheduler into the
+// notification outbox and delivered via drain_notifications — not fired here.
+async fn refresh_worklogs(client: &Client, state: &Arc<Mutex<AppState>>) {
     let today = chrono::Local::now().format("%Y-%m-%d").to_string();
     let resp = client
         .get(format!("{}/api/worklogs?day={}", ui_base(), today))
@@ -212,29 +259,35 @@ async fn refresh_worklogs(app: &tauri::AppHandle, client: &Client, state: &Arc<M
         },
     };
 
-    let notify_new = {
-        let mut s = state.lock().unwrap();
-        let changed = draft_count > s.last_notified_drafts;
-        if draft_count == 0 {
-            s.last_notified_drafts = 0;
-        }
-        s.drafts_count = draft_count;
-        if changed {
-            s.last_notified_drafts = draft_count;
-        }
-        changed
+    state.lock().unwrap().drafts_count = draft_count;
+}
+
+// Poll the daemon's notification outbox and deliver each pending native
+// notification as a macOS toast, then acknowledge it so it never re-fires.
+async fn drain_notifications(app: &tauri::AppHandle, client: &Client) {
+    let resp = client
+        .get(format!("{}/api/notifications/pending", ui_base()))
+        .send()
+        .await
+        .ok();
+
+    let items: Vec<PendingNotif> = match resp {
+        Some(r) if r.status().is_success() => r.json().await.unwrap_or_default(),
+        _ => return,
     };
 
-    if notify_new {
-        let msg = if draft_count == 1 {
-            "1 worklog drafted. Worth a look.".to_string()
-        } else {
-            format!(
-                "{} drafts ready — took you hours, took me 30 seconds.",
-                draft_count
-            )
-        };
-        notify(app, "Meridian", &msg);
+    for n in items {
+        notify(app, &n.title, &n.body);
+        // Acknowledge so the row is marked delivered and never shown twice. A
+        // failed ack just means it retries next tick — at-least-once delivery.
+        let _ = client
+            .post(format!(
+                "{}/api/notifications/{}/delivered",
+                ui_base(),
+                n.id
+            ))
+            .send()
+            .await;
     }
 }
 
@@ -270,6 +323,11 @@ fn update_tray_icon(app: &tauri::AppHandle, state: &Arc<Mutex<AppState>>) {
 }
 
 fn notify(app: &tauri::AppHandle, title: &str, body: &str) {
+    // v1: the native macOS toast shows title + body only. Producers populate a
+    // `deep_link` (e.g. /plan, /worklogs) and the in-app banner channel renders
+    // it as an "Open →" link, but click-to-navigate on a native toast needs
+    // Tauri notification actions + a focus/navigate handler — deferred. The two
+    // channels are intentionally asymmetric here; the banner carries the link.
     let _ = app.notification().builder().title(title).body(body).show();
 }
 

--- a/tray/src-tauri/src/state.rs
+++ b/tray/src-tauri/src/state.rs
@@ -41,8 +41,6 @@ pub struct AppState {
     pub drafts_count: u32,
     pub ui_reachable: bool,
     pub last_poll: Option<Instant>,
-    /// notification dedup
-    pub last_notified_drafts: u32,
     pub daemon_was_healthy: bool,
     pub consecutive_health_failures: u32,
     pub last_menu_state: HealthStatus,
@@ -59,7 +57,6 @@ impl Default for AppState {
             drafts_count: 0,
             ui_reachable: false,
             last_poll: None,
-            last_notified_drafts: 0,
             daemon_was_healthy: false,
             consecutive_health_failures: 0,
             last_menu_state: HealthStatus::Unknown,

--- a/ui/app/api/notifications/[id]/delivered/route.ts
+++ b/ui/app/api/notifications/[id]/delivered/route.ts
@@ -1,0 +1,25 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// POST /api/notifications/:id/delivered — the tray calls this once it has shown
+// the macOS toast, so the row is never re-delivered. Idempotent.
+
+import { NextResponse } from 'next/server'
+import { getWriteDb } from '@/lib/db-write'
+import { markNativeDelivered } from '@/lib/notifications'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const nid = Number(id)
+  if (!Number.isInteger(nid) || nid <= 0) {
+    return NextResponse.json({ error: 'bad id' }, { status: 400 })
+  }
+  try {
+    markNativeDelivered(getWriteDb(), nid)
+    return NextResponse.json({ ok: true })
+  } catch (e) {
+    console.error('notification delivered error:', e)
+    return NextResponse.json({ error: 'write failed' }, { status: 500 })
+  }
+}

--- a/ui/app/api/notifications/[id]/dismiss/route.ts
+++ b/ui/app/api/notifications/[id]/dismiss/route.ts
@@ -1,0 +1,27 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// POST /api/notifications/:id/dismiss — the dashboard calls this when the user
+// dismisses an in-app notification banner. Idempotent.
+
+import { NextResponse } from 'next/server'
+import { getWriteDb } from '@/lib/db-write'
+import { dismissBanner } from '@/lib/notifications'
+import { refresh } from '@/lib/notifications-banner-store'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const nid = Number(id)
+  if (!Number.isInteger(nid) || nid <= 0) {
+    return NextResponse.json({ error: 'bad id' }, { status: 400 })
+  }
+  try {
+    dismissBanner(getWriteDb(), nid)
+    refresh() // push the updated banner set to open SSE connections immediately
+    return NextResponse.json({ ok: true })
+  } catch (e) {
+    console.error('notification dismiss error:', e)
+    return NextResponse.json({ error: 'write failed' }, { status: 500 })
+  }
+}

--- a/ui/app/api/notifications/allowed/route.ts
+++ b/ui/app/api/notifications/allowed/route.ts
@@ -1,0 +1,21 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// GET /api/notifications/allowed?event=<event_key> — whether a notification for
+// this event may fire RIGHT NOW under the user's preferences (master switch +
+// per-type toggle + quiet hours). The tray calls this before firing its direct
+// health/pause toasts, which don't flow through the outbox (the daemon can't
+// enqueue "I'm down" while it's down). Keeps the policy in one place server-side.
+
+import { NextResponse } from 'next/server'
+import { readSettings } from '@/lib/settings'
+import { eventAllowed, inQuietHours } from '@/lib/notifications'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: Request) {
+  const event = new URL(req.url).searchParams.get('event') ?? ''
+  const s = readSettings()
+  // Quiet hours gate toasts (the only channel for these direct events).
+  const allowed = eventAllowed(event, s) && !inQuietHours(s)
+  return NextResponse.json({ allowed })
+}

--- a/ui/app/api/notifications/pending/route.ts
+++ b/ui/app/api/notifications/pending/route.ts
@@ -1,0 +1,25 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// GET /api/notifications/pending — native-channel notifications ready to fire.
+// The tray relay polls this, delivers each as a macOS toast, then POSTs to
+// /api/notifications/:id/delivered. Preference + quiet-hours filtering happens
+// server-side (in lib/notifications) so the tray stays a dumb delivery agent.
+
+import { NextResponse } from 'next/server'
+import getDb from '@/lib/db'
+import { pendingNative } from '@/lib/notifications'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  try {
+    const rows = pendingNative(getDb())
+    return NextResponse.json(
+      rows.map(r => ({ id: r.id, title: r.title, body: r.body, deep_link: r.deep_link, severity: r.severity })),
+    )
+  } catch {
+    // Pre-migration-042 DB (no notifications table) or transient read error —
+    // return an empty queue rather than erroring the tray's poll loop.
+    return NextResponse.json([])
+  }
+}

--- a/ui/app/api/notifications/stream/route.ts
+++ b/ui/app/api/notifications/stream/route.ts
@@ -1,0 +1,25 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// SSE endpoint for the in-app notification banner channel. Mirrors
+// /api/notices/stream: the browser opens one EventSource; this registers a
+// controller with the shared banner store and streams the active banner set.
+
+import { subscribe, unsubscribe } from '@/lib/notifications-banner-store'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  let ctrl: ReadableStreamDefaultController<Uint8Array>
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) { ctrl = controller; subscribe(ctrl) },
+    cancel() { unsubscribe(ctrl) },
+  })
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  })
+}

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -7,6 +7,7 @@ import { Instrument_Serif } from 'next/font/google'
 import './globals.css'
 import { ThemeProvider } from '@/lib/theme-context'
 import NoticeBar from '@/components/NoticeBar'
+import NotificationBanner from '@/components/NotificationBanner'
 
 const instrumentSerif = Instrument_Serif({
   weight: '400',
@@ -27,6 +28,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="min-h-screen font-sans">
         <ThemeProvider>
           <NoticeBar />
+          <NotificationBanner />
           {children}
         </ThemeProvider>
       </body>

--- a/ui/components/NotificationBanner.tsx
+++ b/ui/components/NotificationBanner.tsx
@@ -1,0 +1,85 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// In-app notification banner — the banner-channel half of the notification
+// outbox (the redundant counterpart to the tray's macOS toast). Opens one SSE
+// connection to /api/notifications/stream and renders a dismissible banner per
+// active notification. Distinct from NoticeBar (stateful faults, auto-clear):
+// these are discrete events the user dismisses, or that expire on their own.
+
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import type { BannerNotification } from '@/lib/notifications-banner-store'
+
+const SEVERITY_STYLES: Record<string, { bg: string; border: string; text: string; dot: string }> = {
+  info:    { bg: '#eff6ff', border: '#bfdbfe', text: '#1d4ed8', dot: '#2563eb' },
+  warning: { bg: '#fffbeb', border: '#fcd34d', text: '#92400e', dot: '#d97706' },
+  error:   { bg: '#fff5f5', border: '#feb2b2', text: '#c53030', dot: '#e53e3e' },
+}
+
+export default function NotificationBanner() {
+  const [items, setItems] = useState<BannerNotification[]>([])
+  const esRef = useRef<EventSource | null>(null)
+  const retryRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    function connect() {
+      if (cancelled) return
+      const es = new EventSource('/api/notifications/stream')
+      esRef.current = es
+      es.onmessage = (e) => {
+        try { setItems(JSON.parse(e.data) as BannerNotification[]) } catch { /* ignore */ }
+      }
+      es.onerror = () => {
+        es.close(); esRef.current = null
+        // Reconnect after a backoff, but record the timer so unmount can cancel
+        // it — otherwise it fires connect() after cleanup, leaking an
+        // unclosed EventSource and calling setItems on an unmounted component.
+        retryRef.current = setTimeout(connect, 5_000)
+      }
+    }
+    connect()
+    return () => {
+      cancelled = true
+      if (retryRef.current) { clearTimeout(retryRef.current); retryRef.current = null }
+      esRef.current?.close()
+    }
+  }, [])
+
+  async function dismiss(id: number) {
+    // Optimistic remove; the SSE refresh will reconcile.
+    setItems(prev => prev.filter(i => i.id !== id))
+    try { await fetch(`/api/notifications/${id}/dismiss`, { method: 'POST' }) } catch { /* ignore */ }
+  }
+
+  if (items.length === 0) return null
+
+  return (
+    <div style={{ position: 'sticky', top: 0, zIndex: 49 }}>
+      {items.map((n) => {
+        const s = SEVERITY_STYLES[n.severity] ?? SEVERITY_STYLES.info
+        return (
+          <div key={n.id}
+            style={{ background: s.bg, borderBottom: `1px solid ${s.border}`, padding: '10px 16px', display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+            <span style={{ display: 'inline-block', width: 7, height: 7, borderRadius: '50%', background: s.dot, flexShrink: 0, marginTop: 5 }} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <span style={{ fontSize: 13, fontWeight: 600, color: s.text }}>{n.title}</span>
+              {n.body && <span style={{ fontSize: 12, color: s.text, marginLeft: 8, opacity: 0.85 }}>{n.body}</span>}
+            </div>
+            {n.deep_link && (
+              <a href={n.deep_link}
+                style={{ flexShrink: 0, fontSize: 11, fontWeight: 600, color: s.text, background: 'rgba(0,0,0,0.07)', border: `1px solid ${s.border}`, borderRadius: 5, padding: '3px 8px', textDecoration: 'none', whiteSpace: 'nowrap', alignSelf: 'center' }}>
+                Open →
+              </a>
+            )}
+            <button onClick={() => dismiss(n.id)} aria-label="Dismiss"
+              style={{ flexShrink: 0, fontSize: 15, lineHeight: 1, color: s.text, background: 'transparent', border: 'none', cursor: 'pointer', opacity: 0.6, alignSelf: 'center', padding: '0 2px' }}>
+              ×
+            </button>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/ui/components/ui/TextInput.tsx
+++ b/ui/components/ui/TextInput.tsx
@@ -5,7 +5,7 @@ interface TextInputProps {
   value: string
   onChange: (v: string) => void
   placeholder?: string
-  type?: 'text' | 'password' | 'email'
+  type?: 'text' | 'password' | 'email' | 'time'
   width?: number | string
 }
 

--- a/ui/components/views/SettingsView.tsx
+++ b/ui/components/views/SettingsView.tsx
@@ -103,6 +103,7 @@ export default function SettingsView() {
   const [classificationStatus, setClassificationStatus] = useState<SaveStatus>('idle')
   const [llmStatus, setLlmStatus] = useState<SaveStatus>('idle')
   const [jiraStatus, setJiraStatus] = useState<SaveStatus>('idle')
+  const [notifStatus, setNotifStatus] = useState<SaveStatus>('idle')
 
   useEffect(() => {
     fetch('/api/settings')
@@ -426,6 +427,49 @@ export default function SettingsView() {
           <Switch checked={settings.jira_update_enabled} onCheckedChange={v => patch({ jira_update_enabled: v })} />
         </FieldRow>
         <SaveButton status={jiraStatus} onClick={() => save({ jira_update_enabled: settings.jira_update_enabled }, setJiraStatus)} />
+      </SectionCard>
+
+      {/* Notifications */}
+      <SectionCard>
+        <SectionHeader>Notifications</SectionHeader>
+        <FieldRow label="Notifications" description="Master switch for desktop toasts and in-app banners. Off silences everything below.">
+          <Switch checked={settings.notifications_enabled} onCheckedChange={v => patch({ notifications_enabled: v })} />
+        </FieldRow>
+        {settings.notifications_enabled && (
+          <>
+            <FieldRow label="Plan your day" description="Morning reminder to confirm today's working set on the Plan page.">
+              <Switch checked={settings.notify_plan_nudge} onCheckedChange={v => patch({ notify_plan_nudge: v })} />
+            </FieldRow>
+            <FieldRow label="Worklog drafts ready" description="When the daily worklog drafts are ready to review and approve.">
+              <Switch checked={settings.notify_worklog_ready} onCheckedChange={v => patch({ notify_worklog_ready: v })} />
+            </FieldRow>
+            <FieldRow label="System faults" description="When a tracker sync or the classifier stack fails (also shown as a banner).">
+              <Switch checked={settings.notify_system_fault} onCheckedChange={v => patch({ notify_system_fault: v })} />
+            </FieldRow>
+            <FieldRow label="Quiet hours" description="Hold back desktop toasts during this window (banners still appear). Wraps past midnight.">
+              <Switch checked={settings.quiet_hours_enabled} onCheckedChange={v => patch({ quiet_hours_enabled: v })} />
+            </FieldRow>
+            {settings.quiet_hours_enabled && (
+              <FieldRow label="Window" description="From → to, local time.">
+                <TextInput type="time" width={110} value={settings.quiet_hours_start} onChange={v => patch({ quiet_hours_start: v })} />
+                <span style={{ fontSize: '11px', color: 'var(--ink-3)' }}>→</span>
+                <TextInput type="time" width={110} value={settings.quiet_hours_end} onChange={v => patch({ quiet_hours_end: v })} />
+              </FieldRow>
+            )}
+          </>
+        )}
+        <SaveButton
+          status={notifStatus}
+          onClick={() => save({
+            notifications_enabled: settings.notifications_enabled,
+            notify_plan_nudge: settings.notify_plan_nudge,
+            notify_worklog_ready: settings.notify_worklog_ready,
+            notify_system_fault: settings.notify_system_fault,
+            quiet_hours_enabled: settings.quiet_hours_enabled,
+            quiet_hours_start: settings.quiet_hours_start,
+            quiet_hours_end: settings.quiet_hours_end,
+          }, setNotifStatus)}
+        />
       </SectionCard>
     </div>
   )

--- a/ui/lib/notifications-banner-store.ts
+++ b/ui/lib/notifications-banner-store.ts
@@ -1,0 +1,85 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// SSE broadcast singleton for the in-app notification banner channel — the
+// banner-side mirror of notices-store. One shared 30s poll of the notifications
+// table, one Set of open controllers, regardless of how many tabs are open.
+// State lives on globalThis to survive Next.js HMR re-evaluation.
+
+import getDb from '@/lib/db'
+import { activeBanners } from '@/lib/notifications'
+
+export interface BannerNotification {
+  id: number
+  event_key: string
+  severity: 'info' | 'warning' | 'error'
+  title: string
+  body: string
+  deep_link: string | null
+  created_at: string
+}
+
+type Controller = ReadableStreamDefaultController<Uint8Array>
+
+const g = globalThis as typeof globalThis & {
+  _meridianNotifControllers?: Set<Controller>
+  _meridianNotifInterval?: ReturnType<typeof setInterval>
+  _meridianNotifSnapshot?: string
+}
+if (!g._meridianNotifControllers) g._meridianNotifControllers = new Set()
+
+const encoder = new TextEncoder()
+
+function controllers(): Set<Controller> { return g._meridianNotifControllers! }
+
+function query(): BannerNotification[] {
+  try {
+    return activeBanners(getDb()).map(r => ({
+      id: r.id, event_key: r.event_key, severity: r.severity,
+      title: r.title, body: r.body, deep_link: r.deep_link, created_at: r.created_at,
+    }))
+  } catch {
+    return []
+  }
+}
+
+function broadcast() {
+  const ctrls = controllers()
+  if (ctrls.size === 0) return
+  const snapshot = JSON.stringify(query())
+  if (snapshot === g._meridianNotifSnapshot) return
+  g._meridianNotifSnapshot = snapshot
+  const payload = encoder.encode(`data: ${snapshot}\n\n`)
+  for (const ctrl of ctrls) {
+    try { ctrl.enqueue(payload) } catch { ctrls.delete(ctrl) }
+  }
+}
+
+function ensureInterval() {
+  if (g._meridianNotifInterval != null) return
+  g._meridianNotifInterval = setInterval(broadcast, 30_000)
+}
+
+export function subscribe(ctrl: Controller): void {
+  controllers().add(ctrl)
+  ensureInterval()
+  const snapshot = JSON.stringify(query())
+  g._meridianNotifSnapshot = snapshot
+  ctrl.enqueue(encoder.encode(`data: ${snapshot}\n\n`))
+}
+
+export function unsubscribe(ctrl: Controller): void {
+  controllers().delete(ctrl)
+  // Stop the shared poll once nobody is listening — otherwise the 30s interval
+  // lives on globalThis forever (broadcast() early-returns, so it's a no-op
+  // timer, but a needless one). subscribe() re-arms it via ensureInterval().
+  if (controllers().size === 0 && g._meridianNotifInterval != null) {
+    clearInterval(g._meridianNotifInterval)
+    g._meridianNotifInterval = undefined
+  }
+}
+
+/** Force an immediate re-read + broadcast — call after a dismiss write. */
+export function refresh(): void {
+  g._meridianNotifSnapshot = '' // invalidate so broadcast always pushes
+  broadcast()
+}

--- a/ui/lib/notifications.ts
+++ b/ui/lib/notifications.ts
@@ -1,0 +1,134 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Server-side helpers for the notification outbox (table `notifications`, written
+// by the Rust daemon via src/notifications.rs). This is the single delivery layer:
+// preference + quiet-hours filtering lives here, so producers always enqueue and
+// only the user's settings decide whether an event surfaces.
+
+import type Database from 'better-sqlite3'
+import { readSettings, type RuntimeSettings } from '@/lib/settings'
+
+export interface NotificationRow {
+  id: number
+  dedup_key: string
+  event_key: string
+  severity: 'info' | 'warning' | 'error'
+  title: string
+  body: string
+  deep_link: string | null
+  channels: string
+  scheduled_for: string | null
+  expires_at: string | null
+  delivered_native_at: string | null
+  banner_dismissed_at: string | null
+  attempts: number
+  created_at: string
+}
+
+// Map an event_key to its per-type preference. Unknown event keys default to
+// enabled (a new producer is visible until the user opts out), gated only by the
+// master switch.
+function typeEnabled(eventKey: string, s: RuntimeSettings): boolean {
+  switch (eventKey) {
+    case 'plan.nudge':    return s.notify_plan_nudge
+    case 'worklog.ready': return s.notify_worklog_ready
+    case 'system.fault':  return s.notify_system_fault
+    default:              return true
+  }
+}
+
+/** Whether `event_key` may surface at all, per the master switch + per-type toggle. */
+export function eventAllowed(eventKey: string, s: RuntimeSettings = readSettings()): boolean {
+  return s.notifications_enabled && typeEnabled(eventKey, s)
+}
+
+/** Minutes since local midnight for an 'HH:MM' string, or null if malformed. */
+function hhmmToMinutes(hhmm: string): number | null {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(hhmm.trim())
+  if (!m) return null
+  const h = Number(m[1]); const min = Number(m[2])
+  if (h > 23 || min > 59) return null
+  return h * 60 + min
+}
+
+/**
+ * True if `now` (local) falls inside the configured quiet-hours window. Handles
+ * windows that wrap past midnight (e.g. 22:00→08:00). Returns false when quiet
+ * hours are disabled or the bounds are malformed (fail open — better to notify
+ * than to silently swallow).
+ */
+export function inQuietHours(s: RuntimeSettings = readSettings(), now: Date = new Date()): boolean {
+  if (!s.quiet_hours_enabled) return false
+  const start = hhmmToMinutes(s.quiet_hours_start)
+  const end = hhmmToMinutes(s.quiet_hours_end)
+  if (start === null || end === null || start === end) return false
+  const cur = now.getHours() * 60 + now.getMinutes()
+  return start < end
+    ? cur >= start && cur < end          // same-day window
+    : cur >= start || cur < end          // wraps past midnight
+}
+
+const SELECT_COLS =
+  'id, dedup_key, event_key, severity, title, body, deep_link, channels, ' +
+  'scheduled_for, expires_at, delivered_native_at, banner_dismissed_at, attempts, created_at'
+
+const NOW_ISO = () => new Date().toISOString().replace(/\.\d+Z$/, 'Z')
+
+/** Does a CSV channel set include `channel`? */
+function hasChannel(channels: string, channel: string): boolean {
+  return channels.split(',').map(c => c.trim()).includes(channel)
+}
+
+/**
+ * Native-channel rows ready to fire: undelivered, due (scheduled_for past),
+ * unexpired, channel includes 'native', and allowed by prefs + quiet hours.
+ * FIFO by id. The tray polls this.
+ */
+export function pendingNative(db: Database.Database): NotificationRow[] {
+  const now = NOW_ISO()
+  const rows = db.prepare(
+    `SELECT ${SELECT_COLS} FROM notifications
+      WHERE delivered_native_at IS NULL
+        AND (scheduled_for IS NULL OR scheduled_for <= ?)
+        AND (expires_at IS NULL OR expires_at > ?)
+      ORDER BY id ASC`,
+  ).all(now, now) as NotificationRow[]
+  const settings = readSettings()
+  const quiet = inQuietHours(settings)
+  return rows.filter(r =>
+    hasChannel(r.channels, 'native') &&
+    eventAllowed(r.event_key, settings) &&
+    !quiet,
+  )
+}
+
+/**
+ * Banner-channel rows to display: undismissed, unexpired, channel includes
+ * 'banner', allowed by prefs (quiet hours do NOT gate banners — they're passive,
+ * not interruptive). Newest first.
+ */
+export function activeBanners(db: Database.Database): NotificationRow[] {
+  const now = NOW_ISO()
+  const rows = db.prepare(
+    `SELECT ${SELECT_COLS} FROM notifications
+      WHERE banner_dismissed_at IS NULL
+        AND (expires_at IS NULL OR expires_at > ?)
+      ORDER BY id DESC`,
+  ).all(now) as NotificationRow[]
+  const settings = readSettings()
+  return rows.filter(r => hasChannel(r.channels, 'banner') && eventAllowed(r.event_key, settings))
+}
+
+/** Mark a row delivered on the native channel (idempotent). */
+export function markNativeDelivered(db: Database.Database, id: number): void {
+  db.prepare(
+    'UPDATE notifications SET delivered_native_at = ?, attempts = attempts + 1 WHERE id = ? AND delivered_native_at IS NULL',
+  ).run(NOW_ISO(), id)
+}
+
+/** Mark a row's banner dismissed (idempotent). */
+export function dismissBanner(db: Database.Database, id: number): void {
+  db.prepare(
+    'UPDATE notifications SET banner_dismissed_at = ? WHERE id = ? AND banner_dismissed_at IS NULL',
+  ).run(NOW_ISO(), id)
+}

--- a/ui/lib/settings.ts
+++ b/ui/lib/settings.ts
@@ -23,6 +23,17 @@ export interface RuntimeSettings {
   llm_budget_pct: number
   // Jira updater
   jira_update_enabled: boolean
+  // Notifications — master switch + per-event-type toggles + quiet hours.
+  // Filtering happens once at the delivery layer (the notification API routes),
+  // never in the producers, so every event flows into the outbox and only the
+  // user's preferences decide whether it surfaces.
+  notifications_enabled: boolean
+  notify_plan_nudge: boolean
+  notify_worklog_ready: boolean
+  notify_system_fault: boolean
+  quiet_hours_enabled: boolean
+  quiet_hours_start: string // 'HH:MM' local time, inclusive
+  quiet_hours_end: string   // 'HH:MM' local time, exclusive
 }
 
 export const SETTINGS_DEFAULTS: RuntimeSettings = {
@@ -41,6 +52,13 @@ export const SETTINGS_DEFAULTS: RuntimeSettings = {
   llm_prefer_local: true,
   llm_budget_pct: 0.5,
   jira_update_enabled: true,
+  notifications_enabled: true,
+  notify_plan_nudge: true,
+  notify_worklog_ready: true,
+  notify_system_fault: true,
+  quiet_hours_enabled: false,
+  quiet_hours_start: '22:00',
+  quiet_hours_end: '08:00',
 }
 
 // repoRoot finds the source-checkout root (nearest ancestor with Cargo.toml).


### PR DESCRIPTION
## Why
**#289 and #290 never reached `main`.** They were merged into their stacked base `feat/daily-plan-today-tasks`, but #288 reached `main` as a **squash** — so the notification system and classifier plan-boost are missing from `main` (verified: `src/notifications.rs`, migration 042, `_local_day` all absent on main).

A naive merge of that branch into `main` would **regress #291** (the launchd meridian-bin fix) and **downgrade the 1.53.0 release** version bumps. This branch instead re-applies just the feature delta on top of current `main`:
- keeps main's `meridian-bin.ts`/`.test.ts` and the `{e:#}` source-chain fix from #291
- keeps the 1.53.0 version bumps / CHANGELOG / README
- `src/main.rs` carries **both** #291's fix and the new probe/nudge

## Contents
- **Classifier (#289):** boost today's confirmed `daily_plan` as Tier-1 candidates — `_local_day` (UTC→local), `_fetch_plan_focus`, `★ TODAY'S FOCUS` prompt. Boost-never-filter (recall preserved).
- **Notifications (#290):** outbox (migration 042 + `src/notifications.rs`) → native toast (tray relay) + in-app banner; `plan.nudge` / `worklog.ready` / `system.fault` producers; **proactive MLX `/health` probe** that surfaces a down classifier on the banner + toast; per-type prefs + quiet hours; installer guidance for the screen-sharing notification setting.

## Verification
27 files, feature-only delta (no version/release/meridian-bin churn). Daemon `clippy`, tray `clippy -D warnings`, and UI `build` all green on `main`.
EOF
)