### PR TITLE
feat(observability): one root trace per classified session + frame-range attribution

### DIFF
--- a/services/agents/run_task_linker_mlx.py
+++ b/services/agents/run_task_linker_mlx.py
@@ -579,7 +579,8 @@ def _fetch_session(
     row = con.execute(
         "SELECT id, app_name, started_at, ended_at, duration_s, session_text,"
         "       session_text_source, window_titles, category, confidence,"
-        "       session_summary, claude_session_uuid"
+        "       session_summary, claude_session_uuid,"
+        "       min_frame_id, max_frame_id, frame_count"
         " FROM app_sessions WHERE id = ?",
         (session_id,),
     ).fetchone()
@@ -800,6 +801,17 @@ def _classify_one(
         db_span.set_attribute("duration_s", float(session_raw.get("duration_s") or 0.0))
         db_span.set_attribute("text_source", str(session_raw.get("session_text_source") or ""))
         db_span.set_attribute("session_text_chars", len(session_text))
+        # Frame-range attribution: the contiguous screenpipe frame_id window this
+        # session was built from (min..max, inclusive) plus the kept frame count.
+        # Answers "which capture window fed this classification" — the raw frames
+        # live in screenpipe keyed by these ids. Coding-agent rows have no frames
+        # (min/max = 0), so guard on a real range before stamping.
+        _min_fid = session_raw.get("min_frame_id")
+        _max_fid = session_raw.get("max_frame_id")
+        if isinstance(_min_fid, int) and isinstance(_max_fid, int) and _max_fid > 0:
+            db_span.set_attribute("min_frame_id", _min_fid)
+            db_span.set_attribute("max_frame_id", _max_fid)
+            db_span.set_attribute("frame_count", int(session_raw.get("frame_count") or 0))
         db_span.set_attribute("pm_tasks_count", len(pm_tasks))
         db_span.set_attribute("today_focus_count", len(focus_keys))
         db_span.set_attribute("recent_sessions_count", len(recent))

--- a/src/intelligence/task_linker/mod.rs
+++ b/src/intelligence/task_linker/mod.rs
@@ -250,7 +250,24 @@ async fn call_mlx_server(
         outcome = field::Empty,
     )
 )]
