### PR TITLE
fix(plan): retain completed planned tasks + surface overdue tickets in clean-up

### DIFF
--- a/src/intelligence/task_triage/mod.rs
+++ b/src/intelligence/task_triage/mod.rs
@@ -76,12 +76,16 @@ impl TriageBucket {
 pub enum TriageReason {
     // — positive / active —
     InProgress,
-    DueSoon { in_days: i64 },
+    DueSoon {
+        in_days: i64,
+    },
     InSprint,
     StartDateReached,
     // — quality —
     MissingDescription,
-    ThinDescription { chars: usize },
+    ThinDescription {
+        chars: usize,
+    },
     VagueTitle,
     NoContextAnchor,
     MissingDueDate,
@@ -91,11 +95,24 @@ pub enum TriageReason {
     MissingEstimate,
     MissingAcceptanceCriteria,
     // — staleness —
-    NoActivitySince { days: i64 },
+    NoActivitySince {
+        days: i64,
+    },
     NotStarted,
     NoDueDate,
-    OverdueLong { by_days: i64 },
-    FarFutureDue { in_days: i64 },
+    /// Past its due date but still otherwise live (started / recently touched /
+    /// within the overdue grace) — surfaced as a tidy item so the dev can reschedule
+    /// or close it. Distinct from `OverdueLong`, which is the abandoned-signature
+    /// case that demotes a ticket to `LooksStale`.
+    Overdue {
+        by_days: i64,
+    },
+    OverdueLong {
+        by_days: i64,
+    },
+    FarFutureDue {
+        in_days: i64,
+    },
     NotInSprint,
     AlreadyDone,
     // — ambiguity / meta —
@@ -135,6 +152,9 @@ impl TriageReason {
             }
             TriageReason::NotStarted => "Still sitting in a not-started column.".into(),
             TriageReason::NoDueDate => "No due date set.".into(),
+            TriageReason::Overdue { by_days } => {
+                format!("Overdue by {by_days} day(s) — reschedule or close it.")
+            }
             TriageReason::OverdueLong { by_days } => {
                 format!("Overdue by {by_days} days with no movement.")
             }
@@ -173,6 +193,7 @@ impl TriageReason {
                 f(PickParent, "parent", "Link to an epic or parent", false)
             }
             TriageReason::MissingDueDate => f(DatePicker, "duedate", "Add a due date", false),
+            TriageReason::Overdue { .. } => f(DatePicker, "duedate", "Reschedule due date", false),
             TriageReason::MissingAssignee => f(AssignSelf, "assignee", "Assign to me", false),
             TriageReason::MissingLabels => f(EditLabels, "labels", "Add a label", false),
             TriageReason::MissingPriority => f(PickPriority, "priority", "Set priority", false),
@@ -368,6 +389,13 @@ pub fn triage_ticket(t: &TicketSignals, cfg: &TriageConfig) -> TriageVerdict {
     let far_future = due_in.is_some_and(|d| d > cfg.due_soon_days);
     let has_live_date = due_soon || start_reached;
     let active = started == Startedness::Started || in_sprint || has_live_date;
+    // Past its due date but not caught by the abandoned-signature `OverdueLong`
+    // path below (that one demotes to LooksStale). Carried through every non-stale
+    // verdict so an overdue-but-live ticket surfaces on the cleanup page (it has a
+    // reschedule fix) without changing which bucket it lands in.
+    let overdue = due_in
+        .filter(|&d| d < 0)
+        .map(|d| TriageReason::Overdue { by_days: -d });
 
     // 2. Stale signature. The base requirement (not started, no live date window,
     //    not in an active sprint) demotes only when paired with either evidence of
@@ -403,8 +431,9 @@ pub fn triage_ticket(t: &TicketSignals, cfg: &TriageConfig) -> TriageVerdict {
     //    Each "missing field" check is gated on the board actually using that field
     //    (cfg.usage.*), so a team that doesn't track e.g. story points is never
     //    nagged about them. Every reason here maps to an in-app fix (TriageReason::fix).
-    let reasons = hygiene_issues(t, cfg);
+    let mut reasons = hygiene_issues(t, cfg);
     if !reasons.is_empty() {
+        reasons.extend(overdue);
         return verdict(TriageBucket::NeedsDetail, reasons);
     }
 
@@ -414,7 +443,9 @@ pub fn triage_ticket(t: &TicketSignals, cfg: &TriageConfig) -> TriageVerdict {
         if started == Startedness::Started {
             reasons.push(TriageReason::InProgress);
         }
-        if due_soon {
+        // Only call it "due soon" when it's actually still ahead — a past-due date
+        // is reported by the `Overdue` reason appended below.
+        if due_soon && due_in.is_some_and(|d| d >= 0) {
             reasons.push(TriageReason::DueSoon {
                 in_days: due_in.unwrap(),
             });
@@ -425,12 +456,14 @@ pub fn triage_ticket(t: &TicketSignals, cfg: &TriageConfig) -> TriageVerdict {
         if start_reached && !due_soon {
             reasons.push(TriageReason::StartDateReached);
         }
+        reasons.extend(overdue);
         verdict(TriageBucket::Ready, reasons)
     } else {
         let mut reasons = vec![TriageReason::NoActivitySignal];
         if age.is_none() {
             reasons.push(TriageReason::UnreadableUpdatedAt);
         }
+        reasons.extend(overdue);
         verdict(TriageBucket::NotSure, reasons)
     }
 }
@@ -655,6 +688,41 @@ mod tests {
         t.description_text = "fix it".into();
         let v = triage_ticket(&t, &TriageConfig::new(now(), BoardUsage::default()));
         assert_eq!(v.bucket, TriageBucket::NeedsDetail);
+    }
+
+    #[test]
+    fn overdue_but_active_stays_ready_but_flags_overdue_with_a_fix() {
+        // In progress + detailed + due 3 days ago: still Ready (we don't demote a
+        // live ticket), but it must carry an Overdue reason so the cleanup page
+        // surfaces it, and that reason must have a fix (reschedule the due date).
+        let mut t = base();
+        t.status_raw = "In Progress".into();
+        t.due_date = Some("2026-06-09".into()); // now = 2026-06-12 ⇒ overdue by 3
+        let v = triage_ticket(&t, &TriageConfig::new(now(), BoardUsage::default()));
+        assert_eq!(v.bucket, TriageBucket::Ready);
+        assert!(v.reasons.contains(&TriageReason::Overdue { by_days: 3 }));
+        // not the misleading "Due today" DueSoon for a past-due date
+        assert!(!v
+            .reasons
+            .iter()
+            .any(|r| matches!(r, TriageReason::DueSoon { .. })));
+        assert!(TriageReason::Overdue { by_days: 3 }.fix().is_some());
+    }
+
+    #[test]
+    fn not_yet_due_is_due_soon_not_overdue() {
+        let mut t = base();
+        t.status_raw = "In Progress".into();
+        t.due_date = Some("2026-06-14".into()); // due in 2 days
+        let v = triage_ticket(&t, &TriageConfig::new(now(), BoardUsage::default()));
+        assert!(v
+            .reasons
+            .iter()
+            .any(|r| matches!(r, TriageReason::DueSoon { .. })));
+        assert!(!v
+            .reasons
+            .iter()
+            .any(|r| matches!(r, TriageReason::Overdue { .. })));
     }
 
     #[test]

--- a/src/migrations/044_daily_plan_snapshot.sql
+++ b/src/migrations/044_daily_plan_snapshot.sql
@@ -1,0 +1,17 @@
+-- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+--
+-- Daily-plan task snapshot. `daily_plan` references board tickets by key, joined
+-- against `pm_tasks` at read time for their live title/status/etc. But `pm_tasks`
+-- is the *active* board: when a planned ticket goes Done it is pruned from the
+-- provider sync, so the join finds nothing and the /plan card collapses to a bare
+-- key. We don't want completed tickets back on the active board (they'd pollute
+-- the Tasks page, triage/cleanup, and the classifier candidate set), so instead we
+-- keep a small denormalised snapshot of the ticket ON the plan row.
+--
+-- `task_snapshot` holds a JSON blob captured from `pm_tasks` whenever the dev adds
+-- or confirms the task (while it is still on the board). When the live `pm_tasks`
+-- row later disappears, the /plan reader falls back to this snapshot so a
+-- planned-then-completed ticket stays visible in that day's plan with its real
+-- title / description / epic. NULL until the first write that has board data.
+
+ALTER TABLE daily_plan ADD COLUMN task_snapshot TEXT;

--- a/ui/app/api/plan/route.ts
+++ b/ui/app/api/plan/route.ts
@@ -90,6 +90,22 @@ export async function POST(req: Request) {
     const originMap = new Map(available.map(a => [a.key, a.origin]))
     const originFor = (key: string): string => originMap.get(key) ?? 'manual'
 
+    // Snapshot the ticket's live board fields onto the plan row at write time, so
+    // a planned-then-completed task (pruned from pm_tasks once Done) still renders
+    // its real title/description/epic on the /plan page instead of a bare key.
+    // Returns null when the task isn't on the board (don't clobber an earlier
+    // snapshot — see the COALESCE in the UPSERTs below).
+    const snapStmt = db.prepare(`
+      SELECT title, provider, url, COALESCE(status_raw,'') AS status_raw,
+             COALESCE(is_terminal,0) AS is_terminal, due_date,
+             description_text, epic_title, parent_key, priority, issue_type, story_points
+      FROM pm_tasks WHERE task_key = ?
+    `)
+    const snapshotFor = (key: string): string | null => {
+      const row = snapStmt.get(key)
+      return row ? JSON.stringify(row) : null
+    }
+
     const upsertMeta = (confirmedAt: string | null, skipped: number) => {
       db.prepare(`
         INSERT INTO daily_plan_meta (plan_date, confirmed_at, skipped, created_at, updated_at)
@@ -112,10 +128,13 @@ export async function POST(req: Request) {
       }
       ordered.forEach((key, i) => {
         db.prepare(`
-          INSERT INTO daily_plan (plan_date, task_key, position, origin, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?)
-          ON CONFLICT(plan_date, task_key) DO UPDATE SET position = excluded.position, updated_at = excluded.updated_at
-        `).run(date, key, i, originFor(key), now, now)
+          INSERT INTO daily_plan (plan_date, task_key, position, origin, task_snapshot, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(plan_date, task_key) DO UPDATE SET
+            position      = excluded.position,
+            updated_at    = excluded.updated_at,
+            task_snapshot = COALESCE(excluded.task_snapshot, daily_plan.task_snapshot)
+        `).run(date, key, i, originFor(key), snapshotFor(key), now, now)
       })
     })
     const keysFromBody = () => Array.isArray(body.task_keys) ? body.task_keys.filter((k): k is string => typeof k === 'string') : []
@@ -144,10 +163,10 @@ export async function POST(req: Request) {
         if (typeof key !== 'string' || !key) return NextResponse.json({ error: 'task_key required' }, { status: 400 })
         const max = db.prepare('SELECT COALESCE(MAX(position), -1) AS m FROM daily_plan WHERE plan_date = ?').get(date) as { m: number }
         db.prepare(`
-          INSERT INTO daily_plan (plan_date, task_key, position, origin, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?)
+          INSERT INTO daily_plan (plan_date, task_key, position, origin, task_snapshot, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
           ON CONFLICT(plan_date, task_key) DO NOTHING
-        `).run(date, key, max.m + 1, originFor(key), now, now)
+        `).run(date, key, max.m + 1, originFor(key), snapshotFor(key), now, now)
         break
       }
       case 'remove': {

--- a/ui/app/api/triage/ignore/route.ts
+++ b/ui/app/api/triage/ignore/route.ts
@@ -12,7 +12,7 @@ import { getWriteDb } from '@/lib/db-write'
 export const dynamic = 'force-dynamic'
 
 // Mirror of MUST_FIX in lib/hygiene — these can never be ignored.
-const MUST_FIX = new Set(['missing_description', 'thin_description', 'vague_title', 'missing_due_date'])
+const MUST_FIX = new Set(['missing_description', 'thin_description', 'vague_title', 'missing_due_date', 'overdue'])
 
 export async function POST(req: Request) {
   let body: { task_key?: unknown; code?: unknown; undo?: unknown }

--- a/ui/lib/daily-plan.ts
+++ b/ui/lib/daily-plan.ts
@@ -132,13 +132,37 @@ function dueReason(dueDays: number | null): string | null {
 
 interface MetaRow { confirmed_at: string | null; skipped: number }
 
-/** Committed plan rows joined with their live pm_tasks state. Reads pm_tasks
- *  directly (not the scored `available` map) so a committed task that has since
- *  gone terminal still shows its real title / Done state. */
+// Snapshot of a ticket's board fields, captured onto the daily_plan row at
+// write time (see /api/plan POST). Mirrors the pm_tasks columns we display.
+interface TaskSnapshot {
+  title?: string | null; provider?: string | null; url?: string | null
+  status_raw?: string | null; is_terminal?: number
+  due_date?: string | null; description_text?: string | null
+  epic_title?: string | null; parent_key?: string | null
+  priority?: string | null; issue_type?: string | null; story_points?: string | null
+}
+
+function parseSnapshot(s: string | null): TaskSnapshot | null {
+  if (!s) return null
+  try { return JSON.parse(s) as TaskSnapshot } catch { return null }
+}
+
+/** Committed plan rows joined with their LIVE pm_tasks state. A planned ticket
+ *  that has since gone terminal is pruned from pm_tasks (we keep the active board
+ *  clean — see migration 044), so the live join misses. In that case we fall back
+ *  to the snapshot captured on the plan row, and treat an off-board planned task
+ *  as completed (`is_terminal`) — it left the active board, almost always by being
+ *  finished. This keeps a planned-then-done task visible in the day's plan with
+ *  its real title / description / epic instead of collapsing to a bare key. */
 function loadPlan(db: Database.Database, date: string, now: Date): PlanItem[] {
   if (!tableExists(db, 'daily_plan')) return []
+  const hasSnapshot = !!db.prepare(
+    "SELECT 1 FROM pragma_table_info('daily_plan') WHERE name='task_snapshot'",
+  ).get()
   const rows = db.prepare(`
     SELECT p.task_key, p.position, p.origin,
+           ${hasSnapshot ? 'p.task_snapshot' : 'NULL AS task_snapshot'},
+           (t.task_key IS NOT NULL) AS on_board,
            t.title, t.provider, t.url,
            COALESCE(t.status_raw,'') AS status_raw,
            COALESCE(t.is_terminal,0) AS is_terminal,
@@ -150,28 +174,38 @@ function loadPlan(db: Database.Database, date: string, now: Date): PlanItem[] {
     ORDER BY p.position ASC, p.task_key ASC
   `).all(date) as Array<{
     task_key: string; position: number; origin: string
+    task_snapshot: string | null; on_board: number
     title: string | null; provider: string | null; url: string | null
     status_raw: string; is_terminal: number; due_date: string | null
     description_text: string | null; epic_title: string | null; parent_key: string | null
     priority: string | null; issue_type: string | null; story_points: string | null
   }>
-  return rows.map(r => ({
-    task_key: r.task_key,
-    position: r.position,
-    origin: r.origin,
-    title: r.title ?? r.task_key,
-    provider: r.provider ?? 'jira',
-    url: r.url ?? '',
-    status: r.status_raw,
-    is_terminal: !!r.is_terminal,
-    due_date: r.due_date ?? null,
-    due_days: dueDaysFrom(r.due_date ?? null, now),
-    description: excerpt(r.description_text),
-    epic: (r.epic_title?.trim() || r.parent_key?.trim() || null) ?? null,
-    priority: r.priority?.trim() || null,
-    issue_type: r.issue_type?.trim() || '',
-    story_points: r.story_points?.trim() || null,
-  }))
+  return rows.map(r => {
+    const onBoard = !!r.on_board
+    // Live board row wins; otherwise fall back to the captured snapshot.
+    const snap = onBoard ? null : parseSnapshot(r.task_snapshot)
+    const dueDate = (onBoard ? r.due_date : snap?.due_date) ?? null
+    return {
+      task_key: r.task_key,
+      position: r.position,
+      origin: r.origin,
+      title: (onBoard ? r.title : snap?.title) ?? r.task_key,
+      provider: (onBoard ? r.provider : snap?.provider) ?? 'jira',
+      url: (onBoard ? r.url : snap?.url) ?? '',
+      status: (onBoard ? r.status_raw : (snap?.status_raw ?? '')) || '',
+      // Off the active board ⇒ completed for the day's plan (it was pruned, which
+      // for a planned ticket means Done). On board ⇒ trust the live flag.
+      is_terminal: onBoard ? !!r.is_terminal : true,
+      due_date: dueDate,
+      due_days: dueDaysFrom(dueDate, now),
+      description: excerpt(onBoard ? r.description_text : (snap?.description_text ?? null)),
+      epic: ((onBoard ? r.epic_title : snap?.epic_title)?.trim()
+        || (onBoard ? r.parent_key : snap?.parent_key)?.trim() || null) ?? null,
+      priority: (onBoard ? r.priority : snap?.priority)?.trim() || null,
+      issue_type: (onBoard ? r.issue_type : snap?.issue_type)?.trim() || '',
+      story_points: (onBoard ? r.story_points : snap?.story_points)?.trim() || null,
+    }
+  })
 }
 
 function loadMeta(db: Database.Database, date: string): MetaRow {

--- a/ui/lib/hygiene.ts
+++ b/ui/lib/hygiene.ts
@@ -27,6 +27,7 @@ const MUST_FIX = new Set([
   'thin_description',
   'vague_title',
   'missing_due_date',
+  'overdue',
 ])
 
 function reasonSeverity(code: string): Severity {
@@ -58,6 +59,7 @@ function reasonHint(code: string, d: Record<string, number> | undefined): string
     case 'no_activity_since': return `No board activity in ${d?.days} days.`
     case 'not_started': return 'Still in a not-started column.'
     case 'no_due_date': return 'No due date set.'
+    case 'overdue': return `Overdue by ${d?.by_days} day(s) — reschedule or close it.`
     case 'overdue_long': return `Overdue by ${d?.by_days} days with no movement.`
     case 'far_future_due': return `Not due for ${d?.in_days} days — planned, not current work.`
     case 'not_in_sprint': return 'Not in any sprint.'
@@ -75,6 +77,7 @@ function reasonFix(code: string): HygieneFix | null {
     case 'vague_title': return { control: 'edit_text', field: 'summary', label: 'Make the title specific', ai: true }
     case 'no_context_anchor': return { control: 'pick_parent', field: 'parent', label: 'Link to an epic or parent', ai: false }
     case 'missing_due_date': return { control: 'date_picker', field: 'duedate', label: 'Add a due date', ai: false }
+    case 'overdue': return { control: 'date_picker', field: 'duedate', label: 'Reschedule due date', ai: false }
     case 'missing_assignee': return { control: 'assign_self', field: 'assignee', label: 'Assign to me', ai: false }
     case 'missing_labels': return { control: 'edit_labels', field: 'labels', label: 'Add a label', ai: false }
     case 'missing_priority': return { control: 'pick_priority', field: 'priority', label: 'Set priority', ai: false }


### PR DESCRIPTION
Two small, related board-hygiene fixes (recovered from a stash).

## 1. Keep a completed planned task on the /plan page
A ticket committed to the daily plan that later goes **Done** is pruned from `pm_tasks` (the active board), so `loadPlan`'s `LEFT JOIN` missed and the card collapsed to a bare key.

Rather than re-add Done tickets to `pm_tasks` (which would leak them into the **Tasks page**, **triage/clean-up**, and the **classifier candidate set**), we keep `pm_tasks` pure and make the plan self-sufficient:
- **Migration 044** adds `daily_plan.task_snapshot` (JSON).
- `/api/plan` POST captures the ticket's board fields onto the plan row at write time (`COALESCE`d so an earlier snapshot is never clobbered).
- `loadPlan` falls back to the snapshot when the live `pm_tasks` row is gone, rendering an off-board planned task as completed (strikethrough + Done badge).

Net: Tasks page still excludes Done (unchanged); the /plan page keeps a planned-then-completed task with its real title/description/epic; triage/classifier/worklog untouched.

## 2. Surface overdue tickets in clean-up (must-fix)
An overdue-but-live ticket counted as `due_soon → active → Ready` and never appeared on the clean-up page.
- New `Overdue { by_days }` triage reason with a **reschedule-due-date** fix, emitted on any non-terminal past-due ticket **without changing its bucket** (fixtures unchanged).
- Marked **must-fix** (`hygiene.ts` + ignore route), so it lands in the can't-ignore "Must fix" section.
- Stopped the misleading "Due today" `DueSoon` label from firing on a past-due date.

## Tests
- `cargo test --lib task_triage` (incl. 2 new overdue tests) — pass
- migration applies cleanly (`etl_basic`) — pass
- clippy clean; UI typecheck clean for changed files

## Note
Migration 044 ships a schema change, so the daemon must be **rebuilt + restarted** for the snapshot column and re-triage to take effect. KAN-240 (already pruned before this existed) won't backfill automatically.