### PR TITLE
fix(windows): resolve HOME via meridian_core::paths, quote OAuth browser-launch URLs, fix duplicate ClerkProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5097,6 +5097,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "dirs 5.0.1",
  "rand 0.8.6",
  "reqwest 0.12.28",
  "serde",

--- a/meridian-oauth/Cargo.toml
+++ b/meridian-oauth/Cargo.toml
@@ -25,6 +25,10 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-feature
 # the tray stays lean; the daemon's `full` unifies over this.
 tokio = { version = "1.15", features = ["net", "io-util", "time", "sync"] }
 tracing = "0.1.40"
+# Home-directory fallback for store::oauth_dir() when $HOME is unset (Windows).
+# Same crate/version meridian-core's util::paths already uses — adds nothing
+# new to the workspace lockfile.
+dirs = "5"
 # Cross-process advisory file lock for the rotating refresh token uses std's native
 # File::try_lock/unlock (stable since Rust 1.89; toolchain is pinned to 1.93.1), so
 # no external locking crate is needed — see store::lock_provider.

--- a/meridian-oauth/src/flow.rs
+++ b/meridian-oauth/src/flow.rs
@@ -375,6 +375,13 @@ else{document.querySelector('h2').textContent='No token in URL. Try again.';}\
 /// tokenizer the way it would from an interactive prompt. The URL can't itself
 /// contain a `"` — [`encode`] percent-encodes anything outside the unreserved
 /// set — so this quoting is always safe.
