### PR TITLE
feat(jira): add multi-select project picker for Jira, mirroring GitHub

### DIFF
--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -76,8 +76,18 @@ const ENV_OAUTH_PROVIDERS: [&str; 1] = ["github"];
 const TOKEN_KEYS: &[(&str, &[&str])] = &[
     // Jira connects via OAuth AND via API token (base URL + email + token), so a
     // disconnect must strip these env keys in addition to removing the OAuth json
-    // — otherwise a token-connected Jira can never be disconnected.
-    ("jira", &["JIRA_BASE_URL", "JIRA_EMAIL", "JIRA_API_TOKEN"]),
+    // — otherwise a token-connected Jira can never be disconnected. JIRA_PROJECT_KEYS
+    // is the project picker's selection (see discover_jira_projects) and must go too,
+    // or a reconnect would silently inherit the previous account's project scope.
+    (
+        "jira",
+        &[
+            "JIRA_BASE_URL",
+            "JIRA_EMAIL",
+            "JIRA_API_TOKEN",
+            "JIRA_PROJECT_KEYS",
+        ],
+    ),
     ("github", &["GITHUB_TOKEN", "GITHUB_PROJECT_IDS"]),
     ("linear", &["LINEAR_API_KEY", "LINEAR_TEAM_IDS"]),
     (
@@ -110,6 +120,11 @@ const TOKEN_FIELD_MAP: &[(&str, &[(&str, &str)])] = &[
             ("base_url", "JIRA_BASE_URL"),
             ("email", "JIRA_EMAIL"),
             ("api_token", "JIRA_API_TOKEN"),
+            // Written by the project picker (discover_jira_projects → save here) on
+            // top of EITHER auth mode — API token or a browser-OAuth session. See
+            // missing_required's oauth_connected branch for why this can be saved
+            // with none of the three fields above present in the payload.
+            ("project_keys", "JIRA_PROJECT_KEYS"),
         ],
     ),
     (
@@ -166,18 +181,39 @@ const TOKEN_REQUIRED: &[(&str, &[&str])] = &[
 /// [`get_integrations`], which would otherwise accept the save and then report the
 /// provider disconnected.
 ///
+/// `oauth_connected` covers the Jira analogue of the GitHub gap above, with one
+/// twist: GitHub's OAuth (device flow) writes `GITHUB_TOKEN` straight into
+/// `.env`, so `existing` alone already proves it happened. Jira's browser-OAuth
+/// writes to `~/.meridian/oauth/jira.json` instead — a file `existing` (a parsed
+/// `.env`) can never see — so a jira project-keys-only save (from
+/// [`discover_jira_projects`]'s picker, run after an OAuth connect with no API
+/// token ever set) would otherwise report the three basic-auth fields missing
+/// even though Jira is fully connected. Meaningful only for `provider == "jira"`;
+/// every other provider ignores it.
+///
 /// # Who calls this
 /// [`save_integration_token`], which turns a non-empty result into its error.
 fn missing_required(
     provider: &str,
     updates: &BTreeMap<String, String>,
     existing: &HashMap<String, String>,
+    oauth_connected: bool,
 ) -> Vec<&'static str> {
-    TOKEN_REQUIRED
+    let required = TOKEN_REQUIRED
         .iter()
         .find(|(p, _)| *p == provider)
         .map(|(_, r)| *r)
-        .unwrap_or(&[])
+        .unwrap_or(&[]);
+
+    // A projects-only submit (none of the basic-auth fields in this payload) on
+    // top of an already-live OAuth session needs nothing further from this check.
+    // A submit that DOES include a basic-auth field is a real (re)connect attempt
+    // and must still be validated normally, even if OAuth also happens to exist.
+    if provider == "jira" && oauth_connected && !required.iter().any(|k| updates.contains_key(*k)) {
+        return Vec::new();
+    }
+
+    required
         .iter()
         .copied()
         .filter(|k| match updates.get(*k) {
@@ -209,6 +245,11 @@ pub struct IntegrationsResponse {
     /// project (see [`discover_github_projects`]). Lets the UI tell "connected,
     /// token only" apart from "connected and actually syncing."
     pub github_projects_selected: bool,
+    /// `true` once `JIRA_PROJECT_KEYS` is set — mirrors
+    /// [`Self::github_projects_selected`] for Jira (see
+    /// [`discover_jira_projects`]). `jira` alone means EITHER auth mode is live;
+    /// this additionally means at least one project was picked to sync.
+    pub jira_projects_selected: bool,
     pub sync_errors: BTreeMap<String, String>,
 }
 
@@ -335,6 +376,7 @@ pub async fn get_integrations(
         trello: on.contains(&"trello"),
         azure_devops: on.contains(&"azure_devops"),
         github_projects_selected: is_set(&env, "GITHUB_PROJECT_IDS"),
+        jira_projects_selected: is_set(&env, "JIRA_PROJECT_KEYS"),
         sync_errors,
     })
 }
@@ -513,15 +555,21 @@ pub async fn save_integration_token(body: SaveTokenBody) -> Result<serde_json::V
     // it twice stalls the reactor twice for the same answer.
     let mode = crate::install::detect_install_mode();
     let existing = mode.env_path().map(parse_env).unwrap_or_default();
-    let missing = missing_required(provider, &updates, &existing);
+    let oauth_connected = provider == "jira" && oauth_file_exists("jira");
+    let missing = missing_required(provider, &updates, &existing, oauth_connected);
     if !missing.is_empty() {
         return Err(format!("Missing: {}", missing.join(", ")));
     }
 
     // Jira API token must win over a stale OAuth session: resolve() already
     // prefers the token, but removing the store keeps the UI/get_integrations
-    // unambiguous about which auth is live.
-    if provider == "jira" {
+    // unambiguous about which auth is live. Gated on an ACTUAL basic-auth field
+    // being submitted — a projects-only save (see `oauth_connected` above) must
+    // not delete the very OAuth session it's riding on.
+    let is_basic_auth_submit = updates.contains_key("JIRA_BASE_URL")
+        || updates.contains_key("JIRA_EMAIL")
+        || updates.contains_key("JIRA_API_TOKEN");
+    if provider == "jira" && is_basic_auth_submit {
         if let Some(home) = home() {
             let _ = std::fs::remove_file(home.join(".meridian/oauth/jira.json"));
         }
@@ -882,6 +930,162 @@ pub async fn discover_github_projects() -> Result<GithubDiscoverResponse, String
     let projects = flatten_github_projects(&body);
     tracing::info!(count = projects.len(), "github projects discovered");
     Ok(GithubDiscoverResponse { projects })
+}
+
+/// One Jira project, returned by [`discover_jira_projects`].
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraProjectOption {
+    /// Numeric Jira project id — informational only; `JIRA_PROJECT_KEYS` stores
+    /// [`Self::key`], the identifier the JQL in
+    /// `src/intelligence/providers/jira/fetch.rs` and every other Jira read path
+    /// key off.
+    pub id: String,
+    pub key: String,
+    pub name: String,
+}
+
+/// `{ projects }` — mirrors [`GithubDiscoverResponse`].
+#[derive(Debug, Serialize)]
+pub struct JiraDiscoverResponse {
+    pub projects: Vec<JiraProjectOption>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Deserialize)]
+struct JiraProjectSearchPage {
+    values: Vec<JiraProjectSearchItem>,
+    /// Defensively defaults to `true` (stop paginating) rather than `false` — a
+    /// response shape Jira changed out from under this parser should fail safe
+    /// by returning what it got, not loop forever re-requesting the same page.
+    #[serde(rename = "isLast", default = "default_true")]
+    is_last: bool,
+}
+
+#[derive(Deserialize)]
+struct JiraProjectSearchItem {
+    id: String,
+    key: String,
+    name: String,
+}
+
+/// Parse one `/rest/api/3/project/search` page into `(projects, is_last)`. Pure
+/// function so pagination termination is unit-testable against hand-built
+/// fixtures without a live Jira site. An unparseable body (e.g. an error page
+/// serialised as JSON) reports zero projects and `is_last = true` so the caller
+/// stops rather than looping.
+fn parse_jira_projects_page(body: &serde_json::Value) -> (Vec<JiraProjectOption>, bool) {
+    let page: JiraProjectSearchPage = match serde_json::from_value(body.clone()) {
+        Ok(p) => p,
+        Err(_) => return (Vec::new(), true),
+    };
+    let projects = page
+        .values
+        .into_iter()
+        .map(|v| JiraProjectOption {
+            id: v.id,
+            key: v.key,
+            name: v.name,
+        })
+        .collect();
+    (projects, page.is_last)
+}
+
+/// Resolve a [`meridian_oauth::jira::JiraReqCtx`] for Jira discovery, tray-side.
+/// Mirrors the daemon's `src/intelligence/oauth/jira::resolve` (API token beats
+/// a stored OAuth session — a set `JIRA_API_TOKEN` always wins) but reads
+/// `.env` directly rather than depending on the daemon's `JiraConfig`, the same
+/// crate-boundary reason [`discover_github_projects`] reads `GITHUB_TOKEN`
+/// directly instead of calling into daemon code.
+async fn resolve_jira_ctx() -> Result<meridian_oauth::jira::JiraReqCtx, String> {
+    let mode = crate::install::detect_install_mode();
+    let env = mode.env_path().map(parse_env).unwrap_or_default();
+    let has_basic = is_set(&env, "JIRA_BASE_URL")
+        && is_set(&env, "JIRA_EMAIL")
+        && is_set(&env, "JIRA_API_TOKEN");
+    if has_basic {
+        return Ok(meridian_oauth::jira::JiraReqCtx::Basic {
+            base_url: env.get("JIRA_BASE_URL").cloned().unwrap_or_default(),
+            email: env.get("JIRA_EMAIL").cloned().unwrap_or_default(),
+            api_token: env.get("JIRA_API_TOKEN").cloned().unwrap_or_default(),
+        });
+    }
+    if oauth_file_exists("jira") {
+        let tokens = meridian_oauth::jira::ensure_fresh()
+            .await
+            .map_err(|e| format!("Could not refresh Jira session: {e}"))?;
+        return Ok(meridian_oauth::jira::JiraReqCtx::OAuth {
+            token: tokens.access_token,
+            cloud_id: tokens.cloud_id,
+            site_url: tokens.site_url,
+        });
+    }
+    Err("Jira is not connected yet".to_string())
+}
+
+/// List the Jira projects the connected account/site can see (the Jira
+/// analogue of [`discover_github_projects`]) — works under EITHER auth mode,
+/// API token or browser OAuth, via [`resolve_jira_ctx`]. Paginates
+/// `/rest/api/3/project/search` (50/page) until Jira reports `isLast`, so a
+/// site with more than one page of projects isn't silently truncated the way a
+/// single-call discovery would be.
+///
+/// # Who calls this
+/// `ui/components/IntegrationConnect.tsx`'s `JiraProjectPicker`, both right
+/// after a Jira connect (OAuth or token) succeeds and from the "connected but
+/// no projects selected" prompt in `ConnectedPanel` — mirrors
+/// [`discover_github_projects`]'s two entry points.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn discover_jira_projects() -> Result<JiraDiscoverResponse, String> {
+    let ctx = resolve_jira_ctx().await?;
+    let client = reqwest::Client::new();
+
+    const PAGE_SIZE: u64 = 50;
+    let mut projects = Vec::new();
+    let mut start_at: u64 = 0;
+    loop {
+        let url = ctx.api_url("/rest/api/3/project/search");
+        let resp = ctx
+            .apply(client.get(&url))
+            .query(&[
+                ("startAt", start_at.to_string()),
+                ("maxResults", PAGE_SIZE.to_string()),
+            ])
+            .timeout(Duration::from_secs(15))
+            .send()
+            .instrument(tracing::debug_span!("integrations.jira.projects", start_at))
+            .await
+            .map_err(|e| format!("Could not reach Jira: {e}"))?;
+
+        let status = resp.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+            return Err(
+                "Jira credentials invalid or missing project access — reconnect Jira".to_string(),
+            );
+        }
+        if !status.is_success() {
+            return Err(format!("Jira returned HTTP {status}"));
+        }
+
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("Could not parse Jira response: {e}"))?;
+        let (mut page, is_last) = parse_jira_projects_page(&body);
+        let page_len = page.len() as u64;
+        projects.append(&mut page);
+        if is_last || page_len == 0 {
+            break;
+        }
+        start_at += page_len;
+    }
+
+    projects.sort_unstable_by(|a, b| a.name.cmp(&b.name));
+    tracing::info!(count = projects.len(), "jira projects discovered");
+    Ok(JiraDiscoverResponse { projects })
 }
 
 /// POST body for [`start_oauth`] (`{ provider }`).
