### PR TITLE
fix(uninstall): clear tray app caches and TCC grants on full uninstall

### DIFF
--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -13,8 +13,14 @@
 //! By default it removes only the **installed artifacts** (launchd agents, staged
 //! binaries, the install marker) and **keeps user data**. Three independent,
 //! additive flags widen the scope:
-//! - `--remove-data` — `~/.meridian`'s user data: db, credentials, settings,
-//!   logs, telemetry spool, icon cache, onboarded marker.
+//! - `--remove-data` — `~/.meridian`'s user data (db, credentials, settings,
+//!   logs, telemetry spool, icon cache, onboarded marker), plus (macOS only)
+//!   the OS-managed WebKit/AppKit caches for the tray's bundle id
+//!   (`com.meridiona.tray`'s `Application Support`/`Caches`/`WebKit`/
+//!   `Saved Application State`/`HTTPStorages`) and a best-effort `tccutil
+//!   reset` of the Accessibility/Screen Recording/Input Monitoring grants —
+//!   none of that lives under `~/.meridian` or the app bundle, so it would
+//!   otherwise survive every uninstall path, including this one, forever.
 //! - `--remove-runtime` — the downloaded Python + MLX runtime and any venvs.
 //! - `--remove-models` — Meridian's own MLX models from the shared HuggingFace
 //!   cache, allowlisted by exact directory name (never touches a model the user
