### PR TITLE
feat(tray): force-install updates below a manifest-declared minimum version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -474,6 +474,17 @@ git tag "runtime-v${VER}"         <commit> && git push origin "runtime-v${VER}" 
 - **Two channels, two audiences.** A fix that must reach everyone has to land on **both** `pre-main` and `main` (or both tags) — one channel never feeds the other.
 - **It is not the app binary.** Updating the `.app` alone ships nothing under `services/`; only a runtime republish does.
 
+### Make a DMG release mandatory (force-install on old versions)
+
+DMG auto-updates are consent-based (in-app banner + click) with one exception: when the update manifest declares a **minimum supported version** and the running app is below it, the app installs the update and relaunches automatically. Use this as a kill-switch for releases old versions must not keep running against (broken update path, data-corrupting bug) — not for routine releases.
+
+1. Commit `tray/minimum-version` containing the floor as plain `X.Y.Z` (usually the new release's own version, forcing everyone older) **before cutting the release**. File absent or empty = consent-based, the default; a malformed value fails the release loudly (`scripts/package-updater.sh`).
+2. The release ships it as a `Minimum-Version: X.Y.Z` line inside `latest.json`'s `notes` — the notes body is the transport because `tauri-plugin-updater` drops unknown manifest fields. The staging channel inherits it via `mirror-staging-release.sh`'s verbatim `latest.json` copy.
+3. Installed apps below the floor force-update via `update::enforce_minimum_version` (`tray/src-tauri/src/update.rs`) — checked 30 s after launch and every 6 h thereafter, so long-running trays catch it without a relaunch. A failed forced install falls back to the consent banner and retries next cycle.
+4. Empty or remove `tray/minimum-version` afterwards if later releases should go back to consent-based — the floor ships with **every** release while the file has content.
+
+Only affects the DMG channel; npm/CLI installs still update via `meridian update`, and the MLX runtime has its own always-automatic upgrade (see the runtime task above).
+
 ---
 
 ## Coding-agent pipeline (`src/coding_agent_session_ingest/`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4474,6 +4474,7 @@ dependencies = [
  "reqwest 0.12.28",
  "screenpipe-a11y",
  "screenpipe-screen",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/scripts/package-updater.sh
+++ b/scripts/package-updater.sh
@@ -43,6 +43,24 @@ else
   echo "⚠ ${VERSIONED_DMG} not found — no stable-named DMG (tarball update still works)"
 fi
 
+# Optional mandatory-update floor. When tray/minimum-version contains a semver,
+# it ships as a `Minimum-Version: <v>` line inside the manifest notes — installed
+# apps running BELOW that version install this release automatically instead of
+# waiting for the banner click (tray/src-tauri/src/update.rs
+# enforce_minimum_version; the notes line is the transport because
+# tauri-plugin-updater drops unknown manifest fields). File absent or empty =
+# every update stays consent-based. A malformed value fails the release loudly:
+# a typo silently dropping the floor would defeat the point of setting it.
+MIN_FILE="tray/minimum-version"
+MINIMUM=""
+if [[ -f "${MIN_FILE}" ]]; then
+  MINIMUM="$(tr -d '[:space:]' < "${MIN_FILE}")"
+  if [[ -n "${MINIMUM}" && ! "${MINIMUM}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "✗ ${MIN_FILE} contains '${MINIMUM}' — not a plain semver (X.Y.Z)" >&2
+    exit 1
+  fi
+fi
+
 # latest.json from the real signature. The tarball URL points at the v<version>
 # release tag the @semantic-release/git commit + @semantic-release/github release
 # will create; the app reaches it via the /latest/ redirect baked in tauri.conf.json.
@@ -50,13 +68,16 @@ SIG_CONTENT="$(cat "${SIG}")"
 URL="https://github.com/${REPO}/releases/download/v${VERSION}/Meridian.app.tar.gz"
 PUB_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-python3 - "${MAC}/latest.json" "${VERSION}" "${URL}" "${SIG_CONTENT}" "${PUB_DATE}" <<'PY'
+python3 - "${MAC}/latest.json" "${VERSION}" "${URL}" "${SIG_CONTENT}" "${PUB_DATE}" "${MINIMUM}" <<'PY'
 import json, sys
-out, ver, url, sig, pub = sys.argv[1:6]
+out, ver, url, sig, pub, minimum = sys.argv[1:7]
+notes = f"Meridian v{ver}"
+if minimum:
+    notes += f"\nMinimum-Version: {minimum}"
 json.dump(
     {
         "version": ver,
-        "notes": f"Meridian v{ver}",
+        "notes": notes,
         "pub_date": pub,
         "platforms": {"darwin-aarch64": {"signature": sig, "url": url}},
     },
@@ -64,4 +85,8 @@ json.dump(
     indent=2,
 )
 PY
-echo "✓ ${MAC}/latest.json (v${VERSION} → ${URL})"
+if [[ -n "${MINIMUM}" ]]; then
+  echo "✓ ${MAC}/latest.json (v${VERSION} → ${URL}, minimum supported v${MINIMUM})"
+else
+  echo "✓ ${MAC}/latest.json (v${VERSION} → ${URL})"
+fi

--- a/scripts/package-updater.sh
+++ b/scripts/package-updater.sh
@@ -59,6 +59,20 @@ if [[ -f "${MIN_FILE}" ]]; then
     echo "✗ ${MIN_FILE} contains '${MINIMUM}' — not a plain semver (X.Y.Z)" >&2
     exit 1
   fi
+  # The floor must not exceed the release that carries it — a floor above every
+  # published version would make old apps force-install a build that is itself
+  # still below the minimum (self-terminating, but confusing). Always an
+  # operator error, so fail loudly. Cores only (X.Y.Z), so a prerelease
+  # release version (1.70.0-staging.1) may carry a 1.70.0 floor.
+  if [[ -n "${MINIMUM}" ]]; then
+    python3 - "${MINIMUM}" "${VERSION}" <<'PY' || exit 1
+import sys
+minimum, ver = sys.argv[1], sys.argv[2]
+core = lambda v: tuple(int(x) for x in v.split("-")[0].split("."))
+if core(minimum) > core(ver):
+    sys.exit(f"✗ tray/minimum-version {minimum} exceeds the release version {ver}")
+PY
+  fi
 fi
 
 # latest.json from the real signature. The tarball URL points at the v<version>

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -42,6 +42,9 @@ tauri-plugin-opener = "2"
 tauri-plugin-updater = { version = "2", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Minimum-supported-version comparison for mandatory updates (update.rs);
+# already in the tree via tauri, so a direct dep costs nothing.
+semver = "1"
 # `process` is needed by parents.rs (spawns `meridian ticket-parents`); without
 # it a standalone tray build (no otel → no daemon to unify the feature) fails.
 tokio = { version = "1", features = ["time", "rt-multi-thread", "process", "macros", "io-util", "net"] }

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -459,7 +459,11 @@ pub fn run() {
             // No silent auto-install on launch: the DMG update surfaces as an
             // in-app banner (sidebar + popover) that checks on open via the
             // `check_update` command, so the user sees + consents to the update
-            // rather than the app restarting itself underneath them.
+            // rather than the app restarting itself underneath them. The ONE
+            // exception is a release whose manifest declares a minimum
+            // supported version below the running one — that installs
+            // automatically (see update::enforce_minimum_version).
+            update::enforce_minimum_version(app.handle());
 
             Ok(())
         })

--- a/tray/src-tauri/src/update.rs
+++ b/tray/src-tauri/src/update.rs
@@ -23,11 +23,19 @@
 //!   `install_update` command); emits `update-progress` events for a progress bar.
 //! - [`check_for_updates`] → the tray menu's "Check for Updates…" (notification
 //!   fallback, reusing the same core).
+//! - [`enforce_minimum_version`] → spawned once at launch. The single exception
+//!   to the consent rule: when the manifest notes carry a `Minimum-Version:` line
+//!   and the running version is below it, the update installs + relaunches
+//!   automatically (a kill-switch for releases old versions must not keep
+//!   running — broken update paths, data-corrupting bugs).
 //!
 //! # Related
 //! - [`crate::sys::notify`] — the toast the tray-menu path surfaces through.
+//! - `scripts/package-updater.sh` — the producer of the `Minimum-Version:` notes
+//!   line (reads the optional `tray/minimum-version` file at release time).
 //! - Plan: Obsidian `Decisions/Public distribution + auto-update for the DMG`.
 
+use semver::Version;
 use serde::Serialize;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::{AppHandle, Emitter};
@@ -56,8 +64,15 @@ pub struct UpdateStatus {
     pub current_version: String,
     /// The newer version, when `state == "available"`.
     pub version: Option<String>,
-    /// Release notes (the manifest `notes`), when present.
+    /// Release notes (the manifest `notes` with the `Minimum-Version:` marker
+    /// line stripped — it's transport, not prose), when present.
     pub notes: Option<String>,
+    /// The manifest's minimum supported version, when it declared one.
+    pub minimum_version: Option<String>,
+    /// True when the running version is below `minimum_version` — the update
+    /// installs automatically ([`enforce_minimum_version`]) instead of waiting
+    /// for the banner click.
+    pub mandatory: bool,
     /// Human-readable error text, when `state == "error"`.
     pub error: Option<String>,
 }
@@ -71,6 +86,8 @@ impl UpdateStatus {
             current_version: current,
             version: None,
             notes: None,
+            minimum_version: None,
+            mandatory: false,
             error: None,
         }
     }
@@ -82,9 +99,48 @@ impl UpdateStatus {
             current_version: current,
             version: None,
             notes: None,
+            minimum_version: None,
+            mandatory: false,
             error: Some(msg),
         }
     }
+}
+
+/// Split the manifest `notes` into the minimum supported version (from a
+/// `Minimum-Version: <semver>` line, matched case-insensitively) and the
+/// remaining human-readable notes (`None` when nothing else is left).
+///
+/// The notes body is the transport because `tauri-plugin-updater` drops unknown
+/// manifest fields — a custom top-level `minimumVersion` key in `latest.json`
+/// would never reach the app. An unparsable version is treated as absent (and
+/// logged), never as mandatory: a malformed manifest must not force-restart
+/// every install in the field.
+fn split_minimum_version(notes: &str) -> (Option<Version>, Option<String>) {
+    let mut minimum = None;
+    let mut kept: Vec<&str> = Vec::new();
+    for line in notes.lines() {
+        let trimmed = line.trim();
+        let key = "minimum-version:";
+        // Checked slice: a multibyte char straddling the boundary must not panic.
+        let is_marker = trimmed
+            .get(..key.len())
+            .is_some_and(|p| p.eq_ignore_ascii_case(key));
+        if is_marker {
+            let value = trimmed[key.len()..].trim();
+            match Version::parse(value) {
+                Ok(v) => minimum = Some(v),
+                Err(e) => {
+                    tracing::warn!(value, error = %e, "update: unparsable Minimum-Version in manifest notes — ignoring");
+                }
+            }
+        } else {
+            kept.push(line);
+        }
+    }
+    let rest = kept.join("\n");
+    let rest = rest.trim();
+    let rest = (!rest.is_empty()).then(|| rest.to_string());
+    (minimum, rest)
 }
 
 /// True only for a packaged `.app` run. A source/dev run can't be swapped by the
@@ -114,12 +170,18 @@ pub async fn check_status(app: &AppHandle) -> UpdateStatus {
     };
     match updater.check().await {
         Ok(Some(u)) => {
-            tracing::info!(version = %u.version, "update: newer version available");
+            let (minimum, notes) = split_minimum_version(u.body.as_deref().unwrap_or(""));
+            let mandatory = minimum
+                .as_ref()
+                .is_some_and(|m| app.package_info().version < *m);
+            tracing::info!(version = %u.version, mandatory, "update: newer version available");
             UpdateStatus {
                 state: "available".to_string(),
                 current_version: current,
                 version: Some(u.version.clone()),
-                notes: u.body.clone(),
+                notes,
+                minimum_version: minimum.map(|m| m.to_string()),
+                mandatory,
                 error: None,
             }
         }
@@ -183,6 +245,45 @@ pub async fn download_and_apply(app: &AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Mandatory-update enforcement — the one path that installs without consent.
+/// Spawned once at launch; checks shortly after startup and then every 6 h
+/// (the tray runs for weeks between relaunches, so a launch-only check would
+/// never catch a mandatory release published mid-run). When the manifest marks
+/// the running version as below its minimum, it notifies and installs; on
+/// failure it just waits for the next cycle (the consent banner stays available
+/// as the fallback), and on success [`download_and_apply`] never returns.
+pub fn enforce_minimum_version(app: &AppHandle) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let mut delay = std::time::Duration::from_secs(30);
+        loop {
+            tokio::time::sleep(delay).await;
+            delay = std::time::Duration::from_secs(6 * 60 * 60);
+            let status = check_status(&app).await;
+            // `unsupported` (dev run) never flips to packaged mid-run, so the
+            // loop is pure idle there; keep it anyway — it costs one no-op
+            // check per cycle and avoids a second is_packaged() code path.
+            if status.state != "available" || !status.mandatory {
+                continue;
+            }
+            let v = status.version.clone().unwrap_or_default();
+            tracing::info!(
+                version = %v,
+                minimum = status.minimum_version.as_deref().unwrap_or(""),
+                "update: running version is below the minimum supported - forcing install"
+            );
+            crate::sys::notify(
+                &app,
+                "Updating Meridian",
+                &format!("This version is no longer supported - installing v{v}"),
+            );
+            if let Err(e) = download_and_apply(&app).await {
+                tracing::warn!(error = %e, "update: forced install failed - retrying next cycle");
+            }
+        }
+    });
+}
+
 /// Tray-menu entry ("Check for Updates…"). Notification-driven (the menu has no
 /// window for a banner), reusing the same core as the in-app surfaces. Always
 /// user-initiated, so it installs + relaunches on success and toasts every
