### PR TITLE
feat(timeline): show only TLDR inline for solo-mode hours

### DIFF
--- a/ui/components/timeline/ActivityReport.tsx
+++ b/ui/components/timeline/ActivityReport.tsx
@@ -13,6 +13,18 @@
 import ReactMarkdown from 'react-markdown'
 import type { Components } from 'react-markdown'
 
+/**
+ * Pull just the "### TLDR" paragraph out of an activity-report markdown
+ * string — used by the timeline row, which shows only the TLDR inline and
+ * defers the full report (Core Tasks/Decisions/Resources) to the right-side
+ * hour-detail panel on click. Falls back to the whole report if no TLDR
+ * heading is found (defensive — the prompt always emits one).
+ */
+export function extractTldr(report: string): string {
+  const match = report.match(/###\s*TLDR\s*\n+([\s\S]*?)(?=\n###|\s*$)/i)
+  return match ? match[1].trim() : report.trim()
+}
+
 export function ActivityReport({ report, compact = false }: { report: string; compact?: boolean }) {
   const bodyClass = compact ? 'mt-body-sm' : 'mt-body'
   const components: Components = {

--- a/ui/components/timeline/ActivityReport.tsx
+++ b/ui/components/timeline/ActivityReport.tsx
@@ -25,6 +25,40 @@ export function extractTldr(report: string): string {
   return match ? match[1].trim() : report.trim()
 }
 
+/**
+ * The timeline row's inline preview of an hour's report — a small tinted
+ * card (not raw ReactMarkdown output dropped straight into the row) with a
+ * "SUMMARY" label, a 2-line-clamped TLDR, and a hover affordance hinting
+ * that the row opens the full report (Core Tasks/Decisions/Resources) in
+ * the right panel.
+ */
+export function TldrPreview({ report }: { report: string }) {
+  const tldr = extractTldr(report)
+  return (
+    <div className="group rounded-md px-3 py-2.5 bg-box transition-colors">
+      <div className="flex items-center justify-between gap-2 mb-1">
+        <span className="mt-label" style={{ color: 'var(--color-state-proposal)' }}>✦ Summary</span>
+        <span className="mt-chip shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+          style={{ color: 'var(--color-state-proposal)' }}>
+          Full report ›
+        </span>
+      </div>
+      <p
+        className="mt-body-sm"
+        style={{
+          color: 'var(--t-muted)',
+          display: '-webkit-box',
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: 'vertical',
+          overflow: 'hidden',
+        }}
+      >
+        {tldr}
+      </p>
+    </div>
+  )
+}
+
 export function ActivityReport({ report, compact = false }: { report: string; compact?: boolean }) {
   const bodyClass = compact ? 'mt-body-sm' : 'mt-body'
   const components: Components = {

--- a/ui/components/timeline/TimelineColumn.tsx
+++ b/ui/components/timeline/TimelineColumn.tsx
@@ -20,7 +20,7 @@ import { hourLabel } from './timelineLayout'
 import { isPending, itemKey } from './types'
 import { TimelineCard } from './TimelineCard'
 import { HourBadges, HourTakeover } from './HourBadges'
-import { ActivityReport, extractTldr } from './ActivityReport'
+import { TldrPreview } from './ActivityReport'
 
 interface HourActivity {
   cats: string[]        // distinct category keys seen this hour (for the dots)
@@ -176,13 +176,12 @@ export function TimelineColumn({
                       {!hasContent ? (
                         <p className="mt-body-sm italic py-1.5" style={{ color: 'var(--t-faint-2)' }}>Quiet</p>
                       ) : isSolo && report ? (
-                        // Row shows just the TLDR once the hour's report has
-                        // been generated — the full report (Core Tasks/
-                        // Decisions/Resources) opens in the right panel on
-                        // click (row is already onSelectHour-clickable).
-                        <div className="py-1">
-                          <ActivityReport report={extractTldr(report)} compact />
-                        </div>
+                        // Row shows just the TLDR, in a small tinted card,
+                        // once the hour's report has been generated — the
+                        // full report (Core Tasks/Decisions/Resources) opens
+                        // in the right panel on click (row is already
+                        // onSelectHour-clickable).
+                        <TldrPreview report={report} />
                       ) : isSolo && activity ? (
                         // Report not generated yet — fall back to the coarse
                         // session-derived one-liner so the row isn't empty.

--- a/ui/components/timeline/TimelineColumn.tsx
+++ b/ui/components/timeline/TimelineColumn.tsx
@@ -2,13 +2,13 @@
 //
 // The scrollable vertical hour timeline — one CSS Grid row per hour of the day
 // (`62px 1fr`). Connected users see the hour's worklog/proposal cards stacked
-// vertically; solo users (no tracker) get the hour's real activity-report
-// markdown rendered filling the whole block (get_hour_reports — the same
-// /activity_report LLM output the hour-detail panel shows), falling back to
-// an app-category-dots + one-line summary (drawn from get_today's sessions)
-// only while that hour's report hasn't been generated yet. Clicking an hour
-// selects it (drives the right panel's Overview ↔ Hour-detail switch); the
-// current hour carries a pulsing "now" dot.
+// vertically; solo users (no tracker) get just the hour's TLDR (get_hour_reports
+// — the same /activity_report LLM output the hour-detail panel shows in full),
+// falling back to an app-category-dots + one-line summary (drawn from
+// get_today's sessions) only while that hour's report hasn't been generated
+// yet. Clicking an hour selects it (drives the right panel's Overview ↔
+// Hour-detail switch, which is where the full report — Core Tasks/Decisions/
+// Resources — renders); the current hour carries a pulsing "now" dot.
 
 'use client'
 
@@ -20,7 +20,7 @@ import { hourLabel } from './timelineLayout'
 import { isPending, itemKey } from './types'
 import { TimelineCard } from './TimelineCard'
 import { HourBadges, HourTakeover } from './HourBadges'
-import { ActivityReport } from './ActivityReport'
+import { ActivityReport, extractTldr } from './ActivityReport'
 
 interface HourActivity {
   cats: string[]        // distinct category keys seen this hour (for the dots)
@@ -176,10 +176,12 @@ export function TimelineColumn({
                       {!hasContent ? (
                         <p className="mt-body-sm italic py-1.5" style={{ color: 'var(--t-faint-2)' }}>Quiet</p>
                       ) : isSolo && report ? (
-                        // The whole block renders the hour's actual activity
-                        // report — no truncation — once it's been generated.
+                        // Row shows just the TLDR once the hour's report has
+                        // been generated — the full report (Core Tasks/
+                        // Decisions/Resources) opens in the right panel on
+                        // click (row is already onSelectHour-clickable).
                         <div className="py-1">
-                          <ActivityReport report={report} compact />
+                          <ActivityReport report={extractTldr(report)} compact />
                         </div>
                       ) : isSolo && activity ? (
                         // Report not generated yet — fall back to the coarse


### PR DESCRIPTION
## Summary
- In the Timeline UI, an hour with no PM/tracker context (solo mode) rendered the FULL activity report (TLDR + Core Tasks & Projects + Key Decisions + Resources Consulted) inline in the timeline row — crowding the row and duplicating what's already shown in the right-side hour-detail panel.
- Now the row shows just the TLDR paragraph (`ActivityReport.extractTldr`, pulled from the report markdown via the `### TLDR` heading). Clicking the row (already wired to `onSelectHour`) opens the full report — unchanged — in the right-side `HourDetailPanel`.
- No behavior change for connected (non-solo) users — they never saw the raw activity report inline to begin with (they see ticket-linked `TimelineCard`s).

## Test plan
- [x] `tsc --noEmit` clean on the touched files.
- [x] Pre-push suite (fmt, clippy, ui build/tests, cargo test, security audit) passed.
- [ ] Manual: open the dashboard in solo mode, confirm each generated-report hour shows only the TLDR line, and clicking it opens the full report on the right.