### PR TITLE
perf(release): drop the redundant host cargo build from prepareCmd

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -31,7 +31,7 @@
       ]
     }],
     ["@semantic-release/exec", {
-      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && cargo build --release && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray/src-tauri && cargo clean -p tauri-plugin-notifications --release) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build) && bash scripts/notarize-dmg.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}"
+      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray/src-tauri && cargo clean -p tauri-plugin-notifications --release) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build) && bash scripts/notarize-dmg.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}"
     }],
     ["@semantic-release/git", {
       "assets": [

--- a/.releaserc.staging.json
+++ b/.releaserc.staging.json
@@ -32,7 +32,7 @@
       ]
     }],
     ["@semantic-release/exec", {
-      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && cargo build --release && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray/src-tauri && cargo clean -p tauri-plugin-notifications --release) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build -- --config src-tauri/tauri.staging.conf.json) && bash scripts/notarize-dmg.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}",
+      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray/src-tauri && cargo clean -p tauri-plugin-notifications --release) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build -- --config src-tauri/tauri.staging.conf.json) && bash scripts/notarize-dmg.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}",
       "publishCmd": "bash scripts/mirror-staging-release.sh ${nextRelease.version}"
     }]
   ]


### PR DESCRIPTION
## What

Removes `cargo build --release` from `prepareCmd` in both `.releaserc.json` and `.releaserc.staging.json`. One-token change in each file; nothing else touched.

## Why

Profiling staging run [29687966423](https://github.com/Meridiona/meridian/actions/runs/29687966423) (v1.72.0-staging.1), the 42-minute `release` job breaks down as:

| Phase | Time |
|---|---|
| `cargo build --release` (prepareCmd, host-native) | **4m59s** |
| daemon → `aarch64-apple-darwin` | 4m36s |
| daemon → `x86_64-apple-darwin` | 4m00s |
| `tauri build` tray, slice 1 | 11m34s |
| `tauri build` tray, slice 2 | 13m13s |
| sign + notarize + DMG + upload | ~2m45s |

That first build produces nothing that survives. `tray/package.json`'s `build:daemon` runs `scripts/build-daemon-universal.sh`, which rebuilds `--bin meridian` for both Apple targets and `lipo`s the result *over* `target/release/meridian`; `sign-daemon.sh` signs the universal binary and `tauri build` bundles that as the resource. The host-native artifacts are overwritten or unread.

## Is `--locked` still satisfied?

Yes. `build-daemon-universal.sh` uses `cargo build --locked`, and `set-version.sh` already patches the `[[package]] meridian` version in `Cargo.lock` in lockstep with `Cargo.toml` — with a comment saying that is precisely why. `meridian` is the only workspace member whose version is bumped, so the dependency graph is untouched. The bare build was not what kept the lockfile consistent.

## Expected saving

Less than the 4m59s wall clock. The cross builds do reuse the host-side proc-macros and build scripts this step warms (host artifacts land in `target/release/`), which is why the aarch64 slice still took 4m36s right after it. Realistically ~4 minutes. Only a staging run can confirm it.

## Not in this PR: the cache

The run logged `No cache found.` for `Swatinem/rust-cache`, but that is **not** a key-configuration bug and no config change would fix it:

- rust-cache passes a lockfile-independent fallback restore key (`v0-rust-release-Darwin-arm64-<envhash>`), so the version bump in `Cargo.lock`/`Cargo.toml` does not permanently poison the key.
- This was the first staging run to actually reach the build (every prior `release-staging` run concluded `skipped`), so there was genuinely no prior `release`-namespace cache to restore. One now exists (2.6 GB, saved 13:42).
- Pointing the release job at CI's `macos-universal` cache via `shared-key` would make things *worse*: CI builds debug/`cargo check`, release builds `--release` for two targets. They would thrash a shared `target/`, and the far more frequent CI runs would win.

The real risk is eviction: the repo sits at **12.9 GB of Actions cache against the 10 GB limit**, so the 2.6 GB release cache is the least-recently-used large entry between infrequent releases and will likely be evicted by routine CI. That is a cache-footprint problem worth a separate look, not something to bundle here.

## Testing

`.releaserc.json` and `.releaserc.staging.json` both still parse as JSON. The change cannot be exercised outside a real release - please watch the next staging run's timings before this rides to `main`.