### PR TITLE
fix(capture): drain autorelease pools around per-tick Vision OCR and AX walks

### DIFF
--- a/tray/src-tauri/src/capture/screenpipe.rs
+++ b/tray/src-tauri/src/capture/screenpipe.rs
@@ -98,7 +98,10 @@ impl CaptureEngine for ScreenpipeEngine {
             // and MUST finish before any await: `&dyn TreeWalkerPlatform` is
             // `Send` but not `Sync`, so the reference cannot cross an await
             // point. Returning an owned outcome keeps the borrow local to here.
-            let outcome = try_walk_a11y(walker.as_ref());
+            // Pooled: the AX calls autorelease bridged values into the current
+            // thread's pool, and tokio worker threads never drain one — see
+            // `with_autorelease_pool`.
+            let outcome = with_autorelease_pool(|| try_walk_a11y(walker.as_ref()));
             // Pre-capture gate: macOS blanks/flickers DRM video whenever ANY
             // ScreenCaptureKit session is active on the display — regardless
             // of which window it targets — so the OCR fallback's SCK call
@@ -354,7 +357,14 @@ async fn capture_once_ocr(
         if is_self_app(&win.app_name.to_lowercase()) {
             continue;
         }
-        let (text, _json, _confidence) = screenpipe_screen::perform_ocr_apple(&win.image, &[]);
+        // Pooled: Apple Vision autoreleases its request/observation objects and
+        // intermediate CGImages into the current thread's pool on every call.
+        // This is the hottest allocation site in the engine (a full retina
+        // window bitmap per tick for canvas apps like Figma that always take
+        // the OCR path), so without a per-call drain the process grows without
+        // bound — see `with_autorelease_pool`.
+        let (text, _json, _confidence) =
+            with_autorelease_pool(|| screenpipe_screen::perform_ocr_apple(&win.image, &[]));
         if text.trim().is_empty() {
             continue; // nothing legible in this window — skip it
         }
@@ -425,6 +435,44 @@ async fn send_frame(
             false
         }
     }
+}
+
+/// Run `f` inside a fresh Objective-C autorelease pool, draining it on return.
+///
+/// The capture loop runs on tokio worker threads. Unlike the main thread —
+/// whose run loop drains an autorelease pool every cycle — a tokio worker
+/// lives for the whole process and never drains one, so every object the
+/// Apple frameworks autorelease during a tick (Vision text observations and
+/// their backing CGImages, AX attribute values, bridged NSStrings) stays
+/// referenced by the thread's pool forever. At one tick every 2 s that is
+/// unbounded multi-GB growth over a workday — worst for canvas apps (Figma),
+/// which take the image-grab + Vision-OCR path on every tick.
+///
+/// `objc_autoreleasePoolPush`/`Pop` is the stable libobjc pair that an
+/// `@autoreleasepool` block compiles down to.
+///
+/// `f` must be synchronous — never hold a pool across an `.await` (the task
+/// can resume on a different worker thread, unbalancing push/pop). Taking a
+/// non-async closure enforces that at the call site.
+fn with_autorelease_pool<R>(f: impl FnOnce() -> R) -> R {
+    #[link(name = "objc")]
+    extern "C" {
+        fn objc_autoreleasePoolPush() -> *mut std::ffi::c_void;
+        fn objc_autoreleasePoolPop(pool: *mut std::ffi::c_void);
+    }
+    // Drop guard so the pool is popped even if `f` panics (unwinding past a
+    // pushed pool would otherwise leak it and everything in it).
+    struct PoolGuard(*mut std::ffi::c_void);
+    impl Drop for PoolGuard {
+        fn drop(&mut self) {
+            // Safety: pops the pool pushed below, on the same thread, exactly once.
+            unsafe { objc_autoreleasePoolPop(self.0) }
+        }
+    }
+    // Safety: push/pop are balanced by the guard; no other pool operations
+    // interleave from this scope.
+    let _pool = PoolGuard(unsafe { objc_autoreleasePoolPush() });
+    f()
 }
 
 /// Register for Screen Recording, but **only prompt when it isn't already


### PR DESCRIPTION
## What does this PR do?

Fixes the unbounded memory growth that drove the Meridian tray to 11.58 GB on a user's machine (macOS "your system has run out of application memory" dialog, Meridian force-quit prompt). The in-process capture engine runs its 2-second tick on tokio worker threads, which - unlike the main thread's run loop - never drain an Objective-C autorelease pool. Every tick's synchronous Apple framework calls (the AX tree walk; and, for canvas apps like Figma that always take the OCR fallback, an Apple Vision OCR pass over a full retina window bitmap) autorelease objects (Vision text observations, backing CGImages, AX attribute values, bridged NSStrings) into the calling thread's pool, where they accumulate for the process lifetime. Over a workday that is multi-GB growth - worst for users parked in a canvas app, which matches the affected user (Figma visible in their screenshot). The fix adds a `with_autorelease_pool` helper (the stable `objc_autoreleasePoolPush`/`Pop` libobjc pair that `@autoreleasepool` compiles to, with a panic-safe drop guard) and wraps the two synchronous framework call sites: the per-tick `try_walk_a11y` and each per-window `perform_ocr_apple`. The closure-based API structurally prevents holding a pool across an `.await`.

Residual follow-up (fork-side, out of reach from this repo): `capture_all_visible_windows`/`list_monitors` are async, so their ScreenCaptureKit internals can't be pooled from this call site; if growth persists after this fix, the `Meridiona/screenpipe-fork` capture/OCR internals should get the same audit.

## How was it tested?

- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [ ] UI builds (`cd ui && npm run build`)
- [ ] Manually tested the relevant flow

`cargo fmt --check` passes on `tray/src-tauri`. The touched module is macOS-only (behind the `capture` feature, depending on the private `screenpipe-fork` git crates), so it cannot be compiled in the Linux environment this change was authored in - the release/staging macOS build is the compile gate. The change mirrors the file's existing raw-FFI `extern "C"` patterns and adds no new dependencies. Suggested manual verification on a Mac: run a packaged capture build, park a Figma/Chrome window in the foreground for 30+ minutes, and watch the tray's footprint in Activity Monitor stay flat (it previously grew continuously).

## Checklist

- [ ] Branch named `type/short-description`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] New `.rs`/`.ts`/`.tsx` files start with the file-header comment (see CLAUDE.md)
- [x] New migrations are numbered and don't modify existing ones
- [x] No secrets, credentials, or `.env` files committed

## Related issues

<!-- none filed - fix originated from a user crash report screenshot -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bTb3ftbUfsMxSzHHYwbLU

---
_Generated by [Claude Code](https://claude.ai/code/session_012bTb3ftbUfsMxSzHHYwbLU)_