### PR TITLE
feat: select models from a list instead of typing them

### DIFF
--- a/src/llm/openai_compat.rs
+++ b/src/llm/openai_compat.rs
@@ -60,6 +60,99 @@ impl CustomEndpoint {
     }
 }
 
+/// How long to wait on a models listing. Deliberately short and NOT `cli_timeout_s`: this
+/// runs while a user watches a dropdown, and a slow endpoint should fall back to free text
+/// quickly rather than freeze the picker.
+const MODELS_TIMEOUT_S: u64 = 10;
+
+/// Ask an OpenAI-compatible endpoint what models it serves — `GET <base_url>/models`.
+///
+/// Takes the base URL and key rather than a [`CustomEndpoint`] because the main caller is the
+/// ADD-endpoint form, where no model has been chosen yet and so no endpoint exists to build.
+///
+/// # Why `<base_url>/models` and not `<base_url>/v1/models`
+///
+/// The stored `base_url` already carries the version segment (`https://…/v1`,
+/// `https://…/v1beta/openai`) — the same reason [`CustomEndpoint::chat_url`] appends a bare
+/// `/chat/completions`. Appending `/v1` here would 404 every configured endpoint.
+///
+/// # Who calls this
+///
+/// [`crate::llm`] exposes it to the tray's `list_custom_llm_provider_models` command, which
+/// serves the custom-endpoint model picker.
+///
+/// # Errors
+///
+/// Reuses [`classify_error`], so a 429 comes back as [`LlmError::RateLimited`] and a 401/403
+/// as a key-specific message. Callers are expected to DEGRADE on any error — every field this
+/// populates must stay usable as free text, since plenty of OpenAI-compatible servers don't
+/// implement `/models` at all.
+pub async fn list_models(
+    base_url: &str,
+    api_key: &str,
+    endpoint_id: &str,
+) -> Result<Vec<String>, LlmError> {
+    let url = format!("{}/models", base_url.trim_end_matches('/'));
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(MODELS_TIMEOUT_S))
+        // Same reasoning as the chat call: a 3xx to another origin would forward the
+        // Authorization header (and the key) to a host the user never configured.
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| LlmError::Failed(format!("custom provider client: {e}")))?;
+
+    let resp = client
+        .get(&url)
+        .bearer_auth(api_key)
+        .send()
+        .await
+        // As in `complete`: `e` can carry the URL but never the key (reqwest redacts auth).
+        .map_err(|e| LlmError::Failed(format!("custom provider models request failed: {e}")))?;
+
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let body = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(classify_error(status, &headers, &body, endpoint_id));
+    }
+
+    let parsed: Value = serde_json::from_str(&body)
+        .map_err(|e| LlmError::Failed(format!("custom provider models response: {e}")))?;
+
+    // OpenAI's shape is {"data":[{"id":…}]}. Some compatible servers answer {"models":[…]},
+    // and a few return a bare array. Accept all three rather than make the user hand-type a
+    // model because their vendor picked a different envelope.
+    let items = parsed
+        .get("data")
+        .or_else(|| parsed.get("models"))
+        .unwrap_or(&parsed);
+    let mut ids: Vec<String> = items
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|m| {
+                    // An entry is either {"id": "…"} or, on some servers, a bare string.
+                    m.get("id")
+                        .and_then(Value::as_str)
+                        .or_else(|| m.as_str())
+                        .map(str::to_string)
+                })
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+    ids.sort();
+    ids.dedup();
+
+    tracing::info!(
+        endpoint_id = %endpoint_id,
+        models = ids.len(),
+        "custom provider: listed models"
+    );
+    Ok(ids)
+}
+
 pub struct OpenAiCompatBackend {
     pub cfg: LlmConfig,
 }

--- a/src/llm/openai_compat.rs
+++ b/src/llm/openai_compat.rs
@@ -81,21 +81,23 @@ fn parse_models_body(body: &str) -> Result<Vec<String>, LlmError> {
         .get("data")
         .or_else(|| parsed.get("models"))
         .unwrap_or(&parsed);
+    // A non-array envelope is a FAILURE, not an empty list. Some endpoints answer 200 with
+    // an error object (`{"error":"invalid key"}`); treating that as "listed no models" would
+    // report a working endpoint serving nothing and hide the real reason from the user.
+    let items = items.as_array().ok_or_else(|| {
+        LlmError::Failed("custom provider models response was not a list".to_string())
+    })?;
     let mut ids: Vec<String> = items
-        .as_array()
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|m| {
-                    // An entry is either {"id": "…"} or, on some servers, a bare string.
-                    m.get("id")
-                        .and_then(Value::as_str)
-                        .or_else(|| m.as_str())
-                        .map(str::to_string)
-                })
-                .filter(|s| !s.is_empty())
-                .collect()
+        .iter()
+        .filter_map(|m| {
+            // An entry is either {"id": "…"} or, on some servers, a bare string.
+            m.get("id")
+                .and_then(Value::as_str)
+                .or_else(|| m.as_str())
+                .map(str::to_string)
         })
-        .unwrap_or_default();
+        .filter(|s| !s.is_empty())
+        .collect();
     // Sorted and deduped so the picker's order doesn't depend on the server's, and a vendor
     // that lists the same id twice doesn't render it twice.
     ids.sort();
