### PR TITLE
ci(release): parallelise the production release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,168 +6,183 @@ name: Release
 # it (plus the updater artifacts) to the GitHub release, creates the tag +
 # CHANGELOG, and commits the version bump back to main.
 #
-# Runs on macos-26 (arm64) because the prepare step compiles the Swift
-# Foundation Models bridge — which needs the macOS 26 SDK — plus the Rust
-# daemon and the dashboard. The bridge is weak-linked, so the resulting binary
-# still launches on older macOS (Foundation Models simply reports unavailable
-# there). The x86_64 slice is cross-compiled from this same arm64 runner
-# (`rustup target add x86_64-apple-darwin` below) — Tauri's
-# `--target universal-apple-darwin` builds + lipos both archs itself, no
-# second runner needed.
+# Runs on macos-26 (arm64) because the build compiles the Swift Foundation
+# Models bridge — which needs the macOS 26 SDK — plus the Rust daemon and the
+# dashboard. The bridge is weak-linked, so the resulting binary still launches
+# on older macOS (Foundation Models simply reports unavailable there).
+#
+# PARALLEL BUILD — the two architectures are compiled CONCURRENTLY on separate
+# runners rather than sequentially inside one `tauri build --target
+# universal-apple-darwin`. They share no compiled artifacts (each target needs
+# its own rlibs), so the only thing that made them sequential was running on one
+# runner. Ported from release-staging.yml after that path proved it; see that
+# file for the full rationale and the `tauri build --no-bundle` / `tauri bundle`
+# seam that makes the split possible.
+#
+#   plan     semantic-release --dry-run decides the version (no tag, no release)
+#   build    both arches compile that version, concurrently, on two runners
+#   release  lipo → sign → bundle → notarize → package → THEN semantic-release
+#            runs as a PUBLISHER: .releaserc.json no longer carries an exec
+#            prepareCmd, because everything it did is on disk by then. The
+#            changelog + git plugins are untouched, so the version-bump commit
+#            and CHANGELOG.md still land back on main exactly as before.
+#
+# ── THE ONE THING THIS FILE DOES THAT STAGING DOES NOT ──────────────────────
+#
+# Splitting the build FORCES a pinned SHA: two runners cannot agree on a commit
+# any other way, and if they disagreed the two halves of the universal binary
+# would silently differ. But this workflow previously checked out the TIP of
+# main on purpose, because @semantic-release/git pushes the version-bump commit
+# back — and that push is rejected ("fetch first") if the run is anchored to a
+# commit that is no longer the tip. Staging never hit this: its config has no
+# git plugin, so nothing is pushed and pinning is free.
+#
+# The old comment's real guarantee was not "always check out the tip" — it was
+# "a burst of merges ends with the release == main, and NO failed runs; later
+# runs find nothing to release and no-op cleanly." That guarantee is preserved
+# here by DEFERRING rather than failing: before publishing, the release job
+# compares origin/main against the SHA it built. If main advanced, it exits 0
+# without publishing and lets the newer run — which the concurrency group has
+# already queued — release the newer tip.
+#
+# Deferring is safe precisely because "main moved" always means someone else
+# pushed, and that push always has its own queued run, so a deferral can never
+# drop a release. Failing instead would have converted the burst case from green
+# no-ops into red X's, which is the property the original comment protected.
 
 on:
   push:
     branches: [main]
   workflow_dispatch: {}   # manual re-trigger (e.g. after fixing a secret) without a dummy commit
 
+# Least privilege by default: `plan` only reads history and `build` only
+# compiles, so write is granted per-job to the two that tag, publish and push
+# the version-bump commit.
 permissions:
-  contents: write       # tags, release, the version-bump commit
-  issues: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  SQLX_OFFLINE: "true"
+  # The tray pulls screenpipe-screen/-a11y from the PRIVATE Meridiona/
+  # screenpipe-fork (a git dep). Force cargo to fetch via the git CLI so it
+  # honors the credential the "Authenticate ... screenpipe-fork" step installs
+  # — libgit2 would not pick up the url.insteadOf rewrite.
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+
 jobs:
