### PR TITLE
feat(analytics): ping public updates-counter on worklog post and personal-task write

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -266,6 +266,7 @@ jobs:
       MERIDIAN_JIRA_OAUTH_CLIENT_SECRET: ${{ secrets.JIRA_OAUTH_CLIENT_SECRET }}
       MERIDIAN_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
       MERIDIAN_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+      MERIDIAN_COUNTER_API_KEY: ${{ secrets.COUNTER_API_KEY }}
       MERIDIAN_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_PROD }}
       MERIDIAN_CHANNEL: ${{ needs.prepare.outputs.channel }}
       MERIDIAN_HF_ENDPOINT: https://hf.meridiona.com
@@ -579,6 +580,7 @@ jobs:
       MERIDIAN_JIRA_OAUTH_CLIENT_SECRET: ${{ secrets.JIRA_OAUTH_CLIENT_SECRET }}
       MERIDIAN_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
       MERIDIAN_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+      MERIDIAN_COUNTER_API_KEY: ${{ secrets.COUNTER_API_KEY }}
       MERIDIAN_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_PROD }}
       MERIDIAN_CHANNEL: ${{ needs.prepare.outputs.channel }}
       MERIDIAN_HF_ENDPOINT: https://hf.meridiona.com

--- a/tray/src-tauri/src/commands/plan_tasks.rs
+++ b/tray/src-tauri/src/commands/plan_tasks.rs
@@ -171,6 +171,7 @@ pub async fn create_plan_task(body: CreatePlanTaskBody) -> Result<CreatedTask, S
         synced = created.synced,
         "plan-task-create served"
     );
+    tauri::async_runtime::spawn(crate::counter_ping::ping_task_update());
     Ok(created)
 }
 
@@ -195,6 +196,7 @@ pub async fn edit_plan_task(body: EditPlanTaskBody) -> Result<EditResult, String
 
     let res: EditResult = run_meridian_json(&args, WRITE_TIMEOUT, "plan-task-edit").await?;
     tracing::info!(status = %res.status, provider = %res.provider, "plan-task-edit served");
+    tauri::async_runtime::spawn(crate::counter_ping::ping_task_update());
     Ok(res)
 }
 
@@ -215,6 +217,7 @@ pub async fn set_plan_task_done(body: SetPlanTaskDoneBody) -> Result<EditResult,
 
     let res: EditResult = run_meridian_json(&args, WRITE_TIMEOUT, "plan-task-done").await?;
     tracing::info!(status = %res.status, provider = %res.provider, "plan-task-done served");
+    tauri::async_runtime::spawn(crate::counter_ping::ping_task_update());
     Ok(res)
 }
 

