### PR TITLE
fix(tray): dispatch setup wizard full-screen call to the main thread

### DIFF
--- a/tray/src-tauri/src/tray.rs
+++ b/tray/src-tauri/src/tray.rs
@@ -202,8 +202,19 @@ pub(crate) fn open_wizard_window(app: &tauri::AppHandle) {
         Ok(win) => {
             // Opt the window into native full-screen so the green traffic-light
             // shows the enter-full-screen arrows, not the plain zoom (+) glyph.
+            // make_fullscreenable touches the raw NSWindow directly (no Tauri-safe
+            // wrapper around it), so it must run on the main thread — most callers
+            // of open_wizard_window are already on it (tray menu clicks, dock
+            // reopen are native AppKit callbacks), but the first-launch auto-open
+            // task (lib.rs) calls in from a tokio worker thread after its 800 ms
+            // sleep, and AppKit hard-aborts the process (SIGTRAP) if an NSWindow is
+            // touched off the main thread. run_on_main_thread queues the call
+            // rather than blocking, so it's safe from any caller thread.
             #[cfg(target_os = "macos")]
-            make_fullscreenable(&win);
+            {
+                let fs_win = win.clone();
+                let _ = app.run_on_main_thread(move || make_fullscreenable(&fs_win));
+            }
             // Same gap as the dashboard window — see dismiss_popover_on_focus's
             // doc comment (clicking back into an already-open setup window
             // wouldn't otherwise dismiss a popover reopened on top of it).
@@ -230,8 +241,9 @@ fn make_fullscreenable(win: &tauri::WebviewWindow) {
     };
     // NSWindowCollectionBehaviorFullScreenPrimary = 1 << 7.
     const FULLSCREEN_PRIMARY: usize = 1 << 7;
-    // Safety: called on the main thread (menu dispatch / setup hook) with standard
-    // NSWindow selectors and no ownership transfer.
+    // Safety: caller (open_wizard_window) must run this on the main thread —
+    // AppKit aborts the process if an NSWindow is touched off it. Standard
+    // NSWindow selectors, no ownership transfer.
     unsafe {
         let ns = &*ptr;
         let current: usize = msg_send![ns, collectionBehavior];

--- a/tray/src-tauri/src/tray.rs
+++ b/tray/src-tauri/src/tray.rs
@@ -213,7 +213,9 @@ pub(crate) fn open_wizard_window(app: &tauri::AppHandle) {
             #[cfg(target_os = "macos")]
             {
                 let fs_win = win.clone();
-                let _ = app.run_on_main_thread(move || make_fullscreenable(&fs_win));
+                if let Err(e) = app.run_on_main_thread(move || make_fullscreenable(&fs_win)) {
+                    tracing::warn!(error = %e, "failed to dispatch make_fullscreenable to main thread");
+                }
             }
             // Same gap as the dashboard window — see dismiss_popover_on_focus's
             // doc comment (clicking back into an already-open setup window


### PR DESCRIPTION
## Summary
- The first-launch auto-open-wizard task (`lib.rs`) calls `tray::open_wizard_window()` from a tokio worker thread after an 800ms sleep, not the main thread.
- Inside it, `make_fullscreenable()` makes a raw `msg_send![ns, setCollectionBehavior:...]` AppKit call on the `NSWindow` — AppKit hard-aborts the process (`SIGTRAP`/`EXC_BREAKPOINT`, "Must only be used from the main thread") when touched off the main thread.
- Every other caller of `open_wizard_window` (tray menu click, dock reopen) happens to already run on the main thread as a native AppKit callback, so this only reproduces on a fresh install / re-onboarding launch (no `~/.meridian/onboarded` marker) — reported as the tray icon appearing in the menu bar and immediately disappearing.
- Fix: wrap the `make_fullscreenable` call in `app.run_on_main_thread(...)`, which queues onto the main run loop rather than blocking, so it's safe regardless of which thread calls in.

## Root cause trace
User-reported repro: ran the popover's uninstall wizard with "Meridian data" checked (wipes `~/.meridian/onboarded` among other things), reinstalled a fresh signed+notarized DMG, and the tray crash-looped on every launch. Crash report confirmed:
- `termination`: `SIGNAL` / `Trace/BPT trap: 5`
- `exception`: `EXC_BREAKPOINT` / `SIGTRAP`
- `asi`: `libsystem_c.dylib: ["Must only be used from the main thread"]`
- Faulting thread backtrace: `meridian_tray_lib::tray::open_wizard_window` → `-[NSWindow setCollectionBehavior:]` → AppKit internals, sitting directly on top of `tokio::runtime::scheduler::multi_thread::worker` frames (confirming a tokio worker thread, not main).

Not specific to this user — reproduces on any first-run/re-onboarding launch, on any machine, deterministically.

## Test plan
- [x] `cargo build --lib` clean
- [x] `cargo clippy --lib -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --lib` — 65 passed, 0 failed
- [x] Full pre-push suite (fmt + clippy + ui build/tests + security audit + cargo test) passed
- [x] Manual verify on the reporter's machine: delete `~/.meridian/onboarded`, relaunch the packaged app, confirm the setup wizard opens without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)