### PR TITLE
fix(llm): spawn CLI providers by resolved path, not bare name

### DIFF
--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -91,7 +91,15 @@ pub(crate) async fn run_capture(
     extra_env: &[(&str, &str)],
     remove_env: &[&str],
 ) -> Result<Capture, SummariserError> {
-    let mut cmd = Command::new(program);
+    // Spawn the RESOLVED absolute path, not the bare name. `Command::new("claude")`
+    // searches only the calling process's `PATH`, and the tray is a Finder-launched
+    // `.app` whose `PATH` is the stripped launchd default — so every CLI provider
+    // reported "not found on PATH" in Test Connection on machines where the CLI works
+    // fine. The daemon was unaffected (its plist sets a rich `PATH`), which is why this
+    // only ever surfaced in the tray. Falls back to the bare name so a process that
+    // does have a working `PATH` behaves exactly as before.
+    let resolved = crate::llm::detect::resolve_cli(program).await;
+    let mut cmd = Command::new(resolved.as_deref().unwrap_or_else(|| Path::new(program)));
     cmd.args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -107,7 +115,13 @@ pub(crate) async fn run_capture(
 
     let mut child = cmd.spawn().map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
-            SummariserError::Failed(format!("{program} CLI not found on PATH"))
+            // User-facing (it surfaces on the provider card), so: plain hyphen, and
+            // honest about where we looked - "not on PATH" was actively misleading
+            // once resolution also searches the login shell and the install dirs.
+            SummariserError::Failed(format!(
+                "{program} CLI not found - looked on PATH, in your login shell, \
+                 and in the usual install locations"
+            ))
         } else {
             SummariserError::Failed(format!("{program} spawn failed: {e}"))
         }

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -373,8 +373,14 @@ mod tests {
     /// path that exists. A bare name here would silently reintroduce the tray bug, since
     /// a Finder-launched `.app` has only `/usr/bin:/bin:/usr/sbin:/sbin`.
     ///
-    /// `sh` is the probe target because POSIX guarantees it at an absolute path on every
-    /// machine this runs on, so the test asserts the contract rather than the environment.
+    /// `sh` is the probe target because POSIX guarantees it at an absolute path.
+    ///
+    /// Unix-only, and so is the mechanism under test: the probe shells out to `$SHELL -l`
+    /// and falls back to unix install dirs (`~/.local/bin`, `/opt/homebrew/bin`). On the
+    /// Windows portability job there is no `/bin/sh` for either path to find, so this
+    /// asserted the environment rather than the contract. The bug it guards is macOS-only
+    /// (a Finder-launched `.app`), and the other `resolve_cli` tests still run everywhere.
+    #[cfg(unix)]
     #[tokio::test]
     async fn resolve_cli_returns_an_absolute_existing_path() {
         let found = resolve_cli("sh").await.expect("sh must resolve");

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -323,9 +323,18 @@ pub async fn resolve_cli(bin: &str) -> Option<PathBuf> {
 async fn probe_login_shell(bin: &str) -> Option<PathBuf> {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
     let mut cmd = Command::new(&shell);
+    // `bin` is passed as a POSITIONAL ARGUMENT, never interpolated into the script. The
+    // script text is a fixed literal, so no value of `bin` can be parsed as shell syntax
+    // — `format!("command -v {bin}")` would let a name containing `;`, `$()` or a
+    // backtick execute arbitrary commands in the user's login shell. Every caller passes
+    // a hardcoded literal today, but `resolve_cli` is public and takes an arbitrary
+    // `&str`, so the guarantee belongs here rather than in a caller-side convention.
+    // For `-c`, the first operand becomes `$0`, hence the placeholder before `bin`.
     cmd.arg("-l")
         .arg("-c")
-        .arg(format!("command -v {bin}"))
+        .arg("command -v -- \"$1\"")
+        .arg("meridian-probe")
+        .arg(bin)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -381,6 +390,25 @@ mod tests {
         assert_eq!(
             resolve_cli("meridian-definitely-not-a-real-binary-xyz").await,
             None
+        );
+    }
+
+    /// `resolve_cli` is public and takes an arbitrary `&str`, so a name carrying shell
+    /// metacharacters must resolve to nothing rather than execute. The probe passes the
+    /// name as a positional argument to a fixed script, so there is no way out of it.
+    ///
+    /// The canary is the side effect: if the `;` were interpreted, the injected `touch`
+    /// would run and the file would exist.
+    #[tokio::test]
+    async fn resolve_cli_does_not_execute_shell_metacharacters() {
+        let canary = std::env::temp_dir().join("meridian-injection-canary");
+        let _ = std::fs::remove_file(&canary);
+        let payload = format!("sh; touch {}", canary.display());
+
+        assert_eq!(resolve_cli(&payload).await, None);
+        assert!(
+            !canary.exists(),
+            "injected command ran - the probe is interpolating into the shell script"
         );
     }
 

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -92,9 +92,7 @@ pub async fn detect(provider: LlmProvider) -> ProviderStatus {
         };
     };
 
-    let found = probe_login_shell(bin)
-        .await
-        .or_else(|| probe_candidates(bin));
+    let found = resolve_cli(bin).await;
     ProviderStatus {
         id,
         installed: found.is_some(),
@@ -269,6 +267,55 @@ pub fn persist_test_result(result: &ProviderTestResult) {
     }
 }
 
+/// Successful `bin name → absolute path` resolutions, memoised for the process lifetime.
+///
+/// Only SUCCESSES are cached. A negative result must stay retryable: a user who installs
+/// `claude` while the tray is running would otherwise be told it is missing until they
+/// restart the app. The cost of not caching misses is one login-shell probe per call on a
+/// genuinely absent CLI, bounded by [`PROBE_TIMEOUT`].
+static RESOLVED_BINS: std::sync::OnceLock<std::sync::Mutex<HashMap<String, PathBuf>>> =
+    std::sync::OnceLock::new();
+
+/// Resolve a CLI's absolute path the way [`detect`] does — login shell first, then the
+/// usual install locations.
+///
+/// # Who calls this
+///
+/// [`detect`], for the install probe; and
+/// [`crate::coding_agent_session_ingest::summariser::run_capture`], which spawns the
+/// resolved path instead of a bare program name. That second caller is the load-bearing
+/// one: `Command::new("claude")` searches only the CALLING process's `PATH`, and the tray
+/// is a Finder-launched `.app` whose `PATH` is the stripped launchd default
+/// (`/usr/bin:/bin:/usr/sbin:/sbin`). The daemon never hit this because
+/// `scripts/com.meridiona.daemon.plist` sets a rich `PATH` for it, which is exactly why
+/// the bug only ever showed up in the tray's Test Connection.
+///
+/// Returns `None` when neither probe finds the binary; callers fall back to the bare name
+/// so a working `PATH` still behaves as before.
+pub async fn resolve_cli(bin: &str) -> Option<PathBuf> {
+    if let Some(hit) = RESOLVED_BINS
+        .get_or_init(Default::default)
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(bin)
+        .cloned()
+    {
+        return Some(hit);
+    }
+
+    let found = probe_login_shell(bin)
+        .await
+        .or_else(|| probe_candidates(bin))?;
+
+    tracing::debug!(bin, path = %found.display(), "resolved CLI path");
+    RESOLVED_BINS
+        .get_or_init(Default::default)
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(bin.to_string(), found.clone());
+    Some(found)
+}
+
 /// Ask the user's login shell where the binary is. This is the one that works when the
 /// app was launched from Finder — `-l` sources their profile, so we see the same `PATH`
 /// they see. `-i` is deliberately omitted: an interactive shell can print banners, run
@@ -311,6 +358,47 @@ fn probe_candidates(bin: &str) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The load-bearing property: whatever `resolve_cli` hands back must be something
+    /// `Command::new` can spawn WITHOUT relying on the caller's `PATH` — i.e. an absolute
+    /// path that exists. A bare name here would silently reintroduce the tray bug, since
+    /// a Finder-launched `.app` has only `/usr/bin:/bin:/usr/sbin:/sbin`.
+    ///
+    /// `sh` is the probe target because POSIX guarantees it at an absolute path on every
+    /// machine this runs on, so the test asserts the contract rather than the environment.
+    #[tokio::test]
+    async fn resolve_cli_returns_an_absolute_existing_path() {
+        let found = resolve_cli("sh").await.expect("sh must resolve");
+        assert!(found.is_absolute(), "not absolute: {}", found.display());
+        assert!(found.exists(), "does not exist: {}", found.display());
+    }
+
+    /// A miss must be `None` rather than a bare-name `PathBuf`. `run_capture` treats
+    /// `None` as "fall back to the bare name"; a `Some("nope")` would instead be spawned
+    /// as a literal relative path and fail with a confusing error.
+    #[tokio::test]
+    async fn resolve_cli_misses_are_none() {
+        assert_eq!(
+            resolve_cli("meridian-definitely-not-a-real-binary-xyz").await,
+            None
+        );
+    }
+
+    /// Negative results must NOT be memoised: a user who installs a CLI while the tray is
+    /// running has to be able to Test Connection again without restarting the app.
+    #[tokio::test]
+    async fn resolve_cli_does_not_cache_misses() {
+        let bin = "meridian-not-installed-yet-abc";
+        assert_eq!(resolve_cli(bin).await, None);
+        assert!(
+            !RESOLVED_BINS
+                .get_or_init(Default::default)
+                .lock()
+                .unwrap()
+                .contains_key(bin),
+            "a miss was cached, so installing the CLI later would not be picked up"
+        );
+    }
 
     #[tokio::test]
     async fn detect_all_covers_every_builtin_exactly_once() {


### PR DESCRIPTION
## Symptom

Every CLI provider card in the tray's **Your AI** pane shows `CONNECTION FAILED` — on a machine where all four CLIs are installed and work fine:

```
Claude Code     claude CLI not found on PATH
Codex           codex CLI not found on PATH
Cursor          cursor-agent CLI not found on PATH
GitHub Copilot  copilot CLI not found on PATH
```

The Nvidia (custom endpoint) card works — it's HTTP with no subprocess. That's the control that isolates this to process spawning.

## Root cause: a PATH asymmetry, not a missing binary

All four backends spawn a **bare** program name — `run_capture("claude", …)` in `src/llm/claude.rs:66`, likewise `codex.rs:120`, `cursor.rs:52`, `copilot.rs:56`. `Command::new` searches only the **calling process's** PATH:

| | PATH | Bare name resolves? |
|---|---|---|
| **Daemon** | `com.meridiona.daemon.plist` sets `{{HOME}}/.local/bin:/opt/homebrew/bin:…` | Yes — real summarisation works |
| **Tray** | Finder-launched `.app` → stripped launchd default `/usr/bin:/bin:/usr/sbin:/sbin` | **No** |

The tray runs `test_llm_provider` **in-process** (`tray/src-tauri/src/commands/setup.rs:199` → `meridian::llm::detect::test_provider`), so it inherits its own stripped PATH. These CLIs install to `~/.local/bin`, `/opt/homebrew/bin`, or an npm/VS Code prefix — none of which are there. That's why the bug is only reachable from the tray.

Note the error string the user sees comes from `run_capture`'s `NotFound` arm (`summariser/mod.rs:110`), **not** from the install probe. `detect.rs` was already resolving absolute paths correctly (login shell, then the usual install dirs) and storing them in `ProviderStatus.path` — the invocation path just threw that away. The daemon's plist even carries a comment describing this exact failure mode.

Same bug class as the `selectMeridianBinary` rule in `CLAUDE.md`, re-introduced on the LLM-CLI side.

## Fix

`run_capture` — the single spawn choke point for **all 8 call sites** (4 LLM backends + 4 summariser engines) — now resolves through the new `llm::detect::resolve_cli` and spawns the absolute path, falling back to the bare name so a process with a working PATH behaves exactly as before.

Chosen over threading a `bin_path` through `LlmConfig`: one change point, and it fixes the summariser engines at the same time.

`resolve_cli` memoises **successes only** — caching a miss would tell a user who installs a CLI while the tray is running that it's still missing until they restart.

Second commit hardens `probe_login_shell`, which interpolated the name into its `-c` script. Harmless while callers passed hardcoded literals, but `resolve_cli` is public and takes an arbitrary `&str`. Caught by the pre-push security audit; the name is now a positional argument to a fixed script.

## Verification

Run under the tray's real stripped PATH (`env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin`):

**Before** — all four `NOT FOUND`, i.e. `ErrorKind::NotFound`, the reported bug.

**After:**
```
claude        -> ~/.local/bin/claude
codex         -> /opt/homebrew/bin/codex
cursor-agent  -> ~/.local/bin/cursor-agent
copilot       -> /opt/homebrew/bin/copilot
```

Four new tests in `src/llm/detect.rs`: resolution returns an absolute existing path; misses are `None` (not a bare-name `PathBuf`); misses aren't cached; an injected shell command doesn't execute.

`cargo fmt` + `clippy -D warnings` + `cargo test` (693 passing) green; full pre-push gate passed.

## Not verified

I could not exercise the actual **Test Connection** button in a packaged tray build — that needs a signed `.app` launched from Finder. The resolution layer is proven under the exact PATH that build has, but someone should confirm the card goes green on a staging DMG before this is trusted end to end.