### PR TITLE
feat(worklog): choose which tracker a proposed ticket is created on

### DIFF
--- a/meridian-core/src/readers/day_task_worklogs/mod.rs
+++ b/meridian-core/src/readers/day_task_worklogs/mod.rs
@@ -362,6 +362,67 @@ pub async fn upsert_draft(
     read_back(pool, day_local, task_id).await
 }
 
+/// Choose which tracker a still-`drafted` PROPOSAL will create its new ticket on.
+///
+/// A proposal's provider is assigned at generate time as "the first configured
+/// tracker" (`src/pm_worklog/generate.rs`) — a placeholder that is simply wrong half
+/// the time for anyone on two boards, and until now was not overridable: the user
+/// could see "New Task: …" and had no way to say it belongs in GitHub rather than
+/// Jira. This is that override.
+///
+/// Deliberately scoped to the PROPOSE branch (`propose_title IS NOT NULL`). A match
+/// draft's provider is carried per-target — each matched ticket already lives on a
+/// specific board — so changing the draft-level column there would name a tracker
+/// the update does not actually post to. Callers get an error rather than a silent
+/// no-op, so the UI can say why.
+///
+/// Does NOT re-run the model, for [`retarget_draft`]'s reason: the prose describes
+/// the work, and the work does not change with the board it is filed on.
+///
+/// `WHERE state = 'drafted'` mirrors [`upsert_draft`]'s guard — once approved, the
+/// ticket may already exist on the old provider, and re-pointing the row would make
+/// it name a board the ticket is not on.
+#[tracing::instrument(skip(pool))]
+pub async fn set_draft_provider(
+    pool: &SqlitePool,
+    day_local: &str,
+    task_id: &str,
+    provider: &str,
+    now: &str,
+) -> anyhow::Result<DayTaskWorklogDraft> {
+    let res = sqlx::query(
+        "UPDATE day_task_worklogs SET provider = ?, last_error = NULL, updated_at = ? \
+         WHERE day_local = ? AND task_id = ? AND state = 'drafted' \
+           AND propose_title IS NOT NULL",
+    )
+    .bind(provider)
+    .bind(now)
+    .bind(day_local)
+    .bind(task_id)
+    .execute(pool)
+    .instrument(tracing::debug_span!("day_task_worklogs.write.set_provider"))
+    .await
+    .context("choosing the tracker for a proposed worklog ticket")?;
+
+    if res.rows_affected() == 0 {
+        // Two distinct reasons, and the user can act on only one of them — so look
+        // rather than emit one vague message covering both.
+        let existing = read_back(pool, day_local, task_id).await?;
+        if existing.state != "drafted" {
+            anyhow::bail!(
+                "this worklog has already been approved - the ticket exists on {} now",
+                existing.provider
+            );
+        }
+        anyhow::bail!(
+            "this draft posts to tickets that already exist - each one lives on its own board"
+        );
+    }
+    tracing::info!(provider, "worklog: proposal tracker chosen by the user");
+
+    read_back(pool, day_local, task_id).await
+}
+
 /// Point a still-`drafted` row at the ONE ticket the USER picked, over the whole
 /// board — dropping every ticket the model chose.
 ///

--- a/meridian-core/tests/readers.rs
+++ b/meridian-core/tests/readers.rs
@@ -1549,3 +1549,248 @@ async fn llm_experiments_degrade_to_empty_on_a_pre_064_db() {
         .unwrap()
         .is_none());
 }
