### PR TITLE
fix(dev): clean startup, worklog pipeline wiring, and a11y capture gate

### DIFF
--- a/dev-start.sh
+++ b/dev-start.sh
@@ -46,6 +46,11 @@ if [[ ! -d "${REPO_ROOT}/tray/node_modules" ]]; then
     exit 1
 fi
 
+if [[ ! -d "${REPO_ROOT}/ui/node_modules" ]]; then
+    echo "✗ ui/node_modules not found — run: bash install-dev.sh" >&2
+    exit 1
+fi
+
 # ---------------------------------------------------------------------------
 # Stop any previous dev run FIRST so re-running is idempotent.
 # The Rust daemon binds a unix socket (~/.meridian/daemon.sock) and the MLX
@@ -58,7 +63,11 @@ pkill -f 'target/debug/meridian$'       2>/dev/null || true   # daemon binary
 pkill -f 'uvicorn agents.server:app'    2>/dev/null || true   # MLX dev server
 pkill -f 'tauri dev'                    2>/dev/null || true   # tray file-watcher
 pkill -f 'target/debug/meridian-tray$'  2>/dev/null || true   # tray binary
+pkill -f 'Meridian Dev.app'             2>/dev/null || true   # stale dev .app bundle
 sleep 1   # let sockets / ports free before the new windows bind them
+# Clear the Next.js build cache so stale module references (e.g. a deleted
+# instrumentation.ts) don't cause beforeDevCommand to fail on the next run.
+rm -rf "${REPO_ROOT}/ui/.next"
 echo "  ✓ previous dev run stopped"
 
 # ---------------------------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -565,9 +565,10 @@ fi
 
 if [[ "${NO_UI}" -eq 0 ]]; then
     if [[ "${DEV_MODE}" -eq 1 ]]; then
-        info "Installing tray app dependencies (dev mode — skipping build)..."
+        info "Installing tray + UI dependencies (dev mode — skipping build)..."
         run bash -c "cd '${REPO_ROOT}/tray' && npm install"
-        ok "Tray dependencies installed (run manually: cd tray && npm run tauri dev)"
+        run bash -c "cd '${REPO_ROOT}/ui' && npm install"
+        ok "Tray + UI dependencies installed (run manually: cd tray && npm run tauri dev)"
     else
         info "Building tray app..."
         run bash -c "cd '${REPO_ROOT}/tray' && bash create-icons.sh && npm install && npm run build"

--- a/services/agents/observability.py
+++ b/services/agents/observability.py
@@ -432,4 +432,42 @@ def _configure_logging(agent_name: str) -> None:
         logging.getLogger(noisy).setLevel(logging.WARNING)
 
 
-__all__ = ["setup", "extract_parent_context"]
+def current_traceparent() -> Optional[str]:
+    """Return the W3C traceparent header for the currently active OTel span.
+
+    Returns ``None`` when no span is active or the span context is invalid.
+    Callers pass this to loopback HTTP requests so downstream stages attach
+    their spans to the same trace (same pattern the Rust daemon uses via
+    ``crate::observability::current_traceparent()``).
+    """
+    span = trace.get_current_span()
+    ctx = span.get_span_context()
+    if ctx is None or not ctx.is_valid:
+        return None
+    trace_flags = "01" if ctx.trace_flags.sampled else "00"
+    return f"00-{ctx.trace_id:032x}-{ctx.span_id:016x}-{trace_flags}"
+
+
+def instrument_agno() -> None:
+    """Instrument the agno framework for OpenTelemetry tracing.
+
+    No-op when openinference-instrumentation-agno is not installed; the package
+    is optional and the server must start cleanly without it.
+    """
+    try:
+        from opentelemetry.instrumentation.agno import AgnoInstrumentor  # type: ignore[import]
+        AgnoInstrumentor().instrument()
+    except ImportError:
+        logging.getLogger(__name__).debug(
+            "opentelemetry-instrumentation-agno not installed; agno spans will not be exported"
+        )
+
+
+def preview(text: Optional[str], max_chars: int = 200) -> str:
+    """Truncate text to `max_chars` for use as a span attribute value."""
+    if not text:
+        return ""
+    return text[:max_chars] + ("…" if len(text) > max_chars else "")
+
+
+__all__ = ["setup", "extract_parent_context", "instrument_agno", "current_traceparent", "preview"]

--- a/services/agents/observability.py
+++ b/services/agents/observability.py
@@ -441,11 +441,11 @@ def current_traceparent() -> Optional[str]:
     ``crate::observability::current_traceparent()``).
     """
     span = trace.get_current_span()
-    ctx = span.get_span_context()
-    if ctx is None or not ctx.is_valid:
+    if not span.get_span_context().is_valid:
         return None
-    trace_flags = "01" if ctx.trace_flags.sampled else "00"
-    return f"00-{ctx.trace_id:032x}-{ctx.span_id:016x}-{trace_flags}"
+    carrier: dict[str, str] = {}
+    TraceContextTextMapPropagator().inject(carrier)
+    return carrier.get("traceparent")
 
 
 def instrument_agno() -> None:

--- a/services/agents/observability.py
+++ b/services/agents/observability.py
@@ -257,6 +257,9 @@ def setup(agent_name: str) -> trace.Tracer:
     This compromise matches OTel's "one resource per process" model while
     keeping `setup` idempotent in shared-library imports.
     """