-  release:
-    runs-on: macos-26
+  # ── Stage 1: decide the version, once, for everybody ────────────────────────
+  #
+  # The version has to exist BEFORE any compiling starts, because set-version.sh
+  # bakes it into Cargo.toml (→ the daemon binary) and tauri.conf.json (→ the
+  # value tauri-plugin-updater compares against latest.json). Both build jobs and
+  # the release job must agree on one value.
+  plan:
+    name: Plan (version + SHA)
+    runs-on: ubuntu-latest
     outputs:
-      released: ${{ steps.release.outputs.released }}
-      version: ${{ steps.release.outputs.version }}
-      tag: ${{ steps.release.outputs.tag }}
-    env:
-      SQLX_OFFLINE: "true"
-      # The tray pulls screenpipe-screen/-a11y from the PRIVATE Meridiona/
-      # screenpipe-fork (a git dep). Force cargo to fetch via the git CLI so it
-      # honors the credential the "Authenticate ... screenpipe-fork" step installs
-      # — libgit2 would not pick up the url.insteadOf rewrite.
-      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-      # Baked into the release binary at compile time (consumed by option_env! in
-      # src/intelligence/oauth/jira.rs). Atlassian Cloud's 3LO token endpoint
-      # requires a confidential client_secret even for desktop apps, so the shipped
-      # binary must carry one — but it never lives in source. Set the
-      # JIRA_OAUTH_CLIENT_SECRET repo secret; rotate it together with the value in
-      # the Atlassian developer console.
-      MERIDIAN_JIRA_OAUTH_CLIENT_SECRET: ${{ secrets.JIRA_OAUTH_CLIENT_SECRET }}
-      # Baked into the release binary at compile time (consumed by option_env! in
-      # meridian-oauth/src/github.rs). PUBLIC client id for the GitHub OAuth device
-      # flow — device flow has no client secret, so this value isn't sensitive, but
-      # it's stored as the GH_OAUTH_CLIENT_ID repo secret (masked in logs; can't be
-      # named GITHUB_*, which GitHub reserves). The OAuth App must have "Enable
-      # Device Flow" checked.
-      MERIDIAN_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
-      # Baked into the release binary at compile time (consumed by option_env! in
-      # tray/src-tauri/src/analytics.rs). PostHog Cloud project API key — a
-      # PUBLIC write-only capture token (no account/read access), safe to embed
-      # in a shipped client. Set the POSTHOG_API_KEY repo secret; absent →
-      # analytics compiles in disabled (see analytics::posthog_api_key).
-      MERIDIAN_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
-      # Baked into the release binary at compile time (consumed by option_env! in
-      # tray/src-tauri/src/commands/account.rs's DEFAULT_CLERK_PUBLISHABLE_KEY).
-      # Clerk PRODUCTION instance's publishable key (meridiona.com) — a public
-      # identifier, safe to embed in a shipped client. Every packaged install
-      # (this channel and staging alike) uses production Clerk; only a source
-      # checkout (`cargo run`/`tauri dev`) uses the dev instance, via the repo
-      # root .env's CLERK_PUBLISHABLE_KEY — see account.rs's module doc. Set the
-      # CLERK_PUBLISHABLE_KEY_PROD repo secret; absent → sign-in unavailable in
-      # this build (lib.rs skips registering the Clerk plugin with no key).
-      MERIDIAN_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_PROD }}
-      # Minisign key for the DMG auto-updater: `tauri build` (createUpdaterArtifacts)
-      # signs Meridian.app.tar.gz with these so the installed app can verify the
-      # update against the pubkey baked in tauri.conf.json. The build FAILS LOUDLY
-      # if these are unset (better than silently shipping a release that breaks
-      # auto-update) — set both repo secrets before this lands on main:
-      #   gh secret set TAURI_SIGNING_PRIVATE_KEY < ~/.tauri/meridian-updater.key
-      #   gh secret set TAURI_SIGNING_PRIVATE_KEY_PASSWORD
-      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-      # ── Apple Developer ID signing + notarization (Meridiona LLP, AQTYN9PZ83) ──
-      # Consumed by `tauri build` (via tray/package.json's build script) to sign
-      # the .app/DMG and submit them to Apple's notary service. The cert itself is
-      # imported into a temp keychain by the "Import Developer ID certificate"
-      # step below; these are the identifiers Tauri reads.
-      #
-      # Absent → the bundle is ad-hoc signed, which ships TWO regressions:
-      #   • Gatekeeper's "unidentified developer" scare on first launch, and
-      #   • a fresh cdhash every build, so macOS sees each update as a brand-new
-      #     app and silently drops the user's Screen Recording / Accessibility
-      #     grants (the "Permissions not granted after update" bug).
-      # verify-release-bundle.sh now FAILS the release in that state rather than
-      # publishing it.
-      #
-      # APPLE_API_KEY is the 10-char Key ID and APPLE_API_ISSUER the issuer UUID
-      # (both from App Store Connect → Integrations → Team Keys). The private .p8
-      # is passed by PATH, not content — see APPLE_API_KEY_PATH in that step.
-      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-      APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-      # Tauri's DMG bundler skips the AppleScript step that sets the Finder
-      # window background/icon layout whenever `CI` is set (every GitHub
-      # Actions job sets `CI=true`), assuming CI runners can't drive Finder —
-      # https://github.com/tauri-apps/tauri/issues/1731. GitHub-hosted macOS
-      # runners DO have a full desktop session, so force the decoration step
-      # to run; without this the DMG ships the drag-to-Applications
-      # background.png as an inert file with no .DS_Store, so Finder never
-      # displays it.
-      TAURI_BUNDLER_DMG_IGNORE_CI: "true"
+      sha: ${{ steps.resolve.outputs.sha }}
+      version: ${{ steps.version.outputs.version }}
+      release_due: ${{ steps.version.outputs.release_due }}
     steps:
       - uses: actions/checkout@v4
         with:
