### PR TITLE
fix(worklog): recover hours stuck in 'generating' from a daemon restart

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -958,6 +958,21 @@ async fn main() -> Result<()> {
         Err(e) => tracing::error!("cleanup_incomplete_runs failed: {}", e),
     }
 
+    // 7a-bis. Same recovery, for the worklog pipeline's own ledger: an hour left
+    // `generating` by a crash mid-`/worklog_hour` call would otherwise never
+    // retry and would silently block every hour after it from ever getting a
+    // ledger row (see reset_stuck_generating_hours's doc comment).
+    match meridian::pm_worklog::ledger::reset_stuck_generating_hours(&meridian).await {
+        Ok(0) => {
+            tracing::info!("no stuck-generating worklog hours found");
+        }
+        Ok(n) => tracing::warn!(
+            reset_count = n,
+            "reset worklog hour(s) stuck in generating from a previous crash"
+        ),
+        Err(e) => tracing::error!("reset_stuck_generating_hours failed: {}", e),
+    }
+
     // 7b. Shared handles the poll loop uses to signal ETL ticks to observers.
     let etl_notify: Arc<Notify> = Arc::new(Notify::new());
     let etl_tick_span: Arc<std::sync::Mutex<Option<tracing::Span>>> =

--- a/src/pm_worklog/ledger.rs
+++ b/src/pm_worklog/ledger.rs
@@ -145,6 +145,31 @@ pub async fn mark_hour_pending(pool: &SqlitePool, hour_start: &str) -> Result<()
     Ok(())
 }
 
+/// Startup recovery: reset any hour still marked `generating` back to `pending`.
+///
+/// `mark_hour_generating`/`mark_hour_pending` only cover a call that actually
+/// RETURNS (success -> `done`, error -> reverted to `pending`) — see the
+/// `hour::run_hour` call site in `worklog_pipeline.rs`. If the daemon is killed
+/// or crashes while a `/worklog_hour` call is in flight (a `cargo-watch` rebuild,
+/// `launchd` restart, an OOM kill, a hard crash), the row is left `generating`
+/// forever: nothing else ever queries for it, so the pipeline just treats it as
+/// "someone is still working on this hour" on every future tick, and — because
+/// hours are walked forward from the first not-done one — every hour AFTER it
+/// silently never gets a ledger row either, not just the stuck one.
+///
+/// Mirrors [`crate::db::meridian::cleanup_incomplete_runs`]'s ETL-run recovery:
+/// call this once on startup, before the worklog pipeline's first tick, so a
+/// crash mid-generation costs at most one retried hour rather than a permanent
+/// stall from that hour onward for as long as the daemon runs.
+pub async fn reset_stuck_generating_hours(pool: &SqlitePool) -> Result<u64> {
+    let result =
+        sqlx::query("UPDATE pm_worklog_hours SET status = 'pending' WHERE status = 'generating'")
+            .execute(pool)
+            .await
+            .context("reset stuck generating hours")?;
+    Ok(result.rows_affected())
+}
+
 /// True when the hour's upstream data is complete: ETL has crossed the hour
 /// boundary AND no session started in the hour is still *genuinely in-flight*.
 ///


### PR DESCRIPTION
## Summary
- Root cause: `pm_worklog_hours.status` only ever leaves `generating` when the `/worklog_hour` call for that hour actually returns (success -> `done`, error -> reverted to `pending`). If the daemon process dies mid-call (crash, OOM kill, or a `cargo-watch`/launchd restart), the row is orphaned in `generating` permanently — nothing else re-checks it. Since hours are walked forward sequentially from the first not-done one, every hour *after* the stuck one silently never gets a ledger row either, so a single stuck hour blanks out the rest of the day on the timeline.
- Confirmed this is what happened live on my machine: a stuck 4-5pm hour blanked 5-6pm too; the LLM call layer itself is already safely bounded (90s subprocess timeout with `kill_on_drop`), so this was specifically the missing crash-recovery path, not a hung call.
- Fix: `reset_stuck_generating_hours()` in `pm_worklog/ledger.rs`, called once at daemon startup right next to the existing `cleanup_incomplete_runs` (the equivalent recovery the ETL pipeline already has) — any hour still `generating` from a previous run resets to `pending` and gets retried on the next tick.

## Test plan
- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt` clean
- [x] Verified live: reset fired on daemon restart ("reset worklog hour(s) stuck in generating from a previous crash"), the previously-stuck hour flipped back to `pending` and was picked up again
- [x] Full pre-push suite (fmt, clippy, cargo test, security audit) passed