### PR TITLE
fix(windows): make the Windows build actually work end-to-end

### DIFF
--- a/meridian-oauth/src/flow.rs
+++ b/meridian-oauth/src/flow.rs
@@ -76,9 +76,6 @@ pub async fn run_authcode_flow(
     );
 
     tracing::info!("opening browser to authorize OAuth flow");
-    tracing::info!(
-        "if it doesn't open automatically, check your default browser settings and try again"
-    );
     open_browser(&authorize);
 
     let (code, returned_state) = tokio::time::timeout(CONSENT_TIMEOUT, accept_redirect(&listener))
@@ -282,7 +279,6 @@ pub async fn run_fragment_relay_flow(authorize_url: &str, port: u16) -> Result<S
             format!("binding loopback :{port} for the Trello token relay — is the port free?")
         })?;
     tracing::info!("opening browser to authorize Trello OAuth flow");
-    tracing::info!(url = %authorize_url, "if it doesn't open, paste this URL into your browser");
     open_browser(authorize_url);
     tokio::time::timeout(CONSENT_TIMEOUT, accept_fragment_relay(&listener))
         .await
@@ -355,10 +351,28 @@ else{document.querySelector('h2').textContent='No token in URL. Try again.';}\
     }
 }
 
-/// Open `url` in the system browser. macOS-only (`open`); non-fatal if it fails —
-/// the URL is also printed for manual paste.
+/// Open `url` in the system browser. Non-fatal if the launch fails — the URL
+/// is always logged too, so a failed/headless launch still leaves the user a
+/// way to continue by pasting it manually.
+///
+/// `start` on Windows is a cmd.exe builtin, not a standalone executable, so it
+/// has to be invoked through the shell rather than spawned directly. Its first
+/// argument is a window-title slot, not part of the command — the empty `""`
+/// there is required, otherwise `start` misreads a quoted URL as the title and
+/// never opens it.
 fn open_browser(url: &str) {
-    let _ = std::process::Command::new("open").arg(url).spawn();
+    tracing::info!(url, "if it doesn't open automatically, open this URL yourself");
+    #[cfg(target_os = "windows")]
+    let result = std::process::Command::new("cmd")
+        .args(["/C", "start", "", url])
+        .spawn();
+    #[cfg(target_os = "macos")]
+    let result = std::process::Command::new("open").arg(url).spawn();
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    let result = std::process::Command::new("xdg-open").arg(url).spawn();
+    if let Err(e) = result {
+        tracing::warn!(error = %e, "failed to launch the system browser");
+    }
 }
 
 /// RFC 3986 percent-encoding for a query-component value (unreserved chars pass

--- a/meridian-oauth/src/flow.rs
+++ b/meridian-oauth/src/flow.rs
@@ -361,7 +361,10 @@ else{document.querySelector('h2').textContent='No token in URL. Try again.';}\
 /// there is required, otherwise `start` misreads a quoted URL as the title and
 /// never opens it.
 fn open_browser(url: &str) {
-    tracing::info!(url, "if it doesn't open automatically, open this URL yourself");
+    tracing::info!(
+        url,
+        "if it doesn't open automatically, open this URL yourself"
+    );
     #[cfg(target_os = "windows")]
     let result = std::process::Command::new("cmd")
         .args(["/C", "start", "", url])

--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -88,6 +88,32 @@ pub(crate) struct Capture {
     pub stderr: String,
 }
 
+/// `claude`, `codex`, etc. install as npm-shimmed `.cmd`/`.bat` files on Windows, not PE
+/// executables — `CreateProcess` (what `Command::spawn` calls) refuses to run one directly
+/// and fails with "os error 193, %1 is not a valid Win32 application", even though the exact
+/// same path runs fine typed into a terminal (the shell recognises the extension and
+/// re-invokes it through `cmd.exe` itself; `CreateProcess` doesn't). Route those through
+/// `cmd.exe /C` explicitly. Anything else — a real `.exe`, or any non-Windows target —
+/// returns `None` and spawns directly, unchanged.
+#[cfg(windows)]
+fn windows_shell_wrapper(target: &Path) -> Option<Command> {
+    let is_script = target
+        .extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| e.eq_ignore_ascii_case("cmd") || e.eq_ignore_ascii_case("bat"));
+    if !is_script {
+        return None;
+    }
+    let mut cmd = Command::new("cmd");
+    cmd.arg("/C").arg(target);
+    Some(cmd)
+}
+
+#[cfg(not(windows))]
+fn windows_shell_wrapper(_target: &Path) -> Option<Command> {
+    None
+}
+
 /// Spawn `program args`, feed `stdin_text`, capture stdout/stderr with a hard
 /// timeout. `kill_on_drop` guarantees a timed-out child is reaped (no leak);
 /// stdin is written from a concurrent task so a large prompt can't deadlock the
