### PR TITLE
fix(review): address CodeRabbit findings on PR #440

### DIFF
--- a/.github/actions/import-apple-cert/action.yml
+++ b/.github/actions/import-apple-cert/action.yml
@@ -1,0 +1,89 @@
+name: Import Apple Developer ID certificate
+description: >
+  Imports the Developer ID Application certificate into a throwaway keychain
+  that codesign can reach, and materialises the App Store Connect notarization
+  .p8 key on disk (its path exported as APPLE_API_KEY_PATH via GITHUB_ENV).
+  Shared verbatim by release.yml and release-staging.yml. No-ops gracefully
+  when no certificate is configured (fork PRs, or any build not meant to sign)
+  instead of crashing `security import` with an opaque error - matching the
+  early-exit in sign-daemon.sh / notarize-dmg.sh.
+
+inputs:
+  apple-certificate:
+    description: Base64-encoded Developer ID Application .p12 (secrets.APPLE_CERTIFICATE).
+    required: true
+  apple-certificate-password:
+    description: Password for the .p12 (secrets.APPLE_CERTIFICATE_PASSWORD).
+    required: true
+  apple-api-key-content:
+    description: Contents of the App Store Connect .p8 notarization key (secrets.APPLE_API_KEY_CONTENT).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Import Developer ID certificate + notarization key
+      # Puts the Developer ID cert in a throwaway keychain that `codesign` can
+      # reach, and materialises the notarization key on disk.
+      #
+      # Two non-obvious requirements, each of which silently breaks CI signing:
+      #   1. set-key-partition-list - without it, `codesign` blocks FOREVER
+      #      waiting on a "allow access to your keychain?" GUI prompt that no
+      #      one can answer on a headless runner. The job just hangs to timeout.
+      #   2. APPLE_API_KEY_PATH is a FILE PATH, but our secret stores the .p8
+      #      CONTENT (a GitHub secret can't hold a file), so we write it out to
+      #      RUNNER_TEMP and point Tauri at it. Exported via GITHUB_ENV because
+      #      the `runner` context isn't available in job-level `env:`.
+      shell: bash
+      env:
+        APPLE_CERTIFICATE: ${{ inputs.apple-certificate }}
+        APPLE_CERTIFICATE_PASSWORD: ${{ inputs.apple-certificate-password }}
+        APPLE_API_KEY_CONTENT: ${{ inputs.apple-api-key-content }}
+      run: |
+        set -euo pipefail
+
+        # Guard: with no certificate configured (a fork PR, or a build not
+        # meant to sign), skip gracefully rather than letting `base64`/`security
+        # import` crash the job on empty input - the same graceful no-op
+        # sign-daemon.sh / notarize-dmg.sh use.
+        if [ -z "${APPLE_CERTIFICATE:-}" ]; then
+          echo "::notice::APPLE_CERTIFICATE not set - skipping Developer ID import (unsigned build)"
+          exit 0
+        fi
+
+        KEYCHAIN="${RUNNER_TEMP}/meridian-signing.keychain-db"
+        KEYCHAIN_PW="$(uuidgen)"
+        CERT_P12="${RUNNER_TEMP}/certificate.p12"
+        API_KEY="${RUNNER_TEMP}/apple-api-key.p8"
+
+        security create-keychain -p "${KEYCHAIN_PW}" "${KEYCHAIN}"
+        # -lut 3600: don't auto-lock mid-build (a long Rust+Next build can
+        # outrun the 5-minute default and re-lock the keychain under codesign).
+        security set-keychain-settings -lut 3600 "${KEYCHAIN}"
+        security unlock-keychain -p "${KEYCHAIN_PW}" "${KEYCHAIN}"
+
+        printf '%s' "${APPLE_CERTIFICATE}" | base64 --decode > "${CERT_P12}"
+        # -T /usr/bin/codesign grants ONLY codesign use of the key (never -A).
+        security import "${CERT_P12}" -k "${KEYCHAIN}" \
+          -P "${APPLE_CERTIFICATE_PASSWORD}" -T /usr/bin/codesign
+        rm -f "${CERT_P12}"
+
+        # See (1) above - this is the step everyone forgets.
+        security set-key-partition-list -S apple-tool:,apple:,codesign: \
+          -s -k "${KEYCHAIN_PW}" "${KEYCHAIN}" >/dev/null
+
+        # Prepend our keychain to the search list (keep the existing ones, or
+        # codesign can't reach Apple's intermediate certs).
+        security list-keychains -d user -s "${KEYCHAIN}" \
+          $(security list-keychains -d user | tr -d '"')
+
+        # See (2) above.
+        printf '%s' "${APPLE_API_KEY_CONTENT}" > "${API_KEY}"
+        chmod 600 "${API_KEY}"
+        echo "APPLE_API_KEY_PATH=${API_KEY}" >> "${GITHUB_ENV}"
+
+        # Fail loudly HERE if the cert didn't import, rather than 40 minutes
+        # later at the signing step.
+        security find-identity -v -p codesigning "${KEYCHAIN}" | grep -q "Developer ID Application" \
+          || { echo "::error::Developer ID cert not found in the keychain after import"; exit 1; }
+        echo "✓ Developer ID certificate imported"

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -155,43 +155,14 @@ jobs:
         run: cp .releaserc.staging.json .releaserc.json
 
       - name: Import Developer ID certificate + notarization key
-        # Identical to release.yml — see the commentary there for the two
-        # non-obvious requirements (set-key-partition-list, and APPLE_API_KEY_PATH
-        # being a file path while the secret holds the .p8 content).
-        env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
-        run: |
-          set -euo pipefail
-          KEYCHAIN="${RUNNER_TEMP}/meridian-signing.keychain-db"
-          KEYCHAIN_PW="$(uuidgen)"
-          CERT_P12="${RUNNER_TEMP}/certificate.p12"
-          API_KEY="${RUNNER_TEMP}/apple-api-key.p8"
-
-          security create-keychain -p "${KEYCHAIN_PW}" "${KEYCHAIN}"
-          security set-keychain-settings -lut 3600 "${KEYCHAIN}"
-          security unlock-keychain -p "${KEYCHAIN_PW}" "${KEYCHAIN}"
-
-          printf '%s' "${APPLE_CERTIFICATE}" | base64 --decode > "${CERT_P12}"
-          security import "${CERT_P12}" -k "${KEYCHAIN}" \
-            -P "${APPLE_CERTIFICATE_PASSWORD}" -T /usr/bin/codesign
-          rm -f "${CERT_P12}"
-
-          # Without this, codesign hangs forever on a GUI prompt no one can answer.
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s -k "${KEYCHAIN_PW}" "${KEYCHAIN}" >/dev/null
-
-          security list-keychains -d user -s "${KEYCHAIN}" \
-            $(security list-keychains -d user | tr -d '"')
-
-          printf '%s' "${APPLE_API_KEY_CONTENT}" > "${API_KEY}"
-          chmod 600 "${API_KEY}"
-          echo "APPLE_API_KEY_PATH=${API_KEY}" >> "${GITHUB_ENV}"
-
-          security find-identity -v -p codesigning "${KEYCHAIN}" | grep -q "Developer ID Application" \
-            || { echo "::error::Developer ID cert not found in the keychain after import"; exit 1; }
-          echo "✓ Developer ID certificate imported"
+        # Shared composite action (deduped from release.yml) - see the action's
+        # own comments for the set-key-partition-list / APPLE_API_KEY_PATH
+        # gotchas. Also no-ops gracefully when APPLE_CERTIFICATE is unset.
+        uses: ./.github/actions/import-apple-cert
+        with:
+          apple-certificate: ${{ secrets.APPLE_CERTIFICATE }}
+          apple-certificate-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          apple-api-key-content: ${{ secrets.APPLE_API_KEY_CONTENT }}
 
       - name: semantic-release (staging channel)
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,59 +178,14 @@ jobs:
             "https://github.com/Meridiona/screenpipe-fork"
 
       - name: Import Developer ID certificate + notarization key
