### PR TITLE
chore(deps): pin screenpipe to last MIT release (0.4.6) + CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,27 @@ jobs:
             exit 1
           fi
           echo "OK — no existing migrations were modified, renamed, or deleted."
+
+  # screenpipe relicensed MIT → Commercial on 2026-06-10. 0.4.6 (2026-06-05) is
+  # the last MIT npm release; >= 0.4.17 is Commercial (its "competing product"
+  # clause would then bind our users). Meridian ships zero screenpipe code, so
+  # staying on MIT 0.4.6 keeps the install license-clean. Enforce the pin
+  # server-side so it can't silently drift across the relicense boundary.
+  screenpipe-license-pin:
+    name: screenpipe MIT pin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Assert SCREENPIPE_VERSION stays on the last MIT release (0.4.6)
+        run: |
+          expected="0.4.6"
+          fail=0
+          for f in install.sh scripts/install-from-bundle.sh; do
+            v=$(grep -E '^SCREENPIPE_VERSION=' "$f" | head -1 | cut -d'"' -f2)
+            if [ "$v" != "$expected" ]; then
+              echo "::error file=$f::SCREENPIPE_VERSION='$v' but must be '$expected' — the last MIT npm release. screenpipe >= 0.4.17 is Commercial-licensed; bumping the pin ships users a commercial dependency. Changing this requires legal review (and editing this guard). See the LICENSE PIN comment at the pin."
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ] && echo "OK — screenpipe pinned to the last MIT release ($expected)."

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,14 @@ USE_MLX=1   # MLX inference server is the only backend (powers classify + PM-wor
 MLX_PORT=7823
 # Pinned screenpipe version — the launchd plist expects this exact build
 # (`screenpipe record`). Installed via npm only when screenpipe is absent.
+#
+# ⚠️ LICENSE PIN — DO NOT BUMP past 0.4.6 without legal review.
+# screenpipe relicensed MIT → Commercial on 2026-06-10. 0.4.6 (published
+# 2026-06-05) is the LAST MIT npm release; >= 0.4.17 (2026-06-11+) is under the
+# Commercial license, whose "competing product" clause would then bind our users.
+# Meridian ships zero screenpipe code, so staying on MIT 0.4.6 keeps the whole
+# install license-clean. Bumping this is a deliberate legal decision, not a chore.
+# CI enforces this pin — see .github/workflows/ci.yml `screenpipe-license-pin`.
 SCREENPIPE_VERSION="0.4.6"
 
 # ---------------------------------------------------------------------------

--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -10,6 +10,12 @@
 set -euo pipefail
 
 APP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# ⚠️ LICENSE PIN — DO NOT BUMP past 0.4.6 without legal review.
+# screenpipe relicensed MIT → Commercial on 2026-06-10. 0.4.6 (published
+# 2026-06-05) is the LAST MIT npm release; >= 0.4.17 (2026-06-11+) is Commercial,
+# whose "competing product" clause would then bind our users. Meridian ships zero
+# screenpipe code, so MIT 0.4.6 keeps the install license-clean. Bumping this is a
+# deliberate legal decision. CI enforces it — .github/workflows/ci.yml `screenpipe-license-pin`.
 SCREENPIPE_VERSION="0.4.6"
 MLX_PORT="${MLX_PORT:-7823}"
 UI_PORT="${MERIDIAN_UI_PORT:-3939}"   # dashboard port (override via MERIDIAN_UI_PORT)


### PR DESCRIPTION
## Why
screenpipe relicensed **MIT → Commercial on 2026-06-10**. npm **0.4.6** (published **2026-06-05**) is the **last MIT release**; **≥ 0.4.17** (2026-06-11+) is Commercial, whose "competing product" clause would then bind Meridian's users.

Meridian ships **zero screenpipe code** (external npm/brew install; reads its SQLite DB only), so staying on MIT `0.4.6` keeps the whole install **license-clean**. Confirmed: `screenpipe@0.4.6` is dated 5 days before the relicense.

## The footgun this closes
The pin sat as a bare `SCREENPIPE_VERSION="0.4.6"` with **no rationale** in two install scripts. A routine "bump to latest" would silently ship users a **Commercial-licensed** dependency.

## Changes
- **Document the LICENSE PIN** rationale at both pins (`install.sh`, `scripts/install-from-bundle.sh`).
- **Add a `screenpipe-license-pin` CI job** (mirrors the existing `migration-guard`) that fails the build if the pin drifts off `0.4.6` in either file — server-side, unskippable. Changing the pin now also requires editing the guard, forcing a conscious legal decision.

Verified locally: guard **passes** at 0.4.6, **rejects** 0.4.17.

## Scope
Independent license-hygiene fix, branched off `main` (not part of the DMG/Bucket-1 chain in #321). `npm/` copies are generated by `package-release.sh` from these sources, so fixing the sources covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)