### PR TITLE
docs: clarify PRs target pre-main, main is maintainer-only release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Meridian is a single-process Rust daemon that normalises raw screen-capture fram
 - Validate all input at system boundaries (config load, DB open, frame parsing)
 - NEVER run `git reset`, `git push --force`, or delete local code — other agents may be working on the codebase in parallel
 - NEVER merge a PR automatically — open/update PRs as needed, but leave the actual merge to a human reviewer
-- NEVER push directly to `main` — always create a separate feature branch, commit there, and raise a PR to `main`
+- NEVER push directly to `main` or `pre-main` — always create a separate feature branch, commit there, and raise a PR to `pre-main`. **All features, fixes, and other changes target `pre-main`** (the staging branch), not `main` — only a maintainer opens the `pre-main → main` release PR, and only after everything on `pre-main` has been tested end-to-end on staging
 - ALWAYS use a separate branch per feature/fix — branch name format: `type/short-description` (e.g. `feat/trello-oauth`, `fix/ui-disconnect`)
 - In all **user-facing app text** — window titles, wizard/UI copy, button and menu labels, notification bodies, tray tooltips, any string the user reads — use a plain hyphen `-` only. NEVER an em-dash (`—`), en-dash (`–`), or double hyphen (`--`). Use it spaced (` - `) where a dash separates clauses. (This rule is about displayed strings; code comments and docs are exempt.)
 
@@ -546,4 +546,11 @@ services/.venv/bin/python services/tests/evals/eval_classifier.py         # run,
 - `pre-push` hook runs the full suite: `cargo fmt` + `cargo clippy` + UI build + UI tests + security audit (claude CLI) + `cargo test`
 - Never skip hooks with `--no-verify`
 - Install hooks after cloning: `bash scripts/setup-hooks.sh`
-- Never amend a commit that has already been pushed to `main`
+- Never amend a commit that has already been pushed to `main` or `pre-main`
+
+### PR target branch — `pre-main`, not `main`
+
+- **Every feature/fix PR targets `pre-main`** (`gh pr create --base pre-main`), regardless of what any older doc or habit says — `pre-main` is the staging branch and is where all day-to-day work lands.
+- `pre-main` is deployed to staging and gets exercised end-to-end there (including the staging DMG auto-update channel and `runtime-staging`) before anything reaches production.
+- **Only a maintainer** opens the `pre-main → main` release PR, and only once everything currently on `pre-main` has been verified working end-to-end on staging. Contributors should not open `main`-targeted PRs.
+- This mirrors the runtime-publish model (`runtime-staging` vs `runtime-latest` — see "Ship a `services/` Python change to users" above): `pre-main` is the staging/test channel, `main` is production.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,8 @@ Read **[TESTING.md](TESTING.md)** first. The integration tests in `tests/integra
 - **One branch per change.** Format: `type/short-description` — e.g. `feat/linear-sync`, `fix/timeline-gap`.
 - **Conventional Commits:** `type(scope): summary` — e.g. `fix(etl): detect sleep gaps that span ETL run boundaries`.
   - Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`.
-- **Never push to `main` directly.** Open a PR from your branch.
+- **Never push to `main` or `pre-main` directly.** Open a PR from your branch.
+- **Target `pre-main`, not `main`.** All feature and fix PRs go against `pre-main` — the staging branch. Only a maintainer opens the `pre-main → main` release PR, and only after everything on `pre-main` has been tested end-to-end on staging.
 - **Do not mention Claude as co-author in commit messages.**
 
 Releases are automated by release-please from the commit history, so accurate types matter.
@@ -157,12 +158,14 @@ SQL migrations use the `--` comment form. Python files in `services/agents/` use
 
 ## Opening the pull request
 
-1. Push your branch and open a PR against `main`.
+1. Push your branch and open a PR against **`pre-main`** (`gh pr create --base pre-main`) — not `main`. `pre-main` is the staging branch; every feature and fix lands there first and gets exercised end-to-end on staging.
 2. Fill out the PR template — what changed, why, and how you tested it.
 3. Make sure CI is green.
 4. A maintainer will review. We may ask for changes.
 
 Maintainers never merge their own PRs. Leave the final merge to a reviewer.
+
+Once a batch of changes on `pre-main` has been verified working end-to-end on staging, a **maintainer** opens a separate `pre-main → main` PR to release it to production. Contributors should not open PRs against `main`.
 
 ---
 


### PR DESCRIPTION
## Summary
- `CLAUDE.md` and `CONTRIBUTING.md` said contributors should open PRs against `main`. In practice `pre-main` is the staging branch every feature/fix should land on; `main` gets updated only via a maintainer-opened `pre-main → main` release PR after staging has been exercised end-to-end.
- Updated the Hard Rules and added a new "PR target branch" subsection under Git Hygiene in `CLAUDE.md`, and updated the branch conventions + "Opening the pull request" sections in `CONTRIBUTING.md` to say the same thing.
- No code changes — docs only.

## Test plan
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings` (pre-commit hook)
- [x] Full pre-push suite (fmt + clippy + UI build + UI tests + security audit + `cargo test`)
- [x] Read through both files end-to-end to confirm no other stale "PR to main" references were missed