### PR TITLE
fix: address CodeRabbit review findings on PR #539

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -93,6 +93,7 @@ the branch dropdown set to `pre-main`) — it is no longer cut automatically on
 every merge to `pre-main`.
 
 ### 4. Monitor Build Status
+
 ```bash
 gh run list --workflow=release-prepare.yml --limit=5
 gh run list --workflow=release-build.yml --limit=5

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -566,6 +566,7 @@ jobs:
     name: Windows x86_64
     needs: prepare
     runs-on: windows-latest
+    timeout-minutes: 60 # same cap as macos — bound a hung build instead of falling back to GitHub's 360-minute default
     permissions:
       contents: write # uploads assets into the draft
     env:
@@ -658,8 +659,13 @@ jobs:
         # config is explicitly NULLED OUT by tauri.windows.conf.json, replaced
         # with `target/release/meridian.exe`, which `cargo build --bin meridian`
         # already produces at exactly that path with no cross-target copy step.
+        env:
+          # Bound through env rather than interpolated into `run:`, same
+          # reason as VERSION/CHANNEL/TAG elsewhere in this file — `${{ }}`
+          # inside `run:` is the template-injection shape.
+          CHANNEL: ${{ needs.prepare.outputs.channel }}
         run: |
-          if [ "${{ needs.prepare.outputs.channel }}" = "staging" ]; then
+          if [ "${CHANNEL}" = "staging" ]; then
             npm run build:windows:staging
           else
             npm run build:windows

--- a/meridian-oauth/src/flow.rs
+++ b/meridian-oauth/src/flow.rs
@@ -355,20 +355,20 @@ else{document.querySelector('h2').textContent='No token in URL. Try again.';}\
 /// is always logged too, so a failed/headless launch still leaves the user a
 /// way to continue by pasting it manually.
 ///
-/// `start` on Windows is a cmd.exe builtin, not a standalone executable, so it
-/// has to be invoked through the shell rather than spawned directly. Its first
-/// argument is a window-title slot, not part of the command — the empty `""`
-/// there is required, otherwise `start` misreads a quoted URL as the title and
-/// never opens it.
+/// Windows launches via `explorer.exe`, not `cmd /C start`: the authorize URLs
+/// passed here always carry `&`-separated query params (client_id, redirect_uri,
+/// state, scope), and `cmd.exe` re-parses its whole command line for shell
+/// metacharacters like `&` regardless of Win32 argv quoting — it would split the
+/// URL at the first `&` and try to run the tail as a second command, truncating
+/// the authorize URL. `explorer.exe` takes the URL as a literal argument handed
+/// straight to the registered protocol handler, with no shell re-parsing.
 fn open_browser(url: &str) {
     tracing::info!(
         url,
         "if it doesn't open automatically, open this URL yourself"
     );
     #[cfg(target_os = "windows")]
-    let result = std::process::Command::new("cmd")
-        .args(["/C", "start", "", url])
-        .spawn();
+    let result = std::process::Command::new("explorer").arg(url).spawn();
     #[cfg(target_os = "macos")]
     let result = std::process::Command::new("open").arg(url).spawn();
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -29,13 +29,15 @@ import json, re, sys
 ver = sys.argv[1]
 
 # Cargo.toml: the single top-level `version = "..."` line ([package]).
+# Count matches BEFORE substituting — re.subn(count=1) only ever returns 0 or
+# 1, so checking its own `n` can never catch "more than one match".
+cargo_version_re = re.compile(r'(?m)^version = "[^"]*"')
 with open("Cargo.toml") as fh:
     cargo_toml = fh.read()
-cargo_toml, n = re.subn(
-    r'(?m)^version = "[^"]*"', f'version = "{ver}"', cargo_toml, count=1
-)
+n = len(cargo_version_re.findall(cargo_toml))
 if n != 1:
-    sys.exit(f"set-version: expected exactly one top-level version in Cargo.toml, patched {n}")
+    sys.exit(f"set-version: expected exactly one top-level version in Cargo.toml, found {n}")
+cargo_toml = cargo_version_re.sub(f'version = "{ver}"', cargo_toml, count=1)
 with open("Cargo.toml", "w") as fh:
     fh.write(cargo_toml)
 
@@ -62,16 +64,15 @@ for path in targets:
 # `cargo build --locked` would fail the release). "meridian" is a workspace path
 # crate, so only its own version line changes — the dependency graph is untouched,
 # leaving rust-cache's restore behaviour the same as the Cargo.toml bump already is.
+lock_meridian_re = re.compile(
+    r'(?ms)^(\[\[package\]\]\nname = "meridian"\nversion = ")[^"]*(")'
+)
 with open("Cargo.lock") as fh:
     lock = fh.read()
-lock, n = re.subn(
-    r'(?ms)^(\[\[package\]\]\nname = "meridian"\nversion = ")[^"]*(")',
-    lambda m: m.group(1) + ver + m.group(2),
-    lock,
-    count=1,
-)
+n = len(lock_meridian_re.findall(lock))
 if n != 1:
-    sys.exit(f"set-version: expected exactly one [[package]] meridian in Cargo.lock, patched {n}")
+    sys.exit(f"set-version: expected exactly one [[package]] meridian in Cargo.lock, found {n}")
+lock = lock_meridian_re.sub(lambda m: m.group(1) + ver + m.group(2), lock, count=1)
 with open("Cargo.lock", "w") as fh:
     fh.write(lock)
 print(f"set version {ver} across all manifests + Cargo.lock")

--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -88,32 +88,6 @@ pub(crate) struct Capture {
     pub stderr: String,
 }
 
-/// `claude`, `codex`, etc. install as npm-shimmed `.cmd`/`.bat` files on Windows, not PE
-/// executables — `CreateProcess` (what `Command::spawn` calls) refuses to run one directly
-/// and fails with "os error 193, %1 is not a valid Win32 application", even though the exact
-/// same path runs fine typed into a terminal (the shell recognises the extension and
-/// re-invokes it through `cmd.exe` itself; `CreateProcess` doesn't). Route those through
-/// `cmd.exe /C` explicitly. Anything else — a real `.exe`, or any non-Windows target —
-/// returns `None` and spawns directly, unchanged.
-#[cfg(windows)]
-fn windows_shell_wrapper(target: &Path) -> Option<Command> {
-    let is_script = target
-        .extension()
-        .and_then(|e| e.to_str())
-        .is_some_and(|e| e.eq_ignore_ascii_case("cmd") || e.eq_ignore_ascii_case("bat"));
-    if !is_script {
-        return None;
-    }
-    let mut cmd = Command::new("cmd");
-    cmd.arg("/C").arg(target);
-    Some(cmd)
-}
-
-#[cfg(not(windows))]
-fn windows_shell_wrapper(_target: &Path) -> Option<Command> {
-    None
-}
-
 /// Spawn `program args`, feed `stdin_text`, capture stdout/stderr with a hard
 /// timeout. `kill_on_drop` guarantees a timed-out child is reaped (no leak);
 /// stdin is written from a concurrent task so a large prompt can't deadlock the
@@ -136,7 +110,15 @@ pub(crate) async fn run_capture(
     // does have a working `PATH` behaves exactly as before.
     let resolved = crate::llm::detect::resolve_cli(program).await;
     let target = resolved.as_deref().unwrap_or_else(|| Path::new(program));
-    let mut cmd = windows_shell_wrapper(target).unwrap_or_else(|| Command::new(target));
+    // `claude`, `codex`, etc. install as npm-shimmed `.cmd`/`.bat` files on
+    // Windows, not PE executables. Do NOT hand-wrap these in `cmd.exe /C` —
+    // `Command::new(target)` already detects a `.bat`/`.cmd` target and routes
+    // it through `cmd.exe` internally, with cmd.exe-safe argument escaping
+    // (the fix for the "BatBadBut" class of bugs, GHSA-q455-m56c-85mh). A
+    // manual `cmd.arg("/C").arg(target)` wrapper bypasses that safe escaping —
+    // `args` below can carry session-derived prompt text, so a hand-rolled
+    // wrapper reopens exactly the injection std's built-in handling closes.
+    let mut cmd = Command::new(target);
     cmd.args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -707,7 +707,7 @@ fn probe_current_path(bin: &str) -> Option<PathBuf> {
     let names = path_candidate_names(bin);
     std::env::split_paths(&path)
         .flat_map(|dir| names.iter().map(move |name| dir.join(name)))
-        .find(|p| p.is_file())
+        .find(|p| p.is_absolute() && p.is_file())
 }
 
 /// The file name(s) `bin` could actually be on disk. On Windows, `claude`/`codex`/etc.
@@ -719,9 +719,10 @@ fn probe_current_path(bin: &str) -> Option<PathBuf> {
 /// writes THREE files per CLI — `claude` (an extensionless POSIX shebang script, for
 /// WSL/Git-Bash), `claude.cmd`, and `claude.ps1` — all in the same directory. The bare
 /// `claude` file `is_file()` just as truly as `claude.cmd` does, so checking it first
-/// resolves to the POSIX script: no `.cmd`/`.bat` extension, so `windows_shell_wrapper`
-/// doesn't route it through `cmd /C` either, and it gets handed to `CreateProcess` as a
-/// literal shebang text file — `os error 193, %1 is not a valid Win32 application`, on a
+/// resolves to the POSIX script: no `.cmd`/`.bat` extension, so `Command::new`'s own
+/// `.bat`/`.cmd` auto-detection doesn't route it through `cmd.exe` either, and it gets
+/// handed to `CreateProcess` as a literal shebang text file — `os error 193, %1 is not
+/// a valid Win32 application`, on a
 /// machine where `claude` undeniably "works". A real `cmd.exe`/PowerShell prompt never
 /// makes this mistake because PATHEXT resolution always wins over an extensionless match;
 /// the bare name is kept only as a last-resort fallback for a genuinely extensionless

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -251,7 +251,13 @@ async fn register_service(_backend: &Path, home: &Path, daemon_bin: &Path) -> Re
             );
             install_startup_folder_launcher(daemon_bin).await?;
             // Nothing else will start the daemon until next login — start it now.
