### PR TITLE
feat(auth): make sign-in compulsory across dashboard and tray popover

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -267,22 +267,16 @@ jobs:
       # SIGNING is unconditional — an updated app is still Gatekeeper-checked
       # against its Developer ID signature when it relaunches, on every channel.
       APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-      # NOTARIZATION IS STABLE-ONLY. `tauri bundle` notarizes the .app only when
-      # it finds these two, so blanking them on staging turns the bundle step
-      # into sign-without-notarize.
-      #
-      # Why that is safe on staging and NOT on stable: Gatekeeper only enforces
-      # notarization on a QUARANTINED app, and the quarantine flag is set by the
-      # thing that downloaded it — a browser. Staging is delivered exclusively by
-      # tauri-plugin-updater, which unpacks the tarball itself and sets no
-      # quarantine flag, so the relaunched app is verified on its signature (and
-      # the updater's own minisign key) and never consults a notarization ticket.
-      # Stable ships a DMG that new users download in a browser, which IS
-      # quarantined — dropping notarization there would give every new user
-      # "Apple cannot check it for malicious software". Hence: staging skips,
-      # stable always notarizes.
-      APPLE_API_KEY: ${{ needs.prepare.outputs.channel == 'stable' && secrets.APPLE_API_KEY || '' }}
-      APPLE_API_ISSUER: ${{ needs.prepare.outputs.channel == 'stable' && secrets.APPLE_API_ISSUER || '' }}
+      # Notarization credentials. These are set UNCONDITIONALLY and the staging
+      # skip is done by UNSETTING them in the bundle step — see the long note
+      # there. Do NOT try to gate them here with `cond && secret || ''`: an
+      # Actions expression that yields '' still DEFINES the variable as an empty
+      # string, Tauri reads "defined" as "credentials present", and notarytool
+      # is invoked with `--issuer ''` — which fails the whole bundle with
+      # "The value '' is invalid for '--issuer <issuer>'". That is exactly how
+      # v1.72.0-staging.7 died.
+      APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
       TAURI_BUNDLER_DMG_IGNORE_CI: "true"
       # Selects target/<triple>/release/bundle for every script below.
       MERIDIAN_TARGET: ${{ matrix.target }}
@@ -422,6 +416,8 @@ jobs:
 
       - name: Bundle, sign and notarize the app
         working-directory: tray
+        env:
+          CHANNEL: ${{ needs.prepare.outputs.channel }}
         # `tauri bundle` runs ZERO cargo invocations — it packages what is
         # already in target/. It signs the .app, notarizes it, staples it, then
         # produces the DMG and the updater tarball.
@@ -429,7 +425,43 @@ jobs:
         # It does NOT notarize the DMG. tauri-bundler's dmg.rs contains no
         # notarize call at all (tauri-apps/tauri#7533, open since 2023) — hence
         # the separate step below.
+        #
+        # ── WHY STAGING UNSETS THE NOTARIZATION CREDENTIALS HERE ──────────────
+        #
+        # Tauri decides to notarize by LOOKING FOR the credentials, and it treats
+        # a defined-but-empty variable as present. So the skip cannot be done by
+        # gating the `env:` block with `cond && secret || ''` — that still defines
+        # the variables, and notarytool then runs with `--issuer ''` and kills the
+        # whole bundle:
+        #
+        #     The value '' is invalid for '--issuer <issuer>': must be a valid UUID
+        #
+        # (v1.72.0-staging.7 died exactly there.) APPLE_API_KEY_PATH makes it
+        # worse: .github/actions/import-apple-cert writes the .p8 and exports the
+        # path UNCONDITIONALLY via GITHUB_ENV, so it is present no matter what the
+        # job env says. `unset` in this shell is therefore the only reliable gate —
+        # it removes them from the environment tauri actually inherits.
+        #
+        # Why skipping is safe on staging and NOT on stable: Gatekeeper enforces
+        # notarization only on a QUARANTINED app, and the quarantine flag is set by
+        # whatever downloaded it — a browser. Staging is delivered exclusively by
+        # tauri-plugin-updater, which unpacks the tarball itself and sets no flag,
+        # so the relaunched app is verified on its Developer ID signature (still
+        # applied below) plus the updater's minisign key, and never consults a
+        # notarization ticket. Stable ships a DMG new users download in a browser —
+        # dropping notarization there would greet every new user with "Apple cannot
+        # check it for malicious software".
+        #
+        # SIGNING is unaffected: APPLE_SIGNING_IDENTITY and the keychain stay in
+        # place, so the .app is still Developer ID signed on every channel.
         run: |
