### PR TITLE
feat(setup): show a founder's welcome note with a live download number

### DIFF
--- a/tray/src-tauri/src/commands.rs
+++ b/tray/src-tauri/src/commands.rs
@@ -16,6 +16,8 @@
 //!   (also the local read path for `meridian logs`'s OTel-spool decode — see
 //!   `src/telemetry_spool/render.rs` — since the old JSONL-tailing `logs`
 //!   module and its dashboard consumer are both gone).
+//! - [`downloads`] — live Meridian download count for the setup wizard's
+//!   Welcome screen (`meridiona.com/api/downloads-count`).
 //! - [`integrations`] — which trackers are connected (`/api/integrations`).
 //! - [`notices`]   — clear a fault banner (`/api/notices/[id]` DELETE).
 //! - [`notifications`] — the in-app banner dismiss write.
@@ -45,6 +47,7 @@ pub mod daemon_control;
 pub mod dashboard;
 pub mod day_summary;
 pub mod diagnostics;
+pub mod downloads;
 pub mod health;
 pub mod integrations;
 pub mod llm_lab;
@@ -76,6 +79,7 @@ pub use daemon::*;
 pub use dashboard::*;
 pub use day_summary::*;
 pub use diagnostics::*;
+pub use downloads::*;
 pub use health::*;
 pub use integrations::*;
 pub use llm_lab::*;

--- a/tray/src-tauri/src/commands.rs
+++ b/tray/src-tauri/src/commands.rs
@@ -17,7 +17,7 @@
 //!   `src/telemetry_spool/render.rs` — since the old JSONL-tailing `logs`
 //!   module and its dashboard consumer are both gone).
 //! - [`downloads`] — live Meridian download count for the setup wizard's
-//!   Welcome screen (`meridiona.com/api/downloads-count`).
+//!   Welcome screen (summed asset `download_count` off the GitHub releases API).
 //! - [`integrations`] — which trackers are connected (`/api/integrations`).
 //! - [`notices`]   — clear a fault banner (`/api/notices/[id]` DELETE).
 //! - [`notifications`] — the in-app banner dismiss write.

--- a/tray/src-tauri/src/commands/downloads.rs
+++ b/tray/src-tauri/src/commands/downloads.rs
@@ -1,0 +1,99 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Live count of people who've downloaded Meridian, for the setup wizard's
+//! Welcome screen — a warm, numbered "you're not alone" moment. External
+//! HTTP (not a DB read), so per the porting playbook this lives tray-side
+//! rather than in `meridian-core`.
+//!
+//! # What this is
+//! Calls the meridiona-website Worker's `/api/downloads-count`, which counts
+//! contacts in the Resend "download" audience — the list people join by
+//! hitting the marketing site's `/download` page. The website holds the
+//! Resend API key; the tray never sees it, only the resulting count.
+//!
+//! # Who calls this
+//! [`get_download_count`] → `ui/app/setup/page.tsx`'s `SetupWizard`, which
+//! passes the resolved count down to `steps.tsx`'s `Welcome` component.
+//!
+//! # Related
+//! - `meridiona-website/worker.js`'s `/api/downloads-count` route (the source
+//!   of truth this reads from).
+//! - [`crate::commands::version::get_version`] — the sibling external-HTTP
+//!   check this borrows its process-wide-cache shape from.
+
+use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+use tracing::Instrument;
+
+const DOWNLOADS_COUNT_URL: &str = "https://meridiona.com/api/downloads-count";
+/// Matches the website's own edge-cache TTL — no point re-checking sooner.
+const CACHE_TTL: Duration = Duration::from_secs(300);
+
+/// Process-wide cache of the last successful count. `None` until the first
+/// successful fetch.
+static CACHE: Mutex<Option<(u64, Instant)>> = Mutex::new(None);
+
+#[derive(Deserialize)]
+struct CountResponse {
+    count: u64,
+}
+
+/// `{ count }` for the Welcome screen — `None` when the website is
+/// unreachable and no prior cached value exists, in which case the UI simply
+/// omits the line rather than showing a placeholder.
+#[derive(Debug, Clone, Serialize)]
+pub struct DownloadCount {
+    pub count: Option<u64>,
+}
+
+/// Fetch the live count, honouring the process-wide cache. Never errors — a
+/// network hiccup falls back to any cached value, else `None`; this is a
+/// warm decoration, not something setup depends on.
+async fn fetch_count() -> Option<u64> {
+    if let Some((count, checked)) = CACHE.lock().unwrap().as_ref() {
+        if checked.elapsed() < CACHE_TTL {
+            tracing::debug!(count, "download count: cache hit");
+            return Some(*count);
+        }
+    }
+
+    let fetched: Result<u64, String> = async {
+        let resp = reqwest::Client::new()
+            .get(DOWNLOADS_COUNT_URL)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+        if !resp.status().is_success() {
+            return Err(format!("downloads-count api {}", resp.status()));
+        }
+        resp.json::<CountResponse>()
+            .await
+            .map(|b| b.count)
+            .map_err(|e| e.to_string())
+    }
+    .instrument(tracing::debug_span!("downloads.fetch.website"))
+    .await;
+
+    match fetched {
+        Ok(count) => {
+            *CACHE.lock().unwrap() = Some((count, Instant::now()));
+            tracing::info!(count, "download count served");
+            Some(count)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "download count unavailable");
+            CACHE.lock().unwrap().as_ref().map(|(c, _)| *c)
+        }
+    }
+}
+
+/// The ported Welcome-screen data: how many people have downloaded Meridian
+/// so far, for the "you're the Nth person to give Meridian a shot" line.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn get_download_count() -> DownloadCount {
+    DownloadCount {
+        count: fetch_count().await,
+    }
+}

