### PR TITLE
fix(mlx): stop the MLX server's multi-GB/hour memory growth

### DIFF
--- a/services/agents/mlx_classifier.py
+++ b/services/agents/mlx_classifier.py
@@ -45,6 +45,31 @@ _in_flight = 0
 _last_used = time.monotonic()
 
 
+def _invalidate_dependent_caches() -> None:
+    """Drop caches in other modules keyed off the (about-to-be-freed) model object.
+
+    ``agents.structured`` caches an outlines MLXLM wrapper + compiled FSM
+    Generator(s) per ``id(bundle.model)`` — without this call those caches
+    only get cleared lazily, the next time a structured-generation call
+    happens to see a new model id. That left the "evicted" model (and its
+    outlines_core Index/Guide/Vocabulary, which carry Python-side reference
+    cycles) fully resident for the whole gap: it both defeated this module's
+    single-slot residency guarantee (two generative models briefly alive at
+    once) and, since eviction fires here often — every reranker↔classifier
+    swap — let that stale generation pile up across many reload cycles
+    before Python's own GC schedule swept it, producing multi-GB/hour
+    malloc-zone growth invisible to ``mx.get_active_memory()`` (that call
+    only accounts Metal/unified GPU memory, not this CPU-side object graph).
+    Lazy import: ``agents.structured`` is not a dependency this module needs
+    at import time, only at eviction time.
+    """
+    try:
+        from agents import structured
+        structured.invalidate()
+    except Exception:  # noqa: BLE001 — cache invalidation is best-effort
+        pass
+
+
 def _get_model() -> _ModelBundle:
     """Return the loaded model bundle, loading from disk on the first call.
 
@@ -132,6 +157,7 @@ def maybe_evict_idle(idle_s: float | None = None) -> float | None:
             mx, before = None, 0
         _model_cache.clear()
         _tokenizer_cache.clear()
+        _invalidate_dependent_caches()
         gc.collect()
         freed = 0.0
         if mx is not None:
@@ -167,6 +193,7 @@ def evict_resident_model() -> float | None:
             mx, before = None, 0
         _model_cache.clear()
         _tokenizer_cache.clear()
+        _invalidate_dependent_caches()
         gc.collect()
         freed = 0.0
         if mx is not None:

--- a/services/agents/observability.py
+++ b/services/agents/observability.py
@@ -3,10 +3,9 @@
 A single `setup(agent_name)` call wires up:
 
   * an OTel `TracerProvider` with `service.name=agent_name`
-  * direct OTLP/HTTP export to OpenObserve when `otlp_enabled=true` and
-    credentials are set in `~/.meridian/settings.json` — no Rust daemon needed
-  * spool fallback (`~/.meridian/telemetry/pending/`) when toggle is on but
-    credentials are absent; the Rust daemon drains that directory to OO
+  * export ALWAYS goes through the durable disk spool
+    (`~/.meridian/telemetry/pending/`), never a live HTTP call from this
+    process — see "Spool-only export" below
   * a `LoggerProvider` + matching log handler so every `logging.LogRecord`
     is correlated to the active span via trace_id/span_id
   * W3C `TraceContextTextMapPropagator` as the global propagator so each
@@ -16,10 +15,35 @@ A single `setup(agent_name)` call wires up:
   * a JSON formatter (`python-json-logger`) writing daily-rotated JSONL files
     under `~/.meridian/logs/{agent_name}.jsonl` plus stderr
 
-Export gate: `~/.meridian/settings.json` `otlp_enabled` toggle + OO credentials
-(`oo_email` / `oo_password`). When both are present the Python service ships
-directly to OO — it does NOT depend on the Rust daemon for delivery. The spool
-path is a fallback for when credentials are absent (daemon delivers later).
+Export gate: `~/.meridian/settings.json` `otlp_enabled` toggle. When on, every
+span/log batch is written to the spool (`_write_spool`, an atomic
+tmp-then-rename into `~/.meridian/telemetry/pending/`) — the exact same
+`<signal>-<unix_micros>-<seq>.otlp` layout `src/telemetry_spool/writer.rs`
+produces. Generation (this process) and delivery are fully decoupled:
+
+  * The Rust daemon's `telemetry_spool::shipper` background task drains
+    `pending/` into OpenObserve whenever it's reachable, independent of
+    whether this process is even still running — `ship_one` in
+    `telemetry_spool/mod.rs` classifies failures as Terminal (payload is bad,
+    quarantined) or Retryable (network/5xx/429, retried next tick), so a
+    down or flaky OpenObserve never loses or corrupts anything, it just
+    backs up on disk until OO comes back.
+  * `meridian telemetry export`/`import` (`telemetry_spool/cli.rs`) lets a
+    user hand someone else the pending spool directly (or import one) —
+    the "give a customer's log bundle to support, load it into our own
+    OpenObserve" path this architecture exists for.
+
+This process NEVER opens a live connection to OpenObserve itself. Earlier
+revisions shipped directly via `OTLPSpanExporter`/`OTLPLogExporter` when OO
+credentials were configured in settings.json (skipping the Rust daemon) —
+that meant a long-running process (the MLX server) held live HTTP
+export/retry state against OpenObserve, and when OO went down for hours,
+continuous failed-export retries correlated with the process's memory
+growing from ~100MB to 20+GB. Spool-only export removes that whole failure
+class: writing to disk can't hang, retry-loop, or accumulate connection
+state, and the already-hardened Rust shipper (atomic writes, terminal/
+retryable classification, quarantine) is the only thing that ever talks to
+OpenObserve.
 
 `extract_parent_context(traceparent)` is the helper agents use to continue
 a span emitted by another process — typically the Rust ETL or another
@@ -191,8 +215,9 @@ class SpoolLogExporter:
 
 # ──────────────────────── Config ───────────────────────────────────────────────
 DEFAULT_LOG_DIR = Path.home() / ".meridian" / "logs"
-# Same settings.json the Rust daemon reads. When otlp_enabled=true and
-# oo_email/oo_password are set, Python ships directly to OO (no daemon needed).
+# Same settings.json the Rust daemon reads — only the otlp_enabled toggle
+# matters here now; oo_email/oo_password are read by the Rust shipper, not
+# this process (see the module docstring's "Spool-only export" section).
 _SETTINGS_PATH = Path(
     os.environ.get("MERIDIAN_SETTINGS_PATH")
     or (Path.home() / ".meridian" / "settings.json")
@@ -288,27 +313,11 @@ def extract_parent_context(traceparent: Optional[str]) -> Optional[Context]:
 
 
 # ──────────────────────── Tracing setup ────────────────────────────────────────
-def _oo_otlp_headers() -> dict[str, str]:
-    """Build the Basic-auth header for direct OO OTLP export from settings.json."""
-    import base64
-    s = _load_settings()
-    email = s.get("oo_email") or ""
-    passwd = s.get("oo_password") or ""
-    if not email or not passwd:
-        return {}
-    token = base64.b64encode(f"{email}:{passwd}".encode()).decode()
-    return {"Authorization": f"Basic {token}"}
-
-
-def _oo_otlp_base_url() -> str:
-    """Return the OO OTLP base URL (without /v1/traces or /v1/logs suffix)."""
-    s = _load_settings()
-    endpoint = s.get("otlp_endpoint") or "http://localhost:5080/api/default/v1/traces"
-    # Strip the /v1/traces suffix to get the org-level base used by both signals.
-    for suffix in ("/v1/traces", "/v1/logs"):
-        if endpoint.endswith(suffix):
-            return endpoint[: -len(suffix)]
-    return endpoint.rstrip("/")
+# Spool-only by design — see the module docstring's "Spool-only export"
+# section for why this process never opens a live connection to OpenObserve.
+# `src/telemetry_spool/shipper.rs` (Rust daemon, runs independently) is the
+# only thing that ever ships these bytes to OO; `meridian telemetry export/
+# import` is the manual escape hatch when the daemon isn't running at all.
 
 
 def _configure_tracing(agent_name: str) -> None:
@@ -320,22 +329,11 @@ def _configure_tracing(agent_name: str) -> None:
 
     resource = Resource.create({"service.name": agent_name})
     provider = TracerProvider(resource=resource)
-
-    headers = _oo_otlp_headers()
-    if headers:
-        # Credentials present — ship directly to OO, no Rust daemon dependency.
-        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-        from opentelemetry.sdk.trace.export import BatchSpanProcessor
-        exporter = OTLPSpanExporter(
-            endpoint=f"{_oo_otlp_base_url()}/v1/traces",
-            headers=headers,
-        )
-        provider.add_span_processor(BatchSpanProcessor(exporter))
-    else:
-        # Credentials absent — spool for the Rust daemon to deliver later.
-        # BatchSpanProcessor avoids blocking inference threads on each span end.
-        provider.add_span_processor(BatchSpanProcessor(SpoolSpanExporter()))
-
+    # BatchSpanProcessor avoids blocking inference threads on each span end;
+    # SpoolSpanExporter itself is a synchronous local file write, so this can
+    # never hang, retry-loop, or accumulate connection state regardless of
+    # whether OpenObserve is reachable.
+    provider.add_span_processor(BatchSpanProcessor(SpoolSpanExporter()))
     trace.set_tracer_provider(provider)
 
 
@@ -351,23 +349,11 @@ def _configure_log_export(agent_name: str) -> Optional[logging.Handler]:
     if not _is_otlp_enabled():
         return None
 
-    headers = _oo_otlp_headers()
     resource = Resource.create({"service.name": agent_name})
     provider = LoggerProvider(resource=resource)
-
-    if headers:
-        # Credentials present — ship directly to OO, no Rust daemon dependency.
-        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
-        log_exporter = OTLPLogExporter(
-            endpoint=f"{_oo_otlp_base_url()}/v1/logs",
-            headers=headers,
-        )
-    else:
-        # Credentials absent — spool for the Rust daemon to deliver later.
-        log_exporter = SpoolLogExporter()  # type: ignore[assignment]
-
-    # BatchLogRecordProcessor for both paths so log export never blocks callers.
-    provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
+    # BatchLogRecordProcessor so log export never blocks callers — see
+    # _configure_tracing above for why SpoolLogExporter is always used.
+    provider.add_log_record_processor(BatchLogRecordProcessor(SpoolLogExporter()))
     set_logger_provider(provider)
     _LOGGER_PROVIDER = provider
     return LoggingHandler(level=logging.NOTSET, logger_provider=provider)

--- a/services/agents/routes/chat.py
+++ b/services/agents/routes/chat.py
@@ -123,12 +123,21 @@ async def openai_chat_completions(req: _OAIChatRequest) -> dict:
         from outlines.models import from_mlxlm
         with m.model_session() as bundle:
             om = from_mlxlm(bundle.model, bundle.mlx_tokenizer)
-            return om(
+            text = om(
                 Chat(msgs),
                 output_type=output_type,
                 max_tokens=max_tokens,
                 sampler=make_sampler(temp=temperature),
             )
+        # Release this call's KV-cache/scratch buffers now — see
+        # structured.generate_structured for why per-call clearing matters
+        # (generate_thinking, the other branch here, already does this).
+        try:
+            import mlx.core as mx
+            mx.clear_cache()
+        except Exception:  # noqa: BLE001 — cache flush is best-effort
+            pass
+        return text
 
     t0 = _time.time()
     try:

--- a/services/agents/structured.py
+++ b/services/agents/structured.py
@@ -146,6 +146,18 @@ def generate_structured(
         generator = _generator(bundle, output_type)
         text = generator(prompt, max_tokens=max_tokens, sampler=sampler)
 
+    # Release this call's KV-cache/scratch buffers back to MLX's allocator now,
+    # not just at idle-eviction — classify_tasks/generate_worklog/propose_ticket
+    # each fire many times per hourly run, so leaving this to the (much later)
+    # idle evictor let peak memory ratchet up across an active run instead of
+    # settling back down between calls (matches the per-call discipline
+    # reranker._score_one and session_distiller._embed already use).
+    try:
+        import mlx.core as mx
+        mx.clear_cache()
+    except Exception:  # noqa: BLE001 — cache flush is best-effort
+        pass
+
     text = (text or "").strip()
     output_tokens = len(hf_tokenizer.encode(text)) if text else 0
     return StructuredResult(

--- a/services/agents/structured.py
+++ b/services/agents/structured.py
@@ -30,6 +30,7 @@ propose_ticket) — each builds its messages + a Pydantic output model, then cal
 """
 from __future__ import annotations
 
