### PR TITLE
feat(ci): build the self-contained MLX runtime tarball on an arm64 runner (Approach C, Step 2)

### DIFF
--- a/.github/workflows/build-mlx-runtime.yml
+++ b/.github/workflows/build-mlx-runtime.yml
@@ -1,0 +1,92 @@
+name: Build MLX runtime
+
+# Builds the self-contained MLX runtime tarball for Approach C
+# (download-and-provision): a python-build-standalone CPython + the MLX venv +
+# the agents package, packed for download into ~/.meridian/runtime/ on first run.
+# The customer machine needs no system Python/Node/uv — only Apple Silicon +
+# macOS >= the floor in the manifest. The ~7 GB model is NOT bundled (downloaded
+# on first request).
+#
+# build (macos-14, arm64) → smoke (macos-15, arm64 — a DIFFERENT machine/OS, so
+# relocation + ABI + deployment-target are exercised on a box that didn't build
+# it) → publish (only on a `runtime-v*` tag) attaches the tarball + manifest to
+# the GitHub release. workflow_dispatch builds + smoke-tests without publishing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Runtime version label (defaults to services/pyproject.toml)"
+        required: false
+        default: ""
+  push:
+    tags: ["runtime-v*"]
+
+permissions:
+  contents: write   # publish job attaches assets to the release
+
+concurrency:
+  group: mlx-runtime-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (macos-14 arm64)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build runtime tarball
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+          # On a tag push, stamp the canonical release-download URL into the manifest.
+          RUNTIME_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: bash scripts/build-mlx-runtime.sh
+
+      - name: Upload runtime artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mlx-runtime
+          path: |
+            dist/meridian-mlx-runtime-*-aarch64.tar.gz
+            dist/runtime-manifest.json
+          if-no-files-found: error
+          retention-days: 7
+
+  smoke:
+    name: Smoke test (macos-15 arm64 — clean machine)
+    needs: build
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download runtime artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: mlx-runtime
+          path: dist
+
+      - name: Smoke test on a fresh extraction
+        run: bash scripts/smoke-test-mlx-runtime.sh dist/meridian-mlx-runtime-*-aarch64.tar.gz
+
+  publish:
+    name: Publish to release
+    needs: smoke
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download runtime artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: mlx-runtime
+          path: dist
+
+      - name: Attach tarball + manifest to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${GITHUB_REF_NAME}" \
+            dist/meridian-mlx-runtime-*-aarch64.tar.gz \
+            dist/runtime-manifest.json \
+            --clobber --repo "${GITHUB_REPOSITORY}"

--- a/.github/workflows/build-mlx-runtime.yml
+++ b/.github/workflows/build-mlx-runtime.yml
@@ -55,9 +55,19 @@ jobs:
           retention-days: 7
 
   smoke:
-    name: Smoke test (macos-15 arm64 — clean machine)
+    name: Smoke test (${{ matrix.os }})
     needs: build
-    runs-on: macos-15
+    # Run on every hosted arm64 macOS version so a deployment-target / ABI /
+    # relocation regression is caught across the supported range — and on boxes
+    # that did NOT build the tarball (build is macos-14). macos-13 is Intel, so
+    # the 13.5 manifest floor itself can't be exercised on hosted runners;
+    # macos-14 (Sonoma) is the closest available. fail-fast off so one version
+    # failing still reports the others.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, macos-15, macos-26]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ dist/
 
 # root release-tooling deps
 /node_modules/
+
+# MLX runtime build scratch (scripts/build-mlx-runtime.sh)
+.mlx-runtime-build/

