### PR TITLE
fix(ci): force Tauri DMG Finder decoration on GitHub-hosted runners

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -69,6 +69,15 @@ jobs:
       # latest.json and the mirror no-ops, so the staging channel can't update.
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      # Tauri's DMG bundler skips the AppleScript step that sets the Finder
+      # window background/icon layout whenever `CI` is set (every GitHub
+      # Actions job sets `CI=true`), assuming CI runners can't drive Finder —
+      # https://github.com/tauri-apps/tauri/issues/1731. GitHub-hosted macOS
+      # runners DO have a full desktop session, so force the decoration step
+      # to run; without this the DMG ships the drag-to-Applications
+      # background.png as an inert file with no .DS_Store, so Finder never
+      # displays it.
+      TAURI_BUNDLER_DMG_IGNORE_CI: "true"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,15 @@ jobs:
       #   gh secret set TAURI_SIGNING_PRIVATE_KEY_PASSWORD
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      # Tauri's DMG bundler skips the AppleScript step that sets the Finder
+      # window background/icon layout whenever `CI` is set (every GitHub
+      # Actions job sets `CI=true`), assuming CI runners can't drive Finder —
+      # https://github.com/tauri-apps/tauri/issues/1731. GitHub-hosted macOS
+      # runners DO have a full desktop session, so force the decoration step
+      # to run; without this the DMG ships the drag-to-Applications
+      # background.png as an inert file with no .DS_Store, so Finder never
+      # displays it.
+      TAURI_BUNDLER_DMG_IGNORE_CI: "true"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- The drag-to-Applications DMG background from #426 was silently not rendering in Finder for real installs. Root cause: Tauri's DMG bundler skips the AppleScript step that writes `.DS_Store` (background image reference, icon positions, window bounds) whenever `CI` is set, assuming CI runners can't drive Finder ([tauri-apps/tauri#1731](https://github.com/tauri-apps/tauri/issues/1731)). GitHub Actions sets `CI=true` on every job by default, so every DMG built by `release.yml`/`release-staging.yml` shipped `background.png` as an inert bundled file with no `.DS_Store` pointing Finder at it.
- Verified by downloading `Meridian.dmg` from the latest staging release (`v1.70.0-staging.5`), mounting it, and confirming `background.png` was present and byte-identical to the repo's asset, but `.DS_Store` was completely absent from the volume.
- GitHub-hosted `macos-26` runners have a full interactive desktop session (unlike headless/self-hosted CI), so it's safe to force the decoration step via `TAURI_BUNDLER_DMG_IGNORE_CI=true` in both release workflows' job-level `env`.

## Test plan
- [ ] Trigger a staging release build (`[staging-release]` marker commit or `workflow_dispatch` on `release-staging.yml`) and confirm the run succeeds
- [ ] Download the resulting `Meridian.dmg`, mount it, and confirm `.DS_Store` is now present and Finder renders the themed background + curved arrow
- [ ] No change expected to non-DMG artifacts (`Meridian.app.tar.gz`, `latest.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ADhKy7AoHqknbZwTwLFkS