### PR TITLE
ci: sync the release-pipeline fixes back from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,10 @@ on:
   # The only PR that ever targets main is the `pre-main → main` release merge,
   # and running CI on it re-tests a tree CI has already passed twice: once on
   # each commit's own feature PR, and again on the push to pre-main. main holds
-  # nothing pre-main lacks except `chore(release): X [skip ci]` version bumps,
+  # nothing pre-main lacks except semantic-release's own `chore(release): X`
+  # version bumps (which used to carry GitHub's skip-CI marker — deliberately NOT
+  # spelled out here; see the release-prepare guard for why quoting it literally
+  # is a hazard),
   # so the merge introduces no code that has not already been through the suite.
   #
   # This is NOT the same situation as a feature PR. There, two independently

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -213,6 +213,65 @@ jobs:
             echo "→ tagged ${after} — release-build.yml will pick it up"
           else
             echo "released=false" >> "$GITHUB_OUTPUT"
+
+            # On pre-main this is routine and fine: a push carrying only
+            # chore/docs/ci commits legitimately cuts nothing, and the next
+            # feature merge picks everything up.
+            #
+            # On MAIN it is a FAILURE, and must be loud. The only push to main
+            # is the pre-main → main release merge — a deliberate act whose
+            # entire purpose is to ship a version. If it produces no tag, the
+            # release silently did not happen, and a green check says otherwise.
+            #
+            # This is not hypothetical. It has now happened twice (#517, #522):
+            # both were SQUASH-merged, which collapses every conventional commit
+            # into one subject line — `release: …`, not a releasable type — so
+            # commit-analyzer found nothing and this step exited 0. Production
+            # sat on v1.74.0 while main carried the new code, and nothing in the
+            # UI indicated a problem.
+            #
+            # The cause is the merge method, so that is what the message names.
+            #
+            # ONE EXEMPTION: semantic-release's own version-bump commit. The
+            # stable config's @semantic-release/git plugin commits the bump back
+            # to main, and that push re-enters this workflow. There is
+            # legitimately nothing to release then — `chore(release): …` is not a
+            # releasable type, which is exactly what stops the loop — so failing
+            # would paint a red X on the tail end of a SUCCESSFUL release.
+            #
+            # Detected by the subject rather than a marker on purpose. That
+            # commit used to carry GitHub's skip-CI marker, which suppressed
+            # every workflow for the push — including the TAG push, since the tag
+            # points at this very commit. The tag landed and release-build never
+            # fired, so v1.74.1 tagged and built nothing. The marker is gone (see
+            # .releaserc.json); this check replaces the part of its job that was
+            # actually wanted.
+            subject="$(git log -1 --format=%s)"
+            if [ "${GITHUB_REF_NAME}" = "main" ] && \
+               [ "${subject#chore(release): }" != "${subject}" ]; then
+              echo "→ semantic-release's own bump commit (${subject}); nothing to release, as expected"
+              exit 0
+            fi
+
+            if [ "${GITHUB_REF_NAME}" = "main" ]; then
+              echo "::error::No releasable commits on main — no version was tagged and NOTHING WILL BUILD."
+              {
+                echo "### Release prepare FAILED"
+                echo ""
+                echo "A merge to \`main\` produced no release."
+                echo ""
+                echo "The usual cause is a **squash merge** of the \`pre-main → main\` PR."
+                echo "Squashing collapses every \`feat:\`/\`fix:\` commit into a single"
+                echo "subject line, and semantic-release reads subject lines only —"
+                echo "so it sees nothing to release."
+                echo ""
+                echo "Use **Create a merge commit** for release PRs, so the commits"
+                echo "arrive on \`main\` intact. Feature PRs into \`pre-main\` should still"
+                echo "be squashed."
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+            fi
+
             echo "→ no releasable commits; nothing tagged"
           fi
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -89,7 +89,7 @@
           "packages/meridian-mcp/package.json",
           "tray/src-tauri/tauri.conf.json"
         ],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
       }
     ]
   ]


### PR DESCRIPTION
Brings `pre-main` level with the release-pipeline fixes that landed directly on `main` as #523 and #525.

## Why they bypassed pre-main

`release-prepare.yml` and `.releaserc.json` are read from the branch the workflow runs on. Routing the fixes through `pre-main` would have meant waiting for a `pre-main → main` release merge - which is precisely what was broken. So they went to `main` directly, correctly for the emergency, leaving `pre-main` three files behind.

## Why sync now

**Not a revert risk.** Git's three-way merge would keep `main`'s side on the next release merge, since only `main` touched these files.

**It is a conflict risk.** `pre-main` is where all normal work happens, and there is a lot of CI work in flight. The moment someone edits these files here, the next release merge conflicts on them - and a careless "take theirs" silently undoes fixes that were expensive to find.

## Carried over

- **`release-prepare.yml`** - fails loudly when a push to `main` tags nothing, with a step summary naming the squash-merge cause; exempts semantic-release's own `chore(release)` bump commit so a successful release does not end in a red X
- **`.releaserc.json`** - drops the skip-CI marker from the bump commit, so the release tag pointing at that commit actually triggers `release-build` (this is what left `v1.74.1` tagged-but-unbuilt)
- **`ci.yml`** - the comment now describes the marker instead of quoting it verbatim

## ⚠️ Only the comment was taken from ci.yml, not the file

Copying `main`'s `ci.yml` wholesale would have **reverted the screenpipe-fork pin**:

```diff
-          expected="064c44ccd8c50716f21eec1663e1350e848ca5f5"   ← pre-main (current)
+          expected="825b038d845d7dcc8c1387b2707899b352417233"   ← main (older)
```

`pre-main` advanced that pin in `fix/bump-screenpipe-fork-sck-universal-disable`, which has not reached `main` yet. Only the four comment lines were applied; the pin is untouched, and the pre-push run resolved `064c44cc` from the fork as expected.

The version bumps and CHANGELOG entries for 1.74.1 / 1.74.2 are deliberately **not** carried over - that is `main`-only bookkeeping, and `pre-main` stamps its version from the tag at build time rather than reading `Cargo.toml`.

## No behaviour change on pre-main

The guard's new branch is gated on `GITHUB_REF_NAME = main`, and the staging channel uses `.releaserc.staging.json`, which has no `@semantic-release/git` plugin. Staging releases are unaffected either way.

## Verification

`.releaserc.json` parses as JSON, both workflows parse as YAML, screenpipe pin confirmed still `064c44cc`, full pre-push suite green.