--- a/tray/src-tauri/src/commands/downloads.rs
+++ b/tray/src-tauri/src/commands/downloads.rs
@@ -1,32 +1,36 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
-//! Live count of people who've downloaded Meridian, for the setup wizard's
-//! Welcome screen — a warm, numbered "you're not alone" moment. External
-//! HTTP (not a DB read), so per the porting playbook this lives tray-side
-//! rather than in `meridian-core`.
+//! Live count of Meridian downloads, for the setup wizard's Welcome screen —
+//! a warm, numbered "you're not alone" moment. External HTTP (not a DB
+//! read), so per the porting playbook this lives tray-side rather than in
+//! `meridian-core`.
 //!
 //! # What this is
-//! Calls the meridiona-website Worker's `/api/downloads-count`, which counts
-//! contacts in the Resend "download" audience — the list people join by
-//! hitting the marketing site's `/download` page. The website holds the
-//! Resend API key; the tray never sees it, only the resulting count.
+//! Sums `download_count` across every asset on the latest GitHub release
+//! (the same release the DMG/Windows installer are themselves published to —
+//! see `release.yml` and the website's `/dl` redirect) via the public GitHub
+//! Releases API. No API key and no third-party mailing-list dependency:
+//! GitHub already counts every asset download for us, for free.
 //!
 //! # Who calls this
 //! [`get_download_count`] → `ui/app/setup/page.tsx`'s `SetupWizard`, which
 //! passes the resolved count down to `steps.tsx`'s `Welcome` component.
 //!
 //! # Related
-//! - `meridiona-website/worker.js`'s `/api/downloads-count` route (the source
-//!   of truth this reads from).
-//! - [`crate::commands::version::get_version`] — the sibling external-HTTP
-//!   check this borrows its process-wide-cache shape from.
+//! - [`crate::commands::version::get_version`] — the sibling GitHub-releases
+//!   check this borrows its process-wide-cache shape from. Hits the same
+//!   `releases/latest` endpoint, but cached and called independently — this
+//!   isn't worth sharing state with that check over, since the two read
+//!   different fields for different screens.
 
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use tracing::Instrument;
 
-const DOWNLOADS_COUNT_URL: &str = "https://meridiona.com/api/downloads-count";
-/// Matches the website's own edge-cache TTL — no point re-checking sooner.
+const GITHUB_LATEST_RELEASE_URL: &str =
+    "https://api.github.com/repos/Meridiona/meridian/releases/latest";
+/// No need to re-check more than once every few minutes — the number only
+/// has to be roughly current for a welcome-screen decoration.
 const CACHE_TTL: Duration = Duration::from_secs(300);
 
 /// Process-wide cache of the last successful count. `None` until the first
