### PR TITLE
fix: address PR #542 review comments

### DIFF
--- a/meridian-oauth/src/store.rs
+++ b/meridian-oauth/src/store.rs
@@ -50,17 +50,21 @@ impl OAuthTokens {
 /// `meridian_core::paths::home_dir()`, duplicated here rather than taken as a
 /// dependency: `meridian_core` pulls in sqlx/libsqlite3-sys for its DB layer,
 /// which this config-free, daemon-and-tray-shared crate deliberately has no
-/// reason to carry for one directory lookup.
-fn home_dir() -> PathBuf {
+/// reason to carry for one directory lookup. `None` when both fail, rather
+/// than falling back to the working directory — an OAuth token store must
+/// never land somewhere that depends on whatever `cwd` happened to launch
+/// the process.
+fn home_dir() -> Option<PathBuf> {
     std::env::var_os("HOME")
         .filter(|h| !h.is_empty())
         .map(PathBuf::from)
         .or_else(dirs::home_dir)
-        .unwrap_or_else(|| PathBuf::from("."))
 }
 
-fn oauth_dir() -> PathBuf {
-    home_dir().join(".meridian").join("oauth")
+fn oauth_dir() -> Result<PathBuf> {
+    let home = home_dir()
+        .ok_or_else(|| anyhow::anyhow!("could not resolve the home directory (HOME is unset and no platform profile directory was found)"))?;
+    Ok(home.join(".meridian").join("oauth"))
 }
 
 /// Reject a provider name that isn't a plain identifier, so a token/lock path can
@@ -86,7 +90,7 @@ fn validate_provider(provider: &str) -> Result<()> {
 /// provider name that could escape the oauth dir (see [`validate_provider`]).
 pub fn path(provider: &str) -> Result<PathBuf> {
     validate_provider(provider)?;
-    Ok(oauth_dir().join(format!("{provider}.json")))
+    Ok(oauth_dir()?.join(format!("{provider}.json")))
 }
 
 /// Whether a token file exists for this provider. Used to decide if OAuth is the
@@ -111,7 +115,7 @@ pub fn save(tokens: &OAuthTokens) -> Result<()> {
     // Validate the provider up front (also gates the tmp path below, which
     // interpolates it too) before touching the filesystem.
     let final_path = path(&tokens.provider)?;
-    let dir = oauth_dir();
+    let dir = oauth_dir()?;
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("creating OAuth dir {}", dir.display()))?;
     let tmp_path = dir.join(format!(".{}.json.tmp", tokens.provider));
@@ -171,7 +175,7 @@ impl Drop for ProviderLock {
 /// provider so the lock path can't escape the oauth dir (see [`validate_provider`]).
 fn lock_path(provider: &str) -> Result<PathBuf> {
     validate_provider(provider)?;
-    Ok(oauth_dir().join(format!("{provider}.lock")))
+    Ok(oauth_dir()?.join(format!("{provider}.lock")))
 }
 
 /// Acquire the exclusive cross-process advisory lock for `provider`'s token store,
@@ -198,7 +202,7 @@ async fn lock_provider_with_timeout(
     use anyhow::bail;
 
     let path = lock_path(provider)?; // validates provider before any FS work
-    let dir = oauth_dir();
+    let dir = oauth_dir()?;
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("creating OAuth dir {}", dir.display()))?;
     let file = std::fs::OpenOptions::new()

--- a/tray/src-tauri/src/commands/account.rs
+++ b/tray/src-tauri/src/commands/account.rs
@@ -110,7 +110,7 @@ pub async fn save_account_email(email: String) -> Result<(), String> {
     if email.is_empty() || !email.contains('@') {
         return Err("save_account_email: not a valid email address".into());
     }
-    let path = account_path().ok_or("save_account_email: HOME is not set")?;
+    let path = account_path().ok_or("save_account_email: home directory could not be resolved")?;
     // Crash-safe write via the shared helper. It's sync, so run it on the
     // blocking pool rather than stalling the async command's executor thread.
     let state = AccountState {


### PR DESCRIPTION
## Summary

Addresses the 2 actionable CodeRabbit review comments left on #542 (`pre-main → main`).

- `meridian-oauth/src/store.rs`: `home_dir()` fell back to `PathBuf::from(".")` when both `$HOME` and `dirs::home_dir()` failed to resolve, which would silently write OAuth tokens under whatever directory happened to launch the process instead of failing closed — and diverges from how tray consumers already treat an unresolved home (`None`). `home_dir()` now returns `Option<PathBuf>`, and `oauth_dir()` plus every caller (`path`/`save`/`lock_path`/`lock_provider_with_timeout`) propagate the failure via `Result` instead.
- `tray/src-tauri/src/commands/account.rs`: `save_account_email`'s error on an unresolved `account_path()` said `"HOME is not set"`, which is stale now that `account_path()` is platform-aware (`HOME` can be unset on Windows while resolution still succeeds via `dirs::home_dir()`). Reworded to `"home directory could not be resolved"`.

## Why this is a separate PR, not a push to `pre-main`

Per this repo's hard rules, fixes always land via a feature branch + PR — never a direct push to `pre-main`. #542 is the `pre-main → main` release PR (head = `pre-main` itself), so I can't commit the fix directly onto its branch. Once this PR is reviewed and merged into `pre-main`, the fix will automatically show up in #542's diff (same head branch) — the two CodeRabbit threads there should be resolved once that merge lands, not before.

## Test plan

- [x] `cargo test -p meridian-oauth` — all 20 tests pass
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings` clean on both `meridian-oauth` and `tray/src-tauri`
- [x] `cargo check` on `tray/src-tauri` (exercises `account.rs`)
- [x] Full pre-push suite passed (fmt, clippy, UI build, UI tests, security audit, `cargo test`)