### PR TITLE
fix(worklog): restore WORKLOG_SYSTEM re-export broken by package restore

### DIFF
--- a/services/agents/worklog_pipeline/worklog.py
+++ b/services/agents/worklog_pipeline/worklog.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 
 from agents.worklog_pipeline.models import WorklogDraft
+from agents.worklog_pipeline.prompts.worklog import SYSTEM as WORKLOG_SYSTEM
 
 log = logging.getLogger("meridian.worklog.gen")
 

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meridian-agents"
-version = "1.64.0"
+version = "1.64.1"
 description = "Meridian agents — MLX classifier server and Jira worklog synthesis for meridian.db"
 requires-python = ">=3.11"
 authors = [{ name = "Meridiona" }]


### PR DESCRIPTION
## Problem

No worklogs have drafted on installed machines since ~June 27. Every hourly slot in `pm_worklog_hours` is stuck `status=pending`, `task_count=0`, `processed_at=NULL`, while upstream data is healthy (sessions + `summarised` coding-agent rows are present).

Root cause: the worklog pipeline fires every poll but the MLX server's `/worklog_hour` returns HTTP 500:

```
cannot import name 'WORKLOG_SYSTEM' from 'agents.worklog_pipeline.worklog'
```

`pipeline.py` imports `WORKLOG_SYSTEM` from `worklog.py` (3 references), but the re-export line was dropped when `cf525ba1` ("restore worklog_pipeline package from cleanup branch") restored the package. The constant is defined nowhere, so importing `pipeline` raises `ImportError`, the endpoint 500s, and the Rust daemon leaves every hour pending.

## Fix

- **`worklog.py`** — restore the lost re-export:
  ```python
  from agents.worklog_pipeline.prompts.worklog import SYSTEM as WORKLOG_SYSTEM
  ```
  (`prompts/worklog.py` still defines `SYSTEM` — only the re-export was lost.)
- **`pyproject.toml`** — bump `1.64.0` → `1.64.1` so the runtime auto-upgrade (an equality check) actually triggers on installed machines.

## Verification

Ran the import chain under the runtime's Python against this source:

```
worklog import OK; WORKLOG_SYSTEM len = 933
pipeline import OK: agents.worklog_pipeline.pipeline
```

## ⚠️ Ships nothing until the runtime is republished

This repo fix does not reach any running app on its own — `/worklog_hour` runs from `~/.meridian/runtime/`, versioned independently. After merge, cut runtime tags from the merge commit (`runtime-staging-v1.64.1` and/or `runtime-v1.64.1`). Once installed trays auto-upgrade, the backlog of `pending` hours should process on the next poll since the upstream `summarised` sessions are intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CT9wnEUuQeoBeufqTh46JC