### PR TITLE
fix(windows): make daemon recovery resilient beyond the HOME fix, and stop meridian_bin silently missing the staged exe

### DIFF
--- a/src/health/platform.rs
+++ b/src/health/platform.rs
@@ -36,7 +36,7 @@ fn is_exec(p: &Path) -> bool {
         p.is_file()
             && p.extension().and_then(|e| e.to_str()).is_some_and(|ext| {
                 let dotted = format!(".{}", ext.to_ascii_uppercase());
-                pathext().iter().any(|e| *e == dotted)
+                pathext().contains(&dotted)
             })
     }
 }

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -106,10 +106,50 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
         return;
     }
 
+    // `ensure_backend_installed` runs off the setup hook, after `app.manage(db_pool)`
+    // (see `lib.rs`), so the pool is already there to raise/clear against —
+    // `None` only when the DB itself couldn't be opened, in which case there's
+    // nowhere to write a notice anyway.
+    let pool = app
+        .try_state::<Option<meridian_core::SqlitePool>>()
+        .and_then(|s| s.inner().clone());
+
     tracing::info!(hash = %bundled_hash, "backend_install: installing bundled backend");
     if let Err(e) = install(&backend, &home).await {
         tracing::error!(error = %e, "backend_install: install failed — will retry next launch");
+        // Previously silent beyond the log line: staging/registration can fail
+        // for reasons a user can actually act on (antivirus quarantining the
+        // staged exe, a locked-down profile denying the write, a full disk),
+        // and until the health-check's 2-strike "went quiet" eventually fires
+        // there was no in-app signal at all — and even then, no reason. Surface
+        // it immediately and specifically instead of waiting on that generic
+        // banner.
+        if let Some(p) = pool.as_ref() {
+            if let Err(notice_err) = meridian::notices::raise_typed(
+                p,
+                meridian::notices::Notice {
+                    id: "tray.backend_install_failed",
+                    severity: "error",
+                    title: "Meridian couldn't finish installing.",
+                    detail: &e,
+                    remedy: None,
+                    event_key: "system.health",
+                    deep_link: Some("/logs"),
+                },
+            )
+            .await
+            {
+                tracing::warn!(error = %notice_err, "backend-install-failure notice raise failed");
+            }
+        }
         return;
+    }
+    if let Some(p) = pool.as_ref() {
+        if let Err(e) =
+            meridian::notices::clear_typed(p, "tray.backend_install_failed", "system.health").await
+        {
+            tracing::warn!(error = %e, "backend-install-failure notice clear failed");
+        }
     }
 
     // Persist the marker only on full success so a partial install retries.

--- a/tray/src-tauri/src/commands/daemon_control.rs
+++ b/tray/src-tauri/src/commands/daemon_control.rs
@@ -157,7 +157,46 @@ pub async fn restart() -> Result<(), String> {
     // Task Scheduler has no atomic restart, so end-then-run. `/End` failing is
     // fine (the task may not be running); only `/Run` failing is an error.
     let _ = schtasks(&["/End", "/TN", TASK_NAME]).await;
-    schtasks(&["/Run", "/TN", TASK_NAME]).await
+    match schtasks(&["/Run", "/TN", TASK_NAME]).await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            // `/Run` fails outright — not "task exists but isn't running" — on
+            // any machine where `schtasks /Create` was blocked by policy at
+            // install time (see `backend_install::register_service`): there is
+            // no "Meridian Daemon" task to run, only the Startup-folder VBScript
+            // fallback, which fires once at login and never again. Without this,
+            // a daemon that later crashes on one of those machines stays dead
+            // until the next login — restart() would report success on nothing.
+            // Spawning the staged binary directly is the same recovery
+            // `register_service` already does for a fresh install; the daemon's
+            // own single-instance guard (`daemon_already_running`) makes this
+            // safe to attempt even if the task turns out to still be alive.
+            tracing::warn!(
+                error = %e,
+                "schtasks /Run failed - falling back to spawning the staged daemon directly"
+            );
+            spawn_staged_daemon().map_err(|spawn_err| {
+                format!("schtasks /Run failed ({e}); direct spawn also failed: {spawn_err}")
+            })
+        }
+    }
+}
+
+/// Launch `~/.meridian/bin/meridian.exe` directly, bypassing the Task
+/// Scheduler entirely. Used only as [`restart`]'s fallback when no scheduled
+/// task exists to run.
+#[cfg(target_os = "windows")]
+fn spawn_staged_daemon() -> Result<(), String> {
+    let home = meridian_core::paths::home_dir()
+        .ok_or_else(|| "home directory could not be resolved".to_string())?;
+    let daemon_bin = home.join(".meridian").join("bin").join("meridian.exe");
+    if !daemon_bin.exists() {
+        return Err(format!("no staged daemon at {}", daemon_bin.display()));
+    }
+    std::process::Command::new(&daemon_bin)
+        .spawn()
+        .map(|_| ())
+        .map_err(|e| format!("spawn {} failed: {e}", daemon_bin.display()))
 }
 
 #[cfg(target_os = "windows")]

