### PR TITLE
fix(plan): raise daily plan task limit from 10 to 20

### DIFF
--- a/meridian-core/src/readers/plan.rs
+++ b/meridian-core/src/readers/plan.rs
@@ -43,11 +43,11 @@ const EXCERPT_LEN: usize = 130; // description excerpt length for card display
 /// The most tasks a day's plan may hold.
 ///
 /// A product limit, not a technical one. A plan is a statement of intent for one
-/// day, and a day that claims eleven tasks isn't a plan — it's a backlog, which
+/// day, and a day that claims dozens of tasks isn't a plan — it's a backlog, which
 /// makes the plan useless as the prior the worklog matcher now leans on
 /// ([`load_plan_candidates`]). Most focused days land on 1-3; the existing
 /// advisory nag in `PlanTodayColumn.tsx` fires at 5. This is the hard stop.
-pub const MAX_PLAN_TASKS: usize = 10;
+pub const MAX_PLAN_TASKS: usize = 20;
 
 // ── Types (field names match the TS interfaces byte-for-byte) ─────────────────
 

--- a/meridian-core/tests/readers.rs
+++ b/meridian-core/tests/readers.rs
@@ -1375,9 +1375,12 @@ async fn a_whole_list_write_refuses_past_the_cap() {
             Vec::new(),
         )
         .await
-        .expect_err("11 tasks must be refused");
+        .expect_err("one past the cap must be refused");
         assert!(
-            err.to_string().contains("up to 10 tasks"),
+            err.to_string().contains(&format!(
+                "up to {} tasks",
+                meridian_core::plan::MAX_PLAN_TASKS
+            )),
             "{action}: the user must be told the limit, got: {err}"
         );
     }
@@ -1388,7 +1391,7 @@ async fn a_whole_list_write_refuses_past_the_cap() {
     assert_eq!(n, 0, "a refused write must not half-apply");
 }
 
-/// Exactly the cap is fine — the limit is 10 tasks, not 9.
+/// Exactly the cap is fine — the limit is MAX_PLAN_TASKS tasks, not one fewer.
 #[tokio::test]
 async fn a_whole_list_write_accepts_exactly_the_cap() {
     let pool = make_board_pool().await;
@@ -1434,7 +1437,7 @@ async fn the_cap_counts_distinct_keys() {
     let mut keys: Vec<String> = (1..=meridian_core::plan::MAX_PLAN_TASKS)
         .map(|i| format!("KAN-{i}"))
         .collect();
-    keys.push("KAN-1".to_string()); // 11 entries, 10 distinct
+    keys.push("KAN-1".to_string()); // one more entry than distinct keys
 
     let body = meridian_core::plan::PlanBody {
         action: "set".to_string(),

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -554,7 +554,7 @@ export const LOCAL_PROVIDER = 'local'
  *  It matters beyond tidiness: the plan IS the worklog matcher's candidate set, so
  *  an eleventh task doesn't just clutter a list, it dilutes every match made
  *  against it. */
-export const MAX_PLAN_TASKS = 10
+export const MAX_PLAN_TASKS = 20
 
 /** An AI-drafted task, for the user to review and edit before creating.
  *  Every field may be empty: `error` set + empty fields is the honest answer when the


### PR DESCRIPTION
## Summary
- Raises `MAX_PLAN_TASKS` from 10 to 20 in `meridian-core/src/readers/plan.rs` (the enforcing DB-side guard, mirrored into the UI's advisory copy/wall) and its TS mirror in `ui/lib/api-types.ts`.
- Updates `meridian-core/tests/readers.rs` assertions/comments that hardcoded the old cap.

## Test plan
- [x] `cargo test -p meridian-core --test readers` — 42 passed
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings` clean
- [x] pre-push hook suite (fmt, clippy, ui build/tests, security audit, cargo test) passed