### PR TITLE
fix(ui): stop StatusBanner clicks from bubbling to the dialog overlay

### DIFF
--- a/ui/components/timeline/TaskDetailDialog.tsx
+++ b/ui/components/timeline/TaskDetailDialog.tsx
@@ -234,8 +234,10 @@ export function TaskDetailDialog({
           </div>
         )}
       </div>
-      <StatusBanner undo={undo} note={note} busy={!!statusBusyKey}
-        onUndo={handleUndo} onDismissUndo={dismissUndo} onDismissNote={dismissNote} />
+      <div onClick={e => e.stopPropagation()}>
+        <StatusBanner undo={undo} note={note} busy={!!statusBusyKey}
+          onUndo={handleUndo} onDismissUndo={dismissUndo} onDismissNote={dismissNote} />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Fixes a CodeRabbit finding on Meridiona/meridian#528 (`ui/components/timeline/TaskDetailDialog.tsx`, Major/functional-correctness).

`StatusBanner` was rendered as a sibling of the modal body's `onClick={e => e.stopPropagation()}` div, inside the outer overlay's `onClick={onClose}`. Its Undo/dismiss buttons don't stop propagation, so any click on them bubbled straight to the overlay and closed the whole dialog — undermining the Undo flow that feature added.

## Fix

Wrapped `<StatusBanner />` in its own `onClick={e => e.stopPropagation()}` div, matching the reviewer's proposed fix exactly. `StatusBanner` itself renders as `position: fixed`, so it isn't affected by being nested one level deeper (no ancestor establishes a new containing block).

## Test plan
- [x] Full pre-push suite green: fmt, clippy, UI build, UI tests, `cargo test`