### PR TITLE
feat(trello): API key prerequisite for OAuth + inline prompt UI

### DIFF
--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -76,6 +76,10 @@ const TOKEN_KEYS: &[(&str, &[&str])] = &[
             "AZURE_DEVOPS_ORG_URL",
         ],
     ),
+    // Trello uses OAuth for its primary auth but also stores a user-supplied app
+    // key in .env (prod has it baked in; dev users paste their own). Disconnect
+    // must strip it so a rotated key isn't silently reused on the next connect.
+    ("trello", &["TRELLO_APP_KEY"]),
 ];
 
 /// Token-based connect map: `provider → [(ui_field, env_key)]`. This is the
@@ -266,7 +270,7 @@ fn upsert_env(path: &std::path::Path, updates: &BTreeMap<String, String>) -> std
 /// Disconnect a tracker (the ported /api/integrations DELETE). Removes the
 /// OAuth token store (`~/.meridian/oauth/<p>.json`) AND strips the provider's
 /// `.env` keys — Jira can be connected either way, so both run. (trello = json
-/// only; linear/github/azure = env keys only; jira = both.) After credentials
+/// + env key; linear/github/azure = env keys only; jira = both.) After credentials
 /// are removed, clears the provider's tasks from the DB (best-effort — warns on
 /// failure but does not block the disconnect). Returns `{ ok: true }`; an unknown
 /// provider is the route's 400.

--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -112,6 +112,10 @@ const TOKEN_FIELD_MAP: &[(&str, &[(&str, &str)])] = &[
         "azure_devops",
         &[("url", "AZURE_DEVOPS_URL"), ("pat", "AZURE_DEVOPS_PAT")],
     ),
+    // Trello's app key is baked in for production builds; dev users supply their
+    // own from https://trello.com/app-key via the UI, which saves it here before
+    // the browser OAuth flow starts.
+    ("trello", &[("api_key", "TRELLO_APP_KEY")]),
 ];
 
 /// Env keys that MUST be present for a provider to count as connected. Optional
@@ -332,8 +336,9 @@ pub struct SaveTokenBody {
 /// Write a token-based tracker's credentials to the active `.env` and reload the
 /// daemon — the in-app replacement for "run `meridian config edit`" (ports the
 /// deleted `/api/auth/token` route). Covers jira (API-token / self-hosted),
-/// linear, github (PAT), and azure_devops. Browser-OAuth providers (Jira Cloud
-/// OAuth, Trello) connect via [`start_oauth`] instead.
+/// linear, github (PAT), azure_devops, and trello (API key prerequisite for the
+/// browser OAuth flow; saving `TRELLO_APP_KEY` here lets [`start_oauth`] find the
+/// key and proceed — the OAuth step still runs to write `~/.meridian/oauth/trello.json`).
 ///
 /// Validation mirrors the route: required keys must be non-empty; CR/LF are
 /// stripped from each value (an env file is line-oriented). For jira, any stored

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -184,6 +184,11 @@ function ModeTab({ label, active, onClick }: { label: string; active: boolean; o
 function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () => void }) {
   const [status, setStatus] = useState<'idle' | 'waiting' | 'done' | 'error'>('idle')
   const [error, setError] = useState<string | null>(null)
+  // Trello-specific: set when start_oauth rejects with the "Power-Up app key"
+  // error so the user can supply their own key from https://trello.com/app-key.
+  // Once set, the key is saved to .env before the next start_oauth call.
+  const [apiKeyPrompt, setApiKeyPrompt] = useState(false)
+  const [apiKey, setApiKey] = useState('')
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   // mountedRef lets the async startOAuth body detect an unmount that happened
   // while awaiting mutate — before the interval is created and pollRef assigned.
@@ -208,6 +213,15 @@ function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
   const startOAuth = async () => {
     setStatus('waiting'); setError(null)
     try {
+      // For Trello: if a user-supplied API key is present, persist it to .env
+      // before start_oauth reads it. This unblocks dev builds where the baked-in
+      // DEFAULT_APP_KEY is empty. start_oauth_in_process re-parses .env on each
+      // call, so the write-then-call ordering is sufficient.
+      if (tracker.id === 'trello' && apiKey.trim()) {
+        await mutate('/api/auth/token', 'save_integration_token', {
+          provider: 'trello', fields: { api_key: apiKey.trim() },
+        })
+      }
       await mutate(`/api/auth/oauth/start?provider=${tracker.id}`, 'start_oauth', { provider: tracker.id })
       if (!mountedRef.current) return
       const deadline = Date.now() + OAUTH_DEADLINE_MS
@@ -236,7 +250,14 @@ function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
       }, 2_000)
       pollRef.current = id
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e)); setStatus('error')
+      const msg = e instanceof Error ? e.message : String(e)
+      // Trello without a baked-in or user-supplied app key: show the API key
+      // input so the user can unblock themselves without editing .env manually.
+      if (tracker.id === 'trello' && msg.includes('Power-Up app key')) {
+        setApiKeyPrompt(true); setStatus('idle')
+      } else {
+        setError(msg); setStatus('error')
+      }
     }
   }
 
