### PR TITLE
feat: redesigned AI provider picker + hardened Cursor integration

### DIFF
--- a/meridian-core/src/lib.rs
+++ b/meridian-core/src/lib.rs
@@ -68,7 +68,7 @@ pub use readers::{
 
 pub use canonical_task::{CanonicalTask, PersonRef, Priority, Provider, StatusCategory, TaskKind};
 
-pub use llm_provider::LlmProvider;
+pub use llm_provider::{LlmProvider, CURSOR_CLI_VERSION, CURSOR_INSTALL_CMD};
 /// The custom-endpoint registry types. `CustomLlmProvider` carries the API key and is the
 /// STORAGE form — see its docs before serialising one anywhere.
 pub use settings::{CustomLlmProvider, SchemaRung};

--- a/meridian-core/src/llm_provider.rs
+++ b/meridian-core/src/llm_provider.rs
@@ -140,6 +140,82 @@ impl LlmProvider {
             LlmProvider::Custom => None,
         }
     }
+
+    /// The shell command that installs this provider's CLI, or `None` when there is nothing
+    /// to install ([`LlmProvider::Custom`] is a cloud endpoint, not a binary).
+    ///
+    /// Cursor's is PINNED - see [`CURSOR_CLI_VERSION`].
+    ///
+    /// This is the SAME command the UI shows as its `installHint` (`ui/lib/llm-providers.ts`)
+    /// — kept here as the authoritative copy because the tray now runs it on the user's behalf
+    /// (`crate::llm::detect::install_provider` in the daemon crate). The strings are fixed
+    /// literals, never interpolated with user input, so running them through a login shell is
+    /// safe. Each is the vendor's own official, non-interactive installer.
+    pub fn install_command(self) -> Option<&'static str> {
+        match self {
+            LlmProvider::Claude => Some("npm i -g @anthropic-ai/claude-code"),
+            LlmProvider::Codex => Some("npm i -g @openai/codex"),
+            LlmProvider::Cursor => Some(CURSOR_INSTALL_CMD),
+            LlmProvider::Copilot => Some("npm i -g @github/copilot"),
+            LlmProvider::Custom => None,
+        }
+    }
+}
+
+/// The cursor-agent build Meridian installs and supports.
+///
+/// PINNED DELIBERATELY. `https://cursor.com/install` is a ROLLING script - it hardcodes
+/// whatever build is current when you fetch it, with no version flag or env var. Two
+/// reasons we don't want that:
+///
+/// 1. `crate::llm::cursor` depends on `--allowed-tools`, which is **undocumented**
+///    ("internal only", hidden from `--help`). An unpinned upgrade could drop it
+///    silently. (The backend degrades gracefully if that happens, but a pin means it
+///    doesn't happen unattended in the first place.)
+/// 2. Reproducibility: every user gets the build this was tested against, not whatever
+///    shipped that morning.
+///
+/// This value is the build all of the flag behaviour was verified on. To move it: bump
+/// this constant, re-run the cursor smoke tests, and confirm `--allowed-tools`,
+/// `--workspace` and `--mode ask` still behave.
+pub const CURSOR_CLI_VERSION: &str = "2026.07.16-899851b";
+
+/// Cursor's official installer, rewritten to install [`CURSOR_CLI_VERSION`].
+///
+/// The `sed` rewrites every version string in their script (all 5 occurrences: the temp
+/// dir, the `downloads.cursor.com/lab/<v>/<os>/<arch>/agent-cli-package.tar.gz` URL, the
+/// final dir, and both symlinks) to the pinned build. Matching the version by PATTERN
+/// rather than by literal is what makes this survive Cursor bumping their script - a
+/// literal `s/<old>/<new>/` would silently become a no-op the day they publish a new
+/// build, handing the user "latest" again, which is the exact failure being avoided.
+///
+/// Reusing their script (rather than hand-rolling a download) keeps their OS/arch
+/// detection, symlink layout and PATH guidance. Fixed literal, no user input.
+pub const CURSOR_INSTALL_CMD: &str = concat!(
+    "curl -fsSL https://cursor.com/install | ",
+    "sed -E 's#[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}-[0-9a-f]{7}#",
+    "2026.07.16-899851b",
+    "#g' | bash"
+);
+
+#[cfg(test)]
+mod install_pin_tests {
+    use super::*;
+
+    /// The pin must actually appear in the command, and the constant must stay the single
+    /// source of truth (`concat!` can't interpolate, so the two are pinned together here).
+    #[test]
+    fn cursor_install_command_is_pinned_to_the_supported_version() {
+        assert!(CURSOR_INSTALL_CMD.contains(CURSOR_CLI_VERSION));
+        // Pattern-based rewrite, not a literal old->new swap: a literal would no-op once
+        // Cursor publishes a new build and silently install latest.
+        assert!(CURSOR_INSTALL_CMD.contains("[0-9]{4}"));
+        assert!(CURSOR_INSTALL_CMD.contains("sed -E"));
+        assert_eq!(
+            LlmProvider::Cursor.install_command(),
+            Some(CURSOR_INSTALL_CMD)
+        );
+    }
 }
 
 #[cfg(test)]
@@ -212,5 +288,16 @@ mod tests {
             assert!(p.cli_name().is_some(), "{p:?}");
         }
         assert!(LlmProvider::Custom.cli_name().is_none());
+    }
+
+    /// Every built-in CLI provider has an installer; `Custom` (a cloud endpoint) does not.
+    /// The tray runs these on the user's behalf, so a missing one would leave a card with an
+    /// Install button that can't work.
+    #[test]
+    fn every_builtin_has_an_install_command() {
+        for p in LlmProvider::builtins() {
+            assert!(p.install_command().is_some(), "{p:?}");
+        }
+        assert!(LlmProvider::Custom.install_command().is_none());
     }
 }

--- a/meridian-core/src/llm_provider.rs
+++ b/meridian-core/src/llm_provider.rs
@@ -160,6 +160,21 @@ impl LlmProvider {
             LlmProvider::Custom => None,
         }
     }
+
+    /// The exact CLI build [`Self::install_command`] is supposed to produce, when this provider
+    /// is version-pinned.
+    ///
+    /// Only Cursor pins today, because its installer is a rolling script with no version flag
+    /// and the pin is applied by rewriting it (see [`CURSOR_INSTALL_CMD`]) - a mechanism that
+    /// fails OPEN. Returning the expectation here lets the installer verify that the rewrite
+    /// actually took effect rather than assuming it did. The other CLIs install a named npm
+    /// version range and need no such check.
+    pub fn pinned_cli_version(self) -> Option<&'static str> {
+        match self {
+            LlmProvider::Cursor => Some(CURSOR_CLI_VERSION),
+            _ => None,
+        }
+    }
 }
 
 /// The cursor-agent build Meridian installs and supports.

