### PR TITLE
fix(ui): move Tasks entry row to right after Today's focus

### DIFF
--- a/ui/components/timeline/OverviewPanel.tsx
+++ b/ui/components/timeline/OverviewPanel.tsx
@@ -180,6 +180,8 @@ export function OverviewPanel({ data, onOpen, onOpenTask }: {
         </div>
       )}
 
+      <EntryRow label="Tasks" hint={`${activeTaskCount} active`} onClick={() => onOpen('tasks')} />
+
       <div>
         <p className="mt-label mb-2.5" style={{ color: 'var(--t-faint)' }}>Today</p>
         <div className="grid grid-cols-3 gap-3">
@@ -198,8 +200,6 @@ export function OverviewPanel({ data, onOpen, onOpenTask }: {
         </div>
         <TimeByApp sessions={today?.sessions ?? []} />
       </div>
-
-      <EntryRow label="Tasks" hint={`${activeTaskCount} active`} onClick={() => onOpen('tasks')} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Reorders the right-side overview pane: the "Tasks" entry row now sits directly after "Today's focus", instead of trailing after the Today stats / Time-by-app card.

## Test plan
- [x] `tsc --noEmit` clean on `OverviewPanel.tsx`
- [x] pre-push checks (fmt, clippy, ui build/tests, cargo test, security audit) all passed
- [ ] Visual check in the dashboard: right pane order is now Today's focus → Tasks → Today stats → Time by app