### PR TITLE
fix: 4 memory-growth/leak fixes (ETL session-text, capture retention, MCP DB cache, summariser ledger, UI stores)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,7 @@ There are no JS/TS test suites yet. When adding them, place them under `ui/__tes
 | `MERIDIAN_EMBEDDER_DIR` | `~/.meridian/models/<repo-basename>/` | Override the on-disk directory the session-distiller embedding weights live in (`src/embedder/provision.rs`). |
 | `MERIDIAN_EMBEDDER_REPO` | `BAAI/bge-small-en-v1.5` | Override the HuggingFace repo the embedder weights are fetched from. |
 | `DISTILLER_SEM_DEDUP_THR` | `0.86` | Cosine threshold for the distiller's semantic dedup (`src/worklog_pipeline/distiller/`). |
+| `MERIDIAN_CAPTURE_RETENTION_DAYS` | `30` | Age floor for the capture_frames/capture_ui_events/capture_secondary_screens retention sweep (`src/etl/capture_retention.rs`) — only prunes rows both older than this AND already consumed by the ETL cursor. |
 
 Tilde expansion is handled by `Config::from_env()`. Never hardcode paths.
 

--- a/packages/meridian-mcp/package-lock.json
+++ b/packages/meridian-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meridian-mcp",
-  "version": "1.28.1",
+  "version": "1.74.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meridian-mcp",
-      "version": "1.28.1",
+      "version": "1.74.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",

--- a/packages/meridian-mcp/package.json
+++ b/packages/meridian-mcp/package.json
@@ -12,6 +12,7 @@
     "start": "node dist/index.js",
     "install-mcp": "node dist/install.js",
     "dev": "ts-node src/index.ts",
+    "test": "tsc && node --test \"dist/__tests__/*.test.js\"",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/packages/meridian-mcp/src/__tests__/db-cache.test.ts
+++ b/packages/meridian-mcp/src/__tests__/db-cache.test.ts
@@ -1,0 +1,97 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+
+// Tests for db-cache.ts's mtime/size-gated sql.js Database cache — the fix
+// for the MCP server re-reading + re-allocating the whole meridian.db file
+// on every single tool call. Run via `node --test` (built-in Node test
+// runner, no extra test-framework dependency) against the compiled output:
+// `npm run build && node --test dist/__tests__/`.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import initSqlJs from "sql.js";
+import { openCachedDb, _resetDbCacheForTests, _dbCacheSizeForTests } from "../db-cache.js";
+
+async function makeTempDb(dir: string, name: string, seedRows: number): Promise<string> {
+  const SQL = await initSqlJs();
+  const db = new SQL.Database();
+  db.run("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)");
+  for (let i = 0; i < seedRows; i++) {
+    db.run("INSERT INTO t (val) VALUES (?)", [`row-${i}`]);
+  }
+  const bytes = db.export();
+  db.close();
+  const dbPath = path.join(dir, name);
+  fs.writeFileSync(dbPath, bytes);
+  return dbPath;
+}
+
+test("openCachedDb reuses the same instance when the file is unchanged", async () => {
+  _resetDbCacheForTests();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "meridian-mcp-cache-test-"));
+  try {
+    const dbPath = await makeTempDb(dir, "meridian.db", 3);
+
+    const first = await openCachedDb(dbPath);
+    const second = await openCachedDb(dbPath);
+
+    assert.strictEqual(second, first, "second call must return the exact same cached instance");
+    assert.equal(_dbCacheSizeForTests(), 1, "exactly one path must be cached");
+  } finally {
+    _resetDbCacheForTests();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("openCachedDb reloads when the file's mtime/size changes", async () => {
+  _resetDbCacheForTests();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "meridian-mcp-cache-test-"));
+  try {
+    const dbPath = await makeTempDb(dir, "meridian.db", 3);
+
+    const first = await openCachedDb(dbPath);
+    const firstRows = first.exec("SELECT COUNT(*) AS n FROM t")[0].values[0][0];
+    assert.equal(firstRows, 3);
+
+    // Rewrite the file with different content (different size) and bump
+    // mtime forward so the cache's stat comparison is guaranteed to differ
+    // even on filesystems with coarse mtime resolution.
+    await makeTempDb(dir, "meridian.db", 7);
+    const future = new Date(Date.now() + 5000);
+    fs.utimesSync(dbPath, future, future);
+
+    const second = await openCachedDb(dbPath);
+    assert.notStrictEqual(second, first, "changed file must produce a new instance, not the cached one");
+
+    const secondRows = second.exec("SELECT COUNT(*) AS n FROM t")[0].values[0][0];
+    assert.equal(secondRows, 7, "reloaded instance must reflect the new file contents");
+  } finally {
+    _resetDbCacheForTests();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("openCachedDb throws when the file does not exist", async () => {
+  _resetDbCacheForTests();
+  await assert.rejects(
+    () => openCachedDb("/nonexistent/path/does-not-exist.db"),
+    /Meridian DB not found/,
+  );
+});
+
+test("concurrent openCachedDb calls on a fresh path dedupe onto one load", async () => {
+  _resetDbCacheForTests();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "meridian-mcp-cache-test-"));
+  try {
+    const dbPath = await makeTempDb(dir, "meridian.db", 1);
+
+    const [a, b] = await Promise.all([openCachedDb(dbPath), openCachedDb(dbPath)]);
+    assert.strictEqual(b, a, "concurrent calls for the same fresh path must resolve to one instance");
+    assert.equal(_dbCacheSizeForTests(), 1);
+  } finally {
+    _resetDbCacheForTests();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/meridian-mcp/src/db-cache.ts
+++ b/packages/meridian-mcp/src/db-cache.ts
@@ -1,0 +1,111 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+
+// Cached sql.js Database loader.
+//
+// sql.js is pure WASM (no native compile step) — deliberately chosen over
+// better-sqlite3 for this package specifically because native-module ABI
+// mismatches across Node versions/platforms caused real distribution pain
+// elsewhere in this project's history. Do not swap this for better-sqlite3;
+// see the memory-leak-audit fix that added this module for the full context.
+//
+// Without caching, every MCP tool call did fs.readFileSync(dbPath) (one full
+// copy of meridian.db into a Node Buffer) followed by `new SQL.Database(...)`
+// (a second full copy into WASM linear memory), and emscripten never returns
+// freed WASM pages to the OS — so process RSS climbed to the size of the
+// largest DB ever loaded and stayed there, and got worse every tool call.
+//
+// This module reuses a single long-lived Database instance per dbPath across
+// calls, invalidating (re-reading the file, rebuilding the WASM instance)
+// only when the file's mtime or size changes — a cheap `stat()` per call
+// instead of a full read + WASM rebuild. The daemon is a separate process
+// that writes meridian.db; tool calls are read-mostly, so a small staleness
+// window between a daemon write and the next stat-triggered reload is
+// acceptable in exchange for not re-paying the double-copy cost on every call.
+
+import initSqlJs from "sql.js";
+import * as fs from "fs";
+
+export type SqlJsStatic = Awaited<ReturnType<typeof initSqlJs>>;
+export type SqlDatabase = InstanceType<SqlJsStatic["Database"]>;
+
+interface CachedDb {
+  db: SqlDatabase;
+  mtimeMs: number;
+  size: number;
+}
+
+let _SQL: SqlJsStatic | null = null;
+
+/** One cached Database (+ the file stat it was loaded from) per dbPath. */
+const _dbCache = new Map<string, CachedDb>();
+
+/** Dedupes concurrent reload attempts for the same path onto one load. */
+const _dbLoadInFlight = new Map<string, Promise<SqlDatabase>>();
+
+async function getSqlEngine(): Promise<SqlJsStatic> {
+  if (!_SQL) {
+    _SQL = await initSqlJs();
+  }
+  return _SQL;
+}
+
+/**
+ * Opens (or reuses) a cached sql.js `Database` for `dbPath`.
+ *
+ * Returns the cached instance as long as the file's `mtimeMs`/`size` (from a
+ * cheap `fs.statSync`) match what was loaded last; otherwise re-reads the
+ * file and rebuilds the WASM `Database`, closing the stale instance first —
+ * sql.js/emscripten never returns freed WASM memory to the OS, so leaving the
+ * old instance open would leak on every reload rather than just on every call.
+ *
+ * Throws if `dbPath` does not exist (mirrors the daemon-not-running check the
+ * old per-call `openDb` performed).
+ */
+export async function openCachedDb(dbPath: string): Promise<SqlDatabase> {
+  if (!fs.existsSync(dbPath)) {
+    throw new Error(`Meridian DB not found at ${dbPath}. Is the Meridian daemon running?`);
+  }
+
+  const stat = fs.statSync(dbPath);
+  const cached = _dbCache.get(dbPath);
+  if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+    return cached.db;
+  }
+
+  // Reuse an in-flight reload for this path instead of racing a second one
+  // if two tool calls both observe a stale cache before either finishes.
+  const inFlight = _dbLoadInFlight.get(dbPath);
+  if (inFlight) return inFlight;
+
+  const loadPromise = (async () => {
+    try {
+      const SQL = await getSqlEngine();
+      const fileBuffer = fs.readFileSync(dbPath);
+      const db = new SQL.Database(fileBuffer);
+
+      const prev = _dbCache.get(dbPath);
+      prev?.db.close();
+
+      _dbCache.set(dbPath, { db, mtimeMs: stat.mtimeMs, size: stat.size });
+      return db;
+    } finally {
+      _dbLoadInFlight.delete(dbPath);
+    }
+  })();
+  _dbLoadInFlight.set(dbPath, loadPromise);
+  return loadPromise;
+}
+
+/** Test-only: closes and clears every cached instance. */
+export function _resetDbCacheForTests(): void {
+  for (const { db } of _dbCache.values()) {
+    db.close();
+  }
+  _dbCache.clear();
+  _dbLoadInFlight.clear();
+}
+
+/** Test-only: number of distinct paths currently cached. */
+export function _dbCacheSizeForTests(): number {
+  return _dbCache.size;
+}

--- a/packages/meridian-mcp/src/index.ts
+++ b/packages/meridian-mcp/src/index.ts
@@ -14,37 +14,21 @@ import {
   ReadResourceRequestSchema,
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
-import initSqlJs from "sql.js";
 import * as os from "os";
 import * as path from "path";
-import * as fs from "fs";
 import { runInstaller } from "./install.js";
+import { openCachedDb, SqlDatabase } from "./db-cache.js";
 
-type SqlJsStatic = Awaited<ReturnType<typeof initSqlJs>>;
-type SqlDatabase = InstanceType<SqlJsStatic["Database"]>;
 type SqlVal = string | number | null | Uint8Array;
 
 function getDbPath(): string {
   return process.env.MERIDIAN_DB ?? path.join(os.homedir(), ".meridian", "meridian.db");
 }
 
-let _SQL: SqlJsStatic | null = null;
-
-async function getSqlEngine(): Promise<SqlJsStatic> {
-  if (!_SQL) {
-    _SQL = await initSqlJs();
-  }
-  return _SQL;
-}
-
+// Reuses a single long-lived sql.js Database per dbPath instead of reopening
+// (double-reading + double-allocating) it on every tool call — see db-cache.ts.
 async function openDb(): Promise<SqlDatabase> {
-  const dbPath = getDbPath();
-  if (!fs.existsSync(dbPath)) {
-    throw new Error(`Meridian DB not found at ${dbPath}. Is the Meridian daemon running?`);
-  }
-  const SQL = await getSqlEngine();
-  const fileBuffer = fs.readFileSync(dbPath);
-  return new SQL.Database(fileBuffer);
+  return openCachedDb(getDbPath());
 }
 
 function dbGet(db: SqlDatabase, sql: string, params: SqlVal[] = []): Record<string, unknown> | undefined {
@@ -1089,9 +1073,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       span.setAttribute("error", true);
       logger.error({ tool_name: name, err: msg }, "mcp tool failed");
       return { content: [{ type: "text", text: `Error: ${msg}` }] };
-    } finally {
-      db?.close();
     }
+    // No `finally { db?.close() }` here anymore: `db` is now a cached,
+    // long-lived instance owned by db-cache.ts, reused across tool calls —
+    // closing it per call would defeat the cache. db-cache.ts closes the
+    // stale instance itself when the underlying file changes.
   });
 });
 

--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -671,6 +671,11 @@ async fn drain(
         let outcome = summarise_one(pool, row, cfg, true).await;
         if outcome.written {
             summarised += 1;
+            // Row succeeded and moved past pending_summariser — drop its
+            // ledger entry via record_attempt so `attempts` only ever holds
+            // currently-pending rows that have failed at least once, not
+            // every row that ever failed once over the daemon's lifetime.
+            record_attempt(attempts, row.id, true);
         } else if outcome.rate_limited {
             // Apply per-source backoff so other sources can still drain.
             let until =
@@ -685,8 +690,8 @@ async fn drain(
             );
         } else {
             // Transient failure. Leave pending for retry; log so it isn't silent.
-            let tries = tries + 1;
-            attempts.insert(row.id, tries);
+            let tries = record_attempt(attempts, row.id, false)
+                .expect("record_attempt(.., written=false) always returns Some");
             if tries >= MAX_ROW_ATTEMPTS {
                 if let Err(e) = db::write_dead_letter(pool, row.id).await {
                     tracing::error!(row_id = row.id, error = %e, "failed to dead-letter row");
@@ -715,6 +720,29 @@ async fn drain(
     // Signal global backoff only when ALL rows were skipped due to source
     // backoffs — nothing useful can be done until at least one source recovers.
     skipped_backoff > 0 && skipped_backoff == rows.len() as u32 && summarised == 0
+}
+
+/// Updates the per-row failure ledger (`attempts`, see [`MAX_ROW_ATTEMPTS`])
+/// after one `summarise_one` outcome.
+///
+/// On success (`written = true`) the row's entry is removed entirely —
+/// `attempts` must only ever hold currently-pending rows that have failed at
+/// least once this daemon lifetime, not every row that has ever failed once,
+/// which would otherwise grow the map forever as rows are summarised and new
+/// ones come in. Returns `None` in that case.
+///
+/// On failure (`written = false`) the row's attempt count is incremented and
+/// the new count returned as `Some(tries)`, for the caller to compare against
+/// [`MAX_ROW_ATTEMPTS`].
+fn record_attempt(attempts: &mut HashMap<i64, u32>, row_id: i64, written: bool) -> Option<u32> {
+    if written {
+        attempts.remove(&row_id);
+        None
+    } else {
+        let tries = attempts.get(&row_id).copied().unwrap_or(0) + 1;
+        attempts.insert(row_id, tries);
+        Some(tries)
+    }
 }
 
 /// One-shot CLI: `meridian coding-agent-summarise [--dry-run] [--day D] [--limit N]`.
@@ -844,5 +872,59 @@ mod tests {
 
         let p2 = build_prompt("just work", None, 1000);
         assert!(!p2.contains("EARLIER IN THIS SESSION"));
+    }
+
+    #[test]
+    fn record_attempt_removes_entry_on_success() {
+        let mut attempts: HashMap<i64, u32> = HashMap::new();
+        attempts.insert(42, 2); // simulate two prior failures
+
+        let result = record_attempt(&mut attempts, 42, true);
+
+        assert_eq!(result, None);
+        assert!(
+            !attempts.contains_key(&42),
+            "a row that succeeds must have its ledger entry removed, not just left at its prior count"
+        );
+    }
+
+    #[test]
+    fn record_attempt_increments_on_failure() {
+        let mut attempts: HashMap<i64, u32> = HashMap::new();
+
+        assert_eq!(record_attempt(&mut attempts, 7, false), Some(1));
+        assert_eq!(record_attempt(&mut attempts, 7, false), Some(2));
+        assert_eq!(record_attempt(&mut attempts, 7, false), Some(3));
+        assert_eq!(attempts.get(&7), Some(&3));
+    }
+
+    #[test]
+    fn record_attempt_success_after_failures_leaves_no_trace() {
+        let mut attempts: HashMap<i64, u32> = HashMap::new();
+
+        record_attempt(&mut attempts, 99, false);
+        record_attempt(&mut attempts, 99, false);
+        record_attempt(&mut attempts, 99, true); // succeeds on the third try
+
+        assert!(
+            attempts.is_empty(),
+            "map must not retain any entry for a row once it has succeeded"
+        );
+    }
+
+    #[test]
+    fn record_attempt_only_touches_the_given_row() {
+        let mut attempts: HashMap<i64, u32> = HashMap::new();
+        record_attempt(&mut attempts, 1, false);
+        record_attempt(&mut attempts, 2, false);
+
+        record_attempt(&mut attempts, 1, true);
+
+        assert!(!attempts.contains_key(&1), "row 1 succeeded — removed");
+        assert_eq!(
+            attempts.get(&2),
+            Some(&1),
+            "row 2's independent failure count must be untouched"
+        );
     }
 }

--- a/src/db/meridian.rs
+++ b/src/db/meridian.rs
@@ -95,7 +95,15 @@ pub async fn setup_db(uri: &str) -> anyhow::Result<SqlitePool> {
         // get an immediate SQLITE_BUSY (default timeout 0) whenever the tray
         // holds the WAL write lock, failing the ETL run. Wait instead — matches
         // the tray's open_existing (5s).
-        .busy_timeout(std::time::Duration::from_secs(5));
+        .busy_timeout(std::time::Duration::from_secs(5))
+        // Lets `crate::etl::capture_retention`'s periodic `incremental_vacuum`
+        // actually reclaim disk space freed by its capture_* table deletes.
+        // Only takes effect on a brand-new (table-less) database file — SQLite
+        // requires a full `VACUUM` to convert an already-populated database
+        // from the default `auto_vacuum = NONE`, which we deliberately never
+        // run automatically on a live daemon (see that module's doc comment).
+        // On an existing database this pragma is simply a documented no-op.
+        .pragma("auto_vacuum", "INCREMENTAL");
 
     let pool = SqlitePool::connect_with(opts)
         .await

--- a/src/db/screenpipe.rs
+++ b/src/db/screenpipe.rs
@@ -329,6 +329,56 @@ pub async fn get_frame_full_texts(
         .collect())
 }
 
+/// Page size for [`fetch_frame_text_page`] — bounds how many frames' OCR/a11y
+/// text are held in memory at once when a block's `session_text` is rebuilt by
+/// paginating rather than by a single [`get_frame_full_texts`] call (see
+/// `rebuild_session_text_paginated` in `crate::etl::block_ops`). Chosen in the
+/// 500-1000 range suggested by the existing `BATCH_SIZE` ETL-batch convention.
+pub const FRAME_TEXT_PAGE_SIZE: i64 = 750;
+
+/// Returns up to `limit` frames with `id` in `(after_id, max_frame_id]` that
+/// have non-empty text, ordered oldest-first — a bounded page of
+/// [`get_frame_full_texts`]'s result set. Falls back to `accessibility_text`
+/// when `full_text` is NULL, same as `get_frame_full_texts`.
+///
+/// Callers paginate by looping: start with `after_id = min_frame_id - 1`, feed
+/// each returned page into an incremental accumulator, advance `after_id` to
+/// the last frame's `frame_id`, and stop once a call returns an empty `Vec`.
+/// Pagination is driven entirely by `id` (not by page-length heuristics), so
+/// it is correct regardless of how many rows in a given `id` range get
+/// filtered out by the non-empty-text predicate.
+pub async fn fetch_frame_text_page(
+    pool: &SqlitePool,
+    after_id: i64,
+    max_frame_id: i64,
+    limit: i64,
+) -> Result<Vec<FrameText>> {
+    let rows = sqlx::query_as::<_, (i64, String, String, String)>(
+        "SELECT id, timestamp, COALESCE(full_text, accessibility_text), COALESCE(text_source, 'ocr')
+         FROM capture_frames
+         WHERE id > ?1 AND id <= ?2
+           AND COALESCE(full_text, accessibility_text) IS NOT NULL
+           AND COALESCE(full_text, accessibility_text) != ''
+         ORDER BY id ASC
+         LIMIT ?3",
+    )
+    .bind(after_id)
+    .bind(max_frame_id)
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|(frame_id, timestamp, full_text, text_source)| FrameText {
+            frame_id,
+            timestamp,
+            full_text,
+            text_source,
+        })
+        .collect())
+}
+
 /// Returns clipboard and app_switch UI events within the given timestamp range.
 /// Clipboard events are deduplicated by value — same text copied multiple times is stored once.
 /// For clipboard events `value` is `text_content`; for app_switch it is `app_name`.

--- a/src/etl/block_ops.rs
+++ b/src/etl/block_ops.rs
@@ -7,9 +7,12 @@ use tracing::{debug, info, warn};
 use crate::db::meridian::{
     close_active_session_with, get_active_session, upsert_active_session, write_session_traceparent,
 };
-use crate::db::screenpipe::{get_frame_full_texts, get_last_ui_event_for_app};
+use crate::db::screenpipe::{
+    fetch_frame_text_page, get_last_ui_event_for_app, FRAME_TEXT_PAGE_SIZE,
+};
 use crate::etl::extractor::extract_block_context;
-use crate::etl::text_merge::build_session_text;
+use crate::etl::text_filter::ChromeFreqAccumulator;
+use crate::etl::text_merge::SessionTextBuilder;
 
 use super::session_builder::{build_active_session, merge_into_active};
 
@@ -19,6 +22,58 @@ pub(super) fn timestamp_gap_secs(earlier: &str, later: &str) -> Option<i64> {
     let t0 = chrono::DateTime::parse_from_rfc3339(earlier).ok()?;
     let t1 = chrono::DateTime::parse_from_rfc3339(later).ok()?;
     Some((t1 - t0).num_seconds())
+}
+
+/// Rebuilds `session_text` for the frame range `min_frame_id..=max_frame_id` by
+/// reading frames from the DB in `FRAME_TEXT_PAGE_SIZE`-sized pages instead of
+/// materializing the whole range in one `Vec<FrameText>`.
+///
+/// Two passes over the paginated read are required: chrome-line detection
+/// (`ChromeFreqAccumulator`) needs a global view of line frequencies across the
+/// *entire* range before any single frame can be classified (see
+/// `crate::etl::text_filter::build_chrome_set`), so pass 1 accumulates
+/// frequencies page-by-page and pass 2 re-pages the same range to fold each
+/// frame into the session text using the now-final chrome set.
+///
+/// This is a memory-shape change only: for the same frame range, the returned
+/// string is functionally identical to
+/// `build_session_text(&get_frame_full_texts(pool, min_frame_id, max_frame_id).await?)` —
+/// no data is truncated or dropped, only held in bounded pages rather than all
+/// at once.
+pub(super) async fn rebuild_session_text_paginated(
+    pool: &SqlitePool,
+    min_frame_id: i64,
+    max_frame_id: i64,
+) -> Result<String> {
+    // Pass 1: accumulate chrome-line frequencies across every page.
+    let mut chrome_acc = ChromeFreqAccumulator::new();
+    let mut after_id = min_frame_id - 1;
+    loop {
+        let page = fetch_frame_text_page(pool, after_id, max_frame_id, FRAME_TEXT_PAGE_SIZE)
+            .await
+            .context("paginated frame-text read (chrome frequency pass)")?;
+        if page.is_empty() {
+            break;
+        }
+        after_id = page.last().map(|f| f.frame_id).unwrap_or(after_id);
+        chrome_acc.feed(&page);
+    }
+    let chrome = chrome_acc.finish();
+
+    // Pass 2: re-page the same range and fold each frame into the session text.
+    let mut builder = SessionTextBuilder::new();
+    let mut after_id = min_frame_id - 1;
+    loop {
+        let page = fetch_frame_text_page(pool, after_id, max_frame_id, FRAME_TEXT_PAGE_SIZE)
+            .await
+            .context("paginated frame-text read (session-text build pass)")?;
+        if page.is_empty() {
+            break;
+        }
+        after_id = page.last().map(|f| f.frame_id).unwrap_or(after_id);
+        builder.feed(&page, &chrome);
+    }
+    Ok(builder.finish())
 }
 
 /// Groups the positional fields shared by `close_block` / `upsert_open_block`
@@ -175,10 +230,16 @@ pub(super) async fn close_block(
             // sub-threshold batches (< CHROME_FREQ_THRESHOLD frames) permanently in the
             // stored text; a full rebuild sees the complete frame set so the chrome
             // pre-pass correctly identifies and removes them.
-            let all_frames = get_frame_full_texts(meridian, active.min_frame_id, b.max_frame_id)
-                .await
-                .context("re-fetch frames for session_text rebuild on close")?;
-            let rebuilt_text = build_session_text(&all_frames);
+            //
+            // Paginated rather than a single fetch_all: a session that stays in one app
+            // for hours (an IDE, one browser tab) never closes early, so by the time it
+            // finally does, `active.min_frame_id..b.max_frame_id` can span many thousands
+            // of frames — a single `get_frame_full_texts` there would spike RSS by the
+            // whole session's OCR text at once. See `rebuild_session_text_paginated`.
+            let rebuilt_text =
+                rebuild_session_text_paginated(meridian, active.min_frame_id, b.max_frame_id)
+                    .await
+                    .context("re-fetch frames for session_text rebuild on close")?;
             let merged = merge_into_active(active, &ctx, b.idle_frame_count, Some(rebuilt_text))?;
             let new_id = close_active_session_with(meridian, &merged, run_id).await?;
             info!(

--- a/src/etl/capture_retention.rs
+++ b/src/etl/capture_retention.rs
@@ -1,0 +1,366 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+
+//! Age + processed-based retention sweep for the capture_* tables
+//! (`capture_frames`, `capture_ui_events`, `capture_secondary_screens`) the
+//! tray's in-process capture engine writes into `meridian.db`.
+//!
+//! Nothing previously pruned these — a frame every ~2s per monitor plus every
+//! click/key/clipboard event, each carrying full OCR/a11y text, grows the DB
+//! forever. This module prunes rows that are BOTH:
+//!
+//!   (a) older than `MERIDIAN_CAPTURE_RETENTION_DAYS` (default 30), AND
+//!   (b) already fully processed by the ETL — strictly before the timestamp
+//!       of the frame at `etl_cursor.last_frame_id` — so a frame the ETL
+//!       hasn't consumed yet is never deleted regardless of age.
+//!
+//! `capture_ui_events` and `capture_secondary_screens` have no frame-id link,
+//! so they're bounded by the same cursor-frame timestamp: any row timestamped
+//! at or after it could still belong to a session the ETL hasn't closed, so
+//! it is left alone.
+//!
+//! Deletes alone don't shrink the SQLite file — `run_incremental_vacuum`
+//! reclaims freed pages on a coarser cadence (not every tick, since it's
+//! extra I/O), bounded per call via `PRAGMA incremental_vacuum(N)` so it
+//! can't stall the daemon scanning a large freelist in one call. This only
+//! does anything once the database's `auto_vacuum` mode is `INCREMENTAL`
+//! (set in `db::meridian::setup_db` for brand-new databases only — retrofitting
+//! an already-populated database would require a full, slow `VACUUM`, which
+//! this module deliberately never runs on a live daemon). On a pre-existing
+//! database still in the default `auto_vacuum = NONE` mode,
+//! `incremental_vacuum` is simply a documented no-op — see SQLite's pragma
+//! docs — so pruned rows still stop growing the *logical* table size, they
+//! just don't shrink the on-disk file until the user runs a manual `VACUUM`.
+//!
+//! # Who calls this
+//!
+//! `src/main.rs`'s poll loop, once per tick, right after `run_etl`.
+
+use anyhow::{Context, Result};
+use sqlx::SqlitePool;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Default retention window, in days, for the capture_* tables.
+const DEFAULT_CAPTURE_RETENTION_DAYS: u64 = 30;
+
+/// Run `PRAGMA incremental_vacuum` once every this many `prune_capture_tables`
+/// calls (i.e. roughly once every N poll ticks) rather than every tick.
+const VACUUM_EVERY_N_TICKS: u64 = 60;
+
+/// Max pages reclaimed per `incremental_vacuum` call — bounds how long a single
+/// call can run so it can't stall the daemon on a large freelist.
+const VACUUM_MAX_PAGES: i64 = 500;
+
+/// Tick counter driving the vacuum cadence. Process-lifetime only (resets on
+/// restart) — an off-by-a-few-ticks cadence drift after a restart is harmless.
+static TICK_COUNT: AtomicU64 = AtomicU64::new(0);
+
+fn capture_retention_days() -> u64 {
+    std::env::var("MERIDIAN_CAPTURE_RETENTION_DAYS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_CAPTURE_RETENTION_DAYS)
+}
+
+/// Prunes old, already-ETL-processed rows from `capture_frames`,
+/// `capture_ui_events`, and `capture_secondary_screens`, then — on a coarser
+/// cadence — runs a bounded `incremental_vacuum` to reclaim freed pages.
+///
+/// Call once per ETL poll tick, after `run_etl` has advanced the cursor.
+#[tracing::instrument(skip(pool))]
+pub async fn prune_capture_tables(pool: &SqlitePool) -> Result<()> {
+    let retention_days = capture_retention_days();
+    let cutoff_ts = (chrono::Utc::now() - chrono::Duration::days(retention_days as i64))
+        .to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+
+    // etl_cursor.last_frame_id is the last frame the ETL has actually
+    // consumed — never prune a frame at or after it.
+    let cursor: Option<(i64,)> =
+        sqlx::query_as("SELECT last_frame_id FROM etl_cursor WHERE id = 1")
+            .fetch_optional(pool)
+            .await
+            .context("read etl_cursor for capture retention")?;
+    let Some((last_frame_id,)) = cursor else {
+        tracing::debug!("capture retention: no etl_cursor row yet — nothing to prune");
+        return Ok(());
+    };
+    if last_frame_id <= 0 {
+        tracing::debug!(
+            last_frame_id,
+            "capture retention: cursor at/before 0 — nothing processed yet"
+        );
+        return Ok(());
+    }
+
+    let cursor_frame: Option<(String,)> =
+        sqlx::query_as("SELECT timestamp FROM capture_frames WHERE id = ?1")
+            .bind(last_frame_id)
+            .fetch_optional(pool)
+            .await
+            .context("read cursor frame timestamp for capture retention")?;
+    let Some((cursor_ts,)) = cursor_frame else {
+        // The cursor's own frame is already gone (previously pruned, or a
+        // fresh DB with a stale cursor) — be conservative and skip this tick
+        // rather than guess a boundary.
+        tracing::debug!(
+            last_frame_id,
+            "capture retention: cursor frame not found — skipping this tick"
+        );
+        return Ok(());
+    };
+
+    // capture_frames has an explicit processed marker (id <= last_frame_id),
+    // so "processed" and "age" are independent conditions there — no need to
+    // also bound by the cursor frame's own timestamp.
+    let frames_deleted =
+        sqlx::query("DELETE FROM capture_frames WHERE id <= ?1 AND timestamp < ?2")
+            .bind(last_frame_id)
+            .bind(&cutoff_ts)
+            .execute(pool)
+            .await
+            .context("prune capture_frames")?
+            .rows_affected();
+
+    // capture_ui_events / capture_secondary_screens have no frame-id link, so
+    // "processed" is approximated by "strictly before the cursor frame's own
+    // timestamp" — a row AT that timestamp might belong to a session the ETL
+    // hasn't finished closing yet, so it's left alone. Combined with the age
+    // cutoff via the earlier (chronologically smaller/older) of the two —
+    // never delete anything at or after either boundary.
+    let ui_secondary_boundary = if cutoff_ts < cursor_ts {
+        &cutoff_ts
+    } else {
+        &cursor_ts
+    };
+
+    let ui_events_deleted = sqlx::query("DELETE FROM capture_ui_events WHERE timestamp < ?1")
+        .bind(ui_secondary_boundary)
+        .execute(pool)
+        .await
+        .context("prune capture_ui_events")?
+        .rows_affected();
+
+    let secondary_screens_deleted =
+        sqlx::query("DELETE FROM capture_secondary_screens WHERE timestamp < ?1")
+            .bind(ui_secondary_boundary)
+            .execute(pool)
+            .await
+            .context("prune capture_secondary_screens")?
+            .rows_affected();
+
+    if frames_deleted > 0 || ui_events_deleted > 0 || secondary_screens_deleted > 0 {
+        tracing::info!(
+            frames_deleted,
+            ui_events_deleted,
+            secondary_screens_deleted,
+            cutoff_ts = %cutoff_ts,
+            cursor_ts = %cursor_ts,
+            retention_days,
+            "capture retention: pruned old, already-processed rows"
+        );
+    } else {
+        tracing::debug!(
+            cutoff_ts = %cutoff_ts,
+            cursor_ts = %cursor_ts,
+            retention_days,
+            "capture retention: nothing to prune this tick"
+        );
+    }
+
+    let tick = TICK_COUNT.fetch_add(1, Ordering::Relaxed);
+    if tick.is_multiple_of(VACUUM_EVERY_N_TICKS) {
+        run_incremental_vacuum(pool).await?;
+    }
+
+    Ok(())
+}
+
+/// Runs a page-bounded `incremental_vacuum` to reclaim freed pages from the
+/// deletes above. A no-op (per SQLite's own pragma semantics) unless the
+/// database's `auto_vacuum` mode is `INCREMENTAL` — see this module's header
+/// doc for why we never force that conversion (it requires a full `VACUUM`)
+/// on an already-populated database.
+async fn run_incremental_vacuum(pool: &SqlitePool) -> Result<()> {
+    sqlx::query(&format!("PRAGMA incremental_vacuum({VACUUM_MAX_PAGES})"))
+        .execute(pool)
+        .await
+        .context("incremental_vacuum on capture retention cadence")?;
+    tracing::debug!(
+        max_pages = VACUUM_MAX_PAGES,
+        "capture retention: incremental_vacuum ran"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqliteConnectOptions;
+    use std::str::FromStr;
+
+    async fn make_db() -> SqlitePool {
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+            .unwrap()
+            .create_if_missing(true);
+        let pool = SqlitePool::connect_with(opts).await.unwrap();
+        sqlx::migrate!("src/migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    async fn insert_frame(pool: &SqlitePool, id: i64, ts: &str, text: &str) {
+        sqlx::query(
+            "INSERT INTO capture_frames (id, app_name, window_name, timestamp, accessibility_text, text_source)
+             VALUES (?, 'Code', NULL, ?, ?, 'accessibility')",
+        )
+        .bind(id)
+        .bind(ts)
+        .bind(text)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_ui_event(pool: &SqlitePool, ts: &str) {
+        sqlx::query(
+            "INSERT INTO capture_ui_events (timestamp, event_type, app_name) VALUES (?, 'app_switch', 'Code')",
+        )
+        .bind(ts)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn set_cursor(pool: &SqlitePool, last_frame_id: i64) {
+        // No row exists until the real ETL's get_cursor() lazily seeds one —
+        // upsert here rather than UPDATE so the test doesn't depend on that.
+        sqlx::query(
+            "INSERT INTO etl_cursor (id, last_frame_id) VALUES (1, ?1)
+             ON CONFLICT (id) DO UPDATE SET last_frame_id = excluded.last_frame_id",
+        )
+        .bind(last_frame_id)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// A row older than retention but AT/AFTER the cursor frame (not yet
+    /// processed by the ETL) must survive.
+    #[tokio::test]
+    async fn unprocessed_frame_survives_even_if_old() {
+        let pool = make_db().await;
+
+        let old_ts = (chrono::Utc::now() - chrono::Duration::days(60))
+            .to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+        insert_frame(&pool, 1, &old_ts, "processed old frame").await;
+        insert_frame(&pool, 2, &old_ts, "unprocessed old frame").await;
+        // Cursor only covers frame 1 — frame 2 is not yet processed.
+        set_cursor(&pool, 1).await;
+
+        prune_capture_tables(&pool).await.unwrap();
+
+        let remaining: Vec<(i64,)> = sqlx::query_as("SELECT id FROM capture_frames ORDER BY id")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            remaining,
+            vec![(2,)],
+            "frame 1 (processed + old) must be pruned; frame 2 (unprocessed) must survive"
+        );
+    }
+
+    /// A processed row inside the retention window must survive even though
+    /// the ETL has moved past it.
+    #[tokio::test]
+    async fn processed_recent_frame_survives_retention_window() {
+        let pool = make_db().await;
+
+        let recent_ts = (chrono::Utc::now() - chrono::Duration::days(1))
+            .to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+        insert_frame(&pool, 1, &recent_ts, "recent processed frame").await;
+        set_cursor(&pool, 1).await;
+
+        prune_capture_tables(&pool).await.unwrap();
+
+        let remaining: Vec<(i64,)> = sqlx::query_as("SELECT id FROM capture_frames ORDER BY id")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            remaining,
+            vec![(1,)],
+            "a recent frame must survive regardless of processed status"
+        );
+    }
+
+    /// A processed row older than retention must be pruned.
+    #[tokio::test]
+    async fn processed_old_frame_is_pruned() {
+        let pool = make_db().await;
+
+        let old_ts = (chrono::Utc::now() - chrono::Duration::days(45))
+            .to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+        insert_frame(&pool, 1, &old_ts, "old processed frame").await;
+        set_cursor(&pool, 1).await;
+
+        prune_capture_tables(&pool).await.unwrap();
+
+        let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM capture_frames")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(remaining, 0, "old, already-processed frame must be pruned");
+    }
+
+    /// capture_ui_events rows are bounded by the same cursor-frame timestamp
+    /// boundary — old-and-before-cursor rows are pruned, old-but-at-or-after
+    /// rows survive.
+    #[tokio::test]
+    async fn ui_events_bounded_by_cursor_frame_timestamp() {
+        let pool = make_db().await;
+
+        let old_ts = (chrono::Utc::now() - chrono::Duration::days(60))
+            .to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+        let cursor_ts = (chrono::Utc::now() - chrono::Duration::days(45))
+            .to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+
+        insert_frame(&pool, 1, &cursor_ts, "cursor frame").await;
+        set_cursor(&pool, 1).await;
+
+        insert_ui_event(&pool, &old_ts).await; // before cursor ts — must prune
+        insert_ui_event(&pool, &cursor_ts).await; // at cursor ts — must survive (not strictly before)
+
+        prune_capture_tables(&pool).await.unwrap();
+
+        let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM capture_ui_events")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            remaining, 1,
+            "only the ui_event strictly before the cursor timestamp must be pruned"
+        );
+    }
+
+    /// No etl_cursor row (or last_frame_id == 0) means nothing has been
+    /// processed yet — retention must be a no-op, never guess.
+    #[tokio::test]
+    async fn no_cursor_progress_means_no_pruning() {
+        let pool = make_db().await;
+
+        let old_ts = (chrono::Utc::now() - chrono::Duration::days(90))
+            .to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+        insert_frame(&pool, 1, &old_ts, "old frame, cursor untouched").await;
+        // etl_cursor is seeded with last_frame_id = 0 by migration — leave as-is.
+
+        prune_capture_tables(&pool).await.unwrap();
+
+        let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM capture_frames")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            remaining, 1,
+            "nothing processed yet — nothing must be pruned"
+        );
+    }
+}

--- a/src/etl/mod.rs
+++ b/src/etl/mod.rs
@@ -2,6 +2,7 @@
 // https://github.com/meridiona/meridian
 
 mod block_ops;
+pub mod capture_retention;
 pub mod extractor;
 pub mod runner;
 mod session_builder;

--- a/src/etl/text_filter/mod.rs
+++ b/src/etl/text_filter/mod.rs
@@ -462,36 +462,75 @@ pub fn is_quality_line(line: &str) -> bool {
 /// lines averaging 40 chars each → ~2 MB peak, freed when this function returns
 /// (the returned `HashSet` contains only the small chrome subset).
 pub fn build_chrome_set(frames: &[FrameText]) -> HashSet<String> {
-    // Count how many frames each trimmed line appears in (per-frame deduped).
-    let mut freq: HashMap<String, u32> = HashMap::new();
+    let mut acc = ChromeFreqAccumulator::new();
+    acc.feed(frames);
+    acc.finish()
+}
 
-    // Reuse one HashSet across all frames (allocated once, cleared per frame).
-    // Using u64 hashes avoids lifetime conflicts with &str frame borrows and
-    // removes the per-frame allocation overhead on large blocks.
-    let mut seen_hashes: HashSet<u64> = HashSet::with_capacity(256);
+/// Incremental version of the chrome pre-pass's line-frequency count.
+///
+/// [`build_chrome_set`] requires a single global view of line frequencies
+/// across every frame in a block before it can classify anything — a line
+/// only becomes "chrome" once it's been seen in `CHROME_FREQ_THRESHOLD` or
+/// more distinct frames. When a block's frames are read from the DB in pages
+/// (rather than materialized as one `Vec<FrameText>`), this accumulator lets
+/// the frequency count be built incrementally, one page at a time, via
+/// repeated [`ChromeFreqAccumulator::feed`] calls, then finalized once with
+/// [`ChromeFreqAccumulator::finish`] — producing the identical `HashSet` that
+/// `build_chrome_set(&all_frames)` would have, without ever holding all frames
+/// in memory at once. See `rebuild_session_text_paginated` in
+/// `crate::etl::block_ops`.
+pub struct ChromeFreqAccumulator {
+    freq: HashMap<String, u32>,
+    // Reused per `feed` call (cleared per frame) to avoid a per-frame allocation.
+    seen_hashes: HashSet<u64>,
+}
 
-    for frame in frames {
-        seen_hashes.clear();
-        for raw in frame.full_text.split('\n') {
-            let line = raw.trim();
-            if line.len() < 3 {
-                continue;
-            }
-            let mut h = DefaultHasher::new();
-            line.hash(&mut h);
-            let hash = h.finish();
-            if seen_hashes.insert(hash) {
-                *freq.entry(line.to_owned()).or_insert(0) += 1;
+impl ChromeFreqAccumulator {
+    pub fn new() -> Self {
+        Self {
+            freq: HashMap::new(),
+            seen_hashes: HashSet::with_capacity(256),
+        }
+    }
+
+    /// Folds one page of frames into the running frequency count.
+    pub fn feed(&mut self, frames: &[FrameText]) {
+        for frame in frames {
+            self.seen_hashes.clear();
+            for raw in frame.full_text.split('\n') {
+                let line = raw.trim();
+                if line.len() < 3 {
+                    continue;
+                }
+                let mut h = DefaultHasher::new();
+                line.hash(&mut h);
+                let hash = h.finish();
+                if self.seen_hashes.insert(hash) {
+                    *self.freq.entry(line.to_owned()).or_insert(0) += 1;
+                }
             }
         }
     }
 
-    // Keep lines at or above threshold that are not chrome-exempt (tighter than is_landmark:
-    // excludes `# `/`> ` prefixes, anchors SQL to line start).
-    freq.into_iter()
-        .filter(|(line, count)| *count >= CHROME_FREQ_THRESHOLD && !is_chrome_exempt(line))
-        .map(|(line, _)| line)
-        .collect()
+    /// Consumes the accumulator and applies the threshold filter, producing the
+    /// same chrome-line `HashSet` that [`build_chrome_set`] would for the same
+    /// full frame set.
+    pub fn finish(self) -> HashSet<String> {
+        // Keep lines at or above threshold that are not chrome-exempt (tighter than is_landmark:
+        // excludes `# `/`> ` prefixes, anchors SQL to line start).
+        self.freq
+            .into_iter()
+            .filter(|(line, count)| *count >= CHROME_FREQ_THRESHOLD && !is_chrome_exempt(line))
+            .map(|(line, _)| line)
+            .collect()
+    }
+}
+
+impl Default for ChromeFreqAccumulator {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[cfg(test)]

--- a/src/etl/text_merge.rs
+++ b/src/etl/text_merge.rs
@@ -25,14 +25,65 @@ pub fn build_session_text(frames: &[FrameText]) -> String {
     // The HashSet is freed at the end of this function — ~400KB peak for 1000-frame blocks.
     let chrome = build_chrome_set(frames);
 
-    let mut seen: HashSet<String> = HashSet::with_capacity(4096);
-    let mut out = String::with_capacity(8192);
-    let mut last_marker_secs: Option<i64> = None;
+    let mut builder = SessionTextBuilder::new();
+    builder.feed(frames, &chrome);
+    builder.finish()
+}
 
-    for frame in frames {
-        process_frame(frame, &mut seen, &mut out, &mut last_marker_secs, &chrome);
+/// Incremental version of [`build_session_text`]'s per-frame fold.
+///
+/// Lets a caller build up `session_text` across multiple pages of frames
+/// (e.g. read from the DB in bounded chunks rather than materialized as one
+/// `Vec<FrameText>`) without changing the resulting text at all — feeding all
+/// frames via repeated [`SessionTextBuilder::feed`] calls, in the same order
+/// they'd appear in a single slice, then calling [`SessionTextBuilder::finish`]
+/// once, produces output identical to `build_session_text(&all_frames)`. The
+/// `chrome` set must already reflect the whole frame range (see
+/// `crate::etl::text_filter::ChromeFreqAccumulator`) since chrome lines can
+/// only be identified with a global view. See `rebuild_session_text_paginated`
+/// in `crate::etl::block_ops` for the caller that uses this to avoid an
+/// unbounded-memory rebuild on long single-app sessions.
+pub struct SessionTextBuilder {
+    seen: HashSet<String>,
+    out: String,
+    last_marker_secs: Option<i64>,
+}
+
+impl SessionTextBuilder {
+    pub fn new() -> Self {
+        Self {
+            seen: HashSet::with_capacity(4096),
+            out: String::with_capacity(8192),
+            last_marker_secs: None,
+        }
     }
-    dedup_cursor_prefixes(out)
+
+    /// Folds one page of frames into the running output. `chrome` must be the
+    /// final, fully-accumulated chrome set for the whole frame range — not
+    /// just this page.
+    pub fn feed(&mut self, frames: &[FrameText], chrome: &HashSet<String>) {
+        for frame in frames {
+            process_frame(
+                frame,
+                &mut self.seen,
+                &mut self.out,
+                &mut self.last_marker_secs,
+                chrome,
+            );
+        }
+    }
+
+    /// Consumes the builder, applying the same final cleanup pass
+    /// (`dedup_cursor_prefixes`) that [`build_session_text`] applies.
+    pub fn finish(self) -> String {
+        dedup_cursor_prefixes(self.out)
+    }
+}
+
+impl Default for SessionTextBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// Merge new frame content into an existing session_text string (incremental update).

--- a/src/main.rs
+++ b/src/main.rs
@@ -1047,6 +1047,9 @@ async fn main() -> Result<()> {
             let _ = meridian::notices::clear(&meridian, "etl.failed").await;
         }
         etl_notify.notify_one();
+        if let Err(e) = meridian::etl::capture_retention::prune_capture_tables(&meridian).await {
+            tracing::warn!(error = %e, "capture retention sweep failed");
+        }
         if let Err(e) = run_pm_sync(&meridian, &cfg).await {
             tracing::error!("intelligence run failed: {}", e);
         }
@@ -1185,6 +1188,14 @@ async fn main() -> Result<()> {
                 }
                 // Wake the background task linker to drain newly-created sessions.
                 etl_notify.notify_one();
+
+                // Capture-table retention — age + processed-based prune of
+                // capture_frames/capture_ui_events/capture_secondary_screens,
+                // which otherwise grow unbounded. Runs every tick; internally
+                // paces its own incremental_vacuum to a coarser cadence.
+                if let Err(e) = meridian::etl::capture_retention::prune_capture_tables(&meridian).await {
+                    tracing::warn!(error = %e, "capture retention sweep failed");
+                }
 
                 // Morning plan nudge — idempotent per day, gated to working hours.
                 if let Err(e) = meridian::daily_plan::maybe_nudge(&meridian).await {

--- a/tests/etl_session_text.rs
+++ b/tests/etl_session_text.rs
@@ -6,7 +6,9 @@
 
 mod common;
 
+use meridian::db::screenpipe::get_frame_full_texts;
 use meridian::etl::run_etl;
+use meridian::etl::text_merge::build_session_text;
 
 // Helper: count "[HH:MM:SS]" marker lines in a session_text string.
 fn count_markers(text: &str) -> usize {
@@ -454,4 +456,125 @@ async fn test_session_text_marker_suppressed_for_small_gap() {
         marker_count, 1,
         "20s gap must suppress second marker; got {marker_count} in:\n{text}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Paginated rebuild — session spanning many frames across multiple pages
+// ---------------------------------------------------------------------------
+
+/// A single-app session that stays open across two ETL runs and spans more
+/// frames than one `FRAME_TEXT_PAGE_SIZE` page (750, see
+/// `crate::db::screenpipe`) must, once finally closed by an app switch,
+/// produce a `session_text` in `app_sessions` that is byte-for-byte identical
+/// to what a single non-paginated `get_frame_full_texts` + `build_session_text`
+/// call over the whole frame range would produce.
+///
+/// This guards `rebuild_session_text_paginated` (`src/etl/block_ops.rs`)
+/// against a regression that would silently drop or reorder content from
+/// later pages when a long-running block finally closes — the exact
+/// continuation-merge path (`existing.app_name == ctx.app_name` in
+/// `close_block`) that triggers the paginated re-fetch.
+#[tokio::test]
+async fn test_session_text_paginated_rebuild_matches_non_paginated_fetch() {
+    let md = common::make_meridian_db().await;
+
+    const FIRST_RUN_FRAMES: i64 = 500;
+    const TOTAL_CODE_FRAMES: i64 = 1600; // > 2x FRAME_TEXT_PAGE_SIZE (750) — forces 3 pages
+
+    // Timestamp for frame index i (0-based): base + i seconds. Keeps every
+    // inter-frame gap at 1s, well under the 300s gap threshold, so this never
+    // triggers gap-close logic — only the continuation-merge close path.
+    fn ts_for(i: i64) -> String {
+        let total_secs = i;
+        let hh = 10 + total_secs / 3600;
+        let mm = (total_secs % 3600) / 60;
+        let ss = total_secs % 60;
+        format!("2026-01-01T{hh:02}:{mm:02}:{ss:02}+00:00")
+    }
+
+    // Run 1: frames 1..=500 of app "Code", each with unique content. Ends with
+    // an open block — upsert_open_block writes active_session(min_frame_id=1).
+    let run1_frames: Vec<(String, String, String)> = (0..FIRST_RUN_FRAMES)
+        .map(|i| {
+            (
+                "Code".to_string(),
+                ts_for(i),
+                format!("unique code content line {i}"),
+            )
+        })
+        .collect();
+    let run1_frames_ref: Vec<(&str, &str, &str)> = run1_frames
+        .iter()
+        .map(|(a, b, c)| (a.as_str(), b.as_str(), c.as_str()))
+        .collect();
+    common::insert_frames_with_text(&md, 1, &run1_frames_ref).await;
+
+    run_etl(&md).await.unwrap();
+
+    // Sanity check: active_session must now hold the still-open Code block.
+    let active_min: (i64,) = sqlx::query_as("SELECT min_frame_id FROM active_session WHERE id = 1")
+        .fetch_one(&md)
+        .await
+        .unwrap();
+    assert_eq!(active_min.0, 1, "active_session must start at frame 1");
+
+    // Run 2: frames 501..=1600 continuing app "Code" (unique content), then a
+    // final frame for "Slack" to force the app-switch close. This closes the
+    // whole 1..=1600 lifetime through the continuation-merge path in
+    // `close_block`, which re-fetches the full frame range.
+    let run2_frames: Vec<(String, String, String)> = (FIRST_RUN_FRAMES..TOTAL_CODE_FRAMES)
+        .map(|i| {
+            (
+                "Code".to_string(),
+                ts_for(i),
+                format!("unique code content line {i}"),
+            )
+        })
+        .chain(std::iter::once((
+            "Slack".to_string(),
+            ts_for(TOTAL_CODE_FRAMES),
+            "app switch forces close".to_string(),
+        )))
+        .collect();
+    let run2_frames_ref: Vec<(&str, &str, &str)> = run2_frames
+        .iter()
+        .map(|(a, b, c)| (a.as_str(), b.as_str(), c.as_str()))
+        .collect();
+    common::insert_frames_with_text(&md, FIRST_RUN_FRAMES + 1, &run2_frames_ref).await;
+
+    run_etl(&md).await.unwrap();
+
+    let row: (Option<String>,) =
+        sqlx::query_as("SELECT session_text FROM app_sessions WHERE app_name = 'Code'")
+            .fetch_one(&md)
+            .await
+            .unwrap();
+    let actual_text = row.0.expect("closed session must have session_text");
+
+    // Reference: a single non-paginated fetch over the whole frame lifetime,
+    // fed straight into build_session_text — exactly what the pre-fix code did.
+    let all_frames = get_frame_full_texts(&md, 1, TOTAL_CODE_FRAMES)
+        .await
+        .expect("non-paginated reference fetch must succeed");
+    assert_eq!(
+        all_frames.len(),
+        TOTAL_CODE_FRAMES as usize,
+        "reference fetch must see every Code frame"
+    );
+    let expected_text = build_session_text(&all_frames);
+
+    assert_eq!(
+        actual_text, expected_text,
+        "paginated rebuild must be byte-for-byte identical to the non-paginated reference"
+    );
+
+    // Belt-and-suspenders completeness check: content from every page must
+    // survive (first page, middle page, last page — pages are 750 frames).
+    for i in [0i64, 749, 750, 1499, 1500, TOTAL_CODE_FRAMES - 1] {
+        let line = format!("unique code content line {i}");
+        assert!(
+            actual_text.contains(&line),
+            "missing content from frame {i} (page boundary check): {line:?}"
+        );
+    }
 }

--- a/ui/__tests__/lru.test.ts
+++ b/ui/__tests__/lru.test.ts
@@ -1,0 +1,90 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import { describe, it, expect } from 'bun:test'
+import { LruMap } from '../lib/lru'
+
+// LruMap backs the module-level webview stores (planStore.ts, useWorklog.ts,
+// app-icons.ts) that live for the whole Tauri session — this is the shared
+// eviction logic added so those stores stop growing by one entry per
+// distinct key forever (memory-leak-audit fix).
+
+describe('LruMap', () => {
+  it('get/set round-trip like a Map for keys within capacity', () => {
+    const m = new LruMap<string, number>(3)
+    m.set('a', 1)
+    m.set('b', 2)
+    expect(m.get('a')).toBe(1)
+    expect(m.get('b')).toBe(2)
+    expect(m.get('missing')).toBeUndefined()
+    expect(m.size).toBe(2)
+  })
+
+  it('stores a value of null distinctly from "not cached" (undefined)', () => {
+    const m = new LruMap<string, string | null>(3)
+    m.set('a', null)
+    expect(m.has('a')).toBe(true)
+    expect(m.get('a')).toBeNull()
+    expect(m.get('never-set')).toBeUndefined()
+  })
+
+  it('evicts the least-recently-used entry once capacity is exceeded', () => {
+    const m = new LruMap<string, number>(2)
+    m.set('a', 1)
+    m.set('b', 2)
+    m.set('c', 3) // capacity 2 — 'a' (oldest, untouched) must be evicted
+
+    expect(m.has('a')).toBe(false)
+    expect(m.get('b')).toBe(2)
+    expect(m.get('c')).toBe(3)
+    expect(m.size).toBe(2)
+  })
+
+  it('a get() on a key protects it from eviction (recency, not insertion order)', () => {
+    const m = new LruMap<string, number>(2)
+    m.set('a', 1)
+    m.set('b', 2)
+    m.get('a') // touch 'a' — now 'b' is the least-recently-used
+    m.set('c', 3)
+
+    expect(m.has('b')).toBe(false)
+    expect(m.get('a')).toBe(1)
+    expect(m.get('c')).toBe(3)
+  })
+
+  it('overwriting an existing key bumps its recency without growing size', () => {
+    const m = new LruMap<string, number>(2)
+    m.set('a', 1)
+    m.set('b', 2)
+    m.set('a', 10) // re-set 'a' — now 'b' is the least-recently-used
+    m.set('c', 3)
+
+    expect(m.size).toBe(2)
+    expect(m.has('b')).toBe(false)
+    expect(m.get('a')).toBe(10)
+  })
+
+  it('never exceeds capacity across many inserts', () => {
+    const m = new LruMap<number, number>(5)
+    for (let i = 0; i < 1000; i++) {
+      m.set(i, i)
+    }
+    expect(m.size).toBe(5)
+    // Only the last 5 keys (995..999) should survive.
+    for (let i = 995; i < 1000; i++) {
+      expect(m.get(i)).toBe(i)
+    }
+    expect(m.get(0)).toBeUndefined()
+  })
+
+  it('delete removes an entry and reduces size', () => {
+    const m = new LruMap<string, number>(3)
+    m.set('a', 1)
+    expect(m.delete('a')).toBe(true)
+    expect(m.has('a')).toBe(false)
+    expect(m.size).toBe(0)
+  })
+
+  it('rejects a non-positive capacity', () => {
+    expect(() => new LruMap<string, number>(0)).toThrow()
+    expect(() => new LruMap<string, number>(-1)).toThrow()
+  })
+})

--- a/ui/__tests__/plan-store.test.ts
+++ b/ui/__tests__/plan-store.test.ts
@@ -100,7 +100,9 @@ describe('planStore.ts is the single source of plan truth', () => {
   it('keys entries by day and hands useSyncExternalStore a STABLE empty snapshot', () => {
     // A fresh object per getSnapshot call re-renders forever.
     expect(store).toContain('useSyncExternalStore')
-    expect(store).toMatch(/^const store = new Map<string, PlanEntry>\(\)/m)
+    // LRU-capped (memory-leak-audit fix) rather than a bare Map — same
+    // get/set semantics, bounded growth over the webview's whole lifetime.
+    expect(store).toMatch(/^const store = new LruMap<string, PlanEntry>\(100\)/m)
     expect(store).toMatch(/^const EMPTY: PlanEntry = /m)
   })
 

--- a/ui/components/plan/planStore.ts
+++ b/ui/components/plan/planStore.ts
@@ -31,6 +31,7 @@
 import { useSyncExternalStore } from 'react'
 import { load, mutate } from '@/lib/bridge'
 import type { PlanResponse } from '@/lib/api-types'
+import { LruMap } from '@/lib/lru'
 
 /** Vestigial route label the bridge still takes (Tauri-only now). */
 const API = '/api/plan'
@@ -47,7 +48,11 @@ export interface PlanEntry {
 // identity changes on every call.
 const EMPTY: PlanEntry = { data: null, loaded: false }
 
-const store = new Map<string, PlanEntry>()
+// LRU-capped: this webview session never reloads, so an uncapped Map would
+// grow by one entry per distinct day ever viewed for the app's whole
+// lifetime. 100 days is far beyond realistic usage — this is a hygiene bound,
+// not a fix for an observed runaway.
+const store = new LruMap<string, PlanEntry>(100)
 const listeners = new Set<() => void>()
 
 const snapshot = (date: string): PlanEntry => store.get(date) ?? EMPTY

--- a/ui/components/timeline/useWorklog.ts
+++ b/ui/components/timeline/useWorklog.ts
@@ -24,6 +24,7 @@
 import { useEffect, useState, useSyncExternalStore } from 'react'
 import { load, invoke, mutate } from '@/lib/bridge'
 import type { DayTaskWorklogDraft, ApproveWorklogResponse } from '@/lib/api-types'
+import { LruMap } from '@/lib/lru'
 
 /** Where the flow is right now — drives which footer control the panel shows. */
 export type WorklogPhase = 'loading' | 'idle' | 'generating' | 'approving'
@@ -75,7 +76,13 @@ interface Entry {
 // changes every call).
 const EMPTY: Entry = { draft: null, phase: 'loading', error: null, loaded: false }
 
-const store = new Map<string, Entry>()
+// LRU-capped: this webview session never reloads, so an uncapped Map would
+// grow by one entry per distinct (day, taskId) pair ever opened for the
+// app's whole lifetime. 100 is far beyond realistic usage — a hygiene bound,
+// not a fix for an observed runaway. (An entry mid `generating`/`approving`
+// stays the most-recently-touched one via the `patch`→`store.set` on every
+// state change, so it's never the eviction candidate while active.)
+const store = new LruMap<string, Entry>(100)
 const listeners = new Set<() => void>()
 
 // A space is a safe separator here: `day` is YYYY-MM-DD and `taskId` is T1/T2…,

--- a/ui/lib/app-icons.ts
+++ b/ui/lib/app-icons.ts
@@ -9,10 +9,15 @@
 
 import { useEffect, useState } from 'react'
 import { invoke, assetUrl, isTauri } from '@/lib/bridge'
+import { LruMap } from '@/lib/lru'
 
 type CacheEntry = string | null | Promise<string | null>
 
-const cache = new Map<string, CacheEntry>()
+// LRU-capped: this webview session never reloads, so an uncapped Map would
+// grow by one entry per distinct app name ever seen for the app's whole
+// lifetime. 100 is far beyond realistic usage — a hygiene bound, not a fix
+// for an observed runaway.
+const cache = new LruMap<string, CacheEntry>(100)
 
 function resolve(appName: string): CacheEntry {
   const cached = cache.get(appName)

--- a/ui/lib/lru.ts
+++ b/ui/lib/lru.ts
@@ -1,0 +1,65 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// A minimal LRU-capped Map for module-level webview stores that live for the
+// whole Tauri session (it never reloads) and would otherwise grow by one
+// small entry per distinct key — day, task, app-icon lookup, … — for as long
+// as the app runs. Realistic usage cardinality keeps these well under any
+// sane cap in practice; this is a hygiene bound, not a fix for an observed
+// runaway.
+//
+// Deliberately NOT a full Map re-implementation — just the get/set subset the
+// module-level stores that use this actually need (see planStore.ts,
+// useWorklog.ts, app-icons.ts). Recency is tracked by re-inserting the
+// touched key so the underlying Map's insertion order IS recency order (a
+// well-known JS idiom: Map iterates in insertion order, and re-`set`ting an
+// existing key does NOT move it, so the delete-then-set below is what
+// actually bumps it to "most recent").
+
+export class LruMap<K, V> {
+  private readonly map = new Map<K, V>()
+
+  constructor(private readonly capacity: number) {
+    if (capacity < 1) {
+      throw new Error('LruMap capacity must be >= 1')
+    }
+  }
+
+  /** Reads `key`, marking it most-recently-used. `undefined` means "not
+   *  cached" — a value of `undefined` is never itself stored by any current
+   *  caller, so this is unambiguous for them. */
+  get(key: K): V | undefined {
+    if (!this.map.has(key)) return undefined
+    const value = this.map.get(key) as V
+    // Bump recency: delete + re-set moves the key to the end of iteration
+    // order (Map's order is insertion order; re-setting an existing key
+    // alone would NOT move it).
+    this.map.delete(key)
+    this.map.set(key, value)
+    return value
+  }
+
+  /** Writes `key`, marking it most-recently-used, and evicts the single
+   *  least-recently-used entry if this insert pushed the map past capacity. */
+  set(key: K, value: V): void {
+    this.map.delete(key)
+    this.map.set(key, value)
+    if (this.map.size > this.capacity) {
+      const oldest = this.map.keys().next().value
+      if (oldest !== undefined) {
+        this.map.delete(oldest)
+      }
+    }
+  }
+
+  has(key: K): boolean {
+    return this.map.has(key)
+  }
+
+  delete(key: K): boolean {
+    return this.map.delete(key)
+  }
+
+  get size(): number {
+    return this.map.size
+  }
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meridian-ui",
-  "version": "1.71.0",
+  "version": "1.74.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meridian-ui",
-      "version": "1.71.0",
+      "version": "1.74.0",
       "dependencies": {
         "@clerk/react": "^6.12.2",
         "@hello-pangea/dnd": "^18.0.1",


### PR DESCRIPTION
## Summary

Fixes 4 confirmed memory-growth/leak issues found by a prior read-only audit. Each fix is its own commit, tested before moving to the next.

### Fix 1 (HIGH): unbounded whole-session OCR reload on block close
**Files:** `src/db/screenpipe.rs`, `src/etl/block_ops.rs`, `src/etl/text_filter/mod.rs`, `src/etl/text_merge.rs`, `tests/etl_session_text.rs`

`get_frame_full_texts` did a single `fetch_all` across a block's entire frame-id range when the continuation-merge path in `close_block` rebuilt `session_text` from scratch — a session that stays in one app for hours never closes early, so at close time this could load hours of OCR text into RAM at once.

Added `fetch_frame_text_page` (bounded `id`-driven pagination), `ChromeFreqAccumulator`, and `SessionTextBuilder` so the chrome-detection and text-build passes fold incrementally over pages instead of materializing the whole range as one `Vec`. **No accuracy loss**: output is byte-for-byte identical to the prior non-paginated build for the same input — verified by a new integration test spanning 1600 frames (3 pages) that asserts equality against a direct non-paginated fetch.

### Fix 2 (HIGH): no retention on capture tables + MCP re-reads the whole DB file every call
**Files:** `src/etl/capture_retention.rs` (new), `src/etl/mod.rs`, `src/main.rs`, `src/db/meridian.rs`, `CLAUDE.md`, `packages/meridian-mcp/src/db-cache.ts` (new), `packages/meridian-mcp/src/index.ts`, `packages/meridian-mcp/src/__tests__/db-cache.test.ts` (new)

**(a)** `capture_frames` / `capture_ui_events` / `capture_secondary_screens` had no retention and grew forever. Added an age + processed-based sweep (`MERIDIAN_CAPTURE_RETENTION_DAYS`, default 30) wired into the poll loop right after `run_etl` — only deletes rows both older than the window AND already consumed by `etl_cursor.last_frame_id`, so an unprocessed frame is never pruned regardless of age. Also runs a page-bounded `PRAGMA incremental_vacuum` on a coarser cadence to reclaim freed pages (no-op on already-existing DBs still in `auto_vacuum=NONE` — we deliberately never force a full `VACUUM` on a live daemon; new DBs get `auto_vacuum=INCREMENTAL` so this actually reclaims space for them).

**(b)** The MCP server did `fs.readFileSync` + `new SQL.Database(...)` (two full copies) on every single tool call, and emscripten never returns freed WASM pages to the OS. Extracted DB-open logic into `db-cache.ts`, which reuses one long-lived `Database` per path, invalidated only when a cheap `fs.statSync` shows the file's mtime/size changed. Kept sql.js (not better-sqlite3) per the project's prior native-ABI distribution pain.

### Fix 3 (LOW): summariser retry-attempts map never evicted
**File:** `src/coding_agent_session_ingest/summariser/mod.rs`

The per-row failure ledger (`attempts: HashMap<i64, u32>`) was only ever inserted into, never removed from. Extracted a `record_attempt()` helper that removes a row's entry on success and increments it on failure, so the map only ever holds currently-pending rows with an active failure count.

### Fix 4 (LOW): webview module-level Maps never evict
**Files:** `ui/lib/lru.ts` (new), `ui/components/plan/planStore.ts`, `ui/components/timeline/useWorklog.ts`, `ui/lib/app-icons.ts`, `ui/__tests__/lru.test.ts` (new), `ui/__tests__/plan-store.test.ts`

Added a shared `LruMap` (get/set/has/delete — the subset these stores use) and capped all three module-level stores at 100 entries, evicting least-recently-touched past the cap. No behavior/API change below the cap.

## Why this is safe (no accuracy loss)
- Fix 1: verified byte-for-byte identical output via test, not a truncation.
- Fix 2a: never deletes a frame/event the ETL hasn't consumed yet (id/timestamp-gated against the live cursor).
- Fix 2b: only invalidates the cache when the underlying file actually changes; small staleness window is acceptable for a read-mostly MCP server against a separate-process writer.
- Fix 3: only evicts entries for rows that have already succeeded — no behavior change to retry/dead-letter logic.
- Fix 4: 100-entry cap is far beyond realistic usage cardinality (days/tasks/apps seen in one session) — pure hygiene.

## Test plan
- [x] `cargo fmt --check` (after every commit)
- [x] `cargo clippy --all-targets -- -D warnings` (after every commit)
- [x] `cargo test` — full suite, including new integration/unit tests (after every commit)
- [x] `cd ui && npm run build` + `bun test` (356 tests)
- [x] `cd packages/meridian-mcp && npm run build` + `npm test` (node:test, 4 new tests)
- [x] Pre-push hook (fmt + clippy + ui build + ui tests + cargo test + security audit) passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)