### PR TITLE
fix(error-handling): harden ETL/worklog error paths against silent failure

### DIFF
--- a/src/etl/runner.rs
+++ b/src/etl/runner.rs
@@ -454,12 +454,18 @@ pub async fn run_etl(meridian: &SqlitePool) -> Result<Vec<i64>> {
 
     if let Err(e) = result {
         warn!(error = %e, "ETL run failed — updating cursor to last successful frame");
-        complete_etl_run(meridian, run_id, sessions_closed, Some(&e.to_string()))
-            .await
-            .context("failed to mark etl_runs row failed")?;
-        update_cursor(meridian, last_processed_id, run_id)
-            .await
-            .context("failed to advance etl_cursor after failed run")?;
+        if let Err(recovery_err) =
+            complete_etl_run(meridian, run_id, sessions_closed, Some(&e.to_string())).await
+        {
+            warn!(error = %recovery_err, run_id, "failed to mark etl_runs row failed");
+        }
+        if let Err(recovery_err) = update_cursor(meridian, last_processed_id, run_id).await {
+            warn!(
+                error = %recovery_err,
+                run_id,
+                "failed to advance etl_cursor after failed run"
+            );
+        }
         return Err(e);
     }
 

--- a/src/etl/runner.rs
+++ b/src/etl/runner.rs
@@ -1,6 +1,6 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use sqlx::SqlitePool;
 use tracing::{debug, info, warn};
 
@@ -34,14 +34,18 @@ const GAP_THRESHOLD_SECS: i64 = 300;
     )
 )]
 pub async fn run_etl(meridian: &SqlitePool) -> Result<Vec<i64>> {
-    let cursor = get_cursor(meridian).await?;
+    let cursor = get_cursor(meridian)
+        .await
+        .context("failed to read etl_cursor")?;
     let mut last_processed_id = cursor.last_frame_id;
     let run_start_cursor = last_processed_id;
 
     tracing::Span::current().record("from_frame_id", run_start_cursor);
     info!(from_frame_id = last_processed_id, "ETL run starting");
 
-    let first_batch = get_frames_since(meridian, last_processed_id, BATCH_SIZE).await?;
+    let first_batch = get_frames_since(meridian, last_processed_id, BATCH_SIZE)
+        .await
+        .context("failed to read first frame batch")?;
     if first_batch.is_empty() {
         info!("no new frames — nothing to do");
         return Ok(vec![]);
@@ -52,7 +56,9 @@ pub async fn run_etl(meridian: &SqlitePool) -> Result<Vec<i64>> {
         .map(|f| f.id)
         .unwrap_or(last_processed_id);
 
-    let run_id = insert_etl_run(meridian, run_start_cursor, approx_to_frame_id).await?;
+    let run_id = insert_etl_run(meridian, run_start_cursor, approx_to_frame_id)
+        .await
+        .context("failed to insert etl_runs row")?;
     tracing::Span::current().record("run_id", run_id);
     tracing::Span::current().record("to_frame_id", approx_to_frame_id);
     info!(run_id, "ETL run row inserted");
@@ -128,9 +134,12 @@ pub async fn run_etl(meridian: &SqlitePool) -> Result<Vec<i64>> {
                             kind,
                             run_id,
                         )
-                        .await?;
+                        .await
+                        .context("failed to insert cross-run gap row")?;
                     }
-                    close_active_session(meridian, run_id).await?;
+                    close_active_session(meridian, run_id)
+                        .await
+                        .context("failed to close stale active_session")?;
                     info!(
                         gap_secs,
                         gap_kind = kind,
@@ -274,7 +283,8 @@ pub async fn run_etl(meridian: &SqlitePool) -> Result<Vec<i64>> {
                                     kind,
                                     run_id,
                                 )
-                                .await?;
+                                .await
+                                .context("failed to insert intra-batch gap row")?;
                                 debug!(gap_secs = gap, gap_kind = kind, from = block_last_ts, to = frame.timestamp, "gap recorded");
                             }
 
@@ -296,7 +306,8 @@ pub async fn run_etl(meridian: &SqlitePool) -> Result<Vec<i64>> {
                                     idle_frame_count: block_idle_frame_count,
                                 },
                             )
-                            .await?;
+                            .await
+                            .context("failed to close pre-gap block")?;
                             info!(
                                 session_id = sid,
                                 app_name = closing_app,
@@ -378,7 +389,8 @@ pub async fn run_etl(meridian: &SqlitePool) -> Result<Vec<i64>> {
                                 idle_frame_count: block_idle_frame_count,
                             },
                         )
-                        .await?;
+                        .await
+                        .context("failed to close block on app switch")?;
                         info!(
                             session_id = sid,
                             app_name = old_app,
@@ -404,7 +416,9 @@ pub async fn run_etl(meridian: &SqlitePool) -> Result<Vec<i64>> {
 
             last_processed_id = batch.last().map(|f| f.id).unwrap_or(last_processed_id);
 
-            let next = get_frames_since(meridian, last_processed_id, BATCH_SIZE).await?;
+            let next = get_frames_since(meridian, last_processed_id, BATCH_SIZE)
+                .await
+                .context("failed to read next frame batch")?;
             if next.is_empty() {
                 break;
             }
@@ -429,7 +443,8 @@ pub async fn run_etl(meridian: &SqlitePool) -> Result<Vec<i64>> {
                         idle_frame_count: block_idle_frame_count,
                     },
                 )
-                .await?;
+                .await
+                .context("failed to upsert open block into active_session")?;
             }
         }
 
