### PR TITLE
fix(setup): polish first-run wizard copy, permissions, and window chrome

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Meridian is a single-process Rust daemon that normalises raw screen-capture fram
 - NEVER merge a PR automatically — open/update PRs as needed, but leave the actual merge to a human reviewer
 - NEVER push directly to `main` — always create a separate feature branch, commit there, and raise a PR to `main`
 - ALWAYS use a separate branch per feature/fix — branch name format: `type/short-description` (e.g. `feat/trello-oauth`, `fix/ui-disconnect`)
+- In all **user-facing app text** — window titles, wizard/UI copy, button and menu labels, notification bodies, tray tooltips, any string the user reads — use a plain hyphen `-` only. NEVER an em-dash (`—`), en-dash (`–`), or double hyphen (`--`). Use it spaced (` - `) where a dash separates clauses. (This rule is about displayed strings; code comments and docs are exempt.)
 
 ---
 

--- a/tray/src-tauri/src/capture/ui_events.rs
+++ b/tray/src-tauri/src/capture/ui_events.rs
@@ -88,20 +88,28 @@ fn input_monitoring_granted() -> bool {
 }
 
 /// Run the input recorder until `tx` closes. **Blocking** — call on a dedicated
-/// OS thread. Requests Input Monitoring only when not already granted; degrades
-/// to a no-op recorder (emits nothing) when it's denied, rather than failing.
+/// OS thread. **Never prompts for Input Monitoring:** the setup wizard dropped it
+/// as a permission because the signals the daemon actually consumes
+/// (`clipboard` and `app_switch`, via `get_signals`) come from the
+/// Accessibility-only workspace observer and clipboard poller — see
+/// `screenpipe-a11y` `macos.rs`. When Input Monitoring isn't already granted the
+/// recorder runs in **reduced mode** (clipboard and app/window events, no
+/// click/key/text CGEventTap) rather than surfacing a cold, wizard-less TCC
+/// dialog; the click/key stream feeds only the minor Option-C `ended_at`
+/// refinement. `start()` degrades to a no-op recorder (emits nothing) if even
+/// reduced mode can't attach, rather than failing.
 pub(crate) fn run_ui_event_recorder(tx: UiEventTx) {
     let recorder = UiRecorder::new(recorder_config());
-    // Check Input Monitoring first; only call request_permissions() (which can
-    // prompt) when it isn't already granted, so a granted permission never
-    // re-triggers the system prompt on launch.
+    // Do NOT request Input Monitoring here — prompting would raise a cold TCC
+    // dialog the wizard no longer explains. Just log the current status for
+    // observability; `recorder.start()` selects full vs reduced mode itself.
     if input_monitoring_granted() {
-        info!("capture: input monitoring already granted — not prompting");
+        info!("capture: input monitoring granted — full ui-event capture (incl. click/key/text)");
     } else {
-        let perms = recorder.request_permissions();
-        if !perms.input_monitoring {
-            warn!("capture: input monitoring not granted — ui events unavailable until the user grants it");
-        }
+        info!(
+            "capture: input monitoring not granted — reduced mode \
+             (clipboard + app/window events; no click/key/text tap)"
+        );
     }
     let handle = match recorder.start() {
         Ok(h) => h,

--- a/tray/src-tauri/src/commands/setup.rs
+++ b/tray/src-tauri/src/commands/setup.rs
@@ -118,9 +118,8 @@ pub async fn check_screen_recording() -> bool {
 /// status read that never registers the app. On a fresh install this means the
 /// list under Privacy → Screen Recording shows "No Items", because macOS only
 /// adds an entry the *first* time the app calls `CGRequestScreenCaptureAccess`.
-/// This command calls that request variant (analogous to `request_input_monitoring`)
-/// so clicking the wizard's grant button both registers the app and shows the
-/// system dialog in one shot.
+/// This command calls that request variant so clicking the wizard's grant
+/// button both registers the app and shows the system dialog in one shot.
 #[tauri::command]
 #[tracing::instrument]
 pub async fn request_screen_recording() -> bool {
@@ -140,68 +139,13 @@ pub async fn request_screen_recording() -> bool {
     false
 }
 
-/// Returns `true` when the tray holds macOS **Input Monitoring** permission.
-///
-/// The in-process input recorder (`capture::ui_events::run_ui_event_recorder`)
-/// runs a `CGEventTap` listener, which macOS gates behind Input Monitoring.
-/// Without it the recorder degrades silently and `capture_ui_events` stays empty,
-/// so the daemon's Option C `ended_at` refinement never fires — hence the wizard
-/// must surface it as its own card. `IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)`
-/// reads the grant directly (no prompt, no side effects), mirroring the
-/// `CGPreflightScreenCaptureAccess` / `AXIsProcessTrusted` probes above. The
-/// *grant* action is the wizard's "Open in System Settings" button
-/// ([`crate::commands::system::open_permission_pane`] `"input_monitoring"`).
-#[tauri::command]
-#[tracing::instrument]
-pub async fn check_input_monitoring() -> bool {
-    #[cfg(target_os = "macos")]
-    {
-        #[link(name = "IOKit", kind = "framework")]
-        extern "C" {
-            fn IOHIDCheckAccess(request_type: u32) -> u32;
-        }
-        // kIOHIDRequestTypeListenEvent = 1 (Input Monitoring);
-        // kIOHIDAccessTypeGranted = 0.
-        const LISTEN_EVENT: u32 = 1;
-        const GRANTED: u32 = 0;
-        // Safety: IOHIDCheckAccess is a pure status read — no prompt, no side effects.
-        unsafe { IOHIDCheckAccess(LISTEN_EVENT) == GRANTED }
-    }
-    #[cfg(not(target_os = "macos"))]
-    false
-}
-
-/// Surface the macOS Input Monitoring prompt **and register the app** so it
-/// appears in the Input Monitoring list, then return the resulting grant state.
-///
-/// [`check_input_monitoring`] only *reads* status (`IOHIDCheckAccess`) — it never
-/// registers the app, so on a fresh install the System Settings pane shows
-/// "No Items" and the user has nothing to toggle. `IOHIDRequestAccess` is the
-/// grant analogue of `CGRequestScreenCaptureAccess`: on first call it shows the
-/// system prompt and registers the app; thereafter it's a no-op returning the
-/// current state. The wizard calls this from the Input Monitoring card's button
-/// (alongside opening the pane). Note `IOHIDRequestAccess` returns a `Boolean`
-/// (granted/not) — unlike `IOHIDCheckAccess`, which returns the access-type enum.
-#[tauri::command]
-#[tracing::instrument]
-pub async fn request_input_monitoring() -> bool {
-    #[cfg(target_os = "macos")]
-    {
-        #[link(name = "IOKit", kind = "framework")]
-        extern "C" {
-            fn IOHIDRequestAccess(request_type: u32) -> bool;
-        }
-        // kIOHIDRequestTypeListenEvent = 1 (Input Monitoring).
-        const LISTEN_EVENT: u32 = 1;
-        // Safety: IOHIDRequestAccess surfaces the TCC prompt + registers the app,
-        // then returns a Boolean grant state — no UB.
-        let granted = unsafe { IOHIDRequestAccess(LISTEN_EVENT) };
-        tracing::info!(granted, "setup: requested Input Monitoring access");
-        granted
-    }
-    #[cfg(not(target_os = "macos"))]
-    false
-}
+// Input Monitoring is intentionally NOT a wizard permission — the `check_` /
+// `request_input_monitoring` commands were removed. The signals the daemon
+// consumes (clipboard + app_switch) ride the Accessibility-only capture path;
+// Input Monitoring only added the click/key/text tap (minor Option-C ended_at
+// refinement) and is redundant with Accessibility for everything the wizard
+// gates. See the note on PERMISSIONS in `ui/app/setup/data.ts` and
+// `capture::ui_events::run_ui_event_recorder`.
 
 /// Map the notification plugin's [`tauri_plugin_notifications::PermissionState`]
 /// to the wizard's wire string. Pure so the mapping is unit-testable without a

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -530,8 +530,6 @@ pub fn run() {
             commands::check_accessibility,
             commands::check_screen_recording,
             commands::request_screen_recording,
-            commands::check_input_monitoring,
-            commands::request_input_monitoring,
             commands::check_notifications,
             commands::request_notifications,
             commands::get_mlx_status,

--- a/tray/src-tauri/src/tray.rs
+++ b/tray/src-tauri/src/tray.rs
@@ -168,15 +168,63 @@ pub(crate) fn open_wizard_window(app: &tauri::AppHandle) {
         let _ = win.set_focus();
         return;
     }
-    // The wizard renders the "A · Rail" shell (a 948×628 onboarding window with a
-    // left step rail); size the host window to fit it with a little breathing room.
-    if let Err(e) = WebviewWindowBuilder::new(app, "setup", WebviewUrl::App("setup".into()))
-        .title("Meridian — Setup")
-        .inner_size(980.0, 660.0)
-        .resizable(false)
+    // The wizard renders the "A · Rail" shell — a fixed 948×628 card centred on a
+    // full-bleed backdrop; size the host window to fit it with a little breathing
+    // room. Resizable (with a floor at the design size) so the user can grow it or
+    // enter macOS full-screen — the card stays centred and the backdrop just widens,
+    // so the layout never breaks.
+    match WebviewWindowBuilder::new(app, "setup", WebviewUrl::App("setup".into()))
+        .title("Meridian - Setup")
+        // Transparent title bar so the webview fills the *whole* window and the
+        // centred card gets equal backdrop margins on all four sides. With a
+        // normal (opaque) title bar the bar sits above the webview, so the top
+        // gap reads larger than the sides/bottom. Sized so the 948×628 card keeps
+        // ~26px margins all round — enough clearance for the overlaid traffic
+        // lights + title to sit in the top backdrop, not on the card.
+        .inner_size(1000.0, 680.0)
+        .min_inner_size(1000.0, 680.0)
+        .resizable(true)
+        .title_bar_style(tauri::TitleBarStyle::Transparent)
         .zoom_hotkeys_enabled(true)
         .build()
     {
-        eprintln!("tray: failed to open setup wizard: {e}");
+        Ok(_win) => {
+            // Opt the window into native full-screen so the green traffic-light
+            // shows the enter-full-screen arrows, not the plain zoom (+) glyph.
+            #[cfg(target_os = "macos")]
+            make_fullscreenable(&_win);
+        }
+        Err(e) => eprintln!("tray: failed to open setup wizard: {e}"),
+    }
+}
+
+/// macOS: opt a window into native full-screen. Tauri leaves
+/// `NSWindowCollectionBehaviorFullScreenPrimary` off even for a resizable window,
+/// so the green traffic-light button falls back to zoom (`+`) instead of the
+/// enter-full-screen arrows. OR the flag onto the raw `NSWindow` to fix it.
+#[cfg(target_os = "macos")]
+fn make_fullscreenable(win: &tauri::WebviewWindow) {
+    use objc2::{msg_send, runtime::AnyObject};
+
+    let ptr = match win.ns_window() {
+        Ok(p) if !p.is_null() => p as *mut AnyObject,
+        _ => {
+            tracing::warn!(label = %win.label(), "make_fullscreenable: ns_window unavailable");
+            return;
+        }
+    };
+    // NSWindowCollectionBehaviorFullScreenPrimary = 1 << 7.
+    const FULLSCREEN_PRIMARY: usize = 1 << 7;
+    // Safety: called on the main thread (menu dispatch / setup hook) with standard
+    // NSWindow selectors and no ownership transfer.
+    unsafe {
+        let ns = &*ptr;
+        let current: usize = msg_send![ns, collectionBehavior];
+        let _: () = msg_send![ns, setCollectionBehavior: current | FULLSCREEN_PRIMARY];
+        tracing::info!(
+            label = %win.label(),
+            behavior = current | FULLSCREEN_PRIMARY,
+            "make_fullscreenable: enabled native full-screen"
+        );
     }
 }

--- a/ui/__tests__/setup-data.test.ts
+++ b/ui/__tests__/setup-data.test.ts
@@ -1,0 +1,29 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import { describe, it, expect } from 'bun:test'
+import { MODEL_ID, fmtModelLabel } from '../app/setup/data'
+
+describe('fmtModelLabel', () => {
+  it('formats the real MODEL_ID without duplicating the parameter size (the doubled "2B" bug)', () => {
+    expect(fmtModelLabel(MODEL_ID)).toBe('Qwen3.5 2B · 4-bit')
+  })
+
+  it('strips the org prefix', () => {
+    expect(fmtModelLabel('mlx-community/Qwen3.5-2B-OptiQ-4bit')).not.toContain('mlx-community')
+  })
+
+  it('drops the quantization scheme name', () => {
+    expect(fmtModelLabel('mlx-community/Qwen3.5-2B-OptiQ-4bit')).not.toContain('OptiQ')
+  })
+
+  it('handles an id with no org prefix', () => {
+    expect(fmtModelLabel('Qwen3.5-2B-OptiQ-4bit')).toBe('Qwen3.5 2B · 4-bit')
+  })
+
+  it('handles an id with no bit-width suffix', () => {
+    expect(fmtModelLabel('mlx-community/Some-Model')).toBe('Some Model')
+  })
+
+  it('accepts a hyphenated bit-width form (e.g. "4-bit")', () => {
+    expect(fmtModelLabel('org/Name-8-bit')).toBe('Name · 8-bit')
+  })
+})

--- a/ui/app/setup/data.ts
+++ b/ui/app/setup/data.ts
@@ -49,10 +49,15 @@ export const MODEL_RAM_GB = 1.5
 /** Meridian's own resident footprint (background service), separate from the model. */
 export const APP = { diskGB: 0.18, ramGB: 0.15 }
 
-// ── macOS permissions — the three required TCC grants + optional notifications ─
+// ── macOS permissions — two required TCC grants + optional notifications ─────
 // (The design's Launch-at-login toggle is intentionally omitted: no backend
-// exists for it. The in-process capture pipeline genuinely needs Input
-// Monitoring, which the design omitted.)
+// exists for it. Input Monitoring is omitted too: the signals the daemon
+// actually consumes — clipboard + app_switch (get_signals) — come from the
+// Accessibility-only workspace observer + clipboard poller, so they need no
+// separate Input Monitoring grant. Input Monitoring would only add the
+// click/key/text CGEventTap, which feeds solely the minor Option-C `ended_at`
+// refinement — not worth its own wizard step + TCC prompt. See
+// screenpipe-a11y/src/platform/macos.rs — Thread 2 is "accessibility only".)
 
 /** Notification authorization (`check_notifications`). Tri-state, not boolean:
  *  macOS shows the authorization dialog exactly once, so `denied` and `prompt`
@@ -61,8 +66,8 @@ export const APP = { diskGB: 0.18, ramGB: 0.15 }
 export type NotifState = 'granted' | 'denied' | 'prompt' | 'unavailable'
 
 export interface PermissionMeta {
-  id: 'screen' | 'accessibility' | 'input' | 'notifications'
-  icon: 'screen' | 'access' | 'power' | 'bell'
+  id: 'screen' | 'accessibility' | 'notifications'
+  icon: 'screen' | 'access' | 'bell'
   name: string
   pane: string      // open_permission_pane argument
   desc: string
@@ -78,10 +83,6 @@ export const PERMISSIONS: PermissionMeta[] = [
   {
     id: 'screen', icon: 'screen', name: 'Screen Recording', pane: 'screen_recording', required: true,
     desc: 'Reads on-screen text to understand your work. Pixels/video are never stored; extracted text stays on-device.',
-  },
-  {
-    id: 'input', icon: 'power', name: 'Input Monitoring', pane: 'input_monitoring', required: true,
-    desc: 'Detects clicks and typing so Meridian knows when you switch tasks.',
   },
   {
     id: 'notifications', icon: 'bell', name: 'Notifications', pane: 'notifications', required: false,

--- a/ui/app/setup/data.ts
+++ b/ui/app/setup/data.ts
@@ -46,6 +46,21 @@ export interface SystemSpecs {
 export const MODEL_ID = 'mlx-community/Qwen3.5-2B-OptiQ-4bit'
 export const MODEL_RAM_GB = 1.5
 
+/**
+ * Human label for a model id, e.g. 'mlx-community/Qwen3.5-2B-OptiQ-4bit' →
+ * 'Qwen3.5 2B · 4-bit'. Derived (not hand-typed) so the Completion summary
+ * line can't drift from MODEL_ID or duplicate a segment by hand-editing error.
+ */
+export function fmtModelLabel(id: string): string {
+  const name = id.split('/').pop() ?? id
+  const bits = name.match(/(\d+)-?bit$/i)?.[1]
+  const base = name
+    .replace(/-?\d+-?bit$/i, '')
+    .replace(/-OptiQ$/i, '')
+    .replace(/-/g, ' ')
+  return bits ? `${base} · ${bits}-bit` : base
+}
+
 /** Meridian's own resident footprint (background service), separate from the model. */
 export const APP = { diskGB: 0.18, ramGB: 0.15 }
 

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -30,7 +30,7 @@ export default function SetupWizard() {
   const [mlxErr, setMlxErr] = useState('')
 
   // Step 1 — permissions (live)
-  const [perms, setPerms] = useState<Wiz['perms']>({ accessibility: null, screen: null, input: null, notifications: null })
+  const [perms, setPerms] = useState<Wiz['perms']>({ accessibility: null, screen: null, notifications: null })
 
   // Step 3 — local intelligence (MLX runtime + model)
   const [specs, setSpecs] = useState<SystemSpecs | null>(null)
@@ -57,19 +57,20 @@ export default function SetupWizard() {
     invoke<SystemSpecs>('detect_system_specs').then(setSpecs).catch(() => {})
   }, [])
 
-  // Poll the three required permissions + optional notifications on the
-  // Permissions step. Notification state also refreshes here after the user
-  // answers the OS dialog or flips the toggle in System Settings.
+  // Poll the two required permissions + optional notifications on the
+  // Permissions step. Input Monitoring is intentionally not polled — it's
+  // redundant with Accessibility (see the note on PERMISSIONS in ./data.ts).
+  // Notification state also refreshes here after the user answers the OS
+  // dialog or flips the toggle in System Settings.
   useEffect(() => {
     if (!active || step !== 0) return
     const poll = async () => {
-      const [accessibility, screen, input, notifications] = await Promise.all([
+      const [accessibility, screen, notifications] = await Promise.all([
         invoke<boolean>('check_accessibility').catch(() => false),
         invoke<boolean>('check_screen_recording').catch(() => false),
-        invoke<boolean>('check_input_monitoring').catch(() => false),
         invoke<NotifState>('check_notifications').catch((): NotifState => 'unavailable'),
       ])
-      setPerms({ accessibility, screen, input, notifications })
+      setPerms({ accessibility, screen, notifications })
     }
     poll()
     const id = setInterval(poll, 2000)
@@ -159,19 +160,11 @@ export default function SetupWizard() {
   }, [])
 
   // Screen Recording needs an explicit request to register the app before the
-  // Settings pane shows anything to toggle (same pattern as grantInput).
+  // Settings pane shows anything to toggle (else it lists "No Items").
   const grantScreen = useCallback(async () => {
     setErr('')
     try { await invoke('request_screen_recording') } catch { /* prompt is best-effort */ }
     invoke('open_permission_pane', { pane: 'screen_recording' }).catch((e) => setErr(String(e)))
-  }, [])
-
-  // Input Monitoring needs an explicit request to register the app before the
-  // Settings pane shows anything to toggle (mirrors the original wizard).
-  const grantInput = useCallback(async () => {
-    setErr('')
-    try { await invoke('request_input_monitoring') } catch { /* prompt is best-effort */ }
-    invoke('open_permission_pane', { pane: 'input_monitoring' }).catch((e) => setErr(String(e)))
   }, [])
 
   // Notifications: 'prompt' → request surfaces the one-shot macOS dialog and
@@ -199,7 +192,7 @@ export default function SetupWizard() {
   }, [])
 
   const wiz: Wiz = {
-    perms, openPane, grantScreen, grantInput, grantNotifications,
+    perms, openPane, grantScreen, grantNotifications,
     specs, mlx, downloading, prefetching, modelReady, progress,
     speed: progress?.speed ?? null,
     err: mlxErr, retryModel,
@@ -230,11 +223,25 @@ export default function SetupWizard() {
   }
 
   return (
-    <div style={{ position: 'fixed', inset: 0, display: 'grid', placeItems: 'center', background: 'var(--t-panel)' }}>
+    <div style={{
+      position: 'fixed', inset: 0, display: 'grid', placeItems: 'center',
+      // Subtle top-lit depth so the centred card reads as a distinct surface —
+      // otherwise, when the window is enlarged / full-screened, the card floats
+      // on a big flat panel.
+      background: 'radial-gradient(130% 130% at 50% 0%, color-mix(in srgb, var(--t-card) 34%, var(--t-panel)) 0%, var(--t-panel) 62%)',
+    }}>
       <div className="rise" style={{
         width: 948, height: 628, borderRadius: 18, background: 'var(--t-card)',
         border: '0.5px solid var(--t-card-border)', overflow: 'hidden', color: 'var(--t-title)',
         boxShadow: 'var(--pop-shadow)',
+        // Grow the whole card proportionally as the window grows (macOS
+        // full-screen / manual resize) so it stays a prominent, readable surface
+        // instead of a small rectangle. clamp floor = 1 (never shrinks below the
+        // design size at the default window), cap = 1.7 (won't balloon on a 27").
+        // min() of the width- and height-fits guarantees it never exceeds the
+        // viewport; vector text scales crisply.
+        transform: 'scale(clamp(1, min(calc(100vw / 1010), calc(100vh / 700)), 1.7))',
+        transformOrigin: 'center',
       }}>
         {welcome ? (
           <Welcome onBegin={() => { setWelcome(false); setStep(0) }} />

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -10,7 +10,7 @@
 import type { CSSProperties, ReactNode } from 'react'
 import { Btn, Bar, Check, Kicker, PermIcon, Row, Spinner } from './atoms'
 import {
-  APP, MODEL_RAM_GB, PERMISSIONS, fmtSize,
+  APP, MODEL_ID, MODEL_RAM_GB, PERMISSIONS, fmtModelLabel, fmtSize,
 } from './data'
 import type {
   DownloadProgress, MlxStatusResponse, NotifState, SystemSpecs,
@@ -341,7 +341,7 @@ export function Completion({ wiz }: { wiz: Wiz }) {
   const grantedCount = [wiz.perms.accessibility, wiz.perms.screen].filter(Boolean).length
   const lines = [
     { k: 'Permissions', v: `${grantedCount} of 2 granted` },
-    { k: 'Local model', v: 'Qwen3.5 2B · 2B · 4-bit' },
+    { k: 'Local model', v: fmtModelLabel(MODEL_ID) },
     { k: 'Footprint', v: `${fmtSize(MODEL_RAM_GB + APP.ramGB)} memory` },
     { k: 'Connected', v: connected.length ? connected.map((c) => c.name).join(', ') : 'None yet' },
   ]

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -23,13 +23,12 @@ const SERIF: CSSProperties = { fontFamily: 'var(--font-instrument-serif), Georgi
 
 /** The live wizard handle page.tsx builds and threads to every step body. */
 export interface Wiz {
-  // Step 1 — permissions (live, polled every 2 s). The three TCC grants are
+  // Step 1 — permissions (live, polled every 2 s). The two TCC grants are
   // booleans; notifications is tri-state (see `NotifState`) because deny and
   // not-yet-asked need different grant actions.
-  perms: { accessibility: boolean | null; screen: boolean | null; input: boolean | null; notifications: NotifState | null }
+  perms: { accessibility: boolean | null; screen: boolean | null; notifications: NotifState | null }
   openPane: (pane: string) => void
   grantScreen: () => void
-  grantInput: () => void
   grantNotifications: () => void
   // Step 2 — local intelligence (live MLX status + detected specs)
   specs: SystemSpecs | null
@@ -81,7 +80,7 @@ function PermissionsBody({ wiz }: { wiz: Wiz }) {
                   // 'denied' → macOS won't re-prompt, so it opens the
                   // Notifications pane (grantNotifications picks the path).
                   ? <Btn size="sm" variant="secondary" onClick={() => wiz.grantNotifications()}>{wiz.perms.notifications === 'denied' ? 'Open Settings' : 'Allow'}</Btn>
-                  : <Btn size="sm" variant="secondary" onClick={() => p.id === 'input' ? wiz.grantInput() : p.id === 'screen' ? wiz.grantScreen() : wiz.openPane(p.pane)}>Open Settings</Btn>}
+                  : <Btn size="sm" variant="secondary" onClick={() => p.id === 'screen' ? wiz.grantScreen() : wiz.openPane(p.pane)}>Open Settings</Btn>}
             </div>
           </Row>
         )
@@ -167,7 +166,7 @@ const SETUP_NET_HINTS: { t: string; d: string }[] = [
   { t: 'Internet connection', d: 'Confirm you’re online. On café or hotel Wi-Fi, open a browser and finish any “sign in to connect” page, then Try again.' },
   { t: 'VPN or firewall', d: 'A work VPN or firewall can block the download. Pause the VPN or switch to another network.' },
   { t: 'Network proxy', d: 'If your Mac uses a proxy (System Settings → Network → Proxies), Meridian may not pick it up. Try a network without a proxy.' },
-  { t: 'Security software', d: 'Tools that inspect secure connections can interrupt the download — allow Meridian or pause them briefly.' },
+  { t: 'Security software', d: 'Tools that inspect secure connections can interrupt the download - allow Meridian or pause them briefly.' },
 ]
 
 function MLXBody({ wiz }: { wiz: Wiz }) {
@@ -238,7 +237,7 @@ function MLXBody({ wiz }: { wiz: Wiz }) {
             ? 'The on-device runtime isn’t available for this Mac.'
             : showErr
               ? (wiz.err || 'The download didn’t finish.')
-              : 'Downloading the models that run privately on your Mac — just once.'}
+              : 'Downloading the models that run privately on your Mac - just once.'}
       </p>
 
       {/* Detected specs + expected memory footprint — shown while provisioning
@@ -267,7 +266,7 @@ function MLXBody({ wiz }: { wiz: Wiz }) {
                 <div key={h.t} className="flex items-start" style={{ gap: 8 }}>
                   <span className="font-mono shrink-0" style={{ fontSize: 10.5, color: 'var(--t-faint-2)', fontWeight: 600, lineHeight: 1.55, width: 11 }}>{i + 1}</span>
                   <p style={{ fontSize: 11.5, lineHeight: 1.45, color: 'var(--t-muted)' }}>
-                    <span style={{ fontWeight: 500, color: 'var(--t-title)' }}>{h.t}</span> — {h.d}
+                    <span style={{ fontWeight: 500, color: 'var(--t-title)' }}>{h.t}</span> - {h.d}
                   </p>
                 </div>
               ))}
@@ -292,7 +291,7 @@ function IntegrationsBody({ wiz }: { wiz: Wiz }) {
         <span style={{ width: 5, height: 5, borderRadius: 99, background: connected ? 'var(--color-state-approved)' : 'var(--t-faint-2)' }} />
         {connected > 0
           ? `${connected} connected · Meridian will match sessions and draft worklogs.`
-          : 'Connect your trackers to auto-draft worklogs — or skip and add later from Settings.'}
+          : 'Optional - skip it and Meridian still tracks your day. Connect a tracker anytime from Settings to auto-draft worklogs.'}
       </p>
     </div>
   )
@@ -301,9 +300,9 @@ function IntegrationsBody({ wiz }: { wiz: Wiz }) {
 // ── Welcome (pre-step intro) ──────────────────────────────────────────────────
 export function Welcome({ onBegin }: { onBegin: () => void }) {
   const points = [
-    { t: 'On-device', d: 'Runs on Apple MLX. Classifier input stays local unless you explicitly connect your tools.' },
-    { t: 'Automatic', d: 'Recognises your work and drafts worklogs you approve.' },
-    { t: 'Connected', d: 'Jira and Trello today, more trackers soon.' },
+    { t: 'On-device', d: 'Runs on Apple MLX - your screen is read and understood locally, never uploaded.' },
+    { t: 'Automatic', d: 'Builds an accurate timeline of the tickets you worked on - then drafts the updates for you.' },
+    { t: 'Connected', d: 'Works with Jira, Linear, GitHub, Trello, and Azure DevOps.' },
   ]
   return (
     <div className="flex flex-col items-center justify-center" style={{ height: '100%', textAlign: 'center', padding: '36px 44px' }}>
@@ -313,10 +312,10 @@ export function Welcome({ onBegin }: { onBegin: () => void }) {
       </div>
       <Kicker style={{ marginBottom: 14 }}>First-run setup</Kicker>
       <h1 style={{ ...SERIF, fontSize: 39, lineHeight: 1.02, letterSpacing: '-.015em', color: 'var(--t-title)', maxWidth: 440, textWrap: 'balance' }}>
-        Meridian watches the work, <span style={{ fontStyle: 'italic', color: 'var(--color-state-proposal)' }}>so you don&apos;t have to.</span>
+        Your work, <span style={{ fontStyle: 'italic', color: 'var(--color-state-proposal)' }}>remembered - accurately.</span>
       </h1>
       <p style={{ fontSize: 13.5, lineHeight: 1.55, color: 'var(--t-muted)', marginTop: 14, maxWidth: 380, textWrap: 'pretty' }}>
-        A quiet menu-bar companion that recognises what you&apos;re focused on, drafts your worklogs, and keeps every byte on your Mac.
+        Meridian watches your work on-device and keeps an accurate record of what you actually did - then turns it into worklogs and ticket updates you just approve.
       </p>
       <div className="flex flex-col" style={{ gap: 11, margin: '26px 0 28px', textAlign: 'left', width: '100%', maxWidth: 360 }}>
         {points.map((p) => (
@@ -339,9 +338,9 @@ export function Welcome({ onBegin }: { onBegin: () => void }) {
 // ── Completion ────────────────────────────────────────────────────────────────
 export function Completion({ wiz }: { wiz: Wiz }) {
   const connected = TRACKERS.filter((t) => wiz.integrations?.[t.id])
-  const grantedCount = [wiz.perms.accessibility, wiz.perms.screen, wiz.perms.input].filter(Boolean).length
+  const grantedCount = [wiz.perms.accessibility, wiz.perms.screen].filter(Boolean).length
   const lines = [
-    { k: 'Permissions', v: `${grantedCount} of 3 granted` },
+    { k: 'Permissions', v: `${grantedCount} of 2 granted` },
     { k: 'Local model', v: 'Qwen3.5 2B · 2B · 4-bit' },
     { k: 'Footprint', v: `${fmtSize(MODEL_RAM_GB + APP.ramGB)} memory` },
     { k: 'Connected', v: connected.length ? connected.map((c) => c.name).join(', ') : 'None yet' },
@@ -354,7 +353,7 @@ export function Completion({ wiz }: { wiz: Wiz }) {
       <Kicker style={{ marginBottom: 10 }}>Setup complete</Kicker>
       <h1 style={{ ...SERIF, fontSize: 38, lineHeight: 1, letterSpacing: '-.01em', color: 'var(--t-title)', marginBottom: 10 }}>You&apos;re all set.</h1>
       <p style={{ fontSize: 13.5, lineHeight: 1.5, color: 'var(--t-muted)', maxWidth: 340, textWrap: 'pretty', marginBottom: 22 }}>
-        Meridian is now tracking quietly in your menu bar — on-device, private, and matched to your work.
+        Meridian is now tracking quietly in your menu bar - on-device, private, and matched to your work.
       </p>
       <div style={{ width: '100%', maxWidth: 360, border: '0.5px solid var(--t-card-border)', borderRadius: 13, overflow: 'hidden' }}>
         {lines.map((l, i) => (
@@ -390,15 +389,15 @@ export const STEPS: StepMeta[] = [
   {
     id: 'permissions', n: '01', label: 'Permissions', kicker: 'Access',
     title: 'Let Meridian see your work',
-    subtitle: "Three macOS permissions let Meridian recognise what you're focused on. Read locally, never uploaded.",
+    subtitle: "Two macOS permissions let Meridian recognise what you're focused on. Read locally, never uploaded.",
     Body: PermissionsBody,
-    status: (s) => { const g = [s.perms.accessibility, s.perms.screen, s.perms.input].filter(Boolean).length; return g ? `${g} granted` : 'Not granted' },
-    canNext: (s) => !!(s.perms.accessibility && s.perms.screen && s.perms.input),
+    status: (s) => { const g = [s.perms.accessibility, s.perms.screen].filter(Boolean).length; return g ? `${g} granted` : 'Not granted' },
+    canNext: (s) => !!(s.perms.accessibility && s.perms.screen),
   },
   {
     id: 'integrations', n: '02', label: 'Integrations', kicker: 'Project tools',
     title: 'Connect your trackers',
-    subtitle: 'Link the tools you already use. Meridian matches each session to an issue and drafts a worklog you approve.',
+    subtitle: 'Link the tools you use so Meridian can match sessions to tickets and draft worklogs - skip it and Meridian still tracks your day; connect anytime from Settings.',
     Body: IntegrationsBody,
     status: (s) => { const c = TRACKERS.filter((t) => s.integrations?.[t.id]).length; return c ? `${c} connected` : 'Optional' },
     canNext: () => true,
@@ -406,7 +405,7 @@ export const STEPS: StepMeta[] = [
   {
     id: 'mlx', n: '03', label: 'Local intelligence', kicker: 'On-device AI',
     title: 'Set up on-device intelligence',
-    subtitle: 'Everything runs privately on your Mac with Apple MLX. The models started downloading when setup opened — this is just the finish line.',
+    subtitle: 'Everything runs privately on your Mac with Apple MLX. The models started downloading when setup opened - this is just the finish line.',
     Body: MLXBody,
     status: (s) => s.modelReady ? 'Ready' : (s.mlx?.runtime_found || s.mlx?.runtime_installed) ? 'Downloading…' : 'Installing…',
     // Block Finish until every model is on disk — the worklog pipeline (distill →


### PR DESCRIPTION
## Summary
- Fix the setup window title's em-dash and codify a project-wide rule (CLAUDE.md): all user-facing app text uses a single hyphen, never an em/en-dash.
- Drop **Input Monitoring** from the Permissions step — it's redundant with Accessibility for every signal the daemon actually consumes (`clipboard` + `app_switch` via `get_signals`), and on this hardware it never even produced a real System Settings grant. The capture recorder no longer prompts for it (avoids a cold, wizard-less TCC dialog); it now runs a documented full/reduced capture mode depending on whether it's already granted. Removes the now-orphaned `check_input_monitoring` / `request_input_monitoring` commands.
- Rewrite the Welcome and Integrations copy toward a "see what actually happened" positioning, fix the stale "Jira and Trello today" tracker list (now lists all 5: Jira, Linear, GitHub, Trello, Azure DevOps), and make explicit that connecting a tracker is optional — Meridian still tracks the day without one (the step was already non-blocking; this just makes it legible).
- Make the setup window resizable/full-screenable (native macOS full-screen, not just zoom), scale the wizard card with the window instead of floating small on a big backdrop, and switch to a transparent title bar so the centred card gets symmetric margins on all sides.

## Test plan
- [x] `cargo fmt --check` + `cargo clippy -- -D warnings` clean (root `meridian` package and `tray/src-tauri` both, default + `--no-default-features --features capture`)
- [x] `tsc --noEmit` clean on the setup wizard files
- [x] Manually exercised the wizard in `tauri dev`: title bar, full-screen toggle, 2-permission Permissions step (Accessibility + Screen Recording, gate no longer waits on Input Monitoring), Welcome copy, Integrations optional-skip copy
- [x] Full pre-push suite passed: fmt, ui build, clippy, ui tests, security audit, `cargo test`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01RJ8rU48qbY1A3tthxFkQj8
