### PR TITLE
feat(observability): summariser continuity dashboard + install-time auto-import

### DIFF
--- a/scripts/install-openobserve-daemon.sh
+++ b/scripts/install-openobserve-daemon.sh
@@ -221,6 +221,83 @@ _otlp_enabled() {
     return 1
 }
 
+# Provision the bundled dashboards (services/observability/dashboards/*.json)
+# into OpenObserve via its REST API. Idempotent: a dashboard is created only if
+# no dashboard with the same title already exists (create endpoint always mints
+# a fresh dashboardId, so a blind POST on every install would duplicate). Runs
+# only once the service is up and reachable; degrades silently (never fails the
+# install) when OpenObserve is unreachable or export is off.
+_import_dashboards() {
+    local dash_dir
+    dash_dir="$(cd "${SCRIPT_DIR}/.." && pwd)/services/observability/dashboards"
+    [[ -d "${dash_dir}" ]] || return 0
+    OO_EMAIL="${OO_EMAIL}" OO_PASSWORD="${OO_PASSWORD}" python3 - "${dash_dir}" <<'PYEOF'
+import base64, glob, json, os, sys, time, urllib.request, urllib.error
+
+dash_dir = sys.argv[1]
+base = "http://localhost:5080"
+org = "default"
+auth = base64.b64encode(f'{os.environ["OO_EMAIL"]}:{os.environ["OO_PASSWORD"]}'.encode()).decode()
+
+def call(method, path, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        base + path, data=data, method=method,
+        headers={"Authorization": "Basic " + auth, "Content-Type": "application/json"},
+    )
+    try:
+        r = urllib.request.urlopen(req, timeout=15)
+        return r.status, r.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+    except Exception as e:  # connection refused, DNS, timeout, …
+        return None, str(e).encode()
+
+# Wait for the service to accept authenticated requests (just-kickstarted).
+for _ in range(30):
+    st, _b = call("GET", "/config")
+    if st == 200:
+        break
+    time.sleep(1)
+else:
+    print("  ⚠ OpenObserve not reachable — skipping dashboard import (import later by re-running this script)")
+    sys.exit(0)
+
+st, body = call("GET", f"/api/{org}/dashboards")
+if st != 200:
+    print(f"  ⚠ could not list dashboards ({st}) — skipping dashboard import")
+    sys.exit(0)
+existing = set()
+for d in json.loads(body).get("dashboards", []):
+    for v in ("v1", "v2", "v3", "v4", "v5", "v6"):
+        if d.get(v) and d[v].get("title"):
+            existing.add(d[v]["title"])
+
+created = skipped = failed = 0
+for path in sorted(glob.glob(os.path.join(dash_dir, "*.json"))):
+    try:
+        dash = json.load(open(path))
+    except Exception as e:
+        print(f"  ⚠ {os.path.basename(path)}: invalid JSON ({e}) — skipped")
+        failed += 1
+        continue
+    title = dash.get("title", "")
+    if title in existing:
+        skipped += 1
+        continue
+    st, resp = call("POST", f"/api/{org}/dashboards?folder=default", dash)
+    if st in (200, 201):
+        created += 1
+        print(f"  ✓ imported dashboard: {title}")
+    else:
+        failed += 1
+        print(f"  ⚠ failed to import {os.path.basename(path)} ({st}): {resp[:200].decode(errors='replace')}")
+
+print(f"→ dashboards: {created} imported, {skipped} already present, {failed} failed")
+PYEOF
+    return 0
+}
+
 if [[ "${_no_creds}" -eq 0 ]] && _otlp_enabled; then
     echo "→ bootstrap ${LABEL} (OpenObserve Export is enabled in settings)"
     launchctl bootstrap "${GUI_TARGET}" "${PLIST_DEST}"
@@ -228,6 +305,8 @@ if [[ "${_no_creds}" -eq 0 ]] && _otlp_enabled; then
     launchctl kickstart -k "${GUI_TARGET}/${LABEL}"
     echo
     echo "✓ OpenObserve installed and started"
+    echo "→ importing bundled dashboards"
+    _import_dashboards || true
 else
     launchctl disable "${GUI_TARGET}/${LABEL}" 2>/dev/null || true
     echo