--- a/tray/src-tauri/src/counter_ping.rs
+++ b/tray/src-tauri/src/counter_ping.rs
@@ -1,0 +1,243 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Public "worklog/task update" counter — a single fire-and-forget ping to the
+//! meridiona.com website's live counter, incremented once per confirmed
+//! worklog post or personal-task create/update, powering the "N updates
+//! logged and counting" stat on the landing page.
+//!
+//! # What this is
+//! A single POST to `{COUNTER_HOST}/api/counter/increment`, no payload beyond
+//! auth — the website only needs to know "one more happened", not who or
+//! what. Gated to `build_channel() == "prod"` so dev/staging runs never
+//! inflate the public number (mirrors how `analytics.rs` tags every event
+//! with a `channel` property instead — but this endpoint has no room for a
+//! property, so non-prod channels are filtered out entirely rather than sent
+//! and later excluded by a dashboard filter).
+//!
+//! Two call shapes:
+//! - **Personal task create/update** — a direct, one-shot [`ping_task_update`]
+//!   call from the `#[tauri::command]` wrappers in `commands::plan_tasks`,
+//!   right after `run_meridian_json` confirms success. A single command
+//!   invocation IS the event; no dedup needed.
+//! - **Worklog posted to a PM provider** — the state transition happens in
+//!   the daemon process (`src/pm_worklog/post.rs`), a separate OS process the
+//!   tray has no direct hook into. [`check_worklog_posts`] instead diffs
+//!   today's worklogs (already read every poll tick by
+//!   `poll::refresh::refresh_worklogs`) against a persisted set of
+//!   already-pinged ids, so a newly `posted` row is caught within one ~60s
+//!   tick without the daemon needing any analytics wiring of its own.
+//!
+//! **Best-effort, not exactly-once.** Unlike `analytics.rs`'s retry-until-success
+//! bookkeeping, a failed [`ping_task_update`] is simply dropped. The
+//! worklog-diff path is slightly sturdier: an id is only added to the pinged
+//! set on a successful ping, so a network blip retries it next tick. Either
+//! way, a public vanity counter occasionally missing an increment is an
+//! accepted tradeoff — it doesn't justify `daily_usage`-grade retry machinery.
+//!
+//! # Who calls this
+//! - `commands::plan_tasks::{create_plan_task, edit_plan_task, set_plan_task_done}`
+//! - `poll::mod` (via [`check_worklog_posts`], right after `refresh_worklogs`)
+//!
+//! # Related
+//! - [`crate::analytics`] — the sibling PostHog pipeline; same channel-gating
+//!   idea, different endpoint and no per-event identity.
+//! - `crate::commands::version::build_channel`
+
+use meridian_core::SqlitePool;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// The live counter's public host — the meridiona.com marketing site.
+const COUNTER_HOST: &str = "https://meridiona.com";
+
+/// Compiled-in shared secret for the increment endpoint (mirrors
+/// `analytics::DEFAULT_POSTHOG_API_KEY` — a build-time secret via
+/// `MERIDIAN_COUNTER_API_KEY`, empty in a plain source build, which disables
+/// the ping entirely rather than sending an unauthenticated request the
+/// website would reject).
+const DEFAULT_COUNTER_API_KEY: &str = match option_env!("MERIDIAN_COUNTER_API_KEY") {
+    Some(k) => k,
+    None => "",
+};
+
+/// Resolve the shared secret: the `COUNTER_API_KEY` runtime env override
+/// (e.g. set in `~/.meridian/.env` for a source/dev build) if set and
+/// non-blank, else the compiled-in [`DEFAULT_COUNTER_API_KEY`].
+fn counter_api_key() -> String {
+    std::env::var("COUNTER_API_KEY")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_COUNTER_API_KEY.to_string())
+}
+
+/// POST one increment to the public counter. Returns `true` (a no-op success,
+/// so one-shot callers never treat it as a failure worth retrying) on any
+/// non-`prod` channel or a missing key; a real network/non-2xx failure
+/// returns `false`.
+async fn ping_increment(reason: &str) -> bool {
+    if crate::commands::version::build_channel() != "prod" {
+        tracing::debug!(reason, "counter_ping: non-prod channel — skipping");
+        return true;
+    }
+    let key = counter_api_key();
+    if key.is_empty() {
+        tracing::debug!(reason, "counter_ping: no counter key configured — skipping");
+        return true;
+    }
+    let result = reqwest::Client::new()
+        .post(format!("{COUNTER_HOST}/api/counter/increment"))
+        .bearer_auth(key)
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await;
+    match result {
+        Ok(resp) if resp.status().is_success() => {
+            tracing::debug!(reason, "counter_ping: incremented");
+            true
+        }
+        Ok(resp) => {
+            tracing::warn!(reason, status = %resp.status(), "counter_ping: rejected");
+            false
+        }
+        Err(e) => {
+            tracing::warn!(reason, error = %e, "counter_ping: request failed");
+            false
+        }
+    }
+}
+
+/// One-shot ping for a personal-task create/update, called right after the
+/// owning `#[tauri::command]` confirms success. Callers spawn this via
+/// `tauri::async_runtime::spawn` rather than awaiting it inline, so a slow
+/// counter response never delays the command's response to the UI.
+pub(crate) async fn ping_task_update() {
+    ping_increment("task_update").await;
+}
+
+/// Persisted dedup state for [`check_worklog_posts`] — a plain per-day set of
+/// already-pinged `pm_worklogs.id` values, so a tray restart mid-day doesn't
+/// re-ping rows it already reported. Reset whenever the local day rolls over,
+/// since `refresh_worklogs` (and this check) only ever reads today's rows.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct CounterPingState {
+    day: String,
+    #[serde(default)]
+    pinged_worklog_ids: HashSet<i64>,
+}
+
+fn counter_ping_state_path() -> Option<PathBuf> {
+    meridian_core::paths::home_dir().map(|h| h.join(".meridian/counter_ping_state.json"))
+}
+
+/// Load the state file, starting a fresh (empty) set if absent, unparseable,
+/// or stamped for a previous day.
+fn load_state(path: &std::path::Path, today: &str) -> CounterPingState {
+    if let Ok(s) = std::fs::read_to_string(path) {
+        if let Ok(state) = serde_json::from_str::<CounterPingState>(&s) {
+            if state.day == today {
+                return state;
+            }
+        }
+    }
+    CounterPingState {
+        day: today.to_string(),
+        pinged_worklog_ids: HashSet::new(),
+    }
+}
+
+fn save_state(path: &std::path::Path, state: &CounterPingState) {
+    if let Err(e) = meridian_core::fs_utils::atomic_write_json(path, state) {
+        tracing::warn!(error = %e, "counter_ping: could not persist state file");
+    }
+}
+
+/// Diff today's worklogs against the persisted pinged-id set and ping once
+/// per newly `posted` row. Called every poll tick, right after
+/// `poll::refresh::refresh_worklogs` reads the same list.
+#[tracing::instrument(skip(pool))]
+pub(crate) async fn check_worklog_posts(pool: &SqlitePool) {
+    let Some(path) = counter_ping_state_path() else {
+        return;
+    };
+    let today = meridian_core::date::today_string();
+    let mut state = load_state(&path, &today);
+
+    let worklogs = match meridian_core::worklogs::get_worklogs(pool, &today).await {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::warn!(error = %e, "counter_ping: worklogs read failed");
+            return;
+        }
+    };
+
+    let newly_posted: Vec<i64> = worklogs
+        .items
+        .iter()
+        .filter(|i| i.state == "posted" && !state.pinged_worklog_ids.contains(&i.id))
+        .map(|i| i.id)
+        .collect();
+
+    let mut dirty = false;
+    for id in newly_posted {
+        if ping_increment("worklog_posted").await {
+            state.pinged_worklog_ids.insert(id);
+            dirty = true;
+        }
+    }
+
+    if dirty {
+        save_state(&path, &state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A state file written for a previous day must not leak its pinged ids
+    /// into today — otherwise a worklog posted today that happens to reuse an
+    /// id pinged on a prior day (or, more realistically, a stale file left
+    /// behind by a bug) would be silently skipped.
+    #[test]
+    fn load_state_resets_on_day_change() {
+        let path = std::env::temp_dir().join(format!(
+            "meridian_counter_ping_test_{}.json",
+            std::process::id()
+        ));
+        let stale = CounterPingState {
+            day: "2026-01-01".to_string(),
+            pinged_worklog_ids: HashSet::from([1, 2, 3]),
+        };
+        std::fs::write(&path, serde_json::to_string(&stale).unwrap()).unwrap();
+
+        let state = load_state(&path, "2026-01-02");
+
+        assert_eq!(state.day, "2026-01-02");
+        assert!(state.pinged_worklog_ids.is_empty());
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Same-day reload must preserve the already-pinged ids — otherwise a
+    /// tray restart mid-day would re-ping every worklog posted before it.
+    #[test]
+    fn load_state_preserves_same_day_ids() {
+        let path = std::env::temp_dir().join(format!(
+            "meridian_counter_ping_test_same_{}.json",
+            std::process::id()
+        ));
+        let today = CounterPingState {
+            day: "2026-01-02".to_string(),
+            pinged_worklog_ids: HashSet::from([42]),
+        };
+        std::fs::write(&path, serde_json::to_string(&today).unwrap()).unwrap();
+
+        let state = load_state(&path, "2026-01-02");
+
+        assert_eq!(state.day, "2026-01-02");
+        assert!(state.pinged_worklog_ids.contains(&42));
+
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@
 //! - [`sys`]         — shared uid / notify / dashboard-URL helpers.
 //! - [`format`]      — duration formatting for the popover.
 //! - [`analytics`]   — PostHog product-analytics capture (DMG installs only).
+//! - [`counter_ping`] — public "updates logged" live-counter ping (prod channel only).
 
 mod analytics;
 mod backend_install;
@@ -23,6 +24,7 @@ mod capture;
 // it must exist in non-capture builds too (nothing reads it there — harmless).
 mod capture_ignore;
 mod commands;
+mod counter_ping;
 mod deep_link;
 
 /// Lowercase product name as macOS reports it after [`set_process_display_name`].

--- a/tray/src-tauri/src/poll/mod.rs
+++ b/tray/src-tauri/src/poll/mod.rs
@@ -78,6 +78,14 @@ pub async fn run_poll_loop(app: tauri::AppHandle, state: Arc<Mutex<AppState>>) {
             }
             if do_worklogs {
                 refresh_worklogs(pool, &state).await;
+                // Spawned off, not awaited inline: this can make one HTTP call
+                // per newly-posted worklog this tick, and a slow/hanging
+                // counter response (5s timeout each) must not delay the
+                // more user-visible steps below.
+                let counter_pool = pool.clone();
+                tauri::async_runtime::spawn(async move {
+                    crate::counter_ping::check_worklog_posts(&counter_pool).await;
+                });
             }
             if do_health {
                 permissions::check_permissions(&app, pool).await;


### PR DESCRIPTION
## Summary

Client-side half of the public "N updates logged and counting" live counter on the meridiona.com landing page (companion website PR: Meridiona/meridiona-website#64).

- New `tray/src-tauri/src/counter_ping.rs` module. Two call shapes, both fire-and-forget (`tauri::async_runtime::spawn`, never awaited inline):
  - **Personal task create/edit/done** — a direct one-shot ping from `commands::plan_tasks::{create_plan_task, edit_plan_task, set_plan_task_done}`, right after the command confirms success.
  - **Worklog posted to a PM provider** — the state transition (`state='posted'`) happens in the separate daemon process, so the tray instead diffs today's worklogs (already read every poll tick by `refresh_worklogs`) against a persisted per-day set of already-pinged ids (`~/.meridian/counter_ping_state.json`), pinging once per newly-posted row.
- Gated to `build_channel() == "prod"` — dev/staging runs never inflate the public number, mirroring `analytics.rs`'s existing PostHog wiring.
- Shared secret resolved the same way as the PostHog key: compiled in via `MERIDIAN_COUNTER_API_KEY` (empty in a plain source build → disables the ping entirely), with a `COUNTER_API_KEY` runtime env override for local testing. Added `MERIDIAN_COUNTER_API_KEY: ${{ secrets.COUNTER_API_KEY }}` to both prod build jobs in `.github/workflows/release-build.yml`, next to the existing `MERIDIAN_POSTHOG_API_KEY` line.

## Required manual step before this is live

A new GitHub Actions secret `COUNTER_API_KEY` must be set on this repo, and its value must **exactly match** the `COUNTER_INCREMENT_SECRET` Cloudflare Worker secret set on the website side (`wrangler secret put COUNTER_INCREMENT_SECRET` — see Meridiona/meridiona-website#64's description). Until both are set, the ping silently no-ops (empty compiled-in key → skipped, same behavior as a missing PostHog key).

## Test plan

- [x] `cargo build --lib` / `cargo fmt --check` / `cargo clippy -- -D warnings` all pass
- [x] `cargo test --lib counter_ping` — new unit tests for the day-rollover reset/preserve logic in the persisted dedup state
- [x] Full pre-push suite (fmt + clippy + cargo test + ui tests + security audit) passed on push
- [ ] Manual: once `COUNTER_API_KEY`/`COUNTER_INCREMENT_SECRET` are set and this + the website PR are both deployed, post a real worklog / create a personal task on a prod-channel build and confirm the landing page counter increments