### PR TITLE
docs(notifications): fix test recipe — expires_at must be RFC-3339

### DIFF
--- a/NOTIFICATIONS.md
+++ b/NOTIFICATIONS.md
@@ -164,10 +164,14 @@ packaged build:
 ```bash
 cd tray && npm run build         # signs with scripts/dev-signing.sh identity
 # install target/release/bundle/macos/Meridian.app, then seed:
+# expires_at MUST be RFC-3339 ("YYYY-MM-DDTHH:MM:SSZ") — the drain compares it
+# as a STRING against a "T"-separated UTC now, so SQLite's datetime() format
+# ("YYYY-MM-DD HH:MM:SS", space-separated) sorts BEFORE any "T" timestamp and
+# the row is treated as expired at birth (never delivered, no error anywhere).
 sqlite3 ~/.meridian/meridian.db "INSERT INTO notifications
   (dedup_key,event_key,title,body,channels,category,deep_link,expires_at)
   VALUES ('test:1','my.event','T','B','native','verify_switch','/plan',
-          datetime('now','+2 minutes'))"
+          strftime('%Y-%m-%dT%H:%M:%SZ','now','+2 minutes'))"
 # within one tray tick (~30s): toast with buttons; answer it, then:
 sqlite3 ~/.meridian/meridian.db "SELECT response_action,response_text,
   responded_at,response_consumed_at FROM notifications WHERE dedup_key='test:1'"


### PR DESCRIPTION
The end-to-end test recipe in NOTIFICATIONS.md seeds `expires_at` with SQLite's `datetime('now','+2 minutes')`, which produces `YYYY-MM-DD HH:MM:SS` (space-separated). `pending_native` (`meridian-core/src/notifications/mod.rs:266`) compares `expires_at > now` as **strings** against a `T`-separated UTC RFC-3339 instant. A space sorts before `T`, so the seeded row is treated as **expired at birth** — it never delivers and nothing errors, leading anyone following the doc to conclude notifications are broken.

Found while running the recipe against the v1.70.0-staging.2 build: the seeded row sat with `delivered_native_at IS NULL` until expiry despite OS permission granted and policy open.

Fix: seed with `strftime('%Y-%m-%dT%H:%M:%SZ','now','+2 minutes')` and document the format constraint inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUNrrP7ie4eeJKGPV6EXNp