### PR TITLE
fix(tray): quiet the Windows ARM64 'update check failed' toast (missing platform asset)

### DIFF
--- a/tray/src-tauri/src/update.rs
+++ b/tray/src-tauri/src/update.rs
@@ -188,6 +188,40 @@ fn is_packaged() -> bool {
     crate::sys::is_bundled()
 }
 
+/// Marks an `"unsupported"` [`UpdateStatus`] whose `error` field is a reason
+/// code (`"no-platform-asset"`), not an error to alarm the user with — see
+/// [`is_missing_platform_asset`].
+const NO_PLATFORM_ASSET: &str = "no-platform-asset";
+
+/// True for the `tauri-plugin-updater` errors that mean "this platform has no
+/// published update artifact in `latest.json`" rather than a real check
+/// failure. Concretely this is Windows ARM64 today: `scripts/package-updater-windows.sh`
+/// only ever writes the `windows-x86_64` / `windows-x86_64-nsis` keys (the
+/// `.github/workflows/release-build.yml` `windows` job builds on `windows-latest`,
+/// i.e. x86_64, only — there is no ARM64 Windows release job), so an ARM64
+/// install's updater lookup can never match anything the manifest carries.
+///
+/// Surfacing that as `state: "error"` toasts a scary, unactionable "Update
+/// check failed" on *every* check, forever, for every ARM64 Windows install —
+/// there is no retry that fixes it. Bucketing it with `"unsupported"` (the
+/// same state used for an unbundled dev run) makes both the tray toast and the
+/// dashboard banner go quiet instead, same as the DMG updater already does for
+/// npm-installed CLIs.
+///
+/// Deliberately narrow: only `TargetNotFound`/`TargetsNotFound` map here.
+/// Every other error (network, signature, 404 on `latest.json` itself) still
+/// reports `"error"` — CI's `verify-release-bundle.sh` / `compose-updater-manifest.py`
+/// already fail the release loudly if an *expected* platform key (darwin-aarch64,
+/// windows-x86_64, …) goes missing, so a real regression there won't get
+/// silently swallowed by this.
+fn is_missing_platform_asset(e: &tauri_plugin_updater::Error) -> bool {
+    matches!(
+        e,
+        tauri_plugin_updater::Error::TargetNotFound(_)
+            | tauri_plugin_updater::Error::TargetsNotFound(_)
+    )
+}
+
 /// Check the configured endpoint for a newer version. A pure status read — does
 /// NOT download — so it's safe on every popover open / sidebar mount.
 #[tracing::instrument(skip(app))]
@@ -221,6 +255,12 @@ pub async fn check_status(app: &AppHandle) -> UpdateStatus {
         Ok(None) => {
             tracing::info!("update: already up to date");
             UpdateStatus::simple("uptodate", current)
+        }
+        Err(e) if is_missing_platform_asset(&e) => {
+            tracing::info!(error = %e, "update: no published artifact for this platform — reporting unsupported");
+            let mut status = UpdateStatus::simple("unsupported", current);
+            status.error = Some(NO_PLATFORM_ASSET.to_string());
+            status
         }
         Err(e) => {
             tracing::warn!(error = %e, "update: check failed");
@@ -496,13 +536,18 @@ pub fn check_for_updates(app: &AppHandle) {
                 .await;
             }
             "unsupported" => {
-                notify_update(
-                    &app,
-                    "unsupported",
-                    "Updates via npm",
-                    "This build updates with `meridian update`.",
-                )
-                .await;
+                let (title, body) = if status.error.as_deref() == Some(NO_PLATFORM_ASSET) {
+                    (
+                        "Auto-update not available",
+                        "This build doesn't have a published update package yet.",
+                    )
+                } else {
+                    (
+                        "Updates via npm",
+                        "This build updates with `meridian update`.",
+                    )
+                };
+                notify_update(&app, "unsupported", title, body).await;
             }
             _ => {
                 let msg = status
@@ -613,6 +658,36 @@ mod tests {
         let (min, notes) = split_minimum_version("");
         assert_eq!(min, None);
         assert_eq!(notes, None);
+    }
+
+    #[test]
+    fn missing_platform_asset_matches_target_not_found_variants() {
+        // The Windows ARM64 case this exists for: `windows-x86_64`-only
+        // manifests never carry a `windows-aarch64*` key, so the updater
+        // fails with one of these two variants depending on whether it fell
+        // back to a second key before giving up.
+        assert!(is_missing_platform_asset(
+            &tauri_plugin_updater::Error::TargetNotFound("windows-aarch64".to_string())
+        ));
+        assert!(is_missing_platform_asset(
+            &tauri_plugin_updater::Error::TargetsNotFound(vec![
+                "windows-aarch64-nsis".to_string(),
+                "windows-aarch64".to_string(),
+            ])
+        ));
+    }
+
+    #[test]
+    fn other_updater_errors_are_not_treated_as_missing_platform_asset() {
+        // A real failure (unreachable manifest, no endpoints configured) must
+        // still surface as `state: "error"` — only the two lookup-miss
+        // variants above should get swallowed into "unsupported".
+        assert!(!is_missing_platform_asset(
+            &tauri_plugin_updater::Error::EmptyEndpoints
+        ));
+        assert!(!is_missing_platform_asset(
+            &tauri_plugin_updater::Error::ReleaseNotFound
+        ));
     }
 
     /// The comparison `check_status` performs: strictly-below is mandatory,


### PR DESCRIPTION
## Summary
- `install_provider` (src/llm/detect.rs) unconditionally spawned $SHELL-or-/bin/zsh to run vendor installers. On Windows there is no SHELL env var and no /bin/zsh, so the shell itself failed to start with "could not start a shell to install: os error 3" before the installer (even a plain `npm i -g ...`) ever ran, breaking every Install button (Codex, Cursor, etc.) on Windows. `installer_command()` now branches per platform: `cmd /C` on Windows, the existing login-shell behavior everywhere else.
- The tray's "Check for Updates..." toasted a raw `None of the fallback platforms [...] were found in the response platforms object` error on Windows ARM64 builds. `scripts/package-updater-windows.sh` only ever publishes `windows-x86_64` / `windows-x86_64-nsis` keys (the CI `windows` release job builds on `windows-latest`, i.e. x86_64, only - there is no ARM64 Windows release job), so an ARM64 install can never match anything in `latest.json`, forever. `check_status` (tray/src-tauri/src/update.rs) now recognizes that specific `tauri-plugin-updater` error (`TargetNotFound`/`TargetsNotFound`) and reports `state: "unsupported"` (the same bucket as an unbundled dev run) instead of a scary, unfixable `"error"`, with friendlier toast copy.

## Test plan
- [x] `cargo test -p meridian --lib llm::detect` - 14/14 pass, including new `installer_command_actually_runs_on_this_platform`
- [x] `cargo test --lib update::` (tray/src-tauri) - 14/14 pass, including new `missing_platform_asset_matches_target_not_found_variants` and `other_updater_errors_are_not_treated_as_missing_platform_asset`
- [x] Full pre-push suite (fmt, clippy, ui build/tests, cargo test, security audit) green
- [ ] Manual: install a provider (Codex/Cursor) from a Windows ARM64 staging build and confirm it completes instead of erroring
- [ ] Manual: "Check for Updates..." on the same ARM64 build now shows "Auto-update not available" instead of the raw fallback-platforms error