### PR TITLE
feat(llm-lab): full-screen surface with a variant switcher and task sidebar

### DIFF
--- a/src/llm_experiment/cli.rs
+++ b/src/llm_experiment/cli.rs
@@ -1,5 +1,5 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
-//! `meridian llm-experiment <run|create|exec|list|get>` — the LLM-Lab CLI surface.
+//! `meridian llm-experiment <run|create|exec|list|get|draft-task>` — the LLM-Lab CLI surface.
 //!
 //! * `run    --process hour-report --hour 2026-07-15T14 --variants claude,codex:gpt-5.1,local`
 //!   — create + execute + print the detail JSON (the human one-shot). A `custom:<endpoint-id>`
@@ -12,12 +12,20 @@
 //!   UI polls progress instead of holding a long invoke). Resumable.
 //! * `list   [--limit N]` / `get --id N` — read back via
 //!   `meridian_core::llm_experiments`, printed as one JSON line.
+//! * `draft-task --day D --variant p[:model] --task-json '{…}'` — the ONE exception
+//!   to the paragraph below: an ephemeral, on-demand worklog draft for a single
+//!   inline task that fires a REAL, metered LLM completion (see [`draft_task`]).
 //!
-//! Deliberately ungated in release binaries: it is useful for field debugging and
-//! only ever writes the experiment tables. The UI surface is the gated part.
+//! `run`/`create`/`exec`/`list`/`get` are deliberately ungated in release binaries:
+//! they are useful for field debugging and **only ever write the experiment
+//! tables** — no network, no cost — so an unattended run is harmless. `draft-task`
+//! is different (it calls a live provider and can incur cost), so it alone is
+//! **dev-gated** here too — a release binary refuses it, matching the tray's
+//! `draft_lab_worklog` gate. The UI surface as a whole is the gated part.
 //!
 //! # Who calls this
-//! `main.rs`'s `llm-experiment` dispatch block; the tray's `run_llm_experiment`.
+//! `main.rs`'s `llm-experiment` dispatch block; the tray's `run_llm_experiment`
+//! (and, for `draft-task`, `draft_lab_worklog`).
 
 use anyhow::{bail, Context, Result};
 use sqlx::SqlitePool;
@@ -82,7 +90,17 @@ pub async fn run(pool: &SqlitePool) -> Result<()> {
 /// SIMULATED day, not a production `day_tasks` row - so there is nothing to read
 /// by id. Fires a real, metered completion; the UI gates this behind a
 /// free/local caution. The tray `draft_lab_worklog` command shells out to it.
+///
+/// Unlike its sibling subcommands (which only write local experiment tables), this
+/// one costs money, so it is refused in a release build - it runs only from a dev
+/// binary, the same `debug_assertions` signal the tray's `dev_only` gate uses.
 async fn draft_task(pool: &SqlitePool, args: &[String]) -> Result<()> {
+    if !cfg!(debug_assertions) {
+        bail!(
+            "draft-task is a dev-only subcommand - it fires a real, metered LLM completion, \
+             so a release binary refuses it"
+        );
+    }
     let day = flag(args, "--day").with_context(|| format!("draft-task needs --day - {USAGE}"))?;
     let variant =
         flag(args, "--variant").with_context(|| format!("draft-task needs --variant - {USAGE}"))?;

--- a/src/llm_experiment/cli.rs
+++ b/src/llm_experiment/cli.rs
@@ -24,12 +24,14 @@ use sqlx::SqlitePool;
 
 use super::{
     parse_variants, request, runner, store, ExperimentInput, ExperimentProcess, ExperimentSpec,
+    Variant,
 };
 
 const USAGE: &str = "usage: meridian llm-experiment \
 run|create --process hour-report|workstream-fold|worklog-generate|day-fold \
 (--hour YYYY-MM-DDTHH | --day YYYY-MM-DD [--task-id T]) --variants p1,p2:model,custom:id,… \
-| exec --id N | list [--limit N] | get --id N";
+| exec --id N | list [--limit N] | get --id N \
+| draft-task --day YYYY-MM-DD --variant p[:model] --task-json '{\"title\":…,\"summary\":[…],\"minutes\":N}'";
 
 /// Parse argv and dispatch. Prints exactly one JSON line on success (except
 /// `create`'s `{"experiment_id":N}` — also one line); errors bubble to `main.rs`.
@@ -68,8 +70,58 @@ pub async fn run(pool: &SqlitePool) -> Result<()> {
             let id = flag_i64(&args, "--id")?;
             print_detail(pool, id).await
         }
+        "draft-task" => draft_task(pool, &args).await,
         _ => bail!("{USAGE}"),
     }
+}
+
+/// Ephemeral inline worklog draft for the dev-only LLM Lab: draft ONE fold task
+/// with ONE variant, print `{"draft": <raw model answer>}`, and persist nothing
+/// (no experiment row). The task content is passed inline
+/// (`--task-json {title,summary,minutes}`) because a fold task id is a model's
+/// SIMULATED day, not a production `day_tasks` row - so there is nothing to read
+/// by id. Fires a real, metered completion; the UI gates this behind a
+/// free/local caution. The tray `draft_lab_worklog` command shells out to it.
+async fn draft_task(pool: &SqlitePool, args: &[String]) -> Result<()> {
+    let day = flag(args, "--day").with_context(|| format!("draft-task needs --day - {USAGE}"))?;
+    let variant =
+        flag(args, "--variant").with_context(|| format!("draft-task needs --variant - {USAGE}"))?;
+    let task_json = flag(args, "--task-json")
+        .with_context(|| format!("draft-task needs --task-json - {USAGE}"))?;
+
+    #[derive(serde::Deserialize)]
+    struct InlineTask {
+        title: String,
+        #[serde(default)]
+        summary: Vec<String>,
+        #[serde(default)]
+        minutes: i64,
+    }
+    let task: InlineTask = serde_json::from_str(&task_json).context("parsing --task-json")?;
+
+    // Parse the variant token (validates the provider + the custom:<id> shape),
+    // then resolve its backend from live settings - the same resolution the
+    // experiment runner uses, so a `custom:<id>` draft hits the same endpoint.
+    let v = Variant::parse(&variant)?;
+    let model = v.model.unwrap_or_default();
+    let backend =
+        runner::resolve_backend(v.provider.as_str(), &model).map_err(anyhow::Error::msg)?;
+
+    let (req, _) = crate::pm_worklog::generate::generate_request_from_task(
+        pool,
+        &day,
+        task.title,
+        task.summary,
+        task.minutes,
+    )
+    .await?;
+
+    let out = backend
+        .complete(&req)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    println!("{}", serde_json::json!({ "draft": out.text }));
+    Ok(())
 }
 
 /// Build + snapshot + insert; returns the new experiment id.

