### PR TITLE
fix(oauth): let users cancel a stuck jira/trello browser OAuth attempt

### DIFF
--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -826,6 +826,12 @@ pub async fn start_oauth(body: StartOAuthBody) -> Result<StartOAuthResponse, Str
     }
 }
 
+/// POST body for [`cancel_oauth`] (`{ provider }`).
+#[derive(Debug, Deserialize)]
+pub struct CancelOAuthBody {
+    pub provider: String,
+}
+
 /// Cancel an in-flight jira/trello browser-OAuth attempt (the "Try again"
 /// button's real action — see `IntegrationConnect.tsx`'s `OAuthSetup`).
 ///
@@ -839,8 +845,9 @@ pub async fn start_oauth(body: StartOAuthBody) -> Result<StartOAuthResponse, Str
 /// waiting for the (now never-running) task to reach its own cleanup code —
 /// aborting a task skips the rest of its body entirely.
 #[tauri::command]
-#[tracing::instrument]
-pub async fn cancel_oauth(provider: String) -> Result<(), String> {
+#[tracing::instrument(fields(provider = %body.provider))]
+pub async fn cancel_oauth(body: CancelOAuthBody) -> Result<(), String> {
+    let provider = body.provider;
     let (in_flight, handle_slot): (
         &'static AtomicBool,
         &'static Mutex<Option<tokio::task::JoinHandle<()>>>,

--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -40,6 +40,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 use std::time::Duration;
 use tauri::State;
 use tracing::Instrument;
@@ -50,6 +51,15 @@ use tracing::Instrument;
 static JIRA_OAUTH_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
 static TRELLO_OAUTH_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
 static GITHUB_OAUTH_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+
+// Handle to the currently in-flight jira/trello task, so [`cancel_oauth`] can
+// abort it — this is what actually lets a user retry after closing the
+// browser tab without waiting out the 5-minute `CONSENT_TIMEOUT`: aborting
+// drops the task's `TcpListener` on the spot, freeing the loopback port, and
+// `cancel_oauth` clears the in-flight flag immediately rather than waiting
+// for the (now-aborted) task to reach its own cleanup code.
+static JIRA_OAUTH_HANDLE: Mutex<Option<tokio::task::JoinHandle<()>>> = Mutex::new(None);
+static TRELLO_OAUTH_HANDLE: Mutex<Option<tokio::task::JoinHandle<()>>> = Mutex::new(None);
 
 /// Providers connected via browser OAuth — their token store under
 /// `~/.meridian/oauth/<p>.json` is the connect/disconnect surface.
@@ -816,6 +826,37 @@ pub async fn start_oauth(body: StartOAuthBody) -> Result<StartOAuthResponse, Str
     }
 }
 
+/// Cancel an in-flight jira/trello browser-OAuth attempt (the "Try again"
+/// button's real action — see `IntegrationConnect.tsx`'s `OAuthSetup`).
+///
+/// Closing the browser tab mid-flow tells the tray nothing: the spawned task
+/// stays parked on `TcpListener::accept()` for up to `CONSENT_TIMEOUT` (5 min,
+/// `meridian-oauth/src/flow.rs`), holding both the loopback port and the
+/// per-provider in-flight flag the whole time. Without this command, retrying
+/// before that timeout elapses just re-hits the same "already in progress"
+/// error start_oauth returns. `.abort()` drops the task (and its
+/// `TcpListener`) immediately; we then clear the flag ourselves rather than
+/// waiting for the (now never-running) task to reach its own cleanup code —
+/// aborting a task skips the rest of its body entirely.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn cancel_oauth(provider: String) -> Result<(), String> {
+    let (in_flight, handle_slot): (
+        &'static AtomicBool,
+        &'static Mutex<Option<tokio::task::JoinHandle<()>>>,
+    ) = match provider.as_str() {
+        "trello" => (&TRELLO_OAUTH_IN_FLIGHT, &TRELLO_OAUTH_HANDLE),
+        "jira" => (&JIRA_OAUTH_IN_FLIGHT, &JIRA_OAUTH_HANDLE),
+        other => return Err(format!("cancel_oauth: unsupported provider {other}")),
+    };
+    if let Some(handle) = handle_slot.lock().unwrap().take() {
+        handle.abort();
+    }
+    in_flight.store(false, Ordering::SeqCst);
+    tracing::info!(provider = %provider, "OAuth attempt cancelled");
+    Ok(())
+}
+
 /// Run the jira/trello browser login in-process on the tray's runtime. Returns
 /// immediately (`started=true`); a spawned task drives the flow and writes the
 /// token store on success or the `.error` sentinel (with the REAL error string —
