### PR TITLE
feat(tray,ui): show app version + build channel in dashboard and popover

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -145,4 +145,8 @@ jobs:
           # zone — staging is where we validate the proxy against real installer
           # traffic first.
           MERIDIAN_HF_ENDPOINT: "https://hf.meridiona.com"
+          # Bake the build channel into the binary (commands::version::build_channel,
+          # same option_env! pattern) so the dashboard/popover version badge reads
+          # "staging" instead of the "prod" default. Production leaves this unset.
+          MERIDIAN_CHANNEL: "staging"
         run: npx semantic-release

--- a/tray/package.json
+++ b/tray/package.json
@@ -6,7 +6,7 @@
     "dev": "tauri dev",
     "build:daemon": "cargo build --locked --release --bin meridian --manifest-path ../Cargo.toml",
     "build": "npm run build:daemon && APPLE_SIGNING_IDENTITY=\"${APPLE_SIGNING_IDENTITY:-$(bash ../scripts/dev-signing.sh identity)}\" tauri build",
-    "build:staging": "npm run build:daemon && APPLE_SIGNING_IDENTITY=\"${APPLE_SIGNING_IDENTITY:-$(bash ../scripts/dev-signing.sh identity)}\" MERIDIAN_RUNTIME_MANIFEST_URL=https://github.com/Meridiona/meridian/releases/download/runtime-staging/runtime-manifest.json MERIDIAN_HF_ENDPOINT=https://hf.meridiona.com tauri build",
+    "build:staging": "npm run build:daemon && APPLE_SIGNING_IDENTITY=\"${APPLE_SIGNING_IDENTITY:-$(bash ../scripts/dev-signing.sh identity)}\" MERIDIAN_RUNTIME_MANIFEST_URL=https://github.com/Meridiona/meridian/releases/download/runtime-staging/runtime-manifest.json MERIDIAN_HF_ENDPOINT=https://hf.meridiona.com MERIDIAN_CHANNEL=staging tauri build",
     "test": "vitest run src/__tests__"
   },
   "devDependencies": {

--- a/tray/src-tauri/src/commands/version.rs
+++ b/tray/src-tauri/src/commands/version.rs
@@ -16,7 +16,9 @@
 //! # Who calls this
 //! The `get_version` + `run_update` Tauri commands → the dashboard `Sidebar`
 //! (the version / update line). `get_version` never throws — an update check
-//! must not break the UI.
+//! must not break the UI. `get_app_info` → the dashboard's Account settings
+//! section and the popover footer (the version/channel badge, dev vs staging
+//! vs prod) — synchronous, no npm-registry round trip.
 //!
 //! # Related
 //! - The npm result is cached process-wide for [`CHECK_TTL_MS`] so a dashboard
@@ -228,6 +230,40 @@ fn write_and_open(script_path: &std::path::Path, script: &str) -> std::io::Resul
         .arg(script_path)
         .spawn()
         .map(|_| ())
+}
+
+/// Build channel this binary was compiled for — lets a user tell a local dev
+/// run apart from a staging or production build at a glance. `dev` is a
+/// runtime check (`tauri dev` / unbundled `cargo run`); `staging` is baked in
+/// at compile time via `MERIDIAN_CHANNEL` (same `option_env!` pattern as
+/// [`crate::mlx_server::manifest_url`]) by the staging release workflow;
+/// anything else (a plain release build with no channel baked in) is `prod`.
+fn build_channel() -> &'static str {
+    if cfg!(debug_assertions) {
+        return "dev";
+    }
+    option_env!("MERIDIAN_CHANNEL").unwrap_or("prod")
+}
+
+/// `{ version, channel }` for the small badge in the dashboard and popover.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppInfo {
+    pub version: String,
+    pub channel: String,
+}
+
+/// The binary's baked `tauri.conf.json` version (what the DMG updater compares
+/// against — set in lockstep across the repo by `scripts/set-version.sh`) plus
+/// [`build_channel`]. Synchronous and never touches the network, unlike
+/// [`get_version`] above.
+#[tauri::command]
+#[tracing::instrument(skip(app))]
+pub fn get_app_info(app: tauri::AppHandle) -> AppInfo {
+    let version = app.package_info().version.to_string();
+    let channel = build_channel().to_string();
+    tracing::info!(%version, %channel, "app info served");
+    AppInfo { version, channel }
 }
 
 /// DMG auto-update check for the in-app banners (sidebar + popover). Wraps

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -489,6 +489,7 @@ pub fn run() {
             commands::export_diagnostics_bundle,
             commands::get_ticket_parents,
             commands::get_version,
+            commands::get_app_info,
             commands::check_update,
             commands::install_update,
             commands::get_app_icon,

--- a/tray/src/app.js
+++ b/tray/src/app.js
@@ -47,6 +47,7 @@ const reviewCount = $('review-count')
 const upd = $('upd')
 const updText = $('upd-text')
 const updVer = $('upd-ver')
+const popMeta = $('pop-meta')
 
 // ── State for the local 1-second ticker ──────────────────────────────────────
 let elapsed = 0        // live session seconds; re-synced on every status payload
@@ -439,6 +440,20 @@ upd.addEventListener('click', () => {
   })
 })
 