-          # Release the current tip of the default branch, NOT the commit that
-          # triggered this run. With the concurrency group serialising runs
-          # (cancel-in-progress: false), a burst of merges otherwise has each
-          # run pinned to its own (stale) trigger SHA: the older run releases a
-          # stale snapshot and its `git push HEAD:main` is rejected once a newer
-          # commit lands ("fetch first"). Checking out the tip means the first
-          # queued run releases everything on main and later runs find nothing
-          # new to release (clean no-op) — no failures, the release always == main.
+          # The tip of the default branch, NOT the triggering commit: with runs
+          # serialised (cancel-in-progress: false) a burst of merges would
+          # otherwise have each run plan a stale snapshot. The first queued run
+          # plans everything on main; later runs find nothing new.
           ref: ${{ github.event.repository.default_branch }}
-          fetch-depth: 0          # full history — semantic-release needs commits
-          fetch-tags: true        # explicitly fetch tags so the v0.0.0 baseline is seen
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - id: resolve
+        # Pinned here and used by every downstream job, so the two arch binaries
+        # and the bundle are guaranteed to be the same commit.
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - run: npm ci --no-audit --no-fund
+
+      - name: Compute the next version
+        id: version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+        # `--dry-run` runs analysis only: no tag, no release, no CHANGELOG, no
+        # version-bump commit. Most pushes to main release nothing, and then the
+        # downstream jobs skip rather than burn a 30-minute build.
+        run: |
+          set -o pipefail
+          npx semantic-release --dry-run 2>&1 | tee sr.log || true
+          version="$(grep -oE 'The next release version is [0-9][^ ]*' sr.log | tail -1 | awk '{print $NF}')"
+          if [ -z "${version}" ]; then
+            echo "release_due=false" >> "$GITHUB_OUTPUT"
+            echo "→ nothing to release; downstream jobs will skip"
+          else
+            echo "release_due=true"        >> "$GITHUB_OUTPUT"
+            echo "version=${version}"      >> "$GITHUB_OUTPUT"
+            echo "→ next version: ${version}"
+          fi
+
+  # ── Stage 2: the point of the exercise — both arches at once ────────────────
+  build:
+    name: Build ${{ matrix.target }}
+    needs: plan
+    if: needs.plan.outputs.release_due == 'true'
+    runs-on: macos-26
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [aarch64-apple-darwin, x86_64-apple-darwin]
+    env:
+      # EVERY value below is baked into the binary at COMPILE time, so each build
+      # job needs the full set — a missing one produces no error, just a shipped
+      # app with (say) sign-in quietly unavailable. See the long per-secret notes
+      # in release-staging.yml for what each one does; they are the same secrets.
+      MERIDIAN_JIRA_OAUTH_CLIENT_SECRET: ${{ secrets.JIRA_OAUTH_CLIENT_SECRET }}
+      MERIDIAN_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
+      MERIDIAN_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+      MERIDIAN_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_PROD }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.plan.outputs.sha }}
           persist-credentials: false
 
       - name: Install Rust 1.93.1
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.93.1"
-          targets: "aarch64-apple-darwin,x86_64-apple-darwin"
-      - uses: Swatinem/rust-cache@v2
+          targets: ${{ matrix.target }}
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          # Node 24 satisfies semantic-release v25 (engines: ^22.14 || >=24.10).
+          # REQUIRED: every leg of a matrix shares one github.job, so without it
+          # both arches compute the same key and clobber each other on save.
+          key: ${{ matrix.target }}
+          # Save on main only — this is the branch that cuts releases, and a
+          # cache nothing writes is a permanent miss rather than a saving.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - uses: actions/setup-node@v4
+        with:
           node-version: "24"
