### PR TITLE
fix(ci): unbreak the staging Windows installer and updater manifest

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -535,6 +535,26 @@ jobs:
             nextjs-win-${{ hashFiles('ui/package-lock.json') }}-
             nextjs-win-
 
+      - name: Stamp the version
+        shell: bash
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+        # REQUIRED on staging, unlike production. This job checks out the release
+        # TAG, and on the staging channel that tag points at a tree where the
+        # version was never committed: .releaserc.staging.json has no
+        # @semantic-release/git plugin, so the stamped manifests exist only in
+        # the macOS runner's working tree and die with it.
+        #
+        # Without this the installer was built at whatever Cargo.toml/
+        # tauri.conf.json last held on pre-main — v1.72.0-staging.5 produced
+        # `Meridian_1.71.0_x64-setup.exe` — while the manifest advertised the
+        # real version. A Windows app would update, report the old version, see
+        # the same update again, and loop.
+        #
+        # Production does not need this: its config DOES carry the git plugin,
+        # so the tag points at the version-bump commit and the tree is stamped.
+        run: bash scripts/set-version.sh "$VERSION"
+
       - name: Install JS dependencies
         shell: bash
         run: |
@@ -554,6 +574,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.release.outputs.version }}
           TAG: ${{ needs.release.outputs.tag }}
+          # Windows Python defaults stdout to the cp1252 console codepage, which
+          # cannot encode the `✓` merge-windows-updater.py prints on success.
+          # It died on that print AFTER writing the merged manifest, so the
+          # `gh release upload` below never ran and latest.json never gained its
+          # windows-x86_64 key. Forcing UTF-8 fixes the whole class, not just
+          # this one character.
+          PYTHONIOENCODING: "utf-8"
         run: |
           set -euo pipefail
           NSIS_DIR="target/release/bundle/nsis"

--- a/scripts/merge-windows-updater.py
+++ b/scripts/merge-windows-updater.py
@@ -33,7 +33,11 @@ REQUIRED_DARWIN = ("darwin-aarch64", "darwin-x86_64")
 
 
 def die(msg: str) -> "None":
-    sys.exit(f"✗ merge-windows-updater: {msg}")
+    # ASCII only - see the note by the success print. On windows-latest a
+    # non-ASCII character here would raise UnicodeEncodeError INSTEAD of the
+    # message, turning every one of this script's safety checks into a
+    # confusing traceback at the exact moment it is trying to explain itself.
+    sys.exit(f"FAIL merge-windows-updater: {msg}")
 
 
 def main() -> None:
@@ -52,7 +56,7 @@ def main() -> None:
 
     platforms = manifest.get("platforms")
     if not isinstance(platforms, dict):
-        die("manifest has no 'platforms' object — refusing to write")
+        die("manifest has no 'platforms' object - refusing to write")
 
     # Capture the incoming darwin entries so the post-write check can prove
     # they survived untouched rather than merely being present.
@@ -70,7 +74,7 @@ def main() -> None:
     if manifest.get("version") != version:
         die(
             f"manifest version {manifest.get('version')!r} != release version "
-            f"{version!r} — this is a manifest from a DIFFERENT release. "
+            f"{version!r} - this is a manifest from a DIFFERENT release. "
             f"Writing would point macOS users at the wrong build."
         )
 
@@ -86,11 +90,17 @@ def main() -> None:
     # Prove the darwin entries are exactly as they arrived.
     for key, original in before.items():
         if platforms.get(key) != original:
-            die(f"'{key}' changed during merge — refusing to write")
+            die(f"'{key}' changed during merge - refusing to write")
 
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
     covered = ", ".join(sorted(platforms))
-    print(f"✓ merge-windows-updater: {manifest_path} now covers {covered}")
+    # ASCII only, deliberately. This runs on windows-latest, where Python
+    # defaults stdout to the cp1252 console codepage; a `✓` here raised
+    # UnicodeEncodeError AFTER the manifest was written but BEFORE the caller
+    # could upload it, so the merge silently accomplished nothing and the
+    # release shipped a manifest with no windows-x86_64 key. A success message
+    # must never be able to fail the step it is reporting success from.
+    print(f"OK merge-windows-updater: {manifest_path} now covers {covered}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The context

Staging's `windows-release` job has **never succeeded** - three failures, zero passes:

```
29734394528  failure
29727265408  failure
29698684026  failure
```

#490 fixed the tray *build*, which let run `29734394528` reach a second, older bug for the first time. This is not a regression from the parallel-build restructure (#494); that work only made the failure reachable.

## Fault 1 - the script died on its own success message

`merge-windows-updater.py` prints a `✓`, and Python on `windows-latest` defaults stdout to the **cp1252** console codepage, which cannot encode it:

```
UnicodeEncodeError: 'charmap' codec can't encode character '✓' in position 0
```

The timing is what made it costly. The exception landed **after** the merged manifest was written but **before** the caller could `gh release upload` it - so the merge accomplished nothing, `latest.json` shipped with no `windows-x86_64` key, and Windows could not auto-update. A success message failed the step it was reporting success from.

**The error paths were worse.** `✗` in `die()` plus em-dashes in three of its messages meant any of this script's safety checks - the ones guarding against a Windows-side bug corrupting *macOS* auto-update - would surface as a traceback instead of the explanation it was trying to give, at exactly the moment someone needed to read it.

All output is ASCII now. The workflow also sets `PYTHONIOENCODING: "utf-8"` so the class cannot return via some future character.

**Fixed in the script, not just the caller:** production's `windows-release` runs this same script and would have hit the identical failure the moment its own build started passing. That is now pre-empted rather than waiting to be discovered on the customer branch.

## Fault 2 - the installer carried the wrong version

`v1.72.0-staging.5` produced **`Meridian_1.71.0_x64-setup.exe`**.

The job checks out the release **tag**, and on staging that tag points at a tree where the version was never committed: `.releaserc.staging.json` has no `@semantic-release/git` plugin, so the stamped manifests exist only in the macOS runner's working tree and die with it.

The consequence is a loop, not just a cosmetic mismatch: the manifest advertises `1.72.0-staging.5`, a Windows app updates, the installed app reports `1.71.0`, the updater sees the same update still pending, and it goes round again.

The job now runs `set-version.sh` before building. **Production is unaffected** - its config *does* carry the git plugin, so its tag points at the version-bump commit and the tree is already stamped. Verified:

```
v1.72.0-staging.5 -> tauri.conf.json says 1.71.0   (unstamped)
v1.73.0           -> tauri.conf.json says 1.73.0   (stamped)
```

## Verified

- [x] Merge script happy path: writes `windows-x86_64`, darwin entries byte-identical afterwards
- [x] Error path prints its real message and exits 1, no traceback
- [x] Workflow YAML parses; `Stamp the version` is ordered before the build

## Why this matters beyond staging

This is the third distinct Windows fault found in one day (the cfg-gating in #490, then these two). Every one was invisible until the fault ahead of it was cleared. Worth treating the next green Windows run as the first real signal, not a formality - and it is the gate on #499, the production port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)