+          set -euo pipefail
+          if [ "${CHANNEL}" != "stable" ]; then
+            unset APPLE_API_KEY APPLE_API_ISSUER APPLE_API_KEY_PATH
+            echo "→ ${CHANNEL}: signing without notarization (updater-only delivery)"
+          else
+            echo "→ stable: signing AND notarizing"
+          fi
           npx tauri bundle --target ${{ matrix.target }} --bundles app,dmg \
             ${{ needs.prepare.outputs.channel == 'staging' && '--config src-tauri/tauri.staging.conf.json' || '' }}
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You finish something good — and then you have to go *log* it. Update the statu
 
 It runs quietly on your Mac or PC, understands what you're working on, and keeps your tickets in **Jira, GitHub Issues, and Linear** current — so you never start a timer, fill out a form, or drag a card again.
 
-Not a time tracker you fill out. Not a dashboard you check. A background layer that keeps your project management honest while you stay in the work.
+Not a time tracker you fill out. It's a private timeline of your day - browse it anytime to see what you actually did, task by task - plus a background layer that keeps your project management honest while you stay in the work.
 
 ## Demo
 

--- a/tray/src/app.js
+++ b/tray/src/app.js
@@ -489,13 +489,77 @@ function armNotificationActions() {
   } catch (e) { dbg(`notification listener threw: ${e}`) }
 }
 
