### PR TITLE
feat(setup): notifications permission card in the onboarding wizard

### DIFF
--- a/tray/src-tauri/src/commands/setup.rs
+++ b/tray/src-tauri/src/commands/setup.rs
@@ -203,6 +203,73 @@ pub async fn request_input_monitoring() -> bool {
     false
 }
 
+/// Map the notification plugin's [`tauri_plugin_notifications::PermissionState`]
+/// to the wizard's wire string. Pure so the mapping is unit-testable without a
+/// live plugin: `granted` / `denied` / `prompt` (not yet asked — a request will
+/// show the one-shot macOS dialog).
+fn notification_state_label(state: tauri_plugin_notifications::PermissionState) -> &'static str {
+    use tauri_plugin_notifications::PermissionState;
+    match state {
+        PermissionState::Granted => "granted",
+        PermissionState::Denied => "denied",
+        PermissionState::Prompt | PermissionState::PromptWithRationale => "prompt",
+    }
+}
+
+/// Current macOS notification authorization for the wizard's Notifications card.
+///
+/// Returns `granted` / `denied` / `prompt` (never asked — requesting will show
+/// the system dialog) / `unavailable` (unbundled run: the plugin registers only
+/// inside a `.app` bundle, so `tauri dev` has no notification backend at all).
+///
+/// Unlike the TCC probes above this is not a boolean: `denied` and `prompt`
+/// need different grant actions (macOS shows the authorization dialog exactly
+/// once — after a deny the only path back is System Settings → Notifications),
+/// so the wizard must know which side of that line the user is on.
+#[tauri::command]
+#[tracing::instrument(skip(app))]
+pub async fn check_notifications(app: tauri::AppHandle) -> String {
+    let Some(nf) = crate::sys::notifier(&app) else {
+        return "unavailable".into();
+    };
+    match nf.permission_state().await {
+        Ok(state) => notification_state_label(state).into(),
+        Err(e) => {
+            tracing::warn!(error = %e, "setup: notification permission probe failed");
+            "unavailable".into()
+        }
+    }
+}
+
+/// Surface the one-shot macOS notification authorization dialog and return the
+/// resulting state (same strings as [`check_notifications`]).
+///
+/// The tray already fires this request on every bundled launch (`lib.rs`), so
+/// on a normal first run the dialog appears alongside the wizard; this command
+/// exists for the card's explicit button — covering the user who dismissed
+/// that dialog unanswered. If permission is already `denied`, macOS will NOT
+/// re-prompt: the call returns `denied` unchanged and the frontend falls back
+/// to opening the System Settings pane
+/// ([`crate::commands::system::open_permission_pane`] `"notifications"`).
+#[tauri::command]
+#[tracing::instrument(skip(app))]
+pub async fn request_notifications(app: tauri::AppHandle) -> String {
+    let Some(nf) = crate::sys::notifier(&app) else {
+        return "unavailable".into();
+    };
+    match nf.request_permission().await {
+        Ok(state) => {
+            let label = notification_state_label(state);
+            tracing::info!(state = label, "setup: requested notification permission");
+            label.into()
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "setup: notification permission request failed");
+            "unavailable".into()
+        }
+    }
+}
+
 /// Query the current MLX server status. Polled every 3 seconds by the wizard's
 /// Model step. Returns `runtime_found` alongside status so the UI can distinguish
 /// "not installed" from "installed but offline".
@@ -399,5 +466,28 @@ fn detect_specs_blocking() -> SystemSpecs {
         gpu_cores,
         ram_gb,
         free_disk_gb,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::notification_state_label;
+    use tauri_plugin_notifications::PermissionState;
+
+    // The wizard's card branches on these exact strings (grant button action:
+    // prompt → request dialog, denied → System Settings pane), so the mapping
+    // is contract, not cosmetics.
+    #[test]
+    fn notification_states_map_to_wire_strings() {
+        assert_eq!(
+            notification_state_label(PermissionState::Granted),
+            "granted"
+        );
+        assert_eq!(notification_state_label(PermissionState::Denied), "denied");
+        assert_eq!(notification_state_label(PermissionState::Prompt), "prompt");
+        assert_eq!(
+            notification_state_label(PermissionState::PromptWithRationale),
+            "prompt"
+        );
     }
 }

