### PR TITLE
fix(tray): retire the redundant meridian-a11y-helper Accessibility entry

### DIFF
--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -1,19 +1,17 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 //! Bundled-backend first-run install orchestration (Gap-2 Bucket 1, slice 1b).
 //!
-//! On the self-contained `.app` DMG path the non-capture backend (the Rust
-//! daemon + the a11y-helper) ships inside `Meridian.app/Contents/Resources/backend/`
-//! (wired by `tauri.conf.json`'s `bundle.resources`). This module is the tray
-//! side of that: on startup it stages those binaries to the **stable**
-//! `~/.meridian/bin/` path and registers their launchd agents — the same
-//! daemon + a11y-helper steps `scripts/install-from-bundle.sh` does for the npm
-//! bundle, ported into the tray so the DMG needs no shell installer.
+//! On the self-contained `.app` DMG path the daemon ships inside
+//! `Meridian.app/Contents/Resources/backend/` (wired by `tauri.conf.json`'s
+//! `bundle.resources`). This module is the tray side of that: on startup it
+//! stages the binary to the **stable** `~/.meridian/bin/` path and registers
+//! its launchd agent — the same step `scripts/install-from-bundle.sh` does
+//! for the npm bundle, ported into the tray so the DMG needs no shell
+//! installer.
 //!
-//! It is a **faithful port of the launchctl flow, not SMAppService**: the
-//! a11y-helper's Accessibility grant is keyed to its binary's code hash and
-//! survives updates only because it runs from a stable path *outside* the
-//! re-signed `.app`; SMAppService's managed-Login-Items payoff only matters once
-//! the app is Developer-ID-signed (Gap-2 Bucket 3), so it's deferred to then.
+//! It is a **faithful port of the launchctl flow, not SMAppService**:
+//! SMAppService's managed-Login-Items payoff only matters once the app is
+//! Developer-ID-signed (Gap-2 Bucket 3), so it's deferred to then.
 //!
 //! Unlike the npm bundle (WorkingDirectory `~/.meridian/app`, daemon reads
 //! `~/.meridian/app/.env`), the DMG daemon's WorkingDirectory is `~/.meridian`,
@@ -21,7 +19,17 @@
 //! writes to — unifying tray and daemon on one credential file. A bundle→DMG
 //! migrant's pre-existing `~/.meridian/app/.env` is copied across once
 //! ([`migrate_legacy_bundle_env`]) and stale bundle launchd agents
-//! (screenpipe / MLX / UI server) are booted out during [`install`].
+//! (screenpipe / a11y-helper / MLX / UI server) are booted out during [`install`].
+//!
+//! **The `meridian-a11y-helper` launchd agent is retired** (was
+//! `com.meridiona.a11y-helper`): it existed to poke `AXManualAccessibility`
+//! on Electron/Chromium apps for the old *external* screenpipe process. The
+//! in-process capture engine's `screenpipe-a11y` tree walker
+//! ([`crate::capture::screenpipe`]) now does that poke itself, under the
+//! tray's own Accessibility grant — so the helper's separate launchd agent
+//! and its own "meridian-a11y-helper" entry in System Settings → Privacy &
+//! Security → Accessibility were pure redundancy. [`cleanup_legacy_a11y_helper`]
+//! retires any leftover install from an update.
 //!
 //! # Who calls this
 //! [`crate::run`]'s Tauri `setup` hook spawns [`ensure_backend_installed`] once,
@@ -33,8 +41,8 @@
 //! - [`crate::mlx_server`] — the *other* backend service (provisioned via Approach C,
 //!   not bundled); [`crate::mlx_server::sha256_hex_of`] is reused here for the
 //!   update-detection marker.
-//! - `scripts/install-from-bundle.sh`, `scripts/install-daemon.sh`,
-//!   `scripts/install-a11y-helper-daemon.sh` — the shell flow this ports.
+//! - `scripts/install-from-bundle.sh`, `scripts/install-daemon.sh` — the shell
+//!   flow this ports.
 
 use std::path::{Path, PathBuf};
 
