### PR TITLE
fix(timeline): scope Overview panel's day label and Focus stats to the viewed day

### DIFF
--- a/tray/src-tauri/src/commands/dashboard.rs
+++ b/tray/src-tauri/src/commands/dashboard.rs
@@ -38,17 +38,20 @@ pub async fn get_active(
 }
 
 /// The Today dashboard payload, computed entirely in Rust (the ported
-/// /api/today). Resolves "today" (local) + "now" here so the core fn stays
-/// deterministic/testable.
+/// /api/today). `day` defaults to today (local) when omitted, matching
+/// [`crate::commands::get_worklogs`] — the timeline's Overview panel passes
+/// the currently-viewed day so Focus/Time-by-app track the selected date
+/// instead of always the real "today".
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_today(
     pool: State<'_, Option<meridian_core::SqlitePool>>,
+    day: Option<String>,
 ) -> Result<meridian_core::today::TodayResponse, String> {
     let Some(pool) = pool.inner() else {
         return Err("meridian.db is not open yet".to_string());
     };
-    let date = meridian_core::date::today_string();
+    let date = day.unwrap_or_else(meridian_core::date::today_string);
     let now = chrono::Utc::now().to_rfc3339();
     meridian_core::today::get_today(pool, &date, &now)
         .await

--- a/ui/components/timeline/OverviewPanel.tsx
+++ b/ui/components/timeline/OverviewPanel.tsx
@@ -18,7 +18,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { fmtDur } from '@/components/atoms'
 import { load as loadData, mutate as mutateData, openExternal } from '@/lib/bridge'
 import type { PlanItem, PlanResponse } from '@/lib/api-types'
-import { isPending } from './types'
+import { formatDayLabel, isPending } from './types'
 import { TimeByApp, appTotals } from './TimeByApp'
 import type { TimelineData } from './useTimelineData'
 import type { ActiveModal } from './MeridianTimelineShell'
@@ -28,7 +28,8 @@ export function OverviewPanel({ data, onOpen, onOpenTask }: {
   onOpen: (modal: ActiveModal) => void
   onOpenTask: (key: string, title?: string) => void
 }) {
-  const { today, isSolo, items, cleanupIssueCount, tasks } = data
+  const { today, isSolo, items, cleanupIssueCount, tasks, isToday, day } = data
+  const dayLabel = isToday ? 'Today' : formatDayLabel(day)
   const pendingCount = items.filter(isPending).length
   const focus_s = today?.focus_s ?? 0
   const appTops = today ? appTotals(today.sessions) : []
@@ -86,7 +87,7 @@ export function OverviewPanel({ data, onOpen, onOpenTask }: {
     })
   }, [])
 
-  const greetingEyebrow = 'Today at a glance'
+  const greetingEyebrow = isToday ? 'Today at a glance' : `${dayLabel} at a glance`
   const greetingTitle = isSolo ? 'Your day, in progress' : "You're having a solid day"
   const greetingBody = isSolo
     ? `${fmtDur(focus_s)} of focused activity across ${appCount} app${appCount === 1 ? '' : 's'}.`
@@ -183,7 +184,7 @@ export function OverviewPanel({ data, onOpen, onOpenTask }: {
       <EntryRow label="Tasks" hint={`${activeTaskCount} active`} onClick={() => onOpen('tasks')} />
 
       <div>
-        <p className="mt-label mb-2.5" style={{ color: 'var(--t-faint)' }}>Today</p>
+        <p className="mt-label mb-2.5" style={{ color: 'var(--t-faint)' }}>{dayLabel}</p>
         <div className="grid grid-cols-3 gap-3">
           <Mini label="Logged" value={fmtDur(loggedSeconds)} tint="var(--color-state-approved)" />
           <Mini label="Focus" value={fmtDur(focus_s)} tint="var(--color-state-proposal)" />

--- a/ui/components/timeline/useTimelineData.ts
+++ b/ui/components/timeline/useTimelineData.ts
@@ -91,10 +91,10 @@ export function useTimelineData(day: string) {
       .catch(() => {})
   }, [])
 
-  const loadAux = useCallback(() => {
+  const loadAux = useCallback((d: string) => {
     loadData<IntegrationsResponse>('/api/integrations', 'get_integrations').then(setIntegrations).catch(() => {})
     loadData<TasksResponse>('/api/tasks', 'get_tasks').then((r) => setTasks(r.tasks ?? [])).catch(() => {})
-    loadData<TodayResponse>('/api/today', 'get_today').then(setToday).catch(() => {})
+    loadData<TodayResponse>(`/api/today?day=${d}`, 'get_today', { day: d }).then(setToday).catch(() => {})
     loadData<{ running: boolean }>('/api/daemon/status', 'get_daemon_status')
       .then(s => setCapturing(s.running)).catch(() => {})
   }, [])
@@ -104,11 +104,11 @@ export function useTimelineData(day: string) {
     loadWorklogs(day)
     loadHourStatus(day)
     loadHourReports(day)
-    loadAux()
+    loadAux(day)
     // Poll so approved → posted (daemon sweep), fresh hours, the
     // generating/paused badges, and today's activity reports all stay live.
     const id = setInterval(() => {
-      loadWorklogs(day); loadHourStatus(day); loadHourReports(day); loadAux()
+      loadWorklogs(day); loadHourStatus(day); loadHourReports(day); loadAux(day)
     }, 30_000)
     return () => clearInterval(id)
   }, [day, loadWorklogs, loadHourStatus, loadHourReports, loadAux])


### PR DESCRIPTION
## Summary
- The timeline's right-side Overview panel always showed "Today" as the label, even when browsing a previous date — now it shows the actual day (e.g. "Tue, Jul 7") and only says "Today" when `isToday` is true.
- The Focus stat and Time-by-app chart were sourced from `get_today`, which was hardcoded to the real current day — so browsing a past date still showed live/today's numbers. `get_today` now takes an optional `day` param (same pattern as `get_worklogs`/`get_hour_status`), and the frontend passes the currently-viewed day through.

## Test plan
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test` (via pre-push hook)
- [x] UI build + UI tests (via pre-push hook)
- [x] Verified `meridian_core::today::get_today` returns correct per-day `focus_s` against the real DB for several past days
- [ ] Manually reload the tray app and click through previous days to confirm the label and stats update correctly