-          # Cache ~/.npm for the root npm ci plus the ui/ and tray/ npm ci inside prepareCmd.
           cache: "npm"
           cache-dependency-path: |
-            package-lock.json
             ui/package-lock.json
             tray/package-lock.json
 
-      - name: Cache Next.js build
-        uses: actions/cache@v4
-        with:
-          path: ui/.next/cache
-          # Key on UI source + lockfile; incremental recompile when only
-          # non-page files change; full rebuild only when lockfile changes.
-          key: nextjs-${{ hashFiles('ui/package-lock.json') }}-${{ hashFiles('ui/**/*.ts', 'ui/**/*.tsx') }}
-          restore-keys: |
-            nextjs-${{ hashFiles('ui/package-lock.json') }}-
-            nextjs-
-
-      - name: Install release tooling
-        run: npm ci --no-audit --no-fund
-
       - name: Authenticate git for the private screenpipe-fork dependency
-        # The tray's capture stack (screenpipe-screen/-a11y) is a git dep on the
-        # PRIVATE Meridiona/screenpipe-fork. checkout uses persist-credentials:
-        # false and the default GITHUB_TOKEN is scoped to this repo only, so
-        # cargo's `git fetch` of the fork 403s. Rewrite just that URL to embed a
-        # PAT with read access. REQUIRES the GH_TOKEN secret to be able to read
-        # Meridiona/screenpipe-fork (org-member classic PAT with `repo`, or a
-        # fine-grained PAT granting both meridian AND screenpipe-fork).
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
@@ -175,40 +190,280 @@ jobs:
             url."https://x-access-token:${GH_TOKEN}@github.com/Meridiona/screenpipe-fork".insteadOf \
             "https://github.com/Meridiona/screenpipe-fork"
 
