### PR TITLE
feat: tasks on integration cards + Windows OAuth & build fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,30 @@
+# Normalize line endings to LF for all text files, on every platform.
+#
+# Without this, a Windows checkout with core.autocrlf=true rewrites every file
+# to CRLF. That breaks source-introspection tests (which string-match against
+# "\n") and any tool that assumes LF — none of which the macOS/Linux CI ever
+# sees, so the failures only surface on Windows. Declaring text=auto eol=lf
+# makes the working tree match the LF blobs Git already stores, so builds and
+# tests behave identically across macOS, Linux, and Windows.
+* text=auto eol=lf
+
+# Explicit binaries — never touch these (belt-and-suspenders over auto-detection).
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.icns  binary
+*.webp  binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.otf   binary
+*.wasm  binary
+*.db    binary
+*.dmg   binary
+*.exe   binary
+*.dll   binary
+*.mp4   binary
+*.zip   binary
+*.gz    binary

--- a/meridian-oauth/src/flow.rs
+++ b/meridian-oauth/src/flow.rs
@@ -355,20 +355,29 @@ else{document.querySelector('h2').textContent='No token in URL. Try again.';}\
 /// is always logged too, so a failed/headless launch still leaves the user a
 /// way to continue by pasting it manually.
 ///
-/// Windows launches via `explorer.exe`, not `cmd /C start`: the authorize URLs
-/// passed here always carry `&`-separated query params (client_id, redirect_uri,
-/// state, scope), and `cmd.exe` re-parses its whole command line for shell
-/// metacharacters like `&` regardless of Win32 argv quoting — it would split the
-/// URL at the first `&` and try to run the tail as a second command, truncating
-/// the authorize URL. `explorer.exe` takes the URL as a literal argument handed
-/// straight to the registered protocol handler, with no shell re-parsing.
+/// Windows launches via `rundll32.exe url.dll,FileProtocolHandler`, not
+/// `cmd /C start` or `explorer.exe`. The authorize URLs passed here always carry
+/// `&`-separated query params (client_id, redirect_uri, state, scope), and
+/// `cmd.exe` re-parses its whole command line for shell metacharacters like `&`
+/// regardless of Win32 argv quoting — it would split the URL at the first `&` and
+/// run the tail as a second command. `explorer.exe` avoids that shell re-parsing
+/// but is unreliable for these long OAuth URLs: when it fails to parse the
+/// argument as a URL it silently falls back to opening a file window (the user's
+/// Documents folder) instead of the browser. `rundll32.exe
+/// url.dll,FileProtocolHandler` hands the URL straight to the registered protocol
+/// handler (ShellExecute "open") as a single literal argv argument — no shell
+/// re-parsing — and reliably opens the default browser with the full query string
+/// intact.
 fn open_browser(url: &str) {
     tracing::info!(
         url,
         "if it doesn't open automatically, open this URL yourself"
     );
     #[cfg(target_os = "windows")]
-    let result = std::process::Command::new("explorer").arg(url).spawn();
+    let result = std::process::Command::new("rundll32")
+        .arg("url.dll,FileProtocolHandler")
+        .arg(url)
+        .spawn();
     #[cfg(target_os = "macos")]
     let result = std::process::Command::new("open").arg(url).spawn();
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]

--- a/src/health/platform.rs
+++ b/src/health/platform.rs
@@ -36,7 +36,7 @@ fn is_exec(p: &Path) -> bool {
         p.is_file()
             && p.extension().and_then(|e| e.to_str()).is_some_and(|ext| {
                 let dotted = format!(".{}", ext.to_ascii_uppercase());
-                pathext().iter().any(|e| *e == dotted)
+                pathext().contains(&dotted)
             })
     }
 }

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -15,11 +15,11 @@
 //                      `save_integration_token`.
 
 import { useEffect, useState, type ReactNode } from 'react'
-import { mutate, openExternal } from '@/lib/bridge'
-import type { IntegrationsResponse } from '@/lib/api-types'
+import { load, mutate, openExternal } from '@/lib/bridge'
+import type { IntegrationsResponse, TaskSummary, TasksResponse } from '@/lib/api-types'
 import { TRACKERS } from '@/lib/integrations'
 import type { Tracker, TokenField } from '@/lib/integrations'
