### PR TITLE
feat(ui): polish setup wizard + day-task timeline hour rail

### DIFF
--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -1,7 +1,7 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 
 import type { Metadata } from 'next'
-import { Instrument_Serif } from 'next/font/google'
+import { Instrument_Serif, JetBrains_Mono } from 'next/font/google'
 import './globals.css'
 import { ThemeProvider } from '@/lib/theme-context'
 import ExternalLinks from '@/components/ExternalLinks'
@@ -12,6 +12,18 @@ const instrumentSerif = Instrument_Serif({
   style: ['normal', 'italic'],
   subsets: ['latin'],
   variable: '--font-instrument-serif',
+  display: 'swap',
+})
+
+// One-off exception: --font-jetbrains-mono, used ONLY by the day-task
+// timeline's hour-rail labels (DayTaskColumn.tsx), to match the marketing
+// site's product demo (meridiona-website/assets/css/demo.css .hour-label),
+// which sets real JetBrains Mono rather than the app's aliased --font-mono.
+// Scoped deliberately, not a reversal of the decision below.
+const jetbrainsMono = JetBrains_Mono({
+  weight: ['500', '600'],
+  subsets: ['latin'],
+  variable: '--font-jetbrains-mono',
   display: 'swap',
 })
 
@@ -29,7 +41,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html
       lang="en"
-      className={instrumentSerif.variable}
+      className={`${instrumentSerif.variable} ${jetbrainsMono.variable}`}
     >
       <body className="min-h-screen font-sans">
         <ThemeProvider>

--- a/ui/app/setup/atoms.tsx
+++ b/ui/app/setup/atoms.tsx
@@ -150,8 +150,10 @@ export function MemoryGauge({ pct, size = 96, strokeWidth = 9 }: {
 }
 
 // ── Kicker / eyebrow label ───────────────────────────────────────────────────
-export function Kicker({ children, color = 'var(--t-faint)', style }: { children: ReactNode; color?: string; style?: CSSProperties }) {
-  return (<p className="font-mono" style={{ fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color, ...style }}>{children}</p>)
+// Same class + accent color as the Settings → Intelligence "Your AI" eyebrow
+// (IntelligenceSection.tsx) — the one shared eyebrow style, not a wizard-only one.
+export function Kicker({ children, color = 'var(--color-state-proposal)', style }: { children: ReactNode; color?: string; style?: CSSProperties }) {
+  return (<p className="mt-label" style={{ color, ...style }}>{children}</p>)
 }
 
 // ── Bordered row tile (permission + integration + runtime rows) ──────────────

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -244,13 +244,8 @@ export default function SetupWizard() {
                     <h1 style={{ ...DISPLAY, fontSize: 23, fontWeight: 750, lineHeight: 1.1, letterSpacing: '-.03em', color: 'var(--t-title)' }}>{meta.title}</h1>
                     <p style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--t-muted)', marginTop: 8, maxWidth: 460, textWrap: 'pretty' }}>{meta.subtitle}</p>
                   </div>
-                  <div className="nice-scroll flex flex-col" style={{ flex: 1, overflowY: 'auto', padding: '4px 32px 22px' }}>
-                    {/* marginBlock:auto vertically centres a short step body (no more
-                        top-loaded content + empty bottom) while a tall body — the
-                        provider list — still scrolls from the top without clipping. */}
-                    <div style={{ marginBlock: 'auto', width: '100%' }}>
-                      <meta.Body wiz={wiz} />
-                    </div>
+                  <div className="nice-scroll flex flex-col" style={{ flex: 1, overflowY: 'auto', padding: '18px 32px 22px' }}>
+                    <meta.Body wiz={wiz} />
                   </div>
                   <Footer step={step} last={last} canNext={meta.canNext(wiz)} err={err}
                     onBack={() => { setErr(''); setStep(Math.max(0, step - 1)) }}
@@ -299,14 +294,14 @@ function Rail({ step, done, wiz, goStep }: { step: number; done: boolean; wiz: W
               }}>{ok ? <Check size={13} color="#fff" /> : s.n}</span>
               <div style={{ minWidth: 0, paddingTop: 1 }}>
                 <p style={{ fontSize: 13, fontWeight: isCur ? 600 : 450, color: reached ? 'var(--t-title)' : 'var(--t-muted)' }}>{s.label}</p>
-                <p className="font-mono" style={{ fontSize: 10, color: ok ? 'var(--color-state-approved)' : 'var(--t-faint)', marginTop: 2, letterSpacing: '.02em' }}>{s.status(wiz)}</p>
+                <p className="mt-mono-sm" style={{ fontSize: 10, color: ok ? 'var(--color-state-approved)' : 'var(--t-faint)', marginTop: 2 }}>{s.status(wiz)}</p>
               </div>
             </button>
           )
         })}
       </div>
       <div style={{ flex: 1 }} />
