### PR TITLE
feat(cleanup): mark overdue tickets as done or cancelled

### DIFF
--- a/dev-start.sh
+++ b/dev-start.sh
@@ -69,6 +69,25 @@ sleep 1   # let sockets / ports free before the new windows bind them
 echo "  ✓ previous dev run stopped"
 
 # ---------------------------------------------------------------------------
+# Ensure screenpipe is up — meridian stop disables it via launchctl, so it
+# won't auto-restart. Re-enable + bootstrap + kickstart it here so the daemon
+# has frames to read. Idempotent: safe to run when screenpipe is already live.
+# ---------------------------------------------------------------------------
+LABEL_SCREENPIPE="com.meridiona.screenpipe"
+GUI_TARGET="gui/$(id -u)"
+SP_PLIST="${HOME}/Library/LaunchAgents/${LABEL_SCREENPIPE}.plist"
+if [[ -f "$SP_PLIST" ]]; then
+    echo "→ ensuring screenpipe is running…"
+    launchctl enable    "${GUI_TARGET}/${LABEL_SCREENPIPE}" 2>/dev/null || true
+    launchctl bootstrap "${GUI_TARGET}" "$SP_PLIST"        2>/dev/null || true
+    # bootstrap + RunAtLoad starts screenpipe immediately; no kickstart needed
+    # (kickstart -k would block waiting for screenpipe to re-initialise camera/screen capture)
+    echo "  ✓ screenpipe (re)started"
+else
+    echo "  ⚠ screenpipe plist not found — run: bash install-dev.sh"
+fi
+
+# ---------------------------------------------------------------------------
 # Launch each service in its own Terminal window
 # ---------------------------------------------------------------------------
 

--- a/src/intelligence/ticket_update/azure_devops.rs
+++ b/src/intelligence/ticket_update/azure_devops.rs
@@ -24,13 +24,18 @@ pub async fn apply(cfg: &AzureDevOpsConfig, key: &str, write: &WriteField) -> Re
         .build()
         .context("building HTTP client")?;
 
-    if let WriteField::Close = write {
+    if let WriteField::Close | WriteField::Cancel = write {
+        let reason = if matches!(write, WriteField::Cancel) {
+            "set the work item's State to your process's cancelled state in Azure DevOps"
+        } else {
+            "set the work item's State to your process's done state in Azure DevOps"
+        };
         return Ok(ApplyResult::redirected(
             "azure_devops",
             key,
-            "close",
+            write.label(),
             edit_url(cfg, &item),
-            "set the work item's State to your process's done state in Azure DevOps",
+            reason,
         ));
     }
 
@@ -64,7 +69,7 @@ pub async fn apply(cfg: &AzureDevOpsConfig, key: &str, write: &WriteField) -> Re
             let parent = parse_task_key(parent_key)?;
             vec![add_parent_relation(cfg, &parent)]
         }
-        WriteField::Close => unreachable!("redirected above"),
+        WriteField::Close | WriteField::Cancel => unreachable!("redirected above"),
     };
 
     patch_work_item(&client, cfg, &item, &ops).await?;
@@ -230,6 +235,7 @@ fn field_name(write: &WriteField) -> &'static str {
         WriteField::Summary(_) => "summary",
         WriteField::Description(_) => "description",
         WriteField::Close => "close",
+        WriteField::Cancel => "cancel",
     }
 }
 

--- a/src/intelligence/ticket_update/github.rs
+++ b/src/intelligence/ticket_update/github.rs
@@ -71,6 +71,15 @@ pub async fn apply(cfg: &GitHubConfig, key: &str, write: &WriteField) -> Result<
             )
             .await?;
         }
+        WriteField::Cancel => {
+            patch(
+                cfg,
+                &client,
+                &issue_url(&issue),
+                json!({ "state": "closed", "state_reason": "not_planned" }),
+            )
+            .await?;
+        }
     }
 
     Ok(ApplyResult::applied("github", key, field_name(write)))
@@ -179,6 +188,7 @@ fn field_name(write: &WriteField) -> &'static str {
         WriteField::Summary(_) => "summary",
         WriteField::Description(_) => "description",
         WriteField::Close => "close",
+        WriteField::Cancel => "cancel",
     }
 }
 

--- a/src/intelligence/ticket_update/jira.rs
+++ b/src/intelligence/ticket_update/jira.rs
@@ -74,6 +74,9 @@ pub async fn apply(cfg: &JiraConfig, key: &str, write: &WriteField) -> Result<Ap
         WriteField::Close => {
             close(&ctx, &client, key).await?;
         }
+        WriteField::Cancel => {
+            cancel(&ctx, &client, key).await?;
+        }
     }
 
     Ok(ApplyResult::applied("jira", key, write_field_name(write)))
