### PR TITLE
fix(review): second-round CodeRabbit findings on the #440 fixes

### DIFF
--- a/meridian-core/src/fs_utils.rs
+++ b/meridian-core/src/fs_utils.rs
@@ -17,6 +17,7 @@
 
 use anyhow::Context;
 use serde::Serialize;
+use std::io::Write;
 use std::path::Path;
 
 /// Crash-safely persist `value` as pretty (2-space) JSON to `path`.
@@ -32,8 +33,18 @@ pub fn atomic_write_json<T: Serialize>(path: &Path, value: &T) -> anyhow::Result
     let json = serde_json::to_string_pretty(value).context("serialising JSON")?;
     // Temp file in the SAME directory so the rename is atomic (same filesystem).
     let tmp = path.with_extension("json.tmp");
-    std::fs::write(&tmp, json.as_bytes())
-        .with_context(|| format!("writing temp file {}", tmp.display()))?;
+    {
+        let mut f = std::fs::File::create(&tmp)
+            .with_context(|| format!("creating temp file {}", tmp.display()))?;
+        f.write_all(json.as_bytes())
+            .with_context(|| format!("writing temp file {}", tmp.display()))?;
+        // fsync the data to disk BEFORE the rename. `rename` only makes the
+        // directory entry swap atomic; without this flush, a crash/power-loss
+        // right after the rename could persist the new dir entry while the data
+        // blocks are still buffered, leaving `path` empty or torn.
+        f.sync_all()
+            .with_context(|| format!("flushing temp file {}", tmp.display()))?;
+    }
     std::fs::rename(&tmp, path)
         .with_context(|| format!("atomically replacing {}", path.display()))?;
     Ok(())

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -278,7 +278,11 @@ fn run_human(plan: &Plan) {
         );
     }
 
