### PR TITLE
feat(tray): auto-open the Plan your day view once per day

### DIFF
--- a/meridian-core/src/lib.rs
+++ b/meridian-core/src/lib.rs
@@ -35,6 +35,10 @@ pub mod settings;
 /// Notification delivery policy + native pending queue (ported from lib/notifications.ts).
 pub mod notifications;
 
+/// The `~/.meridian/plan_auto_opened` marker format — written by the tray's
+/// daily planner auto-open, read by the daemon's plan-nudge hold-back.
+pub mod plan_marker;
+
 /// In-process capture-frame writer (Gap-2 Bucket 2). Inverted ownership: the
 /// tray writes `capture_frames`, the daemon's ETL reads it.
 pub mod capture;

--- a/meridian-core/src/plan_marker.rs
+++ b/meridian-core/src/plan_marker.rs
@@ -1,0 +1,91 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! The `~/.meridian/plan_auto_opened` marker — the shared record of when the
+//! tray last auto-opened the daily planner.
+//!
+//! One file, two consumers with different questions:
+//! - The **tray** (writer) asks "did I already open the planner today?" —
+//!   [`opened_today`] — to fire at most once per local day.
+//! - The **daemon** (reader) asks "how long ago did it open?" — [`opened_at`]
+//!   — to hold the `plan.nudge` reminder back for a grace period after the
+//!   auto-open instead of toasting over the window that just opened.
+//!
+//! The content is a single RFC3339 local timestamp (e.g.
+//! `2026-07-13T09:18:52+05:30`); its first 10 chars are the local date, which
+//! keeps [`opened_today`] a plain prefix check and stays readable in a shell.
+//! This module owns the format so the two sides can never drift.
+//!
+//! # Who calls this
+//! - `tray/src-tauri/src/poll/plan_auto_open.rs` — path + stamp + opened_today.
+//! - The daemon's `src/daily_plan.rs::maybe_nudge` — path + opened_today +
+//!   opened_at (the nudge hold-back).
+//!
+//! # Related
+//! - [`crate::plan`] — `plan_handled`, the sibling "day already planned" gate.
+
+use chrono::{DateTime, FixedOffset, Local};
+use std::path::{Path, PathBuf};
+
+/// File name under `~/.meridian` (same convention as the `onboarded` marker).
+pub const MARKER_FILE: &str = "plan_auto_opened";
+
+/// `<meridian_dir>/plan_auto_opened` — callers pass `~/.meridian`.
+pub fn marker_path(meridian_dir: &Path) -> PathBuf {
+    meridian_dir.join(MARKER_FILE)
+}
+
+/// The marker content for an auto-open happening `now`: an RFC3339 local
+/// timestamp whose first 10 chars are the local date.
+pub fn stamp(now: &DateTime<Local>) -> String {
+    now.to_rfc3339_opts(chrono::SecondsFormat::Secs, false)
+}
+
+/// True when the marker records an auto-open on `today` (local `YYYY-MM-DD`).
+/// A prefix match, so it accepts both the timestamp form and a legacy bare
+/// date; whitespace-tolerant; empty/missing/garbage content → `false`.
+pub fn opened_today(marker_contents: &str, today: &str) -> bool {
+    marker_contents.trim().starts_with(today)
+}
+
+/// The instant the auto-open happened, if the marker carries a parseable
+/// timestamp. `None` for a legacy bare-date or garbage marker — callers that
+/// measure elapsed time treat that as "age unknown".
+pub fn opened_at(marker_contents: &str) -> Option<DateTime<FixedOffset>> {
+    DateTime::parse_from_rfc3339(marker_contents.trim()).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stamp_round_trips_and_prefixes_the_local_date() {
+        let now = Local::now();
+        let s = stamp(&now);
+        let today = now.format("%Y-%m-%d").to_string();
+        assert!(opened_today(&s, &today));
+        assert!(!opened_today(&s, "1999-01-01"));
+        let parsed = opened_at(&s).expect("stamp must parse back");
+        assert_eq!(parsed.timestamp(), now.timestamp());
+    }
+
+    #[test]
+    fn opened_today_accepts_legacy_bare_date_and_rejects_garbage() {
+        assert!(opened_today("2026-07-13", "2026-07-13"), "legacy bare date");
+        assert!(opened_today("2026-07-13\n", "2026-07-13"));
+        assert!(opened_today("  2026-07-13T09:18:52+05:30  ", "2026-07-13"));
+        assert!(!opened_today("2026-07-12T23:59:59+05:30", "2026-07-13"));
+        assert!(!opened_today("", "2026-07-13"));
+        assert!(!opened_today("garbage", "2026-07-13"));
+    }
+
+    #[test]
+    fn opened_at_is_none_for_legacy_or_garbage() {
+        assert!(
+            opened_at("2026-07-13").is_none(),
+            "bare date has no instant"
+        );
+        assert!(opened_at("").is_none());
+        assert!(opened_at("garbage").is_none());
+        assert!(opened_at("2026-07-13T09:18:52+05:30").is_some());
+    }
+}

--- a/meridian-core/src/plan_marker.rs
+++ b/meridian-core/src/plan_marker.rs
@@ -16,6 +16,8 @@
 //!
 //! # Who calls this
 //! - `tray/src-tauri/src/poll/plan_auto_open.rs` — path + stamp + opened_today.
+//! - The tray's `plan_dismissed` command — [`restamp_if_today`], restarting
+//!   the hold-back clock when the user closes the planner without confirming.
 //! - The daemon's `src/daily_plan.rs::maybe_nudge` — path + opened_today +
 //!   opened_at (the nudge hold-back).
 //!
@@ -53,6 +55,22 @@ pub fn opened_at(marker_contents: &str) -> Option<DateTime<FixedOffset>> {
     DateTime::parse_from_rfc3339(marker_contents.trim()).ok()
 }
 
