### PR TITLE
fix(oauth): unhang connect UI under StrictMode + serialize Jira token refresh

### DIFF
--- a/meridian-oauth/Cargo.toml
+++ b/meridian-oauth/Cargo.toml
@@ -25,3 +25,11 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-feature
 # the tray stays lean; the daemon's `full` unifies over this.
 tokio = { version = "1.15", features = ["net", "io-util", "time", "sync"] }
 tracing = "0.1.40"
+# Cross-process advisory file lock for the rotating refresh token uses std's native
+# File::try_lock/unlock (stable since Rust 1.89; toolchain is pinned to 1.93.1), so
+# no external locking crate is needed — see store::lock_provider.
+
+[dev-dependencies]
+# A minimal current-thread runtime so the lock unit tests can drive the async
+# `lock_provider` fn (the lib itself needs no `rt`/`macros` — it polls try_lock).
+tokio = { version = "1.15", features = ["rt", "macros", "time"] }

--- a/meridian-oauth/src/jira.rs
+++ b/meridian-oauth/src/jira.rs
@@ -24,14 +24,15 @@ use tokio::sync::Mutex;
 use crate::flow::{self, ProviderSpec};
 use crate::store::{self, OAuthTokens};
 
-// FIXME(cross-process-lock): this mutex is per-process. The daemon and the tray
-// each compile meridian-oauth and hold independent mutex instances. If both call
-// ensure_fresh() simultaneously (daemon background sync + tray user action), both
-// read the same expired token store, both POST to Atlassian's token endpoint, and
-// the second POST 401s because the first call already rotated and consumed the
-// refresh token — permanently invalidating the pair. Fix requires a file lock on
-// the OAuth store path (e.g. via the `fd-lock` crate) to serialise across processes.
-// Tracked as a follow-up; in practice the race requires exact timing overlap.
+// This mutex serialises refreshes WITHIN a process. It is NOT sufficient on its
+// own: the daemon and the tray (and a stray second daemon) each compile
+// meridian-oauth and hold independent mutex instances, so two processes could
+// both read the same expired token, both POST to Atlassian, and the second POST
+// 401 because the first already rotated and consumed the refresh token. The
+// cross-process half of the fix lives in ensure_fresh(), which takes an advisory
+// FILE lock (`store::lock_provider`) and re-checks expiry under it; this mutex
+// stays as the cheap intra-process first gate so threads don't even reach the
+// file lock concurrently.
 fn refresh_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
@@ -237,14 +238,46 @@ pub async fn login(client_id: &str, client_secret: &str, port: u16) -> Result<St
 
 /// Load the stored tokens, refreshing the access token if it's within 120 s of
 /// expiry. Persists the rotated refresh token. Returns ready-to-use tokens.
-/// Serializes concurrent refresh requests via a static mutex to avoid
-/// double-refreshing and losing the rotated refresh token.
+///
+/// Refreshes are serialised on TWO levels so the rotating refresh token is never
+/// double-spent: a static mutex within this process, and an advisory FILE lock
+/// ([`store::lock_provider`]) across every Meridian process. After taking the file
+/// lock it RE-LOADS and re-checks expiry — so a process that waited on the lock
+/// adopts the peer's freshly-refreshed token instead of POSTing again with the
+/// now-consumed one (the old single-process-mutex behaviour caused that 401 loop).
 pub async fn ensure_fresh() -> Result<OAuthTokens> {
-    let _guard = refresh_lock().lock().await;
-    let mut t = store::load("jira")?;
+    let _guard = refresh_lock().lock().await; // intra-process serialisation
+
+    // Fast path: a still-fresh token needs neither a refresh nor the file lock.
+    let t = store::load("jira")?;
     if !t.is_expired(now_unix(), 120) {
         return Ok(t);
     }
+
+    // Slow path: enter the cross-process critical section. A peer (a second daemon,
+    // the tray's in-process refresh) may be rotating the SAME refresh token right
+    // now. Best-effort — if the lock can't be taken we log and proceed rather than
+    // turn the lock itself into a new way for Jira auth to fail.
+    let _flock = match store::lock_provider("jira").await {
+        Ok(g) => Some(g),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "could not acquire OAuth refresh lock — proceeding without cross-process serialisation"
+            );
+            None
+        }
+    };
+
+    // Re-load UNDER the lock and re-check: if a peer refreshed while we waited,
+    // adopt their token instead of refreshing again with the dead one. This
+    // double-check is what actually breaks the race.
+    let mut t = store::load("jira")?;
+    if !t.is_expired(now_unix(), 120) {
+        tracing::debug!("jira token already refreshed by another process — adopting it");
+        return Ok(t);
+    }
+
     tracing::debug!("jira OAuth access token expired — refreshing");
     let resp = flow::refresh(&t.client_id, &spec(), &t.refresh_token)
         .await

