### PR TITLE
feat(plan): let a user delete a personal task they created

### DIFF
--- a/meridian-core/src/readers/plan.rs
+++ b/meridian-core/src/readers/plan.rs
@@ -387,6 +387,8 @@ pub async fn build_available(
     recent_since_day: &str,
 ) -> anyhow::Result<Vec<AvailableTask>> {
     let has_curation = table_exists(pool, "pm_task_curation").await;
+    // `t.deleted_at IS NULL` (migration 075) — a task the user deleted from the
+    // composer must not be offered back as a suggestion.
     let sql = format!(
         r#"SELECT t.task_key, t.title, t.provider, t.url,
                   COALESCE(t.status_raw,'') AS status_raw,
@@ -396,7 +398,8 @@ pub async fn build_available(
                   t.priority, t.issue_type, t.story_points,
                   {} AS decision
            FROM pm_tasks t
-           {}"#,
+           {}
+           WHERE t.deleted_at IS NULL"#,
         if has_curation { "c.decision" } else { "NULL" },
         if has_curation {
             "LEFT JOIN pm_task_curation c ON c.task_key = t.task_key"
@@ -533,6 +536,12 @@ struct PlanJoinRow {
     priority: Option<String>,
     issue_type: Option<String>,
     story_points: Option<String>,
+    /// Set (migration 075) when the user deleted this personal task from the
+    /// composer. Unlike `on_board = false` (the ticket's `pm_tasks` row is simply
+    /// gone, e.g. pruned off a tracker's board — shown as completed via its
+    /// snapshot), a deleted task must vanish outright: filtered out in
+    /// [`load_plan`] / [`load_plan_candidates`] before [`resolve_row`] ever sees it.
+    deleted_at: Option<String>,
 }
 
 /// A ticket's board fields captured onto the `daily_plan` row at write time
@@ -666,6 +675,7 @@ pub async fn load_plan_candidates(
     Ok(plan_join_rows(pool, date)
         .await?
         .into_iter()
+        .filter(|r| r.deleted_at.is_none())
         .map(resolve_row)
         .collect())
 }
@@ -686,6 +696,9 @@ async fn load_plan(
     Ok(plan_join_rows(pool, date)
         .await?
         .into_iter()
+        // A deleted personal task must vanish outright, unlike a merely off-board
+        // one (`on_board = false`, still shown via its snapshot as completed).
+        .filter(|r| r.deleted_at.is_none())
         .map(resolve_row)
         .map(|c| PlanItem {
             due_days: crate::date::due_days_from(c.due_date.as_deref(), today),
@@ -730,7 +743,7 @@ async fn plan_join_rows(pool: &SqlitePool, date: &str) -> anyhow::Result<Vec<Pla
                   COALESCE(t.status_raw,'') AS status_raw,
                   COALESCE(t.is_terminal,0) AS is_terminal,
                   t.due_date, t.description_text, t.epic_title, t.parent_key,
-                  t.priority, t.issue_type, t.story_points
+                  t.priority, t.issue_type, t.story_points, t.deleted_at
            FROM daily_plan p
            LEFT JOIN pm_tasks t ON t.task_key = p.task_key
            WHERE p.plan_date = ?

--- a/meridian-core/src/readers/task_create.rs
+++ b/meridian-core/src/readers/task_create.rs
@@ -37,10 +37,20 @@
 //! itself, or promoting it to a real ticket if a tracker is connected) instead of
 //! refusing it.
 //!
+//! # `deleted_at` (migration 075) — a SEPARATE filter, orthogonal to `provider`
+//! [`delete_local_task`] hides a personal task by setting `deleted_at` rather than
+//! removing the row (see its doc for why). Every site that LISTS tasks to a user
+//! must also exclude a hidden one: `tasks::get_tasks`, `plan::build_available`,
+//! and `plan::plan_join_rows` (which `plan::load_plan` and the worklog matcher's
+//! candidate set both resolve through) all filter `deleted_at IS NULL`. A lookup by
+//! exact key ([`provider_of`], [`task_exists`], `task_detail`) deliberately does
+//! NOT filter it — those aren't listings, and a stale direct reference should still
+//! resolve to a clear "this was deleted" rather than a confusing 404.
+//!
 //! # Who calls this
-//! `src/plan_tasks/{create,edit}.rs` (daemon) → the `meridian plan-task-create` /
-//! `plan-task-edit` CLIs → the tray's `create_plan_task` / `edit_plan_task` → the
-//! daily plan's task composer.
+//! `src/plan_tasks/{create,edit,delete}.rs` (daemon) → the `meridian plan-task-create` /
+//! `plan-task-edit` / `plan-task-delete` CLIs → the tray's `create_plan_task` /
+//! `edit_plan_task` / `delete_plan_task` → the daily plan's task composer.
 //!
 //! # Related
 //! - [`crate::plan`] — the daily plan these tasks are added to; its `apply_plan_action`
@@ -55,9 +65,9 @@ use tracing::Instrument;
 pub const LOCAL_PROVIDER: &str = "local";
 
 /// The `LOCAL-<n>` key prefix. `<n>` is `MAX(<n>) + 1` over existing personal tasks.
-/// Keys are never reused — nothing here deletes a task (see the note at the bottom of
-/// this module), so the max only ever grows. That matters: a reissued key would let a
-/// new task inherit the old one's `app_sessions` / `daily_plan` history.
+/// Keys are never reused — [`delete_local_task`] hides a row rather than removing
+/// it (see its doc), so the max only ever grows. That matters: a reissued key would
+/// let a new task inherit the old one's `app_sessions` / `daily_plan` history.
 const LOCAL_KEY_PREFIX: &str = "LOCAL-";
 
 /// One task row to create. `provider` is [`LOCAL_PROVIDER`] for a personal task, or a
@@ -145,8 +155,10 @@ async fn try_create_local(
         .await
         .context("opening the create transaction")?;
 
-    // Highest existing LOCAL-<n>, counting DELETED keys is impossible (they're gone),
-    // so this is "highest live + 1". Keys are not reused; see LOCAL_KEY_PREFIX.
+    // Highest existing LOCAL-<n>, INCLUDING hidden (`deleted_at` set) ones — a
+    // hidden row still counts toward "highest ever minted", which is what keeps a
+    // key from being reissued. Live-only would let a deleted task's number come
+    // back around.
     let max_n: i64 = sqlx::query_scalar(
         "SELECT COALESCE(MAX(CAST(SUBSTR(task_key, 7) AS INTEGER)), 0) \
          FROM pm_tasks WHERE provider = ? AND task_key LIKE 'LOCAL-%'",
@@ -175,6 +187,38 @@ async fn try_create_local(
 
     tx.commit().await.context("committing the new task")?;
     Ok(key)
+}
+
+/// "Delete" a personal task: hide it, don't remove the row. **Scoped
+/// `WHERE provider = 'local'` deliberately** — same rationale as
+/// [`update_task_text`]/[`set_local_terminal`], this must never be pointable at a
+/// tracker-synced row. Soft rather than a real `DELETE` because keys are minted as
+/// `MAX(<n>) + 1` over every row ever inserted (see [`LOCAL_KEY_PREFIX`]) — actually
+/// removing the row would free its number for reuse, letting a later task silently
+/// inherit this one's `app_sessions` / `daily_plan` history. `deleted_at` is the
+/// durable record instead; every reader that lists tasks (`tasks`,
+/// `plan::build_available`, `plan::plan_join_rows`) filters it out, so a hidden task
+/// simply stops appearing anywhere. Idempotent: hiding an already-hidden task is a
+/// no-op, not an error. Returns whether a row changed, so the caller can tell "not a
+/// personal task" (or already hidden) from "hidden".
+#[tracing::instrument(skip(pool))]
+pub async fn delete_local_task(pool: &SqlitePool, task_key: &str, now: &str) -> Result<bool> {
+    let res = sqlx::query(
+        "UPDATE pm_tasks SET deleted_at = ? \
+         WHERE task_key = ? AND provider = ? AND deleted_at IS NULL",
+    )
+    .bind(now)
+    .bind(task_key)
+    .bind(LOCAL_PROVIDER)
+    .execute(pool)
+    .instrument(tracing::debug_span!("task_create.write.delete"))
+    .await
+    .context("hiding the personal task")?;
+    let deleted = res.rows_affected() > 0;
+    if deleted {
+        tracing::info!(key = %task_key, "task_create: personal task deleted");
+    }
+    Ok(deleted)
 }
 
 /// The provider that owns `task_key`, or `None` if it isn't a known task. Callers
@@ -351,12 +395,8 @@ pub async fn set_local_status(
     Ok(res.rows_affected() > 0)
 }
 
-// NOTE: there is deliberately NO delete. A personal task is disposed of exactly the
-// way a board ticket is — mark it done ([`set_local_terminal`]), which drops it from
-// `build_available`. Removing a task from a day is the plan's `remove` action, which
-// touches `daily_plan` and leaves the task itself alone.
-//
-// This is not just YAGNI: because keys are minted as `MAX(<n>) + 1` over the live
-// rows, deleting the highest task would let the NEXT mint reissue its key, and the
-// new task would silently inherit the old one's `app_sessions` history. No delete
-// means no reuse, which is what makes the "never reused" guarantee above true.
+// A personal task can be disposed of three ways: mark it done ([`set_local_terminal`],
+// which drops it from `build_available` but keeps its history); remove it from just
+// one day (the plan's `remove` action, which only touches `daily_plan`); or delete it
+// outright ([`delete_local_task`]), for a task the user never wanted to have created —
+// which hides it everywhere without touching its row (see that fn's doc for why).

--- a/meridian-core/src/readers/tasks.rs
+++ b/meridian-core/src/readers/tasks.rs
@@ -180,11 +180,15 @@ pub async fn get_tasks(
         "NULL AS canonical_id, NULL AS status_category, NULL AS reporter_name, \
          NULL AS completed_at, NULL AS ancestor_path, NULL AS project_ids"
     };
+    // `deleted_at IS NULL` (migration 075) — a task the user deleted from the
+    // composer must stop appearing here even though its row still exists (see
+    // meridian_core::task_create's module doc for why it's a soft hide).
     let task_rows: Vec<TaskRow> = sqlx::query_as::<_, TaskRow>(&format!(
         "SELECT task_key, title, description_text, COALESCE(issue_type,'') AS issue_type, \
                 status_raw, is_terminal, provider, url, parent_key, epic_title, due_date, start_date, \
                 {cdm_cols} \
          FROM pm_tasks \
+         WHERE deleted_at IS NULL \
          ORDER BY task_key DESC"
     ))
     .fetch_all(pool)

--- a/meridian-core/tests/readers.rs
+++ b/meridian-core/tests/readers.rs
@@ -34,7 +34,7 @@ async fn make_pool() -> SqlitePool {
         CREATE TABLE pm_tasks (
             task_key TEXT, title TEXT, description_text TEXT, issue_type TEXT,
             status_raw TEXT, is_terminal INTEGER, provider TEXT, url TEXT,
-            parent_key TEXT, epic_title TEXT, due_date TEXT, start_date TEXT
+            parent_key TEXT, epic_title TEXT, due_date TEXT, start_date TEXT, deleted_at TEXT
         );
         "#,
     )
@@ -376,7 +376,8 @@ async fn make_plan_pool() -> SqlitePool {
         r#"CREATE TABLE pm_tasks (
             task_key TEXT, title TEXT, provider TEXT, url TEXT, status_raw TEXT,
             is_terminal INTEGER, due_date TEXT, updated_at TEXT, description_text TEXT,
-            epic_title TEXT, parent_key TEXT, priority TEXT, issue_type TEXT, story_points TEXT
+            epic_title TEXT, parent_key TEXT, priority TEXT, issue_type TEXT, story_points TEXT,
+            deleted_at TEXT
         );"#,
         r#"CREATE TABLE pm_task_curation (task_key TEXT, decision TEXT);"#,
         r#"CREATE TABLE app_sessions (
@@ -754,7 +755,7 @@ async fn make_task_create_pool() -> SqlitePool {
             is_terminal INTEGER NOT NULL DEFAULT 0, due_date TEXT, updated_at TEXT NOT NULL,
             description_text TEXT NOT NULL DEFAULT '', epic_title TEXT, parent_key TEXT,
             priority TEXT NOT NULL DEFAULT '', issue_type TEXT NOT NULL DEFAULT '',
-            story_points TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT ''
+            story_points TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', deleted_at TEXT
         );"#,
         r#"CREATE TABLE pm_task_curation (task_key TEXT, decision TEXT);"#,
         r#"CREATE TABLE app_sessions (
@@ -1324,7 +1325,7 @@ async fn make_board_pool() -> sqlx::SqlitePool {
             is_terminal INTEGER NOT NULL DEFAULT 0, due_date TEXT, updated_at TEXT NOT NULL,
             description_text TEXT NOT NULL DEFAULT '', epic_title TEXT, parent_key TEXT,
             priority TEXT NOT NULL DEFAULT '', issue_type TEXT NOT NULL DEFAULT '',
-            story_points TEXT
+            story_points TEXT, deleted_at TEXT
         );"#,
         r#"CREATE TABLE pm_task_curation (task_key TEXT, decision TEXT);"#,
         // Migration 041 + 044. The matcher's candidate set reads this.
@@ -1697,7 +1698,7 @@ async fn make_worklog_pool() -> SqlitePool {
         CREATE TABLE pm_tasks (
             task_key TEXT, title TEXT, description_text TEXT, issue_type TEXT,
             status_raw TEXT, is_terminal INTEGER, provider TEXT, url TEXT,
-            parent_key TEXT, epic_title TEXT, due_date TEXT, start_date TEXT
+            parent_key TEXT, epic_title TEXT, due_date TEXT, start_date TEXT, deleted_at TEXT
         );
         "#,
     )

--- a/src/migrations/075_pm_tasks_soft_delete.sql
+++ b/src/migrations/075_pm_tasks_soft_delete.sql
@@ -1,0 +1,9 @@
+-- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+--
+-- "Delete" a personal (provider = 'local') task the user created by mistake,
+-- without actually removing the row (see meridian-core/src/readers/task_create.rs
+-- for why keys are never reused). Setting `deleted_at` hides it from every place
+-- a task is listed (the Tasks board, the day's plan, the worklog matcher's
+-- candidate set); NULL means live. Never set for a tracker-synced row - that
+-- ticket isn't Meridian's to hide.
+ALTER TABLE pm_tasks ADD COLUMN deleted_at TEXT;

--- a/src/plan_tasks/cli.rs
+++ b/src/plan_tasks/cli.rs
@@ -49,6 +49,10 @@ pub async fn try_handle() -> Result<bool> {
             run_done().await;
             Ok(true)
         }
+        "plan-task-delete" => {
+            run_delete().await;
+            Ok(true)
+        }
         _ => Ok(false),
     }
 }
@@ -193,5 +197,28 @@ async fn run_done() {
     match res {
         Ok(r) => finish(&r, obs_guard).await,
         Err(e) => die("plan-task-done", format!("{e:#}"), obs_guard).await,
+    }
+}
+
+/// `meridian plan-task-delete --key K` — hide a personal task everywhere it's
+/// listed (refuses anything not `provider = 'local'`). Prints `{task_key, deleted}`.
+async fn run_delete() {
+    let key = flag("--key").unwrap_or_default();
+    if key.trim().is_empty() {
+        eprintln!("plan-task-delete: --key is required");
+        std::process::exit(2);
+    }
+
+    let cfg = Config::from_env();
+    let obs_guard = observability::init("meridian-rust").ok();
+    let pool = match setup_db(&cfg.meridian_db_uri()).await {
+        Ok(p) => p,
+        Err(e) => die("plan-task-delete", format!("open db: {e:#}"), obs_guard).await,
+    };
+    let res = super::delete::delete(&pool, &key).await;
+    pool.close().await;
+    match res {
+        Ok(r) => finish(&r, obs_guard).await,
+        Err(e) => die("plan-task-delete", format!("{e:#}"), obs_guard).await,
     }
 }

--- a/src/plan_tasks/delete.rs
+++ b/src/plan_tasks/delete.rs
@@ -1,0 +1,59 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Deleting a personal task the user created by mistake — the daemon half of
+//! "there must be an option to delete a task I created".
+//!
+//! # Personal tasks only
+//! Unlike [`super::edit`], there is no tracker branch here. A tracker-synced ticket
+//! is owned by the tracker; Meridian only mirrors it, and removing a ticket from a
+//! board is the tracker's own delete, not something this app does on the user's
+//! behalf. Pointed at anything other than a `provider = 'local'` row, this refuses
+//! rather than silently doing something destructive to someone's real board.
+//!
+//! # Who calls this
+//! [`super::cli`]'s `plan-task-delete` → the tray's `delete_plan_task` → the plan's
+//! task card / detail dialog.
+//!
+//! # Related
+//! - [`meridian_core::task_create::delete_local_task`] — the actual write. Soft: it
+//!   sets `deleted_at` rather than removing the row (that fn's doc has the why), so
+//!   every task listing simply stops showing it — nothing else has to be told.
+
+use anyhow::{Context, Result};
+use meridian_core::task_create;
+use serde::Serialize;
+use sqlx::SqlitePool;
+
+/// The outcome of a delete, serialized to the CLI's one JSON line.
+#[derive(Debug, Clone, Serialize)]
+pub struct DeleteResult {
+    pub task_key: String,
+    pub deleted: bool,
+}
+
+/// Delete `task_key` if — and only if — it is a personal task.
+#[tracing::instrument(skip(pool))]
+pub async fn delete(pool: &SqlitePool, task_key: &str) -> Result<DeleteResult> {
+    let provider = task_create::provider_of(pool, task_key)
+        .await?
+        .with_context(|| format!("no task {task_key} - it may already be gone"))?;
+    if provider != task_create::LOCAL_PROVIDER {
+        anyhow::bail!(
+            "{task_key} is a {provider} ticket - only a personal task you created \
+             yourself can be deleted here"
+        );
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let deleted = task_create::delete_local_task(pool, task_key, &now)
+        .await
+        .context("deleting the personal task")?;
+    tracing::info!(
+        task_key,
+        deleted,
+        "plan_task: personal task delete requested"
+    );
+    Ok(DeleteResult {
+        task_key: task_key.to_string(),
+        deleted,
+    })
+}

--- a/src/plan_tasks/mod.rs
+++ b/src/plan_tasks/mod.rs
@@ -29,6 +29,7 @@
 
 pub mod cli;
 pub mod create;
+pub mod delete;
 pub mod done;
 pub mod draft;
 pub mod edit;

--- a/tray/src-tauri/src/commands/plan_tasks.rs
+++ b/tray/src-tauri/src/commands/plan_tasks.rs
@@ -9,6 +9,8 @@
 //!   it to the day's plan.
 //! - [`edit_plan_task`] — rewrite a task's title/description, wherever it lives.
 //! - [`set_plan_task_done`] — tick/untick a task, wherever it lives.
+//! - [`delete_plan_task`] — hide a personal task everywhere it's listed. Refuses
+//!   anything synced to a tracker — that ticket isn't Meridian's to delete.
 //!
 //! # Why these SHELL OUT
 //! The chosen LLM provider (`settings.json`) and tracker auth (`~/.meridian/.env`)
@@ -109,6 +111,13 @@ pub struct EditResult {
     pub reason: Option<String>,
 }
 
+/// [`delete_plan_task`] response — mirrors `plan_tasks::delete::DeleteResult`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeletePlanTaskResult {
+    pub task_key: String,
+    pub deleted: bool,
+}
+
 /// Draft a task from a rough note. Spawns `meridian plan-task-draft --note <n>`.
 ///
 /// Only errors when the CLI itself failed (spawn/timeout). A model failure comes back
@@ -206,5 +215,25 @@ pub async fn set_plan_task_done(body: SetPlanTaskDoneBody) -> Result<EditResult,
 
     let res: EditResult = run_meridian_json(&args, WRITE_TIMEOUT, "plan-task-done").await?;
     tracing::info!(status = %res.status, provider = %res.provider, "plan-task-done served");
+    Ok(res)
+}
+
+/// Hide a personal task everywhere it's listed. Spawns
+/// `meridian plan-task-delete --key K`.
+///
+/// The daemon-side CLI refuses anything not `provider = 'local'` — a tracker ticket
+/// isn't Meridian's to delete — so a mis-pointed call surfaces as a clear error
+/// rather than silently doing nothing.
+#[tauri::command]
+#[tracing::instrument(fields(task_key = %task_key))]
+pub async fn delete_plan_task(task_key: String) -> Result<DeletePlanTaskResult, String> {
+    if task_key.trim().is_empty() {
+        return Err("a task key is required".to_string());
+    }
+    let args: Vec<&str> = vec!["plan-task-delete", "--key", &task_key];
+
+    let res: DeletePlanTaskResult =
+        run_meridian_json(&args, WRITE_TIMEOUT, "plan-task-delete").await?;
+    tracing::info!(deleted = res.deleted, "plan-task-delete served");
     Ok(res)
 }

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -522,6 +522,7 @@ pub fn run() {
             commands::create_plan_task,
             commands::edit_plan_task,
             commands::set_plan_task_done,
+            commands::delete_plan_task,
             commands::triage_decision,
             commands::triage_ignore,
             commands::apply_ticket_fix,

--- a/ui/components/plan/PlanView.tsx
+++ b/ui/components/plan/PlanView.tsx
@@ -329,6 +329,7 @@ export default function PlanView() {
           onClose={() => setOpenTask(null)}
           onAdd={() => commit([...today, openTask])}
           onRemove={() => commit(today.filter(t => t.key !== openTask.key))}
+          onDeleted={() => commit(today.filter(t => t.key !== openTask.key))}
         />
       )}
     </DragDropContext>

--- a/ui/components/timeline/TaskDetailDialog.tsx
+++ b/ui/components/timeline/TaskDetailDialog.tsx
@@ -27,7 +27,7 @@ import { useTaskStatusChange, StatusBanner } from './useTaskStatusChange'
 import { WorklogTicketPicker } from './WorklogTicketPicker'
 
 export function TaskDetailDialog({
-  taskKey, fallbackTitle, onClose, inToday, canEdit = true, onAdd, onRemove, day, editableTask = true,
+  taskKey, fallbackTitle, onClose, inToday, canEdit = true, onAdd, onRemove, onDeleted, day, editableTask = true,
 }: {
   taskKey: string
   fallbackTitle?: string
@@ -38,6 +38,10 @@ export function TaskDetailDialog({
   canEdit?: boolean
   onAdd?: () => void
   onRemove?: () => void
+  // Fired after a personal task is deleted (see `canEditText`/delete below), right
+  // before the dialog closes itself — lets the caller drop it from whatever list
+  // it's currently showing without waiting on that list's own next refetch.
+  onDeleted?: () => void
   // The day this dialog was opened from — used to refresh that day's plan
   // store after a title/description edit lands, so a "Today's focus" card
   // showing this task updates without a manual poll.
@@ -57,6 +61,11 @@ export function TaskDetailDialog({
   const [draftDescription, setDraftDescription] = useState('')
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
+  // Deleting a personal task: a confirm step (it disappears from every list, not
+  // just today's), then the write.
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
   // Escalation: promote this personal task onto a real tracker (create a new
   // ticket, or match an existing one) and post its auto-logged update there.
   const [escalating, setEscalating] = useState(false)
@@ -120,6 +129,24 @@ export function TaskDetailDialog({
       })
       .catch(e => setSaveError(e instanceof Error ? e.message : 'Couldn’t save the task'))
       .finally(() => setSaving(false))
+  }
+
+  /** Delete this personal task: it stops appearing anywhere it's listed (today's
+   *  plan, the Tasks board, suggestions) — see `meridian_core::task_create`'s
+   *  `delete_local_task` for why this is a hide, not a hard DB delete. */
+  function deleteTask() {
+    if (deleting) return
+    setDeleting(true)
+    setDeleteError(null)
+    invoke('delete_plan_task', { taskKey })
+      .then(() => {
+        onDeleted?.()
+        onClose()
+      })
+      .catch(e => {
+        setDeleteError(e instanceof Error ? e.message : 'Couldn’t delete the task')
+        setDeleting(false)
+      })
   }
 
   /** The task just GRADUATED into a real ticket - it isn't personal anymore.
@@ -296,7 +323,29 @@ export function TaskDetailDialog({
           )}
         </div>
 
-        {(detail?.url || onAdd || onRemove || canEditText) && (
+        {confirmingDelete ? (
+          <div className="px-7 py-5 border-t shrink-0" style={{ borderColor: 'var(--t-hair)' }}>
+            <p className="mt-body-sm mb-3" style={{ color: 'var(--t-muted)' }}>
+              Delete this task? It disappears from today&apos;s plan, the Tasks board,
+              and future suggestions. This can&apos;t be undone from here.
+            </p>
+            {deleteError && (
+              <p className="mt-body-sm mb-3" style={{ color: 'var(--color-state-pending)' }}>{deleteError}</p>
+            )}
+            <div className="flex items-center gap-2.5">
+              <button onClick={deleteTask} disabled={deleting}
+                className="mt-body-sm px-3.5 py-2 rounded-lg"
+                style={{ background: 'var(--color-state-pending)', color: '#fff', opacity: deleting ? 0.6 : 1 }}>
+                {deleting ? 'Deleting…' : 'Yes, delete'}
+              </button>
+              <button onClick={() => setConfirmingDelete(false)} disabled={deleting}
+                className="mt-body-sm px-3.5 py-2 rounded-lg bg-ctrl"
+                style={{ border: '1px solid var(--t-ctrl-border)', color: 'var(--t-muted)' }}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : (detail?.url || onAdd || onRemove || canEditText) && (
           <div className="px-7 py-5 border-t shrink-0 flex items-center gap-2.5" style={{ borderColor: 'var(--t-hair)' }}>
             {canEditText && (editing ? (
               <>
@@ -312,11 +361,18 @@ export function TaskDetailDialog({
                 </button>
               </>
             ) : (
-              <button onClick={startEdit}
-                className="mt-body-sm px-3.5 py-2 rounded-lg bg-ctrl"
-                style={{ border: '1px solid var(--t-ctrl-border)', color: 'var(--t-muted)' }}>
-                Edit
-              </button>
+              <>
+                <button onClick={startEdit}
+                  className="mt-body-sm px-3.5 py-2 rounded-lg bg-ctrl"
+                  style={{ border: '1px solid var(--t-ctrl-border)', color: 'var(--t-muted)' }}>
+                  Edit
+                </button>
+                <button onClick={() => setConfirmingDelete(true)}
+                  className="mt-body-sm px-3.5 py-2 rounded-lg bg-ctrl"
+                  style={{ border: '1px solid var(--t-ctrl-border)', color: 'var(--color-state-pending)' }}>
+                  Delete
+                </button>
+              </>
             ))}
             {canEdit && (inToday ? (onRemove && (
               <button onClick={() => { onRemove(); onClose() }}


### PR DESCRIPTION
## Summary
- A personal (`provider='local'`) task previously had no delete — only mark-done or remove-from-one-day. Adds `delete_local_task`, which **hides** the task (`deleted_at`) rather than removing the row: keys are minted as `MAX(<n>)+1` over every row ever inserted, so actually deleting one would free its number for reuse and let a later task silently inherit the old one's `app_sessions`/`daily_plan` history.
- Every reader that lists tasks now filters `deleted_at IS NULL`: `tasks::get_tasks` (Tasks board), `plan::build_available` (suggestions), and `plan::plan_join_rows` (today's committed plan cards + the worklog matcher's candidate set, both resolve through it) — so a deleted task simply stops appearing anywhere it used to show up.
- Wired end-to-end: `meridian plan-task-delete` CLI → tray's `delete_plan_task` command → a **Delete** action with an inline confirm step in `TaskDetailDialog`, shown only for a task's own creator (personal + currently editable).

## Test plan
- [x] `cargo test -p meridian-core` (236 unit + 42 integration tests) — all pass
- [x] `cargo test -p meridian` (720 tests across all suites) — all pass
- [x] `cargo clippy -- -D warnings` clean on `meridian-core`, `meridian`, and the tray crate
- [x] `npm run build` (Next.js + popover sync) succeeds
- [x] Pre-push hook (fmt + clippy + UI build/tests + security audit + `cargo test`) passed on push