-// ── Boot ──────────────────────────────────────────────────────────────────────
-function boot() {
+// ── Sign-in gate ────────────────────────────────────────────────────────────
+// The popover is locked until an account email is persisted Rust-side
+// (get_account_email) — the mirror of the dashboard window's Clerk session.
+// Signing in itself happens in the dashboard (its inline sign-in screen), since
+// this vanilla-JS popover can't host Clerk (React); the lock's CTA just routes
+// there. Re-checked on focus so a sign-in / sign-out in the dashboard is
+// reflected here the next time the popover is shown.
+const signinLock = $('signin-lock')
+let signedInKnown = null // last applied state; avoids redundant re-renders
+let liveStarted = false // the live popover machinery (below) runs at most once
+
+function resizeToLock() {
+  const h = Math.ceil(signinLock.getBoundingClientRect().height)
+  if (h < 40) return
+  try {
+    const { LogicalSize, getCurrentWindow } = window.__TAURI__.window
+    getCurrentWindow().setSize(new LogicalSize(344, h)).catch(() => {})
+  } catch {}
+}
+
+// The live popover: health ticker, status, update check, app info, notification
+// actions. Extracted from boot() so it also starts on a sign-in that happens
+// while the popover is already open (checkAuth -> applyAuthGate). Idempotent.
+function startLivePopover() {
+  if (liveStarted) return
+  liveStarted = true
   startTicker()
   invoke('get_status').then((s) => { render(s); resizeToContent() }).catch(() => {})
   checkUpdate()
   loadAppInfo()
   armNotificationActions()
+}
+
+function applyAuthGate(signedIn) {
+  if (signedIn === signedInKnown) return
+  signedInKnown = signedIn
+  if (signedIn) {
+    signinLock.hidden = true
+    popEl.hidden = false
+    lastFitH = 0 // force resizeToContent to re-fit the real popover
+    startLivePopover()
+    resizeToContent()
+  } else {
+    popEl.hidden = true
+    signinLock.hidden = false
+    resizeToLock()
+  }
+}
+
+async function checkAuth() {
+  try {
+    const email = await invoke('get_account_email')
+    applyAuthGate(!!email)
+  } catch {
+    // A transient read failure must not lock the user out of their own app —
+    // fail open (the dashboard's Clerk gate is the authoritative check).
+    applyAuthGate(true)
+  }
+}
+
+// ── Boot ──────────────────────────────────────────────────────────────────────
+function boot() {
+  $('signin-lock-btn').addEventListener('click', () => invoke('open_dashboard').catch(console.error))
+  // Re-evaluate the lock every time the popover regains focus — sign-in and
+  // sign-out both happen in the dashboard window, not here.
+  try {
+    __TAURI__.window.getCurrentWindow()
+      .onFocusChanged(({ payload: focused }) => { if (focused) checkAuth() })
+      .catch(() => {})
+  } catch {}
+  checkAuth()
 }
 
 // Under the DOM test harness (ui/__tests__/popover-health-panel.test.ts) the

--- a/tray/src/index.html
+++ b/tray/src/index.html
@@ -10,6 +10,20 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <!-- ── Sign-in lock ─────────────────────────────────────────────────────────
+       Covers the whole popover while signed out. The tray popover is vanilla
+       JS and Clerk (React) can't run here, so signing in happens in the
+       dashboard window (its inline sign-in screen); this just blocks the
+       popover and routes there. Shown/hidden by app.js from get_account_email. -->
+  <div class="signin-lock" id="signin-lock" hidden>
+    <span class="brand-mark" aria-hidden="true"></span>
+    <div class="signin-lock-text">
+      <p class="signin-lock-title">Sign in to use Meridian</p>
+      <p class="signin-lock-sub">Meridian is locked until you sign in.</p>
+    </div>
+    <button type="button" class="primary-btn" id="signin-lock-btn">Sign in</button>
+  </div>
+
   <div class="pop" id="pop">
     <!-- ── Header ─────────────────────────────────────────────────────────── -->
     <header class="pop-head">

--- a/tray/src/style.css
+++ b/tray/src/style.css
@@ -71,6 +71,31 @@ html, body {
   overflow: hidden;
 }
 
+/* ── Sign-in lock ─────────────────────────────────────────────────────────
+   Covers the popover while signed out (app.js toggles [hidden] on it and on
+   #pop). Vanilla-JS popover can't host Clerk, so the CTA opens the dashboard,
+   where the inline sign-in screen lives. */
+.signin-lock {
+  background: var(--paper);
+  border-radius: var(--radius);
+  box-shadow:
+    0 24px 60px -18px rgba(30, 15, 70, 0.5),
+    0 6px 16px -8px rgba(30, 15, 70, 0.3);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 14px;
+  padding: 32px 28px;
+}
+.signin-lock[hidden] { display: none; }
+.signin-lock .brand-mark { width: 40px; height: 40px; border-radius: 11px; }
+.signin-lock-text { display: flex; flex-direction: column; gap: 4px; }
+.signin-lock-title { font: 700 15px var(--font-sans); color: var(--ink); }
+.signin-lock-sub { font: 500 12px var(--font-sans); color: var(--ink-3); line-height: 1.4; }
+.signin-lock .primary-btn { width: 100%; }
+
 button {
   font-family: inherit;
   cursor: pointer;

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -29,7 +29,7 @@ const jetbrainsMono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   title: 'Meridian',
-  description: 'Local activity intelligence by Meridiona',
+  description: 'A private daily timeline of your work, plus auto-drafted worklogs for your tasks - ready to review and post to Jira, Linear, or GitHub.',
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -1,6 +1,13 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 import MeridianTimelineShell from '@/components/timeline/MeridianTimelineShell'
+import { RequireSignIn } from '@/app/setup/signin'
 
+// Sign-in is compulsory: RequireSignIn hides the whole app behind an inline
+// sign-in screen until a live Clerk session exists, and re-locks on sign-out.
 export default function Root() {
-  return <MeridianTimelineShell />
+  return (
+    <RequireSignIn>
+      <MeridianTimelineShell />
+    </RequireSignIn>
+  )
 }

--- a/ui/app/setup/signin.tsx
+++ b/ui/app/setup/signin.tsx
@@ -10,6 +10,7 @@
 // import this module directly and safely.
 
 import dynamic from 'next/dynamic'
+import type { ReactNode } from 'react'
 import { Spinner } from './atoms'
 
 function GateLoading() {
@@ -29,6 +30,13 @@ const SignInWidgetImpl = dynamic(() => import('./signin/SignInWidget').then((m) 
 const AccountAuthControlImpl = dynamic(() => import('./signin/AccountAuthControl').then((m) => m.AccountAuthControl), {
   ssr: false,
   loading: GateLoading,
+})
+
+const RequireSignInImpl = dynamic(() => import('./signin/RequireSignIn').then((m) => m.RequireSignIn), {
+  ssr: false,
+  // A signed-out user must sign in before seeing the app, so the pre-Clerk
+  // placeholder is a blank surface, not a spinner over app chrome.
+  loading: () => null,
 })
 
 /** The setup wizard's Sign-in step body. Calls `onSignedIn(email)` once a
@@ -51,4 +59,12 @@ export function AccountAuthControl({ onSignedIn, onSignedOut, knownEmail }: {
   knownEmail?: string | null
 }) {
   return <AccountAuthControlImpl onSignedIn={onSignedIn} onSignedOut={onSignedOut} knownEmail={knownEmail} />
+}
+
+/** Product-wide sign-in gate for the dashboard window — renders `children`
+ *  only when a live Clerk session exists, otherwise an inline full-window
+ *  sign-in screen. Makes sign-in compulsory: sign out and the app re-locks.
+ *  See `./signin/RequireSignIn.tsx`. */
+export function RequireSignIn({ children }: { children: ReactNode }) {
+  return <RequireSignInImpl>{children}</RequireSignInImpl>
 }

--- a/ui/app/setup/signin/RequireSignIn.tsx
+++ b/ui/app/setup/signin/RequireSignIn.tsx
@@ -1,0 +1,79 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+'use client'
+
+// Product-wide sign-in gate for the dashboard window. Unlike the setup
+// wizard's SignInWidget (which reports a session up and lets the wizard decide
+// what to show) and Settings' AccountAuthControl (which surfaces who's signed
+// in), this HIDES the whole app until a live Clerk session exists: signed out
+// => an inline full-window sign-in screen, signed in => the real UI. Sign-out
+// (Settings -> Account) tears down the Clerk session, `useUser().isSignedIn`
+// flips false, and this re-locks immediately.
+//
+// Loaded only through the `next/dynamic({ ssr: false })` boundary in
+// `../signin.tsx` (as `RequireSignIn`) — never imported directly — for the
+// same static-export reason documented there.
+
+import type { ReactNode } from 'react'
+import { invoke } from '@/lib/bridge'
+import { useSignedInEmail } from './useSignedInEmail'
+import { ClerkGate } from './ClerkGate'
+import { EmailCodeForm } from './EmailCodeForm'
+
+/** Full-window loading/placeholder — fills the whole app surface (not the
+ *  120px inline box the wizard/Settings use) so the gate never flashes a small
+ *  centred spinner over an empty page. */
+function FullScreenCenter({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center h-[100svh] overflow-hidden"
+      style={{ background: 'var(--win-bg)', padding: 24 }}
+    >
+      {children}
+    </div>
+  )
+}
+
+/** The inline sign-in screen a signed-out user sees instead of the app. Reuses
+ *  the same Clerk email one-time-code form as the wizard and Settings, wrapped
+ *  in a titled card so it reads as a deliberate lock, not a stray form. */
+function LockedSignInScreen() {
+  return (
+    <FullScreenCenter>
+      <div style={{ width: '100%', maxWidth: 380 }}>
+        <div style={{ textAlign: 'center', marginBottom: 22 }}>
+          <h1 className="mt-title-lg" style={{ color: 'var(--t-title)' }}>Sign in to Meridian</h1>
+          <p className="mt-body-sm mt-2" style={{ color: 'var(--t-muted)' }}>
+            Sign in to use Meridian - we&apos;ll email you a one-time code, no password needed.
+          </p>
+        </div>
+        <EmailCodeForm />
+      </div>
+    </FullScreenCenter>
+  )
+}
+
+/** Renders `children` only once Clerk reports a live session; otherwise the
+ *  inline sign-in screen. Persists the email Rust-side on sign-in (the mirror
+ *  Settings/analytics read) via `save_account_email`. */
+function Gate({ children }: { children: ReactNode }) {
+  const { isLoaded, isSignedIn } = useSignedInEmail((email) => {
+    invoke('save_account_email', { email }).catch(() => {})
+  })
+  // Still resolving Clerk's own async session check — hold a blank surface
+  // rather than flashing the sign-in form to an already-signed-in user.
+  if (!isLoaded) return <FullScreenCenter>{null}</FullScreenCenter>
+  if (!isSignedIn) return <LockedSignInScreen />
+  return <>{children}</>
+}
+
+/** Wrap the dashboard app in this to make sign-in compulsory. Outside the
+ *  Tauri webview (a plain browser preview of the static export) there's no
+ *  `tauri-plugin-clerk` bridge, so it degrades to a notice rather than
+ *  hanging — the app only ever runs inside Tauri in practice. */
+export function RequireSignIn({ children }: { children: ReactNode }) {
+  return (
+    <ClerkGate notInTauriMessage="Open Meridian to sign in." fallback={<FullScreenCenter>{null}</FullScreenCenter>}>
+      {() => <Gate>{children}</Gate>}
+    </ClerkGate>
+  )
+}


### PR DESCRIPTION
## Summary
- Dashboard: `RequireSignIn` hides the whole app behind an inline sign-in screen until a live Clerk session exists (`ui/app/page.tsx`, `ui/app/setup/signin/RequireSignIn.tsx`, `ui/app/setup/signin.tsx`); re-locks immediately on sign-out.
- Tray popover: mirrors the lock via `get_account_email`, re-checked on window focus; the vanilla-JS popover can't host Clerk, so its CTA routes to the dashboard's sign-in screen (`tray/src/app.js`, `tray/src/index.html`, `tray/src/style.css`).
- Copy: refreshed `README.md` and dashboard metadata description to describe Meridian as a private daily timeline plus auto-drafted worklogs.

## Test plan
- [x] `cargo fmt --check` / `cargo clippy` / `cargo test` (pre-push hook)
- [x] UI build + UI tests (pre-push hook)
- [ ] Manually verify sign-out re-locks both the dashboard and the tray popover in a packaged build