### PR TITLE
fix(ci): register the parallel staging workflow so it can be dispatched

### DIFF
--- a/.github/workflows/release-staging-parallel.yml
+++ b/.github/workflows/release-staging-parallel.yml
@@ -33,9 +33,21 @@ name: Release (staging, parallel — EXPERIMENTAL)
 # remains the only thing that cuts a staging release. Wire publishing in here only
 # once these timings are trusted.
 #
-# Manual dispatch only, deliberately: this is an experiment, not a release path.
+# Nothing here ever runs on its own: see TRIGGERING below. This is an experiment,
+# not a release path.
 
+# TRIGGERING - a `workflow_dispatch`-only workflow is NOT dispatchable unless the
+# file also exists on the DEFAULT branch, and this one deliberately lives only on
+# `pre-main` (it is an experiment, not a release path). The `push` trigger below is
+# what REGISTERS the workflow with the Actions API so `gh workflow run --ref
+# pre-main` resolves at all - the same reason release-staging.yml carries one.
+#
+# It must never actually build on an ordinary pre-main push, so every job is gated
+# on a manual dispatch or an explicit `[parallel-release-test]` marker commit. An
+# unmarked push creates a run whose jobs all skip, which is enough to register it.
 on:
+  push:
+    branches: [pre-main]
   workflow_dispatch: {}
 
 permissions:
@@ -67,6 +79,10 @@ jobs:
   # silently disagree with each other and with the bundle.
   plan:
     name: Plan (version + SHA)
+    # The gate for the whole workflow: `build` and `bundle` both chain off this
+    # job, so skipping it skips them. Ordinary pre-main pushes register the
+    # workflow and do nothing else.
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[parallel-release-test]') }}
     runs-on: ubuntu-latest
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}


### PR DESCRIPTION
## The bug

The workflow merged in #491 cannot be run. It shipped `workflow_dispatch`-only and lives solely on `pre-main`:

```
$ gh workflow run release-staging-parallel.yml --ref pre-main
HTTP 404: workflow release-staging-parallel.yml not found on the default branch
```

GitHub resolves a dispatch against the **default branch**, so a workflow that never lands on `main` is unreachable regardless of which `--ref` you pass. It doesn't show up in `gh workflow list` either.

My mistake in #491 — I made it dispatch-only for safety and made it unreachable in the process.

## The fix

`release-staging.yml` already solves this: it carries a `push` trigger purely to register itself, and its own comments note dispatch works only "after the first push-triggered run has registered the workflow." Same treatment here.

- `push: branches: [pre-main]` added — registration only.
- The `plan` job is gated on a manual dispatch or an explicit `[parallel-release-test]` marker commit.

`build` and `bundle` both chain off `plan`, so gating that one job skips the whole workflow. An unmarked push to `pre-main` creates a run whose jobs all skip — enough to register it, without ever burning a macOS runner. Identical marker pattern to `release-staging.yml`.

Also corrects a header comment that still claimed "manual dispatch only", which the new trigger contradicts.

## After merging

Merging this **is** the registering push. Dispatch works afterwards:

```
gh workflow run release-staging-parallel.yml --ref pre-main
```

Reminder on what that run does: builds both arches concurrently, lipos, signs, notarizes, reports timings. **It does not publish** and does not touch the `updater-staging` channel.

Expect the first dispatch to need debugging — the artifact round-trip, `semantic-release --dry-run` parsing, and secret propagation into matrix legs have no local equivalent and are untested.