### PR TITLE
fix(integrations): address deferred review findings from #338

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4467,6 +4467,7 @@ dependencies = [
  "block2",
  "chrono",
  "cidre 0.13.1",
+ "dotenvy",
  "futures-util",
  "meridian",
  "meridian-core",

--- a/meridian-oauth/src/jira.rs
+++ b/meridian-oauth/src/jira.rs
@@ -24,7 +24,14 @@ use tokio::sync::Mutex;
 use crate::flow::{self, ProviderSpec};
 use crate::store::{self, OAuthTokens};
 
-// Static mutex serializes concurrent token refreshes to avoid race conditions.
+// FIXME(cross-process-lock): this mutex is per-process. The daemon and the tray
+// each compile meridian-oauth and hold independent mutex instances. If both call
+// ensure_fresh() simultaneously (daemon background sync + tray user action), both
+// read the same expired token store, both POST to Atlassian's token endpoint, and
+// the second POST 401s because the first call already rotated and consumed the
+// refresh token — permanently invalidating the pair. Fix requires a file lock on
+// the OAuth store path (e.g. via the `fd-lock` crate) to serialise across processes.
+// Tracked as a follow-up; in practice the race requires exact timing overlap.
 fn refresh_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
@@ -99,7 +106,14 @@ const ACCESSIBLE_RESOURCES_URL: &str = "https://api.atlassian.com/oauth/token/ac
 /// fetch, `write:jira-work` powers worklog/comment posting, `read:jira-user`
 /// powers the `/myself` health probe (`meridian doctor`), and `offline_access` is
 /// what yields a refresh token at all.
+///
+/// Used by `ensure_fresh()` which resolves the secret from env — fine for the
+/// daemon. Interactive `login()` takes the secret explicitly to avoid `set_var`.
 fn spec() -> ProviderSpec {
+    spec_with_secret(client_secret())
+}
+
+fn spec_with_secret(secret: String) -> ProviderSpec {
     ProviderSpec {
         authorize_url: "https://auth.atlassian.com/authorize",
         token_url: "https://auth.atlassian.com/oauth/token",
@@ -108,7 +122,7 @@ fn spec() -> ProviderSpec {
             ("audience", "api.atlassian.com".to_string()),
             ("prompt", "consent".to_string()),
         ],
-        client_secret: Some(client_secret()),
+        client_secret: Some(secret),
     }
 }
 
@@ -174,9 +188,13 @@ async fn discover_cloud(access_token: &str) -> Result<(String, String)> {
 
 /// Run the interactive browser login and persist the resulting tokens. Returns
 /// the chosen site URL for a friendly confirmation message.
-pub async fn login(client_id: &str, port: u16) -> Result<String> {
-    let secret = client_secret();
-    if secret.trim().is_empty() {
+///
+/// `client_secret` is passed explicitly rather than read from `std::env` so
+/// callers (the tray's in-process flow) can source it from `.env` without
+/// calling `std::env::set_var` on a Tokio worker thread (POSIX setenv is not
+/// thread-safe). Pass [`client_secret()`] when you want the env-var resolution.
+pub async fn login(client_id: &str, client_secret: &str, port: u16) -> Result<String> {
+    if client_secret.trim().is_empty() {
         bail!(
             "Jira OAuth requires a client secret that is baked in at build time via \
              MERIDIAN_JIRA_OAUTH_CLIENT_SECRET. This is a source build without that \
@@ -184,7 +202,12 @@ pub async fn login(client_id: &str, port: u16) -> Result<String> {
              or use the API-token fallback (JIRA_BASE_URL / JIRA_EMAIL / JIRA_API_TOKEN)."
         );
     }
-    let tokens = flow::run_authcode_flow(client_id, &spec(), port).await?;
+    let tokens = flow::run_authcode_flow(
+        client_id,
+        &spec_with_secret(client_secret.to_string()),
+        port,
+    )
+    .await?;
 
     // No refresh token ⇒ `offline_access` wasn't granted (app misconfigured or the
     // scope wasn't consented). Fail NOW with a clear message rather than letting
@@ -236,7 +259,22 @@ pub async fn ensure_fresh() -> Result<OAuthTokens> {
     if !resp.scope.is_empty() {
         t.scopes = resp.scope;
     }
-    store::save(&t).context("persisting refreshed Jira OAuth tokens")?;
+    // Save the rotated tokens. If save fails (disk full, permissions), log a
+    // critical error and return the in-memory tokens anyway — the access token
+    // is valid for ~1h so the current request succeeds. On the next expiry the
+    // stored (now-invalid) refresh token will cause a 401 and the user must
+    // re-authenticate. A critical log surfaces this before it happens.
+    match store::save(&t) {
+        Ok(()) => {}
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                "CRITICAL: failed to persist rotated Jira refresh token — access token \
+                 valid for ~1h but re-authentication required after expiry. Fix \
+                 permissions at ~/.meridian/oauth/ then re-run `meridian oauth-login jira`."
+            );
+        }
+    }
     Ok(t)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,8 @@ async fn main() -> Result<()> {
                 println!(
                     "Starting Jira browser authorization (redirect http://127.0.0.1:{port}/callback)…"
                 );
-                match meridian::intelligence::oauth::jira::login(&client_id, port).await {
+                let client_secret = meridian::intelligence::oauth::jira::client_secret();
+                match meridian::intelligence::oauth::jira::login(&client_id, &client_secret, port).await {
                     Ok(site) => println!(
                         "\n✓ Jira connected: {site}\n  Tokens saved to ~/.meridian/oauth/jira.json — run `meridian restart` to pick them up."
                     ),

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ futures-util = "0.3"
 sha2 = "0.10"
 chrono = { version = "0.4", features = ["clock"] }
 anyhow = "1"
+dotenvy = "0.15"
 # Lean shared data layer (DB row types + read queries) — NOT the full daemon.
 meridian-core = { path = "../../meridian-core" }
 # Shared OAuth/token engine — lets the tray run the Jira/Trello browser login

--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -38,9 +38,16 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tauri::State;
 use tracing::Instrument;
+
+// Per-provider in-flight guard: prevents two concurrent OAuth flows from racing
+// to bind the same loopback port or write the same token file. Checked before
+// spawning; cleared (success or failure) inside the spawned task.
+static JIRA_OAUTH_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+static TRELLO_OAUTH_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
 
 /// Providers connected via browser OAuth — their token store under
 /// `~/.meridian/oauth/<p>.json` is the connect/disconnect surface.
@@ -130,30 +137,15 @@ fn home() -> Option<PathBuf> {
     std::env::var("HOME").ok().map(PathBuf::from)
 }
 
+/// Parse a `.env` file using dotenvy so edge cases (export prefix, quoted
+/// values, backslash continuation) are handled the same way the daemon handles
+/// them via `dotenvy::dotenv_override()`. The old hand-rolled parser diverged
+/// on these cases, which could cause the tray and daemon to read different
+/// values for the same key.
 fn parse_env(path: &std::path::Path) -> HashMap<String, String> {
-    let mut out = HashMap::new();
-    let Ok(contents) = std::fs::read_to_string(path) else {
-        return out;
-    };
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
-        }
-        if let Some(eq) = trimmed.find('=') {
-            if eq < 1 {
-                continue;
-            }
-            let key = trimmed[..eq].trim();
-            // Strip surrounding quotes so KEY="" and KEY='' register as empty.
-            let raw = trimmed[eq + 1..].trim();
-            let val = raw.trim_matches('"').trim_matches('\'').trim();
-            if !key.is_empty() && !val.is_empty() {
-                out.insert(key.to_string(), val.to_string());
-            }
-        }
-    }
-    out
+    dotenvy::from_path_iter(path)
+        .map(|iter| iter.filter_map(|item| item.ok()).collect())
+        .unwrap_or_default()
 }
 
 /// A value counts as "set" only if present and not a leftover `.env.example`
@@ -404,19 +396,26 @@ pub async fn save_integration_token(body: SaveTokenBody) -> Result<serde_json::V
         let _ = std::fs::remove_file(&sentinel);
     }
 
-    // Resolve + write inside a scope so the &Path borrow of `mode` is released
-    // before the daemon-reload await below.
+    // Resolve + write. `upsert_env` is synchronous std::fs I/O; run it on the
+    // blocking thread pool so we don't stall the Tokio reactor.
+    let key_count = updates.len();
     {
         let mode = crate::install::detect_install_mode();
-        let env_path = mode.env_path().ok_or("could not resolve .env path")?;
-        upsert_env(env_path, &updates).map_err(|e| {
-            tracing::warn!(error = %e, "could not write .env");
-            format!("could not write .env: {e}")
-        })?;
+        let env_path = mode
+            .env_path()
+            .ok_or("could not resolve .env path")?
+            .to_owned();
+        tokio::task::spawn_blocking(move || upsert_env(&env_path, &updates))
+            .await
+            .map_err(|e| format!("spawn_blocking panicked: {e}"))?
+            .map_err(|e| {
+                tracing::warn!(error = %e, "could not write .env");
+                format!("could not write .env: {e}")
+            })?;
     }
     tracing::info!(
         provider,
-        keys = updates.len(),
+        keys = key_count,
         "integration token saved to .env"
     );
 
@@ -605,37 +604,75 @@ pub async fn start_oauth(body: StartOAuthBody) -> Result<StartOAuthResponse, Str
     }
 }
 
-/// Forward connect-time OAuth creds from the active `.env` into the tray's
-/// process env so the in-process `meridian_oauth` resolvers (`client_id`,
-/// `client_secret`, `redirect_port`, `app_key` — they read `std::env`) pick them
-/// up. Packaged builds bake the Jira secret at compile time and inject
-/// `TRELLO_APP_KEY` into the bundle `.env`; this is the dev/source path and the
-/// bundle-`.env` path, mirroring the env the old subprocess flow forwarded. Only
-/// sets a key absent from the process env, so a real env var always wins.
-fn forward_oauth_env() {
-    let mode = crate::install::detect_install_mode();
-    let dot_env = mode.env_path().map(parse_env).unwrap_or_default();
-    for key in [
-        "JIRA_OAUTH_CLIENT_SECRET",
-        "JIRA_OAUTH_CLIENT_ID",
-        "JIRA_OAUTH_REDIRECT_PORT",
-        "TRELLO_APP_KEY",
-        "TRELLO_OAUTH_REDIRECT_PORT",
-    ] {
-        if std::env::var_os(key).is_none() {
-            if let Some(val) = dot_env.get(key) {
-                std::env::set_var(key, val);
-            }
-        }
-    }
-}
-
 /// Run the jira/trello browser login in-process on the tray's runtime. Returns
 /// immediately (`started=true`); a spawned task drives the flow and writes the
 /// token store on success or the `.error` sentinel (with the REAL error string —
 /// no log-tail guessing) on failure, which [`get_oauth_status`] surfaces.
+///
+/// Credentials are read from `.env` and passed explicitly to `meridian_oauth`
+/// functions — avoiding `std::env::set_var` on a Tokio worker thread (POSIX
+/// setenv is not thread-safe under concurrent env reads). A per-provider
+/// [`AtomicBool`] prevents two flows from racing to bind the same loopback port.
 fn start_oauth_in_process(provider: String) -> Result<StartOAuthResponse, String> {
-    forward_oauth_env();
+    // Resolve credentials from .env WITHOUT mutating process env.
+    let mode = crate::install::detect_install_mode();
+    let dot_env = mode.env_path().map(parse_env).unwrap_or_default();
+    let jira_secret = dot_env
+        .get("JIRA_OAUTH_CLIENT_SECRET")
+        .cloned()
+        .unwrap_or_else(meridian_oauth::jira::client_secret);
+    let jira_client_id = dot_env
+        .get("JIRA_OAUTH_CLIENT_ID")
+        .cloned()
+        .unwrap_or_else(meridian_oauth::jira::client_id);
+    let jira_port = dot_env
+        .get("JIRA_OAUTH_REDIRECT_PORT")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(meridian_oauth::jira::redirect_port);
+    let trello_key = dot_env
+        .get("TRELLO_APP_KEY")
+        .cloned()
+        .unwrap_or_else(meridian_oauth::trello::app_key);
+    let trello_port = dot_env
+        .get("TRELLO_OAUTH_REDIRECT_PORT")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(meridian_oauth::trello::redirect_port);
+
+    // Validate credentials before spawning — surface "not configured" immediately
+    // rather than letting the user wait for a browser callback that never works.
+    if provider == "jira" && jira_secret.trim().is_empty() {
+        return Err(
+            "Jira OAuth requires a client secret baked in at build time \
+             (MERIDIAN_JIRA_OAUTH_CLIENT_SECRET). Source builds must set \
+             JIRA_OAUTH_CLIENT_SECRET in ~/.meridian/.env, or use the API-token path instead."
+                .to_string(),
+        );
+    }
+    if provider == "trello" && trello_key.trim().is_empty() {
+        return Err(
+            "Trello OAuth requires a Power-Up app key. Set TRELLO_APP_KEY in \
+             ~/.meridian/.env. Register a Power-Up at https://trello.com/power-ups/admin \
+             and add http://127.0.0.1:9123/ as an allowed origin."
+                .to_string(),
+        );
+    }
+
+    // Claim the per-provider in-flight slot. A second start_oauth call while
+    // a flow is running returns an error — port 9123 can't be shared and the
+    // token file would be written by two racing tasks.
+    let in_flight: &'static AtomicBool = match provider.as_str() {
+        "trello" => &TRELLO_OAUTH_IN_FLIGHT,
+        _ => &JIRA_OAUTH_IN_FLIGHT,
+    };
+    if in_flight
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Err(format!(
+            "{provider} OAuth is already in progress — check your browser"
+        ));
+    }
+
     // Clear any previous error sentinel before launching a fresh flow.
     if let Some(sentinel) = oauth_error_path(&provider) {
         let _ = std::fs::remove_file(&sentinel);
@@ -644,21 +681,16 @@ fn start_oauth_in_process(provider: String) -> Result<StartOAuthResponse, String
     let task_provider = provider.clone();
     tauri::async_runtime::spawn(async move {
         let result: anyhow::Result<()> = match task_provider.as_str() {
-            "jira" => meridian_oauth::jira::login(
-                &meridian_oauth::jira::client_id(),
-                meridian_oauth::jira::redirect_port(),
-            )
-            .await
-            .map(|_site_url| ()),
-            "trello" => {
-                meridian_oauth::trello::login(
-                    &meridian_oauth::trello::app_key(),
-                    meridian_oauth::trello::redirect_port(),
-                )
+            "jira" => meridian_oauth::jira::login(&jira_client_id, &jira_secret, jira_port)
                 .await
-            }
-            _ => anyhow::bail!("unhandled OAuth provider: {task_provider}"),
+                .map(|_site_url| ()),
+            "trello" => meridian_oauth::trello::login(&trello_key, trello_port).await,
+            // Return an Err VALUE — `bail!` would `return` from the whole async
+            // block, forcing it to be Result-typed and breaking the trailing match.
+            _ => Err(anyhow::anyhow!("unhandled OAuth provider: {task_provider}")),
         };
+        // Always clear the in-flight flag before returning, regardless of outcome.
+        in_flight.store(false, Ordering::SeqCst);
         match result {
             Ok(()) => tracing::info!(provider = %task_provider, "in-process OAuth login succeeded"),
             Err(e) => {


### PR DESCRIPTION
## Summary

Seven architectural findings from the PR #338 review that were deferred to a follow-up:

- **`login()` explicit secret param** — removes `std::env::set_var` from the Tokio worker thread (`forward_oauth_env` deleted). POSIX `setenv` is not async-signal-safe and Rust 1.93+ warns on it. Credentials are now read from `.env` and passed directly to `meridian_oauth` login functions.
- **`ensure_fresh()` graceful degradation** — if `store::save` fails after Atlassian rotates the refresh token, the old code hard-failed, permanently locking out the user. Now logs a `CRITICAL` error and returns the in-memory access token (valid ~1h), giving the user a window to fix disk permissions before re-authing.
- **`FIXME(cross-process-lock)` comment** on `refresh_lock()` in `jira.rs` — documents the daemon/tray race where independent per-process mutexes don't prevent a double-refresh race across processes. Tracked for a future `fd-lock`-based fix.
- **`parse_env` → dotenvy** — the hand-rolled parser diverged from the daemon's `dotenvy::dotenv_override()` on edge cases (export prefix, quoted values, backslash continuation). Now uses `dotenvy::from_path_iter` so both processes agree on credential values.
- **Early secret/key validation** — `start_oauth_in_process` now validates `client_secret` (jira) and `app_key` (trello) before spawning. Returns a clear error immediately rather than letting the user wait through the browser callback for a flow that was never going to succeed.
- **Per-provider `AtomicBool` in-flight guard** — `JIRA_OAUTH_IN_FLIGHT` / `TRELLO_OAUTH_IN_FLIGHT` prevent two concurrent flows from racing to bind the same loopback port or write the same token file. The guard is always cleared (success or failure) before the spawned task exits.
- **`spawn_blocking` for `upsert_env`** — `upsert_env` does synchronous `std::fs` I/O and was being called directly in an `async fn`. Wrapped in `tokio::task::spawn_blocking`.

## Test plan

- [ ] `cargo clippy -- -D warnings` passes on `meridian` and `meridian-tray` (verified in pre-commit hook)
- [ ] `cargo fmt --check` passes (verified in pre-commit hook)
- [ ] `cargo test` on the main workspace passes
- [ ] Manual: Jira OAuth connect flow works end-to-end in a dev build
- [ ] Manual: Double-clicking "Connect Jira" while flow is in progress returns the in-flight error message
- [ ] Manual: Source build with empty `JIRA_OAUTH_CLIENT_SECRET` shows the "not configured" error immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)