### PR TITLE
fix(review): resolve CodeRabbit findings on the pre-main release (#568)

### DIFF
--- a/meridian-core/src/readers/plan.rs
+++ b/meridian-core/src/readers/plan.rs
@@ -208,6 +208,21 @@ async fn table_exists(pool: &SqlitePool, name: &str) -> bool {
         .is_some()
 }
 
+/// Whether `table` has `column` — used to stay graceful on a DB that predates a
+/// migration (here, `pm_tasks.deleted_at` from 075). Same swallow-on-error shape
+/// as [`table_exists`]: a probe failure reads as "absent", so the caller falls
+/// back to the pre-migration query instead of erroring.
+async fn column_exists(pool: &SqlitePool, table: &str, column: &str) -> bool {
+    sqlx::query_scalar::<_, i64>("SELECT 1 FROM pragma_table_info(?) WHERE name=?")
+        .bind(table)
+        .bind(column)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten()
+        .is_some()
+}
+
 // ── Loaders ───────────────────────────────────────────────────────────────────
 
 struct MetaRow {
@@ -388,7 +403,10 @@ pub async fn build_available(
 ) -> anyhow::Result<Vec<AvailableTask>> {
     let has_curation = table_exists(pool, "pm_task_curation").await;
     // `t.deleted_at IS NULL` (migration 075) — a task the user deleted from the
-    // composer must not be offered back as a suggestion.
+    // composer must not be offered back as a suggestion. Gated on the column
+    // existing so a DB not yet migrated to 075 still reads (graceful missing
+    // schema, like the curation join above).
+    let has_deleted_at = column_exists(pool, "pm_tasks", "deleted_at").await;
     let sql = format!(
         r#"SELECT t.task_key, t.title, t.provider, t.url,
                   COALESCE(t.status_raw,'') AS status_raw,
@@ -399,10 +417,15 @@ pub async fn build_available(
                   {} AS decision
            FROM pm_tasks t
            {}
-           WHERE t.deleted_at IS NULL"#,
+           {}"#,
         if has_curation { "c.decision" } else { "NULL" },
         if has_curation {
             "LEFT JOIN pm_task_curation c ON c.task_key = t.task_key"
+        } else {
+            ""
+        },
+        if has_deleted_at {
+            "WHERE t.deleted_at IS NULL"
         } else {
             ""
         },
@@ -735,6 +758,12 @@ async fn plan_join_rows(pool: &SqlitePool, date: &str) -> anyhow::Result<Vec<Pla
     .flatten()
     .is_some();
 
+    // 075 added pm_tasks.deleted_at; a DB that predates it lacks the column, so
+    // select a NULL literal instead of erroring on `t.deleted_at` (the join's
+    // consumers treat a NULL as "not deleted" — see the `deleted_at.is_none()`
+    // filter in load_plan).
+    let has_deleted_at = column_exists(pool, "pm_tasks", "deleted_at").await;
+
     let sql = format!(
         r#"SELECT p.task_key, p.position, p.origin,
                   {},
@@ -743,7 +772,7 @@ async fn plan_join_rows(pool: &SqlitePool, date: &str) -> anyhow::Result<Vec<Pla
                   COALESCE(t.status_raw,'') AS status_raw,
                   COALESCE(t.is_terminal,0) AS is_terminal,
                   t.due_date, t.description_text, t.epic_title, t.parent_key,
-                  t.priority, t.issue_type, t.story_points, t.deleted_at
+                  t.priority, t.issue_type, t.story_points, {}
            FROM daily_plan p
            LEFT JOIN pm_tasks t ON t.task_key = p.task_key
            WHERE p.plan_date = ?
@@ -752,6 +781,11 @@ async fn plan_join_rows(pool: &SqlitePool, date: &str) -> anyhow::Result<Vec<Pla
             "p.task_snapshot"
         } else {
             "NULL AS task_snapshot"
+        },
+        if has_deleted_at {
+            "t.deleted_at"
+        } else {
+            "NULL AS deleted_at"
         },
     );
     let rows: Vec<PlanJoinRow> = sqlx::query_as::<_, PlanJoinRow>(&sql)

--- a/meridian-core/src/readers/tasks.rs
+++ b/meridian-core/src/readers/tasks.rs
@@ -182,13 +182,20 @@ pub async fn get_tasks(
     };
     // `deleted_at IS NULL` (migration 075) — a task the user deleted from the
     // composer must stop appearing here even though its row still exists (see
-    // meridian_core::task_create's module doc for why it's a soft hide).
+    // meridian_core::task_create's module doc for why it's a soft hide). Gated on
+    // the column existing so a DB not yet migrated to 075 still reads, matching
+    // the CDM columns above (ported readers must degrade gracefully on old schema).
+    let deleted_filter = if column_exists(pool, "pm_tasks", "deleted_at").await? {
+        "WHERE deleted_at IS NULL "
+    } else {
+        ""
+    };
     let task_rows: Vec<TaskRow> = sqlx::query_as::<_, TaskRow>(&format!(
         "SELECT task_key, title, description_text, COALESCE(issue_type,'') AS issue_type, \
                 status_raw, is_terminal, provider, url, parent_key, epic_title, due_date, start_date, \
                 {cdm_cols} \
          FROM pm_tasks \
-         WHERE deleted_at IS NULL \
+         {deleted_filter}\
          ORDER BY task_key DESC"
     ))
     .fetch_all(pool)

--- a/meridian-core/tests/readers.rs
+++ b/meridian-core/tests/readers.rs
@@ -889,6 +889,103 @@ async fn local_task_appears_on_the_board_and_is_not_done() {
 }
 
 #[tokio::test]
+async fn soft_deleting_a_personal_task_hides_it_everywhere_and_is_idempotent() {
+    // Deleting a personal task is a soft hide (`deleted_at`), migration 075: the
+    // row must stay (its key is never reissued), the second delete must be a
+    // no-op rather than an error, and the hidden task must vanish from both the
+    // available-plan reader (`build_available`) and the committed-plan reader
+    // (`build_plan_response`).
+    let pool = make_task_create_pool().await;
+
+    let today = chrono::Local::now().date_naive();
+    let date = today.format("%Y-%m-%d").to_string();
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let recent_since = (chrono::Local::now()
+        - Duration::days(meridian_core::plan::RECENT_WORK_DAYS))
+    .format("%Y-%m-%d")
+    .to_string();
+
+    // Create a personal task and commit it to today's plan.
+    let key =
+        meridian_core::task_create::create_local_task(&pool, "Draft the memo", "d", "Task", "t0")
+            .await
+            .unwrap();
+    let available =
+        meridian_core::plan::build_available(&pool, &date, today, now_ms, &recent_since)
+            .await
+            .unwrap();
+    assert!(
+        available.iter().any(|a| a.key == key),
+        "sanity: the task is on the board before deletion"
+    );
+    let body = meridian_core::plan::PlanBody {
+        action: "confirm".into(),
+        date: Some(date.clone()),
+        task_key: None,
+        task_keys: Some(vec![key.clone()]),
+    };
+    meridian_core::plan::apply_plan_action(&pool, &body, &date, today, "t0", available.clone())
+        .await
+        .unwrap();
+    let before = meridian_core::plan::build_plan_response(&pool, &date, today, available.clone())
+        .await
+        .unwrap();
+    assert!(
+        before.plan.iter().any(|p| p.task_key == key),
+        "sanity: the task is in the committed plan before deletion"
+    );
+
+    // First delete hides the row; a second is idempotent (no-op, not an error).
+    assert!(
+        meridian_core::task_create::delete_local_task(&pool, &key, "t1")
+            .await
+            .unwrap(),
+        "first delete reports a row changed"
+    );
+    assert!(
+        !meridian_core::task_create::delete_local_task(&pool, &key, "t2")
+            .await
+            .unwrap(),
+        "re-deleting an already-hidden task is a no-op"
+    );
+    assert!(
+        meridian_core::task_create::task_exists(&pool, &key)
+            .await
+            .unwrap(),
+        "soft delete keeps the row so its key is never reissued"
+    );
+
+    // Excluded from the available-plan reader.
+    let available_after =
+        meridian_core::plan::build_available(&pool, &date, today, now_ms, &recent_since)
+            .await
+            .unwrap();
+    assert!(
+        !available_after.iter().any(|a| a.key == key),
+        "a hidden task must leave build_available"
+    );
+
+    // Excluded from the committed-plan reader, even though its daily_plan row remains.
+    let after =
+        meridian_core::plan::build_plan_response(&pool, &date, today, available_after.clone())
+            .await
+            .unwrap();
+    assert!(
+        !after.plan.iter().any(|p| p.task_key == key),
+        "a hidden task must leave the committed plan"
+    );
+
+    // Key allocation is preserved: the next personal task climbs past the hidden one.
+    let next = meridian_core::task_create::create_local_task(&pool, "Next", "d", "Task", "t3")
+        .await
+        .unwrap();
+    assert_eq!(
+        next, "LOCAL-2",
+        "a hidden task's key must never be reissued"
+    );
+}
+
+#[tokio::test]
 async fn local_task_survives_a_provider_scoped_prune() {
     // THE load-bearing invariant. Every sync's prune is `WHERE provider = '<tracker>'`,
     // which is what makes it structurally unable to see a 'local' row. If a future

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -361,7 +361,9 @@ fn run_human(plan: &Plan) {
         remove_path_reporting(f);
     }
     if flags.remove_data {
-        reset_tcc_grants();
+        for f in reset_tcc_grants() {
+            eprintln!("⚠ could not reset TCC grant {f}");
+        }
     }
     for f in &plan.runtime {
         remove_path_reporting(f);
@@ -387,6 +389,11 @@ fn run_human(plan: &Plan) {
         "\nDone. If the Meridian menubar app is still running, quit it (or drag \
          Meridian.app to the Trash) - the MLX server is its child and exits with it."
     );
+    // These Accessibility / Screen Recording / Input Monitoring grants are a
+    // macOS TCC concept: there is nothing analogous to reset or explain on other
+    // platforms, and `reset_tcc_grants` is a no-op there, so the messaging is
+    // gated to macOS rather than falsely claiming a reset was attempted.
+    #[cfg(target_os = "macos")]
     if flags.remove_data {
         println!(
             "\nAlso attempted to reset the Accessibility / Screen Recording / Input \
@@ -410,17 +417,57 @@ fn run_human(plan: &Plan) {
 /// the same tool for the retired a11y-helper. Non-fatal: `tccutil` may be
 /// missing, sandboxed, or refuse without Full Disk Access, and none of that
 /// should abort the rest of the uninstall.
+///
+/// Returns a `service: reason` line for each reset that did NOT clearly succeed
+/// (tool failed to launch, or exited non-zero) so both uninstall paths can
+/// surface it — previously a denied or missing `tccutil` was indistinguishable
+/// from a clean reset. Every outcome is also logged with structured `service`,
+/// `status`/`error` fields.
 #[cfg(target_os = "macos")]
-fn reset_tcc_grants() {
+fn reset_tcc_grants() -> Vec<String> {
+    let mut failures = Vec::new();
     for service in ["Accessibility", "ScreenCapture", "ListenEvent"] {
-        let _ = std::process::Command::new("tccutil")
+        match std::process::Command::new("tccutil")
             .args(["reset", service, "com.meridiona.tray"])
-            .output();
+            .output()
+        {
+            Ok(out) if out.status.success() => {
+                tracing::info!(service, "uninstall: tcc grant reset");
+            }
+            Ok(out) => {
+                let status = out
+                    .status
+                    .code()
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "terminated by signal".to_string());
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                let stderr = stderr.trim();
+                tracing::warn!(
+                    service,
+                    status = %status,
+                    stderr = %stderr,
+                    "uninstall: tccutil reset returned non-zero"
+                );
+                let reason = if stderr.is_empty() {
+                    format!("{service}: tccutil exited {status}")
+                } else {
+                    format!("{service}: tccutil exited {status} ({stderr})")
+                };
+                failures.push(reason);
+            }
+            Err(e) => {
+                tracing::warn!(service, error = %e, "uninstall: tccutil reset failed to launch");
+                failures.push(format!("{service}: {e}"));
+            }
+        }
     }
+    failures
 }
 
 #[cfg(not(target_os = "macos"))]
-fn reset_tcc_grants() {}
+fn reset_tcc_grants() -> Vec<String> {
+    Vec::new()
+}
 
 /// `~/.meridian` user-data items removed by `--remove-data`/`--purge`, plus (on
 /// macOS) the OS-managed app caches WebKit/AppKit create for the tray's bundle

--- a/src/uninstall/json.rs
+++ b/src/uninstall/json.rs
@@ -103,7 +103,11 @@ pub(super) fn run_json(plan: &Plan) {
         }
     }
     if flags.remove_data {
-        reset_tcc_grants();
+        // Surface any TCC reset that didn't clearly succeed so automation sees
+        // the real outcome instead of assuming a clean reset.
+        for f in reset_tcc_grants() {
+            report.errors.push(format!("tccutil reset {f}"));
+        }
     }
     // `--purge` only: nuke anything left under ~/.meridian the itemized lists
     // above didn't name. Mirrors the human path's `--purge`-only gate — see the

--- a/tray/src-tauri/src/analytics.rs
+++ b/tray/src-tauri/src/analytics.rs
@@ -61,7 +61,7 @@
 //! **Nothing is lost on failure.** [`capture`] reports success/failure via
 //! its return value, and both call sites ([`maybe_send_daily_tick`],
 //! [`send_daily_usage`]) only flip their persisted "sent" bookkeeping
-//! (`install_events_sent` / `last_sent_day`) on a confirmed success. A DB read
+//! (`install_events_sent` / `last_sent_day_by_email`) on a confirmed success. A DB read
 //! failure, a network error, a timeout, or a non-2xx from PostHog all leave
 //! that bookkeeping untouched, so the *exact same* pending event (the same
 //! day, carrying that day's own `date` property — never today's) is retried
@@ -85,7 +85,7 @@
 
 use meridian_core::SqlitePool;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -162,9 +162,21 @@ struct AnalyticsState {
     #[serde(default)]
     install_events_sent: HashSet<String>,
     /// The last LOCAL calendar day ("YYYY-MM-DD") a `daily_usage` event was
-    /// sent for. `None` before the first day boundary has been observed
-    /// (which never happens before the first sign-in — see [`maybe_send_daily_tick`]).
-    last_sent_day: Option<String>,
+    /// sent for, keyed by the signed-in account email it was accrued under —
+    /// NOT a single device-wide cursor. Scoped per email for the same reason
+    /// `install_events_sent` is a set: one device can see more than one
+    /// signed-in email over its lifetime (sign-out, sign back in as someone
+    /// else). A shared cursor would let account A's still-pending day be sent
+    /// under account B's `distinct_id` after a switch, and could suppress
+    /// account B's own first eligible day as "already sent" — so each email
+    /// carries its own cursor. An email absent from the map has observed no
+    /// day boundary yet (which never happens before that email's first
+    /// sign-in — see [`maybe_send_daily_tick`]). `#[serde(default)]` so an
+    /// older install's file (no such field, or the old scalar `last_sent_day`)
+    /// just starts empty rather than failing to parse — the currently
+    /// signed-in email simply re-arms today with no send, never a double-send.
+    #[serde(default)]
+    last_sent_day_by_email: HashMap<String, String>,
 }
 
 fn analytics_state_path() -> Option<PathBuf> {
@@ -183,7 +195,7 @@ fn load_or_init_state(path: &std::path::Path) -> AnalyticsState {
     AnalyticsState {
         device_id: uuid::Uuid::new_v4().to_string(),
         install_events_sent: HashSet::new(),
-        last_sent_day: None,
+        last_sent_day_by_email: HashMap::new(),
     }
 }
 
@@ -304,7 +316,7 @@ fn base_properties(
 /// returning `Some` — nothing is ever sent anonymously (see the module doc).
 /// While no email is on file (sign-in never completed, or the user signed
 /// out), this is a no-op every tick: no HTTP call, and day-rollover
-/// bookkeeping (`last_sent_day`) stays un-armed, so the day the user
+/// bookkeeping (`last_sent_day_by_email`) stays un-armed for that email, so the day the user
 /// eventually signs in on is never reported — only the first FULL day after
 /// that is, matching the "never backfill" rule elsewhere in this module.
 ///
@@ -344,11 +356,15 @@ pub(crate) async fn maybe_send_daily_tick(app: &tauri::AppHandle, pool: &SqliteP
     }
 
     let today = meridian_core::date::today_string();
-    match day_rollover_action(state.last_sent_day.as_deref(), &today) {
+    // Read/advance THIS email's own cursor — never a shared one — so a
+    // still-pending day accrued under a previously signed-in account can never
+    // be attributed to whoever is signed in now (see [`AnalyticsState::last_sent_day_by_email`]).
+    let last_sent_day = state.last_sent_day_by_email.get(&email).cloned();
+    match day_rollover_action(last_sent_day.as_deref(), &today) {
         Some(None) => {
-            // First observation since sign-in (or ever) — nothing has closed
-            // yet, so there's nothing to report.
-            state.last_sent_day = Some(today);
+            // First observation since sign-in (or ever) for THIS email —
+            // nothing has closed yet, so there's nothing to report.
+            state.last_sent_day_by_email.insert(email.clone(), today);
             dirty = true;
         }
         Some(Some(day)) => {
@@ -356,7 +372,7 @@ pub(crate) async fn maybe_send_daily_tick(app: &tauri::AppHandle, pool: &SqliteP
             // read hiccup must retry next tick, not silently report (and
             // permanently skip) a fabricated zero-usage day.
             if send_daily_usage(app, pool, &email, &state.device_id, &day).await {
-                state.last_sent_day = Some(today);
+                state.last_sent_day_by_email.insert(email.clone(), today);
                 dirty = true;
             }
         }
@@ -516,6 +532,84 @@ mod day_rollover_tests {
         assert_eq!(
             day_rollover_action(Some("2026-07-01"), "2026-07-09"),
             Some(Some("2026-07-01".to_string()))
+        );
+    }
+}
+
+#[cfg(test)]
+mod per_email_cursor_tests {
+    //! Regression coverage for the per-email daily-usage cursor
+    //! ([`AnalyticsState::last_sent_day_by_email`]). These mirror the exact
+    //! cursor read/advance that [`maybe_send_daily_tick`] performs for the
+    //! signed-in email, minus the live DB/HTTP send, so they assert the
+    //! scoping decision without a Tauri app or SQLite pool.
+    use super::{day_rollover_action, AnalyticsState};
+    use std::collections::{HashMap, HashSet};
+
+    fn state_with_cursors(cursors: &[(&str, &str)]) -> AnalyticsState {
+        AnalyticsState {
+            device_id: "test-device".to_string(),
+            install_events_sent: HashSet::new(),
+            last_sent_day_by_email: cursors
+                .iter()
+                .map(|(email, day)| (email.to_string(), day.to_string()))
+                .collect::<HashMap<_, _>>(),
+        }
+    }
+
+    /// The day (if any) that `maybe_send_daily_tick` would actually SEND a
+    /// `daily_usage` for, for `email` on `today` — reading only that email's
+    /// own cursor, exactly as the tick does. `None` = arm-only / no-op.
+    fn day_to_send_for(state: &AnalyticsState, email: &str, today: &str) -> Option<String> {
+        match day_rollover_action(
+            state.last_sent_day_by_email.get(email).map(|s| s.as_str()),
+            today,
+        ) {
+            Some(Some(day)) => Some(day),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn account_switch_does_not_misattribute_pending_day() {
+        // Account A armed its cursor at 2026-07-08 while signed in; a local-day
+        // boundary then passed (today is 2026-07-09) with A's 2026-07-08 usage
+        // still pending. A signs out and B signs in before the next tick fires.
+        let state = state_with_cursors(&[("a@example.com", "2026-07-08")]);
+
+        // B has no cursor of its own, so the tick arms B at today WITHOUT
+        // sending anything — A's pending 2026-07-08 day is never attributed to
+        // B. (The pre-fix shared cursor would have sent 2026-07-08 under B's
+        // email, since prev != today.)
+        assert_eq!(day_to_send_for(&state, "b@example.com", "2026-07-09"), None);
+
+        // And A's own cursor is untouched: when A signs back in, its pending
+        // 2026-07-08 day is still sent — under A's own email, where it belongs.
+        assert_eq!(
+            day_to_send_for(&state, "a@example.com", "2026-07-09"),
+            Some("2026-07-08".to_string())
+        );
+    }
+
+    #[test]
+    fn newly_signed_in_account_still_gets_its_first_full_day() {
+        // A device that has already reported days for account A. Account B
+        // signs in fresh — a shared cursor sitting at A's latest day could
+        // suppress B's first eligible day as "already sent".
+        let mut state = state_with_cursors(&[("a@example.com", "2026-07-09")]);
+
+        // First tick after B signs in: nothing has closed for B yet → arm
+        // only, no send.
+        assert_eq!(day_to_send_for(&state, "b@example.com", "2026-07-09"), None);
+        state
+            .last_sent_day_by_email
+            .insert("b@example.com".to_string(), "2026-07-09".to_string());
+
+        // Next local day: B's own first full day (2026-07-09) is now sent,
+        // independent of A's cursor.
+        assert_eq!(
+            day_to_send_for(&state, "b@example.com", "2026-07-10"),
+            Some("2026-07-09".to_string())
         );
     }
 }

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -200,15 +200,17 @@ async fn install(backend: &Path, home: &Path) -> Result<(), String> {
         migrate_legacy_bundle_env(home).await;
     }
 
+    let daemon_bin = home.join(".meridian").join("bin").join(DAEMON_FILE);
+
     // Windows keeps a running exe's pages mapped, so overwriting it fails with
     // "the process cannot access the file" (os error 32) — and this isn't just
     // a first-install concern: `ensure_backend_installed` re-stages on every
     // version bump while the *previous* build's daemon is still alive from an
-    // earlier login. Stop it first so the copy below can succeed.
+    // earlier login. Stop it first so the copy below can succeed; if it can't
+    // be stopped, propagate the failure rather than staging over a locked file.
     #[cfg(target_os = "windows")]
-    stop_running_daemon_before_stage().await;
+    stop_running_daemon_before_stage(&daemon_bin).await?;
 
-    let daemon_bin = home.join(".meridian").join("bin").join(DAEMON_FILE);
     stage_binary(&backend.join(DAEMON_FILE), &daemon_bin).await?;
 
     register_service(backend, home, &daemon_bin).await
@@ -320,56 +322,142 @@ async fn register_service(_backend: &Path, home: &Path, daemon_bin: &Path) -> Re
     }
 }
 
-/// Stop any running instance of the staged daemon so [`stage_binary`] can
-/// overwrite `~/.meridian/bin/meridian.exe`. Best-effort on two fronts,
-/// because the daemon can be running via either path [`register_service`] may
-/// have taken:
-/// - `schtasks /End` stops it if the scheduled task is what launched it.
-/// - `taskkill /IM` also catches the Startup-folder-launcher fallback case,
-///   where the process was spawned directly by `wscript` and has no
-///   association with the scheduled task for `/End` to find.
+/// Stop the running instance(s) of **the staged daemon** so [`stage_binary`]
+/// can overwrite `~/.meridian/bin/meridian.exe`. Targets only processes whose
+/// executable is exactly `daemon_bin` — never an unrelated `meridian.exe` (an
+/// interactive CLI run, say, or a different tool sharing that image name).
 ///
-/// Killing the process doesn't release its file handle instantaneously, so
-/// this polls (mirroring the launchd bootout wait in [`register_agent`])
-/// rather than proceeding immediately — a fixed sleep would either race a
-/// slow exit or pad every install with unnecessary wait time.
+/// The daemon can be running via either path [`register_service`] may have
+/// taken, so two stop mechanisms are used:
+/// - `schtasks /End` stops it if the scheduled task is what launched it; it
+///   targets our task by name, so it never touches anything else.
+/// - `taskkill /F /PID` (per matched PID) also catches the Startup-folder
+///   launcher fallback, where the process was spawned directly by `wscript`
+///   and has no association with the scheduled task for `/End` to find. Killing
+///   by PID — not by `/IM` image name — is what keeps unrelated `meridian.exe`
+///   processes alive.
+///
+/// Killing a process doesn't release its file handle instantaneously, so this
+/// polls (mirroring the launchd bootout wait in [`register_agent`]) rather than
+/// proceeding immediately. If any matching process is *still* alive once the
+/// polling window closes, this returns `Err`: staging over a file the daemon
+/// still holds open would fail with os error 32, and the caller must surface
+/// that as an install failure rather than silently continuing.
 #[cfg(target_os = "windows")]
-async fn stop_running_daemon_before_stage() {
+async fn stop_running_daemon_before_stage(daemon_bin: &Path) -> Result<(), String> {
+    // Targets our task by name — safe regardless of what else is named meridian.exe.
     let _ = tokio::process::Command::new("schtasks")
         .args(["/End", "/TN", WINDOWS_TASK_NAME])
         .no_window()
         .output()
         .await;
-    let _ = tokio::process::Command::new("taskkill")
-        .args(["/F", "/IM", DAEMON_FILE])
-        .no_window()
-        .output()
-        .await;
-    for _ in 0..10 {
-        if !daemon_process_running().await {
-            break;
+
+    for pid in matching_daemon_pids(daemon_bin).await {
+        let out = tokio::process::Command::new("taskkill")
+            .args(["/F", "/PID", &pid.to_string()])
+            .no_window()
+            .output()
+            .await;
+        match out {
+            Ok(o) if o.status.success() => {
+                tracing::info!(pid, path = %daemon_bin.display(), "backend_install: stopped staged daemon process");
+            }
+            Ok(o) => {
+                tracing::warn!(
+                    pid,
+                    path = %daemon_bin.display(),
+                    status = %o.status,
+                    stderr = %String::from_utf8_lossy(&o.stderr).trim(),
+                    "backend_install: taskkill did not stop staged daemon process"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(pid, path = %daemon_bin.display(), error = %e, "backend_install: taskkill spawn failed");
+            }
         }
+    }
+
+    // Poll until the staged daemon's own processes are gone (the file handle
+    // lingers briefly after the kill), then require an empty set — a still-alive
+    // holder means the overwrite below would fail, so fail loudly here instead.
+    for attempt in 0..10 {
+        let remaining = matching_daemon_pids(daemon_bin).await;
+        if remaining.is_empty() {
+            return Ok(());
+        }
+        tracing::debug!(
+            attempt,
+            path = %daemon_bin.display(),
+            remaining = remaining.len(),
+            "backend_install: waiting for staged daemon to exit"
+        );
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
     }
+
+    let remaining = matching_daemon_pids(daemon_bin).await;
+    if remaining.is_empty() {
+        return Ok(());
+    }
+    tracing::error!(
+        path = %daemon_bin.display(),
+        pids = ?remaining,
+        "backend_install: staged daemon still running after stop attempts"
+    );
+    Err(format!(
+        "staged daemon {} still running after stop attempts (pids: {remaining:?}) - cannot overwrite a locked binary",
+        daemon_bin.display()
+    ))
 }
 
-/// Whether a process named [`DAEMON_FILE`] currently shows up in `tasklist`.
+/// PIDs of running processes whose executable is exactly the staged daemon
+/// binary `daemon_bin` — never a process that merely shares the `meridian.exe`
+/// image name. Uses a `Get-CimInstance Win32_Process` query for PID + full
+/// `ExecutablePath`, which `tasklist` alone can't supply. Enumeration failure
+/// is logged and yields an empty set (best-effort): the caller's post-poll
+/// check still guards the actual overwrite.
 #[cfg(target_os = "windows")]
-async fn daemon_process_running() -> bool {
-    let out = tokio::process::Command::new("tasklist")
-        .args([
-            "/FI",
-            &format!("IMAGENAME eq {DAEMON_FILE}"),
-            "/FO",
-            "CSV",
-            "/NH",
-        ])
+async fn matching_daemon_pids(daemon_bin: &Path) -> Vec<u32> {
+    let script = format!(
+        "Get-CimInstance Win32_Process -Filter \"Name='{DAEMON_FILE}'\" | ForEach-Object {{ \"$($_.ProcessId)`t$($_.ExecutablePath)\" }}"
+    );
+    let out = tokio::process::Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
         .no_window()
         .output()
         .await;
-    match out {
-        Ok(o) => String::from_utf8_lossy(&o.stdout).contains(DAEMON_FILE),
-        Err(_) => false,
+    let stdout = match out {
+        Ok(o) => o.stdout,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %daemon_bin.display(), "backend_install: could not enumerate daemon processes");
+            return Vec::new();
+        }
+    };
+    String::from_utf8_lossy(&stdout)
+        .lines()
+        .filter_map(|line| {
+            let (pid, path) = line.split_once('\t')?;
+            let pid: u32 = pid.trim().parse().ok()?;
+            let path = path.trim();
+            if path.is_empty() {
+                return None;
+            }
+            same_windows_path(Path::new(path), daemon_bin).then_some(pid)
+        })
+        .collect()
+}
+
+/// Whether two paths resolve to the same file on Windows, tolerant of case,
+/// separator, and verbatim-prefix differences. Prefers `canonicalize` (both
+/// paths point at one physical file), falling back to a case-insensitive string
+/// compare when the file can no longer be canonicalized.
+#[cfg(target_os = "windows")]
+fn same_windows_path(a: &Path, b: &Path) -> bool {
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => {
+            let norm = |p: &Path| p.to_string_lossy().replace('/', "\\").to_ascii_lowercase();
+            norm(a) == norm(b)
+        }
     }
 }
 

--- a/tray/src-tauri/src/poll/mod.rs
+++ b/tray/src-tauri/src/poll/mod.rs
@@ -32,6 +32,7 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::{Emitter, Manager};
+use tracing::Instrument;
 
 const TICK: Duration = Duration::from_secs(30);
 
@@ -88,10 +89,17 @@ pub async fn run_daemon_watchdog() {
             continue;
         }
 
-        tracing::info!("daemon watchdog: endpoint down ~{down_after_s}s — restarting");
-        if let Err(e) = crate::commands::daemon_control::restart().await {
-            tracing::warn!(error = %e, "daemon watchdog: restart attempt failed");
+        // Wrap the discrete recovery operation in a span so the whole attempt is
+        // traceable end-to-end; `down_after_s` rides on the span as a structured
+        // field (queryable in JSON sinks) rather than baked into a message.
+        async {
+            tracing::info!("daemon watchdog: endpoint down, restarting");
+            if let Err(e) = crate::commands::daemon_control::restart().await {
+                tracing::warn!(error = %e, "daemon watchdog: restart attempt failed");
+            }
         }
+        .instrument(tracing::info_span!("daemon_watchdog.restart", down_after_s))
+        .await;
         cooldown_until = Some(Instant::now() + WATCHDOG_COOLDOWN);
         consecutive_down = 0;
     }

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -17,6 +17,7 @@ use crate::state::{ActiveSession, AppState, HealthStatus, TodayBreakdown};
 use meridian_core::SqlitePool;
 use std::sync::{Arc, Mutex};
 use tauri::Emitter;
+use tracing::Instrument;
 
 /// Run the local health check, fold it into [`AppState`], and raise/clear the
 /// went-quiet / back-online notice (debounced to the 2nd consecutive failure).
@@ -89,12 +90,18 @@ pub(super) async fn refresh_health(
     // user-facing notice below does. Best-effort: the result feeds the notice
     // detail when we also notify.
     let restart_result = if attempt_restart {
-        let r = crate::commands::daemon_control::restart().await;
-        match &r {
-            Err(e) => tracing::warn!(error = %e, "daemon-health auto-restart attempt failed"),
-            Ok(()) => tracing::info!("daemon-health auto-restart attempted"),
+        // Wrap the restart attempt in a span so the health-path recovery is
+        // traceable end-to-end, matching the fast watchdog's span.
+        async {
+            let r = crate::commands::daemon_control::restart().await;
+            match &r {
+                Err(e) => tracing::warn!(error = %e, "daemon-health auto-restart attempt failed"),
+                Ok(()) => tracing::info!("daemon-health auto-restart attempted"),
+            }
+            Some(r)
         }
-        Some(r)
+        .instrument(tracing::info_span!("daemon_watchdog.restart"))
+        .await
     } else {
         None
     };
@@ -114,7 +121,7 @@ pub(super) async fn refresh_health(
             Some(Err(_)) => {
                 "Tried to restart it automatically and that failed too. Tap to check what happened."
             }
-            _ => "Tried restarting it automatically — give it a moment.",
+            _ => "Tried restarting it automatically - give it a moment.",
         };
         if let Err(e) = meridian::notices::raise_typed(
             pool,

--- a/ui/components/timeline/TaskDetailDialog.tsx
+++ b/ui/components/timeline/TaskDetailDialog.tsx
@@ -110,6 +110,10 @@ export function TaskDetailDialog({
   // ticket's title/description stays read-only here (edit it in the tracker).
   const isPersonal = detail?.provider === LOCAL_PROVIDER
   const canEditText = isPersonal && editableTask
+  // Deletion is available for every personal task, even one on a past-day plan
+  // (editableTask=false): removing a mistakenly created task must not be gated
+  // on the historical text-edit permission. Editing stays gated by canEditText.
+  const canDeleteTask = isPersonal
 
   function startEdit() {
     setDraftTitle(detail?.title ?? '')
@@ -354,7 +358,7 @@ export function TaskDetailDialog({
               </button>
             </div>
           </div>
-        ) : (detail?.url || onAdd || onRemove || canEditText) && (
+        ) : (detail?.url || onAdd || onRemove || canEditText || canDeleteTask) && (
           <div className="px-7 py-5 border-t shrink-0 flex items-center gap-2.5" style={{ borderColor: 'var(--t-hair)' }}>
             {canEditText && (editing ? (
               <>
@@ -370,19 +374,19 @@ export function TaskDetailDialog({
                 </button>
               </>
             ) : (
-              <>
-                <button onClick={startEdit}
-                  className="mt-body-sm px-3.5 py-2 rounded-lg bg-ctrl"
-                  style={{ border: '1px solid var(--t-ctrl-border)', color: 'var(--t-muted)' }}>
-                  Edit
-                </button>
-                <button onClick={() => setConfirmingDelete(true)}
-                  className="mt-body-sm px-3.5 py-2 rounded-lg bg-ctrl"
-                  style={{ border: '1px solid var(--t-ctrl-border)', color: 'var(--color-state-pending)' }}>
-                  Delete
-                </button>
-              </>
+              <button onClick={startEdit}
+                className="mt-body-sm px-3.5 py-2 rounded-lg bg-ctrl"
+                style={{ border: '1px solid var(--t-ctrl-border)', color: 'var(--t-muted)' }}>
+                Edit
+              </button>
             ))}
+            {canDeleteTask && !editing && (
+              <button onClick={() => setConfirmingDelete(true)}
+                className="mt-body-sm px-3.5 py-2 rounded-lg bg-ctrl"
+                style={{ border: '1px solid var(--t-ctrl-border)', color: 'var(--color-state-pending)' }}>
+                Delete
+              </button>
+            )}
             {canEdit && (inToday ? (onRemove && (
               <button onClick={() => { onRemove(); onClose() }}
                 className="mt-body-sm px-3.5 py-2 rounded-lg bg-ctrl"


### PR DESCRIPTION
Resolves the 10 actionable comments from the CodeRabbit review of the pre-main -> main release PR #568. Merge this into pre-main and #568 picks the fixes up automatically (its head is pre-main).

## Findings addressed

**Major**
- readers: gate `pm_tasks.deleted_at` (migration 075) on column presence in `get_tasks` + `build_available` + `plan_join_rows`, so readers degrade gracefully on a pre-075 DB instead of erroring with `no such column: deleted_at`.
- uninstall: `reset_tcc_grants` now returns per-service failures with structured tracing, surfaced in both the human (stderr) and JSON (`report.errors`) paths.
- analytics: the daily-usage cursor is now scoped per signed-in email, so a pending day cannot be misattributed after an account switch (regression tests added).
- backend_install (windows): stop only the staged daemon - match by executable path, kill by PID, require it to exit, and propagate the failure so a locked binary surfaces as an install error instead of silently staging over it.
- ui: Delete is shown for every personal task (no longer gated on historical text-edit permission); Edit stays gated by `editableTask`.

**Minor / Trivial**
- uninstall: gate the macOS TCC / System Settings messaging behind `cfg(macos)` so a non-macOS uninstall never claims a reset was attempted.
- poll: wrap daemon-restart attempts in tracing spans; emit `down_after_s` as a structured field; replace an em-dash in a user-facing notice.
- tests: add soft-delete behavioral coverage (idempotent hide, key allocation preserved, excluded from the available + committed plan readers).

## Validation
Local full pre-push suite all green: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test`, `next build`, `bun test` (348 pass), `cargo audit`.

Base = `pre-main`.