+      - name: Stamp the version
+        # Bound through `env` rather than interpolated into the shell: the value
+        # traces back to commit messages via semantic-release's output.
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: bash scripts/set-version.sh "$VERSION"
+
+      - name: Install UI + tray deps
+        # The UI must build before the tray compiles: frontendDist (ui/out) is
+        # EMBEDDED into the binary by generate_context! at compile time, so it is
+        # a build input here, not a packaging step.
+        run: |
+          (cd ui && npm ci --no-audit --no-fund)
+          (cd tray && npm ci --no-audit --no-fund)
+
+      - name: Regenerate the icons
+        # Also a compile-time input via generate_context!. Kept from the previous
+        # sequential prepareCmd so the shipped icon set is byte-for-byte what
+        # production has always produced.
+        working-directory: tray
+        run: bash create-icons.sh
+
+      - name: Build daemon (${{ matrix.target }})
+        run: cargo build --locked --release --bin meridian --target ${{ matrix.target }}
+
+      - name: Place the daemon where tauri-build expects it
+        # tauri-build only STATS bundle.resources during compilation (it reads the
+        # contents at bundle time), but the path must exist or the build script
+        # fails. This job's own arch slice satisfies that; the real universal
+        # daemon is lipo'd in the release job.
+        run: |
+          mkdir -p target/release
+          cp "target/${{ matrix.target }}/release/meridian" target/release/meridian
+
+      - name: Evict the stale tauri-plugin-notifications fingerprint
+        # rust-cache restores target/ (so the fingerprint says "fresh") but NOT
+        # registry/src, where the pinned 0.4.6 fork's build.rs writes the Swift
+        # static lib. The build script is skipped while the .a it produces is
+        # gone, and linking fails. `--release` is load-bearing: without it the
+        # clean targets the debug profile and reports "Removed 0 files".
+        working-directory: tray/src-tauri
+        run: cargo clean -p tauri-plugin-notifications --release
+
+      - name: Compile the tray (${{ matrix.target }}, no bundling)
+        working-directory: tray
+        run: npx tauri build --no-bundle --target ${{ matrix.target }}
+
+      - name: Upload the two binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: slice-${{ matrix.target }}
+          path: |
+            target/${{ matrix.target }}/release/meridian
+            target/${{ matrix.target }}/release/meridian-tray
+          retention-days: 1
+          # Mach-O binaries barely compress; level 0 trades a bigger upload for a
+          # much faster one, and this transfer sits on the critical path.
+          compression-level: 0
+
+  # ── Stage 3: join — lipo, sign, bundle, notarize, publish ───────────────────
+  release:
+    name: Bundle universal + publish
+    needs: [plan, build]
+    if: needs.plan.outputs.release_due == 'true'
+    runs-on: macos-26
+    permissions:
+      contents: write            # the tag, the release, the version-bump commit
+      # @semantic-release/github comments on the issues/PRs a release closes.
+      # Staging turns that off (successComment: false); production does not, so
+      # it needs both scopes or the publish step 403s at the very last moment.
+      issues: write
+      pull-requests: write
+    outputs:
+      released: ${{ steps.publish.outputs.released }}
+      version: ${{ steps.publish.outputs.version }}
+      tag: ${{ steps.publish.outputs.tag }}
+    env:
+      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+      APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+      # Tauri's DMG bundler skips the Finder decoration step whenever `CI` is
+      # set, assuming CI runners cannot drive Finder. GitHub-hosted macOS runners
+      # DO have a desktop session, so force it; without this the DMG ships the
+      # drag-to-Applications background as an inert file with no .DS_Store.
+      TAURI_BUNDLER_DMG_IGNORE_CI: "true"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The pinned SHA, not `main` by name: this job tags and publishes, and
+          # tagging the exact commit the binaries were built from is the point.
+          ref: ${{ needs.plan.outputs.sha }}
+          fetch-depth: 0      # full history — semantic-release needs the commits
+          fetch-tags: true    # and the v* tags, for the version baseline
+          persist-credentials: false
+
+      - name: Defer if main advanced during the build
+        id: freshness
+        env:
+          PLANNED_SHA: ${{ needs.plan.outputs.sha }}
+        # See the header. A merge that landed while the ~30-minute build ran has
+        # its own run queued behind this one, so the newer tip WILL be released;
+        # publishing this older snapshot would tag a stale tree, and
+        # @semantic-release/git's push of the version bump would be rejected
+        # ("fetch first") AFTER the GitHub release already exists — a tagged,
+        # published release with no bump commit. Deferring exits 0 instead:
+        # green, nothing published, the queued run takes over.
+        run: |
+          git fetch origin main --quiet
+          tip="$(git rev-parse origin/main)"
+          if [ "${tip}" != "${PLANNED_SHA}" ]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::main advanced ${PLANNED_SHA} → ${tip} during the build; deferring to the queued run for the newer tip. Nothing published."
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+            echo "✓ main is still ${PLANNED_SHA}"
+          fi
+
+      - uses: actions/setup-node@v4
+        if: steps.freshness.outputs.stale != 'true'
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: |
+            package-lock.json
+            ui/package-lock.json
+            tray/package-lock.json
+
+      - name: Stamp the version
+        # The same value the binaries were built with. tauri.conf.json's version
+        # is read at BUNDLE time and becomes what the updater compares against,
+        # and this stamped tree is what @semantic-release/git commits back.
+        if: steps.freshness.outputs.stale != 'true'
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: bash scripts/set-version.sh "$VERSION"
+
+      - name: Install UI + tray deps, and materialise ui/out
+        # `tauri bundle` runs beforeBundleCommand, NOT beforeBuildCommand, so
+        # nothing here recreates ui/out on its own. The assets are already
+        # embedded in the binaries, but frontendDist still points at ui/out and
+        # the bundler resolves that path, so it has to exist.
+        if: steps.freshness.outputs.stale != 'true'
+        run: |
+          (cd ui && npm ci --no-audit --no-fund && npm run build)
+          (cd tray && npm ci --no-audit --no-fund)
+
+      - uses: actions/download-artifact@v4
+        if: steps.freshness.outputs.stale != 'true'
+        with:
+          path: slices
+
+      - name: Assemble the universal binaries
+        # upload-artifact does NOT preserve the executable bit, so chmod first or
+        # lipo and codesign fail in confusing ways.
+        if: steps.freshness.outputs.stale != 'true'
+        run: |
+          set -euo pipefail
+          chmod +x slices/slice-*/meridian slices/slice-*/meridian-tray
+          mkdir -p target/release target/universal-apple-darwin/release
+          lipo -create \
+            slices/slice-aarch64-apple-darwin/meridian \
+            slices/slice-x86_64-apple-darwin/meridian \
+            -output target/release/meridian
+          lipo -create \
+            slices/slice-aarch64-apple-darwin/meridian-tray \
+            slices/slice-x86_64-apple-darwin/meridian-tray \
+            -output target/universal-apple-darwin/release/meridian-tray
+          echo "daemon: $(lipo -archs target/release/meridian)"
+          echo "tray:   $(lipo -archs target/universal-apple-darwin/release/meridian-tray)"
+
       - name: Import Developer ID certificate + notarization key
