### PR TITLE
perf(ci): sub-10-minute staging builds - warm cache on main, skip staging notarization

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,0 +1,151 @@
+name: Cache warm (macOS release)
+
+# SEEDS THE RELEASE COMPILE CACHE ON `main`. SHIPS NOTHING.
+#
+# ── WHY THIS EXISTS ──────────────────────────────────────────────────────────
+#
+# Because release-build.yml is triggered by a TAG, and GitHub scopes Actions
+# caches by ref. A workflow run may restore caches created in
+#
+#     • its own ref, or
+#     • the DEFAULT branch (main)
+#
+# and nothing else. It cannot read a sibling tag's cache, and it cannot read
+# pre-main's.
+#
+# Every release cuts a NEW tag (v1.72.0-staging.6, .7, .8 …), so each build
+# saved its 1.45GB cache under its own tag ref and the next tag started from
+# nothing. Measured on run 29812896206: `Compile daemon + tray` took
+# 1495s — ~25 of the 24-minute build. Notarization, by contrast, was 79s. The
+# cold compile IS the build time; everything else is rounding error.
+#
+# The fix is to make a release-shaped cache exist on the DEFAULT branch, which
+# every tag build can read. Nothing else on main produces one: release-build
+# runs on tags (saves to tag scope) and ci.yml compiles a different profile
+# under a different shared-key. Hence this job — its ONLY output is a warm
+# cache under `refs/heads/main`.
+#
+# ── WHY IT COMPILES THE SAME WAY release-build DOES ──────────────────────────
+#
+# rust-cache keys on the shared-key + runner + toolchain + lockfile, and the
+# cache is only useful if the target/ it saves matches the fingerprints a
+# release build will look for. So this mirrors release-build.yml's macOS job
+# exactly: same runner, same pinned toolchain, same target triple, the same two
+# cargo invocations, the same shared-key. Change that job's compile step and
+# you must change this one, or the cache silently stops matching and every
+# release quietly goes cold again — the failure is invisible, it just gets slow.
+#
+# It deliberately does NOT sign, notarize, bundle or publish. It is a compile
+# and a cache write.
+
+on:
+  # Every push to main re-seeds the cache with whatever production is at, so a
+  # release cut minutes later is warm.
+  push:
+    branches: [main]
+  # Nightly, so staging tags stay warm even during a long stretch with no
+  # production release. 04:00 UTC — off-peak for GitHub's macOS runner pool.
+  schedule:
+    - cron: "0 4 * * *"
+  # For seeding on demand (e.g. right after this lands, rather than waiting for
+  # the first nightly).
+  workflow_dispatch:
+
+# One warm at a time. Two would race to write the same cache key and the loser's
+# upload is wasted; never cancel a run that may be mid-save.
+concurrency:
+  group: cache-warm
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  SQLX_OFFLINE: "true"
+  CARGO_INCREMENTAL: "0"
+  CARGO_NET_RETRY: "3"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
+jobs:
+  warm:
+    name: Warm the aarch64 release cache
+    runs-on: macos-26
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Authenticate git for the private screenpipe-fork dependency
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          git config --global \
+            url."https://x-access-token:${GH_TOKEN}@github.com/Meridiona/screenpipe-fork".insteadOf \
+            "https://github.com/Meridiona/screenpipe-fork"
+
+      - name: Install Rust 1.93.1
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.93.1"
+          targets: aarch64-apple-darwin
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # MUST match release-build.yml's macOS job byte for byte — this is the
+          # whole point of the workflow. `add-job-id-key: false` keeps the key
+          # free of this job's name so release-build computes the same one.
+          add-job-id-key: false
+          shared-key: macos-release-aarch64-apple-darwin
+          cache-directories: |
+            ~/.cargo/registry/src
+          # Unconditional: this job only ever runs on main (push/schedule) or by
+          # hand, and writing the main-scoped cache is its entire purpose.
+          save-if: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: |
+            ui/package-lock.json
+            tray/package-lock.json
+
+      - name: Install UI + tray deps
+        # `tauri build` runs the UI build as its beforeBuildCommand, so the node
+        # deps are a prerequisite of compiling at all.
+        run: |
+          (cd ui && npm ci --no-audit --no-fund)
+          (cd tray && npm ci --no-audit --no-fund)
+
+      - name: Stub the daemon so tauri-build's resource check passes
+        # tauri-build only STATS bundle.resources during compilation; a
+        # zero-byte placeholder satisfies it. Same trick as ci.yml and
+        # release-build.yml.
+        run: |
+          mkdir -p target/release
+          : > target/release/meridian
+
+      - name: Compile daemon + tray (aarch64-apple-darwin)
+        working-directory: tray
+        # IDENTICAL to release-build.yml's compile step. Two invocations, for the
+        # reason documented there: `tauri build` injects
+        # `--features tauri/custom-protocol`, which cargo cannot apply to the
+        # `-p meridian` scope (no tauri dependency), so the two crates cannot
+        # share one invocation.
+        run: |
+          cargo build --release --locked --target aarch64-apple-darwin \
+            -p meridian --bin meridian
+          npx tauri build --no-bundle --target aarch64-apple-darwin \
+            --config src-tauri/tauri.staging.conf.json
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Cache warm"
+            echo "Seeded \`macos-release-aarch64-apple-darwin\` under \`refs/heads/main\`."
+            echo ""
+            echo "Tag-triggered release builds restore from the default branch, so"
+            echo "staging and production tags both start warm."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -258,9 +258,25 @@ jobs:
       # Signing + updater material. TAURI_SIGNING_* is consumed at BUNDLE time.
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      # SIGNING is unconditional — an updated app is still Gatekeeper-checked
+      # against its Developer ID signature when it relaunches, on every channel.
       APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-      APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+      # NOTARIZATION IS STABLE-ONLY. `tauri bundle` notarizes the .app only when
