### PR TITLE
ci(release): DMG auto-update staging channel on pre-main

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -1,0 +1,105 @@
+name: Release (staging)
+
+# Staging-channel releases via semantic-release, on the `pre-main` branch.
+# Triggered MANUALLY (workflow_dispatch) — each run cuts a PRERELEASE version
+# (X.Y.Z-staging.N, computed from main's reachable v* tags) that builds the SAME
+# signed DMG + updater artifacts as the production flow, but:
+#   • bakes the STAGING updater endpoint (…/releases/download/updater-staging/
+#     latest.json) into the .app at build time via a --config overlay — never
+#     committed, so it cannot leak to `main`;
+#   • is GitHub-only (NO npm publish, NO version-bump commit back to pre-main);
+#   • mirrors latest.json onto the rolling `updater-staging` prerelease so an
+#     installed staging app self-updates staging→staging.
+#
+# Differs from release.yml (production/main) only in: it targets pre-main, cuts a
+# prerelease, swaps in .releaserc.staging.json, and publishes to GitHub only.
+# Same macos-26 runner because the prepare step builds the Swift Foundation
+# Models bridge + Metal/MLX + the dashboard, exactly like main.
+#
+# Manual only by design (a full macOS build is ~45 min); run it when you want a
+# staging cut: `gh workflow run release-staging.yml --ref pre-main`.
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: write       # tags, the GitHub prerelease(s), the rolling updater-staging release
+
+concurrency:
+  group: release-staging
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: macos-26
+    env:
+      SQLX_OFFLINE: "true"
+      # Baked into the staging binary at compile time (see release.yml); same
+      # secret. Absent → Jira OAuth simply unavailable in the staging build.
+      MERIDIAN_JIRA_OAUTH_CLIENT_SECRET: ${{ secrets.JIRA_OAUTH_CLIENT_SECRET }}
+      # Minisign key for the DMG auto-updater: `tauri build` (createUpdaterArtifacts)
+      # signs Meridian.app.tar.gz so the installed staging app can verify the
+      # update against the pubkey baked in tauri.conf.json. REQUIRED here (unlike
+      # the legacy staging flow) — without it package-updater.sh emits no
+      # latest.json and the mirror no-ops, so the staging channel can't update.
+      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: pre-main           # release the pre-main tip — NOT the default branch
+          fetch-depth: 0          # full history — semantic-release needs commits
+          fetch-tags: true        # see main's v* tags (reachable: pre-main is off main)
+          persist-credentials: false
+
+      - name: Install Rust 1.93.1
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.93.1"
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: |
+            package-lock.json
+            ui/package-lock.json
+            tray/package-lock.json
+
+      - name: Cache uv packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ hashFiles('services/uv.lock') }}
+          restore-keys: uv-
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: ui/.next/cache
+          key: nextjs-${{ hashFiles('ui/package-lock.json') }}-${{ hashFiles('ui/**/*.ts', 'ui/**/*.tsx') }}
+          restore-keys: |
+            nextjs-${{ hashFiles('ui/package-lock.json') }}-
+            nextjs-
+
+      - name: Install release tooling
+        run: npm ci --no-audit --no-fund
+
+      - name: Use staging release config
+        # Ephemeral in CI — .releaserc.json is not in any git-asset list, so this
+        # is never committed. Keeps the staging config out of main's tree.
+        run: cp .releaserc.staging.json .releaserc.json
+
+      - name: semantic-release (staging channel)
+        env:
+          # PAT to create the tag/prerelease past branch protection; falls back
+          # to GITHUB_TOKEN. No npm token — the staging channel is GitHub-only.
+          # Also authenticates the `gh` calls in mirror-staging-release.sh.
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          # Bake the staging runtime channel into the build at compile time
+          # (mlx_server::manifest_url reads this via option_env!). A packaged .app
+          # has no shell env, so the staging .app must compile in runtime-staging.
+          MERIDIAN_RUNTIME_MANIFEST_URL: "https://github.com/Meridiona/meridian/releases/download/runtime-staging/runtime-manifest.json"
+        run: npx semantic-release

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -1,9 +1,9 @@
 name: Release (staging)
 
 # Staging-channel releases via semantic-release, on the `pre-main` branch.
-# Triggered MANUALLY (workflow_dispatch) — each run cuts a PRERELEASE version
-# (X.Y.Z-staging.N, computed from main's reachable v* tags) that builds the SAME
-# signed DMG + updater artifacts as the production flow, but:
+# Each run cuts a PRERELEASE version (X.Y.Z-staging.N, computed from main's
+# reachable v* tags) that builds the SAME signed DMG + updater artifacts as the
+# production flow, but:
 #   • bakes the STAGING updater endpoint (…/releases/download/updater-staging/
 #     latest.json) into the .app at build time via a --config overlay — never
 #     committed, so it cannot leak to `main`;
@@ -16,10 +16,21 @@ name: Release (staging)
 # Same macos-26 runner because the prepare step builds the Swift Foundation
 # Models bridge + Metal/MLX + the dashboard, exactly like main.
 #
