### PR TITLE
fix(ui): brighten the Intelligence picker and gate switching behind Save

### DIFF
--- a/ui/__tests__/intelligence-provider-save.test.ts
+++ b/ui/__tests__/intelligence-provider-save.test.ts
@@ -1,0 +1,186 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+
+// Regression guard for "Settings claims a provider the daemon rejected".
+//
+// THE BUG: Settings → Intelligence wrote the AI-provider choice on a single click:
+//
+//     patch(fields)          // optimistic - mutates the shared RuntimeSettings NOW
+//     save(fields, setStatus)
+//
+// with a code comment claiming `save` "rolls the store back to the server's answer
+// on failure". It does not. `useRuntimeSettings.save` calls `setSettings` ONLY on
+// success and swallows the error (settings/useRuntimeSettings.ts), so a REJECTED
+// write left the optimistic patch in place: the panel went on showing a provider
+// the daemon had refused, with nothing but a transient status to hint otherwise.
+//
+// THE FIX IS STRUCTURAL: a pick is STAGED in component-local `pending` state and
+// nothing is written until an explicit Save reports success. Because no write
+// happens before the outcome is known, there is no rollback to get wrong. On
+// failure the staged pick deliberately SURVIVES, so the user can press Save again
+// without re-picking.
+//
+// Two further rules these guards pin, both easy to regress:
+//   - the dirty check compares the (provider, custom_id) PAIR. 'custom' is a KIND,
+//     so two different endpoints are both id === 'custom'; comparing the id alone
+//     makes switching between them invisible and Save never lights up.
+//   - re-picking whatever is already saved CLEARS the stage, so Save can never
+//     offer to write a change that isn't one.
+//
+// The repo has no React render harness (see plan-store / oauth-setup-lifecycle), so
+// we model the transitions and scan the source for the required shape rather than
+// mounting the component.
+
+const uiRoot = import.meta.dir + '/..'
+const section = readFileSync(uiRoot + '/components/timeline/settings/IntelligenceSection.tsx', 'utf8')
+
+/** Source with comments stripped. The structural guards below assert on CODE - the
+ *  module header deliberately describes the removed `patch()`-on-click behaviour, so
+ *  scanning raw text would conflate documenting the old bug with still doing it. */
+const code = section
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^\s*\/\/.*$/gm, '')
+
+// ── The staging model ────────────────────────────────────────────────────────
+// Mirrors IntelligenceSection's two transitions: `onChange` (stage a pick) and
+// the `save` status callback (resolve it).
+
+interface Choice { id: string; customId: string | null }
+
+/** `onChange`: stage a pick, or clear the stage when it IS the saved choice. */
+function stage(saved: Choice, pick: Choice): Choice | null {
+  const nextCustomId = pick.id === 'custom' ? pick.customId ?? null : null
+  const backToSaved = pick.id === saved.id && (pick.id !== 'custom' || nextCustomId === saved.customId)
+  return backToSaved ? null : { id: pick.id, customId: nextCustomId }
+}
+
+/** The `save` status callback: the stage clears on 'saved' only. */
+function onSaveStatus(pending: Choice | null, status: 'idle' | 'saved' | 'error'): Choice | null {
+  return status === 'saved' ? null : pending
+}
+
+/** What the panel DISPLAYS: the staged pick while one is held, else what's on disk. */
+function shown(saved: Choice, pending: Choice | null): Choice {
+  return pending ?? saved
+}
+
+const CLAUDE: Choice = { id: 'claude', customId: null }
+const LOCAL: Choice = { id: 'local', customId: null }
+const CUSTOM_A: Choice = { id: 'custom', customId: 'endpoint-a' }
+const CUSTOM_B: Choice = { id: 'custom', customId: 'endpoint-b' }
+
+describe('a provider pick is staged, not written', () => {
+  it('picking a different provider stages it without touching the saved choice', () => {
+    const pending = stage(CLAUDE, LOCAL)
+    expect(pending).toEqual(LOCAL)
+    // The panel shows the staged pick...
+    expect(shown(CLAUDE, pending).id).toBe('local')
+    // ...but nothing has been persisted, so the saved choice is still Claude.
+    expect(CLAUDE.id).toBe('claude')
+  })
+
+  it('re-picking the saved provider clears the stage, so Save cannot offer a no-op', () => {
+    expect(stage(CLAUDE, CLAUDE)).toBeNull()
+    // And staging then coming back also clears it.
+    const staged = stage(CLAUDE, LOCAL)
+    expect(staged).not.toBeNull()
+    expect(stage(CLAUDE, CLAUDE)).toBeNull()
+  })
+
+  it('a successful save resolves the stage', () => {
+    const pending = stage(CLAUDE, LOCAL)
+    expect(onSaveStatus(pending, 'saved')).toBeNull()
+  })
+})
+
+// ── The reviewer's explicit ask, and the bug this PR fixes ───────────────────
+describe('a FAILED save keeps the staged pick', () => {
+  it('keeps it, so the user can press Save again without re-picking', () => {
+    const pending = stage(CLAUDE, LOCAL)
+    const after = onSaveStatus(pending, 'error')
+    expect(after).toEqual(LOCAL)
+  })
+
+  it("and the saved choice is untouched — the panel never claims a rejected provider", () => {
+    const saved = CLAUDE
+    const pending = stage(saved, LOCAL)
+    onSaveStatus(pending, 'error')
+    // Nothing was written, so what is actually in force is still Claude.
+    expect(saved).toEqual(CLAUDE)
+  })
+
+  it('the OLD optimistic path retained the rejected provider — proving these discriminate', () => {
+    // Model the pre-fix behaviour: patch() mutated the shared settings BEFORE the
+    // write, and the failure path never restored it.
+    let settings: Choice = { ...CLAUDE }
+    const optimisticPatch = (next: Choice) => { settings = next }
+    optimisticPatch(LOCAL)
+    // save() fails: useRuntimeSettings.save only setSettings on SUCCESS, so nothing
+    // undoes the patch.
+    expect(settings).toEqual(LOCAL)      // <- the bug: shows a provider that was rejected
+    expect(settings).not.toEqual(CLAUDE) // <- and the real setting is misreported
+  })
+})
+
+// ── The pair comparison ──────────────────────────────────────────────────────
+describe("the dirty check compares the (provider, custom_id) pair", () => {
+  it('switching between two custom endpoints registers as a change', () => {
+    const pending = stage(CUSTOM_A, CUSTOM_B)
+    expect(pending).toEqual(CUSTOM_B)
+  })
+
+  it('re-picking the same custom endpoint clears the stage', () => {
+    expect(stage(CUSTOM_A, CUSTOM_A)).toBeNull()
+  })
+
+  it('comparing the id ALONE would miss it — proving the pair matters', () => {
+    const idOnly = (saved: Choice, pick: Choice) => (pick.id === saved.id ? null : pick)
+    // Both are id === 'custom', so an id-only check sees no change and Save never lights up.
+    expect(idOnly(CUSTOM_A, CUSTOM_B)).toBeNull()
+    expect(stage(CUSTOM_A, CUSTOM_B)).not.toBeNull()
+  })
+
+  it('leaving custom for a built-in drops the endpoint id', () => {
+    expect(stage(CUSTOM_A, CLAUDE)).toEqual({ id: 'claude', customId: null })
+  })
+})
+
+// ── The source shape that keeps the above true ───────────────────────────────
+describe('IntelligenceSection writes nothing before a successful save', () => {
+  it('has no optimistic patch() — the call the bug depended on is gone', () => {
+    // `patch` is no longer even a prop; the write happens only inside onSave.
+    expect(code).not.toContain('patch')
+  })
+
+  it('clears the stage only on a SAVED status, never unconditionally', () => {
+    // The single setPending(null) that resolves a save must be guarded by 'saved'.
+    expect(code).toMatch(/'saved'\s*\)\s*setPending\(null\)/)
+    // ...and that is the ONLY place the stage is cleared post-save.
+    const clears = code.match(/setPending\(null\)/g) ?? []
+    expect(clears.length).toBe(1)
+  })
+
+  it('stages the pick in onChange rather than saving from it', () => {
+    expect(code).toContain('setPending(')
+    // onChange must not call save directly - that would restore click-to-apply.
+    const onChangeBody = code.slice(code.indexOf('const onChange'), code.indexOf('const onSave'))
+    expect(onChangeBody).not.toContain('save(')
+  })
+
+  it('renders the picker from the staged pick, so the panel shows what Save would write', () => {
+    expect(code).toMatch(/pending\?\.id\s*\?\?\s*savedId/)
+  })
+})
+
+describe('the Save control cannot fall below the fold', () => {
+  it('is sticky and only rendered while a pick is staged', () => {
+    expect(code).toContain('sticky bottom-0')
+    expect(code).toMatch(/\{pending && \(/)
+  })
+
+  it('tells the user the pick survived a failed write', () => {
+    // Generic "Failed to save" can't say the stage was kept; this line must.
+    expect(code).toContain('still selected here')
+  })
+})

--- a/ui/components/CustomProviders.tsx
+++ b/ui/components/CustomProviders.tsx
@@ -297,16 +297,24 @@ export function CustomProviderCard({ p, picked, probing, onPick, onProbe, onRemo
       style={{
         gap: 8, padding: '13px 14px', borderRadius: 13,
         cursor: selectable ? 'pointer' : 'default',
-        background: picked ? 'color-mix(in srgb, var(--color-state-proposal) 7%, transparent)' : 'var(--t-box)',
-        border: `1px solid ${picked ? 'var(--color-state-proposal)' : 'var(--t-card-border)'}`,
+        // Surfaces match <ProviderCard> exactly - these tiles share its grid, so any
+        // divergence reads as one of the two being broken. See the layering note there
+        // (card on --t-card, inner elements on --t-box).
+        background: picked
+          ? 'color-mix(in srgb, var(--color-state-proposal) 12%, var(--t-card))'
+          : 'var(--t-card)',
+        border: `1px solid ${picked ? 'var(--color-state-proposal)' : 'var(--t-ctrl-border)'}`,
+        boxShadow: picked
+          ? 'inset 0 0 0 1px color-mix(in srgb, var(--color-state-proposal) 30%, transparent)'
+          : '0 1px 2px rgba(0,0,0,.04)',
         opacity: selectable ? 1 : 0.72,
       }}>
       <div className="flex items-start" style={{ gap: 10 }}>
         <span className="flex items-center justify-center shrink-0" style={{
           width: 30, height: 30, borderRadius: 9,
-          background: picked ? 'color-mix(in srgb, var(--color-state-proposal) 12%, transparent)' : 'var(--t-box)',
-          border: '0.5px solid var(--t-card-border)',
-          color: picked ? 'var(--color-state-proposal)' : 'var(--t-faint)',
+          background: picked ? 'color-mix(in srgb, var(--color-state-proposal) 16%, transparent)' : 'var(--t-box)',
+          border: '1px solid var(--t-ctrl-border)',
+          color: picked ? 'var(--color-state-proposal)' : 'var(--t-muted)',
         }}>
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
             <path d="M17.5 19a4.5 4.5 0 0 0 .5-8.97A6 6 0 0 0 6.1 9.4 4.5 4.5 0 0 0 6.5 19z" />
@@ -315,11 +323,13 @@ export function CustomProviderCard({ p, picked, probing, onPick, onProbe, onRemo
         <div style={{ flex: 1, minWidth: 0 }}>
           <span style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--t-title)' }}>{p.name}</span>
           <div className="flex items-center flex-wrap" style={{ gap: 5, marginTop: 4 }}>
+            {/* Sizing/weight kept in step with <Badge> in LlmProviderPicker. */}
             <span className="font-mono" style={{
-              fontSize: 8.5, letterSpacing: '.1em',
+              fontSize: 9.5, letterSpacing: '.09em',
               color: p.production_eligible ? 'var(--color-state-approved)' : 'var(--color-state-pending)',
-              border: `0.5px solid ${p.production_eligible ? 'var(--color-state-approved)' : 'var(--color-state-pending)'}`,
-              borderRadius: 4, padding: '1px 5px', whiteSpace: 'nowrap', textTransform: 'uppercase',
+              border: `1px solid ${p.production_eligible ? 'var(--color-state-approved)' : 'var(--color-state-pending)'}`,
+              background: `color-mix(in srgb, ${p.production_eligible ? 'var(--color-state-approved)' : 'var(--color-state-pending)'} 10%, transparent)`,
+              borderRadius: 4, padding: '1.5px 5px', whiteSpace: 'nowrap', textTransform: 'uppercase',
             }}>
               {probing ? 'TESTING…' : rungLabel(p.effective_rung)}
             </span>
@@ -336,7 +346,7 @@ export function CustomProviderCard({ p, picked, probing, onPick, onProbe, onRemo
         )}
       </div>
 
-      <p className="font-mono" style={{ fontSize: 10, lineHeight: 1.4, color: 'var(--t-faint)', wordBreak: 'break-all' }}>
+      <p className="font-mono" style={{ fontSize: 10, lineHeight: 1.4, color: 'var(--t-muted)', wordBreak: 'break-all' }}>
         {p.model}
       </p>
 
@@ -358,9 +368,10 @@ export function CustomProviderCard({ p, picked, probing, onPick, onProbe, onRemo
           disabled={probing}
           className="font-mono"
           style={{
-            fontSize: 9.5, letterSpacing: '.08em', textTransform: 'uppercase',
-            color: 'var(--t-title)', border: '0.5px solid var(--t-title)',
-            borderRadius: 5, padding: '3px 7px', background: 'transparent',
+            // Filled controls, matching the Test button in <ProviderCard>.
+            fontSize: 10, letterSpacing: '.08em', textTransform: 'uppercase',
+            color: 'var(--t-title)', border: '1px solid var(--t-ctrl-border)',
+            borderRadius: 5, padding: '4px 8px', background: 'var(--t-box)',
             cursor: probing ? 'default' : 'pointer', opacity: probing ? 0.55 : 1,
           }}>
           {probing ? 'Testing…' : p.fully_probed ? 'Re-test' : 'Test'}
@@ -368,9 +379,9 @@ export function CustomProviderCard({ p, picked, probing, onPick, onProbe, onRemo
         <button onClick={remove} disabled={probing}
           className="font-mono"
           style={{
-            fontSize: 9.5, letterSpacing: '.08em', textTransform: 'uppercase',
-            color: 'var(--t-faint)', border: '0.5px solid var(--t-card-border)',
-            borderRadius: 5, padding: '3px 7px', background: 'transparent', cursor: 'pointer',
+            fontSize: 10, letterSpacing: '.08em', textTransform: 'uppercase',
+            color: 'var(--t-muted)', border: '1px solid var(--t-ctrl-border)',
+            borderRadius: 5, padding: '4px 8px', background: 'var(--t-box)', cursor: 'pointer',
           }}>
           Remove
         </button>
@@ -384,14 +395,28 @@ export function AddCustomProvider({ onAdd }: {
   onAdd: (fields: { vendor: string; name: string; base_url: string; model: string; api_key: string }) => Promise<ProbeOutcome>
 }) {
   const [open, setOpen] = useState(false)
-  if (open) return <AddForm onAdd={onAdd} onCancel={() => setOpen(false)} />
+  // The form is wide (URL, model, key), so it takes the whole grid row; the closed tile
+  // is just one more cell. The span lives here because only this component knows which
+  // of the two is showing.
+  if (open) {
+    return (
+      <div style={{ gridColumn: '1 / -1' }}>
+        <AddForm onAdd={onAdd} onCancel={() => setOpen(false)} />
+      </div>
+    )
+  }
   return (
     <button onClick={() => setOpen(true)}
       className="flex items-center justify-center h-full"
       style={{
+        // Same wrap as <ProviderCard>/<CustomProviderCard> - padding, radius, surface and
+        // border weight all match, so it sits in the grid as a peer rather than an
+        // afterthought. Only the border stays DASHED, which is what still reads it as an
+        // "add" affordance instead of a selectable option.
         gap: 7, padding: '13px 14px', borderRadius: 13, minHeight: 76,
-        background: 'transparent', border: '1px dashed var(--t-card-border)',
-        color: 'var(--t-faint)', cursor: 'pointer', fontSize: 12,
+        background: 'var(--t-card)', border: '1px dashed var(--t-ctrl-border)',
+        boxShadow: '0 1px 2px rgba(0,0,0,.04)',
+        color: 'var(--t-muted)', cursor: 'pointer', fontSize: 12,
       }}>
       + Add a custom endpoint
     </button>

--- a/ui/components/LlmProviderPicker.tsx
+++ b/ui/components/LlmProviderPicker.tsx
@@ -132,12 +132,17 @@ function timeAgo(iso: string): string {
 }
 
 function ProviderGlyph({ id, on }: { id: LlmProviderId; on: boolean }) {
-  const color = on ? 'var(--color-state-proposal)' : 'var(--t-faint)'
+  // Unselected uses --t-muted, not --t-faint: on the ink palette --t-faint (#9A8FC2)
+  // against the card reads as disabled rather than merely unselected.
+  const color = on ? 'var(--color-state-proposal)' : 'var(--t-muted)'
   return (
     <span className="flex items-center justify-center shrink-0" style={{
       width: 30, height: 30, borderRadius: 9,
-      background: on ? 'color-mix(in srgb, var(--color-state-proposal) 12%, transparent)' : 'var(--t-box)',
-      border: '0.5px solid var(--t-card-border)', color,
+      // --t-box (the subtle-fill token), not --t-ctrl: on the light palettes --t-ctrl is
+      // #FFFFFF, the same value as the --t-card the glyph now sits on, so it would read
+      // as an empty outline. --t-box lifts off the card on all three palettes.
+      background: on ? 'color-mix(in srgb, var(--color-state-proposal) 16%, transparent)' : 'var(--t-box)',
+      border: '1px solid var(--t-ctrl-border)', color,
     }}>
       {id === 'local' ? (
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
@@ -158,9 +163,12 @@ function Badge({ text, tone }: { text: string; tone: 'accent' | 'warn' | 'muted'
     : tone === 'ok' ? 'var(--color-state-approved)' : 'var(--t-title)'
   return (
     <span className="font-mono" style={{
-      fontSize: 8.5, letterSpacing: '.1em', color: c,
-      border: `0.5px solid ${tone === 'muted' ? 'var(--t-card-border)' : c}`,
-      borderRadius: 4, padding: '1px 5px', whiteSpace: 'nowrap',
+      // 9.5px, not 8.5: at 8.5 these badges carry real state (VERIFIED / NOT
+      // INSTALLED / CONNECTION FAILED) at a size that reads as decorative.
+      fontSize: 9.5, letterSpacing: '.09em', color: c,
+      border: `1px solid ${tone === 'muted' ? 'var(--t-ctrl-border)' : c}`,
+      background: tone === 'muted' ? 'transparent' : `color-mix(in srgb, ${c} 10%, transparent)`,
+      borderRadius: 4, padding: '1.5px 5px', whiteSpace: 'nowrap',
     }}>{text}</span>
   )
 }
@@ -197,9 +205,16 @@ function ProviderCard({ p, picked, missing, testing, lastTest, onPick, onTest }:
       className="flex flex-col text-left h-full"
       style={{
         gap: 8, padding: '13px 14px', borderRadius: 13, cursor: 'pointer',
-        background: picked ? 'color-mix(in srgb, var(--color-state-proposal) 7%, transparent)' : 'var(--t-box)',
-        border: `1px solid ${picked ? 'var(--color-state-proposal)' : 'var(--t-card-border)'}`,
-        boxShadow: picked ? 'inset 0 0 0 1px color-mix(in srgb, var(--color-state-proposal) 22%, transparent)' : 'none',
+        // --t-card, not --t-box: on the ink palette --t-box is rgba(255,255,255,.055),
+        // which leaves the cards barely distinguishable from the desk behind them. The
+        // real card surface reads as a solid, lit object on all three palettes.
+        background: picked
+          ? 'color-mix(in srgb, var(--color-state-proposal) 12%, var(--t-card))'
+          : 'var(--t-card)',
+        border: `1px solid ${picked ? 'var(--color-state-proposal)' : 'var(--t-ctrl-border)'}`,
+        boxShadow: picked
+          ? 'inset 0 0 0 1px color-mix(in srgb, var(--color-state-proposal) 30%, transparent)'
+          : '0 1px 2px rgba(0,0,0,.04)',
         transition: 'background .14s, border-color .14s',
       }}>
       <div className="flex items-start" style={{ gap: 10 }}>
@@ -233,9 +248,11 @@ function ProviderCard({ p, picked, missing, testing, lastTest, onPick, onTest }:
         </p>
       )}
 
-      {/* Picking an uninstalled CLI is allowed, not blocked — show exactly how to get it. */}
+      {/* Picking an uninstalled CLI is allowed, not blocked — show exactly how to get it.
+          Surfaced on --t-key-bg, not --t-card: the card itself is now --t-card, so this
+          inset command block needs its own surface to stay legible as a nested element. */}
       {missing && picked && (
-        <p className="font-mono" style={{ fontSize: 10.5, lineHeight: 1.5, color: 'var(--t-title)', background: 'var(--t-card)', borderRadius: 6, padding: '6px 8px' }}>
+        <p className="font-mono" style={{ fontSize: 10.5, lineHeight: 1.5, color: 'var(--t-key-text)', background: 'var(--t-key-bg)', borderRadius: 6, padding: '6px 8px' }}>
           {p.installHint}
         </p>
       )}
@@ -250,10 +267,13 @@ function ProviderCard({ p, picked, missing, testing, lastTest, onPick, onTest }:
           disabled={testing}
           className="font-mono self-start"
           style={{
-            fontSize: 9.5, letterSpacing: '.08em', textTransform: 'uppercase',
-            color: 'var(--t-title)', border: '0.5px solid var(--t-title)',
-            borderRadius: 5, padding: '3px 7px', cursor: testing ? 'default' : 'pointer',
-            opacity: testing ? 0.55 : 1, background: 'transparent',
+            fontSize: 10, letterSpacing: '.08em', textTransform: 'uppercase',
+            // A filled control on --t-box rather than a hairline outline on transparent,
+            // which on the card surface read as a disabled label. (--t-box, not --t-ctrl:
+            // --t-ctrl equals --t-card on the light palettes - see ProviderGlyph.)
+            color: 'var(--t-title)', border: '1px solid var(--t-ctrl-border)',
+            borderRadius: 5, padding: '4px 8px', cursor: testing ? 'default' : 'pointer',
+            opacity: testing ? 0.55 : 1, background: 'var(--t-box)',
           }}>
           {testing ? 'Testing…' : 'Test connection'}
         </button>
@@ -288,7 +308,10 @@ export default function LlmProviderPicker({ value, selectedCustomId, onChange, s
 
   return (
     <div className="flex flex-col" style={{ gap: 12 }}>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 9 }}>
+      {/* auto-fill rather than a fixed 2 columns: the same grid serves the narrow setup
+          wizard (falls to 2) and the wider Settings pane (fits 3), and more columns means
+          fewer rows, which is what keeps Settings' Save button above the fold. */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(232px, 1fr))', gap: 9 }}>
         {LLM_PROVIDERS.map((p) => {
           const isPicked = p.id === value
           // Unknown (probe failed) is NOT "missing" — only say "not installed" when we
@@ -324,15 +347,15 @@ export default function LlmProviderPicker({ value, selectedCustomId, onChange, s
           />
         ))}
 
-        {/* The form is wide (URL, model, key), so it takes the full row rather than a cell. */}
-        <div style={{ gridColumn: '1 / -1' }}>
-          {!custom.loading && <AddCustomProvider onAdd={custom.add} />}
-        </div>
+        {/* Renders as one more card in the grid; it spans the full row only while its
+            form is open (URL, model, key need the width) - that span is owned by
+            <AddCustomProvider> itself, since only it knows whether the form is showing. */}
+        {!custom.loading && <AddCustomProvider onAdd={custom.add} />}
       </div>
 
       {/* Usage-footprint reassurance — only meaningful when a paid CLI is in play. */}
       {usingCli && (
-        <p style={{ fontSize: 11, lineHeight: 1.45, color: 'var(--t-faint)' }}>
+        <p style={{ fontSize: 11, lineHeight: 1.45, color: 'var(--t-muted)' }}>
           {USAGE_FOOTPRINT_NOTE}
         </p>
       )}
@@ -342,7 +365,7 @@ export default function LlmProviderPicker({ value, selectedCustomId, onChange, s
       {usingCli && picked?.privacyUrl && (
         <div className="flex items-start" style={{
           gap: 8, padding: '10px 12px', borderRadius: 10,
-          background: 'var(--t-box)', border: '0.5px solid var(--t-card-border)',
+          background: 'var(--t-card)', border: '1px solid var(--t-ctrl-border)',
         }}>
           <span className="shrink-0" style={{ marginTop: 1, color: 'var(--color-state-approved)' }} aria-hidden="true">🔒</span>
           <p style={{ fontSize: 11, lineHeight: 1.5, color: 'var(--t-muted)' }}>
@@ -365,17 +388,18 @@ export default function LlmProviderPicker({ value, selectedCustomId, onChange, s
       )}
 
       <div className="flex items-center justify-between">
-        <p style={{ fontSize: 11, color: 'var(--t-faint)', lineHeight: 1.45, flex: 1, paddingRight: 12 }}>
+        <p style={{ fontSize: 11, color: 'var(--t-muted)', lineHeight: 1.45, flex: 1, paddingRight: 12 }}>
           The four coding agents use the login you already have in that CLI - Meridian never asks
           them for an API key, and an hour they can’t serve quietly falls back to on-device. A custom
           endpoint is the exception: it runs on a key you paste here.
         </p>
         <button onClick={rescan} disabled={busy} className="font-mono shrink-0"
           style={{
-            fontSize: 10, letterSpacing: '.08em', textTransform: 'uppercase',
-            color: 'var(--t-title)', border: '0.5px solid var(--t-title)',
-            borderRadius: 6, padding: '4px 9px', cursor: busy ? 'default' : 'pointer',
-            opacity: busy ? 0.55 : 1, background: 'transparent',
+            fontSize: 10.5, letterSpacing: '.08em', textTransform: 'uppercase',
+            // Same fill as the per-card Test buttons - they are the same class of control.
+            color: 'var(--t-title)', border: '1px solid var(--t-ctrl-border)',
+            borderRadius: 6, padding: '5px 10px', cursor: busy ? 'default' : 'pointer',
+            opacity: busy ? 0.55 : 1, background: 'var(--t-box)',
           }}>
           {scanning ? 'Scanning…' : testingIds.size > 0 ? 'Testing…' : 'Rescan'}
         </button>

--- a/ui/components/timeline/SettingsModal.tsx
+++ b/ui/components/timeline/SettingsModal.tsx
@@ -70,7 +70,8 @@ export function SettingsModal({ onClose, initialSection }: {
                   <IntegrationsSection integrations={integrations} onChanged={fetchIntegrations} />
                 )
               )}
-              {section === 'intelligence' && <IntelligenceSection settings={settings} patch={patch} save={save} />}
+              {/* No `patch`: Intelligence stages its pick locally and writes only on Save. */}
+              {section === 'intelligence' && <IntelligenceSection settings={settings} save={save} />}
               {section === 'capture' && <CaptureSection settings={settings} patch={patch} save={save} />}
               {section === 'notifications' && <NotificationsSection settings={settings} patch={patch} save={save} />}
               {section === 'appearance' && <AppearanceSection />}

--- a/ui/components/timeline/settings/IntelligenceSection.tsx
+++ b/ui/components/timeline/settings/IntelligenceSection.tsx
@@ -5,6 +5,16 @@
 // two surfaces can never drift. Switching here takes effect on the NEXT hour with nothing
 // to restart: the resolver re-reads settings.json on every call (src/llm/resolver.rs), so
 // there is deliberately no reload_daemon() here.
+//
+// Unlike the wizard (where each pick writes straight through, because the wizard's own
+// Next/Back is the commit), a pick HERE is only STAGED — it lands in `pending` and is
+// persisted by an explicit Save, matching every other Settings section (Advanced,
+// Capture, Notifications all use <SaveButton>). Staging also removes the old optimistic
+// `patch()`-on-click: `save` only calls setSettings on SUCCESS (useRuntimeSettings.ts),
+// so an optimistic patch survived a FAILED write and left the panel claiming a provider
+// the daemon had rejected. Nothing is written until Save now, so there is nothing to
+// roll back. Only the selection is gated — Test connection, Rescan, and adding/removing
+// custom endpoints stay immediate, since those are actions, not this setting.
 
 'use client'
 
@@ -12,20 +22,32 @@ import { useCallback, useState } from 'react'
 import type { RuntimeSettings } from '@/lib/settings'
 import { llmProvider, type LlmProviderId } from '@/lib/llm-providers'
 import LlmProviderPicker, { useLlmProviderDetection } from '@/components/LlmProviderPicker'
-import type { SaveStatus } from './fields'
+import { SaveButton, type SaveStatus } from './fields'
 
-export function IntelligenceSection({ settings, patch, save }: {
+/** A staged, not-yet-saved provider choice. `customId` is the chosen endpoint when
+ *  `id` is 'custom', else null — the two always travel together (see `onChange`). */
+interface PendingChoice {
+  id: LlmProviderId
+  customId: string | null
+}
+
+export function IntelligenceSection({ settings, save }: {
   settings: RuntimeSettings
-  patch: (changes: Partial<RuntimeSettings>) => void
   save: (fields: Partial<RuntimeSettings>, setStatus?: (s: SaveStatus) => void) => Promise<void>
 }) {
   const { status, scanning, testingIds, testOne, rescan } = useLlmProviderDetection()
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle')
+  const [pending, setPending] = useState<PendingChoice | null>(null)
 
-  const provider = settings.llm_provider
+  const savedId = settings.llm_provider
+  const savedCustomId = settings.llm_provider_custom_id ?? null
+  // What the panel SHOWS: the staged pick while one is held, else what's on disk. Every
+  // dependent read below (badges, warnings) uses this, so the whole section describes the
+  // provider you are about to commit rather than half-describing the old one.
+  const provider = pending?.id ?? savedId
+  const selectedCustomId = pending ? pending.customId : savedCustomId
   const picked = llmProvider(provider)
   const localReady = settings.llm_local_chat_model_ready
-  const missing = picked.kind === 'cli' && status[picked.id]?.installed === false
 
   // The chosen provider's last real connectivity test, if any — not a guess. When it
   // failed, the "no fallback" warning below can say what's ACTUALLY happening right now
@@ -34,33 +56,50 @@ export function IntelligenceSection({ settings, patch, save }: {
   const selectedBroken = !!selectedTest && selectedTest.outcome.status !== 'ok'
 
   const onChange = useCallback((id: LlmProviderId, customId?: string) => {
-    if (id === provider && !customId) return
     // 'custom' names a KIND, so it always travels with the endpoint's id - either alone is
     // not a valid choice, and update_settings rejects a custom selection that names no
-    // configured endpoint.
-    const fields: Partial<RuntimeSettings> =
-      id === 'custom' ? { llm_provider: id, llm_provider_custom_id: customId ?? null } : { llm_provider: id }
-    // Optimistic: reflect the pick immediately, then persist. `save` rolls the store back
-    // to the server's answer on failure (it setSettings to the response), so a rejected
-    // write can't leave the UI claiming a provider the daemon isn't running.
-    patch(fields)
-    save(fields, setSaveStatus)
-  }, [provider, patch, save])
+    // configured endpoint. Comparing the PAIR (not just the id) is what makes switching
+    // between two custom endpoints register as a change.
+    const nextCustomId = id === 'custom' ? customId ?? null : null
+    const backToSaved = id === savedId && (id !== 'custom' || nextCustomId === savedCustomId)
+    setSaveStatus('idle')
+    // Re-picking the saved provider clears the stage, so Save can't offer to write a
+    // change that isn't one.
+    setPending(backToSaved ? null : { id, customId: nextCustomId })
+  }, [savedId, savedCustomId])
 
+  const onSave = useCallback(() => {
+    if (!pending) return
+    const fields: Partial<RuntimeSettings> = pending.id === 'custom'
+      ? { llm_provider: pending.id, llm_provider_custom_id: pending.customId }
+      : { llm_provider: pending.id }
+    // `save` never rejects — it reports through the status callback — so the staged pick
+    // is cleared on 'saved' only. On 'error' it deliberately survives, so the user can hit
+    // Save again without re-picking.
+    save(fields, (s) => {
+      setSaveStatus(s)
+      if (s === 'saved') setPending(null)
+    })
+  }, [pending, save])
+
+  // Wider than the other sections' 640px: this one carries a card GRID, and the extra
+  // width buys a third column (see the picker's auto-fill), which is what removes a whole
+  // row of scrolling. Still inside the 980px modal's ~916px of usable width.
   return (
-    <div className="max-w-[640px] flex flex-col gap-5">
+    <div className="max-w-[880px] flex flex-col gap-5">
       <div>
         <p className="mt-label" style={{ color: 'var(--color-state-proposal)' }}>Your AI</p>
         <h1 className="mt-title-lg mt-1.5" style={{ color: 'var(--t-title)' }}>Intelligence</h1>
         <p className="mt-body-sm mt-2 max-w-[520px]" style={{ color: 'var(--t-muted)' }}>
           The AI that writes your hourly summaries. Use a coding-agent CLI you already pay for, or
-          keep it entirely on-device. Takes effect from the next hour - nothing to restart.
+          keep it entirely on-device. Pick one and hit Save - it takes effect from the next hour,
+          with nothing to restart.
         </p>
       </div>
 
       <LlmProviderPicker
         value={provider}
-        selectedCustomId={settings.llm_provider_custom_id}
+        selectedCustomId={selectedCustomId}
         onChange={onChange}
         status={status}
         scanning={scanning}
@@ -68,13 +107,6 @@ export function IntelligenceSection({ settings, patch, save }: {
         testOne={testOne}
         rescan={rescan}
       />
-
-      {/* Save feedback — mirrors the other sections' inline status. */}
-      {saveStatus === 'error' && (
-        <p className="mt-body-sm" style={{ color: 'var(--status-error-dot)' }}>
-          Couldn&apos;t save that choice. Try again.
-        </p>
-      )}
 
       {/* A KNOWN failure, from the last real test — stronger than the hypothetical warning
           below, since it says what IS happening, not what could. */}
@@ -106,6 +138,23 @@ export function IntelligenceSection({ settings, patch, save }: {
             nothing to fall back to and that hour will be skipped. It downloads automatically the next
             time the model set is fetched.
           </p>
+        </div>
+      )}
+
+      {/* Save is offered only while a pick is staged, so a settled panel carries no dead
+          control - and it is STICKY, pinned to the bottom of the Settings scroll area, so
+          it can never fall below the fold however many providers, custom endpoints or
+          warnings are on screen. Rendered last (after the warnings) so, once scrolled to
+          the end, it sits in natural document order rather than overlapping anything.
+          <SaveButton> supplies its own 'Saved'/'Failed to save' status, the same as
+          Advanced/Capture/Notifications. */}
+      {pending && (
+        <div className="sticky bottom-0 flex flex-col gap-2 pb-1"
+          style={{ background: 'var(--t-panel)' }}>
+          <p className="mt-body-sm" style={{ color: 'var(--color-state-pending)' }}>
+            {`${llmProvider(pending.id).name} isn't in use yet - Save to switch to it.`}
+          </p>
+          <SaveButton status={saveStatus} onClick={onSave} />
         </div>
       )}
     </div>

--- a/ui/components/timeline/settings/IntelligenceSection.tsx
+++ b/ui/components/timeline/settings/IntelligenceSection.tsx
@@ -147,12 +147,18 @@ export function IntelligenceSection({ settings, save }: {
           warnings are on screen. Rendered last (after the warnings) so, once scrolled to
           the end, it sits in natural document order rather than overlapping anything.
           <SaveButton> supplies its own 'Saved'/'Failed to save' status, the same as
-          Advanced/Capture/Notifications. */}
+          Advanced/Capture/Notifications; the line above it carries the part that generic
+          status can't - WHICH provider is staged, and (on failure) that the pick survived
+          the failed write, so Save can simply be pressed again without re-picking. */}
       {pending && (
         <div className="sticky bottom-0 flex flex-col gap-2 pb-1"
           style={{ background: 'var(--t-panel)' }}>
-          <p className="mt-body-sm" style={{ color: 'var(--color-state-pending)' }}>
-            {`${llmProvider(pending.id).name} isn't in use yet - Save to switch to it.`}
+          <p className="mt-body-sm" style={{
+            color: saveStatus === 'error' ? 'var(--status-error-dot)' : 'var(--color-state-pending)',
+          }}>
+            {saveStatus === 'error'
+              ? `Couldn't switch to ${llmProvider(pending.id).name} - it's still selected here, so you can press Save to try again.`
+              : `${llmProvider(pending.id).name} isn't in use yet - Save to switch to it.`}
           </p>
           <SaveButton status={saveStatus} onClick={onSave} />
         </div>


### PR DESCRIPTION
## What does this PR do?

Two things the Settings -> Intelligence panel was getting wrong: it read as pale and greyed out, and switching the AI provider applied on a single click with no confirmation.

### 1. Readability

The provider cards had their **surface layering inverted**. The *card* was painted with `--t-box` - on the `ink` palette that is `rgba(255,255,255,.055)`, all but invisible against the desk - behind a `0.5px` border at 10% white, while the elements *inside* it used the solid `--t-card`.

Swapped to the correct order: card on `--t-card`, inner elements (glyph, Test button) on `--t-box`, with a full-weight `1px --t-ctrl-border`, badges up from 8.5px to 9.5px, and the dim `--t-faint` body notes lifted to `--t-muted`.

Deliberately **avoided `--t-ctrl` for inner fills**: it is `#FFFFFF` on the light palettes, identical to the `--t-card` those elements now sit on, so they would have disappeared. Everything stays token-based, so it holds across `lilac` / `blush` / `ink`.

### 2. Switching now requires Save

A pick stages into local `pending` state and is written only by an explicit Save - matching every other Settings section (Advanced, Capture and Notifications all use `<SaveButton>`). Intelligence was the outlier.

- The dirty check compares the **`(provider, custom_id)` pair**, so switching between two custom endpoints registers as a change.
- Re-picking the saved provider clears the stage, so Save can never offer a non-change.
- **Only the selection is gated.** Test connection, Rescan and adding/removing custom endpoints stay immediate - those are actions, not this setting.

### 3. Fixes a real bug along the way

The old code applied the pick optimistically via `patch()` before saving, with a comment claiming `save` "rolls the store back on failure". **It does not** - `useRuntimeSettings.save` only calls `setSettings` on *success* (it swallows the error), so a failed write left the panel claiming a provider the daemon had rejected. With nothing written until Save there is nothing to roll back, and a failed save now *keeps* the staged pick so the user can retry without re-picking.

### 4. Layout

- The **Save bar is sticky**, pinned to the bottom of the Settings scroll area, so it cannot fall below the fold however many providers, endpoints or warnings are on screen. (Widening alone would have fixed one screen and regressed the moment another endpoint was added.)
- Section widens **640px -> 880px** (it sat inside a 980px modal, wasting ~280px) and the grid becomes `auto-fill / minmax(232px, 1fr)`, giving Settings a **third column** while the narrower setup wizard naturally keeps two.
- **"+ Add a custom endpoint"** now shares the card wrap and occupies a normal grid cell instead of a full row, keeping only its dashed border to read as an affordance. Its form still spans the row - a span now owned by `AddCustomProvider`, since only it knows whether the form is open.

Also fixes a missing space in "&lt;name&gt; isn't in use yet" and drops a dead `missing` local.

## How was it tested?

- [x] `npm run build` (UI) passes
- [x] `bun test` - 235 pass, 0 fail
- [x] Full pre-push suite green (fmt, clippy, cargo test, ui build, ui tests, security audit)
- [ ] **Not visually verified across all three themes** - see below

## Notes for the reviewer

- **`LlmProviderPicker` is shared** between this panel and the setup wizard's Intelligence step, so the restyle intentionally lands on both. The Save gating does **not** - it lives in `IntelligenceSection` only, because the wizard's own Next/Back is its commit and each pick there writes through by design.
- `IntelligenceSection` no longer takes `patch`; the prop was dropped at the `SettingsModal` call site. The other three sections still use it, so `useRuntimeSettings` is unchanged.
- **Please eyeball this in a running build.** The colour work was reasoned from the token tables rather than seen rendered, so the *magnitude* of the brightening is the thing most worth a second opinion - particularly the sticky bar's `--t-panel` background as content scrolls under it. If the cards feel too narrow at three columns, the `232px` minimum in the grid is the single number to raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Amk5pH47wJj76HBm5oDu9X