--- a/meridian-oauth/src/store.rs
+++ b/meridian-oauth/src/store.rs
@@ -49,20 +49,42 @@ fn oauth_dir() -> PathBuf {
     PathBuf::from(home).join(".meridian").join("oauth")
 }
 
-/// Path to a provider's token file, e.g. `~/.meridian/oauth/jira.json`.
-pub fn path(provider: &str) -> PathBuf {
-    oauth_dir().join(format!("{provider}.json"))
+/// Reject a provider name that isn't a plain identifier, so a token/lock path can
+/// never escape the oauth dir via `..` or a path separator. Defense-in-depth: every
+/// caller today passes a hardcoded literal ("jira"/"trello"), but validating at the
+/// boundary means a future untrusted source can't turn this into path traversal.
+fn validate_provider(provider: &str) -> Result<()> {
+    let ok = !provider.is_empty()
+        && provider
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+    if ok {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "invalid OAuth provider {provider:?} — only [A-Za-z0-9_-] is allowed; refusing \
+             to build a token path that could escape the store dir"
+        )
+    }
+}
+
+/// Path to a provider's token file, e.g. `~/.meridian/oauth/jira.json`. Errors on a
+/// provider name that could escape the oauth dir (see [`validate_provider`]).
+pub fn path(provider: &str) -> Result<PathBuf> {
+    validate_provider(provider)?;
+    Ok(oauth_dir().join(format!("{provider}.json")))
 }
 
 /// Whether a token file exists for this provider. Used to decide if OAuth is the