--- a/services/observability/dashboards/coding-agent-summariser.json
+++ b/services/observability/dashboards/coding-agent-summariser.json
@@ -1,0 +1,621 @@
+{
+  "version": 8,
+  "title": "Coding-Agent Summariser — Continuity",
+  "description": "Every sealed coding-agent segment turned into a prose summary, newest first. The continuity signal: `prior_present=true` means the segment was summarised WITH the previous burst's summary injected as context (a resumed session reading as one story); `prior_chars` is how much context carried over. Backed by the `summarise_segment` spans (service meridian — the Rust daemon's in-process summariser). Copy a row's trace_id and open it in Traces for the full span. Filter by session UUID or agent above; use Continuity = 'with prior' to see only resumed-session summaries.",
+  "tabs": [
+    {
+      "tabId": "default",
+      "name": "Default",
+      "panels": [
+        {
+          "id": "stat_total",
+          "type": "metric",
+          "title": "Segments summarised",
+          "description": "Total summarise_segment spans in range",
+          "config": {
+            "show_legends": false,
+            "legends_position": null,
+            "decimals": 0.0,
+            "base_map": null,
+            "map_view": null,
+            "no_value_replacement": "0"
+          },
+          "queryType": "sql",
+          "queries": [
+            {
+              "query": "SELECT count(*) as \"y_axis_1\" FROM \"default\" WHERE operation_name='summarise_segment'",
+              "vrlFunctionQuery": "",
+              "customQuery": true,
+              "fields": {
+                "stream": "default",
+                "stream_type": "traces",
+                "x": [],
+                "y": [
+                  {
+                    "label": "Segments",
+                    "alias": "y_axis_1",
+                    "column": "y_axis_1",
+                    "type": "custom",
+                    "color": "#5960b2",
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  }
+                ],
+                "z": [],
+                "breakdown": [],
+                "filter": {
+                  "filterType": "group",
+                  "logicalOperator": "AND",
+                  "conditions": []
+                }
+              },
+              "config": {
+                "promql_legend": "",
+                "layer_type": "scatter",
+                "weight_fixed": 1.0
+              }
+            }
+          ],
+          "layout": {
+            "x": 0,
+            "y": 0,
+            "w": 32,
+            "h": 18,
+            "i": 1
+          }
+        },
+        {
+          "id": "stat_with_prior",
+          "type": "metric",
+          "title": "With continuity",
+          "description": "Segments summarised with the prior burst's summary as context",
+          "config": {
+            "show_legends": false,
+            "legends_position": null,
+            "decimals": 0.0,
+            "base_map": null,
+            "map_view": null,
+            "no_value_replacement": "0"
+          },
+          "queryType": "sql",
+          "queries": [
+            {
+              "query": "SELECT count(*) as \"y_axis_1\" FROM \"default\" WHERE operation_name='summarise_segment' AND prior_present='true'",
+              "vrlFunctionQuery": "",
+              "customQuery": true,
+              "fields": {
+                "stream": "default",
+                "stream_type": "traces",
+                "x": [],
+                "y": [
+                  {
+                    "label": "With continuity",
+                    "alias": "y_axis_1",
+                    "column": "y_axis_1",
+                    "type": "custom",
+                    "color": "#59b27a",
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  }
+                ],
+                "z": [],
+                "breakdown": [],
+                "filter": {
+                  "filterType": "group",
+                  "logicalOperator": "AND",
+                  "conditions": []
+                }
+              },
+              "config": {
+                "promql_legend": "",
+                "layer_type": "scatter",
+                "weight_fixed": 1.0
+              }
+            }
+          ],
+          "layout": {
+            "x": 32,
+            "y": 0,
+            "w": 32,
+            "h": 18,
+            "i": 2
+          }
+        },
+        {
+          "id": "stat_continuity_rate",
+          "type": "metric",
+          "title": "Continuity rate %",
+          "description": "Share of segments that carried prior-burst context",
+          "config": {
+            "show_legends": false,
+            "legends_position": null,
+            "unit": "percent",
+            "decimals": 1.0,
+            "base_map": null,
+            "map_view": null,
+            "no_value_replacement": "0"
+          },
+          "queryType": "sql",
+          "queries": [
+            {
+              "query": "SELECT round(100.0 * sum(CASE WHEN prior_present='true' THEN 1 ELSE 0 END) / count(*), 1) as \"y_axis_1\" FROM \"default\" WHERE operation_name='summarise_segment'",
+              "vrlFunctionQuery": "",
+              "customQuery": true,
+              "fields": {
+                "stream": "default",
+                "stream_type": "traces",
+                "x": [],
+                "y": [
+                  {
+                    "label": "Continuity rate",
+                    "alias": "y_axis_1",
+                    "column": "y_axis_1",
+                    "type": "custom",
+                    "color": "#b29959",
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  }
+                ],
+                "z": [],
+                "breakdown": [],
+                "filter": {
+                  "filterType": "group",
+                  "logicalOperator": "AND",
+                  "conditions": []
+                }
+              },
+              "config": {
+                "promql_legend": "",
+                "layer_type": "scatter",
+                "weight_fixed": 1.0
+              }
+            }
+          ],
+          "layout": {
+            "x": 64,
+            "y": 0,
+            "w": 32,
+            "h": 18,
+            "i": 3
+          }
+        },
+        {
+          "id": "stat_fallback",
+          "type": "metric",
+          "title": "MLX fallback %",
+          "description": "Share summarised by the MLX fallback (primary agent CLI unavailable) — primary-engine health",
+          "config": {
+            "show_legends": false,
+            "legends_position": null,
+            "decimals": 1.0,
+            "base_map": null,
+            "map_view": null,
+            "no_value_replacement": "0",
+            "unit": "percent"
+          },
+          "queryType": "sql",
+          "queries": [
+            {
+              "query": "SELECT round(100.0 * sum(CASE WHEN summary_source='mlx' THEN 1 ELSE 0 END) / count(*), 1) as \"y_axis_1\" FROM \"default\" WHERE operation_name='summarise_segment'",
+              "vrlFunctionQuery": "",
+              "customQuery": true,
+              "fields": {
+                "stream": "default",
+                "stream_type": "traces",
+                "x": [],
+                "y": [
+                  {
+                    "label": "MLX fallback %",
+                    "alias": "y_axis_1",
+                    "column": "y_axis_1",
+                    "type": "custom",
+                    "color": "#9959b2",
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  }
+                ],
+                "z": [],
+                "breakdown": [],
+                "filter": {
+                  "filterType": "group",
+                  "logicalOperator": "AND",
+                  "conditions": []
+                }
+              },
+              "config": {
+                "promql_legend": "",
+                "layer_type": "scatter",
+                "weight_fixed": 1.0
+              }
+            }
+          ],
+          "layout": {
+            "x": 96,
+            "y": 0,
+            "w": 32,
+            "h": 18,
+            "i": 4
+          }
+        },
+        {
+          "id": "stat_avg_summary",
+          "type": "metric",
+          "title": "Avg summary chars",
+          "description": "Mean length of produced summaries (successful only)",
+          "config": {
+            "show_legends": false,
+            "legends_position": null,
+            "decimals": 0.0,
+            "base_map": null,
+            "map_view": null,
+            "no_value_replacement": "0"
+          },
+          "queryType": "sql",
+          "queries": [
+            {
+              "query": "SELECT round(avg(CAST(summary_chars AS DOUBLE))) as \"y_axis_1\" FROM \"default\" WHERE operation_name='summarise_segment' AND is_error='false'",
+              "vrlFunctionQuery": "",
+              "customQuery": true,
+              "fields": {
+                "stream": "default",
+                "stream_type": "traces",
+                "x": [],
+                "y": [
+                  {
+                    "label": "Avg summary chars",
+                    "alias": "y_axis_1",
+                    "column": "y_axis_1",
+                    "type": "custom",
+                    "color": "#59a0b2",
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  }
+                ],
+                "z": [],
+                "breakdown": [],
+                "filter": {
+                  "filterType": "group",
+                  "logicalOperator": "AND",
+                  "conditions": []
+                }
+              },
+              "config": {
+                "promql_legend": "",
+                "layer_type": "scatter",
+                "weight_fixed": 1.0
+              }
+            }
+          ],
+          "layout": {
+            "x": 128,
+            "y": 0,
+            "w": 32,
+            "h": 18,
+            "i": 5
+          }
+        },
+        {
+          "id": "stat_errors",
+          "type": "metric",
+          "title": "Errors",
+          "description": "Segments that failed to summarise (is_error=true)",
+          "config": {
+            "show_legends": false,
+            "legends_position": null,
+            "decimals": 0.0,
+            "base_map": null,
+            "map_view": null,
+            "no_value_replacement": "0"
+          },
+          "queryType": "sql",
+          "queries": [
+            {
+              "query": "SELECT count(*) as \"y_axis_1\" FROM \"default\" WHERE operation_name='summarise_segment' AND is_error='true'",
+              "vrlFunctionQuery": "",
+              "customQuery": true,
+              "fields": {
+                "stream": "default",
+                "stream_type": "traces",
+                "x": [],
+                "y": [
+                  {
+                    "label": "Errors",
+                    "alias": "y_axis_1",
+                    "column": "y_axis_1",
+                    "type": "custom",
+                    "color": "#b25959",
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  }
+                ],
+                "z": [],
+                "breakdown": [],
+                "filter": {
+                  "filterType": "group",
+                  "logicalOperator": "AND",
+                  "conditions": []
+                }
+              },
+              "config": {
+                "promql_legend": "",
+                "layer_type": "scatter",
+                "weight_fixed": 1.0
+              }
+            }
+          ],
+          "layout": {
+            "x": 160,
+            "y": 0,
+            "w": 32,
+            "h": 18,
+            "i": 6
+          }
+        },
+        {
+          "id": "table_all",
+          "type": "table",
+          "title": "All segments (newest first)",
+          "description": "Filter with the Session UUID / Agent / Continuity variables above. 'Prior' = whether the previous burst's summary was injected; 'Prior chars' = how much context carried over. Click any row → opens that trace's spans.",
+          "config": {
+            "show_legends": false,
+            "legends_position": null,
+            "base_map": null,
+            "map_view": null,
+            "drilldown": [
+              {
+                "name": "Open this trace's spans",
+                "type": "byUrl",
+                "targetBlank": true,
+                "findBy": "name",
+                "data": {
+                  "url": "/web/traces?org_identifier=default&stream=default&search_type=ui&search_mode=spans&period=30d&query=${row.field.trace_filter}",
+                  "folder": "",
+                  "dashboard": "",
+                  "tab": "",
+                  "passAllVariables": false,
+                  "variables": []
+                }
+              }
+            ],
+            "wrap_table_cells": false,
+            "table_dynamic_columns": false
+          },
+          "queryType": "sql",
+          "queries": [
+            {
+              "query": "SELECT to_char(to_timestamp_micros(_timestamp + 19800000000),'%Y-%m-%d %H:%M:%S') as \"Time\", substr(session_uuid,1,8) as \"Session\", agent as \"Agent\", prior_present as \"Prior\", prior_chars as \"Prior chars\", transcript_chars as \"Transcript chars\", prompt_chars as \"Prompt chars\", summary_chars as \"Summary chars\", summary_source as \"Engine\", is_error as \"Error\", round(CAST(duration AS DOUBLE)/1000000,2) as \"Time taken (s)\", trace_id as \"trace_id\", encode(concat('trace_id=''', trace_id, ''''),'base64') as \"trace_filter\" FROM \"default\" WHERE operation_name='summarise_segment' AND ('$session_uuid'='' OR session_uuid LIKE '%$session_uuid%') AND ('$agent'='' OR agent LIKE '%$agent%') AND ('$continuity'='' OR prior_present='$continuity') ORDER BY _timestamp DESC",
+              "vrlFunctionQuery": "",
+              "customQuery": true,
+              "fields": {
+                "stream": "default",
+                "stream_type": "traces",
+                "x": [
+                  {
+                    "label": "Time",
+                    "alias": "Time",
+                    "column": "_timestamp",
+                    "type": "custom",
+                    "color": null,
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  },
+                  {
+                    "label": "Session",
+                    "alias": "Session",
+                    "column": "session_uuid",
+                    "type": "custom",
+                    "color": null,
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  },
+                  {
+                    "label": "Agent",
+                    "alias": "Agent",
+                    "column": "agent",
+                    "type": "custom",
+                    "color": null,
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  },
+                  {
+                    "label": "Prior",
+                    "alias": "Prior",
+                    "column": "prior_present",
+                    "type": "custom",
+                    "color": null,
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  },
+                  {
+                    "label": "Prior chars",
+                    "alias": "Prior chars",
+                    "column": "prior_chars",
+                    "type": "custom",
+                    "color": null,
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  },
+                  {
+                    "label": "Transcript chars",
+                    "alias": "Transcript chars",
+                    "column": "transcript_chars",
+                    "type": "custom",
+                    "color": null,
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  },
+                  {
+                    "label": "Prompt chars",
+                    "alias": "Prompt chars",
+                    "column": "prompt_chars",
+                    "type": "custom",
+                    "color": null,
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  },
+                  {
+                    "label": "Summary chars",
+                    "alias": "Summary chars",
+                    "column": "summary_chars",
+                    "type": "custom",
+                    "color": null,
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  },
+                  {
+                    "label": "Engine",
+                    "alias": "Engine",
+                    "column": "summary_source",
+                    "type": "custom",
+                    "color": null,
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  },
+                  {
+                    "label": "Error",
+                    "alias": "Error",
+                    "column": "is_error",
+                    "type": "custom",
+                    "color": null,
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  },
+                  {
+                    "label": "Time taken (s)",
+                    "alias": "Time taken (s)",
+                    "column": "duration",
+                    "type": "custom",
+                    "color": null,
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  },
+                  {
+                    "label": "Trace ID",
+                    "alias": "trace_id",
+                    "column": "trace_id",
+                    "type": "custom",
+                    "color": null,
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  },
+                  {
+                    "label": "trace_filter",
+                    "alias": "trace_filter",
+                    "column": "trace_filter",
+                    "type": "custom",
+                    "color": null,
+                    "args": [],
+                    "isDerived": false,
+                    "havingConditions": []
+                  }
+                ],
+                "y": [],
+                "z": [],
+                "breakdown": [],
+                "filter": {
+                  "filterType": "group",
+                  "logicalOperator": "AND",
+                  "conditions": []
+                }
+              },
+              "config": {
+                "promql_legend": "",
+                "layer_type": "scatter",
+                "weight_fixed": 1.0
+              }
+            }
+          ],
+          "layout": {
+            "x": 0,
+            "y": 18,
+            "w": 192,
+            "h": 40,
+            "i": 7
+          }
+        }
+      ]
+    }
+  ],
+  "variables": {
+    "list": [
+      {
+        "type": "textbox",
+        "name": "session_uuid",
+        "label": "Session UUID",
+        "query_data": null,
+        "value": "",
+        "options": [],
+        "multiSelect": false,
+        "hideOnDashboard": false,
+        "selectAllValueForMultiSelect": "custom",
+        "customMultiSelectValue": [],
+        "escapeSingleQuotes": true
+      },
+      {
+        "type": "textbox",
+        "name": "agent",
+        "label": "Agent",
+        "query_data": null,
+        "value": "",
+        "options": [],
+        "multiSelect": false,
+        "hideOnDashboard": false,
+        "selectAllValueForMultiSelect": "custom",
+        "customMultiSelectValue": [],
+        "escapeSingleQuotes": true
+      },
+      {
+        "type": "custom",
+        "name": "continuity",
+        "label": "Continuity",
+        "query_data": null,
+        "value": "",
+        "options": [
+          {
+            "label": "All",
+            "value": "",
+            "selected": true
+          },
+          {
+            "label": "With prior",
+            "value": "true",
+            "selected": false
+          },
+          {
+            "label": "Fresh burst",
+            "value": "false",
+            "selected": false
+          }
+        ],
+        "multiSelect": false,
+        "hideOnDashboard": false,
+        "selectAllValueForMultiSelect": "custom",
+        "customMultiSelectValue": [],
+        "escapeSingleQuotes": true
+      }
+    ],
+    "showDynamicFilters": true
+  },
+  "defaultDatetimeDuration": {
+    "type": "relative",
+    "relativeTimePeriod": "12h"
+  }
+}