--- a/src/coding_agent_session_ingest/cursor_agent_init.rs
+++ b/src/coding_agent_session_ingest/cursor_agent_init.rs
@@ -111,12 +111,18 @@ fn auto_install_enabled() -> bool {
 /// Install cursor-agent via the official installer script (opt-in only — see
 /// `auto_install_enabled`). Runs once per daemon lifetime (cached by
 /// ensure_ready).
+///
+/// Uses the PINNED installer ([`meridian_core::CURSOR_INSTALL_CMD`]) — the same command
+/// the tray's "Install" button runs — so an unattended daemon install can never pull a
+/// newer cursor-agent than the build this code was verified against.
 async fn try_auto_install() -> anyhow::Result<PathBuf> {
-    tracing::info!("running cursor-agent installer: curl https://cursor.com/install -fsS | bash");
+    let cmd = meridian_core::CURSOR_INSTALL_CMD;
+    tracing::info!(
+        version = meridian_core::CURSOR_CLI_VERSION,
+        "running pinned cursor-agent installer"
+    );
     let output = run_with_timeout(
-        Command::new("bash")
-            .arg("-c")
-            .arg("curl https://cursor.com/install -fsS | bash"),
+        Command::new("bash").arg("-c").arg(cmd),
         INSTALL_TIMEOUT,
         "cursor-agent install",
     )

--- a/src/coding_agent_session_ingest/sources/mod.rs
+++ b/src/coding_agent_session_ingest/sources/mod.rs
@@ -183,14 +183,16 @@ pub async fn sweep(pool: &SqlitePool, now: DateTime<Utc>) -> (u64, u64) {
             if !has_new_turns(&records, endpoints.get(&uuid).map(String::as_str)) {
                 continue;
             }
-            // Circular-dependency cut: a summariser engine that persists its
-            // own sessions into the store it is summarised FROM (cursor-agent
-            // is unprobed; future engines may) would otherwise loop —
-            // summarise → new session → ingest → summarise. Any conversation
-            // opening with our own summary prompt is a summariser artifact,
-            // never developer activity. Applies to every source uniformly.
-            if is_summariser_artifact(&records) {
-                tracing::info!(agent, uuid = %uuid, "skipping summariser-artifact session");
+            // Circular-dependency cut: cursor-agent has no way to skip session
+            // persistence, so every Meridian call it makes (coding-agent
+            // summaries AND every other AI process when Cursor is the selected
+            // provider) persists a chat into the store we ingest FROM —
+            // otherwise looping summarise/answer → new session → ingest →
+            // summarise. Any conversation opening with one of our own markers is
+            // a Meridian artifact, never developer activity. Applies to every
+            // source uniformly.
+            if is_meridian_artifact(&records) {
+                tracing::info!(agent, uuid = %uuid, "skipping meridian-issued session");
                 continue;
             }
             // An explicit end-of-session marker AFTER the last turn (Copilot
@@ -228,15 +230,19 @@ fn session_ended(records: &[NormRecord]) -> bool {
         .any(|r| r.is_session_end)
 }
 
-/// True iff the conversation was started by the summariser itself: the first
-/// user prompt carries the summary-prompt fingerprint. Such sessions are the
-/// engine's own runs, not developer activity — ingesting them would loop.
-fn is_summariser_artifact(records: &[NormRecord]) -> bool {
+/// True iff the conversation was started by Meridian itself: the first user
+/// prompt carries one of our fingerprints — the coding-agent summary prompt
+/// (`SUMMARY_PROMPT_MARKER`) or the general AI-process marker every
+/// `cursor-agent` call stamps (`llm::MERIDIAN_PROMPT_MARKER`, since Cursor can't
+/// skip session persistence). Such sessions are our own runs, not developer
+/// activity — ingesting them would loop.
+fn is_meridian_artifact(records: &[NormRecord]) -> bool {
     use crate::coding_agent_session_ingest::summariser::prompts::SUMMARY_PROMPT_MARKER;
+    use crate::llm::MERIDIAN_PROMPT_MARKER;
     records
         .iter()
         .find(|r| r.is_user_prompt)
-        .map(|r| r.body.contains(SUMMARY_PROMPT_MARKER))
+        .map(|r| r.body.contains(SUMMARY_PROMPT_MARKER) || r.body.contains(MERIDIAN_PROMPT_MARKER))
         .unwrap_or(false)
 }
 
@@ -368,7 +374,7 @@ mod tests {
     }
 
     #[test]
-    fn summariser_artifact_sessions_are_detected() {
+    fn meridian_artifact_sessions_are_detected() {
         use crate::coding_agent_session_ingest::summariser::prompts;
 
         let prompt_rec = |body: &str| NormRecord {
@@ -385,21 +391,31 @@ mod tests {
         // whether the marker leads (codex style) or is prefixed by the
         // skill preamble (cursor-agent embeds the instruction mid-prompt).
         let own = vec![prompt_rec(&prompts::summary_instruction())];
-        assert!(is_summariser_artifact(&own));
+        assert!(is_meridian_artifact(&own));
         let embedded = vec![prompt_rec(&format!(
             "{} Summarise the coding-session transcript below.\n\n[transcript]",
             prompts::summary_instruction()
         ))];
-        assert!(is_summariser_artifact(&embedded));
+        assert!(is_meridian_artifact(&embedded));
+
+        // Every OTHER AI process routed through Cursor (worklog, classify,
+        // propose, distil) carries the general marker instead — cursor-agent
+        // can't skip session persistence, so those chats land in the store we
+        // ingest from and must be dropped just the same.
+        let general = vec![prompt_rec(&format!(
+            "{}\nDraft a worklog for the hour.\n\n[activity]",
+            crate::llm::MERIDIAN_PROMPT_MARKER
+        ))];
+        assert!(is_meridian_artifact(&general));
 
         // A developer merely DISCUSSING the summariser prompt in a later turn
         // is not an artifact — only the FIRST user prompt is fingerprinted.
         let mut discussion = vec![prompt_rec("why does the summariser loop?")];
         discussion.push(prompt_rec(&prompts::summary_instruction()));
-        assert!(!is_summariser_artifact(&discussion));
+        assert!(!is_meridian_artifact(&discussion));
 
         // Ordinary sessions pass through.
-        assert!(!is_summariser_artifact(&[prompt_rec("fix the login bug")]));
-        assert!(!is_summariser_artifact(&[]));
+        assert!(!is_meridian_artifact(&[prompt_rec("fix the login bug")]));
+        assert!(!is_meridian_artifact(&[]));
     }
 }

--- a/src/coding_agent_session_ingest/summariser/README.md
+++ b/src/coding_agent_session_ingest/summariser/README.md
@@ -15,7 +15,9 @@ and sharper. The summary is also what the Jira updater quotes as evidence.
 
 One transcript in flight at a time (sequential → flat memory, no rate-limit
 bursts). **Each agent's transcripts go to its own CLI** (routed on the row's
-`app_name`); there is **no cross-engine fallback**:
+`app_name`). There is **no cross-engine fallback** — the only substitute is the
+user's own globally chosen AI provider, and only once the agent's CLI is
+permanently unable to answer:
 
 ```
 Codex session          ──▶  codex exec    ─┐
@@ -23,10 +25,16 @@ GitHub Copilot session ──▶  copilot -p    ─┤
 Cursor Agent session   ──▶  cursor-agent  ─┼─ try that agent's CLI up to `primary_attempts` (2) times
 else (Claude/unknown)  ──▶  claude -p     ─┘        │
                                                      ├─ rate-limited?  ──▶  leave row pending, back off this source
-                                                     └─ all attempts failed?  ──▶  leave row pending, retry next drain
-                                                                                   │
+                                                     │                      (a quota refills — wait it out, never route around)
+                                                     └─ all attempts failed?  ──▶  the global AI provider, once (`fallback.rs`)
+                                                                                   │   (skipped without a call when it IS that same CLI)
+                                                                                   └─ still nothing?  ──▶  leave row pending, retry next drain
                                             (a row that fails MAX_ROW_ATTEMPTS drains is dead-lettered)
 ```
+
+A fallback summary is recorded as `summary_source = "fallback:<provider>"`, so a
+summary written by a substitute is never mistaken for one the agent that did the
+work produced.
 
 - **Claude sessions → `claude -p`** (`claude.rs`) — loads the `session-summary`
   skill, structured output. Runs on the user's Claude subscription;

--- a/src/coding_agent_session_ingest/summariser/cursor_agent.rs
+++ b/src/coding_agent_session_ingest/summariser/cursor_agent.rs
@@ -23,6 +23,18 @@ use super::{cap_transcript, run_capture, EngineOutput, SummariserError};
 /// Linux would cap a single string at 128 KiB).
 const ARG_TRANSCRIPT_CAP: usize = 180_000;
 
+/// Lets `cursor_cli::run_hardened` classify our failures. Mirrors the provider backend's impl
+/// for `LlmError`: a `Failed` may name a degradable cause, a `RateLimited` never does - Cursor
+/// limits are account-level, so degrading and retrying would spend quota to hit the same wall.
+impl crate::llm::cursor_cli::CursorCallError for SummariserError {
+    fn degradable_message(&self) -> Option<&str> {
+        match self {
+            SummariserError::Failed(m) => Some(m),
+            SummariserError::RateLimited(_) => None,
+        }
+    }
+}
+
 pub async fn run_cursor_agent(
     stdin_text: &str,
     cfg: &SummariserConfig,
@@ -54,19 +66,33 @@ pub async fn run_cursor_agent(
     } else {
         cfg.cursor_model.as_str()
     };
-    let mut args: Vec<String> = vec!["-p".into(), prompt];
-    args.extend(["--output-format".into(), "text".into()]);
-    args.extend(crate::llm::cursor_cli::safety_args(model, true));
+    // The degradation ladder comes from `cursor_cli` too, not just the flags. Passing the
+    // undocumented `--allowed-tools` with no way to retry without it would mean that the day
+    // Cursor drops the flag, the provider backend degrades gracefully while EVERY coding-agent
+    // summary fails - the same drift this shared module exists to prevent, one level up.
+    crate::llm::cursor_cli::run_hardened(model, |safety, env| run_once(&prompt, safety, env, cfg))
+        .await
+}
 
-    let sandbox = crate::llm::cursor_cli::sandbox_home();
-    let env = crate::llm::cursor_cli::env_overrides(sandbox.as_deref());
+/// One `cursor-agent` attempt with the safety argv/environment chosen by the ladder.
+async fn run_once(
+    prompt: &str,
+    safety: Vec<String>,
+    env: Vec<(&'static str, String)>,
+    cfg: &SummariserConfig,
+) -> Result<EngineOutput, SummariserError> {
+    let mut args: Vec<String> = vec!["-p".into(), prompt.to_string()];
+    args.extend(["--output-format".into(), "text".into()]);
+    args.extend(safety);
+
     let env_refs: Vec<(&str, &str)> = env.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
     let cap = run_capture(
         "cursor-agent",
         &args,
         "", // transcript is embedded in the prompt (stdin support unprobed)
-        &cfg.meridian_home,
+        // See the note in llm/cursor.rs: a cwd outside $HOME so rule discovery cannot regress.
+        &crate::llm::cursor_cli::neutral_workspace(),
         cfg.cursor_timeout_s,
         &env_refs,
         crate::llm::cursor_cli::ENV_REMOVE,

--- a/src/coding_agent_session_ingest/summariser/cursor_agent.rs
+++ b/src/coding_agent_session_ingest/summariser/cursor_agent.rs
@@ -2,11 +2,14 @@
 //
 // Run `cursor-agent` to summarise a Cursor session (symmetry with claude.rs /
 // codex.rs / copilot.rs — each agent's transcripts go to its own CLI, with no
-// cross-engine fallback). Flags pinned against cursor-agent 2026.06.04 live:
-// `-p --output-format text --trust` (without --trust headless runs die with
-// "Workspace Trust Required"). The transcript rides in the prompt argument,
-// and any failure leaves the row pending for a later drain (Failed → retried up
-// to primary_attempts, then left pending).
+// cross-engine fallback). The transcript rides in the prompt argument, and any
+// failure leaves the row pending for a later drain (Failed → retried up to
+// primary_attempts, then left pending).
+//
+// Only `-p --output-format text` is decided here; every safety flag, the
+// environment and the skills-free sandbox HOME come from `llm::cursor_cli`, so
+// this path and the LLM-provider backend cannot diverge. See that module for
+// why each lever exists.
 // Persistence probed: `-p` runs write to ~/.cursor/chats/, NOT the vscdb we
 // ingest from — so a summariser run cannot re-enter the indexer (the
 // SUMMARY_PROMPT_MARKER guard in sources/mod.rs backstops this anyway).
@@ -39,21 +42,25 @@ pub async fn run_cursor_agent(
         prompts::summary_instruction(),
         cap_transcript(stdin_text, ARG_TRANSCRIPT_CAP),
     );
-    // --trust: cursor-agent refuses untrusted workspaces even in print mode
-    // ("Workspace Trust Required", exit 1 — observed live 2026-06-06 running
-    // under cfg.meridian_home). Trusting is safe here: the prompt is our own
-    // summary instruction, not repo code execution.
-    let mut args: Vec<String> = vec![
-        "-p".into(),
-        prompt,
-        "--output-format".into(),
-        "text".into(),
-        "--trust".into(),
-    ];
-    if !cfg.cursor_model.is_empty() {
-        args.push("--model".into());
-        args.push(cfg.cursor_model.clone());
-    }
+    // Safety flags, environment and the skills-free sandbox HOME all come from
+    // `llm::cursor_cli` — the single source of truth shared with the LLM-provider backend. This
+    // call site used to build its own argv, which meant it summarised UNTRUSTED transcripts with
+    // cursor-agent's default full write+shell tool access; routing through the shared helper is
+    // what closes that gap and keeps the two sites from drifting again.
+    let model = if cfg.cursor_model.is_empty() {
+        // Follow the account default here rather than pinning: the summariser predates the
+        // provider layer and has its own configured model, so an empty value means "unset".
+        "auto"
+    } else {
+        cfg.cursor_model.as_str()
+    };
+    let mut args: Vec<String> = vec!["-p".into(), prompt];
+    args.extend(["--output-format".into(), "text".into()]);
+    args.extend(crate::llm::cursor_cli::safety_args(model, true));
+
+    let sandbox = crate::llm::cursor_cli::sandbox_home();
+    let env = crate::llm::cursor_cli::env_overrides(sandbox.as_deref());
+    let env_refs: Vec<(&str, &str)> = env.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
     let cap = run_capture(
         "cursor-agent",
@@ -61,8 +68,8 @@ pub async fn run_cursor_agent(
         "", // transcript is embedded in the prompt (stdin support unprobed)
         &cfg.meridian_home,
         cfg.cursor_timeout_s,
-        &[("MERIDIAN_SUMMARISER", "1")],
-        &[],
+        &env_refs,
+        crate::llm::cursor_cli::ENV_REMOVE,
     )
     .await?;
 

--- a/src/coding_agent_session_ingest/summariser/fallback.rs
+++ b/src/coding_agent_session_ingest/summariser/fallback.rs
@@ -1,0 +1,139 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Last-resort summarisation via the user's globally chosen AI provider.
+//!
+//! # The rule this implements
+//!
+//! A coding-agent transcript is summarised by **its own CLI** - a Codex session by `codex`,
+//! a Cursor session by `cursor-agent`. That agent already holds the context and its
+//! subscription is already paid for, so it is always tried first, `primary_attempts` times.
+//!
+//! This module is what happens *after* those attempts are exhausted: rather than leaving
+//! the row to be dead-lettered, the segment is summarised by whatever provider the user
+//! picked in Settings ([`crate::llm::resolver`]). Usually that is the same CLI, in which
+//! case we do not call at all (see [`try_summarise`]) - but it need not be, and when it
+//! differs it is the difference between a summarised hour and a lost one.
+//!
+//! # A rate limit is NOT a permanent failure
+//!
+//! This is the load-bearing distinction. A quota that refused us will refill, so a
+//! rate-limited primary must be *waited out*, never routed around: the caller breaks out
+//! before reaching this module, backs the source off, and retries on a later tick. Only a
+//! `Failed` primary - crashed, not installed, signed out, subscription ended, output
+//! unusable - reaches here, and only after every retry is spent. Falling back on a rate
+//! limit would spend a second subscription's quota to dodge a wait of minutes, and would
+//! silently attribute the work to a provider whose turn it was not.
+//!
+//! # Related
+//! - [`super::summarise_one`] - the caller; owns the primary attempt loop and the ordering
+//! - [`crate::llm::resolver::complete`] - the global provider call, with its own retry and
+//!   rate-limit backoff (this module adds none of its own)
+
+use crate::llm::{LlmError, LlmProvider, PromptRequest};
+
+use super::{prompts, Source, SummariserError};
+
+/// Which provider a primary engine corresponds to, so an identical fallback can be skipped.
+///
+/// The two vocabularies were deliberately kept in sync (see [`LlmProvider`]'s wire forms),
+/// and this is the one place that bridges them.
+fn provider_of(source: Source) -> Option<LlmProvider> {
+    match source {
+        Source::Claude => Some(LlmProvider::Claude),
+        Source::Codex => Some(LlmProvider::Codex),
+        Source::Copilot => Some(LlmProvider::Copilot),
+        Source::CursorAgent => Some(LlmProvider::Cursor),
+        Source::Mlx | Source::None | Source::Fallback(_) => None,
+    }
+}
+
+/// Summarise `prompt` with the user's globally chosen provider.
+///
+/// Returns `Ok(None)` - not an error - when the chosen provider IS the engine that just
+/// failed. Re-running the same CLI a third time would fail the same way; the row is better
+/// left pending for a tick when that CLI is healthy again.
+///
+/// `label` is the trace label (the session uuid), never the model.
+#[tracing::instrument(skip(prompt), fields(primary = primary.as_str(), provider = tracing::field::Empty))]
+pub async fn try_summarise(
+    prompt: &str,
+    label: &str,
+    primary: Source,
+) -> Result<Option<(String, LlmProvider)>, SummariserError> {
+    let chosen = crate::llm::resolver::chosen_provider();
+    tracing::Span::current().record("provider", chosen.as_str());
+
+    if provider_of(primary) == Some(chosen) {
+        tracing::debug!(
+            provider = chosen.as_str(),
+            "summariser fallback skipped - the global provider is the engine that just failed"
+        );
+        return Ok(None);
+    }
+
+    tracing::info!(
+        provider = chosen.as_str(),
+        primary = primary.as_str(),
+        "summariser falling back to the global AI provider - the session's own CLI failed every attempt"
+    );
+
+    let mut req = PromptRequest::new(
+        prompts::SUMMARY_RULES,
+        prompt.to_string(),
+        label.to_string(),
+    );
+    // Schema-capable backends (claude/codex) enforce it; the rest carry it in the prompt and
+    // `extract_summary` unwraps whichever shape comes back.
+    if let Ok(schema) = serde_json::from_str(&prompts::summary_schema_json()) {
+        req = req.with_schema(schema);
+    }
+
+    match crate::llm::resolver::complete(&req).await {
+        Ok((out, provider)) => {
+            let summary = prompts::extract_summary(&out.text);
+            if summary.is_empty() {
+                return Err(SummariserError::Failed(format!(
+                    "{} fallback returned no usable summary",
+                    provider.as_str()
+                )));
+            }
+            Ok(Some((summary, provider)))
+        }
+        // Surfaced as `Failed`, deliberately: the caller's `rate_limited` flag drives the
+        // per-AGENT-SOURCE backoff, and the fallback provider is a different account
+        // entirely. Parking the agent's own queue because a substitute ran out of quota
+        // would punish the wrong subscription. The provider-level backoff inside
+        // `resolver::complete` already stops us dialling it again until it resets.
+        Err(LlmError::RateLimited { message, .. }) => Err(SummariserError::Failed(format!(
+            "{} fallback rate-limited: {message}",
+            chosen.as_str()
+        ))),
+        Err(e) => Err(SummariserError::Failed(format!(
+            "{} fallback failed: {e}",
+            chosen.as_str()
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_primary_engine_maps_to_its_provider() {
+        // The skip check is only correct if this mapping is total over the real engines -
+        // a missing arm would silently re-run the CLI that just failed.
+        assert_eq!(provider_of(Source::Claude), Some(LlmProvider::Claude));
+        assert_eq!(provider_of(Source::Codex), Some(LlmProvider::Codex));
+        assert_eq!(provider_of(Source::Copilot), Some(LlmProvider::Copilot));
+        assert_eq!(provider_of(Source::CursorAgent), Some(LlmProvider::Cursor));
+    }
+
+    #[test]
+    fn non_engine_sources_have_no_provider() {
+        // `None` here means "never skip", which is the safe direction: these are not
+        // engines that could have just failed.
+        assert_eq!(provider_of(Source::None), None);
+        assert_eq!(provider_of(Source::Mlx), None);
+        assert_eq!(provider_of(Source::Fallback(LlmProvider::Claude)), None);
+    }
+}

--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -6,12 +6,21 @@
 //
 // Engine routing per segment: Codex sessions → `codex exec`, else → `claude -p`
 // (both Rust subprocesses on the user's subscription). Each engine is tried up to
-// `primary_attempts` times; a rate-limit short-circuits. There is no fallback
-// engine — the local MLX server used to catch every failure here, and with it
-// deprecated a row its own agent cannot summarise stays pending and is retried
-// on later ticks, then dead-lettered to 'subprocess_error' after
-// MAX_ROW_ATTEMPTS so it cannot churn forever. Sequential (one transcript in
-// flight) keeps memory flat and avoids bursting rate limits.
+// `primary_attempts` times.
+//
+// Escalation, in order:
+//   1. the session's OWN agent CLI, `primary_attempts` times
+//   2. a rate limit → stop immediately, back the source off, retry on a later
+//      tick. A quota refills; it is waited out, never routed around.
+//   3. otherwise (crashed / not installed / signed out / unusable output) → the
+//      user's globally chosen AI provider, once (`fallback`). Usually the same
+//      CLI, in which case it is skipped without a call.
+//   4. still nothing → the row stays `pending_summariser` and the drain loop's
+//      attempt ledger dead-letters it to 'subprocess_error' after
+//      MAX_ROW_ATTEMPTS so it cannot churn forever.
+//
+// Sequential (one transcript in flight) keeps memory flat and avoids bursting
+// rate limits.
 //
 // Cadence: woken in-process by the indexer's own seals (near-instant) plus a
 // short catch-up sweep for hook-sealed rows — no listener (local-only rule).
@@ -22,6 +31,7 @@ pub mod config;
 pub mod copilot;
 pub mod cursor_agent;
 pub mod db;
+pub mod fallback;
 pub mod prompts;
 
 use std::collections::HashMap;
@@ -166,6 +176,11 @@ pub enum Source {
     Codex,
     Copilot,
     CursorAgent,
+    /// The user's globally chosen AI provider, used only after the session's own CLI
+    /// failed every attempt (see [`fallback`]). Carries WHICH provider answered so the
+    /// persisted `summary_source` records that this summary did not come from the agent
+    /// that produced the transcript.
+    Fallback(crate::llm::LlmProvider),
     /// Historical only — nothing produces this any more.
     ///
     /// MLX used to be the shared fallback for every agent; that was removed with the
@@ -177,6 +192,9 @@ pub enum Source {
 }
 
 impl Source {
+    /// The persisted `summary_source` value. Fallback summaries are prefixed so a
+    /// consumer can tell "summarised by the agent that did the work" from "summarised by
+    /// a substitute" without a second column.
     pub fn as_str(self) -> &'static str {
         match self {
             Source::Claude => "claude",
@@ -185,6 +203,13 @@ impl Source {
             Source::CursorAgent => "cursor",
             Source::Mlx => "mlx",
             Source::None => "none",
+            Source::Fallback(p) => match p {
+                crate::llm::LlmProvider::Claude => "fallback:claude",
+                crate::llm::LlmProvider::Codex => "fallback:codex",
+                crate::llm::LlmProvider::Cursor => "fallback:cursor",
+                crate::llm::LlmProvider::Copilot => "fallback:copilot",
+                crate::llm::LlmProvider::Custom => "fallback:custom",
+            },
         }
     }
 }
@@ -296,10 +321,10 @@ async fn summarise_one_inner(
 
     // The session's own agent summarises it, up to `primary_attempts` tries
     // (codex→codex, copilot→copilot, cursor→cursor-agent, claude/unknown→claude).
-    // There is no fallback engine: MLX used to catch every failure here. A row the
-    // agent can't summarise is left `pending_summariser` for a later tick rather
-    // than written with a weaker answer, and `drain`'s attempt ledger dead-letters
-    // it after MAX_ROW_ATTEMPTS so a permanently-broken row cannot churn.
+    // Only once those attempts are spent on a NON-quota failure does the user's
+    // global provider get a turn (`fallback`); a row neither can summarise is left
+    // `pending_summariser` for a later tick, and `drain`'s attempt ledger
+    // dead-letters it after MAX_ROW_ATTEMPTS so a broken row cannot churn.
     let agent = row.agent.trim();
     let primary_source = if agent.eq_ignore_ascii_case("codex") {
         Source::Codex
@@ -375,9 +400,29 @@ async fn summarise_one_inner(
             }
         }
 
-        // No fallback: a coding-agent transcript is summarised by ITS OWN CLI, so routing
-        // a Codex session to some other engine would be wrong. On primary failure the row
-        // is left pending and the drain loop retries it on a later tick.
+        // Last resort: the user's globally chosen provider. Reached ONLY when the
+        // session's own CLI failed every attempt for a non-quota reason — a rate limit
+        // breaks out above, because a quota refills and must be waited out rather than
+        // routed around onto a second subscription. See `fallback` for the full rule.
+        if summary.is_none() && !rate_limited {
+            match fallback::try_summarise(&stdin_text, &row.session_uuid, primary_source).await {
+                Ok(Some((s, provider))) => {
+                    summary = Some(s);
+                    source = Source::Fallback(provider);
+                }
+                // The global provider IS the engine that just failed — nothing to add.
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        row_id = row.id,
+                        error = %e,
+                        "summariser fallback provider failed — leaving the row pending"
+                    );
+                    errors.push(format!("fallback: {e}"));
+                }
+            }
+        }
+
         (summary, source, rate_limited, attempts_made)
     }
     .instrument(infer_span.clone())
@@ -391,6 +436,10 @@ async fn summarise_one_inner(
         Source::CursorAgent if !cfg.cursor_model.is_empty() => cfg.cursor_model.clone(),
         Source::CursorAgent => "cursor-agent-default".into(),
         Source::Copilot => "copilot-default".into(),
+        // The concrete model is the global provider's own configured one, already recorded
+        // on the `llm.call` span that `resolver::complete` opened; naming the provider here
+        // keeps this field meaningful without guessing at a value we do not own.
+        Source::Fallback(p) => format!("provider:{}", p.as_str()),
         // Unreachable now that nothing sets `Source::Mlx`; kept so the match stays total
         // and reads correctly against rows written before the fallback was removed.
         Source::Mlx => "mlx-server".into(),
@@ -754,6 +803,26 @@ mod tests {
         assert!(capped.starts_with(&"A".repeat(70)), "70% head kept");
         assert!(capped.ends_with(&"B".repeat(30)), "30% tail kept");
         assert!(capped.contains("chars elided"));
+    }
+
+    /// `summary_source` is a PERSISTED vocabulary read back by the worklog pipeline, so
+    /// these strings are a contract. A fallback summary must be distinguishable from one
+    /// the session's own agent produced - same prefix, never the bare provider name.
+    #[test]
+    fn fallback_source_is_distinguishable_from_the_primary_engine() {
+        use crate::llm::LlmProvider;
+        assert_eq!(Source::Claude.as_str(), "claude");
+        assert_eq!(
+            Source::Fallback(LlmProvider::Claude).as_str(),
+            "fallback:claude"
+        );
+        assert_ne!(
+            Source::CursorAgent.as_str(),
+            Source::Fallback(LlmProvider::Cursor).as_str()
+        );
+        for p in LlmProvider::all() {
+            assert!(Source::Fallback(p).as_str().starts_with("fallback:"));
+        }
     }
 
     #[test]

--- a/src/llm/cursor.rs
+++ b/src/llm/cursor.rs
@@ -27,63 +27,46 @@ use super::{prompts, LlmBackend, LlmConfig, LlmError, LlmOutput, LlmProvider, Pr
 
 const ARG_CAP: usize = 180_000;
 
-/// Pinned model for every Meridian AI process on Cursor: small, fast, cheap and ZDR-eligible
-/// (Cursor flags non-ZDR models explicitly in `--list-models`; this is not one) - the right tier
-/// for summarise/classify/draft, and deterministic across users, unlike the account default
-/// `auto` which is server-routed and varies per call AND per account.
-///
-/// `-medium` is the effort suffix Cursor displays as plain "GPT-5.4 Mini"; the ladder is
-/// `-none/-low/-medium/-high/-xhigh`. A given plan may not carry it, so [`FALLBACK_MODEL`] keeps
-/// the call working rather than failing.
-const DEFAULT_MODEL: &str = "gpt-5.4-mini-medium";
-
-/// Cursor's server-routed default, used only when [`DEFAULT_MODEL`] is unavailable on the account.
-const FALLBACK_MODEL: &str = "auto";
-
 pub struct CursorBackend {
     pub cfg: LlmConfig,
 }
 
-/// How far the call has degraded. Each step is a response to a specific, detected failure - never
-/// a blind retry - so a working install always takes the fully hardened path.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Hardening {
-    /// Everything on: no tools, skills-free sandbox HOME.
-    Full,
-    /// This CLI build rejected `--allowed-tools` (undocumented flag removed upstream).
-    NoToolFlag,
-    /// Auth could not be read from the sandbox HOME; fall back to the inherited one.
-    RealHome,
+/// Lets [`cursor_cli::run_hardened`] classify our failures: a `Failed` may be a degradable
+/// cause, a `RateLimited` never is (account-level, so a retry spends quota to hit the same
+/// wall).
+impl cursor_cli::CursorCallError for LlmError {
+    fn degradable_message(&self) -> Option<&str> {
+        match self {
+            LlmError::Failed(m) => Some(m),
+            LlmError::RateLimited { .. } => None,
+        }
+    }
 }
 
 impl CursorBackend {
-    /// One `cursor-agent -p` call, returning the answer text or a classified error.
-    #[tracing::instrument(skip(self, prompt), fields(model, hardening = ?hardening))]
-    async fn run(
+    /// One `cursor-agent -p` attempt with the safety argv and environment handed down by
+    /// [`cursor_cli::run_hardened`], returning the answer text or a classified error.
+    #[tracing::instrument(skip(self, prompt, safety, env))]
+    async fn attempt(
         &self,
         prompt: &str,
-        model: &str,
-        hardening: Hardening,
+        safety: Vec<String>,
+        env: Vec<(&'static str, String)>,
     ) -> Result<String, LlmError> {
         let mut args: Vec<String> = vec!["-p".into(), prompt.to_string()];
         args.extend(["--output-format".into(), "json".into()]);
-        args.extend(cursor_cli::safety_args(
-            model,
-            hardening != Hardening::NoToolFlag,
-        ));
+        args.extend(safety);
 
-        let sandbox = match hardening {
-            Hardening::RealHome => None,
-            _ => cursor_cli::sandbox_home(),
-        };
-        let env = cursor_cli::env_overrides(sandbox.as_deref());
         let env_refs: Vec<(&str, &str)> = env.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
         let cap = run_capture(
             "cursor-agent",
             &args,
             "", // payload is in the prompt (argv), not stdin
-            &self.cfg.meridian_home,
+            // The neutral workspace, NOT ~/.meridian: `--workspace` governs rule discovery
+            // today, but the cwd is inside $HOME, so if Cursor ever also seeds discovery from
+            // it the no-rule-injection guarantee would regress silently. Free to pin.
+            &cursor_cli::neutral_workspace(),
             self.cfg.cli_timeout_s,
             &env_refs,
             cursor_cli::ENV_REMOVE,
@@ -166,60 +149,20 @@ impl LlmBackend for CursorBackend {
     #[tracing::instrument(skip(self, req), fields(label = %req.label))]
     async fn complete(&self, req: &PromptRequest) -> Result<LlmOutput, LlmError> {
         let t0 = std::time::Instant::now();
-
-        // Marker first: cursor-agent has no --no-session-persistence, so this call persists a
-        // chat to ~/.cursor/chats. The ingest self-guard drops any session whose first prompt
-        // carries MERIDIAN_PROMPT_MARKER, so our own calls are never re-ingested and
-        // re-summarised - for every AI process routed through Cursor, not just the summariser.
-        let mut prompt = format!(
-            "{}\n{}\n\n{}",
-            super::MERIDIAN_PROMPT_MARKER,
-            req.system,
-            cap_transcript(&req.user, ARG_CAP)
-        );
-        if let Some(schema) = &req.schema {
-            prompt.push_str(&prompts::schema_instruction(schema));
-        }
+        let prompt = build_prompt(req);
 
         // Empty override = the pinned default (deterministic, ZDR). A non-empty override is the
         // user's explicit choice and is passed through as-is.
         let model = if self.cfg.model.is_empty() {
-            DEFAULT_MODEL
+            cursor_cli::DEFAULT_MODEL
         } else {
             self.cfg.model.as_str()
         };
 
-        // Degrade one step at a time on a DETECTED cause, never blindly: drop the undocumented
-        // tool flag if this build rejects it, fall back to the real HOME if the sandbox hid the
-        // credentials, then to the server-routed model if the pinned one is not on this plan.
-        // A rate limit deliberately does NOT retry - Cursor limits are account-level, so a second
-        // call would burn quota to hit the same wall; the work stays pending for the next cycle.
-        let text = match self.run(&prompt, model, Hardening::Full).await {
-            Ok(t) => t,
-            Err(LlmError::Failed(msg)) if cursor_cli::looks_unsupported_flag(&msg) => {
-                tracing::warn!(
-                    "cursor: this CLI build rejects --allowed-tools - retrying without it \
-                     (call still works, just carries the full tool context)"
-                );
-                self.run(&prompt, model, Hardening::NoToolFlag).await?
-            }
-            Err(LlmError::Failed(msg)) if cursor_cli::looks_auth_failure(&msg) => {
-                tracing::warn!(
-                    "cursor: credentials not visible from the sandbox HOME - retrying on the \
-                     real HOME (call still works, just carries the user's skill list)"
-                );
-                self.run(&prompt, model, Hardening::RealHome).await?
-            }
-            Err(LlmError::Failed(msg)) if model != FALLBACK_MODEL && looks_unknown_model(&msg) => {
-                tracing::warn!(
-                    model,
-                    fallback = FALLBACK_MODEL,
-                    "cursor: pinned model unavailable on this account - retrying with auto"
-                );
-                self.run(&prompt, FALLBACK_MODEL, Hardening::Full).await?
-            }
-            Err(e) => return Err(e),
-        };
+        // The degradation ladder lives in `cursor_cli` so the summariser inherits it too.
+        let text =
+            cursor_cli::run_hardened(model, |safety, env| self.attempt(&prompt, safety, env))
+                .await?;
 
         let elapsed_s = t0.elapsed().as_secs_f64();
         tracing::info!(
@@ -239,48 +182,61 @@ impl LlmBackend for CursorBackend {
     }
 }
 
-/// Heuristic: did the CLI reject the pinned model as unavailable on this account? Cursor plans
-/// differ in model access, so a pinned id can be absent - detecting that lets
-/// [`CursorBackend::complete`] fall back to `auto` rather than failing every call.
-fn looks_unknown_model(msg: &str) -> bool {
-    let m = msg.to_lowercase();
-    m.contains("model")
-        && (m.contains("unknown")
-            || m.contains("not available")
-            || m.contains("unavailable")
-            || m.contains("invalid")
-            || m.contains("not found")
-            || m.contains("does not exist")
-            || m.contains("no access"))
+/// The exact text sent to `cursor-agent -p`.
+///
+/// Extracted from [`CursorBackend::complete`] so a test can assert on the prompt the product
+/// actually builds. Inlining it made the marker assertion a tautology - the test rebuilt the
+/// `format!` itself, so deleting the marker from the real call site still passed.
+///
+/// The marker leads: cursor-agent has no `--no-session-persistence`, so this call persists a
+/// chat to `~/.cursor/chats`. The ingest self-guard drops any session carrying
+/// [`super::MERIDIAN_PROMPT_MARKER`], so our own calls are never re-ingested and
+/// re-summarised - for every AI process routed through Cursor, not just the summariser.
+fn build_prompt(req: &PromptRequest) -> String {
+    let mut prompt = format!(
+        "{}\n{}\n\n{}",
+        super::MERIDIAN_PROMPT_MARKER,
+        req.system,
+        cap_transcript(&req.user, ARG_CAP)
+    );
+    if let Some(schema) = &req.schema {
+        prompt.push_str(&prompts::schema_instruction(schema));
+    }
+    prompt
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn req() -> PromptRequest {
+        PromptRequest::new("SYSTEM PROMPT", "USER INPUT", "test-label")
+    }
+
+    /// The marker is what cuts the summarise -> ingest -> summarise loop, so the property to
+    /// pin is its PRESENCE in the prompt `complete()` really sends. Asserted against
+    /// [`build_prompt`] rather than a string rebuilt here, so deleting or moving the marker at
+    /// the call site fails this test.
     #[test]
-    fn unknown_model_detection_matches_availability_errors() {
-        assert!(looks_unknown_model("Unknown model: gpt-5.4-mini-medium"));
-        assert!(looks_unknown_model(
-            "cursor-agent reported: model not available on your plan"
-        ));
-        assert!(looks_unknown_model("Invalid model id"));
-        // Not a model-availability problem - must NOT trigger a silent model swap.
-        assert!(!looks_unknown_model("rate limit reached"));
-        assert!(!looks_unknown_model("network error"));
-        assert!(!looks_unknown_model("workspace trust required"));
+    fn the_real_prompt_carries_the_self_ingest_marker() {
+        let prompt = build_prompt(&req());
+        assert!(
+            prompt.contains(super::super::MERIDIAN_PROMPT_MARKER),
+            "without the marker every Meridian cursor call is re-ingested as developer activity"
+        );
+        // The guard uses `contains`, so position is not the contract - but the system prompt
+        // and the user input must both actually make it through.
+        assert!(prompt.contains("SYSTEM PROMPT"));
+        assert!(prompt.contains("USER INPUT"));
     }
 
     #[test]
-    fn marker_leads_the_prompt_so_ingest_can_drop_our_own_sessions() {
-        // The self-ingest guard checks the FIRST user prompt for the marker; the backend must
-        // put it there. Guards against a refactor that reorders the format!.
-        let prompt = format!(
-            "{}\n{}\n\n{}",
-            super::super::MERIDIAN_PROMPT_MARKER,
-            "sys",
-            "user"
-        );
-        assert!(prompt.starts_with(super::super::MERIDIAN_PROMPT_MARKER));
+    fn a_schema_request_appends_the_json_contract() {
+        // Cursor has no --json-schema, so the contract can only ride in the prompt; losing
+        // this silently degrades every structured caller to unparseable prose.
+        let plain = build_prompt(&req());
+        let with_schema = build_prompt(&req().with_schema(serde_json::json!({"type": "object"})));
+        assert!(with_schema.len() > plain.len());
+        assert!(with_schema.starts_with(&plain));
     }
 }

--- a/src/llm/cursor.rs
+++ b/src/llm/cursor.rs
@@ -1,69 +1,97 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
-//! Cursor backend — `cursor-agent -p`, on the user's own Cursor subscription.
+//! Cursor backend - `cursor-agent -p`, on the user's own Cursor subscription.
 //!
-//! Like copilot, and unlike claude/codex: **no schema mechanism**, so the JSON contract
-//! rides in the prompt and the answer is parsed tolerantly. The payload goes in argv
-//! (stdin support is unprobed on this CLI; argv is known to work).
+//! This is the LLM-provider entry point: when the user selects Cursor, EVERY Meridian AI process
+//! (coding-agent summaries, hourly distillation, worklog generation, ticket proposals, task
+//! classification, and the Settings connection probe) resolves here.
 //!
-//! `--trust` is required: cursor-agent refuses an untrusted workspace even in print mode
-//! ("Workspace Trust Required", exit 1). Trusting is safe here — the prompt is our own
-//! text and the agent is not being asked to execute anything.
+//! The safety flags, environment and sandbox are NOT defined here - they live in
+//! [`crate::llm::cursor_cli`] so the summariser's call site cannot drift out of sync. What is
+//! local to this module is the JSON envelope and its error classification.
+//!
+//! Unlike claude/codex there is **no schema mechanism**, so the JSON contract rides in the prompt
+//! and the answer is parsed tolerantly. The payload goes in argv (stdin is unprobed on this CLI).
+//!
+//! # Related
+//! - [`crate::llm::cursor_cli`] - shared flags/env/sandbox (read this first)
+//! - [`crate::llm::claude`] - the equivalent backend whose hardening this mirrors
 
 use async_trait::async_trait;
+use serde_json::Value;
 
 use crate::coding_agent_session_ingest::summariser::prompts as sp;
 use crate::coding_agent_session_ingest::summariser::{cap_transcript, run_capture};
 
+use super::cursor_cli;
 use super::{prompts, LlmBackend, LlmConfig, LlmError, LlmOutput, LlmProvider, PromptRequest};
 
 const ARG_CAP: usize = 180_000;
+
+/// Pinned model for every Meridian AI process on Cursor: small, fast, cheap and ZDR-eligible
+/// (Cursor flags non-ZDR models explicitly in `--list-models`; this is not one) - the right tier
+/// for summarise/classify/draft, and deterministic across users, unlike the account default
+/// `auto` which is server-routed and varies per call AND per account.
+///
+/// `-medium` is the effort suffix Cursor displays as plain "GPT-5.4 Mini"; the ladder is
+/// `-none/-low/-medium/-high/-xhigh`. A given plan may not carry it, so [`FALLBACK_MODEL`] keeps
+/// the call working rather than failing.
+const DEFAULT_MODEL: &str = "gpt-5.4-mini-medium";
+
+/// Cursor's server-routed default, used only when [`DEFAULT_MODEL`] is unavailable on the account.
+const FALLBACK_MODEL: &str = "auto";
 
 pub struct CursorBackend {
     pub cfg: LlmConfig,
 }
 
-#[async_trait]
-impl LlmBackend for CursorBackend {
-    fn provider(&self) -> LlmProvider {
-        LlmProvider::Cursor
-    }
+/// How far the call has degraded. Each step is a response to a specific, detected failure - never
+/// a blind retry - so a working install always takes the fully hardened path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Hardening {
+    /// Everything on: no tools, skills-free sandbox HOME.
+    Full,
+    /// This CLI build rejected `--allowed-tools` (undocumented flag removed upstream).
+    NoToolFlag,
+    /// Auth could not be read from the sandbox HOME; fall back to the inherited one.
+    RealHome,
+}
 
-    async fn complete(&self, req: &PromptRequest) -> Result<LlmOutput, LlmError> {
-        let t0 = std::time::Instant::now();
+impl CursorBackend {
+    /// One `cursor-agent -p` call, returning the answer text or a classified error.
+    #[tracing::instrument(skip(self, prompt), fields(model, hardening = ?hardening))]
+    async fn run(
+        &self,
+        prompt: &str,
+        model: &str,
+        hardening: Hardening,
+    ) -> Result<String, LlmError> {
+        let mut args: Vec<String> = vec!["-p".into(), prompt.to_string()];
+        args.extend(["--output-format".into(), "json".into()]);
+        args.extend(cursor_cli::safety_args(
+            model,
+            hardening != Hardening::NoToolFlag,
+        ));
 
-        let mut prompt = format!("{}\n\n{}", req.system, cap_transcript(&req.user, ARG_CAP));
-        if let Some(schema) = &req.schema {
-            prompt.push_str(&prompts::schema_instruction(schema));
-        }
-
-        let mut args: Vec<String> = vec![
-            "-p".into(),
-            prompt,
-            "--output-format".into(),
-            "text".into(),
-            "--trust".into(),
-        ];
-        if !self.cfg.model.is_empty() {
-            args.push("--model".into());
-            args.push(self.cfg.model.clone());
-        }
+        let sandbox = match hardening {
+            Hardening::RealHome => None,
+            _ => cursor_cli::sandbox_home(),
+        };
+        let env = cursor_cli::env_overrides(sandbox.as_deref());
+        let env_refs: Vec<(&str, &str)> = env.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
         let cap = run_capture(
             "cursor-agent",
             &args,
-            "", // payload is in the prompt
+            "", // payload is in the prompt (argv), not stdin
             &self.cfg.meridian_home,
             self.cfg.cli_timeout_s,
-            // Cursor exposes no per-call telemetry flag — the no-training guarantee is its
-            // account-level Privacy Mode (it sends a ZDR flag upstream). Set DO_NOT_TRACK as
-            // the best-effort standard opt-out we can control; the UI points users at
-            // Privacy Mode for the real training/retention guarantee.
-            &[("MERIDIAN_SUMMARISER", "1"), super::DO_NOT_TRACK],
-            &[],
+            &env_refs,
+            cursor_cli::ENV_REMOVE,
         )
         .await
         .map_err(super::resolver::from_summariser_error)?;
 
+        // On a hard failure cursor-agent emits no well-formed JSON - the error is on stderr.
         if !cap.success {
             let blob = format!("{}\n{}", cap.stderr, cap.stdout);
             if sp::looks_rate_limited(&blob) {
@@ -82,18 +110,177 @@ impl LlmBackend for CursorBackend {
             )));
         }
 
-        let text = cap.stdout.trim().to_string();
+        // `--output-format json`: one {type:"result", subtype, is_error, result, usage} object.
+        let payload: Value = serde_json::from_str(&cap.stdout).map_err(|e| {
+            let head: String = cap.stdout.chars().take(200).collect();
+            LlmError::Failed(format!("cursor-agent output not JSON ({e}): {head:?}"))
+        })?;
+
+        // Exit 0 does not mean success: the envelope can still report an error (a limit hit
+        // mid-run, for instance), and that error is where the rate-limit signal lives.
+        let is_error = payload
+            .get("is_error")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let subtype = payload.get("subtype").and_then(Value::as_str);
+        if is_error || !matches!(subtype, None | Some("success")) {
+            let detail: String = payload
+                .get("result")
+                .and_then(Value::as_str)
+                .or(subtype)
+                .unwrap_or("error")
+                .chars()
+                .take(200)
+                .collect();
+            if sp::looks_rate_limited(&detail) {
+                return Err(LlmError::rate_limited(detail));
+            }
+            return Err(LlmError::Failed(format!("cursor-agent reported: {detail}")));
+        }
+
+        let text = payload
+            .get("result")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .trim()
+            .to_string();
         if text.is_empty() {
             return Err(LlmError::Failed(
                 "cursor-agent returned an empty answer".into(),
             ));
         }
 
+        if let Some(usage) = payload.get("usage") {
+            tracing::debug!(usage = %usage, "cursor: call usage");
+        }
+        Ok(text)
+    }
+}
+
+#[async_trait]
+impl LlmBackend for CursorBackend {
+    fn provider(&self) -> LlmProvider {
+        LlmProvider::Cursor
+    }
+
+    #[tracing::instrument(skip(self, req), fields(label = %req.label))]
+    async fn complete(&self, req: &PromptRequest) -> Result<LlmOutput, LlmError> {
+        let t0 = std::time::Instant::now();
+
+        // Marker first: cursor-agent has no --no-session-persistence, so this call persists a
+        // chat to ~/.cursor/chats. The ingest self-guard drops any session whose first prompt
+        // carries MERIDIAN_PROMPT_MARKER, so our own calls are never re-ingested and
+        // re-summarised - for every AI process routed through Cursor, not just the summariser.
+        let mut prompt = format!(
+            "{}\n{}\n\n{}",
+            super::MERIDIAN_PROMPT_MARKER,
+            req.system,
+            cap_transcript(&req.user, ARG_CAP)
+        );
+        if let Some(schema) = &req.schema {
+            prompt.push_str(&prompts::schema_instruction(schema));
+        }
+
+        // Empty override = the pinned default (deterministic, ZDR). A non-empty override is the
+        // user's explicit choice and is passed through as-is.
+        let model = if self.cfg.model.is_empty() {
+            DEFAULT_MODEL
+        } else {
+            self.cfg.model.as_str()
+        };
+
+        // Degrade one step at a time on a DETECTED cause, never blindly: drop the undocumented
+        // tool flag if this build rejects it, fall back to the real HOME if the sandbox hid the
+        // credentials, then to the server-routed model if the pinned one is not on this plan.
+        // A rate limit deliberately does NOT retry - Cursor limits are account-level, so a second
+        // call would burn quota to hit the same wall; the work stays pending for the next cycle.
+        let text = match self.run(&prompt, model, Hardening::Full).await {
+            Ok(t) => t,
+            Err(LlmError::Failed(msg)) if cursor_cli::looks_unsupported_flag(&msg) => {
+                tracing::warn!(
+                    "cursor: this CLI build rejects --allowed-tools - retrying without it \
+                     (call still works, just carries the full tool context)"
+                );
+                self.run(&prompt, model, Hardening::NoToolFlag).await?
+            }
+            Err(LlmError::Failed(msg)) if cursor_cli::looks_auth_failure(&msg) => {
+                tracing::warn!(
+                    "cursor: credentials not visible from the sandbox HOME - retrying on the \
+                     real HOME (call still works, just carries the user's skill list)"
+                );
+                self.run(&prompt, model, Hardening::RealHome).await?
+            }
+            Err(LlmError::Failed(msg)) if model != FALLBACK_MODEL && looks_unknown_model(&msg) => {
+                tracing::warn!(
+                    model,
+                    fallback = FALLBACK_MODEL,
+                    "cursor: pinned model unavailable on this account - retrying with auto"
+                );
+                self.run(&prompt, FALLBACK_MODEL, Hardening::Full).await?
+            }
+            Err(e) => return Err(e),
+        };
+
+        let elapsed_s = t0.elapsed().as_secs_f64();
+        tracing::info!(
+            model,
+            elapsed_s,
+            chars = text.len(),
+            "cursor: call complete"
+        );
         Ok(LlmOutput {
             text,
+            // The CLI reports usage in its envelope but not a comparable prompt/completion split;
+            // logged on the call span instead of guessed at here.
             input_tokens: 0,
             output_tokens: 0,
-            elapsed_s: t0.elapsed().as_secs_f64(),
+            elapsed_s,
         })
+    }
+}
+
+/// Heuristic: did the CLI reject the pinned model as unavailable on this account? Cursor plans
+/// differ in model access, so a pinned id can be absent - detecting that lets
+/// [`CursorBackend::complete`] fall back to `auto` rather than failing every call.
+fn looks_unknown_model(msg: &str) -> bool {
+    let m = msg.to_lowercase();
+    m.contains("model")
+        && (m.contains("unknown")
+            || m.contains("not available")
+            || m.contains("unavailable")
+            || m.contains("invalid")
+            || m.contains("not found")
+            || m.contains("does not exist")
+            || m.contains("no access"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_model_detection_matches_availability_errors() {
+        assert!(looks_unknown_model("Unknown model: gpt-5.4-mini-medium"));
+        assert!(looks_unknown_model(
+            "cursor-agent reported: model not available on your plan"
+        ));
+        assert!(looks_unknown_model("Invalid model id"));
+        // Not a model-availability problem - must NOT trigger a silent model swap.
+        assert!(!looks_unknown_model("rate limit reached"));
+        assert!(!looks_unknown_model("network error"));
+        assert!(!looks_unknown_model("workspace trust required"));
+    }
+
+    #[test]
+    fn marker_leads_the_prompt_so_ingest_can_drop_our_own_sessions() {
+        // The self-ingest guard checks the FIRST user prompt for the marker; the backend must
+        // put it there. Guards against a refactor that reorders the format!.
+        let prompt = format!(
+            "{}\n{}\n\n{}",
+            super::super::MERIDIAN_PROMPT_MARKER,
+            "sys",
+            "user"
+        );
+        assert!(prompt.starts_with(super::super::MERIDIAN_PROMPT_MARKER));
     }
 }

--- a/src/llm/cursor_cli.rs
+++ b/src/llm/cursor_cli.rs
@@ -1,0 +1,393 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! The single source of truth for **how Meridian invokes `cursor-agent`**.
+//!
+//! Two call sites shell out to this CLI - the LLM provider backend ([`crate::llm::cursor`],
+//! used by every AI process when Cursor is the selected provider) and the coding-agent
+//! summariser ([`crate::coding_agent_session_ingest::summariser::cursor_agent`]). They differ
+//! only in output format and parsing, so everything *else* - the safety flags, the environment,
+//! and the sandbox - lives here. Adding a hardening flag in one place must not leave the other
+//! call site running unprotected, which is exactly what happened before this module existed.
+//!
+//! # What the hardening is for
+//!
+//! Every Meridian AI call is pure inference (summarise / classify / draft) over **untrusted**
+//! text - coding-agent transcripts and screen OCR that Meridian did not author. `cursor-agent`
+//! is a coding agent that defaults to full write + shell access, so the defaults are wrong for
+//! us in both directions: too much capability, and a large irrelevant context.
+//!
+//! | Lever | Effect (measured on cursor-agent 2026.07.16) |
+//! |---|---|
+//! | `--allowed-tools ""` | no tools at all; -11,000 input tokens |
+//! | `--mode ask` | read-only, server-enforced; belt-and-braces with the empty allowlist |
+//! | `--workspace <empty>` | stops Cursor walking UP into the user's `~/CLAUDE.md` / `AGENTS.md` |
+//! | [`sandbox_home`] | stops the user's ~190 skills being injected; -6,500 further tokens |
+//! | `CURSOR_API_KEY` stripped | the user's subscription is used, never metered API billing |
+//!
+//! Net: ~21,000 -> ~3,400 input tokens per call, with summary quality unchanged.
+//!
+//! # Related
+//! - [`crate::llm::cursor`] - JSON-envelope backend for all AI processes
+//! - [`crate::coding_agent_session_ingest::summariser::cursor_agent`] - text-output summariser
+//! - [`meridian_core::CURSOR_CLI_VERSION`] - the pinned build these flags are verified against
+
+use std::path::{Path, PathBuf};
+
+/// Skill roots `cursor-agent` discovers relative to `$HOME`, as directory names to neutralise.
+///
+/// `.cursor` is rebuilt selectively (it also holds auth/config we must keep); the rest are
+/// simply never created in the sandbox. Sourced from the CLI bundle's own discovery patterns:
+/// `.cursor/skills`, `.cursor/skills-cursor`, `.claude/skills`, `.codex/skills`,
+/// `.agents/skills`, plus plugin-provided skills under `.cursor/plugins`.
+const SKILL_ROOT_DIRS: &[&str] = &[".claude", ".codex", ".agents"];
+
+/// Entries inside `.cursor` that carry skills. Recreated EMPTY and READ-ONLY rather than just
+/// omitted: `cursor-agent` self-provisions its built-in skills and plugin cache on startup, so
+/// an absent directory is simply recreated and repopulated. A present-but-unwritable one is not.
+const CURSOR_SKILL_ENTRIES: &[&str] = &["skills", "skills-cursor", "plugins", "agents"];
+
+/// Directory mode for the neutralised skill dirs: readable and traversable, NOT writable.
+#[cfg(unix)]
+const READ_ONLY_DIR_MODE: u32 = 0o555;
+
+/// Build (idempotently) a private `$HOME` for `cursor-agent` that contains the user's real
+/// auth/config but NO skills, and return it.
+///
+/// # Why a sandbox HOME
+///
+/// Cursor resolves skills from `homedir()`, and there is no flag to disable them
+/// (`--exclude-workspace-context` exists but the server refuses it for ordinary accounts).
+/// Pointing `HOME` at a directory that mirrors everything EXCEPT the skill roots is the only
+/// mechanism that works, and it cuts ~6,500 tokens of skill listings off every call.
+///
+/// # This never touches the user's real files
+///
+/// Everything created lives under this sandbox. The user's `~/.cursor/skills-cursor`,
+/// `~/.claude/skills` and friends are neither written, moved, nor deleted - they are simply not
+/// linked in. The override applies only to the `cursor-agent` subprocess Meridian spawns, so the
+/// user's own Cursor and Claude sessions are unaffected.
+///
+/// # Layout
+///
+/// - every top-level entry of the real `$HOME` is symlinked, EXCEPT [`SKILL_ROOT_DIRS`] and
+///   `.cursor` - mirroring wholesale means auth keeps working without this code needing to know
+///   where each platform stores it
+/// - `.cursor` is a real directory whose children are symlinked individually, minus
+///   [`CURSOR_SKILL_ENTRIES`]
+/// - those entries are then created empty and read-only, so the CLI cannot repopulate them
+///
+/// Returns `None` if the sandbox cannot be built; callers must then fall back to the inherited
+/// `HOME` (a fatter call, never a broken one).
+pub fn sandbox_home() -> Option<PathBuf> {
+    let real = meridian_core::paths::home_dir_or_cwd();
+    let root = std::env::temp_dir().join("meridian-cursor-home");
+
+    if let Err(e) = build_sandbox(&real, &root) {
+        tracing::warn!(
+            error = %e,
+            path = %root.display(),
+            "cursor: could not build the skills-free sandbox HOME - falling back to the real HOME \
+             (the call still works, it just carries the user's skill list)"
+        );
+        return None;
+    }
+    tracing::debug!(path = %root.display(), "cursor: using skills-free sandbox HOME");
+    Some(root)
+}
+
+/// Create or refresh the sandbox. Idempotent: safe to call on every invocation, and it repairs
+/// itself if the OS reaped the temp directory between calls.
+fn build_sandbox(real: &Path, root: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(root)?;
+    restrict(root, 0o700)?;
+
+    // Mirror the real HOME, minus the skill roots and .cursor (rebuilt below).
+    for entry in std::fs::read_dir(real)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        if name_str == ".cursor" || SKILL_ROOT_DIRS.contains(&name_str) {
+            continue;
+        }
+        link(&entry.path(), &root.join(name_str));
+    }
+
+    // .cursor: keep auth/config, drop the skill-bearing entries.
+    let cursor_dst = root.join(".cursor");
+    std::fs::create_dir_all(&cursor_dst)?;
+    let cursor_src = real.join(".cursor");
+    if cursor_src.is_dir() {
+        for entry in std::fs::read_dir(&cursor_src)? {
+            let entry = entry?;
+            let name = entry.file_name();
+            let Some(name_str) = name.to_str() else {
+                continue;
+            };
+            if CURSOR_SKILL_ENTRIES.contains(&name_str) {
+                continue;
+            }
+            link(&entry.path(), &cursor_dst.join(name_str));
+        }
+    }
+
+    // Neutralise the skill entries: present (so they are not recreated) but unwritable (so they
+    // cannot be repopulated). Order matters - create while still writable, then restrict.
+    for name in CURSOR_SKILL_ENTRIES {
+        let dir = cursor_dst.join(name);
+        let _ = std::fs::create_dir_all(&dir);
+        let _ = restrict(&dir, READ_ONLY_DIR_MODE);
+    }
+    Ok(())
+}
+
+/// Symlink `src` to `dst`, ignoring an existing link (the sandbox is long-lived and rebuilt on
+/// every call; a present link is the steady state, not an error).
+fn link(src: &Path, dst: &Path) {
+    if dst.exists() || dst.is_symlink() {
+        return;
+    }
+    #[cfg(unix)]
+    let r = std::os::unix::fs::symlink(src, dst);
+    #[cfg(windows)]
+    let r = if src.is_dir() {
+        std::os::windows::fs::symlink_dir(src, dst)
+    } else {
+        std::os::windows::fs::symlink_file(src, dst)
+    };
+    if let Err(e) = r {
+        tracing::trace!(error = %e, src = %src.display(), "cursor: sandbox link skipped");
+    }
+}
+
+/// Set a directory's permission bits. No-op off unix.
+#[allow(unused_variables)]
+fn restrict(path: &Path, mode: u32) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))?;
+    }
+    Ok(())
+}
+
+/// An empty, Meridian-owned directory OUTSIDE `$HOME`, used as `--workspace` for every call.
+///
+/// Cursor resolves "always applied workspace rules" by walking **UP** from the workspace, so a
+/// workspace anywhere under the user's home silently injects their global `~/CLAUDE.md` /
+/// `AGENTS.md` / `.cursorrules` - measured: the entire file arrives as
+/// `<always_applied_workspace_rules>`. That is coding-assistant instruction text contaminating a
+/// pure summarise/classify call, and this is Cursor's equivalent of what Claude's
+/// `--setting-sources ""` suppresses. `std::env::temp_dir()` sits outside the home tree on macOS
+/// (`$TMPDIR` -> `/var/folders/…`) and Linux (`/tmp`), so no such ancestor can exist. An empty
+/// workspace also leaves the agent nothing to read - every input we need is already in the prompt.
+pub fn neutral_workspace() -> PathBuf {
+    let dir = std::env::temp_dir().join("meridian-llm-workspace");
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        tracing::debug!(error = %e, path = %dir.display(), "cursor: neutral workspace mkdir failed");
+    }
+    dir
+}
+
+/// The safety flags every Meridian `cursor-agent` call carries, in argv order.
+///
+/// `no_tools` adds `--allowed-tools ""` (an EMPTY allowlist = no tools at all). That flag is
+/// UNDOCUMENTED - hidden from `--help`, marked "internal only" in the CLI bundle - so callers
+/// must be able to retry without it; see [`looks_unsupported_flag`].
+///
+/// Callers append their own `--output-format` and any prompt/model arguments.
+pub fn safety_args(model: &str, no_tools: bool) -> Vec<String> {
+    let mut args = vec![
+        // Read-only Q&A. Server-enforced: the request carries a system_reminder stating the
+        // agent MUST NOT edit or run non-readonly tools, superseding other instructions.
+        "--mode".into(),
+        "ask".into(),
+        // Required, or cursor-agent exits 1 with "Workspace Trust Required" even in print mode.
+        // Safe here: the prompt is our own text and, with no tools, nothing can be executed.
+        "--trust".into(),
+        "--model".into(),
+        model.to_string(),
+        "--workspace".into(),
+        neutral_workspace().to_string_lossy().into_owned(),
+    ];
+    if no_tools {
+        args.push("--allowed-tools".into());
+        args.push(String::new());
+    }
+    args
+}
+
+/// Environment overrides for every call: mark the run as ours so the coding-agent indexer can
+/// ignore it, opt out of telemetry, and point `HOME` at the skills-free sandbox.
+///
+/// `sandbox` is threaded in rather than resolved here so a caller can retry WITHOUT it (see
+/// [`looks_auth_failure`]) and so tests can exercise both paths.
+pub fn env_overrides(sandbox: Option<&Path>) -> Vec<(&'static str, String)> {
+    let mut env = vec![
+        ("MERIDIAN_SUMMARISER", "1".to_string()),
+        // Cursor exposes no per-call telemetry flag - the no-training guarantee is its
+        // account-level Privacy Mode (a ZDR flag it sends upstream). This is the best-effort
+        // standard opt-out we can control; the UI points users at Privacy Mode for the real
+        // training/retention guarantee.
+        (
+            crate::llm::DO_NOT_TRACK.0,
+            crate::llm::DO_NOT_TRACK.1.into(),
+        ),
+    ];
+    if let Some(home) = sandbox {
+        env.push(("HOME", home.to_string_lossy().into_owned()));
+    }
+    env
+}
+
+/// Environment variables removed from every call.
+///
+/// A stray `CURSOR_API_KEY` would silently move the user off their subscription onto metered
+/// API billing. Mirrors `claude.rs` stripping `ANTHROPIC_API_KEY`.
+pub const ENV_REMOVE: &[&str] = &["CURSOR_API_KEY"];
+
+/// Did this CLI build reject one of our flags outright?
+///
+/// `--allowed-tools` is an undocumented internal option, so a future cursor-agent may drop it -
+/// commander exits with `error: unknown option '--allowed-tools'`. Detecting that lets a caller
+/// retry unhardened instead of failing every AI process on a CLI upgrade.
+pub fn looks_unsupported_flag(msg: &str) -> bool {
+    let m = msg.to_lowercase();
+    m.contains("unknown option") || m.contains("unknown argument") || m.contains("unrecognized")
+}
+
+/// Did the call fail because `cursor-agent` could not see its credentials?
+///
+/// The sandbox `HOME` mirrors the real one, but auth storage differs per platform and could move
+/// between CLI builds. If it ever does, the symptom is an auth error - and the right response is
+/// to retry on the inherited `HOME` (a fatter call) rather than leave every AI process broken.
+pub fn looks_auth_failure(msg: &str) -> bool {
+    let m = msg.to_lowercase();
+    m.contains("not logged in")
+        || m.contains("unauthorized")
+        || m.contains("unauthenticated")
+        || m.contains("not authenticated")
+        || m.contains("please log in")
+        || m.contains("login required")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safety_args_carry_the_read_only_and_no_tool_levers() {
+        let a = safety_args("some-model", true).join(" ");
+        assert!(a.contains("--mode ask"), "read-only mode is not optional");
+        assert!(a.contains("--trust"), "headless runs die without --trust");
+        assert!(a.contains("--model some-model"));
+        assert!(
+            a.contains("--workspace"),
+            "workspace pin stops rule injection"
+        );
+        assert!(a.contains("--allowed-tools"), "empty allowlist = no tools");
+    }
+
+    #[test]
+    fn safety_args_can_drop_only_the_undocumented_flag() {
+        // The retry path: everything else must survive so a CLI that lost --allowed-tools is
+        // still read-only and still free of workspace rules.
+        let a = safety_args("m", false).join(" ");
+        assert!(!a.contains("--allowed-tools"));
+        assert!(a.contains("--mode ask"));
+        assert!(a.contains("--workspace"));
+    }
+
+    #[test]
+    fn env_overrides_track_the_sandbox_and_always_opt_out_of_telemetry() {
+        let without = env_overrides(None);
+        assert!(without.iter().all(|(k, _)| *k != "HOME"));
+        assert!(without.iter().any(|(k, _)| *k == "DO_NOT_TRACK"));
+        assert!(without.iter().any(|(k, _)| *k == "MERIDIAN_SUMMARISER"));
+
+        let with = env_overrides(Some(Path::new("/tmp/x")));
+        assert_eq!(
+            with.iter()
+                .find(|(k, _)| *k == "HOME")
+                .map(|(_, v)| v.as_str()),
+            Some("/tmp/x")
+        );
+    }
+
+    #[test]
+    fn api_key_is_always_stripped() {
+        assert!(ENV_REMOVE.contains(&"CURSOR_API_KEY"));
+    }
+
+    #[test]
+    fn unsupported_flag_detection_drives_the_unhardened_retry() {
+        assert!(looks_unsupported_flag(
+            "cursor-agent exited Some(1): error: unknown option '--allowed-tools'"
+        ));
+        // Ordinary failures must NOT silently drop the hardening.
+        assert!(!looks_unsupported_flag("rate limit reached"));
+        assert!(!looks_unsupported_flag(
+            "cursor-agent returned an empty answer"
+        ));
+    }
+
+    #[test]
+    fn auth_failure_detection_drives_the_real_home_retry() {
+        assert!(looks_auth_failure("Not logged in"));
+        assert!(looks_auth_failure(
+            "cursor-agent exited Some(1): unauthorized"
+        ));
+        // Must not mistake a quota problem for an auth problem - that retry would waste a call.
+        assert!(!looks_auth_failure("rate/usage limit reached"));
+        assert!(!looks_auth_failure("workspace trust required"));
+    }
+
+    /// The sandbox must never be the user's real home - that is the whole safety property.
+    #[test]
+    fn sandbox_is_outside_the_real_home() {
+        let real = meridian_core::paths::home_dir_or_cwd();
+        let sandbox = std::env::temp_dir().join("meridian-cursor-home");
+        assert!(
+            !sandbox.starts_with(&real),
+            "sandbox must not live under $HOME"
+        );
+        assert!(
+            !neutral_workspace().starts_with(&real),
+            "workspace must not live under $HOME"
+        );
+    }
+
+    /// Building it twice must be a no-op, and it must contain neutralised skill dirs.
+    #[test]
+    fn build_sandbox_is_idempotent_and_neutralises_skill_dirs() {
+        let tmp = std::env::temp_dir().join(format!("meridian-sbx-test-{}", std::process::id()));
+        let fake_home = tmp.join("home");
+        std::fs::create_dir_all(fake_home.join(".cursor").join("skills-cursor")).unwrap();
+        std::fs::create_dir_all(fake_home.join(".claude").join("skills")).unwrap();
+        std::fs::write(fake_home.join(".cursor").join("cli-config.json"), "{}").unwrap();
+        let root = tmp.join("sandbox");
+
+        build_sandbox(&fake_home, &root).unwrap();
+        build_sandbox(&fake_home, &root).unwrap(); // idempotent
+
+        // Auth/config carried over, skill roots not linked, skill entries present-but-empty.
+        assert!(root.join(".cursor").join("cli-config.json").exists());
+        assert!(
+            !root.join(".claude").exists(),
+            "third-party skill root must not be linked"
+        );
+        let skills = root.join(".cursor").join("skills-cursor");
+        assert!(skills.is_dir(), "must exist so the CLI cannot recreate it");
+        assert_eq!(
+            std::fs::read_dir(&skills).unwrap().count(),
+            0,
+            "must be empty"
+        );
+
+        // Clean up (restore write bits first - we deliberately made them read-only).
+        for name in CURSOR_SKILL_ENTRIES {
+            let _ = restrict(&root.join(".cursor").join(name), 0o755);
+        }
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/src/llm/cursor_cli.rs
+++ b/src/llm/cursor_cli.rs
@@ -46,7 +46,11 @@ const SKILL_ROOT_DIRS: &[&str] = &[".claude", ".codex", ".agents"];
 const CURSOR_SKILL_ENTRIES: &[&str] = &["skills", "skills-cursor", "plugins", "agents"];
 
 /// Directory mode for the neutralised skill dirs: readable and traversable, NOT writable.
-#[cfg(unix)]
+///
+/// Defined on every platform even though only unix consumes it - [`restrict`] no-ops elsewhere,
+/// and gating the const instead of its use broke the Windows build (the call site is
+/// unconditional).
+#[cfg_attr(not(unix), allow(dead_code))]
 const READ_ONLY_DIR_MODE: u32 = 0o555;
 
 /// Build (idempotently) a private `$HOME` for `cursor-agent` that contains the user's real
@@ -79,7 +83,7 @@ const READ_ONLY_DIR_MODE: u32 = 0o555;
 /// `HOME` (a fatter call, never a broken one).
 pub fn sandbox_home() -> Option<PathBuf> {
     let real = meridian_core::paths::home_dir_or_cwd();
-    let root = std::env::temp_dir().join("meridian-cursor-home");
+    let root = scratch_root("meridian-cursor-home");
 
     if let Err(e) = build_sandbox(&real, &root) {
         tracing::warn!(
@@ -178,15 +182,71 @@ fn restrict(path: &Path, mode: u32) -> std::io::Result<()> {
 /// `AGENTS.md` / `.cursorrules` - measured: the entire file arrives as
 /// `<always_applied_workspace_rules>`. That is coding-assistant instruction text contaminating a
 /// pure summarise/classify call, and this is Cursor's equivalent of what Claude's
-/// `--setting-sources ""` suppresses. `std::env::temp_dir()` sits outside the home tree on macOS
-/// (`$TMPDIR` -> `/var/folders/…`) and Linux (`/tmp`), so no such ancestor can exist. An empty
-/// workspace also leaves the agent nothing to read - every input we need is already in the prompt.
+/// `--setting-sources ""` suppresses. [`scratch_root`] guarantees no such ancestor can exist. An
+/// empty workspace also leaves the agent nothing to read - every input we need is already in the
+/// prompt.
 pub fn neutral_workspace() -> PathBuf {
-    let dir = std::env::temp_dir().join("meridian-llm-workspace");
+    let dir = scratch_root("meridian-llm-workspace");
     if let Err(e) = std::fs::create_dir_all(&dir) {
         tracing::debug!(error = %e, path = %dir.display(), "cursor: neutral workspace mkdir failed");
     }
     dir
+}
+
+/// A Meridian-owned scratch directory that is NOT under the user's home.
+///
+/// Both callers depend on that property for correctness, for different reasons: the workspace
+/// because Cursor walks UP from it looking for rule files, and the sandbox because a `HOME`
+/// nested inside the real one mirrors itself.
+///
+/// `std::env::temp_dir()` satisfies it on macOS (`$TMPDIR` -> `/var/folders/…`) and Linux
+/// (`/tmp`) but **not on Windows**, where it resolves to `%USERPROFILE%\AppData\Local\Temp` -
+/// i.e. *inside* the home, so `~\CLAUDE.md` and `.cursorrules` would be back in scope. There we
+/// prefer `%PUBLIC%` (`C:\Users\Public`), which is user-writable by default and a sibling of the
+/// profile rather than a child.
+///
+/// If neither is outside the home the temp path is still returned - a fatter, rule-contaminated
+/// call beats no call - but it is logged, because that silently weakens a guarantee the module
+/// docs claim.
+fn scratch_root(name: &str) -> PathBuf {
+    let home = meridian_core::paths::home_dir_or_cwd();
+    let temp = std::env::temp_dir().join(name);
+    if !is_under(&temp, &home) {
+        return temp;
+    }
+    if let Some(public) = std::env::var_os("PUBLIC").map(PathBuf::from) {
+        let candidate = public.join(name);
+        if !is_under(&candidate, &home) {
+            return candidate;
+        }
+    }
+    tracing::warn!(
+        path = %temp.display(),
+        home = %home.display(),
+        "cursor: no scratch directory outside the home - workspace rules may be injected"
+    );
+    temp
+}
+
+/// Is `path` inside `ancestor`? Both are canonicalised where they exist, so a symlinked or
+/// short-name (`C:\Users\RUNNER~1`) temp dir cannot make an inside path look outside - which is
+/// exactly how a naive check passes on CI for the wrong reason.
+fn is_under(path: &Path, ancestor: &Path) -> bool {
+    let real = |p: &Path| {
+        std::fs::canonicalize(p).unwrap_or_else(|_| {
+            // Not created yet: canonicalise the nearest existing parent and re-join.
+            match p.parent() {
+                Some(parent) => std::fs::canonicalize(parent)
+                    .map(|c| match p.file_name() {
+                        Some(n) => c.join(n),
+                        None => c,
+                    })
+                    .unwrap_or_else(|_| p.to_path_buf()),
+                None => p.to_path_buf(),
+            }
+        })
+    };
+    real(path).starts_with(real(ancestor))
 }
 
 /// The safety flags every Meridian `cursor-agent` call carries, in argv order.
@@ -235,7 +295,12 @@ pub fn env_overrides(sandbox: Option<&Path>) -> Vec<(&'static str, String)> {
         ),
     ];
     if let Some(home) = sandbox {
-        env.push(("HOME", home.to_string_lossy().into_owned()));
+        let home = home.to_string_lossy().into_owned();
+        env.push(("HOME", home.clone()));
+        // cursor-agent is a Node bundle, and Node's `os.homedir()` reads `USERPROFILE` on
+        // Windows - `HOME` alone moves nothing there, so the skills would come straight back.
+        // Harmless on unix, where nothing reads it.
+        env.push(("USERPROFILE", home));
     }
     env
 }
@@ -271,9 +336,254 @@ pub fn looks_auth_failure(msg: &str) -> bool {
         || m.contains("login required")
 }
 
+/// Did the CLI reject the model as unavailable on this account?
+///
+/// Cursor plans differ in model access, so a pinned id can simply be absent. Detecting that
+/// lets the ladder fall back to [`FALLBACK_MODEL`] rather than failing every call.
+pub fn looks_unknown_model(msg: &str) -> bool {
+    let m = msg.to_lowercase();
+    m.contains("model")
+        && (m.contains("unknown")
+            || m.contains("not available")
+            || m.contains("unavailable")
+            || m.contains("invalid")
+            || m.contains("not found")
+            || m.contains("does not exist")
+            || m.contains("no access"))
+}
+
+/// Pinned model for every Meridian `cursor-agent` call: small, fast, cheap and ZDR-eligible
+/// (Cursor flags non-ZDR models explicitly in `--list-models`; this is not one) - the right
+/// tier for summarise/classify/draft, and deterministic across users unlike the account
+/// default `auto`, which is server-routed and varies per call AND per account.
+///
+/// `-medium` is the effort suffix Cursor displays as plain "GPT-5.4 Mini"; the ladder is
+/// `-none/-low/-medium/-high/-xhigh`.
+pub const DEFAULT_MODEL: &str = "gpt-5.4-mini-medium";
+
+/// Cursor's server-routed default, used only when [`DEFAULT_MODEL`] is not on the account.
+pub const FALLBACK_MODEL: &str = "auto";
+
+/// A failure a [`run_hardened`] caller can classify.
+///
+/// Implemented by both call sites' error types so the ladder is written once. Returning
+/// `None` means "never degrade past this" - it is what keeps a rate limit from being
+/// mistaken for a broken install and burning a second attempt on an account-level wall.
+pub trait CursorCallError {
+    /// The failure text to classify, or `None` when this failure must not be retried.
+    fn degradable_message(&self) -> Option<&str>;
+}
+
+/// Which levers are still engaged. Each is dropped only in response to a DETECTED cause, so
+/// a healthy install always takes the fully hardened path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Levers {
+    no_tools: bool,
+    sandbox: bool,
+}
+
+/// Run a `cursor-agent` call, degrading one lever at a time when - and only when - the CLI
+/// says so.
+///
+/// `run` receives the safety argv and the environment for one attempt and performs the actual
+/// spawn/parse; everything about *which* flags to use and *when* to back off lives here. That
+/// is the whole point: before this existed the provider backend had the recovery ladder and
+/// the summariser did not, so the day Cursor drops the undocumented `--allowed-tools` the
+/// backend would have degraded gracefully while every coding-agent summary failed.
+///
+/// The ladder, each step gated on a detected cause:
+/// 1. `--allowed-tools` rejected -> retry without it (fatter context, still works)
+/// 2. auth invisible from the sandbox `HOME` -> retry on the inherited one (carries skills)
+/// 3. model unavailable on this plan -> retry on [`FALLBACK_MODEL`]
+///
+/// A rate limit degrades nothing: `degradable_message` returns `None` and the error is
+/// returned immediately, because Cursor limits are account-level and a second call would
+/// spend quota to hit the same wall.
+pub async fn run_hardened<T, E, F, Fut>(model: &str, mut run: F) -> Result<T, E>
+where
+    E: CursorCallError,
+    F: FnMut(Vec<String>, Vec<(&'static str, String)>) -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+{
+    let mut levers = Levers {
+        no_tools: true,
+        sandbox: true,
+    };
+    let mut model = model.to_string();
+    let mut tried_fallback_model = model == FALLBACK_MODEL;
+
+    loop {
+        let sandbox = if levers.sandbox { sandbox_home() } else { None };
+        let err = match run(
+            safety_args(&model, levers.no_tools),
+            env_overrides(sandbox.as_deref()),
+        )
+        .await
+        {
+            Ok(v) => return Ok(v),
+            Err(e) => e,
+        };
+
+        // `None` = not classifiable / must not be retried (a rate limit). Stop here.
+        let Some(msg) = err.degradable_message() else {
+            return Err(err);
+        };
+
+        if levers.no_tools && looks_unsupported_flag(msg) {
+            tracing::warn!(
+                "cursor: this CLI build rejects --allowed-tools - retrying without it \
+                 (call still works, just carries the full tool context)"
+            );
+            levers.no_tools = false;
+        } else if levers.sandbox && looks_auth_failure(msg) {
+            tracing::warn!(
+                "cursor: credentials not visible from the sandbox HOME - retrying on the \
+                 real HOME (call still works, just carries the user's skill list)"
+            );
+            levers.sandbox = false;
+        } else if !tried_fallback_model && looks_unknown_model(msg) {
+            tracing::warn!(
+                model = %model,
+                fallback = FALLBACK_MODEL,
+                "cursor: model unavailable on this account - retrying with auto"
+            );
+            model = FALLBACK_MODEL.to_string();
+            tried_fallback_model = true;
+        } else {
+            // Nothing left to degrade, or a cause no lever addresses.
+            return Err(err);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A stand-in for the real error types, so the ladder can be exercised without spawning
+    /// anything. `None` models the rate-limit case.
+    struct TestErr(Option<String>);
+    impl CursorCallError for TestErr {
+        fn degradable_message(&self) -> Option<&str> {
+            self.0.as_deref()
+        }
+    }
+
+    /// Drive `run_hardened` with a canned failure for the first `fail_n` attempts, recording
+    /// the argv/env of every attempt.
+    async fn ladder(
+        model: &str,
+        errs: Vec<Option<&'static str>>,
+    ) -> (
+        Result<usize, TestErr>,
+        Vec<(Vec<String>, Vec<(&'static str, String)>)>,
+    ) {
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let calls = std::sync::Arc::new(std::sync::Mutex::new(0usize));
+        let s2 = seen.clone();
+        let res = run_hardened(model, move |args, env| {
+            let s2 = s2.clone();
+            let calls = calls.clone();
+            let errs = errs.clone();
+            async move {
+                let n = {
+                    let mut c = calls.lock().unwrap();
+                    *c += 1;
+                    *c - 1
+                };
+                s2.lock().unwrap().push((args, env));
+                match errs.get(n) {
+                    Some(e) => Err(TestErr(e.map(str::to_string))),
+                    None => Ok(n),
+                }
+            }
+        })
+        .await;
+        let seen = seen.lock().unwrap().clone();
+        (res, seen)
+    }
+
+    #[tokio::test]
+    async fn a_healthy_call_takes_the_fully_hardened_path_and_never_retries() {
+        let (res, seen) = ladder(DEFAULT_MODEL, vec![]).await;
+        assert!(res.is_ok());
+        assert_eq!(seen.len(), 1, "no degradation without a detected cause");
+        assert!(seen[0].0.contains(&"--allowed-tools".to_string()));
+        assert!(seen[0].1.iter().any(|(k, _)| *k == "HOME"));
+    }
+
+    /// THE regression this module exists for: the recovery must be shared, so an unsupported
+    /// flag degrades rather than failing every call on a CLI upgrade.
+    #[tokio::test]
+    async fn an_unknown_option_drops_the_tool_flag_and_retries() {
+        let (res, seen) = ladder(
+            DEFAULT_MODEL,
+            vec![Some("error: unknown option '--allowed-tools'")],
+        )
+        .await;
+        assert!(res.is_ok());
+        assert_eq!(seen.len(), 2);
+        assert!(!seen[1].0.contains(&"--allowed-tools".to_string()));
+    }
+
+    #[tokio::test]
+    async fn an_auth_failure_drops_the_sandbox_home() {
+        let (res, seen) = ladder(DEFAULT_MODEL, vec![Some("Not logged in")]).await;
+        assert!(res.is_ok());
+        assert_eq!(seen.len(), 2);
+        assert!(
+            !seen[1].1.iter().any(|(k, _)| *k == "HOME"),
+            "the retry must inherit the real HOME"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unavailable_model_falls_back_to_auto() {
+        let (res, seen) = ladder(DEFAULT_MODEL, vec![Some("Unknown model: gpt-5.4-mini")]).await;
+        assert!(res.is_ok());
+        assert_eq!(seen.len(), 2);
+        assert!(seen[1].0.contains(&FALLBACK_MODEL.to_string()));
+    }
+
+    /// A rate limit must NOT walk the ladder - Cursor limits are account-level, so a retry
+    /// spends quota to hit the same wall.
+    #[tokio::test]
+    async fn a_rate_limit_returns_immediately_without_degrading() {
+        let (res, seen) = ladder(DEFAULT_MODEL, vec![None, None, None, None]).await;
+        assert!(res.is_err());
+        assert_eq!(seen.len(), 1, "a rate limit degrades nothing");
+    }
+
+    /// An unrelated failure is not a licence to strip hardening.
+    #[tokio::test]
+    async fn an_unrecognised_failure_does_not_degrade() {
+        let (res, seen) = ladder(DEFAULT_MODEL, vec![Some("connection reset by peer")]).await;
+        assert!(res.is_err());
+        assert_eq!(seen.len(), 1);
+    }
+
+    /// Each lever drops at most once, so a persistently failing CLI terminates instead of
+    /// looping.
+    #[tokio::test]
+    async fn the_ladder_terminates_after_every_lever_is_spent() {
+        let errs = vec![
+            Some("unknown option '--allowed-tools'"),
+            Some("Not logged in"),
+            Some("Unknown model: x"),
+            Some("unknown option '--allowed-tools'"),
+        ];
+        let (res, seen) = ladder(DEFAULT_MODEL, errs).await;
+        assert!(res.is_err());
+        assert_eq!(seen.len(), 4, "3 degradations, then give up");
+    }
+
+    /// Starting on `auto` means there is no model left to fall back to.
+    #[tokio::test]
+    async fn auto_does_not_fall_back_to_itself() {
+        let (res, seen) = ladder(FALLBACK_MODEL, vec![Some("Unknown model: auto")]).await;
+        assert!(res.is_err());
+        assert_eq!(seen.len(), 1);
+    }
 
     #[test]
     fn safety_args_carry_the_read_only_and_no_tool_levers() {
@@ -346,15 +656,46 @@ mod tests {
     #[test]
     fn sandbox_is_outside_the_real_home() {
         let real = meridian_core::paths::home_dir_or_cwd();
-        let sandbox = std::env::temp_dir().join("meridian-cursor-home");
+        // Assert on what the PRODUCT computes, via the same containment check it uses.
+        // Re-deriving the path here (`temp_dir().join(...)`) and comparing with a raw
+        // `starts_with` is how this passes for the wrong reason: on Windows CI the temp dir is
+        // an 8.3 short name (`C:\Users\RUNNER~1\…`) that never string-matches the home even
+        // though it is inside it.
         assert!(
-            !sandbox.starts_with(&real),
-            "sandbox must not live under $HOME"
+            !is_under(&scratch_root("meridian-cursor-home"), &real),
+            "sandbox must not live under $HOME - a nested sandbox mirrors itself"
         );
         assert!(
-            !neutral_workspace().starts_with(&real),
-            "workspace must not live under $HOME"
+            !is_under(&neutral_workspace(), &real),
+            "workspace must not live under $HOME - Cursor walks UP from it for rule files"
         );
+    }
+
+    /// The containment check must see through symlinks and short names, or the guarantee above
+    /// is only as good as the string comparison.
+    #[test]
+    fn containment_resolves_paths_rather_than_comparing_strings() {
+        let home = meridian_core::paths::home_dir_or_cwd();
+        assert!(is_under(&home.join("some-child"), &home));
+        assert!(!is_under(Path::new("/"), &home));
+        // The macOS case that motivated canonicalising: /tmp is a symlink to /private/tmp.
+        #[cfg(target_os = "macos")]
+        assert!(is_under(Path::new("/tmp/x"), Path::new("/private/tmp")));
+    }
+
+    /// The sandbox is useless on Windows without this: Node reads `USERPROFILE`, not `HOME`.
+    #[test]
+    fn the_sandbox_overrides_both_home_variables() {
+        let env = env_overrides(Some(Path::new("/tmp/sbx")));
+        let home = env.iter().find(|(k, _)| *k == "HOME");
+        let profile = env.iter().find(|(k, _)| *k == "USERPROFILE");
+        assert_eq!(home.map(|(_, v)| v.as_str()), Some("/tmp/sbx"));
+        assert_eq!(profile.map(|(_, v)| v.as_str()), Some("/tmp/sbx"));
+        // No sandbox = inherit both, so the fallback path really is the user's real home.
+        let plain = env_overrides(None);
+        assert!(!plain
+            .iter()
+            .any(|(k, _)| *k == "HOME" || *k == "USERPROFILE"));
     }
 
     /// Building it twice must be a no-op, and it must contain neutralised skill dirs.

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -225,6 +225,202 @@ pub async fn test_all_installed(settings: &RuntimeSettings) -> Vec<ProviderTestR
     futures::future::join_all(futures).await
 }
 
+// ── Install: run the provider's own CLI installer on the user's behalf ───────────────────
+
+/// How long the installer may run before we give up. `npm i -g` fetching a fresh toolchain,
+/// or `curl … | bash` pulling a signed tarball, can legitimately take a couple of minutes on
+/// a slow link — but not five, and the user is watching a spinner.
+const INSTALL_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// What running a provider's installer produced. Serialised to the UI, which shows the
+/// message verbatim and, on success, moves straight to a connectivity test.
+#[derive(Debug, Clone, Serialize)]
+pub struct InstallOutcome {
+    /// The installer exited 0 AND the CLI is now resolvable.
+    pub ok: bool,
+    /// Human-readable result — the installer's own tail on failure, a short confirmation on
+    /// success. Shown to the user as-is.
+    pub message: String,
+    /// Where the CLI landed, when we can now find it. `None` on failure.
+    pub path: Option<String>,
+    /// The exact command that was run, so the UI can offer a "run it yourself" fallback.
+    pub command: String,
+}
+
+/// Install `provider`'s CLI by running its official installer through the user's LOGIN shell,
+/// then confirm the binary is now resolvable.
+///
+/// # Why a login shell
+///
+/// The tray is a Finder-launched `.app` with the stripped launchd `PATH`
+/// (`/usr/bin:/bin:/usr/sbin:/sbin`), which has no `npm`, `node`, or Homebrew. `npm i -g …`
+/// would fail with "command not found" spawned directly. `$SHELL -l` sources the user's
+/// profile, so it sees the same `npm`/PATH they do in a terminal — the same reason
+/// [`resolve_cli`] probes through a login shell.
+///
+/// # Safety
+///
+/// The command comes from [`LlmProvider::install_command`], a fixed literal per provider with
+/// no user input, so passing it to `-c` cannot inject anything. This is the ONE place the
+/// daemon runs a vendor installer, and only ever on an explicit user click (the tray's
+/// `install_llm_provider` command) — never automatically.
+pub async fn install_provider(provider: LlmProvider) -> InstallOutcome {
+    let Some(cmd) = provider.install_command() else {
+        return InstallOutcome {
+            ok: false,
+            message: "This provider is a cloud endpoint - there is nothing to install.".into(),
+            path: None,
+            command: String::new(),
+        };
+    };
+    let bin = provider.cli_name().unwrap_or("");
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+
+    tracing::info!(provider = provider.as_str(), %cmd, "llm: running provider installer");
+    let mut command = Command::new(&shell);
+    command
+        .arg("-l")
+        .arg("-c")
+        .arg(cmd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let output = match command.spawn() {
+        Ok(child) => match tokio::time::timeout(INSTALL_TIMEOUT, child.wait_with_output()).await {
+            Ok(Ok(out)) => out,
+            Ok(Err(e)) => return install_failed(cmd, format!("could not run the installer: {e}")),
+            Err(_) => {
+                return install_failed(
+                    cmd,
+                    format!(
+                        "the installer took longer than {}s and was stopped",
+                        INSTALL_TIMEOUT.as_secs()
+                    ),
+                )
+            }
+        },
+        Err(e) => return install_failed(cmd, format!("could not start a shell to install: {e}")),
+    };
+
+    if !output.status.success() {
+        // The tail of stderr is the useful part (npm/curl print the real reason last); keep it
+        // bounded so a noisy installer can't flood the toast.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let tail: String = stderr.trim().chars().rev().take(400).collect::<String>();
+        let tail: String = tail.chars().rev().collect();
+        return install_failed(
+            cmd,
+            if tail.is_empty() {
+                "the installer exited with an error".to_string()
+            } else {
+                tail
+            },
+        );
+    }
+
+    // Exit 0 is necessary but not sufficient — confirm the binary is actually resolvable now,
+    // the same probe the install-state badge uses, so "installed" means the same thing here.
+    match resolve_cli(bin).await {
+        Some(p) => {
+            tracing::info!(provider = provider.as_str(), path = %p.display(), "llm: provider installed");
+            InstallOutcome {
+                ok: true,
+                message: "Installed. Checking your sign-in…".into(),
+                path: Some(p.display().to_string()),
+                command: cmd.to_string(),
+            }
+        }
+        None => install_failed(
+            cmd,
+            "the installer finished but the CLI still isn't on your PATH - try running it in a terminal".into(),
+        ),
+    }
+}
+
+/// How long the interactive Cursor sign-in may take - a human finishing an OAuth flow in their
+/// browser, so generous, but not unbounded.
+const CURSOR_LOGIN_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Run the interactive `cursor-agent login` on the user's behalf — the "Sign in to Cursor"
+/// button in the provider detail view.
+///
+/// This signs into the user's own Cursor account, so the coding-agent summariser then runs on
+/// their **Cursor subscription** — there is no API key and nothing metered. The browser is
+/// deliberately ENABLED here (the daemon's unattended `cursor_agent_init::ensure_ready` sets
+/// `NO_OPEN_BROWSER` because it can't ask a human anything; this path is an explicit click, so
+/// opening the browser to finish the sign-in is exactly what's wanted). Once it completes,
+/// cursor-agent persists the auth and every later daemon run just adopts it.
+pub async fn cursor_sign_in() -> InstallOutcome {
+    let label = "cursor-agent login";
+    let Some(path) = resolve_cli("cursor-agent").await else {
+        return install_failed(
+            label,
+            "cursor-agent isn't installed yet - install it first".into(),
+        );
+    };
+
+    tracing::info!("llm: launching interactive cursor-agent login");
+    let mut cmd = Command::new(&path);
+    cmd.arg("login")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let output = match cmd.spawn() {
+        Ok(child) => match tokio::time::timeout(CURSOR_LOGIN_TIMEOUT, child.wait_with_output())
+            .await
+        {
+            Ok(Ok(out)) => out,
+            Ok(Err(e)) => {
+                return install_failed(label, format!("couldn't run cursor-agent login: {e}"))
+            }
+            Err(_) => {
+                return install_failed(
+                    label,
+                    "the sign-in wasn't finished in time - click Sign in to Cursor again".into(),
+                )
+            }
+        },
+        Err(e) => return install_failed(label, format!("couldn't start cursor-agent: {e}")),
+    };
+
+    if output.status.success() {
+        tracing::info!("llm: cursor-agent login succeeded");
+        InstallOutcome {
+            ok: true,
+            message: "Signed in to Cursor.".into(),
+            path: Some(path.display().to_string()),
+            command: label.to_string(),
+        }
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let tail: String = stderr.trim().chars().rev().take(400).collect::<String>();
+        let tail: String = tail.chars().rev().collect();
+        install_failed(
+            label,
+            if tail.is_empty() {
+                "cursor-agent login failed".to_string()
+            } else {
+                tail
+            },
+        )
+    }
+}
+
+/// Build a failed [`InstallOutcome`], logging the reason.
+fn install_failed(cmd: &str, message: String) -> InstallOutcome {
+    tracing::warn!(%cmd, %message, "llm: provider install failed");
+    InstallOutcome {
+        ok: false,
+        message,
+        path: None,
+        command: cmd.to_string(),
+    }
+}
+
 // ── Cache: last-known test result per provider, survives restarts ───────────────────────
 
 fn test_cache_path() -> PathBuf {

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -305,17 +305,13 @@ pub async fn install_provider(provider: LlmProvider) -> InstallOutcome {
     };
 
     if !output.status.success() {
-        // The tail of stderr is the useful part (npm/curl print the real reason last); keep it
-        // bounded so a noisy installer can't flood the toast.
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let tail: String = stderr.trim().chars().rev().take(400).collect::<String>();
-        let tail: String = tail.chars().rev().collect();
+        let reason = tail(String::from_utf8_lossy(&output.stderr).trim(), 400);
         return install_failed(
             cmd,
-            if tail.is_empty() {
+            if reason.is_empty() {
                 "the installer exited with an error".to_string()
             } else {
-                tail
+                reason
             },
         );
     }
@@ -325,6 +321,7 @@ pub async fn install_provider(provider: LlmProvider) -> InstallOutcome {
     match resolve_cli(bin).await {
         Some(p) => {
             tracing::info!(provider = provider.as_str(), path = %p.display(), "llm: provider installed");
+            warn_if_version_unpinned(provider, &p).await;
             InstallOutcome {
                 ok: true,
                 message: "Installed. Checking your sign-in…".into(),
@@ -336,6 +333,57 @@ pub async fn install_provider(provider: LlmProvider) -> InstallOutcome {
             cmd,
             "the installer finished but the CLI still isn't on your PATH - try running it in a terminal".into(),
         ),
+    }
+}
+
+/// Confirm a pinned CLI actually installed at the pinned version, and warn loudly if not.
+///
+/// Only Cursor pins today. The pin works by rewriting version strings in the vendor's rolling
+/// installer **by pattern**, which means it **fails open**: if Cursor ever changes its version
+/// format the `sed` matches nothing, the script installs latest, and the user silently ends up
+/// on an unverified build - exactly the outcome the pin exists to prevent, and one that would
+/// surface much later as an unexplained flag rejection. This turns that into a log line at the
+/// moment it happens.
+///
+/// Deliberately does NOT fail the install: an unpinned CLI still works (the invocation ladder
+/// in [`crate::llm::cursor_cli`] degrades on an unknown flag), so blocking the user over a
+/// version mismatch would be worse than telling them.
+async fn warn_if_version_unpinned(provider: LlmProvider, path: &std::path::Path) {
+    let Some(expected) = provider.pinned_cli_version() else {
+        return;
+    };
+    let out = Command::new(path)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .output()
+        .await;
+    let Ok(out) = out else {
+        tracing::warn!(
+            provider = provider.as_str(),
+            "llm: could not read the installed CLI version - cannot confirm the pin applied"
+        );
+        return;
+    };
+    let reported = String::from_utf8_lossy(&out.stdout);
+    let reported = reported.trim();
+    if reported.contains(expected) {
+        tracing::info!(
+            provider = provider.as_str(),
+            version = expected,
+            "llm: installed CLI matches the pinned version"
+        );
+    } else {
+        tracing::warn!(
+            provider = provider.as_str(),
+            expected,
+            reported = %reported,
+            "llm: the version pin did not apply - the vendor installer's version format probably \
+             changed, so an UNVERIFIED build was installed. Update CURSOR_CLI_VERSION and the \
+             rewrite pattern in meridian-core/src/llm_provider.rs."
+        );
     }
 }
 
@@ -369,22 +417,54 @@ pub async fn cursor_sign_in() -> InstallOutcome {
         .stderr(Stdio::piped())
         .kill_on_drop(true);
 
-    let output = match cmd.spawn() {
-        Ok(child) => match tokio::time::timeout(CURSOR_LOGIN_TIMEOUT, child.wait_with_output())
-            .await
-        {
-            Ok(Ok(out)) => out,
-            Ok(Err(e)) => {
-                return install_failed(label, format!("couldn't run cursor-agent login: {e}"))
-            }
-            Err(_) => {
-                return install_failed(
-                    label,
-                    "the sign-in wasn't finished in time - click Sign in to Cursor again".into(),
-                )
-            }
-        },
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
         Err(e) => return install_failed(label, format!("couldn't start cursor-agent: {e}")),
+    };
+
+    // Drain stdout as it arrives rather than only via `wait_with_output`. `cursor-agent login`
+    // prints its verification URL / device code to STDOUT while it waits, and that is precisely
+    // what the user needs when the browser does not open for them (no default browser, wrong
+    // profile, a headless session). Waiting for exit would discard it on the timeout path -
+    // leaving a 180 s spinner followed by an error with no way to finish the sign-in by hand.
+    let seen = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    if let Some(out) = child.stdout.take() {
+        let seen = seen.clone();
+        tokio::spawn(async move {
+            use tokio::io::{AsyncBufReadExt, BufReader};
+            let mut lines = BufReader::new(out).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                tracing::info!(line = %line, "cursor-agent login");
+                let mut buf = seen.lock().unwrap_or_else(|e| e.into_inner());
+                buf.push_str(&line);
+                buf.push('\n');
+            }
+        });
+    }
+    let login_output = |seen: &std::sync::Mutex<String>| -> String {
+        let buf = seen.lock().unwrap_or_else(|e| e.into_inner());
+        tail(buf.trim(), 300)
+    };
+
+    let output = match tokio::time::timeout(CURSOR_LOGIN_TIMEOUT, child.wait_with_output()).await {
+        Ok(Ok(out)) => out,
+        Ok(Err(e)) => {
+            return install_failed(label, format!("couldn't run cursor-agent login: {e}"))
+        }
+        Err(_) => {
+            let printed = login_output(&seen);
+            return install_failed(
+                label,
+                if printed.is_empty() {
+                    "the sign-in wasn't finished in time - click Sign in to Cursor again".into()
+                } else {
+                    format!(
+                        "the sign-in wasn't finished in time. Finish it by hand with what \
+                         cursor-agent printed:\n{printed}"
+                    )
+                },
+            );
+        }
     };
 
     if output.status.success() {
@@ -396,18 +476,32 @@ pub async fn cursor_sign_in() -> InstallOutcome {
             command: label.to_string(),
         }
     } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let tail: String = stderr.trim().chars().rev().take(400).collect::<String>();
-        let tail: String = tail.chars().rev().collect();
+        // stderr first (that is where the reason goes), but fall back to what the CLI printed
+        // on stdout - on some failures the URL/device code is the only useful thing said.
+        let reason = tail(String::from_utf8_lossy(&output.stderr).trim(), 400);
+        let reason = if reason.is_empty() {
+            login_output(&seen)
+        } else {
+            reason
+        };
         install_failed(
             label,
-            if tail.is_empty() {
+            if reason.is_empty() {
                 "cursor-agent login failed".to_string()
             } else {
-                tail
+                reason
             },
         )
     }
+}
+
+/// The last `n` characters of `s`, char-safe.
+///
+/// The tail is the useful end of CLI output - npm, curl and cursor-agent all print the real
+/// reason last - and bounding it stops a noisy installer flooding a toast.
+fn tail(s: &str, n: usize) -> String {
+    let rev: String = s.trim().chars().rev().take(n).collect();
+    rev.chars().rev().collect()
 }
 
 /// Build a failed [`InstallOutcome`], logging the reason.

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -31,6 +31,7 @@ pub mod codex;
 pub mod config;
 pub mod copilot;
 pub mod cursor;
+pub mod cursor_cli;
 pub mod detect;
 pub mod openai_compat;
 pub mod probe;
@@ -62,6 +63,20 @@ pub use resolver::{complete, resolve};
 /// subprocess cannot flip it. The setup/Settings UI says so and links each provider's
 /// toggle; do not add copy here claiming we turned training off, because we didn't.
 pub const DO_NOT_TRACK: (&str, &str) = ("DO_NOT_TRACK", "1");
+
+/// Stamped on the first line of every Meridian-issued `cursor-agent` prompt.
+///
+/// Cursor has **no** `--no-session-persistence` (Claude does, and uses it), so each
+/// `cursor-agent -p` call writes a chat to `~/.cursor/chats`. The cursor-cli ingest
+/// source (`coding_agent_session_ingest::sources::cursor_cli`) would otherwise pick
+/// those up as developer activity and re-summarise them next hour - summarise → new
+/// session → ingest → summarise. The ingest self-guard
+/// (`sources::is_meridian_artifact`) drops any session whose first prompt carries this
+/// marker, cutting that loop for **every** AI process routed through Cursor - not just
+/// the coding-agent summariser (which is separately fingerprinted by
+/// `summariser::prompts::SUMMARY_PROMPT_MARKER`). Keep the string distinctive so a real
+/// developer prompt can never collide with it.
+pub const MERIDIAN_PROMPT_MARKER: &str = "[meridian-internal-ai-call]";
 
 /// Why a backend failed.
 ///

--- a/src/llm/resolver.rs
+++ b/src/llm/resolver.rs
@@ -212,8 +212,17 @@ pub fn backend_for(provider: LlmProvider, cfg: LlmConfig) -> Box<dyn LlmBackend>
 pub fn resolve() -> Box<dyn LlmBackend> {
     let s = load_runtime_settings();
     let cfg = LlmConfig::from_settings(&s);
-    let chosen = LlmProvider::from_wire(&s.llm_provider).unwrap_or_default();
-    backend_for(chosen, cfg)
+    backend_for(chosen_provider(), cfg)
+}
+
+/// WHICH provider the user has chosen, without building a backend.
+///
+/// The single place that reads the stored choice, so callers that only need to *reason*
+/// about the provider (rather than call it) do not re-implement the parse-and-default
+/// dance. Used by the coding-agent summariser's fallback to answer "is my global provider
+/// the same CLI that just failed?" before spending a call to find out.
+pub fn chosen_provider() -> LlmProvider {
+    LlmProvider::from_wire(&load_runtime_settings().llm_provider).unwrap_or_default()
 }
 
 /// Run one prose call through the user's provider, with retry and rate-limit handling.

--- a/tray/src-tauri/src/commands/setup.rs
+++ b/tray/src-tauri/src/commands/setup.rs
@@ -213,6 +213,38 @@ pub async fn test_llm_provider(
     Ok(result)
 }
 
+/// Install one provider's CLI by running its official installer on the user's behalf - the
+/// provider detail view's "Install" button. Runs through the user's login shell so `npm`/PATH
+/// resolve (see [`meridian::llm::detect::install_provider`]), then confirms the binary is now
+/// present. Only ever on an explicit click - the daemon never installs anything automatically.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn install_llm_provider(
+    id: String,
+) -> Result<meridian::llm::detect::InstallOutcome, String> {
+    let provider = meridian_core::LlmProvider::from_wire(&id)
+        .ok_or_else(|| format!("unknown provider {id:?}"))?;
+    let outcome = meridian::llm::detect::install_provider(provider).await;
+    tracing::info!(
+        provider = %id,
+        ok = outcome.ok,
+        "llm: provider install complete"
+    );
+    Ok(outcome)
+}
+
+/// Run the interactive `cursor-agent login` - the Cursor detail view's "Sign in to Cursor"
+/// button. Opens the user's browser to sign into their own Cursor account, so the summariser
+/// runs on their Cursor SUBSCRIPTION (no API key, nothing metered). Only ever on an explicit
+/// click; the daemon's own unattended path never opens a browser.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn cursor_sign_in() -> Result<meridian::llm::detect::InstallOutcome, String> {
+    let outcome = meridian::llm::detect::cursor_sign_in().await;
+    tracing::info!(ok = outcome.ok, "llm: cursor sign-in complete");
+    Ok(outcome)
+}
+
 /// Test every currently-installed provider at once - the Intelligence panel's Rescan
 /// action. Each result is persisted as it lands (see
 /// [`meridian::llm::detect::test_all_installed`]), so a slow or hanging CLI can't hold the

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -602,6 +602,8 @@ pub fn run() {
             commands::detect_llm_providers,
             commands::test_llm_provider,
             commands::test_all_llm_providers,
+            commands::install_llm_provider,
+            commands::cursor_sign_in,
             // Custom cloud endpoints (add/probe/remove). `add` + `probe` spend real metered
             // requests measuring the endpoint — only ever on explicit user action.
             commands::add_custom_llm_provider,

--- a/ui/__tests__/intelligence-provider-save.test.ts
+++ b/ui/__tests__/intelligence-provider-save.test.ts
@@ -27,13 +27,20 @@ import { readFileSync } from 'fs'
 // transition and scan the source for the required shape rather than mounting the component.
 
 const uiRoot = import.meta.dir + '/..'
-const section = readFileSync(uiRoot + '/components/timeline/settings/IntelligenceSection.tsx', 'utf8')
 
-/** Source with comments stripped. The module header deliberately describes the removed optimistic
+/** Source with comments stripped. The module headers deliberately describe the removed optimistic
  *  behaviour, so scanning raw text would conflate documenting the old bug with still doing it. */
-const code = section
-  .replace(/\/\*[\s\S]*?\*\//g, '')
-  .replace(/^\s*\/\/.*$/gm, '')
+function sourceOf(rel: string): string {
+  return readFileSync(uiRoot + rel, 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '')
+}
+
+const code = sourceOf('/components/timeline/settings/IntelligenceSection.tsx')
+/** The OTHER surface that can change the provider. Asserting these invariants only against
+ *  Settings was false confidence: the wizard violated both (it kept optimistic local state and
+ *  never cleared llm_provider_model), and the suite stayed green because it looked away. */
+const setup = sourceOf('/app/setup/page.tsx')
 
 // ── The commit model ─────────────────────────────────────────────────────────
 // The displayed provider is `settings.llm_provider`; the parent's `save` updates that only on a
@@ -84,7 +91,9 @@ describe('IntelligenceSection writes nothing before a successful save', () => {
 
   it('does not stage the pick - the pick commits immediately, there is no pending state', () => {
     expect(code).not.toContain('setPending')
-    expect(code).not.toContain('pending')
+    // Match the IDENTIFIER, not the substring: a bare `toContain('pending')` also trips on an
+    // unrelated `var(--color-state-pending)`, which would fail for a reason that isn't the rule.
+    expect(code).not.toMatch(/\bpendingProvider\b|\bpending\s*[,=)]/)
   })
 
   it('reads the displayed provider straight from settings on disk, not from local state', () => {
@@ -99,5 +108,42 @@ describe('IntelligenceSection writes nothing before a successful save', () => {
     expect(code).toMatch(/reject\(/)
     // The only writes go through `commit`, which is the sole caller of `save`.
     expect(code).toContain('commit(')
+  })
+})
+
+// ── The same invariants, on the wizard ───────────────────────────────────────
+// Both surfaces write the provider, so both must obey the rules. These are the assertions that
+// would have caught the divergence.
+describe('the setup wizard obeys the same commit rules as Settings', () => {
+  it('moves the UI only after the write resolves - no optimistic pick to roll back', () => {
+    // The old shape called setProviderState(id) BEFORE mutate() and undid it in .catch. Two
+    // overlapping picks could then roll back to a value the disk no longer held.
+    expect(setup).not.toMatch(/setProviderState\(id\)[\s\S]{0,200}?mutate</)
+    expect(setup).toMatch(/mutate<RuntimeSettings>[\s\S]*?\.then\(\(\) => \{[\s\S]*?setProviderState\(id\)/)
+  })
+
+  it('returns the promise so a failed switch can surface in the shared detail view', () => {
+    expect(setup).toMatch(/return mutate<RuntimeSettings>/)
+    expect(setup).toMatch(/throw e/)
+  })
+
+  it('builds the written fields with the SHARED helper, not a hand-rolled literal', () => {
+    // The finding this pins: the wizard's own object omitted llm_provider_model, so a stale
+    // override rode onto the new CLI (and on Cursor suppressed the pinned ZDR-eligible model).
+    expect(setup).toContain('providerChoiceFields(')
+    expect(setup).not.toMatch(/\{\s*llm_provider:\s*id\s*\}/)
+  })
+})
+
+describe('both provider surfaces share one field-builder', () => {
+  it('neither hand-rolls the settings patch', () => {
+    for (const src of [code, setup]) expect(src).toContain('providerChoiceFields(')
+  })
+
+  it('switching a built-in clears any stale model override', () => {
+    const helper = sourceOf('/lib/llm-providers.ts')
+    expect(helper).toMatch(/llm_provider_model:\s*null/)
+    // 'custom' keeps its model - it is a real per-endpoint setting, not a leftover.
+    expect(helper).toMatch(/llm_provider_custom_id:\s*customId \?\? null/)
   })
 })

--- a/ui/__tests__/intelligence-provider-save.test.ts
+++ b/ui/__tests__/intelligence-provider-save.test.ts
@@ -4,183 +4,100 @@ import { readFileSync } from 'fs'
 
 // Regression guard for "Settings claims a provider the daemon rejected".
 //
-// THE BUG: Settings → Intelligence wrote the AI-provider choice on a single click:
+// THE ORIGINAL BUG: Settings → Intelligence wrote the AI-provider choice on a single click:
 //
 //     patch(fields)          // optimistic - mutates the shared RuntimeSettings NOW
 //     save(fields, setStatus)
 //
-// with a code comment claiming `save` "rolls the store back to the server's answer
-// on failure". It does not. `useRuntimeSettings.save` calls `setSettings` ONLY on
-// success and swallows the error (settings/useRuntimeSettings.ts), so a REJECTED
-// write left the optimistic patch in place: the panel went on showing a provider
-// the daemon had refused, with nothing but a transient status to hint otherwise.
+// with a comment claiming `save` "rolls the store back on failure". It does not:
+// `useRuntimeSettings.save` calls `setSettings` ONLY on success (settings/useRuntimeSettings.ts),
+// so a REJECTED write left the optimistic patch in place - the panel went on showing a provider
+// the daemon had refused.
 //
-// THE FIX IS STRUCTURAL: a pick is STAGED in component-local `pending` state and
-// nothing is written until an explicit Save reports success. Because no write
-// happens before the outcome is known, there is no rollback to get wrong. On
-// failure the staged pick deliberately SURVIVES, so the user can press Save again
-// without re-picking.
+// THE ARCHITECTURE NOW: the provider chooser is a two-level <LlmProviderPicker> (chooser +
+// per-provider detail). A pick COMMITS IMMEDIATELY through the detail view's explicit "Use
+// <provider>" button - there is no staging - but the anti-bug invariant is kept STRUCTURALLY a
+// different way: the panel reads the displayed provider straight from `settings.llm_provider`
+// (what is on disk), and `commit` writes ONLY through `save`, which mutates the in-memory
+// settings only on success. So a failed write never changes what the panel shows, and there is
+// no optimistic patch to roll back. `commit` also REJECTS on an error status, so the detail view
+// can surface the failure instead of silently swallowing it.
 //
-// Two further rules these guards pin, both easy to regress:
-//   - the dirty check compares the (provider, custom_id) PAIR. 'custom' is a KIND,
-//     so two different endpoints are both id === 'custom'; comparing the id alone
-//     makes switching between them invisible and Save never lights up.
-//   - re-picking whatever is already saved CLEARS the stage, so Save can never
-//     offer to write a change that isn't one.
-//
-// The repo has no React render harness (see plan-store / oauth-setup-lifecycle), so
-// we model the transitions and scan the source for the required shape rather than
-// mounting the component.
+// The repo has no React render harness (see plan-store / oauth-setup-lifecycle), so we model the
+// transition and scan the source for the required shape rather than mounting the component.
 
 const uiRoot = import.meta.dir + '/..'
 const section = readFileSync(uiRoot + '/components/timeline/settings/IntelligenceSection.tsx', 'utf8')
 
-/** Source with comments stripped. The structural guards below assert on CODE - the
- *  module header deliberately describes the removed `patch()`-on-click behaviour, so
- *  scanning raw text would conflate documenting the old bug with still doing it. */
+/** Source with comments stripped. The module header deliberately describes the removed optimistic
+ *  behaviour, so scanning raw text would conflate documenting the old bug with still doing it. */
 const code = section
   .replace(/\/\*[\s\S]*?\*\//g, '')
   .replace(/^\s*\/\/.*$/gm, '')
 
-// ── The staging model ────────────────────────────────────────────────────────
-// Mirrors IntelligenceSection's two transitions: `onChange` (stage a pick) and
-// the `save` status callback (resolve it).
+// ── The commit model ─────────────────────────────────────────────────────────
+// The displayed provider is `settings.llm_provider`; the parent's `save` updates that only on a
+// successful write. `commit` resolves on 'saved' and rejects on 'error'.
 
-interface Choice { id: string; customId: string | null }
-
-/** `onChange`: stage a pick, or clear the stage when it IS the saved choice. */
-function stage(saved: Choice, pick: Choice): Choice | null {
-  const nextCustomId = pick.id === 'custom' ? pick.customId ?? null : null
-  const backToSaved = pick.id === saved.id && (pick.id !== 'custom' || nextCustomId === saved.customId)
-  return backToSaved ? null : { id: pick.id, customId: nextCustomId }
+/** What the panel SHOWS after a commit attempt: the pick only once the write succeeded. */
+function shownAfter(saved: string, pick: string, status: 'saved' | 'error'): string {
+  return status === 'saved' ? pick : saved
 }
 
-/** The `save` status callback: the stage clears on 'saved' only. */
-function onSaveStatus(pending: Choice | null, status: 'idle' | 'saved' | 'error'): Choice | null {
-  return status === 'saved' ? null : pending
+/** Does `commit` reject (so the detail view can show the failure)? */
+function commitRejects(status: 'saved' | 'error'): boolean {
+  return status === 'error'
 }
 
-/** What the panel DISPLAYS: the staged pick while one is held, else what's on disk. */
-function shown(saved: Choice, pending: Choice | null): Choice {
-  return pending ?? saved
-}
-
-const CLAUDE: Choice = { id: 'claude', customId: null }
-const LOCAL: Choice = { id: 'local', customId: null }
-const CUSTOM_A: Choice = { id: 'custom', customId: 'endpoint-a' }
-const CUSTOM_B: Choice = { id: 'custom', customId: 'endpoint-b' }
-
-describe('a provider pick is staged, not written', () => {
-  it('picking a different provider stages it without touching the saved choice', () => {
-    const pending = stage(CLAUDE, LOCAL)
-    expect(pending).toEqual(LOCAL)
-    // The panel shows the staged pick...
-    expect(shown(CLAUDE, pending).id).toBe('local')
-    // ...but nothing has been persisted, so the saved choice is still Claude.
-    expect(CLAUDE.id).toBe('claude')
+describe('a provider pick commits through save, never optimistically', () => {
+  it('shows the new provider only after the write succeeds', () => {
+    expect(shownAfter('claude', 'codex', 'saved')).toBe('codex')
   })
 
-  it('re-picking the saved provider clears the stage, so Save cannot offer a no-op', () => {
-    expect(stage(CLAUDE, CLAUDE)).toBeNull()
-    // And staging then coming back also clears it.
-    const staged = stage(CLAUDE, LOCAL)
-    expect(staged).not.toBeNull()
-    expect(stage(CLAUDE, CLAUDE)).toBeNull()
+  it('a FAILED write leaves the panel on the saved provider - never claims a rejected one', () => {
+    // The whole point: no optimistic patch to survive, so what shows is still what is in force.
+    expect(shownAfter('claude', 'codex', 'error')).toBe('claude')
   })
 
-  it('a successful save resolves the stage', () => {
-    const pending = stage(CLAUDE, LOCAL)
-    expect(onSaveStatus(pending, 'saved')).toBeNull()
-  })
-})
-
-// ── The reviewer's explicit ask, and the bug this PR fixes ───────────────────
-describe('a FAILED save keeps the staged pick', () => {
-  it('keeps it, so the user can press Save again without re-picking', () => {
-    const pending = stage(CLAUDE, LOCAL)
-    const after = onSaveStatus(pending, 'error')
-    expect(after).toEqual(LOCAL)
+  it('a failed commit rejects, so the detail view can surface it instead of swallowing it', () => {
+    expect(commitRejects('error')).toBe(true)
+    expect(commitRejects('saved')).toBe(false)
   })
 
-  it("and the saved choice is untouched — the panel never claims a rejected provider", () => {
-    const saved = CLAUDE
-    const pending = stage(saved, LOCAL)
-    onSaveStatus(pending, 'error')
-    // Nothing was written, so what is actually in force is still Claude.
-    expect(saved).toEqual(CLAUDE)
-  })
-
-  it('the OLD optimistic path retained the rejected provider — proving these discriminate', () => {
-    // Model the pre-fix behaviour: patch() mutated the shared settings BEFORE the
-    // write, and the failure path never restored it.
-    let settings: Choice = { ...CLAUDE }
-    const optimisticPatch = (next: Choice) => { settings = next }
-    optimisticPatch(LOCAL)
-    // save() fails: useRuntimeSettings.save only setSettings on SUCCESS, so nothing
-    // undoes the patch.
-    expect(settings).toEqual(LOCAL)      // <- the bug: shows a provider that was rejected
-    expect(settings).not.toEqual(CLAUDE) // <- and the real setting is misreported
-  })
-})
-
-// ── The pair comparison ──────────────────────────────────────────────────────
-describe("the dirty check compares the (provider, custom_id) pair", () => {
-  it('switching between two custom endpoints registers as a change', () => {
-    const pending = stage(CUSTOM_A, CUSTOM_B)
-    expect(pending).toEqual(CUSTOM_B)
-  })
-
-  it('re-picking the same custom endpoint clears the stage', () => {
-    expect(stage(CUSTOM_A, CUSTOM_A)).toBeNull()
-  })
-
-  it('comparing the id ALONE would miss it — proving the pair matters', () => {
-    const idOnly = (saved: Choice, pick: Choice) => (pick.id === saved.id ? null : pick)
-    // Both are id === 'custom', so an id-only check sees no change and Save never lights up.
-    expect(idOnly(CUSTOM_A, CUSTOM_B)).toBeNull()
-    expect(stage(CUSTOM_A, CUSTOM_B)).not.toBeNull()
-  })
-
-  it('leaving custom for a built-in drops the endpoint id', () => {
-    expect(stage(CUSTOM_A, CLAUDE)).toEqual({ id: 'claude', customId: null })
+  it('the OLD optimistic path retained the rejected provider - proving these discriminate', () => {
+    // Model the pre-fix behaviour: patch() mutated the shared settings BEFORE the write, and the
+    // failure path never restored it.
+    let settings = 'claude'
+    const optimisticPatch = (next: string) => { settings = next }
+    optimisticPatch('codex')
+    // save() fails; useRuntimeSettings.save only setSettings on SUCCESS, so nothing undoes it.
+    expect(settings).toBe('codex')      // <- the bug: shows a provider that was rejected
+    expect(settings).not.toBe('claude') // <- and the real setting is misreported
   })
 })
 
 // ── The source shape that keeps the above true ───────────────────────────────
 describe('IntelligenceSection writes nothing before a successful save', () => {
-  it('has no optimistic patch() — the call the bug depended on is gone', () => {
-    // `patch` is no longer even a prop; the write happens only inside onSave.
+  it('has no optimistic patch() - the call the bug depended on is gone', () => {
     expect(code).not.toContain('patch')
   })
 
-  it('clears the stage only on a SAVED status, never unconditionally', () => {
-    // The single setPending(null) that resolves a save must be guarded by 'saved'.
-    expect(code).toMatch(/'saved'\s*\)\s*setPending\(null\)/)
-    // ...and that is the ONLY place the stage is cleared post-save.
-    const clears = code.match(/setPending\(null\)/g) ?? []
-    expect(clears.length).toBe(1)
+  it('does not stage the pick - the pick commits immediately, there is no pending state', () => {
+    expect(code).not.toContain('setPending')
+    expect(code).not.toContain('pending')
   })
 
-  it('stages the pick in onChange rather than saving from it', () => {
-    expect(code).toContain('setPending(')
-    // onChange must not call save directly - that would restore click-to-apply.
-    const onChangeBody = code.slice(code.indexOf('const onChange'), code.indexOf('const onSave'))
-    expect(onChangeBody).not.toContain('save(')
+  it('reads the displayed provider straight from settings on disk, not from local state', () => {
+    // `value={provider}` where `provider = settings.llm_provider`, so a failed write can't change it.
+    expect(code).toMatch(/const provider = settings\.llm_provider/)
+    expect(code).toContain('value={provider}')
   })
 
-  it('renders the picker from the staged pick, so the panel shows what Save would write', () => {
-    expect(code).toMatch(/pending\?\.id\s*\?\?\s*savedId/)
-  })
-})
-
-describe('the Save control cannot fall below the fold', () => {
-  it('is sticky and only rendered while a pick is staged', () => {
-    expect(code).toContain('sticky bottom-0')
-    expect(code).toMatch(/\{pending && \(/)
-  })
-
-  it('tells the user the pick survived a failed write', () => {
-    // Generic "Failed to save" can't say the stage was kept; this line must.
-    expect(code).toContain('still selected here')
+  it('commits only through save, resolving on saved and rejecting on error', () => {
+    expect(code).toMatch(/s === 'saved'/)
+    expect(code).toMatch(/s === 'error'/)
+    expect(code).toMatch(/reject\(/)
+    // The only writes go through `commit`, which is the sole caller of `save`.
+    expect(code).toContain('commit(')
   })
 })

--- a/ui/__tests__/model-picker.test.ts
+++ b/ui/__tests__/model-picker.test.ts
@@ -32,6 +32,8 @@ const picker = readFileSync(uiRoot + '/components/ModelPicker.tsx', 'utf8')
 const section = readFileSync(uiRoot + '/components/timeline/settings/IntelligenceSection.tsx', 'utf8')
 const composer = readFileSync(uiRoot + '/components/timeline/llmlab/RunComposer.tsx', 'utf8')
 const registry = readFileSync(uiRoot + '/lib/llm-providers.ts', 'utf8')
+/** The setup wizard - the second surface that writes the provider. */
+const setup = readFileSync(uiRoot + '/app/setup/page.tsx', 'utf8')
 
 /** Source with comments stripped - these guards assert on CODE, and the headers above
  *  each file describe the very behaviour being guarded against. */
@@ -64,22 +66,32 @@ describe('a stored model override is cleared when the provider changes', () => {
   })
 })
 
-describe('the settings section persists the provider correctly', () => {
-  const code = stripComments(section)
+// Both surfaces that can change the provider must obey this, not just Settings. Asserting it
+// against IntelligenceSection alone was false confidence: the wizard hand-rolled its own
+// `{ llm_provider: id }` and so never cleared the override, and this suite stayed green because
+// it did not read that file. Now the rule is pinned on the SHARED builder both of them call.
+describe('every provider surface persists the choice through one builder', () => {
+  const helper = stripComments(registry)
 
   it('does not write the shared model override for a custom endpoint', () => {
     // A custom endpoint's model lives on its own row; openai_compat sends ep.model and ignores
     // cfg.model, so the custom arm writes only the endpoint id, never the shared field.
-    const start = code.indexOf('? commit(')
-    const customArm = code.slice(start, code.indexOf(': commit(', start))
+    const start = helper.indexOf('return id === \'custom\'')
+    const customArm = helper.slice(start, helper.indexOf(': {', start))
     expect(customArm).toContain('llm_provider_custom_id')
     expect(customArm).not.toContain('llm_provider_model')
   })
 
-  it('clears the stored model on a provider switch', () => {
-    // The built-in arm of onChange writes llm_provider_model: null - the SOURCE tie for the rule
-    // modelled above.
-    expect(code).toMatch(/llm_provider: id, llm_provider_model: null/)
+  it('clears the stored model on a built-in provider switch', () => {
+    expect(helper).toMatch(/llm_provider: id, llm_provider_model: null/)
+  })
+
+  it('neither Settings nor the wizard hand-rolls the patch', () => {
+    for (const src of [stripComments(section), stripComments(setup)]) {
+      expect(src).toContain('providerChoiceFields(')
+      // The literal the wizard used to write, which silently omitted the model clear.
+      expect(src).not.toMatch(/\{\s*llm_provider:\s*id\s*\}/)
+    }
   })
 })
 

--- a/ui/__tests__/model-picker.test.ts
+++ b/ui/__tests__/model-picker.test.ts
@@ -39,89 +39,47 @@ function stripComments(src: string): string {
   return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
 }
 
-// ── Rule 1: the staging model ────────────────────────────────────────────────
-// Mirrors IntelligenceSection's `onChange` / `onModelChange`.
+// ── Rule 1: a stored model override never rides onto another provider ────────
+// The redesigned settings UI has NO per-provider model control - the model always follows the
+// provider's own default. But `llm_provider_model` still exists on disk (older builds wrote it,
+// and src/llm/config.rs still passes it into --model), so switching a built-in provider must
+// CLEAR it: a value left from claude must not reach codex's -m.
 
-interface Choice { id: string; customId: string | null; model: string }
-
-/** `onChange`: stage a provider pick, dropping the model unless we land back on the
- *  saved provider (where the saved model is what's on disk). */
-function stageProvider(saved: Choice, pickId: string, pickCustomId: string | null = null): Choice | null {
-  const nextCustomId = pickId === 'custom' ? pickCustomId : null
-  const nextModel = pickId === saved.id ? saved.model : ''
-  const backToSaved = pickId === saved.id && (pickId !== 'custom' || nextCustomId === saved.customId)
-  return backToSaved ? null : { id: pickId, customId: nextCustomId, model: nextModel }
+/** onChange for a provider pick: the fields committed. A built-in clears the stored model. */
+function switchFields(id: string): Record<string, unknown> {
+  return id === 'custom'
+    ? { llm_provider: id, llm_provider_custom_id: null }
+    : { llm_provider: id, llm_provider_model: null }
 }
 
-/** `onModelChange`: stage a model, collapsing to null once the whole triple matches disk. */
-function stageModel(saved: Choice, pending: Choice | null, next: string): Choice | null {
-  const staged = { ...(pending ?? saved), model: next }
-  const settled = staged.id === saved.id
-    && (staged.id !== 'custom' || staged.customId === saved.customId)
-    && staged.model === saved.model
-  return settled ? null : staged
-}
-
-describe('the model override is scoped to its provider', () => {
-  const saved: Choice = { id: 'claude', customId: null, model: 'opus' }
-
-  it('drops the staged model when the provider changes', () => {
-    // The leak this exists to stop: claude's "opus" reaching codex's -m.
-    expect(stageProvider(saved, 'codex')?.model).toBe('')
+describe('a stored model override is cleared when the provider changes', () => {
+  it('clears llm_provider_model when switching to another built-in', () => {
+    // The leak this stops: claude's "opus" reaching codex's -m.
+    expect(switchFields('codex').llm_provider_model).toBeNull()
   })
 
-  it('restores the saved model when the provider comes back', () => {
-    const away = stageProvider(saved, 'codex')
-    expect(away?.model).toBe('')
-    // Re-picking the saved provider clears the stage entirely, so what renders is
-    // the value on disk rather than the '' we passed through on the way out.
-    expect(stageProvider(saved, 'claude')).toBeNull()
-  })
-
-  it('keeps a model staged across an unrelated re-render', () => {
-    const staged = stageModel(saved, null, 'haiku')
-    expect(staged).toEqual({ id: 'claude', customId: null, model: 'haiku' })
-  })
-
-  it('clears the stage when the model returns to what is saved', () => {
-    const staged = stageModel(saved, null, 'haiku')
-    expect(stageModel(saved, staged, 'opus')).toBeNull()
-  })
-
-  it('treats clearing the model to the provider default as a real change', () => {
-    // '' is a legitimate value ("use the provider's default"), not a no-op, so it
-    // must stage and be savable - it is written as null.
-    expect(stageModel(saved, null, '')).toEqual({ id: 'claude', customId: null, model: '' })
+  it('a custom switch carries the endpoint id, never the shared model override', () => {
+    expect(switchFields('custom')).not.toHaveProperty('llm_provider_model')
+    expect(switchFields('custom').llm_provider_custom_id).toBeNull()
   })
 })
 
-describe('the settings section persists the override correctly', () => {
+describe('the settings section persists the provider correctly', () => {
   const code = stripComments(section)
 
-  it('writes llm_provider_model for a CLI provider', () => {
-    expect(code).toContain('llm_provider_model')
+  it('does not write the shared model override for a custom endpoint', () => {
+    // A custom endpoint's model lives on its own row; openai_compat sends ep.model and ignores
+    // cfg.model, so the custom arm writes only the endpoint id, never the shared field.
+    const start = code.indexOf('? commit(')
+    const customArm = code.slice(start, code.indexOf(': commit(', start))
+    expect(customArm).toContain('llm_provider_custom_id')
+    expect(customArm).not.toContain('llm_provider_model')
   })
 
-  it('stores an empty model as null, matching Option<String>/None in Rust', () => {
-    expect(code).toMatch(/llm_provider_model:\s*pending\.model\s*\|\|\s*null/)
-  })
-
-  it('does not write the shared override for a custom endpoint', () => {
-    // A custom endpoint's model lives on its own row; openai_compat sends ep.model
-    // and ignores cfg.model, so writing the shared field would be a dead setting.
-    const customBranch = code.slice(code.indexOf("pending.id === 'custom'"))
-    const arm = customBranch.slice(0, customBranch.indexOf(':'))
-    expect(arm).not.toContain('llm_provider_model')
-  })
-
-  it('only offers the picker for a backend that passes the model through', () => {
-    expect(code).toContain('supportsModelOverride')
-  })
-
-  it('actually resets the model on a provider switch', () => {
-    // The transition tests above model this rule; this one ties it to the SOURCE, so
-    // the guard can't keep passing against a component that stopped honouring it.
-    expect(code).toMatch(/id === savedId\s*\?\s*savedModel\s*:\s*''/)
+  it('clears the stored model on a provider switch', () => {
+    // The built-in arm of onChange writes llm_provider_model: null - the SOURCE tie for the rule
+    // modelled above.
+    expect(code).toMatch(/llm_provider: id, llm_provider_model: null/)
   })
 })
 

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -16,7 +16,7 @@ import type { Wiz } from './steps'
 import type { NotifState } from './data'
 import type { IntegrationsResponse } from '@/lib/api-types'
 import type { RuntimeSettings } from '@/lib/settings'
-import { DEFAULT_LLM_PROVIDER, type LlmProviderId } from '@/lib/llm-providers'
+import { DEFAULT_LLM_PROVIDER, providerChoiceFields, type LlmProviderId } from '@/lib/llm-providers'
 import { useLlmProviderDetection } from '@/components/LlmProviderPicker'
 import { Btn, Check, DISPLAY, Kicker } from './atoms'
 
@@ -61,20 +61,26 @@ export default function SetupWizard() {
       .catch(() => {})
   }, [])
 
+  // Commit the choice, and only THEN move the UI. Settings works this way (it renders
+  // `settings.llm_provider` straight off disk); setup used to set local state optimistically
+  // and roll back on failure, which is not the same invariant — two overlapping picks could
+  // roll back to a value the disk no longer held, and the error it set is cleared by any
+  // navigation, so the mismatch could disappear unseen. Returning the promise is what lets
+  // the shared detail view render "Switching…" and surface a failure here too.
   const setProvider = useCallback((id: LlmProviderId, customId?: string) => {
-    const prev = provider
-    const prevCustom = providerCustomId
-    // 'custom' is a kind, not an endpoint — it only ever travels with the id of the one
-    // chosen, which update_settings requires and validates.
-    const fields: Partial<RuntimeSettings> =
-      id === 'custom' ? { llm_provider: id, llm_provider_custom_id: customId ?? null } : { llm_provider: id }
-    setProviderState(id)  // optimistic — the picker must feel instant
-    if (id === 'custom') setProviderCustomIdState(customId ?? null)
-    mutate<RuntimeSettings>('/api/settings', 'update_settings', fields, 'PUT')
-      // Roll back on a rejected write, or the UI would claim a choice the daemon
-      // isn't honouring — the exact silent-mismatch update_settings validates against.
-      .catch((e) => { setProviderState(prev); setProviderCustomIdState(prevCustom); setErr(String(e)) })
-  }, [provider, providerCustomId])
+    const fields = providerChoiceFields(id, customId) as Partial<RuntimeSettings>
+    return mutate<RuntimeSettings>('/api/settings', 'update_settings', fields, 'PUT')
+      .then(() => {
+        setProviderState(id)
+        if (id === 'custom') setProviderCustomIdState(customId ?? null)
+      })
+      .catch((e) => {
+        // Never claim a choice the daemon isn't honouring — the exact silent mismatch
+        // update_settings validates against. Rethrown so the detail view can show it.
+        setErr(String(e))
+        throw e
+      })
+  }, [])
 
   const active = !welcome && !done
 

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -46,7 +46,8 @@ export default function SetupWizard() {
   const [providerCustomId, setProviderCustomIdState] = useState<string | null>(null)
   const {
     status: providers, scanning: scanningProviders,
-    testingIds: testingProviderIds, testOne: testProvider, rescan: rescanProviders,
+    testingIds: testingProviderIds, installingIds: installingProviderIds, signingIds: signingProviderIds,
+    testOne: testProvider, install: installProvider, signIn: signInProvider, rescan: rescanProviders,
   } = useLlmProviderDetection()
 
   // Seed from settings.json rather than assuming the default — a re-run of the wizard
@@ -174,7 +175,8 @@ export default function SetupWizard() {
     integrations, refetchIntegrations,
     signedInEmail, onSignedIn,
     provider, providerCustomId, setProvider, providers, scanningProviders,
-    testingProviderIds, testProvider, rescanProviders,
+    testingProviderIds, installingProviderIds, signingProviderIds,
+    testProvider, installProvider, signInProvider, rescanProviders,
   }
 
   // ── Navigation ───────────────────────────────────────────────────────────────

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -12,7 +12,7 @@ import { PERMISSIONS } from './data'
 import type { NotifState } from './data'
 import type { IntegrationsResponse } from '@/lib/api-types'
 import { TRACKERS } from '@/lib/integrations'
-import { llmProvider, type LlmProviderId } from '@/lib/llm-providers'
+import { llmProvider, LLM_INTRO_BODY, LLM_INTRO_TITLE, type LlmProviderId } from '@/lib/llm-providers'
 import ConnectTrackers from '@/components/IntegrationConnect'
 import LlmProviderPicker, { type InstallOutcome, type ProviderStatus } from '@/components/LlmProviderPicker'
 import { SignInWidget } from './signin'
@@ -40,7 +40,9 @@ export interface Wiz {
   provider: LlmProviderId
   /** Which custom endpoint, when `provider` is 'custom'. */
   providerCustomId: string | null
-  setProvider: (id: LlmProviderId, customId?: string) => void
+  /** Resolves when the choice is persisted, rejects if it wasn't - the shared detail view
+   *  awaits this to render "Switching…" and surface a failure. */
+  setProvider: (id: LlmProviderId, customId?: string) => Promise<void>
   providers: Record<string, ProviderStatus>
   scanningProviders: boolean
   testingProviderIds: Set<string>
@@ -285,8 +287,10 @@ export const STEPS: StepMeta[] = [
   },
   {
     id: 'provider', n: '04', label: 'Intelligence', kicker: 'Your AI',
-    title: 'Choose your AI provider',
-    subtitle: 'Meridian uses this to write your hourly summaries and worklogs - about one short request per active hour, well under 1% of your Claude, Codex, or Cursor plan. Pick one, or bring your own API key.',
+    // The SHARED copy - the same words Settings shows. These used to be hardcoded here with
+    // different wording while llm-providers.ts claimed they were shared.
+    title: LLM_INTRO_TITLE,
+    subtitle: LLM_INTRO_BODY,
     Body: IntelligenceBody,
     status: (s) => llmProvider(s.provider).name,
     // Never gates. Every path out of this step is valid — including picking a CLI that

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -14,7 +14,7 @@ import type { IntegrationsResponse } from '@/lib/api-types'
 import { TRACKERS } from '@/lib/integrations'
 import { llmProvider, type LlmProviderId } from '@/lib/llm-providers'
 import ConnectTrackers from '@/components/IntegrationConnect'
-import LlmProviderPicker, { type ProviderStatus } from '@/components/LlmProviderPicker'
+import LlmProviderPicker, { type InstallOutcome, type ProviderStatus } from '@/components/LlmProviderPicker'
 import { SignInWidget } from './signin'
 
 /** The live wizard handle page.tsx builds and threads to every step body. */
@@ -44,7 +44,11 @@ export interface Wiz {
   providers: Record<string, ProviderStatus>
   scanningProviders: boolean
   testingProviderIds: Set<string>
+  installingProviderIds: Set<string>
+  signingProviderIds: Set<string>
   testProvider: (id: string) => void
+  installProvider: (id: string) => Promise<InstallOutcome>
+  signInProvider: (id: string) => Promise<InstallOutcome>
   rescanProviders: () => void
 }
 
@@ -146,38 +150,26 @@ function SignInBody({ wiz }: { wiz: Wiz }) {
 // resolver re-reads it on every call (src/llm/resolver.rs), so changing it later in
 // Settings takes effect on the next hour with nothing to restart.
 //
-// The choice is never blocked on the CLI being installed: the probe reports *installed*,
-// not *signed in* (we refuse to probe auth — see src/llm/detect.rs), so a hard gate here
-// would be built on a half-truth. Picking a missing CLI shows the install command and an
-// honest note that those hours stay pending until it's there.
+// The whole surface is the shared <LlmProviderPicker>: a chooser of the three recommended
+// coding agents (+ bring-your-own-key), each opening a detail view that installs the CLI,
+// confirms the sign-in, and sets the provider as default. The choice is never blocked on the
+// CLI being installed — the detail view walks the user through getting it there instead.
 function IntelligenceBody({ wiz }: { wiz: Wiz }) {
-  const picked = llmProvider(wiz.provider)
-  const missing = picked.kind === 'cli' && wiz.providers[picked.id]?.installed === false
   return (
-    <div className="flex flex-col" style={{ gap: 9 }}>
-      <LlmProviderPicker
-        value={wiz.provider}
-        selectedCustomId={wiz.providerCustomId}
-        onChange={wiz.setProvider}
-        status={wiz.providers}
-        scanning={wiz.scanningProviders}
-        testingIds={wiz.testingProviderIds}
-        testOne={wiz.testProvider}
-        rescan={wiz.rescanProviders}
-      />
-      <p className="flex items-start" style={{ gap: 7, fontSize: 11, lineHeight: 1.5, color: 'var(--t-muted)', marginTop: 3 }}>
-        <span style={{
-          width: 5, height: 5, borderRadius: 99, marginTop: 5, flexShrink: 0,
-          background: missing ? 'var(--color-state-pending)' : 'var(--color-state-approved)',
-        }} />
-        {missing
-          ? `${picked.name} isn't installed yet - install it and hit Rescan, or those hours stay pending until it's there.`
-          : picked.kind === 'custom'
-            // Not "your own subscription" - this one bills per call on the key they pasted.
-            ? 'Summaries are written by your own endpoint, billed to your own API key. Change it anytime in Settings.'
-            : `Summaries are written by ${picked.name}, on your own subscription. Change it anytime in Settings.`}
-      </p>
-    </div>
+    <LlmProviderPicker
+      value={wiz.provider}
+      selectedCustomId={wiz.providerCustomId}
+      onChange={wiz.setProvider}
+      status={wiz.providers}
+      scanning={wiz.scanningProviders}
+      testingIds={wiz.testingProviderIds}
+      installingIds={wiz.installingProviderIds}
+      signingIds={wiz.signingProviderIds}
+      testOne={wiz.testProvider}
+      install={wiz.installProvider}
+      signIn={wiz.signInProvider}
+      rescan={wiz.rescanProviders}
+    />
   )
 }
 
@@ -293,8 +285,8 @@ export const STEPS: StepMeta[] = [
   },
   {
     id: 'provider', n: '04', label: 'Intelligence', kicker: 'Your AI',
-    title: 'Choose the AI that writes your summaries',
-    subtitle: 'One choice, used everywhere Meridian writes prose about your day. Use a coding-agent CLI you already pay for, or a custom cloud endpoint on your own key.',
+    title: 'Choose your AI provider',
+    subtitle: 'Meridian uses this to write your hourly summaries and worklogs - about one short request per active hour, well under 1% of your Claude, Codex, or Cursor plan. Pick one, or bring your own API key.',
     Body: IntelligenceBody,
     status: (s) => llmProvider(s.provider).name,
     // Never gates. Every path out of this step is valid — including picking a CLI that

--- a/ui/components/LlmProviderDetail.tsx
+++ b/ui/components/LlmProviderDetail.tsx
@@ -3,7 +3,8 @@
 
 // The per-provider DETAIL view — what opens when a provider tile is clicked in the chooser.
 // One provider, one screen: install its CLI if it's missing, confirm the sign-in if it's
-// there, optionally set its model, and make it the default. Kept deliberately linear so a
+// there, and make it the default (the model always follows the provider's own default -
+// there is deliberately no model control). Kept deliberately linear so a
 // non-technical user is only ever looking at one next action.
 //
 // The three coding-agent CLIs run on a subscription the user already has, so there is no API

--- a/ui/components/LlmProviderDetail.tsx
+++ b/ui/components/LlmProviderDetail.tsx
@@ -1,0 +1,426 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+'use client'
+
+// The per-provider DETAIL view — what opens when a provider tile is clicked in the chooser.
+// One provider, one screen: install its CLI if it's missing, confirm the sign-in if it's
+// there, optionally set its model, and make it the default. Kept deliberately linear so a
+// non-technical user is only ever looking at one next action.
+//
+// The three coding-agent CLIs run on a subscription the user already has, so there is no API
+// key to paste here — the only setup is "install the CLI" and "be signed in to it", and this
+// view walks both. The custom (bring-your-own-key) case has its own flow and is NOT rendered
+// here (see <LlmProviderPicker>'s custom detail).
+
+import { useEffect, useRef, useState } from 'react'
+import { openExternal } from '@/lib/bridge'
+import { ProviderLogo } from '@/components/LlmProviderLogos'
+import { LLM_RECOMMENDED_BADGE, USAGE_FOOTPRINT_NOTE, type LlmProviderMeta } from '@/lib/llm-providers'
+import type { InstallOutcome, ProviderStatus, ProviderTestResult } from '@/components/LlmProviderPicker'
+
+/** The connection state we render, derived from install + last-test + in-flight flags. */
+type Phase =
+  | { kind: 'installing' }
+  | { kind: 'signing' }
+  | { kind: 'not_installed' }
+  | { kind: 'testing' }
+  | { kind: 'ok' }
+  | { kind: 'failed'; message: string }
+  | { kind: 'rate_limited'; message: string }
+  | { kind: 'ready_untested' }
+  | { kind: 'unknown' }
+
+function phaseFor(
+  installing: boolean,
+  signing: boolean,
+  testing: boolean,
+  probed: ProviderStatus | undefined,
+  lastTest: ProviderTestResult | null,
+): Phase {
+  if (installing) return { kind: 'installing' }
+  if (signing) return { kind: 'signing' }
+  if (testing) return { kind: 'testing' }
+  // Only say "not installed" when we actually probed and came up empty — a failed probe is
+  // "unknown", not "missing" (picking/installing is still allowed).
+  if (probed && !probed.installed) return { kind: 'not_installed' }
+  if (lastTest) {
+    if (lastTest.outcome.status === 'ok') return { kind: 'ok' }
+    if (lastTest.outcome.status === 'rate_limited')
+      return { kind: 'rate_limited', message: lastTest.outcome.message }
+    return { kind: 'failed', message: lastTest.outcome.message }
+  }
+  if (probed?.installed) return { kind: 'ready_untested' }
+  return { kind: 'unknown' }
+}
+
+function Dot({ color }: { color: string }) {
+  return <span style={{ width: 7, height: 7, borderRadius: 99, background: color, flexShrink: 0, marginTop: 6 }} />
+}
+
+function Spinner() {
+  return (
+    <span className="inline-block" style={{
+      width: 13, height: 13, borderRadius: 99, marginTop: 3, flexShrink: 0,
+      border: '2px solid var(--t-ctrl-border)', borderTopColor: 'var(--color-state-proposal)',
+      animation: 'spin 0.7s linear infinite',
+    }} />
+  )
+}
+
+export interface LlmProviderDetailProps {
+  p: LlmProviderMeta
+  probed: ProviderStatus | undefined
+  testing: boolean
+  installing: boolean
+  signing: boolean
+  /** This provider is the one currently saved/in use. */
+  selected: boolean
+  onBack: () => void
+  /** Run the vendor installer; resolves with what happened so we can show the message. */
+  onInstall: () => Promise<InstallOutcome>
+  /** Run the interactive Cursor sign-in (browser OAuth on their subscription). Cursor-only. */
+  onSignIn: () => Promise<InstallOutcome>
+  onTest: () => void
+  /** Commit this provider as the default. Rejects if the write failed (Settings save). */
+  onUse: () => Promise<void>
+}
+
+export default function LlmProviderDetail({
+  p, probed, testing, installing, signing, selected, onBack, onInstall, onSignIn, onTest, onUse,
+}: LlmProviderDetailProps) {
+  const lastTest = probed?.last_test ?? null
+  const phase = phaseFor(installing, signing, testing, probed, lastTest)
+  const [installMsg, setInstallMsg] = useState<string | null>(null)
+  const [signInMsg, setSignInMsg] = useState<string | null>(null)
+  const [applying, setApplying] = useState(false)
+  const [applyErr, setApplyErr] = useState<string | null>(null)
+
+  // Auto-test once when we open on an installed CLI with no recent result — "if already
+  // installed, test automatically". Guarded so a status refresh can't re-fire it, and skipped
+  // when a test ran in the last minute so flipping back and forth doesn't burn requests.
+  const autoTested = useRef<string | null>(null)
+  useEffect(() => {
+    if (autoTested.current === p.id) return
+    if (installing || testing) return
+    if (!probed?.installed) return
+    const recent = lastTest && Date.now() - Date.parse(lastTest.tested_at) < 60_000
+    if (recent) { autoTested.current = p.id; return }
+    autoTested.current = p.id
+    onTest()
+  }, [p.id, probed?.installed, installing, testing, lastTest, onTest])
+
+  async function install() {
+    setInstallMsg(null)
+    const outcome = await onInstall()
+    // On success the hook re-detects and auto-tests, so the panel moves on by itself; only a
+    // failure needs its message surfaced here.
+    if (!outcome.ok) setInstallMsg(outcome.message)
+    else autoTested.current = p.id // the hook already tested; don't double-fire the effect
+  }
+
+  async function signIn() {
+    setSignInMsg(null)
+    const outcome = await onSignIn()
+    if (!outcome.ok) setSignInMsg(outcome.message)
+    else autoTested.current = p.id // the hook re-tested after sign-in
+  }
+
+  async function use() {
+    setApplying(true); setApplyErr(null)
+    try { await onUse() } catch (e) { setApplyErr(String(e)) } finally { setApplying(false) }
+  }
+
+  return (
+    <div className="flex flex-col" style={{ gap: 14 }}>
+      {/* Back to the chooser */}
+      <button onClick={onBack} className="self-start flex items-center"
+        style={{ gap: 6, fontSize: 12, color: 'var(--t-muted)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}>
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><path d="M10 4 6 8l4 4" /></svg>
+        All providers
+      </button>
+
+      {/* Header */}
+      <div className="flex items-center" style={{ gap: 13 }}>
+        <span className="flex items-center justify-center shrink-0" style={{
+          width: 46, height: 46, borderRadius: 12,
+          background: selected ? 'color-mix(in srgb, var(--color-state-proposal) 15%, transparent)' : 'var(--t-box)',
+          border: '1px solid var(--t-ctrl-border)',
+          color: selected ? 'var(--color-state-proposal)' : 'var(--t-title)',
+        }}>
+          <ProviderLogo id={p.id} size={24} />
+        </span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div className="flex items-center flex-wrap" style={{ gap: 8 }}>
+            <span style={{ fontSize: 17, fontWeight: 600, color: 'var(--t-title)' }}>{p.name}</span>
+            <span className="font-mono" style={{
+              fontSize: 9.5, letterSpacing: '.09em', color: 'var(--color-state-proposal)',
+              border: '1px solid var(--color-state-proposal)',
+              background: 'color-mix(in srgb, var(--color-state-proposal) 10%, transparent)',
+              borderRadius: 4, padding: '1.5px 5px',
+            }}>{LLM_RECOMMENDED_BADGE}</span>
+            {selected && (
+              <span className="font-mono flex items-center" style={{
+                gap: 4, fontSize: 9.5, letterSpacing: '.09em', color: 'var(--color-state-approved)',
+                border: '1px solid var(--color-state-approved)',
+                background: 'color-mix(in srgb, var(--color-state-approved) 10%, transparent)',
+                borderRadius: 4, padding: '1.5px 5px',
+              }}>IN USE</span>
+            )}
+          </div>
+          <p style={{ fontSize: 12, lineHeight: 1.45, color: 'var(--t-muted)', marginTop: 3 }}>{p.blurb}</p>
+        </div>
+      </div>
+
+      {/* Connection panel — one clear next action */}
+      <div className="flex flex-col" style={{
+        gap: 10, padding: '14px 15px', borderRadius: 12,
+        background: 'var(--t-card)', border: '1px solid var(--t-ctrl-border)',
+      }}>
+        <ConnectionBody
+          phase={phase}
+          name={p.name}
+          providerId={p.id}
+          installHint={p.installHint}
+          installMsg={installMsg}
+          signInMsg={signInMsg}
+          onInstall={install}
+          onSignIn={signIn}
+          onTest={onTest}
+        />
+      </div>
+
+      {/* Privacy — honest: we disable telemetry per call, but opting out of TRAINING is a
+          one-time account setting we can't flip. */}
+      {p.privacyUrl && (
+        <div className="flex items-start" style={{ gap: 8 }}>
+          <span className="shrink-0" style={{ marginTop: 1, color: 'var(--color-state-approved)' }} aria-hidden="true">🔒</span>
+          <p style={{ fontSize: 11, lineHeight: 1.5, color: 'var(--t-muted)' }}>
+            Meridian turns off usage telemetry on every call. To also keep your prompts out of model
+            training, switch on {p.name}&apos;s privacy setting once:{' '}
+            <button onClick={() => p.privacyUrl && openExternal(p.privacyUrl)}
+              style={{ color: 'var(--color-state-proposal)', background: 'none', border: 'none', padding: 0, cursor: 'pointer', font: 'inherit', textDecoration: 'underline' }}>
+              {p.privacyLabel ?? 'open settings'} ↗
+            </button>
+          </p>
+        </div>
+      )}
+
+      {/* Primary action */}
+      <div className="flex flex-col" style={{ gap: 6 }}>
+        {applyErr && <p style={{ fontSize: 11, lineHeight: 1.4, color: 'var(--status-error-dot)' }}>{applyErr}</p>}
+        {selected ? (
+          <div className="flex items-center self-start" style={{
+            gap: 7, fontSize: 13, fontWeight: 500, color: 'var(--color-state-approved)',
+            padding: '9px 15px', borderRadius: 9,
+            background: 'color-mix(in srgb, var(--color-state-approved) 10%, transparent)',
+            border: '1px solid var(--color-state-approved)',
+          }}>
+            <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M13 4 6 11 3 8" /></svg>
+            {p.name} is writing your summaries
+          </div>
+        ) : (
+          <button onClick={use} disabled={applying} className="self-start"
+            style={{
+              fontSize: 13, fontWeight: 600, padding: '9px 18px', borderRadius: 9, border: 'none',
+              background: applying ? 'var(--t-ctrl)' : 'var(--btn-primary-bg)',
+              color: applying ? 'var(--t-faint)' : '#fff', cursor: applying ? 'default' : 'pointer',
+            }}>
+            {applying ? 'Switching…' : `Use ${p.name}`}
+          </button>
+        )}
+        <p style={{ fontSize: 11, lineHeight: 1.45, color: 'var(--t-muted)' }}>
+          {USAGE_FOOTPRINT_NOTE}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+/** The body of the connection panel — one message and (at most) one button per phase. */
+function ConnectionBody({ phase, name, providerId, installHint, installMsg, signInMsg, onInstall, onSignIn, onTest }: {
+  phase: Phase; name: string; providerId: string
+  installHint?: string; installMsg: string | null; signInMsg: string | null
+  onInstall: () => void; onSignIn: () => void; onTest: () => void
+}) {
+  const mono = { fontSize: 11, lineHeight: 1.5, color: 'var(--t-key-text)', background: 'var(--t-key-bg)', borderRadius: 6, padding: '6px 9px' } as const
+  const isCursor = providerId === 'cursor'
+
+  switch (phase.kind) {
+    case 'installing':
+      return (
+        <div className="flex items-start" style={{ gap: 9 }}>
+          <Spinner />
+          <p style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--t-title)' }}>
+            Installing the {name} CLI… this can take a minute.
+          </p>
+        </div>
+      )
+
+    case 'signing':
+      return (
+        <div className="flex items-start" style={{ gap: 9 }}>
+          <Spinner />
+          <p style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--t-title)' }}>
+            Opening your browser… finish signing in to Cursor, then this updates on its own.
+          </p>
+        </div>
+      )
+
+    case 'not_installed':
+      return (
+        <div className="flex flex-col" style={{ gap: 10 }}>
+          <div className="flex items-start" style={{ gap: 9 }}>
+            <Dot color="var(--color-state-pending)" />
+            <p style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--t-title)' }}>
+              The {name} CLI isn&apos;t installed yet. Meridian can install it for you now - one click,
+              nothing to configure.
+            </p>
+          </div>
+          <button onClick={onInstall} className="self-start"
+            style={{
+              fontSize: 12.5, fontWeight: 600, padding: '8px 15px', borderRadius: 9, border: 'none',
+              background: 'var(--btn-primary-bg)', color: '#fff', cursor: 'pointer',
+            }}>
+            Install {name}
+          </button>
+          {installHint && (
+            <p style={{ fontSize: 10.5, lineHeight: 1.5, color: 'var(--t-faint)' }}>
+              Runs <code style={{ fontFamily: 'var(--font-mono, ui-monospace)' }}>{installHint}</code> in your shell.
+            </p>
+          )}
+          {installMsg && (
+            <div className="flex flex-col" style={{ gap: 6 }}>
+              <p style={{ fontSize: 11.5, lineHeight: 1.5, color: 'var(--status-error-dot)' }}>
+                That didn&apos;t work: {installMsg}
+              </p>
+              {installHint && <p className="font-mono" style={mono}>{installHint}</p>}
+              <p style={{ fontSize: 10.5, lineHeight: 1.5, color: 'var(--t-faint)' }}>
+                Run the command above in your terminal, then come back and reopen this.
+              </p>
+            </div>
+          )}
+        </div>
+      )
+
+    case 'testing':
+      return (
+        <div className="flex items-start" style={{ gap: 9 }}>
+          <Spinner />
+          <p style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--t-title)' }}>
+            Checking your {name} sign-in…
+          </p>
+        </div>
+      )
+
+    case 'ok':
+      return (
+        <div className="flex items-start" style={{ gap: 9 }}>
+          <span className="shrink-0" style={{ marginTop: 2, color: 'var(--color-state-approved)' }} aria-hidden="true">
+            <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M13 4 6 11 3 8" /></svg>
+          </span>
+          <p style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--t-title)' }}>
+            Connected and ready - you&apos;re signed in to {name}.
+          </p>
+        </div>
+      )
+
+    case 'rate_limited':
+      return (
+        <div className="flex flex-col" style={{ gap: 8 }}>
+          <div className="flex items-start" style={{ gap: 9 }}>
+            <Dot color="var(--color-state-pending)" />
+            <p style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--t-title)' }}>
+              {name} is signed in but rate-limited right now: {phase.message}. It&apos;ll pick back up on
+              its own once the limit clears.
+            </p>
+          </div>
+          <TestAgain onTest={onTest} />
+        </div>
+      )
+
+    case 'failed':
+      // Cursor's "failure" is almost always just "not signed in yet" - a one-time OAuth on the
+      // user's own Cursor subscription (no API key). Offer it as a one-click browser sign-in,
+      // with the terminal command as a fallback.
+      if (isCursor) {
+        return (
+          <div className="flex flex-col" style={{ gap: 10 }}>
+            <div className="flex items-start" style={{ gap: 9 }}>
+              <Dot color="var(--color-state-pending)" />
+              <p style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--t-title)' }}>
+                {name} is installed but not signed in yet. Sign in with your Cursor account and it
+                runs on your Cursor subscription - no API key.
+              </p>
+            </div>
+            <button onClick={onSignIn} className="self-start"
+              style={{
+                fontSize: 12.5, fontWeight: 600, padding: '8px 15px', borderRadius: 9, border: 'none',
+                background: 'var(--btn-primary-bg)', color: '#fff', cursor: 'pointer',
+              }}>
+              Sign in to Cursor
+            </button>
+            <p style={{ fontSize: 10.5, lineHeight: 1.5, color: 'var(--t-faint)' }}>
+              Opens your browser to finish the sign-in. Prefer the terminal? Run{' '}
+              <code style={{ fontFamily: 'var(--font-mono, ui-monospace)' }}>cursor-agent login</code>, then Test again.
+            </p>
+            {signInMsg && (
+              <p style={{ fontSize: 11.5, lineHeight: 1.5, color: 'var(--status-error-dot)' }}>
+                Sign-in didn&apos;t complete: {signInMsg}
+              </p>
+            )}
+            <TestAgain onTest={onTest} />
+          </div>
+        )
+      }
+      return (
+        <div className="flex flex-col" style={{ gap: 9 }}>
+          <div className="flex items-start" style={{ gap: 9 }}>
+            <Dot color="var(--status-error-dot)" />
+            <p style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--t-title)' }}>
+              {name} isn&apos;t responding: {phase.message}
+            </p>
+          </div>
+          <TestAgain onTest={onTest} />
+        </div>
+      )
+
+    case 'ready_untested':
+      return (
+        <div className="flex flex-col" style={{ gap: 8 }}>
+          <div className="flex items-start" style={{ gap: 9 }}>
+            <Dot color="var(--color-state-approved)" />
+            <p style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--t-title)' }}>
+              {name} is installed. Test the connection to confirm you&apos;re signed in.
+            </p>
+          </div>
+          <TestAgain onTest={onTest} label="Test connection" />
+        </div>
+      )
+
+    default:
+      return (
+        <div className="flex flex-col" style={{ gap: 8 }}>
+          <div className="flex items-start" style={{ gap: 9 }}>
+            <Dot color="var(--t-muted)" />
+            <p style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--t-title)' }}>
+              Couldn&apos;t tell whether {name} is installed. You can still select it - if the CLI is
+              there and signed in, it just works.
+            </p>
+          </div>
+          <TestAgain onTest={onTest} label="Test connection" />
+        </div>
+      )
+  }
+}
+
+function TestAgain({ onTest, label = 'Test again' }: { onTest: () => void; label?: string }) {
+  return (
+    <button onClick={onTest} className="self-start font-mono"
+      style={{
+        fontSize: 10.5, letterSpacing: '.08em', textTransform: 'uppercase',
+        color: 'var(--t-title)', border: '1px solid var(--t-ctrl-border)',
+        borderRadius: 6, padding: '5px 10px', background: 'var(--t-box)', cursor: 'pointer',
+      }}>
+      {label}
+    </button>
+  )
+}

--- a/ui/components/LlmProviderLogos.tsx
+++ b/ui/components/LlmProviderLogos.tsx
@@ -1,0 +1,88 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+'use client'
+
+// The provider brand marks, in one place so the chooser tiles and the detail header show the
+// SAME logo. Each is a simple monochrome glyph drawn with `currentColor`, so the caller sets
+// the colour (neutral when idle, accent when the provider is in use) and both light and dark
+// palettes are handled for free. These are recognisable, deliberately-simplified marks - not
+// pixel-exact brand assets - kept lightweight and theme-aware rather than shipped as raster
+// logos.
+
+import type { LlmProviderId } from '@/lib/llm-providers'
+
+/** Anthropic / Claude - the radial sunburst. */
+function ClaudeMark({ s }: { s: number }) {
+  return (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      {Array.from({ length: 12 }).map((_, i) => (
+        <rect
+          key={i}
+          x="11.2"
+          y="2.4"
+          width="1.6"
+          height="7.2"
+          rx="0.8"
+          transform={`rotate(${i * 30} 12 12)`}
+        />
+      ))}
+    </svg>
+  )
+}
+
+/** OpenAI / Codex - a simplified interlocking rosette. */
+function CodexMark({ s }: { s: number }) {
+  return (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <ellipse key={i} cx="12" cy="12" rx="3.4" ry="8" transform={`rotate(${i * 30} 12 12)`} />
+      ))}
+    </svg>
+  )
+}
+
+/** Cursor - the isometric cube. */
+function CursorMark({ s }: { s: number }) {
+  return (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 2.6 20.5 7v10L12 21.4 3.5 17V7z" />
+      <path d="M12 2.6V12M12 12l8.5-5M12 12l-8.5-5M12 12v9.4" />
+    </svg>
+  )
+}
+
+/** Bring-your-own custom endpoint - a key. */
+function KeyMark({ s }: { s: number }) {
+  return (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="8" cy="8" r="4.2" />
+      <path d="M11 11l7.5 7.5M16 16l2-2M14 18l2-2" />
+    </svg>
+  )
+}
+
+/**
+ * The brand mark for one provider id. `custom` gets the key; an unknown id falls back to a
+ * generic terminal glyph so the tile still renders.
+ */
+export function ProviderLogo({ id, size = 22 }: { id: LlmProviderId; size?: number }) {
+  switch (id) {
+    case 'claude':
+      return <ClaudeMark s={size} />
+    case 'codex':
+      return <CodexMark s={size} />
+    case 'cursor':
+      return <CursorMark s={size} />
+    case 'custom':
+      return <KeyMark s={size} />
+    default:
+      return (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+          strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <rect x="3" y="4" width="18" height="16" rx="2" /><path d="M7 9l3 3-3 3M13 15h4" />
+        </svg>
+      )
+  }
+}

--- a/ui/components/LlmProviderPicker.tsx
+++ b/ui/components/LlmProviderPicker.tsx
@@ -1,22 +1,30 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 'use client'
 
-// The AI-provider picker — ONE component, mounted in both the setup wizard's
-// Intelligence step and the dashboard's Settings, exactly as <ConnectTrackers> is shared
-// between the wizard and the dashboard. The provider list itself lives in
-// `@/lib/llm-providers`; this only renders it and reports the choice up.
+// The AI-provider picker — ONE component, mounted in both the setup wizard's Intelligence step
+// and the dashboard's Settings, so the two surfaces can never drift. The provider list lives in
+// `@/lib/llm-providers`.
 //
-// Layout is a 2-column card GRID (not a stacked list) so the providers read as
-// comparable options at a glance. Order is the recommendation: coding agents first
-// (frontier accuracy), then a custom OpenAI-compatible endpoint.
+// Two levels, on purpose (this replaced a flat grid of cards each carrying every control at
+// once, which read as busy and buried the one decision):
 //
-// It deliberately does NOT save. The wizard and Settings persist differently (the wizard
-// writes once per pick; Settings the same through useRuntimeSettings), so the owner does
-// the write and this stays a controlled input — one source of truth per surface.
+//   CHOOSER  — three recommended coding-agent tiles (logo + name + RECOMMENDED) plus one
+//              "bring your own API key" tile. Just the choice, nothing else.
+//   DETAIL   — click a tile and you get its own screen: install the CLI if missing, confirm the
+//              sign-in if it's there, optionally set a model, and make it the default. One
+//              provider, one next action.
+//
+// It deliberately does NOT save. The wizard writes each pick straight through; Settings commits
+// through its own save(). The owner does the write and this stays a controlled input.
 
 import { useCallback, useEffect, useState } from 'react'
-import { invoke, openExternal } from '@/lib/bridge'
-import { CUSTOM_PROVIDER_COST_NOTE, LLM_PROVIDERS, USAGE_FOOTPRINT_NOTE, type LlmProviderId, type LlmProviderMeta } from '@/lib/llm-providers'
+import {
+  CHOOSER_PROVIDER_IDS, LLM_RECOMMENDED_BADGE, LLM_RECOMMENDED_NOTE,
+  llmProvider, type LlmProviderId,
+} from '@/lib/llm-providers'
+import { invoke } from '@/lib/bridge'
+import { ProviderLogo } from '@/components/LlmProviderLogos'
+import LlmProviderDetail from '@/components/LlmProviderDetail'
 import { AddCustomProvider, CustomProviderCard, useCustomProviders } from '@/components/CustomProviders'
 
 /** What one real connectivity test found (mirrors `ProviderTestOutcome` in src/llm/detect.rs). */
@@ -41,361 +49,316 @@ export interface ProviderStatus {
   path: string | null
   /** Always null — Meridian reports *installed*, not *signed in*. See src/llm/detect.rs. */
   authenticated: boolean | null
-  /** The last real connectivity test on record, if any. `null` means never tested — not
-   *  failed. A stale test (from before the CLI was reinstalled/re-authed) is still shown;
-   *  Rescan and the per-card Test button are how the user refreshes it. */
+  /** The last real connectivity test on record, if any. `null` means never tested — not failed. */
   last_test: ProviderTestResult | null
 }
 
+/** What running a provider's installer produced (mirrors `InstallOutcome` in src/llm/detect.rs). */
+export interface InstallOutcome {
+  ok: boolean
+  message: string
+  path: string | null
+  command: string
+}
+
 /**
- * Probe which provider CLIs exist on this Mac (free, instant), then - for every one that
- * IS installed - run a real connectivity test (spends one request per provider against
- * the user's own subscription). Re-run on demand (the Rescan button): the user will
- * alt-tab out to `npm i -g …` or `claude login` and come back mid-wizard, and a cached
- * "not installed"/"not working" would then be a lie.
+ * Probe which provider CLIs exist on this Mac (free, instant). Unlike before, this NO LONGER
+ * fires a real connectivity test for every installed CLI on mount — that spent a request per
+ * provider and surfaced scary failures for CLIs the user never even opened (e.g. a stray
+ * cursor-agent that isn't signed in). Testing now happens in the DETAIL view, only for the
+ * provider the user actually opened. `install` runs the vendor installer, then re-detects and
+ * auto-tests just that one.
  */
 export function useLlmProviderDetection() {
   const [status, setStatus] = useState<Record<string, ProviderStatus>>({})
   const [scanning, setScanning] = useState(true)
   const [testingIds, setTestingIds] = useState<Set<string>>(new Set())
+  const [installingIds, setInstallingIds] = useState<Set<string>>(new Set())
+  const [signingIds, setSigningIds] = useState<Set<string>>(new Set())
 
-  /** Re-test ONE provider on demand (a card's own Test button) without re-testing every
-   *  other installed provider - e.g. right after fixing that CLI's login. */
-  const testOne = useCallback(async (id: string) => {
-    setTestingIds((prev) => new Set(prev).add(id))
+  /** Free install-state probe. Re-run on demand (Rescan / after a manual install). */
+  const detect = useCallback(async () => {
+    setScanning(true)
+    try {
+      const found = await invoke<ProviderStatus[]>('detect_llm_providers')
+      setStatus(Object.fromEntries(found.map((p) => [p.id, p])))
+    } catch {
+      // A failed probe must not block the step: an un-probed provider renders as "can't tell",
+      // and picking it is still allowed.
+      setStatus({})
+    } finally {
+      setScanning(false)
+    }
+  }, [])
+
+  /** One real connectivity test — spends one request against the user's own subscription.
+   *  `silent` runs + persists the test WITHOUT the "Testing…" spinner, so a confirm-in-the
+   *  background (e.g. right after sign-in) doesn't yank the panel back to a spinner. */
+  const testOne = useCallback(async (id: string, opts?: { silent?: boolean }) => {
+    if (!opts?.silent) setTestingIds((prev) => new Set(prev).add(id))
     try {
       const result = await invoke<ProviderTestResult>('test_llm_provider', { id })
       setStatus((prev) => (prev[id] ? { ...prev, [id]: { ...prev[id], last_test: result } } : prev))
     } catch {
-      // Leave whatever was cached before - a failed probe call itself is not evidence
-      // the provider stopped working, just that we couldn't find out right now.
+      // A failed probe CALL isn't evidence the provider stopped working — keep what was cached.
     } finally {
-      setTestingIds((prev) => {
+      if (!opts?.silent) {
+        setTestingIds((prev) => {
+          const next = new Set(prev)
+          next.delete(id)
+          return next
+        })
+      }
+    }
+  }, [])
+
+  /** Run the vendor installer for one provider, then re-detect and (on success) auto-test it. */
+  const install = useCallback(async (id: string): Promise<InstallOutcome> => {
+    setInstallingIds((prev) => new Set(prev).add(id))
+    try {
+      const outcome = await invoke<InstallOutcome>('install_llm_provider', { id })
+      await detect()
+      if (outcome.ok) await testOne(id)
+      return outcome
+    } catch (e) {
+      return { ok: false, message: String(e), path: null, command: '' }
+    } finally {
+      setInstallingIds((prev) => {
         const next = new Set(prev)
         next.delete(id)
         return next
       })
     }
-  }, [])
+  }, [detect, testOne])
 
-  const rescan = useCallback(async () => {
-    setScanning(true)
-    let found: ProviderStatus[] = []
+  /** Run the interactive Cursor sign-in (browser OAuth on the user's own subscription).
+   *  Cursor-only - the tray command takes no provider. */
+  const signIn = useCallback(async (id: string): Promise<InstallOutcome> => {
+    setSigningIds((prev) => new Set(prev).add(id))
     try {
-      found = await invoke<ProviderStatus[]>('detect_llm_providers')
-      setStatus(Object.fromEntries(found.map((p) => [p.id, p])))
-    } catch {
-      // A failed probe must not block the step: an un-probed provider renders as
-      // "can't tell", and picking it is still allowed (the CLI may well be there).
-      setStatus({})
-    } finally {
-      setScanning(false)
-    }
-
-    // The expensive half: a real call per installed CLI, run concurrently server-side.
-    // Never spends a request on a provider that isn't even on the machine.
-    const installedIds = found.filter((p) => p.installed).map((p) => p.id)
-    if (installedIds.length === 0) return
-    setTestingIds(new Set(installedIds))
-    try {
-      const results = await invoke<ProviderTestResult[]>('test_all_llm_providers')
-      setStatus((prev) => {
-        const next = { ...prev }
-        for (const r of results) {
-          if (next[r.id]) next[r.id] = { ...next[r.id], last_test: r }
+      const outcome = await invoke<InstallOutcome>('cursor_sign_in')
+      if (outcome.ok) {
+        // `cursor-agent login` exits 0 only AFTER the browser OAuth completes, so this is the
+        // exact moment the user finished signing in. Flip the panel to "connected" NOW rather
+        // than making them wait on a slow follow-up completion call, then confirm + persist it
+        // with a silent background test (which corrects the badge if it somehow isn't usable).
+        const result: ProviderTestResult = {
+          id, outcome: { status: 'ok' }, elapsed_ms: 0, tested_at: new Date().toISOString(),
         }
+        setStatus((prev) => {
+          const cur = prev[id] ?? { id, installed: true, path: null, authenticated: null, last_test: null }
+          return { ...prev, [id]: { ...cur, installed: true, last_test: result } }
+        })
+        void testOne(id, { silent: true })
+      } else {
+        // Sign-in didn't complete - refresh at least the install state.
+        await detect()
+      }
+      return outcome
+    } catch (e) {
+      return { ok: false, message: String(e), path: null, command: '' }
+    } finally {
+      setSigningIds((prev) => {
+        const next = new Set(prev)
+        next.delete(id)
         return next
       })
-    } catch {
-      // Same reasoning as above - stale-but-cached beats blocking the panel.
-    } finally {
-      setTestingIds(new Set())
     }
-  }, [])
+  }, [detect, testOne])
 
-  useEffect(() => { rescan() }, [rescan])
-  return { status, scanning, testingIds, testOne, rescan }
+  useEffect(() => { detect() }, [detect])
+  return { status, scanning, testingIds, installingIds, signingIds, testOne, install, signIn, rescan: detect }
 }
 
-/** "3m ago" / "2h ago" / "5d ago" from an RFC3339 timestamp. Never throws on a bad string -
- *  falls back to blank, since a badge with no relative time is still honest. */
-function timeAgo(iso: string): string {
-  const then = Date.parse(iso)
-  if (Number.isNaN(then)) return ''
-  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000))
-  if (secs < 60) return 'just now'
-  const mins = Math.floor(secs / 60)
-  if (mins < 60) return `${mins}m ago`
-  const hours = Math.floor(mins / 60)
-  if (hours < 24) return `${hours}h ago`
-  return `${Math.floor(hours / 24)}d ago`
-}
-
-function ProviderGlyph({ on }: { on: boolean }) {
-  // Unselected uses --t-muted, not --t-faint: on the ink palette --t-faint (#9A8FC2)
-  // against the card reads as disabled rather than merely unselected.
-  const color = on ? 'var(--color-state-proposal)' : 'var(--t-muted)'
-  return (
-    <span className="flex items-center justify-center shrink-0" style={{
-      width: 30, height: 30, borderRadius: 9,
-      // --t-box (the subtle-fill token), not --t-ctrl: on the light palettes --t-ctrl is
-      // #FFFFFF, the same value as the --t-card the glyph now sits on, so it would read
-      // as an empty outline. --t-box lifts off the card on all three palettes.
-      background: on ? 'color-mix(in srgb, var(--color-state-proposal) 16%, transparent)' : 'var(--t-box)',
-      border: '1px solid var(--t-ctrl-border)', color,
-    }}>
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
-        <rect x="3" y="4" width="18" height="16" rx="2" /><path d="M7 9l3 3-3 3M13 15h4" />
-      </svg>
-    </span>
-  )
-}
-
-function Badge({ text, tone }: { text: string; tone: 'accent' | 'warn' | 'muted' | 'ok' }) {
-  const c = tone === 'accent' ? 'var(--color-state-proposal)'
-    : tone === 'warn' ? 'var(--color-state-pending)'
-    : tone === 'ok' ? 'var(--color-state-approved)' : 'var(--t-title)'
-  return (
-    <span className="font-mono" style={{
-      // 9.5px, not 8.5: at 8.5 these badges carry real state (VERIFIED / NOT
-      // INSTALLED / CONNECTION FAILED) at a size that reads as decorative.
-      fontSize: 9.5, letterSpacing: '.09em', color: c,
-      border: `1px solid ${tone === 'muted' ? 'var(--t-ctrl-border)' : c}`,
-      background: tone === 'muted' ? 'transparent' : `color-mix(in srgb, ${c} 10%, transparent)`,
-      borderRadius: 4, padding: '1.5px 5px', whiteSpace: 'nowrap',
-    }}>{text}</span>
-  )
-}
-
-/** Badge + detail for the last real connectivity test, or nothing if never tested. */
-function TestBadge({ testing, lastTest }: { testing: boolean; lastTest: ProviderTestResult | null }) {
-  if (testing) return <Badge text="TESTING…" tone="muted" />
-  if (!lastTest) return null
-  const when = timeAgo(lastTest.tested_at)
-  if (lastTest.outcome.status === 'ok') {
-    return <Badge text={when ? `VERIFIED · ${when}` : 'VERIFIED'} tone="ok" />
-  }
-  if (lastTest.outcome.status === 'rate_limited') {
-    return <Badge text={when ? `RATE LIMITED · ${when}` : 'RATE LIMITED'} tone="warn" />
-  }
-  return <Badge text={when ? `CONNECTION FAILED · ${when}` : 'CONNECTION FAILED'} tone="warn" />
-}
-
-/** One card in the grid. A `div` shell (not `button`) so a real Test button can nest
- *  inside without invalid nested-interactive-element markup; keyboard/role parity with a
- *  native button is kept by hand (role, tabIndex, Enter/Space). */
-function ProviderCard({ p, picked, missing, testing, lastTest, onPick, onTest }: {
-  p: LlmProviderMeta; picked: boolean; missing: boolean
-  testing: boolean; lastTest: ProviderTestResult | null
-  onPick: () => void; onTest: () => void
+/** One tile in the top-level chooser: logo + name + a badge, nothing else. */
+function ChooserTile({ id, name, badge, selected, subtitle, onOpen }: {
+  id: LlmProviderId; name: string; badge: string; selected: boolean
+  subtitle?: string; onOpen: () => void
 }) {
-  const testable = p.kind === 'cli' && !missing
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={onPick}
-      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onPick() } }}
-      className="flex flex-col text-left h-full"
+    <button onClick={onOpen} className="flex flex-col text-left h-full"
       style={{
-        gap: 8, padding: '13px 14px', borderRadius: 13, cursor: 'pointer',
-        // --t-card, not --t-box: on the ink palette --t-box is rgba(255,255,255,.055),
-        // which leaves the cards barely distinguishable from the desk behind them. The
-        // real card surface reads as a solid, lit object on all three palettes.
-        background: picked
-          ? 'color-mix(in srgb, var(--color-state-proposal) 12%, var(--t-card))'
-          : 'var(--t-card)',
-        border: `1px solid ${picked ? 'var(--color-state-proposal)' : 'var(--t-ctrl-border)'}`,
-        boxShadow: picked
-          ? 'inset 0 0 0 1px color-mix(in srgb, var(--color-state-proposal) 30%, transparent)'
-          : '0 1px 2px rgba(0,0,0,.04)',
-        transition: 'background .14s, border-color .14s',
+        gap: 9, padding: '15px 15px', borderRadius: 13, cursor: 'pointer',
+        background: selected ? 'color-mix(in srgb, var(--color-state-proposal) 10%, var(--t-card))' : 'var(--t-card)',
+        border: `1px solid ${selected ? 'var(--color-state-proposal)' : 'var(--t-ctrl-border)'}`,
+        boxShadow: '0 1px 2px rgba(0,0,0,.04)',
       }}>
-      <div className="flex items-start" style={{ gap: 10 }}>
-        <ProviderGlyph on={picked} />
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div className="flex items-center" style={{ gap: 8 }}>
-            <span style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--t-title)' }}>{p.name}</span>
-          </div>
-          <div className="flex items-center flex-wrap" style={{ gap: 5, marginTop: 4 }}>
-            {missing && <Badge text="NOT INSTALLED" tone="warn" />}
-            <TestBadge testing={testing} lastTest={lastTest} />
-          </div>
-        </div>
-        {/* Radio dot */}
+      <div className="flex items-start justify-between" style={{ gap: 10 }}>
         <span className="flex items-center justify-center shrink-0" style={{
-          width: 17, height: 17, borderRadius: 99, marginTop: 1,
-          border: `1.5px solid ${picked ? 'var(--color-state-proposal)' : 'var(--t-card-border)'}`,
-          background: picked ? 'var(--color-state-proposal)' : 'transparent',
+          width: 38, height: 38, borderRadius: 10,
+          background: selected ? 'color-mix(in srgb, var(--color-state-proposal) 15%, transparent)' : 'var(--t-box)',
+          border: '1px solid var(--t-ctrl-border)',
+          color: selected ? 'var(--color-state-proposal)' : 'var(--t-title)',
         }}>
-          {picked && <span style={{ width: 6, height: 6, borderRadius: 99, background: '#fff' }} />}
+          <ProviderLogo id={id} size={21} />
         </span>
+        {selected && (
+          <span className="font-mono" style={{
+            fontSize: 9, letterSpacing: '.09em', color: 'var(--color-state-approved)',
+            border: '1px solid var(--color-state-approved)',
+            background: 'color-mix(in srgb, var(--color-state-approved) 10%, transparent)',
+            borderRadius: 4, padding: '1.5px 5px', whiteSpace: 'nowrap',
+          }}>IN USE</span>
+        )}
       </div>
-
-      <p style={{ fontSize: 11.5, lineHeight: 1.4, color: 'var(--t-title)' }}>{p.blurb}</p>
-
-      {/* The failure/rate-limit message from the last test, when there is one. */}
-      {lastTest && lastTest.outcome.status !== 'ok' && (
-        <p style={{ fontSize: 10.5, lineHeight: 1.4, color: 'var(--t-title)' }}>
-          {lastTest.outcome.message}
-        </p>
-      )}
-
-      {/* Picking an uninstalled CLI is allowed, not blocked — show exactly how to get it.
-          Surfaced on --t-key-bg, not --t-card: the card itself is now --t-card, so this
-          inset command block needs its own surface to stay legible as a nested element. */}
-      {missing && picked && (
-        <p className="font-mono" style={{ fontSize: 10.5, lineHeight: 1.5, color: 'var(--t-key-text)', background: 'var(--t-key-bg)', borderRadius: 6, padding: '6px 8px' }}>
-          {p.installHint}
-        </p>
-      )}
-
-      {testable && (
-        <button
-          onClick={(e) => { e.stopPropagation(); onTest() }}
-          // Also stop keydown: Enter/Space fires this button natively, but without
-          // this the same keypress bubbles to the card's role="button" onKeyDown and
-          // switches the selected provider too.
-          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') e.stopPropagation() }}
-          disabled={testing}
-          className="font-mono self-start"
-          style={{
-            fontSize: 10, letterSpacing: '.08em', textTransform: 'uppercase',
-            // A filled control on --t-box rather than a hairline outline on transparent,
-            // which on the card surface read as a disabled label. (--t-box, not --t-ctrl:
-            // --t-ctrl equals --t-card on the light palettes - see ProviderGlyph.)
-            color: 'var(--t-title)', border: '1px solid var(--t-ctrl-border)',
-            borderRadius: 5, padding: '4px 8px', cursor: testing ? 'default' : 'pointer',
-            opacity: testing ? 0.55 : 1, background: 'var(--t-box)',
-          }}>
-          {testing ? 'Testing…' : 'Test connection'}
-        </button>
-      )}
-    </div>
+      <div className="flex flex-col" style={{ gap: 4 }}>
+        <span style={{ fontSize: 14.5, fontWeight: 550, color: 'var(--t-title)' }}>{name}</span>
+        <span className="font-mono self-start" style={{
+          fontSize: 8.5, letterSpacing: '.09em', color: 'var(--t-faint)',
+        }}>{badge}</span>
+        {subtitle && <span style={{ fontSize: 11, lineHeight: 1.4, color: 'var(--t-muted)' }}>{subtitle}</span>}
+      </div>
+    </button>
   )
 }
 
 export interface LlmProviderPickerProps {
   value: LlmProviderId
-  /** Which custom endpoint, when `value` is 'custom'. The registry can hold several, so the
-   *  kind alone can't say which card is chosen. Ignored otherwise. */
+  /** Which custom endpoint, when `value` is 'custom'. */
   selectedCustomId?: string | null
-  /** `customId` is set only when `id` is 'custom'; the owner persists BOTH fields together
-   *  (`llm_provider` + `llm_provider_custom_id`), since either alone is not a valid choice. */
-  onChange: (id: LlmProviderId, customId?: string) => void
+  /** The owner persists BOTH fields together (`llm_provider` + `llm_provider_custom_id`). May
+   *  return a promise the detail view awaits to show "Switching…"/failure. */
+  onChange: (id: LlmProviderId, customId?: string) => void | Promise<void>
   status: Record<string, ProviderStatus>
   scanning: boolean
-  /** Providers a real connectivity test is currently in flight for — from Rescan (all
-   *  installed providers at once) or a single card's own Test button. */
   testingIds: Set<string>
-  /** Run a real connectivity test for one provider on demand. */
+  installingIds: Set<string>
+  signingIds: Set<string>
   testOne: (id: string) => void
+  install: (id: string) => Promise<InstallOutcome>
+  signIn: (id: string) => Promise<InstallOutcome>
   rescan: () => void
 }
 
-export default function LlmProviderPicker({ value, selectedCustomId, onChange, status, scanning, testingIds, testOne, rescan }: LlmProviderPickerProps) {
-  const picked = LLM_PROVIDERS.find((p) => p.id === value)
-  const usingCli = picked?.kind === 'cli'
-  const busy = scanning || testingIds.size > 0
+export default function LlmProviderPicker({
+  value, selectedCustomId, onChange, status, scanning, testingIds, installingIds, signingIds,
+  testOne, install, signIn, rescan,
+}: LlmProviderPickerProps) {
+  // Which provider's detail is open, or null for the chooser. `'custom'` opens the BYO flow.
+  const [openId, setOpenId] = useState<LlmProviderId | null>(null)
   const custom = useCustomProviders()
+
+  // A provider the user has selected but that isn't one of the three recommended tiles (a
+  // legacy Copilot pick). We don't render a Copilot card, but we mustn't strand them either.
+  const usingHidden = value !== 'custom' && !CHOOSER_PROVIDER_IDS.includes(value)
+
+  if (openId && openId !== 'custom') {
+    const p = llmProvider(openId)
+    return (
+      <LlmProviderDetail
+        p={p}
+        probed={status[openId]}
+        testing={testingIds.has(openId)}
+        installing={installingIds.has(openId)}
+        signing={signingIds.has(openId)}
+        selected={value === openId}
+        onBack={() => setOpenId(null)}
+        onInstall={() => install(openId)}
+        onSignIn={() => signIn(openId)}
+        onTest={() => testOne(openId)}
+        onUse={async () => { await onChange(openId) }}
+      />
+    )
+  }
+
+  if (openId === 'custom') {
+    return (
+      <CustomDetail
+        value={value}
+        selectedCustomId={selectedCustomId ?? null}
+        custom={custom}
+        onBack={() => setOpenId(null)}
+        onPick={(id) => onChange('custom', id)}
+      />
+    )
+  }
 
   return (
     <div className="flex flex-col" style={{ gap: 12 }}>
-      {/* auto-fill rather than a fixed 2 columns: the same grid serves the narrow setup
-          wizard (falls to 2) and the wider Settings pane (fits 3), and more columns means
-          fewer rows, which is what keeps Settings' Save button above the fold. */}
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(232px, 1fr))', gap: 9 }}>
-        {LLM_PROVIDERS.map((p) => {
-          const isPicked = p.id === value
-          // Unknown (probe failed) is NOT "missing" — only say "not installed" when we
-          // actually looked and didn't find it.
-          const probed = status[p.id]
-          const missing = p.kind === 'cli' && !!probed && !probed.installed
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(190px, 1fr))', gap: 10 }}>
+        {CHOOSER_PROVIDER_IDS.map((id) => {
+          const p = llmProvider(id)
           return (
-            <ProviderCard
-              key={p.id}
-              p={p}
-              picked={isPicked}
-              missing={missing}
-              testing={testingIds.has(p.id)}
-              lastTest={probed?.last_test ?? null}
-              onPick={() => onChange(p.id)}
-              onTest={() => testOne(p.id)}
+            <ChooserTile
+              key={id}
+              id={id}
+              name={p.name}
+              badge={LLM_RECOMMENDED_BADGE}
+              selected={value === id}
+              onOpen={() => setOpenId(id)}
             />
           )
         })}
+        <ChooserTile
+          id="custom"
+          name="Bring your own API key"
+          badge="ADVANCED"
+          selected={value === 'custom'}
+          subtitle="Your own OpenAI-compatible endpoint."
+          onOpen={() => setOpenId('custom')}
+        />
+      </div>
 
-        {/* The user's own endpoints, after the built-ins: they are the advanced case, and
-            unlike the built-ins they only become selectable once MEASURED (the settings
-            write rejects an ineligible one - the card says why). */}
+      <p style={{ fontSize: 11, lineHeight: 1.45, color: 'var(--t-muted)' }}>
+        {LLM_RECOMMENDED_NOTE}
+      </p>
+
+      {/* A legacy Copilot user isn't stranded: tell them what they're on and let them switch. */}
+      {usingHidden && (
+        <p style={{ fontSize: 11, lineHeight: 1.45, color: 'var(--color-state-pending)' }}>
+          You&apos;re currently using {llmProvider(value).name}. Pick one of the recommended providers
+          above to switch.
+        </p>
+      )}
+
+      {/* Re-probe for a CLI the user installed in a terminal while this was open. */}
+      <button onClick={rescan} disabled={scanning} className="self-start"
+        style={{
+          fontSize: 11, color: 'var(--t-muted)', background: 'none', border: 'none',
+          padding: 0, cursor: scanning ? 'default' : 'pointer', textDecoration: 'underline',
+        }}>
+        {scanning ? 'Checking what’s installed…' : 'Installed a CLI yourself? Rescan'}
+      </button>
+    </div>
+  )
+}
+
+/** The bring-your-own-key detail — the existing custom-endpoint registry, behind a Back button. */
+function CustomDetail({ value, selectedCustomId, custom, onBack, onPick }: {
+  value: LlmProviderId
+  selectedCustomId: string | null
+  custom: ReturnType<typeof useCustomProviders>
+  onBack: () => void
+  onPick: (id: string) => void
+}) {
+  return (
+    <div className="flex flex-col" style={{ gap: 13 }}>
+      <button onClick={onBack} className="self-start flex items-center"
+        style={{ gap: 6, fontSize: 12, color: 'var(--t-muted)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}>
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><path d="M10 4 6 8l4 4" /></svg>
+        All providers
+      </button>
+      <div>
+        <span style={{ fontSize: 17, fontWeight: 600, color: 'var(--t-title)' }}>Bring your own API key</span>
+        <p style={{ fontSize: 12, lineHeight: 1.45, color: 'var(--t-muted)', marginTop: 3, maxWidth: 520 }}>
+          Point Meridian at your own OpenAI-compatible endpoint. Unlike the coding agents, this
+          bills your own key for every call - so a free-tier key is the right choice.
+        </p>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(232px, 1fr))', gap: 9 }}>
         {custom.providers.map((c) => (
           <CustomProviderCard
             key={c.id}
             p={c}
             picked={value === 'custom' && selectedCustomId === c.id}
             probing={custom.probingIds.has(c.id)}
-            onPick={() => onChange('custom', c.id)}
+            onPick={() => onPick(c.id)}
             onProbe={(hard) => custom.probe(c.id, hard)}
             onRemove={() => custom.remove(c.id)}
           />
         ))}
-
-        {/* Renders as one more card in the grid; it spans the full row only while its
-            form is open (URL, model, key need the width) - that span is owned by
-            <AddCustomProvider> itself, since only it knows whether the form is showing. */}
         {!custom.loading && <AddCustomProvider onAdd={custom.add} />}
-      </div>
-
-      {/* Usage-footprint reassurance — only meaningful when a paid CLI is in play. */}
-      {usingCli && (
-        <p style={{ fontSize: 11, lineHeight: 1.45, color: 'var(--t-muted)' }}>
-          {USAGE_FOOTPRINT_NOTE}
-        </p>
-      )}
-
-      {/* Honesty on privacy: we disable telemetry on every call, but opting your prompts
-          out of model TRAINING is a one-time account setting we can't flip for you. */}
-      {usingCli && picked?.privacyUrl && (
-        <div className="flex items-start" style={{
-          gap: 8, padding: '10px 12px', borderRadius: 10,
-          background: 'var(--t-card)', border: '1px solid var(--t-ctrl-border)',
-        }}>
-          <span className="shrink-0" style={{ marginTop: 1, color: 'var(--color-state-approved)' }} aria-hidden="true">🔒</span>
-          <p style={{ fontSize: 11, lineHeight: 1.5, color: 'var(--t-muted)' }}>
-            Meridian turns off usage telemetry on every call. To also keep your prompts out of model
-            training, switch on {picked.name}’s privacy setting once:{' '}
-            <button onClick={() => picked.privacyUrl && openExternal(picked.privacyUrl)}
-              style={{ color: 'var(--color-state-proposal)', background: 'none', border: 'none', padding: 0, cursor: 'pointer', font: 'inherit', textDecoration: 'underline' }}>
-              {picked.privacyLabel ?? 'open settings'} ↗
-            </button>
-          </p>
-        </div>
-      )}
-
-      {/* Standing warning while a custom endpoint is the chosen provider - the pipeline then
-          bills the user's own key every hour, unattended. */}
-      {value === 'custom' && (
-        <p style={{ fontSize: 11, lineHeight: 1.45, color: 'var(--color-state-pending)' }}>
-          {CUSTOM_PROVIDER_COST_NOTE}
-        </p>
-      )}
-
-      <div className="flex items-center justify-between">
-        <p style={{ fontSize: 11, color: 'var(--t-muted)', lineHeight: 1.45, flex: 1, paddingRight: 12 }}>
-          The four coding agents use the login you already have in that CLI - Meridian never asks
-          them for an API key, and an hour they can’t serve is left pending and retried. A custom
-          endpoint is the exception: it runs on a key you paste here.
-        </p>
-        <button onClick={rescan} disabled={busy} className="font-mono shrink-0"
-          style={{
-            fontSize: 10.5, letterSpacing: '.08em', textTransform: 'uppercase',
-            // Same fill as the per-card Test buttons - they are the same class of control.
-            color: 'var(--t-title)', border: '1px solid var(--t-ctrl-border)',
-            borderRadius: 6, padding: '5px 10px', cursor: busy ? 'default' : 'pointer',
-            opacity: busy ? 0.55 : 1, background: 'var(--t-box)',
-          }}>
-          {scanning ? 'Scanning…' : testingIds.size > 0 ? 'Testing…' : 'Rescan'}
-        </button>
       </div>
     </div>
   )

--- a/ui/components/LlmProviderPicker.tsx
+++ b/ui/components/LlmProviderPicker.tsx
@@ -11,7 +11,7 @@
 //   CHOOSER  — three recommended coding-agent tiles (logo + name + RECOMMENDED) plus one
 //              "bring your own API key" tile. Just the choice, nothing else.
 //   DETAIL   — click a tile and you get its own screen: install the CLI if missing, confirm the
-//              sign-in if it's there, optionally set a model, and make it the default. One
+//              sign-in if it's there, and make it the default. One
 //              provider, one next action.
 //
 // It deliberately does NOT save. The wizard writes each pick straight through; Settings commits

--- a/ui/components/timeline/settings/IntelligenceSection.tsx
+++ b/ui/components/timeline/settings/IntelligenceSection.tsx
@@ -1,131 +1,67 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 //
-// Settings → Intelligence. The post-setup home of the same AI-provider choice the
-// wizard makes on its Intelligence step — same list, same <LlmProviderPicker>, so the
-// two surfaces can never drift. Switching here takes effect on the NEXT hour with nothing
-// to restart: the resolver re-reads settings.json on every call (src/llm/resolver.rs), so
-// there is deliberately no reload_daemon() here.
+// Settings → Intelligence. The post-setup home of the same AI-provider choice the wizard makes
+// on its Intelligence step — same list, same <LlmProviderPicker>, so the two surfaces can never
+// drift. Switching here takes effect on the NEXT hour with nothing to restart: the resolver
+// re-reads settings.json on every call (src/llm/resolver.rs), so there is no reload_daemon().
 //
-// Unlike the wizard (where each pick writes straight through, because the wizard's own
-// Next/Back is the commit), a pick HERE is only STAGED — it lands in `pending` and is
-// persisted by an explicit Save, matching every other Settings section (Advanced,
-// Capture, Notifications all use <SaveButton>). Staging also removes the old optimistic
-// `patch()`-on-click: `save` only calls setSettings on SUCCESS (useRuntimeSettings.ts),
-// so an optimistic patch survived a FAILED write and left the panel claiming a provider
-// the daemon had rejected. Nothing is written until Save now, so there is nothing to
-// roll back. Only the selection is gated — Test connection, Rescan, and adding/removing
-// custom endpoints stay immediate, since those are actions, not this setting.
+// A pick COMMITS IMMEDIATELY (there is no staged Save anymore): the user opens a provider's
+// detail view and the "Use <provider>" button is itself the explicit, deliberate write — so the
+// old optimistic-patch-survives-a-failed-write problem can't happen. `save` only updates the
+// in-memory settings on success and reports failure through the status callback, which the
+// detail view surfaces; on failure `settings.llm_provider` is unchanged, so nothing rolls back.
+// Model changes commit the same way (debounced in the detail view so free-text typing isn't a
+// write per keystroke).
 
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
 import type { RuntimeSettings } from '@/lib/settings'
-import { llmProvider, type LlmProviderId } from '@/lib/llm-providers'
+import { LLM_INTRO_BODY, LLM_INTRO_TITLE, type LlmProviderId } from '@/lib/llm-providers'
 import LlmProviderPicker, { useLlmProviderDetection } from '@/components/LlmProviderPicker'
-import { ModelSelect, ModelUnsupportedNote } from '@/components/ModelPicker'
-import { SaveButton, type SaveStatus } from './fields'
-
-/** A staged, not-yet-saved provider choice. `customId` is the chosen endpoint when
- *  `id` is 'custom', else null — the two always travel together (see `onChange`).
- *  `model` is the optional per-provider model override; '' means the provider's default. */
-interface PendingChoice {
-  id: LlmProviderId
-  customId: string | null
-  model: string
-}
+import type { SaveStatus } from './fields'
 
 export function IntelligenceSection({ settings, save }: {
   settings: RuntimeSettings
   save: (fields: Partial<RuntimeSettings>, setStatus?: (s: SaveStatus) => void) => Promise<void>
 }) {
-  const { status, scanning, testingIds, testOne, rescan } = useLlmProviderDetection()
-  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle')
-  const [pending, setPending] = useState<PendingChoice | null>(null)
+  const { status, scanning, testingIds, installingIds, signingIds, testOne, install, signIn, rescan } = useLlmProviderDetection()
 
-  const savedId = settings.llm_provider
-  const savedCustomId = settings.llm_provider_custom_id ?? null
-  const savedModel = settings.llm_provider_model ?? ''
-  // What the panel SHOWS: the staged pick while one is held, else what's on disk. Every
-  // dependent read below (badges, warnings) uses this, so the whole section describes the
-  // provider you are about to commit rather than half-describing the old one.
-  const provider = pending?.id ?? savedId
-  const selectedCustomId = pending ? pending.customId : savedCustomId
-  const model = pending ? pending.model : savedModel
-  const picked = llmProvider(provider)
-  // The override is only meaningful for a CLI backend that actually passes it through.
-  // A custom endpoint carries its model on the endpoint ROW instead (openai_compat sends
-  // `ep.model` and ignores cfg.model), and copilot has no model flag at all.
-  const showModelPicker = picked.kind === 'cli' && picked.supportsModelOverride
+  const provider = settings.llm_provider
+  const selectedCustomId = settings.llm_provider_custom_id ?? null
 
-  // The chosen provider's last real connectivity test, if any — not a guess. When it
-  // failed, the warning below says what's ACTUALLY happening right now instead of only
-  // what could theoretically happen.
-  const selectedTest = picked.kind === 'cli' ? status[picked.id]?.last_test ?? null : null
-  const selectedBroken = !!selectedTest && selectedTest.outcome.status !== 'ok'
+  // Commit a change and resolve/reject on the real save outcome, so the detail view can show
+  // "Switching…" and a failure. `save` never rejects itself (it reports via the callback), so
+  // the promise bridge is here.
+  const commit = useCallback(
+    (fields: Partial<RuntimeSettings>) =>
+      new Promise<void>((resolve, reject) => {
+        save(fields, (s) => {
+          if (s === 'saved') resolve()
+          else if (s === 'error') reject(new Error("Couldn't save - try again."))
+        })
+      }),
+    [save],
+  )
 
-  const onChange = useCallback((id: LlmProviderId, customId?: string) => {
-    // 'custom' names a KIND, so it always travels with the endpoint's id - either alone is
-    // not a valid choice, and update_settings rejects a custom selection that names no
-    // configured endpoint. Comparing the PAIR (not just the id) is what makes switching
-    // between two custom endpoints register as a change.
-    const nextCustomId = id === 'custom' ? customId ?? null : null
-    // The override is scoped to the CHOSEN provider - src/llm/detect.rs clears cfg.model
-    // when testing any other one, precisely so one CLI's model string can't leak into
-    // another's --model. Switching provider therefore DROPS the staged model instead of
-    // carrying e.g. a claude alias over to codex; returning to the saved provider restores
-    // whatever is on disk.
-    const nextModel = id === savedId ? savedModel : ''
-    const backToSaved = id === savedId && (id !== 'custom' || nextCustomId === savedCustomId)
-    setSaveStatus('idle')
-    // Re-picking the saved provider clears the stage, so Save can't offer to write a
-    // change that isn't one.
-    setPending(backToSaved ? null : { id, customId: nextCustomId, model: nextModel })
-  }, [savedId, savedCustomId, savedModel])
+  const onChange = useCallback(
+    (id: LlmProviderId, customId?: string) =>
+      // 'custom' always travels with its endpoint id. Switching a built-in also clears any
+      // stored model override (there is no model UI - the setting always follows the provider's
+      // default now - but a value left over from an older build must not ride onto a new CLI,
+      // since src/llm/config.rs still passes it into --model).
+      id === 'custom'
+        ? commit({ llm_provider: id, llm_provider_custom_id: customId ?? null })
+        : commit({ llm_provider: id, llm_provider_model: null }),
+    [commit],
+  )
 
-  // Staging a model follows the same rule as staging a provider: land it in `pending`, and
-  // collapse back to "nothing staged" the moment the pair matches what is on disk, so Save
-  // never offers to write a non-change.
-  const onModelChange = useCallback((next: string) => {
-    setSaveStatus('idle')
-    setPending(prev => {
-      const staged = { ...(prev ?? { id: savedId, customId: savedCustomId, model: savedModel }), model: next }
-      const settled = staged.id === savedId
-        && (staged.id !== 'custom' || staged.customId === savedCustomId)
-        && staged.model === savedModel
-      return settled ? null : staged
-    })
-  }, [savedId, savedCustomId, savedModel])
-
-  const onSave = useCallback(() => {
-    if (!pending) return
-    // A custom endpoint's model lives on the endpoint row, so the shared override is not
-    // written for it. '' means "the provider's own default" and is stored as null, matching
-    // `Option<String>`/`None` in meridian-core/src/settings.rs.
-    const fields: Partial<RuntimeSettings> = pending.id === 'custom'
-      ? { llm_provider: pending.id, llm_provider_custom_id: pending.customId }
-      : { llm_provider: pending.id, llm_provider_model: pending.model || null }
-    // `save` never rejects — it reports through the status callback — so the staged pick
-    // is cleared on 'saved' only. On 'error' it deliberately survives, so the user can hit
-    // Save again without re-picking.
-    save(fields, (s) => {
-      setSaveStatus(s)
-      if (s === 'saved') setPending(null)
-    })
-  }, [pending, save])
-
-  // Wider than the other sections' 640px: this one carries a card GRID, and the extra
-  // width buys a third column (see the picker's auto-fill), which is what removes a whole
-  // row of scrolling. Still inside the 980px modal's ~916px of usable width.
   return (
-    <div className="max-w-[880px] flex flex-col gap-5">
+    <div className="max-w-[760px] flex flex-col gap-5">
       <div>
         <p className="mt-label" style={{ color: 'var(--color-state-proposal)' }}>Your AI</p>
-        <h1 className="mt-title-lg mt-1.5" style={{ color: 'var(--t-title)' }}>Intelligence</h1>
-        <p className="mt-body-sm mt-2 max-w-[520px]" style={{ color: 'var(--t-muted)' }}>
-          The AI that writes your hourly summaries. Use a coding-agent CLI you already pay for, or
-          a custom endpoint on your own key. Pick one and hit Save - it takes effect from the next hour,
-          with nothing to restart.
-        </p>
+        <h1 className="mt-title-lg mt-1.5" style={{ color: 'var(--t-title)' }}>{LLM_INTRO_TITLE}</h1>
+        <p className="mt-body-sm mt-2 max-w-[560px]" style={{ color: 'var(--t-muted)' }}>{LLM_INTRO_BODY}</p>
       </div>
 
       <LlmProviderPicker
@@ -135,92 +71,13 @@ export function IntelligenceSection({ settings, save }: {
         status={status}
         scanning={scanning}
         testingIds={testingIds}
+        installingIds={installingIds}
+        signingIds={signingIds}
         testOne={testOne}
+        install={install}
+        signIn={signIn}
         rescan={rescan}
       />
-
-      {/* The model within the chosen provider. Net-new UI: `llm_provider_model` has existed
-          on both sides of the wire for a while (meridian-core/src/settings.rs, consumed at
-          src/llm/config.rs) but nothing ever wrote it, so the override was unreachable.
-          Blank stays the default - most users never need this. */}
-      <div className="flex flex-col gap-2">
-        <p className="mt-label" style={{ color: 'var(--t-faint)' }}>MODEL</p>
-        {showModelPicker ? (
-          <>
-            <ModelSelect
-              value={model}
-              onChange={onModelChange}
-              models={picked.models}
-              emptyLabel={`${picked.name} default`}
-            />
-            <p className="mt-body-sm max-w-[520px]" style={{ color: 'var(--t-muted)' }}>
-              Leave this on the default unless you have a reason not to - Meridian follows
-              whatever {picked.name} would pick for itself. A model this list doesn't carry
-              can be typed in; nothing here is a fixed set.
-            </p>
-          </>
-        ) : picked.kind === 'custom' ? (
-          <p className="mt-body-sm max-w-[520px]" style={{ color: 'var(--t-muted)' }}>
-            A custom endpoint carries its own model - change it on the endpoint itself, above.
-          </p>
-        ) : (
-          <ModelUnsupportedNote providerName={picked.name} />
-        )}
-      </div>
-
-      {/* A KNOWN failure, from the last real test. Since the on-device fallback was
-          removed there is nothing to degrade to, so this is the one thing to tell the
-          user: the affected hours are deferred, not lost. A failed SAVE is reported by
-          the sticky footer below, not here. */}
-      {selectedBroken && selectedTest && selectedTest.outcome.status !== 'ok' && (
-        <div className="rounded-xl p-3.5 flex items-start gap-2.5"
-          style={{ border: '1px solid var(--status-error-dot)', background: 'color-mix(in srgb, var(--status-error-dot) 7%, transparent)' }}>
-          <span className="shrink-0" style={{ marginTop: 2, color: 'var(--status-error-dot)' }} aria-hidden="true">⚠</span>
-          <p className="mt-body-sm" style={{ color: 'var(--t-muted)' }}>
-            {selectedTest.outcome.status === 'rate_limited'
-              ? `${picked.name} is currently rate-limited: ${selectedTest.outcome.message}. `
-              : `${picked.name} isn't responding right now: ${selectedTest.outcome.message}. `}
-            Those hours are being held until this clears, then picked up automatically.
-          </p>
-        </div>
-      )}
-
-      {/* Save is offered only while a pick is staged, so a settled panel carries no dead
-          control - and it is STICKY, pinned to the bottom of the Settings scroll area, so
-          it can never fall below the fold however many providers, custom endpoints or
-          warnings are on screen. Rendered last (after the warnings) so, once scrolled to
-          the end, it sits in natural document order rather than overlapping anything.
-          <SaveButton> supplies its own 'Saved'/'Failed to save' status, the same as
-          Advanced/Capture/Notifications; the line above it carries the part that generic
-          status can't - WHICH provider is staged, and (on failure) that the pick survived
-          the failed write, so Save can simply be pressed again without re-picking. */}
-      {pending && (
-        <div className="sticky bottom-0 flex flex-col gap-2 pb-1"
-          style={{ background: 'var(--t-panel)' }}>
-          {/* A staged change is now either a provider switch OR a model-only edit, and the
-              guidance has to match: telling someone who changed the model that a provider
-              "isn't in use yet" describes a switch that isn't happening. */}
-          <p className="mt-body-sm" style={{
-            color: saveStatus === 'error' ? 'var(--status-error-dot)' : 'var(--color-state-pending)',
-          }}>
-            {(() => {
-              const name = llmProvider(pending.id).name
-              const providerChanged = pending.id !== savedId
-                || (pending.id === 'custom' && pending.customId !== savedCustomId)
-              const target = pending.model === '' ? `the ${name} default model` : pending.model
-              if (saveStatus === 'error') {
-                return providerChanged
-                  ? `Couldn't switch to ${name} - it's still selected here, so you can press Save to try again.`
-                  : `Couldn't change the model to ${target} - it's still selected here, so you can press Save to try again.`
-              }
-              return providerChanged
-                ? `${name} isn't in use yet - Save to switch to it.`
-                : `${name} is still using its current model - Save to switch to ${target}.`
-            })()}
-          </p>
-          <SaveButton status={saveStatus} onClick={onSave} />
-        </div>
-      )}
     </div>
   )
 }

--- a/ui/components/timeline/settings/IntelligenceSection.tsx
+++ b/ui/components/timeline/settings/IntelligenceSection.tsx
@@ -10,14 +10,14 @@
 // old optimistic-patch-survives-a-failed-write problem can't happen. `save` only updates the
 // in-memory settings on success and reports failure through the status callback, which the
 // detail view surfaces; on failure `settings.llm_provider` is unchanged, so nothing rolls back.
-// Model changes commit the same way (debounced in the detail view so free-text typing isn't a
-// write per keystroke).
+// There is no model control: the model always follows the provider's own default, and picking
+// a built-in provider CLEARS any override an older build left behind.
 
 'use client'
 
 import { useCallback } from 'react'
 import type { RuntimeSettings } from '@/lib/settings'
-import { LLM_INTRO_BODY, LLM_INTRO_TITLE, type LlmProviderId } from '@/lib/llm-providers'
+import { LLM_INTRO_BODY, LLM_INTRO_TITLE, providerChoiceFields, type LlmProviderId } from '@/lib/llm-providers'
 import LlmProviderPicker, { useLlmProviderDetection } from '@/components/LlmProviderPicker'
 import type { SaveStatus } from './fields'
 
@@ -44,15 +44,10 @@ export function IntelligenceSection({ settings, save }: {
     [save],
   )
 
+  // Which fields a provider pick writes is shared with the setup wizard (see
+  // providerChoiceFields) - the two used to hand-roll it and silently drifted.
   const onChange = useCallback(
-    (id: LlmProviderId, customId?: string) =>
-      // 'custom' always travels with its endpoint id. Switching a built-in also clears any
-      // stored model override (there is no model UI - the setting always follows the provider's
-      // default now - but a value left over from an older build must not ride onto a new CLI,
-      // since src/llm/config.rs still passes it into --model).
-      id === 'custom'
-        ? commit({ llm_provider: id, llm_provider_custom_id: customId ?? null })
-        : commit({ llm_provider: id, llm_provider_model: null }),
+    (id: LlmProviderId, customId?: string) => commit(providerChoiceFields(id, customId)),
     [commit],
   )
 

--- a/ui/lib/llm-providers.ts
+++ b/ui/lib/llm-providers.ts
@@ -266,7 +266,13 @@ export const LLM_PROVIDERS: LlmProviderMeta[] = [
     blurb: 'Uses your Cursor subscription through the cursor-agent CLI.',
     kind: 'cli',
     bin: 'cursor-agent',
-    installHint: 'curl https://cursor.com/install -fsS | bash',
+    // Pinned to the cursor-agent build Meridian is verified against - mirrors
+    // CURSOR_INSTALL_CMD in meridian-core/src/llm_provider.rs (the authoritative copy the
+    // tray actually runs). cursor.com/install is a rolling script with no version flag,
+    // so the sed rewrites its version strings; matching by pattern keeps working after
+    // Cursor bumps their script.
+    installHint:
+      "curl -fsSL https://cursor.com/install | sed -E 's#[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}-[0-9a-f]{7}#2026.07.16-899851b#g' | bash",
     installUrl: 'https://cursor.com/cli',
     privacyUrl: 'https://cursor.com/settings',
     privacyLabel: 'Cursor - Privacy Mode',
@@ -331,6 +337,31 @@ export function supportsModelOverride(id: LlmProviderId): boolean {
  * unconfigured choice resolves here.
  */
 export const DEFAULT_LLM_PROVIDER: LlmProviderId = 'claude'
+
+/**
+ * The providers shown at the TOP LEVEL of the picker, in order — the three coding-agent CLIs
+ * we recommend. Copilot is still a valid stored value and is still probed by the backend, but
+ * it is deliberately NOT offered here: it needs org policy that often blocks it and it can't
+ * take a model, so it made a poor default. A user who already has it selected is handled with
+ * a small banner rather than a card (see <LlmProviderPicker>).
+ */
+export const CHOOSER_PROVIDER_IDS: LlmProviderId[] = ['claude', 'codex', 'cursor']
+
+/** The single shared heading for the provider chooser - same words in the wizard and Settings
+ *  so the one choice reads identically wherever it is made. Plain hyphens (user-facing). */
+export const LLM_INTRO_TITLE = 'First, choose your AI provider'
+
+/** The shared sub-heading. States the job, the tiny footprint, and the escape hatch in one
+ *  breath, in plain language. */
+export const LLM_INTRO_BODY =
+  'Meridian uses this to write your hourly summaries and worklogs. It sends about one short request per active hour - well under 1% of your plan with Claude, Codex, or Cursor, so it never eats into your own coding. Pick one, or bring your own API key.'
+
+/** The badge every recommended CLI carries at the top level. */
+export const LLM_RECOMMENDED_BADGE = 'RECOMMENDED'
+
+/** Why we recommend them - shown once under the recommended row. */
+export const LLM_RECOMMENDED_NOTE =
+  'These run on frontier models through a subscription you already pay for - the most accurate option, and no extra cost.'
 
 /**
  * The rough share of a plan's usage limit that Meridian's hourly summaries consume - one

--- a/ui/lib/llm-providers.ts
+++ b/ui/lib/llm-providers.ts
@@ -349,7 +349,7 @@ export const CHOOSER_PROVIDER_IDS: LlmProviderId[] = ['claude', 'codex', 'cursor
 
 /** The single shared heading for the provider chooser - same words in the wizard and Settings
  *  so the one choice reads identically wherever it is made. Plain hyphens (user-facing). */
-export const LLM_INTRO_TITLE = 'First, choose your AI provider'
+export const LLM_INTRO_TITLE = 'Choose your AI provider'
 
 /** The shared sub-heading. States the job, the tiny footprint, and the escape hatch in one
  *  breath, in plain language. */
@@ -476,6 +476,32 @@ export const CUSTOM_PROVIDER_META: LlmProviderMeta = {
   // Empty on purpose: these are the one provider whose models can be enumerated LIVE,
   // from the endpoint's own {base_url}/models. Nothing to hand-maintain here.
   models: [],
+}
+
+/**
+ * The EXACT settings fields to write when the user picks a provider - the single source of
+ * truth for both surfaces that can make that choice (the setup wizard and Settings →
+ * Intelligence).
+ *
+ * Shared because the two hand-rolled copies drifted, and the drift was silent: Settings
+ * cleared `llm_provider_model` and setup did not, so switching provider in the WIZARD carried
+ * a stale model override onto the new CLI. `src/llm/config.rs` still passes that value into
+ * `--model`, so e.g. a leftover `"opus"` became `codex --model opus` - a failure surfacing an
+ * hour later, far from the click. On Cursor it is worse than a bad arg: a non-empty override
+ * suppresses the pinned ZDR-eligible default in `src/llm/cursor.rs`, so a stale value silently
+ * moves the user off the model we pinned partly for that guarantee.
+ *
+ * `custom` is a KIND, not an endpoint, so it always travels with the id of the chosen one
+ * (which `update_settings` requires and validates) - and it keeps its model, because a custom
+ * endpoint's model is a real per-row setting rather than a leftover.
+ */
+export function providerChoiceFields(
+  id: LlmProviderId,
+  customId?: string,
+): { llm_provider: LlmProviderId; llm_provider_custom_id?: string | null; llm_provider_model?: null } {
+  return id === 'custom'
+    ? { llm_provider: id, llm_provider_custom_id: customId ?? null }
+    : { llm_provider: id, llm_provider_model: null }
 }
 
 export function llmProvider(id: LlmProviderId): LlmProviderMeta {


### PR DESCRIPTION
## What

Three related pieces of work on the AI-provider layer: a redesigned picker shared by setup and Settings, a substantial hardening of how Meridian invokes `cursor-agent`, and a last-resort fallback so a permanently-broken agent CLI no longer costs us the summary.

## The picker

Setup and Settings now render the same component, so they cannot drift. Three recommended providers (Claude Code, Codex, Cursor) plus bring-your-own-API-key; each opens a detail view that installs the CLI, tests the connection, and sets it as default. Copilot is dropped from the chooser but stays a valid stored value, so legacy users get a switch banner rather than being stranded.

Two behavioural fixes worth calling out:

- The hook no longer bulk-tests every installed CLI on mount. That was what produced a spurious "CONNECTION FAILED" on providers the user had never configured.
- Selecting a provider **commits immediately** instead of staging a Save. This reverses an earlier staged-Save fix, so the anti-bug invariant is preserved structurally instead: `value` reads from `settings.llm_provider` on disk, and the commit only mutates state on success. The two regression tests that pinned the old shape are rewritten against the new invariants.

In-app install runs the vendor installer through the user's **login shell** (the tray is a Finder-launched `.app` with the stripped launchd PATH, which has no npm/node). Cursor sign-in uses `cursor-agent login` with the browser enabled, so the user's **subscription** is used - no API key, nothing metered.

## The Cursor hardening

`cursor-agent` is a coding agent, but Meridian only ever asks it for inference over **untrusted** text (coding-agent transcripts, screen OCR). Its defaults are wrong in both directions: too much capability, and a large irrelevant context. `src/llm/cursor_cli.rs` is now the single source of truth for invoking it.

This also closes a **real gap**: the summariser built its own argv, so it summarised untrusted transcripts with cursor-agent's default full **write + shell** tool access. It now inherits the same hardening as the provider backend.

| Lever | Effect |
|---|---|
| `--allowed-tools ""` | no tools at all; 21,040 -> 9,970 tokens |
| sandbox `HOME` | `<agent_skills>` 190 entries -> 0 |
| `--workspace <empty>` | stops Cursor injecting the user's `~/CLAUDE.md` |
| `--mode ask` | read-only, server-enforced |
| `--output-format json` | real error / usage-limit detection |
| `CURSOR_API_KEY` stripped | subscription guaranteed, never metered |

**Net: ~21,000 -> ~3,400 input tokens per call, summary quality unchanged.**

The non-obvious part of the sandbox: the four `.cursor` skill entries must be recreated **empty and read-only**, because cursor-agent self-provisions its built-in skills and plugin cache on startup and would otherwise just repopulate them. The sandbox **never touches the user's files** - it only creates entries under its own directory, and the real skill directories are simply not linked in.

Every degradation is driven by a **detected cause**, never a blind retry: unknown flag -> unhardened call, auth failure -> real HOME, unavailable model -> `auto`. A usage limit deliberately does **not** retry, because Cursor limits are account-level and a second call would burn quota to hit the same wall.

## Self-ingest fix

cursor-agent has no `--no-session-persistence`, so every call writes a chat into the store the cursor-cli source ingests from. Only the summariser was fingerprinted, so every *other* AI process routed through Cursor was ingested as developer activity and re-summarised next tick. All Meridian-issued prompts now carry a marker the ingest guard drops.

## Summariser fallback

A coding-agent transcript is still summarised by its **own** CLI - that agent holds the context and its subscription is already paid for. What changes is the outcome when that CLI is *permanently* unable to answer. Previously the row was simply left pending and dead-lettered after three drains; now it escalates once to the provider the user chose in Settings.

```
1. the session's own CLI          x2 attempts      (codex -> codex, cursor -> cursor-agent, ...)
2. rate limit?      -> STOP. back the source off, retry on a later tick
3. otherwise failed -> the global provider, ONCE
4. still nothing    -> row stays pending; dead-lettered after 3 drains
```

**Step 2 is the load-bearing one.** A `RateLimited` breaks out of the loop *before* the fallback code is reachable, so there is no path where a quota triggers a substitute - a quota refills, and is waited out. Only a `Failed` (crashed, not installed, signed out, subscription ended, unusable output) escalates, and only after every retry is spent.

Two decisions worth a reviewer's eye:

- When the global provider **is** the CLI that just failed (the normal case), `fallback::try_summarise` returns `Ok(None)` and spawns nothing. A third run of the same binary would fail identically.
- A fallback provider hitting **its own** rate limit is reported as `Failed`, not `RateLimited`. That flag drives the per-*agent-source* backoff, and the fallback is a different account - parking Codex's queue because Claude ran out of quota would punish the wrong subscription. The resolver's provider-level backoff already prevents redialling.

Fallback summaries persist as `summary_source = "fallback:<provider>"`, so a substitute's work is never mistaken for the agent's own. Nothing downstream reads that column today, so the vocabulary change is additive.

## Version pin

`cursor.com/install` is a rolling script with no version flag. Pinned to the build this was verified against, by rewriting version strings **by pattern** - a literal swap would silently no-op the day Cursor publishes a new build and hand the user "latest" again.

## Verification

- fmt, clippy `-D warnings`, **707 Rust tests**, tray check, UI build, **252 UI tests** - all green
- Live smoke tests against a real Cursor subscription throughout; token counts and the empty `<agent_skills>` block verified by decoding the actual persisted request
