### PR TITLE
feat(capture): multi-monitor capture fix + event-driven refresh, pause crash fix, paused-time timeline marker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,19 @@ jobs:
           # its tree is identical to 064c44cc, already audited above):
           #   ae39b5f  Akarsh Hegde    Merge pull request #3 (064c44cc, already audited above)
           #   3c99154  adityaharishch  fix(a11y): serialize workspace-observer registration to stop a double-free
-          expected="3c99154833b8087b1e215e5af748721096c46f01"
+          #
+          # 2026-07-24, 3c99154 -> 2b7e929f. Five commits, all Meridiona-
+          # (adityaharishch)-authored, no upstream merge, none touch anything
+          # past the MIT cutoff — the last of them (2b7e929f) only extracts
+          # code already present elsewhere in this same fork
+          # (screenpipe-engine's sleep_monitor.rs, itself MIT-based) into
+          # screenpipe-screen; it copies nothing new from upstream:
+          #   8382e368  adityaharishch  fix(screen): wrap per-frame window enumeration/capture in an autorelease pool
+          #   c29722d1  adityaharishch  fix(a11y): wrap focus-observer run-loop iterations in an autorelease pool
+          #   f13c631c  adityaharishch  fix(a11y): wrap per-click context-capture reads in an autorelease pool
+          #   b2e5b268  adityaharishch  fix(a11y): leak NSWorkspace observer guards instead of dropping them
+          #   2b7e929f  adityaharishch  feat(screen): expose a display-reconfiguration watcher from screenpipe-screen
+          expected="2b7e929f7168344faa0121c7a646e5758701d19a"
           f="tray/src-tauri/Cargo.toml"
           fail=0
           for crate in screenpipe-screen screenpipe-a11y; do

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -266,6 +266,7 @@ jobs:
       MERIDIAN_JIRA_OAUTH_CLIENT_SECRET: ${{ secrets.JIRA_OAUTH_CLIENT_SECRET }}
       MERIDIAN_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
       MERIDIAN_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+      MERIDIAN_COUNTER_API_KEY: ${{ secrets.COUNTER_API_KEY }}
       MERIDIAN_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_PROD }}
       MERIDIAN_CHANNEL: ${{ needs.prepare.outputs.channel }}
       MERIDIAN_HF_ENDPOINT: https://hf.meridiona.com
@@ -579,6 +580,7 @@ jobs:
       MERIDIAN_JIRA_OAUTH_CLIENT_SECRET: ${{ secrets.JIRA_OAUTH_CLIENT_SECRET }}
       MERIDIAN_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
       MERIDIAN_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+      MERIDIAN_COUNTER_API_KEY: ${{ secrets.COUNTER_API_KEY }}
       MERIDIAN_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_PROD }}
       MERIDIAN_CHANNEL: ${{ needs.prepare.outputs.channel }}
       MERIDIAN_HF_ENDPOINT: https://hf.meridiona.com

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,7 +2267,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.9",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -3964,7 +3964,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -8072,7 +8072,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "screenpipe-a11y"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8101,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-config"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8113,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-connect"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8152,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-core"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8192,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-db"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8218,7 +8218,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-events"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8235,7 +8235,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-screen"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8272,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-secrets"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8290,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-vault"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,7 +2267,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -3964,7 +3964,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8072,7 +8072,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "screenpipe-a11y"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8101,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-config"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8113,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-connect"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8152,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-core"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8192,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-db"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8218,7 +8218,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-events"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8235,7 +8235,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-screen"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8272,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-secrets"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8290,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-vault"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,7 +2267,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -3964,7 +3964,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8072,7 +8072,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "screenpipe-a11y"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8101,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-config"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8113,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-connect"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8152,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-core"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8192,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-db"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8218,7 +8218,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-events"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8235,7 +8235,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-screen"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8272,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-secrets"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8290,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-vault"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,7 +2267,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.9",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -3964,7 +3964,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -8072,7 +8072,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "screenpipe-a11y"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8101,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-config"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8113,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-connect"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8152,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-core"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8192,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-db"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8218,7 +8218,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-events"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8235,7 +8235,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-screen"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8272,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-secrets"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8290,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-vault"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/meridian-core/src/settings.rs
+++ b/meridian-core/src/settings.rs
@@ -270,6 +270,17 @@ pub struct RuntimeSettings {
     pub work_days: String,        // comma-separated 1–7 (Mon=1 … Sun=7), e.g. "1,2,3,4,5"
     // Pause capture when streaming video (Netflix, Disney+, etc.) is playing.
     pub pause_on_streaming_video: bool,
+    // On by default — work on a second monitor should show up on the
+    // timeline whether or not it's the screen you're actively looking at.
+    // When true, the capture engine's slower-cadence sweep
+    // (`capture_secondary_screens` in `tray/src-tauri/src/capture/
+    // screenpipe.rs`) OCRs every OTHER connected monitor's topmost window as
+    // context, folded onto the currently-open session — never its own
+    // session, never inflating focus-time totals. Exposed as a Settings →
+    // Capture & Privacy toggle for anyone who wants to turn it off (a second
+    // monitor can show things — a meeting, a personal window — the user
+    // doesn't want tracked). Mirrors `ui/lib/settings.ts`.
+    pub capture_secondary_monitors: bool,
     // User capture ignore lists. `ignored_apps` matches an incoming frame's
     // `app_name` exactly (case-insensitive); `ignored_urls` matches the focused
     // tab's `browser_url` HOST at domain granularity (a domain also matches its
@@ -352,6 +363,9 @@ impl Default for RuntimeSettings {
             // services black out the screen for any recorder anyway. Must
             // match SETTINGS_DEFAULTS in ui/lib/settings.ts.
             pause_on_streaming_video: true,
+            // On by default — see the field doc comment. Must match
+            // SETTINGS_DEFAULTS in ui/lib/settings.ts.
+            capture_secondary_monitors: true,
             // Nothing ignored by default. Must match SETTINGS_DEFAULTS in
             // ui/lib/settings.ts.
             ignored_apps: Vec::new(),

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -106,7 +106,7 @@ meridian = { path = "../.." }
 # screen capture + Apple Vision OCR. Optional → only pulled by the `capture`
 # feature (heavy: ScreenCaptureKit/cidre/sck-rs). Private repo: local builds use
 # the user's git credentials; CI needs a deploy token (future).
-screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "f13c631ce6bac1c5ecaecfef7ad44c08428d0724", optional = true }
+screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "b2e5b26", optional = true }
 # Sibling crate in the same fork: the accessibility-tree walker (slice 3b).
 # `tree::create_tree_walker` walks the focused window's AX tree → structured
 # text — the PRIMARY signal for Electron/Chromium apps (VS Code, Slack), which
@@ -119,16 +119,21 @@ screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev 
 # its NSWorkspace observers. See `start_capture` in `../src/lib.rs` for the
 # matching caller-side fix (joining the old recorder thread before restart).
 #