@@ -1306,6 +1510,7 @@ mod tests {
             "github",
             &updates(&[("GITHUB_PROJECT_IDS", "PVT_1,PVT_2")]),
             &env_of(&[("GITHUB_TOKEN", "gho_live_token")]),
+            false,
         );
         assert!(
             missing.is_empty(),
@@ -1321,6 +1526,7 @@ mod tests {
             "github",
             &updates(&[("GITHUB_PROJECT_IDS", "PVT_1")]),
             &env_of(&[]),
+            false,
         );
         assert_eq!(missing, vec!["GITHUB_TOKEN"]);
     }
@@ -1334,6 +1540,7 @@ mod tests {
             "github",
             &updates(&[("GITHUB_PROJECT_IDS", "PVT_1")]),
             &env_of(&[("GITHUB_TOKEN", "your-token-here")]),
+            false,
         );
         assert_eq!(missing, vec!["GITHUB_TOKEN"]);
     }
@@ -1349,6 +1556,7 @@ mod tests {
             "github",
             &updates(&[("GITHUB_TOKEN", "your-token-here")]),
             &env_of(&[]),
+            false,
         );
         assert_eq!(missing, vec!["GITHUB_TOKEN"]);
     }
@@ -1365,6 +1573,7 @@ mod tests {
             "github",
             &updates(&[("GITHUB_TOKEN", "your-token-here")]),
             &env_of(&[("GITHUB_TOKEN", "ghp_valid_and_working")]),
+            false,
         );
         assert_eq!(missing, vec!["GITHUB_TOKEN"]);
     }