+// ── Version / channel badge ─────────────────────────────────────────────────
+// dev (unbundled `tauri dev`) vs staging vs prod, so it's obvious at a glance
+// which build is running — see commands::version::get_app_info.
+function loadAppInfo() {
+  invoke('get_app_info').then((info) => {
+    if (!info) return
+    popMeta.textContent = info.channel === 'prod'
+      ? `v${info.version}`
+      : `v${info.version} · ${info.channel}`
+    popMeta.dataset.channel = info.channel
+    resizeToContent()
+  }).catch((e) => dbg(`get_app_info failed: ${e}`))
+}
+
 // ── Window sizing ─────────────────────────────────────────────────────────────
 // Resize the Tauri window to exactly match the card's rendered height so no
 // transparent gap appears below the popup (a gap reads as a white band over the
@@ -512,6 +527,7 @@ function boot() {
   startTicker()
   invoke('get_status').then((s) => { render(s); resizeToContent() }).catch(() => {})
   checkUpdate()
+  loadAppInfo()
   armNotificationActions()
 }
 

--- a/tray/src/index.html
+++ b/tray/src/index.html
@@ -146,6 +146,9 @@
       <span class="foot-sep"></span>
       <button type="button" class="foot-btn foot-quit" id="btn-quit">Quit</button>
     </footer>
+
+    <!-- ── Version / channel badge — dev vs staging vs prod at a glance ────── -->
+    <div class="pop-meta" id="pop-meta"></div>
   </div>
 
   <script src="pause-utils.js"></script>