@@ -439,14 +454,22 @@ pub async fn run_etl(meridian: &SqlitePool) -> Result<Vec<i64>> {
 
     if let Err(e) = result {
         warn!(error = %e, "ETL run failed — updating cursor to last successful frame");
-        complete_etl_run(meridian, run_id, sessions_closed, Some(&e.to_string())).await?;
-        update_cursor(meridian, last_processed_id, run_id).await?;
+        complete_etl_run(meridian, run_id, sessions_closed, Some(&e.to_string()))
+            .await
+            .context("failed to mark etl_runs row failed")?;
+        update_cursor(meridian, last_processed_id, run_id)
+            .await
+            .context("failed to advance etl_cursor after failed run")?;
         return Err(e);
     }
 
-    update_cursor(meridian, last_processed_id, run_id).await?;
+    update_cursor(meridian, last_processed_id, run_id)
+        .await
+        .context("failed to advance etl_cursor")?;
     debug!(cursor = last_processed_id, run_id, "ETL cursor advanced");
-    complete_etl_run(meridian, run_id, sessions_closed, None).await?;
+    complete_etl_run(meridian, run_id, sessions_closed, None)
+        .await
+        .context("failed to mark etl_runs row successful")?;
 
     tracing::Span::current().record("sessions_closed", sessions_closed);
     info!(

--- a/src/intelligence/session_categorizer/mod.rs
+++ b/src/intelligence/session_categorizer/mod.rs
@@ -543,4 +543,16 @@ mod tests {
         assert!(ActivityKind::Coding.is_pm_mappable());
         assert!(ActivityKind::DeploymentDevops.is_pm_mappable());
     }
+
+    #[test]
+    fn winner_does_not_panic_on_nan_score() {
+        // total_cmp's total order ranks a positive NaN above every finite
+        // value, so a NaN score wins outright rather than panicking like
+        // partial_cmp would.
+        let mut scores = Scores::new();
+        scores.add(ActivityKind::Coding, f32::NAN);
+        scores.add(ActivityKind::Meeting, 1.0);
+        let (winner, _confidence) = scores.winner();
+        assert_eq!(winner, ActivityKind::Coding);
+    }
 }

--- a/src/intelligence/session_categorizer/mod.rs
+++ b/src/intelligence/session_categorizer/mod.rs
@@ -186,8 +186,8 @@ impl Scores {
             .0
             .iter()
             .enumerate()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
-            .unwrap();
+            .max_by(|a, b| a.1.total_cmp(b.1))
+            .expect("scores array is fixed-size and non-empty");
         (ActivityKind::from_index(idx), max / total)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -983,7 +983,7 @@ async fn main() -> Result<()> {
     {
         let cfg = Config::from_env();
         let startup_tick = tracing::info_span!("startup_tick");
-        *etl_tick_span.lock().unwrap() = Some(startup_tick.clone());
+        *etl_tick_span.lock().unwrap_or_else(|e| e.into_inner()) = Some(startup_tick.clone());
         let _guard = startup_tick.enter();
         tracing::info!("running initial ETL pass");
         if let Err(e) = run_etl(&meridian).await {
@@ -1123,7 +1123,7 @@ async fn main() -> Result<()> {
                     "poll_tick",
                     poll_interval_secs = cfg.runtime.poll_interval_secs
                 );
-                *etl_tick_span.lock().unwrap() = Some(poll_tick.clone());
+                *etl_tick_span.lock().unwrap_or_else(|e| e.into_inner()) = Some(poll_tick.clone());
                 let _guard = poll_tick.enter();
                 tracing::debug!("starting ETL tick");
                 if let Err(e) = run_etl(&meridian).await {

--- a/src/pm_worklog/generate.rs
+++ b/src/pm_worklog/generate.rs
@@ -234,7 +234,11 @@ pub async fn approve(
                 let now = chrono::Utc::now().to_rfc3339();
                 let msg = format!("{e:#}");
                 // Record the failure; leave the row `approved` for a safe retry.
-                let _ = day_task_worklogs::mark_error(pool, day_local, task_id, &msg, &now).await;
+                if let Err(mark_err) =
+                    day_task_worklogs::mark_error(pool, day_local, task_id, &msg, &now).await
+                {
+                    tracing::warn!(error = %mark_err, task_id, "worklog: failed to record approve error on row");
+                }
                 tracing::warn!(error = %e, "worklog: approve failed - left retry-safe");
                 tracing::Span::current().record("posted", false);
                 Ok(ApproveResult {
@@ -333,8 +337,11 @@ async fn approve_inner(
                             // Definite failure: nothing was filed, so release the claim
                             // and let a later retry try again.
                             Err(e) => {
-                                let _ = day_task_worklogs::revert_create(pool, day_local, task_id)
-                                    .await;
+                                if let Err(revert_err) =
+                                    day_task_worklogs::revert_create(pool, day_local, task_id).await
+                                {
+                                    tracing::warn!(error = %revert_err, task_id, "worklog: failed to revert create claim after ticket-create failure");
+                                }
                                 return Err(e)
                                     .context("creating the proposed ticket on the tracker");
                             }
@@ -484,17 +491,23 @@ async fn approve_inner(
                 // side effect, so releasing the claim is known-safe and lets a
                 // normal retry re-attempt it. This is the ONLY safe place to
                 // release: a crash never reaches here, which is the point.
-                let _ =
+                if let Err(revert_err) =
                     day_task_worklogs::targets::revert_post(pool, day_local, task_id, &t.task_key)
-                        .await;
-                let _ = day_task_worklogs::targets::mark_error(
+                        .await
+                {
+                    tracing::warn!(error = %revert_err, task_id, task_key = t.task_key, "worklog: failed to revert post claim after target-post failure");
+                }
+                if let Err(mark_err) = day_task_worklogs::targets::mark_error(
                     pool,
                     day_local,
                     task_id,
                     &t.task_key,
                     &msg,
                 )
-                .await;
+                .await
+                {
+                    tracing::warn!(error = %mark_err, task_id, task_key = t.task_key, "worklog: failed to record target post error");
+                }
                 out.push(PostedTarget {
                     task_key: t.task_key.clone(),
                     posted: false,


### PR DESCRIPTION
## Summary
Follow-up audit after the recent pm_worklog stuck-hour fix (#471). Went through `src/` looking for the same failure class (state that can wedge silently) plus general error-handling gaps: bare `unwrap()`, swallowed errors, and missing `.context()` on the DB/IO path.

- **`etl/runner.rs`**: added `.context()` to every DB/IO call in `run_etl` — previously the daemon's most crash-sensitive loop propagated bare errors with no indication of which step failed (cursor read, frame batch read, gap insert, block close, cursor advance, etc).
- **`main.rs`**: the two `etl_tick_span` mutex locks used a plain `.lock().unwrap()`; made them poison-tolerant (`unwrap_or_else(|e| e.into_inner())`), matching the pattern already used elsewhere in this codebase for the same hazard — a panic anywhere else while holding the lock would otherwise permanently kill future tick spans.
- **`session_categorizer`**: `partial_cmp(...).unwrap()` in the score-winner comparison could panic on a NaN score; switched to `total_cmp` which is total-order and panic-free.
- **`pm_worklog/generate.rs`**: the recovery writes that run after a worklog action fails (`mark_error`, `revert_create`, `revert_post`) were silently swallowing their own failures (`let _ = ...`). The primary error was already logged, but if the recovery write itself failed, that was invisible. Now logged via `tracing::warn!`.

Also audited for other "stuck state after crash" bugs analogous to the pm_worklog one — checked `etl_runs`, `day_task_worklogs`, and other status-column tables; all either already have startup/tick-time recovery or are dev-only/dead-code paths not reachable in normal daemon operation, so no further table needed a fix.

## Test plan
- [x] `cargo build`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (669 passed)
- [x] ETL integration test targets (`etl_basic`, `etl_gaps`, `etl_session_close`, `etl_session_text`, `etl_ui_events`, `etl_coding_agent_skip`)
- [x] pre-push hook suite (fmt, clippy, ui build/tests, security audit, cargo test) — all green