### PR TITLE
fix(tasks): refresh the Tasks board after a personal-task delete

### DIFF
--- a/ui/components/timeline/TaskDetailDialog.tsx
+++ b/ui/components/timeline/TaskDetailDialog.tsx
@@ -133,13 +133,22 @@ export function TaskDetailDialog({
 
   /** Delete this personal task: it stops appearing anywhere it's listed (today's
    *  plan, the Tasks board, suggestions) — see `meridian_core::task_create`'s
-   *  `delete_local_task` for why this is a hide, not a hard DB delete. */
+   *  `delete_local_task` for why this is a hide, not a hard DB delete.
+   *
+   *  This dialog is a shared modal layered on top of whatever surface opened it
+   *  (the Tasks board, the daily plan, a timeline card) — it never remounts that
+   *  surface, so its own already-fetched list would otherwise stay stale after a
+   *  successful delete. `onDeleted` covers the one caller that wires it
+   *  (PlanView); the `meridian:task-deleted` window event (same pattern as
+   *  NoticeBar's `meridian:open-tasks`) is the broadcast every OTHER list-owning
+   *  surface listens for instead of threading a callback through every opener. */
   function deleteTask() {
     if (deleting) return
     setDeleting(true)
     setDeleteError(null)
     invoke('delete_plan_task', { taskKey })
       .then(() => {
+        window.dispatchEvent(new CustomEvent('meridian:task-deleted', { detail: { taskKey } }))
         onDeleted?.()
         onClose()
       })

--- a/ui/components/timeline/TasksPanel.tsx
+++ b/ui/components/timeline/TasksPanel.tsx
@@ -82,6 +82,16 @@ export function TasksPanel({ onOpenTask }: { onOpenTask: (key: string, title?: s
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  // TaskDetailDialog is a separate modal layered on top of this panel (it never
+  // remounts this component), so a delete made there needs its own signal to
+  // drop the row from this already-fetched list — see that dialog's `deleteTask`.
+  useEffect(() => {
+    const onDeleted = () => fetchTasks()
+    window.addEventListener('meridian:task-deleted', onDeleted)
+    return () => window.removeEventListener('meridian:task-deleted', onDeleted)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const header = (
     <div className="flex items-center justify-between mb-5">
       <p className="mt-body-sm" style={{ color: 'var(--t-faint)' }}>


### PR DESCRIPTION
## Summary
- Follow-up to #560. Deleting a personal task actually succeeded server-side (`deleted_at` was set correctly), but the Tasks board kept showing the stale row — `TaskDetailDialog` is a modal layered on top of whatever surface opened it, so it never remounts that surface's already-fetched list.
- `TaskDetailDialog`'s `deleteTask` now broadcasts a `meridian:task-deleted` window event on success (same pattern `NoticeBar` already uses for `meridian:open-tasks`), and `TasksPanel` listens for it to refetch immediately.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] Pre-push hook (fmt + clippy + UI build/tests + security audit + `cargo test`) passed on push
- [x] Manually confirmed in the running app: deleting a personal task from the Tasks board now drops it from the list immediately instead of requiring a modal reopen/poll