### PR TITLE
docs(contributing): add no-Claude-co-author commit rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,7 @@ Read **[TESTING.md](TESTING.md)** first. The integration tests in `tests/integra
 - **Conventional Commits:** `type(scope): summary` — e.g. `fix(etl): detect sleep gaps that span ETL run boundaries`.
   - Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`.
 - **Never push to `main` directly.** Open a PR from your branch.
+- **Do not mention Claude as co-author in commit messages.**
 
 Releases are automated by release-please from the commit history, so accurate types matter.
 


### PR DESCRIPTION
## What

Adds an explicit rule to CONTRIBUTING.md's commit conventions: **do not mention Claude as co-author in commit messages.**

## Why

Project policy — we don't want AI co-author attribution (`Co-Authored-By: Claude …` trailers) in the git history. The rule was already being followed; this documents it and fixes the broken markdown (the bullet had an unclosed `**` bleeding bold into the rest of the section).

## Test

Docs-only change. Rendered the bullet locally to confirm the bold now closes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)