### PR TITLE
fix(ci): force clean notifications-plugin build so its Swift static lib links

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -31,7 +31,7 @@
       ]
     }],
     ["@semantic-release/exec", {
-      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && cargo build --release && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build) && bash scripts/notarize-dmg.sh ${nextRelease.version} && bash scripts/package-release.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}",
+      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && cargo build --release && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray/src-tauri && cargo clean -p tauri-plugin-notifications) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build) && bash scripts/notarize-dmg.sh ${nextRelease.version} && bash scripts/package-release.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}",
       "publishCmd": "npm publish ./npm/meridian-darwin-arm64 --access public"
     }],
     ["@semantic-release/npm", { "pkgRoot": "npm/meridian" }],

--- a/.releaserc.staging.json
+++ b/.releaserc.staging.json
@@ -32,7 +32,7 @@
       ]
     }],
     ["@semantic-release/exec", {
-      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && cargo build --release && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build -- --config src-tauri/tauri.staging.conf.json) && bash scripts/notarize-dmg.sh ${nextRelease.version} && bash scripts/package-release.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}",
+      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && cargo build --release && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray/src-tauri && cargo clean -p tauri-plugin-notifications) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build -- --config src-tauri/tauri.staging.conf.json) && bash scripts/notarize-dmg.sh ${nextRelease.version} && bash scripts/package-release.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}",
       "publishCmd": "bash scripts/mirror-staging-release.sh ${nextRelease.version}"
     }]
   ]


### PR DESCRIPTION
## What

Adds `(cd tray/src-tauri && cargo clean -p tauri-plugin-notifications)` before the tray `tauri build` in both release `prepareCmd`s (`.releaserc.staging.json` and `.releaserc.json`).

## Why

The staging release ([run 29633169319](https://github.com/Meridiona/meridian/actions/runs/29633169319), and again on re-run 29633739910) failed the tray Tauri build with:

```
error: could not find native static library `tauri-plugin-notifications`, perhaps an -L flag is missing?
error: could not compile `tauri-plugin-notifications` (lib) due to 1 previous error
```

The daemon `cargo build --release`, the UI build, and codesigning all succeeded first — only the tray's native link of the notifications fork failed. It surfaces inside `@semantic-release/exec`, so the top-level symptom read as "semantic-release failed."

**Root cause is a rust-cache + build-script interaction, not the released code.** The pinned community fork `tauri-plugin-notifications = "=0.4.6"` has a `build.rs` that runs `swift build` and writes `libtauri-plugin-notifications.a` **into its cargo registry source tree** (`~/.cargo/registry/src/.../macos/.build/arm64-apple-macosx/release/`), then emits `cargo:rustc-link-search` to that same path. `Swatinem/rust-cache@v2` caches `target/` (including the plugin's build-script fingerprint) but **not** `registry/src` (it re-extracts it empty). On a cache restore the fingerprint reads "up to date", so cargo **skips `build.rs`** → `swift build` never runs → the `.a` is absent at link time → the linker error above.

Verified:
- The passing build (04:19) and both failing builds used the **same** runner image `macos-26-arm64/20260715.0248` and Swift toolchain.
- The plugin pin and `tray/src-tauri/Cargo.lock` are **byte-identical** across pass and fail.
- No `swift` compiler diagnostics in the log — Swift was skipped, not failing (the fork's own `assert!("Swift build failed")` never fired).
- Reproduced twice on the same SHA; re-running does **not** clear it.

## Fix

Force `build.rs` to re-run before the tray build so `swift build` regenerates the `.a` into the freshly-extracted source, matching the emitted `-L`. ~30-60s of Swift recompile per release, negligible against a ~45-min build. Applied to both staging and production prepare commands since they share the pattern.

## Deeper fix (follow-up, not in this PR)

The real bug is upstream: a build script must emit generated artifacts into `OUT_DIR` (cached, co-located with the fingerprint), not into its own registry source. The clean fix is forking the plugin under Meridiona (already floated in the `Cargo.toml` comment) and pointing `swift_library_static_lib_dir()` at `OUT_DIR`.

## Verification after merge

Once merged to `pre-main`, trigger a staging build with a `[staging-release]` marker commit and confirm the tray build links and the DMG publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)