### PR TITLE
chore(deps): bump screenpipe-fork license pin to 3c99154 (a11y double-free fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,13 @@ jobs:
           # authored, no upstream merge:
           #   552e7f8b adityaharishch  Merge pull request #2 (825b038d, already audited above)
           #   064c44cc Akarsh Hegde    fix(screen): disable sck-rs unconditionally, not just on macOS 26+
-          expected="064c44ccd8c50716f21eec1663e1350e848ca5f5"
+          #
+          # 2026-07-22, 064c44cc -> 3c99154. Two commits, all Meridiona-
+          # authored, no upstream merge (ae39b5f is a no-op merge wrapper —
+          # its tree is identical to 064c44cc, already audited above):
+          #   ae39b5f  Akarsh Hegde    Merge pull request #3 (064c44cc, already audited above)
+          #   3c99154  adityaharishch  fix(a11y): serialize workspace-observer registration to stop a double-free
+          expected="3c99154833b8087b1e215e5af748721096c46f01"
           f="tray/src-tauri/Cargo.toml"
           fail=0
           for crate in screenpipe-screen screenpipe-a11y; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,7 +2267,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -3963,7 +3963,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8070,7 +8070,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "screenpipe-a11y"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8099,7 +8099,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-config"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8111,7 +8111,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-connect"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8150,7 +8150,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-core"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8190,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-db"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8216,7 +8216,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-events"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8233,7 +8233,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-screen"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8270,7 +8270,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-secrets"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8288,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-vault"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -106,7 +106,7 @@ meridian = { path = "../.." }
 # screen capture + Apple Vision OCR. Optional → only pulled by the `capture`
 # feature (heavy: ScreenCaptureKit/cidre/sck-rs). Private repo: local builds use
 # the user's git credentials; CI needs a deploy token (future).
-screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "3c99154", optional = true }
+screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "3c99154833b8087b1e215e5af748721096c46f01", optional = true }
 # Sibling crate in the same fork: the accessibility-tree walker (slice 3b).
 # `tree::create_tree_walker` walks the focused window's AX tree → structured
 # text — the PRIMARY signal for Electron/Chromium apps (VS Code, Slack), which
@@ -118,7 +118,7 @@ screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev 
 # recording session started before the outgoing one finished unregistering
 # its NSWorkspace observers. See `start_capture` in `../src/lib.rs` for the
 # matching caller-side fix (joining the old recorder thread before restart).
-screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "3c99154", optional = true }
+screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "3c99154833b8087b1e215e5af748721096c46f01", optional = true }
 # Console log subscriber for capture-enabled non-otel runs (otel installs its
 # own). Makes the `capture: …` logs visible during a `cargo run --features capture`.
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }


### PR DESCRIPTION
## Summary
CI's screenpipe-license-pin guard blocked PR #552's rev bump (it hard-pins screenpipe-screen/screenpipe-a11y to the last MIT-based fork commit, since upstream screenpipe went Commercial-licensed at 0.4.17, and requires a manually-audited bump before the pin can move).

Audited via the exact command the guard prescribes (gh api repos/Meridiona/screenpipe-fork/compare/OLD...NEW --jq of commits). Two commits between the old and new pin, both Meridiona-authored, no upstream merge:
- ae39b5f Akarsh Hegde - merge commit for PR #3, tree-identical to 064c44cc (already audited) - a no-op wrapper
- 3c99154 adityaharishch - fix(a11y): serialize workspace-observer registration to stop a double-free (the crash fix from PR #552)

## Changes
- .github/workflows/ci.yml: bumps the guard's expected hash + records the audit trail, matching the format of the two prior entries.
- tray/src-tauri/Cargo.toml: both revs switched to the full 40-char SHA (the guard does an exact string compare against this field, so the short form used in #552 needed to match).
- Cargo.lock: refreshed via cargo update -p screenpipe-a11y -p screenpipe-screen.

## Test plan
- [x] Guard logic verified locally against the new Cargo.toml values - matches expected
- [x] Full pre-push suite (fmt + clippy + UI build/tests + security audit + cargo test) - all green
- [ ] CI screenpipe MIT pin job passes on this PR