--- a/tray/src/style.css
+++ b/tray/src/style.css
@@ -434,3 +434,18 @@ button:focus-visible {
 .foot-btn:hover { background: var(--surface-2); }
 .foot-quit { color: var(--danger); }
 .foot-sep { width: 1px; height: 14px; background: var(--rule-2); }
+
+/* ── Version / channel badge ───────────────────────────────────────────────
+   Muted + neutral for a production build; colored for dev/staging so a
+   non-prod popover is unmistakable at a glance. Empty until boot() paints it
+   (invoke('get_app_info')), so it takes no layout space before then. */
+.pop-meta {
+  text-align: center;
+  font: 600 9.5px var(--font-mono);
+  letter-spacing: .03em;
+  color: var(--ink-4);
+  padding: 0 16px 8px;
+}
+.pop-meta:empty { display: none; }
+.pop-meta[data-channel="dev"] { color: var(--accent); }
+.pop-meta[data-channel="staging"] { color: var(--warn); }

--- a/ui/components/timeline/settings/AccountSection.tsx
+++ b/ui/components/timeline/settings/AccountSection.tsx
@@ -5,10 +5,26 @@
 
 'use client'
 
-import { mutate } from '@/lib/bridge'
+import { useEffect, useState } from 'react'
+import { load, mutate } from '@/lib/bridge'
+import type { AppInfo } from '@/lib/api-types'
 import { SectionCard, SectionHeader, FieldRow, SettingsButton } from './fields'
 
+// Colored only for a non-prod build — a prod dashboard shouldn't draw the eye
+// to its own version line; dev/staging should be unmistakable.
+const CHANNEL_COLOR: Record<AppInfo['channel'], string> = {
+  dev: 'var(--color-state-proposal)',
+  staging: 'var(--color-state-pending)',
+  prod: 'var(--t-faint)',
+}
+
 export function AccountSection() {
+  const [appInfo, setAppInfo] = useState<AppInfo | null>(null)
+
+  useEffect(() => {
+    load<AppInfo>('/api/app-info', 'get_app_info').then(setAppInfo).catch(() => {})
+  }, [])
+
   return (
     <div className="max-w-[640px] flex flex-col gap-5">
       <div>
@@ -27,6 +43,17 @@ export function AccountSection() {
           }}>
             Go to Setup
           </SettingsButton>
+        </FieldRow>
+      </SectionCard>
+
+      <SectionCard>
+        <SectionHeader>About</SectionHeader>
+        <FieldRow label="Version" description="Which build of Meridian this is — dev, staging, or production.">
+          {appInfo && (
+            <span className="mt-body-sm font-mono font-semibold" style={{ color: CHANNEL_COLOR[appInfo.channel] }}>
+              v{appInfo.version}{appInfo.channel !== 'prod' && ` · ${appInfo.channel}`}
+            </span>
+          )}
         </FieldRow>
       </SectionCard>
     </div>

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -334,3 +334,10 @@ export interface BannerNotification {
   deep_link: string | null
   created_at: string
 }
+
+// ── App info (`get_app_info`) ──────────────────────────────────────────────────
+
+export interface AppInfo {
+  version: string
+  channel: 'dev' | 'staging' | 'prod'
+}


### PR DESCRIPTION
## Summary
- Adds a `get_app_info` Tauri command returning `{ version, channel }` — `version` is the binary's baked `tauri.conf.json` version (what the DMG updater already compares against); `channel` is `dev` (debug/`tauri dev`), `staging` (baked via a new `MERIDIAN_CHANNEL` compile-time env var, same `option_env!` pattern already used for the runtime-manifest/HF-endpoint bakes), or `prod` (default).
- Bakes `MERIDIAN_CHANNEL=staging` into the staging release workflow (`release-staging.yml`) and the `build:staging` npm script, alongside the existing `MERIDIAN_RUNTIME_MANIFEST_URL`/`MERIDIAN_HF_ENDPOINT` bakes. Production leaves it unset.
- Tray popover: a small mono-font line under the footer (`tray/src/index.html`/`app.js`/`style.css`) — muted for prod, colored (purple/amber) for dev/staging.
- Dashboard: a new "About" card in Settings → Account (`AccountSection.tsx`) showing the same version/channel.

## Test plan
- [x] `cargo check` / `cargo fmt --check` / `cargo clippy -D warnings` / `cargo test` all pass (tray/src-tauri)
- [x] Verified from Tauri's own codegen source (`tauri-codegen`) that `package_info().version` reads `tauri.conf.json`'s top-level `version` field, not `Cargo.toml`'s
- [x] `bun test ui/__tests__/popover-health-panel.test.ts` passes (8/8)
- [x] `tsc --noEmit` clean on the touched dashboard files
- [x] Manually ran `tauri dev` locally (temporary alternate port to avoid clashing with a concurrent dev session) and confirmed the popover footer badge and the Settings → Account "About" card both render `v1.69.1 · dev` in the dev color
- [x] Pre-push hook suite (fmt, clippy, ui build/tests, security audit, cargo test) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UUn5ezNxQMTsebRNKXxRn