### PR TITLE
fix(health): resolve PR #330 review findings

### DIFF
--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -260,10 +260,10 @@ ok "node + python ($(${PYTHON_BIN} --version 2>&1)) + uv ($(${UV_BIN} --version 
 if ! command -v screenpipe >/dev/null 2>&1; then
     info "Installing screenpipe ${SCREENPIPE_VERSION} via npm…"
     if npm_global_writable; then
-        npm install -g "screenpipe@${SCREENPIPE_VERSION}"
+        npm install -g --ignore-scripts "screenpipe@${SCREENPIPE_VERSION}"
     else
         warn "global npm prefix needs root — elevating just this install (you may be prompted)…"
-        sudo npm install -g "screenpipe@${SCREENPIPE_VERSION}"
+        sudo npm install -g --ignore-scripts "screenpipe@${SCREENPIPE_VERSION}"
     fi
 fi
 ok "screenpipe"

--- a/src/health/capture.rs
+++ b/src/health/capture.rs
@@ -439,18 +439,24 @@ const COVERAGE_IGNORE_APPS: &[&str] = &[
 ];
 
 async fn capture_coverage(pool: &SqlitePool, window: &str) -> Check {
+    // Use julianday() for both sides of the comparison: `datetime('now', ?1)`
+    // produces '2026-06-23 17:00:00' (space separator, no Z), but
+    // insert_capture_frame writes RFC 3339 '2026-06-24T16:00:00.000000Z'
+    // (T + Z). String comparison at index 10 would have 'T' (0x54) > ' '
+    // (0x20), so every row passes the filter regardless of date — the window
+    // never excludes anything. julianday() normalises both formats internally.
     let rows = sqlx::query_as::<_, (String, i64, i64)>(
         "SELECT u.app_name, u.f, COALESCE(fr.n, 0)
          FROM (SELECT app_name, COUNT(*) AS f
                FROM capture_ui_events
                WHERE event_type IN ('app_switch', 'window_focus')
-                 AND timestamp > datetime('now', ?1)
+                 AND julianday(timestamp) > julianday('now', ?1)
                  AND app_name IS NOT NULL AND app_name != ''
                GROUP BY app_name
                HAVING f >= ?2) u
          LEFT JOIN (SELECT app_name, COUNT(*) AS n
                     FROM capture_frames
-                    WHERE timestamp > datetime('now', ?1)
+                    WHERE julianday(timestamp) > julianday('now', ?1)
                     GROUP BY app_name) fr
            ON fr.app_name = u.app_name",
     )

--- a/src/health/platform.rs
+++ b/src/health/platform.rs
@@ -11,7 +11,6 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const LABEL_DAEMON: &str = "com.meridiona.daemon";
-const LABEL_UI: &str = "com.meridiona.ui";
 const LABEL_MLX: &str = "com.meridiona.mlx-server";
 
 // ── shared helpers ──────────────────────────────────────────────────────────
@@ -204,32 +203,16 @@ fn venv_check() -> Check {
     }
 }
 
