### PR TITLE
ci: authenticate private screenpipe-fork git dep in the Rust job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,29 @@ jobs:
   rust:
     name: Rust
     runs-on: ubuntu-latest
+    env:
+      # The tray pulls screenpipe-screen/-a11y from the PRIVATE Meridiona/
+      # screenpipe-fork (a git dep). They are optional/capture-gated, but cargo
+      # still RESOLVES them for the workspace (fmt/clippy/test), so it must fetch
+      # the source. Force the git CLI so cargo honors the url.insteadOf rewrite
+      # the auth step installs — libgit2 would not pick it up.
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - uses: actions/checkout@v4
+
+      - name: Authenticate git for the private screenpipe-fork dependency
+        # checkout's persist-credentials and the default GITHUB_TOKEN are both
+        # scoped to THIS repo, so cargo's `git fetch` of the fork 403s. Rewrite
+        # just that URL to embed a PAT with read access. REQUIRES the GH_TOKEN
+        # secret to read Meridiona/screenpipe-fork (org-member classic PAT with
+        # `repo`, or a fine-grained PAT granting both meridian AND screenpipe-fork).
+        # Same secret + mechanism as release.yml / release-staging.yml.
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          git config --global \
+            url."https://x-access-token:${GH_TOKEN}@github.com/Meridiona/screenpipe-fork".insteadOf \
+            "https://github.com/Meridiona/screenpipe-fork"
 
       - name: Install Rust 1.93.1
         uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
## Problem

CI on #330 (`pre-main` → `main`) fails at the **Rust** job:

```
fatal: could not read Username for 'https://github.com': No such device or address
error: failed to get `screenpipe-a11y` as a dependency of package `meridian-tray`
  ... Unable to update https://github.com/Meridiona/screenpipe-fork?rev=d6d2b318...
```

`ci.yml`'s `rust` job runs `cargo fmt/clippy/test` over the whole workspace. That **resolves** the tray's `screenpipe-screen` / `screenpipe-a11y` deps — a git dependency on the **private** `Meridiona/screenpipe-fork` — even though they're `optional` / `capture`-gated and never compiled here. With only the repo-scoped `GITHUB_TOKEN`, cargo's `git fetch` of the fork can't authenticate, so the job dies before clippy even runs.

## Fix

Port the **exact** mechanism `release.yml` and `release-staging.yml` already use (those jobs build the tray against the fork and pass):

- `CARGO_NET_GIT_FETCH_WITH_CLI: "true"` on the `rust` job — cargo's libgit2 ignores `url.insteadOf`; the git CLI honors it.
- A `git config --global url."https://x-access-token:${GH_TOKEN}@…".insteadOf …` step using `secrets.GH_TOKEN` (already proven to read the fork — the `release` check is green on #330).

No source/build changes; CI-only. Merging this into `pre-main` re-triggers #330's CI, which should then go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)