### PR TITLE
ci(release): let the staging build actually keep its cache

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -197,12 +197,20 @@ jobs:
           # so without it both arches would compute the same cache key and
           # clobber each other's target/ on save.
           key: ${{ matrix.target }}
-          # Restore-only, deliberately. Two per-arch target/ caches would add
-          # ~4GB to a repo already at its 10GB quota (see #488, merged
-          # specifically to get back under it) and would evict release.yml's
-          # cache. Worth revisiting once the quota has headroom — saving here is
-          # the remaining easy win on top of the parallel split.
-          save-if: "false"
+          # SAVE, on pre-main only. Restore-only was the original call, to stay
+          # under the repo's 10GB cache quota (see #488) — but restore-only
+          # against a key NOTHING writes is a permanent miss, not a saving. Every
+          # staging build logged "No cache found." and recompiled the workspace
+          # cold: 19m19s for the arm64 tray on run 29734394528.
+          #
+          # The quota objection is also stale. Retiring the sequential staging
+          # build (#494) orphaned its two 2.4GB `rust-macos-universal` caches, one
+          # per branch — roughly exactly the room the two per-arch caches need.
+          #
+          # Scoped to pre-main so a feature branch cannot evict the release
+          # cache: GitHub isolates caches per branch on READ but not on write
+          # eviction, and only pre-main ever cuts a staging release.
+          save-if: ${{ github.ref == 'refs/heads/pre-main' }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## The finding

Every staging build has been compiling the workspace **cold**. Run `29734394528` logged `No cache found.` on both arches:

| step | aarch64 | x86_64 |
|---|---|---|
| rust-cache restore | **0m (miss)** | **0m (miss)** |
| Build daemon | 7.8m | 4.8m |
| Compile tray | **19.3m** | **13.7m** |

## Why it could never hit

The build jobs are restore-only (`save-if: "false"`) against a cache key scoped to `${{ matrix.target }}` - **a key nothing in the repo ever writes**. Restore-only against a key nobody saves is a permanent miss, not a saving. It paid the lookup on every run and got nothing back.

This was my call in #494 and it was wrong. The comment justified it as staying under the repo's 10GB cache quota, which was a real constraint - but restore-only does not economise on a cache that does not exist. The two options were "save and use the quota" or "drop the cache step"; what shipped was the cost of both with the benefit of neither.

## Why the quota objection is now stale

The repo sits at **9.8 GB of 10 GB**, and the two largest entries are:

```
2.4GB  refs/heads/main      v0-rust-macos-universal-Darwin-arm64-...
2.4GB  refs/heads/pre-main  v0-rust-macos-universal-Darwin-arm64-...
```

Those are the caches of the **sequential** staging build - the one #494 replaced. Nothing writes or reads them anymore. That is ~4.8 GB of dead weight, roughly exactly the room two per-arch caches need. GitHub evicts LRU once over quota, so they age out without intervention; I have not deleted them by hand.

## The change

```yaml
save-if: ${{ github.ref == 'refs/heads/pre-main' }}
```

Scoped to `pre-main` rather than unconditional: GitHub isolates caches per branch on **read** but not on write eviction, and only `pre-main` ever cuts a staging release - a feature branch has no business evicting the release cache.

## Expected effect

The first run after merge still compiles cold and populates the cache; the benefit starts on the second. A warm Rust cache typically avoids recompiling unchanged dependencies, which is most of that 19m - but I would rather report the measured number after two runs than promise one here.

## Not included

Splitting the daemon into its own job (it costs 4.8-7.8m ahead of the tray compile, and `tauri-build` only *stats* `bundle.resources` at compile time, so the tray could start against a placeholder). That is a real further win but a bigger restructure with a real risk - shipping a bundle whose nested daemon is the placeholder. Worth measuring against a warm cache first; the daemon build may be cheap enough afterwards that the moving parts are not worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)