### PR TITLE
feat(setup): port "A · Rail" first-run wizard with on-device model picker

### DIFF
--- a/meridian-core/src/settings.rs
+++ b/meridian-core/src/settings.rs
@@ -45,6 +45,12 @@ pub struct RuntimeSettings {
     pub agent_queue_floor: f64,
     pub llm_prefer_local: bool,
     pub llm_budget_pct: f64,
+    // The on-device classifier model the user chose in the setup wizard, as a
+    // HuggingFace repo id (e.g. "mlx-community/Qwen3.5-9B-OptiQ-4bit"). `None`
+    // (the default) means "let `llm_selector` choose automatically". When set,
+    // the MLX server's `_resolve_model_id()` passes it as the preferred model —
+    // a strong bias that still degrades gracefully if it can't fit Metal budget.
+    pub llm_model_preference: Option<String>,
     pub poll_interval_secs: u64,
     pub jira_update_enabled: bool,
     // OpenObserve OTLP export — all three must be non-empty for export to
@@ -78,6 +84,8 @@ impl Default for RuntimeSettings {
             agent_queue_floor: 0.40,
             llm_prefer_local: true,
             llm_budget_pct: 0.5,
+            // Unset → automatic spec-aware selection (the eval-tuned default).
+            llm_model_preference: None,
             poll_interval_secs: 60,
             jira_update_enabled: true,
             // OpenObserve export is opt-in — off until enabled in Settings (the UI

--- a/services/agents/run_task_linker_mlx.py
+++ b/services/agents/run_task_linker_mlx.py
@@ -101,6 +101,31 @@ _DEFAULT_MLX_MODEL_MIN_RAM_GB = 6.5
 # runtime by llm_selector.select_mlx_model_id() based on available compute.
 _MLX_MODEL_ID_PIN = os.environ.get("MLX_MODEL_ID")
 
+# `~/.meridian/settings.json` — the SAME file the Rust daemon + tray read/write.
+# We read only `llm_model_preference` here: the HuggingFace repo id the user
+# chose in the setup wizard (written by the tray's `set_model_preference`).
+_SETTINGS_PATH = Path(
+    os.environ.get("MERIDIAN_SETTINGS_PATH")
+    or (Path.home() / ".meridian" / "settings.json")
+)
+
+
+def _settings_model_preference() -> "str | None":
+    """Return the user's chosen model HF id from settings.json, or None.
+
+    A blank/absent value means "no preference" → fall through to dynamic
+    selection. Never raises — a malformed or missing file is treated as unset.
+    """
+    try:
+        with _SETTINGS_PATH.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    pref = data.get("llm_model_preference")
+    return pref if isinstance(pref, str) and pref.strip() else None
+
 # Resolved lazily and cached for the process lifetime by _resolve_model_id().
 # Kept as a module attribute (not just a function return) so /info, /v1/models,
 # and the llm_inference span all report the same, truthful id.
@@ -127,12 +152,23 @@ def _resolve_model_id() -> str:
         from agents.llm_selector import (
             APPLE_INTELLIGENCE_ID, resolve_model, select_mlx_model_id,
         )
-        entry = resolve_model(_DEFAULT_MLX_MODEL_ID)
+        # The user's wizard choice (if any) becomes the preferred model; otherwise
+        # fall back to the eval-tuned default. Either way `select_mlx_model_id`
+        # keeps the preference when Metal budget allows and degrades when it can't,
+        # so an over-ambitious choice on a small Mac never OOMs.
+        user_pref = _settings_model_preference()
+        preferred_id = user_pref or _DEFAULT_MLX_MODEL_ID
+        if user_pref:
+            log.info(
+                "run_task_linker_mlx: model preference from settings.json=%s",
+                user_pref,
+            )
+        entry = resolve_model(preferred_id)
         preferred_min_ram = (
             entry["min_ram_gb"] if entry else _DEFAULT_MLX_MODEL_MIN_RAM_GB
         )
         selected = select_mlx_model_id(
-            preferred_hf_id=_DEFAULT_MLX_MODEL_ID,
+            preferred_hf_id=preferred_id,
             preferred_min_ram_gb=preferred_min_ram,
         )
         # Propagate the Apple Intelligence sentinel as-is; fall back to the

--- a/tray/src-tauri/src/commands/setup.rs
+++ b/tray/src-tauri/src/commands/setup.rs
@@ -257,3 +257,152 @@ pub async fn start_mlx_server_cmd(mlx: tauri::State<'_, SharedMlxManager>) -> Re
     }
     mlx_server::start(port, &mlx).await
 }
+
+/// Detected hardware specs for the wizard's "Local intelligence" step. Drives the
+/// real spec panel + the memory gauge (the model's resident footprint is sized
+/// against `ram_gb`), so every number here must be live — never fabricated.
+#[derive(Debug, Serialize, Default)]
+pub struct SystemSpecs {
+    /// Marketing chip name, e.g. "Apple M3 Pro" (empty if undetectable).
+    pub chip: String,
+    /// "macOS <version>", e.g. "macOS 15.5".
+    pub macos: String,
+    /// Physical CPU core count (`hw.physicalcpu`).
+    pub cpu_cores: u32,
+    /// GPU core count parsed from `system_profiler` (0 when unknown).
+    pub gpu_cores: u32,
+    /// Unified memory in whole GB (`hw.memsize`, rounded).
+    pub ram_gb: u32,
+    /// Free space in whole GB on the data volume (0 when undetectable).
+    pub free_disk_gb: u32,
+}
+
+/// Probe this Mac's chip, core counts, unified memory, and free disk for the
+/// wizard's Local-intelligence step. macOS-only — all reads are non-privileged
+/// (`sysctl`, `sw_vers`, `system_profiler`, `df`); on other platforms the wizard
+/// gets `SystemSpecs::default()` (all zeros) and degrades to a generic panel.
+///
+/// Runs the shell-outs on a blocking thread (`system_profiler` can take ~1 s) so
+/// the async runtime isn't stalled during the one-time wizard probe.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn detect_system_specs() -> SystemSpecs {
+    #[cfg(target_os = "macos")]
+    {
+        let specs = tokio::task::spawn_blocking(detect_specs_blocking)
+            .await
+            .unwrap_or_default();
+        tracing::info!(
+            chip = %specs.chip,
+            cpu_cores = specs.cpu_cores,
+            gpu_cores = specs.gpu_cores,
+            ram_gb = specs.ram_gb,
+            free_disk_gb = specs.free_disk_gb,
+            "setup: system specs detected"
+        );
+        specs
+    }
+    #[cfg(not(target_os = "macos"))]
+    SystemSpecs::default()
+}
+
+#[cfg(target_os = "macos")]
+fn detect_specs_blocking() -> SystemSpecs {
+    use std::process::Command;
+
+    // Trim a command's stdout to a clean single-line String ("" on any failure).
+    let run = |bin: &str, args: &[&str]| -> String {
+        Command::new(bin)
+            .args(args)
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_default()
+    };
+
+    let chip = run("sysctl", &["-n", "machdep.cpu.brand_string"]);
+    let macos_ver = run("sw_vers", &["-productVersion"]);
+    let macos = if macos_ver.is_empty() {
+        String::new()
+    } else {
+        format!("macOS {macos_ver}")
+    };
+    let cpu_cores: u32 = run("sysctl", &["-n", "hw.physicalcpu"])
+        .parse()
+        .unwrap_or(0);
+    let mem_bytes: u64 = run("sysctl", &["-n", "hw.memsize"]).parse().unwrap_or(0);
+    // Round to the nearest whole GB (16 GB reports as 17179869184 bytes ≈ 16.0).
+    let ram_gb = ((mem_bytes as f64) / 1e9).round() as u32;
+
+    // GPU cores live in `system_profiler SPDisplaysDataType` as a
+    // "Total Number of Cores: <n>" line on Apple Silicon.
+    let gpu_cores = run("system_profiler", &["SPDisplaysDataType"])
+        .lines()
+        .find_map(|l| {
+            let l = l.trim();
+            l.strip_prefix("Total Number of Cores:")
+                .and_then(|n| n.trim().parse::<u32>().ok())
+        })
+        .unwrap_or(0);
+
+    // Free space on the user-data volume. `df -k` prints 1 K-blocks; column 4 is
+    // available. Parse the data row (the 2nd line of output).
+    let free_disk_gb = run("df", &["-k", "/System/Volumes/Data"])
+        .lines()
+        .nth(1)
+        .and_then(|row| row.split_whitespace().nth(3))
+        .and_then(|kb| kb.parse::<u64>().ok())
+        .map(|kb| ((kb as f64) * 1024.0 / 1e9).round() as u32)
+        .unwrap_or(0);
+
+    SystemSpecs {
+        chip,
+        macos,
+        cpu_cores,
+        gpu_cores,
+        ram_gb,
+        free_disk_gb,
+    }
+}
+
+/// Persist the user's on-device model choice (a HuggingFace repo id) to
+/// `settings.json`'s `llm_model_preference`, so the MLX server's
+/// `_resolve_model_id()` prefers it on the next load + the next `prefetch_model`.
+/// Pass `None` (or an empty string) to clear the preference → automatic
+/// spec-aware selection. Uses the raw read/write helpers so every other settings
+/// key round-trips untouched.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn set_model_preference(model_id: Option<String>) -> Result<(), String> {
+    let mut v = meridian_core::settings::read_settings_value();
+    let cleaned = model_id.filter(|s| !s.trim().is_empty());
+    if let Some(obj) = v.as_object_mut() {
+        obj.insert(
+            "llm_model_preference".to_string(),
+            cleaned
+                .clone()
+                .map(serde_json::Value::String)
+                .unwrap_or(serde_json::Value::Null),
+        );
+    }
+    meridian_core::settings::write_settings_value(&v).map_err(|e| {
+        tracing::warn!(error = %e, "set_model_preference: write failed");
+        e.to_string()
+    })?;
+    tracing::info!(model = ?cleaned, "setup: model preference written");
+    Ok(())
+}
+
+/// Read the persisted model preference (HF repo id), or `None` when unset /
+/// blank. The wizard calls this on the Model step to pre-select the matching
+/// tile after a relaunch.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn get_model_preference() -> Option<String> {
+    meridian_core::settings::read_settings_value()
+        .get("llm_model_preference")
+        .and_then(|x| x.as_str())
+        .map(str::to_string)
+        .filter(|s| !s.is_empty())
+}

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -313,6 +313,9 @@ pub fn run() {
             commands::start_mlx_server_cmd,
             commands::download_runtime_cmd,
             commands::prefetch_model_cmd,
+            commands::detect_system_specs,
+            commands::set_model_preference,
+            commands::get_model_preference,
         ])
         .run(tauri::generate_context!())
         .expect("error running meridian tray");

--- a/tray/src-tauri/src/tray.rs
+++ b/tray/src-tauri/src/tray.rs
@@ -130,9 +130,11 @@ pub(crate) fn open_wizard_window(app: &tauri::AppHandle) {
         let _ = win.set_focus();
         return;
     }
+    // The wizard renders the "A · Rail" shell (a 948×628 onboarding window with a
+    // left step rail); size the host window to fit it with a little breathing room.
     if let Err(e) = WebviewWindowBuilder::new(app, "setup", WebviewUrl::App("setup".into()))
         .title("Meridian — Setup")
-        .inner_size(560.0, 660.0)
+        .inner_size(980.0, 660.0)
         .resizable(false)
         .build()
     {

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -45,6 +45,8 @@
   --success:      #2D7A4F;
   --warn:         #A36A1A;
   --tint:         rgba(196, 130, 42, 0.07);
+  /* Floating-window shadow — used by the setup wizard's onboarding card. */
+  --pop-shadow:   0 1px 1px rgba(0,0,0,.04), 0 18px 40px -10px rgba(20,18,14,.28), 0 44px 88px -18px rgba(20,18,14,.34);
 }
 
 /* ── Palette — dark ──────────────────────────────────────────────────────── */
@@ -64,6 +66,7 @@ html.dark {
   --success:      #5AB87A;
   --warn:         #D4A044;
   --tint:         rgba(212, 148, 46, 0.08);
+  --pop-shadow:   0 1px 1px rgba(0,0,0,.4), 0 18px 40px -10px rgba(0,0,0,.6), 0 48px 90px -18px rgba(0,0,0,.66);
 }
 
 /* ── Base ────────────────────────────────────────────────────────────────── */