@@ -259,6 +262,72 @@ fn pick_done_transition(transitions: &[Value]) -> Option<String> {
         .and_then(id_of)
 }
 
+/// Cancel a ticket by finding a transition with a cancelled/won't-do name and POSTing it.
+/// Jira has no standard "cancelled" statusCategory — these transitions typically fall under
+/// the "done" category with recognisable names.
+async fn cancel(ctx: &JiraReqCtx, client: &reqwest::Client, key: &str) -> Result<()> {
+    let url = ctx.api_url(&format!("/rest/api/3/issue/{key}/transitions"));
+    let resp = ctx
+        .apply(client.get(&url))
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .context("GET transitions")?;
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        bail!("Jira GET transitions for {key} returned {status}: {text}");
+    }
+    let v: Value = serde_json::from_str(&text).context("parsing transitions")?;
+    let transitions = v
+        .get("transitions")
+        .and_then(|t| t.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let id = pick_cancel_transition(&transitions)
+        .with_context(|| format!("no 'cancelled' transition available for {key}"))?;
+
+    let post_url = ctx.api_url(&format!("/rest/api/3/issue/{key}/transitions"));
+    let resp = ctx
+        .apply(client.post(&post_url))
+        .header("Accept", "application/json")
+        .json(&json!({ "transition": { "id": id } }))
+        .send()
+        .await
+        .context("POST transition")?;
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        bail!("Jira POST cancel transition for {key} returned {status}: {text}");
+    }
+    Ok(())
+}
+
+/// Choose the transition that represents a cancellation. Uses name heuristics since Jira
+/// has no standard "cancelled" statusCategory (these often sit under "done").
+fn pick_cancel_transition(transitions: &[Value]) -> Option<String> {
+    let id_of = |t: &Value| t.get("id").and_then(|i| i.as_str()).map(String::from);
+    transitions
+        .iter()
+        .find(|t| {
+            let n = t
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or("")
+                .to_lowercase();
+            n.contains("cancel")
+                || n.contains("won't do")
+                || n.contains("wont do")
+                || n.contains("won't fix")
+                || n.contains("wontfix")
+                || n.contains("rejected")
+                || n.contains("declined")
+                || n.contains("invalid")
+                || n.contains("duplicate")
+        })
+        .and_then(id_of)
+}
+
 /// Plain text → Atlassian Document Format (Jira Cloud descriptions are ADF).
 fn adf(text: &str) -> Value {
     json!({
@@ -281,6 +350,7 @@ fn write_field_name(write: &WriteField) -> &'static str {
         WriteField::Summary(_) => "summary",
         WriteField::Description(_) => "description",
         WriteField::Close => "close",
+        WriteField::Cancel => "cancel",
     }
 }
 

--- a/src/intelligence/ticket_update/linear.rs
+++ b/src/intelligence/ticket_update/linear.rs
@@ -53,6 +53,10 @@ pub async fn apply(cfg: &LinearConfig, key: &str, write: &WriteField) -> Result<
             let state_id = completed_state_id(&client, cfg, &uuid).await?;
             json!({ "stateId": state_id })
         }
+        WriteField::Cancel => {
+            let state_id = cancelled_state_id(&client, cfg, &uuid).await?;
+            json!({ "stateId": state_id })
+        }
         WriteField::AddLabel(_) => unreachable!("handled above"),
     };
 
@@ -129,6 +133,30 @@ fn pick_completed_state(nodes: &[Value]) -> Option<String> {
         .and_then(|s| s.get("id").and_then(|i| i.as_str()).map(String::from))
 }
 
+/// The team's cancelled workflow state for the issue (type == "cancelled").
+async fn cancelled_state_id(
+    client: &reqwest::Client,
+    cfg: &LinearConfig,
+    uuid: &str,
+) -> Result<String> {
+    let query = "query IssueStates($id: String!) { issue(id: $id) { team { states { nodes { id name type } } } } }";
+    let payload = json!({ "query": query, "variables": { "id": uuid } });
+    let data = graphql(client, cfg, &payload).await?;
+    let nodes = data
+        .pointer("/issue/team/states/nodes")
+        .and_then(|n| n.as_array())
+        .cloned()
+        .unwrap_or_default();
+    pick_cancelled_state(&nodes).context("no cancelled workflow state on this Linear team")
+}
+
+fn pick_cancelled_state(nodes: &[Value]) -> Option<String> {
+    nodes
+        .iter()
+        .find(|s| s.get("type").and_then(|t| t.as_str()) == Some("cancelled"))
+        .and_then(|s| s.get("id").and_then(|i| i.as_str()).map(String::from))
+}
+
 /// Human URL for the redirect fallback.
 async fn issue_url(client: &reqwest::Client, cfg: &LinearConfig, id: &str) -> String {
     let query = "query IssueUrl($id: String!) { issue(id: $id) { url } }";
@@ -176,6 +204,7 @@ fn field_name(write: &WriteField) -> &'static str {
         WriteField::Summary(_) => "summary",
         WriteField::Description(_) => "description",
         WriteField::Close => "close",
+        WriteField::Cancel => "cancel",
     }
 }
 

