### PR TITLE
fix(tray): bake the PostHog key at build time instead of hardcoding it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -159,6 +159,18 @@
 # AZURE_DEVOPS_PAT=your-pat-here
 
 # ---------------------------------------------------------------------------
+# PostHog product analytics (tray/DMG build only)
+#
+# A release build bakes the PostHog project API key in at compile time
+# (CI-only, from the POSTHOG_API_KEY repo secret; never committed to source).
+# A LOCAL SOURCE BUILD (cargo run / npm run tauri dev) has no baked-in key, so
+# analytics compiles in silently disabled unless you set POSTHOG_API_KEY below
+# — only needed if you're specifically testing the analytics capture path.
+# ---------------------------------------------------------------------------
+
+# POSTHOG_API_KEY=phc_your_project_api_key_here
+
+# ---------------------------------------------------------------------------
 # Python LLM backend — cloud fallback for the coding-agent summariser (Claude/
 # Codex paths). The MLX classifier server ignores these.
 # ---------------------------------------------------------------------------

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -59,6 +59,9 @@ jobs:
       # Public GitHub OAuth device-flow client id (see release.yml); GH_OAUTH_CLIENT_ID
       # repo secret. Absent → GitHub browser connect unavailable in the staging build.
       MERIDIAN_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
+      # Baked into the staging binary at compile time (see release.yml); same
+      # secret. Absent → PostHog analytics simply disabled in the staging build.
+      MERIDIAN_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
       # Minisign key for the DMG auto-updater: `tauri build` (createUpdaterArtifacts)
       # signs Meridian.app.tar.gz so the installed staging app can verify the
       # update against the pubkey baked in tauri.conf.json. REQUIRED here (unlike

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,12 @@ jobs:
       # named GITHUB_*, which GitHub reserves). The OAuth App must have "Enable
       # Device Flow" checked.
       MERIDIAN_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
+      # Baked into the release binary at compile time (consumed by option_env! in
+      # tray/src-tauri/src/analytics.rs). PostHog Cloud project API key — a
+      # PUBLIC write-only capture token (no account/read access), safe to embed
+      # in a shipped client. Set the POSTHOG_API_KEY repo secret; absent →
+      # analytics compiles in disabled (see analytics::posthog_api_key).
+      MERIDIAN_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
       # Minisign key for the DMG auto-updater: `tauri build` (createUpdaterArtifacts)
       # signs Meridian.app.tar.gz with these so the installed app can verify the
       # update against the pubkey baked in tauri.conf.json. The build FAILS LOUDLY

--- a/tray/src-tauri/build.rs
+++ b/tray/src-tauri/build.rs
@@ -12,6 +12,11 @@ fn main() {
     // (`mlx_server.rs::hf_endpoint`, `option_env!("MERIDIAN_HF_ENDPOINT")`).
     println!("cargo:rerun-if-env-changed=MERIDIAN_HF_ENDPOINT");
 
+    // Same reasoning for the PostHog project API key (analytics.rs,
+    // `option_env!("MERIDIAN_POSTHOG_API_KEY")`) — a GitHub Actions secret
+    // baked into the release binary; see .github/workflows/release.yml.
+    println!("cargo:rerun-if-env-changed=MERIDIAN_POSTHOG_API_KEY");
+
     // The notifications plugin's macOS layer is Swift (swift-bridge): its build
     // script links the static Swift lib but adds NO rpath, and the Swift
     // runtime dylibs it references (libswift_Concurrency & co.) resolve via

--- a/tray/src-tauri/src/analytics.rs
+++ b/tray/src-tauri/src/analytics.rs
@@ -48,15 +48,30 @@ use std::time::Duration;
 use tracing::Instrument;
 
 /// PostHog Cloud (US region) project token — a **public** write-only capture
-/// key, safe to embed in a shipped client (unlike a personal/secret API key).
-/// Overridable via `MERIDIAN_POSTHOG_KEY` for testing against a different
-/// project.
-const DEFAULT_POSTHOG_API_KEY: &str = "phc_zDagQwSLyR9dwT6LPQ6QfygQkpnXrGAKhrJLv5kBFbvH";
+/// key (safe to embed in a shipped client, unlike a personal/secret API key;
+/// see the PR #427 discussion). **Baked in at compile time**, never committed
+/// to source: the official release build injects it via the
+/// `MERIDIAN_POSTHOG_API_KEY` build env (a GitHub Actions secret — see
+/// `.github/workflows/release.yml` / `release-staging.yml`), mirroring
+/// `meridian-oauth`'s `DEFAULT_CLIENT_SECRET` pattern. A plain source build
+/// without that env compiles in an empty string, which disables analytics
+/// entirely (see [`posthog_api_key`]) rather than shipping a placeholder.
+const DEFAULT_POSTHOG_API_KEY: &str = match option_env!("MERIDIAN_POSTHOG_API_KEY") {
+    Some(k) => k,
+    None => "",
+};
 /// US Cloud ingestion host — matches the project's region.
 const POSTHOG_HOST: &str = "https://us.i.posthog.com";
 
+/// Resolve the capture key: the `POSTHOG_API_KEY` runtime env override (e.g.
+/// set in `~/.meridian/.env` for a source/dev build — the daemon/tray already
+/// load that file via `dotenvy`) if set and non-blank, else the compiled-in
+/// [`DEFAULT_POSTHOG_API_KEY`].
 fn posthog_api_key() -> String {
-    std::env::var("MERIDIAN_POSTHOG_KEY").unwrap_or_else(|_| DEFAULT_POSTHOG_API_KEY.to_string())
+    std::env::var("POSTHOG_API_KEY")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_POSTHOG_API_KEY.to_string())
 }
 
 /// Persisted analytics bookkeeping. Deliberately its own file — never merged