-      <p className="font-mono" style={{ fontSize: 10, letterSpacing: '.12em', color: 'var(--t-faint)', padding: '0 8px', textTransform: 'uppercase' }}>First-run setup</p>
+      <p className="mt-chip" style={{ color: 'var(--t-faint)', padding: '0 8px' }}>First-run setup</p>
     </div>
   )
 }

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -74,7 +74,7 @@ function PermissionsBody({ wiz }: { wiz: Wiz }) {
             <div style={{ flex: 1, minWidth: 0 }}>
               <div className="flex items-center" style={{ gap: 8 }}>
                 <span style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--t-title)' }}>{p.name}</span>
-                {!notif && <span className="font-mono" style={{ fontSize: 9, letterSpacing: '.1em', color: 'var(--t-muted)', border: '0.5px solid var(--t-card-border)', borderRadius: 4, padding: '1px 5px' }}>{p.required ? 'REQUIRED' : 'OPTIONAL'}</span>}
+                {!notif && <span className="mt-chip" style={{ color: 'var(--t-muted)', border: '0.5px solid var(--t-card-border)', borderRadius: 4, padding: '1px 5px' }}>{p.required ? 'REQUIRED' : 'OPTIONAL'}</span>}
               </div>
               <p style={{ fontSize: 11.5, lineHeight: 1.4, color: 'var(--t-muted)', marginTop: 3 }}>{p.desc}</p>
             </div>
@@ -93,8 +93,8 @@ function PermissionsBody({ wiz }: { wiz: Wiz }) {
           </Row>
         )
       })}
-      <p className="flex items-center" style={{ gap: 7, fontSize: 11, color: 'var(--t-muted)', marginTop: 3 }}>
-        <span style={{ width: 5, height: 5, borderRadius: 99, background: 'var(--color-state-approved)' }} />
+      <p className="flex items-start" style={{ gap: 7, fontSize: 11, lineHeight: 1.5, color: 'var(--t-muted)', marginTop: 3 }}>
+        <span style={{ width: 5, height: 5, borderRadius: 99, background: 'var(--color-state-approved)', marginTop: 5, flexShrink: 0 }} />
         Your screen, tasks, and worklogs stay on this Mac and are never uploaded. We send usage stats - daily focus time, app version, and your email once you sign in - to improve Meridian, never your content.
       </p>
     </div>
