### PR TITLE
fix(capture): fall back to OCR when browser a11y tree is chrome-only

### DIFF
--- a/tray/src-tauri/src/capture/screenpipe.rs
+++ b/tray/src-tauri/src/capture/screenpipe.rs
@@ -109,12 +109,23 @@ fn try_walk_a11y(walker: &dyn TreeWalkerPlatform) -> A11yOutcome {
                 debug!(app = %snap.app_name, "capture: a11y tree empty (warm-up) — OCR fallback");
                 return A11yOutcome::FallBackToOcr;
             }
+            let app_lower = snap.app_name.to_lowercase();
+            // Canvas-rendered apps (Figma, design tools): content is GPU pixels,
+            // not in the AX tree. The a11y snapshot gives only toolbar/menu text;
+            // OCR is the only path to actual canvas content.
+            if is_canvas_app(&app_lower) {
+                debug!(
+                    app = %snap.app_name,
+                    "capture: canvas app — a11y can't reach GPU content, OCR fallback"
+                );
+                return A11yOutcome::FallBackToOcr;
+            }
             // Browsers return non-empty a11y text even when the page hasn't been
             // exposed: the tab strip (AXTab/AXButton nodes) alone gives ~695 chars
-            // of tab titles. Without this check we'd emit chrome-only text and
-            // never capture actual page content. Fall back to OCR so the screen
-            // pixels give us real page content for this tick.
-            if a11y_content_is_thin(&snap) {
+            // of tab titles. Gate on is_browser so we don't apply the density
+            // heuristic to non-browser apps (sparse dialogs, preferences panes, etc.)
+            // where thin a11y text is expected and OCR adds no value.
+            if is_browser(&app_lower) && a11y_content_is_thin(&snap) {
                 debug!(
                     app = %snap.app_name,
                     chars = snap.text_content.len(),
@@ -151,6 +162,32 @@ fn try_walk_a11y(walker: &dyn TreeWalkerPlatform) -> A11yOutcome {
     }
 }
 
+/// Returns `true` when `app_lower` is a known browser.
+fn is_browser(app_lower: &str) -> bool {
+    [
+        "chrome", "safari", "firefox", "arc", "edge", "brave", "opera", "vivaldi",
+    ]
+    .iter()
+    .any(|b| app_lower.contains(b))
+}
+
+/// Returns `true` when `app_lower` is a canvas-rendering design tool whose
+/// content is drawn to a GPU surface and is therefore absent from the AX tree.
+fn is_canvas_app(app_lower: &str) -> bool {
+    [
+        "figma",
+        "canva",
+        "miro",
+        "sketch",
+        "origami",
+        "principle",
+        "framer",
+        "penpot",
+    ]
+    .iter()
+    .any(|a| app_lower.contains(a))
+}
+
 /// Returns `true` when the a11y snapshot contains mostly browser-chrome roles
 /// (tab strip, toolbar, buttons) rather than real page content. When this is
 /// the case, the tray falls back to OCR so we capture what's actually on screen.
@@ -180,6 +217,13 @@ fn a11y_content_is_thin(snap: &TreeSnapshot) -> bool {
         "AXComboBox",
         "AXScrollBar",
     ];
+
+    // If the walker returned no node metadata (max-node budget exhausted and
+    // all nodes were elided), we have no role data to reason about — treat as
+    // non-thin so the text_content we do have is used rather than discarded.
+    if snap.nodes.is_empty() {
+        return false;
+    }
 
     let mut content_chars: usize = 0;
     let mut total_chars: usize = 0;

--- a/tray/src-tauri/src/capture/screenpipe.rs
+++ b/tray/src-tauri/src/capture/screenpipe.rs
@@ -31,7 +31,7 @@ use std::time::Duration;
 
 use chrono::Utc;
 use screenpipe_a11y::tree::{
-    create_tree_walker, TreeWalkResult, TreeWalkerConfig, TreeWalkerPlatform,
+    create_tree_walker, TreeSnapshot, TreeWalkResult, TreeWalkerConfig, TreeWalkerPlatform,
 };
 use screenpipe_screen::capture_screenshot_by_window::{capture_all_visible_windows, WindowFilters};
 use tracing::{debug, info, warn};
@@ -109,6 +109,19 @@ fn try_walk_a11y(walker: &dyn TreeWalkerPlatform) -> A11yOutcome {
                 debug!(app = %snap.app_name, "capture: a11y tree empty (warm-up) — OCR fallback");
                 return A11yOutcome::FallBackToOcr;
             }
+            // Browsers return non-empty a11y text even when the page hasn't been
+            // exposed: the tab strip (AXTab/AXButton nodes) alone gives ~695 chars
+            // of tab titles. Without this check we'd emit chrome-only text and
+            // never capture actual page content. Fall back to OCR so the screen
+            // pixels give us real page content for this tick.
+            if a11y_content_is_thin(&snap) {
+                debug!(
+                    app = %snap.app_name,
+                    chars = snap.text_content.len(),
+                    "capture: a11y tree is browser-chrome-only — OCR fallback for page content"
+                );
+                return A11yOutcome::FallBackToOcr;
+            }
             debug!(
                 app = %snap.app_name,
                 chars = snap.text_content.len(),
@@ -136,6 +149,58 @@ fn try_walk_a11y(walker: &dyn TreeWalkerPlatform) -> A11yOutcome {
             A11yOutcome::FallBackToOcr
         }
     }
+}
+
+/// Returns `true` when the a11y snapshot contains mostly browser-chrome roles
+/// (tab strip, toolbar, buttons) rather than real page content. When this is
+/// the case, the tray falls back to OCR so we capture what's actually on screen.
+///
+/// Ported from `screenpipe-capture::paired_capture::a11y_content_is_thin` —
+/// the same heuristic used by the screenpipe CLI's paired-capture path.
+///
+/// Thresholds:
+/// - fewer than 100 total chars → always thin (no meaningful content)
+/// - content-role chars < 30 % of total → thin (mostly chrome)
+fn a11y_content_is_thin(snap: &TreeSnapshot) -> bool {
+    // AX roles that represent browser UI chrome rather than document content.
+    const CHROME_ROLES: &[&str] = &[
+        "AXButton",
+        "AXMenuItem",
+        "AXMenuBar",
+        "AXMenu",
+        "AXToolbar",
+        "AXTabGroup",
+        "AXTab",
+        "AXPopUpButton",
+        "AXCheckBox",
+        "AXRadioButton",
+        "AXDisclosureTriangle",
+        "AXSlider",
+        "AXIncrementor",
+        "AXComboBox",
+        "AXScrollBar",
+    ];
+
+    let mut content_chars: usize = 0;
+    let mut total_chars: usize = 0;
+
+    for node in &snap.nodes {
+        let len = node.text.len();
+        if len == 0 {
+            continue;
+        }
+        total_chars += len;
+        if !CHROME_ROLES.iter().any(|r| node.role == *r) {
+            content_chars += len;
+        }
+    }
+
+    if total_chars < 100 {
+        return true;
+    }
+
+    let ratio = content_chars as f64 / total_chars as f64;
+    ratio < 0.3
 }
 
 /// Route one tick's [`A11yOutcome`]: send the a11y frame, drop a privacy-skip,


### PR DESCRIPTION
## Summary

- Chrome's a11y tree returns non-empty text even before page content is materialised — the tab strip (`AXTab`/`AXButton` nodes) contributes ~695 chars of tab titles alone
- `try_walk_a11y` had no thinness check, so it returned an `Accessibility` frame from chrome-only text and the OCR fallback never ran → actual page content was never captured
- Ports the content-density heuristic from `screenpipe-capture::paired_capture::a11y_content_is_thin` (the screenpipe CLI path that had this working): classifies each node's role as chrome vs content, falls back to OCR when content-role chars < 30% of total (or < 100 total chars)

## Root cause

`tray/src-tauri/src/capture/screenpipe.rs:try_walk_a11y` only checked for an empty `text_content` to decide whether to OCR. Chrome's tab strip is non-empty (always present), so it always "won" over OCR — page content was never captured from day one on the screenpipe-fork tray path.

The screenpipe CLI (`paired_capture.rs`) already had `a11y_content_is_thin` solving exactly this; the tray's simplified engine was missing it.

## Test plan

- [ ] Open Chrome to any page with visible text content
- [ ] Verify `capture_frames` rows now have `accessibility_text` / `full_text` with actual page text, not just tab titles
- [ ] Verify incognito windows still produce no frames (the `Skipped` path is untouched)
- [ ] Verify non-browser apps (VS Code, Slack) still use the a11y path (their nodes are mostly `AXStaticText`/`AXGroup` → ratio > 0.3)