### PR TITLE
ci: run CI on pushes and PRs targeting pre-main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, pre-main]
   pull_request:
-    branches: [main]
+    branches: [main, pre-main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Add `pre-main` to the `push` and `pull_request` branch filters in `.github/workflows/ci.yml` so the full CI gate runs on pre-main PRs and merges — not just at `pre-main → main`.

```diff
 on:
   push:
-    branches: [main]
+    branches: [main, pre-main]
   pull_request:
-    branches: [main]
+    branches: [main, pre-main]
```

## Why
CI triggered only on `main` / PRs to `main`. The recent feature PRs opened against `pre-main` got **zero** automated checks (only CodeRabbit, disabled for that base), so the Rust + UI + migration-guard + license-pin suite ran only at promotion time. This closes that gap — the same `fmt + clippy + cargo test`, UI `bun test` + build, `migration-guard`, and `screenpipe-license-pin` jobs now run on every pre-main PR.

The `migration-guard` job is already base-branch-agnostic (`if: github.event_name == 'pull_request'`, diffs `base.sha...HEAD`), so it guards pre-main PRs with no change.

## Note on rollout
GitHub uses the **base branch's** workflow file for `pull_request` events, so this takes effect for pre-main PRs only **after it merges into `pre-main`**. This PR itself (and the other open pre-main PRs) won't show the new checks until then; re-pushing or reopening them afterward will trigger CI.

## Test plan
- [x] YAML validated (parses to `push`/`pull_request` → `[main, pre-main]`).
- [x] Pre-push suite green.
- [ ] After merge: open/re-push a pre-main PR and confirm the `Rust` / `UI` / `Migrations append-only` / `screenpipe MIT pin` checks appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)