+      # it finds these two, so blanking them on staging turns the bundle step
+      # into sign-without-notarize.
+      #
+      # Why that is safe on staging and NOT on stable: Gatekeeper only enforces
+      # notarization on a QUARANTINED app, and the quarantine flag is set by the
+      # thing that downloaded it — a browser. Staging is delivered exclusively by
+      # tauri-plugin-updater, which unpacks the tarball itself and sets no
+      # quarantine flag, so the relaunched app is verified on its signature (and
+      # the updater's own minisign key) and never consults a notarization ticket.
+      # Stable ships a DMG that new users download in a browser, which IS
+      # quarantined — dropping notarization there would give every new user
+      # "Apple cannot check it for malicious software". Hence: staging skips,
+      # stable always notarizes.
+      APPLE_API_KEY: ${{ needs.prepare.outputs.channel == 'stable' && secrets.APPLE_API_KEY || '' }}
+      APPLE_API_ISSUER: ${{ needs.prepare.outputs.channel == 'stable' && secrets.APPLE_API_ISSUER || '' }}
       TAURI_BUNDLER_DMG_IGNORE_CI: "true"
       # Selects target/<triple>/release/bundle for every script below.
       MERIDIAN_TARGET: ${{ matrix.target }}
@@ -412,6 +428,10 @@ jobs:
             ${{ needs.prepare.outputs.channel == 'staging' && '--config src-tauri/tauri.staging.conf.json' || '' }}
 
       - name: Notarize and staple the DMG
+        # STABLE ONLY — staging is delivered by the updater, which never sets the
+        # quarantine flag, so no notarization ticket is ever consulted. See the
+        # APPLE_API_* note in this job's `env:` for the full reasoning.
+        if: needs.prepare.outputs.channel == 'stable'
         # A notarization ticket is keyed to the cdhash of what was submitted, so
         # the stapled .app inside does not cover the container. Without this the
         # DMG a user downloads trips "can't check it for malicious software".
@@ -431,8 +451,15 @@ jobs:
         # Independently re-checks signing, notarization, stapling and the
         # presence of the updater artifacts. A non-zero exit aborts while the
         # release is still a draft and nothing is publicly reachable.
+        #
+        # MERIDIAN_CHANNEL tells the script which assertions apply: on staging
+        # the notarized/stapled checks are skipped (nothing was notarized, by
+        # design) while every SIGNING check still runs — a staging build with a
+        # broken signature must still fail loudly, because the updater's
+        # relaunch depends on it.
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
+          MERIDIAN_CHANNEL: ${{ needs.prepare.outputs.channel }}
         run: bash scripts/verify-release-bundle.sh "$VERSION"
 
       - name: Upload this architecture's assets into the draft

--- a/scripts/verify-release-bundle.sh
+++ b/scripts/verify-release-bundle.sh
@@ -126,20 +126,45 @@ pass "app + bundled daemon: Developer ID (${TEAM_ID}), Hardened Runtime"
 codesign --verify --deep --strict "${APP}" 2>/dev/null || fail "codesign --verify --deep --strict failed on ${APP} — the bundle seal is broken"
 pass "bundle seal verifies (--deep --strict)"
 
