### PR TITLE
feat(timeline): richer Overview + Hour-detail panels for solo/no-PM use

### DIFF
--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -367,6 +367,19 @@ body, .font-sans {
 @keyframes mer-pop { from { opacity: 0; transform: scale(.82); } to { opacity: 1; transform: scale(1); } }
 .mer-pop { animation: mer-pop .32s cubic-bezier(.2,.7,.2,1) both; }
 
+/* "Connect a tracker" CTA curved connector (CurvedArrow.tsx) — a flowing
+   marching-ants dash along the curve plus a gentle float on the whole glyph,
+   so it reads as pointing FROM the content above INTO the CTA below rather
+   than a flat static "→". */
+@keyframes mer-arrow-flow { to { stroke-dashoffset: -18; } }
+.mer-arrow-flow { animation: mer-arrow-flow 1s linear infinite; }
+
+@keyframes mer-arrow-float {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(3px); }
+}
+.mer-curved-arrow { display: block; animation: mer-arrow-float 2s ease-in-out infinite; }
+
 /* Timeline hour-row "Generating this hour's work log" takeover — ported
    verbatim from the Claude Design mock (Meridian Timeline.dc.html):
    genShimmer (the card's own background sweeps), genBlink (the sparkle icon

--- a/ui/components/timeline/ActivityReport.tsx
+++ b/ui/components/timeline/ActivityReport.tsx
@@ -26,6 +26,26 @@ export function extractTldr(report: string): string {
 }
 
 /**
+ * Pull just the bolded topic names out of the "### Core Tasks & Projects"
+ * section (each thread's header is `**Topic name**` per the prompt) — used
+ * by the hour-detail panel's condensed summary, which lists task names only
+ * and defers the full WHY/WHAT/HOW body to the full-report dialog.
+ */
+export function extractCoreTaskNames(report: string): string[] {
+  const section = report.match(/###\s*Core Tasks(?:\s*&\s*Projects)?\s*\n+([\s\S]*?)(?=\n###|\s*$)/i)
+  if (!section) return []
+  const names: string[] = []
+  // Only bold spans at the START of a line are thread headers — the
+  // WHY/WHAT/HOW bullets underneath also bold their labels
+  // ("- **WHY:** ..."), but those lines start with "-", not "**", so the
+  // line-start anchor excludes them.
+  const re = /^[ \t]*\*\*(.+?)\*\*/gm
+  let m: RegExpExecArray | null
+  while ((m = re.exec(section[1])) !== null) names.push(m[1].trim())
+  return names
+}
+
+/**
  * The timeline row's inline preview of an hour's report — a small tinted
  * card (not raw ReactMarkdown output dropped straight into the row) with a
  * "SUMMARY" label, a 2-line-clamped TLDR, and a hover affordance hinting

--- a/ui/components/timeline/ActivityReportModal.tsx
+++ b/ui/components/timeline/ActivityReportModal.tsx
@@ -1,0 +1,27 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Big-screen dialog for an hour's FULL activity report — opened from
+// HourDetailPanel's condensed summary (TLDR + Core Tasks names only) via a
+// "View full report" button. Reuses ModalShell's overlay/backdrop/Escape
+// chrome; wide (860px) so the report's markdown reads comfortably at full
+// type scale (ActivityReport, non-compact).
+
+'use client'
+
+import { ModalShell } from './ModalShell'
+import { ActivityReport } from './ActivityReport'
+import { hourLabel } from './timelineLayout'
+
+export function ActivityReportModal({ hour, report, onClose }: {
+  hour: number
+  report: string
+  onClose: () => void
+}) {
+  return (
+    <ModalShell title={`${hourLabel(hour)} · Activity report`} onClose={onClose} maxWidth={860}>
+      <div className="rounded-xl p-6 bg-box">
+        <ActivityReport report={report} />
+      </div>
+    </ModalShell>
+  )
+}

--- a/ui/components/timeline/CurvedArrow.tsx
+++ b/ui/components/timeline/CurvedArrow.tsx
@@ -1,0 +1,20 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Small decorative curved connector used above the "Connect a tracker" CTAs
+// (OverviewPanel, HourDetailPanel) — curves down from the content above (the
+// Activity summary / today's stats) into the CTA below it, with a flowing
+// animated dash and a gentle float, so the CTA reads as pointed-to rather
+// than a disconnected banner. Replaces a flat "→" character.
+
+'use client'
+
+export function CurvedArrow({ size = 40 }: { size?: number }) {
+  return (
+    <svg width={size} height={size * 0.68} viewBox="0 0 44 30" fill="none" className="mer-curved-arrow" aria-hidden="true">
+      <path d="M4 2 C4 16, 16 24, 35 26" stroke="var(--color-state-proposal)" strokeWidth="2.25"
+        strokeLinecap="round" strokeDasharray="3 6" className="mer-arrow-flow" />
+      <path d="M27 21 L36 27 L28 29" stroke="var(--color-state-proposal)" strokeWidth="2.25"
+        strokeLinecap="round" strokeLinejoin="round" fill="none" />
+    </svg>
+  )
+}

--- a/ui/components/timeline/HourDetailPanel.tsx
+++ b/ui/components/timeline/HourDetailPanel.tsx
@@ -4,22 +4,27 @@
 // activity REPORT (get_hour_text backend data — migration 054's hour_report,
 // the /activity_report LLM OUTPUT, not the raw distilled input) — solo users
 // only, since it's the substitute for the PM-matched work logs a connected
-// user gets instead — rendered as markdown (ActivityReport), plus the hour's
-// work logs with inline Dismiss/Edit/Approve. Solo users get a dashed
-// empty-state instead of work logs. A null report is EXPECTED (future/
+// user gets instead. Connected users get the hour's work logs (with inline
+// Dismiss/Edit/Approve) instead — solo mode has no tracker to match against,
+// so that section doesn't render at all rather than showing an empty state
+// alongside the Activity summary. A null report is EXPECTED (future/
 // unprocessed hours) — it renders a placeholder, never an error. Time-by-app
 // lives only in OverviewPanel — it isn't scoped per-hour/per-ticket data.
 
 'use client'
 
+import { useState } from 'react'
 import { fmtClock } from '@/components/atoms'
 import { hourLabel } from './timelineLayout'
 import { isPending, itemKey } from './types'
 import { TimelineCard } from './TimelineCard'
-import { ActivityReport } from './ActivityReport'
+import { ActivityReport, extractCoreTaskNames, extractTldr } from './ActivityReport'
+import { ActivityReportModal } from './ActivityReportModal'
+import { CurvedArrow } from './CurvedArrow'
 import type { TimelineData } from './useTimelineData'
+import type { SettingsSection } from './settings/types'
 
-export function HourDetailPanel({ hour, selectedCardKey, onBack, data, onEditWorklog }: {
+export function HourDetailPanel({ hour, selectedCardKey, onBack, data, onEditWorklog, onOpenSettings }: {
   hour: number
   // When set, a specific card was clicked on the timeline — show only that
   // one ticket instead of every worklog in the hour.
@@ -27,8 +32,12 @@ export function HourDetailPanel({ hour, selectedCardKey, onBack, data, onEditWor
   onBack: () => void
   data: TimelineData
   onEditWorklog: (cardKey: string) => void
+  // Deep-link into Settings → Integrations — the solo-mode "Connect a
+  // tracker" CTA below uses this.
+  onOpenSettings: (section?: SettingsSection) => void
 }) {
   const { hourBuckets, isSolo, actions, hourReports } = data
+  const [showFullReport, setShowFullReport] = useState(false)
 
   // Still-drafted work never shows here — a draft click opens the Review
   // dialog instead (TimelineColumn/MeridianTimelineShell); this panel is for
@@ -60,46 +69,95 @@ export function HourDetailPanel({ hour, selectedCardKey, onBack, data, onEditWor
           instead (the Section below), so this is that surface's substitute,
           not an addition to it. */}
       {isSolo && (
-        <Section label="Activity summary">
+        <Section label="Activity summary" emphasize>
           {report ? (
-            <div className="rounded-xl p-5 bg-box">
-              <ActivityReport report={report} />
-              <p className="mt-label mt-3" style={{ color: 'var(--t-faint)' }}>◈ Captured from screen · accessibility tree + OCR</p>
+            <div className="rounded-xl p-5 bg-box space-y-4">
+              <ActivityReport report={extractTldr(report)} />
+              {(() => {
+                const taskNames = extractCoreTaskNames(report)
+                return taskNames.length > 0 ? (
+                  <div>
+                    <p className="mt-label mb-2" style={{ color: 'var(--t-faint)' }}>Core Tasks &amp; Projects</p>
+                    <ul className="space-y-1.5" style={{ listStyle: 'none', paddingLeft: 0 }}>
+                      {taskNames.map((name, i) => (
+                        <li key={i} className="mt-body-sm flex items-center gap-2" style={{ color: 'var(--t-title)' }}>
+                          <span aria-hidden="true" style={{ color: 'var(--t-faint)' }}>·</span>
+                          <span className="min-w-0">{name}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null
+              })()}
+              <button onClick={() => setShowFullReport(true)}
+                className="mt-body-sm inline-flex items-center gap-1"
+                style={{ color: 'var(--color-state-proposal)', fontWeight: 700 }}>
+                View full report ↗
+              </button>
             </div>
           ) : (
             <p className="mt-body-sm italic" style={{ color: 'var(--t-faint-2)' }}>Not yet available for this hour.</p>
           )}
+
+          {report && (
+            <>
+              <div className="flex justify-start pl-4 -mb-2" aria-hidden="true">
+                <CurvedArrow size={36} />
+              </div>
+              <button onClick={() => onOpenSettings('integrations')}
+                className="w-full flex items-center gap-3 rounded-xl px-4 py-3 text-left transition-colors mt-card-hover"
+                style={{
+                  border: '1px dashed color-mix(in srgb, var(--color-state-proposal) 45%, transparent)',
+                  background: 'color-mix(in srgb, var(--color-state-proposal) 6%, transparent)',
+                }}>
+                <span className="flex-1 min-w-0">
+                  <p className="mt-body-sm" style={{ color: 'var(--t-title)', fontWeight: 700 }}>Want this logged to your PM app?</p>
+                  <p className="mt-body-sm mt-0.5" style={{ color: 'var(--t-muted)' }}>Connect a tracker and Meridian matches your work automatically.</p>
+                </span>
+              </button>
+            </>
+          )}
         </Section>
       )}
 
-      {/* work logs, or the solo empty-state */}
-      <Section label={isSolo ? 'Work logs' : `Work logs${items.length ? ` · ${items.length}` : ''}`}>
-        {isSolo ? (
-          <div className="rounded-xl p-5 text-center" style={{ border: '1px dashed var(--t-hair)' }}>
-            <p className="mt-title text-title">No work logs in Solo mode</p>
-            <p className="mt-body-sm mt-1.5" style={{ color: 'var(--t-muted)' }}>
-              Connect a tracker to turn this hour&apos;s activity into matched work logs automatically.
-            </p>
-          </div>
-        ) : items.length === 0 ? (
-          <p className="mt-body-sm italic" style={{ color: 'var(--t-faint-2)' }}>Nothing logged this hour.</p>
-        ) : (
-          <div className="space-y-3">
-            {items.map(w => (
-              <TimelineCard key={itemKey(w)} item={w} variant="detail" actions={actions}
-                onEdit={() => onEditWorklog(itemKey(w))} />
-            ))}
-          </div>
-        )}
-      </Section>
+      {showFullReport && report && (
+        <ActivityReportModal hour={hour} report={report} onClose={() => setShowFullReport(false)} />
+      )}
+
+      {/* Work logs — connected users only. Solo mode has no tracker to match
+          against, so there's nothing to show here; Activity summary above is
+          the whole story for that hour, not a section alongside an empty one. */}
+      {!isSolo && (
+        <Section label={`Work logs${items.length ? ` · ${items.length}` : ''}`}>
+          {items.length === 0 ? (
+            <p className="mt-body-sm italic" style={{ color: 'var(--t-faint-2)' }}>Nothing logged this hour.</p>
+          ) : (
+            <div className="space-y-3">
+              {items.map(w => (
+                <TimelineCard key={itemKey(w)} item={w} variant="detail" actions={actions}
+                  onEdit={() => onEditWorklog(itemKey(w))} />
+              ))}
+            </div>
+          )}
+        </Section>
+      )}
     </div>
   )
 }
 
-function Section({ label, children }: { label: string; children: React.ReactNode }) {
+// `emphasize` (Activity summary only — the report is the primary content in
+// solo mode) swaps the standard faint uppercase eyebrow for a bold title-color
+// heading; `Work logs` keeps the plain eyebrow style.
+function Section({ label, children, emphasize = false }: { label: string; children: React.ReactNode; emphasize?: boolean }) {
   return (
     <div>
-      <p className="mt-label mb-2.5" style={{ color: 'var(--t-faint)' }}>{label}</p>
+      {emphasize ? (
+        <p className="mb-2.5" style={{ font: "800 13.5px 'Plus Jakarta Sans', var(--font-pjs), sans-serif", color: 'var(--t-title)' }}>
+          {label}
+        </p>
+      ) : (
+        <p className="mt-label mb-2.5" style={{ color: 'var(--t-faint)' }}>{label}</p>
+      )}
       {children}
     </div>
   )

--- a/ui/components/timeline/MeridianTimelineShell.tsx
+++ b/ui/components/timeline/MeridianTimelineShell.tsx
@@ -170,6 +170,7 @@ export default function MeridianTimelineShell() {
             onOpen={setActiveModal}
             onOpenTask={(key, title) => setOpenTask({ key, title })}
             onEditWorklog={openReview}
+            onOpenSettings={(section) => { setSettingsSection(section); setActiveModal('settings') }}
           />
         </div>
       </div>

--- a/ui/components/timeline/OverviewPanel.tsx
+++ b/ui/components/timeline/OverviewPanel.tsx
@@ -68,7 +68,11 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
   // the underlying today.autonomous_s data is still computed server-side,
   // this just stops surfacing it in the UI while the framing gets rethought).
   // const autonomous_s = today?.autonomous_s ?? 0
-  const appTops = today ? appTotals(today.sessions, codingAgents?.agents ?? []) : []
+  // get_coding_agents has no date param (it always reads today's totals —
+  // tray/src-tauri/src/commands/dashboard.rs hardcodes today_string()), so
+  // only fold it in while viewing today; on a past day it would inject
+  // TODAY's coding time into that day's app breakdown.
+  const appTops = today ? appTotals(today.sessions, isToday ? (codingAgents?.agents ?? []) : []) : []
   const appCount = appTops.length
   const catTops = today ? categoryRows(today.sessions, agent_s) : []
   // Pull the "Coding" number straight out of the SAME merged rows the
@@ -271,7 +275,7 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
             <p className="mt-body-sm" style={{ color: 'var(--t-faint)' }}>most in {appTops[0].app}</p>
           )}
         </div>
-        <TimeByApp sessions={today?.sessions ?? []} agentTotals={codingAgents?.agents ?? []} />
+        <TimeByApp sessions={today?.sessions ?? []} agentTotals={isToday ? (codingAgents?.agents ?? []) : []} />
       </div>
 
       <div className="rounded-xl p-5 bg-card" style={{ border: '1px solid var(--t-card-border)' }}>

--- a/ui/components/timeline/OverviewPanel.tsx
+++ b/ui/components/timeline/OverviewPanel.tsx
@@ -17,23 +17,68 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { fmtDur } from '@/components/atoms'
 import { load as loadData, mutate as mutateData, openExternal } from '@/lib/bridge'
-import type { PlanItem, PlanResponse } from '@/lib/api-types'
+import type { PlanItem, PlanResponse, CodingAgentsResponse } from '@/lib/api-types'
 import { formatDayLabel, isPending } from './types'
 import { TimeByApp, appTotals } from './TimeByApp'
+import { TimeByCategory, categoryRows } from './TimeByCategory'
 import type { TimelineData } from './useTimelineData'
 import type { ActiveModal } from './MeridianTimelineShell'
+import type { SettingsSection } from './settings/types'
 
-export function OverviewPanel({ data, onOpen, onOpenTask }: {
+
+export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
   data: TimelineData
   onOpen: (modal: ActiveModal) => void
   onOpenTask: (key: string, title?: string) => void
+  onOpenSettings: (section?: SettingsSection) => void
 }) {
   const { today, isSolo, items, cleanupIssueCount, tasks, isToday, day } = data
   const dayLabel = isToday ? 'Today' : formatDayLabel(day)
   const pendingCount = items.filter(isPending).length
-  const focus_s = today?.focus_s ?? 0
-  const appTops = today ? appTotals(today.sessions) : []
+  // Per-tool coding-agent breakdown (Claude Code/Codex/GitHub Copilot/Cursor
+  // Agent) — get_coding_agents, polled independently of get_today since it's
+  // its own Tauri command. Used to give Time by App real per-tool rows
+  // instead of one generic bucket.
+  const [codingAgents, setCodingAgents] = useState<CodingAgentsResponse | null>(null)
+  useEffect(() => {
+    const fetchAgents = () => loadData<CodingAgentsResponse>('/api/coding-agents', 'get_coding_agents').then(setCodingAgents).catch(() => {})
+    fetchAgents()
+    const id = setInterval(fetchAgents, 30_000)
+    return () => clearInterval(id)
+  }, [])
+  // "Focus" is inclusive of ALL engaged time, not just foreground presence —
+  // today.engaged_s (= focus_s + autonomous_s, computed server-side in
+  // meridian-core/src/readers/today/mod.rs) folds in autonomous agent time
+  // (agent runs that happened while you were away) so Focus can never read
+  // lower than the autonomous chunk baked into Coding — the two totals stay
+  // in a coherent "Focus ≥ what happened today" relationship instead of
+  // Focus looking artificially small next to Coding.
+  const focus_s = today?.engaged_s ?? 0
+  // Total time in coding-agent TOOLS today (Claude Code/Codex/Copilot/Cursor
+  // Agent) — a separate overlay stream from `today.sessions`, already unioned
+  // server-side to avoid double-counting overlapping agent/foreground time.
+  // NOT shown as its own top-level stat — it's folded into Time by
+  // category's "Coding" slice (categoryRows) as the one number that tells
+  // the coding story. A standalone "Agent time" card alongside a
+  // Coding-inclusive-of-agent-time slice put the same number in two places
+  // (once as a subset, once inside a bigger total) with no visual link
+  // between them, which read as a mismatch even though both were correct.
+  const agent_s = today?.agent_s ?? 0
+  // Autonomous-time breakdown disabled for now (commented out, not deleted —
+  // the underlying today.autonomous_s data is still computed server-side,
+  // this just stops surfacing it in the UI while the framing gets rethought).
+  // const autonomous_s = today?.autonomous_s ?? 0
+  const appTops = today ? appTotals(today.sessions, codingAgents?.agents ?? []) : []
   const appCount = appTops.length
+  const catTops = today ? categoryRows(today.sessions, agent_s) : []
+  // Pull the "Coding" number straight out of the SAME merged rows the
+  // category chart renders, rather than recomputing it — guarantees the top
+  // stat and the pie slice can never disagree, since they're reading the
+  // identical value, not two independently-derived numbers that happen to
+  // match today and drift apart the next time either side changes.
+  const codingRow = catTops.find(r => r.cat === 'coding')
+  const coding_s = codingRow?.seconds ?? 0
+  // const codingSub = agent_s > 0 && autonomous_s > 0 ? `incl. ${fmtDur(autonomous_s)} autonomous` : undefined
   // Real worklogs only — is_proposed items carry an 'approved'/'posted' state
   // once a user approves them in-app, but the daemon hasn't necessarily swept
   // them into an actual pm_worklogs row (real ticket created + worklog posted)
@@ -102,18 +147,32 @@ export function OverviewPanel({ data, onOpen, onOpenTask }: {
         <p className="mt-body mt-1.5" style={{ color: 'var(--t-muted)' }}>{greetingBody}</p>
       </div>
 
-      {!isSolo && pendingCount > 0 && (
-        <button onClick={() => onOpen('review')}
-          className="w-full text-left rounded-xl px-4 py-3.5 flex items-center gap-3 transition-transform active:scale-[.99]"
-          style={{ background: 'linear-gradient(120deg, #8B5CF6, #F472B6)', color: '#fff', boxShadow: '0 10px 24px -8px rgba(219,39,119,0.5)' }}>
-          <span className="mt-title-lg shrink-0">{pendingCount}</span>
-          <span className="flex-1 min-w-0">
-            <p className="mt-title">draft{pendingCount === 1 ? '' : 's'} to review</p>
-            <p className="mt-body-sm mt-0.5" style={{ opacity: 0.92 }}>Swipe to approve, dismiss or edit</p>
-          </span>
-          <span className="mt-body-sm px-2.5 py-1 rounded-full shrink-0" style={{ background: 'rgba(255,255,255,0.25)' }}>Review →</span>
-        </button>
-      )}
+      <div className="rounded-xl overflow-hidden bg-card p-4" style={{ border: '1px solid var(--t-card-border)' }}>
+        <div className="mb-3"><SectionHeading>{dayLabel}</SectionHeading></div>
+        {/* Solo mode: Logged/Drafts both require PM-matched worklogs, which
+            don't exist without a tracker — showing them here would always
+            read "0s"/some stale count. Focus is the one stat that's real.
+            One uniform card style for every tile (no per-stat hue) — these
+            are plain counters, not distinct categories that need color
+            coding to tell apart. */}
+        {isSolo ? (
+          <div className={`grid gap-3 ${coding_s > 0 ? 'grid-cols-2' : 'grid-cols-1'}`}>
+            <Mini label="Focus" value={fmtDur(focus_s)} />
+            {coding_s > 0 && <Mini label="Coding" value={fmtDur(coding_s)} />}
+          </div>
+        ) : (
+          // 2×2 (not 4-across) — a 4-column grid in a ~340px panel left no
+          // room for "3h 24m"-length values without wrapping. Order: Focus
+          // leads, Coding next when there's agent/coding time, then the
+          // remaining two.
+          <div className="grid grid-cols-2 gap-3">
+            <Mini label="Focus" value={fmtDur(focus_s)} />
+            {coding_s > 0 && <Mini label="Coding" value={fmtDur(coding_s)} />}
+            <Mini label="Logged" value={fmtDur(loggedSeconds)} />
+            <Mini label="Drafts" value={String(pendingCount)} />
+          </div>
+        )}
+      </div>
 
       {!isSolo && cleanupIssueCount > 0 && (
         <button onClick={() => onOpen('cleanup')}
@@ -131,12 +190,30 @@ export function OverviewPanel({ data, onOpen, onOpenTask }: {
 
       {!isSolo && (
         <div>
-          <div className="flex items-center justify-between mb-2.5">
-            <p className="mt-label" style={{ color: 'var(--t-faint)' }}>Today&apos;s focus</p>
-            <button onClick={() => onOpen('plan')} className="mt-body-sm" style={{ color: 'var(--color-state-proposal)', fontWeight: 700 }}>Edit plan</button>
-          </div>
+          {focusItems.length === 0 && (
+            <div className="flex items-center justify-between mb-2.5">
+              <SectionHeading>Today&apos;s focus</SectionHeading>
+              <button onClick={() => onOpen('plan')} className="mt-body-sm" style={{ color: 'var(--color-state-proposal)', fontWeight: 700 }}>Edit plan</button>
+            </div>
+          )}
           {focusItems.length > 0 ? (
-            <div className="space-y-2">
+            <div className="rounded-xl overflow-hidden bg-card" style={{ border: '1px solid var(--t-card-border)' }}>
+              <div className="flex items-center justify-between px-4 py-3">
+                <SectionHeading>Today&apos;s focus</SectionHeading>
+                <button onClick={() => onOpen('plan')} className="mt-body-sm" style={{ color: 'var(--color-state-proposal)', fontWeight: 700 }}>Edit plan</button>
+              </div>
+              {(() => {
+                const doneCount = focusItems.filter(t => overrideTerminal[t.task_key] ?? t.is_terminal).length
+                return (
+                  <div className="flex items-center gap-2 px-4 py-3">
+                    <span className="flex-1 h-1 rounded-full overflow-hidden bg-track">
+                      <span className="block h-full rounded-full transition-all"
+                        style={{ width: `${(doneCount / focusItems.length) * 100}%`, background: 'var(--color-state-proposal)' }} />
+                    </span>
+                    <span className="mt-mono-sm text-[10.5px] shrink-0" style={{ color: 'var(--t-faint)' }}>{Math.round((doneCount / focusItems.length) * 100)}%</span>
+                  </div>
+                )
+              })()}
               {focusItems.map(t => {
                 const terminal = overrideTerminal[t.task_key] ?? t.is_terminal
                 const busy = !!toggling[t.task_key]
@@ -146,8 +223,7 @@ export function OverviewPanel({ data, onOpen, onOpenTask }: {
                     role="button" tabIndex={0}
                     onClick={() => onOpenTask(t.task_key, t.title)}
                     onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpenTask(t.task_key, t.title) } }}
-                    className="w-full text-left flex items-center gap-3 rounded-xl px-4 py-3 bg-card cursor-pointer"
-                    style={{ border: '1px solid var(--t-card-border)' }}>
+                    className="w-full text-left flex items-center gap-3 px-4 py-3 cursor-pointer">
                     <button
                       onClick={e => { e.stopPropagation(); toggleDone(t, terminal) }}
                       disabled={busy}
@@ -181,27 +257,58 @@ export function OverviewPanel({ data, onOpen, onOpenTask }: {
         </div>
       )}
 
-      <EntryRow label="Tasks" hint={`${activeTaskCount} active`} onClick={() => onOpen('tasks')} />
-
-      <div>
-        <p className="mt-label mb-2.5" style={{ color: 'var(--t-faint)' }}>{dayLabel}</p>
-        <div className="grid grid-cols-3 gap-3">
-          <Mini label="Logged" value={fmtDur(loggedSeconds)} tint="var(--color-state-approved)" />
-          <Mini label="Focus" value={fmtDur(focus_s)} tint="var(--color-state-proposal)" />
-          <Mini label="Drafts" value={String(pendingCount)} tint="var(--color-state-pending)" />
-        </div>
-      </div>
+      {/* Tasks entry pulls from the connected tracker — with no PM
+          integration there's nothing to pull, so it would always read
+          "0 active". Connected users only. */}
+      {!isSolo && (
+        <EntryRow label="Tasks" hint={`${activeTaskCount} active`} onClick={() => onOpen('tasks')} />
+      )}
 
       <div className="rounded-xl p-5 bg-card" style={{ border: '1px solid var(--t-card-border)' }}>
         <div className="flex items-center justify-between mb-2.5">
-          <p className="mt-label" style={{ color: 'var(--t-faint)' }}>Time by app</p>
+          <SectionHeading>Time by app</SectionHeading>
           {appTops[0] && (
             <p className="mt-body-sm" style={{ color: 'var(--t-faint)' }}>most in {appTops[0].app}</p>
           )}
         </div>
-        <TimeByApp sessions={today?.sessions ?? []} />
+        <TimeByApp sessions={today?.sessions ?? []} agentTotals={codingAgents?.agents ?? []} />
       </div>
+
+      <div className="rounded-xl p-5 bg-card" style={{ border: '1px solid var(--t-card-border)' }}>
+        <div className="flex items-center justify-between mb-2.5">
+          <SectionHeading>Time by category</SectionHeading>
+          {catTops[0] && (
+            <p className="mt-body-sm" style={{ color: 'var(--t-faint)' }}>most in {catTops[0].label}</p>
+          )}
+        </div>
+        <TimeByCategory sessions={today?.sessions ?? []} agentSeconds={agent_s} />
+      </div>
+
+      {isSolo && (
+        <button onClick={() => onOpenSettings('integrations')}
+          className="w-full text-left rounded-xl px-4 py-3 flex items-center gap-2.5 mt-card-hover"
+          style={{ background: 'color-mix(in srgb, var(--color-state-proposal) 12%, transparent)', border: '1px solid color-mix(in srgb, var(--color-state-proposal) 30%, transparent)' }}>
+          <span className="inline-flex items-center justify-center rounded-full shrink-0 text-[13px]"
+            style={{ width: 26, height: 26, background: 'color-mix(in srgb, var(--color-state-proposal) 20%, transparent)' }}>🔗</span>
+          <span className="flex-1 min-w-0">
+            <p className="mt-card-title" style={{ color: 'var(--color-state-proposal)' }}>Auto-post your work logs</p>
+            <p className="mt-body-sm mt-0.5" style={{ color: 'var(--t-muted)' }}>Connect a tracker to match today&apos;s activity automatically</p>
+          </span>
+          <span style={{ color: 'var(--color-state-proposal)' }}>→</span>
+        </button>
+      )}
     </div>
+  )
+}
+
+// Bolder than the default faint-uppercase `.mt-label` eyebrow — used for this
+// panel's actual section headings (Today / Today's focus / Time by app /
+// Time by category) so they read as real section breaks, not micro-labels.
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <p style={{ font: "800 13px 'Plus Jakarta Sans', var(--font-pjs), sans-serif", color: 'var(--t-title)' }}>
+      {children}
+    </p>
   )
 }
 
@@ -217,11 +324,12 @@ function EntryRow({ label, hint, onClick }: { label: string; hint: string; onCli
   )
 }
 
-function Mini({ label, value, tint }: { label: string; value: string; tint: string }) {
+function Mini({ label, value, sub }: { label: string; value: string; sub?: string }) {
   return (
-    <div className="rounded-xl p-3" style={{ background: `color-mix(in srgb, ${tint} 14%, transparent)` }}>
-      <p className="mt-stat" style={{ color: tint }}>{value}</p>
+    <div className="rounded-xl p-3 bg-box">
+      <p className="mt-stat text-title whitespace-nowrap">{value}</p>
       <p className="mt-label mt-1" style={{ color: 'var(--t-faint)' }}>{label}</p>
+      {sub && <p className="mt-body-sm mt-0.5" style={{ color: 'var(--t-faint)', fontSize: 10.5 }}>{sub}</p>}
     </div>
   )
 }

--- a/ui/components/timeline/RightPanel.tsx
+++ b/ui/components/timeline/RightPanel.tsx
@@ -9,8 +9,9 @@ import { OverviewPanel } from './OverviewPanel'
 import { HourDetailPanel } from './HourDetailPanel'
 import type { TimelineData } from './useTimelineData'
 import type { ActiveModal } from './MeridianTimelineShell'
+import type { SettingsSection } from './settings/types'
 
-export function RightPanel({ data, selectedHour, selectedCardKey, onSelectHour, onOpen, onOpenTask, onEditWorklog }: {
+export function RightPanel({ data, selectedHour, selectedCardKey, onSelectHour, onOpen, onOpenTask, onEditWorklog, onOpenSettings }: {
   data: TimelineData
   selectedHour: number | null
   selectedCardKey: string | null
@@ -20,8 +21,13 @@ export function RightPanel({ data, selectedHour, selectedCardKey, onSelectHour, 
   // Edit an approved/posted card — opens the same Review dialog drafts use,
   // scoped to this one ticket (see MeridianTimelineShell's openReview).
   onEditWorklog: (cardKey: string) => void
+  // Deep-link into Settings (e.g. 'integrations') — the solo-mode "Connect a
+  // tracker" CTAs in OverviewPanel/HourDetailPanel use this.
+  onOpenSettings: (section?: SettingsSection) => void
 }) {
-  if (selectedHour === null) return <OverviewPanel data={data} onOpen={onOpen} onOpenTask={onOpenTask} />
+  if (selectedHour === null) {
+    return <OverviewPanel data={data} onOpen={onOpen} onOpenTask={onOpenTask} onOpenSettings={onOpenSettings} />
+  }
   return (
     <HourDetailPanel
       hour={selectedHour}
@@ -29,6 +35,7 @@ export function RightPanel({ data, selectedHour, selectedCardKey, onSelectHour, 
       onBack={() => onSelectHour(null)}
       data={data}
       onEditWorklog={onEditWorklog}
+      onOpenSettings={onOpenSettings}
     />
   )
 }

--- a/ui/components/timeline/TimeByApp.tsx
+++ b/ui/components/timeline/TimeByApp.tsx
@@ -11,7 +11,7 @@
 import { useMemo } from 'react'
 import { fmtDur, AppGlyph } from '@/components/atoms'
 import { BRAND_ICONS } from '@/lib/brand-icons'
-import type { TodaySession } from '@/lib/api-types'
+import type { TodaySession, AgentTotal } from '@/lib/api-types'
 
 function appHue(app: string): number {
   let h = 0
@@ -24,20 +24,35 @@ function appColor(app: string): string {
   return BRAND_ICONS[app]?.hex ?? `hsl(${appHue(app)}, 55%, 55%)`
 }
 
-/** Aggregate sessions into app totals, descending, capped to `limit`. */
-export function appTotals(sessions: TodaySession[]): Array<{ app: string; seconds: number }> {
+/**
+ * Aggregate sessions into app totals, descending, capped to `limit`.
+ * `agentTotals` (get_coding_agents) is folded in by real tool name (Claude
+ * Code / Codex / GitHub Copilot / Cursor Agent) — those sessions are a
+ * separate overlay stream, filtered OUT of `sessions` server-side
+ * (meridian-core/src/readers/today/mod.rs), so they'd otherwise be entirely
+ * invisible here even though real time went into them.
+ */
+export function appTotals(sessions: TodaySession[], agentTotals: AgentTotal[] = []): Array<{ app: string; seconds: number }> {
   const by = new Map<string, number>()
   for (const s of sessions) {
     if (!s.app) continue
     by.set(s.app, (by.get(s.app) ?? 0) + s.dur)
+  }
+  for (const a of agentTotals) {
+    if (!a.app || a.total_s <= 0) continue
+    by.set(a.app, (by.get(a.app) ?? 0) + a.total_s)
   }
   return Array.from(by.entries())
     .map(([app, seconds]) => ({ app, seconds }))
     .sort((a, b) => b.seconds - a.seconds)
 }
 
-export function TimeByApp({ sessions, limit = 6 }: { sessions: TodaySession[]; limit?: number }) {
-  const rows = useMemo(() => appTotals(sessions).slice(0, limit), [sessions, limit])
+export function TimeByApp({ sessions, agentTotals = [], limit = 6 }: {
+  sessions: TodaySession[]
+  agentTotals?: AgentTotal[]
+  limit?: number
+}) {
+  const rows = useMemo(() => appTotals(sessions, agentTotals).slice(0, limit), [sessions, agentTotals, limit])
   const max = rows[0]?.seconds ?? 1
 
   if (rows.length === 0) {

--- a/ui/components/timeline/TimeByCategory.tsx
+++ b/ui/components/timeline/TimeByCategory.tsx
@@ -1,0 +1,150 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Interactive "time by category" donut chart — the Overview panel's
+// Time-by-app sibling, but aggregates get_today sessions by `cat` (coding,
+// meeting, research, …) instead of `app`, and renders as a hoverable SVG
+// donut + legend instead of horizontal bars (a pie/donut reads distribution
+// share — "how much of today" — more directly than stacked bars for a small,
+// mutually-exclusive category set). Segment/dot colors are the exact hex
+// values behind the existing `.cat-<key>` classes (globals.css) so this
+// matches every other category dot in the app (TimelineColumn's hour-row
+// dots, CatDot) rather than inventing a new palette — SVG `stroke` can't
+// consume a CSS class the way a `background` can, so the hexes are mirrored
+// here; keep them in sync if globals.css's cat-* values ever change.
+//
+// `agentSeconds` (today.agent_s, the Overview panel's "Agent time" stat) is
+// added into the "Coding" slice rather than shown as its own category — from
+// a user's perspective, coding-agent tool time IS coding, just delegated;
+// splitting it into a second slice/label made the chart read as if two
+// unrelated numbers disagreed. The Overview panel's separate "Agent time"
+// card still shows the agent-only breakdown (incl. how much ran
+// autonomously) for anyone who wants that detail.
+
+'use client'
+
+import { useMemo, useState } from 'react'
+import { fmtDur, CATS } from '@/components/atoms'
+import type { TodaySession } from '@/lib/api-types'
+
+const CAT_HEX: Record<string, string> = {
+  coding:             '#3B6FE0',
+  code_review:        '#7C3AED',
+  meeting:            '#D97706',
+  communication:      '#059669',
+  design:             '#DB2777',
+  documentation:      '#0891B2',
+  planning:           '#C4822A',
+  deployment_devops:  '#DC2626',
+  research:           '#4F46E5',
+  idle_personal:      '#78716C',
+}
+const FALLBACK_HEX = '#8B5CF6'
+/** Aggregate sessions into category totals, descending. */
+export function categoryTotals(sessions: TodaySession[]): Array<{ cat: string; seconds: number }> {
+  const by = new Map<string, number>()
+  for (const s of sessions) {
+    if (!s.cat) continue
+    by.set(s.cat, (by.get(s.cat) ?? 0) + s.dur)
+  }
+  return Array.from(by.entries())
+    .map(([cat, seconds]) => ({ cat, seconds }))
+    .sort((a, b) => b.seconds - a.seconds)
+}
+
+interface Row { cat: string; seconds: number; label: string; color: string }
+
+/** categoryTotals, with `agentSeconds` (today.agent_s) folded into "coding" — see file header. */
+export function categoryRows(sessions: TodaySession[], agentSeconds = 0): Row[] {
+  const totals = categoryTotals(sessions)
+  const merged = agentSeconds > 0
+    ? (totals.some(r => r.cat === 'coding')
+        ? totals.map(r => r.cat === 'coding' ? { ...r, seconds: r.seconds + agentSeconds } : r)
+        : [...totals, { cat: 'coding', seconds: agentSeconds }])
+    : totals
+  return merged
+    .map(r => ({ ...r, label: CATS[r.cat]?.label ?? r.cat, color: CAT_HEX[r.cat] ?? FALLBACK_HEX }))
+    .sort((a, b) => b.seconds - a.seconds)
+}
+
+const SIZE = 116
+const STROKE = 15
+const R = (SIZE - STROKE) / 2
+const CIRC = 2 * Math.PI * R
+
+export function TimeByCategory({ sessions, agentSeconds = 0, limit = 7 }: {
+  sessions: TodaySession[]
+  agentSeconds?: number
+  limit?: number
+}) {
+  const rows = useMemo(() => categoryRows(sessions, agentSeconds).slice(0, limit), [sessions, agentSeconds, limit])
+  const total = rows.reduce((a, r) => a + r.seconds, 0)
+  const [hover, setHover] = useState<string | null>(null)
+
+  if (rows.length === 0) {
+    return <p className="mt-body-sm italic" style={{ color: 'var(--t-faint-2)' }}>No category activity yet.</p>
+  }
+
+  const active = hover ? rows.find(r => r.cat === hover) : null
+  let cumulative = 0
+
+  return (
+    <div className="flex items-center gap-5">
+      <div className="relative shrink-0" style={{ width: SIZE, height: SIZE }}>
+        <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`} style={{ transform: 'rotate(-90deg)' }}>
+          <circle cx={SIZE / 2} cy={SIZE / 2} r={R} fill="none" stroke="var(--t-track)" strokeWidth={STROKE} />
+          {rows.map(row => {
+            const frac = total > 0 ? row.seconds / total : 0
+            const dash = frac * CIRC
+            const offset = -(cumulative / total) * CIRC
+            cumulative += row.seconds
+            const dimmed = hover !== null && hover !== row.cat
+            return (
+              <circle
+                key={row.cat}
+                cx={SIZE / 2} cy={SIZE / 2} r={R} fill="none"
+                stroke={row.color}
+                strokeWidth={hover === row.cat ? STROKE + 3 : STROKE}
+                strokeDasharray={`${dash} ${CIRC - dash}`}
+                strokeDashoffset={offset}
+                opacity={dimmed ? 0.35 : 1}
+                style={{ cursor: 'pointer', transition: 'opacity .15s, stroke-width .15s' }}
+                onMouseEnter={() => setHover(row.cat)}
+                onMouseLeave={() => setHover(null)}
+              />
+            )
+          })}
+        </svg>
+        {/* center label — active segment on hover, else the day's total */}
+        <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none text-center px-2">
+          <p className="mt-stat" style={{ color: active ? active.color : 'var(--t-title)', fontSize: 15 }}>
+            {fmtDur(active ? active.seconds : total)}
+          </p>
+          <p className="mt-label truncate" style={{ color: 'var(--t-faint)', fontSize: 8.5, maxWidth: SIZE - 24 }}>
+            {active ? active.label : 'Total'}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex-1 min-w-0 space-y-1.5">
+        {rows.map(row => {
+          const pct = total > 0 ? Math.round((row.seconds / total) * 100) : 0
+          return (
+            <div key={row.cat}
+              role="button" tabIndex={0}
+              onMouseEnter={() => setHover(row.cat)}
+              onMouseLeave={() => setHover(null)}
+              className="flex items-center gap-2 rounded-md px-1.5 py-1 -mx-1.5 transition-colors"
+              style={{ background: hover === row.cat ? 'var(--t-row-hover)' : 'transparent', cursor: 'default' }}>
+              <span className="inline-block w-2.5 h-2.5 rounded-full shrink-0" style={{ background: row.color }} aria-hidden="true" />
+              <span className="mt-body-sm truncate flex-1 min-w-0" style={{ color: 'var(--t-muted)' }}>
+                {row.label}
+              </span>
+              <span className="mt-mono-sm text-[10px] shrink-0" style={{ color: 'var(--t-faint)' }}>{pct}%</span>
+              <span className="mt-mono-sm text-[11px] shrink-0 w-11 text-right" style={{ color: 'var(--t-faint)' }}>{fmtDur(row.seconds)}</span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -86,6 +86,19 @@ export interface TodayResponse {
   task_agent_summaries: Record<string, AgentSummary[]>
 }
 
+// ── Coding agents (`get_coding_agents`) ──────────────────────────────────────
+
+export interface AgentTotal {
+  app: string     // "Claude Code" / "Codex" / "GitHub Copilot" / "Cursor Agent"
+  total_s: number // union seconds across that agent's sessions today (overlap counted once)
+}
+
+export interface CodingAgentsResponse {
+  date: string
+  total_s: number // union across ALL coding-agent sessions (overlap deduped)
+  agents: AgentTotal[]
+}
+
 // ── Tasks (`get_tasks`) ──────────────────────────────────────────────────────
 
 export interface TaskSummary {


### PR DESCRIPTION
## Summary
Overview panel:
- "Today" and "Today's focus" wrapped in bordered cards with the heading as the card's own first row, a minimal % progress bar, no per-row dividers
- New "time spent coding" stat (`today.engaged_s`, inclusive of supervised + autonomous agent time)
- New interactive "Time by category" donut and "Time by app" bar list, hover-synced legends; coding-agent time folds directly into the "coding" row so the top stat and chart can never disagree
- Removed the dead solo-mode "Tasks" entry and "N drafts to review" CTA; bolded all section headings
- New "Connect a tracker" CTA for solo-mode users, deep-linking into Settings → Integrations

Hour-detail panel:
- Condensed report view (TLDR + Core Tasks names only) with a "View full report" modal; fixed `extractCoreTaskNames` matching WHY/WHAT/HOW bullet labels as task names
- Removed the "No work logs in Solo mode" empty state
- New curved, animated "Connect a tracker" CTA

Stacked on prior PRs in this chain — this is the last one.

## Test plan
- [x] `npm run build` in `ui/` (repeated after every incremental change during the session)
- [ ] Manual click-through in a packaged/dev Tauri build (data only renders inside the real webview)