--- a/tray/src-tauri/src/install.rs
+++ b/tray/src-tauri/src/install.rs
@@ -186,6 +186,13 @@ fn dev_env(repo: &std::path::Path) -> std::path::PathBuf {
 /// `~/.local/bin/meridian` is a `#!/usr/bin/env node` wrapper that dies when
 /// launchd's PATH lacks `node`, so it's only the fallback; bare `meridian`
 /// (relies on `$PATH`) is the last resort.
+///
+/// On Windows the staged binary is `meridian.exe` (`backend_install`'s
+/// `DAEMON_FILE`) — the candidate list below must match that exact name, or
+/// `Path::exists()` never matches and every CLI shell-out (`day-summary`,
+/// `worklog generate`, `triage`, `uninstall`, …) silently falls through to
+/// the bare-`meridian`/`$PATH` last resort, which is almost always empty on
+/// a per-user install.
 pub(crate) fn meridian_bin() -> String {
     // Checked in BOTH profiles, before anything else: an explicit, logged opt-in
     // beats every rule below. Ignored (with a warning) when it points at nothing,
@@ -207,15 +214,30 @@ pub(crate) fn meridian_bin() -> String {
         if let Some(home) = meridian_core::paths::home_dir() {
             // `~/.meridian/bin/meridian` is the DMG path (staged by `backend_install`) —
             // native, no runtime deps, so it works under launchd's minimal PATH; the
-            // `~/.local/bin` node wrapper is the last resort.
-            for rel in [".meridian/bin/meridian", ".local/bin/meridian"] {
+            // `~/.local/bin` node wrapper is the last resort. On Windows the staged
+            // file (and the only candidate that can ever exist there) is
+            // `meridian.exe` — `.local/bin` is a POSIX/npm-wrapper convention with
+            // no Windows equivalent, so it's skipped rather than probed for nothing.
+            #[cfg(target_os = "windows")]
+            let candidates: &[&str] = &[".meridian/bin/meridian.exe"];
+            #[cfg(not(target_os = "windows"))]
+            let candidates: &[&str] = &[".meridian/bin/meridian", ".local/bin/meridian"];
+
+            for rel in candidates {
                 let p = home.join(rel);
                 if p.exists() {
                     return p.to_string_lossy().into_owned();
                 }
             }
         }
-        "meridian".to_string()
+        #[cfg(target_os = "windows")]
+        {
+            "meridian.exe".to_string()
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            "meridian".to_string()
+        }
     }
 }
 

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -73,13 +73,29 @@ pub(super) async fn refresh_health(
 
     let Some(pool) = pool else { return };
     if notify_down {
+        // A confirmed outage (2nd consecutive failed poll, not a transient
+        // blip) is worth one automatic recovery attempt before bothering the
+        // user — most causes (a crashed process, a machine where the
+        // scheduled task/launchd agent lost track of it) self-heal from a
+        // plain restart, and someone who isn't watching the tray shouldn't
+        // have to notice the banner and click "Restart daemon" for that.
+        // Best-effort: either outcome still raises the notice below, just
+        // with detail reflecting whether the attempt worked.
+        let restart_result = crate::commands::daemon_control::restart().await;
+        let detail = if let Err(e) = &restart_result {
+            tracing::warn!(error = %e, "daemon-health auto-restart attempt failed");
+            "Tried to restart it automatically and that failed too. Tap to check what happened."
+        } else {
+            tracing::info!("daemon-health auto-restart attempted");
+            "Tried restarting it automatically — give it a moment."
+        };
         if let Err(e) = meridian::notices::raise_typed(
             pool,
             meridian::notices::Notice {
                 id: "tray.daemon_quiet",
                 severity: "warning",
                 title: "Meridian went quiet.",
-                detail: "Tap to check what happened.",
+                detail,
                 remedy: None,
                 event_key: "system.health",
                 deep_link: Some("/logs"),


### PR DESCRIPTION
## Summary

The HOME-resolution fix (`abb2ad73`) stopped the daemon from failing to install/start on Windows, but left three related gaps that would still produce a silent, unrecoverable "Meridian went quiet" with no actionable signal:

- **`install::meridian_bin()`** release-path candidates were `.meridian/bin/meridian` / `.local/bin/meridian` with no `.exe` variant, so `Path::exists()` never matched the actual staged `.meridian/bin/meridian.exe` on Windows. Every CLI shell-out (`day-summary`, `worklog generate`, `triage`, `uninstall`, ...) silently fell through to a bare `meridian` relying on `$PATH`, which is empty on a per-user install.
- **`daemon_control::restart()`** (Windows) only tried `schtasks /Run`, which fails outright - not "not running", just absent - on any machine where `schtasks /Create` was blocked by policy at install time and `register_service` fell back to the Startup-folder launcher. That fallback fires once at login and never again, so a daemon that later crashed had no recovery path until next login. `restart()` now falls back to spawning the staged binary directly; the daemon's own single-instance guard makes this safe even if the task turns out to still be alive.
- **`refresh_health`** raised the "went quiet" notice but never attempted recovery, requiring the user to notice the banner and click "Restart daemon" manually. It now makes one automatic restart attempt on the 2nd consecutive failed health check (debounced, so a transient blip never triggers it), for any platform, and the notice detail reflects whether that attempt worked.
- **`backend_install::ensure_backend_installed`** swallowed `install()` failures into a log line only a developer could read. It now raises a specific system_notice (`tray.backend_install_failed`) with the actual error, so antivirus quarantine / permission-denied / disk-full show up in the app immediately instead of waiting on the generic 2-strike health banner.

Also fixes an unrelated pre-existing clippy failure (`manual_contains`) in `src/health/platform.rs` that was blocking the pre-commit hook on this branch.

## Test plan

- [x] `cargo check -p meridian-tray`
- [x] `cargo test -p meridian-tray --lib` (146 passed; 2 pre-existing, unrelated Windows-path-separator test failures confirmed present on `pre-main` before this change too)
- [x] `cargo clippy -p meridian-tray --lib --no-deps` (clean)
- [x] `cargo fmt --check`
- [x] Full pre-push suite (fmt, clippy, ui build, ui tests, security audit, full `cargo test`) passed

?? Generated with [Claude Code](https://claude.com/claude-code)