### PR TITLE
fix(capture): stop an a11y observer double-free crash on capture restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,8 +1310,8 @@ dependencies = [
 
 [[package]]
 name = "cidre"
-version = "0.15.2"
-source = "git+https://github.com/yury/cidre.git#623ddffa25a68696014e54a5f84916baedd953b9"
+version = "0.16.1"
+source = "git+https://github.com/yury/cidre.git#b3db4fd67a073a0be08f4d67327e7cdce42cc726"
 dependencies = [
  "cc",
  "cidre-macros 0.6.0",
@@ -2267,7 +2267,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.9",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -3963,7 +3963,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5588,7 +5588,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8047,7 +8047,7 @@ name = "sck-rs"
 version = "0.1.0"
 source = "git+https://github.com/screenpipe/sck-rs?rev=b7f48a1236b2339350baa1375a805c7ce32f88df#b7f48a1236b2339350baa1375a805c7ce32f88df"
 dependencies = [
- "cidre 0.15.2",
+ "cidre 0.16.1",
  "image",
  "once_cell",
  "thiserror 1.0.69",
@@ -8070,7 +8070,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "screenpipe-a11y"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8099,7 +8099,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-config"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8111,7 +8111,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-connect"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8150,7 +8150,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-core"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8190,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-db"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8216,7 +8216,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-events"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8233,7 +8233,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-screen"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8270,7 +8270,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-secrets"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8288,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-vault"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=064c44ccd8c50716f21eec1663e1350e848ca5f5#064c44ccd8c50716f21eec1663e1350e848ca5f5"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "argon2",
  "chacha20poly1305",
@@ -9924,7 +9924,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
+ "toml 0.9.12+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -106,13 +106,19 @@ meridian = { path = "../.." }
 # screen capture + Apple Vision OCR. Optional → only pulled by the `capture`
 # feature (heavy: ScreenCaptureKit/cidre/sck-rs). Private repo: local builds use
 # the user's git credentials; CI needs a deploy token (future).
-screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "064c44ccd8c50716f21eec1663e1350e848ca5f5", optional = true }
+screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "3c99154", optional = true }
 # Sibling crate in the same fork: the accessibility-tree walker (slice 3b).
 # `tree::create_tree_walker` walks the focused window's AX tree → structured
 # text — the PRIMARY signal for Electron/Chromium apps (VS Code, Slack), which
 # expose nothing to OCR-free a11y until the walker sets AXManualAccessibility
 # itself. Optional → only the `capture` feature pulls it.
-screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "064c44ccd8c50716f21eec1663e1350e848ca5f5", optional = true }
+#
+# rev 3c99154 fixes a double-free crash (BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
+# in run_app_observer's NotificationGuard teardown) that could fire when a new
+# recording session started before the outgoing one finished unregistering
+# its NSWorkspace observers. See `start_capture` in `../src/lib.rs` for the
+# matching caller-side fix (joining the old recorder thread before restart).
+screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "3c99154", optional = true }
 # Console log subscriber for capture-enabled non-otel runs (otel installs its
 # own). Makes the `capture: …` logs visible during a `cargo run --features capture`.
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -1002,6 +1002,18 @@ fn set_process_display_name(name: &str) {
 /// spawning fresh ones, so pausing then resuming is idempotent. Does nothing
 /// when Screen Recording is not granted (logs and returns).
 ///
+/// **Joins the previous UI-event recorder thread before spawning its
+/// replacement.** That thread's `run_app_observer` (screenpipe-a11y)
+/// registers `NotificationGuard`s on the shared `NSWorkspace` notification
+/// center and unregisters them on stop; spawning a new recorder while the
+/// old one is still mid-teardown puts two threads on that one shared
+/// singleton at once, which has produced a double-free abort
+/// (`BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED` under
+/// `removeObserver:`/`_Block_release`) in production. The join is bounded —
+/// the old thread only blocks on its own recorder's `handle.stop()`, at most
+/// a few hundred ms — and only runs on a restart (pause/resume, launch),
+/// never on the steady-state capture path.
+///
 /// # Who calls this
 /// Once from `lib.rs`'s `setup()` on launch, and again from
 /// `commands::pause_for_duration` on resume.
@@ -1057,11 +1069,18 @@ pub(crate) fn start_capture(
         s.capture_ignore.clone()
     };
 
-    // Drop any previous cancel senders — this signals the old tasks to exit.
-    {
+    // Drop any previous cancel senders — this signals the old tasks to exit —
+    // then join the old UI-event recorder thread so its screenpipe-a11y
+    // observer teardown fully completes before we spawn a replacement below
+    // (see this fn's doc comment for why that ordering matters).
+    let previous_ui_recorder_thread = {
         let mut s = app_state.lock().unwrap();
         drop(s.engine_cancel.take());
         drop(s.ui_consumer_cancel.take());
+        s.ui_recorder_thread.take()
+    };
+    if let Some(handle) = previous_ui_recorder_thread {
+        let _ = handle.join();
     }
 
     // Cancellation channels: dropping the Sender exits the receiving task.
@@ -1199,12 +1218,16 @@ pub(crate) fn start_capture(
             }
         }
     });
