### PR TITLE
fix(setup): notification pane deep-link opens Meridian's settings, skip redundant re-request

### DIFF
--- a/tray/src-tauri/src/commands/system.rs
+++ b/tray/src-tauri/src/commands/system.rs
@@ -109,19 +109,29 @@ pub async fn open_permission_pane(app: tauri::AppHandle, pane: String) -> Result
     let url = match pane.as_str() {
         "screen_recording" => {
             "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+                .to_string()
         }
         "accessibility" => {
             "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+                .to_string()
         }
         "input_monitoring" => {
             "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
+                .to_string()
         }
         // Notification authorization lives under Notifications, not Privacy &
-        // Security. Bare pane, no ?id=<bundle-id> anchor — per-app anchoring is
-        // undocumented and inconsistent across macOS versions. This is the deny
+        // Security. Anchored to our own bundle id so this opens Meridian's
+        // specific notification detail pane (Allow toggle, Alert Style, …)
+        // instead of just the app list — verified working via the
+        // `?id=<bundle-id>` param, which the pane's own extension metadata
+        // (`NotificationsSettings.appex`'s `allowsXAppleSystemPreferencesURLScheme`)
+        // supports even though it's otherwise undocumented. This is the deny
         // recovery path: macOS shows the authorization dialog exactly once, so
         // after a deny the wizard can only send the user here.
-        "notifications" => "x-apple.systempreferences:com.apple.preference.notifications",
+        "notifications" => format!(
+            "x-apple.systempreferences:com.apple.preference.notifications?id={}",
+            app.config().identifier
+        ),
         other => return Err(format!("unknown permission pane: {other}")),
     };
     dismiss_popover(&app);

--- a/ui/app/setup/atoms.tsx
+++ b/ui/app/setup/atoms.tsx
@@ -111,6 +111,40 @@ export function Bar({ pct, height = 6, track = 'var(--t-hair)', fill = 'var(--co
   )
 }
 
+// ── Semi-circular memory gauge ───────────────────────────────────────────────
+// Distinct on purpose from `Bar` above (straight, used for download progress):
+// this reads as a capacity dial rather than a loading indicator, so the two
+// never get confused for one another. Drawn as two arcs meeting at `pct` —
+// amber for the footprint Meridian expects to use, green for the unified
+// memory left over — rather than a single fill against a neutral track.
+export function MemoryGauge({ pct, size = 96, strokeWidth = 9 }: {
+  pct: number; size?: number; strokeWidth?: number
+}) {
+  const r = size / 2 - strokeWidth
+  const cx = size / 2
+  const cy = size / 2
+  const clamped = Math.max(0, Math.min(100, pct))
+  const splitAngle = 180 + (clamped / 100) * 180
+  const polar = (angleDeg: number) => {
+    const rad = (angleDeg * Math.PI) / 180
+    return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) }
+  }
+  const arc = (startAngle: number, endAngle: number) => {
+    const start = polar(startAngle)
+    const end = polar(endAngle)
+    const largeArc = endAngle - startAngle > 180 ? 1 : 0
+    return `M ${start.x} ${start.y} A ${r} ${r} 0 ${largeArc} 1 ${end.x} ${end.y}`
+  }
+  return (
+    <svg width={size} height={size / 2 + strokeWidth} viewBox={`0 0 ${size} ${size / 2 + strokeWidth}`}>
+      <path d={arc(splitAngle, 360)} fill="none" stroke="var(--color-state-approved)"
+        strokeWidth={strokeWidth} strokeLinecap="round" />
+      <path d={arc(180, splitAngle)} fill="none" stroke="var(--color-state-pending)"
+        strokeWidth={strokeWidth} strokeLinecap="round" />
+    </svg>
+  )
+}
+
 // ── Kicker / eyebrow label ───────────────────────────────────────────────────
 export function Kicker({ children, color = 'var(--t-faint)', style }: { children: ReactNode; color?: string; style?: CSSProperties }) {
   return (<p className="font-mono" style={{ fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color, ...style }}>{children}</p>)

--- a/ui/app/setup/data.ts
+++ b/ui/app/setup/data.ts
@@ -101,7 +101,7 @@ export const PERMISSIONS: PermissionMeta[] = [
   },
   {
     id: 'notifications', icon: 'bell', name: 'Notifications', pane: 'notifications', required: false,
-    desc: 'Nudges you when a worklog draft is ready or your plan needs attention. Quiet by default — you control every type in Settings.',
+    desc: 'Nudges you when a worklog draft is ready or your plan needs attention. Quiet by default - you control every type in Settings.',
   },
 ]
 

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -70,7 +70,18 @@ export default function SetupWizard() {
         invoke<boolean>('check_screen_recording').catch(() => false),
         invoke<NotifState>('check_notifications').catch((): NotifState => 'unavailable'),
       ])
