### PR TITLE
fix(integrations): save API tokens on a fresh install (no .env yet)

### DIFF
--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -401,10 +401,15 @@ pub async fn save_integration_token(body: SaveTokenBody) -> Result<serde_json::V
     let key_count = updates.len();
     {
         let mode = crate::install::detect_install_mode();
-        let env_path = mode
-            .env_path()
-            .ok_or("could not resolve .env path")?
-            .to_owned();
+        // On a fresh `.app` install no `.env` exists yet, so `detect_install_mode`
+        // returns `Bare` (no path). Credentials must be saveable before any `.env`
+        // exists — default to the canonical `~/.meridian/.env`, which `upsert_env`
+        // creates (parent dir + file). Dev/Canonical modes keep their resolved path.
+        let env_path = match mode.env_path() {
+            Some(p) => p.to_owned(),
+            None => crate::install::canonical_env_path()
+                .ok_or("could not resolve home directory for .env")?,
+        };
         tokio::task::spawn_blocking(move || upsert_env(&env_path, &updates))
             .await
             .map_err(|e| format!("spawn_blocking panicked: {e}"))?

--- a/tray/src-tauri/src/install.rs
+++ b/tray/src-tauri/src/install.rs
@@ -65,6 +65,17 @@ pub(crate) fn detect_install_mode() -> InstallMode {
     InstallMode::Bare
 }
 
+/// The canonical credential `.env` path (`~/.meridian/.env`) — the **write**
+/// target when no `.env` exists yet (a fresh `.app`/DMG install, where nothing
+/// pre-creates it). Saving credentials must work before any `.env` exists, so
+/// the write path defaults here rather than failing in [`InstallMode::Bare`]
+/// (whose [`InstallMode::env_path`] is `None`). `None` only when `$HOME` is unset.
+pub(crate) fn canonical_env_path() -> Option<std::path::PathBuf> {
+    std::env::var("HOME")
+        .ok()
+        .map(|h| std::path::PathBuf::from(h).join(".meridian/.env"))
+}
+
 /// Resolve the `meridian` CLI binary, native build first — the shared resolver
 /// for every command that shells out to it (`tasks-sync`, `ticket-update`,
 /// `ticket-parents`, …). Mirrors the Node `selectMeridianBinary(meridianCandidates())`:

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -276,7 +276,7 @@ function TokenSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
       await mutate('/api/auth/token', 'save_integration_token', { provider: tracker.id, fields: values })
       setDone(true); clearProviderNotice(tracker.id); onSuccess?.()
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Could not save credentials')
+      setError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Could not save credentials')
     } finally {
       setSaving(false)
     }
@@ -377,7 +377,7 @@ function AzureDevOpsSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?
         fields: { url: `https://dev.azure.com/${selectedOrg}/${selectedProject}`, pat: pat.trim() },
       })
       setDone(true); clearProviderNotice('azure_devops'); onSuccess?.()
-    } catch (e) { setError(e instanceof Error ? e.message : 'Could not save credentials') }
+    } catch (e) { setError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Could not save credentials') }
     finally { setLoading(null) }
   }
 


### PR DESCRIPTION
## Bug

On a fresh `.app`/DMG install, connecting **any** tracker by API token (Jira, Linear, GitHub, Azure DevOps) failed with **"Could not save credentials."**

## Root cause

`~/.meridian/.env` does not exist on a fresh `.app` install (nothing pre-creates it — only the npm `install-from-bundle.sh` path does). So `install::detect_install_mode()` returns `Bare`, whose `env_path()` is `None`, and `save_integration_token` bailed with `"could not resolve .env path"`. The UI's `catch` only read `e.message` for `Error` instances — but Tauri rejects a `Result<_, String>` command with a **plain string** — so the real cause was discarded and the generic *"Could not save credentials"* shown instead.

It's a chicken-and-egg: the canonical `.env` is created **by** saving credentials, but saving required it to already exist.

## Fix

- **`install.rs`** — new `canonical_env_path()` → `~/.meridian/.env`, the write target.
- **`commands/integrations.rs`** — `save_integration_token` falls back to the canonical `.env` when none exists; `upsert_env` already creates the parent dir + file. `Dev`/`Canonical` modes are unchanged.
- **`components/IntegrationConnect.tsx`** — surface the real error (`typeof e === 'string' ? e : …`), so future failures show the actual message instead of the generic fallback.

## Validation

- Tray crate type-checks clean with these changes.
- Manual workaround that confirms the diagnosis (and unblocks affected machines now): `mkdir -p ~/.meridian && touch ~/.meridian/.env` flips detection to `Canonical` and saving works.

## Notes

- This is an **app** fix (ships in the tray binary via the app release), not a runtime change.
- Targeted at `pre-main`; needs to reach `main`/production to fix production installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)