@@ -139,6 +142,13 @@ body, .font-sans {
 .rise { animation: mer-rise .4s cubic-bezier(.16,1,.3,1) both; }
 
 @keyframes spin { to { transform: rotate(360deg); } }
+
+/* Setup wizard — spinner + pop-in (the design's mer-spin / mer-pop). */
+@keyframes mer-spin { to { transform: rotate(360deg); } }
+.mer-spin { animation: mer-spin .8s linear infinite; }
+
+@keyframes mer-pop { from { opacity: 0; transform: scale(.82); } to { opacity: 1; transform: scale(1); } }
+.mer-pop { animation: mer-pop .32s cubic-bezier(.2,.7,.2,1) both; }
 
 /* ── Utility ─────────────────────────────────────────────────────────────── */
 .tnum { font-variant-numeric: tabular-nums; }

--- a/ui/app/setup/atoms.tsx
+++ b/ui/app/setup/atoms.tsx
@@ -1,0 +1,122 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+'use client'
+
+// Shared presentational atoms for the setup wizard (ported from the design's
+// wizard-atoms.jsx). Retokenized onto the product's own CSS variables
+// (globals.css) so the wizard matches the dashboard it hands off to — the
+// design's standalone token block is dropped in favour of --accent/--ink/etc.
+
+import type { CSSProperties, ReactNode } from 'react'
+
+// ── Rounded mono glyph mark (apps / integrations) ────────────────────────────
+export function Mark({ mono, color, size = 34, radius }: {
+  mono: string; color: string; size?: number; radius?: number
+}) {
+  return (
+    <span className="inline-flex items-center justify-center font-mono shrink-0"
+      style={{
+        width: size, height: size, borderRadius: radius ?? size * 0.28,
+        background: color + '16', color,
+        fontSize: Math.max(11, size * 0.4), fontWeight: 600, letterSpacing: '-0.02em',
+      }}>{mono}</span>
+  )
+}
+
+// ── Monoline permission icons (basic shapes only) ────────────────────────────
+export function PermIcon({ icon, size = 18 }: { icon: string; size?: number }) {
+  const c = { width: size, height: size }
+  const s = { fill: 'none', stroke: 'currentColor', strokeWidth: 1.4, strokeLinecap: 'round', strokeLinejoin: 'round' } as const
+  if (icon === 'access')
+    return (<svg viewBox="0 0 18 18" style={c}><circle cx="9" cy="5" r="2.2" {...s} /><path d="M3.5 15c0-3 2.5-5 5.5-5s5.5 2 5.5 5" {...s} /></svg>)
+  if (icon === 'screen')
+    return (<svg viewBox="0 0 18 18" style={c}><rect x="2.5" y="3.5" width="13" height="8.5" rx="1.4" {...s} /><path d="M6.5 15h5M9 12v3" {...s} /></svg>)
+  if (icon === 'power')
+    return (<svg viewBox="0 0 18 18" style={c}><path d="M9 3v6" {...s} /><path d="M5.5 5.5a5 5 0 1 0 7 0" {...s} /></svg>)
+  return null
+}
+
+// ── Check + spinner ──────────────────────────────────────────────────────────
+export function Check({ size = 14, color = 'currentColor', w = 2 }: { size?: number; color?: string; w?: number }) {
+  return (<svg width={size} height={size} viewBox="0 0 16 16" fill="none"
+    stroke={color} strokeWidth={w} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+    <path d="M3.5 8.5 6.5 11.5 12.5 5" /></svg>)
+}
+
+export function Spinner({ size = 14, width = 1.6, color = 'var(--accent)' }: { size?: number; width?: number; color?: string }) {
+  return (
+    <span className="mer-spin inline-block" style={{ width: size, height: size }} aria-hidden>
+      <svg width={size} height={size} viewBox="0 0 16 16" fill="none">
+        <circle cx="8" cy="8" r="6.2" stroke="currentColor" strokeOpacity="0.18" strokeWidth={width} />
+        <path d="M8 1.8a6.2 6.2 0 0 1 6.2 6.2" stroke={color} strokeWidth={width} strokeLinecap="round" />
+      </svg>
+    </span>
+  )
+}
+
+// ── Button ───────────────────────────────────────────────────────────────────
+export function Btn({ children, variant = 'primary', size = 'md', disabled, onClick, style, title }: {
+  children: ReactNode
+  variant?: 'primary' | 'secondary' | 'ghost' | 'soft'
+  size?: 'sm' | 'md'
+  disabled?: boolean
+  onClick?: () => void
+  style?: CSSProperties
+  title?: string
+}) {
+  const base: CSSProperties = {
+    display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 7,
+    padding: size === 'sm' ? '6px 12px' : '9px 18px', fontSize: size === 'sm' ? 12 : 13,
+    fontWeight: 500, borderRadius: 9, lineHeight: 1, whiteSpace: 'nowrap',
+    transition: 'all .14s', cursor: disabled ? 'default' : 'pointer',
+    border: '0.5px solid transparent',
+  }
+  const skins: Record<string, CSSProperties> = {
+    primary: { background: 'var(--accent)', color: '#fff', boxShadow: '0 1px 2px rgba(0,0,0,.12)' },
+    secondary: { background: 'var(--surface)', color: 'var(--ink)', borderColor: 'var(--rule-2)' },
+    ghost: { background: 'transparent', color: 'var(--ink-3)' },
+    soft: { background: 'var(--accent-soft)', color: 'var(--accent)' },
+  }
+  const dim: CSSProperties | null = disabled ? { opacity: 0.4, filter: 'saturate(.6)' } : null
+  return (
+    <button title={title} onClick={disabled ? undefined : onClick} disabled={disabled}
+      style={{ ...base, ...skins[variant], ...dim, ...style }}
+      onMouseEnter={(e) => { if (disabled) return
+        if (variant === 'primary') e.currentTarget.style.filter = 'brightness(1.06)'
+        else e.currentTarget.style.background = 'var(--surface-2)' }}
+      onMouseLeave={(e) => { if (disabled) return
+        e.currentTarget.style.filter = 'none'
+        if (variant !== 'primary') e.currentTarget.style.background = String(skins[variant].background) }}>
+      {children}
+    </button>
+  )
+}
+
+// ── Progress bar ─────────────────────────────────────────────────────────────
+export function Bar({ pct, height = 6, track = 'var(--rule)', fill = 'var(--accent)' }: {
+  pct: number; height?: number; track?: string; fill?: string
+}) {
+  return (
+    <div style={{ height, borderRadius: 99, background: track, overflow: 'hidden', width: '100%' }}>
+      <div style={{ width: `${Math.max(0, Math.min(100, pct))}%`, height: '100%', borderRadius: 99,
+        background: fill, transition: 'width .25s linear' }} />
+    </div>
+  )
+}
+
+// ── Kicker / eyebrow label ───────────────────────────────────────────────────
+export function Kicker({ children, color = 'var(--ink-3)', style }: { children: ReactNode; color?: string; style?: CSSProperties }) {
+  return (<p className="font-mono" style={{ fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color, ...style }}>{children}</p>)
+}
+
+// ── Bordered row tile (permission + integration + runtime rows) ──────────────
+export function Row({ children, tone = 'surface', style }: {
+  children: ReactNode; tone?: 'surface' | 'tint' | 'soft'; style?: CSSProperties
+}) {
+  const bg = tone === 'tint' ? 'var(--tint)' : tone === 'soft' ? 'var(--surface-2)' : 'var(--surface)'
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 13, padding: '13px 15px',
+      border: '0.5px solid var(--rule-2)', borderRadius: 13, background: bg, ...style,
+    }}>{children}</div>
+  )
+}

--- a/ui/app/setup/data.ts
+++ b/ui/app/setup/data.ts
@@ -144,15 +144,6 @@ export const INTEGRATIONS: Integration[] = [
   { id: 'asana',  mono: 'As', color: '#F06A6A', name: 'Asana',         account: 'Coming soon',               oauth: false },
 ]
 
-// ── Dock app marks (decorative, Welcome screen is text-only so unused there) ──
-
-export const APPS: Record<string, { mono: string; color: string }> = {
-  Antigravity: { mono: 'Aᴳ', color: '#7C3AED' },
-  'Google Chrome': { mono: 'Ch', color: '#3B82F6' },
-  Terminal: { mono: '>_', color: '#111827' },
-  Claude: { mono: 'Cl', color: '#D97757' },
-}
-
 /** Whole-GB / MB size label, matching the design's `fmtSize`. */
 export const fmtSize = (gb: number): string =>
   gb < 1 ? `${Math.round(gb * 1000)} MB` : gb < 100 ? `${gb.toFixed(1)} GB` : `${Math.round(gb)} GB`

