### PR TITLE
fix(capture): bump screenpipe-fork to disable sck-rs on every macOS version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,12 @@ jobs:
           #   1bc2ba88 adityaharishch  fix(a11y): prune browser tab strip …
           #   4f9ba866 adityaharishch  Merge pull request #1 (same, ours)
           #   825b038d Akarsh Hegde    fix(screen): disable sck-rs on macOS 26
-          expected="825b038d845d7dcc8c1387b2707899b352417233"
+          #
+          # 2026-07-21, 825b038d -> 064c44cc. Two commits, all Meridiona-
+          # authored, no upstream merge:
+          #   552e7f8b adityaharishch  Merge pull request #2 (825b038d, already audited above)
+          #   064c44cc Akarsh Hegde    fix(screen): disable sck-rs unconditionally, not just on macOS 26+
+          expected="064c44ccd8c50716f21eec1663e1350e848ca5f5"
           f="tray/src-tauri/Cargo.toml"
           fail=0
           for crate in screenpipe-screen screenpipe-a11y; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8067,7 +8067,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "screenpipe-a11y"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8096,7 +8096,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-config"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8108,7 +8108,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-connect"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8147,7 +8147,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-core"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8187,7 +8187,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-db"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8213,7 +8213,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-events"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8230,7 +8230,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-screen"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8267,7 +8267,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-secrets"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8285,7 +8285,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-vault"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=825b038d845d7dcc8c1387b2707899b352417233#825b038d845d7dcc8c1387b2707899b352417233"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -106,13 +106,13 @@ meridian = { path = "../.." }
 # screen capture + Apple Vision OCR. Optional → only pulled by the `capture`
 # feature (heavy: ScreenCaptureKit/cidre/sck-rs). Private repo: local builds use
 # the user's git credentials; CI needs a deploy token (future).
-screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "825b038d845d7dcc8c1387b2707899b352417233", optional = true }
+screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "064c44ccd8c50716f21eec1663e1350e848ca5f5", optional = true }
 # Sibling crate in the same fork: the accessibility-tree walker (slice 3b).
 # `tree::create_tree_walker` walks the focused window's AX tree → structured
 # text — the PRIMARY signal for Electron/Chromium apps (VS Code, Slack), which
 # expose nothing to OCR-free a11y until the walker sets AXManualAccessibility
 # itself. Optional → only the `capture` feature pulls it.
-screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "825b038d845d7dcc8c1387b2707899b352417233", optional = true }
+screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "064c44ccd8c50716f21eec1663e1350e848ca5f5", optional = true }
 # Console log subscriber for capture-enabled non-otel runs (otel installs its
 # own). Makes the `capture: …` logs visible during a `cargo run --features capture`.
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }


### PR DESCRIPTION
## Summary

Follow-up to #(the macOS 26 sck-abort fix, commit `64198590`, `fix/macos26-sck-abort`),
which disabled `sck-rs` only on macOS 26+ after `SCShareableContent`'s
completion block turned out to be released once too often — a double-free
inside ScreenCaptureKit's own XPC reply teardown, on the
`com.apple.NSXPCConnection.m-user.com.apple.replayd` thread. Deterministic
there: aborted on the very first call, every time.

An independent field report against a production DMG install (macOS 14.7.4,
8GB RAM, heavy swap pressure) collected **14 crash reports** whose faulting
thread queue is, in every single one, exactly
`com.apple.NSXPCConnection.m-user.com.apple.replayd` — confirmed by parsing
the `.ips` files directly, not by inference from the truncated backtrace the
reporter's own analysis included. Same use-after-free/double-free as the
26+ case; below 26 it reproduces as a probabilistic race under memory
pressure (launch-time, idle, and click-triggered — consistent with a race
reachable from more than one call site into the same buggy binding) instead
of a guaranteed one. The version-scoped gate left every pre-26 install still
exposed.

Ruled out before landing on this diagnosis: WKWebView/webview IPC, the
notifications plugin, and the `open_external_url`/Tauri opener command (all
initially plausible given the report's own — incorrect — guess that this was
webview-related; the opener just spawns `/usr/bin/open`, no NSWorkspace/XPC
call happens in-process). The queue name is the same across all 14 reports
regardless of which of the two observed triggers (a UI click vs. idle
background activity) produced it, which is what points at the shared
capture engine rather than either specific call site.

## Change

Bumps `screenpipe-screen`/`screenpipe-a11y`'s pinned rev to
`Meridiona/screenpipe-fork`'s `fix/disable-sck-rs-universally`
(**Meridiona/screenpipe-fork#3**), which widens `use_sck_rs()` to return
`false` unconditionally instead of only on macOS 26+ — same
xcap/CoreGraphics fallback already proven safe there.
`SCREENPIPE_FORCE_SCK=1` still re-enables ScreenCaptureKit for testing
whether a newer sck-rs/cidre has actually fixed the binding.

`Cargo.lock` diff is scoped to only the 9 `screenpipe-*` crates sourced from
the fork. The unrelated, unpinned `cidre` transitive dependency briefly
floated to its upstream HEAD as a side effect of a multi-package
`cargo update`; re-pinned it back to its previously locked commit before
committing, so this PR carries no incidental dependency drift.

Per repo convention (see `64198590`), this pins to the fork's fix branch tip
commit ahead of that PR merging — Meridiona/screenpipe-fork#3 is open but
not yet merged.

## Test plan
- [x] `cargo build --release --bin meridian` (daemon, needed by the tray build in a fresh worktree)
- [x] `cargo check --features capture` (tray) — clean, pulls the new pinned rev
- [x] `cargo clippy --features capture -- -D warnings` (tray) — clean
- [x] `cargo test --features capture` (tray) — 131 passed
- [x] `cargo fmt --check` — clean
- [x] Full pre-push suite (fmt, ui build, ui tests, clippy, security audit, cargo test) passed on push
- [ ] Manual repro on the reporter's machine (or a memory-capped VM): confirm the tray no longer aborts under the same conditions once this + Meridiona/screenpipe-fork#3 both land

🤖 Generated with [Claude Code](https://claude.com/claude-code)