+/// Returns a single Info check confirming the dashboard is embedded in the
+/// Tauri binary. The `com.meridiona.ui` launchd agent was retired with the
+/// Next-fold (PR #298); probing for its plist always produces a false CRITICAL
+/// on healthy post-fold installs.
 pub fn ui_service() -> Vec<Check> {
-    let run = match launchd_pid(LABEL_UI) {
-        Some(pid) => Check::ok("ui service", "system", format!("pid {pid}")),
-        None => Check::warn("ui service", "system", "not loaded — dashboard unavailable")
-            .with_remedy("meridian start"),
-    };
-    let build_check = if let Some(root) = repo_root() {
-        // Dev / source-checkout install: ui/.next must exist.
-        if root.join("ui/.next").is_dir() {
-            Check::ok("ui built", "system", ".next present")
-        } else {
-            Check::warn("ui built", "system", "not built")
-                .with_remedy("cd ui && npm ci && npm run build")
-        }
-    } else {
-        // Bundle install: the standalone server.js is extracted from ui.tar.gz
-        // into ~/.meridian/app/ui/ — no Cargo.toml, so repo_root() is None.
-        let bundle_server = home().join(".meridian/app/ui/server.js");
-        if bundle_server.is_file() {
-            Check::ok("ui built", "system", "bundle server.js present")
-        } else {
-            Check::warn("ui built", "system", "bundle not extracted")
-                .with_remedy("re-run the installer: curl -fsSL https://raw.githubusercontent.com/Meridiona/meridian/main/scripts/bootstrap.sh | bash")
-        }
-    };
-    vec![plist_check(LABEL_UI, "ui plist"), run, build_check]
+    vec![Check::info(
+        "ui service",
+        "system",
+        "dashboard embedded in the Tauri binary (no separate service)",
+    )]
 }
 
 pub fn mcp_service() -> Vec<Check> {

--- a/src/health/ui.rs
+++ b/src/health/ui.rs
@@ -1,218 +1,28 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 //
-// UI *readiness* — not just liveness. `ui service` (a launchd PID) and `ui
-// built` (`.next` exists) both pass for a running-but-broken dashboard: a stale
-// build or an output:'standalone' / `next start` mismatch serves HTML whose
-// _next/static assets 404/500, blanking the page. So we functionally probe what
-// is actually served, and flag the serve-mode mismatch that causes it.
+// Dashboard health — the dashboard is now a static export embedded in the
+// Tauri binary (no separate Node server or launchd `com.meridiona.ui` agent).
+// The Node-era HTTP probes (`serve_health`, `serve_mode_check`, asset checks)
+// are gone; `doctor` reports an informational line instead of a false CRITICAL.
 
 use crate::config::Config;
-use crate::health::platform::repo_root;
 use crate::health::Check;
-use std::path::PathBuf;
-use std::time::Duration;
 
-fn home() -> PathBuf {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("."))
-}
-
-fn ui_port() -> u16 {
-    std::env::var("MERIDIAN_UI_PORT")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(3939)
-}
-
+/// Returns a single Info check confirming the dashboard is embedded in the
+/// Tauri binary. The Node-era HTTP probe (was `GET http://localhost:3939/`) is
+/// removed — it always fails on healthy post-fold installs and misattributes
+/// the "fault" to the dashboard when the real topology has no separate service.
 pub async fn checks(_cfg: &Config) -> Vec<Check> {
-    let mut out = vec![serve_mode_check()];
-    out.extend(serve_health(ui_port()).await);
-    out
-}
-
-/// Probe the UI's own /api/health endpoint so `doctor` catches the
-/// "database not found" banner that the UI shows when the DB is missing.
-pub async fn api_health_check(port: u16) -> Option<Check> {
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(4))
-        .build()
-        .ok()?;
-    let url = format!("http://localhost:{port}/api/health");
-    let body: serde_json::Value = client.get(&url).send().await.ok()?.json().await.ok()?;
-    // {} is the first-call placeholder — treat as unknown, skip.
-    if body.as_object().map(|m| m.is_empty()).unwrap_or(true) {
-        return None;
-    }
-    if body.get("database_ready") == Some(&serde_json::Value::Bool(false)) {
-        let msg = body
-            .get("error")
-            .and_then(|v| v.as_str())
-            .unwrap_or("database not accessible from UI");
-        return Some(Check::critical("ui db access", "ui", msg).with_remedy(
-            "start the daemon: launchctl load ~/Library/LaunchAgents/com.meridiona.daemon.plist",
-        ));
-    }
-    Some(Check::ok(
-        "ui db access",
+    vec![Check::info(
+        "ui serving",
         "ui",
-        "database accessible from UI",
-    ))
+        "dashboard embedded in the Tauri binary (no separate service)",
+    )]
 }
 