-pub async fn run_task_linking(pool: &SqlitePool, cfg: &Config) -> Result<TaskLinkOutcome> {
+pub async fn run_task_linking(
+    pool: &SqlitePool,
+    cfg: &Config,
+    tick_link: Option<opentelemetry::trace::SpanContext>,
+) -> Result<TaskLinkOutcome> {
+    // This call is its OWN root trace — the caller deliberately does not parent it
+    // under the poll/startup tick, so each drained session is a self-contained
+    // trace (one `classify_session` subtree, not N siblings sharing one tick
+    // trace). Link back to the triggering tick so the daemon→session relationship
+    // stays navigable in OpenObserve without collapsing the drain into one trace.
+    if let Some(sc) = tick_link {
+        use tracing_opentelemetry::OpenTelemetrySpanExt;
+        tracing::Span::current().add_link_with_attributes(
+            sc,
+            vec![opentelemetry::KeyValue::new("link.kind", "poll_tick")],
+        );
+    }
+
     if !cfg.classification_enabled {
         tracing::Span::current().record("outcome", "disabled");
         debug!("classification disabled — skipping");
@@ -474,7 +491,11 @@ pub async fn run_task_linking(pool: &SqlitePool, cfg: &Config) -> Result<TaskLin
 /// order, so it never collides with the screen-capture cursor. The MLX server
 /// reasons over each row's `session_summary` (not the transcript); we persist
 /// the task fields WITHOUT touching `session_summary`. Returns rows classified.
-pub async fn run_coding_agent_classification(pool: &SqlitePool, cfg: &Config) -> Result<usize> {
+pub async fn run_coding_agent_classification(
+    pool: &SqlitePool,
+    cfg: &Config,
+    tick_link: Option<opentelemetry::trace::SpanContext>,
+) -> Result<usize> {
     if !cfg.classification_enabled {
         return Ok(0);
     }
@@ -498,15 +519,33 @@ pub async fn run_coding_agent_classification(pool: &SqlitePool, cfg: &Config) ->
     // whole batch.
     let mut n = 0usize;
     for id in ids {
-        let input = ClassifyInput {
-            session_ids: vec![id],
-            meridian_db: cfg.meridian_db.clone(),
-            traceparent: crate::observability::current_traceparent(),
-        };
+        use tracing::Instrument;
 
-        let out = match call_mlx_server(&input, cfg.mlx_server_port, cfg.classification_timeout_s)
-            .await
-        {
+        // One root trace per coding-agent session (same rationale as the ETL
+        // classify path): the `current_traceparent()` sent to the MLX server is
+        // captured INSIDE this span, so the server's `classify_session` subtree
+        // nests under this session alone. Link back to the triggering tick.
+        let sess_span = tracing::info_span!("coding_agent_classify_session", session_id = id);
+        if let Some(sc) = tick_link.clone() {
+            use tracing_opentelemetry::OpenTelemetrySpanExt;
+            sess_span.add_link_with_attributes(
+                sc,
+                vec![opentelemetry::KeyValue::new("link.kind", "poll_tick")],
+            );
+        }
+
+        let out = async {
+            let input = ClassifyInput {
+                session_ids: vec![id],
+                meridian_db: cfg.meridian_db.clone(),
+                traceparent: crate::observability::current_traceparent(),
+            };
+            call_mlx_server(&input, cfg.mlx_server_port, cfg.classification_timeout_s).await
+        }
+        .instrument(sess_span)
+        .await;
+
+        let out = match out {
             Ok(out) => out,
             Err(e) => {
                 // Don't abort the whole batch on one row — log and move on so a

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ use meridian::intelligence::{
 use meridian::observability;
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::Notify;
-use tracing::Instrument as _;
 
 /// After this many consecutive subprocess failures for the same session,
 /// write a `subprocess_error` sentinel and advance the cursor past it.
@@ -79,7 +78,7 @@ async fn main() -> Result<()> {
             Ok(pool) => {
                 let mut total = 0usize;
                 loop {
-                    match run_coding_agent_classification(&pool, &cfg).await {
+                    match run_coding_agent_classification(&pool, &cfg, None).await {
                         Ok(0) => break,
                         Ok(n) => {
                             total += n;
@@ -684,6 +683,17 @@ async fn main() -> Result<()> {
                     _ = tokio::time::sleep(Duration::from_secs(300)) => tracing::Span::none(),
                 };
 
+                // Each classification below runs as its OWN root trace (not a child
+                // of this tick), so a backlog drain produces one self-contained trace
+                // per session instead of N siblings collapsed into one tick trace.
+                // We still want the daemon→session relationship, so capture the tick's
+                // span context here and pass it down as a span LINK. `Span::none()`
+                // (the 5-min fallback wake) yields no context → no link, which is fine.
+                let tick_link = parent_span
+                    .in_scope(meridian::observability::current_traceparent)
+                    .as_deref()
+                    .and_then(meridian::observability::span_context_from_traceparent);
+
                 // Whether this wake settled at least one session — if so, wake the
                 // PM-worklog driver afterwards so a now-complete hour drafts at once.
                 let mut classified_any = false;
@@ -691,12 +701,12 @@ async fn main() -> Result<()> {
                 // Drain: classify oldest-first until nothing is left or a failure stops us.
                 loop {
                     let cfg = Config::from_env();
-                    // .instrument() enters parent_span on each poll; #[tracing::instrument]
-                    // on run_task_linking creates its span inside the async block at first
-                    // poll (tracing-attributes >= 0.1.24), so it sees parent_span as current
-                    // and becomes its child.
-                    match run_task_linking(&meridian_linker, &cfg)
-                        .instrument(parent_span.clone())
+                    // No `.instrument(parent_span)` here on purpose: run_task_linking's
+                    // own #[tracing::instrument] span is created with no ambient parent,
+                    // so it starts a fresh root trace. `tick_link` (the tick's span
+                    // context) is passed as a LINK instead — daemon→session stays
+                    // navigable without merging every drained session into one trace.
+                    match run_task_linking(&meridian_linker, &cfg, tick_link.clone())
                         .await
                     {
                         Ok(TaskLinkOutcome::Classified) => {
@@ -710,9 +720,12 @@ async fn main() -> Result<()> {
                             // classify queue (summarised rows → task linking), the
                             // last link of seal→summarise→classify. Repeat until empty.
                             loop {
-                                match run_coding_agent_classification(&meridian_linker, &cfg)
-                                    .instrument(parent_span.clone())
-                                    .await
+                                match run_coding_agent_classification(
+                                    &meridian_linker,
+                                    &cfg,
+                                    tick_link.clone(),
+                                )
+                                .await
                                 {
                                     Ok(0) => break,
                                     Ok(n) => {

--- a/tests/task_linker_smoke.rs
+++ b/tests/task_linker_smoke.rs
@@ -152,7 +152,7 @@ async fn real_classification_writes_task_and_advances_cursor() {
     .await;
 
     let cfg = make_cfg(&db_path);
-    run_task_linking(&pool, &cfg).await.unwrap();
+    run_task_linking(&pool, &cfg, None).await.unwrap();
 
     // task classification written to app_sessions
     let row = sqlx::query(
@@ -223,8 +223,8 @@ async fn real_classification_does_not_reprocess_classified_session() {
     .await;
 
     let cfg = make_cfg(&db_path);
-    run_task_linking(&pool, &cfg).await.unwrap(); // classifies
-    run_task_linking(&pool, &cfg).await.unwrap(); // should be a no-op
+    run_task_linking(&pool, &cfg, None).await.unwrap(); // classifies
+    run_task_linking(&pool, &cfg, None).await.unwrap(); // should be a no-op
 
     let run_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM agent_runs")
         .fetch_one(&pool)
@@ -265,7 +265,7 @@ async fn classifiable_session_paused_until_pipeline_ready() {
 
     // No pm_tasks seeded → pm_tasks_present() is false → pipeline is paused.
     let cfg = make_cfg(&db_path);
-    run_task_linking(&pool, &cfg).await.unwrap();
+    run_task_linking(&pool, &cfg, None).await.unwrap();
 
     // Session must remain unclassified (task_method still NULL).
     let method: Option<String> =
@@ -319,7 +319,7 @@ async fn short_session_is_not_classified() {
         runtime: RuntimeSettings::default(),
     };
 
-    run_task_linking(&pool, &cfg).await.unwrap();
+    run_task_linking(&pool, &cfg, None).await.unwrap();
 
     let count: (i64,) =
         sqlx::query_as("SELECT COUNT(*) FROM app_sessions WHERE task_method IS NOT NULL")
@@ -358,7 +358,7 @@ async fn trivial_session_is_marked_overhead_without_server() {
         runtime: RuntimeSettings::default(),
     };
 
-    run_task_linking(&pool, &cfg).await.unwrap();
+    run_task_linking(&pool, &cfg, None).await.unwrap();
 
     let row = sqlx::query("SELECT task_method, task_routing FROM app_sessions WHERE id = ?")
         .bind(id)


### PR DESCRIPTION
## Problem

Opening a session's classifier trace in OpenObserve showed **many** `classify_session` blocks, not just that session's. Reported as "I see so many session blocks in the same trace, it is not making any sense."

**Root cause** (`src/main.rs` drain loop): the classifier drains the backlog one session at a time (`BATCH_LIMIT = 1`), but every `run_task_linking` / `run_coding_agent_classification` call was `.instrument(parent_span)`-ed under the **same** poll/startup tick span. So a drain of N sessions collapsed into **one trace** with N sibling `classify_session` subtrees. The earlier "minimal single-session trace" change removed the batch-*wrapper* span but never made each session its own **root trace**.

## Fix

1. **One root trace per session.** The drain loop no longer parents classification under the tick. Each `run_task_linking` starts a fresh root trace (its `#[tracing::instrument]` span has no ambient parent), and the tick's span context is passed down as a **span Link** (`link.kind=poll_tick`) — daemon→session stays navigable without merging the drain into one trace. Clicking a dashboard row → its `classify_traceparent` → a trace with **exactly one** session.
2. **Coding-agent path too.** Same bug (internal per-id loop under the tick). Each per-id call now runs in its own root span, with the MLX `traceparent` captured inside it so the server's `classify_session` subtree nests under that one session.
3. **Frame-range attribution.** Stamp the session's screenpipe frame window (`min_frame_id`/`max_frame_id`/`frame_count`) onto the `db_fetch` span — answers "which capture window fed this classification." No migration (columns exist since `001_initial.sql`); guarded so coding-agent rows (no frames) are skipped.

## Notes

- The worklog lineage links (`pm_worklog/route.rs`) keep working and improve: the classification link now jumps to a single-session trace.
- The poll/startup tick trace still carries `run_etl`; only classification moved out (+ link back).

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --test task_linker_smoke` — 3 passed, 2 ignored (need live MLX server)
- `py_compile services/agents/run_task_linker_mlx.py` — OK