### PR TITLE
feat(release): sign + notarize the macOS bundle with the Meridiona Developer ID

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -74,6 +74,14 @@ jobs:
       # latest.json and the mirror no-ops, so the staging channel can't update.
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      # Apple Developer ID signing + notarization — identical to release.yml (see
+      # the long note there). Staging signs with the SAME Developer ID cert on
+      # purpose: staging is where we prove the signed/notarized DMG works end to
+      # end (Gatekeeper-clean install, TCC grants surviving an auto-update) before
+      # the same machinery ships to production.
+      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+      APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
       # Tauri's DMG bundler skips the AppleScript step that sets the Finder
       # window background/icon layout whenever `CI` is set (every GitHub
       # Actions job sets `CI=true`), assuming CI runners can't drive Finder —
@@ -146,6 +154,45 @@ jobs:
         # is never committed. Keeps the staging config out of main's tree.
         run: cp .releaserc.staging.json .releaserc.json
 
+      - name: Import Developer ID certificate + notarization key
+        # Identical to release.yml — see the commentary there for the two
+        # non-obvious requirements (set-key-partition-list, and APPLE_API_KEY_PATH
+        # being a file path while the secret holds the .p8 content).
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="${RUNNER_TEMP}/meridian-signing.keychain-db"
+          KEYCHAIN_PW="$(uuidgen)"
+          CERT_P12="${RUNNER_TEMP}/certificate.p12"
+          API_KEY="${RUNNER_TEMP}/apple-api-key.p8"
+
+          security create-keychain -p "${KEYCHAIN_PW}" "${KEYCHAIN}"
+          security set-keychain-settings -lut 3600 "${KEYCHAIN}"
+          security unlock-keychain -p "${KEYCHAIN_PW}" "${KEYCHAIN}"
+
+          printf '%s' "${APPLE_CERTIFICATE}" | base64 --decode > "${CERT_P12}"
+          security import "${CERT_P12}" -k "${KEYCHAIN}" \
+            -P "${APPLE_CERTIFICATE_PASSWORD}" -T /usr/bin/codesign
+          rm -f "${CERT_P12}"
+
+          # Without this, codesign hangs forever on a GUI prompt no one can answer.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "${KEYCHAIN_PW}" "${KEYCHAIN}" >/dev/null
+
+          security list-keychains -d user -s "${KEYCHAIN}" \
+            $(security list-keychains -d user | tr -d '"')
+
+          printf '%s' "${APPLE_API_KEY_CONTENT}" > "${API_KEY}"
+          chmod 600 "${API_KEY}"
+          echo "APPLE_API_KEY_PATH=${API_KEY}" >> "${GITHUB_ENV}"
+
+          security find-identity -v -p codesigning "${KEYCHAIN}" | grep -q "Developer ID Application" \
+            || { echo "::error::Developer ID cert not found in the keychain after import"; exit 1; }
+          echo "✓ Developer ID certificate imported"
+
       - name: semantic-release (staging channel)
         env:
           # PAT to create the tag/prerelease past branch protection; falls back
@@ -167,3 +214,10 @@ jobs:
           # "staging" instead of the "prod" default. Production leaves this unset.
           MERIDIAN_CHANNEL: "staging"
         run: npx semantic-release
