### PR TITLE
fix(etl): paginate session-text rebuild in extract_block_context

### DIFF
--- a/src/etl/block_ops.rs
+++ b/src/etl/block_ops.rs
@@ -7,12 +7,9 @@ use tracing::{debug, info, warn};
 use crate::db::meridian::{
     close_active_session_with, get_active_session, upsert_active_session, write_session_traceparent,
 };
-use crate::db::screenpipe::{
-    fetch_frame_text_page, get_last_ui_event_for_app, FRAME_TEXT_PAGE_SIZE,
-};
+use crate::db::screenpipe::get_last_ui_event_for_app;
 use crate::etl::extractor::extract_block_context;
-use crate::etl::text_filter::ChromeFreqAccumulator;
-use crate::etl::text_merge::SessionTextBuilder;
+use crate::etl::text_merge::rebuild_session_text_paginated;
 
 use super::session_builder::{build_active_session, merge_into_active};
 
@@ -22,58 +19,6 @@ pub(super) fn timestamp_gap_secs(earlier: &str, later: &str) -> Option<i64> {
     let t0 = chrono::DateTime::parse_from_rfc3339(earlier).ok()?;
     let t1 = chrono::DateTime::parse_from_rfc3339(later).ok()?;
     Some((t1 - t0).num_seconds())
-}
-
-/// Rebuilds `session_text` for the frame range `min_frame_id..=max_frame_id` by
-/// reading frames from the DB in `FRAME_TEXT_PAGE_SIZE`-sized pages instead of
-/// materializing the whole range in one `Vec<FrameText>`.
-///
-/// Two passes over the paginated read are required: chrome-line detection
-/// (`ChromeFreqAccumulator`) needs a global view of line frequencies across the
-/// *entire* range before any single frame can be classified (see
-/// `crate::etl::text_filter::build_chrome_set`), so pass 1 accumulates
-/// frequencies page-by-page and pass 2 re-pages the same range to fold each
-/// frame into the session text using the now-final chrome set.
-///
-/// This is a memory-shape change only: for the same frame range, the returned
-/// string is functionally identical to
-/// `build_session_text(&get_frame_full_texts(pool, min_frame_id, max_frame_id).await?)` —
-/// no data is truncated or dropped, only held in bounded pages rather than all
-/// at once.
-pub(super) async fn rebuild_session_text_paginated(
-    pool: &SqlitePool,
-    min_frame_id: i64,
-    max_frame_id: i64,
-) -> Result<String> {
-    // Pass 1: accumulate chrome-line frequencies across every page.
-    let mut chrome_acc = ChromeFreqAccumulator::new();
-    let mut after_id = min_frame_id - 1;
-    loop {
-        let page = fetch_frame_text_page(pool, after_id, max_frame_id, FRAME_TEXT_PAGE_SIZE)
-            .await
-            .context("paginated frame-text read (chrome frequency pass)")?;
-        if page.is_empty() {
-            break;
-        }
-        after_id = page.last().map(|f| f.frame_id).unwrap_or(after_id);
-        chrome_acc.feed(&page);
-    }
-    let chrome = chrome_acc.finish();
-
-    // Pass 2: re-page the same range and fold each frame into the session text.
-    let mut builder = SessionTextBuilder::new();
-    let mut after_id = min_frame_id - 1;
-    loop {
-        let page = fetch_frame_text_page(pool, after_id, max_frame_id, FRAME_TEXT_PAGE_SIZE)
-            .await
-            .context("paginated frame-text read (session-text build pass)")?;
-        if page.is_empty() {
-            break;
-        }
-        after_id = page.last().map(|f| f.frame_id).unwrap_or(after_id);
-        builder.feed(&page, &chrome);
-    }
-    Ok(builder.finish())
 }
 
 /// Groups the positional fields shared by `close_block` / `upsert_open_block`

--- a/src/etl/extractor.rs
+++ b/src/etl/extractor.rs
@@ -5,11 +5,11 @@ use anyhow::Result;
 use sqlx::SqlitePool;
 
 use crate::db::screenpipe::{
-    get_audio_snippets, get_frame_full_texts, get_secondary_screen_events, get_signals,
-    get_window_titles, AudioSnippet, SecondaryScreenEvent, SignalEvent, WindowTitleCount,
+    get_audio_snippets, get_secondary_screen_events, get_signals, get_window_titles, AudioSnippet,
+    SecondaryScreenEvent, SignalEvent, WindowTitleCount,
 };
 use crate::etl::session_builder::{is_coding_agent_terminal, is_vscode_like};
-use crate::etl::text_merge::build_session_text;
+use crate::etl::text_merge::rebuild_session_text_paginated;
 
 // ---------------------------------------------------------------------------
 // BlockContext