@@ -107,6 +109,36 @@ fn parse_models_body(body: &str) -> Result<Vec<String>, LlmError> {
 /// runs while a user watches a dropdown, and a slow endpoint should fall back to free text
 /// quickly rather than freeze the picker.
 const MODELS_TIMEOUT_S: u64 = 10;
+
+/// Ceiling on a `/models` body. Generous for the use case — the longest real listing is a
+/// few hundred entries, well under 100 KB — while still bounded.
+const MODELS_MAX_BODY_BYTES: usize = 2 * 1024 * 1024;
+
+/// Read a response body with a hard byte ceiling.
+///
+/// `resp.text()` buffers without limit, and the URL here is **user-supplied**: a faulty or
+/// hostile endpoint could stream indefinitely and exhaust tray memory, which the request
+/// timeout does not prevent (a steady trickle never times out). Chunks are accumulated and
+/// the read is abandoned the moment it exceeds the cap.
+async fn read_capped_body(mut resp: reqwest::Response) -> Result<String, LlmError> {
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| LlmError::Failed(format!("custom provider models response: {e}")))?
+    {
+        if buf.len() + chunk.len() > MODELS_MAX_BODY_BYTES {
+            return Err(LlmError::Failed(format!(
+                "custom provider models response exceeded {} KB",
+                MODELS_MAX_BODY_BYTES / 1024
+            )));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    // Lossy rather than strict: a body that is almost-JSON with one bad byte should reach
+    // the parser and fail there with a useful message, not die as an encoding error.
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
 
 /// Ask an OpenAI-compatible endpoint what models it serves — `GET <base_url>/models`.
 ///
@@ -155,7 +187,7 @@ pub async fn list_models(
 
     let status = resp.status();
     let headers = resp.headers().clone();
-    let body = resp.text().await.unwrap_or_default();
+    let body = read_capped_body(resp).await?;
     if !status.is_success() {
         return Err(classify_error(status, &headers, &body, endpoint_id));
     }
@@ -490,6 +522,15 @@ mod models_listing_tests {
     #[test]
     fn rejects_a_non_json_body() {
         assert!(parse_models_body("<html>502 Bad Gateway</html>").is_err());
+    }
+
+    /// Valid JSON that isn't a list must fail for the same reason. Some endpoints answer
+    /// **200** with an error object, and reporting that as "no models" would blame the
+    /// endpoint for serving nothing while hiding the actual cause (a bad key, usually).
+    #[test]
+    fn rejects_a_non_array_envelope() {
+        assert!(parse_models_body(r#"{"error":"invalid key"}"#).is_err());
+        assert!(parse_models_body(r#"{"data":{"id":"a"}}"#).is_err());
     }
 }
 

--- a/src/llm/openai_compat.rs
+++ b/src/llm/openai_compat.rs
@@ -60,6 +60,49 @@ impl CustomEndpoint {
     }
 }
 
+/// Pull the model ids out of a `/models` response body.
+///
+/// Split out from [`list_models`] so the envelope handling is unit-testable without a live
+/// endpoint — the shapes below are the whole reason this function is fallible.
+///
+/// OpenAI answers `{"data":[{"id":…}]}`. Some compatible servers answer `{"models":[…]}`, and
+/// a few return a bare array; entries are usually objects but are sometimes bare strings. All
+/// are accepted, because the alternative is making a user hand-type a model purely because
+/// their vendor picked a different envelope.
+///
+/// Returns an empty vec — NOT an error — for a well-formed response listing nothing. That is
+/// a real answer ("this endpoint serves no models it will admit to"), and callers already
+/// treat empty as "fall back to free text".
+fn parse_models_body(body: &str) -> Result<Vec<String>, LlmError> {
+    let parsed: Value = serde_json::from_str(body)
+        .map_err(|e| LlmError::Failed(format!("custom provider models response: {e}")))?;
+
+    let items = parsed
+        .get("data")
+        .or_else(|| parsed.get("models"))
+        .unwrap_or(&parsed);
+    let mut ids: Vec<String> = items
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|m| {
+                    // An entry is either {"id": "…"} or, on some servers, a bare string.
+                    m.get("id")
+                        .and_then(Value::as_str)
+                        .or_else(|| m.as_str())
+                        .map(str::to_string)
+                })
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+    // Sorted and deduped so the picker's order doesn't depend on the server's, and a vendor
+    // that lists the same id twice doesn't render it twice.
+    ids.sort();
+    ids.dedup();
+    Ok(ids)
+}
+
 /// How long to wait on a models listing. Deliberately short and NOT `cli_timeout_s`: this
 /// runs while a user watches a dropdown, and a slow endpoint should fall back to free text
 /// quickly rather than freeze the picker.
@@ -117,33 +160,7 @@ pub async fn list_models(
         return Err(classify_error(status, &headers, &body, endpoint_id));
     }
 
-    let parsed: Value = serde_json::from_str(&body)
-        .map_err(|e| LlmError::Failed(format!("custom provider models response: {e}")))?;
-
-    // OpenAI's shape is {"data":[{"id":…}]}. Some compatible servers answer {"models":[…]},
-    // and a few return a bare array. Accept all three rather than make the user hand-type a
-    // model because their vendor picked a different envelope.
-    let items = parsed
-        .get("data")
-        .or_else(|| parsed.get("models"))
-        .unwrap_or(&parsed);
-    let mut ids: Vec<String> = items
-        .as_array()
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|m| {
-                    // An entry is either {"id": "…"} or, on some servers, a bare string.
-                    m.get("id")
-                        .and_then(Value::as_str)
-                        .or_else(|| m.as_str())
-                        .map(str::to_string)
-                })
-                .filter(|s| !s.is_empty())
-                .collect()
-        })
-        .unwrap_or_default();
-    ids.sort();
-    ids.dedup();
+    let ids = parse_models_body(&body)?;
 
     tracing::info!(
         endpoint_id = %endpoint_id,
@@ -410,6 +427,70 @@ fn classify_error(
         ));
     }
     LlmError::Failed(format!("custom provider {status}: {head}"))
+}
+
+#[cfg(test)]
+mod models_listing_tests {
+    use super::*;
+
+    /// The OpenAI shape, which Groq/OpenRouter/Gemini's compat layer all follow.
+    #[test]
+    fn reads_the_openai_data_envelope() {
+        let body = r#"{"object":"list","data":[
+            {"id":"gpt-5.1","object":"model"},
+            {"id":"gpt-5.5","object":"model"}
+        ]}"#;
+        assert_eq!(parse_models_body(body).unwrap(), vec!["gpt-5.1", "gpt-5.5"]);
+    }
+
+    /// Some compatible servers use `models` instead of `data`.
+    #[test]
+    fn reads_the_models_envelope() {
+        let body = r#"{"models":[{"id":"llama-3.3-70b"}]}"#;
+        assert_eq!(parse_models_body(body).unwrap(), vec!["llama-3.3-70b"]);
+    }
+
+    /// …and a few return the array itself, sometimes as bare strings.
+    #[test]
+    fn reads_a_bare_array_of_objects_or_strings() {
+        assert_eq!(
+            parse_models_body(r#"[{"id":"a"},"b"]"#).unwrap(),
+            vec!["a", "b"]
+        );
+    }
+
+    /// Order comes from us, not the server, and a duplicate id renders once.
+    #[test]
+    fn sorts_and_dedupes() {
+        let body = r#"{"data":[{"id":"z"},{"id":"a"},{"id":"z"}]}"#;
+        assert_eq!(parse_models_body(body).unwrap(), vec!["a", "z"]);
+    }
+
+    /// A well-formed response listing nothing is an ANSWER, not a failure - the caller
+    /// falls back to free text either way, but an Err would surface a scary message for
+    /// what is simply an endpoint with nothing to declare.
+    #[test]
+    fn empty_list_is_ok_not_an_error() {
+        assert_eq!(
+            parse_models_body(r#"{"data":[]}"#).unwrap(),
+            Vec::<String>::new()
+        );
+    }
+
+    /// Entries we can't read a usable id from are skipped rather than poisoning the list
+    /// with empty options.
+    #[test]
+    fn skips_entries_with_no_usable_id() {
+        let body = r#"{"data":[{"id":"good"},{"object":"model"},{"id":""}]}"#;
+        assert_eq!(parse_models_body(body).unwrap(), vec!["good"]);
+    }
+
+    /// A non-JSON body (an HTML error page from a proxy, say) must fail rather than be
+    /// reported as "no models", which would look like a working endpoint serving nothing.
+    #[test]
+    fn rejects_a_non_json_body() {
+        assert!(parse_models_body("<html>502 Bad Gateway</html>").is_err());
+    }
 }
 
 #[cfg(test)]

--- a/tray/src-tauri/src/commands/custom_llm.rs
+++ b/tray/src-tauri/src/commands/custom_llm.rs
@@ -420,6 +420,77 @@ pub async fn remove_custom_llm_provider(id: String) -> Result<Vec<CustomProvider
         .collect())
 }
 
+/// Ask an endpoint which models it serves, for the model picker.
+///
+/// Two callers, two shapes:
+///
+/// * **A saved endpoint** — pass `id` alone. The base URL and key are read from the registry
+///   here, because [`CustomProviderView`] deliberately omits `api_key` (there is a test
+///   pinning that), so the frontend has no key to hand back and MUST go through the id.
+/// * **The add-endpoint form** — pass `base_url` + `api_key`, which the user has just typed
+///   and no row exists for yet.
+///
+/// # This is best-effort by design
+///
+/// Plenty of OpenAI-compatible servers never implement `/models`. Every caller must treat an
+/// error as "offer free text" rather than a failure — the model field stays hand-typeable in
+/// all cases, so a missing listing costs convenience and nothing else.
+///
+/// # Cost
+///
+/// One unmetered-in-practice `GET`, only ever on an explicit user action (opening or
+/// refreshing the picker) — never on a mount or a poll tick. Unlike
+/// [`probe_custom_llm_provider`] it spends no completion tokens, so it takes no rate-limit
+/// reservation; a 429 is surfaced to the caller instead of retried.
+///
+/// # Related
+///
+/// [`meridian::llm::openai_compat::list_models`] does the request and response shaping.
+#[tauri::command]
+#[tracing::instrument(skip(api_key))]
+pub async fn list_custom_llm_provider_models(
+    id: Option<String>,
+    base_url: Option<String>,
+    api_key: Option<String>,
+) -> Result<Vec<String>, String> {
+    // Resolve to (base_url, key, id-for-logging) from whichever shape the caller used.
+    let (url, key, log_id) = match id {
+        Some(id) => {
+            let settings_v = settings::read_settings_value();
+            let rows = read_rows(&settings_v);
+            let row = rows
+                .iter()
+                .find(|r| r.id == id)
+                .ok_or_else(|| format!("no custom endpoint with id {id}"))?;
+            (row.base_url.clone(), row.api_key.clone(), id)
+        }
+        None => {
+            let url = base_url.unwrap_or_default();
+            let key = api_key.unwrap_or_default();
+            if key.trim().is_empty() {
+                return Err("API key is required to list models".into());
+            }
+            if !url.starts_with("http://") && !url.starts_with("https://") {
+                return Err("base URL must start with http:// or https://".into());
+            }
+            // Same header-injection guard `validate` applies before storing these.
+            for (field, v) in [("API key", &key), ("base URL", &url)] {
+                if v.contains('\n') || v.contains('\r') {
+                    return Err(format!("{field} contains invalid characters"));
+                }
+            }
+            (url, key, "unsaved".to_string())
+        }
+    };
+
+    meridian::llm::openai_compat::list_models(&url, &key, &log_id)
+        .await
+        .map_err(|e| {
+            tracing::warn!(endpoint_id = %log_id, error = %e, "custom_llm: model listing failed");
+            e.to_string()
+        })
+}
+
 /// Every configured endpoint, keyless — what the picker and the Lab's variant list render.
 #[tauri::command]
 #[tracing::instrument]

--- a/tray/src-tauri/src/commands/custom_llm.rs
+++ b/tray/src-tauri/src/commands/custom_llm.rs
@@ -194,6 +194,29 @@ fn make_id(name: &str, existing: &[CustomLlmProvider]) -> String {
         .unwrap()
 }
 
+/// The checks every outbound request needs, whatever it is being sent for.
+///
+/// Shared by [`validate`] (adding an endpoint) and
+/// [`list_custom_llm_provider_models`] (listing one that isn't saved yet) so the two cannot
+/// drift — a rule enforced on the add path but not the listing path would be a rule with a
+/// hole in it.
+fn validate_transport_inputs(base_url: &str, api_key: &str) -> Result<(), String> {
+    if api_key.trim().is_empty() {
+        return Err("API key is required".into());
+    }
+    if !base_url.starts_with("http://") && !base_url.starts_with("https://") {
+        return Err("base URL must start with http:// or https://".into());
+    }
+    // The key becomes an Authorization header and the URL becomes a request line: a newline
+    // in either is header injection, exactly as `oo_email`/`oo_password` guard against.
+    for (field, v) in [("API key", api_key), ("base URL", base_url)] {
+        if v.contains('\n') || v.contains('\r') {
+            return Err(format!("{field} contains invalid characters"));
+        }
+    }
+    Ok(())
+}
+
 /// Reject what would break the request or the file. Kept strict at the door: the alternative
 /// is discovering it hours later as a failed fold.
 fn validate(name: &str, base_url: &str, model: &str, api_key: &str) -> Result<(), String> {
@@ -204,22 +227,11 @@ fn validate(name: &str, base_url: &str, model: &str, api_key: &str) -> Result<()
         // Unlike a CLI provider there is no "the provider's default model" to fall back to.
         return Err("model is required - a custom endpoint has no default".into());
     }