--- a/src/intelligence/ticket_update/mod.rs
+++ b/src/intelligence/ticket_update/mod.rs
@@ -51,6 +51,8 @@ pub enum WriteField {
     Description(String),
     /// ticket-level "close" action — transition to the provider's done state.
     Close,
+    /// ticket-level "cancel" action — transition to the provider's cancelled/won't-do state.
+    Cancel,
 }
 
 impl WriteField {
@@ -69,6 +71,7 @@ impl WriteField {
             "summary" => (!v.is_empty()).then(|| Self::Summary(v.to_string())),
             "description" => (!v.is_empty()).then(|| Self::Description(v.to_string())),
             "close" => Some(Self::Close),
+            "cancel" => Some(Self::Cancel),
             _ => None,
         }
     }
@@ -85,6 +88,7 @@ impl WriteField {
             Self::Summary(_) => "title",
             Self::Description(_) => "description",
             Self::Close => "status",
+            Self::Cancel => "cancel",
         }
     }
 }
@@ -265,6 +269,7 @@ mod tests {
             Some(WriteField::Parent("KAN-5".into()))
         );
         assert_eq!(WriteField::parse("close", ""), Some(WriteField::Close));
+        assert_eq!(WriteField::parse("cancel", ""), Some(WriteField::Cancel));
     }
 
     #[test]

--- a/src/intelligence/ticket_update/trello.rs
+++ b/src/intelligence/ticket_update/trello.rs
@@ -28,7 +28,8 @@ pub async fn apply(cfg: &TrelloConfig, key: &str, write: &WriteField) -> Result<
         | WriteField::Priority(_)
         | WriteField::StoryPoints(_)
         | WriteField::Parent(_)
