### PR TITLE
fix(mlx-server): serialize model calls + raise worklog timeout + fix coding metrics

### DIFF
--- a/services/agents/pm_worklog_update/config.py
+++ b/services/agents/pm_worklog_update/config.py
@@ -32,7 +32,7 @@ MLX_SERVER_MODEL  = os.environ.get("MLX_SERVER_MODEL", "qwen3.5-9b-instruct")
 # Token caps. The MLX model exposes 128-262K context — a single Synthesise
 # call comfortably swallows even the heaviest hour of work.
 PM_WORKLOG_SYNTH_MAX_TOKENS  = int(os.environ.get("PM_WORKLOG_SYNTH_MAX_TOKENS",  "8000"))
-PM_WORKLOG_REQUEST_TIMEOUT_S = int(os.environ.get("PM_WORKLOG_REQUEST_TIMEOUT_S", "300"))
+PM_WORKLOG_REQUEST_TIMEOUT_S = int(os.environ.get("PM_WORKLOG_REQUEST_TIMEOUT_S", "900"))
 
 # Temperature tuned for each step. Lower = more deterministic.
 PM_WORKLOG_TEMP_COLLECT = 0.0

--- a/services/agents/server.py
+++ b/services/agents/server.py
@@ -62,6 +62,25 @@ async def _idle_evictor(mlx_module: Any) -> None:
             log.warning("server: idle-evictor error: %s", exc)
 
 
+def _model_sem() -> "asyncio.Semaphore":
+    """Return the process-global single-slot model semaphore.
+
+    Created once in _lifespan and stored in _app_state. Every endpoint that
+    runs a model inference acquires this before calling run_in_threadpool so
+    that classify, synthesise_worklog, and summarise never compete on the GPU.
+    The synthesise path is indirectly serialised: /synthesise_worklog itself
+    does NOT hold the semaphore (agno calls /v1/chat/completions internally),
+    so /v1/chat/completions acquires it instead — no nested acquisition,
+    no deadlock.
+    """
+    import asyncio
+    sem = _app_state.get("model_sem")
+    if sem is None:  # fallback if called before lifespan (e.g. tests)
+        sem = asyncio.Semaphore(1)
+        _app_state["model_sem"] = sem
+    return sem
+
+
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     import asyncio
@@ -69,6 +88,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     import agents.run_task_linker_mlx as _mlx
     _app_state["mlx_module"] = _mlx
     _app_state["loaded_at"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    _app_state["model_sem"] = asyncio.Semaphore(1)
     from agents.llm_selector import APPLE_INTELLIGENCE_ID
     evictor: "asyncio.Task | None" = None
     if _mlx._resolve_model_id() == APPLE_INTELLIGENCE_ID:
@@ -332,7 +352,8 @@ async def classify_sessions(req: ClassifySessionsRequest) -> dict:
             if _tok is not None:
                 _otel_context.detach(_tok)
 
-    results = await run_in_threadpool(_classify_all)
+    async with _model_sem():
+        results = await run_in_threadpool(_classify_all)
     return {"results": results}
 
 
@@ -489,7 +510,8 @@ async def openai_chat_completions(req: _OAIChatRequest) -> dict:
 
     t0 = _time.time()
     try:
-        text = await run_in_threadpool(_generate)
+        async with _model_sem():
+            text = await run_in_threadpool(_generate)
     except Exception as exc:                            # noqa: BLE001
         log.warning("openai_chat_completions: inference error: %s", exc)
         raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -618,7 +640,8 @@ async def summarise(req: _SummariseRequest) -> _SummariseResponse:
             )
 
     try:
-        raw = await run_in_threadpool(_generate)
+        async with _model_sem():
+            raw = await run_in_threadpool(_generate)
         obj = _SummarySchema.model_validate_json(raw)
     except Exception as exc:                            # noqa: BLE001
         log.warning("summarise: inference/parse error: %s", exc)
@@ -832,6 +855,9 @@ async def synthesise_worklog(req: _SynthWorklogRequest) -> dict:
                         except Exception as exc:  # noqa: BLE001 — never crash the shared server
                             last_detail = f"agent run raised {type(exc).__name__}: {exc}"
                             log.warning("synthesise_worklog: attempt %d %s", attempt, last_detail)
+                            if attempt < 3:
+                                import time as _t
+                                _t.sleep(5 * attempt)  # 5s, 10s between retries
                             continue
                         raw = getattr(response, "content", response)
                         if raw is None:

--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -34,6 +34,7 @@ use sqlx::SqlitePool;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 use tokio::sync::{watch, Notify};
+use tracing::Instrument;
 
 use config::SummariserConfig;
 use db::PendingRow;