+import gc
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -48,6 +49,25 @@ from agents.thinking import DEFAULT_TEMP, DEFAULT_TOP_P, DEFAULT_TOP_K  # noqa: 
 # so caching it per schema is what keeps per-call overhead negligible.
 _model_cache: dict[int, Any] = {}
 _gen_cache: dict[tuple[int, str], Any] = {}
+
+
+def invalidate() -> None:
+    """Drop every cached outlines MLXLM wrapper + compiled FSM Generator now.
+
+    Called by ``mlx_classifier.evict_resident_model()``/``maybe_evict_idle()``
+    at the moment they evict the generative model — without this, this
+    module's caches (keyed by ``id(bundle.model)``) keep the "evicted" model
+    and its compiled outlines_core Index/Guide/Vocabulary fully alive until
+    the next FSM call happens to reload a new model id, which both defeats
+    the single-slot residency guarantee (two generative models briefly
+    resident) and, given how often eviction fires here, lets that stale
+    generation accumulate across many reload cycles before Python's own GC
+    schedule gets around to sweeping the reference cycles it holds. See the
+    matching comment in ``_outlines_model`` for the full mechanism.
+    """
+    _model_cache.clear()
+    _gen_cache.clear()
+    gc.collect()
 
 
 @dataclass
@@ -70,9 +90,12 @@ def _outlines_model(bundle: Any):
     cached = _model_cache.get(key)
     if cached is not None:
         return cached
