### PR TITLE
fix(windows): stop the running daemon before restaging its binary

### DIFF
--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -195,6 +195,14 @@ async fn install(backend: &Path, home: &Path) -> Result<(), String> {
         migrate_legacy_bundle_env(home).await;
     }
 
+    // Windows keeps a running exe's pages mapped, so overwriting it fails with
+    // "the process cannot access the file" (os error 32) — and this isn't just
+    // a first-install concern: `ensure_backend_installed` re-stages on every
+    // version bump while the *previous* build's daemon is still alive from an
+    // earlier login. Stop it first so the copy below can succeed.
+    #[cfg(target_os = "windows")]
+    stop_running_daemon_before_stage().await;
+
     let daemon_bin = home.join(".meridian").join("bin").join(DAEMON_FILE);
     stage_binary(&backend.join(DAEMON_FILE), &daemon_bin).await?;
 
@@ -304,6 +312,56 @@ async fn register_service(_backend: &Path, home: &Path, daemon_bin: &Path) -> Re
             );
             Ok(())
         }
+    }
+}
+
+/// Stop any running instance of the staged daemon so [`stage_binary`] can
+/// overwrite `~/.meridian/bin/meridian.exe`. Best-effort on two fronts,
+/// because the daemon can be running via either path [`register_service`] may
+/// have taken:
+/// - `schtasks /End` stops it if the scheduled task is what launched it.
+/// - `taskkill /IM` also catches the Startup-folder-launcher fallback case,
+///   where the process was spawned directly by `wscript` and has no
+///   association with the scheduled task for `/End` to find.
+///
+/// Killing the process doesn't release its file handle instantaneously, so
+/// this polls (mirroring the launchd bootout wait in [`register_agent`])
+/// rather than proceeding immediately — a fixed sleep would either race a
+/// slow exit or pad every install with unnecessary wait time.
+#[cfg(target_os = "windows")]
+async fn stop_running_daemon_before_stage() {
+    let _ = tokio::process::Command::new("schtasks")
+        .args(["/End", "/TN", WINDOWS_TASK_NAME])
+        .output()
+        .await;
+    let _ = tokio::process::Command::new("taskkill")
+        .args(["/F", "/IM", DAEMON_FILE])
+        .output()
+        .await;
+    for _ in 0..10 {
+        if !daemon_process_running().await {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    }
+}
+
+/// Whether a process named [`DAEMON_FILE`] currently shows up in `tasklist`.
+#[cfg(target_os = "windows")]
+async fn daemon_process_running() -> bool {
+    let out = tokio::process::Command::new("tasklist")
+        .args([
+            "/FI",
+            &format!("IMAGENAME eq {DAEMON_FILE}"),
+            "/FO",
+            "CSV",
+            "/NH",
+        ])
+        .output()
+        .await;
+    match out {
+        Ok(o) => String::from_utf8_lossy(&o.stdout).contains(DAEMON_FILE),
+        Err(_) => false,
     }
 }
 


### PR DESCRIPTION
## Summary
- `ensure_backend_installed` re-stages the bundled daemon into `~/.meridian/bin/meridian.exe` on every version bump, but the previous build's daemon can still be running from that exact path (via the scheduled task, or the Startup-folder VBScript fallback on machines where `schtasks` is policy-blocked). Windows keeps a running exe's pages mapped, so the copy fails with "the process cannot access the file" (os error 32), surfaced to users as "Meridian couldn't finish installing."
- Added a Windows-only `stop_running_daemon_before_stage` step in `backend_install::install`, run right before `stage_binary`: best-effort `schtasks /End` (stops it if the scheduled task launched it) plus `taskkill /F /IM meridian.exe` (also catches the Startup-folder-launcher case), then polls `tasklist` for up to ~3s so the file handle actually clears before the copy is attempted.
- macOS is unaffected (block is `#[cfg(target_os = "windows")]`).

## Test plan
- [x] `cargo check` / `cargo clippy -- -D warnings` on the tray crate
- [x] Full `pre-push` hook suite (fmt, ui build, clippy, ui tests, cargo test, security audit) — all green
- [ ] Verify on a real machine that a version update no longer raises the "Meridian couldn't finish installing" notice
