### PR TITLE
fix(runtime): check out repo in publish jobs (exit 127 — publish never ran)

### DIFF
--- a/.github/workflows/build-mlx-runtime.yml
+++ b/.github/workflows/build-mlx-runtime.yml
@@ -154,6 +154,11 @@ jobs:
     env:
       CHANNEL: runtime-staging
     steps:
+      # The publish logic lives in scripts/publish-runtime-channel.sh, so the repo
+      # must be checked out — and BEFORE download-artifact, since actions/checkout
+      # cleans the workspace and would otherwise wipe the downloaded dist/.
+      - uses: actions/checkout@v7
+
       - name: Download runtime artifact
         uses: actions/download-artifact@v8
         with:
@@ -179,6 +184,10 @@ jobs:
     env:
       CHANNEL: runtime-latest
     steps:
+      # See publish-staging: checkout (for the publish script) must precede
+      # download-artifact so it doesn't clean away the downloaded dist/.
+      - uses: actions/checkout@v7
+
       - name: Download runtime artifact
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
## Hotfix for the auto-publish regression from #372

#372 extracted the channel-publish logic into `scripts/publish-runtime-channel.sh`, but the `publish-staging` / `publish-production` jobs in `build-mlx-runtime.yml` never run `actions/checkout`, so the script isn't on disk → `bash: scripts/publish-runtime-channel.sh: No such file or directory` (**exit 127**). The gate/build/smoke jobs all check out; only the two publish jobs were missed in the inline→script refactor.

**Caught on the first real auto-publish** — the #372 merge to `pre-main` ran: gate ✓, build (1.64.1) ✓, smoke macOS 14/15/26 ✓, then **publish-staging failed (exit 127)**. So `runtime-staging` is still stuck at **1.63.0** (the broken-worklog runtime). [Failed run](https://github.com/Meridiona/meridian/actions/runs/28429586316)

## Fix
Add `actions/checkout@v7` as the **first** step in both publish jobs — before `download-artifact`, because `actions/checkout` cleans the workspace by default and would otherwise wipe the just-downloaded `dist/`.

## After merge
Re-triggers the workflow on `pre-main`; the gate still sees `1.64.1 > 1.63.0` → builds + (this time) publishes `runtime-staging` at 1.64.1, carrying the #365 `WORKLOG_SYSTEM` fix.

## Known follow-up (separate, not in this PR)
`scripts/build-mlx-runtime.sh:59` fetches python-build-standalone from `api.github.com` **unauthenticated** (60/hr/IP) — it 403'd on the first attempt, cleared on rerun. Worth authenticating with `GITHUB_TOKEN` before the one-shot prod `runtime-latest` publish, where a 403 would block the fix reaching customers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)