### PR TITLE
fix(daily-plan): expire plan nudges at local midnight so banners don't stack

### DIFF
--- a/src/daily_plan.rs
+++ b/src/daily_plan.rs
@@ -3,10 +3,14 @@
 // Morning "plan your day" nudge. Once per local day, when the dev has neither
 // confirmed nor skipped today's plan and there are open tickets to plan against,
 // enqueue a `plan.nudge` notification. Idempotent via the outbox dedup key, so
-// the poll loop can call this every tick without spamming.
+// the poll loop can call this every tick without spamming. A nudge is only
+// meaningful on its own day, so it carries an `expires_at` of the next local
+// midnight, and any still-live nudge from a previous day (or one whose plan has
+// since been confirmed/skipped) is expired on sight — otherwise an unactioned
+// banner stacks under the next day's identical one.
 
-use anyhow::Result;
-use chrono::{Local, Timelike};
+use anyhow::{Context, Result};
+use chrono::{Local, TimeZone, Timelike, Utc};
 use sqlx::{Row, SqlitePool};
 
 use crate::notifications::{self, NewNotification};
@@ -26,8 +30,26 @@ pub async fn maybe_nudge(pool: &SqlitePool) -> Result<()> {
         return Ok(());
     }
     let today = now.format("%Y-%m-%d").to_string();
+    let dedup = format!("plan.nudge:{today}");
+    let now_utc = utc_iso(&now);
 
-    // Already confirmed or skipped today? Nothing to nudge.
+    // Expire any still-live nudge from a previous day. Rows written before
+    // expiry stamping existed have `expires_at` NULL, so yesterday's unactioned
+    // banner would otherwise sit under today's identical one forever.
+    sqlx::query(
+        "UPDATE notifications SET expires_at = ?
+         WHERE event_key = 'plan.nudge' AND dedup_key <> ?
+           AND (expires_at IS NULL OR expires_at > ?)",
+    )
+    .bind(&now_utc)
+    .bind(&dedup)
+    .bind(&now_utc)
+    .execute(pool)
+    .await
+    .context("expiring stale plan nudges")?;
+
+    // Already confirmed or skipped today? Expire today's nudge (its job is
+    // done — don't make the user dismiss it) and stop.
     if let Some(row) =
         sqlx::query("SELECT confirmed_at, skipped FROM daily_plan_meta WHERE plan_date = ?")
             .bind(&today)
@@ -37,6 +59,16 @@ pub async fn maybe_nudge(pool: &SqlitePool) -> Result<()> {
         let confirmed: Option<String> = row.try_get("confirmed_at").unwrap_or(None);
         let skipped: i64 = row.try_get("skipped").unwrap_or(0);
         if confirmed.is_some() || skipped != 0 {
+            sqlx::query(
+                "UPDATE notifications SET expires_at = ?
+                 WHERE dedup_key = ? AND (expires_at IS NULL OR expires_at > ?)",
+            )
+            .bind(&now_utc)
+            .bind(&dedup)
+            .bind(&now_utc)
+            .execute(pool)
+            .await
+            .context("expiring actioned plan nudge")?;
             return Ok(());
         }
     }
@@ -52,16 +84,54 @@ pub async fn maybe_nudge(pool: &SqlitePool) -> Result<()> {
         return Ok(());
     }
 
-    let dedup = format!("plan.nudge:{today}");
-    notifications::enqueue(
-        pool,
-        NewNotification::event(
-            &dedup,
-            "plan.nudge",
-            "Plan your day",
-            "Pick what you're working on today so Meridian can match your work to the right tickets.",
-        )
-        .link("/plan"),
+    // Expiry = the next local midnight; if that's ever uncomputable (calendar
+    // edge), the enqueue still goes out and the stale-nudge sweep above expires
+    // the row the next day.
+    let expires = next_local_midnight_utc(&now);
+    let mut nudge = NewNotification::event(
+        &dedup,
+        "plan.nudge",
+        "Plan your day",
+        "Pick what you're working on today so Meridian can match your work to the right tickets.",
     )
-    .await
+    .link("/plan");
+    if let Some(exp) = expires.as_deref() {
+        nudge = nudge.expiring(exp);
+    }
+    notifications::enqueue(pool, nudge).await
+}
+
+/// `t` as the UTC ISO-8601 string shape (`2026-07-05T02:30:24Z`) the
+/// notifications table string-compares `expires_at` against.
+fn utc_iso(t: &chrono::DateTime<Local>) -> String {
+    t.with_timezone(&Utc)
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string()
+}
+
+/// First instant of the next local day, as a UTC ISO string — the moment
+/// today's nudge stops being meaningful. `None` only on calendar edges (last
+/// representable date, a DST transition swallowing midnight).
+fn next_local_midnight_utc(now: &chrono::DateTime<Local>) -> Option<String> {
+    let midnight = now.date_naive().succ_opt()?.and_hms_opt(0, 0, 0)?;
+    let local = Local.from_local_datetime(&midnight).earliest()?;
+    Some(utc_iso(&local))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expiry_is_the_next_local_midnight() {
+        let now = Local::now();
+        let exp = next_local_midnight_utc(&now).expect("expiry computable");
+        let parsed = chrono::DateTime::parse_from_rfc3339(&exp).expect("valid ISO instant");
+        let local = parsed.with_timezone(&Local);
+        assert_eq!(local.date_naive(), now.date_naive().succ_opt().unwrap());
+        assert_eq!((local.hour(), local.minute(), local.second()), (0, 0, 0));
+        // Must sort AFTER "now" in the shared string format, or the banner
+        // would be born expired.
+        assert!(exp > utc_iso(&now));
+    }
 }


### PR DESCRIPTION
## Problem

The dashboard showed **two identical "Plan your day" banners** (screenshot from 2026-07-05). Root cause: `daily_plan::maybe_nudge` enqueues one nudge per day (`plan.nudge:<date>` dedup key) with **no `expires_at`**, and nothing ever retracts it. `active_banners` shows every undismissed, unexpired row — so yesterday's unactioned nudge (id 2083, 2026-07-04) stayed live alongside today's (id 2685). Left alone another day, there would be three.

## Fix (all in `src/daily_plan.rs`)

- **Stamp `expires_at` = next local midnight** on every new nudge (via the existing `NewNotification::expiring` builder, same UTC-ISO string shape the banner query compares against). A plan nudge for the 4th is meaningless on the 5th.
- **Retro-expire stale prior-day nudges** each tick — heals rows already sitting in users' DBs from before expiry stamping existed (idempotent no-op afterwards).
- **Expire today's nudge once the plan is confirmed or skipped** — previously the banner lingered until manually dismissed even after the user actioned the plan.

## Verification

- New unit test `expiry_is_the_next_local_midnight` (round-trips the expiry string, asserts it is tomorrow's local 00:00:00 and string-sorts after now).
- `cargo clippy -- -D warnings` clean; full daemon suite passes (411 lib tests + integration suites).
- Pre-push hook suite green (the wave-1 "ui build ✗" was environmental — fresh worktree without `node_modules`; no UI code is touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)