### PR TITLE
feat(ui): show a brand mark for every connected tracker in the toolbar pill

### DIFF
--- a/ui/components/timeline/MeridianTimelineShell.tsx
+++ b/ui/components/timeline/MeridianTimelineShell.tsx
@@ -84,7 +84,7 @@ export default function MeridianTimelineShell() {
   const [worklogPrompted, setWorklogPrompted] = useState<boolean | null>(null)
 
   const data = useTimelineData(day)
-  const { items, isSolo, connectedProviderName, connectedProviderId, isToday, integrations } = data
+  const { items, isSolo, connectedProviderName, connectedProviderIds, isToday, integrations } = data
   const pendingCount = items.filter(isPending).length
   const hasTracker = !!integrations && !isSolo
 
@@ -204,7 +204,7 @@ export default function MeridianTimelineShell() {
         onShiftDay={shift}
         isSolo={isSolo}
         connectedProviderName={connectedProviderName}
-        connectedProviderId={connectedProviderId}
+        connectedProviderIds={connectedProviderIds}
         onOpenSettings={(section) => { setSettingsSection(section); setActiveModal('settings') }}
         onOpenReport={() => setActiveModal('report')}
         showLlmLab={channel === 'dev'}

--- a/ui/components/timeline/Toolbar.tsx
+++ b/ui/components/timeline/Toolbar.tsx
@@ -30,7 +30,7 @@ import { ProviderIcon } from '@/components/ProviderIcon'
 import type { SettingsSection } from './settings/types'
 
 export function Toolbar({
-  day, isToday, onShiftDay, isSolo, connectedProviderName, connectedProviderId, onOpenSettings, onOpenReport, onOpenWhatsNew, onOpenSummary,
+  day, isToday, onShiftDay, isSolo, connectedProviderName, connectedProviderIds, onOpenSettings, onOpenReport, onOpenWhatsNew, onOpenSummary,
   showLlmLab = false, onOpenLlmLab,
 }: {
   day: string
@@ -38,7 +38,8 @@ export function Toolbar({
   onShiftDay: (delta: number) => void
   isSolo: boolean
   connectedProviderName: string | null
-  connectedProviderId: string | null
+  /** Every connected provider - each one gets its brand mark in the pill. */
+  connectedProviderIds: string[]
   onOpenSettings: (section?: SettingsSection) => void
   onOpenReport: () => void
   onOpenWhatsNew: () => void
@@ -107,8 +108,10 @@ export function Toolbar({
         <span className="w-px h-5" style={{ background: 'var(--t-hair)' }} />
         <span className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 bg-ctrl"
           style={{ border: '1px solid var(--t-ctrl-border)' }}>
-          {connectedProviderId
-            ? <ProviderIcon provider={connectedProviderId} size={12} />
+          {connectedProviderIds.length > 0
+            ? <span className="inline-flex items-center gap-1">
+                {connectedProviderIds.map(id => <ProviderIcon key={id} provider={id} size={12} />)}
+              </span>
             : <span className="inline-block w-1.5 h-1.5 rounded-full"
                 style={{ background: isSolo ? 'var(--t-faint)' : 'var(--color-state-proposal)' }} />}
           <span className="mt-body-sm" style={{ color: 'var(--t-muted)' }}>{connectionLabel}</span>

--- a/ui/components/timeline/useTimelineData.ts
+++ b/ui/components/timeline/useTimelineData.ts
@@ -218,15 +218,17 @@ export function useTimelineData(day: string) {
 
   const hourBuckets = useMemo(() => bucketByHour(items), [items])
 
-  // Solo iff no tracker is connected; connectedProviderName/Id are the single
-  // connected provider's display name/id when EXACTLY one is on, else null.
-  const { isSolo, connectedProviderName, connectedProviderId } = useMemo(() => {
-    if (!integrations) return { isSolo: false, connectedProviderName: null as string | null, connectedProviderId: null as string | null }
+  // Solo iff no tracker is connected. connectedProviderIds lists EVERY connected
+  // provider (registry order, so the toolbar pill and the Settings banner agree);
+  // connectedProviderName is the display name only when exactly one is on, since
+  // the pill falls back to a generic "Connected" label once there are several.
+  const { isSolo, connectedProviderName, connectedProviderIds } = useMemo(() => {
+    if (!integrations) return { isSolo: false, connectedProviderName: null as string | null, connectedProviderIds: [] as TrackerId[] }
     const on = PROVIDER_IDS.filter(id => integrations[id])
     return {
       isSolo: on.length === 0,
       connectedProviderName: on.length === 1 ? TRACKER_BY_ID[on[0]].name : null,
-      connectedProviderId: on.length === 1 ? on[0] : null,
+      connectedProviderIds: on,
     }
   }, [integrations])
 
@@ -248,7 +250,7 @@ export function useTimelineData(day: string) {
   return {
     items, hourBuckets, counts, loading, busy, isToday, day, draftedIds,
     act, reject, saveEdit, rematch, proposedAct, saveProposedTitle, saveProposedBody, approveAll,
-    actions, integrations, isSolo, connectedProviderName, connectedProviderId, tasks, cleanupIssueCount, today,
+    actions, integrations, isSolo, connectedProviderName, connectedProviderIds, tasks, cleanupIssueCount, today,
     hourStatus, capturing, hourReports, refetchTasks,
   }
 }


### PR DESCRIPTION
## What

The toolbar connection pill previously rendered a provider icon only when **exactly one** tracker was connected — with two or more connected, it fell back to a plain status dot. This tracks **every** connected provider and renders each one's brand mark in the pill.

## Changes

- `useTimelineData.ts` — replaces `connectedProviderId: string | null` with `connectedProviderIds: TrackerId[]` (registry order, so the pill and the Settings banner agree). `connectedProviderName` still resolves only when exactly one is on, since the pill uses a generic "Connected" label beyond that.
- `Toolbar.tsx` — renders one `<ProviderIcon>` per connected id; falls back to the status dot only when none are connected.
- `MeridianTimelineShell.tsx` — threads the new prop through.

## Testing

Pre-push suite passed (fmt + clippy + UI build + UI tests + cargo test + security audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)