@@ -125,9 +140,20 @@ async fn capture(
     distinct_id: &str,
     mut properties: serde_json::Map<String, serde_json::Value>,
 ) {
+    let api_key = posthog_api_key();
+    if api_key.is_empty() {
+        // No compiled-in secret and no runtime override — a source build
+        // without MERIDIAN_POSTHOG_API_KEY set. Skip silently rather than
+        // POST an unauthenticated request PostHog will just reject.
+        tracing::debug!(
+            event,
+            "analytics: no PostHog key configured — skipping capture"
+        );
+        return;
+    }
     properties.insert("$geoip_disable".to_string(), serde_json::Value::Bool(true));
     let body = serde_json::json!({
-        "api_key": posthog_api_key(),
+        "api_key": api_key,
         "event": event,
         "distinct_id": distinct_id,
         "properties": properties,


### PR DESCRIPTION
## Summary
- Moves the PostHog project API key out of source and into the same compile-time secret pattern `meridian-oauth` already uses for the Jira client secret (`meridian-oauth/src/jira.rs`'s `DEFAULT_CLIENT_SECRET`).
- Baked in via `option_env!("MERIDIAN_POSTHOG_API_KEY")` in `tray/src-tauri/src/analytics.rs`, sourced from the `POSTHOG_API_KEY` GitHub Actions repo secret in both `release.yml` (production) and `release-staging.yml` (staging) — same wiring style as `JIRA_OAUTH_CLIENT_SECRET`/`GH_OAUTH_CLIENT_ID`.
- Adds a `POSTHOG_API_KEY` **runtime** env override for source/dev builds (settable in `~/.meridian/.env`, already loaded via `dotenvy`).
- A build with neither the compile-time nor runtime value set compiles in an empty key; `capture()` now checks for that and skips sending entirely instead of firing a doomed unauthenticated request.
- `tray/src-tauri/build.rs` declares `cargo:rerun-if-env-changed=MERIDIAN_POSTHOG_API_KEY` so a CI cache can't bake a stale key after rotation (mirrors the root `build.rs`'s handling of the Jira/GitHub secrets).

## Why
Follow-up to #427 — the key was previously a literal string constant in `analytics.rs`. It's a public write-only capture token (safe to embed, unlike a personal API key) so this was never an actual vulnerability, but keeping secrets out of source/git history entirely is the established convention in this codebase and is worth matching.

## Test plan
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test` (pre-commit + pre-push hooks)
- [x] Manually verified the build-time bake actually responds to the env var: `cargo test` with `MERIDIAN_POSTHOG_API_KEY` unset vs set both recompile and pass
- [ ] Set the `POSTHOG_API_KEY` repo secret (see PR comment) before the next release build, or analytics silently compiles disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional notification permission setup to onboarding, with guidance and direct access to macOS settings when needed.
  * Improved setup window sizing, responsiveness, and full-screen behavior.
  * Refreshed the macOS installer background and drag-to-install presentation.
  * Added anonymous product usage analytics for packaged builds, including installation and daily usage events.

* **Improvements**
  * Setup now displays clearer model names, permission requirements, and updated onboarding copy.
  * Input Monitoring permission prompts are no longer requested automatically.

* **Documentation**
  * Updated UI styling guidance and notification testing instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->