### PR TITLE
fix(services): cap transformers <5.13 — restore MLX runtime smoke/publish

### DIFF
--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -45,7 +45,11 @@ mlx = [
     # Xet downloads. Tuned harder with HF_XET_HIGH_PERFORMANCE=1 (MLX server plist).
     "hf-xet>=1.5.1,<2",
     "outlines[mlxlm]>=1.3,<2",
-    "transformers>=5.0.0",
+    # Capped <5.13: transformers 5.13.0 rejects mlx-lm 0.31.x's string-based
+    # AutoTokenizer.register("NewlineTokenizer", …) at import time
+    # ('str' has no attribute '__module__') — broke the runtime smoke test on
+    # every OS. Lift the cap once mlx-lm registers with a config CLASS.
+    "transformers>=5.0.0,<5.13",
     "sentence-transformers>=3",
     "pydantic>=2.10,<3",
     "fastapi>=0.115,<1",


### PR DESCRIPTION
## Problem

The first real MLX runtime build in a while ([run 28739827453](https://github.com/Meridiona/meridian/actions/runs/28739827453) — un-gated by #388 raising `services/pyproject.toml` to 1.69.1 vs the channels' live 1.68.0) failed its smoke test on **all three** macOS runners and published nothing. The floating `transformers>=5.0.0` pin freshly resolved **5.13.0**, which rejects `mlx-lm` 0.31.x's string-based `AutoTokenizer.register('NewlineTokenizer', …)` at import time:

```
AttributeError: 'str' object has no attribute '__module__'
```

Until fixed, every pre-main push rebuilds and fails, and the same failure will block the production channel at the next promotion — while prod's `runtime-latest` is already pending an update.

## Fix

Cap `transformers>=5.0.0,<5.13` (resolves 5.12.1 today), with a comment explaining when to lift it (once mlx-lm registers the tokenizer with a config *class*; mlx-lm 0.31.3 is the newest release, so no fixed version exists to bump to yet).

## Verification (local, fresh py3.11 venv, full `[mlx,pm_worklog_update]` install)

1. Reproduced the exact CI crash with `mlx-lm==0.31.3 + transformers==5.13.0`.
2. With the cap (resolves `transformers 5.12.1 + mlx-lm 0.31.3`), replicated the complete `smoke-test-mlx-runtime.sh` sequence:
   - `import mlx, mlx_lm, outlines, fastapi, agents` ✓
   - every non-test `agents` submodule imports ✓
   - `server.py` boots, `/health` → 200 ✓

## Publish mechanics

No version bump: 1.69.1 is already strictly ahead of both live channels (1.68.0), so on merge the gate re-attempts the staging publish with the fixed pin. Reminder that a production runtime needs this to land on `main` via the normal pre-main → main promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvJAgU1eEFC68AAG8etezG