+/// The `raw_arg` line itself, pulled out as a pure function so the quoting
+/// shape is unit-testable without mocking `Command::spawn`.
+#[cfg(target_os = "windows")]
+fn windows_start_line(url: &str) -> String {
+    format!("start \"\" \"{url}\"")
+}
+
 #[cfg(target_os = "windows")]
 fn open_browser(url: &str) {
     use std::os::windows::process::CommandExt;
@@ -384,7 +391,7 @@ fn open_browser(url: &str) {
     );
     let result = std::process::Command::new("cmd")
         .arg("/C")
-        .raw_arg(format!("start \"\" \"{url}\""))
+        .raw_arg(windows_start_line(url))
         .spawn();
     if let Err(e) = result {
         tracing::warn!(error = %e, "failed to launch the system browser");
@@ -482,6 +489,32 @@ mod tests {
         assert_eq!(decode("a%20b"), "a b");
         assert_eq!(decode("abc-_123"), "abc-_123");
         assert_eq!(decode("x%2Fy"), "x/y");
+    }
+
+    /// The regression this whole PR exists for: a URL with `&`-joined query
+    /// params must come out fully wrapped in real quotes, so cmd.exe's
+    /// tokenizer can never see an unescaped `&` and split the command line.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_start_line_quotes_the_whole_url() {
+        let url = "https://auth.atlassian.com/authorize?response_type=code&client_id=abc&redirect_uri=http%3A%2F%2F127.0.0.1%3A9123%2Fcallback&state=xyz";
+        let line = windows_start_line(url);
+        assert_eq!(line, format!("start \"\" \"{url}\""));
+        // The URL's own `&`s must all land strictly inside the quoted span.
+        let open = line.find('"').unwrap();
+        let close = line.rfind('"').unwrap();
+        assert!(
+            close > open + 1,
+            "URL must be wrapped in a non-empty quoted span"
+        );
+        for (i, c) in line.char_indices() {
+            if c == '&' {
+                assert!(
+                    i > open && i < close,
+                    "found an `&` outside the quoted span at byte {i}: {line}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/meridian-oauth/src/flow.rs
+++ b/meridian-oauth/src/flow.rs
@@ -360,15 +360,43 @@ else{document.querySelector('h2').textContent='No token in URL. Try again.';}\
 /// argument is a window-title slot, not part of the command — the empty `""`
 /// there is required, otherwise `start` misreads a quoted URL as the title and
 /// never opens it.
+///
+/// The whole `/C ...` line is built with [`CommandExt::raw_arg`] rather than
+/// passed as normal `args` elements: `Command`'s automatic Windows quoting
+/// only wraps an argument in `"..."` when it contains a space, tab, or `"` —
+/// an authorize URL has none of those, only `&`-joined query params, so it
+/// went out unquoted. `cmd.exe` then parsed each unescaped `&` as a command
+/// separator and only the query string up to the FIRST `&` ever reached the
+/// browser (`response_type=code`, with `client_id`/`redirect_uri`/`scope`/
+/// `state` silently dropped as bogus follow-on commands) — the exact shape of
+/// Atlassian's "authorize request was incomplete or invalid" and GitHub's
+/// consent page hanging on a `redirect_uri`-less Authorize click. Wrapping the
+/// URL in real quotes inside the raw command line protects `&` from cmd.exe's
+/// tokenizer the way it would from an interactive prompt. The URL can't itself
+/// contain a `"` — [`encode`] percent-encodes anything outside the unreserved
+/// set — so this quoting is always safe.
+#[cfg(target_os = "windows")]
+fn open_browser(url: &str) {
+    use std::os::windows::process::CommandExt;
+    tracing::info!(
+        url,
+        "if it doesn't open automatically, open this URL yourself"
+    );
+    let result = std::process::Command::new("cmd")
+        .arg("/C")
+        .raw_arg(format!("start \"\" \"{url}\""))
+        .spawn();
+    if let Err(e) = result {
+        tracing::warn!(error = %e, "failed to launch the system browser");
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
 fn open_browser(url: &str) {
     tracing::info!(
         url,
         "if it doesn't open automatically, open this URL yourself"
     );
-    #[cfg(target_os = "windows")]
-    let result = std::process::Command::new("cmd")
-        .args(["/C", "start", "", url])
-        .spawn();
     #[cfg(target_os = "macos")]
     let result = std::process::Command::new("open").arg(url).spawn();
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]

--- a/meridian-oauth/src/store.rs
+++ b/meridian-oauth/src/store.rs
@@ -44,9 +44,23 @@ impl OAuthTokens {
     }
 }
 
+/// The current user's home directory. `$HOME` is normally unset on Windows,
+/// so `dirs::home_dir()` (the platform profile-directory API, `%USERPROFILE%`
+/// there) is the fallback — the same resolution order as
+/// `meridian_core::paths::home_dir()`, duplicated here rather than taken as a
+/// dependency: `meridian_core` pulls in sqlx/libsqlite3-sys for its DB layer,
+/// which this config-free, daemon-and-tray-shared crate deliberately has no
+/// reason to carry for one directory lookup.
+fn home_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .filter(|h| !h.is_empty())
+        .map(PathBuf::from)
+        .or_else(dirs::home_dir)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
 fn oauth_dir() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".meridian").join("oauth")
+    home_dir().join(".meridian").join("oauth")
 }
 
 /// Reject a provider name that isn't a plain identifier, so a token/lock path can

--- a/tray/src-tauri/src/analytics.rs
+++ b/tray/src-tauri/src/analytics.rs
@@ -123,9 +123,7 @@ struct AnalyticsState {
 }
 
 fn analytics_state_path() -> Option<PathBuf> {
-    std::env::var("HOME")
-        .ok()
-        .map(|h| PathBuf::from(h).join(".meridian/analytics_state.json"))
+    meridian_core::paths::home_dir().map(|h| h.join(".meridian/analytics_state.json"))
 }
 
 /// Load the state file, creating a fresh one (new random `distinct_id`) if

--- a/tray/src-tauri/src/commands/account.rs
+++ b/tray/src-tauri/src/commands/account.rs
@@ -92,9 +92,7 @@ struct AccountState {
 }
 
 fn account_path() -> Option<PathBuf> {
-    std::env::var("HOME")
-        .ok()
-        .map(|h| PathBuf::from(h).join(".meridian/account.json"))
+    meridian_core::paths::home_dir().map(|h| h.join(".meridian/account.json"))
 }
 
 /// Persist the signed-in user's email after the setup wizard's sign-in step

--- a/tray/src-tauri/src/commands/dashboard.rs
+++ b/tray/src-tauri/src/commands/dashboard.rs
@@ -437,12 +437,10 @@ pub async fn dismiss_worklog_target(
 #[tauri::command]
 #[tracing::instrument]
 pub async fn plan_dismissed() {
-    let home = std::env::var("HOME").unwrap_or_default();
-    if home.is_empty() {
+    let Some(home) = meridian_core::paths::home_dir() else {
         return;
-    }
-    let marker =
-        meridian_core::plan_marker::marker_path(&std::path::Path::new(&home).join(".meridian"));
+    };
+    let marker = meridian_core::plan_marker::marker_path(&home.join(".meridian"));
     if meridian_core::plan_marker::restamp_if_today(&marker, &chrono::Local::now()) {
         tracing::info!("plan_dismissed: nudge hold-back clock restarted");
     }

--- a/tray/src-tauri/src/commands/diagnostics.rs
+++ b/tray/src-tauri/src/commands/diagnostics.rs
@@ -53,8 +53,9 @@ pub async fn export_diagnostics_bundle(app: tauri::AppHandle) -> Result<String, 
 /// `~/Downloads/meridian-diagnostics-<unix_micros>.tar.gz` — a location every
 /// user can find without knowing about `~/.meridian/telemetry/`.
 fn default_export_path() -> anyhow::Result<std::path::PathBuf> {
-    let home = std::env::var("HOME").map_err(|_| anyhow::anyhow!("HOME not set"))?;
-    let dir = std::path::PathBuf::from(home).join("Downloads");
+    let home = meridian_core::paths::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("home directory could not be resolved"))?;
+    let dir = home.join("Downloads");
     std::fs::create_dir_all(&dir)?;
     let micros = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/tray/src-tauri/src/commands/health.rs
+++ b/tray/src-tauri/src/commands/health.rs
@@ -85,7 +85,7 @@ async fn check_database() -> (bool, Option<String>) {
         Err(_) => (
             false,
             Some(format!(
-                "Database not found — start the daemon: {}",
+                "meridian.db not found - start the daemon: {}",
                 start_daemon_hint()
             )),
         ),
@@ -102,12 +102,13 @@ fn start_daemon_hint() -> String {
     "launchctl load ~/Library/LaunchAgents/com.meridiona.daemon.plist".to_string()
 }
 
-#[cfg(target_os = "windows")]
-fn start_daemon_hint() -> String {
-    "run the \"Meridian Daemon\" task in Task Scheduler, or restart Meridian".to_string()
-}
+// Windows shares the generic "restart Meridian" hint below rather than
+// naming the "Meridian Daemon" Task Scheduler entry: `register_service`
+// falls back to a Startup-folder launcher (no Task Scheduler entry at all)
+// on machines where policy blocks `schtasks /Create`, so pointing at Task
+// Scheduler wouldn't always apply.
 
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[cfg(not(target_os = "macos"))]
 fn start_daemon_hint() -> String {
     "restart Meridian".to_string()
 }

--- a/tray/src-tauri/src/commands/health.rs
+++ b/tray/src-tauri/src/commands/health.rs
@@ -84,13 +84,32 @@ async fn check_database() -> (bool, Option<String>) {
         Ok(_) => (true, None),
         Err(_) => (
             false,
-            Some(
-                "Database not found — start the daemon: \
-                 launchctl load ~/Library/LaunchAgents/com.meridiona.daemon.plist"
-                    .to_string(),
-            ),
+            Some(format!(
+                "Database not found — start the daemon: {}",
+                start_daemon_hint()
+            )),
         ),
     }
+}
+
+/// Platform-specific instructions for manually (re-)starting the daemon —
+/// used only in the health banner's "database not found" message, so a user
+/// stuck on a broken autostart has something concrete to try. Must stay in
+/// sync with how each platform's `backend_install::register_service` starts
+/// the daemon at login.
+#[cfg(target_os = "macos")]
+fn start_daemon_hint() -> String {
+    "launchctl load ~/Library/LaunchAgents/com.meridiona.daemon.plist".to_string()
+}
+
+#[cfg(target_os = "windows")]
+fn start_daemon_hint() -> String {
+    "run the \"Meridian Daemon\" task in Task Scheduler, or restart Meridian".to_string()
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn start_daemon_hint() -> String {
+    "restart Meridian".to_string()
 }
 
 /// Walk the last 200 lines of `~/.meridian/logs/a11y-helper.log` for a trust

--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -213,7 +213,7 @@ pub struct IntegrationsResponse {
 }
 
 fn home() -> Option<PathBuf> {
-    std::env::var("HOME").ok().map(PathBuf::from)
+    meridian_core::paths::home_dir()
 }
 
 /// Parse a `.env` file using dotenvy so edge cases (export prefix, quoted

--- a/tray/src-tauri/src/commands/whats_new.rs
+++ b/tray/src-tauri/src/commands/whats_new.rs
@@ -116,11 +116,11 @@ pub fn mark_whats_new_seen(home: &Path, current_version: &str) -> std::io::Resul
 #[tauri::command]
 #[tracing::instrument(skip(app))]
 pub fn mark_whats_new_seen_cmd(app: tauri::AppHandle) {
-    let Ok(home) = std::env::var("HOME") else {
+    let Some(home) = meridian_core::paths::home_dir() else {
         return;
     };
     let current = app.package_info().version.to_string();
-    if let Err(e) = mark_whats_new_seen(Path::new(&home), &current) {
+    if let Err(e) = mark_whats_new_seen(&home, &current) {
         tracing::warn!(error = %e, "whats-new: failed to write last_seen_version");
     }
 }

--- a/tray/src-tauri/src/install.rs
+++ b/tray/src-tauri/src/install.rs
@@ -71,7 +71,7 @@ pub(crate) fn detect_install_mode() -> InstallMode {
     }
     #[cfg(not(debug_assertions))]
     {
-        let home = std::env::var("HOME").ok().map(std::path::PathBuf::from);
+        let home = meridian_core::paths::home_dir();
         if let Some(p) = home.as_ref().map(|h| h.join(".meridian/.env")) {
             if p.exists() {
                 return InstallMode::Canonical(p);
@@ -111,9 +111,7 @@ pub(crate) fn canonical_env_path() -> Option<std::path::PathBuf> {
     }
     #[cfg(not(debug_assertions))]
     {
-        std::env::var("HOME")
-            .ok()
-            .map(|h| std::path::PathBuf::from(h).join(".meridian/.env"))
+        meridian_core::paths::home_dir().map(|h| h.join(".meridian/.env"))
     }
 }
 
@@ -206,12 +204,12 @@ pub(crate) fn meridian_bin() -> String {
     }
     #[cfg(not(debug_assertions))]
     {
-        if let Ok(home) = std::env::var("HOME") {
+        if let Some(home) = meridian_core::paths::home_dir() {
             // `~/.meridian/bin/meridian` is the DMG path (staged by `backend_install`) —
             // native, no runtime deps, so it works under launchd's minimal PATH; the
             // `~/.local/bin` node wrapper is the last resort.
-            for rel in ["/.meridian/bin/meridian", "/.local/bin/meridian"] {
-                let p = std::path::PathBuf::from(format!("{home}{rel}"));
+            for rel in [".meridian/bin/meridian", ".local/bin/meridian"] {
+                let p = home.join(rel);
                 if p.exists() {
                     return p.to_string_lossy().into_owned();
                 }
@@ -241,9 +239,10 @@ pub(crate) fn cli_cwd() -> Result<std::path::PathBuf, String> {
     }
     #[cfg(not(debug_assertions))]
     {
-        let home = std::env::var("HOME")
-            .map_err(|_| "HOME env var not set - cannot locate ~/.meridian".to_string())?;
-        let cwd = std::path::PathBuf::from(&home).join(".meridian");
+        let home = meridian_core::paths::home_dir().ok_or_else(|| {
+            "home directory could not be resolved - cannot locate ~/.meridian".to_string()
+        })?;
+        let cwd = home.join(".meridian");
         if !cwd.exists() {
             std::fs::create_dir_all(&cwd)
                 .map_err(|e| format!("could not create ~/.meridian: {e}"))?;
@@ -299,8 +298,8 @@ pub(crate) fn meridian_db_path() -> String {
             return p;
         }
     }
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    let p = format!("{}/.meridian/meridian.db", home);
+    let home = meridian_core::paths::home_dir_or_cwd();
+    let p = format!("{}/.meridian/meridian.db", home.display());
     tracing::info!(source = ?mode, path = %p, "meridian_db resolved (default)");
     p
 }

--- a/tray/src-tauri/src/install.rs
+++ b/tray/src-tauri/src/install.rs
@@ -299,7 +299,11 @@ pub(crate) fn meridian_db_path() -> String {
         }
     }
     let home = meridian_core::paths::home_dir_or_cwd();
-    let p = format!("{}/.meridian/meridian.db", home.display());
+    let p = home
+        .join(".meridian")
+        .join("meridian.db")
+        .display()
+        .to_string();
     tracing::info!(source = ?mode, path = %p, "meridian_db resolved (default)");
     p
 }

--- a/tray/src-tauri/src/poll/plan_auto_open.rs
+++ b/tray/src-tauri/src/poll/plan_auto_open.rs
@@ -41,11 +41,10 @@ use std::path::Path;
 /// docs for the gate order and rationale.
 #[tracing::instrument(skip(app, pool))]
 pub(crate) async fn maybe_auto_open_plan(app: &tauri::AppHandle, pool: &meridian_core::SqlitePool) {
-    let home = std::env::var("HOME").unwrap_or_default();
-    if home.is_empty() {
+    let Some(home) = meridian_core::paths::home_dir() else {
         return;
-    }
-    let meridian_dir = Path::new(&home).join(".meridian");
+    };
+    let meridian_dir = home.join(".meridian");
     let now = chrono::Local::now();
     let today = now.format("%Y-%m-%d").to_string();
 

--- a/tray/src-tauri/src/poll/whats_new_auto_open.rs
+++ b/tray/src-tauri/src/poll/whats_new_auto_open.rs
@@ -34,18 +34,16 @@
 //!   What's New modal.
 
 use crate::commands::whats_new;
-use std::path::Path;
 use tauri::Manager;
 
 /// Once per app version, open the dashboard on the What's New modal. See the
 /// module docs for the gate order and rationale.
 #[tracing::instrument(skip(app))]
 pub(crate) async fn maybe_auto_open_whats_new(app: &tauri::AppHandle) {
-    let home = std::env::var("HOME").unwrap_or_default();
-    if home.is_empty() {
+    let Some(home) = meridian_core::paths::home_dir() else {
         return;
-    }
-    let home = Path::new(&home);
+    };
+    let home = home.as_path();
     let current_version = app.package_info().version.to_string();
 
     // 1. Already seen this version — the common case on every tick after the

--- a/ui/app/setup/signin.tsx
+++ b/ui/app/setup/signin.tsx
@@ -49,16 +49,15 @@ export function SignInWidget({ onSignedIn }: { onSignedIn: (email: string) => vo
 }
 
 /** Settings → Account's sign-in/sign-out control (see AccountSection.tsx) —
- *  same Clerk session as the setup wizard, but this one shows who's signed
- *  in and lets them sign out, since that's the whole reason to visit it.
- *  `knownEmail` is the Rust-persisted email — passed straight through so the
- *  identity row can render before Clerk's own session check resolves. */
-export function AccountAuthControl({ onSignedIn, onSignedOut, knownEmail }: {
+ *  same live Clerk session as the rest of the dashboard (RequireSignIn
+ *  already established it; see AccountAuthControl.tsx's module doc for why
+ *  this must NOT mount a second ClerkProvider), shows who's signed in and
+ *  lets them sign out. */
+export function AccountAuthControl({ onSignedIn, onSignedOut }: {
   onSignedIn: (email: string) => void
   onSignedOut: () => void
-  knownEmail?: string | null
 }) {
-  return <AccountAuthControlImpl onSignedIn={onSignedIn} onSignedOut={onSignedOut} knownEmail={knownEmail} />
+  return <AccountAuthControlImpl onSignedIn={onSignedIn} onSignedOut={onSignedOut} />
 }
 
 /** Product-wide sign-in gate for the dashboard window — renders `children`

--- a/ui/app/setup/signin/AccountAuthControl.tsx
+++ b/ui/app/setup/signin/AccountAuthControl.tsx
@@ -4,28 +4,25 @@
 // Settings → Account's sign-in/sign-out control — see `../signin.tsx` for
 // why this module (and everything it imports) is only ever loaded through a
 // `next/dynamic(..., { ssr: false })` boundary, never imported directly.
+//
+// Unlike SignInWidget and RequireSignIn, this does NOT wrap itself in a
+// ClerkGate: Settings is only ever reachable from inside the dashboard,
+// which RequireSignIn (app/page.tsx) already wraps in one ClerkProvider.
+// A second <ClerkProvider> here would nest inside that one, and
+// @clerk/react hard-refuses that ("You've added multiple <ClerkProvider>
+// components") — the exact crash this used to throw, caught by
+// ClerkErrorBoundary and shown as a generic "not configured" message that
+// had nothing to do with configuration. useClerk()/useSignedInEmail() below
+// read from RequireSignIn's already-live provider instead.
 
 import { useState } from 'react'
 import { useClerk } from '@clerk/react'
 import { Btn, Spinner } from '../atoms'
 import { useSignedInEmail } from './useSignedInEmail'
-import { ClerkGate } from './ClerkGate'
 import { GateLoading, AccountIdentityRow } from './identity'
 import { EmailCodeForm } from './EmailCodeForm'
 
 const SIGNED_IN_CAPTION = 'Signed in with a one-time email code'
-
-/** Optimistic render for the moment between mount and Clerk finishing its
- *  own (async) session check — used as `ClerkGate`'s Suspense fallback when
- *  the Rust-persisted email (`get_account_email`) is already known, so
- *  Settings → Account shows the identity immediately instead of a bare
- *  spinner on every open, matching how account pages elsewhere avoid a
- *  needless loading flash for state they already have cached. Sign out isn't
- *  wired yet at this point (no live Clerk instance) — a static spinner in
- *  its place, swapped for the real button the moment Clerk resolves. */
-function KnownAccountFallback({ email }: { email: string }) {
-  return <AccountIdentityRow email={email} caption={SIGNED_IN_CAPTION} action={<Spinner size={13} width={1.8} />} />
-}
 
 /** An identity row (avatar, email, how they signed in) with a Sign out
  *  action, or the sign-in form if not signed in yet — the standard "who am I
@@ -88,19 +85,13 @@ function AccountStatus({ onSignedIn, onSignedOut }: {
   )
 }
 
-/** Settings → Account's sign-in/sign-out control. `knownEmail` (the
- *  Rust-persisted email, passed by `AccountSection`) renders instantly while
- *  Clerk's own async session check is still in flight — see
- *  `KnownAccountFallback`. */
-export function AccountAuthControl({ onSignedIn, onSignedOut, knownEmail }: {
+/** Settings → Account's sign-in/sign-out control. Renders straight into the
+ *  dashboard's existing Clerk session (see the module doc above) — Clerk is
+ *  already loaded by the time Settings is reachable, so `AccountStatus`'s
+ *  own `!isLoaded` check is the only loading state this needs. */
+export function AccountAuthControl({ onSignedIn, onSignedOut }: {
   onSignedIn: (email: string) => void
   onSignedOut: () => void
-  knownEmail?: string | null
 }) {
-  const fallback = knownEmail ? <KnownAccountFallback email={knownEmail} /> : <GateLoading />
-  return (
-    <ClerkGate notInTauriMessage="Open Meridian to manage sign-in." fallback={fallback}>
-      {() => <AccountStatus onSignedIn={onSignedIn} onSignedOut={onSignedOut} />}
-    </ClerkGate>
-  )
+  return <AccountStatus onSignedIn={onSignedIn} onSignedOut={onSignedOut} />
 }

--- a/ui/components/HealthBanner.tsx
+++ b/ui/components/HealthBanner.tsx
@@ -34,7 +34,7 @@ export default function HealthBanner() {
     const isNotFound = health.error?.toLowerCase().includes('not found') ?? false
     const bannerTitle = isNotFound ? 'Database not found' : 'Database schema mismatch'
     const defaultDetail = isNotFound
-      ? <>Start the daemon: <code className="text-xs font-mono">launchctl load ~/Library/LaunchAgents/com.meridiona.daemon.plist</code></>
+      ? 'Restart Meridian to start the daemon.'
       : <>The database needs migration: <code className="text-xs font-mono">meridian migrate-db</code></>
     return (
       <div
@@ -51,7 +51,7 @@ export default function HealthBanner() {
               <strong>{bannerTitle}</strong>
             </p>
             <p className="text-xs mt-0.5" style={{ color: 'var(--ink-3)' }}>
-              {isNotFound ? defaultDetail : (health.error ?? defaultDetail)}
+              {health.error ?? defaultDetail}
             </p>
           </div>
         </div>

--- a/ui/components/timeline/settings/AccountSection.tsx
+++ b/ui/components/timeline/settings/AccountSection.tsx
@@ -21,11 +21,9 @@ const CHANNEL_COLOR: Record<AppInfo['channel'], string> = {
 
 export function AccountSection() {
   const [appInfo, setAppInfo] = useState<AppInfo | null>(null)
-  const [signedInEmail, setSignedInEmail] = useState<string | null>(null)
 
   useEffect(() => {
     load<AppInfo>('/api/app-info', 'get_app_info').then(setAppInfo).catch(() => {})
-    invoke<string | null>('get_account_email').then(setSignedInEmail).catch(() => {})
   }, [])
 
   return (
@@ -41,13 +39,10 @@ export function AccountSection() {
       <SectionCard>
         <SectionHeader>Account</SectionHeader>
         <AccountAuthControl
-          knownEmail={signedInEmail}
           onSignedIn={(email) => {
-            setSignedInEmail(email)
             invoke('save_account_email', { email }).catch(() => {})
           }}
           onSignedOut={() => {
-            setSignedInEmail(null)
             invoke('clear_account_email').catch(() => {})
           }}
         />


### PR DESCRIPTION
## Summary

Three bugs found live-testing the just-shipped `v1.75.0-staging.2` build, two Windows-specific and one platform-agnostic (reproduced live on this dev machine too, running the real staging binary).

### 1. Raw `HOME` reads across `tray/src-tauri`

`HOME` is never set on Windows. `backend_install.rs` already had this fixed earlier in the cycle (`meridian_core::paths::home_dir()`, which falls back to `dirs::home_dir()` -- the correct `%USERPROFILE%`-based resolution), but that migration missed a dozen other call sites still doing `std::env::var("HOME")` directly:

- `install.rs`: `detect_install_mode()`, `canonical_env_path()`, `meridian_db_path()`'s default fallback, and the CLI bin/cwd resolvers (`meridian_bin()`, `cli_cwd()`)
- `commands/account.rs`: `account_path()` -- the signed-in-email persistence
- `commands/integrations.rs`: `home()` -- tracker credential resolution
- `commands/dashboard.rs`, `commands/whats_new.rs`, `commands/diagnostics.rs`
- `analytics.rs`, `poll/whats_new_auto_open.rs`, `poll/plan_auto_open.rs`

On Windows every one of these silently fell through to its no-op/Bare/default path instead of erroring loudly. This is what explains **"Database not found"** on the health banner -- `meridian_db_path()`'s HOME-dependent fallback never resolved a usable path.

Call sites already `#[cfg(target_os = "macos")]`-gated or marked `dead_code` off macOS (`lib.rs`'s Dock-reopen handler, both `app_icons.rs` occurrences) were left untouched -- they're correctly scoped already.

Side note found while chasing this: `detect_install_mode()`'s release-path fallback also walks up to 8 parent directories from the process's cwd looking for a bare `.env` -- on a machine that also has a dev checkout, launching the *packaged* binary from (or near) that checkout directory silently borrows the checkout's dev credentials (dev Clerk key, etc.) instead of the compiled-in production ones. Not fixed here (it's an edge case that doesn't affect real end-user machines, which have no dev checkout), but flagged since it caused a confusing dead-end during this investigation.

### 2. OAuth browser launch truncates the authorize URL on Windows

`meridian-oauth`'s `open_browser()` spawned:

```rust
Command::new("cmd").args(["/C", "start", "", url]).spawn()
```

`Command`'s automatic Windows argument quoting only wraps an argument in `"..."` when it contains a space, tab, or `"`. An OAuth authorize URL has none of those -- only `&`-joined query params -- so it went out **unquoted**. `cmd.exe` then parsed the command line itself and treated every unescaped `&` as a command separator: only the query string up to the *first* `&` (`response_type=code`) ever reached the browser. `client_id`, `redirect_uri`, `scope`, `state`, `code_challenge` -- everything after -- were silently dropped as bogus follow-on "commands".

This is exactly Atlassian's *"We're having trouble logging you in -- the authorize request was incomplete or invalid"* error on Jira sign-in. Fixed by building the raw `cmd /C start "" "<url>"` line with `CommandExt::raw_arg`, so the URL is genuinely quoted and `&` is protected from cmd.exe's tokenizer. The URL can never contain a literal `"` (`encode()` percent-encodes everything outside the unreserved set), so the quoting is always safe.

(GitHub's reported "stuck rotating" Authorize page uses a device-code flow that doesn't go through this function at all, so it's very likely unrelated/a separate GitHub-side issue -- flagged in the original PR description as a guess, now walked back since it doesn't hold up on closer reading of `github.rs`.)

### 3. Duplicate `<ClerkProvider>` in Settings -> Account -- the actual Clerk bug

This is **not Windows-specific** and not a build-config issue at all, despite `ClerkErrorBoundary`'s generic "Sign-in isn't configured for this build" message strongly suggesting one. Root-caused by attaching WebView2's remote debugging (`WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS=--remote-debugging-port=9222`) to the actual running `v1.75.0-staging.2` binary and driving it via the Chrome DevTools Protocol. The real thrown error:

```
@clerk/react: You've added multiple <ClerkProvider> components in your React
component tree. Wrap your components in a single <ClerkProvider>.
```

`RequireSignIn` (`app/page.tsx`) wraps the *entire dashboard* -- including Settings -- in one `ClerkGate`/`<ClerkProvider>`, established the moment the dashboard is reachable at all (sign-in is compulsory app-wide). `AccountAuthControl` (Settings -> Account) independently wrapped itself in *another* `ClerkGate`/`<ClerkProvider>`, nested inside the first. `@clerk/react` hard-refuses that combination, `initClerk()`'s promise rejects, and `ClerkErrorBoundary` papered over what was actually a component-tree bug with a message about missing configuration. The setup wizard's `SignInWidget` was unaffected because it runs in a separate, non-`RequireSignIn`-gated window/context -- its `ClerkGate` is the only provider in that tree, which is why sign-in "worked" there and only broke once you opened Settings afterward.

Fixed by having `AccountAuthControl` render directly against the dashboard's already-live session (`useClerk()`/`useUser()` via `useSignedInEmail()`) instead of mounting a redundant provider. The `knownEmail`/`KnownAccountFallback` optimistic-render plumbing existed only to paper over that redundant provider's own async re-init roundtrip, so it's removed along with it -- `AccountStatus`'s existing `!isLoaded` check already covers the (now near-instant, already-warm) loading state. `AccountSection`'s now-unused `signedInEmail` local state and its `get_account_email` prefetch go for the same reason; the `save_account_email`/`clear_account_email` side-effect calls stay (analytics still needs them for the `$set` email upgrade).

### 4. Health banner hardcoded macOS instructions

`commands/health.rs`'s "database not found" message and its `ui/components/HealthBanner.tsx` consumer both hardcoded `launchctl load ~/Library/LaunchAgents/com.meridiona.daemon.plist` regardless of platform. Made the message platform-aware on the Rust side (`start_daemon_hint()`, cfg'd per OS) and had the frontend actually use the backend's message instead of unconditionally overriding it with the macOS default for the "not found" case.

## Verification

- `cargo check --workspace` (root) and `cargo check` (tray/src-tauri, separate workspace): clean.
- `cargo fmt --check`: clean in both workspaces.
- `cargo test -p meridian-oauth`: all 20 tests pass.
- `npx tsc --noEmit` (ui/): no errors in any changed file (pre-existing, unrelated `bun:test` type-decl errors in `__tests__/` are environment noise on this machine, not caused by this change).
- The `ClerkProvider` fix (#3) was reproduced AND verified fixed live, against the actual running staging binary, via WebView2 remote debugging + CDP -- not just inferred from reading code.
- The `HOME` (#1) and OAuth URL (#2) fixes are not yet re-verified against a live Windows 10 install with a fresh build.

## Test plan

- [ ] Cut a new staging build from `pre-main` including this fix.
- [ ] Fresh-install on the Windows 10 machine that surfaced these bugs; confirm the daemon starts and the DB is found without manual intervention.
- [x] Confirm Settings -> Account shows the signed-in state (no Clerk "not configured" error) after visiting the dashboard post-wizard -- verified live on this dev machine against the real staging binary before/after the fix.
- [ ] Retry Jira OAuth sign-in end-to-end; confirm it completes without Atlassian's "incomplete or invalid" error.
- [ ] Retry GitHub OAuth; confirm whether Authorize still hangs (now believed unrelated to this PR's fixes -- needs separate investigation if it persists).