@@ -879,9 +920,12 @@ fn start_oauth_in_process(provider: String) -> Result<StartOAuthResponse, String
     // Claim the per-provider in-flight slot. A second start_oauth call while
     // a flow is running returns an error — port 9123 can't be shared and the
     // token file would be written by two racing tasks.
-    let in_flight: &'static AtomicBool = match provider.as_str() {
-        "trello" => &TRELLO_OAUTH_IN_FLIGHT,
-        _ => &JIRA_OAUTH_IN_FLIGHT,
+    let (in_flight, handle_slot): (
+        &'static AtomicBool,
+        &'static Mutex<Option<tokio::task::JoinHandle<()>>>,
+    ) = match provider.as_str() {
+        "trello" => (&TRELLO_OAUTH_IN_FLIGHT, &TRELLO_OAUTH_HANDLE),
+        _ => (&JIRA_OAUTH_IN_FLIGHT, &JIRA_OAUTH_HANDLE),
     };
     if in_flight
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
@@ -898,7 +942,10 @@ fn start_oauth_in_process(provider: String) -> Result<StartOAuthResponse, String
     }
 
     let task_provider = provider.clone();
-    tauri::async_runtime::spawn(async move {
+    // `tokio::spawn` (not `tauri::async_runtime::spawn`) so we get a real
+    // `tokio::task::JoinHandle` — its `.abort()` is what `cancel_oauth` uses
+    // to drop the task's `TcpListener` and free the loopback port on retry.
+    let handle = tokio::spawn(async move {
         let result: anyhow::Result<()> = match task_provider.as_str() {
             "jira" => meridian_oauth::jira::login(&jira_client_id, &jira_secret, jira_port)
                 .await
@@ -921,6 +968,7 @@ fn start_oauth_in_process(provider: String) -> Result<StartOAuthResponse, String
             }
         }
     });
+    *handle_slot.lock().unwrap() = Some(handle);
 
     tracing::info!(provider = %provider, "in-process OAuth login launched");
     Ok(StartOAuthResponse {

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -517,6 +517,7 @@ pub fn run() {
             commands::discover_github_projects,
             commands::save_integration_token,
             commands::start_oauth,
+            commands::cancel_oauth,
             commands::get_oauth_status,
             // OS/window actions
             commands::open_permission_pane,

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -410,7 +410,7 @@ function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
               {/* jira/trello only — a rejection Atlassian/Trello shows on THEIR
                   consent screen (e.g. "no Jira site access") never redirects
                   back here, so there's no automatic error to catch; without
-                  this the user is stuck watching "Waiting…" for up to 3 min. */}
+                  this the user is stuck watching "Waiting…" for up to 5 min. */}
               {(tracker.id === 'jira' || tracker.id === 'trello') && (
                 <button onClick={cancelAndReset} className="text-[11px]" style={{ color: 'var(--t-faint)', cursor: 'pointer' }}>
                   Not going through? Cancel

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -30,6 +30,15 @@ function clearProviderNotice(provider: string): void {
   void invoke('delete_notice', { noticeId: `pm.${provider}` }).catch(() => {})
 }
 
+// Abort a still-running jira/trello browser-OAuth attempt so a fresh
+// start_oauth call doesn't hit "already in progress". Only jira/trello are
+// wired server-side (cancel_oauth) — github's device flow has no loopback
+// port to free, so this is a silent no-op for it. Fire-and-forget: worst case
+// (the daemon is unreachable) is the pre-existing 5-minute timeout behavior.
+function cancelOAuth(provider: string): void {
+  void mutate('/api/auth/oauth/cancel', 'cancel_oauth', { provider }).catch(() => {})
+}
+
 // ── Main list ─────────────────────────────────────────────────────────────────
 export default function ConnectTrackers({
   integrations, onChanged, compact,
@@ -225,6 +234,11 @@ function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
   // mountedRef lets the async startOAuth body detect an unmount that happened
   // while awaiting mutate — before the interval is created and pollRef assigned.
   const mountedRef = useRef(true)
+  // Mirrors `status` for the unmount cleanup below, which closes over the
+  // value from whichever render installed it (an empty-deps effect only runs
+  // once) — a ref always reads the latest value regardless of when it fires.
+  const statusRef = useRef(status)
+  statusRef.current = status
 
   // Set the flag TRUE on (re)mount, not just FALSE on unmount. Under React
   // StrictMode (on in `next dev`, which `tauri dev` serves) effects run
@@ -239,8 +253,27 @@ function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
     return () => {
       mountedRef.current = false
       if (pollRef.current != null) clearInterval(pollRef.current)
+      // Closing Settings (or switching providers) mid-flow is the same
+      // "abandoned the browser tab" situation "Try again" fixes below —
+      // cancel server-side too so reopening doesn't hit "already in progress".
+      if (statusRef.current === 'waiting' && (tracker.id === 'jira' || tracker.id === 'trello')) {
+        cancelOAuth(tracker.id)
+      }
     }
-  }, [])
+  }, [tracker.id])
+
+  // Bail out of a 'waiting' OR 'error' attempt back to 'idle': stops the poll
+  // (if still running), tells the backend to abort/free the loopback port
+  // (jira/trello only — see cancelOAuth), and resets local state. Used by
+  // both the "waiting" state's manual Cancel (for failures Atlassian/Trello
+  // block at THEIR consent screen and never redirect back for — the loopback
+  // listener would otherwise sit waiting the full timeout with no feedback)
+  // and the "error" state's "Try again".
+  const cancelAndReset = () => {
+    if (pollRef.current != null) { clearInterval(pollRef.current); pollRef.current = null }
+    if (tracker.id === 'jira' || tracker.id === 'trello') cancelOAuth(tracker.id)
+    setStatus('idle'); setError(null); setDeviceCode(null); setVerifyUri(null)
+  }
 
   const startOAuth = async () => {
     setStatus('waiting'); setError(null); setDeviceCode(null); setVerifyUri(null)
@@ -374,6 +407,15 @@ function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
             <>
               <p className="text-[12px]" style={{ color: 'var(--t-muted)' }}>Your browser should have opened. Authorize the app, then come back here.</p>
               <p className="text-[11px]" style={{ color: 'var(--t-faint-2)' }}>Waiting for authorization…</p>
+              {/* jira/trello only — a rejection Atlassian/Trello shows on THEIR
+                  consent screen (e.g. "no Jira site access") never redirects
+                  back here, so there's no automatic error to catch; without
+                  this the user is stuck watching "Waiting…" for up to 3 min. */}
+              {(tracker.id === 'jira' || tracker.id === 'trello') && (
+                <button onClick={cancelAndReset} className="text-[11px]" style={{ color: 'var(--t-faint)', cursor: 'pointer' }}>
+                  Not going through? Cancel
+                </button>
+              )}
             </>
           )}
         </div>
@@ -386,7 +428,9 @@ function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
       {status === 'error' && (
         <div className="space-y-2">
           <p className="text-[12px]" style={{ color: 'var(--status-error-dot)' }}>{error ?? 'OAuth failed.'}</p>
-          <button onClick={() => setStatus('idle')} className="text-[11px]" style={{ color: 'var(--color-state-proposal)', cursor: 'pointer' }}>Try again</button>
+          <button onClick={cancelAndReset} className="text-[11px]" style={{ color: 'var(--color-state-proposal)', cursor: 'pointer' }}>
+            Try again
+          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Closing the OAuth browser tab mid-flow left the tray's in-flight guard held for the full 5-minute `CONSENT_TIMEOUT`, so "Try again" (a pure UI no-op) just re-hit "already in progress"
- Switches the spawned OAuth task to `tokio::spawn`, stores its `JoinHandle`, and adds a `cancel_oauth` command that aborts it + clears the flag immediately
- Wires this into "Try again", unmount-while-waiting, and a new "Not going through? Cancel" link for the case where Atlassian's own consent screen blocks (e.g. no Jira site access) and never redirects back at all

Stacked on prior PRs in this chain.

## Test plan
- [x] `cargo fmt --check`, `cargo build -p meridian-tray`, `cargo clippy -p meridian-tray -- -D warnings`, `cargo test -p meridian-tray -p meridian-oauth`