-# Manual only by design (a full macOS build is ~45 min); run it when you want a
-# staging cut: `gh workflow run release-staging.yml --ref pre-main`.
+# TRIGGERING — a full macOS build is ~45 min, and `pre-main` is a busy
+# integration branch, so this does NOT build on every push. It builds only when:
+#   • a push to pre-main whose head-commit message contains the marker
+#     `[staging-release]` (the controlled test loop — e.g.
+#     `git commit --allow-empty -m "chore(release): staging [staging-release]" && git push`), OR
+#   • a manual `workflow_dispatch` (available in the Actions tab / `gh workflow
+#     run release-staging.yml --ref pre-main` after the first push-triggered run
+#     has registered the workflow).
+# We deliberately do NOT keep this workflow on `main` — semantic-release reads
+# the channel from GITHUB_REF, so the run must carry ref=pre-main (else it would
+# treat the build as `main` and try to cut a STABLE release from pre-main code).
 
 on:
+  push:
+    branches: [pre-main]
   workflow_dispatch: {}
 
 permissions:
@@ -31,6 +42,9 @@ concurrency:
 
 jobs:
   release:
+    # Build only on a manual dispatch or a marker commit — never on ordinary
+    # pre-main integration pushes (fold merges, feature merges).
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[staging-release]') }}
     runs-on: macos-26
     env:
       SQLX_OFFLINE: "true"

--- a/.releaserc.staging.json
+++ b/.releaserc.staging.json
@@ -1,0 +1,39 @@
+{
+  "branches": ["main", { "name": "pre-main", "prerelease": "staging" }],
+  "tagFormat": "v${version}",
+  "plugins": [
+    ["@semantic-release/commit-analyzer", { "preset": "conventionalcommits" }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits",
+      "presetConfig": {
+        "types": [
+          { "type": "feat", "section": "🚀 Features" },
+          { "type": "fix", "section": "🐛 Bug Fixes" },
+          { "type": "perf", "section": "⚡ Performance" },
+          { "type": "refactor", "section": "♻️ Refactoring" },
+          { "type": "build", "section": "📦 Build System" },
+          { "type": "ci", "section": "🤖 CI" },
+          { "type": "test", "section": "✅ Tests" },
+          { "type": "docs", "section": "📝 Documentation" },
+          { "type": "style", "section": "🎨 Styles" },
+          { "type": "chore", "section": "🔧 Chores" },
+          { "type": "revert", "section": "⏪ Reverts" }
+        ]
+      }
+    }],
+    ["@semantic-release/github", {
+      "successComment": false,
+      "failComment": false,
+      "assets": [
+        { "path": "target/release/bundle/dmg/Meridian.dmg", "label": "Meridian.dmg (macOS, Apple silicon) — staging ${nextRelease.gitTag}" },
+        { "path": "target/release/bundle/macos/Meridian.app.tar.gz", "label": "Meridian.app.tar.gz (updater)" },
+        { "path": "target/release/bundle/macos/Meridian.app.tar.gz.sig", "label": "Meridian.app.tar.gz.sig" },
+        { "path": "target/release/bundle/macos/latest.json", "label": "latest.json (updater manifest)" }
+      ]
+    }],
+    ["@semantic-release/exec", {
+      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && cargo build --release && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build -- --config src-tauri/tauri.staging.conf.json) && bash scripts/package-release.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}",
+      "publishCmd": "bash scripts/mirror-staging-release.sh ${nextRelease.version}"
+    }]
+  ]
+}

