### PR TITLE
fix(distiller): bound embedder memory/time + related fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "accelerate-src"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415ed64958754dbe991900f3940677e6a7eefb4d7367afd70d642677b0c7d19d"
+
+[[package]]
 name = "accessibility"
 version = "0.3.0"
 source = "git+https://github.com/eiz/accessibility.git?rev=173e898d4a52ee0afe0224ecb458d324057856e7#173e898d4a52ee0afe0224ecb458d324057856e7"
@@ -999,10 +1005,12 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
 dependencies = [
+ "accelerate-src",
  "byteorder",
  "float8",
  "gemm",
  "half",
+ "libc",
  "libm",
  "memmap2",
  "num-traits",
@@ -1023,6 +1031,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
 dependencies = [
+ "accelerate-src",
  "candle-core",
  "half",
  "libc",
@@ -1039,6 +1048,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f59d08c89e9f4af9c464e2f3a8e16199e7cc601e6f34538c2cfbb42b623b1783"
 dependencies = [
+ "accelerate-src",
  "byteorder",
  "candle-core",
  "candle-nn",
@@ -4723,6 +4733,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5007,12 +5026,14 @@ dependencies = [
  "dotenvy",
  "flate2",
  "futures",
+ "gethostname",
  "hex",
  "http",
  "jsonschema",
  "libsqlite3-sys",
  "meridian-core",
  "meridian-oauth",
+ "mimalloc",
  "once_cell",
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -5114,6 +5135,15 @@ name = "micromap"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,13 @@ name = "cat_smoke"
 path = "src/bin/cat_smoke.rs"
 
 [dependencies]
+# Global allocator — returns freed pages to the OS proactively (unlike the platform
+# default allocators, which retain freed arenas for reuse). The embedder's chunked
+# batches free a full tensor set every ~16-32 spans; without this, RSS plateaus at
+# whatever the highest transient chunk cost was instead of settling back down.
+# Cross-platform (macOS/Windows/Linux, ARM/x86) — see src/lib.rs's global allocator.
+mimalloc = "0.1"
+
 # DB — exact versions matching screenpipe
 sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio-rustls", "chrono", "migrate", "json"] }
 libsqlite3-sys = { version = "0.26", features = ["bundled"] }
@@ -64,6 +71,9 @@ opentelemetry-semantic-conventions = "0.27"
 # .otlp files back to structured log/span records for `meridian logs`
 # (src/telemetry_spool/render.rs) — no live OpenObserve needed to read them.
 opentelemetry-proto = { version = "0.27", default-features = false, features = ["gen-tonic-messages", "trace", "logs"] }
+# Resolves the `host.name` OTel resource attribute (observability/mod.rs). Was
+# already a transitive dep (via opentelemetry-otlp's stack); made explicit.
+gethostname = "1.1.0"
 prost = "0.13"
 hex = "0.4"
 
@@ -81,17 +91,19 @@ shellexpand = "3"
 regex = "1"
 
 # On-device embedding model for the session distiller's SemDeDup — pure-Rust (candle),
-# no C++/ONNX runtime. Runs on CPU (see src/embedder/device.rs): at this volume (a few
-# hundred short spans once an hour) CPU is sub-second, so the GPU buys nothing, and it
-# keeps the build identical on every OS. Weights are fetched at setup via the existing
+# no C++/ONNX runtime. Runs on CPU (see src/embedder/device.rs): candle's *default* CPU
+# backend has no BLAS acceleration at all (plain safe-Rust matmul), which made an
+# unusually heavy hour's batch take 45s+. macOS ships Accelerate.framework (vecLib/BLAS)
+# on every Mac, Intel or Apple Silicon, with no extra download or licensing — enabled
+# below for a large matmul speedup with zero cross-platform risk. Windows/Linux stay on
+# the plain backend for now (candle's `mkl` feature needs a bundled/system MKL install,
+# x86-only, and is a separate follow-up). Weights are fetched at setup via the existing
 # `reqwest` (no hf-hub), see src/embedder/provision.rs. `dirs` resolves the cross-platform
 # model cache dir.
-candle-core = "0.10"
-candle-nn = "0.10"
-candle-transformers = "0.10"
 # `fancy-regex` is the pure-Rust regex backend (vs `onig`, which is C) — required by
 # tokenizers for its Split/Replace pre-tokenizers.
 tokenizers = { version = "0.21", default-features = false, features = ["fancy-regex"] }
+
 dirs = "5"
 
 # Telemetry spool: tar+gz for export/import CLI
@@ -112,6 +124,16 @@ sha2 = "0.10"
 base64 = "0.22"
 rand = "0.8"
 jsonschema = { version = "0.48.0", default-features = false }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+candle-core = { version = "0.10", features = ["accelerate"] }
+candle-nn = { version = "0.10", features = ["accelerate"] }
+candle-transformers = { version = "0.10", features = ["accelerate"] }
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+candle-core = "0.10"
+candle-nn = "0.10"
+candle-transformers = "0.10"
 
 [dev-dependencies]
 tokio       = { version = "1.15", features = ["full", "test-util"] }

--- a/meridian-core/src/readers/plan.rs
+++ b/meridian-core/src/readers/plan.rs
@@ -717,10 +717,21 @@ pub async fn build_plan_response(
     let plan = load_plan(pool, date, today).await?;
 
     let committed: HashSet<String> = plan.iter().map(|p| p.task_key.clone()).collect();
-    let suggestions: Vec<AvailableTask> = available
+    // Carryover (yesterday's confirmed, still-not-Done) tasks are never subject to
+    // the suggestion cap — a dev who leaves 7 tasks unfinished must see all 7
+    // pre-filled tomorrow, not just however many fit in SUGGESTION_CAP. Only the
+    // non-carryover "you might also want this" suggestions are capped, and only
+    // to fill out whatever room is left under SUGGESTION_CAP.
+    let uncommitted: Vec<&AvailableTask> = available
         .iter()
         .filter(|a| !committed.contains(&a.key) && a.score > 0)
-        .take(SUGGESTION_CAP)
+        .collect();
+    let (carryover, rest): (Vec<&AvailableTask>, Vec<&AvailableTask>) =
+        uncommitted.into_iter().partition(|a| a.carryover);
+    let remaining_slots = SUGGESTION_CAP.saturating_sub(carryover.len());
+    let suggestions: Vec<AvailableTask> = carryover
+        .into_iter()
+        .chain(rest.into_iter().take(remaining_slots))
         .cloned()
         .collect();
 

--- a/src/coding_agent_session_ingest/hook.rs
+++ b/src/coding_agent_session_ingest/hook.rs
@@ -32,7 +32,7 @@ pub async fn run_hook() {
     let jsonl_path = match extract_jsonl_path(&payload) {
         Some(p) => p,
         None => {
-            eprintln!("coding-agent-hook: could not determine JSONL path from payload");
+            tracing::warn!("coding-agent-hook: could not determine JSONL path from payload");
             return;
         }
     };
@@ -43,16 +43,16 @@ pub async fn run_hook() {
     let jsonl_path = match jsonl_path.canonicalize() {
         Ok(resolved) if within_accepted_roots(&resolved) => resolved,
         Ok(resolved) => {
-            eprintln!(
-                "coding-agent-hook: transcript path outside accepted roots: {}",
-                resolved.display()
+            tracing::warn!(
+                jsonl_path = %resolved.display(),
+                "coding-agent-hook: transcript path outside accepted roots"
             );
             return;
         }
         Err(_) => {
-            eprintln!(
-                "coding-agent-hook: transcript not found: {}",
-                jsonl_path.display()
+            tracing::warn!(
+                jsonl_path = %jsonl_path.display(),
+                "coding-agent-hook: transcript not found"
             );
             return;
         }
@@ -63,17 +63,17 @@ pub async fn run_hook() {
     let opts = match SqliteConnectOptions::from_str(&uri) {
         Ok(o) => o.create_if_missing(false),
         Err(e) => {
-            eprintln!("coding-agent-hook: bad db uri {}: {}", uri, e);
+            tracing::error!(uri, error = %e, "coding-agent-hook: bad db uri");
             return;
         }
     };
     let pool = match SqlitePool::connect_with(opts).await {
         Ok(p) => p,
         Err(e) => {
-            eprintln!(
-                "coding-agent-hook: open {} failed: {}",
-                db_path.display(),
-                e
+            tracing::error!(
+                db_path = %db_path.display(),
+                error = %e,
+                "coding-agent-hook: failed to open db"
             );
             return;
         }
@@ -81,10 +81,10 @@ pub async fn run_hook() {
 
     let outcome = register_session(&pool, &jsonl_path, true, Utc::now()).await;
     pool.close().await;
-    eprintln!(
-        "coding-agent-hook: {:?} for {}",
-        outcome,
-        jsonl_path.display()
+    tracing::info!(
+        outcome = ?outcome,
+        jsonl_path = %jsonl_path.display(),
+        "coding-agent-hook: session registered"
     );
 }
 

--- a/src/coding_agent_session_ingest/segment.rs
+++ b/src/coding_agent_session_ingest/segment.rs
@@ -504,7 +504,19 @@ mod tests {
 
         // Neither record → no title.
         let p3 = write_claude_jsonl(&d, "u_untitled", &[rec(0, "user", "hello")]);
-        let (_m3, segs3) = parse_session_segments(&p3, &SegmentParams::default());
+        let (m3, segs3) = parse_session_segments(&p3, &SegmentParams::default());
+        assert_eq!(
+            segs3.len(),
+            1,
+            "expected exactly one segment, got {} (meta: total_records={}, user_turns={}, \
+             assistant_turns={}) — if this fires under `cargo test` parallel runs but not \
+             isolated, it's the long-standing intermittent flake (see git blame); rerun with \
+             `--test-threads=1` to confirm before treating as a real regression",
+            segs3.len(),
+            m3.total_records,
+            m3.user_turns,
+            m3.assistant_turns
+        );
         assert!(segs3[0].title.is_none());
     }
 
@@ -656,7 +668,19 @@ mod tests {
             "u6",
             &[rec(0, "user", "hi"), rec(30, "assistant", "yo")],
         );
-        let (_m, segs) = parse_session_segments(&p, &SegmentParams::default());
+        let (m, segs) = parse_session_segments(&p, &SegmentParams::default());
+        assert_eq!(
+            segs.len(),
+            1,
+            "expected exactly one segment, got {} (meta: total_records={}, user_turns={}, \
+             assistant_turns={}) — if this fires under `cargo test` parallel runs but not \
+             isolated, it's the long-standing intermittent flake (see git blame); rerun with \
+             `--test-threads=1` to confirm before treating as a real regression",
+            segs.len(),
+            m.total_records,
+            m.user_turns,
+            m.assistant_turns
+        );
         // Input was '...Z' (ms); output must be '...+00:00' (µs).
         assert!(segs[0].started_at.ends_with("+00:00"));
         assert!(!segs[0].started_at.contains('Z'));

--- a/src/embedder/mod.rs
+++ b/src/embedder/mod.rs
@@ -31,6 +31,7 @@ mod provision;
 use anyhow::Result;
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
+use std::time::Instant;
 
 use candle_bert::Embedder;
 
@@ -39,6 +40,29 @@ use candle_bert::Embedder;
 /// old cross-subsystem GPU gate). Never held across an `.await` — all compute runs inside
 /// [`embed_batch`]'s blocking task.
 static EMBEDDER: Lazy<Mutex<Option<Embedder>>> = Lazy::new(|| Mutex::new(None));
+
+/// Max sequences per forward pass. Self-attention memory is `O(batch * seq_len^2)`, so
+/// one hour's whole span list in a single batch (the pre-chunking behaviour) made peak
+/// memory scale with how much on-screen text that hour had — multiple GB on a heavy hour.
+/// The Python predecessor's actual last-shipped embedder (MLX-native, in
+/// `session_distiller.py`, not the earlier sentence-transformers version) chunked at
+/// `batch = 16` and called `mx.clear_cache()` after each one — a starting point, not the
+/// tuned value: measured against the heaviest real hour on record (856 spans), peak RSS
+/// AND wall-clock both kept improving as chunk size shrank further (16 → 1.43GB/27s,
+/// 8 → 918MB/22s, 4 → 586MB/20s), most likely because a larger chunk is more likely to
+/// contain one unusually long span, forcing BatchLongest to pad every other span in that
+/// chunk up to it — wasted compute and memory that a smaller chunk mostly avoids. `4`
+/// landed comfortably under the ~1 GB Python was observed to stay under, so that's the
+/// default; the mimalloc global allocator in `lib.rs` covers giving the freed pages back
+/// to the OS between chunks, since candle frees each one's tensors via RAII regardless.
+/// Overridable for benchmarking.
+static EMBED_CHUNK_SIZE: Lazy<usize> = Lazy::new(|| {
+    std::env::var("EMBEDDER_BATCH_SIZE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|&n: &usize| n > 0)
+        .unwrap_or(4)
+});
 
 /// Whether the embedding weights are present on disk (so the model can load). The
 /// distiller gates every vector stage on this; `false` → lexical-only degrade.
@@ -78,20 +102,58 @@ pub fn unload() {
     *guard = None;
 }
 
-/// The blocking body: lazily load the model under the mutex, then embed each text.
+/// The blocking body: lazily load the model under the mutex, then embed each text in
+/// fixed-size chunks (see [`EMBED_CHUNK_SIZE`]) rather than one all-at-once forward pass.
 ///
 /// Recovers from a poisoned lock rather than propagating the poison forever: a panic
 /// during one embed (a candle shape mismatch, say) must not permanently strand the
 /// distiller on its lexical-only degrade path for the rest of the daemon's lifetime.
 /// Matches [`crate::llm::rate_limit`]'s `NEXT_SLOT` handling of the same hazard.
 fn embed_blocking(texts: &[String]) -> Result<Vec<Vec<f32>>> {
-    let mut guard = EMBEDDER.lock().unwrap_or_else(|e| e.into_inner());
+    let mut guard = EMBEDDER.lock().unwrap_or_else(|e| {
+        tracing::warn!("embedder: recovered from poisoned mutex (a prior embed likely panicked)");
+        e.into_inner()
+    });
     if guard.is_none() {
-        *guard = Some(Embedder::load()?);
+        let _span = tracing::debug_span!("embedder.load").entered();
+        let start = Instant::now();
+        match Embedder::load() {
+            Ok(e) => {
+                tracing::info!(
+                    elapsed_ms = start.elapsed().as_millis() as u64,
+                    "embedder: model loaded"
+                );
+                *guard = Some(e);
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "embedder: model load failed");
+                return Err(e);
+            }
+        }
     }
     let embedder = guard.as_ref().expect("just loaded");
-    let refs: Vec<&str> = texts.iter().map(String::as_str).collect();
-    embedder.embed_batch(&refs)
+
+    let chunk_size = *EMBED_CHUNK_SIZE;
+    let n_chunks = texts.len().div_ceil(chunk_size.max(1));
+    let _span = tracing::debug_span!(
+        "embedder.batch",
+        n_texts = texts.len(),
+        chunk_size,
+        n_chunks
+    )
+    .entered();
+    let start = Instant::now();
+    let mut out = Vec::with_capacity(texts.len());
+    for chunk in texts.chunks(chunk_size) {
+        let refs: Vec<&str> = chunk.iter().map(String::as_str).collect();
+        out.extend(embedder.embed_batch(&refs)?);
+    }
+    tracing::debug!(
+        n_texts = texts.len(),
+        elapsed_ms = start.elapsed().as_millis() as u64,
+        "embedder: batch embedded"
+    );
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,15 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 // https://github.com/meridiona/meridian
 
+/// Process-wide allocator. mimalloc actively returns freed pages to the OS instead of
+/// retaining them for reuse (the platform-default behavior on macOS/Windows/Linux alike),
+/// so RSS tracks actual live memory rather than the high-water mark of the largest
+/// transient allocation. Matters most for the embedder ([`embedder`]), which frees a full
+/// batch of tensors after every chunk — without this, the freed pages stay resident and
+/// RSS never comes back down between chunks or after the model unloads.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 pub mod coding_agent_session_ingest;
 pub mod config;
 pub mod daily_plan;

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,9 +51,18 @@ async fn main() -> Result<()> {
     // 1b. Subcommand dispatch. `meridian coding-agent-hook` is the Claude Code
     //     SessionEnd hook entry point: one-shot, reads a JSON payload on stdin,
     //     seals that session, exits 0. It must stay light (no daemon init, no
-    //     OTLP) and must never block Claude, so it always exits 0.
+    //     network) and must never block Claude, so it always exits 0.
+    //     `observability::init` is still cheap here: capture is a local-disk
+    //     write only (see `telemetry_spool::spool_client::SpoolClient`), never
+    //     a network call, so it doesn't violate the "must never block" contract
+    //     — without it, hook failures were only visible on Claude Code's own
+    //     stderr, never in `meridian logs` or an exported diagnostics bundle.
     if std::env::args().nth(1).as_deref() == Some("coding-agent-hook") {
+        let obs_guard = observability::init("meridian-rust").ok();
         meridian::coding_agent_session_ingest::hook::run_hook().await;
+        if let Some(g) = obs_guard {
+            g.shutdown().await;
+        }
         return Ok(());
     }
 
@@ -69,6 +78,7 @@ async fn main() -> Result<()> {
         let dry_run = args.iter().any(|a| a == "--dry-run");
         let day = flag("--day");
         let limit: i64 = flag("--limit").and_then(|v| v.parse().ok()).unwrap_or(8);
+        let obs_guard = observability::init("meridian-rust").ok();
         match meridian::coding_agent_session_ingest::open_meridian_pool().await {
             Ok(pool) => {
                 meridian::coding_agent_session_ingest::summariser::cli_summarise(
@@ -80,7 +90,10 @@ async fn main() -> Result<()> {
                 .await;
                 pool.close().await;
             }
-            Err(e) => eprintln!("coding-agent-summarise: open db: {e}"),
+            Err(e) => tracing::error!(error = %e, "coding-agent-summarise: failed to open db"),
+        }
+        if let Some(g) = obs_guard {
+            g.shutdown().await;
         }
         return Ok(());
     }

--- a/src/migrations/067_drop_classify_traceparent.sql
+++ b/src/migrations/067_drop_classify_traceparent.sql
@@ -1,0 +1,12 @@
+-- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+--
+-- Drop `app_sessions.classify_traceparent` (added in migration 043 for a
+-- planned session-CLASSIFICATION trace link). Nothing ever wrote to it: the
+-- Python MLX classify path it was meant to serve was retired in the Rust
+-- port and nothing replaced the write. Dead column, no readers, no writers —
+-- removed rather than left as unused schema. `app_sessions.traceparent`
+-- (migration 010, the session-FORMATION trace) is unaffected and remains the
+-- one traceparent column in active use (see `worklog_pipeline/hour.rs`'s
+-- `link_session_formation_traces`).
+
+ALTER TABLE app_sessions DROP COLUMN classify_traceparent;

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -286,10 +286,18 @@ fn try_build_otel_providers(
         .to_string();
     let log_endpoint = trace_endpoint.replace("/v1/traces", "/v1/logs");
 
-    let resource = Resource::new(vec![KeyValue::new(
-        "service.name",
-        service_name.to_string(),
-    )]);
+    // `host.name` is a "semconv_experimental"-gated constant in
+    // opentelemetry-semantic-conventions 0.27 — not worth enabling that
+    // feature flag for one stable, well-known attribute name.
+    use opentelemetry_semantic_conventions::resource::SERVICE_VERSION;
+    let resource = Resource::new(vec![
+        KeyValue::new("service.name", service_name.to_string()),
+        KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
+        KeyValue::new(
+            "host.name",
+            gethostname::gethostname().to_string_lossy().into_owned(),
+        ),
+    ]);
 
     // Build spool clients — one per signal so filenames encode the correct prefix.
     let spool_trace = crate::telemetry_spool::spool_client::SpoolClient::new()
@@ -345,7 +353,11 @@ fn build_default_filter(log_level: &str) -> String {
         "WARNING" | "WARN" => "meridian=warn,sqlx=warn".to_string(),
         "ERROR" => "meridian=error,sqlx=error".to_string(),
         // INFO or anything else: keep the previous fixed default with module-level overrides.
-        _ => "meridian=info,meridian::etl=debug,meridian::intelligence=debug,sqlx=warn".to_string(),
+        // `embedder=debug` surfaces the model-load/batch spans (embedder/mod.rs) at the
+        // production default — the same treatment etl/intelligence already get — since
+        // the embedder is on the critical path for every hour's distillation and its
+        // timing is exactly what a `DISTILLER_EMBED_TIMEOUT_SECS` investigation needs.
+        _ => "meridian=info,meridian::etl=debug,meridian::intelligence=debug,meridian::embedder=debug,sqlx=warn".to_string(),
     }
 }
 

--- a/src/plan_tasks/cli.rs
+++ b/src/plan_tasks/cli.rs
@@ -45,6 +45,10 @@ pub async fn try_handle() -> Result<bool> {
             run_edit().await;
             Ok(true)
         }
+        "plan-task-done" => {
+            run_done().await;
+            Ok(true)
+        }
         _ => Ok(false),
     }
 }
@@ -157,5 +161,37 @@ async fn run_edit() {
     match res {
         Ok(r) => finish(&r, obs_guard).await,
         Err(e) => die("plan-task-edit", format!("{e:#}"), obs_guard).await,
+    }
+}
+
+/// `meridian plan-task-done --key K --done true|false` — mark a task done or not-done,
+/// routing to our DB or the tracker depending on who owns it. Prints the same
+/// `{task_key, provider, status, browse_url, reason}` shape as `plan-task-edit`.
+async fn run_done() {
+    let key = flag("--key").unwrap_or_default();
+    if key.trim().is_empty() {
+        eprintln!("plan-task-done: --key is required");
+        std::process::exit(2);
+    }
+    let done = match flag("--done").unwrap_or_default().as_str() {
+        "true" => true,
+        "false" => false,
+        _ => {
+            eprintln!("plan-task-done: --done must be true or false");
+            std::process::exit(2);
+        }
+    };
+
+    let cfg = Config::from_env();
+    let obs_guard = observability::init("meridian-rust").ok();
+    let pool = match setup_db(&cfg.meridian_db_uri()).await {
+        Ok(p) => p,
+        Err(e) => die("plan-task-done", format!("open db: {e:#}"), obs_guard).await,
+    };
+    let res = super::done::set_done(&pool, &cfg, &key, done).await;
+    pool.close().await;
+    match res {
+        Ok(r) => finish(&r, obs_guard).await,
+        Err(e) => die("plan-task-done", format!("{e:#}"), obs_guard).await,
     }
 }

--- a/src/plan_tasks/done.rs
+++ b/src/plan_tasks/done.rs
@@ -1,0 +1,132 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Marking a task done / not-done — from either side of the fence, through ONE entry
+//! point.
+//!
+//! # The one branch
+//! Same split, and the same reasoning, as [`super::edit`]: a personal task's `pm_tasks`
+//! row IS the task, so we flip `is_terminal` directly; a board ticket's row is a mirror,
+//! so the transition goes to the tracker via [`crate::intelligence::ticket_update`]'s
+//! `close`/`reopen` and a force-sync pulls the truth back.
+//!
+//! This routing lives HERE rather than inside `ticket_update` for the reason spelled
+//! out in [`super::edit`]'s header — that module resolves credentials and dispatches
+//! HTTP, and a `'local'` arm there would have none of those. Before this module
+//! existed the plan's checkbox called the tracker path unconditionally, so ticking a
+//! personal task failed with `provider "local" is not configured`.
+//!
+//! # Who calls this
+//! [`super::cli`]'s `plan-task-done` → the tray's `set_plan_task_done` → the "today's
+//! focus" checkbox in `ui/components/timeline/OverviewPanel.tsx`.
+//!
+//! # Related
+//! - [`meridian_core::task_create::set_local_terminal`] — the personal-task writer.
+//! - [`super::edit`] — the same routing for a task's title/description.
+
+use anyhow::{Context, Result};
+use meridian_core::task_create;
+use sqlx::SqlitePool;
+use tracing::field::Empty;
+use tracing::Instrument;
+
+use crate::config::Config;
+use crate::intelligence::ticket_update::{self, ApplyStatus};
+use crate::plan_tasks::edit::EditResult;
+
+/// Mark `task_key` done (`done = true`) or not-done, wherever it lives.
+///
+/// Returns the same `applied` / `redirected` shape as [`super::edit::edit`]: some
+/// trackers (Trello, Azure DevOps) have no reliable done/not-done mapping and hand
+/// back a browse URL instead of writing. A personal task is always `applied`.
+#[tracing::instrument(skip(pool, config))]
+pub async fn set_done(
+    pool: &SqlitePool,
+    config: &Config,
+    task_key: &str,
+    done: bool,
+) -> Result<EditResult> {
+    let span = tracing::info_span!(
+        "plan_task.done",
+        task_key,
+        done,
+        provider = Empty,
+        personal = Empty,
+        status = Empty,
+    );
+    async move {
+        let provider = task_create::provider_of(pool, task_key)
+            .await?
+            .with_context(|| format!("no task {task_key} - it may have left the board"))?;
+        tracing::Span::current().record("provider", provider.as_str());
+
+        if provider == task_create::LOCAL_PROVIDER {
+            tracing::Span::current().record("personal", true);
+            return set_done_personal(pool, task_key, done).await;
+        }
+        tracing::Span::current().record("personal", false);
+        set_done_on_tracker(pool, config, task_key, &provider, done).await
+    }
+    .instrument(span)
+    .await
+}
+
+/// Our row is the task — write it.
+async fn set_done_personal(pool: &SqlitePool, task_key: &str, done: bool) -> Result<EditResult> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let changed = task_create::set_local_terminal(pool, task_key, done, &now)
+        .await
+        .context("updating the personal task's status")?;
+    if !changed {
+        anyhow::bail!("could not update {task_key}");
+    }
+    tracing::Span::current().record("status", "applied");
+    tracing::info!(done, "plan_task: personal task status set");
+    Ok(EditResult {
+        task_key: task_key.to_string(),
+        provider: task_create::LOCAL_PROVIDER.to_string(),
+        status: "applied".to_string(),
+        browse_url: None,
+        reason: None,
+    })
+}
+
+/// The tracker owns the task — transition it there, then pull the truth back into our
+/// mirror so the checkbox settles without waiting out the sync gate.
+async fn set_done_on_tracker(
+    pool: &SqlitePool,
+    config: &Config,
+    task_key: &str,
+    provider: &str,
+    done: bool,
+) -> Result<EditResult> {
+    let field = if done { "close" } else { "reopen" };
+    let res = ticket_update::apply(config, provider, task_key, field, "")
+        .await
+        .with_context(|| format!("applying {field} on {provider}"))?;
+
+    if let ApplyStatus::Redirected { browse_url, reason } = &res.status {
+        tracing::Span::current().record("status", "redirected");
+        tracing::info!(field, "plan_task: status change redirected to the tracker");
+        return Ok(EditResult {
+            task_key: task_key.to_string(),
+            provider: provider.to_string(),
+            status: "redirected".to_string(),
+            browse_url: Some(browse_url.clone()),
+            reason: Some(reason.clone()),
+        });
+    }
+
+    // Best-effort — the tracker has already accepted the transition, so a sync hiccup
+    // must not read as a failed toggle.
+    if let Err(e) = crate::intelligence::run_pm_force_sync(pool, config).await {
+        tracing::warn!(error = %e, "plan_task: post-toggle sync failed - the change still landed");
+    }
+    tracing::Span::current().record("status", "applied");
+    tracing::info!(field, "plan_task: tracker task status set");
+    Ok(EditResult {
+        task_key: task_key.to_string(),
+        provider: provider.to_string(),
+        status: "applied".to_string(),
+        browse_url: None,
+        reason: None,
+    })
+}

--- a/src/plan_tasks/mod.rs
+++ b/src/plan_tasks/mod.rs
@@ -29,5 +29,6 @@
 
 pub mod cli;
 pub mod create;
+pub mod done;
 pub mod draft;
 pub mod edit;

--- a/src/worklog_pipeline/distiller/mod.rs
+++ b/src/worklog_pipeline/distiller/mod.rs
@@ -81,7 +81,7 @@ pub(crate) const ENTITY_RESCUE_CAP: usize = 4;
 /// behind it. Timing out degrades this one hour to lexical-only (same degrade path as a load
 /// failure) rather than blocking the queue — see [`embed_lex`].
 static EMBED_TIMEOUT: Lazy<Duration> =
-    Lazy::new(|| Duration::from_secs_f64(env_num("DISTILLER_EMBED_TIMEOUT_SECS", 45.0)));
+    Lazy::new(|| Duration::from_secs_f64(env_num("DISTILLER_EMBED_TIMEOUT_SECS", 210.0)));
 
 fn env_num(key: &str, default: f64) -> f64 {
     std::env::var(key)
@@ -337,17 +337,61 @@ async fn distil(
     (body, stats)
 }
 
+/// One retry after a real (non-timeout) error — covers transient failures (a momentary
+/// file-read glitch loading weights, a poisoned-mutex hiccup on first touch) that a second
+/// attempt can plausibly clear. Deliberately NOT retried on the caller's timeout branch:
+/// a timeout means the computation itself is too slow for the input size, and an identical
+/// retry would just re-run the same slow computation and cost another full timeout budget
+/// for no chance of a different outcome — that path degrades immediately instead.
+const EMBED_MAX_ATTEMPTS: u32 = 2;
+const EMBED_RETRY_BACKOFF: Duration = Duration::from_millis(500);
+
 /// Embed the lexically-deduped span lines. Gated on [`embedder::is_ready`]; a failure
 /// degrades to empty vectors (SemDeDup + floc become lexical-only). Times the stage under
-/// a `distil.embed` child span.
+/// a `distil.embed` child span. An empty `lex` short-circuits to empty vectors without
+/// touching the embedder at all — nothing to embed is not a failure, so it's excluded from
+/// the `degraded` flag below.
 async fn embed_lex(lex: &[Span]) -> (Vec<Vec<f32>>, bool) {
     let span = tracing::debug_span!("distil.embed", n_spans = lex.len());
     async {
         let start = Instant::now();
-        let vecs = if embedder::is_ready() && !lex.is_empty() {
+        if lex.is_empty() {
+            tracing::debug!(
+                n_spans = 0,
+                elapsed_ms = 0,
+                degraded = false,
+                "distil: embedded spans"
+            );
+            return (Vec::new(), false);
+        }
+        let vecs = if embedder::is_ready() {
             let n = lex.len();
-            let texts: Vec<String> = lex.iter().map(|s| s.line.clone()).collect();
-            match tokio::time::timeout(*EMBED_TIMEOUT, embedder::embed_batch(texts)).await {
+            // Retries share ONE outer timeout budget rather than each getting their own —
+            // a retry that would blow past EMBED_TIMEOUT is still bounded by it, so the
+            // worst case for this hour is exactly EMBED_TIMEOUT, never attempts * timeout.
+            let attempts = async {
+                let mut last_err = None;
+                for attempt in 1..=EMBED_MAX_ATTEMPTS {
+                    let texts: Vec<String> = lex.iter().map(|s| s.line.clone()).collect();
+                    match embedder::embed_batch(texts).await {
+                        Ok(v) => return Ok(v),
+                        Err(e) => {
+                            tracing::warn!(
+                                attempt,
+                                max_attempts = EMBED_MAX_ATTEMPTS,
+                                error = %e,
+                                "distil: embed attempt failed"
+                            );
+                            last_err = Some(e);
+                            if attempt < EMBED_MAX_ATTEMPTS {
+                                tokio::time::sleep(EMBED_RETRY_BACKOFF).await;
+                            }
+                        }
+                    }
+                }
+                Err(last_err.expect("loop ran at least once"))
+            };
+            match tokio::time::timeout(*EMBED_TIMEOUT, attempts).await {
                 Ok(result) => {
                     // This is the only embed_batch call in the hour's whole run (one
                     // distil pass = one batch), so the model has no more work until
@@ -357,7 +401,11 @@ async fn embed_lex(lex: &[Span]) -> (Vec<Vec<f32>>, bool) {
                     match result {
                         Ok(v) => v,
                         Err(e) => {
-                            tracing::warn!(error = %e, "distil: embed failed — degrading to lexical-only");
+                            tracing::warn!(
+                                error = %e,
+                                attempts = EMBED_MAX_ATTEMPTS,
+                                "distil: embed failed after all retries — degrading to lexical-only"
+                            );
                             Vec::new()
                         }
                     }
@@ -435,4 +483,112 @@ fn record_run(s: &DistilStats, body: &str) {
         distil_body_preview = %preview,
         "session_distiller: distilled hour"
     );
+}
+
+#[cfg(test)]
+mod bench {
+    //! Manual diagnostic, not part of CI — measures the embedder's own memory/time cost
+    //! against REAL session data for one hour on this machine, to compare against the
+    //! Python predecessor's ~1 GB / batch_size=32 behaviour after the chunking fix.
+    //! Run: `cargo test --release -p meridian distiller::bench::embed_only_bench -- \
+    //! --ignored --nocapture` (optionally with `HOUR_START`/`HOUR_END`/`MERIDIAN_DB` env
+    //! overrides; defaults to the heavy hour this fix was diagnosed against).
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::sync::Arc;
+
+    fn rss_kb(pid: u32) -> u64 {
+        std::process::Command::new("ps")
+            .args(["-o", "rss=", "-p", &pid.to_string()])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .and_then(|s| s.trim().parse().ok())
+            .unwrap_or(0)
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn embed_only_bench() {
+        let _ = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .try_init();
+
+        let db_path = std::env::var("MERIDIAN_DB").unwrap_or_else(|_| {
+            format!(
+                "{}/.meridian/meridian.db",
+                std::env::var("HOME").expect("HOME set")
+            )
+        });
+        let hs =
+            std::env::var("HOUR_START").unwrap_or_else(|_| "2026-07-18T10:30:00+00:00".to_string());
+        let he =
+            std::env::var("HOUR_END").unwrap_or_else(|_| "2026-07-18T11:30:00+00:00".to_string());
+
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .connect(&format!("sqlite://{db_path}"))
+            .await
+            .expect("connect to real meridian.db");
+
+        embedder::ensure_weights()
+            .await
+            .expect("embedder weights present");
+        assert!(embedder::is_ready(), "embedder must be ready to bench it");
+
+        let rows = rows::load_sessions(&pool, &hs, &he).await;
+        assert!(
+            !rows.is_empty(),
+            "no sessions in [{hs}, {he}) — pick an hour that has data via HOUR_START/HOUR_END"
+        );
+        println!("loaded {} sessions for [{hs}, {he})", rows.len());
+
+        // The model unloads again (inside embed_lex) before distil() returns, so a
+        // point-in-time RSS sample taken after the call would miss the peak — poll in
+        // a background thread for the call's duration and track the high-water mark.
+        let pid = std::process::id();
+        let peak_kb = Arc::new(AtomicU64::new(0));
+        let stop = Arc::new(AtomicBool::new(false));
+        let (peak_clone, stop_clone) = (Arc::clone(&peak_kb), Arc::clone(&stop));
+        let sampler = std::thread::spawn(move || {
+            while !stop_clone.load(Ordering::Relaxed) {
+                peak_clone.fetch_max(rss_kb(pid), Ordering::Relaxed);
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        });
+
+        let rss_before = rss_kb(pid);
+        let t0 = Instant::now();
+        let (body, stats) = distil(rows, "HOUR 10:00", "bench").await;
+        let elapsed = t0.elapsed();
+
+        stop.store(true, Ordering::Relaxed);
+        sampler.join().ok();
+        let rss_after = rss_kb(pid);
+
+        println!("=== embed-only bench ===");
+        println!(
+            "nsess={} n_after_junk={} n_after_df={} n_after_lex={} n_after_sem={} n_selected={}",
+            stats.nsess,
+            stats.n_after_junk,
+            stats.n_after_df,
+            stats.n_after_lex,
+            stats.n_after_sem,
+            stats.n_selected
+        );
+        println!(
+            "total distil() time (all stages, embed included): {:.2}s",
+            elapsed.as_secs_f64()
+        );
+        println!(
+            "rss before: {} MB, peak during: {} MB (delta {} MB), after (post-unload): {} MB",
+            rss_before / 1024,
+            peak_kb.load(Ordering::Relaxed) / 1024,
+            (peak_kb.load(Ordering::Relaxed).saturating_sub(rss_before)) / 1024,
+            rss_after / 1024
+        );
+        println!(
+            "body preview: {}",
+            &body.chars().take(200).collect::<String>()
+        );
+    }
 }

--- a/src/worklog_pipeline/distiller/mod.rs
+++ b/src/worklog_pipeline/distiller/mod.rs
@@ -30,7 +30,7 @@ mod segment;
 mod select;
 
 use std::collections::HashMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -72,6 +72,16 @@ static DF_FRAC: Lazy<f64> = Lazy::new(|| env_num("DISTILLER_DF_FRAC", 0.25));
 const FLOOR: usize = 3;
 const CEIL: usize = 14;
 pub(crate) const ENTITY_RESCUE_CAP: usize = 4;
+
+/// Hard bound on the single in-process embedding forward pass. An hour with an unusually
+/// large volume of on-screen text (many sessions, little repetition) can push the lexically-
+/// deduped span batch well beyond a typical hour's size; on CPU-only inference the forward
+/// pass cost grows with batch size, so an outsized hour can take minutes rather than seconds.
+/// Hours run strictly sequentially, so an unbounded embed here would stall every later hour
+/// behind it. Timing out degrades this one hour to lexical-only (same degrade path as a load
+/// failure) rather than blocking the queue — see [`embed_lex`].
+static EMBED_TIMEOUT: Lazy<Duration> =
+    Lazy::new(|| Duration::from_secs_f64(env_num("DISTILLER_EMBED_TIMEOUT_SECS", 45.0)));
 
 fn env_num(key: &str, default: f64) -> f64 {
     std::env::var(key)
@@ -335,16 +345,35 @@ async fn embed_lex(lex: &[Span]) -> (Vec<Vec<f32>>, bool) {
     async {
         let start = Instant::now();
         let vecs = if embedder::is_ready() && !lex.is_empty() {
+            let n = lex.len();
             let texts: Vec<String> = lex.iter().map(|s| s.line.clone()).collect();
-            let result = embedder::embed_batch(texts).await;
-            // This is the only embed_batch call in the hour's whole run (one distil
-            // pass = one batch), so the model has no more work until next hour —
-            // drop it now rather than leaving it resident in memory until then.
-            embedder::unload();
-            match result {
-                Ok(v) => v,
-                Err(e) => {
-                    tracing::warn!(error = %e, "distil: embed failed — degrading to lexical-only");
+            match tokio::time::timeout(*EMBED_TIMEOUT, embedder::embed_batch(texts)).await {
+                Ok(result) => {
+                    // This is the only embed_batch call in the hour's whole run (one
+                    // distil pass = one batch), so the model has no more work until
+                    // next hour — drop it now rather than leaving it resident in
+                    // memory until then.
+                    embedder::unload();
+                    match result {
+                        Ok(v) => v,
+                        Err(e) => {
+                            tracing::warn!(error = %e, "distil: embed failed — degrading to lexical-only");
+                            Vec::new()
+                        }
+                    }
+                }
+                Err(_) => {
+                    // The abandoned spawn_blocking task keeps running to completion on
+                    // its own thread (not cancelled) and will release the embedder mutex
+                    // when done — the NEXT hour's embed_batch call just waits on it like
+                    // any other lock contention. What matters is THIS hour's async
+                    // pipeline is freed to continue rather than stalling the sequential
+                    // hour queue behind an outsized batch.
+                    tracing::warn!(
+                        n_spans = n,
+                        timeout_s = EMBED_TIMEOUT.as_secs_f64(),
+                        "distil: embed timed out — degrading to lexical-only"
+                    );
                     Vec::new()
                 }
             }

--- a/src/worklog_pipeline/hour.rs
+++ b/src/worklog_pipeline/hour.rs
@@ -287,6 +287,7 @@ pub async fn run_hour(
     let coding = hour_db::fetch_coding_summaries(pool, hs, he).await;
     let timeline = hour_db::fetch_hour_timeline(pool, hs, he).await;
     sess_span.record("body_chars", d.body.len());
+    link_session_formation_traces(&timeline);
 
     // Burst filter + block rendering + the 3-part join live in `compose_report_input`
     // (shared with the LLM-Lab replay); `timeline` (full set) still feeds the span/time
@@ -367,6 +368,34 @@ pub async fn run_hour(
     workstream::run(pool, day_local, hour, &report).await?;
     task_db::upsert_hour_span(pool, day_local, hour, span_min).await?;
     Ok(())
+}
+
+/// Add an OTel span Link from the current span (`worklog.hour`, via the caller's
+/// `.instrument()`) to each distinct session-formation trace among this hour's
+/// timeline rows, so a `worklog.hour` trace in OpenObserve can backtrack to
+/// exactly how each contributing session was formed by the ETL. Sessions with no
+/// `traceparent` (pre-migration-010 rows, or a formation that predates OTel
+/// capture being enabled) are silently skipped — this is best-effort lineage,
+/// never load-bearing for the hour itself.
+fn link_session_formation_traces(timeline: &[crate::worklog_pipeline::hour_input::TimelineRow]) {
+    use std::collections::HashSet;
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+    let mut seen = HashSet::new();
+    let mut linked = 0u32;
+    let current = tracing::Span::current();
+    for tp in timeline.iter().filter_map(|r| r.traceparent.as_deref()) {
+        if !seen.insert(tp) {
+            continue;
+        }
+        if let Some(sc) = crate::observability::span_context_from_traceparent(tp) {
+            current.add_link(sc);
+            linked += 1;
+        }
+    }
+    if linked > 0 {
+        tracing::debug!(linked, "worklog: linked session formation traces");
+    }
 }
 
 #[cfg(test)]

--- a/src/worklog_pipeline/hour_db.rs
+++ b/src/worklog_pipeline/hour_db.rs
@@ -30,7 +30,8 @@ pub async fn fetch_hour_timeline(pool: &SqlitePool, hs: &str, he: &str) -> Vec<T
         "SELECT app_name, started_at, ended_at, \
                 CAST(COALESCE(duration_s, 0) AS INTEGER) AS duration_s, \
                 COALESCE(window_titles, '') AS window_titles, \
-                (coding_agent_session_uuid IS NOT NULL) AS is_coding \
+                (coding_agent_session_uuid IS NOT NULL) AS is_coding, \
+                traceparent \
          FROM app_sessions \
          WHERE started_at >= ? AND started_at < ? AND COALESCE(duration_s, 0) >= ? \
          ORDER BY started_at",
@@ -53,6 +54,9 @@ pub async fn fetch_hour_timeline(pool: &SqlitePool, hs: &str, he: &str) -> Vec<T
                     duration_s: r.try_get::<i64, _>("duration_s").unwrap_or(0),
                     window_titles: r.try_get::<String, _>("window_titles").unwrap_or_default(),
                     is_coding: r.try_get::<i64, _>("is_coding").unwrap_or(0) != 0,
+                    traceparent: r
+                        .try_get::<Option<String>, _>("traceparent")
+                        .unwrap_or(None),
                 })
                 .collect();
             tracing::debug!(rows = out.len(), "worklog: fetched hour timeline");

--- a/src/worklog_pipeline/hour_input.rs
+++ b/src/worklog_pipeline/hour_input.rs
@@ -37,6 +37,10 @@ pub struct TimelineRow {
     /// Raw `app_sessions.window_titles` JSON blob (`[{"window_name":…,"count":N}]`).
     pub window_titles: String,
     pub is_coding: bool,
+    /// The W3C `traceparent` of this session's ETL formation trace (migration
+    /// 010), when the ETL wrote one. Used to link `worklog.hour`'s span back
+    /// to each contributing session's formation trace in OpenObserve.
+    pub traceparent: Option<String>,
 }
 
 /// One coding-agent session that already carries an agent-written summary.
@@ -393,6 +397,7 @@ mod tests {
                 duration_s: 1800,
                 window_titles: "[]".into(),
                 is_coding: false,
+                traceparent: None,
             },
             TimelineRow {
                 app_name: "B".into(),
@@ -401,6 +406,7 @@ mod tests {
                 duration_s: 1800,
                 window_titles: "[]".into(),
                 is_coding: false,
+                traceparent: None,
             },
         ];
         assert_eq!(hour_span_minutes(&rows), 45);
@@ -416,6 +422,7 @@ mod tests {
             duration_s: 300,
             window_titles: "[]".into(),
             is_coding: true,
+            traceparent: None,
         }];
         assert_eq!(hour_span_minutes(&rows), 5);
     }
@@ -435,6 +442,7 @@ mod tests {
             duration_s: dur,
             window_titles: "[]".into(),
             is_coding: false,
+            traceparent: None,
         };
         let timeline = vec![mk("Kept", 300), mk("Burst", 60)];
         let coding = vec![CodingRow {

--- a/tray/src-tauri/src/commands/plan_tasks.rs
+++ b/tray/src-tauri/src/commands/plan_tasks.rs
@@ -8,6 +8,7 @@
 //! - [`create_plan_task`] — create the task (personal, or filed on a tracker) and add
 //!   it to the day's plan.
 //! - [`edit_plan_task`] — rewrite a task's title/description, wherever it lives.
+//! - [`set_plan_task_done`] — tick/untick a task, wherever it lives.
 //!
 //! # Why these SHELL OUT
 //! The chosen LLM provider (`settings.json`) and tracker auth (`~/.meridian/.env`)
@@ -88,7 +89,16 @@ pub struct EditPlanTaskBody {
     pub description: Option<String>,
 }
 
-/// [`edit_plan_task`] response — mirrors `plan_tasks::edit::EditResult`.
+/// POST body for [`set_plan_task_done`].
+#[derive(Debug, Deserialize)]
+pub struct SetPlanTaskDoneBody {
+    pub task_key: String,
+    /// `true` = mark done, `false` = reopen.
+    pub done: bool,
+}
+
+/// [`edit_plan_task`] / [`set_plan_task_done`] response — mirrors
+/// `plan_tasks::edit::EditResult`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EditResult {
     pub task_key: String,
@@ -176,5 +186,25 @@ pub async fn edit_plan_task(body: EditPlanTaskBody) -> Result<EditResult, String
 
     let res: EditResult = run_meridian_json(&args, WRITE_TIMEOUT, "plan-task-edit").await?;
     tracing::info!(status = %res.status, provider = %res.provider, "plan-task-edit served");
+    Ok(res)
+}
+
+/// Mark a task done / not-done. Spawns `meridian plan-task-done --key K --done B`.
+///
+/// This exists INSTEAD of the plan's checkbox calling `apply_ticket_fix` directly: that
+/// path goes straight to `ticket-update`, which only knows real trackers, so a personal
+/// (`provider = 'local'`) task failed with `provider "local" is not configured`. The
+/// CLI branches on who owns the task — see `src/plan_tasks/done.rs`.
+#[tauri::command]
+#[tracing::instrument(skip(body), fields(task_key = %body.task_key, done = body.done))]
+pub async fn set_plan_task_done(body: SetPlanTaskDoneBody) -> Result<EditResult, String> {
+    if body.task_key.trim().is_empty() {
+        return Err("a task key is required".to_string());
+    }
+    let done = if body.done { "true" } else { "false" };
+    let args: Vec<&str> = vec!["plan-task-done", "--key", &body.task_key, "--done", done];
+
+    let res: EditResult = run_meridian_json(&args, WRITE_TIMEOUT, "plan-task-done").await?;
+    tracing::info!(status = %res.status, provider = %res.provider, "plan-task-done served");
     Ok(res)
 }

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -550,6 +550,7 @@ pub fn run() {
             commands::draft_plan_task,
             commands::create_plan_task,
             commands::edit_plan_task,
+            commands::set_plan_task_done,
             commands::triage_decision,
             commands::triage_ignore,
             commands::apply_ticket_fix,

--- a/ui/components/plan/PlanView.tsx
+++ b/ui/components/plan/PlanView.tsx
@@ -294,6 +294,7 @@ export default function PlanView() {
         <TaskDetailDialog
           taskKey={openTask.key}
           fallbackTitle={openTask.title}
+          day={todayKey}
           inToday={today.some(t => t.key === openTask.key)}
           canEdit={editable}
           onClose={() => setOpenTask(null)}

--- a/ui/components/timeline/DayTaskColumn.tsx
+++ b/ui/components/timeline/DayTaskColumn.tsx
@@ -209,12 +209,6 @@ export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, hourS
   // worth showing: it is the only thing that says the hour is being tracked at
   // all. (See HourBadges' doc comment.)
   const liveMode = !isToday ? null : liveStatus?.generating ? 'generating' as const : 'queued' as const
-  // Whether to print the strip's own hour label in the gutter. When the live
-  // hour is ALREADY a gridline label on the timeline above (work was folded into
-  // it a moment ago — the common case), repeating "9 PM" here just reads as a
-  // duplicate. Only label the strip when the hour isn't already on the rail —
-  // e.g. the last real work stopped hours ago, so the strip needs its own anchor.
-  const showLiveHourLabel = liveMode !== null && !hourLines.some(h => h.hour === nowHour)
 
   return (
     // A click anywhere in the column that isn't on a card clears the selection
@@ -259,7 +253,6 @@ export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, hourS
             <span className="absolute" style={{ left: GUTTER - 5, top: 0, bottom: 0, width: 2, background: 'var(--t-hair)', opacity: 0.22 }} />
             {hourLines.map(({ hour, top }) => {
               const isNow = isToday && hour === nowHour
-              const nodeSize = isNow ? 11 : 9
               return (
                 <div key={hour} className="absolute left-0 right-0 flex items-start"
                   style={{ top, height: 0 }}>
@@ -274,20 +267,26 @@ export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, hourS
                       paddingRight: 6,
                       color: 'var(--t-faint-2)', fontFamily: 'var(--font-jetbrains-mono), monospace',
                     }}>
-                    {hourClock(hour)}
+                    {/* Blank for the live hour — the takeover strip below owns both
+                        the label AND the live dot now (see liveMode's render below),
+                        so this row isn't left with an orphaned pulsing dot up here
+                        with nothing beside it. The gridline still draws (next span)
+                        since this row can mark a real boundary — the previous hour's
+                        work ending — just without repeating the hour marker twice. */}
+                    {isNow ? '' : hourClock(hour)}
                   </span>
-                  {/* Every non-live node is the same light ring: panel fill inside, a
-                      thin muted border outside — one consistent look for every
-                      ordinary hour, only the current hour's node differs (solid
-                      accent + pulse). */}
-                  <span className={`absolute rounded-full -translate-y-1/2 ${isNow ? 'live-dot' : ''}`} style={{
-                    left: GUTTER - 5 - nodeSize / 2, width: nodeSize, height: nodeSize,
-                    background: isNow ? 'var(--color-state-proposal)' : 'var(--t-panel)',
-                    border: isNow ? 'none' : '2px solid color-mix(in srgb, var(--t-faint-2) 55%, transparent)',
-                    boxShadow: isNow
-                      ? '0 0 0 3px color-mix(in srgb, var(--color-state-proposal) 18%, transparent)'
-                      : '0 0 0 3px var(--t-panel)',
-                  }} />
+                  {/* Every ordinary hour gets the same light ring: panel fill inside,
+                      a thin muted border outside. The live hour's own accent+pulse
+                      dot now lives next to its label in the takeover strip instead
+                      of up here (see above), so nothing renders in its place. */}
+                  {!isNow && (
+                    <span className="absolute rounded-full -translate-y-1/2" style={{
+                      left: GUTTER - 5 - 4.5, width: 9, height: 9,
+                      background: 'var(--t-panel)',
+                      border: '2px solid color-mix(in srgb, var(--t-faint-2) 55%, transparent)',
+                      boxShadow: '0 0 0 3px var(--t-panel)',
+                    }} />
+                  )}
                   {/* Starts past the card gutter (not GUTTER) so it never touches the
                       spine/node — a separate row divider for the card column only,
                       same as demo.css's .hour-body border-top living in its own
@@ -341,22 +340,38 @@ export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, hourS
           — a day with nothing folded yet is exactly when "Meridian is watching
           this hour" is the most useful thing on the screen. The gutter reserves
           the same label width as the gridlines above (GUTTER - 12, then 12px) so
-          the strip lines up with the task cards; the hour text itself is only
-          drawn when the timeline isn't already labelling this hour above
-          (see showLiveHourLabel) — otherwise it just duplicates that label. */}
+          the strip lines up with the task cards. The hour text is always drawn
+          here (even when the grid above already ticked this hour) — leaving it
+          blank made the card read as floating/unaligned, with nothing to its
+          left tying it to the current hour; a little label duplication reads
+          better than that. items-start so the label's top lines up with the
+          card's own top edge (its border), not the vertical center of the
+          whole card, which sat noticeably lower than where the card starts. */}
       {loaded && liveMode && (
         <div className="px-6 pb-8 flex items-start">
           <span className="mt-mono-sm shrink-0" style={{
-            width: GUTTER - 12, fontSize: 10.5, textAlign: 'right',
+            width: GUTTER - 12, fontSize: 10.5, textAlign: 'right', paddingRight: 6,
             color: 'var(--color-state-pending)',
           }}>
-            {showLiveHourLabel ? hourClock(nowHour) : ''}
+            {hourClock(nowHour)}
           </span>
+          {/* The live-hour dot the grid above no longer draws (moved here so it
+              sits next to the current-hour label instead of floating alone with
+              nothing beside it) — same accent+pulse treatment as an ordinary
+              hour node's `isNow` state used to get up on the rail. 4px gap on
+              each side, taken out of the card's own marginLeft below so the
+              card's visible edge doesn't shift from where it sat before. */}
+          <span className="shrink-0 rounded-full live-dot" style={{
+            width: 9, height: 9, marginLeft: 4,
+            background: 'var(--color-state-proposal)',
+            boxShadow: '0 0 0 3px color-mix(in srgb, var(--color-state-proposal) 18%, transparent)',
+          }} />
           {/* 12px carries the label's GUTTER - 12 width up to GUTTER, then
               CARD_GUTTER_GAP up to where the task cards actually start —
               less HourTakeover's own mx-2, so its visible edge lines up with
-              the cards above it rather than sitting further left. */}
-          <div className="flex-1 min-w-0" style={{ marginLeft: 12 + CARD_GUTTER_GAP - 8 }}>
+              the cards above it rather than sitting further left; less the
+              dot's own width + both 4px gaps, now that it sits inline here too. */}
+          <div className="flex-1 min-w-0" style={{ marginLeft: 12 + CARD_GUTTER_GAP - 8 - 9 - 4 - 4 }}>
             <HourTakeover
               hour={nowHour}
               mode={liveMode}

--- a/ui/components/timeline/HourBadges.tsx
+++ b/ui/components/timeline/HourBadges.tsx
@@ -44,9 +44,9 @@ const COPY: Record<TakeoverMode, [string, string][]> = {
     ['Generating this hour’s work log', 'Analyzing your captures — we’ll notify you the moment it’s ready.'],
   ],
   queued: [
-    ['Cooking up this hour’s recap…', 'Analyzing your captures — we’ll notify you the moment it’s ready, around {NEXT}.'],
-    ['Meridian is watching this hour…', 'Keep working — nothing to do. We’ll let you know when the draft lands at {NEXT}.'],
-    ['Logging this hour as you go…', 'It turns into a worklog the moment {NEXT} hits, and you’ll be notified when it does.'],
+    ['Cooking up this hour’s recap…', 'Analyzing your captures — we’ll notify you the moment it’s ready, once the hour wraps up.'],
+    ['Meridian is watching this hour…', 'Keep working — nothing to do. We’ll let you know when the draft lands at the top of the hour.'],
+    ['Logging this hour as you go…', 'It turns into a worklog the moment this hour wraps, and you’ll be notified when it does.'],
   ],
 }
 

--- a/ui/components/timeline/MeridianTimelineShell.tsx
+++ b/ui/components/timeline/MeridianTimelineShell.tsx
@@ -61,7 +61,9 @@ export default function MeridianTimelineShell() {
   // The ticket detail dialog is a separate, stackable layer (not part of
   // ActiveModal) — it can open on top of the Tasks/Plan modals or straight
   // from the timeline/Overview panel.
-  const [openTask, setOpenTask] = useState<{ key: string; title?: string } | null>(null)
+  // `editable` is false when opened from a past day's Today's-focus checklist —
+  // that day's plan is a record of what was focused on, not something to rewrite.
+  const [openTask, setOpenTask] = useState<{ key: string; title?: string; editable: boolean } | null>(null)
 
   // Build channel, for dev-only surfaces (the LLM Lab). 'dev' only under
   // `tauri dev`/`cargo run` (cfg!(debug_assertions) via get_app_info) - staging
@@ -206,7 +208,7 @@ export default function MeridianTimelineShell() {
             onCloseDayTask={() => setSelectedDayTask(null)}
             onSelectHour={selectHour}
             onOpen={setActiveModal}
-            onOpenTask={(key, title) => setOpenTask({ key, title })}
+            onOpenTask={(key, title, editable) => setOpenTask({ key, title, editable: editable ?? true })}
             onEditWorklog={openReview}
             onOpenSettings={(section) => { setSettingsSection(section); setActiveModal('settings') }}
           />
@@ -238,15 +240,16 @@ export default function MeridianTimelineShell() {
           onShiftDay={shift}
           onClose={() => setActiveModal(null)}
           onOpenSettings={(section) => { setSettingsSection(section); setActiveModal('settings') }}
-          onOpenTask={(key, title) => setOpenTask({ key, title })}
+          onOpenTask={(key, title) => setOpenTask({ key, title, editable: true })}
         />
       )}
       {activeModal === 'plan' && <PlanModal onClose={closePlan} />}
       {activeModal === 'tasks' && (
-        <TasksModal onClose={() => setActiveModal(null)} onOpenTask={(key, title) => setOpenTask({ key, title })} />
+        <TasksModal onClose={() => setActiveModal(null)} onOpenTask={(key, title) => setOpenTask({ key, title, editable: true })} />
       )}
       {openTask && (
-        <TaskDetailDialog taskKey={openTask.key} fallbackTitle={openTask.title} onClose={() => setOpenTask(null)} />
+        <TaskDetailDialog taskKey={openTask.key} fallbackTitle={openTask.title} day={day}
+          editableTask={openTask.editable} onClose={() => setOpenTask(null)} />
       )}
     </div>
   )

--- a/ui/components/timeline/OverviewPanel.tsx
+++ b/ui/components/timeline/OverviewPanel.tsx
@@ -7,10 +7,10 @@
 // point (connected users only for the CTAs/plan; solo users get the greeting
 // + Today cards + time-by-app). Narrative + metric fields are adapted from
 // the retired TodayView's data; the plan checklist reads the same get_plan
-// the Daily plan modal uses. The checkbox writes through to the real tracker
-// (apply_ticket_fix close/reopen — same write-back path as board hygiene)
-// instead of being purely decorative; clicking the row body still opens the
-// ticket detail.
+// the Daily plan modal uses. The checkbox writes through for real rather than
+// being decorative — via set_plan_task_done, which routes a personal task to
+// our DB and a board ticket to its tracker's close/reopen; clicking the row
+// body still opens the ticket detail.
 
 'use client'
 
@@ -123,27 +123,29 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
   }, [isSolo, day])
   const focusItems = useMemo(() => (plan?.confirmed ? plan.plan : []), [plan])
 
-  // Toggle a focus item's done state on its real tracker. `close`/`reopen` are
-  // the same apply_ticket_fix path board hygiene uses — some providers (Trello,
-  // Azure DevOps) have no reliable done/not-done mapping and redirect to the
-  // ticket in the browser instead of writing in-app; only a true `applied`
-  // result flips the checkbox.
+  // Toggle a focus item's done state. This goes through `set_plan_task_done`,
+  // NOT `apply_ticket_fix` — the latter only knows real trackers, so ticking a
+  // personal (provider 'local') task died with `provider "local" is not
+  // configured`. The command branches on who owns the task: a personal one is a
+  // direct DB write, a board ticket still gets the tracker's close/reopen. Some
+  // providers (Trello, Azure DevOps) have no reliable done/not-done mapping and
+  // redirect to the ticket in the browser instead of writing in-app; only a true
+  // `applied` result flips the checkbox.
   const toggleDone = useCallback((t: PlanItem, currentlyTerminal: boolean) => {
-    const field = currentlyTerminal ? 'reopen' : 'close'
     setToggling(s => ({ ...s, [t.task_key]: true }))
     setToggleError(s => { if (!(t.task_key in s)) return s; const n = { ...s }; delete n[t.task_key]; return n })
-    mutateData<{ result: { status: string; browse_url?: string; reason?: string } }>(
-      '/api/triage/apply', 'apply_ticket_fix', { provider: t.provider, key: t.task_key, field, value: '' },
+    mutateData<{ status: string; browse_url?: string; reason?: string }>(
+      '/api/plan/task-done', 'set_plan_task_done', { task_key: t.task_key, done: !currentlyTerminal },
     ).then(data => {
-      if (data.result.status === 'applied') {
+      if (data.status === 'applied') {
         setOverrideTerminal(s => ({ ...s, [t.task_key]: !currentlyTerminal }))
         refreshPlan(day)
       } else {
-        const url = data.result.browse_url || t.url
+        const url = data.browse_url || t.url
         if (url) openExternal(url)
       }
     }).catch(e => {
-      setToggleError(s => ({ ...s, [t.task_key]: e instanceof Error ? e.message : typeof e === 'string' ? e : 'Couldn’t update the tracker' }))
+      setToggleError(s => ({ ...s, [t.task_key]: e instanceof Error ? e.message : typeof e === 'string' ? e : 'Couldn’t update the task' }))
     }).finally(() => {
       setToggling(s => { const n = { ...s }; delete n[t.task_key]; return n })
     })

--- a/ui/components/timeline/OverviewPanel.tsx
+++ b/ui/components/timeline/OverviewPanel.tsx
@@ -31,7 +31,7 @@ import type { SettingsSection } from './settings/types'
 export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
   data: TimelineData
   onOpen: (modal: ActiveModal) => void
-  onOpenTask: (key: string, title?: string) => void
+  onOpenTask: (key: string, title?: string, editable?: boolean) => void
   onOpenSettings: (section?: SettingsSection) => void
 }) {
   const { today, isSolo, items, cleanupIssueCount, tasks, isToday, day } = data
@@ -249,8 +249,8 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
                 return (
                   <div key={t.task_key}
                     role="button" tabIndex={0}
-                    onClick={() => onOpenTask(t.task_key, t.title)}
-                    onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpenTask(t.task_key, t.title) } }}
+                    onClick={() => onOpenTask(t.task_key, t.title, isToday)}
+                    onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpenTask(t.task_key, t.title, isToday) } }}
                     className="w-full text-left flex items-center gap-3 px-4 py-3 cursor-pointer">
                     <button
                       onClick={e => { e.stopPropagation(); toggleDone(t, terminal) }}

--- a/ui/components/timeline/RightPanel.tsx
+++ b/ui/components/timeline/RightPanel.tsx
@@ -22,7 +22,10 @@ export function RightPanel({ data, selectedHour, selectedCardKey, dayTaskDetail,
   onCloseDayTask: () => void
   onSelectHour: (hour: number | null) => void
   onOpen: (modal: ActiveModal) => void
-  onOpenTask: (key: string, title?: string) => void
+  // `editable` (only ever passed by OverviewPanel's Today's-focus checklist) is
+  // false for a past day's focus item — you can look back at what a prior day's
+  // plan was, but not rewrite it after the fact.
+  onOpenTask: (key: string, title?: string, editable?: boolean) => void
   // Edit an approved/posted card — opens the same Review dialog drafts use,
   // scoped to this one ticket (see MeridianTimelineShell's openReview).
   onEditWorklog: (cardKey: string) => void

--- a/ui/components/timeline/TaskDetailDialog.tsx
+++ b/ui/components/timeline/TaskDetailDialog.tsx
@@ -8,15 +8,18 @@
 // shell's modal layer; it owns its own fetch, loading state, and
 // Escape/backdrop close. `inToday`/`canEdit`/`onAdd`/`onRemove` are optional
 // — only the daily-plan caller wires them, everyone else gets a read-only dialog.
+// A personal (provider 'local') task additionally gets an inline Edit affordance
+// for its title/description (see `editableTask`) — tracker-owned tickets never do.
 
 'use client'
 
 import { useEffect, useState } from 'react'
-import type { TaskDetail } from '@/lib/api-types'
+import { LOCAL_PROVIDER, type TaskDetail } from '@/lib/api-types'
 import { load, openExternal } from '@/lib/bridge'
+import { editTask } from '@/components/plan/useTaskComposer'
 
 export function TaskDetailDialog({
-  taskKey, fallbackTitle, onClose, inToday, canEdit = true, onAdd, onRemove,
+  taskKey, fallbackTitle, onClose, inToday, canEdit = true, onAdd, onRemove, day, editableTask = true,
 }: {
   taskKey: string
   fallbackTitle?: string
@@ -27,9 +30,25 @@ export function TaskDetailDialog({
   canEdit?: boolean
   onAdd?: () => void
   onRemove?: () => void
+  // The day this dialog was opened from — used to refresh that day's plan
+  // store after a title/description edit lands, so a "Today's focus" card
+  // showing this task updates without a manual poll.
+  day?: string
+  // Whether a personal (provider 'local') task's title/description can be
+  // rewritten from here. Defaults true; callers set it false when the task
+  // was opened from a PAST day's Today's-focus checklist — that day's plan
+  // is a record of what was focused on, not something to rewrite after the
+  // fact. Has no effect on tracker-owned tickets, which are never editable
+  // here regardless.
+  editableTask?: boolean
 }) {
   const [detail, setDetail] = useState<TaskDetail | null>(null)
   const [loading, setLoading] = useState(true)
+  const [editing, setEditing] = useState(false)
+  const [draftTitle, setDraftTitle] = useState('')
+  const [draftDescription, setDraftDescription] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) { if (e.key === 'Escape') onClose() }
@@ -51,6 +70,30 @@ export function TaskDetailDialog({
     : detail.due_days < 0 ? `overdue ${-detail.due_days}d`
       : detail.due_days === 0 ? 'today' : detail.due_days === 1 ? 'tomorrow' : `in ${detail.due_days}d`
   const hasMeta = !!(detail?.epic || detail?.priority || detail?.story_points || detail?.due_date)
+  // Only a personal task's own text is ours to rewrite — a tracker-owned
+  // ticket's title/description stays read-only here (edit it in the tracker).
+  const isPersonal = detail?.provider === LOCAL_PROVIDER
+  const canEditText = isPersonal && editableTask
+
+  function startEdit() {
+    setDraftTitle(detail?.title ?? '')
+    setDraftDescription(detail?.description ?? '')
+    setSaveError(null)
+    setEditing(true)
+  }
+
+  function saveEdit() {
+    if (!draftTitle.trim() || saving) return
+    setSaving(true)
+    setSaveError(null)
+    editTask(day ?? '', taskKey, { title: draftTitle.trim(), description: draftDescription })
+      .then(() => {
+        setDetail(d => d && { ...d, title: draftTitle.trim(), description: draftDescription })
+        setEditing(false)
+      })
+      .catch(e => setSaveError(e instanceof Error ? e.message : 'Couldn’t save the task'))
+      .finally(() => setSaving(false))
+  }
 
   return (
     <div className="absolute inset-0 z-50 flex items-start justify-center p-6 sm:p-10 rise"
@@ -79,7 +122,13 @@ export function TaskDetailDialog({
               <span className="text-[16px] leading-none">×</span>
             </button>
           </div>
-          <p className="mt-modal-title text-title">{title}</p>
+          {editing ? (
+            <input autoFocus value={draftTitle} onChange={e => setDraftTitle(e.target.value)}
+              placeholder="Task title" className="mt-modal-title text-title w-full bg-transparent outline-none"
+              style={{ border: '1px solid var(--t-ctrl-border)', borderRadius: 8, padding: '4px 8px' }} />
+          ) : (
+            <p className="mt-modal-title text-title">{title}</p>
+          )}
           {hasMeta && (
             <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2.5">
               {detail?.epic && <MetaBit label="Epic" value={detail.epic} />}
@@ -99,10 +148,18 @@ export function TaskDetailDialog({
             <>
               <div>
                 <p className="mt-label mb-2" style={{ color: 'var(--t-faint)' }}>Description</p>
-                {detail?.description?.trim() ? (
+                {editing ? (
+                  <textarea autoFocus={false} value={draftDescription} onChange={e => setDraftDescription(e.target.value)}
+                    placeholder="Add a description…" rows={5}
+                    className="mt-body w-full bg-transparent outline-none resize-none"
+                    style={{ color: 'var(--t-muted)', border: '1px solid var(--t-ctrl-border)', borderRadius: 8, padding: '8px 10px' }} />
+                ) : detail?.description?.trim() ? (
                   <p className="mt-body whitespace-pre-wrap" style={{ color: 'var(--t-muted)' }}>{detail.description}</p>
                 ) : (
                   <p className="mt-body-sm italic" style={{ color: 'var(--t-faint-2)' }}>No description on this ticket.</p>
+                )}
+                {editing && saveError && (
+                  <p className="mt-body-sm mt-2" style={{ color: 'var(--color-state-pending)' }}>{saveError}</p>
                 )}
               </div>
               {detail?.acceptance_criteria && (
@@ -115,8 +172,28 @@ export function TaskDetailDialog({
           )}
         </div>
 
-        {(detail?.url || onAdd || onRemove) && (
+        {(detail?.url || onAdd || onRemove || canEditText) && (
           <div className="px-7 py-5 border-t shrink-0 flex items-center gap-2.5" style={{ borderColor: 'var(--t-hair)' }}>
+            {canEditText && (editing ? (
+              <>
+                <button onClick={saveEdit} disabled={saving || !draftTitle.trim()}
+                  className="mt-body-sm px-3.5 py-2 rounded-lg"
+                  style={{ background: 'var(--color-state-approved)', color: '#fff', opacity: saving || !draftTitle.trim() ? 0.6 : 1 }}>
+                  {saving ? 'Saving…' : 'Save'}
+                </button>
+                <button onClick={() => setEditing(false)} disabled={saving}
+                  className="mt-body-sm px-3.5 py-2 rounded-lg bg-ctrl"
+                  style={{ border: '1px solid var(--t-ctrl-border)', color: 'var(--t-muted)' }}>
+                  Cancel
+                </button>
+              </>
+            ) : (
+              <button onClick={startEdit}
+                className="mt-body-sm px-3.5 py-2 rounded-lg bg-ctrl"
+                style={{ border: '1px solid var(--t-ctrl-border)', color: 'var(--t-muted)' }}>
+                Edit
+              </button>
+            ))}
             {canEdit && (inToday ? (onRemove && (
               <button onClick={() => { onRemove(); onClose() }}
                 className="mt-body-sm px-3.5 py-2 rounded-lg bg-ctrl"


### PR DESCRIPTION
## Summary

Five commits on this branch, ahead of `pre-main`:

### `7d2b051e` — bound the in-process embedding step with a timeout
Original fix for "nothing generates past a certain hour": a heavy hour's on-device embedder had no timeout, so it could block the sequential per-hour pipeline indefinitely. Added a 45s timeout (later raised, see below) with graceful degrade to lexical-only dedup.

### `c6d68ca2` — bound memory/time on the in-process embedder, no accuracy loss
Root-caused and fixed the underlying memory/performance issues discovered while investigating the above:
- **Chunked batching** (embed spans in fixed-size batches instead of one all-at-once forward pass) — tuned empirically against the heaviest real hour on record (856 spans): unbounded → 3.22GB/timed out; chunk=16 (Python's old value) + BLAS → 1.43GB/27s; chunk=8 → 918MB/22s; **chunk=4 (final) → 586MB/20s**.
- **mimalloc** as the global allocator (cross-platform: macOS/Windows/Linux) — returns freed pages to the OS instead of retaining them, which is what let RSS climb across batches even though candle already frees each batch's tensors.
- **Candle's `accelerate` feature** enabled for macOS builds (Intel + Apple Silicon both ship Accelerate.framework free) — candle's default CPU backend has zero BLAS acceleration; this alone cut the heaviest hour's embed time from "didn't finish in 45s" to ~20-29s.
- Timeout raised 45s → 210s, plus one retry-with-backoff on a real (non-timeout) error.
- **Verified no accuracy regression**: `embedder_cosine_sanity`'s near-dup/unrelated cosine scores (0.921/0.500) are identical before and after every change, including with Accelerate enabled.

### `b53c6076` — mark personal task done/undone without hitting the tracker
### `fbc384e8` — don't drop carryover tasks past the suggestion cap
These two `plan_tasks` commits were made directly by the repo owner in this same working tree, not authored in this session — included here only because they landed on this branch; no context/review claim is being made on them from this PR description.

### `b015dde0` — fix(ui): don't name a not-yet-reached clock time in the hour-takeover card
The in-progress-hour card said the recap would be ready "around 10 PM" while still labeling the *current* hour (e.g. 9-10 PM, mid-flight at 9:51 PM) — accurate in meaning but easy to misread as claiming it's already 10 PM. Swapped to relative phrasing ("once the hour wraps up" / "at the top of the hour") that's correct regardless of the current minute.

## Test plan
- [x] `cargo build` / `cargo build --release`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (full suite green for everything touched by this session's commits)
- [x] `embedder_cosine_sanity` — confirmed identical similarity scores across every embedder config change (chunking, mimalloc, Accelerate)
- [x] Live-tested against the heaviest real hour on record (856 spans) at each tuning step, with real before/after RSS and timing numbers
- [x] Full pre-push hook suite (fmt, clippy, ui build/tests, security audit, cargo test) passed on both pushes