### PR TITLE
fix(windows): suppress the console-window flash on child process spawns

### DIFF
--- a/meridian-core/Cargo.toml
+++ b/meridian-core/Cargo.toml
@@ -22,6 +22,13 @@ dirs = "5"
 # Instrumentation facade only (~no-op without a subscriber) — the heavy OTLP
 # exporter is wired by the binary (daemon, or the tray's `otel` dev feature).
 tracing = "0.1"
+# Only the `process` feature, only for `proc_ext::NoWindow`'s impl on
+# `tokio::process::Command` (the std impl needs no dep). tokio is already in the
+# workspace tree via sqlx's tokio runtime and every binary that depends on this
+# crate (daemon, tray) already builds it with `full`, so feature-unification
+# means this adds nothing new to compile — it just brings the `process` module
+# into scope here.
+tokio = { version = "1", features = ["process"] }
 
 [dev-dependencies]
 # For the #[ignore]d golden-compare smoke test (runs get_today against the real DB).

--- a/meridian-core/src/lib.rs
+++ b/meridian-core/src/lib.rs
@@ -50,6 +50,10 @@ pub mod plan_marker;
 /// tray writes `capture_frames`, the daemon's ETL reads it.
 pub mod capture;
 
+/// `.no_window()` for `Command` — suppresses the Windows console-window flash
+/// on a console-subsystem child spawn. No-op on every other OS.
+pub mod proc_ext;
+
 // ── Curated public API: flat module paths, stable across file moves ──────────
 pub use db::{get_active_session, open_existing, ActiveSession};
 

--- a/meridian-core/src/proc_ext.rs
+++ b/meridian-core/src/proc_ext.rs
@@ -40,3 +40,42 @@ impl NoWindow for tokio::process::Command {
         self
     }
 }
+
+// Windows-only: the trait does nothing off Windows, and `cmd.exe` (the console
+// child these exercise) exists only there. Both tests assert `.no_window()`
+// still produces a working spawn — the flag suppresses the console window, it
+// must not break launching the child. That the window is actually suppressed
+// was confirmed out-of-band on a real Windows host (a nested `cmd.exe →
+// powershell` grandchild reports a console `HWND` of 0 with the flag set and a
+// non-zero one without it); there is no non-flaky way to assert the window's
+// absence from a headless test, so these lock in the spawn-still-works half.
+#[cfg(all(test, windows))]
+mod tests {
+    use super::NoWindow;
+
+    #[test]
+    fn create_no_window_has_the_documented_value() {
+        assert_eq!(super::CREATE_NO_WINDOW, 0x0800_0000);
+    }
+
+    #[test]
+    fn no_window_std_command_still_spawns() {
+        let status = std::process::Command::new("cmd")
+            .args(["/C", "exit 0"])
+            .no_window()
+            .status()
+            .expect("cmd should spawn with CREATE_NO_WINDOW set");
+        assert!(status.success());
+    }
+
+    #[tokio::test]
+    async fn no_window_tokio_command_still_spawns() {
+        let status = tokio::process::Command::new("cmd")
+            .args(["/C", "exit 0"])
+            .no_window()
+            .status()
+            .await
+            .expect("cmd should spawn with CREATE_NO_WINDOW set (tokio)");
+        assert!(status.success());
+    }
+}

--- a/meridian-core/src/proc_ext.rs
+++ b/meridian-core/src/proc_ext.rs
@@ -1,0 +1,42 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Suppress the console-window flash Windows creates when a GUI process (the
+//! tray) or a console-less daemon spawns a console-subsystem child — every
+//! plain Win32 console app (`schtasks`, `taskkill`, `tasklist`, `powershell`)
+//! and every npm-shimmed `.cmd`/`.bat` CLI (`claude`, `codex`, …, which
+//! `Command::new` routes through `cmd.exe`) is one. Piping the child's
+//! stdio does NOT suppress this — Windows still allocates and briefly shows
+//! a console window unless the process is created with `CREATE_NO_WINDOW`.
+//!
+//! A no-op on every other OS, so callers can chain `.no_window()`
+//! unconditionally rather than wrapping each call site in `#[cfg(windows)]`.
+
+/// [`CREATE_NO_WINDOW`](https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags).
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Chainable `.no_window()` for both `std::process::Command` and
+/// `tokio::process::Command` — see the module docs for why this matters.
+pub trait NoWindow {
+    fn no_window(&mut self) -> &mut Self;
+}
+
+impl NoWindow for std::process::Command {
+    fn no_window(&mut self) -> &mut Self {
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            self.creation_flags(CREATE_NO_WINDOW);
+        }
+        self
+    }
+}
+
+impl NoWindow for tokio::process::Command {
+    fn no_window(&mut self) -> &mut Self {
+        #[cfg(windows)]
+        {
+            self.creation_flags(CREATE_NO_WINDOW);
+        }
+        self
+    }
+}

