### PR TITLE
fix(integrations): refuse a submitted placeholder over a stored token

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -55,7 +55,7 @@ name: Release (staging)
 # carry ref=pre-main or it would treat the build as `main` and try to cut a STABLE
 # release from pre-main code. The `push` trigger below is what REGISTERS the
 # workflow with the Actions API so `gh workflow run --ref pre-main` resolves at
-# all - the same reason release-staging.yml carries one.
+# all - the same reason release.yml carries one.
 #
 # It must never actually build on an ordinary pre-main push, so every job is gated
 # on a manual dispatch or an explicit `[staging-release]` marker commit. An
@@ -66,8 +66,11 @@ on:
     branches: [pre-main]
   workflow_dispatch: {}
 
+# Least privilege by default: `plan` only reads history, and `build` only
+# compiles and uploads artifacts. Write is granted per-job to the two that
+# actually tag and publish.
 permissions:
-  contents: write       # tags, the versioned prerelease, the rolling updater-staging release
+  contents: read
 
 concurrency:
   # Serialise staging releases: two in flight would fight over the same tags,
@@ -167,7 +170,7 @@ jobs:
       # EVERY value below is baked into the binary at COMPILE time, so each build
       # job needs the full set — a missing one produces no error, just a staging
       # app with (say) sign-in quietly unavailable. Kept byte-identical to
-      # release-staging.yml; see that file for what each one does.
+      # release.yml; see that file for what each one does.
       MERIDIAN_JIRA_OAUTH_CLIENT_SECRET: ${{ secrets.JIRA_OAUTH_CLIENT_SECRET }}
       MERIDIAN_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
       MERIDIAN_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
@@ -218,7 +221,12 @@ jobs:
             "https://github.com/Meridiona/screenpipe-fork"
 
       - name: Stamp the version
-        run: bash scripts/set-version.sh "${{ needs.plan.outputs.version }}"
+        # Bound through `env` rather than interpolated into the shell: the value
+        # traces back to commit messages via semantic-release's output, and
+        # `${{ }}` inside `run:` is the template-injection shape.
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: bash scripts/set-version.sh "$VERSION"
 
       - name: Install UI + tray deps
         # The UI must build before the tray compiles: frontendDist (ui/out) is
@@ -273,6 +281,8 @@ jobs:
     needs: [plan, build]
     if: needs.plan.outputs.release_due == 'true'
     runs-on: macos-26
+    permissions:
+      contents: write     # the tag, the versioned prerelease, updater-staging
     outputs:
       released: ${{ steps.publish.outputs.released }}
       version: ${{ steps.publish.outputs.version }}
@@ -307,7 +317,9 @@ jobs:
       - name: Stamp the version
         # Same value the binaries were built with — tauri.conf.json's version is
         # read at BUNDLE time and becomes what the updater compares against.
-        run: bash scripts/set-version.sh "${{ needs.plan.outputs.version }}"
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: bash scripts/set-version.sh "$VERSION"
 
       - name: Install UI + tray deps, and materialise ui/out
         # `tauri bundle` runs beforeBundleCommand, NOT beforeBuildCommand, so
@@ -369,20 +381,26 @@ jobs:
         # DMG a user downloads trips "can't check it for malicious software".
         # Must precede package-updater.sh: stapling rewrites the file, so the
         # stable-named copy has to be taken afterwards to inherit the ticket.
-        run: bash scripts/notarize-dmg.sh "${{ needs.plan.outputs.version }}"
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: bash scripts/notarize-dmg.sh "$VERSION"
 
       - name: Package the updater artifacts
         # Writes latest.json from the real minisign signature and makes the
         # stable-named Meridian.dmg copy. ALSO the only thing that reads
         # tray/minimum-version and stamps `Minimum-Version:` into the manifest
         # notes — skip it and the forced-update floor silently stops shipping.
-        run: bash scripts/package-updater.sh "${{ needs.plan.outputs.version }}"
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: bash scripts/package-updater.sh "$VERSION"
 
       - name: Verify the release bundle
         # Independently re-checks signing, notarization, stapling and the
         # presence of the updater artifacts. A non-zero exit here aborts before
         # the tag exists and before anything is published.
-        run: bash scripts/verify-release-bundle.sh "${{ needs.plan.outputs.version }}"
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: bash scripts/verify-release-bundle.sh "$VERSION"
 
       - name: Install release tooling
         run: npm ci --no-audit --no-fund
@@ -459,6 +477,8 @@ jobs:
     needs: release
     if: needs.release.outputs.released == 'true'
     runs-on: windows-latest
+    permissions:
+      contents: write     # uploads the installer + merged manifest
     env:
       SQLX_OFFLINE: "true"
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"

