### PR TITLE
fix(ui): address GitHub Advanced Security findings from PR #416

### DIFF
--- a/ui/__tests__/popover-health-panel.test.ts
+++ b/ui/__tests__/popover-health-panel.test.ts
@@ -27,11 +27,24 @@ import { GlobalRegistrator } from '@happy-dom/global-registrator'
 const trayDir = import.meta.dir + '/../../tray/src'
 
 // Extract the popover markup from index.html (minus its <script> tags, which we
-// load manually) so the elements app.js queries by id actually exist.
+// load manually) so the elements app.js queries by id actually exist. Loops
+// to a fixed point (not a single pass) and tolerates attributes on the open
+// tag / whitespace before the closing '>' (e.g. </script >), matching what a
+// browser actually treats as a script tag.
+function stripScriptTags(html: string): string {
+  let out = html
+  let prev: string
+  do {
+    prev = out
+    out = out.replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, '')
+  } while (out !== prev)
+  return out
+}
+
 function popoverBody(): string {
   const html = readFileSync(trayDir + '/index.html', 'utf8')
   const m = html.match(/<body[^>]*>([\s\S]*)<\/body>/i)
-  return (m ? m[1] : '').replace(/<script[\s\S]*?<\/script>/gi, '')
+  return stripScriptTags(m ? m[1] : '')
 }
 
 const pauseUtilsSrc = readFileSync(trayDir + '/pause-utils.js', 'utf8')

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -695,14 +695,18 @@ function GitHubProjectPicker({ onSuccess }: { onSuccess?: () => void }) {
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  // Separate from saveError: this one gates the early return below, so
+  // reusing it for save failures would replace the whole picker (losing the
+  // user's selection) instead of showing an inline error next to Save.
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [saveError, setSaveError] = useState<string | null>(null)
   const [reloadWarning, setReloadWarning] = useState(false)
 
   useEffect(() => {
     let cancelled = false
     load<{ projects?: GithubProject[] }>('/api/integrations/github/discover', 'discover_github_projects')
       .then((json) => { if (!cancelled) setProjects(json.projects ?? []) })
-      .catch((e) => { if (!cancelled) setError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Failed to load GitHub Projects') })
+      .catch((e) => { if (!cancelled) setLoadError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Failed to load GitHub Projects') })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
   }, [])
@@ -717,7 +721,7 @@ function GitHubProjectPicker({ onSuccess }: { onSuccess?: () => void }) {
 
   const save = async () => {
     if (selected.size === 0 || saving) return
-    setSaving(true); setError(null)
+    setSaving(true); setSaveError(null)
     try {
       const res = await mutate<{ ok: boolean; reloaded: boolean }>('/api/auth/token', 'save_integration_token', {
         provider: 'github', fields: { project_ids: Array.from(selected).join(',') },
@@ -725,7 +729,7 @@ function GitHubProjectPicker({ onSuccess }: { onSuccess?: () => void }) {
       setReloadWarning(res?.reloaded === false)
       clearProviderNotice('github'); onSuccess?.()
     } catch (e) {
-      setError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Could not save project selection')
+      setSaveError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Could not save project selection')
     } finally {
       setSaving(false)
     }
@@ -733,7 +737,7 @@ function GitHubProjectPicker({ onSuccess }: { onSuccess?: () => void }) {
 
   if (loading) return <p className="text-[11px]" style={{ color: 'var(--ink-3)' }}>Loading your GitHub Projects…</p>
 
-  if (error) return <p className="text-[12px]" style={{ color: '#e53e3e' }}>{error}</p>
+  if (loadError) return <p className="text-[12px]" style={{ color: '#e53e3e' }}>{loadError}</p>
 
   if (!projects || projects.length === 0) {
     return (
@@ -767,7 +771,7 @@ function GitHubProjectPicker({ onSuccess }: { onSuccess?: () => void }) {
           </div>
         ))}
       </div>
-      {error && <p className="text-[11px]" style={{ color: '#e53e3e' }}>{error}</p>}
+      {saveError && <p className="text-[11px]" style={{ color: '#e53e3e' }}>{saveError}</p>}
       <button onClick={save} disabled={selected.size === 0 || saving} className="text-[12px] px-4 py-2 rounded-md font-medium transition-opacity"
         style={{ background: 'var(--accent)', color: '#fff', opacity: (selected.size === 0 || saving) ? 0.5 : 1, cursor: (selected.size === 0 || saving) ? 'not-allowed' : 'pointer' }}>
         {saving ? 'Saving…' : selected.size === 0 ? 'Select a project' : `Sync ${selected.size} project${selected.size === 1 ? '' : 's'}`}


### PR DESCRIPTION
## Summary
Fixes the two GitHub Advanced Security / code-quality findings left on #416 ("promote: pre-main → main"):

- **`ui/__tests__/popover-health-panel.test.ts`** (CodeQL: bad HTML filtering regexp / incomplete multi-character sanitization) — the `<script>`-stripping regex only matched an exact `</script>` close tag in a single non-looping pass. Now tolerates attributes on the open tag and whitespace before the closing `>` (e.g. `</script >`), and loops to a fixed point.
- **`ui/components/IntegrationConnect.tsx`** (code-quality: useless conditional) — `GitHubProjectPicker`'s inline error paragraph next to the Save button was dead code: it shared the same `error` state as the initial-load early return, which always short-circuits first once that state is set. Split into `loadError`/`saveError` so a save failure now actually surfaces inline instead of being masked — and no longer wipes out the user's board selection by falling through to the full-page error view.

## Test plan
- [x] `bun test` in `ui/` — 243 pass, 0 fail (was 8/8 for the touched popover test, confirmed unaffected)
- [x] `bun test __tests__/oauth-setup-lifecycle.test.ts` (references `IntegrationConnect`) — 8/8 pass
- [x] `npx tsc --noEmit` — no new errors introduced

Once merged, `pre-main`'s promotion into #416 will pick this up automatically since #416's head is `pre-main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)