### PR TITLE
fix(ci): add --release to notifications-plugin clean so it actually rebuilds

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -31,7 +31,7 @@
       ]
     }],
     ["@semantic-release/exec", {
-      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && cargo build --release && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray/src-tauri && cargo clean -p tauri-plugin-notifications) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build) && bash scripts/notarize-dmg.sh ${nextRelease.version} && bash scripts/package-release.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}",
+      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && cargo build --release && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray/src-tauri && cargo clean -p tauri-plugin-notifications --release) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build) && bash scripts/notarize-dmg.sh ${nextRelease.version} && bash scripts/package-release.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}",
       "publishCmd": "npm publish ./npm/meridian-darwin-arm64 --access public"
     }],
     ["@semantic-release/npm", { "pkgRoot": "npm/meridian" }],

--- a/.releaserc.staging.json
+++ b/.releaserc.staging.json
@@ -32,7 +32,7 @@
       ]
     }],
     ["@semantic-release/exec", {
-      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && cargo build --release && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray/src-tauri && cargo clean -p tauri-plugin-notifications) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build -- --config src-tauri/tauri.staging.conf.json) && bash scripts/notarize-dmg.sh ${nextRelease.version} && bash scripts/package-release.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}",
+      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && cargo build --release && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray/src-tauri && cargo clean -p tauri-plugin-notifications --release) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build -- --config src-tauri/tauri.staging.conf.json) && bash scripts/notarize-dmg.sh ${nextRelease.version} && bash scripts/package-release.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}",
       "publishCmd": "bash scripts/mirror-staging-release.sh ${nextRelease.version}"
     }]
   ]


### PR DESCRIPTION
## TL;DR

#461's `cargo clean -p tauri-plugin-notifications` was a **no-op** — without `--release` it cleans only the dev-profile artifacts, so the release build's fingerprint stayed intact and `build.rs` never re-ran. That's why staging failed **identically** after #461 ([run 29634723442](https://github.com/Meridiona/meridian/actions/runs/29634723442)). This adds `--release`.

## Root cause (now verified end-to-end)

The pinned fork `tauri-plugin-notifications = "=0.4.6"` has a `build.rs` that runs `swift build` and writes `libtauri-plugin-notifications.a` **into the cargo registry source tree** (`~/.cargo/registry/src/.../macos/.build/…`), then emits `-L` there. `Swatinem/rust-cache` caches `target/` (incl. the plugin's build-script fingerprint) but **not** `registry/src` (re-extracted pristine). So on a cache restore: fingerprint says "up to date" → `build.rs` skipped → `swift build` never runs → the `.a` is absent at link time.

#461 tried to force the rebuild but used `cargo clean -p <pkg>` **without `--release`**, which only touches dev-profile artifacts.

## Verified on the CI-identical toolchain (macOS 26 / Xcode 26.6 / Swift 6.3.3)

Simulating the runner's state (target cached, registry-src `.build` wiped):

```
cargo clean -p tauri-plugin-notifications            → "Removed 0 files"  → plugin NOT rebuilt → .a absent  (reproduces CI)
cargo clean -p tauri-plugin-notifications --release  → "Removed 21 files" → "Compiling tauri-plugin-notifications v0.4.6" → .a regenerated → links ✅
```

## Change

Add `--release` to the clean in both `.releaserc.staging.json` and `.releaserc.json` (prod uses the same pattern).

## Follow-up (separate, not this PR)

The band-aid is reliable but the fork's `build.rs` is the real problem, and upstream **already fixed it** — issue [Choochmeque#183](https://github.com/Choochmeque/tauri-plugin-notifications/issues/183) is this exact error, resolved by building into `OUT_DIR` (present in `0.5.0-rc.11` / `main`, absent in the stable `0.4.6` we pin). Durable fix is to move to the OUT_DIR-fixed version (or a Meridiona fork of `0.4.6` + that patch) and drop this clean step. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)