### PR TITLE
fix(setup): address CodeRabbit findings on PR #347

### DIFF
--- a/services/agents/_state.py
+++ b/services/agents/_state.py
@@ -13,7 +13,7 @@ app_state: dict[str, Any] = {}
 # `received`/`total` are AGGREGATE byte counts summed across every pipeline model
 # (llm + reranker + embedder), so the wizard's progress bar has a single honest
 # denominator. The wire contract the Rust tray decodes is exactly
-# state/received/total/error (tray/src-tauri/src/mlx_server.rs::PrefetchStatus);
+# state/received/total/error/speed (tray/src-tauri/src/mlx_server.rs::PrefetchStatus);
 # `models` is an additive per-model breakdown the tray ignores.
 prefetch_state: dict[str, Any] = {
     "state": "idle",

--- a/services/agents/routes/prefetch.py
+++ b/services/agents/routes/prefetch.py
@@ -139,7 +139,7 @@ def _run_prefetch(specs: list[model_registry.ModelSpec]) -> None:
                 prefetch_state["error"] = str(exc)
                 prefetch_state["speed"] = 0.0
             root.set_status(trace.Status(trace.StatusCode.ERROR, str(exc)))
-            log.error("server: model prefetch failed", extra={"error": str(exc)})
+            log.exception("server: model prefetch failed", extra={"error": str(exc)})
 
 
 @router.post("/prefetch_model")
@@ -188,7 +188,7 @@ async def prefetch_model() -> dict:
         return_exceptions=True,
     )
     totals: list[int] = []
-    for spec, r in zip(specs, probe_results):
+    for spec, r in zip(specs, probe_results, strict=True):
         if isinstance(r, int):
             totals.append(r)
         else:

--- a/services/agents/routes/prefetch.py
+++ b/services/agents/routes/prefetch.py
@@ -33,10 +33,9 @@ router = APIRouter()
 # Speed is derived from the growth of on-disk `received` between /prefetch_status
 # polls — NOT from a tqdm hook. hf_xet (the Xet accelerator these models use) does
 # its download in Rust and bypasses the classic tqdm bar, so a tqdm_class never
-# fires; the byte-delta approach works for any backend. These hold the last
-# (received, monotonic-time) sample to diff against.
-_last_recv = 0
-_last_recv_ts = 0.0
+# fires; the byte-delta approach works for any backend. Stored as a dict so both
+# functions can mutate it in-place without `global` declarations.
+_speed_state: dict[str, float | int] = {"recv": 0, "ts": 0.0}
 
 
 def _hf_cache_dir_for(model_id: str) -> Path:
@@ -160,13 +159,13 @@ async def prefetch_model() -> dict:
 
     from fastapi.concurrency import run_in_threadpool
 
-    global _last_recv, _last_recv_ts
     specs = list(model_registry.ALL_SPECS)
 
     with prefetch_lock:
         if prefetch_state["state"] in ("downloading", "done"):
             return dict(prefetch_state)  # idempotent — no duplicate downloads
