### PR TITLE
fix(ci): fail the release when a merge to main tags nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,10 @@ on:
   # The only PR that ever targets main is the `pre-main → main` release merge,
   # and running CI on it re-tests a tree CI has already passed twice: once on
   # each commit's own feature PR, and again on the push to pre-main. main holds
-  # nothing pre-main lacks except `chore(release): X [skip ci]` version bumps,
+  # nothing pre-main lacks except semantic-release's own `chore(release): X`
+  # version bumps (which carry GitHub's skip-CI marker — deliberately NOT spelled
+  # out here; see the release-prepare guard for why quoting it literally is a
+  # hazard),
   # so the merge introduces no code that has not already been through the suite.
   #
   # This is NOT the same situation as a feature PR. There, two independently

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -213,6 +213,43 @@ jobs:
             echo "→ tagged ${after} — release-build.yml will pick it up"
           else
             echo "released=false" >> "$GITHUB_OUTPUT"
+
+            # On pre-main this is routine and fine: a push carrying only
+            # chore/docs/ci commits legitimately cuts nothing, and the next
+            # feature merge picks everything up.
+            #
+            # On MAIN it is a FAILURE, and must be loud. The only push to main
+            # is the pre-main → main release merge — a deliberate act whose
+            # entire purpose is to ship a version. If it produces no tag, the
+            # release silently did not happen, and a green check says otherwise.
+            #
+            # This is not hypothetical. It has now happened twice (#517, #522):
+            # both were SQUASH-merged, which collapses every conventional commit
+            # into one subject line — `release: …`, not a releasable type — so
+            # commit-analyzer found nothing and this step exited 0. Production
+            # sat on v1.74.0 while main carried the new code, and nothing in the
+            # UI indicated a problem.
+            #
+            # The cause is the merge method, so that is what the message names.
+            if [ "${GITHUB_REF_NAME}" = "main" ]; then
+              echo "::error::No releasable commits on main — no version was tagged and NOTHING WILL BUILD."
+              {
+                echo "### Release prepare FAILED"
+                echo ""
+                echo "A merge to \`main\` produced no release."
+                echo ""
+                echo "The usual cause is a **squash merge** of the \`pre-main → main\` PR."
+                echo "Squashing collapses every \`feat:\`/\`fix:\` commit into a single"
+                echo "subject line, and semantic-release reads subject lines only —"
+                echo "so it sees nothing to release."
+                echo ""
+                echo "Use **Create a merge commit** for release PRs, so the commits"
+                echo "arrive on \`main\` intact. Feature PRs into \`pre-main\` should still"
+                echo "be squashed."
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+            fi
+
             echo "→ no releasable commits; nothing tagged"
           fi
 


### PR DESCRIPTION
Targets `main` directly - the fix has to reach `main` to be releasable, and landing it is also what unblocks v1.75.0.

## ⚠️ Merge with "Create a merge commit", not squash

A squash collapses `fix(ci):` into whatever the PR title becomes, and semantic-release reads subject lines only - so it would find nothing to release and we would be in the same place a third time.

## Why this exists

`release-prepare` exited 0 when semantic-release found no releasable commits.

On `pre-main` that is correct - a push carrying only chore/docs/ci commits legitimately cuts nothing, and the next feature merge picks it all up. On `main` it is a failure. The only push to `main` is the `pre-main → main` release merge, a deliberate act whose entire purpose is to ship a version. Producing no tag means the release silently did not happen, and a green check actively said otherwise.

It has now happened twice. Both #517 and #522 were squash-merged:

```
$ git log v1.74.0..main --oneline
2d1ce104 release: cut v1.75.0 (re-merge #517 with history intact) (#522)
93a8d0f5 release: staging → production (Silicon-only pipeline, warm cache) (#517)

$ git rev-list --parents -n1 2d1ce104
2d1ce104 93a8d0f5      ← one parent: squash, not a merge
```

Both subjects start with `release:`, not a releasable type. The real `feat:`/`fix:` commits survive only as bullets in the body, which commit-analyzer does not read. Result:

```
Analysis of 1 commits complete: no release
There are no relevant changes, so no new version is released.
→ no releasable commits; nothing tagged
```

Exit 0. Green check. Production stayed on v1.74.0 while `main` carried the new pipeline, with nothing in the UI to indicate it.

## What changes

A `main` push that tags nothing now exits 1 with a `::error::` and a step summary naming the likely cause and the fix - use a merge commit for release PRs, keep squashing feature PRs into `pre-main`. `pre-main` behaviour is unchanged.

## Also: a self-inflicted hazard, defused

`ci.yml` carried a comment that quoted GitHub's skip-CI marker verbatim while explaining the version-bump commits. When #522 was squashed, every commit body was concatenated into `main`'s commit message, that quoted marker came along, and **GitHub skipped every workflow on the merge** - `CI`, `Cache warm` and `release-prepare` all never ran. So the merge failed for two independent reasons at once.

The comment now describes the marker instead of spelling it out. This is the same class of bug as the old `[staging-release]` marker documented in `release-prepare.yml`'s own header - *"this repo's own workflow comments quote the literal marker"* - which is why the replacement comment points at this guard rather than repeating the string.

## On merge

`fix(ci):` is releasable, so `release-prepare` should cut **v1.75.0**, commit the bump, push the tag, and `release-build` will publish the Apple-Silicon DMG (signed and notarized). The cache is already warm on `main` - `Cache warm (macOS release)` succeeded at 11:11 - so this should be the first build materially under the old ~25 minutes.

Note the payload it releases is everything already sitting on `main` from #517 and #522, which includes **dropping Windows and Intel from production** and **#520, compulsory sign-in**.

## Follow-up

`allowed_merge_methods` on the `main` ruleset is still `["merge","squash","rebase"]`, and GitHub remembers the last-used method per repo - which is why the button keeps defaulting to squash. Removing `squash` there makes this failure mode impossible rather than something to remember at the moment of merging. This PR only makes it *loud*.

## Verification

Both workflow files parse; the modified `run:` block passes `bash -n`; full pre-push suite green (fmt, clippy, UI build, UI tests, `cargo test`, security audit).
