### PR TITLE
fix(release): wire set-version.sh back into semantic-release via exec

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -71,6 +71,12 @@
       }
     ],
     [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "bash scripts/set-version.sh ${nextRelease.version}"
+      }
+    ],
+    [
       "@semantic-release/github",
       {
         "successComment": false,

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -10,7 +10,13 @@
 # packages/meridian-mcp/package.json, and tray/src-tauri/tauri.conf.json (the
 # version the DMG auto-updater compares against — MUST be bumped BEFORE the tray
 # build so the packaged .app bakes the release version, not a stale 0.1.0).
-# Uses BSD sed (the release runs on macOS).
+#
+# Runs on BOTH macOS (release-build.yml's per-arch build job) and Linux
+# (release-prepare.yml's ubuntu-latest exec prepareCmd) — everything below
+# goes through python3, not sed, because `sed -i` is not portable between BSD
+# (macOS) and GNU (Linux): `sed -i '' -E '...'` works on BSD but on GNU sed the
+# `''` is consumed as the script itself, not the in-place suffix, and the real
+# expression gets treated as a filename.
 set -euo pipefail
 
 VER="${1:?usage: set-version.sh <version>}"
@@ -18,13 +24,21 @@ VER="${VER#v}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT}"
 
-# TOML: the single top-level `version = "..."` line ([package] / [project]).
-sed -i '' -E "s/^version = \"[^\"]*\"/version = \"${VER}\"/" Cargo.toml
-
-# JSON manifests via python (reliable; preserves structure).
 python3 - "${VER}" <<'PY'
-import json, sys
+import json, re, sys
 ver = sys.argv[1]
+
+# Cargo.toml: the single top-level `version = "..."` line ([package]).
+with open("Cargo.toml") as fh:
+    cargo_toml = fh.read()
+cargo_toml, n = re.subn(
+    r'(?m)^version = "[^"]*"', f'version = "{ver}"', cargo_toml, count=1
+)
+if n != 1:
+    sys.exit(f"set-version: expected exactly one top-level version in Cargo.toml, patched {n}")
+with open("Cargo.toml", "w") as fh:
+    fh.write(cargo_toml)
+
 targets = [
     "ui/package.json",
     "packages/meridian-mcp/package.json",
@@ -48,7 +62,6 @@ for path in targets:
 # `cargo build --locked` would fail the release). "meridian" is a workspace path
 # crate, so only its own version line changes — the dependency graph is untouched,
 # leaving rust-cache's restore behaviour the same as the Cargo.toml bump already is.
-import re
 with open("Cargo.lock") as fh:
     lock = fh.read()
 lock, n = re.subn(


### PR DESCRIPTION
## Summary
- Re-adds the `@semantic-release/exec` plugin to `.releaserc.json` (stable channel) with `prepareCmd: bash scripts/set-version.sh ${nextRelease.version}`, run before `@semantic-release/git` commits the release bump.
- Rewrites `scripts/set-version.sh`'s `Cargo.toml` edit from BSD-only `sed -i ''` to the same portable python3 approach it already uses for the JSON manifests and `Cargo.lock`.

## Why
`@semantic-release/exec` was in `package.json` and `scripts/set-version.sh`'s own header says it's "called by semantic-release (@semantic-release/exec prepareCmd)", but `.releaserc.json`'s plugin list never actually included it — it was dropped during the release-prepare/release-build split and never restored. Nothing wrote the new version into `Cargo.toml`/`Cargo.lock`/`ui/package.json`/`packages/meridian-mcp/package.json`/`tray/src-tauri/tauri.conf.json`, so the `chore(release): X.Y.Z` commit only ever touched `CHANGELOG.md`.

`release-build.yml`'s "Assert the tag matches the committed version" step (stable channel only) then always fails, because the tagged commit's `Cargo.toml` is stale. This is exactly what happened to `v1.75.0`: tag `v1.75.0` vs. committed `Cargo.toml` version `1.74.0` → build failed → the GitHub release has been stuck in draft with no assets.

The sed rewrite is necessary, not cosmetic: the exec `prepareCmd` now runs inside `release-prepare.yml` on `ubuntu-latest` (GNU sed), while the same script is also invoked directly by `release-build.yml`'s per-arch "Stamp the version" step on both macOS and Windows runners. `sed -i '' -E '...'` only works on BSD sed — on GNU sed the empty string is consumed as the script itself and the real expression is treated as a filename, so leaving it as-is would have made `release-prepare` fail outright on the next stable release. Folding the `Cargo.toml` edit into the existing python3 block (already used for the JSON manifests + `Cargo.lock`) sidesteps the BSD/GNU split entirely and now works identically on all three runner OSes.

## Not included
This does not fix the already-tagged `v1.75.0` — that tag/commit predates this fix and its `Cargo.toml` will still read `1.74.0`. Separate cleanup needed (delete + recut, most likely as `1.75.1` since `CHANGELOG.md`/the `chore(release): 1.75.0` commit are already on `pre-main`/`main`); flagging for a decision rather than doing it here since it's destructive (deleting a tag/release).

## Test plan
- [ ] Verified locally: ran the rewritten `set-version.sh` against a scratch fixture (`Cargo.toml`, `Cargo.lock` with an unrelated second `[[package]]` entry, `ui/package.json`, `packages/meridian-mcp/package.json`, `tray/src-tauri/tauri.conf.json`) and confirmed only the `meridian` version lines changed and JSON stayed valid.
- [ ] Merge to `main` (or a controlled dry run) and confirm the `chore(release): X.Y.Z` commit now includes `Cargo.toml`/`Cargo.lock`/the three JSON manifests, not just `CHANGELOG.md`.
- [ ] Confirm `release-build.yml`'s version-assert step passes on the resulting tag and the release leaves draft state.