### PR TITLE
ci: save rust caches only on the integration branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,16 @@ jobs:
 
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
+        with:
+          # Restore everywhere, save only on the two integration branches.
+          # GitHub scopes caches by REF, so a branch that is both pushed and
+          # has an open PR stored two near-identical copies of every target/
+          # cache (observed: 2582MB vs 2527MB for macos-universal alone).
+          # Six Rust caches totalled 9.6GB against the 10GB repo quota, which
+          # evicted the release job's cache within ~3h of it being written and
+          # forced every release to compile cold. PR runs still RESTORE from
+          # the base branch; they just stop writing a duplicate.
+          save-if: ${{ github.ref == 'refs/heads/pre-main' || github.ref == 'refs/heads/main' }}
 
       - name: fmt
         run: cargo fmt --check
@@ -111,6 +121,9 @@ jobs:
 
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
+        with:
+          # Save only on the integration branches - see the Rust job above.
+          save-if: ${{ github.ref == 'refs/heads/pre-main' || github.ref == 'refs/heads/main' }}
 
       - name: check
         run: cargo check -p meridian -p meridian-core --all-targets
@@ -184,6 +197,9 @@ jobs:
 
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
+        with:
+          # Save only on the integration branches - see the Rust job above.
+          save-if: ${{ github.ref == 'refs/heads/pre-main' || github.ref == 'refs/heads/main' }}
 
       # Same stub trick as the Windows tray check: tauri-build only STATS the
       # bundle.resources daemon path during `cargo check`, never reads it, so a


### PR DESCRIPTION
## What

Adds `save-if` to all three `Swatinem/rust-cache@v2` steps in `ci.yml` (`rust`, `windows-portability`, `macos-universal`):

```yaml
save-if: ${{ github.ref == 'refs/heads/pre-main' || github.ref == 'refs/heads/main' }}
```

PR runs keep **restoring** — GitHub lets a PR run read caches from its base branch — they just stop **writing** a duplicate.

## Why

Actions caches are scoped by **ref**. A branch that is both pushed to `pre-main` and has an open PR therefore stores two near-identical copies of every `target/` cache. Measured 2026-07-19:

| Cache | pre-main | pull/483/merge |
|---|---|---|
| `macos-universal` | 2582 MB | 2527 MB |
| `windows-portability` | 1269 MB | 1262 MB |
| `rust` (Linux) | 1091 MB | 851 MB |

**9.58 GB against a 10 GB per-repo quota**, from six entries all created inside one 15-minute window. GitHub evicted LRU to stay under, and the casualty was the release job's own 2618 MB cache — written at 13:42, gone by ~16:55. Release run [29696118671](https://github.com/Meridiona/meridian/actions/runs/29696118671) consequently compiled fully cold.

This frees ~4.9 GB (12.18 GB → ~7.3 GB).

## Why not `cache-targets: false`

That was the other candidate and it's the worse trade. Those jobs are already the slowest in CI *with* a warm cache — on run [29695608454](https://github.com/Meridiona/meridian/actions/runs/29695608454): Windows portability **8.1 min**, macOS **6.2 min**, Rust 2.3 min. Dropping `target/` would add ~10 min to every PR to save ~20 min on an infrequent release.

## Costs and limits, stated plainly

- A long-lived PR branch that drifts from its base gets progressively staler restores. Bounded — never worse than the cold build it would otherwise get.
- **This makes the release cache able to survive, not guaranteed to.** ~7.3 GB + 2.62 GB release ≈ 9.9 GB is still close to the line, and a sustained week of CI could age it out. The durable fixes are a scheduled warm-up run on `pre-main` that refreshes the release-namespace cache, or more quota. Neither is in this PR.
- Existing stale entries aren't pruned here. Two generations from 07-18 (2.35 GB combined) are still held on superseded lockfile hashes; clearing those would add real headroom.

## Testing

`save-if` is confirmed present in `action.yml` at the pinned SHA (`e18b497`). The effect is only observable across runs — after merge, the check is that PR runs stop appearing as `pull/*` refs in `gh cache list` while still logging a restore.