-    if plan.nothing_to_do() {
+    // `--purge` must still wipe ~/.meridian even when none of the itemized
+    // scopes matched — e.g. the directory holds only files the catalog doesn't
+    // name — so don't short-circuit "nothing to do" in that case.
+    let purge_pending = flags.purge && plan.meridian_dir.is_dir();
+    if plan.nothing_to_do() && !purge_pending {
         println!("\nNothing to remove - Meridian is not installed here.");
         return;
     }
@@ -294,11 +298,23 @@ fn run_human(plan: &Plan) {
     // Execute.
     let uid = uid_str();
     for (label, plist) in &plan.agents {
+        // `bootout` can legitimately return non-zero (the agent isn't currently
+        // loaded); it's best-effort, so its exit status isn't an error here.
         let _ = std::process::Command::new("launchctl")
             .args(["bootout", &format!("gui/{uid}/{label}")])
             .status();
-        let _ = std::fs::remove_file(plist);
-        println!("✓ removed agent  {label}");
+        // But don't claim "✓ removed" if the plist deletion actually failed.
+        match std::fs::remove_file(plist) {
+            Ok(()) => println!("✓ removed agent  {label}"),
+            // Already gone (a prior partial uninstall) — still booted out above.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                println!("✓ removed agent  {label}")
+            }
+            Err(e) => eprintln!(
+                "⚠ could not remove agent {label} plist {}: {e}",
+                plist.display()
+            ),
+        }
     }
     for f in &plan.staged_binaries {
         remove_path_reporting(f);

--- a/src/uninstall/json.rs
+++ b/src/uninstall/json.rs
@@ -76,6 +76,10 @@ pub(super) fn run_json(plan: &Plan) {
     report.executed = true;
     let uid = uid_str();
     for (label, plist) in &plan.agents {
+        // `bootout` can legitimately return non-zero (the agent isn't currently
+        // loaded); it's best-effort, so its exit status isn't an error. The
+        // meaningful outcome is whether the plist itself was removed, tracked
+        // via `report.removed`/`report.errors` below.
         let _ = std::process::Command::new("launchctl")
             .args(["bootout", &format!("gui/{uid}/{label}")])
             .status();

--- a/src/uninstall/tests.rs
+++ b/src/uninstall/tests.rs
@@ -1,8 +1,13 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 //! Unit tests for `meridian uninstall`, split out of [`super`] to keep that
 //! file under the 500-line guideline.
+//!
+//! Each test uses a `tempfile::TempDir` for its scratch space so cleanup runs
+//! via `Drop` — including during panic unwinding, so a failing assertion never
+//! leaks a directory under `/tmp`.
 
 use super::*;
+use tempfile::TempDir;
 
 #[test]
 fn label_matches_only_meridiona_plists() {
@@ -46,9 +51,8 @@ fn purge_flag_is_not_implied_by_remove_data_plus_remove_runtime() {
 
 #[test]
 fn enumerates_only_meridiona_agents() {
-    let dir = std::env::temp_dir().join("meridian-uninstall-test-agents");
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
     for f in [
         "com.meridiona.daemon.plist",
         "com.meridiona.a11y-helper.plist",
@@ -57,7 +61,7 @@ fn enumerates_only_meridiona_agents() {
     ] {
         std::fs::write(dir.join(f), "x").unwrap();
     }
-    let found: Vec<String> = meridiona_agent_plists(&dir)
+    let found: Vec<String> = meridiona_agent_plists(dir)
         .into_iter()
         .map(|(l, _)| l)
         .collect();
@@ -68,14 +72,14 @@ fn enumerates_only_meridiona_agents() {
             "com.meridiona.daemon".to_string()
         ]
     );
-    std::fs::remove_dir_all(&dir).ok();
 }
 
 #[test]
 fn missing_launch_agents_dir_is_empty() {
-    let dir = std::env::temp_dir().join("meridian-uninstall-test-nope-xyz");
-    let _ = std::fs::remove_dir_all(&dir);
-    assert!(meridiona_agent_plists(&dir).is_empty());
+    let tmp = TempDir::new().unwrap();
+    // A path *inside* the temp dir that was never created.
+    let missing = tmp.path().join("does-not-exist");
+    assert!(meridiona_agent_plists(&missing).is_empty());
 }
 
 /// `data_items`/`runtime_items` must only list entries that actually exist
@@ -83,19 +87,15 @@ fn missing_launch_agents_dir_is_empty() {
 /// stay disjoint from each other so the two checkboxes don't double-count.
 #[test]
 fn data_and_runtime_items_only_list_existing_entries_and_stay_disjoint() {
-    let dir = std::env::temp_dir().join(format!(
-        "meridian-uninstall-test-items-{}",
-        std::process::id()
-    ));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
     std::fs::write(dir.join(".env"), "x").unwrap();
     std::fs::write(dir.join("meridian.db"), "x").unwrap();
     std::fs::create_dir_all(dir.join("runtime")).unwrap();
     // "settings.json" and "mlx-server-venv" deliberately absent.
 
-    let data = data_items(&dir);
-    let runtime = runtime_items(&dir);
+    let data = data_items(dir);
+    let runtime = runtime_items(dir);
 
     assert!(data.contains(&dir.join(".env")));
     assert!(data.contains(&dir.join("meridian.db")));
@@ -109,40 +109,29 @@ fn data_and_runtime_items_only_list_existing_entries_and_stay_disjoint() {
             "data and runtime item lists must be disjoint: {p:?}"
         );
     }
-
-    std::fs::remove_dir_all(&dir).ok();
 }
 
 /// `model_items` only returns catalog entries that exist on disk, and never
 /// invents a path for a model that isn't in [`MODEL_CATALOG`].
 #[test]
 fn model_items_filters_to_existing_catalog_dirs() {
-    let home = std::env::temp_dir().join(format!(
-        "meridian-uninstall-test-models-{}",
-        std::process::id()
-    ));
-    let _ = std::fs::remove_dir_all(&home);
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path();
     let hub = home.join(".cache/huggingface/hub");
     std::fs::create_dir_all(&hub).unwrap();
     std::fs::create_dir_all(hub.join("models--mlx-community--Qwen3.5-2B-OptiQ-4bit")).unwrap();
     // A non-Meridian model the user downloaded for another tool — must be ignored.
     std::fs::create_dir_all(hub.join("models--some-other-org--unrelated-model")).unwrap();
 
-    let found = model_items(&home);
+    let found = model_items(home);
     assert_eq!(found.len(), 1);
     assert!(found[0].ends_with("models--mlx-community--Qwen3.5-2B-OptiQ-4bit"));
-
-    std::fs::remove_dir_all(&home).ok();
 }
 
 #[test]
 fn remove_path_handles_files_and_directories() {
-    let dir = std::env::temp_dir().join(format!(
-        "meridian-uninstall-test-remove-{}",
-        std::process::id()
-    ));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
 
     let file = dir.join("a-file");
     std::fs::write(&file, "x").unwrap();
@@ -159,6 +148,4 @@ fn remove_path_handles_files_and_directories() {
         remove_path(&dir.join("missing")).unwrap_err().kind(),
         std::io::ErrorKind::NotFound
     );
-
-    std::fs::remove_dir_all(&dir).ok();
 }

--- a/tray/src-tauri/src/commands/account.rs
+++ b/tray/src-tauri/src/commands/account.rs
@@ -106,7 +106,8 @@ fn account_path() -> Option<PathBuf> {
 /// the next scheduled `app_installed`/`daily_usage` capture.
 #[tauri::command]
 // skip `email` too: it's PII and must never land in a span field / log line.
-#[tracing::instrument(skip(app, email))]
+// `err` records the failure + marks the span status ERROR on the `Err` path.
+#[tracing::instrument(skip(app, email), err)]
 pub async fn save_account_email(app: tauri::AppHandle, email: String) -> Result<(), String> {
     let email = email.trim().to_string();
     if email.is_empty() || !email.contains('@') {


### PR DESCRIPTION
## Summary

After #445 / #446 merged into `pre-main`, CodeRabbit re-reviewed promotion PR #440 and flagged 5 follow-ups **on the fix code itself**. All addressed here.

- **fs_utils `atomic_write_json` — fsync before rename (Major):** `sync_all()` the temp file before the atomic rename, so a crash/power-loss right after the rename can't persist the new directory entry while the data blocks are still buffered (empty/torn file). Hardens all three call sites (settings / analytics / account) at once.
- **uninstall — `--purge` short-circuit (Major, correctness):** `nothing_to_do()` ignores `~/.meridian`, so a `--purge` whose directory holds only uncatalogued files would print "Nothing to remove" and skip the wholesale `rm -rf`. Now the human path proceeds to the purge in that case.
- **uninstall — honest agent-removal reporting (Major):** the human path no longer prints "✓ removed agent" when the plist deletion actually failed (reports ⚠ instead). Documents why `launchctl bootout`'s exit status stays best-effort in both paths (a not-loaded agent legitimately returns non-zero).
- **account `save_account_email` — span status (Minor):** added `err` to `#[tracing::instrument]` so a failure marks the span ERROR.
- **uninstall/tests — temp-dir hygiene (Trivial):** switched to `tempfile::TempDir` so scratch dirs clean up via `Drop`, including during panic unwinding — no `/tmp` leak on a failing assertion.

## Test plan
- `cargo test --lib`: 437 pass; `cargo test --lib uninstall` + `-p meridian-core fs_utils` green
- `cargo clippy -- -D warnings` + `cargo fmt --check`: clean (root + tray)

Last of the review follow-ups for #440. Once this lands on `pre-main`, #440's diff reflects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)