-        # Shared composite action (deduped from release-staging.yml). It also
-        # no-ops gracefully when APPLE_CERTIFICATE is unset instead of crashing
-        # `security import`. Requires the repo to be checked out first (above).
+        if: steps.freshness.outputs.stale != 'true'
         uses: ./.github/actions/import-apple-cert
         with:
           apple-certificate: ${{ secrets.APPLE_CERTIFICATE }}
           apple-certificate-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           apple-api-key-content: ${{ secrets.APPLE_API_KEY_CONTENT }}
 
-      - name: semantic-release
-        id: release
+      - name: Sign the daemon
+        # Must precede bundling: the daemon is copied into the .app as a resource,
+        # and re-signing the enclosing bundle does not sign nested Mach-Os.
+        if: steps.freshness.outputs.stale != 'true'
+        run: bash scripts/sign-daemon.sh
+
+      - name: Bundle, sign and notarize the app
+        if: steps.freshness.outputs.stale != 'true'
+        working-directory: tray
+        run: npx tauri bundle --target universal-apple-darwin --bundles app,dmg
+
+      - name: Notarize and staple the DMG
+        # `tauri bundle` notarizes and staples the .app but only SIGNS the disk
+        # image — a notarization ticket is keyed to the cdhash of what was
+        # submitted, so the stapled app inside does not cover its container.
+        # Must precede package-updater.sh: stapling rewrites the file, so the
+        # stable-named copy has to be taken afterwards to inherit the ticket.
+        if: steps.freshness.outputs.stale != 'true'
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: bash scripts/notarize-dmg.sh "$VERSION"
+
+      - name: Package the updater artifacts
+        # Writes latest.json from the real minisign signature and makes the
+        # stable-named Meridian.dmg copy. ALSO the only thing that reads
+        # tray/minimum-version and stamps `Minimum-Version:` into the manifest
+        # notes — skip it and the forced-update floor stops shipping.
+        if: steps.freshness.outputs.stale != 'true'
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: bash scripts/package-updater.sh "$VERSION"
+
+      - name: Verify the release bundle
+        # Independently re-checks signing, notarization, stapling and the updater
+        # artifacts. A non-zero exit aborts before the tag exists.
+        if: steps.freshness.outputs.stale != 'true'
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: bash scripts/verify-release-bundle.sh "$VERSION"
+
+      - name: Install release tooling
+        if: steps.freshness.outputs.stale != 'true'
+        run: npm ci --no-audit --no-fund
+
+      - name: Assert the version has not moved
+        if: steps.freshness.outputs.stale != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          PLANNED: ${{ needs.plan.outputs.version }}
+        # Secondary tripwire behind the freshness check above: that one catches
+        # main moving, this one catches a TAG appearing from elsewhere (the
+        # staging workflow sits in a different concurrency group and cuts v*
+        # tags). Publishing then would stamp artifacts with a version the tag
+        # does not match — a silently broken update.
+        run: |
+          set -o pipefail
+          npx semantic-release --dry-run 2>&1 | tee sr-verify.log || true
+          actual="$(grep -oE 'The next release version is [0-9][^ ]*' sr-verify.log | tail -1 | awk '{print $NF}')"
+          if [ "${actual}" != "${PLANNED}" ]; then
+            echo "::error::version moved between plan and publish - built ${PLANNED}, semantic-release now wants ${actual:-<none>}. Re-run the workflow."
+            exit 1
+          fi
+          echo "✓ version still ${PLANNED}"
+
+      - name: semantic-release (publish)
+        id: publish
+        if: steps.freshness.outputs.stale != 'true'
         env:
           # GitHub PAT (repo scope) to push the version commit to main past
