### PR TITLE
fix(ui): guard ProviderTasks.fetchTasks against overlapping stale responses

### DIFF
--- a/ui/__tests__/tasks-panel-stale-fetch.test.ts
+++ b/ui/__tests__/tasks-panel-stale-fetch.test.ts
@@ -1,0 +1,25 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+
+// Guard for a stale-response race in ProviderTasks (IntegrationConnect.tsx):
+// the lazy load on panel-expand and the sync-triggered reload both call
+// fetchTasks(), and can overlap. Without a generation guard, a slower older
+// response landing after a newer one would silently overwrite fresher data
+// with stale data. The repo has no React render harness (see
+// oauth-setup-lifecycle.test.ts), so this asserts the guard's shape directly
+// against the source.
+const uiRoot = import.meta.dir + '/..'
+const view = readFileSync(uiRoot + '/components/IntegrationConnect.tsx', 'utf8')
+
+describe('ProviderTasks.fetchTasks stale-response guard', () => {
+  it('stamps each fetch with a generation counter', () => {
+    expect(view).toMatch(/const fetchGen = useRef\(0\)/)
+    expect(view).toMatch(/const gen = \+\+fetchGen\.current/)
+  })
+
+  it('only applies a response if it is still the latest generation', () => {
+    expect(view).toMatch(/if \(gen === fetchGen\.current\) setTasks\(/)
+    expect(view).toMatch(/if \(gen === fetchGen\.current\) setLoadError\(/)
+  })
+})

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -14,7 +14,7 @@
 //   - Azure DevOps   → `discover_azure_devops` (PAT → org → project) then
 //                      `save_integration_token`.
 
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { load, mutate, openExternal } from '@/lib/bridge'
 import type { IntegrationsResponse, TaskSummary, TasksResponse } from '@/lib/api-types'
 import { TRACKERS } from '@/lib/integrations'
@@ -187,12 +187,17 @@ function ProviderTasks({ tracker, expanded, onToggle, onSynced }: {
   const [loadError, setLoadError] = useState<string | null>(null)
   const [syncing, setSyncing] = useState(false)
   const [syncError, setSyncError] = useState<string | null>(null)
+  // The lazy load (on expand) and the sync-triggered reload can overlap — a
+  // fetch generation counter so a slower, older response can never overwrite
+  // a fresher one that already landed.
+  const fetchGen = useRef(0)
 
   const fetchTasks = () => {
+    const gen = ++fetchGen.current
     setLoadError(null)
     load<TasksResponse>('/api/tasks', 'get_tasks')
-      .then((d) => setTasks(d.tasks.filter((t) => t.provider === tracker.id)))
-      .catch((e) => setLoadError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Could not load tasks'))
+      .then((d) => { if (gen === fetchGen.current) setTasks(d.tasks.filter((t) => t.provider === tracker.id)) })
+      .catch((e) => { if (gen === fetchGen.current) setLoadError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Could not load tasks') })
   }
 
   // Load lazily — only once the user opens the list, and only the first time.


### PR DESCRIPTION
## Summary

Addresses the remaining actionable CodeRabbit finding on #542 (`pre-main → main`) — flagged after #543 ("View tasks / Sync now" for connected trackers) merged into `pre-main` and its diff appeared in #542's review.

`ProviderTasks` in `ui/components/IntegrationConnect.tsx` calls `fetchTasks()` from two places that can overlap: the lazy load on panel-expand, and `handleSync()`'s reload after a sync completes. Without ordering, a slower response from the *older* call could resolve after the newer one and silently overwrite fresher `tasks`/`loadError` state with stale data.

Fixed with a `fetchGen` request-generation counter: each `fetchTasks()` call stamps its own generation, and only applies its response (`setTasks`/`setLoadError`) if it's still the most recently issued call by the time the promise settles. Older, now-superseded responses are dropped.

## Why this is a separate PR, not a push to `pre-main`

Same reason as #544: #542's head is `pre-main` itself, and this repo's rules forbid pushing directly there. Once this merges into `pre-main`, the fix lands in #542 automatically (same head branch), and that CodeRabbit thread should be resolved then.

## Test plan

- [x] Added `ui/__tests__/tasks-panel-stale-fetch.test.ts` — a source-scan regression test (this repo has no React render harness) asserting the generation-guard shape stays in place
- [x] `bun test` — 334/334 pass (up from 333)
- [x] `npm run build` (Next TypeScript check + static export) passes clean
- [x] Full pre-push suite passed (fmt, clippy, UI build, UI tests, security audit, `cargo test`)