### PR TITLE
feat(tray): open dashboard when app is re-activated externally

### DIFF
--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -511,8 +511,29 @@ pub fn run() {
             commands::detect_system_specs,
             tray_debug,
         ])
-        .run(tauri::generate_context!())
-        .expect("error running meridian tray");
+        .build(tauri::generate_context!())
+        .expect("error running meridian tray")
+        .run(|app, event| {
+            // macOS: fires when the user re-activates the app externally
+            // (Spotlight, dock click, `open -a Meridian`). The tray runs as an
+            // Accessory app so there is no dock icon most of the time; without
+            // this handler, hitting "Meridian" in Spotlight is silently a no-op
+            // when the app is already running. Route to the dashboard when the
+            // user has finished setup, otherwise re-open the wizard so a partial
+            // onboard can be resumed. The setup hook already opens the wizard on
+            // cold start, so this only matters for warm activation.
+            if let tauri::RunEvent::Reopen { .. } = event {
+                let home = std::env::var("HOME").unwrap_or_default();
+                let onboarded =
+                    std::path::Path::new(&format!("{home}/.meridian/onboarded")).exists();
+                tracing::info!(onboarded, "app.reopen: routing external activation");
+                if onboarded {
+                    tray::open_native_dashboard(app);
+                } else {
+                    tray::open_wizard_window(app);
+                }
+            }
+        });
 }
 
 /// Debug bridge: lets the popover/tooltip JS forward `window.onerror` reports and

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -529,6 +529,13 @@ pub fn run() {
             // avoid unused warnings. The routing decision lives in the
             // platform-independent [`reopen_target`] / [`is_onboarded`] so it is
             // unit-testable without a live Tauri app (see the tests below).
+            //
+            // `has_visible_windows` is intentionally ignored (`{ .. }`): both
+            // openers already reuse an existing dashboard/wizard window via
+            // `get_webview_window(..)` + show/focus before building a new one,
+            // so a Reopen while a window is already up just re-focuses it — the
+            // flag would only matter if we wanted different behaviour for
+            // "windows visible" vs "all minimised", which we don't.
             #[cfg(target_os = "macos")]
             if let tauri::RunEvent::Reopen { .. } = _event {
                 let home = std::env::var("HOME").unwrap_or_default();

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -513,7 +513,7 @@ pub fn run() {
         ])
         .build(tauri::generate_context!())
         .expect("error running meridian tray")
-        .run(|app, event| {
+        .run(|_app, _event| {
             // macOS: fires when the user re-activates the app externally
             // (Spotlight, dock click, `open -a Meridian`). The tray runs as an
             // Accessory app so there is no dock icon most of the time; without
@@ -522,18 +522,57 @@ pub fn run() {
             // user has finished setup, otherwise re-open the wizard so a partial
             // onboard can be resumed. The setup hook already opens the wizard on
             // cold start, so this only matters for warm activation.
-            if let tauri::RunEvent::Reopen { .. } = event {
+            //
+            // `RunEvent::Reopen` is a macOS-only enum variant (it doesn't exist
+            // on other targets), so the whole arm is cfg-gated — on Linux/Windows
+            // the closure is a no-op and the params stay underscore-prefixed to
+            // avoid unused warnings. The routing decision lives in the
+            // platform-independent [`reopen_target`] / [`is_onboarded`] so it is
+            // unit-testable without a live Tauri app (see the tests below).
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Reopen { .. } = _event {
                 let home = std::env::var("HOME").unwrap_or_default();
-                let onboarded =
-                    std::path::Path::new(&format!("{home}/.meridian/onboarded")).exists();
+                let onboarded = is_onboarded(std::path::Path::new(&home));
                 tracing::info!(onboarded, "app.reopen: routing external activation");
-                if onboarded {
-                    tray::open_native_dashboard(app);
-                } else {
-                    tray::open_wizard_window(app);
+                match reopen_target(onboarded) {
+                    ReopenTarget::Dashboard => tray::open_native_dashboard(_app),
+                    ReopenTarget::Wizard => tray::open_wizard_window(_app),
                 }
             }
         });
+}
+
+/// Which window an external re-activation (Spotlight, dock, `open -a Meridian`)
+/// opens. Split out of the `RunEvent::Reopen` handler so the routing decision is
+/// unit-testable without a live Tauri app.
+///
+/// Defined for every target (not just macOS) so its tests run in CI, which
+/// builds the workspace on Linux; `allow(dead_code)` off-macOS keeps that from
+/// tripping `-D warnings` where the reopen handler is compiled out.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+#[derive(Debug, PartialEq, Eq)]
+enum ReopenTarget {
+    Dashboard,
+    Wizard,
+}
+
+/// True when onboarding has completed — the `~/.meridian/onboarded` marker
+/// exists under `home`. The inverse of [`commands::setup::is_first_run`]'s
+/// check, kept a pure filesystem read so it can be tested against a temp dir.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn is_onboarded(home: &std::path::Path) -> bool {
+    home.join(".meridian/onboarded").exists()
+}
+
+/// Route an external re-activation: finished onboarding → the dashboard;
+/// otherwise the wizard, so a partial onboard can be resumed.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn reopen_target(onboarded: bool) -> ReopenTarget {
+    if onboarded {
+        ReopenTarget::Dashboard
+    } else {
+        ReopenTarget::Wizard
+    }
 }
 
 /// Debug bridge: lets the popover/tooltip JS forward `window.onerror` reports and
@@ -870,4 +909,36 @@ pub(crate) fn start_capture(
     s.engine_cancel = Some(engine_cancel_tx);
     s.ui_consumer_cancel = Some(ui_cancel_tx);
     tracing::info!("capture: engine and ui recorder started");
+}
+
+#[cfg(test)]
+mod reopen_tests {
+    use super::{is_onboarded, reopen_target, ReopenTarget};
+
+    #[test]
+    fn reopen_target_routes_by_onboarded() {
+        // Onboarded users land on the dashboard; everyone else resumes the wizard.
+        assert_eq!(reopen_target(true), ReopenTarget::Dashboard);
+        assert_eq!(reopen_target(false), ReopenTarget::Wizard);
+    }
+
+    #[test]
+    fn is_onboarded_reflects_the_marker_file() {
+        // Use a unique temp dir so parallel test runs don't collide.
+        let dir = std::env::temp_dir().join(format!("meridian-reopen-{}", std::process::id()));
+        let meridian = dir.join(".meridian");
+        std::fs::create_dir_all(&meridian).unwrap();
+
+        // No marker yet → not onboarded → the reopen handler would open the wizard.
+        assert!(!is_onboarded(&dir));
+        assert_eq!(reopen_target(is_onboarded(&dir)), ReopenTarget::Wizard);
+
+        // Marker present (mark_setup_complete writes an RFC-3339 stamp here) →
+        // onboarded → the handler would open the dashboard.
+        std::fs::write(meridian.join("onboarded"), "2026-07-07T00:00:00Z").unwrap();
+        assert!(is_onboarded(&dir));
+        assert_eq!(reopen_target(is_onboarded(&dir)), ReopenTarget::Dashboard);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/tray/src-tauri/src/tray.rs
+++ b/tray/src-tauri/src/tray.rs
@@ -84,7 +84,7 @@ pub(crate) fn handle_menu_event(app: &tauri::AppHandle, id: &str) {
 /// — this is the native tray-menu path (right-click → Open Dashboard / Review
 /// Drafts), independent of the popover's own `invoke('open_dashboard')` button,
 /// so it needs the same fix to avoid leaving the popover stuck on screen.
-fn open_native_dashboard(app: &tauri::AppHandle) {
+pub(crate) fn open_native_dashboard(app: &tauri::AppHandle) {
     crate::commands::system::dismiss_popover(app);
     if let Some(win) = app.get_webview_window("dashboard") {
         let _ = win.show();


### PR DESCRIPTION
## Summary
- Add a Tauri `RunEvent::Reopen` handler so activating Meridian externally (Spotlight, dock click, `open -a Meridian`) actually opens something instead of being a silent no-op while the tray is running.
- Onboarded → dashboard window. Not onboarded → setup wizard (resumes a partial onboard).
- Cold-start behavior unchanged: the setup hook still auto-opens the wizard on first launch.

## Why
The tray runs as `ActivationPolicy::Accessory` — no dock icon most of the time — and Tauri drops the reopen event on the floor without a handler. Users hitting ⌘Space → "Meridian" ⏎ saw nothing happen.

## Test plan
- [ ] Fresh `~/.meridian` (no `onboarded` file) → Spotlight-launch Meridian on an already-running tray → setup wizard opens.
- [ ] With `onboarded` present → Spotlight-launch Meridian → dashboard window opens (or focuses if already open).
- [ ] Dock click while dashboard is open → dashboard focuses.
- [ ] `cargo check` + `cargo clippy` clean on `tray/src-tauri/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)