+
+      - name: Clean up signing material
+        # Runs even on failure — never leave the cert/key on a runner.
+        if: always()
+        run: |
+          security delete-keychain "${RUNNER_TEMP}/meridian-signing.keychain-db" 2>/dev/null || true
+          rm -f "${RUNNER_TEMP}/apple-api-key.p8" "${RUNNER_TEMP}/certificate.p12"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,26 @@ jobs:
       #   gh secret set TAURI_SIGNING_PRIVATE_KEY_PASSWORD
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      # ── Apple Developer ID signing + notarization (Meridiona LLP, AQTYN9PZ83) ──
+      # Consumed by `tauri build` (via tray/package.json's build script) to sign
+      # the .app/DMG and submit them to Apple's notary service. The cert itself is
+      # imported into a temp keychain by the "Import Developer ID certificate"
+      # step below; these are the identifiers Tauri reads.
+      #
+      # Absent → the bundle is ad-hoc signed, which ships TWO regressions:
+      #   • Gatekeeper's "unidentified developer" scare on first launch, and
+      #   • a fresh cdhash every build, so macOS sees each update as a brand-new
+      #     app and silently drops the user's Screen Recording / Accessibility
+      #     grants (the "Permissions not granted after update" bug).
+      # verify-release-bundle.sh now FAILS the release in that state rather than
+      # publishing it.
+      #
+      # APPLE_API_KEY is the 10-char Key ID and APPLE_API_ISSUER the issuer UUID
+      # (both from App Store Connect → Integrations → Team Keys). The private .p8
+      # is passed by PATH, not content — see APPLE_API_KEY_PATH in that step.
+      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+      APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
       # Tauri's DMG bundler skips the AppleScript step that sets the Finder
       # window background/icon layout whenever `CI` is set (every GitHub
       # Actions job sets `CI=true`), assuming CI runners can't drive Finder —
@@ -157,6 +177,61 @@ jobs:
             url."https://x-access-token:${GH_TOKEN}@github.com/Meridiona/screenpipe-fork".insteadOf \
             "https://github.com/Meridiona/screenpipe-fork"
 
+      - name: Import Developer ID certificate + notarization key
+        # Puts the Developer ID cert in a throwaway keychain that `codesign` can
+        # reach, and materialises the notarization key on disk.
+        #
+        # Two non-obvious requirements, each of which silently breaks CI signing:
+        #   1. set-key-partition-list — without it, `codesign` blocks FOREVER
+        #      waiting on a "allow access to your keychain?" GUI prompt that no
+        #      one can answer on a headless runner. The job just hangs to timeout.
+        #   2. APPLE_API_KEY_PATH is a FILE PATH, but our secret stores the .p8
+        #      CONTENT (a GitHub secret can't hold a file), so we write it out to
+        #      RUNNER_TEMP and point Tauri at it. Exported via GITHUB_ENV because
+        #      the `runner` context isn't available in job-level `env:`.
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="${RUNNER_TEMP}/meridian-signing.keychain-db"
+          KEYCHAIN_PW="$(uuidgen)"
+          CERT_P12="${RUNNER_TEMP}/certificate.p12"
+          API_KEY="${RUNNER_TEMP}/apple-api-key.p8"
+
+          security create-keychain -p "${KEYCHAIN_PW}" "${KEYCHAIN}"
+          # -lut 3600: don't auto-lock mid-build (a long Rust+Next build can
+          # outrun the 5-minute default and re-lock the keychain under codesign).
+          security set-keychain-settings -lut 3600 "${KEYCHAIN}"
+          security unlock-keychain -p "${KEYCHAIN_PW}" "${KEYCHAIN}"
+
+          printf '%s' "${APPLE_CERTIFICATE}" | base64 --decode > "${CERT_P12}"
+          # -T /usr/bin/codesign grants ONLY codesign use of the key (never -A).
+          security import "${CERT_P12}" -k "${KEYCHAIN}" \
+            -P "${APPLE_CERTIFICATE_PASSWORD}" -T /usr/bin/codesign
+          rm -f "${CERT_P12}"
+
+          # See (1) above — this is the step everyone forgets.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "${KEYCHAIN_PW}" "${KEYCHAIN}" >/dev/null
+
+          # Prepend our keychain to the search list (keep the existing ones, or
+          # codesign can't reach Apple's intermediate certs).
+          security list-keychains -d user -s "${KEYCHAIN}" \
+            $(security list-keychains -d user | tr -d '"')
+
+          # See (2) above.
+          printf '%s' "${APPLE_API_KEY_CONTENT}" > "${API_KEY}"
+          chmod 600 "${API_KEY}"
+          echo "APPLE_API_KEY_PATH=${API_KEY}" >> "${GITHUB_ENV}"
+
+          # Fail loudly HERE if the cert didn't import, rather than 40 minutes
+          # later at the signing step.
+          security find-identity -v -p codesigning "${KEYCHAIN}" | grep -q "Developer ID Application" \
+            || { echo "::error::Developer ID cert not found in the keychain after import"; exit 1; }
+          echo "✓ Developer ID certificate imported"
+
       - name: semantic-release
         env:
           # GitHub PAT (repo scope) to push the version commit to main past