+/// Restart the nudge hold-back clock at planner dismissal: re-stamp the
+/// marker with `now`, but ONLY when it already records `now`'s local day —
+/// i.e. the auto-open actually fired today. A manual planner open/close on a
+/// day without the auto-open (feature off, pre-8am machine, tray restart
+/// races) must not suppress the daemon's nudge. Returns whether a re-stamp
+/// was written; fs errors read as `false` (the clock simply keeps running
+/// from the original open — a reminder that's early beats one that's lost).
+pub fn restamp_if_today(marker: &Path, now: &DateTime<Local>) -> bool {
+    let today = now.format("%Y-%m-%d").to_string();
+    let contents = std::fs::read_to_string(marker).unwrap_or_default();
+    if !opened_today(&contents, &today) {
+        return false;
+    }
+    std::fs::write(marker, stamp(now)).is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,6 +94,34 @@ mod tests {
         assert!(!opened_today("2026-07-12T23:59:59+05:30", "2026-07-13"));
         assert!(!opened_today("", "2026-07-13"));
         assert!(!opened_today("garbage", "2026-07-13"));
+    }
+
+    #[test]
+    fn restamp_only_refreshes_a_today_marker() {
+        let dir = std::env::temp_dir().join(format!("meridian-restamp-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let marker = marker_path(&dir);
+        let now = Local::now();
+
+        // No marker (auto-open never fired today) → no re-stamp, no file.
+        assert!(!restamp_if_today(&marker, &now));
+        assert!(!marker.exists());
+
+        // Stale (prior-day) marker → left untouched.
+        std::fs::write(&marker, "1999-01-01T09:00:00+00:00").unwrap();
+        assert!(!restamp_if_today(&marker, &now));
+        assert!(std::fs::read_to_string(&marker)
+            .unwrap()
+            .starts_with("1999-01-01"));
+
+        // Today's marker → refreshed to `now` (the dismissal instant).
+        let earlier = now - chrono::Duration::seconds(1800);
+        std::fs::write(&marker, stamp(&earlier)).unwrap();
+        assert!(restamp_if_today(&marker, &now));
+        let refreshed = opened_at(&std::fs::read_to_string(&marker).unwrap()).unwrap();
+        assert_eq!(refreshed.timestamp(), now.timestamp());
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/meridian-core/src/readers/plan.rs
+++ b/meridian-core/src/readers/plan.rs
@@ -230,6 +230,21 @@ async fn load_meta(pool: &SqlitePool, date: &str) -> anyhow::Result<MetaRow> {
     })
 }
 
+/// True when `date`'s plan is already handled — confirmed or explicitly
+/// skipped in `daily_plan_meta`. The tray's daily auto-open gate: an
+/// already-planned day must not pop the planner again. Missing table or no
+/// row for `date` (and any read error) → `false`.
+///
+/// # Who calls this
+/// The tray poll loop (`tray/src-tauri/src/poll/plan_auto_open.rs`).
+#[tracing::instrument(skip(pool))]
+pub async fn plan_handled(pool: &SqlitePool, date: &str) -> bool {
+    load_meta(pool, date)
+        .await
+        .map(|m| m.confirmed_at.is_some() || m.skipped == 1)
+        .unwrap_or(false)
+}
+
 /// task_keys committed on the most recent planned day strictly before `date`.
 async fn carryover_keys(pool: &SqlitePool, date: &str) -> anyhow::Result<HashSet<String>> {
     if !table_exists(pool, "daily_plan").await {

--- a/meridian-core/src/settings.rs
+++ b/meridian-core/src/settings.rs
@@ -65,6 +65,10 @@ pub struct RuntimeSettings {
     // `quiet_hours_*` are 'HH:MM' local time (start inclusive, end exclusive).
     pub notifications_enabled: bool,
     pub notify_plan_nudge: bool,
+    // Daily planner auto-open — once per local day the tray opens the dashboard
+    // on the Plan modal (first launch or first poll tick of a new day). A window
+    // behaviour, not a toast, so it is NOT gated by `notifications_enabled`.
+    pub auto_open_plan: bool,
     pub notify_worklog_ready: bool,
     pub notify_system_fault: bool,
     pub quiet_hours_enabled: bool,
@@ -107,6 +111,7 @@ impl Default for RuntimeSettings {
             // enabled). Must match SETTINGS_DEFAULTS in ui/lib/settings.ts.
             notifications_enabled: true,
             notify_plan_nudge: true,
+            auto_open_plan: true,
             notify_worklog_ready: true,
             notify_system_fault: true,
             quiet_hours_enabled: false,

--- a/meridian-core/tests/readers.rs
+++ b/meridian-core/tests/readers.rs
@@ -683,3 +683,52 @@ async fn current_task_percent_none_without_story_points() {
         "no pm_tasks row → percent should be None"
     );
 }
+
+// ── plan_handled (tray auto-open gate) ────────────────────────────────────────
+
+#[tokio::test]
+async fn plan_handled_reads_meta_states() {
+    let pool = make_plan_pool().await;
+    let today = "2026-07-13";
+
+    // No row for the date → not handled.
+    assert!(!meridian_core::plan::plan_handled(&pool, today).await);
+
+    // Row present but neither confirmed nor skipped → still not handled.
+    sqlx::query(
+        "INSERT INTO daily_plan_meta (plan_date, confirmed_at, skipped, created_at, updated_at) \
+         VALUES (?, NULL, 0, 't', 't')",
+    )
+    .bind(today)
+    .execute(&pool)
+    .await
+    .unwrap();
+    assert!(!meridian_core::plan::plan_handled(&pool, today).await);
+
+    // Confirmed → handled.
+    sqlx::query("UPDATE daily_plan_meta SET confirmed_at = 't' WHERE plan_date = ?")
+        .bind(today)
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert!(meridian_core::plan::plan_handled(&pool, today).await);
+
+    // Skipped (not confirmed) → handled.
+    sqlx::query("UPDATE daily_plan_meta SET confirmed_at = NULL, skipped = 1 WHERE plan_date = ?")
+        .bind(today)
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert!(meridian_core::plan::plan_handled(&pool, today).await);
+}
+
+#[tokio::test]
+async fn plan_handled_false_without_table() {
+    // A bare DB (no daily_plan_meta) must read as "not handled", not error.
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+    assert!(!meridian_core::plan::plan_handled(&pool, "2026-07-13").await);
+}

--- a/src/daily_plan.rs
+++ b/src/daily_plan.rs
@@ -2,7 +2,10 @@
 //
 // Morning "plan your day" nudge. Once per local day, when the dev has neither
 // confirmed nor skipped today's plan and there are open tickets to plan against,
-// enqueue a `plan.nudge` notification. Idempotent via the outbox dedup key, so
+// enqueue a `plan.nudge` notification. If the tray's daily planner auto-open
+// (`~/.meridian/plan_auto_opened`) fired within the last hour, the nudge waits
+// — it is the second-chance reminder after a dismissed planner, not a
+// duplicate toast over the window that just opened. Idempotent via the outbox dedup key, so
 // the poll loop can call this every tick without spamming. A nudge is only
 // meaningful on its own day, so it carries an `expires_at` of the next local
 // midnight, and any still-live nudge from a previous day (or one whose plan has
@@ -19,6 +22,13 @@ use crate::notifications::{self, NewNotification};
 // once-per-day dedup means the nudge lands on the first tick after the start hour.
 const NUDGE_FROM_HOUR: u32 = 8;
 const NUDGE_UNTIL_HOUR: u32 = 18;
+
+// How long after the tray's daily planner auto-open to hold the nudge back —
+// deliberately the same grace as a "Snooze 1h" answer (`SNOOZE_SECS` in
+// notification_responses.rs). The auto-open already put the planner in the
+// user's face; the nudge is the second chance if they dismissed it without
+// planning, not a toast over the window that just opened.
+const AUTO_OPEN_GRACE_SECS: i64 = 3600;
 
 /// Enqueue today's plan nudge if it's due and not already actioned. Best-effort:
 /// any DB error (e.g. a pre-migration-041 database with no `daily_plan` tables)
@@ -67,6 +77,20 @@ pub async fn maybe_nudge(pool: &SqlitePool) -> Result<()> {
         }
     }
 
+    // Auto-open aware hold-back: if the tray auto-opened the planner today,
+    // give the user an hour with it before reminding (the marker holds the
+    // open's timestamp — see `meridian_core::plan_marker`). Once the hour has
+    // passed and the plan is still unconfirmed, the nudge fires as usual, so
+    // a dismissed planner still gets its reminder later.
+    if let Ok(home) = std::env::var("HOME") {
+        let path =
+            meridian_core::plan_marker::marker_path(&std::path::Path::new(&home).join(".meridian"));
+        let marker = std::fs::read_to_string(path).unwrap_or_default();
+        if nudge_held_back(&marker, &today, &now) {
+            return Ok(());
+        }
+    }
+
     // Nothing on the board to plan against → no nudge.
     let has_open_tasks: i64 = sqlx::query_scalar(
         "SELECT EXISTS(SELECT 1 FROM pm_tasks WHERE COALESCE(is_terminal, 0) = 0)",
@@ -96,6 +120,24 @@ pub async fn maybe_nudge(pool: &SqlitePool) -> Result<()> {
         nudge = nudge.expiring(exp);
     }
     notifications::enqueue(pool, nudge).await
+}
+
+/// True while the nudge should wait because the tray's planner auto-open
+/// happened less than [`AUTO_OPEN_GRACE_SECS`] ago today. Pure so the three
+/// regimes are unit-testable: no/stale/foreign-day marker → don't hold;
+/// today's marker within the grace hour → hold; past it → fire. A today
+/// marker whose timestamp can't be parsed (legacy bare-date form) → don't
+/// hold — age unknown beats never reminding.
+fn nudge_held_back(marker_contents: &str, today: &str, now: &chrono::DateTime<Local>) -> bool {
+    if !meridian_core::plan_marker::opened_today(marker_contents, today) {
+        return false;
+    }
+    match meridian_core::plan_marker::opened_at(marker_contents) {
+        Some(opened) => {
+            now.signed_duration_since(opened) < chrono::Duration::seconds(AUTO_OPEN_GRACE_SECS)
+        }
+        None => false,
+    }
 }
 
 /// `t` as the UTC ISO-8601 string shape (`2026-07-05T02:30:24Z`) the
@@ -191,6 +233,29 @@ mod tests {
             Some(now),
             "a prior-day nudge must be expired"
         );
+    }
+
+    #[test]
+    fn nudge_hold_back_covers_the_grace_hour_only() {
+        let now = Local::now();
+        let today = now.format("%Y-%m-%d").to_string();
+        let stamp_ago =
+            |secs: i64| meridian_core::plan_marker::stamp(&(now - chrono::Duration::seconds(secs)));
+
+        // No marker / a prior-day marker → nudge free to fire.
+        assert!(!nudge_held_back("", &today, &now));
+        assert!(!nudge_held_back("1999-01-01T09:00:00+00:00", &today, &now));
+        // Opened 30 min ago → held. Opened 2 h ago → fires (second chance).
+        assert!(nudge_held_back(&stamp_ago(1800), &today, &now));
+        assert!(!nudge_held_back(&stamp_ago(7200), &today, &now));
+        // Exactly at the boundary the hold ends.
+        assert!(!nudge_held_back(
+            &stamp_ago(AUTO_OPEN_GRACE_SECS),
+            &today,
+            &now
+        ));
+        // Legacy bare-date marker (no timestamp): age unknown → don't hold.
+        assert!(!nudge_held_back(&today, &today, &now));
     }
 
     #[test]

--- a/tray/src-tauri/src/commands/dashboard.rs
+++ b/tray/src-tauri/src/commands/dashboard.rs
@@ -182,6 +182,28 @@ pub async fn plan_action(
         })
 }
 
+/// The user closed the Plan modal. Restarts the plan-nudge hold-back clock:
+/// re-stamps `~/.meridian/plan_auto_opened` with now, so the daemon's
+/// "Plan your day" reminder fires one hour after the DISMISSAL (not the
+/// auto-open) when the plan is still unconfirmed. A no-op unless the marker
+/// already records today — a manual planner open/close on a day the
+/// auto-open didn't fire must not suppress the nudge
+/// ([`meridian_core::plan_marker::restamp_if_today`] owns that guard).
+/// Fire-and-forget from the shell; never errors.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn plan_dismissed() {
+    let home = std::env::var("HOME").unwrap_or_default();
+    if home.is_empty() {
+        return;
+    }
+    let marker =
+        meridian_core::plan_marker::marker_path(&std::path::Path::new(&home).join(".meridian"));
+    if meridian_core::plan_marker::restamp_if_today(&marker, &chrono::Local::now()) {
+        tracing::info!("plan_dismissed: nudge hold-back clock restarted");
+    }
+}
+
 /// `YYYY-MM-DD` validation shared by the plan read/write date coercions.
 fn is_iso_date(d: &str) -> bool {
     let b = d.as_bytes();

--- a/tray/src-tauri/src/commands/notifications.rs
+++ b/tray/src-tauri/src/commands/notifications.rs
@@ -115,18 +115,16 @@ pub async fn record_notification_response(
 
     // The dashboard is a single window (deep_link routes were folded into one
     // page), so every foreground answer lands on the same opener. The link is
-    // handed to the window via the pending-deep-link pull (fresh window) AND a
-    // `dashboard-navigate` emit (already-open window) — see [`crate::deep_link`]
-    // — so the click actually lands on the linked view (e.g. the Plan modal),
-    // not just the default timeline.
+    // handed to the window first ([`crate::deep_link::navigate_dashboard`]:
+    // parked for a fresh window's mount-time pull, or emitted to an
+    // already-open one) so the click actually lands on the linked view (e.g.
+    // the Plan modal), not just the default timeline.
     if matches!(action.as_str(), "tap" | "open" | "view") {
         if let Some(link) = meridian_core::notifications::notification_deep_link(pool, id).await {
-            crate::deep_link::set_pending(&app, &link);
-            if let Err(e) = crate::commands::open_dashboard(app.clone()).await {
+            crate::deep_link::navigate_dashboard(&app, &link);
+            if let Err(e) = crate::commands::open_dashboard(app).await {
                 tracing::warn!(error = %e, id, "notification click-through open failed");
             }
-            use tauri::Emitter;
-            let _ = app.emit_to("dashboard", "dashboard-navigate", link);
         }
     }
     Ok(())

--- a/tray/src-tauri/src/commands/notifications.rs
+++ b/tray/src-tauri/src/commands/notifications.rs
@@ -114,14 +114,19 @@ pub async fn record_notification_response(
     );
 
     // The dashboard is a single window (deep_link routes were folded into one
-    // page), so every foreground answer lands on the same opener.
-    if matches!(action.as_str(), "tap" | "open" | "view")
-        && meridian_core::notifications::notification_deep_link(pool, id)
-            .await
-            .is_some()
-    {
-        if let Err(e) = crate::commands::open_dashboard(app).await {
-            tracing::warn!(error = %e, id, "notification click-through open failed");
+    // page), so every foreground answer lands on the same opener. The link is
+    // handed to the window via the pending-deep-link pull (fresh window) AND a
+    // `dashboard-navigate` emit (already-open window) — see [`crate::deep_link`]
+    // — so the click actually lands on the linked view (e.g. the Plan modal),
+    // not just the default timeline.
+    if matches!(action.as_str(), "tap" | "open" | "view") {
+        if let Some(link) = meridian_core::notifications::notification_deep_link(pool, id).await {
+            crate::deep_link::set_pending(&app, &link);
+            if let Err(e) = crate::commands::open_dashboard(app.clone()).await {
+                tracing::warn!(error = %e, id, "notification click-through open failed");
+            }
+            use tauri::Emitter;
+            let _ = app.emit_to("dashboard", "dashboard-navigate", link);
         }
     }
     Ok(())

--- a/tray/src-tauri/src/commands/system.rs
+++ b/tray/src-tauri/src/commands/system.rs
@@ -99,6 +99,17 @@ pub async fn open_setup(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Fetch-and-clear the pending dashboard navigation target (e.g. "/plan") —
+/// the pull half of [`crate::deep_link`]. Called once by
+/// `MeridianTimelineShell` on mount; `None` on a plain open. Infallible today,
+/// but returns `Result` like its sibling commands so the bridge's error path
+/// stays uniform if a failure mode appears.
+#[tracing::instrument(skip(app))]
+#[tauri::command]
+pub async fn take_pending_deep_link(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    Ok(crate::deep_link::take_pending(&app))
+}
+
 /// Deep-link straight to a macOS privacy pane in System Settings. `pane` is
 /// one of the wizard's known keys; anything else is rejected so the frontend
 /// can't open an arbitrary URL. We always offer this button regardless of

--- a/tray/src-tauri/src/deep_link.rs
+++ b/tray/src-tauri/src/deep_link.rs
@@ -5,21 +5,24 @@
 //! A freshly built `dashboard` webview can't receive a Tauri event emitted
 //! before its JS has mounted (no listener yet — the emit is lost), so pushing
 //! the target at the window races window creation. This module inverts it into
-//! a pull: the opener stores the target in managed state BEFORE opening the
-//! window, and `MeridianTimelineShell` fetches-and-clears it on mount via the
-//! `take_pending_deep_link` command. For a window that is ALREADY open (no
-//! remount, so no pull), openers additionally emit a `dashboard-navigate`
-//! event; double delivery is harmless — opening the same modal twice is
-//! idempotent.
+//! a pull: [`navigate_dashboard`] stores the target in managed state BEFORE
+//! the caller opens the window, and `MeridianTimelineShell` fetches-and-clears
+//! it on mount via the `take_pending_deep_link` command. For a window that is
+//! ALREADY open it emits a `dashboard-navigate` event instead — strictly one
+//! of the two, decided by whether the window exists: parking a pending target
+//! that the emit path already delivered would leave the slot dirty (an open
+//! window never remounts, so never pulls), and the NEXT manual dashboard open
+//! would consume the stale target and jump to that view unexpectedly.
 //!
 //! Targets are the former route paths the notification producers already use
 //! as `deep_link`s (`/plan`, `/worklogs`, …); the shell owns the mapping to a
 //! modal.
 //!
 //! # Who calls this
-//! - Setters: the poll loop's daily plan auto-open
+//! - [`navigate_dashboard`]: the poll loop's daily plan auto-open
 //!   ([`crate::poll`]'s `plan_auto_open`) and the notification tap handler
-//!   (`commands::record_notification_response`).
+//!   (`commands::record_notification_response`) — both immediately before
+//!   their open/focus-dashboard call.
 //! - Taker: the `take_pending_deep_link` command (`commands/system.rs`),
 //!   invoked once by `ui/components/timeline/MeridianTimelineShell.tsx` on
 //!   mount.
@@ -34,10 +37,28 @@ use tauri::Manager;
 /// an await).
 pub struct PendingDeepLink(pub std::sync::Mutex<Option<String>>);
 
+/// Deliver `target` to the dashboard, by whichever half fits the window's
+/// state: an already-open window gets a `dashboard-navigate` emit (its shell
+/// listener is live); a not-yet-existing one gets the target parked for its
+/// mount-time pull. Callers follow with their open/focus-dashboard call.
+///
+/// Known race, accepted: a window that exists but whose JS hasn't mounted yet
+/// (another path is creating it this instant) takes the emit branch and the
+/// event is lost — the cost is one missed navigation, never a stale one.
+pub fn navigate_dashboard(app: &tauri::AppHandle, target: &str) {
+    if app.get_webview_window("dashboard").is_some() {
+        use tauri::Emitter;
+        let _ = app.emit_to("dashboard", "dashboard-navigate", target);
+        tracing::debug!(target, "deep link emitted to the open dashboard");
+    } else {
+        set_pending(app, target);
+    }
+}
+
 /// Store `target` as the pending navigation for the next dashboard mount,
 /// replacing any previous (undelivered) one — last writer wins, matching how
 /// a user would perceive two rapid-fire opens.
-pub fn set_pending(app: &tauri::AppHandle, target: &str) {
+fn set_pending(app: &tauri::AppHandle, target: &str) {
     let slot = app.state::<PendingDeepLink>();
     let mut guard = slot.0.lock().unwrap_or_else(|p| p.into_inner());
     if let Some(prev) = guard.replace(target.to_string()) {

--- a/tray/src-tauri/src/deep_link.rs
+++ b/tray/src-tauri/src/deep_link.rs
@@ -1,0 +1,58 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Pending deep-link handoff — how tray-side code steers a dashboard window
+//! that may not exist yet to a specific in-app view (e.g. the Plan modal).
+//!
+//! A freshly built `dashboard` webview can't receive a Tauri event emitted
+//! before its JS has mounted (no listener yet — the emit is lost), so pushing
+//! the target at the window races window creation. This module inverts it into
+//! a pull: the opener stores the target in managed state BEFORE opening the
+//! window, and `MeridianTimelineShell` fetches-and-clears it on mount via the
+//! `take_pending_deep_link` command. For a window that is ALREADY open (no
+//! remount, so no pull), openers additionally emit a `dashboard-navigate`
+//! event; double delivery is harmless — opening the same modal twice is
+//! idempotent.
+//!
+//! Targets are the former route paths the notification producers already use
+//! as `deep_link`s (`/plan`, `/worklogs`, …); the shell owns the mapping to a
+//! modal.
+//!
+//! # Who calls this
+//! - Setters: the poll loop's daily plan auto-open
+//!   ([`crate::poll`]'s `plan_auto_open`) and the notification tap handler
+//!   (`commands::record_notification_response`).
+//! - Taker: the `take_pending_deep_link` command (`commands/system.rs`),
+//!   invoked once by `ui/components/timeline/MeridianTimelineShell.tsx` on
+//!   mount.
+//!
+//! # Related
+//! - [`crate::tray`] — `open_native_dashboard`, the window the target lands in.
+
+use tauri::Manager;
+
+/// Managed slot holding at most one pending navigation target. Registered in
+/// `lib.rs` via `.manage(...)`; a plain `std::sync::Mutex` (never held across
+/// an await).
+pub struct PendingDeepLink(pub std::sync::Mutex<Option<String>>);
+
+/// Store `target` as the pending navigation for the next dashboard mount,
+/// replacing any previous (undelivered) one — last writer wins, matching how
+/// a user would perceive two rapid-fire opens.
+pub fn set_pending(app: &tauri::AppHandle, target: &str) {
+    let slot = app.state::<PendingDeepLink>();
+    let mut guard = slot.0.lock().unwrap_or_else(|p| p.into_inner());
+    if let Some(prev) = guard.replace(target.to_string()) {
+        tracing::debug!(prev, target, "pending deep link replaced before delivery");
+    }
+    tracing::debug!(target, "pending deep link set");
+}
+
+/// Fetch-and-clear the pending target. `None` on a plain dashboard open (the
+/// common case) — the shell then just shows the default timeline.
+pub fn take_pending(app: &tauri::AppHandle) -> Option<String> {
+    let slot = app.state::<PendingDeepLink>();
+    let taken = slot.0.lock().unwrap_or_else(|p| p.into_inner()).take();
+    if let Some(t) = &taken {
+        tracing::debug!(target = %t, "pending deep link taken");
+    }
+    taken
+}

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ mod backend_install;
 #[cfg(feature = "capture")]
 mod capture;
 mod commands;
+mod deep_link;
 
 /// Lowercase product name as macOS reports it after [`set_process_display_name`].
 /// The capture engine uses this to skip self-capture — keep it in sync with the
@@ -105,6 +106,9 @@ pub fn run() {
     builder
         .manage(app_state.clone())
         .manage(mlx_manager.clone())
+        // Pending dashboard navigation target (e.g. "/plan") — set by tray-side
+        // openers, pulled by the dashboard shell on mount. See `deep_link`.
+        .manage(deep_link::PendingDeepLink(std::sync::Mutex::new(None)))
         .setup(move |app| {
             #[cfg(target_os = "macos")]
             app.set_activation_policy(tauri::ActivationPolicy::Accessory);
@@ -531,6 +535,7 @@ pub fn run() {
             commands::cancel_oauth,
             commands::get_oauth_status,
             // OS/window actions
+            commands::take_pending_deep_link,
             commands::open_permission_pane,
             commands::open_external_url,
             commands::quit_app,

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -509,6 +509,7 @@ pub fn run() {
             commands::get_app_icon,
             // DB writes (ported /api/* POSTs/PATCH/DELETE)
             commands::plan_action,
+            commands::plan_dismissed,
             commands::triage_decision,
             commands::triage_ignore,
             commands::apply_ticket_fix,

--- a/tray/src-tauri/src/poll/mod.rs
+++ b/tray/src-tauri/src/poll/mod.rs
@@ -21,6 +21,7 @@
 
 mod live;
 mod notifications;
+mod plan_auto_open;
 mod refresh;
 
 pub(crate) use notifications::notifications_allowed;
@@ -133,6 +134,10 @@ pub async fn run_poll_loop(app: tauri::AppHandle, state: Arc<Mutex<AppState>>) {
         // feature is enabled; never overrides a user-initiated timed pause.
         if let Some(pool) = &pool {
             check_work_hours(&app, &state, pool).await;
+            // Daily "Plan your day" auto-open — at most once per local day
+            // (marker-file gated; a single file stat on the common path). If
+            // the pool isn't open yet this tick, it simply retries next tick.
+            plan_auto_open::maybe_auto_open_plan(&app, pool).await;
         }
 
         // Drain the daemon's notification outbox every tick — this is the single

--- a/tray/src-tauri/src/poll/plan_auto_open.rs
+++ b/tray/src-tauri/src/poll/plan_auto_open.rs
@@ -9,8 +9,9 @@
 //!
 //! Gates, cheapest first:
 //! 1. marker file `~/.meridian/plan_auto_opened` already records today (it
-//!    holds the open's timestamp — `meridian_core::plan_marker` — which the
-//!    daemon also reads to hold its plan nudge back an hour after the open)
+//!    holds a timestamp — `meridian_core::plan_marker` — refreshed when the
+//!    user dismisses the planner, which the daemon reads to hold its plan
+//!    nudge back until an hour after the open/dismissal)
 //! 2. `auto_open_plan` disabled in settings
 //! 3. not onboarded (no `~/.meridian/onboarded` — don't open over the wizard)
 //! 4. today's plan already confirmed/skipped (`daily_plan_meta`) — the marker

--- a/tray/src-tauri/src/poll/plan_auto_open.rs
+++ b/tray/src-tauri/src/poll/plan_auto_open.rs
@@ -8,7 +8,9 @@
 //! "logged in this morning" and "new day started while the tray kept running".
 //!
 //! Gates, cheapest first:
-//! 1. marker file `~/.meridian/plan_auto_opened` already holds today's date
+//! 1. marker file `~/.meridian/plan_auto_opened` already records today (it
+//!    holds the open's timestamp — `meridian_core::plan_marker` — which the
+//!    daemon also reads to hold its plan nudge back an hour after the open)
 //! 2. `auto_open_plan` disabled in settings
 //! 3. not onboarded (no `~/.meridian/onboarded` — don't open over the wizard)
 //! 4. today's plan already confirmed/skipped (`daily_plan_meta`) — the marker
@@ -31,12 +33,9 @@
 //! - `src/daily_plan.rs` (daemon) — the sibling notification nudge; both read
 //!   the same `daily_plan_meta` "already handled" state.
 
-use std::path::{Path, PathBuf};
+use meridian_core::plan_marker;
+use std::path::Path;
 use tauri::Emitter;
-
-/// Marker file under `~/.meridian` holding the local date (`YYYY-MM-DD`) of
-/// the last auto-open. Same convention as the `onboarded` marker.
-const MARKER_FILE: &str = "plan_auto_opened";
 
 /// Once per local day, open the dashboard on the Plan modal. See the module
 /// docs for the gate order and rationale.
@@ -47,12 +46,16 @@ pub(crate) async fn maybe_auto_open_plan(app: &tauri::AppHandle, pool: &meridian
         return;
     }
     let meridian_dir = Path::new(&home).join(".meridian");
-    let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+    let now = chrono::Local::now();
+    let today = now.format("%Y-%m-%d").to_string();
 
-    // 1. Already fired today — one file stat on the common path.
-    let marker = marker_path(&meridian_dir);
+    // 1. Already fired today — one file stat on the common path. The marker
+    //    holds the open's RFC3339 timestamp (see `meridian_core::plan_marker`);
+    //    the daemon reads the same file to hold its plan nudge back for an
+    //    hour after the auto-open.
+    let marker = plan_marker::marker_path(&meridian_dir);
     let marker_contents = std::fs::read_to_string(&marker).unwrap_or_default();
-    if already_opened(&marker_contents, &today) {
+    if plan_marker::opened_today(&marker_contents, &today) {
         return;
     }
 
@@ -69,7 +72,7 @@ pub(crate) async fn maybe_auto_open_plan(app: &tauri::AppHandle, pool: &meridian
     // 4. Day already planned (confirmed or skipped, e.g. via the notification
     //    nudge) — settle the day without opening.
     if meridian_core::plan::plan_handled(pool, &today).await {
-        write_marker(&marker, &today);
+        write_marker(&marker, &now);
         tracing::info!(%today, "plan auto-open: plan already handled — marking day settled");
         return;
     }
@@ -79,30 +82,18 @@ pub(crate) async fn maybe_auto_open_plan(app: &tauri::AppHandle, pool: &meridian
     // deep link, open/focus the window, and also emit for an already-open
     // window (which won't remount and thus never pulls). Double delivery is
     // idempotent — the shell opens the same modal.
-    write_marker(&marker, &today);
+    write_marker(&marker, &now);
     crate::deep_link::set_pending(app, "/plan");
     crate::tray::open_native_dashboard(app);
     let _ = app.emit_to("dashboard", "dashboard-navigate", "/plan");
     tracing::info!(%today, "plan auto-open: opened dashboard on the Plan view");
 }
 
-/// `~/.meridian/plan_auto_opened`. Split out (and pure over the dir) so tests
-/// can point it at a temp dir.
-fn marker_path(meridian_dir: &Path) -> PathBuf {
-    meridian_dir.join(MARKER_FILE)
-}
-
-/// True when the marker already records `today`. Pure so the date comparison
-/// (whitespace tolerance, stale dates, empty/missing file) is unit-testable.
-fn already_opened(marker_contents: &str, today: &str) -> bool {
-    marker_contents.trim() == today
-}
-
-/// Persist today's date into the marker. A failure is logged but not fatal:
-/// the worst case is the open firing again after a tray restart — annoying,
-/// not incorrect.
-fn write_marker(marker: &Path, today: &str) {
-    if let Err(e) = std::fs::write(marker, today) {
+/// Persist the open's timestamp into the marker. A failure is logged but not
+/// fatal: the worst case is the open firing again after a tray restart —
+/// annoying, not incorrect.
+fn write_marker(marker: &Path, now: &chrono::DateTime<chrono::Local>) {
+    if let Err(e) = std::fs::write(marker, plan_marker::stamp(now)) {
         tracing::warn!(error = %e, path = %marker.display(), "plan auto-open: marker write failed");
     }
 }
@@ -111,54 +102,31 @@ fn write_marker(marker: &Path, today: &str) {
 mod tests {
     use super::*;
 
-    #[test]
-    fn already_opened_matches_today_only() {
-        assert!(already_opened("2026-07-13", "2026-07-13"));
-        assert!(
-            already_opened("2026-07-13\n", "2026-07-13"),
-            "trailing newline tolerated"
-        );
-        assert!(
-            already_opened("  2026-07-13  ", "2026-07-13"),
-            "surrounding whitespace tolerated"
-        );
-        assert!(
-            !already_opened("", "2026-07-13"),
-            "missing/empty marker → not opened"
-        );
-        assert!(
-            !already_opened("2026-07-12", "2026-07-13"),
-            "stale marker → fire again"
-        );
-        assert!(!already_opened("garbage", "2026-07-13"));
-    }
-
+    // Format/date semantics are covered in `meridian_core::plan_marker`; this
+    // exercises the tray's write half against the real fs.
     #[test]
     fn marker_round_trips_through_the_fs() {
         let dir = std::env::temp_dir().join(format!("meridian-plan-marker-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
-        let marker = marker_path(&dir);
-        assert_eq!(marker.file_name().unwrap(), MARKER_FILE);
+        let marker = plan_marker::marker_path(&dir);
+        assert_eq!(marker.file_name().unwrap(), plan_marker::MARKER_FILE);
 
-        assert!(!already_opened(
+        let now = chrono::Local::now();
+        let today = now.format("%Y-%m-%d").to_string();
+        assert!(!plan_marker::opened_today(
             &std::fs::read_to_string(&marker).unwrap_or_default(),
-            "2026-07-13"
+            &today
         ));
-        write_marker(&marker, "2026-07-13");
-        assert!(already_opened(
-            &std::fs::read_to_string(&marker).unwrap(),
-            "2026-07-13"
-        ));
-        // Next day: stale marker no longer counts, and a rewrite wins.
-        assert!(!already_opened(
-            &std::fs::read_to_string(&marker).unwrap(),
-            "2026-07-14"
-        ));
-        write_marker(&marker, "2026-07-14");
-        assert!(already_opened(
-            &std::fs::read_to_string(&marker).unwrap(),
-            "2026-07-14"
-        ));
+        write_marker(&marker, &now);
+        let contents = std::fs::read_to_string(&marker).unwrap();
+        assert!(plan_marker::opened_today(&contents, &today));
+        // The daemon's hold-back can recover the instant from what we wrote.
+        assert_eq!(
+            plan_marker::opened_at(&contents).map(|t| t.timestamp()),
+            Some(now.timestamp())
+        );
+        // A different day no longer matches (stale marker → fire again).
+        assert!(!plan_marker::opened_today(&contents, "1999-01-01"));
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/tray/src-tauri/src/poll/plan_auto_open.rs
+++ b/tray/src-tauri/src/poll/plan_auto_open.rs
@@ -1,0 +1,165 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Daily "Plan your day" auto-open — once per local day, open the dashboard
+//! window on the Plan modal so the user starts the day by planning it.
+//!
+//! Runs every poll tick (30 s). The tick — not a launch hook — is the trigger
+//! because on most days the machine just wakes from sleep with the tray
+//! already running for days; tick 0 fires at launch, so one check covers both
+//! "logged in this morning" and "new day started while the tray kept running".
+//!
+//! Gates, cheapest first:
+//! 1. marker file `~/.meridian/plan_auto_opened` already holds today's date
+//! 2. `auto_open_plan` disabled in settings
+//! 3. not onboarded (no `~/.meridian/onboarded` — don't open over the wizard)
+//! 4. today's plan already confirmed/skipped (`daily_plan_meta`) — the marker
+//!    is written WITHOUT opening, so the day stays settled
+//!
+//! The marker is written BEFORE the window opens: under launchd `KeepAlive` a
+//! crash-relaunch loop would otherwise re-open the planner on every relaunch.
+//! Worst case of the inverse (marker written, open failed) is one missed day.
+//!
+//! Deliberately NO hour gate (product call: "first activity of the day, any
+//! time"). An unattended overnight wake (Power Nap) can therefore fire under
+//! the lock screen — the window simply greets the user at unlock.
+//!
+//! # Who calls this
+//! [`crate::poll::run_poll_loop`], every tick, once the DB pool is open.
+//!
+//! # Related
+//! - [`crate::deep_link`] — how the freshly opened window learns to show the
+//!   Plan modal.
+//! - `src/daily_plan.rs` (daemon) — the sibling notification nudge; both read
+//!   the same `daily_plan_meta` "already handled" state.
+
+use std::path::{Path, PathBuf};
+use tauri::Emitter;
+
+/// Marker file under `~/.meridian` holding the local date (`YYYY-MM-DD`) of
+/// the last auto-open. Same convention as the `onboarded` marker.
+const MARKER_FILE: &str = "plan_auto_opened";
+
+/// Once per local day, open the dashboard on the Plan modal. See the module
+/// docs for the gate order and rationale.
+#[tracing::instrument(skip(app, pool))]
+pub(crate) async fn maybe_auto_open_plan(app: &tauri::AppHandle, pool: &meridian_core::SqlitePool) {
+    let home = std::env::var("HOME").unwrap_or_default();
+    if home.is_empty() {
+        return;
+    }
+    let meridian_dir = Path::new(&home).join(".meridian");
+    let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+
+    // 1. Already fired today — one file stat on the common path.
+    let marker = marker_path(&meridian_dir);
+    let marker_contents = std::fs::read_to_string(&marker).unwrap_or_default();
+    if already_opened(&marker_contents, &today) {
+        return;
+    }
+
+    // 2. Feature toggle.
+    if !meridian_core::settings::load_runtime_settings().auto_open_plan {
+        return;
+    }
+
+    // 3. Don't open the planner over (or instead of) the first-run wizard.
+    if !meridian_dir.join("onboarded").exists() {
+        return;
+    }
+
+    // 4. Day already planned (confirmed or skipped, e.g. via the notification
+    //    nudge) — settle the day without opening.
+    if meridian_core::plan::plan_handled(pool, &today).await {
+        write_marker(&marker, &today);
+        tracing::info!(%today, "plan auto-open: plan already handled — marking day settled");
+        return;
+    }
+
+    // Fire. Marker first (crash-safe vs KeepAlive relaunch loops), then hand
+    // the target to the (possibly not-yet-existing) window via the pending
+    // deep link, open/focus the window, and also emit for an already-open
+    // window (which won't remount and thus never pulls). Double delivery is
+    // idempotent — the shell opens the same modal.
+    write_marker(&marker, &today);
+    crate::deep_link::set_pending(app, "/plan");
+    crate::tray::open_native_dashboard(app);
+    let _ = app.emit_to("dashboard", "dashboard-navigate", "/plan");
+    tracing::info!(%today, "plan auto-open: opened dashboard on the Plan view");
+}
+
+/// `~/.meridian/plan_auto_opened`. Split out (and pure over the dir) so tests
+/// can point it at a temp dir.
+fn marker_path(meridian_dir: &Path) -> PathBuf {
+    meridian_dir.join(MARKER_FILE)
+}
+
+/// True when the marker already records `today`. Pure so the date comparison
+/// (whitespace tolerance, stale dates, empty/missing file) is unit-testable.
+fn already_opened(marker_contents: &str, today: &str) -> bool {
+    marker_contents.trim() == today
+}
+
+/// Persist today's date into the marker. A failure is logged but not fatal:
+/// the worst case is the open firing again after a tray restart — annoying,
+/// not incorrect.
+fn write_marker(marker: &Path, today: &str) {
+    if let Err(e) = std::fs::write(marker, today) {
+        tracing::warn!(error = %e, path = %marker.display(), "plan auto-open: marker write failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn already_opened_matches_today_only() {
+        assert!(already_opened("2026-07-13", "2026-07-13"));
+        assert!(
+            already_opened("2026-07-13\n", "2026-07-13"),
+            "trailing newline tolerated"
+        );
+        assert!(
+            already_opened("  2026-07-13  ", "2026-07-13"),
+            "surrounding whitespace tolerated"
+        );
+        assert!(
+            !already_opened("", "2026-07-13"),
+            "missing/empty marker → not opened"
+        );
+        assert!(
+            !already_opened("2026-07-12", "2026-07-13"),
+            "stale marker → fire again"
+        );
+        assert!(!already_opened("garbage", "2026-07-13"));
+    }
+
+    #[test]
+    fn marker_round_trips_through_the_fs() {
+        let dir = std::env::temp_dir().join(format!("meridian-plan-marker-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let marker = marker_path(&dir);
+        assert_eq!(marker.file_name().unwrap(), MARKER_FILE);
+
+        assert!(!already_opened(
+            &std::fs::read_to_string(&marker).unwrap_or_default(),
+            "2026-07-13"
+        ));
+        write_marker(&marker, "2026-07-13");
+        assert!(already_opened(
+            &std::fs::read_to_string(&marker).unwrap(),
+            "2026-07-13"
+        ));
+        // Next day: stale marker no longer counts, and a rewrite wins.
+        assert!(!already_opened(
+            &std::fs::read_to_string(&marker).unwrap(),
+            "2026-07-14"
+        ));
+        write_marker(&marker, "2026-07-14");
+        assert!(already_opened(
+            &std::fs::read_to_string(&marker).unwrap(),
+            "2026-07-14"
+        ));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/tray/src-tauri/src/poll/plan_auto_open.rs
+++ b/tray/src-tauri/src/poll/plan_auto_open.rs
@@ -36,7 +36,6 @@
 
 use meridian_core::plan_marker;
 use std::path::Path;
-use tauri::Emitter;
 
 /// Once per local day, open the dashboard on the Plan modal. See the module
 /// docs for the gate order and rationale.
@@ -79,14 +78,13 @@ pub(crate) async fn maybe_auto_open_plan(app: &tauri::AppHandle, pool: &meridian
     }
 
     // Fire. Marker first (crash-safe vs KeepAlive relaunch loops), then hand
-    // the target to the (possibly not-yet-existing) window via the pending
-    // deep link, open/focus the window, and also emit for an already-open
-    // window (which won't remount and thus never pulls). Double delivery is
-    // idempotent — the shell opens the same modal.
+    // the target to the window — parked for a fresh window's mount-time pull,
+    // or emitted to an already-open one (`deep_link::navigate_dashboard`
+    // picks; parking both ways would leave a stale target for a later manual
+    // open) — then open/focus the window.
     write_marker(&marker, &now);
-    crate::deep_link::set_pending(app, "/plan");
+    crate::deep_link::navigate_dashboard(app, "/plan");
     crate::tray::open_native_dashboard(app);
-    let _ = app.emit_to("dashboard", "dashboard-navigate", "/plan");
     tracing::info!(%today, "plan auto-open: opened dashboard on the Plan view");
 }
 

--- a/ui/components/timeline/MeridianTimelineShell.tsx
+++ b/ui/components/timeline/MeridianTimelineShell.tsx
@@ -10,7 +10,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { load, subscribe } from '@/lib/bridge'
+import { invoke, load, subscribe } from '@/lib/bridge'
 import type { RuntimeSettings } from '@/lib/settings'
 import { applyTheme } from '@/lib/theme'
 import HealthBanner from '@/components/HealthBanner'
@@ -187,7 +187,11 @@ export default function MeridianTimelineShell() {
         <SettingsModal onClose={() => setActiveModal(null)} initialSection={settingsSection} />
       )}
       {activeModal === 'report' && <ReportModal onClose={() => setActiveModal(null)} />}
-      {activeModal === 'plan' && <PlanModal onClose={() => setActiveModal(null)} />}
+      {/* Closing the planner restarts the daemon's plan-nudge hold-back clock
+          (fire-and-forget; only meaningful on a day the auto-open fired — the
+          command's marker guard handles that), so the "Plan your day" reminder
+          lands an hour after the DISMISSAL, not the auto-open. */}
+      {activeModal === 'plan' && <PlanModal onClose={() => { invoke('plan_dismissed').catch(() => {}); setActiveModal(null) }} />}
       {activeModal === 'tasks' && (
         <TasksModal onClose={() => setActiveModal(null)} onOpenTask={(key, title) => setOpenTask({ key, title })} />
       )}

--- a/ui/components/timeline/MeridianTimelineShell.tsx
+++ b/ui/components/timeline/MeridianTimelineShell.tsx
@@ -114,6 +114,15 @@ export default function MeridianTimelineShell() {
     setSelectedCardKey(cardKey)
   }
 
+  // Closing the planner restarts the daemon's plan-nudge hold-back clock
+  // (fire-and-forget; only meaningful on a day the auto-open fired — the
+  // command's marker guard handles that), so the "Plan your day" reminder
+  // lands an hour after the DISMISSAL, not the auto-open.
+  function closePlan() {
+    invoke('plan_dismissed').catch(() => {})
+    setActiveModal(null)
+  }
+
   // Opens the same swipeable Review dialog the pill/nav use, scoped to just
   // one ticket, instead of the right-side Hour-detail panel. Two callers:
   // a still-drafted card clicked directly on the timeline (TimelineColumn —
@@ -187,11 +196,7 @@ export default function MeridianTimelineShell() {
         <SettingsModal onClose={() => setActiveModal(null)} initialSection={settingsSection} />
       )}
       {activeModal === 'report' && <ReportModal onClose={() => setActiveModal(null)} />}
-      {/* Closing the planner restarts the daemon's plan-nudge hold-back clock
-          (fire-and-forget; only meaningful on a day the auto-open fired — the
-          command's marker guard handles that), so the "Plan your day" reminder
-          lands an hour after the DISMISSAL, not the auto-open. */}
-      {activeModal === 'plan' && <PlanModal onClose={() => { invoke('plan_dismissed').catch(() => {}); setActiveModal(null) }} />}
+      {activeModal === 'plan' && <PlanModal onClose={closePlan} />}
       {activeModal === 'tasks' && (
         <TasksModal onClose={() => setActiveModal(null)} onOpenTask={(key, title) => setOpenTask({ key, title })} />
       )}

--- a/ui/components/timeline/MeridianTimelineShell.tsx
+++ b/ui/components/timeline/MeridianTimelineShell.tsx
@@ -10,7 +10,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { load } from '@/lib/bridge'
+import { load, subscribe } from '@/lib/bridge'
 import type { RuntimeSettings } from '@/lib/settings'
 import { applyTheme } from '@/lib/theme'
 import HealthBanner from '@/components/HealthBanner'
@@ -71,6 +71,25 @@ export default function MeridianTimelineShell() {
     const openTasks = () => setActiveModal('tasks')
     window.addEventListener('meridian:open-tasks', openTasks)
     return () => window.removeEventListener('meridian:open-tasks', openTasks)
+  }, [])
+
+  // Tray-side openers (the daily plan auto-open, notification click-throughs)
+  // steer this window to a specific view. subscribe()'s prime is the pull half
+  // (`take_pending_deep_link` — a fresh window misses any event emitted before
+  // its listener exists, so the tray parks the target in managed state), and
+  // its listener is the push half (`dashboard-navigate`, for a window that is
+  // already open and won't remount). Targets are the former route paths the
+  // notification producers still use as `deep_link`s.
+  useEffect(() => {
+    const navigate = (target: string | null) => {
+      if (target === '/plan') {
+        setActiveModal('plan')
+      } else if (target === '/worklogs') {
+        setReviewFocusKey(null)
+        setActiveModal('review')
+      }
+    }
+    return subscribe<string | null>('/deep-link', 'take_pending_deep_link', 'dashboard-navigate', navigate)
   }, [])
 
   // Changing day resets the selected hour (its detail no longer applies).

--- a/ui/components/timeline/settings/NotificationsSection.tsx
+++ b/ui/components/timeline/settings/NotificationsSection.tsx
@@ -34,6 +34,12 @@ export function NotificationsSection({ settings, patch, save }: {
         <FieldRow label="Notifications" description="Master switch for desktop toasts and in-app banners. Off silences everything below.">
           <Switch checked={settings.notifications_enabled} onCheckedChange={v => patch({ notifications_enabled: v })} />
         </FieldRow>
+        {/* A window behaviour, not a toast — deliberately outside the
+            notifications_enabled gate so silencing toasts doesn't also kill
+            the morning planner. */}
+        <FieldRow label="Open planner each day" description="Once a day, open the dashboard on the Plan view when you start using your machine.">
+          <Switch checked={settings.auto_open_plan} onCheckedChange={v => patch({ auto_open_plan: v })} />
+        </FieldRow>
         {settings.notifications_enabled && (
           <>
             <FieldRow label="Plan your day" description="Morning reminder to confirm today's working set on the Plan page.">
@@ -61,6 +67,7 @@ export function NotificationsSection({ settings, patch, save }: {
           status={status}
           onClick={() => save({
             notifications_enabled: settings.notifications_enabled,
+            auto_open_plan: settings.auto_open_plan,
             notify_plan_nudge: settings.notify_plan_nudge,
             notify_worklog_ready: settings.notify_worklog_ready,
             notify_system_fault: settings.notify_system_fault,

--- a/ui/components/timeline/settings/NotificationsSection.tsx
+++ b/ui/components/timeline/settings/NotificationsSection.tsx
@@ -42,7 +42,7 @@ export function NotificationsSection({ settings, patch, save }: {
         </FieldRow>
         {settings.notifications_enabled && (
           <>
-            <FieldRow label="Plan your day reminder" description="Reminder to confirm today's plan - waits an hour after the planner auto-opens, so it only fires if you dismissed it without planning.">
+            <FieldRow label="Plan your day reminder" description="If you close the planner without confirming a plan, this reminds you an hour later.">
               <Switch checked={settings.notify_plan_nudge} onCheckedChange={v => patch({ notify_plan_nudge: v })} />
             </FieldRow>
             <FieldRow label="Worklog drafts ready" description="When the daily worklog drafts are ready to review and approve.">

--- a/ui/components/timeline/settings/NotificationsSection.tsx
+++ b/ui/components/timeline/settings/NotificationsSection.tsx
@@ -42,7 +42,7 @@ export function NotificationsSection({ settings, patch, save }: {
         </FieldRow>
         {settings.notifications_enabled && (
           <>
-            <FieldRow label="Plan your day" description="Morning reminder to confirm today's working set on the Plan page.">
+            <FieldRow label="Plan your day reminder" description="Reminder to confirm today's plan - waits an hour after the planner auto-opens, so it only fires if you dismissed it without planning.">
               <Switch checked={settings.notify_plan_nudge} onCheckedChange={v => patch({ notify_plan_nudge: v })} />
             </FieldRow>
             <FieldRow label="Worklog drafts ready" description="When the daily worklog drafts are ready to review and approve.">

--- a/ui/lib/settings.ts
+++ b/ui/lib/settings.ts
@@ -34,6 +34,10 @@ export interface RuntimeSettings {
   // user's preferences decide whether it surfaces.
   notifications_enabled: boolean
   notify_plan_nudge: boolean
+  // Daily planner auto-open — the tray opens the dashboard on the Plan modal
+  // once per local day. A window behaviour, not a toast, so NOT gated by
+  // notifications_enabled.
+  auto_open_plan: boolean
   notify_worklog_ready: boolean
   notify_system_fault: boolean
   quiet_hours_enabled: boolean
@@ -65,6 +69,7 @@ export const SETTINGS_DEFAULTS: RuntimeSettings = {
   jira_update_enabled: true,
   notifications_enabled: true,
   notify_plan_nudge: true,
+  auto_open_plan: true,
   notify_worklog_ready: true,
   notify_system_fault: true,
   quiet_hours_enabled: false,


### PR DESCRIPTION
## What

Every day, at the user's first activity - login, or the first poll tick after a new day starts (the tray usually wakes from sleep already running, so the 30s poll tick is the trigger, not a launch hook) - the tray opens the dashboard window on the **Plan modal** so the day starts with a plan.

## How

- **`poll/plan_auto_open.rs`** - the once-per-day check, gated cheapest-first:
  1. `~/.meridian/plan_auto_opened` date marker already holds today - done (one file stat on the common path)
  2. `auto_open_plan` setting off - skip
  3. not onboarded - never open over the first-run wizard
  4. today's plan already confirmed/skipped in `daily_plan_meta` (e.g. via the notification nudge) - settle the day **without** opening
  
  The marker is written *before* the window opens, so a `KeepAlive` crash-relaunch loop can never re-open repeatedly. No hour gate by design (product call: first activity of the day, any time).
- **`deep_link.rs` + `take_pending_deep_link`** - pull-model handoff: a freshly created dashboard webview misses any event emitted before its listener exists, so the tray parks the target (`/plan`) in managed state and `MeridianTimelineShell` pulls it on mount; a `dashboard-navigate` emit covers the already-open window (which won't remount). Double delivery is idempotent.
- **Notification click-through fix (pre-existing bug)** - `record_notification_response` now hands the row's `deep_link` through the same mechanism, so tapping a "Plan your day" toast lands on the Plan view instead of the default timeline.
- **Settings** - `auto_open_plan` (default on) in `RuntimeSettings` + `ui/lib/settings.ts`, with an "Open planner each day" toggle in Settings -> Notifications, deliberately outside the `notifications_enabled` gate (window behaviour, not a toast).
- **`meridian_core::plan::plan_handled`** - public `daily_plan_meta` read backing gate 4.

## Testing

- `cargo fmt` + `cargo clippy --workspace -- -D warnings` clean
- All Rust tests pass (daemon, meridian-core, tray), incl. new ones: `plan_handled` (no table / unconfirmed / confirmed / skipped) and the marker date logic (stale date, whitespace, fs round-trip)
- Next.js static build + all 175 UI tests pass
- Local demo: delete `~/.meridian/plan_auto_opened` (or write yesterday's date while the tray runs) - fires within one 30s tick; with today's plan already confirmed, the day settles silently and only the marker is written

## Risks / notes

- The open takes focus (dashboard opens maximized) - once per day by design; if too aggressive, a follow-up can skip `set_focus` on the mid-day boundary path.
- An unattended overnight wake (Power Nap) can fire under the lock screen - the window simply greets the user at unlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)