-    if api_key.trim().is_empty() {
-        return Err("API key is required".into());
-    }
-    if !base_url.starts_with("http://") && !base_url.starts_with("https://") {
-        return Err("base URL must start with http:// or https://".into());
-    }
-    // The key becomes an Authorization header and the URL becomes a request line: a newline
-    // in either is header injection, exactly as `oo_email`/`oo_password` guard against.
-    for (field, v) in [
-        ("API key", api_key),
-        ("base URL", base_url),
-        ("model", model),
-    ] {
-        if v.contains('\n') || v.contains('\r') {
-            return Err(format!("{field} contains invalid characters"));
-        }
+    validate_transport_inputs(base_url, api_key)?;
+    // The model rides in the request BODY rather than a header or the request line, so it is
+    // checked here rather than in the shared transport helper.
+    if model.contains('\n') || model.contains('\r') {
+        return Err("model contains invalid characters".into());
     }
     Ok(())
 }
@@ -447,7 +459,11 @@ pub async fn remove_custom_llm_provider(id: String) -> Result<Vec<CustomProvider
 ///
 /// [`meridian::llm::openai_compat::list_models`] does the request and response shaping.
 #[tauri::command]
-#[tracing::instrument(skip(api_key))]
+// `base_url` is skipped alongside the key, not just the key: a base URL can carry a
+// credential in a query string, and this span goes to the telemetry spool that ships inside
+// a diagnostics bundle. The endpoint id is the one safe thing to record - the same rule the
+// backend follows (see the logging note in src/llm/openai_compat.rs).
+#[tracing::instrument(skip(base_url, api_key))]
 pub async fn list_custom_llm_provider_models(
     id: Option<String>,
     base_url: Option<String>,
@@ -467,18 +483,8 @@ pub async fn list_custom_llm_provider_models(
         None => {
             let url = base_url.unwrap_or_default();
             let key = api_key.unwrap_or_default();
-            if key.trim().is_empty() {
-                return Err("API key is required to list models".into());
-            }
-            if !url.starts_with("http://") && !url.starts_with("https://") {
-                return Err("base URL must start with http:// or https://".into());
-            }
-            // Same header-injection guard `validate` applies before storing these.
-            for (field, v) in [("API key", &key), ("base URL", &url)] {
-                if v.contains('\n') || v.contains('\r') {
-                    return Err(format!("{field} contains invalid characters"));
-                }
-            }
+            // The same door the add path uses - see `validate_transport_inputs`.
+            validate_transport_inputs(&url, &key)?;
             (url, key, "unsaved".to_string())
         }
     };

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -608,6 +608,7 @@ pub fn run() {
             commands::probe_custom_llm_provider,
             commands::remove_custom_llm_provider,
             commands::list_custom_llm_providers,
+            commands::list_custom_llm_provider_models,
             // Uninstall wizard (plan + execute; see src/uninstall.rs for the CLI it drives)
             commands::get_uninstall_plan,
             commands::execute_uninstall,

--- a/ui/__tests__/model-picker.test.ts
+++ b/ui/__tests__/model-picker.test.ts
@@ -168,6 +168,33 @@ describe('free text is always reachable', () => {
     expect(multi).toContain('<input')
   })
 
+  // The escape hatch was BROKEN on first submission and the string-scan guards above did
+  // not catch it: picking "Custom model…" clears the value, and an empty value against a
+  // non-empty list is indistinguishable from "nothing chosen yet", so the derived flag went
+  // straight back to false and the text input never rendered. Model the derivation to pin
+  // the behaviour, not just the presence of the option.
+  const isFreeText = (customMode: boolean, models: string[], value: string) =>
+    customMode || models.length === 0 || (value !== '' && !models.includes(value))
+
+  it('stays in free text after picking Custom model on a non-empty list', () => {
+    // customMode must be held explicitly - this is the case that regressed.
+    expect(isFreeText(true, ['opus', 'sonnet'], '')).toBe(true)
+  })
+
+  it('would NOT stay in free text if the mode were derived from the value alone', () => {
+    // Documents why the explicit flag exists: without it this is the failing case.
+    expect(isFreeText(false, ['opus', 'sonnet'], '')).toBe(false)
+  })
+
+  it('leaves free text once a listed model is picked', () => {
+    expect(isFreeText(false, ['opus', 'sonnet'], 'opus')).toBe(false)
+  })
+
+  it('holds the explicit custom-entry flag in component state', () => {
+    expect(code).toContain('customMode')
+    expect(code).toMatch(/setCustomMode\(custom\)/)
+  })
+
   it('shows an unlisted stored model rather than snapping it to a listed one', () => {
     // A value we don't carry must switch the control to free text, or revisiting the
     // page would silently rewrite the user's model.

--- a/ui/__tests__/model-picker.test.ts
+++ b/ui/__tests__/model-picker.test.ts
@@ -1,0 +1,190 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+
+// Guards for the model pickers that replaced free-text model entry.
+//
+// Three rules here are load-bearing and every one of them is invisible at the type
+// level, so nothing but a test stops a later edit from quietly undoing them:
+//
+//   1. THE MODEL OVERRIDE IS SCOPED TO ONE PROVIDER. `src/llm/detect.rs` clears
+//      cfg.model when testing any provider that is not the selected one, precisely
+//      so one CLI's model string cannot end up in another's --model. The settings UI
+//      has to honour the same rule: switching provider must DROP the staged model.
+//      Carrying it over would hand `claude`'s "opus" to codex's -m, which fails only
+//      at run time, as a nonzero CLI exit an hour later.
+//
+//   2. A PROVIDER THAT DISCARDS THE MODEL MUST NOT FAN OUT. copilot's argv is built
+//      without a model flag and never reads cfg.model (src/llm/copilot.rs), so a
+//      `copilot:<model>` Lab variant would render a column promising a comparison the
+//      run cannot actually make - two identical results labelled as different models.
+//
+//   3. FREE TEXT IS NEVER REMOVED. Nothing validates a model string anywhere in the
+//      pipeline; it goes verbatim into argv or a JSON body. The curated lists are a
+//      convenience, so a stale list must never be able to block a model that works.
+//      This is the whole reason `cursor` ships an empty list rather than guesses.
+//
+// The repo has no React render harness (see intelligence-provider-save), so we model
+// the transitions and scan the source for the required shape rather than mounting.
+
+const uiRoot = import.meta.dir + '/..'
+const picker = readFileSync(uiRoot + '/components/ModelPicker.tsx', 'utf8')
+const section = readFileSync(uiRoot + '/components/timeline/settings/IntelligenceSection.tsx', 'utf8')
+const composer = readFileSync(uiRoot + '/components/timeline/llmlab/RunComposer.tsx', 'utf8')
+const registry = readFileSync(uiRoot + '/lib/llm-providers.ts', 'utf8')
+
+/** Source with comments stripped - these guards assert on CODE, and the headers above
+ *  each file describe the very behaviour being guarded against. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+}
+
+// ── Rule 1: the staging model ────────────────────────────────────────────────
+// Mirrors IntelligenceSection's `onChange` / `onModelChange`.
+
+interface Choice { id: string; customId: string | null; model: string }
+
+/** `onChange`: stage a provider pick, dropping the model unless we land back on the
+ *  saved provider (where the saved model is what's on disk). */
+function stageProvider(saved: Choice, pickId: string, pickCustomId: string | null = null): Choice | null {
+  const nextCustomId = pickId === 'custom' ? pickCustomId : null
+  const nextModel = pickId === saved.id ? saved.model : ''
+  const backToSaved = pickId === saved.id && (pickId !== 'custom' || nextCustomId === saved.customId)
+  return backToSaved ? null : { id: pickId, customId: nextCustomId, model: nextModel }
+}
+
+/** `onModelChange`: stage a model, collapsing to null once the whole triple matches disk. */
+function stageModel(saved: Choice, pending: Choice | null, next: string): Choice | null {
+  const staged = { ...(pending ?? saved), model: next }
+  const settled = staged.id === saved.id
+    && (staged.id !== 'custom' || staged.customId === saved.customId)
+    && staged.model === saved.model
+  return settled ? null : staged
+}
+
+describe('the model override is scoped to its provider', () => {
+  const saved: Choice = { id: 'claude', customId: null, model: 'opus' }
+
+  it('drops the staged model when the provider changes', () => {
+    // The leak this exists to stop: claude's "opus" reaching codex's -m.
+    expect(stageProvider(saved, 'codex')?.model).toBe('')
+  })
+
+  it('restores the saved model when the provider comes back', () => {
+    const away = stageProvider(saved, 'codex')
+    expect(away?.model).toBe('')
+    // Re-picking the saved provider clears the stage entirely, so what renders is
+    // the value on disk rather than the '' we passed through on the way out.
+    expect(stageProvider(saved, 'claude')).toBeNull()
+  })
+
+  it('keeps a model staged across an unrelated re-render', () => {
+    const staged = stageModel(saved, null, 'haiku')
+    expect(staged).toEqual({ id: 'claude', customId: null, model: 'haiku' })
+  })
+
+  it('clears the stage when the model returns to what is saved', () => {
+    const staged = stageModel(saved, null, 'haiku')
+    expect(stageModel(saved, staged, 'opus')).toBeNull()
+  })
+
+  it('treats clearing the model to the provider default as a real change', () => {
+    // '' is a legitimate value ("use the provider's default"), not a no-op, so it
+    // must stage and be savable - it is written as null.
+    expect(stageModel(saved, null, '')).toEqual({ id: 'claude', customId: null, model: '' })
+  })
+})
+
+describe('the settings section persists the override correctly', () => {
+  const code = stripComments(section)
+
+  it('writes llm_provider_model for a CLI provider', () => {
+    expect(code).toContain('llm_provider_model')
+  })
+
+  it('stores an empty model as null, matching Option<String>/None in Rust', () => {
+    expect(code).toMatch(/llm_provider_model:\s*pending\.model\s*\|\|\s*null/)
+  })
+
+  it('does not write the shared override for a custom endpoint', () => {
+    // A custom endpoint's model lives on its own row; openai_compat sends ep.model
+    // and ignores cfg.model, so writing the shared field would be a dead setting.
+    const customBranch = code.slice(code.indexOf("pending.id === 'custom'"))
+    const arm = customBranch.slice(0, customBranch.indexOf(':'))
+    expect(arm).not.toContain('llm_provider_model')
+  })
+
+  it('only offers the picker for a backend that passes the model through', () => {
+    expect(code).toContain('supportsModelOverride')
+  })
+
+  it('actually resets the model on a provider switch', () => {
+    // The transition tests above model this rule; this one ties it to the SOURCE, so
+    // the guard can't keep passing against a component that stopped honouring it.
+    expect(code).toMatch(/id === savedId\s*\?\s*savedModel\s*:\s*''/)
+  })
+})
+
+describe('a provider that discards the model never fans out', () => {
+  const code = stripComments(composer)
+
+  it('gates the Lab variant fan-out on supportsModelOverride', () => {
+    // Without this, a stale string in state still emits `copilot:<model>` columns.
+    // Bound the slice from the filter forward - `customVariantId` also appears in the
+    // import line above it, which would make this an empty (vacuously passing) slice.
+    const start = code.indexOf('LLM_PROVIDERS.filter')
+    const variantBlock = code.slice(start, code.indexOf('customVariantId', start))
+    expect(variantBlock).toContain('supportsModelOverride')
+  })
+
+  it('marks copilot as not supporting a model override', () => {
+    const copilotBlock = registry.slice(registry.indexOf("id: 'copilot'"))
+    expect(copilotBlock).toMatch(/supportsModelOverride:\s*false/)
+  })
+
+  it('marks the model-passing CLIs as supporting it', () => {
+    for (const id of ['claude', 'codex', 'cursor']) {
+      const block = registry.slice(registry.indexOf(`id: '${id}'`))
+      expect(block).toMatch(/supportsModelOverride:\s*true/)
+    }
+  })
+})
+
+describe('free text is always reachable', () => {
+  const code = stripComments(picker)
+
+  it('keeps an escape hatch in the single-model control', () => {
+    expect(code).toContain('Custom model…')
+  })
+
+  it('falls back to free text when there is nothing curated to offer', () => {
+    // cursor ships an empty list on purpose; an empty list must degrade to a text
+    // field rather than render a dropdown with no options.
+    expect(code).toMatch(/models\.length === 0/)
+  })
+
+  it('keeps a text input in the Lab multi-select', () => {
+    const multi = code.slice(code.indexOf('export function ModelMultiSelect'))
+    expect(multi).toContain('<input')
+  })
+
+  it('shows an unlisted stored model rather than snapping it to a listed one', () => {
+    // A value we don't carry must switch the control to free text, or revisiting the
+    // page would silently rewrite the user's model.
+    expect(code).toMatch(/value !== ''\s*&&\s*!known/)
+  })
+})
+
+describe('the curated registry stays honest', () => {
+  it('ships cursor with no invented model ids', () => {
+    // cursor-agent takes --model, but no verifiable value exists; a wrong one is
+    // accepted silently and fails only when the CLI runs.
+    const block = registry.slice(registry.indexOf("id: 'cursor'"), registry.indexOf("id: 'copilot'"))
+    expect(block).toMatch(/models:\s*\[\]/)
+  })
+
+  it('leaves custom endpoints to live enumeration', () => {
+    const block = registry.slice(registry.indexOf('CUSTOM_PROVIDER_META'))
+    expect(block).toMatch(/models:\s*\[\]/)
+  })
+})

--- a/ui/components/CustomProviders.tsx
+++ b/ui/components/CustomProviders.tsx
@@ -25,8 +25,10 @@ import {
   capacityNotice,
   type CapacityAssessment,
   type CustomProviderView,
+  type LlmModelOption,
   type ProbeOutcome,
 } from '@/lib/llm-providers'
+import { ModelSelect } from '@/components/ModelPicker'
 
 /**
  * The configured endpoints, plus the writes that change them.
@@ -170,6 +172,37 @@ function AddForm({ onAdd, onCancel }: {
   }, [rpm, rpd])
   const addNotice = capacity ? capacityNotice(capacity) : null
 
+  // Models as reported by the endpoint itself. null = never asked (or the ask failed), which
+  // is NOT an error state: many OpenAI-compatible servers don't implement /models, so the
+  // field stays hand-typeable throughout and this only ever adds convenience.
+  const [models, setModels] = useState<LlmModelOption[] | null>(null)
+  const [listing, setListing] = useState(false)
+  const [listError, setListError] = useState<string | null>(null)
+
+  // Both are needed for the call: the key authenticates it, the URL addresses it.
+  const canList = baseUrl.trim() !== '' && apiKey.trim() !== ''
+
+  async function listModels() {
+    setListing(true)
+    setListError(null)
+    try {
+      // No `id` - this endpoint isn't saved yet, so the tray takes the typed URL and key
+      // directly. camelCase per the note in `add` above.
+      const ids = await invoke<string[]>('list_custom_llm_provider_models', {
+        baseUrl,
+        apiKey,
+      })
+      setModels(ids.map((m) => ({ id: m, label: m })))
+      if (ids.length === 0) setListError('This endpoint listed no models - type one instead.')
+    } catch (e) {
+      // Degrade, never block: the model field is still a text box.
+      setModels(null)
+      setListError(String(e))
+    } finally {
+      setListing(false)
+    }
+  }
+
   const preset = customVendorPreset(vendor)
   // Only the escape hatch types its own URL; a preset's URL is fixed so a typo can't turn
   // "Gemini" into an endpoint that isn't Gemini.
@@ -226,8 +259,6 @@ function AddForm({ onAdd, onCancel }: {
         <Field label="Base URL" value={baseUrl} onChange={setBaseUrl} mono
           placeholder="https://host/v1" />
       )}
-      <Field label="Model" value={model} onChange={setModel} mono placeholder="gemini-flash-latest" />
-
       {/* The cost warning sits with the key field, because that is where the money decision
           is made - see CUSTOM_PROVIDER_COST_NOTE. */}
       <div className="flex items-start" style={{
@@ -247,6 +278,43 @@ function AddForm({ onAdd, onCancel }: {
           style={{ fontSize: 10.5, color: 'var(--color-state-proposal)', background: 'none', border: 'none', padding: 0, cursor: 'pointer', textDecoration: 'underline' }}>
           Get a {preset.name} key ↗
         </button>
+      )}
+
+      {/* Model sits AFTER the key on purpose: listing what an endpoint serves needs the key,
+          so asking for the model first would mean typing it blind. This is the one provider
+          whose models can be enumerated live - every other one is a CLI with no such
+          endpoint. Required here because, unlike a CLI, a custom endpoint has no default. */}
+      <label className="flex flex-col" style={{ gap: 4 }}>
+        <span className="font-mono" style={{ fontSize: 9, letterSpacing: '.1em', textTransform: 'uppercase', color: 'var(--t-faint)' }}>
+          Model
+        </span>
+        <ModelSelect
+          value={model}
+          onChange={setModel}
+          models={models ?? []}
+          required
+          action={
+            <button
+              type="button"
+              onClick={listModels}
+              disabled={!canList || listing}
+              style={{
+                fontSize: 10.5, padding: '5px 9px', borderRadius: 7, whiteSpace: 'nowrap',
+                border: '1px solid var(--t-ctrl-border)', background: 'var(--t-ctrl)',
+                color: canList ? 'var(--t-title)' : 'var(--t-faint)',
+                cursor: canList && !listing ? 'pointer' : 'not-allowed',
+              }}
+              title={canList ? 'Ask this endpoint which models it serves' : 'Enter the base URL and API key first'}
+            >
+              {listing ? 'Listing…' : models ? 'Refresh' : 'List models'}
+            </button>
+          }
+        />
+      </label>
+      {listError && (
+        <p style={{ fontSize: 10.5, lineHeight: 1.45, color: 'var(--t-faint)', marginTop: -4 }}>
+          {listError} You can still type the model name yourself.
+        </p>
       )}
 
       <Field label="Requests per minute" value={rpm} onChange={setRpm} type="number" mono

--- a/ui/components/CustomProviders.tsx
+++ b/ui/components/CustomProviders.tsx
@@ -15,7 +15,7 @@
 //     selects an ineligible endpoint, so the UI must not offer one as selectable - a
 //     rejected save would silently roll the choice back with nothing to explain it.
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { invoke, openExternal } from '@/lib/bridge'
 import {
   CUSTOM_PROVIDER_COST_NOTE,
@@ -178,11 +178,28 @@ function AddForm({ onAdd, onCancel }: {
   const [models, setModels] = useState<LlmModelOption[] | null>(null)
   const [listing, setListing] = useState(false)
   const [listError, setListError] = useState<string | null>(null)
+  // Bumped whenever the endpoint being described changes. A listing carries the generation
+  // it started in and is DISCARDED if that no longer matches, so a slow answer for the old
+  // URL/key can't repopulate the picker after the user has retargeted the form - which would
+  // otherwise let a model that doesn't exist on the new endpoint be selected and saved.
+  const listGen = useRef(0)
+
+  /** Drop everything discovered about the previous endpoint. */
+  const resetModelDiscovery = useCallback(() => {
+    listGen.current += 1
+    setModels(null)
+    setListError(null)
+    setListing(false)
+    // The chosen model belonged to the old endpoint; keeping it would submit a model the
+    // new one may not serve.
+    setModel('')
+  }, [])
 
   // Both are needed for the call: the key authenticates it, the URL addresses it.
   const canList = baseUrl.trim() !== '' && apiKey.trim() !== ''
 
   async function listModels() {
+    const gen = listGen.current
     setListing(true)
     setListError(null)
     try {
@@ -192,14 +209,16 @@ function AddForm({ onAdd, onCancel }: {
         baseUrl,
         apiKey,
       })
+      if (gen !== listGen.current) return
       setModels(ids.map((m) => ({ id: m, label: m })))
       if (ids.length === 0) setListError('This endpoint listed no models - type one instead.')
     } catch (e) {
+      if (gen !== listGen.current) return
       // Degrade, never block: the model field is still a text box.
       setModels(null)
       setListError(String(e))
     } finally {
-      setListing(false)
+      if (gen === listGen.current) setListing(false)
     }
   }
 
@@ -213,6 +232,9 @@ function AddForm({ onAdd, onCancel }: {
     const p = customVendorPreset(id)
     setBaseUrl(p?.baseUrl ?? '')
     if (!name.trim() && p && id !== 'other') setName(p.name)
+    // A different vendor is a different endpoint - anything discovered about the last one
+    // is now wrong.
+    resetModelDiscovery()
   }
 
   async function submit() {
@@ -256,7 +278,7 @@ function AddForm({ onAdd, onCancel }: {
 
       <Field label="Name" value={name} onChange={setName} placeholder="Gemini Flash" />
       {urlEditable && (
-        <Field label="Base URL" value={baseUrl} onChange={setBaseUrl} mono
+        <Field label="Base URL" value={baseUrl} onChange={(v) => { setBaseUrl(v); resetModelDiscovery() }} mono
           placeholder="https://host/v1" />
       )}
       {/* The cost warning sits with the key field, because that is where the money decision
@@ -270,7 +292,9 @@ function AddForm({ onAdd, onCancel }: {
         <p style={{ fontSize: 10.5, lineHeight: 1.45, color: 'var(--t-muted)' }}>{CUSTOM_PROVIDER_COST_NOTE}</p>
       </div>
 
-      <Field label="API key" value={apiKey} onChange={setApiKey} type="password" mono
+      {/* A different key can address a different account, and therefore a different set of
+          models - so it invalidates a listing just as the URL does. */}
+      <Field label="API key" value={apiKey} onChange={(v) => { setApiKey(v); resetModelDiscovery() }} type="password" mono
         placeholder="pasted once - never shown again" />
       {preset?.keyUrl && (
         <button onClick={() => preset.keyUrl && openExternal(preset.keyUrl)}

--- a/ui/components/ModelPicker.tsx
+++ b/ui/components/ModelPicker.tsx
@@ -1,0 +1,243 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+'use client'
+
+/**
+ * The model-selection controls, shared by every surface that used to make the user TYPE a
+ * model name: the Lab's variant cards, Intelligence settings, and the custom-endpoint form.
+ *
+ * # Two components, on purpose
+ *
+ * [`ModelSelect`] picks ONE model. [`ModelMultiSelect`] edits the Lab's comma-separated
+ * fan-out list, where each model becomes its own variant column. They share this file and the
+ * registry in `@/lib/llm-providers`, but not a component: collapsing them would mean one
+ * control with a `multi` flag toggling both its markup and its value type, which is more
+ * abstraction than two short components are worth.
+ *
+ * # Free text is never taken away
+ *
+ * Nothing in the pipeline validates a model string - it is passed verbatim into the CLI's
+ * argv (`src/llm/claude.rs` and friends) or an endpoint's JSON body - so the curated lists
+ * here are a convenience, not a whitelist. Both controls always keep a way to type a model we
+ * have not listed, because a stale list must never block a user from a model that works. This
+ * matters most for `cursor`, whose curated list is deliberately empty.
+ *
+ * # Who calls this
+ *
+ * `RunComposer` (multi), `IntelligenceSection` (single), `CustomProviders` (single).
+ */
+
+import { useId } from 'react'
+import type { LlmModelOption } from '@/lib/llm-providers'
+
+/** The sentinel `<option>` value meaning "the user wants to type their own". */
+const FREE_TEXT = '__free__'
+
+interface ModelSelectProps {
+  /** The current model string. Empty means "no override" - see `emptyLabel`. */
+  value: string
+  onChange: (next: string) => void
+  /** Curated options. May be empty, in which case this degrades to a plain text field. */
+  models: LlmModelOption[]
+  /**
+   * What an empty value means to THIS caller - "Provider default" in settings, where blank is
+   * legitimate, vs a prompt to choose where a model is required.
+   */
+  emptyLabel?: string
+  /** Set when a model is mandatory (a custom endpoint has no default to fall back to). */
+  required?: boolean
+  /** Rendered next to the control - the refresh affordance for live-listed endpoints. */
+  action?: React.ReactNode
+  /** Replaces the control with a disabled note (a live listing in flight, say). */
+  busyLabel?: string | null
+}
+
+/**
+ * A single-model control: a dropdown over `models`, plus a "Custom model…" escape hatch that
+ * swaps in a free-text field.
+ *
+ * The escape hatch is also what renders when `models` is empty or when `value` is a model we
+ * do not list - so a user who has already stored an unlisted model keeps seeing it, rather
+ * than having it silently snap to something else on their next visit.
+ */
+export function ModelSelect({
+  value,
+  onChange,
+  models,
+  emptyLabel = 'Provider default',
+  required = false,
+  action,
+  busyLabel = null,
+}: ModelSelectProps) {
+  const id = useId()
+  const known = models.some(m => m.id === value)
+  // Free text whenever we have nothing to offer, or the stored value isn't in what we offer.
+  const freeText = models.length === 0 || (value !== '' && !known)
+  const selected = freeText ? FREE_TEXT : value
+  const note = models.find(m => m.id === value)?.note
+
+  if (busyLabel) {
+    return (
+      <p className="mt-body-sm" style={{ color: 'var(--t-faint)' }}>
+        {busyLabel}
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <select
+          id={id}
+          value={selected}
+          onChange={e => {
+            // Switching TO free text clears the value so the field starts empty and the
+            // control doesn't flip straight back to the dropdown on the next render.
+            onChange(e.target.value === FREE_TEXT ? '' : e.target.value)
+          }}
+          className="rounded-lg px-2.5 py-1.5 bg-ctrl min-w-0"
+          style={{
+            border: '1px solid var(--t-ctrl-border)',
+            color: 'var(--t-title)',
+            font: '500 12px var(--font-sans)',
+            cursor: 'pointer',
+          }}
+        >
+          {required ? (
+            // A required field with nothing chosen still needs an option matching the empty
+            // value, or the browser renders the FIRST model while the value is actually ''
+            // - the control would claim a model the form isn't holding. Disabled, so it can
+            // be shown but not re-selected.
+            value === '' && <option value="" disabled>Select a model…</option>
+          ) : (
+            <option value="">{emptyLabel}</option>
+          )}
+          {models.map(m => (
+            <option key={m.id} value={m.id}>
+              {m.label}
+            </option>
+          ))}
+          <option value={FREE_TEXT}>Custom model…</option>
+        </select>
+        {action}
+      </div>
+
+      {freeText && (
+        <input
+          type="text"
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder="model id, e.g. gemini-flash-latest"
+          className="w-full rounded-lg px-2 py-1 bg-ctrl"
+          style={{
+            border: '1px solid var(--t-ctrl-border)',
+            color: 'var(--t-title)',
+            font: '500 11px var(--font-mono, ui-monospace)',
+          }}
+        />
+      )}
+      {note && (
+        <p className="mt-body-sm" style={{ color: 'var(--t-faint)' }}>
+          {note}
+        </p>
+      )}
+    </div>
+  )
+}
+
+interface ModelMultiSelectProps {
+  /**
+   * The raw comma-separated list, kept as a STRING rather than an array so the Lab's variant
+   * assembly (`RunComposer`) keeps splitting it exactly as it did when this was a text input.
+   */
+  value: string
+  onChange: (next: string) => void
+  models: LlmModelOption[]
+}
+
+/** Split the stored comma list into trimmed, non-empty model ids. */
+function parseList(value: string): string[] {
+  return value
+    .split(',')
+    .map(m => m.trim())
+    .filter(Boolean)
+}
+
+/**
+ * The Lab's fan-out control: tick any number of curated models, each of which becomes its own
+ * variant column, and still type anything else alongside them.
+ *
+ * Empty means "the provider's default model, one variant" - which is why nothing is ticked by
+ * default and why the free-text field stays: the Lab's whole point is comparing models we may
+ * not have listed yet.
+ */
+export function ModelMultiSelect({ value, onChange, models }: ModelMultiSelectProps) {
+  const picked = parseList(value)
+
+  function toggle(id: string) {
+    const next = picked.includes(id) ? picked.filter(m => m !== id) : [...picked, id]
+    onChange(next.join(', '))
+  }
+
+  return (
+    <div className="mt-2 flex flex-col gap-1.5">
+      {models.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {models.map(m => {
+            const on = picked.includes(m.id)
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => toggle(m.id)}
+                title={m.note ?? m.id}
+                className="rounded-full px-2 py-0.5"
+                style={{
+                  border: `1px solid ${on ? 'var(--btn-primary-bg)' : 'var(--t-ctrl-border)'}`,
+                  background: on ? 'var(--btn-primary-bg)' : 'var(--t-ctrl)',
+                  color: on ? '#fff' : 'var(--t-muted)',
+                  font: '600 10.5px var(--font-sans)',
+                  cursor: 'pointer',
+                }}
+              >
+                {m.label}
+              </button>
+            )
+          })}
+        </div>
+      )}
+      <input
+        type="text"
+        placeholder={
+          models.length > 0
+            ? 'or type model(s), comma-separated'
+            : 'model(s), comma-separated (optional)'
+        }
+        title="Empty = the provider's default model. Several models = one variant each."
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        className="w-full rounded-lg px-2 py-1 bg-ctrl"
+        style={{
+          border: '1px solid var(--t-ctrl-border)',
+          color: 'var(--t-title)',
+          font: '500 11px var(--font-mono, ui-monospace)',
+        }}
+      />
+    </div>
+  )
+}
+
+/**
+ * What we show instead of a picker for a provider whose backend discards the model.
+ *
+ * Only `copilot` today: its argv is built without a model flag and it never reads `cfg.model`
+ * (`src/llm/copilot.rs`). A dropdown here would write a setting nothing reads - strictly worse
+ * than saying so.
+ */
+export function ModelUnsupportedNote({ providerName }: { providerName: string }) {
+  return (
+    <p className="mt-body-sm" style={{ color: 'var(--t-faint)' }}>
+      Model is managed by the {providerName} CLI - Meridian uses whichever model it is signed
+      in to.
+    </p>
+  )
+}

--- a/ui/components/ModelPicker.tsx
+++ b/ui/components/ModelPicker.tsx
@@ -26,7 +26,7 @@
  * `RunComposer` (multi), `IntelligenceSection` (single), `CustomProviders` (single).
  */
 
-import { useId } from 'react'
+import { useId, useState } from 'react'
 import type { LlmModelOption } from '@/lib/llm-providers'
 
 /** The sentinel `<option>` value meaning "the user wants to type their own". */
@@ -70,8 +70,15 @@ export function ModelSelect({
 }: ModelSelectProps) {
   const id = useId()
   const known = models.some(m => m.id === value)
-  // Free text whenever we have nothing to offer, or the stored value isn't in what we offer.
-  const freeText = models.length === 0 || (value !== '' && !known)
+  // Picking "Custom model…" has to be held explicitly. Deriving it from the value alone
+  // cannot work: that choice clears the value, and an empty value against a non-empty list
+  // is indistinguishable from "nothing chosen yet" - so the text input would never appear
+  // and the escape hatch this component promises would be unreachable.
+  const [customMode, setCustomMode] = useState(false)
+  // Also free text when there is nothing to offer, or the stored value is one we don't list
+  // (which is how an already-saved unlisted model keeps rendering instead of being snapped
+  // to something else).
+  const freeText = customMode || models.length === 0 || (value !== '' && !known)
   const selected = freeText ? FREE_TEXT : value
   const note = models.find(m => m.id === value)?.note
 
@@ -90,9 +97,10 @@ export function ModelSelect({
           id={id}
           value={selected}
           onChange={e => {
-            // Switching TO free text clears the value so the field starts empty and the
-            // control doesn't flip straight back to the dropdown on the next render.
-            onChange(e.target.value === FREE_TEXT ? '' : e.target.value)
+            const custom = e.target.value === FREE_TEXT
+            setCustomMode(custom)
+            // Switching TO free text clears the value so the field starts empty.
+            onChange(custom ? '' : e.target.value)
           }}
           className="rounded-lg px-2.5 py-1.5 bg-ctrl min-w-0"
           style={{

--- a/ui/components/timeline/llmlab/RunComposer.tsx
+++ b/ui/components/timeline/llmlab/RunComposer.tsx
@@ -15,6 +15,7 @@ import type { DayTasksResponse, LlmExperimentProcess, RunLlmExperimentBody } fro
 import { LLM_PROVIDERS, customVariantId, rungLabel, type LlmProviderId } from '@/lib/llm-providers'
 import { useLlmProviderDetection } from '@/components/LlmProviderPicker'
 import { useCustomProviders } from '@/components/CustomProviders'
+import { ModelMultiSelect, ModelUnsupportedNote } from '@/components/ModelPicker'
 import { dayString } from '../types'
 
 const PROCESSES: { id: LlmExperimentProcess; name: string; hint: string }[] = [
@@ -79,7 +80,12 @@ export function RunComposer({ starting, error, onRun }: {
   // model-override fan-out.
   const variants = useMemo(() => ([
     ...LLM_PROVIDERS.filter(p => picked.has(p.id)).flatMap(p => {
-      const overrides = (models[p.id] ?? '').split(',').map(m => m.trim()).filter(Boolean)
+      // A provider whose backend discards the model (copilot) never fans out, even if a
+      // stale string is still held in state - a `copilot:<model>` column would promise a
+      // comparison the run can't actually make.
+      const overrides = p.supportsModelOverride
+        ? (models[p.id] ?? '').split(',').map(m => m.trim()).filter(Boolean)
+        : []
       return overrides.length ? overrides.map(m => `${p.id}:${m}`) : [p.id]
     }),
     ...custom.providers.filter(c => pickedCustom.has(c.id)).map(c => customVariantId(c.id)),
@@ -177,13 +183,20 @@ export function RunComposer({ starting, error, onRun }: {
                     : installable ? 'installed' : 'not installed'}
                 </span>
               </label>
-              {on && (
-                <input type="text" placeholder="model(s), comma-separated (optional)"
-                  title="Empty = the provider's default model. Several models = one variant each, e.g. gpt-5.3, gpt-5.1-mini"
-                  value={models[p.id] ?? ''} onChange={e => setModels(m => ({ ...m, [p.id]: e.target.value }))}
-                  className="mt-2 w-full rounded-lg px-2 py-1 bg-ctrl"
-                  style={{ border: '1px solid var(--t-ctrl-border)', color: 'var(--t-title)', font: '500 11px var(--font-mono, ui-monospace)' }} />
-              )}
+              {/* Tick curated models and/or type your own; both feed the same comma list, so
+                  the variant assembly above is unchanged. copilot takes no model at all, so
+                  it gets a note rather than a control that would be silently discarded. */}
+              {on && (p.supportsModelOverride ? (
+                <ModelMultiSelect
+                  value={models[p.id] ?? ''}
+                  onChange={next => setModels(m => ({ ...m, [p.id]: next }))}
+                  models={p.models}
+                />
+              ) : (
+                <div className="mt-2">
+                  <ModelUnsupportedNote providerName={p.name} />
+                </div>
+              ))}
             </div>
           )
         })}

--- a/ui/components/timeline/settings/IntelligenceSection.tsx
+++ b/ui/components/timeline/settings/IntelligenceSection.tsx
@@ -197,12 +197,26 @@ export function IntelligenceSection({ settings, save }: {
       {pending && (
         <div className="sticky bottom-0 flex flex-col gap-2 pb-1"
           style={{ background: 'var(--t-panel)' }}>
+          {/* A staged change is now either a provider switch OR a model-only edit, and the
+              guidance has to match: telling someone who changed the model that a provider
+              "isn't in use yet" describes a switch that isn't happening. */}
           <p className="mt-body-sm" style={{
             color: saveStatus === 'error' ? 'var(--status-error-dot)' : 'var(--color-state-pending)',
           }}>
-            {saveStatus === 'error'
-              ? `Couldn't switch to ${llmProvider(pending.id).name} - it's still selected here, so you can press Save to try again.`
-              : `${llmProvider(pending.id).name} isn't in use yet - Save to switch to it.`}
+            {(() => {
+              const name = llmProvider(pending.id).name
+              const providerChanged = pending.id !== savedId
+                || (pending.id === 'custom' && pending.customId !== savedCustomId)
+              const target = pending.model === '' ? `the ${name} default model` : pending.model
+              if (saveStatus === 'error') {
+                return providerChanged
+                  ? `Couldn't switch to ${name} - it's still selected here, so you can press Save to try again.`
+                  : `Couldn't change the model to ${target} - it's still selected here, so you can press Save to try again.`
+              }
+              return providerChanged
+                ? `${name} isn't in use yet - Save to switch to it.`
+                : `${name} is still using its current model - Save to switch to ${target}.`
+            })()}
           </p>
           <SaveButton status={saveStatus} onClick={onSave} />
         </div>

--- a/ui/components/timeline/settings/IntelligenceSection.tsx
+++ b/ui/components/timeline/settings/IntelligenceSection.tsx
@@ -22,13 +22,16 @@ import { useCallback, useState } from 'react'
 import type { RuntimeSettings } from '@/lib/settings'
 import { llmProvider, type LlmProviderId } from '@/lib/llm-providers'
 import LlmProviderPicker, { useLlmProviderDetection } from '@/components/LlmProviderPicker'
+import { ModelSelect, ModelUnsupportedNote } from '@/components/ModelPicker'
 import { SaveButton, type SaveStatus } from './fields'
 
 /** A staged, not-yet-saved provider choice. `customId` is the chosen endpoint when
- *  `id` is 'custom', else null — the two always travel together (see `onChange`). */
+ *  `id` is 'custom', else null — the two always travel together (see `onChange`).
+ *  `model` is the optional per-provider model override; '' means the provider's default. */
 interface PendingChoice {
   id: LlmProviderId
   customId: string | null
+  model: string
 }
 
 export function IntelligenceSection({ settings, save }: {
@@ -41,12 +44,18 @@ export function IntelligenceSection({ settings, save }: {
 
   const savedId = settings.llm_provider
   const savedCustomId = settings.llm_provider_custom_id ?? null
+  const savedModel = settings.llm_provider_model ?? ''
   // What the panel SHOWS: the staged pick while one is held, else what's on disk. Every
   // dependent read below (badges, warnings) uses this, so the whole section describes the
   // provider you are about to commit rather than half-describing the old one.
   const provider = pending?.id ?? savedId
   const selectedCustomId = pending ? pending.customId : savedCustomId
+  const model = pending ? pending.model : savedModel
   const picked = llmProvider(provider)
+  // The override is only meaningful for a CLI backend that actually passes it through.
+  // A custom endpoint carries its model on the endpoint ROW instead (openai_compat sends
+  // `ep.model` and ignores cfg.model), and copilot has no model flag at all.
+  const showModelPicker = picked.kind === 'cli' && picked.supportsModelOverride
 
   // The chosen provider's last real connectivity test, if any — not a guess. When it
   // failed, the warning below says what's ACTUALLY happening right now instead of only
@@ -60,18 +69,41 @@ export function IntelligenceSection({ settings, save }: {
     // configured endpoint. Comparing the PAIR (not just the id) is what makes switching
     // between two custom endpoints register as a change.
     const nextCustomId = id === 'custom' ? customId ?? null : null
+    // The override is scoped to the CHOSEN provider - src/llm/detect.rs clears cfg.model
+    // when testing any other one, precisely so one CLI's model string can't leak into
+    // another's --model. Switching provider therefore DROPS the staged model instead of
+    // carrying e.g. a claude alias over to codex; returning to the saved provider restores
+    // whatever is on disk.
+    const nextModel = id === savedId ? savedModel : ''
     const backToSaved = id === savedId && (id !== 'custom' || nextCustomId === savedCustomId)
     setSaveStatus('idle')
     // Re-picking the saved provider clears the stage, so Save can't offer to write a
     // change that isn't one.
-    setPending(backToSaved ? null : { id, customId: nextCustomId })
-  }, [savedId, savedCustomId])
+    setPending(backToSaved ? null : { id, customId: nextCustomId, model: nextModel })
+  }, [savedId, savedCustomId, savedModel])
+
+  // Staging a model follows the same rule as staging a provider: land it in `pending`, and
+  // collapse back to "nothing staged" the moment the pair matches what is on disk, so Save
+  // never offers to write a non-change.
+  const onModelChange = useCallback((next: string) => {
+    setSaveStatus('idle')
+    setPending(prev => {
+      const staged = { ...(prev ?? { id: savedId, customId: savedCustomId, model: savedModel }), model: next }
+      const settled = staged.id === savedId
+        && (staged.id !== 'custom' || staged.customId === savedCustomId)
+        && staged.model === savedModel
+      return settled ? null : staged
+    })
+  }, [savedId, savedCustomId, savedModel])
 
   const onSave = useCallback(() => {
     if (!pending) return
+    // A custom endpoint's model lives on the endpoint row, so the shared override is not
+    // written for it. '' means "the provider's own default" and is stored as null, matching
+    // `Option<String>`/`None` in meridian-core/src/settings.rs.
     const fields: Partial<RuntimeSettings> = pending.id === 'custom'
       ? { llm_provider: pending.id, llm_provider_custom_id: pending.customId }
-      : { llm_provider: pending.id }
+      : { llm_provider: pending.id, llm_provider_model: pending.model || null }
     // `save` never rejects — it reports through the status callback — so the staged pick
     // is cleared on 'saved' only. On 'error' it deliberately survives, so the user can hit
     // Save again without re-picking.
@@ -106,6 +138,35 @@ export function IntelligenceSection({ settings, save }: {
         testOne={testOne}
         rescan={rescan}
       />
+
+      {/* The model within the chosen provider. Net-new UI: `llm_provider_model` has existed
+          on both sides of the wire for a while (meridian-core/src/settings.rs, consumed at
+          src/llm/config.rs) but nothing ever wrote it, so the override was unreachable.
+          Blank stays the default - most users never need this. */}
+      <div className="flex flex-col gap-2">
+        <p className="mt-label" style={{ color: 'var(--t-faint)' }}>MODEL</p>
+        {showModelPicker ? (
+          <>
+            <ModelSelect
+              value={model}
+              onChange={onModelChange}
+              models={picked.models}
+              emptyLabel={`${picked.name} default`}
+            />
+            <p className="mt-body-sm max-w-[520px]" style={{ color: 'var(--t-muted)' }}>
+              Leave this on the default unless you have a reason not to - Meridian follows
+              whatever {picked.name} would pick for itself. A model this list doesn't carry
+              can be typed in; nothing here is a fixed set.
+            </p>
+          </>
+        ) : picked.kind === 'custom' ? (
+          <p className="mt-body-sm max-w-[520px]" style={{ color: 'var(--t-muted)' }}>
+            A custom endpoint carries its own model - change it on the endpoint itself, above.
+          </p>
+        ) : (
+          <ModelUnsupportedNote providerName={picked.name} />
+        )}
+      </div>
 
       {/* A KNOWN failure, from the last real test. Since the on-device fallback was
           removed there is nothing to degrade to, so this is the one thing to tell the

--- a/ui/lib/llm-providers.ts
+++ b/ui/lib/llm-providers.ts
@@ -294,8 +294,16 @@ export const LLM_PROVIDERS: LlmProviderMeta[] = [
   },
 ]
 
-/** Look up one provider's metadata, or undefined for an unknown id. */
+/**
+ * Look up one provider's metadata, or undefined for an unknown id.
+ *
+ * `LLM_PROVIDERS` holds only the built-ins that get a card in the grid, so 'custom' has to
+ * be answered from [`CUSTOM_PROVIDER_META`] - exactly as `llmProvider` does. Without that,
+ * `supportsModelOverride('custom')` would answer false even though a custom endpoint does
+ * carry a model, which is the wrong answer for any caller that asks by id.
+ */
 export function providerMeta(id: LlmProviderId): LlmProviderMeta | undefined {
+  if (id === 'custom') return CUSTOM_PROVIDER_META
   return LLM_PROVIDERS.find((p) => p.id === id)
 }
 

--- a/ui/lib/llm-providers.ts
+++ b/ui/lib/llm-providers.ts
@@ -162,6 +162,22 @@ export function customVariantId(id: string): string {
   return `custom:${id}`
 }
 
+/**
+ * One selectable model in a provider's curated list.
+ *
+ * The list is a CONVENIENCE, never a constraint: nothing in the pipeline validates the
+ * string (it is passed verbatim into the CLI's argv - see `src/llm/claude.rs` and friends),
+ * so the picker always allows a free-text value for a model we haven't listed.
+ */
+export interface LlmModelOption {
+  /** The exact string handed to the backend - a CLI alias or a full model id. */
+  id: string
+  /** What the picker shows. */
+  label: string
+  /** Optional one-liner shown under the label. */
+  note?: string
+}
+
 export interface LlmProviderMeta {
   id: LlmProviderId
   name: string
@@ -177,6 +193,21 @@ export interface LlmProviderMeta {
   /** Shown when the CLI is not installed - the command that installs it. */
   installHint?: string
   installUrl?: string
+  /**
+   * Whether this backend actually passes a model through. FALSE for copilot, whose argv is
+   * built without a model flag and never reads `cfg.model` (`src/llm/copilot.rs`) - the
+   * picker must show "managed by the CLI" there rather than a control that silently does
+   * nothing. Mirrors the doc comment on `llm_provider_model` in meridian-core/src/settings.rs,
+   * which likewise omits copilot.
+   */
+  supportsModelOverride: boolean
+  /**
+   * The curated model list offered in the picker. May be empty for a provider whose model
+   * names we can't enumerate confidently - the picker then falls back to free text alone.
+   * These are CLI subprocesses with no models endpoint, so this list is hand-maintained;
+   * only custom endpoints can be enumerated live (see `list_custom_llm_provider_models`).
+   */
+  models: LlmModelOption[]
   /**
    * Where the user opts their prompts OUT of model training. This is ACCOUNT-LEVEL for
    * every provider (a subprocess can't flip it - Meridian only disables telemetry per
@@ -200,6 +231,17 @@ export const LLM_PROVIDERS: LlmProviderMeta[] = [
     installUrl: 'https://claude.com/claude-code',
     privacyUrl: 'https://claude.ai/settings/data-privacy-controls',
     privacyLabel: 'Claude - Privacy controls',
+    supportsModelOverride: true,
+    // The claude CLI accepts both tier aliases and full model ids. Aliases are listed
+    // first: they keep working across releases, where a pinned id eventually retires.
+    models: [
+      { id: 'opus', label: 'Opus', note: 'Most capable - the default for hourly summaries' },
+      { id: 'sonnet', label: 'Sonnet', note: 'Balanced speed and quality' },
+      { id: 'haiku', label: 'Haiku', note: 'Fastest and cheapest' },
+      { id: 'claude-opus-4-8', label: 'Claude Opus 4.8', note: 'Pinned version of Opus' },
+      { id: 'claude-sonnet-5', label: 'Claude Sonnet 5', note: 'Pinned version of Sonnet' },
+      { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5', note: 'Pinned version of Haiku' },
+    ],
   },
   {
     id: 'codex',
@@ -211,6 +253,12 @@ export const LLM_PROVIDERS: LlmProviderMeta[] = [
     installUrl: 'https://developers.openai.com/codex/cli',
     privacyUrl: 'https://chatgpt.com/#settings/DataControls',
     privacyLabel: 'ChatGPT - Data Controls',
+    supportsModelOverride: true,
+    models: [
+      { id: 'gpt-5.5', label: 'GPT-5.5', note: 'Latest general model' },
+      { id: 'gpt-5.1-codex', label: 'GPT-5.1 Codex', note: 'Tuned for coding' },
+      { id: 'gpt-5.1', label: 'GPT-5.1' },
+    ],
   },
   {
     id: 'cursor',
@@ -222,6 +270,11 @@ export const LLM_PROVIDERS: LlmProviderMeta[] = [
     installUrl: 'https://cursor.com/cli',
     privacyUrl: 'https://cursor.com/settings',
     privacyLabel: 'Cursor - Privacy Mode',
+    supportsModelOverride: true,
+    // Deliberately empty: cursor-agent takes --model, but its accepted values aren't
+    // pinned anywhere we can verify, and an invented id would be passed verbatim into
+    // argv and fail at run time. Free text only until we can source a real list.
+    models: [],
   },
   {
     id: 'copilot',
@@ -233,8 +286,36 @@ export const LLM_PROVIDERS: LlmProviderMeta[] = [
     installUrl: 'https://github.com/features/copilot/cli',
     privacyUrl: 'https://github.com/settings/copilot/features',
     privacyLabel: 'GitHub - Copilot policies',
+    // The copilot backend builds its argv without a model flag and never reads cfg.model
+    // (src/llm/copilot.rs) - the model is whatever the CLI itself is configured to use.
+    // Offering a picker here would write a setting the backend drops on the floor.
+    supportsModelOverride: false,
+    models: [],
   },
 ]
+
+/** Look up one provider's metadata, or undefined for an unknown id. */
+export function providerMeta(id: LlmProviderId): LlmProviderMeta | undefined {
+  return LLM_PROVIDERS.find((p) => p.id === id)
+}
+
+/**
+ * The curated models for a provider - empty when we can't enumerate them (cursor) or the
+ * backend ignores the model entirely (copilot). Callers must treat empty as "free text
+ * only", NOT as "this provider has no models".
+ */
+export function modelsFor(id: LlmProviderId): LlmModelOption[] {
+  return providerMeta(id)?.models ?? []
+}
+
+/**
+ * Whether a model control should be offered for this provider at all. False means the
+ * chosen model would be silently discarded by the backend - show an explanatory note
+ * instead of a picker.
+ */
+export function supportsModelOverride(id: LlmProviderId): boolean {
+  return providerMeta(id)?.supportsModelOverride ?? false
+}
 
 /**
  * The stored default - Claude, the first/recommended coding agent (matches
@@ -349,6 +430,13 @@ export const CUSTOM_PROVIDER_META: LlmProviderMeta = {
   bin: null,
   // Account-level, and it varies per vendor - there is no one link to send them to.
   privacyUrl: null,
+  // A custom endpoint carries its model per-row (`CustomEndpoint.model`, sent as the
+  // "model" body field in src/llm/openai_compat.rs) rather than through the shared
+  // `llm_provider_model` setting - but a model IS selectable, hence true.
+  supportsModelOverride: true,
+  // Empty on purpose: these are the one provider whose models can be enumerated LIVE,
+  // from the endpoint's own {base_url}/models. Nothing to hand-maintain here.
+  models: [],
 }
 
 export function llmProvider(id: LlmProviderId): LlmProviderMeta {

--- a/ui/lib/llm-providers.ts
+++ b/ui/lib/llm-providers.ts
@@ -235,12 +235,12 @@ export const LLM_PROVIDERS: LlmProviderMeta[] = [
     // The claude CLI accepts both tier aliases and full model ids. Aliases are listed
     // first: they keep working across releases, where a pinned id eventually retires.
     models: [
-      { id: 'opus', label: 'Opus', note: 'Most capable - the default for hourly summaries' },
+      { id: 'opus', label: 'Opus', note: 'Most capable - follows each new Opus release' },
       { id: 'sonnet', label: 'Sonnet', note: 'Balanced speed and quality' },
       { id: 'haiku', label: 'Haiku', note: 'Fastest and cheapest' },
-      { id: 'claude-opus-4-8', label: 'Claude Opus 4.8', note: 'Pinned version of Opus' },
-      { id: 'claude-sonnet-5', label: 'Claude Sonnet 5', note: 'Pinned version of Sonnet' },
-      { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5', note: 'Pinned version of Haiku' },
+      { id: 'claude-opus-4-8', label: 'Claude Opus 4.8', note: 'Stays on this exact model' },
+      { id: 'claude-sonnet-5', label: 'Claude Sonnet 5', note: 'Stays on this exact model' },
+      { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5', note: 'Stays on this exact model' },
     ],
   },
   {


### PR DESCRIPTION
Replaces free-text model entry with pickers on all three surfaces, and exposes a model override in Intelligence settings that previously had no UI at all.

## What changed

**A curated model registry** (`ui/lib/llm-providers.ts`) — colocated with `LLM_PROVIDERS` so the two cannot drift; the compiler now requires every provider to declare `supportsModelOverride` and `models`.

**Live model listing for custom endpoints** — `openai_compat::list_models` + a `list_custom_llm_provider_models` tray command. This is the one provider whose models can be enumerated; the rest are CLI subprocesses with no such endpoint.

**Three wire-ups** — Lab variants (multi-select fan-out), Intelligence settings (single override), custom endpoint form (live-listed).

## Three things worth reviewing closely

**Copilot gets a note, not a picker.** Its argv is built without a model flag and it never reads `cfg.model` (`src/llm/copilot.rs`), so a control there would write a setting the backend drops on the floor — worse than saying so. It also no longer fans out in the Lab, where a `copilot:<model>` column would promise a comparison the run cannot make. Adding the flag is a reasonable follow-up but is a behaviour change to a working provider, so it is deliberately not in this PR.

**Cursor ships an empty list.** `cursor-agent` takes `--model`, but no verifiable value for it exists anywhere in the repo. Since nothing validates a model string — it goes verbatim into argv — an invented id would not fail loudly, it would fail an hour later as a nonzero CLI exit. Free text only until we can source a real list. **If a reviewer knows cursor-agent's accepted values, that is a one-line addition.**

**Switching provider drops the staged model.** `src/llm/detect.rs` already clears `cfg.model` when testing a non-selected provider, precisely so one CLI's model cannot leak into another's `--model`. The settings UI now honours the same rule.

## Two details that would have been bugs

- The probe URL is `{base_url}/models`, **not** `/v1/models` — the stored `base_url` already carries the version segment (`https://…/v1`, `https://…/v1beta/openai`), so appending `/v1` would 404 every configured endpoint.
- The custom-endpoint Model field moved *below* the API key, because listing models needs the key — asking for the model first meant typing it blind.

## Free text is never removed

Nothing in the pipeline validates a model string, so the curated lists are a convenience and never a whitelist. Every control keeps a way to type an unlisted model, and a stored model the list does not carry keeps rendering as free text rather than silently snapping to a listed one.

## Verification

- `cargo clippy --all-targets` clean; 676 daemon + 104 tray tests pass
- `tsc`, `next build`, and 261 UI tests pass (18 new)
- `/models` envelope parsing has unit tests for the OpenAI `data` shape, the `models` shape, bare arrays, dedup, empty-is-not-an-error, and non-JSON-is-an-error
- The provider-switch guard was mutation-checked: breaking the reset in source makes it fail

**Not verified:** `list_models` has never hit a live endpoint — I have no API key, and running the tray from this worktree risks migrating the real `meridian.db` ahead of the installed app. Its parsing is unit-tested against the documented shapes, but a reviewer with a real key should exercise **List models** once on the add-endpoint form. The UI has not been visually rendered for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015J2ioRixcpoesWosQhrwpA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model selection and override support for eligible providers.
  * Added curated model lists with free-text entry and multi-model selection.
  * Added live model discovery for custom endpoints using their URL and API key.
  * Added clear feedback when model discovery fails or a provider does not support overrides.
* **Bug Fixes**
  * Prevented unsupported or stale model overrides from being applied.
  * Preserved unlisted and manually entered model names.
* **Tests**
  * Added coverage for model selection, provider switching, custom endpoints, and model discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->