--- a/tray/src-tauri/src/commands/system.rs
+++ b/tray/src-tauri/src/commands/system.rs
@@ -116,6 +116,12 @@ pub async fn open_permission_pane(app: tauri::AppHandle, pane: String) -> Result
         "input_monitoring" => {
             "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
         }
+        // Notification authorization lives under Notifications, not Privacy &
+        // Security. Bare pane, no ?id=<bundle-id> anchor — per-app anchoring is
+        // undocumented and inconsistent across macOS versions. This is the deny
+        // recovery path: macOS shows the authorization dialog exactly once, so
+        // after a deny the wizard can only send the user here.
+        "notifications" => "x-apple.systempreferences:com.apple.preference.notifications",
         other => return Err(format!("unknown permission pane: {other}")),
     };
     dismiss_popover(&app);

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -532,6 +532,8 @@ pub fn run() {
             commands::request_screen_recording,
             commands::check_input_monitoring,
             commands::request_input_monitoring,
+            commands::check_notifications,
+            commands::request_notifications,
             commands::get_mlx_status,
             commands::start_mlx_server_cmd,
             commands::download_runtime_cmd,

--- a/tray/src-tauri/src/sys.rs
+++ b/tray/src-tauri/src/sys.rs
@@ -60,7 +60,9 @@ pub fn is_bundled() -> bool {
 }
 
 /// The plugin state, if the plugin was registered (bundled runs only).
-fn notifier(app: &tauri::AppHandle) -> Option<&Notifications<tauri::Wry>> {
+/// `pub(crate)` so the setup wizard's permission probes
+/// ([`crate::commands::setup::check_notifications`]) share the one lookup.
+pub(crate) fn notifier(app: &tauri::AppHandle) -> Option<&Notifications<tauri::Wry>> {
     let state = app.try_state::<Notifications<tauri::Wry>>()?;
     Some(state.inner())
 }

--- a/ui/app/setup/atoms.tsx
+++ b/ui/app/setup/atoms.tsx
@@ -38,6 +38,8 @@ export function PermIcon({ icon, size = 18 }: { icon: string; size?: number }) {
     return (<svg viewBox="0 0 18 18" style={c}><rect x="2.5" y="3.5" width="13" height="8.5" rx="1.4" {...s} /><path d="M6.5 15h5M9 12v3" {...s} /></svg>)
   if (icon === 'power')
     return (<svg viewBox="0 0 18 18" style={c}><path d="M9 3v6" {...s} /><path d="M5.5 5.5a5 5 0 1 0 7 0" {...s} /></svg>)
+  if (icon === 'bell')
+    return (<svg viewBox="0 0 18 18" style={c}><path d="M9 3a4 4 0 0 1 4 4v2.5l1.2 2.3H3.8L5 9.5V7a4 4 0 0 1 4-4z" {...s} /><path d="M7.6 14.5a1.5 1.5 0 0 0 2.8 0" {...s} /></svg>)
   return null
 }
 

--- a/ui/app/setup/data.ts
+++ b/ui/app/setup/data.ts
@@ -49,31 +49,43 @@ export const MODEL_RAM_GB = 1.5
 /** Meridian's own resident footprint (background service), separate from the model. */
 export const APP = { diskGB: 0.18, ramGB: 0.15 }
 
-// ── macOS permissions — the three the backend actually requires + polls ───────
-// (The design's Notifications + Launch-at-login toggles are intentionally
-// omitted: no backend exists for them, and the in-process capture pipeline
-// genuinely needs Input Monitoring, which the design omitted.)
+// ── macOS permissions — the three required TCC grants + optional notifications ─
+// (The design's Launch-at-login toggle is intentionally omitted: no backend
+// exists for it. The in-process capture pipeline genuinely needs Input
+// Monitoring, which the design omitted.)
+
+/** Notification authorization (`check_notifications`). Tri-state, not boolean:
+ *  macOS shows the authorization dialog exactly once, so `denied` and `prompt`
+ *  need different grant actions (Settings pane vs system dialog).
+ *  `unavailable` = unbundled run (`tauri dev`) — the card hides itself. */
+export type NotifState = 'granted' | 'denied' | 'prompt' | 'unavailable'
 
 export interface PermissionMeta {
-  id: 'screen' | 'accessibility' | 'input'
-  icon: 'screen' | 'access' | 'power'
+  id: 'screen' | 'accessibility' | 'input' | 'notifications'
+  icon: 'screen' | 'access' | 'power' | 'bell'
   name: string
   pane: string      // open_permission_pane argument
   desc: string
+  /** Required grants gate the step's Continue; optional ones never do. */
+  required: boolean
 }
 
 export const PERMISSIONS: PermissionMeta[] = [
   {
-    id: 'accessibility', icon: 'access', name: 'Accessibility', pane: 'accessibility',
+    id: 'accessibility', icon: 'access', name: 'Accessibility', pane: 'accessibility', required: true,
     desc: 'Reads the active app, window titles, and UI labels for accurate context.',
   },
   {
-    id: 'screen', icon: 'screen', name: 'Screen Recording', pane: 'screen_recording',
+    id: 'screen', icon: 'screen', name: 'Screen Recording', pane: 'screen_recording', required: true,
     desc: 'Reads on-screen text to understand your work. Pixels/video are never stored; extracted text stays on-device.',
   },
   {
-    id: 'input', icon: 'power', name: 'Input Monitoring', pane: 'input_monitoring',
+    id: 'input', icon: 'power', name: 'Input Monitoring', pane: 'input_monitoring', required: true,
     desc: 'Detects clicks and typing so Meridian knows when you switch tasks.',
+  },
+  {
+    id: 'notifications', icon: 'bell', name: 'Notifications', pane: 'notifications', required: false,
+    desc: 'Nudges you when a worklog draft is ready or your plan needs attention. Quiet by default — you control every type in Settings.',
   },
 ]
 

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -13,7 +13,7 @@ import type { CSSProperties, ReactNode } from 'react'
 import { invoke, load, tauri } from '@/lib/bridge'
 import { STEPS, Welcome, Completion } from './steps'
 import type { Wiz } from './steps'
-import type { DownloadProgress, MlxStatusResponse, SystemSpecs } from './data'
+import type { DownloadProgress, MlxStatusResponse, NotifState, SystemSpecs } from './data'
 import type { IntegrationsResponse } from '@/lib/api-types'
 import { Btn, Check, Kicker } from './atoms'
 
@@ -30,7 +30,7 @@ export default function SetupWizard() {
   const [mlxErr, setMlxErr] = useState('')
 
   // Step 1 — permissions (live)
-  const [perms, setPerms] = useState<Wiz['perms']>({ accessibility: null, screen: null, input: null })
+  const [perms, setPerms] = useState<Wiz['perms']>({ accessibility: null, screen: null, input: null, notifications: null })
 
   // Step 3 — local intelligence (MLX runtime + model)
   const [specs, setSpecs] = useState<SystemSpecs | null>(null)
@@ -57,16 +57,19 @@ export default function SetupWizard() {
     invoke<SystemSpecs>('detect_system_specs').then(setSpecs).catch(() => {})
   }, [])
 
-  // Poll the three required permissions on the Permissions step.
+  // Poll the three required permissions + optional notifications on the
+  // Permissions step. Notification state also refreshes here after the user
+  // answers the OS dialog or flips the toggle in System Settings.
   useEffect(() => {
     if (!active || step !== 0) return
     const poll = async () => {
-      const [accessibility, screen, input] = await Promise.all([
+      const [accessibility, screen, input, notifications] = await Promise.all([
         invoke<boolean>('check_accessibility').catch(() => false),
         invoke<boolean>('check_screen_recording').catch(() => false),
         invoke<boolean>('check_input_monitoring').catch(() => false),
+        invoke<NotifState>('check_notifications').catch((): NotifState => 'unavailable'),
       ])
-      setPerms({ accessibility, screen, input })
+      setPerms({ accessibility, screen, input, notifications })
     }
     poll()
     const id = setInterval(poll, 2000)
@@ -171,6 +174,21 @@ export default function SetupWizard() {
     invoke('open_permission_pane', { pane: 'input_monitoring' }).catch((e) => setErr(String(e)))
   }, [])
 
+  // Notifications: 'prompt' → request surfaces the one-shot macOS dialog and
+  // returns the answer; after a deny macOS never re-prompts, so the only
+  // recovery is the System Settings → Notifications pane. The request result
+  // updates state immediately; the 2 s poll keeps it honest after pane edits.
+  const grantNotifications = useCallback(async () => {
+    setErr('')
+    try {
+      const state = await invoke<NotifState>('request_notifications')
+      setPerms((prev) => ({ ...prev, notifications: state }))
+      if (state === 'denied') {
+        invoke('open_permission_pane', { pane: 'notifications' }).catch((e) => setErr(String(e)))
+      }
+    } catch (e) { setErr(String(e)) }
+  }, [])
+
   // Retry after a runtime/model provisioning error: clear the one-shot guards so
   // the poll re-drives install → start → prefetch from wherever it stalled.
   const retryModel = useCallback(() => {
@@ -181,7 +199,7 @@ export default function SetupWizard() {
   }, [])
 
   const wiz: Wiz = {
-    perms, openPane, grantScreen, grantInput,
+    perms, openPane, grantScreen, grantInput, grantNotifications,
     specs, mlx, downloading, prefetching, modelReady, progress,
     speed: progress?.speed ?? null,
     err: mlxErr, retryModel,

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -13,7 +13,7 @@ import {
   APP, MODEL_RAM_GB, PERMISSIONS, fmtSize,
 } from './data'
 import type {
-  DownloadProgress, MlxStatusResponse, SystemSpecs,
+  DownloadProgress, MlxStatusResponse, NotifState, SystemSpecs,
 } from './data'
 import type { IntegrationsResponse } from '@/lib/api-types'
 import { TRACKERS } from '@/lib/integrations'
@@ -23,11 +23,14 @@ const SERIF: CSSProperties = { fontFamily: 'var(--font-instrument-serif), Georgi
 
 /** The live wizard handle page.tsx builds and threads to every step body. */
 export interface Wiz {
-  // Step 1 — permissions (live, polled every 2 s)
-  perms: { accessibility: boolean | null; screen: boolean | null; input: boolean | null }
+  // Step 1 — permissions (live, polled every 2 s). The three TCC grants are
+  // booleans; notifications is tri-state (see `NotifState`) because deny and
+  // not-yet-asked need different grant actions.
+  perms: { accessibility: boolean | null; screen: boolean | null; input: boolean | null; notifications: NotifState | null }
   openPane: (pane: string) => void
   grantScreen: () => void
   grantInput: () => void
+  grantNotifications: () => void
   // Step 2 — local intelligence (live MLX status + detected specs)
   specs: SystemSpecs | null
   mlx: MlxStatusResponse | null
@@ -48,7 +51,11 @@ function PermissionsBody({ wiz }: { wiz: Wiz }) {
   return (
     <div className="flex flex-col" style={{ gap: 9 }}>
       {PERMISSIONS.map((p) => {
-        const granted = !!wiz.perms[p.id]
+        const notif = p.id === 'notifications'
+        // Unbundled runs (`tauri dev`) have no notification plugin at all —
+        // nothing to grant, so the card hides rather than dead-ends.
+        if (notif && wiz.perms.notifications === 'unavailable') return null
+        const granted = notif ? wiz.perms.notifications === 'granted' : !!wiz.perms[p.id]
         return (
           <Row key={p.id} tone={granted ? 'tint' : 'surface'}>
             <span className="flex items-center justify-center shrink-0" style={{
@@ -61,7 +68,7 @@ function PermissionsBody({ wiz }: { wiz: Wiz }) {
             <div style={{ flex: 1, minWidth: 0 }}>
               <div className="flex items-center" style={{ gap: 8 }}>
                 <span style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--t-title)' }}>{p.name}</span>
-                <span className="font-mono" style={{ fontSize: 9, letterSpacing: '.1em', color: 'var(--t-faint)', border: '0.5px solid var(--t-card-border)', borderRadius: 4, padding: '1px 5px' }}>REQUIRED</span>
+                <span className="font-mono" style={{ fontSize: 9, letterSpacing: '.1em', color: 'var(--t-faint)', border: '0.5px solid var(--t-card-border)', borderRadius: 4, padding: '1px 5px' }}>{p.required ? 'REQUIRED' : 'OPTIONAL'}</span>
               </div>
               <p style={{ fontSize: 11.5, lineHeight: 1.4, color: 'var(--t-faint)', marginTop: 3 }}>{p.desc}</p>
             </div>
@@ -69,7 +76,12 @@ function PermissionsBody({ wiz }: { wiz: Wiz }) {
             <div className="shrink-0">
               {granted
                 ? <span className="flex items-center" style={{ gap: 6, fontSize: 12, color: 'var(--color-state-approved)', fontWeight: 500 }}><Check size={15} color="var(--color-state-approved)" />Granted</span>
-                : <Btn size="sm" variant="secondary" onClick={() => p.id === 'input' ? wiz.grantInput() : p.id === 'screen' ? wiz.grantScreen() : wiz.openPane(p.pane)}>Open Settings</Btn>}
+                : notif
+                  // 'prompt' → the button surfaces the one-shot OS dialog;
+                  // 'denied' → macOS won't re-prompt, so it opens the
+                  // Notifications pane (grantNotifications picks the path).
+                  ? <Btn size="sm" variant="secondary" onClick={() => wiz.grantNotifications()}>{wiz.perms.notifications === 'denied' ? 'Open Settings' : 'Allow'}</Btn>
+                  : <Btn size="sm" variant="secondary" onClick={() => p.id === 'input' ? wiz.grantInput() : p.id === 'screen' ? wiz.grantScreen() : wiz.openPane(p.pane)}>Open Settings</Btn>}
             </div>
           </Row>
         )


### PR DESCRIPTION
## Why

The tray already fires `request_permission()` on every bundled launch (`lib.rs`), so the one-shot macOS notification dialog appears at first launch — but **beside** the wizard, with no context. If the user denies it (or dismisses it unanswered and later denies), there is no recovery surface anywhere in the product: toasts silently never show, and the only trace is a log line. With interactive nudges now the main proactive channel (#392: plan nudge, worklog-ready, snooze buttons), that silent-deny hole matters.

## What

**Rust (tray)**
- `check_notifications` / `request_notifications` commands (`commands/setup.rs`) — return the tri-state authorization as `granted` / `denied` / `prompt`, or `unavailable` on unbundled runs (the plugin registers only inside a `.app`, per NOTIFICATIONS.md gotcha 4). Tri-state because deny vs not-yet-asked need different grant actions: macOS shows the dialog exactly once.
- Pure `notification_state_label` mapper + unit test.
- `open_permission_pane` gains a `notifications` pane (bare pane, no per-app anchor — undocumented and version-inconsistent) — the deny recovery path.
- `sys::notifier` widened to `pub(crate)` so the probe shares the one plugin lookup.

**Wizard (ui/app/setup)**
- New **Notifications** card on the Permissions step, marked `OPTIONAL` (the three TCC grants keep `REQUIRED`); it never gates Continue.
- Button behaviour: `prompt` → **Allow** (surfaces the OS dialog via `request_notifications`); `denied` → **Open Settings** (deep-links the Notifications pane). Granted state joins the existing 2 s poll, so toggling in System Settings reflects live.
- Card hides entirely when `unavailable` (`tauri dev`) instead of dead-ending.
- `PermissionMeta` gains `required`; new bell `PermIcon`.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean; `cargo test` 51/51 (incl. new mapper test)
- `ui`: `npm run build` (static export) clean; `bun test` 243/243
- Interactive behaviour needs a packaged build (plugin gotcha 4) — needs a staging build to verify the dialog/Settings paths end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUNrrP7ie4eeJKGPV6EXNp