### PR TITLE
Daily-plan visibility + task status changes from the timeline

### DIFF
--- a/meridian-core/src/readers/task_create.rs
+++ b/meridian-core/src/readers/task_create.rs
@@ -235,7 +235,8 @@ pub async fn update_task_text(
 
 /// Mark a personal task done / not-done. The tracker equivalent is
 /// `ticket_update`'s `close`/`reopen`; same `provider = 'local'` scoping rationale as
-/// [`update_task_text`].
+/// [`update_task_text`]. A thin wrapper over [`set_local_status`] for the two callers
+/// (the plan checkbox, `src/plan_tasks/done.rs`) that only ever mean "done" or "To Do".
 #[tracing::instrument(skip(pool))]
 pub async fn set_local_terminal(
     pool: &SqlitePool,
@@ -243,12 +244,102 @@ pub async fn set_local_terminal(
     done: bool,
     now: &str,
 ) -> Result<bool> {
+    set_local_status(
+        pool,
+        task_key,
+        if done { "Done" } else { "To Do" },
+        done,
+        now,
+    )
+    .await
+}
+
+/// One status a personal task can be moved to. Unlike a real tracker, there is no
+/// workflow to ask — a personal task always offers exactly this fixed three-status
+/// lifecycle (todo/in_progress/done), mirroring the canonical categories a tracker's
+/// own statuses are normalised into (see `src/intelligence/ticket_update/statuses.rs`'s
+/// `StatusOption`) so the UI's `StatusPicker` treats a personal task identically to a
+/// tracker one.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LocalStatusOption {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub category: &'static str,
+}
+
+/// The personal-task lifecycle, in display order. `id` doubles as the wire value the
+/// UI's `StatusPicker` sends back on a pick — there is no separate tracker-assigned id
+/// to preserve, unlike Jira's transition ids.
+pub const LOCAL_STATUSES: &[LocalStatusOption] = &[
+    LocalStatusOption {
+        id: "todo",
+        name: "To Do",
+        category: "todo",
+    },
+    LocalStatusOption {
+        id: "in_progress",
+        name: "In Progress",
+        category: "in_progress",
+    },
+    LocalStatusOption {
+        id: "done",
+        name: "Done",
+        category: "done",
+    },
+];
+
+/// Resolve a chosen status against [`LOCAL_STATUSES`]: an exact id match wins, else a
+/// case-insensitive name match — the same id-or-name contract
+/// `ticket_update::statuses::resolve_choice` uses for a real tracker, which is what
+/// lets the UI's Undo pass back the previous status's NAME uniformly for either kind
+/// of task.
+pub fn resolve_local_status(choice: &str) -> Option<&'static LocalStatusOption> {
+    LOCAL_STATUSES
+        .iter()
+        .find(|o| o.id.eq_ignore_ascii_case(choice))
+        .or_else(|| {
+            LOCAL_STATUSES
+                .iter()
+                .find(|o| o.name.eq_ignore_ascii_case(choice))
+        })
+}
+
+/// A personal task's current `(status_raw, is_terminal)`, or `None` if `task_key`
+/// isn't a personal task (unknown key, or owned by a real tracker).
+#[tracing::instrument(skip(pool))]
+pub async fn local_task_current(
+    pool: &SqlitePool,
+    task_key: &str,
+) -> Result<Option<(String, bool)>> {
+    let row: Option<(String, i64)> = sqlx::query_as(
+        "SELECT status_raw, is_terminal FROM pm_tasks WHERE task_key = ? AND provider = ?",
+    )
+    .bind(task_key)
+    .bind(LOCAL_PROVIDER)
+    .fetch_optional(pool)
+    .await
+    .context("reading the personal task's current status")?;
+    Ok(row.map(|(status, terminal)| (status, terminal != 0)))
+}
+
+/// Move a personal task to `status_name` (one of [`LOCAL_STATUSES`]'s display names),
+/// with `is_terminal` set from that status's category — the same two columns
+/// [`set_local_terminal`] used to write directly, now shared with the richer
+/// todo/in_progress/done picker.
+#[tracing::instrument(skip(pool))]
+pub async fn set_local_status(
+    pool: &SqlitePool,
+    task_key: &str,
+    status_name: &str,
+    is_terminal: bool,
+    now: &str,
+) -> Result<bool> {
     let res = sqlx::query(
         "UPDATE pm_tasks SET is_terminal = ?, status_raw = ?, updated_at = ? \
          WHERE task_key = ? AND provider = ?",
     )
-    .bind(i64::from(done))
-    .bind(if done { "Done" } else { "To Do" })
+    .bind(i64::from(is_terminal))
+    .bind(status_name)
     .bind(now)
     .bind(task_key)
     .bind(LOCAL_PROVIDER)

--- a/meridian-core/tests/readers.rs
+++ b/meridian-core/tests/readers.rs
@@ -1017,6 +1017,46 @@ async fn local_task_edits_round_trip() {
 }
 
 #[tokio::test]
+async fn local_task_moves_through_the_in_progress_status() {
+    // The richer todo/in_progress/done picker a personal task's StatusPicker now
+    // offers (same UI as a tracker ticket) — set_local_terminal only ever wrote
+    // "To Do"/"Done"; this is the middle status it couldn't reach.
+    let pool = make_task_create_pool().await;
+    let key = meridian_core::task_create::create_local_task(&pool, "T", "d", "Task", "t0")
+        .await
+        .unwrap();
+
+    let in_progress = meridian_core::task_create::resolve_local_status("in_progress").unwrap();
+    assert_eq!(in_progress.name, "In Progress");
+    assert!(meridian_core::task_create::set_local_status(
+        &pool,
+        &key,
+        in_progress.name,
+        in_progress.category == "done",
+        "t1",
+    )
+    .await
+    .unwrap());
+
+    let (status, terminal) = meridian_core::task_create::local_task_current(&pool, &key)
+        .await
+        .unwrap()
+        .expect("the task must still exist");
+    assert_eq!(status, "In Progress");
+    assert!(!terminal, "In Progress is not a terminal category");
+
+    // Case-insensitive name resolution (the Undo path passes back a status NAME,
+    // same contract as a real tracker's `resolve_choice`).
+    assert_eq!(
+        meridian_core::task_create::resolve_local_status("DONE")
+            .unwrap()
+            .id,
+        "done"
+    );
+    assert!(meridian_core::task_create::resolve_local_status("bogus").is_none());
+}
+
+#[tokio::test]
 async fn insert_task_is_idempotent_on_a_double_submit() {
     let pool = make_task_create_pool().await;
     let t = meridian_core::task_create::NewTask {

--- a/tray/src-tauri/src/commands/statuses.rs
+++ b/tray/src-tauri/src/commands/statuses.rs
@@ -12,9 +12,15 @@
 //!
 //! Tracker auth lives in the daemon (`~/.meridian/.env`), so — exactly like
 //! [`crate::commands::apply_ticket_fix`] and [`crate::commands::get_ticket_parents`]
-//! — these **shell out to the `meridian` CLI** (`ticket-statuses` /
-//! `ticket-set-status`) rather than talking to any tracker in-process. They are
-//! NOT DB reads, so they live tray-side, not in meridian-core.
+//! — a TRACKER-owned ticket **shells out to the `meridian` CLI** (`ticket-statuses` /
+//! `ticket-set-status`) rather than talking to any tracker in-process.
+//!
+//! A **personal** (`provider = 'local'`) task is different: there is no tracker to
+//! authenticate against, just our own `pm_tasks` row, so both commands short-circuit
+//! straight to [`meridian_core::task_create`]'s local-status helpers instead of
+//! shelling out — a personal task's fixed To Do/In Progress/Done lifecycle
+//! ([`meridian_core::task_create::LOCAL_STATUSES`]) is a plain DB read/write, not a
+//! process worth spawning for.
 //!
 //! # Who calls this
 //! Registered in `lib.rs`'s `invoke_handler!`; consumed by the dashboard's status
@@ -31,6 +37,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
+use tauri::State;
 
 // The CLI-spawning contract (argv/no shell, `current_dir(~/.meridian)` so dotenvy
 // finds the daemon's `.env`, a timeout, last-line JSON, and a diagnostic that names
@@ -82,17 +89,51 @@ pub struct SetStatusBody {
     pub status_id: String,
 }
 
-/// List the statuses `key` can move to (+ its current status) on `provider`.
-/// Spawns `meridian ticket-statuses --provider <p> --key <k>` (argv, no shell —
-/// no injection), 30 s timeout, and parses the last JSON line of stdout.
+/// One [`meridian_core::task_create::LocalStatusOption`] shaped as a [`StatusOptionDto`].
+fn local_status_dto(o: &meridian_core::task_create::LocalStatusOption) -> StatusOptionDto {
+    StatusOptionDto {
+        id: o.id.to_string(),
+        name: o.name.to_string(),
+        category: o.category.to_string(),
+    }
+}
+
+/// List the statuses `key` can move to (+ its current status) on `provider`. A
+/// personal task reads its fixed local lifecycle straight from `pm_tasks`
+/// (see the module header); a tracker-owned ticket spawns
+/// `meridian ticket-statuses --provider <p> --key <k>` (argv, no shell — no
+/// injection), 30 s timeout, and parses the last JSON line of stdout.
 #[tauri::command]
-#[tracing::instrument]
+#[tracing::instrument(skip(pool))]
 pub async fn list_task_statuses(
+    pool: State<'_, Option<meridian_core::SqlitePool>>,
     provider: String,
     key: String,
 ) -> Result<StatusListResponse, String> {
     if provider.is_empty() || key.is_empty() {
         return Err("provider and key are required".to_string());
+    }
+    if provider == meridian_core::task_create::LOCAL_PROVIDER {
+        let Some(pool) = pool.inner() else {
+            return Err("meridian.db is not open yet".to_string());
+        };
+        let current = meridian_core::task_create::local_task_current(pool, &key)
+            .await
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("no personal task {key}"))?;
+        let (current_name, _) = current;
+        let current_id = meridian_core::task_create::resolve_local_status(&current_name)
+            .map(|o| o.id.to_string());
+        let resp = StatusListResponse {
+            statuses: meridian_core::task_create::LOCAL_STATUSES
+                .iter()
+                .map(local_status_dto)
+                .collect(),
+            current_id,
+            current_name: Some(current_name),
+        };
+        tracing::info!(%key, "list_task_statuses served (personal task)");
+        return Ok(resp);
     }
     let resp: StatusListResponse = run_meridian_json(
         &["ticket-statuses", "--provider", &provider, "--key", &key],
@@ -104,15 +145,50 @@ pub async fn list_task_statuses(
     Ok(resp)
 }
 
-/// Move `key` to `status_id` (an id OR a status name) on `provider`. Spawns
-/// `meridian ticket-set-status --provider <p> --key <k> --status <s>` (argv, no
+/// Move `key` to `status_id` (an id OR a status name) on `provider`. A personal task
+/// writes straight to `pm_tasks` (see the module header); a tracker-owned ticket
+/// spawns `meridian ticket-set-status --provider <p> --key <k> --status <s>` (argv, no
 /// shell), 60 s timeout (an applied move re-syncs the board), and parses the last
 /// JSON line of stdout.
 #[tauri::command]
-#[tracing::instrument(skip(body), fields(provider = %body.provider, key = %body.key, status_id = %body.status_id))]
-pub async fn set_task_status(body: SetStatusBody) -> Result<SetStatusResponse, String> {
+#[tracing::instrument(skip(body, pool), fields(provider = %body.provider, key = %body.key, status_id = %body.status_id))]
+pub async fn set_task_status(
+    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    body: SetStatusBody,
+) -> Result<SetStatusResponse, String> {
     if body.provider.is_empty() || body.key.is_empty() || body.status_id.is_empty() {
         return Err("provider, key and status_id are required".to_string());
+    }
+    if body.provider == meridian_core::task_create::LOCAL_PROVIDER {
+        let Some(pool) = pool.inner() else {
+            return Err("meridian.db is not open yet".to_string());
+        };
+        let Some(opt) = meridian_core::task_create::resolve_local_status(&body.status_id) else {
+            return Err(format!("unknown status \"{}\"", body.status_id));
+        };
+        let now = chrono::Utc::now().to_rfc3339();
+        let is_terminal = opt.category == "done";
+        let changed = meridian_core::task_create::set_local_status(
+            pool,
+            &body.key,
+            opt.name,
+            is_terminal,
+            &now,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+        if !changed {
+            return Err(format!("could not update {}", body.key));
+        }
+        tracing::info!(status = opt.name, "set_task_status applied (personal task)");
+        return Ok(SetStatusResponse {
+            result: SetStatusOutcome {
+                status: "applied".to_string(),
+                browse_url: None,
+                reason: None,
+            },
+            new_status: Some(local_status_dto(opt)),
+        });
     }
     let resp: SetStatusResponse = run_meridian_json(
         &[

--- a/ui/components/plan/PlanView.tsx
+++ b/ui/components/plan/PlanView.tsx
@@ -23,7 +23,7 @@ import { TaskDetailDialog } from '@/components/timeline/TaskDetailDialog'
 import { dayString } from '@/components/timeline/types'
 import type { PlanResponse, IntegrationsResponse } from '@/lib/api-types'
 import { MAX_PLAN_TASKS } from '@/lib/api-types'
-import { load as bridgeLoad } from '@/lib/bridge'
+import { load as bridgeLoad, mutate as bridgeMutate } from '@/lib/bridge'
 import { connectedTrackers } from '@/lib/integrations'
 import { usePlan, refreshPlan, planAction, pausePlanRefresh } from '@/components/plan/planStore'
 
@@ -50,6 +50,8 @@ export default function PlanView() {
   const [capHit, setCapHit] = useState(false)
   const [openTask, setOpenTask] = useState<CardTask | null>(null)
   const [trackers, setTrackers] = useState<ReturnType<typeof connectedTrackers>>([])
+  const [syncing, setSyncing] = useState(false)
+  const [syncError, setSyncError] = useState(false)
   const draggingRef = useRef(false)
 
   const derive = useCallback((d: PlanResponse) => {
@@ -85,6 +87,19 @@ export default function PlanView() {
     const id = setInterval(() => load(false), 30_000)
     return () => clearInterval(id)
   }, [load])
+
+  // Pull the latest tickets from every connected tracker before re-deriving the
+  // board — same `sync_tasks` command and refresh-after pattern as the Tasks
+  // page's own Refresh button (TasksPanel.tsx's handleSync). Only meaningful
+  // with a tracker connected: personal-only plans have nothing to sync.
+  const handleSync = useCallback(() => {
+    if (syncing) return
+    setSyncing(true); setSyncError(false)
+    bridgeMutate('/api/tasks/sync', 'sync_tasks', {})
+      .then(() => load(true))
+      .catch(() => setSyncError(true))
+      .finally(() => setSyncing(false))
+  }, [syncing, load])
 
   // Which trackers are connected decides whether the composer offers a "file it on
   // my board" choice at all. A failure here is not fatal: [] means personal-only,
@@ -230,7 +245,21 @@ export default function PlanView() {
     <DragDropContext onDragStart={() => { draggingRef.current = true; pausePlanRefresh(true) }} onDragEnd={onDragEnd}>
       <div className="flex-1 min-h-0 flex flex-col">
         <header className="shrink-0 flex items-center justify-between gap-4 px-6 pt-5 pb-4 border-b" style={{ borderColor: 'var(--t-hair)' }}>
-          <p className="mt-label" style={{ color: 'var(--t-faint)' }}>{dateLabel}</p>
+          <div className="flex items-center gap-3">
+            <p className="mt-label" style={{ color: 'var(--t-faint)' }}>{dateLabel}</p>
+            {/* Only meaningful with a tracker connected — a personal-only plan
+                has nothing on a remote board to pull. Same sync + button
+                treatment as the Tasks page's Refresh (TasksPanel.tsx). */}
+            {trackers.length > 0 && (
+              <button onClick={handleSync} disabled={syncing}
+                className="mt-body-sm px-2.5 py-1 rounded-md bg-ctrl inline-flex items-center gap-1.5"
+                style={{ border: `1px solid ${syncError ? 'var(--color-state-pending)' : 'var(--t-ctrl-border)'}`, color: syncError ? 'var(--color-state-pending)' : 'var(--t-muted)', opacity: syncing ? 0.6 : 1 }}
+                title="Pull latest tickets from your trackers">
+                <span style={{ display: 'inline-block', animation: syncing ? 'spin 1s linear infinite' : 'none' }}>{syncError ? '⚠' : '↻'}</span>
+                {syncing ? 'Syncing…' : syncError ? 'Sync failed' : 'Refresh'}
+              </button>
+            )}
+          </div>
           <div className="text-right shrink-0">
             {confirmedMode
               ? (editing

--- a/ui/components/timeline/OverviewPanel.tsx
+++ b/ui/components/timeline/OverviewPanel.tsx
@@ -3,7 +3,8 @@
 // The right panel's default state (no hour selected). Layout mirrors the
 // design mock: eyebrow + greeting + summary line, drafts-to-review CTA,
 // board-cleanup CTA, a "Today's focus" plan checklist, a "Today" mini-card
-// row (Logged / Focus / Drafts), the time-by-app chart, and a Tasks entry
+// row (Focus / Drafts — Drafts opens the swipeable review dialog), the
+// time-by-app chart, and a Tasks entry
 // point (connected users only for the CTAs/plan; solo users get the greeting
 // + Today cards + time-by-app). Narrative + metric fields are adapted from
 // the retired TodayView's data; the plan checklist reads the same get_plan
@@ -81,14 +82,6 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
   const appTops = today ? appTotals(today.sessions, codingAgents?.agents ?? []) : []
   const appCount = appTops.length
   const catTops = today ? categoryRows(today.sessions, agent_s) : []
-  // Pull the "Coding" number straight out of the SAME merged rows the
-  // category chart renders, rather than recomputing it — guarantees the top
-  // stat and the pie slice can never disagree, since they're reading the
-  // identical value, not two independently-derived numbers that happen to
-  // match today and drift apart the next time either side changes.
-  const codingRow = catTops.find(r => r.cat === 'coding')
-  const coding_s = codingRow?.seconds ?? 0
-  // const codingSub = agent_s > 0 && autonomous_s > 0 ? `incl. ${fmtDur(autonomous_s)} autonomous` : undefined
   // Real worklogs only — is_proposed items carry an 'approved'/'posted' state
   // once a user approves them in-app, but the daemon hasn't necessarily swept
   // them into an actual pm_worklogs row (real ticket created + worklog posted)
@@ -160,18 +153,6 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
 
   return (
     <div className="h-full overflow-y-auto nice-scroll p-6 space-y-7">
-      {/* The plan feature's own empty-state CTA — first thing in the panel so
-          it's impossible to scroll past. Shown to EVERY user (including solo/
-          no-tracker — PlanView's composer already supports a personal,
-          tracker-free task, see PlanView.tsx's `boardEmpty` path), only for
-          today (a past day's empty plan is a quiet historical fact, not
-          something to act on — see the read-only branch further down), and
-          only once the plan has actually loaded so it never flashes before
-          `get_plan` resolves. */}
-      {isToday && plan && focusItems.length === 0 && (
-        <EmptyPlanNudge onOpen={() => onOpen('plan')} />
-      )}
-
       {/* DMG update CTA — only renders when a newer version is available; sits
           at the top of the sidebar so it's noticeable without stealing the
           whole header. Sibling of the tray popover's update banner. */}
@@ -185,27 +166,24 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
 
       <div className="rounded-xl overflow-hidden bg-card p-4" style={{ border: '1px solid var(--t-card-border)' }}>
         <div className="mb-3"><SectionHeading>{dayLabel}</SectionHeading></div>
-        {/* Solo mode: Logged/Drafts both require PM-matched worklogs, which
-            don't exist without a tracker — showing them here would always
-            read "0s"/some stale count. Focus is the one stat that's real.
-            One uniform card style for every tile (no per-stat hue) — these
-            are plain counters, not distinct categories that need color
-            coding to tell apart. */}
+        {/* Solo mode: Drafts requires PM-matched worklogs, which don't exist
+            without a tracker — showing it here would always read some stale
+            count. Focus is the one stat that's real. */}
         {isSolo ? (
-          <div className={`grid gap-3 ${coding_s > 0 ? 'grid-cols-2' : 'grid-cols-1'}`}>
+          <div className="grid grid-cols-1 gap-3">
             <Mini label="Focus" value={fmtDur(focus_s)} />
-            {coding_s > 0 && <Mini label="Coding" value={fmtDur(coding_s)} />}
           </div>
         ) : (
-          // 2×2 (not 4-across) — a 4-column grid in a ~340px panel left no
-          // room for "3h 24m"-length values without wrapping. Order: Focus
-          // leads, Coding next when there's agent/coding time, then the
-          // remaining two.
+          // Just Focus + Drafts — Drafts doubles as the entry point into the
+          // swipeable review dialog (same one FloatingDraftsPill opens), so
+          // it renders as a button once there's something to review, with an
+          // accent color to signal it's live/actionable rather than a plain
+          // counter like the other tiles used to be.
           <div className="grid grid-cols-2 gap-3">
             <Mini label="Focus" value={fmtDur(focus_s)} />
-            {coding_s > 0 && <Mini label="Coding" value={fmtDur(coding_s)} />}
-            <Mini label="Logged" value={fmtDur(loggedSeconds)} />
-            <Mini label="Drafts" value={String(pendingCount)} />
+            <Mini label="Drafts" value={String(pendingCount)}
+              onClick={pendingCount > 0 ? () => onOpen('review') : undefined}
+              accent={pendingCount > 0} />
           </div>
         )}
       </div>
@@ -227,12 +205,21 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
       {/* Editing is a today-only action — you plan the day you're in, not the
           past. On a past date the section is read-only: it shows that day's
           committed focus (or a quiet empty note), with no Edit/Add
-          affordances. `focusLabel` relabels the heading off "Today's". The
-          empty-today case no longer renders anything here — the top-of-panel
-          EmptyPlanNudge above owns that CTA now. */}
-      {!isSolo && (focusItems.length > 0 || !isToday) && (
+          affordances. `focusLabel` relabels the heading off "Today's".
+          The empty-TODAY case is shown to every user, including solo/
+          no-tracker (PlanView's composer already supports a personal,
+          tracker-free task, see PlanView.tsx's `boardEmpty` path) — everything
+          else (the populated checklist, and a past day's read-only note)
+          stays tracker-only, unchanged. `plan` gates the empty branch so it
+          never flashes before the first `get_plan` resolves. */}
+      {((isToday && plan && focusItems.length === 0) || (!isSolo && (focusItems.length > 0 || !isToday))) && (
         <div>
-          {focusItems.length > 0 ? (
+          {focusItems.length === 0 && isToday ? (
+            <div>
+              <div className="mb-2.5"><SectionHeading>Today&apos;s focus</SectionHeading></div>
+              <EmptyPlanNudge onOpen={() => onOpen('plan')} />
+            </div>
+          ) : focusItems.length > 0 ? (
             <div className="rounded-xl overflow-hidden bg-card" style={{ border: '1px solid var(--t-card-border)' }}>
               <div className="flex items-center justify-between px-4 py-3">
                 <SectionHeading>{focusLabel}</SectionHeading>
@@ -389,12 +376,29 @@ function EntryRow({ label, hint, onClick }: { label: string; hint: string; onCli
   )
 }
 
-function Mini({ label, value, sub }: { label: string; value: string; sub?: string }) {
-  return (
-    <div className="rounded-xl p-3 bg-box">
-      <p className="mt-stat text-title whitespace-nowrap">{value}</p>
+// `onClick` + `accent` turn this into a live entry point (used for Drafts,
+// once there's something to review) rather than a plain counter — accent
+// colors the value the same amber as FloatingDraftsPill so the two read as
+// the same affordance, and the button semantics + hover/press feedback
+// signal it's clickable without adding a whole separate visual style.
+function Mini({ label, value, sub, onClick, accent }: {
+  label: string; value: string; sub?: string; onClick?: () => void; accent?: boolean
+}) {
+  const content = (
+    <>
+      <p className="mt-stat whitespace-nowrap"
+        style={{ color: accent ? 'var(--color-state-pending)' : 'var(--t-title)' }}>{value}</p>
       <p className="mt-label mt-1" style={{ color: 'var(--t-faint)' }}>{label}</p>
       {sub && <p className="mt-body-sm mt-0.5" style={{ color: 'var(--t-faint)', fontSize: 10.5 }}>{sub}</p>}
-    </div>
+    </>
   )
+  if (onClick) {
+    return (
+      <button onClick={onClick}
+        className="w-full text-left rounded-xl p-3 bg-box mt-card-hover transition-transform active:scale-95 cursor-pointer">
+        {content}
+      </button>
+    )
+  }
+  return <div className="rounded-xl p-3 bg-box">{content}</div>
 }

--- a/ui/components/timeline/OverviewPanel.tsx
+++ b/ui/components/timeline/OverviewPanel.tsx
@@ -160,6 +160,18 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
 
   return (
     <div className="h-full overflow-y-auto nice-scroll p-6 space-y-7">
+      {/* The plan feature's own empty-state CTA — first thing in the panel so
+          it's impossible to scroll past. Shown to EVERY user (including solo/
+          no-tracker — PlanView's composer already supports a personal,
+          tracker-free task, see PlanView.tsx's `boardEmpty` path), only for
+          today (a past day's empty plan is a quiet historical fact, not
+          something to act on — see the read-only branch further down), and
+          only once the plan has actually loaded so it never flashes before
+          `get_plan` resolves. */}
+      {isToday && plan && focusItems.length === 0 && (
+        <EmptyPlanNudge onOpen={() => onOpen('plan')} />
+      )}
+
       {/* DMG update CTA — only renders when a newer version is available; sits
           at the top of the sidebar so it's noticeable without stealing the
           whole header. Sibling of the tray popover's update banner. */}
@@ -212,18 +224,14 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
         </button>
       )}
 
-      {!isSolo && (
+      {/* Editing is a today-only action — you plan the day you're in, not the
+          past. On a past date the section is read-only: it shows that day's
+          committed focus (or a quiet empty note), with no Edit/Add
+          affordances. `focusLabel` relabels the heading off "Today's". The
+          empty-today case no longer renders anything here — the top-of-panel
+          EmptyPlanNudge above owns that CTA now. */}
+      {!isSolo && (focusItems.length > 0 || !isToday) && (
         <div>
-          {/* Editing is a today-only action — you plan the day you're in, not
-              the past. On a past date the section is read-only: it shows that
-              day's committed focus (or a quiet empty note), with no Edit/Add
-              affordances. `focusLabel` relabels the heading off "Today's". */}
-          {focusItems.length === 0 && isToday && (
-            <div className="flex items-center justify-between mb-2.5">
-              <SectionHeading>Today&apos;s focus</SectionHeading>
-              <button onClick={() => onOpen('plan')} className="mt-body-sm" style={{ color: 'var(--color-state-proposal)', fontWeight: 700 }}>Edit plan</button>
-            </div>
-          )}
           {focusItems.length > 0 ? (
             <div className="rounded-xl overflow-hidden bg-card" style={{ border: '1px solid var(--t-card-border)' }}>
               <div className="flex items-center justify-between px-4 py-3">
@@ -275,13 +283,9 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
                 )
               })}
             </div>
-          ) : isToday ? (
-            <button onClick={() => onOpen('plan')}
-              className="w-full text-left rounded-xl px-4 py-3.5" style={{ border: '1px dashed var(--t-hair)' }}>
-              <p className="mt-body-sm" style={{ color: 'var(--t-muted)' }}>Nothing planned yet for today.</p>
-              <p className="mt-body-sm mt-0.5" style={{ color: 'var(--color-state-proposal)', fontWeight: 700 }}>Add tasks to your plan →</p>
-            </button>
           ) : (
+            // Reachable only for a past day (the outer condition excludes
+            // today when empty) — a quiet historical fact, no CTA.
             <div>
               <div className="mb-2.5"><SectionHeading>{focusLabel}</SectionHeading></div>
               <div className="rounded-xl px-4 py-3.5" style={{ border: '1px dashed var(--t-hair)' }}>
@@ -344,6 +348,32 @@ function SectionHeading({ children }: { children: React.ReactNode }) {
     <p style={{ font: "800 13px var(--font-sans)", color: 'var(--t-title)' }}>
       {children}
     </p>
+  )
+}
+
+// The plan feature's empty-state CTA, promoted to the top of the panel so it's
+// the first thing a user sees rather than the 4th card down. Soft/pastel
+// (color-mix over the panel surface, same recipe as the cleanup/tracker-connect
+// CTAs elsewhere in this file) so it reads as an inviting nudge, not a warning
+// — purple (--color-state-proposal) matches the rest of the plan feature's own
+// color language (the "Edit plan"/progress-bar/done-check accents), so this
+// reads as the same feature rather than a new, unrelated color.
+function EmptyPlanNudge({ onOpen }: { onOpen: () => void }) {
+  return (
+    <button onClick={onOpen}
+      className="w-full text-left rounded-xl px-4 py-3.5 flex items-center gap-2.5 mt-card-hover"
+      style={{
+        background: 'color-mix(in srgb, var(--color-state-proposal) 12%, transparent)',
+        border: '1px solid color-mix(in srgb, var(--color-state-proposal) 30%, transparent)',
+      }}>
+      <span className="inline-flex items-center justify-center rounded-full shrink-0 text-[13px]"
+        style={{ width: 26, height: 26, background: 'color-mix(in srgb, var(--color-state-proposal) 20%, transparent)' }}>✨</span>
+      <span className="flex-1 min-w-0">
+        <p className="mt-card-title" style={{ color: 'var(--color-state-proposal)' }}>What are you working on today?</p>
+        <p className="mt-body-sm mt-0.5" style={{ color: 'var(--t-muted)' }}>Add a few tasks so Meridian can help you stay on track</p>
+      </span>
+      <span style={{ color: 'var(--color-state-proposal)' }}>→</span>
+    </button>
   )
 }
 

--- a/ui/components/timeline/OverviewPanel.tsx
+++ b/ui/components/timeline/OverviewPanel.tsx
@@ -3,10 +3,9 @@
 // The right panel's default state (no hour selected). Layout mirrors the
 // design mock: eyebrow + greeting + summary line, drafts-to-review CTA,
 // board-cleanup CTA, a "Today's focus" plan checklist, a "Today" mini-card
-// row (Focus / Drafts — Drafts opens the swipeable review dialog), the
-// time-by-app chart, and a Tasks entry
-// point (connected users only for the CTAs/plan; solo users get the greeting
-// + Today cards + time-by-app). Narrative + metric fields are adapted from
+// row (Focus / Drafts — Drafts opens the swipeable review dialog), and the
+// time-by-app chart (connected users only for the CTAs/plan; solo users get
+// the greeting + Today cards + time-by-app). Narrative + metric fields are adapted from
 // the retired TodayView's data; the plan checklist reads the same get_plan
 // the Daily plan modal uses. The checkbox writes through for real rather than
 // being decorative — via set_plan_task_done, which routes a personal task to
@@ -35,7 +34,7 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
   onOpenTask: (key: string, title?: string, editable?: boolean) => void
   onOpenSettings: (section?: SettingsSection) => void
 }) {
-  const { today, isSolo, items, cleanupIssueCount, tasks, isToday, day } = data
+  const { today, isSolo, items, cleanupIssueCount, isToday, day } = data
   const dayLabel = isToday ? 'Today' : formatDayLabel(day)
   // "Today's focus" only reads right on today; a past date shows that day's plan
   // under a neutral "Focus" heading (the day itself is already named above).
@@ -89,7 +88,6 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
   const loggedItems = items.filter(i => !i.is_proposed && (i.state === 'approved' || i.state === 'posted'))
   const loggedCount = loggedItems.length
   const loggedSeconds = loggedItems.reduce((a, i) => a + (i.time_spent_seconds || 0), 0)
-  const activeTaskCount = tasks.filter(t => !t.is_terminal).length
 
   // "Today's focus" — the locked daily plan. The checkbox writes through to the
   // real tracker (close/reopen), so `overrideTerminal` holds the optimistic
@@ -283,13 +281,6 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
         </div>
       )}
 
-      {/* Tasks entry pulls from the connected tracker — with no PM
-          integration there's nothing to pull, so it would always read
-          "0 active". Connected users only. */}
-      {!isSolo && (
-        <EntryRow label="Tasks" hint={`${activeTaskCount} active`} onClick={() => onOpen('tasks')} />
-      )}
-
       <div className="rounded-xl p-5 bg-card" style={{ border: '1px solid var(--t-card-border)' }}>
         <div className="flex items-center justify-between mb-2.5">
           <SectionHeading>Time by app</SectionHeading>
@@ -360,18 +351,6 @@ function EmptyPlanNudge({ onOpen }: { onOpen: () => void }) {
         <p className="mt-body-sm mt-0.5" style={{ color: 'var(--t-muted)' }}>Add a few tasks so Meridian can help you stay on track</p>
       </span>
       <span style={{ color: 'var(--color-state-proposal)' }}>→</span>
-    </button>
-  )
-}
-
-function EntryRow({ label, hint, onClick }: { label: string; hint: string; onClick: () => void }) {
-  return (
-    <button onClick={onClick}
-      className="w-full flex items-center gap-3 rounded-xl px-5 py-3.5 bg-card"
-      style={{ border: '1px solid var(--t-card-border)' }}>
-      <span className="mt-title text-title flex-1 text-left">{label}</span>
-      <span className="mt-mono-sm text-[11px]" style={{ color: 'var(--t-faint)' }}>{hint}</span>
-      <span style={{ color: 'var(--t-faint)' }}>›</span>
     </button>
   )
 }

--- a/ui/components/timeline/StatusPicker.tsx
+++ b/ui/components/timeline/StatusPicker.tsx
@@ -13,7 +13,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { load } from '@/lib/bridge'
-import type { TaskSummary, StatusListResponse, TaskStatusOption } from '@/lib/api-types'
+import type { TaskStatusTarget, StatusListResponse, TaskStatusOption } from '@/lib/api-types'
 
 // Canonical category → a dot colour, so a status reads as done / active / to-do
 // at a glance regardless of provider.
@@ -26,7 +26,7 @@ function categoryColor(category: string, isTerminal: boolean): string {
 }
 
 export function StatusPicker({ task, onPick, busy }: {
-  task: TaskSummary
+  task: TaskStatusTarget
   onPick: (option: TaskStatusOption) => void
   busy: boolean
 }) {

--- a/ui/components/timeline/TaskDetailDialog.tsx
+++ b/ui/components/timeline/TaskDetailDialog.tsx
@@ -10,13 +10,19 @@
 // — only the daily-plan caller wires them, everyone else gets a read-only dialog.
 // A personal (provider 'local') task additionally gets an inline Edit affordance
 // for its title/description (see `editableTask`) — tracker-owned tickets never do.
+// The status badge is always a live `StatusPicker` (same component + hook as the
+// Tasks page's TasksDetailPane) — moving a tracker ticket writes through to the
+// tracker, and moving a personal task's To Do/In Progress/Done writes straight to
+// our own DB; both get the same optimistic patch + Undo banner.
 
 'use client'
 
 import { useEffect, useState } from 'react'
-import { LOCAL_PROVIDER, type TaskDetail } from '@/lib/api-types'
+import { LOCAL_PROVIDER, type TaskDetail, type TaskStatusTarget } from '@/lib/api-types'
 import { load, openExternal } from '@/lib/bridge'
 import { editTask } from '@/components/plan/useTaskComposer'
+import { StatusPicker } from './StatusPicker'
+import { useTaskStatusChange, StatusBanner } from './useTaskStatusChange'
 
 export function TaskDetailDialog({
   taskKey, fallbackTitle, onClose, inToday, canEdit = true, onAdd, onRemove, day, editableTask = true,
@@ -49,6 +55,20 @@ export function TaskDetailDialog({
   const [draftDescription, setDraftDescription] = useState('')
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
+
+  // Same status-change plumbing as the Tasks page's detail pane
+  // (TasksDetailPane.tsx) — the mutate call, optimistic patch, and Undo/redirect
+  // banner all live in the shared hook, so this dialog gets identical behavior
+  // (including a personal task's To Do/In Progress/Done lifecycle, which
+  // `set_task_status` now also serves — see meridian_core::task_create's
+  // local-status helpers) rather than a second implementation.
+  const patchTaskStatus = (key: string, status: string, isTerminal: boolean) =>
+    setDetail(d => d && d.key === key ? { ...d, status, is_terminal: isTerminal } : d)
+  const { statusBusyKey, undo, note, handleSetStatus, handleUndo, dismissUndo, dismissNote } =
+    useTaskStatusChange(patchTaskStatus)
+  const statusTarget: TaskStatusTarget | null = detail
+    ? { key: detail.key, provider: detail.provider, status: detail.status, is_terminal: detail.is_terminal }
+    : null
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) { if (e.key === 'Escape') onClose() }
@@ -109,12 +129,9 @@ export function TaskDetailDialog({
                 {detail.issue_type}
               </span>
             )}
-            {detail?.status && (
-              <span className="mt-body-sm inline-flex items-center gap-1.5" style={{ color: 'var(--t-muted)' }}>
-                <span className="inline-block w-1.5 h-1.5 rounded-full"
-                  style={{ background: detail.is_terminal ? 'var(--color-state-approved)' : 'var(--color-state-proposal)' }} />
-                {detail.status}
-              </span>
+            {statusTarget && (
+              <StatusPicker task={statusTarget} onPick={o => handleSetStatus(statusTarget, o)}
+                busy={statusBusyKey === statusTarget.key} />
             )}
             <button onClick={onClose} aria-label="Close"
               className="ml-auto inline-flex items-center justify-center rounded-full bg-wrap shrink-0"
@@ -217,6 +234,8 @@ export function TaskDetailDialog({
           </div>
         )}
       </div>
+      <StatusBanner undo={undo} note={note} busy={!!statusBusyKey}
+        onUndo={handleUndo} onDismissUndo={dismissUndo} onDismissNote={dismissNote} />
     </div>
   )
 }

--- a/ui/components/timeline/useTaskStatusChange.tsx
+++ b/ui/components/timeline/useTaskStatusChange.tsx
@@ -11,7 +11,7 @@
 'use client'
 
 import { useRef, useState, useEffect } from 'react'
-import type { TaskSummary, TaskStatusOption, SetStatusResponse } from '@/lib/api-types'
+import type { TaskStatusTarget, TaskStatusOption, SetStatusResponse } from '@/lib/api-types'
 import { mutate, openExternal } from '@/lib/bridge'
 
 // How long the Undo affordance (or a redirect/error note) lingers before it fades.
@@ -67,8 +67,9 @@ export function useTaskStatusChange(
 
   const dismissNote = () => setNote(null)
 
-  // Change a task's status on its tracker, capturing an Undo.
-  const handleSetStatus = (task: TaskSummary, option: TaskStatusOption) => {
+  // Change a task's status on its tracker (or, for a personal task, straight in our
+  // own DB — see meridian_core::task_create's local-status helpers), capturing an Undo.
+  const handleSetStatus = (task: TaskStatusTarget, option: TaskStatusOption) => {
     if (statusBusyKey) return
     const prevStatus = task.status
     const prevTerminal = task.is_terminal

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -157,6 +157,18 @@ export interface SetStatusResponse {
   new_status: TaskStatusOption | null
 }
 
+// The minimal shape `StatusPicker`/`useTaskStatusChange` need to drive a status
+// change — deliberately narrower than `TaskSummary` so `TaskDetail` (the plan's
+// task-detail dialog) can be passed straight in too, without an adapter. Both
+// `TaskSummary` and `TaskDetail` already carry every one of these fields, so
+// either satisfies this structurally.
+export interface TaskStatusTarget {
+  key: string
+  provider: string
+  status: string
+  is_terminal: boolean
+}
+
 // ── Worklogs (`get_worklogs`) ────────────────────────────────────────────────
 
 export interface WorklogBullet {


### PR DESCRIPTION
## Summary
- Surface the empty "today's plan" state as a soft, colored nudge inside the "Today's focus" section (right panel), visible to solo/no-tracker users too.
- Remove the "Tasks" board-count entry row from the timeline's right panel.
- Add a Refresh button inside the Plan page's header, shown when a PM tracker is connected (reuses the Tasks page's `sync_tasks` flow).
- Let the task-detail dialog (opened from the daily plan, Today's focus, timeline cards) change a task's status — reuses the Tasks page's `StatusPicker` + `useTaskStatusChange` (optimistic update + Undo banner).
- Extend status changes to personal (no-tracker) tasks: a fixed To Do / In Progress / Done lifecycle written straight to `pm_tasks`, since there's no tracker to shell out to for those.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (root crate: 720 passed; `meridian-core`: all passed, incl. new `local_task_moves_through_the_in_progress_status`)
- [x] `npm run build` (ui) passes
- [ ] Manual: open Timeline with an empty plan (today) as both a connected and solo user — confirm the colored nudge appears under "Today's focus" and opens the Plan modal
- [ ] Manual: open Plan with a tracker connected — confirm Refresh pulls fresh tickets
- [ ] Manual: open a task's detail dialog (tracker-owned) — change its status, confirm it reflects on the tracker and Undo works
- [ ] Manual: open a personal task's detail dialog — move it through To Do → In Progress → Done, confirm Undo works