@@ -109,7 +135,8 @@ pub(crate) async fn run_capture(
     // only ever surfaced in the tray. Falls back to the bare name so a process that
     // does have a working `PATH` behaves exactly as before.
     let resolved = crate::llm::detect::resolve_cli(program).await;
-    let mut cmd = Command::new(resolved.as_deref().unwrap_or_else(|| Path::new(program)));
+    let target = resolved.as_deref().unwrap_or_else(|| Path::new(program));
+    let mut cmd = windows_shell_wrapper(target).unwrap_or_else(|| Command::new(target));
     cmd.args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -59,7 +59,10 @@ fn candidate_dirs() -> Vec<PathBuf> {
         .map(|a| vec![PathBuf::from(a).join("npm").to_string_lossy().into_owned()])
         .unwrap_or_default();
     #[cfg(not(windows))]
-    let platform: Vec<String> = vec!["/opt/homebrew/bin".to_string(), "/usr/local/bin".to_string()];
+    let platform: Vec<String> = vec![
+        "/opt/homebrew/bin".to_string(),
+        "/usr/local/bin".to_string(),
+    ];
 
     [
         home.join(".local/bin").to_string_lossy().into_owned(),
@@ -633,7 +636,9 @@ pub async fn resolve_cli(bin: &str) -> Option<PathBuf> {
 
     let found = match probe_current_path(bin) {
         Some(p) => Some(p),
-        None => probe_login_shell(bin).await.or_else(|| probe_candidates(bin)),
+        None => probe_login_shell(bin)
+            .await
+            .or_else(|| probe_candidates(bin)),
     }?;
 
     tracing::debug!(bin, path = %found.display(), "resolved CLI path");
@@ -877,7 +882,10 @@ mod tests {
 
         let original_path = std::env::var_os("PATH");
         let new_path = match &original_path {
-            Some(p) => std::env::join_paths(std::iter::once(dir.clone()).chain(std::env::split_paths(p))).unwrap(),
+            Some(p) => {
+                std::env::join_paths(std::iter::once(dir.clone()).chain(std::env::split_paths(p)))
+                    .unwrap()
+            }
             None => dir.clone().into_os_string(),
         };
         std::env::set_var("PATH", &new_path);

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -709,11 +709,25 @@ fn probe_current_path(bin: &str) -> Option<PathBuf> {
 /// install as npm-shimmed `.cmd` files, not bare `.exe`s — `CreateProcess` only appends a
 /// `PATHEXT` extension automatically when spawning *by name*, not when we hand back (and a
 /// caller later spawns) an absolute path, so the extension has to be resolved right here.
+///
+/// `PATHEXT` extensions are tried BEFORE the bare name, not after. npm's global install
+/// writes THREE files per CLI — `claude` (an extensionless POSIX shebang script, for
+/// WSL/Git-Bash), `claude.cmd`, and `claude.ps1` — all in the same directory. The bare
+/// `claude` file `is_file()` just as truly as `claude.cmd` does, so checking it first
+/// resolves to the POSIX script: no `.cmd`/`.bat` extension, so `windows_shell_wrapper`
+/// doesn't route it through `cmd /C` either, and it gets handed to `CreateProcess` as a
+/// literal shebang text file — `os error 193, %1 is not a valid Win32 application`, on a
+/// machine where `claude` undeniably "works". A real `cmd.exe`/PowerShell prompt never
+/// makes this mistake because PATHEXT resolution always wins over an extensionless match;
+/// the bare name is kept only as a last-resort fallback for a genuinely extensionless
+/// native binary.
 #[cfg(windows)]
 fn path_candidate_names(bin: &str) -> Vec<String> {
     let exts = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
-    std::iter::once(bin.to_string())
-        .chain(exts.split(';').filter(|e| !e.is_empty()).map(|ext| format!("{bin}{ext}")))
+    exts.split(';')
+        .filter(|e| !e.is_empty())
+        .map(|ext| format!("{bin}{ext}"))
+        .chain(std::iter::once(bin.to_string()))
         .collect()
 }
 
@@ -839,6 +853,48 @@ mod tests {
             .await
             .is_none());
         assert!(probe_candidates("meridian-definitely-not-a-real-binary").is_none());
+    }
+
+    /// npm's global install writes an extensionless POSIX shebang script (`claude`)
+    /// alongside `claude.cmd` in the SAME directory, for WSL/Git-Bash use. Both
+    /// `is_file()`. A resolver that checks the bare name before `PATHEXT` extensions
+    /// would match the shebang script instead — which then fails to spawn as a native
+    /// binary (`os error 193`) even though `claude` plainly "works" on this machine.
+    /// This reproduces exactly that directory layout and asserts the `.CMD` file wins.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn probe_current_path_prefers_pathext_over_a_bare_extensionless_shim() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!(
+            "meridian-detect-pathext-test-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let bare = dir.join("meridian-fake-cli");
+        let shimmed = dir.join("meridian-fake-cli.CMD");
+        std::fs::write(&bare, "#!/bin/sh\necho fake\n").unwrap();
+        std::fs::write(&shimmed, "@echo fake\r\n").unwrap();
+
+        let original_path = std::env::var_os("PATH");
+        let new_path = match &original_path {
+            Some(p) => std::env::join_paths(std::iter::once(dir.clone()).chain(std::env::split_paths(p))).unwrap(),
+            None => dir.clone().into_os_string(),
+        };
+        std::env::set_var("PATH", &new_path);
+
+        let found = probe_current_path("meridian-fake-cli");
+
+        match original_path {
+            Some(p) => std::env::set_var("PATH", p),
+            None => std::env::remove_var("PATH"),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert_eq!(
+            found.as_deref(),
+            Some(shimmed.as_path()),
+            "resolved {found:?}, expected the .CMD shim, not the bare shebang script"
+        );
     }
 
     /// `MERIDIAN_HOME` is a process-global env var and cargo runs tests in parallel threads

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -46,17 +46,29 @@ use super::{resolver::backend_for, LlmConfig, LlmError, PromptRequest};
 const PROBE_TIMEOUT: Duration = Duration::from_secs(6);
 
 /// Where these CLIs actually land, for when the login shell is unavailable or too slow.
+///
+/// Unix-only paths — Windows has no `probe_login_shell` to fall back FROM (see
+/// [`resolve_cli`]), so it never reaches this tier for the common case anyway. The one
+/// Windows location worth listing is npm's global bin, `%APPDATA%\npm`, for the rare case
+/// where a fresh shell's `PATH` hasn't picked it up yet even though `PATH` is otherwise
+/// trustworthy on this platform.
 fn candidate_dirs() -> Vec<PathBuf> {
     let home = meridian_core::paths::home_dir_or_cwd();
+    #[cfg(windows)]
+    let platform: Vec<String> = std::env::var("APPDATA")
+        .map(|a| vec![PathBuf::from(a).join("npm").to_string_lossy().into_owned()])
+        .unwrap_or_default();
+    #[cfg(not(windows))]
+    let platform: Vec<String> = vec!["/opt/homebrew/bin".to_string(), "/usr/local/bin".to_string()];
+
     [
         home.join(".local/bin").to_string_lossy().into_owned(),
         home.join(".npm-global/bin").to_string_lossy().into_owned(),
         home.join(".bun/bin").to_string_lossy().into_owned(),
         home.join(".volta/bin").to_string_lossy().into_owned(),
-        "/opt/homebrew/bin".to_string(),
-        "/usr/local/bin".to_string(),
     ]
     .into_iter()
+    .chain(platform)
     .map(PathBuf::from)
     .collect()
 }
@@ -599,8 +611,15 @@ static RESOLVED_BINS: std::sync::OnceLock<std::sync::Mutex<HashMap<String, PathB
 /// `scripts/com.meridiona.daemon.plist` sets a rich `PATH` for it, which is exactly why
 /// the bug only ever showed up in the tray's Test Connection.
 ///
-/// Returns `None` when neither probe finds the binary; callers fall back to the bare name
-/// so a working `PATH` still behaves as before.
+/// Returns `None` when no probe finds the binary; callers fall back to the bare name so a
+/// working `PATH` still behaves as before.
+///
+/// [`probe_current_path`] runs first and is the ONLY tier that matters on Windows: there is
+/// no Finder-style PATH stripping there, so a GUI/daemon process already sees the same
+/// `PATH` a terminal does — the login-shell probe below would just fail outright (no
+/// `/bin/zsh`, no `$SHELL`) and waste up to [`PROBE_TIMEOUT`] doing it. It also short-circuits
+/// the slow shell spawn on macOS whenever the current process's `PATH` is already good (e.g.
+/// the daemon's launchd-configured one, per the `resolve_cli` doc above).
 pub async fn resolve_cli(bin: &str) -> Option<PathBuf> {
     if let Some(hit) = RESOLVED_BINS
         .get_or_init(Default::default)
@@ -612,9 +631,10 @@ pub async fn resolve_cli(bin: &str) -> Option<PathBuf> {
         return Some(hit);
     }
 
-    let found = probe_login_shell(bin)
-        .await
-        .or_else(|| probe_candidates(bin))?;
+    let found = match probe_current_path(bin) {
+        Some(p) => Some(p),
+        None => probe_login_shell(bin).await.or_else(|| probe_candidates(bin)),
+    }?;
 
     tracing::debug!(bin, path = %found.display(), "resolved CLI path");
     RESOLVED_BINS
@@ -673,6 +693,35 @@ fn probe_candidates(bin: &str) -> Option<PathBuf> {
         .find(|p| p.exists())
 }
 
+/// Check the CURRENT process's own `PATH` for `bin` — the cheap, no-subprocess probe that
+/// [`probe_login_shell`]/[`probe_candidates`] exist to work AROUND on macOS (a Finder-launched
+/// `.app` gets a stripped `PATH` there, so trusting it isn't safe). Windows has no equivalent
+/// stripping, so this tier alone is normally sufficient there.
+fn probe_current_path(bin: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    let names = path_candidate_names(bin);
+    std::env::split_paths(&path)
+        .flat_map(|dir| names.iter().map(move |name| dir.join(name)))
+        .find(|p| p.is_file())
+}
+
+/// The file name(s) `bin` could actually be on disk. On Windows, `claude`/`codex`/etc.
+/// install as npm-shimmed `.cmd` files, not bare `.exe`s — `CreateProcess` only appends a
+/// `PATHEXT` extension automatically when spawning *by name*, not when we hand back (and a
+/// caller later spawns) an absolute path, so the extension has to be resolved right here.
+#[cfg(windows)]
+fn path_candidate_names(bin: &str) -> Vec<String> {
+    let exts = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
+    std::iter::once(bin.to_string())
+        .chain(exts.split(';').filter(|e| !e.is_empty()).map(|ext| format!("{bin}{ext}")))
+        .collect()
+}
+
+#[cfg(not(windows))]
+fn path_candidate_names(bin: &str) -> Vec<String> {
+    vec![bin.to_string()]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -693,6 +742,18 @@ mod tests {
     #[tokio::test]
     async fn resolve_cli_returns_an_absolute_existing_path() {
         let found = resolve_cli("sh").await.expect("sh must resolve");
+        assert!(found.is_absolute(), "not absolute: {}", found.display());
+        assert!(found.exists(), "does not exist: {}", found.display());
+    }
+
+    /// Windows analogue of the unix test above. `cmd` is guaranteed present (`%SystemRoot%\
+    /// System32` is always on the default `PATH`) and is reachable ONLY through
+    /// `probe_current_path` — there is no login shell or unix candidate dir that could find
+    /// it — so a pass here proves that tier actually runs on this platform.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn resolve_cli_returns_an_absolute_existing_path() {
+        let found = resolve_cli("cmd").await.expect("cmd must resolve");
         assert!(found.is_absolute(), "not absolute: {}", found.display());
         assert!(found.exists(), "does not exist: {}", found.display());
     }

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -82,10 +82,10 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
             return;
         }
     };
-    let home = match std::env::var("HOME") {
-        Ok(h) => PathBuf::from(h),
-        Err(_) => {
-            tracing::warn!("backend_install: HOME unset — cannot stage backend");
+    let home = match meridian_core::paths::home_dir() {
+        Some(h) => h,
+        None => {
+            tracing::warn!("backend_install: home directory could not be resolved — cannot stage backend");
             return;
         }
     };
@@ -194,7 +194,8 @@ async fn register_service(backend: &Path, home: &Path, daemon_bin: &Path) -> Res
 
 /// Register the staged daemon to run at login and keep running.
 ///
-/// Windows: a **per-user scheduled task**, via `schtasks.exe`.
+/// Windows: a **per-user scheduled task**, via `schtasks.exe`, falling back to
+/// a Startup-folder launcher when that's blocked.
 ///
 /// # Why not a Windows Service
 ///
@@ -213,8 +214,56 @@ async fn register_service(backend: &Path, home: &Path, daemon_bin: &Path) -> Res
 /// `schtasks.exe` is used rather than the `windows-service` crate because this
 /// needs the Task Scheduler, not the Service Control Manager, and shelling out
 /// avoids taking a dependency for one idempotent call.
+///
+/// # Fallback: some machines refuse `schtasks /Create`
+///
+/// Managed/corporate machines can have Task Scheduler creation locked down by
+/// policy for standard (non-elevated) users — `schtasks` then fails with
+/// "Access is denied" even though the service itself is running fine. Rather
+/// than leave the daemon permanently unstarted on those machines, a failed
+/// `schtasks /Create` falls back to [`install_startup_folder_launcher`]: a
+/// hidden VBScript dropped in the user's Startup folder, which Windows runs
+/// at every login with no Task Scheduler involvement. It loses `KeepAlive`
+/// (no restart if the daemon crashes — the same trade-off the retired `Run`
+/// registry key would have had), but that is strictly better than "never
+/// starts at all".
 #[cfg(target_os = "windows")]
 async fn register_service(_backend: &Path, home: &Path, daemon_bin: &Path) -> Result<(), String> {
+    match register_scheduled_task(daemon_bin).await {
+        Ok(()) => {
+            // A prior run on this same machine may have left a Startup-folder
+            // fallback behind (e.g. a policy that has since been relaxed) —
+            // clear it so the daemon isn't launched twice at next login.
+            let _ = remove_startup_folder_launcher().await;
+            tracing::info!(
+                task = WINDOWS_TASK_NAME,
+                home = %home.display(),
+                "backend_install: scheduled task registered"
+            );
+            Ok(())
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "backend_install: schtasks registration failed — falling back to a Startup-folder launcher"
+            );
+            install_startup_folder_launcher(daemon_bin).await?;
+            // Nothing else will start the daemon until next login — start it now.
+            let _ = tokio::process::Command::new(daemon_bin).spawn();
+            tracing::info!(
+                home = %home.display(),
+                "backend_install: Startup-folder launcher installed"
+            );
+            Ok(())
+        }
+    }
+}
+
+/// `schtasks /Create` (+ a best-effort immediate `/Run`) for the daemon's
+/// per-user login task. Split out from [`register_service`] so a failure here
+/// is a recoverable `Err` the caller can fall back from, not a hard stop.
+#[cfg(target_os = "windows")]
+async fn register_scheduled_task(daemon_bin: &Path) -> Result<(), String> {
     // `/F` replaces an existing task, so re-registering on every update is
     // idempotent — the role `launchctl bootout` + `bootstrap` plays on macOS.
     //
@@ -251,13 +300,60 @@ async fn register_service(_backend: &Path, home: &Path, daemon_bin: &Path) -> Re
         .args(["/Run", "/TN", WINDOWS_TASK_NAME])
         .output()
         .await;
-
-    tracing::info!(
-        task = WINDOWS_TASK_NAME,
-        home = %home.display(),
-        "backend_install: scheduled task registered"
-    );
     Ok(())
+}
+
+/// File name of the Startup-folder fallback launcher. `.vbs` (not `.bat`/`.cmd`)
+/// specifically so it runs via `wscript.exe` with no console window flash —
+/// `WScript.Shell.Run`'s third argument (`0`) is the hidden window style, the
+/// same effect `KeepAlive`-less silence needs.
+#[cfg(target_os = "windows")]
+const STARTUP_LAUNCHER_NAME: &str = "MeridianDaemon.vbs";
+
+/// `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup` — every file
+/// directly inside runs once per login, no registration step required. This
+/// is the one directory Windows treats as "run these at logon" without going
+/// through Task Scheduler or the registry, which is exactly what a
+/// policy-restricted machine still allows a standard user to write to.
+#[cfg(target_os = "windows")]
+fn startup_folder() -> Result<PathBuf, String> {
+    let appdata = std::env::var("APPDATA").map_err(|_| "%APPDATA% is not set".to_string())?;
+    Ok(PathBuf::from(appdata).join(r"Microsoft\Windows\Start Menu\Programs\Startup"))
+}
+
+/// Write the hidden-launch VBScript to the Startup folder. Idempotent:
+/// overwrites unconditionally, same as `schtasks /Create /F`.
+#[cfg(target_os = "windows")]
+async fn install_startup_folder_launcher(daemon_bin: &Path) -> Result<(), String> {
+    let dir = startup_folder()?;
+    tokio::fs::create_dir_all(&dir)
+        .await
+        .map_err(|e| format!("mkdir {}: {e}", dir.display()))?;
+    let script = dir.join(STARTUP_LAUNCHER_NAME);
+    // VBScript has no backslash-escaping to worry about — only `"` needs
+    // doubling to embed a literal quote, wrapping the path so a space
+    // anywhere in it (a differently-named Windows profile, say) can't split
+    // `Run`'s argument.
+    let contents = format!(
+        "CreateObject(\"WScript.Shell\").Run \"\"\"{}\"\"\", 0, False\r\n",
+        daemon_bin.display()
+    );
+    tokio::fs::write(&script, contents)
+        .await
+        .map_err(|e| format!("write {}: {e}", script.display()))
+}
+
+/// Remove a previously-installed Startup-folder launcher. Best-effort: a
+/// missing file is not an error, and any other failure is swallowed by the
+/// caller (this only ever runs opportunistically after `schtasks` succeeds).
+#[cfg(target_os = "windows")]
+async fn remove_startup_folder_launcher() -> Result<(), String> {
+    let path = startup_folder()?.join(STARTUP_LAUNCHER_NAME);
+    match tokio::fs::remove_file(&path).await {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(format!("remove {}: {e}", path.display())),
+    }
 }
 
 /// Task Scheduler name for the daemon's per-user login task.

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -85,7 +85,9 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
     let home = match meridian_core::paths::home_dir() {
         Some(h) => h,
         None => {
-            tracing::warn!("backend_install: home directory could not be resolved — cannot stage backend");
+            tracing::warn!(
+                "backend_install: home directory could not be resolved — cannot stage backend"
+            );
             return;
         }
     };

--- a/tray/src-tauri/src/commands/setup.rs
+++ b/tray/src-tauri/src/commands/setup.rs
@@ -14,11 +14,17 @@
 
 /// Returns `true` on the first launch — no `~/.meridian/onboarded` flag exists.
 /// The wizard auto-opens when `true` and is skipped on subsequent launches.
+///
+/// Uses [`meridian_core::paths::meridian_dir`] rather than a raw `HOME`
+/// env var read — `HOME` is unset on Windows, which used to make this fall
+/// back to a bogus `.`-relative (cwd) path instead of `%USERPROFILE%\.meridian`.
 #[tauri::command]
 #[tracing::instrument]
 pub async fn is_first_run() -> bool {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    !std::path::Path::new(&format!("{home}/.meridian/onboarded")).exists()
+    match meridian_core::paths::meridian_dir() {
+        Some(dir) => !dir.join("onboarded").exists(),
+        None => true,
+    }
 }
 
 /// Write `~/.meridian/onboarded` (RFC-3339 timestamp) to mark wizard completion.
@@ -26,8 +32,8 @@ pub async fn is_first_run() -> bool {
 #[tauri::command]
 #[tracing::instrument]
 pub async fn mark_setup_complete() -> Result<(), String> {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    let dir = std::path::PathBuf::from(format!("{home}/.meridian"));
+    let dir = meridian_core::paths::meridian_dir()
+        .ok_or_else(|| "could not resolve home directory".to_string())?;
     tokio::fs::create_dir_all(&dir)
         .await
         .map_err(|e| format!("create ~/.meridian: {e}"))?;
@@ -36,6 +42,15 @@ pub async fn mark_setup_complete() -> Result<(), String> {
         .map_err(|e| format!("write onboarded: {e}"))?;
     tracing::info!("setup: onboarded flag written");
     Ok(())
+}
+
+/// The current OS, for the wizard to adapt its copy/steps — e.g. the
+/// Permissions step is macOS-only (Windows capture needs no TCC-style grant;
+/// see `screenpipe_a11y::platform::windows`) and is skipped entirely when this
+/// returns `"windows"`.
+#[tauri::command]
+pub fn get_platform() -> &'static str {
+    std::env::consts::OS
 }
 
 /// Returns `true` when the current process (the tray) has Accessibility trust.

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -251,10 +251,8 @@ pub fn run() {
                                     let pop_w = 344_i32;
                                     let icon_pos = rect.position.to_physical::<i32>(1.0);
                                     let icon_size = rect.size.to_physical::<i32>(1.0);
-                                    let pop_h = win
-                                        .outer_size()
-                                        .map(|s| s.height as i32)
-                                        .unwrap_or(0);
+                                    let pop_h =
+                                        win.outer_size().map(|s| s.height as i32).unwrap_or(0);
                                     let (x, y) = tray_anchor_position(
                                         (icon_pos.x, icon_pos.y),
                                         (icon_size.width, icon_size.height),

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -241,15 +241,26 @@ pub fn run() {
                                 } else {
                                     #[cfg(target_os = "macos")]
                                     make_visible_over_fullscreen(&win);
-                                    // Position the popover directly below the tray icon
-                                    // using the click rect — same approach as the tooltip.
-                                    // tauri-plugin-positioner's TrayCenter placed the window
-                                    // overlapping the menu bar on macOS 14+.
+                                    // Position the popover against the tray icon using the
+                                    // click rect — same approach as the tooltip. Below the
+                                    // icon on macOS (menu bar, top of screen; also sidesteps
+                                    // tauri-plugin-positioner's TrayCenter overlapping the
+                                    // menu bar on macOS 14+); above it on Windows, whose tray
+                                    // icon sits at the bottom of the taskbar — see
+                                    // `tray_anchor_position`.
                                     let pop_w = 344_i32;
                                     let icon_pos = rect.position.to_physical::<i32>(1.0);
                                     let icon_size = rect.size.to_physical::<i32>(1.0);
-                                    let x = (icon_pos.x + icon_size.width / 2 - pop_w / 2).max(0);
-                                    let y = icon_pos.y + icon_size.height;
+                                    let pop_h = win
+                                        .outer_size()
+                                        .map(|s| s.height as i32)
+                                        .unwrap_or(0);
+                                    let (x, y) = tray_anchor_position(
+                                        (icon_pos.x, icon_pos.y),
+                                        (icon_size.width, icon_size.height),
+                                        (pop_w, pop_h),
+                                        cfg!(target_os = "windows"),
+                                    );
                                     let _ = win.set_position(tauri::Position::Physical(
                                         tauri::PhysicalPosition::new(x, y),
                                     ));
@@ -289,14 +300,21 @@ pub fn run() {
                                 return;
                             }
                             if let Some(tt) = app.get_webview_window("tray-tooltip") {
-                                // Position the tooltip centred below the tray icon.
-                                // scale_factor 1.0 because the tray_icon crate already
-                                // gives us physical pixel coords before the dpi wrapper.
+                                // Position the tooltip centred against the tray icon —
+                                // below it on macOS, above it on Windows. See
+                                // `tray_anchor_position`. scale_factor 1.0 because the
+                                // tray_icon crate already gives us physical pixel coords
+                                // before the dpi wrapper.
                                 let tt_w = 300_i32;
                                 let icon_pos = rect.position.to_physical::<i32>(1.0);
                                 let icon_size = rect.size.to_physical::<i32>(1.0);
-                                let x = (icon_pos.x + icon_size.width / 2 - tt_w / 2).max(0);
-                                let y = icon_pos.y + icon_size.height;
+                                let tt_h = tt.outer_size().map(|s| s.height as i32).unwrap_or(0);
+                                let (x, y) = tray_anchor_position(
+                                    (icon_pos.x, icon_pos.y),
+                                    (icon_size.width, icon_size.height),
+                                    (tt_w, tt_h),
+                                    cfg!(target_os = "windows"),
+                                );
                                 let _ = tt.set_position(tauri::Position::Physical(
                                     tauri::PhysicalPosition::new(x, y),
                                 ));
@@ -409,12 +427,18 @@ pub fn run() {
 
             // Auto-open the setup wizard on first launch (no ~/.meridian/onboarded).
             // The 800 ms delay lets the tray menu settle before the window appears.
+            //
+            // Uses meridian_core::paths::meridian_dir() rather than a raw
+            // `HOME` env var read — HOME is unset on Windows, which used to make
+            // this check fall through to a bogus root-relative path, so the
+            // marker could never be found there.
             {
                 let wizard_handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
                     tokio::time::sleep(tokio::time::Duration::from_millis(800)).await;
-                    let home = std::env::var("HOME").unwrap_or_default();
-                    if !std::path::Path::new(&format!("{home}/.meridian/onboarded")).exists() {
+                    let onboarded = meridian_core::paths::meridian_dir()
+                        .is_some_and(|dir| dir.join("onboarded").exists());
+                    if !onboarded {
                         tray::open_wizard_window(&wizard_handle);
                     }
                 });
@@ -535,6 +559,7 @@ pub fn run() {
             // Setup wizard (first-run, permissions, providers)
             commands::is_first_run,
             commands::mark_setup_complete,
+            commands::get_platform,
             commands::save_account_email,
             commands::get_account_email,
             commands::clear_account_email,
@@ -629,6 +654,68 @@ fn reopen_target(onboarded: bool) -> ReopenTarget {
         ReopenTarget::Dashboard
     } else {
         ReopenTarget::Wizard
+    }
+}
+
+/// Top-left position for a window anchored to the tray icon's click rect —
+/// centred horizontally on the icon, and placed either below it or above it.
+///
+/// macOS keeps the tray icon in the menu bar at the *top* of the screen, so
+/// anchoring below (`icon_pos.y + icon_size.height`) lands the popover/tooltip
+/// on-screen. Windows puts the tray icon in the notification area at the
+/// *bottom* of the taskbar, so that same "below" math pushes the window off
+/// the bottom of the screen — invisible, not just misplaced. `anchor_above`
+/// picks which side; callers pass `cfg!(target_os = "windows")`.
+///
+/// Pure and platform-independent so it's unit-testable without a live window —
+/// same rationale as [`is_onboarded`] / [`reopen_target`] above.
+fn tray_anchor_position(
+    icon_pos: (i32, i32),
+    icon_size: (i32, i32),
+    win_size: (i32, i32),
+    anchor_above: bool,
+) -> (i32, i32) {
+    let x = (icon_pos.0 + icon_size.0 / 2 - win_size.0 / 2).max(0);
+    let y = if anchor_above {
+        (icon_pos.1 - win_size.1).max(0)
+    } else {
+        icon_pos.1 + icon_size.1
+    };
+    (x, y)
+}
+
+#[cfg(test)]
+mod tray_anchor_position_tests {
+    use super::tray_anchor_position;
+
+    #[test]
+    fn below_places_top_edge_at_icon_bottom() {
+        // macOS-style: icon near the top of the screen, popover grows downward.
+        let (x, y) = tray_anchor_position((1500, 0), (24, 24), (344, 400), false);
+        assert_eq!(x, 1500 + 12 - 172); // centred under the icon
+        assert_eq!(y, 24); // flush with the icon's bottom edge
+    }
+
+    #[test]
+    fn above_places_bottom_edge_at_icon_top() {
+        // Windows-style: icon near the bottom of the screen, popover grows upward.
+        let (x, y) = tray_anchor_position((1500, 1040), (24, 24), (344, 400), true);
+        assert_eq!(x, 1500 + 12 - 172); // centred over the icon, same as below
+        assert_eq!(y, 1040 - 400); // flush with the icon's top edge
+    }
+
+    #[test]
+    fn x_never_goes_negative_when_icon_is_near_the_left_edge() {
+        let (x, _) = tray_anchor_position((5, 0), (24, 24), (344, 400), false);
+        assert_eq!(x, 0);
+    }
+
+    #[test]
+    fn above_never_goes_negative_when_window_is_taller_than_the_icons_offset() {
+        // A pathologically tall window anchored above a near-top icon must clamp
+        // to 0 rather than requesting a negative y (off the top of the screen).
+        let (_, y) = tray_anchor_position((100, 50), (24, 24), (344, 2000), true);
+        assert_eq!(y, 0);
     }
 }
 

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -8,11 +8,11 @@
 // permission polling, integrations, sign-in, and the AI-provider choice — is all
 // live. No fabricated state.
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import type { ReactNode } from 'react'
 import { invoke, load, mutate, tauri } from '@/lib/bridge'
-import { STEPS, Welcome, Completion } from './steps'
-import type { Wiz } from './steps'
+import { buildSteps, Welcome, Completion } from './steps'
+import type { StepMeta, Wiz } from './steps'
 import type { NotifState } from './data'
 import type { IntegrationsResponse } from '@/lib/api-types'
 import type { RuntimeSettings } from '@/lib/settings'
@@ -25,6 +25,16 @@ export default function SetupWizard() {
   const [step, setStep] = useState(0)
   const [done, setDone] = useState(false)
   const [err, setErr] = useState('')
+
+  // Platform gates which steps exist — Permissions is macOS-only (Windows
+  // capture needs no TCC-style grant; see buildSteps in ./steps.tsx). `null`
+  // until resolved is treated as "include it" so the (Welcome-gated) first
+  // paint never has to un-render a step a moment later.
+  const [platform, setPlatform] = useState<string | null>(null)
+  useEffect(() => {
+    invoke<string>('get_platform').then(setPlatform).catch(() => {})
+  }, [])
+  const steps = useMemo(() => buildSteps(platform), [platform])
 
   // Step 1 — permissions (live)
   const [perms, setPerms] = useState<Wiz['perms']>({ accessibility: null, screen: null, notifications: null })
@@ -90,7 +100,7 @@ export default function SetupWizard() {
   // Notification state also refreshes here after the user answers the OS
   // dialog or flips the toggle in System Settings.
   useEffect(() => {
-    if (!active || step !== 0) return
+    if (!active || steps[step]?.id !== 'permissions') return
     const poll = async () => {
       const [accessibility, screen, notifications] = await Promise.all([
         invoke<boolean>('check_accessibility').catch(() => false),
@@ -113,7 +123,7 @@ export default function SetupWizard() {
     poll()
     const id = setInterval(poll, 2000)
     return () => clearInterval(id)
-  }, [active, step])
+  }, [active, step, steps])
 
   // Keep the live connected-state fresh while on the Integrations step, so the
   // rail status + completion summary reflect connects made via <ConnectTrackers>
@@ -126,11 +136,11 @@ export default function SetupWizard() {
   }, [])
 
   useEffect(() => {
-    if (!active || step !== 1) return  // Integrations is now step index 1 (2nd tab)
+    if (!active || steps[step]?.id !== 'integrations') return
     refetchIntegrations()
     const id = setInterval(refetchIntegrations, 3000)
     return () => clearInterval(id)
-  }, [active, step, refetchIntegrations])
+  }, [active, step, steps, refetchIntegrations])
 
   // ── Actions ────────────────────────────────────────────────────────────────
   const openPane = useCallback((pane: string) => {
@@ -186,8 +196,8 @@ export default function SetupWizard() {
   }
 
   // ── Navigation ───────────────────────────────────────────────────────────────
-  const meta = STEPS[step]
-  const last = step === STEPS.length - 1
+  const meta = steps[step]
+  const last = step === steps.length - 1
   const goStep = (i: number) => { setErr(''); setWelcome(false); setDone(false); setStep(i) }
   const finish = async () => {
     // `mark_setup_complete` writes the onboarded flag that stops the wizard
@@ -230,10 +240,10 @@ export default function SetupWizard() {
         transformOrigin: 'center',
       }}>
         {welcome ? (
-          <Welcome onBegin={() => { setWelcome(false); setStep(0) }} />
+          <Welcome onBegin={() => { setWelcome(false); setStep(0) }} steps={steps} />
         ) : (
           <div className="flex" style={{ height: '100%' }}>
-            <Rail step={step} done={done} wiz={wiz} goStep={goStep} />
+            <Rail step={step} done={done} wiz={wiz} steps={steps} goStep={goStep} />
             <div className="flex flex-col" style={{ flex: 1, minWidth: 0 }}>
               {done ? (
                 <div className="nice-scroll" style={{ flex: 1, overflowY: 'auto', display: 'grid', placeItems: 'center', padding: '28px 32px' }}>
@@ -266,7 +276,9 @@ export default function SetupWizard() {
 }
 
 // ── Left step rail ────────────────────────────────────────────────────────────
-function Rail({ step, done, wiz, goStep }: { step: number; done: boolean; wiz: Wiz; goStep: (i: number) => void }) {
+function Rail({ step, done, wiz, steps, goStep }: {
+  step: number; done: boolean; wiz: Wiz; steps: StepMeta[]; goStep: (i: number) => void
+}) {
   return (
     <div className="flex flex-col" style={{ width: 250, flexShrink: 0, background: 'var(--t-box)', borderRight: '1px solid var(--t-hair)', padding: '22px 18px' }}>
       <div style={{ padding: '0 6px', marginBottom: 26 }}>
@@ -276,14 +288,14 @@ function Rail({ step, done, wiz, goStep }: { step: number; done: boolean; wiz: W
         </div>
       </div>
       <div className="flex flex-col" style={{ gap: 2 }}>
-        {STEPS.map((s, i) => {
+        {steps.map((s, i) => {
           const isCur = i === step && !done
           const reached = done || i <= step
           const ok = done || i < step
           // A future step is reachable only once every step between the current
           // one and it satisfies its gate — so the rail can't skip a required
           // step (e.g. permissions) that the Footer's "Continue" would block.
-          const reachable = done || i <= step || STEPS.slice(step, i).every((p) => p.canNext(wiz))
+          const reachable = done || i <= step || steps.slice(step, i).every((p) => p.canNext(wiz))
           return (
             <button key={s.id} disabled={!reachable} onClick={() => { if (reachable) goStep(i) }} className="flex items-start"
               style={{ gap: 12, padding: '10px 8px', borderRadius: 10, textAlign: 'left',

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -176,9 +176,9 @@ function IntelligenceBody({ wiz }: { wiz: Wiz }) {
 }
 
 // ── Welcome (pre-step intro) ──────────────────────────────────────────────────
-export function Welcome({ onBegin }: { onBegin: () => void }) {
+export function Welcome({ onBegin, steps }: { onBegin: () => void; steps: StepMeta[] }) {
   const points = [
-    { t: 'On-device', d: 'Your screen is read and understood locally on your Mac, never uploaded.' },
+    { t: 'On-device', d: 'Your screen is read and understood locally on your device, never uploaded.' },
     { t: 'Automatic', d: 'Builds an accurate timeline of the tickets you worked on, then drafts the updates for you.' },
     { t: 'Connected', d: 'Works with Jira, Linear, GitHub, Trello, and Azure DevOps.' },
   ]
@@ -208,7 +208,7 @@ export function Welcome({ onBegin }: { onBegin: () => void }) {
         ))}
       </div>
       <Btn onClick={onBegin} style={{ padding: '11px 26px', fontSize: 13.5 }}>Get started</Btn>
-      <p className="font-mono" style={{ fontSize: 10.5, letterSpacing: '.04em', color: 'var(--t-faint)', marginTop: 14 }}>{STEPS.length} quick steps · about a minute</p>
+      <p className="font-mono" style={{ fontSize: 10.5, letterSpacing: '.04em', color: 'var(--t-faint)', marginTop: 14 }}>{steps.length} quick steps · about a minute</p>
     </div>
   )
 }
@@ -257,10 +257,16 @@ export interface StepMeta {
   canNext: (w: Wiz) => boolean
 }
 
-// Permissions stays first (capture needs them); the AI-provider choice comes
-// last so the user has connected their trackers and signed in before picking
-// which model writes their summaries.
-export const STEPS: StepMeta[] = [
+// Permissions stays first on macOS (capture needs them); the AI-provider
+// choice comes last so the user has connected their trackers and signed in
+// before picking which model writes their summaries.
+//
+// Permissions is macOS-only: Windows capture (UIA + WGC) has no TCC-style
+// consent system — screenpipe_a11y::platform::windows reports every grant as
+// already true — so there is nothing for that step to request, and its copy
+// ("Two macOS permissions...") is actively wrong on Windows. `buildSteps`
+// drops it entirely there rather than rendering an always-green no-op card.
+const ALL_STEPS: StepMeta[] = [
   {
     id: 'permissions', n: '01', label: 'Permissions', kicker: 'Access',
     title: 'Let Meridian see your work',
@@ -298,3 +304,10 @@ export const STEPS: StepMeta[] = [
     canNext: () => true,
   },
 ]
+
+/** Platform-specific step list. `n` is renumbered to the filtered position so
+ *  the rail never shows a gap (e.g. "02, 03, 04" with only three steps). */
+export function buildSteps(platform: string | null): StepMeta[] {
+  const steps = platform === 'windows' ? ALL_STEPS.filter((s) => s.id !== 'permissions') : ALL_STEPS
+  return steps.map((s, i) => ({ ...s, n: String(i + 1).padStart(2, '0') }))
+}

--- a/ui/components/LlmProviderPicker.tsx
+++ b/ui/components/LlmProviderPicker.tsx
@@ -147,10 +147,14 @@ export function useLlmProviderDetection() {
   return { status, scanning, testingIds, installingIds, signingIds, testOne, install, signIn, rescan: detect }
 }
 
-/** One tile in the top-level chooser: logo + name + a badge, nothing else. */
-function ChooserTile({ id, name, badge, selected, subtitle, onOpen }: {
+/** One tile in the top-level chooser: logo + name + a badge, nothing else.
+ *  `warning`, when set, replaces the normal badge/subtitle with a confirmed problem —
+ *  either "not installed" (a real probe came up empty) or "erroring" (the last real
+ *  test failed, e.g. a spawn error). Both come from real signals, never an
+ *  unprobed/slow state, so a card never falsely flags a provider that's actually fine. */
+function ChooserTile({ id, name, badge, selected, subtitle, warning, onOpen }: {
   id: LlmProviderId; name: string; badge: string; selected: boolean
-  subtitle?: string; onOpen: () => void
+  subtitle?: string; warning?: { label: string; message: string }; onOpen: () => void
 }) {
   return (
     <button onClick={onOpen} className="flex flex-col text-left h-full"
@@ -170,12 +174,23 @@ function ChooserTile({ id, name, badge, selected, subtitle, onOpen }: {
           <ProviderLogo id={id} size={21} />
         </span>
         {selected && (
-          <span className="font-mono" style={{
-            fontSize: 9, letterSpacing: '.09em', color: 'var(--color-state-approved)',
-            border: '1px solid var(--color-state-approved)',
-            background: 'color-mix(in srgb, var(--color-state-approved) 10%, transparent)',
-            borderRadius: 4, padding: '1.5px 5px', whiteSpace: 'nowrap',
-          }}>IN USE</span>
+          // Selected-but-confirmed-broken must not say "IN USE" — that reads as
+          // "working", which is exactly wrong when the daemon can't spawn/find it.
+          warning ? (
+            <span className="font-mono" style={{
+              fontSize: 9, letterSpacing: '.09em', color: 'var(--color-state-pending)',
+              border: '1px solid var(--color-state-pending)',
+              background: 'color-mix(in srgb, var(--color-state-pending) 10%, transparent)',
+              borderRadius: 4, padding: '1.5px 5px', whiteSpace: 'nowrap',
+            }}>{warning.label}</span>
+          ) : (
+            <span className="font-mono" style={{
+              fontSize: 9, letterSpacing: '.09em', color: 'var(--color-state-approved)',
+              border: '1px solid var(--color-state-approved)',
+              background: 'color-mix(in srgb, var(--color-state-approved) 10%, transparent)',
+              borderRadius: 4, padding: '1.5px 5px', whiteSpace: 'nowrap',
+            }}>IN USE</span>
+          )
         )}
       </div>
       <div className="flex flex-col" style={{ gap: 4 }}>
@@ -183,7 +198,11 @@ function ChooserTile({ id, name, badge, selected, subtitle, onOpen }: {
         <span className="font-mono self-start" style={{
           fontSize: 8.5, letterSpacing: '.09em', color: 'var(--t-faint)',
         }}>{badge}</span>
-        {subtitle && <span style={{ fontSize: 11, lineHeight: 1.4, color: 'var(--t-muted)' }}>{subtitle}</span>}
+        {warning ? (
+          <span style={{ fontSize: 11, lineHeight: 1.4, color: 'var(--color-state-pending)' }}>
+            {warning.message}
+          </span>
+        ) : subtitle && <span style={{ fontSize: 11, lineHeight: 1.4, color: 'var(--t-muted)' }}>{subtitle}</span>}
       </div>
     </button>
   )
@@ -255,13 +274,27 @@ export default function LlmProviderPicker({
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(190px, 1fr))', gap: 10 }}>
         {CHOOSER_PROVIDER_IDS.map((id) => {
           const p = llmProvider(id)
+          const probed = status[id]
+          const isSelected = value === id
+          const warning =
+            probed && !probed.installed
+              ? {
+                  label: 'NOT DETECTED',
+                  message: isSelected
+                    ? "Selected, but the CLI isn't installed on this machine."
+                    : 'Not installed on this machine.',
+                }
+              : probed?.last_test?.outcome.status === 'failed'
+                ? { label: 'ERROR', message: probed.last_test.outcome.message }
+                : undefined
           return (
             <ChooserTile
               key={id}
               id={id}
               name={p.name}
               badge={LLM_RECOMMENDED_BADGE}
-              selected={value === id}
+              selected={isSelected}
+              warning={warning}
               onOpen={() => setOpenId(id)}
             />
           )


### PR DESCRIPTION
## Summary

First real end-to-end verification of the Windows build — set up the full dev toolchain from scratch on a Windows ARM64 (Parallels/Apple Silicon host) machine, ran the daemon + tray, and fixed everything that broke along the way. All of these are genuine platform gaps, not this-machine-only quirks: the code paths were either macOS-only by construction or had zero Windows branch at all.

## What's fixed

**LLM provider CLIs were unusable on Windows** (`src/llm/detect.rs`, `src/coding_agent_session_ingest/summariser/mod.rs`)
- `resolve_cli()`'s only two probes — a login-shell spawn (`/bin/zsh`) and a hardcoded Unix install-path list (`~/.local/bin`, `/opt/homebrew/bin`, ...) — exist purely to work around macOS's Finder-stripped-`PATH` problem. Neither can ever succeed on Windows, so every provider reported "not found" regardless of whether it actually worked. Added `probe_current_path()`, tried first: checks the calling process's own `PATH` with `PATHEXT` resolution for npm's `.cmd`/`.bat` shims. This is normally sufficient on Windows (no Finder-style stripping there) and also speeds up macOS resolution when the daemon's own `PATH` is already good.
- Once resolved, the CLI was spawned directly via `Command::new(path)`. On Windows, `claude`/`codex`/etc. install as `.cmd` files, not PE executables — `CreateProcess` rejects them outright with `os error 193, %1 is not a valid Win32 application`, even though the same path runs fine typed into a terminal. Added `windows_shell_wrapper()`, routing `.cmd`/`.bat` targets through `cmd.exe /C`.
- New Windows-specific unit test proves `probe_current_path` actually runs on this platform. Verified live: `claude -p "..."` now returns a real authenticated response through the daemon's exact invocation path.

**OAuth browser launch was macOS-only** (`meridian-oauth/src/flow.rs`)
- `open_browser()` unconditionally shelled to `open` (macOS-only). `.spawn()` failed silently on Windows, so the Jira/Trello flows logged "opening browser..." and nothing ever opened, with no URL fallback for Jira. Now routes through `cmd /C start` on Windows, `xdg-open` on Linux, and always logs the URL as a manual-paste fallback regardless of platform.

**Tray popover/tooltip positioned off-screen on Windows** (`tray/src-tauri/src/lib.rs`)
- Both windows always anchored *below* the tray icon's click rect — correct on macOS (menu bar, top of screen), but Windows' tray icon sits at the bottom of the taskbar, so "below" placed them off the bottom edge: present, never visible. Extracted `tray_anchor_position()` (pure, unit tested for both directions + clamping) — anchors above the icon on Windows.

**Onboarding marker used a raw `HOME` env var** (`tray/src-tauri/src/lib.rs`, `commands/setup.rs`)
- The auto-open-wizard check, `is_first_run`, and `mark_setup_complete` each read `std::env::var("HOME")` directly instead of the existing `meridian_core::paths::meridian_dir()` (which already has a correct `dirs`-crate fallback). `HOME` is unset on Windows, so each of the three fell back differently (empty string vs `"."`), meaning the onboarded marker could be written and read from three different, wrong locations.

**Setup wizard showed a dead macOS-only step on Windows** (`tray/src-tauri/src/commands/setup.rs`, `ui/app/setup/*.tsx`)
- The Permissions step is macOS-only — Windows capture (UIA + WGC) has no TCC-style consent system, `screenpipe_a11y::platform::windows` reports every grant as already `true` — but it was hardcoded as step 1 unconditionally, copy and all ("Two macOS permissions..."). Added a `get_platform` command and `buildSteps(platform)`, which drops the step entirely on Windows and renumbers the rail/step-count copy accordingly. Also fixed the Welcome screen's "locally on your Mac" copy to be platform-neutral.

**Provider chooser could show "IN USE" for a broken provider** (`ui/components/LlmProviderPicker.tsx`)
- The top-level chooser tile only reflected `settings.json`'s saved choice, never whether the provider actually worked — so a selected-but-broken CLI still read as fine at a glance. `ChooserTile` now takes a `warning` (label + message) computed from the same probed/last-test signals the detail view already uses: `NOT DETECTED` when a real probe came up empty, `ERROR` with the last test's message when a real test failed. Neither ever fires from an unprobed/slow state.

## Not touched

- CI (`release-build.yml`) is intentionally Apple-Silicon-only right now (see its header comment) — that was a deliberate recent decision, not an oversight, so this PR doesn't touch it. Re-adding the Windows matrix entry is a follow-up if/when wanted.
- No changes to `install.sh`/`dev-start.sh`'s macOS-only assumptions — out of scope here; the Windows dev flow currently means running `cargo`/`npm` commands directly rather than through those scripts.

## Test plan

- [x] `cargo test --lib llm::detect` — 12/12 pass, including the new Windows `resolve_cli` test
- [x] `cargo test` for the new `tray_anchor_position` unit tests — 4/4 pass
- [x] `npm run typecheck` (ui/) — clean
- [x] Full toolchain bootstrap + `cargo build`/`npm ci` on a fresh Windows ARM64 machine
- [x] Daemon + `tauri dev` running live; popover/tooltip confirmed on-screen via window-rect inspection
- [x] `claude -p "..."` verified working end-to-end through the daemon's real spawn path (not just the unit test)
- [x] Local NSIS installer built successfully (`npm run build:windows`) for manual install testing
- [ ] Real Jira/Trello OAuth round-trip (browser now opens correctly; the Atlassian-side "trouble logging you in" error encountered separately looks like an app-registration issue, not a Windows bug — not addressed here)
