### PR TITLE
fix(worklog): fall back to Task when a project has no Bug issue type

### DIFF
--- a/src/intelligence/providers/azure_devops/db.rs
+++ b/src/intelligence/providers/azure_devops/db.rs
@@ -9,6 +9,10 @@
 use anyhow::{Context, Result};
 use sqlx::SqlitePool;
 
+/// Delete `pm_tasks` rows no longer returned by the active-task fetch (closed,
+/// reassigned, etc.) — EXCEPT a task_key that has worklog history
+/// (`pm_worklogs`), which is kept forever so a completed work item's title
+/// never disappears from the timeline once it's closed.
 pub(super) async fn prune(pool: &SqlitePool, kept_keys: &[String]) -> Result<()> {
     if kept_keys.is_empty() {
         sqlx::query(
@@ -18,10 +22,13 @@ pub(super) async fn prune(pool: &SqlitePool, kept_keys: &[String]) -> Result<()>
         .execute(pool)
         .await
         .context("pruning all azure_devops pm_task_embeddings")?;
-        sqlx::query("DELETE FROM pm_tasks WHERE provider = 'azure_devops'")
-            .execute(pool)
-            .await
-            .context("pruning all azure_devops pm_tasks")?;
+        sqlx::query(
+            "DELETE FROM pm_tasks WHERE provider = 'azure_devops' \
+             AND task_key NOT IN (SELECT DISTINCT task_key FROM pm_worklogs)",
+        )
+        .execute(pool)
+        .await
+        .context("pruning all azure_devops pm_tasks")?;
         return Ok(());
     }
 
@@ -42,7 +49,8 @@ pub(super) async fn prune(pool: &SqlitePool, kept_keys: &[String]) -> Result<()>
 
     let sql_tasks = format!(
         "DELETE FROM pm_tasks \
-         WHERE provider = 'azure_devops' AND task_key NOT IN ({placeholders})"
+         WHERE provider = 'azure_devops' AND task_key NOT IN ({placeholders}) \
+         AND task_key NOT IN (SELECT DISTINCT task_key FROM pm_worklogs)"
     );
     let mut q2 = sqlx::query(&sql_tasks);
     for k in kept_keys {

--- a/src/intelligence/providers/github/mod.rs
+++ b/src/intelligence/providers/github/mod.rs
@@ -103,6 +103,10 @@ async fn upsert(pool: &SqlitePool, tasks: &[(GhTask, serde_json::Value)]) -> Res
 // Prune (scoped to provider = 'github')
 // ---------------------------------------------------------------------------
 
+/// Delete `pm_tasks` rows no longer returned by the active-task fetch (closed,
+/// reassigned, etc.) — EXCEPT a task_key that has worklog history
+/// (`pm_worklogs`), which is kept forever so a completed ticket's title never
+/// disappears from the timeline once it's closed.
 async fn prune(pool: &SqlitePool, fetched_keys: &[String]) -> Result<usize> {
     let placeholders = fetched_keys
         .iter()
@@ -123,7 +127,8 @@ async fn prune(pool: &SqlitePool, fetched_keys: &[String]) -> Result<usize> {
         .context("pruning github pm_task_embeddings")?;
 
     let task_sql = format!(
-        "DELETE FROM pm_tasks WHERE provider = 'github' AND task_key NOT IN ({placeholders})"
+        "DELETE FROM pm_tasks WHERE provider = 'github' AND task_key NOT IN ({placeholders}) \
+         AND task_key NOT IN (SELECT DISTINCT task_key FROM pm_worklogs)"
     );
     let mut q = sqlx::query(&task_sql);
     for key in fetched_keys {
@@ -240,9 +245,12 @@ pub async fn refresh_if_stale(
             Ok(p) => tracing::info!(pruned_count = p, "pruned stale github tasks"),
             Err(e) => tracing::warn!(error = %e, "github prune failed"),
         }
-    } else if let Err(e) = sqlx::query("DELETE FROM pm_tasks WHERE provider = 'github'")
-        .execute(pool)
-        .await
+    } else if let Err(e) = sqlx::query(
+        "DELETE FROM pm_tasks WHERE provider = 'github' \
+         AND task_key NOT IN (SELECT DISTINCT task_key FROM pm_worklogs)",
+    )
+    .execute(pool)
+    .await
     {
         tracing::warn!(error = %e, "github full-clear failed");
     }

--- a/src/intelligence/providers/jira/fetch.rs
+++ b/src/intelligence/providers/jira/fetch.rs
@@ -79,6 +79,49 @@ pub(super) async fn fetch(
     ctx: &JiraReqCtx,
     start_date_field: Option<&str>,
 ) -> Result<Vec<(JiraIssue, serde_json::Value)>> {
+    search(
+        ctx,
+        start_date_field,
+        "assignee = currentUser() AND statusCategory != Done AND type IN (Task, Feature) ORDER BY updated DESC",
+    )
+    .await
+}
+
+/// Fetch specific issues by key regardless of assignee/status/type — used to
+/// backfill a `pm_tasks` row for a ticket that has worklog history but was
+/// never (or is no longer) covered by the active-task scope of [`fetch`] (e.g.
+/// it's Done, or assigned to someone else). Without this, such a ticket's
+/// title can never appear on the timeline once its `pm_tasks` row is missing,
+/// since [`fetch`]'s JQL will never surface it again.
+pub(super) async fn fetch_by_keys(
+    ctx: &JiraReqCtx,
+    start_date_field: Option<&str>,
+    keys: &[String],
+) -> Result<Vec<(JiraIssue, serde_json::Value)>> {
+    if keys.is_empty() {
+        return Ok(Vec::new());
+    }
+    let jql = key_in_jql(keys);
+    search(ctx, start_date_field, &jql).await
+}
+
+/// Builds a `key IN ("A-1","A-2")` JQL clause. Strips embedded quotes from
+/// each key defensively — a Jira key is always `[A-Z]+-[0-9]+`, so this never
+/// fires in practice, but it keeps a malformed key from breaking the query.
+fn key_in_jql(keys: &[String]) -> String {
+    let list = keys
+        .iter()
+        .map(|k| format!("\"{}\"", k.replace('"', "")))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("key IN ({list})")
+}
+
+async fn search(
+    ctx: &JiraReqCtx,
+    start_date_field: Option<&str>,
+    jql: &str,
+) -> Result<Vec<(JiraIssue, serde_json::Value)>> {
     let client = reqwest::Client::new();
     let url = ctx.api_url("/rest/api/3/search/jql");
 
@@ -104,7 +147,7 @@ pub(super) async fn fetch(
     }
 
     let body = serde_json::json!({
-        "jql": "assignee = currentUser() AND statusCategory != Done AND type IN (Task, Feature) ORDER BY updated DESC",
+        "jql": jql,
         "maxResults": MAX_RESULTS,
         "fields": fields,
     });
@@ -142,4 +185,27 @@ pub(super) async fn fetch(
     let keys: Vec<&str> = data.issues.iter().map(|i| i.key.as_str()).collect();
     tracing::debug!(count = issue_count, ?keys, "parsed Jira response");
     Ok(data.issues.into_iter().zip(raw_issues).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_in_jql_quotes_and_joins_keys() {
+        let keys = vec!["KAN-64".to_string(), "KAN-67".to_string()];
+        assert_eq!(key_in_jql(&keys), r#"key IN ("KAN-64","KAN-67")"#);
+    }
+
+    #[test]
+    fn key_in_jql_single_key() {
+        let keys = vec!["KAN-1".to_string()];
+        assert_eq!(key_in_jql(&keys), r#"key IN ("KAN-1")"#);
+    }
+
+    #[test]
+    fn key_in_jql_strips_embedded_quotes() {
+        let keys = vec!["KAN\"-1".to_string()];
+        assert_eq!(key_in_jql(&keys), r#"key IN ("KAN-1")"#);
+    }
 }

--- a/src/intelligence/providers/jira/mod.rs
+++ b/src/intelligence/providers/jira/mod.rs
@@ -13,7 +13,7 @@ mod fetch;
 #[cfg(test)]
 mod tests;
 
-use fetch::{discover_start_date_field, fetch, MAX_RESULTS};
+use fetch::{discover_start_date_field, fetch, fetch_by_keys, MAX_RESULTS};
 
 // ---------------------------------------------------------------------------
 // Jira REST response shapes
@@ -344,11 +344,70 @@ async fn prune(pool: &SqlitePool, fetched_keys: &[String]) -> Result<usize> {
 }
 
 // ---------------------------------------------------------------------------
+// Backfill (worklogged tasks the active-task scope will never surface again)
+// ---------------------------------------------------------------------------
+
+/// Batch size for `fetch_by_keys` JQL calls — keeps the request well under
+/// Jira's JQL length limits and `MAX_RESULTS` per page.
+const BACKFILL_BATCH_SIZE: usize = 50;
+
+/// Fetch and upsert a `pm_tasks` row for any Jira task_key that has worklog
+/// history but is missing from `pm_tasks` — a ticket that's Done, reassigned,
+/// or otherwise fell outside [`fetch`]'s active-task JQL and so was never (or
+/// no longer) covered by the regular sync. Without this, such a ticket's
+/// title can never appear on the timeline: `fetch`'s JQL will never surface
+/// it again, no matter how many times the regular sync runs.
+///
+/// Cheap when there's nothing to do — the DB check runs unconditionally
+/// (every call to [`refresh_if_stale`]) but only reaches the network when it
+/// actually finds a gap, which is rare once the backlog is caught up.
+async fn backfill_worklogged(pool: &SqlitePool, jira: &JiraConfig) -> Result<usize> {
+    let missing: Vec<(String,)> = sqlx::query_as(
+        "SELECT DISTINCT task_key FROM pm_worklogs
+         WHERE provider = 'jira' AND task_key NOT IN
+           (SELECT task_key FROM pm_tasks WHERE provider = 'jira')",
+    )
+    .fetch_all(pool)
+    .await
+    .context("finding jira worklogs missing a pm_tasks row")?;
+    if missing.is_empty() {
+        return Ok(0);
+    }
+    let keys: Vec<String> = missing.into_iter().map(|(k,)| k).collect();
+
+    let ctx = crate::intelligence::oauth::jira::resolve(jira)
+        .await
+        .context("resolving Jira auth for worklog backfill")?;
+    let start_date_field = discover_start_date_field(&ctx).await;
+
+    let mut backfilled = 0usize;
+    for batch in keys.chunks(BACKFILL_BATCH_SIZE) {
+        let issues = fetch_by_keys(&ctx, start_date_field.as_deref(), batch)
+            .await
+            .context("backfilling jira worklogged tasks")?;
+        backfilled += issues.len();
+        upsert(pool, &issues, jira, &ctx, start_date_field.as_deref()).await?;
+    }
+    if backfilled > 0 {
+        tracing::info!(
+            requested = keys.len(),
+            backfilled,
+            "backfilled pm_tasks rows for worklogged jira tickets"
+        );
+    }
+    Ok(backfilled)
+}
+
+// ---------------------------------------------------------------------------
 // Public entry point
 // ---------------------------------------------------------------------------
 
 #[tracing::instrument(skip(pool, jira))]
 pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Option<Vec<String>>> {
+    if let Err(e) = backfill_worklogged(pool, jira).await {
+        tracing::warn!(error = %e, "jira worklog backfill failed — will retry next sync");
+    }
+
     let threshold = format!("-{SYNC_INTERVAL_MINS} minutes");
     let (is_fresh,): (i64,) = sqlx::query_as(
         "SELECT EXISTS(

--- a/src/intelligence/providers/jira/mod.rs
+++ b/src/intelligence/providers/jira/mod.rs
@@ -307,6 +307,10 @@ async fn upsert(
 // Prune
 // ---------------------------------------------------------------------------
 
+/// Delete `pm_tasks` rows no longer returned by the active-task fetch (closed,
+/// reassigned, etc.) — EXCEPT a task_key that has worklog history
+/// (`pm_worklogs`), which is kept forever so a completed ticket's title never
+/// disappears from the timeline once it's Done.
 async fn prune(pool: &SqlitePool, fetched_keys: &[String]) -> Result<usize> {
     let placeholders = fetched_keys
         .iter()
@@ -328,7 +332,8 @@ async fn prune(pool: &SqlitePool, fetched_keys: &[String]) -> Result<usize> {
         .context("pruning pm_task_embeddings")?;
 
     let task_sql = format!(
-        "DELETE FROM pm_tasks WHERE provider = 'jira' AND task_key NOT IN ({placeholders})"
+        "DELETE FROM pm_tasks WHERE provider = 'jira' AND task_key NOT IN ({placeholders}) \
+         AND task_key NOT IN (SELECT DISTINCT task_key FROM pm_worklogs)"
     );
     let mut q = sqlx::query(&task_sql);
     for key in fetched_keys {

--- a/src/intelligence/providers/jira/tests.rs
+++ b/src/intelligence/providers/jira/tests.rs
@@ -124,6 +124,51 @@ async fn embedding_count(pool: &SqlitePool, task_key: &str) -> i64 {
 }
 
 // -----------------------------------------------------------------------
+// Test: the missing-keys query backfill_worklogged() runs finds exactly the
+// worklogged task_keys that have no pm_tasks row (Done/reassigned tickets
+// that fell out of the active-task JQL scope).
+// -----------------------------------------------------------------------
+
+/// Runs the same "find missing worklogged tasks" SQL that
+/// `backfill_worklogged()` executes.
+async fn find_missing_worklogged(pool: &SqlitePool) -> Vec<String> {
+    let rows: Vec<(String,)> = sqlx::query_as(
+        "SELECT DISTINCT task_key FROM pm_worklogs
+         WHERE provider = 'jira' AND task_key NOT IN
+           (SELECT task_key FROM pm_tasks WHERE provider = 'jira')",
+    )
+    .fetch_all(pool)
+    .await
+    .unwrap();
+    let mut keys: Vec<String> = rows.into_iter().map(|(k,)| k).collect();
+    keys.sort();
+    keys
+}
+
+#[tokio::test]
+async fn backfill_query_finds_worklogged_tasks_missing_from_pm_tasks() {
+    let pool = make_db().await;
+
+    // KAN-1 has a pm_tasks row already — not missing.
+    insert_jira_task(&pool, "KAN-1").await;
+    insert_worklog(&pool, "KAN-1").await;
+    // KAN-2 has worklog history but no pm_tasks row (e.g. Done, pruned/never synced).
+    insert_worklog(&pool, "KAN-2").await;
+    // KAN-3 is a linear worklog — must not be treated as a missing jira task.
+    sqlx::query(
+        "INSERT INTO pm_worklogs
+           (task_key, provider, day_utc, window_start, window_end, state, payload_json)
+         VALUES ('KAN-3', 'linear', '2026-07-14', '2026-07-14T10:00:00+00:00',
+                 '2026-07-14T11:00:00+00:00', 'posted', '{}')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(find_missing_worklogged(&pool).await, vec!["KAN-2"]);
+}
+
+// -----------------------------------------------------------------------
 // Test: stale task (not in fetched set) is deleted from pm_tasks
 // -----------------------------------------------------------------------
 

--- a/src/intelligence/providers/jira/tests.rs
+++ b/src/intelligence/providers/jira/tests.rs
@@ -77,7 +77,8 @@ async fn run_prune_sql(pool: &SqlitePool, fetched_keys: &[&str]) -> usize {
     q.execute(pool).await.unwrap();
 
     let task_sql = format!(
-        "DELETE FROM pm_tasks WHERE provider = 'jira' AND task_key NOT IN ({placeholders})"
+        "DELETE FROM pm_tasks WHERE provider = 'jira' AND task_key NOT IN ({placeholders}) \
+         AND task_key NOT IN (SELECT DISTINCT task_key FROM pm_worklogs)"
     );
     let mut q = sqlx::query(&task_sql);
     for key in fetched_keys {
@@ -85,6 +86,21 @@ async fn run_prune_sql(pool: &SqlitePool, fetched_keys: &[&str]) -> usize {
     }
     let result = q.execute(pool).await.unwrap();
     result.rows_affected() as usize
+}
+
+/// Inserts a minimal `pm_worklogs` row for `task_key` — enough to mark it as
+/// having worklog history for the prune exclusion.
+async fn insert_worklog(pool: &SqlitePool, task_key: &str) {
+    sqlx::query(
+        "INSERT INTO pm_worklogs
+           (task_key, day_utc, window_start, window_end, state, payload_json)
+         VALUES (?, '2026-07-14', '2026-07-14T10:00:00+00:00', '2026-07-14T11:00:00+00:00',
+                 'posted', '{}')",
+    )
+    .bind(task_key)
+    .execute(pool)
+    .await
+    .unwrap();
 }
 
 /// Helper: count rows in `pm_tasks` with a given `task_key`.
@@ -123,6 +139,40 @@ async fn prune_removes_stale_jira_task() {
     assert_eq!(deleted, 1, "prune must delete exactly the stale row");
     assert_eq!(task_count(&pool, "KAN-1").await, 1, "KAN-1 must survive");
     assert_eq!(task_count(&pool, "KAN-2").await, 0, "KAN-2 must be deleted");
+}
+
+// -----------------------------------------------------------------------
+// Test: a stale task with worklog history is kept (so its title never
+// disappears from the timeline once the ticket is Done/reassigned/closed)
+// -----------------------------------------------------------------------
+
+#[tokio::test]
+async fn prune_keeps_stale_task_with_worklog_history() {
+    let pool = make_db().await;
+
+    insert_jira_task(&pool, "KAN-100").await; // fresh — in fetched set
+    insert_jira_task(&pool, "KAN-101").await; // stale, no worklog — must be pruned
+    insert_jira_task(&pool, "KAN-102").await; // stale, HAS worklog history — must survive
+    insert_worklog(&pool, "KAN-102").await;
+
+    let deleted = run_prune_sql(&pool, &["KAN-100"]).await;
+
+    assert_eq!(deleted, 1, "only the stale task with no worklog is deleted");
+    assert_eq!(
+        task_count(&pool, "KAN-100").await,
+        1,
+        "KAN-100 must survive"
+    );
+    assert_eq!(
+        task_count(&pool, "KAN-101").await,
+        0,
+        "KAN-101 must be pruned"
+    );
+    assert_eq!(
+        task_count(&pool, "KAN-102").await,
+        1,
+        "KAN-102 must survive — it has worklog history"
+    );
 }
 
 // -----------------------------------------------------------------------

--- a/src/intelligence/providers/linear/mod.rs
+++ b/src/intelligence/providers/linear/mod.rs
@@ -366,6 +366,10 @@ async fn upsert(
 // Prune (identical shape to the Jira connector, scoped to provider = 'linear')
 // ---------------------------------------------------------------------------
 
+/// Delete `pm_tasks` rows no longer returned by the active-task fetch (closed,
+/// reassigned, etc.) — EXCEPT a task_key that has worklog history
+/// (`pm_worklogs`), which is kept forever so a completed ticket's title never
+/// disappears from the timeline once it's closed.
 async fn prune(pool: &SqlitePool, fetched_keys: &[String]) -> Result<usize> {
     let placeholders = fetched_keys
         .iter()
@@ -386,7 +390,8 @@ async fn prune(pool: &SqlitePool, fetched_keys: &[String]) -> Result<usize> {
         .context("pruning linear pm_task_embeddings")?;
 
     let task_sql = format!(
-        "DELETE FROM pm_tasks WHERE provider = 'linear' AND task_key NOT IN ({placeholders})"
+        "DELETE FROM pm_tasks WHERE provider = 'linear' AND task_key NOT IN ({placeholders}) \
+         AND task_key NOT IN (SELECT DISTINCT task_key FROM pm_worklogs)"
     );
     let mut q = sqlx::query(&task_sql);
     for key in fetched_keys {
@@ -446,10 +451,13 @@ pub async fn refresh_if_stale(
                         Err(e) => tracing::warn!(error = %e, "linear prune failed"),
                     }
                 } else {
-                    // No live tasks at all → delete every linear row.
-                    if let Err(e) = sqlx::query("DELETE FROM pm_tasks WHERE provider = 'linear'")
-                        .execute(pool)
-                        .await
+                    // No live tasks at all → delete every linear row without worklog history.
+                    if let Err(e) = sqlx::query(
+                        "DELETE FROM pm_tasks WHERE provider = 'linear' \
+                         AND task_key NOT IN (SELECT DISTINCT task_key FROM pm_worklogs)",
+                    )
+                    .execute(pool)
+                    .await
                     {
                         tracing::warn!(error = %e, "linear full-clear failed");
                     }

--- a/src/intelligence/providers/trello.rs
+++ b/src/intelligence/providers/trello.rs
@@ -215,6 +215,10 @@ async fn upsert(
 // Prune
 // ---------------------------------------------------------------------------
 
+/// Delete `pm_tasks` rows no longer returned by the active-task fetch (closed,
+/// reassigned, etc.) — EXCEPT a task_key that has worklog history
+/// (`pm_worklogs`), which is kept forever so a completed card's title never
+/// disappears from the timeline once it's closed.
 async fn prune(pool: &SqlitePool, fetched_keys: &[String]) -> Result<usize> {
     let placeholders = fetched_keys
         .iter()
@@ -235,7 +239,8 @@ async fn prune(pool: &SqlitePool, fetched_keys: &[String]) -> Result<usize> {
         .context("pruning trello pm_task_embeddings")?;
 
     let task_sql = format!(
-        "DELETE FROM pm_tasks WHERE provider = 'trello' AND task_key NOT IN ({placeholders})"
+        "DELETE FROM pm_tasks WHERE provider = 'trello' AND task_key NOT IN ({placeholders}) \
+         AND task_key NOT IN (SELECT DISTINCT task_key FROM pm_worklogs)"
     );
     let mut q = sqlx::query(&task_sql);
     for key in fetched_keys {
@@ -292,9 +297,12 @@ pub async fn refresh_if_stale(
                         Ok(p) => tracing::info!(pruned_count = p, "pruned stale trello tasks"),
                         Err(e) => tracing::warn!(error = %e, "trello prune failed"),
                     }
-                } else if let Err(e) = sqlx::query("DELETE FROM pm_tasks WHERE provider = 'trello'")
-                    .execute(pool)
-                    .await
+                } else if let Err(e) = sqlx::query(
+                    "DELETE FROM pm_tasks WHERE provider = 'trello' \
+                     AND task_key NOT IN (SELECT DISTINCT task_key FROM pm_worklogs)",
+                )
+                .execute(pool)
+                .await
                 {
                     tracing::warn!(error = %e, "trello full-clear failed");
                 }

--- a/src/intelligence/ticket_update/azure_devops.rs
+++ b/src/intelligence/ticket_update/azure_devops.rs
@@ -136,7 +136,10 @@ async fn patch_work_item(
     Ok(())
 }
 
-async fn my_unique_name(client: &reqwest::Client, cfg: &AzureDevOpsConfig) -> Result<String> {
+pub(crate) async fn my_unique_name(
+    client: &reqwest::Client,
+    cfg: &AzureDevOpsConfig,
+) -> Result<String> {
     let url = format!(
         "{}/_apis/connectionData?api-version=7.1",
         cfg.api_base.trim_end_matches('/')

--- a/src/intelligence/ticket_update/jira.rs
+++ b/src/intelligence/ticket_update/jira.rs
@@ -117,7 +117,7 @@ async fn put_issue(
 }
 
 /// Resolve the current user's accountId for "assign to me".
-async fn my_account_id(ctx: &JiraReqCtx, client: &reqwest::Client) -> Result<String> {
+pub(crate) async fn my_account_id(ctx: &JiraReqCtx, client: &reqwest::Client) -> Result<String> {
     let url = ctx.api_url("/rest/api/3/myself");
     let resp = ctx
         .apply(client.get(&url))

--- a/src/main.rs
+++ b/src/main.rs
@@ -739,8 +739,17 @@ async fn main() -> Result<()> {
                     )
                     .await;
                 }
-                // pm_tasks is refreshed on demand at its read boundaries
-                // (drafting in the worklog driver), so no timer-driven refresh is needed here.
+                // Refresh the PM task cache (pm_tasks) every tick — interval-gated
+                // per provider (~5 min), so this is a cheap no-op most ticks. The
+                // legacy drafting driver that used to trigger this before every
+                // pass was retired when the worklog pipeline moved to the
+                // clock-aligned Python trigger, which never calls this itself —
+                // leaving pm_tasks (and hence a ticket's title on the timeline)
+                // stuck at whatever it was at the last daemon restart. This is
+                // the only thing that keeps it live during normal operation.
+                if let Err(e) = run_pm_sync(&meridian, &cfg).await {
+                    tracing::warn!(error = %e, "pm_tasks refresh failed — using cached tasks");
+                }
             }
         }
     }

--- a/src/pm_worklog/create.rs
+++ b/src/pm_worklog/create.rs
@@ -61,6 +61,19 @@ fn norm_issue_type(issue_type: &str) -> &'static str {
     }
 }
 
+/// Resolve what to actually create when the wanted type is unavailable in the
+/// target project/process (e.g. no "Bug" type configured — common on
+/// team-managed Jira projects and Azure's Basic process template). Falls back
+/// to "Task" with the type prefixed onto the title so the information isn't
+/// silently lost.
+fn bug_fallback(wanted: &'static str, has_bug_type: bool, title: &str) -> (&'static str, String) {
+    if wanted == "Bug" && !has_bug_type {
+        ("Task", format!("Bug: {title}"))
+    } else {
+        (wanted, title.to_string())
+    }
+}
+
 // ── Config finders ────────────────────────────────────────────────────────────
 
 fn jira_cfg(c: &Config) -> Result<&JiraConfig> {
@@ -121,11 +134,18 @@ async fn jira_create(
         .project_keys
         .first()
         .context("Jira create needs a project key (none configured)")?;
+    let ctx = jira_resolve(jira).await.context("resolving Jira auth")?;
+    let client = reqwest::Client::new();
+
+    let wanted = norm_issue_type(issue_type);
+    let has_bug = wanted != "Bug" || jira_has_issue_type(&ctx, &client, project, "Bug").await?;
+    let (type_name, title) = bug_fallback(wanted, has_bug, title);
+
     let payload = json!({
         "fields": {
             "project": { "key": project },
             "summary": title,
-            "issuetype": { "name": norm_issue_type(issue_type) },
+            "issuetype": { "name": type_name },
             "description": {
                 "type": "doc", "version": 1,
                 "content": [ { "type": "paragraph",
@@ -133,9 +153,7 @@ async fn jira_create(
             }
         }
     });
-    let ctx = jira_resolve(jira).await.context("resolving Jira auth")?;
     let url = ctx.api_url("/rest/api/3/issue");
-    let client = reqwest::Client::new();
     let resp = ctx
         .apply(client.post(&url))
         .header("Accept", "application/json")
@@ -153,6 +171,37 @@ async fn jira_create(
         .and_then(|k| k.as_str())
         .map(str::to_string)
         .context("Jira create response missing `key`")
+}
+
+/// True if `name` is one of the project's configured issue types. Used to
+/// avoid a hard 400 (`Specify a valid issue type`) when a project's scheme
+/// doesn't include "Bug" (common on team-managed projects) — the caller
+/// falls back to creating a "Task" prefixed with "Bug: " instead.
+async fn jira_has_issue_type(
+    ctx: &meridian_oauth::jira::JiraReqCtx,
+    client: &reqwest::Client,
+    project: &str,
+    name: &str,
+) -> Result<bool> {
+    let url = ctx.api_url(&format!("/rest/api/3/project/{project}?fields=issueTypes"));
+    let resp = ctx
+        .apply(client.get(&url))
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .with_context(|| format!("network error checking Jira issue types at {url}"))?;
+    let body = resp
+        .text()
+        .await
+        .context("reading Jira project issue-types response")?;
+    let v: Value = serde_json::from_str(&body).context("parsing Jira project issue types")?;
+    Ok(v.get("issueTypes")
+        .and_then(|t| t.as_array())
+        .is_some_and(|types| {
+            types
+                .iter()
+                .any(|t| t.get("name").and_then(|n| n.as_str()) == Some(name))
+        }))
 }
 
 // ── Linear: GraphQL issueCreate ───────────────────────────────────────────────
@@ -292,22 +341,25 @@ async fn azure_create(
     issue_type: &str,
 ) -> Result<String> {
     use base64::Engine;
-    // Azure work-item type goes in the URL (`$Task` / `$Bug`).
-    let url = format!(
-        "{}/{}/_apis/wit/workitems/${}?api-version=7.0",
-        cfg.api_base,
-        cfg.project,
-        norm_issue_type(issue_type)
-    );
     let auth = format!(
         "Basic {}",
         base64::engine::general_purpose::STANDARD.encode(format!(":{}", cfg.pat).as_bytes())
+    );
+    let client = reqwest::Client::new();
+
+    let wanted = norm_issue_type(issue_type);
+    let has_bug = wanted != "Bug" || azure_has_work_item_type(cfg, &client, &auth, "Bug").await?;
+    let (work_item_type, title) = bug_fallback(wanted, has_bug, title);
+
+    // Azure work-item type goes in the URL (`$Task` / `$Bug`).
+    let url = format!(
+        "{}/{}/_apis/wit/workitems/${work_item_type}?api-version=7.0",
+        cfg.api_base, cfg.project,
     );
     let patch = json!([
         { "op": "add", "path": "/fields/System.Title", "value": title },
         { "op": "add", "path": "/fields/System.Description", "value": description }
     ]);
-    let client = reqwest::Client::new();
     let resp = client
         .post(&url)
         .header("Authorization", auth)
@@ -327,4 +379,71 @@ async fn azure_create(
         .and_then(|i| i.as_i64())
         .context("Azure create response missing `id`")?;
     Ok(id.to_string())
+}
+
+/// True if `name` is one of the project's work-item types. Azure's process
+/// template (e.g. Basic) may not include "Bug" — the caller falls back to
+/// creating a "Task" prefixed with "Bug: " instead of a hard 404.
+async fn azure_has_work_item_type(
+    cfg: &AzureDevOpsConfig,
+    client: &reqwest::Client,
+    auth: &str,
+    name: &str,
+) -> Result<bool> {
+    let url = format!(
+        "{}/{}/_apis/wit/workitemtypes?api-version=7.0",
+        cfg.api_base, cfg.project
+    );
+    let resp = client
+        .get(&url)
+        .header("Authorization", auth)
+        .send()
+        .await
+        .with_context(|| format!("network error checking Azure work-item types at {url}"))?;
+    let body = resp
+        .text()
+        .await
+        .context("reading Azure work-item-types response")?;
+    let v: Value = serde_json::from_str(&body).context("parsing Azure work-item types")?;
+    Ok(v.get("value")
+        .and_then(|t| t.as_array())
+        .is_some_and(|types| {
+            types
+                .iter()
+                .any(|t| t.get("name").and_then(|n| n.as_str()) == Some(name))
+        }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn norm_issue_type_maps_bug_case_insensitively() {
+        assert_eq!(norm_issue_type("bug"), "Bug");
+        assert_eq!(norm_issue_type("BUG"), "Bug");
+        assert_eq!(norm_issue_type("Task"), "Task");
+        assert_eq!(norm_issue_type("Story"), "Task");
+    }
+
+    #[test]
+    fn bug_fallback_keeps_bug_when_project_has_it() {
+        let (kind, title) = bug_fallback("Bug", true, "Fix the thing");
+        assert_eq!(kind, "Bug");
+        assert_eq!(title, "Fix the thing");
+    }
+
+    #[test]
+    fn bug_fallback_demotes_to_task_and_prefixes_title_when_missing() {
+        let (kind, title) = bug_fallback("Bug", false, "Fix the thing");
+        assert_eq!(kind, "Task");
+        assert_eq!(title, "Bug: Fix the thing");
+    }
+
+    #[test]
+    fn bug_fallback_is_noop_for_task() {
+        let (kind, title) = bug_fallback("Task", false, "Do the thing");
+        assert_eq!(kind, "Task");
+        assert_eq!(title, "Do the thing");
+    }
 }

--- a/src/pm_worklog/create.rs
+++ b/src/pm_worklog/create.rs
@@ -26,6 +26,8 @@ use crate::config::{
 };
 use crate::intelligence::oauth::jira::resolve as jira_resolve;
 use crate::intelligence::oauth::trello as oauth_trello;
+use crate::intelligence::ticket_update::azure_devops as azure_ticket_update;
+use crate::intelligence::ticket_update::jira as jira_ticket_update;
 
 /// Create a real ticket for `provider` from a proposal's (title, description) and
 /// return its `task_key`. `sample_key` is any existing task_key of that provider
@@ -141,7 +143,7 @@ async fn jira_create(
     let has_bug = wanted != "Bug" || jira_has_issue_type(&ctx, &client, project, "Bug").await?;
     let (type_name, title) = bug_fallback(wanted, has_bug, title);
 
-    let payload = json!({
+    let mut payload = json!({
         "fields": {
             "project": { "key": project },
             "summary": title,
@@ -153,6 +155,17 @@ async fn jira_create(
             }
         }
     });
+    // Self-assign so the ticket is discoverable by the `assignee = currentUser()`
+    // sync query (see intelligence/providers/jira/fetch.rs) — an unassigned
+    // ticket never enters pm_tasks, so its title never appears on the timeline.
+    // Best-effort: a lookup failure shouldn't block ticket creation.
+    match jira_ticket_update::my_account_id(&ctx, &client).await {
+        Ok(account_id) => payload["fields"]["assignee"] = json!({ "accountId": account_id }),
+        Err(e) => tracing::warn!(
+            error = %e,
+            "Jira create: couldn't resolve self accountId — creating unassigned"
+        ),
+    }
     let url = ctx.api_url("/rest/api/3/issue");
     let resp = ctx
         .apply(client.post(&url))
@@ -356,10 +369,23 @@ async fn azure_create(
         "{}/{}/_apis/wit/workitems/${work_item_type}?api-version=7.0",
         cfg.api_base, cfg.project,
     );
-    let patch = json!([
-        { "op": "add", "path": "/fields/System.Title", "value": title },
-        { "op": "add", "path": "/fields/System.Description", "value": description }
-    ]);
+    let mut patch = vec![
+        json!({ "op": "add", "path": "/fields/System.Title", "value": title }),
+        json!({ "op": "add", "path": "/fields/System.Description", "value": description }),
+    ];
+    // Self-assign so the work item is discoverable by the `AssignedTo = @me`
+    // sync query (see intelligence/providers/azure_devops/fetch.rs) — an
+    // unassigned item never enters pm_tasks, so its title never appears on
+    // the timeline. Best-effort: a lookup failure shouldn't block creation.
+    match azure_ticket_update::my_unique_name(&client, cfg).await {
+        Ok(me) => {
+            patch.push(json!({ "op": "add", "path": "/fields/System.AssignedTo", "value": me }))
+        }
+        Err(e) => tracing::warn!(
+            error = %e,
+            "Azure DevOps create: couldn't resolve self identity — creating unassigned"
+        ),
+    }
     let resp = client
         .post(&url)
         .header("Authorization", auth)


### PR DESCRIPTION
## Summary
- Your `KAN` Jira project's scheme only has Epic/Subtask/Feature/Task — no "Bug" — so any proposal classified as a bug 400'd forever with `Specify a valid issue type` and retried every sweep (visible as the repeating `proposal ticket creation failed` warnings)
- Same failure mode exists for Azure DevOps projects on process templates (e.g. Basic) that don't define a Bug work-item type
- Before creating, check the target project's actual issue/work-item types; if "Bug" isn't available, create a "Task" instead and prefix the title with `Bug: ` so the original classification isn't lost
- Applies to both providers that model an issue type (Jira, Azure DevOps) — Linear/GitHub/Trello have no type concept and are unaffected

## Test plan
- [x] New unit tests for the `bug_fallback` decision (keep/demote/no-op cases) — `cargo test --lib pm_worklog::create`
- [x] `cargo fmt` / `cargo clippy -D warnings` / `cargo test` (pre-commit + pre-push hooks passed)
- [ ] Manual verification on staging: confirm proposals 192/194 (or new ones) now create as "Task" titled "Bug: ..." instead of failing