-/// Static config contract: an `output: 'standalone'` build must be served with
-/// `node .next/standalone/server.js`, NOT `next start` — the latter serves a
-/// manifest pointing at assets that aren't where `next start` looks for them.
-fn serve_mode_check() -> Check {
-    let Some(root) = repo_root() else {
-        return Check::info("ui serve mode", "ui", "repo root not found");
-    };
-    let standalone = ["ts", "js", "mjs"].iter().any(|ext| {
-        std::fs::read_to_string(root.join(format!("ui/next.config.{ext}")))
-            .map(|s| s.contains("standalone"))
-            .unwrap_or(false)
-    });
-    if !standalone {
-        return Check::ok("ui serve mode", "ui", "not standalone");
-    }
-    let plist = home().join("Library/LaunchAgents/com.meridiona.ui.plist");
-    let runs_next_start = std::fs::read_to_string(&plist)
-        .map(|s| s.contains("next start") || s.contains("<string>start</string>"))
-        .unwrap_or(false);
-    if runs_next_start {
-        Check::critical(
-            "ui serve mode",
-            "ui",
-            "output:'standalone' build but the service runs `next start`",
-        )
-        .with_remedy("serve via `node .next/standalone/server.js` in com.meridiona.ui.plist")
-    } else {
-        Check::ok("ui serve mode", "ui", "standalone, served correctly")
-    }
-}
-
-/// Functional probe: GET `/`, then fetch a `_next/static` asset the HTML
-/// references. The asset fetch is the real signal — a stale/broken build returns
-/// 200 on `/` but 404/500 on its chunks, which is what blanks the dashboard.
-async fn serve_health(port: u16) -> Vec<Check> {
-    let base = format!("http://localhost:{port}");
-    let client = match reqwest::Client::builder()
-        .timeout(Duration::from_secs(4))
-        .build()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            return vec![Check::warn(
-                "ui serving",
-                "ui",
-                format!("http client error ({e})"),
-            )]
-        }
-    };
-
-    let html = match client.get(&base).send().await {
-        Err(_) => {
-            return vec![
-                Check::warn("ui serving", "ui", format!("not reachable at {base}"))
-                    .with_remedy("meridian start"),
-            ]
-        }
-        Ok(resp) if !resp.status().is_success() => {
-            return vec![Check::critical(
-                "ui serving",
-                "ui",
-                format!("/ returned HTTP {}", resp.status().as_u16()),
-            )
-            .with_remedy("rebuild + restart the UI (cd ui && npm run build)")]
-        }
-        Ok(resp) => resp.text().await.unwrap_or_default(),
-    };
-
-    vec![
-        Check::ok("ui serving", "ui", "/ → 200"),
-        asset_check(&client, &base, &html).await,
-    ]
-}
-
-async fn asset_check(client: &reqwest::Client, base: &str, html: &str) -> Check {
-    let Some(asset) = first_asset(html) else {
-        return Check::info("ui assets", "ui", "no static asset referenced (unusual)");
-    };
-    match client.get(format!("{base}{asset}")).send().await {
-        Ok(resp) if resp.status().is_success() => {
-            Check::ok("ui assets", "ui", "static assets load")
-        }
-        Ok(resp) => Check::critical(
-            "ui assets",
-            "ui",
-            format!(
-                "{} → HTTP {} — stale/broken build",
-                short(&asset),
-                resp.status().as_u16()
-            ),
-        )
-        .with_remedy("rebuild + restart the UI; check output:'standalone' vs `next start`"),
-        Err(_) => Check::warn("ui assets", "ui", "could not fetch a static asset"),
-    }
-}
-
-/// First `/_next/static/...` asset URL in the HTML, preferring CSS then JS.
-fn first_asset(html: &str) -> Option<String> {
-    [".css", ".js"]
-        .into_iter()
-        .find_map(|ext| find_asset_with_ext(html, ext))
-}
-
-fn find_asset_with_ext(html: &str, ext: &str) -> Option<String> {
-    const NEEDLE: &str = "/_next/static/";
-    let mut from = 0;
-    while let Some(rel) = html[from..].find(NEEDLE) {
-        let i = from + rel;
-        let rest = &html[i..];
-        let end = rest.find(['"', '\'', '>', ' ']).unwrap_or(rest.len());
-        let url = &rest[..end];
-        if url.ends_with(ext) {
-            return Some(url.to_string());
-        }
-        from = i + NEEDLE.len();
-    }
+/// Returns `None` — the `/api/health` endpoint was retired with the Node
+/// server. Post-fold the dashboard runs embedded in the Tauri webview; there
+/// is no HTTP port to probe.
+pub async fn api_health_check(_port: u16) -> Option<Check> {
     None
-}
-
-/// Tail of an asset path for compact display.
-fn short(url: &str) -> String {
-    url.rsplit('/').next().unwrap_or(url).to_string()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn extracts_css_asset_then_js() {
-        let html = r#"<link rel="stylesheet" href="/_next/static/chunks/a1b2.css"/><script src="/_next/static/chunks/main.js"></script>"#;
-        assert_eq!(
-            first_asset(html).as_deref(),
-            Some("/_next/static/chunks/a1b2.css")
-        );
-    }
-
-    #[test]
-    fn falls_back_to_js_when_no_css() {
-        let html = r#"<script src="/_next/static/chunks/main-xyz.js"></script>"#;
-        assert_eq!(
-            first_asset(html).as_deref(),
-            Some("/_next/static/chunks/main-xyz.js")
-        );
-    }
-
-    #[test]
-    fn no_asset_when_absent() {
-        assert!(first_asset("<html><body>hi</body></html>").is_none());
-    }
-
-    #[test]
-    fn short_takes_basename() {
-        assert_eq!(short("/_next/static/chunks/a.css"), "a.css");
-    }
 }

--- a/tray/src-tauri/src/mlx_server.rs
+++ b/tray/src-tauri/src/mlx_server.rs
@@ -197,8 +197,10 @@ pub fn resolve_mlx_command() -> Option<(PathBuf, PathBuf)> {
 }
 
 /// Resolve the runtime manifest URL, in priority order:
-/// 1. **Runtime** `MERIDIAN_RUNTIME_MANIFEST_URL` — dev / tests (a packaged
-///    `.app` launched from Finder has no shell env, so this only fires in dev).
+/// 1. **Runtime** `MERIDIAN_RUNTIME_MANIFEST_URL` — dev builds only (a
+///    packaged `.app` from Finder has no shell env, but the env-var path is
+///    also gated behind `#[cfg(debug_assertions)]` so it cannot be used to
+///    redirect the manifest in a release binary).
 /// 2. **Compile-time** `MERIDIAN_RUNTIME_MANIFEST_URL` (`option_env!`) — BAKED
 ///    into a channel build. The staging release sets it at build time so the
 ///    staging `.app` pins `runtime-staging`; production builds leave it unset.
@@ -206,6 +208,9 @@ pub fn resolve_mlx_command() -> Option<(PathBuf, PathBuf)> {
 ///
 /// `None` → no runtime published for this channel (wizard shows "not available").
 pub fn manifest_url() -> Option<String> {
+    // Env-var override is debug-only: prevents a compromised environment from
+    // redirecting the manifest URL in a production binary.
+    #[cfg(debug_assertions)]
     if let Ok(url) = std::env::var("MERIDIAN_RUNTIME_MANIFEST_URL") {
         if !url.is_empty() {
             return Some(url);

--- a/tray/src-tauri/src/poll/mod.rs
+++ b/tray/src-tauri/src/poll/mod.rs
@@ -46,6 +46,14 @@ const TICK: Duration = Duration::from_secs(30);
 /// spawn-storming. Reset to 0 the moment `/health` answers.
 const MLX_MAX_RESTARTS: u32 = 5;
 
+/// After exhausting [`MLX_MAX_RESTARTS`], how many additional health ticks to
+/// wait before allowing another restart cycle (~10 min at 60 s / tick). Using
+/// the single `attempts` counter (letting it grow past `MLX_MAX_RESTARTS`)
+/// avoids a second mutable state variable. Once the window closes, `attempts`
+/// resets to 0 and supervision resumes — preventing a permanent wedge after an
+/// OOM / crash that keeps `/health` silent.
+const MLX_COOLING_TICKS: u32 = 10;
+
 /// How often (in ticks) to check for a newer published MLX runtime and upgrade in
 /// the background. `720 * 30 s = 6 h`. Also fires at tick 0, so a relaunch checks
 /// immediately. The check is a single small manifest GET when already current.
@@ -148,6 +156,17 @@ pub async fn run_poll_loop(app: tauri::AppHandle, state: Arc<Mutex<AppState>>) {
 /// human fix). User-facing "offline" messaging stays with the daemon's notice;
 /// this loop only logs (and remediates).
 async fn supervise_mlx(mlx: &SharedMlxManager, attempts: &mut u32) {
+    // After the restart budget is exhausted, let `attempts` grow past
+    // MLX_MAX_RESTARTS to count out the cooling window. Once it reaches
+    // MLX_MAX_RESTARTS + MLX_COOLING_TICKS, reset to 0 so supervise() runs
+    // again and can kill any zombie on port 7823 before attempting a fresh
+    // restart cycle. This prevents a permanent wedge after an OOM / crash
+    // that keeps `/health` silent indefinitely.
+    if *attempts >= MLX_MAX_RESTARTS + MLX_COOLING_TICKS {
+        tracing::info!("mlx: cooling period elapsed — resetting restart budget for a new cycle");
+        *attempts = 0;
+    }
+
     if *attempts >= MLX_MAX_RESTARTS {
         let port = mlx.lock().await.port;
         if mlx_server::health_check(port).await {
@@ -155,9 +174,11 @@ async fn supervise_mlx(mlx: &SharedMlxManager, attempts: &mut u32) {
             mlx.lock().await.status = mlx_server::MlxStatus::Running;
             tracing::info!("mlx: recovered after restart budget exhausted");
         } else {
+            *attempts += 1;
             tracing::warn!(
                 attempts = *attempts,
-                "mlx: restart budget exhausted — not restarting (see daemon's mlx.down notice)"
+                cooling_remaining = MLX_MAX_RESTARTS + MLX_COOLING_TICKS - *attempts,
+                "mlx: restart budget exhausted — cooling before next cycle",
             );
         }
         return;

--- a/ui/lib/bridge.ts
+++ b/ui/lib/bridge.ts
@@ -91,7 +91,13 @@ export function subscribe<T = unknown>(
   let unlisten: UnlistenFn | null = null
   // Prime with the current snapshot so the view isn't empty until the next emit
   // (skipped for delta streams, where `command` is null and the caller primes).
-  if (command) t.core.invoke(command, args).then((d) => { if (!cancelled) onData(d as T) }).catch(() => {})
+  if (command) {
+    const prime = () => t.core.invoke(command, args).then((d) => { if (!cancelled) onData(d as T) })
+    // Retry once after 2 s on the first failure: the tray can beat the daemon
+    // on startup, leaving the DB not yet open. Log on second failure so it is
+    // visible in DevTools rather than silently swallowed.
+    prime().catch(() => setTimeout(() => { if (!cancelled) prime().catch((e) => console.warn(`subscribe('${apiPath}') snapshot prime failed:`, e)) }, 2000))
+  }
   t.event
     .listen<T>(eventName, (e) => { if (!cancelled) onData(e.payload) })
     .then((un) => { if (cancelled) un(); else unlisten = un })


### PR DESCRIPTION
## Summary

Addresses all review findings raised by @adityaharishch on PR #330. Targets `pre-main` so it is included in the `pre-main → main` promotion.

### Fixed

**[HIGH CORRECTNESS] `meridian doctor` exits non-zero on every healthy post-fold install**
- `src/health/ui.rs`: Replaced the entire Node-era UI probe (HTTP GET `http://localhost:3939`, `/_next/static` asset check, `serve_mode_check`) with a single `Info` check: "dashboard embedded in the Tauri binary (no separate service)". The `com.meridiona.ui` launchd agent no longer exists post-fold; probing for it always produced a false `CRITICAL`.
- `src/health/platform.rs`: Removed `LABEL_UI` constant and replaced `ui_service()` body with the same `Info` check. The Node-era plist/PID check is gone.

**[HIGH CORRECTNESS] MLX restart-budget exhaustion permanently wedges**
- `tray/src-tauri/src/poll/mod.rs`: Added `MLX_COOLING_TICKS = 10`. After `MLX_MAX_RESTARTS` consecutive failures, `attempts` now increments through the cooling window. At `MAX_RESTARTS + COOLING_TICKS` (~10 min), it resets to `0` — `supervise()` re-runs, kills any zombie holding port 7823 (via the existing `KilledWedged` path), and allows a fresh restart cycle. Previously the tray would stay wedged forever.

**[HIGH SECURITY] `MERIDIAN_RUNTIME_MANIFEST_URL` redirectable in release builds**
- `tray/src-tauri/src/mlx_server.rs`: Gated the runtime env-var override behind `#[cfg(debug_assertions)]`. A release binary can no longer be redirected to an attacker-controlled manifest via a compromised environment variable.
- **Deferred**: The self-referential SHA-256 issue (manifest and tarball both served from the same origin — a compromised server can swap both atomically) requires an out-of-band trust root (minisign or embedded public key, similar to the updater's `pub_key`). This is a follow-up design task; the env-var gate closes the more immediate attack surface.

**[MEDIUM CORRECTNESS] `capture_coverage` datetime comparison bug**
- `src/health/capture.rs`: `datetime('now', ?1)` produces `'2026-06-23 17:00:00'` (space separator, no Z), but `insert_capture_frame` writes RFC 3339 `'2026-06-24T16:00:00.000000Z'` (T+Z). At index 10, `'T'` (0x54) > `' '` (0x20) — every row passed the filter, so the 1-day window never excluded anything and coverage ghosting went undetected. Fixed to `julianday(timestamp) > julianday('now', ?1)` following the `frame_freshness` pattern already in the same file.

**[MEDIUM CORRECTNESS] `subscribe()` snapshot prime silently swallows errors**
- `ui/lib/bridge.ts`: Replaced `.catch(() => {})` with retry-once-after-2s (targeted at the cold-DB startup race — tray can beat the daemon by ~1 s), then `console.warn(...)` on second failure. The view can still stay blank if the DB never opens, but the error is now visible in DevTools rather than silently dropped.

**[MEDIUM SECURITY] `sudo npm install` runs lifecycle scripts as root**
- `scripts/install-from-bundle.sh`: Added `--ignore-scripts` to both `npm install -g` lines (non-sudo and sudo paths). A compromised `screenpipe@0.4.6` tarball can no longer execute lifecycle scripts as root.

### Deferred (noted, not blocked)

- **`install.sh` OO sha256**: OpenObserve v0.90.3 tarball is downloaded without integrity verification. Fix requires sha256 of the official arm64 + amd64 tarballs. These need to be fetched from the OO release page and pinned — straightforward but requires the real values.
- **`build-mlx-runtime.sh` PBS version pin**: `releases/latest` is resolved at build time without a sha256 check. Fix requires pinning `PBS_RELEASE_TAG` to a specific astral-sh/python-build-standalone release and verifying the downloaded archive.
- **MLX manifest self-referential SHA-256**: Manifest and tarball served from the same origin — requires a minisign/ed25519 out-of-band trust root. Design tracked separately.

## Test plan
- [ ] `cargo clippy -- -D warnings` — clean ✅ (pre-push verified)
- [ ] `cargo test` — all passing ✅ (pre-push verified)
- [ ] UI build — clean ✅ (pre-push verified)
- [ ] `meridian doctor` on a post-fold install should show `Info` for the ui group, not `Critical`/`Warn`
- [ ] MLX wedge: manually exhaust `MLX_MAX_RESTARTS`; verify `attempts` increments through cooling and resets at tick 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKdh3tKWLZhtQ9FCfA5RYH