### PR TITLE
feat(meridian-core): ProviderAdapter trait + Jira/Linear/Azure DevOps adapters

### DIFF
--- a/meridian-core/src/adapters/azure_devops.rs
+++ b/meridian-core/src/adapters/azure_devops.rs
@@ -1,0 +1,362 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Azure DevOps adapter — reference [`ProviderAdapter`] for ADO (DRAFT).
+//!
+//! Maps an ADO Work Item (REST `/wit/workitems/{id}` shape, dotted field keys
+//! under `fields`) onto [`CanonicalTask`], handling the ADO-specific traps from
+//! the six-provider audit:
+//!
+//! - **Org-namespaced id.** Work-item ids are unique only within an
+//!   organization, so the stable key is `{org}:{id}` → `canonical_id`
+//!   `azure_devops:{org}:{id}`. The adapter carries the org (falling back to
+//!   parsing it from the work-item `url`).
+//! - **Priority is `Int` 1–4** (`1` = highest) → explicit lookup.
+//! - **Tags are semicolon-delimited** (`System.Tags`) → split into `labels`.
+//! - **Status is process-template-dependent.** `System.State` is mapped by name
+//!   (Removed → Cancelled, Resolved → InReview, Closed/Done/Completed → Done,
+//!   …). NOTE: the same state name can mean different categories across
+//!   work-item types/processes (the CMMI "Resolved" trap); full fidelity needs
+//!   the process's state-category metadata (the WIT states API). `status_raw`
+//!   keeps the literal state regardless.
+//!
+//! # Who calls this
+//! Nothing yet (draft). See [`crate::adapters`].
+//!
+//! # Related
+//! - [`crate::adapters::ProviderAdapter`] — the trait this implements.
+//! - [`crate::canonical_task`] — the output shape.
+
+use super::ProviderAdapter;
+use crate::canonical_task::{
+    CanonicalTask, PersonRef, Priority, Provider, StatusCategory, TaskKind,
+};
+use anyhow::Context;
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+
+/// Maps ADO work items to [`CanonicalTask`].
+///
+/// Carries the organization name because work-item ids are not globally unique
+/// (so the canonical key must be `{org}:{id}`). If `org` is empty, the adapter
+/// falls back to parsing it from the work item's `url`.
+#[derive(Debug, Default, Clone)]
+pub struct AzureDevopsAdapter {
+    pub org: String,
+}
+
+impl AzureDevopsAdapter {
+    /// Build an adapter pinned to an organization.
+    pub fn new(org: impl Into<String>) -> Self {
+        Self { org: org.into() }
+    }
+
+    /// Resolve the org: the configured one, else parsed from a work-item `url`
+    /// like `https://dev.azure.com/{org}/_apis/wit/workItems/{id}`.
+    fn resolve_org(&self, raw: &Value) -> String {
+        if !self.org.is_empty() {
+            return self.org.clone();
+        }
+        raw.get("url")
+            .and_then(Value::as_str)
+            .and_then(org_from_url)
+            .unwrap_or_default()
+    }
+}
+
+impl ProviderAdapter for AzureDevopsAdapter {
+    fn provider(&self) -> Provider {
+        Provider::AzureDevops
+    }
+
+    fn to_canonical(&self, raw: &Value) -> anyhow::Result<CanonicalTask> {
+        let id = id_str(raw.get("id")).context("azure_devops: work item missing `id`")?;
+        let org = self.resolve_org(raw);
+        // Org-namespaced stable key (ids aren't globally unique).
+        let provider_id = format!("{org}:{id}");
+
+        let wit = field_str(raw, "System.WorkItemType").unwrap_or_default();
+        let state = field_str(raw, "System.State").unwrap_or_default();
+
+        let labels = field(raw, "System.Tags")
+            .and_then(Value::as_str)
+            .map(|s| {
+                s.split(';')
+                    .map(str::trim)
+                    .filter(|t| !t.is_empty())
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let ancestor_path = field(raw, "System.Parent")
+            .and_then(|v| id_str(Some(v)))
+            .map(|pid| {
+                vec![CanonicalTask::canonical_id_for(
+                    Provider::AzureDevops,
+                    &format!("{org}:{pid}"),
+                )]
+            })
+            .unwrap_or_default();
+
+        let mut custom_fields: BTreeMap<String, Value> = BTreeMap::new();
+        if let Some(project) = field_str(raw, "System.TeamProject") {
+            custom_fields.insert("team_project".to_string(), json!(project));
+        }
+
+        Ok(CanonicalTask {
+            canonical_id: CanonicalTask::canonical_id_for(Provider::AzureDevops, &provider_id),
+            provider: Provider::AzureDevops,
+            provider_id,
+            url: str_at(raw, "url").unwrap_or_default(),
+            title: field_str(raw, "System.Title").unwrap_or_default(),
+            description: field_str(raw, "System.Description").unwrap_or_default(),
+            kind: map_kind(&wit),
+            kind_raw: wit,
+            status_category: map_status(&state),
+            status_raw: state,
+            priority: map_priority(field(raw, "Microsoft.VSTS.Common.Priority")),
+            assignees: person(field(raw, "System.AssignedTo"))
+                .into_iter()
+                .collect(),
+            reporter: person(field(raw, "System.CreatedBy")),
+            ancestor_path,
+            // System.TeamProject is the project *name*, not an id, so it's kept
+            // in custom_fields rather than project_ids (which expects ids).
+            project_ids: Vec::new(),
+            created_at: field_str(raw, "System.CreatedDate"),
+            updated_at: field_str(raw, "System.ChangedDate"),
+            completed_at: field_str(raw, "Microsoft.VSTS.Common.ClosedDate"),
+            start_date: field_str(raw, "Microsoft.VSTS.Scheduling.StartDate"),
+            due_date: field_str(raw, "Microsoft.VSTS.Scheduling.DueDate"),
+            labels,
+            custom_fields,
+            raw_payload: raw.clone(),
+        })
+    }
+}
+
+/// Parse the org segment from a `dev.azure.com/{org}/...` work-item URL.
+fn org_from_url(url: &str) -> Option<String> {
+    let rest = url.split("dev.azure.com/").nth(1)?;
+    let org = rest.split('/').next()?;
+    (!org.is_empty()).then(|| org.to_string())
+}
+
+/// A work-item id (a JSON number or string) as a string.
+fn id_str(v: Option<&Value>) -> Option<String> {
+    match v? {
+        Value::Number(n) => Some(n.to_string()),
+        Value::String(s) if !s.is_empty() => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// A top-level non-empty string field.
+fn str_at(v: &Value, key: &str) -> Option<String> {
+    v.get(key)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+}
+
+/// A value under the dotted `fields` object (`System.Title`, etc.).
+fn field<'a>(raw: &'a Value, name: &str) -> Option<&'a Value> {
+    raw.get("fields").and_then(|f| f.get(name))
+}
+
+/// A non-empty string from the dotted `fields` object.
+fn field_str(raw: &Value, name: &str) -> Option<String> {
+    field(raw, name)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+}
+
+/// An ADO identity object → [`PersonRef`]. `uniqueName` is usually the email.
+fn person(v: Option<&Value>) -> Option<PersonRef> {
+    let v = v?;
+    if v.is_null() {
+        return None;
+    }
+    let provider_user_id = v
+        .get("id")
+        .and_then(Value::as_str)
+        .or_else(|| v.get("descriptor").and_then(Value::as_str))
+        .unwrap_or_default()
+        .to_string();
+    let display_name = v
+        .get("displayName")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    if provider_user_id.is_empty() && display_name.is_empty() {
+        return None;
+    }
+    Some(PersonRef {
+        // uniqueName can be a domain account; only treat it as email if it is one.
+        email: v
+            .get("uniqueName")
+            .and_then(Value::as_str)
+            .filter(|s| s.contains('@'))
+            .map(String::from),
+        display_name,
+        provider_user_id,
+    })
+}
+
+/// Map `System.WorkItemType` → best-effort [`TaskKind`]. Verbatim type is kept
+/// in `kind_raw`.
+fn map_kind(wit: &str) -> TaskKind {
+    match wit.to_ascii_lowercase().as_str() {
+        "epic" => TaskKind::Epic,
+        "feature" => TaskKind::Feature,
+        "user story" | "story" | "product backlog item" => TaskKind::Story,
+        "task" => TaskKind::Task,
+        "bug" => TaskKind::Bug,
+        _ => TaskKind::Other,
+    }
+}
+
+/// Map `System.State` → canonical category by name. Covers the Agile / Scrum /
+/// CMMI defaults. See the module note: the same name can differ by process, so
+/// this is best-effort and `status_raw` is authoritative.
+fn map_status(state: &str) -> Option<StatusCategory> {
+    match state.to_ascii_lowercase().as_str() {
+        "new" | "proposed" | "approved" | "to do" | "open" => Some(StatusCategory::Todo),
+        "active" | "committed" | "in progress" | "doing" => Some(StatusCategory::InProgress),
+        "resolved" => Some(StatusCategory::InReview),
+        "removed" => Some(StatusCategory::Cancelled),
+        "closed" | "done" | "completed" => Some(StatusCategory::Done),
+        _ => None,
+    }
+}
+
+/// Map ADO `Priority` (`Int` 1–4, `1` highest) → canonical [`Priority`].
+fn map_priority(p: Option<&Value>) -> Priority {
+    match p.and_then(Value::as_i64) {
+        Some(1) => Priority::Urgent,
+        Some(2) => Priority::High,
+        Some(3) => Priority::Medium,
+        Some(4) => Priority::Low,
+        _ => Priority::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_item() -> Value {
+        json!({
+            "id": 1234,
+            "url": "https://dev.azure.com/acme/_apis/wit/workItems/1234",
+            "fields": {
+                "System.Title": "Adopt the canonical model",
+                "System.Description": "<div>Map ADO work items into CanonicalTask.</div>",
+                "System.WorkItemType": "User Story",
+                "System.State": "Active",
+                "System.Tags": "backend; cdm ; ",
+                "System.TeamProject": "Platform",
+                "System.Parent": 1000,
+                "Microsoft.VSTS.Common.Priority": 2,
+                "System.AssignedTo": {
+                    "id": "ado-1",
+                    "displayName": "Developer",
+                    "uniqueName": "developer@example.com"
+                },
+                "System.CreatedBy": {"id": "ado-2", "displayName": "Lead", "uniqueName": "DOMAIN\\lead"},
+                "System.CreatedDate": "2026-06-01T09:00:00Z",
+                "System.ChangedDate": "2026-06-28T12:00:00Z",
+                "Microsoft.VSTS.Scheduling.StartDate": "2026-06-20T00:00:00Z",
+                "Microsoft.VSTS.Scheduling.DueDate": "2026-07-01T00:00:00Z"
+            }
+        })
+    }
+
+    #[test]
+    fn maps_a_full_item() {
+        let task = AzureDevopsAdapter::new("acme")
+            .to_canonical(&sample_item())
+            .unwrap();
+
+        // Org-namespaced stable key.
+        assert_eq!(task.provider_id, "acme:1234");
+        assert_eq!(task.canonical_id, "azure_devops:acme:1234");
+
+        assert_eq!(task.title, "Adopt the canonical model");
+        assert_eq!(task.kind, TaskKind::Story);
+        assert_eq!(task.kind_raw, "User Story");
+        assert_eq!(task.status_raw, "Active");
+        assert_eq!(task.status_category, Some(StatusCategory::InProgress));
+        assert_eq!(task.priority, Priority::High);
+
+        // Semicolon-delimited tags, trimmed, empties dropped.
+        assert_eq!(task.labels, vec!["backend", "cdm"]);
+
+        // Parent is org-namespaced too.
+        assert_eq!(task.ancestor_path, vec!["azure_devops:acme:1000"]);
+        assert_eq!(
+            task.custom_fields.get("team_project"),
+            Some(&json!("Platform"))
+        );
+
+        assert_eq!(task.assignees.len(), 1);
+        assert_eq!(
+            task.assignees[0].email.as_deref(),
+            Some("developer@example.com")
+        );
+        // Reporter uniqueName is a domain account, not an email → email None.
+        let reporter = task.reporter.as_ref().expect("reporter");
+        assert_eq!(reporter.email, None);
+
+        assert_eq!(task.start_date.as_deref(), Some("2026-06-20T00:00:00Z"));
+        assert_eq!(task.due_date.as_deref(), Some("2026-07-01T00:00:00Z"));
+        assert_eq!(task.completed_at, None); // no ClosedDate
+        assert!(!task.is_terminal());
+    }
+
+    #[test]
+    fn org_falls_back_to_url_when_unset() {
+        // Default adapter has empty org → parse from the url.
+        let task = AzureDevopsAdapter::default()
+            .to_canonical(&sample_item())
+            .unwrap();
+        assert_eq!(task.provider_id, "acme:1234");
+    }
+
+    #[test]
+    fn status_mapping_covers_the_documented_traps() {
+        assert_eq!(map_status("New"), Some(StatusCategory::Todo));
+        assert_eq!(map_status("Active"), Some(StatusCategory::InProgress));
+        assert_eq!(map_status("Resolved"), Some(StatusCategory::InReview));
+        assert_eq!(map_status("Removed"), Some(StatusCategory::Cancelled));
+        assert_eq!(map_status("Closed"), Some(StatusCategory::Done));
+        assert_eq!(map_status("Completed"), Some(StatusCategory::Done));
+        assert_eq!(map_status("Whatever"), None);
+    }
+
+    #[test]
+    fn priority_is_one_through_four() {
+        assert_eq!(map_priority(Some(&json!(1))), Priority::Urgent);
+        assert_eq!(map_priority(Some(&json!(2))), Priority::High);
+        assert_eq!(map_priority(Some(&json!(3))), Priority::Medium);
+        assert_eq!(map_priority(Some(&json!(4))), Priority::Low);
+        assert_eq!(map_priority(None), Priority::None);
+    }
+
+    #[test]
+    fn removed_item_is_terminal() {
+        let mut raw = sample_item();
+        raw["fields"]["System.State"] = json!("Removed");
+        raw["fields"]["Microsoft.VSTS.Common.ClosedDate"] = json!("2026-06-30T10:00:00Z");
+        let task = AzureDevopsAdapter::new("acme").to_canonical(&raw).unwrap();
+        assert_eq!(task.status_category, Some(StatusCategory::Cancelled));
+        assert!(task.is_terminal());
+        assert_eq!(task.completed_at.as_deref(), Some("2026-06-30T10:00:00Z"));
+    }
+
+    #[test]
+    fn missing_id_is_an_error() {
+        let raw = json!({"fields": {"System.Title": "no id"}});
+        assert!(AzureDevopsAdapter::new("acme").to_canonical(&raw).is_err());
+    }
+}

--- a/meridian-core/src/adapters/azure_devops.rs
+++ b/meridian-core/src/adapters/azure_devops.rs
@@ -70,6 +70,16 @@ impl ProviderAdapter for AzureDevopsAdapter {
     fn to_canonical(&self, raw: &Value) -> anyhow::Result<CanonicalTask> {
         let id = id_str(raw.get("id")).context("azure_devops: work item missing `id`")?;
         let org = self.resolve_org(raw);
+        // An empty org would yield a degenerate ":{id}" key (canonical
+        // "azure_devops::{id}") — exactly the cross-org collision the
+        // namespacing exists to prevent. Refuse rather than emit it.
+        if org.is_empty() {
+            anyhow::bail!(
+                "azure_devops: cannot resolve org for work item {id} \
+                 (set AzureDevopsAdapter.org or include a dev.azure.com url); \
+                 refusing to emit an unnamespaced canonical id"
+            );
+        }
         // Org-namespaced stable key (ids aren't globally unique).
         let provider_id = format!("{org}:{id}");
 
@@ -321,6 +331,14 @@ mod tests {
             .to_canonical(&sample_item())
             .unwrap();
         assert_eq!(task.provider_id, "acme:1234");
+    }
+
+    #[test]
+    fn unresolvable_org_is_an_error_not_a_degenerate_key() {
+        // No configured org AND no parseable dev.azure.com url → refuse rather
+        // than emit "azure_devops::1234".
+        let raw = json!({"id": 1234, "fields": {"System.Title": "no org"}});
+        assert!(AzureDevopsAdapter::default().to_canonical(&raw).is_err());
     }
 
     #[test]

--- a/meridian-core/src/adapters/jira.rs
+++ b/meridian-core/src/adapters/jira.rs
@@ -278,8 +278,8 @@ mod tests {
                 "priority": {"name": "High"},
                 "assignee": {
                     "accountId": "acc-1",
-                    "displayName": "Akarsh",
-                    "emailAddress": "akarsh@example.com"
+                    "displayName": "Developer",
+                    "emailAddress": "developer@example.com"
                 },
                 "reporter": {"accountId": "acc-2", "displayName": "Lead"},
                 "parent": {"id": "10001", "key": "KAN-1"},
@@ -314,7 +314,7 @@ mod tests {
         assert_eq!(task.assignees.len(), 1);
         assert_eq!(
             task.assignees[0].email.as_deref(),
-            Some("akarsh@example.com")
+            Some("developer@example.com")
         );
 
         // Reporter has no emailAddress (GDPR-hidden) → email None, id intact.

--- a/meridian-core/src/adapters/jira.rs
+++ b/meridian-core/src/adapters/jira.rs
@@ -279,7 +279,7 @@ mod tests {
                 "assignee": {
                     "accountId": "acc-1",
                     "displayName": "Akarsh",
-                    "emailAddress": "akarsh@meridiona.com"
+                    "emailAddress": "akarsh@example.com"
                 },
                 "reporter": {"accountId": "acc-2", "displayName": "Lead"},
                 "parent": {"id": "10001", "key": "KAN-1"},
@@ -314,7 +314,7 @@ mod tests {
         assert_eq!(task.assignees.len(), 1);
         assert_eq!(
             task.assignees[0].email.as_deref(),
-            Some("akarsh@meridiona.com")
+            Some("akarsh@example.com")
         );
 
         // Reporter has no emailAddress (GDPR-hidden) → email None, id intact.

--- a/meridian-core/src/adapters/jira.rs
+++ b/meridian-core/src/adapters/jira.rs
@@ -1,0 +1,409 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Jira adapter — the reference [`ProviderAdapter`] implementation (DRAFT).
+//!
+//! Maps a Jira REST issue (`/rest/api/3/issue/{id}` shape) onto
+//! [`CanonicalTask`], handling the Jira-specific traps from the six-provider
+//! audit:
+//!
+//! - **Stable id = numeric `id`, not the `KAN-42` key.** Jira keys are mutable
+//!   (re-keyed when an issue moves project), so the canonical key uses the
+//!   immutable numeric id; the human key is stashed in `custom_fields.jira_key`.
+//! - **Only 3 native status categories** (`new`/`indeterminate`/`done`). The
+//!   canonical model has six, so Backlog / In-Review / Cancelled are resolved
+//!   from the literal status *name* before falling back to the category key.
+//! - **Emails are often hidden (GDPR).** `emailAddress` may be absent → `email`
+//!   stays `None`; `accountId` → `provider_user_id` is the reliable join key.
+//!
+//! # Who calls this
+//! Nothing yet (draft). See [`crate::adapters`].
+//!
+//! # Related
+//! - [`crate::adapters::ProviderAdapter`] — the trait this implements.
+//! - [`crate::canonical_task`] — the output shape.
+
+use super::ProviderAdapter;
+use crate::canonical_task::{
+    CanonicalTask, PersonRef, Priority, Provider, StatusCategory, TaskKind,
+};
+use anyhow::Context;
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+
+/// Maps Jira issues to [`CanonicalTask`].
+///
+/// Config-less for the sketch. A production adapter will likely carry the site
+/// base URL (to build `…/browse/{key}` links) and a custom-field id map (Jira
+/// stores start date / story points / sprint under per-instance
+/// `customfield_*` ids), threaded in here without changing the trait.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct JiraAdapter;
+
+impl ProviderAdapter for JiraAdapter {
+    fn provider(&self) -> Provider {
+        Provider::Jira
+    }
+
+    fn to_canonical(&self, raw: &Value) -> anyhow::Result<CanonicalTask> {
+        // Stable key is the numeric id, NOT the (mutable) issue key.
+        let provider_id = raw
+            .get("id")
+            .and_then(Value::as_str)
+            .context("jira: issue missing string `id`")?
+            .to_string();
+        let fields = raw.get("fields").context("jira: issue missing `fields`")?;
+
+        let issuetype = fields.get("issuetype").unwrap_or(&Value::Null);
+        let status = fields.get("status").unwrap_or(&Value::Null);
+
+        // Human-facing key kept retrievable but never used as the stable key.
+        let mut custom_fields: BTreeMap<String, Value> = BTreeMap::new();
+        if let Some(key) = raw.get("key").and_then(Value::as_str) {
+            custom_fields.insert("jira_key".to_string(), json!(key));
+        }
+
+        let assignees = person(fields.get("assignee")).into_iter().collect();
+
+        let ancestor_path = fields
+            .get("parent")
+            .and_then(|p| p.get("id"))
+            .and_then(Value::as_str)
+            .map(|pid| vec![CanonicalTask::canonical_id_for(Provider::Jira, pid)])
+            .unwrap_or_default();
+
+        let project_ids = fields
+            .get("project")
+            .and_then(|p| p.get("id"))
+            .and_then(Value::as_str)
+            .map(|pid| vec![CanonicalTask::canonical_id_for(Provider::Jira, pid)])
+            .unwrap_or_default();
+
+        let labels = fields
+            .get("labels")
+            .and_then(Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(CanonicalTask {
+            // INVARIANT: derive, never assign — keeps canonical_id consistent.
+            canonical_id: CanonicalTask::canonical_id_for(Provider::Jira, &provider_id),
+            provider: Provider::Jira,
+            provider_id,
+            // `self` is the REST URL; a configured adapter would build the
+            // `…/browse/{key}` link from a site base instead.
+            url: str_field(raw, "self").unwrap_or_default(),
+            title: str_field(fields, "summary").unwrap_or_default(),
+            description: description(fields),
+            kind: map_kind(issuetype),
+            kind_raw: str_field(issuetype, "name").unwrap_or_default(),
+            status_raw: str_field(status, "name").unwrap_or_default(),
+            status_category: map_status(status),
+            priority: fields
+                .get("priority")
+                .map(map_priority)
+                .unwrap_or(Priority::None),
+            assignees,
+            reporter: person(fields.get("reporter")),
+            ancestor_path,
+            project_ids,
+            created_at: str_field(fields, "created"),
+            updated_at: str_field(fields, "updated"),
+            completed_at: str_field(fields, "resolutiondate"),
+            // No standard Jira start-date field — it's a per-instance custom
+            // field, resolved once the adapter carries a custom-field id map.
+            start_date: None,
+            due_date: str_field(fields, "duedate"),
+            labels,
+            custom_fields,
+            raw_payload: raw.clone(),
+        })
+    }
+}
+
+/// A non-empty string field, treating JSON null / absent / "" as `None`.
+fn str_field(v: &Value, key: &str) -> Option<String> {
+    v.get(key)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+}
+
+/// Jira v2 returns `description` as a string; v3 returns an ADF object. Take the
+/// string when present; otherwise leave it empty (the full ADF stays in
+/// `raw_payload`, to be flattened by a later slice).
+fn description(fields: &Value) -> String {
+    match fields.get("description") {
+        Some(Value::String(s)) => s.clone(),
+        _ => String::new(),
+    }
+}
+
+/// A Jira user object → [`PersonRef`]. `None` for null/absent or an empty user.
+fn person(v: Option<&Value>) -> Option<PersonRef> {
+    let v = v?;
+    if v.is_null() {
+        return None;
+    }
+    let provider_user_id = v
+        .get("accountId")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let display_name = v
+        .get("displayName")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    if provider_user_id.is_empty() && display_name.is_empty() {
+        return None;
+    }
+    Some(PersonRef {
+        // emailAddress is frequently withheld for privacy → optional.
+        email: v
+            .get("emailAddress")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(String::from),
+        display_name,
+        provider_user_id,
+    })
+}
+
+/// Map issuetype → best-effort [`TaskKind`]. The `subtask` flag wins; otherwise
+/// match on the (user-customizable) type name. Verbatim name lives in `kind_raw`.
+fn map_kind(issuetype: &Value) -> TaskKind {
+    if issuetype
+        .get("subtask")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return TaskKind::Subtask;
+    }
+    match issuetype
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "epic" => TaskKind::Epic,
+        "feature" => TaskKind::Feature,
+        "story" => TaskKind::Story,
+        "task" => TaskKind::Task,
+        "bug" | "defect" => TaskKind::Bug,
+        "sub-task" | "subtask" => TaskKind::Subtask,
+        _ => TaskKind::Other,
+    }
+}
+
+/// Resolve Jira's status into the canonical category. Jira exposes only three
+/// native categories (`new`/`indeterminate`/`done`), so Backlog / InReview /
+/// Cancelled are derived from the literal status *name* first, then the
+/// category key is the fallback. `None` if neither is recognisable.
+fn map_status(status: &Value) -> Option<StatusCategory> {
+    let name = status
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    // Name-based refinements the 3 native categories can't express.
+    if name.contains("backlog") {
+        return Some(StatusCategory::Backlog);
+    }
+    if name.contains("review") {
+        return Some(StatusCategory::InReview);
+    }
+    if name.contains("cancel")
+        || name.contains("won't")
+        || name.contains("wont")
+        || name.contains("reject")
+        || name.contains("abandon")
+    {
+        return Some(StatusCategory::Cancelled);
+    }
+
+    match status
+        .get("statusCategory")
+        .and_then(|c| c.get("key"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+    {
+        "new" => Some(StatusCategory::Todo),
+        "indeterminate" => Some(StatusCategory::InProgress),
+        "done" => Some(StatusCategory::Done),
+        _ => None,
+    }
+}
+
+/// Map Jira priority name → canonical [`Priority`]. Jira priority schemes are
+/// configurable; this covers the common defaults. Absent/unknown → `None`.
+fn map_priority(p: &Value) -> Priority {
+    match p
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "highest" | "blocker" => Priority::Urgent,
+        "high" | "critical" | "major" => Priority::High,
+        "medium" | "normal" => Priority::Medium,
+        "low" | "minor" => Priority::Low,
+        "lowest" | "trivial" => Priority::Low,
+        _ => Priority::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_issue() -> Value {
+        json!({
+            "id": "10042",
+            "key": "KAN-42",
+            "self": "https://acme.atlassian.net/rest/api/3/issue/10042",
+            "fields": {
+                "summary": "Wire up the canonical adapter",
+                "description": "Map Jira issues into CanonicalTask.",
+                "issuetype": {"name": "Story", "subtask": false},
+                "status": {
+                    "name": "In Review",
+                    "statusCategory": {"key": "indeterminate", "name": "In Progress"}
+                },
+                "priority": {"name": "High"},
+                "assignee": {
+                    "accountId": "acc-1",
+                    "displayName": "Akarsh",
+                    "emailAddress": "akarsh@meridiona.com"
+                },
+                "reporter": {"accountId": "acc-2", "displayName": "Lead"},
+                "parent": {"id": "10001", "key": "KAN-1"},
+                "project": {"id": "10000", "key": "KAN"},
+                "labels": ["backend", "cdm"],
+                "created": "2026-06-01T09:00:00.000+0000",
+                "updated": "2026-06-28T12:00:00.000+0000",
+                "resolutiondate": null,
+                "duedate": "2026-07-01"
+            }
+        })
+    }
+
+    #[test]
+    fn maps_a_full_issue() {
+        let task = JiraAdapter.to_canonical(&sample_issue()).unwrap();
+
+        // Stable key is the numeric id; the human key is retained separately.
+        assert_eq!(task.provider_id, "10042");
+        assert_eq!(task.canonical_id, "jira:10042");
+        assert_eq!(task.custom_fields.get("jira_key"), Some(&json!("KAN-42")));
+
+        assert_eq!(task.title, "Wire up the canonical adapter");
+        assert_eq!(task.kind, TaskKind::Story);
+        assert_eq!(task.kind_raw, "Story");
+        assert_eq!(task.priority, Priority::High);
+
+        // Name-based refinement: "In Review" over the `indeterminate` category.
+        assert_eq!(task.status_raw, "In Review");
+        assert_eq!(task.status_category, Some(StatusCategory::InReview));
+
+        assert_eq!(task.assignees.len(), 1);
+        assert_eq!(
+            task.assignees[0].email.as_deref(),
+            Some("akarsh@meridiona.com")
+        );
+
+        // Reporter has no emailAddress (GDPR-hidden) → email None, id intact.
+        let reporter = task.reporter.as_ref().expect("reporter present");
+        assert_eq!(reporter.provider_user_id, "acc-2");
+        assert_eq!(reporter.email, None);
+
+        assert_eq!(task.ancestor_path, vec!["jira:10001"]);
+        assert_eq!(task.project_ids, vec!["jira:10000"]);
+        assert_eq!(task.completed_at, None); // resolutiondate was null
+        assert_eq!(task.due_date.as_deref(), Some("2026-07-01"));
+        assert_eq!(task.labels, vec!["backend", "cdm"]);
+        assert!(!task.is_terminal());
+    }
+
+    #[test]
+    fn status_resolution_covers_all_six_categories() {
+        let cases = [
+            ("Backlog", "new", Some(StatusCategory::Backlog)),
+            ("To Do", "new", Some(StatusCategory::Todo)),
+            (
+                "In Progress",
+                "indeterminate",
+                Some(StatusCategory::InProgress),
+            ),
+            (
+                "Code Review",
+                "indeterminate",
+                Some(StatusCategory::InReview),
+            ),
+            ("Done", "done", Some(StatusCategory::Done)),
+            // Terminal-but-cancelled is name-derived over the `done` category.
+            ("Cancelled", "done", Some(StatusCategory::Cancelled)),
+            ("Won't Do", "done", Some(StatusCategory::Cancelled)),
+        ];
+        for (name, key, expected) in cases {
+            let status = json!({"name": name, "statusCategory": {"key": key}});
+            assert_eq!(map_status(&status), expected, "status name {name:?}");
+        }
+        // Unrecognisable → None.
+        assert_eq!(map_status(&json!({})), None);
+    }
+
+    #[test]
+    fn priority_lookup_is_name_based() {
+        assert_eq!(map_priority(&json!({"name": "Highest"})), Priority::Urgent);
+        assert_eq!(map_priority(&json!({"name": "High"})), Priority::High);
+        assert_eq!(map_priority(&json!({"name": "Medium"})), Priority::Medium);
+        assert_eq!(map_priority(&json!({"name": "Lowest"})), Priority::Low);
+        assert_eq!(map_priority(&json!({"name": "Whatever"})), Priority::None);
+    }
+
+    #[test]
+    fn unassigned_issue_has_empty_assignees() {
+        let mut raw = sample_issue();
+        raw["fields"]["assignee"] = Value::Null;
+        let task = JiraAdapter.to_canonical(&raw).unwrap();
+        assert!(task.assignees.is_empty());
+    }
+
+    #[test]
+    fn subtask_flag_wins_over_type_name() {
+        let issuetype = json!({"name": "Story", "subtask": true});
+        assert_eq!(map_kind(&issuetype), TaskKind::Subtask);
+    }
+
+    #[test]
+    fn cancelled_issue_is_terminal() {
+        let mut raw = sample_issue();
+        raw["fields"]["status"] = json!({"name": "Cancelled", "statusCategory": {"key": "done"}});
+        raw["fields"]["resolutiondate"] = json!("2026-06-30T10:00:00.000+0000");
+        let task = JiraAdapter.to_canonical(&raw).unwrap();
+        assert_eq!(task.status_category, Some(StatusCategory::Cancelled));
+        assert!(task.is_terminal());
+        assert!(task.completed_at.is_some());
+    }
+
+    #[test]
+    fn missing_id_is_an_error() {
+        let raw = json!({"fields": {"summary": "no id"}});
+        assert!(JiraAdapter.to_canonical(&raw).is_err());
+    }
+
+    #[test]
+    fn adapter_is_object_safe() {
+        let adapter: Box<dyn ProviderAdapter> = Box::new(JiraAdapter);
+        assert_eq!(adapter.provider(), Provider::Jira);
+        let out = adapter.to_canonical_many(&[sample_issue()]);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].is_ok());
+    }
+}

--- a/meridian-core/src/adapters/jira.rs
+++ b/meridian-core/src/adapters/jira.rs
@@ -209,32 +209,43 @@ fn map_status(status: &Value) -> Option<StatusCategory> {
         .and_then(Value::as_str)
         .unwrap_or_default()
         .to_ascii_lowercase();
+    let cat_key = status
+        .get("statusCategory")
+        .and_then(|c| c.get("key"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
 
-    // Name-based refinements the 3 native categories can't express.
+    let is_cancel = name.contains("cancel")
+        || name.contains("won't")
+        || name.contains("wont")
+        || name.contains("reject")
+        || name.contains("abandon");
+
+    // The `done` category is terminal: distinguish Done vs Cancelled by name
+    // only — never let a "review"/"backlog" substring (e.g. a terminal
+    // "Reviewed" column) pull a done status back to a non-terminal category.
+    if cat_key == "done" {
+        return Some(if is_cancel {
+            StatusCategory::Cancelled
+        } else {
+            StatusCategory::Done
+        });
+    }
+
+    // Non-terminal categories: Jira's `new`/`indeterminate` can't express
+    // Backlog / InReview / Cancelled, so refine from the status name first.
     if name.contains("backlog") {
         return Some(StatusCategory::Backlog);
     }
     if name.contains("review") {
         return Some(StatusCategory::InReview);
     }
-    if name.contains("cancel")
-        || name.contains("won't")
-        || name.contains("wont")
-        || name.contains("reject")
-        || name.contains("abandon")
-    {
+    if is_cancel {
         return Some(StatusCategory::Cancelled);
     }
-
-    match status
-        .get("statusCategory")
-        .and_then(|c| c.get("key"))
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-    {
+    match cat_key {
         "new" => Some(StatusCategory::Todo),
         "indeterminate" => Some(StatusCategory::InProgress),
-        "done" => Some(StatusCategory::Done),
         _ => None,
     }
 }
@@ -349,6 +360,9 @@ mod tests {
             // Terminal-but-cancelled is name-derived over the `done` category.
             ("Cancelled", "done", Some(StatusCategory::Cancelled)),
             ("Won't Do", "done", Some(StatusCategory::Cancelled)),
+            // A terminal "Reviewed" column keeps Done — the `done` category is
+            // never pulled non-terminal by the "review" substring.
+            ("Reviewed", "done", Some(StatusCategory::Done)),
         ];
         for (name, key, expected) in cases {
             let status = json!({"name": name, "statusCategory": {"key": key}});

--- a/meridian-core/src/adapters/linear.rs
+++ b/meridian-core/src/adapters/linear.rs
@@ -1,0 +1,321 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Linear adapter — reference [`ProviderAdapter`] for Linear (DRAFT).
+//!
+//! Maps a Linear GraphQL `Issue` node onto [`CanonicalTask`], handling the
+//! Linear-specific traps from the six-provider audit:
+//!
+//! - **Stable id = the UUID `id`.** The human `identifier` (`ENG-123`) is kept
+//!   in `custom_fields.linear_identifier`.
+//! - **Priority is an inverted `Int` 0–4** (`1` = Urgent … `4` = Low, `0` = no
+//!   priority). Mapped through an explicit table — never an ordinal cast.
+//! - **Status comes from `WorkflowState.type`** (the 6 system types incl.
+//!   `triage`), not the state name. Teams' custom "In Review" states have
+//!   `type = "started"`, so they fold into [`StatusCategory::InProgress`] — the
+//!   canonical `InReview` is never emitted for Linear (by design).
+//! - **No issue-type concept** — every issue maps to [`TaskKind::Task`] with an
+//!   empty `kind_raw`.
+//! - `completedAt` / `canceledAt` feed `completed_at`; `parent` → `ancestor_path`,
+//!   `project` → `project_ids`; `estimate` / `cycle` are kept in `custom_fields`.
+//!
+//! # Who calls this
+//! Nothing yet (draft). See [`crate::adapters`].
+//!
+//! # Related
+//! - [`crate::adapters::ProviderAdapter`] — the trait this implements.
+//! - [`crate::canonical_task`] — the output shape.
+
+use super::ProviderAdapter;
+use crate::canonical_task::{
+    CanonicalTask, PersonRef, Priority, Provider, StatusCategory, TaskKind,
+};
+use anyhow::Context;
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+
+/// Maps Linear issues to [`CanonicalTask`].
+///
+/// Config-less: a Linear `Issue` node carries everything needed (`url`,
+/// `identifier`, `state.type`) so there's nothing per-workspace to thread in.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LinearAdapter;
+
+impl ProviderAdapter for LinearAdapter {
+    fn provider(&self) -> Provider {
+        Provider::Linear
+    }
+
+    fn to_canonical(&self, raw: &Value) -> anyhow::Result<CanonicalTask> {
+        let provider_id = raw
+            .get("id")
+            .and_then(Value::as_str)
+            .context("linear: issue missing string `id`")?
+            .to_string();
+
+        let mut custom_fields: BTreeMap<String, Value> = BTreeMap::new();
+        // Human-facing identifier kept retrievable; the UUID stays the key.
+        if let Some(ident) = raw.get("identifier").and_then(Value::as_str) {
+            custom_fields.insert("linear_identifier".to_string(), json!(ident));
+        }
+        // Linear-specific signals worth preserving but with no canonical slot.
+        if let Some(est) = raw.get("estimate").filter(|v| !v.is_null()) {
+            custom_fields.insert("estimate".to_string(), est.clone());
+        }
+        if let Some(cycle) = raw
+            .get("cycle")
+            .and_then(|c| c.get("id"))
+            .and_then(Value::as_str)
+        {
+            custom_fields.insert("cycle_id".to_string(), json!(cycle));
+        }
+
+        let assignees = person(raw.get("assignee")).into_iter().collect();
+
+        let ancestor_path = raw
+            .get("parent")
+            .and_then(|p| p.get("id"))
+            .and_then(Value::as_str)
+            .map(|pid| vec![CanonicalTask::canonical_id_for(Provider::Linear, pid)])
+            .unwrap_or_default();
+
+        let project_ids = raw
+            .get("project")
+            .and_then(|p| p.get("id"))
+            .and_then(Value::as_str)
+            .map(|pid| vec![CanonicalTask::canonical_id_for(Provider::Linear, pid)])
+            .unwrap_or_default();
+
+        let labels = raw
+            .get("labels")
+            .and_then(|l| l.get("nodes"))
+            .and_then(Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .filter_map(|n| n.get("name").and_then(Value::as_str).map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Terminal timestamp: completedAt, else canceledAt.
+        let completed_at = str_field(raw, "completedAt").or_else(|| str_field(raw, "canceledAt"));
+
+        Ok(CanonicalTask {
+            canonical_id: CanonicalTask::canonical_id_for(Provider::Linear, &provider_id),
+            provider: Provider::Linear,
+            provider_id,
+            url: str_field(raw, "url").unwrap_or_default(),
+            title: str_field(raw, "title").unwrap_or_default(),
+            description: str_field(raw, "description").unwrap_or_default(),
+            // Linear has no issue-type concept — everything is a plain issue.
+            kind: TaskKind::Task,
+            kind_raw: String::new(),
+            status_raw: raw
+                .get("state")
+                .and_then(|s| s.get("name"))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            status_category: map_status(raw.get("state")),
+            priority: map_priority(raw.get("priority")),
+            assignees,
+            reporter: person(raw.get("creator")),
+            ancestor_path,
+            project_ids,
+            created_at: str_field(raw, "createdAt"),
+            updated_at: str_field(raw, "updatedAt"),
+            completed_at,
+            // Linear has no planned start-date field.
+            start_date: None,
+            due_date: str_field(raw, "dueDate"),
+            labels,
+            custom_fields,
+            raw_payload: raw.clone(),
+        })
+    }
+}
+
+/// A non-empty string field, treating JSON null / absent / "" as `None`.
+fn str_field(v: &Value, key: &str) -> Option<String> {
+    v.get(key)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+}
+
+/// A Linear `User` node → [`PersonRef`]. `None` for null/absent or an empty user.
+fn person(v: Option<&Value>) -> Option<PersonRef> {
+    let v = v?;
+    if v.is_null() {
+        return None;
+    }
+    let provider_user_id = v
+        .get("id")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    // Linear exposes both `displayName` and `name`; prefer the former.
+    let display_name = v
+        .get("displayName")
+        .and_then(Value::as_str)
+        .or_else(|| v.get("name").and_then(Value::as_str))
+        .unwrap_or_default()
+        .to_string();
+    if provider_user_id.is_empty() && display_name.is_empty() {
+        return None;
+    }
+    Some(PersonRef {
+        email: v
+            .get("email")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(String::from),
+        display_name,
+        provider_user_id,
+    })
+}
+
+/// Map `WorkflowState.type` → canonical category. Linear's six system types are
+/// the source of truth; custom states (e.g. "In Review") carry one of these
+/// types (`started`), so name-based refinement is deliberately NOT done.
+fn map_status(state: Option<&Value>) -> Option<StatusCategory> {
+    match state?.get("type").and_then(Value::as_str)? {
+        "triage" | "backlog" => Some(StatusCategory::Backlog),
+        "unstarted" => Some(StatusCategory::Todo),
+        // Custom "In Review" states are `type = started` → fold into InProgress.
+        "started" => Some(StatusCategory::InProgress),
+        "completed" => Some(StatusCategory::Done),
+        "canceled" => Some(StatusCategory::Cancelled),
+        _ => None,
+    }
+}
+
+/// Map Linear's inverted `Int` priority (0–4) → canonical [`Priority`].
+/// `1` = Urgent … `4` = Low, `0`/absent = no priority. Explicit table — an
+/// ordinal cast would invert the meaning.
+fn map_priority(p: Option<&Value>) -> Priority {
+    match p.and_then(Value::as_i64).unwrap_or(0) {
+        1 => Priority::Urgent,
+        2 => Priority::High,
+        3 => Priority::Medium,
+        4 => Priority::Low,
+        _ => Priority::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_issue() -> Value {
+        json!({
+            "id": "11111111-2222-3333-4444-555555555555",
+            "identifier": "ENG-123",
+            "url": "https://linear.app/acme/issue/ENG-123",
+            "title": "Adopt the canonical model",
+            "description": "Map Linear issues into CanonicalTask.",
+            "priority": 2,
+            "state": {"type": "started", "name": "In Review"},
+            "assignee": {
+                "id": "usr-1",
+                "displayName": "Developer",
+                "name": "dev",
+                "email": "developer@example.com"
+            },
+            "creator": {"id": "usr-2", "displayName": "Lead"},
+            "parent": {"id": "uuid-parent"},
+            "project": {"id": "proj-uuid"},
+            "labels": {"nodes": [{"name": "backend"}, {"name": "cdm"}]},
+            "createdAt": "2026-06-01T09:00:00.000Z",
+            "updatedAt": "2026-06-28T12:00:00.000Z",
+            "completedAt": null,
+            "canceledAt": null,
+            "dueDate": "2026-07-01",
+            "estimate": 3,
+            "cycle": {"id": "cycle-9"}
+        })
+    }
+
+    #[test]
+    fn maps_a_full_issue() {
+        let task = LinearAdapter.to_canonical(&sample_issue()).unwrap();
+
+        // UUID is the stable key; the human identifier is retained separately.
+        assert_eq!(task.provider_id, "11111111-2222-3333-4444-555555555555");
+        assert_eq!(
+            task.canonical_id,
+            "linear:11111111-2222-3333-4444-555555555555"
+        );
+        assert_eq!(
+            task.custom_fields.get("linear_identifier"),
+            Some(&json!("ENG-123"))
+        );
+        assert_eq!(task.custom_fields.get("estimate"), Some(&json!(3)));
+        assert_eq!(task.custom_fields.get("cycle_id"), Some(&json!("cycle-9")));
+
+        // No issue-type concept in Linear.
+        assert_eq!(task.kind, TaskKind::Task);
+        assert_eq!(task.kind_raw, "");
+
+        // "In Review" custom state has type=started → InProgress (verbatim kept).
+        assert_eq!(task.status_raw, "In Review");
+        assert_eq!(task.status_category, Some(StatusCategory::InProgress));
+
+        // Inverted priority: 2 → High.
+        assert_eq!(task.priority, Priority::High);
+
+        assert_eq!(task.assignees.len(), 1);
+        assert_eq!(
+            task.assignees[0].email.as_deref(),
+            Some("developer@example.com")
+        );
+        assert_eq!(task.ancestor_path, vec!["linear:uuid-parent"]);
+        assert_eq!(task.project_ids, vec!["linear:proj-uuid"]);
+        assert_eq!(task.completed_at, None);
+        assert_eq!(task.labels, vec!["backend", "cdm"]);
+        assert!(!task.is_terminal());
+    }
+
+    #[test]
+    fn priority_table_is_inverted_not_ordinal() {
+        let p = |n: i64| map_priority(Some(&json!(n)));
+        assert_eq!(p(0), Priority::None);
+        assert_eq!(p(1), Priority::Urgent);
+        assert_eq!(p(2), Priority::High);
+        assert_eq!(p(3), Priority::Medium);
+        assert_eq!(p(4), Priority::Low);
+        // Absent priority → None.
+        assert_eq!(map_priority(None), Priority::None);
+    }
+
+    #[test]
+    fn status_maps_from_state_type() {
+        let by = |t: &str| map_status(Some(&json!({"type": t, "name": "x"})));
+        assert_eq!(by("triage"), Some(StatusCategory::Backlog));
+        assert_eq!(by("backlog"), Some(StatusCategory::Backlog));
+        assert_eq!(by("unstarted"), Some(StatusCategory::Todo));
+        assert_eq!(by("started"), Some(StatusCategory::InProgress));
+        assert_eq!(by("completed"), Some(StatusCategory::Done));
+        assert_eq!(by("canceled"), Some(StatusCategory::Cancelled));
+        assert_eq!(map_status(None), None);
+    }
+
+    #[test]
+    fn completed_at_falls_back_to_canceled_at() {
+        let mut raw = sample_issue();
+        raw["state"] = json!({"type": "canceled", "name": "Cancelled"});
+        raw["canceledAt"] = json!("2026-06-30T10:00:00.000Z");
+        let task = LinearAdapter.to_canonical(&raw).unwrap();
+        assert_eq!(task.status_category, Some(StatusCategory::Cancelled));
+        assert!(task.is_terminal());
+        assert_eq!(
+            task.completed_at.as_deref(),
+            Some("2026-06-30T10:00:00.000Z")
+        );
+    }
+
+    #[test]
+    fn missing_id_is_an_error() {
+        assert!(LinearAdapter
+            .to_canonical(&json!({"title": "no id"}))
+            .is_err());
+    }
+}

--- a/meridian-core/src/adapters/mod.rs
+++ b/meridian-core/src/adapters/mod.rs
@@ -20,14 +20,19 @@
 //!
 //! # Related
 //! - [`crate::canonical_task`] — the output shape these produce.
-//! - [`jira`] — the reference implementation (handles the Jira-specific traps:
-//!   numeric id as the stable key, 3-native-category status resolution,
-//!   GDPR-hidden emails).
+//! - [`jira`] — numeric id as the stable key, 3-native-category status
+//!   resolution, GDPR-hidden emails.
+//! - [`linear`] — UUID id, inverted Int priority lookup, `WorkflowState.type`
+//!   → category (custom "In Review" folds into In-Progress).
+//! - [`azure_devops`] — org-namespaced id (`{org}:{id}`), Int 1–4 priority,
+//!   state→category by name, semicolon-delimited tags.
 
 use crate::canonical_task::{CanonicalTask, Provider};
 use serde_json::Value;
 
+pub mod azure_devops;
 pub mod jira;
+pub mod linear;
 
 /// Maps a tracker's raw API payload onto the canonical task shape.
 ///

--- a/meridian-core/src/adapters/mod.rs
+++ b/meridian-core/src/adapters/mod.rs
@@ -1,0 +1,62 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Provider adapters — Step 2 of the CDM migration (DRAFT sketch).
+//!
+//! Each tracker implements [`ProviderAdapter`] to map its raw API payload (one
+//! issue / card / work-item, exactly as the tracker returned it) onto the
+//! canonical [`CanonicalTask`] shape. This is the single enforcement point for
+//! the `canonical_id` invariant: adapters MUST derive `canonical_id` via
+//! [`CanonicalTask::canonical_id_for`] rather than setting it freely, so a
+//! `CanonicalTask` produced by an adapter can never carry a mismatched key.
+//!
+//! Adapters are **pure transformations** — no HTTP, no DB, no I/O. Fetching the
+//! payload stays in the daemon (which owns `reqwest`); the adapter only maps an
+//! already-fetched `serde_json::Value`. That keeps this layer in `meridian-core`
+//! (DB-free, like [`crate::hygiene`]) and trivially unit-testable.
+//!
+//! # Who calls this
+//! Nothing yet (draft). The daemon's ingestion paths will own one adapter per
+//! configured tracker and call [`ProviderAdapter::to_canonical`] on each fetched
+//! item before persisting it.
+//!
+//! # Related
+//! - [`crate::canonical_task`] — the output shape these produce.
+//! - [`jira`] — the reference implementation (handles the Jira-specific traps:
+//!   numeric id as the stable key, 3-native-category status resolution,
+//!   GDPR-hidden emails).
+
+use crate::canonical_task::{CanonicalTask, Provider};
+use serde_json::Value;
+
+pub mod jira;
+
+/// Maps a tracker's raw API payload onto the canonical task shape.
+///
+/// Implementors are responsible for the per-tracker normalisation traps
+/// (stable-id selection, status-category derivation, priority lookup tables,
+/// hierarchy flattening) documented in each adapter module. The contract:
+///
+/// - `canonical_id` MUST be built with [`CanonicalTask::canonical_id_for`] from
+///   the same `provider`/`provider_id` the adapter sets — never freely assigned.
+/// - The full input is preserved verbatim in `raw_payload`, and any
+///   tracker-specific field that doesn't map to the core goes in `custom_fields`
+///   — normalisation is never lossy.
+/// - Best-effort fields (`status_category`, `kind`, `priority`) may degrade to
+///   `None`/`Other`/`Priority::None`; the verbatim `*_raw` companions still
+///   carry the original.
+pub trait ProviderAdapter {
+    /// The provider this adapter handles. Used to namespace canonical ids.
+    fn provider(&self) -> Provider;
+
+    /// Map a single raw payload into the canonical shape.
+    ///
+    /// Returns an error only when the payload is structurally unusable (e.g.
+    /// missing the stable id) — recoverable gaps map to best-effort defaults
+    /// rather than failing.
+    fn to_canonical(&self, raw: &Value) -> anyhow::Result<CanonicalTask>;
+
+    /// Map a batch, isolating per-item failures so one malformed payload can't
+    /// sink the whole ingestion run. Provided default; adapters rarely override.
+    fn to_canonical_many(&self, raws: &[Value]) -> Vec<anyhow::Result<CanonicalTask>> {
+        raws.iter().map(|raw| self.to_canonical(raw)).collect()
+    }
+}

--- a/meridian-core/src/lib.rs
+++ b/meridian-core/src/lib.rs
@@ -22,6 +22,7 @@
 pub use sqlx::SqlitePool;
 
 // ── Internal organization ───────────────────────────────────────────────────
+pub mod adapters;
 pub mod canonical_task;
 mod db;
 mod readers;
@@ -53,3 +54,5 @@ pub use readers::{
 };
 
 pub use canonical_task::{CanonicalTask, PersonRef, Priority, Provider, StatusCategory, TaskKind};
+
+pub use adapters::ProviderAdapter;


### PR DESCRIPTION
## Summary

**Step 2** of the CDM + provider-adapters migration: the adapter layer that maps each tracker's raw API payload onto `CanonicalTask`. Stacked on **#361** (`feat/canonical-task-model`) — review/merge that first; GitHub auto-retargets this to `pre-main` afterward.

This now covers the **`ProviderAdapter` trait + the three trackers Meridian ingests today (Jira, Linear, Azure DevOps)**. GitHub Projects + Asana are Step 4. The daemon-side ingestion *wiring* (replacing the existing fetch→persist paths with these adapters) is intentionally **not** here — that touches the daemon crate and is a separate step.

## What's included

**`adapters/mod.rs` — the `ProviderAdapter` trait**

```rust
pub trait ProviderAdapter {
    fn provider(&self) -> Provider;
    fn to_canonical(&self, raw: &Value) -> anyhow::Result<CanonicalTask>;
    fn to_canonical_many(&self, raws: &[Value]) -> Vec<anyhow::Result<CanonicalTask>> { /* provided */ }
}
```

- **Pure transformation** — `&serde_json::Value` in, `CanonicalTask` out. No HTTP/DB/I/O; fetching stays in the daemon. Keeps the layer in `meridian-core` (DB-free, like `hygiene`) and fully unit-testable.
- **Object-safe**; `to_canonical_many` isolates per-item failures (one bad payload can't sink a batch).
- The **single enforcement point** for the `canonical_id` invariant — adapters derive it via `canonical_id_for`, never freely.

**Three reference adapters**, each handling its audited traps:

| Adapter | Key traps handled |
|---|---|
| **Jira** (`jira.rs`) | numeric `id` as stable key (human key → `custom_fields.jira_key`); six-category status resolved from the status *name* over Jira's 3 native categories; GDPR-hidden emails (`accountId` → `provider_user_id`); name-based priority; `parent` → `ancestor_path`; `resolutiondate` → `completed_at` |
| **Linear** (`linear.rs`) | UUID `id` (identifier → `custom_fields`); **inverted** Int 0–4 priority via explicit table; `WorkflowState.type` → category (custom "In Review" = `type started` folds into InProgress — `InReview` not emitted, by design); no issue-type → `TaskKind::Task`; `completedAt`/`canceledAt` → `completed_at`; `estimate`/`cycle` preserved |
| **Azure DevOps** (`azure_devops.rs`) | **org-namespaced** stable key `{org}:{id}` (ids aren't globally unique; org configured or parsed from `url`); Int 1–4 priority; semicolon-delimited `System.Tags` → labels; `System.State` → category by name (Removed→Cancelled, Resolved→InReview, Closed/Done/Completed→Done); dotted `System.*` field access; parent org-namespaced too |

## Deliberately NOT included (scope guard)

- No GitHub Projects / Asana adapters (Step 4).
- No daemon ingestion wiring, no DB persistence, no migration. Nothing calls these yet.
- ADO status is mapped by **name**; the same name can mean different categories across process templates (the CMMI "Resolved" trap). Full fidelity needs the process's state-category metadata (WIT states API) — documented in-module, and `status_raw` stays authoritative.
- ADF→text flattening (Jira/ADO HTML descriptions) and per-instance Jira custom-field resolution are stubbed with doc notes.
- Test fixtures use a generic `Developer` / `example.com` identity (no real data).

## Testing

Gates run against an isolated copy of `meridian-core` **and** against the real workspace lockfile (with the unrelated, unreachable `tray/src-tauri` member dropped):

- `cargo fmt --check` — clean
- `cargo clippy -- -D warnings` — zero warnings
- `cargo test` — all green: **19 adapter tests** (Jira 8 · Linear 5 · ADO 6) + the `canonical_task` and reader suites (78 unit + 10 integration total)

Per-adapter tests cover full-payload mapping, the status/priority lookup tables (incl. Linear's inversion and ADO's by-name traps), stable-id selection, terminal-state + `completed_at`, hierarchy namespacing, unassigned/empty handling, and missing-id errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)