### PR TITLE
fix(jira): surface correct remedy for OAuth vs API-token sync failures

### DIFF
--- a/src/intelligence/oauth/jira.rs
+++ b/src/intelligence/oauth/jira.rs
@@ -22,8 +22,10 @@ use crate::config::JiraConfig;
 pub use meridian_oauth::jira::*;
 
 /// True when all three Basic-auth fields are non-empty after trimming. Extracted
-/// so the eligibility check can be unit-tested without touching the OAuth store.
-fn has_basic_auth(jira: &JiraConfig) -> bool {
+/// so the eligibility check can be unit-tested without touching the OAuth store,
+/// and so callers outside this module (e.g. the sync-error remedy mapping in
+/// `providers::jira`) can tell which auth path a failure came from.
+pub(crate) fn has_basic_auth(jira: &JiraConfig) -> bool {
     !jira.base_url.trim().is_empty()
         && !jira.email.trim().is_empty()
         && !jira.api_token.trim().is_empty()

--- a/src/intelligence/providers/jira/mod.rs
+++ b/src/intelligence/providers/jira/mod.rs
@@ -458,7 +458,16 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
         Err(e) => {
             tracing::warn!(error = %e, "jira auth unavailable — keeping stale cache");
             let msg = format!("Jira auth failed — {e}");
-            let _ = super::stamp_sync_error(pool, "jira", &msg).await;
+            // Basic-auth (JIRA_API_TOKEN/JIRA_BASE_URL) and OAuth are mutually
+            // exclusive here — has_basic_auth() mirrors resolve()'s own choice —
+            // so the remedy must match whichever path this failure came from,
+            // not always point at the .env fields.
+            let remedy = if crate::intelligence::oauth::jira::has_basic_auth(jira) {
+                "Set JIRA_API_TOKEN and JIRA_BASE_URL in .env"
+            } else {
+                "Run: meridian oauth-login jira"
+            };
+            let _ = super::stamp_sync_error_with_remedy(pool, "jira", &msg, Some(remedy)).await;
             return Ok(None);
         }
     };

--- a/src/intelligence/providers/mod.rs
+++ b/src/intelligence/providers/mod.rs
@@ -15,6 +15,19 @@ use sqlx::SqlitePool;
 /// (for the connect-status indicators) and `system_notices` (for the global
 /// UI fault bus that surfaces banners on every page).
 pub async fn stamp_sync_error(pool: &SqlitePool, provider: &str, error: &str) -> Result<()> {
+    stamp_sync_error_with_remedy(pool, provider, error, None).await
+}
+
+/// Like [`stamp_sync_error`], but lets the caller override the default
+/// per-provider remedy text. Needed when a provider supports more than one
+/// auth method (e.g. Jira's static API token vs. OAuth) and the generic
+/// remedy would point at the wrong one — see `providers::jira::refresh_if_stale`.
+pub async fn stamp_sync_error_with_remedy(
+    pool: &SqlitePool,
+    provider: &str,
+    error: &str,
+    remedy_override: Option<&str>,
+) -> Result<()> {
     sqlx::query(
         "INSERT INTO pm_sync_state (provider, last_synced_at, last_error)
          VALUES (?, '1970-01-01T00:00:00Z', ?)
@@ -42,6 +55,7 @@ pub async fn stamp_sync_error(pool: &SqlitePool, provider: &str, error: &str) ->
         ),
         _ => ("PM sync failing", None),
     };
+    let remedy = remedy_override.or(remedy);
     let _ = crate::notices::raise(
         pool,
         &format!("pm.{provider}"),


### PR DESCRIPTION
## Summary
- `stamp_sync_error` always told users to set `JIRA_API_TOKEN`/`JIRA_BASE_URL` in `.env`, even when the failure came from the OAuth refresh path — a confusing/wrong remedy for OAuth users.
- Added `stamp_sync_error_with_remedy` so a caller can override the default per-provider remedy.
- `refresh_if_stale` in the Jira provider now checks `oauth::jira::has_basic_auth` (made `pub(crate)`) to determine which auth method is actually configured, and surfaces the matching fix: `Set JIRA_API_TOKEN and JIRA_BASE_URL in .env` for static-token users, `Run: meridian oauth-login jira` for OAuth users.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test --lib jira` (51 passed)
- [x] Full pre-push suite (fmt, ui build, ui tests, clippy, cargo test, security audit) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)