@@ -245,8 +266,35 @@ function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
       {status === 'idle' && (
         <div className="space-y-3">
           <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-2)' }}>{tracker.oauth?.hint}</p>
-          <button onClick={startOAuth} className="text-[12px] px-4 py-2 rounded-md font-medium"
-            style={{ background: 'var(--accent)', color: '#fff', cursor: 'pointer' }}>
+          {apiKeyPrompt && (
+            <>
+              <p className="text-[12px]" style={{ color: '#d97706' }}>
+                A Trello API key is required.{' '}
+                <a href="https://trello.com/app-key" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)' }}>Get it at trello.com/app-key ↗</a>
+              </p>
+              <label className="block">
+                <span className="text-[11px]" style={{ color: 'var(--ink-3)' }}>API Key</span>
+                <input
+                  type="text"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter' && apiKey.trim()) void startOAuth() }}
+                  placeholder="Paste your Trello API key"
+                  className="mt-1 w-full font-mono text-[11px] px-2 py-1.5 rounded-md border"
+                  style={{ color: 'var(--ink)', background: 'var(--surface)', borderColor: 'var(--rule)', outline: 'none' }}
+                />
+              </label>
+            </>
+          )}
+          <button
+            onClick={() => void startOAuth()}
+            disabled={apiKeyPrompt && !apiKey.trim()}
+            className="text-[12px] px-4 py-2 rounded-md font-medium transition-opacity"
+            style={{
+              background: 'var(--accent)', color: '#fff',
+              opacity: apiKeyPrompt && !apiKey.trim() ? 0.5 : 1,
+              cursor: apiKeyPrompt && !apiKey.trim() ? 'not-allowed' : 'pointer',
+            }}>
             Connect {tracker.name} →
           </button>
         </div>

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -180,6 +180,10 @@ function ModeTab({ label, active, onClick }: { label: string; active: boolean; o
   )
 }
 
+// Sentinel matched against the Rust error message when TRELLO_APP_KEY is unset.
+// Extracted here so a rewording of the Rust error string is a single-site change.
+const TRELLO_MISSING_KEY_SENTINEL = 'Power-Up app key'
+
 // ── Browser OAuth (start_oauth + poll) ───────────────────────────────────────
 function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () => void }) {
   const [status, setStatus] = useState<'idle' | 'waiting' | 'done' | 'error'>('idle')
@@ -253,7 +257,7 @@ function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
       const msg = e instanceof Error ? e.message : String(e)
       // Trello without a baked-in or user-supplied app key: show the API key
       // input so the user can unblock themselves without editing .env manually.
-      if (tracker.id === 'trello' && msg.includes('Power-Up app key')) {
+      if (tracker.id === 'trello' && msg.includes(TRELLO_MISSING_KEY_SENTINEL)) {
         setApiKeyPrompt(true); setStatus('idle')
       } else {
         setError(msg); setStatus('error')
@@ -272,18 +276,13 @@ function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
                 A Trello API key is required.{' '}
                 <a href="https://trello.com/app-key" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)' }}>Get it at trello.com/app-key ↗</a>
               </p>
-              <label className="block">
-                <span className="text-[11px]" style={{ color: 'var(--ink-3)' }}>API Key</span>
-                <input
-                  type="text"
-                  value={apiKey}
-                  onChange={(e) => setApiKey(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === 'Enter' && apiKey.trim()) void startOAuth() }}
-                  placeholder="Paste your Trello API key"
-                  className="mt-1 w-full font-mono text-[11px] px-2 py-1.5 rounded-md border"
-                  style={{ color: 'var(--ink)', background: 'var(--surface)', borderColor: 'var(--rule)', outline: 'none' }}
-                />
-              </label>
+              <Field
+                field={{ name: 'api_key', label: 'API Key', placeholder: 'Paste your Trello API key', required: true }}
+                value={apiKey}
+                onChange={setApiKey}
+                onEnter={() => { if (apiKey.trim()) void startOAuth() }}
+                autoFocus
+              />
             </>
           )}
           <button
@@ -372,8 +371,8 @@ function TokenSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
   )
 }
 
-function Field({ field, value, onChange, onEnter }: {
-  field: TokenField; value: string; onChange: (v: string) => void; onEnter?: () => void
+function Field({ field, value, onChange, onEnter, autoFocus }: {
+  field: TokenField; value: string; onChange: (v: string) => void; onEnter?: () => void; autoFocus?: boolean
 }) {
   return (
     <label className="block">
@@ -384,6 +383,7 @@ function Field({ field, value, onChange, onEnter }: {
         onChange={(e) => onChange(e.target.value)}
         onKeyDown={(e) => { if (e.key === 'Enter' && onEnter) onEnter() }}
         placeholder={field.placeholder}
+        autoFocus={autoFocus}
         className="mt-1 w-full font-mono text-[11px] px-2 py-1.5 rounded-md border"
         style={{ color: 'var(--ink)', background: 'var(--surface)', borderColor: 'var(--rule)', outline: 'none' }}
       />


### PR DESCRIPTION
## Summary

- Adds `trello` to `TOKEN_FIELD_MAP` in `integrations.rs` so `save_integration_token` can persist `TRELLO_APP_KEY` to `.env` before the OAuth flow reads it
- `OAuthSetup` in `IntegrationConnect.tsx` now catches the "Power-Up app key" error from `start_oauth` and surfaces an inline input field — the user can paste their key from `trello.com/app-key` and retry without touching `.env` manually
- Button is disabled until the key is non-empty; Enter key submits

This also includes the commits already merged to `pre-main` via PRs #358–360 that this branch branched from after the last merge.

## Test plan

- [ ] Connect Trello in a dev build (no baked-in `DEFAULT_APP_KEY`) — should show the API key prompt on first attempt
- [ ] Paste a valid key, click Connect — OAuth flow proceeds and writes `~/.meridian/oauth/trello.json`
- [ ] Production build with baked-in key — prompt never appears, flow proceeds directly
- [ ] Verify `TRELLO_APP_KEY` written to `.env` after supplying key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXzRoAakhnwnrWtDGJHnRb