### PR TITLE
feat(capture): capture context from secondary monitors

### DIFF
--- a/meridian-core/src/capture.rs
+++ b/meridian-core/src/capture.rs
@@ -99,6 +99,59 @@ pub async fn insert_capture_frame(pool: &SqlitePool, frame: &CaptureFrameInsert)
     }
 }
 
+/// One OCR'd sample from a monitor OTHER than the one holding the
+/// currently-focused window (multi-screen capture, context-only — see
+/// `tray/src-tauri/src/capture/screenpipe.rs`'s secondary-monitor sweep).
+/// Never defines a session boundary; folded into whichever session is open
+/// when the ETL closes/upserts a block (`src/etl/extractor.rs`).
+#[derive(Debug, Clone)]
+pub struct CaptureSecondaryScreenInsert {
+    /// Capture instant. Stored as RFC3339 UTC, microsecond precision.
+    pub timestamp: DateTime<Utc>,
+    /// Display name (`SafeMonitor::name()`, falling back to `stable_id()` when empty).
+    pub monitor_name: String,
+    /// Foreground app on that monitor's topmost window, if known.
+    pub app_name: Option<String>,
+    pub window_name: Option<String>,
+    /// OCR text of that window.
+    pub text: String,
+}
+
+/// Insert one secondary-monitor sample into `capture_secondary_screens`. Same
+/// graceful missing-table behaviour as [`insert_capture_frame`] (a schema lag
+/// never crashes the tray).
+pub async fn insert_capture_secondary_screen(
+    pool: &SqlitePool,
+    sample: &CaptureSecondaryScreenInsert,
+) -> Result<()> {
+    let ts = sample
+        .timestamp
+        .to_rfc3339_opts(SecondsFormat::Micros, true);
+    let res = sqlx::query(
+        "INSERT INTO capture_secondary_screens
+           (timestamp, monitor_name, app_name, window_name, text)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+    )
+    .bind(&ts)
+    .bind(&sample.monitor_name)
+    .bind(&sample.app_name)
+    .bind(&sample.window_name)
+    .bind(&sample.text)
+    .execute(pool)
+    .await;
+
+    match res {
+        Ok(_) => Ok(()),
+        Err(e) if is_missing_table(&e) => {
+            tracing::debug!(
+                "capture_secondary_screens absent (daemon not yet migrated to 068) — sample dropped"
+            );
+            Ok(())
+        }
+        Err(e) => Err(e).context("insert capture_secondary_screen"),
+    }
+}
+
 /// One input event to persist into `capture_ui_events`. Maps onto the
 /// read-subset of screenpipe's `ui_events`: `get_signals` (clipboard/app_switch)
 /// and `get_last_ui_event_for_app` (click/key/text timestamps). `text_content`

--- a/meridian-core/src/db.rs
+++ b/meridian-core/src/db.rs
@@ -39,6 +39,10 @@ pub struct ActiveSession {
     pub category: String,
     pub confidence: f64,
     pub session_text: Option<String>,
+    /// OCR samples from monitors other than the one this session's app was
+    /// focused on — context, not activity (JSON array, see
+    /// `src/db/screenpipe.rs::SecondaryScreenEvent` on the daemon side).
+    pub secondary_screens: Option<String>,
 }
 
 /// Open an EXISTING meridian.db WITHOUT running migrations or creating the file.
@@ -76,7 +80,7 @@ pub async fn get_active_session(pool: &SqlitePool) -> anyhow::Result<Option<Acti
         SELECT id, app_name, started_at, last_seen_at,
                window_titles, audio_snippets, signals,
                min_frame_id, max_frame_id, frame_count, idle_frame_count,
-               category, confidence, session_text
+               category, confidence, session_text, secondary_screens
         FROM active_session WHERE id = 1
         "#,
     )

--- a/meridian-core/src/lib.rs
+++ b/meridian-core/src/lib.rs
@@ -54,8 +54,8 @@ pub mod capture;
 pub use db::{get_active_session, open_existing, ActiveSession};
 
 pub use capture::{
-    insert_capture_frame, insert_capture_ui_event, insert_pause_gap, CaptureFrameInsert,
-    CaptureUiEventInsert,
+    insert_capture_frame, insert_capture_secondary_screen, insert_capture_ui_event,
+    insert_pause_gap, CaptureFrameInsert, CaptureSecondaryScreenInsert, CaptureUiEventInsert,
 };
 
 pub use util::{date, hygiene, intervals, llm_capacity, paths};

--- a/src/db/meridian.rs
+++ b/src/db/meridian.rs
@@ -372,8 +372,8 @@ pub async fn upsert_active_session(
             id, app_name, started_at, last_seen_at,
             window_titles, audio_snippets, signals,
             min_frame_id, max_frame_id, frame_count, idle_frame_count,
-            category, confidence, session_text
-        ) VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+            category, confidence, session_text, secondary_screens
+        ) VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
         ON CONFLICT (id) DO UPDATE SET
             app_name         = excluded.app_name,
             started_at       = excluded.started_at,
@@ -387,7 +387,8 @@ pub async fn upsert_active_session(
             idle_frame_count = excluded.idle_frame_count,
             category         = excluded.category,
             confidence       = excluded.confidence,
-            session_text     = excluded.session_text
+            session_text     = excluded.session_text,
+            secondary_screens = excluded.secondary_screens
         "#,
     )
     .bind(&session.app_name)