--- a/src/llm_experiment/runner.rs
+++ b/src/llm_experiment/runner.rs
@@ -118,18 +118,27 @@ pub async fn exec(pool: &SqlitePool, experiment_id: i64) -> Result<()> {
 /// custom provider). An id that names no row errors this one variant rather than falling
 /// back to the wrong endpoint silently.
 fn variant_backend(v: &store::StoredVariant) -> Result<Box<dyn LlmBackend>, String> {
-    let Some(provider) = LlmProvider::from_wire(&v.provider) else {
-        return Err(format!("unknown provider {:?}", v.provider));
+    resolve_backend(&v.provider, &v.model)
+}
+
+/// The token-level core of [`variant_backend`]: resolve a backend from a raw
+/// `(provider, model)` pair. `model` is a model override, EXCEPT for `custom`,
+/// where it is an endpoint id (see [`crate::llm_experiment::Variant`]) that points
+/// the config at that specific registry row. Shared with the ephemeral LLM-Lab
+/// draft path ([`crate::llm_experiment::cli`]), which has no stored variant row.
+pub(crate) fn resolve_backend(provider: &str, model: &str) -> Result<Box<dyn LlmBackend>, String> {
+    let Some(provider) = LlmProvider::from_wire(provider) else {
+        return Err(format!("unknown provider {provider:?}"));
     };
     let settings = load_runtime_settings();
     let mut cfg = LlmConfig::from_settings(&settings);
     if provider == LlmProvider::Custom {
         let row = settings
-            .custom_provider(&v.model)
-            .ok_or_else(|| format!("no custom endpoint with id {:?}", v.model))?;
+            .custom_provider(model)
+            .ok_or_else(|| format!("no custom endpoint with id {model:?}"))?;
         cfg = cfg.with_custom(row);
-    } else if !v.model.is_empty() {
-        cfg.model = v.model.clone();
+    } else if !model.is_empty() {
+        cfg.model = model.to_string();
     }
     Ok(backend_for(provider, cfg))
 }

--- a/src/pm_worklog/generate.rs
+++ b/src/pm_worklog/generate.rs
@@ -1064,6 +1064,68 @@ mod tests {
         assert_eq!(keys, vec!["KAN-1".to_string()]);
     }
 
+    #[test]
+    fn build_user_prompt_pins_the_shape_both_draft_paths_share() {
+        // build_user_prompt is the ONE assembler both generate_request (DB task)
+        // and generate_request_from_task (inline task) feed, so pinning its exact
+        // output guards the two paths against silent drift.
+        let report = WorkstreamReport {
+            title: "Auth refactor".to_string(),
+            summary: vec![
+                "Split token refresh".to_string(),
+                "Added a file lock".to_string(),
+            ],
+            minutes: 45,
+        };
+        let candidates = vec![Candidate {
+            task_key: "KAN-12".to_string(),
+            provider: "jira".to_string(),
+            doc: "[Task] Auth. Epic: E. Reworked refresh".to_string(),
+        }];
+
+        let expected = "=== WORKSTREAM (one strand of the day's work) ===\n\
+TITLE: Auth refactor\n\
+WHAT WAS DONE:\n\
+- Split token refresh\n\
+- Added a file lock\n\
+(measured ~45 min across the day)\n\n\
+=== TODAY'S PLANNED TASKS (the ONLY tickets you may match to - by task_key; any number, or none) ===\n\
+- KAN-12 [jira] [Task] Auth. Epic: E. Reworked refresh\n";
+
+        assert_eq!(build_user_prompt(&report, &candidates), expected);
+    }
+
+    #[tokio::test]
+    async fn inline_draft_request_matches_the_worklog_generate_contract() {
+        // The LLM-Lab draft path: generate_request_from_task must build the SAME
+        // request contract as the DB-backed generate_request - only the workstream
+        // source differs (inline title/summary/minutes vs a day_tasks read).
+        let pool = db().await;
+        // No plan seeded -> empty candidate set, exactly like a fresh day.
+        let (req, n) = generate_request_from_task(
+            &pool,
+            "2026-07-17",
+            "Auth refactor".to_string(),
+            vec![
+                "Split token refresh".to_string(),
+                "Added a file lock".to_string(),
+            ],
+            45,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(n, 0, "no plan seeded -> no candidates");
+        assert_eq!(req.system, prompts::WORKLOG_GENERATE);
+        assert_eq!(req.schema, Some(prompts::worklog_generate_schema()));
+        assert_eq!(req.max_tokens, GENERATE_MAX_TOKENS);
+        // The inline title/summary/minutes reach the workstream block verbatim.
+        assert!(req.user.contains("TITLE: Auth refactor"));
+        assert!(req.user.contains("- Split token refresh"));
+        assert!(req.user.contains("(measured ~45 min across the day)"));
+        assert!(req.user.contains("(no tasks were planned for this day"));
+    }
+
     #[tokio::test]
     async fn a_checked_off_planned_task_is_still_a_candidate() {
         // Checking a task off the plan CLOSES the real ticket (is_terminal = 1).

--- a/src/pm_worklog/generate.rs
+++ b/src/pm_worklog/generate.rs
@@ -507,6 +507,37 @@ pub(crate) async fn generate_request(
     Ok((req, candidates.len()))
 }
 
+/// Like [`generate_request`], but for a task supplied **inline** rather than read
+/// from `day_tasks`. The dev-only LLM-Lab draft button drafts a fold variant's OWN
+/// simulated task, whose id (`T1`, `T2`) is that model's in-memory day, not a
+/// production row — so the workstream report is built from the passed
+/// title/summary/minutes. Only the candidate set (the day's REAL plan) is read
+/// from the DB, which is correct and desirable: a Lab draft still compares against
+/// the actual board. Read-only.
+pub(crate) async fn generate_request_from_task(
+    pool: &SqlitePool,
+    day_local: &str,
+    title: String,
+    summary: Vec<String>,
+    minutes: i64,
+) -> Result<(PromptRequest, usize)> {
+    let report = WorkstreamReport {
+        title,
+        summary,
+        minutes,
+    };
+    let candidates = fetch_plan_candidates(pool, day_local).await?;
+    let user = build_user_prompt(&report, &candidates);
+    let req = PromptRequest {
+        system: prompts::WORKLOG_GENERATE,
+        user,
+        schema: Some(prompts::worklog_generate_schema()),
+        max_tokens: GENERATE_MAX_TOKENS,
+        label: format!("worklog-generate {day_local} (inline)"),
+    };
+    Ok((req, candidates.len()))
+}
+
 /// A day-task's whole-story report as the matcher sees it.
 struct WorkstreamReport {
     title: String,

--- a/tray/src-tauri/src/commands/llm_lab.rs
+++ b/tray/src-tauri/src/commands/llm_lab.rs
@@ -3,24 +3,31 @@
 //! experiments (no route - new work).
 //!
 //! # What this is
-//! Three commands behind the LLM Lab modal, a **development-only** surface for
+//! Four commands behind the LLM Lab, a **development-only** full-screen surface for
 //! comparing how the pipeline's prose stages come out across LLM providers:
 //! - [`run_llm_experiment`] — start one: shells `meridian llm-experiment create`
 //!   (fast, returns the id), then spawns `exec --id N` **detached** — an N-variant
 //!   run can far outlive any reasonable invoke budget, so the UI polls instead.
 //! - [`get_llm_experiments`] / [`get_llm_experiment`] — the past-runs list and the
-//!   per-variant detail the modal polls while a run progresses.
+//!   per-variant detail the UI polls while a run progresses.
+//! - [`draft_lab_worklog`] — the sidebar's on-demand "draft this task with the
+//!   shown variant": shells `meridian llm-experiment draft-task` and returns the
+//!   model's answer. EPHEMERAL (writes nothing) but fires a REAL, metered
+//!   completion, so the UI puts a free/local caution on the button.
 //!
 //! Every command is refused outside a dev build ([`dev_only`]): the Lab must not
-//! exist for users, even against a hand-crafted `invoke`. (The `llm-experiment`
-//! CLI itself stays ungated for field debugging — the UI is the gated surface.
-//! UI visibility rides `get_app_info().channel === 'dev'`, the same
-//! `cfg!(debug_assertions)` signal, in `MeridianTimelineShell`.)
+//! exist for users, even against a hand-crafted `invoke`. The read/run
+//! `llm-experiment` subcommands stay ungated for field debugging (they only write
+//! local experiment tables), but `draft-task` is dev-gated in the CLI too, since it
+//! alone calls a live provider and can incur cost. UI visibility rides
+//! `get_app_info().channel === 'dev'`, the same `cfg!(debug_assertions)` signal, in
+//! `MeridianTimelineShell`.
 //!
 //! # Who calls this
 //! Registered in `lib.rs`'s `invoke_handler!`; consumed by
 //! `ui/components/timeline/llmlab/` via `ui/lib/bridge.ts` — `load` for the two
-//! reads (flat named args), `invoke('run_llm_experiment', {body})` for the run.
+//! reads (flat named args), `invoke('run_llm_experiment', {body})` for a run, and
+//! `invoke('draft_lab_worklog', {body})` for the sidebar draft.
 //!
 //! # Related
 //! - `src/llm_experiment/` — the daemon-side harness the run command spawns.

--- a/tray/src-tauri/src/commands/llm_lab.rs
+++ b/tray/src-tauri/src/commands/llm_lab.rs
@@ -159,3 +159,56 @@ pub async fn get_llm_experiment(
             e.to_string()
         })
 }
+
+/// POST body for [`draft_lab_worklog`] - the selected fold task plus the variant
+/// to draft it with. `task` carries the inline content the daemon drafts from
+/// (`{title, summary, minutes}`); it is deliberately NOT looked up by id, because
+/// a fold task id is a model's SIMULATED day, not a production `day_tasks` row.
+#[derive(Debug, Deserialize)]
+pub struct DraftLabWorklogBody {
+    pub day: String,
+    /// A variant token: `provider`, `provider:model`, or `custom:<endpoint-id>`.
+    pub variant: String,
+    /// `{title, summary, minutes}` - passed through to the CLI as `--task-json`.
+    pub task: serde_json::Value,
+}
+
+/// `draft-task`'s one JSON line.
+#[derive(Debug, Deserialize)]
+struct DraftAck {
+    draft: String,
+}
+
+/// Draft ONE fold task's worklog with ONE variant, on demand - shells
+/// `meridian llm-experiment draft-task` (EPHEMERAL: no experiment row is written)
+/// and returns the model's raw answer for the sidebar to render. This fires a
+/// REAL, metered completion against the chosen variant, so the UI puts a
+/// free/local caution on the button. Dev-only, like the rest of the Lab.
+#[tauri::command]
+#[tracing::instrument(skip(body), fields(variant = %body.variant, day = %body.day))]
+pub async fn draft_lab_worklog(body: DraftLabWorklogBody) -> Result<String, String> {
+    dev_only()?;
+    let task_json = serde_json::to_string(&body.task).map_err(|e| e.to_string())?;
+    let args: Vec<String> = vec![
+        "llm-experiment".into(),
+        "draft-task".into(),
+        "--day".into(),
+        body.day.clone(),
+        "--variant".into(),
+        body.variant.clone(),
+        "--task-json".into(),
+        task_json,
+    ];
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    // The bottleneck is a full worklog-generate completion, which can be slow on a
+    // large model - a generous ceiling, not the 30 s the create step uses.
+    let stdout = run_meridian(
+        &arg_refs,
+        Duration::from_secs(180),
+        "llm-experiment-draft-task",
+    )
+    .await?;
+    let ack: DraftAck = parse_last_line(&stdout)?;
+    tracing::info!("llm-lab: inline worklog draft complete");
+    Ok(ack.draft)
+}

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -541,6 +541,7 @@ pub fn run() {
             commands::get_llm_experiments,
             commands::get_llm_experiment,
             commands::run_llm_experiment,
+            commands::draft_lab_worklog,
             commands::get_version,
             commands::get_app_info,
             commands::check_update,

--- a/ui/components/timeline/MeridianTimelineShell.tsx
+++ b/ui/components/timeline/MeridianTimelineShell.tsx
@@ -28,7 +28,7 @@ import { PlanModal } from './PlanModal'
 import { TasksModal } from './TasksModal'
 import { TaskDetailDialog } from './TaskDetailDialog'
 import { ReportModal } from './ReportModal'
-import { LlmLabModal } from './llmlab/LlmLabModal'
+import { LlmLabScreen } from './llmlab/LlmLabScreen'
 import type { AppInfo } from '@/lib/api-types'
 import type { SettingsSection } from './settings/types'
 
@@ -210,7 +210,7 @@ export default function MeridianTimelineShell() {
       )}
       {activeModal === 'report' && <ReportModal onClose={() => setActiveModal(null)} />}
       {activeModal === 'llmlab' && channel === 'dev' && (
-        <LlmLabModal onClose={() => setActiveModal(null)} />
+        <LlmLabScreen onClose={() => setActiveModal(null)} />
       )}
       {activeModal === 'plan' && <PlanModal onClose={closePlan} />}
       {activeModal === 'tasks' && (

--- a/ui/components/timeline/llmlab/LabTaskSidebar.tsx
+++ b/ui/components/timeline/llmlab/LabTaskSidebar.tsx
@@ -5,25 +5,64 @@
 // timeline. Read-only by design and DELIBERATELY not DayTaskDetailPanel - that
 // panel drives useWorklog (get / generate / approve) against the PRODUCTION
 // day_task_worklogs tables for a task id, and a fold's task ids are a model's
-// SIMULATED day, not real rows. So this shows only what the fold result itself
-// carries: when the task was worked, and the model's own per-task log. The
-// "draft with this model" action (a metered, on-demand call) is wired in Phase B.
-// Dev-only surface - plain hyphens in all copy.
+// SIMULATED day, not real rows. So the "when / what was done" section shows only
+// what the fold result itself carries (the model's own per-task log).
+//
+// The "Draft with this model" action is on-demand and EPHEMERAL: it drafts THIS
+// task's worklog with the variant currently shown (invoke -> draft_lab_worklog ->
+// meridian llm-experiment draft-task), renders the answer here, and writes nothing
+// anywhere. It fires a REAL, metered completion, so it carries a free/local
+// caution - never auto-run. Dev-only surface - plain hyphens in all copy.
 
 'use client'
 
+import { useState } from 'react'
 import { fmtDur } from '@/components/atoms'
+import { invoke } from '@/lib/bridge'
 import { clockLabel } from '../dayTaskLayout'
 import { Bullets, Field } from '../dayTaskKit'
 import type { DayTaskDetail } from '../DayTaskDetailPanel'
 
-export function LabTaskSidebar({ detail, onClose }: {
+/** The worklog_generate answer shape (mirrors prompts::worklog_generate_schema).
+ *  Every field is optional here because this renders a RAW model answer that may
+ *  be partial or malformed - we fall back to the raw text when it doesn't parse. */
+interface WorklogDraft {
+  matches?: { task_key: string; confidence: number }[]
+  propose?: { issue_type: string; title: string; description: string } | null
+  update?: { summary?: string; sections?: { heading: string; points: string[] }[] }
+}
+
+export function LabTaskSidebar({ detail, variantToken, onClose }: {
   detail: DayTaskDetail
+  // The variant token to draft with (e.g. "local", "custom:nvidia"). Threaded
+  // from RunView so the draft uses whichever variant the timeline is showing.
+  variantToken: string
   onClose: () => void
 }) {
-  const { title, hue, minutes, segments, summary, footLo, footHi } = detail
+  const { title, hue, minutes, segments, summary, footLo, footHi, day } = detail
   const range = segments.length > 0 ? `${clockLabel(footLo)} - ${clockLabel(footHi)}` : ''
   const sittings = segments.length
+
+  const [drafting, setDrafting] = useState(false)
+  const [draft, setDraft] = useState<string | null>(null)
+  const [draftErr, setDraftErr] = useState<string | null>(null)
+  const [showRaw, setShowRaw] = useState(false)
+
+  async function onDraft() {
+    setDrafting(true)
+    setDraft(null)
+    setDraftErr(null)
+    try {
+      const out = await invoke<string>('draft_lab_worklog', {
+        body: { day, variant: variantToken, task: { title, summary, minutes } },
+      })
+      setDraft(out)
+    } catch (e) {
+      setDraftErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setDrafting(false)
+    }
+  }
 
   return (
     <div className="shrink-0 border-l flex flex-col min-h-0"
@@ -67,8 +106,97 @@ export function LabTaskSidebar({ detail, onClose }: {
           </p>
         </Field>
 
-        {/* Phase B: the on-demand "Draft worklog with this model" action lands here. */}
+        {/* On-demand draft: one real, metered call with the shown variant. */}
+        <div className="pt-1 border-t" style={{ borderColor: 'var(--t-hair)' }}>
+          <div className="pt-3">
+            <button onClick={onDraft} disabled={drafting}
+              className="w-full rounded-lg px-3 py-2"
+              style={{
+                border: '1px solid var(--t-ctrl-border)',
+                background: drafting ? 'var(--t-wrap)' : 'var(--t-ctrl)',
+                color: 'var(--t-title)', cursor: drafting ? 'default' : 'pointer',
+                font: '700 12px var(--font-sans)',
+              }}>
+              {drafting ? 'Drafting…' : 'Draft worklog with this model'}
+            </button>
+            <p className="mt-body-sm mt-1.5" style={{ color: 'var(--t-faint)', fontSize: 10.5, lineHeight: 1.45 }}>
+              Sends one real request to this variant - run it only on free or local endpoints.
+            </p>
+          </div>
+
+          {draftErr && (
+            <p className="mt-body-sm mt-3 whitespace-pre-wrap break-words" style={{ color: '#E11D48' }}>
+              {draftErr}
+            </p>
+          )}
+
+          {draft !== null && (
+            <div className="mt-3">
+              <div className="flex items-center justify-between mb-1">
+                <p className="mt-label" style={{ color: 'var(--t-faint)' }}>DRAFTED WORKLOG</p>
+                <button onClick={() => setShowRaw(v => !v)} className="rounded px-1.5 py-0.5"
+                  style={{
+                    border: '1px solid var(--t-ctrl-border)', fontSize: 10, cursor: 'pointer',
+                    background: showRaw ? 'var(--t-wrap)' : 'var(--t-ctrl)', color: 'var(--t-muted)',
+                  }}>
+                  {showRaw ? 'formatted' : 'raw'}
+                </button>
+              </div>
+              <DraftBody raw={draft} showRaw={showRaw} accent={hue} />
+              <p className="mt-body-sm mt-2" style={{ color: 'var(--t-faint)', fontSize: 10.5 }}>
+                Not posted anywhere - a Lab draft for comparison only.
+              </p>
+            </div>
+          )}
+        </div>
       </div>
+    </div>
+  )
+}
+
+/** Render the model's raw worklog_generate answer: the drafted update prose when
+ *  it parses to the expected shape, else the raw text. `raw` mode always shows the
+ *  raw answer verbatim. */
+function DraftBody({ raw, showRaw, accent }: { raw: string; showRaw: boolean; accent: string }) {
+  let parsed: WorklogDraft | null = null
+  if (!showRaw) {
+    try {
+      parsed = JSON.parse(raw) as WorklogDraft
+    } catch {
+      parsed = null
+    }
+  }
+
+  if (showRaw || !parsed?.update) {
+    return (
+      <pre className="whitespace-pre-wrap break-words"
+        style={{ font: '400 11px/1.5 var(--font-mono, ui-monospace)', color: 'var(--t-muted)', margin: 0 }}>
+        {raw}
+      </pre>
+    )
+  }
+
+  const { matches, propose, update } = parsed
+  const target = matches && matches.length > 0
+    ? `Posts to ${matches.map(m => m.task_key).join(', ')}`
+    : propose
+      ? `Proposes a new ticket: [${propose.issue_type}] ${propose.title}`
+      : 'No ticket match - unposted note'
+
+  return (
+    <div className="space-y-2">
+      <p className="mt-body-sm" style={{ color: 'var(--t-faint)', fontSize: 10.5 }}>{target}</p>
+      {update?.summary && (
+        <p className="mt-body-sm" style={{ color: 'var(--t-muted)', lineHeight: 1.5 }}>{update.summary}</p>
+      )}
+      {update?.sections?.map((s, i) => (
+        <div key={i}>
+          <p className="mt-body-sm mt-1" style={{ color: 'var(--t-title)', fontWeight: 700, fontSize: 11.5 }}>
+            {s.heading}
+          </p>
+          <Bullets items={s.points} accent={accent} size={11.5} />
+        </div>
+      ))}
     </div>
   )
 }

--- a/ui/components/timeline/llmlab/LabTaskSidebar.tsx
+++ b/ui/components/timeline/llmlab/LabTaskSidebar.tsx
@@ -1,0 +1,74 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// The LLM Lab's task sidebar: when a task card is clicked in a fold variant's
+// timeline (VariantBody -> DayTaskColumn), its breakdown renders HERE, beside the
+// timeline. Read-only by design and DELIBERATELY not DayTaskDetailPanel - that
+// panel drives useWorklog (get / generate / approve) against the PRODUCTION
+// day_task_worklogs tables for a task id, and a fold's task ids are a model's
+// SIMULATED day, not real rows. So this shows only what the fold result itself
+// carries: when the task was worked, and the model's own per-task log. The
+// "draft with this model" action (a metered, on-demand call) is wired in Phase B.
+// Dev-only surface - plain hyphens in all copy.
+
+'use client'
+
+import { fmtDur } from '@/components/atoms'
+import { clockLabel } from '../dayTaskLayout'
+import { Bullets, Field } from '../dayTaskKit'
+import type { DayTaskDetail } from '../DayTaskDetailPanel'
+
+export function LabTaskSidebar({ detail, onClose }: {
+  detail: DayTaskDetail
+  onClose: () => void
+}) {
+  const { title, hue, minutes, segments, summary, footLo, footHi } = detail
+  const range = segments.length > 0 ? `${clockLabel(footLo)} - ${clockLabel(footHi)}` : ''
+  const sittings = segments.length
+
+  return (
+    <div className="shrink-0 border-l flex flex-col min-h-0"
+      style={{ width: 340, borderColor: 'var(--t-hair)', background: 'var(--t-box)' }}>
+      {/* header: task title + close */}
+      <div className="flex items-start gap-2 px-4 py-3 border-b shrink-0" style={{ borderColor: 'var(--t-hair)' }}>
+        <span className="shrink-0 rounded-full mt-1" style={{ width: 8, height: 8, background: hue }} />
+        <div className="flex-1 min-w-0">
+          <p className="mt-label" style={{ color: 'var(--t-faint)' }}>TASK</p>
+          <p className="mt-card-title" style={{ color: 'var(--t-title)', lineHeight: 1.3 }}>
+            {title || 'Activity'}
+          </p>
+        </div>
+        <button onClick={onClose} aria-label="Close"
+          className="inline-flex items-center justify-center rounded-full bg-wrap shrink-0"
+          style={{ width: 26, height: 26, color: 'var(--t-muted)' }}>
+          <span className="text-[15px] leading-none">×</span>
+        </button>
+      </div>
+
+      {/* scrolling detail */}
+      <div className="flex-1 min-h-0 overflow-y-auto nice-scroll px-4 py-4 space-y-4">
+        <Field label="WHEN">
+          <p className="mt-body-sm" style={{ color: 'var(--t-muted)' }}>
+            {range || 'No timing recorded'}
+            {minutes > 0 && <span style={{ color: 'var(--t-faint)' }}> · {fmtDur(minutes * 60)}</span>}
+            {sittings > 1 && <span style={{ color: 'var(--t-faint)' }}> · {sittings} sittings</span>}
+          </p>
+        </Field>
+
+        <Field label="WHAT WAS DONE">
+          {summary.length > 0 ? (
+            <Bullets items={summary} accent={hue} size={12.5} />
+          ) : (
+            <p className="mt-body-sm" style={{ color: 'var(--t-faint)' }}>
+              This model logged no per-task detail.
+            </p>
+          )}
+          <p className="mt-body-sm mt-2" style={{ color: 'var(--t-faint)', fontSize: 10.5 }}>
+            This is the model's own per-task log - Lab output, not posted.
+          </p>
+        </Field>
+
+        {/* Phase B: the on-demand "Draft worklog with this model" action lands here. */}
+      </div>
+    </div>
+  )
+}

--- a/ui/components/timeline/llmlab/LlmLabScreen.tsx
+++ b/ui/components/timeline/llmlab/LlmLabScreen.tsx
@@ -1,33 +1,45 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 //
-// The dev-only "LLM Lab" modal: replay one pipeline prose stage across several
-// provider/model variants and compare the outcomes side by side. Left rail =
-// past runs (click to reopen); right pane = the RunComposer for a new run, or
-// the ResultsGrid for the selected/active one. Rendered by MeridianTimelineShell
-// ONLY when get_app_info reports the 'dev' channel; every backing command is
-// additionally refused in release builds (commands/llm_lab.rs) - this surface
-// does not exist for users. Plain hyphens in all copy.
+// The dev-only "LLM Lab" surface: replay one pipeline prose stage across several
+// provider/model variants and compare the outcomes. A FULL-SCREEN panel (its own
+// dashboard, not a modal) - left rail = past runs (click to reopen); right =
+// the RunComposer for a new run, or RunView for the selected/active one (a single
+// timeline with a variant switcher + task sidebar). Rendered by
+// MeridianTimelineShell ONLY when get_app_info reports the 'dev' channel; every
+// backing command is additionally refused in release builds (commands/llm_lab.rs)
+// - this surface does not exist for users. Plain hyphens in all copy.
 
 'use client'
 
-import { ModalShell } from '../ModalShell'
-import { ResultsGrid } from './ResultsGrid'
+import { useEffect } from 'react'
 import { RunComposer } from './RunComposer'
+import { RunView, PROCESS_NAMES } from './RunView'
 import { useLlmLab } from './useLlmLab'
 import type { LlmExperimentSummary } from '@/lib/api-types'
 
-const PROCESS_NAMES: Record<string, string> = {
-  hour_report: 'Hour report',
-  workstream_fold: 'Day-task fold',
-  day_fold: 'Full-day fold',
-  worklog_generate: 'Worklog draft',
-}
-
-export function LlmLabModal({ onClose }: { onClose: () => void }) {
+export function LlmLabScreen({ onClose }: { onClose: () => void }) {
   const { runs, detail, starting, error, run, openRun, closeRun } = useLlmLab()
 
+  // Escape closes the surface (matches the wrapper-modal convention it replaces).
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
   return (
-    <ModalShell title="LLM Lab (dev only)" onClose={onClose} maxWidth={1180} scrollInside>
+    <div className="absolute inset-0 z-40 flex flex-col bg-panel rise">
+      {/* header */}
+      <div className="flex items-center justify-between px-6 py-4 border-b shrink-0" style={{ borderColor: 'var(--t-hair)' }}>
+        <p className="mt-modal-title text-title">LLM Lab (dev only)</p>
+        <button onClick={onClose} aria-label="Close"
+          className="inline-flex items-center justify-center rounded-full bg-wrap"
+          style={{ width: 30, height: 30, color: 'var(--t-muted)' }}>
+          <span className="text-[17px] leading-none">×</span>
+        </button>
+      </div>
+
+      {/* body: past-runs rail | composer or run */}
       <div className="flex flex-1 min-h-0">
         {/* past runs rail */}
         <div className="shrink-0 border-r flex flex-col min-h-0" style={{ width: 250, borderColor: 'var(--t-hair)' }}>
@@ -56,26 +68,18 @@ export function LlmLabModal({ onClose }: { onClose: () => void }) {
           </div>
         </div>
 
-        {/* composer / results */}
-        <div className="flex-1 min-w-0 min-h-0 flex flex-col p-5">
+        {/* composer / run */}
+        <div className="flex-1 min-w-0 min-h-0 flex flex-col">
           {detail
-            ? (
-              <>
-                <div className="flex items-baseline gap-2.5 pb-3 shrink-0">
-                  <p className="mt-card-title" style={{ color: 'var(--t-title)' }}>
-                    {PROCESS_NAMES[detail.process] ?? detail.process} · {detail.input_ref}
-                  </p>
-                  <span className="mt-body-sm" style={{ color: 'var(--t-faint)' }}>
-                    {detail.status === 'running' ? 'running…' : detail.status} · run #{detail.id}
-                  </span>
-                </div>
-                <ResultsGrid detail={detail} />
-              </>
-            )
-            : <RunComposer starting={starting} error={error} onRun={run} />}
+            ? <RunView key={detail.id} detail={detail} />
+            : (
+              <div className="flex-1 min-h-0 overflow-y-auto nice-scroll p-5">
+                <RunComposer starting={starting} error={error} onRun={run} />
+              </div>
+            )}
         </div>
       </div>
-    </ModalShell>
+    </div>
   )
 }
 

--- a/ui/components/timeline/llmlab/RunView.tsx
+++ b/ui/components/timeline/llmlab/RunView.tsx
@@ -1,0 +1,119 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// One LLM Lab run, shown as a single timeline with a variant switcher. The run
+// fanned a prose stage across N provider/model variants; instead of N columns
+// side by side, this shows ONE variant full-width (VariantBody) with a tab strip
+// to swap between them - so a fold variant's day fills the pane as the real
+// dashboard timeline. Clicking a task card opens the run's shared LabTaskSidebar
+// beside the timeline. Mounted by LlmLabScreen (keyed by run id). Dev-only
+// surface - plain hyphens in all copy.
+
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import type { LlmExperimentDetail } from '@/lib/api-types'
+import { llmProvider, type LlmProviderId } from '@/lib/llm-providers'
+import type { DayTaskDetail } from '../DayTaskDetailPanel'
+import { VariantBody, STATUS_META, isFoldProcess } from './VariantBody'
+import { LabTaskSidebar } from './LabTaskSidebar'
+
+/** Wire process -> display name. Also used by LlmLabScreen's past-runs rail. */
+export const PROCESS_NAMES: Record<string, string> = {
+  hour_report: 'Hour report',
+  workstream_fold: 'Day-task fold',
+  day_fold: 'Full-day fold',
+  worklog_generate: 'Worklog draft',
+}
+
+export function RunView({ detail }: { detail: LlmExperimentDetail }) {
+  const fold = isFoldProcess(detail.process)
+  const results = detail.results
+
+  // Default the switcher to the first ok variant (else the first) - computed once
+  // for this run; the view is keyed by run id, so a new run gets a fresh default.
+  const firstOk = useMemo(() => {
+    const i = results.findIndex(r => r.status === 'ok')
+    return i >= 0 ? i : 0
+  }, [results])
+
+  const [selectedIdx, setSelectedIdx] = useState(firstOk)
+  const [selectedTask, setSelectedTask] = useState<DayTaskDetail | null>(null)
+
+  // The results array grows/settles as the run polls; keep the index in range.
+  useEffect(() => {
+    if (selectedIdx >= results.length) setSelectedIdx(0)
+  }, [results.length, selectedIdx])
+
+  const selected = results[selectedIdx]
+
+  // Switching variant clears the task selection - task ids (T1, T2) are
+  // per-variant (each model builds its OWN day), so a stale id must not carry
+  // across a switch.
+  function pickVariant(idx: number) {
+    setSelectedIdx(idx)
+    setSelectedTask(null)
+  }
+
+  return (
+    <div className="flex-1 min-h-0 flex flex-col">
+      {/* run header */}
+      <div className="flex items-baseline gap-2.5 px-5 pt-4 pb-3 shrink-0">
+        <p className="mt-card-title" style={{ color: 'var(--t-title)' }}>
+          {PROCESS_NAMES[detail.process] ?? detail.process} · {detail.input_ref}
+        </p>
+        <span className="mt-body-sm" style={{ color: 'var(--t-faint)' }}>
+          {detail.status === 'running' ? 'running…' : detail.status} · run #{detail.id}
+        </span>
+      </div>
+
+      {/* variant switcher */}
+      <div className="flex items-center gap-2 px-5 pb-3 shrink-0 overflow-x-auto nice-scroll">
+        {results.map((r, idx) => {
+          const meta = llmProvider(r.provider as LlmProviderId)
+          const status = STATUS_META[r.status] ?? STATUS_META.pending
+          const active = idx === selectedIdx
+          return (
+            <button key={r.variant_idx} onClick={() => pickVariant(idx)}
+              className="inline-flex items-center gap-2 rounded-full px-3 py-1.5 shrink-0"
+              style={{
+                border: `1px solid ${active ? 'var(--btn-primary-bg)' : 'var(--t-card-border)'}`,
+                background: active ? 'var(--t-wrap)' : 'var(--t-box)',
+                cursor: 'pointer',
+              }}>
+              <span className="inline-block w-2 h-2 rounded-full shrink-0" style={{ background: status.color }} />
+              <span className="mt-card-title" style={{ color: active ? 'var(--t-title)' : 'var(--t-muted)', fontSize: 12 }}>
+                {meta.name}
+              </span>
+              {r.model !== '' && (
+                <span className="font-mono rounded px-1 py-0.5"
+                  style={{ fontSize: 9.5, background: 'var(--t-wrap)', color: 'var(--t-faint)' }}>
+                  {r.model}
+                </span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* selected variant, full-width, + the run's shared task sidebar */}
+      <div className="flex-1 min-h-0 flex border-t" style={{ borderColor: 'var(--t-hair)' }}>
+        {selected ? (
+          <VariantBody
+            key={selected.variant_idx}
+            result={selected}
+            fold={fold}
+            selectedTask={selectedTask}
+            onSelectTask={setSelectedTask}
+          />
+        ) : (
+          <p className="flex-1 mt-body-sm px-5 py-4" style={{ color: 'var(--t-faint)' }}>
+            This run has no variants.
+          </p>
+        )}
+        {fold && selectedTask && (
+          <LabTaskSidebar detail={selectedTask} onClose={() => setSelectedTask(null)} />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/ui/components/timeline/llmlab/RunView.tsx
+++ b/ui/components/timeline/llmlab/RunView.tsx
@@ -11,11 +11,20 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import type { LlmExperimentDetail } from '@/lib/api-types'
+import type { LlmExperimentDetail, LlmExperimentResult } from '@/lib/api-types'
 import { llmProvider, type LlmProviderId } from '@/lib/llm-providers'
 import type { DayTaskDetail } from '../DayTaskDetailPanel'
 import { VariantBody, STATUS_META, isFoldProcess } from './VariantBody'
 import { LabTaskSidebar } from './LabTaskSidebar'
+
+/** The variant token the daemon understands (matches the composer / CLI): a
+ *  custom endpoint is `custom:<id>`, an explicit model is `provider:model`, and a
+ *  bare provider is just its id. Threaded to the draft button so it drafts with
+ *  the variant currently shown. */
+function variantToken(r: LlmExperimentResult): string {
+  if (r.provider === 'custom') return `custom:${r.model}`
+  return r.model ? `${r.provider}:${r.model}` : r.provider
+}
 
 /** Wire process -> display name. Also used by LlmLabScreen's past-runs rail. */
 export const PROCESS_NAMES: Record<string, string> = {
@@ -110,8 +119,13 @@ export function RunView({ detail }: { detail: LlmExperimentDetail }) {
             This run has no variants.
           </p>
         )}
-        {fold && selectedTask && (
-          <LabTaskSidebar detail={selectedTask} onClose={() => setSelectedTask(null)} />
+        {fold && selectedTask && selected && (
+          <LabTaskSidebar
+            key={selectedTask.id}
+            detail={selectedTask}
+            variantToken={variantToken(selected)}
+            onClose={() => setSelectedTask(null)}
+          />
         )}
       </div>
     </div>

--- a/ui/components/timeline/llmlab/RunView.tsx
+++ b/ui/components/timeline/llmlab/RunView.tsx
@@ -38,8 +38,8 @@ export function RunView({ detail }: { detail: LlmExperimentDetail }) {
   const fold = isFoldProcess(detail.process)
   const results = detail.results
 
-  // Default the switcher to the first ok variant (else the first) - computed once
-  // for this run; the view is keyed by run id, so a new run gets a fresh default.
+  // The first ok variant, else the first. Recomputed as the run polls, so it
+  // tracks completions rather than being frozen at mount.
   const firstOk = useMemo(() => {
     const i = results.findIndex(r => r.status === 'ok')
     return i >= 0 ? i : 0
@@ -47,6 +47,22 @@ export function RunView({ detail }: { detail: LlmExperimentDetail }) {
 
   const [selectedIdx, setSelectedIdx] = useState(firstOk)
   const [selectedTask, setSelectedTask] = useState<DayTaskDetail | null>(null)
+  // Whether the user has clicked a switcher tab. Until they do, the view
+  // auto-follows the first variant to finish; the view is keyed by run id, so a
+  // new run starts untouched.
+  const [touched, setTouched] = useState(false)
+
+  // Auto-follow the first completion: while untouched, if the shown variant is
+  // not itself ok and SOME variant now is, snap to the first ok one. This lands a
+  // still-running run on whichever model finishes first, instead of sitting on a
+  // pending/failed variant. Once the shown variant is ok (or the user clicks) it
+  // stays put - no jumping back to a lower-index variant that finishes later.
+  useEffect(() => {
+    if (touched) return
+    if (results[selectedIdx]?.status !== 'ok' && results.some(r => r.status === 'ok')) {
+      setSelectedIdx(firstOk)
+    }
+  }, [touched, results, selectedIdx, firstOk])
 
   // The results array grows/settles as the run polls; keep the index in range.
   useEffect(() => {
@@ -55,12 +71,13 @@ export function RunView({ detail }: { detail: LlmExperimentDetail }) {
 
   const selected = results[selectedIdx]
 
-  // Switching variant clears the task selection - task ids (T1, T2) are
-  // per-variant (each model builds its OWN day), so a stale id must not carry
-  // across a switch.
+  // A manual pick freezes the choice (stops auto-follow) and clears the task
+  // selection - task ids (T1, T2) are per-variant (each model builds its OWN
+  // day), so a stale id must not carry across a switch.
   function pickVariant(idx: number) {
     setSelectedIdx(idx)
     setSelectedTask(null)
+    setTouched(true)
   }
 
   return (

--- a/ui/components/timeline/llmlab/VariantBody.tsx
+++ b/ui/components/timeline/llmlab/VariantBody.tsx
@@ -1,21 +1,23 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 //
-// The LLM Lab's side-by-side comparison: one column per provider/model variant,
-// each showing its outcome badge, timing/token metrics, and the output. For the
-// fold processes (workstream_fold / day_fold) a successful variant's
-// output_rendered is a DayTasksResponse - it is fed straight into the REAL
-// DayTaskColumn, so each column shows the day's actual dashboard timeline as
-// that model would have built it. Other processes render text; every column has
-// a raw toggle. Dev-only surface - plain hyphens in all copy.
+// One LLM Lab variant's rendered outcome, drawn full-width for the single-timeline
+// view (RunView). For a fold process (workstream_fold / day_fold) a successful
+// variant's output_rendered is a DayTasksResponse - it is fed straight into the
+// REAL DayTaskColumn, so the pane shows the day's actual dashboard timeline as
+// that model would have built it, and clicking a card drives the run's shared
+// task sidebar (selection is owned by RunView, not here). Other processes render
+// text with a raw toggle; failed / rate-limited / pending variants show their
+// status instead of an empty pane. Extracted from the former ResultsGrid's
+// VariantColumn. Dev-only surface - plain hyphens in all copy.
 
 'use client'
 
 import { useMemo, useState } from 'react'
-import type { DayTasksResponse, LlmExperimentDetail, LlmExperimentResult } from '@/lib/api-types'
-import { llmProvider, type LlmProviderId } from '@/lib/llm-providers'
+import type { DayTasksResponse, LlmExperimentResult } from '@/lib/api-types'
 import { DayTaskColumn } from '../DayTaskColumn'
+import type { DayTaskDetail } from '../DayTaskDetailPanel'
 
-const STATUS_META: Record<string, { label: string; color: string }> = {
+export const STATUS_META: Record<string, { label: string; color: string }> = {
   pending: { label: 'Queued', color: 'var(--t-faint)' },
   running: { label: 'Running…', color: 'var(--color-state-pending)' },
   ok: { label: 'OK', color: 'var(--color-state-approved)' },
@@ -25,7 +27,7 @@ const STATUS_META: Record<string, { label: string; color: string }> = {
 
 /** The two processes whose rendered output is a day-task set the real timeline
  *  can draw. */
-function isFoldProcess(process: string): boolean {
+export function isFoldProcess(process: string): boolean {
   return process === 'workstream_fold' || process === 'day_fold'
 }
 
@@ -43,28 +45,20 @@ function fmtTokens(n: number | null): string {
   return n && n > 0 ? String(n) : '-'
 }
 
-export function ResultsGrid({ detail }: { detail: LlmExperimentDetail }) {
-  const fold = isFoldProcess(detail.process)
-  return (
-    <div className="flex-1 min-h-0 flex gap-3 overflow-x-auto nice-scroll" style={{ padding: 2 }}>
-      {detail.results.map(r => (
-        <VariantColumn key={r.variant_idx} result={r} fold={fold} />
-      ))}
-    </div>
-  )
-}
-
 /** A fold variant's rendered payload: the day-task set (+ optional honesty note,
  *  e.g. "no usable placements" / "stopped at <hour>"). */
 type FoldRender = (DayTasksResponse & { note?: string }) | null
 
-function VariantColumn({ result, fold }: { result: LlmExperimentResult; fold: boolean }) {
+/** One variant's body, full-width. `selectedTask` / `onSelectTask` are the run's
+ *  shared task selection (owned by RunView) - clicking a fold card opens the
+ *  sidebar beside this pane. */
+export function VariantBody({ result, fold, selectedTask, onSelectTask }: {
+  result: LlmExperimentResult
+  fold: boolean
+  selectedTask: DayTaskDetail | null
+  onSelectTask: (detail: DayTaskDetail | null) => void
+}) {
   const [showRaw, setShowRaw] = useState(false)
-  // Local selection so clicking a task card highlights it (there is no right
-  // panel inside the modal to show its detail).
-  const [selectedTask, setSelectedTask] = useState<string | null>(null)
-  const meta = llmProvider(result.provider as LlmProviderId)
-  const status = STATUS_META[result.status] ?? STATUS_META.pending
 
   // Parse the fold payload once per result; a parse failure falls back to text.
   const foldRender: FoldRender = useMemo(() => {
@@ -80,28 +74,10 @@ function VariantColumn({ result, fold }: { result: LlmExperimentResult; fold: bo
   const timeline = foldRender !== null && !showRaw
 
   return (
-    <div className="flex flex-col shrink-0 rounded-xl overflow-hidden"
-      style={{ width: fold ? 420 : 340, border: '1px solid var(--t-card-border)', background: 'var(--t-box)' }}>
-      {/* header: provider + model chip + status badge */}
-      <div className="flex items-center gap-2 px-3.5 py-2.5 border-b shrink-0" style={{ borderColor: 'var(--t-hair)' }}>
-        <span className="mt-card-title truncate" style={{ color: 'var(--t-title)' }}>{meta.name}</span>
-        {result.model !== '' && (
-          <span className="font-mono truncate rounded px-1.5 py-0.5"
-            style={{ fontSize: 10, background: 'var(--t-wrap)', color: 'var(--t-muted)' }}>
-            {result.model}
-          </span>
-        )}
-        <span className="ml-auto inline-flex items-center gap-1.5 shrink-0">
-          {result.status === 'running' && (
-            <span className="inline-block w-2 h-2 rounded-full animate-pulse" style={{ background: status.color }} />
-          )}
-          <span className="mt-body-sm" style={{ color: status.color, fontWeight: 700 }}>{status.label}</span>
-        </span>
-      </div>
-
+    <div className="flex-1 min-h-0 flex flex-col">
       {/* metrics row */}
-      <div className="flex items-center gap-3 px-3.5 py-1.5 border-b shrink-0"
-        style={{ borderColor: 'var(--t-hair)', color: 'var(--t-faint)', fontSize: 10.5 }}>
+      <div className="flex items-center gap-3 px-4 py-2 border-b shrink-0"
+        style={{ borderColor: 'var(--t-hair)', color: 'var(--t-faint)', fontSize: 11 }}>
         <span>time {fmtElapsed(result.elapsed_s)}</span>
         <span>tokens in {fmtTokens(result.input_tokens)} / out {fmtTokens(result.output_tokens)}</span>
         {result.status === 'ok' && (
@@ -117,29 +93,30 @@ function VariantColumn({ result, fold }: { result: LlmExperimentResult; fold: bo
 
       {/* honesty note from the renderer (kept prior state / partial day) */}
       {timeline && foldRender?.note && (
-        <p className="px-3.5 py-1.5 border-b shrink-0 mt-body-sm"
-          style={{ borderColor: 'var(--t-hair)', color: 'var(--color-state-pending)', fontSize: 10.5 }}>
+        <p className="px-4 py-1.5 border-b shrink-0"
+          style={{ borderColor: 'var(--t-hair)', color: 'var(--color-state-pending)', fontSize: 11 }}>
           {foldRender.note}
         </p>
       )}
 
       {/* body */}
       {timeline && foldRender ? (
-        // The REAL dashboard timeline, fed this variant's simulated day.
+        // The REAL dashboard timeline, fed this variant's simulated day. Selection
+        // is the run's shared state, so a click here opens the task sidebar.
         <div className="flex-1 min-h-0">
           <DayTaskColumn
             day={foldRender.day}
             isToday={false}
-            selectedId={selectedTask}
-            onSelect={d => setSelectedTask(d?.id ?? null)}
+            selectedId={selectedTask?.id ?? null}
+            onSelect={onSelectTask}
             tasks={foldRender.tasks}
           />
         </div>
       ) : (
-        <div className="flex-1 min-h-0 overflow-y-auto nice-scroll px-3.5 py-3">
+        <div className="flex-1 min-h-0 overflow-y-auto nice-scroll px-5 py-4">
           {result.status === 'ok' && (
             <pre className="whitespace-pre-wrap break-words"
-              style={{ font: '400 11.5px/1.55 var(--font-mono, ui-monospace)', color: 'var(--t-muted)', margin: 0 }}>
+              style={{ font: '400 12px/1.6 var(--font-mono, ui-monospace)', color: 'var(--t-muted)', margin: 0, maxWidth: 760 }}>
               {(showRaw ? result.output_text : result.output_rendered) ?? '(no output recorded)'}
             </pre>
           )}
@@ -151,7 +128,7 @@ function VariantColumn({ result, fold }: { result: LlmExperimentResult; fold: bo
               {/* A failed day-fold still carries the partial day it built. */}
               {result.output_rendered && fold && (
                 <pre className="whitespace-pre-wrap break-words mt-2"
-                  style={{ font: '400 10.5px/1.5 var(--font-mono, ui-monospace)', color: 'var(--t-faint)', margin: 0 }}>
+                  style={{ font: '400 11px/1.5 var(--font-mono, ui-monospace)', color: 'var(--t-faint)', margin: 0 }}>
                   {result.output_rendered}
                 </pre>
               )}


### PR DESCRIPTION
> **Base / scope note:** this PR targets `feat/llm-provider-enum`, which trails `feat/llm-provider-connectivity-test` (the branch this was cut from) by the whole in-flight LLM-provider + Lab stack. So the raw diff is large (~127 files). The change THIS PR adds is the **top two commits** (`875641ea`, `8f8a7853`) - 11 files under `ui/components/timeline/llmlab/`, `src/llm_experiment/`, `src/pm_worklog/generate.rs`, and the tray `llm_lab` command. Re-target the base to `feat/llm-provider-connectivity-test` for a clean 2-commit review.

## What

Turns the dev-only **LLM Lab** from a 1180px modal into its **own full-screen surface**. A run now shows **one variant's timeline at a time** with a **variant-switcher** tab strip, clicking a task card in a fold variant opens a **task sidebar** beside the timeline, and the sidebar can **draft that task's worklog on demand** with the shown variant.

## Phase A - full-screen surface, switcher, sidebar

- **`LlmLabModal` -> `LlmLabScreen`**: full-viewport panel (`absolute inset-0`, own header, Escape-to-close) replacing the `ModalShell` wrapper.
- **`RunView`** (new): run header + variant-switcher tab strip + single full-width body. Switching variant **clears the task selection** - task ids (`T1`,`T2`) are per-variant (each model builds its own day), so a stale id must not carry across a switch.
- **`VariantBody`** (extracted from the former `ResultsGrid.VariantColumn`): one variant, full-width, preserving every `ok` / `failed` / `rate_limited` / `pending` branch so a non-ok variant shows its status, not a blank pane.
- **`LabTaskSidebar`** (new): Lab-local read-only detail (When + the model's per-task log) from the `DayTaskDetail` the timeline already emits. **Deliberately not `DayTaskDetailPanel`/`useWorklog`** - those drive production worklog tables for a task id, and a fold's ids are a model's simulated day, not real rows.
- `ResultsGrid.tsx` / `LlmLabModal.tsx` removed; shell import + JSX updated.

## Phase B - on-demand "Draft with this model"

The sidebar drafts THIS fold task's worklog with whichever variant the timeline is showing - a **metered, ephemeral** call, gated behind a **free/local caution**, that writes nothing.

- Because a fold task id is a model's simulated day (not a production `day_tasks` row), the draft is built from the task's **inline content**, never a production lookup:
  - `generate.rs`: `generate_request_from_task` builds the worklog-generate request from an inline title/summary/minutes, reusing the real board candidate set + the identical prompt/schema.
  - `runner.rs`: `variant_backend`'s core is now `resolve_backend(provider, model)`, shared with the draft path (`custom:<id>` included).
  - `cli.rs`: `meridian llm-experiment draft-task --day --variant --task-json` - one completion, prints `{"draft": …}`, persists nothing.
  - tray `draft_lab_worklog`: dev-gated command that shells out to it.
  - `LabTaskSidebar`: the button + free/local caution + a formatted/raw render of the drafted update (posts-to / summary / sections).

## Reconciliation carried in code

A fold `DayTask` has no drafted-worklog prose - only `summary` bullets. Real prose comes only from `worklog_generate`, which reads production `day_tasks`. So the sidebar shows the summary log for free, and the polished prose is the **on-demand, metered** draft above - never auto-run.

## Gating

Unchanged - dev-only (`channel === 'dev'` in the shell + `commands/llm_lab.rs` release refusal). This surface does not exist for users.

## Verified

- Daemon: `cargo clippy` clean; `llm_experiment` tests (20) pass.
- Tray: `cargo clippy -- -D warnings` clean.
- UI: `npm run build` (TypeScript pass) + `bun test` (227 pass).
- **Draft path exercised end-to-end** against the freshly-built binary (temp DB, free `local` variant): `meridian llm-experiment draft-task --variant local …` returns a real drafted worklog in the `{update:{summary,sections}}` shape the sidebar renders - so `generate_request_from_task` -> `resolve_backend` -> `complete` all run.
- Pre-push suite (fmt + clippy + cargo test + ui build/tests + security audit) green.

## Not yet verified

- The **in-app GUI click-through** in a live tray (full-screen layout, variant switcher, sidebar, and the draft button invoke) has not been run - it needs a dev tray build. Recommend a smoke test on a real `day_fold` run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)