-        _last_recv, _last_recv_ts = 0, 0.0
+        _speed_state["recv"] = 0
+        _speed_state["ts"] = 0.0
         prefetch_state.update(
             state="downloading",
             received=0,
@@ -223,7 +222,6 @@ async def prefetch_status() -> dict:
     """
     from fastapi.concurrency import run_in_threadpool
 
-    global _last_recv, _last_recv_ts
     with prefetch_lock:
         st = dict(prefetch_state)
         models = list(st.get("models", []))
@@ -252,12 +250,13 @@ async def prefetch_status() -> dict:
     # EMA-smoothed; decays to 0 when bytes stop flowing (delta 0) or the run ends.
     now = time.monotonic()
     with prefetch_lock:
-        if st["state"] == "downloading" and _last_recv_ts and now > _last_recv_ts:
-            inst = max(0, st["received"] - _last_recv) / (now - _last_recv_ts)
+        if st["state"] == "downloading" and _speed_state["ts"] and now > _speed_state["ts"]:
+            inst = max(0, st["received"] - _speed_state["recv"]) / (now - _speed_state["ts"])
             prev = prefetch_state.get("speed", 0.0) or 0.0
             prefetch_state["speed"] = inst if prev == 0.0 else prev * 0.5 + inst * 0.5
         elif st["state"] != "downloading":
             prefetch_state["speed"] = 0.0
-        _last_recv, _last_recv_ts = st["received"], now
+        _speed_state["recv"] = st["received"]
+        _speed_state["ts"] = now
         st["speed"] = prefetch_state["speed"]
     return st

--- a/services/agents/session_distiller.py
+++ b/services/agents/session_distiller.py
@@ -96,7 +96,7 @@ _ENTITY_RESCUE_CAP = 4
 _embedder = None  # cached (model, tokenizer) tuple
 
 
-def _get_embedder():
+def _get_embedder() -> tuple:
     global _embedder
     if _embedder is None:
         import mlx_embeddings
@@ -135,7 +135,8 @@ def evict_embedder() -> None:
         _embedder = None
         gc.collect()
         try:
-            import mlx.core as mx; mx.clear_cache()
+            import mlx.core as mx
+            mx.clear_cache()
         except Exception:  # noqa: BLE001 — cache flush is best-effort; non-fatal if mlx absent
             pass
         log.info("session_distiller: embedding model evicted from memory")

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -32,7 +32,7 @@ export default function SetupWizard() {
   // Step 1 — permissions (live)
   const [perms, setPerms] = useState<Wiz['perms']>({ accessibility: null, screen: null, input: null })
 
-  // Step 2 — specs + MLX + model
+  // Step 3 — local intelligence (MLX runtime + model)
   const [specs, setSpecs] = useState<SystemSpecs | null>(null)
   const [mlx, setMlx] = useState<MlxStatusResponse | null>(null)
   const [downloading, setDownloading] = useState(false)
@@ -45,7 +45,7 @@ export default function SetupWizard() {
   const runtimeStarted = useRef(false)
   const prefetchStarted = useRef(false)
 
-  // Step 3 — integrations. The shared <ConnectTrackers> drives the actual
+  // Step 2 — integrations. The shared <ConnectTrackers> drives the actual
   // connect flows (OAuth + token save); this just holds the live connected-state
   // (get_integrations) so the rail status + completion summary stay accurate.
   const [integrations, setIntegrations] = useState<IntegrationsResponse | null>(null)

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -277,10 +277,12 @@ export const STEPS: StepMeta[] = [
     subtitle: 'Everything runs privately on your Mac with Apple MLX. The models started downloading when setup opened — this is just the finish line.',
     Body: MLXBody,
     status: (s) => s.modelReady ? 'Ready' : (s.mlx?.runtime_found || s.mlx?.runtime_installed) ? 'Downloading…' : 'Installing…',
-    // Block Finish until every model is on disk: the worklog pipeline (distill →
+    // Block Finish until every model is on disk — the worklog pipeline (distill →
     // rerank → match) can't run a cycle without all three, so the user must not
     // reach the dashboard early. The download has had the whole wizard to run, so
     // this is usually instant; visible progress + Retry keep it from being a dead end.
-    canNext: (s) => s.modelReady,
+    // Exception: if the runtime itself is unavailable (incompatible hardware, no
+    // download_available), gate open — there is no download to wait for.
+    canNext: (s) => s.modelReady || !!(s.mlx && !s.mlx.runtime_found && !s.mlx.runtime_installed && !s.mlx.download_available),
   },
 ]


### PR DESCRIPTION
Resolves all open CodeRabbit comments on PR #347 (pre-main → main).

## Changes

**`services/agents/_state.py`**
- Update wire-contract comment: `PrefetchStatus` in `mlx_server.rs` already decodes `speed`; the comment was stale saying "exactly state/received/total/error".

**`services/agents/routes/prefetch.py`** (also has the `_speed_state` dict fix from the first commit)
- `log.error` → `log.exception` in `_run_prefetch` failure handler — preserves the traceback that `log.error` dropped (Ruff TRY400; `span.record_exception` was already there, the log was the gap)
- `zip(strict=True)` on `specs`/`probe_results` — documents and enforces the equal-length invariant guaranteed by `asyncio.gather` (Ruff B905)

**`services/agents/session_distiller.py`**
- Add `-> tuple` return type to `_get_embedder` (Ruff ANN202)
- Split `import mlx.core as mx; mx.clear_cache()` onto two lines (Ruff E702)

**`ui/app/setup/steps.tsx` + `page.tsx`** (🟠 Major fix)
- **Dead-end in the Local-intelligence step**: when the MLX runtime is unavailable (`runtime_found=false`, `runtime_installed=false`, `download_available=false`) the `unavailable` state showed a message but no Retry, and `canNext` was `s.modelReady` — always `false`. User could never finish setup.
- Fix: `canNext` now also gates open for the unavailable case, matching the same condition `MLXBody` uses to render the "not available for this Mac" message.
- Also correct two stale `// Step N` comments in `page.tsx` that were left over from the Integrations/MLX tab reorder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)