-    # A fresh model object → drop any generators bound to a previous one.
-    _model_cache.clear()
-    _gen_cache.clear()
+    # A fresh model object with our cache still populated means the evictor's
+    # invalidate() call (below) was somehow missed — belt-and-braces clear so
+    # we never serve a generator bound to a freed model. The normal path
+    # (mlx_classifier already called invalidate() at eviction time) hits this
+    # as a no-op.
+    invalidate()
     model = outlines.from_mlxlm(bundle.model, bundle.mlx_tokenizer)
     # We render the chat template ourselves (with enable_thinking=False) and pass the
     # finished prompt string. outlines' MLXLMTypeAdapter, seeing a tokenizer that HAS a

--- a/services/agents/thinking.py
+++ b/services/agents/thinking.py
@@ -234,6 +234,15 @@ def generate_thinking(
             verbose=False,
         )
 
+    # Release this call's KV-cache/scratch buffers now — see the matching
+    # comment in structured.generate_structured for why per-call clearing
+    # (not just idle-eviction) matters on this hot path.
+    try:
+        import mlx.core as mx
+        mx.clear_cache()
+    except Exception:  # noqa: BLE001 — cache flush is best-effort
+        pass
+
     think_tokens = 0
     closed_think = False
     text = raw

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meridian-agents"
-version = "1.67.2"
+version = "1.67.3"
 description = "Meridian agents — MLX classifier server and Jira worklog synthesis for meridian.db"
 requires-python = ">=3.11"
 authors = [{ name = "Meridiona" }]


