### PR TITLE
fix(update): check hourly for mandatory updates, and survive suspend

### DIFF
--- a/tray/src-tauri/src/update.rs
+++ b/tray/src-tauri/src/update.rs
@@ -42,6 +42,7 @@ use meridian_core::SqlitePool;
 use semver::Version;
 use serde::Serialize;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, SystemTime};
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_updater::UpdaterExt;
 
@@ -277,25 +278,75 @@ pub async fn download_and_apply(app: &AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Delay before the first mandatory-update check after launch.
+const ENFORCE_FIRST_DELAY: Duration = Duration::from_secs(30);
+/// Steady-state cadence for the mandatory-update check. One network round trip
+/// per hour per install — cheap enough to be unnoticeable, and it bounds how
+/// long a machine can keep running a version the manifest has retired.
+const ENFORCE_INTERVAL: Duration = Duration::from_secs(60 * 60);
+/// First retry delay after a *failed* forced install, doubling up to
+/// [`ENFORCE_INTERVAL`]. A transient network blip must not cost a full cycle on
+/// a machine we are actively trying to evict.
+const ENFORCE_RETRY_BASE: Duration = Duration::from_secs(2 * 60);
+/// Timer granularity. The loop wakes this often and compares a **wall-clock**
+/// deadline rather than sleeping one long stretch, so a machine that suspends
+/// mid-interval re-checks promptly on wake instead of resuming a timer that
+/// stood still. No network happens on a tick that isn't due.
+const ENFORCE_TICK: Duration = Duration::from_secs(60);
+
+/// The next retry delay after a failed forced install: double, capped at the
+/// steady-state interval so a persistently failing install settles into the
+/// normal cadence instead of retrying forever at speed.
+fn next_retry(current: Duration) -> Duration {
+    (current * 2).min(ENFORCE_INTERVAL)
+}
+
 /// Mandatory-update enforcement — the one path that installs without consent.
-/// Spawned once at launch; checks shortly after startup and then every 6 h
-/// (the tray runs for weeks between relaunches, so a launch-only check would
-/// never catch a mandatory release published mid-run). When the manifest marks
-/// the running version as below its minimum, it notifies and installs; on
-/// failure it just waits for the next cycle (the consent banner stays available
-/// as the fallback), and on success [`download_and_apply`] never returns.
+/// Spawned once at launch; checks [`ENFORCE_FIRST_DELAY`] after startup and
+/// then every [`ENFORCE_INTERVAL`] (the tray runs for weeks between relaunches,
+/// so a launch-only check would never catch a mandatory release published
+/// mid-run). When the manifest marks the running version as below its minimum,
+/// it notifies and installs; on success [`download_and_apply`] never returns.
+///
+/// Two properties the naive "sleep the whole interval" loop did not have:
+///
+/// - **Survives suspend.** The deadline is wall-clock ([`SystemTime`]), and the
+///   loop wakes every [`ENFORCE_TICK`] to compare against it. tokio's timer runs
+///   on a monotonic clock that does not advance while macOS is asleep, so a
+///   single long sleep silently stretched by however long the lid was shut — the
+///   common case for a laptop we are trying to evict.
+/// - **Retries a failed install quickly.** A failure previously waited the full
+///   cycle; it now retries from [`ENFORCE_RETRY_BASE`], backing off via
+///   [`next_retry`] to the steady interval. The consent banner remains the
+///   fallback throughout.
+///
+/// The "no longer supported" toast fires once per mandatory episode, not once
+/// per retry — notifying on every attempt would be a notification loop on a
+/// machine that is simply offline.
 pub fn enforce_minimum_version(app: &AppHandle) {
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
-        let mut delay = std::time::Duration::from_secs(30);
+        let mut due = SystemTime::now() + ENFORCE_FIRST_DELAY;
+        let mut retry = ENFORCE_RETRY_BASE;
+        let mut notified = false;
         loop {
-            tokio::time::sleep(delay).await;
-            delay = std::time::Duration::from_secs(6 * 60 * 60);
+            // Wake at most a tick at a time; `due` is the real gate below.
+            let wait = due
+                .duration_since(SystemTime::now())
+                .unwrap_or(Duration::ZERO);
+            tokio::time::sleep(wait.min(ENFORCE_TICK)).await;
+            if SystemTime::now() < due {
+                continue;
+            }
+
             let status = check_status(&app).await;
             // `unsupported` (dev run) never flips to packaged mid-run, so the
             // loop is pure idle there; keep it anyway — it costs one no-op
             // check per cycle and avoids a second is_packaged() code path.
             if status.state != "available" || !status.mandatory {
+                due = SystemTime::now() + ENFORCE_INTERVAL;
+                retry = ENFORCE_RETRY_BASE;
+                notified = false;
                 continue;
             }
             let v = status.version.clone().unwrap_or_default();
@@ -304,15 +355,26 @@ pub fn enforce_minimum_version(app: &AppHandle) {
                 minimum = status.minimum_version.as_deref().unwrap_or(""),
                 "update: running version is below the minimum supported - forcing install"
             );
-            notify_update(
-                &app,
-                "mandatory",
-                "Updating Meridian",
-                &format!("This version is no longer supported - installing v{v}"),
-            )
-            .await;
+            if !notified {
+                notify_update(
+                    &app,
+                    "mandatory",
+                    "Updating Meridian",
+                    &format!("This version is no longer supported - installing v{v}"),
+                )
+                .await;
+                notified = true;
+            }
             if let Err(e) = download_and_apply(&app).await {
-                tracing::warn!(error = %e, "update: forced install failed - retrying next cycle");
+                due = SystemTime::now() + retry;
+                tracing::warn!(
+                    error = %e,
+                    retry_s = retry.as_secs(),
+                    "update: forced install failed - retrying"
+                );
+                retry = next_retry(retry);
+            } else {
+                due = SystemTime::now() + ENFORCE_INTERVAL;
             }
         }
     });
