### PR TITLE
chore: stop duplicate worklog_hour runs from concurrent daemons

### DIFF
--- a/dev-start.sh
+++ b/dev-start.sh
@@ -56,6 +56,13 @@ fi
 # The Rust daemon binds a unix socket (~/.meridian/daemon.sock) and the MLX
 # server binds port 7823. `npm run tauri dev` manages the Next.js dev server
 # lifecycle internally (beforeDevCommand) — killing it here is enough.
+#
+# Also stops the CANONICAL launchd-managed daemon (com.meridiona.daemon), if
+# a packaged/npm install of Meridian is also present on this machine. Without
+# this, both the launchd daemon and the dev-build daemon started below run
+# concurrently against the same meridian.db, each independently firing the
+# clock-aligned worklog-hour trigger — producing two worklog runs (two
+# distinct trace_ids, near-duplicate results) for the same hour window.
 # ---------------------------------------------------------------------------
 echo "→ stopping any previous dev run…"
 pkill -f 'cargo-watch.*--bin meridian'  2>/dev/null || true   # daemon file-watcher
@@ -64,6 +71,11 @@ pkill -f 'uvicorn agents.server:app'    2>/dev/null || true   # MLX dev server
 pkill -f 'tauri dev'                    2>/dev/null || true   # tray file-watcher
 pkill -f 'target/debug/meridian-tray$'  2>/dev/null || true   # tray binary
 pkill -f 'Meridian Dev.app'             2>/dev/null || true   # stale dev .app bundle
+if launchctl print "gui/$(id -u)/com.meridiona.daemon" >/dev/null 2>&1; then
+    launchctl disable "gui/$(id -u)/com.meridiona.daemon" 2>/dev/null || true
+    launchctl bootout "gui/$(id -u)/com.meridiona.daemon" 2>/dev/null || true
+    echo "  ✓ stopped canonical launchd daemon (com.meridiona.daemon) — re-enable with: meridian start"
+fi
 sleep 1   # let sockets / ports free before the new windows bind them
 # Clear the Next.js build cache so stale module references (e.g. a deleted
 # instrumentation.ts) don't cause beforeDevCommand to fail on the next run.

--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -111,6 +111,24 @@ cmd_stop() {
         pkill -f "mlx_lm.server" 2>/dev/null || true
         info "killed orphaned mlx_lm.server process(es)"
     fi
+    # Kill any orphaned dev-build daemons (`cargo watch`/`cargo run --bin
+    # meridian` from dev-start.sh, or a bare `cargo run`) — not tracked by
+    # launchd, so `bootout` above never touches them. Closing the Terminal
+    # window a dev session runs in (instead of Ctrl-C, or re-running
+    # dev-start.sh, which has its own cleanup) reparents this chain to PID 1
+    # and it silently keeps running — including its clock-aligned worklog
+    # trigger, which then races the canonical daemon and double-runs every
+    # hour's worklog pipeline. Anchored to the debug/release binary path so
+    # this never matches the canonical `~/.meridian/bin/meridian` or the
+    # `meridian`/`meridian-daemon` CLI wrappers.
+    if pgrep -f "target/(debug|release)/meridian$" >/dev/null 2>&1; then
+        pkill -f "target/(debug|release)/meridian$" 2>/dev/null || true
+        info "killed orphaned dev-build daemon process(es)"
+    fi
+    if pgrep -f "cargo-watch.*--bin meridian" >/dev/null 2>&1; then
+        pkill -f "cargo-watch.*--bin meridian" 2>/dev/null || true
+        info "killed orphaned cargo-watch process(es)"
+    fi
 }
 
 # --- restart ---


### PR DESCRIPTION
## Summary
- Root cause of duplicate `worklog_hour` pipeline runs (two near-identical runs per hour, distinct trace_ids) traced to two `meridian` daemon processes running concurrently against the same `meridian.db` — each independently fires the clock-aligned worklog trigger.
- `meridian stop` now also sweeps orphaned dev-build daemon/`cargo-watch` processes (reparented to PID 1 when a dev Terminal window is closed instead of Ctrl-C'd), not just the launchd-managed one.
- `dev-start.sh` now also stops the canonical launchd daemon before starting a fresh dev session — previously it never touched it, so a legitimate dev session and the always-on packaged daemon would both run and both race the worklog trigger.

## Test plan
- [x] `bash -n` syntax check on both scripts
- [x] Verified `pgrep -f`/`pkill -f` extended-regex alternation works on macOS's BSD pgrep/pkill
- [x] Live-reproduced and resolved the actual duplicate-daemon scenario on a dev machine (two `meridian` processes running, confirmed via `ps`, stopped the launchd one, confirmed only one remained)
- [x] Full pre-push suite (fmt, clippy, ui build/tests, security audit, cargo test) passed on push — no Rust code touched, these are bash-only changes