### PR TITLE
fix(worklog): stop retrying posts that hit Jira's per-issue worklog cap

### DIFF
--- a/src/pm_worklog/post.rs
+++ b/src/pm_worklog/post.rs
@@ -20,7 +20,10 @@
 // see meridian_core::worklogs::rematch_worklog), so idempotency is scoped
 // per-row (`id`), not per (task, window) — two distinct rows may legitimately
 // share a window and both need their own post. A post failure leaves the row
-// `approved` with `last_post_error` recorded, and the next sweep retries.
+// `approved` with `last_post_error` recorded, and the next sweep retries —
+// UNLESS `is_permanent_provider_error` recognises it as unrecoverable (e.g.
+// Jira's per-issue worklog cap), in which case it's failed terminally instead
+// so it doesn't retry-spam the same doomed post forever.
 
 use anyhow::Result;
 use sqlx::SqlitePool;
@@ -68,6 +71,18 @@ pub async fn post_approved(
         match post_one(pool, config, cfg, &w).await {
             Ok(true) => summary.posted += 1,
             Ok(false) => {} // ineligible/skipped — already recorded
+            Err(e) if is_permanent_provider_error(&e) => {
+                // A retry can never succeed (e.g. Jira's hard per-issue
+                // worklog cap) — leaving it `approved` would spam this same
+                // failure every sweep (60s) forever. Fail it terminally, same
+                // as an empty comment or below-minimum duration.
+                summary.failed += 1;
+                tracing::warn!(
+                    pm_worklog_id = w.id, task = %w.task_key, provider = %w.provider, error = %e,
+                    "approved worklog post failed permanently — will not retry"
+                );
+                db::fail_worklog(pool, w.id, &format!("{e:#}")).await?;
+            }
             Err(e) => {
                 summary.failed += 1;
                 tracing::warn!(
@@ -79,6 +94,19 @@ pub async fn post_approved(
         }
     }
     Ok(summary)
+}
+
+/// True for provider errors a retry can never fix — the sweep should fail the
+/// row terminally instead of leaving it `approved` to be retried (and re-fail
+/// identically) every sweep forever.
+///
+/// - `WORKLOGS_PER_ISSUE_LIMIT_EXCEEDED`: Jira hard-caps a single issue at
+///   10,000 worklogs (HTTP 413). Once an issue hits it, POSTing another
+///   worklog to that issue will fail the same way indefinitely — the only
+///   fix is deleting old worklogs on that issue in Jira itself, which this
+///   daemon has no way to do or wait for.
+fn is_permanent_provider_error(e: &anyhow::Error) -> bool {
+    format!("{e:#}").contains("WORKLOGS_PER_ISSUE_LIMIT_EXCEEDED")
 }
 
 /// Format a stored UTC ISO timestamp as local wall-clock — so the worklog_post

--- a/ui/components/timeline/TimelineCard.tsx
+++ b/ui/components/timeline/TimelineCard.tsx
@@ -18,7 +18,7 @@ import { ProviderIcon } from '@/components/ProviderIcon'
 import type { WorklogItem } from '@/lib/api-types'
 import { openExternal } from '@/lib/bridge'
 import { ReviewRejectPicker } from './ReviewRejectPicker'
-import { isPending, stateColor, stateLabel, visualState, type RejectCorrection } from './types'
+import { failureReason, isPending, stateColor, stateLabel, visualState, type RejectCorrection } from './types'
 import type { WorklogActions } from './useTimelineData'
 
 // Compact-card summary preview — just the first few words, not the full comment.
@@ -161,6 +161,16 @@ function DetailBody({ item, actions, onEdit }: { item: WorklogItem; actions?: Wo
             {item.is_proposed ? 'Why a new ticket' : 'Why this task'}
           </p>
           <p className="mt-body-sm" style={{ color: 'var(--t-muted)' }}>{item.reasoning}</p>
+        </div>
+      )}
+
+      {item.state === 'failed' && item.last_post_error && (
+        <div className="rounded-md p-2.5" style={{
+          background: 'color-mix(in srgb, var(--color-state-pending) 8%, transparent)',
+          border: '1px solid color-mix(in srgb, var(--color-state-pending) 24%, transparent)',
+        }}>
+          <p className="mt-label mb-1" style={{ color: 'var(--color-state-pending)' }}>Why this failed</p>
+          <p className="mt-body-sm" style={{ color: 'var(--t-muted)' }}>{failureReason(item.last_post_error)}</p>
         </div>
       )}
 

--- a/ui/components/timeline/types.ts
+++ b/ui/components/timeline/types.ts
@@ -55,6 +55,20 @@ export function stateLabel(w: WorklogItem): string {
   return STATE_LABEL[w.state] ?? w.state
 }
 
+/** Human-readable reason a `failed` worklog didn't post, for known
+ *  unrecoverable provider errors — the raw message (`last_post_error`) is
+ *  API-response text (e.g. Jira's `{"errorMessages":["WORKLOGS_PER_ISSUE_LIMIT_EXCEEDED: 10000"]}`),
+ *  not something to show a user as-is. Falls back to the raw message for
+ *  anything not specifically recognized, so nothing is ever hidden — just
+ *  clarified where possible. Always points at the fix (re-match via Edit)
+ *  since that's the one recovery path every `failed` row has. */
+export function failureReason(error: string): string {
+  if (error.includes('WORKLOGS_PER_ISSUE_LIMIT_EXCEEDED')) {
+    return "This ticket has hit Jira's 10,000-worklog limit and can never accept another entry. Click Edit to re-match this worklog to a different ticket, then approve it again."
+  }
+  return error
+}
+
 /** Kind label shown next to the ticket key — the ticket's actual issue type
  *  ("Bug" / "Task" / "Story"), prefixed "New " for a live proposal. Never
  *  "Work log" (that's the card's own generic content, not the ticket's type):


### PR DESCRIPTION
## Summary
- Jira's `WORKLOGS_PER_ISSUE_LIMIT_EXCEEDED` (per-issue 10,000-worklog hard cap) can never succeed on retry, so those posts were spamming the same failure every sweep (60s) forever
- Detect this permanent provider error and fail the row terminally instead of leaving it `approved` for endless retry
- Surface a clear "Why this failed" explanation + fix path (re-match via Edit) in the timeline detail view

## Test plan
- [x] `cargo fmt` / `cargo clippy` / `cargo test` (pre-commit + pre-push hooks passed)
- [x] UI build + UI tests (pre-push hooks passed)
- [ ] Manual verification on staging once merged: trigger a Jira worklog post against an issue at the cap and confirm the row fails terminally with the new explanation shown in the timeline