### PR TITLE
fix(ui): hide the Advanced tab and simplify notification settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,7 +382,7 @@ spooled files to OpenObserve, and it refuses to do so entirely for a
 Only a Dev/Bare checkout with `otlp_enabled` + `oo_email`/`oo_password`
 configured ships live, for an engineer debugging against their own
 OpenObserve instance. A shipped install's only path to a developer's
-OpenObserve is the tray Settings → Advanced → **Export Diagnostics** button
+OpenObserve is the tray Settings → Account → **Export Diagnostics** button
 (or `meridian telemetry export`), which bundles the spool + the launchd
 crash-safety-net logs into a `.tar.gz` the user hands to support, imported by
 hand with `meridian telemetry import <bundle> --endpoint <url> --auth

--- a/NOTIFICATIONS.md
+++ b/NOTIFICATIONS.md
@@ -55,7 +55,7 @@ use crate::notifications::{self, NewNotification};
 
 notifications::enqueue(pool, NewNotification::event(
     &format!("my.event:{scope}"),   // dedup: '<event_key>:<scope>'
-    "my.event",                     // event_key — preference lookup
+    "my.event",                     // event_key — dedup/category grouping, not a preference lookup
     "Title", "Body",
 )
 .link("/route")                     // optional dashboard deep link
@@ -64,9 +64,11 @@ notifications::enqueue(pool, NewNotification::event(
 ).await?;
 ```
 
-That's the whole producer. Delivery policy (master switch, per-type toggle,
-quiet hours) is enforced at drain time by `meridian-core`, never by producers —
-**always enqueue; the user's settings decide whether it surfaces.**
+That's the whole producer. Delivery policy (master switch, quiet hours) is
+enforced at drain time by `meridian-core`, never by producers — **always
+enqueue; the user's settings decide whether it surfaces.** There is no
+per-type toggle — every event is treated the same, gated only by those two
+knobs, kept deliberately simple for the user.
 
 ## Add an interactive notification (buttons / inline reply)
 
