### PR TITLE
fix(runtime): authenticate the python-build-standalone API lookup (403 → build fails)

### DIFF
--- a/.github/workflows/build-mlx-runtime.yml
+++ b/.github/workflows/build-mlx-runtime.yml
@@ -61,7 +61,9 @@ on:
       - "runtime-staging-v*"  # staging channel → runtime-staging
 
 permissions:
-  contents: write   # publish jobs attach assets to the release
+  contents: read   # least-privilege default; only the publish jobs override to write.
+                   # gate/build/smoke run third-party code (pip backends, the built
+                   # runtime) and must not hold a release-write token.
 
 jobs:
   gate:
@@ -151,6 +153,9 @@ jobs:
     needs: [gate, smoke]
     if: needs.gate.outputs.should_publish == 'true' && needs.gate.outputs.channel == 'runtime-staging'
     runs-on: ubuntu-latest
+    # Only the publish jobs need write — they create/upload the channel release.
+    permissions:
+      contents: write
     # Serialize publishes per channel and never cancel a publish mid-upload.
     concurrency:
       group: mlx-runtime-publish-staging
@@ -179,6 +184,9 @@ jobs:
     needs: [gate, smoke]
     if: needs.gate.outputs.should_publish == 'true' && needs.gate.outputs.channel == 'runtime-latest'
     runs-on: ubuntu-latest
+    # Only the publish jobs need write — they create/upload the channel release.
+    permissions:
+      contents: write
     # The production-runtime Environment carries the required-reviewer rule — a
     # maintainer must approve before this job runs and customers get the runtime.
     environment: production-runtime

--- a/.github/workflows/build-mlx-runtime.yml
+++ b/.github/workflows/build-mlx-runtime.yml
@@ -104,6 +104,10 @@ jobs:
           # not publish, so default to runtime-latest for the build stamp.
           RUNTIME_TAG: ${{ needs.gate.outputs.channel || 'runtime-latest' }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          # Authenticates the api.github.com python-build-standalone lookup in
+          # build-mlx-runtime.sh so it doesn't hit the 60/hr unauthenticated
+          # rate limit (403 → build fails; bit the first auto-publish run).
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/build-mlx-runtime.sh
 
       - name: Upload runtime artifact

--- a/scripts/build-mlx-runtime.sh
+++ b/scripts/build-mlx-runtime.sh
@@ -56,7 +56,17 @@ rm -rf "${BUILD}" && mkdir -p "${BUILD}" "${DIST}"
 PBS_ASSET_URL="${PBS_ASSET_URL:-}"
 if [[ -z "${PBS_ASSET_URL}" ]]; then
     echo "→ resolving latest python-build-standalone ${PY_SERIES} (aarch64, install_only)"
-    PBS_JSON="$(curl -fsSL https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest)"
+    # Authenticate the api.github.com lookup when a token is available. The
+    # unauthenticated GitHub API limit is 60 req/hr/IP and CI runners share
+    # IPs, so this call intermittently 403s (curl exit 56) — it failed the very
+    # first auto-publish. A token raises the limit to 1000/hr. The header is
+    # added only when a token is present, so local runs still work
+    # unauthenticated. (The asset download below is a CDN redirect and is
+    # deliberately left unauthenticated.)
+    PBS_AUTH=()
+    PBS_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+    [[ -n "${PBS_TOKEN}" ]] && PBS_AUTH=(-H "Authorization: Bearer ${PBS_TOKEN}")
+    PBS_JSON="$(curl -fsSL ${PBS_AUTH[@]+"${PBS_AUTH[@]}"} https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest)"
     PBS_ASSET_URL="$(printf '%s' "${PBS_JSON}" | python3 -c "
 import json, re, sys
 rel = json.load(sys.stdin)


### PR DESCRIPTION
## Why
`scripts/build-mlx-runtime.sh` resolves the latest python-build-standalone release via an **unauthenticated** `api.github.com` call (60 req/hr/IP). CI runners share IPs, so it intermittently **403s** (`curl exit 56`) and the build dies before producing the tarball.

This already bit us: the **first auto-publish run** after #372 merged to `pre-main` failed at the build step on this 403 and only passed on re-run ([run 28429586316](https://github.com/Meridiona/meridian/actions/runs/28429586316)).

The real risk is **production**: `publish-production` is approval-gated (the `production-runtime` Environment). A 403 there means *approve → build 403s → re-run → approve again* on a gated, single-shot publish that delivers customer fixes.

## Fix
- `build-mlx-runtime.sh`: add a `Authorization: Bearer` header to the **api.github.com lookup only** when a token is present (`GH_TOKEN`, falling back to `GITHUB_TOKEN`), raising the limit to 1000/hr. Header is omitted when no token is set, so **local builds still work**. The asset download is a CDN redirect and is deliberately left unauthenticated.
- `build-mlx-runtime.yml`: pass `secrets.GITHUB_TOKEN` into the build step's env.

## Validation
- `bash -n` clean; `ruby -ryaml` confirms the workflow YAML is valid.
- The conditional array expansion (`${PBS_AUTH[@]+...}`) is verified safe under `set -euo pipefail` on **bash 3.2.57** — the exact version the macOS runner ships — both with and without a token:
  - no token → `args: []` (unauthenticated, no unbound-var error)
  - with token → `-H "Authorization: Bearer …"`

Clears the remaining caveat on the `pre-main → main` promotion path (with #372 + #373).

🤖 Generated with [Claude Code](https://claude.com/claude-code)