### PR TITLE
fix(ci): bind the tag through env, stop persisting the checkout token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
       migrations: ${{ steps.f.outputs.migrations }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Nothing in this workflow pushes; don't leave the token in .git/config
+          # where any later step or third-party action could read it.
+          persist-credentials: false
       - uses: dorny/paths-filter@v3
         id: f
         with:
@@ -76,6 +80,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Nothing in this workflow pushes; don't leave the token in .git/config
+          # where any later step or third-party action could read it.
+          persist-credentials: false
 
       - name: Authenticate git for the private screenpipe-fork dependency
         # checkout's default GITHUB_TOKEN is scoped to THIS repo, so cargo's
@@ -132,6 +140,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Nothing in this workflow pushes; don't leave the token in .git/config
+          # where any later step or third-party action could read it.
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -180,6 +192,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Reject modified, renamed, or deleted migrations
         run: |
@@ -203,6 +216,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Nothing in this workflow pushes; don't leave the token in .git/config
+          # where any later step or third-party action could read it.
+          persist-credentials: false
 
       - name: Assert the screenpipe-fork git rev stays pinned to the last MIT-based commit
         run: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -164,6 +164,13 @@ jobs:
       - name: Assert the tag matches the committed version
         env:
           VERSION: ${{ steps.ctx.outputs.version }}
+          # Bound through env, never interpolated into `run:`. A tag name is a
+          # PUSHABLE ref — anyone who can push `v*` chooses this string, so
+          # expanding it into the shell would let a tag name carrying shell
+          # metacharacters execute on the runner. Same reason RAW_TAG above is
+          # bound rather than interpolated.
+          CHANNEL: ${{ steps.ctx.outputs.channel }}
+          TAG: ${{ steps.ctx.outputs.tag }}
         # The version is an INPUT to this pipeline, read from the repo, never
         # recomputed. This is the Zed/clash-verge guard: if the tag and the
         # manifests disagree we would build binaries stamped with one version
@@ -179,13 +186,13 @@ jobs:
         # config DOES commit the bump, can be checked.
         run: |
           set -euo pipefail
-          if [ "${{ steps.ctx.outputs.channel }}" != "stable" ]; then
+          if [ "${CHANNEL}" != "stable" ]; then
             echo "→ staging channel: version is stamped from the tag, nothing committed to compare"
             exit 0
           fi
           manifest="$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)"
           if [ "${manifest}" != "${VERSION}" ]; then
-            echo "::error::tag ${{ steps.ctx.outputs.tag }} does not match Cargo.toml version ${manifest}."
+            echo "::error::tag ${TAG} does not match Cargo.toml version ${manifest}."
             exit 1
           fi
           echo "✓ Cargo.toml version ${manifest} matches the tag"

--- a/meridian-core/src/readers/day_task_worklogs/mod.rs
+++ b/meridian-core/src/readers/day_task_worklogs/mod.rs
@@ -382,7 +382,28 @@ pub async fn upsert_draft(
 /// `WHERE state = 'drafted'` mirrors [`upsert_draft`]'s guard — once approved, the
 /// ticket may already exist on the old provider, and re-pointing the row would make
 /// it name a board the ticket is not on.
-#[tracing::instrument(skip(pool))]
+///
+/// # Parameters
+/// * `day_local` — local day key (`YYYY-MM-DD`), half of the row's composite key.
+/// * `task_id` — the day-task this draft belongs to; the other half of the key.
+/// * `provider` — tracker id to file the proposed ticket on. Validated against the
+///   CONNECTED trackers by the caller ([`crate::commands::set_worklog_provider`] in
+///   the tray) — this fn writes whatever it is handed.
+/// * `now` — RFC3339 timestamp written to `updated_at`; passed in so the core stays
+///   deterministic and testable.
+///
+/// # Returns
+/// The row as it stands after the update, re-read via `read_back`.
+///
+/// # Errors
+/// * The row is no longer `drafted` (already approved) — the message names the
+///   provider the ticket now lives on.
+/// * The row is a MATCH draft (`propose_title IS NULL`) — providers are per-target
+///   there, so there is nothing at draft level to set.
+///
+/// Both surface as an error rather than a silent no-op so the UI can explain why.
+/// Also clears `last_error`: the previous failure was against the old tracker.
+#[tracing::instrument(skip(pool), err)]
 pub async fn set_draft_provider(
     pool: &SqlitePool,
     day_local: &str,
@@ -418,7 +439,11 @@ pub async fn set_draft_provider(
             "this draft posts to tickets that already exist - each one lives on its own board"
         );
     }
-    tracing::info!(provider, "worklog: proposal tracker chosen by the user");
+    tracing::info!(
+        provider,
+        rows = res.rows_affected(),
+        "worklog: proposal tracker chosen by the user"
+    );
 
     read_back(pool, day_local, task_id).await
 }

--- a/tray/src-tauri/src/commands/dashboard.rs
+++ b/tray/src-tauri/src/commands/dashboard.rs
@@ -364,7 +364,7 @@ pub struct SetWorklogProviderBody {
 /// probe `get_integrations` shows the user. An id that isn't connected is refused
 /// rather than written and left to fail later inside the approve.
 #[tauri::command]
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn set_worklog_provider(
     pool: State<'_, Option<meridian_core::SqlitePool>>,
     body: SetWorklogProviderBody,


### PR DESCRIPTION
Addresses the CodeRabbit review on #517. Four of the five comments were real; the fifth is a misread and is explained below rather than actioned.

## Fixed

**1. Template injection in `release-build.yml` (the one that actually mattered)**

The version-assert step expanded `${{ steps.ctx.outputs.tag }}` straight into `run:`. A tag name is a *pushable ref* - attacker-chosen input - so a tag carrying shell metacharacters would execute on the runner, on a job that holds the Apple signing cert and `GH_TOKEN`. Bound through `env:` as `TAG`/`CHANNEL`, matching `RAW_TAG` and `VERSION` elsewhere in the file. Audited every other `steps.ctx.outputs.*` / `needs.prepare.outputs.*` use: all were already env-bound or are `ref:`/config-literal contexts, so this step was the only leak.

**2. `persist-credentials: false` in `ci.yml`**

CodeRabbit flagged the two new checkouts; all **five** in the file had the same issue, so all five are fixed - fixing two of five identical cases would just leave the inconsistency it was complaining about. None of these jobs push, and the workflow runs third-party actions (`paths-filter`, `setup-node`, `rust-cache`) that would otherwise have the token in reach. `cache-warm.yml` already did this; `ci.yml` now matches.

**3 + 4. Rust doc + tracing guidelines**

`set_draft_provider` gains `# Parameters` / `# Returns` / `# Errors` sections per the readers-module path instruction. Both provider-selection fns gain `err` on `#[tracing::instrument]` so a failure marks the span `ERROR` (it currently returns `Err` with the span still green - exactly the case the observability rule exists for), and the success log carries `rows_affected`.

## Not fixed - comment 5 is inverted

> Remove `~/.cargo/registry/src` from `cache-directories`; rust-cache already leaves that path out.

That is the reason the line exists, not a reason to delete it. rust-cache deliberately excludes `registry/src` because it is normally re-extractable from `registry/cache`. It isn't here: the pinned `tauri-plugin-notifications` fork's `build.rs` writes its **Swift static lib into its `registry/src` directory**. Restore `target/` without it and the fingerprint says "fresh" while the `.a` is gone, and linking dies with `could not find native static library tauri-plugin-notifications`.

The old pipeline papered over this with a `cargo clean -p tauri-plugin-notifications --release` on every run. Caching the directory removes the cause. Taking this suggestion would reintroduce a build failure the comment on those exact lines already documents.

## Verification

`cargo check` clean on `meridian-core` and `meridian-tray`; both workflow files parse; full pre-push suite (fmt, clippy, UI build, UI tests, cargo test, security audit) green.