@@ -249,17 +251,15 @@ registered`, `outbox toast delivered`, `notification action event: {...}`,
 | *(reserved)* | `verify_switch` | Yes · No · Reply… | — (PR 2: task-switch verification) |
 | *(generic)* | `generic_link` | Open | — (stamp only) |
 
-`system.notif_permission` / `system.capture_permission` / `system.disk_low`
-are deliberately ungated by a per-type settings toggle (`type_enabled`
-defaults unknown keys to allowed) — a user shouldn't be able to silence the
-one alert explaining why everything else went quiet. Every other new event_key
-above has a `notify_<type>` toggle in `RuntimeSettings` /
-`NotificationsSection.tsx`.
+There is no per-type settings toggle for any `event_key` — `event_allowed`
+gates every event the same way, on the master switch alone (plus quiet hours
+for the native channel). `RuntimeSettings`/`NotificationsSection.tsx` expose
+exactly two notification controls: the master switch and quiet hours.
 
 Deferred (same rails, thin slices when needed): task-switch verify producer +
-rate cap + `notify_task_verify` toggle (PR 2), goal check-in / distraction
-producers, LLM-generated copy (routed through the chosen CLI provider, `src/llm/`), APNs/phone
-delivery, a `worklog.ready` producer (needs a decision: build a real scheduler
-for unattended draft generation, or repoint the event at something already
-autonomous), an onboarding-stuck reminder (needs a resumable
-wizard-progress timestamp — today's `~/.meridian/onboarded` flag is one-shot).
+rate cap (PR 2), goal check-in / distraction producers, LLM-generated copy
+(routed through the chosen CLI provider, `src/llm/`), APNs/phone delivery, a
+`worklog.ready` producer (needs a decision: build a real scheduler for
+unattended draft generation, or repoint the event at something already
+autonomous), an onboarding-stuck reminder (needs a resumable wizard-progress
+timestamp — today's `~/.meridian/onboarded` flag is one-shot).

--- a/meridian-core/src/notifications/mod.rs
+++ b/meridian-core/src/notifications/mod.rs
@@ -4,9 +4,10 @@
 //!
 //! The Rust daemon (`src/notifications.rs`) ENQUEUES into the `notifications`
 //! table; this module is the single place the *delivery* decision lives:
-//! master switch + per-type toggle ([`event_allowed`]) and quiet hours
-//! ([`in_quiet_hours`]). Producers always enqueue; only the user's settings
-//! decide whether an event actually surfaces. The two delivery writes
+//! master switch ([`event_allowed`]) and quiet hours ([`in_quiet_hours`]) —
+//! deliberately the ONLY two knobs, no per-category toggles. Producers always
+//! enqueue; only the user's settings decide whether an event actually
+//! surfaces. The two delivery writes
 //! ([`mark_native_delivered`], [`dismiss_banner`]) ack a row so it isn't
 //! re-delivered / re-shown — idempotent, mirroring the same-named TS helpers.
 //!
@@ -112,30 +113,10 @@ pub struct PendingNotification {
     pub actions: Option<String>,
 }
 
-/// Per-type preference for an `event_key`. Unknown keys default to enabled (a new
-/// producer is visible until the user opts out), gated only by the master switch.
-fn type_enabled(event_key: &str, s: &RuntimeSettings) -> bool {
-    match event_key {
-        "plan.nudge" => s.notify_plan_nudge,
-        "worklog.ready" => s.notify_worklog_ready,
-        "system.fault" => s.notify_system_fault,
-        "system.pause" => s.notify_system_pause,
-        "system.health" => s.notify_system_health,
-        "system.update" => s.notify_system_update,
-        "summariser.dead_letter" => s.notify_summariser_digest,
-        "board.hygiene" => s.notify_board_hygiene,
-        // Safety-critical: notification/capture-permission revoked and low disk
-        // space stay ungated by a per-type toggle (unknown keys default
-        // enabled) — a user shouldn't be able to silence the one alert that
-        // explains why everything else went quiet.
-        _ => true,
-    }
-}
-
-/// Whether `event_key` may surface at all: master switch AND per-type toggle.
-/// Mirrors `eventAllowed` in ui/lib/notifications.ts.
-pub fn event_allowed(event_key: &str, s: &RuntimeSettings) -> bool {
-    s.notifications_enabled && type_enabled(event_key, s)
+/// Whether an event may surface at all: the master switch, full stop. Every
+/// event type is treated the same — there is no per-category toggle.
+pub fn event_allowed(s: &RuntimeSettings) -> bool {
+    s.notifications_enabled
 }
 
 /// Minutes since midnight for an 'HH:MM' string, or `None` if malformed.
@@ -194,7 +175,6 @@ pub fn in_quiet_hours(s: &RuntimeSettings) -> bool {
 #[derive(FromRow)]
 struct NotifRow {
     id: i64,
-    event_key: String,
     severity: String,
     title: String,
     body: String,
@@ -268,7 +248,7 @@ pub async fn pending_native(
         "NULL AS category, NULL AS actions"
     };
     let rows: Vec<NotifRow> = sqlx::query_as::<_, NotifRow>(&format!(
-        r#"SELECT id, event_key, severity, title, body, deep_link, channels, {action_cols}
+        r#"SELECT id, severity, title, body, deep_link, channels, {action_cols}
            FROM notifications
            WHERE delivered_native_at IS NULL
              AND (scheduled_for IS NULL OR scheduled_for <= ?)
@@ -289,7 +269,7 @@ pub async fn pending_native(
 
     let out: Vec<PendingNotification> = rows
         .into_iter()
-        .filter(|r| has_channel(&r.channels, "native") && event_allowed(&r.event_key, s))
+        .filter(|r| has_channel(&r.channels, "native") && event_allowed(s))
         .map(|r| PendingNotification {
             id: r.id,
             title: r.title,
@@ -358,7 +338,7 @@ pub async fn active_banners(
 
     let out: Vec<BannerNotification> = rows
         .into_iter()
-        .filter(|r| has_channel(&r.channels, "banner") && event_allowed(&r.event_key, s))
+        .filter(|r| has_channel(&r.channels, "banner") && event_allowed(s))
         .map(|r| BannerNotification {
             id: r.id,
             event_key: r.event_key,

--- a/meridian-core/src/notifications/tests.rs
+++ b/meridian-core/src/notifications/tests.rs
@@ -131,16 +131,11 @@ async fn active_banners_filters_channel_dismissed_expired_and_prefs() {
 }
 
 #[test]
-fn event_allowed_respects_master_and_type() {
+fn event_allowed_respects_only_the_master_switch() {
     let mut s = settings();
-    assert!(event_allowed("plan.nudge", &s));
-    assert!(event_allowed("unknown.event", &s)); // unknown → enabled
-    s.notify_plan_nudge = false;
-    assert!(!event_allowed("plan.nudge", &s));
-    s.notify_plan_nudge = true;
-    s.notifications_enabled = false; // master off → nothing
-    assert!(!event_allowed("plan.nudge", &s));
-    assert!(!event_allowed("unknown.event", &s));
+    assert!(event_allowed(&s));
+    s.notifications_enabled = false;
+    assert!(!event_allowed(&s), "master off → nothing surfaces");
 }
 
 #[test]

--- a/meridian-core/src/settings.rs
+++ b/meridian-core/src/settings.rs
@@ -238,28 +238,12 @@ pub struct RuntimeSettings {
     pub otlp_endpoint: Option<String>,
     pub oo_email: Option<String>,
     pub oo_password: Option<String>,
-    // Notification preferences — the master switch + per-type toggles + quiet
-    // hours. Read by [`crate::notifications`] (the policy ported from
-    // ui/lib/notifications.ts) to decide whether an event may surface.
-    // `quiet_hours_*` are 'HH:MM' local time (start inclusive, end exclusive).
+    // Notification preferences — a master switch + quiet hours. Read by
+    // [`crate::notifications`] to decide whether an event may surface;
+    // every event type is gated ONLY by these two (no per-category toggles —
+    // kept deliberately simple for the user). `quiet_hours_*` are 'HH:MM'
+    // local time (start inclusive, end exclusive).
     pub notifications_enabled: bool,
-    pub notify_plan_nudge: bool,
-    // Daily planner auto-open — once per local day the tray opens the dashboard
-    // on the Plan modal (first launch or first poll tick of a new day). A window
-    // behaviour, not a toast, so it is NOT gated by `notifications_enabled`.
-    pub auto_open_plan: bool,
-    pub notify_worklog_ready: bool,
-    pub notify_system_fault: bool,
-    // Folded from direct tray-side toasts (pause/resume, daemon health,
-    // updates) into the outbox — each now has its own toggle instead of
-    // sharing `notify_system_fault` or being ungated entirely.
-    pub notify_system_pause: bool,
-    pub notify_system_health: bool,
-    pub notify_system_update: bool,
-    // Daily batched digests — see src/coding_agent_session_ingest and
-    // src/intelligence::triage_after_sync.
-    pub notify_summariser_digest: bool,
-    pub notify_board_hygiene: bool,
     pub quiet_hours_enabled: bool,
     pub quiet_hours_start: String,
     pub quiet_hours_end: String,
@@ -343,15 +327,6 @@ impl Default for RuntimeSettings {
             // Notifications on by default; quiet hours off (22:00–08:00 when
             // enabled). Must match SETTINGS_DEFAULTS in ui/lib/settings.ts.
             notifications_enabled: true,
-            notify_plan_nudge: true,
-            auto_open_plan: true,
-            notify_worklog_ready: true,
-            notify_system_fault: true,
-            notify_system_pause: true,
-            notify_system_health: true,
-            notify_system_update: true,
-            notify_summariser_digest: true,
-            notify_board_hygiene: true,
             quiet_hours_enabled: false,
             quiet_hours_start: "22:00".to_string(),
             quiet_hours_end: "08:00".to_string(),

--- a/src/notices.rs
+++ b/src/notices.rs
@@ -15,7 +15,7 @@ use sqlx::SqlitePool;
 /// Raise (or refresh) a named notice. Idempotent — upserts so repeated calls
 /// from the poll loop don't accumulate duplicate rows. The paired toast is
 /// always stamped `system.fault` — use [`raise_typed`] when the caller needs
-/// its own per-type settings toggle instead of sharing `notify_system_fault`.
+/// its own distinct `event_key` instead of sharing the `system.fault` bucket.
 pub async fn raise(
     pool: &SqlitePool,
     id: &str,
@@ -54,8 +54,8 @@ pub struct Notice<'a> {
     pub title: &'a str,
     pub detail: &'a str,
     pub remedy: Option<&'a str>,
-    /// The paired toast's event_key — its own `notify_<type>` settings toggle,
-    /// instead of the shared `system.fault` bucket [`raise`] uses.
+    /// The paired toast's event_key, distinct from the shared `system.fault`
+    /// bucket [`raise`] uses.
     pub event_key: &'a str,
     pub deep_link: Option<&'a str>,
 }

--- a/tray/src-tauri/src/commands/daemon.rs
+++ b/tray/src-tauri/src/commands/daemon.rs
@@ -46,9 +46,9 @@ pub async fn restart_daemon() -> Result<(), String> {
 }
 
 /// Pause (stop) or resume (start) the daemon. On success, raises/clears a
-/// `tray.daemon_paused` notice — same `system.pause` event_key (and
-/// `notify_system_pause` toggle) as [`crate::commands::pause`]'s capture-pause
-/// notice, so quiet-hours/master-switch/per-type policy applies identically.
+/// `tray.daemon_paused` notice — same `system.pause` event_key as
+/// [`crate::commands::pause`]'s capture-pause notice, so quiet-hours/master-
+/// switch policy applies identically.
 ///
 /// Start/stop goes through [`super::daemon_control`] (launchd on macOS, the
 /// scheduled task on Windows) rather than `launchctl` directly.

--- a/tray/src-tauri/src/commands/diagnostics.rs
+++ b/tray/src-tauri/src/commands/diagnostics.rs
@@ -13,7 +13,7 @@
 //!
 //! # Who calls this
 //! `export_diagnostics_bundle` is registered in `lib.rs`'s `invoke_handler!`;
-//! consumed by `ui/components/timeline/settings/AdvancedSection.tsx`'s
+//! consumed by `ui/components/timeline/settings/AccountSection.tsx`'s
 //! "Export Diagnostics" button via `mutate`/`load` in `@/lib/bridge`.
 //!
 //! # Related

--- a/tray/src-tauri/src/commands/pause.rs
+++ b/tray/src-tauri/src/commands/pause.rs
@@ -19,8 +19,8 @@
 //!   this was split from.
 //! - [`crate::state::PauseSource`] — the pause-kind enum these commands set.
 //! - [`meridian::notices`] — the fault-bus the pause/resume notice routes through
-//!   (id `tray.paused`, event_key `system.pause`); quiet-hours/master-switch/the
-//!   `notify_system_pause` toggle are all enforced there, not by these commands.
+//!   (id `tray.paused`, event_key `system.pause`); quiet-hours/master-switch
+//!   policy is all enforced there, not by these commands.
 
 use crate::state::{AppState, PauseSource};
 use chrono::{DateTime, SecondsFormat, Utc};

--- a/tray/src-tauri/src/commands/settings.rs
+++ b/tray/src-tauri/src/commands/settings.rs
@@ -23,8 +23,8 @@
 //!   installs/manages a local OpenObserve service for them.
 //!
 //! **No UI writes these OTLP-shipping fields anymore** (the config panel was
-//! replaced by the "Export Diagnostics" button in `AdvancedSection.tsx` — see
-//! that component's history). This is intentional: OTLP shipping is a
+//! replaced by the "Export Diagnostics" button, now in `AccountSection.tsx`
+//! — see that component's history). This is intentional: OTLP shipping is a
 //! Dev/Bare-only, engineer-facing debugging feature (a packaged/Canonical
 //! install can never ship, regardless of these fields — see
 //! `is_canonical_install()`), so an engineer who wants their dev daemon to

--- a/tray/src-tauri/src/poll/plan_auto_open.rs
+++ b/tray/src-tauri/src/poll/plan_auto_open.rs
@@ -12,9 +12,8 @@
 //!    holds a timestamp — `meridian_core::plan_marker` — refreshed when the
 //!    user dismisses the planner, which the daemon reads to hold its plan
 //!    nudge back until an hour after the open/dismissal)
-//! 2. `auto_open_plan` disabled in settings
-//! 3. not onboarded (no `~/.meridian/onboarded` — don't open over the wizard)
-//! 4. today's plan already confirmed/skipped (`daily_plan_meta`) — the marker
+//! 2. not onboarded (no `~/.meridian/onboarded` — don't open over the wizard)
+//! 3. today's plan already confirmed/skipped (`daily_plan_meta`) — the marker
 //!    is written WITHOUT opening, so the day stays settled
 //!
 //! The marker is written BEFORE the window opens: under launchd `KeepAlive` a
@@ -58,17 +57,12 @@ pub(crate) async fn maybe_auto_open_plan(app: &tauri::AppHandle, pool: &meridian
         return;
     }
 
-    // 2. Feature toggle.
-    if !meridian_core::settings::load_runtime_settings().auto_open_plan {
-        return;
-    }
-
-    // 3. Don't open the planner over (or instead of) the first-run wizard.
+    // 2. Don't open the planner over (or instead of) the first-run wizard.
     if !meridian_dir.join("onboarded").exists() {
         return;
     }
 
-    // 4. Day already planned (confirmed or skipped, e.g. via the notification
+    // 3. Day already planned (confirmed or skipped, e.g. via the notification
     //    nudge) — settle the day without opening.
     if meridian_core::plan::plan_handled(pool, &today).await {
         write_marker(&marker, &now);

--- a/tray/src-tauri/src/update.rs
+++ b/tray/src-tauri/src/update.rs
@@ -31,9 +31,9 @@
 //!
 //! # Related
 //! - [`notify_update`] — routes every tray-menu toast through the outbox
-//!   (event_key `system.update`) instead of a direct bypass, so quiet-hours,
-//!   the master switch, and the `notify_system_update` toggle all apply —
-//!   previously these six call sites skipped that policy entirely.
+//!   (event_key `system.update`) instead of a direct bypass, so quiet-hours
+//!   and the master switch all apply — previously these six call sites
+//!   skipped that policy entirely.
 //! - `scripts/package-updater.sh` — the producer of the `Minimum-Version:` notes
 //!   line (reads the optional `tray/minimum-version` file at release time).
 //! - Plan: Obsidian `Decisions/Public distribution + auto-update for the DMG`.
@@ -51,8 +51,8 @@ use tauri_plugin_updater::UpdaterExt;
 /// one-shot event (a check outcome, a download starting), not an ongoing
 /// condition to raise/clear like [`meridian::notices`] models — so this goes
 /// straight to [`meridian::notifications::enqueue`], gated by `system.update`
-/// (master switch + quiet hours + the `notify_system_update` toggle) the same
-/// way every other outbox producer is. `dedup_suffix` only needs to be unique
+/// (master switch + quiet hours) the same way every other outbox producer
+/// is. `dedup_suffix` only needs to be unique
 /// per call (the current timestamp is fine — these are user-triggered or
 /// rare background events, never a tight loop that would spam distinct keys).
 async fn notify_update(app: &AppHandle, dedup_suffix: &str, title: &str, body: &str) {

--- a/ui/__tests__/advanced-tab-hidden.test.ts
+++ b/ui/__tests__/advanced-tab-hidden.test.ts
@@ -1,0 +1,45 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+
+// Guards the "Advanced" settings tab being hidden from the sidebar/modal, and
+// specifically the regression a review caught: hiding it must NOT also hide
+// "Export Diagnostics" — a packaged install's only GUI path to handing a
+// developer a local telemetry bundle (see CLAUDE.md's "Telemetry: local-only
+// capture, dev-only shipping"). That control was moved to AccountSection.tsx,
+// which stays reachable, rather than dropped.
+
+const uiRoot = import.meta.dir + '/..'
+const readSrc = (rel: string): string => readFileSync(uiRoot + '/' + rel, 'utf8')
+
+describe('Advanced tab is hidden, not deleted', () => {
+  it('the sidebar nav entry is commented out, not removed', () => {
+    const src = readSrc('components/timeline/settings/SettingsSidebar.tsx')
+    expect(src).toContain("// { id: 'advanced'")
+    expect(src).not.toMatch(/^\s*\{\s*id:\s*'advanced'/m)
+  })
+
+  it("the modal's render branch is commented out, not removed", () => {
+    const src = readSrc('components/timeline/SettingsModal.tsx')
+    expect(src).toContain("{/* {section === 'advanced' && (")
+    expect(src).not.toMatch(/^\s*\{section === 'advanced' && \(/m)
+  })
+})
+
+describe('Export Diagnostics stays reachable via Account', () => {
+  const accountSrc = readSrc('components/timeline/settings/AccountSection.tsx')
+  const advancedSrc = readSrc('components/timeline/settings/AdvancedSection.tsx')
+
+  it('AccountSection wires the export button through useExportDiagnostics', () => {
+    expect(accountSrc).toContain("import { useExportDiagnostics } from './useExportDiagnostics'")
+    expect(accountSrc).toContain('exportBundle')
+    expect(accountSrc).toContain('Export Diagnostics')
+  })
+
+  it('AdvancedSection no longer duplicates the export button', () => {
+    // A doc comment may still mention it moved; the functional wiring must not.
+    expect(advancedSrc).not.toContain('useExportDiagnostics(')
+    expect(advancedSrc).not.toContain('exportBundle')
+    expect(advancedSrc).not.toContain('<SettingsButton onClick={exportBundle}')
+  })
+})

--- a/ui/__tests__/notifications-settings-simplified.test.ts
+++ b/ui/__tests__/notifications-settings-simplified.test.ts
@@ -1,0 +1,66 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+
+// Guards the simplified Settings → Notifications surface: a master switch and
+// quiet hours only. The per-category toggles (plan nudge, worklog ready,
+// system fault/pause/health/update, summariser digest, board hygiene) and the
+// "Open planner each day" toggle were removed — every event is now gated
+// solely by notifications_enabled + quiet hours, enforced at drain time in
+// meridian-core (see meridian-core/src/notifications/mod.rs::event_allowed).
+
+const uiRoot = import.meta.dir + '/..'
+const readSrc = (rel: string): string => readFileSync(uiRoot + '/' + rel, 'utf8')
+
+const REMOVED_SETTINGS_FIELDS = [
+  'notify_plan_nudge',
+  'notify_worklog_ready',
+  'notify_system_fault',
+  'notify_system_pause',
+  'notify_system_health',
+  'notify_system_update',
+  'notify_summariser_digest',
+  'notify_board_hygiene',
+  'auto_open_plan',
+]
+
+describe('NotificationsSection', () => {
+  const src = readSrc('components/timeline/settings/NotificationsSection.tsx')
+
+  it('exposes only the master switch and quiet hours controls', () => {
+    expect(src).toContain('notifications_enabled')
+    expect(src).toContain('quiet_hours_enabled')
+    expect(src).toContain('quiet_hours_start')
+    expect(src).toContain('quiet_hours_end')
+  })
+
+  it('no longer renders any of the removed per-category toggles', () => {
+    for (const field of REMOVED_SETTINGS_FIELDS) {
+      expect(src).not.toContain(field)
+    }
+  })
+
+  it('the master switch still gates everything below it, quiet hours included', () => {
+    const gateIndex = src.indexOf('{settings.notifications_enabled && (')
+    const quietHoursIndex = src.indexOf('quiet_hours_enabled')
+    expect(gateIndex).toBeGreaterThan(-1)
+    expect(quietHoursIndex).toBeGreaterThan(gateIndex)
+  })
+})
+
+describe('RuntimeSettings (ui/lib/settings.ts)', () => {
+  const src = readSrc('lib/settings.ts')
+
+  it('keeps notifications_enabled and quiet_hours_* in the type and defaults', () => {
+    expect(src).toContain('notifications_enabled: boolean')
+    expect(src).toContain('notifications_enabled: true')
+    expect(src).toContain('quiet_hours_enabled: boolean')
+    expect(src).toContain('quiet_hours_enabled: false')
+  })
+
+  it('no longer declares any of the removed per-category settings fields', () => {
+    for (const field of REMOVED_SETTINGS_FIELDS) {
+      expect(src).not.toContain(field)
+    }
+  })
+})

--- a/ui/components/timeline/SettingsModal.tsx
+++ b/ui/components/timeline/SettingsModal.tsx
@@ -21,7 +21,7 @@ import { IntelligenceSection } from './settings/IntelligenceSection'
 import { CaptureSection } from './settings/CaptureSection'
 import { NotificationsSection } from './settings/NotificationsSection'
 import { AppearanceSection } from './settings/AppearanceSection'
-import { AdvancedSection } from './settings/AdvancedSection'
+// import { AdvancedSection } from './settings/AdvancedSection'
 import { AccountSection } from './settings/AccountSection'
 import { useRuntimeSettings } from './settings/useRuntimeSettings'
 import { DEFAULT_SETTINGS_SECTION, type SettingsSection } from './settings/types'
@@ -33,7 +33,7 @@ export function SettingsModal({ onClose, initialSection }: {
   const [section, setSection] = useState<SettingsSection>(initialSection ?? DEFAULT_SETTINGS_SECTION)
   const [integrations, setIntegrations] = useState<IntegrationsResponse | null>(null)
   const [integrationsError, setIntegrationsError] = useState(false)
-  const { settings, setSettings, patch, save } = useRuntimeSettings()
+  const { settings, patch, save } = useRuntimeSettings()
 
   const fetchIntegrations = () => {
     load<IntegrationsResponse>('/api/integrations', 'get_integrations')
@@ -79,9 +79,9 @@ export function SettingsModal({ onClose, initialSection }: {
               {section === 'capture' && <CaptureSection settings={settings} patch={patch} save={save} />}
               {section === 'notifications' && <NotificationsSection settings={settings} patch={patch} save={save} />}
               {section === 'appearance' && <AppearanceSection />}
-              {section === 'advanced' && (
+              {/* {section === 'advanced' && (
                 <AdvancedSection settings={settings} setSettings={setSettings} patch={patch} save={save} />
-              )}
+              )} */}
               {section === 'account' && <AccountSection />}
             </>
           )}

--- a/ui/components/timeline/settings/AccountSection.tsx
+++ b/ui/components/timeline/settings/AccountSection.tsx
@@ -2,6 +2,13 @@
 //
 // Settings → Account. Migrated 1:1 from the old SettingsView's "Setup &
 // Onboarding" card — the only Account-ish control that existed before.
+//
+// Also hosts "Export Diagnostics" (moved from the now-hidden Advanced tab):
+// the ONLY GUI path a packaged install has to hand a developer a local
+// telemetry bundle (`meridian telemetry export` is the terminal fallback —
+// not realistic mid support-ticket). See CLAUDE.md's "Telemetry: local-only
+// capture, dev-only shipping" section — keep that doc's Settings path in
+// sync if this ever moves again.
 
 'use client'
 
@@ -10,6 +17,7 @@ import { invoke, load, mutate } from '@/lib/bridge'
 import type { AppInfo } from '@/lib/api-types'
 import { AccountAuthControl } from '@/app/setup/signin'
 import { SectionCard, SectionHeader, FieldRow, SettingsButton } from './fields'
+import { useExportDiagnostics } from './useExportDiagnostics'
 
 // Colored only for a non-prod build — a prod dashboard shouldn't draw the eye
 // to its own version line; dev/staging should be unmistakable.
@@ -21,6 +29,7 @@ const CHANNEL_COLOR: Record<AppInfo['channel'], string> = {
 
 export function AccountSection() {
   const [appInfo, setAppInfo] = useState<AppInfo | null>(null)
+  const { status: exportStatus, path: exportPath, errorMsg: exportError, exportBundle } = useExportDiagnostics()
 
   useEffect(() => {
     load<AppInfo>('/api/app-info', 'get_app_info').then(setAppInfo).catch(() => {})
@@ -68,6 +77,17 @@ export function AccountSection() {
             </span>
           )}
         </FieldRow>
+        <FieldRow label="Export Diagnostics" description="Captures your local logs and traces for troubleshooting — nothing leaves your machine until you share this file. Saved to your Downloads folder and revealed in Finder.">
+          <SettingsButton onClick={exportBundle} disabled={exportStatus === 'exporting'}>
+            {exportStatus === 'exporting' ? 'Exporting…' : 'Export Diagnostics'}
+          </SettingsButton>
+        </FieldRow>
+        {exportStatus === 'done' && exportPath && (
+          <span className="text-[12px]" style={{ color: 'var(--color-state-approved)' }}>Saved to {exportPath}</span>
+        )}
+        {exportStatus === 'error' && (
+          <span className="text-[12px]" style={{ color: 'var(--color-state-pending)' }}>{exportError ?? 'Export failed'}</span>
+        )}
       </SectionCard>
     </div>
   )

--- a/ui/components/timeline/settings/AdvancedSection.tsx
+++ b/ui/components/timeline/settings/AdvancedSection.tsx
@@ -1,13 +1,20 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 //
-// Settings → Advanced. Runtime-tuning knobs migrated 1:1 from the old
-// SettingsView: Observability (local capture + log level; export via
-// useExportDiagnostics — the shipped app never installs/runs a local
-// OpenObserve service), ETL Pipeline poll interval, Session Classification
-// thresholds, LLM local-model preference, and the Jira Updater toggle. These
-// don't fit Integrations/Capture/Notifications/Appearance — they're internal
-// daemon behavior, not user-facing product surfaces, so they're grouped here
-// rather than invented a home for each.
+// Settings → Advanced. Currently unreferenced — the nav entry + render
+// branch are commented out in SettingsSidebar.tsx / SettingsModal.tsx, kept
+// for easy re-enable. Runtime-tuning knobs migrated 1:1 from the old
+// SettingsView: Observability (local capture + log level), ETL Pipeline poll
+// interval, Session Classification thresholds, LLM local-model preference,
+// and the Jira Updater toggle. These don't fit
+// Integrations/Capture/Notifications/Appearance — they're internal daemon
+// behavior, not user-facing product surfaces, so they're grouped here rather
+// than invented a home for each.
+//
+// "Export Diagnostics" moved OUT of here to `AccountSection.tsx` (always
+// reachable) when this tab was hidden — a packaged install's only GUI path
+// to handing a developer a telemetry bundle can't live behind a hidden tab.
+// Don't re-add it here if this section is ever re-enabled; it would just
+// duplicate the Account one.
 
 'use client'
 
@@ -16,8 +23,7 @@ import { Select } from '@/components/ui/Select'
 import { Switch } from '@/components/ui/Switch'
 import { NumberStepper } from '@/components/ui/NumberStepper'
 import type { RuntimeSettings } from '@/lib/settings'
-import { SectionCard, SectionHeader, FieldRow, SaveButton, SettingsButton, type SaveStatus } from './fields'
-import { useExportDiagnostics } from './useExportDiagnostics'
+import { SectionCard, SectionHeader, FieldRow, SaveButton, type SaveStatus } from './fields'
 
 const LOG_LEVEL_OPTIONS = [
   { value: 'DEBUG',   label: 'DEBUG' },
@@ -37,7 +43,6 @@ export function AdvancedSection({ settings, setSettings, patch, save }: {
   const [llmStatus, setLlmStatus] = useState<SaveStatus>('idle')
   const [jiraStatus, setJiraStatus] = useState<SaveStatus>('idle')
   const [logLevelStatus, setLogLevelStatus] = useState<SaveStatus>('idle')
-  const { status: exportStatus, path: exportPath, errorMsg: exportError, exportBundle } = useExportDiagnostics()
 
   return (
     <div className="max-w-[640px] flex flex-col gap-5">
@@ -60,17 +65,6 @@ export function AdvancedSection({ settings, setSettings, patch, save }: {
           />
         </FieldRow>
         <SaveButton status={logLevelStatus} onClick={() => save({ log_level: settings.log_level }, setLogLevelStatus)} />
-        <FieldRow label="Export Diagnostics" description="Captures your local logs and traces for troubleshooting — nothing leaves your machine until you share this file. Saved to your Downloads folder and revealed in Finder.">
-          <SettingsButton onClick={exportBundle} disabled={exportStatus === 'exporting'}>
-            {exportStatus === 'exporting' ? 'Exporting…' : 'Export Diagnostics'}
-          </SettingsButton>
-        </FieldRow>
-        {exportStatus === 'done' && exportPath && (
-          <span className="text-[12px]" style={{ color: 'var(--color-state-approved)' }}>Saved to {exportPath}</span>
-        )}
-        {exportStatus === 'error' && (
-          <span className="text-[12px]" style={{ color: 'var(--color-state-pending)' }}>{exportError ?? 'Export failed'}</span>
-        )}
       </SectionCard>
 
       <SectionCard>

--- a/ui/components/timeline/settings/NotificationsSection.tsx
+++ b/ui/components/timeline/settings/NotificationsSection.tsx
@@ -1,8 +1,7 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 //
-// Settings → Notifications. Migrated 1:1 from the old SettingsView's
-// "Notifications" card: master switch, per-event-type toggles, and the quiet
-// hours window.
+// Settings → Notifications. Deliberately minimal: a master switch and a
+// quiet hours window — no per-event-type toggles.
 
 'use client'
 
@@ -34,38 +33,8 @@ export function NotificationsSection({ settings, patch, save }: {
         <FieldRow label="Notifications" description="Master switch for desktop toasts and in-app banners. Off silences everything below.">
           <Switch checked={settings.notifications_enabled} onCheckedChange={v => patch({ notifications_enabled: v })} />
         </FieldRow>
-        {/* A window behaviour, not a toast — deliberately outside the
-            notifications_enabled gate so silencing toasts doesn't also kill
-            the morning planner. */}
-        <FieldRow label="Open planner each day" description="Once a day, open the dashboard on the Plan view when you start using your machine.">
-          <Switch checked={settings.auto_open_plan} onCheckedChange={v => patch({ auto_open_plan: v })} />
-        </FieldRow>
         {settings.notifications_enabled && (
           <>
-            <FieldRow label="Plan your day reminder" description="If you close the planner without confirming a plan, this reminds you an hour later.">
-              <Switch checked={settings.notify_plan_nudge} onCheckedChange={v => patch({ notify_plan_nudge: v })} />
-            </FieldRow>
-            <FieldRow label="Worklog drafts ready" description="When the daily worklog drafts are ready to review and approve.">
-              <Switch checked={settings.notify_worklog_ready} onCheckedChange={v => patch({ notify_worklog_ready: v })} />
-            </FieldRow>
-            <FieldRow label="System faults" description="When a tracker sync or the classifier stack fails (also shown as a banner).">
-              <Switch checked={settings.notify_system_fault} onCheckedChange={v => patch({ notify_system_fault: v })} />
-            </FieldRow>
-            <FieldRow label="Pause / resume" description="When tracking is paused or resumes, manually or on a schedule.">
-              <Switch checked={settings.notify_system_pause} onCheckedChange={v => patch({ notify_system_pause: v })} />
-            </FieldRow>
-            <FieldRow label="Daemon health" description="When Meridian's background daemon goes quiet or comes back online.">
-              <Switch checked={settings.notify_system_health} onCheckedChange={v => patch({ notify_system_health: v })} />
-            </FieldRow>
-            <FieldRow label="Updates" description="When a new version is available, installing, or fails to install.">
-              <Switch checked={settings.notify_system_update} onCheckedChange={v => patch({ notify_system_update: v })} />
-            </FieldRow>
-            <FieldRow label="Summarisation issues" description="A daily digest if any coding-agent sessions couldn't be summarised.">
-              <Switch checked={settings.notify_summariser_digest} onCheckedChange={v => patch({ notify_summariser_digest: v })} />
-            </FieldRow>
-            <FieldRow label="Board hygiene" description="A daily digest if tickets on your board need attention.">
-              <Switch checked={settings.notify_board_hygiene} onCheckedChange={v => patch({ notify_board_hygiene: v })} />
-            </FieldRow>
             <FieldRow label="Quiet hours" description="Hold back desktop toasts during this window (banners still appear). Wraps past midnight.">
               <Switch checked={settings.quiet_hours_enabled} onCheckedChange={v => patch({ quiet_hours_enabled: v })} />
             </FieldRow>
@@ -82,15 +51,6 @@ export function NotificationsSection({ settings, patch, save }: {
           status={status}
           onClick={() => save({
             notifications_enabled: settings.notifications_enabled,
-            auto_open_plan: settings.auto_open_plan,
-            notify_plan_nudge: settings.notify_plan_nudge,
-            notify_worklog_ready: settings.notify_worklog_ready,
-            notify_system_fault: settings.notify_system_fault,
-            notify_system_pause: settings.notify_system_pause,
-            notify_system_health: settings.notify_system_health,
-            notify_system_update: settings.notify_system_update,
-            notify_summariser_digest: settings.notify_summariser_digest,
-            notify_board_hygiene: settings.notify_board_hygiene,
             quiet_hours_enabled: settings.quiet_hours_enabled,
             quiet_hours_start: settings.quiet_hours_start,
             quiet_hours_end: settings.quiet_hours_end,

--- a/ui/components/timeline/settings/SettingsSidebar.tsx
+++ b/ui/components/timeline/settings/SettingsSidebar.tsx
@@ -23,7 +23,7 @@ const NAV: { id: SettingsSection; label: string; glyph: string }[] = [
   { id: 'capture', label: 'Capture & Privacy', glyph: '◉' },
   { id: 'notifications', label: 'Notifications', glyph: '◔' },
   { id: 'appearance', label: 'Appearance', glyph: '◑' },
-  { id: 'advanced', label: 'Advanced', glyph: '▤' },
+  // { id: 'advanced', label: 'Advanced', glyph: '▤' },
   { id: 'account', label: 'Account', glyph: '◍' },
 ]
 

--- a/ui/lib/settings.ts
+++ b/ui/lib/settings.ts
@@ -33,26 +33,12 @@ export interface RuntimeSettings {
   llm_budget_pct: number
   // Jira updater
   jira_update_enabled: boolean
-  // Notifications — master switch + per-event-type toggles + quiet hours.
-  // Filtering happens once at the delivery layer (the notification API routes),
-  // never in the producers, so every event flows into the outbox and only the
-  // user's preferences decide whether it surfaces.
+  // Notifications — a master switch + quiet hours. Filtering happens once at
+  // the delivery layer (the notification API routes), never in the
+  // producers, so every event flows into the outbox and only these two
+  // preferences decide whether it surfaces. Deliberately no per-event-type
+  // toggles — kept simple for the user.
   notifications_enabled: boolean
-  notify_plan_nudge: boolean
-  // Daily planner auto-open — the tray opens the dashboard on the Plan modal
-  // once per local day. A window behaviour, not a toast, so NOT gated by
-  // notifications_enabled.
-  auto_open_plan: boolean
-  notify_worklog_ready: boolean
-  notify_system_fault: boolean
-  // Folded from direct tray-side toasts (pause/resume, daemon health,
-  // updates) into the outbox — each has its own toggle.
-  notify_system_pause: boolean
-  notify_system_health: boolean
-  notify_system_update: boolean
-  // Daily batched digests.
-  notify_summariser_digest: boolean
-  notify_board_hygiene: boolean
   quiet_hours_enabled: boolean
   quiet_hours_start: string // 'HH:MM' local time, inclusive
   quiet_hours_end: string   // 'HH:MM' local time, exclusive
@@ -101,15 +87,6 @@ export const SETTINGS_DEFAULTS: RuntimeSettings = {
   llm_budget_pct: 0.5,
   jira_update_enabled: true,
   notifications_enabled: true,
-  notify_plan_nudge: true,
-  auto_open_plan: true,
-  notify_worklog_ready: true,
-  notify_system_fault: true,
-  notify_system_pause: true,
-  notify_system_health: true,
-  notify_system_update: true,
-  notify_summariser_digest: true,
-  notify_board_hygiene: true,
   quiet_hours_enabled: false,
   quiet_hours_start: '22:00',
   quiet_hours_end: '08:00',


### PR DESCRIPTION
## Summary
- Comment out the Advanced nav entry in the Settings sidebar and its section render in the Settings modal, so the tab is no longer reachable from the UI (`AdvancedSection` component itself is left intact, just unreferenced, for easy re-enable later)
- Simplify Settings -> Notifications down to two controls: the master on/off switch and quiet hours
- Removed the per-category toggles (plan reminder, worklog ready, system fault, pause/resume, daemon health, updates, summarisation issues, board hygiene) and the "Open planner each day" toggle
- Every notification event is now gated only by `notifications_enabled` + quiet hours, decided at drain time in `meridian-core::notifications::event_allowed` — producers already enqueued unconditionally, so this is a pure policy simplification, not a behavior loss for any individual event type
- The daily planner auto-open keeps running (still governed by its marker/onboarded/plan-handled gates) since it's no longer user-toggleable — flagging this explicitly since it's the one behavior-visible change: users can no longer turn off the daily planner pop-up
- Removed the now-dead `notify_*` / `auto_open_plan` fields from `RuntimeSettings` (Rust + TS mirror) and updated stale doc comments across the tray/daemon that referenced the old per-type toggles
- Added a Rust unit test (`event_allowed_respects_only_the_master_switch`) and a new UI test file (`ui/__tests__/notifications-settings-simplified.test.ts`) covering the simplified surface

## Test plan
- [x] `cargo test --workspace` — 733+ tests pass, 0 failures
- [x] `cargo clippy --workspace -- -D warnings` and `cargo fmt --check` — clean
- [x] `npm run build` in `ui/` succeeds with no TypeScript/lint errors
- [x] `bun test` in `ui/` — 361 tests pass, 0 failures
- [x] pre-push checks pass (fmt, clippy, ui build/tests, security audit, cargo test)
- [ ] Manually open Settings in the tray and confirm: no "Advanced" entry in the sidebar; Notifications shows only the master switch + quiet hours