-    std::thread::spawn(move || capture::ui_events::run_ui_event_recorder(ui_tx));
+    let ui_recorder_thread =
+        std::thread::spawn(move || capture::ui_events::run_ui_event_recorder(ui_tx));
 
-    // Store senders in state; dropping them (on pause) cancels the tasks.
+    // Store senders + thread handle in state; dropping the senders (on pause)
+    // cancels the tasks, and the next start_capture joins the handle before
+    // spawning a replacement.
     let mut s = app_state.lock().unwrap();
     s.engine_cancel = Some(engine_cancel_tx);
     s.ui_consumer_cancel = Some(ui_cancel_tx);
+    s.ui_recorder_thread = Some(ui_recorder_thread);
     tracing::info!("capture: engine and ui recorder started");
 }
 

--- a/tray/src-tauri/src/state.rs
+++ b/tray/src-tauri/src/state.rs
@@ -166,6 +166,11 @@ pub struct AppState {
     /// Dropping this sender cancels the UI event consumer task, which causes the OS
     /// recorder thread to exit (it checks `tx.is_closed()` every 500ms).
     pub ui_consumer_cancel: Option<oneshot::Sender<()>>,
+    /// Handle to the OS thread running `capture::ui_events::run_ui_event_recorder`.
+    /// `start_capture` joins this before spawning a replacement — see its
+    /// doc comment for why a synchronous handoff here matters (a screenpipe-a11y
+    /// double-free otherwise reachable when two recorder generations overlap).
+    pub ui_recorder_thread: Option<std::thread::JoinHandle<()>>,
 }
 
 impl Default for AppState {
@@ -201,6 +206,7 @@ impl Default for AppState {
             last_menu_state: HealthStatus::Unknown,
             engine_cancel: None,
             ui_consumer_cancel: None,
+            ui_recorder_thread: None,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Root-caused 8 SIGABRT crash reports on shipped v1.74.0 (`BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED` inside `screenpipe_a11y::run_app_observer`'s `NotificationGuard` teardown, `removeObserver:` → `CFXNotificationRegistrarRemoveToken` → `_Block_release`).
- Cause: `start_capture` (`tray/src-tauri/src/lib.rs`) signalled the old UI-event recorder to stop and immediately spawned its replacement, without waiting for the old recorder's OS thread to actually exit. That thread only notices the stop signal on its own ~500ms poll, so for a window after every restart (pause/resume, launch) two threads held live `NotificationGuard`s against the same shared `NSWorkspace` notification center at once — racing its block-based observer teardown.
- Two-sided fix:
  - `Meridiona/screenpipe-fork` (pushed to `main`, rev `3c99154`): added a process-wide `WORKSPACE_OBSERVER_LOCK` held for the whole `run_app_observer` call, so at most one thread ever touches the shared center regardless of how a caller sequences start/stop. This repo's pinned `screenpipe-a11y`/`screenpipe-screen` rev is bumped to pick it up.
  - Here: `AppState` now keeps the UI-event recorder's `JoinHandle`; `start_capture` joins it before spawning the replacement, closing the race at the source rather than relying only on the fork's defense-in-depth lock.

## Test plan
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings` (capture feature) — clean
- [x] `cargo test --features capture` — 151 passed
- [x] Full pre-push suite (fmt + clippy + UI build/tests + security audit + cargo test) — all green
- [ ] Manual: exercise pause → resume repeatedly on Apple Silicon and confirm no crash reports over an extended session