--- a/ui/app/setup/data.ts
+++ b/ui/app/setup/data.ts
@@ -1,0 +1,158 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+
+// Static content + types for the first-run setup wizard ("A · Rail" shell,
+// ported from the Meridian Setup design). Data only — no React, no side effects.
+// Everything the wizard renders that ISN'T live machine state lives here.
+
+// ── Live backend response shapes (mirror tray/src-tauri/src/commands/setup.rs) ──
+
+/** MLX server status — polled on the Model step (`get_mlx_status`). */
+export type MlxStatus = 'offline' | 'starting' | 'running' | { error: string }
+
+export interface MlxStatusResponse {
+  status: MlxStatus
+  port: number
+  runtime_found: boolean
+  runtime_installed: boolean
+  download_available: boolean
+}
+
+/** Streamed by both the runtime download and the model prefetch. */
+export interface DownloadProgress {
+  received: number
+  total: number
+  message: string
+}
+
+/** Detected hardware (`detect_system_specs`). All-zero on non-macOS / probe failure. */
+export interface SystemSpecs {
+  chip: string
+  macos: string
+  cpu_cores: number
+  gpu_cores: number
+  ram_gb: number
+  free_disk_gb: number
+}
+
+// ── On-device model tiers ────────────────────────────────────────────────────
+// Each tier maps to a REAL MLX checkpoint in the llm_selector catalog
+// (services/agents/llm_selector.py). The picker writes the chosen `hfId` to
+// settings.json via `set_model_preference`; the server then prefers it. We show
+// the real model identity (family · params · quant) — never invented names.
+// `ramGB` is the resident working set from the catalog; `sizeGB` is the
+// approximate 4-bit download size. Both feed the footprint gauge against the
+// machine's real detected memory.
+
+export interface ModelTier {
+  id: 'nano' | 'core' | 'max'
+  label: string      // friendly tier name shown prominently
+  model: string      // real model identity (mono sub-line)
+  spec: string       // params · quant
+  hfId: string       // HuggingFace repo id persisted as the preference
+  sizeGB: number     // approx download size
+  ramGB: number      // resident working set (catalog min_ram_gb)
+  speed: string      // rough tok/s on Apple Silicon
+  recommended?: boolean
+  blurb: string
+}
+
+export const MODELS: ModelTier[] = [
+  {
+    id: 'nano', label: 'Compact', model: 'Qwen3.5 4B', spec: '4B · 4-bit',
+    hfId: 'mlx-community/Qwen3.5-4B-MLX-4bit',
+    sizeGB: 2.2, ramGB: 2.5, speed: '~75 tok/s',
+    blurb: 'Fastest and lightest. Great on 8 GB Macs.',
+  },
+  {
+    id: 'core', label: 'Balanced', model: 'Qwen3.5 9B', spec: '9B · 4-bit',
+    hfId: 'mlx-community/Qwen3.5-9B-OptiQ-4bit',
+    sizeGB: 5.0, ramGB: 6.5, speed: '~48 tok/s', recommended: true,
+    blurb: "Tuned for Meridian's classifier. Best balance for Apple Silicon.",
+  },
+  {
+    id: 'max', label: 'Maximum', model: 'Phi-4 14B', spec: '14B · 4-bit',
+    hfId: 'mlx-community/phi-4-4bit',
+    sizeGB: 8.0, ramGB: 8.5, speed: '~30 tok/s',
+    blurb: 'Highest accuracy. Needs 16 GB+ unified memory.',
+  },
+]
+
+export const MODEL_BY_ID: Record<string, ModelTier> =
+  Object.fromEntries(MODELS.map((m) => [m.id, m]))
+
+/** Meridian's own resident footprint (background service), separate from the model. */
+export const APP = { diskGB: 0.18, ramGB: 0.15 }
+
+/**
+ * The tier best suited to a machine's unified memory — drives the default
+ * selection's "Best for you" badge. `core` is the classifier-tuned default and
+ * the safe fallback when specs are unknown (ramGB === 0).
+ */
+export function recommendTier(ramGB: number): ModelTier['id'] {
+  if (ramGB >= 32) return 'max'
+  if (ramGB >= 16) return 'core'
+  if (ramGB > 0) return 'nano'
+  return 'core'
+}
+
+// ── macOS permissions — the three the backend actually requires + polls ───────
+// (The design's Notifications + Launch-at-login toggles are intentionally
+// omitted: no backend exists for them, and the in-process capture pipeline
+// genuinely needs Input Monitoring, which the design omitted.)
+
+export interface PermissionMeta {
+  id: 'screen' | 'accessibility' | 'input'
+  icon: 'screen' | 'access' | 'power'
+  name: string
+  pane: string      // open_permission_pane argument
+  desc: string
+}
+
+export const PERMISSIONS: PermissionMeta[] = [
+  {
+    id: 'accessibility', icon: 'access', name: 'Accessibility', pane: 'accessibility',
+    desc: 'Reads the active app, window titles, and UI labels for accurate context.',
+  },
+  {
+    id: 'screen', icon: 'screen', name: 'Screen Recording', pane: 'screen_recording',
+    desc: 'Reads on-screen text to understand your work. Frames stay on-device, never stored.',
+  },
+  {
+    id: 'input', icon: 'power', name: 'Input Monitoring', pane: 'input_monitoring',
+    desc: 'Detects clicks and typing so Meridian knows when you switch tasks.',
+  },
+]
+
+// ── Project-management integrations ──────────────────────────────────────────
+// Only jira + trello have a real OAuth flow (`start_oauth`). The rest render in
+// the same style but explicitly disabled — never wired to error on click.
+
+export interface Integration {
+  id: string
+  mono: string
+  color: string
+  name: string
+  account: string
+  oauth: boolean    // true → real start_oauth/get_oauth_status flow
+}
+
+export const INTEGRATIONS: Integration[] = [
+  { id: 'jira',   mono: 'Ji', color: '#2684FF', name: 'Jira',          account: 'Authorize in your browser', oauth: true },
+  { id: 'trello', mono: 'Tr', color: '#0079BF', name: 'Trello',        account: 'Authorize in your browser', oauth: true },
+  { id: 'linear', mono: 'Li', color: '#5E6AD2', name: 'Linear',        account: 'Coming soon',               oauth: false },
+  { id: 'github', mono: 'Gh', color: '#181717', name: 'GitHub Issues', account: 'Coming soon',               oauth: false },
+  { id: 'asana',  mono: 'As', color: '#F06A6A', name: 'Asana',         account: 'Coming soon',               oauth: false },
+]
+
+// ── Dock app marks (decorative, Welcome screen is text-only so unused there) ──
+
+export const APPS: Record<string, { mono: string; color: string }> = {
+  Antigravity: { mono: 'Aᴳ', color: '#7C3AED' },
+  'Google Chrome': { mono: 'Ch', color: '#3B82F6' },
+  Terminal: { mono: '>_', color: '#111827' },
+  Claude: { mono: 'Cl', color: '#D97757' },
+}
+
+/** Whole-GB / MB size label, matching the design's `fmtSize`. */
+export const fmtSize = (gb: number): string =>
+  gb < 1 ? `${Math.round(gb * 1000)} MB` : gb < 100 ? `${gb.toFixed(1)} GB` : `${Math.round(gb)} GB`

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -1,405 +1,298 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 'use client'
 
-// The onboarding wizard — the first Next route rendered inside a Tauri window
-// (the "setup" window opened from tray.rs::open_wizard_window). Talks to Rust
-// exclusively over the Tauri `invoke` bridge — no /api fetch, no Node server.
+// The first-run onboarding wizard — the "A · Rail" shell from the Meridian Setup
+// design, wired to the real backend. Renders inside the Tauri "setup" window
+// (tray.rs::open_wizard_window) and talks to Rust exclusively over the `invoke`
+// bridge. Presentation comes from the design (atoms/steps/data); behaviour —
+// permission polling, MLX status + download, hardware specs, model selection,
+// OAuth — is all live. No fabricated state.
 
-import { useState, useEffect, useRef } from 'react'
-import { invoke, tauri } from '@/lib/bridge'
+import { useState, useEffect, useRef, useCallback } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+import { invoke, mutate, load, tauri } from '@/lib/bridge'
+import { STEPS, Welcome, Completion } from './steps'
+import type { Wiz } from './steps'
+import { MODELS, MODEL_BY_ID } from './data'
+import type { DownloadProgress, MlxStatusResponse, ModelTier, SystemSpecs } from './data'
+import { Btn, Check, Kicker } from './atoms'
 
-const STEPS = ['Welcome', 'Permissions', 'Model', 'Connect', 'Done'] as const
-
-type MlxStatus = 'offline' | 'starting' | 'running' | { error: string }
-
-interface MlxStatusResponse {
-  status: MlxStatus
-  port: number
-  runtime_found: boolean
-  runtime_installed: boolean
-  download_available: boolean
-}
-
-interface DownloadProgress {
-  received: number
-  total: number
-  message: string
-}
+const SERIF: CSSProperties = { fontFamily: 'var(--font-instrument-serif), Georgia, serif' }
+const OAUTH_PROVIDERS = ['jira', 'trello'] as const
 
 export default function SetupWizard() {
+  const [welcome, setWelcome] = useState(true)
   const [step, setStep] = useState(0)
+  const [done, setDone] = useState(false)
   const [err, setErr] = useState('')
-  const last = STEPS.length - 1
 
-  // Step 1: live permission state
-  const [screenGrant, setScreenGrant] = useState<boolean | null>(null)
-  const [a11yGrant, setA11yGrant] = useState<boolean | null>(null)
-  const [inputMonGrant, setInputMonGrant] = useState<boolean | null>(null)
+  // Step 1 — permissions (live)
+  const [perms, setPerms] = useState<Wiz['perms']>({ accessibility: null, screen: null, input: null })
 
-  // Step 2: MLX server state + runtime download
+  // Step 2 — specs + MLX + model
+  const [specs, setSpecs] = useState<SystemSpecs | null>(null)
   const [mlx, setMlx] = useState<MlxStatusResponse | null>(null)
   const [downloading, setDownloading] = useState(false)
-  const [progress, setProgress] = useState<DownloadProgress | null>(null)
-  // Step 2b: eager model prefetch (kicks off once the server is up). The ref
-  // guards one-shot triggering from inside the polling closure (which captures
-  // stale state); `prefetching` drives the progress UI.
   const [prefetching, setPrefetching] = useState(false)
+  const [modelReady, setModelReady] = useState(false)
+  const [progress, setProgress] = useState<DownloadProgress | null>(null)
+  const [model, setModel] = useState<ModelTier['id']>('core')
+  // The user must explicitly commit a model (the Download button) before we
+  // prefetch — otherwise an auto-prefetch would fetch the *default* before they
+  // pick, then a later pick would mislabel the row as "Ready" for a model the
+  // server never loaded. `wantModel` is that commit gate.
+  const [wantModel, setWantModel] = useState(false)
   const prefetchStarted = useRef(false)
 
-  // Poll Screen Recording + Accessibility on step 1
+  // Step 3 — integrations (live OAuth)
+  const [integrations, setIntegrations] = useState<Record<string, 'idle' | 'connecting' | 'connected'>>({})
+
+  const active = !welcome && !done
+
+  // Detect hardware once on mount + restore any persisted model choice. Both are
+  // cheap one-shots; specs are ready by the time the user reaches the Model step.
   useEffect(() => {
-    if (step !== 1) return
+    invoke<SystemSpecs>('detect_system_specs').then(setSpecs).catch(() => {})
+    invoke<string | null>('get_model_preference')
+      .then((id) => { const t = MODELS.find((m) => m.hfId === id); if (t) setModel(t.id) })
+      .catch(() => {})
+  }, [])
+
+  // Poll the three required permissions on the Permissions step.
+  useEffect(() => {
+    if (!active || step !== 0) return
     const poll = async () => {
-      const [sr, ax, im] = await Promise.all([
-        invoke<boolean>('check_screen_recording').catch(() => false),
+      const [accessibility, screen, input] = await Promise.all([
         invoke<boolean>('check_accessibility').catch(() => false),
+        invoke<boolean>('check_screen_recording').catch(() => false),
         invoke<boolean>('check_input_monitoring').catch(() => false),
       ])
-      setScreenGrant(sr)
-      setA11yGrant(ax)
-      setInputMonGrant(im)
+      setPerms({ accessibility, screen, input })
     }
     poll()
     const id = setInterval(poll, 2000)
     return () => clearInterval(id)
-  }, [step])
+  }, [active, step])
 
-  // Poll MLX status on step 2; auto-start only when the runtime is provisioned.
-  // If no runtime is installed yet, the user downloads it via startDownload().
+  // Poll MLX status while on the Model step OR while a commit is in flight (so a
+  // model that's still downloading keeps progressing after the user clicks
+  // Continue). Auto-starts the server when the runtime is present; only prefetches
+  // once the user has committed a model (`wantModel`), guaranteeing the chosen
+  // preference is on disk before the server resolves which model to fetch.
   useEffect(() => {
-    if (step !== 2) return
+    const polling = active && !modelReady && (step === 1 || wantModel || downloading || prefetching)
+    if (!polling) return
     const poll = async () => {
       try {
         const s = await invoke<MlxStatusResponse>('get_mlx_status')
         setMlx(s)
-        if (s.runtime_found && s.status === 'offline') {
-          invoke('start_mlx_server_cmd').catch(() => {})
-        }
-        // Server up → eagerly prefetch the spec-aware model (once). The download
-        // runs server-side, so it continues in the background after Continue;
-        // the model is only needed at the first classification.
-        if (s.status === 'running' && !prefetchStarted.current) {
+        if (s.runtime_found && s.status === 'offline') invoke('start_mlx_server_cmd').catch(() => {})
+        if (wantModel && s.status === 'running' && !prefetchStarted.current) {
           prefetchStarted.current = true
           setPrefetching(true)
           setProgress({ received: 0, total: 0, message: 'Preparing model…' })
           invoke('prefetch_model_cmd')
+            .then(() => setModelReady(true))
             .catch((e) => setErr(String(e)))
             .finally(() => setPrefetching(false))
         }
-      } catch (_) {
-        // no-op: server not yet available
-      }
+      } catch { /* server not yet available */ }
     }
     poll()
     const id = setInterval(poll, 3000)
     return () => clearInterval(id)
-  }, [step])
+  }, [active, step, modelReady, wantModel, downloading, prefetching])
 
-  // Listen for download progress events (shared by the runtime download and the
-  // model prefetch) while either phase is in flight.
+  // Stream download progress (shared by the runtime download + the model prefetch).
   useEffect(() => {
     if (!downloading && !prefetching) return
     let unlisten: (() => void) | undefined
-    tauri()
-      ?.event.listen<DownloadProgress>('mlx-download-progress', (e) => setProgress(e.payload))
-      .then((un) => { unlisten = un })
-      .catch(() => {})
+    tauri()?.event.listen<DownloadProgress>('mlx-download-progress', (e) => setProgress(e.payload))
+      .then((un) => { unlisten = un }).catch(() => {})
     return () => { if (unlisten) unlisten() }
   }, [downloading, prefetching])
 