@@ -1377,6 +1586,7 @@ mod tests {
             "github",
             &updates(&[("GITHUB_TOKEN", "ghp_fresh")]),
             &env_of(&[]),
+            false,
         );
         assert!(missing.is_empty());
     }
@@ -1387,7 +1597,12 @@ mod tests {
     #[test]
     fn jira_reports_every_unset_key_and_accepts_a_partial_edit() {
         assert_eq!(
-            missing_required("jira", &updates(&[("JIRA_EMAIL", "a@b.c")]), &env_of(&[])),
+            missing_required(
+                "jira",
+                &updates(&[("JIRA_EMAIL", "a@b.c")]),
+                &env_of(&[]),
+                false
+            ),
             vec!["JIRA_BASE_URL", "JIRA_API_TOKEN"]
         );
         assert!(missing_required(
@@ -1397,15 +1612,93 @@ mod tests {
                 ("JIRA_BASE_URL", "https://x.atlassian.net"),
                 ("JIRA_API_TOKEN", "ATATT3x"),
             ]),
+            false,
         )
         .is_empty());
+    }
+
+    /// The Jira analogue of the GitHub project-ids-alone test above, but for a
+    /// browser-OAuth session rather than a token in `.env`: a projects-only save
+    /// (no basic-auth fields in the payload) must be accepted once OAuth is
+    /// connected, even though NONE of the three basic-auth keys are set anywhere.
+    #[test]
+    fn jira_project_keys_alone_are_enough_when_oauth_is_connected() {
+        let missing = missing_required(
+            "jira",
+            &updates(&[("JIRA_PROJECT_KEYS", "KAN,ENG")]),
+            &env_of(&[]),
+            true,
+        );
+        assert!(
+            missing.is_empty(),
+            "an OAuth session must satisfy the requirement for a projects-only save, got {missing:?}"
+        );
+    }
+
+    /// The guard for the above: with no OAuth session AND no basic auth anywhere,
+    /// a projects-only save must still be refused.
+    #[test]
+    fn jira_project_keys_alone_still_fail_with_no_auth_anywhere() {
+        let missing = missing_required(
+            "jira",
+            &updates(&[("JIRA_PROJECT_KEYS", "KAN")]),
+            &env_of(&[]),
+            false,
+        );
+        assert_eq!(
+            missing,
+            vec!["JIRA_BASE_URL", "JIRA_EMAIL", "JIRA_API_TOKEN"]
+        );
+    }
+
+    /// A real (re)connect attempt — the payload includes a basic-auth field —
+    /// must still be validated normally even when a stale OAuth session exists;
+    /// `oauth_connected` only excuses a PURE projects-only submit.
+    #[test]
+    fn jira_basic_auth_submit_is_still_validated_even_when_oauth_connected() {
+        let missing = missing_required(
+            "jira",
+            &updates(&[("JIRA_EMAIL", "a@b.c")]),
+            &env_of(&[]),
+            true,
+        );
+        assert_eq!(missing, vec!["JIRA_BASE_URL", "JIRA_API_TOKEN"]);
     }
 
     /// A provider with no required entry (trello: its app key is baked in for
     /// production builds) is unconstrained.
     #[test]
     fn a_provider_with_no_required_keys_is_unconstrained() {
-        assert!(missing_required("trello", &updates(&[]), &env_of(&[])).is_empty());
+        assert!(missing_required("trello", &updates(&[]), &env_of(&[]), false).is_empty());
+    }
+
+    /// [`parse_jira_projects_page`] pulls id/key/name from `values[]` and passes
+    /// `isLast` through verbatim — this is the pagination termination signal
+    /// [`discover_jira_projects`] loops on.
+    #[test]
+    fn parse_jira_projects_page_reads_values_and_is_last() {
+        let body = serde_json::json!({
+            "values": [
+                {"id": "10001", "key": "KAN", "name": "Kanban Project"},
+                {"id": "10002", "key": "ENG", "name": "Engineering"},
+            ],
+            "isLast": false,
+        });
+        let (projects, is_last) = parse_jira_projects_page(&body);
+        assert_eq!(projects.len(), 2);
+        assert_eq!(projects[0].key, "KAN");
+        assert_eq!(projects[1].name, "Engineering");
+        assert!(!is_last);
+    }
+
+    /// A body that doesn't match the expected shape (e.g. an unexpected error
+    /// page) must stop pagination rather than looping — `is_last` defaults to
+    /// `true` and no projects are returned.
+    #[test]
+    fn parse_jira_projects_page_fails_safe_on_unparseable_body() {
+        let (projects, is_last) = parse_jira_projects_page(&serde_json::json!({"unexpected": 1}));
+        assert!(projects.is_empty());
+        assert!(is_last);
     }
 
     #[test]

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -546,6 +546,7 @@ pub fn run() {
             commands::disconnect_integration,
             commands::discover_azure_devops,
             commands::discover_github_projects,
+            commands::discover_jira_projects,
             commands::save_integration_token,
             commands::start_oauth,
             commands::cancel_oauth,

--- a/ui/__tests__/github-connect-flow.test.ts
+++ b/ui/__tests__/github-connect-flow.test.ts
@@ -130,11 +130,15 @@ describe('the project picker appears as the next step, not a separate screen', (
 // ── PAT flow → project picker wiring (IntegrationConnect.tsx) ─────────────────
 describe('PAT flow shows the project picker after save', () => {
   it('renders GitHubProjectPicker in TokenSetup for github once the token is saved', () => {
-    expect(view).toMatch(/if \(tracker\.id === 'github'\) \{[\s\S]*?<GitHubProjectPicker onSuccess=\{onSuccess\} \/>/)
+    // Jira shares this done-branch (its token/OAuth connect also needs a
+    // project picked), so the github check is now one arm of an || rather
+    // than a standalone condition — the GitHubProjectPicker render itself is
+    // unchanged.
+    expect(view).toMatch(/if \(tracker\.id === 'github' \|\| tracker\.id === 'jira'\) \{[\s\S]*?<GitHubProjectPicker onSuccess=\{onSuccess\} \/>/)
   })
 
   it('defers onSuccess for github so the picker is not unmounted before a board is picked', () => {
-    expect(view).toMatch(/if \(tracker\.id !== 'github'\) onSuccess\?\.\(\)/)
+    expect(view).toMatch(/if \(tracker\.id !== 'github' && tracker\.id !== 'jira'\) onSuccess\?\.\(\)/)
   })
 })
 

--- a/ui/__tests__/jira-project-picker.test.ts
+++ b/ui/__tests__/jira-project-picker.test.ts
@@ -1,0 +1,103 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+
+// Guards for the Jira project picker (feat/jira-project-picker): pulls every
+// Jira project the connected account/site can see (via EITHER auth mode —
+// browser OAuth or API token) and lets the user multi-select which ones sync,
+// mirroring the GitHub Projects v2 picker (see github-connect-flow.test.ts).
+//
+// The repo has no React render harness (see oauth-setup-lifecycle.test.ts), so
+// component behaviour is asserted by scanning the source for the required shape.
+
+const uiRoot = import.meta.dir + '/..'
+const view = readFileSync(uiRoot + '/components/IntegrationConnect.tsx', 'utf8')
+const rustCmd = readFileSync(uiRoot + '/../tray/src-tauri/src/commands/integrations.rs', 'utf8')
+const store = readFileSync(uiRoot + '/components/integrationConnectStore.ts', 'utf8')
+
+// ── Backend: discovery works under either auth mode ──────────────────────────
+describe('discover_jira_projects resolves either auth mode', () => {
+  it('tries API-token basic auth first, then falls back to a stored OAuth session', () => {
+    expect(rustCmd).toContain('async fn resolve_jira_ctx()')
+    expect(rustCmd).toMatch(/has_basic[\s\S]*?JiraReqCtx::Basic/)
+    expect(rustCmd).toContain('oauth_file_exists("jira")')
+    expect(rustCmd).toContain('meridian_oauth::jira::ensure_fresh()')
+  })
+
+  it('paginates /rest/api/3/project/search until Jira reports isLast', () => {
+    expect(rustCmd).toContain('"/rest/api/3/project/search"')
+    expect(rustCmd).toMatch(/if is_last \|\| page_len == 0 \{\s*break;\s*\}/)
+  })
+
+  it('is registered as a tauri command the UI can invoke', () => {
+    expect(rustCmd).toContain('pub async fn discover_jira_projects()')
+  })
+})
+
+// ── Backend: a projects-only save must not require basic-auth fields ─────────
+describe('save_integration_token accepts a projects-only save under OAuth', () => {
+  it('bypasses the basic-auth required check when OAuth is connected and no basic field is submitted', () => {
+    expect(rustCmd).toMatch(
+      /if provider == "jira" && oauth_connected && !required\.iter\(\)\.any\(\|k\| updates\.contains_key\(\*k\)\)\s*\{\s*return Vec::new\(\)/
+    )
+  })
+
+  it('still validates a real (re)connect attempt even when OAuth already exists', () => {
+    // oauth_connected only excuses a PURE projects-only submit — a payload that
+    // includes a basic-auth field must still go through the normal filter below.
+    expect(rustCmd).toMatch(/oauth_connected[\s\S]{0,400}required\s*\.iter\(\)\s*\.copied\(\)\s*\.filter/)
+  })
+
+  it('keeps project_keys → JIRA_PROJECT_KEYS in TOKEN_FIELD_MAP', () => {
+    expect(rustCmd).toContain('("project_keys", "JIRA_PROJECT_KEYS")')
+  })
+
+  it('strips JIRA_PROJECT_KEYS on disconnect alongside the other jira keys', () => {
+    expect(rustCmd).toMatch(/"jira",\s*&\[\s*"JIRA_BASE_URL",\s*"JIRA_EMAIL",\s*"JIRA_API_TOKEN",\s*"JIRA_PROJECT_KEYS",/)
+  })
+
+  it('does not delete a live OAuth session on a projects-only submit', () => {
+    // Regression guard: an earlier version of this gate deleted jira.json for
+    // ANY jira save, which would destroy the very OAuth session a
+    // projects-only submit rides on.
+    expect(rustCmd).toMatch(/is_basic_auth_submit[\s\S]{0,200}if provider == "jira" && is_basic_auth_submit/)
+  })
+})
+
+// ── Frontend: the picker appears at every entry point ─────────────────────────
+describe('JiraProjectPicker is wired into every Jira connect path', () => {
+  it('renders after a browser-OAuth connect completes', () => {
+    expect(view).toMatch(/status === 'done'[\s\S]*?tracker\.id === 'jira'[\s\S]*?<JiraProjectPicker onSuccess=\{onSuccess\} \/>/)
+  })
+
+  it('renders after an API-token connect completes', () => {
+    expect(view).toMatch(/tracker\.id === 'github' \|\| tracker\.id === 'jira'[\s\S]*?<JiraProjectPicker onSuccess=\{onSuccess\} \/>/)
+  })
+
+  it('renders from the "no projects selected" nudge in ConnectedPanel', () => {
+    expect(view).toContain('No Jira projects selected - tasks won&apos;t sync yet.')
+    expect(view).toMatch(/needsJiraProjects[\s\S]*?setPickingProjects\(true\)/)
+  })
+
+  it('defers onSuccess for jira exactly like github, in both OAuth and token flows', () => {
+    expect(view).toMatch(/if \(status === 'done' && tracker\.id !== 'github' && tracker\.id !== 'jira'\) onSuccess\?\.\(\)/)
+    expect(view).toMatch(/if \(tracker\.id !== 'github' && tracker\.id !== 'jira'\) onSuccess\?\.\(\)/)
+  })
+})
+
+// ── Store: same retry-safety guard as the GitHub picker ──────────────────────
+describe('jiraEnsureLoaded allows retrying after a failed discovery', () => {
+  it('does not skip a re-fetch when the last attempt ended in loadError', () => {
+    // Same bug class githubEnsureLoaded guards against: a failed discovery
+    // must not latch permanently and block every later connect attempt.
+    expect(store).toMatch(/export function jiraEnsureLoaded\(\): void \{\s*const s = jpGet\(\)\s*if \(\(s\.loaded && !s\.loadError\) \|\| s\.saving\) return/)
+  })
+})
+
+// ── Store: the save submits project KEYS, not numeric ids ────────────────────
+describe('jiraSave submits project keys', () => {
+  it('maps the selected ids back to their keys before saving', () => {
+    expect(store).toMatch(/const keys = \(projects \?\? \[\]\)\.filter\(\(p\) => selected\.has\(p\.id\)\)\.map\(\(p\) => p\.key\)/)
+    expect(store).toContain('fields: { project_keys: keys.join(\',\') }')
+  })
+})

--- a/ui/__tests__/tasks-provider-filter.test.ts
+++ b/ui/__tests__/tasks-provider-filter.test.ts
@@ -9,6 +9,7 @@ const task = (provider: string, today_s = 0) => ({ provider, today_s })
 const ALL_DISCONNECTED: IntegrationsResponse = {
   jira: false, linear: false, github: false, trello: false, azure_devops: false,
   github_projects_selected: false,
+  jira_projects_selected: false,
   sync_errors: {},
 }
 
@@ -26,6 +27,7 @@ const JIRA_AND_LINEAR: IntegrationsResponse = {
 const ALL_CONNECTED: IntegrationsResponse = {
   jira: true, linear: true, github: true, trello: true, azure_devops: true,
   github_projects_selected: true,
+  jira_projects_selected: true,
   sync_errors: {},
 }
 

--- a/ui/__tests__/toolbar-connected-pill.test.ts
+++ b/ui/__tests__/toolbar-connected-pill.test.ts
@@ -29,6 +29,7 @@ const integrations = (on: TrackerId[]): IntegrationsResponse => ({
   trello: on.includes('trello'),
   azure_devops: on.includes('azure_devops'),
   github_projects_selected: false,
+  jira_projects_selected: false,
   sync_errors: {},
 })
 

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -26,8 +26,9 @@ import {
   azureStore, azureLookupOrgs, azureSelectOrg, azureSubmitManualOrg, azureConnect,
   setAzurePat, setAzureSelectedProject, setAzureManualOrg, resetAzureIfSettled,
   githubPickerStore, githubEnsureLoaded, githubToggle, githubSave, resetGithubPickerIfSaved,
+  jiraPickerStore, jiraEnsureLoaded, jiraToggle, jiraSave, resetJiraPickerIfSaved,
 } from '@/components/integrationConnectStore'
-import type { GithubProject } from '@/components/integrationConnectStore'
+import type { GithubProject, JiraProject } from '@/components/integrationConnectStore'
 
 // ── Main list ─────────────────────────────────────────────────────────────────
 export default function ConnectTrackers({
@@ -93,7 +94,8 @@ export default function ConnectTrackers({
               {isOpen && connected && (
                 <ConnectedPanel tracker={t} syncError={syncError} disconnecting={disconnecting === t.id}
                   onDisconnect={() => handleDisconnect(t.id)} onChanged={onChanged}
-                  githubProjectsSelected={integrations?.github_projects_selected} />
+                  githubProjectsSelected={integrations?.github_projects_selected}
+                  jiraProjectsSelected={integrations?.jira_projects_selected} />
               )}
               {isOpen && !connected && <TrackerSetup tracker={t} onSuccess={onChanged} />}
             </div>
@@ -106,11 +108,13 @@ export default function ConnectTrackers({
 
 // ── Connected (manage / disconnect / re-authorize) ───────────────────────────
 function ConnectedPanel({
-  tracker, syncError, disconnecting, onDisconnect, onChanged, githubProjectsSelected,
+  tracker, syncError, disconnecting, onDisconnect, onChanged, githubProjectsSelected, jiraProjectsSelected,
 }: {
   tracker: Tracker; syncError?: string; disconnecting: boolean; onDisconnect: () => void; onChanged?: () => void
   /** Only meaningful for tracker.id === 'github' — undefined for every other tracker. */
   githubProjectsSelected?: boolean
+  /** Only meaningful for tracker.id === 'jira' — undefined for every other tracker. */
+  jiraProjectsSelected?: boolean
 }) {
   const [reauthorizing, setReauthorizing] = useState(false)
   const [pickingProjects, setPickingProjects] = useState(false)
@@ -121,6 +125,10 @@ function ConnectedPanel({
   // exactly the gap a token connected outside the OAuth-connect picker (or an
   // account connected before this picker existed) is stuck in.
   const needsGithubProjects = tracker.id === 'github' && githubProjectsSelected === false
+  // Jira's analogue — a connection (OAuth OR API token) alone doesn't sync
+  // anything either; a project must be picked too (discover_jira_projects →
+  // save_integration_token).
+  const needsJiraProjects = tracker.id === 'jira' && jiraProjectsSelected === false
 
   return (
     <div className="px-4 pb-4 pt-2" style={{ background: 'var(--t-box)' }}>
@@ -146,9 +154,22 @@ function ConnectedPanel({
           </button>
         </div>
       )}
+      {needsJiraProjects && !reauthorizing && !pickingProjects && (
+        <div className="mb-3 rounded-md px-3 py-2" style={{ background: 'var(--status-info-bg)', border: '1px solid var(--status-info-border)' }}>
+          <p className="text-[12px] leading-relaxed" style={{ color: 'var(--status-info-text)' }}>
+            No Jira projects selected - tasks won&apos;t sync yet.
+          </p>
+          <button onClick={() => setPickingProjects(true)} className="mt-2 text-[11px] px-3 py-1 rounded-md"
+            style={{ background: 'var(--status-info-text)', color: '#fff', cursor: 'pointer' }}>
+            Select Projects
+          </button>
+        </div>
+      )}
       {pickingProjects ? (
         <div className="mb-1">
-          <GitHubProjectPicker onSuccess={() => { setPickingProjects(false); onChanged?.() }} />
+          {tracker.id === 'github'
+            ? <GitHubProjectPicker onSuccess={() => { setPickingProjects(false); onChanged?.() }} />
+            : <JiraProjectPicker onSuccess={() => { setPickingProjects(false); onChanged?.() }} />}
           <button onClick={() => setPickingProjects(false)} className="mt-2 text-[11px]" style={{ color: 'var(--ink-4)', cursor: 'pointer' }}>Cancel</button>
         </div>
       ) : reauthorizing ? (
@@ -400,13 +421,14 @@ function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
   // touch a 'waiting' one, which is the in-flight state we exist to preserve.
   useEffect(() => { resetOAuthIfSettled(tracker.id) }, [tracker.id])
 
-  // Fire onSuccess when the flow completes. GitHub defers this to its Projects
-  // picker (rendered below for status==='done'), which calls onSuccess once a
-  // board is actually saved. Every other provider is done the moment its store
-  // exists. The store poll sets 'done' whether or not this panel is mounted; if
-  // it isn't, reopening reloads integrations anyway, so nothing is missed.
+  // Fire onSuccess when the flow completes. GitHub and Jira both defer this to
+  // their Projects pickers (rendered below for status==='done'), which call
+  // onSuccess once a project is actually saved. Every other provider is done
+  // the moment its store exists. The store poll sets 'done' whether or not
+  // this panel is mounted; if it isn't, reopening reloads integrations anyway,
+  // so nothing is missed.
   useEffect(() => {
-    if (status === 'done' && tracker.id !== 'github') onSuccess?.()
+    if (status === 'done' && tracker.id !== 'github' && tracker.id !== 'jira') onSuccess?.()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status, tracker.id])
 
@@ -546,7 +568,14 @@ function OAuthSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
               </DeviceStep>
             </div>
           )
-          : <p className="text-[12px]" style={{ color: 'var(--color-state-approved)' }}>✓ Connected! Your tasks will appear shortly.</p>
+          : tracker.id === 'jira'
+            ? (
+              <div className="space-y-2">
+                <p className="text-[12px]" style={{ color: 'var(--color-state-approved)' }}>✓ Connected! Choose which projects to sync:</p>
+                <JiraProjectPicker onSuccess={onSuccess} />
+              </div>
+            )
+            : <p className="text-[12px]" style={{ color: 'var(--color-state-approved)' }}>✓ Connected! Your tasks will appear shortly.</p>
       )}
       {status === 'error' && (
         <div className="space-y-2">
@@ -585,7 +614,7 @@ function TokenSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
       // now would reload integrations, flip the row to "connected", and unmount
       // this panel — tearing the picker away before the user picks. Mirrors
       // OAuthSetup's github handling. Every other provider is done on save.
-      if (tracker.id !== 'github') onSuccess?.()
+      if (tracker.id !== 'github' && tracker.id !== 'jira') onSuccess?.()
     } catch (e) {
       setError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Could not save credentials')
     } finally {
@@ -594,13 +623,15 @@ function TokenSetup({ tracker, onSuccess }: { tracker: Tracker; onSuccess?: () =
   }
 
   if (done) {
-    // GitHub: the token alone doesn't sync anything — a Projects v2 board must be
+    // GitHub/Jira: the token alone doesn't sync anything — a project must be
     // selected too. Show the same discover-and-tick picker the browser OAuth flow
-    // uses (discover_github_projects → save_integration_token with project_ids).
-    if (tracker.id === 'github') {
+    // uses (discover_github_projects / discover_jira_projects → save_integration_token).
+    if (tracker.id === 'github' || tracker.id === 'jira') {
       return (
         <div className="px-4 pb-4 pt-2" style={{ background: 'var(--t-box)' }}>
-          <GitHubProjectPicker onSuccess={onSuccess} />
+          {tracker.id === 'github'
+            ? <GitHubProjectPicker onSuccess={onSuccess} />
+            : <JiraProjectPicker onSuccess={onSuccess} />}
           {reloadWarning && (
             <p className="text-[11px] mt-2" style={{ color: 'var(--t-faint)' }}>
               The daemon wasn&apos;t running - credentials saved, will take effect on next start.
@@ -847,6 +878,68 @@ function GitHubProjectPicker({ onSuccess }: { onSuccess?: () => void }) {
       </div>
       {saveError && <p className="text-[11px]" style={{ color: 'var(--status-error-text)' }}>{saveError}</p>}
       <button onClick={() => void githubSave()} disabled={selected.size === 0 || saving} className="text-[12px] px-4 py-2 rounded-md font-medium transition-opacity"
+        style={{ background: 'var(--accent)', color: '#fff', opacity: (selected.size === 0 || saving) ? 0.5 : 1, cursor: (selected.size === 0 || saving) ? 'not-allowed' : 'pointer' }}>
+        {saving ? 'Saving…' : selected.size === 0 ? 'Select a project' : `Sync ${selected.size} project${selected.size === 1 ? '' : 's'}`}
+      </button>
+      {reloadWarning && (
+        <p className="text-[11px]" style={{ color: 'var(--t-faint)' }}>
+          The daemon wasn&apos;t running — saved, will take effect on next start.
+        </p>
+      )}
+    </div>
+  )
+}
+
+// ── Jira project picker (discover_jira_projects → save_integration_token) ────
+// Runs right after a Jira connect succeeds — OAuth (OAuthSetup's status==='done'
+// branch) OR API token (TokenSetup's done branch) — AND from ConnectedPanel's
+// "no projects selected" prompt. Same component, three entry points, since the
+// underlying gap (connected, no project chosen) is identical across all of them.
+// A thin view over `jiraPickerStore` so the discovered project list and the
+// user's checkbox selection survive the panel unmounting. Flat list (no
+// owner grouping — a Jira site's projects have no GitHub-org analogue).
+function JiraProjectPicker({ onSuccess }: { onSuccess?: () => void }) {
+  const { projects, selected, loading, saving, loadError, saveError, reloadWarning, saved } = useConnectStore(jiraPickerStore, 'jira')
+
+  // Load once (store-guarded), and clear a completed save so reopening re-discovers.
+  useEffect(() => { resetJiraPickerIfSaved(); jiraEnsureLoaded() }, [])
+  useEffect(() => { if (saved) onSuccess?.(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [saved])
+
+  if (loading) return <p className="text-[11px]" style={{ color: 'var(--ink-3)' }}>Loading your Jira projects…</p>
+
+  if (loadError) return (
+    <div className="space-y-2">
+      <p className="text-[12px]" style={{ color: 'var(--status-error-text)' }}>{loadError}</p>
+      <button onClick={() => jiraEnsureLoaded()} className="text-[11px] px-3 py-1.5 rounded-md"
+        style={{ color: 'var(--color-state-proposal)', border: '1px solid var(--t-hair)', cursor: 'pointer', background: 'transparent' }}>
+        Retry
+      </button>
+    </div>
+  )
+
+  if (!projects || projects.length === 0) {
+    return (
+      <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-3)' }}>
+        No Jira projects found for this account.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-[12px] leading-relaxed" style={{ color: 'var(--ink-2)' }}>
+        Pick which Jira projects to sync tasks from.
+      </p>
+      <div className="space-y-1 max-h-48 overflow-y-auto">
+        {projects.map((p: JiraProject) => (
+          <label key={p.id} className="flex items-center gap-2 py-1 text-[12px]" style={{ color: 'var(--ink)' }}>
+            <input type="checkbox" checked={selected.has(p.id)} onChange={() => jiraToggle(p.id)} />
+            {p.name} <span style={{ color: 'var(--ink-4)' }}>({p.key})</span>
+          </label>
+        ))}
+      </div>
+      {saveError && <p className="text-[11px]" style={{ color: 'var(--status-error-text)' }}>{saveError}</p>}
+      <button onClick={() => void jiraSave()} disabled={selected.size === 0 || saving} className="text-[12px] px-4 py-2 rounded-md font-medium transition-opacity"
         style={{ background: 'var(--accent)', color: '#fff', opacity: (selected.size === 0 || saving) ? 0.5 : 1, cursor: (selected.size === 0 || saving) ? 'not-allowed' : 'pointer' }}>
         {saving ? 'Saving…' : selected.size === 0 ? 'Select a project' : `Sync ${selected.size} project${selected.size === 1 ? '' : 's'}`}
       </button>

--- a/ui/components/integrationConnectStore.ts
+++ b/ui/components/integrationConnectStore.ts
@@ -1,8 +1,8 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 //
-// Module-level state for the three long-running "connect a tracker" flows in
+// Module-level state for the long-running "connect a tracker" flows in
 // IntegrationConnect.tsx — browser/device OAuth, Azure DevOps (PAT → org →
-// project), and the GitHub Projects v2 picker.
+// project), the GitHub Projects v2 picker, and the Jira project picker.
 //
 // WHY A STORE INSTEAD OF useState IN THE COMPONENTS: each flow is rendered
 // inside an accordion row that unmounts the moment the user collapses it,
@@ -398,4 +398,85 @@ export async function githubSave(): Promise<void> {
  *  discover). Preserves an in-progress selection that hasn't been saved. */
 export function resetGithubPickerIfSaved(): void {
   if (ghGet().saved) githubPickerStore.set(GH_KEY, { ...GH_EMPTY })
+}
+
+// ── Jira project picker ───────────────────────────────────────────────────────
+// Mirrors the GitHub Projects v2 picker above, but for Jira's `/rest/api/3/project/search`
+// (works under EITHER auth mode — OAuth or API token — the tray command resolves
+// whichever is live). A flat list rather than `byOwner`-grouped: a Jira site's
+// projects have no owner grouping analogous to a GitHub org.
+
+export type JiraProject = { id: string; key: string; name: string }
+
+export interface JiraPickerState {
+  projects: JiraProject[] | null
+  selected: Set<string>
+  loading: boolean
+  saving: boolean
+  loaded: boolean
+  loadError: string | null
+  saveError: string | null
+  reloadWarning: boolean
+  saved: boolean
+}
+
+const JIRA_PICKER_EMPTY: JiraPickerState = Object.freeze({
+  projects: null,
+  selected: new Set<string>(),
+  loading: true,
+  saving: false,
+  loaded: false,
+  loadError: null,
+  saveError: null,
+  reloadWarning: false,
+  saved: false,
+})
+
+export const jiraPickerStore = createKeyedStore<JiraPickerState>(JIRA_PICKER_EMPTY)
+
+const JIRA_KEY = 'jira'
+const jpSet = (next: Partial<JiraPickerState>) => jiraPickerStore.set(JIRA_KEY, next)
+const jpGet = () => jiraPickerStore.get(JIRA_KEY)
+
+/** Load the project list once. No-op if already loaded (successfully) or a save
+ *  is in flight — but a PRIOR FAILURE must not block a retry, same reasoning as
+ *  [`githubEnsureLoaded`] (a stale error must not latch forever across a fresh
+ *  OAuth or token connect attempt). */
+export function jiraEnsureLoaded(): void {
+  const s = jpGet()
+  if ((s.loaded && !s.loadError) || s.saving) return
+  jpSet({ loading: true, loadError: null })
+  load<{ projects?: JiraProject[] }>('/api/integrations/jira/discover', 'discover_jira_projects')
+    .then((json) => jpSet({ projects: json.projects ?? [], loading: false, loaded: true }))
+    .catch((e) => jpSet({ loadError: errMsg(e, 'Failed to load Jira projects'), loading: false, loaded: true }))
+}
+
+export function jiraToggle(id: string): void {
+  const next = new Set(jpGet().selected)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  jpSet({ selected: next })
+}
+
+export async function jiraSave(): Promise<void> {
+  const { projects, selected, saving } = jpGet()
+  if (selected.size === 0 || saving) return
+  const keys = (projects ?? []).filter((p) => selected.has(p.id)).map((p) => p.key)
+  jpSet({ saving: true, saveError: null })
+  try {
+    const res = await mutate<{ ok: boolean; reloaded: boolean }>('/api/auth/token', 'save_integration_token', {
+      provider: JIRA_KEY,
+      fields: { project_keys: keys.join(',') },
+    })
+    jpSet({ reloadWarning: res?.reloaded === false, saving: false, saved: true })
+    clearProviderNotice(JIRA_KEY)
+  } catch (e) {
+    jpSet({ saveError: errMsg(e, 'Could not save project selection'), saving: false })
+  }
+}
+
+/** Reset the picker so reopening after a completed save starts fresh (a fresh
+ *  discover). Preserves an in-progress selection that hasn't been saved. */
+export function resetJiraPickerIfSaved(): void {
+  if (jpGet().saved) jiraPickerStore.set(JIRA_KEY, { ...JIRA_PICKER_EMPTY })
 }

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -442,6 +442,9 @@ export interface IntegrationsResponse {
   // true once GITHUB_PROJECT_IDS is set — github alone only means the OAuth
   // token exists; sync additionally needs at least one selected project.
   github_projects_selected: boolean
+  // true once JIRA_PROJECT_KEYS is set — jira alone means either auth mode is
+  // live; sync additionally needs at least one selected project.
+  jira_projects_selected: boolean
   sync_errors: Partial<Record<string, string>>
 }
 


### PR DESCRIPTION
## Summary
- Adds `discover_jira_projects` (tray command) that lists every Jira project the connected account/site can see via `/rest/api/3/project/search`, working under EITHER auth mode (browser OAuth or API token). Resolves a `JiraReqCtx` tray-side (mirrors `discover_github_projects` reading `.env` directly rather than depending on the daemon crate) and paginates until `isLast` so multi-page sites aren't truncated.
- Selected project keys are persisted as `JIRA_PROJECT_KEYS` (mirrors `GITHUB_PROJECT_IDS`), consumed by the existing daemon-side filter in `src/intelligence/providers/jira/mod.rs`.
- `save_integration_token`'s `missing_required` gains an `oauth_connected` bypass: a projects-only save (submitted after a browser-OAuth connect, which never populates `JIRA_BASE_URL`/`EMAIL`/`API_TOKEN`) is no longer rejected as "missing" fields it was never meant to have. A real (re)connect submission is still validated normally, and the projects-only save no longer deletes the live OAuth session it depends on (a bug the same PR would otherwise have introduced).
- UI: `JiraProjectPicker` mirrors `GitHubProjectPicker` (flat list, no owner grouping — Jira projects have no GitHub-org analogue), wired into all three entry points: post-OAuth-connect, post-token-connect, and the "no projects selected" nudge on an already-connected Jira.
- Windows/macOS: no platform-specific code — reqwest + loopback-TCP OAuth (already used by the existing Jira OAuth flow) works unchanged on both.

Verified the daemon-side filter and env parsing directly (not just via subagent research):
- `jira/mod.rs`: `if !jira.project_keys.is_empty() && !jira.project_keys.contains(&issue.fields.project.key) { continue; }` — an **empty** `JIRA_PROJECT_KEYS` means **sync everything**, so existing Jira connections are unaffected until a user opts into filtering.
- Filter matches on project **key** (what the picker persists), not id or name.
- `config.rs`'s `env_list` comma-splits/trims/filters-empty, compatible with the picker's `keys.join(',')`.

## Test plan
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings` (tray crate) — clean
- [x] `cargo test -p meridian-tray` — 28/28 pass, including new tests for `missing_required`'s OAuth bypass and `parse_jira_projects_page` pagination/fail-safe behavior
- [x] `bun test` (ui) — 348/348 pass, including a new `jira-project-picker.test.ts` pinning the wiring (backend resolve/pagination/gate, frontend entry points, store save-by-key)
- [x] `npm run build` (ui) — clean production build
- [x] Full pre-push suite (fmt + clippy + ui build/tests + security audit + `cargo test`) — all green
- [ ] Not manually exercised against a live Jira OAuth consent flow / real project list — verified via build, unit tests, and source-pinning tests only

🤖 Generated with [Claude Code](https://claude.com/claude-code)