-        # Puts the Developer ID cert in a throwaway keychain that `codesign` can
-        # reach, and materialises the notarization key on disk.
-        #
-        # Two non-obvious requirements, each of which silently breaks CI signing:
-        #   1. set-key-partition-list — without it, `codesign` blocks FOREVER
-        #      waiting on a "allow access to your keychain?" GUI prompt that no
-        #      one can answer on a headless runner. The job just hangs to timeout.
-        #   2. APPLE_API_KEY_PATH is a FILE PATH, but our secret stores the .p8
-        #      CONTENT (a GitHub secret can't hold a file), so we write it out to
-        #      RUNNER_TEMP and point Tauri at it. Exported via GITHUB_ENV because
-        #      the `runner` context isn't available in job-level `env:`.
-        env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
-        run: |
-          set -euo pipefail
-          KEYCHAIN="${RUNNER_TEMP}/meridian-signing.keychain-db"
-          KEYCHAIN_PW="$(uuidgen)"
-          CERT_P12="${RUNNER_TEMP}/certificate.p12"
-          API_KEY="${RUNNER_TEMP}/apple-api-key.p8"
-
-          security create-keychain -p "${KEYCHAIN_PW}" "${KEYCHAIN}"
-          # -lut 3600: don't auto-lock mid-build (a long Rust+Next build can
-          # outrun the 5-minute default and re-lock the keychain under codesign).
-          security set-keychain-settings -lut 3600 "${KEYCHAIN}"
-          security unlock-keychain -p "${KEYCHAIN_PW}" "${KEYCHAIN}"
-
-          printf '%s' "${APPLE_CERTIFICATE}" | base64 --decode > "${CERT_P12}"
-          # -T /usr/bin/codesign grants ONLY codesign use of the key (never -A).
-          security import "${CERT_P12}" -k "${KEYCHAIN}" \
-            -P "${APPLE_CERTIFICATE_PASSWORD}" -T /usr/bin/codesign
-          rm -f "${CERT_P12}"
-
-          # See (1) above — this is the step everyone forgets.
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s -k "${KEYCHAIN_PW}" "${KEYCHAIN}" >/dev/null
-
-          # Prepend our keychain to the search list (keep the existing ones, or
-          # codesign can't reach Apple's intermediate certs).
-          security list-keychains -d user -s "${KEYCHAIN}" \
-            $(security list-keychains -d user | tr -d '"')
-
-          # See (2) above.
-          printf '%s' "${APPLE_API_KEY_CONTENT}" > "${API_KEY}"
-          chmod 600 "${API_KEY}"
-          echo "APPLE_API_KEY_PATH=${API_KEY}" >> "${GITHUB_ENV}"
-
-          # Fail loudly HERE if the cert didn't import, rather than 40 minutes
-          # later at the signing step.
-          security find-identity -v -p codesigning "${KEYCHAIN}" | grep -q "Developer ID Application" \
-            || { echo "::error::Developer ID cert not found in the keychain after import"; exit 1; }
-          echo "✓ Developer ID certificate imported"
+        # Shared composite action (deduped from release-staging.yml). It also
+        # no-ops gracefully when APPLE_CERTIFICATE is unset instead of crashing
+        # `security import`. Requires the repo to be checked out first (above).
+        uses: ./.github/actions/import-apple-cert
+        with:
+          apple-certificate: ${{ secrets.APPLE_CERTIFICATE }}
+          apple-certificate-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          apple-api-key-content: ${{ secrets.APPLE_API_KEY_CONTENT }}
 
       - name: semantic-release
         env:

--- a/meridian-core/src/fs_utils.rs
+++ b/meridian-core/src/fs_utils.rs
@@ -1,0 +1,113 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Small filesystem helpers shared across the daemon and the tray.
+//!
+//! The one thing here today is [`atomic_write_json`] — the crash-safe
+//! "serialise → temp file → atomic rename" idiom. It was hand-rolled in at
+//! least three places ([`crate::settings::write_settings_value`], the tray's
+//! `analytics::save_state`, and `commands::account::save_account_email`); this
+//! is the single tested implementation they now all call, so the
+//! crash-safety-sensitive sequence lives in exactly one place.
+//!
+//! # Who calls this
+//! - [`crate::settings::write_settings_value`] — `settings.json`.
+//! - `tray/src-tauri/src/analytics.rs::save_state` — the PostHog state file.
+//! - `tray/src-tauri/src/commands/account.rs::save_account_email` — the
+//!   signed-in account file (via `spawn_blocking`, since it's a sync fn called
+//!   from an async command).
+
+use anyhow::Context;
+use serde::Serialize;
+use std::path::Path;
+
+/// Crash-safely persist `value` as pretty (2-space) JSON to `path`.
+///
+/// Creates the parent directory if needed, serialises to a temp file **in the
+/// same directory** (so the rename stays on one filesystem and is therefore
+/// atomic), then renames it over `path`. A crash mid-write can only ever leave
+/// the stale `path` or the temp file — never a truncated `path`.
+pub fn atomic_write_json<T: Serialize>(path: &Path, value: &T) -> anyhow::Result<()> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).with_context(|| format!("creating dir {}", dir.display()))?;
+    }
+    let json = serde_json::to_string_pretty(value).context("serialising JSON")?;
+    // Temp file in the SAME directory so the rename is atomic (same filesystem).
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, json.as_bytes())
+        .with_context(|| format!("writing temp file {}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("atomically replacing {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Sample {
+        name: String,
+        n: u32,
+    }
+
+    #[test]
+    fn writes_and_creates_parent_dir() {
+        let dir =
+            std::env::temp_dir().join(format!("meridian-fs-utils-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        // Nested path whose parent does not exist yet.
+        let path = dir.join("nested").join("sample.json");
+
+        let value = Sample {
+            name: "meridian".into(),
+            n: 42,
+        };
+        atomic_write_json(&path, &value).unwrap();
+
+        let round: Sample = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(round, value);
+        // No temp file left behind.
+        assert!(!path.with_extension("json.tmp").exists());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn overwrites_existing_atomically() {
+        let dir = std::env::temp_dir().join(format!(
+            "meridian-fs-utils-test-overwrite-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("sample.json");
+
+        atomic_write_json(
+            &path,
+            &Sample {
+                name: "a".into(),
+                n: 1,
+            },
+        )
+        .unwrap();
+        atomic_write_json(
+            &path,
+            &Sample {
+                name: "b".into(),
+                n: 2,
+            },
+        )
+        .unwrap();
+
+        let round: Sample = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            round,
+            Sample {
+                name: "b".into(),
+                n: 2
+            }
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/meridian-core/src/lib.rs
+++ b/meridian-core/src/lib.rs
@@ -28,6 +28,10 @@ mod db;
 mod readers;
 mod util;
 
+/// Small crash-safe filesystem helpers (atomic JSON write) shared by the
+/// daemon, the app config layer, and the tray.
+pub mod fs_utils;
+
 // ── Public config module (kept top-level; daemon re-exports it) ──────────────
 /// Runtime settings (settings.json) — shared by the daemon (re-exported) and the app.
 pub mod settings;

--- a/meridian-core/src/settings.rs
+++ b/meridian-core/src/settings.rs
@@ -242,17 +242,8 @@ pub fn read_settings_value() -> Value {
 /// practice). Creates the parent dir on first write.
 pub fn write_settings_value(settings: &Value) -> anyhow::Result<()> {
     let path = settings_json_path();
-    if let Some(dir) = path.parent() {
-        std::fs::create_dir_all(dir)
-            .with_context(|| format!("creating settings dir {}", dir.display()))?;
-    }
-    let json = serde_json::to_string_pretty(settings).context("serialising settings")?;
-    // Temp file in the SAME directory so the rename is atomic (same filesystem).
-    let tmp = path.with_extension("json.tmp");
-    std::fs::write(&tmp, json.as_bytes())
-        .with_context(|| format!("writing temp settings {}", tmp.display()))?;
-    std::fs::rename(&tmp, &path)
-        .with_context(|| format!("atomically replacing {}", path.display()))?;
+    crate::fs_utils::atomic_write_json(&path, settings)
+        .with_context(|| format!("writing settings {}", path.display()))?;
     tracing::info!(path = %path.display(), "settings.json written");
     Ok(())
 }

--- a/packages/meridian-design-system/.design-sync/previews/TimelineCard.tsx
+++ b/packages/meridian-design-system/.design-sync/previews/TimelineCard.tsx
@@ -15,7 +15,7 @@ const proposal = {
   id: 2, task_key: 'MER-NEW-1', task_title: 'Add retry with backoff to hf-proxy fetch', task_url: null,
   provider: 'jira', window_start: '2026-07-09T10:00:00Z', window_end: '2026-07-09T11:00:00Z',
   state: 'proposed', confidence: 0.71, coverage: 0.55, time_spent_seconds: 1800,
-  summary: 'Session matched no existing ticket — proposing a new one from the work observed.',
+  summary: 'Session matched no existing ticket - proposing a new one from the work observed.',
   bullets: [], next_steps: ['Confirm scope with the team'], risk_flags: [], reasoning: 'Keyword match on "hf-proxy" and "retry" across 3 sessions.',
   posted_worklog_id: null, last_post_error: null, edited: false, is_proposed: true, issue_type: 'Task',
 }
@@ -25,7 +25,7 @@ const rejected = {
   provider: 'jira', window_start: '2026-07-09T09:00:00Z', window_end: '2026-07-09T09:30:00Z',
   state: 'dismissed', confidence: 0.4, coverage: 0.3, time_spent_seconds: 900,
   summary: 'Low-confidence match, dismissed by reviewer.',
-  bullets: [], next_steps: [], risk_flags: [], reasoning: 'Weak signal — window titles mostly idle.',
+  bullets: [], next_steps: [], risk_flags: [], reasoning: 'Weak signal - window titles mostly idle.',
   posted_worklog_id: null, last_post_error: null, edited: false, issue_type: 'Task',
 }
 

--- a/src/intelligence/providers/github/mod.rs
+++ b/src/intelligence/providers/github/mod.rs
@@ -239,20 +239,17 @@ pub async fn refresh_if_stale(
         tracing::warn!(
             "partial github fetch — skipping prune to preserve tasks from failed project(s)"
         );
-    } else if !keys.is_empty() {
+    } else {
+        // `prune` is safe for an empty `keys` slice: it emits `NOT IN ()`
+        // (always true in modern SQLite) so it full-clears, and crucially it
+        // deletes dependent `pm_task_embeddings` rows BEFORE `pm_tasks`. The old
+        // empty-keys fallback deleted `pm_tasks` directly and hit the
+        // `pm_task_embeddings.task_key` foreign key, failing the full-clear.
         match prune(pool, &keys).await {
             Ok(0) => {}
             Ok(p) => tracing::info!(pruned_count = p, "pruned stale github tasks"),
             Err(e) => tracing::warn!(error = %e, "github prune failed"),
         }
-    } else if let Err(e) = sqlx::query(
-        "DELETE FROM pm_tasks WHERE provider = 'github' \
-         AND task_key NOT IN (SELECT DISTINCT task_key FROM pm_worklogs)",
-    )
-    .execute(pool)
-    .await
-    {
-        tracing::warn!(error = %e, "github full-clear failed");
     }
 
     tracing::info!(upserted_count = keys.len(), "github tasks refreshed");

--- a/src/intelligence/providers/linear/mod.rs
+++ b/src/intelligence/providers/linear/mod.rs
@@ -444,23 +444,16 @@ pub async fn refresh_if_stale(
             // Only prune when the response was not truncated — otherwise tasks
             // beyond the first page would be wrongly deleted.
             if raw_count < MAX_RESULTS {
-                if !kept.is_empty() {
-                    match prune(pool, &kept).await {
-                        Ok(0) => {}
-                        Ok(p) => tracing::info!(pruned_count = p, "pruned stale linear tasks"),
-                        Err(e) => tracing::warn!(error = %e, "linear prune failed"),
-                    }
-                } else {
-                    // No live tasks at all → delete every linear row without worklog history.
-                    if let Err(e) = sqlx::query(
-                        "DELETE FROM pm_tasks WHERE provider = 'linear' \
-                         AND task_key NOT IN (SELECT DISTINCT task_key FROM pm_worklogs)",
-                    )
-                    .execute(pool)
-                    .await
-                    {
-                        tracing::warn!(error = %e, "linear full-clear failed");
-                    }
+                // `prune` is safe for an empty `kept` slice (no live tasks): it
+                // emits `NOT IN ()` (always true in modern SQLite) so it
+                // full-clears, and deletes dependent `pm_task_embeddings` rows
+                // BEFORE `pm_tasks`. The old empty-keys fallback deleted
+                // `pm_tasks` directly and hit the `pm_task_embeddings.task_key`
+                // foreign key, failing the full-clear.
+                match prune(pool, &kept).await {
+                    Ok(0) => {}
+                    Ok(p) => tracing::info!(pruned_count = p, "pruned stale linear tasks"),
+                    Err(e) => tracing::warn!(error = %e, "linear prune failed"),
                 }
             }
             tracing::info!(upserted_count = n, "linear tasks refreshed");

--- a/src/pm_worklog/create.rs
+++ b/src/pm_worklog/create.rs
@@ -137,7 +137,12 @@ async fn jira_create(
         .first()
         .context("Jira create needs a project key (none configured)")?;
     let ctx = jira_resolve(jira).await.context("resolving Jira auth")?;
-    let client = reqwest::Client::new();
+    // Bound the up-to-3 sequential calls (type check, self-assign, create) so a
+    // slow/unresponsive tracker can't hang the approved-proposal sweep.
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
+        .context("building Jira create HTTP client")?;
 
     let wanted = norm_issue_type(issue_type);
     let has_bug = wanted != "Bug" || jira_has_issue_type(&ctx, &client, project, "Bug").await?;
@@ -358,7 +363,12 @@ async fn azure_create(
         "Basic {}",
         base64::engine::general_purpose::STANDARD.encode(format!(":{}", cfg.pat).as_bytes())
     );
-    let client = reqwest::Client::new();
+    // Bound the up-to-3 sequential calls so a slow/unresponsive tracker can't
+    // hang the approved-proposal sweep.
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
+        .context("building Azure DevOps create HTTP client")?;
 
     let wanted = norm_issue_type(issue_type);
     let has_bug = wanted != "Bug" || azure_has_work_item_type(cfg, &client, &auth, "Bug").await?;

--- a/src/pm_worklog/post.rs
+++ b/src/pm_worklog/post.rs
@@ -25,7 +25,7 @@
 // Jira's per-issue worklog cap), in which case it's failed terminally instead
 // so it doesn't retry-spam the same doomed post forever.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use sqlx::SqlitePool;
 use tokio::sync::watch;
 
@@ -81,7 +81,9 @@ pub async fn post_approved(
                     pm_worklog_id = w.id, task = %w.task_key, provider = %w.provider, error = %e,
                     "approved worklog post failed permanently — will not retry"
                 );
-                db::fail_worklog(pool, w.id, &format!("{e:#}")).await?;
+                db::fail_worklog(pool, w.id, &format!("{e:#}"))
+                    .await
+                    .context("marking worklog failed permanently")?;
             }
             Err(e) => {
                 summary.failed += 1;
@@ -89,7 +91,9 @@ pub async fn post_approved(
                     pm_worklog_id = w.id, task = %w.task_key, provider = %w.provider, error = %e,
                     "approved worklog post failed — left approved for retry"
                 );
-                db::mark_post_failed(pool, w.id, &format!("{e:#}")).await?;
+                db::mark_post_failed(pool, w.id, &format!("{e:#}"))
+                    .await
+                    .context("marking worklog post failed for retry")?;
             }
         }
     }

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -21,7 +21,9 @@
 //!   downloaded separately for another tool).
 //! - `--purge` is shorthand for all three, and additionally removes `~/.meridian`
 //!   as a single `rm -rf` (rather than the itemized list) so nothing new added to
-//!   that directory since is left behind.
+//!   that directory since is left behind. The full `rm -rf` fires on `--purge`
+//!   **only** — not on `--remove-data --remove-runtime`, which stay scoped to the
+//!   itemized lists the plan shows.
 //!
 //! `--json` emits a single machine-readable JSON line instead of the human plan/
 //! result text — the tray's uninstall-wizard commands parse this to drive its
@@ -33,6 +35,8 @@
 //! invoked by `tray/src-tauri/src/commands/uninstall.rs` (the in-app wizard).
 //!
 //! # Related
+//! - [`json`] — the `--json` reporting path (`JsonReport` + `run_json`), split
+//!   out of this file to keep it under the 500-line guideline.
 //! - `tray/src-tauri/src/backend_install.rs` — the install side this undoes
 //!   (same agent labels + staged paths; small intentional duplication across the
 //!   crate boundary — the daemon crate can't depend on the tray).
@@ -40,6 +44,10 @@
 //!   commands, both of which shell out to this binary.
 //! - `scripts/uninstall-*.sh` / `scripts/meridian-cli.sh` — the per-service shell
 //!   uninstallers (npm/dev path); `MODEL_CATALOG` mirrors the bash allowlist.
+
+mod json;
+#[cfg(test)]
+mod tests;
 
 use serde::Serialize;
 use std::path::{Path, PathBuf};
@@ -96,143 +104,172 @@ impl Item {
     }
 }
 
-/// The `--json` output shape — a full plan (dry-run) or a full result
-/// (executed), depending on `executed`. The tray's uninstall commands are the
-/// only consumers; keep this contract in sync with
-/// `tray/src-tauri/src/commands/uninstall.rs`.
-#[derive(Debug, Serialize, Default)]
-struct JsonReport {
-    dry_run: bool,
-    executed: bool,
+/// The scope + mode flags parsed from `argv`. Grouped into one struct so the
+/// plan builder and both output paths take a single value rather than a long
+/// argument list (Clippy's seven-argument limit).
+#[derive(Debug, Clone, Copy)]
+struct Flags {
+    /// `--purge`: remove everything, then `rm -rf ~/.meridian` wholesale.
+    purge: bool,
     remove_data: bool,
     remove_runtime: bool,
     remove_models: bool,
-    agents: Vec<Item>,
-    staged_binaries: Vec<Item>,
-    data: Vec<Item>,
-    runtime: Vec<Item>,
-    models: Vec<Item>,
-    /// Paths successfully removed (only populated when `executed`).
-    removed: Vec<String>,
-    /// Non-fatal removal failures, `"<path>: <error>"` (only when `executed`).
-    errors: Vec<String>,
+    dry_run: bool,
+    yes: bool,
+    json: bool,
 }
 
-/// Run `meridian uninstall`. User-facing CLI (prints a plan, confirms on a TTY,
-/// unless `--json` is passed — see the module doc for the full flag list).
-pub fn run(args: &[String]) {
-    let purge = args.iter().any(|a| a == "--purge");
-    let remove_data = purge || args.iter().any(|a| a == "--remove-data");
-    let remove_runtime = purge || args.iter().any(|a| a == "--remove-runtime");
-    let remove_models = purge || args.iter().any(|a| a == "--remove-models");
-    let dry_run = args.iter().any(|a| a == "--dry-run");
-    let yes = args.iter().any(|a| a == "--yes" || a == "-y");
-    let json = args.iter().any(|a| a == "--json");
-
-    let home = match std::env::var("HOME") {
-        Ok(h) => PathBuf::from(h),
-        Err(_) => {
-            if json {
-                println!(r#"{{"error":"HOME not set — cannot locate the install"}}"#);
-            } else {
-                eprintln!("✗ HOME not set — cannot locate the install");
-            }
-            std::process::exit(1);
+impl Flags {
+    fn from_args(args: &[String]) -> Self {
+        let purge = args.iter().any(|a| a == "--purge");
+        Self {
+            purge,
+            remove_data: purge || args.iter().any(|a| a == "--remove-data"),
+            remove_runtime: purge || args.iter().any(|a| a == "--remove-runtime"),
+            remove_models: purge || args.iter().any(|a| a == "--remove-models"),
+            dry_run: args.iter().any(|a| a == "--dry-run"),
+            yes: args.iter().any(|a| a == "--yes" || a == "-y"),
+            json: args.iter().any(|a| a == "--json"),
         }
-    };
-    let meridian_dir = home.join(".meridian");
+    }
+}
 
-    let agents = meridiona_agent_plists(&home.join("Library/LaunchAgents"));
-    let staged_binaries: Vec<PathBuf> = [
-        // Staged native binaries (DMG path).
-        ".meridian/bin/meridian",
-        ".meridian/bin/meridian-a11y-helper",
-        ".meridian/backend-version",
-        // CLI on PATH — the DMG symlink and the npm node-wrapper both land here;
-        // "remove the CLI" (SETUP.md) means clearing whichever is present.
-        ".local/bin/meridian",
-        ".local/bin/meridian-daemon",
-    ]
-    .iter()
-    .map(|r| home.join(r))
-    // symlink_metadata so a dangling symlink (target already gone) still counts.
-    .filter(|p| p.symlink_metadata().is_ok())
-    .collect();
+/// A fully-computed uninstall plan: the resolved paths for each scope plus the
+/// flags that produced them. Built once in [`run`], then consumed by either the
+/// human-text path or [`json::run_json`], so both branches see identical data.
+struct Plan {
+    meridian_dir: PathBuf,
+    /// `(label, plist path)` for each Meridian launchd agent found.
+    agents: Vec<(String, PathBuf)>,
+    staged_binaries: Vec<PathBuf>,
+    data: Vec<PathBuf>,
+    runtime: Vec<PathBuf>,
+    models: Vec<PathBuf>,
+    flags: Flags,
+}
 
-    let data = if remove_data {
-        data_items(&meridian_dir)
-    } else {
-        Vec::new()
-    };
-    let runtime = if remove_runtime {
-        runtime_items(&meridian_dir)
-    } else {
-        Vec::new()
-    };
-    let models = if remove_models {
-        model_items(&home)
-    } else {
-        Vec::new()
-    };
+impl Plan {
+    /// Scan the filesystem and build the plan for the given `home` + `flags`.
+    fn build(home: PathBuf, flags: Flags) -> Self {
+        let meridian_dir = home.join(".meridian");
 
-    let nothing_to_do = agents.is_empty()
-        && staged_binaries.is_empty()
-        && data.is_empty()
-        && runtime.is_empty()
-        && models.is_empty();
+        let agents = meridiona_agent_plists(&home.join("Library/LaunchAgents"));
+        let staged_binaries: Vec<PathBuf> = [
+            // Staged native binaries (DMG path).
+            ".meridian/bin/meridian",
+            ".meridian/bin/meridian-a11y-helper",
+            ".meridian/backend-version",
+            // CLI on PATH — the DMG symlink and the npm node-wrapper both land here;
+            // "remove the CLI" (SETUP.md) means clearing whichever is present.
+            ".local/bin/meridian",
+            ".local/bin/meridian-daemon",
+        ]
+        .iter()
+        .map(|r| home.join(r))
+        // symlink_metadata so a dangling symlink (target already gone) still counts.
+        .filter(|p| p.symlink_metadata().is_ok())
+        .collect();
 
-    if json {
-        run_json(
-            &home,
-            &meridian_dir,
+        let data = if flags.remove_data {
+            data_items(&meridian_dir)
+        } else {
+            Vec::new()
+        };
+        let runtime = if flags.remove_runtime {
+            runtime_items(&meridian_dir)
+        } else {
+            Vec::new()
+        };
+        let models = if flags.remove_models {
+            model_items(&home)
+        } else {
+            Vec::new()
+        };
+
+        Self {
+            meridian_dir,
             agents,
             staged_binaries,
             data,
             runtime,
             models,
-            purge,
-            remove_data,
-            remove_runtime,
-            remove_models,
-            dry_run,
-            yes,
-        );
+            flags,
+        }
+    }
+
+    /// True when the scan found no installed artifacts and no in-scope data.
+    fn nothing_to_do(&self) -> bool {
+        self.agents.is_empty()
+            && self.staged_binaries.is_empty()
+            && self.data.is_empty()
+            && self.runtime.is_empty()
+            && self.models.is_empty()
+    }
+}
+
+/// Run `meridian uninstall`. User-facing CLI (prints a plan, confirms on a TTY,
+/// unless `--json` is passed — see the module doc for the full flag list).
+pub fn run(args: &[String]) {
+    let flags = Flags::from_args(args);
+
+    let home = match std::env::var("HOME") {
+        Ok(h) => PathBuf::from(h),
+        Err(_) => {
+            if flags.json {
+                println!(r#"{{"error":"HOME not set - cannot locate the install"}}"#);
+            } else {
+                eprintln!("✗ HOME not set - cannot locate the install");
+            }
+            std::process::exit(1);
+        }
+    };
+
+    let plan = Plan::build(home, flags);
+
+    if flags.json {
+        json::run_json(&plan);
         return;
     }
 
-    // Print the plan (human text).
-    println!("meridian uninstall — plan:");
-    for (label, _) in &agents {
+    run_human(&plan);
+}
+
+/// The human-text path: print the plan, confirm on a TTY, then execute.
+fn run_human(plan: &Plan) {
+    let flags = plan.flags;
+
+    println!("meridian uninstall - plan:");
+    for (label, _) in &plan.agents {
         println!("  • stop + remove launchd agent  {label}");
     }
-    for f in &staged_binaries {
+    for f in &plan.staged_binaries {
         println!("  • remove  {}", f.display());
     }
-    if remove_data {
+    if flags.remove_data {
         println!("  • remove Meridian data:");
-        for f in &data {
+        for f in &plan.data {
             println!("      {}", f.display());
         }
     } else {
         println!(
             "  keeping your data: {0}/.env, meridian.db, oauth/, settings.json, logs/ (pass --remove-data or --purge to remove)",
-            meridian_dir.display()
+            plan.meridian_dir.display()
         );
     }
-    if remove_runtime {
+    if flags.remove_runtime {
         println!("  • remove the Python/MLX runtime:");
-        for f in &runtime {
+        for f in &plan.runtime {
             println!("      {}", f.display());
         }
     } else {
         println!(
             "  keeping the downloaded MLX runtime: {0}/runtime/ (pass --remove-runtime or --purge to remove)",
-            meridian_dir.display()
+            plan.meridian_dir.display()
         );
     }
-    if remove_models {
+    if flags.remove_models {
         println!("  • remove downloaded MLX models from the HuggingFace cache:");
-        for f in &models {
+        for f in &plan.models {
             println!("      {}", f.display());
         }
     } else {
@@ -241,139 +278,63 @@ pub fn run(args: &[String]) {
         );
     }
 
-    if nothing_to_do {
-        println!("\nNothing to remove — Meridian is not installed here.");
+    if plan.nothing_to_do() {
+        println!("\nNothing to remove - Meridian is not installed here.");
         return;
     }
-    if dry_run {
-        println!("\n(dry run — nothing changed)");
+    if flags.dry_run {
+        println!("\n(dry run - nothing changed)");
         return;
     }
-    if !yes && !confirm("\nProceed?") {
-        println!("Aborted — nothing changed.");
+    if !flags.yes && !confirm("\nProceed?") {
+        println!("Aborted - nothing changed.");
         return;
     }
 
     // Execute.
     let uid = uid_str();
-    for (label, plist) in &agents {
+    for (label, plist) in &plan.agents {
         let _ = std::process::Command::new("launchctl")
             .args(["bootout", &format!("gui/{uid}/{label}")])
             .status();
         let _ = std::fs::remove_file(plist);
         println!("✓ removed agent  {label}");
     }
-    for f in &staged_binaries {
+    for f in &plan.staged_binaries {
         remove_path_reporting(f);
     }
-    for f in &data {
+    for f in &plan.data {
         remove_path_reporting(f);
     }
-    for f in &runtime {
+    for f in &plan.runtime {
         remove_path_reporting(f);
     }
-    for f in &models {
+    for f in &plan.models {
         remove_path_reporting(f);
     }
     // `--purge` also nukes anything else left under ~/.meridian that the
     // itemized lists above didn't name, so a future addition to that directory
-    // is never orphaned.
-    if remove_data && remove_runtime && meridian_dir.is_dir() {
-        match std::fs::remove_dir_all(&meridian_dir) {
-            Ok(()) => println!("✓ purged  {}", meridian_dir.display()),
+    // is never orphaned. This wholesale `rm -rf` fires on `--purge` ONLY — the
+    // itemized `--remove-data`/`--remove-runtime` scopes must not silently take
+    // out the rest of ~/.meridian (e.g. an unrelated sibling file the plan
+    // never listed).
+    if flags.purge && plan.meridian_dir.is_dir() {
+        match std::fs::remove_dir_all(&plan.meridian_dir) {
+            Ok(()) => println!("✓ purged  {}", plan.meridian_dir.display()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => eprintln!("⚠ could not purge {}: {e}", meridian_dir.display()),
+            Err(e) => eprintln!("⚠ could not purge {}: {e}", plan.meridian_dir.display()),
         }
     }
 
     println!(
         "\nDone. If the Meridian menubar app is still running, quit it (or drag \
-         Meridian.app to the Trash) — the MLX server is its child and exits with it."
+         Meridian.app to the Trash) - the MLX server is its child and exits with it."
     );
     println!(
         "\nNote: deleting or uninstalling does NOT revoke the Accessibility / \
-         Screen Recording / Input Monitoring grants in System Settings — macOS \
+         Screen Recording / Input Monitoring grants in System Settings - macOS \
          keeps that entry until you remove it there yourself."
     );
-}
-
-/// The `--json` path: same computation as the human branch, emitted as one
-/// JSON line, no prompts (a missing `--yes` under `--json` is treated as a
-/// refusal to execute non-interactively — callers must pass both).
-#[allow(clippy::too_many_arguments)]
-fn run_json(
-    home: &Path,
-    meridian_dir: &Path,
-    agents: Vec<(String, PathBuf)>,
-    staged_binaries: Vec<PathBuf>,
-    data: Vec<PathBuf>,
-    runtime: Vec<PathBuf>,
-    models: Vec<PathBuf>,
-    _purge: bool,
-    remove_data: bool,
-    remove_runtime: bool,
-    remove_models: bool,
-    dry_run: bool,
-    yes: bool,
-) {
-    let mut report = JsonReport {
-        dry_run,
-        executed: false,
-        remove_data,
-        remove_runtime,
-        remove_models,
-        agents: agents
-            .iter()
-            .map(|(label, path)| Item::new(label.clone(), path))
-            .collect(),
-        staged_binaries: staged_binaries.iter().map(|p| Item::from_path(p)).collect(),
-        data: data.iter().map(|p| Item::from_path(p)).collect(),
-        runtime: runtime.iter().map(|p| Item::from_path(p)).collect(),
-        models: models.iter().map(|p| Item::from_path(p)).collect(),
-        removed: Vec::new(),
-        errors: Vec::new(),
-    };
-
-    if dry_run || !yes {
-        println!("{}", serde_json::to_string(&report).unwrap_or_default());
-        return;
-    }
-
-    report.executed = true;
-    let uid = uid_str();
-    for (label, plist) in &agents {
-        let _ = std::process::Command::new("launchctl")
-            .args(["bootout", &format!("gui/{uid}/{label}")])
-            .status();
-        match std::fs::remove_file(plist) {
-            Ok(()) => report.removed.push(plist.display().to_string()),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => report.errors.push(format!("{}: {e}", plist.display())),
-        }
-    }
-    for f in staged_binaries
-        .iter()
-        .chain(&data)
-        .chain(&runtime)
-        .chain(&models)
-    {
-        match remove_path(f) {
-            Ok(()) => report.removed.push(f.display().to_string()),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => report.errors.push(format!("{}: {e}", f.display())),
-        }
-    }
-    if remove_data && remove_runtime && meridian_dir.is_dir() {
-        match std::fs::remove_dir_all(meridian_dir) {
-            Ok(()) => report.removed.push(meridian_dir.display().to_string()),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => report
-                .errors
-                .push(format!("{}: {e}", meridian_dir.display())),
-        }
-    }
-    let _ = home; // reserved for future report fields (e.g. echoing HOME)
-    println!("{}", serde_json::to_string(&report).unwrap_or_default());
 }
 
 /// `~/.meridian` user-data items removed by `--remove-data`/`--purge`.
@@ -479,7 +440,7 @@ fn meridiona_label(path: &Path) -> Option<String> {
 fn confirm(prompt: &str) -> bool {
     use std::io::{BufRead, IsTerminal, Write};
     if !std::io::stdin().is_terminal() {
-        eprintln!("{prompt} refusing without a TTY — pass --yes to confirm.");
+        eprintln!("{prompt} refusing without a TTY - pass --yes to confirm.");
         return false;
     }
     print!("{prompt} [y/N]: ");
@@ -500,143 +461,4 @@ fn uid_str() -> String {
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
         .unwrap_or_else(|| "501".to_string())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn label_matches_only_meridiona_plists() {
-        assert_eq!(
-            meridiona_label(Path::new("/x/com.meridiona.daemon.plist")).as_deref(),
-            Some("com.meridiona.daemon")
-        );
-        assert_eq!(
-            meridiona_label(Path::new("/x/com.meridiona.a11y-helper.plist")).as_deref(),
-            Some("com.meridiona.a11y-helper")
-        );
-        assert_eq!(meridiona_label(Path::new("/x/com.apple.thing.plist")), None);
-        assert_eq!(meridiona_label(Path::new("/x/com.meridiona.daemon")), None); // not a plist
-        assert_eq!(meridiona_label(Path::new("/x/notes.txt")), None);
-    }
-
-    #[test]
-    fn enumerates_only_meridiona_agents() {
-        let dir = std::env::temp_dir().join("meridian-uninstall-test-agents");
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        for f in [
-            "com.meridiona.daemon.plist",
-            "com.meridiona.a11y-helper.plist",
-            "com.apple.something.plist",
-            "random.txt",
-        ] {
-            std::fs::write(dir.join(f), "x").unwrap();
-        }
-        let found: Vec<String> = meridiona_agent_plists(&dir)
-            .into_iter()
-            .map(|(l, _)| l)
-            .collect();
-        assert_eq!(
-            found,
-            vec![
-                "com.meridiona.a11y-helper".to_string(),
-                "com.meridiona.daemon".to_string()
-            ]
-        );
-        std::fs::remove_dir_all(&dir).ok();
-    }
-
-    #[test]
-    fn missing_launch_agents_dir_is_empty() {
-        let dir = std::env::temp_dir().join("meridian-uninstall-test-nope-xyz");
-        let _ = std::fs::remove_dir_all(&dir);
-        assert!(meridiona_agent_plists(&dir).is_empty());
-    }
-
-    /// `data_items`/`runtime_items` must only list entries that actually exist
-    /// (a wizard checkbox should never advertise removing nothing), and must
-    /// stay disjoint from each other so the two checkboxes don't double-count.
-    #[test]
-    fn data_and_runtime_items_only_list_existing_entries_and_stay_disjoint() {
-        let dir = std::env::temp_dir().join(format!(
-            "meridian-uninstall-test-items-{}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join(".env"), "x").unwrap();
-        std::fs::write(dir.join("meridian.db"), "x").unwrap();
-        std::fs::create_dir_all(dir.join("runtime")).unwrap();
-        // "settings.json" and "mlx-server-venv" deliberately absent.
-
-        let data = data_items(&dir);
-        let runtime = runtime_items(&dir);
-
-        assert!(data.contains(&dir.join(".env")));
-        assert!(data.contains(&dir.join("meridian.db")));
-        assert!(!data.iter().any(|p| p.ends_with("settings.json")));
-        assert!(runtime.contains(&dir.join("runtime")));
-        assert!(!runtime.iter().any(|p| p.ends_with("mlx-server-venv")));
-
-        for p in &data {
-            assert!(
-                !runtime.contains(p),
-                "data and runtime item lists must be disjoint: {p:?}"
-            );
-        }
-
-        std::fs::remove_dir_all(&dir).ok();
-    }
-
-    /// `model_items` only returns catalog entries that exist on disk, and never
-    /// invents a path for a model that isn't in [`MODEL_CATALOG`].
-    #[test]
-    fn model_items_filters_to_existing_catalog_dirs() {
-        let home = std::env::temp_dir().join(format!(
-            "meridian-uninstall-test-models-{}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&home);
-        let hub = home.join(".cache/huggingface/hub");
-        std::fs::create_dir_all(&hub).unwrap();
-        std::fs::create_dir_all(hub.join("models--mlx-community--Qwen3.5-2B-OptiQ-4bit")).unwrap();
-        // A non-Meridian model the user downloaded for another tool — must be ignored.
-        std::fs::create_dir_all(hub.join("models--some-other-org--unrelated-model")).unwrap();
-
-        let found = model_items(&home);
-        assert_eq!(found.len(), 1);
-        assert!(found[0].ends_with("models--mlx-community--Qwen3.5-2B-OptiQ-4bit"));
-
-        std::fs::remove_dir_all(&home).ok();
-    }
-
-    #[test]
-    fn remove_path_handles_files_and_directories() {
-        let dir = std::env::temp_dir().join(format!(
-            "meridian-uninstall-test-remove-{}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-
-        let file = dir.join("a-file");
-        std::fs::write(&file, "x").unwrap();
-        remove_path(&file).unwrap();
-        assert!(!file.exists());
-
-        let subdir = dir.join("a-dir");
-        std::fs::create_dir_all(subdir.join("nested")).unwrap();
-        remove_path(&subdir).unwrap();
-        assert!(!subdir.exists());
-
-        // A path that doesn't exist reports NotFound rather than panicking.
-        assert_eq!(
-            remove_path(&dir.join("missing")).unwrap_err().kind(),
-            std::io::ErrorKind::NotFound
-        );
-
-        std::fs::remove_dir_all(&dir).ok();
-    }
 }

--- a/src/uninstall/json.rs
+++ b/src/uninstall/json.rs
@@ -1,0 +1,114 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! The `--json` reporting path for `meridian uninstall`, split out of
+//! [`super`] to keep that file under the 500-line guideline.
+//!
+//! Emits a single machine-readable JSON line — a full plan (dry-run) or a full
+//! result (executed) — instead of the human plan/result text. The tray's
+//! uninstall-wizard commands parse this to drive its checkboxes and show a real
+//! result, rather than re-implementing the scan.
+//!
+//! # Who calls this
+//! [`super::run`], when `--json` is present.
+//!
+//! # Related
+//! - [`super`] — the human-text path + the shared [`super::Plan`] this consumes.
+//! - `tray/src-tauri/src/commands/uninstall.rs` — the only consumer of this
+//!   contract; keep [`JsonReport`]'s shape in sync with it.
+
+use super::{remove_path, uid_str, Item, Plan};
+use serde::Serialize;
+
+/// The `--json` output shape — a full plan (dry-run) or a full result
+/// (executed), depending on `executed`. The tray's uninstall commands are the
+/// only consumers; keep this contract in sync with
+/// `tray/src-tauri/src/commands/uninstall.rs`.
+#[derive(Debug, Serialize, Default)]
+struct JsonReport {
+    dry_run: bool,
+    executed: bool,
+    remove_data: bool,
+    remove_runtime: bool,
+    remove_models: bool,
+    agents: Vec<Item>,
+    staged_binaries: Vec<Item>,
+    data: Vec<Item>,
+    runtime: Vec<Item>,
+    models: Vec<Item>,
+    /// Paths successfully removed (only populated when `executed`).
+    removed: Vec<String>,
+    /// Non-fatal removal failures, `"<path>: <error>"` (only when `executed`).
+    errors: Vec<String>,
+}
+
+/// The `--json` path: same computation as the human branch, emitted as one
+/// JSON line, no prompts (a missing `--yes` under `--json` is treated as a
+/// refusal to execute non-interactively — callers must pass both).
+pub(super) fn run_json(plan: &Plan) {
+    let flags = plan.flags;
+    let mut report = JsonReport {
+        dry_run: flags.dry_run,
+        executed: false,
+        remove_data: flags.remove_data,
+        remove_runtime: flags.remove_runtime,
+        remove_models: flags.remove_models,
+        agents: plan
+            .agents
+            .iter()
+            .map(|(label, path)| Item::new(label.clone(), path))
+            .collect(),
+        staged_binaries: plan
+            .staged_binaries
+            .iter()
+            .map(|p| Item::from_path(p))
+            .collect(),
+        data: plan.data.iter().map(|p| Item::from_path(p)).collect(),
+        runtime: plan.runtime.iter().map(|p| Item::from_path(p)).collect(),
+        models: plan.models.iter().map(|p| Item::from_path(p)).collect(),
+        removed: Vec::new(),
+        errors: Vec::new(),
+    };
+
+    if flags.dry_run || !flags.yes {
+        println!("{}", serde_json::to_string(&report).unwrap_or_default());
+        return;
+    }
+
+    report.executed = true;
+    let uid = uid_str();
+    for (label, plist) in &plan.agents {
+        let _ = std::process::Command::new("launchctl")
+            .args(["bootout", &format!("gui/{uid}/{label}")])
+            .status();
+        match std::fs::remove_file(plist) {
+            Ok(()) => report.removed.push(plist.display().to_string()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => report.errors.push(format!("{}: {e}", plist.display())),
+        }
+    }
+    for f in plan
+        .staged_binaries
+        .iter()
+        .chain(&plan.data)
+        .chain(&plan.runtime)
+        .chain(&plan.models)
+    {
+        match remove_path(f) {
+            Ok(()) => report.removed.push(f.display().to_string()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => report.errors.push(format!("{}: {e}", f.display())),
+        }
+    }
+    // `--purge` only: nuke anything left under ~/.meridian the itemized lists
+    // above didn't name. Mirrors the human path's `--purge`-only gate — see the
+    // note there; `--remove-data --remove-runtime` must NOT trigger this.
+    if flags.purge && plan.meridian_dir.is_dir() {
+        match std::fs::remove_dir_all(&plan.meridian_dir) {
+            Ok(()) => report.removed.push(plan.meridian_dir.display().to_string()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => report
+                .errors
+                .push(format!("{}: {e}", plan.meridian_dir.display())),
+        }
+    }
+    println!("{}", serde_json::to_string(&report).unwrap_or_default());
+}

--- a/src/uninstall/tests.rs
+++ b/src/uninstall/tests.rs
@@ -1,0 +1,164 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Unit tests for `meridian uninstall`, split out of [`super`] to keep that
+//! file under the 500-line guideline.
+
+use super::*;
+
+#[test]
+fn label_matches_only_meridiona_plists() {
+    assert_eq!(
+        meridiona_label(Path::new("/x/com.meridiona.daemon.plist")).as_deref(),
+        Some("com.meridiona.daemon")
+    );
+    assert_eq!(
+        meridiona_label(Path::new("/x/com.meridiona.a11y-helper.plist")).as_deref(),
+        Some("com.meridiona.a11y-helper")
+    );
+    assert_eq!(meridiona_label(Path::new("/x/com.apple.thing.plist")), None);
+    assert_eq!(meridiona_label(Path::new("/x/com.meridiona.daemon")), None); // not a plist
+    assert_eq!(meridiona_label(Path::new("/x/notes.txt")), None);
+}
+
+/// `--purge` widens all three scopes; `--remove-data --remove-runtime`
+/// (without `--purge`) must NOT set `purge` — that is the guard behind the
+/// full `rm -rf ~/.meridian` step, which is scoped to `--purge` only.
+#[test]
+fn purge_flag_is_not_implied_by_remove_data_plus_remove_runtime() {
+    let s =
+        |args: &[&str]| Flags::from_args(&args.iter().map(|a| a.to_string()).collect::<Vec<_>>());
+
+    let purge = s(&["--purge"]);
+    assert!(purge.purge);
+    assert!(purge.remove_data && purge.remove_runtime && purge.remove_models);
+
+    let both = s(&["--remove-data", "--remove-runtime"]);
+    assert!(
+        !both.purge,
+        "--remove-data --remove-runtime must not imply --purge"
+    );
+    assert!(both.remove_data && both.remove_runtime);
+    assert!(!both.remove_models);
+
+    let neither = s(&["--dry-run"]);
+    assert!(!neither.purge);
+    assert!(!neither.remove_data && !neither.remove_runtime && !neither.remove_models);
+}
+
+#[test]
+fn enumerates_only_meridiona_agents() {
+    let dir = std::env::temp_dir().join("meridian-uninstall-test-agents");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    for f in [
+        "com.meridiona.daemon.plist",
+        "com.meridiona.a11y-helper.plist",
+        "com.apple.something.plist",
+        "random.txt",
+    ] {
+        std::fs::write(dir.join(f), "x").unwrap();
+    }
+    let found: Vec<String> = meridiona_agent_plists(&dir)
+        .into_iter()
+        .map(|(l, _)| l)
+        .collect();
+    assert_eq!(
+        found,
+        vec![
+            "com.meridiona.a11y-helper".to_string(),
+            "com.meridiona.daemon".to_string()
+        ]
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn missing_launch_agents_dir_is_empty() {
+    let dir = std::env::temp_dir().join("meridian-uninstall-test-nope-xyz");
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(meridiona_agent_plists(&dir).is_empty());
+}
+
+/// `data_items`/`runtime_items` must only list entries that actually exist
+/// (a wizard checkbox should never advertise removing nothing), and must
+/// stay disjoint from each other so the two checkboxes don't double-count.
+#[test]
+fn data_and_runtime_items_only_list_existing_entries_and_stay_disjoint() {
+    let dir = std::env::temp_dir().join(format!(
+        "meridian-uninstall-test-items-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(".env"), "x").unwrap();
+    std::fs::write(dir.join("meridian.db"), "x").unwrap();
+    std::fs::create_dir_all(dir.join("runtime")).unwrap();
+    // "settings.json" and "mlx-server-venv" deliberately absent.
+
+    let data = data_items(&dir);
+    let runtime = runtime_items(&dir);
+
+    assert!(data.contains(&dir.join(".env")));
+    assert!(data.contains(&dir.join("meridian.db")));
+    assert!(!data.iter().any(|p| p.ends_with("settings.json")));
+    assert!(runtime.contains(&dir.join("runtime")));
+    assert!(!runtime.iter().any(|p| p.ends_with("mlx-server-venv")));
+
+    for p in &data {
+        assert!(
+            !runtime.contains(p),
+            "data and runtime item lists must be disjoint: {p:?}"
+        );
+    }
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// `model_items` only returns catalog entries that exist on disk, and never
+/// invents a path for a model that isn't in [`MODEL_CATALOG`].
+#[test]
+fn model_items_filters_to_existing_catalog_dirs() {
+    let home = std::env::temp_dir().join(format!(
+        "meridian-uninstall-test-models-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&home);
+    let hub = home.join(".cache/huggingface/hub");
+    std::fs::create_dir_all(&hub).unwrap();
+    std::fs::create_dir_all(hub.join("models--mlx-community--Qwen3.5-2B-OptiQ-4bit")).unwrap();
+    // A non-Meridian model the user downloaded for another tool — must be ignored.
+    std::fs::create_dir_all(hub.join("models--some-other-org--unrelated-model")).unwrap();
+
+    let found = model_items(&home);
+    assert_eq!(found.len(), 1);
+    assert!(found[0].ends_with("models--mlx-community--Qwen3.5-2B-OptiQ-4bit"));
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn remove_path_handles_files_and_directories() {
+    let dir = std::env::temp_dir().join(format!(
+        "meridian-uninstall-test-remove-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let file = dir.join("a-file");
+    std::fs::write(&file, "x").unwrap();
+    remove_path(&file).unwrap();
+    assert!(!file.exists());
+
+    let subdir = dir.join("a-dir");
+    std::fs::create_dir_all(subdir.join("nested")).unwrap();
+    remove_path(&subdir).unwrap();
+    assert!(!subdir.exists());
+
+    // A path that doesn't exist reports NotFound rather than panicking.
+    assert_eq!(
+        remove_path(&dir.join("missing")).unwrap_err().kind(),
+        std::io::ErrorKind::NotFound
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/tray/src-tauri/src/analytics.rs
+++ b/tray/src-tauri/src/analytics.rs
@@ -111,28 +111,12 @@ fn load_or_init_state(path: &std::path::Path) -> AnalyticsState {
     }
 }
 
-/// Crash-safely persist the state file (temp + rename), matching the pattern
-/// `meridian_core::settings::write_settings_value` uses.
+/// Crash-safely persist the state file via the shared atomic-write helper
+/// ([`meridian_core::fs_utils::atomic_write_json`]) — best-effort, logs on
+/// failure like the rest of this module.
 fn save_state(path: &std::path::Path, state: &AnalyticsState) {
-    let Some(dir) = path.parent() else { return };
-    if let Err(e) = std::fs::create_dir_all(dir) {
-        tracing::warn!(error = %e, "analytics: could not create state dir");
-        return;
-    }
-    let json = match serde_json::to_string_pretty(state) {
-        Ok(j) => j,
-        Err(e) => {
-            tracing::warn!(error = %e, "analytics: could not serialise state");
-            return;
-        }
-    };
-    let tmp = path.with_extension("json.tmp");
-    if let Err(e) = std::fs::write(&tmp, json.as_bytes()) {
-        tracing::warn!(error = %e, "analytics: could not write temp state file");
-        return;
-    }
-    if let Err(e) = std::fs::rename(&tmp, path) {
-        tracing::warn!(error = %e, "analytics: could not replace state file");
+    if let Err(e) = meridian_core::fs_utils::atomic_write_json(path, state) {
+        tracing::warn!(error = %e, "analytics: could not persist state file");
     }
 }
 

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -96,13 +96,13 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
 
     tracing::info!(hash = %bundled_hash, "backend_install: installing bundled backend");
     if let Err(e) = install(&backend, &home).await {
-        tracing::warn!(error = %e, "backend_install: install failed — will retry next launch");
+        tracing::error!(error = %e, "backend_install: install failed — will retry next launch");
         return;
     }
 
     // Persist the marker only on full success so a partial install retries.
     if let Err(e) = tokio::fs::write(&marker, &bundled_hash).await {
-        tracing::warn!(error = %e, "backend_install: could not write version marker");
+        tracing::error!(error = %e, "backend_install: could not write version marker");
     }
     tracing::info!("backend_install: backend installed");
 }

--- a/tray/src-tauri/src/commands/account.rs
+++ b/tray/src-tauri/src/commands/account.rs
@@ -105,30 +105,23 @@ fn account_path() -> Option<PathBuf> {
 /// so the person record picks up the email right away instead of waiting on
 /// the next scheduled `app_installed`/`daily_usage` capture.
 #[tauri::command]
-#[tracing::instrument(skip(app))]
+// skip `email` too: it's PII and must never land in a span field / log line.
+#[tracing::instrument(skip(app, email))]
 pub async fn save_account_email(app: tauri::AppHandle, email: String) -> Result<(), String> {
     let email = email.trim().to_string();
     if email.is_empty() || !email.contains('@') {
         return Err("save_account_email: not a valid email address".into());
     }
     let path = account_path().ok_or("save_account_email: HOME is not set")?;
-    let dir = path
-        .parent()
-        .ok_or("save_account_email: account path has no parent dir")?;
-    tokio::fs::create_dir_all(dir)
-        .await
-        .map_err(|e| format!("create ~/.meridian: {e}"))?;
-    let json = serde_json::to_string_pretty(&AccountState {
+    // Crash-safe write via the shared helper. It's sync, so run it on the
+    // blocking pool rather than stalling the async command's executor thread.
+    let state = AccountState {
         email: email.clone(),
-    })
-    .map_err(|e| format!("serialise account state: {e}"))?;
-    let tmp = path.with_extension("json.tmp");
-    tokio::fs::write(&tmp, json.as_bytes())
+    };
+    tokio::task::spawn_blocking(move || meridian_core::fs_utils::atomic_write_json(&path, &state))
         .await
-        .map_err(|e| format!("write temp account file: {e}"))?;
-    tokio::fs::rename(&tmp, &path)
-        .await
-        .map_err(|e| format!("replace account file: {e}"))?;
+        .map_err(|e| format!("join account write task: {e}"))?
+        .map_err(|e| format!("persist account file: {e:#}"))?;
     tracing::info!("account: email captured");
     crate::analytics::identify_signed_in_email(&app).await;
     Ok(())

--- a/tray/src-tauri/src/commands/uninstall.rs
+++ b/tray/src-tauri/src/commands/uninstall.rs
@@ -114,7 +114,7 @@ pub async fn get_uninstall_plan() -> UninstallPlan {
             }
         }
         Err(e) => {
-            tracing::warn!(error = %e, "get_uninstall_plan failed");
+            tracing::error!(error = %e, "get_uninstall_plan failed");
             UninstallPlan {
                 error: Some(e),
                 ..Default::default()
@@ -168,7 +168,7 @@ pub async fn execute_uninstall(
             })
         }
         Err(e) => {
-            tracing::warn!(error = %e, "execute_uninstall failed");
+            tracing::error!(error = %e, "execute_uninstall failed");
             Err(e)
         }
     }

--- a/tray/src-tauri/src/mlx_server.rs
+++ b/tray/src-tauri/src/mlx_server.rs
@@ -827,12 +827,12 @@ pub async fn auto_upgrade_runtime(manager: &SharedMlxManager) {
     {
         Ok(Ok(s)) => s,
         Ok(Err(e)) => {
-            tracing::warn!(error = %e, "mlx: runtime upgrade download failed — keeping current runtime");
+            tracing::error!(error = %e, "mlx: runtime upgrade download failed — keeping current runtime");
             let _ = tokio::fs::remove_dir_all(staging_dir()).await;
             return;
         }
         Err(_) => {
-            tracing::warn!(
+            tracing::error!(
                 secs = RUNTIME_DOWNLOAD_TIMEOUT.as_secs(),
                 "mlx: runtime upgrade download timed out — keeping current runtime"
             );
@@ -873,7 +873,7 @@ pub async fn auto_upgrade_runtime(manager: &SharedMlxManager) {
             }
         }
         Err(e) => {
-            tracing::warn!(error = %e, "mlx: post-upgrade restart failed — supervise will retry")
+            tracing::error!(error = %e, "mlx: post-upgrade restart failed — supervise will retry")
         }
     }
 }

--- a/ui/app/setup/signin/EmailCodeForm.tsx
+++ b/ui/app/setup/signin/EmailCodeForm.tsx
@@ -36,7 +36,13 @@ export function EmailCodeForm() {
 
   useEffect(() => {
     if (!resendReadyAt) return
-    const id = setInterval(() => forceTick((n) => n + 1), 1000)
+    const id = setInterval(() => {
+      // Once the cooldown elapses, clear `resendReadyAt` so this effect
+      // re-runs and tears the interval down — otherwise it would keep forcing
+      // a re-render every second forever after the countdown hits zero.
+      if (Date.now() >= resendReadyAt) setResendReadyAt(null)
+      else forceTick((n) => n + 1)
+    }, 1000)
     return () => clearInterval(id)
   }, [resendReadyAt])
 
@@ -70,6 +76,15 @@ export function EmailCodeForm() {
       const sent = await signIn.emailCode.sendCode()
       if (sent.error) { setErr(clerkErrorMessage(sent.error, 'Could not send a code - try again.')); return }
       setMode('signIn'); setPhase('code'); setResendReadyAt(Date.now() + RESEND_COOLDOWN_S * 1000)
+    } catch (e) {
+      // Clerk's Future API returns { error } rather than throwing, but a
+      // transport-level failure still rejects. Catch it here so it surfaces to
+      // the user instead of bubbling as an unhandled rejection (the
+      // ClerkErrorBoundary only covers render/use() failures, not these
+      // async handlers).
+      // eslint-disable-next-line no-console -- only diagnostic for this failure
+      console.error('sign-in: submitEmail threw', e)
+      setErr('Something went wrong - check your connection and try again.')
     } finally {
       submitting.current = false
       setBusy(false)
@@ -118,6 +133,12 @@ export function EmailCodeForm() {
       }
       const finalized = await resource.finalize()
       if (finalized.error) setErr(clerkErrorMessage(finalized.error, 'Could not complete sign-in - try again.'))
+    } catch (e) {
+      // A transport-level rejection (see submitEmail's note) — surface it
+      // rather than letting it escape as an unhandled rejection.
+      // eslint-disable-next-line no-console -- see above
+      console.error('sign-in: submitCode threw', e)
+      setErr('Something went wrong - check your connection and try again.')
     } finally {
       submitting.current = false
       setBusy(false)
@@ -146,6 +167,12 @@ export function EmailCodeForm() {
       }
       setCode('')
       setResendReadyAt(Date.now() + RESEND_COOLDOWN_S * 1000)
+    } catch (e) {
+      // A transport-level rejection (see submitEmail's note) — surface it
+      // rather than letting it escape as an unhandled rejection.
+      // eslint-disable-next-line no-console -- see above
+      console.error('sign-in: resendCode threw', e)
+      setErr('Could not resend the code - check your connection and try again.')
     } finally {
       submitting.current = false
       setBusy(false)

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -94,7 +94,7 @@ function PermissionsBody({ wiz }: { wiz: Wiz }) {
       })}
       <p className="flex items-center" style={{ gap: 7, fontSize: 11, color: 'var(--t-faint)', marginTop: 3 }}>
         <span style={{ width: 5, height: 5, borderRadius: 99, background: 'var(--color-state-approved)' }} />
-        Your screen, tasks, and worklogs stay on this Mac and are never uploaded. We send anonymous usage stats (like daily focus time) to improve Meridian - never your content.
+        Your screen, tasks, and worklogs stay on this Mac and are never uploaded. We send usage stats - daily focus time, app version, and your email once you sign in - to improve Meridian, never your content.
       </p>
     </div>
   )

--- a/ui/lib/brand-icons.ts
+++ b/ui/lib/brand-icons.ts
@@ -25,11 +25,16 @@
 // `"‎WhatsApp"`, a leading left-to-right mark, not `"WhatsApp"`), which
 // silently fail an exact-match lookup and fall through to the hashed-hue
 // fallback with no visible error.
-export interface BrandIcon {
-  viewBox?: string
-  path?: string
-  hex: string
-}
+// `viewBox` and `path` are tied together: an entry either has a real glyph
+// (both present) or is colour-only (both absent). `AppGlyph` renders
+// `<svg viewBox={brand.viewBox}><path d={brand.path} /></svg>` whenever
+// `brand.path` is set, so a `path` without a `viewBox` would produce a
+// viewBox-less SVG. The union makes that combination a compile error instead
+// of a silent runtime bug.
+export type BrandIcon = { hex: string } & (
+  | { viewBox: string; path: string }
+  | { viewBox?: undefined; path?: undefined }
+)
 
 /** Strips invisible Unicode formatting marks (LRM, RLM, zero-width chars, BOM)
  * that some apps' native window titles carry, then trims — so `BRAND_ICONS`


### PR DESCRIPTION
## Summary

Follow-up fixes for the CodeRabbit review threads on the `pre-main → main` promotion PR #440. Once this lands on `pre-main`, #440's diff picks the fixes up automatically.

Per the triage on #440, this branch carries the clear bugs, one privacy hardening, and the refactors approved for it. Two items are handled elsewhere: the Jira backfill critical is in its **own focused PR #446** (risky daemon-sync change), and the email→PostHog capture is a **deliberate keep** (copy softened instead).

### Correctness / safety
- **uninstall — full-wipe scope bug (Critical):** gate the wholesale `rm -rf ~/.meridian` on `--purge` only, not `--remove-data && --remove-runtime` (a user could set both without intending a full wipe). Fixed in the human **and** `--json` paths; regression test added.
- **intelligence (github/linear) — FK violation (Major):** full-clear via `prune()` unconditionally, so the empty-keys path deletes `pm_task_embeddings` before `pm_tasks`. The old fallback deleted `pm_tasks` directly and hit the FK, silently leaving stale tasks.
- **pm_worklog/create — unbounded hang (Major):** 20 s `reqwest` timeout on the jira/azure create clients (matches `azure_devops::apply`).
- **account — PII in traces (Major):** `skip(email)` in `#[tracing::instrument]` so the signed-in address never lands in a span field / log.
- **pm_worklog/post:** `.context(...)` on the `fail_worklog` / `mark_post_failed` DB calls.

### Refactors (approved for this branch)
- **uninstall:** split into `uninstall.rs` + `uninstall/json.rs` + `uninstall/tests.rs` (each < 500 lines); the 13-arg `run_json` is now a `Plan` / `Flags` struct.
- **meridian-core:** new `fs_utils::atomic_write_json` — one tested crash-safe temp+rename JSON writer; `settings`, tray `analytics`, and `account` all call it now.
- **CI:** extract the duplicated Apple cert-import block into `.github/actions/import-apple-cert` (shared by `release.yml` + `release-staging.yml`), with a graceful no-op when `APPLE_CERTIFICATE` is unset instead of crashing `security import`.

### UI / smaller fixes
- **setup/EmailCodeForm:** stop the resend-cooldown ticker when the countdown elapses; add `catch` blocks so a rejected Clerk promise surfaces to the user instead of an unhandled rejection.
- **setup/steps:** soften onboarding privacy copy — telemetry isn't strictly anonymous (metadata + email after sign-in), while keeping "never your content".
- **brand-icons:** tie `BrandIcon.viewBox`/`path` together in the type so a glyph can't render a viewBox-less SVG.
- **tray:** `warn!` → `error!` on genuine failure paths (uninstall commands, MLX runtime upgrade, backend install).
- **em-dashes → plain hyphens** in user-facing strings (uninstall CLI, design-system preview mock data).

### Skipped (with rationale, commented on the #440 threads)
- `commands.rs` / `api-types.ts` "missing header comment" — **already present on line 1** (CodeRabbit anchored mid-file); stale.
- `CLAUDE.md` "afterwards" → "afterward" — docs file, not user-facing app text; the US-locale nit doesn't apply.

## Test plan
- `cargo test` (workspace): 437 + integration suites pass
- `cargo clippy -- -D warnings`: clean (root + tray)
- `cargo fmt --check`: clean (root + tray)
- `cd tray/src-tauri && cargo test`: 65 pass
- `cd ui && npm run build`: clean (TypeScript check passes); `bun test`: 181 pass
- Workflow YAML validated (release.yml, release-staging.yml, the new composite action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)