### PR TITLE
fix(tray): finish the Windows port of the in-process capture module

### DIFF
--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -272,6 +272,7 @@ const WINDOWS_TASK_NAME: &str = "Meridian Daemon";
 /// requests Screen Recording (a duplicate prompt) and races the tray's in-process
 /// capture. Boot it out, remove its plist + binary, and kill any live process.
 /// Entirely best-effort and non-fatal — a launchctl hiccup must not abort install.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 async fn cleanup_legacy_screenpipe(home: &Path) {
     let label = "com.meridiona.screenpipe";
     let target = format!("gui/{}/{label}", crate::sys::uid_str());
@@ -295,6 +296,7 @@ async fn cleanup_legacy_screenpipe(home: &Path) {
 /// `install-mlx-server-daemon.sh`) on port 7823. That whole subsystem has been
 /// removed (generation runs through the user's CLI provider now), so on update we
 /// boot out any surviving agent and remove its plist. Best-effort.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 async fn cleanup_legacy_mlx_server(home: &Path) {
     let label = "com.meridiona.mlx-server";
     let target = format!("gui/{}/{label}", crate::sys::uid_str());
@@ -318,6 +320,7 @@ async fn cleanup_legacy_mlx_server(home: &Path) {
 /// any live process, and best-effort clear its TCC grant (`tccutil reset`) so
 /// the entry doesn't linger grayed-out after the binary is gone. Entirely
 /// best-effort + non-fatal — a launchctl/tccutil hiccup must not abort install.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 async fn cleanup_legacy_a11y_helper(home: &Path) {
     let label = "com.meridiona.a11y-helper";
     let target = format!("gui/{}/{label}", crate::sys::uid_str());
@@ -347,6 +350,7 @@ async fn cleanup_legacy_a11y_helper(home: &Path) {
 /// via the setup wizard. Copy the bundle file across **only when the canonical
 /// one doesn't already exist** — never clobber creds the tray already wrote.
 /// Best-effort + non-fatal.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 async fn migrate_legacy_bundle_env(home: &Path) {
     let canonical = home.join(".meridian/.env");
     let bundle = home.join(".meridian/app/.env");
@@ -403,6 +407,7 @@ async fn set_executable(_path: &Path) -> Result<(), String> {
 
 /// Replace each `{{KEY}}` in `template` with its value. Pure — the testable core
 /// of [`render_plist`].
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn apply_subs(template: &str, subs: &[(&str, &str)]) -> String {
     let mut text = template.to_string();
     for (key, val) in subs {
@@ -413,6 +418,7 @@ fn apply_subs(template: &str, subs: &[(&str, &str)]) -> String {
 
 /// Read a bundled plist template, replace each `{{KEY}}`, write it to
 /// `~/Library/LaunchAgents/`, and `plutil -lint` the result.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 async fn render_plist(template: &Path, dest: &Path, subs: &[(&str, &str)]) -> Result<(), String> {
     let raw = tokio::fs::read_to_string(template)
         .await
@@ -443,6 +449,7 @@ async fn render_plist(template: &Path, dest: &Path, subs: &[(&str, &str)]) -> Re
 /// kickstart the agent under `gui/<uid>` — the same dance the shell installers
 /// run, ported. `bootout` is async, so we poll `launchctl print` until the label
 /// clears (≤15 s) before bootstrapping, else `bootstrap` can fail with EIO.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 async fn register_agent(label: &str, plist: &Path) -> Result<(), String> {
     let gui = format!("gui/{}", crate::sys::uid_str());
     let target = format!("{gui}/{label}");
@@ -471,6 +478,7 @@ async fn register_agent(label: &str, plist: &Path) -> Result<(), String> {
 
 /// Run `launchctl <args>`, returning `Ok(true)` on exit 0. Errors only on spawn
 /// failure; a non-zero exit is `Ok(false)` so callers decide what's fatal.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 async fn launchctl(args: &[&str]) -> Result<bool, String> {
     tokio::process::Command::new("launchctl")
         .args(args)

--- a/tray/src-tauri/src/capture/drm_detector.rs
+++ b/tray/src-tauri/src/capture/drm_detector.rs
@@ -104,6 +104,7 @@ pub fn is_streaming_content(app_name: &str, url: Option<&str>) -> bool {
 }
 
 /// Safari uses "current tab" terminology in its AppleScript dictionary.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 const SAFARI_STYLE_BROWSERS: &[&str] = &["Safari"];
 
 /// Chromium-based browsers share the same "active tab of front window"
@@ -112,6 +113,7 @@ const SAFARI_STYLE_BROWSERS: &[&str] = &["Safari"];
 /// well-documented Chromium convention but weren't installed on this machine
 /// to verify directly. Firefox is deliberately absent — it has no reliable
 /// AppleScript command for the active tab's URL.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 const CHROMIUM_STYLE_BROWSERS: &[&str] = &[
     "Google Chrome",
     "Arc",
@@ -154,6 +156,7 @@ pub fn resolve_url_via_applescript(_app_name: &str) -> Option<String> {
 /// URL, or `None` if it isn't a known scriptable browser. Split out from
 /// [`resolve_url_via_applescript`] so the browser-family dispatch logic is
 /// unit-testable without spawning a real process.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn current_tab_url_script(app_name: &str) -> Option<String> {
     if SAFARI_STYLE_BROWSERS
         .iter()
@@ -195,6 +198,7 @@ fn run_osascript(script: &str) -> Option<String> {
 /// All scriptable browsers we can ask directly for their current-tab URL via
 /// AppleScript (see [`resolve_url_via_applescript`]) — the union of both
 /// dictionary styles.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn scriptable_browsers() -> impl Iterator<Item = &'static str> {
     SAFARI_STYLE_BROWSERS
         .iter()
@@ -205,6 +209,7 @@ fn scriptable_browsers() -> impl Iterator<Item = &'static str> {
 /// Best-effort process-name hints for native streaming apps, used only to
 /// decide whether it's worth checking further — NOT full detection (that's
 /// [`is_streaming_app`], matched against the AX/OCR-observed `app_name`).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 const NATIVE_APP_PROCESS_HINTS: &[&str] = &[
     "Netflix",
     "Disney+",

--- a/tray/src-tauri/src/capture/screenpipe.rs
+++ b/tray/src-tauri/src/capture/screenpipe.rs
@@ -515,6 +515,19 @@ fn with_autorelease_pool<R>(f: impl FnOnce() -> R) -> R {
     f()
 }
 
+/// Non-Apple counterpart of [`with_autorelease_pool`] — runs `f` directly.
+///
+/// Autorelease pools are an Objective-C runtime concept with no counterpart
+/// off Apple platforms; there is no deferred-release queue to drain, so the
+/// unbounded-growth problem the macOS arm exists to solve cannot arise. Kept as
+/// a pass-through wrapper rather than `cfg`-ing the call sites so the engine
+/// loop stays platform-agnostic — the AX walk at the top of the loop is shared
+/// by both platforms, and the fork dispatches `create_tree_walker` internally.
+#[cfg(not(target_os = "macos"))]
+fn with_autorelease_pool<R>(f: impl FnOnce() -> R) -> R {
+    f()
+}
+
 /// Register for Screen Recording, but **only prompt when it isn't already
 /// granted**. Preflights with `CGPreflightScreenCaptureAccess` (a pure status
 /// read) first and only calls the prompting `CGRequestScreenCaptureAccess` when

--- a/tray/src-tauri/src/capture/ui_events.rs
+++ b/tray/src-tauri/src/capture/ui_events.rs
@@ -75,6 +75,7 @@ fn recorder_config() -> UiCaptureConfig {
 
 /// Whether this process already holds macOS Input Monitoring — a pure status read
 /// (`IOHIDCheckAccess`, no prompt) used to skip re-requesting an existing grant.
+#[cfg(target_os = "macos")]
 fn input_monitoring_granted() -> bool {
     #[link(name = "IOKit", kind = "framework")]
     extern "C" {
@@ -85,6 +86,20 @@ fn input_monitoring_granted() -> bool {
     const GRANTED: u32 = 0;
     // Safety: IOHIDCheckAccess is a pure status read — no prompt, no side effects.
     unsafe { IOHIDCheckAccess(LISTEN_EVENT) == GRANTED }
+}
+
+/// Windows counterpart of [`input_monitoring_granted`] — always `true`.
+///
+/// Same reasoning as the capture engine's `request_screen_capture_access`:
+/// Windows has no TCC, so there is no Input Monitoring grant to hold and no
+/// reduced mode to fall back to. The low-level input hooks the recorder installs
+/// need no per-app permission — the fork's own
+/// `screenpipe_a11y::platform::windows` `check_permissions()` hardcodes the same,
+/// noting that "Windows doesn't require explicit permissions for hooks". `true`
+/// is therefore the accurate answer, not a placeholder.
+#[cfg(target_os = "windows")]
+fn input_monitoring_granted() -> bool {
+    true
 }
 
 /// Run the input recorder until `tx` closes. **Blocking** — call on a dedicated

--- a/tray/src-tauri/src/capture/ui_events.rs
+++ b/tray/src-tauri/src/capture/ui_events.rs
@@ -88,16 +88,20 @@ fn input_monitoring_granted() -> bool {
     unsafe { IOHIDCheckAccess(LISTEN_EVENT) == GRANTED }
 }
 
-/// Windows counterpart of [`input_monitoring_granted`] — always `true`.
+/// Non-Apple counterpart of [`input_monitoring_granted`] — always `true`.
 ///
 /// Same reasoning as the capture engine's `request_screen_capture_access`:
-/// Windows has no TCC, so there is no Input Monitoring grant to hold and no
-/// reduced mode to fall back to. The low-level input hooks the recorder installs
-/// need no per-app permission — the fork's own
+/// Input Monitoring is a TCC concept, so off macOS there is no grant to hold and
+/// no reduced mode to fall back to. The low-level input hooks the recorder
+/// installs need no per-app permission — the fork's own
 /// `screenpipe_a11y::platform::windows` `check_permissions()` hardcodes the same,
 /// noting that "Windows doesn't require explicit permissions for hooks". `true`
 /// is therefore the accurate answer, not a placeholder.
-#[cfg(target_os = "windows")]
+///
+/// Gated `not(macos)` rather than `windows` so the pair is target-complete: a
+/// third target still resolves, matching `screenpipe::with_autorelease_pool` and
+/// [`crate::sys`]'s own platform pairs.
+#[cfg(not(target_os = "macos"))]
 fn input_monitoring_granted() -> bool {
     true
 }

--- a/tray/src-tauri/src/commands/app_icons.rs
+++ b/tray/src-tauri/src/commands/app_icons.rs
@@ -80,6 +80,7 @@ fn resolve_bundle_path_in(dirs: &[PathBuf], app_name: &str) -> Option<PathBuf> {
 /// Sanitize an app name into a safe cache filename — app names can contain
 /// spaces/slashes (e.g. browser profile suffixes), neither of which belong
 /// in a path segment.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn cache_key(app_name: &str) -> String {
     app_name
         .to_lowercase()

--- a/tray/src-tauri/src/commands/system.rs
+++ b/tray/src-tauri/src/commands/system.rs
@@ -54,13 +54,7 @@ pub async fn open_dashboard(app: tauri::AppHandle) -> Result<(), String> {
         Ok(win) => {
             // Revert to Accessory (no dock icon) when the dashboard is closed
             // so the tray-only UX is restored.
-            let app_handle = app.clone();
-            win.on_window_event(move |event| {
-                if let WindowEvent::Destroyed = event {
-                    #[cfg(target_os = "macos")]
-                    let _ = app_handle.set_activation_policy(tauri::ActivationPolicy::Accessory);
-                }
-            });
+            crate::sys::revert_to_accessory_on_close(&app, &win);
             // Clicking back into an already-open dashboard while the popover
             // happens to be open on top of it wouldn't otherwise dismiss the
             // popover — see dismiss_popover_on_focus's doc comment.

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -924,11 +924,25 @@ pub(crate) fn start_capture(
 ) {
     use capture::{screenpipe::ScreenpipeEngine, CaptureEngine};
 
-    #[link(name = "CoreGraphics", kind = "framework")]
-    extern "C" {
-        fn CGPreflightScreenCaptureAccess() -> bool;
-    }
-    let screen_granted = unsafe { CGPreflightScreenCaptureAccess() };
+    // Launch-time gate: don't even spawn the engine when Screen Recording is
+    // missing. Distinct from the engine's own `request_screen_capture_access`,
+    // which prompts — this one is a silent preflight, so a first launch before
+    // the wizard's grant doesn't race a cold TCC dialog.
+    //
+    // Windows has no TCC: Windows Graphics Capture needs no persistent per-app
+    // grant, so there is nothing to preflight and the gate is always open —
+    // matching the engine's own Windows permission stubs.
+    #[cfg(target_os = "macos")]
+    let screen_granted = {
+        #[link(name = "CoreGraphics", kind = "framework")]
+        extern "C" {
+            fn CGPreflightScreenCaptureAccess() -> bool;
+        }
+        unsafe { CGPreflightScreenCaptureAccess() }
+    };
+    #[cfg(not(target_os = "macos"))]
+    let screen_granted = true;
+
     if !screen_granted {
         tracing::info!(
             "capture: Screen Recording not granted — engine deferred until next launch after grant"

--- a/tray/src-tauri/src/sys.rs
+++ b/tray/src-tauri/src/sys.rs
@@ -27,6 +27,7 @@ use tauri_plugin_notifications::Notifications;
 /// The current user's numeric uid as a string (for `launchctl gui/<uid>/…`
 /// domain targets). Falls back to `"501"` (the first macOS user) if `id -u`
 /// can't be read — better than failing the whole launchctl call.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub fn uid_str() -> String {
     std::process::Command::new("id")
         .arg("-u")
@@ -376,10 +377,7 @@ pub fn register_notification_categories(app: &tauri::AppHandle) {
 /// # Related
 /// - [`crate::commands::system::dismiss_popover_on_focus`] — the other
 ///   window-event hook the dashboard openers install.
-pub(crate) fn revert_to_accessory_on_close(
-    app: &tauri::AppHandle,
-    #[cfg_attr(not(target_os = "macos"), allow(unused_variables))] win: &tauri::WebviewWindow,
-) {
+pub(crate) fn revert_to_accessory_on_close(app: &tauri::AppHandle, win: &tauri::WebviewWindow) {
     #[cfg(target_os = "macos")]
     {
         let app_handle = app.clone();
@@ -389,8 +387,9 @@ pub(crate) fn revert_to_accessory_on_close(
             }
         });
     }
+    // One mechanism for both params, so the signature stays attribute-free.
     #[cfg(not(target_os = "macos"))]
-    let _ = app;
+    let _ = (app, win);
 }
 
 #[cfg(test)]

--- a/tray/src-tauri/src/sys.rs
+++ b/tray/src-tauri/src/sys.rs
@@ -359,6 +359,40 @@ pub fn register_notification_categories(app: &tauri::AppHandle) {
     }
 }
 
+/// Restore the tray-only UX when `win` closes: revert the app to the Accessory
+/// activation policy (no dock icon), undoing the Regular policy a window opener
+/// sets so the dashboard gets a dock entry while it is open.
+///
+/// **macOS-only behaviour, deliberately a no-op elsewhere.** Activation policy
+/// is an AppKit concept (`NSApplication.activationPolicy`) with no Windows
+/// analogue — there is no dock to leave an orphaned icon in — so on Windows the
+/// window event is simply never registered.
+///
+/// # Who calls this
+/// Both dashboard openers, which previously each carried their own copy of this
+/// closure: [`crate::tray`]'s tray-menu opener and
+/// [`crate::commands::system::open_dashboard`].
+///
+/// # Related
+/// - [`crate::commands::system::dismiss_popover_on_focus`] — the other
+///   window-event hook the dashboard openers install.
+pub(crate) fn revert_to_accessory_on_close(
+    app: &tauri::AppHandle,
+    #[cfg_attr(not(target_os = "macos"), allow(unused_variables))] win: &tauri::WebviewWindow,
+) {
+    #[cfg(target_os = "macos")]
+    {
+        let app_handle = app.clone();
+        win.on_window_event(move |event| {
+            if let tauri::WindowEvent::Destroyed = event {
+                let _ = app_handle.set_activation_policy(tauri::ActivationPolicy::Accessory);
+            }
+        });
+    }
+    #[cfg(not(target_os = "macos"))]
+    let _ = app;
+}
+
 #[cfg(test)]
 mod tests {
     /// The non-macOS half of [`super::is_bundled`], factored out so the

--- a/tray/src-tauri/src/tray.rs
+++ b/tray/src-tauri/src/tray.rs
@@ -197,8 +197,10 @@ pub(crate) fn open_wizard_window(app: &tauri::AppHandle) {
     // Applied as a separate statement rather than inline in the chain because
     // both `title_bar_style` and `tauri::TitleBarStyle` are macOS-only in Tauri
     // — a `#[cfg]` on the method call alone would still leave the unresolvable
-    // type in a Windows build. Windows keeps its standard title bar, so the
-    // card sits ~26px lower than on macOS; cosmetic, and the layout still holds.
+    // type in a Windows build. Off macOS the window keeps its standard title
+    // bar; since `inner_size` sizes the CLIENT area, the webview is still
+    // 1000×680 and the card still centres within it — only the outer window
+    // grows by the title-bar height. No layout change, just a taller frame.
     #[cfg(target_os = "macos")]
     let builder = builder.title_bar_style(tauri::TitleBarStyle::Transparent);
     match builder.build() {

--- a/tray/src-tauri/src/tray.rs
+++ b/tray/src-tauri/src/tray.rs
@@ -14,7 +14,7 @@ use crate::state::{AppState, HealthStatus};
 use std::sync::{Arc, Mutex};
 use tauri::{
     menu::{Menu, MenuBuilder, MenuItemBuilder, PredefinedMenuItem},
-    Manager, Runtime, WebviewUrl, WebviewWindowBuilder, WindowEvent,
+    Manager, Runtime, WebviewUrl, WebviewWindowBuilder,
 };
 
 /// The toggle item's label for a given daemon health. Kept next to the menu
@@ -119,14 +119,7 @@ pub(crate) fn open_native_dashboard(app: &tauri::AppHandle) {
             Ok(win) => {
                 // Revert to Accessory (no dock icon) when the dashboard is closed
                 // so the tray-only UX is restored.
-                let app_handle = app.clone();
-                win.on_window_event(move |event| {
-                    if let WindowEvent::Destroyed = event {
-                        #[cfg(target_os = "macos")]
-                        let _ =
-                            app_handle.set_activation_policy(tauri::ActivationPolicy::Accessory);
-                    }
-                });
+                crate::sys::revert_to_accessory_on_close(app, &win);
             }
             Err(e) => {
                 eprintln!("tray: failed to open native dashboard: {e}");
@@ -188,21 +181,27 @@ pub(crate) fn open_wizard_window(app: &tauri::AppHandle) {
     // room. Resizable (with a floor at the design size) so the user can grow it or
     // enter macOS full-screen — the card stays centred and the backdrop just widens,
     // so the layout never breaks.
-    match WebviewWindowBuilder::new(app, "setup", WebviewUrl::App("setup".into()))
+    let builder = WebviewWindowBuilder::new(app, "setup", WebviewUrl::App("setup".into()))
         .title("Meridian - Setup")
-        // Transparent title bar so the webview fills the *whole* window and the
-        // centred card gets equal backdrop margins on all four sides. With a
-        // normal (opaque) title bar the bar sits above the webview, so the top
-        // gap reads larger than the sides/bottom. Sized so the 948×628 card keeps
-        // ~26px margins all round — enough clearance for the overlaid traffic
-        // lights + title to sit in the top backdrop, not on the card.
         .inner_size(1000.0, 680.0)
         .min_inner_size(1000.0, 680.0)
         .resizable(true)
-        .title_bar_style(tauri::TitleBarStyle::Transparent)
-        .zoom_hotkeys_enabled(true)
-        .build()
-    {
+        .zoom_hotkeys_enabled(true);
+    // Transparent title bar so the webview fills the *whole* window and the
+    // centred card gets equal backdrop margins on all four sides. With a
+    // normal (opaque) title bar the bar sits above the webview, so the top
+    // gap reads larger than the sides/bottom. The size above is chosen so the
+    // 948×628 card keeps ~26px margins all round — enough clearance for the
+    // overlaid traffic lights + title to sit in the top backdrop, not on the card.
+    //
+    // Applied as a separate statement rather than inline in the chain because
+    // both `title_bar_style` and `tauri::TitleBarStyle` are macOS-only in Tauri
+    // — a `#[cfg]` on the method call alone would still leave the unresolvable
+    // type in a Windows build. Windows keeps its standard title bar, so the
+    // card sits ~26px lower than on macOS; cosmetic, and the layout still holds.
+    #[cfg(target_os = "macos")]
+    let builder = builder.title_bar_style(tauri::TitleBarStyle::Transparent);
+    match builder.build() {
         Ok(win) => {
             // Opt the window into native full-screen so the green traffic-light
             // shows the enter-full-screen arrows, not the plain zoom (+) glyph.


### PR DESCRIPTION
## The failure

The Windows tray build failed to compile `meridian-tray` with six errors — all one class: **macOS-only code reaching a Windows build**.

```
error[E0455]: link kind `framework` is only supported on Apple targets
  --> tray\src-tauri\src\capture\ui_events.rs:79:35
error[E0455]: link kind `framework` is only supported on Apple targets
   --> tray\src-tauri\src\lib.rs:927:42
error[E0425]: cannot find function `with_autorelease_pool` in this scope
   --> tray\src-tauri\src\capture\screenpipe.rs:106:27
error[E0599]: no method named `title_bar_style` found ...
   --> tray\src-tauri\src\tray.rs:202:10
error: unused variable: `app_handle`  (system.rs:57, tray.rs:122)
```

## Diagnosis

The capture module *looks* Apple-only (Apple Vision OCR, autorelease pools, IOKit), which invites the wrong fix — gating capture off on Windows. The code says otherwise: `capture/screenpipe.rs:468` already has a `perform_ocr_windows` arm, `drm_detector.rs` is fully paired macOS/non-macOS, and there are documented Windows permission stubs at 573/583. The forked screenpipe crates compile on Windows too — **nothing in the CI log failed inside them**, only in `meridian-tray`.

So this is an **incomplete Windows port**, not unportable code. Gating capture off would have silently disabled a feature that is actively being built, and left the Windows tray producing no sessions.

## The fix

Three missing Windows arms, mirroring the both-arms pattern already in these files:

| Site | Fix |
|---|---|
| `capture/screenpipe.rs` | `with_autorelease_pool` was macOS-gated but called from the **shared** engine loop (L106). Added a pass-through non-macOS arm, so the loop stays platform-agnostic instead of `cfg`-ing the call site. |
| `capture/ui_events.rs` | `input_monitoring_granted` (IOKit) gated to macOS + a Windows arm returning `true` — no TCC there, matching the fork's own `screenpipe_a11y::platform::windows` `check_permissions()`. |
| `lib.rs` | `start_capture`'s `CGPreflightScreenCaptureAccess` launch gate scoped to macOS, always-open on Windows. |

Two errors were **unrelated to capture**, and were the same eight duplicated lines in `tray.rs` and `commands/system.rs`: a revert-to-Accessory window hook whose `#[cfg]` sat on the closure *body*, so on Windows the closure captured nothing and `app_handle` tripped `-D warnings`. Extracted to `sys::revert_to_accessory_on_close` — gated once instead of twice — and dropped the now-unused `WindowEvent` import from `tray.rs`.

`title_bar_style` is restructured out of the builder chain because both the method **and** `tauri::TitleBarStyle` are macOS-only — a `#[cfg]` on the call alone still leaves an unresolvable type. Windows keeps a standard title bar (the wizard card sits ~26px lower; cosmetic, layout holds).

## Verification — please read

- **macOS: genuinely clean.** `cargo clippy --all-targets` clean, `cargo fmt --check` clean, 114 tests pass.
- **Windows: unverified locally.** Every line added here is `cfg`'d out on macOS, so the local checks verified *zero* of it. Cross-compiling is blocked by `ring`'s C build needing the MSVC headers, which wouldn't faithfully reproduce the msvc CI anyway.

Worth flagging for review: the Windows-only arms — **including the pre-existing `perform_ocr_windows` path** — have never been type-checked by any compiler, because resolution errors (E0455/E0425) abort before type-checking. A round-2 CI error is possible, most likely another unused-on-Windows-only binding under `-D warnings`, which is exactly what errors 5 and 6 were. Windows CI on this PR is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Amk5pH47wJj76HBm5oDu9X