-/// active auth path before falling back to a static API token.
+/// active auth path before falling back to a static API token. An invalid provider
+/// name is treated as "not present" rather than surfacing an error.
 pub fn exists(provider: &str) -> bool {
-    path(provider).exists()
+    path(provider).map(|p| p.exists()).unwrap_or(false)
 }
 
 /// Load and parse a provider's tokens. Errors if the file is missing or corrupt.
 pub fn load(provider: &str) -> Result<OAuthTokens> {
-    let p = path(provider);
+    let p = path(provider)?;
     let raw = std::fs::read_to_string(&p)
         .with_context(|| format!("reading OAuth token file {}", p.display()))?;
     serde_json::from_str(&raw).with_context(|| format!("parsing OAuth token file {}", p.display()))
@@ -72,10 +94,12 @@ pub fn load(provider: &str) -> Result<OAuthTokens> {
 /// the refresh/access tokens aren't world-readable. On Unix, sets permissions before
 /// writing to avoid a race window where other users could read the file.
 pub fn save(tokens: &OAuthTokens) -> Result<()> {
+    // Validate the provider up front (also gates the tmp path below, which
+    // interpolates it too) before touching the filesystem.
+    let final_path = path(&tokens.provider)?;
     let dir = oauth_dir();
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("creating OAuth dir {}", dir.display()))?;
-    let final_path = path(&tokens.provider);
     let tmp_path = dir.join(format!(".{}.json.tmp", tokens.provider));
 
     let json = serde_json::to_string_pretty(tokens).context("serialising OAuth tokens")?;
@@ -109,6 +133,94 @@ pub fn save(tokens: &OAuthTokens) -> Result<()> {
     Ok(())
 }
 
+/// Held exclusive advisory lock on a provider's token store. The OS `flock` is
+/// tied to the open file description, so keeping this guard alive holds the lock;
+/// dropping it (here, explicitly, and again when the fd closes) releases it.
+pub struct ProviderLock {
+    file: std::fs::File,
+    path: PathBuf,
+}
+
+impl Drop for ProviderLock {
+    fn drop(&mut self) {
+        // Best-effort: the lock also releases when the fd closes on drop, so a
+        // failed explicit unlock is harmless — just note it for debugging.
+        if let Err(e) = self.file.unlock() {
+            tracing::debug!(path = %self.path.display(), error = %e, "releasing OAuth lock");
+        }
+    }
+}
+
+/// Lock file path for a provider, e.g. `~/.meridian/oauth/jira.lock`. Deliberately
+/// SEPARATE from `<provider>.json`: [`save`] renames a temp file over the json, so
+/// a lock taken on the json itself would be lost across that rename. Validates the
+/// provider so the lock path can't escape the oauth dir (see [`validate_provider`]).
+fn lock_path(provider: &str) -> Result<PathBuf> {
+    validate_provider(provider)?;
+    Ok(oauth_dir().join(format!("{provider}.lock")))
+}
+
+/// Acquire the exclusive cross-process advisory lock for `provider`'s token store,
+/// blocking (async) until it's free or a 10 s safety timeout elapses.
+///
+/// This serialises the rotating-refresh-token read-modify-write across EVERY
+/// Meridian process — a second daemon, the tray's in-process refresh, the daemon's
+/// background sync. Without it, two `ensure_fresh()` calls both load the same
+/// expired token, both POST a refresh, and the second 401s because the first
+/// already consumed (rotated) the refresh token — permanently invalidating the
+/// pair (the FIXME race in `jira.rs`). The caller MUST re-load and re-check expiry
+/// AFTER acquiring this, so a process that waited adopts the peer's fresh token
+/// instead of refreshing again with the now-dead one.
+pub async fn lock_provider(provider: &str) -> Result<ProviderLock> {
+    lock_provider_with_timeout(provider, std::time::Duration::from_secs(10)).await
+}
+
+/// [`lock_provider`] with an explicit timeout (the public fn fixes it at 10 s;
+/// tests pass a short one to exercise contention without a real wait).
+async fn lock_provider_with_timeout(
+    provider: &str,
+    timeout: std::time::Duration,
+) -> Result<ProviderLock> {
+    use anyhow::bail;
+
+    let path = lock_path(provider)?; // validates provider before any FS work
+    let dir = oauth_dir();
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("creating OAuth dir {}", dir.display()))?;
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)
+        .with_context(|| format!("opening OAuth lock file {}", path.display()))?;
+
+    // Poll a NON-blocking try-lock (std's native `File::try_lock`, stable since
+    // Rust 1.89) so the async executor is never parked on flock. Contention is rare
+    // and brief (one HTTP refresh) and a crashed holder releases automatically
+    // (the lock dies with its fd), so a short poll resolves quickly.
+    let step = std::time::Duration::from_millis(50);
+    let mut waited = std::time::Duration::ZERO;
+    loop {
+        match file.try_lock() {
+            Ok(()) => return Ok(ProviderLock { file, path }),
+            Err(std::fs::TryLockError::WouldBlock) => {
+                if waited >= timeout {
+                    bail!(
+                        "timed out after {timeout:?} acquiring the OAuth refresh lock for \
+                         {provider} — another Meridian process may be stuck refreshing"
+                    );
+                }
+                tokio::time::sleep(step).await;
+                waited += step;
+            }
+            Err(std::fs::TryLockError::Error(e)) => {
+                return Err(e)
+                    .with_context(|| format!("acquiring exclusive lock on {}", path.display()))
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -116,12 +228,29 @@ mod tests {
     #[test]
     fn path_is_under_meridian_oauth() {
         std::env::set_var("HOME", "/tmp/meridian_oauth_test_home");
-        let p = path("jira");
+        let p = path("jira").unwrap();
         assert!(
             p.ends_with(".meridian/oauth/jira.json"),
             "got {}",
             p.display()
         );
+    }
+
+    #[test]
+    fn path_rejects_traversal_providers() {
+        // A provider name that could escape the oauth dir must be refused at the
+        // boundary, for both the token path and the lock path.
+        for bad in ["../../etc/passwd", "a/b", "..", "", "jira\0", "jira.json"] {
+            assert!(path(bad).is_err(), "path({bad:?}) must be rejected");
+            assert!(
+                lock_path(bad).is_err(),
+                "lock_path({bad:?}) must be rejected"
+            );
+        }
+        // The real providers stay valid.
+        for good in ["jira", "trello", "azure_devops", "github"] {
+            assert!(path(good).is_ok(), "path({good:?}) must be allowed");
+        }
     }
 
     #[test]
@@ -166,12 +295,44 @@ mod tests {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let mode = std::fs::metadata(path("jira"))
+            let mode = std::fs::metadata(path("jira").unwrap())
                 .unwrap()
                 .permissions()
                 .mode();
             assert_eq!(mode & 0o777, 0o600, "token file must be 0600");
         }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn lock_provider_serialises_then_releases() {
+        // flock is per-open-file-description, so two separate opens contend even in
+        // one process — enough to prove cross-process serialisation works.
+        let dir = std::env::temp_dir().join(format!("meridian_oauth_lock_{}", std::process::id()));
+        std::env::set_var("HOME", &dir);
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let short = std::time::Duration::from_millis(150);
+            let held = lock_provider("jira").await.expect("first lock acquires");
+
+            // A second acquisition while the first is held must time out (contended).
+            let contended = lock_provider_with_timeout("jira", short).await;
+            assert!(
+                contended.is_err(),
+                "second lock must not be granted while the first is held"
+            );
+
+            // After releasing, the lock is immediately available again.
+            drop(held);
+            let reacquired = lock_provider_with_timeout("jira", short).await;
+            assert!(
+                reacquired.is_ok(),
+                "lock must be acquirable once the holder drops it"
+            );
+        });
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/ui/__tests__/oauth-setup-lifecycle.test.ts
+++ b/ui/__tests__/oauth-setup-lifecycle.test.ts
@@ -1,0 +1,113 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+
+// Regression guard for the OAuth "stuck on Waiting…" bug.
+//
+// `OAuthSetup` (components/IntegrationConnect.tsx) keeps a `mountedRef` so its
+// async `startOAuth` body can detect an unmount that happened while awaiting
+// `mutate('start_oauth')` — before the poll interval exists to be cleared:
+//
+//     await mutate(..., 'start_oauth', ...)   // backend runs, writes creds
+//     if (!mountedRef.current) return          // bail if we unmounted meanwhile
+//     ... create the 2s poll interval ...      // detects success + surfaces errors
+//
+// The original effect was cleanup-ONLY — it set the flag false on unmount but
+// never set it true on (re)mount:
+//
+//     useEffect(() => () => { mountedRef.current = false; ... }, [])   // BUG
+//
+// `next.config.ts` has `reactStrictMode: true`, and `tauri dev` serves via the
+// Next dev server, so React StrictMode runs effects mount→cleanup→mount. With a
+// cleanup-only effect the first cleanup flips the flag false and the remount
+// never restores it, leaving a LIVE component with `mountedRef.current === false`.
+// `startOAuth` then bails right after the backend already wrote the credentials,
+// the poll interval never starts, and the UI hangs on "Waiting…" forever — with
+// any real OAuth error silently swallowed (the error path lives in that poll).
+//
+// The repo has no React render harness (no @testing-library/jsdom), so — like the
+// other UI guards (cursor-pointer, NumberStepper) — we model the lifecycle and
+// scan the source for the fixed shape rather than mount the component.
+
+const uiRoot = import.meta.dir + '/..'
+const src = readFileSync(uiRoot + '/components/IntegrationConnect.tsx', 'utf8')
+
+type MountRef = { current: boolean }
+
+// Faithful model of the FIXED effect: set the flag true on (re)mount, return a
+// cleanup that sets it false. This is the contract the component must honour.
+function fixedMountEffect(ref: MountRef): () => void {
+  ref.current = true
+  return () => { ref.current = false }
+}
+
+// The OLD buggy effect: body is JUST the cleanup, nothing re-arms the flag.
+function buggyMountEffect(ref: MountRef): () => void {
+  return () => { ref.current = false }
+}
+
+// Drive React's two lifecycle shapes against an effect.
+function runNormalMount(effect: (r: MountRef) => () => void, ref: MountRef) {
+  effect(ref) // single mount, cleanup runs only on real unmount
+}
+function runStrictModeMount(effect: (r: MountRef) => () => void, ref: MountRef) {
+  const cleanup1 = effect(ref) // initial mount
+  cleanup1() // StrictMode simulated unmount
+  effect(ref) // StrictMode remount — component stays alive, no further cleanup
+}
+
+describe('OAuthSetup mount flag survives React StrictMode double-invoke', () => {
+  it('fixed effect: flag is true after a normal single mount', () => {
+    const ref: MountRef = { current: true }
+    runNormalMount(fixedMountEffect, ref)
+    expect(ref.current).toBe(true)
+  })
+
+  it('fixed effect: flag is true after StrictMode mount→cleanup→mount', () => {
+    const ref: MountRef = { current: true }
+    runStrictModeMount(fixedMountEffect, ref)
+    expect(ref.current).toBe(true)
+  })
+
+  it('buggy effect: StrictMode leaves the flag false — proving the test discriminates', () => {
+    // Documents the exact regression the fix prevents: with a cleanup-only
+    // effect, a live component ends up with mountedRef.current === false.
+    const ref: MountRef = { current: true }
+    runStrictModeMount(buggyMountEffect, ref)
+    expect(ref.current).toBe(false)
+  })
+
+  it('startOAuth guard does NOT bail when the (fixed) flag is true', () => {
+    const ref: MountRef = { current: true }
+    runStrictModeMount(fixedMountEffect, ref)
+    // startOAuth: `if (!mountedRef.current) return` — true ⇒ the poll can start.
+    const bailedBeforeCreatingPoll = !ref.current
+    expect(bailedBeforeCreatingPoll).toBe(false)
+  })
+
+  it('startOAuth guard WOULD bail under the buggy effect (the user-visible hang)', () => {
+    const ref: MountRef = { current: true }
+    runStrictModeMount(buggyMountEffect, ref)
+    const bailedBeforeCreatingPoll = !ref.current
+    expect(bailedBeforeCreatingPoll).toBe(true)
+  })
+})
+
+describe('IntegrationConnect.tsx OAuthSetup re-arms the mount flag', () => {
+  it("the mount effect sets mountedRef.current = true BEFORE returning its cleanup", () => {
+    // Must re-arm on (re)mount, not just clear on unmount. This regex fails for
+    // the old cleanup-only `useEffect(() => () => { ... }, [])` shape.
+    expect(src).toMatch(
+      /useEffect\(\(\)\s*=>\s*\{[\s\S]*?mountedRef\.current\s*=\s*true[\s\S]*?return\s*\(\)\s*=>\s*\{/,
+    )
+  })
+
+  it('still clears the flag on unmount and tears down the poll interval', () => {
+    expect(src).toContain('mountedRef.current = false')
+    expect(src).toMatch(/clearInterval\(pollRef\.current\)/)
+  })
+
+  it('startOAuth still guards on the flag after awaiting start_oauth', () => {
+    expect(src).toMatch(/if \(!mountedRef\.current\) return/)
+  })
+})

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -189,9 +189,20 @@ function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
   // while awaiting mutate — before the interval is created and pollRef assigned.
   const mountedRef = useRef(true)
 
-  useEffect(() => () => {
-    mountedRef.current = false
-    if (pollRef.current != null) clearInterval(pollRef.current)
+  // Set the flag TRUE on (re)mount, not just FALSE on unmount. Under React
+  // StrictMode (on in `next dev`, which `tauri dev` serves) effects run
+  // mount → cleanup → mount: the first cleanup flips this to false, and without
+  // re-arming it here the component stays alive with mountedRef.current === false.
+  // startOAuth's `if (!mountedRef.current) return` guard would then bail right
+  // after `await mutate('start_oauth')`, so the poll interval that detects
+  // success AND surfaces OAuth errors never starts — the UI hangs on "Waiting…"
+  // forever even though the backend already wrote the credentials.
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      if (pollRef.current != null) clearInterval(pollRef.current)
+    }
   }, [])
 
   const startOAuth = async () => {


### PR DESCRIPTION
## Summary

Fixes two OAuth bugs reported from the setup wizard, plus a path-traversal hardening surfaced by the pre-push security audit.

### 1. Connect UI hung on "Waiting for authorization…" (Jira / GitHub / Trello)
`OAuthSetup` (`ui/components/IntegrationConnect.tsx`) set `mountedRef.current = false` on unmount but **never re-armed it to `true` on remount**. With `reactStrictMode: true` and `tauri dev` serving via `next dev`, React StrictMode runs effects mount→cleanup→mount, leaving the flag `false` on a **live** component. `startOAuth` then bailed at `if (!mountedRef.current) return` immediately after the backend wrote the credentials, so the poll that detects success **and surfaces OAuth errors** never started — the UI hung forever even though `jira.json` / `GITHUB_TOKEN` were already on disk.

**Fix:** re-arm `mountedRef.current = true` in the effect body. No-op in static-export prod builds (StrictMode off there); the real fix in dev.

### 2. Jira "Sync error: auth failed — refreshing"
The cross-process **rotating-refresh-token race**: when more than one `meridian` process refreshes the same `~/.meridian/oauth/jira.json`, one rotates+consumes the refresh token and the other 401s (`invalid_grant`). Commonly triggered by the installed launchd daemon running alongside a `cargo-watch` dev daemon.

**Fix:** `ensure_fresh()` now takes an advisory file lock (`store::lock_provider`, std `File::try_lock`/`unlock` — Rust 1.89+, **no new crate**) and **re-loads + re-checks expiry under the lock**, so a process that waited adopts the peer's fresh token instead of re-spending the dead one. The per-process mutex stays as the cheap first gate.

### 3. Token-store path-traversal hardening
`store::path()`/`lock_path()` interpolated `provider` into a filesystem path with no validation. All callers pass hardcoded literals (`"jira"`/`"trello"`), but the boundary is now validated (`[A-Za-z0-9_-]` only) so a `..`/separator can't escape `~/.meridian/oauth`.

## Tests
- `ui/__tests__/oauth-setup-lifecycle.test.ts` — 8 new tests: model the StrictMode mount lifecycle (discriminates the buggy vs fixed shape) + source-guard the fixed component. **141 UI tests pass.**
- `meridian-oauth/src/store.rs` — lock contention test (acquire→contend→release→reacquire) + provider traversal-rejection test. **17 oauth tests pass.**
- Full pre-push suite green: fmt, clippy, ui build, ui tests, cargo test, security audit.

## Manual step for the reporter
Click **"Fix: Reconnect Jira"** — a diagnostic refresh during investigation consumed the stored OAuth token, and api-token creds are no longer in `.env`, so OAuth is the only path until reconnect. After reconnecting, the file lock keeps the race from recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)