@@ -403,6 +404,7 @@ pub async fn upsert_active_session(
     .bind(&session.category)
     .bind(session.confidence)
     .bind(&session.session_text)
+    .bind(&session.secondary_screens)
     .execute(pool)
     .await
     .context("upsert_active_session: upsert failed")?;
@@ -445,8 +447,8 @@ pub async fn close_active_session_with(
             window_titles, audio_snippets, signals,
             min_frame_id, max_frame_id, frame_count,
             idle_frame_count, etl_run_id,
-            category, confidence, session_text
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+            category, confidence, session_text, secondary_screens
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
         "#,
     )
     .bind(&active.app_name)
@@ -464,6 +466,7 @@ pub async fn close_active_session_with(
     .bind(&active.category)
     .bind(active.confidence)
     .bind(&active.session_text)
+    .bind(&active.secondary_screens)
     .execute(pool)
     .await
     .context("close_active_session_with: insert into app_sessions failed")?;

--- a/src/db/screenpipe.rs
+++ b/src/db/screenpipe.rs
@@ -52,6 +52,20 @@ pub struct SignalEvent {
     pub timestamp: String,
 }
 
+/// One deduplicated secondary-monitor OCR sample within a session's time
+/// window (multi-screen capture, context-only — see `capture_secondary_screens`
+/// migration 068). Never defines a session boundary; folded into
+/// `BlockContext::secondary_screens` and merged onto whichever app_sessions /
+/// active_session row is open.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SecondaryScreenEvent {
+    pub monitor_name: String,
+    pub app_name: Option<String>,
+    pub window_name: Option<String>,
+    pub text: String,
+    pub timestamp: String,
+}
+
 /// One frame's text content fetched from screenpipe for session_text building.
 #[derive(Debug, Clone)]
 pub struct FrameText {
@@ -355,4 +369,221 @@ pub async fn get_signals(
         .collect();
 
     Ok(result)
+}
+
+/// Returns secondary-monitor OCR samples within the given timestamp range.
+/// Deduplicated by (monitor, app, window, text) — the same topmost window
+/// unchanged across sweep ticks collapses to one entry, same spirit as
+/// `get_signals`'s clipboard/app_switch dedup.
+pub async fn get_secondary_screen_events(
+    pool: &SqlitePool,
+    start_ts: &str,
+    end_ts: &str,
+) -> Result<Vec<SecondaryScreenEvent>> {
+    let rows = sqlx::query_as::<_, (String, Option<String>, Option<String>, String, String)>(
+        "SELECT monitor_name, app_name, window_name, text, MIN(timestamp) AS timestamp
+         FROM capture_secondary_screens
+         WHERE timestamp BETWEEN ? AND ?
+           AND text IS NOT NULL AND text != ''
+         GROUP BY monitor_name, app_name, window_name, text
+         ORDER BY timestamp",
+    )
+    .bind(start_ts)
+    .bind(end_ts)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(
+            |(monitor_name, app_name, window_name, text, timestamp)| SecondaryScreenEvent {
+                monitor_name,
+                app_name,
+                window_name,
+                text,
+                timestamp,
+            },
+        )
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get_secondary_screen_events;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn seeded_pool() -> sqlx::SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("open in-memory db");
+        sqlx::migrate!("src/migrations")
+            .run(&pool)
+            .await
+            .expect("migrate");
+        pool
+    }
+
+    async fn insert(
+        pool: &sqlx::SqlitePool,
+        ts: &str,
+        monitor: &str,
+        app: &str,
+        window: &str,
+        text: &str,
+    ) {
+        sqlx::query(
+            "INSERT INTO capture_secondary_screens (timestamp, monitor_name, app_name, window_name, text)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+        )
+        .bind(ts)
+        .bind(monitor)
+        .bind(app)
+        .bind(window)
+        .bind(text)
+        .execute(pool)
+        .await
+        .expect("insert capture_secondary_screens row");
+    }
+
+    #[tokio::test]
+    async fn dedupes_identical_repeated_samples() {
+        let pool = seeded_pool().await;
+        // Same topmost window OCR'd across three sweep ticks — identical text each time.
+        insert(
+            &pool,
+            "2026-01-01T10:00:00.000000Z",
+            "DELL U2718Q",
+            "Slack",
+            "general",
+            "hello",
+        )
+        .await;
+        insert(
+            &pool,
+            "2026-01-01T10:00:10.000000Z",
+            "DELL U2718Q",
+            "Slack",
+            "general",
+            "hello",
+        )
+        .await;
+        insert(
+            &pool,
+            "2026-01-01T10:00:20.000000Z",
+            "DELL U2718Q",
+            "Slack",
+            "general",
+            "hello",
+        )
+        .await;
+
+        let events = get_secondary_screen_events(
+            &pool,
+            "2026-01-01T09:00:00.000000Z",
+            "2026-01-01T11:00:00.000000Z",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            events.len(),
+            1,
+            "identical repeated samples collapse to one"
+        );
+        assert_eq!(
+            events[0].timestamp, "2026-01-01T10:00:00.000000Z",
+            "earliest timestamp wins"
+        );
+    }
+
+    #[tokio::test]
+    async fn keeps_distinct_text_and_windows() {
+        let pool = seeded_pool().await;
+        insert(
+            &pool,
+            "2026-01-01T10:00:00.000000Z",
+            "DELL U2718Q",
+            "Slack",
+            "general",
+            "hello",
+        )
+        .await;
+        insert(
+            &pool,
+            "2026-01-01T10:00:10.000000Z",
+            "DELL U2718Q",
+            "Slack",
+            "general",
+            "goodbye",
+        )
+        .await;
+        insert(
+            &pool,
+            "2026-01-01T10:00:20.000000Z",
+            "LG 27UK850",
+            "Notion",
+            "Roadmap",
+            "hello",
+        )
+        .await;
+
+        let events = get_secondary_screen_events(
+            &pool,
+            "2026-01-01T09:00:00.000000Z",
+            "2026-01-01T11:00:00.000000Z",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            events.len(),
+            3,
+            "different text/window/monitor are distinct samples"
+        );
+    }
+
+    #[tokio::test]
+    async fn respects_timestamp_window() {
+        let pool = seeded_pool().await;
+        insert(
+            &pool,
+            "2026-01-01T09:00:00.000000Z",
+            "DELL U2718Q",
+            "Slack",
+            "general",
+            "before",
+        )
+        .await;
+        insert(
+            &pool,
+            "2026-01-01T10:00:00.000000Z",
+            "DELL U2718Q",
+            "Slack",
+            "general",
+            "inside",
+        )
+        .await;
+        insert(
+            &pool,
+            "2026-01-01T12:00:00.000000Z",
+            "DELL U2718Q",
+            "Slack",
+            "general",
+            "after",
+        )
+        .await;
+
+        let events = get_secondary_screen_events(
+            &pool,
+            "2026-01-01T09:30:00.000000Z",
+            "2026-01-01T11:00:00.000000Z",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].text, "inside");
+    }
 }

--- a/src/etl/extractor.rs
+++ b/src/etl/extractor.rs
@@ -5,8 +5,8 @@ use anyhow::Result;
 use sqlx::SqlitePool;
 
 use crate::db::screenpipe::{
-    get_audio_snippets, get_frame_full_texts, get_signals, get_window_titles, AudioSnippet,
-    SignalEvent, WindowTitleCount,
+    get_audio_snippets, get_frame_full_texts, get_secondary_screen_events, get_signals,
+    get_window_titles, AudioSnippet, SecondaryScreenEvent, SignalEvent, WindowTitleCount,
 };
 use crate::etl::session_builder::{is_coding_agent_terminal, is_vscode_like};
 use crate::etl::text_merge::build_session_text;
@@ -27,6 +27,9 @@ pub struct BlockContext {
     pub window_titles: Vec<WindowTitleCount>,
     pub audio_snippets: Vec<AudioSnippet>,
     pub signals: Vec<SignalEvent>,
+    /// OCR samples from monitors other than the one this block's app was
+    /// focused on — context, not activity (see [`crate::db::screenpipe::get_secondary_screen_events`]).
+    pub secondary_screens: Vec<SecondaryScreenEvent>,
     /// Deduplicated, timestamped union of all frame full_text for this block.
     pub session_text: String,
 }
@@ -49,6 +52,7 @@ pub struct BlockContext {
         window_title_count = tracing::field::Empty,
         audio_snippet_count = tracing::field::Empty,
         signal_count = tracing::field::Empty,
+        secondary_screen_count = tracing::field::Empty,
         session_text_bytes = tracing::field::Empty,
     )
 )]
@@ -61,16 +65,18 @@ pub async fn extract_block_context(
     max_frame_id: i64,
     frame_count: i64,
 ) -> Result<BlockContext> {
-    let (window_titles_res, audio_res, signals_res, frames_res) = tokio::join!(
+    let (window_titles_res, audio_res, signals_res, secondary_screens_res, frames_res) = tokio::join!(
         get_window_titles(meridian, min_frame_id, max_frame_id, app_name),
         get_audio_snippets(meridian, started_at, ended_at),
         get_signals(meridian, started_at, ended_at),
+        get_secondary_screen_events(meridian, started_at, ended_at),
         get_frame_full_texts(meridian, min_frame_id, max_frame_id),
     );
 
     let session_text = build_session_text(&frames_res?);
     let audio_snippets = audio_res?;
     let signals = signals_res?;
+    let secondary_screens = secondary_screens_res?;
 
     // get_window_titles queries capture_frames by frame-id range and sees ALL
     // frames in that range — including coding-agent terminal frames that were
@@ -84,6 +90,7 @@ pub async fn extract_block_context(
     tracing::Span::current().record("window_title_count", window_titles.len());
     tracing::Span::current().record("audio_snippet_count", audio_snippets.len());
     tracing::Span::current().record("signal_count", signals.len());
+    tracing::Span::current().record("secondary_screen_count", secondary_screens.len());
     tracing::Span::current().record("session_text_bytes", session_text.len());
 
     tracing::debug!(
@@ -91,6 +98,7 @@ pub async fn extract_block_context(
         window_titles = window_titles.len(),
         audio_snippets = audio_snippets.len(),
         signals = signals.len(),
+        secondary_screens = secondary_screens.len(),
         session_text_bytes = session_text.len(),
         "block context extracted"
     );
@@ -105,6 +113,7 @@ pub async fn extract_block_context(
         window_titles,
         audio_snippets,
         signals,
+        secondary_screens,
         session_text,
     })
 }

--- a/src/etl/session_builder.rs
+++ b/src/etl/session_builder.rs
@@ -3,12 +3,42 @@
 use anyhow::Result;
 
 use crate::db::meridian::ActiveSession;
-use crate::db::screenpipe::{AudioSnippet, SignalEvent, WindowTitleCount};
+use crate::db::screenpipe::{AudioSnippet, SecondaryScreenEvent, SignalEvent, WindowTitleCount};
 use crate::etl::extractor::BlockContext;
 use crate::etl::text_merge::merge_session_texts;
 use crate::intelligence::session_categorizer::{categorize, SessionSignals};
 
 const AUDIO_SNIPPET_CAP: usize = 50;
+/// Caps how many secondary-monitor OCR samples accumulate on one session —
+/// context, not the primary activity signal, so it doesn't need the same
+/// depth as audio. Mirrors the historical `OCR_SAMPLE_CAP` (dropped in
+/// migration 014 when the primary path moved to a merged `session_text`).
+const SECONDARY_SCREEN_CAP: usize = 20;
+
+/// Appends `new` secondary-screen samples onto `existing`, deduplicating by
+/// (monitor, app, window, text) and stopping at [`SECONDARY_SCREEN_CAP`] —
+/// same treatment as `audio_snippets`.
+fn merge_secondary_screens(
+    existing: &[SecondaryScreenEvent],
+    new: &[SecondaryScreenEvent],
+) -> Vec<SecondaryScreenEvent> {
+    let mut merged: Vec<SecondaryScreenEvent> = existing.to_vec();
+    for sample in new {
+        if merged.len() >= SECONDARY_SCREEN_CAP {
+            break;
+        }
+        let is_dup = merged.iter().any(|e| {
+            e.monitor_name == sample.monitor_name
+                && e.app_name == sample.app_name
+                && e.window_name == sample.window_name
+                && e.text == sample.text
+        });
+        if !is_dup {
+            merged.push(sample.clone());
+        }
+    }
+    merged
+}
 
 struct ClassifyInput<'a> {
     app_name: &'a str,
@@ -67,6 +97,10 @@ pub(super) fn build_active_session(
         category,
         confidence,
         session_text: Some(ctx.session_text.clone()),
+        secondary_screens: Some(serde_json::to_string(&merge_secondary_screens(
+            &[],
+            &ctx.secondary_screens,
+        ))?),
     })
 }
 