@@ -34,13 +38,19 @@ const CACHE_TTL: Duration = Duration::from_secs(300);
 static CACHE: Mutex<Option<(u64, Instant)>> = Mutex::new(None);
 
 #[derive(Deserialize)]
-struct CountResponse {
-    count: u64,
+struct ReleaseAsset {
+    download_count: u64,
 }
 
-/// `{ count }` for the Welcome screen — `None` when the website is
-/// unreachable and no prior cached value exists, in which case the UI simply
-/// omits the line rather than showing a placeholder.
+#[derive(Deserialize)]
+struct ReleaseResponse {
+    #[serde(default)]
+    assets: Vec<ReleaseAsset>,
+}
+
+/// `{ count }` for the Welcome screen — `None` when GitHub is unreachable
+/// and no prior cached value exists, in which case the UI simply omits the
+/// line rather than showing a placeholder.
 #[derive(Debug, Clone, Serialize)]
 pub struct DownloadCount {
     pub count: Option<u64>,
@@ -59,20 +69,23 @@ async fn fetch_count() -> Option<u64> {
 
     let fetched: Result<u64, String> = async {
         let resp = reqwest::Client::new()
-            .get(DOWNLOADS_COUNT_URL)
+            .get(GITHUB_LATEST_RELEASE_URL)
+            // GitHub's API rejects requests without a User-Agent (403).
+            .header(reqwest::header::USER_AGENT, "meridian-tray")
+            .header(reqwest::header::ACCEPT, "application/vnd.github+json")
             .timeout(Duration::from_secs(5))
             .send()
             .await
             .map_err(|e| e.to_string())?;
         if !resp.status().is_success() {
-            return Err(format!("downloads-count api {}", resp.status()));
+            return Err(format!("github releases api {}", resp.status()));
         }
-        resp.json::<CountResponse>()
-            .await
-            .map(|b| b.count)
-            .map_err(|e| e.to_string())
+        let body: ReleaseResponse = resp.json().await.map_err(|e| e.to_string())?;
+        // Sum across every asset (macOS DMG + Windows installer) so the
+        // number reflects every platform, not just whichever shipped first.
+        Ok(body.assets.iter().map(|a| a.download_count).sum())
     }
-    .instrument(tracing::debug_span!("downloads.fetch.website"))
+    .instrument(tracing::debug_span!("downloads.fetch.github_releases"))
     .await;
 
     match fetched {
@@ -88,8 +101,9 @@ async fn fetch_count() -> Option<u64> {
     }
 }
 
-/// The ported Welcome-screen data: how many people have downloaded Meridian
-/// so far, for the "you're the Nth person to give Meridian a shot" line.
+/// The Welcome-screen data: how many times Meridian's release assets have
+/// been downloaded so far, for the "you're the Nth person to bring Meridian
+/// into their day" line.
 #[tauri::command]
 #[tracing::instrument]
 pub async fn get_download_count() -> DownloadCount {

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -568,6 +568,7 @@ pub fn run() {
             commands::is_first_run,
             commands::mark_setup_complete,
             commands::get_platform,
+            commands::get_download_count,
             commands::save_account_email,
             commands::get_account_email,
             commands::clear_account_email,

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -14,7 +14,7 @@ import { invoke, load, mutate, tauri } from '@/lib/bridge'
 import { buildSteps, Welcome, Completion } from './steps'
 import type { StepMeta, Wiz } from './steps'
 import type { NotifState } from './data'
-import type { IntegrationsResponse } from '@/lib/api-types'
+import type { DownloadCountResponse, IntegrationsResponse } from '@/lib/api-types'
 import type { RuntimeSettings } from '@/lib/settings'
 import { DEFAULT_LLM_PROVIDER, providerChoiceFields, type LlmProviderId } from '@/lib/llm-providers'
 import { useLlmProviderDetection } from '@/components/LlmProviderPicker'
@@ -41,6 +41,17 @@ export default function SetupWizard() {
   }, [])
   useEffect(() => { resolvePlatform() }, [resolvePlatform])
   const steps = useMemo(() => buildSteps(platform), [platform])
+
+  // The live "you're the Nth person" count for the Welcome screen — a warm
+  // one-time fetch (no polling; the number only needs to be roughly current).
+  // Stays null on any failure, which the Welcome screen treats as "say nothing"
+  // rather than showing a placeholder.
+  const [downloadCount, setDownloadCount] = useState<number | null>(null)
+  useEffect(() => {
+    load<DownloadCountResponse>('/api/downloads-count', 'get_download_count')
+      .then((r) => setDownloadCount(r?.count ?? null))
+      .catch(() => {})
+  }, [])
 
   // Step 1 — permissions (live)
   const [perms, setPerms] = useState<Wiz['perms']>({ accessibility: null, screen: null, notifications: null })
@@ -252,6 +263,7 @@ export default function SetupWizard() {
             ready={platform !== null}
             error={platformError}
             onRetry={resolvePlatform}
+            downloadCount={downloadCount}
           />
         ) : (
           <div className="flex" style={{ height: '100%' }}>

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -48,7 +48,7 @@ export default function SetupWizard() {
   // rather than showing a placeholder.
   const [downloadCount, setDownloadCount] = useState<number | null>(null)
   useEffect(() => {
-    load<DownloadCountResponse>('/api/downloads-count', 'get_download_count')
+    load<DownloadCountResponse>('/api/download-count', 'get_download_count')
       .then((r) => setDownloadCount(r?.count ?? null))
       .catch(() => {})
   }, [])

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -242,11 +242,10 @@ export function Welcome({ onBegin, steps, ready, error, onRetry, downloadCount }
           border: '0.5px solid var(--t-card-border)',
         }}>
           <p style={{ fontSize: 12, lineHeight: 1.55, color: 'var(--t-muted)' }}>
-            Hey - you're the <span style={{ fontWeight: 600, color: 'var(--t-title)' }}>{ordinal(downloadCount)}</span> person
-            {' '}to give Meridian a shot. That still means a lot to me - every one of you is who I'm building this for: people
-            doing hard work who deserve to be seen for it. Welcome aboard.
+            You're the <span style={{ fontWeight: 600, color: 'var(--t-title)' }}>{ordinal(downloadCount)}</span> person
+            {' '}to let Meridian watch a day of their work. This only gets built by people like you actually using
+            it - so if a day you cared about used to slip past unrecorded, it won't anymore. Glad you're here.
           </p>
-          <p style={{ fontSize: 12, color: 'var(--t-faint)', marginTop: 6 }}>- Aditya</p>
         </div>
       )}
       {error ? (

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -243,7 +243,7 @@ export function Welcome({ onBegin, steps, ready, error, onRetry, downloadCount }
         }}>
           <p style={{ fontSize: 12, lineHeight: 1.55, color: 'var(--t-muted)' }}>
             You're the <span style={{ fontWeight: 600, color: 'var(--t-title)' }}>{ordinal(downloadCount)}</span> person
-            {' '}to let Meridian watch a day of their work. This only gets built by people like you actually using
+            {' '}to bring Meridian into their day. This only gets built by people like you actually using
             it - so if a day you cared about used to slip past unrecorded, it won't anymore. Glad you're here.
           </p>
         </div>

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -176,7 +176,21 @@ function IntelligenceBody({ wiz }: { wiz: Wiz }) {
 }
 
 // ── Welcome (pre-step intro) ──────────────────────────────────────────────────
-export function Welcome({ onBegin, steps, ready, error, onRetry }: {
+
+/** `214` → `'214th'`, `1` → `'1st'`, `11`/`12`/`13` → `'11th'`/`'12th'`/`'13th'`
+ *  (the -11/-12/-13 exception to the usual 1/2/3 → st/nd/rd rule). */
+function ordinal(n: number): string {
+  const rem100 = n % 100
+  if (rem100 >= 11 && rem100 <= 13) return `${n}th`
+  switch (n % 10) {
+    case 1: return `${n}st`
+    case 2: return `${n}nd`
+    case 3: return `${n}rd`
+    default: return `${n}th`
+  }
+}
+
+export function Welcome({ onBegin, steps, ready, error, onRetry, downloadCount }: {
   onBegin: () => void
   steps: StepMeta[]
   /** False until `get_platform` resolves — "Get started" stays disabled so the
@@ -184,6 +198,11 @@ export function Welcome({ onBegin, steps, ready, error, onRetry }: {
   ready: boolean
   error: boolean
   onRetry: () => void
+  /** Live count of Meridian downloads so far (page.tsx's `get_download_count`
+   *  fetch), for the founder-note card below. `null` while loading or if the
+   *  website was unreachable — the card just doesn't render rather than
+   *  showing a placeholder or a stale-looking zero. */
+  downloadCount: number | null
 }) {
   const points = [
     { t: 'On-device', d: 'Your screen is read and understood locally on your device, never uploaded.' },
@@ -215,6 +234,21 @@ export function Welcome({ onBegin, steps, ready, error, onRetry }: {
           </div>
         ))}
       </div>
+      {downloadCount !== null && (
+        <div style={{
+          maxWidth: 360, width: '100%', textAlign: 'left', margin: '0 0 22px',
+          padding: '13px 15px', borderRadius: 13,
+          background: 'color-mix(in srgb, var(--color-state-proposal) 6%, transparent)',
+          border: '0.5px solid var(--t-card-border)',
+        }}>
+          <p style={{ fontSize: 12, lineHeight: 1.55, color: 'var(--t-muted)' }}>
+            Hey - you're the <span style={{ fontWeight: 600, color: 'var(--t-title)' }}>{ordinal(downloadCount)}</span> person
+            {' '}to give Meridian a shot. That still means a lot to me - every one of you is who I'm building this for: people
+            doing hard work who deserve to be seen for it. Welcome aboard.
+          </p>
+          <p style={{ fontSize: 12, color: 'var(--t-faint)', marginTop: 6 }}>- Aditya</p>
+        </div>
+      )}
       {error ? (
         <div className="flex flex-col items-center" style={{ gap: 8 }}>
           <p style={{ fontSize: 12, color: 'var(--color-state-pending)' }}>Couldn't detect your platform - try again.</p>

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -936,8 +936,8 @@ export interface InstallOutcome {
 
 /** Live Meridian download count for the setup wizard's Welcome screen.
  *  Mirrors `DownloadCount` in `tray/src-tauri/src/commands/downloads.rs`.
- *  `count` is null when the website was unreachable and there's no cached
- *  value yet — the Welcome screen just omits the line in that case. */
+ *  `count` is null when the GitHub releases API was unreachable and there's
+ *  no cached value yet — the Welcome screen just omits the line in that case. */
 export interface DownloadCountResponse {
   count: number | null
 }

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -931,3 +931,13 @@ export interface InstallOutcome {
   /** The command that was actually run, for display and debugging. */
   command: string
 }
+
+// ── setup wizard ─────────────────────────────────────────────────────────────
+
+/** Live Meridian download count for the setup wizard's Welcome screen.
+ *  Mirrors `DownloadCount` in `tray/src-tauri/src/commands/downloads.rs`.
+ *  `count` is null when the website was unreachable and there's no cached
+ *  value yet — the Welcome screen just omits the line in that case. */
+export interface DownloadCountResponse {
+  count: number | null
+}


### PR DESCRIPTION
## Summary
- The setup wizard's Welcome screen now shows a short note that names which downloader you are ("You're the 214th person to bring Meridian into their day...") - the goal is to make the very first screen feel personal, not like a tool booted up.
- The number is the sum of `download_count` across every asset on the latest GitHub release, read from the public GitHub Releases API - the same source `get_version` already reads. No Resend, no companion website endpoint, no secrets: Meridian's DMG/installer are published as GitHub release assets and the website's `/dl` redirect already points there, so GitHub is already counting every download for us.
- Fails silently: if GitHub is unreachable and there's no cached count yet, the card just doesn't render - this is a warm decoration, never something setup depends on.

## Design notes
- No email/sign-in required to show this - it renders on the very first Welcome screen, before the wizard steps begin.
- Count is cached process-wide in the tray for 5 minutes.
- (Earlier revision of this PR sourced the count from a Resend audience via a new website endpoint - dropped once Resend was ruled out as a dependency, in favor of this simpler zero-secret approach.)

## Test plan
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings`
- [x] `cargo build` / `cargo check` on the tray crate
- [x] `npm run build` (ui) - static export builds clean, `tsc --noEmit` shows no errors in changed files
- [x] Full pre-push suite passed (fmt, clippy, ui build/tests, security audit, cargo test)
- [ ] Manual check in a packaged/dev build: open the setup wizard and confirm the welcome-note card renders with a real number