-  const startDownload = async () => {
+  // Poll OAuth completion on the Integrations step so a browser-completed connect
+  // flips the row to "Connected" without the user clicking again.
+  useEffect(() => {
+    if (!active || step !== 2) return
+    const poll = async () => {
+      for (const provider of OAUTH_PROVIDERS) {
+        const st = await load<{ connected: boolean; error?: string | null }>(
+          `/api/auth/oauth/status?provider=${provider}`, 'get_oauth_status', { provider },
+        ).catch(() => null)
+        if (st?.error) { setErr(st.error); setIntegrations((s) => ({ ...s, [provider]: 'idle' })) }
+        else if (st?.connected) setIntegrations((s) => (s[provider] === 'connected' ? s : { ...s, [provider]: 'connected' }))
+      }
+    }
+    poll()
+    const id = setInterval(poll, 2000)
+    return () => clearInterval(id)
+  }, [active, step])
+
+  // ── Actions ────────────────────────────────────────────────────────────────
+  const openPane = useCallback((pane: string) => {
+    setErr(''); invoke('open_permission_pane', { pane }).catch((e) => setErr(String(e)))
+  }, [])
+
+  // Input Monitoring needs an explicit request to register the app before the
+  // Settings pane shows anything to toggle (mirrors the original wizard).
+  const grantInput = useCallback(async () => {
+    setErr('')
+    try { await invoke('request_input_monitoring') } catch { /* prompt is best-effort */ }
+    invoke('open_permission_pane', { pane: 'input_monitoring' }).catch((e) => setErr(String(e)))
+  }, [])
+
+  const selectModel = useCallback((id: ModelTier['id']) => {
+    setModel(id)
+    invoke('set_model_preference', { modelId: MODEL_BY_ID[id].hfId }).catch(() => {})
+  }, [])
+
+  // Provision the MLX runtime tarball, then bring the server up. No model is
+  // fetched here — that waits for an explicit Download (downloadModel).
+  const installRuntime = useCallback(async () => {
     setErr('')
     setDownloading(true)
     setProgress({ received: 0, total: 0, message: 'Starting…' })
     try {
       await invoke('download_runtime_cmd')
-      // Runtime now provisioned — kick the server. The poll will reflect it.
       invoke('start_mlx_server_cmd').catch(() => {})
-    } catch (e) {
-      setErr(String(e))
-    } finally {
-      setDownloading(false)
-    }
+    } catch (e) { setErr(String(e)) } finally { setDownloading(false) }
+  }, [])
+
+  // Commit the chosen model: persist the preference FIRST, then flag `wantModel`
+  // so the poll prefetches it once the server is running. Writing before the
+  // prefetch is what makes the "Ready" badge truthful about which model loaded.
+  const downloadModel = useCallback(async () => {
+    setErr('')
+    try { await invoke('set_model_preference', { modelId: MODEL_BY_ID[model].hfId }) } catch { /* best-effort */ }
+    invoke('start_mlx_server_cmd').catch(() => {})
+    setWantModel(true)
+    setProgress({ received: 0, total: 0, message: 'Preparing model…' })
+  }, [model])
+
+  const connect = useCallback((id: string) => {
+    setErr('')
+    setIntegrations((s) => ({ ...s, [id]: 'connecting' }))
+    mutate(`/api/auth/oauth/start?provider=${id}`, 'start_oauth', { provider: id })
+      .catch((e) => { setErr(String(e)); setIntegrations((s) => ({ ...s, [id]: 'idle' })) })
+  }, [])
+
+  const wiz: Wiz = {
+    perms, openPane, grantInput,
+    specs, mlx, model, selectModel, downloading, prefetching, modelReady, progress,
+    installRuntime, downloadModel,
+    integrations, connect,
   }
 
-  const openPane = (pane: string) => {
-    setErr('')
-    invoke('open_permission_pane', { pane }).catch((e) => setErr(String(e)))
+  // ── Navigation ───────────────────────────────────────────────────────────────
+  const meta = STEPS[step]
+  const last = step === STEPS.length - 1
+  const goStep = (i: number) => { setErr(''); setWelcome(false); setDone(false); setStep(i) }
+  const finish = async () => {
+    try { await invoke('mark_setup_complete') } catch { /* best-effort */ }
+    setDone(true)
   }
-
-  // Input Monitoring needs an explicit IOHIDRequestAccess to register the app +
-  // surface the prompt (a status read alone leaves the Settings pane empty —
-  // "No Items"). Request first so the app appears, then open the pane to toggle.
-  const grantInputMonitoring = async () => {
-    setErr('')
-    try { await invoke('request_input_monitoring') } catch { /* prompt is best-effort */ }
-    invoke('open_permission_pane', { pane: 'input_monitoring' }).catch((e) => setErr(String(e)))
-  }
-
-  const connectTracker = (provider: string) => {
-    setErr('')
-    invoke('start_oauth', { provider }).catch((e) => setErr(String(e)))
-  }
-
-  const next = async () => {
-    setErr('')
-    if (step === last) {
-      try {
-        await invoke('mark_setup_complete')
-      } catch (_) {
-        // best-effort — don't block the user if the write fails
-      }
-      tauri()?.window.getCurrentWindow().close()
-    } else {
-      setStep(step + 1)
-    }
-  }
+  const closeWindow = () => { tauri()?.window.getCurrentWindow().close() }
 
   return (
-    <div className="flex min-h-screen flex-col">
-      {/* Step rail */}
-      <div className="flex gap-2 px-6 pt-5">
-        {STEPS.map((s, i) => (
-          <div
-            key={s}
-            className={`h-[3px] flex-1 rounded-full transition-colors ${
-              i < step ? 'bg-emerald-500' : i === step ? 'bg-blue-500' : 'bg-current/15'
-            }`}
-          />
-        ))}
+    <div style={{ position: 'fixed', inset: 0, display: 'grid', placeItems: 'center', background: 'var(--paper)' }}>
+      <div className="rise" style={{
+        width: 948, height: 628, borderRadius: 18, background: 'var(--surface)',
+        border: '0.5px solid var(--rule-2)', overflow: 'hidden', color: 'var(--ink)',
+        boxShadow: 'var(--pop-shadow)',
+      }}>
+        {welcome ? (
+          <Welcome onBegin={() => { setWelcome(false); setStep(0) }} />
+        ) : (
+          <div className="flex" style={{ height: '100%' }}>
+            <Rail step={step} done={done} wiz={wiz} goStep={goStep} />
+            <div className="flex flex-col" style={{ flex: 1, minWidth: 0 }}>
+              {done ? (
+                <div className="nice-scroll" style={{ flex: 1, overflowY: 'auto', display: 'grid', placeItems: 'center', padding: '28px 32px' }}>
+                  <div className="flex flex-col items-center">
+                    <Completion wiz={wiz} />
+                    <Btn onClick={closeWindow} style={{ marginTop: 22, padding: '10px 24px', fontSize: 13.5 }}>Open Meridian</Btn>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div style={{ padding: '26px 32px 16px' }}>
+                    <Kicker style={{ marginBottom: 9 }}>{meta.kicker}</Kicker>
+                    <h1 style={{ ...SERIF, fontSize: 27, lineHeight: 1.04, letterSpacing: '-.01em', color: 'var(--ink)' }}>{meta.title}</h1>
+                    <p style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--ink-2)', marginTop: 8, maxWidth: 460, textWrap: 'pretty' }}>{meta.subtitle}</p>
+                  </div>
+                  <div className="nice-scroll" style={{ flex: 1, overflowY: 'auto', padding: '4px 32px 22px' }}>
+                    <meta.Body wiz={wiz} />
+                  </div>
+                  <Footer step={step} last={last} canNext={meta.canNext(wiz)} err={err}
+                    onBack={() => { setErr(''); setStep(Math.max(0, step - 1)) }}
+                    onNext={() => (last ? finish() : (setErr(''), setStep(step + 1)))} />
+                </>
+              )}
+            </div>
+          </div>
+        )}
       </div>
-
-      <main className="flex-1 overflow-y-auto px-8 pt-7 pb-2">
-        {step === 0 && (
-          <section>
-            <h1 className="mb-1.5 text-2xl font-semibold">Welcome to Meridian</h1>
-            <p className="mb-3.5 text-[15px] opacity-60">
-              Meridian watches what you do and keeps your project tickets up to date — automatically,
-              on-device. Let&apos;s get a few things set up. It takes about a minute.
-            </p>
-            <p className="text-[15px] opacity-60">Nothing leaves your Mac unless you connect a tracker at the end.</p>
-          </section>
-        )}
-
-        {step === 1 && (
-          <section>
-            <h1 className="mb-1.5 text-2xl font-semibold">Permissions</h1>
-            <p className="mb-3.5 text-[15px] opacity-70">
-              Meridian needs three macOS permissions. Open each in System Settings and toggle Meridian on.
-            </p>
-            <PermissionCard
-              title="Screen Recording"
-              sub="Reads on-screen text to understand what you're working on."
-              granted={screenGrant}
-              onOpen={() => openPane('screen_recording')}
-            />
-            <PermissionCard
-              title="Accessibility"
-              sub="Reads window titles and UI labels for accurate context."
-              granted={a11yGrant}
-              onOpen={() => openPane('accessibility')}
-            />
-            <PermissionCard
-              title="Input Monitoring"
-              sub="Detects clicks and typing to mark when you switch tasks."
-              granted={inputMonGrant}
-              onOpen={grantInputMonitoring}
-            />
-            {screenGrant && a11yGrant && inputMonGrant && (
-              <p className="mt-3 text-[13px] text-emerald-600 font-medium">
-                All permissions granted — ready to continue.
-              </p>
-            )}
-          </section>
-        )}
-
-        {step === 2 && (
-          <section>
-            <h1 className="mb-1.5 text-2xl font-semibold">On-device model</h1>
-            <p className="mb-3.5 text-[15px] opacity-70">
-              Meridian classifies your work with a local model so nothing is sent to the cloud. The
-              runtime and model download once; the model keeps downloading in the background, so you
-              can continue.
-            </p>
-            <MlxRow
-              mlx={mlx}
-              downloading={downloading}
-              prefetching={prefetching}
-              progress={progress}
-              onDownload={startDownload}
-            />
-          </section>
-        )}
-
-        {step === 3 && (
-          <section>
-            <h1 className="mb-1.5 text-2xl font-semibold">Connect a tracker</h1>
-            <p className="mb-3.5 text-[15px] opacity-70">
-              Connect Jira or Trello so Meridian can update your tickets. Optional — do it later from Settings.
-            </p>
-            <Row title="Jira" sub="Opens a browser to authorize Meridian.">
-              <button
-                onClick={() => connectTracker('jira')}
-                className="rounded-lg border border-current/20 px-3 py-1.5 text-[13px] hover:bg-current/5 transition-colors"
-              >
-                Connect
-              </button>
-            </Row>
-            <Row title="Trello" sub="Opens a browser to authorize Meridian.">
-              <button
-                onClick={() => connectTracker('trello')}
-                className="rounded-lg border border-current/20 px-3 py-1.5 text-[13px] hover:bg-current/5 transition-colors"
-              >
-                Connect
-              </button>
-            </Row>
-            <p className="mt-3 text-[11px] opacity-55">Connecting a tracker is optional — skip with Continue.</p>
-          </section>
-        )}
-
-        {step === 4 && (
-          <section>
-            <h1 className="mb-1.5 text-2xl font-semibold">You&apos;re all set</h1>
-            <p className="mb-3.5 text-[15px] opacity-60">
-              Meridian is running in your menu bar. It&apos;ll start capturing sessions and drafting ticket
-              updates as you work.
-            </p>
-            <p className="text-[15px] opacity-60">Open the dashboard any time from the tray icon.</p>
-          </section>
-        )}
-      </main>
-
-      <footer className="flex items-center justify-between border-t border-current/10 px-8 pb-5 pt-3.5">
-        <button
-          onClick={() => { setErr(''); setStep(Math.max(0, step - 1)) }}
-          className={`rounded-lg border border-current/20 px-4 py-2 text-[14px] ${step === 0 ? 'invisible' : ''}`}
-        >
-          Back
-        </button>
-        <span className="text-xs text-red-600">{err}</span>
-        <button onClick={next} className="rounded-lg bg-blue-500 px-4 py-2 text-[14px] font-medium text-white hover:bg-blue-600 transition-colors">
-          {step === last ? 'Finish' : 'Continue'}
-        </button>
-      </footer>
     </div>
   )
 }
 