-import { ProviderGlyph } from '@/components/atoms'
+import { ProviderGlyph, fmtDur } from '@/components/atoms'
 import {
   useConnectStore, clearProviderNotice,
   oauthStore, startOAuth, cancelOAuth, setOAuthApiKey, resetOAuthIfSettled,
@@ -114,6 +114,7 @@ function ConnectedPanel({
 }) {
   const [reauthorizing, setReauthorizing] = useState(false)
   const [pickingProjects, setPickingProjects] = useState(false)
+  const [showTasks, setShowTasks] = useState(false)
   const cleanError = syncError ? syncError.replace(/^permission_error: |^sync_error: /, '') : null
   // GitHub's token alone doesn't sync anything — a Projects v2 board must be
   // selected too (discover_github_projects → save_integration_token). This is
@@ -158,7 +159,8 @@ function ConnectedPanel({
         </div>
       ) : (
         <>
-          <p className="text-[12px] leading-relaxed mb-3" style={{ color: 'var(--t-faint)' }}>
+          <ProviderTasks tracker={tracker} expanded={showTasks} onToggle={() => setShowTasks((s) => !s)} onSynced={onChanged} />
+          <p className="text-[12px] leading-relaxed mb-3 mt-4" style={{ color: 'var(--t-faint)' }}>
             Disconnect removes the stored credentials. The daemon reloads automatically.
           </p>
           <button onClick={onDisconnect} disabled={disconnecting} className="text-[12px] px-3 py-1.5 rounded-md transition-opacity"
@@ -166,6 +168,106 @@ function ConnectedPanel({
             {disconnecting ? 'Disconnecting…' : `Disconnect ${tracker.name}`}
           </button>
         </>
+      )}
+    </div>
+  )
+}
+
+// ── View tasks + sync (per connected tracker) ────────────────────────────────
+// The "Task list" surface, folded into the tracker card. "View tasks" loads the
+// board via `get_tasks` and filters to THIS provider (TaskSummary.provider ===
+// tracker.id); "Sync now" runs `sync_tasks` (= `meridian tasks-sync`, all
+// providers — there is no per-provider sync command) then reloads the list and
+// the parent integrations state. Both tray commands already back the old
+// TasksPanel, so this reuses the exact data path.
+function ProviderTasks({ tracker, expanded, onToggle, onSynced }: {
+  tracker: Tracker; expanded: boolean; onToggle: () => void; onSynced?: () => void
+}) {
+  const [tasks, setTasks] = useState<TaskSummary[] | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [syncing, setSyncing] = useState(false)
+  const [syncError, setSyncError] = useState<string | null>(null)
+
+  const fetchTasks = () => {
+    setLoadError(null)
+    load<TasksResponse>('/api/tasks', 'get_tasks')
+      .then((d) => setTasks(d.tasks.filter((t) => t.provider === tracker.id)))
+      .catch((e) => setLoadError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Could not load tasks'))
+  }
+
+  // Load lazily — only once the user opens the list, and only the first time.
+  useEffect(() => { if (expanded && tasks === null && loadError === null) fetchTasks() /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [expanded])
+
+  const handleSync = () => {
+    if (syncing) return
+    setSyncing(true); setSyncError(null)
+    mutate('/api/tasks/sync', 'sync_tasks', {})
+      .then(() => { fetchTasks(); onSynced?.() })
+      .catch((e) => setSyncError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Sync failed'))
+      .finally(() => setSyncing(false))
+  }
+
+  // Active (on-board) tasks first, then by time-touched-today — mirrors the board.
+  const sorted = tasks ? [...tasks].sort((a, b) => Number(b.on_board) - Number(a.on_board) || b.today_s - a.today_s) : null
+  const activeCount = tasks?.filter((t) => t.on_board).length ?? 0
+
+  return (
+    <div className="mb-1">
+      <div className="flex items-center gap-2">
+        <button onClick={onToggle}
+          className="text-[12px] px-3 py-1.5 rounded-md inline-flex items-center gap-1.5"
+          style={{ background: 'var(--t-ctrl, var(--t-card))', border: '1px solid var(--t-ctrl-border, var(--t-hair))', color: 'var(--t-muted)', cursor: 'pointer' }}>
+          <span className="inline-block transition-transform" style={{ transform: expanded ? 'rotate(90deg)' : 'none', color: 'var(--t-faint-2)' }}>›</span>
+          {expanded ? 'Hide tasks' : 'View tasks'}
+          {expanded && tasks !== null && (
+            <span className="text-[11px]" style={{ color: 'var(--t-faint-2)' }}>({activeCount})</span>
+          )}
+        </button>
+        <button onClick={handleSync} disabled={syncing}
+          className="text-[12px] px-3 py-1.5 rounded-md inline-flex items-center gap-1.5"
+          style={{ background: 'var(--color-state-proposal)', color: '#fff', border: 'none', opacity: syncing ? 0.6 : 1, cursor: syncing ? 'not-allowed' : 'pointer' }}
+          title="Pull the latest tasks from your trackers">
+          <span style={{ display: 'inline-block', animation: syncing ? 'spin 1s linear infinite' : 'none' }}>↻</span>
+          {syncing ? 'Syncing…' : 'Sync now'}
+        </button>
+      </div>
+
+      {syncError && <p className="text-[11px] mt-2" style={{ color: 'var(--status-error-dot)' }}>{syncError}</p>}
+
+      {expanded && (
+        <div className="mt-3 rounded-lg overflow-hidden" style={{ border: '1px solid var(--t-hair)', background: 'var(--t-card)' }}>
+          {loadError ? (
+            <div className="px-3 py-3">
+              <p className="text-[12px]" style={{ color: 'var(--status-error-dot)' }}>{loadError}</p>
+              <button onClick={fetchTasks} className="text-[11px] mt-2" style={{ color: 'var(--color-state-proposal)', cursor: 'pointer' }}>Retry</button>
+            </div>
+          ) : sorted === null ? (
+            <p className="text-[12px] px-3 py-3" style={{ color: 'var(--t-faint)' }}>Loading tasks…</p>
+          ) : sorted.length === 0 ? (
+            <p className="text-[12px] px-3 py-3 leading-relaxed" style={{ color: 'var(--t-muted)' }}>
+              No tasks assigned to you on {tracker.name}. Make sure issues are assigned to your account, then hit Sync now.
+            </p>
+          ) : (
+            <div className="max-h-64 overflow-y-auto">
+              {sorted.map((t, i) => (
+                <div key={t.key} className="flex items-center gap-2.5 px-3 py-2"
+                  style={{ borderTop: i > 0 ? '1px solid var(--t-hair)' : undefined, opacity: t.on_board ? 1 : 0.55 }}>
+                  <a href={t.url} onClick={(e) => { e.preventDefault(); if (t.url) openExternal(t.url) }}
+                    className="text-[11px] font-mono px-1.5 py-0.5 rounded shrink-0"
+                    style={{ background: 'var(--t-box)', color: 'var(--color-state-proposal)', cursor: t.url ? 'pointer' : 'default' }}
+                    title={t.url ? `Open ${t.key} ↗` : t.key}>
+                    {t.key}
+                  </a>
+                  <span className="text-[12px] truncate flex-1" style={{ color: 'var(--t-title)' }}>{t.title}</span>
+                  {!t.on_board && <span className="text-[10px] shrink-0" style={{ color: 'var(--t-faint-2)' }}>done</span>}
+                  <span className="text-[11px] font-mono shrink-0" style={{ color: t.today_s > 0 ? 'var(--t-muted)' : 'var(--t-faint-2)' }}>
+                    {t.today_s > 0 ? fmtDur(t.today_s) : '—'}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
## What changed

Four commits, all validated by the local pre-push suite (fmt, clippy, UI build, UI tests, cargo test) on Windows:

### feat(integrations) - View tasks + Sync now on connected tracker cards

Folds the old **Task list** surface into each connected integration card (Settings -> Integrations). On a connected tracker:

- **View tasks** lazily loads the board via `get_tasks` and filters to that provider. Each row shows the ticket key (opens externally), title, and time tracked today, with done/off-board tickets dimmed and active tickets sorted first.
- **Sync now** runs `sync_tasks` (`meridian tasks-sync`) and refreshes the list.

Reuses the exact tray commands that backed the standalone `TasksPanel`, so behaviour matches what was there before.

### fix(oauth) - open the browser via rundll32 on Windows

The Jira/Trello **Browser OAuth** flow opened **File Explorer** (the user's Documents folder) instead of the browser. Root cause: `explorer.exe <url>` is unreliable for the long, query-heavy authorize URLs - when it can't parse the argument as a URL it silently falls back to a file window. Switched to `rundll32.exe url.dll,FileProtocolHandler <url>`, which hands the URL straight to the registered protocol handler as a single literal argv argument and reliably opens the default browser with the full query string intact. **Verified end-to-end: Jira browser OAuth now connects.**

### fix(health) - satisfy clippy on Windows

`manual_contains` fires on the Windows-only (`#[cfg(windows)]`) executable-probe branch in `health/platform.rs`, which the macOS CI clippy never compiles - so it went unseen and blocked every Windows commit. `iter().any(|e| *e == dotted)` becomes `contains(&dotted)`.

### chore - add .gitattributes (LF)

A Windows checkout with `core.autocrlf=true` rewrote every file to CRLF, breaking source-introspection tests (they string-match against `\n`) - failures the macOS/Linux CI never sees. `* text=auto eol=lf` makes the working tree match the LF blobs Git already stores, so builds and tests behave identically across platforms.

## Testing

- Built and ran the app on Windows 11 (ARM64); Jira browser OAuth confirmed working.
- New integration-card **View tasks** / **Sync now** verified live against the connected Jira board.
- Full local pre-push suite green on Windows: cargo fmt, cargo clippy -D warnings, next build, bun test, cargo test.

## Notes

- Targets `pre-main` per contributing guidelines.
- The three non-feature commits are Windows build/dev-experience fixes surfaced while building `pre-main` from source on Windows; none change macOS behaviour.
