### PR TITLE
feat(release): ship Meridian as a universal (Apple Silicon + Intel) binary

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -57,8 +57,8 @@ body:
   - type: input
     id: chip
     attributes:
-      label: Apple Silicon chip
-      description: e.g. M1, M2 Pro, M4
+      label: Chip
+      description: e.g. M1, M2 Pro, M4, Intel Core i7
       placeholder: "M3 Pro"
     validations:
       required: false

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -2,8 +2,8 @@ name: Release (staging)
 
 # Staging-channel releases via semantic-release, on the `pre-main` branch.
 # Each run cuts a PRERELEASE version (X.Y.Z-staging.N, computed from main's
-# reachable v* tags) that builds the SAME signed DMG + updater artifacts as the
-# production flow, but:
+# reachable v* tags) that builds the SAME signed universal (arm64 + x86_64)
+# DMG + updater artifacts as the production flow, but:
 #   • bakes the STAGING updater endpoint (…/releases/download/updater-staging/
 #     latest.json) into the .app at build time via a --config overlay — never
 #     committed, so it cannot leak to `main`;
@@ -103,6 +103,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.93.1"
+          targets: "aarch64-apple-darwin,x86_64-apple-darwin"
       - uses: Swatinem/rust-cache@v2
 
       - name: Set up Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,18 @@ name: Release
 
 # semantic-release: on every push to main it analyzes conventional commits and,
 # when a release is warranted, bumps the version across all manifests, builds
-# the signed + notarized macOS arm64 .app/DMG, publishes it (plus the updater
-# artifacts) to the GitHub release, creates the tag + CHANGELOG, and commits the
-# version bump back to main.
+# the signed + notarized macOS universal (arm64 + x86_64) .app/DMG, publishes
+# it (plus the updater artifacts) to the GitHub release, creates the tag +
+# CHANGELOG, and commits the version bump back to main.
 #
 # Runs on macos-26 (arm64) because the prepare step compiles the Swift
 # Foundation Models bridge — which needs the macOS 26 SDK — plus the Rust
 # daemon and the dashboard. The bridge is weak-linked, so the resulting binary
 # still launches on older macOS (Foundation Models simply reports unavailable
-# there).
+# there). The x86_64 slice is cross-compiled from this same arm64 runner
+# (`rustup target add x86_64-apple-darwin` below) — Tauri's
+# `--target universal-apple-darwin` builds + lipos both archs itself, no
+# second runner needed.
 
 on:
   push:
@@ -124,6 +127,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.93.1"
+          targets: "aarch64-apple-darwin,x86_64-apple-darwin"
       - uses: Swatinem/rust-cache@v2
 
       - name: Set up Node.js

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -24,10 +24,10 @@
     ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
     ["@semantic-release/github", {
       "assets": [
-        { "path": "target/release/bundle/dmg/Meridian.dmg", "label": "Meridian.dmg (macOS, Apple silicon)" },
-        { "path": "target/release/bundle/macos/Meridian.app.tar.gz", "label": "Meridian.app.tar.gz (updater)" },
-        { "path": "target/release/bundle/macos/Meridian.app.tar.gz.sig", "label": "Meridian.app.tar.gz.sig" },
-        { "path": "target/release/bundle/macos/latest.json", "label": "latest.json (updater manifest)" }
+        { "path": "target/universal-apple-darwin/release/bundle/dmg/Meridian.dmg", "label": "Meridian.dmg (macOS, Apple Silicon + Intel)" },
+        { "path": "target/universal-apple-darwin/release/bundle/macos/Meridian.app.tar.gz", "label": "Meridian.app.tar.gz (updater)" },
+        { "path": "target/universal-apple-darwin/release/bundle/macos/Meridian.app.tar.gz.sig", "label": "Meridian.app.tar.gz.sig" },
+        { "path": "target/universal-apple-darwin/release/bundle/macos/latest.json", "label": "latest.json (updater manifest)" }
       ]
     }],
     ["@semantic-release/exec", {

--- a/.releaserc.staging.json
+++ b/.releaserc.staging.json
@@ -25,10 +25,10 @@
       "successComment": false,
       "failComment": false,
       "assets": [
-        { "path": "target/release/bundle/dmg/Meridian.dmg", "label": "Meridian.dmg (macOS, Apple silicon) — staging ${nextRelease.gitTag}" },
-        { "path": "target/release/bundle/macos/Meridian.app.tar.gz", "label": "Meridian.app.tar.gz (updater)" },
-        { "path": "target/release/bundle/macos/Meridian.app.tar.gz.sig", "label": "Meridian.app.tar.gz.sig" },
-        { "path": "target/release/bundle/macos/latest.json", "label": "latest.json (updater manifest)" }
+        { "path": "target/universal-apple-darwin/release/bundle/dmg/Meridian.dmg", "label": "Meridian.dmg (macOS, Apple Silicon + Intel) — staging ${nextRelease.gitTag}" },
+        { "path": "target/universal-apple-darwin/release/bundle/macos/Meridian.app.tar.gz", "label": "Meridian.app.tar.gz (updater)" },
+        { "path": "target/universal-apple-darwin/release/bundle/macos/Meridian.app.tar.gz.sig", "label": "Meridian.app.tar.gz.sig" },
+        { "path": "target/universal-apple-darwin/release/bundle/macos/latest.json", "label": "latest.json (updater manifest)" }
       ]
     }],
     ["@semantic-release/exec", {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ See **[CLAUDE.md](CLAUDE.md)** for the full architecture and per-task recipes.
 
 ## Development setup
 
-**Requirements:** macOS on Apple Silicon (M1+), Rust 1.93.1 (pinned via `rust-toolchain.toml`), Node 20+.
+**Requirements:** macOS (Apple Silicon or Intel), Rust 1.93.1 (pinned via `rust-toolchain.toml`), Node 20+.
 
 ### First-time setup
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/Meridiona/meridian/actions/workflows/ci.yml/badge.svg)](https://github.com/Meridiona/meridian/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Platform: macOS Apple Silicon](https://img.shields.io/badge/platform-macOS%20Apple%20Silicon-111111.svg)](#install)
+[![Platform: macOS](https://img.shields.io/badge/platform-macOS-111111.svg)](#install)
 [![Built with Rust](https://img.shields.io/badge/built%20with-Rust-dea584.svg)](https://www.rust-lang.org/)
 
 </div>
@@ -49,9 +49,9 @@ A dashboard inside the Meridian app (open it from the menu-bar tray icon) shows 
 
 ## Install
 
-**Requirements:** macOS on Apple Silicon (M1+).
+**Requirements:** macOS (Apple Silicon or Intel).
 
-> Meridian is **Apple Silicon only** — the in-process capture stack and the Metal-accelerated local embedder are arm64/macOS-only, so **Intel Macs are not supported** (the installer checks the hardware and refuses cleanly), and **Windows and Linux are not supported** either. A Rosetta x86_64 terminal or Homebrew on an Apple Silicon Mac is fine — Meridian's own binaries are native arm64 regardless of what's on your `PATH`.
+> Meridian ships as a universal binary — Apple Silicon and Intel Macs are both supported. **Windows and Linux are not supported.** The local embedder is CPU-only (not Metal-accelerated), so it behaves identically on both architectures. A Rosetta x86_64 terminal or Homebrew on an Apple Silicon Mac is fine — Meridian's own binaries carry native code for both architectures regardless of what's on your `PATH`.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Meridiona/meridian/main/scripts/bootstrap.sh | bash

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,6 +1,6 @@
 # Meridian Setup
 
-**Platform:** macOS, Apple Silicon (M1 or later). Intel Macs are not supported.
+**Platform:** macOS (Apple Silicon or Intel). Ships as a universal binary.
 
 ---
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,7 +2,8 @@
 # ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 #
 # Bootstrap installer. Downloads the latest signed + notarized Meridian.app
-# (macOS, Apple Silicon) from the GitHub release, installs it to /Applications,
+# (macOS, universal — Apple Silicon + Intel) from the GitHub release, installs
+# it to /Applications,
 # and launches it. The app stages its own background daemon on first run and
 # opens the setup wizard (permissions + AI provider + tracker) - there is no npm,
 # Node, or Python to install; the .app is fully self-contained.
@@ -24,7 +25,6 @@ err()  { printf '✗ %s\n'   "$*" >&2; exit 1; }
 
 # ── 0. Platform + safety guards ──────────────────────────────────────────────
 [[ "$(uname -s)" == "Darwin" ]] || err "Meridian requires macOS."
-[[ "$(uname -m)" == "arm64"  ]] || err "Meridian requires Apple Silicon (arm64)."
 [[ "$(id -u)" -ne 0          ]] || err "Do not run as root / with sudo. Re-run as your normal user."
 
 DMG_URL="https://github.com/Meridiona/meridian/releases/latest/download/Meridian.dmg"

--- a/scripts/build-daemon-universal.sh
+++ b/scripts/build-daemon-universal.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+#
+# Build the `meridian` daemon as a universal (arm64 + x86_64) binary at
+# target/release/meridian — the fixed path `tauri.conf.json`'s
+# `bundle.resources` embeds into the app (`backend/meridian`).
+#
+# Why this exists: `tauri build --target universal-apple-darwin` auto-lipos
+# the TRAY's own Rust binary, but it does NOT touch arbitrary
+# `bundle.resources` files — the daemon is one of those (a fixed-path
+# resource, not a Tauri externalBin/sidecar), so it needs its own two builds +
+# manual `lipo` before `tauri build` runs. `scripts/sign-daemon.sh` (which
+# runs right after this) already signs whatever binary — thin or fat — ends
+# up at target/release/meridian, so it needs no changes for a universal build.
+#
+#   bash scripts/build-daemon-universal.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+for target in aarch64-apple-darwin x86_64-apple-darwin; do
+  echo "→ build-daemon-universal: cargo build --release --target ${target}"
+  cargo build --locked --release --bin meridian --target "${target}"
+done
+
+mkdir -p target/release
+lipo -create \
+  "target/aarch64-apple-darwin/release/meridian" \
+  "target/x86_64-apple-darwin/release/meridian" \
+  -output "target/release/meridian"
+
+echo "✓ build-daemon-universal: target/release/meridian ($(lipo -archs target/release/meridian))"

--- a/scripts/mirror-staging-release.sh
+++ b/scripts/mirror-staging-release.sh
@@ -23,8 +23,10 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT}"
 
 TAG="updater-staging"
-MAC="target/release/bundle/macos"
-DMG="target/release/bundle/dmg/Meridian.dmg"
+# `--target universal-apple-darwin` bundles under target/universal-apple-darwin/,
+# not plain target/release/.
+MAC="target/universal-apple-darwin/release/bundle/macos"
+DMG="target/universal-apple-darwin/release/bundle/dmg/Meridian.dmg"
 LATEST="${MAC}/latest.json"
 
 # package-updater.sh skips latest.json when updater artifacts weren't signed

--- a/scripts/notarize-dmg.sh
+++ b/scripts/notarize-dmg.sh
@@ -29,7 +29,11 @@ VERSION="${VERSION#v}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
 
-DMG="target/release/bundle/dmg/Meridian_${VERSION}_aarch64.dmg"
+# `--target universal-apple-darwin` bundles under target/universal-apple-darwin/
+# (not plain target/release/) and its DMG filename suffix isn't the fixed
+# "_aarch64" a single-arch build used — glob for it rather than hardcode.
+DMG_DIR="target/universal-apple-darwin/release/bundle/dmg"
+DMG="$(ls "${DMG_DIR}"/Meridian_${VERSION}_*.dmg 2>/dev/null | head -1)"
 IDENTITY="${APPLE_SIGNING_IDENTITY:-}"
 
 case "${IDENTITY}" in
@@ -40,7 +44,7 @@ case "${IDENTITY}" in
         ;;
 esac
 
-[[ -f "${DMG}" ]] || { echo "✗ notarize-dmg: ${DMG} not found" >&2; exit 1; }
+[[ -n "${DMG}" && -f "${DMG}" ]] || { echo "✗ notarize-dmg: no Meridian_${VERSION}_*.dmg found in ${DMG_DIR}" >&2; exit 1; }
 
 : "${APPLE_API_KEY:?notarize-dmg: APPLE_API_KEY (the 10-char Key ID) is unset}"
 : "${APPLE_API_ISSUER:?notarize-dmg: APPLE_API_ISSUER (the issuer UUID) is unset}"

--- a/scripts/package-updater.sh
+++ b/scripts/package-updater.sh
@@ -4,9 +4,13 @@
 # Generate the DMG auto-update artifacts for the GitHub release:
 #   - latest.json  — the manifest tauri-plugin-updater fetches from
 #                    /releases/latest/download/latest.json (built from the REAL
-#                    minisign signature `tauri build` just produced)
-#   - Meridian.dmg — a stable-named copy of Meridian_<version>_aarch64.dmg so the
-#                    public download link /releases/latest/download/Meridian.dmg
+#                    minisign signature `tauri build` just produced). One
+#                    universal Meridian.app.tar.gz serves both architectures,
+#                    so BOTH darwin-aarch64 and darwin-x86_64 keys point at the
+#                    same payload/signature — tauri-plugin-updater resolves the
+#                    key to use from the running app's arch, not the manifest.
+#   - Meridian.dmg — a stable-named copy of the universal Meridian_<version>_*.dmg
+#                    so the public download link /releases/latest/download/Meridian.dmg
 #                    is version-independent
 #
 # Called by semantic-release (@semantic-release/exec prepareCmd) AFTER the tray
@@ -22,8 +26,10 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT}"
 
 REPO="Meridiona/meridian"
-MAC="target/release/bundle/macos"
-DMG_DIR="target/release/bundle/dmg"
+# `--target universal-apple-darwin` bundles under target/universal-apple-darwin/,
+# not plain target/release/.
+MAC="target/universal-apple-darwin/release/bundle/macos"
+DMG_DIR="target/universal-apple-darwin/release/bundle/dmg"
 SIG="${MAC}/Meridian.app.tar.gz.sig"
 
 # The build fails earlier when createUpdaterArtifacts can't be signed (pubkey
@@ -34,13 +40,14 @@ if [[ ! -f "${SIG}" ]]; then
   exit 0
 fi
 
-# Stable-named DMG for a version-independent public download link.
-VERSIONED_DMG="${DMG_DIR}/Meridian_${VERSION}_aarch64.dmg"
-if [[ -f "${VERSIONED_DMG}" ]]; then
+# Stable-named DMG for a version-independent public download link. Universal
+# builds don't carry the old fixed "_aarch64" suffix, so glob for it.
+VERSIONED_DMG="$(ls "${DMG_DIR}"/Meridian_${VERSION}_*.dmg 2>/dev/null | head -1)"
+if [[ -n "${VERSIONED_DMG}" && -f "${VERSIONED_DMG}" ]]; then
   cp "${VERSIONED_DMG}" "${DMG_DIR}/Meridian.dmg"
   echo "✓ ${DMG_DIR}/Meridian.dmg (copy of $(basename "${VERSIONED_DMG}"))"
 else
-  echo "⚠ ${VERSIONED_DMG} not found — no stable-named DMG (tarball update still works)"
+  echo "⚠ no Meridian_${VERSION}_*.dmg found in ${DMG_DIR} — no stable-named DMG (tarball update still works)"
 fi
 
 # Optional mandatory-update floor. When tray/minimum-version contains a semver,
@@ -88,12 +95,16 @@ out, ver, url, sig, pub, minimum = sys.argv[1:7]
 notes = f"Meridian v{ver}"
 if minimum:
     notes += f"\nMinimum-Version: {minimum}"
+# One universal Meridian.app.tar.gz serves both architectures — tauri-plugin-updater
+# resolves the platform key from the RUNNING app's arch, so both keys must be
+# present and point at the same payload + signature.
+platform = {"signature": sig, "url": url}
 json.dump(
     {
         "version": ver,
         "notes": notes,
         "pub_date": pub,
-        "platforms": {"darwin-aarch64": {"signature": sig, "url": url}},
+        "platforms": {"darwin-aarch64": platform, "darwin-x86_64": platform},
     },
     open(out, "w"),
     indent=2,

--- a/scripts/test-updater-github.sh
+++ b/scripts/test-updater-github.sh
@@ -29,7 +29,9 @@ cd "${ROOT}"
 
 KEY="${HOME}/.tauri/meridian-updater.key"
 CONF="tray/src-tauri/tauri.conf.json"
-BUNDLE="target/release/bundle/macos"
+# `--target universal-apple-darwin` (invoked by `npm run build` below) bundles
+# under target/universal-apple-darwin/, not plain target/release/.
+BUNDLE="target/universal-apple-darwin/release/bundle/macos"
 REPO="Meridiona/meridian"
 TAG="updater-test"
 SERVE_DIR="${HOME}/meridian-updater-test"
@@ -95,11 +97,13 @@ SIG="$(cat "${BUNDLE}/Meridian.app.tar.gz.sig")"
 python3 - "${SERVE_DIR}/latest.json" "${NEW_VER}" "${TARBALL_URL}" "${SIG}" <<'PY'
 import json, sys
 out, ver, url, sig = sys.argv[1:5]
+platform = {"signature": sig, "url": url}
 manifest = {
     "version": ver,
     "notes": "Throwaway updater dry-run build.",
     "pub_date": "2026-01-01T00:00:00Z",
-    "platforms": {"darwin-aarch64": {"signature": sig, "url": url}},
+    # Universal build — same payload serves both archs.
+    "platforms": {"darwin-aarch64": platform, "darwin-x86_64": platform},
 }
 with open(out, "w") as fh:
     json.dump(manifest, fh, indent=2)

--- a/scripts/test-updater-local.sh
+++ b/scripts/test-updater-local.sh
@@ -32,7 +32,9 @@ cd "${ROOT}"
 
 KEY="${HOME}/.tauri/meridian-updater.key"
 CONF="tray/src-tauri/tauri.conf.json"
-BUNDLE="target/release/bundle/macos"
+# `--target universal-apple-darwin` (invoked by `npm run build` below) bundles
+# under target/universal-apple-darwin/, not plain target/release/.
+BUNDLE="target/universal-apple-darwin/release/bundle/macos"
 PORT=8000
 SERVE_DIR="${HOME}/meridian-updater-test"
 OLD_VER="0.1.0"
@@ -102,16 +104,16 @@ SIG="$(cat "${BUNDLE}/Meridian.app.tar.gz.sig")"
 python3 - "${SERVE_DIR}/latest.json" "${NEW_VER}" "${PORT}" "${SIG}" <<'PY'
 import json, sys
 out, ver, port, sig = sys.argv[1:5]
+platform = {
+    "signature": sig,
+    "url": f"http://localhost:{port}/Meridian.app.tar.gz",
+}
 manifest = {
     "version": ver,
     "notes": "Local updater test build.",
     "pub_date": "2026-01-01T00:00:00Z",
-    "platforms": {
-        "darwin-aarch64": {
-            "signature": sig,
-            "url": f"http://localhost:{port}/Meridian.app.tar.gz",
-        }
-    },
+    # Universal build — same payload serves both archs.
+    "platforms": {"darwin-aarch64": platform, "darwin-x86_64": platform},
 }
 with open(out, "w") as fh:
     json.dump(manifest, fh, indent=2)

--- a/scripts/verify-release-bundle.sh
+++ b/scripts/verify-release-bundle.sh
@@ -39,12 +39,26 @@ echo "→ Pre-publish smoke test (v${VERSION})"
 #     `codesign --verify --deep --strict` PASSES on an ad-hoc nested binary, so it
 #     canNOT be relied on here — the Team ID must be asserted explicitly.
 #   • un-notarized/un-stapled → first launch is blocked or needs an online check.
-APP="target/release/bundle/macos/Meridian.app"
-DMG="target/release/bundle/dmg/Meridian.dmg"
+# `--target universal-apple-darwin` bundles under target/universal-apple-darwin/,
+# not plain target/release/.
+BUNDLE_DIR="target/universal-apple-darwin/release/bundle"
+APP="${BUNDLE_DIR}/macos/Meridian.app"
+DMG="${BUNDLE_DIR}/dmg/Meridian.dmg"
 DAEMON_IN_APP="${APP}/Contents/Resources/backend/meridian"
 TEAM_ID="AQTYN9PZ83"   # Meridiona LLP
 
 [[ -d "${APP}" ]] || fail "${APP} not found — the tauri build did not produce an .app"
+
+# 3z. Both the tray binary and the bundled daemon must actually carry both
+#     architectures — catches a silent fallback to a single-arch build (e.g.
+#     the universal-apple-darwin target flag getting dropped) before it ships.
+for _target in "${APP}/Contents/MacOS/meridian-tray:tray binary" "${DAEMON_IN_APP}:bundled daemon"; do
+    _path="${_target%%:*}"; _what="${_target##*:}"
+    _archs="$(lipo -archs "${_path}" 2>/dev/null || true)"
+    [[ "${_archs}" == *arm64* && "${_archs}" == *x86_64* ]] \
+        || fail "${_what} at ${_path} is not universal (lipo -archs: '${_archs}') — expected both arm64 and x86_64"
+done
+pass "tray binary + bundled daemon: universal (arm64 + x86_64)"
 
 # 3a. Both Mach-Os must carry a Developer ID signature under Meridiona's Team ID
 #     with the Hardened Runtime flag set (notarization requires all three).
@@ -86,12 +100,21 @@ fi
 # with auto-update dead. Assert the artifacts exist rather than trusting exit
 # codes. (A wrong/absent TAURI_SIGNING_PRIVATE_KEY_PASSWORD is the usual cause.)
 for _art in \
-    "target/release/bundle/macos/Meridian.app.tar.gz:updater payload" \
-    "target/release/bundle/macos/Meridian.app.tar.gz.sig:updater signature" \
-    "target/release/bundle/macos/latest.json:updater manifest"; do
+    "${BUNDLE_DIR}/macos/Meridian.app.tar.gz:updater payload" \
+    "${BUNDLE_DIR}/macos/Meridian.app.tar.gz.sig:updater signature" \
+    "${BUNDLE_DIR}/macos/latest.json:updater manifest"; do
     _p="${_art%%:*}"; _w="${_art##*:}"
     [[ -s "${_p}" ]] || fail "${_w} missing/empty at ${_p} — auto-update would be dead for every installed user. Check TAURI_SIGNING_PRIVATE_KEY / _PASSWORD (tauri build logs the failure but exits 0)."
 done
 pass "updater artifacts present: payload + minisign signature + latest.json"
+
+# latest.json must carry BOTH platform keys (pointing at the same universal
+# payload) — package-updater.sh dropping one silently would leave that arch's
+# installs never seeing an update.
+for _plat in darwin-aarch64 darwin-x86_64; do
+    python3 -c "import json,sys; sys.exit(0 if '${_plat}' in json.load(open('${BUNDLE_DIR}/macos/latest.json'))['platforms'] else 1)" \
+        || fail "latest.json is missing the '${_plat}' platform key"
+done
+pass "latest.json covers both darwin-aarch64 and darwin-x86_64"
 
 echo "✓ Smoke test passed — safe to publish v${VERSION}"

--- a/tray/package.json
+++ b/tray/package.json
@@ -4,9 +4,9 @@
   "scripts": {
     "tauri": "tauri",
     "dev": "tauri dev",
-    "build:daemon": "cargo build --locked --release --bin meridian --manifest-path ../Cargo.toml",
-    "build": "npm run build:daemon && export APPLE_SIGNING_IDENTITY=\"${APPLE_SIGNING_IDENTITY:-$(bash ../scripts/dev-signing.sh identity)}\" && bash ../scripts/sign-daemon.sh && tauri build",
-    "build:staging": "npm run build:daemon && export APPLE_SIGNING_IDENTITY=\"${APPLE_SIGNING_IDENTITY:-$(bash ../scripts/dev-signing.sh identity)}\" MERIDIAN_RUNTIME_MANIFEST_URL=https://github.com/Meridiona/meridian/releases/download/runtime-staging/runtime-manifest.json MERIDIAN_HF_ENDPOINT=https://hf.meridiona.com MERIDIAN_CHANNEL=staging && bash ../scripts/sign-daemon.sh && tauri build",
+    "build:daemon": "bash ../scripts/build-daemon-universal.sh",
+    "build": "npm run build:daemon && export APPLE_SIGNING_IDENTITY=\"${APPLE_SIGNING_IDENTITY:-$(bash ../scripts/dev-signing.sh identity)}\" && bash ../scripts/sign-daemon.sh && tauri build --target universal-apple-darwin",
+    "build:staging": "npm run build:daemon && export APPLE_SIGNING_IDENTITY=\"${APPLE_SIGNING_IDENTITY:-$(bash ../scripts/dev-signing.sh identity)}\" MERIDIAN_RUNTIME_MANIFEST_URL=https://github.com/Meridiona/meridian/releases/download/runtime-staging/runtime-manifest.json MERIDIAN_HF_ENDPOINT=https://hf.meridiona.com MERIDIAN_CHANNEL=staging && bash ../scripts/sign-daemon.sh && tauri build --target universal-apple-darwin",
     "test": "vitest run src/__tests__"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Ships Meridian as a universal (arm64 + x86_64) macOS binary instead of Apple-Silicon-only
- Daemon binary is cross-compiled for both targets and `lipo`'d manually (it's embedded via `bundle.resources`, not a Tauri sidecar, so Tauri's own universal-target lipo step doesn't cover it) — see new `scripts/build-daemon-universal.sh`
- Tray build now uses `tauri build --target universal-apple-darwin`, which builds + lipos its own binary automatically
- Release scripts (`notarize-dmg.sh`, `package-updater.sh`, `verify-release-bundle.sh`, `mirror-staging-release.sh`, the dev updater-test scripts) updated for Tauri's new `target/universal-apple-darwin/` output path and `Meridian_<version>_universal.dmg` naming
- `latest.json` now carries both `darwin-aarch64` and `darwin-x86_64` keys pointing at the same universal payload/signature — `tauri-plugin-updater` resolves by the running app's arch, no client-side code change needed
- `verify-release-bundle.sh` gained a `lipo -archs` assertion on both the tray binary and bundled daemon, plus a check that `latest.json` covers both platform keys — catches a silent single-arch fallback before it ships
- Dropped `scripts/bootstrap.sh`'s `uname -m == arm64` hard refusal
- Updated user-facing docs (`README.md`, `SETUP.md`, `CONTRIBUTING.md`, the bug report template) to reflect universal support, and fixed a stale README claim that the embedder is Metal/arm64-only (it's CPU-only by design)
- CI (`release.yml` / `release-staging.yml`) now installs the `x86_64-apple-darwin` Rust target — cross-compiled from the same arm64 `macos-26` runner, no second runner needed

Investigated and ruled out as non-blockers: `candle` (embedder) is CPU-only already; MLX is fully removed; the private `screenpipe-fork` capture stack (screenpipe-screen/-a11y) cross-compiles cleanly to x86_64 (verified live); no `target_arch`-gated dependencies exist in the tree.

## Test plan
- [x] `cargo check --target x86_64-apple-darwin` (root + tray crate with `--features capture`) — clean, no code changes needed
- [x] `bash scripts/build-daemon-universal.sh` — produces `target/release/meridian` reporting `x86_64 arm64` via `lipo -archs`
- [x] Full `npm run build` (ad-hoc signed) in `tray/` — compiles both targets, bundles `Meridian.app` at the new `target/universal-apple-darwin/release/bundle/` path, both the tray binary and bundled daemon inside the `.app` report `x86_64 arm64`
- [x] `scripts/package-updater.sh` and `scripts/verify-release-bundle.sh` run against the real build output — behave correctly (graceful skip on unsigned artifacts, correct failure on non-Developer-ID signing, new universal-arch assertion passes)
- [ ] Full CI release run on a real Developer ID cert (signing + notarization) — not exercised locally, first real signal will be the next staging release
- [ ] Install on an actual Intel Mac (or Rosetta-disabled) and confirm capture/daemon/auto-update end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)