@@ -65,15 +65,15 @@ pub async fn extract_block_context(
     max_frame_id: i64,
     frame_count: i64,
 ) -> Result<BlockContext> {
-    let (window_titles_res, audio_res, signals_res, secondary_screens_res, frames_res) = tokio::join!(
+    let (window_titles_res, audio_res, signals_res, secondary_screens_res, session_text_res) = tokio::join!(
         get_window_titles(meridian, min_frame_id, max_frame_id, app_name),
         get_audio_snippets(meridian, started_at, ended_at),
         get_signals(meridian, started_at, ended_at),
         get_secondary_screen_events(meridian, started_at, ended_at),
-        get_frame_full_texts(meridian, min_frame_id, max_frame_id),
+        rebuild_session_text_paginated(meridian, min_frame_id, max_frame_id),
     );
 
-    let session_text = build_session_text(&frames_res?);
+    let session_text = session_text_res?;
     let audio_snippets = audio_res?;
     let signals = signals_res?;
     let secondary_screens = secondary_screens_res?;

--- a/src/etl/text_merge.rs
+++ b/src/etl/text_merge.rs
@@ -2,8 +2,11 @@
 
 use std::collections::HashSet;
 
-use super::text_filter::{build_chrome_set, is_landmark, is_quality_line};
-use crate::db::screenpipe::FrameText;
+use anyhow::{Context, Result};
+use sqlx::SqlitePool;
+
+use super::text_filter::{build_chrome_set, is_landmark, is_quality_line, ChromeFreqAccumulator};
+use crate::db::screenpipe::{fetch_frame_text_page, FrameText, FRAME_TEXT_PAGE_SIZE};
 
 /// Minimum elapsed seconds between consecutive [HH:MM:SS] markers.
 const MARKER_GAP_SECS: i64 = 30;
@@ -28,6 +31,60 @@ pub fn build_session_text(frames: &[FrameText]) -> String {
     let mut builder = SessionTextBuilder::new();
     builder.feed(frames, &chrome);
     builder.finish()
+}
+
+/// Rebuilds session_text for the frame range `min_frame_id..=max_frame_id` by
+/// reading frames from the DB in `FRAME_TEXT_PAGE_SIZE`-sized pages instead of
+/// materializing the whole range in one `Vec<FrameText>`.
+///
+/// Two passes over the paginated read are required: chrome-line detection
+/// (`ChromeFreqAccumulator`) needs a global view of line frequencies across the
+/// *entire* range before any single frame can be classified (see
+/// `crate::etl::text_filter::build_chrome_set`), so pass 1 accumulates
+/// frequencies page-by-page and pass 2 re-pages the same range to fold each
+/// frame into the session text using the now-final chrome set.
+///
+/// This is a memory-shape change only: for the same frame range, the returned
+/// string is functionally identical to
+/// `build_session_text(&get_frame_full_texts(pool, min_frame_id, max_frame_id).await?)` —
+/// no data is truncated or dropped, only held in bounded pages rather than all
+/// at once. Used both when closing a completed block (`crate::etl::block_ops`)
+/// and when extracting context for the block still being processed in the
+/// current ETL run (`crate::etl::extractor`).
+pub async fn rebuild_session_text_paginated(
+    pool: &SqlitePool,
+    min_frame_id: i64,
+    max_frame_id: i64,
+) -> Result<String> {
+    // Pass 1: accumulate chrome-line frequencies across every page.
+    let mut chrome_acc = ChromeFreqAccumulator::new();
+    let mut after_id = min_frame_id - 1;
+    loop {
+        let page = fetch_frame_text_page(pool, after_id, max_frame_id, FRAME_TEXT_PAGE_SIZE)
+            .await
+            .context("paginated frame-text read (chrome frequency pass)")?;
+        if page.is_empty() {
+            break;
+        }
+        after_id = page.last().map(|f| f.frame_id).unwrap_or(after_id);
+        chrome_acc.feed(&page);
+    }
+    let chrome = chrome_acc.finish();
+
+    // Pass 2: re-page the same range and fold each frame into the session text.
+    let mut builder = SessionTextBuilder::new();
+    let mut after_id = min_frame_id - 1;
+    loop {
+        let page = fetch_frame_text_page(pool, after_id, max_frame_id, FRAME_TEXT_PAGE_SIZE)
+            .await
+            .context("paginated frame-text read (session-text build pass)")?;
+        if page.is_empty() {
+            break;
+        }
+        after_id = page.last().map(|f| f.frame_id).unwrap_or(after_id);
+        builder.feed(&page, &chrome);
+    }
+    Ok(builder.finish())
 }
 
 /// Incremental version of [`build_session_text`]'s per-frame fold.


### PR DESCRIPTION
## Summary
- Follow-up to #566 (memory-leak audit fixes). `extract_block_context` still called the unbounded `get_frame_full_texts` + `build_session_text` over the *current run's* block range — the whole-session close path was fixed, but this per-run extraction path wasn't.
- On a first-run backfill after long daemon downtime, one `run_etl` batch can span many frames for a single long-lived app block, spiking RSS the same way the pre-#566 whole-session rebuild did.
- Moves `rebuild_session_text_paginated` from `block_ops.rs` into `text_merge.rs` (a leaf module both `block_ops` and `extractor` can depend on) and wires `extractor.rs` to call it instead of the unbounded fetch+build.

## Why this is safe
- Output is unchanged — `rebuild_session_text_paginated` already has a dedicated parity test (`test_session_text_paginated_rebuild_matches_non_paginated_fetch`) proving its output is byte-for-byte identical to the old unbounded `build_session_text(&get_frame_full_texts(...))` path, and `extract_block_context` now calls that exact same function.
- No behavior change to callers — `BlockContext.session_text` is still the same string, just built from bounded pages instead of one unbounded `Vec<FrameText>`.

## Test plan
- [x] `cargo test` — all 14 suites pass, no failures
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Full pre-push gate (fmt + clippy + ui build + ui tests + cargo test + security audit) — passed