### PR TITLE
feat(tray): enable zoom hotkeys on dashboard/setup windows

### DIFF
--- a/tray/src-tauri/capabilities/default.json
+++ b/tray/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
     "core:default",
     "core:window:allow-close",
     "core:window:allow-set-size",
+    "core:webview:allow-set-webview-zoom",
     "positioner:default",
     "notifications:default",
     "opener:default",

--- a/tray/src-tauri/src/commands/system.rs
+++ b/tray/src-tauri/src/commands/system.rs
@@ -48,6 +48,7 @@ pub async fn open_dashboard(app: tauri::AppHandle) -> Result<(), String> {
         .minimizable(true)
         .closable(true)
         .maximized(true)
+        .zoom_hotkeys_enabled(true)
         .build()
     {
         Ok(win) => {

--- a/tray/src-tauri/src/tray.rs
+++ b/tray/src-tauri/src/tray.rs
@@ -103,6 +103,7 @@ pub(crate) fn open_native_dashboard(app: &tauri::AppHandle) {
             .minimizable(true)
             .closable(true)
             .maximized(true)
+            .zoom_hotkeys_enabled(true)
             .build()
         {
             Ok(win) => {
@@ -173,6 +174,7 @@ pub(crate) fn open_wizard_window(app: &tauri::AppHandle) {
         .title("Meridian — Setup")
         .inner_size(980.0, 660.0)
         .resizable(false)
+        .zoom_hotkeys_enabled(true)
         .build()
     {
         eprintln!("tray: failed to open setup wizard: {e}");

--- a/tray/src-tauri/tauri.conf.json
+++ b/tray/src-tauri/tauri.conf.json
@@ -13,7 +13,11 @@
     "macOSPrivateApi": true,
     "withGlobalTauri": true,
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["$HOME/.meridian/icon-cache/*"]
+      }
     },
     "windows": [
       {
@@ -32,7 +36,8 @@
         "minimizable": false,
         "closable": false,
         "shadow": true,
-        "focus": false
+        "focus": false,
+        "zoomHotkeysEnabled": true
       },
       {
         "label": "tray-tooltip",
@@ -50,7 +55,8 @@
         "minimizable": false,
         "closable": false,
         "shadow": false,
-        "focus": false
+        "focus": false,
+        "zoomHotkeysEnabled": true
       }
     ]
   },


### PR DESCRIPTION
## Summary
- Cmd+/Cmd- did nothing in the dashboard/setup webviews; enable `zoomHotkeysEnabled` on both config-defined and runtime-built windows, plus the matching `core:webview:allow-set-webview-zoom` permission
- Also scopes the webview asset protocol to `$HOME/.meridian/icon-cache/*`, laying the groundwork for the per-app icon extraction PR (narrowly scoped, not a general filesystem read)

Stacked on prior PRs in this chain.

## Test plan
- [x] `cargo build -p meridian-tray`, `cargo clippy -p meridian-tray -- -D warnings`