### PR TITLE
feat(ui): dashboard full-screen with dock + MLX server startup fix

### DIFF
--- a/services/agents/observability.py
+++ b/services/agents/observability.py
@@ -308,6 +308,31 @@ def extract_parent_context(traceparent: Optional[str]) -> Optional[Context]:
     return TraceContextTextMapPropagator().extract({"traceparent": traceparent})
 
 
+def instrument_agno() -> None:
+    """Attach agno's OpenInference instrumentor to the global TracerProvider.
+
+    Requires ``openinference-instrumentation-agno`` — if it isn't installed the
+    call is a no-op (warning logged).  The package is optional because the MLX
+    server works fine without OpenInference spans; it just won't export
+    Agent/Workflow run spans to OpenObserve.
+
+    Must be called after :func:`setup` so the global TracerProvider is already
+    configured.
+    """
+    try:
+        from openinference.instrumentation.agno import AgnoInstrumentor  # type: ignore
+    except ImportError:
+        logging.getLogger(__name__).warning(
+            "instrument_agno: openinference-instrumentation-agno not installed; "
+            "agno Agent/Workflow spans will not be exported. "
+            "Install with: pip install openinference-instrumentation-agno"
+        )
+        return
+
+    provider = trace.get_tracer_provider()
+    AgnoInstrumentor().instrument(tracer_provider=provider)
+
+
 # ──────────────────────── Tracing setup ────────────────────────────────────────
 def _configure_tracing(agent_name: str) -> None:
     resource = Resource.create({"service.name": agent_name})

--- a/services/agents/observability.py
+++ b/services/agents/observability.py
@@ -322,10 +322,16 @@ def instrument_agno() -> None:
     try:
         from openinference.instrumentation.agno import AgnoInstrumentor  # type: ignore
     except ImportError:
+        span = trace.get_current_span()
+        if span.is_recording():
+            span.set_status(trace.StatusCode.ERROR, "openinference-instrumentation-agno not installed")
         logging.getLogger(__name__).warning(
-            "instrument_agno: openinference-instrumentation-agno not installed; "
-            "agno Agent/Workflow spans will not be exported. "
-            "Install with: pip install openinference-instrumentation-agno"
+            "instrument_agno: agno spans will not be exported",
+            extra={
+                "package": "openinference-instrumentation-agno",
+                "reason": "not installed",
+                "fix": "pip install openinference-instrumentation-agno",
+            },
         )
         return
 
@@ -381,6 +387,8 @@ def _configure_logging(agent_name: str) -> None:
     # Sanitise agent_name to prevent path traversal — only allow chars that are
     # safe as a filename component (alphanumeric, hyphen, underscore).
     safe_name = "".join(c if c.isalnum() or c in "-_" else "_" for c in agent_name)
+    if not safe_name:
+        safe_name = "agent"
     log_path = log_dir / f"{safe_name}.jsonl"
 
     level_name = os.environ.get("LOG_LEVEL", "INFO").upper()

--- a/services/agents/observability.py
+++ b/services/agents/observability.py
@@ -378,7 +378,10 @@ def _configure_log_export(agent_name: str) -> Optional[logging.Handler]:
 def _configure_logging(agent_name: str) -> None:
     log_dir = Path(os.environ.get("MERIDIAN_LOG_DIR") or DEFAULT_LOG_DIR)
     log_dir.mkdir(parents=True, exist_ok=True)
-    log_path = log_dir / f"{agent_name}.jsonl"
+    # Sanitise agent_name to prevent path traversal — only allow chars that are
+    # safe as a filename component (alphanumeric, hyphen, underscore).
+    safe_name = "".join(c if c.isalnum() or c in "-_" else "_" for c in agent_name)
+    log_path = log_dir / f"{safe_name}.jsonl"
 
     level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)


### PR DESCRIPTION
## Summary

- **Dashboard full-screen with dock integration** — opens full-screen on launch with a dock icon; adds "Go to Setup" button wiring
- **Activation policy fix** — reverts activation policy on dashboard close + adds tracing on `open_setup`
- **MLX server startup fix** — adds missing `instrument_agno()` to `observability.py` (server was crashing on startup with `AttributeError` since the cleanup commit 155b26c added the call without writing the function)
- **Security** — sanitises `agent_name` before using it as a log filename in `_configure_logging` to prevent path traversal

## Test plan

- [ ] Open Meridian → dashboard opens full-screen with dock icon visible
- [ ] "Go to Setup" button navigates to the setup window
- [ ] Close dashboard → tray still visible, activation policy restored correctly
- [ ] Start MLX server via `dev-start.sh` — no `AttributeError` on startup, server reaches `Waiting for application startup` cleanly
- [ ] `meridian doctor` shows no capture or daemon faults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional agent instrumentation support for improved telemetry when the required package is installed.

* **Bug Fixes**
  * Improved log file naming by safely sanitizing agent names, reducing the risk of invalid or unsafe filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->