### PR TITLE
fix(capture): bump screenpipe-fork to disable sck-rs on macOS 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,24 @@ jobs:
           # path this guard used to check was removed with the npm channel
           # (DMG-only distribution). Capture now pulls the fork as a git dep
           # in tray/src-tauri/Cargo.toml — that `rev` is the pin.
-          expected="d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e"
+          #
+          # What this guard actually protects is the LICENSE BASE: the fork is
+          # cut from screenpipe's last MIT commit (892199f74), and screenpipe
+          # >= 0.4.17 is Commercial-licensed. Meridiona's OWN commits on top of
+          # that base are ours and carry no license risk — so bumping `expected`
+          # is legitimate ONLY when every commit the bump introduces is ours and
+          # none merges upstream screenpipe code past the MIT cutoff.
+          #
+          # Audit each time you bump, and record it here:
+          #   gh api repos/Meridiona/screenpipe-fork/compare/<old>...<new> \
+          #     --jq '.commits[] | .sha[0:8] + "  " + .commit.author.name'
+          #
+          # 2026-07-19, d6d2b318 -> 825b038d. Three commits, all Meridiona-
+          # authored, no upstream merge:
+          #   1bc2ba88 adityaharishch  fix(a11y): prune browser tab strip …
+          #   4f9ba866 adityaharishch  Merge pull request #1 (same, ours)
+          #   825b038d Akarsh Hegde    fix(screen): disable sck-rs on macOS 26
+          expected="825b038d845d7dcc8c1387b2707899b352417233"
           f="tray/src-tauri/Cargo.toml"
           fail=0
           for crate in screenpipe-screen screenpipe-a11y; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8067,7 +8067,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "screenpipe-a11y"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e#d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8096,7 +8096,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-config"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e#d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8108,7 +8108,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-connect"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e#d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8147,7 +8147,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-core"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e#d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8187,7 +8187,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-db"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e#d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8213,7 +8213,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-events"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e#d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8230,7 +8230,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-screen"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e#d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8267,7 +8267,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-secrets"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e#d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8285,7 +8285,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-vault"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e#d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -91,13 +91,13 @@ meridian = { path = "../.." }
 # screen capture + Apple Vision OCR. Optional → only pulled by the `capture`
 # feature (heavy: ScreenCaptureKit/cidre/sck-rs). Private repo: local builds use
 # the user's git credentials; CI needs a deploy token (future).
-screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e", optional = true }
+screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "825b038d845d7dcc8c1387b2707899b352417233", optional = true }
 # Sibling crate in the same fork: the accessibility-tree walker (slice 3b).
 # `tree::create_tree_walker` walks the focused window's AX tree → structured
 # text — the PRIMARY signal for Electron/Chromium apps (VS Code, Slack), which
 # expose nothing to OCR-free a11y until the walker sets AXManualAccessibility
 # itself. Optional → only the `capture` feature pulls it.
-screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "d6d2b318cfe1fffbc9e923e627e8659df1b2ff7e", optional = true }
+screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "825b038d845d7dcc8c1387b2707899b352417233", optional = true }
 # Console log subscriber for capture-enabled non-otel runs (otel installs its
 # own). Makes the `capture: …` logs visible during a `cargo run --features capture`.
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }


### PR DESCRIPTION
Depends on **Meridiona/screenpipe-fork#2** (merge that first, then this rev is already correct - it pins the commit, not the branch).

## Symptom

The tray aborts within seconds of anything reaching the OCR fallback path - clicking the tray, opening the dashboard, focusing a canvas app. Capture dies with it:

| day | accessibility | ocr |
|---|---|---|
| 07-16 | 11,654 | 363 |
| 07-17 | 12,498 | 359 |
| 07-18 | 10,750 | 230 |
| **07-19** | 361 | **0** |

Hits the shipped product too - `/Applications/Meridian.app` (signed, notarized, granted) aborts with the byte-identical signature, so this is not a dev-build artifact.

## Cause

Double-free inside ScreenCaptureKit's own XPC reply teardown, on the `replayd` connection thread:

```
_Block_release
ScreenCaptureKit  __destroy_helper_block_e8_32s40s
___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
abort
```

Stage instrumentation placed it exactly: `list_monitors()` is entered and never returns, so `capture_all_visible_windows()` and `perform_ocr()` are never reached. **Despite the "OCR fallback" label, no OCR is involved** - it's the ScreenCaptureKit monitor enumeration that runs first.

The completion block handed to `SCShareableContent` is released once too often - a bug in the sck-rs/cidre binding, not in SCK. A standalone Swift program calling the same API on the same machine enumerates 1 display / 32 apps / 156 windows and exits cleanly.

## Ruled out (each by test, not inspection)

| suspect | test | result |
|---|---|---|
| cidre duplication (0.15.1 + 0.15.2) | unified via `[patch]` | still aborts |
| cidre version skew | upstream HEAD 0.16.1 | still aborts |
| stale build artifacts | `cargo clean` + full rebuild | still aborts |
| TCC / permissions | preflight granted; real denial returns `PermissionDenied` | not it |
| bundling / signing | signed notarized `.app` | aborts identically |
| `replayd` state | restarted | still aborts |
| this repo | fork rev, cidre pins, SDK all untouched since 06-21 | nothing changed |
| ScreenCaptureKit itself | Swift probe, same machine, same API | **works** |

## Change

Rev bump only. The fix is in the fork: gate `use_sck_rs()` off on macOS 26+ so monitor and window enumeration take the xcap/CoreGraphics path.

It has to be decided up front rather than attempted and recovered from - a libmalloc double-free calls `abort()` directly, so there's no error to match on and nothing to catch.

This rev also carries the fork's browser a11y tab-strip prune (`1bc2ba8`), which landed on fork `main` after the previously pinned rev.

## Verification

macOS 26.5.1 (25F80), Mac Studio, OCR path forced every tick:

- **Before:** aborts on the first shareable-content fetch, every run, zero OCR frames.
- **After:** runs indefinitely; OCR frames 5,812 → 5,833 at the normal 2 s cadence, ~7 KB/frame, correct window titles and legible text.

Full pre-push suite green (fmt, clippy, UI tests, security audit, cargo test).

## Caveat

**Mitigation, not a cure.** `xcap` uses `CGWindowListCreateImage`, deprecated since macOS 14 and removable in a future release. The real fix is repairing the binding and dropping the gate. `SCREENPIPE_FORCE_SCK=1` re-enables SCK to retest once a newer sck-rs/cidre lands.

**Open question:** why this worked through 07-18 and broke on 07-19 with provably identical code, dependencies, and OS is unexplained. The binding bug is deterministic now; something about system state kept it latent. The fix holds regardless, but that loose end is not tied off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Amk5pH47wJj76HBm5oDu9X