### PR TITLE
chore: remove retired daemon/service artifacts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,6 @@
 # Core (optional — defaults shown)
 # ---------------------------------------------------------------------------
 
-# SCREENPIPE_DB=~/.screenpipe/db.sqlite
 # MERIDIAN_DB=~/.meridian/meridian.db
 # POLL_INTERVAL_SECS=60
 # RUST_LOG=meridian=info

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,6 @@ There are no JS/TS test suites yet. When adding them, place them under `ui/__tes
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `SCREENPIPE_DB` | `~/.screenpipe/db.sqlite` | **Vestigial after the Bucket-2 cutover** — the daemon no longer reads screenpipe (capture is in-process → `meridian.db` capture tables). Still parsed into `Config` with a default; slated for removal. |
 | `MERIDIAN_DB` | `~/.meridian/meridian.db` | Path to meridian's output SQLite file |
 | `POLL_INTERVAL_SECS` | `60` | ETL poll cadence in seconds |
 | `RUST_LOG` | `meridian=info` | Tracing filter |
@@ -259,7 +258,7 @@ JSON columns (`window_titles`, `ocr_samples`, `elements_samples`, `audio_snippet
 
 ### Capture source — in-process (Gap-2 Bucket 2 cutover, branch `feat/in-process-capture`)
 
-> **The daemon no longer reads screenpipe.** Since the slice-4b cutover, capture runs **in-process in the tray** (behind the `capture` feature): the forked `screenpipe-screen` + `screenpipe-a11y` crates produce a11y-tree/OCR frames + input events, which `meridian_core::capture` writes into **`capture_frames` / `capture_ui_events`** in `meridian.db`. The daemon ETL reads *those* tables (via `src/db/screenpipe.rs`, name unchanged for now) from the meridian pool — there is no screenpipe DB/process/pool anymore. **Implication:** a build with the `capture` feature OFF has **no data source** (the daemon produces no sessions); the shipping DMG must enable it. **Audio is dropped** (`get_audio_snippets` stubbed empty) and **gaps all classify `system_sleep`** (no in-process idle detection yet — `capture_trigger` is NULL); both are accepted v1 degradations with idle-detection/audio as future slices. `SCREENPIPE_DB` is now vestigial for the daemon.
+> **The daemon no longer reads screenpipe.** Since the slice-4b cutover, capture runs **in-process in the tray** (behind the `capture` feature): the forked `screenpipe-screen` + `screenpipe-a11y` crates produce a11y-tree/OCR frames + input events, which `meridian_core::capture` writes into **`capture_frames` / `capture_ui_events`** in `meridian.db`. The daemon ETL reads *those* tables (via `src/db/screenpipe.rs`, name unchanged for now) from the meridian pool — there is no screenpipe DB/process/pool anymore. **Implication:** a build with the `capture` feature OFF has **no data source** (the daemon produces no sessions); the shipping DMG must enable it. **Audio is dropped** (`get_audio_snippets` stubbed empty) and **gaps all classify `system_sleep`** (no in-process idle detection yet — `capture_trigger` is NULL); both are accepted v1 degradations with idle-detection/audio as future slices. The `SCREENPIPE_DB` env var + `Config::screenpipe_db` field have been removed (the daemon never reads a screenpipe DB anymore).
 >
 > Column contract: `capture_frames` mirrors screenpipe's `frames` read-subset (`app_name`/`window_name`/`browser_url`/`timestamp`/`capture_trigger` + `full_text`(OCR)/`accessibility_text`(a11y)/`text_source`, resolved by `COALESCE(full_text, accessibility_text)`); `capture_ui_events` mirrors the `ui_events` read-subset (`event_type`/`app_name`/`text_content`/`timestamp`). **Inverted ownership:** these tables are written by the *tray*, read by the *daemon*.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -27,13 +27,10 @@ these break whenever `runner.rs` or `extractor.rs` changes. test ALL of these af
 - [ ] **meridian DB path override** — `MERIDIAN_DB=/tmp/test.db ./meridian`; DB created at the custom path, not the default.
 - [ ] **tilde expansion in env vars** — `MERIDIAN_DB=~/custom/meridian.db`; tilde expanded correctly to home directory.
 
