### PR TITLE
ci: stop storing every Rust cache twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,33 @@ jobs:
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
         with:
-          # Restore everywhere, save only on the two integration branches.
-          # GitHub scopes caches by REF, so a branch that is both pushed and
-          # has an open PR stored two near-identical copies of every target/
-          # cache (observed: 2582MB vs 2527MB for macos-universal alone).
-          # Six Rust caches totalled 9.6GB against the 10GB repo quota, which
-          # evicted the release job's cache within ~3h of it being written and
-          # forced every release to compile cold. PR runs still RESTORE from
-          # the base branch; they just stop writing a duplicate.
-          save-if: ${{ github.ref == 'refs/heads/pre-main' || github.ref == 'refs/heads/main' }}
+          # Restore everywhere, save ONLY on main - the default branch.
+          #
+          # GitHub scopes caches by REF, so saving on both integration branches
+          # stored the same cache twice. Not near-identical: byte-identical
+          # KEYS, e.g. both main and pre-main held
+          # `v0-rust-macos-universal-Darwin-arm64-201b0125-da9962c3`. Across the
+          # three Rust jobs that was ~4.46GB of a 10GB quota spent on a second
+          # copy of something already present.
+          #
+          # A run restores from its own branch OR the default branch, so pre-main
+          # and PR runs read main's copy and simply stop writing their own. This
+          # is the same reasoning that already stopped PR branches duplicating;
+          # it just was not carried the last step to pre-main.
+          #
+          # Cost is bounded and small: the key only diverges when Cargo.lock,
+          # the toolchain, or RUSTFLAGS change - 39 of 650 commits (6%) touched
+          # Cargo.lock over the last 30 days - and rust-cache "will try to
+          # restore from a previous Cargo.lock version as well, so lockfile
+          # updates should only re-build changed dependencies", so even that
+          # case degrades to incremental work rather than a cold build.
+          #
+          # Why it matters: six Rust caches at 9.6GB previously evicted the
+          # release cache within ~3h of it being written and forced every
+          # release to compile cold. The release path has since split into two
+          # per-arch caches, so the demand grew again; this is where the room
+          # comes from.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: fmt
         run: cargo fmt --check
@@ -122,8 +140,8 @@ jobs:
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
         with:
-          # Save only on the integration branches - see the Rust job above.
-          save-if: ${{ github.ref == 'refs/heads/pre-main' || github.ref == 'refs/heads/main' }}
+          # Save only on main - see the Rust job above.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: check
         run: cargo check -p meridian -p meridian-core --all-targets
@@ -198,8 +216,8 @@ jobs:
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
         with:
-          # Save only on the integration branches - see the Rust job above.
-          save-if: ${{ github.ref == 'refs/heads/pre-main' || github.ref == 'refs/heads/main' }}
+          # Save only on main - see the Rust job above.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Same stub trick as the Windows tray check: tauri-build only STATS the
       # bundle.resources daemon path during `cargo check`, never reads it, so a


### PR DESCRIPTION
> Supersedes this branch's first approach (narrowing the Windows job to registry-only). That freed 2.36GB by making a blocking gate slower. **This frees ~4.46GB and makes nothing slower.** Windows keeps its target cache.

## The finding

The repo cache sits at **9.8GB of 10GB**, and roughly **4.46GB of it is a second copy of something already present.**

GitHub scopes caches by ref, and all three Rust jobs saved on *both* integration branches. These are not near-identical caches - they are **byte-identical keys**:

```
main      v0-rust-macos-universal-Darwin-arm64-201b0125-da9962c3
pre-main  v0-rust-macos-universal-Darwin-arm64-201b0125-da9962c3

main      v0-rust-windows-portability-Windows_NT-x64-2f1d0420-20ffafee
pre-main  v0-rust-windows-portability-Windows_NT-x64-2f1d0420-20ffafee

main      v0-rust-rust-Linux-x64-acc56c03-da9962c3
pre-main  v0-rust-rust-Linux-x64-acc56c03-da9962c3
```

## The change

Save on `main` only. A run restores from its own branch **or the default branch**, so `pre-main` and PR runs read main's copy and simply stop writing their own.

The `rust` job already reasoned exactly this way for PR branches - "PR runs still RESTORE from the base branch; they just stop writing a duplicate." It just was not carried the last step to `pre-main`.

## Cost, bounded

The key only diverges when `Cargo.lock`, the toolchain, or `RUSTFLAGS` change - **39 of 650 commits (6%)** touched `Cargo.lock` in the last 30 days.

And even that case is not a cold build. Per rust-cache's own docs:

> The action will try to restore from a previous `Cargo.lock` version as well, so lockfile updates should only re-build changed dependencies.

So a lockfile change on `pre-main` degrades to incremental work, not a full recompile. (I verified this against the action's README rather than assuming it - see the correction below for why.)

## Why now

> Six Rust caches totalled 9.6GB against the 10GB repo quota, which evicted the release job's cache within ~3h of it being written and forced every release to compile cold.

That is `ci.yml`'s own comment, from the last time this bit. Capping `save-if` bought room once; the release path has since split into **two** per-arch caches, so demand grew again. This is where the room comes from - and the priority is fast macOS releases on staging and production.

## The builds themselves are not the problem

Checked before blaming the cache. `target/release` is **4.8GB** locally, 3.9GB of it `deps/`, dominated by `objc2_app_kit` (92MB rlib + 85MB rmeta) and `cidre` (43MB, twice). There is no `[profile.release]` override and debug info is already off by default. 4.8GB compressing to 2.4GB is simply what this workspace costs to compile - the waste was the duplication, not the size.

## Correction carried over from #497

I claimed there that #494 orphaned two 2.4GB `rust-macos-universal` caches and freed ~4.8GB. That was wrong: `macos-universal` is a **CI job** (`ci.yml:171`), and both copies were last read minutes before I checked. There was no headroom. #497 as merged would have evicted live CI caches to store release caches LRU would evict again before the next release. This PR is the space that claim assumed.

## Test plan

- [x] `ci.yml` parses; all six jobs intact; all three rust-cache steps now `save-if: main`
- [ ] After merge, confirm CI on `pre-main` still restores (look for a cache hit, not "No cache found")
- [ ] Confirm the repo cache total drops by ~4.46GB as the pre-main copies age out
- [ ] Confirm `windows-portability` stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)