### PR TITLE
feat(llm): warn when an endpoint's quota can't cover a working day

### DIFF
--- a/meridian-core/src/lib.rs
+++ b/meridian-core/src/lib.rs
@@ -58,7 +58,7 @@ pub use capture::{
     CaptureUiEventInsert,
 };
 
-pub use util::{date, hygiene, intervals};
+pub use util::{date, hygiene, intervals, llm_capacity};
 
 pub use readers::{
     active, board, capture_apps, coding_agents, current_task, day_evidence, day_summaries,

--- a/meridian-core/src/settings.rs
+++ b/meridian-core/src/settings.rs
@@ -127,6 +127,21 @@ pub struct CustomLlmProvider {
     /// `x-ratelimit-reset-tokens` header on a 429. See `src/llm/rate_limit.rs`.
     #[serde(default)]
     pub rpm: u32,
+    /// Requests-per-DAY ceiling this endpoint's plan allows. `0` (the default) means
+    /// "not known" — never "zero allowed" — so a user who leaves it blank is told we
+    /// cannot judge, not that their key is bad.
+    ///
+    /// Advisory only: nothing paces against it. Unlike [`Self::rpm`], a daily quota has no
+    /// remedy in software — pacing can spread requests across a minute, but it cannot
+    /// conjure a 21st request out of a 20-a-day key. All this field buys is the ability to
+    /// TELL the user before they rely on the endpoint, which is why it feeds
+    /// [`crate::llm_capacity::assess`] and nothing else.
+    ///
+    /// User-entered because it is not discoverable: RPM occasionally arrives in an
+    /// `x-ratelimit-limit-requests` header, but a daily ceiling essentially never does, and
+    /// inferring one from a 429 would mean learning it only after burning the day's quota.
+    #[serde(default)]
+    pub rpd: u32,
     /// The rung measured for EACH pipeline schema, keyed by schema name — not one scalar.
     /// The schemas differ in what they demand (`worklog_generate` carries a union type and
     /// deeper nesting than `workstream`), and a vendor's support is not guaranteed uniform

--- a/meridian-core/src/util/llm_capacity.rs
+++ b/meridian-core/src/util/llm_capacity.rs
@@ -1,0 +1,222 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Is this endpoint's quota big enough to actually run Meridian?
+//!
+//! A free-tier key can be perfectly valid, authenticate fine, answer a test prompt —
+//! and still be unable to serve a working day. The user has no way to know that from
+//! the provider's dashboard, because the number that matters is not "requests per
+//! minute" but "requests per day measured against what this app actually asks for".
+//! This module owns that arithmetic so the answer is computed once, from measured
+//! demand, rather than guessed at in UI copy.
+//!
+//! # The demand figures are measured, not estimated
+//!
+//! Every constant below was counted from the call sites, not assumed:
+//!
+//! * [`CALLS_PER_ACTIVE_HOUR`] — `worklog_pipeline::hour::build_report` makes one call
+//!   and `workstream::run` makes one, sequentially, per hour that clears the activity
+//!   gate. Quiet hours are marked done without any call at all, and the local
+//!   `/distill_hour` step is on-device, so it costs an endpoint nothing.
+//! * [`PROBE_MAX_REQUESTS`] — `llm::probe` walks 4 pipeline schemas × a 4-rung ladder,
+//!   stopping at the first rung that answers. Typically 4 requests, 16 worst case.
+//! * [`DISCRETIONARY_CALLS_PER_DAY`] — the on-demand buttons (day summary, PM worklog
+//!   draft, plan-task draft) are one call each. This is the one genuinely soft number:
+//!   it is a usage guess, not a code-derived count, which is why the verdict leans on
+//!   the automatic figure and treats this as headroom.
+//!
+//! # Why RPM is not the headline
+//!
+//! Pacing (`meridian::llm::rate_limit`) spaces requests to whatever RPM is configured,
+//! so a low RPM costs TIME, not correctness — a 5-RPM key just makes the setup probe
+//! take about three minutes. RPD has no such remedy: when a daily quota is exhausted
+//! the work simply does not happen that day. So the daily figure drives the verdict
+//! and RPM is reported only when it is low enough to be worth mentioning.
+//!
+//! # Who calls this
+//!
+//! `tray/src-tauri/src/commands/custom_llm.rs` — attached to each endpoint's view so
+//! the provider card can warn, and consulted when adding one.
+//!
+//! # Related
+//! - [`crate::settings::CustomLlmProvider`] — where `rpm` / `rpd` are stored.
+
+use serde::{Deserialize, Serialize};
+
+/// LLM calls one hour of real activity costs: the activity report, then the
+/// workstream fold. Both are skipped entirely for an hour that fails the activity
+/// gate, so this is a per-ACTIVE-hour figure.
+pub const CALLS_PER_ACTIVE_HOUR: u32 = 2;
+
+/// Active hours in the working day the verdict is sized for.
+///
+/// A deliberate assumption, and the one most likely to be wrong for a given user —
+/// so the copy built from this states it rather than presenting the verdict as fact.
+pub const ASSUMED_ACTIVE_HOURS: u32 = 8;
+
+/// Worst-case metered requests to measure one endpoint: 4 pipeline schemas × 4
+/// ladder rungs. Typically 4, because most endpoints answer on the first rung.
+///
+/// This is the sharpest test of a daily quota. An endpoint whose whole day is
+/// smaller than its own setup cost cannot be onboarded at all - and unlike the
+/// hourly load it is not spread out, so there is nothing to wait for.
+pub const PROBE_MAX_REQUESTS: u32 = 16;
+
+/// Allowance for the on-demand buttons over a day. A usage guess, unlike the others.
+pub const DISCRETIONARY_CALLS_PER_DAY: u32 = 7;
+
+/// Requests a normal working day needs, excluding one-time setup.
+pub const fn daily_demand() -> u32 {
+    CALLS_PER_ACTIVE_HOUR * ASSUMED_ACTIVE_HOURS + DISCRETIONARY_CALLS_PER_DAY
+}
+
+/// How serious the shortfall is. Ordered from "say nothing" upward.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapacityVerdict {
+    /// Comfortably enough for a working day.
+    Sufficient,
+    /// No limits were entered, so nothing can be judged. Not a problem with the key.
+    Unknown,
+    /// Will run, but the daily quota is expected to run out before the day does.
+    Tight,
+    /// Cannot cover a normal day - hours will be dropped once the quota is spent.
+    Insufficient,
+    /// The daily quota is smaller than the one-time setup probe, so the endpoint
+    /// cannot even be measured, and an unmeasured endpoint is refused by the
+    /// production gate. This key is unusable regardless of how it is paced.
+    CannotOnboard,
+}
+
+/// The full assessment of one endpoint's configured limits.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapacityAssessment {
+    pub verdict: CapacityVerdict,
+    /// Active hours per day this quota covers, once the setup probe is paid for.
+    /// `None` when RPD is unknown.
+    pub covered_active_hours: Option<u32>,
+    /// Requests a normal day needs - what `covered_active_hours` is measured against.
+    pub daily_demand: u32,
+    /// Set when RPM is low enough that the setup probe will visibly pace. Not a
+    /// failure: pacing makes it slow, not broken.
+    pub probe_seconds_at_rpm: Option<u32>,
+}
+
+/// Judge an endpoint's configured limits against what the app actually asks for.
+///
+/// `rpm` / `rpd` of `0` mean "not known" (the settings default), not "zero allowed" —
+/// a user who leaves the fields blank gets [`CapacityVerdict::Unknown`], never a false
+/// alarm. Judging is deliberately based on RPD alone: see the module docs on why a low
+/// RPM is a delay rather than a defect.
+pub fn assess(rpm: u32, rpd: u32) -> CapacityAssessment {
+    let demand = daily_demand();
+
+    // Below this many requests per minute the probe's 16-request burst is paced out
+    // far enough that a user watching the spinner deserves to be told why.
+    let probe_seconds_at_rpm = if rpm > 0 && rpm < PROBE_MAX_REQUESTS {
+        // Even spacing: the first request goes immediately, so it is the GAPS that
+        // cost time - one fewer than the request count.
+        Some((PROBE_MAX_REQUESTS - 1) * 60 / rpm)
+    } else {
+        None
+    };
+
+    if rpd == 0 {
+        return CapacityAssessment {
+            verdict: CapacityVerdict::Unknown,
+            covered_active_hours: None,
+            daily_demand: demand,
+            probe_seconds_at_rpm,
+        };
+    }
+
+    // Setup is paid out of the same daily bucket, so it comes off the top before
+    // asking how much of the working day is left.
+    let after_probe = rpd.saturating_sub(PROBE_MAX_REQUESTS);
+    let covered = after_probe / CALLS_PER_ACTIVE_HOUR;
+
+    let verdict = if rpd <= PROBE_MAX_REQUESTS {
+        CapacityVerdict::CannotOnboard
+    } else if covered >= ASSUMED_ACTIVE_HOURS {
+        CapacityVerdict::Sufficient
+    } else if covered >= ASSUMED_ACTIVE_HOURS / 2 {
+        CapacityVerdict::Tight
+    } else {
+        CapacityVerdict::Insufficient
+    };
+
+    CapacityAssessment {
+        verdict,
+        covered_active_hours: Some(covered),
+        daily_demand: demand,
+        probe_seconds_at_rpm,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The case that prompted this: a real free tier at 5 RPM / 20 RPD. The daily
+    /// quota barely exceeds the setup probe, leaving 2 requests - one active hour.
+    #[test]
+    fn a_twenty_a_day_free_tier_is_insufficient() {
+        let a = assess(5, 20);
+        assert_eq!(a.verdict, CapacityVerdict::Insufficient);
+        assert_eq!(a.covered_active_hours, Some(2));
+    }
+
+    /// A daily quota at or under the probe cost cannot be measured at all, and the
+    /// production gate refuses an unmeasured endpoint - so this is unusable, not slow.
+    #[test]
+    fn a_quota_smaller_than_the_probe_cannot_onboard() {
+        assert_eq!(assess(5, 16).verdict, CapacityVerdict::CannotOnboard);
+        assert_eq!(assess(5, 10).verdict, CapacityVerdict::CannotOnboard);
+        // One request clear of the probe is survivable-in-principle, so it must NOT
+        // claim the endpoint cannot be set up - the honest verdict is "not enough".
+        assert_eq!(assess(5, 17).verdict, CapacityVerdict::Insufficient);
+    }
+
+    /// The other real free tier tested against: 15 RPM / 500 RPD comfortably covers
+    /// a working day, and must not nag.
+    #[test]
+    fn a_five_hundred_a_day_free_tier_is_sufficient() {
+        let a = assess(15, 500);
+        assert_eq!(a.verdict, CapacityVerdict::Sufficient);
+        assert!(a.covered_active_hours.unwrap() >= ASSUMED_ACTIVE_HOURS);
+    }
+
+    /// Blank fields are the settings default. A user who does not know their key's
+    /// limits must get "we cannot tell", never a warning about a key that may be fine.
+    #[test]
+    fn unknown_limits_never_raise_a_false_alarm() {
+        let a = assess(0, 0);
+        assert_eq!(a.verdict, CapacityVerdict::Unknown);
+        assert_eq!(a.covered_active_hours, None);
+        assert_eq!(a.probe_seconds_at_rpm, None);
+        // RPM alone still cannot judge daily capacity.
+        assert_eq!(assess(40, 0).verdict, CapacityVerdict::Unknown);
+    }
+
+    /// RPM affects how long setup TAKES, never whether the key is adequate - pacing
+    /// handles it. A 40-RPM key clears the probe burst outright, so there is nothing
+    /// to report.
+    #[test]
+    fn low_rpm_reports_probe_time_without_changing_the_verdict() {
+        let slow = assess(5, 500);
+        let fast = assess(40, 500);
+        assert_eq!(slow.verdict, fast.verdict);
+        assert_eq!(slow.probe_seconds_at_rpm, Some(180)); // 15 gaps at 12s
+        assert_eq!(fast.probe_seconds_at_rpm, None);
+    }
+
+    /// The boundary the copy hangs on: exactly a full working day is sufficient, one
+    /// request short of it is not.
+    #[test]
+    fn the_sufficiency_boundary_is_a_full_working_day() {
+        let need = PROBE_MAX_REQUESTS + CALLS_PER_ACTIVE_HOUR * ASSUMED_ACTIVE_HOURS;
+        assert_eq!(assess(0, need).verdict, CapacityVerdict::Sufficient);
+        assert_eq!(
+            assess(0, need - CALLS_PER_ACTIVE_HOUR).verdict,
+            CapacityVerdict::Tight
+        );
+    }
+}

--- a/meridian-core/src/util/mod.rs
+++ b/meridian-core/src/util/mod.rs
@@ -3,8 +3,8 @@
 //! local-day boundaries, and board-hygiene reason mapping.
 //!
 //! These modules are re-exported at the crate root (`meridian_core::intervals`,
-//! `::date`, `::hygiene`) so the public API is unchanged; `util` is internal
-//! organization only.
+//! `::date`, `::hygiene`, `::llm_capacity`) so the public API is unchanged; `util`
+//! is internal organization only.
 
 /// Wall-clock interval math shared by the dashboard routes (ported from intervals.ts).
 pub mod intervals;
@@ -14,3 +14,6 @@ pub mod date;
 
 /// Board-hygiene reason → hint/fix mapping (ported from lib/hygiene.ts).
 pub mod hygiene;
+
+/// Is a custom endpoint's configured quota big enough to run the app for a day?
+pub mod llm_capacity;

--- a/src/llm/probe.rs
+++ b/src/llm/probe.rs
@@ -369,6 +369,7 @@ mod tests {
             // resume path still works when a real free tier cuts us off partway. Pacing it
             // would make the very case it covers unreachable.
             rpm: 0,
+            rpd: 0,
             rungs: BTreeMap::new(),
         };
 

--- a/tray/src-tauri/src/commands/custom_llm.rs
+++ b/tray/src-tauri/src/commands/custom_llm.rs
@@ -22,6 +22,7 @@
 //!   the `llm_provider` write.
 //! - `meridian::llm::probe` — the measurement; `meridian_core::SchemaRung` — what it means.
 
+use meridian_core::llm_capacity::{self, CapacityAssessment};
 use meridian_core::{settings, CustomLlmProvider, SchemaRung};
 use serde::Serialize;
 use serde_json::Value;
@@ -48,6 +49,12 @@ pub struct CustomProviderView {
     /// Requests-per-minute ceiling, `0` = unpaced. Safe to surface: unlike the key it is a
     /// user-entered plan limit, not a secret.
     pub rpm: u32,
+    /// Requests-per-day ceiling, `0` = not known. Same safety note as `rpm`.
+    pub rpd: u32,
+    /// Whether these limits can actually run the app for a day, computed in
+    /// `meridian-core` so the frontend renders a verdict rather than deriving a second,
+    /// drifting one from the raw numbers.
+    pub capacity: CapacityAssessment,
     /// Measured rung per schema key. Missing key = never measured.
     pub rungs: std::collections::BTreeMap<String, SchemaRung>,
     /// The weakest measured rung — what the endpoint can actually be trusted to hold.
@@ -69,6 +76,8 @@ impl CustomProviderView {
             base_url: row.base_url.clone(),
             model: row.model.clone(),
             rpm: row.rpm,
+            rpd: row.rpd,
+            capacity: llm_capacity::assess(row.rpm, row.rpd),
             rungs: row.rungs.clone(),
             effective_rung: row.effective_rung(),
             fully_probed: row.is_fully_probed(),
@@ -76,6 +85,19 @@ impl CustomProviderView {
             selected: selected_id == Some(row.id.as_str()),
         }
     }
+}
+
+/// Judge a prospective endpoint's limits WITHOUT saving or contacting anything.
+///
+/// Exists so the add form can warn before the user commits. It could not just do this
+/// arithmetic in TypeScript: adding an endpoint spends real requests from the very quota
+/// being judged, so the warning has to be right the first time, and a second
+/// implementation of [`llm_capacity::assess`] in the frontend would be free to drift
+/// from the one the saved card then shows.
+#[tauri::command]
+#[tracing::instrument]
+pub fn assess_llm_capacity(rpm: u32, rpd: u32) -> CapacityAssessment {
+    llm_capacity::assess(rpm, rpd)
 }
 
 /// What `add`/`probe` report back: the row plus what the measurement cost and whether it
@@ -225,6 +247,7 @@ pub async fn add_custom_llm_provider(
     model: String,
     api_key: String,
     rpm: u32,
+    rpd: u32,
 ) -> Result<ProbeOutcome, String> {
     validate(&name, &base_url, &model, &api_key)?;
 
@@ -251,6 +274,7 @@ pub async fn add_custom_llm_provider(
         model: model.trim().to_string(),
         api_key: api_key.trim().to_string(),
         rpm,
+        rpd,
         rungs: Default::default(),
     };
 

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -624,6 +624,7 @@ pub fn run() {
             // Custom cloud endpoints (add/probe/remove). `add` + `probe` spend real metered
             // requests measuring the endpoint — only ever on explicit user action.
             commands::add_custom_llm_provider,
+            commands::assess_llm_capacity,
             commands::probe_custom_llm_provider,
             commands::remove_custom_llm_provider,
             commands::list_custom_llm_providers,

--- a/ui/components/CustomProviders.tsx
+++ b/ui/components/CustomProviders.tsx
@@ -22,6 +22,8 @@ import {
   CUSTOM_VENDOR_PRESETS,
   customVendorPreset,
   rungLabel,
+  capacityNotice,
+  type CapacityAssessment,
   type CustomProviderView,
   type ProbeOutcome,
 } from '@/lib/llm-providers'
@@ -55,7 +57,7 @@ export function useCustomProviders() {
 
   /** Add + measure one endpoint. Throws the tray's message for the form to show verbatim. */
   const add = useCallback(async (fields: {
-    vendor: string; name: string; base_url: string; model: string; api_key: string; rpm: number
+    vendor: string; name: string; base_url: string; model: string; api_key: string; rpm: number; rpd: number
   }): Promise<ProbeOutcome> => {
     // Tauri maps the Rust command's snake_case params to camelCase JS keys, so the invoke
     // args must be camelCase - `base_url`/`api_key` would be rejected as missing `baseUrl`.
@@ -66,6 +68,7 @@ export function useCustomProviders() {
       model: fields.model,
       apiKey: fields.api_key,
       rpm: fields.rpm,
+      rpd: fields.rpd,
     })
     await refresh()
     return outcome
@@ -132,7 +135,7 @@ function Field({ label, value, onChange, placeholder, type = 'text', mono }: {
  * actually made, not buried in docs read after a billing-enabled key is already pasted.
  */
 function AddForm({ onAdd, onCancel }: {
-  onAdd: (fields: { vendor: string; name: string; base_url: string; model: string; api_key: string; rpm: number }) => Promise<ProbeOutcome>
+  onAdd: (fields: { vendor: string; name: string; base_url: string; model: string; api_key: string; rpm: number; rpd: number }) => Promise<ProbeOutcome>
   onCancel: () => void
 }) {
   const [vendor, setVendor] = useState(CUSTOM_VENDOR_PRESETS[0].id)
@@ -143,12 +146,29 @@ function AddForm({ onAdd, onCancel }: {
   // Held as a string because the number input reports one; coerced at submit. Empty or
   // unparseable means 0, i.e. unpaced - the same as the field never being touched.
   const [rpm, setRpm] = useState('0')
+  const [rpd, setRpd] = useState('0')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   /** A probe that stopped early - the endpoint IS saved, so this is a "resume it" notice,
    *  not a failure. Keeping the form open to say so beats making the user infer it from a
    *  card that merely isn't fully tested. */
   const [incomplete, setIncomplete] = useState<string | null>(null)
+
+  // The quota verdict for what is CURRENTLY typed. Asked of Rust rather than computed
+  // here so the form and the saved card can never disagree - see `assess_llm_capacity`.
+  const [capacity, setCapacity] = useState<CapacityAssessment | null>(null)
+  useEffect(() => {
+    let live = true
+    invoke<CapacityAssessment>('assess_llm_capacity', {
+      rpm: Number(rpm) || 0,
+      rpd: Number(rpd) || 0,
+    })
+      .then(c => { if (live) setCapacity(c) })
+      .catch(() => { if (live) setCapacity(null) })
+    // Guards against a slow answer for old input overwriting a newer one.
+    return () => { live = false }
+  }, [rpm, rpd])
+  const addNotice = capacity ? capacityNotice(capacity) : null
 
   const preset = customVendorPreset(vendor)
   // Only the escape hatch types its own URL; a preset's URL is fixed so a typo can't turn
@@ -167,7 +187,7 @@ function AddForm({ onAdd, onCancel }: {
     setError(null)
     setIncomplete(null)
     try {
-      const outcome = await onAdd({ vendor, name, base_url: baseUrl, model, api_key: apiKey, rpm: Number(rpm) || 0 })
+      const outcome = await onAdd({ vendor, name, base_url: baseUrl, model, api_key: apiKey, rpm: Number(rpm) || 0, rpd: Number(rpd) || 0 })
       setApiKey('')  // the key is stored daemon-side now and never comes back - don't keep it here
       // The endpoint is saved either way; only a COMPLETE measurement closes the form, since
       // an incomplete one has something the user needs to act on.
@@ -237,6 +257,27 @@ function AddForm({ onAdd, onCancel }: {
         when measuring this endpoint. Leave 0 if your plan has no limit.
       </p>
 
+      <Field label="Requests per day" value={rpd} onChange={setRpd} type="number" mono
+        placeholder="0 - not sure" />
+      <p style={{ fontSize: 10.5, lineHeight: 1.45, color: 'var(--t-muted)' }}>
+        The one that usually bites. Nothing can pace around a daily cap, so Meridian uses this
+        only to tell you up front whether the plan covers a working day. Leave 0 if you
+        don&apos;t know it.
+      </p>
+
+      {/* The verdict BEFORE the key is spent. Adding an endpoint costs real requests from the
+          very quota being judged, so someone with a 20-a-day key should learn it is hopeless
+          while they can still choose a different model. */}
+      {addNotice && (
+        <p style={{
+          fontSize: 10.5, lineHeight: 1.45,
+          color: addNotice.tone === 'error' ? 'var(--status-error-dot)'
+            : addNotice.tone === 'warn' ? 'var(--color-state-pending)' : 'var(--t-muted)',
+        }}>
+          {addNotice.text}
+        </p>
+      )}
+
       {error && <p style={{ fontSize: 10.5, lineHeight: 1.4, color: 'var(--status-error-dot)' }}>{error}</p>}
 
       {/* Saved, but not fully measured - say so plainly, because the card alone would only
@@ -287,6 +328,7 @@ export function CustomProviderCard({ p, picked, probing, onPick, onProbe, onRemo
 }) {
   const [removeError, setRemoveError] = useState<string | null>(null)
   const selectable = p.production_eligible
+  const cardNotice = capacityNotice(p.capacity)
 
   async function remove(e: React.MouseEvent) {
     e.stopPropagation()
@@ -361,6 +403,19 @@ export function CustomProviderCard({ p, picked, probing, onPick, onProbe, onRemo
         </p>
       )}
 
+      {/* Quota verdict. Kept on the card, not just the add form, because a plan's limits
+          can change under a key that was fine when it was added - and because a user who
+          skipped the daily limit at add time still gets one chance to fill it in. */}
+      {cardNotice && (
+        <p style={{
+          fontSize: 10.5, lineHeight: 1.4,
+          color: cardNotice.tone === 'error' ? 'var(--status-error-dot)'
+            : cardNotice.tone === 'warn' ? 'var(--color-state-pending)' : 'var(--t-faint)',
+        }}>
+          {cardNotice.text}
+        </p>
+      )}
+
       {removeError && <p style={{ fontSize: 10.5, lineHeight: 1.4, color: 'var(--status-error-dot)' }}>{removeError}</p>}
 
       <div className="flex items-center" style={{ gap: 6 }}>
@@ -393,7 +448,7 @@ export function CustomProviderCard({ p, picked, probing, onPick, onProbe, onRemo
 
 /** The "+ Add custom endpoint" tile, and the form it opens in place. */
 export function AddCustomProvider({ onAdd }: {
-  onAdd: (fields: { vendor: string; name: string; base_url: string; model: string; api_key: string; rpm: number }) => Promise<ProbeOutcome>
+  onAdd: (fields: { vendor: string; name: string; base_url: string; model: string; api_key: string; rpm: number; rpd: number }) => Promise<ProbeOutcome>
 }) {
   const [open, setOpen] = useState(false)
   if (open) return <AddForm onAdd={onAdd} onCancel={() => setOpen(false)} />

--- a/ui/lib/llm-providers.ts
+++ b/ui/lib/llm-providers.ts
@@ -42,11 +42,36 @@ export interface CustomProviderView {
   model: string
   /** Requests-per-minute ceiling; 0 = unpaced. See `CustomLlmProvider::rpm` in Rust. */
   rpm: number
+  /** Requests-per-day ceiling; 0 = not known (never "zero allowed"). */
+  rpd: number
+  /** Whether these limits can run the app for a day. Computed in Rust - never re-derive
+   *  it here from rpm/rpd, or the two answers will drift. */
+  capacity: CapacityAssessment
   rungs: Record<string, SchemaRung>
   effective_rung: SchemaRung
   fully_probed: boolean
   production_eligible: boolean
   selected: boolean
+}
+
+/** How an endpoint's configured quota compares with what the app actually asks for.
+ *  Mirrors `meridian_core::llm_capacity::CapacityVerdict`. */
+export type CapacityVerdict =
+  | 'sufficient'
+  | 'unknown'
+  | 'tight'
+  | 'insufficient'
+  | 'cannot_onboard'
+
+/** Mirrors `meridian_core::llm_capacity::CapacityAssessment`. */
+export interface CapacityAssessment {
+  verdict: CapacityVerdict
+  /** Active hours/day this quota covers once setup is paid for; null when RPD is unknown. */
+  covered_active_hours: number | null
+  /** Requests a normal working day needs. */
+  daily_demand: number
+  /** Seconds the setup probe will take at this RPM, when low enough to be worth saying. */
+  probe_seconds_at_rpm: number | null
 }
 
 /** What `add_custom_llm_provider` / `probe_custom_llm_provider` report back. */
@@ -56,6 +81,64 @@ export interface ProbeOutcome {
   requests: number
   /** Why the probe stopped early (usually a rate limit), or null if it completed. */
   incomplete: string | null
+}
+
+/** What to tell the user about an endpoint's quota, or null when there is nothing worth
+ *  saying. Returns the severity so the caller can style it, and prose that states the
+ *  working-day assumption rather than presenting the verdict as fact.
+ *
+ *  All hyphens here are plain `-` on purpose: this is user-facing app text. */
+export function capacityNotice(
+  c: CapacityAssessment,
+): { tone: 'error' | 'warn' | 'info'; text: string } | null {
+  const day = `about ${c.daily_demand} requests a day`
+  switch (c.verdict) {
+    case 'cannot_onboard':
+      return {
+        tone: 'error',
+        text:
+          `This key's daily limit is too small to even measure the endpoint - checking which ` +
+          `JSON modes it supports costs up to 16 requests on its own. Pick a model with a ` +
+          `higher requests-per-day allowance.`,
+      }
+    case 'insufficient':
+      return {
+        tone: 'error',
+        text:
+          `This key covers roughly ${c.covered_active_hours} active ${hours(c.covered_active_hours)} ` +
+          `a day. Meridian needs ${day} for a normal 8-hour day, so hours past that will be ` +
+          `skipped until the quota resets. Pick a model with a higher requests-per-day allowance.`,
+      }
+    case 'tight':
+      return {
+        tone: 'warn',
+        text:
+          `This key covers roughly ${c.covered_active_hours} active ${hours(c.covered_active_hours)} ` +
+          `a day - enough for a short day, not a full one (Meridian needs ${day}). A model with a ` +
+          `higher requests-per-day allowance would be safer.`,
+      }
+    case 'unknown':
+      return {
+        tone: 'info',
+        text:
+          `Add this plan's requests-per-day limit and Meridian can tell you whether it's enough ` +
+          `for a full day - it needs ${day}. Free tiers are often capped low enough to matter.`,
+      }
+    case 'sufficient':
+      return c.probe_seconds_at_rpm && c.probe_seconds_at_rpm > 60
+        ? {
+            tone: 'info',
+            text:
+              `Plenty for a day's work. The one-time setup check will take about ` +
+              `${Math.round(c.probe_seconds_at_rpm / 60)} minutes, because requests are spaced out ` +
+              `to stay under this key's per-minute limit.`,
+          }
+        : null
+  }
+}
+
+function hours(n: number | null): string {
+  return n === 1 ? 'hour' : 'hours'
 }
 
 /** Human label for a measured rung - what the card says about how far it can be trusted. */


### PR DESCRIPTION
**Stacked on #465** (`feat/llm-rate-limit`) - it reads the same per-endpoint limit config. Base this PR's review on the diff against that branch; retarget to `pre-main` once #465 lands.

## Why

A free-tier key can authenticate fine, answer a test prompt, and still be unable to run the app for a day. Nothing told the user - they found out when hours started going missing. The observed Gemini 3.5 Flash free tier sits at **5 RPM / 20 RPD**, and a counter already reading 6/5 and 22/20.

## The demand figures are measured, not guessed

New `meridian-core::llm_capacity` judges an endpoint against numbers counted from the call sites:

| Constant | Value | Where it comes from |
|---|---|---|
| `CALLS_PER_ACTIVE_HOUR` | 2 | `hour::build_report` + `workstream::run`, sequentially. Quiet hours are gated out entirely and `/distill_hour` is on-device, so neither costs the endpoint. |
| `PROBE_MAX_REQUESTS` | 16 | 4 pipeline schemas x 4 ladder rungs (typically 4 - most endpoints answer on rung one). |
| `daily_demand()` | ~23 | 8 active hours + an allowance for the on-demand buttons. |

The per-hour count corrected a stale claim in `resolver.rs` that said three calls.

## The verdict keys on RPD, not RPM

Pacing (from #465) already spaces requests to whatever RPM is configured, so **a low RPM costs time, not correctness** - a 5-RPM key just makes setup take ~3 minutes, which the copy says out loud. A daily quota has no such remedy: when it is spent, the work does not happen.

| Limits | Verdict |
|---|---|
| 5 RPM / 20 RPD | **Insufficient** - covers ~2 active hours |
| 15 RPM / 500 RPD | **Sufficient**, silent |
| `rpd <= 16` | **CannotOnboard** - the daily quota is smaller than the probe, and the production gate refuses an unmeasured endpoint |

`rpd = 0` means **not known**, never "zero allowed": blank fields produce a soft "add this and we can tell you" note, not a false alarm. RPD is user-entered because it is not discoverable - it essentially never appears in a response header, and inferring it from a 429 means learning it only after burning the day's quota.

## Where it surfaces

- **In the add form, before saving.** Adding an endpoint spends real requests from the very quota being judged, so someone with a 20-a-day key should learn it is hopeless while they can still pick a different model.
- **On the saved card**, since a plan's limits can change under a key that was fine when added, and a user who skipped the field gets another chance to fill it in.

Both render the same verdict from the same Rust function via a new `assess_llm_capacity` command. The arithmetic is deliberately **not** reimplemented in TypeScript, where it would be free to drift from what the card shows.

Advisory only - nothing is blocked, matching the existing warning pattern in `IntelligenceSection`.

## Testing

6 unit tests pinned to the real free tiers (both boundary directions, the unknown-limits case, and that RPM never changes the verdict). Full suite 738 passed / 0 failed; clippy clean on both workspaces; `tsc` and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)