@@ -167,3 +242,10 @@ jobs:
           # via OIDC trusted publishing using the id-token above. Requires a
           # Trusted Publisher to be configured on npm for BOTH packages.
         run: npx semantic-release
+
+      - name: Clean up signing material
+        # Runs even on failure — never leave the cert/key on a runner.
+        if: always()
+        run: |
+          security delete-keychain "${RUNNER_TEMP}/meridian-signing.keychain-db" 2>/dev/null || true
+          rm -f "${RUNNER_TEMP}/apple-api-key.p8" "${RUNNER_TEMP}/certificate.p12"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -31,7 +31,7 @@
       ]
     }],
     ["@semantic-release/exec", {
-      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && cargo build --release && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build) && bash scripts/package-release.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}",
+      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && cargo build --release && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build) && bash scripts/notarize-dmg.sh ${nextRelease.version} && bash scripts/package-release.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}",
       "publishCmd": "npm publish ./npm/meridian-darwin-arm64 --access public"
     }],
     ["@semantic-release/npm", { "pkgRoot": "npm/meridian" }],

--- a/.releaserc.staging.json
+++ b/.releaserc.staging.json
@@ -32,7 +32,7 @@
       ]
     }],
     ["@semantic-release/exec", {
-      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && cargo build --release && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build -- --config src-tauri/tauri.staging.conf.json) && bash scripts/package-release.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}",
+      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && cargo build --release && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build -- --config src-tauri/tauri.staging.conf.json) && bash scripts/notarize-dmg.sh ${nextRelease.version} && bash scripts/package-release.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}",
       "publishCmd": "bash scripts/mirror-staging-release.sh ${nextRelease.version}"
     }]
   ]

--- a/scripts/notarize-dmg.sh
+++ b/scripts/notarize-dmg.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+#
+# Notarize + staple the DMG. Runs after `tauri build`, before package-updater.sh
+# makes its stable-named `Meridian.dmg` copy (stapling rewrites the file, so the
+# copy inherits the ticket).
+#
+# Why this exists: Tauri notarizes and staples the .app (tauri-bundler's
+# macos/app.rs), but it only *signs* the DMG — there is no notarize/staple call
+# for the disk image anywhere in the bundler. Apple's guidance is explicit that
+# the container you actually distribute must itself be notarized: a quarantined,
+# un-notarized DMG makes macOS tell the user it "can't check it for malicious
+# software" when they open it — which is precisely the scare a paid product
+# cannot ship, and precisely what the Developer ID was bought to avoid. The app
+# inside being stapled does not cover the DMG: a notarization ticket is keyed to
+# the cdhash of the thing submitted, and the DMG's own cdhash was never seen by
+# Apple.
+#
+#   bash scripts/notarize-dmg.sh <version>
+#
+# NO-OP unless APPLE_SIGNING_IDENTITY names a real Developer ID cert, so local
+# dev builds don't try (and fail) to reach Apple's notary service. When it IS a
+# Developer ID build, missing notarization credentials are a HARD failure — a
+# silently-unnotarized release is the exact bug this script exists to prevent.
+set -euo pipefail
+
+VERSION="${1:?usage: notarize-dmg.sh <version>}"
+VERSION="${VERSION#v}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+DMG="target/release/bundle/dmg/Meridian_${VERSION}_aarch64.dmg"
+IDENTITY="${APPLE_SIGNING_IDENTITY:-}"
+
+case "${IDENTITY}" in
+    "Developer ID Application:"*) ;;
+    *)
+        echo "→ notarize-dmg: skipping (APPLE_SIGNING_IDENTITY is not a Developer ID cert)"
+        exit 0
+        ;;
+esac
+
+[[ -f "${DMG}" ]] || { echo "✗ notarize-dmg: ${DMG} not found" >&2; exit 1; }
+
+: "${APPLE_API_KEY:?notarize-dmg: APPLE_API_KEY (the 10-char Key ID) is unset}"
+: "${APPLE_API_ISSUER:?notarize-dmg: APPLE_API_ISSUER (the issuer UUID) is unset}"
+: "${APPLE_API_KEY_PATH:?notarize-dmg: APPLE_API_KEY_PATH (path to the .p8) is unset}"
+[[ -f "${APPLE_API_KEY_PATH}" ]] || { echo "✗ notarize-dmg: no .p8 at ${APPLE_API_KEY_PATH}" >&2; exit 1; }
+
+# --wait blocks until Apple returns Accepted/Invalid (typically 1-5 min). Without
+# it the submission is fire-and-forget and the staple below would race it.
+echo "→ notarize-dmg: submitting $(basename "${DMG}") to Apple's notary service…"
+xcrun notarytool submit "${DMG}" \
+    --key "${APPLE_API_KEY_PATH}" \
+    --key-id "${APPLE_API_KEY}" \
+    --issuer "${APPLE_API_ISSUER}" \
+    --wait
+
+# Staple the ticket INTO the dmg so Gatekeeper accepts it with no network.
+xcrun stapler staple "${DMG}"
+xcrun stapler validate "${DMG}"
+
+echo "✓ notarize-dmg: $(basename "${DMG}") notarized + stapled"

