### PR TITLE
feat(today): replace AI-assisted % with coding time + fix Shape of Day

### DIFF
--- a/ui/components/ShapeOfDay.tsx
+++ b/ui/components/ShapeOfDay.tsx
@@ -25,26 +25,15 @@ export default function ShapeOfDay({ data }: { data: TodayResponse }) {
     const byCat: Record<string, number> = {}
     data.sessions.forEach(s => { byCat[s.cat] = (byCat[s.cat] || 0) + s.dur })
     if (data.active) byCat[data.active.cat] = (byCat[data.active.cat] || 0) + data.active.elapsed_s
+    // Autonomous agent time (coding agent ran while you were away) is extra coding
+    // time not captured in any foreground session — add it to the coding slice.
+    if (data.autonomous_s > 0) byCat['coding'] = (byCat['coding'] || 0) + data.autonomous_s
     const total = Object.values(byCat).reduce((sum, v) => sum + v, 0) || 1
     return Object.entries(byCat).map(([cat, seconds]) => ({
       cat, seconds,
       percentage: (seconds / total) * 100,
       label: CATS[cat]?.label || cat,
     })).sort((a, b) => b.seconds - a.seconds)
-  }, [data])
-
-  const longestFocusBlock = useMemo(() => {
-    const activities = [
-      ...data.sessions.map(s => ({ kind: 'session' as const, startH: toH(s.started_at), dur: s.dur })),
-      ...(data.active ? [{ kind: 'session' as const, startH: toH(data.active.started_at), dur: data.active.elapsed_s }] : []),
-      ...data.gaps.map(g => ({ kind: 'gap' as const, startH: toH(g.started_at), dur: g.dur })),
-    ].sort((a, b) => a.startH - b.startH)
-    let maxBlock = 0, currentBlock = 0
-    activities.forEach(act => {
-      if (act.kind === 'gap' && act.dur > 300) { maxBlock = Math.max(maxBlock, currentBlock); currentBlock = 0 }
-      else if (act.kind === 'session') currentBlock += act.dur
-    })
-    return Math.max(maxBlock, currentBlock)
   }, [data])
 
   const slices = useMemo(() => {
@@ -96,9 +85,9 @@ export default function ShapeOfDay({ data }: { data: TodayResponse }) {
             </svg>
             <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
               <p className="font-mono tnum text-[28px] leading-none" style={{ color: 'var(--ink)' }}>
-                {fmtDur(data.focus_s)}
+                {fmtDur(data.engaged_s || data.focus_s)}
               </p>
-              <p className="text-[10px] uppercase tracking-wide mt-1" style={{ color: 'var(--ink-3)' }}>active</p>
+              <p className="text-[10px] uppercase tracking-wide mt-1" style={{ color: 'var(--ink-3)' }}>engaged</p>
             </div>
           </div>
         </div>
@@ -106,8 +95,9 @@ export default function ShapeOfDay({ data }: { data: TodayResponse }) {
         <div className="flex-1 space-y-4">
           <div className="grid grid-cols-2 gap-3 pb-4 rule-b" style={{ borderBottomColor: 'var(--rule)' }}>
             <div>
-              <p className="text-[10px] uppercase tracking-wide mb-1" style={{ color: 'var(--ink-3)' }}>Longest block</p>
-              <p className="font-mono tnum text-[20px] leading-none" style={{ color: 'var(--success)' }}>{fmtDur(longestFocusBlock)}</p>
+              <p className="text-[10px] uppercase tracking-wide mb-1" style={{ color: 'var(--ink-3)' }}>Top category</p>
+              <p className="font-mono tnum text-[20px] leading-none" style={{ color: 'var(--success)' }}>{fmtDur(catData[0]?.seconds ?? 0)}</p>
+              <p className="text-[11px] mt-1" style={{ color: 'var(--ink-3)' }}>{catData[0]?.label ?? '—'}</p>
             </div>
             <div>
               <p className="text-[10px] uppercase tracking-wide mb-1" style={{ color: 'var(--ink-3)' }}>Idle time</p>

--- a/ui/components/TodayMetrics.tsx
+++ b/ui/components/TodayMetrics.tsx
@@ -16,10 +16,11 @@ interface Props {
   agent_s: number
   supervised_s: number
   autonomous_s: number
+  coding_s: number
   switch_count: number
 }
 
-type Key = 'focus' | 'ai' | 'switches'
+type Key = 'focus' | 'coding' | 'switches'
 
 const pct = (part: number, whole: number) => (whole > 0 ? Math.round((part / whole) * 100) : 0)
 
@@ -36,14 +37,15 @@ function DetailRow({ label, value, hint }: { label: string; value: string; hint?
 }
 
 export default function TodayMetrics(props: Props) {
-  const { focus_s, idle_s, agent_s, supervised_s, autonomous_s, switch_count } = props
+  const { focus_s, idle_s, agent_s, supervised_s, autonomous_s, coding_s, switch_count } = props
   const [open, setOpen] = useState<Key | null>(null)
 
   const tiles: { key: Key; label: string; value: string; note: string }[] = [
     { key: 'focus', label: 'Focus', value: fmtDur(focus_s), note: 'active' },
-    { key: 'ai', label: 'AI-assisted', value: `${pct(supervised_s, focus_s)}%`, note: 'of focus' },
+    { key: 'coding', label: 'Coding', value: fmtDur(coding_s), note: 'time coding' },
     { key: 'switches', label: 'Switches', value: String(switch_count), note: 'context switches' },
   ]
+  const showAgentLine = autonomous_s >= 60
 
   const detail = (key: Key) => {
     switch (key) {
@@ -52,15 +54,14 @@ export default function TodayMetrics(props: Props) {
           <>
             <DetailRow label="Active" value={fmtDur(focus_s)} hint="you, at the keyboard" />
             <DetailRow label="Idle / away" value={fmtDur(idle_s)} hint="no input detected" />
-            <DetailRow label="AI-assisted" value={`${fmtDur(supervised_s)} · ${pct(supervised_s, focus_s)}%`} hint="of your active time" />
           </>
         )
-      case 'ai':
+      case 'coding':
         return (
           <>
-            <DetailRow label="Supervised" value={fmtDur(supervised_s)} hint="agent ran while you were active" />
-            <DetailRow label="Autonomous" value={fmtDur(autonomous_s)} hint="agent ran while you were away" />
-            <DetailRow label="Agent total" value={fmtDur(agent_s)} hint="engaged Claude / Codex time" />
+            <DetailRow label="Your coding" value={fmtDur(coding_s - autonomous_s)} hint="at the keyboard" />
+            <DetailRow label="Agent (solo)" value={fmtDur(autonomous_s)} hint="Claude / Codex ran while you were away" />
+            <DetailRow label="Total" value={fmtDur(agent_s)} hint="engaged Claude / Codex time" />
           </>
         )
       case 'switches':
@@ -94,7 +95,10 @@ export default function TodayMetrics(props: Props) {
                 <span className="text-[9px]" style={{ color: 'var(--ink-4)', transform: isOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s' }}>▾</span>
               </p>
               <p className="font-mono tnum text-[20px] leading-none" style={{ color: 'var(--ink)' }}>{t.value}</p>
-              <p className="text-[11px] mt-1.5" style={{ color: 'var(--ink-3)' }}>{t.note}</p>
+              {t.key === 'coding' && showAgentLine
+                ? <p className="text-[11px] mt-1.5" style={{ color: 'var(--live)' }}>incl. {fmtDur(autonomous_s)} autonomous AI agent</p>
+                : <p className="text-[11px] mt-1.5" style={{ color: 'var(--ink-3)' }}>{t.note}</p>
+              }
             </button>
           )
         })}

--- a/ui/components/views/TodayView.tsx
+++ b/ui/components/views/TodayView.tsx
@@ -458,6 +458,12 @@ export default function TodayView() {
     )
   }
 
+  // Total time in coding category: foreground coding sessions + active if coding
+  // + autonomous agent time (Claude Code / Codex ran while you were away).
+  const coding_s = data.sessions.filter(s => s.cat === 'coding').reduce((a, s) => a + s.dur, 0)
+    + (data.active?.cat === 'coding' ? data.active.elapsed_s : 0)
+    + (data.autonomous_s ?? 0)
+
   // Build buckets. The "% of day" denominator is total ENGAGED time (your
   // foreground presence + autonomous agent time), so a task carrying agent work
   // never exceeds 100%. Falls back to focus_s on older API responses.
@@ -589,6 +595,7 @@ export default function TodayView() {
         agent_s={data.agent_s}
         supervised_s={data.supervised_s}
         autonomous_s={data.autonomous_s}
+        coding_s={coding_s}
         switch_count={data.switch_count}
       />
 


### PR DESCRIPTION
## Summary

- **Coding tile**: replaces the "AI-assisted %" metric with total coding time (foreground sessions + autonomous AI agent time); shows `incl. Xm autonomous AI agent` sub-label when the agent ran solo while you were away
- **Shape of Day pie**: Claude Code / Codex sessions now appear in the coding slice — autonomous agent time (`autonomous_s`) is added to the coding category so the chart reflects actual coding done, not just screen-capture sessions; donut center updated to `engaged_s` (your time + AI time)
- **Top category stat**: replaces the confusing "Longest block" number (which users couldn't easily relate to the category list) with the top category name + its duration — immediately interpretable

## Test plan

- [ ] Coding tile shows total coding time; sub-label appears only when autonomous > 60s
- [ ] Expanding Coding tile shows "Your coding" / "Agent (solo)" / "Total" breakdown
- [ ] Shape of Day pie coding slice is larger than before (includes autonomous time)
- [ ] Donut center shows `engaged_s`, labeled "engaged"
- [ ] Top category stat matches the first row in the category list
- [ ] Build passes: `npm run build`