### PR TITLE
fix(tray): reconcile a stale daemon_quiet notice on tray restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5129,6 +5129,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "sqlx",
  "tauri",
  "tauri-build",
  "tauri-plugin-clerk",

--- a/src/notices.rs
+++ b/src/notices.rs
@@ -112,7 +112,19 @@ pub async fn clear(pool: &SqlitePool, id: &str) -> Result<()> {
 
 /// Clear a notice raised via [`raise_typed`] with the matching `event_key`.
 pub async fn clear_typed(pool: &SqlitePool, id: &str, event_key: &str) -> Result<()> {
-    sqlx::query("DELETE FROM system_notices WHERE notice_id = ?")
+    clear_typed_reporting(pool, id, event_key).await?;
+    Ok(())
+}
+
+/// Same as [`clear_typed`], but reports whether a notice actually existed and
+/// was deleted. Used by callers that must tell "a real fault was cleared"
+/// apart from "there was nothing to clear" — e.g. `refresh_health`'s
+/// startup reconciliation, which clears a `tray.daemon_quiet` notice that may
+/// be stale from a *previous* process instance (a fresh tray process can
+/// never observe that instance's down→up transition itself) and should only
+/// fire the "back online" toast when something was actually there.
+pub async fn clear_typed_reporting(pool: &SqlitePool, id: &str, event_key: &str) -> Result<bool> {
+    let result = sqlx::query("DELETE FROM system_notices WHERE notice_id = ?")
         .bind(id)
         .execute(pool)
         .await
@@ -120,5 +132,58 @@ pub async fn clear_typed(pool: &SqlitePool, id: &str, event_key: &str) -> Result
     // Retract the paired toast so a future re-occurrence of this fault notifies
     // again instead of being deduped away.
     let _ = crate::notifications::retract(pool, &format!("{event_key}:{id}")).await;
-    Ok(())
+    Ok(result.rows_affected() > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqliteConnectOptions;
+    use std::str::FromStr;
+
+    async fn fresh_db() -> SqlitePool {
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+            .unwrap()
+            .create_if_missing(true);
+        let pool = SqlitePool::connect_with(opts).await.unwrap();
+        sqlx::migrate!("src/migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn clear_typed_reporting_is_true_only_when_a_row_actually_existed() {
+        let pool = fresh_db().await;
+
+        // Nothing raised yet — clearing is a no-op, reported as such.
+        let cleared_nothing = clear_typed_reporting(&pool, "tray.daemon_quiet", "system.health")
+            .await
+            .unwrap();
+        assert!(!cleared_nothing);
+
+        raise_typed(
+            &pool,
+            Notice {
+                id: "tray.daemon_quiet",
+                severity: "warning",
+                title: "Meridian went quiet.",
+                detail: "Tap to check what happened.",
+                remedy: None,
+                event_key: "system.health",
+                deep_link: Some("/logs"),
+            },
+        )
+        .await
+        .unwrap();
+
+        // A real notice exists — clearing it reports true, exactly once.
+        let cleared_real = clear_typed_reporting(&pool, "tray.daemon_quiet", "system.health")
+            .await
+            .unwrap();
+        assert!(cleared_real);
+
+        let cleared_again = clear_typed_reporting(&pool, "tray.daemon_quiet", "system.health")
+            .await
+            .unwrap();
+        assert!(!cleared_again);
+    }
 }

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -191,3 +191,8 @@ capture = [
 # whatever happens to exist on the machine running the tests.
 [dev-dependencies]
 tempfile = "3"
+# Test-only: an in-memory migrated DB for poll::refresh's stale-notice
+# reconciliation test — `meridian_core::SqlitePool` is the pool type, but
+# querying result rows needs sqlx itself, which the tray binary otherwise
+# never touches directly (all DB access goes through meridian/meridian-core).
+sqlx = { version = "0.7", default-features = false, features = ["sqlite", "runtime-tokio-rustls", "migrate"] }

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -20,6 +20,9 @@ use tauri::Emitter;
 
 /// Run the local health check, fold it into [`AppState`], and raise/clear the
 /// went-quiet / back-online notice (debounced to the 2nd consecutive failure).
+/// Also reconciles a `tray.daemon_quiet` notice left stale by a previous
+/// process instance on this process's first healthy tick — see
+/// `startup_health_reconciled` on [`AppState`].
 pub(super) async fn refresh_health(
     app: &tauri::AppHandle,
     state: &Arc<Mutex<AppState>>,
@@ -42,32 +45,30 @@ pub(super) async fn refresh_health(
         HealthStatus::Unhealthy
     };
 
-    let (notify_down, notify_back) = {
+    let (notify_down, notify_back, reconcile_stale) = {
         let Ok(mut s) = state.lock() else {
             tracing::warn!("refresh_health: state lock poisoned");
             return;
         };
         let now_healthy = new_health == HealthStatus::Healthy;
-
-        let notify_down = if !now_healthy {
-            s.consecutive_health_failures += 1;
-            // Notify only on the second consecutive failure — one miss is a transient blip.
-            s.consecutive_health_failures == 2 && s.daemon_was_healthy
-        } else {
-            false
-        };
-        // Fire "back online" only when we had previously sent a "gone quiet" notification
-        // (consecutive_health_failures reached 2), so a brief outage during startup is silent.
-        let notify_back = now_healthy && s.consecutive_health_failures >= 2;
-
-        if now_healthy {
-            s.consecutive_health_failures = 0;
-            s.daemon_was_healthy = true;
-        }
+        // One explicit deref first: disjoint field borrows aren't provable
+        // across separate `MutexGuard::deref_mut` calls, only through a
+        // single plain `&mut AppState`.
+        let s = &mut *s;
+        let decision = decide_health_notice(
+            now_healthy,
+            &mut s.consecutive_health_failures,
+            &mut s.daemon_was_healthy,
+            &mut s.startup_health_reconciled,
+        );
         s.ui_reachable = true; // health checks are now direct (no HTTP); always reachable
         s.health = new_health;
 
-        (notify_down, notify_back)
+        (
+            decision.notify_down,
+            decision.notify_back,
+            decision.reconcile_stale,
+        )
     };
 
     let Some(pool) = pool else { return };
@@ -94,22 +95,181 @@ pub(super) async fn refresh_health(
         {
             tracing::warn!(error = %e, "daemon-health notice clear failed");
         }
-        // "Back online" is a discrete confirmation, not a state to leave
-        // sitting as a banner once the fault it answers is already cleared.
-        let dedup = format!(
-            "system.health:back_online:{}",
-            chrono::Utc::now().timestamp()
-        );
-        let n = meridian::notifications::NewNotification::event(
-            &dedup,
-            "system.health",
-            "Back online.",
-            "Picking up where you left off.",
-        )
-        .via(meridian::notifications::CHANNEL_NATIVE);
-        if let Err(e) = meridian::notifications::enqueue(pool, n).await {
-            tracing::warn!(error = %e, "back-online notification enqueue failed");
+        send_back_online_toast(pool).await;
+    } else if reconcile_stale {
+        match meridian::notices::clear_typed_reporting(pool, "tray.daemon_quiet", "system.health")
+            .await
+        {
+            // A notice really was sitting there from a prior process instance —
+            // confirm the recovery the same way the normal path does.
+            Ok(true) => send_back_online_toast(pool).await,
+            Ok(false) => {}
+            Err(e) => tracing::warn!(error = %e, "daemon-health stale notice reconcile failed"),
         }
+    }
+}
+
+/// "Back online" is a discrete confirmation, not a state to leave sitting as a
+/// banner once the fault it answers is already cleared.
+async fn send_back_online_toast(pool: &SqlitePool) {
+    let dedup = format!(
+        "system.health:back_online:{}",
+        chrono::Utc::now().timestamp()
+    );
+    let n = meridian::notifications::NewNotification::event(
+        &dedup,
+        "system.health",
+        "Back online.",
+        "Picking up where you left off.",
+    )
+    .via(meridian::notifications::CHANNEL_NATIVE);
+    if let Err(e) = meridian::notifications::enqueue(pool, n).await {
+        tracing::warn!(error = %e, "back-online notification enqueue failed");
+    }
+}
+
+/// The three notice actions a health tick can trigger. At most one is ever
+/// true — see [`decide_health_notice`].
+struct HealthNoticeDecision {
+    notify_down: bool,
+    notify_back: bool,
+    reconcile_stale: bool,
+}
+
+/// Pure decision over one health tick's state transition, extracted out of
+/// `refresh_health` so the debounce/reconcile rules are unit-testable without
+/// a DB, `AppState`'s `Mutex`, or `check_health()`'s IO. Mutates the three
+/// counters exactly as `refresh_health` used to inline; keep this in sync
+/// with that call site.
+fn decide_health_notice(
+    now_healthy: bool,
+    consecutive_health_failures: &mut u32,
+    daemon_was_healthy: &mut bool,
+    startup_health_reconciled: &mut bool,
+) -> HealthNoticeDecision {
+    let notify_down = if !now_healthy {
+        *consecutive_health_failures += 1;
+        // Notify only on the second consecutive failure — one miss is a transient blip.
+        *consecutive_health_failures == 2 && *daemon_was_healthy
+    } else {
+        false
+    };
+    // Fire "back online" only when we had previously sent a "gone quiet" notification
+    // (consecutive_health_failures reached 2), so a brief outage during startup is silent.
+    let notify_back = now_healthy && *consecutive_health_failures >= 2;
+
+    // One-shot, and mutually exclusive with notify_back: if THIS process's own
+    // counter already reached 2 failures and recovered, notify_back above is
+    // the right (and already correct) path. reconcile_stale only fires on
+    // this process's first-ever healthy tick when that didn't happen — e.g.
+    // the daemon was already healthy again by the time this fresh tray
+    // process started, so a `tray.daemon_quiet` notice raised by the PREVIOUS
+    // instance is sitting in system_notices with no process left able to
+    // observe the transition that would clear it.
+    let reconcile_stale = now_healthy && !*startup_health_reconciled && !notify_back;
+
+    if now_healthy {
+        *consecutive_health_failures = 0;
+        *daemon_was_healthy = true;
+        *startup_health_reconciled = true;
+    }
+
+    HealthNoticeDecision {
+        notify_down,
+        notify_back,
+        reconcile_stale,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact bug this fix targets: a fresh tray process (all counters at
+    /// their `AppState::default()` values) whose very first health check is
+    /// already healthy — e.g. the daemon recovered from an overnight sleep
+    /// gap before this process even started. The normal down→up transition
+    /// can never be observed by this process, so reconciliation must fire
+    /// directly instead.
+    #[test]
+    fn reconciles_stale_notice_on_first_healthy_tick_after_restart() {
+        let mut failures = 0u32;
+        let mut was_healthy = false;
+        let mut reconciled = false;
+
+        let d = decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+
+        assert!(!d.notify_down);
+        assert!(!d.notify_back);
+        assert!(
+            d.reconcile_stale,
+            "must reconcile on the first healthy tick"
+        );
+        assert!(reconciled, "startup_health_reconciled must be latched true");
+        assert!(was_healthy);
+        assert_eq!(failures, 0);
+    }
+
+    /// The one-shot must not re-fire on every subsequent healthy tick — only
+    /// the first one this process observes.
+    #[test]
+    fn does_not_reconcile_again_after_the_first_healthy_tick() {
+        let mut failures = 0u32;
+        let mut was_healthy = false;
+        let mut reconciled = false;
+
+        decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+        let second = decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+
+        assert!(!second.reconcile_stale);
+        assert!(!second.notify_back);
+    }
+
+    /// Normal case, unchanged by this fix: this process itself observes 2
+    /// consecutive failures (after having been healthy at least once), then
+    /// recovers — notify_back handles it, not the startup reconciler.
+    #[test]
+    fn normal_down_then_up_uses_notify_back_not_reconcile() {
+        let mut failures = 0u32;
+        let mut was_healthy = true; // already established healthy earlier
+        let mut reconciled = true; // startup reconciliation already happened
+
+        let first_fail =
+            decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
+        assert!(!first_fail.notify_down); // only 1 consecutive failure so far
+
+        let second_fail =
+            decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
+        assert!(second_fail.notify_down); // 2nd consecutive failure
+
+        let recovered =
+            decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+        assert!(recovered.notify_back);
+        assert!(!recovered.reconcile_stale);
+    }
+
+    /// Preserves existing (pre-fix) behavior: a cold-start outage that never
+    /// establishes healthy first stays silent — `daemon_was_healthy` gates
+    /// `notify_down` off — but recovery still clears via `notify_back` once
+    /// the failure count has reached 2, same as before this change.
+    #[test]
+    fn cold_start_outage_is_silent_until_recovery() {
+        let mut failures = 0u32;
+        let mut was_healthy = false;
+        let mut reconciled = false;
+
+        let f1 = decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
+        let f2 = decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
+        assert!(!f1.notify_down);
+        assert!(
+            !f2.notify_down,
+            "never-yet-healthy daemon must not notify down"
+        );
+
+        let recovered =
+            decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+        assert!(recovered.notify_back);
+        assert!(!recovered.reconcile_stale);
     }
 }
 

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -181,98 +181,6 @@ fn decide_health_notice(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The exact bug this fix targets: a fresh tray process (all counters at
-    /// their `AppState::default()` values) whose very first health check is
-    /// already healthy — e.g. the daemon recovered from an overnight sleep
-    /// gap before this process even started. The normal down→up transition
-    /// can never be observed by this process, so reconciliation must fire
-    /// directly instead.
-    #[test]
-    fn reconciles_stale_notice_on_first_healthy_tick_after_restart() {
-        let mut failures = 0u32;
-        let mut was_healthy = false;
-        let mut reconciled = false;
-
-        let d = decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
-
-        assert!(!d.notify_down);
-        assert!(!d.notify_back);
-        assert!(
-            d.reconcile_stale,
-            "must reconcile on the first healthy tick"
-        );
-        assert!(reconciled, "startup_health_reconciled must be latched true");
-        assert!(was_healthy);
-        assert_eq!(failures, 0);
-    }
-
-    /// The one-shot must not re-fire on every subsequent healthy tick — only
-    /// the first one this process observes.
-    #[test]
-    fn does_not_reconcile_again_after_the_first_healthy_tick() {
-        let mut failures = 0u32;
-        let mut was_healthy = false;
-        let mut reconciled = false;
-
-        decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
-        let second = decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
-
-        assert!(!second.reconcile_stale);
-        assert!(!second.notify_back);
-    }
-
-    /// Normal case, unchanged by this fix: this process itself observes 2
-    /// consecutive failures (after having been healthy at least once), then
-    /// recovers — notify_back handles it, not the startup reconciler.
-    #[test]
-    fn normal_down_then_up_uses_notify_back_not_reconcile() {
-        let mut failures = 0u32;
-        let mut was_healthy = true; // already established healthy earlier
-        let mut reconciled = true; // startup reconciliation already happened
-
-        let first_fail =
-            decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
-        assert!(!first_fail.notify_down); // only 1 consecutive failure so far
-
-        let second_fail =
-            decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
-        assert!(second_fail.notify_down); // 2nd consecutive failure
-
-        let recovered =
-            decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
-        assert!(recovered.notify_back);
-        assert!(!recovered.reconcile_stale);
-    }
-
-    /// Preserves existing (pre-fix) behavior: a cold-start outage that never
-    /// establishes healthy first stays silent — `daemon_was_healthy` gates
-    /// `notify_down` off — but recovery still clears via `notify_back` once
-    /// the failure count has reached 2, same as before this change.
-    #[test]
-    fn cold_start_outage_is_silent_until_recovery() {
-        let mut failures = 0u32;
-        let mut was_healthy = false;
-        let mut reconciled = false;
-
-        let f1 = decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
-        let f2 = decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
-        assert!(!f1.notify_down);
-        assert!(
-            !f2.notify_down,
-            "never-yet-healthy daemon must not notify down"
-        );
-
-        let recovered =
-            decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
-        assert!(recovered.notify_back);
-        assert!(!recovered.reconcile_stale);
-    }
-}
-
 /// Read the active session (direct DB) and store the app name + elapsed seconds.
 /// On a read error we keep the previous value rather than clearing the pill on a
 /// transient blip.
@@ -411,5 +319,183 @@ pub(super) async fn refresh_worklogs(pool: &SqlitePool, state: &Arc<Mutex<AppSta
             s.logged_s = logged_s;
         }
         Err(e) => tracing::warn!(error = %e, "refresh_worklogs failed"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact bug this fix targets: a fresh tray process (all counters at
+    /// their `AppState::default()` values) whose very first health check is
+    /// already healthy — e.g. the daemon recovered from an overnight sleep
+    /// gap before this process even started. The normal down→up transition
+    /// can never be observed by this process, so reconciliation must fire
+    /// directly instead.
+    #[test]
+    fn reconciles_stale_notice_on_first_healthy_tick_after_restart() {
+        let mut failures = 0u32;
+        let mut was_healthy = false;
+        let mut reconciled = false;
+
+        let d = decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+
+        assert!(!d.notify_down);
+        assert!(!d.notify_back);
+        assert!(
+            d.reconcile_stale,
+            "must reconcile on the first healthy tick"
+        );
+        assert!(reconciled, "startup_health_reconciled must be latched true");
+        assert!(was_healthy);
+        assert_eq!(failures, 0);
+    }
+
+    /// The one-shot must not re-fire on every subsequent healthy tick — only
+    /// the first one this process observes.
+    #[test]
+    fn does_not_reconcile_again_after_the_first_healthy_tick() {
+        let mut failures = 0u32;
+        let mut was_healthy = false;
+        let mut reconciled = false;
+
+        decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+        let second = decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+
+        assert!(!second.reconcile_stale);
+        assert!(!second.notify_back);
+    }
+
+    /// Normal case, unchanged by this fix: this process itself observes 2
+    /// consecutive failures (after having been healthy at least once), then
+    /// recovers — notify_back handles it, not the startup reconciler.
+    #[test]
+    fn normal_down_then_up_uses_notify_back_not_reconcile() {
+        let mut failures = 0u32;
+        let mut was_healthy = true; // already established healthy earlier
+        let mut reconciled = true; // startup reconciliation already happened
+
+        let first_fail =
+            decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
+        assert!(!first_fail.notify_down); // only 1 consecutive failure so far
+
+        let second_fail =
+            decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
+        assert!(second_fail.notify_down); // 2nd consecutive failure
+
+        let recovered =
+            decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+        assert!(recovered.notify_back);
+        assert!(!recovered.reconcile_stale);
+    }
+
+    /// Preserves existing (pre-fix) behavior: a cold-start outage that never
+    /// establishes healthy first stays silent — `daemon_was_healthy` gates
+    /// `notify_down` off — but recovery still clears via `notify_back` once
+    /// the failure count has reached 2, same as before this change.
+    #[test]
+    fn cold_start_outage_is_silent_until_recovery() {
+        let mut failures = 0u32;
+        let mut was_healthy = false;
+        let mut reconciled = false;
+
+        let f1 = decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
+        let f2 = decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
+        assert!(!f1.notify_down);
+        assert!(
+            !f2.notify_down,
+            "never-yet-healthy daemon must not notify down"
+        );
+
+        let recovered =
+            decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+        assert!(recovered.notify_back);
+        assert!(!recovered.reconcile_stale);
+    }
+
+    async fn fresh_db() -> meridian_core::SqlitePool {
+        use sqlx::sqlite::SqliteConnectOptions;
+        use std::str::FromStr;
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+            .unwrap()
+            .create_if_missing(true);
+        let pool = meridian_core::SqlitePool::connect_with(opts).await.unwrap();
+        sqlx::migrate!("../../src/migrations")
+            .run(&pool)
+            .await
+            .unwrap();
+        pool
+    }
+
+    /// End-to-end DB check for the scenario the code review flagged as
+    /// hardest to unit-test: a `tray.daemon_quiet` notice raised by one
+    /// process instance, still sitting in `system_notices` when a FRESH
+    /// process's first-ever health check comes back healthy. Composes
+    /// `decide_health_notice` with the real `meridian::notices` DB calls
+    /// against an in-memory schema-migrated database — exactly the sequence
+    /// `refresh_health`'s `reconcile_stale` branch runs — rather than a mock.
+    /// Short of driving an actual packaged tray process through a real
+    /// sleep/restart cycle, this is the strongest verification available
+    /// from an automated test.
+    #[tokio::test]
+    async fn stale_notice_from_a_prior_process_instance_is_actually_cleared() {
+        let pool = fresh_db().await;
+
+        // The PREVIOUS process instance raised the fault before it exited.
+        meridian::notices::raise_typed(
+            &pool,
+            meridian::notices::Notice {
+                id: "tray.daemon_quiet",
+                severity: "warning",
+                title: "Meridian went quiet.",
+                detail: "Tap to check what happened.",
+                remedy: None,
+                event_key: "system.health",
+                deep_link: Some("/logs"),
+            },
+        )
+        .await
+        .unwrap();
+
+        // A FRESH process's AppState defaults, observing its first-ever health
+        // tick as healthy (the daemon recovered before this process started).
+        let mut failures = 0u32;
+        let mut was_healthy = false;
+        let mut reconciled = false;
+        let decision = decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+        assert!(
+            decision.reconcile_stale,
+            "a fresh process's first healthy tick must trigger reconciliation"
+        );
+        assert!(!decision.notify_back);
+
+        // Exactly what refresh_health's reconcile_stale branch does.
+        let cleared =
+            meridian::notices::clear_typed_reporting(&pool, "tray.daemon_quiet", "system.health")
+                .await
+                .unwrap();
+        assert!(
+            cleared,
+            "a real stale notice must report as actually cleared"
+        );
+        send_back_online_toast(&pool).await;
+
+        let remaining: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM system_notices WHERE notice_id = 'tray.daemon_quiet'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(remaining, 0, "the banner's backing row must be gone");
+
+        let toast_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM notifications WHERE event_key = 'system.health' AND title = 'Back online.'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            toast_count, 1,
+            "a back-online toast must confirm the recovery"
+        );
     }
 }

--- a/tray/src-tauri/src/state.rs
+++ b/tray/src-tauri/src/state.rs
@@ -152,6 +152,14 @@ pub struct AppState {
     pub last_poll: Option<Instant>,
     pub daemon_was_healthy: bool,
     pub consecutive_health_failures: u32,
+    /// Set the first time this process observes a *healthy* check. Gates a
+    /// one-shot reconciliation in `refresh_health`: a `tray.daemon_quiet`
+    /// notice can be left over from a previous process instance (this one's
+    /// `consecutive_health_failures` starts at 0, so it can never itself
+    /// observe that instance's down→up transition) and needs clearing
+    /// directly on first contact instead of waiting for a 2-failure cycle
+    /// that will never happen.
+    pub startup_health_reconciled: bool,
     pub last_menu_state: HealthStatus,
     /// Dropping this sender cancels the ScreenpipeEngine task, stopping screen capture.
     pub engine_cancel: Option<oneshot::Sender<()>>,
@@ -189,6 +197,7 @@ impl Default for AppState {
             last_poll: None,
             daemon_was_healthy: false,
             consecutive_health_failures: 0,
+            startup_health_reconciled: false,
             last_menu_state: HealthStatus::Unknown,
             engine_cancel: None,
             ui_consumer_cancel: None,


### PR DESCRIPTION
## Summary

Fixes Finding 02 of the field report field-reported on 2026-07-20/21: the
"Meridian went quiet. Tap to check what happened." banner could get stuck
forever, with no way to clear it short of a manual `DELETE FROM
system_notices`.

**Root cause:** `refresh_health` only clears `tray.daemon_quiet` when the
*same process* observes a down→up transition (`consecutive_health_failures`
hits 2, then recovers). If the Mac sleeps overnight and the tray process
itself restarts before the next health check, the fresh process's counter
starts at 0 — its first check is already healthy, so that transition can
never be observed, and a notice raised by the *previous* process instance
sits in `system_notices` indefinitely.

**Fix:** on each process's first-ever healthy tick, reconcile directly —
clear any stale `tray.daemon_quiet` notice instead of waiting for a 2-failure
cycle that will never happen. `clear_typed_reporting` (new, alongside the
existing `clear_typed`) reports whether a row actually existed, so the "Back
online" toast only fires when there was a real stale fault to confirm — a
normal, already-healthy launch stays silent.

The debounce/reconcile decision was extracted into a pure `decide_health_notice`
so the state-transition rules (down-notify, back-notify, one-shot reconcile,
and the existing "outage before first healthy tick is silent" rule) are unit
tested without a DB or `AppState`'s mutex.

Out of scope: Finding 01 (a thin activity hour permanently marked "done") is
working as designed per the report's own conclusion (the fold's LLM step
independently agreed nothing was worth surfacing) — its suggested "grace
window/reopen" enhancement touches idempotency invariants around the
worklog fold's done-lock and needs product judgment, not a same-PR fix. The
report's other suggestion — a manual dismiss backstop in `NoticeBar.tsx` —
is left as a follow-up: it needs a new command and a UX decision (dismiss
session-only vs. delete server-side) beyond this bug's actual root cause.

## Test plan
- [x] `cargo test --lib` (daemon crate) — 720 passed, including new
      `notices::tests::clear_typed_reporting_is_true_only_when_a_row_actually_existed`
- [x] `cargo test` (tray crate) — 136 passed, including 4 new
      `poll::refresh::tests::*` covering: reconcile-on-first-healthy-tick,
      no double-reconcile, normal down→up unaffected, and cold-start-outage
      silence preserved
- [x] `cargo fmt --check` + `cargo clippy -- -D warnings` clean on both crates
- [x] Full pre-push suite (fmt, clippy, ui build, ui tests, security audit,
      cargo test) passed on push
- [ ] Manual repro on staging: put the tray into a raised `tray.daemon_quiet`
      state, restart the tray process while the daemon stays healthy, confirm
      the banner clears without a DB edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)