### PR TITLE
ci: make the staging release manual-only, not merge-triggered

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -85,14 +85,17 @@ cd packages/meridian-mcp && npm run build && cd ../..
 ```
 
 ### 3. Trigger a Release
-Production: merge conventional-commit PRs into `main` — `release.yml` runs
-semantic-release automatically on push. Staging: push to `pre-main` with
-`[staging-release]` in the commit message, or `gh workflow run
-release-staging.yml`.
+Production: merge conventional-commit PRs into `main` — `release-prepare.yml`
+runs semantic-release automatically on push there, tags `vX.Y.Z`, and the tag
+push triggers `release-build.yml`. Staging is manual-only: `gh workflow run
+release-prepare.yml --ref pre-main` (or "Run workflow" in the Actions UI with
+the branch dropdown set to `pre-main`) — it is no longer cut automatically on
+every merge to `pre-main`.
 
 ### 4. Monitor Build Status
 ```bash
-gh run list --workflow=release.yml --limit=5
+gh run list --workflow=release-prepare.yml --limit=5
+gh run list --workflow=release-build.yml --limit=5
 gh run view <RUN_ID> --json status,conclusion,jobs
 gh run view <RUN_ID> --log-failed 2>&1 | tail -100
 ```

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -52,35 +52,36 @@ name: Release (prepare)
 # version cheaply (or read it from the repo), then build from an immutable ref.
 
 on:
-  # AUTO on every push to pre-main. Every merge to the staging branch runs
-  # semantic-release, which cuts a new staging prerelease WHENEVER there are
-  # releasable commits (feat/fix/perf/…) since the last staging tag — and does
-  # nothing when a merge carries only chore/docs/ci commits. That "does it
-  # warrant a release?" decision belongs to semantic-release's commit analysis,
-  # not to us. This is the canonical way semantic-release is meant to run: point
-  # it at the release branch and let it decide.
+  # AUTO only on push to main — that push is the deliberate pre-main → main
+  # release merge, and its whole purpose is to ship a stable version, so it
+  # stays automatic. Stable channel picks up .releaserc.json (committed,
+  # changelog + git plugins) below.
   #
-  # There is intentionally NO commit-message marker gate. The previous design
-  # gated on a `[staging-release]` substring, which backfired: a squash merge
-  # folds every PR commit BODY into the merge message, and this repo's own
-  # workflow comments quote the literal marker — so merging a PR that merely
-  # TOUCHED these files matched the gate and cut an unintended release
-  # (v1.72.0-staging.6, deleted). Running unconditionally on push and letting
-  # semantic-release judge the commits removes that whole class of accident:
-  # there is no fragile string match left to misfire.
+  # Staging is intentionally NOT auto-triggered on push to pre-main anymore.
+  # It used to fire on every merge to pre-main, cutting a new
+  # `vX.Y.Z-staging.N` prerelease per merge whether or not anyone wanted a
+  # staging build right then. That churned through macOS-runner minutes and
+  # notarization budget on every PR merge. Staging is now cut on demand only,
+  # via "Run workflow" (workflow_dispatch) with the branch dropdown set to
+  # `pre-main` — pick that branch in the Actions UI and dispatch.
   #
-  # BOTH CHANNELS. `pre-main` cuts staging prereleases, `main` cuts stable
-  # releases — one pipeline, so the two can never drift from each other. The old
-  # monolithic release.yml that used to own `main` has been deleted; leaving it
-  # in place would double-fire on every push here.
+  # There is intentionally NO commit-message marker gate on either trigger.
+  # The previous design gated staging auto-release on a `[staging-release]`
+  # substring, which backfired: a squash merge folds every PR commit BODY
+  # into the merge message, and this repo's own workflow comments quote the
+  # literal marker — so merging a PR that merely TOUCHED these files matched
+  # the gate and cut an unintended release (v1.72.0-staging.6, deleted).
   #
-  # Which channel a run is depends only on the branch, and it selects the
-  # semantic-release config below. The BUILD does not read this at all — it
-  # derives the channel from the tag it is handed, so there is exactly one
-  # source of truth for "is this stable or staging".
+  # Which channel a run is depends only on the branch it runs against
+  # (`GITHUB_REF_NAME`), and that selects the semantic-release config below.
+  # The BUILD does not read this at all — it derives the channel from the tag
+  # it is handed, so there is exactly one source of truth for "is this stable
+  # or staging".
   push:
-    branches: [pre-main, main]
-  # Kept for on-demand runs and version previews (dry_run) without a merge.
+    branches: [main]
+  # Staging releases are manual-only now: pick `pre-main` in the branch
+  # dropdown and dispatch. Also used for dry-run version previews on any
+  # branch without cutting anything.
   workflow_dispatch:
     inputs:
       dry_run:
@@ -103,10 +104,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # pushes the version-bump commit and the tag
-    # No `if:` gate. The job runs on every push to pre-main (and on manual
-    # dispatch); semantic-release itself decides whether the commits warrant a
-    # release. There is deliberately no commit-message substring match — that is
-    # what previously cut an accidental release (see `on:` above).
+    # No `if:` gate. The job runs on every push to main and on manual dispatch
+    # (e.g. against pre-main for a staging cut); semantic-release itself
+    # decides whether the commits warrant a release. There is deliberately no
+    # commit-message substring match — that is what previously cut an
+    # accidental release (see `on:` above).
     outputs:
       released: ${{ steps.run.outputs.released }}
       version: ${{ steps.run.outputs.version }}


### PR DESCRIPTION
## Summary
- Staging (`pre-main`) releases no longer auto-cut on every merge — `release-prepare.yml`'s `push` trigger now only covers `main`.
- Cut a staging prerelease on demand: Actions → "Release (prepare)" → Run workflow, with the branch dropdown set to `pre-main`.
- `main` keeps its automatic release-on-push behavior unchanged.
- Updated `.claude/skills/release/SKILL.md`'s trigger instructions to match.

## Why
Every merge to `pre-main` was auto-cutting a `vX.Y.Z-staging.N` prerelease (full macOS build + notarize), whether or not a staging build was actually wanted at that moment.

## Test plan
- [ ] Merge a PR into `pre-main` and confirm `release-prepare.yml` does NOT run automatically.
- [ ] Manually dispatch `release-prepare.yml` against `pre-main` and confirm it still tags a `-staging.N` prerelease and `release-build.yml` picks it up.
- [ ] Confirm a push to `main` still auto-cuts a stable release as before.