-        | WriteField::Close => {
+        | WriteField::Close
+        | WriteField::Cancel => {
             return Ok(ApplyResult::redirected(
                 "trello",
                 key,
@@ -51,12 +52,15 @@ pub async fn apply(cfg: &TrelloConfig, key: &str, write: &WriteField) -> Result<
         }
         WriteField::AssignMe => {
             let me = my_member_id(&client, cfg, &token).await?;
-            // idMembers add endpoint is additive.
-            let url = format!(
-                "{TRELLO_BASE}/cards/{short_link}/idMembers?key={}&token={}&value={}",
-                cfg.app_key, token, me
-            );
-            post(&client, &url).await?;
+            // idMembers add endpoint is additive. Use append_pair for correct URL encoding.
+            let mut url =
+                reqwest::Url::parse(&format!("{TRELLO_BASE}/cards/{short_link}/idMembers"))
+                    .context("building Trello idMembers URL")?;
+            url.query_pairs_mut()
+                .append_pair("key", &cfg.app_key)
+                .append_pair("token", &token)
+                .append_pair("value", &me);
+            post(&client, url.as_str()).await?;
         }
         WriteField::Summary(text) => {
             put_card(
@@ -153,5 +157,6 @@ fn field_name(write: &WriteField) -> &'static str {
         WriteField::Summary(_) => "summary",
         WriteField::Description(_) => "description",
         WriteField::Close => "close",
+        WriteField::Cancel => "cancel",
     }
 }

--- a/ui/components/HygieneDialog.tsx
+++ b/ui/components/HygieneDialog.tsx
@@ -101,42 +101,47 @@ function FixRow({ issue, index, task, onApplied }: { issue: HygieneIssue; index:
   const [value, setValue] = useState('')
   const [state, setState] = useState<RowState>('idle')
   const [msg, setMsg] = useState('')
+  // Tracks which terminal action button is pending ('close' | 'cancel' | null).
+  const [terminalPending, setTerminalPending] = useState<string | null>(null)
 
   const needsValue = fix?.control !== 'assign_self'
   const canApply = !!fix && state !== 'saving' && state !== 'applied' && (!needsValue || value.trim().length > 0)
 
-  // Apply a concrete value for this field (the epic picker passes the epic key
-  // directly; the standard controls pass their own input).
-  const applyValue = async (val: string) => {
-    if (!fix) return
+  const callApply = async (field: string, val: string) => {
     setState('saving'); setMsg('')
     try {
-      const payload = {
-        provider: task.provider,
-        key: task.key,
-        field: fix.field,
-        value: fix.control === 'assign_self' ? '@me' : val.trim(),
-      }
+      const payload = { provider: task.provider, key: task.key, field, value: val }
       const res = await fetch('/api/triage/apply', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       })
       const data = await res.json()
-      if (!res.ok) { setState('error'); setMsg(data.error ?? 'Save failed'); return }
+      if (!res.ok) { setState('error'); setTerminalPending(null); setMsg(data.error ?? 'Save failed'); return }
       const result = data.result as { status: string; browse_url?: string; reason?: string }
       if (result.status === 'applied') {
-        setState('applied'); setMsg('Saved to tracker')
+        setState('applied'); setTerminalPending(null); setMsg('Saved to tracker')
         onApplied?.()
       } else {
-        // Provider can't write this field — open the card so the dev finishes there.
-        setState('redirected')
+        setState('redirected'); setTerminalPending(null)
         setMsg(result.reason ?? 'Finish this in your tracker')
         const url = result.browse_url || task.url
         if (url) window.open(url, '_blank', 'noopener')
       }
     } catch {
-      setState('error'); setMsg('Network error')
+      setState('error'); setTerminalPending(null); setMsg('Network error')
     }
+  }
+
+  // Apply a concrete value for this field (the epic picker passes the epic key
+  // directly; the standard controls pass their own input).
+  const applyValue = async (val: string) => {
+    if (!fix) return
+    await callApply(fix.field, fix.control === 'assign_self' ? '@me' : val.trim())
+  }
+
+  const applyTerminal = (action: 'close' | 'cancel') => {
+    setTerminalPending(action)
+    callApply(action, '')
   }
 
   const apply = () => applyValue(value)
@@ -187,9 +192,28 @@ function FixRow({ issue, index, task, onApplied }: { issue: HygieneIssue; index:
                 color: canApply ? '#fff' : 'var(--ink-4)',
                 cursor: canApply ? 'pointer' : 'not-allowed',
               }}>
-              {state === 'saving' ? 'Saving…' : (fix?.label ?? 'Fix')}
+              {state === 'saving' && terminalPending === null ? 'Saving…' : (fix?.label ?? 'Fix')}
             </button>
           </div>
+          {issue.code === 'overdue' && (
+            <div className="flex items-center gap-2 mt-2.5 pt-2.5" style={{ borderTop: '1px solid var(--rule)' }}>
+              <span className="text-[11px]" style={{ color: 'var(--ink-4)' }}>or mark as</span>
+              <button
+                disabled={state === 'saving'}
+                onClick={() => applyTerminal('close')}
+                className="text-[12px] px-3 py-1.5 rounded-md border transition-colors"
+                style={{ borderColor: 'var(--rule)', color: 'var(--ink-2)', background: 'var(--paper)' }}>
+                {terminalPending === 'close' ? 'Saving…' : 'Done'}
+              </button>
+              <button
+                disabled={state === 'saving'}
+                onClick={() => applyTerminal('cancel')}
+                className="text-[12px] px-3 py-1.5 rounded-md border transition-colors"
+                style={{ borderColor: 'var(--rule)', color: 'var(--ink-2)', background: 'var(--paper)' }}>
+                {terminalPending === 'cancel' ? 'Saving…' : 'Cancelled'}
+              </button>
+            </div>
+          )}
           {(state === 'error' || state === 'redirected') && (
             <p className="text-[11px] mt-2" style={{ color: state === 'error' ? 'var(--warn)' : 'var(--ink-3)' }}>{msg}</p>
           )}


### PR DESCRIPTION
## Summary

- Overdue tickets in the cleanup page now show **Done** and **Cancelled** buttons alongside the existing date picker, so you can close out tickets that are already complete or abandoned rather than just rescheduling them
- Provider support: Jira (name-heuristic transition), Linear (cancelled workflow state), GitHub (`state_reason: not_planned`), Trello + Azure DevOps (redirect to card)
- New `WriteField::Cancel` variant wired end-to-end through all 5 providers
- Bonus: fix Trello `AssignMe` to use `append_pair()` for correct URL encoding of the member ID

## Test plan

- [ ] Open the cleanup page with an overdue ticket — confirm the "Done" / "Cancelled" row appears below the date picker
- [ ] Click **Done** on a Jira ticket — verify it transitions to a done-category status
- [ ] Click **Cancelled** on a Jira ticket with a cancel transition — verify it lands on the right status
- [ ] Click **Cancelled** on Trello/Azure — verify it opens the card URL instead
- [ ] Click **Done** on a Linear ticket — verify completed state
- [ ] Click **Cancelled** on a Linear ticket — verify cancelled state
- [ ] Click **Cancelled** on a GitHub issue — verify closes with `not_planned` reason
- [ ] Clicking either button shows "Saving…" while in flight, "Saved to tracker" on success