### PR TITLE
feat(notifications): harden delivery and close coverage gaps

### DIFF
--- a/NOTIFICATIONS.md
+++ b/NOTIFICATIONS.md
@@ -190,13 +190,31 @@ registered`, `outbox toast delivered`, `notification action event: {...}`,
 | event_key | category | buttons | consumer arm |
 |---|---|---|---|
 | `plan.nudge` | `plan_nudge` | Open Plan · Snooze 1h | snooze → re-enqueue +1h |
-| `worklog.ready` | `worklog_ready` | Open Worklogs · Snooze 1h | snooze → re-enqueue +1h |
+| `worklog.ready` | `worklog_ready` | Open Worklogs · Snooze 1h | snooze → re-enqueue +1h — **registered but no producer fires it yet** (needs its own scoping: worklog generation is currently on-demand/user-clicked, not scheduled) |
 | `system.fault` | `system_fault` | View | — (stamp only) |
+| `system.pause` | `system_fault` | View | — (stamp only) — pause/resume, folded off the `sys::notify` bypass |
+| `system.health` | `system_fault` | View | — (stamp only) — daemon went-quiet/back-online, folded off the bypass |
+| `system.update` | `system_fault`\* | View\* | — (stamp only) — update check/download/failure, folded off the bypass. \*Discrete one-shot events (not raise/clear state), so these go through `notifications::enqueue` directly rather than `notices::raise_typed` — see `tray/src-tauri/src/update.rs::notify_update` |
+| `system.notif_permission` | `system_fault` | View | — (stamp only) — macOS notification permission revoked; the one notice guaranteed to reach the user via the dashboard banner even when toasts themselves are broken |
+| `system.capture_permission` | `system_fault` | View | — (stamp only) — Accessibility/Screen Recording revoked mid-session |
+| `system.disk_low` | `system_fault` | View | — (stamp only) — `~/.meridian`'s volume below 2 GB free |
+| `pm_worklog.{provider}` | `system_fault` | View | — (stamp only) — a worklog post to the tracker failed permanently |
+| `summariser.dead_letter` | `generic_link` | Open | — (stamp only) — daily digest of permanently-failed coding-agent summarisation, `dedup_key` scoped per day |
+| `board.hygiene` | `generic_link` | Open | — (stamp only) — daily digest of tickets needing attention, `dedup_key` scoped per day |
 | *(reserved)* | `verify_switch` | Yes · No · Reply… | — (PR 2: task-switch verification) |
 | *(generic)* | `generic_link` | Open | — (stamp only) |
+
+`system.notif_permission` / `system.capture_permission` / `system.disk_low`
+are deliberately ungated by a per-type settings toggle (`type_enabled`
+defaults unknown keys to allowed) — a user shouldn't be able to silence the
+one alert explaining why everything else went quiet. Every other new event_key
+above has a `notify_<type>` toggle in `RuntimeSettings` /
+`NotificationsSection.tsx`.
 
 Deferred (same rails, thin slices when needed): task-switch verify producer +
 rate cap + `notify_task_verify` toggle (PR 2), goal check-in / distraction
 producers, LLM-generated copy (routed through the chosen CLI provider, `src/llm/`), APNs/phone
-delivery, folding the direct `sys::notify` bypass callers (pause/update/health
-toasts) into the outbox.
+delivery, a `worklog.ready` producer (needs a decision: build a real scheduler
+for unattended draft generation, or repoint the event at something already
+autonomous), an onboarding-stuck reminder (needs a resumable
+wizard-progress timestamp — today's `~/.meridian/onboarded` flag is one-shot).

--- a/meridian-core/src/notifications/mod.rs
+++ b/meridian-core/src/notifications/mod.rs
@@ -119,6 +119,15 @@ fn type_enabled(event_key: &str, s: &RuntimeSettings) -> bool {
         "plan.nudge" => s.notify_plan_nudge,
         "worklog.ready" => s.notify_worklog_ready,
         "system.fault" => s.notify_system_fault,
+        "system.pause" => s.notify_system_pause,
+        "system.health" => s.notify_system_health,
+        "system.update" => s.notify_system_update,
+        "summariser.dead_letter" => s.notify_summariser_digest,
+        "board.hygiene" => s.notify_board_hygiene,
+        // Safety-critical: notification/capture-permission revoked and low disk
+        // space stay ungated by a per-type toggle (unknown keys default
+        // enabled) — a user shouldn't be able to silence the one alert that
+        // explains why everything else went quiet.
         _ => true,
     }
 }

--- a/meridian-core/src/settings.rs
+++ b/meridian-core/src/settings.rs
@@ -249,6 +249,16 @@ pub struct RuntimeSettings {
     pub auto_open_plan: bool,
     pub notify_worklog_ready: bool,
     pub notify_system_fault: bool,
+    // Folded from direct tray-side toasts (pause/resume, daemon health,
+    // updates) into the outbox — each now has its own toggle instead of
+    // sharing `notify_system_fault` or being ungated entirely.
+    pub notify_system_pause: bool,
+    pub notify_system_health: bool,
+    pub notify_system_update: bool,
+    // Daily batched digests — see src/coding_agent_session_ingest and
+    // src/intelligence::triage_after_sync.
+    pub notify_summariser_digest: bool,
+    pub notify_board_hygiene: bool,
     pub quiet_hours_enabled: bool,
     pub quiet_hours_start: String,
     pub quiet_hours_end: String,
@@ -309,6 +319,11 @@ impl Default for RuntimeSettings {
             auto_open_plan: true,
             notify_worklog_ready: true,
             notify_system_fault: true,
+            notify_system_pause: true,
+            notify_system_health: true,
+            notify_system_update: true,
+            notify_summariser_digest: true,
+            notify_board_hygiene: true,
             quiet_hours_enabled: false,
             quiet_hours_start: "22:00".to_string(),
             quiet_hours_end: "08:00".to_string(),

--- a/src/coding_agent_session_ingest/summariser/db.rs
+++ b/src/coding_agent_session_ingest/summariser/db.rs
@@ -188,6 +188,24 @@ pub async fn write_dead_letter(pool: &SqlitePool, row_id: i64) -> Result<()> {
     Ok(())
 }
 
+/// Count sessions dead-lettered "today" for the digest notice
+/// ([`super::maybe_notify_dead_letters`]). Scoped by `ended_at` (the session's
+/// own end time, not the moment it was dead-lettered — there's no separate
+/// dead-letter timestamp column, so a row dead-lettered on a later day than it
+/// ended can undercount on the day it actually happened; accepted drift rather
+/// than adding a migration for one notice).
+pub async fn count_dead_lettered_since(pool: &SqlitePool, since_utc: &str) -> Result<i64> {
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM app_sessions WHERE task_method = ? AND ended_at >= ?",
+    )
+    .bind(TASK_METHOD_DEAD_LETTER)
+    .bind(since_utc)
+    .fetch_one(pool)
+    .await
+    .context("count dead-lettered sessions")?;
+    Ok(count)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -686,6 +686,41 @@ pub async fn cli_summarise(pool: &SqlitePool, dry_run: bool, day: Option<&str>, 
     }
 }
 
+/// Daily digest: if any coding-agent sessions were permanently dead-lettered
+/// today (see [`db::write_dead_letter`]), enqueue one batched notification
+/// rather than a toast per row — matches [`crate::daily_plan::maybe_nudge`]'s
+/// once-per-day dedup shape (`dedup_key` scoped to today), so calling this
+/// unconditionally every ETL tick is safe: the outbox's UNIQUE constraint on
+/// `dedup_key` makes a repeat call within the same day a no-op.
+///
+/// # Who calls this
+/// The daemon's poll-tick loop (`src/main.rs`), alongside `daily_plan::maybe_nudge`.
+pub async fn maybe_notify_dead_letters(pool: &SqlitePool) -> anyhow::Result<()> {
+    let today = meridian_core::date::today_string();
+    let (since_utc, _) = meridian_core::date::local_day_bounds(&today);
+    let count = db::count_dead_lettered_since(pool, &since_utc).await?;
+    if count == 0 {
+        return Ok(());
+    }
+    let dedup = format!("summariser.dead_letter:{today}");
+    let body = format!(
+        "{count} coding session{} couldn't be summarised. Check that your coding-agent CLIs are signed in.",
+        if count == 1 { "" } else { "s" }
+    );
+    crate::notifications::enqueue(
+        pool,
+        crate::notifications::NewNotification::event(
+            &dedup,
+            "summariser.dead_letter",
+            "Some coding sessions weren't summarised",
+            &body,
+        )
+        .link("/settings"),
+    )
+    .await?;
+    Ok(())
+}
+
 // ──────────────────────── Tests ─────────────────────────────────────────────
 
 #[cfg(test)]

--- a/src/health/platform.rs
+++ b/src/health/platform.rs
@@ -202,11 +202,27 @@ fn node_check() -> Check {
     }
 }
 
+/// GB free space below which `~/.meridian`'s volume counts as "low" — shared
+/// by [`disk_check`] (the `meridian doctor` sweep) and [`meridian_data_low_gb`]
+/// (the daemon's background poll check).
+const DISK_LOW_THRESHOLD_GB: f64 = 2.0;
+
 fn disk_check(name: &'static str, path: &Path) -> Check {
     match disk_free_gb(path) {
-        Some(gb) if gb < 2.0 => Check::warn(name, "system", format!("{gb:.1} GB free — low"))
-            .with_remedy("free disk space"),
+        Some(gb) if gb < DISK_LOW_THRESHOLD_GB => {
+            Check::warn(name, "system", format!("{gb:.1} GB free — low"))
+                .with_remedy("free disk space")
+        }
         Some(gb) => Check::ok(name, "system", format!("{gb:.0} GB free")),
         None => Check::info(name, "system", "usage unknown"),
     }
+}
+
+/// Free space in GB on `~/.meridian`'s volume when it has dropped below
+/// [`DISK_LOW_THRESHOLD_GB`], `None` otherwise (including "couldn't read it" —
+/// fail open, don't alarm on a transient `df` failure). Used by the daemon's
+/// background poll tick to raise/clear a `system.disk_low` notice; the
+/// on-demand `meridian doctor` sweep uses [`disk_check`] directly instead.
+pub fn meridian_data_low_gb() -> Option<f64> {
+    disk_free_gb(&home().join(".meridian")).filter(|gb| *gb < DISK_LOW_THRESHOLD_GB)
 }

--- a/src/intelligence/mod.rs
+++ b/src/intelligence/mod.rs
@@ -124,14 +124,47 @@ pub async fn run_pm_sync(meridian: &SqlitePool, config: &Config) -> Result<()> {
 /// log and move on.
 async fn triage_after_sync(meridian: &SqlitePool) {
     match task_triage::run_triage(meridian, chrono::Utc::now()).await {
-        Ok(s) => tracing::debug!(
-            ready = s.ready,
-            needs_detail = s.needs_detail,
-            looks_stale = s.looks_stale,
-            not_sure = s.not_sure,
-            pruned = s.pruned,
-            "board triaged"
-        ),
+        Ok(s) => {
+            tracing::debug!(
+                ready = s.ready,
+                needs_detail = s.needs_detail,
+                looks_stale = s.looks_stale,
+                not_sure = s.not_sure,
+                pruned = s.pruned,
+                "board triaged"
+            );
+            maybe_notify_board_hygiene(meridian, &s).await;
+        }
         Err(e) => tracing::warn!(error = %e, "board triage after sync failed"),
+    }
+}
+
+/// Daily digest: if the board has tickets needing attention (not `Ready`),
+/// enqueue one batched notification rather than nudging on every sync tick —
+/// same once-per-day dedup shape as [`crate::daily_plan::maybe_nudge`]. Safe
+/// to call unconditionally on every `triage_after_sync` pass (potentially
+/// several times a day): the outbox's UNIQUE constraint on `dedup_key` makes
+/// a repeat call within the same day a no-op, so no extra gate is needed.
+async fn maybe_notify_board_hygiene(pool: &SqlitePool, s: &task_triage::TriageSummary) {
+    let attention = s.needs_detail + s.looks_stale + s.not_sure;
+    if attention == 0 {
+        return;
+    }
+    let today = meridian_core::date::today_string();
+    let dedup = format!("board.hygiene:{today}");
+    let body = format!(
+        "{attention} ticket{} on your board need{} a closer look.",
+        if attention == 1 { "" } else { "s" },
+        if attention == 1 { "s" } else { "" }
+    );
+    let n = crate::notifications::NewNotification::event(
+        &dedup,
+        "board.hygiene",
+        "Board hygiene",
+        &body,
+    )
+    .link("/tasks?integrations=1");
+    if let Err(e) = crate::notifications::enqueue(pool, n).await {
+        tracing::warn!(error = %e, "board hygiene digest enqueue failed");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1145,6 +1145,46 @@ async fn main() -> Result<()> {
                     tracing::debug!(error = %e, "plan nudge check skipped");
                 }
 
+                // Coding-agent summariser dead-letter digest — idempotent per day.
+                if let Err(e) =
+                    meridian::coding_agent_session_ingest::summariser::maybe_notify_dead_letters(
+                        &meridian,
+                    )
+                    .await
+                {
+                    tracing::debug!(error = %e, "summariser dead-letter digest check skipped");
+                }
+
+                // Disk space on ~/.meridian's volume — raise/clear every tick,
+                // same idempotent pattern as etl.failed above.
+                match meridian::health::platform::meridian_data_low_gb() {
+                    Some(gb) => {
+                        let _ = meridian::notices::raise_typed(
+                            &meridian,
+                            meridian::notices::Notice {
+                                id: "system.disk_low",
+                                severity: "warning",
+                                title: "Disk space is low",
+                                detail: &format!(
+                                    "Only {gb:.1} GB free — Meridian's database may stop writing."
+                                ),
+                                remedy: Some("Free up disk space to keep tracking running."),
+                                event_key: "system.disk_low",
+                                deep_link: None,
+                            },
+                        )
+                        .await;
+                    }
+                    None => {
+                        let _ = meridian::notices::clear_typed(
+                            &meridian,
+                            "system.disk_low",
+                            "system.disk_low",
+                        )
+                        .await;
+                    }
+                }
+
                 // Interactive-notification responses — act on the user's answers
                 // (snooze re-enqueues an hour out). Idempotent end-to-end, so the
                 // same cadence as the nudge above is safe.

--- a/src/notices.rs
+++ b/src/notices.rs
@@ -13,7 +13,9 @@ use anyhow::{Context, Result};
 use sqlx::SqlitePool;
 
 /// Raise (or refresh) a named notice. Idempotent — upserts so repeated calls
-/// from the poll loop don't accumulate duplicate rows.
+/// from the poll loop don't accumulate duplicate rows. The paired toast is
+/// always stamped `system.fault` — use [`raise_typed`] when the caller needs
+/// its own per-type settings toggle instead of sharing `notify_system_fault`.
 pub async fn raise(
     pool: &SqlitePool,
     id: &str,
@@ -22,6 +24,47 @@ pub async fn raise(
     detail: &str,
     remedy: Option<&str>,
 ) -> Result<()> {
+    let link = if id.starts_with("pm.") {
+        Some("/tasks?integrations=1")
+    } else {
+        Some("/logs")
+    };
+    raise_typed(
+        pool,
+        Notice {
+            id,
+            severity,
+            title,
+            detail,
+            remedy,
+            event_key: "system.fault",
+            deep_link: link,
+        },
+    )
+    .await
+}
+
+/// A notice to raise via [`raise_typed`] — grouped into a struct so callers
+/// read clearly and to stay under clippy's argument limit (see `BlockBounds`
+/// in `src/etl/runner.rs` for the same convention elsewhere in this repo).
+pub struct Notice<'a> {
+    pub id: &'a str,
+    /// `info` | `warning` | `error`.
+    pub severity: &'a str,
+    pub title: &'a str,
+    pub detail: &'a str,
+    pub remedy: Option<&'a str>,
+    /// The paired toast's event_key — its own `notify_<type>` settings toggle,
+    /// instead of the shared `system.fault` bucket [`raise`] uses.
+    pub event_key: &'a str,
+    pub deep_link: Option<&'a str>,
+}
+
+/// Raise (or refresh) a named notice whose paired toast is stamped with
+/// `n.event_key` instead of the shared `system.fault` bucket [`raise`] uses.
+/// Same upsert/idempotency semantics as `raise`; pair with [`clear_typed`]
+/// using the same `event_key` so the retract dedup key matches the enqueue.
+pub async fn raise_typed(pool: &SqlitePool, n: Notice<'_>) -> Result<()> {
     sqlx::query(
         "INSERT INTO system_notices (notice_id, severity, title, detail, remedy)
          VALUES (?, ?, ?, ?, ?)
@@ -32,41 +75,43 @@ pub async fn raise(
            remedy    = excluded.remedy,
            raised_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')",
     )
-    .bind(id)
-    .bind(severity)
-    .bind(title)
-    .bind(detail)
-    .bind(remedy)
+    .bind(n.id)
+    .bind(n.severity)
+    .bind(n.title)
+    .bind(n.detail)
+    .bind(n.remedy)
     .execute(pool)
     .await
     .context("raising system notice")?;
 
     // Promote the fault to an OS-level toast (the dashboard banner already comes
     // from this table, so the notification is native-only to avoid a double
-    // banner). Deduped on the notice id → one toast per fault, cleared below when
-    // the fault recovers so a later re-occurrence toasts again. Best-effort:
+    // banner). Deduped on `<event_key>:<id>` → one toast per fault, cleared below
+    // when the fault recovers so a later re-occurrence toasts again. Best-effort:
     // never let notification delivery break the fault-bus write.
-    let dedup = format!("system.fault:{id}");
-    let link = if id.starts_with("pm.") {
-        Some("/tasks?integrations=1")
-    } else {
-        Some("/logs")
-    };
+    let dedup = format!("{}:{}", n.event_key, n.id);
     // Native-only (the dashboard banner already comes from this table).
     // `.interactive()` pairs category + actions from the one source of truth, so
     // the [View] button set can't drift from the other producers.
     use meridian_core::notifications::categories;
-    let mut n = crate::notifications::NewNotification::event(&dedup, "system.fault", title, detail)
-        .via(crate::notifications::CHANNEL_NATIVE)
-        .interactive(categories::SYSTEM_FAULT);
-    n.severity = severity;
-    n.deep_link = link;
-    let _ = crate::notifications::enqueue(pool, n).await;
+    let mut note =
+        crate::notifications::NewNotification::event(&dedup, n.event_key, n.title, n.detail)
+            .via(crate::notifications::CHANNEL_NATIVE)
+            .interactive(categories::SYSTEM_FAULT);
+    note.severity = n.severity;
+    note.deep_link = n.deep_link;
+    let _ = crate::notifications::enqueue(pool, note).await;
     Ok(())
 }
 
-/// Clear a notice — called when the daemon recovers from a fault.
+/// Clear a notice raised via [`raise`] — called when the daemon recovers from
+/// a fault.
 pub async fn clear(pool: &SqlitePool, id: &str) -> Result<()> {
+    clear_typed(pool, id, "system.fault").await
+}
+
+/// Clear a notice raised via [`raise_typed`] with the matching `event_key`.
+pub async fn clear_typed(pool: &SqlitePool, id: &str, event_key: &str) -> Result<()> {
     sqlx::query("DELETE FROM system_notices WHERE notice_id = ?")
         .bind(id)
         .execute(pool)
@@ -74,6 +119,6 @@ pub async fn clear(pool: &SqlitePool, id: &str) -> Result<()> {
         .context("clearing system notice")?;
     // Retract the paired toast so a future re-occurrence of this fault notifies
     // again instead of being deduped away.
-    let _ = crate::notifications::retract(pool, &format!("system.fault:{id}")).await;
+    let _ = crate::notifications::retract(pool, &format!("{event_key}:{id}")).await;
     Ok(())
 }

--- a/src/pm_worklog/post.rs
+++ b/src/pm_worklog/post.rs
@@ -69,7 +69,14 @@ pub async fn post_approved(
 
     for w in approved {
         match post_one(pool, config, cfg, &w).await {
-            Ok(true) => summary.posted += 1,
+            Ok(true) => {
+                summary.posted += 1;
+                // Clear any standing "posts to this provider are failing"
+                // notice — this row made it through, so whatever tripped a
+                // prior permanent failure for this provider is no longer
+                // universally true.
+                let _ = crate::notices::clear(pool, &format!("pm_worklog.{}", w.provider)).await;
+            }
             Ok(false) => {} // ineligible/skipped — already recorded
             Err(e) if is_permanent_provider_error(&e) => {
                 // A retry can never succeed (e.g. Jira's hard per-issue
@@ -84,6 +91,21 @@ pub async fn post_approved(
                 db::fail_worklog(pool, w.id, &format!("{e:#}"))
                     .await
                     .context("marking worklog failed permanently")?;
+                // Terminal failures are the only ones that notify — a
+                // transient retry-next-sweep error (below) would otherwise
+                // spam a toast every 60s.
+                let _ = crate::notices::raise(
+                    pool,
+                    &format!("pm_worklog.{}", w.provider),
+                    "warning",
+                    "Worklog post failed",
+                    &format!("{e:#}"),
+                    Some(&format!(
+                        "Check your {} connection in Settings.",
+                        w.provider
+                    )),
+                )
+                .await;
             }
             Err(e) => {
                 summary.failed += 1;

--- a/tray/src-tauri/src/commands/daemon.rs
+++ b/tray/src-tauri/src/commands/daemon.rs
@@ -11,13 +11,16 @@
 //! `SettingsView.tsx` during a reload via `ui/lib/bridge.ts::load`.
 //!
 //! # Related
-//! - [`crate::sys`] — shared `uid_str` (launchctl domain) + `notify` (toast).
-//! - [`crate::poll::notifications_allowed`] — quiet-hours gate for the toggle toast.
+//! - [`crate::sys`] — shared `uid_str` (launchctl domain).
+//! - [`meridian::notices`] — the fault-bus the toggle notice routes through (id
+//!   `tray.daemon_paused`, event_key `system.pause`, same toggle as
+//!   [`crate::commands::pause`]'s capture-pause notice).
 //! - [`crate::commands::pause`] — `pause_for_duration`/`pause_indefinitely`, split
 //!   out of this module (CLAUDE.md's 500-line file cap).
 
 use crate::state::{AppState, StatusPayload};
 use crate::sys;
+use meridian_core::SqlitePool;
 use serde::Serialize;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -52,11 +55,17 @@ pub async fn restart_daemon() -> Result<(), String> {
     }
 }
 
-/// Pause (`stop`) or resume (`start`) the daemon. On success, fires a toast
-/// honoring the user's notification prefs (master switch + quiet hours), the
-/// same policy the outbox notifications follow.
+/// Pause (`stop`) or resume (`start`) the daemon. On success, raises/clears a
+/// `tray.daemon_paused` notice — same `system.pause` event_key (and
+/// `notify_system_pause` toggle) as [`crate::commands::pause`]'s capture-pause
+/// notice, so quiet-hours/master-switch/per-type policy applies identically.
 #[tauri::command]
-pub async fn toggle_daemon(app: tauri::AppHandle, is_running: bool) -> Result<(), String> {
+pub async fn toggle_daemon(
+    _app: tauri::AppHandle,
+    is_running: bool,
+    db_pool: State<'_, Option<SqlitePool>>,
+) -> Result<(), String> {
+    let pool = db_pool.inner().clone();
     let uid = sys::uid_str();
     let service = format!("gui/{}/com.meridiona.daemon", uid);
 
@@ -72,13 +81,27 @@ pub async fn toggle_daemon(app: tauri::AppHandle, is_running: bool) -> Result<()
     .map_err(|e| format!("launchctl failed: {}", e))?;
 
     if status.success() {
-        let (title, body) = if is_running {
-            ("Paused", "Meridian is paused. Click to resume.")
-        } else {
-            ("Resumed", "Meridian is back tracking.")
-        };
-        if crate::poll::notifications_allowed("system.pause").await {
-            sys::notify(&app, title, body);
+        if let Some(p) = pool.as_ref() {
+            let result = if is_running {
+                meridian::notices::raise_typed(
+                    p,
+                    meridian::notices::Notice {
+                        id: "tray.daemon_paused",
+                        severity: "info",
+                        title: "Paused",
+                        detail: "Meridian is paused. Click to resume.",
+                        remedy: None,
+                        event_key: "system.pause",
+                        deep_link: None,
+                    },
+                )
+                .await
+            } else {
+                meridian::notices::clear_typed(p, "tray.daemon_paused", "system.pause").await
+            };
+            if let Err(e) = result {
+                tracing::warn!(error = %e, is_running, "daemon toggle notice write failed");
+            }
         }
         Ok(())
     } else {

--- a/tray/src-tauri/src/commands/pause.rs
+++ b/tray/src-tauri/src/commands/pause.rs
@@ -18,10 +18,11 @@
 //! - [`crate::commands::daemon`] — daemon lifecycle/status; the sibling module
 //!   this was split from.
 //! - [`crate::state::PauseSource`] — the pause-kind enum these commands set.
-//! - [`crate::poll::notifications_allowed`] — quiet-hours gate for the pause toast.
+//! - [`meridian::notices`] — the fault-bus the pause/resume notice routes through
+//!   (id `tray.paused`, event_key `system.pause`); quiet-hours/master-switch/the
+//!   `notify_system_pause` toggle are all enforced there, not by these commands.
 
 use crate::state::{AppState, PauseSource};
-use crate::sys;
 use chrono::{DateTime, SecondsFormat, Utc};
 use meridian_core::SqlitePool;
 use std::sync::atomic::Ordering;
@@ -141,9 +142,24 @@ pub async fn pause_for_duration(
 
     tracing::info!(seconds, until, "capture paused for duration");
 
-    if crate::poll::notifications_allowed("system.pause").await {
-        let label = pause_label(seconds);
-        sys::notify(&app, "Tracking paused", &format!("Paused for {}.", label));
+    if let Some(p) = pool.as_ref() {
+        let detail = format!("Paused for {}.", pause_label(seconds));
+        if let Err(e) = meridian::notices::raise_typed(
+            p,
+            meridian::notices::Notice {
+                id: "tray.paused",
+                severity: "info",
+                title: "Tracking paused",
+                detail: &detail,
+                remedy: None,
+                event_key: "system.pause",
+                deep_link: None,
+            },
+        )
+        .await
+        {
+            tracing::warn!(error = %e, "pause notice raise failed");
+        }
     }
 
     // Spawn the auto-resume task. Checks `pause_until` on wake to detect early
@@ -197,8 +213,23 @@ pub async fn pause_indefinitely(
 
     tracing::info!("capture paused indefinitely");
 
-    if crate::poll::notifications_allowed("system.pause").await {
-        sys::notify(&app, "Tracking paused", "Paused until you resume.");
+    if let Some(p) = pool.as_ref() {
+        if let Err(e) = meridian::notices::raise_typed(
+            p,
+            meridian::notices::Notice {
+                id: "tray.paused",
+                severity: "info",
+                title: "Tracking paused",
+                detail: "Paused until you resume.",
+                remedy: None,
+                event_key: "system.pause",
+                deep_link: None,
+            },
+        )
+        .await
+        {
+            tracing::warn!(error = %e, "pause notice raise failed");
+        }
     }
 
     Ok(())
@@ -293,8 +324,29 @@ pub(crate) async fn resume_capture(
     }
 
     tracing::info!(auto, "capture resumed");
-    if !auto && crate::poll::notifications_allowed("system.pause").await {
-        sys::notify(app, "Resumed", "Meridian is back tracking.");
+    if let Some(p) = pool {
+        // The pause condition is over either way — clear the "you're paused"
+        // notice/banner regardless of who resumed it.
+        if let Err(e) = meridian::notices::clear_typed(p, "tray.paused", "system.pause").await {
+            tracing::warn!(error = %e, "pause notice clear failed");
+        }
+        // The "Resumed" confirmation is a discrete one-shot event, not a
+        // state to clear later — only for a manual resume (matches the prior
+        // behavior of staying silent on auto-resume, e.g. after a schedule
+        // window or an expired timed pause, to avoid over-notifying).
+        if !auto {
+            let dedup = format!("system.pause:resumed:{}", now_secs());
+            let n = meridian::notifications::NewNotification::event(
+                &dedup,
+                "system.pause",
+                "Resumed",
+                "Meridian is back tracking.",
+            )
+            .via(meridian::notifications::CHANNEL_NATIVE);
+            if let Err(e) = meridian::notifications::enqueue(p, n).await {
+                tracing::warn!(error = %e, "resume notification enqueue failed");
+            }
+        }
     }
 }
 

--- a/tray/src-tauri/src/commands/setup.rs
+++ b/tray/src-tauri/src/commands/setup.rs
@@ -48,23 +48,7 @@ pub async fn mark_setup_complete() -> Result<(), String> {
 #[tauri::command]
 #[tracing::instrument]
 pub async fn check_accessibility() -> bool {
-    #[cfg(target_os = "macos")]
-    return ax_is_trusted();
-    #[cfg(not(target_os = "macos"))]
-    false
-}
-
-#[cfg(target_os = "macos")]
-fn ax_is_trusted() -> bool {
-    // ApplicationServices.framework is a system framework present on all macOS
-    // versions; no additional Cargo dep required.
-    #[link(name = "ApplicationServices", kind = "framework")]
-    #[allow(improper_ctypes)]
-    extern "C" {
-        fn AXIsProcessTrusted() -> bool;
-    }
-    // Safety: AXIsProcessTrusted is a pure status read with no side effects or UB.
-    unsafe { AXIsProcessTrusted() }
+    crate::sys::accessibility_trusted()
 }
 
 /// Returns `true` when the tray itself holds macOS Screen Recording permission.
@@ -78,17 +62,7 @@ fn ax_is_trusted() -> bool {
 #[tauri::command]
 #[tracing::instrument]
 pub async fn check_screen_recording() -> bool {
-    #[cfg(target_os = "macos")]
-    {
-        #[link(name = "CoreGraphics", kind = "framework")]
-        extern "C" {
-            fn CGPreflightScreenCaptureAccess() -> bool;
-        }
-        // Safety: preflight is a pure status read — no prompt, no side effects.
-        unsafe { CGPreflightScreenCaptureAccess() }
-    }
-    #[cfg(not(target_os = "macos"))]
-    false
+    crate::sys::screen_recording_trusted()
 }
 
 /// Surface the macOS Screen Recording prompt **and register the app** so it
@@ -154,15 +128,9 @@ fn notification_state_label(state: tauri_plugin_notifications::PermissionState) 
 #[tauri::command]
 #[tracing::instrument(skip(app))]
 pub async fn check_notifications(app: tauri::AppHandle) -> String {
-    let Some(nf) = crate::sys::notifier(&app) else {
-        return "unavailable".into();
-    };
-    match nf.permission_state().await {
-        Ok(state) => notification_state_label(state).into(),
-        Err(e) => {
-            tracing::warn!(error = %e, "setup: notification permission probe failed");
-            "unavailable".into()
-        }
+    match crate::sys::notification_permission_state(&app).await {
+        Some(state) => notification_state_label(state).into(),
+        None => "unavailable".into(),
     }
 }
 

--- a/tray/src-tauri/src/poll/mod.rs
+++ b/tray/src-tauri/src/poll/mod.rs
@@ -8,8 +8,8 @@
 //!
 //! - [`refresh`] — the per-tick fetch-and-store functions (also emits
 //!   `health-update`, the ported `/api/health/stream`).
-//! - [`notifications`] — outbox drain + the quiet-hours policy check
-//!   ([`notifications_allowed`], re-exported here for [`crate::commands::daemon`]).
+//! - [`notifications`] — the daemon's outbox drain (own policy check happens
+//!   server-side per row).
 //! - [`live`] — the live data → Tauri events that replace the dashboard's SSE
 //!   streams: `notices-update`, `notifications-update`.
 //!
@@ -17,11 +17,10 @@
 
 mod live;
 mod notifications;
+mod permissions;
 mod plan_auto_open;
 mod refresh;
 mod whats_new_auto_open;
-
-pub(crate) use notifications::notifications_allowed;
 
 use crate::state::{AppState, HealthStatus, PauseSource};
 use chrono::{Datelike, Local, Timelike};
@@ -59,7 +58,7 @@ pub async fn run_poll_loop(app: tauri::AppHandle, state: Arc<Mutex<AppState>>) {
             .and_then(|s| s.inner().clone());
 
         if do_health {
-            refresh_health(&app, &state).await;
+            refresh_health(&app, &state, pool.as_ref()).await;
         }
         if let Some(pool) = &pool {
             refresh_active(pool, &state).await;
@@ -79,6 +78,9 @@ pub async fn run_poll_loop(app: tauri::AppHandle, state: Arc<Mutex<AppState>>) {
             }
             if do_worklogs {
                 refresh_worklogs(pool, &state).await;
+            }
+            if do_health {
+                permissions::check_permissions(&app, pool).await;
             }
         }
         // Work-hours schedule enforcement: auto-pause capture outside the

--- a/tray/src-tauri/src/poll/notifications.rs
+++ b/tray/src-tauri/src/poll/notifications.rs
@@ -10,9 +10,12 @@
 //! delivery ack is now a direct `meridian.db` write too — the loop is HTTP-free.
 //!
 //! # Related
-//! - [`super::refresh::refresh_health`] — gates its toasts via [`notifications_allowed`].
-//! - [`crate::commands::daemon::toggle_daemon`] — same gate for the pause/resume toast.
 //! - [`meridian_core::notifications::mark_native_delivered`] — the delivery ack.
+//! - [`meridian::notices`] — every tray-originated toast (pause/resume, daemon
+//!   health, updates, permission/disk checks) now routes through this fault
+//!   bus rather than a direct bypass toast, so it gets the same
+//!   master-switch/per-type/quiet-hours policy this module's outbox drain
+//!   already applies to daemon-originated notifications.
 
 use crate::sys::{notify_outbox, retract_toast};
 use tauri::Manager;
@@ -66,15 +69,4 @@ pub(super) async fn drain_notifications(app: &tauri::AppHandle) {
         }
         retract_toast(app, id);
     }
-}
-
-/// Whether a notification for `event_key` may fire right now — master switch +
-/// per-type toggle + quiet hours, computed directly from `settings.json` (ported
-/// `/api/notifications/allowed`, no HTTP). Fails open when settings are
-/// missing/corrupt (`load_runtime_settings` → defaults, notifications on) so an
-/// operational alert (e.g. "went quiet") is never lost to a policy-read failure.
-pub(crate) async fn notifications_allowed(event_key: &str) -> bool {
-    let s = meridian_core::settings::load_runtime_settings();
-    meridian_core::notifications::event_allowed(event_key, &s)
-        && !meridian_core::notifications::in_quiet_hours(&s)
 }

--- a/tray/src-tauri/src/poll/permissions.rs
+++ b/tray/src-tauri/src/poll/permissions.rs
@@ -1,0 +1,105 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Periodic re-checks of the macOS permissions the notification system and
+//! capture pipeline depend on.
+//!
+//! Each of these is checked exactly once during onboarding
+//! ([`crate::commands::setup`]) and never again — if the user revokes one
+//! afterward (System Settings, or a macOS reset), the app degrades silently:
+//! capture starts producing thin/no frames, or every native toast just stops
+//! firing with nothing to say why. This module closes that gap by raising a
+//! `system_notices` row per permission on loss, cleared on restore. The
+//! dashboard banner this produces is the resilient path by construction — it
+//! reads `system_notices` independent of the toast channel, so it's the one
+//! notice guaranteed to reach the user even when the thing it's reporting is
+//! "toasts are broken."
+//!
+//! # Related
+//! - [`crate::sys::notification_permission_state`] / [`crate::sys::accessibility_trusted`] /
+//!   [`crate::sys::screen_recording_trusted`] — the shared probes, also used by the setup wizard.
+//! - [`crate::commands::setup`] — the one-shot onboarding checks this periodically re-runs.
+//! - [`meridian::notices`] — the fault-bus this writes into.
+
+use meridian_core::SqlitePool;
+
+/// Re-check notification, accessibility, and screen-recording permission and
+/// raise/clear the matching `system_notices` row for each. Runs on the same
+/// cadence as [`super::refresh::refresh_health`] (every 2nd tick, ~60s) — a
+/// TCC read is cheap, no need for the full 30s tick. Skipped entirely in
+/// unbundled runs (`tauri dev`): the notification plugin never registers
+/// there and TCC prompts behave differently outside a signed `.app`, so
+/// there's nothing meaningful to police.
+#[tracing::instrument(skip(app, pool))]
+pub(super) async fn check_permissions(app: &tauri::AppHandle, pool: &SqlitePool) {
+    if !crate::sys::is_bundled() {
+        return;
+    }
+    check_notification_permission(app, pool).await;
+    check_bool_permission(
+        pool,
+        "tray.accessibility_revoked",
+        "system.capture_permission",
+        "Accessibility access is off",
+        "Meridian can't see window and app activity without it, so tracking has effectively stopped.",
+        crate::sys::accessibility_trusted(),
+    )
+    .await;
+    check_bool_permission(
+        pool,
+        "tray.screen_recording_revoked",
+        "system.capture_permission",
+        "Screen Recording access is off",
+        "Meridian can't read on-screen text without it, so tracking has effectively stopped.",
+        crate::sys::screen_recording_trusted(),
+    )
+    .await;
+}
+
+async fn check_notification_permission(app: &tauri::AppHandle, pool: &SqlitePool) {
+    let denied = matches!(
+        crate::sys::notification_permission_state(app).await,
+        Some(tauri_plugin_notifications::PermissionState::Denied)
+    );
+    check_bool_permission(
+        pool,
+        "tray.notifications_denied",
+        "system.notif_permission",
+        "Notifications are off",
+        "Meridian can't show reminders or alerts without them.",
+        !denied,
+    )
+    .await;
+}
+
+/// Raise `id` when `granted` is false, clear it when true. Idempotent either
+/// way — [`meridian::notices::raise_typed`]/[`meridian::notices::clear_typed`]
+/// upsert/delete, so a steady-state tick that finds nothing changed is a cheap
+/// no-op (same pattern as the daemon's own `etl.failed`/`pm.*` checks).
+async fn check_bool_permission(
+    pool: &SqlitePool,
+    id: &str,
+    event_key: &str,
+    title: &str,
+    detail: &str,
+    granted: bool,
+) {
+    let result = if granted {
+        meridian::notices::clear_typed(pool, id, event_key).await
+    } else {
+        meridian::notices::raise_typed(
+            pool,
+            meridian::notices::Notice {
+                id,
+                severity: "warning",
+                title,
+                detail,
+                remedy: Some("Open System Settings \u{2192} Privacy & Security to re-grant it."),
+                event_key,
+                deep_link: Some("/settings"),
+            },
+        )
+        .await
+    };
+    if let Err(e) = result {
+        tracing::warn!(error = %e, id, "permission notice write failed");
+    }
+}

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -8,19 +8,23 @@
 //!
 //! # Related
 //! - [`super`] — the loop that schedules these and the tray-sync that follows.
-//! - [`super::notifications_allowed`] — the quiet-hours gate `refresh_health` consults.
+//! - [`meridian::notices`] — the fault-bus `refresh_health` raises/clears
+//!   `tray.daemon_quiet` through (event_key `system.health`).
 //! - [`crate::commands::health::check_health`] — the direct health check.
 
 use crate::commands::health::check_health;
 use crate::state::{ActiveSession, AppState, HealthStatus, TodayBreakdown};
-use crate::sys::notify;
 use meridian_core::SqlitePool;
 use std::sync::{Arc, Mutex};
 use tauri::Emitter;
 
-/// Run the local health check, fold it into [`AppState`], and fire the
-/// went-quiet / back-online toasts (debounced to the 2nd consecutive failure).
-pub(super) async fn refresh_health(app: &tauri::AppHandle, state: &Arc<Mutex<AppState>>) {
+/// Run the local health check, fold it into [`AppState`], and raise/clear the
+/// went-quiet / back-online notice (debounced to the 2nd consecutive failure).
+pub(super) async fn refresh_health(
+    app: &tauri::AppHandle,
+    state: &Arc<Mutex<AppState>>,
+    pool: Option<&SqlitePool>,
+) {
     let hr = check_health().await;
 
     // Push the health detail to the dashboard webview (the ported
@@ -66,10 +70,46 @@ pub(super) async fn refresh_health(app: &tauri::AppHandle, state: &Arc<Mutex<App
         (notify_down, notify_back)
     };
 
-    if notify_down && super::notifications_allowed("system.health").await {
-        notify(app, "Meridian went quiet.", "Tap to check what happened.");
-    } else if notify_back && super::notifications_allowed("system.health").await {
-        notify(app, "Back online.", "Picking up where you left off.");
+    let Some(pool) = pool else { return };
+    if notify_down {
+        if let Err(e) = meridian::notices::raise_typed(
+            pool,
+            meridian::notices::Notice {
+                id: "tray.daemon_quiet",
+                severity: "warning",
+                title: "Meridian went quiet.",
+                detail: "Tap to check what happened.",
+                remedy: None,
+                event_key: "system.health",
+                deep_link: Some("/logs"),
+            },
+        )
+        .await
+        {
+            tracing::warn!(error = %e, "daemon-health notice raise failed");
+        }
+    } else if notify_back {
+        if let Err(e) =
+            meridian::notices::clear_typed(pool, "tray.daemon_quiet", "system.health").await
+        {
+            tracing::warn!(error = %e, "daemon-health notice clear failed");
+        }
+        // "Back online" is a discrete confirmation, not a state to leave
+        // sitting as a banner once the fault it answers is already cleared.
+        let dedup = format!(
+            "system.health:back_online:{}",
+            chrono::Utc::now().timestamp()
+        );
+        let n = meridian::notifications::NewNotification::event(
+            &dedup,
+            "system.health",
+            "Back online.",
+            "Picking up where you left off.",
+        )
+        .via(meridian::notifications::CHANNEL_NATIVE);
+        if let Err(e) = meridian::notifications::enqueue(pool, n).await {
+            tracing::warn!(error = %e, "back-online notification enqueue failed");
+        }
     }
 }
 

--- a/tray/src-tauri/src/sys.rs
+++ b/tray/src-tauri/src/sys.rs
@@ -163,6 +163,62 @@ pub fn retract_toast(app: &tauri::AppHandle, id: i64) {
     }
 }
 
+/// Current macOS notification authorization, shared by the setup wizard's
+/// probe ([`crate::commands::setup::check_notifications`]) and the background
+/// re-check ([`crate::poll::permissions`]) so the two never drift. `None`
+/// covers both "plugin absent" (unbundled run) and a probe error — callers
+/// that need to distinguish those log separately; both mean "can't toast".
+pub async fn notification_permission_state(
+    app: &tauri::AppHandle,
+) -> Option<tauri_plugin_notifications::PermissionState> {
+    let nf = notifier(app)?;
+    match nf.permission_state().await {
+        Ok(state) => Some(state),
+        Err(e) => {
+            tracing::warn!(error = %e, "notification permission probe failed");
+            None
+        }
+    }
+}
+
+/// Whether the tray process holds macOS Accessibility trust
+/// (`AXIsProcessTrusted`) — a pure status read, no prompt. Shared by the setup
+/// wizard's probe ([`crate::commands::setup::check_accessibility`]) and the
+/// background re-check ([`crate::poll::permissions`]).
+pub fn accessibility_trusted() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        #[link(name = "ApplicationServices", kind = "framework")]
+        #[allow(improper_ctypes)]
+        extern "C" {
+            fn AXIsProcessTrusted() -> bool;
+        }
+        // Safety: AXIsProcessTrusted is a pure status read with no side effects or UB.
+        unsafe { AXIsProcessTrusted() }
+    }
+    #[cfg(not(target_os = "macos"))]
+    false
+}
+
+/// Whether the tray process holds macOS Screen Recording permission
+/// (`CGPreflightScreenCaptureAccess`) — a pure status read, no prompt. Shared
+/// by the setup wizard's probe
+/// ([`crate::commands::setup::check_screen_recording`]) and the background
+/// re-check ([`crate::poll::permissions`]).
+pub fn screen_recording_trusted() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        #[link(name = "CoreGraphics", kind = "framework")]
+        extern "C" {
+            fn CGPreflightScreenCaptureAccess() -> bool;
+        }
+        // Safety: preflight is a pure status read — no prompt, no side effects.
+        unsafe { CGPreflightScreenCaptureAccess() }
+    }
+    #[cfg(not(target_os = "macos"))]
+    false
+}
+
 /// Register the fixed interactive-category set (`meridian_core`'s
 /// [`meridian_core::notifications::categories`]) with the OS. Called once at
 /// startup from `lib.rs` on bundled runs; a failure downgrades every

--- a/tray/src-tauri/src/tray.rs
+++ b/tray/src-tauri/src/tray.rs
@@ -146,7 +146,9 @@ fn toggle_from_menu(app: &tauri::AppHandle) {
         drop(state_guard);
         let app_for_notify = app.clone();
         tauri::async_runtime::spawn(async move {
-            let _ = crate::commands::toggle_daemon(app_for_notify, is_running).await;
+            let db_pool = app_for_notify.state::<Option<meridian_core::SqlitePool>>();
+            let _ =
+                crate::commands::toggle_daemon(app_for_notify.clone(), is_running, db_pool).await;
         });
     }
 }

--- a/tray/src-tauri/src/update.rs
+++ b/tray/src-tauri/src/update.rs
@@ -30,16 +30,48 @@
 //!   running — broken update paths, data-corrupting bugs).
 //!
 //! # Related
-//! - [`crate::sys::notify`] — the toast the tray-menu path surfaces through.
+//! - [`notify_update`] — routes every tray-menu toast through the outbox
+//!   (event_key `system.update`) instead of a direct bypass, so quiet-hours,
+//!   the master switch, and the `notify_system_update` toggle all apply —
+//!   previously these six call sites skipped that policy entirely.
 //! - `scripts/package-updater.sh` — the producer of the `Minimum-Version:` notes
 //!   line (reads the optional `tray/minimum-version` file at release time).
 //! - Plan: Obsidian `Decisions/Public distribution + auto-update for the DMG`.
 
+use meridian_core::SqlitePool;
 use semver::Version;
 use serde::Serialize;
 use std::sync::atomic::{AtomicBool, Ordering};
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_updater::UpdaterExt;
+
+/// Enqueue a discrete update-related toast through the outbox instead of the
+/// direct `sys::notify` bypass. Each of these six call sites represents a
+/// one-shot event (a check outcome, a download starting), not an ongoing
+/// condition to raise/clear like [`meridian::notices`] models — so this goes
+/// straight to [`meridian::notifications::enqueue`], gated by `system.update`
+/// (master switch + quiet hours + the `notify_system_update` toggle) the same
+/// way every other outbox producer is. `dedup_suffix` only needs to be unique
+/// per call (the current timestamp is fine — these are user-triggered or
+/// rare background events, never a tight loop that would spam distinct keys).
+async fn notify_update(app: &AppHandle, dedup_suffix: &str, title: &str, body: &str) {
+    let Some(pool) = app
+        .try_state::<Option<SqlitePool>>()
+        .and_then(|s| s.inner().clone())
+    else {
+        tracing::debug!(title, "notify_update: DB not open yet — toast dropped");
+        return;
+    };
+    let dedup = format!(
+        "system.update:{dedup_suffix}:{}",
+        chrono::Utc::now().timestamp_millis()
+    );
+    let n = meridian::notifications::NewNotification::event(&dedup, "system.update", title, body)
+        .via(meridian::notifications::CHANNEL_NATIVE);
+    if let Err(e) = meridian::notifications::enqueue(&pool, n).await {
+        tracing::warn!(error = %e, title, "update notification enqueue failed");
+    }
+}
 
 /// Guards the tray-menu path against re-entry (a second click mid-download).
 static CHECKING: AtomicBool = AtomicBool::new(false);
@@ -272,11 +304,13 @@ pub fn enforce_minimum_version(app: &AppHandle) {
                 minimum = status.minimum_version.as_deref().unwrap_or(""),
                 "update: running version is below the minimum supported - forcing install"
             );
-            crate::sys::notify(
+            notify_update(
                 &app,
+                "mandatory",
                 "Updating Meridian",
                 &format!("This version is no longer supported - installing v{v}"),
-            );
+            )
+            .await;
             if let Err(e) = download_and_apply(&app).await {
                 tracing::warn!(error = %e, "update: forced install failed - retrying next cycle");
             }
@@ -299,28 +333,48 @@ pub fn check_for_updates(app: &AppHandle) {
         match status.state.as_str() {
             "available" => {
                 let v = status.version.clone().unwrap_or_default();
-                crate::sys::notify(&app, "Updating Meridian", &format!("Downloading v{v}…"));
+                notify_update(
+                    &app,
+                    "downloading",
+                    "Updating Meridian",
+                    &format!("Downloading v{v}…"),
+                )
+                .await;
                 if let Err(e) = download_and_apply(&app).await {
                     tracing::warn!(error = %e, "update: install failed");
-                    crate::sys::notify(&app, "Update failed", "The update couldn't be installed.");
+                    notify_update(
+                        &app,
+                        "failed",
+                        "Update failed",
+                        "The update couldn't be installed.",
+                    )
+                    .await;
                 }
             }
-            "uptodate" => crate::sys::notify(
-                &app,
-                "Meridian is up to date",
-                "You're on the latest version.",
-            ),
-            "unsupported" => crate::sys::notify(
-                &app,
-                "Updates via npm",
-                "This build updates with `meridian update`.",
-            ),
+            "uptodate" => {
+                notify_update(
+                    &app,
+                    "uptodate",
+                    "Meridian is up to date",
+                    "You're on the latest version.",
+                )
+                .await;
+            }
+            "unsupported" => {
+                notify_update(
+                    &app,
+                    "unsupported",
+                    "Updates via npm",
+                    "This build updates with `meridian update`.",
+                )
+                .await;
+            }
             _ => {
                 let msg = status
                     .error
                     .as_deref()
                     .unwrap_or("Couldn't reach the update server.");
-                crate::sys::notify(&app, "Update check failed", msg);
+                notify_update(&app, "check_failed", "Update check failed", msg).await;
             }
         }
         CHECKING.store(false, Ordering::SeqCst);

--- a/ui/components/timeline/settings/NotificationsSection.tsx
+++ b/ui/components/timeline/settings/NotificationsSection.tsx
@@ -51,6 +51,21 @@ export function NotificationsSection({ settings, patch, save }: {
             <FieldRow label="System faults" description="When a tracker sync or the classifier stack fails (also shown as a banner).">
               <Switch checked={settings.notify_system_fault} onCheckedChange={v => patch({ notify_system_fault: v })} />
             </FieldRow>
+            <FieldRow label="Pause / resume" description="When tracking is paused or resumes, manually or on a schedule.">
+              <Switch checked={settings.notify_system_pause} onCheckedChange={v => patch({ notify_system_pause: v })} />
+            </FieldRow>
+            <FieldRow label="Daemon health" description="When Meridian's background daemon goes quiet or comes back online.">
+              <Switch checked={settings.notify_system_health} onCheckedChange={v => patch({ notify_system_health: v })} />
+            </FieldRow>
+            <FieldRow label="Updates" description="When a new version is available, installing, or fails to install.">
+              <Switch checked={settings.notify_system_update} onCheckedChange={v => patch({ notify_system_update: v })} />
+            </FieldRow>
+            <FieldRow label="Summarisation issues" description="A daily digest if any coding-agent sessions couldn't be summarised.">
+              <Switch checked={settings.notify_summariser_digest} onCheckedChange={v => patch({ notify_summariser_digest: v })} />
+            </FieldRow>
+            <FieldRow label="Board hygiene" description="A daily digest if tickets on your board need attention.">
+              <Switch checked={settings.notify_board_hygiene} onCheckedChange={v => patch({ notify_board_hygiene: v })} />
+            </FieldRow>
             <FieldRow label="Quiet hours" description="Hold back desktop toasts during this window (banners still appear). Wraps past midnight.">
               <Switch checked={settings.quiet_hours_enabled} onCheckedChange={v => patch({ quiet_hours_enabled: v })} />
             </FieldRow>
@@ -71,6 +86,11 @@ export function NotificationsSection({ settings, patch, save }: {
             notify_plan_nudge: settings.notify_plan_nudge,
             notify_worklog_ready: settings.notify_worklog_ready,
             notify_system_fault: settings.notify_system_fault,
+            notify_system_pause: settings.notify_system_pause,
+            notify_system_health: settings.notify_system_health,
+            notify_system_update: settings.notify_system_update,
+            notify_summariser_digest: settings.notify_summariser_digest,
+            notify_board_hygiene: settings.notify_board_hygiene,
             quiet_hours_enabled: settings.quiet_hours_enabled,
             quiet_hours_start: settings.quiet_hours_start,
             quiet_hours_end: settings.quiet_hours_end,

--- a/ui/lib/settings.ts
+++ b/ui/lib/settings.ts
@@ -45,6 +45,14 @@ export interface RuntimeSettings {
   auto_open_plan: boolean
   notify_worklog_ready: boolean
   notify_system_fault: boolean
+  // Folded from direct tray-side toasts (pause/resume, daemon health,
+  // updates) into the outbox — each has its own toggle.
+  notify_system_pause: boolean
+  notify_system_health: boolean
+  notify_system_update: boolean
+  // Daily batched digests.
+  notify_summariser_digest: boolean
+  notify_board_hygiene: boolean
   quiet_hours_enabled: boolean
   quiet_hours_start: string // 'HH:MM' local time, inclusive
   quiet_hours_end: string   // 'HH:MM' local time, exclusive
@@ -82,6 +90,11 @@ export const SETTINGS_DEFAULTS: RuntimeSettings = {
   auto_open_plan: true,
   notify_worklog_ready: true,
   notify_system_fault: true,
+  notify_system_pause: true,
+  notify_system_health: true,
+  notify_system_update: true,
+  notify_summariser_digest: true,
+  notify_board_hygiene: true,
   quiet_hours_enabled: false,
   quiet_hours_start: '22:00',
   quiet_hours_end: '08:00',


### PR DESCRIPTION
## Summary
- Close a structural single point of failure: macOS notification permission was checked once at onboarding and never again — if revoked later, every toast (including the one that would explain why) silently stopped firing. Now periodically re-checked, with a dashboard banner as a resilient fallback that doesn't depend on the toast channel itself working.
- Same periodic re-check added for Accessibility/Screen Recording permission and low disk space on `~/.meridian`'s volume.
- Fold the pause/resume, daemon-health, and update toasts off the direct `sys::notify` bypass into the outbox — each gets its own `notify_system_*` settings toggle, and update toasts (previously ungated entirely) now respect quiet hours/master switch like everything else. Closes the tech debt `NOTIFICATIONS.md` itself flagged as deferred.
- Raise a notice when an approved worklog permanently fails to post to its tracker (mirrors the existing `pm.{provider}` sync-fault pattern).
- Add daily, batched digests (not one toast per event) for permanently dead-lettered coding-agent summarisation and board hygiene issues needing attention.

## Explicitly out of scope
Written up in `NOTIFICATIONS.md`'s Deferred section:
- A `worklog.ready` producer — investigation found no autonomous trigger exists yet (worklog generation is on-demand/user-clicked today, not scheduled); needs its own scoping conversation.
- An onboarding-stuck reminder — needs a resumable wizard-progress timestamp (today's `~/.meridian/onboarded` flag is one-shot).
- Toasts for internal-only quality signals (distiller lexical fallback, first-ETL-run) — intentionally log-only per notification-fatigue best practice.
- Actual Windows notification delivery — the product is macOS-only end-to-end today; the outbox architecture (DB schema, producer API, `RuntimeSettings`) stays platform-neutral as it mostly already was, but no Windows delivery mechanism was built.

## Test plan
- [x] `cargo fmt --check` + `cargo clippy -- -D warnings` clean on both the daemon (`meridian`, `meridian-core`) and tray (`meridian-tray`) crates
- [x] `cargo test` — 309 tests passing across both crates (no new failures, no skipped)
- [x] Full pre-push suite passed: fmt, UI build, UI tests, clippy, cargo test, security audit
- [ ] Manual packaged-build verification (interactive toasts only work outside `tauri dev`, per `NOTIFICATIONS.md`'s existing recipe): revoke/restore notification + Accessibility + Screen Recording permission, low-disk banner, pause/resume/daemon-down/update toasts respecting a toggled-off setting, forced worklog-post failure, seeded dead-letter/hygiene digest rows