-      setPerms({ accessibility, screen, notifications })
+      setPerms((prev) => ({
+        accessibility, screen,
+        // Bundled-ness is fixed for the process lifetime, so once we've seen a
+        // real state (prompt/granted/denied) a later 'unavailable' can only be
+        // a transient Swift-bridge hiccup on this one poll tick, never a
+        // genuine regression — keep the last known-good state instead of
+        // flashing the card away and back every ~2s.
+        notifications:
+          notifications === 'unavailable' && prev.notifications && prev.notifications !== 'unavailable'
+            ? prev.notifications
+            : notifications,
+      }))
     }
     poll()
     const id = setInterval(poll, 2000)

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -169,10 +169,17 @@ export default function SetupWizard() {
 
   // Notifications: 'prompt' → request surfaces the one-shot macOS dialog and
   // returns the answer; after a deny macOS never re-prompts, so the only
-  // recovery is the System Settings → Notifications pane. The request result
+  // recovery is the System Settings → Notifications pane — go straight there
+  // instead of re-requesting (the request would just silently re-resolve to
+  // 'denied' with no dialog, adding a pointless round-trip through the
+  // notification plugin before ever reaching the pane). The request result
   // updates state immediately; the 2 s poll keeps it honest after pane edits.
-  const grantNotifications = useCallback(async () => {
+  const grantNotifications = useCallback(async (alreadyDenied: boolean) => {
     setErr('')
+    if (alreadyDenied) {
+      invoke('open_permission_pane', { pane: 'notifications' }).catch((e) => setErr(String(e)))
+      return
+    }
     try {
       const state = await invoke<NotifState>('request_notifications')
       setPerms((prev) => ({ ...prev, notifications: state }))

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -29,7 +29,7 @@ export interface Wiz {
   perms: { accessibility: boolean | null; screen: boolean | null; notifications: NotifState | null }
   openPane: (pane: string) => void
   grantScreen: () => void
-  grantNotifications: () => void
+  grantNotifications: (alreadyDenied: boolean) => void
   // Step 2 — local intelligence (live MLX status + detected specs)
   specs: SystemSpecs | null
   mlx: MlxStatusResponse | null
@@ -78,8 +78,9 @@ function PermissionsBody({ wiz }: { wiz: Wiz }) {
                 : notif
                   // 'prompt' → the button surfaces the one-shot OS dialog;
                   // 'denied' → macOS won't re-prompt, so it opens the
-                  // Notifications pane (grantNotifications picks the path).
-                  ? <Btn size="sm" variant="secondary" onClick={() => wiz.grantNotifications()}>{wiz.perms.notifications === 'denied' ? 'Open Settings' : 'Allow'}</Btn>
+                  // Notifications pane directly (grantNotifications skips the
+                  // pointless re-request when told it's already denied).
+                  ? <Btn size="sm" variant="secondary" onClick={() => wiz.grantNotifications(wiz.perms.notifications === 'denied')}>{wiz.perms.notifications === 'denied' ? 'Open Settings' : 'Allow'}</Btn>
                   : <Btn size="sm" variant="secondary" onClick={() => p.id === 'screen' ? wiz.grantScreen() : wiz.openPane(p.pane)}>Open Settings</Btn>}
             </div>
           </Row>

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -67,7 +67,7 @@ function PermissionsBody({ wiz }: { wiz: Wiz }) {
             <div style={{ flex: 1, minWidth: 0 }}>
               <div className="flex items-center" style={{ gap: 8 }}>
                 <span style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--t-title)' }}>{p.name}</span>
-                <span className="font-mono" style={{ fontSize: 9, letterSpacing: '.1em', color: 'var(--t-faint)', border: '0.5px solid var(--t-card-border)', borderRadius: 4, padding: '1px 5px' }}>{p.required ? 'REQUIRED' : 'OPTIONAL'}</span>
+                {!notif && <span className="font-mono" style={{ fontSize: 9, letterSpacing: '.1em', color: 'var(--t-faint)', border: '0.5px solid var(--t-card-border)', borderRadius: 4, padding: '1px 5px' }}>{p.required ? 'REQUIRED' : 'OPTIONAL'}</span>}
               </div>
               <p style={{ fontSize: 11.5, lineHeight: 1.4, color: 'var(--t-faint)', marginTop: 3 }}>{p.desc}</p>
             </div>

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -8,7 +8,7 @@
 // detected hardware, and the model tiles map to real checkpoints.
 
 import type { CSSProperties, ReactNode } from 'react'
-import { Btn, Bar, Check, Kicker, PermIcon, Row, Spinner } from './atoms'
+import { Btn, Bar, Check, Kicker, MemoryGauge, PermIcon, Row, Spinner } from './atoms'
 import {
   APP, MODEL_ID, MODEL_RAM_GB, PERMISSIONS, fmtModelLabel, fmtSize,
 } from './data'
@@ -149,7 +149,11 @@ function SpecMemoryPanel({ specs }: { specs: SystemSpecs | null }) {
           ≈&nbsp;{fmtSize(footprintGb)}{ram > 0 ? ` of ${ram} GB` : ''}
         </span>
       </div>
-      {pct !== null && <Bar pct={pct} height={5} />}
+      {pct !== null && (
+        <div className="flex items-center justify-center" style={{ marginBottom: 2 }}>
+          <MemoryGauge pct={pct} />
+        </div>
+      )}
       {specBits.length > 0 && (
         <p className="font-mono" style={{ fontSize: 10.5, color: 'var(--t-faint-2)', marginTop: 9, letterSpacing: '.02em' }}>
           {specBits.join('  ·  ')}


### PR DESCRIPTION
## Summary
- `open_permission_pane`'s notifications URL had no app anchor, so "Open Settings" landed on the general Notifications list instead of Meridian's own row. Anchored it with `?id=<bundle-id>` — verified live against `NotificationsSettings.appex`'s metadata, which documents support for this param (`allowsXAppleSystemPreferencesURLScheme`).
- `grantNotifications` always called `request_notifications` first, even when already denied. macOS never re-prompts after a deny, so this was a pointless async round-trip through the Swift notification-plugin bridge before ever reaching the Settings pane — a plausible source of the reported "flickers, doesn't open" behavior. Now skips straight to `open_permission_pane` when the caller already knows the state is denied.
- **Notifications card flicker (found during live manual testing above)**: `check_notifications` polls every 2s; a transient Swift-bridge hiccup can make the Rust command return `'unavailable'` as a normal (non-error) result for a single poll tick, which the card's hide-when-unavailable check then treats as the plugin having vanished — flashing the whole card away and back. Bundled-ness is fixed for the process lifetime, so once a real state (`prompt`/`granted`/`denied`) has been observed, a later `'unavailable'` can only be that glitch, never a genuine regression — the poll now keeps the last known-good state instead.
- **Notifications row now omits the REQUIRED/OPTIONAL badge** (Accessibility/Screen Recording still show `REQUIRED`). Intentional, requested during live wizard testing: unlike those two, notifications doesn't gate `canNext` on the Permissions step — nothing about the row conveys a requirement to satisfy, so the `OPTIONAL` label was pure visual noise where `REQUIRED` on the other two rows is actually meaningful (it signals what blocks continuing). Dropping it declutters the row without losing information.
- **Copy**: notifications description now uses a plain hyphen (`Quiet by default - you control…`) instead of an em dash, matching the hyphen style used everywhere else in the wizard's copy.
- **New**: semi-circular gauge (`MemoryGauge` in `atoms.tsx`) for the Local-intelligence step's "Expected memory" panel, replacing the straight `Bar` there. Kept `Bar` itself untouched/reused as-is for download progress elsewhere — the two are visually distinct on purpose (straight = loading, arc = capacity). Drawn as two arcs meeting at the footprint percentage: amber for what Meridian expects to use, green for the unified memory left over.

All found/requested while manually testing PR #418 (notifications permission card) on a staging build, then a locally packaged build of this branch.

## Test plan
- [x] `cargo fmt --check` + `cargo clippy -- -D warnings` clean
- [x] `npm run build` (ui) succeeds, `/setup` route compiles
- [x] Verified the `?id=com.meridiona.tray` deep link lands on Meridian's specific notification detail pane (Allow toggle, Alert Style, etc.) rather than the general app list, via direct `open` testing against this machine's `NotificationsSettings.appex`
- [x] Manual: clicked "Open Settings" on a denied Notifications permission in a locally packaged build of this branch — opens directly to Meridian's row, no flicker
- [x] Manual: verified the memory gauge renders correctly (amber/green split arc) in the same packaged build