### PR TITLE
fix(ci): address CodeRabbit review on #528

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -133,11 +133,16 @@ jobs:
         # `--features tauri/custom-protocol`, which cargo cannot apply to the
         # `-p meridian` scope (no tauri dependency), so the two crates cannot
         # share one invocation.
+        #
+        # No `--config src-tauri/tauri.staging.conf.json`: this job only ever
+        # runs on `main` (see the header), which release-build.yml always builds
+        # with the default (stable) Tauri config — never the staging one. Passing
+        # the staging config here would warm a cache under a different Tauri
+        # fingerprint than the stable release build actually compiles with.
         run: |
           cargo build --release --locked --target aarch64-apple-darwin \
             -p meridian --bin meridian
-          npx tauri build --no-bundle --target aarch64-apple-darwin \
-            --config src-tauri/tauri.staging.conf.json
+          npx tauri build --no-bundle --target aarch64-apple-darwin
 
       - name: Summary
         if: always()

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -277,11 +277,18 @@ jobs:
 
       - name: Summary
         if: always()
+        # Bound through env, not interpolated into `run:` — same reason as the
+        # RAW_TAG/VERSION binding elsewhere: a `run:` step is attacker-reachable
+        # via the expression's source, so step outputs go through env rather
+        # than straight into the shell script.
+        env:
+          RELEASED: ${{ steps.run.outputs.released }}
+          TAG: ${{ steps.run.outputs.tag }}
         run: |
           {
             echo "### Release prepare"
-            if [ "${{ steps.run.outputs.released }}" = "true" ]; then
-              echo "Tagged \`${{ steps.run.outputs.tag }}\`."
+            if [ "${RELEASED}" = "true" ]; then
+              echo "Tagged \`${TAG}\`."
               echo ""
               echo "\`release-build.yml\` builds and publishes it."
             else

--- a/scripts/notarize-dmg.sh
+++ b/scripts/notarize-dmg.sh
@@ -42,6 +42,13 @@ cd "${REPO_ROOT}"
 # per-arch build's suffix is tauri-bundler's own arch spelling, not the triple)
 # — so glob for it rather than trying to reconstruct the name.
 TARGET="${MERIDIAN_TARGET:-universal-apple-darwin}"
+# Same validation as package-updater.sh / mirror-staging-release.sh: fail on the
+# typo'd/unsupported target here rather than falling through to the generic "no
+# DMG found" error below, which doesn't say why.
+case "${TARGET}" in
+  universal-apple-darwin|aarch64-apple-darwin|x86_64-apple-darwin) ;;
+  *) echo "✗ notarize-dmg: unsupported MERIDIAN_TARGET '${TARGET}'" >&2; exit 1 ;;
+esac
 DMG_DIR="target/${TARGET}/release/bundle/dmg"
 DMG="$(ls "${DMG_DIR}"/Meridian_${VERSION}_*.dmg 2>/dev/null | head -1)"
 IDENTITY="${APPLE_SIGNING_IDENTITY:-}"


### PR DESCRIPTION
## Summary

Addresses the still-valid CodeRabbit findings from the review on #528 (`pre-main → main`). Verified each finding against the current tip of `pre-main` (`903daef2`, post-#526/#527) before touching anything — several were already resolved by #526 and are noted below as stale, not re-fixed.

## Fixed

- **`cache-warm.yml`**: dropped `--config src-tauri/tauri.staging.conf.json` from the compile step. This job only ever runs on `main` (see its own header), which `release-build.yml` always builds with the **default/stable** Tauri config — the staging config is only used when `channel == 'staging'`. Warming the cache with the staging fingerprint meant every real stable release build looked for a cache keyed under a different fingerprint than what got warmed, silently defeating the point of the job.
- **`release-prepare.yml`**: bound the Summary step's `released`/`tag` outputs through `env:` instead of interpolating `${{ steps.run.outputs.* }}` straight into `run:`, matching the `RAW_TAG`/`VERSION` env-binding convention already used elsewhere in this same workflow (and the fix in #518).
- **`scripts/notarize-dmg.sh`**: added the same `MERIDIAN_TARGET` case-validation `package-updater.sh` and `mirror-staging-release.sh` already have, so a typo'd target fails loudly here too instead of falling through to a generic "no DMG found".

## Confirmed already fixed (no action needed)

- **`.releaserc.json` `[skip ci]` marker** — CodeRabbit flagged this as critical, but #526 already removed it from `pre-main`. Verified: current file has no `[skip ci]` in the release commit message.
- **`ci.yml` stale `[skip ci]` comment** — also already fixed by #526's comment update.

## Skipped, with reason

- **Repo-wide GitHub Actions SHA-pinning** — real hardening suggestion, but a documented, maintained pinning policy across 4 workflow files (15+ action refs) is a standalone initiative, not a fix scoped to this review. Filing as a follow-up rather than bundling into a release-promotion cleanup.
- **`ci.yml` aggregate gate for conditional `rust`/`ui`/`migration-guard` jobs** — this only matters if those jobs are required branch-protection status checks. Checked: **neither `main` nor `pre-main` has any branch protection configured**, so nothing can currently get stuck on a skipped check. Moot until protection rules exist.
- **`scripts/mirror-updater-channel.sh` / `mirror-staging-release.sh` de-dup** — real duplication, but the suggested fix is a shared-helper refactor across two release-critical scripts. Flagged as "heavy lift" by the reviewer itself; doing that days before/inside a release-promotion cleanup is more risk than the duplication currently costs.
- **`README.md` hyphen → em-dash** — CLAUDE.md's plain-hyphen rule is explicitly for user-facing app text; it calls out docs as exempt. Leaving the hyphens; this is a style preference, not a defect.
- **`toolbar-connected-pill.test.ts` fixed char-offset window** — real fragility, low value/trivial per the reviewer's own tag. Left as-is rather than rewriting the anchor under review-response time pressure.

## Why this targets `pre-main`, not #528 directly

#528 is the `pre-main → main` release-promotion PR; per this repo's hard rule, no direct pushes to `pre-main` or `main` — fixes land via a normal feature branch + PR into `pre-main`, same pattern as #518 and #526. Once merged, these commits flow into #528 automatically since it tracks `pre-main`.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on both changed workflow YAML files
- [x] `bash -n scripts/notarize-dmg.sh`
- [x] Full pre-push suite (fmt, clippy, ui build, ui tests, cargo test) — all green