@@ -224,4 +325,61 @@ pub fn check_for_updates(app: &AppHandle) {
         }
         CHECKING.store(false, Ordering::SeqCst);
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_marker_keeps_notes_verbatim() {
+        let (min, notes) = split_minimum_version("Meridian v1.70.0");
+        assert_eq!(min, None);
+        assert_eq!(notes.as_deref(), Some("Meridian v1.70.0"));
+    }
+
+    #[test]
+    fn marker_is_extracted_and_stripped() {
+        let (min, notes) = split_minimum_version("Meridian v1.70.0\nMinimum-Version: 1.68.0");
+        assert_eq!(min, Some(Version::new(1, 68, 0)));
+        assert_eq!(notes.as_deref(), Some("Meridian v1.70.0"));
+    }
+
+    #[test]
+    fn marker_matches_case_insensitively_and_tolerates_whitespace() {
+        let (min, notes) = split_minimum_version("  minimum-version:   1.2.3  \nnotes");
+        assert_eq!(min, Some(Version::new(1, 2, 3)));
+        assert_eq!(notes.as_deref(), Some("notes"));
+    }
+
+    #[test]
+    fn marker_only_notes_become_none() {
+        let (min, notes) = split_minimum_version("Minimum-Version: 2.0.0");
+        assert_eq!(min, Some(Version::new(2, 0, 0)));
+        assert_eq!(notes, None);
+    }
+
+    #[test]
+    fn unparsable_version_is_ignored_not_mandatory() {
+        let (min, notes) = split_minimum_version("Meridian v1.70.0\nMinimum-Version: not-semver");
+        assert_eq!(min, None);
+        assert_eq!(notes.as_deref(), Some("Meridian v1.70.0"));
+    }
+
+    #[test]
+    fn empty_notes_are_none() {
+        let (min, notes) = split_minimum_version("");
+        assert_eq!(min, None);
+        assert_eq!(notes, None);
+    }
+
+    /// The comparison `check_status` performs: strictly-below is mandatory,
+    /// equal or above is not.
+    #[test]
+    fn mandatory_is_strictly_below_minimum() {
+        let min = Version::new(1, 68, 0);
+        assert!(Version::new(1, 67, 9) < min);
+        assert!(Version::new(1, 68, 0) >= min);
+        assert!(Version::new(1, 69, 0) >= min);
+    }
 }