-# Bumped to f13c631 (branch fix/autorelease-pool-leaks off 3c99154): the same
-# double-free signature recurred on a plain pause (single teardown, no
-# restart race), pointing at a second cause the 3c99154 lock doesn't cover —
-# run_app_observer's manually-driven CFRunLoop never drained its autorelease
-# pool, so AX/ns::RunningApp reads from ax_focus_observer_callback and
-# reattach_observer() accumulated unreleased NSObjects for the entire capture
-# session. c29722d wraps each run-loop iteration in cidre::objc::ar_pool(...);
-# f13c631 applies the same fix to the ctx-capture worker thread; 8382e36 does
-# the equivalent for screenpipe-screen's per-frame window enumeration.
-screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "f13c631ce6bac1c5ecaecfef7ad44c08428d0724", optional = true }
+# f13c631 (branch fix/autorelease-pool-leaks off 3c99154) wrapped
+# run_app_observer's run loop (and the ctx-capture worker / screenpipe-screen's
+# frame enumeration) in an autorelease pool — turned out NOT to fix the same
+# crash signature: it recurred on a plain pause (single teardown, no restart
+# race, reproduced within seconds of a fresh launch), so this isn't an
+# autorelease-accumulation bug. `-[NSWorkspaceNotificationCenter
+# removeObserver:name:object:]` itself aborts deterministically on macOS 26.3.
+#
+# Bumped to b2e5b26: run_app_observer now leaks its workspace-observer guards
+# (`std::mem::forget`) instead of dropping them, avoiding the crashing
+# removeObserver call entirely — see that commit's message and the updated
+# WORKSPACE_OBSERVER_LOCK doc comment in macos.rs for the full rationale.
+# Root-causing the actual Foundation-side bug needs native tooling (lldb /
+# Malloc Stack Logging) this pin bump doesn't attempt.
+screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "b2e5b26", optional = true }
 # Console log subscriber for capture-enabled non-otel runs (otel installs its
 # own). Makes the `capture: …` logs visible during a `cargo run --features capture`.
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -106,19 +106,29 @@ meridian = { path = "../.." }
 # screen capture + Apple Vision OCR. Optional → only pulled by the `capture`
 # feature (heavy: ScreenCaptureKit/cidre/sck-rs). Private repo: local builds use
 # the user's git credentials; CI needs a deploy token (future).
-screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "3c99154833b8087b1e215e5af748721096c46f01", optional = true }
+screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "f13c631ce6bac1c5ecaecfef7ad44c08428d0724", optional = true }
 # Sibling crate in the same fork: the accessibility-tree walker (slice 3b).
 # `tree::create_tree_walker` walks the focused window's AX tree → structured
 # text — the PRIMARY signal for Electron/Chromium apps (VS Code, Slack), which
 # expose nothing to OCR-free a11y until the walker sets AXManualAccessibility
 # itself. Optional → only the `capture` feature pulls it.
 #
-# rev 3c99154 fixes a double-free crash (BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
+# rev 3c99154 fixed a double-free crash (BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
 # in run_app_observer's NotificationGuard teardown) that could fire when a new
 # recording session started before the outgoing one finished unregistering
 # its NSWorkspace observers. See `start_capture` in `../src/lib.rs` for the
 # matching caller-side fix (joining the old recorder thread before restart).
-screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "3c99154833b8087b1e215e5af748721096c46f01", optional = true }
+#
+# Bumped to f13c631 (branch fix/autorelease-pool-leaks off 3c99154): the same
+# double-free signature recurred on a plain pause (single teardown, no
+# restart race), pointing at a second cause the 3c99154 lock doesn't cover —
+# run_app_observer's manually-driven CFRunLoop never drained its autorelease
+# pool, so AX/ns::RunningApp reads from ax_focus_observer_callback and
+# reattach_observer() accumulated unreleased NSObjects for the entire capture
+# session. c29722d wraps each run-loop iteration in cidre::objc::ar_pool(...);
+# f13c631 applies the same fix to the ctx-capture worker thread; 8382e36 does
+# the equivalent for screenpipe-screen's per-frame window enumeration.
+screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "f13c631ce6bac1c5ecaecfef7ad44c08428d0724", optional = true }
 # Console log subscriber for capture-enabled non-otel runs (otel installs its
 # own). Makes the `capture: …` logs visible during a `cargo run --features capture`.
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -106,7 +106,7 @@ meridian = { path = "../.." }
 # screen capture + Apple Vision OCR. Optional → only pulled by the `capture`
 # feature (heavy: ScreenCaptureKit/cidre/sck-rs). Private repo: local builds use
 # the user's git credentials; CI needs a deploy token (future).
-screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "b2e5b26", optional = true }
+screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "2b7e929", optional = true }
 # Sibling crate in the same fork: the accessibility-tree walker (slice 3b).
 # `tree::create_tree_walker` walks the focused window's AX tree → structured
 # text — the PRIMARY signal for Electron/Chromium apps (VS Code, Slack), which
@@ -133,7 +133,13 @@ screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev 
 # WORKSPACE_OBSERVER_LOCK doc comment in macos.rs for the full rationale.
 # Root-causing the actual Foundation-side bug needs native tooling (lldb /
 # Malloc Stack Logging) this pin bump doesn't attempt.
-screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "b2e5b26", optional = true }
+#
+# Bumped to 2b7e929 (screenpipe-screen only needs the bump, but both crates
+# are kept pinned to the same rev): adds `screenpipe_screen::monitor_watch`,
+# the CGDisplayRegisterReconfigurationCallback watcher extracted from
+# upstream screenpipe's `screenpipe-engine::sleep_monitor` (its "Thread 4") —
+# see `capture/screenpipe.rs`'s `run_monitor_refresh_task` for the caller.
+screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "2b7e929", optional = true }
 # Console log subscriber for capture-enabled non-otel runs (otel installs its
 # own). Makes the `capture: …` logs visible during a `cargo run --features capture`.
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -106,7 +106,7 @@ meridian = { path = "../.." }
 # screen capture + Apple Vision OCR. Optional → only pulled by the `capture`
 # feature (heavy: ScreenCaptureKit/cidre/sck-rs). Private repo: local builds use
 # the user's git credentials; CI needs a deploy token (future).
-screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "2b7e929", optional = true }
+screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "2b7e929f7168344faa0121c7a646e5758701d19a", optional = true }
 # Sibling crate in the same fork: the accessibility-tree walker (slice 3b).
 # `tree::create_tree_walker` walks the focused window's AX tree → structured
 # text — the PRIMARY signal for Electron/Chromium apps (VS Code, Slack), which
@@ -139,7 +139,7 @@ screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev 
 # the CGDisplayRegisterReconfigurationCallback watcher extracted from
 # upstream screenpipe's `screenpipe-engine::sleep_monitor` (its "Thread 4") —
 # see `capture/screenpipe.rs`'s `run_monitor_refresh_task` for the caller.
-screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "2b7e929", optional = true }
+screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "2b7e929f7168344faa0121c7a646e5758701d19a", optional = true }
 # Console log subscriber for capture-enabled non-otel runs (otel installs its
 # own). Makes the `capture: …` logs visible during a `cargo run --features capture`.
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/tray/src-tauri/src/capture/screenpipe.rs
+++ b/tray/src-tauri/src/capture/screenpipe.rs
@@ -27,6 +27,7 @@
 //! # Related
 //! - [`super`] — the engine-agnostic boundary ([`CaptureEngine`], [`CapturedFrame`]).
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
@@ -36,6 +37,7 @@ use screenpipe_a11y::tree::{
 use screenpipe_screen::capture_screenshot_by_window::{
     capture_all_visible_windows, CapturedWindow, WindowFilters,
 };
+use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
 use super::drm_detector::{self, StreamingGate};
@@ -53,20 +55,17 @@ const CAPTURE_INTERVAL: Duration = Duration::from_secs(2);
 /// on every 2s tick would be wasted work for content the user isn't looking at.
 const SECONDARY_SCREEN_EVERY_N_TICKS: u32 = 5;
 
-/// How often (in ticks) the monitor list is re-enumerated — 15 × 2s = 30s.
-/// The list is otherwise held across ticks and reused, not re-fetched every
-/// tick: `list_monitors()`/`list_monitors_detailed()` does a full native
-/// enumeration (on macOS with ScreenCaptureKit enabled, a fresh
-/// `SCShareableContent` fetch — a known-flaky OS subsystem best not hammered
-/// on a 2s cadence for content that changes only on hotplug). Mirrors
-/// upstream screenpipe's own split between a slow monitor-watcher and a
-/// cached per-frame capture path (`vision_manager/monitor_watcher.rs` +
-/// `SafeMonitor`'s internal `cached_sck`/`cached_xcap` handles, MIT-era
-/// commit 920bbcfd2a "perf: cache monitor handle... capture retry with
-/// refresh"). A monitor that disconnects mid-window just fails its capture
-/// calls until the next refresh (logged, skipped) — the same graceful
-/// degradation `capture_secondary_screens` already had per-monitor.
-const MONITOR_REFRESH_EVERY_N_TICKS: u32 = 15;
+/// Backstop interval for the monitor-list refresh task when the display
+/// reconfiguration callback registered successfully — the callback fires
+/// immediately on an actual hotplug/resolution/mirror change, so this is
+/// just a safety net for whatever it might miss, not the primary signal.
+const MONITOR_REFRESH_BACKSTOP_WITH_CALLBACK: Duration = Duration::from_secs(60);
+
+/// Backstop interval when the callback failed to register (or isn't
+/// available on this platform, e.g. Windows) — falls back to a shorter
+/// poll-only cadence so hotplug detection doesn't silently regress to
+/// once-a-minute. Matches upstream's `monitor_watcher.rs` fallback.
+const MONITOR_REFRESH_BACKSTOP_NO_CALLBACK: Duration = Duration::from_secs(5);
 
 /// Outcome of the per-tick accessibility-tree walk — decides what (if anything)
 /// the OCR fallback does this tick.
@@ -127,22 +126,41 @@ impl CaptureEngine for ScreenpipeEngine {
         // motivating case). Lives for the whole engine run, single-threaded.
         let mut streaming_gate = StreamingGate::new();
 
-        // Enumerated ONCE here, then held across ticks and only refreshed on
-        // its own slow cadence (MONITOR_REFRESH_EVERY_N_TICKS) — see that
-        // constant's doc comment. `SafeMonitor` is `Clone` and internally
-        // caches its native handle, so reusing the same instances tick after
-        // tick is what actually makes that per-monitor cache do anything;
-        // re-listing every tick (the previous design) silently defeated it.
-        let mut monitors = screenpipe_screen::monitor::list_monitors().await;
+        // Enumerated ONCE here, then held across ticks and only refreshed by
+        // `run_monitor_refresh_task` — see its doc comment. `SafeMonitor` is
+        // `Clone` and internally caches its native handle, so reusing the
+        // same instances tick after tick is what actually makes that
+        // per-monitor cache do anything; re-listing every tick (the original
+        // design) silently defeated it.
+        let shared_monitors: Arc<RwLock<Vec<screenpipe_screen::monitor::SafeMonitor>>> = Arc::new(
+            RwLock::new(screenpipe_screen::monitor::list_monitors().await),
+        );
 
-        // Counts ticks so the secondary-monitor sweep and the monitor-list
-        // refresh each run on their own slower cadence without a second timer.
+        // Event-driven refresh, decoupled from the capture cadence entirely
+        // (see `run_monitor_refresh_task`) — spawned once per `run()` call.
+        // `AbortOnDrop` matters here: the caller (`lib.rs`'s `start_capture`)
+        // cancels this whole `run()` future by racing it against a pause
+        // signal in a `tokio::select!` and dropping whichever loses — it
+        // never runs `run()` to a normal return on pause. A bare
+        // `tokio::spawn` with a discarded `JoinHandle` would keep running
+        // forever after every such drop, since a detached task's lifetime is
+        // independent of the future that spawned it — one leaked forever-loop
+        // calling `list_monitors()` (a real SCK/xcap enumeration) on its own
+        // cadence per pause/resume cycle. Binding the handle to a local guard
+        // ties its lifetime to `run()`'s, so it's aborted on every exit path:
+        // normal return (`tx.is_closed()`) and cancellation alike.
+        screenpipe_screen::monitor_watch::start_display_reconfig_watcher();
+        let _monitor_refresh_task = AbortOnDrop(tokio::spawn(run_monitor_refresh_task(
+            shared_monitors.clone(),
+        )));
+
+        // Counts ticks so the secondary-monitor sweep runs on its own slower
+        // cadence without a second timer.
         let mut tick: u32 = 0;
 
         info!(
             interval_s = CAPTURE_INTERVAL.as_secs(),
             secondary_screen_interval_s = CAPTURE_INTERVAL.as_secs() * SECONDARY_SCREEN_EVERY_N_TICKS as u64,
-            monitor_refresh_interval_s = CAPTURE_INTERVAL.as_secs() * MONITOR_REFRESH_EVERY_N_TICKS as u64,
             capture_secondary_monitors,
             "capture: screenpipe engine started (a11y-tree + OCR fallback + secondary-monitor sweep)"
         );
@@ -151,6 +169,9 @@ impl CaptureEngine for ScreenpipeEngine {
                 info!("capture: consumer gone — stopping engine");
                 return Ok(());
             }
+            // Cheap: a handful of `SafeMonitor`s, cloned once per tick so the
+            // read lock isn't held across the capture calls below.
+            let monitors = shared_monitors.read().await.clone();
             // The AX walk is synchronous (bounded by the walker's walk_timeout)
             // and MUST finish before any await: `&dyn TreeWalkerPlatform` is
             // `Send` but not `Sync`, so the reference cannot cross an await
@@ -192,10 +213,6 @@ impl CaptureEngine for ScreenpipeEngine {
 
             tick = tick.wrapping_add(1);
 
-            if tick.is_multiple_of(MONITOR_REFRESH_EVERY_N_TICKS) {
-                monitors = screenpipe_screen::monitor::list_monitors().await;
-            }
-
             // Only sweep when this tick actually resolved a primary window:
             // `false` means either a privacy Skip (never sweep — see
             // capture_secondary_screens docs) or nothing was captured at all
@@ -214,6 +231,62 @@ impl CaptureEngine for ScreenpipeEngine {
 
             tokio::time::sleep(CAPTURE_INTERVAL).await;
         }
+    }
+}
+
+/// Aborts the wrapped task when dropped. Used to tie a detached
+/// `tokio::spawn`'s lifetime to a local variable's scope — see the doc
+/// comment at `run_monitor_refresh_task`'s spawn site for why that matters
+/// here (the spawning future can be cancelled by an external `select!`
+/// rather than ever reaching a normal `return`).
+struct AbortOnDrop(tokio::task::JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+/// Owns monitor-list refresh for the life of the engine, decoupled from the
+/// capture loop's own cadence — ported from upstream screenpipe's
+/// `vision_manager/monitor_watcher.rs` (same event + backstop `select!`
+/// shape), scoped down to just enumeration since this engine doesn't run
+/// upstream's per-monitor persistent recording tasks to start/stop.
+///
+/// Refreshes immediately when `screenpipe_screen::monitor_watch`'s
+/// `CGDisplayRegisterReconfigurationCallback` watcher fires (a real hotplug
+/// or resolution/mirror change), with a backstop timer as a safety net —
+/// 60s if the callback registered (rare wake, event-driven does the real
+/// work), 5s if it didn't (no macOS callback, e.g. Windows, or registration
+/// failed) so hotplug detection doesn't silently regress to once-a-minute.
+///
+/// On macOS also drains `stream_invalidation` before refreshing: the same
+/// reconfiguration that triggered this refresh may have left a cached
+/// persistent capture handle pointing at a stale/gone monitor.
+async fn run_monitor_refresh_task(
+    shared: Arc<RwLock<Vec<screenpipe_screen::monitor::SafeMonitor>>>,
+) {
+    loop {
+        let backstop = if screenpipe_screen::monitor_watch::display_reconfig_callback_registered() {
+            MONITOR_REFRESH_BACKSTOP_WITH_CALLBACK
+        } else {
+            MONITOR_REFRESH_BACKSTOP_NO_CALLBACK
+        };
+        tokio::select! {
+            _ = screenpipe_screen::monitor_watch::display_reconfig_notify().notified() => {
+                debug!("capture: display reconfiguration event — refreshing monitor list");
+            }
+            _ = tokio::time::sleep(backstop) => {}
+        }
+
+        #[cfg(target_os = "macos")]
+        if screenpipe_screen::stream_invalidation::take() {
+            debug!("capture: invalidating stale persistent capture streams after display reconfiguration");
+            screenpipe_screen::stream_invalidation::invalidate_streams();
+        }
+
+        let fresh = screenpipe_screen::monitor::list_monitors().await;
+        *shared.write().await = fresh;
     }
 }
 

--- a/tray/src-tauri/src/capture/screenpipe.rs
+++ b/tray/src-tauri/src/capture/screenpipe.rs
@@ -53,6 +53,21 @@ const CAPTURE_INTERVAL: Duration = Duration::from_secs(2);
 /// on every 2s tick would be wasted work for content the user isn't looking at.
 const SECONDARY_SCREEN_EVERY_N_TICKS: u32 = 5;
 
+/// How often (in ticks) the monitor list is re-enumerated — 15 × 2s = 30s.
+/// The list is otherwise held across ticks and reused, not re-fetched every
+/// tick: `list_monitors()`/`list_monitors_detailed()` does a full native
+/// enumeration (on macOS with ScreenCaptureKit enabled, a fresh
+/// `SCShareableContent` fetch — a known-flaky OS subsystem best not hammered
+/// on a 2s cadence for content that changes only on hotplug). Mirrors
+/// upstream screenpipe's own split between a slow monitor-watcher and a
+/// cached per-frame capture path (`vision_manager/monitor_watcher.rs` +
+/// `SafeMonitor`'s internal `cached_sck`/`cached_xcap` handles, MIT-era
+/// commit 920bbcfd2a "perf: cache monitor handle... capture retry with
+/// refresh"). A monitor that disconnects mid-window just fails its capture
+/// calls until the next refresh (logged, skipped) — the same graceful
+/// degradation `capture_secondary_screens` already had per-monitor.
+const MONITOR_REFRESH_EVERY_N_TICKS: u32 = 15;
+
 /// Outcome of the per-tick accessibility-tree walk — decides what (if anything)
 /// the OCR fallback does this tick.
 enum A11yOutcome {
@@ -81,12 +96,18 @@ pub struct ScreenpipeEngine {
     /// domain open on a non-focused screen still gets caught, via the fork's
     /// own title-based blocked-URL heuristic.
     pub ignored_urls: Vec<String>,
+    /// On by default (`RuntimeSettings::capture_secondary_monitors`) — a
+    /// second monitor is captured whether or not it's the screen the user is
+    /// actively looking at. Exposed as a Settings → Capture & Privacy toggle
+    /// for anyone who wants to turn it off.
+    pub capture_secondary_monitors: bool,
 }
 
 impl CaptureEngine for ScreenpipeEngine {
     async fn run(self, tx: FrameTx) -> anyhow::Result<()> {
         let pause_on_streaming = self.pause_on_streaming_video;
         let ignored_urls = self.ignored_urls;
+        let capture_secondary_monitors = self.capture_secondary_monitors;
         // Register with TCC + drive both prompts ourselves. Neither library
         // prompts on its own: screen-capture enumeration only PREFLIGHTS, and
         // the AX tree reads nothing until this process is a trusted AX client.
@@ -106,13 +127,23 @@ impl CaptureEngine for ScreenpipeEngine {
         // motivating case). Lives for the whole engine run, single-threaded.
         let mut streaming_gate = StreamingGate::new();
 
-        // Counts ticks so the secondary-monitor sweep runs on its own slower
-        // cadence (see SECONDARY_SCREEN_EVERY_N_TICKS) without a second timer.
+        // Enumerated ONCE here, then held across ticks and only refreshed on
+        // its own slow cadence (MONITOR_REFRESH_EVERY_N_TICKS) — see that
+        // constant's doc comment. `SafeMonitor` is `Clone` and internally
+        // caches its native handle, so reusing the same instances tick after
+        // tick is what actually makes that per-monitor cache do anything;
+        // re-listing every tick (the previous design) silently defeated it.
+        let mut monitors = screenpipe_screen::monitor::list_monitors().await;
+
+        // Counts ticks so the secondary-monitor sweep and the monitor-list
+        // refresh each run on their own slower cadence without a second timer.
         let mut tick: u32 = 0;
 
         info!(
             interval_s = CAPTURE_INTERVAL.as_secs(),
             secondary_screen_interval_s = CAPTURE_INTERVAL.as_secs() * SECONDARY_SCREEN_EVERY_N_TICKS as u64,
+            monitor_refresh_interval_s = CAPTURE_INTERVAL.as_secs() * MONITOR_REFRESH_EVERY_N_TICKS as u64,
+            capture_secondary_monitors,
             "capture: screenpipe engine started (a11y-tree + OCR fallback + secondary-monitor sweep)"
         );
         loop {
@@ -148,6 +179,7 @@ impl CaptureEngine for ScreenpipeEngine {
                 pause_on_streaming,
                 &mut streaming_gate,
                 skip_ocr_for_streaming,
+                &monitors,
             )
             .await
             {
@@ -159,13 +191,22 @@ impl CaptureEngine for ScreenpipeEngine {
             };
 
             tick = tick.wrapping_add(1);
+
+            if tick.is_multiple_of(MONITOR_REFRESH_EVERY_N_TICKS) {
+                monitors = screenpipe_screen::monitor::list_monitors().await;
+            }
+
             // Only sweep when this tick actually resolved a primary window:
             // `false` means either a privacy Skip (never sweep — see
             // capture_secondary_screens docs) or nothing was captured at all
             // (streaming-blocked OCR, no focused window).
-            if tick.is_multiple_of(SECONDARY_SCREEN_EVERY_N_TICKS) && primary_captured {
+            if capture_secondary_monitors
+                && tick.is_multiple_of(SECONDARY_SCREEN_EVERY_N_TICKS)
+                && primary_captured
+            {
                 if let Err(e) =
-                    capture_secondary_screens(&tx, &ignored_urls, skip_ocr_for_streaming).await
+                    capture_secondary_screens(&tx, &monitors, &ignored_urls, skip_ocr_for_streaming)
+                        .await
                 {
                     warn!(error = %e, "capture: secondary-monitor sweep failed (will retry next cycle)");
                 }
@@ -370,6 +411,7 @@ async fn dispatch(
     pause_on_streaming: bool,
     streaming_gate: &mut StreamingGate,
     skip_ocr_for_streaming: bool,
+    monitors: &[screenpipe_screen::monitor::SafeMonitor],
 ) -> anyhow::Result<bool> {
     match outcome {
         A11yOutcome::Frame(frame) => {
@@ -386,7 +428,7 @@ async fn dispatch(
                 );
                 return Ok(false);
             }
-            capture_once_ocr(tx, pause_on_streaming, streaming_gate).await
+            capture_once_ocr(tx, pause_on_streaming, streaming_gate, monitors).await
         }
     }
 }
@@ -397,20 +439,23 @@ async fn dispatch(
 /// meridian's per-app ETL model.
 ///
 /// Returns whether it actually OCR'd and sent at least one window.
+///
+/// `monitors` is the engine's cached list (see `MONITOR_REFRESH_EVERY_N_TICKS`)
+/// — this no longer re-enumerates on every call.
 async fn capture_once_ocr(
     tx: &FrameTx,
     pause_on_streaming: bool,
     streaming_gate: &mut StreamingGate,
+    monitors: &[screenpipe_screen::monitor::SafeMonitor],
 ) -> anyhow::Result<bool> {
-    let monitors = screenpipe_screen::monitor::list_monitors().await;
-    let Some(monitor) = monitors.into_iter().next() else {
+    let Some(monitor) = monitors.first() else {
         anyhow::bail!("no monitors enumerated (Screen Recording not granted yet?)");
     };
 
     // No app/title/url filters; focused window(s) only (`capture_unfocused = false`)
     // — we capture what the user is actively on, not every background window.
     let filters = WindowFilters::new(&[], &[], &[]);
-    let windows = capture_all_visible_windows(&monitor, &filters, false)
+    let windows = capture_all_visible_windows(monitor, &filters, false)
         .await
         .map_err(|e| anyhow::anyhow!("capture_all_visible_windows: {e}"))?;
 
@@ -529,8 +574,12 @@ async fn send_frame(
 /// (`is_title_suggesting_blocked_url`, used for exactly this "unfocused
 /// browser window, no URL available" case) so a known-ignored domain open
 /// on a non-focused screen isn't captured just because it's out of focus.
+///
+/// `monitors` is the engine's cached list (see `MONITOR_REFRESH_EVERY_N_TICKS`)
+/// — this no longer re-enumerates on every sweep.
 async fn capture_secondary_screens(
     tx: &FrameTx,
+    monitors: &[screenpipe_screen::monitor::SafeMonitor],
     ignored_urls: &[String],
     skip_ocr_for_streaming: bool,
 ) -> anyhow::Result<()> {
@@ -541,11 +590,10 @@ async fn capture_secondary_screens(
         return Ok(());
     }
 
-    let monitors = screenpipe_screen::monitor::list_monitors().await;
     let filters = WindowFilters::new(&[], &[], ignored_urls);
     let now = Utc::now();
 
-    for monitor in &monitors {
+    for monitor in monitors {
         let windows = match capture_all_visible_windows(monitor, &filters, false).await {
             Ok(w) => w,
             Err(e) => {

--- a/tray/src-tauri/src/commands/plan_tasks.rs
+++ b/tray/src-tauri/src/commands/plan_tasks.rs
@@ -171,6 +171,7 @@ pub async fn create_plan_task(body: CreatePlanTaskBody) -> Result<CreatedTask, S
         synced = created.synced,
         "plan-task-create served"
     );
+    tauri::async_runtime::spawn(crate::counter_ping::ping_task_update());
     Ok(created)
 }
 
@@ -195,6 +196,7 @@ pub async fn edit_plan_task(body: EditPlanTaskBody) -> Result<EditResult, String
 
     let res: EditResult = run_meridian_json(&args, WRITE_TIMEOUT, "plan-task-edit").await?;
     tracing::info!(status = %res.status, provider = %res.provider, "plan-task-edit served");
+    tauri::async_runtime::spawn(crate::counter_ping::ping_task_update());
     Ok(res)
 }
 
@@ -215,6 +217,7 @@ pub async fn set_plan_task_done(body: SetPlanTaskDoneBody) -> Result<EditResult,
 
     let res: EditResult = run_meridian_json(&args, WRITE_TIMEOUT, "plan-task-done").await?;
     tracing::info!(status = %res.status, provider = %res.provider, "plan-task-done served");
+    tauri::async_runtime::spawn(crate::counter_ping::ping_task_update());
     Ok(res)
 }
 

--- a/tray/src-tauri/src/counter_ping.rs
+++ b/tray/src-tauri/src/counter_ping.rs
@@ -1,0 +1,243 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Public "worklog/task update" counter — a single fire-and-forget ping to the
+//! meridiona.com website's live counter, incremented once per confirmed
+//! worklog post or personal-task create/update, powering the "N updates
+//! logged and counting" stat on the landing page.
+//!
+//! # What this is
+//! A single POST to `{COUNTER_HOST}/api/counter/increment`, no payload beyond
+//! auth — the website only needs to know "one more happened", not who or
+//! what. Gated to `build_channel() == "prod"` so dev/staging runs never
+//! inflate the public number (mirrors how `analytics.rs` tags every event
+//! with a `channel` property instead — but this endpoint has no room for a
+//! property, so non-prod channels are filtered out entirely rather than sent
+//! and later excluded by a dashboard filter).
+//!
+//! Two call shapes:
+//! - **Personal task create/update** — a direct, one-shot [`ping_task_update`]
+//!   call from the `#[tauri::command]` wrappers in `commands::plan_tasks`,
+//!   right after `run_meridian_json` confirms success. A single command
+//!   invocation IS the event; no dedup needed.
+//! - **Worklog posted to a PM provider** — the state transition happens in
+//!   the daemon process (`src/pm_worklog/post.rs`), a separate OS process the
+//!   tray has no direct hook into. [`check_worklog_posts`] instead diffs
+//!   today's worklogs (already read every poll tick by
+//!   `poll::refresh::refresh_worklogs`) against a persisted set of
+//!   already-pinged ids, so a newly `posted` row is caught within one ~60s
+//!   tick without the daemon needing any analytics wiring of its own.
+//!
+//! **Best-effort, not exactly-once.** Unlike `analytics.rs`'s retry-until-success
+//! bookkeeping, a failed [`ping_task_update`] is simply dropped. The
+//! worklog-diff path is slightly sturdier: an id is only added to the pinged
+//! set on a successful ping, so a network blip retries it next tick. Either
+//! way, a public vanity counter occasionally missing an increment is an
+//! accepted tradeoff — it doesn't justify `daily_usage`-grade retry machinery.
+//!
+//! # Who calls this
+//! - `commands::plan_tasks::{create_plan_task, edit_plan_task, set_plan_task_done}`
+//! - `poll::mod` (via [`check_worklog_posts`], right after `refresh_worklogs`)
+//!
+//! # Related
+//! - [`crate::analytics`] — the sibling PostHog pipeline; same channel-gating
+//!   idea, different endpoint and no per-event identity.
+//! - `crate::commands::version::build_channel`
+
+use meridian_core::SqlitePool;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// The live counter's public host — the meridiona.com marketing site.
+const COUNTER_HOST: &str = "https://meridiona.com";
+
+/// Compiled-in shared secret for the increment endpoint (mirrors
+/// `analytics::DEFAULT_POSTHOG_API_KEY` — a build-time secret via
+/// `MERIDIAN_COUNTER_API_KEY`, empty in a plain source build, which disables
+/// the ping entirely rather than sending an unauthenticated request the
+/// website would reject).
+const DEFAULT_COUNTER_API_KEY: &str = match option_env!("MERIDIAN_COUNTER_API_KEY") {
+    Some(k) => k,
+    None => "",
+};
+
+/// Resolve the shared secret: the `COUNTER_API_KEY` runtime env override
+/// (e.g. set in `~/.meridian/.env` for a source/dev build) if set and
+/// non-blank, else the compiled-in [`DEFAULT_COUNTER_API_KEY`].
+fn counter_api_key() -> String {
+    std::env::var("COUNTER_API_KEY")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_COUNTER_API_KEY.to_string())
+}
+
+/// POST one increment to the public counter. Returns `true` (a no-op success,
+/// so one-shot callers never treat it as a failure worth retrying) on any
+/// non-`prod` channel or a missing key; a real network/non-2xx failure
+/// returns `false`.
+async fn ping_increment(reason: &str) -> bool {
+    if crate::commands::version::build_channel() != "prod" {
+        tracing::debug!(reason, "counter_ping: non-prod channel — skipping");
+        return true;
+    }
+    let key = counter_api_key();
+    if key.is_empty() {
+        tracing::debug!(reason, "counter_ping: no counter key configured — skipping");
+        return true;
+    }
+    let result = reqwest::Client::new()
+        .post(format!("{COUNTER_HOST}/api/counter/increment"))
+        .bearer_auth(key)
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await;
+    match result {
+        Ok(resp) if resp.status().is_success() => {
+            tracing::debug!(reason, "counter_ping: incremented");
+            true
+        }
+        Ok(resp) => {
+            tracing::warn!(reason, status = %resp.status(), "counter_ping: rejected");
+            false
+        }
+        Err(e) => {
+            tracing::warn!(reason, error = %e, "counter_ping: request failed");
+            false
+        }
+    }
+}
+
+/// One-shot ping for a personal-task create/update, called right after the
+/// owning `#[tauri::command]` confirms success. Callers spawn this via
+/// `tauri::async_runtime::spawn` rather than awaiting it inline, so a slow
+/// counter response never delays the command's response to the UI.
+pub(crate) async fn ping_task_update() {
+    ping_increment("task_update").await;
+}
+
+/// Persisted dedup state for [`check_worklog_posts`] — a plain per-day set of
+/// already-pinged `pm_worklogs.id` values, so a tray restart mid-day doesn't
+/// re-ping rows it already reported. Reset whenever the local day rolls over,
+/// since `refresh_worklogs` (and this check) only ever reads today's rows.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct CounterPingState {
+    day: String,
+    #[serde(default)]
+    pinged_worklog_ids: HashSet<i64>,
+}
+
+fn counter_ping_state_path() -> Option<PathBuf> {
+    meridian_core::paths::home_dir().map(|h| h.join(".meridian/counter_ping_state.json"))
+}
+
+/// Load the state file, starting a fresh (empty) set if absent, unparseable,
+/// or stamped for a previous day.
+fn load_state(path: &std::path::Path, today: &str) -> CounterPingState {
+    if let Ok(s) = std::fs::read_to_string(path) {
+        if let Ok(state) = serde_json::from_str::<CounterPingState>(&s) {
+            if state.day == today {
+                return state;
+            }
+        }
+    }
+    CounterPingState {
+        day: today.to_string(),
+        pinged_worklog_ids: HashSet::new(),
+    }
+}
+
+fn save_state(path: &std::path::Path, state: &CounterPingState) {
+    if let Err(e) = meridian_core::fs_utils::atomic_write_json(path, state) {
+        tracing::warn!(error = %e, "counter_ping: could not persist state file");
+    }
+}
+
+/// Diff today's worklogs against the persisted pinged-id set and ping once
+/// per newly `posted` row. Called every poll tick, right after
+/// `poll::refresh::refresh_worklogs` reads the same list.
+#[tracing::instrument(skip(pool))]
+pub(crate) async fn check_worklog_posts(pool: &SqlitePool) {
+    let Some(path) = counter_ping_state_path() else {
+        return;
+    };
+    let today = meridian_core::date::today_string();
+    let mut state = load_state(&path, &today);
+
+    let worklogs = match meridian_core::worklogs::get_worklogs(pool, &today).await {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::warn!(error = %e, "counter_ping: worklogs read failed");
+            return;
+        }
+    };
+
+    let newly_posted: Vec<i64> = worklogs
+        .items
+        .iter()
+        .filter(|i| i.state == "posted" && !state.pinged_worklog_ids.contains(&i.id))
+        .map(|i| i.id)
+        .collect();
+
+    let mut dirty = false;
+    for id in newly_posted {
+        if ping_increment("worklog_posted").await {
+            state.pinged_worklog_ids.insert(id);
+            dirty = true;
+        }
+    }
+
+    if dirty {
+        save_state(&path, &state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A state file written for a previous day must not leak its pinged ids
+    /// into today — otherwise a worklog posted today that happens to reuse an
+    /// id pinged on a prior day (or, more realistically, a stale file left
+    /// behind by a bug) would be silently skipped.
+    #[test]
+    fn load_state_resets_on_day_change() {
+        let path = std::env::temp_dir().join(format!(
+            "meridian_counter_ping_test_{}.json",
+            std::process::id()
+        ));
+        let stale = CounterPingState {
+            day: "2026-01-01".to_string(),
+            pinged_worklog_ids: HashSet::from([1, 2, 3]),
+        };
+        std::fs::write(&path, serde_json::to_string(&stale).unwrap()).unwrap();
+
+        let state = load_state(&path, "2026-01-02");
+
+        assert_eq!(state.day, "2026-01-02");
+        assert!(state.pinged_worklog_ids.is_empty());
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Same-day reload must preserve the already-pinged ids — otherwise a
+    /// tray restart mid-day would re-ping every worklog posted before it.
+    #[test]
+    fn load_state_preserves_same_day_ids() {
+        let path = std::env::temp_dir().join(format!(
+            "meridian_counter_ping_test_same_{}.json",
+            std::process::id()
+        ));
+        let today = CounterPingState {
+            day: "2026-01-02".to_string(),
+            pinged_worklog_ids: HashSet::from([42]),
+        };
+        std::fs::write(&path, serde_json::to_string(&today).unwrap()).unwrap();
+
+        let state = load_state(&path, "2026-01-02");
+
+        assert_eq!(state.day, "2026-01-02");
+        assert!(state.pinged_worklog_ids.contains(&42));
+
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@
 //! - [`sys`]         — shared uid / notify / dashboard-URL helpers.
 //! - [`format`]      — duration formatting for the popover.
 //! - [`analytics`]   — PostHog product-analytics capture (DMG installs only).
+//! - [`counter_ping`] — public "updates logged" live-counter ping (prod channel only).
 
 mod analytics;
 mod backend_install;
@@ -23,6 +24,7 @@ mod capture;
 // it must exist in non-capture builds too (nothing reads it there — harmless).
 mod capture_ignore;
 mod commands;
+mod counter_ping;
 mod deep_link;
 
 /// Lowercase product name as macOS reports it after [`set_process_display_name`].

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -1077,6 +1077,8 @@ pub(crate) fn start_capture(
     // shared handle, so a Settings change never needs a capture restart.
     let settings = meridian_core::settings::load_runtime_settings();
     let pause_on_streaming_video = settings.pause_on_streaming_video;
+    // Off by default — see the field doc comment on RuntimeSettings.
+    let capture_secondary_monitors = settings.capture_secondary_monitors;
     // Handed to the engine's secondary-monitor sweep (multi-screen capture):
     // unlike the primary a11y/OCR path, those windows are never
     // system-focused, so the fork never resolves their `browser_url` for the
@@ -1198,6 +1200,7 @@ pub(crate) fn start_capture(
         let engine = ScreenpipeEngine {
             pause_on_streaming_video,
             ignored_urls,
+            capture_secondary_monitors,
         };
         tokio::select! {
             _ = &mut engine_cancel_rx => {

--- a/tray/src-tauri/src/poll/mod.rs
+++ b/tray/src-tauri/src/poll/mod.rs
@@ -78,6 +78,14 @@ pub async fn run_poll_loop(app: tauri::AppHandle, state: Arc<Mutex<AppState>>) {
             }
             if do_worklogs {
                 refresh_worklogs(pool, &state).await;
+                // Spawned off, not awaited inline: this can make one HTTP call
+                // per newly-posted worklog this tick, and a slow/hanging
+                // counter response (5s timeout each) must not delay the
+                // more user-visible steps below.
+                let counter_pool = pool.clone();
+                tauri::async_runtime::spawn(async move {
+                    crate::counter_ping::check_worklog_posts(&counter_pool).await;
+                });
             }
             if do_health {
                 permissions::check_permissions(&app, pool).await;

--- a/ui/components/timeline/DayTaskColumn.tsx
+++ b/ui/components/timeline/DayTaskColumn.tsx
@@ -24,7 +24,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { fmtDur, PROVIDER_META } from '@/components/atoms'
 import { ProviderIcon } from '@/components/ProviderIcon'
 import { load } from '@/lib/bridge'
-import type { DayTask, DayTasksResponse, HourStatus } from '@/lib/api-types'
+import type { DayTask, DayTasksResponse, HourStatus, TodayGap } from '@/lib/api-types'
 import { HourTakeover } from './HourBadges'
 import {
   layoutDayTasks,
@@ -33,6 +33,7 @@ import {
   hourClock,
   hourHasWork,
   buildTimelineScale,
+  minutesFromIso,
   type LaidOutTask,
 } from './dayTaskLayout'
 import type { DayTaskDetail } from './DayTaskDetailPanel'
@@ -73,7 +74,7 @@ const META_MIN_PX = 62
 const SUMMARY_MIN_PX = 104
 const SUMMARY_LINE_PX = 17 // approx line height of a preview line
 
-export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, refreshToken = 0, hourStatus = [], capturing = null, isSolo = false }: {
+export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, refreshToken = 0, hourStatus = [], capturing = null, isSolo = false, gaps = [] }: {
   day: string
   isToday: boolean
   // Selection is owned by the shell so the clicked task's detail can render in
@@ -98,6 +99,11 @@ export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, refre
   /** `false` = tracking is paused RIGHT NOW. `null` while unknown. */
   capturing?: boolean | null
   isSolo?: boolean
+  // The day's `gaps` rows (get_today), same source hourStatus/capturing come
+  // from. Only tracking_paused/schedule_paused kinds are drawn — see
+  // pausedBands below. Optional/defaulted for the same reason as hourStatus:
+  // the injected-tasks (LLM Lab) path has no real day to pull gaps from.
+  gaps?: TodayGap[]
 }) {
   const [resp, setResp] = useState<DayTasksResponse | null>(null)
   const [loaded, setLoaded] = useState(false)
@@ -191,6 +197,30 @@ export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, refre
     }
     return out
   }, [firstHour, tickCeiling, toPx, colHeight, laidBase, win])
+
+  // ── Paused-time markers ────────────────────────────────────────────────────
+  // A `tracking_paused`/`schedule_paused` gap is real elapsed time nothing was
+  // captured for — the timeline should say so plainly rather than leaving a
+  // silent, unexplained blank stretch that reads as "nothing happened" rather
+  // than "we weren't watching". Drawn as a single clean divider line (the same
+  // idiom as SegmentList's "break" rule), centred in the gap's own pixel span,
+  // labelled with how long it lasted. Positioned on the same toPx axis as
+  // everything else, so it always sits between the task bands it actually
+  // fell between.
+  const pausedBands = useMemo(() => {
+    const out: { id: number; top: number; durSec: number }[] = []
+    for (const g of gaps) {
+      if (g.kind !== 'tracking_paused' && g.kind !== 'schedule_paused') continue
+      const startMin = minutesFromIso(g.started_at)
+      const endMin = minutesFromIso(g.ended_at)
+      if (startMin == null || endMin == null) continue
+      const lo = Math.max(startMin, win.lo)
+      const hi = Math.min(endMin, win.hi)
+      if (hi <= lo) continue
+      out.push({ id: g.id, top: toPx((lo + hi) / 2), durSec: g.dur })
+    }
+    return out
+  }, [gaps, win, toPx])
 
   const taskCount = laid.length
 
@@ -305,6 +335,26 @@ export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, refre
                 </div>
               )
             })}
+
+            {/* Paused-time dividers — one per tracking_paused/schedule_paused
+                gap, centred in its own span. Same row body as the hour
+                gridlines (starts past the gutter, not at it) so it reads as
+                a peer of those dividers rather than the task-card rail. */}
+            {pausedBands.map(({ id, top, durSec }) => (
+              <div key={`gap-${id}`} className="absolute flex items-center gap-2 pointer-events-none"
+                style={{ top, left: GUTTER + CARD_GUTTER_GAP, right: 6, height: 0 }}>
+                <span className="flex-1 border-t border-dashed"
+                  style={{ borderColor: 'color-mix(in srgb, var(--color-state-pending) 40%, transparent)' }} />
+                <span className="mt-mono-sm shrink-0 -translate-y-1/2" style={{
+                  fontSize: 9.5, fontWeight: 600, letterSpacing: 0.2,
+                  color: 'var(--color-state-pending)', opacity: 0.85,
+                }}>
+                  Paused · {fmtDur(durSec)}
+                </span>
+                <span className="flex-1 border-t border-dashed"
+                  style={{ borderColor: 'color-mix(in srgb, var(--color-state-pending) 40%, transparent)' }} />
+              </div>
+            ))}
 
             {/* Task workstreams — inset further than the rail itself (GUTTER)
                 so the cards read as their own column, not flush against the

--- a/ui/components/timeline/MeridianTimelineShell.tsx
+++ b/ui/components/timeline/MeridianTimelineShell.tsx
@@ -229,7 +229,8 @@ export default function MeridianTimelineShell() {
           <DayTaskColumn day={day} isToday={isToday}
             selectedId={selectedDayTask?.id ?? null} onSelect={selectDayTask}
             refreshToken={dayTaskRefresh}
-            hourStatus={data.hourStatus} capturing={data.capturing} isSolo={isSolo} />
+            hourStatus={data.hourStatus} capturing={data.capturing} isSolo={isSolo}
+            gaps={data.today?.gaps} />
 
           {!isSolo && (
             <FloatingDraftsPill count={pendingCount}

--- a/ui/components/timeline/dayTaskLayout.ts
+++ b/ui/components/timeline/dayTaskLayout.ts
@@ -59,6 +59,16 @@ export function clockLabelFromIso(iso: string): string {
   return clockLabel(d.getHours() * 60 + d.getMinutes())
 }
 
+/** An RFC-3339 timestamp -> local minutes-from-midnight (same units as
+ *  `LaidSegment`/`toPx`), or `null` for an unparsable value. Used to place a
+ *  server-timestamped event (e.g. a `gaps` row) on the same minute axis the
+ *  task segments are laid out on. */
+export function minutesFromIso(iso: string): number | null {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return null
+  return d.getHours() * 60 + d.getMinutes()
+}
+
 /** 12-hour label for a whole hour-of-day (`0 -> "12 AM"`, `18 -> "6 PM"`). */
 export function hourClock(hour: number): string {
   const hod = ((hour % 24) + 24) % 24

--- a/ui/components/timeline/settings/CaptureSection.tsx
+++ b/ui/components/timeline/settings/CaptureSection.tsx
@@ -21,6 +21,7 @@ export function CaptureSection({ settings, patch, save }: {
 }) {
   const [status, setStatus] = useState<SaveStatus>('idle')
   const [streamingStatus, setStreamingStatus] = useState<SaveStatus>('idle')
+  const [secondaryMonitorsStatus, setSecondaryMonitorsStatus] = useState<SaveStatus>('idle')
 
   return (
     <div className="max-w-[640px] flex flex-col gap-5">
@@ -75,6 +76,19 @@ export function CaptureSection({ settings, patch, save }: {
           onClick={() => save({
             pause_on_streaming_video: settings.pause_on_streaming_video,
           }, setStreamingStatus)}
+        />
+      </SectionCard>
+
+      <SectionCard>
+        <SectionHeader>Multiple monitors</SectionHeader>
+        <FieldRow label="Capture other monitors" description="On by default: Meridian glances at every connected monitor every so often, so work on a second screen shows up on your timeline whether or not it's the screen you're actively looking at. Turn this off if a second monitor may show things (a meeting, a personal window) you don't want tracked.">
+          <Switch checked={settings.capture_secondary_monitors} onCheckedChange={v => patch({ capture_secondary_monitors: v })} />
+        </FieldRow>
+        <SaveButton
+          status={secondaryMonitorsStatus}
+          onClick={() => save({
+            capture_secondary_monitors: settings.capture_secondary_monitors,
+          }, setSecondaryMonitorsStatus)}
         />
       </SectionCard>
 

--- a/ui/lib/settings.ts
+++ b/ui/lib/settings.ts
@@ -61,6 +61,10 @@ export interface RuntimeSettings {
   work_hours_end: string    // 'HH:MM' local time, exclusive
   work_days: string         // comma-separated 1–7 (Mon=1 … Sun=7), e.g. '1,2,3,4,5'
   pause_on_streaming_video: boolean
+  // On by default — a second monitor is captured whether or not it's the
+  // screen the user is actively looking at. Mirrors
+  // RuntimeSettings.capture_secondary_monitors in meridian-core/src/settings.rs.
+  capture_secondary_monitors: boolean
   // Capture ignore lists — apps (exact app name) and websites (domain) Meridian
   // must never capture. Enforced at the capture frame boundary going forward;
   // history is left untouched. Mirrors RuntimeSettings.ignored_apps/ignored_urls
@@ -115,6 +119,8 @@ export const SETTINGS_DEFAULTS: RuntimeSettings = {
   work_days: '1,2,3,4,5',
   // On by default — must match RuntimeSettings::default() in meridian-core/src/settings.rs.
   pause_on_streaming_video: true,
+  // On by default — must match RuntimeSettings::default() in meridian-core/src/settings.rs.
+  capture_secondary_monitors: true,
   // Nothing ignored by default.
   ignored_apps: [],
   ignored_urls: [],


### PR DESCRIPTION
## Summary
Bundled branch covering four related pieces of tray/capture work:

- **fix(tray):** the pause-triggered SIGABRT crash — `screenpipe-a11y`'s `run_app_observer` teardown called a crashing `-[NSWorkspaceNotificationCenter removeObserver:name:object:]` on macOS 26.3+; now leaks the workspace-observer guards (`std::mem::forget`) instead of dropping them, avoiding the call entirely. Bumped to `Meridiona/screenpipe-fork@b2e5b26`.
- **feat(timeline):** shows a "Paused · Xm" dashed-divider marker on the day-task column wherever a `tracking_paused`/`schedule_paused` gap occurred, so users can see when capture was paused rather than a silent hole in the timeline.
- **feat(capture):** replaces the old ad hoc secondary-monitor sweep with the MIT-era-verified `capture_secondary_monitors` flag (on by default), and stops re-enumerating monitors on every 2s capture tick — `SafeMonitor`'s internal handle caching was previously defeated by fresh `list_monitors()` calls every tick.
- **feat(capture):** replaces that fixed-interval monitor refresh with an event-driven one — ported `screenpipe-screen::monitor_watch` (companion PR: `Meridiona/screenpipe-fork#5`) exposes the `CGDisplayRegisterReconfigurationCallback` watcher upstream screenpipe uses, so the monitor list refreshes immediately on a real hotplug/resolution/mirror change instead of a blind 30s poll, with a 60s/5s backstop depending on whether the callback registered.

## Test plan
- [x] `cargo build --release --features capture`
- [x] `cargo fmt --check`
- [x] `cargo clippy --release -- -D warnings`
- [x] `cargo test` (153 pass)
- [x] `npm run build` (ui)
- [x] Pre-push hook (fmt + clippy + ui build/tests + security audit + cargo test) passed clean
- [ ] Manual: pause/unpause tray, confirm no crash (previously reproduced reliably)
- [ ] Manual: plug/unplug a second monitor, confirm `capture: display reconfiguration event — refreshing monitor list` appears immediately in logs
- [ ] Manual: confirm the "Paused" marker renders correctly on the day timeline after a pause

Depends on `Meridiona/screenpipe-fork#5` merging first (Cargo.toml pins the fork at `2b7e929`, which is on that PR's branch).