@@ -82,6 +116,7 @@ pub(super) fn build_active_session(
 /// - `window_titles`: counts from identical titles are incremented; new titles are appended.
 /// - `audio_snippets`: appended, capped at `AUDIO_SNIPPET_CAP`.
 /// - `signals`: all new signals appended.
+/// - `secondary_screens`: appended, deduplicated, capped at `SECONDARY_SCREEN_CAP`.
 /// - `session_text`: when `session_text_override` is `Some(text)`, that text is used
 ///   directly (full rebuild from all frames — avoids chrome leaks from early sub-threshold
 ///   batches). When `None`, falls back to the additive `merge_session_texts` path.
@@ -126,6 +161,14 @@ pub(super) fn merge_into_active(
         .unwrap_or_default();
     signals.extend(ctx.signals.iter().cloned());
 
+    let existing_secondary_screens: Vec<SecondaryScreenEvent> = existing
+        .secondary_screens
+        .as_deref()
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or_default();
+    let secondary_screens =
+        merge_secondary_screens(&existing_secondary_screens, &ctx.secondary_screens);
+
     let merged_session_text = match session_text_override {
         Some(text) => text,
         None => merge_session_texts(
@@ -159,6 +202,7 @@ pub(super) fn merge_into_active(
         category,
         confidence,
         session_text: Some(merged_session_text),
+        secondary_screens: Some(serde_json::to_string(&secondary_screens)?),
     })
 }
 
@@ -320,7 +364,56 @@ pub(super) fn vscode_project(window_name: &str) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
-    use super::is_coding_agent_terminal;
+    use super::{is_coding_agent_terminal, merge_secondary_screens, SECONDARY_SCREEN_CAP};
+    use crate::db::screenpipe::SecondaryScreenEvent;
+
+    fn sample(monitor: &str, app: &str, window: &str, text: &str) -> SecondaryScreenEvent {
+        SecondaryScreenEvent {
+            monitor_name: monitor.to_string(),
+            app_name: Some(app.to_string()),
+            window_name: Some(window.to_string()),
+            text: text.to_string(),
+            timestamp: "2026-01-01T00:00:00.000000Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn merge_secondary_screens_deduplicates_identical_samples() {
+        let existing = vec![sample("DELL U2718Q", "Slack", "general", "hello")];
+        let new = vec![sample("DELL U2718Q", "Slack", "general", "hello")];
+        let merged = merge_secondary_screens(&existing, &new);
+        assert_eq!(
+            merged.len(),
+            1,
+            "identical (monitor, app, window, text) must not duplicate"
+        );
+    }
+
+    #[test]
+    fn merge_secondary_screens_keeps_distinct_samples() {
+        let existing = vec![sample("DELL U2718Q", "Slack", "general", "hello")];
+        let new = vec![sample("DELL U2718Q", "Slack", "general", "goodbye")];
+        let merged = merge_secondary_screens(&existing, &new);
+        assert_eq!(
+            merged.len(),
+            2,
+            "different text on the same window is a distinct sample"
+        );
+    }
+
+    #[test]
+    fn merge_secondary_screens_caps_at_limit() {
+        let existing: Vec<SecondaryScreenEvent> = Vec::new();
+        let new: Vec<SecondaryScreenEvent> = (0..SECONDARY_SCREEN_CAP + 10)
+            .map(|i| sample("DELL U2718Q", "Slack", "general", &format!("msg {i}")))
+            .collect();
+        let merged = merge_secondary_screens(&existing, &new);
+        assert_eq!(
+            merged.len(),
+            SECONDARY_SCREEN_CAP,
+            "must stop at SECONDARY_SCREEN_CAP"
+        );
+    }
 
     #[test]
     fn detects_claude_code_spinner() {

--- a/src/migrations/068_capture_secondary_screens.sql
+++ b/src/migrations/068_capture_secondary_screens.sql
@@ -1,0 +1,33 @@
+-- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+--
+-- capture_secondary_screens — OCR text from monitors OTHER than the one
+-- holding the currently-focused window (multi-screen capture, context-only).
+--
+-- OWNERSHIP IS INVERTED vs every other meridian.db table, same as
+-- capture_frames: this one is WRITTEN BY THE TRAY (the in-process capture
+-- engine's secondary-monitor sweep, via meridian_core::insert_capture_secondary_screen)
+-- and READ BY THE DAEMON's ETL (src/db/screenpipe.rs::get_secondary_screen_events).
+-- Append-only; rows are never updated after insert.
+--
+-- Unlike capture_frames, rows here never define a session boundary — the ETL
+-- state machine in src/etl/runner.rs never reads this table. It is folded in
+-- at session-close/upsert time as extra context on whichever app_sessions /
+-- active_session row is open (see BlockContext::secondary_screens), attached
+-- to the session the user was actually working in, not tracked as separate
+-- activity of its own.
+
+CREATE TABLE IF NOT EXISTS capture_secondary_screens (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    -- RFC3339 UTC, microsecond precision — matches capture_frames.timestamp.
+    timestamp    TEXT NOT NULL,
+    -- Display name (SafeMonitor::name(), falling back to stable_id() when empty).
+    monitor_name TEXT NOT NULL,
+    -- Foreground app on that monitor's topmost window, if known.
+    app_name     TEXT,
+    window_name  TEXT,
+    -- OCR text of that window. NULL/empty rows are never inserted (writer skips them).
+    text         TEXT
+);
+
+-- get_secondary_screen_events scans a timestamp window, mirroring capture_frames' index.
+CREATE INDEX IF NOT EXISTS idx_capture_secondary_screens_timestamp ON capture_secondary_screens(timestamp);

--- a/src/migrations/069_secondary_screens_column.sql
+++ b/src/migrations/069_secondary_screens_column.sql
@@ -1,0 +1,17 @@
+-- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+--
+-- Adds secondary_screens (JSON array) to app_sessions / active_session — the
+-- per-session rollup of capture_secondary_screens rows (multi-screen capture,
+-- context-only). Same shape/treatment as the existing audio_snippets column:
+-- nullable, NULL for pre-existing rows, capped + deduplicated on write (see
+-- src/etl/session_builder.rs SECONDARY_SCREEN_CAP).
+--
+-- Kept as its own column rather than folded into `signals`: signals is a
+-- generic {event_type, value, timestamp} bucket (src/db/screenpipe.rs
+-- SignalEvent) for single-value events (clipboard, app_switch);
+-- secondary-screen samples carry a richer payload (monitor + app + window +
+-- OCR text) that doesn't fit that shape, same reasoning window_titles and
+-- audio_snippets already get their own columns.
+
+ALTER TABLE app_sessions ADD COLUMN secondary_screens TEXT;
+ALTER TABLE active_session ADD COLUMN secondary_screens TEXT;

--- a/tests/etl_session_close.rs
+++ b/tests/etl_session_close.rs
@@ -41,6 +41,7 @@ async fn test_close_active_session_with_inserts_and_clears() {
         category: "idle_personal".into(),
         confidence: 0.0,
         session_text: None,
+        secondary_screens: None,
     };
 
     upsert_active_session(&md, &session).await.unwrap();
@@ -95,6 +96,7 @@ async fn test_close_active_session_with_stale_then_new() {
         category: "communication".into(),
         confidence: 0.8,
         session_text: None,
+        secondary_screens: None,
     };
 
     upsert_active_session(&md, &stale).await.unwrap();
@@ -119,6 +121,7 @@ async fn test_close_active_session_with_stale_then_new() {
         category: "coding".into(),
         confidence: 0.7,
         session_text: None,
+        secondary_screens: None,
     };
 
     close_active_session_with(&md, &new_session, etl_run_id)

--- a/tray/src-tauri/src/capture/mod.rs
+++ b/tray/src-tauri/src/capture/mod.rs
@@ -11,13 +11,18 @@
 //! ffmpeg/video-encode dependency is pulled, and it's the "we store only text,
 //! never screenshots" privacy property.
 //!
-//! Frames flow over an mpsc channel ([`FrameTx`]) so the consumer can be swapped
-//! without touching the engine: a logger now (slice 2), a `meridian.db` writer
-//! later (slice 4). Mirrors the columns meridian's ETL reads (`src/db/screenpipe.rs`).
+//! Items flow over an mpsc channel ([`FrameTx`] of [`CaptureItem`]) so the
+//! consumer can be swapped without touching the engine: a logger now (slice 2),
+//! a `meridian.db` writer later (slice 4). Mirrors the columns meridian's ETL
+//! reads (`src/db/screenpipe.rs`). Two item shapes travel the same channel:
+//! [`CapturedFrame`] (the per-tick primary window — defines session
+//! boundaries) and [`SecondaryScreenSample`] (OCR text from other connected
+//! monitors — context folded onto whichever session is open, never a
+//! boundary of its own; multi-screen capture).
 //!
 //! # Who calls this
 //! `lib.rs`'s setup hook spawns the engine (behind the `capture` feature) + a
-//! consumer task; the engine sends [`CapturedFrame`]s, the consumer drains them.
+//! consumer task; the engine sends [`CaptureItem`]s, the consumer drains them.
 //!
 //! # Related
 //! - Obsidian `Decisions/Bucket 2 implementation plan - in-process capture.md` — the slice plan.
@@ -73,9 +78,36 @@ pub struct CapturedFrame {
     pub text_source: TextSource,
 }
 
-/// Channel the engine pushes frames onto. A bounded mpsc so a slow consumer
-/// applies backpressure to the capture loop rather than growing unbounded.
-pub type FrameTx = tokio::sync::mpsc::Sender<CapturedFrame>;
+/// One OCR sample from a monitor OTHER than the one holding the
+/// currently-focused window (multi-screen capture). Context, not activity:
+/// it never defines a session boundary on its own — the ETL folds it onto
+/// whichever session is open when the block containing `timestamp` closes
+/// (see `meridian_core::CaptureSecondaryScreenInsert` / migration 068).
+#[derive(Debug, Clone)]
+pub struct SecondaryScreenSample {
+    /// When the sample was captured.
+    pub timestamp: DateTime<Utc>,
+    /// Display name (`SafeMonitor::name()`, falling back to `stable_id()` when empty).
+    pub monitor_name: String,
+    /// Foreground app on that monitor's topmost window, if known.
+    pub app_name: Option<String>,
+    pub window_name: Option<String>,
+    /// OCR text of that window.
+    pub text: String,
+}
+
+/// One item the engine can push: the primary per-tick frame (defines session
+/// boundaries) or a secondary-monitor context sample (never does).
+#[derive(Debug, Clone)]
+pub enum CaptureItem {
+    Frame(CapturedFrame),
+    Secondary(SecondaryScreenSample),
+}
+
+/// Channel the engine pushes captured items onto. A bounded mpsc so a slow
+/// consumer applies backpressure to the capture loop rather than growing
+/// unbounded.
+pub type FrameTx = tokio::sync::mpsc::Sender<CaptureItem>;
 
 /// An in-process capture backend. [`run`](CaptureEngine::run) drives a capture
 /// loop until the process exits, sending each extracted frame on `tx`. Returns

--- a/tray/src-tauri/src/capture/screenpipe.rs
+++ b/tray/src-tauri/src/capture/screenpipe.rs
@@ -39,11 +39,24 @@ use screenpipe_screen::capture_screenshot_by_window::{
 use tracing::{debug, info, warn};
 
 use super::drm_detector::{self, StreamingGate};
-use super::{CaptureEngine, CapturedFrame, FrameTx, TextSource};
+use super::{
+    CaptureEngine, CaptureItem, CapturedFrame, FrameTx, SecondaryScreenSample, TextSource,
+};
 
 /// Seconds between capture passes. Conservative fixed cadence for v1;
 /// screenpipe's idle-adaptive frame rate is a later refinement.
 const CAPTURE_INTERVAL: Duration = Duration::from_secs(2);
+
+/// How often (in ticks of `CAPTURE_INTERVAL`) the secondary-monitor sweep
+/// runs — 5 × 2s ≈ 10s. Background-monitor context doesn't need the primary
+/// window's freshness, and Vision OCR against every OTHER connected monitor
+/// on every 2s tick would be wasted work for content the user isn't looking at.
+const SECONDARY_SCREEN_EVERY_N_TICKS: u32 = 5;
+
+/// Identifies the window a tick's primary capture (a11y or OCR fallback)
+/// actually processed, so the secondary-monitor sweep can skip re-capturing
+/// the same window on whichever monitor it happens to live on.
+type WindowIdentity = (String, String);
 
 /// Outcome of the per-tick accessibility-tree walk — decides what (if anything)
 /// the OCR fallback does this tick.
@@ -63,11 +76,22 @@ enum A11yOutcome {
 pub struct ScreenpipeEngine {
     /// Whether to pause capture when streaming video is detected
     pub pause_on_streaming_video: bool,
+    /// User-configured ignored URL patterns (Settings → ignore list). The
+    /// primary a11y/OCR path doesn't need these threaded in explicitly — the
+    /// focused window's `browser_url` is always resolved by the fork, and
+    /// `lib.rs`'s consumer filters on it downstream. Secondary-monitor
+    /// windows are never focused, so the fork never resolves their
+    /// `browser_url` at all (see `capture_secondary_screens`) — passing
+    /// these into that sweep's `WindowFilters` is the only way an ignored
+    /// domain open on a non-focused screen still gets caught, via the fork's
+    /// own title-based blocked-URL heuristic.
+    pub ignored_urls: Vec<String>,
 }
 
 impl CaptureEngine for ScreenpipeEngine {
     async fn run(self, tx: FrameTx) -> anyhow::Result<()> {
         let pause_on_streaming = self.pause_on_streaming_video;
+        let ignored_urls = self.ignored_urls;
         // Register with TCC + drive both prompts ourselves. Neither library
         // prompts on its own: screen-capture enumeration only PREFLIGHTS, and
         // the AX tree reads nothing until this process is a trusted AX client.
@@ -87,9 +111,14 @@ impl CaptureEngine for ScreenpipeEngine {
         // motivating case). Lives for the whole engine run, single-threaded.
         let mut streaming_gate = StreamingGate::new();
 
+        // Counts ticks so the secondary-monitor sweep runs on its own slower
+        // cadence (see SECONDARY_SCREEN_EVERY_N_TICKS) without a second timer.
+        let mut tick: u32 = 0;
+
         info!(
             interval_s = CAPTURE_INTERVAL.as_secs(),
-            "capture: screenpipe engine started (a11y-tree + OCR fallback)"
+            secondary_screen_interval_s = CAPTURE_INTERVAL.as_secs() * SECONDARY_SCREEN_EVERY_N_TICKS as u64,
+            "capture: screenpipe engine started (a11y-tree + OCR fallback + secondary-monitor sweep)"
         );
         loop {
             if tx.is_closed() {
@@ -118,7 +147,7 @@ impl CaptureEngine for ScreenpipeEngine {
                 && tokio::task::spawn_blocking(drm_detector::any_streaming_content_visible)
                     .await
                     .unwrap_or(false);
-            if let Err(e) = dispatch(
+            let primary_identity = match dispatch(
                 &tx,
                 outcome,
                 pause_on_streaming,
@@ -127,8 +156,33 @@ impl CaptureEngine for ScreenpipeEngine {
             )
             .await
             {
-                warn!(error = %e, "capture: tick failed (will retry)");
+                Ok(identity) => identity,
+                Err(e) => {
+                    warn!(error = %e, "capture: tick failed (will retry)");
+                    None
+                }
+            };
+
+            tick = tick.wrapping_add(1);
+            // Only sweep when this tick resolved a primary window: `None` means
+            // either a privacy Skip (never sweep — see capture_secondary_screens
+            // docs) or nothing was captured at all (streaming-blocked OCR, no
+            // focused window), in which case there's no identity to exclude.
+            if tick.is_multiple_of(SECONDARY_SCREEN_EVERY_N_TICKS) {
+                if let Some(identity) = &primary_identity {
+                    if let Err(e) = capture_secondary_screens(
+                        &tx,
+                        identity,
+                        &ignored_urls,
+                        skip_ocr_for_streaming,
+                    )
+                    .await
+                    {
+                        warn!(error = %e, "capture: secondary-monitor sweep failed (will retry next cycle)");
+                    }
+                }
             }
+
             tokio::time::sleep(CAPTURE_INTERVAL).await;
         }
     }
@@ -304,6 +358,11 @@ fn a11y_content_is_thin(snap: &TreeSnapshot) -> bool {
 /// or run the OCR fallback. Best-effort — a failed OCR pass is logged and
 /// retried, never fatal (capture must not crash the tray).
 ///
+/// Returns the `(app_name, window_name)` of whatever was actually processed
+/// as this tick's primary window — `None` when nothing was (a privacy
+/// `Skip`, or a fallback that captured no legible window) — so the
+/// secondary-monitor sweep knows which window to exclude from its own pass.
+///
 /// `skip_ocr_for_streaming`: when true, the OCR fallback is skipped entirely
 /// for this tick — never invoking ScreenCaptureKit — because streaming
 /// content is on screen somewhere and any SCK call would trigger macOS's
@@ -314,19 +373,25 @@ async fn dispatch(
     pause_on_streaming: bool,
     streaming_gate: &mut StreamingGate,
     skip_ocr_for_streaming: bool,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Option<WindowIdentity>> {
     match outcome {
         A11yOutcome::Frame(frame) => {
+            let identity = (
+                frame.app_name.clone().unwrap_or_default(),
+                frame.window_name.clone().unwrap_or_default(),
+            );
             send_frame(tx, *frame, pause_on_streaming, streaming_gate).await;
-            Ok(())
+            Ok(Some(identity))
         }
-        A11yOutcome::Skip => Ok(()),
+        // Privacy decision — never sweep other monitors this tick either (see
+        // capture_secondary_screens' caller in `run`).
+        A11yOutcome::Skip => Ok(None),
         A11yOutcome::FallBackToOcr => {
             if skip_ocr_for_streaming {
                 debug!(
                     "capture: skipping OCR fallback this tick — streaming content on screen (avoiding DRM blank/flicker)"
                 );
-                return Ok(());
+                return Ok(None);
             }
             capture_once_ocr(tx, pause_on_streaming, streaming_gate).await
         }
@@ -337,11 +402,14 @@ async fn dispatch(
 /// window(s)** of the primary monitor. Per-window (not monitor-level) so each
 /// frame carries the app/window/url the classifier keys on — matching
 /// meridian's per-app ETL model.
+///
+/// Returns the identity of the first window it actually OCR'd and sent
+/// (normally there's exactly one), or `None` if nothing legible was found.
 async fn capture_once_ocr(
     tx: &FrameTx,
     pause_on_streaming: bool,
     streaming_gate: &mut StreamingGate,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Option<WindowIdentity>> {
     let monitors = screenpipe_screen::monitor::list_monitors().await;
     let Some(monitor) = monitors.into_iter().next() else {
         anyhow::bail!("no monitors enumerated (Screen Recording not granted yet?)");
@@ -355,6 +423,7 @@ async fn capture_once_ocr(
         .map_err(|e| anyhow::anyhow!("capture_all_visible_windows: {e}"))?;
 
     let now = Utc::now();
+    let mut identity = None;
     for win in windows {
         if is_self_app(&win.app_name.to_lowercase()) {
             continue;
@@ -366,6 +435,9 @@ async fn capture_once_ocr(
             continue; // nothing legible in this window — skip it
         }
         debug!(app = %win.app_name, chars = text.len(), "capture: window OCR'd");
+        if identity.is_none() {
+            identity = Some((win.app_name.clone(), win.window_name.clone()));
+        }
         let frame = CapturedFrame {
             timestamp: now,
             app_name: Some(win.app_name),
@@ -378,7 +450,7 @@ async fn capture_once_ocr(
             break; // consumer backpressure / gone — end this tick
         }
     }
-    Ok(())
+    Ok(identity)
 }
 
 /// Non-blocking send: under backpressure drop the frame rather than stall the
@@ -425,13 +497,112 @@ async fn send_frame(
         }
     }
 
-    match tx.try_send(frame) {
+    match tx.try_send(CaptureItem::Frame(frame)) {
         Ok(()) => true,
         Err(e) => {
             debug!(error = %e, "capture: frame dropped (consumer backpressure / gone)");
             false
         }
     }
+}
+
+/// Sweeps every connected monitor OTHER than the one hosting `primary`'s
+/// window, OCR's each one's topmost window, and sends the results as
+/// [`SecondaryScreenSample`]s. Context, not activity — never sent as a
+/// [`CapturedFrame`], so it can never define a session boundary.
+///
+/// Reuses `capture_all_visible_windows(&monitor, &filters, false)` — the same
+/// call the primary OCR fallback makes — which already resolves to "the
+/// topmost window on THIS monitor" via per-monitor z-order (not global
+/// focus), so no bounds/bookkeeping is needed to figure out which monitor
+/// hosts which window. A monitor whose topmost window matches `primary`
+/// exactly (same app + window name) is skipped — that's the monitor the
+/// primary a11y/OCR path already covered this tick; capturing it again here
+/// would be a redundant duplicate OCR of the same window.
+///
+/// Best-effort like the primary OCR path: a failed pass is logged and
+/// retried next sweep, never fatal.
+///
+/// `ignored_urls` is threaded into `WindowFilters` (unlike the primary OCR
+/// fallback, which passes an empty list): secondary-monitor windows are
+/// never the system-focused window, so the fork never resolves their
+/// `browser_url` — `is_url_blocked` can't fire on it downstream the way it
+/// does for the focused window. Passing the real ignored-URL list here at
+/// least activates the fork's own title-based blocked-URL heuristic
+/// (`is_title_suggesting_blocked_url`, used for exactly this "unfocused
+/// browser window, no URL available" case) so a known-ignored domain open
+/// on a non-focused screen isn't captured just because it's out of focus.
+async fn capture_secondary_screens(
+    tx: &FrameTx,
+    primary: &WindowIdentity,
+    ignored_urls: &[String],
+    skip_ocr_for_streaming: bool,
+) -> anyhow::Result<()> {
+    if skip_ocr_for_streaming {
+        debug!(
+            "capture: skipping secondary-monitor sweep — streaming content on screen (avoiding DRM blank/flicker)"
+        );
+        return Ok(());
+    }
+
+    let monitors = screenpipe_screen::monitor::list_monitors().await;
+    let filters = WindowFilters::new(&[], &[], ignored_urls);
+    let now = Utc::now();
+
+    for monitor in &monitors {
+        let windows = match capture_all_visible_windows(monitor, &filters, false).await {
+            Ok(w) => w,
+            Err(e) => {
+                debug!(monitor = monitor.name(), error = %e, "capture: secondary-monitor capture failed — skipping this monitor this sweep");
+                continue;
+            }
+        };
+
+        for win in windows {
+            if is_self_app(&win.app_name.to_lowercase()) {
+                continue;
+            }
+            if (win.app_name.as_str(), win.window_name.as_str())
+                == (primary.0.as_str(), primary.1.as_str())
+            {
+                debug!(
+                    monitor = monitor.name(),
+                    app = %win.app_name,
+                    "capture: secondary sweep skipping — same window already captured as primary this tick"
+                );
+                continue;
+            }
+            let Some(text) = perform_ocr(&win).await else {
+                continue;
+            };
+            if text.trim().is_empty() {
+                continue;
+            }
+            let monitor_name = if monitor.name().is_empty() {
+                monitor.stable_id()
+            } else {
+                monitor.name().to_string()
+            };
+            debug!(
+                monitor = %monitor_name,
+                app = %win.app_name,
+                chars = text.len(),
+                "capture: secondary-monitor window OCR'd"
+            );
+            let sample = SecondaryScreenSample {
+                timestamp: now,
+                monitor_name,
+                app_name: Some(win.app_name),
+                window_name: Some(win.window_name),
+                text,
+            };
+            if tx.try_send(CaptureItem::Secondary(sample)).is_err() {
+                debug!("capture: secondary-screen sample dropped (consumer backpressure / gone)");
+                return Ok(());
+            }
+        }
+    }
+    Ok(())
 }
 
 /// OCR one window image, returning its text.

--- a/tray/src-tauri/src/capture/screenpipe.rs
+++ b/tray/src-tauri/src/capture/screenpipe.rs
@@ -53,11 +53,6 @@ const CAPTURE_INTERVAL: Duration = Duration::from_secs(2);
 /// on every 2s tick would be wasted work for content the user isn't looking at.
 const SECONDARY_SCREEN_EVERY_N_TICKS: u32 = 5;
 
-/// Identifies the window a tick's primary capture (a11y or OCR fallback)
-/// actually processed, so the secondary-monitor sweep can skip re-capturing
-/// the same window on whichever monitor it happens to live on.
-type WindowIdentity = (String, String);
-
 /// Outcome of the per-tick accessibility-tree walk — decides what (if anything)
 /// the OCR fallback does this tick.
 enum A11yOutcome {
@@ -147,7 +142,7 @@ impl CaptureEngine for ScreenpipeEngine {
                 && tokio::task::spawn_blocking(drm_detector::any_streaming_content_visible)
                     .await
                     .unwrap_or(false);
-            let primary_identity = match dispatch(
+            let primary_captured = match dispatch(
                 &tx,
                 outcome,
                 pause_on_streaming,
@@ -156,30 +151,23 @@ impl CaptureEngine for ScreenpipeEngine {
             )
             .await
             {
-                Ok(identity) => identity,
+                Ok(captured) => captured,
                 Err(e) => {
                     warn!(error = %e, "capture: tick failed (will retry)");
-                    None
+                    false
                 }
             };
 
             tick = tick.wrapping_add(1);
-            // Only sweep when this tick resolved a primary window: `None` means
-            // either a privacy Skip (never sweep — see capture_secondary_screens
-            // docs) or nothing was captured at all (streaming-blocked OCR, no
-            // focused window), in which case there's no identity to exclude.
-            if tick.is_multiple_of(SECONDARY_SCREEN_EVERY_N_TICKS) {
-                if let Some(identity) = &primary_identity {
-                    if let Err(e) = capture_secondary_screens(
-                        &tx,
-                        identity,
-                        &ignored_urls,
-                        skip_ocr_for_streaming,
-                    )
-                    .await
-                    {
-                        warn!(error = %e, "capture: secondary-monitor sweep failed (will retry next cycle)");
-                    }
+            // Only sweep when this tick actually resolved a primary window:
+            // `false` means either a privacy Skip (never sweep — see
+            // capture_secondary_screens docs) or nothing was captured at all
+            // (streaming-blocked OCR, no focused window).
+            if tick.is_multiple_of(SECONDARY_SCREEN_EVERY_N_TICKS) && primary_captured {
+                if let Err(e) =
+                    capture_secondary_screens(&tx, &ignored_urls, skip_ocr_for_streaming).await
+                {
+                    warn!(error = %e, "capture: secondary-monitor sweep failed (will retry next cycle)");
                 }
             }
 
@@ -358,10 +346,19 @@ fn a11y_content_is_thin(snap: &TreeSnapshot) -> bool {
 /// or run the OCR fallback. Best-effort — a failed OCR pass is logged and
 /// retried, never fatal (capture must not crash the tray).
 ///
-/// Returns the `(app_name, window_name)` of whatever was actually processed
-/// as this tick's primary window — `None` when nothing was (a privacy
-/// `Skip`, or a fallback that captured no legible window) — so the
-/// secondary-monitor sweep knows which window to exclude from its own pass.
+/// Returns whether a primary frame was actually captured+sent this tick —
+/// `false` when nothing was (a privacy `Skip`, or a fallback that captured no
+/// legible window) — so the secondary-monitor sweep knows whether to run at
+/// all this tick. It does NOT try to identify which window was captured:
+/// `capture_secondary_screens` excludes the focused window via
+/// `CapturedWindow::is_focused` instead, because the a11y walker's
+/// `app_name`/`window_name` (from the AX tree) and CGWindowList's (from the
+/// secondary sweep) describe the SAME window differently — e.g. a11y reports
+/// a focused terminal tab's title while CGWindowList reports the OS window
+/// title bar — so string-matching them to detect "same window" is unreliable
+/// (confirmed live: a11y saw app "Code"/window "Terminal - ⠂ …", CGWindowList
+/// saw app "Visual Studio Code"/window "⠐ … — meridian" for the identical
+/// window at the identical instant).
 ///
 /// `skip_ocr_for_streaming`: when true, the OCR fallback is skipped entirely
 /// for this tick — never invoking ScreenCaptureKit — because streaming
@@ -373,25 +370,21 @@ async fn dispatch(
     pause_on_streaming: bool,
     streaming_gate: &mut StreamingGate,
     skip_ocr_for_streaming: bool,
-) -> anyhow::Result<Option<WindowIdentity>> {
+) -> anyhow::Result<bool> {
     match outcome {
         A11yOutcome::Frame(frame) => {
-            let identity = (
-                frame.app_name.clone().unwrap_or_default(),
-                frame.window_name.clone().unwrap_or_default(),
-            );
             send_frame(tx, *frame, pause_on_streaming, streaming_gate).await;
-            Ok(Some(identity))
+            Ok(true)
         }
         // Privacy decision — never sweep other monitors this tick either (see
         // capture_secondary_screens' caller in `run`).
-        A11yOutcome::Skip => Ok(None),
+        A11yOutcome::Skip => Ok(false),
         A11yOutcome::FallBackToOcr => {
             if skip_ocr_for_streaming {
                 debug!(
                     "capture: skipping OCR fallback this tick — streaming content on screen (avoiding DRM blank/flicker)"
                 );
-                return Ok(None);
+                return Ok(false);
             }
             capture_once_ocr(tx, pause_on_streaming, streaming_gate).await
         }
@@ -403,13 +396,12 @@ async fn dispatch(
 /// frame carries the app/window/url the classifier keys on — matching
 /// meridian's per-app ETL model.
 ///
-/// Returns the identity of the first window it actually OCR'd and sent
-/// (normally there's exactly one), or `None` if nothing legible was found.
+/// Returns whether it actually OCR'd and sent at least one window.
 async fn capture_once_ocr(
     tx: &FrameTx,
     pause_on_streaming: bool,
     streaming_gate: &mut StreamingGate,
-) -> anyhow::Result<Option<WindowIdentity>> {
+) -> anyhow::Result<bool> {
     let monitors = screenpipe_screen::monitor::list_monitors().await;
     let Some(monitor) = monitors.into_iter().next() else {
         anyhow::bail!("no monitors enumerated (Screen Recording not granted yet?)");
@@ -423,7 +415,7 @@ async fn capture_once_ocr(
         .map_err(|e| anyhow::anyhow!("capture_all_visible_windows: {e}"))?;
 
     let now = Utc::now();
-    let mut identity = None;
+    let mut captured = false;
     for win in windows {
         if is_self_app(&win.app_name.to_lowercase()) {
             continue;
@@ -435,9 +427,7 @@ async fn capture_once_ocr(
             continue; // nothing legible in this window — skip it
         }
         debug!(app = %win.app_name, chars = text.len(), "capture: window OCR'd");
-        if identity.is_none() {
-            identity = Some((win.app_name.clone(), win.window_name.clone()));
-        }
+        captured = true;
         let frame = CapturedFrame {
             timestamp: now,
             app_name: Some(win.app_name),
@@ -450,7 +440,7 @@ async fn capture_once_ocr(
             break; // consumer backpressure / gone — end this tick
         }
     }
-    Ok(identity)
+    Ok(captured)
 }
 
 /// Non-blocking send: under backpressure drop the frame rather than stall the
@@ -506,19 +496,26 @@ async fn send_frame(
     }
 }
 
-/// Sweeps every connected monitor OTHER than the one hosting `primary`'s
-/// window, OCR's each one's topmost window, and sends the results as
-/// [`SecondaryScreenSample`]s. Context, not activity — never sent as a
+/// Sweeps every connected monitor, OCR's each one's topmost window, and
+/// sends the results as [`SecondaryScreenSample`]s — except the monitor
+/// currently holding the system-focused window, which the primary a11y/OCR
+/// path already covered this tick. Context, not activity — never sent as a
 /// [`CapturedFrame`], so it can never define a session boundary.
 ///
 /// Reuses `capture_all_visible_windows(&monitor, &filters, false)` — the same
 /// call the primary OCR fallback makes — which already resolves to "the
 /// topmost window on THIS monitor" via per-monitor z-order (not global
 /// focus), so no bounds/bookkeeping is needed to figure out which monitor
-/// hosts which window. A monitor whose topmost window matches `primary`
-/// exactly (same app + window name) is skipped — that's the monitor the
-/// primary a11y/OCR path already covered this tick; capturing it again here
-/// would be a redundant duplicate OCR of the same window.
+/// hosts which window. The focused window is excluded via
+/// `CapturedWindow::is_focused` (only one window system-wide can be `true`),
+/// **not** by matching its app/window name against the tick's primary
+/// capture — a11y's `app_name`/`window_name` (the AX tree) and
+/// CGWindowList's (this sweep) describe the same window differently enough
+/// that string-matching them missed real matches in practice (observed live:
+/// a11y "Code" / "Terminal - ⠂ …" vs. CGWindowList "Visual Studio Code" /
+/// "⠐ … — meridian" for the identical window at the identical instant),
+/// which would have silently double-captured the focused window as
+/// "secondary" content.
 ///
 /// Best-effort like the primary OCR path: a failed pass is logged and
 /// retried next sweep, never fatal.
@@ -534,7 +531,6 @@ async fn send_frame(
 /// on a non-focused screen isn't captured just because it's out of focus.
 async fn capture_secondary_screens(
     tx: &FrameTx,
-    primary: &WindowIdentity,
     ignored_urls: &[String],
     skip_ocr_for_streaming: bool,
 ) -> anyhow::Result<()> {
@@ -562,13 +558,11 @@ async fn capture_secondary_screens(
             if is_self_app(&win.app_name.to_lowercase()) {
                 continue;
             }
-            if (win.app_name.as_str(), win.window_name.as_str())
-                == (primary.0.as_str(), primary.1.as_str())
-            {
+            if win.is_focused {
                 debug!(
                     monitor = monitor.name(),
                     app = %win.app_name,
-                    "capture: secondary sweep skipping — same window already captured as primary this tick"
+                    "capture: secondary sweep skipping — this monitor holds the system-focused window (already captured as primary this tick)"
                 );
                 continue;
             }

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -1043,6 +1043,12 @@ pub(crate) fn start_capture(
     // shared handle, so a Settings change never needs a capture restart.
     let settings = meridian_core::settings::load_runtime_settings();
     let pause_on_streaming_video = settings.pause_on_streaming_video;
+    // Handed to the engine's secondary-monitor sweep (multi-screen capture):
+    // unlike the primary a11y/OCR path, those windows are never
+    // system-focused, so the fork never resolves their `browser_url` for the
+    // usual downstream `should_drop_frame` check to catch — see
+    // `ScreenpipeEngine::ignored_urls`.
+    let ignored_urls = settings.ignored_urls.clone();
     let capture_ignore = {
         let s = app_state.lock().unwrap();
         *s.capture_ignore.lock().unwrap() =
@@ -1063,46 +1069,86 @@ pub(crate) fn start_capture(
     let (engine_cancel_tx, mut engine_cancel_rx) = tokio::sync::oneshot::channel::<()>();
     let (ui_cancel_tx, mut ui_cancel_rx) = tokio::sync::oneshot::channel::<()>();
 
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<capture::CapturedFrame>(64);
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<capture::CaptureItem>(64);
 
     // Frame consumer: exits when engine task finishes (tx drops → rx returns None).
+    // Handles both item shapes the engine can send — the primary per-tick frame
+    // and secondary-monitor context samples (multi-screen capture) — through the
+    // same ignore-list gate, routed to their own tables.
     let consumer_pool = pool.clone();
     let frame_ignore = capture_ignore.clone();
     tauri::async_runtime::spawn(async move {
-        while let Some(frame) = rx.recv().await {
-            tracing::debug!(
-                ts = %frame.timestamp,
-                app = ?frame.app_name,
-                chars = frame.text.len(),
-                "capture: frame received"
-            );
-            // User ignore list (apps + website domains): drop the frame before it
-            // is ever persisted, so an ignored app/site leaves no trace on the
-            // timeline. Going forward only — history is untouched.
-            if frame_ignore
-                .lock()
-                .unwrap()
-                .should_drop_frame(frame.app_name.as_deref(), frame.browser_url.as_deref())
-            {
-                tracing::debug!(
-                    app = ?frame.app_name,
-                    "capture: frame ignored (user ignore list) — not persisted"
-                );
-                continue;
-            }
-            let Some(p) = consumer_pool.as_ref() else {
-                continue;
-            };
-            let row = meridian_core::CaptureFrameInsert {
-                timestamp: frame.timestamp,
-                app_name: frame.app_name,
-                window_name: frame.window_name,
-                browser_url: frame.browser_url,
-                text: frame.text,
-                text_source: frame.text_source.as_str().to_string(),
-            };
-            if let Err(e) = meridian_core::insert_capture_frame(p, &row).await {
-                tracing::warn!(error = %e, "capture: failed to persist frame");
+        while let Some(item) = rx.recv().await {
+            match item {
+                capture::CaptureItem::Frame(frame) => {
+                    tracing::debug!(
+                        ts = %frame.timestamp,
+                        app = ?frame.app_name,
+                        chars = frame.text.len(),
+                        "capture: frame received"
+                    );
+                    // User ignore list (apps + website domains): drop the frame before it
+                    // is ever persisted, so an ignored app/site leaves no trace on the
+                    // timeline. Going forward only — history is untouched.
+                    if frame_ignore
+                        .lock()
+                        .unwrap()
+                        .should_drop_frame(frame.app_name.as_deref(), frame.browser_url.as_deref())
+                    {
+                        tracing::debug!(
+                            app = ?frame.app_name,
+                            "capture: frame ignored (user ignore list) — not persisted"
+                        );
+                        continue;
+                    }
+                    let Some(p) = consumer_pool.as_ref() else {
+                        continue;
+                    };
+                    let row = meridian_core::CaptureFrameInsert {
+                        timestamp: frame.timestamp,
+                        app_name: frame.app_name,
+                        window_name: frame.window_name,
+                        browser_url: frame.browser_url,
+                        text: frame.text,
+                        text_source: frame.text_source.as_str().to_string(),
+                    };
+                    if let Err(e) = meridian_core::insert_capture_frame(p, &row).await {
+                        tracing::warn!(error = %e, "capture: failed to persist frame");
+                    }
+                }
+                capture::CaptureItem::Secondary(sample) => {
+                    tracing::debug!(
+                        ts = %sample.timestamp,
+                        monitor = %sample.monitor_name,
+                        app = ?sample.app_name,
+                        chars = sample.text.len(),
+                        "capture: secondary-screen sample received"
+                    );
+                    if frame_ignore
+                        .lock()
+                        .unwrap()
+                        .should_drop_frame(sample.app_name.as_deref(), None)
+                    {
+                        tracing::debug!(
+                            app = ?sample.app_name,
+                            "capture: secondary-screen sample ignored (user ignore list) — not persisted"
+                        );
+                        continue;
+                    }
+                    let Some(p) = consumer_pool.as_ref() else {
+                        continue;
+                    };
+                    let row = meridian_core::CaptureSecondaryScreenInsert {
+                        timestamp: sample.timestamp,
+                        monitor_name: sample.monitor_name,
+                        app_name: sample.app_name,
+                        window_name: sample.window_name,
+                        text: sample.text,
+                    };
+                    if let Err(e) = meridian_core::insert_capture_secondary_screen(p, &row).await {
+                        tracing::warn!(error = %e, "capture: failed to persist secondary-screen sample");
+                    }
+                }
             }
         }
     });
@@ -1113,6 +1159,7 @@ pub(crate) fn start_capture(
     tauri::async_runtime::spawn(async move {
         let engine = ScreenpipeEngine {
             pause_on_streaming_video,
+            ignored_urls,
         };
         tokio::select! {
             _ = &mut engine_cancel_rx => {


### PR DESCRIPTION
## Summary
- The in-process capture engine only ever looked at the first enumerated monitor, so on a multi-monitor setup content on other screens was never captured. Adds a slower-cadence sweep (~10s vs. the primary 2s cadence) that OCRs the topmost window on every OTHER connected monitor.
- Deliberately **context, not activity**: secondary-monitor text is folded onto whichever session is currently open (new `secondary_screens` JSON column, capped/deduplicated like `audio_snippets`) rather than tracked as an independent concurrent `app_session`. This avoids inflating daily/weekly focus-time totals (`SUM(duration_s)`) past real wall-clock time, which would otherwise feed directly into worklog-hour drafting.
- No changes to the ETL app-switch/gap/cursor state machine, `active_session`'s single-row model, or the session categorizer.

## Changes
- Migrations `068` (`capture_secondary_screens` table, written by the tray/read by the daemon, same inverted-ownership convention as `capture_frames`) and `069` (`secondary_screens` column on `app_sessions`/`active_session`)
- Tray: `CaptureItem` enum carries both the primary per-tick frame and secondary-screen samples over the existing channel; the sweep reuses the fork's existing `capture_all_visible_windows` per-monitor (already resolves "topmost window on THIS monitor" via per-monitor z-order) and skips whichever monitor's topmost window matches the tick's primary capture, to avoid a duplicate OCR
- ETL: `get_secondary_screen_events` (deduplicated), merged into `BlockContext` and capped/merged onto the open session, same treatment as `audio_snippets`
- Threads the user's `ignored_urls` into the sweep's `WindowFilters` — secondary-monitor windows are never system-focused, so the fork never resolves their `browser_url` for the usual downstream ignore-list check to catch; this activates the fork's own title-based blocked-URL heuristic instead

## Explicitly out of scope (noted in-code)
- No dashboard UI for `secondary_screens` yet — data is captured/stored, display is a follow-up
- No fork changes to walk a non-focused window's a11y tree — secondary monitors are OCR-only
- Does not fix the pre-existing `capture_once_ocr` monitor[0]-only fallback bug (separate, self-contained issue)

## Test plan
- [x] `cargo fmt --check` + `cargo clippy -- -D warnings` clean on both the daemon (`meridian`, `meridian-core`) and tray (`meridian-tray`) crates
- [x] `cargo test` — 732 passed, 0 failed, including 6 new unit tests (secondary-screen cap/dedup logic in `session_builder.rs`, dedup query in `db/screenpipe.rs`)
- [x] Full pre-push suite (fmt + clippy + ui build + ui tests + security audit + cargo test) passed
- [ ] Manual verification on real multi-monitor hardware (in progress) — confirm `capture_secondary_screens` rows appear for the non-focused monitor, the primary window is correctly excluded from the sweep, and `active_session.secondary_screens` populates on the next ETL poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)