### PR TITLE
ci(runtime): smoke-test imports every agents submodule

### DIFF
--- a/scripts/smoke-test-mlx-runtime.sh
+++ b/scripts/smoke-test-mlx-runtime.sh
@@ -5,10 +5,12 @@
 #
 # Extracts the tarball to a FRESH path (deliberately not where it was built),
 # exactly as the app does (`tar --strip-components=1` into ~/.meridian/runtime/),
-# then proves it actually works: import the native stack, boot the server, and
-# hit /health. Green here ⇒ green on a customer's Mac. Catches arch / Python-ABI
-# / macOS-deployment-target / relocation mismatches in one shot — the failures
-# that otherwise only surface on the user's machine.
+# then proves it actually works: import the native stack, import EVERY agents
+# submodule, boot the server, and hit /health. Green here ⇒ green on a customer's
+# Mac. Catches arch / Python-ABI / macOS-deployment-target / relocation
+# mismatches AND lazy-import regressions (a broken `from … import NAME` in an
+# endpoint module that only 500s in production) in one shot — the failures that
+# otherwise only surface on the user's machine.
 #
 # Run on a DIFFERENT runner/macOS version than the build for a real portability
 # check. Usage: scripts/smoke-test-mlx-runtime.sh <path-to-tarball>
@@ -36,7 +38,39 @@ echo "→ interpreter: $("${PY}" --version)"
 echo "→ importing native stack…"
 "${PY}" -c "import mlx, mlx_lm, outlines, fastapi, agents; print('  imports ok:', mlx.__name__, mlx_lm.__name__)"
 
-# 2. Boot the server and probe /health (the model lazy-loads on first request,
+# 2. Whole-package import check — walk EVERY agents submodule and import it.
+#    Step 1 only runs agents/__init__; endpoint code (e.g. the worklog pipeline)
+#    is imported LAZILY inside request handlers like /worklog_hour, so a broken
+#    `from … import NAME` there sails past both __init__ AND /health and only
+#    500s in production. Importing every module turns that class of regression
+#    into a red build. Import ≠ run: no 7 GB model download, no DB. Excludes
+#    agents.tests (pytest-only, not part of the shipped runtime).
+echo "→ importing every agents submodule…"
+"${PY}" - <<'PYEOF'
+import importlib
+import pkgutil
+import sys
+
+import agents
+
+failures = []
+for mod in pkgutil.walk_packages(agents.__path__, prefix="agents."):
+    if mod.name.startswith("agents.tests"):
+        continue
+    try:
+        importlib.import_module(mod.name)
+    except Exception as exc:  # noqa: BLE001 — any import failure must fail the build
+        failures.append((mod.name, repr(exc)))
+
+if failures:
+    print(f"✗ {len(failures)} agents submodule(s) failed to import:", file=sys.stderr)
+    for name, err in failures:
+        print(f"    {name} -> {err}", file=sys.stderr)
+    sys.exit(1)
+print("  all agents submodules import ok")
+PYEOF
+
+# 3. Boot the server and probe /health (the model lazy-loads on first request,
 #    so this does NOT need the 7 GB download).
 echo "→ booting server on :${PORT}…"
 "${PY}" "${RT}/server.py" --port "${PORT}" >"${TMP}/server.log" 2>&1 &


### PR DESCRIPTION
## Why

The `WORKLOG_SYSTEM` ImportError (#365) shipped to **production** and silently killed worklog drafting because the runtime smoke test never exercised the broken code path. The smoke test:

1. ran `import agents` — only executes `agents/__init__`, not the submodules, and
2. booted the server + hit `/health`.

But endpoint code is imported **lazily inside request handlers** — `/worklog_hour` does `from agents.worklog_pipeline.workflow import run_hour_workflow` → `pipeline` → the broken `from … import WORKLOG_SYSTEM`. So the regression sailed past both `__init__` and `/health` and only 500'd once a real worklog hour was processed on a customer machine.

This is a **gate** gap, independent of how the runtime is triggered — closing it is the highest-value guard against this whole class of bug.

## What

New smoke step (between native import and server boot): walk **every** `agents` submodule with `pkgutil` + `importlib` and fail the build on any import error. Excludes `agents.tests` (pytest-only, not shipped). Import ≠ run — no 7 GB model download, no DB.

## Verification (local, against real runtime tarballs)

| Tarball | Result |
|---|---|
| Installed runtime **with** the `WORKLOG_SYSTEM` regression | **exit 1** at the new step, before boot — flags `agents.worklog_pipeline.pipeline` + `workflow` |
| Same runtime **with the #365 fix** applied | **exit 0** — walk passes, server boots, `/health` 200, `✓ runtime smoke test passed` |

Had this been in place, the broken runtime could never have published.

## Follow-ups (separate)

This is item #1 of the runtime-pipeline hardening discussed. Items #2/#3 (auto-publish staging on `pre-main` merge; gated production publish on `main` merge with a version-bump CI check) will follow in their own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CT9wnEUuQeoBeufqTh46JC