+
+// ── day_task_worklogs::set_draft_provider ────────────────────────────────────
+//
+// The propose branch's provider is assigned at generate time as "the first
+// configured tracker", which is arbitrary for anyone on two boards. These cover
+// the override that lets the user re-point it, and — more importantly — the three
+// cases where it must REFUSE, because each one would otherwise make the row name a
+// tracker the ticket is not actually on.
+
+/// In-memory pool with the generated-worklog ledger (migrations 060/062/063) and
+/// the `pm_tasks` the target read left-joins for titles.
+async fn make_worklog_pool() -> SqlitePool {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("open in-memory db");
+    sqlx::query(
+        r#"
+        CREATE TABLE day_task_worklogs (
+            day_local TEXT NOT NULL, task_id TEXT NOT NULL, provider TEXT NOT NULL,
+            match_task_key TEXT, match_confidence REAL,
+            propose_issue_type TEXT, propose_title TEXT, propose_description TEXT,
+            update_summary TEXT NOT NULL DEFAULT '', update_json TEXT NOT NULL DEFAULT '{}',
+            reasoning TEXT NOT NULL DEFAULT '', state TEXT NOT NULL DEFAULT 'drafted',
+            target_key TEXT, created_task_key TEXT, posted_comment_id TEXT, browse_url TEXT,
+            last_error TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+            PRIMARY KEY (day_local, task_id)
+        );
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"
+        CREATE TABLE day_task_worklog_targets (
+            day_local TEXT NOT NULL, task_id TEXT NOT NULL, task_key TEXT NOT NULL,
+            provider TEXT NOT NULL, confidence REAL NOT NULL DEFAULT 0,
+            manual INTEGER NOT NULL DEFAULT 0, position INTEGER NOT NULL DEFAULT 0,
+            posted_comment_id TEXT, browse_url TEXT, posted_at TEXT, last_error TEXT,
+            post_attempt_at TEXT, created_at TEXT NOT NULL,
+            PRIMARY KEY (day_local, task_id, task_key)
+        );
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"
+        CREATE TABLE pm_tasks (
+            task_key TEXT, title TEXT, description_text TEXT, issue_type TEXT,
+            status_raw TEXT, is_terminal INTEGER, provider TEXT, url TEXT,
+            parent_key TEXT, epic_title TEXT, due_date TEXT, start_date TEXT
+        );
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    pool
+}
+
+/// Seed one draft. `propose` = the PROPOSE branch (a new ticket); otherwise the
+/// row is a MATCH with one target ticket.
+async fn seed_draft(pool: &SqlitePool, state: &str, provider: &str, propose: bool) {
+    sqlx::query(
+        "INSERT INTO day_task_worklogs (day_local, task_id, provider, propose_issue_type, \
+            propose_title, propose_description, update_summary, update_json, reasoning, state, \
+            created_at, updated_at) \
+         VALUES ('2026-07-20', 'T1', ?, ?, ?, ?, 'did things', '{}', 'because', ?, 't0', 't0')",
+    )
+    .bind(provider)
+    .bind(if propose { Some("Task") } else { None })
+    .bind(if propose {
+        Some("Ship the thing")
+    } else {
+        None
+    })
+    .bind(if propose { Some("A description") } else { None })
+    .bind(state)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    if !propose {
+        sqlx::query(
+            "INSERT INTO day_task_worklog_targets \
+                (day_local, task_id, task_key, provider, confidence, manual, position, created_at) \
+             VALUES ('2026-07-20', 'T1', 'KAN-1', ?, 0.9, 0, 0, 't0')",
+        )
+        .bind(provider)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn set_draft_provider_repoints_a_drafted_proposal() {
+    let pool = make_worklog_pool().await;
+    seed_draft(&pool, "drafted", "jira", true).await;
+
+    let out = meridian_core::day_task_worklogs::set_draft_provider(
+        &pool,
+        "2026-07-20",
+        "T1",
+        "github",
+        "t1",
+    )
+    .await
+    .expect("a drafted proposal is re-pointable");
+
+    assert_eq!(out.provider, "github");
+    // The proposal itself is untouched — this changes WHERE it lands, not WHAT.
+    assert_eq!(out.propose.as_ref().unwrap().title, "Ship the thing");
+    assert_eq!(out.state, "drafted");
+}
+
+#[tokio::test]
+async fn set_draft_provider_stamps_updated_at_and_clears_a_stale_error() {
+    let pool = make_worklog_pool().await;
+    seed_draft(&pool, "drafted", "jira", true).await;
+    sqlx::query("UPDATE day_task_worklogs SET last_error = 'jira rejected it'")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let out = meridian_core::day_task_worklogs::set_draft_provider(
+        &pool,
+        "2026-07-20",
+        "T1",
+        "github",
+        "t1",
+    )
+    .await
+    .unwrap();
+
+    // A failure against the OLD provider must not be shown against the new one —
+    // the user would read it as "GitHub rejected it", which never happened.
+    assert_eq!(out.error, None);
+    assert_eq!(out.updated_at, "t1");
+}
+
+#[tokio::test]
+async fn set_draft_provider_is_idempotent_on_the_same_provider() {
+    let pool = make_worklog_pool().await;
+    seed_draft(&pool, "drafted", "jira", true).await;
+
+    let out = meridian_core::day_task_worklogs::set_draft_provider(
+        &pool,
+        "2026-07-20",
+        "T1",
+        "jira",
+        "t1",
+    )
+    .await
+    .expect("re-choosing the current provider is not an error");
+    assert_eq!(out.provider, "jira");
+}
+
+#[tokio::test]
+async fn set_draft_provider_refuses_a_match_draft() {
+    let pool = make_worklog_pool().await;
+    seed_draft(&pool, "drafted", "jira", false).await;
+
+    let err = meridian_core::day_task_worklogs::set_draft_provider(
+        &pool,
+        "2026-07-20",
+        "T1",
+        "github",
+        "t1",
+    )
+    .await
+    .expect_err("a matched draft's provider is per-target, not per-draft");
+    assert!(
+        err.to_string().contains("already exist"),
+        "the message must say why, got: {err}"
+    );
+
+    // And the row is untouched — a refusal must not half-apply.
+    let after: String =
+        sqlx::query_scalar("SELECT provider FROM day_task_worklogs WHERE task_id = 'T1'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(after, "jira");
+}
+
+#[tokio::test]
+async fn set_draft_provider_refuses_once_approved() {
+    let pool = make_worklog_pool().await;
+    seed_draft(&pool, "approved", "jira", true).await;
+
+    let err = meridian_core::day_task_worklogs::set_draft_provider(
+        &pool,
+        "2026-07-20",
+        "T1",
+        "github",
+        "t1",
+    )
+    .await
+    .expect_err("an approved row may already have created the ticket");
+    assert!(
+        err.to_string().contains("already been approved"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn set_draft_provider_refuses_once_posted() {
+    let pool = make_worklog_pool().await;
+    seed_draft(&pool, "posted", "jira", true).await;
+
+    let err = meridian_core::day_task_worklogs::set_draft_provider(
+        &pool,
+        "2026-07-20",
+        "T1",
+        "github",
+        "t1",
+    )
+    .await
+    .expect_err("a posted comment is live on the old provider");
+    assert!(
+        err.to_string().contains("already been approved"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn set_draft_provider_errors_on_a_draft_that_does_not_exist() {
+    let pool = make_worklog_pool().await;
+    // No seed at all: nothing to re-point, and the read-back must not panic.
+    let err = meridian_core::day_task_worklogs::set_draft_provider(
+        &pool,
+        "2026-07-20",
+        "T404",
+        "github",
+        "t1",
+    )
+    .await
+    .expect_err("no draft, no provider to set");
+    assert!(err.to_string().contains("vanished"), "got: {err}");
+}

--- a/tray/src-tauri/src/commands/dashboard.rs
+++ b/tray/src-tauri/src/commands/dashboard.rs
@@ -340,6 +340,61 @@ pub async fn retarget_day_task_worklog(
     })
 }
 
+/// The body of a [`set_worklog_provider`] call.
+#[derive(Debug, serde::Deserialize)]
+pub struct SetWorklogProviderBody {
+    pub day: String,
+    pub task_id: String,
+    /// The tracker to create the proposed ticket on. VALIDATED, never trusted.
+    pub provider: String,
+}
+
+/// Choose which tracker a proposed worklog ticket gets created on.
+///
+/// Only reachable for the propose branch of a draft, where the provider was picked
+/// for the user as "the first configured tracker" - arbitrary for anyone on two
+/// boards. A matched draft carries its provider per-target and the core call refuses
+/// there.
+///
+/// **The provider is validated against the connected trackers before it is written.**
+/// [`retarget_day_task_worklog`] states the rule this obeys: the frontend must not be
+/// able to name an arbitrary tracker for a comment to be posted to. It cannot come
+/// from `pm_tasks` here (a proposed ticket does not exist yet), so the check is
+/// against [`crate::commands::connected_providers`] instead - the same credential
+/// probe `get_integrations` shows the user. An id that isn't connected is refused
+/// rather than written and left to fail later inside the approve.
+#[tauri::command]
+#[tracing::instrument(skip(pool))]
+pub async fn set_worklog_provider(
+    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    body: SetWorklogProviderBody,
+) -> Result<meridian_core::day_task_worklogs::DayTaskWorklogDraft, String> {
+    let Some(pool) = pool.inner() else {
+        return Err("meridian.db is not open yet".to_string());
+    };
+    if !crate::commands::connected_providers().contains(&body.provider.as_str()) {
+        tracing::warn!(provider = %body.provider, "set_worklog_provider: unconnected tracker refused");
+        return Err(format!(
+            "{} isn't connected - connect it in Settings first",
+            body.provider
+        ));
+    }
+
+    let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    meridian_core::day_task_worklogs::set_draft_provider(
+        pool,
+        &body.day,
+        &body.task_id,
+        &body.provider,
+        &now,
+    )
+    .await
+    .map_err(|e| {
+        tracing::warn!(error = %e, "set_worklog_provider failed");
+        e.to_string()
+    })
+}
+
 /// The body of a [`dismiss_worklog_target`] call.
 #[derive(Debug, serde::Deserialize)]
 pub struct DismissTargetBody {

--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -257,6 +257,58 @@ fn oauth_error_path(provider: &str) -> Option<PathBuf> {
     home().map(|h| h.join(".meridian/oauth").join(format!("{provider}.error")))
 }
 
+/// Which trackers have usable credentials, in the canonical provider order the UI
+/// also uses (`ui/components/timeline/useTimelineData.ts`'s `PROVIDER_IDS`).
+///
+/// The credential-probing half of [`get_integrations`], split out so a command can
+/// ask "is this provider actually connected?" without going through the response
+/// struct field by field.
+///
+/// `has_oauth` is injected rather than calling [`oauth_file_exists`] directly: the
+/// two OAuth-backed trackers are otherwise decided by files under the real `$HOME`,
+/// which would make this untestable (and its result quietly dependent on whichever
+/// machine it runs on).
+fn connected_from_env(
+    env: &HashMap<String, String>,
+    has_oauth: impl Fn(&str) -> bool,
+) -> Vec<&'static str> {
+    let jira_basic =
+        is_set(env, "JIRA_BASE_URL") && is_set(env, "JIRA_EMAIL") && is_set(env, "JIRA_API_TOKEN");
+    let azure = is_set(env, "AZURE_DEVOPS_PAT")
+        && (is_set(env, "AZURE_DEVOPS_URL")
+            || is_set(env, "AZURE_DEVOPS_ORG")
+            || is_set(env, "AZURE_DEVOPS_ORG_URL"));
+
+    let mut on = Vec::new();
+    if has_oauth("jira") || jira_basic {
+        on.push("jira");
+    }
+    if is_set(env, "LINEAR_API_KEY") {
+        on.push("linear");
+    }
+    if is_set(env, "GITHUB_TOKEN") {
+        on.push("github");
+    }
+    if has_oauth("trello") {
+        on.push("trello");
+    }
+    if azure {
+        on.push("azure_devops");
+    }
+    on
+}
+
+/// Every connected tracker id, resolved through the same install-mode `.env` the
+/// GET reads.
+///
+/// Exists so other commands can VALIDATE a provider id the frontend sent instead of
+/// trusting it - see [`crate::commands::set_worklog_provider`].
+pub fn connected_providers() -> Vec<&'static str> {
+    let mode = crate::install::detect_install_mode();
+    let env = mode.env_path().map(parse_env).unwrap_or_default();
+    connected_from_env(&env, oauth_file_exists)
+}
+
 /// Which trackers are connected (the ported /api/integrations GET).
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
@@ -265,10 +317,7 @@ pub async fn get_integrations(
 ) -> Result<IntegrationsResponse, String> {
     let mode = crate::install::detect_install_mode();
     let env = mode.env_path().map(parse_env).unwrap_or_default();
-
-    let jira_basic = is_set(&env, "JIRA_BASE_URL")
-        && is_set(&env, "JIRA_EMAIL")
-        && is_set(&env, "JIRA_API_TOKEN");
+    let on = connected_from_env(&env, oauth_file_exists);
 
     // Sync errors are best-effort: a missing/uninitialised DB just omits them
     // (matches the route's silent catch).
@@ -280,14 +329,11 @@ pub async fn get_integrations(
     };
 
     Ok(IntegrationsResponse {
-        jira: oauth_file_exists("jira") || jira_basic,
-        linear: is_set(&env, "LINEAR_API_KEY"),
-        github: is_set(&env, "GITHUB_TOKEN"),
-        trello: oauth_file_exists("trello"),
-        azure_devops: is_set(&env, "AZURE_DEVOPS_PAT")
-            && (is_set(&env, "AZURE_DEVOPS_URL")
-                || is_set(&env, "AZURE_DEVOPS_ORG")
-                || is_set(&env, "AZURE_DEVOPS_ORG_URL")),
+        jira: on.contains(&"jira"),
+        linear: on.contains(&"linear"),
+        github: on.contains(&"github"),
+        trello: on.contains(&"trello"),
+        azure_devops: on.contains(&"azure_devops"),
         github_projects_selected: is_set(&env, "GITHUB_PROJECT_IDS"),
         sync_errors,
     })
@@ -1506,5 +1552,98 @@ mod tests {
         assert!(!out.contains("JIRA_EMAIL"));
         assert!(!out.contains("JIRA_API_TOKEN"));
         std::fs::remove_file(&path).ok();
+    }
+
+    // ── connected_from_env ────────────────────────────────────────────────
+    //
+    // This list is what `set_worklog_provider` validates against, so a provider
+    // wrongly reported connected here means a worklog ticket filed at a tracker
+    // with no usable credentials — a failure the user only sees after approving.
+
+    /// No OAuth files — the default for these tests, so only env creds count.
+    fn no_oauth(_: &str) -> bool {
+        false
+    }
+
+    #[test]
+    fn connected_from_env_reports_nothing_for_an_empty_env() {
+        assert!(connected_from_env(&env_of(&[]), no_oauth).is_empty());
+    }
+
+    #[test]
+    fn connected_from_env_reads_the_token_backed_trackers() {
+        let env = env_of(&[("LINEAR_API_KEY", "lin_abc"), ("GITHUB_TOKEN", "ghp_abc")]);
+        assert_eq!(connected_from_env(&env, no_oauth), vec!["linear", "github"]);
+    }
+
+    #[test]
+    fn connected_from_env_keeps_the_canonical_provider_order() {
+        // The UI renders trackers in this order (PROVIDER_IDS / TRACKERS); the two
+        // must agree or the same set reads differently in two places.
+        let env = env_of(&[
+            ("GITHUB_TOKEN", "ghp_abc"),
+            ("LINEAR_API_KEY", "lin_abc"),
+            ("AZURE_DEVOPS_PAT", "pat"),
+            ("AZURE_DEVOPS_ORG", "acme"),
+            ("JIRA_BASE_URL", "https://x.atlassian.net"),
+            ("JIRA_EMAIL", "a@b.c"),
+            ("JIRA_API_TOKEN", "tok"),
+        ]);
+        assert_eq!(
+            connected_from_env(&env, |p| p == "trello"),
+            vec!["jira", "linear", "github", "trello", "azure_devops"]
+        );
+    }
+
+    #[test]
+    fn connected_from_env_needs_all_three_jira_basic_fields() {
+        // Two of three is a half-configured tracker: it would pass a naive check
+        // and then fail every API call.
+        let partial = env_of(&[
+            ("JIRA_BASE_URL", "https://x.atlassian.net"),
+            ("JIRA_EMAIL", "a@b.c"),
+        ]);
+        assert!(connected_from_env(&partial, no_oauth).is_empty());
+    }
+
+    #[test]
+    fn connected_from_env_accepts_jira_by_oauth_without_any_env_creds() {
+        // The OAuth flow writes a token store, not .env keys.
+        assert_eq!(
+            connected_from_env(&env_of(&[]), |p| p == "jira"),
+            vec!["jira"]
+        );
+    }
+
+    #[test]
+    fn connected_from_env_needs_a_host_alongside_the_azure_pat() {
+        let pat_only = env_of(&[("AZURE_DEVOPS_PAT", "pat")]);
+        assert!(connected_from_env(&pat_only, no_oauth).is_empty());
+
+        // Any one of the three host spellings is enough.
+        for host in [
+            "AZURE_DEVOPS_URL",
+            "AZURE_DEVOPS_ORG",
+            "AZURE_DEVOPS_ORG_URL",
+        ] {
+            let env = env_of(&[("AZURE_DEVOPS_PAT", "pat"), (host, "acme")]);
+            assert_eq!(
+                connected_from_env(&env, no_oauth),
+                vec!["azure_devops"],
+                "{host} should satisfy the Azure host requirement"
+            );
+        }
+    }
+
+    #[test]
+    fn connected_from_env_rejects_env_example_placeholders() {
+        // A user who copied .env.example has a GITHUB_TOKEN line and no token. It
+        // must not count as connected — `is_set` is what catches that, and this
+        // pins that connected_from_env actually goes through it.
+        let env = env_of(&[
+            ("GITHUB_TOKEN", "your-token-here"),
+            ("LINEAR_API_KEY", "lin_real_key"),
+        ]);
+        assert_eq!(connected_from_env(&env, no_oauth), vec!["linear"]);
     }
 }

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -489,6 +489,7 @@ pub fn run() {
             commands::get_board_tickets,
             commands::retarget_day_task_worklog,
             commands::dismiss_worklog_target,
+            commands::set_worklog_provider,
             commands::plan_dismissed,
             commands::draft_plan_task,
             commands::create_plan_task,

--- a/ui/__tests__/composer-board-target.test.ts
+++ b/ui/__tests__/composer-board-target.test.ts
@@ -1,0 +1,143 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// The task composer's "where does this go" choice, after the N-cards-per-tracker row
+// collapsed into ONE board option with a tracker picker inside it.
+//
+// `boardProviderFor` / `isBoardTarget` are imported and exercised for real (the store
+// module has no DOM dependency). The rendering rules that can't be imported without a
+// React harness — which this repo does not have, see task-composer.test.ts — are
+// pinned by scanning the source, the same convention the sibling tests use.
+
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  boardProviderFor, isBoardTarget, type ComposerState,
+} from '../components/plan/useTaskComposer'
+import { LOCAL_PROVIDER } from '../lib/api-types'
+
+const composer = readFileSync(join(import.meta.dir, '../components/plan/TaskComposer.tsx'), 'utf8')
+const store = readFileSync(join(import.meta.dir, '../components/plan/useTaskComposer.ts'), 'utf8')
+
+/** A composer state with only the fields these predicates read. */
+const state = (over: Partial<ComposerState> = {}): ComposerState => ({
+  note: '', title: '', description: '', issueType: 'Task',
+  target: LOCAL_PROVIDER, boardProvider: null, phase: 'idle',
+  titleDrafted: false, descriptionDrafted: false,
+  error: null, note_after: null, created: null,
+  ...over,
+})
+
+describe('boardProviderFor', () => {
+  it('is null with no tracker connected - there is no board option to offer', () => {
+    expect(boardProviderFor(state(), [])).toBe(null)
+    expect(boardProviderFor(state({ boardProvider: 'jira' }), [])).toBe(null)
+  })
+
+  it('defaults to the first connected tracker before the user has chosen', () => {
+    expect(boardProviderFor(state(), ['jira', 'github'])).toBe('jira')
+    expect(boardProviderFor(state(), ['github', 'jira'])).toBe('github')
+  })
+
+  it('keeps the tracker the user chose, not whichever sorts first', () => {
+    expect(boardProviderFor(state({ boardProvider: 'github' }), ['jira', 'github'])).toBe('github')
+  })
+
+  it('falls back to the first tracker when the remembered one was disconnected', () => {
+    // Settings can disconnect a tracker while the composer sits open. Filing at a
+    // provider with no credentials fails at the daemon, after the user committed.
+    expect(boardProviderFor(state({ boardProvider: 'github' }), ['jira'])).toBe('jira')
+  })
+
+  it('survives a boardProvider that was never a real tracker id', () => {
+    expect(boardProviderFor(state({ boardProvider: 'nonsense' }), ['linear'])).toBe('linear')
+  })
+
+  it('is stable for a single connected tracker whatever was remembered', () => {
+    for (const remembered of [null, 'jira', 'github', 'trello']) {
+      expect(boardProviderFor(state({ boardProvider: remembered }), ['linear'])).toBe('linear')
+    }
+  })
+})
+
+describe('isBoardTarget', () => {
+  it('is false for the personal default', () => {
+    expect(isBoardTarget(state())).toBe(false)
+    expect(isBoardTarget(state({ target: LOCAL_PROVIDER }))).toBe(false)
+  })
+
+  it('is true for every provider id', () => {
+    for (const id of ['jira', 'linear', 'github', 'trello', 'azure_devops']) {
+      expect(isBoardTarget(state({ target: id }))).toBe(true)
+    }
+  })
+
+  it('does not depend on boardProvider - only where the create actually goes', () => {
+    // Remembering GitHub while sitting on Personal must still read as personal,
+    // or a trip through the board option would silently file the task.
+    expect(isBoardTarget(state({ target: LOCAL_PROVIDER, boardProvider: 'github' }))).toBe(false)
+  })
+})
+
+describe('the board choice is remembered across a trip through Personal', () => {
+  it('setTarget records a provider as the board choice and leaves it on local', () => {
+    // The branch is the whole mechanism: picking a provider must ALSO write
+    // boardProvider, and selecting Personal must NOT clear it.
+    expect(store).toContain(
+      "patch(target === LOCAL_PROVIDER ? { target } : { target, boardProvider: target })",
+    )
+  })
+
+  it('starts on Personal, so filing on a shared board is always a deliberate click', () => {
+    expect(store).toContain('target: LOCAL_PROVIDER,')
+    expect(store).toContain('boardProvider: null,')
+  })
+})
+
+describe('the composer renders ONE board option, not one per tracker', () => {
+  it('no longer maps trackers into a row of "Create in X" cards', () => {
+    expect(/trackers\.map\([^)]*=>\s*\(?\s*<TargetOption/.test(composer)).toBe(false)
+  })
+
+  it('offers exactly two TargetOptions - personal and board', () => {
+    expect(composer.match(/<TargetOption/g)?.length).toBe(2)
+  })
+
+  it('names the tracker directly when there is only one, and generalises past that', () => {
+    expect(composer).toContain("trackers.length > 1 ? 'Create on your board' : `Create in ${trackers[0].name}`")
+  })
+
+  it('hides the tracker picker when there is nothing to pick between', () => {
+    expect(composer).toContain('{trackers.length > 1 && (')
+  })
+
+  it('shows a brand mark beside each tracker in the picker', () => {
+    expect(composer).toContain('<ProviderIcon provider={t.id} size={12} />')
+  })
+
+  it('drops the whole Where block when no tracker is connected', () => {
+    // boardProvider is null exactly then - solo users are offered no choice at all.
+    expect(composer).toContain('{boardProvider && (')
+  })
+
+  it('keeps the tracker picker out of the radio button element', () => {
+    // A <button> inside a <button> is invalid HTML and browsers drop one of them,
+    // which would make either the card or the chips unclickable.
+    expect(/<button[^>]*role="radio"[^>]*>[\s\S]{0,400}?<button/.test(
+      composer.slice(composer.indexOf('function TargetOption')),
+    )).toBe(false)
+  })
+
+  it('repairs a target stranded by a disconnect instead of filing blind', () => {
+    expect(composer).toContain('boardProviderFor(s, trackers.map(t => t.id)) ?? LOCAL_PROVIDER')
+  })
+})
+
+describe('the create still sends one target field', () => {
+  it('posts the provider id (or local), never a "board" sentinel', () => {
+    // The daemon routes on this exact value; a sentinel would need translating
+    // somewhere, and that somewhere is where it would drift.
+    expect(store).toContain('target: state.target,')
+    expect(store).not.toContain("target: 'board'")
+  })
+})

--- a/ui/__tests__/toolbar-connected-pill.test.ts
+++ b/ui/__tests__/toolbar-connected-pill.test.ts
@@ -1,0 +1,133 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// The toolbar's Connected/Solo pill, after it went from showing at most ONE brand
+// mark (only when exactly one tracker was connected) to showing every connected
+// provider's mark.
+//
+// The derivation in useTimelineData is mirrored here - it lives inside a hook body
+// and this repo has no React render harness (see task-composer.test.ts) - and the
+// rendering rules are pinned by scanning the source, so a regression in either half
+// fails rather than passing on the other's correctness.
+
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { TRACKERS, TRACKER_BY_ID, type TrackerId } from '../lib/integrations'
+import type { IntegrationsResponse } from '../lib/api-types'
+
+const src = (p: string) => readFileSync(join(import.meta.dir, '..', p), 'utf8')
+const toolbar = src('components/timeline/Toolbar.tsx')
+const data = src('components/timeline/useTimelineData.ts')
+
+const PROVIDER_IDS: TrackerId[] = ['jira', 'linear', 'github', 'trello', 'azure_devops']
+
+/** An integrations response with `on` connected and everything else off. */
+const integrations = (on: TrackerId[]): IntegrationsResponse => ({
+  jira: on.includes('jira'),
+  linear: on.includes('linear'),
+  github: on.includes('github'),
+  trello: on.includes('trello'),
+  azure_devops: on.includes('azure_devops'),
+  github_projects_selected: false,
+  sync_errors: {},
+})
+
+/** The hook's derivation, mirrored. The source is the contract; this pins its shape. */
+function pill(int: IntegrationsResponse | null) {
+  if (!int) return { isSolo: false, connectedProviderName: null, connectedProviderIds: [] }
+  const on = PROVIDER_IDS.filter(id => (int as unknown as Record<string, boolean>)[id])
+  return {
+    isSolo: on.length === 0,
+    connectedProviderName: on.length === 1 ? TRACKER_BY_ID[on[0]].name : null,
+    connectedProviderIds: on,
+  }
+}
+
+const label = (p: ReturnType<typeof pill>) =>
+  p.isSolo ? 'Solo' : p.connectedProviderName ?? 'Connected'
+
+describe('the pill with nothing connected', () => {
+  it('reads Solo and offers no marks', () => {
+    const p = pill(integrations([]))
+    expect(p.isSolo).toBe(true)
+    expect(p.connectedProviderIds).toEqual([])
+    expect(label(p)).toBe('Solo')
+  })
+})
+
+describe('the pill with one tracker', () => {
+  it('names that tracker and shows its mark', () => {
+    const p = pill(integrations(['jira']))
+    expect(p.connectedProviderIds).toEqual(['jira'])
+    expect(label(p)).toBe('Jira')
+    expect(p.isSolo).toBe(false)
+  })
+
+  it('works for every provider, not just the first in the list', () => {
+    for (const t of TRACKERS) {
+      const p = pill(integrations([t.id]))
+      expect(p.connectedProviderIds).toEqual([t.id])
+      expect(label(p)).toBe(t.name)
+    }
+  })
+})
+
+describe('the pill with several trackers - the case that used to render one dot', () => {
+  it('lists every connected provider', () => {
+    expect(pill(integrations(['jira', 'github'])).connectedProviderIds).toEqual(['jira', 'github'])
+  })
+
+  it('falls back to a generic label, since no single name is right', () => {
+    expect(label(pill(integrations(['jira', 'github'])))).toBe('Connected')
+  })
+
+  it('handles all five at once', () => {
+    const p = pill(integrations([...PROVIDER_IDS]))
+    expect(p.connectedProviderIds).toHaveLength(5)
+    expect(label(p)).toBe('Connected')
+  })
+
+  it('orders marks by the registry, not by the response key order', () => {
+    // The Settings banner ("Connected to Jira, GitHub") derives from the same
+    // registry order - the two surfaces must not disagree about the same set.
+    expect(pill(integrations(['github', 'jira'])).connectedProviderIds).toEqual(['jira', 'github'])
+  })
+})
+
+describe('the pill while integrations are still loading', () => {
+  it('is neither Solo nor connected - no flash of a wrong state', () => {
+    const p = pill(null)
+    expect(p.isSolo).toBe(false)
+    expect(p.connectedProviderIds).toEqual([])
+    expect(label(p)).toBe('Connected')
+  })
+})
+
+describe('the source backs the derivation', () => {
+  it('exposes the full id list, not a single id', () => {
+    expect(data).toContain('connectedProviderIds: on,')
+    expect(data).not.toContain('connectedProviderId:')
+  })
+
+  it('still names a single tracker only when exactly one is connected', () => {
+    expect(data).toContain("connectedProviderName: on.length === 1 ? TRACKER_BY_ID[on[0]].name : null")
+  })
+
+  it('renders one mark per connected provider', () => {
+    expect(toolbar).toContain('connectedProviderIds.map(id => <ProviderIcon key={id} provider={id} size={12} />)')
+  })
+
+  it('keys the marks, so React does not reorder them on a connect/disconnect', () => {
+    expect(toolbar).toContain('key={id}')
+  })
+
+  it('keeps the dot fallback for the no-marks case', () => {
+    expect(toolbar).toContain('connectedProviderIds.length > 0')
+    expect(toolbar).toContain("background: isSolo ? 'var(--t-faint)' : 'var(--color-state-proposal)'")
+  })
+
+  it('is display-only - the pill is not a toggle', () => {
+    const pillBlock = toolbar.slice(toolbar.indexOf('connectedProviderIds.length > 0') - 400)
+    expect(pillBlock.slice(0, 600)).not.toContain('onClick')
+  })
+})

--- a/ui/__tests__/worklog-propose-provider.test.ts
+++ b/ui/__tests__/worklog-propose-provider.test.ts
@@ -1,0 +1,142 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Choosing which tracker a PROPOSED worklog ticket gets created on.
+//
+// The bug this covers: a proposal's provider is assigned at generate time as "the
+// first configured tracker" (src/pm_worklog/generate.rs), so with Jira and GitHub
+// both connected every new ticket was filed in Jira - and the card's corner icon,
+// which reads the provider the worklog actually landed on, dutifully showed Jira
+// for all of it. The fix is a picker; these pin when it may be shown and what the
+// write is allowed to do.
+//
+// `canPickProposalProvider` is imported and exercised for real. The rest is scanned
+// from source - this repo has no React render harness (see task-composer.test.ts).
+
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { canPickProposalProvider } from '../components/timeline/WorklogTargets'
+import { trackerName } from '../lib/integrations'
+
+const src = (p: string) => readFileSync(join(import.meta.dir, '..', p), 'utf8')
+const targets = src('components/timeline/WorklogTargets.tsx')
+const worklog = src('components/timeline/useWorklog.ts')
+const panel = src('components/timeline/DayTaskDetailPanel.tsx')
+const column = src('components/timeline/DayTaskColumn.tsx')
+
+const PROPOSE = { issue_type: 'Task', title: 'Ship it', description: 'do the thing' }
+
+describe('canPickProposalProvider', () => {
+  it('is true for a drafted proposal with two trackers connected', () => {
+    expect(canPickProposalProvider({ propose: PROPOSE, state: 'drafted' }, 2)).toBe(true)
+  })
+
+  it('is false for a matched draft - each matched ticket carries its own board', () => {
+    expect(canPickProposalProvider({ propose: null, state: 'drafted' }, 2)).toBe(false)
+  })
+
+  it('is false once approved or posted - the ticket may already exist', () => {
+    expect(canPickProposalProvider({ propose: PROPOSE, state: 'approved' }, 2)).toBe(false)
+    expect(canPickProposalProvider({ propose: PROPOSE, state: 'posted' }, 2)).toBe(false)
+  })
+
+  it('is false with one tracker - a choice of one is a label, not a decision', () => {
+    expect(canPickProposalProvider({ propose: PROPOSE, state: 'drafted' }, 1)).toBe(false)
+  })
+
+  it('is false with no tracker connected', () => {
+    expect(canPickProposalProvider({ propose: PROPOSE, state: 'drafted' }, 0)).toBe(false)
+  })
+
+  it('stays true as more trackers connect', () => {
+    for (const n of [2, 3, 4, 5]) {
+      expect(canPickProposalProvider({ propose: PROPOSE, state: 'drafted' }, n)).toBe(true)
+    }
+  })
+
+  it('needs every condition, not any of them', () => {
+    // Guards against the predicate degrading to an OR in a later edit.
+    expect(canPickProposalProvider({ propose: null, state: 'approved' }, 5)).toBe(false)
+    expect(canPickProposalProvider({ propose: null, state: 'drafted' }, 0)).toBe(false)
+  })
+})
+
+describe('the non-pickable case still says where the ticket goes', () => {
+  it('falls through to a statement naming the tracker', () => {
+    expect(targets).toContain("{draft.created_task_key ? 'Created in' : 'Will be created in'}")
+    expect(targets).toContain('trackerName(draft.provider)')
+  })
+
+  it('reads past tense once the ticket exists', () => {
+    // "Will be created in Jira" beside a ticket that already exists is a lie the
+    // user would reasonably act on.
+    expect(targets).toContain('draft.created_task_key ?')
+  })
+})
+
+describe('trackerName', () => {
+  it('maps every known provider id to its display name', () => {
+    expect(trackerName('jira')).toBe('Jira')
+    expect(trackerName('github')).toBe('GitHub')
+    expect(trackerName('linear')).toBe('Linear')
+    expect(trackerName('trello')).toBe('Trello')
+    expect(trackerName('azure_devops')).toBe('Azure DevOps')
+  })
+
+  it('falls back to the raw id rather than rendering an empty gap', () => {
+    expect(trackerName('some_new_tracker')).toBe('some_new_tracker')
+    expect(trackerName('')).toBe('')
+  })
+})
+
+describe('the write goes through the store, never straight from the component', () => {
+  it('the command lives in useWorklog, not in a component file', () => {
+    expect(worklog).toContain("'set_worklog_provider'")
+    expect(targets).not.toContain('set_worklog_provider')
+    expect(panel).not.toContain('set_worklog_provider')
+  })
+
+  it('sends the day, task and provider - the daemon needs all three to find the row', () => {
+    expect(/set_worklog_provider',\s*\{\s*day,\s*task_id: taskId,\s*provider,/.test(worklog)).toBe(true)
+  })
+
+  it('refuses to fire while a generate or approve is in flight', () => {
+    // Re-pointing a draft mid-approve would race a ticket that is being created.
+    const fn = worklog.slice(worklog.indexOf('function runSetProvider'))
+    expect(fn).toContain("if (cur?.phase === 'approving' || cur?.phase === 'generating') return")
+  })
+
+  it('skips the round-trip when the provider is already selected', () => {
+    const fn = worklog.slice(worklog.indexOf('function runSetProvider'))
+    expect(fn).toContain('if (cur?.draft?.provider === provider) return')
+  })
+
+  it('renders from the draft the server returns, not an optimistic local patch', () => {
+    // The server owns the rules (it can refuse); echoing the click locally would
+    // show a choice that was never written.
+    const fn = worklog.slice(worklog.indexOf('function runSetProvider'))
+    expect(fn).toContain('patch(key, { draft: r, phase: \'idle\', loaded: true, error: r.error ?? null })')
+  })
+
+  it('cancels a pending post-confirm, which named the old board', () => {
+    expect(worklog).toContain('setProvider: (provider: string) => {\n      setConfirming(false)')
+  })
+})
+
+describe('the confirm names the board before an irreversible create', () => {
+  it('says which tracker the new ticket lands in', () => {
+    expect(panel).toContain('Create a new ${draft.propose.issue_type} in ${providerName(draft.provider)}')
+  })
+})
+
+describe('the card corner icon follows the provider, and is never hardcoded', () => {
+  it('reads posted_provider off the task rather than assuming one tracker', () => {
+    expect(column).toContain('provider={laid.task.posted_provider}')
+    for (const id of ['"jira"', "'jira'"]) expect(column).not.toContain(`<ProviderIcon provider=${id}`)
+  })
+
+  it('renders no pill at all when nothing has been posted yet', () => {
+    // Better a missing pill than one claiming a board the work never reached.
+    expect(column).toContain('laid.task.posted_provider &&')
+  })
+})

--- a/ui/components/plan/TaskComposer.tsx
+++ b/ui/components/plan/TaskComposer.tsx
@@ -22,9 +22,11 @@ import { LOCAL_PROVIDER } from '@/lib/api-types'
 import {
   useTaskComposer, setNote, setTitle, setDescription, setIssueType, setTarget,
   draftFromNote, createTask, canCreate, resetComposer, titleWords, MIN_TITLE_WORDS,
+  boardProviderFor, isBoardTarget,
 } from '@/components/plan/useTaskComposer'
 import { FOCUS, PRIMARY_BTN } from '@/components/plan/planStyles'
 import { GeneratingBar } from '@/components/GeneratingBar'
+import { ProviderIcon } from '@/components/ProviderIcon'
 
 const INPUT = 'w-full px-3 py-2 rounded-lg mt-body'
 const inputStyle = {
@@ -72,6 +74,17 @@ export function TaskComposer({ day, trackers, onDone, onCancel, hero = false }: 
     noteRef.current?.focus()
   }, [])
 
+  // A tracker can be disconnected in Settings while this composer sits open, stranding
+  // `target` on a provider that is no longer connected — the create would then fail at
+  // the daemon with nothing the user could have seen coming. Re-point at the surviving
+  // board choice; if none survives, fall back to Personal rather than filing blind.
+  useEffect(() => {
+    if (!isBoardTarget(s)) return
+    if (trackers.some(t => t.id === s.target)) return
+    setTarget(boardProviderFor(s, trackers.map(t => t.id)) ?? LOCAL_PROVIDER)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [s.target, trackers])
+
   // The create landed — let the parent close/refresh. Kept as an effect so the store,
   // not the click handler, is the single source of "it worked".
   useEffect(() => {
@@ -83,6 +96,9 @@ export function TaskComposer({ day, trackers, onDone, onCancel, hero = false }: 
   const creating = s.phase === 'creating'
   const ready = canCreate(s)
   const words = titleWords(s.title)
+  // Null exactly when no tracker is connected - the whole "Where" block is then moot.
+  const boardProvider = boardProviderFor(s, trackers.map(t => t.id))
+  const onBoard = isBoardTarget(s)
 
   return (
     <div className={hero ? 'w-full max-w-[560px] mx-auto' : 'flex flex-col min-h-0 h-full'}>
@@ -188,23 +204,49 @@ export function TaskComposer({ day, trackers, onDone, onCancel, hero = false }: 
         </div>
 
         {/* ── Where it goes. Solo users have no choice to make, so none is shown.
-             Every connected tracker gets its own option - someone on Jira AND
-             GitHub must be able to reach both, not just whichever sorts first. */}
-        {trackers.length > 0 && (
+             ONE board option, not one per tracker: "personal vs. my team sees this" is
+             the decision that matters, and which tracker it lands on is a detail of
+             that choice - so it lives inside the option as a picker rather than
+             fanning the row out into N cards that all say the same sentence. */}
+        {boardProvider && (
           <div className="mt-4">
             <FieldLabel>Where</FieldLabel>
             <div role="radiogroup" aria-label="Where to create this task"
-              className={`grid gap-2 ${trackers.length > 1 ? 'grid-cols-1 sm:grid-cols-2' : 'grid-cols-2'}`}>
+              className="grid gap-2 grid-cols-1 sm:grid-cols-2">
               <TargetOption
-                selected={s.target === LOCAL_PROVIDER} onSelect={() => setTarget(LOCAL_PROVIDER)}
+                selected={!onBoard} onSelect={() => setTarget(LOCAL_PROVIDER)}
                 label="Keep personal" hint="Only in Meridian. Nothing is posted to your board."
               />
-              {trackers.map(t => (
-                <TargetOption key={t.id}
-                  selected={s.target === t.id} onSelect={() => setTarget(t.id)}
-                  label={`Create in ${t.name}`} hint={`Files a real ${t.name} ticket your team can see.`}
-                />
-              ))}
+              <TargetOption
+                selected={onBoard} onSelect={() => setTarget(boardProvider)}
+                label={trackers.length > 1 ? 'Create on your board' : `Create in ${trackers[0].name}`}
+                hint={trackers.length > 1
+                  ? 'Files a real ticket your team can see. Pick where:'
+                  : `Files a real ${trackers[0].name} ticket your team can see.`}>
+                {/* Only worth showing when there is genuinely a choice - with one
+                    tracker connected the label above already names it. */}
+                {trackers.length > 1 && (
+                  <div role="radiogroup" aria-label="Which tracker to file in" className="flex flex-wrap gap-1.5 mt-2">
+                    {trackers.map(t => {
+                      const picked = onBoard && s.target === t.id
+                      return (
+                        <button key={t.id} role="radio" aria-checked={picked}
+                          onClick={() => setTarget(t.id)}
+                          className={`mt-chip inline-flex items-center gap-1.5 px-2 py-1 rounded-md transition-colors ${FOCUS}`}
+                          style={{
+                            border: `1px solid ${picked ? 'var(--color-state-approved)' : 'var(--t-ctrl-border)'}`,
+                            background: picked ? 'color-mix(in srgb, var(--color-state-approved) 14%, transparent)' : 'var(--t-ctrl)',
+                            color: picked ? 'var(--t-title)' : 'var(--t-faint)',
+                            fontWeight: picked ? 700 : 500,
+                          }}>
+                          <ProviderIcon provider={t.id} size={12} />
+                          {t.name}
+                        </button>
+                      )
+                    })}
+                  </div>
+                )}
+              </TargetOption>
             </div>
           </div>
         )}
@@ -242,19 +284,27 @@ export function TaskComposer({ day, trackers, onDone, onCancel, hero = false }: 
 }
 
 /** One "where does this go" choice. A radio, not a toggle - both options are equally
- *  legible, because filing on a shared board is a decision worth reading first. */
-function TargetOption({ selected, onSelect, label, hint }: {
+ *  legible, because filing on a shared board is a decision worth reading first.
+ *
+ *  `children` (the tracker picker) sits OUTSIDE the button element, inside the same
+ *  bordered shell: a button nested in a button is invalid HTML, and browsers recover
+ *  from it by dropping one of them. */
+function TargetOption({ selected, onSelect, label, hint, children }: {
   selected: boolean; onSelect: () => void; label: string; hint: string
+  children?: React.ReactNode
 }) {
   return (
-    <button role="radio" aria-checked={selected} onClick={onSelect}
-      className={`text-left rounded-lg px-3 py-2.5 transition-colors ${FOCUS}`}
+    <div className="rounded-lg px-3 py-2.5 transition-colors"
       style={{
         border: `1px solid ${selected ? 'var(--color-state-approved)' : 'var(--t-ctrl-border)'}`,
         background: selected ? 'color-mix(in srgb, var(--color-state-approved) 8%, transparent)' : 'var(--t-ctrl)',
       }}>
-      <span className="mt-body-sm block" style={{ fontWeight: 700, color: 'var(--t-title)' }}>{label}</span>
-      <span className="mt-body-sm block mt-0.5" style={{ color: 'var(--t-faint)', fontSize: 11.5, lineHeight: 1.4 }}>{hint}</span>
-    </button>
+      <button role="radio" aria-checked={selected} onClick={onSelect}
+        className={`text-left w-full ${FOCUS}`} style={{ background: 'transparent' }}>
+        <span className="mt-body-sm block" style={{ fontWeight: 700, color: 'var(--t-title)' }}>{label}</span>
+        <span className="mt-body-sm block mt-0.5" style={{ color: 'var(--t-faint)', fontSize: 11.5, lineHeight: 1.4 }}>{hint}</span>
+      </button>
+      {children}
+    </div>
   )
 }

--- a/ui/components/plan/useTaskComposer.ts
+++ b/ui/components/plan/useTaskComposer.ts
@@ -46,6 +46,10 @@ export interface ComposerState {
   issueType: string
   /** `'local'` = personal, or a provider id to file a real ticket. */
   target: string
+  /** The provider the "on your board" option is currently pointed at, remembered
+   *  across a trip through Personal so flipping back doesn't silently re-pick the
+   *  first tracker. Null until the user has chosen one. Never `'local'`. */
+  boardProvider: string | null
   phase: ComposerPhase
   /** True once a draft landed and the user hasn't edited the field yet - drives the
    *  small "Drafted" chip. Cleared per-field on first keystroke. */
@@ -68,6 +72,7 @@ const EMPTY: ComposerState = Object.freeze({
   // shared team board is outward-facing and hard to undo, so it must be a deliberate
   // click rather than what a mis-tap does on a morning planning screen.
   target: LOCAL_PROVIDER,
+  boardProvider: null,
   phase: 'idle' as ComposerPhase,
   titleDrafted: false,
   descriptionDrafted: false,
@@ -102,7 +107,30 @@ export const setTitle = (title: string) => patch({ title, titleDrafted: false })
 export const setDescription = (description: string) =>
   patch({ description, descriptionDrafted: false })
 export const setIssueType = (issueType: string) => patch({ issueType })
-export const setTarget = (target: string) => patch({ target })
+/** Point the composer at Personal or at one specific provider.
+ *
+ *  Picking a provider also remembers it as the board choice, so the "on your board"
+ *  option stays on the tracker the user last chose rather than snapping back to
+ *  whichever tracker happens to sort first. */
+export const setTarget = (target: string) =>
+  patch(target === LOCAL_PROVIDER ? { target } : { target, boardProvider: target })
+
+/** Which provider the board option represents right now, given the trackers that are
+ *  actually connected.
+ *
+ *  Falls back to the first connected tracker when nothing has been chosen yet, and ALSO
+ *  when the remembered choice is no longer connected - a tracker can be disconnected in
+ *  Settings while the composer sits open, and filing at a dead provider would fail at
+ *  the daemon with nothing the user could have seen coming. Returns null only when there
+ *  is no tracker at all, in which case no board option is offered. */
+export const boardProviderFor = (s: ComposerState, trackerIds: string[]): string | null => {
+  if (trackerIds.length === 0) return null
+  if (s.boardProvider && trackerIds.includes(s.boardProvider)) return s.boardProvider
+  return trackerIds[0]
+}
+
+/** True when the composer will file a real ticket (as opposed to keeping it personal). */
+export const isBoardTarget = (s: ComposerState): boolean => s.target !== LOCAL_PROVIDER
 
 /** Wipe the composer back to a blank slate (on open, and after a successful create). */
 export const resetComposer = () => {

--- a/ui/components/timeline/DayTaskDetailPanel.tsx
+++ b/ui/components/timeline/DayTaskDetailPanel.tsx
@@ -20,7 +20,8 @@ import { useEffect, useState } from 'react'
 import { fmtDur, PROVIDER_META, ProviderGlyph } from '@/components/atoms'
 import { GeneratingBar } from '@/components/GeneratingBar'
 import { load } from '@/lib/bridge'
-import { connectedTrackerNames } from '@/lib/integrations'
+import { connectedTrackers, trackerName as providerName } from '@/lib/integrations'
+import type { Tracker } from '@/lib/integrations'
 import type { DayTaskWorklogDraft, IntegrationsResponse } from '@/lib/api-types'
 import { clockLabel, clockLabelFromIso, type LaidSegment } from './dayTaskLayout'
 import type { SettingsSection } from './settings/types'
@@ -74,7 +75,10 @@ export function DayTaskDetailPanel({ detail, onClose, onOpenSettings, onOpenTask
       .catch(() => {})
     return () => { alive = false }
   }, [])
-  const trackers = connectedTrackerNames(integrations)
+  // Objects for the propose-branch board picker, names for the CTA copy. One read,
+  // two shapes - never a second get_integrations call that could disagree.
+  const connected = connectedTrackers(integrations)
+  const trackers = connected.map(t => t.name)
 
   return (
     <div className="dt-detail h-full flex flex-col">
@@ -93,8 +97,9 @@ export function DayTaskDetailPanel({ detail, onClose, onOpenSettings, onOpenTask
         )}
 
         {wl.draft && (
-          <DraftPreview draft={wl.draft} hue={hue} onOpenTask={onOpenTask}
-            busy={wl.phase === 'generating' || wl.phase === 'approving'} onDismiss={wl.dismiss} />
+          <DraftPreview draft={wl.draft} hue={hue} onOpenTask={onOpenTask} trackers={connected}
+            busy={wl.phase === 'generating' || wl.phase === 'approving'} onDismiss={wl.dismiss}
+            onSetProvider={wl.setProvider} />
         )}
       </div>
 
@@ -171,10 +176,13 @@ function SegmentList({ segments, hue }: { segments: LaidSegment[]; hue: string }
 // ── Worklog: draft preview (scrolls) + pinned action footer ──────────────────
 
 /** The generated worklog draft — preview only; the actions live in the footer. */
-function DraftPreview({ draft, hue, busy, onOpenTask, onDismiss }: {
+function DraftPreview({ draft, hue, busy, trackers, onOpenTask, onDismiss, onSetProvider }: {
   draft: DayTaskWorklogDraft; hue: string; busy: boolean
+  /** Connected trackers, for the propose branch's board picker. */
+  trackers: Tracker[]
   onOpenTask: (key: string, title?: string) => void
   onDismiss: (taskKey: string) => void
+  onSetProvider: (provider: string) => void
 }) {
   // No link chip here: the tickets are already named twice below — by DraftTargets
   // ("Comment on KAN-12 · 87% match") before you post, and by the footer's
@@ -193,7 +201,8 @@ function DraftPreview({ draft, hue, busy, onOpenTask, onDismiss }: {
       </div>
       <div className="rounded-xl p-4 space-y-3"
         style={{ border: `1px solid color-mix(in srgb, ${hue} 26%, transparent)`, background: `color-mix(in srgb, ${hue} 5%, var(--t-card))` }}>
-        <DraftTargets draft={draft} busy={busy} onOpenTask={onOpenTask} onDismiss={onDismiss} />
+        <DraftTargets draft={draft} busy={busy} trackers={trackers} onOpenTask={onOpenTask}
+          onDismiss={onDismiss} onSetProvider={onSetProvider} />
         {draft.update.summary && (
           <p className="mt-body-sm" style={{ color: 'var(--t-title)', fontSize: 12.5, lineHeight: 1.55 }}>{draft.update.summary}</p>
         )}
@@ -428,7 +437,9 @@ function ConfirmPost({ draft, busy, approving, onApprove, onCancel }: {
     <div className="space-y-2">
       <p className="mt-body-sm text-center" style={{ color: 'var(--t-muted)', fontSize: 12.5 }}>
         {draft.propose
-          ? `Create a new ${draft.propose.issue_type} and post this update?`
+          // Names the board too: creating a ticket is outward-facing and can't be
+          // undone, and with two trackers connected "a new Task" doesn't say where.
+          ? `Create a new ${draft.propose.issue_type} in ${providerName(draft.provider)} and post this update?`
           : `Post this update to ${where || 'the tracker'}?`}
       </p>
       <div className="flex items-center gap-2">

--- a/ui/components/timeline/MeridianTimelineShell.tsx
+++ b/ui/components/timeline/MeridianTimelineShell.tsx
@@ -84,7 +84,7 @@ export default function MeridianTimelineShell() {
   const [worklogPrompted, setWorklogPrompted] = useState<boolean | null>(null)
 
   const data = useTimelineData(day)
-  const { items, isSolo, connectedProviderName, connectedProviderId, isToday, integrations } = data
+  const { items, isSolo, connectedProviderName, connectedProviderIds, isToday, integrations } = data
   const pendingCount = items.filter(isPending).length
   const hasTracker = !!integrations && !isSolo
 
@@ -204,7 +204,7 @@ export default function MeridianTimelineShell() {
         onShiftDay={shift}
         isSolo={isSolo}
         connectedProviderName={connectedProviderName}
-        connectedProviderId={connectedProviderId}
+        connectedProviderIds={connectedProviderIds}
         onOpenSettings={(section) => { setSettingsSection(section); setActiveModal('settings') }}
         onOpenReport={() => setActiveModal('report')}
         showLlmLab={channel === 'dev'}

--- a/ui/components/timeline/Toolbar.tsx
+++ b/ui/components/timeline/Toolbar.tsx
@@ -30,7 +30,7 @@ import { ProviderIcon } from '@/components/ProviderIcon'
 import type { SettingsSection } from './settings/types'
 
 export function Toolbar({
-  day, isToday, onShiftDay, isSolo, connectedProviderName, connectedProviderId, onOpenSettings, onOpenReport, onOpenWhatsNew, onOpenSummary,
+  day, isToday, onShiftDay, isSolo, connectedProviderName, connectedProviderIds, onOpenSettings, onOpenReport, onOpenWhatsNew, onOpenSummary,
   showLlmLab = false, onOpenLlmLab,
 }: {
   day: string
@@ -38,7 +38,8 @@ export function Toolbar({
   onShiftDay: (delta: number) => void
   isSolo: boolean
   connectedProviderName: string | null
-  connectedProviderId: string | null
+  /** Every connected provider - each one gets its brand mark in the pill. */
+  connectedProviderIds: string[]
   onOpenSettings: (section?: SettingsSection) => void
   onOpenReport: () => void
   onOpenWhatsNew: () => void
@@ -107,8 +108,10 @@ export function Toolbar({
         <span className="w-px h-5" style={{ background: 'var(--t-hair)' }} />
         <span className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 bg-ctrl"
           style={{ border: '1px solid var(--t-ctrl-border)' }}>
-          {connectedProviderId
-            ? <ProviderIcon provider={connectedProviderId} size={12} />
+          {connectedProviderIds.length > 0
+            ? <span className="inline-flex items-center gap-1">
+                {connectedProviderIds.map(id => <ProviderIcon key={id} provider={id} size={12} />)}
+              </span>
             : <span className="inline-block w-1.5 h-1.5 rounded-full"
                 style={{ background: isSolo ? 'var(--t-faint)' : 'var(--color-state-proposal)' }} />}
           <span className="mt-body-sm" style={{ color: 'var(--t-muted)' }}>{connectionLabel}</span>

--- a/ui/components/timeline/WorklogTargets.tsx
+++ b/ui/components/timeline/WorklogTargets.tsx
@@ -12,6 +12,9 @@
 'use client'
 
 import type { DayTaskWorklogDraft, WorklogTarget } from '@/lib/api-types'
+import type { Tracker } from '@/lib/integrations'
+import { ProviderIcon } from '@/components/ProviderIcon'
+import { trackerName } from '@/lib/integrations'
 
 /** Where the update will land: every matched ticket, or the proposed new one.
  *
@@ -19,13 +22,20 @@ import type { DayTaskWorklogDraft, WorklogTarget } from '@/lib/api-types'
  *  percentage. The model's confidence is clamped to 1.0 on the way in, so a manual
  *  pick would otherwise render as "100% match" - the AI taking credit for a
  *  decision it did not make. */
-export function DraftTargets({ draft, busy, onOpenTask, onDismiss }: {
+export function DraftTargets({ draft, busy, trackers, onOpenTask, onDismiss, onSetProvider }: {
   draft: DayTaskWorklogDraft
   busy: boolean
+  /** Connected trackers. 0 or 1 means there is no board choice to offer. */
+  trackers: Tracker[]
   onOpenTask: (key: string, title?: string) => void
   onDismiss: (taskKey: string) => void
+  onSetProvider: (provider: string) => void
 }) {
   if (draft.propose) {
+    // The provider a proposal carries is assigned as "the first configured tracker"
+    // at generate time - a coin toss for anyone on two boards, and creating a ticket
+    // is not undoable. So when there IS a choice, it is shown up front rather than
+    // discovered afterwards in the tracker it landed on.
     return (
       <div className="rounded-lg px-3 py-2" style={{ background: 'color-mix(in srgb, var(--color-state-pending) 12%, transparent)' }}>
         <p className="mt-body-sm" style={{ color: 'var(--color-state-pending)', fontSize: 12, fontWeight: 700 }}>
@@ -34,6 +44,7 @@ export function DraftTargets({ draft, busy, onOpenTask, onDismiss }: {
         {draft.propose.description && (
           <p className="mt-body-sm mt-1" style={{ color: 'var(--t-muted)', fontSize: 11.5, lineHeight: 1.45 }}>{draft.propose.description}</p>
         )}
+        <ProposeProvider draft={draft} trackers={trackers} busy={busy} onSetProvider={onSetProvider} />
       </div>
     )
   }
@@ -56,6 +67,73 @@ export function DraftTargets({ draft, busy, onOpenTask, onDismiss }: {
           onOpen={() => onOpenTask(t.task_key, t.task_title ?? undefined)}
           onDismiss={() => onDismiss(t.task_key)} />
       ))}
+    </div>
+  )
+}
+
+/** Whether the user may still choose the board a PROPOSED ticket is created on.
+ *
+ *  All three conditions are load-bearing:
+ *  - a proposal (not a match): a matched draft's provider is per-target, and the
+ *    core command refuses to set a draft-level one;
+ *  - still `drafted`: once approved the ticket may already exist on the old board,
+ *    and re-pointing the row would make it name a tracker the ticket is not on;
+ *  - two or more trackers: with one there is no choice, only a label.
+ *
+ *  Exported for its unit tests - the repo has no React render harness, so the rule
+ *  is tested here rather than through the component. */
+export function canPickProposalProvider(
+  draft: Pick<DayTaskWorklogDraft, 'propose' | 'state'>,
+  trackerCount: number,
+): boolean {
+  return draft.propose !== null && draft.state === 'drafted' && trackerCount >= 2
+}
+
+/** Which board a proposed ticket gets created on.
+ *
+ *  Renders as a STATEMENT when there's nothing to decide - one tracker connected, or
+ *  the draft already approved and the ticket already filed - and as a picker only
+ *  when the choice is both real and still open. A radiogroup of chips rather than a
+ *  select: two or three trackers all fit, and seeing the alternative is the point. */
+function ProposeProvider({ draft, trackers, busy, onSetProvider }: {
+  draft: DayTaskWorklogDraft
+  trackers: Tracker[]
+  busy: boolean
+  onSetProvider: (provider: string) => void
+}) {
+  if (!canPickProposalProvider(draft, trackers.length)) {
+    return (
+      <p className="mt-body-sm mt-2 inline-flex items-center gap-1.5" style={{ color: 'var(--t-faint)', fontSize: 11.5 }}>
+        <ProviderIcon provider={draft.provider} size={11} />
+        {draft.created_task_key ? 'Created in' : 'Will be created in'} {trackerName(draft.provider)}
+      </p>
+    )
+  }
+
+  return (
+    <div className="mt-2">
+      <p className="mt-label mb-1" style={{ color: 'var(--t-faint)' }}>Create it in</p>
+      <div role="radiogroup" aria-label="Which tracker to create this ticket in" className="flex flex-wrap gap-1.5">
+        {trackers.map(t => {
+          const picked = draft.provider === t.id
+          return (
+            <button key={t.id} role="radio" aria-checked={picked} disabled={busy}
+              onClick={() => onSetProvider(t.id)}
+              className="mt-chip inline-flex items-center gap-1.5 px-2 py-1 rounded-md transition-colors"
+              style={{
+                border: `1px solid ${picked ? 'var(--color-state-pending)' : 'var(--t-ctrl-border)'}`,
+                background: picked ? 'color-mix(in srgb, var(--color-state-pending) 16%, transparent)' : 'var(--t-ctrl)',
+                color: picked ? 'var(--t-title)' : 'var(--t-faint)',
+                fontWeight: picked ? 700 : 500,
+                opacity: busy ? 0.55 : 1,
+                cursor: busy ? 'default' : 'pointer',
+              }}>
+              <ProviderIcon provider={t.id} size={12} />
+              {t.name}
+            </button>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/ui/components/timeline/useTimelineData.ts
+++ b/ui/components/timeline/useTimelineData.ts
@@ -218,15 +218,17 @@ export function useTimelineData(day: string) {
 
   const hourBuckets = useMemo(() => bucketByHour(items), [items])
 
-  // Solo iff no tracker is connected; connectedProviderName/Id are the single
-  // connected provider's display name/id when EXACTLY one is on, else null.
-  const { isSolo, connectedProviderName, connectedProviderId } = useMemo(() => {
-    if (!integrations) return { isSolo: false, connectedProviderName: null as string | null, connectedProviderId: null as string | null }
+  // Solo iff no tracker is connected. connectedProviderIds lists EVERY connected
+  // provider (registry order, so the toolbar pill and the Settings banner agree);
+  // connectedProviderName is the display name only when exactly one is on, since
+  // the pill falls back to a generic "Connected" label once there are several.
+  const { isSolo, connectedProviderName, connectedProviderIds } = useMemo(() => {
+    if (!integrations) return { isSolo: false, connectedProviderName: null as string | null, connectedProviderIds: [] as TrackerId[] }
     const on = PROVIDER_IDS.filter(id => integrations[id])
     return {
       isSolo: on.length === 0,
       connectedProviderName: on.length === 1 ? TRACKER_BY_ID[on[0]].name : null,
-      connectedProviderId: on.length === 1 ? on[0] : null,
+      connectedProviderIds: on,
     }
   }, [integrations])
 
@@ -248,7 +250,7 @@ export function useTimelineData(day: string) {
   return {
     items, hourBuckets, counts, loading, busy, isToday, day, draftedIds,
     act, reject, saveEdit, rematch, proposedAct, saveProposedTitle, saveProposedBody, approveAll,
-    actions, integrations, isSolo, connectedProviderName, connectedProviderId, tasks, cleanupIssueCount, today,
+    actions, integrations, isSolo, connectedProviderName, connectedProviderIds, tasks, cleanupIssueCount, today,
     hourStatus, capturing, hourReports, refetchTasks,
   }
 }

--- a/ui/components/timeline/useWorklog.ts
+++ b/ui/components/timeline/useWorklog.ts
@@ -50,6 +50,9 @@ export interface WorklogState {
   retarget: (taskKey: string) => void
   /** Drop one ticket the AI matched, keeping the rest. */
   dismiss: (taskKey: string) => void
+  /** Choose which connected tracker a PROPOSED new ticket is created on. A no-op
+   *  on a matched draft, where each target carries its own provider. */
+  setProvider: (provider: string) => void
 }
 
 const errMsg = (e: unknown): string =>
@@ -166,6 +169,29 @@ function runDismiss(day: string, taskId: string, taskKey: string) {
     .catch((e) => patch(key, { phase: 'idle', error: errMsg(e) }))
 }
 
+/** Choose which tracker a PROPOSED new ticket gets created on.
+ *
+ *  Only meaningful on the propose branch: a matched draft's provider is per-ticket
+ *  and the command refuses there. Like retarget/dismiss it's a plain DB write, so it
+ *  reuses the `approving` phase - "a write is in flight, don't touch the draft" - and
+ *  renders from the updated draft the server returns. */
+function runSetProvider(day: string, taskId: string, provider: string) {
+  const key = keyOf(day, taskId)
+  const cur = store.get(key)
+  if (cur?.phase === 'approving' || cur?.phase === 'generating') return
+  // Already there — skipping the round-trip keeps a tap on the selected chip from
+  // flickering the panel through a write state for no change.
+  if (cur?.draft?.provider === provider) return
+  patch(key, { phase: 'approving', error: null })
+  mutate<DayTaskWorklogDraft>(API, 'set_worklog_provider', {
+    day,
+    task_id: taskId,
+    provider,
+  })
+    .then((r) => patch(key, { draft: r, phase: 'idle', loaded: true, error: r.error ?? null }))
+    .catch((e) => patch(key, { phase: 'idle', error: errMsg(e) }))
+}
+
 /** Retarget the draft at a user-picked ticket. Unlike generate this is a plain DB
  *  write (no LLM, no CLI spawn), so it resolves in milliseconds — but it still
  *  goes through the store, because the panel can unmount mid-flight like anything
@@ -229,6 +255,13 @@ export function useWorklog(day: string, taskId: string): WorklogState {
     dismiss: (taskKey: string) => {
       setConfirming(false)
       runDismiss(day, taskId, taskKey)
+    },
+    // Changing where a proposed ticket lands invalidates a pending confirm: the
+    // user is now agreeing to create it on a different board than the one the
+    // confirm prompt named.
+    setProvider: (provider: string) => {
+      setConfirming(false)
+      runSetProvider(day, taskId, provider)
     },
   }
 }

--- a/ui/lib/integrations.ts
+++ b/ui/lib/integrations.ts
@@ -158,6 +158,15 @@ export function connectedTrackers(integrations: IntegrationsResponse | null): Tr
   return TRACKERS.filter(t => int[t.id])
 }
 
+/** A provider id's display name (`'azure_devops'` → `'Azure DevOps'`).
+ *
+ *  Falls back to the raw id rather than throwing or rendering nothing: an id the
+ *  registry doesn't know is a backend that got ahead of the UI, and showing
+ *  `some_tracker` beats showing an empty gap where the board name should be. */
+export function trackerName(id: string): string {
+  return TRACKER_BY_ID[id as TrackerId]?.name ?? id
+}
+
 /** The display names of the PM trackers currently connected (e.g. `['Jira']`),
  *  in `TRACKERS` order. `null` integrations (still loading) yields `[]`. Used to
  *  name the tracker in copy and to decide whether any tracker is connected. */


### PR DESCRIPTION
## Why

With Jira and GitHub both connected, a proposed worklog ticket was always filed at `config.pm_providers.first()` (`src/pm_worklog/generate.rs:126`) - so **every** new task landed in Jira, and nothing in the UI let the user say otherwise.

The task card's corner icon was a symptom, not a separate bug: it already reads `posted_provider`, the board the worklog actually landed on, and was honestly reporting Jira every time. Fixing where proposals go fixes the icon for free.

## What changed

**Pick the board for a proposed ticket**
- `set_draft_provider` (meridian-core) re-points a still-`drafted` **proposal** at another tracker. Scoped to the propose branch - a matched draft's provider is carried per-target - and refuses once `approved`/`posted`, since the ticket may already exist on the old board.
- `set_worklog_provider` (tray) **validates the id against the connected trackers** rather than trusting the frontend, per the rule `retarget_day_task_worklog` already states. It can't come from `pm_tasks` here (a proposed ticket doesn't exist yet), so `connected_from_env` is split out of `get_integrations` for it - with the OAuth-file probe injected, so the two OAuth-backed trackers aren't decided by files under the real `$HOME`.
- The draft preview offers the picker only when the choice is real and still open, and states the board otherwise ("Will be created in Jira" / "Created in GitHub"). The post-confirm names it too - creating a ticket is outward-facing and can't be undone.

**One board option in the task composer**
The `Create in Jira` / `Create in GitHub` rows collapse into a single "Create on your board" option with the tracker picker inside it (it still names the tracker directly when only one is connected). A tracker disconnected mid-compose re-points instead of filing blind.

**Header pill shows every connected provider**
It previously rendered a brand mark only when exactly one tracker was connected, and a bare dot otherwise.

## Scope note

Forward-looking: cards already posted to Jira keep their Jira icon. This changes where *new* proposals go - it does not rewrite history.

## Tests - 54 new

- 7 DB tests for `set_draft_provider`: repoint, idempotent re-selection, stale-error clearing, and all four refusals (match draft, approved, posted, missing row).
- 7 for `connected_from_env`, including that `.env.example` placeholders don't count as connected and that provider order matches the UI's.
- 40 TS across three specs - the composer's board target, the propose-provider picker, and the toolbar pill.

Full suite green: 719 Rust + 312 bun + tsc + `npm run build`. Pre-push passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)