--- a/src/coding_agent_session_ingest/cursor_agent_init.rs
+++ b/src/coding_agent_session_ingest/cursor_agent_init.rs
@@ -197,7 +197,10 @@ async fn run_with_timeout(
     timeout: Duration,
     label: &str,
 ) -> anyhow::Result<std::process::Output> {
-    cmd.stdin(std::process::Stdio::null()).kill_on_drop(true);
+    use meridian_core::proc_ext::NoWindow;
+    cmd.stdin(std::process::Stdio::null())
+        .kill_on_drop(true)
+        .no_window();
     match tokio::time::timeout(timeout, cmd.output()).await {
         Ok(Ok(output)) => Ok(output),
         Ok(Err(e)) => anyhow::bail!("{label}: {e}"),

--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -42,6 +42,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
+use meridian_core::proc_ext::NoWindow;
 use sqlx::SqlitePool;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
@@ -124,7 +125,8 @@ pub(crate) async fn run_capture(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .current_dir(cwd)
-        .kill_on_drop(true);
+        .kill_on_drop(true)
+        .no_window();
     for k in remove_env {
         cmd.env_remove(k);
     }

--- a/src/health/platform.rs
+++ b/src/health/platform.rs
@@ -109,7 +109,8 @@ fn candidate_names(bin: &str) -> Vec<String> {
 }
 
 fn cmd_output(bin: &str, args: &[&str]) -> Option<String> {
-    let out = Command::new(bin).args(args).output().ok()?;
+    use meridian_core::proc_ext::NoWindow;
+    let out = Command::new(bin).args(args).no_window().output().ok()?;
     out.status
         .success()
         .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -34,6 +34,7 @@ use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 
+use meridian_core::proc_ext::NoWindow;
 use meridian_core::settings::RuntimeSettings;
 use meridian_core::LlmProvider;
 use serde::{Deserialize, Serialize};
@@ -308,7 +309,8 @@ pub async fn install_provider(provider: LlmProvider) -> InstallOutcome {
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .kill_on_drop(true);
+        .kill_on_drop(true)
+        .no_window();
 
     let output = match command.spawn() {
         Ok(child) => match tokio::time::timeout(INSTALL_TIMEOUT, child.wait_with_output()).await {
@@ -384,6 +386,7 @@ async fn warn_if_version_unpinned(provider: LlmProvider, path: &std::path::Path)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true)
+        .no_window()
         .output()
         .await;
     let Ok(out) = out else {
@@ -442,7 +445,8 @@ pub async fn cursor_sign_in() -> InstallOutcome {
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .kill_on_drop(true);
+        .kill_on_drop(true)
+        .no_window();
 
     let mut child = match cmd.spawn() {
         Ok(c) => c,
@@ -672,7 +676,8 @@ async fn probe_login_shell(bin: &str) -> Option<PathBuf> {
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
-        .kill_on_drop(true);
+        .kill_on_drop(true)
+        .no_window();
 
     let child = cmd.spawn().ok()?;
     let out = tokio::time::timeout(PROBE_TIMEOUT, child.wait_with_output())

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -154,6 +154,7 @@ pub fn service_manifest(_label: &str) -> super::ServiceManifest {
 /// caller treats as every-CLI-running and defers to the idle backstop, so a
 /// failure here can never seal a live session early.
 pub async fn list_process_argvs() -> Option<Vec<String>> {
+    use meridian_core::proc_ext::NoWindow;
     let mut cmd = tokio::process::Command::new("powershell");
     cmd.args([
         "-NoProfile",
@@ -161,7 +162,8 @@ pub async fn list_process_argvs() -> Option<Vec<String>> {
         "-Command",
         "Get-CimInstance Win32_Process | ForEach-Object { $_.CommandLine }",
     ])
-    .kill_on_drop(true);
+    .kill_on_drop(true)
+    .no_window();
     // Longer than the Unix budget: PowerShell start-up plus a CIM query is
     // genuinely slower than `ps`, and this runs once every ten minutes.
     let output = tokio::time::timeout(std::time::Duration::from_secs(15), cmd.output())

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -323,8 +323,10 @@ fn run_human(plan: &Plan) {
     // which is the normal case on a second uninstall.
     #[cfg(target_os = "windows")]
     {
+        use meridian_core::proc_ext::NoWindow;
         let out = std::process::Command::new("schtasks")
             .args(["/Delete", "/F", "/TN", "Meridian Daemon"])
+            .no_window()
             .output();
         match out {
             Ok(o) if o.status.success() => println!("✓ removed login task  Meridian Daemon"),

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -195,6 +195,14 @@ async fn install(backend: &Path, home: &Path) -> Result<(), String> {
         migrate_legacy_bundle_env(home).await;
     }
 
+    // Windows keeps a running exe's pages mapped, so overwriting it fails with
+    // "the process cannot access the file" (os error 32) — and this isn't just
+    // a first-install concern: `ensure_backend_installed` re-stages on every
+    // version bump while the *previous* build's daemon is still alive from an
+    // earlier login. Stop it first so the copy below can succeed.
+    #[cfg(target_os = "windows")]
+    stop_running_daemon_before_stage().await;
+
     let daemon_bin = home.join(".meridian").join("bin").join(DAEMON_FILE);
     stage_binary(&backend.join(DAEMON_FILE), &daemon_bin).await?;
 
@@ -304,6 +312,56 @@ async fn register_service(_backend: &Path, home: &Path, daemon_bin: &Path) -> Re
             );
             Ok(())
         }
+    }
+}
+
+/// Stop any running instance of the staged daemon so [`stage_binary`] can
+/// overwrite `~/.meridian/bin/meridian.exe`. Best-effort on two fronts,
+/// because the daemon can be running via either path [`register_service`] may
+/// have taken:
+/// - `schtasks /End` stops it if the scheduled task is what launched it.
+/// - `taskkill /IM` also catches the Startup-folder-launcher fallback case,
+///   where the process was spawned directly by `wscript` and has no
+///   association with the scheduled task for `/End` to find.
+///
+/// Killing the process doesn't release its file handle instantaneously, so
+/// this polls (mirroring the launchd bootout wait in [`register_agent`])
+/// rather than proceeding immediately — a fixed sleep would either race a
+/// slow exit or pad every install with unnecessary wait time.
+#[cfg(target_os = "windows")]
+async fn stop_running_daemon_before_stage() {
+    let _ = tokio::process::Command::new("schtasks")
+        .args(["/End", "/TN", WINDOWS_TASK_NAME])
+        .output()
+        .await;
+    let _ = tokio::process::Command::new("taskkill")
+        .args(["/F", "/IM", DAEMON_FILE])
+        .output()
+        .await;
+    for _ in 0..10 {
+        if !daemon_process_running().await {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    }
+}
+
+/// Whether a process named [`DAEMON_FILE`] currently shows up in `tasklist`.
+#[cfg(target_os = "windows")]
+async fn daemon_process_running() -> bool {
+    let out = tokio::process::Command::new("tasklist")
+        .args([
+            "/FI",
+            &format!("IMAGENAME eq {DAEMON_FILE}"),
+            "/FO",
+            "CSV",
+            "/NH",
+        ])
+        .output()
+        .await;
+    match out {
+        Ok(o) => String::from_utf8_lossy(&o.stdout).contains(DAEMON_FILE),
+        Err(_) => false,
     }
 }
 

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -41,6 +41,11 @@
 
 use std::path::{Path, PathBuf};
 
+// Used only by the Windows service-registration spawns below (schtasks / taskkill
+// / tasklist / the daemon launch) to suppress their console-window flash; the
+// trait method is a no-op on other platforms and would be an unused import there.
+#[cfg(target_os = "windows")]
+use meridian_core::proc_ext::NoWindow;
 use tauri::Manager;
 
 /// SHA-256 of a file as a lowercase hex string — the bundled-daemon update marker.
@@ -299,7 +304,7 @@ async fn register_service(_backend: &Path, home: &Path, daemon_bin: &Path) -> Re
             );
             install_startup_folder_launcher(daemon_bin).await?;
             // Nothing else will start the daemon until next login — start it now.
-            if let Err(e) = tokio::process::Command::new(daemon_bin).spawn() {
+            if let Err(e) = tokio::process::Command::new(daemon_bin).no_window().spawn() {
                 tracing::warn!(
                     error = %e,
                     bin = %daemon_bin.display(),
@@ -332,10 +337,12 @@ async fn register_service(_backend: &Path, home: &Path, daemon_bin: &Path) -> Re
 async fn stop_running_daemon_before_stage() {
     let _ = tokio::process::Command::new("schtasks")
         .args(["/End", "/TN", WINDOWS_TASK_NAME])
+        .no_window()
         .output()
         .await;
     let _ = tokio::process::Command::new("taskkill")
         .args(["/F", "/IM", DAEMON_FILE])
+        .no_window()
         .output()
         .await;
     for _ in 0..10 {
@@ -357,6 +364,7 @@ async fn daemon_process_running() -> bool {
             "CSV",
             "/NH",
         ])
+        .no_window()
         .output()
         .await;
     match out {
@@ -389,6 +397,7 @@ async fn register_scheduled_task(daemon_bin: &Path) -> Result<(), String> {
             "/TR",
         ])
         .arg(format!("\"{}\"", daemon_bin.display()))
+        .no_window()
         .output()
         .await
         .map_err(|e| format!("run schtasks: {e}"))?;
@@ -404,6 +413,7 @@ async fn register_scheduled_task(daemon_bin: &Path) -> Result<(), String> {
     // at login regardless.
     let _ = tokio::process::Command::new("schtasks")
         .args(["/Run", "/TN", WINDOWS_TASK_NAME])
+        .no_window()
         .output()
         .await;
     Ok(())

--- a/tray/src-tauri/src/commands/app_icons.rs
+++ b/tray/src-tauri/src/commands/app_icons.rs
@@ -138,7 +138,7 @@ pub fn get_app_icon(app_name: String) -> Result<Option<String>, String> {
     #[cfg(not(target_os = "macos"))]
     {
         tracing::debug!("app icon extraction is macOS-only");
-        return Ok(None);
+        Ok(None)
     }
 
     #[cfg(target_os = "macos")]

--- a/tray/src-tauri/src/commands/cli_exec.rs
+++ b/tray/src-tauri/src/commands/cli_exec.rs
@@ -29,6 +29,7 @@
 //! - [`crate::commands::triage`]'s `apply_ticket_fix` — the origin of the CWD
 //!   rationale (it predates this module and keeps its own bespoke variant).
 
+use meridian_core::proc_ext::NoWindow;
 use serde::Deserialize;
 use std::time::Duration;
 
@@ -55,6 +56,7 @@ pub(crate) async fn run_meridian(
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
+        .no_window()
         .output();
 
     let output = match tokio::time::timeout(timeout, child).await {
@@ -105,6 +107,7 @@ pub(crate) fn spawn_meridian_detached(args: &[String], label: &'static str) -> R
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
+        .no_window()
         .spawn()
         .map_err(|e| {
             tracing::warn!(bin = %bin, error = %e, "{label} detached spawn failed");

--- a/tray/src-tauri/src/commands/daemon_control.rs
+++ b/tray/src-tauri/src/commands/daemon_control.rs
@@ -127,6 +127,11 @@ async fn launchctl(args: &[&str], what: &str) -> Result<(), String> {
 
 // ── Windows: named pipe + Task Scheduler ────────────────────────────────────
 
+// Suppresses the console-window flash on the schtasks / direct-daemon spawns
+// below; no-op on other platforms, so kept behind the same cfg as its callers.
+#[cfg(target_os = "windows")]
+use meridian_core::proc_ext::NoWindow;
+
 #[cfg(target_os = "windows")]
 pub async fn probe() -> Probe {
     use std::time::Duration;
@@ -194,6 +199,7 @@ fn spawn_staged_daemon() -> Result<(), String> {
         return Err(format!("no staged daemon at {}", daemon_bin.display()));
     }
     std::process::Command::new(&daemon_bin)
+        .no_window()
         .spawn()
         .map(|_| ())
         .map_err(|e| format!("spawn {} failed: {e}", daemon_bin.display()))
@@ -230,6 +236,7 @@ pub async fn reload() -> Result<u32, String> {
 async fn schtasks(args: &[&str]) -> Result<(), String> {
     let out = tokio::process::Command::new("schtasks")
         .args(args)
+        .no_window()
         .output()
         .await
         .map_err(|e| format!("schtasks failed: {e}"))?;

--- a/tray/src-tauri/src/commands/parents.rs
+++ b/tray/src-tauri/src/commands/parents.rs
@@ -22,6 +22,7 @@
 //! - [`crate::install::meridian_bin`] — the shared "native binary first" resolver
 //!   (mirrors the Node helper `ui/lib/meridian-bin.ts`'s `selectMeridianBinary`).
 
+use meridian_core::proc_ext::NoWindow;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -81,6 +82,7 @@ pub async fn get_ticket_parents(provider: String, key: String) -> ParentsRespons
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
+        .no_window()
         .output();
 
     let output = match tokio::time::timeout(Duration::from_secs(30), child).await {

--- a/tray/src-tauri/src/commands/tasks.rs
+++ b/tray/src-tauri/src/commands/tasks.rs
@@ -16,6 +16,7 @@
 //! - [`crate::install::meridian_bin`] — the shared native-first binary resolver.
 //! - [`crate::commands::parents`] — the other read-side `meridian` CLI shell-out.
 
+use meridian_core::proc_ext::NoWindow;
 use serde::Serialize;
 use std::time::Duration;
 
@@ -54,6 +55,7 @@ pub async fn sync_tasks() -> Result<SyncResult, String> {
         // the board) after the UI reports a failure. The deleted /api/tasks/sync route
         // called child.kill() on its 30s timer — kill_on_drop preserves that contract.
         .kill_on_drop(true)
+        .no_window()
         .output();
 
     let output = match tokio::time::timeout(Duration::from_secs(30), child).await {

--- a/tray/src-tauri/src/commands/triage.rs
+++ b/tray/src-tauri/src/commands/triage.rs
@@ -25,6 +25,7 @@
 //!   ([`meridian_core::triage::record_decision`] / [`meridian_core::triage::set_ignored`]).
 //! - [`crate::commands::dashboard`] — sibling DB-read commands.
 
+use meridian_core::proc_ext::NoWindow;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use tauri::State;
@@ -251,6 +252,7 @@ pub async fn apply_ticket_fix(body: ApplyBody) -> Result<ApplyResponse, String> 
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
+        .no_window()
         .output();
 
     let output = match tokio::time::timeout(Duration::from_secs(60), child).await {

--- a/tray/src-tauri/src/commands/uninstall.rs
+++ b/tray/src-tauri/src/commands/uninstall.rs
@@ -24,6 +24,7 @@
 //! - [`crate::commands::system::open_permission_pane`] — the wizard's "revoke
 //!   permissions" step reuses this to deep-link System Settings.
 
+use meridian_core::proc_ext::NoWindow;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -174,6 +175,7 @@ async fn run_cli(bin: &str, args: &[&str]) -> Result<CliReport, String> {
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
+        .no_window()
         .output();
 
     let output = match tokio::time::timeout(Duration::from_secs(30), child).await {


### PR DESCRIPTION
## Summary
On Windows, every `Command::new` spawn of a **console-subsystem** program pops a visible console window unless the process is created with `CREATE_NO_WINDOW` — piping stdio does not suppress it. The tray is a GUI app and the daemon runs console-less, so each such spawn flashed a window. Two user-visible symptoms:
- a popup on nearly **every tray operation** (the tray shelling out to `meridian.exe` for tasks-sync, ticket-update, ticket-parents, uninstall, daemon control, backend install)
- a popup on **"claude verification"** (the coding-agent summariser's `claude`/`codex`/`cursor-agent` CLI calls, which npm installs as `.cmd` shims routed through `cmd.exe`)

## What changed
- New `meridian_core::proc_ext::NoWindow` trait: a chainable `.no_window()` implemented for **both** `std::process::Command` and `tokio::process::Command`. Sets `CREATE_NO_WINDOW` on Windows, no-op everywhere else, so call sites chain it unconditionally.
- Applied `.no_window()` to every console-subsystem spawn across the daemon and tray: `schtasks`/`taskkill`/`tasklist`/`powershell`, the CLI provider calls (summariser, detect, cursor-agent init), the `meridian.exe` shell-outs, and the daemon binary itself.
- Deliberately **not** applied to `health::fix::exec` — `meridian doctor --fix` runs in a real terminal and inherits stdio; suppressing it would swallow output the user wants.
- Promotes `tokio` from a dev-dependency to a real dependency of `meridian-core` (`process` feature only) for the tokio `Command` impl. tokio is already in the tree via sqlx's runtime, so feature-unification means this adds nothing new to compile.
- Removes a `needless_return` in `app_icons.rs` that only trips clippy on the non-macOS build (the macOS CI never compiles that cfg arm) and would otherwise block the Windows pre-push clippy gate.

## Note on the base
This branch is **stacked on `fix/windows-stage-copy-daemon-lock` (#565)** because both change `backend_install.rs`. Until #565 merges, this PR's diff will also show #565's commit; once #565 merges into `pre-main`, it will show only the console-flash change. Merge #565 first.

## Test plan
- [x] `cargo check` + `cargo clippy -- -D warnings` on the daemon and tray, compiled for the `aarch64-pc-windows-msvc` target (so the `#[cfg(windows)]` arms were actually type-checked and linted)
- [x] Full `pre-push` hook suite (fmt, ui build, clippy, ui tests, cargo test, security audit) — all green
- [ ] Confirm on a real Windows run that tray operations and summariser runs no longer flash a console window