--- a/scripts/sign-daemon.sh
+++ b/scripts/sign-daemon.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+#
+# Developer-ID-sign the `meridian` daemon binary BEFORE `tauri build` copies it
+# into Meridian.app as a bundle resource (bundle.resources → backend/meridian).
+#
+# Why this exists: Tauri signs the .app and its own tray binary, but NOT the
+# extra Mach-O we inject via `bundle.resources`. Left alone, the daemon ships
+# inside the bundle ad-hoc/linker-signed with no Team ID — and Apple's notary
+# service rejects a submission where ANY nested Mach-O lacks a Developer ID
+# signature + Hardened Runtime. Note that `codesign --verify --deep --strict`
+# still PASSES in that state (an ad-hoc signature is a valid signature), so this
+# only surfaces at notarization; hence the explicit step rather than trusting a
+# deep-verify to catch it.
+#
+# Signing must happen INSIDE-OUT: the daemon is sealed into the app's resource
+# hashes, so it has to carry its final signature before Tauri seals the outer
+# bundle. Re-signing it afterwards would invalidate the app's seal.
+#
+#   bash scripts/sign-daemon.sh            # signs target/release/meridian
+#
+# NO-OP unless APPLE_SIGNING_IDENTITY names a real Developer ID cert. Local dev
+# builds (ad-hoc "-" or the self-signed "Meridian Dev" identity from
+# scripts/dev-signing.sh) are left untouched: they are never notarized, and the
+# dev identity deliberately keeps its own stable cdhash for TCC (see
+# dev-signing.sh). Called from tray/package.json's `build` / `build:staging`,
+# between `build:daemon` and `tauri build`.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="${REPO_ROOT}/target/release/meridian"
+IDENTITY="${APPLE_SIGNING_IDENTITY:-}"
+
+# Only a real Developer ID cert is worth signing with here — see the header.
+case "${IDENTITY}" in
+    "Developer ID Application:"*) ;;
+    *)
+        echo "→ sign-daemon: skipping (APPLE_SIGNING_IDENTITY is not a Developer ID cert)"
+        exit 0
+        ;;
+esac
+
+[[ -f "${BIN}" ]] || { echo "✗ sign-daemon: ${BIN} not found — run the daemon build first" >&2; exit 1; }
+
+# --options runtime  : Hardened Runtime, mandatory for notarization.
+# --timestamp        : secure timestamp from Apple's TSA, also mandatory (needs
+#                      network; a signature without one is rejected by notary).
+# --force            : replace the ad-hoc signature cargo/ld left behind.
+echo "→ sign-daemon: signing target/release/meridian as '${IDENTITY}'"
+codesign --force --options runtime --timestamp --sign "${IDENTITY}" "${BIN}"
+codesign --verify --strict --verbose=2 "${BIN}"
+
+echo "✓ sign-daemon: daemon signed + verified (Developer ID, Hardened Runtime)"