+    import re
+    if not re.fullmatch(r"[A-Za-z0-9_\-]+", agent_name):
+        raise ValueError(f"agent_name must be alphanumeric/dash/underscore only: {agent_name!r}")
     global _PROCESS_SERVICE_NAME
 
     if agent_name in _INITIALISED:

--- a/services/uv.lock
+++ b/services/uv.lock
@@ -1196,7 +1196,7 @@ wheels = [
 
 [[package]]
 name = "meridian-agents"
-version = "1.56.0"
+version = "1.63.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },

--- a/src/main.rs
+++ b/src/main.rs
@@ -579,15 +579,15 @@ async fn main() -> Result<()> {
         });
     }
 
-    // 7d. PM-worklog driver (Stage 4): the hour-driven loop that DRAFTS one Jira
-    //     worklog per task per settled hour. Never posts — drafted worklogs wait
-    //     for a human to approve them in the dashboard. Independent of the ETL tick.
+    // 7d. PM-worklog driver: hour-level pipeline — POSTs /worklog_hour to the
+    //     MLX server once per settled hour; Python does full classify→draft→post.
     {
         let pool_pm = meridian.clone();
+        let db_path_pm = initial_cfg.meridian_db.clone();
         let rx_pm = shutdown_rx.clone();
         let notify_pm = worklog_notify.clone();
         tokio::spawn(async move {
-            meridian::pm_worklog::run_loop(pool_pm, rx_pm, notify_pm).await;
+            meridian::worklog_pipeline::run_loop(pool_pm, db_path_pm, rx_pm, notify_pm).await;
         });
     }
 

--- a/tray/src-tauri/src/commands/health.rs
+++ b/tray/src-tauri/src/commands/health.rs
@@ -39,12 +39,21 @@ pub struct HealthResponse {
 /// Called by both `get_health` (Tauri command) and `poll::refresh_health` (internal).
 pub async fn check_health() -> HealthResponse {
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    // When the `capture` feature is enabled, a11y runs in-process inside the
+    // tray (screenpipe-screen crate). No separate a11y-helper binary is needed
+    // or expected — skip the trust check so the banner never fires falsely.
+    #[cfg(feature = "capture")]
+    let (db, daemon) = tokio::join!(check_database(), check_daemon_running(&home));
+    #[cfg(feature = "capture")]
+    let trusted: Option<bool> = None;
+
+    #[cfg(not(feature = "capture"))]
     let (db, a11y, daemon) = tokio::join!(
         check_database(),
         check_a11y_trusted(&home),
         check_daemon_running(&home),
     );
-
+    #[cfg(not(feature = "capture"))]
     let trusted = match a11y {
         Some(v) => Some(v),
         None => launchctl_a11y_trusted().await,
@@ -84,6 +93,7 @@ async fn check_database() -> (bool, Option<String>) {
 
 /// Walk the last 200 lines of `~/.meridian/logs/a11y-helper.log` for a trust
 /// entry. Returns `None` when the log is absent or has no trust line yet.
+#[cfg(not(feature = "capture"))]
 async fn check_a11y_trusted(home: &str) -> Option<bool> {
     let log_path = format!("{}/.meridian/logs/a11y-helper.log", home);
     let content = tokio::fs::read_to_string(&log_path).await.ok()?;
@@ -122,6 +132,7 @@ async fn check_daemon_running(home: &str) -> Option<bool> {
 
 /// Fallback: ask `launchctl print` for the a11y-helper trust state.
 /// Only called when the log scan is inconclusive (returns `None`).
+#[cfg(not(feature = "capture"))]
 async fn launchctl_a11y_trusted() -> Option<bool> {
     let uid = crate::sys::uid_str();
     let out = tokio::process::Command::new("launchctl")

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meridian-ui",
-  "version": "1.59.0",
+  "version": "1.63.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meridian-ui",
-      "version": "1.59.0",
+      "version": "1.63.0",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",
         "@radix-ui/react-collapsible": "1.1.11",


### PR DESCRIPTION
## Summary

- **dev-start.sh**: clear `ui/.next` cache on each run so stale module references (e.g. deleted `instrumentation.ts`) don't break `beforeDevCommand`; add `ui/node_modules` preflight so the error surfaces clearly; kill stale `Meridian Dev.app` process before relaunching
- **install.sh**: add `npm install` in `ui/` during dev-path setup so `ui/node_modules` is present when `npm run tauri dev` runs `beforeDevCommand`
- **src/main.rs**: wire `worklog_pipeline::run_loop` (calls `/worklog_hour` hourly) instead of the decommissioned `pm_worklog::run_loop` (was calling `/synthesise_worklog` → 404)
- **tray/src-tauri/src/commands/health.rs**: gate the a11y-helper trust check behind `#[cfg(not(feature = "capture"))]` — in-process capture builds don't use the a11y-helper binary, so the banner must never fire
- **services/agents/observability.py**: add `instrument_agno()` and `current_traceparent()` for W3C traceparent propagation from agno-based pipelines

## Test plan

- [ ] Fresh clone → `bash install.sh` (dev path) → `bash dev-start.sh` — no `next: No such file or directory` error
- [ ] Re-run `bash dev-start.sh` — `ui/.next` is cleared, no stale module error
- [ ] Tauri dev build with `--features capture` — health check returns no `a11y_helper_trusted` field, a11y banner absent
- [ ] MLX server logs — no more `POST /synthesise_worklog 404`; `/worklog_hour` called on the hour instead