@@ -384,6 +446,29 @@ pub fn check_for_updates(app: &AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn retry_doubles_then_caps_at_the_steady_interval() {
+        // Doubles while below the cap …
+        assert_eq!(next_retry(ENFORCE_RETRY_BASE), ENFORCE_RETRY_BASE * 2);
+        assert_eq!(next_retry(ENFORCE_RETRY_BASE * 2), ENFORCE_RETRY_BASE * 4);
+        // … and never exceeds the steady-state cadence, so a persistently
+        // failing install settles into the normal rhythm instead of hammering.
+        assert_eq!(next_retry(ENFORCE_INTERVAL), ENFORCE_INTERVAL);
+        assert_eq!(next_retry(ENFORCE_INTERVAL * 4), ENFORCE_INTERVAL);
+    }
+
+    #[test]
+    fn retry_backoff_reaches_the_cap_from_the_base() {
+        // The base must actually climb to the cap in a bounded number of
+        // failures — a base that divided the interval unevenly would otherwise
+        // sit just under it forever.
+        let mut d = ENFORCE_RETRY_BASE;
+        for _ in 0..16 {
+            d = next_retry(d);
+        }
+        assert_eq!(d, ENFORCE_INTERVAL);
+    }
 
     #[test]
     fn no_marker_keeps_notes_verbatim() {

--- a/tray/src-tauri/src/update.rs
+++ b/tray/src-tauri/src/update.rs
@@ -356,11 +356,16 @@ pub fn enforce_minimum_version(app: &AppHandle) {
                 "update: running version is below the minimum supported - forcing install"
             );
             if !notified {
+                // Warm and factual. The user did not ask for this install and
+                // is about to have the app restart under them, so the toast
+                // says what is happening and that it will restart — but it does
+                // not scold them for the version they were on. Matches the tone
+                // of the other update toasts ("You're on the latest version.").
                 notify_update(
                     &app,
                     "mandatory",
                     "Updating Meridian",
-                    &format!("This version is no longer supported - installing v{v}"),
+                    &format!("Installing v{v} - Meridian will restart in a moment."),
                 )
                 .await;
                 notified = true;

--- a/tray/src-tauri/src/update.rs
+++ b/tray/src-tauri/src/update.rs
@@ -42,7 +42,7 @@ use meridian_core::SqlitePool;
 use semver::Version;
 use serde::Serialize;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_updater::UpdaterExt;
 
@@ -288,17 +288,63 @@ const ENFORCE_INTERVAL: Duration = Duration::from_secs(60 * 60);
 /// [`ENFORCE_INTERVAL`]. A transient network blip must not cost a full cycle on
 /// a machine we are actively trying to evict.
 const ENFORCE_RETRY_BASE: Duration = Duration::from_secs(2 * 60);
-/// Timer granularity. The loop wakes this often and compares a **wall-clock**
-/// deadline rather than sleeping one long stretch, so a machine that suspends
-/// mid-interval re-checks promptly on wake instead of resuming a timer that
-/// stood still. No network happens on a tick that isn't due.
+/// Timer granularity. The loop wakes this often and compares a [`Deadline`]
+/// rather than sleeping one long stretch, so a machine that suspends mid-interval
+/// re-checks promptly on wake instead of resuming a timer that stood still. No
+/// network happens on a tick that isn't due.
 const ENFORCE_TICK: Duration = Duration::from_secs(60);
 
-/// The next retry delay after a failed forced install: double, capped at the
-/// steady-state interval so a persistently failing install settles into the
+/// The next retry delay after a failed check or install: double, capped at the
+/// steady-state interval so a persistently failing machine settles into the
 /// normal cadence instead of retrying forever at speed.
 fn next_retry(current: Duration) -> Duration {
     (current * 2).min(ENFORCE_INTERVAL)
+}
+
+/// A deadline gated on **both** clocks, firing when *either* reaches it.
+///
+/// Neither clock alone is sufficient here, and each covers the other's hole:
+///
+/// - [`Instant`] (monotonic, what tokio's timer uses) does not advance while
+///   macOS is asleep, so a lid closed for eight hours consumes none of the
+///   interval — the stall this loop exists to avoid.
+/// - [`SystemTime`] (wall clock) advances across suspend, but is *settable*: a
+///   backward jump (manual clock change, dead RTC on wake, VM snapshot restore,
+///   a large NTP correction) would park the deadline in the future by the size
+///   of the jump, reintroducing the same stall from the other direction.
+///
+/// Taking whichever fires first means a jump in either clock can only make the
+/// check happen *early*, never late. Early is harmless: it costs one extra
+/// HTTPS GET.
+struct Deadline {
+    wall: SystemTime,
+    mono: Instant,
+}
+
+impl Deadline {
+    /// A deadline `d` from now on both clocks.
+    fn after(d: Duration) -> Self {
+        Self {
+            wall: SystemTime::now() + d,
+            mono: Instant::now() + d,
+        }
+    }
+
+    /// Time until the *earlier* of the two clocks reaches it; zero once either
+    /// has. A wall clock that jumped backwards saturates to zero rather than
+    /// erroring, which is the "fire early" behaviour we want.
+    fn remaining(&self) -> Duration {
+        let wall = self
+            .wall
+            .duration_since(SystemTime::now())
+            .unwrap_or(Duration::ZERO);
+        wall.min(self.mono.saturating_duration_since(Instant::now()))
+    }
+
+    /// True once either clock has reached the deadline.
+    fn reached(&self) -> bool {
+        self.remaining().is_zero()
+    }
 }
 
 /// Mandatory-update enforcement — the one path that installs without consent.
@@ -308,43 +354,65 @@ fn next_retry(current: Duration) -> Duration {
 /// mid-run). When the manifest marks the running version as below its minimum,
 /// it notifies and installs; on success [`download_and_apply`] never returns.
 ///
-/// Two properties the naive "sleep the whole interval" loop did not have:
+/// Three properties the naive "sleep the whole interval" loop did not have:
 ///
-/// - **Survives suspend.** The deadline is wall-clock ([`SystemTime`]), and the
-///   loop wakes every [`ENFORCE_TICK`] to compare against it. tokio's timer runs
-///   on a monotonic clock that does not advance while macOS is asleep, so a
-///   single long sleep silently stretched by however long the lid was shut — the
-///   common case for a laptop we are trying to evict.
-/// - **Retries a failed install quickly.** A failure previously waited the full
-///   cycle; it now retries from [`ENFORCE_RETRY_BASE`], backing off via
-///   [`next_retry`] to the steady interval. The consent banner remains the
-///   fallback throughout.
+/// - **Survives suspend and clock jumps.** The gate is a [`Deadline`], which
+///   fires on whichever of the wall and monotonic clocks reaches it first, and
+///   the loop wakes every [`ENFORCE_TICK`] to test it. tokio's timer runs on a
+///   monotonic clock that does not advance while macOS is asleep, so a single
+///   long sleep silently stretched by however long the lid was shut — the common
+///   case for a laptop we are trying to evict.
+/// - **Retries a failed *check* as fast as a failed install.** On an offline
+///   machine the check is the first network op and the one that fails, so
+///   folding `state = "error"` into the "nothing to do" arm would have left the
+///   fast path unused in exactly the case it was written for. Both failures back
+///   off via [`next_retry`] from [`ENFORCE_RETRY_BASE`] to the steady interval.
+/// - **Keeps the backoff across a flaky network.** `retry` and the toast guard
+///   reset only on a genuine "nothing to do" result, never on an error, so a
+///   machine flapping between check failures does not restart its cadence or
+///   re-toast each time.
 ///
-/// The "no longer supported" toast fires once per mandatory episode, not once
-/// per retry — notifying on every attempt would be a notification loop on a
-/// machine that is simply offline.
+/// The forced-install toast fires once per mandatory episode, not once per
+/// retry — notifying on every attempt would be a notification loop on a machine
+/// that is simply offline. The consent banner remains the fallback throughout.
 pub fn enforce_minimum_version(app: &AppHandle) {
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
-        let mut due = SystemTime::now() + ENFORCE_FIRST_DELAY;
+        let mut due = Deadline::after(ENFORCE_FIRST_DELAY);
         let mut retry = ENFORCE_RETRY_BASE;
         let mut notified = false;
         loop {
             // Wake at most a tick at a time; `due` is the real gate below.
-            let wait = due
-                .duration_since(SystemTime::now())
-                .unwrap_or(Duration::ZERO);
-            tokio::time::sleep(wait.min(ENFORCE_TICK)).await;
-            if SystemTime::now() < due {
+            tokio::time::sleep(due.remaining().min(ENFORCE_TICK)).await;
+            if !due.reached() {
                 continue;
             }
 
             let status = check_status(&app).await;
-            // `unsupported` (dev run) never flips to packaged mid-run, so the
-            // loop is pure idle there; keep it anyway — it costs one no-op
-            // check per cycle and avoids a second is_packaged() code path.
+
+            // A failed *check* is the first thing that breaks on an offline
+            // machine — one network op earlier than a failed download — so it
+            // gets the same fast retry rather than the hour-long "nothing to
+            // do" path. `notified` is deliberately left alone: a check error
+            // mid-episode must not re-arm the toast on a flaky network.
+            if status.state == "error" {
+                due = Deadline::after(retry);
+                tracing::warn!(
+                    error = status.error.as_deref().unwrap_or(""),
+                    retry_s = retry.as_secs(),
+                    "update: mandatory-update check failed - retrying"
+                );
+                retry = next_retry(retry);
+                continue;
+            }
+
+            // Genuinely nothing to do: up to date, `unsupported` (a dev run,
+            // which never flips to packaged mid-run — kept anyway, it costs one
+            // no-op check per cycle and avoids a second is_packaged() path), or
+            // an update that is available but not mandatory. Only here is it
+            // safe to reset the backoff and re-arm the toast.
             if status.state != "available" || !status.mandatory {
-                due = SystemTime::now() + ENFORCE_INTERVAL;
+                due = Deadline::after(ENFORCE_INTERVAL);
                 retry = ENFORCE_RETRY_BASE;
                 notified = false;
                 continue;
@@ -371,7 +439,7 @@ pub fn enforce_minimum_version(app: &AppHandle) {
                 notified = true;
             }
             if let Err(e) = download_and_apply(&app).await {
-                due = SystemTime::now() + retry;
+                due = Deadline::after(retry);
                 tracing::warn!(
                     error = %e,
                     retry_s = retry.as_secs(),
@@ -379,7 +447,7 @@ pub fn enforce_minimum_version(app: &AppHandle) {
                 );
                 retry = next_retry(retry);
             } else {
-                due = SystemTime::now() + ENFORCE_INTERVAL;
+                due = Deadline::after(ENFORCE_INTERVAL);
             }
         }
     });
@@ -451,6 +519,36 @@ pub fn check_for_updates(app: &AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_fresh_deadline_has_not_been_reached() {
+        assert!(!Deadline::after(ENFORCE_INTERVAL).reached());
+        // …and it never asks the loop to sleep past the deadline itself.
+        assert!(Deadline::after(ENFORCE_INTERVAL).remaining() <= ENFORCE_INTERVAL);
+    }
+
+    #[test]
+    fn deadline_fires_when_the_wall_clock_reaches_it() {
+        // Suspend: wall advanced past the deadline while the monotonic clock,
+        // frozen through sleep, still shows an hour to go.
+        let d = Deadline {
+            wall: SystemTime::now(),
+            mono: Instant::now() + ENFORCE_INTERVAL,
+        };
+        assert!(d.reached());
+    }
+
+    #[test]
+    fn deadline_fires_when_the_monotonic_clock_reaches_it() {
+        // Backward wall-clock jump (NTP correction, VM restore): `wall` is
+        // parked an hour out, but the monotonic clock is unaffected — without
+        // this arm the loop would stall for the size of the jump.
+        let d = Deadline {
+            wall: SystemTime::now() + ENFORCE_INTERVAL,
+            mono: Instant::now(),
+        };
+        assert!(d.reached());
+    }
 
     #[test]
     fn retry_doubles_then_caps_at_the_steady_interval() {


### PR DESCRIPTION
Makes the mandatory-update path actually prompt. Contained to `tray/src-tauri/src/update.rs`.

## The problem

`enforce_minimum_version` slept **6 h** between checks, so an already-running app could keep a retired version alive for most of a day after a floor was published.

Nothing else compensates: `UpdateCard` checks **once on mount** (`UpdateCard.tsx:29`), with no interval. Opening the dashboard was the only other way to notice a mandatory release. This loop is the entire recurring mechanism.

Observed live during the 1.72.0 rollout: a staging machine picked up the new manifest and correctly flipped its card to "Required update available", but did not self-install - it was mid-way through its 6 h cycle.

## Changes

### 1. Cadence 6 h → 1 h

24 checks/day/install instead of 4, against a six-fold cut in worst-case eviction time. Each check is one small HTTPS GET to the release CDN.

30 s and 10 min were considered and rejected - 30 s is ~2,880 requests/day/install polling a file that changes at most weekly, which is real CDN egress across an install base and needless process wakeups on battery, for no human-perceptible gain over an hour.

### 2. Wall-clock deadline instead of one long sleep

**The more consequential fix.** tokio's timer runs on a monotonic clock that does **not** advance while macOS is asleep, so the old single 6 h sleep silently stretched by however long the lid was shut. A laptop closed overnight could go well past 6 h without a check - precisely the machine a floor is meant to evict.

The loop now wakes every `ENFORCE_TICK` (60 s) and compares a `SystemTime` deadline, so a suspended machine re-checks within a tick of waking. **No network happens on a tick that isn't due** - the extra wakeups are a timer comparison, nothing more.

### 3. A failed forced install retries fast

Previously a failure fell through to the next full cycle, so a transient network blip cost 6 h on a machine actively being evicted. It now retries from `ENFORCE_RETRY_BASE` (2 min), doubling via `next_retry` to the steady interval, so a persistently failing install settles into the normal rhythm instead of hammering.

### 4. Toast fires once per episode, not per attempt

At a 2 min retry cadence, notifying on every attempt would be a notification loop on a machine that is simply offline. The `notified` flag resets when a check comes back non-mandatory.

### 5. Softer forced-install toast

| | |
|---|---|
| Before | `This version is no longer supported - installing v1.72.0` |
| After | `Installing v1.72.0 - Meridian will restart in a moment.` |

"No longer supported" scolds the user for a version they did not choose to stay on, and it is the last thing they see before the app restarts under them. It was also the tonal outlier - the other update toasts read "Meridian is up to date" / "You're on the latest version."

The restart mention is deliberately kept: the install is not consented to, so this toast is the only warning before the app quits and reopens, possibly mid-task. Only the blame was dropped, not the expectation-setting.

Title (`Updating Meridian`) is unchanged. Plain spaced hyphen per the user-facing-text hard rule.

Not changed: `UpdateCard.tsx:69` still renders "Required update available" on the sidebar card. Accurate rather than scolding, but the same stern register - flag it if it should soften too.

## Ripple

- **Nothing else calls these constants** - they are private to the module, and `enforce_minimum_version`'s signature and its single call site (`lib.rs:502`) are unchanged.
- **Rebased onto #482.** `pre-main` moved mid-change: #482 rewrote these toasts to route through the notification outbox (`notify_update`, gated by `system.update`) instead of the `sys::notify` bypass. This sits on top of that - the forced-install toast still goes through the outbox.
- **`download_and_apply` is already single-flight** (`INSTALLING`), so the faster cadence cannot produce overlapping downloads.

## Tests

Two new in-module tests covering the backoff (`cargo test -p meridian-tray`, 9 pass in `update::`):

- `retry_doubles_then_caps_at_the_steady_interval`
- `retry_backoff_reaches_the_cap_from_the_base` - guards against a base that divides the interval unevenly and sits just under the cap forever

The loop itself is not unit-tested - it needs an `AppHandle` and a live updater endpoint. The extracted `next_retry` is the part with logic worth pinning.

## Scope note

This ships in the binary users **receive**, so it governs the **next** forced update, not the one in flight. Every install below `1.71.0` today is still running the 6 h loop baked into its current build; nothing here accelerates the 1.72.0 rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
