### PR TITLE
fix(integrations): surface real Azure DevOps error instead of generic fallback

### DIFF
--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -536,9 +536,11 @@ pub async fn discover_azure_devops(
     let profile = azure_get(profile_url, &body.pat)
         .instrument(tracing::debug_span!("integrations.azure.profile"))
         .await
-        .map_err(|(status, _detail)| {
+        .map_err(|(status, detail)| {
             if status == 401 || status == 403 {
-                "PAT is invalid or expired — check it and try again".to_string()
+                "PAT is invalid or org-scoped — enter your org name manually below, or use an 'All accessible organizations' PAT".to_string()
+            } else if status == 0 {
+                format!("Could not reach Azure DevOps: {detail}")
             } else {
                 format!("Azure DevOps profile API returned HTTP {status}")
             }
@@ -558,7 +560,13 @@ pub async fn discover_azure_devops(
     let accounts = azure_get(accounts_url, &body.pat)
         .instrument(tracing::debug_span!("integrations.azure.accounts"))
         .await
-        .map_err(|(status, _detail)| format!("Could not list organizations (HTTP {status})"))?;
+        .map_err(|(status, detail)| {
+            if status == 0 {
+                format!("Could not list organizations: {detail}")
+            } else {
+                format!("Could not list organizations (HTTP {status})")
+            }
+        })?;
     let orgs = sorted_names(&accounts, "accountName");
     tracing::info!(count = orgs.len(), "azure orgs discovered");
     Ok(AzureDiscoverResponse {

--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -513,9 +513,11 @@ pub async fn discover_azure_devops(
         let body_json = azure_get(url, &body.pat)
             .instrument(tracing::debug_span!("integrations.azure.projects"))
             .await
-            .map_err(|(status, _detail)| {
+            .map_err(|(status, detail)| {
                 if status == 401 || status == 403 {
                     "PAT is invalid or lacks Work Items → Read & write scope".to_string()
+                } else if status == 0 {
+                    format!("Could not reach Azure DevOps: {detail}")
                 } else {
                     format!("Azure DevOps returned HTTP {status}")
                 }

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -370,6 +370,11 @@ function AzureDevOpsSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?
 
   const handleOrgChange = (org: string) => { setSelectedOrg(org); if (org) lookupProjects(org) }
 
+  const submitManualOrg = () => {
+    const org = manualOrg.trim()
+    if (org) { setSelectedOrg(org); lookupProjects(org) }
+  }
+
   const connect = async () => {
     if (!selectedOrg || !selectedProject) return
     setLoading('saving'); setError(null)
@@ -453,21 +458,12 @@ function AzureDevOpsSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?
             <input
               value={manualOrg}
               onChange={(e) => setManualOrg(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && manualOrg.trim()) {
-                  const org = manualOrg.trim()
-                  setSelectedOrg(org)
-                  lookupProjects(org)
-                }
-              }}
+              onKeyDown={(e) => e.key === 'Enter' && submitManualOrg()}
               placeholder="e.g. my-company"
               className="flex-1 text-[11px] px-2 py-1.5 rounded-md border"
               style={{ color: 'var(--ink)', background: 'var(--surface)', borderColor: 'var(--rule)', outline: 'none' }} />
             <button
-              onClick={() => {
-                const org = manualOrg.trim()
-                if (org) { setSelectedOrg(org); lookupProjects(org) }
-              }}
+              onClick={submitManualOrg}
               disabled={!manualOrg.trim() || loading === 'projects'}
               className="text-[11px] px-3 py-1.5 rounded-md shrink-0"
               style={{ background: 'var(--accent)', color: '#fff', opacity: (!manualOrg.trim() || loading === 'projects') ? 0.5 : 1, cursor: (!manualOrg.trim() || loading === 'projects') ? 'not-allowed' : 'pointer' }}>

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -343,15 +343,17 @@ function AzureDevOpsSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?
   const [loading, setLoading] = useState<'orgs' | 'projects' | 'saving' | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [done, setDone] = useState(false)
+  const [showManualOrg, setShowManualOrg] = useState(false)
+  const [manualOrg, setManualOrg] = useState('')
 
   const lookupOrgs = async () => {
     if (!pat.trim()) return
-    setLoading('orgs'); setError(null); setOrgs(null); setSelectedOrg(''); setProjects(null); setSelectedProject('')
+    setLoading('orgs'); setError(null); setOrgs(null); setSelectedOrg(''); setProjects(null); setSelectedProject(''); setShowManualOrg(false); setManualOrg('')
     try {
       const json = await mutate<{ orgs?: string[] }>('/api/integrations/azure-devops/discover', 'discover_azure_devops', { pat: pat.trim() })
       setOrgs(json.orgs ?? [])
       if ((json.orgs ?? []).length === 1) { setSelectedOrg(json.orgs![0]); lookupProjects(json.orgs![0]) }
-    } catch (e) { setError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Failed to fetch organisations') }
+    } catch (e) { setError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Failed to fetch organisations'); setShowManualOrg(true) }
     finally { setLoading(null) }
   }
 
@@ -392,8 +394,8 @@ function AzureDevOpsSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?
   return (
     <div className="px-4 pb-4 pt-2 space-y-3" style={{ background: 'var(--surface-2)' }}>
       <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-2)' }}>
-        In Azure DevOps go to User settings → Personal access tokens → New token, scope{' '}
-        <strong>Work Items → Read &amp; write</strong>.{' '}
+        In Azure DevOps go to User settings → Personal access tokens → New token, set scope to{' '}
+        <strong>All accessible organizations</strong> and enable <strong>Work Items → Read &amp; write</strong>.{' '}
         <a href="https://dev.azure.com" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)' }}>Open ↗</a>
       </p>
       <div className="flex gap-2">
@@ -443,6 +445,37 @@ function AzureDevOpsSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?
       )}
 
       {error && <p className="text-[11px]" style={{ color: '#e53e3e' }}>{error}</p>}
+
+      {showManualOrg && !orgs && (
+        <div className="space-y-1.5">
+          <p className="text-[11px]" style={{ color: 'var(--ink-3)' }}>Enter your org name manually:</p>
+          <div className="flex gap-2">
+            <input
+              value={manualOrg}
+              onChange={(e) => setManualOrg(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && manualOrg.trim()) {
+                  const org = manualOrg.trim()
+                  setSelectedOrg(org)
+                  lookupProjects(org)
+                }
+              }}
+              placeholder="e.g. my-company"
+              className="flex-1 text-[11px] px-2 py-1.5 rounded-md border"
+              style={{ color: 'var(--ink)', background: 'var(--surface)', borderColor: 'var(--rule)', outline: 'none' }} />
+            <button
+              onClick={() => {
+                const org = manualOrg.trim()
+                if (org) { setSelectedOrg(org); lookupProjects(org) }
+              }}
+              disabled={!manualOrg.trim() || loading === 'projects'}
+              className="text-[11px] px-3 py-1.5 rounded-md shrink-0"
+              style={{ background: 'var(--accent)', color: '#fff', opacity: (!manualOrg.trim() || loading === 'projects') ? 0.5 : 1, cursor: (!manualOrg.trim() || loading === 'projects') ? 'not-allowed' : 'pointer' }}>
+              {loading === 'projects' ? 'Looking up…' : 'Look up projects'}
+            </button>
+          </div>
+        </div>
+      )}
 
       {selectedOrg && selectedProject && (
         <button onClick={connect} disabled={loading === 'saving'} className="text-[12px] px-4 py-2 rounded-md font-medium transition-opacity"

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -351,7 +351,7 @@ function AzureDevOpsSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?
       const json = await mutate<{ orgs?: string[] }>('/api/integrations/azure-devops/discover', 'discover_azure_devops', { pat: pat.trim() })
       setOrgs(json.orgs ?? [])
       if ((json.orgs ?? []).length === 1) { setSelectedOrg(json.orgs![0]); lookupProjects(json.orgs![0]) }
-    } catch (e) { setError(e instanceof Error ? e.message : 'Failed to fetch organisations') }
+    } catch (e) { setError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Failed to fetch organisations') }
     finally { setLoading(null) }
   }
 
@@ -362,7 +362,7 @@ function AzureDevOpsSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?
       const json = await mutate<{ projects?: string[] }>('/api/integrations/azure-devops/discover', 'discover_azure_devops', { pat: pat.trim(), org })
       setProjects(json.projects ?? [])
       if ((json.projects ?? []).length === 1) setSelectedProject(json.projects![0])
-    } catch (e) { setError(e instanceof Error ? e.message : 'Failed to fetch projects') }
+    } catch (e) { setError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Failed to fetch projects') }
     finally { setLoading(null) }
   }
 
@@ -377,7 +377,7 @@ function AzureDevOpsSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?
         fields: { url: `https://dev.azure.com/${selectedOrg}/${selectedProject}`, pat: pat.trim() },
       })
       setDone(true); clearProviderNotice('azure_devops'); onSuccess?.()
-    } catch (e) { setError(e instanceof Error ? e.message : 'Could not save credentials') }
+    } catch (e) { setError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Could not save credentials') }
     finally { setLoading(null) }
   }
 


### PR DESCRIPTION
## Summary

Three layered fixes to the Azure DevOps connection flow:

**1. Surface real Tauri errors in the UI (original fix)**
- `Tauri` command rejections with `Err(String)` produce a plain JS string, not an `Error` object
- The three `catch` blocks in `AzureDevOpsSetup` checked `e instanceof Error`, which was always `false`, so the real backend message was silently dropped
- Fix: prefix each check with `typeof e === 'string' ? e :` — applied to `lookupOrgs`, `lookupProjects`, and `connect`

**2. Surface network errors from reqwest (HTTP 0)**
- When `reqwest` can't establish a TCP connection (DNS failure, TLS error, etc.) it returns status `0`; the actual error detail string was bound to `_detail` and discarded
- Fix: rename to `detail` and format as `"Could not reach Azure DevOps: {detail}"` — applied to both the profile API call and the accounts API call

**3. Handle org-scoped PATs gracefully**
- PATs scoped to a specific org cannot call `app.vssps.visualstudio.com/_apis/profile/profiles/me` — they return 401/403
- The error message now says "PAT is invalid or org-scoped — enter your org name manually below, or use an 'All accessible organizations' PAT"
- Instruction text updated to say "All accessible organizations" scope is required
- A manual org name input appears after any failed org discovery so org-scoped PAT users can still connect without recreating their token

## Root cause (original)

```ts
// Before — string rejections always hit the fallback:
catch (e) { setError(e instanceof Error ? e.message : 'Failed to fetch organisations') }

// After — Tauri string rejections are surfaced directly:
catch (e) { setError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Failed to fetch organisations') }
```

## Test plan

- [ ] Paste a PAT scoped to "All accessible organizations" → org dropdown appears normally
- [ ] Paste an org-scoped PAT → error shows the org-scoped message + manual org input appears; entering the org name and clicking "Look up projects" works
- [ ] Network unreachable (e.g. wrong URL) → shows the actual reqwest error string instead of "HTTP 0"
- [ ] Invalid/expired PAT → shows the backend error message directly instead of generic fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)