-# 3c. Notarized + stapled: Gatekeeper must accept the app OFFLINE. `spctl`
-#     reports "Notarized Developer ID" only when a stapled ticket is present.
-_spctl="$(spctl --assess --type exec -vv "${APP}" 2>&1 || true)"
-grep -q "accepted" <<<"${_spctl}" || fail "Gatekeeper REJECTED ${APP}: ${_spctl}"
-grep -q "Notarized Developer ID" <<<"${_spctl}" || fail "${APP} is signed but NOT notarized (${_spctl}) — users get a Gatekeeper warning. Check the APPLE_API_* notarization secrets."
-xcrun stapler validate "${APP}" >/dev/null 2>&1 || fail "no stapled notarization ticket on ${APP} — first launch would need an online Gatekeeper check"
-pass "notarized + stapled (Gatekeeper accepts offline)"
+# 3c/3d. Notarization — STABLE ONLY.
+#
+# Gatekeeper enforces notarization only on a QUARANTINED app, and the quarantine
+# flag is set by whatever downloaded it — a browser. The two channels differ in
+# exactly that:
+#
+#   stable  — ships a DMG that new users download in a browser. Quarantined, so
+#             an un-notarized build gives every new user "Apple cannot check it
+#             for malicious software". Notarization is mandatory.
+#   staging — delivered ONLY by tauri-plugin-updater, which unpacks the tarball
+#             itself and sets no quarantine flag. The relaunched app is verified
+#             on its Developer ID signature (checked above, unconditionally) and
+#             the updater's minisign key. No notarization ticket is ever
+#             consulted, so submitting one costs build time and buys nothing.
+#
+# The SIGNING assertions above run on every channel and are the ones that matter
+# for staging: a broken signature breaks the updater's relaunch.
+if [[ "${MERIDIAN_CHANNEL:-stable}" == "stable" ]]; then
+    # Notarized + stapled: Gatekeeper must accept the app OFFLINE. `spctl`
+    # reports "Notarized Developer ID" only when a stapled ticket is present.
+    _spctl="$(spctl --assess --type exec -vv "${APP}" 2>&1 || true)"
+    grep -q "accepted" <<<"${_spctl}" || fail "Gatekeeper REJECTED ${APP}: ${_spctl}"
+    grep -q "Notarized Developer ID" <<<"${_spctl}" || fail "${APP} is signed but NOT notarized (${_spctl}) — users get a Gatekeeper warning. Check the APPLE_API_* notarization secrets."
+    xcrun stapler validate "${APP}" >/dev/null 2>&1 || fail "no stapled notarization ticket on ${APP} — first launch would need an online Gatekeeper check"
+    pass "notarized + stapled (Gatekeeper accepts offline)"
 
-# 3d. The DMG users actually download must itself be stapled.
-if [[ -f "${DMG}" ]]; then
-    xcrun stapler validate "${DMG}" >/dev/null 2>&1 || fail "no stapled notarization ticket on ${DMG} — the downloaded DMG would trip Gatekeeper"
-    pass "DMG stapled: $(basename "${DMG}")"
+    # The DMG users actually download must itself be stapled.
+    if [[ -f "${DMG}" ]]; then
+        xcrun stapler validate "${DMG}" >/dev/null 2>&1 || fail "no stapled notarization ticket on ${DMG} — the downloaded DMG would trip Gatekeeper"
+        pass "DMG stapled: $(basename "${DMG}")"
+    else
+        fail "${DMG} not found — package-updater.sh should have made the stable-named copy"
+    fi
 else
-    fail "${DMG} not found — package-updater.sh should have made the stable-named copy"
+    echo "  ~ skipping notarization checks (channel=${MERIDIAN_CHANNEL}) — updater-only delivery sets no quarantine flag"
+    # The DMG must still EXIST even unstapled: package-updater.sh produces the
+    # stable-named copy the manifest and the download link both point at.
+    [[ -f "${DMG}" ]] || fail "${DMG} not found — package-updater.sh should have made the stable-named copy"
+    pass "DMG present (unstapled, staging): $(basename "${DMG}")"
 fi
 
 # ── 2. updater artifacts — the silent-no-auto-update guard ───────────────────


### PR DESCRIPTION
## The problem, measured
On the last release (`v1.72.0-staging.6`, run 29812896206):

| Step | Time |
|---|---|
| **Compile daemon + tray** | **1495s (~25 min)** |
| Bundle + sign + notarize .app | 79s |
| Everything else | ~2 min |

**The cold compile is the build time.** Notarization is rounding error.

## Why it was cold every single time
`release-build` is **tag-triggered**, and GitHub scopes Actions caches by ref - a run restores only from **its own ref or the default branch**. Every release cuts a *new* tag, so the 1.45 GB cache saved under `refs/heads/refs/tags/v1.72.0-staging.6` was unreachable from `…staging.7`. Nothing on `main` carried a release-shaped cache either. Result: 25 min of compiling, every build, forever.

Cache quota made it worse - the repo sat at **12.16 GB against a 10 GB limit**, so GitHub was actively evicting. ~6.6 GB of obsolete Intel/Windows/universal caches have been deleted out-of-band.

## The fix
1. **`cache-warm.yml` (new)** - runs the *same two cargo invocations* as release-build's macOS job on push to `main` + nightly, saving `macos-release-aarch64-apple-darwin` under `refs/heads/main`. Tag builds restore from the default branch, so **staging and production tags both start warm**. Its compile step must stay in lockstep with release-build's or the cache silently stops matching.
2. **Staging skips notarization** - Gatekeeper enforces notarization only on a **quarantined** app, and the quarantine flag is set by the browser that downloads it. Staging is delivered *exclusively* by `tauri-plugin-updater`, which unpacks the tarball itself and sets no flag, so the relaunched app is verified on its **Developer ID signature** (still unconditional) plus the updater's **minisign** key. **Stable still fully notarizes** - new users download that DMG in a browser.
3. **`verify-release-bundle.sh`** - channel-aware: every signing assertion still runs on staging (a broken signature breaks the updater relaunch); only the notarized/stapled checks are skipped.

## Expected result
Staging: **~25 min cold → target <10 min warm.** Production is untouched by this PR.

## Note
The warm cache only exists after `cache-warm` runs once on `main`. I'll dispatch it manually after merge rather than wait for the first nightly.