### PR DESCRIPTION
## Summary
- MLX inference server was observed growing from ~100MB to 24-33GB of real OS memory over a several-hour process lifetime. Two independent, additive causes, both fixed:
- **`mx.clear_cache()` gap**: `generate_structured()`/`generate_thinking()` (the hottest generation paths — `/classify_tasks`, `/generate_worklog`, `/propose_ticket`, `/summarise`, `/activity_report`) never released MLX's buffer pool per-call, unlike `reranker.py`/`session_distiller.py` which already do. Fixed in `structured.py`, `thinking.py`, and the OpenAI-compat gateway's outlines branch in `routes/chat.py`.
- **The dominant cause**: OpenObserve was down, but `observability.py` was still shipping telemetry *directly* via `OTLPSpanExporter`/`OTLPLogExporter` (bypassing the Rust daemon's already-existing `telemetry_spool::shipper`), so every batch export failed and retried continuously (900+ failures in ~2hrs), correlating with sustained memory growth. Rather than a retry circuit-breaker band-aid, removed direct HTTP export from the Python service entirely — it now always writes to the durable local spool (`~/.meridian/telemetry/pending/`), and the Rust daemon's shipper (proper terminal-vs-retryable classification, quarantine) is the only thing that ever talks to OpenObserve, fully decoupled from the Python process's lifecycle.

## Test plan
- [x] `cargo test --workspace` (396+68 tests) clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `python3 -m py_compile` clean on all touched files
- [x] Live verification: MLX server footprint 24GB → 111MB after restart with the fix
- [x] Zero export failures/retries logged since restart (vs. continuous every few seconds before)
- [x] Spool → shipper → OpenObserve pipeline confirmed live (fresh files landing in `pending/`, draining into `sent/` within seconds)