### PR TITLE
fix(tray): dismiss tooltip on right-click, dismiss popover on other-window focus

### DIFF
--- a/tray/src-tauri/src/commands/system.rs
+++ b/tray/src-tauri/src/commands/system.rs
@@ -61,6 +61,10 @@ pub async fn open_dashboard(app: tauri::AppHandle) -> Result<(), String> {
                     let _ = app_handle.set_activation_policy(tauri::ActivationPolicy::Accessory);
                 }
             });
+            // Clicking back into an already-open dashboard while the popover
+            // happens to be open on top of it wouldn't otherwise dismiss the
+            // popover — see dismiss_popover_on_focus's doc comment.
+            dismiss_popover_on_focus(&app, &win);
             Ok(())
         }
         Err(e) => {
@@ -209,6 +213,28 @@ pub(crate) fn dismiss_popover(app: &tauri::AppHandle) {
         }
         let _ = win.hide();
     }
+}
+
+/// Wires `win` to dismiss the popover whenever it gains focus. Call once,
+/// right after building any window OTHER than the popover itself (`dashboard`,
+/// `setup`, …).
+///
+/// `dismiss_popover` at open-time (above) only covers the moment a window is
+/// FIRST opened. It does not cover the case where that window was already
+/// open in the background, the popover is reopened on top of it, and the user
+/// then clicks back into the already-open window: `install_click_outside_monitor`'s
+/// global `NSEvent` monitor never fires for that click because
+/// `addGlobalMonitorForEventsMatchingMask:` only fires for events delivered to
+/// OTHER processes, not clicks landing on one of our own windows (see that
+/// function's doc comment in `lib.rs`). `Focused(true)` on the other window is
+/// the one signal that does fire for an in-app click, so it's the dismiss hook.
+pub(crate) fn dismiss_popover_on_focus(app: &tauri::AppHandle, win: &tauri::WebviewWindow) {
+    let app_handle = app.clone();
+    win.on_window_event(move |event| {
+        if let WindowEvent::Focused(true) = event {
+            dismiss_popover(&app_handle);
+        }
+    });
 }
 
 #[cfg(test)]

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -183,15 +183,21 @@ pub fn run() {
                     let app = tray_handle.app_handle();
                     match &event {
                         TrayIconEvent::Click {
-                            button: MouseButton::Left,
+                            button,
                             button_state: MouseButtonState::Up,
                             rect,
                             ..
                         } => {
-                            tracing::info!("tray.event: Click");
-                            // Hide the hover tooltip on click (popover takes over).
+                            tracing::info!(?button, "tray.event: Click");
+                            // Hide the hover tooltip on ANY click — left (popover takes
+                            // over) or right (native menu takes over). Right-click was
+                            // previously unhandled here, leaving the tooltip stuck
+                            // visible behind the context menu.
                             if let Some(tt) = app.get_webview_window("tray-tooltip") {
                                 let _ = tt.hide();
+                            }
+                            if *button != MouseButton::Left {
+                                return;
                             }
                             if let Some(win) = app.get_webview_window("main") {
                                 let visible = win.is_visible().unwrap_or(false);

--- a/tray/src-tauri/src/tray.rs
+++ b/tray/src-tauri/src/tray.rs
@@ -188,11 +188,15 @@ pub(crate) fn open_wizard_window(app: &tauri::AppHandle) {
         .zoom_hotkeys_enabled(true)
         .build()
     {
-        Ok(_win) => {
+        Ok(win) => {
             // Opt the window into native full-screen so the green traffic-light
             // shows the enter-full-screen arrows, not the plain zoom (+) glyph.
             #[cfg(target_os = "macos")]
-            make_fullscreenable(&_win);
+            make_fullscreenable(&win);
+            // Same gap as the dashboard window — see dismiss_popover_on_focus's
+            // doc comment (clicking back into an already-open setup window
+            // wouldn't otherwise dismiss a popover reopened on top of it).
+            crate::commands::system::dismiss_popover_on_focus(app, &win);
         }
         Err(e) => eprintln!("tray: failed to open setup wizard: {e}"),
     }

--- a/tray/src/style.css
+++ b/tray/src/style.css
@@ -75,7 +75,6 @@ html, body {
 .pop {
   background: var(--paper);
   border-radius: var(--radius);
-  border: 1px solid rgba(120, 90, 200, 0.14);
   box-shadow:
     0 24px 60px -18px rgba(30, 15, 70, 0.5),
     0 6px 16px -8px rgba(30, 15, 70, 0.3);


### PR DESCRIPTION
## Summary

Three tray popover bugs found during manual QA of the running dev app (independent of the dashboard style-cleanup work — no file overlap, safe to review/merge on its own):

1. **Hover tooltip stuck visible behind the right-click menu.** `on_tray_icon_event` in `tray/src-tauri/src/lib.rs` only hid the tooltip on `Click { button: Left, button_state: Up }` — right-click (which opens the native context menu) was never matched, so nothing dismissed it. Fixed: any click (left or right) now hides the tooltip; only left-click still toggles the popover.

2. **Popover doesn't dismiss when clicking into an already-open dashboard/setup window.** `install_click_outside_monitor` uses macOS's `addGlobalMonitorForEventsMatchingMask:`, which — per Apple's own docs — only fires for mouse-down events delivered to *other processes*, never for clicks landing on one of our own windows. So if the dashboard (or setup wizard) was already open in the background and the popover got reopened on top of it, clicking back into that window did nothing. Added `dismiss_popover_on_focus` (`tray/src-tauri/src/commands/system.rs`), wired onto both windows' `Focused(true)` event — the one in-app signal that *does* fire for a same-app click.

3. **Popover had a visible dark hairline border.** Removed the `.pop` card's `border: 1px solid rgba(120, 90, 200, 0.14)` in `tray/src/style.css` — against the transparent NSPanel window it read as a hard dark line; the existing box-shadow provides enough definition on its own.

## Test plan
- [x] `cargo check` / `cargo fmt --check` / `cargo clippy -D warnings` — clean
- [x] `cargo test` / UI build / UI tests / security audit — all clean (pre-push hook)
- [x] Manually verified in a running dev build (`tauri dev`, this worktree): right-click no longer leaves the tooltip stuck, and the popover border is gone
- [ ] Manual re-verification of the click-outside-onto-other-window dismiss fix recommended before merge (harder to script than the other two — needs a human clicking between the popover and an already-open dashboard/setup window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)