### PR TITLE
feat(integrations): let the GitHub connect flow pick Projects v2 boards

### DIFF
--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -138,6 +138,11 @@ pub struct IntegrationsResponse {
     pub github: bool,
     pub trello: bool,
     pub azure_devops: bool,
+    /// `true` once `GITHUB_PROJECT_IDS` is set — `github` alone only means the
+    /// OAuth token exists; sync additionally needs at least one selected
+    /// project (see [`discover_github_projects`]). Lets the UI tell "connected,
+    /// token only" apart from "connected and actually syncing."
+    pub github_projects_selected: bool,
     pub sync_errors: BTreeMap<String, String>,
 }
 
@@ -210,6 +215,7 @@ pub async fn get_integrations(
             && (is_set(&env, "AZURE_DEVOPS_URL")
                 || is_set(&env, "AZURE_DEVOPS_ORG")
                 || is_set(&env, "AZURE_DEVOPS_ORG_URL")),
+        github_projects_selected: is_set(&env, "GITHUB_PROJECT_IDS"),
         sync_errors,
     })
 }
@@ -591,6 +597,154 @@ pub async fn discover_azure_devops(
     })
 }
 
+/// One GitHub Projects v2 board, returned by [`discover_github_projects`].
+#[derive(Debug, Clone, Serialize)]
+pub struct GithubProjectOption {
+    /// Projects v2 node id (`PVT_xxx`) — what `GITHUB_PROJECT_IDS` stores.
+    pub id: String,
+    pub title: String,
+    /// The viewer's own login, or the owning org's login.
+    pub owner: String,
+}
+
+/// `{ projects }` — mirrors [`AzureDiscoverResponse`]'s single-populated-field
+/// shape, minus the two-step org/project split (GitHub returns everything the
+/// token can see in one GraphQL round trip).
+#[derive(Debug, Serialize)]
+pub struct GithubDiscoverResponse {
+    pub projects: Vec<GithubProjectOption>,
+}
+
+/// Flatten the GraphQL response body into a sorted, owner-tagged project list.
+/// Pure function so it's unit-testable against a hand-built fixture — mirrors
+/// the shape `viewer.projectsV2` + `viewer.organizations.nodes[].projectsV2`.
+fn flatten_github_projects(body: &serde_json::Value) -> Vec<GithubProjectOption> {
+    let viewer = body.pointer("/data/viewer");
+    let nodes_of = |v: &serde_json::Value| -> Vec<serde_json::Value> {
+        v.pointer("/projectsV2/nodes")
+            .and_then(|n| n.as_array())
+            .cloned()
+            .unwrap_or_default()
+    };
+
+    let mut projects = Vec::new();
+    if let Some(viewer) = viewer {
+        let owner = viewer
+            .get("login")
+            .and_then(|l| l.as_str())
+            .unwrap_or("you")
+            .to_string();
+        for node in nodes_of(viewer) {
+            if let (Some(id), Some(title)) = (
+                node.get("id").and_then(|v| v.as_str()),
+                node.get("title").and_then(|v| v.as_str()),
+            ) {
+                projects.push(GithubProjectOption {
+                    id: id.to_string(),
+                    title: title.to_string(),
+                    owner: owner.clone(),
+                });
+            }
+        }
+        let orgs = viewer
+            .pointer("/organizations/nodes")
+            .and_then(|n| n.as_array())
+            .cloned()
+            .unwrap_or_default();
+        for org in orgs {
+            let owner = org
+                .get("login")
+                .and_then(|l| l.as_str())
+                .unwrap_or("org")
+                .to_string();
+            for node in nodes_of(&org) {
+                if let (Some(id), Some(title)) = (
+                    node.get("id").and_then(|v| v.as_str()),
+                    node.get("title").and_then(|v| v.as_str()),
+                ) {
+                    projects.push(GithubProjectOption {
+                        id: id.to_string(),
+                        title: title.to_string(),
+                        owner: owner.clone(),
+                    });
+                }
+            }
+        }
+    }
+    projects.sort_unstable_by(|a, b| {
+        (a.owner.as_str(), a.title.as_str()).cmp(&(b.owner.as_str(), b.title.as_str()))
+    });
+    projects
+}
+
+/// List the GitHub Projects v2 boards the connected account can see (the
+/// browser-OAuth-connect follow-up: `discover_azure_devops`'s PAT→org→project
+/// discovery, but GitHub returns everything in one GraphQL call). Reads
+/// `GITHUB_TOKEN` from the resolved `.env` — no args, since discovery only
+/// makes sense once [`start_oauth`]/[`save_integration_token`] already wrote a
+/// token there (unlike Azure DevOps, whose PAT is pasted in *before* it's saved).
+///
+/// # Who calls this
+/// `ui/components/IntegrationConnect.tsx`'s `GitHubProjectPicker`, both right
+/// after a GitHub OAuth connect succeeds and from the "connected but no
+/// projects selected" prompt in `ConnectedPanel`.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn discover_github_projects() -> Result<GithubDiscoverResponse, String> {
+    let mode = crate::install::detect_install_mode();
+    let env = mode.env_path().map(parse_env).unwrap_or_default();
+    let token = env
+        .get("GITHUB_TOKEN")
+        .filter(|t| !t.trim().is_empty())
+        .ok_or("GitHub is not connected yet")?;
+
+    const QUERY: &str = r#"{ viewer { login
+        projectsV2(first: 50) { nodes { id title } }
+        organizations(first: 25) { nodes { login projectsV2(first: 50) { nodes { id title } } } }
+    } }"#;
+
+    let resp = reqwest::Client::new()
+        .post("https://api.github.com/graphql")
+        .bearer_auth(token)
+        .header(reqwest::header::USER_AGENT, "meridian-tray")
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .json(&serde_json::json!({ "query": QUERY }))
+        .timeout(Duration::from_secs(15))
+        .send()
+        .instrument(tracing::debug_span!("integrations.github.projects"))
+        .await
+        .map_err(|e| format!("Could not reach GitHub: {e}"))?;
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(
+            "GitHub token invalid or missing the read:project scope — reconnect GitHub".to_string(),
+        );
+    }
+    if !status.is_success() {
+        return Err(format!("GitHub returned HTTP {status}"));
+    }
+
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("Could not parse GitHub response: {e}"))?;
+
+    if let Some(errors) = body.get("errors").and_then(|e| e.as_array()) {
+        if let Some(first) = errors
+            .first()
+            .and_then(|e| e.get("message"))
+            .and_then(|m| m.as_str())
+        {
+            return Err(format!("GitHub API error: {first}"));
+        }
+    }
+
+    let projects = flatten_github_projects(&body);
+    tracing::info!(count = projects.len(), "github projects discovered");
+    Ok(GithubDiscoverResponse { projects })
+}
+
 /// POST body for [`start_oauth`] (`{ provider }`).
 #[derive(Debug, Deserialize)]
 pub struct StartOAuthBody {
@@ -906,6 +1060,42 @@ mod tests {
             "value": [{ "name": "Zebra" }, { "name": "Apple" }, { "other": "skip" }]
         });
         assert_eq!(sorted_names(&body, "name"), vec!["Apple", "Zebra"]);