-            let _ = tokio::process::Command::new(daemon_bin).spawn();
+            if let Err(e) = tokio::process::Command::new(daemon_bin).spawn() {
+                tracing::warn!(
+                    error = %e,
+                    bin = %daemon_bin.display(),
+                    "backend_install: immediate daemon start failed — will still run at next login via Startup folder"
+                );
+            }
             tracing::info!(
                 home = %home.display(),
                 "backend_install: Startup-folder launcher installed"

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -258,6 +258,7 @@ pub fn run() {
                                         (icon_size.width, icon_size.height),
                                         (pop_w, pop_h),
                                         cfg!(target_os = "windows"),
+                                        monitor_work_area(&win),
                                     );
                                     let _ = win.set_position(tauri::Position::Physical(
                                         tauri::PhysicalPosition::new(x, y),
@@ -312,6 +313,7 @@ pub fn run() {
                                     (icon_size.width, icon_size.height),
                                     (tt_w, tt_h),
                                     cfg!(target_os = "windows"),
+                                    monitor_work_area(&tt),
                                 );
                                 let _ = tt.set_position(tauri::Position::Physical(
                                     tauri::PhysicalPosition::new(x, y),
@@ -665,6 +667,11 @@ fn reopen_target(onboarded: bool) -> ReopenTarget {
 /// the bottom of the screen — invisible, not just misplaced. `anchor_above`
 /// picks which side; callers pass `cfg!(target_os = "windows")`.
 ///
+/// `monitor_bounds` is `(left, top, right, bottom)` of the target monitor's
+/// work area (see [`monitor_work_area`]) — clamping against it, not just
+/// zero, is what keeps a right-edge tray icon (common on Windows multi-monitor
+/// setups) from placing the window past the monitor's right or bottom edge.
+///
 /// Pure and platform-independent so it's unit-testable without a live window —
 /// same rationale as [`is_onboarded`] / [`reopen_target`] above.
 fn tray_anchor_position(
@@ -672,24 +679,56 @@ fn tray_anchor_position(
     icon_size: (i32, i32),
     win_size: (i32, i32),
     anchor_above: bool,
+    monitor_bounds: (i32, i32, i32, i32),
 ) -> (i32, i32) {
-    let x = (icon_pos.0 + icon_size.0 / 2 - win_size.0 / 2).max(0);
+    let (mon_left, mon_top, mon_right, mon_bottom) = monitor_bounds;
+    let x = (icon_pos.0 + icon_size.0 / 2 - win_size.0 / 2)
+        .max(mon_left)
+        .min(mon_right - win_size.0);
     let y = if anchor_above {
-        (icon_pos.1 - win_size.1).max(0)
+        icon_pos.1 - win_size.1
     } else {
         icon_pos.1 + icon_size.1
     };
+    let y = y.max(mon_top).min(mon_bottom - win_size.1);
     (x, y)
+}
+
+/// The window's current monitor's work area as `(left, top, right, bottom)` in
+/// physical pixels — the work area excludes the taskbar/menu bar, so clamping
+/// against it can't still place a window behind either.
+///
+/// Falls back to an effectively unbounded rect when Tauri can't resolve a
+/// monitor (headless CI, a monitor unplugged mid-call) so callers degrade to
+/// the old zero-only clamp instead of failing the whole positioning step.
+fn monitor_work_area(window: &tauri::WebviewWindow) -> (i32, i32, i32, i32) {
+    match window.current_monitor() {
+        Ok(Some(monitor)) => {
+            let area = monitor.work_area();
+            (
+                area.position.x,
+                area.position.y,
+                area.position.x + area.size.width as i32,
+                area.position.y + area.size.height as i32,
+            )
+        }
+        _ => (0, 0, i32::MAX, i32::MAX),
+    }
 }
 
 #[cfg(test)]
 mod tray_anchor_position_tests {
     use super::tray_anchor_position;
 
+    const UNBOUNDED: (i32, i32, i32, i32) = (0, 0, i32::MAX, i32::MAX);
+    // A 1920x1080 monitor at the origin, work area only (no taskbar cutout —
+    // irrelevant to these tests since they probe the left/top/right clamps).
+    const SCREEN_1080P: (i32, i32, i32, i32) = (0, 0, 1920, 1080);
+
     #[test]
     fn below_places_top_edge_at_icon_bottom() {
         // macOS-style: icon near the top of the screen, popover grows downward.
-        let (x, y) = tray_anchor_position((1500, 0), (24, 24), (344, 400), false);
+        let (x, y) = tray_anchor_position((1500, 0), (24, 24), (344, 400), false, UNBOUNDED);
         assert_eq!(x, 1500 + 12 - 172); // centred under the icon
         assert_eq!(y, 24); // flush with the icon's bottom edge
     }
@@ -697,14 +736,14 @@ mod tray_anchor_position_tests {
     #[test]
     fn above_places_bottom_edge_at_icon_top() {
         // Windows-style: icon near the bottom of the screen, popover grows upward.
-        let (x, y) = tray_anchor_position((1500, 1040), (24, 24), (344, 400), true);
+        let (x, y) = tray_anchor_position((1500, 1040), (24, 24), (344, 400), true, UNBOUNDED);
         assert_eq!(x, 1500 + 12 - 172); // centred over the icon, same as below
         assert_eq!(y, 1040 - 400); // flush with the icon's top edge
     }
 
     #[test]
     fn x_never_goes_negative_when_icon_is_near_the_left_edge() {
-        let (x, _) = tray_anchor_position((5, 0), (24, 24), (344, 400), false);
+        let (x, _) = tray_anchor_position((5, 0), (24, 24), (344, 400), false, UNBOUNDED);
         assert_eq!(x, 0);
     }
 
@@ -712,8 +751,25 @@ mod tray_anchor_position_tests {
     fn above_never_goes_negative_when_window_is_taller_than_the_icons_offset() {
         // A pathologically tall window anchored above a near-top icon must clamp
         // to 0 rather than requesting a negative y (off the top of the screen).
-        let (_, y) = tray_anchor_position((100, 50), (24, 24), (344, 2000), true);
+        let (_, y) = tray_anchor_position((100, 50), (24, 24), (344, 2000), true, UNBOUNDED);
         assert_eq!(y, 0);
+    }
+
+    #[test]
+    fn x_clamps_to_the_monitors_right_edge() {
+        // A tray icon hard against the right edge of a 1920px-wide monitor —
+        // centring the 344px popover under it would push its right edge past
+        // 1920, common on Windows multi-monitor taskbars.
+        let (x, _) = tray_anchor_position((1900, 1040), (24, 24), (344, 400), true, SCREEN_1080P);
+        assert_eq!(x, 1920 - 344); // flush with the monitor's right edge, not overflowing it
+    }
+
+    #[test]
+    fn y_clamps_to_the_monitors_bottom_edge() {
+        // macOS-style anchor-below near the bottom of a short/rotated monitor:
+        // the popover must not extend past the work area's bottom edge.
+        let (_, y) = tray_anchor_position((100, 700), (24, 24), (344, 400), false, SCREEN_1080P);
+        assert_eq!(y, 1080 - 400);
     }
 }
 

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -28,12 +28,18 @@ export default function SetupWizard() {
 
   // Platform gates which steps exist — Permissions is macOS-only (Windows
   // capture needs no TCC-style grant; see buildSteps in ./steps.tsx). `null`
-  // until resolved is treated as "include it" so the (Welcome-gated) first
-  // paint never has to un-render a step a moment later.
+  // until resolved. The Welcome screen (the only way past `welcome`) blocks
+  // "Get started" until this resolves, so `steps` can never change shape
+  // out from under a `step` index the user already navigated to — a late
+  // resolve reshaping the list AFTER the user has begun would otherwise let
+  // `step` point at the wrong step or past the end of a now-shorter list.
   const [platform, setPlatform] = useState<string | null>(null)
-  useEffect(() => {
-    invoke<string>('get_platform').then(setPlatform).catch(() => {})
+  const [platformError, setPlatformError] = useState(false)
+  const resolvePlatform = useCallback(() => {
+    setPlatformError(false)
+    invoke<string>('get_platform').then(setPlatform).catch(() => setPlatformError(true))
   }, [])
+  useEffect(() => { resolvePlatform() }, [resolvePlatform])
   const steps = useMemo(() => buildSteps(platform), [platform])
 
   // Step 1 — permissions (live)
@@ -240,7 +246,13 @@ export default function SetupWizard() {
         transformOrigin: 'center',
       }}>
         {welcome ? (
-          <Welcome onBegin={() => { setWelcome(false); setStep(0) }} steps={steps} />
+          <Welcome
+            onBegin={() => { setWelcome(false); setStep(0) }}
+            steps={steps}
+            ready={platform !== null}
+            error={platformError}
+            onRetry={resolvePlatform}
+          />
         ) : (
           <div className="flex" style={{ height: '100%' }}>
             <Rail step={step} done={done} wiz={wiz} steps={steps} goStep={goStep} />

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -176,7 +176,15 @@ function IntelligenceBody({ wiz }: { wiz: Wiz }) {
 }
 
 // ── Welcome (pre-step intro) ──────────────────────────────────────────────────
-export function Welcome({ onBegin, steps }: { onBegin: () => void; steps: StepMeta[] }) {
+export function Welcome({ onBegin, steps, ready, error, onRetry }: {
+  onBegin: () => void
+  steps: StepMeta[]
+  /** False until `get_platform` resolves — "Get started" stays disabled so the
+   *  step list (which depends on platform) can't reshape after the user begins. */
+  ready: boolean
+  error: boolean
+  onRetry: () => void
+}) {
   const points = [
     { t: 'On-device', d: 'Your screen is read and understood locally on your device, never uploaded.' },
     { t: 'Automatic', d: 'Builds an accurate timeline of the tickets you worked on, then drafts the updates for you.' },
@@ -207,7 +215,16 @@ export function Welcome({ onBegin, steps }: { onBegin: () => void; steps: StepMe
           </div>
         ))}
       </div>
-      <Btn onClick={onBegin} style={{ padding: '11px 26px', fontSize: 13.5 }}>Get started</Btn>
+      {error ? (
+        <div className="flex flex-col items-center" style={{ gap: 8 }}>
+          <p style={{ fontSize: 12, color: 'var(--color-state-pending)' }}>Couldn't detect your platform - try again.</p>
+          <Btn onClick={onRetry} style={{ padding: '11px 26px', fontSize: 13.5 }}>Retry</Btn>
+        </div>
+      ) : (
+        <Btn onClick={onBegin} disabled={!ready} style={{ padding: '11px 26px', fontSize: 13.5 }}>
+          {ready ? 'Get started' : 'Preparing setup…'}
+        </Btn>
+      )}
       <p className="font-mono" style={{ fontSize: 10.5, letterSpacing: '.04em', color: 'var(--t-faint)', marginTop: 14 }}>{steps.length} quick steps · about a minute</p>
     </div>
   )


### PR DESCRIPTION
## Summary
Addresses all 10 CodeRabbit findings left on PR #539 (the `pre-main` → `main` promotion). Full rationale per-finding is in the commit message; short version:

| Severity | File | Fix |
|---|---|---|
| 🔴 Critical | `src/coding_agent_session_ingest/summariser/mod.rs` | Removed the manual `cmd.exe /C` wrapper for `.cmd`/`.bat` CLI targets — it bypassed the safe argument-escaping `Command::new(target)` already does natively (BatBadBut fix, GHSA-q455-m56c-85mh) on our pinned Rust 1.93.1, reopening injection via session-derived prompt args. |
| 🟠 Major | `meridian-oauth/src/flow.rs` | OAuth authorize URLs always contain `&`; `cmd /C start` re-parses the whole line for shell metacharacters and would truncate the URL. Switched to `explorer.exe` (literal-arg, no shell re-parse). |
| 🟠 Major | `scripts/set-version.sh` | `re.subn(..., count=1)` can only ever return `n=0` or `n=1` — the "more than one match" guard was a no-op. Count with `findall` before substituting, for both the `Cargo.toml` and `Cargo.lock` blocks. |
| 🟠 Major | `tray/src-tauri/src/lib.rs` | `tray_anchor_position` only clamped against `0` — a right-edge tray icon (common on Windows multi-monitor) could place the popover/tooltip past the monitor's right/bottom edge. Added `monitor_work_area()` (Tauri `current_monitor`) and clamp both axes' upper bound too; 2 new tests. |
| 🟠 Major | `ui/app/setup/page.tsx`, `steps.tsx` | Empty `catch` on `get_platform` left the macOS-only permissions step showing forever on Windows if the call failed; a late resolve after the user began could reshape `steps` under an already-chosen `step` index. Welcome now blocks "Get started" until platform resolves, with a retry affordance on failure. |
| 🟡 Minor | `src/llm/detect.rs` | `probe_current_path` now enforces the documented "always absolute" invariant. |
| 🟡 Minor | `tray/src-tauri/src/backend_install.rs` | The immediate post-fallback daemon spawn now logs a structured warning on failure instead of silently discarding it. |
| 🟡 Minor | `.github/workflows/release-build.yml` | Bound `channel` through `env:` instead of `${{ }}` interpolation in the Windows NSIS build step (matches this file's own convention). |
| 🔵 Trivial | `.github/workflows/release-build.yml` | Added `timeout-minutes: 60` to the `windows` job, matching `macos`. |
| 🟡 Minor | `.claude/skills/release/SKILL.md` | markdownlint blank-line fix. |

## Test plan
- [x] `cargo build/clippy/test --release` clean at the repo root
- [x] `cargo clippy/test` clean for the `tray/src-tauri` crate — 142 tests passing, including 6 `tray_anchor_position` tests (2 new, covering right-edge and bottom-edge clamping)
- [x] `npm run build` and `tsc --noEmit` clean for `ui/`
- [x] Full pre-push hook suite (fmt, clippy, ui build/tests, security audit, cargo test) passed on push
- [ ] Windows summariser CLI invocation and OAuth browser-open smoke-tested on real Windows hardware (can't verify from this environment)