--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -180,9 +180,19 @@ fn missing_required(
         .unwrap_or(&[])
         .iter()
         .copied()
-        .filter(|k| {
-            let submitted = updates.get(*k).is_some_and(|v| value_is_set(v));
-            !submitted && !is_set(existing, k)
+        .filter(|k| match updates.get(*k) {
+            // Submitted: judge the payload's value, and ONLY that. Falling back
+            // to `.env` here is what let a submitted placeholder pass — it was
+            // not "set", but the valid token already on disk satisfied the
+            // check, and `upsert_env` then wrote the placeholder over it,
+            // destroying working credentials. A submitted placeholder must fail
+            // the required-field check so the write never happens.
+            Some(v) => !value_is_set(v),
+            // Not submitted: the write leaves whatever `.env` holds, so that is
+            // what the check judges. This is the case the GitHub project picker
+            // depends on — it submits only `project_ids` on top of a token its
+            // OAuth device flow already wrote.
+            None => !is_set(existing, k),
         })
         .collect()
 }
@@ -452,10 +462,11 @@ pub async fn save_integration_token(body: SaveTokenBody) -> Result<serde_json::V
     // Read through `detect_install_mode().env_path()`, the same resolver
     // `discover_github_projects` reads the token with, so the check and the call
     // that proves the token exists can never disagree about which file is live.
-    let existing = crate::install::detect_install_mode()
-        .env_path()
-        .map(parse_env)
-        .unwrap_or_default();
+    // Resolved ONCE and reused for the write below: `detect_install_mode` does
+    // synchronous filesystem probing, and this is an async command, so calling
+    // it twice stalls the reactor twice for the same answer.
+    let mode = crate::install::detect_install_mode();
+    let existing = mode.env_path().map(parse_env).unwrap_or_default();
     let missing = missing_required(provider, &updates, &existing);
     if !missing.is_empty() {
         return Err(format!("Missing: {}", missing.join(", ")));
@@ -481,7 +492,6 @@ pub async fn save_integration_token(body: SaveTokenBody) -> Result<serde_json::V
     // blocking thread pool so we don't stall the Tokio reactor.
     let key_count = updates.len();
     {
-        let mode = crate::install::detect_install_mode();
         // On a fresh `.app` install no `.env` exists yet, so `detect_install_mode`
         // returns `Bare` (no path). Credentials must be saveable before any `.env`
         // exists — default to the canonical `~/.meridian/.env`, which `upsert_env`
@@ -1287,6 +1297,22 @@ mod tests {
             "github",
             &updates(&[("GITHUB_TOKEN", "your-token-here")]),
             &env_of(&[]),
+        );
+        assert_eq!(missing, vec!["GITHUB_TOKEN"]);
+    }
+
+    /// The destructive case the sibling test above does NOT cover: it passes an
+    /// EMPTY `.env`, so it held under the old logic too. With a valid token
+    /// already on disk, falling back to `.env` for a key that WAS submitted let
+    /// the placeholder through the check — and `upsert_env` then wrote it over
+    /// the working credential. A submitted placeholder must be refused whether
+    /// or not something valid is already stored.
+    #[test]
+    fn a_submitted_placeholder_cannot_overwrite_a_stored_token() {
+        let missing = missing_required(
+            "github",
+            &updates(&[("GITHUB_TOKEN", "your-token-here")]),
+            &env_of(&[("GITHUB_TOKEN", "ghp_valid_and_working")]),
         );
         assert_eq!(missing, vec!["GITHUB_TOKEN"]);
     }


### PR DESCRIPTION
Resolves the review comments left on #495. Opened against `pre-main` because #495's head **is** `pre-main` - commits cannot be pushed onto it directly, so the fixes land here and flow into that promotion.

## The one that matters: credential corruption

`missing_required` judged a submitted key by falling back to what `.env` already held. A placeholder like `your-token-here` is not "set", but a valid token on disk satisfied the requirement - so validation passed, and since `upsert_env` writes every submitted key verbatim, the placeholder landed **on top of the working credential**.

```rust
// before - `existing` rescues a key the payload got wrong
let submitted = updates.get(*k).is_some_and(|v| value_is_set(v));
!submitted && !is_set(existing, k)
```

The check now judges the payload's value and only that when a key is submitted, and consults `.env` only when the key is absent. That fallback is exactly what the GitHub project picker from #493 needs (it submits `project_ids` alone on top of an OAuth-written token), so it is preserved for that case and no other.

**The existing test could not have caught this** - `a_submitted_placeholder_token_is_refused_like_a_stored_one` passes an empty `.env`, so it held under the old logic too. The new test supplies a valid stored token and **fails without the fix** (verified by reverting the logic and re-running).

## Also fixed

- **`detect_install_mode` called twice per save.** Synchronous filesystem probing, twice, for the same answer, in an async command. Resolved once and reused.
- **Self-referential workflow comments.** The parallel-build fold left two comments naming `release-staging.yml` *from inside* `release-staging.yml`; both meant `release.yml`. My copy-paste artifact.
- **Blanket `contents: write`** on the staging workflow narrowed to the two jobs that tag and publish. `plan` reads history; `build` compiles and uploads artifacts - neither needs write.
- **Version bound through `env`** rather than interpolated into `run:` shells. It traces back to commit messages via semantic-release's output, which is the template-injection shape.

## Not taken, with reasons

- **Pinning `dtolnay/rust-toolchain@master` to a SHA.** It is used in **all seven** places across every workflow in the repo. Pinning one file would be inconsistent rather than safer. Worth doing repo-wide, in its own change - the review framed this as an existing repo policy, but nothing in `.github/workflows/` is pinned today.
- **Loosening the placeholder heuristic.** `value_is_set` rejects anything containing `your-`, `_your_` or `-here`, which can in principle reject a valid Jira URL. But the failing examples are contrived, and tightening the rule is a product judgement about what a real credential looks like - not something to decide inside a review-fix PR. Worth its own issue if a user ever hits it.

## Verified

- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] 16 integrations tests pass (15 before)
- [x] New test fails without the fix, passes with it
- [x] Workflow YAML parses; permissions are `read` at top, `write` on `release` + `windows-release` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)