-### 3. screenpipe DB compatibility
+### 3. capture DB compatibility
 
-- [ ] **missing screenpipe DB** — `SCREENPIPE_DB=/nonexistent.db ./meridian`; daemon exits with a clear, readable error message (not a panic).
-- [ ] **empty screenpipe DB** — screenpipe DB exists but contains zero frames; ETL runs without crash, no sessions written, cursor remains at 0.
-- [ ] **screenpipe DB opened read-only** — verify no write lock is held on screenpipe's DB while meridian is running (screenpipe must continue writing frames unimpeded).
-- [ ] **WAL mode** — both DBs operating in WAL mode; no `SQLITE_BUSY` or `SQLITE_LOCKED` errors under concurrent read/write.
-- [ ] **screenpipe DB path override** — `SCREENPIPE_DB=/custom/path.db`; daemon reads from the custom path.
+- [ ] **empty capture DB** — no capture_frames rows yet; ETL runs without crash, no sessions written, cursor remains at 0.
+- [ ] **WAL mode** — meridian.db operating in WAL mode; no `SQLITE_BUSY` or `SQLITE_LOCKED` errors under concurrent read/write from the tray-side capture writer.
 
 ### 4. session data extraction
 

--- a/npm/meridian-darwin-arm64/package.json
+++ b/npm/meridian-darwin-arm64/package.json
@@ -16,7 +16,6 @@
   ],
   "files": [
     "bin/",
-    "ui.tar.gz",
     "services/",
     "scripts/",
     ".env.example",

--- a/scripts/com.meridiona.daemon.plist
+++ b/scripts/com.meridiona.daemon.plist
@@ -37,8 +37,6 @@
              ahead of the system defaults. -->
         <key>PATH</key>
         <string>{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-        <key>SCREENPIPE_DB</key>
-        <string>{{HOME}}/.screenpipe/db.sqlite</string>
         <key>MERIDIAN_DB</key>
         <string>{{HOME}}/.meridian/meridian.db</string>
         <key>POLL_INTERVAL_SECS</key>

--- a/scripts/install-from-bundle.sh
+++ b/scripts/install-from-bundle.sh
@@ -129,30 +129,6 @@ source "${APP_ROOT}/scripts/lib-trello-setup.sh"
 GUI_TARGET="gui/$(id -u)"
 LAUNCH_AGENTS="${HOME}/Library/LaunchAgents"
 
-# Retire the legacy standalone dashboard Node server. The dashboard now ships
-# embedded INSIDE the tray binary (static export, no Node server), so any
-# `com.meridiona.ui` launchd agent from a pre-fold install is a zombie — a
-# KeepAlive=true Node server holding the old dashboard port. Boot it out + remove
-# its plist, and drop the now-orphaned ABI-matched Node runtime cache. Idempotent
-# (no-op when absent) and non-fatal (a launchctl hiccup must not abort the
-# update) — but logged, never silent.
-retire_legacy_ui_server() {
-    local label="com.meridiona.ui"
-    local plist="${LAUNCH_AGENTS}/${label}.plist"
-    if launchctl print "${GUI_TARGET}/${label}" >/dev/null 2>&1; then
-        info "Retiring the legacy dashboard server (now bundled in the tray app)…"
-        launchctl bootout "${GUI_TARGET}/${label}" 2>/dev/null \
-            || warn "could not bootout ${label} (continuing)"
-    fi
-    if [[ -f "${plist}" ]]; then
-        rm -f "${plist}" && ok "removed legacy ${label} launchd agent" \
-            || warn "could not remove ${plist} (continuing)"
-    fi
-    # The pinned Node runtime existed only to ABI-match better-sqlite3 in the old
-    # server; nothing uses it now.
-    rm -rf "${HOME}/.meridian/node-runtime" 2>/dev/null || true
-}
-
 # Enable accessibility mode in VS Code / Cursor / Antigravity so screenpipe
 # captures their a11y tree instead of falling back to OCR. Chromium/Electron
 # editors only expose their AX tree when editor.accessibilitySupport = "on"
@@ -477,11 +453,6 @@ fi
 # Enable a11y mode in installed VS Code-family editors (idempotent). Without
 # this, screenpipe falls back to OCR for those editors instead of their a11y tree.
 configure_editor_accessibility
-
-# ── 5b. Retire the legacy dashboard Node server (one-time, for pre-fold installs) ─
-# The dashboard is now embedded in the tray binary, so an old standalone UI agent
-# is a zombie. This runs on every (re)install/update — idempotent + non-fatal.
-retire_legacy_ui_server
 
 # ── 6. Daemons — restart only what changed ───────────────────────────────────
 # screenpipe: external npm binary, plist may have changed → always refresh.

--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -11,7 +11,6 @@ REPO_ROOT="$(cd "$(dirname "$SELF")/.." && pwd)"
 # --- constants ---
 LABEL_SCREENPIPE="com.meridiona.screenpipe"
 LABEL_DAEMON="com.meridiona.daemon"
-LABEL_UI="com.meridiona.ui"
 LABEL_MLX="com.meridiona.mlx-server"
 # Capture runs in-process in the tray (no screenpipe launchd agent since Bucket-2).
 # Jira worklogs and coding-agent ingest run inside the Rust daemon — no
@@ -279,7 +278,6 @@ _doctor_fallback() {
     _plist_row "$LABEL_DAEMON" "daemon plist"
     _plist_row "$LABEL_SCREENPIPE" "screenpipe plist"
     _plist_row "$LABEL_MLX" "mlx plist"
-    _plist_row "$LABEL_UI" "ui plist"
     _group "builds"
     _row "$([[ -f "${REPO_ROOT}/packages/meridian-mcp/dist/index.js" ]] && echo ok || echo fail)" "mcp built" ""
     _row "$([[ -d "${REPO_ROOT}/ui/.next" ]] && echo ok || echo fail)" "ui built" ""
@@ -691,24 +689,10 @@ _dev_wait_mlx() {
 _dev_build_daemon() { info "building daemon (cargo --release)…"; ( cd "${REPO_ROOT}" && cargo build --release ); }
 _dev_build_ui()     { info "building UI (npm run build)…";       ( cd "${REPO_ROOT}/ui" && npm run build ); }
 
-# Stop the launchd (production) dashboard so `next dev` can bind its port.
-# Disable too, so KeepAlive doesn't race to relaunch the prod server.
-_dev_stop_prod_ui() {
-    if launchctl print "${GUI_TARGET}/${LABEL_UI}" >/dev/null 2>&1; then
-        set +e
-        launchctl disable "${GUI_TARGET}/${LABEL_UI}" 2>/dev/null
-        launchctl bootout  "${GUI_TARGET}/${LABEL_UI}" 2>/dev/null
-        set -e
-        info "stopped launchd dashboard (freeing the port for the dev server)"
-    fi
-}
-
 # Run the Next.js dev server in the FOREGROUND (hot reload). Replaces this shell
 # (exec), so Ctrl-C stops just the UI server — backing services keep running.
-# Re-enable the prod dashboard later with `meridian start`.
 _dev_ui_server() {
     local port="${MERIDIAN_UI_PORT:-3939}"
-    _dev_stop_prod_ui
     echo
     info "UI dev server (hot reload) → http://localhost:${port}   ·   Ctrl-C to stop"
     info "edit-and-save reflects instantly; backing services keep running in the background"

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,7 +94,6 @@ impl PmProviderConfig {
 // ---------------------------------------------------------------------------
 
 pub struct Config {
-    pub screenpipe_db: String,
     pub meridian_db: String,
     pub poll_interval_secs: u64,
     /// All configured PM providers. Empty = intelligence silently disabled.
@@ -331,7 +330,6 @@ impl Config {
     /// Build config from environment variables, falling back to defaults.
     ///
     /// Core vars:
-    ///   SCREENPIPE_DB       — path to screenpipe's SQLite file
     ///   MERIDIAN_DB         — path to meridian's SQLite file
     ///   POLL_INTERVAL_SECS  — poll cadence in seconds (default 60)
     ///
@@ -347,13 +345,6 @@ impl Config {
     ///   LINEAR_API_KEY
     ///   LINEAR_TEAM_IDS     — optional comma-separated filter
     pub fn from_env() -> Self {
-        let screenpipe_db = std::env::var("SCREENPIPE_DB")
-            .map(|v| expand_tilde(&v))
-            .unwrap_or_else(|_| {
-                let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_owned());
-                format!("{}/.screenpipe/db.sqlite", home)
-            });
-
         let meridian_db = std::env::var("MERIDIAN_DB")
             .map(|v| expand_tilde(&v))
             .unwrap_or_else(|_| {
@@ -428,7 +419,6 @@ impl Config {
         let provider_names: Vec<&str> = pm_providers.iter().map(|p| p.provider_name()).collect();
 
         tracing::info!(
-            screenpipe_db = %screenpipe_db,
             meridian_db = %meridian_db,
             poll_interval_secs,
             classification_enabled,
@@ -437,7 +427,6 @@ impl Config {
         );
 
         Self {
-            screenpipe_db,
             meridian_db,
             poll_interval_secs,
             pm_providers,
@@ -454,10 +443,6 @@ impl Config {
             jira_office_end_hour,
             runtime,
         }
-    }
-
-    pub fn screenpipe_db_uri(&self) -> String {
-        format!("sqlite://{}", self.screenpipe_db)
     }
 
     pub fn meridian_db_uri(&self) -> String {
@@ -488,11 +473,9 @@ mod tests {
     #[test]
     fn test_default_paths_contain_expected_dirs() {
         let _guard = env_lock().lock().unwrap();
-        std::env::remove_var("SCREENPIPE_DB");
         std::env::remove_var("MERIDIAN_DB");
         std::env::set_var("HOME", "/tmp/test_home");
         let cfg = Config::from_env();
-        assert!(cfg.screenpipe_db.contains(".screenpipe"));
         assert!(cfg.meridian_db.contains(".meridian"));
         std::env::remove_var("HOME");
     }
@@ -500,15 +483,12 @@ mod tests {
     #[test]
     fn test_env_overrides() {
         let _guard = env_lock().lock().unwrap();
-        std::env::set_var("SCREENPIPE_DB", "/custom/screenpipe.db");
         std::env::set_var("MERIDIAN_DB", "/custom/meridian.db");
         let cfg = Config::from_env();
-        assert_eq!(cfg.screenpipe_db, "/custom/screenpipe.db");
         assert_eq!(cfg.meridian_db, "/custom/meridian.db");
         // poll_interval_secs is driven by settings.json (runtime), not POLL_INTERVAL_SECS env var.
         // Default runtime value is 60 when settings.json is absent.
         assert_eq!(cfg.runtime.poll_interval_secs, cfg.poll_interval_secs);
-        std::env::remove_var("SCREENPIPE_DB");
         std::env::remove_var("MERIDIAN_DB");
     }
 
@@ -526,11 +506,11 @@ mod tests {
     fn test_tilde_expansion() {
         let _guard = env_lock().lock().unwrap();
         std::env::set_var("HOME", "/Users/testuser");
-        std::env::set_var("SCREENPIPE_DB", "~/custom/db.sqlite");
+        std::env::set_var("MERIDIAN_DB", "~/custom/db.sqlite");
         let cfg = Config::from_env();
-        assert_eq!(cfg.screenpipe_db, "/Users/testuser/custom/db.sqlite");
+        assert_eq!(cfg.meridian_db, "/Users/testuser/custom/db.sqlite");
         std::env::remove_var("HOME");
-        std::env::remove_var("SCREENPIPE_DB");
+        std::env::remove_var("MERIDIAN_DB");
     }
 
     #[test]
@@ -665,12 +645,9 @@ mod tests {
     #[test]
     fn test_uri_prefix() {
         let _guard = env_lock().lock().unwrap();
-        std::env::set_var("SCREENPIPE_DB", "/some/path/db.sqlite");
         std::env::set_var("MERIDIAN_DB", "/other/meridian.db");
         let cfg = Config::from_env();
-        assert!(cfg.screenpipe_db_uri().starts_with("sqlite://"));
         assert!(cfg.meridian_db_uri().starts_with("sqlite://"));
-        std::env::remove_var("SCREENPIPE_DB");
         std::env::remove_var("MERIDIAN_DB");
     }
 

--- a/src/health/platform.rs
+++ b/src/health/platform.rs
@@ -204,8 +204,8 @@ fn venv_check() -> Check {
 }
 
 /// Returns a single Info check confirming the dashboard is embedded in the
-/// Tauri binary. The `com.meridiona.ui` launchd agent was retired with the
-/// Next-fold (PR #298); probing for its plist always produces a false CRITICAL
+/// Tauri binary. The legacy standalone-UI launchd agent was retired with the
+/// Next-fold (PR #298); probing for its plist always produced a false CRITICAL
 /// on healthy post-fold installs.
 pub fn ui_service() -> Vec<Check> {
     vec![Check::info(

--- a/src/health/ui.rs
+++ b/src/health/ui.rs
@@ -1,9 +1,9 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 //
 // Dashboard health — the dashboard is now a static export embedded in the
-// Tauri binary (no separate Node server or launchd `com.meridiona.ui` agent).
-// The Node-era HTTP probes (`serve_health`, `serve_mode_check`, asset checks)
-// are gone; `doctor` reports an informational line instead of a false CRITICAL.
+// Tauri binary (no separate Node server). The Node-era HTTP probes
+// (`serve_health`, `serve_mode_check`, asset checks) are gone; `doctor` reports
+// an informational line instead of a false CRITICAL.
 
 use crate::config::Config;
 use crate::health::Check;

--- a/tests/install/test_plist_lint.sh
+++ b/tests/install/test_plist_lint.sh
@@ -14,8 +14,4 @@ start_test "plutil -lint: com.meridiona.screenpipe.plist"
 assert_ok "plutil -lint: com.meridiona.screenpipe.plist" \
     plutil -lint "${REPO_ROOT}/scripts/com.meridiona.screenpipe.plist"
 
-start_test "plutil -lint: com.meridiona.ui.plist"
-assert_ok "plutil -lint: com.meridiona.ui.plist" \
-    plutil -lint "${REPO_ROOT}/scripts/com.meridiona.ui.plist"
-
 exit "$FAIL_COUNT"

--- a/tests/install/test_plist_render.sh
+++ b/tests/install/test_plist_render.sh
@@ -49,21 +49,4 @@ assert_eq "0" "$_leftover_count" "no leftover placeholders"
 start_test "screenpipe plist: rendered plist passes plutil -lint"
 assert_ok "plutil -lint on rendered screenpipe plist" plutil -lint "$RENDERED_SCREENPIPE"
 
-# --- ui plist ---
-UI_PLIST="${REPO_ROOT}/scripts/com.meridiona.ui.plist"
-RENDERED_UI="${TMPDIR_RENDER}/com.meridiona.ui.rendered.plist"
-
-sed \
-    -e "s|{{REPO_ROOT}}|/tmp/test-repo|g" \
-    -e "s|{{HOME}}|/tmp/test-home|g" \
-    -e "s|{{NPM_BIN}}|/opt/homebrew/bin/npm|g" \
-    "$UI_PLIST" > "$RENDERED_UI"
-
-start_test "ui plist: no leftover {{placeholders}} after render"
-_leftover_count="$(grep -c '{{' "$RENDERED_UI" || true)"
-assert_eq "0" "$_leftover_count" "no leftover placeholders"
-
-start_test "ui plist: rendered plist passes plutil -lint"
-assert_ok "plutil -lint on rendered ui plist" plutil -lint "$RENDERED_UI"
-
 exit "$FAIL_COUNT"

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -125,17 +125,15 @@ async fn install(backend: &Path, home: &Path) -> Result<(), String> {
         .await
         .map_err(|e| format!("mkdir {}: {e}", launch_agents.display()))?;
 
-    // Purge leftovers from a pre-fold / pre-cutover **bundle** install before
-    // staging the in-process backend. A user migrating from the old npm/curl
-    // bundle to this DMG carries launchd agents the new topology either replaced
-    // (the in-process capturer supersedes screenpipe; the tray supervises MLX
-    // itself) or retired (the embedded dashboard replaced the standalone UI
-    // server). Left running they race the tray, contend for :7823, or burn RAM.
-    // `install-from-bundle.sh` boots these out for the bundle path; the DMG path
-    // needs the same. All best-effort + non-fatal.
+    // Purge leftovers from a pre-cutover **bundle** install before staging the
+    // in-process backend. A user migrating from the old npm/curl bundle to this
+    // DMG carries launchd agents the new topology replaced (the in-process
+    // capturer supersedes screenpipe; the tray supervises MLX itself); left
+    // running they race the tray or contend for :7823. `install-from-bundle.sh`
+    // boots these out for the bundle path; the DMG path needs the same. All
+    // best-effort + non-fatal.
     cleanup_legacy_screenpipe(home).await;
     cleanup_legacy_mlx_server(home).await;
-    cleanup_legacy_ui(home).await;
     // Recover tracker credentials the bundle wrote to ~/.meridian/app/.env so the
     // DMG daemon (which reads the canonical ~/.meridian/.env) doesn't lose them.
     migrate_legacy_bundle_env(home).await;
@@ -222,22 +220,6 @@ async fn cleanup_legacy_mlx_server(home: &Path) {
     let _ =
         tokio::fs::remove_file(home.join("Library/LaunchAgents/com.meridiona.mlx-server.plist"))
             .await;
-}
-
-/// Purge a leftover **standalone UI server agent**. Pre-fold, the Next.js
-/// dashboard ran as `com.meridiona.ui` (a `KeepAlive` Node server on
-/// localhost:3939). The fold embeds the dashboard in the tray webview, so a
-/// leftover agent is a zombie Node process burning ~150 MB indefinitely (no port
-/// clash — 3939 is dev-only). Boot it out and remove its plist. Mirrors the
-/// `install-from-bundle.sh` cleanup for the bundle path. Best-effort.
-async fn cleanup_legacy_ui(home: &Path) {
-    let label = "com.meridiona.ui";
-    let target = format!("gui/{}/{label}", crate::sys::uid_str());
-    if launchctl(&["print", &target]).await.is_ok_and(|s| s) {
-        let _ = launchctl(&["bootout", &target]).await;
-        tracing::info!(label, "backend_install: removed leftover UI server agent");
-    }
-    let _ = tokio::fs::remove_file(home.join("Library/LaunchAgents/com.meridiona.ui.plist")).await;
 }
 
 /// Recover tracker credentials when migrating from a **bundle** install. The

--- a/tray/src-tauri/src/commands/setup.rs
+++ b/tray/src-tauri/src/commands/setup.rs
@@ -91,9 +91,8 @@ fn ax_is_trusted() -> bool {
 /// Post-cutover (Gap-2 Bucket 2) capture runs in-process, so the **tray** is
 /// the process that needs Screen Recording. `CGPreflightScreenCaptureAccess()`
 /// reads that grant directly — no prompt, no side effects — replacing the old
-/// `pgrep screenpipe` / `~/.screenpipe/db.sqlite` proxy, which misreported on
-/// an in-process install (no screenpipe process or DB ever exists). The
-/// wizard's *grant* action (which surfaces the system prompt via
+/// external-capture proxy checks that misreported on an in-process install.
+/// The wizard's *grant* action (which surfaces the system prompt via
 /// `CGRequestScreenCaptureAccess`) is separate slice-5 work.
 #[tauri::command]
 #[tracing::instrument]


### PR DESCRIPTION
## Summary
Four groups of dead references from earlier retirements are excised in one pass. All **dead** references go away. One deliberate behavior change: removing `cleanup_legacy_ui` / `retire_legacy_ui_server` drops the one-time purge of a leftover pre-Next-fold `com.meridiona.ui` launchd agent — a passive zombie (dev-only port, no clash), acceptable for the current actively-updating pilot base. The active-conflict purges (`screenpipe`, `mlx-server`) are kept.

### com.meridiona.ui (retired standalone Node dashboard)
- `scripts/meridian-cli.sh` — drop `LABEL_UI`, the doctor's `ui plist` row, and `_dev_stop_prod_ui`
- `scripts/install-from-bundle.sh` — drop `retire_legacy_ui_server` fn + call site
- `tray/src-tauri/src/backend_install.rs` — drop `cleanup_legacy_ui` fn + call site
- `tests/install/test_plist_lint.sh` + `tests/install/test_plist_render.sh` — strip the ui-plist blocks (files stay; they still cover daemon + screenpipe plists)
- `src/health/{ui,platform}.rs` — retouch docstrings that named `com.meridiona.ui`

### ui.tar.gz
- Drop the `ui.tar.gz` entry from `npm/meridian-darwin-arm64/package.json` `files[]` — bundle hasn't shipped it since the tray-embed cutover.

### SCREENPIPE_DB (vestigial post in-process capture)
- `src/config.rs` — drop `screenpipe_db` field, env parse, default, tracing site, struct init, and the `screenpipe_db_uri()` method
- Trim the four config tests to remove SCREENPIPE_DB set/remove/assert (tests keep their MERIDIAN_DB coverage)
- `scripts/com.meridiona.daemon.plist` — drop `<key>SCREENPIPE_DB</key>` entry
- `.env.example` — drop the commented line
- `TESTING.md` §3 — rewrite from "screenpipe DB compatibility" to "capture DB compatibility" (empty capture + WAL)
- `tray/src-tauri/src/commands/setup.rs` — retouch the docstring line referencing the old proxy check

### coding_agent_indexer
Intentionally left alone. What looked like cleanup candidates are all load-bearing:
- `src/coding_agent_session_ingest/db.rs`'s `CATEGORY_METHOD = "coding_agent_indexer"` is the DB row provenance label — data continuity.
- Migration comments in 025-027 are immutable historical text.
- `services/scripts/install-claude-hook.sh`'s `OUR_MARKERS` tuple + `scripts/uninstall-daemon.sh`'s legacy boot-out loop are functional upgrade cleanups that still purge pre-port installs.

## Test plan
- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test -p meridian --lib config::` — 17 config tests pass
- [x] `bash tests/install/test_plist_lint.sh` — daemon + screenpipe plists lint
- [x] `bash tests/install/test_plist_render.sh` — daemon + screenpipe plists render + lint
- [ ] Manual: fresh install still boots (no dependence on the removed cleanup helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