### PR DESCRIPTION
## What

- Adds the **Coding-Agent Summariser — Continuity** OpenObserve dashboard (`services/observability/dashboards/coding-agent-summariser.json`), which surfaces the prior-burst continuity spans the summariser emits: `summariser_prompt` / `summariser_inference` / `summariser_output` (engine used, model, `prior_present`/`prior_chars`, prompt size, fell-back-to-MLX, latency).
- Adds an idempotent `_import_dashboards()` step to `scripts/install-openobserve-daemon.sh` so the bundled dashboards under `services/observability/dashboards/*.json` are auto-provisioned into OpenObserve at install time.

## Why

Continuity injection (the prior segment's summary inlined into the next summarisation) is engine-agnostic — including the MLX fallback — but until now there was no first-class view of whether it actually fired per run. The dashboard makes that observable; the installer hook means a fresh install gets it without manual import.

## Import behaviour

- **Title-deduped** — only creates a dashboard when no dashboard with the same title exists (the create endpoint always mints a fresh id, so a blind POST would duplicate).
- **Waits** for the just-kickstarted service to accept authenticated requests before importing.
- **Degrades silently** — never fails the install when OpenObserve is unreachable or export is disabled; prints a hint to re-run the script later.

## Test

- `cargo fmt` / `clippy` / `test` + UI build/tests pass (pre-push suite green).
- No Rust/TS source changed — shell + dashboard JSON only.