### PR DESCRIPTION
## What

Adds a **mandatory-update floor** to the DMG auto-update channel. Updates stay consent-based (banner + click) with one new exception: when the update manifest declares a minimum supported version and the running app is below it, the update downloads, installs, and relaunches automatically. This is the kill-switch for releases old versions must not keep running against (broken update paths, data-corrupting bugs).

## How

**Producer — `scripts/package-updater.sh`**
- Reads the optional `tray/minimum-version` file (plain `X.Y.Z`) at release time and ships it as a `Minimum-Version: X.Y.Z` line inside `latest.json`'s `notes`. The notes body is the transport because `tauri-plugin-updater` drops unknown manifest fields — a custom top-level key would never reach the app.
- File absent or empty (the default — the file is not committed) = every update stays consent-based. A malformed value fails the release loudly rather than silently dropping the floor.
- The staging channel inherits the marker automatically via `mirror-staging-release.sh`'s verbatim `latest.json` copy.

**Consumer — `tray/src-tauri/src/update.rs`**
- `split_minimum_version()` parses the marker (case-insensitive, checked UTF-8 slicing, unparsable value → ignored + warned, never mandatory).
- `UpdateStatus` gains `minimumVersion` + `mandatory`; the marker line is stripped from the `notes` the banners display.
- New `enforce_minimum_version()` task, spawned at launch (`lib.rs`): checks 30s after startup and then every 6h (the tray runs for weeks between relaunches, so launch-only would never catch a mandatory release published mid-run). When mandatory, it notifies ("This version is no longer supported - installing vX") and runs the existing `download_and_apply`.
- A failed forced install just waits for the next cycle — the consent banner remains as fallback. The existing `INSTALLING` single-flight guard covers races between the forced path and a banner click.

## Rollout

To make a release mandatory, commit `tray/minimum-version` containing the floor (typically the new release's own version) before cutting the release; remove or empty it afterwards if subsequent releases should go back to consent-based.

## Testing

- 7 new unit tests for marker parsing + the strictly-below comparison (`cargo test update::tests` — all pass; full tray suite 64/64).
- Release script exercised against a faked bundle layout: no file → notes unchanged; `1.68.0` → `"Meridian v1.70.0\nMinimum-Version: 1.68.0"`; garbage → exit 1.
- `cargo fmt` + `cargo clippy -- -D warnings` clean; full pre-push suite passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)