-          # branch protection; falls back to GITHUB_TOKEN. The release publishes
-          # only to the GitHub release (the DMG + updater artifacts) — no npm.
+          # branch protection; falls back to GITHUB_TOKEN.
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-        # Whether a release actually happened is derived from the newest v* tag
-        # moving, rather than from parsing semantic-release's output: most runs
-        # legitimately release nothing, and the Windows job below must not try
-        # to attach artifacts to a release that was never cut.
+        # Whether a release happened is derived from the newest v* tag moving
+        # rather than from parsing output: the Windows job below must not try to
+        # attach artifacts to a release that was never cut.
         run: |
           before="$(git tag --list 'v*' --sort=-v:refname | head -1)"
           npx semantic-release
           after="$(git tag --list 'v*' --sort=-v:refname | head -1)"
           if [ -n "${after}" ] && [ "${before}" != "${after}" ]; then
-            echo "released=true"            >> "$GITHUB_OUTPUT"
-            echo "version=${after#v}"       >> "$GITHUB_OUTPUT"
-            echo "tag=${after}"             >> "$GITHUB_OUTPUT"
+            echo "released=true"      >> "$GITHUB_OUTPUT"
+            echo "version=${after#v}" >> "$GITHUB_OUTPUT"
+            echo "tag=${after}"       >> "$GITHUB_OUTPUT"
             echo "→ released ${after}"
           else
             echo "released=false" >> "$GITHUB_OUTPUT"
             echo "→ no release this run (newest tag still ${before:-none})"
           fi
+
+      - name: Report what was produced
+        if: always()
+        run: |
+          out=target/universal-apple-darwin/release/bundle
+          echo "app:  $(lipo -archs "$out/macos/Meridian.app/Contents/MacOS/meridian-tray" 2>/dev/null || echo '<absent>')"
+          ls -la "$out/dmg/" "$out/macos/" || true
 
       - name: Clean up signing material
         # Runs even on failure — never leave the cert/key on a runner.
@@ -217,20 +472,12 @@ jobs:
           security delete-keychain "${RUNNER_TEMP}/meridian-signing.keychain-db" 2>/dev/null || true
           rm -f "${RUNNER_TEMP}/apple-api-key.p8" "${RUNNER_TEMP}/certificate.p12"
 
-  # ── Windows: build + attach to the release the macOS job just cut ──────────
-  #
-  # A separate job because Windows artifacts cannot be produced on the macOS
-  # runner, and deliberately NOT folded into semantic-release's asset list:
-  # that list and its prepareCmd are what publish the macOS DMG, and a Windows
-  # change reaching into them is the one way this work could regress the
-  # shipping macOS release path.
-  #
-  # Runs only when the macOS job actually cut a release — most pushes to main
-  # release nothing, and there would be no tag to attach to.
   windows-release:
     needs: release
     if: needs.release.outputs.released == 'true'
     runs-on: windows-latest
+    permissions:
+      contents: write     # uploads the installer + merged manifest to the release
     env:
       SQLX_OFFLINE: "true"
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -30,9 +30,6 @@
         { "path": "target/universal-apple-darwin/release/bundle/macos/latest.json", "label": "latest.json (updater manifest)" }
       ]
     }],