--- a/scripts/verify-release-bundle.sh
+++ b/scripts/verify-release-bundle.sh
@@ -13,6 +13,11 @@
 #   2. binaries present  — the daemon + tray binaries must be in the package. The
 #      dashboard ships embedded in the tray binary (static export), so there's no
 #      separate ui.tar.gz / Node runtime / better-sqlite3 addon to ABI-check.
+#   3. signing + notarization — the .app AND the daemon nested inside it must both
+#      carry a Developer ID signature under Meridiona's Team ID with the Hardened
+#      Runtime, and the .app + DMG must be notarized AND stapled. Catches an
+#      ad-hoc-signed release (Gatekeeper scare + TCC grants dropped on every
+#      update, because the cdhash changes) and a missing notarization secret.
 #
 #   scripts/verify-release-bundle.sh <version>
 set -euo pipefail
@@ -48,5 +53,70 @@ for _bin in bin/meridian bin/meridian-tray; do
     grep -qx "${_bin}" <<<"${_files}" || fail "${_bin} missing from the npm package"
 done
 pass "binaries present: daemon + tray (dashboard embedded in the tray binary)"
+
+# ── 3. macOS code signing + notarization — the Gatekeeper/TCC guard ──────────
+# Every failure below has shipped (or would ship) a broken release:
+#   • ad-hoc signature      → Gatekeeper "unidentified developer" scare on first
+#     launch, AND a fresh cdhash every build, so macOS treats each update as a
+#     brand-new app and silently drops the user's Screen Recording / Accessibility
+#     grants (the "Permissions not granted after update" bug).
+#   • unsigned nested Mach-O → Apple's notary rejects the whole submission. Note
+#     `codesign --verify --deep --strict` PASSES on an ad-hoc nested binary, so it
+#     canNOT be relied on here — the Team ID must be asserted explicitly.
+#   • un-notarized/un-stapled → first launch is blocked or needs an online check.
+APP="target/release/bundle/macos/Meridian.app"
+DMG="target/release/bundle/dmg/Meridian.dmg"
+DAEMON_IN_APP="${APP}/Contents/Resources/backend/meridian"
+TEAM_ID="AQTYN9PZ83"   # Meridiona LLP
+
+[[ -d "${APP}" ]] || fail "${APP} not found — the tauri build did not produce an .app"
+
+# 3a. Both Mach-Os must carry a Developer ID signature under Meridiona's Team ID
+#     with the Hardened Runtime flag set (notarization requires all three).
+for _target in "${APP}:app bundle" "${DAEMON_IN_APP}:bundled daemon"; do
+    _path="${_target%%:*}"; _what="${_target##*:}"
+    [[ -e "${_path}" ]] || fail "${_what} missing at ${_path}"
+    _info="$(codesign -dv --verbose=4 "${_path}" 2>&1)"
+    grep -q "Authority=Developer ID Application: Meridiona LLP (${TEAM_ID})" <<<"${_info}" \
+        || fail "${_what} is not signed with the Developer ID cert (found: $(grep -m1 '^Signature' <<<"${_info}" || echo 'no signature')). Are APPLE_CERTIFICATE / APPLE_SIGNING_IDENTITY set in CI?"
+    grep -q "TeamIdentifier=${TEAM_ID}" <<<"${_info}" || fail "${_what} has no/wrong TeamIdentifier (want ${TEAM_ID})"
+    grep -qE 'flags=.*runtime' <<<"${_info}" || fail "${_what} is not signed with the Hardened Runtime (--options runtime) — notarization will reject it"
+done
+pass "app + bundled daemon: Developer ID (${TEAM_ID}), Hardened Runtime"
+
+# 3b. The bundle seal is intact and every nested piece verifies.
+codesign --verify --deep --strict "${APP}" 2>/dev/null || fail "codesign --verify --deep --strict failed on ${APP} — the bundle seal is broken"
+pass "bundle seal verifies (--deep --strict)"
+
+# 3c. Notarized + stapled: Gatekeeper must accept the app OFFLINE. `spctl`
+#     reports "Notarized Developer ID" only when a stapled ticket is present.
+_spctl="$(spctl --assess --type exec -vv "${APP}" 2>&1 || true)"
+grep -q "accepted" <<<"${_spctl}" || fail "Gatekeeper REJECTED ${APP}: ${_spctl}"
+grep -q "Notarized Developer ID" <<<"${_spctl}" || fail "${APP} is signed but NOT notarized (${_spctl}) — users get a Gatekeeper warning. Check the APPLE_API_* notarization secrets."
+xcrun stapler validate "${APP}" >/dev/null 2>&1 || fail "no stapled notarization ticket on ${APP} — first launch would need an online Gatekeeper check"
+pass "notarized + stapled (Gatekeeper accepts offline)"
+
+# 3d. The DMG users actually download must itself be stapled.
+if [[ -f "${DMG}" ]]; then
+    xcrun stapler validate "${DMG}" >/dev/null 2>&1 || fail "no stapled notarization ticket on ${DMG} — the downloaded DMG would trip Gatekeeper"
+    pass "DMG stapled: $(basename "${DMG}")"
+else
+    fail "${DMG} not found — package-updater.sh should have made the stable-named copy"
+fi
+
+# ── 4. updater artifacts — the silent-no-auto-update guard ───────────────────
+# `tauri build` logs "failed to decode secret key: incorrect updater private key
+# password" but STILL EXITS 0; package-updater.sh then finds no .sig and skips
+# latest.json with a friendly message. Net effect: a green release that ships
+# with auto-update dead. Assert the artifacts exist rather than trusting exit
+# codes. (A wrong/absent TAURI_SIGNING_PRIVATE_KEY_PASSWORD is the usual cause.)
+for _art in \
+    "target/release/bundle/macos/Meridian.app.tar.gz:updater payload" \
+    "target/release/bundle/macos/Meridian.app.tar.gz.sig:updater signature" \
+    "target/release/bundle/macos/latest.json:updater manifest"; do
+    _p="${_art%%:*}"; _w="${_art##*:}"
+    [[ -s "${_p}" ]] || fail "${_w} missing/empty at ${_p} — auto-update would be dead for every installed user. Check TAURI_SIGNING_PRIVATE_KEY / _PASSWORD (tauri build logs the failure but exits 0)."
+done
+pass "updater artifacts present: payload + minisign signature + latest.json"
 
 echo "✓ Smoke test passed — safe to publish v${VERSION}"

