### PR TITLE
perf(embedder): unload the model after its one per-hour use

### DIFF
--- a/src/embedder/mod.rs
+++ b/src/embedder/mod.rs
@@ -67,6 +67,17 @@ pub async fn embed_batch(texts: Vec<String>) -> Result<Vec<Vec<f32>>> {
         .map_err(|e| anyhow::anyhow!("embedder task panicked: {e}"))?
 }
 
+/// Drop the cached model, freeing its weights/tensors. The distiller calls this
+/// right after its one `embed_batch` call for the hour (see
+/// [`crate::worklog_pipeline::distiller::embed_lex`]) — the model is used once
+/// per hour, so there is nothing gained by keeping ~130 MB of weights resident in
+/// a background daemon for the other 55-ish minutes until the next hour. The next
+/// call to [`embed_batch`] reloads it from disk exactly like the first-ever call.
+pub fn unload() {
+    let mut guard = EMBEDDER.lock().unwrap_or_else(|e| e.into_inner());
+    *guard = None;
+}
+
 /// The blocking body: lazily load the model under the mutex, then embed each text.
 ///
 /// Recovers from a poisoned lock rather than propagating the poison forever: a panic

--- a/src/worklog_pipeline/distiller/mod.rs
+++ b/src/worklog_pipeline/distiller/mod.rs
@@ -336,7 +336,12 @@ async fn embed_lex(lex: &[Span]) -> (Vec<Vec<f32>>, bool) {
         let start = Instant::now();
         let vecs = if embedder::is_ready() && !lex.is_empty() {
             let texts: Vec<String> = lex.iter().map(|s| s.line.clone()).collect();
-            match embedder::embed_batch(texts).await {
+            let result = embedder::embed_batch(texts).await;
+            // This is the only embed_batch call in the hour's whole run (one distil
+            // pass = one batch), so the model has no more work until next hour —
+            // drop it now rather than leaving it resident in memory until then.
+            embedder::unload();
+            match result {
                 Ok(v) => v,
                 Err(e) => {
                     tracing::warn!(error = %e, "distil: embed failed — degrading to lexical-only");


### PR DESCRIPTION
## Summary
- The candle BGE embedder (used only by the session distiller's SemDeDup/facility-location stage) lazily loaded on first use into a process-lifetime static cache — but the distiller only calls `embed_batch` once per hour (one batch per hour's worth of deduped spans). That left ~130 MB of model weights resident in a background daemon's memory for the ~55 idle minutes between hours.
- Added `embedder::unload()`, called right after the distiller's one `embed_batch` call returns each hour, dropping the cached model. The next hour's call reloads it from disk exactly like the very first call (same lazy-load path, no behavior change to callers).

## Test plan
- [x] `cargo check` / `cargo clippy -- -D warnings` / `cargo fmt` clean
- [x] Full pre-push suite (fmt, clippy, cargo test, security audit) passed
- [ ] Confirm via Activity Monitor / `ps` RSS that the daemon's memory drops back down after an hourly distiller run completes