@@ -43,15 +51,9 @@ use tauri::Manager;
 use crate::mlx_server;
 
 /// launchd agents this stages, paired with their bundled plist template.
-const AGENTS: &[(&str, &str)] = &[
-    ("com.meridiona.daemon", "com.meridiona.daemon.plist"),
-    (
-        "com.meridiona.a11y-helper",
-        "com.meridiona.a11y-helper.plist",
-    ),
-];
+const AGENTS: &[(&str, &str)] = &[("com.meridiona.daemon", "com.meridiona.daemon.plist")];
 
-/// Stage the bundled backend and register its launchd agents — idempotent and
+/// Stage the bundled backend and register its launchd agent — idempotent and
 /// non-fatal.
 ///
 /// No-op unless **all** hold: running from a packaged `.app` whose
@@ -60,7 +62,7 @@ const AGENTS: &[(&str, &str)] = &[
 /// differs from the last successful install (first run, or a post-update where
 /// the shipped binary changed). Any staging/launchctl failure is logged and
 /// swallowed so a backend hiccup never crashes the tray; the marker is persisted
-/// **only after** both agents bootstrap, so a partial failure retries next launch.
+/// **only after** the agent bootstraps, so a partial failure retries next launch.
 #[tracing::instrument(skip(app))]
 pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
     let backend = match bundled_backend_dir(app) {
@@ -111,7 +113,7 @@ fn bundled_backend_dir(app: &tauri::AppHandle) -> Option<PathBuf> {
     dir.is_dir().then_some(dir)
 }
 
-/// Stage both binaries, render + lint both plists, register both agents.
+/// Stage the daemon binary, render + lint its plist, register its agent.
 /// Returns `Err` if any step fails so the caller skips the success marker.
 async fn install(backend: &Path, home: &Path) -> Result<(), String> {
     for dir in [".meridian/bin", ".meridian/logs"] {
@@ -128,22 +130,22 @@ async fn install(backend: &Path, home: &Path) -> Result<(), String> {
     // Purge leftovers from a pre-cutover **bundle** install before staging the
     // in-process backend. A user migrating from the old npm/curl bundle to this
     // DMG carries launchd agents the new topology replaced (the in-process
-    // capturer supersedes screenpipe; the tray supervises MLX itself); left
-    // running they race the tray or contend for :7823. `install-from-bundle.sh`
-    // boots these out for the bundle path; the DMG path needs the same. All
-    // best-effort + non-fatal.
+    // capturer supersedes screenpipe and does its own AX poke; the tray
+    // supervises MLX itself); left running they race the tray, contend for
+    // :7823, or surface a redundant "meridian-a11y-helper" Accessibility
+    // entry. `install-from-bundle.sh` boots these out for the bundle path;
+    // the DMG path needs the same. All best-effort + non-fatal.
     cleanup_legacy_screenpipe(home).await;
     cleanup_legacy_mlx_server(home).await;
+    cleanup_legacy_a11y_helper(home).await;
     // Recover tracker credentials the bundle wrote to ~/.meridian/app/.env so the
     // DMG daemon (which reads the canonical ~/.meridian/.env) doesn't lose them.
     migrate_legacy_bundle_env(home).await;
 
     let daemon_bin = home.join(".meridian/bin/meridian");
-    let helper_bin = home.join(".meridian/bin/meridian-a11y-helper");
     stage_binary(&backend.join("meridian"), &daemon_bin).await?;
-    stage_binary(&backend.join("meridian-a11y-helper"), &helper_bin).await?;
 
-    // Render the two plists. The bundled templates carry {{…}} placeholders the
+    // Render the plist. The bundled template carries {{…}} placeholders the
     // npm installer substitutes too; here REPO_ROOT (the daemon's WorkingDirectory)
     // is ~/.meridian so dotenvy self-loads ~/.meridian/.env, and OTLP is left
     // empty for the daemon to self-load (a baked value would go stale).
@@ -156,15 +158,6 @@ async fn install(backend: &Path, home: &Path) -> Result<(), String> {
             ("{{REPO_ROOT}}", &home.join(".meridian").to_string_lossy()),
             ("{{DAEMON_BIN}}", &daemon_bin.to_string_lossy()),
             ("{{MERIDIAN_OTLP_ENDPOINT}}", ""),
-        ],
-    )
-    .await?;
-    render_plist(
-        &backend.join("com.meridiona.a11y-helper.plist"),
-        &launch_agents.join("com.meridiona.a11y-helper.plist"),
-        &[
-            ("{{HOME}}", home_str.as_ref()),
-            ("{{HELPER_BIN}}", &helper_bin.to_string_lossy()),
         ],
     )
     .await?;
@@ -220,6 +213,38 @@ async fn cleanup_legacy_mlx_server(home: &Path) {
     let _ =
         tokio::fs::remove_file(home.join("Library/LaunchAgents/com.meridiona.mlx-server.plist"))
             .await;
+}
+
+/// Purge a leftover **a11y-helper** launchd agent + its stale Accessibility
+/// grant. The helper existed to poke `AXManualAccessibility` on Electron apps
+/// for the old *external* screenpipe process; the in-process capture engine's
+/// `screenpipe-a11y` tree walker does that poke itself now, under the tray's
+/// own Accessibility grant, so the helper is pure redundancy — and its
+/// separate ad-hoc-signed binary shows up as a second, confusingly-named
+/// "meridian-a11y-helper" entry in System Settings → Privacy & Security →
+/// Accessibility. Boot out the agent, remove its plist + staged binary, kill
+/// any live process, and best-effort clear its TCC grant (`tccutil reset`) so
+/// the entry doesn't linger grayed-out after the binary is gone. Entirely
+/// best-effort + non-fatal — a launchctl/tccutil hiccup must not abort install.
+async fn cleanup_legacy_a11y_helper(home: &Path) {
+    let label = "com.meridiona.a11y-helper";
+    let target = format!("gui/{}/{label}", crate::sys::uid_str());
+    if launchctl(&["print", &target]).await.is_ok_and(|s| s) {
+        let _ = launchctl(&["bootout", &target]).await;
+        tracing::info!(label, "backend_install: removed leftover a11y-helper agent");
+    }
+    let _ =
+        tokio::fs::remove_file(home.join("Library/LaunchAgents/com.meridiona.a11y-helper.plist"))
+            .await;
+    let _ = tokio::fs::remove_file(home.join(".meridian/bin/meridian-a11y-helper")).await;
+    let _ = tokio::process::Command::new("pkill")
+        .args(["-f", "meridian-a11y-helper"])
+        .output()
+        .await;
+    let _ = tokio::process::Command::new("tccutil")
+        .args(["reset", "Accessibility", "com.meridiona.a11y-helper"])
+        .output()
+        .await;
 }
 
 /// Recover tracker credentials when migrating from a **bundle** install. The
@@ -452,10 +477,11 @@ mod tests {
         out
     }
 
-    /// The bundled templates must have NO `{{…}}` left **in the live body** after
-    /// the exact sub sets `install()` applies — a new body placeholder added
-    /// upstream without a matching sub would otherwise ship a broken plist. Reads
-    /// the real committed templates so the two can't drift apart silently.
+    /// The bundled daemon plist template must have NO `{{…}}` left **in the
+    /// live body** after the exact sub set `install()` applies — a new body
+    /// placeholder added upstream without a matching sub would otherwise ship
+    /// a broken plist. Reads the real committed template so the two can't
+    /// drift apart silently.
     #[test]
     fn bundled_templates_fully_substituted() {
         let scripts = concat!(env!("CARGO_MANIFEST_DIR"), "/../../scripts");
@@ -474,23 +500,6 @@ mod tests {
         assert!(
             !rendered.contains("{{"),
             "daemon plist body still has an unsubstituted placeholder: {rendered}"
-        );
-
-        let helper = std::fs::read_to_string(format!("{scripts}/com.meridiona.a11y-helper.plist"))
-            .expect("read a11y-helper plist template");
-        let rendered = strip_xml_comments(&apply_subs(
-            &helper,
-            &[
-                ("{{HOME}}", "/Users/me"),
-                (
-                    "{{HELPER_BIN}}",
-                    "/Users/me/.meridian/bin/meridian-a11y-helper",
-                ),
-            ],
-        ));
-        assert!(
-            !rendered.contains("{{"),
-            "a11y-helper plist body still has an unsubstituted placeholder: {rendered}"
         );
     }
 }

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -450,6 +450,47 @@ mod tests {
         let _ = tokio::fs::remove_dir_all(&base).await;
     }
 
+    /// `cleanup_legacy_a11y_helper` must remove the stale plist + staged binary
+    /// it leaves behind from a pre-cutover install — the concrete, automatable
+    /// half of the PR #431 review's "confirm the update path boots out the old
+    /// agent" ask (the `launchctl`/`tccutil` system calls are real syscalls with
+    /// no fake-able state to assert on in a unit test, but the file-removal side
+    /// — the part that actually stops the stale entry from lingering once no
+    /// process owns it — is fully verifiable here).
+    #[tokio::test]
+    async fn cleanup_legacy_a11y_helper_removes_stale_files() {
+        let home = std::env::temp_dir().join(format!(
+            "meridian-a11y-helper-cleanup-{}-{}",
+            std::process::id(),
+            "test"
+        ));
+        let _ = tokio::fs::remove_dir_all(&home).await;
+        tokio::fs::create_dir_all(home.join("Library/LaunchAgents"))
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(home.join(".meridian/bin"))
+            .await
+            .unwrap();
+
+        let plist = home.join("Library/LaunchAgents/com.meridiona.a11y-helper.plist");
+        let bin = home.join(".meridian/bin/meridian-a11y-helper");
+        tokio::fs::write(&plist, "<plist/>").await.unwrap();
+        tokio::fs::write(&bin, "fake binary").await.unwrap();
+
+        cleanup_legacy_a11y_helper(&home).await;
+
+        assert!(
+            tokio::fs::metadata(&plist).await.is_err(),
+            "leftover a11y-helper plist should have been removed"
+        );
+        assert!(
+            tokio::fs::metadata(&bin).await.is_err(),
+            "leftover a11y-helper binary should have been removed"
+        );
+
+        let _ = tokio::fs::remove_dir_all(&home).await;
+    }
+
     #[test]
     fn apply_subs_replaces_every_occurrence() {
         let out = apply_subs(

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -420,11 +420,13 @@ pub fn run() {
                 });
             }
 
-            // Stage + register the bundled backend (daemon + a11y-helper) on the
-            // self-contained .app DMG path. No-op under dev/source (no bundled
-            // Resources/backend) and on launches where the binary is unchanged.
-            // Spawned off the setup hook because the launchd bootout-wait can
-            // take several seconds and must not block tray startup.
+            // Stage + register the bundled daemon on the self-contained .app DMG
+            // path (also retires any leftover a11y-helper agent from an older
+            // install — see backend_install's module docs). No-op under
+            // dev/source (no bundled Resources/backend) and on launches where
+            // the binary is unchanged. Spawned off the setup hook because the
+            // launchd bootout-wait can take several seconds and must not block
+            // tray startup.
             {
                 let backend_handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {

--- a/tray/src-tauri/tauri.conf.json
+++ b/tray/src-tauri/tauri.conf.json
@@ -89,9 +89,7 @@
     },
     "resources": {
       "../../target/release/meridian": "backend/meridian",
-      "../../scripts/a11y-helper/meridian-a11y-helper": "backend/meridian-a11y-helper",
-      "../../scripts/com.meridiona.daemon.plist": "backend/com.meridiona.daemon.plist",
-      "../../scripts/com.meridiona.a11y-helper.plist": "backend/com.meridiona.a11y-helper.plist"
+      "../../scripts/com.meridiona.daemon.plist": "backend/com.meridiona.daemon.plist"
     }
   }
 }


### PR DESCRIPTION
## Summary

The DMG install path (`backend_install.rs`) unconditionally staged and registered a separate `com.meridiona.a11y-helper` launchd agent on every packaged install/update — even though `capture` has been the default (and only shipped) feature since the Gap-2 Bucket 2 cutover.

That agent's whole job was poking `AXManualAccessibility` on Electron/Chromium apps so the old *external* screenpipe process could see their AX tree. Since the cutover, the in-process capture engine's `screenpipe-a11y` tree walker (`tray/src-tauri/src/capture/screenpipe.rs`) already does that same poke itself, under the tray's own Accessibility grant (confirmed in that module's own doc comment: *"Running the frame grab + OCR + AX walk in this process is what yields the single 'Meridian' Screen-Recording / Accessibility TCC entries"*). `health.rs` even already special-cases `#[cfg(feature = "capture")]` to skip the a11y-helper trust check for exactly this reason.

So the helper agent was pure dead weight — its only visible effect was a second, confusingly-named **"meridian-a11y-helper"** entry showing up in System Settings → Privacy & Security → Accessibility, alongside the real "Meridian" entry.

This is also consistent with an existing guard test (`tests/tray_assets.rs::install_dev_skips_screenpipe_agents`), whose comment already states *"a11y capture is in-process inside the Tauri tray since v1.64.0"* — `install-dev.sh` was already correctly skipping this; only the packaged DMG install path (`backend_install.rs`) had missed the memo.

## Changes

- `tray/src-tauri/src/backend_install.rs`: stop staging/registering the a11y-helper binary + launchd agent in `install()`. Added `cleanup_legacy_a11y_helper()` (mirroring the existing `cleanup_legacy_screenpipe`/`cleanup_legacy_mlx_server` pattern) that boots out any leftover agent from a prior install, removes its plist + staged binary, kills any live process, and best-effort `tccutil reset`s its Accessibility grant so the stale entry doesn't linger grayed-out in System Settings after the binary is gone. Updated module docs and the `bundled_templates_fully_substituted` test accordingly.
- `tray/src-tauri/tauri.conf.json`: stop bundling `meridian-a11y-helper` + its plist into `Meridian.app/Contents/Resources/backend/`.
- `tray/src-tauri/src/lib.rs`: updated the `ensure_backend_installed` call-site comment.
- `tray/src-tauri/src/backend_install.rs` (review follow-up): added `cleanup_legacy_a11y_helper_removes_stale_files`, a regression test proving the leftover plist + staged binary get removed.

## Scope note

Intentionally left `scripts/a11y-helper/`, `scripts/install-a11y-helper-daemon.sh`, and the npm/curl bundle path (`scripts/install-from-bundle.sh`) untouched — that install path still runs the *external* screenpipe process (see its pinned `SCREENPIPE_VERSION`), where the helper may still be load-bearing. This PR only retires it from the DMG/tray path ("the app"), which is the one built on `capture` by default and the one this was reported against.

## Test plan
- [x] `cargo fmt --check` (workspace + tray crate)
- [x] `cargo clippy -- -D warnings` (workspace + tray crate)
- [x] `cargo test --lib backend_install` — 4/4 pass, including the new `cleanup_legacy_a11y_helper_removes_stale_files` and the updated `bundled_templates_fully_substituted`
- [x] Full `pre-push` hook (fmt + clippy + UI build + UI tests + security audit + `cargo test`) — all green
- [x] Structural: `tauri.conf.json`'s `bundle.resources` ships only `backend/meridian` + `backend/com.meridiona.daemon.plist` — nothing exists for a fresh install to stage/register, so no "meridian-a11y-helper" entry can appear
- [x] Automated: `cleanup_legacy_a11y_helper_removes_stale_files` proves the plist + staged binary are actually removed on an update
- [ ] Manual (needs a real machine/GUI): on a machine with a pre-existing `com.meridiona.a11y-helper` launchd agent + Accessibility grant, confirm an update boots out the agent and the entry disappears from System Settings → Privacy & Security → Accessibility (the `launchctl`/`tccutil` syscalls themselves aren't unit-testable — see PR comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUNrrP7ie4eeJKGPV6EXNp