--- a/tray/package.json
+++ b/tray/package.json
@@ -5,8 +5,8 @@
     "tauri": "tauri",
     "dev": "tauri dev",
     "build:daemon": "cargo build --locked --release --bin meridian --manifest-path ../Cargo.toml",
-    "build": "npm run build:daemon && APPLE_SIGNING_IDENTITY=\"${APPLE_SIGNING_IDENTITY:-$(bash ../scripts/dev-signing.sh identity)}\" tauri build",
-    "build:staging": "npm run build:daemon && APPLE_SIGNING_IDENTITY=\"${APPLE_SIGNING_IDENTITY:-$(bash ../scripts/dev-signing.sh identity)}\" MERIDIAN_RUNTIME_MANIFEST_URL=https://github.com/Meridiona/meridian/releases/download/runtime-staging/runtime-manifest.json MERIDIAN_HF_ENDPOINT=https://hf.meridiona.com MERIDIAN_CHANNEL=staging tauri build",
+    "build": "npm run build:daemon && export APPLE_SIGNING_IDENTITY=\"${APPLE_SIGNING_IDENTITY:-$(bash ../scripts/dev-signing.sh identity)}\" && bash ../scripts/sign-daemon.sh && tauri build",
+    "build:staging": "npm run build:daemon && export APPLE_SIGNING_IDENTITY=\"${APPLE_SIGNING_IDENTITY:-$(bash ../scripts/dev-signing.sh identity)}\" MERIDIAN_RUNTIME_MANIFEST_URL=https://github.com/Meridiona/meridian/releases/download/runtime-staging/runtime-manifest.json MERIDIAN_HF_ENDPOINT=https://hf.meridiona.com MERIDIAN_CHANNEL=staging && bash ../scripts/sign-daemon.sh && tauri build",
     "test": "vitest run src/__tests__"
   },
   "devDependencies": {


### PR DESCRIPTION
Meridiona LLP's Apple Developer Program enrollment is approved (Team ID `AQTYN9PZ83`), so the release pipeline can stop shipping ad-hoc-signed builds.

An ad-hoc signature caused two user-visible regressions:
- Gatekeeper's **"unidentified developer"** scare on first launch.
- The cdhash changes on **every** build, so macOS treats each update as a brand-new app and silently drops the user's Screen Recording / Accessibility grants - the "Permissions not granted after update" bug.

## What Tauri does NOT do (verified against a real signed build, not assumed)

**It doesn't sign Mach-Os injected via `bundle.resources`.** The `meridian` daemon shipped inside the `.app` ad-hoc/linker-signed with no Team ID, and Apple's notary rejects any submission with an unsigned nested Mach-O. The trap: `codesign --verify --deep --strict` **passes** on it, so a deep-verify can't be the guard - the Team ID has to be asserted explicitly. `scripts/sign-daemon.sh` signs it inside-out, before `tauri build` seals the bundle over it.

**It notarizes + staples the `.app` but only *signs* the DMG.** `notarize`/`staple` appear only in `tauri-bundler`'s `macos/app.rs`; `dmg/mod.rs` just signs. The app's ticket doesn't cover the container - a ticket is keyed to the cdhash of the thing submitted, and the DMG's own cdhash was never seen by Apple. So the DMG users download would still be flagged. `scripts/notarize-dmg.sh` submits and staples it.

**`tauri build` exits 0 even when updater signing fails** (`incorrect updater private key password`), after which `package-updater.sh` silently skips `latest.json` - a green release with auto-update dead. Now gated.

## Changes

| File | What |
|---|---|
| `scripts/sign-daemon.sh` (new) | Developer-ID-sign the daemon before it's sealed into the `.app`. No-ops for dev builds. |
| `scripts/notarize-dmg.sh` (new) | Notarize + staple the DMG. No-ops for dev builds; **fails closed** if a Developer ID build lacks creds. |
| `scripts/verify-release-bundle.sh` | Fail the release rather than publish it when the `.app` **or** the nested daemon isn't Developer ID signed with Hardened Runtime, or the `.app`/DMG isn't notarized **and** stapled; assert the updater artifacts exist. |
| `release.yml` / `release-staging.yml` | Import the cert into a throwaway keychain; materialise the notarization key. |
| `.releaserc*.json` | Run `notarize-dmg.sh` before packaging (so the stable-named `Meridian.dmg` copy inherits the staple). |
| `tray/package.json` | Run the daemon pre-sign between `build:daemon` and `tauri build`. |

Two non-obvious CI requirements are handled: `security set-key-partition-list` (without it `codesign` **hangs forever** on a headless runner waiting for a GUI prompt), and `APPLE_API_KEY_PATH` being a *file path* while a GitHub secret can only hold the `.p8` *content*.

**No entitlements file is needed** - the app signs, seals and verifies under Hardened Runtime with an empty entitlement set. (The plan doc assumed WebView JIT/unsigned-memory entitlements would be required; it was wrong, so I didn't add them.)

## Verified

- Nested daemon now carries `Authority=Developer ID Application: Meridiona LLP (AQTYN9PZ83)` + `flags=runtime`; outer bundle still seals (`--deep --strict`).
- The gate correctly **rejects** a signed-but-unnotarized build (`source=Unnotarized Developer ID`) - it would have caught today's releases.
- Both new scripts no-op on dev builds and fail closed on a credential-less Developer ID build.

## Not yet verified

A full rebuild **with** the notarization credentials, run end-to-end through the packaging + gate scripts. That is the last step before triggering a staging release - a 45-minute CI build is a slow way to discover a bad credential.

Requires repo secrets: `APPLE_SIGNING_IDENTITY`, `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_API_KEY`, `APPLE_API_ISSUER`, `APPLE_API_KEY_CONTENT` (all six are set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ctcf2YbLSiWTT5q47RZxNg