### PR TITLE
ci: stop re-running the suite on pre-main → main release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,35 @@
 name: CI
 
 on:
+  # Both release branches, so `main` still gets a full post-merge signal.
   push:
     branches: [main, pre-main]
+  # PRs into pre-main ONLY — deliberately NOT main.
+  #
+  # The only PR that ever targets main is the `pre-main → main` release merge,
+  # and running CI on it re-tests a tree CI has already passed twice: once on
+  # each commit's own feature PR, and again on the push to pre-main. main holds
+  # nothing pre-main lacks except `chore(release): X [skip ci]` version bumps,
+  # so the merge introduces no code that has not already been through the suite.
+  #
+  # This is NOT the same situation as a feature PR. There, two independently
+  # green branches can combine into something broken — the PR run tests your
+  # branch against the pre-main of that moment, and someone else's PR can land
+  # in between, so the post-merge push run is what catches the semantic
+  # conflict. A release merge has no second code stream, so there is no
+  # conflict surface and nothing for a re-run to find.
+  #
+  # It also removes a real cost: while a pre-main → main PR is open, pre-main is
+  # the PR's head branch, so every push to it fired the whole suite TWICE (once
+  # as `push`, once as `pull_request`) — including the macOS Rust job, the
+  # slowest and most expensive one in the workflow.
+  #
+  # Production is not left unguarded: the `push: main` trigger above still runs
+  # the full suite on the merge commit. The check that actually gates a release
+  # is human anyway — "has this been exercised end to end on the staging DMG" —
+  # which no status check can express (see CLAUDE.md, "PR target branch").
   pull_request:
-    branches: [main, pre-main]
+    branches: [pre-main]
 
 permissions:
   contents: read


### PR DESCRIPTION
`ci.yml` ran on `pull_request` into `main` as well as `pre-main`. Scoped to `pre-main` only.

## Why

The only PR that ever targets `main` is the `pre-main → main` release merge. Running the suite there re-tests a tree it has **already passed twice** - once on each commit's own feature PR, once on the push to `pre-main`.

`main` holds nothing `pre-main` lacks except version bumps:

```
5fcc25c9 chore(release): 1.74.0 [skip ci]
ec751d73 chore(release): 1.73.0 [skip ci]
99b7499d chore(release): 1.72.0 [skip ci]
```

So the merge introduces no code that has not already been through CI.

This is **not** the same situation as a feature PR. There, the PR run tests your branch against the `pre-main` of that moment, and someone else's PR can land before yours - two independently green branches combining into something broken. The post-merge `push` run is what catches that semantic conflict, and it stays exactly as it was. A release merge has no second code stream, so there is no conflict surface for a re-run to find.

## It also cost real runner time

While a `pre-main → main` PR is open, `pre-main` is that PR's **head branch**. Every push to `pre-main` therefore fired the whole suite twice - once as `push`, once as `pull_request` for the open release PR - including `Rust (macOS Apple Silicon)`, the slowest and most expensive job in the workflow. That doubling ran for the entire life of every release PR.

## What is unchanged

- **`push: [main, pre-main]`** - production still gets a full run on the merge commit. This is the signal that matters for `main`, and it now runs once instead of twice.
- **`migration-guard`** was already `pull_request`-gated (`if: github.event_name == 'pull_request'`). It now scopes to PRs into `pre-main`, which is where migrations actually enter the codebase - it was never able to run on a release PR's `push` event anyway.
- No job's `if:` conditions were touched.

## Note on gating

None of these checks are *required* today regardless - the `main` ruleset enforces only `required_approving_review_count: 1`, with no `required_status_checks` rule. The real gate on a release is human: has `pre-main` been exercised end to end on the staging DMG, per CLAUDE.md's "PR target branch" section. No status check can express that.
