### PR TITLE
feat(coding-agents): widen get_coding_agents to all 4 ingested tools

### DIFF
--- a/meridian-core/src/readers/coding_agents.rs
+++ b/meridian-core/src/readers/coding_agents.rs
@@ -9,8 +9,12 @@
 //! way `today`/the session-interval math does), so neither do we — byte-identical.
 //!
 //! # Who calls this
-//! The tray `get_coding_agents` command → (currently no dashboard consumer; Today
-//! already surfaces agent time via `agent_s`/`agent_segments`). Ported for parity.
+//! The tray `get_coding_agents` command → `ui/components/timeline/OverviewPanel.tsx`
+//! (polled every 30s), which folds the per-agent breakdown into the Time-by-app
+//! chart (`TimeByApp.tsx`'s `appTotals`) — those sessions are excluded from
+//! `get_today`'s `sessions` (a separate overlay stream), so this is the only
+//! source of a real per-tool split. `today`'s `agent_s`/`agent_segments` remain
+//! the combined-across-all-agents total used elsewhere (Focus/Coding stats).
 //!
 //! # Related
 //! - [`crate::intervals::union_seconds`] does the overlap-dedup math.
@@ -23,8 +27,14 @@ use anyhow::Context;
 use serde::Serialize;
 use tracing::Instrument;
 
-/// The agents we attribute (matches the route's `CODING_AGENTS`).
-const CODING_AGENTS: [&str; 2] = ["Claude Code", "Codex"];
+/// The agents we attribute — every `app_name` the coding-agent ingest
+/// pipeline actually writes (CLAUDE.md "Ingested agents" table: Claude Code,
+/// Codex, GitHub Copilot (CLI + VS Code chat share this app_name), Cursor
+/// Agent (Cursor IDE + cursor-agent CLI share this app_name)). Antigravity is
+/// intentionally excluded — its adapter is detection-only and never ingests
+/// sessions (`sources::antigravity`), so it would only ever contribute a
+/// filtered-out zero row.
+const CODING_AGENTS: [&str; 4] = ["Claude Code", "Codex", "GitHub Copilot", "Cursor Agent"];
 
 /// One agent's deduped total for the day.
 #[derive(Debug, Clone, Serialize)]
@@ -68,7 +78,7 @@ pub async fn get_coding_agents(
             FROM app_sessions
             WHERE coding_agent_session_uuid IS NOT NULL
               AND substr(started_at, 1, 10) = ?
-              AND app_name IN ('Claude Code', 'Codex')
+              AND app_name IN ('Claude Code', 'Codex', 'GitHub Copilot', 'Cursor Agent')
             "#,
         )
         .bind(date)

--- a/meridian-core/tests/readers.rs
+++ b/meridian-core/tests/readers.rs
@@ -83,7 +83,10 @@ async fn make_today_pool() -> SqlitePool {
 async fn coding_agents_unions_overlap_per_agent_and_total() {
     let pool = make_pool().await;
     // Claude Code: 10:00–10:10 ∪ 10:05–10:15 → 10:00–10:15 = 900 s.
-    // Codex: 11:00–11:05 = 300 s. No CC/Codex overlap → total = 1200 s.
+    // Codex: 11:00–11:05 = 300 s.
+    // GitHub Copilot: 12:00–12:04 = 240 s.
+    // Cursor Agent: 13:00–13:02 = 120 s.
+    // No overlap across agents → total = 1560 s.
     let rows = [
         (
             "Claude Code",
@@ -100,6 +103,16 @@ async fn coding_agents_unions_overlap_per_agent_and_total() {
             "2026-06-16T11:00:00+00:00",
             "2026-06-16T11:05:00+00:00",
         ),
+        (
+            "GitHub Copilot",
+            "2026-06-16T12:00:00+00:00",
+            "2026-06-16T12:04:00+00:00",
+        ),
+        (
+            "Cursor Agent",
+            "2026-06-16T13:00:00+00:00",
+            "2026-06-16T13:02:00+00:00",
+        ),
     ];
     for (app, s, e) in rows {
         sqlx::query(
@@ -113,13 +126,17 @@ async fn coding_agents_unions_overlap_per_agent_and_total() {
         .await
         .unwrap();
 
-    assert_eq!(r.total_s, 1200);
-    assert_eq!(r.agents.len(), 2);
-    // Sorted descending: Claude Code (900) before Codex (300).
+    assert_eq!(r.total_s, 1560);
+    assert_eq!(r.agents.len(), 4);
+    // Sorted descending: Claude Code (900), Codex (300), GitHub Copilot (240), Cursor Agent (120).
     assert_eq!(r.agents[0].app, "Claude Code");
     assert_eq!(r.agents[0].total_s, 900);
     assert_eq!(r.agents[1].app, "Codex");
     assert_eq!(r.agents[1].total_s, 300);
+    assert_eq!(r.agents[2].app, "GitHub Copilot");
+    assert_eq!(r.agents[2].total_s, 240);
+    assert_eq!(r.agents[3].app, "Cursor Agent");
+    assert_eq!(r.agents[3].total_s, 120);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- `CODING_AGENTS` only listed Claude Code and Codex, silently dropping GitHub Copilot and Cursor Agent sessions from `get_coding_agents`
- Widens to all 4 ingested tools per CLAUDE.md's coding-agent pipeline table; Antigravity stays excluded (detection-only, never ingests)

Stacked on #(fix/dev-start-orphan-cleanup) — diff will shrink to just this commit once that merges.

## Test plan
- [x] `cargo build -p meridian-core`