@@ -181,6 +182,36 @@ pub async fn summarise_one(
     cfg: &SummariserConfig,
     write: bool,
 ) -> Outcome {
+    // One span per sealed segment — exported to OpenObserve via the tracing→OTel
+    // bridge. The `prior_*` attributes make prior-burst continuity (a resumed
+    // session reading as one story) a first-class, queryable signal: whether the
+    // model received the earlier burst's summary as context, and how much.
+    let span = tracing::info_span!(
+        "summarise_segment",
+        row_id = row.id,
+        session_uuid = %row.session_uuid,
+        agent = %row.agent,
+        prior_present = tracing::field::Empty,
+        prior_chars = tracing::field::Empty,
+        transcript_chars = tracing::field::Empty,
+        prompt_chars = tracing::field::Empty,
+        summary_source = tracing::field::Empty,
+        summary_chars = tracing::field::Empty,
+        written = tracing::field::Empty,
+        is_error = tracing::field::Empty,
+    );
+    async move { summarise_one_inner(pool, row, cfg, write).await }
+        .instrument(span)
+        .await
+}
+
+async fn summarise_one_inner(
+    pool: &SqlitePool,
+    row: &PendingRow,
+    cfg: &SummariserConfig,
+    write: bool,
+) -> Outcome {
+    let span = tracing::Span::current();
     let err = |row_id, e: String| Outcome {
         row_id,
         written: false,
@@ -192,9 +223,13 @@ pub async fn summarise_one(
 
     let transcript = match db::fetch_transcript(pool, row.id).await {
         Ok(t) => t,
-        Err(e) => return err(row.id, format!("fetch transcript: {e}")),
+        Err(e) => {
+            span.record("is_error", true);
+            return err(row.id, format!("fetch transcript: {e}"));
+        }
     };
     if transcript.trim().is_empty() {
+        span.record("is_error", true);
         return err(row.id, "empty transcript".into());
     }
     let prior = db::fetch_prior_summary(pool, &row.session_uuid, &row.segment_started_at)
@@ -202,9 +237,36 @@ pub async fn summarise_one(
         .unwrap_or(None);
     let stdin_text = build_prompt(&transcript, prior.as_deref(), cfg.transcript_cap_chars);
 
-    let mut summary: Option<String> = None;
-    let mut source = Source::None;
-    let mut rate_limited = false;
+    // Continuity telemetry: record the prior-burst context on the span and emit a
+    // dedicated log line when it was applied, so a resumed-session summary is
+    // distinguishable from a fresh-burst one in both Traces and Logs.
+    let prior_chars = prior.as_deref().map(str::len).unwrap_or(0) as i64;
+    span.record("prior_present", prior.is_some());
+    span.record("prior_chars", prior_chars);
+    span.record("transcript_chars", transcript.len() as i64);
+    span.record("prompt_chars", stdin_text.len() as i64);
+    if prior.is_some() {
+        tracing::info!(
+            row_id = row.id,
+            prior_chars,
+            "summarising coding-agent segment with prior-burst continuity context"
+        );
+    }
+
+    // Debug child span: the EXACT prompt sent to the engine (post-cap, with the
+    // prior-burst context already inlined). `llm_input` is an OpenObserve FTS key,
+    // so a questionable summary can be traced straight back to what the model
+    // actually saw. Mirrors the classifier's `classifier_input` span.
+    tracing::info_span!(
+        "summariser_prompt",
+        llm_input = %stdin_text,
+        prior_present = prior.is_some(),
+        prior_chars = prior_chars,
+        transcript_chars = transcript.len() as i64,
+        prompt_chars = stdin_text.len() as i64,
+    )
+    .in_scope(|| {});
+
     let mut errors: Vec<String> = Vec::new();
 
     // 1. Primary: the session's own agent, up to `primary_attempts` tries.
@@ -221,68 +283,116 @@ pub async fn summarise_one(
     } else {
         Source::Claude
     };
-    for attempt in 1..=cfg.primary_attempts.max(1) {
-        let res = match primary_source {
-            Source::Codex => codex::run_codex(&stdin_text, cfg).await,
-            Source::Copilot => copilot::run_copilot(&stdin_text, cfg).await,
-            Source::CursorAgent => cursor_agent::run_cursor_agent(&stdin_text, cfg).await,
-            _ => claude::run_claude(&stdin_text, cfg).await,
-        };
-        match res {
-            Ok(out) => {
-                summary = Some(out.summary);
-                source = primary_source;
-                break;
-            }
-            Err(SummariserError::RateLimited(m)) => {
-                rate_limited = true;
-                // Log the primary failure even though MLX will likely save the row
-                // — otherwise a degraded-to-MLX state is invisible (this is exactly
-                // how the missing-PATH outage hid: every row silently became mlx).
-                tracing::warn!(
-                    row_id = row.id,
-                    engine = primary_source.as_str(),
-                    error = %m,
-                    "primary summariser rate-limited — falling back to MLX"
-                );
-                errors.push(format!("{} rate-limited: {m}", primary_source.as_str()));
-                break; // retrying a limit is pointless → fall through to MLX
-            }
-            Err(SummariserError::Failed(m)) => {
-                tracing::warn!(
-                    row_id = row.id,
-                    engine = primary_source.as_str(),
-                    attempt,
-                    error = %m,
-                    "primary summariser attempt failed"
-                );
-                errors.push(format!(
-                    "{} attempt {attempt} failed: {m}",
-                    primary_source.as_str()
-                ));
-            }
-        }
-    }
 
-    // 2. Fallback: local MLX (on any primary failure).
-    if summary.is_none() {
-        match mlx::run_mlx(&stdin_text, cfg).await {
-            Ok(s) => {
-                tracing::warn!(
-                    row_id = row.id,
-                    primary = primary_source.as_str(),
-                    "summarised via MLX fallback — primary engine unavailable"
-                );
-                summary = Some(s);
-                source = Source::Mlx;
+    // Debug child span: the operational story of one summarisation — which engine
+    // ran, how many attempts, whether it fell back to MLX, and wall-clock. Mirrors
+    // the classifier's `llm_inference` span; the per-attempt warn! logs below
+    // attach to it, so a degraded-to-MLX state is never silent.
+    let infer_span = tracing::info_span!(
+        "summariser_inference",
+        primary_engine = primary_source.as_str(),
+        engine_used = tracing::field::Empty,
+        model = tracing::field::Empty,
+        attempts_made = tracing::field::Empty,
+        fell_back_to_mlx = tracing::field::Empty,
+        rate_limited = tracing::field::Empty,
+        elapsed_s = tracing::field::Empty,
+        is_error = tracing::field::Empty,
+    );
+    let t_infer = std::time::Instant::now();
+    let (summary, source, rate_limited, attempts_made) = async {
+        let mut summary: Option<String> = None;
+        let mut source = Source::None;
+        let mut rate_limited = false;
+        let mut attempts_made: u32 = 0;
+        for attempt in 1..=cfg.primary_attempts.max(1) {
+            attempts_made = attempt;
+            let res = match primary_source {
+                Source::Codex => codex::run_codex(&stdin_text, cfg).await,
+                Source::Copilot => copilot::run_copilot(&stdin_text, cfg).await,
+                Source::CursorAgent => cursor_agent::run_cursor_agent(&stdin_text, cfg).await,
+                _ => claude::run_claude(&stdin_text, cfg).await,
+            };
+            match res {
+                Ok(out) => {
+                    summary = Some(out.summary);
+                    source = primary_source;
+                    break;
+                }
+                Err(SummariserError::RateLimited(m)) => {
+                    rate_limited = true;
+                    // Log the primary failure even though MLX will likely save the
+                    // row — otherwise a degraded-to-MLX state is invisible (exactly
+                    // how the missing-PATH outage hid: every row silently → mlx).
+                    tracing::warn!(
+                        row_id = row.id,
+                        engine = primary_source.as_str(),
+                        error = %m,
+                        "primary summariser rate-limited — falling back to MLX"
+                    );
+                    errors.push(format!("{} rate-limited: {m}", primary_source.as_str()));
+                    break; // retrying a limit is pointless → fall through to MLX
+                }
+                Err(SummariserError::Failed(m)) => {
+                    tracing::warn!(
+                        row_id = row.id,
+                        engine = primary_source.as_str(),
+                        attempt,
+                        error = %m,
+                        "primary summariser attempt failed"
+                    );
+                    errors.push(format!(
+                        "{} attempt {attempt} failed: {m}",
+                        primary_source.as_str()
+                    ));
+                }
             }
-            Err(e) => errors.push(format!("mlx failed: {e}")),
         }
+
+        // 2. Fallback: local MLX (on any primary failure).
+        if summary.is_none() {
+            match mlx::run_mlx(&stdin_text, cfg).await {
+                Ok(s) => {
+                    tracing::warn!(
+                        row_id = row.id,
+                        primary = primary_source.as_str(),
+                        "summarised via MLX fallback — primary engine unavailable"
+                    );
+                    summary = Some(s);
+                    source = Source::Mlx;
+                }
+                Err(e) => errors.push(format!("mlx failed: {e}")),
+            }
+        }
+        (summary, source, rate_limited, attempts_made)
     }
+    .instrument(infer_span.clone())
+    .await;
+    // Which concrete model produced this summary — the configured model for the
+    // engine that actually ran (empty config → that CLI's own default).
+    let model_used = match source {
+        Source::Claude => cfg.claude_model.clone(),
+        Source::Codex if !cfg.codex_model.is_empty() => cfg.codex_model.clone(),
+        Source::Codex => "codex-default".into(),
+        Source::CursorAgent if !cfg.cursor_model.is_empty() => cfg.cursor_model.clone(),
+        Source::CursorAgent => "cursor-agent-default".into(),
+        Source::Copilot => "copilot-default".into(),
+        Source::Mlx => "mlx-server".into(),
+        Source::None => String::new(),
+    };
+    infer_span.record("engine_used", source.as_str());
+    infer_span.record("model", model_used.as_str());
+    infer_span.record("attempts_made", attempts_made as i64);
+    infer_span.record("fell_back_to_mlx", matches!(source, Source::Mlx));
+    infer_span.record("rate_limited", rate_limited);
+    infer_span.record("elapsed_s", t_infer.elapsed().as_secs_f64());
+    infer_span.record("is_error", summary.is_none());
 
     let summary = match summary {
         Some(s) => s,
         None => {
+            span.record("is_error", true);
+            span.record("summary_source", Source::None.as_str());
             return Outcome {
                 row_id: row.id,
                 written: false,
@@ -290,9 +400,21 @@ pub async fn summarise_one(
                 rate_limited,
                 error: Some(errors.join("; ")),
                 summary: None,
-            }
+            };
         }
     };
+
+    // Debug child span: the EXACT summary produced (`llm_output`, FTS-indexed).
+    // Pairs with `summariser_prompt` so the full input→output of one summarisation
+    // is reconstructable from the trace. Mirrors the classifier's
+    // `classifier_output` span.
+    tracing::info_span!(
+        "summariser_output",
+        llm_output = %summary,
+        summary_source = source.as_str(),
+        summary_chars = summary.len() as i64,
+    )
+    .in_scope(|| {});
 
     let written = if write {
         db::write_summary(pool, row.id, &summary, source.as_str())
@@ -301,6 +423,10 @@ pub async fn summarise_one(
     } else {
         false
     };
+    span.record("summary_source", source.as_str());
+    span.record("summary_chars", summary.len() as i64);
+    span.record("written", written);
+    span.record("is_error", false);
     let uuid_short: String = row.session_uuid.chars().take(8).collect();
     tracing::info!(
         row_id = row.id, uuid = %uuid_short, source = source.as_str(),

--- a/ui/components/TodayMetrics.tsx
+++ b/ui/components/TodayMetrics.tsx
@@ -60,8 +60,8 @@ export default function TodayMetrics(props: Props) {
         return (
           <>
             <DetailRow label="Your coding" value={fmtDur(coding_s - autonomous_s)} hint="at the keyboard" />
-            <DetailRow label="Agent (solo)" value={fmtDur(autonomous_s)} hint="Claude / Codex ran while you were away" />
-            <DetailRow label="Total" value={fmtDur(agent_s)} hint="engaged Claude / Codex time" />
+            <DetailRow label="AI coding (solo)" value={fmtDur(autonomous_s)} hint="Claude / Codex ran while you were away" />
+            <DetailRow label="Total" value={fmtDur(coding_s)} hint="your coding + AI agent" />
           </>
         )
       case 'switches':


### PR DESCRIPTION
## Summary

- **Server-side model semaphore**: `asyncio.Semaphore(1)` in the MLX server now guards all three model-calling endpoints (`/classify_sessions`, `/v1/chat/completions`, `/summarise`). The Rust-side `llm_gate` resets on daemon restart — confirmed from OO logs that a restart mid-classify let a concurrent worklog synthesis through, causing a 546s classify to race against the worklog and timeout. The server-side semaphore persists across daemon restarts.
- **Worklog timeout 300→900s**: A classify call can take up to ~600s (observed). The old 300s timeout meant the worklog HTTP request expired while queuing. 900s gives enough headroom for the worst-case classify + synthesis.
- **Retry backoff**: 5s / 10s sleep between worklog synth retry attempts to avoid immediately hammering a server that just returned an error.
- **TodayMetrics coding rows**: Fixed `Total` using `agent_s` instead of `coding_s` — detail rows now add up to the headline number (`Your coding + AI solo = Total`).

## Test plan

- [ ] Restart the MLX server; verify `/info` responds
- [ ] Trigger a classify + simultaneous worklog synth; confirm worklog queues (OO traces show sequential, not overlapping, model spans)
- [ ] Verify no 500s on `/summarise` during concurrent classify
- [ ] Check `TodayMetrics` coding breakdown adds up in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)