--- a/scripts/mirror-staging-release.sh
+++ b/scripts/mirror-staging-release.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+#
+# Mirror the freshly-built staging updater manifest onto a FIXED, rolling
+# `updater-staging` GitHub prerelease, so an installed staging .app — which
+# bakes the endpoint …/releases/download/updater-staging/latest.json (see
+# tray/src-tauri/tauri.staging.conf.json) — always finds the newest staging
+# build at one stable URL. Mirrors the repo's existing `runtime-staging`
+# fixed-tag channel convention.
+#
+# Called by semantic-release (@semantic-release/exec publishCmd) on the pre-main
+# staging channel, AFTER @semantic-release/github has created the versioned
+# v<version> prerelease — which carries the Meridian.app.tar.gz that
+# latest.json's `url` points at. So we only mirror latest.json here; the signed
+# tarball stays on the immutable versioned release.
+#
+#   scripts/mirror-staging-release.sh <version>
+set -euo pipefail
+
+VERSION="${1:?usage: mirror-staging-release.sh <version>}"
+VERSION="${VERSION#v}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT}"
+
+TAG="updater-staging"
+MAC="target/release/bundle/macos"
+DMG="target/release/bundle/dmg/Meridian.dmg"
+LATEST="${MAC}/latest.json"
+
+# package-updater.sh skips latest.json when updater artifacts weren't signed
+# (no TAURI_SIGNING_PRIVATE_KEY). Nothing to mirror then — no-op, don't fail.
+if [[ ! -f "${LATEST}" ]]; then
+  echo "→ ${LATEST} absent — updater artifacts not built; skipping staging mirror"
+  exit 0
+fi
+
+# Ensure the rolling prerelease exists (idempotent across runs). Marked
+# --prerelease so GitHub's "latest" (the production endpoint) never resolves to
+# it. Anchored to pre-main at first creation; the tag never moves afterwards —
+# only its attached assets are clobbered, and the asset download URL is
+# tag-stable regardless of which commit the tag points at.
+if ! gh release view "${TAG}" >/dev/null 2>&1; then
+  gh release create "${TAG}" \
+    --prerelease \
+    --target pre-main \
+    --title "Updater staging channel (rolling)" \
+    --notes "Rolling staging updater channel. The latest.json here always points at the newest pre-main staging build, so installed staging apps self-update. Auto-managed by scripts/mirror-staging-release.sh — do not edit by hand."
+  echo "✓ created rolling ${TAG} prerelease"
+fi
+
+# Clobber the manifest so the fixed endpoint serves the newest build.
+gh release upload "${TAG}" "${LATEST}" --clobber
+echo "✓ ${TAG}/latest.json ← v${VERSION}"
+
+# Also publish a stable-named DMG for a fixed staging-tester download link
+# (…/releases/download/updater-staging/Meridian.dmg). Not required for
+# auto-update (latest.json's url points at the versioned tarball) — convenience.
+if [[ -f "${DMG}" ]]; then
+  gh release upload "${TAG}" "${DMG}" --clobber
+  echo "✓ ${TAG}/Meridian.dmg ← v${VERSION}"
+fi

--- a/tray/src-tauri/tauri.staging.conf.json
+++ b/tray/src-tauri/tauri.staging.conf.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/Meridiona/meridian/releases/download/updater-staging/latest.json"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## What

Stands up a **pre-production staging release channel on `pre-main`** that exercises the full release pipeline + the packaged app + **live auto-update** before `pre-main → main`, with zero impact on production.

Reuses the proven staging skeleton (GitHub-only, prerelease-versioned) and grafts on the DMG auto-update piece the legacy `staging`-branch config predated (it had no signing key, no DMG, no `latest.json`).

## Files (4 new)

| File | Role |
|---|---|
| `tray/src-tauri/tauri.staging.conf.json` | Build-time `--config` overlay pointing the updater at the staging endpoint (`…/releases/download/updater-staging/latest.json`). **Never committed into `tauri.conf.json` → cannot leak to `main`.** |
| `.releaserc.staging.json` | Staging semantic-release config: `branches` adds `{pre-main, prerelease: staging}`; `set-version` runs **first** (fixes the version-baking footgun); tray build takes the overlay; GitHub-only (dropped npm/git/changelog → no version-bump commits pollute `pre-main`); `publishCmd` mirrors `latest.json`. |
| `scripts/mirror-staging-release.sh` | Clobbers `latest.json` (+ stable DMG) onto a fixed `updater-staging` prerelease so installed staging apps self-update. Mirrors the repo's existing `runtime-staging` fixed-tag convention. |
| `.github/workflows/release-staging.yml` | Builds `pre-main` only on a **`[staging-release]` marker commit** or a manual dispatch — never on ordinary integration pushes. Adds `TAURI_SIGNING_*`; `cp`s the staging config in-CI (ephemeral). |

## Isolation guarantee

Production (`main`: `release.yml` + `.releaserc.json`) is **untouched**, and this workflow is **not** added to `main`. The staging endpoint is baked **only at build time via `--config`**; the committed `tauri.conf.json` keeps the production endpoint, so even after `pre-main → main` merges, `main` builds bake production.

## Why marker-commit + dispatch (not plain `workflow_dispatch`)

Two GitHub constraints: a dispatch-by-name needs the workflow **registered** (normally requires it on the default branch), and **semantic-release reads the channel from `GITHUB_REF`** — so the run must carry `ref=pre-main` or it would treat the build as `main` and cut a **stable** release from pre-main code. Triggering from `pre-main` (gated by a marker so the busy integration branch doesn't build on every push) satisfies both and keeps the workflow off `main`.

## How to test (after merge)

1. Cut the first staging build:
   ```
   git checkout pre-main && git pull
   git commit --allow-empty -m "chore(release): first staging cut [staging-release]"
   git push
   ```
   → expect a `v1.64.0-staging.1` **prerelease** with DMG + tarball + sig + `latest.json`, and an `updater-staging` rolling release.
2. Install the staging DMG → app reports `1.64.0-staging.1`, endpoint = `updater-staging`.
3. Push another `[staging-release]` commit → `v1.64.0-staging.2`; the installed app self-updates staging→staging. (After the first run, `gh workflow run release-staging.yml --ref pre-main` also works.)

> ⚠️ One first-run checkpoint: confirm Tauri resolves `--config src-tauri/tauri.staging.conf.json` relative to the tray dir; if not, the build errors clearly and the path is a one-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)