-    ["@semantic-release/exec", {
-      "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version} && (cd ui && npm ci --no-audit --no-fund && npm run build) && (cd tray/src-tauri && cargo clean -p tauri-plugin-notifications --release) && (cd tray && bash create-icons.sh && npm ci --no-audit --no-fund && npm run build) && bash scripts/notarize-dmg.sh ${nextRelease.version} && bash scripts/package-updater.sh ${nextRelease.version} && bash scripts/verify-release-bundle.sh ${nextRelease.version}"
-    }],
     ["@semantic-release/git", {
       "assets": [
         "CHANGELOG.md",


### PR DESCRIPTION
> [!WARNING]
> **Do not merge yet.** Gated on two things, both listed under "Before this merges" below. Opened now so the design can be reviewed while staging finishes proving itself.

## What

Ports the restructure `release-staging.yml` proved to production: the two macOS arches compile **concurrently on separate runners** instead of sequentially inside one `tauri build --target universal-apple-darwin`. semantic-release stops compiling and becomes a publisher - `.releaserc.json` loses its exec `prepareCmd`, and everything it did becomes explicit workflow steps.

The **changelog and git plugins are untouched**, so `CHANGELOG.md` and the version-bump commit still land back on `main` exactly as before.

## The part that is not a copy of staging

Splitting the build **forces a pinned SHA** - two runners cannot agree on a commit any other way, and if they disagreed the two halves of the universal binary would silently differ.

But this workflow deliberately checked out the **tip of main**, and said so:

> a burst of merges otherwise has each run pinned to its own (stale) trigger SHA: the older run releases a stale snapshot and its `git push HEAD:main` is rejected once a newer commit lands ("fetch first")

That is `@semantic-release/git` pushing the version bump. Staging never hit it - no git plugin, nothing pushed, so pinning was free. Here, pinning is load-bearing for the build and disqualifying for the publish.

**Resolved by deferring, not failing.** Read what that comment actually guarantees: a burst of merges ends with the release == main **and no failed runs** - later runs "find nothing new to release (clean no-op)". A hard failure on "main moved" would have thrown that away, converting green no-ops into red X's. So instead:

```
plan     pins SHA1 (tip at plan time)
build    ~30 min. Meanwhile SHA2 lands -> its own run queues behind this one
release  before publishing: if origin/main != SHA1, log and exit 0.
         Nothing published, no failure. The SHA2 run releases the newer tip.
```

Deferring is safe **precisely because** "main moved" always means someone else pushed, and that push always has its own queued run - so a deferral can never drop a release. It cannot livelock either: `main` only takes infrequent release-PR merges plus `[skip ci]` version bumps.

The version assertion from staging is kept as a **secondary** tripwire - the SHA check catches `main` moving, the version check catches a `v*` tag appearing from elsewhere (the staging workflow is in a different concurrency group and cuts tags).

## Production-only details staging did not need

- **`issues: write` + `pull-requests: write`** on the release job. Prod's `@semantic-release/github` comments on what a release closes; staging sets `successComment: false`. Without these the publish step 403s at the very last moment.
- **`create-icons.sh` kept in the build jobs.** The icons are a compile-time input via `generate_context!`, so this preserves byte-for-byte what production has always shipped. (Staging's build omits it and relies on the committed icons.)
- **`save-if` scoped to `refs/heads/main`**, matching #497's reasoning for staging.

## Before this merges

- [ ] **Staging's `windows-release` job goes green**, and `windows-x86_64` lands in the staging `latest.json`. 1.73.0 broke on the Windows job *specifically* - porting a path whose Windows arm has not been watched succeed would be repeating that mistake.
- [ ] **#495 merges first.** It unsticks actual stranded Windows customers and is the more urgent change.

## The risk I cannot test

**`@semantic-release/git`'s push-back has no dry-run.** The first real merge of this PR *is* its test, on the branch that ships to customers. Everything else here was exercised on staging; this one thing structurally cannot be.

Mitigations worth considering before merging: rehearse via `workflow_dispatch`, or treat the first release after this as **supervised** rather than fire-and-forget. If the push is rejected, the failure mode is a tagged, published release with no version-bump commit - recoverable by hand, but it should be caught in minutes, not on the next release.

## Measured on staging (run 29734394528)

| | aarch64 | x86_64 |
|---|---|---|
| Build daemon | 7.8m | 4.8m |
| Compile tray | 19.3m | 13.7m |

Wall clock is the slower arch, so this is bounded by aarch64, not the sum. With #497's cache fix landing separately, both numbers should drop substantially on warm runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)