### PR TITLE
fix(jira): stop flapping OAuth sync error on transient refresh failures

### DIFF
--- a/meridian-oauth/src/flow.rs
+++ b/meridian-oauth/src/flow.rs
@@ -48,6 +48,68 @@ pub struct TokenResponse {
     pub scope: String,
 }
 
+/// Whether a token-endpoint failure is worth retrying, or means the grant is
+/// dead. This is the distinction the background refresh loop needs: a passing
+/// network blip must not be surfaced to the user as "re-authenticate".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenFailure {
+    /// The grant itself was rejected and won't recover on its own — an OAuth 4xx
+    /// (`invalid_grant`, a revoked/expired refresh token, a bad client). The
+    /// stored refresh token is dead; the user must re-authenticate.
+    Terminal,
+    /// A passing condition — a network error, request timeout, HTTP 429, or a
+    /// 5xx from the provider. The stored refresh token is still valid and a
+    /// later retry will succeed.
+    Transient,
+}
+
+/// A classified token-endpoint error. It is threaded into the `anyhow` chain
+/// (via `?`/`.context`) so the sync loop can tell "re-authenticate" from "try
+/// again later" without string-matching messages — see [`is_transient`].
+#[derive(Debug)]
+pub struct TokenError {
+    pub failure: TokenFailure,
+    detail: String,
+}
+
+impl TokenError {
+    fn transient(detail: impl Into<String>) -> Self {
+        Self {
+            failure: TokenFailure::Transient,
+            detail: detail.into(),
+        }
+    }
+    fn terminal(detail: impl Into<String>) -> Self {
+        Self {
+            failure: TokenFailure::Terminal,
+            detail: detail.into(),
+        }
+    }
+    fn is_transient(&self) -> bool {
+        matches!(self.failure, TokenFailure::Transient)
+    }
+}
+
+impl std::fmt::Display for TokenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.detail)
+    }
+}
+
+impl std::error::Error for TokenError {}
+
+/// Whether an `anyhow` error from the OAuth flow was a *transient* token-endpoint
+/// failure (retryable — network/timeout/429/5xx) rather than a dead grant.
+/// Walks the whole error chain, so it still finds the [`TokenError`] under the
+/// `.context()` layers `refresh`/`ensure_fresh` add. Defaults to `false` when no
+/// `TokenError` is present, so an unclassified failure still surfaces the
+/// re-authenticate remedy rather than being silently swallowed.
+pub fn is_transient(err: &anyhow::Error) -> bool {
+    err.chain()
+        .find_map(|cause| cause.downcast_ref::<TokenError>())
+        .is_some_and(TokenError::is_transient)
+}
+
 /// How long to wait for the user to complete the browser consent before giving up.
 const CONSENT_TIMEOUT: Duration = Duration::from_secs(300);
 
@@ -101,7 +163,7 @@ pub async fn refresh(
         "refresh_token": refresh_token,
     });
     with_client_secret(&mut body, spec);
-    post_token(spec.token_url, &body)
+    post_token_retrying(spec.token_url, &body)
         .await
         .context("refreshing OAuth access token")
 }
@@ -153,7 +215,7 @@ async fn exchange_code(
         "code_verifier": verifier,
     });
     with_client_secret(&mut body, spec);
-    post_token(spec.token_url, &body)
+    post_token_retrying(spec.token_url, &body)
         .await
         .context("exchanging authorization code for tokens")
 }
@@ -168,23 +230,84 @@ fn with_client_secret(body: &mut serde_json::Value, spec: &ProviderSpec) {
     }
 }
 
