### PR TITLE
docs(whats-new): add the 1.72.0 entry for the post-1.71.0 work

### DIFF
--- a/tray/src-tauri/resources/whats-new.json
+++ b/tray/src-tauri/resources/whats-new.json
@@ -1,6 +1,28 @@
 {
   "releases": [
     {
+      "version": "1.72.0",
+      "date": "2026-07-18",
+      "highlights": [
+        "Choose apps and websites for Meridian to ignore, so nothing from them is ever captured. Set them up in Settings.",
+        "Bring your own cloud AI provider: add any OpenAI-compatible endpoint from the provider picker and Meridian will use it for worklogs and summaries.",
+        "Test your AI provider connection from Settings or during setup, so you can confirm it works before relying on it.",
+        "A new AI-composed daily summary that reads like a summary of your day, with the charts chosen to fit what actually happened.",
+        "The day timeline shows the current hour as a live strip again, so you can watch the hour fill in as you work.",
+        "Worklogs now follow the day's plan and post to every ticket you actually moved forward.",
+        "Added a \"suggest a feature\" link to the roadmap in What's New."
+      ],
+      "fixes": [
+        "Fixed a memory leak that made Meridian's memory use climb while screen capture was running.",
+        "Fixed duplicate and missing worklogs when the same hour was processed more than once.",
+        "Fixed worklog drafting failing on the Codex provider, and it now reports the real reason when it does fail.",
+        "Fixed a failed update showing a stale download percentage when you retried it.",
+        "Fixed modals scrolling instead of fitting, clipped task titles, and changing a task's status from Cleanup.",
+        "Fixed a task card's summary clipping mid-line instead of leaving room for the \"+N more\" label.",
+        "Made the AI provider picker easier to read."
+      ]
+    },
+    {
       "version": "1.71.0",
       "date": "2026-07-15",
       "highlights": [


### PR DESCRIPTION
## What

Adds a new **1.72.0** entry to the front of `tray/src-tauri/resources/whats-new.json`, covering the user-visible work that landed on `pre-main` after the 1.71.0 release.

`v1.71.0` was published to users on 2026-07-15 (not a prerelease, marked Latest), so **its entry is left untouched** - these notes go in a new entry rather than amending shipped release notes.

## Highlights (7)

App/website ignore rules in Settings, custom OpenAI-compatible cloud providers from the provider picker, the provider connectivity test, the AI-composed daily summary, the live-hour strip back on the day timeline, plan-scoped worklog posting, and the roadmap's "suggest a feature" link.

## Fixes (7)

The capture memory leak, duplicate/missing worklogs when an hour was processed twice, Codex worklog drafting (and it now reports the real error), the stale retry download percentage, modal/task-title/Cleanup status issues, task-card summary clipping, and provider-picker readability.

## Deliberately excluded

Everything dev-only, since none of it is user-visible: the entire LLM Lab line, `dev-start` changes, the `MERIDIAN_BIN` override, and the CI build fixes.

## Conventions

- Every bullet rewritten in plain user terms, not lifted from commit messages (per the What's New task in CLAUDE.md).
- All copy uses plain hyphens - verified no em-dash, en-dash, or double-hyphen anywhere in the file.
- `cargo test -p meridian-tray whats_new` passes: `whats_new_json_parses` ok (4 passed, 0 failed).

## Before merging - two things to confirm

1. **Version.** I assumed `1.72.0` (a minor bump above the shipped `1.71.0`, since this batch contains `feat:` commits). Note that staging is currently cutting `1.71.0-staging.N`, which is *below* the already-published `1.71.0` - the staging channel appears to compute from `1.70.0`. If that versioning is off, the next prod release may not land as `1.72.0` and this `version` field should be adjusted to match.
2. **Date.** `2026-07-18` is the drafting date; set it to the actual release day when the release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)