--- a/scripts/build-mlx-runtime.sh
+++ b/scripts/build-mlx-runtime.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+#
+# Build the self-contained MLX runtime tarball for Approach C (download-and-provision).
+#
+# Produces:
+#   dist/meridian-mlx-runtime-<ver>-aarch64.tar.gz   (CPython + venv + agents pkg + launcher)
+#   dist/runtime-manifest.json                        (version, url, sha256, size, floors)
+#
+# The tarball bundles its OWN python-build-standalone CPython, so the customer
+# machine needs NO system Python/Node/uv — only Apple Silicon + macOS >= the
+# floor below. The ~7 GB model is NOT in here; the server downloads it on first
+# request. Layout matches tray/src-tauri/src/mlx_server.rs::resolve_mlx_command
+# (extracted to ~/.meridian/runtime/ with `tar --strip-components=1`):
+#   meridian-mlx-runtime/bin/python        ← invoked by the tray
+#   meridian-mlx-runtime/lib/.../site-packages/{mlx,mlx_lm,outlines,fastapi,agents,…}
+#   meridian-mlx-runtime/server.py         ← thin launcher (resolver looks for this)
+#
+# MUST run on an arm64 runner. The venv is built WITH the bundled interpreter
+# (ABI match) — never the runner's system Python. See the Step-2 portability
+# notes in the PR. Run from the repo root.
+set -euo pipefail
+
+# ── Parameters (env-overridable) ─────────────────────────────────────────────
+PY_SERIES="${PY_SERIES:-3.11}"                       # matches requires-python >= 3.11
+# MLX/Metal floor — the binding macOS constraint (PBS itself goes back to 11).
+# Anything that compiles from source inherits this; prebuilt wheels carry their own.
+export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-13.5}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SERVICES_DIR="${REPO_ROOT}/services"
+DIST="${REPO_ROOT}/dist"
+BUILD="${REPO_ROOT}/.mlx-runtime-build"
+RUNTIME_NAME="meridian-mlx-runtime"
+
+VERSION="${VERSION:-$(grep -m1 '^version' "${SERVICES_DIR}/pyproject.toml" | sed -E 's/.*"([^"]+)".*/\1/')}"
+TARBALL="${RUNTIME_NAME}-${VERSION}-aarch64.tar.gz"
+
+# Where the asset will live once published (filled by the workflow on a tag).
+# RUNTIME_TAG + GITHUB_REPOSITORY → the canonical release-download URL the app fetches.
+DOWNLOAD_URL="${RUNTIME_DOWNLOAD_URL:-}"
+if [[ -z "${DOWNLOAD_URL}" && -n "${RUNTIME_TAG:-}" && -n "${GITHUB_REPOSITORY:-}" ]]; then
+    DOWNLOAD_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RUNTIME_TAG}/${TARBALL}"
+fi
+
+echo "→ building ${TARBALL}"
+echo "  python series   : ${PY_SERIES}"
+echo "  deployment floor: macOS ${MACOSX_DEPLOYMENT_TARGET}"
+echo "  arch            : $(uname -m) (must be arm64)"
+[[ "$(uname -m)" == "arm64" ]] || { echo "✗ must build on an arm64 runner (got $(uname -m))" >&2; exit 1; }
+
+rm -rf "${BUILD}" && mkdir -p "${BUILD}" "${DIST}"
+
+# ── 1. Fetch a relocatable python-build-standalone CPython (install_only) ─────
+# Resolve the install_only aarch64-apple-darwin asset for PY_SERIES from PBS's
+# latest release. Pin by setting PBS_ASSET_URL to bypass this lookup.
+PBS_ASSET_URL="${PBS_ASSET_URL:-}"
+if [[ -z "${PBS_ASSET_URL}" ]]; then
+    echo "→ resolving latest python-build-standalone ${PY_SERIES} (aarch64, install_only)"
+    PBS_JSON="$(curl -fsSL https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest)"
+    PBS_ASSET_URL="$(printf '%s' "${PBS_JSON}" | python3 -c "
+import json, re, sys
+rel = json.load(sys.stdin)
+pat = re.compile(r'^cpython-${PY_SERIES}\.\d+\+\d+-aarch64-apple-darwin-install_only\.tar\.gz$')
+urls = [a['browser_download_url'] for a in rel['assets'] if pat.match(a['name'])]
+if not urls:
+    sys.exit('no matching PBS asset for ${PY_SERIES} aarch64 install_only')
+print(sorted(urls)[-1])
+")"
+fi
+echo "  PBS asset: ${PBS_ASSET_URL}"
+curl -fsSL "${PBS_ASSET_URL}" -o "${BUILD}/python.tar.gz"
+
+# PBS install_only extracts to ./python/ — rename it to the runtime dir.
+tar -xzf "${BUILD}/python.tar.gz" -C "${BUILD}"
+mv "${BUILD}/python" "${BUILD}/${RUNTIME_NAME}"
+RT="${BUILD}/${RUNTIME_NAME}"
+PYBIN="${RT}/bin/python3"
+# The resolver invokes `bin/python` — guarantee that symlink exists.
+[[ -e "${RT}/bin/python" ]] || ln -s python3 "${RT}/bin/python"
+
+echo "→ bundled interpreter: $("${PYBIN}" --version)"
+
+# ── 2. Install the MLX stack + agents package WITH the bundled interpreter ────
+# ABI match is the whole game: the wheels must be built for THIS CPython, so we
+# drive pip through the bundled python — never the runner's system python.
+"${PYBIN}" -m pip install --upgrade --no-cache-dir pip wheel >/dev/null
+# Non-editable install of meridian-agents[mlx,pm_worklog_update] → the `agents`
+# package lands in site-packages, so `import agents` works from any cwd.
+"${PYBIN}" -m pip install --no-cache-dir "${SERVICES_DIR}[mlx,pm_worklog_update]"
+
+# ── 3. Thin launcher at the runtime root (what the resolver looks for) ────────
+cat > "${RT}/server.py" <<'PYEOF'
+# ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+"""Bundled Meridian MLX runtime launcher (Approach C).
+
+The tray invokes `<runtime>/bin/python <runtime>/server.py --port <p>`. `agents`
+is installed as a site-package in this runtime, so the import resolves
+regardless of working directory.
+"""
+from agents.server import main
+
+if __name__ == "__main__":
+    main()
+PYEOF
+
+# ── 4. Trim build-only cruft (keeps the tarball lean; safe — not imported) ────
+find "${RT}" -type d -name "__pycache__" -prune -exec rm -rf {} + 2>/dev/null || true
+find "${RT}" -type d -name "tests" -path "*/site-packages/*" -prune -exec rm -rf {} + 2>/dev/null || true
+
+# ── 5. Pack, hash, and emit the manifest ──────────────────────────────────────
+echo "→ packing ${TARBALL}"
+tar -czf "${DIST}/${TARBALL}" -C "${BUILD}" "${RUNTIME_NAME}"
+
+SHA256="$(shasum -a 256 "${DIST}/${TARBALL}" | awk '{print $1}')"
+SIZE="$(stat -f%z "${DIST}/${TARBALL}" 2>/dev/null || stat -c%s "${DIST}/${TARBALL}")"
+PY_FULL="$("${PYBIN}" -c 'import platform; print(platform.python_version())')"
+
+cat > "${DIST}/runtime-manifest.json" <<EOF
+{
+  "version": "${VERSION}",
+  "arch": "aarch64",
+  "python": "${PY_FULL}",
+  "min_macos": "${MACOSX_DEPLOYMENT_TARGET}",
+  "tarball": "${TARBALL}",
+  "url": "${DOWNLOAD_URL}",
+  "sha256": "${SHA256}",
+  "size": ${SIZE}
+}
+EOF
+
+echo "✓ built ${DIST}/${TARBALL}"
+echo "  size  : $(( SIZE / 1048576 )) MB"
+echo "  sha256: ${SHA256}"
+echo "  manifest: ${DIST}/runtime-manifest.json"

--- a/scripts/smoke-test-mlx-runtime.sh
+++ b/scripts/smoke-test-mlx-runtime.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+#
+# Clean-machine smoke test for the MLX runtime tarball.
+#
+# Extracts the tarball to a FRESH path (deliberately not where it was built),
+# exactly as the app does (`tar --strip-components=1` into ~/.meridian/runtime/),
+# then proves it actually works: import the native stack, boot the server, and
+# hit /health. Green here ⇒ green on a customer's Mac. Catches arch / Python-ABI
+# / macOS-deployment-target / relocation mismatches in one shot — the failures
+# that otherwise only surface on the user's machine.
+#
+# Run on a DIFFERENT runner/macOS version than the build for a real portability
+# check. Usage: scripts/smoke-test-mlx-runtime.sh <path-to-tarball>
+set -euo pipefail
+
+TARBALL="${1:?usage: smoke-test-mlx-runtime.sh <tarball>}"
+PORT="${SMOKE_PORT:-7799}"   # not 7823, so we never collide with a real server
+
+[[ "$(uname -m)" == "arm64" ]] || { echo "✗ smoke test must run on arm64 (got $(uname -m))" >&2; exit 1; }
+echo "→ macOS $(sw_vers -productVersion 2>/dev/null || echo '?')  arch $(uname -m)"
+
+# Extract to a fresh dir, mirroring the app's extraction exactly.
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+RT="${TMP}/runtime"
+mkdir -p "${RT}"
+tar -xzf "${TARBALL}" -C "${RT}" --strip-components=1
+
+PY="${RT}/bin/python"
+[[ -x "${PY}" ]] || { echo "✗ ${PY} missing/not executable after extraction" >&2; exit 1; }
+echo "→ interpreter: $("${PY}" --version)"
+
+# 1. Native import check — the relocation/ABI smoke. If mlx loads from a fresh
+#    path on a clean machine, the heavy lifting is proven.
+echo "→ importing native stack…"
+"${PY}" -c "import mlx, mlx_lm, outlines, fastapi, agents; print('  imports ok:', mlx.__name__, mlx_lm.__name__)"
+
+# 2. Boot the server and probe /health (the model lazy-loads on first request,
+#    so this does NOT need the 7 GB download).
+echo "→ booting server on :${PORT}…"
+"${PY}" "${RT}/server.py" --port "${PORT}" >"${TMP}/server.log" 2>&1 &
+SRV_PID=$!
+trap 'kill "${SRV_PID}" 2>/dev/null || true; rm -rf "${TMP}"' EXIT
+
+ok=""
+for i in $(seq 1 40); do
+    sleep 2
+    if ! kill -0 "${SRV_PID}" 2>/dev/null; then
+        echo "✗ server exited during startup; log:" >&2
+        tail -30 "${TMP}/server.log" >&2
+        exit 1
+    fi
+    code="$(curl -s -m 3 -o /dev/null -w '%{http_code}' "http://127.0.0.1:${PORT}/health" 2>/dev/null || echo 000)"
+    if [[ "${code}" == "200" ]]; then
+        echo "✓ /health 200 after ~$(( i * 2 ))s"
+        curl -s "http://127.0.0.1:${PORT}/health"; echo
+        ok="yes"
+        break
+    fi
+done
+
+if [[ -z "${ok}" ]]; then
+    echo "✗ /health never returned 200 within 80s; log:" >&2
+    tail -30 "${TMP}/server.log" >&2
+    exit 1
+fi
+
+echo "✓ runtime smoke test passed"


### PR DESCRIPTION
## Summary
Step 2 of Approach C: a CI pipeline that builds the **download-and-provision runtime** — `meridian-mlx-runtime-<ver>-aarch64.tar.gz` + `runtime-manifest.json`. This is the payload the tray fetches into `~/.meridian/runtime/` on first run. It bundles its **own** `python-build-standalone` CPython, so a customer machine needs **no system Python/Node/uv** — only Apple Silicon + macOS ≥ the manifest floor (13.5). The ~7 GB model stays a separate first-run download.

## Files
- **`scripts/build-mlx-runtime.sh`** — resolves the latest PBS `install_only` aarch64 CPython 3.11; builds the venv **with that bundled interpreter** (ABI match — never the runner's system python); installs `meridian-agents[mlx,pm_worklog_update]`; drops a thin `server.py` launcher at the runtime root (matches `mlx_server.rs`'s resolver); strips pycache/tests; emits tarball + sha256 + manifest. Sets `MACOSX_DEPLOYMENT_TARGET=13.5` so source builds can't raise the floor.
- **`scripts/smoke-test-mlx-runtime.sh`** — extracts to a **fresh** path (exactly as the app does, `--strip-components=1`), imports the native stack, boots the server, asserts `/health` 200.
- **`.github/workflows/build-mlx-runtime.yml`** — `build` (macos-14) → `smoke` (macos-15, a *different* arm64 machine/OS → exercises relocation + ABI + deployment-target on a box that didn't build it) → `publish` to the release on a `runtime-v*` tag. `workflow_dispatch` builds + smoke-tests without publishing.

## Verified locally (M4 Max / macOS 26)
- Built a **165 MB** tarball — Python 3.11.15, all **arm64** wheels (incl. `mlx-metal 0.31.2`), manifest with sha256.
- Smoke test extracted it to a clean temp path; the **bundled** interpreter imported `mlx, mlx_lm, outlines, fastapi, agents` and booted the MLX server to **`/health` 200 in ~2s** — proving the runtime is self-contained and relocatable.

## Notes / follow-ups
- `RUNTIME_TARBALL_URL` in `mlx_server.rs` is still empty — once this workflow publishes a release, point it (or `MERIDIAN_RUNTIME_URL`) at the asset to light up the wizard's download.
- **Step 3** (separate PR): SHA-256 + version verification in `download_runtime()` (the manifest now carries the hash to check against).
- v1 ships the **full** venv (no prune). The `pyarrow`/`pandas`/`transformers` prune is a deliberate follow-up, gated by this smoke test so a dropped import fails CI rather than a customer.
- Stacked on `feat/tray-mlx-supervision` (→ `feat/dmg-onboarding` → `spike/meridian-core`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7jfB95RakvdwJ8hRogrs4