-async fn post_token(token_url: &str, body: &serde_json::Value) -> Result<TokenResponse> {
+/// Total tries [`post_token_retrying`] gives the token endpoint before it gives
+/// up on a *transient* failure. Three attempts across ~1.6 s of backoff ride out
+/// the momentary network blips and provider 5xx/429s that otherwise surfaced a
+/// spurious "re-authenticate" sync error on the very next 30-min poll. A dead
+/// grant (4xx) still fails on the first try — retries are spent only on failures
+/// that can actually clear.
+const TOKEN_POST_ATTEMPTS: usize = 3;
+
+/// [`post_token`] with bounded retry-with-backoff for transient failures. Only
+/// [`TokenFailure::Transient`] errors are retried; a terminal rejection returns
+/// immediately so a genuinely dead token isn't hidden behind seconds of backoff.
+async fn post_token_retrying(
+    token_url: &str,
+    body: &serde_json::Value,
+) -> Result<TokenResponse, TokenError> {
+    let mut backoff = Duration::from_millis(400);
+    for attempt in 1..=TOKEN_POST_ATTEMPTS {
+        match post_token(token_url, body).await {
+            Ok(resp) => return Ok(resp),
+            Err(e) if e.is_transient() && attempt < TOKEN_POST_ATTEMPTS => {
+                tracing::warn!(
+                    attempt,
+                    max = TOKEN_POST_ATTEMPTS,
+                    error = %e,
+                    "OAuth token endpoint transient failure — retrying after backoff"
+                );
+                tokio::time::sleep(backoff).await;
+                backoff *= 3; // 400ms → 1200ms
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    // The `attempt < TOKEN_POST_ATTEMPTS` guard means the final attempt always
+    // takes a return arm above.
+    unreachable!("post_token_retrying loop returns on the last attempt")
+}
+
+/// POST a grant to the token endpoint once and classify any failure as transient
+/// or terminal (see [`TokenError`]). The 8 s timeout is per attempt; [`post_token_retrying`]
+/// wraps this with backoff.
+async fn post_token(
+    token_url: &str,
+    body: &serde_json::Value,
+) -> Result<TokenResponse, TokenError> {
     let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(6))
-        .build()?;
-    let resp = client
+        .timeout(std::time::Duration::from_secs(8))
+        .build()
+        .map_err(|e| TokenError::transient(format!("building HTTP client: {e}")))?;
+    let resp = match client
         .post(token_url)
         .header("Accept", "application/json")
         .json(body)
         .send()
         .await
-        .with_context(|| format!("POST {token_url}"))?;
+    {
+        Ok(r) => r,
+        // Connect refused, DNS failure, TLS error, or the 8 s timeout — the
+        // endpoint was unreachable, which says nothing about the token's validity.
+        Err(e) => return Err(TokenError::transient(format!("POST {token_url}: {e}"))),
+    };
     let status = resp.status();
     let text = resp.text().await.unwrap_or_default();
     if !status.is_success() {
-        bail!("token endpoint {token_url} → {status}: {text}");
+        let detail = format!("token endpoint {token_url} → {status}: {text}");
+        // 429 (rate limited) and 5xx are the provider briefly faltering — retry.
+        // Every other non-2xx is a real rejection: a 4xx `invalid_grant` / bad
+        // client / revoked-or-rotated refresh token the user must act on.
+        return Err(if status.as_u16() == 429 || status.is_server_error() {
+            TokenError::transient(detail)
+        } else {
+            TokenError::terminal(detail)
+        });
     }
-    serde_json::from_str(&text).with_context(|| format!("parsing token response: {text}"))
+    // A 2xx whose body isn't valid JSON is almost always a proxy or captive-portal
+    // interstitial standing in for the real payload, not a malformed token grant —
+    // treat it as transient so a later retry (off the hostile network) can succeed.
+    serde_json::from_str(&text)
+        .map_err(|e| TokenError::transient(format!("parsing token response: {e}: {text}")))
 }
 
 /// Accept exactly one inbound connection, parse the `GET /callback?...` request
@@ -436,6 +559,26 @@ fn decode(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `is_transient` must find the [`TokenError`] even under the `.context()`
+    /// layers `refresh`/`ensure_fresh` wrap it in — that chain walk is the whole
+    /// point (a top-level-only downcast would miss it and every refresh failure
+    /// would read as terminal again). Terminal errors, and errors carrying no
+    /// `TokenError` at all, must both report `false`.
+    #[test]
+    fn is_transient_classifies_through_context_layers() {
+        let transient = anyhow::Error::new(TokenError::transient("502 bad gateway"))
+            .context("refreshing OAuth access token");
+        assert!(is_transient(&transient));
+
+        let terminal = anyhow::Error::new(TokenError::terminal("invalid_grant"))
+            .context("refreshing OAuth access token");
+        assert!(!is_transient(&terminal));
+
+        // No TokenError in the chain → default to terminal (surface the remedy).
+        let unclassified = anyhow::anyhow!("disk error").context("loading token store");
+        assert!(!is_transient(&unclassified));
+    }
 
     fn spec() -> ProviderSpec {
         ProviderSpec {

--- a/meridian-oauth/src/lib.rs
+++ b/meridian-oauth/src/lib.rs
@@ -31,6 +31,11 @@ pub mod pkce;
 pub mod store;
 pub mod trello;
 
+/// Classify whether an OAuth failure was a transient (retryable) token-endpoint
+/// blip rather than a dead grant — so the sync loop keeps quiet on a network
+/// hiccup instead of nagging the user to re-authenticate. See [`flow::TokenError`].
+pub use flow::is_transient;
+
 /// Serialises tests that mutate process-global env vars (`HOME`,
 /// `GITHUB_OAUTH_CLIENT_ID`, …). `cargo test` runs tests in parallel and POSIX
 /// `setenv` is process-wide (and not thread-safe), so without this two

--- a/src/health/jira.rs
+++ b/src/health/jira.rs
@@ -68,6 +68,18 @@ async fn auth_basic(base: &str, email: &str, token: &str) -> Check {
 async fn auth_oauth() -> Check {
     let tokens = match oauth_jira::ensure_fresh().await {
         Ok(t) => t,
+        // A transient refresh failure (network/timeout/429/5xx) is not a dead
+        // token — reporting it as critical "re-run oauth-login" is the same
+        // false alarm the sync path used to raise. Downgrade to a warn; only a
+        // terminal failure tells the user to re-authenticate.
+        Err(e) if meridian_oauth::is_transient(&e) => {
+            return Check::warn(
+                "auth",
+                "L2",
+                format!("OAuth token refresh unreachable ({e})"),
+            )
+            .with_remedy("transient — check network; the daemon retries automatically")
+        }
         Err(e) => {
             return Check::critical("auth", "L2", format!("OAuth token refresh failed ({e})"))
                 .with_remedy("re-run `meridian oauth-login jira`")

--- a/src/intelligence/providers/jira/mod.rs
+++ b/src/intelligence/providers/jira/mod.rs
@@ -460,6 +460,21 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
     let ctx = match crate::intelligence::oauth::jira::resolve(jira).await {
         Ok(ctx) => ctx,
         Err(e) => {
+            // A refresh that failed only because Atlassian was briefly
+            // unreachable (network blip, timeout, 429, 5xx) does NOT mean the
+            // token is dead — the stored refresh token is still valid and the
+            // next tick will almost certainly succeed. Raising a "Reconnect
+            // Jira / re-run oauth-login" sync error for that transient case is
+            // exactly what made this fault flap on and off at random. Keep the
+            // stale cache and stay quiet; the notice is reserved for a terminal
+            // auth failure the user actually has to act on.
+            if meridian_oauth::is_transient(&e) {
+                tracing::warn!(
+                    error = %e,
+                    "jira auth temporarily unavailable — keeping stale cache, will retry next sync"
+                );
+                return Ok(None);
+            }
             tracing::warn!(error = %e, "jira auth unavailable — keeping stale cache");
             let msg = format!("Jira auth failed — {e}");
             // Basic-auth (JIRA_API_TOKEN/JIRA_BASE_URL) and OAuth are mutually


### PR DESCRIPTION
## Problem

The `Sync failed: Jira auth failed - re-run `meridian oauth-login jira`` notice pops up at random, then clears itself on the next sync. It is not a dead token - it is a **transient refresh failure treated as fatal**.

`meridian-oauth::flow::post_token` (the OAuth access-token refresh) used a tight **6s timeout** and treated **every** non-2xx status and network error as fatal, **with no retry**. So a momentary network blip or an Atlassian `429`/`5xx` at the ~30-min refresh tick surfaced a scary `Reconnect Jira` sync error - which then vanished on the next successful poll. Classic flap.

## Fix

- **Classify** token-endpoint failures (`TokenError` / `TokenFailure`): network / timeout / `429` / `5xx` => **Transient** (refresh token still valid); a real `4xx` (`invalid_grant`, revoked/rotated, bad client) => **Terminal** (user must re-auth). Carried in the `anyhow` chain so callers classify via `meridian_oauth::is_transient` without string-matching.
- **Retry transient failures** 3x with backoff (400ms -> 1200ms); per-attempt timeout 6s -> 8s. A dead grant still fails on the first try - no backoff wasted.
- **Only surface the re-auth notice for terminal failures**: the sync path (`providers/jira`) keeps the stale cache and stays quiet on a transient blip instead of raising the `Reconnect Jira` notice; the health check downgrades transient from *critical* to *warn*.

## Test / verification

- New unit test `is_transient_classifies_through_context_layers` (chain-walk through `.context()` layers).
- `cargo test -p meridian-oauth` green; daemon `cargo check` + `cargo clippy -D warnings` clean.
- Full pre-push suite (fmt / UI build / clippy / ui tests / audit / cargo test) passed.

Files: `meridian-oauth/src/flow.rs`, `meridian-oauth/src/lib.rs`, `src/intelligence/providers/jira/mod.rs`, `src/health/jira.rs`.

Generated with [Claude Code](https://claude.com/claude-code)