### PR TITLE
fix(hooks): propagate pre-push check failures out of background jobs

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -10,17 +10,21 @@ FAIL=0
 # before any background subshells start (they can't read stdin after forking).
 PUSH_INFO=$(cat)
 
+# Runs as a background job, so it CANNOT mutate the parent's FAIL — a subshell's
+# variables die with it. Failure is reported through the job's exit status
+# instead; every caller must collect it with `wait $PID || FAIL=1`.
 run_check() {
   local label="$1"; shift
   local log; log=$(mktemp)
   if "$@" >"$log" 2>&1; then
     echo "  ✓ $label"
+    rm -f "$log"
   else
     echo "  ✗ $label"
     cat "$log"
-    FAIL=1
+    rm -f "$log"
+    return 1
   fi
-  rm -f "$log"
 }
 
 echo ""
@@ -36,8 +40,8 @@ W1_FMT=$!
 run_check "ui build" bash -c "cd '$REPO_ROOT/ui' && npm run build" &
 W1_UI=$!
 
-wait $W1_FMT
-wait $W1_UI
+wait $W1_FMT || FAIL=1
+wait $W1_UI || FAIL=1
 
 if [[ $FAIL -ne 0 ]]; then
   echo ""
@@ -55,8 +59,8 @@ W2_CLIPPY=$!
 run_check "ui tests" bash -c "cd '$REPO_ROOT/ui' && bun test" &
 W2_UI=$!
 
-wait $W2_CLIPPY
-wait $W2_UI
+wait $W2_CLIPPY || FAIL=1
+wait $W2_UI || FAIL=1
 
 if [[ $FAIL -ne 0 ]]; then
   echo ""
@@ -100,7 +104,7 @@ fi
 run_check "cargo test" cargo test &
 W3_TEST=$!
 
-wait $W3_TEST
+wait $W3_TEST || FAIL=1
 
 if [ -n "$AUDIT_PID" ]; then
   wait "$AUDIT_PID" || true


### PR DESCRIPTION
## Problem

Every parallel check in `.githooks/pre-push` was a **dead gate**. `run_check` sets `FAIL=1`, but each check is launched with `&` — a background subshell, whose variable writes never reach the parent. The parent's `FAIL` stayed `0`, so all three `if [[ $FAIL -ne 0 ]]; then exit 1` gates were unreachable and **fmt, ui build, clippy, ui tests, and cargo test could all fail without blocking the push**. Only the security audit (evaluated in the parent shell) could actually block.

Proven live on a push from a fresh worktree: `✗ ui build` printed, followed by `All pre-push checks passed`, exit 0. This matters double for `pre-main` PRs, which get no GitHub CI checks (`ci.yml` targets `main` only) — this hook is their only gate.

## Fix

Failure now travels through the background job's **exit status** instead of a shared variable:
- `run_check` returns 1 when its check fails (and keeps printing `✗` + the captured log)
- every `wait $PID` collects it: `wait $PID || FAIL=1`

7 lines changed, one file; the parallel-wave structure is untouched. `pre-commit` was checked and does not have this bug (sequential, no subshells).

## Verification

Ran the fixed hook with PATH-shimmed `cargo`/`npm`/`bun`/`claude` to exercise every path against the real script:

| case | exit | gate message |
|---|---|---|
| all pass | 0 | All pre-push checks passed |
| ui build fails (the live repro) | 1 | Wave 1 failed |
| fmt fails | 1 | Wave 1 failed |
| clippy fails | 1 | Wave 2 failed |
| ui tests fail | 1 | Wave 2 failed |
| cargo test fails | 1 | Wave 3 failed |

Also `bash -n` clean, and the real full suite ran green on this branch's push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)