### PR TITLE
fix(ui): open external links via opener plugin in Tauri webview

### DIFF
--- a/ui/__tests__/external-links.test.ts
+++ b/ui/__tests__/external-links.test.ts
@@ -1,7 +1,7 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 import { describe, it, expect } from 'bun:test'
 import { readFileSync, readdirSync, statSync } from 'fs'
-import { isExternalHttp } from '../lib/bridge'
+import { isExternalHttp, opensExternally, openExternal } from '../lib/bridge'
 
 // Regression guard for "external links do nothing inside the app".
 //
@@ -50,6 +50,25 @@ describe('isExternalHttp', () => {
   })
 })
 
+// ── opensExternally — adds mailto:/tel: on top of external http(s) ───────────
+
+describe('opensExternally', () => {
+  const origin = 'http://localhost:3939'
+
+  it('accepts mailto: and tel: (WKWebView drops them like target=_blank)', () => {
+    expect(opensExternally('mailto:hey@meridiona.com?subject=Bug', origin)).toBe(true)
+    expect(opensExternally('tel:+1555000', origin)).toBe(true)
+    expect(opensExternally('MAILTO:hey@meridiona.com', origin)).toBe(true)
+  })
+
+  it('delegates http(s) decisions to isExternalHttp', () => {
+    expect(opensExternally('https://trello.com/app-key', origin)).toBe(true)
+    expect(opensExternally('http://localhost:3939/today', origin)).toBe(false)
+    expect(opensExternally('/today', origin)).toBe(false)
+    expect(opensExternally('x-apple.systempreferences:com.apple.x', origin)).toBe(false)
+  })
+})
+
 // ── openExternal routes through the opener plugin ─────────────────────────────
 
 describe('lib/bridge.ts openExternal', () => {
@@ -62,6 +81,28 @@ describe('lib/bridge.ts openExternal', () => {
   it('falls back to window.open in a plain browser', () => {
     expect(src).toMatch(/openExternal[\s\S]*?window\.open\(url/)
   })
+
+  it('falls back to window.open when the plugin invoke rejects', async () => {
+    // A rejection that only logs would reproduce the silent dead-link bug this
+    // helper fixes, so the .catch() must open the URL anyway. bridge reads
+    // `window` at call time, so a stub installed here is picked up.
+    const opened: string[] = []
+    const g = globalThis as { window?: unknown }
+    g.window = {
+      __TAURI__: { core: { invoke: () => Promise.reject(new Error('forbidden url')) } },
+      open: (url: string) => { opened.push(url); return null },
+    }
+    const warn = console.warn
+    console.warn = () => {}
+    try {
+      openExternal('https://example.com/x')
+      await new Promise((r) => setTimeout(r, 0))
+      expect(opened).toEqual(['https://example.com/x'])
+    } finally {
+      console.warn = warn
+      delete g.window
+    }
+  })
 })
 
 // ── The interceptor exists and is mounted globally ────────────────────────────
@@ -71,7 +112,7 @@ describe('ExternalLinks interceptor', () => {
 
   it('listens for document clicks and routes external anchors via openExternal', () => {
     expect(src).toContain("document.addEventListener('click'")
-    expect(src).toContain('isExternalHttp(href, window.location.origin)')
+    expect(src).toContain('opensExternally(href, window.location.origin)')
     expect(src).toContain('e.preventDefault()')
     expect(src).toContain('openExternal(href)')
   })
@@ -99,7 +140,8 @@ describe('no raw window.open in components', () => {
   }
 
   it('every external open goes through openExternal (WKWebView drops window.open)', () => {
-    const offenders = walk(uiRoot + '/components')
+    const offenders = ['/components', '/app']
+      .flatMap((d) => walk(uiRoot + d))
       .filter((p) => readFileSync(p, 'utf8').includes('window.open('))
       .map((p) => p.slice(uiRoot.length + 1))
     expect(offenders).toEqual([])

--- a/ui/__tests__/external-links.test.ts
+++ b/ui/__tests__/external-links.test.ts
@@ -1,0 +1,107 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import { describe, it, expect } from 'bun:test'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { isExternalHttp } from '../lib/bridge'
+
+// Regression guard for "external links do nothing inside the app".
+//
+// The dashboard renders inside a Tauri WKWebView, which has NO new-window
+// handler: a plain `<a target="_blank">` click or a `window.open(url)` call is
+// silently dropped — nothing opens, no error. This bit users on the Trello
+// connect flow (the "Get it at trello.com/app-key" link was dead, blocking the
+// API-key prompt entirely).
+//
+// The fix has three parts, each guarded here:
+//   1. `openExternal` in lib/bridge.ts routes URLs through the opener plugin
+//      (`plugin:opener|open_url` — allowed by `opener:default` in the tray's
+//      capabilities/default.json) with a window.open fallback for a plain browser.
+//   2. `components/ExternalLinks.tsx` — a document-level click interceptor
+//      mounted in the root layout, so EVERY external http(s) anchor works
+//      without per-component wiring.
+//   3. The former direct `window.open(...)` call sites now use `openExternal`.
+
+const uiRoot = import.meta.dir + '/..'
+
+function readSrc(relPath: string): string {
+  return readFileSync(uiRoot + '/' + relPath, 'utf8')
+}
+
+// ── isExternalHttp — the interceptor's decision function ─────────────────────
+
+describe('isExternalHttp', () => {
+  const origin = 'http://localhost:3939'
+
+  it('accepts absolute http(s) URLs on a different origin', () => {
+    expect(isExternalHttp('https://trello.com/app-key', origin)).toBe(true)
+    expect(isExternalHttp('http://localhost:5080', origin)).toBe(true) // different port = different origin
+    expect(isExternalHttp('HTTPS://TRELLO.COM/x', origin)).toBe(true) // scheme is case-insensitive
+  })
+
+  it('rejects same-origin, relative, and non-http URLs', () => {
+    expect(isExternalHttp('http://localhost:3939/today', origin)).toBe(false)
+    expect(isExternalHttp('/today', origin)).toBe(false)
+    expect(isExternalHttp('#anchor', origin)).toBe(false)
+    expect(isExternalHttp('mailto:a@b.com', origin)).toBe(false)
+    expect(isExternalHttp('x-apple.systempreferences:com.apple.x', origin)).toBe(false)
+  })
+
+  it('rejects malformed URLs instead of throwing', () => {
+    expect(isExternalHttp('http://', origin)).toBe(false)
+  })
+})
+
+// ── openExternal routes through the opener plugin ─────────────────────────────
+
+describe('lib/bridge.ts openExternal', () => {
+  const src = readSrc('lib/bridge.ts')
+
+  it('invokes the opener plugin command inside Tauri', () => {
+    expect(src).toContain("invoke('plugin:opener|open_url'")
+  })
+
+  it('falls back to window.open in a plain browser', () => {
+    expect(src).toMatch(/openExternal[\s\S]*?window\.open\(url/)
+  })
+})
+
+// ── The interceptor exists and is mounted globally ────────────────────────────
+
+describe('ExternalLinks interceptor', () => {
+  const src = readSrc('components/ExternalLinks.tsx')
+
+  it('listens for document clicks and routes external anchors via openExternal', () => {
+    expect(src).toContain("document.addEventListener('click'")
+    expect(src).toContain('isExternalHttp(href, window.location.origin)')
+    expect(src).toContain('e.preventDefault()')
+    expect(src).toContain('openExternal(href)')
+  })
+
+  it('removes the listener on unmount', () => {
+    expect(src).toContain("document.removeEventListener('click'")
+  })
+
+  it('is mounted in the root layout (covers dashboard AND setup wizard)', () => {
+    const layout = readSrc('app/layout.tsx')
+    expect(layout).toContain('<ExternalLinks />')
+  })
+})
+
+// ── No component bypasses openExternal with a raw window.open ─────────────────
+
+describe('no raw window.open in components', () => {
+  function walk(dir: string, acc: string[] = []): string[] {
+    for (const name of readdirSync(dir)) {
+      const p = dir + '/' + name
+      if (statSync(p).isDirectory()) walk(p, acc)
+      else if (/\.(ts|tsx)$/.test(name)) acc.push(p)
+    }
+    return acc
+  }
+
+  it('every external open goes through openExternal (WKWebView drops window.open)', () => {
+    const offenders = walk(uiRoot + '/components')
+      .filter((p) => readFileSync(p, 'utf8').includes('window.open('))
+      .map((p) => p.slice(uiRoot.length + 1))
+    expect(offenders).toEqual([])
+  })
+})

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next'
 import { Instrument_Serif, Plus_Jakarta_Sans, JetBrains_Mono } from 'next/font/google'
 import './globals.css'
 import { ThemeProvider } from '@/lib/theme-context'
+import ExternalLinks from '@/components/ExternalLinks'
 import NoticeBar from '@/components/NoticeBar'
 import NotificationBanner from '@/components/NotificationBanner'
 
@@ -46,6 +47,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     >
       <body className="min-h-screen font-sans">
         <ThemeProvider>
+          <ExternalLinks />
           <NoticeBar />
           <NotificationBanner />
           {children}

--- a/ui/components/ExternalLinks.tsx
+++ b/ui/components/ExternalLinks.tsx
@@ -1,0 +1,33 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+'use client'
+
+// Global external-link interceptor. The dashboard runs inside a Tauri
+// WKWebView, which has no new-window handler: a plain `<a target="_blank">`
+// click is silently dropped — nothing opens, no error. Rather than rewriting
+// every external anchor onto a bespoke onClick, this listens once at the
+// document level and routes any external http(s) anchor click through the
+// opener plugin (`openExternal`). In a plain browser (`isTauri()` false) it
+// does nothing and anchors behave natively.
+//
+// Rendered by app/layout.tsx (root layout), so it covers every window that
+// serves the Next app — the dashboard and the setup wizard.
+
+import { useEffect } from 'react'
+import { isTauri, isExternalHttp, openExternal } from '@/lib/bridge'
+
+export default function ExternalLinks() {
+  useEffect(() => {
+    if (!isTauri()) return
+    const onClick = (e: MouseEvent) => {
+      if (e.defaultPrevented) return
+      const el = e.target instanceof Element ? e.target : null
+      const href = el?.closest('a[href]')?.getAttribute('href')
+      if (!href || !isExternalHttp(href, window.location.origin)) return
+      e.preventDefault()
+      openExternal(href)
+    }
+    document.addEventListener('click', onClick)
+    return () => document.removeEventListener('click', onClick)
+  }, [])
+  return null
+}

--- a/ui/components/ExternalLinks.tsx
+++ b/ui/components/ExternalLinks.tsx
@@ -3,17 +3,18 @@
 
 // Global external-link interceptor. The dashboard runs inside a Tauri
 // WKWebView, which has no new-window handler: a plain `<a target="_blank">`
-// click is silently dropped — nothing opens, no error. Rather than rewriting
-// every external anchor onto a bespoke onClick, this listens once at the
-// document level and routes any external http(s) anchor click through the
-// opener plugin (`openExternal`). In a plain browser (`isTauri()` false) it
-// does nothing and anchors behave natively.
+// click — or a mailto:/tel: anchor — is silently dropped: nothing opens, no
+// error. Rather than rewriting every external anchor onto a bespoke onClick,
+// this listens once at the document level and routes any external http(s) /
+// mailto: / tel: anchor click through the opener plugin (`openExternal`). In
+// a plain browser (`isTauri()` false) it does nothing and anchors behave
+// natively.
 //
 // Rendered by app/layout.tsx (root layout), so it covers every window that
 // serves the Next app — the dashboard and the setup wizard.
 
 import { useEffect } from 'react'
-import { isTauri, isExternalHttp, openExternal } from '@/lib/bridge'
+import { isTauri, opensExternally, openExternal } from '@/lib/bridge'
 
 export default function ExternalLinks() {
   useEffect(() => {
@@ -22,7 +23,7 @@ export default function ExternalLinks() {
       if (e.defaultPrevented) return
       const el = e.target instanceof Element ? e.target : null
       const href = el?.closest('a[href]')?.getAttribute('href')
-      if (!href || !isExternalHttp(href, window.location.origin)) return
+      if (!href || !opensExternally(href, window.location.origin)) return
       e.preventDefault()
       openExternal(href)
     }

--- a/ui/components/HygieneDialog.tsx
+++ b/ui/components/HygieneDialog.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react'
 import { TaskKey, ProviderGlyph, StatusPill } from '@/components/atoms'
 import type { TaskSummary } from '@/lib/api-types'
 import type { HygieneIssue } from '@/lib/hygiene'
-import { load, mutate } from '@/lib/bridge'
+import { load, mutate, openExternal } from '@/lib/bridge'
 
 const PRIORITIES = ['Highest', 'High', 'Medium', 'Low', 'Lowest']
 
@@ -124,7 +124,7 @@ function FixRow({ issue, index, task, onApplied }: { issue: HygieneIssue; index:
         setState('redirected'); setTerminalPending(null)
         setMsg(result.reason ?? 'Finish this in your tracker')
         const url = result.browse_url || task.url
-        if (url) window.open(url, '_blank', 'noopener')
+        if (url) openExternal(url)
       }
     } catch (e) {
       // Tauri rejects with a plain string, not an Error object — handle both.

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -275,7 +275,12 @@ function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
                 <a href="https://trello.com/app-key" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--color-state-proposal)' }}>Get it at trello.com/app-key ↗</a>
               </p>
               <Field
-                field={{ name: 'api_key', label: 'API Key', placeholder: 'Paste your Trello API key', required: true }}
+                field={{
+                  name: 'api_key', label: 'API Key', placeholder: 'Paste your Trello API key', required: true,
+                  // Trello only redirects back to origins on the key's allow-list,
+                  // so without this the browser flow dead-ends after consent.
+                  hint: 'On the same page, add http://127.0.0.1:9123 under Allowed Origins — Trello only redirects back to listed origins.',
+                }}
                 value={apiKey}
                 onChange={setApiKey}
                 onEnter={() => { if (apiKey.trim()) void startOAuth() }}

--- a/ui/components/timeline/CleanupCard.tsx
+++ b/ui/components/timeline/CleanupCard.tsx
@@ -18,7 +18,7 @@ import { useEffect, useState } from 'react'
 import { ProviderGlyph } from '@/components/atoms'
 import type { TaskSummary } from '@/lib/api-types'
 import type { HygieneIssue } from '@/lib/hygiene'
-import { load, mutate } from '@/lib/bridge'
+import { load, mutate, openExternal } from '@/lib/bridge'
 
 export type CleanupGroup = 'must' | 'nice' | 'review'
 
@@ -151,7 +151,7 @@ function FixRow({ issue, task, onApplied, onIgnore }: {
         setState('redirected'); setTerminalPending(null)
         setMsg(result.reason ?? 'Finish this in your tracker')
         const url = result.browse_url || task.url
-        if (url) window.open(url, '_blank', 'noopener')
+        if (url) openExternal(url)
       }
     } catch (e) {
       // Tauri rejects with a plain string, not an Error object — handle both.

--- a/ui/components/timeline/OverviewPanel.tsx
+++ b/ui/components/timeline/OverviewPanel.tsx
@@ -16,7 +16,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { fmtDur } from '@/components/atoms'
-import { load as loadData, mutate as mutateData } from '@/lib/bridge'
+import { load as loadData, mutate as mutateData, openExternal } from '@/lib/bridge'
 import type { PlanItem, PlanResponse } from '@/lib/api-types'
 import { isPending } from './types'
 import { TimeByApp, appTotals } from './TimeByApp'
@@ -77,7 +77,7 @@ export function OverviewPanel({ data, onOpen, onOpenTask }: {
         loadData<PlanResponse>('/api/plan', 'get_plan').then(setPlan).catch(() => {})
       } else {
         const url = data.result.browse_url || t.url
-        if (url) window.open(url, '_blank', 'noopener')
+        if (url) openExternal(url)
       }
     }).catch(e => {
       setToggleError(s => ({ ...s, [t.task_key]: e instanceof Error ? e.message : typeof e === 'string' ? e : 'Couldn’t update the tracker' }))

--- a/ui/components/timeline/settings/AdvancedSection.tsx
+++ b/ui/components/timeline/settings/AdvancedSection.tsx
@@ -16,6 +16,7 @@ import { Switch } from '@/components/ui/Switch'
 import { NumberStepper } from '@/components/ui/NumberStepper'
 import { TextInput } from '@/components/ui/TextInput'
 import type { RuntimeSettings } from '@/lib/settings'
+import { openExternal } from '@/lib/bridge'
 import { SectionCard, SectionHeader, FieldRow, SaveButton, SettingsButton, type SaveStatus } from './fields'
 import { useApplyObservability } from './useApplyObservability'
 
@@ -95,7 +96,7 @@ export function AdvancedSection({ settings, setSettings, patch, save }: {
               try {
                 if (settings.otlp_endpoint) base = new URL(settings.otlp_endpoint).origin
               } catch { /* keep default */ }
-              window.open(base, '_blank', 'noopener,noreferrer')
+              openExternal(base)
             }}>
               Open OpenObserve
             </SettingsButton>

--- a/ui/lib/bridge.ts
+++ b/ui/lib/bridge.ts
@@ -43,6 +43,25 @@ export async function invoke<T = unknown>(cmd: string, args?: Record<string, unk
   return t.core.invoke(cmd, args) as Promise<T>
 }
 
+/** True when `href` is an absolute http(s) URL pointing outside `origin` —
+ *  i.e. a navigation the Tauri webview cannot perform itself. Exported for
+ *  the ExternalLinks interceptor and its tests. */
+export function isExternalHttp(href: string, origin: string): boolean {
+  if (!/^https?:\/\//i.test(href)) return false
+  try { return new URL(href).origin !== origin } catch { return false }
+}
+
+/** Open a URL in the user's default browser. The dashboard renders inside a
+ *  WKWebView with no new-window handler, so `target="_blank"` anchors and
+ *  `window.open` are silently dropped — external URLs must go through the
+ *  opener plugin (`opener:default` in capabilities allows http/https). Falls
+ *  back to `window.open` in a plain browser (next dev outside the app). */
+export function openExternal(url: string): void {
+  const t = tauri()
+  if (t) void t.core.invoke('plugin:opener|open_url', { url }).catch((e) => console.warn(`openExternal('${url}') failed:`, e))
+  else window.open(url, '_blank', 'noopener,noreferrer')
+}
+
 /** Data load via the Rust command (`apiPath` is the former route it replaced). */
 export async function load<T = unknown>(
   apiPath: string,

--- a/ui/lib/bridge.ts
+++ b/ui/lib/bridge.ts
@@ -51,15 +51,32 @@ export function isExternalHttp(href: string, origin: string): boolean {
   try { return new URL(href).origin !== origin } catch { return false }
 }
 
-/** Open a URL in the user's default browser. The dashboard renders inside a
- *  WKWebView with no new-window handler, so `target="_blank"` anchors and
- *  `window.open` are silently dropped — external URLs must go through the
- *  opener plugin (`opener:default` in capabilities allows http/https). Falls
- *  back to `window.open` in a plain browser (next dev outside the app). */
+/** True when `href` should be handed to the OS instead of navigated in-app:
+ *  an external http(s) URL, or a mailto:/tel: link (the WKWebView drops those
+ *  just like target="_blank"; both schemes are in the opener plugin's default
+ *  scope). The ExternalLinks interceptor's decision function. */
+export function opensExternally(href: string, origin: string): boolean {
+  return /^(mailto:|tel:)/i.test(href) || isExternalHttp(href, origin)
+}
+
+/** Open a URL in the user's default browser / mail client. The dashboard
+ *  renders inside a WKWebView with no new-window handler, so `target="_blank"`
+ *  anchors, mailto:, and `window.open` are silently dropped — external URLs
+ *  must go through the opener plugin (`opener:default` in capabilities allows
+ *  http/https/mailto/tel). A plugin rejection falls back to `window.open`
+ *  rather than only logging — a silent miss here would reproduce the exact
+ *  dead-link bug this helper exists to fix. Outside Tauri (next dev in a
+ *  plain browser) it uses `window.open` directly. */
 export function openExternal(url: string): void {
   const t = tauri()
-  if (t) void t.core.invoke('plugin:opener|open_url', { url }).catch((e) => console.warn(`openExternal('${url}') failed:`, e))
-  else window.open(url, '_blank', 'noopener,noreferrer')
+  if (t) {
+    void t.core.invoke('plugin:opener|open_url', { url }).catch((e) => {
+      console.warn(`openExternal('${url}') failed:`, e)
+      window.open(url, '_blank', 'noopener,noreferrer')
+    })
+  } else {
+    window.open(url, '_blank', 'noopener,noreferrer')
+  }
 }
 
 /** Data load via the Rust command (`apiPath` is the former route it replaced). */


### PR DESCRIPTION
## Problem

The dashboard runs inside a Tauri WKWebView, which has **no new-window handler**: every `<a target="_blank">` click and `window.open()` call is silently dropped — nothing opens, no error. Every external link in the app was dead.

This blocked the Trello connect flow outright: on dev builds (no baked-in `TRELLO_APP_KEY`) the UI shows the API-key prompt, but its **"Get it at trello.com/app-key"** link never opened, dead-ending the whole setup.

## Fix

- **`ui/lib/bridge.ts`** — new `openExternal(url)`: routes URLs through the opener plugin (`plugin:opener|open_url`, already permitted by `opener:default` in `capabilities/default.json` — no Rust/capability change needed), with a `window.open` fallback for a plain browser. Plus the pure predicate `isExternalHttp()`.
- **`ui/components/ExternalLinks.tsx`** (new) — a document-level click interceptor mounted in the root layout, so every external http(s) anchor in every window (dashboard + setup wizard) works without per-component wiring. No-op outside Tauri.
- **4 direct `window.open()` call sites** (HygieneDialog, OverviewPanel, CleanupCard, AdvancedSection) now use `openExternal` — these were equally broken in the webview.
- **Trello API-key prompt** now documents the *Allowed Origins* requirement (`http://127.0.0.1:9123`) — Trello refuses to redirect back after consent unless the origin is on the key's allow-list, which was the next failure in the flow.

## Testing

- New `ui/__tests__/external-links.test.ts` (9 tests): the URL predicate, the plugin routing, the layout mount, and a guard that no component reintroduces raw `window.open`.
- Full UI suite: 210 pass / 0 fail; `next build` passes.
- Verified live in the running `tauri dev` app: the trello.com/app-key link opens the default browser, and the full Trello browser-OAuth connect + task sync + due-date write-back now work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvJAgU1eEFC68AAG8etezG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Tauri-aware external-link interceptor so external links open via the system handler (including consistent `mailto:`/`tel:` support).
  * Added Trello sign-in guidance for required local redirect origin.
* **Bug Fixes**
  * Updated multiple app flows to stop using direct `window.open(...)` and route external destinations through the unified external-link behavior.
* **Tests**
  * Added a regression test suite covering URL classification and external-opening behavior, including ensuring external opens don’t bypass the shared handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->