+    }
+
+    #[test]
+    fn flatten_github_projects_merges_viewer_and_org_boards_sorted() {
+        let body = serde_json::json!({
+            "data": {
+                "viewer": {
+                    "login": "akarsh",
+                    "projectsV2": { "nodes": [{ "id": "PVT_1", "title": "Zebra board" }] },
+                    "organizations": { "nodes": [
+                        {
+                            "login": "meridiona",
+                            "projectsV2": { "nodes": [
+                                { "id": "PVT_2", "title": "Roadmap" },
+                                { "id": "PVT_3", "title": "Apple board" },
+                            ] },
+                        },
+                    ] },
+                },
+            },
+        });
+        let projects = flatten_github_projects(&body);
+        assert_eq!(projects.len(), 3);
+        // Sorted by (owner, title): akarsh's board first, then meridiona's two
+        // alphabetically.
+        assert_eq!(projects[0].id, "PVT_1");
+        assert_eq!(projects[0].owner, "akarsh");
+        assert_eq!(projects[1].id, "PVT_3");
+        assert_eq!(projects[1].title, "Apple board");
+        assert_eq!(projects[2].id, "PVT_2");
+    }
+
+    #[test]
+    fn flatten_github_projects_empty_on_missing_viewer() {
+        let body = serde_json::json!({ "errors": [{ "message": "bad credentials" }] });
+        assert!(flatten_github_projects(&body).is_empty());
     }
 
     fn tmp_env(name: &str) -> std::path::PathBuf {

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -487,6 +487,7 @@ pub fn run() {
             // tracker connect/disconnect (ported /api/integrations + /api/auth/oauth)
             commands::disconnect_integration,
             commands::discover_azure_devops,
+            commands::discover_github_projects,
             commands::save_integration_token,
             commands::start_oauth,
             commands::get_oauth_status,

--- a/ui/__tests__/tasks-provider-filter.test.ts
+++ b/ui/__tests__/tasks-provider-filter.test.ts
@@ -8,6 +8,7 @@ const task = (provider: string, today_s = 0) => ({ provider, today_s })
 
 const ALL_DISCONNECTED: IntegrationsResponse = {
   jira: false, linear: false, github: false, trello: false, azure_devops: false,
+  github_projects_selected: false,
   sync_errors: {},
 }
 
@@ -24,6 +25,7 @@ const JIRA_AND_LINEAR: IntegrationsResponse = {
 
 const ALL_CONNECTED: IntegrationsResponse = {
   jira: true, linear: true, github: true, trello: true, azure_devops: true,
+  github_projects_selected: true,
   sync_errors: {},
 }
 

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -92,7 +92,8 @@ export default function ConnectTrackers({
               </button>
               {isOpen && connected && (
                 <ConnectedPanel tracker={t} syncError={syncError} disconnecting={disconnecting === t.id}
-                  onDisconnect={() => handleDisconnect(t.id)} onChanged={onChanged} />
+                  onDisconnect={() => handleDisconnect(t.id)} onChanged={onChanged}
+                  githubProjectsSelected={integrations?.github_projects_selected} />
               )}
               {isOpen && !connected && <TrackerSetup tracker={t} onSuccess={onChanged} />}
             </div>
@@ -105,16 +106,24 @@ export default function ConnectTrackers({
 
 // ── Connected (manage / disconnect / re-authorize) ───────────────────────────
 function ConnectedPanel({
-  tracker, syncError, disconnecting, onDisconnect, onChanged,
+  tracker, syncError, disconnecting, onDisconnect, onChanged, githubProjectsSelected,
 }: {
   tracker: Tracker; syncError?: string; disconnecting: boolean; onDisconnect: () => void; onChanged?: () => void
+  /** Only meaningful for tracker.id === 'github' — undefined for every other tracker. */
+  githubProjectsSelected?: boolean
 }) {
   const [reauthorizing, setReauthorizing] = useState(false)
+  const [pickingProjects, setPickingProjects] = useState(false)
   const cleanError = syncError ? syncError.replace(/^permission_error: |^sync_error: /, '') : null
+  // GitHub's token alone doesn't sync anything — a Projects v2 board must be
+  // selected too (discover_github_projects → save_integration_token). This is
+  // exactly the gap a token connected outside the OAuth-connect picker (or an
+  // account connected before this picker existed) is stuck in.
+  const needsGithubProjects = tracker.id === 'github' && githubProjectsSelected === false
 
   return (
     <div className="px-4 pb-4 pt-2" style={{ background: 'var(--t-box)' }}>
-      {cleanError && !reauthorizing && (
+      {cleanError && !reauthorizing && !pickingProjects && (
         <div className="mb-3 rounded-md px-3 py-2" style={{ background: '#fef3c7', border: '1px solid #fcd34d' }}>
           <p className="text-[12px] leading-relaxed" style={{ color: '#92400e' }}>
             <strong>Sync failed:</strong> {cleanError}
@@ -125,7 +134,23 @@ function ConnectedPanel({
           </button>
         </div>
       )}
-      {reauthorizing ? (
+      {needsGithubProjects && !reauthorizing && !pickingProjects && (
+        <div className="mb-3 rounded-md px-3 py-2" style={{ background: '#eff6ff', border: '1px solid #bfdbfe' }}>
+          <p className="text-[12px] leading-relaxed" style={{ color: '#1e40af' }}>
+            No GitHub Projects selected — tasks won&apos;t sync yet.
+          </p>
+          <button onClick={() => setPickingProjects(true)} className="mt-2 text-[11px] px-3 py-1 rounded-md"
+            style={{ background: '#1e40af', color: '#fff', cursor: 'pointer' }}>
+            Select Projects
+          </button>
+        </div>
+      )}
+      {pickingProjects ? (
+        <div className="mb-1">
+          <GitHubProjectPicker onSuccess={() => { setPickingProjects(false); onChanged?.() }} />
+          <button onClick={() => setPickingProjects(false)} className="mt-2 text-[11px]" style={{ color: 'var(--ink-4)', cursor: 'pointer' }}>Cancel</button>
+        </div>
+      ) : reauthorizing ? (
         <div className="mb-1">
           <p className="text-[12px] mb-2" style={{ color: 'var(--t-muted)' }}>Reconnect {tracker.name}:</p>
           <TrackerSetup tracker={tracker} onSuccess={() => { setReauthorizing(false); onChanged?.() }} />
@@ -247,7 +272,12 @@ function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
         if (stopped || !data) return
         if (data[tracker.id]) {
           stopped = true; clearInterval(id); pollRef.current = null
-          setStatus('done'); clearProviderNotice(tracker.id); onSuccess?.()
+          setStatus('done'); clearProviderNotice(tracker.id)
+          // GitHub needs a Projects v2 board picked before sync does anything —
+          // the picker (rendered below for status==='done') calls onSuccess
+          // itself once a project is actually saved. Every other provider is
+          // done syncing-wise the moment the token/OAuth store exists.
+          if (tracker.id !== 'github') onSuccess?.()
         }
       }, 2_000)
       pollRef.current = id
@@ -302,7 +332,11 @@ function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
           <p className="text-[11px]" style={{ color: 'var(--t-faint-2)' }}>Waiting for authorization…</p>
         </div>
       )}
-      {status === 'done' && <p className="text-[12px]" style={{ color: 'var(--color-state-approved)' }}>✓ Connected! Your tasks will appear shortly.</p>}
+      {status === 'done' && (
+        tracker.id === 'github'
+          ? <GitHubProjectPicker onSuccess={onSuccess} />
+          : <p className="text-[12px]" style={{ color: 'var(--color-state-approved)' }}>✓ Connected! Your tasks will appear shortly.</p>
+      )}
       {status === 'error' && (
         <div className="space-y-2">
           <p className="text-[12px]" style={{ color: '#e53e3e' }}>{error ?? 'OAuth failed.'}</p>
@@ -541,6 +575,97 @@ function AzureDevOpsSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?
           {loading === 'saving' ? 'Connecting…' : 'Connect Azure DevOps'}
         </button>
       )}
+    </div>
+  )
+}
+
+// ── GitHub Projects v2 picker (discover_github_projects → save_integration_token) ──
+// Runs right after a GitHub OAuth connect succeeds (see OAuthSetup's status==='done'
+// branch) AND from ConnectedPanel's "no projects selected" prompt — same component,
+// two entry points, since the underlying gap (token connected, no board chosen) is
+// identical either way.
+type GithubProject = { id: string; title: string; owner: string }
+
+function GitHubProjectPicker({ onSuccess }: { onSuccess?: () => void }) {
+  const [projects, setProjects] = useState<GithubProject[] | null>(null)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    load<{ projects?: GithubProject[] }>('/api/integrations/github/discover', 'discover_github_projects')
+      .then((json) => { if (!cancelled) setProjects(json.projects ?? []) })
+      .catch((e) => { if (!cancelled) setError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Failed to load GitHub Projects') })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [])
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id); else next.add(id)
+      return next
+    })
+  }
+
+  const save = async () => {
+    if (selected.size === 0 || saving) return
+    setSaving(true); setError(null)
+    try {
+      await mutate('/api/auth/token', 'save_integration_token', {
+        provider: 'github', fields: { project_ids: Array.from(selected).join(',') },
+      })
+      clearProviderNotice('github'); onSuccess?.()
+    } catch (e) {
+      setError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Could not save project selection')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) return <p className="text-[11px]" style={{ color: 'var(--ink-3)' }}>Loading your GitHub Projects…</p>
+
+  if (error) return <p className="text-[12px]" style={{ color: '#e53e3e' }}>{error}</p>
+
+  if (!projects || projects.length === 0) {
+    return (
+      <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-3)' }}>
+        No GitHub Projects v2 boards found on this account.{' '}
+        <a href="https://github.com/users/me/projects" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)' }}>Create one ↗</a>
+      </p>
+    )
+  }
+
+  const byOwner = projects.reduce<Record<string, GithubProject[]>>((acc, p) => {
+    (acc[p.owner] ??= []).push(p)
+    return acc
+  }, {})
+
+  return (
+    <div className="space-y-3">
+      <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-2)' }}>
+        Pick which GitHub Projects v2 boards to sync tasks from.
+      </p>
+      <div className="space-y-2 max-h-48 overflow-y-auto">
+        {Object.entries(byOwner).map(([owner, ps]) => (
+          <div key={owner}>
+            <span className="text-[10px] uppercase tracking-wide" style={{ color: 'var(--ink-4)' }}>{owner}</span>
+            {ps.map((p) => (
+              <label key={p.id} className="flex items-center gap-2 py-1 text-[12px]" style={{ color: 'var(--ink)' }}>
+                <input type="checkbox" checked={selected.has(p.id)} onChange={() => toggle(p.id)} />
+                {p.title}
+              </label>
+            ))}
+          </div>
+        ))}
+      </div>
+      {error && <p className="text-[11px]" style={{ color: '#e53e3e' }}>{error}</p>}
+      <button onClick={save} disabled={selected.size === 0 || saving} className="text-[12px] px-4 py-2 rounded-md font-medium transition-opacity"
+        style={{ background: 'var(--accent)', color: '#fff', opacity: (selected.size === 0 || saving) ? 0.5 : 1, cursor: (selected.size === 0 || saving) ? 'not-allowed' : 'pointer' }}>
+        {saving ? 'Saving…' : selected.size === 0 ? 'Select a project' : `Sync ${selected.size} project${selected.size === 1 ? '' : 's'}`}
+      </button>
     </div>
   )
 }

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -241,6 +241,9 @@ export interface IntegrationsResponse {
   github: boolean
   trello: boolean
   azure_devops: boolean
+  // true once GITHUB_PROJECT_IDS is set — github alone only means the OAuth
+  // token exists; sync additionally needs at least one selected project.
+  github_projects_selected: boolean
   sync_errors: Partial<Record<string, string>>
 }
 


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` already connects via a real browser OAuth flow (`gh auth login --web`), but task sync additionally needs `GITHUB_PROJECT_IDS` — until now the only way to set it was running `gh api graphql` in a terminal and pasting the id into `.env` by hand.
- Adds `discover_github_projects` (mirrors `discover_azure_devops`'s PAT→org→project discovery, but GitHub returns viewer + org-owned Projects v2 boards in one GraphQL call) and a checkbox picker in the Settings UI.
- The picker appears right after a GitHub OAuth connect succeeds, and also as a "no projects selected" prompt on accounts that were already connected before this existed (confirmed live: dev daemon logs showed `no GITHUB_PROJECT_IDS configured — skipping github sync` on every tick despite a valid token).
- `IntegrationsResponse` gains `github_projects_selected: bool` so the UI can tell "token connected" apart from "actually syncing."

## Test plan
- [x] `cargo test` in `tray/src-tauri` — 40/40 pass, including 2 new `flatten_github_projects` unit tests
- [x] `cargo clippy -- -D warnings` / `cargo fmt --check` clean
- [x] `bun test` in `ui/` — 166/166 pass (updated `tasks-provider-filter.test.ts` fixtures for the new response field)
- [x] `npx tsc --noEmit` — no new type errors
- [x] `npm run build` in `ui/` — static export builds clean
- [x] Verified the exact GraphQL query against a real token/account — correctly surfaced both a personal board and an org-owned board (`Meridiona/Meridian project`), confirming discovery (not a hardcoded id) is the right approach
- [ ] Manual click-through of the picker UI (not yet done — this branch isn't wired into the currently-running dev instance, which is on a different worktree/branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UXWzYWkMk9rKnUEJupWWd