### PR TITLE
fix(ci): let a stable release tag actually trigger its build

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -231,6 +231,28 @@ jobs:
             # UI indicated a problem.
             #
             # The cause is the merge method, so that is what the message names.
+            #
+            # ONE EXEMPTION: semantic-release's own version-bump commit. The
+            # stable config's @semantic-release/git plugin commits the bump back
+            # to main, and that push re-enters this workflow. There is
+            # legitimately nothing to release then — `chore(release): …` is not a
+            # releasable type, which is exactly what stops the loop — so failing
+            # would paint a red X on the tail end of a SUCCESSFUL release.
+            #
+            # Detected by the subject rather than a marker on purpose. That
+            # commit used to carry GitHub's skip-CI marker, which suppressed
+            # every workflow for the push — including the TAG push, since the tag
+            # points at this very commit. The tag landed and release-build never
+            # fired, so v1.74.1 tagged and built nothing. The marker is gone (see
+            # .releaserc.json); this check replaces the part of its job that was
+            # actually wanted.
+            subject="$(git log -1 --format=%s)"
+            if [ "${GITHUB_REF_NAME}" = "main" ] && \
+               [ "${subject#chore(release): }" != "${subject}" ]; then
+              echo "→ semantic-release's own bump commit (${subject}); nothing to release, as expected"
+              exit 0
+            fi
+
             if [ "${GITHUB_REF_NAME}" = "main" ]; then
               echo "::error::No releasable commits on main — no version was tagged and NOTHING WILL BUILD."
               {

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -89,7 +89,7 @@
           "packages/meridian-mcp/package.json",
           "tray/src-tauri/tauri.conf.json"
         ],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
       }
     ]
   ]


### PR DESCRIPTION
Makes a stable release publish itself, which it currently cannot. Targets `main`, since that is where the config lives.

## The bug

`.releaserc.json`'s `@semantic-release/git` plugin committed the version bump with GitHub's skip-CI marker in the subject:

```
chore(release): ${nextRelease.version} [skip ci]
```

The release tag points at **that very commit**. GitHub applies the skip to any push whose head commit carries the marker - **tag pushes included** - so `release-build.yml`, whose only trigger is `push: tags: ["v*"]`, never fired.

`v1.74.1` is tagged right now and built nothing. `release-prepare` reported success, because from its side the tag was cut correctly:

```
[semantic-release] The next release version is 1.74.1
→ tagged v1.74.1 — release-build.yml will pick it up
```

It did not. No draft, no DMG, no release. Production is still on v1.74.0.

This is structural and would have repeated on **every** stable release. It could not surface on staging: `.releaserc.staging.json` has no `@semantic-release/git` plugin at all, so staging tags point at ordinary commits and build fine - staging.11 and .12 both published themselves unattended. `v1.74.1` was the first stable tag this pipeline ever cut, and the first time the two halves met.

## Why removing the marker is safe

It was never what prevented a loop. The bump commit's subject is `chore(release):`, which is **not a releasable type** - so when its push re-enters `release-prepare`, commit-analyzer finds nothing and stops. That is the actual termination condition; the marker was belt-and-braces that turned out to cut the belt.

## The guard needs a matching carve-out

`release-prepare` now fails loudly when a push to `main` tags nothing (#523). Without the marker, the bump commit's own push hits exactly that path - so it would paint a red X on the tail end of a *successful* release.

The guard now exempts that one commit, detected by its `chore(release): ` subject:

```sh
subject="$(git log -1 --format=%s)"
if [ "${GITHUB_REF_NAME}" = "main" ] && \
   [ "${subject#chore(release): }" != "${subject}" ]; then
  echo "→ semantic-release's own bump commit (${subject}); nothing to release, as expected"
  exit 0
fi
```

Detected by subject rather than by a marker, deliberately - a marker is what caused this in the first place. A squash-merged release PR (`release: …`) still fails loudly, which is the case the guard exists for. Both branches verified:

```
subject="chore(release): 1.75.0"          → exempt
subject="release: staging to main (#522)" → fails loudly
```

## Cost

The bump commit's push now runs `CI`, `Cache warm` and a no-op `release-prepare`. That is a few extra runner-minutes per release, and the `Cache warm` run is actively useful - it reseeds the cache at the exact commit the next release branches from.

## After this lands

A stable release is hands-off again, matching staging:

```
merge pre-main → main (merge commit)
  → release-prepare tags vX.Y.Z
  → tag push fires release-build
  → draft created, signed, notarized, published
```

## Note on v1.74.1

This does not retroactively build the existing tag - that commit already carries the marker. Dispatch it when ready:

```
gh workflow run release-build.yml -f tag=v1.74.1
```

## Merging

**Use "Create a merge commit."** The title is `fix(ci): …`, so a squash would still be releasable here - but the habit is what cost #517 and #522, and `allowed_merge_methods` on the `main` ruleset still includes `squash`.

## Verification

`.releaserc.json` parses as JSON; workflow parses as YAML; the modified `run:` block passes `bash -n`; both guard branches exercised as shown above; full pre-push suite green.
