### PR TITLE
test: move tray popover tests into ui/__tests__ (bun auto-discovers)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -49,9 +49,11 @@ if [[ $FAIL -ne 0 ]]; then
   exit 1
 fi
 
-# ── Wave 2: clippy + UI tests + tray popover tests (independent; start together) ─
+# ── Wave 2: clippy + UI tests (independent of each other, start together) ───
+# The `ui` bun test run also covers the tray popover's JS tests — they live in
+# ui/__tests__ so this single run discovers them (no separate tray runner).
 echo ""
-echo "[wave 2/3] cargo clippy  +  ui tests  +  tray popover tests"
+echo "[wave 2/3] cargo clippy  +  ui tests"
 
 run_check "cargo clippy" cargo clippy -- -D warnings &
 W2_CLIPPY=$!
@@ -59,18 +61,12 @@ W2_CLIPPY=$!
 run_check "ui tests" bash -c "cd '$REPO_ROOT/ui' && bun test" &
 W2_UI=$!
 
-# The tray popover (tray/src) is plain HTML+JS outside the ui/ Next app, so its
-# bun tests are not discovered by the ui run above — run them explicitly.
-run_check "tray popover tests" bash -c "cd '$REPO_ROOT/tray/src' && bun test" &
-W2_TRAY=$!
-
 wait $W2_CLIPPY || FAIL=1
 wait $W2_UI || FAIL=1
-wait $W2_TRAY || FAIL=1
 
 if [[ $FAIL -ne 0 ]]; then
   echo ""
-  echo "Wave 2 failed — fix clippy/UI test/tray test errors before pushing."
+  echo "Wave 2 failed — fix clippy/UI test errors before pushing."
   exit 1
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -49,9 +49,9 @@ if [[ $FAIL -ne 0 ]]; then
   exit 1
 fi
 
-# ── Wave 2: clippy + UI tests (independent of each other, start together) ───
+# ── Wave 2: clippy + UI tests + tray popover tests (independent; start together) ─
 echo ""
-echo "[wave 2/3] cargo clippy  +  ui tests"
+echo "[wave 2/3] cargo clippy  +  ui tests  +  tray popover tests"
 
 run_check "cargo clippy" cargo clippy -- -D warnings &
 W2_CLIPPY=$!
@@ -59,12 +59,18 @@ W2_CLIPPY=$!
 run_check "ui tests" bash -c "cd '$REPO_ROOT/ui' && bun test" &
 W2_UI=$!
 
+# The tray popover (tray/src) is plain HTML+JS outside the ui/ Next app, so its
+# bun tests are not discovered by the ui run above — run them explicitly.
+run_check "tray popover tests" bash -c "cd '$REPO_ROOT/tray/src' && bun test" &
+W2_TRAY=$!
+
 wait $W2_CLIPPY || FAIL=1
 wait $W2_UI || FAIL=1
+wait $W2_TRAY || FAIL=1
 
 if [[ $FAIL -ne 0 ]]; then
   echo ""
-  echo "Wave 2 failed — fix clippy/UI test errors before pushing."
+  echo "Wave 2 failed — fix clippy/UI test/tray test errors before pushing."
   exit 1
 fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,15 @@ jobs:
         run: bun test
         working-directory: ui
 
+      # The tray popover is plain HTML+JS (not part of the ui/ Next app), so its
+      # bun tests live under tray/src and are NOT discovered by the `ui` run
+      # above. Run them explicitly — they're pure-logic (pause-utils) + a
+      # happy-dom-free require, so no install is needed beyond the bun already
+      # set up for this job.
+      - name: Tray popover tests
+        run: bun test
+        working-directory: tray/src
+
       - name: UI build
         run: npm run build
         working-directory: ui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,18 +91,12 @@ jobs:
         run: npm ci
         working-directory: ui
 
+      # `bun test` here also covers the tray popover's JS tests — they live in
+      # ui/__tests__ (popover-pause-utils, popover-health-panel) even though the
+      # popover source is tray/src, precisely so this one run discovers them.
       - name: UI tests
         run: bun test
         working-directory: ui
-
-      # The tray popover is plain HTML+JS (not part of the ui/ Next app), so its
-      # bun tests live under tray/src and are NOT discovered by the `ui` run
-      # above. Run them explicitly — they're pure-logic (pause-utils) + a
-      # happy-dom-free require, so no install is needed beyond the bun already
-      # set up for this job.
-      - name: Tray popover tests
-        run: bun test
-        working-directory: tray/src
 
       - name: UI build
         run: npm run build

--- a/ui/__tests__/popover-pause-utils.test.js
+++ b/ui/__tests__/popover-pause-utils.test.js
@@ -1,7 +1,12 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 'use strict'
 
-const { fmtCountdown, parsePauseMins, pauseLabel } = require('../pause-utils.js')
+// Tests the tray popover's pause helpers (tray/src/pause-utils.js). The popover
+// is plain HTML+JS outside the Next app, but this test lives here in
+// ui/__tests__ — alongside popover-health-panel.test.ts — so the single
+// `bun test` run (CI + pre-push, both `working-directory: ui`) auto-discovers
+// it; no separate runner or CI step needed.
+const { fmtCountdown, parsePauseMins, pauseLabel } = require('../../tray/src/pause-utils.js')
 
 // ── US-1: Quick preset pause ─────────────────────────────────────────────────
 // The preset buttons pass a fixed `data-secs` value straight to


### PR DESCRIPTION
## Summary
Run `tray/src/__tests__/pause.test.js` under CI + pre-push by **moving it into `ui/__tests__`** (renamed `popover-pause-utils.test.js`), so the single existing `bun test` run auto-discovers it — no bespoke CI step or extra hook line.

## Why (updated approach)
`pause.test.js` — 33 pure-logic tests for the popover's pause helpers (`parsePauseMins` / `fmtCountdown` / `pauseLabel`) — was never run: CI and the pre-push hook invoke `bun test` only with `working-directory: ui`, and bun only discovers tests under its cwd.

The first cut added an explicit `bun test` step in `tray/src` to both CI and the hook. Simpler, per review feedback: just move the test to `ui/__tests__`, where the popover's other test (`popover-health-panel.test.ts`) already lives. bun then picks it up in the one run, and the extra CI step + pre-push line are reverted.

## Details
- `git mv tray/src/__tests__/pause.test.js → ui/__tests__/popover-pause-utils.test.js` (94% unchanged); require path repointed to `../../tray/src/pause-utils.js`.
- Reverted the `Tray popover tests` step in `ci.yml` and the wave-2 tray line in `.githooks/pre-push`.
- File stays plain `.js` (require-based, matching `pause-utils.js`'s CommonJS export). `ui/tsconfig.json` `include` globs only `**/*.ts(x)`, so `npm run build` doesn't typecheck it; `bun test` runs it fine.

## Test plan
- [x] `cd ui && bun test` → **268 pass** (includes the 33 moved pause-utils tests).
- [x] `cd ui && npm run build` clean (the `.js` test isn't in the tsc include set).
- [x] `ci.yml` YAML valid; `bash -n .githooks/pre-push` clean.
- [x] Pre-push hook exercised on push — `ui tests` covers the moved test, no separate tray step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)