@@ -109,8 +109,8 @@ function IntegrationsBody({ wiz }: { wiz: Wiz }) {
   return (
     <div className="flex flex-col" style={{ gap: 9 }}>
       <ConnectTrackers integrations={wiz.integrations} onChanged={wiz.refetchIntegrations} compact />
-      <p className="flex items-center" style={{ gap: 7, fontSize: 11, color: 'var(--t-muted)', marginTop: 3 }}>
-        <span style={{ width: 5, height: 5, borderRadius: 99, background: connected ? 'var(--color-state-approved)' : 'var(--t-faint-2)' }} />
+      <p className="flex items-start" style={{ gap: 7, fontSize: 11, lineHeight: 1.5, color: 'var(--t-muted)', marginTop: 3 }}>
+        <span style={{ width: 5, height: 5, borderRadius: 99, background: connected ? 'var(--color-state-approved)' : 'var(--t-faint-2)', marginTop: 5, flexShrink: 0 }} />
         {connected > 0
           ? `${connected} connected · Meridian will match sessions and draft worklogs.`
           : 'Optional - skip it and Meridian still tracks your day. Connect a tracker anytime from Settings to auto-draft worklogs.'}
@@ -169,9 +169,9 @@ function IntelligenceBody({ wiz }: { wiz: Wiz }) {
         testOne={wiz.testProvider}
         rescan={wiz.rescanProviders}
       />
-      <p className="flex items-center" style={{ gap: 7, fontSize: 11, color: 'var(--t-muted)', marginTop: 3 }}>
+      <p className="flex items-start" style={{ gap: 7, fontSize: 11, lineHeight: 1.5, color: 'var(--t-muted)', marginTop: 3 }}>
         <span style={{
-          width: 5, height: 5, borderRadius: 99,
+          width: 5, height: 5, borderRadius: 99, marginTop: 5, flexShrink: 0,
           background: missing ? 'var(--color-state-pending)' : 'var(--color-state-approved)',
         }} />
         {missing
@@ -245,7 +245,7 @@ export function Completion({ wiz }: { wiz: Wiz }) {
       <div style={{ width: '100%', maxWidth: 360, border: '0.5px solid var(--t-card-border)', borderRadius: 13, overflow: 'hidden' }}>
         {lines.map((l, i) => (
           <div key={l.k} className="flex items-center justify-between" style={{ padding: '10px 14px', borderTop: i ? '1px solid var(--t-hair)' : 'none' }}>
-            <span className="font-mono" style={{ fontSize: 10, letterSpacing: '.12em', textTransform: 'uppercase', color: 'var(--t-faint)' }}>{l.k}</span>
+            <span className="mt-chip" style={{ color: 'var(--t-faint)' }}>{l.k}</span>
             <span style={{ fontSize: 12.5, color: 'var(--t-title)', fontWeight: 450 }}>{l.v}</span>
           </div>
         ))}

--- a/ui/components/timeline/DayTaskColumn.tsx
+++ b/ui/components/timeline/DayTaskColumn.tsx
@@ -50,6 +50,10 @@ import { taskHue, Bullets } from './dayTaskKit'
 // tall even after idle collapsing simply scrolls.
 const FALLBACK_PANE_PX = 560 // used before the pane is measured (first paint / SSR)
 const GUTTER = 58 // px reserved on the left for hour labels
+// Breathing room between the hour rail (dots/spine, which sits at the GUTTER
+// edge) and the task cards, so cards read as their own column rather than
+// butting up against the rail — see demo.css's dedicated .hour-spine column.
+const CARD_GUTTER_GAP = 16
 // A task card never draws thinner than this, so even a few-minute workstream stays
 // visible, labelled, and tappable (a small honest over-draw for very short work).
 const MIN_SEG_PX = 22
@@ -177,7 +181,6 @@ export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, hourS
     return out
   }, [firstHour, lastHour, toPx, colHeight, laidBase, win])
 
-  const dayLabel = isToday ? 'Today' : day
   const taskCount = laid.length
 
   // ── The live hour ─────────────────────────────────────────────────────────
@@ -219,13 +222,12 @@ export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, hourS
     // clicking one still just selects/toggles it.
     <div className="relative h-full" onClick={() => { if (selected) onSelect(null) }}>
       <div ref={scrollRef} className="h-full overflow-y-auto nice-scroll">
+      {/* Task count only — no date line above it (the date already lives in the
+          toolbar above this column; repeating it here was redundant). */}
       <div ref={headerRef} className="px-6 pt-6 pb-2 flex items-baseline justify-between">
-        <div>
-          <p className="mt-label" style={{ color: 'var(--t-faint)' }}>{dayLabel}</p>
-          <p className="mt-greeting text-title mt-1" style={{ fontSize: 20 }}>
-            {taskCount > 0 ? `${taskCount} task${taskCount === 1 ? '' : 's'} today` : 'Your day, in tasks'}
-          </p>
-        </div>
+        <p className="mt-greeting text-title" style={{ fontSize: 20 }}>
+          {taskCount > 0 ? `${taskCount} task${taskCount === 1 ? '' : 's'} today` : 'Your day, in tasks'}
+        </p>
         {taskCount > 0 && (
           <p className="mt-body-sm" style={{ color: 'var(--t-faint)' }}>
             {fmtDur(laid.reduce((a, l) => a + l.task.minutes, 0) * 60)} tracked
@@ -238,25 +240,67 @@ export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, hourS
       ) : (
         // The live strip below supplies the bottom padding when it is there, so
         // the two don't stack into a large dead gap.
-        <div className={liveMode ? 'px-6 pb-4' : 'px-6 pb-8'}>
+        <div className={liveMode ? 'px-6 pt-4 pb-4' : 'px-6 pt-4 pb-8'}>
+          {/* pt-4: the topmost hour tick sits at colHeight-relative top:0 and is
+              itself centred on its row via -translate-y-1/2 (see below), so
+              without this cushion its top half is clipped by the scroll
+              viewport's own edge — this is what left "8 AM" invisible. */}
           <div className="relative" style={{ height: colHeight }}>
             {/* Hour gridlines + labels — positioned via the same scale as the
                 cards beneath them (see hourLines) so a label always sits at its
                 real hour on the rail, decluttered for runs of hours inside one
-                compressed gap segment. */}
-            {hourLines.map(({ hour, top }) => (
-              <div key={hour} className="absolute left-0 right-0 flex items-start"
-                style={{ top, height: 0 }}>
-                <span className="mt-mono-sm shrink-0 -translate-y-1/2"
-                  style={{ width: GUTTER - 12, fontSize: 10.5, color: 'var(--t-faint)', textAlign: 'right' }}>
-                  {hourClock(hour)}
-                </span>
-                <span className="flex-1 border-t" style={{ borderColor: 'var(--t-hair)', opacity: 0.6 }} />
-              </div>
-            ))}
+                compressed gap segment. Ported from the marketing site's product
+                demo (meridiona-website/assets/js/demo.js renderTimeline +
+                assets/css/demo.css .hour-spine/.hour-node): one vertical spine
+                with a node per hour — the same light ring for every ordinary
+                hour, solid + pulsing accent only for the current one. The
+                label itself never changes weight/color by state — only the
+                node does. */}
+            <span className="absolute" style={{ left: GUTTER - 5, top: 0, bottom: 0, width: 2, background: 'var(--t-hair)', opacity: 0.22 }} />
+            {hourLines.map(({ hour, top }) => {
+              const isNow = isToday && hour === nowHour
+              const nodeSize = isNow ? 11 : 9
+              return (
+                <div key={hour} className="absolute left-0 right-0 flex items-start"
+                  style={{ top, height: 0 }}>
+                  {/* One-off: real JetBrains Mono (--font-jetbrains-mono, layout.tsx),
+                      not the app's --font-mono alias — matches the reference demo's
+                      .hour-label exactly, scoped to this rail only. */}
+                  <span className="shrink-0 -translate-y-1/2"
+                    style={{
+                      width: GUTTER - 12, fontSize: 10.5, fontWeight: 600, textAlign: 'right',
+                      // paddingRight: breathing room before the dot/spine — without it
+                      // the right-aligned text sits almost flush against the node.
+                      paddingRight: 6,
+                      color: 'var(--t-faint-2)', fontFamily: 'var(--font-jetbrains-mono), monospace',
+                    }}>
+                    {hourClock(hour)}
+                  </span>
+                  {/* Every non-live node is the same light ring: panel fill inside, a
+                      thin muted border outside — one consistent look for every
+                      ordinary hour, only the current hour's node differs (solid
+                      accent + pulse). */}
+                  <span className={`absolute rounded-full -translate-y-1/2 ${isNow ? 'live-dot' : ''}`} style={{
+                    left: GUTTER - 5 - nodeSize / 2, width: nodeSize, height: nodeSize,
+                    background: isNow ? 'var(--color-state-proposal)' : 'var(--t-panel)',
+                    border: isNow ? 'none' : '2px solid color-mix(in srgb, var(--t-faint-2) 55%, transparent)',
+                    boxShadow: isNow
+                      ? '0 0 0 3px color-mix(in srgb, var(--color-state-proposal) 18%, transparent)'
+                      : '0 0 0 3px var(--t-panel)',
+                  }} />
+                  {/* Starts past the card gutter (not GUTTER) so it never touches the
+                      spine/node — a separate row divider for the card column only,
+                      same as demo.css's .hour-body border-top living in its own
+                      grid column rather than the spine's. */}
+                  <span className="flex-1 border-t" style={{ borderColor: 'var(--t-hair)', opacity: 0.5, marginLeft: 12 + CARD_GUTTER_GAP }} />
+                </div>
+              )
+            })}
 
-            {/* Task workstreams */}
-            <div className="absolute top-0 bottom-0" style={{ left: GUTTER, right: 6 }}>
+            {/* Task workstreams — inset further than the rail itself (GUTTER)
+                so the cards read as their own column, not flush against the
+                dots/spine (see demo.css's dedicated 26px .hour-spine column). */}
+            <div className="absolute top-0 bottom-0" style={{ left: GUTTER + CARD_GUTTER_GAP, right: 6 }}>
               {laid.map((l, idx) => {
                 const hue = taskHue(l.task.id, idx)
                 return (
@@ -308,10 +352,11 @@ export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, hourS
           }}>
             {showLiveHourLabel ? hourClock(nowHour) : ''}
           </span>
-          {/* 12px would carry the label's GUTTER - 12 width up to GUTTER, where
-              the task cards' rail sits — less HourTakeover's own mx-2, so its
-              visible edge lands on that rail rather than 8px inside it. */}
-          <div className="flex-1 min-w-0" style={{ marginLeft: 12 - 8 }}>
+          {/* 12px carries the label's GUTTER - 12 width up to GUTTER, then
+              CARD_GUTTER_GAP up to where the task cards actually start —
+              less HourTakeover's own mx-2, so its visible edge lines up with
+              the cards above it rather than sitting further left. */}
+          <div className="flex-1 min-w-0" style={{ marginLeft: 12 + CARD_GUTTER_GAP - 8 }}>
             <HourTakeover
               hour={nowHour}
               mode={liveMode}
@@ -334,8 +379,11 @@ export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, hourS
  *  title, then a meta row, then as many summary lines as fit — a tall card shows
  *  what was done rather than sitting empty. */
 /** The "synced to {tracker}" pill on a posted task card: the tracker's brand mark
- *  + a check, in a soft approved-green pill. Sits in-flow at the end of the title
- *  row so it scales and is never clipped by the card's rounded corner. */
+ *  + a check. Sits in-flow at the end of the title row so it scales and is never
+ *  clipped by the card's rounded corner. The pill's own background is the card's
+ *  surface color (not a green tint) with a crisp white ring around it, so it reads
+ *  as a badge sitting ON the card rather than a colored chip competing with it —
+ *  only the check mark itself stays approved-green, as the one "done" signal. */
 function PostedPill({ provider, targetKey, alignTop }: { provider: string; targetKey: string | null; alignTop: boolean }) {
   const label = PROVIDER_META[provider]?.label ?? provider
   return (
@@ -345,9 +393,10 @@ function PostedPill({ provider, targetKey, alignTop }: { provider: string; targe
       style={{
         alignSelf: alignTop ? 'flex-start' : 'center',
         marginTop: alignTop ? 1 : 0,
-        padding: '2px 6px 2px 5px',
-        background: 'color-mix(in srgb, var(--color-state-approved) 13%, var(--t-card))',
-        border: '1px solid color-mix(in srgb, var(--color-state-approved) 32%, transparent)',
+        padding: '2.5px 7px 2.5px 6px',
+        background: 'var(--t-card)',
+        border: '1.5px solid #fff',
+        boxShadow: '0 1px 3px rgba(0,0,0,0.12)',
       }}>
       <ProviderIcon provider={provider} size={11} />
       <svg width="9" height="9" viewBox="0 0 24 24" fill="none" aria-hidden

--- a/ui/components/timeline/DayTaskDetailPanel.tsx
+++ b/ui/components/timeline/DayTaskDetailPanel.tsx
@@ -17,7 +17,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { fmtDur } from '@/components/atoms'
+import { fmtDur, PROVIDER_META, ProviderGlyph } from '@/components/atoms'
 import { GeneratingBar } from '@/components/GeneratingBar'
 import { load } from '@/lib/bridge'
 import { connectedTrackerNames } from '@/lib/integrations'
@@ -263,7 +263,7 @@ function WorklogFooter({ wl, hue, linkedTicket, integrations, trackers, onOpenSe
         <GeneratingBar hue={hue} label="Generating your worklog…"
           detail="Reading your work, comparing it against today's tasks and drafting the update - you can keep using Meridian while this runs." />
       ) : posted ? (
-        <PostedBar done={done} linkedTicket={linkedTicket} />
+        <PostedBar done={done} linkedTicket={linkedTicket} provider={draft?.provider ?? ''} />
       ) : !draft ? (
         noTracker
           ? <ConnectTrackerCta hue={hue} onConnect={() => onOpenSettings('integrations')} />
@@ -286,15 +286,23 @@ function WorklogFooter({ wl, hue, linkedTicket, integrations, trackers, onOpenSe
  *  Lists every ticket rather than the day-task's `linked_ticket`: that column holds
  *  one key, so a two-ticket update would silently report half of what it did. The
  *  linked ticket is only the fallback for a row posted before the draft existed. */
-function PostedBar({ done, linkedTicket }: { done: PostedLink[]; linkedTicket: string | null }) {
+function PostedBar({ done, linkedTicket, provider }: { done: PostedLink[]; linkedTicket: string | null; provider: string }) {
   const links: PostedLink[] = done.length > 0
     ? done
-    : linkedTicket ? [{ task_key: linkedTicket, browse_url: null }] : []
+    : linkedTicket ? [{ task_key: linkedTicket, browse_url: null, provider }] : []
+  // All of a draft's targets share one tracker, so the first link's provider (or
+  // the draft's own, for the linkedTicket-only fallback with no targets at all)
+  // is the one to badge.
+  const meta = PROVIDER_META[links[0]?.provider ?? provider]
   return (
     <div className="space-y-1.5">
-      <p className="mt-body-sm inline-flex items-center gap-1.5" style={{ color: 'var(--color-state-approved)', fontSize: 13, fontWeight: 700 }}>
-        <span aria-hidden>✓</span> Posted{links.length > 1 ? ` to ${links.length} tickets` : links[0] ? ` to ${links[0].task_key}` : ''}
-      </p>
+      <span className="inline-flex items-center gap-1.5 rounded-full py-1 pl-1 pr-3"
+        style={{ background: `color-mix(in srgb, ${meta?.color ?? 'var(--color-state-approved)'} 14%, transparent)` }}>
+        <ProviderGlyph provider={links[0]?.provider ?? provider} size={18} />
+        <span className="mt-body-sm" style={{ color: meta?.color ?? 'var(--color-state-approved)', fontSize: 12.5, fontWeight: 700 }}>
+          Posted{links.length > 1 ? ` to ${links.length} tickets` : links[0] ? ` to ${links[0].task_key}` : ''}
+        </span>
+      </span>
       {links.length > 0 && (
         <div className="flex flex-wrap items-center gap-1.5">
           {links.map((l) => <LinkChip key={l.task_key} label={l.task_key} url={l.browse_url} />)}
@@ -305,7 +313,7 @@ function PostedBar({ done, linkedTicket }: { done: PostedLink[]; linkedTicket: s
 }
 
 /** The slice of a posted target [`PostedBar`] links to. */
-interface PostedLink { task_key: string; browse_url: string | null }
+interface PostedLink { task_key: string; browse_url: string | null; provider: string }
 
 /** No draft yet, a tracker connected — the primary generate CTA.
  *

--- a/ui/components/timeline/HourBadges.tsx
+++ b/ui/components/timeline/HourBadges.tsx
@@ -44,7 +44,7 @@ const COPY: Record<TakeoverMode, [string, string][]> = {
     ['Generating this hour’s work log', 'Analyzing your captures — we’ll notify you the moment it’s ready.'],
   ],
   queued: [
-    ['This hour is being tracked…', 'A worklog drafts itself here automatically at {NEXT} — we’ll notify you when it arrives.'],
+    ['Cooking up this hour’s recap…', 'Analyzing your captures — we’ll notify you the moment it’s ready, around {NEXT}.'],
     ['Meridian is watching this hour…', 'Keep working — nothing to do. We’ll let you know when the draft lands at {NEXT}.'],
     ['Logging this hour as you go…', 'It turns into a worklog the moment {NEXT} hits, and you’ll be notified when it does.'],
   ],


### PR DESCRIPTION
## Summary
- Setup wizard: fixed spacing/contrast regressions (removed a `marginBlock:auto` that made steps land at inconsistent vertical positions), unified eyebrow/chip labels onto the shared `mt-label`/`mt-chip`/`mt-mono-sm` classes instead of one-off `font-mono` styling, aligned dot-bullet notes to their first line.
- Day-task timeline: ported the hour rail (label + spine + node) from the marketing site's product demo (`meridiona-website/assets/css/demo.css` `.hour-label`/`.hour-spine`/`.hour-node`), added breathing room between the rail and the task cards, restyled the posted-to-tracker pill on task cards to sit as a neutral white-ringed badge on the card's own surface instead of a green-tinted chip, and refreshed the live-hour copy ("Cooking up this hour's recap…").
- Scoped a one-off JetBrains Mono font load (`--font-jetbrains-mono`) to just the timeline's hour-rail labels, matching the reference demo without touching the app-wide `--font-mono` → SF Pro alias.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `cargo fmt` / `cargo clippy` / `cargo test` (pre-push hooks) passed
- [ ] Visual check in a packaged/dev build of the setup wizard and timeline (light + dark theme)