-function Row({ title, sub, children }: { title: string; sub: string; children: React.ReactNode }) {
+// ── Left step rail ────────────────────────────────────────────────────────────
+function Rail({ step, done, wiz, goStep }: { step: number; done: boolean; wiz: Wiz; goStep: (i: number) => void }) {
   return (
-    <div className="mb-3 flex items-center gap-3.5 rounded-[10px] border border-current/15 px-4 py-3.5">
-      <div className="flex-1">
-        <div className="font-semibold text-[14px]">{title}</div>
-        <div className="text-xs opacity-60 mt-0.5">{sub}</div>
+    <div className="flex flex-col" style={{ width: 250, flexShrink: 0, background: 'var(--surface-2)', borderRight: '1px solid var(--rule)', padding: '22px 18px' }}>
+      <div style={{ padding: '0 6px', marginBottom: 26 }}>
+        <div className="flex items-center" style={{ gap: 8 }}>
+          <span style={{ width: 8, height: 8, borderRadius: 99, background: 'var(--accent)' }} />
+          <span style={{ ...SERIF, fontSize: 21, lineHeight: 1, letterSpacing: '.01em', color: 'var(--ink)' }}>meridian</span>
+        </div>
       </div>
-      {children}
+      <div className="flex flex-col" style={{ gap: 2 }}>
+        {STEPS.map((s, i) => {
+          const isCur = i === step && !done
+          const reached = done || i <= step
+          const ok = done || i < step
+          return (
+            <button key={s.id} onClick={() => goStep(i)} className="flex items-start"
+              style={{ gap: 12, padding: '10px 8px', borderRadius: 10, textAlign: 'left',
+                background: isCur ? 'var(--tint)' : 'transparent', transition: 'background .14s' }}
+              onMouseEnter={(e) => { if (!isCur) e.currentTarget.style.background = 'var(--surface)' }}
+              onMouseLeave={(e) => { if (!isCur) e.currentTarget.style.background = 'transparent' }}>
+              <span className="flex items-center justify-center font-mono shrink-0" style={{
+                width: 24, height: 24, borderRadius: 99, fontSize: 11, fontWeight: 600, marginTop: 1,
+                background: ok ? 'var(--accent)' : isCur ? 'var(--surface)' : 'transparent',
+                color: ok ? '#fff' : isCur ? 'var(--accent)' : 'var(--ink-4)',
+                border: ok ? 'none' : `1px solid ${isCur ? 'var(--accent)' : 'var(--rule-2)'}`,
+              }}>{ok ? <Check size={13} color="#fff" /> : s.n}</span>
+              <div style={{ minWidth: 0, paddingTop: 1 }}>
+                <p style={{ fontSize: 13, fontWeight: isCur ? 500 : 400, color: reached ? 'var(--ink)' : 'var(--ink-3)' }}>{s.label}</p>
+                <p className="font-mono" style={{ fontSize: 10, color: ok ? 'var(--success)' : 'var(--ink-4)', marginTop: 2, letterSpacing: '.02em' }}>{s.status(wiz)}</p>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+      <div style={{ flex: 1 }} />
+      <p className="font-mono" style={{ fontSize: 10, letterSpacing: '.12em', color: 'var(--ink-4)', padding: '0 8px', textTransform: 'uppercase' }}>First-run setup</p>
     </div>
   )
 }
 
-function PermissionCard({
-  title,
-  sub,
-  granted,
-  onOpen,
-}: {
-  title: string
-  sub: string
-  granted: boolean | null
-  onOpen: () => void
+// ── Footer ────────────────────────────────────────────────────────────────────
+function Footer({ step, last, canNext, err, onBack, onNext }: {
+  step: number; last: boolean; canNext: boolean; err: string; onBack: () => void; onNext: () => void
 }) {
   return (
-    <Row title={title} sub={sub}>
-      {granted === true ? (
-        <span className="rounded-full bg-emerald-500/20 px-2.5 py-1 text-xs font-semibold text-emerald-600">
-          granted
-        </span>
-      ) : (
-        <>
-          <span className="rounded-full bg-orange-500/20 px-2.5 py-1 text-xs font-semibold text-orange-600">
-            required
-          </span>
-          <button
-            onClick={onOpen}
-            className="rounded-lg border border-current/20 px-3 py-1.5 text-[13px] hover:bg-current/5 transition-colors"
-          >
-            Open Settings
-          </button>
-        </>
-      )}
-    </Row>
+    <div className="flex items-center justify-between" style={{ padding: '16px 28px', borderTop: '1px solid var(--rule)', background: 'var(--surface-2)' }}>
+      <Btn variant="ghost" disabled={step === 0} onClick={onBack}><ArrowL />Back</Btn>
+      <span style={{ fontSize: 11, color: 'var(--warn)', flex: 1, textAlign: 'center', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', padding: '0 12px' }}>{err}</span>
+      <Btn variant="primary" disabled={!canNext} onClick={onNext}>
+        {last ? 'Finish setup' : 'Continue'}{!last && <ArrowR />}
+      </Btn>
+    </div>
   )
 }
 
-function MlxRow({
-  mlx,
-  downloading,
-  prefetching,
-  progress,
-  onDownload,
-}: {
-  mlx: MlxStatusResponse | null
-  downloading: boolean
-  prefetching: boolean
-  progress: DownloadProgress | null
-  onDownload: () => void
-}) {
-  // Download in flight — show a progress bar instead of a status badge. Covers
-  // both phases: the runtime tarball, then the eager model prefetch.
-  if (downloading || prefetching) {
-    const pct = progress && progress.total > 0 ? (progress.received / progress.total) * 100 : 0
-    return (
-      <div className="mb-3 rounded-[10px] border border-current/15 px-4 py-3.5">
-        <div className="mb-2 flex items-center justify-between">
-          <span className="font-semibold text-[14px]">{prefetching ? 'Downloading model' : 'Downloading runtime'}</span>
-          <span className="text-xs opacity-60">{progress?.message ?? 'Starting…'}</span>
-        </div>
-        <div className="h-2 overflow-hidden rounded-full bg-current/10">
-          <div
-            className="h-full rounded-full bg-blue-500 transition-all"
-            style={{ width: progress && progress.total > 0 ? `${pct}%` : '100%' }}
-          />
-        </div>
-      </div>
-    )
-  }
-
-  let badge: React.ReactNode
-  let sub: string
-
-  if (!mlx) {
-    badge = <span className="rounded-full bg-current/10 px-2.5 py-1 text-xs opacity-50">checking…</span>
-    sub = 'Checking server status…'
-  } else if (mlx.status === 'running') {
-    badge = <span className="rounded-full bg-emerald-500/20 px-2.5 py-1 text-xs font-semibold text-emerald-600">running</span>
-    sub = `Classifier ready on port ${mlx.port}.`
-  } else if (mlx.status === 'starting') {
-    badge = <span className="rounded-full bg-blue-500/20 px-2.5 py-1 text-xs font-semibold text-blue-600">starting…</span>
-    sub = 'Server is loading the model — this may take a moment on first run.'
-  } else if (mlx.runtime_found) {
-    // Runtime present (downloaded or dev), server just not up yet.
-    badge = <span className="rounded-full bg-current/10 px-2.5 py-1 text-xs opacity-50">offline</span>
-    sub = 'Runtime installed — attempting to start the server…'
-  } else if (mlx.download_available) {
-    // No runtime, but a download is configured — offer the download button.
-    return (
-      <Row
-        title="Classifier model (Qwen3)"
-        sub="Downloads the on-device runtime, then the classifier model (~7 GB) chosen for this Mac. One-time setup; the model finishes in the background."
-      >
-        <button
-          onClick={onDownload}
-          className="rounded-lg bg-blue-500 px-3 py-1.5 text-[13px] font-medium text-white hover:bg-blue-600 transition-colors"
-        >
-          Download
-        </button>
-      </Row>
-    )
-  } else {
-    // No runtime and no download URL configured yet.
-    badge = <span className="rounded-full bg-orange-500/20 px-2.5 py-1 text-xs font-semibold text-orange-600">not available</span>
-    sub = 'The downloadable runtime is not published yet. For dev, run: cd services && uv sync.'
-  }
-
-  return <Row title="Classifier model (Qwen3)" sub={sub}>{badge}</Row>
-}
+const ArrowL = (): ReactNode => (<svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><path d="M10 4 6 8l4 4" /></svg>)
+const ArrowR = (): ReactNode => (<svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><path d="M6 4l4 4-4 4" /></svg>)

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -13,12 +13,14 @@ import type { CSSProperties, ReactNode } from 'react'
 import { invoke, mutate, load, tauri } from '@/lib/bridge'
 import { STEPS, Welcome, Completion } from './steps'
 import type { Wiz } from './steps'
-import { MODELS, MODEL_BY_ID } from './data'
+import { INTEGRATIONS, MODELS, MODEL_BY_ID } from './data'
 import type { DownloadProgress, MlxStatusResponse, ModelTier, SystemSpecs } from './data'
 import { Btn, Check, Kicker } from './atoms'
 
 const SERIF: CSSProperties = { fontFamily: 'var(--font-instrument-serif), Georgia, serif' }
-const OAUTH_PROVIDERS = ['jira', 'trello'] as const
+// Single source of truth for "which trackers have a real OAuth flow".
+const OAUTH_PROVIDERS = INTEGRATIONS.filter((i) => i.oauth).map((i) => i.id)
+const OAUTH_DEADLINE_MS = 180_000  // mirrors TasksView's 3-minute connect window
 
 export default function SetupWizard() {
   const [welcome, setWelcome] = useState(true)
@@ -44,8 +46,10 @@ export default function SetupWizard() {
   const [wantModel, setWantModel] = useState(false)
   const prefetchStarted = useRef(false)
 
-  // Step 3 — integrations (live OAuth)
+  // Step 3 — integrations (live OAuth). `oauthDeadline` holds the per-provider
+  // timeout for an in-flight connect so the poll can resolve an abandoned flow.
   const [integrations, setIntegrations] = useState<Record<string, 'idle' | 'connecting' | 'connected'>>({})
+  const oauthDeadline = useRef<Record<string, number>>({})
 
   const active = !welcome && !done
 
@@ -93,7 +97,13 @@ export default function SetupWizard() {
           setProgress({ received: 0, total: 0, message: 'Preparing model…' })
           invoke('prefetch_model_cmd')
             .then(() => setModelReady(true))
-            .catch((e) => setErr(String(e)))
+            .catch((e) => {
+              setErr(String(e))
+              // Re-arm so the Download button can retry: clear the one-shot guard
+              // and the commit flag, dropping the row back to an actionable state.
+              prefetchStarted.current = false
+              setWantModel(false)
+            })
             .finally(() => setPrefetching(false))
         }
       } catch { /* server not yet available */ }
@@ -113,7 +123,10 @@ export default function SetupWizard() {
   }, [downloading, prefetching])
 
   // Poll OAuth completion on the Integrations step so a browser-completed connect
-  // flips the row to "Connected" without the user clicking again.
+  // flips the row to "Connected" without the user clicking again. A per-provider
+  // deadline (set in `connect`) resolves an abandoned flow to idle+error instead
+  // of spinning "Connecting…" forever, and we only `setErr`/transition on an
+  // actual state change so a persistent error doesn't re-fire every tick.
   useEffect(() => {
     if (!active || step !== 2) return
     const poll = async () => {
@@ -121,8 +134,20 @@ export default function SetupWizard() {
         const st = await load<{ connected: boolean; error?: string | null }>(
           `/api/auth/oauth/status?provider=${provider}`, 'get_oauth_status', { provider },
         ).catch(() => null)
-        if (st?.error) { setErr(st.error); setIntegrations((s) => ({ ...s, [provider]: 'idle' })) }
-        else if (st?.connected) setIntegrations((s) => (s[provider] === 'connected' ? s : { ...s, [provider]: 'connected' }))
+        if (st?.connected) {
+          delete oauthDeadline.current[provider]
+          setIntegrations((s) => (s[provider] === 'connected' ? s : { ...s, [provider]: 'connected' }))
+          continue
+        }
+        // Only act on a provider with an active connect attempt in flight.
+        const deadline = oauthDeadline.current[provider]
+        if (deadline === undefined) continue
+        const reason = st?.error ?? (Date.now() > deadline ? 'Timed out — try again' : null)
+        if (reason) {
+          delete oauthDeadline.current[provider]
+          setErr(reason)
+          setIntegrations((s) => ({ ...s, [provider]: 'idle' }))
+        }
       }
     }
     poll()
@@ -173,14 +198,16 @@ export default function SetupWizard() {
 
   const connect = useCallback((id: string) => {
     setErr('')
+    oauthDeadline.current[id] = Date.now() + OAUTH_DEADLINE_MS
     setIntegrations((s) => ({ ...s, [id]: 'connecting' }))
     mutate(`/api/auth/oauth/start?provider=${id}`, 'start_oauth', { provider: id })
-      .catch((e) => { setErr(String(e)); setIntegrations((s) => ({ ...s, [id]: 'idle' })) })
+      .catch((e) => { delete oauthDeadline.current[id]; setErr(String(e)); setIntegrations((s) => ({ ...s, [id]: 'idle' })) })
   }, [])
 
   const wiz: Wiz = {
     perms, openPane, grantInput,
     specs, mlx, model, selectModel, downloading, prefetching, modelReady, progress,
+    committing: wantModel && !prefetching && !modelReady,
     installRuntime, downloadModel,
     integrations, connect,
   }

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -32,6 +32,7 @@ export interface Wiz {
   selectModel: (id: ModelTier['id']) => void
   downloading: boolean    // runtime tarball in flight
   prefetching: boolean    // model download in flight
+  committing: boolean     // committed (Download clicked) but server not yet running
   modelReady: boolean
   progress: DownloadProgress | null
   installRuntime: () => void  // provision the MLX runtime
@@ -211,7 +212,7 @@ function MLXBody({ wiz }: { wiz: Wiz }) {
       <div style={{ opacity: runtimeInstalled ? 1 : 0.45, pointerEvents: runtimeInstalled ? 'auto' : 'none', transition: 'opacity .25s' }}>
         <div className="flex items-center justify-between" style={{ marginBottom: 7 }}>
           <Kicker>Model</Kicker>
-          {!picking && !wiz.modelReady && !wiz.prefetching && (
+          {!picking && !wiz.modelReady && !wiz.prefetching && !wiz.committing && (
             <button onClick={() => setPicking(true)} style={{ fontSize: 11, color: 'var(--ink-3)' }}
               onMouseEnter={(e) => e.currentTarget.style.color = 'var(--ink)'}
               onMouseLeave={(e) => e.currentTarget.style.color = 'var(--ink-3)'}>Change model</button>
@@ -252,7 +253,7 @@ function MLXBody({ wiz }: { wiz: Wiz }) {
                 <span className="font-mono" style={{ fontSize: 10.5, color: 'var(--ink-3)' }}>{sel.model} · {sel.spec}</span>
                 {sel.recommended && <span className="font-mono" style={{ fontSize: 8.5, letterSpacing: '.08em', color: 'var(--accent)', background: 'var(--accent-soft)', padding: '1px 5px', borderRadius: 4 }}>RECOMMENDED</span>}
               </div>
-              {wiz.prefetching && !wiz.modelReady ? (
+              {(wiz.prefetching || wiz.committing) && !wiz.modelReady ? (
                 <p className="font-mono tnum" style={{ fontSize: 11, color: 'var(--ink-3)', marginTop: 3 }}>
                   {wiz.progress?.message ?? 'Downloading model…'}
                 </p>
@@ -263,9 +264,11 @@ function MLXBody({ wiz }: { wiz: Wiz }) {
             <div className="shrink-0" style={{ minWidth: 100, textAlign: 'right' }}>
               {wiz.modelReady
                 ? <span className="flex items-center justify-end" style={{ gap: 6, fontSize: 12, color: 'var(--success)', fontWeight: 500 }}><Check size={15} color="var(--success)" />Ready</span>
-                : wiz.prefetching
-                  ? <span className="font-mono tnum" style={{ fontSize: 13, color: 'var(--accent)', fontWeight: 600 }}>{pct !== null ? `${pct}%` : '…'}</span>
-                  : <Btn size="sm" onClick={wiz.downloadModel}>Download</Btn>}
+                : wiz.committing
+                  ? <span className="flex items-center justify-end" style={{ gap: 7, fontSize: 11.5, color: 'var(--ink-2)' }}><Spinner />Starting…</span>
+                  : wiz.prefetching
+                    ? <span className="font-mono tnum" style={{ fontSize: 13, color: 'var(--accent)', fontWeight: 600 }}>{pct !== null ? `${pct}%` : '…'}</span>
+                    : <Btn size="sm" onClick={wiz.downloadModel}>Download</Btn>}
             </div>
           </Row>
         )}

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -1,0 +1,457 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+'use client'
+
+// Wizard step bodies + Welcome + Completion + the STEPS meta (ported from the
+// design's steps.jsx). Every body is driven by the live `Wiz` handle built in
+// page.tsx — permissions, MLX status, hardware specs, and OAuth state are all
+// real. Nothing here fabricates data: the spec panel and memory gauge render
+// detected hardware, and the model tiles map to real checkpoints.
+
+import { useState } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+import { Btn, Bar, Check, Kicker, Mark, PermIcon, Row, Spinner } from './atoms'
+import {
+  APP, INTEGRATIONS, MODELS, MODEL_BY_ID, PERMISSIONS, fmtSize, recommendTier,
+} from './data'
+import type {
+  DownloadProgress, Integration, MlxStatusResponse, ModelTier, SystemSpecs,
+} from './data'
+
+const SERIF: CSSProperties = { fontFamily: 'var(--font-instrument-serif), Georgia, serif' }
+
+/** The live wizard handle page.tsx builds and threads to every step body. */
+export interface Wiz {
+  // Step 1 — permissions (live, polled every 2 s)
+  perms: { accessibility: boolean | null; screen: boolean | null; input: boolean | null }
+  openPane: (pane: string) => void
+  grantInput: () => void
+  // Step 2 — local intelligence (live MLX status + detected specs + model choice)
+  specs: SystemSpecs | null
+  mlx: MlxStatusResponse | null
+  model: ModelTier['id']
+  selectModel: (id: ModelTier['id']) => void
+  downloading: boolean    // runtime tarball in flight
+  prefetching: boolean    // model download in flight
+  modelReady: boolean
+  progress: DownloadProgress | null
+  installRuntime: () => void  // provision the MLX runtime
+  downloadModel: () => void   // commit the chosen model, then prefetch it
+  // Step 3 — integrations (live OAuth state)
+  integrations: Record<string, 'idle' | 'connecting' | 'connected'>
+  connect: (id: string) => void
+}
+
+// ── STEP 1 — Permissions ──────────────────────────────────────────────────────
+function PermissionsBody({ wiz }: { wiz: Wiz }) {
+  return (
+    <div className="flex flex-col" style={{ gap: 9 }}>
+      {PERMISSIONS.map((p) => {
+        const granted = !!wiz.perms[p.id]
+        return (
+          <Row key={p.id} tone={granted ? 'tint' : 'surface'}>
+            <span className="flex items-center justify-center shrink-0" style={{
+              width: 34, height: 34, borderRadius: 10,
+              background: granted ? 'var(--accent-soft)' : 'var(--surface-2)',
+              color: granted ? 'var(--accent)' : 'var(--ink-3)',
+              border: '0.5px solid var(--rule-2)',
+            }}><PermIcon icon={p.icon} /></span>
+
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div className="flex items-center" style={{ gap: 8 }}>
+                <span style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--ink)' }}>{p.name}</span>
+                <span className="font-mono" style={{ fontSize: 9, letterSpacing: '.1em', color: 'var(--ink-3)', border: '0.5px solid var(--rule-2)', borderRadius: 4, padding: '1px 5px' }}>REQUIRED</span>
+              </div>
+              <p style={{ fontSize: 11.5, lineHeight: 1.4, color: 'var(--ink-3)', marginTop: 3 }}>{p.desc}</p>
+            </div>
+
+            <div className="shrink-0">
+              {granted
+                ? <span className="flex items-center" style={{ gap: 6, fontSize: 12, color: 'var(--success)', fontWeight: 500 }}><Check size={15} color="var(--success)" />Granted</span>
+                : <Btn size="sm" variant="secondary" onClick={() => p.id === 'input' ? wiz.grantInput() : wiz.openPane(p.pane)}>Open Settings</Btn>}
+            </div>
+          </Row>
+        )
+      })}
+      <p className="flex items-center" style={{ gap: 7, fontSize: 11, color: 'var(--ink-3)', marginTop: 3 }}>
+        <span style={{ width: 5, height: 5, borderRadius: 99, background: 'var(--success)' }} />
+        Everything is processed on your Mac. Meridian has no servers to send to.
+      </p>
+    </div>
+  )
+}
+
+// ── STEP 2 — Local intelligence ──────────────────────────────────────────────
+function SpecCell({ v, l, b }: { v: string | number; l: string; b?: boolean }) {
+  return (
+    <div style={{ padding: '11px 14px', borderRight: b ? '1px solid var(--rule)' : 'none' }}>
+      <p className="font-mono tnum" style={{ fontSize: 19, fontWeight: 500, letterSpacing: '-.02em', color: 'var(--ink)', lineHeight: 1 }}>{v}</p>
+      <p style={{ fontSize: 9.5, letterSpacing: '.08em', textTransform: 'uppercase', color: 'var(--ink-3)', marginTop: 6 }}>{l}</p>
+    </div>
+  )
+}
+function FootStat({ v, l, b }: { v: string; l: string; b?: boolean }) {
+  return (
+    <div style={{ padding: '10px 14px', borderRight: b ? '1px solid var(--rule)' : 'none' }}>
+      <p className="font-mono tnum" style={{ fontSize: 15, fontWeight: 500, letterSpacing: '-.01em', color: 'var(--ink)', lineHeight: 1 }}>{v}</p>
+      <p style={{ fontSize: 9.5, letterSpacing: '.08em', textTransform: 'uppercase', color: 'var(--ink-3)', marginTop: 5 }}>{l}</p>
+    </div>
+  )
+}
+function MemoryGauge({ model, app, total }: { model: number; app: number; total: number }) {
+  const size = 132, sw = 13
+  const cx = size / 2, cy = size / 2
+  const r = (size - sw) / 2 - 1
+  const C = 2 * Math.PI * r
+  const sweep = 0.72
+  const draw = sweep * C
+  const start = 270 - sweep * 180
+  const free = Math.max(0, total - model - app)
+  const modelLen = Math.max(0, (model / total) * draw)
+  const appLen = Math.max((app / total) * draw, app > 0 ? 3 : 0)
+  return (
+    <div style={{ position: 'relative', width: size, height: size, flexShrink: 0 }}>
+      <svg width={size} height={size} style={{ display: 'block' }}>
+        <g transform={`rotate(${start} ${cx} ${cy})`} fill="none" strokeLinecap="round">
+          <circle cx={cx} cy={cy} r={r} stroke="var(--rule)" strokeWidth={sw} strokeDasharray={`${draw} ${C}`} />
+          <circle cx={cx} cy={cy} r={r} stroke="#7C3AED" strokeWidth={sw} strokeDasharray={`${appLen} ${C}`} strokeDashoffset={`${-modelLen}`} style={{ transition: 'stroke-dasharray .4s, stroke-dashoffset .4s' }} />
+          <circle cx={cx} cy={cy} r={r} stroke="var(--accent)" strokeWidth={sw} strokeDasharray={`${modelLen} ${C}`} style={{ transition: 'stroke-dasharray .4s' }} />
+        </g>
+      </svg>
+      <div className="flex flex-col items-center justify-center" style={{ position: 'absolute', inset: 0 }}>
+        <span className="font-mono tnum" style={{ fontSize: 25, fontWeight: 500, letterSpacing: '-.02em', lineHeight: 1, color: 'var(--ink)' }}>
+          {free.toFixed(1)}<span style={{ fontSize: 11, color: 'var(--ink-3)', marginLeft: 2 }}>GB</span>
+        </span>
+        <span style={{ fontSize: 9.5, letterSpacing: '.1em', textTransform: 'uppercase', color: 'var(--ink-3)', marginTop: 5 }}>free of {total} GB</span>
+      </div>
+    </div>
+  )
+}
+function GaugeLegend({ color, label, sub, val }: { color: string; label: string; sub: string; val: string }) {
+  return (
+    <div className="flex items-center" style={{ gap: 9 }}>
+      <span style={{ width: 9, height: 9, borderRadius: 3, background: color, flexShrink: 0 }} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <p style={{ fontSize: 12, color: 'var(--ink)', fontWeight: 450, lineHeight: 1.2 }}>{label}</p>
+        <p style={{ fontSize: 10, color: 'var(--ink-4)', marginTop: 1 }}>{sub}</p>
+      </div>
+      <span className="font-mono tnum" style={{ fontSize: 12, color: 'var(--ink-2)', flexShrink: 0 }}>{val}</span>
+    </div>
+  )
+}
+
+function MLXBody({ wiz }: { wiz: Wiz }) {
+  const [picking, setPicking] = useState(false)
+  const sel = MODEL_BY_ID[wiz.model]
+  const specs = wiz.specs
+  const ram = specs?.ram_gb ?? 0
+  const m = wiz.mlx
+  const runtimeInstalled = !!(m && (m.runtime_found || m.runtime_installed))
+  const machineRec = recommendTier(ram)
+  const pct = wiz.progress && wiz.progress.total > 0 ? Math.round(wiz.progress.received / wiz.progress.total * 100) : null
+
+  const memModel = sel.ramGB, memApp = APP.ramGB
+  const memFree = Math.max(0, ram - memModel - memApp)
+  const tight = ram > 0 && memModel + memApp > ram * 0.85
+
+  return (
+    <div className="flex flex-col" style={{ gap: 14 }}>
+      {/* YOUR MAC — detected specs */}
+      <div>
+        <Kicker style={{ marginBottom: 7 }}>Your Mac</Kicker>
+        <div style={{ border: '0.5px solid var(--rule-2)', borderRadius: 13, overflow: 'hidden', background: 'var(--surface)' }}>
+          <div className="flex items-center" style={{ gap: 11, padding: '12px 15px', borderBottom: '1px solid var(--rule)' }}>
+            <Mark mono="M" color="#7C3AED" size={30} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <p style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--ink)' }}>{specs?.chip || 'Detecting your Mac…'}</p>
+              <p className="font-mono" style={{ fontSize: 10.5, color: 'var(--ink-3)', marginTop: 1 }}>{specs?.macos || '—'}</p>
+            </div>
+            {specs && (specs.chip || ram > 0) && (
+              <span className="flex items-center" style={{ gap: 5, fontSize: 10.5, color: 'var(--success)' }}>
+                <Check size={13} color="var(--success)" />Detected
+              </span>
+            )}
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)' }}>
+            <SpecCell v={specs?.cpu_cores || '—'} l="CPU cores" b />
+            <SpecCell v={specs?.gpu_cores || '—'} l="GPU cores" b />
+            <SpecCell v={ram ? `${ram} GB` : '—'} l="Unified memory" b />
+            <SpecCell v={specs?.free_disk_gb ? `${specs.free_disk_gb} GB` : '—'} l="Free storage" />
+          </div>
+        </div>
+      </div>
+
+      {/* RUNTIME */}
+      <div>
+        <Kicker style={{ marginBottom: 7 }}>Runtime</Kicker>
+        <Row tone={runtimeInstalled ? 'tint' : 'surface'}>
+          <Mark mono="MLX" color="#7C3AED" size={34} />
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <p style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--ink)' }}>Apple MLX runtime</p>
+            <p className="font-mono" style={{ fontSize: 11, color: 'var(--ink-3)', marginTop: 2 }}>
+              {specs?.gpu_cores ? `Accelerated on the ${specs.gpu_cores}-core GPU` : 'GPU-accelerated inference'}
+            </p>
+          </div>
+          <div className="shrink-0" style={{ minWidth: 96, textAlign: 'right' }}>
+            {runtimeInstalled
+              ? <span className="flex items-center justify-end" style={{ gap: 6, fontSize: 12, color: 'var(--success)', fontWeight: 500 }}><Check size={15} color="var(--success)" />Installed</span>
+              : wiz.downloading
+                ? <span className="flex items-center justify-end font-mono tnum" style={{ gap: 7, fontSize: 11.5, color: 'var(--ink-2)' }}><Spinner />{pct !== null ? `${pct}%` : '…'}</span>
+                : m && m.download_available
+                  ? <Btn size="sm" variant="secondary" onClick={wiz.installRuntime}>Install</Btn>
+                  : <span className="font-mono" style={{ fontSize: 11, color: 'var(--warn)' }}>Unavailable</span>}
+          </div>
+        </Row>
+        {wiz.downloading && pct !== null && (
+          <div style={{ marginTop: 8 }}><Bar pct={pct} height={4} /></div>
+        )}
+      </div>
+
+      {/* MODEL — interactive once the runtime is present; until then the picker
+          is dimmed (the server must be up before a model can be fetched). */}
+      <div style={{ opacity: runtimeInstalled ? 1 : 0.45, pointerEvents: runtimeInstalled ? 'auto' : 'none', transition: 'opacity .25s' }}>
+        <div className="flex items-center justify-between" style={{ marginBottom: 7 }}>
+          <Kicker>Model</Kicker>
+          {!picking && !wiz.modelReady && !wiz.prefetching && (
+            <button onClick={() => setPicking(true)} style={{ fontSize: 11, color: 'var(--ink-3)' }}
+              onMouseEnter={(e) => e.currentTarget.style.color = 'var(--ink)'}
+              onMouseLeave={(e) => e.currentTarget.style.color = 'var(--ink-3)'}>Change model</button>
+          )}
+        </div>
+
+        {picking ? (
+          <div className="flex flex-col" style={{ gap: 7 }}>
+            {MODELS.map((mod) => {
+              const on = mod.id === wiz.model
+              return (
+                <button key={mod.id} onClick={() => { wiz.selectModel(mod.id); setPicking(false) }}
+                  style={{ textAlign: 'left', display: 'flex', alignItems: 'center', gap: 12, padding: '11px 13px',
+                    borderRadius: 12, border: `0.5px solid ${on ? 'var(--accent)' : 'var(--rule-2)'}`,
+                    background: on ? 'var(--tint)' : 'var(--surface)', transition: 'all .12s' }}>
+                  <span className="flex items-center justify-center shrink-0" style={{ width: 16, height: 16, borderRadius: 99, border: `1.5px solid ${on ? 'var(--accent)' : 'var(--rule-2)'}` }}>
+                    {on && <span style={{ width: 8, height: 8, borderRadius: 99, background: 'var(--accent)' }} />}
+                  </span>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div className="flex items-center" style={{ gap: 8 }}>
+                      <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--ink)' }}>{mod.label}</span>
+                      <span className="font-mono" style={{ fontSize: 10.5, color: 'var(--ink-3)' }}>{mod.model} · {mod.spec}</span>
+                      {mod.id === machineRec && <span className="font-mono" style={{ fontSize: 8.5, letterSpacing: '.08em', color: 'var(--accent)', background: 'var(--accent-soft)', padding: '1px 5px', borderRadius: 4 }}>BEST FOR YOU</span>}
+                    </div>
+                    <p style={{ fontSize: 11, color: 'var(--ink-3)', marginTop: 2 }}>{mod.blurb}</p>
+                  </div>
+                  <span className="font-mono tnum shrink-0" style={{ fontSize: 11, color: 'var(--ink-2)' }}>{mod.ramGB} GB RAM</span>
+                </button>
+              )
+            })}
+          </div>
+        ) : (
+          <Row tone={wiz.modelReady ? 'tint' : 'surface'}>
+            <Mark mono="m" color="var(--accent)" size={34} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div className="flex items-center" style={{ gap: 8 }}>
+                <span style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--ink)' }}>{sel.label}</span>
+                <span className="font-mono" style={{ fontSize: 10.5, color: 'var(--ink-3)' }}>{sel.model} · {sel.spec}</span>
+                {sel.recommended && <span className="font-mono" style={{ fontSize: 8.5, letterSpacing: '.08em', color: 'var(--accent)', background: 'var(--accent-soft)', padding: '1px 5px', borderRadius: 4 }}>RECOMMENDED</span>}
+              </div>
+              {wiz.prefetching && !wiz.modelReady ? (
+                <p className="font-mono tnum" style={{ fontSize: 11, color: 'var(--ink-3)', marginTop: 3 }}>
+                  {wiz.progress?.message ?? 'Downloading model…'}
+                </p>
+              ) : (
+                <p className="font-mono" style={{ fontSize: 11, color: 'var(--ink-3)', marginTop: 2 }}>{sel.sizeGB} GB download · {sel.speed} on your Mac</p>
+              )}
+            </div>
+            <div className="shrink-0" style={{ minWidth: 100, textAlign: 'right' }}>
+              {wiz.modelReady
+                ? <span className="flex items-center justify-end" style={{ gap: 6, fontSize: 12, color: 'var(--success)', fontWeight: 500 }}><Check size={15} color="var(--success)" />Ready</span>
+                : wiz.prefetching
+                  ? <span className="font-mono tnum" style={{ fontSize: 13, color: 'var(--accent)', fontWeight: 600 }}>{pct !== null ? `${pct}%` : '…'}</span>
+                  : <Btn size="sm" onClick={wiz.downloadModel}>Download</Btn>}
+            </div>
+          </Row>
+        )}
+        {wiz.prefetching && !wiz.modelReady && !picking && pct !== null && (
+          <div style={{ marginTop: 8 }}><Bar pct={pct} /></div>
+        )}
+      </div>
+
+      {/* FOOTPRINT — real, against detected memory */}
+      {ram > 0 && (
+        <div>
+          <div className="flex items-center justify-between" style={{ marginBottom: 7 }}>
+            <Kicker>Estimated footprint</Kicker>
+            <span className="flex items-center font-mono" style={{ gap: 5, fontSize: 10, color: tight ? 'var(--warn)' : 'var(--success)' }}>
+              <span style={{ width: 5, height: 5, borderRadius: 99, background: tight ? 'var(--warn)' : 'var(--success)' }} />
+              {tight ? 'Heavy for this Mac' : 'Comfortable fit'}
+            </span>
+          </div>
+          <div style={{ border: '0.5px solid var(--rule-2)', borderRadius: 13, overflow: 'hidden', background: 'var(--surface)' }}>
+            <div className="flex items-center" style={{ gap: 18, padding: '16px 18px' }}>
+              <MemoryGauge model={memModel} app={memApp} total={ram} />
+              <div className="flex flex-col" style={{ flex: 1, minWidth: 0, gap: 11 }}>
+                <GaugeLegend color="var(--accent)" label={sel.label} sub={`${sel.model} · ${sel.spec}`} val={fmtSize(memModel)} />
+                <GaugeLegend color="#7C3AED" label="Meridian app" sub="background service" val={fmtSize(memApp)} />
+                <GaugeLegend color="var(--rule-2)" label="Free for everything else" sub={`${Math.round(memFree / ram * 100)}% of memory`} val={fmtSize(memFree)} />
+              </div>
+            </div>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', borderTop: '1px solid var(--rule)' }}>
+              <FootStat v={fmtSize(sel.sizeGB + APP.diskGB)} l="Install size" b />
+              <FootStat v={specs?.free_disk_gb ? fmtSize(specs.free_disk_gb - sel.sizeGB - APP.diskGB) : '—'} l="Disk free after" b />
+              <FootStat v={sel.speed} l="Inference" />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── STEP 3 — Integrations ─────────────────────────────────────────────────────
+function IntegrationRow({ it, wiz }: { it: Integration; wiz: Wiz }) {
+  const st = wiz.integrations[it.id] || 'idle'
+  const on = st === 'connected'
+  return (
+    <Row tone={on ? 'tint' : 'surface'} style={it.oauth ? undefined : { opacity: 0.55 }}>
+      <Mark mono={it.mono} color={it.color} size={34} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <p style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--ink)' }}>{it.name}</p>
+        <p className="font-mono" style={{ fontSize: 11, color: on ? 'var(--ink-2)' : 'var(--ink-3)', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{it.account}</p>
+      </div>
+      <div className="shrink-0">
+        {!it.oauth
+          ? <span className="font-mono" style={{ fontSize: 10, letterSpacing: '.08em', color: 'var(--ink-4)', textTransform: 'uppercase' }}>Soon</span>
+          : on
+            ? <span className="flex items-center" style={{ gap: 6, fontSize: 12, color: 'var(--success)', fontWeight: 500 }}><Check size={15} color="var(--success)" />Connected</span>
+            : st === 'connecting'
+              ? <span className="flex items-center" style={{ gap: 7, fontSize: 11.5, color: 'var(--ink-2)' }}><Spinner />Connecting…</span>
+              : <Btn size="sm" variant="secondary" onClick={() => wiz.connect(it.id)}>Connect</Btn>}
+      </div>
+    </Row>
+  )
+}
+
+function IntegrationsBody({ wiz }: { wiz: Wiz }) {
+  const connected = INTEGRATIONS.filter((i) => wiz.integrations[i.id] === 'connected').length
+  return (
+    <div className="flex flex-col" style={{ gap: 9 }}>
+      {INTEGRATIONS.map((it) => <IntegrationRow key={it.id} it={it} wiz={wiz} />)}
+      <p className="flex items-center" style={{ gap: 7, fontSize: 11, color: 'var(--ink-3)', marginTop: 3 }}>
+        <span style={{ width: 5, height: 5, borderRadius: 99, background: connected ? 'var(--success)' : 'var(--ink-4)' }} />
+        {connected > 0
+          ? `${connected} connected · Meridian will match sessions and draft worklogs.`
+          : 'Connect Jira or Trello to auto-draft worklogs — or skip and add later from Settings.'}
+      </p>
+    </div>
+  )
+}
+
+// ── Welcome (pre-step intro) ──────────────────────────────────────────────────
+export function Welcome({ onBegin }: { onBegin: () => void }) {
+  const points = [
+    { t: 'On-device', d: 'Runs on Apple MLX. Nothing leaves your Mac.' },
+    { t: 'Automatic', d: 'Recognises your work and drafts worklogs you approve.' },
+    { t: 'Connected', d: 'Jira and Trello today, more trackers soon.' },
+  ]
+  return (
+    <div className="flex flex-col items-center justify-center" style={{ height: '100%', textAlign: 'center', padding: '36px 44px' }}>
+      <div className="flex items-center mer-pop" style={{ gap: 9, marginBottom: 24 }}>
+        <span style={{ width: 9, height: 9, borderRadius: 99, background: 'var(--accent)' }} />
+        <span style={{ ...SERIF, fontSize: 25, lineHeight: 1, letterSpacing: '.01em', color: 'var(--ink)' }}>meridian</span>
+      </div>
+      <Kicker style={{ marginBottom: 14 }}>First-run setup</Kicker>
+      <h1 style={{ ...SERIF, fontSize: 39, lineHeight: 1.02, letterSpacing: '-.015em', color: 'var(--ink)', maxWidth: 440, textWrap: 'balance' }}>
+        Meridian watches the work, <span style={{ fontStyle: 'italic', color: 'var(--accent)' }}>so you don&apos;t have to.</span>
+      </h1>
+      <p style={{ fontSize: 13.5, lineHeight: 1.55, color: 'var(--ink-2)', marginTop: 14, maxWidth: 380, textWrap: 'pretty' }}>
+        A quiet menu-bar companion that recognises what you&apos;re focused on, drafts your worklogs, and keeps every byte on your Mac.
+      </p>
+      <div className="flex flex-col" style={{ gap: 11, margin: '26px 0 28px', textAlign: 'left', width: '100%', maxWidth: 360 }}>
+        {points.map((p) => (
+          <div key={p.t} className="flex items-start" style={{ gap: 11 }}>
+            <span className="flex items-center justify-center shrink-0" style={{ width: 19, height: 19, borderRadius: 99, background: 'var(--accent-soft)', marginTop: 1 }}>
+              <Check size={12} color="var(--accent)" w={2.2} />
+            </span>
+            <p style={{ fontSize: 12.5, lineHeight: 1.4, color: 'var(--ink-2)' }}>
+              <span style={{ fontWeight: 500, color: 'var(--ink)' }}>{p.t}.</span> {p.d}
+            </p>
+          </div>
+        ))}
+      </div>
+      <Btn onClick={onBegin} style={{ padding: '11px 26px', fontSize: 13.5 }}>Get started</Btn>
+      <p className="font-mono" style={{ fontSize: 10.5, letterSpacing: '.04em', color: 'var(--ink-4)', marginTop: 14 }}>Three quick steps · about a minute</p>
+    </div>
+  )
+}
+
+// ── Completion ────────────────────────────────────────────────────────────────
+export function Completion({ wiz }: { wiz: Wiz }) {
+  const connected = INTEGRATIONS.filter((i) => wiz.integrations[i.id] === 'connected')
+  const model = MODEL_BY_ID[wiz.model]
+  const grantedCount = [wiz.perms.accessibility, wiz.perms.screen, wiz.perms.input].filter(Boolean).length
+  const lines = [
+    { k: 'Permissions', v: `${grantedCount} of 3 granted` },
+    { k: 'Local model', v: `${model.label} · ${model.model}` },
+    { k: 'Footprint', v: `${fmtSize(model.ramGB + APP.ramGB)} memory` },
+    { k: 'Connected', v: connected.length ? connected.map((c) => c.name).join(', ') : 'None yet' },
+  ]
+  return (
+    <div className="flex flex-col items-center" style={{ textAlign: 'center', padding: '8px 8px 0' }}>
+      <span className="flex items-center justify-center mer-pop" style={{ width: 56, height: 56, borderRadius: 99, background: 'var(--accent-soft)', color: 'var(--accent)', marginBottom: 18 }}>
+        <Check size={28} color="var(--accent)" w={2.2} />
+      </span>
+      <Kicker style={{ marginBottom: 10 }}>Setup complete</Kicker>
+      <h1 style={{ ...SERIF, fontSize: 38, lineHeight: 1, letterSpacing: '-.01em', color: 'var(--ink)', marginBottom: 10 }}>You&apos;re all set.</h1>
+      <p style={{ fontSize: 13.5, lineHeight: 1.5, color: 'var(--ink-2)', maxWidth: 340, textWrap: 'pretty', marginBottom: 22 }}>
+        Meridian is now tracking quietly in your menu bar — on-device, private, and matched to your work.
+      </p>
+      <div style={{ width: '100%', maxWidth: 360, border: '0.5px solid var(--rule-2)', borderRadius: 13, overflow: 'hidden' }}>
+        {lines.map((l, i) => (
+          <div key={l.k} className="flex items-center justify-between" style={{ padding: '10px 14px', borderTop: i ? '1px solid var(--rule)' : 'none' }}>
+            <span className="font-mono" style={{ fontSize: 10, letterSpacing: '.12em', textTransform: 'uppercase', color: 'var(--ink-3)' }}>{l.k}</span>
+            <span style={{ fontSize: 12.5, color: 'var(--ink)', fontWeight: 450 }}>{l.v}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ── STEP META — order, labels, headers, gating, rail status ───────────────────
+export interface StepMeta {
+  id: string
+  n: string
+  label: string
+  kicker: string
+  title: string
+  subtitle: string
+  Body: (props: { wiz: Wiz }) => ReactNode
+  status: (w: Wiz) => string
+  canNext: (w: Wiz) => boolean
+}
+
+export const STEPS: StepMeta[] = [
+  {
+    id: 'permissions', n: '01', label: 'Permissions', kicker: 'Access',
+    title: 'Let Meridian see your work',
+    subtitle: "Three macOS permissions let Meridian recognise what you're focused on. Read locally, never uploaded.",
+    Body: PermissionsBody,
+    status: (s) => { const g = [s.perms.accessibility, s.perms.screen, s.perms.input].filter(Boolean).length; return g ? `${g} granted` : 'Not granted' },
+    canNext: (s) => !!(s.perms.accessibility && s.perms.screen && s.perms.input),
+  },
+  {
+    id: 'mlx', n: '02', label: 'Local intelligence', kicker: 'On-device AI',
+    title: 'Install the on-device engine',
+    subtitle: "Meridian runs entirely on your Mac with Apple MLX. We've sized a model to your hardware — here's exactly what it will use.",
+    Body: MLXBody,
+    status: (s) => s.modelReady ? 'Ready' : (s.mlx?.runtime_found || s.mlx?.runtime_installed) ? 'Model pending' : 'Not installed',
+    // Never trap the user: the model finishes downloading in the background.
+    canNext: () => true,
+  },
+  {
+    id: 'integrations', n: '03', label: 'Integrations', kicker: 'Project tools',
+    title: 'Connect your trackers',
+    subtitle: 'Link the tools you already use. Meridian matches each session to an issue and drafts a worklog you approve.',
+    Body: IntegrationsBody,
+    status: (s) => { const c = INTEGRATIONS.filter((i) => s.integrations[i.id] === 'connected').length; return c ? `${c} connected` : 'Optional' },
+    canNext: () => true,
+  },
+]

--- a/ui/lib/settings.ts
+++ b/ui/lib/settings.ts
@@ -21,6 +21,9 @@ export interface RuntimeSettings {
   // LLM
   llm_prefer_local: boolean
   llm_budget_pct: number
+  // The setup wizard's on-device model choice (HuggingFace repo id). null →
+  // automatic spec-aware selection. Mirrors RuntimeSettings.llm_model_preference.
+  llm_model_preference: string | null
   // Jira updater
   jira_update_enabled: boolean
   // Notifications — master switch + per-event-type toggles + quiet hours.
@@ -51,6 +54,7 @@ export const SETTINGS_DEFAULTS: RuntimeSettings = {
   agent_queue_floor: 0.40,
   llm_prefer_local: true,
   llm_budget_pct: 0.5,
+  llm_model_preference: null,
   jira_update_enabled: true,
   notifications_enabled: true,
   notify_plan_nudge: true,


### PR DESCRIPTION
Ports the **"A · Rail"** direction of the Meridian Setup design into the real first-run wizard. Re-skins the working flow (no behaviour rebuild): live commands drive it, the design supplies presentation, retokenized onto the product palette (amber, not the mock's orange) so the wizard matches the dashboard it hands off to.

## Scope
**UI** (`ui/app/setup/`, split to stay under the 500-line rule): Welcome → Permissions → Local intelligence → Integrations → Completion, in a centered 948×628 card.
- Permissions: the **three real required** cards incl. Input Monitoring (the design omitted it; the in-process capture pipeline needs it). The design's Notifications / Launch-at-login toggles are dropped — no backend.
- Integrations: Jira + Trello use the real `start_oauth` / `get_oauth_status` flow; Linear/GitHub/Asana render explicitly disabled, never wired to error.
- `globals.css`: adds `--pop-shadow` + `mer-spin` / `mer-pop`.

**Deep model step** — a real, working 3-tier picker:
- Tiers map to **real checkpoints** (`Qwen3.5-4B` / `Qwen3.5-9B-OptiQ` / `phi-4`) with honest model identity, not fictional names.
- Live hardware-spec panel + a memory gauge sized against **detected RAM**.
- Prefetch only fires on an **explicit Download** with the preference written first, so the "Ready" badge can't mislabel which model loaded.

**Backend**
- `meridian-core` settings + `ui/lib/settings.ts`: new `llm_model_preference`.
- `run_task_linker_mlx._resolve_model_id` honours that preference (degrades via `llm_selector` when it can't fit the Metal budget).
- New tray commands: `detect_system_specs`, `set_model_preference`, `get_model_preference`.
- `tray.rs` widens the setup window 560×660 → 980×660 for the Rail shell.

## Verified
Tray build + clippy clean · `meridian-core` test passes · `cargo fmt --check` clean · Python compiles · UI build + TypeScript passes · `/setup` in the static export · headless render check of Welcome + the Deep Model step. Full pre-push suite (incl. `cargo test`, UI build, security audit) passed on push.

## Known limitation
The MLX server resolves its model id once per process. Fresh-install (shipping) ordering is correct; on a dev machine where the server is already running with a different model cached, changing the pick won't hot-swap until the server restarts (no reload command today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)