@@ -181,7 +187,7 @@ impl Plan {
         .collect();
 
         let data = if flags.remove_data {
-            data_items(&meridian_dir)
+            data_items(&home)
         } else {
             Vec::new()
         };
@@ -352,6 +358,9 @@ fn run_human(plan: &Plan) {
     for f in &plan.data {
         remove_path_reporting(f);
     }
+    if flags.remove_data {
+        reset_tcc_grants();
+    }
     for f in &plan.runtime {
         remove_path_reporting(f);
     }
@@ -376,18 +385,52 @@ fn run_human(plan: &Plan) {
         "\nDone. If the Meridian menubar app is still running, quit it (or drag \
          Meridian.app to the Trash) - the MLX server is its child and exits with it."
     );
-    println!(
-        "\nNote: deleting or uninstalling does NOT revoke the Accessibility / \
-         Screen Recording / Input Monitoring grants in System Settings - macOS \
-         keeps that entry until you remove it there yourself."
-    );
+    if flags.remove_data {
+        println!(
+            "\nAlso attempted to reset the Accessibility / Screen Recording / Input \
+             Monitoring grants for Meridian in System Settings - macOS best-effort \
+             only, so double-check they're gone if it matters to you."
+        );
+    } else {
+        println!(
+            "\nNote: deleting or uninstalling does NOT revoke the Accessibility / \
+             Screen Recording / Input Monitoring grants in System Settings - macOS \
+             keeps that entry until you remove it there yourself (pass --remove-data \
+             or --purge to have this attempt it automatically)."
+        );
+    }
 }
 
-/// `~/.meridian` user-data items removed by `--remove-data`/`--purge`.
+/// Best-effort `tccutil reset` for every TCC service Meridian's tray
+/// (`com.meridiona.tray`) can be granted, so a full uninstall doesn't leave a
+/// grayed-out permission entry behind once the app is gone. Mirrors
+/// `tray/src-tauri/src/backend_install.rs::cleanup_legacy_a11y_helper`'s use of
+/// the same tool for the retired a11y-helper. Non-fatal: `tccutil` may be
+/// missing, sandboxed, or refuse without Full Disk Access, and none of that
+/// should abort the rest of the uninstall.
+#[cfg(target_os = "macos")]
+fn reset_tcc_grants() {
+    for service in ["Accessibility", "ScreenCapture", "ListenEvent"] {
+        let _ = std::process::Command::new("tccutil")
+            .args(["reset", service, "com.meridiona.tray"])
+            .output();
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn reset_tcc_grants() {}
+
+/// `~/.meridian` user-data items removed by `--remove-data`/`--purge`, plus (on
+/// macOS) the OS-managed app caches WebKit/AppKit create for the tray's bundle
+/// id (`com.meridiona.tray`) — `Application Support`, `Caches`, `WebKit`,
+/// `Saved Application State`, `HTTPStorages`. Dragging the app to the Trash
+/// never removes these (they live outside the bundle and outside
+/// `~/.meridian`), so without this they'd survive every uninstall path forever.
 /// Deliberately excludes the runtime/venv directories (tracked separately by
 /// [`runtime_items`]) so the wizard's checkboxes stay independent of each other.
-fn data_items(meridian: &Path) -> Vec<PathBuf> {
-    [
+fn data_items(home: &Path) -> Vec<PathBuf> {
+    let meridian = home.join(".meridian");
+    let mut items: Vec<PathBuf> = [
         ".env",
         "meridian.db",
         "meridian.db-shm",
@@ -403,7 +446,46 @@ fn data_items(meridian: &Path) -> Vec<PathBuf> {
     .iter()
     .map(|r| meridian.join(r))
     .filter(|p| p.symlink_metadata().is_ok())
-    .collect()
+    .collect();
+    items.extend(app_cache_items(home));
+    items
+}
+
+/// The tray's OS-managed WebKit/AppKit caches, keyed off its bundle id
+/// (`com.meridiona.tray`) — macOS creates these the first time the app runs,
+/// independent of anything Meridian's own code writes. No-op on non-macOS.
+fn app_cache_items(home: &Path) -> Vec<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        const BUNDLE_ID: &str = "com.meridiona.tray";
+        [
+            "Library/Application Support",
+            "Library/Caches",
+            "Library/WebKit",
+            "Library/Saved Application State",
+            "Library/HTTPStorages",
+        ]
+        .iter()
+        .map(|dir| home.join(dir).join(format!("{BUNDLE_ID}{}", suffix(dir))))
+        .filter(|p| p.symlink_metadata().is_ok())
+        .collect()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = home;
+        Vec::new()
+    }
+}
+
+/// `Saved Application State` suffixes the bundle id with `.savedState`; every
+/// other cache dir here is named exactly the bundle id.
+#[cfg(target_os = "macos")]
+fn suffix(dir: &str) -> &'static str {
+    if dir == "Library/Saved Application State" {
+        ".savedState"
+    } else {
+        ""
+    }
 }
 
 /// The downloaded Python + MLX runtime and venvs, removed by

--- a/src/uninstall/json.rs
+++ b/src/uninstall/json.rs
@@ -15,7 +15,7 @@
 //! - `tray/src-tauri/src/commands/uninstall.rs` — the only consumer of this
 //!   contract; keep [`JsonReport`]'s shape in sync with it.
 
-use super::{remove_path, uid_str, Item, Plan};
+use super::{remove_path, reset_tcc_grants, uid_str, Item, Plan};
 use serde::Serialize;
 
 /// The `--json` output shape — a full plan (dry-run) or a full result
@@ -101,6 +101,9 @@ pub(super) fn run_json(plan: &Plan) {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => report.errors.push(format!("{}: {e}", f.display())),
         }
+    }
+    if flags.remove_data {
+        reset_tcc_grants();
     }
     // `--purge` only: nuke anything left under ~/.meridian the itemized lists
     // above didn't name. Mirrors the human path's `--purge`-only gate — see the

--- a/src/uninstall/tests.rs
+++ b/src/uninstall/tests.rs
@@ -88,19 +88,21 @@ fn missing_launch_agents_dir_is_empty() {
 #[test]
 fn data_and_runtime_items_only_list_existing_entries_and_stay_disjoint() {
     let tmp = TempDir::new().unwrap();
-    let dir = tmp.path();
-    std::fs::write(dir.join(".env"), "x").unwrap();
-    std::fs::write(dir.join("meridian.db"), "x").unwrap();
-    std::fs::create_dir_all(dir.join("runtime")).unwrap();
+    let home = tmp.path();
+    let meridian = home.join(".meridian");
+    std::fs::create_dir_all(&meridian).unwrap();
+    std::fs::write(meridian.join(".env"), "x").unwrap();
+    std::fs::write(meridian.join("meridian.db"), "x").unwrap();
+    std::fs::create_dir_all(meridian.join("runtime")).unwrap();
     // "settings.json" and "mlx-server-venv" deliberately absent.
 
-    let data = data_items(dir);
-    let runtime = runtime_items(dir);
+    let data = data_items(home);
+    let runtime = runtime_items(&meridian);
 
-    assert!(data.contains(&dir.join(".env")));
-    assert!(data.contains(&dir.join("meridian.db")));
+    assert!(data.contains(&meridian.join(".env")));
+    assert!(data.contains(&meridian.join("meridian.db")));
     assert!(!data.iter().any(|p| p.ends_with("settings.json")));
-    assert!(runtime.contains(&dir.join("runtime")));
+    assert!(runtime.contains(&meridian.join("runtime")));
     assert!(!runtime.iter().any(|p| p.ends_with("mlx-server-venv")));
 
     for p in &data {
@@ -109,6 +111,25 @@ fn data_and_runtime_items_only_list_existing_entries_and_stay_disjoint() {
             "data and runtime item lists must be disjoint: {p:?}"
         );
     }
+}
+
+/// On macOS, `data_items` also picks up the tray's OS-managed WebKit/AppKit
+/// caches (keyed off `com.meridiona.tray`) when present, and ignores them when
+/// absent — mirrors the on-disk existence filter every other item list uses.
+#[cfg(target_os = "macos")]
+#[test]
+fn data_items_includes_app_caches_when_present() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path();
+    let cache = home.join("Library/Caches/com.meridiona.tray");
+    std::fs::create_dir_all(&cache).unwrap();
+    // Saved Application State deliberately absent — must not appear.
+
+    let data = data_items(home);
+    assert!(data.contains(&cache));
+    assert!(!data
+        .iter()
+        .any(|p| p.ends_with("com.meridiona.tray.savedState")));
 }
 
 /// `model_items` only returns catalog entries that exist on disk, and never


### PR DESCRIPTION
## Summary
- `meridian uninstall --remove-data`/`--purge` (and the in-app "Uninstall Meridian…" wizard's "Meridian data" checkbox, which shells out to the same code) now also removes the OS-managed WebKit/AppKit caches macOS creates for the tray's bundle id (`com.meridiona.tray`) — `Application Support`, `Caches`, `WebKit`, `Saved Application State`, `HTTPStorages`. None of these live under `~/.meridian` or the app bundle, so they previously survived every uninstall path.
- Also does a best-effort `tccutil reset` of the Accessibility / Screen Recording / Input Monitoring grants when data is removed, mirroring the existing pattern used for the retired a11y-helper agent.
- Updated the CLI's trailing message to reflect that permissions are now attempted automatically rather than claiming they're never touched.

Dragging `Meridian.app` straight to the Trash still can't be intercepted (no macOS API notifies an app of that — confirmed via research into how Docker Desktop/Slack/etc. handle this), so "Uninstall Meridian…" (CLI or in-app wizard) remains the one true full-cleanup path — this PR makes that path actually complete.

## Test plan
- [x] `cargo test uninstall` — 8/8 passing, including a new test asserting the app-cache paths are picked up only when present
- [x] `cargo clippy --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Full pre-push hook suite (fmt, clippy, ui build, ui tests, security audit, cargo test) passed on push