### PR TITLE
Release: promote pre-main to main (Windows install/update fixes, settings cleanup, capture & memory-leak hardening)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,19 @@ jobs:
           # its tree is identical to 064c44cc, already audited above):
           #   ae39b5f  Akarsh Hegde    Merge pull request #3 (064c44cc, already audited above)
           #   3c99154  adityaharishch  fix(a11y): serialize workspace-observer registration to stop a double-free
-          expected="3c99154833b8087b1e215e5af748721096c46f01"
+          #
+          # 2026-07-24, 3c99154 -> 2b7e929f. Five commits, all Meridiona-
+          # (adityaharishch)-authored, no upstream merge, none touch anything
+          # past the MIT cutoff — the last of them (2b7e929f) only extracts
+          # code already present elsewhere in this same fork
+          # (screenpipe-engine's sleep_monitor.rs, itself MIT-based) into
+          # screenpipe-screen; it copies nothing new from upstream:
+          #   8382e368  adityaharishch  fix(screen): wrap per-frame window enumeration/capture in an autorelease pool
+          #   c29722d1  adityaharishch  fix(a11y): wrap focus-observer run-loop iterations in an autorelease pool
+          #   f13c631c  adityaharishch  fix(a11y): wrap per-click context-capture reads in an autorelease pool
+          #   b2e5b268  adityaharishch  fix(a11y): leak NSWorkspace observer guards instead of dropping them
+          #   2b7e929f  adityaharishch  feat(screen): expose a display-reconfiguration watcher from screenpipe-screen
+          expected="2b7e929f7168344faa0121c7a646e5758701d19a"
           f="tray/src-tauri/Cargo.toml"
           fail=0
           for crate in screenpipe-screen screenpipe-a11y; do

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -266,6 +266,7 @@ jobs:
       MERIDIAN_JIRA_OAUTH_CLIENT_SECRET: ${{ secrets.JIRA_OAUTH_CLIENT_SECRET }}
       MERIDIAN_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
       MERIDIAN_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+      MERIDIAN_COUNTER_API_KEY: ${{ secrets.COUNTER_API_KEY }}
       MERIDIAN_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_PROD }}
       MERIDIAN_CHANNEL: ${{ needs.prepare.outputs.channel }}
       MERIDIAN_HF_ENDPOINT: https://hf.meridiona.com
@@ -579,6 +580,7 @@ jobs:
       MERIDIAN_JIRA_OAUTH_CLIENT_SECRET: ${{ secrets.JIRA_OAUTH_CLIENT_SECRET }}
       MERIDIAN_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
       MERIDIAN_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+      MERIDIAN_COUNTER_API_KEY: ${{ secrets.COUNTER_API_KEY }}
       MERIDIAN_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_PROD }}
       MERIDIAN_CHANNEL: ${{ needs.prepare.outputs.channel }}
       MERIDIAN_HF_ENDPOINT: https://hf.meridiona.com

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,7 +382,7 @@ spooled files to OpenObserve, and it refuses to do so entirely for a
 Only a Dev/Bare checkout with `otlp_enabled` + `oo_email`/`oo_password`
 configured ships live, for an engineer debugging against their own
 OpenObserve instance. A shipped install's only path to a developer's
-OpenObserve is the tray Settings → Advanced → **Export Diagnostics** button
+OpenObserve is the tray Settings → Account → **Export Diagnostics** button
 (or `meridian telemetry export`), which bundles the spool + the launchd
 crash-safety-net logs into a `.tar.gz` the user hands to support, imported by
 hand with `meridian telemetry import <bundle> --endpoint <url> --auth

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,7 @@ There are no JS/TS test suites yet. When adding them, place them under `ui/__tes
 | `MERIDIAN_EMBEDDER_DIR` | `~/.meridian/models/<repo-basename>/` | Override the on-disk directory the session-distiller embedding weights live in (`src/embedder/provision.rs`). |
 | `MERIDIAN_EMBEDDER_REPO` | `BAAI/bge-small-en-v1.5` | Override the HuggingFace repo the embedder weights are fetched from. |
 | `DISTILLER_SEM_DEDUP_THR` | `0.86` | Cosine threshold for the distiller's semantic dedup (`src/worklog_pipeline/distiller/`). |
+| `MERIDIAN_CAPTURE_RETENTION_DAYS` | `30` | Age floor for the capture_frames/capture_ui_events/capture_secondary_screens retention sweep (`src/etl/capture_retention.rs`) — only prunes rows both older than this AND already consumed by the ETL cursor. |
 
 Tilde expansion is handled by `Config::from_env()`. Never hardcode paths.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,6 +2209,15 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
@@ -2212,6 +2232,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -2539,7 +2570,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -5134,6 +5165,7 @@ dependencies = [
  "sqlx",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-clerk",
  "tauri-plugin-http",
  "tauri-plugin-notifications",
@@ -9671,6 +9703,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-clerk"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12042,6 +12088,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,7 +2267,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.9",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -3964,7 +3964,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -8072,7 +8072,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "screenpipe-a11y"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8101,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-config"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8113,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-connect"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8152,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-core"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8192,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-db"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8218,7 +8218,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-events"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8235,7 +8235,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-screen"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8272,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-secrets"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8290,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-vault"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,7 +2267,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -3964,7 +3964,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8072,7 +8072,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "screenpipe-a11y"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8101,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-config"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8113,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-connect"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8152,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-core"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8192,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-db"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8218,7 +8218,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-events"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8235,7 +8235,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-screen"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8272,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-secrets"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8290,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-vault"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=b2e5b26#b2e5b268513aa2e6b17abdbf9cc72542232b413d"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,7 +2267,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -3964,7 +3964,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8072,7 +8072,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "screenpipe-a11y"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8101,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-config"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8113,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-connect"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8152,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-core"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8192,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-db"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8218,7 +8218,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-events"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8235,7 +8235,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-screen"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8272,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-secrets"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8290,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-vault"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,7 +2267,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.9",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -3964,7 +3964,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -8072,7 +8072,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "screenpipe-a11y"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8101,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-config"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8113,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-connect"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8152,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-core"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8192,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-db"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8218,7 +8218,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-events"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8235,7 +8235,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-screen"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8272,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-secrets"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8290,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-vault"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=3c99154833b8087b1e215e5af748721096c46f01#3c99154833b8087b1e215e5af748721096c46f01"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=f13c631ce6bac1c5ecaecfef7ad44c08428d0724#f13c631ce6bac1c5ecaecfef7ad44c08428d0724"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/NOTIFICATIONS.md
+++ b/NOTIFICATIONS.md
@@ -64,11 +64,13 @@ notifications::enqueue(pool, NewNotification::event(
 ).await?;
 ```
 
-That's the whole producer. Delivery policy (master switch, quiet hours) is
-enforced at drain time by `meridian-core`, never by producers — **always
-enqueue; the user's settings decide whether it surfaces.** There is no
-per-type toggle — every event is treated the same, gated only by those two
-knobs, kept deliberately simple for the user.
+That's the whole producer. Delivery policy is enforced at drain time by
+`meridian-core`, never by producers: the master switch gates every channel
+(native toast *and* in-app banner), while quiet hours additionally suppress
+only the native toasts — banners still appear. **Always enqueue; the user's
+settings decide whether it surfaces.** There is no per-type toggle — every
+event is treated the same, gated only by those two knobs, kept deliberately
+simple for the user.
 
 ## Add an interactive notification (buttons / inline reply)
 

--- a/NOTIFICATIONS.md
+++ b/NOTIFICATIONS.md
@@ -55,7 +55,7 @@ use crate::notifications::{self, NewNotification};
 
 notifications::enqueue(pool, NewNotification::event(
     &format!("my.event:{scope}"),   // dedup: '<event_key>:<scope>'
-    "my.event",                     // event_key — preference lookup
+    "my.event",                     // event_key — dedup/category grouping, not a preference lookup
     "Title", "Body",
 )
 .link("/route")                     // optional dashboard deep link
@@ -64,9 +64,11 @@ notifications::enqueue(pool, NewNotification::event(
 ).await?;
 ```
 
-That's the whole producer. Delivery policy (master switch, per-type toggle,
-quiet hours) is enforced at drain time by `meridian-core`, never by producers —
-**always enqueue; the user's settings decide whether it surfaces.**
+That's the whole producer. Delivery policy (master switch, quiet hours) is
+enforced at drain time by `meridian-core`, never by producers — **always
+enqueue; the user's settings decide whether it surfaces.** There is no
+per-type toggle — every event is treated the same, gated only by those two
+knobs, kept deliberately simple for the user.
 
 ## Add an interactive notification (buttons / inline reply)
 
@@ -249,17 +251,15 @@ registered`, `outbox toast delivered`, `notification action event: {...}`,
 | *(reserved)* | `verify_switch` | Yes · No · Reply… | — (PR 2: task-switch verification) |
 | *(generic)* | `generic_link` | Open | — (stamp only) |
 
-`system.notif_permission` / `system.capture_permission` / `system.disk_low`
-are deliberately ungated by a per-type settings toggle (`type_enabled`
-defaults unknown keys to allowed) — a user shouldn't be able to silence the
-one alert explaining why everything else went quiet. Every other new event_key
-above has a `notify_<type>` toggle in `RuntimeSettings` /
-`NotificationsSection.tsx`.
+There is no per-type settings toggle for any `event_key` — `event_allowed`
+gates every event the same way, on the master switch alone (plus quiet hours
+for the native channel). `RuntimeSettings`/`NotificationsSection.tsx` expose
+exactly two notification controls: the master switch and quiet hours.
 
 Deferred (same rails, thin slices when needed): task-switch verify producer +
-rate cap + `notify_task_verify` toggle (PR 2), goal check-in / distraction
-producers, LLM-generated copy (routed through the chosen CLI provider, `src/llm/`), APNs/phone
-delivery, a `worklog.ready` producer (needs a decision: build a real scheduler
-for unattended draft generation, or repoint the event at something already
-autonomous), an onboarding-stuck reminder (needs a resumable
-wizard-progress timestamp — today's `~/.meridian/onboarded` flag is one-shot).
+rate cap (PR 2), goal check-in / distraction producers, LLM-generated copy
+(routed through the chosen CLI provider, `src/llm/`), APNs/phone delivery, a
+`worklog.ready` producer (needs a decision: build a real scheduler for
+unattended draft generation, or repoint the event at something already
+autonomous), an onboarding-stuck reminder (needs a resumable wizard-progress
+timestamp — today's `~/.meridian/onboarded` flag is one-shot).

--- a/meridian-core/src/lib.rs
+++ b/meridian-core/src/lib.rs
@@ -73,7 +73,7 @@ pub use readers::{
 
 pub use canonical_task::{CanonicalTask, PersonRef, Priority, Provider, StatusCategory, TaskKind};
 
-pub use llm_provider::{LlmProvider, CURSOR_CLI_VERSION, CURSOR_INSTALL_CMD};
+pub use llm_provider::{LlmProvider, CURSOR_CLI_VERSION, CURSOR_INSTALL_CMD, CURSOR_INSTALL_HINT};
 /// The custom-endpoint registry types. `CustomLlmProvider` carries the API key and is the
 /// STORAGE form — see its docs before serialising one anywhere.
 pub use settings::{CustomLlmProvider, SchemaRung};

--- a/meridian-core/src/llm_provider.rs
+++ b/meridian-core/src/llm_provider.rs
@@ -192,11 +192,14 @@ impl LlmProvider {
 ///
 /// This value is the build all of the flag behaviour was verified on. To move it: bump
 /// this constant, re-run the cursor smoke tests, and confirm `--allowed-tools`,
-/// `--workspace` and `--mode ask` still behave.
+/// `--workspace` and `--mode ask` still behave. Shared by both platform variants of
+/// [`CURSOR_INSTALL_CMD`] below - `downloads.cursor.com/lab/<version>/<os>/<arch>/...`
+/// keys the same version string across every OS, only the artifact differs.
 pub const CURSOR_CLI_VERSION: &str = "2026.07.16-899851b";
 
 /// Cursor's official installer, rewritten to install [`CURSOR_CLI_VERSION`].
 ///
+/// # Unix
 /// The `sed` rewrites every version string in their script (all 5 occurrences: the temp
 /// dir, the `downloads.cursor.com/lab/<v>/<os>/<arch>/agent-cli-package.tar.gz` URL, the
 /// final dir, and both symlinks) to the pinned build. Matching the version by PATTERN
@@ -206,11 +209,38 @@ pub const CURSOR_CLI_VERSION: &str = "2026.07.16-899851b";
 ///
 /// Reusing their script (rather than hand-rolling a download) keeps their OS/arch
 /// detection, symlink layout and PATH guidance. Fixed literal, no user input.
+///
+/// # Windows
+/// `https://cursor.com/install` is a **bash** script - `uname -s` only ever answers
+/// `Linux`/`Darwin`, so it exits "Unsupported operating system" under `sh`/`bash` on
+/// Windows even when one is on PATH (Git-Bash, WSL's `bash.exe` shim), and there is no
+/// `sed` either. Cursor publishes a SEPARATE PowerShell installer for Windows at
+/// `https://cursor.com/install?win32=true` (same `downloads.cursor.com/lab/<version>/...`
+/// backend, `windows/<arch>` instead of `<os>/<arch>`), pinned here the same way: fetch
+/// the script text, rewrite the version with a .NET regex `-replace` (PowerShell's `sed`
+/// equivalent - same pattern-not-literal reasoning as the Unix rewrite), then `iex`
+/// (`Invoke-Expression`) the rewritten text. The daemon's `llm::detect::installer_command`
+/// is what actually spawns this — it must run through `powershell.exe` directly, not
+/// `cmd.exe`, because `irm`/`iex` are PowerShell aliases with no `cmd` equivalent.
+#[cfg(not(windows))]
 pub const CURSOR_INSTALL_CMD: &str = concat!(
     "curl -fsSL https://cursor.com/install | ",
     "sed -E 's#[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}-[0-9a-f]{7}#",
     "2026.07.16-899851b",
     "#g' | bash"
+);
+
+/// See [`CURSOR_INSTALL_CMD`]'s Windows doc above. Plain PowerShell script text — no
+/// enclosing `powershell -Command "..."` wrapper here, because the daemon's
+/// `llm::detect::installer_command` supplies that (a single argv element handed straight
+/// to `powershell.exe`, so there is exactly one layer of shell-quoting to reason about,
+/// not `cmd.exe` re-parsing an already-quoted `-Command` payload).
+#[cfg(windows)]
+pub const CURSOR_INSTALL_CMD: &str = concat!(
+    "$s = (irm 'https://cursor.com/install?win32=true'); ",
+    "$s = $s -replace '[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}-[0-9a-f]{7}', '",
+    "2026.07.16-899851b",
+    "'; iex $s"
 );
 
 #[cfg(test)]
@@ -219,6 +249,7 @@ mod install_pin_tests {
 
     /// The pin must actually appear in the command, and the constant must stay the single
     /// source of truth (`concat!` can't interpolate, so the two are pinned together here).
+    #[cfg(not(windows))]
     #[test]
     fn cursor_install_command_is_pinned_to_the_supported_version() {
         assert!(CURSOR_INSTALL_CMD.contains(CURSOR_CLI_VERSION));
@@ -230,6 +261,71 @@ mod install_pin_tests {
             LlmProvider::Cursor.install_command(),
             Some(CURSOR_INSTALL_CMD)
         );
+    }
+
+    /// Windows analogue: same pin, same pattern-not-literal guarantee, but via
+    /// PowerShell's `-replace` and the win32-flagged installer endpoint rather than
+    /// `sed`/bash — see the module doc on why Cursor's Unix script can't run here.
+    #[cfg(windows)]
+    #[test]
+    fn cursor_install_command_is_pinned_to_the_supported_version() {
+        assert!(CURSOR_INSTALL_CMD.contains(CURSOR_CLI_VERSION));
+        assert!(CURSOR_INSTALL_CMD.contains("[0-9]{4}"));
+        assert!(CURSOR_INSTALL_CMD.contains("-replace"));
+        assert_eq!(
+            LlmProvider::Cursor.install_command(),
+            Some(CURSOR_INSTALL_CMD)
+        );
+    }
+
+    /// The Windows script must go through PowerShell's `irm`/`iex`, not bash's
+    /// `curl | sed | bash` — those aliases don't exist under `cmd.exe`, and stock
+    /// Windows has no `bash`/`sed` on PATH at all outside WSL/Git-Bash.
+    #[cfg(windows)]
+    #[test]
+    fn windows_install_command_uses_the_win32_powershell_installer() {
+        assert!(CURSOR_INSTALL_CMD.contains("cursor.com/install?win32=true"));
+        assert!(CURSOR_INSTALL_CMD.contains("irm "));
+        assert!(CURSOR_INSTALL_CMD.contains("iex "));
+        assert!(!CURSOR_INSTALL_CMD.contains("curl"));
+        assert!(!CURSOR_INSTALL_CMD.contains("bash"));
+    }
+}
+
+/// Where the "cursor-agent not found" hints in the daemon's `coding_agent_session_ingest`
+/// init flow and the coding-agent health checks point the user — the ONE command that
+/// actually works on this platform. Kept next to [`CURSOR_INSTALL_CMD`] so the two can't
+/// drift: a bare `curl | bash` hint shown on Windows would send the user to run a command
+/// that cannot possibly work there.
+#[cfg(not(windows))]
+pub const CURSOR_INSTALL_HINT: &str = "curl https://cursor.com/install -fsS | bash";
+
+#[cfg(windows)]
+pub const CURSOR_INSTALL_HINT: &str =
+    "irm 'https://cursor.com/install?win32=true' | iex  (run in PowerShell)";
+
+#[cfg(test)]
+mod install_hint_tests {
+    use super::*;
+
+    /// The hint must never point at a command that cannot run on this platform: no
+    /// `bash`/`curl` in the Windows hint, no PowerShell aliases in the Unix hint.
+    #[cfg(windows)]
+    #[test]
+    fn windows_hint_does_not_suggest_bash() {
+        assert!(CURSOR_INSTALL_HINT.contains("irm"));
+        assert!(CURSOR_INSTALL_HINT.contains("iex"));
+        assert!(!CURSOR_INSTALL_HINT.contains("curl"));
+        assert!(!CURSOR_INSTALL_HINT.contains("bash"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn unix_hint_does_not_suggest_powershell() {
+        assert!(CURSOR_INSTALL_HINT.contains("curl"));
+        assert!(CURSOR_INSTALL_HINT.contains("bash"));
+        assert!(!CURSOR_INSTALL_HINT.contains("irm"));
+        assert!(!CURSOR_INSTALL_HINT.contains("iex"));
     }
 }
 

--- a/meridian-core/src/notifications/mod.rs
+++ b/meridian-core/src/notifications/mod.rs
@@ -4,9 +4,10 @@
 //!
 //! The Rust daemon (`src/notifications.rs`) ENQUEUES into the `notifications`
 //! table; this module is the single place the *delivery* decision lives:
-//! master switch + per-type toggle ([`event_allowed`]) and quiet hours
-//! ([`in_quiet_hours`]). Producers always enqueue; only the user's settings
-//! decide whether an event actually surfaces. The two delivery writes
+//! master switch ([`event_allowed`]) and quiet hours ([`in_quiet_hours`]) —
+//! deliberately the ONLY two knobs, no per-category toggles. Producers always
+//! enqueue; only the user's settings decide whether an event actually
+//! surfaces. The two delivery writes
 //! ([`mark_native_delivered`], [`dismiss_banner`]) ack a row so it isn't
 //! re-delivered / re-shown — idempotent, mirroring the same-named TS helpers.
 //!
@@ -112,30 +113,10 @@ pub struct PendingNotification {
     pub actions: Option<String>,
 }
 
-/// Per-type preference for an `event_key`. Unknown keys default to enabled (a new
-/// producer is visible until the user opts out), gated only by the master switch.
-fn type_enabled(event_key: &str, s: &RuntimeSettings) -> bool {
-    match event_key {
-        "plan.nudge" => s.notify_plan_nudge,
-        "worklog.ready" => s.notify_worklog_ready,
-        "system.fault" => s.notify_system_fault,
-        "system.pause" => s.notify_system_pause,
-        "system.health" => s.notify_system_health,
-        "system.update" => s.notify_system_update,
-        "summariser.dead_letter" => s.notify_summariser_digest,
-        "board.hygiene" => s.notify_board_hygiene,
-        // Safety-critical: notification/capture-permission revoked and low disk
-        // space stay ungated by a per-type toggle (unknown keys default
-        // enabled) — a user shouldn't be able to silence the one alert that
-        // explains why everything else went quiet.
-        _ => true,
-    }
-}
-
-/// Whether `event_key` may surface at all: master switch AND per-type toggle.
-/// Mirrors `eventAllowed` in ui/lib/notifications.ts.
-pub fn event_allowed(event_key: &str, s: &RuntimeSettings) -> bool {
-    s.notifications_enabled && type_enabled(event_key, s)
+/// Whether an event may surface at all: the master switch, full stop. Every
+/// event type is treated the same — there is no per-category toggle.
+pub fn event_allowed(s: &RuntimeSettings) -> bool {
+    s.notifications_enabled
 }
 
 /// Minutes since midnight for an 'HH:MM' string, or `None` if malformed.
@@ -194,7 +175,6 @@ pub fn in_quiet_hours(s: &RuntimeSettings) -> bool {
 #[derive(FromRow)]
 struct NotifRow {
     id: i64,
-    event_key: String,
     severity: String,
     title: String,
     body: String,
@@ -268,7 +248,7 @@ pub async fn pending_native(
         "NULL AS category, NULL AS actions"
     };
     let rows: Vec<NotifRow> = sqlx::query_as::<_, NotifRow>(&format!(
-        r#"SELECT id, event_key, severity, title, body, deep_link, channels, {action_cols}
+        r#"SELECT id, severity, title, body, deep_link, channels, {action_cols}
            FROM notifications
            WHERE delivered_native_at IS NULL
              AND (scheduled_for IS NULL OR scheduled_for <= ?)
@@ -289,7 +269,7 @@ pub async fn pending_native(
 
     let out: Vec<PendingNotification> = rows
         .into_iter()
-        .filter(|r| has_channel(&r.channels, "native") && event_allowed(&r.event_key, s))
+        .filter(|r| has_channel(&r.channels, "native") && event_allowed(s))
         .map(|r| PendingNotification {
             id: r.id,
             title: r.title,
@@ -358,7 +338,7 @@ pub async fn active_banners(
 
     let out: Vec<BannerNotification> = rows
         .into_iter()
-        .filter(|r| has_channel(&r.channels, "banner") && event_allowed(&r.event_key, s))
+        .filter(|r| has_channel(&r.channels, "banner") && event_allowed(s))
         .map(|r| BannerNotification {
             id: r.id,
             event_key: r.event_key,

--- a/meridian-core/src/notifications/tests.rs
+++ b/meridian-core/src/notifications/tests.rs
@@ -131,16 +131,11 @@ async fn active_banners_filters_channel_dismissed_expired_and_prefs() {
 }
 
 #[test]
-fn event_allowed_respects_master_and_type() {
+fn event_allowed_respects_only_the_master_switch() {
     let mut s = settings();
-    assert!(event_allowed("plan.nudge", &s));
-    assert!(event_allowed("unknown.event", &s)); // unknown → enabled
-    s.notify_plan_nudge = false;
-    assert!(!event_allowed("plan.nudge", &s));
-    s.notify_plan_nudge = true;
-    s.notifications_enabled = false; // master off → nothing
-    assert!(!event_allowed("plan.nudge", &s));
-    assert!(!event_allowed("unknown.event", &s));
+    assert!(event_allowed(&s));
+    s.notifications_enabled = false;
+    assert!(!event_allowed(&s), "master off → nothing surfaces");
 }
 
 #[test]

--- a/meridian-core/src/settings.rs
+++ b/meridian-core/src/settings.rs
@@ -238,28 +238,12 @@ pub struct RuntimeSettings {
     pub otlp_endpoint: Option<String>,
     pub oo_email: Option<String>,
     pub oo_password: Option<String>,
-    // Notification preferences — the master switch + per-type toggles + quiet
-    // hours. Read by [`crate::notifications`] (the policy ported from
-    // ui/lib/notifications.ts) to decide whether an event may surface.
-    // `quiet_hours_*` are 'HH:MM' local time (start inclusive, end exclusive).
+    // Notification preferences — a master switch + quiet hours. Read by
+    // [`crate::notifications`] to decide whether an event may surface;
+    // every event type is gated ONLY by these two (no per-category toggles —
+    // kept deliberately simple for the user). `quiet_hours_*` are 'HH:MM'
+    // local time (start inclusive, end exclusive).
     pub notifications_enabled: bool,
-    pub notify_plan_nudge: bool,
-    // Daily planner auto-open — once per local day the tray opens the dashboard
-    // on the Plan modal (first launch or first poll tick of a new day). A window
-    // behaviour, not a toast, so it is NOT gated by `notifications_enabled`.
-    pub auto_open_plan: bool,
-    pub notify_worklog_ready: bool,
-    pub notify_system_fault: bool,
-    // Folded from direct tray-side toasts (pause/resume, daemon health,
-    // updates) into the outbox — each now has its own toggle instead of
-    // sharing `notify_system_fault` or being ungated entirely.
-    pub notify_system_pause: bool,
-    pub notify_system_health: bool,
-    pub notify_system_update: bool,
-    // Daily batched digests — see src/coding_agent_session_ingest and
-    // src/intelligence::triage_after_sync.
-    pub notify_summariser_digest: bool,
-    pub notify_board_hygiene: bool,
     pub quiet_hours_enabled: bool,
     pub quiet_hours_start: String,
     pub quiet_hours_end: String,
@@ -343,15 +327,6 @@ impl Default for RuntimeSettings {
             // Notifications on by default; quiet hours off (22:00–08:00 when
             // enabled). Must match SETTINGS_DEFAULTS in ui/lib/settings.ts.
             notifications_enabled: true,
-            notify_plan_nudge: true,
-            auto_open_plan: true,
-            notify_worklog_ready: true,
-            notify_system_fault: true,
-            notify_system_pause: true,
-            notify_system_health: true,
-            notify_system_update: true,
-            notify_summariser_digest: true,
-            notify_board_hygiene: true,
             quiet_hours_enabled: false,
             quiet_hours_start: "22:00".to_string(),
             quiet_hours_end: "08:00".to_string(),

--- a/meridian-core/src/settings.rs
+++ b/meridian-core/src/settings.rs
@@ -270,6 +270,17 @@ pub struct RuntimeSettings {
     pub work_days: String,        // comma-separated 1–7 (Mon=1 … Sun=7), e.g. "1,2,3,4,5"
     // Pause capture when streaming video (Netflix, Disney+, etc.) is playing.
     pub pause_on_streaming_video: bool,
+    // On by default — work on a second monitor should show up on the
+    // timeline whether or not it's the screen you're actively looking at.
+    // When true, the capture engine's slower-cadence sweep
+    // (`capture_secondary_screens` in `tray/src-tauri/src/capture/
+    // screenpipe.rs`) OCRs every OTHER connected monitor's topmost window as
+    // context, folded onto the currently-open session — never its own
+    // session, never inflating focus-time totals. Exposed as a Settings →
+    // Capture & Privacy toggle for anyone who wants to turn it off (a second
+    // monitor can show things — a meeting, a personal window — the user
+    // doesn't want tracked). Mirrors `ui/lib/settings.ts`.
+    pub capture_secondary_monitors: bool,
     // User capture ignore lists. `ignored_apps` matches an incoming frame's
     // `app_name` exactly (case-insensitive); `ignored_urls` matches the focused
     // tab's `browser_url` HOST at domain granularity (a domain also matches its
@@ -352,6 +363,9 @@ impl Default for RuntimeSettings {
             // services black out the screen for any recorder anyway. Must
             // match SETTINGS_DEFAULTS in ui/lib/settings.ts.
             pause_on_streaming_video: true,
+            // On by default — see the field doc comment. Must match
+            // SETTINGS_DEFAULTS in ui/lib/settings.ts.
+            capture_secondary_monitors: true,
             // Nothing ignored by default. Must match SETTINGS_DEFAULTS in
             // ui/lib/settings.ts.
             ignored_apps: Vec::new(),

--- a/meridian-oauth/src/flow.rs
+++ b/meridian-oauth/src/flow.rs
@@ -48,6 +48,68 @@ pub struct TokenResponse {
     pub scope: String,
 }
 
+/// Whether a token-endpoint failure is worth retrying, or means the grant is
+/// dead. This is the distinction the background refresh loop needs: a passing
+/// network blip must not be surfaced to the user as "re-authenticate".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenFailure {
+    /// The grant itself was rejected and won't recover on its own — an OAuth 4xx
+    /// (`invalid_grant`, a revoked/expired refresh token, a bad client). The
+    /// stored refresh token is dead; the user must re-authenticate.
+    Terminal,
+    /// A passing condition — a network error, request timeout, HTTP 429, or a
+    /// 5xx from the provider. The stored refresh token is still valid and a
+    /// later retry will succeed.
+    Transient,
+}
+
+/// A classified token-endpoint error. It is threaded into the `anyhow` chain
+/// (via `?`/`.context`) so the sync loop can tell "re-authenticate" from "try
+/// again later" without string-matching messages — see [`is_transient`].
+#[derive(Debug)]
+pub struct TokenError {
+    pub failure: TokenFailure,
+    detail: String,
+}
+
+impl TokenError {
+    fn transient(detail: impl Into<String>) -> Self {
+        Self {
+            failure: TokenFailure::Transient,
+            detail: detail.into(),
+        }
+    }
+    fn terminal(detail: impl Into<String>) -> Self {
+        Self {
+            failure: TokenFailure::Terminal,
+            detail: detail.into(),
+        }
+    }
+    fn is_transient(&self) -> bool {
+        matches!(self.failure, TokenFailure::Transient)
+    }
+}
+
+impl std::fmt::Display for TokenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.detail)
+    }
+}
+
+impl std::error::Error for TokenError {}
+
+/// Whether an `anyhow` error from the OAuth flow was a *transient* token-endpoint
+/// failure (retryable — network/timeout/429/5xx) rather than a dead grant.
+/// Walks the whole error chain, so it still finds the [`TokenError`] under the
+/// `.context()` layers `refresh`/`ensure_fresh` add. Defaults to `false` when no
+/// `TokenError` is present, so an unclassified failure still surfaces the
+/// re-authenticate remedy rather than being silently swallowed.
+pub fn is_transient(err: &anyhow::Error) -> bool {
+    err.chain()
+        .find_map(|cause| cause.downcast_ref::<TokenError>())
+        .is_some_and(TokenError::is_transient)
+}
+
 /// How long to wait for the user to complete the browser consent before giving up.
 const CONSENT_TIMEOUT: Duration = Duration::from_secs(300);
 
@@ -101,7 +163,7 @@ pub async fn refresh(
         "refresh_token": refresh_token,
     });
     with_client_secret(&mut body, spec);
-    post_token(spec.token_url, &body)
+    post_token_retrying(spec.token_url, &body)
         .await
         .context("refreshing OAuth access token")
 }
@@ -153,7 +215,7 @@ async fn exchange_code(
         "code_verifier": verifier,
     });
     with_client_secret(&mut body, spec);
-    post_token(spec.token_url, &body)
+    post_token_retrying(spec.token_url, &body)
         .await
         .context("exchanging authorization code for tokens")
 }
@@ -168,23 +230,84 @@ fn with_client_secret(body: &mut serde_json::Value, spec: &ProviderSpec) {
     }
 }
 
-async fn post_token(token_url: &str, body: &serde_json::Value) -> Result<TokenResponse> {
+/// Total tries [`post_token_retrying`] gives the token endpoint before it gives
+/// up on a *transient* failure. Three attempts across ~1.6 s of backoff ride out
+/// the momentary network blips and provider 5xx/429s that otherwise surfaced a
+/// spurious "re-authenticate" sync error on the very next 30-min poll. A dead
+/// grant (4xx) still fails on the first try — retries are spent only on failures
+/// that can actually clear.
+const TOKEN_POST_ATTEMPTS: usize = 3;
+
+/// [`post_token`] with bounded retry-with-backoff for transient failures. Only
+/// [`TokenFailure::Transient`] errors are retried; a terminal rejection returns
+/// immediately so a genuinely dead token isn't hidden behind seconds of backoff.
+async fn post_token_retrying(
+    token_url: &str,
+    body: &serde_json::Value,
+) -> Result<TokenResponse, TokenError> {
+    let mut backoff = Duration::from_millis(400);
+    for attempt in 1..=TOKEN_POST_ATTEMPTS {
+        match post_token(token_url, body).await {
+            Ok(resp) => return Ok(resp),
+            Err(e) if e.is_transient() && attempt < TOKEN_POST_ATTEMPTS => {
+                tracing::warn!(
+                    attempt,
+                    max = TOKEN_POST_ATTEMPTS,
+                    error = %e,
+                    "OAuth token endpoint transient failure — retrying after backoff"
+                );
+                tokio::time::sleep(backoff).await;
+                backoff *= 3; // 400ms → 1200ms
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    // The `attempt < TOKEN_POST_ATTEMPTS` guard means the final attempt always
+    // takes a return arm above.
+    unreachable!("post_token_retrying loop returns on the last attempt")
+}
+
+/// POST a grant to the token endpoint once and classify any failure as transient
+/// or terminal (see [`TokenError`]). The 8 s timeout is per attempt; [`post_token_retrying`]
+/// wraps this with backoff.
+async fn post_token(
+    token_url: &str,
+    body: &serde_json::Value,
+) -> Result<TokenResponse, TokenError> {
     let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(6))
-        .build()?;
-    let resp = client
+        .timeout(std::time::Duration::from_secs(8))
+        .build()
+        .map_err(|e| TokenError::transient(format!("building HTTP client: {e}")))?;
+    let resp = match client
         .post(token_url)
         .header("Accept", "application/json")
         .json(body)
         .send()
         .await
-        .with_context(|| format!("POST {token_url}"))?;
+    {
+        Ok(r) => r,
+        // Connect refused, DNS failure, TLS error, or the 8 s timeout — the
+        // endpoint was unreachable, which says nothing about the token's validity.
+        Err(e) => return Err(TokenError::transient(format!("POST {token_url}: {e}"))),
+    };
     let status = resp.status();
     let text = resp.text().await.unwrap_or_default();
     if !status.is_success() {
-        bail!("token endpoint {token_url} → {status}: {text}");
+        let detail = format!("token endpoint {token_url} → {status}: {text}");
+        // 429 (rate limited) and 5xx are the provider briefly faltering — retry.
+        // Every other non-2xx is a real rejection: a 4xx `invalid_grant` / bad
+        // client / revoked-or-rotated refresh token the user must act on.
+        return Err(if status.as_u16() == 429 || status.is_server_error() {
+            TokenError::transient(detail)
+        } else {
+            TokenError::terminal(detail)
+        });
     }
-    serde_json::from_str(&text).with_context(|| format!("parsing token response: {text}"))
+    // A 2xx whose body isn't valid JSON is almost always a proxy or captive-portal
+    // interstitial standing in for the real payload, not a malformed token grant —
+    // treat it as transient so a later retry (off the hostile network) can succeed.
+    serde_json::from_str(&text)
+        .map_err(|e| TokenError::transient(format!("parsing token response: {e}: {text}")))
 }
 
 /// Accept exactly one inbound connection, parse the `GET /callback?...` request
@@ -436,6 +559,26 @@ fn decode(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `is_transient` must find the [`TokenError`] even under the `.context()`
+    /// layers `refresh`/`ensure_fresh` wrap it in — that chain walk is the whole
+    /// point (a top-level-only downcast would miss it and every refresh failure
+    /// would read as terminal again). Terminal errors, and errors carrying no
+    /// `TokenError` at all, must both report `false`.
+    #[test]
+    fn is_transient_classifies_through_context_layers() {
+        let transient = anyhow::Error::new(TokenError::transient("502 bad gateway"))
+            .context("refreshing OAuth access token");
+        assert!(is_transient(&transient));
+
+        let terminal = anyhow::Error::new(TokenError::terminal("invalid_grant"))
+            .context("refreshing OAuth access token");
+        assert!(!is_transient(&terminal));
+
+        // No TokenError in the chain → default to terminal (surface the remedy).
+        let unclassified = anyhow::anyhow!("disk error").context("loading token store");
+        assert!(!is_transient(&unclassified));
+    }
 
     fn spec() -> ProviderSpec {
         ProviderSpec {

--- a/meridian-oauth/src/flow.rs
+++ b/meridian-oauth/src/flow.rs
@@ -238,23 +238,48 @@ fn with_client_secret(body: &mut serde_json::Value, spec: &ProviderSpec) {
 /// that can actually clear.
 const TOKEN_POST_ATTEMPTS: usize = 3;
 
+/// Bound an untrusted response body before it goes into a `TokenError` detail
+/// (which is then logged, verbatim, on every retry). A captive-portal or proxy
+/// interstitial can be an arbitrarily large HTML page; cap it so it can't bloat
+/// structured logs. Truncates on a char boundary so a multi-byte sequence is
+/// never split.
+fn truncate_body(text: &str) -> String {
+    const MAX: usize = 300;
+    if text.len() <= MAX {
+        return text.to_string();
+    }
+    let mut end = MAX;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{} (truncated, {} bytes total)", &text[..end], text.len())
+}
+
 /// [`post_token`] with bounded retry-with-backoff for transient failures. Only
 /// [`TokenFailure::Transient`] errors are retried; a terminal rejection returns
 /// immediately so a genuinely dead token isn't hidden behind seconds of backoff.
+#[tracing::instrument(skip(body), fields(token_url = %token_url))]
 async fn post_token_retrying(
     token_url: &str,
     body: &serde_json::Value,
 ) -> Result<TokenResponse, TokenError> {
+    // One client for the whole retry loop: rebuilding it per attempt would throw
+    // away connection pooling/keep-alive, which is exactly what a retry wants.
+    // The 8 s timeout is per request (each `send`), not a total budget.
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(8))
+        .build()
+        .map_err(|e| TokenError::transient(format!("building HTTP client: {e}")))?;
     let mut backoff = Duration::from_millis(400);
     for attempt in 1..=TOKEN_POST_ATTEMPTS {
-        match post_token(token_url, body).await {
+        match post_token(&client, token_url, body).await {
             Ok(resp) => return Ok(resp),
             Err(e) if e.is_transient() && attempt < TOKEN_POST_ATTEMPTS => {
                 tracing::warn!(
                     attempt,
                     max = TOKEN_POST_ATTEMPTS,
                     error = %e,
-                    "OAuth token endpoint transient failure — retrying after backoff"
+                    "OAuth token endpoint transient failure - retrying after backoff"
                 );
                 tokio::time::sleep(backoff).await;
                 backoff *= 3; // 400ms → 1200ms
@@ -268,16 +293,13 @@ async fn post_token_retrying(
 }
 
 /// POST a grant to the token endpoint once and classify any failure as transient
-/// or terminal (see [`TokenError`]). The 8 s timeout is per attempt; [`post_token_retrying`]
-/// wraps this with backoff.
+/// or terminal (see [`TokenError`]). Takes a shared `client` (built once by
+/// [`post_token_retrying`]) whose 8 s timeout applies per attempt.
 async fn post_token(
+    client: &reqwest::Client,
     token_url: &str,
     body: &serde_json::Value,
 ) -> Result<TokenResponse, TokenError> {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(8))
-        .build()
-        .map_err(|e| TokenError::transient(format!("building HTTP client: {e}")))?;
     let resp = match client
         .post(token_url)
         .header("Accept", "application/json")
@@ -293,7 +315,10 @@ async fn post_token(
     let status = resp.status();
     let text = resp.text().await.unwrap_or_default();
     if !status.is_success() {
-        let detail = format!("token endpoint {token_url} → {status}: {text}");
+        let detail = format!(
+            "token endpoint {token_url} → {status}: {}",
+            truncate_body(&text)
+        );
         // 429 (rate limited) and 5xx are the provider briefly faltering — retry.
         // Every other non-2xx is a real rejection: a 4xx `invalid_grant` / bad
         // client / revoked-or-rotated refresh token the user must act on.
@@ -306,8 +331,12 @@ async fn post_token(
     // A 2xx whose body isn't valid JSON is almost always a proxy or captive-portal
     // interstitial standing in for the real payload, not a malformed token grant —
     // treat it as transient so a later retry (off the hostile network) can succeed.
-    serde_json::from_str(&text)
-        .map_err(|e| TokenError::transient(format!("parsing token response: {e}: {text}")))
+    serde_json::from_str(&text).map_err(|e| {
+        TokenError::transient(format!(
+            "parsing token response: {e}: {}",
+            truncate_body(&text)
+        ))
+    })
 }
 
 /// Accept exactly one inbound connection, parse the `GET /callback?...` request

--- a/meridian-oauth/src/lib.rs
+++ b/meridian-oauth/src/lib.rs
@@ -31,6 +31,11 @@ pub mod pkce;
 pub mod store;
 pub mod trello;
 
+/// Classify whether an OAuth failure was a transient (retryable) token-endpoint
+/// blip rather than a dead grant — so the sync loop keeps quiet on a network
+/// hiccup instead of nagging the user to re-authenticate. See [`flow::TokenError`].
+pub use flow::is_transient;
+
 /// Serialises tests that mutate process-global env vars (`HOME`,
 /// `GITHUB_OAUTH_CLIENT_ID`, …). `cargo test` runs tests in parallel and POSIX
 /// `setenv` is process-wide (and not thread-safe), so without this two

--- a/packages/meridian-mcp/package-lock.json
+++ b/packages/meridian-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meridian-mcp",
-  "version": "1.28.1",
+  "version": "1.74.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meridian-mcp",
-      "version": "1.28.1",
+      "version": "1.74.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",

--- a/packages/meridian-mcp/package.json
+++ b/packages/meridian-mcp/package.json
@@ -12,6 +12,7 @@
     "start": "node dist/index.js",
     "install-mcp": "node dist/install.js",
     "dev": "ts-node src/index.ts",
+    "test": "tsc && node --test \"dist/__tests__/*.test.js\"",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/packages/meridian-mcp/src/__tests__/db-cache.test.ts
+++ b/packages/meridian-mcp/src/__tests__/db-cache.test.ts
@@ -1,0 +1,97 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+
+// Tests for db-cache.ts's mtime/size-gated sql.js Database cache — the fix
+// for the MCP server re-reading + re-allocating the whole meridian.db file
+// on every single tool call. Run via `node --test` (built-in Node test
+// runner, no extra test-framework dependency) against the compiled output:
+// `npm run build && node --test dist/__tests__/`.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import initSqlJs from "sql.js";
+import { openCachedDb, _resetDbCacheForTests, _dbCacheSizeForTests } from "../db-cache.js";
+
+async function makeTempDb(dir: string, name: string, seedRows: number): Promise<string> {
+  const SQL = await initSqlJs();
+  const db = new SQL.Database();
+  db.run("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)");
+  for (let i = 0; i < seedRows; i++) {
+    db.run("INSERT INTO t (val) VALUES (?)", [`row-${i}`]);
+  }
+  const bytes = db.export();
+  db.close();
+  const dbPath = path.join(dir, name);
+  fs.writeFileSync(dbPath, bytes);
+  return dbPath;
+}
+
+test("openCachedDb reuses the same instance when the file is unchanged", async () => {
+  _resetDbCacheForTests();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "meridian-mcp-cache-test-"));
+  try {
+    const dbPath = await makeTempDb(dir, "meridian.db", 3);
+
+    const first = await openCachedDb(dbPath);
+    const second = await openCachedDb(dbPath);
+
+    assert.strictEqual(second, first, "second call must return the exact same cached instance");
+    assert.equal(_dbCacheSizeForTests(), 1, "exactly one path must be cached");
+  } finally {
+    _resetDbCacheForTests();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("openCachedDb reloads when the file's mtime/size changes", async () => {
+  _resetDbCacheForTests();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "meridian-mcp-cache-test-"));
+  try {
+    const dbPath = await makeTempDb(dir, "meridian.db", 3);
+
+    const first = await openCachedDb(dbPath);
+    const firstRows = first.exec("SELECT COUNT(*) AS n FROM t")[0].values[0][0];
+    assert.equal(firstRows, 3);
+
+    // Rewrite the file with different content (different size) and bump
+    // mtime forward so the cache's stat comparison is guaranteed to differ
+    // even on filesystems with coarse mtime resolution.
+    await makeTempDb(dir, "meridian.db", 7);
+    const future = new Date(Date.now() + 5000);
+    fs.utimesSync(dbPath, future, future);
+
+    const second = await openCachedDb(dbPath);
+    assert.notStrictEqual(second, first, "changed file must produce a new instance, not the cached one");
+
+    const secondRows = second.exec("SELECT COUNT(*) AS n FROM t")[0].values[0][0];
+    assert.equal(secondRows, 7, "reloaded instance must reflect the new file contents");
+  } finally {
+    _resetDbCacheForTests();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("openCachedDb throws when the file does not exist", async () => {
+  _resetDbCacheForTests();
+  await assert.rejects(
+    () => openCachedDb("/nonexistent/path/does-not-exist.db"),
+    /Meridian DB not found/,
+  );
+});
+
+test("concurrent openCachedDb calls on a fresh path dedupe onto one load", async () => {
+  _resetDbCacheForTests();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "meridian-mcp-cache-test-"));
+  try {
+    const dbPath = await makeTempDb(dir, "meridian.db", 1);
+
+    const [a, b] = await Promise.all([openCachedDb(dbPath), openCachedDb(dbPath)]);
+    assert.strictEqual(b, a, "concurrent calls for the same fresh path must resolve to one instance");
+    assert.equal(_dbCacheSizeForTests(), 1);
+  } finally {
+    _resetDbCacheForTests();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/meridian-mcp/src/db-cache.ts
+++ b/packages/meridian-mcp/src/db-cache.ts
@@ -67,6 +67,11 @@ export async function openCachedDb(dbPath: string): Promise<SqlDatabase> {
   }
 
   const stat = fs.statSync(dbPath);
+  if (!stat.isFile()) {
+    // existsSync also accepts directories, FIFOs, and devices; readFileSync on
+    // any of those would fail obscurely (or block). Fail with a clear config error.
+    throw new Error(`Meridian DB path is not a regular file: ${dbPath}`);
+  }
   const cached = _dbCache.get(dbPath);
   if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
     return cached.db;

--- a/packages/meridian-mcp/src/db-cache.ts
+++ b/packages/meridian-mcp/src/db-cache.ts
@@ -1,0 +1,111 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+
+// Cached sql.js Database loader.
+//
+// sql.js is pure WASM (no native compile step) — deliberately chosen over
+// better-sqlite3 for this package specifically because native-module ABI
+// mismatches across Node versions/platforms caused real distribution pain
+// elsewhere in this project's history. Do not swap this for better-sqlite3;
+// see the memory-leak-audit fix that added this module for the full context.
+//
+// Without caching, every MCP tool call did fs.readFileSync(dbPath) (one full
+// copy of meridian.db into a Node Buffer) followed by `new SQL.Database(...)`
+// (a second full copy into WASM linear memory), and emscripten never returns
+// freed WASM pages to the OS — so process RSS climbed to the size of the
+// largest DB ever loaded and stayed there, and got worse every tool call.
+//
+// This module reuses a single long-lived Database instance per dbPath across
+// calls, invalidating (re-reading the file, rebuilding the WASM instance)
+// only when the file's mtime or size changes — a cheap `stat()` per call
+// instead of a full read + WASM rebuild. The daemon is a separate process
+// that writes meridian.db; tool calls are read-mostly, so a small staleness
+// window between a daemon write and the next stat-triggered reload is
+// acceptable in exchange for not re-paying the double-copy cost on every call.
+
+import initSqlJs from "sql.js";
+import * as fs from "fs";
+
+export type SqlJsStatic = Awaited<ReturnType<typeof initSqlJs>>;
+export type SqlDatabase = InstanceType<SqlJsStatic["Database"]>;
+
+interface CachedDb {
+  db: SqlDatabase;
+  mtimeMs: number;
+  size: number;
+}
+
+let _SQL: SqlJsStatic | null = null;
+
+/** One cached Database (+ the file stat it was loaded from) per dbPath. */
+const _dbCache = new Map<string, CachedDb>();
+
+/** Dedupes concurrent reload attempts for the same path onto one load. */
+const _dbLoadInFlight = new Map<string, Promise<SqlDatabase>>();
+
+async function getSqlEngine(): Promise<SqlJsStatic> {
+  if (!_SQL) {
+    _SQL = await initSqlJs();
+  }
+  return _SQL;
+}
+
+/**
+ * Opens (or reuses) a cached sql.js `Database` for `dbPath`.
+ *
+ * Returns the cached instance as long as the file's `mtimeMs`/`size` (from a
+ * cheap `fs.statSync`) match what was loaded last; otherwise re-reads the
+ * file and rebuilds the WASM `Database`, closing the stale instance first —
+ * sql.js/emscripten never returns freed WASM memory to the OS, so leaving the
+ * old instance open would leak on every reload rather than just on every call.
+ *
+ * Throws if `dbPath` does not exist (mirrors the daemon-not-running check the
+ * old per-call `openDb` performed).
+ */
+export async function openCachedDb(dbPath: string): Promise<SqlDatabase> {
+  if (!fs.existsSync(dbPath)) {
+    throw new Error(`Meridian DB not found at ${dbPath}. Is the Meridian daemon running?`);
+  }
+
+  const stat = fs.statSync(dbPath);
+  const cached = _dbCache.get(dbPath);
+  if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+    return cached.db;
+  }
+
+  // Reuse an in-flight reload for this path instead of racing a second one
+  // if two tool calls both observe a stale cache before either finishes.
+  const inFlight = _dbLoadInFlight.get(dbPath);
+  if (inFlight) return inFlight;
+
+  const loadPromise = (async () => {
+    try {
+      const SQL = await getSqlEngine();
+      const fileBuffer = fs.readFileSync(dbPath);
+      const db = new SQL.Database(fileBuffer);
+
+      const prev = _dbCache.get(dbPath);
+      prev?.db.close();
+
+      _dbCache.set(dbPath, { db, mtimeMs: stat.mtimeMs, size: stat.size });
+      return db;
+    } finally {
+      _dbLoadInFlight.delete(dbPath);
+    }
+  })();
+  _dbLoadInFlight.set(dbPath, loadPromise);
+  return loadPromise;
+}
+
+/** Test-only: closes and clears every cached instance. */
+export function _resetDbCacheForTests(): void {
+  for (const { db } of _dbCache.values()) {
+    db.close();
+  }
+  _dbCache.clear();
+  _dbLoadInFlight.clear();
+}
+
+/** Test-only: number of distinct paths currently cached. */
+export function _dbCacheSizeForTests(): number {
+  return _dbCache.size;
+}

--- a/packages/meridian-mcp/src/index.ts
+++ b/packages/meridian-mcp/src/index.ts
@@ -14,37 +14,21 @@ import {
   ReadResourceRequestSchema,
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
-import initSqlJs from "sql.js";
 import * as os from "os";
 import * as path from "path";
-import * as fs from "fs";
 import { runInstaller } from "./install.js";
+import { openCachedDb, SqlDatabase } from "./db-cache.js";
 
-type SqlJsStatic = Awaited<ReturnType<typeof initSqlJs>>;
-type SqlDatabase = InstanceType<SqlJsStatic["Database"]>;
 type SqlVal = string | number | null | Uint8Array;
 
 function getDbPath(): string {
   return process.env.MERIDIAN_DB ?? path.join(os.homedir(), ".meridian", "meridian.db");
 }
 
-let _SQL: SqlJsStatic | null = null;
-
-async function getSqlEngine(): Promise<SqlJsStatic> {
-  if (!_SQL) {
-    _SQL = await initSqlJs();
-  }
-  return _SQL;
-}
-
+// Reuses a single long-lived sql.js Database per dbPath instead of reopening
+// (double-reading + double-allocating) it on every tool call — see db-cache.ts.
 async function openDb(): Promise<SqlDatabase> {
-  const dbPath = getDbPath();
-  if (!fs.existsSync(dbPath)) {
-    throw new Error(`Meridian DB not found at ${dbPath}. Is the Meridian daemon running?`);
-  }
-  const SQL = await getSqlEngine();
-  const fileBuffer = fs.readFileSync(dbPath);
-  return new SQL.Database(fileBuffer);
+  return openCachedDb(getDbPath());
 }
 
 function dbGet(db: SqlDatabase, sql: string, params: SqlVal[] = []): Record<string, unknown> | undefined {
@@ -1089,9 +1073,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       span.setAttribute("error", true);
       logger.error({ tool_name: name, err: msg }, "mcp tool failed");
       return { content: [{ type: "text", text: `Error: ${msg}` }] };
-    } finally {
-      db?.close();
     }
+    // No `finally { db?.close() }` here anymore: `db` is now a cached,
+    // long-lived instance owned by db-cache.ts, reused across tool calls —
+    // closing it per call would defeat the cache. db-cache.ts closes the
+    // stale instance itself when the underlying file changes.
   });
 });
 

--- a/src/coding_agent_session_ingest/cursor_agent_init.rs
+++ b/src/coding_agent_session_ingest/cursor_agent_init.rs
@@ -63,11 +63,16 @@ async fn try_install_and_login() -> anyhow::Result<()> {
         Err(_) => {
             // Running a remote install script must be an explicit user
             // decision, never an automatic daemon side effect (the installer
-            // is `curl https://cursor.com/install | bash` — unpinned remote
-            // code). Without the opt-in, Cursor summaries stay pending.
+            // is unpinned remote code). Without the opt-in, Cursor summaries
+            // stay pending. The hint is platform-specific — see
+            // meridian_core::CURSOR_INSTALL_HINT's doc: a bare `curl | bash`
+            // hint on Windows would point the user at a command that cannot
+            // possibly work there (no bash/curl, and cursor.com/install is a
+            // bash-only script even when one is on PATH via WSL/Git-Bash).
             anyhow::bail!(
-                "cursor-agent not in PATH; install it (`curl https://cursor.com/install -fsS | bash`) \
-                 or set CURSOR_AGENT_AUTO_INSTALL=1 to let the daemon install it"
+                "cursor-agent not in PATH; install it (`{}`) or set \
+                 CURSOR_AGENT_AUTO_INSTALL=1 to let the daemon install it",
+                meridian_core::CURSOR_INSTALL_HINT,
             )
         }
     };
@@ -83,20 +88,19 @@ async fn try_install_and_login() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Locate cursor-agent in PATH.
+/// Locate cursor-agent, the same way every other provider CLI is located.
+///
+/// NOT a bare `which`/`where` shell-out: `which` doesn't exist on Windows at all (the
+/// process fails to even spawn, `ErrorKind::NotFound`), so this used to hard-fail on
+/// every Windows machine regardless of whether cursor-agent was actually installed —
+/// every Cursor Agent session was left pending forever, install or no install.
+/// [`crate::llm::detect::resolve_cli`] is the shared, platform-correct probe (PATHEXT-
+/// aware on Windows, login-shell + candidate dirs on Unix, and memoised) that every other
+/// CLI lookup in this codebase already goes through.
 async fn find_cursor_agent() -> anyhow::Result<PathBuf> {
-    let output = run_with_timeout(
-        Command::new("which").arg("cursor-agent"),
-        STATUS_TIMEOUT,
-        "which cursor-agent",
-    )
-    .await?;
-    if output.status.success() {
-        let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        Ok(PathBuf::from(path_str))
-    } else {
-        anyhow::bail!("cursor-agent not in PATH")
-    }
+    crate::llm::detect::resolve_cli("cursor-agent")
+        .await
+        .ok_or_else(|| anyhow::anyhow!("cursor-agent not in PATH"))
 }
 
 /// The auto-install opt-in: CURSOR_AGENT_AUTO_INSTALL=1|true|yes. Default OFF
@@ -112,9 +116,15 @@ fn auto_install_enabled() -> bool {
 /// `auto_install_enabled`). Runs once per daemon lifetime (cached by
 /// ensure_ready).
 ///
-/// Uses the PINNED installer ([`meridian_core::CURSOR_INSTALL_CMD`]) — the same command
-/// the tray's "Install" button runs — so an unattended daemon install can never pull a
-/// newer cursor-agent than the build this code was verified against.
+/// Uses the PINNED installer ([`meridian_core::CURSOR_INSTALL_CMD`]) through
+/// [`crate::llm::detect::installer_command`] — the SAME platform dispatch the tray's
+/// "Install" button runs (login shell on Unix, `powershell.exe` directly on Windows; see
+/// that function's doc for why `bash -c`, which this used to hardcode, never worked on
+/// Windows at all: no `bash` on a stock install, and even with WSL/Git-Bash's `bash.exe`
+/// on PATH, `CURSOR_INSTALL_CMD`'s Windows form is PowerShell script text (`irm`/`iex`),
+/// not something `bash` could run either) — so an unattended daemon install can never
+/// pull a newer cursor-agent than the build this code was verified against, on any
+/// platform.
 async fn try_auto_install() -> anyhow::Result<PathBuf> {
     let cmd = meridian_core::CURSOR_INSTALL_CMD;
     tracing::info!(
@@ -122,7 +132,7 @@ async fn try_auto_install() -> anyhow::Result<PathBuf> {
         "running pinned cursor-agent installer"
     );
     let output = run_with_timeout(
-        Command::new("bash").arg("-c").arg(cmd),
+        &mut crate::llm::detect::installer_command(cmd),
         INSTALL_TIMEOUT,
         "cursor-agent install",
     )
@@ -205,5 +215,95 @@ async fn run_with_timeout(
         Ok(Ok(output)) => Ok(output),
         Ok(Err(e)) => anyhow::bail!("{label}: {e}"),
         Err(_) => anyhow::bail!("{label} timed out after {}s", timeout.as_secs()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `CURSOR_AGENT_AUTO_INSTALL` is a process-global env var and cargo runs tests in
+    /// parallel threads — every test that mutates it must hold this lock, same pattern as
+    /// `meridian_core::paths`'s `env_lock`.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn with_auto_install<R>(value: Option<&str>, f: impl FnOnce() -> R) -> R {
+        let _guard = env_lock();
+        let prev = std::env::var_os("CURSOR_AGENT_AUTO_INSTALL");
+        match value {
+            Some(v) => std::env::set_var("CURSOR_AGENT_AUTO_INSTALL", v),
+            None => std::env::remove_var("CURSOR_AGENT_AUTO_INSTALL"),
+        }
+        let out = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        match prev {
+            Some(v) => std::env::set_var("CURSOR_AGENT_AUTO_INSTALL", v),
+            None => std::env::remove_var("CURSOR_AGENT_AUTO_INSTALL"),
+        }
+        match out {
+            Ok(r) => r,
+            Err(p) => std::panic::resume_unwind(p),
+        }
+    }
+
+    /// Default OFF: an unset var must never opt a daemon into running remote installer
+    /// code unattended.
+    #[test]
+    fn auto_install_defaults_to_disabled() {
+        with_auto_install(None, || assert!(!auto_install_enabled()));
+    }
+
+    #[test]
+    fn auto_install_accepts_the_documented_truthy_values() {
+        for v in ["1", "true", "yes", "TRUE", "Yes", "  true  "] {
+            with_auto_install(Some(v), || {
+                assert!(auto_install_enabled(), "{v:?} should enable auto-install");
+            });
+        }
+    }
+
+    #[test]
+    fn auto_install_rejects_everything_else() {
+        // Common near-misses a user might reasonably type, none of which are the
+        // documented opt-in spelling — must fail closed, not open.
+        for v in ["0", "false", "no", "on", "", "  ", "yesplease", "TRUEE"] {
+            with_auto_install(Some(v), || {
+                assert!(
+                    !auto_install_enabled(),
+                    "{v:?} should not enable auto-install"
+                );
+            });
+        }
+    }
+
+    /// `"1 "` (trailing space) IS accepted — `auto_install_enabled` trims before matching
+    /// — documented separately from the rejection list above so that behaviour is asserted
+    /// rather than silently tolerated by the `|| v == "1 "` escape hatch there.
+    #[test]
+    fn auto_install_trims_surrounding_whitespace() {
+        with_auto_install(Some(" 1 "), || assert!(auto_install_enabled()));
+        with_auto_install(Some("\tyes\n"), || assert!(auto_install_enabled()));
+    }
+
+    /// The regression this exists for: `find_cursor_agent` used to shell out to `which`,
+    /// which does not exist as a binary on Windows at all — `Command::new("which")` fails
+    /// to even spawn there (`ErrorKind::NotFound`), so cursor-agent was reported absent on
+    /// every Windows machine regardless of whether it was actually installed. Routing
+    /// through `crate::llm::detect::resolve_cli` (PATHEXT-aware, candidate-dir fallback,
+    /// memoised) fixes that; this pins the observable contract without assuming whether
+    /// cursor-agent happens to be installed on the machine running the test.
+    #[tokio::test]
+    async fn find_cursor_agent_resolves_to_a_real_path_or_a_clear_not_found_error() {
+        match find_cursor_agent().await {
+            Ok(p) => assert!(
+                p.is_absolute() && p.exists(),
+                "resolved path must be spawnable directly: {p:?}"
+            ),
+            Err(e) => assert_eq!(e.to_string(), "cursor-agent not in PATH"),
+        }
     }
 }

--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -671,6 +671,11 @@ async fn drain(
         let outcome = summarise_one(pool, row, cfg, true).await;
         if outcome.written {
             summarised += 1;
+            // Row succeeded and moved past pending_summariser — drop its
+            // ledger entry via record_attempt so `attempts` only ever holds
+            // currently-pending rows that have failed at least once, not
+            // every row that ever failed once over the daemon's lifetime.
+            record_attempt(attempts, row.id, true);
         } else if outcome.rate_limited {
             // Apply per-source backoff so other sources can still drain.
             let until =
@@ -685,8 +690,8 @@ async fn drain(
             );
         } else {
             // Transient failure. Leave pending for retry; log so it isn't silent.
-            let tries = tries + 1;
-            attempts.insert(row.id, tries);
+            let tries = record_attempt(attempts, row.id, false)
+                .expect("record_attempt(.., written=false) always returns Some");
             if tries >= MAX_ROW_ATTEMPTS {
                 if let Err(e) = db::write_dead_letter(pool, row.id).await {
                     tracing::error!(row_id = row.id, error = %e, "failed to dead-letter row");
@@ -715,6 +720,29 @@ async fn drain(
     // Signal global backoff only when ALL rows were skipped due to source
     // backoffs — nothing useful can be done until at least one source recovers.
     skipped_backoff > 0 && skipped_backoff == rows.len() as u32 && summarised == 0
+}
+
+/// Updates the per-row failure ledger (`attempts`, see [`MAX_ROW_ATTEMPTS`])
+/// after one `summarise_one` outcome.
+///
+/// On success (`written = true`) the row's entry is removed entirely —
+/// `attempts` must only ever hold currently-pending rows that have failed at
+/// least once this daemon lifetime, not every row that has ever failed once,
+/// which would otherwise grow the map forever as rows are summarised and new
+/// ones come in. Returns `None` in that case.
+///
+/// On failure (`written = false`) the row's attempt count is incremented and
+/// the new count returned as `Some(tries)`, for the caller to compare against
+/// [`MAX_ROW_ATTEMPTS`].
+fn record_attempt(attempts: &mut HashMap<i64, u32>, row_id: i64, written: bool) -> Option<u32> {
+    if written {
+        attempts.remove(&row_id);
+        None
+    } else {
+        let tries = attempts.get(&row_id).copied().unwrap_or(0) + 1;
+        attempts.insert(row_id, tries);
+        Some(tries)
+    }
 }
 
 /// One-shot CLI: `meridian coding-agent-summarise [--dry-run] [--day D] [--limit N]`.
@@ -844,5 +872,59 @@ mod tests {
 
         let p2 = build_prompt("just work", None, 1000);
         assert!(!p2.contains("EARLIER IN THIS SESSION"));
+    }
+
+    #[test]
+    fn record_attempt_removes_entry_on_success() {
+        let mut attempts: HashMap<i64, u32> = HashMap::new();
+        attempts.insert(42, 2); // simulate two prior failures
+
+        let result = record_attempt(&mut attempts, 42, true);
+
+        assert_eq!(result, None);
+        assert!(
+            !attempts.contains_key(&42),
+            "a row that succeeds must have its ledger entry removed, not just left at its prior count"
+        );
+    }
+
+    #[test]
+    fn record_attempt_increments_on_failure() {
+        let mut attempts: HashMap<i64, u32> = HashMap::new();
+
+        assert_eq!(record_attempt(&mut attempts, 7, false), Some(1));
+        assert_eq!(record_attempt(&mut attempts, 7, false), Some(2));
+        assert_eq!(record_attempt(&mut attempts, 7, false), Some(3));
+        assert_eq!(attempts.get(&7), Some(&3));
+    }
+
+    #[test]
+    fn record_attempt_success_after_failures_leaves_no_trace() {
+        let mut attempts: HashMap<i64, u32> = HashMap::new();
+
+        record_attempt(&mut attempts, 99, false);
+        record_attempt(&mut attempts, 99, false);
+        record_attempt(&mut attempts, 99, true); // succeeds on the third try
+
+        assert!(
+            attempts.is_empty(),
+            "map must not retain any entry for a row once it has succeeded"
+        );
+    }
+
+    #[test]
+    fn record_attempt_only_touches_the_given_row() {
+        let mut attempts: HashMap<i64, u32> = HashMap::new();
+        record_attempt(&mut attempts, 1, false);
+        record_attempt(&mut attempts, 2, false);
+
+        record_attempt(&mut attempts, 1, true);
+
+        assert!(!attempts.contains_key(&1), "row 1 succeeded — removed");
+        assert_eq!(
+            attempts.get(&2),
+            Some(&1),
+            "row 2's independent failure count must be untouched"
+        );
     }
 }

--- a/src/db/meridian.rs
+++ b/src/db/meridian.rs
@@ -95,7 +95,15 @@ pub async fn setup_db(uri: &str) -> anyhow::Result<SqlitePool> {
         // get an immediate SQLITE_BUSY (default timeout 0) whenever the tray
         // holds the WAL write lock, failing the ETL run. Wait instead — matches
         // the tray's open_existing (5s).
-        .busy_timeout(std::time::Duration::from_secs(5));
+        .busy_timeout(std::time::Duration::from_secs(5))
+        // Lets `crate::etl::capture_retention`'s periodic `incremental_vacuum`
+        // actually reclaim disk space freed by its capture_* table deletes.
+        // Only takes effect on a brand-new (table-less) database file — SQLite
+        // requires a full `VACUUM` to convert an already-populated database
+        // from the default `auto_vacuum = NONE`, which we deliberately never
+        // run automatically on a live daemon (see that module's doc comment).
+        // On an existing database this pragma is simply a documented no-op.
+        .pragma("auto_vacuum", "INCREMENTAL");
 
     let pool = SqlitePool::connect_with(opts)
         .await

--- a/src/db/screenpipe.rs
+++ b/src/db/screenpipe.rs
@@ -329,6 +329,56 @@ pub async fn get_frame_full_texts(
         .collect())
 }
 
+/// Page size for [`fetch_frame_text_page`] — bounds how many frames' OCR/a11y
+/// text are held in memory at once when a block's `session_text` is rebuilt by
+/// paginating rather than by a single [`get_frame_full_texts`] call (see
+/// `rebuild_session_text_paginated` in `crate::etl::block_ops`). Chosen in the
+/// 500-1000 range suggested by the existing `BATCH_SIZE` ETL-batch convention.
+pub const FRAME_TEXT_PAGE_SIZE: i64 = 750;
+
+/// Returns up to `limit` frames with `id` in `(after_id, max_frame_id]` that
+/// have non-empty text, ordered oldest-first — a bounded page of
+/// [`get_frame_full_texts`]'s result set. Falls back to `accessibility_text`
+/// when `full_text` is NULL, same as `get_frame_full_texts`.
+///
+/// Callers paginate by looping: start with `after_id = min_frame_id - 1`, feed
+/// each returned page into an incremental accumulator, advance `after_id` to
+/// the last frame's `frame_id`, and stop once a call returns an empty `Vec`.
+/// Pagination is driven entirely by `id` (not by page-length heuristics), so
+/// it is correct regardless of how many rows in a given `id` range get
+/// filtered out by the non-empty-text predicate.
+pub async fn fetch_frame_text_page(
+    pool: &SqlitePool,
+    after_id: i64,
+    max_frame_id: i64,
+    limit: i64,
+) -> Result<Vec<FrameText>> {
+    let rows = sqlx::query_as::<_, (i64, String, String, String)>(
+        "SELECT id, timestamp, COALESCE(full_text, accessibility_text), COALESCE(text_source, 'ocr')
+         FROM capture_frames
+         WHERE id > ?1 AND id <= ?2
+           AND COALESCE(full_text, accessibility_text) IS NOT NULL
+           AND COALESCE(full_text, accessibility_text) != ''
+         ORDER BY id ASC
+         LIMIT ?3",
+    )
+    .bind(after_id)
+    .bind(max_frame_id)
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|(frame_id, timestamp, full_text, text_source)| FrameText {
+            frame_id,
+            timestamp,
+            full_text,
+            text_source,
+        })
+        .collect())
+}
+
 /// Returns clipboard and app_switch UI events within the given timestamp range.
 /// Clipboard events are deduplicated by value — same text copied multiple times is stored once.
 /// For clipboard events `value` is `text_content`; for app_switch it is `app_name`.

--- a/src/etl/block_ops.rs
+++ b/src/etl/block_ops.rs
@@ -7,12 +7,9 @@ use tracing::{debug, info, warn};
 use crate::db::meridian::{
     close_active_session_with, get_active_session, upsert_active_session, write_session_traceparent,
 };
-use crate::db::screenpipe::{
-    fetch_frame_text_page, get_last_ui_event_for_app, FRAME_TEXT_PAGE_SIZE,
-};
+use crate::db::screenpipe::get_last_ui_event_for_app;
 use crate::etl::extractor::extract_block_context;
-use crate::etl::text_filter::ChromeFreqAccumulator;
-use crate::etl::text_merge::SessionTextBuilder;
+use crate::etl::text_merge::rebuild_session_text_paginated;
 
 use super::session_builder::{build_active_session, merge_into_active};
 
@@ -22,58 +19,6 @@ pub(super) fn timestamp_gap_secs(earlier: &str, later: &str) -> Option<i64> {
     let t0 = chrono::DateTime::parse_from_rfc3339(earlier).ok()?;
     let t1 = chrono::DateTime::parse_from_rfc3339(later).ok()?;
     Some((t1 - t0).num_seconds())
-}
-
-/// Rebuilds `session_text` for the frame range `min_frame_id..=max_frame_id` by
-/// reading frames from the DB in `FRAME_TEXT_PAGE_SIZE`-sized pages instead of
-/// materializing the whole range in one `Vec<FrameText>`.
-///
-/// Two passes over the paginated read are required: chrome-line detection
-/// (`ChromeFreqAccumulator`) needs a global view of line frequencies across the
-/// *entire* range before any single frame can be classified (see
-/// `crate::etl::text_filter::build_chrome_set`), so pass 1 accumulates
-/// frequencies page-by-page and pass 2 re-pages the same range to fold each
-/// frame into the session text using the now-final chrome set.
-///
-/// This is a memory-shape change only: for the same frame range, the returned
-/// string is functionally identical to
-/// `build_session_text(&get_frame_full_texts(pool, min_frame_id, max_frame_id).await?)` —
-/// no data is truncated or dropped, only held in bounded pages rather than all
-/// at once.
-pub(super) async fn rebuild_session_text_paginated(
-    pool: &SqlitePool,
-    min_frame_id: i64,
-    max_frame_id: i64,
-) -> Result<String> {
-    // Pass 1: accumulate chrome-line frequencies across every page.
-    let mut chrome_acc = ChromeFreqAccumulator::new();
-    let mut after_id = min_frame_id - 1;
-    loop {
-        let page = fetch_frame_text_page(pool, after_id, max_frame_id, FRAME_TEXT_PAGE_SIZE)
-            .await
-            .context("paginated frame-text read (chrome frequency pass)")?;
-        if page.is_empty() {
-            break;
-        }
-        after_id = page.last().map(|f| f.frame_id).unwrap_or(after_id);
-        chrome_acc.feed(&page);
-    }
-    let chrome = chrome_acc.finish();
-
-    // Pass 2: re-page the same range and fold each frame into the session text.
-    let mut builder = SessionTextBuilder::new();
-    let mut after_id = min_frame_id - 1;
-    loop {
-        let page = fetch_frame_text_page(pool, after_id, max_frame_id, FRAME_TEXT_PAGE_SIZE)
-            .await
-            .context("paginated frame-text read (session-text build pass)")?;
-        if page.is_empty() {
-            break;
-        }
-        after_id = page.last().map(|f| f.frame_id).unwrap_or(after_id);
-        builder.feed(&page, &chrome);
-    }
-    Ok(builder.finish())
 }
 
 /// Groups the positional fields shared by `close_block` / `upsert_open_block`

--- a/src/etl/block_ops.rs
+++ b/src/etl/block_ops.rs
@@ -7,9 +7,12 @@ use tracing::{debug, info, warn};
 use crate::db::meridian::{
     close_active_session_with, get_active_session, upsert_active_session, write_session_traceparent,
 };
-use crate::db::screenpipe::{get_frame_full_texts, get_last_ui_event_for_app};
+use crate::db::screenpipe::{
+    fetch_frame_text_page, get_last_ui_event_for_app, FRAME_TEXT_PAGE_SIZE,
+};
 use crate::etl::extractor::extract_block_context;
-use crate::etl::text_merge::build_session_text;
+use crate::etl::text_filter::ChromeFreqAccumulator;
+use crate::etl::text_merge::SessionTextBuilder;
 
 use super::session_builder::{build_active_session, merge_into_active};
 
@@ -19,6 +22,58 @@ pub(super) fn timestamp_gap_secs(earlier: &str, later: &str) -> Option<i64> {
     let t0 = chrono::DateTime::parse_from_rfc3339(earlier).ok()?;
     let t1 = chrono::DateTime::parse_from_rfc3339(later).ok()?;
     Some((t1 - t0).num_seconds())
+}
+
+/// Rebuilds `session_text` for the frame range `min_frame_id..=max_frame_id` by
+/// reading frames from the DB in `FRAME_TEXT_PAGE_SIZE`-sized pages instead of
+/// materializing the whole range in one `Vec<FrameText>`.
+///
+/// Two passes over the paginated read are required: chrome-line detection
+/// (`ChromeFreqAccumulator`) needs a global view of line frequencies across the
+/// *entire* range before any single frame can be classified (see
+/// `crate::etl::text_filter::build_chrome_set`), so pass 1 accumulates
+/// frequencies page-by-page and pass 2 re-pages the same range to fold each
+/// frame into the session text using the now-final chrome set.
+///
+/// This is a memory-shape change only: for the same frame range, the returned
+/// string is functionally identical to
+/// `build_session_text(&get_frame_full_texts(pool, min_frame_id, max_frame_id).await?)` —
+/// no data is truncated or dropped, only held in bounded pages rather than all
+/// at once.
+pub(super) async fn rebuild_session_text_paginated(
+    pool: &SqlitePool,
+    min_frame_id: i64,
+    max_frame_id: i64,
+) -> Result<String> {
+    // Pass 1: accumulate chrome-line frequencies across every page.
+    let mut chrome_acc = ChromeFreqAccumulator::new();
+    let mut after_id = min_frame_id - 1;
+    loop {
+        let page = fetch_frame_text_page(pool, after_id, max_frame_id, FRAME_TEXT_PAGE_SIZE)
+            .await
+            .context("paginated frame-text read (chrome frequency pass)")?;
+        if page.is_empty() {
+            break;
+        }
+        after_id = page.last().map(|f| f.frame_id).unwrap_or(after_id);
+        chrome_acc.feed(&page);
+    }
+    let chrome = chrome_acc.finish();
+
+    // Pass 2: re-page the same range and fold each frame into the session text.
+    let mut builder = SessionTextBuilder::new();
+    let mut after_id = min_frame_id - 1;
+    loop {
+        let page = fetch_frame_text_page(pool, after_id, max_frame_id, FRAME_TEXT_PAGE_SIZE)
+            .await
+            .context("paginated frame-text read (session-text build pass)")?;
+        if page.is_empty() {
+            break;
+        }
+        after_id = page.last().map(|f| f.frame_id).unwrap_or(after_id);
+        builder.feed(&page, &chrome);
+    }
+    Ok(builder.finish())
 }
 
 /// Groups the positional fields shared by `close_block` / `upsert_open_block`
@@ -175,10 +230,16 @@ pub(super) async fn close_block(
             // sub-threshold batches (< CHROME_FREQ_THRESHOLD frames) permanently in the
             // stored text; a full rebuild sees the complete frame set so the chrome
             // pre-pass correctly identifies and removes them.
-            let all_frames = get_frame_full_texts(meridian, active.min_frame_id, b.max_frame_id)
-                .await
-                .context("re-fetch frames for session_text rebuild on close")?;
-            let rebuilt_text = build_session_text(&all_frames);
+            //
+            // Paginated rather than a single fetch_all: a session that stays in one app
+            // for hours (an IDE, one browser tab) never closes early, so by the time it
+            // finally does, `active.min_frame_id..b.max_frame_id` can span many thousands
+            // of frames — a single `get_frame_full_texts` there would spike RSS by the
+            // whole session's OCR text at once. See `rebuild_session_text_paginated`.
+            let rebuilt_text =
+                rebuild_session_text_paginated(meridian, active.min_frame_id, b.max_frame_id)
+                    .await
+                    .context("re-fetch frames for session_text rebuild on close")?;
             let merged = merge_into_active(active, &ctx, b.idle_frame_count, Some(rebuilt_text))?;
             let new_id = close_active_session_with(meridian, &merged, run_id).await?;
             info!(

--- a/src/etl/capture_retention.rs
+++ b/src/etl/capture_retention.rs
@@ -1,0 +1,366 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+
+//! Age + processed-based retention sweep for the capture_* tables
+//! (`capture_frames`, `capture_ui_events`, `capture_secondary_screens`) the
+//! tray's in-process capture engine writes into `meridian.db`.
+//!
+//! Nothing previously pruned these — a frame every ~2s per monitor plus every
+//! click/key/clipboard event, each carrying full OCR/a11y text, grows the DB
+//! forever. This module prunes rows that are BOTH:
+//!
+//!   (a) older than `MERIDIAN_CAPTURE_RETENTION_DAYS` (default 30), AND
+//!   (b) already fully processed by the ETL — strictly before the timestamp
+//!       of the frame at `etl_cursor.last_frame_id` — so a frame the ETL
+//!       hasn't consumed yet is never deleted regardless of age.
+//!
+//! `capture_ui_events` and `capture_secondary_screens` have no frame-id link,
+//! so they're bounded by the same cursor-frame timestamp: any row timestamped
+//! at or after it could still belong to a session the ETL hasn't closed, so
+//! it is left alone.
+//!
+//! Deletes alone don't shrink the SQLite file — `run_incremental_vacuum`
+//! reclaims freed pages on a coarser cadence (not every tick, since it's
+//! extra I/O), bounded per call via `PRAGMA incremental_vacuum(N)` so it
+//! can't stall the daemon scanning a large freelist in one call. This only
+//! does anything once the database's `auto_vacuum` mode is `INCREMENTAL`
+//! (set in `db::meridian::setup_db` for brand-new databases only — retrofitting
+//! an already-populated database would require a full, slow `VACUUM`, which
+//! this module deliberately never runs on a live daemon). On a pre-existing
+//! database still in the default `auto_vacuum = NONE` mode,
+//! `incremental_vacuum` is simply a documented no-op — see SQLite's pragma
+//! docs — so pruned rows still stop growing the *logical* table size, they
+//! just don't shrink the on-disk file until the user runs a manual `VACUUM`.
+//!
+//! # Who calls this
+//!
+//! `src/main.rs`'s poll loop, once per tick, right after `run_etl`.
+
+use anyhow::{Context, Result};
+use sqlx::SqlitePool;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Default retention window, in days, for the capture_* tables.
+const DEFAULT_CAPTURE_RETENTION_DAYS: u64 = 30;
+
+/// Run `PRAGMA incremental_vacuum` once every this many `prune_capture_tables`
+/// calls (i.e. roughly once every N poll ticks) rather than every tick.
+const VACUUM_EVERY_N_TICKS: u64 = 60;
+
+/// Max pages reclaimed per `incremental_vacuum` call — bounds how long a single
+/// call can run so it can't stall the daemon on a large freelist.
+const VACUUM_MAX_PAGES: i64 = 500;
+
+/// Tick counter driving the vacuum cadence. Process-lifetime only (resets on
+/// restart) — an off-by-a-few-ticks cadence drift after a restart is harmless.
+static TICK_COUNT: AtomicU64 = AtomicU64::new(0);
+
+fn capture_retention_days() -> u64 {
+    std::env::var("MERIDIAN_CAPTURE_RETENTION_DAYS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_CAPTURE_RETENTION_DAYS)
+}
+
+/// Prunes old, already-ETL-processed rows from `capture_frames`,
+/// `capture_ui_events`, and `capture_secondary_screens`, then — on a coarser
+/// cadence — runs a bounded `incremental_vacuum` to reclaim freed pages.
+///
+/// Call once per ETL poll tick, after `run_etl` has advanced the cursor.
+#[tracing::instrument(skip(pool))]
+pub async fn prune_capture_tables(pool: &SqlitePool) -> Result<()> {
+    let retention_days = capture_retention_days();
+    let cutoff_ts = (chrono::Utc::now() - chrono::Duration::days(retention_days as i64))
+        .to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+
+    // etl_cursor.last_frame_id is the last frame the ETL has actually
+    // consumed — never prune a frame at or after it.
+    let cursor: Option<(i64,)> =
+        sqlx::query_as("SELECT last_frame_id FROM etl_cursor WHERE id = 1")
+            .fetch_optional(pool)
+            .await
+            .context("read etl_cursor for capture retention")?;
+    let Some((last_frame_id,)) = cursor else {
+        tracing::debug!("capture retention: no etl_cursor row yet — nothing to prune");
+        return Ok(());
+    };
+    if last_frame_id <= 0 {
+        tracing::debug!(
+            last_frame_id,
+            "capture retention: cursor at/before 0 — nothing processed yet"
+        );
+        return Ok(());
+    }
+
+    let cursor_frame: Option<(String,)> =
+        sqlx::query_as("SELECT timestamp FROM capture_frames WHERE id = ?1")
+            .bind(last_frame_id)
+            .fetch_optional(pool)
+            .await
+            .context("read cursor frame timestamp for capture retention")?;
+    let Some((cursor_ts,)) = cursor_frame else {
+        // The cursor's own frame is already gone (previously pruned, or a
+        // fresh DB with a stale cursor) — be conservative and skip this tick
+        // rather than guess a boundary.
+        tracing::debug!(
+            last_frame_id,
+            "capture retention: cursor frame not found — skipping this tick"
+        );
+        return Ok(());
+    };
+
+    // capture_frames has an explicit processed marker (id <= last_frame_id),
+    // so "processed" and "age" are independent conditions there — no need to
+    // also bound by the cursor frame's own timestamp.
+    let frames_deleted =
+        sqlx::query("DELETE FROM capture_frames WHERE id <= ?1 AND timestamp < ?2")
+            .bind(last_frame_id)
+            .bind(&cutoff_ts)
+            .execute(pool)
+            .await
+            .context("prune capture_frames")?
+            .rows_affected();
+
+    // capture_ui_events / capture_secondary_screens have no frame-id link, so
+    // "processed" is approximated by "strictly before the cursor frame's own
+    // timestamp" — a row AT that timestamp might belong to a session the ETL
+    // hasn't finished closing yet, so it's left alone. Combined with the age
+    // cutoff via the earlier (chronologically smaller/older) of the two —
+    // never delete anything at or after either boundary.
+    let ui_secondary_boundary = if cutoff_ts < cursor_ts {
+        &cutoff_ts
+    } else {
+        &cursor_ts
+    };
+
+    let ui_events_deleted = sqlx::query("DELETE FROM capture_ui_events WHERE timestamp < ?1")
+        .bind(ui_secondary_boundary)
+        .execute(pool)
+        .await
+        .context("prune capture_ui_events")?
+        .rows_affected();
+
+    let secondary_screens_deleted =
+        sqlx::query("DELETE FROM capture_secondary_screens WHERE timestamp < ?1")
+            .bind(ui_secondary_boundary)
+            .execute(pool)
+            .await
+            .context("prune capture_secondary_screens")?
+            .rows_affected();
+
+    if frames_deleted > 0 || ui_events_deleted > 0 || secondary_screens_deleted > 0 {
+        tracing::info!(
+            frames_deleted,
+            ui_events_deleted,
+            secondary_screens_deleted,
+            cutoff_ts = %cutoff_ts,
+            cursor_ts = %cursor_ts,
+            retention_days,
+            "capture retention: pruned old, already-processed rows"
+        );
+    } else {
+        tracing::debug!(
+            cutoff_ts = %cutoff_ts,
+            cursor_ts = %cursor_ts,
+            retention_days,
+            "capture retention: nothing to prune this tick"
+        );
+    }
+
+    let tick = TICK_COUNT.fetch_add(1, Ordering::Relaxed);
+    if tick.is_multiple_of(VACUUM_EVERY_N_TICKS) {
+        run_incremental_vacuum(pool).await?;
+    }
+
+    Ok(())
+}
+
+/// Runs a page-bounded `incremental_vacuum` to reclaim freed pages from the
+/// deletes above. A no-op (per SQLite's own pragma semantics) unless the
+/// database's `auto_vacuum` mode is `INCREMENTAL` — see this module's header
+/// doc for why we never force that conversion (it requires a full `VACUUM`)
+/// on an already-populated database.
+async fn run_incremental_vacuum(pool: &SqlitePool) -> Result<()> {
+    sqlx::query(&format!("PRAGMA incremental_vacuum({VACUUM_MAX_PAGES})"))
+        .execute(pool)
+        .await
+        .context("incremental_vacuum on capture retention cadence")?;
+    tracing::debug!(
+        max_pages = VACUUM_MAX_PAGES,
+        "capture retention: incremental_vacuum ran"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqliteConnectOptions;
+    use std::str::FromStr;
+
+    async fn make_db() -> SqlitePool {
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+            .unwrap()
+            .create_if_missing(true);
+        let pool = SqlitePool::connect_with(opts).await.unwrap();
+        sqlx::migrate!("src/migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    async fn insert_frame(pool: &SqlitePool, id: i64, ts: &str, text: &str) {
+        sqlx::query(
+            "INSERT INTO capture_frames (id, app_name, window_name, timestamp, accessibility_text, text_source)
+             VALUES (?, 'Code', NULL, ?, ?, 'accessibility')",
+        )
+        .bind(id)
+        .bind(ts)
+        .bind(text)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_ui_event(pool: &SqlitePool, ts: &str) {
+        sqlx::query(
+            "INSERT INTO capture_ui_events (timestamp, event_type, app_name) VALUES (?, 'app_switch', 'Code')",
+        )
+        .bind(ts)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn set_cursor(pool: &SqlitePool, last_frame_id: i64) {
+        // No row exists until the real ETL's get_cursor() lazily seeds one —
+        // upsert here rather than UPDATE so the test doesn't depend on that.
+        sqlx::query(
+            "INSERT INTO etl_cursor (id, last_frame_id) VALUES (1, ?1)
+             ON CONFLICT (id) DO UPDATE SET last_frame_id = excluded.last_frame_id",
+        )
+        .bind(last_frame_id)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// A row older than retention but AT/AFTER the cursor frame (not yet
+    /// processed by the ETL) must survive.
+    #[tokio::test]
+    async fn unprocessed_frame_survives_even_if_old() {
+        let pool = make_db().await;
+
+        let old_ts = (chrono::Utc::now() - chrono::Duration::days(60))
+            .to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+        insert_frame(&pool, 1, &old_ts, "processed old frame").await;
+        insert_frame(&pool, 2, &old_ts, "unprocessed old frame").await;
+        // Cursor only covers frame 1 — frame 2 is not yet processed.
+        set_cursor(&pool, 1).await;
+
+        prune_capture_tables(&pool).await.unwrap();
+
+        let remaining: Vec<(i64,)> = sqlx::query_as("SELECT id FROM capture_frames ORDER BY id")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            remaining,
+            vec![(2,)],
+            "frame 1 (processed + old) must be pruned; frame 2 (unprocessed) must survive"
+        );
+    }
+
+    /// A processed row inside the retention window must survive even though
+    /// the ETL has moved past it.
+    #[tokio::test]
+    async fn processed_recent_frame_survives_retention_window() {
+        let pool = make_db().await;
+
+        let recent_ts = (chrono::Utc::now() - chrono::Duration::days(1))
+            .to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+        insert_frame(&pool, 1, &recent_ts, "recent processed frame").await;
+        set_cursor(&pool, 1).await;
+
+        prune_capture_tables(&pool).await.unwrap();
+
+        let remaining: Vec<(i64,)> = sqlx::query_as("SELECT id FROM capture_frames ORDER BY id")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            remaining,
+            vec![(1,)],
+            "a recent frame must survive regardless of processed status"
+        );
+    }
+
+    /// A processed row older than retention must be pruned.
+    #[tokio::test]
+    async fn processed_old_frame_is_pruned() {
+        let pool = make_db().await;
+
+        let old_ts = (chrono::Utc::now() - chrono::Duration::days(45))
+            .to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+        insert_frame(&pool, 1, &old_ts, "old processed frame").await;
+        set_cursor(&pool, 1).await;
+
+        prune_capture_tables(&pool).await.unwrap();
+
+        let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM capture_frames")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(remaining, 0, "old, already-processed frame must be pruned");
+    }
+
+    /// capture_ui_events rows are bounded by the same cursor-frame timestamp
+    /// boundary — old-and-before-cursor rows are pruned, old-but-at-or-after
+    /// rows survive.
+    #[tokio::test]
+    async fn ui_events_bounded_by_cursor_frame_timestamp() {
+        let pool = make_db().await;
+
+        let old_ts = (chrono::Utc::now() - chrono::Duration::days(60))
+            .to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+        let cursor_ts = (chrono::Utc::now() - chrono::Duration::days(45))
+            .to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+
+        insert_frame(&pool, 1, &cursor_ts, "cursor frame").await;
+        set_cursor(&pool, 1).await;
+
+        insert_ui_event(&pool, &old_ts).await; // before cursor ts — must prune
+        insert_ui_event(&pool, &cursor_ts).await; // at cursor ts — must survive (not strictly before)
+
+        prune_capture_tables(&pool).await.unwrap();
+
+        let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM capture_ui_events")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            remaining, 1,
+            "only the ui_event strictly before the cursor timestamp must be pruned"
+        );
+    }
+
+    /// No etl_cursor row (or last_frame_id == 0) means nothing has been
+    /// processed yet — retention must be a no-op, never guess.
+    #[tokio::test]
+    async fn no_cursor_progress_means_no_pruning() {
+        let pool = make_db().await;
+
+        let old_ts = (chrono::Utc::now() - chrono::Duration::days(90))
+            .to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+        insert_frame(&pool, 1, &old_ts, "old frame, cursor untouched").await;
+        // etl_cursor is seeded with last_frame_id = 0 by migration — leave as-is.
+
+        prune_capture_tables(&pool).await.unwrap();
+
+        let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM capture_frames")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            remaining, 1,
+            "nothing processed yet — nothing must be pruned"
+        );
+    }
+}

--- a/src/etl/extractor.rs
+++ b/src/etl/extractor.rs
@@ -5,11 +5,11 @@ use anyhow::Result;
 use sqlx::SqlitePool;
 
 use crate::db::screenpipe::{
-    get_audio_snippets, get_frame_full_texts, get_secondary_screen_events, get_signals,
-    get_window_titles, AudioSnippet, SecondaryScreenEvent, SignalEvent, WindowTitleCount,
+    get_audio_snippets, get_secondary_screen_events, get_signals, get_window_titles, AudioSnippet,
+    SecondaryScreenEvent, SignalEvent, WindowTitleCount,
 };
 use crate::etl::session_builder::{is_coding_agent_terminal, is_vscode_like};
-use crate::etl::text_merge::build_session_text;
+use crate::etl::text_merge::rebuild_session_text_paginated;
 
 // ---------------------------------------------------------------------------
 // BlockContext
@@ -65,15 +65,15 @@ pub async fn extract_block_context(
     max_frame_id: i64,
     frame_count: i64,
 ) -> Result<BlockContext> {
-    let (window_titles_res, audio_res, signals_res, secondary_screens_res, frames_res) = tokio::join!(
+    let (window_titles_res, audio_res, signals_res, secondary_screens_res, session_text_res) = tokio::join!(
         get_window_titles(meridian, min_frame_id, max_frame_id, app_name),
         get_audio_snippets(meridian, started_at, ended_at),
         get_signals(meridian, started_at, ended_at),
         get_secondary_screen_events(meridian, started_at, ended_at),
-        get_frame_full_texts(meridian, min_frame_id, max_frame_id),
+        rebuild_session_text_paginated(meridian, min_frame_id, max_frame_id),
     );
 
-    let session_text = build_session_text(&frames_res?);
+    let session_text = session_text_res?;
     let audio_snippets = audio_res?;
     let signals = signals_res?;
     let secondary_screens = secondary_screens_res?;

--- a/src/etl/mod.rs
+++ b/src/etl/mod.rs
@@ -2,6 +2,7 @@
 // https://github.com/meridiona/meridian
 
 mod block_ops;
+pub mod capture_retention;
 pub mod extractor;
 pub mod runner;
 mod session_builder;

--- a/src/etl/text_filter/mod.rs
+++ b/src/etl/text_filter/mod.rs
@@ -462,36 +462,75 @@ pub fn is_quality_line(line: &str) -> bool {
 /// lines averaging 40 chars each → ~2 MB peak, freed when this function returns
 /// (the returned `HashSet` contains only the small chrome subset).
 pub fn build_chrome_set(frames: &[FrameText]) -> HashSet<String> {
-    // Count how many frames each trimmed line appears in (per-frame deduped).
-    let mut freq: HashMap<String, u32> = HashMap::new();
+    let mut acc = ChromeFreqAccumulator::new();
+    acc.feed(frames);
+    acc.finish()
+}
 
-    // Reuse one HashSet across all frames (allocated once, cleared per frame).
-    // Using u64 hashes avoids lifetime conflicts with &str frame borrows and
-    // removes the per-frame allocation overhead on large blocks.
-    let mut seen_hashes: HashSet<u64> = HashSet::with_capacity(256);
+/// Incremental version of the chrome pre-pass's line-frequency count.
+///
+/// [`build_chrome_set`] requires a single global view of line frequencies
+/// across every frame in a block before it can classify anything — a line
+/// only becomes "chrome" once it's been seen in `CHROME_FREQ_THRESHOLD` or
+/// more distinct frames. When a block's frames are read from the DB in pages
+/// (rather than materialized as one `Vec<FrameText>`), this accumulator lets
+/// the frequency count be built incrementally, one page at a time, via
+/// repeated [`ChromeFreqAccumulator::feed`] calls, then finalized once with
+/// [`ChromeFreqAccumulator::finish`] — producing the identical `HashSet` that
+/// `build_chrome_set(&all_frames)` would have, without ever holding all frames
+/// in memory at once. See `rebuild_session_text_paginated` in
+/// `crate::etl::block_ops`.
+pub struct ChromeFreqAccumulator {
+    freq: HashMap<String, u32>,
+    // Reused per `feed` call (cleared per frame) to avoid a per-frame allocation.
+    seen_hashes: HashSet<u64>,
+}
 
-    for frame in frames {
-        seen_hashes.clear();
-        for raw in frame.full_text.split('\n') {
-            let line = raw.trim();
-            if line.len() < 3 {
-                continue;
-            }
-            let mut h = DefaultHasher::new();
-            line.hash(&mut h);
-            let hash = h.finish();
-            if seen_hashes.insert(hash) {
-                *freq.entry(line.to_owned()).or_insert(0) += 1;
+impl ChromeFreqAccumulator {
+    pub fn new() -> Self {
+        Self {
+            freq: HashMap::new(),
+            seen_hashes: HashSet::with_capacity(256),
+        }
+    }
+
+    /// Folds one page of frames into the running frequency count.
+    pub fn feed(&mut self, frames: &[FrameText]) {
+        for frame in frames {
+            self.seen_hashes.clear();
+            for raw in frame.full_text.split('\n') {
+                let line = raw.trim();
+                if line.len() < 3 {
+                    continue;
+                }
+                let mut h = DefaultHasher::new();
+                line.hash(&mut h);
+                let hash = h.finish();
+                if self.seen_hashes.insert(hash) {
+                    *self.freq.entry(line.to_owned()).or_insert(0) += 1;
+                }
             }
         }
     }
 
-    // Keep lines at or above threshold that are not chrome-exempt (tighter than is_landmark:
-    // excludes `# `/`> ` prefixes, anchors SQL to line start).
-    freq.into_iter()
-        .filter(|(line, count)| *count >= CHROME_FREQ_THRESHOLD && !is_chrome_exempt(line))
-        .map(|(line, _)| line)
-        .collect()
+    /// Consumes the accumulator and applies the threshold filter, producing the
+    /// same chrome-line `HashSet` that [`build_chrome_set`] would for the same
+    /// full frame set.
+    pub fn finish(self) -> HashSet<String> {
+        // Keep lines at or above threshold that are not chrome-exempt (tighter than is_landmark:
+        // excludes `# `/`> ` prefixes, anchors SQL to line start).
+        self.freq
+            .into_iter()
+            .filter(|(line, count)| *count >= CHROME_FREQ_THRESHOLD && !is_chrome_exempt(line))
+            .map(|(line, _)| line)
+            .collect()
+    }
+}
+
+impl Default for ChromeFreqAccumulator {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[cfg(test)]

--- a/src/etl/text_merge.rs
+++ b/src/etl/text_merge.rs
@@ -2,8 +2,11 @@
 
 use std::collections::HashSet;
 
-use super::text_filter::{build_chrome_set, is_landmark, is_quality_line};
-use crate::db::screenpipe::FrameText;
+use anyhow::{Context, Result};
+use sqlx::SqlitePool;
+
+use super::text_filter::{build_chrome_set, is_landmark, is_quality_line, ChromeFreqAccumulator};
+use crate::db::screenpipe::{fetch_frame_text_page, FrameText, FRAME_TEXT_PAGE_SIZE};
 
 /// Minimum elapsed seconds between consecutive [HH:MM:SS] markers.
 const MARKER_GAP_SECS: i64 = 30;
@@ -28,6 +31,60 @@ pub fn build_session_text(frames: &[FrameText]) -> String {
     let mut builder = SessionTextBuilder::new();
     builder.feed(frames, &chrome);
     builder.finish()
+}
+
+/// Rebuilds session_text for the frame range `min_frame_id..=max_frame_id` by
+/// reading frames from the DB in `FRAME_TEXT_PAGE_SIZE`-sized pages instead of
+/// materializing the whole range in one `Vec<FrameText>`.
+///
+/// Two passes over the paginated read are required: chrome-line detection
+/// (`ChromeFreqAccumulator`) needs a global view of line frequencies across the
+/// *entire* range before any single frame can be classified (see
+/// `crate::etl::text_filter::build_chrome_set`), so pass 1 accumulates
+/// frequencies page-by-page and pass 2 re-pages the same range to fold each
+/// frame into the session text using the now-final chrome set.
+///
+/// This is a memory-shape change only: for the same frame range, the returned
+/// string is functionally identical to
+/// `build_session_text(&get_frame_full_texts(pool, min_frame_id, max_frame_id).await?)` —
+/// no data is truncated or dropped, only held in bounded pages rather than all
+/// at once. Used both when closing a completed block (`crate::etl::block_ops`)
+/// and when extracting context for the block still being processed in the
+/// current ETL run (`crate::etl::extractor`).
+pub async fn rebuild_session_text_paginated(
+    pool: &SqlitePool,
+    min_frame_id: i64,
+    max_frame_id: i64,
+) -> Result<String> {
+    // Pass 1: accumulate chrome-line frequencies across every page.
+    let mut chrome_acc = ChromeFreqAccumulator::new();
+    let mut after_id = min_frame_id - 1;
+    loop {
+        let page = fetch_frame_text_page(pool, after_id, max_frame_id, FRAME_TEXT_PAGE_SIZE)
+            .await
+            .context("paginated frame-text read (chrome frequency pass)")?;
+        if page.is_empty() {
+            break;
+        }
+        after_id = page.last().map(|f| f.frame_id).unwrap_or(after_id);
+        chrome_acc.feed(&page);
+    }
+    let chrome = chrome_acc.finish();
+
+    // Pass 2: re-page the same range and fold each frame into the session text.
+    let mut builder = SessionTextBuilder::new();
+    let mut after_id = min_frame_id - 1;
+    loop {
+        let page = fetch_frame_text_page(pool, after_id, max_frame_id, FRAME_TEXT_PAGE_SIZE)
+            .await
+            .context("paginated frame-text read (session-text build pass)")?;
+        if page.is_empty() {
+            break;
+        }
+        after_id = page.last().map(|f| f.frame_id).unwrap_or(after_id);
+        builder.feed(&page, &chrome);
+    }
+    Ok(builder.finish())
 }
 
 /// Incremental version of [`build_session_text`]'s per-frame fold.

--- a/src/etl/text_merge.rs
+++ b/src/etl/text_merge.rs
@@ -25,14 +25,65 @@ pub fn build_session_text(frames: &[FrameText]) -> String {
     // The HashSet is freed at the end of this function — ~400KB peak for 1000-frame blocks.
     let chrome = build_chrome_set(frames);
 
-    let mut seen: HashSet<String> = HashSet::with_capacity(4096);
-    let mut out = String::with_capacity(8192);
-    let mut last_marker_secs: Option<i64> = None;
+    let mut builder = SessionTextBuilder::new();
+    builder.feed(frames, &chrome);
+    builder.finish()
+}
 
-    for frame in frames {
-        process_frame(frame, &mut seen, &mut out, &mut last_marker_secs, &chrome);
+/// Incremental version of [`build_session_text`]'s per-frame fold.
+///
+/// Lets a caller build up `session_text` across multiple pages of frames
+/// (e.g. read from the DB in bounded chunks rather than materialized as one
+/// `Vec<FrameText>`) without changing the resulting text at all — feeding all
+/// frames via repeated [`SessionTextBuilder::feed`] calls, in the same order
+/// they'd appear in a single slice, then calling [`SessionTextBuilder::finish`]
+/// once, produces output identical to `build_session_text(&all_frames)`. The
+/// `chrome` set must already reflect the whole frame range (see
+/// `crate::etl::text_filter::ChromeFreqAccumulator`) since chrome lines can
+/// only be identified with a global view. See `rebuild_session_text_paginated`
+/// in `crate::etl::block_ops` for the caller that uses this to avoid an
+/// unbounded-memory rebuild on long single-app sessions.
+pub struct SessionTextBuilder {
+    seen: HashSet<String>,
+    out: String,
+    last_marker_secs: Option<i64>,
+}
+
+impl SessionTextBuilder {
+    pub fn new() -> Self {
+        Self {
+            seen: HashSet::with_capacity(4096),
+            out: String::with_capacity(8192),
+            last_marker_secs: None,
+        }
     }
-    dedup_cursor_prefixes(out)
+
+    /// Folds one page of frames into the running output. `chrome` must be the
+    /// final, fully-accumulated chrome set for the whole frame range — not
+    /// just this page.
+    pub fn feed(&mut self, frames: &[FrameText], chrome: &HashSet<String>) {
+        for frame in frames {
+            process_frame(
+                frame,
+                &mut self.seen,
+                &mut self.out,
+                &mut self.last_marker_secs,
+                chrome,
+            );
+        }
+    }
+
+    /// Consumes the builder, applying the same final cleanup pass
+    /// (`dedup_cursor_prefixes`) that [`build_session_text`] applies.
+    pub fn finish(self) -> String {
+        dedup_cursor_prefixes(self.out)
+    }
+}
+
+impl Default for SessionTextBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// Merge new frame content into an existing session_text string (incremental update).

--- a/src/health/codingagent.rs
+++ b/src/health/codingagent.rs
@@ -100,11 +100,11 @@ pub fn checks(_cfg: &Config) -> Vec<Check> {
                 Check::info(
                     "cursor-agent CLI",
                     "L2",
-                    "Cursor detected but cursor-agent not on PATH — Cursor summaries can't run (left pending)",
+                    "Cursor detected but cursor-agent not on PATH - Cursor summaries can't run (left pending)",
                 )
                 .with_remedy(
                     format!(
-                        "install: {}; then: cursor-agent login — or set CURSOR_AGENT_AUTO_INSTALL=1 in ~/.meridian/app/.env to let the daemon install it",
+                        "install: {}; then: cursor-agent login - or set CURSOR_AGENT_AUTO_INSTALL=1 in ~/.meridian/app/.env to let the daemon install it",
                         meridian_core::CURSOR_INSTALL_HINT,
                     ),
                 ),

--- a/src/health/codingagent.rs
+++ b/src/health/codingagent.rs
@@ -103,7 +103,10 @@ pub fn checks(_cfg: &Config) -> Vec<Check> {
                     "Cursor detected but cursor-agent not on PATH — Cursor summaries can't run (left pending)",
                 )
                 .with_remedy(
-                    "install: curl https://cursor.com/install -fsS | bash; then: cursor-agent login — or set CURSOR_AGENT_AUTO_INSTALL=1 in ~/.meridian/app/.env to let the daemon install it",
+                    format!(
+                        "install: {}; then: cursor-agent login — or set CURSOR_AGENT_AUTO_INSTALL=1 in ~/.meridian/app/.env to let the daemon install it",
+                        meridian_core::CURSOR_INSTALL_HINT,
+                    ),
                 ),
             );
         }

--- a/src/health/jira.rs
+++ b/src/health/jira.rs
@@ -66,25 +66,26 @@ async fn auth_basic(base: &str, email: &str, token: &str) -> Check {
 
 /// Probe `/myself` via the OAuth gateway, refreshing the access token first.
 async fn auth_oauth() -> Check {
-    let tokens = match oauth_jira::ensure_fresh().await {
-        Ok(t) => t,
-        // A transient refresh failure (network/timeout/429/5xx) is not a dead
-        // token — reporting it as critical "re-run oauth-login" is the same
-        // false alarm the sync path used to raise. Downgrade to a warn; only a
-        // terminal failure tells the user to re-authenticate.
-        Err(e) if meridian_oauth::is_transient(&e) => {
-            return Check::warn(
+    let tokens =
+        match oauth_jira::ensure_fresh().await {
+            Ok(t) => t,
+            // A transient refresh failure (network/timeout/429/5xx) is not a dead
+            // token — reporting it as critical "re-run oauth-login" is the same
+            // false alarm the sync path used to raise. Downgrade to a warn; only a
+            // terminal failure tells the user to re-authenticate.
+            Err(e) if meridian_oauth::is_transient(&e) => return Check::warn(
                 "auth",
                 "L2",
-                format!("OAuth token refresh unreachable ({e})"),
+                format!("OAuth token refresh temporarily failed ({e})"),
             )
-            .with_remedy("transient — check network; the daemon retries automatically")
-        }
-        Err(e) => {
-            return Check::critical("auth", "L2", format!("OAuth token refresh failed ({e})"))
-                .with_remedy("re-run `meridian oauth-login jira`")
-        }
-    };
+            .with_remedy(
+                "transient network or provider (429/5xx) issue; the daemon retries automatically",
+            ),
+            Err(e) => {
+                return Check::critical("auth", "L2", format!("OAuth token refresh failed ({e})"))
+                    .with_remedy("re-run `meridian oauth-login jira`")
+            }
+        };
     let url = format!(
         "https://api.atlassian.com/ex/jira/{}/rest/api/3/myself",
         tokens.cloud_id

--- a/src/health/jira.rs
+++ b/src/health/jira.rs
@@ -68,6 +68,18 @@ async fn auth_basic(base: &str, email: &str, token: &str) -> Check {
 async fn auth_oauth() -> Check {
     let tokens = match oauth_jira::ensure_fresh().await {
         Ok(t) => t,
+        // A transient refresh failure (network/timeout/429/5xx) is not a dead
+        // token — reporting it as critical "re-run oauth-login" is the same
+        // false alarm the sync path used to raise. Downgrade to a warn; only a
+        // terminal failure tells the user to re-authenticate.
+        Err(e) if meridian_oauth::is_transient(&e) => {
+            return Check::warn(
+                "auth",
+                "L2",
+                format!("OAuth token refresh unreachable ({e})"),
+            )
+            .with_remedy("transient — check network; the daemon retries automatically")
+        }
         Err(e) => {
             return Check::critical("auth", "L2", format!("OAuth token refresh failed ({e})"))
                 .with_remedy("re-run `meridian oauth-login jira`")

--- a/src/intelligence/providers/jira/mod.rs
+++ b/src/intelligence/providers/jira/mod.rs
@@ -460,6 +460,21 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
     let ctx = match crate::intelligence::oauth::jira::resolve(jira).await {
         Ok(ctx) => ctx,
         Err(e) => {
+            // A refresh that failed only because Atlassian was briefly
+            // unreachable (network blip, timeout, 429, 5xx) does NOT mean the
+            // token is dead — the stored refresh token is still valid and the
+            // next tick will almost certainly succeed. Raising a "Reconnect
+            // Jira / re-run oauth-login" sync error for that transient case is
+            // exactly what made this fault flap on and off at random. Keep the
+            // stale cache and stay quiet; the notice is reserved for a terminal
+            // auth failure the user actually has to act on.
+            if meridian_oauth::is_transient(&e) {
+                tracing::warn!(
+                    error = %e,
+                    "jira auth temporarily unavailable — keeping stale cache, will retry next sync"
+                );
+                return Ok(None);
+            }
             tracing::warn!(error = %e, "jira auth unavailable — keeping stale cache");
             let msg = format!("Jira auth failed — {e}");
             // Basic-auth (JIRA_API_TOKEN/JIRA_BASE_URL) and OAuth are mutually

--- a/src/intelligence/providers/jira/mod.rs
+++ b/src/intelligence/providers/jira/mod.rs
@@ -471,12 +471,12 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
             if meridian_oauth::is_transient(&e) {
                 tracing::warn!(
                     error = %e,
-                    "jira auth temporarily unavailable — keeping stale cache, will retry next sync"
+                    "jira auth temporarily unavailable - keeping stale cache, will retry next sync"
                 );
                 return Ok(None);
             }
-            tracing::warn!(error = %e, "jira auth unavailable — keeping stale cache");
-            let msg = format!("Jira auth failed — {e}");
+            tracing::warn!(error = %e, "jira auth unavailable - keeping stale cache");
+            let msg = format!("Jira auth failed: {e}");
             // Basic-auth (JIRA_API_TOKEN/JIRA_BASE_URL) and OAuth are mutually
             // exclusive here — has_basic_auth() mirrors resolve()'s own choice —
             // so the remedy must match whichever path this failure came from,

--- a/src/llm/claude.rs
+++ b/src/llm/claude.rs
@@ -11,6 +11,33 @@
 //!
 //! NOTE: the inherited env must carry HOME/PATH/USER/LOGNAME or the login keychain
 //! cannot unlock — the daemon's launchd plist owns that.
+//!
+//! # The whole prompt goes over stdin, not argv — two separate bugs, one fix
+//!
+//! It used to be `claude -p <req.system>` (positional argv) + `req.user` piped over stdin
+//! SEPARATELY, at the same time. Two independent things were wrong with that:
+//!
+//! 1. **`req.user` never reached the model, on any platform.** Confirmed live: `claude -p
+//!    "<prompt>"` with data ALSO piped on stdin silently ignores the piped data entirely —
+//!    stdin is only consulted as a FALLBACK when no positional prompt is given, never as a
+//!    second input alongside one. Every real Claude summarisation call has been running on
+//!    instructions alone, with the actual hour's data discarded before it ever reached Claude.
+//! 2. **Windows spawn failure.** `req.system` is a Markdown-sourced instruction prompt, so
+//!    it is always multi-line for a real call. On THIS machine `claude` happens to resolve to
+//!    a native `.exe` (unaffected), but an npm-installed Claude Code (`npm i -g
+//!    @anthropic-ai/claude-code` — the exact command
+//!    [`meridian_core::LlmProvider::install_command`] runs for this provider) resolves to
+//!    `claude.cmd` on Windows — an npm-generated batch file — and Rust's std library REFUSES
+//!    to spawn a `.bat`/`.cmd` target when an argument contains characters it cannot safely
+//!    escape (the CVE-2024-24576 "BatBadBut" fix), notably embedded newlines: the same
+//!    `io::Error { kind: InvalidInput, "batch file arguments are invalid" }` confirmed live
+//!    for [`crate::llm::cursor`] and [`crate::llm::codex`] would hit any Windows user who
+//!    installed this way.
+//!
+//! `claude -p` (bare flag, no positional value) reads the whole prompt from stdin instead —
+//! confirmed live — with no restriction on content or platform, fixing both at once:
+//! [`claude_stdin`] combines `req.system` and `req.user` into the one blob the model actually
+//! sees now.
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -19,6 +46,47 @@ use crate::coding_agent_session_ingest::summariser::prompts as sp;
 use crate::coding_agent_session_ingest::summariser::run_capture;
 
 use super::{LlmBackend, LlmConfig, LlmError, LlmOutput, LlmProvider, PromptRequest};
+
+/// The full prompt sent over stdin — see the module doc. `req.user`, when present, follows
+/// `req.system` after a blank line (the same shape [`crate::llm::cursor`]'s `build_prompt`
+/// already uses for its combined single-channel prompt).
+fn claude_stdin(req: &PromptRequest) -> String {
+    if req.user.is_empty() {
+        req.system.to_string()
+    } else {
+        format!("{}\n\n{}", req.system, req.user)
+    }
+}
+
+/// The concise, human-readable message out of claude's JSON result envelope
+/// (`{"is_error": bool, "subtype": "...", "result": "..."}`), when the envelope actually
+/// reports an error. `None` when it doesn't look like an error envelope at all — a payload
+/// with `is_error: false` and `subtype` absent/`"success"` — so callers know to treat the
+/// call as having succeeded rather than manufacturing a failure out of a normal result.
+///
+/// Used for BOTH exit codes: claude reports plenty of failures (not signed in, workspace
+/// trust, a limit hit mid-run) with a full envelope on stdout and a non-zero exit, not just
+/// a bare line on stderr — see the module doc.
+fn claude_envelope_detail(payload: &Value) -> Option<String> {
+    let is_error = payload
+        .get("is_error")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let subtype = payload.get("subtype").and_then(Value::as_str);
+    if !is_error && matches!(subtype, None | Some("success")) {
+        return None;
+    }
+    Some(
+        payload
+            .get("result")
+            .and_then(Value::as_str)
+            .or(subtype)
+            .unwrap_or("error")
+            .chars()
+            .take(200)
+            .collect(),
+    )
+}
 
 pub struct ClaudeBackend {
     pub cfg: LlmConfig,
@@ -33,9 +101,11 @@ impl LlmBackend for ClaudeBackend {
     async fn complete(&self, req: &PromptRequest) -> Result<LlmOutput, LlmError> {
         let t0 = std::time::Instant::now();
 
+        // `-p` is a bare flag here - no positional value. See the module doc: a positional
+        // value forces the prompt through argv, which Windows' batch-file spawn guard rejects
+        // outright whenever it contains a newline (every real prompt does).
         let mut args: Vec<String> = vec![
             "-p".into(),
-            req.system.to_string(),
             "--output-format".into(),
             "json".into(),
             "--no-session-persistence".into(),
@@ -63,10 +133,11 @@ impl LlmBackend for ClaudeBackend {
             args.push(self.cfg.model.clone());
         }
 
+        let stdin_text = claude_stdin(req);
         let cap = run_capture(
             "claude",
             &args,
-            &req.user, // the hour's input goes on stdin
+            &stdin_text,
             &self.cfg.meridian_home,
             self.cfg.cli_timeout_s,
             &[
@@ -83,7 +154,24 @@ impl LlmBackend for ClaudeBackend {
         .await
         .map_err(super::resolver::from_summariser_error)?;
 
+        // Parsed regardless of exit code: `claude -p --output-format json` still emits a
+        // full `{is_error, subtype, result, ...}` envelope on many failures (not signed in,
+        // workspace trust, a limit hit mid-run) — not just on success. Ignoring that on a
+        // non-zero exit is what used to dump the WHOLE raw envelope as the error message
+        // (`claude exited Some(1): {"type":"result",...400 more characters...}`) instead of
+        // the CLI's own already-clean one-liner (`"result":"Not logged in · Please run
+        // /login"`) — confirmed live: a signed-out Claude showed exactly that raw dump.
+        let envelope: Option<Value> = serde_json::from_str(&cap.stdout).ok();
+
         if !cap.success {
+            if let Some(detail) = envelope.as_ref().and_then(claude_envelope_detail) {
+                if sp::looks_rate_limited(&detail) {
+                    return Err(LlmError::rate_limited(detail));
+                }
+                return Err(LlmError::Failed(format!("claude reported: {detail}")));
+            }
+            // No parseable envelope at all (a crash before the CLI could emit one) - fall
+            // back to whatever text it managed to print.
             let blob = format!("{}\n{}", cap.stderr, cap.stdout);
             if sp::looks_rate_limited(&blob) {
                 let msg =
@@ -108,27 +196,14 @@ impl LlmBackend for ClaudeBackend {
             )));
         }
 
-        let payload: Value = serde_json::from_str(&cap.stdout).map_err(|e| {
+        let payload = envelope.ok_or_else(|| {
             let head: String = cap.stdout.chars().take(200).collect();
-            LlmError::Failed(format!("claude output not JSON ({e}): {head:?}"))
+            LlmError::Failed(format!("claude output not JSON: {head:?}"))
         })?;
 
         // Exit 0 does not mean success: the envelope can still report an error (a limit
         // hit mid-run, for instance), and that error is where the rate-limit signal lives.
-        let is_error = payload
-            .get("is_error")
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
-        let subtype = payload.get("subtype").and_then(Value::as_str);
-        if is_error || !matches!(subtype, None | Some("success")) {
-            let detail: String = payload
-                .get("result")
-                .and_then(Value::as_str)
-                .or(subtype)
-                .unwrap_or("error")
-                .chars()
-                .take(200)
-                .collect();
+        if let Some(detail) = claude_envelope_detail(&payload) {
             if sp::looks_rate_limited(&detail) {
                 return Err(LlmError::rate_limited(detail));
             }
@@ -158,5 +233,86 @@ impl LlmBackend for ClaudeBackend {
             output_tokens: 0,
             elapsed_s: t0.elapsed().as_secs_f64(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The regression this exists for: `req.user` used to be piped over stdin ALONGSIDE a
+    /// positional `-p <req.system>` argv value — but `claude -p` silently discards piped
+    /// stdin whenever a positional prompt is ALSO given (confirmed live), so the hour's data
+    /// never reached the model on any platform. Pins that the combined stdin text carries
+    /// both.
+    #[test]
+    fn claude_stdin_carries_both_the_system_prompt_and_the_user_data() {
+        let req = PromptRequest::new("RULES\nmulti-line", "the transcript", "test");
+        let text = claude_stdin(&req);
+        assert!(text.starts_with("RULES\nmulti-line"));
+        assert!(text.contains("the transcript"));
+    }
+
+    /// No data to summarise (the connectivity probe: `req.user` is empty) must not leave a
+    /// trailing blank-line artefact in what the model sees.
+    #[test]
+    fn claude_stdin_is_just_the_system_prompt_when_there_is_no_user_data() {
+        let req = PromptRequest::new("Reply with exactly: OK.", "", "test");
+        assert_eq!(claude_stdin(&req), "Reply with exactly: OK.");
+    }
+
+    /// Verbatim envelope from the live failure: a signed-out Claude exits non-zero but still
+    /// prints a full, already-clean JSON envelope. This exists because that clean text used
+    /// to be thrown away entirely - the error shown was the whole raw envelope dumped as
+    /// text (`claude exited Some(1): {"type":"result",...}`), not this one-liner.
+    const REAL_NOT_LOGGED_IN_ENVELOPE: &str = r#"{"type":"result","subtype":"success","is_error":true,"api_error_status":null,"duration_ms":108,"duration_api_ms":0,"num_turns":1,"result":"Not logged in · Please run /login","stop_reason":"stop_sequence"}"#;
+
+    #[test]
+    fn envelope_detail_extracts_the_clean_message_from_a_real_not_logged_in_failure() {
+        let payload: serde_json::Value = serde_json::from_str(REAL_NOT_LOGGED_IN_ENVELOPE).unwrap();
+        assert_eq!(
+            claude_envelope_detail(&payload).as_deref(),
+            Some("Not logged in · Please run /login")
+        );
+    }
+
+    /// The load-bearing property this whole fix is for: `subtype` alone is NOT enough to
+    /// tell success from failure (the real payload above has `"subtype":"success"` on a
+    /// genuine failure) — `is_error` is the field that actually says so, and it must win.
+    #[test]
+    fn envelope_detail_trusts_is_error_over_a_misleading_subtype() {
+        let payload = serde_json::json!({
+            "subtype": "success",
+            "is_error": true,
+            "result": "something went wrong",
+        });
+        assert_eq!(
+            claude_envelope_detail(&payload).as_deref(),
+            Some("something went wrong")
+        );
+    }
+
+    /// A genuine success (`is_error: false`, `subtype: "success"`) must not be reinterpreted
+    /// as a failure - that would turn every working call into an error.
+    #[test]
+    fn envelope_detail_is_none_for_a_real_success() {
+        let payload = serde_json::json!({
+            "subtype": "success",
+            "is_error": false,
+            "result": "the actual summary text",
+        });
+        assert_eq!(claude_envelope_detail(&payload), None);
+    }
+
+    /// Not JSON shaped like an envelope at all (e.g. an empty object from a crash) - `None`,
+    /// not a manufactured error, so the caller falls back to raw stderr/stdout text instead
+    /// of claiming a specific cause it can't actually support.
+    #[test]
+    fn envelope_detail_is_none_for_something_that_is_not_an_error_envelope() {
+        assert_eq!(claude_envelope_detail(&serde_json::json!({})), None);
+        assert_eq!(
+            claude_envelope_detail(&serde_json::json!("just a string")),
+            None
+        );
     }
 }

--- a/src/llm/codex.rs
+++ b/src/llm/codex.rs
@@ -11,6 +11,19 @@
 //! The shared schema is rewritten to OpenAI's strict dialect on the way out — see
 //! [`crate::llm::schema::strictify`], without which no schema-bearing call reaches the
 //! model at all.
+//!
+//! # The whole prompt goes over stdin, not argv (Windows)
+//!
+//! It used to be `codex exec <req.system>` (positional argv) + `req.user` piped over stdin.
+//! `codex` resolves to `codex.cmd` on Windows - an npm-generated batch file, not a native exe -
+//! and Rust's std library REFUSES to spawn a `.bat`/`.cmd` target when an argument contains
+//! characters it cannot safely escape (the CVE-2024-24576 "BatBadBut" fix), notably embedded
+//! newlines. `req.system` is loaded from a Markdown rules file (`SUMMARY_RULES`), so it is
+//! always multi-line — meaning every real summarisation call failed to even spawn on Windows
+//! with `io::Error { kind: InvalidInput, "batch file arguments are invalid" }`, confirmed live
+//! with the exact production prompt. `codex exec` (no positional prompt at all) reads the whole
+//! prompt from stdin instead - documented, and confirmed live - and stdin has no such
+//! restriction on any platform, so this fixes Windows without changing behaviour anywhere else.
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -113,6 +126,20 @@ fn classify_login_status(success: bool, stdout: &str, stderr: &str) -> Option<St
     })
 }
 
+/// The full prompt sent over stdin - see the module doc on why nothing goes over argv
+/// anymore. `req.system` (always multi-line - it's a Markdown rules file) is the
+/// instructions; `req.user`, when present, is the data to summarise, demarcated with
+/// `<stdin>` tags the same way `codex exec` itself used to wrap piped stdin when a
+/// positional prompt was ALSO given - so the model sees the identical effective text it did
+/// before this moved off argv, just assembled by us instead of by codex internally.
+fn codex_stdin(req: &PromptRequest) -> String {
+    if req.user.is_empty() {
+        req.system.to_string()
+    } else {
+        format!("{}\n\n<stdin>\n{}\n</stdin>\n", req.system, req.user)
+    }
+}
+
 pub struct CodexBackend {
     pub cfg: LlmConfig,
 }
@@ -140,9 +167,10 @@ impl LlmBackend for CodexBackend {
         let _guard = TempDirGuard(td.clone());
 
         let out_path = td.join("last_message.txt");
+        // No positional prompt argument - see the module doc. `req.system` goes over stdin
+        // instead, along with `req.user`.
         let mut args: Vec<String> = vec![
             "exec".into(),
-            req.system.to_string(),
             "-s".into(),
             "read-only".into(),
             "--skip-git-repo-check".into(),
@@ -170,10 +198,11 @@ impl LlmBackend for CodexBackend {
             args.push(self.cfg.model.clone());
         }
 
+        let stdin_text = codex_stdin(req);
         let cap = run_capture(
             "codex",
             &args,
-            &req.user, // codex exec reads the input from stdin
+            &stdin_text,
             &self.cfg.meridian_home,
             self.cfg.cli_timeout_s,
             &[("MERIDIAN_SUMMARISER", "1"), super::DO_NOT_TRACK],
@@ -298,5 +327,28 @@ mod tests {
             None
         );
         assert_eq!(classify_login_status(false, "", ""), None);
+    }
+
+    /// The regression this exists for: `req.system` used to go over argv (`codex exec
+    /// <system>`), and `req.system` is loaded from a Markdown rules file - always multi-line.
+    /// `codex.cmd` is a batch file on Windows, and Rust refuses to spawn a `.bat`/`.cmd`
+    /// target with a newline in any argument (confirmed live: "batch file arguments are
+    /// invalid"), so every real summarisation call failed to even spawn. Pins that the
+    /// combined stdin text preserves the exact same content the model used to see, just
+    /// assembled by us instead of relying on codex's own `<stdin>`-wrapping of piped input.
+    #[test]
+    fn codex_stdin_wraps_user_data_the_way_codex_itself_used_to() {
+        let req = PromptRequest::new("RULES\nmulti-line", "the transcript", "test");
+        let text = codex_stdin(&req);
+        assert!(text.starts_with("RULES\nmulti-line"));
+        assert!(text.contains("<stdin>\nthe transcript\n</stdin>"));
+    }
+
+    /// No data to summarise (the connectivity probe: `req.user` is empty) must not leave a
+    /// pointless empty `<stdin></stdin>` wrapper in what the model sees.
+    #[test]
+    fn codex_stdin_is_just_the_system_prompt_when_there_is_no_user_data() {
+        let req = PromptRequest::new("Reply with exactly: OK.", "", "test");
+        assert_eq!(codex_stdin(&req), "Reply with exactly: OK.");
     }
 }

--- a/src/llm/codex.rs
+++ b/src/llm/codex.rs
@@ -63,6 +63,56 @@ fn codex_error(stderr: &str) -> String {
     sp::first_line(rest)
 }
 
+/// How long the cheap "are you even signed in" pre-check may take. Purely local (reads a
+/// cached credential file, no network round-trip) — measured ~0.2s on codex-cli 0.145.0 — so
+/// this is a generous ceiling, not a real budget.
+const LOGIN_STATUS_TIMEOUT_S: u64 = 8;
+
+/// Fast pre-flight: is Codex signed out? `None` means "proceed with the real call" — covers
+/// both "signed in" and "couldn't tell" (a pre-check that itself fails or times out must never
+/// block a call that might otherwise succeed; fail open).
+///
+/// # Why this exists
+///
+/// Without it, a signed-out Codex fails through the SLOW path: `codex exec` reaches the
+/// network, gets a 401, and retries — 5 WebSocket reconnects, a fallback to HTTPS, 5 more
+/// retries — before finally giving up at ~23s (measured live). That is LONGER than the Test
+/// Connection button's 20s budget (`PROBE_TIMEOUT_S` in `super::detect`), so the real "you're
+/// not signed in" never reaches the user — they see a bare, unactionable "timed out" instead,
+/// on every real hourly call too, not just the Test button. `codex login status` answers the
+/// same question in a fraction of a second because it only reads a local credential file.
+async fn signed_out(cfg: &LlmConfig) -> Option<String> {
+    let cap = run_capture(
+        "codex",
+        &["login".into(), "status".into()],
+        "",
+        &cfg.meridian_home,
+        LOGIN_STATUS_TIMEOUT_S,
+        &[],
+        &[],
+    )
+    .await
+    .ok()?;
+    classify_login_status(cap.success, &cap.stdout, &cap.stderr)
+}
+
+/// The pure classification `signed_out` applies to `codex login status`'s result — split out
+/// so it can be unit-tested without spawning a process or touching `resolve_cli`'s global
+/// success cache (a fake `codex` on `PATH` would otherwise memoise under the real key).
+///
+/// Only trusts the "not logged in" text when the command also FAILED (non-zero exit): the
+/// message is checked as a substring, so a coincidental match in a differently-shaped success
+/// message (or a future CLI version's phrasing) must not misfire and block a working call.
+/// Anything else — an unrelated failure, a version that phrases this differently — returns
+/// `None` and lets the real call proceed; a wrong "you're signed out" would be worse than one
+/// slow, honestly-reported real failure.
+fn classify_login_status(success: bool, stdout: &str, stderr: &str) -> Option<String> {
+    let blob = format!("{stdout}\n{stderr}").to_lowercase();
+    (!success && blob.contains("not logged in")).then(|| {
+        "Codex isn't signed in yet - run `codex login` in a terminal, then try again.".to_string()
+    })
+}
+
 pub struct CodexBackend {
     pub cfg: LlmConfig,
 }
@@ -75,6 +125,10 @@ impl LlmBackend for CodexBackend {
 
     async fn complete(&self, req: &PromptRequest) -> Result<LlmOutput, LlmError> {
         let t0 = std::time::Instant::now();
+
+        if let Some(msg) = signed_out(&self.cfg).await {
+            return Err(LlmError::Failed(msg));
+        }
 
         let td = std::env::temp_dir().join(format!(
             "meridian-llm-codex-{}-{}",
@@ -207,5 +261,42 @@ mod tests {
             codex_error("banner\nERROR: stream disconnected\n"),
             "stream disconnected"
         );
+    }
+
+    /// The regression this exists for: a signed-out Codex used to fail through `codex exec`'s
+    /// slow retry-then-401 path (~23s, measured live) - longer than the Test Connection
+    /// button's 20s budget, so the user saw a bare "timed out" instead of "you're not signed
+    /// in". `codex login status` (real output, verbatim) answers the same question instantly.
+    #[test]
+    fn classify_login_status_recognises_the_real_not_logged_in_output() {
+        let msg = classify_login_status(false, "Not logged in\n", "");
+        assert!(msg.is_some());
+        assert!(msg.unwrap().contains("codex login"));
+    }
+
+    #[test]
+    fn classify_login_status_is_case_insensitive_and_checks_stderr_too() {
+        assert!(classify_login_status(false, "NOT LOGGED IN", "").is_some());
+        assert!(classify_login_status(false, "", "Not Logged In").is_some());
+    }
+
+    /// A SUCCESSFUL call must never be misread as signed-out, even if "not logged in" somehow
+    /// appears in its output (e.g. echoed back from a prompt) - trusting text over the exit
+    /// code here would risk blocking a call that actually works.
+    #[test]
+    fn classify_login_status_ignores_the_text_on_success() {
+        assert_eq!(classify_login_status(true, "not logged in", ""), None);
+    }
+
+    /// An unrelated failure (network hiccup, a future CLI's different phrasing, a crash) must
+    /// return `None` and let the real call proceed - misclassifying it as "signed out" would
+    /// block a call for the wrong reason and hide the actual error.
+    #[test]
+    fn classify_login_status_does_not_misclassify_an_unrelated_failure() {
+        assert_eq!(
+            classify_login_status(false, "", "connection reset by peer"),
+            None
+        );
+        assert_eq!(classify_login_status(false, "", ""), None);
     }
 }

--- a/src/llm/cursor.rs
+++ b/src/llm/cursor.rs
@@ -10,7 +10,20 @@
 //! local to this module is the JSON envelope and its error classification.
 //!
 //! Unlike claude/codex there is **no schema mechanism**, so the JSON contract rides in the prompt
-//! and the answer is parsed tolerantly. The payload goes in argv (stdin is unprobed on this CLI).
+//! and the answer is parsed tolerantly. The payload goes over **stdin**, not argv.
+//!
+//! # Why stdin, not argv (Windows)
+//!
+//! It used to be argv (`-p <prompt>`). `cursor-agent` resolves to `cursor-agent.cmd` on
+//! Windows, a batch file rather than a native exe, and Rust's std library REFUSES to spawn a
+//! `.bat`/`.cmd` target when an argument contains characters it cannot safely escape (the
+//! CVE-2024-24576 "BatBadBut" fix), notably embedded newlines. [`build_prompt`] always
+//! produces a multi-line string (marker + system prompt + blank line + transcript), so EVERY
+//! real call failed to even spawn on Windows, with `io::Error { kind: InvalidInput, "batch
+//! file arguments are invalid" }`, confirmed live. `cursor-agent -p` (bare flag, no positional
+//! value) reads the full prompt from stdin instead, also confirmed live, and stdin has no such
+//! restriction on any platform (it is a byte stream, not a command-line argument), so this
+//! fixes Windows without changing behaviour anywhere else.
 //!
 //! # Related
 //! - [`crate::llm::cursor_cli`] - shared flags/env/sandbox (read this first)
@@ -53,7 +66,10 @@ impl CursorBackend {
         safety: Vec<String>,
         env: Vec<(&'static str, String)>,
     ) -> Result<String, LlmError> {
-        let mut args: Vec<String> = vec!["-p".into(), prompt.to_string()];
+        // `-p` is a bare flag here - no positional value. See the module doc: a positional
+        // value forces the prompt through argv, which Windows' batch-file spawn guard rejects
+        // outright whenever it contains a newline (every real prompt does).
+        let mut args: Vec<String> = vec!["-p".into()];
         args.extend(["--output-format".into(), "json".into()]);
         args.extend(safety);
 
@@ -62,7 +78,7 @@ impl CursorBackend {
         let cap = run_capture(
             "cursor-agent",
             &args,
-            "", // payload is in the prompt (argv), not stdin
+            prompt, // payload goes over stdin - see the module doc
             // The neutral workspace, NOT ~/.meridian: `--workspace` governs rule discovery
             // today, but the cwd is inside $HOME, so if Cursor ever also seeds discovery from
             // it the no-rule-injection guarantee would regress silently. Free to pin.

--- a/src/llm/cursor_cli.rs
+++ b/src/llm/cursor_cli.rs
@@ -17,7 +17,7 @@
 //!
 //! | Lever | Effect (measured on cursor-agent 2026.07.16) |
 //! |---|---|
-//! | `--allowed-tools ""` | no tools at all; -11,000 input tokens |
+//! | `--allowed-tools=` | no tools at all; -11,000 input tokens |
 //! | `--mode ask` | read-only, server-enforced; belt-and-braces with the empty allowlist |
 //! | `--workspace <empty>` | stops Cursor walking UP into the user's `~/CLAUDE.md` / `AGENTS.md` |
 //! | [`sandbox_home`] | stops the user's ~190 skills being injected; -6,500 further tokens |
@@ -251,9 +251,28 @@ fn is_under(path: &Path, ancestor: &Path) -> bool {
 
 /// The safety flags every Meridian `cursor-agent` call carries, in argv order.
 ///
-/// `no_tools` adds `--allowed-tools ""` (an EMPTY allowlist = no tools at all). That flag is
+/// `no_tools` adds `--allowed-tools=` (an EMPTY allowlist = no tools at all). That flag is
 /// UNDOCUMENTED - hidden from `--help`, marked "internal only" in the CLI bundle - so callers
 /// must be able to retry without it; see [`looks_unsupported_flag`].
+///
+/// # Why `--allowed-tools=`, not `--allowed-tools` + `""` as two argv elements
+///
+/// It used to be two elements, which is correct on macOS/Linux but silently BREAKS on Windows:
+/// `cursor-agent.cmd` (Cursor's own installer output, not npm's) forwards argv to node.exe via
+/// `cursor-agent.ps1`'s bare `$args` - and Windows PowerShell 5.1's array-to-native-argv
+/// flattening DROPS an empty-string element entirely (`$PSNativeCommandArgumentPassing` did not
+/// exist in 5.1). The result: `node.exe` sees `--allowed-tools` immediately followed by
+/// whatever the NEXT real argument was, so commander.js reports
+/// `error: option '--allowed-tools <tool>' argument missing` — a CLI-parsing failure, not an
+/// auth one. `CursorCallError`'s ladder doesn't recognise that message ([`looks_auth_failure`]/
+/// [`looks_unsupported_flag`] both miss it), so it propagates as an opaque `Failed`, and the
+/// tray's Cursor-specific UI (`ui/components/LlmProviderDetail.tsx`) shows EVERY unclassified
+/// failure as "not signed in yet" — so a real, signed-in user saw a permanent, un-clearable
+/// sign-in prompt. Reproduced live on Windows ARM64 both via a direct `cursor-agent.cmd`
+/// invocation and confirmed fixed by switching to a single `--allowed-tools=` token, which
+/// survives the flattening because it is never an empty array ELEMENT (the empty string lives
+/// after the `=` inside one non-empty token). Standard long-option syntax, so this is not
+/// platform-gated - it is correct (and unnecessary-but-harmless) on macOS/Linux too.
 ///
 /// Callers append their own `--output-format` and any prompt/model arguments.
 pub fn safety_args(model: &str, no_tools: bool) -> Vec<String> {
@@ -271,8 +290,7 @@ pub fn safety_args(model: &str, no_tools: bool) -> Vec<String> {
         neutral_workspace().to_string_lossy().into_owned(),
     ];
     if no_tools {
-        args.push("--allowed-tools".into());
-        args.push(String::new());
+        args.push("--allowed-tools=".into());
     }
     args
 }
@@ -508,7 +526,7 @@ mod tests {
         let (res, seen) = ladder(DEFAULT_MODEL, vec![]).await;
         assert!(res.is_ok());
         assert_eq!(seen.len(), 1, "no degradation without a detected cause");
-        assert!(seen[0].0.contains(&"--allowed-tools".to_string()));
+        assert!(seen[0].0.contains(&"--allowed-tools=".to_string()));
         assert!(seen[0].1.iter().any(|(k, _)| *k == "HOME"));
     }
 
@@ -606,6 +624,34 @@ mod tests {
         assert!(!a.contains("--allowed-tools"));
         assert!(a.contains("--mode ask"));
         assert!(a.contains("--workspace"));
+    }
+
+    /// The regression this exists for: on Windows, `cursor-agent.cmd` -> `cursor-agent.ps1`
+    /// forwards argv via PowerShell 5.1's bare `$args`, which silently DROPS a standalone
+    /// empty-string array element when flattening it onto node.exe's command line. Two argv
+    /// elements (`"--allowed-tools"`, `""`) used to reach `safety_args`' caller; the second
+    /// vanished in transit, so cursor-agent saw `--allowed-tools` with nothing after it and
+    /// exited `error: option '--allowed-tools <tool>' argument missing` - a CLI-parsing
+    /// failure that `CursorCallError`'s ladder does not recognise, so it surfaced to the user
+    /// as a permanent "not signed in yet" (the tray's Cursor-specific catch-all for any
+    /// unclassified failure). Reproduced live on Windows ARM64 and confirmed fixed by using a
+    /// single combined `--allowed-tools=` token instead - this pins that it stays that way.
+    #[test]
+    fn no_tools_never_emits_a_standalone_empty_argv_element() {
+        let args = safety_args("some-model", true);
+        assert!(
+            !args.iter().any(|a| a.is_empty()),
+            "an empty-string element is dropped by Windows PowerShell 5.1's $args \
+             flattening in cursor-agent's own Windows wrapper: {args:?}"
+        );
+        assert!(
+            args.iter().any(|a| a == "--allowed-tools="),
+            "expected a single combined '--allowed-tools=' token: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a == "--allowed-tools"),
+            "must not also emit the flag as a separate element: {args:?}"
+        );
     }
 
     #[test]

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -49,16 +49,40 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(6);
 /// Where these CLIs actually land, for when the login shell is unavailable or too slow.
 ///
 /// Unix-only paths — Windows has no `probe_login_shell` to fall back FROM (see
-/// [`resolve_cli`]), so it never reaches this tier for the common case anyway. The one
-/// Windows location worth listing is npm's global bin, `%APPDATA%\npm`, for the rare case
-/// where a fresh shell's `PATH` hasn't picked it up yet even though `PATH` is otherwise
-/// trustworthy on this platform.
+/// [`resolve_cli`]), so it never reaches this tier for the common case anyway. The
+/// Windows locations worth listing are npm's global bin, `%APPDATA%\npm` (claude/codex/
+/// copilot), and cursor-agent's own installer root, `%LOCALAPPDATA%\cursor-agent` (Cursor
+/// does not go through npm on Windows — see [`meridian_core::CURSOR_INSTALL_CMD`]'s
+/// Windows doc) — for the rare case where a fresh shell's `PATH` hasn't picked either up
+/// yet even though `PATH` is otherwise trustworthy on this platform. This is not
+/// hypothetical for cursor-agent specifically: [`install_provider`] confirms the install
+/// by immediately re-probing in the SAME process, whose own `PATH` cannot yet see a user
+/// `PATH` write the installer just made (that only takes effect for new processes) —
+/// without this fallback, a successful Windows Cursor install would report itself as
+/// failed.
 fn candidate_dirs() -> Vec<PathBuf> {
     let home = meridian_core::paths::home_dir_or_cwd();
     #[cfg(windows)]
-    let platform: Vec<String> = std::env::var("APPDATA")
-        .map(|a| vec![PathBuf::from(a).join("npm").to_string_lossy().into_owned()])
-        .unwrap_or_default();
+    let platform: Vec<String> = {
+        let mut dirs = Vec::new();
+        if let Ok(appdata) = std::env::var("APPDATA") {
+            dirs.push(
+                PathBuf::from(appdata)
+                    .join("npm")
+                    .to_string_lossy()
+                    .into_owned(),
+            );
+        }
+        if let Ok(local_appdata) = std::env::var("LOCALAPPDATA") {
+            dirs.push(
+                PathBuf::from(local_appdata)
+                    .join("cursor-agent")
+                    .to_string_lossy()
+                    .into_owned(),
+            );
+        }
+        dirs
+    };
     #[cfg(not(windows))]
     let platform: Vec<String> = vec![
         "/opt/homebrew/bin".to_string(),
@@ -263,21 +287,28 @@ pub struct InstallOutcome {
     pub command: String,
 }
 
-/// Install `provider`'s CLI by running its official installer through the user's LOGIN shell,
+/// Install `provider`'s CLI by running its official installer through the platform's shell,
 /// then confirm the binary is now resolvable.
 ///
-/// # Why a login shell
+/// # Why a shell at all
 ///
-/// The tray is a Finder-launched `.app` with the stripped launchd `PATH`
+/// On macOS/Linux, the tray is a Finder-launched `.app` with the stripped launchd `PATH`
 /// (`/usr/bin:/bin:/usr/sbin:/sbin`), which has no `npm`, `node`, or Homebrew. `npm i -g …`
 /// would fail with "command not found" spawned directly. `$SHELL -l` sources the user's
 /// profile, so it sees the same `npm`/PATH they do in a terminal — the same reason
 /// [`resolve_cli`] probes through a login shell.
 ///
+/// Windows has no equivalent stripping (see [`resolve_cli`]'s doc), so [`installer_command`]
+/// doesn't need a login shell for that reason — but it still needs a REAL shell for Cursor's
+/// installer specifically: [`meridian_core::CURSOR_INSTALL_CMD`]'s Windows form uses `irm`/
+/// `iex`, PowerShell aliases with no `cmd.exe` equivalent, so [`installer_command`] spawns
+/// `powershell.exe` directly there (not nested inside `cmd /C`, which would need a second,
+/// fragile layer of quote-escaping for the embedded `-Command` payload).
+///
 /// # Safety
 ///
 /// The command comes from [`LlmProvider::install_command`], a fixed literal per provider with
-/// no user input, so passing it to `-c` cannot inject anything. This is the ONE place the
+/// no user input, so passing it to the shell cannot inject anything. This is the ONE place the
 /// daemon runs a vendor installer, and only ever on an explicit user click (the tray's
 /// `install_llm_provider` command) — never automatically.
 #[tracing::instrument(
@@ -298,14 +329,10 @@ pub async fn install_provider(provider: LlmProvider) -> InstallOutcome {
         };
     };
     let bin = provider.cli_name().unwrap_or("");
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
 
     tracing::info!(provider = provider.as_str(), %cmd, "llm: running provider installer");
-    let mut command = Command::new(&shell);
+    let mut command = installer_command(cmd);
     command
-        .arg("-l")
-        .arg("-c")
-        .arg(cmd)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -362,6 +389,53 @@ pub async fn install_provider(provider: LlmProvider) -> InstallOutcome {
             "the installer finished but the CLI still isn't on your PATH - try running it in a terminal".into(),
         ),
     }
+}
+
+/// Build the (unspawned) command that runs `cmd` through the platform's shell.
+///
+/// `pub(crate)`: also reused by
+/// [`crate::coding_agent_session_ingest::cursor_agent_init::try_auto_install`], the daemon's
+/// own (opt-in) unattended installer — so both the tray's "Install" button and the daemon's
+/// background install go through the exact same platform dispatch instead of growing two
+/// copies that can drift (the daemon's used to hardcode `bash -c`, which never worked on
+/// Windows in the first place).
+///
+/// Unix: the user's login shell (`$SHELL -l -c`) — see the module docs on why a login shell
+/// specifically.
+///
+/// Windows: `powershell.exe` directly, NOT `cmd.exe`. `cmd /C` cannot run Cursor's Windows
+/// installer (`irm`/`iex` are PowerShell aliases, no `cmd` equivalent — see
+/// [`meridian_core::CURSOR_INSTALL_CMD`]'s Windows doc), and nesting `cmd /C "powershell
+/// ... -Command \"...\""` to work around that would need a second, mismatched layer of
+/// quote-escaping (`cmd.exe`'s quote handling and a C-runtime-style argv escape do not agree
+/// on what `\"` means) on top of the one Rust already does to hand `cmd` a single argv
+/// element — spawning `powershell.exe` directly keeps it to that one layer. Plain commands
+/// (`npm i -g …`) run identically well under `-Command` as they did under `cmd /C`.
+/// `-ExecutionPolicy Bypass` is defensive: inline `-Command` text isn't normally subject to
+/// the script-file execution policy, but a locked-down machine's policy could still be
+/// stricter than default, and there is no `.ps1` file here to sign. `; exit $LASTEXITCODE`
+/// guarantees the process's own exit code reflects the command's success/failure — relying on
+/// PowerShell's implicit propagation for the LAST statement in a `-Command` script is not
+/// documented behaviour and would silently report a failed `npm i -g …` as a successful
+/// install.
+#[cfg(windows)]
+pub(crate) fn installer_command(cmd: &str) -> Command {
+    let mut command = Command::new("powershell");
+    command
+        .arg("-NoProfile")
+        .arg("-ExecutionPolicy")
+        .arg("Bypass")
+        .arg("-Command")
+        .arg(format!("{cmd}; exit $LASTEXITCODE"));
+    command
+}
+
+#[cfg(not(windows))]
+pub(crate) fn installer_command(cmd: &str) -> Command {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+    let mut command = Command::new(shell);
+    command.arg("-l").arg("-c").arg(cmd);
+    command
 }
 
 /// Confirm a pinned CLI actually installed at the pinned version, and warn loudly if not.
@@ -696,11 +770,27 @@ async fn probe_login_shell(bin: &str) -> Option<PathBuf> {
 
 /// Fallback: look where these things actually install. Used when the login shell is
 /// unavailable, slow, or exotic.
+///
+/// Resolves through [`path_candidate_names`] the same way [`probe_current_path`] does, NOT a
+/// bare `d.join(bin)`: on Windows an install dir can hold the same bare-shebang-plus-`.cmd`
+/// layout `probe_current_path`'s doc describes (npm writes all three), and this tier is
+/// reached precisely when the current process's `PATH` doesn't have the dir yet (a fresh
+/// install's `PATH` write not being visible to an already-running process) — the exact
+/// situation [`install_provider`] hits when it re-probes right after running an installer.
+/// Joining the bare name first would resolve to the extensionless POSIX script and fail to
+/// spawn with `os error 193`, reproducing the same bug `probe_current_path` was fixed for, one
+/// tier down.
 fn probe_candidates(bin: &str) -> Option<PathBuf> {
-    candidate_dirs()
-        .into_iter()
-        .map(|d| d.join(bin))
-        .find(|p| p.exists())
+    let names = path_candidate_names(bin);
+    for dir in candidate_dirs() {
+        for name in &names {
+            let p = dir.join(name);
+            if p.is_file() {
+                return Some(p);
+            }
+        }
+    }
+    None
 }
 
 /// Check the CURRENT process's own `PATH` for `bin` — the cheap, no-subprocess probe that
@@ -903,6 +993,126 @@ mod tests {
             None => std::env::remove_var("PATH"),
         }
         let _ = std::fs::remove_dir_all(&dir);
+
+        assert_eq!(
+            found.as_deref(),
+            Some(shimmed.as_path()),
+            "resolved {found:?}, expected the .CMD shim, not the bare shebang script"
+        );
+    }
+
+    /// The regression this exists for: `install_provider` used to build its command with
+    /// `Command::new(SHELL-or-"/bin/zsh")` unconditionally, which on Windows fails to even
+    /// spawn (`os error 3`, no such path) before the installer — even a plain `npm i -g …`
+    /// — gets any chance to run. `installer_command` must produce something that actually
+    /// starts and executes the given command on every platform.
+    #[tokio::test]
+    async fn installer_command_actually_runs_on_this_platform() {
+        let mut cmd = installer_command("echo hello-from-installer");
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let output = cmd.output().await.expect("installer_command must spawn");
+        assert!(output.status.success(), "{output:?}");
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("hello-from-installer"),
+            "{output:?}"
+        );
+    }
+
+    /// A failing installer must be reported as failed. On Windows this is the whole reason
+    /// for the `; exit $LASTEXITCODE` suffix in `installer_command`: PowerShell's own exit
+    /// code for a `-Command` script is not guaranteed to mirror a native command's exit
+    /// code, so without it a failing `npm i -g …` could be reported to the user as a
+    /// successful install.
+    #[tokio::test]
+    async fn installer_command_propagates_a_failure_exit_code() {
+        let mut cmd = installer_command("exit 7");
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let output = cmd.output().await.expect("installer_command must spawn");
+        assert!(!output.status.success());
+        assert_eq!(output.status.code(), Some(7));
+    }
+
+    /// cursor-agent does not install via npm on Windows (see
+    /// `meridian_core::CURSOR_INSTALL_CMD`'s Windows doc) — its own installer root must be a
+    /// fallback candidate dir, or a Cursor install's post-install re-probe (same process,
+    /// stale `PATH`) reports a successful install as failed.
+    #[cfg(windows)]
+    #[test]
+    fn candidate_dirs_includes_the_cursor_agent_install_root() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let original = std::env::var_os("LOCALAPPDATA");
+        std::env::set_var("LOCALAPPDATA", r"C:\Users\meridian-test\AppData\Local");
+
+        let dirs = candidate_dirs();
+
+        match original {
+            Some(v) => std::env::set_var("LOCALAPPDATA", v),
+            None => std::env::remove_var("LOCALAPPDATA"),
+        }
+
+        assert!(
+            dirs.contains(&PathBuf::from(
+                r"C:\Users\meridian-test\AppData\Local\cursor-agent"
+            )),
+            "{dirs:?}"
+        );
+    }
+
+    /// The `LOCALAPPDATA`-less case must not panic or produce a bogus dir — an unset var is
+    /// simply "nothing to add here", same as `APPDATA`'s existing handling.
+    #[cfg(windows)]
+    #[test]
+    fn candidate_dirs_tolerates_a_missing_localappdata() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let original = std::env::var_os("LOCALAPPDATA");
+        std::env::remove_var("LOCALAPPDATA");
+
+        let dirs = candidate_dirs();
+
+        if let Some(v) = original {
+            std::env::set_var("LOCALAPPDATA", v);
+        }
+
+        assert!(
+            dirs.iter().all(|d| !d.ends_with("cursor-agent")),
+            "{dirs:?}"
+        );
+    }
+
+    /// The fallback-directory tier must resolve `PATHEXT` the same way the `PATH` tier does
+    /// (`probe_current_path`). A bare `d.join(bin)` would match an extensionless shebang
+    /// script before its `.CMD` shim in the same directory and fail to spawn (`os error
+    /// 193`) — exactly the bug `probe_current_path` was fixed for, one tier down, and this
+    /// tier is reached precisely when a just-installed CLI's directory isn't on the current
+    /// process's `PATH` yet (the post-install re-probe in `install_provider`).
+    #[cfg(windows)]
+    #[test]
+    fn probe_candidates_prefers_pathext_over_a_bare_extensionless_shim() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let original_home = std::env::var_os("HOME");
+        let temp_home = std::env::temp_dir().join(format!(
+            "meridian-detect-candidates-test-{}",
+            std::process::id()
+        ));
+        let bin_dir = temp_home.join(".local").join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let bare = bin_dir.join("meridian-fake-cli2");
+        let shimmed = bin_dir.join("meridian-fake-cli2.CMD");
+        std::fs::write(&bare, "#!/bin/sh\necho fake\n").unwrap();
+        std::fs::write(&shimmed, "@echo fake\r\n").unwrap();
+        std::env::set_var("HOME", &temp_home);
+
+        let found = probe_candidates("meridian-fake-cli2");
+
+        match original_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        let _ = std::fs::remove_dir_all(&temp_home);
 
         assert_eq!(
             found.as_deref(),

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -173,7 +173,16 @@ pub async fn detect_all() -> Vec<ProviderStatus> {
 /// and the user is watching a spinner.
 const PROBE_TIMEOUT_S: u64 = 20;
 
-const PROBE_SYSTEM: &str = "Reply with exactly: OK. No other text, no punctuation, nothing else.";
+/// Deliberately MULTI-LINE, not a single sentence. A single-line probe cannot catch a real,
+/// previously-shipped bug: on Windows, `claude`/`codex`/`cursor-agent` resolve to `.cmd`/
+/// `.bat` shims, and Rust's std library refuses to spawn one when an argument contains a
+/// newline (the CVE-2024-24576 "BatBadBut" fix) - which every real prompt does (Markdown
+/// rules files, multi-paragraph instructions). A one-line probe passed every Test Connection
+/// click while every real hourly summarisation call failed outright, so the bug went
+/// undetected until it showed up in production. This shape is the minimum needed to exercise
+/// the same spawn path a real call takes.
+const PROBE_SYSTEM: &str =
+    "You are being connectivity-tested by Meridian.\n\nReply with exactly: OK. No other text, no punctuation, nothing else.";
 
 /// What a real connectivity test found. Mirrors [`super::LlmError`]'s two failure shapes
 /// (rate-limited vs everything else) so the UI can tell "this works, just not right now"
@@ -916,6 +925,18 @@ mod tests {
                 .unwrap()
                 .contains_key(bin),
             "a miss was cached, so installing the CLI later would not be picked up"
+        );
+    }
+
+    /// The regression this exists for: a single-line probe passed Test Connection on every
+    /// provider while every REAL summarisation call (multi-line prompts) failed to even spawn
+    /// on Windows. See `PROBE_SYSTEM`'s doc — this must stay multi-line or the probe silently
+    /// stops exercising the spawn path that actually broke.
+    #[test]
+    fn probe_system_is_multiline_to_catch_the_windows_batch_spawn_bug() {
+        assert!(
+            PROBE_SYSTEM.contains('\n'),
+            "a single-line probe passes even when a real prompt would fail to spawn on Windows"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1047,6 +1047,9 @@ async fn main() -> Result<()> {
             let _ = meridian::notices::clear(&meridian, "etl.failed").await;
         }
         etl_notify.notify_one();
+        if let Err(e) = meridian::etl::capture_retention::prune_capture_tables(&meridian).await {
+            tracing::warn!(error = %e, "capture retention sweep failed");
+        }
         if let Err(e) = run_pm_sync(&meridian, &cfg).await {
             tracing::error!("intelligence run failed: {}", e);
         }
@@ -1185,6 +1188,14 @@ async fn main() -> Result<()> {
                 }
                 // Wake the background task linker to drain newly-created sessions.
                 etl_notify.notify_one();
+
+                // Capture-table retention — age + processed-based prune of
+                // capture_frames/capture_ui_events/capture_secondary_screens,
+                // which otherwise grow unbounded. Runs every tick; internally
+                // paces its own incremental_vacuum to a coarser cadence.
+                if let Err(e) = meridian::etl::capture_retention::prune_capture_tables(&meridian).await {
+                    tracing::warn!(error = %e, "capture retention sweep failed");
+                }
 
                 // Morning plan nudge — idempotent per day, gated to working hours.
                 if let Err(e) = meridian::daily_plan::maybe_nudge(&meridian).await {

--- a/src/notices.rs
+++ b/src/notices.rs
@@ -15,7 +15,7 @@ use sqlx::SqlitePool;
 /// Raise (or refresh) a named notice. Idempotent — upserts so repeated calls
 /// from the poll loop don't accumulate duplicate rows. The paired toast is
 /// always stamped `system.fault` — use [`raise_typed`] when the caller needs
-/// its own per-type settings toggle instead of sharing `notify_system_fault`.
+/// its own distinct `event_key` instead of sharing the `system.fault` bucket.
 pub async fn raise(
     pool: &SqlitePool,
     id: &str,
@@ -54,8 +54,8 @@ pub struct Notice<'a> {
     pub title: &'a str,
     pub detail: &'a str,
     pub remedy: Option<&'a str>,
-    /// The paired toast's event_key — its own `notify_<type>` settings toggle,
-    /// instead of the shared `system.fault` bucket [`raise`] uses.
+    /// The paired toast's event_key, distinct from the shared `system.fault`
+    /// bucket [`raise`] uses.
     pub event_key: &'a str,
     pub deep_link: Option<&'a str>,
 }

--- a/tests/etl_session_text.rs
+++ b/tests/etl_session_text.rs
@@ -6,7 +6,9 @@
 
 mod common;
 
+use meridian::db::screenpipe::get_frame_full_texts;
 use meridian::etl::run_etl;
+use meridian::etl::text_merge::build_session_text;
 
 // Helper: count "[HH:MM:SS]" marker lines in a session_text string.
 fn count_markers(text: &str) -> usize {
@@ -454,4 +456,125 @@ async fn test_session_text_marker_suppressed_for_small_gap() {
         marker_count, 1,
         "20s gap must suppress second marker; got {marker_count} in:\n{text}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Paginated rebuild — session spanning many frames across multiple pages
+// ---------------------------------------------------------------------------
+
+/// A single-app session that stays open across two ETL runs and spans more
+/// frames than one `FRAME_TEXT_PAGE_SIZE` page (750, see
+/// `crate::db::screenpipe`) must, once finally closed by an app switch,
+/// produce a `session_text` in `app_sessions` that is byte-for-byte identical
+/// to what a single non-paginated `get_frame_full_texts` + `build_session_text`
+/// call over the whole frame range would produce.
+///
+/// This guards `rebuild_session_text_paginated` (`src/etl/block_ops.rs`)
+/// against a regression that would silently drop or reorder content from
+/// later pages when a long-running block finally closes — the exact
+/// continuation-merge path (`existing.app_name == ctx.app_name` in
+/// `close_block`) that triggers the paginated re-fetch.
+#[tokio::test]
+async fn test_session_text_paginated_rebuild_matches_non_paginated_fetch() {
+    let md = common::make_meridian_db().await;
+
+    const FIRST_RUN_FRAMES: i64 = 500;
+    const TOTAL_CODE_FRAMES: i64 = 1600; // > 2x FRAME_TEXT_PAGE_SIZE (750) — forces 3 pages
+
+    // Timestamp for frame index i (0-based): base + i seconds. Keeps every
+    // inter-frame gap at 1s, well under the 300s gap threshold, so this never
+    // triggers gap-close logic — only the continuation-merge close path.
+    fn ts_for(i: i64) -> String {
+        let total_secs = i;
+        let hh = 10 + total_secs / 3600;
+        let mm = (total_secs % 3600) / 60;
+        let ss = total_secs % 60;
+        format!("2026-01-01T{hh:02}:{mm:02}:{ss:02}+00:00")
+    }
+
+    // Run 1: frames 1..=500 of app "Code", each with unique content. Ends with
+    // an open block — upsert_open_block writes active_session(min_frame_id=1).
+    let run1_frames: Vec<(String, String, String)> = (0..FIRST_RUN_FRAMES)
+        .map(|i| {
+            (
+                "Code".to_string(),
+                ts_for(i),
+                format!("unique code content line {i}"),
+            )
+        })
+        .collect();
+    let run1_frames_ref: Vec<(&str, &str, &str)> = run1_frames
+        .iter()
+        .map(|(a, b, c)| (a.as_str(), b.as_str(), c.as_str()))
+        .collect();
+    common::insert_frames_with_text(&md, 1, &run1_frames_ref).await;
+
+    run_etl(&md).await.unwrap();
+
+    // Sanity check: active_session must now hold the still-open Code block.
+    let active_min: (i64,) = sqlx::query_as("SELECT min_frame_id FROM active_session WHERE id = 1")
+        .fetch_one(&md)
+        .await
+        .unwrap();
+    assert_eq!(active_min.0, 1, "active_session must start at frame 1");
+
+    // Run 2: frames 501..=1600 continuing app "Code" (unique content), then a
+    // final frame for "Slack" to force the app-switch close. This closes the
+    // whole 1..=1600 lifetime through the continuation-merge path in
+    // `close_block`, which re-fetches the full frame range.
+    let run2_frames: Vec<(String, String, String)> = (FIRST_RUN_FRAMES..TOTAL_CODE_FRAMES)
+        .map(|i| {
+            (
+                "Code".to_string(),
+                ts_for(i),
+                format!("unique code content line {i}"),
+            )
+        })
+        .chain(std::iter::once((
+            "Slack".to_string(),
+            ts_for(TOTAL_CODE_FRAMES),
+            "app switch forces close".to_string(),
+        )))
+        .collect();
+    let run2_frames_ref: Vec<(&str, &str, &str)> = run2_frames
+        .iter()
+        .map(|(a, b, c)| (a.as_str(), b.as_str(), c.as_str()))
+        .collect();
+    common::insert_frames_with_text(&md, FIRST_RUN_FRAMES + 1, &run2_frames_ref).await;
+
+    run_etl(&md).await.unwrap();
+
+    let row: (Option<String>,) =
+        sqlx::query_as("SELECT session_text FROM app_sessions WHERE app_name = 'Code'")
+            .fetch_one(&md)
+            .await
+            .unwrap();
+    let actual_text = row.0.expect("closed session must have session_text");
+
+    // Reference: a single non-paginated fetch over the whole frame lifetime,
+    // fed straight into build_session_text — exactly what the pre-fix code did.
+    let all_frames = get_frame_full_texts(&md, 1, TOTAL_CODE_FRAMES)
+        .await
+        .expect("non-paginated reference fetch must succeed");
+    assert_eq!(
+        all_frames.len(),
+        TOTAL_CODE_FRAMES as usize,
+        "reference fetch must see every Code frame"
+    );
+    let expected_text = build_session_text(&all_frames);
+
+    assert_eq!(
+        actual_text, expected_text,
+        "paginated rebuild must be byte-for-byte identical to the non-paginated reference"
+    );
+
+    // Belt-and-suspenders completeness check: content from every page must
+    // survive (first page, middle page, last page — pages are 750 frames).
+    for i in [0i64, 749, 750, 1499, 1500, TOTAL_CODE_FRAMES - 1] {
+        let line = format!("unique code content line {i}");
+        assert!(
+            actual_text.contains(&line),
+            "missing content from frame {i} (page boundary check): {line:?}"
+        );
+    }
 }

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -66,6 +66,10 @@ tauri-plugin-store = "=2.4.3"
 # native-tls. This is the DMG path; npm installs still update via `meridian
 # update` in a Terminal (commands::run_update) — the two are independent.
 tauri-plugin-updater = { version = "2", default-features = false, features = ["rustls-tls"] }
+# Launch-at-login: registers a macOS LaunchAgent (matches the daemon's own
+# LaunchAgent approach, see backend_install.rs) or a Windows Run-key entry
+# pointing at the installed .app/exe. See `autostart.rs`.
+tauri-plugin-autostart = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Minimum-supported-version comparison for mandatory updates (update.rs);

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -106,7 +106,7 @@ meridian = { path = "../.." }
 # screen capture + Apple Vision OCR. Optional → only pulled by the `capture`
 # feature (heavy: ScreenCaptureKit/cidre/sck-rs). Private repo: local builds use
 # the user's git credentials; CI needs a deploy token (future).
-screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "f13c631ce6bac1c5ecaecfef7ad44c08428d0724", optional = true }
+screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "b2e5b26", optional = true }
 # Sibling crate in the same fork: the accessibility-tree walker (slice 3b).
 # `tree::create_tree_walker` walks the focused window's AX tree → structured
 # text — the PRIMARY signal for Electron/Chromium apps (VS Code, Slack), which
@@ -119,16 +119,21 @@ screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev 
 # its NSWorkspace observers. See `start_capture` in `../src/lib.rs` for the
 # matching caller-side fix (joining the old recorder thread before restart).
 #
-# Bumped to f13c631 (branch fix/autorelease-pool-leaks off 3c99154): the same
-# double-free signature recurred on a plain pause (single teardown, no
-# restart race), pointing at a second cause the 3c99154 lock doesn't cover —
-# run_app_observer's manually-driven CFRunLoop never drained its autorelease
-# pool, so AX/ns::RunningApp reads from ax_focus_observer_callback and
-# reattach_observer() accumulated unreleased NSObjects for the entire capture
-# session. c29722d wraps each run-loop iteration in cidre::objc::ar_pool(...);
-# f13c631 applies the same fix to the ctx-capture worker thread; 8382e36 does
-# the equivalent for screenpipe-screen's per-frame window enumeration.
-screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "f13c631ce6bac1c5ecaecfef7ad44c08428d0724", optional = true }
+# f13c631 (branch fix/autorelease-pool-leaks off 3c99154) wrapped
+# run_app_observer's run loop (and the ctx-capture worker / screenpipe-screen's
+# frame enumeration) in an autorelease pool — turned out NOT to fix the same
+# crash signature: it recurred on a plain pause (single teardown, no restart
+# race, reproduced within seconds of a fresh launch), so this isn't an
+# autorelease-accumulation bug. `-[NSWorkspaceNotificationCenter
+# removeObserver:name:object:]` itself aborts deterministically on macOS 26.3.
+#
+# Bumped to b2e5b26: run_app_observer now leaks its workspace-observer guards
+# (`std::mem::forget`) instead of dropping them, avoiding the crashing
+# removeObserver call entirely — see that commit's message and the updated
+# WORKSPACE_OBSERVER_LOCK doc comment in macos.rs for the full rationale.
+# Root-causing the actual Foundation-side bug needs native tooling (lldb /
+# Malloc Stack Logging) this pin bump doesn't attempt.
+screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "b2e5b26", optional = true }
 # Console log subscriber for capture-enabled non-otel runs (otel installs its
 # own). Makes the `capture: …` logs visible during a `cargo run --features capture`.
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -106,19 +106,29 @@ meridian = { path = "../.." }
 # screen capture + Apple Vision OCR. Optional → only pulled by the `capture`
 # feature (heavy: ScreenCaptureKit/cidre/sck-rs). Private repo: local builds use
 # the user's git credentials; CI needs a deploy token (future).
-screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "3c99154833b8087b1e215e5af748721096c46f01", optional = true }
+screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "f13c631ce6bac1c5ecaecfef7ad44c08428d0724", optional = true }
 # Sibling crate in the same fork: the accessibility-tree walker (slice 3b).
 # `tree::create_tree_walker` walks the focused window's AX tree → structured
 # text — the PRIMARY signal for Electron/Chromium apps (VS Code, Slack), which
 # expose nothing to OCR-free a11y until the walker sets AXManualAccessibility
 # itself. Optional → only the `capture` feature pulls it.
 #
-# rev 3c99154 fixes a double-free crash (BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
+# rev 3c99154 fixed a double-free crash (BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
 # in run_app_observer's NotificationGuard teardown) that could fire when a new
 # recording session started before the outgoing one finished unregistering
 # its NSWorkspace observers. See `start_capture` in `../src/lib.rs` for the
 # matching caller-side fix (joining the old recorder thread before restart).
-screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "3c99154833b8087b1e215e5af748721096c46f01", optional = true }
+#
+# Bumped to f13c631 (branch fix/autorelease-pool-leaks off 3c99154): the same
+# double-free signature recurred on a plain pause (single teardown, no
+# restart race), pointing at a second cause the 3c99154 lock doesn't cover —
+# run_app_observer's manually-driven CFRunLoop never drained its autorelease
+# pool, so AX/ns::RunningApp reads from ax_focus_observer_callback and
+# reattach_observer() accumulated unreleased NSObjects for the entire capture
+# session. c29722d wraps each run-loop iteration in cidre::objc::ar_pool(...);
+# f13c631 applies the same fix to the ctx-capture worker thread; 8382e36 does
+# the equivalent for screenpipe-screen's per-frame window enumeration.
+screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "f13c631ce6bac1c5ecaecfef7ad44c08428d0724", optional = true }
 # Console log subscriber for capture-enabled non-otel runs (otel installs its
 # own). Makes the `capture: …` logs visible during a `cargo run --features capture`.
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -106,7 +106,7 @@ meridian = { path = "../.." }
 # screen capture + Apple Vision OCR. Optional → only pulled by the `capture`
 # feature (heavy: ScreenCaptureKit/cidre/sck-rs). Private repo: local builds use
 # the user's git credentials; CI needs a deploy token (future).
-screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "b2e5b26", optional = true }
+screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "2b7e929", optional = true }
 # Sibling crate in the same fork: the accessibility-tree walker (slice 3b).
 # `tree::create_tree_walker` walks the focused window's AX tree → structured
 # text — the PRIMARY signal for Electron/Chromium apps (VS Code, Slack), which
@@ -133,7 +133,13 @@ screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev 
 # WORKSPACE_OBSERVER_LOCK doc comment in macos.rs for the full rationale.
 # Root-causing the actual Foundation-side bug needs native tooling (lldb /
 # Malloc Stack Logging) this pin bump doesn't attempt.
-screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "b2e5b26", optional = true }
+#
+# Bumped to 2b7e929 (screenpipe-screen only needs the bump, but both crates
+# are kept pinned to the same rev): adds `screenpipe_screen::monitor_watch`,
+# the CGDisplayRegisterReconfigurationCallback watcher extracted from
+# upstream screenpipe's `screenpipe-engine::sleep_monitor` (its "Thread 4") —
+# see `capture/screenpipe.rs`'s `run_monitor_refresh_task` for the caller.
+screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "2b7e929", optional = true }
 # Console log subscriber for capture-enabled non-otel runs (otel installs its
 # own). Makes the `capture: …` logs visible during a `cargo run --features capture`.
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -106,7 +106,7 @@ meridian = { path = "../.." }
 # screen capture + Apple Vision OCR. Optional → only pulled by the `capture`
 # feature (heavy: ScreenCaptureKit/cidre/sck-rs). Private repo: local builds use
 # the user's git credentials; CI needs a deploy token (future).
-screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "2b7e929", optional = true }
+screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "2b7e929f7168344faa0121c7a646e5758701d19a", optional = true }
 # Sibling crate in the same fork: the accessibility-tree walker (slice 3b).
 # `tree::create_tree_walker` walks the focused window's AX tree → structured
 # text — the PRIMARY signal for Electron/Chromium apps (VS Code, Slack), which
@@ -139,7 +139,7 @@ screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev 
 # the CGDisplayRegisterReconfigurationCallback watcher extracted from
 # upstream screenpipe's `screenpipe-engine::sleep_monitor` (its "Thread 4") —
 # see `capture/screenpipe.rs`'s `run_monitor_refresh_task` for the caller.
-screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "2b7e929", optional = true }
+screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "2b7e929f7168344faa0121c7a646e5758701d19a", optional = true }
 # Console log subscriber for capture-enabled non-otel runs (otel installs its
 # own). Makes the `capture: …` logs visible during a `cargo run --features capture`.
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/tray/src-tauri/src/autostart.rs
+++ b/tray/src-tauri/src/autostart.rs
@@ -1,0 +1,125 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Launch-at-login registration — makes the tray come back on its own after a
+//! reboot/login, the same way [`crate::backend_install`] keeps the daemon
+//! running via its own `LaunchAgent`.
+//!
+//! # Who calls this
+//! [`crate::run`]'s `setup()` hook, once per launch (bundled runs only — see
+//! [`crate::sys::is_bundled`]).
+//!
+//! # Related
+//! - [`crate::backend_install`] — the daemon's equivalent self-heal registration.
+
+use tauri_plugin_autostart::ManagerExt;
+
+/// Marker written after the first successful [`enable`] call — a sibling of
+/// the `onboarded` marker ([`crate::commands::setup::mark_setup_complete`]),
+/// but deliberately separate so it also self-heals installs that finished
+/// onboarding *before* this feature shipped.
+///
+/// After that first success we never call `enable()` again: the OS Login
+/// Items toggle becomes the user's to manage, and re-enabling on every
+/// launch would silently override a manual "off" in System Settings.
+const MARKER_FILE: &str = "autostart_configured";
+
+/// Register the tray as a login item exactly once ever, self-healing across
+/// both fresh installs and pre-existing ones. Best-effort: a failure (no
+/// `~/.meridian`, `auto_launch` I/O error) is logged and retried on the next
+/// launch — the marker is only written on success.
+pub async fn ensure_enabled_once(app: &tauri::AppHandle) {
+    let Some(dir) = meridian_core::paths::meridian_dir() else {
+        tracing::warn!("autostart: could not resolve ~/.meridian — skipping");
+        return;
+    };
+    let marker = dir.join(MARKER_FILE);
+    if marker.exists() {
+        return;
+    }
+    // Don't pin a login item while the app is running from a transient path
+    // (a mounted DMG, or Gatekeeper's translocation quarantine). The plugin
+    // records `current_exe()` as the target; from `/Volumes/…` that path is
+    // gone the moment the disk image ejects, and because we register exactly
+    // once (marker on success) the broken pin would never self-heal. Deferring
+    // — without writing the marker — retries on the next launch, by which time
+    // the user has dragged the app into a stable location (e.g. /Applications).
+    if !running_from_stable_location() {
+        tracing::info!(
+            "autostart: running from a transient location (DMG mount / translocation) — \
+             deferring login-item registration until the app is in a stable path"
+        );
+        return;
+    }
+    if let Err(e) = tokio::fs::create_dir_all(&dir).await {
+        tracing::warn!(error = %e, "autostart: could not create ~/.meridian");
+        return;
+    }
+    match app.autolaunch().enable() {
+        Ok(()) => {
+            tracing::info!("autostart: login item registered");
+            if let Err(e) = tokio::fs::write(&marker, chrono::Local::now().to_rfc3339()).await {
+                tracing::warn!(error = %e, "autostart: failed to write marker (will retry next launch)");
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "autostart: failed to register login item (will retry next launch)");
+        }
+    }
+}
+
+/// macOS: `true` unless the running binary sits in a location that won't
+/// survive — a mounted disk image (`/Volumes/…`, read-only and ejected after a
+/// drag-install) or Gatekeeper's App Translocation quarantine
+/// (`…/AppTranslocation/…`, a randomized read-only mount the OS discards). See
+/// [`ensure_enabled_once`] for why pinning a login item from those paths would
+/// silently and permanently break self-heal.
+///
+/// Non-macOS: always `true` — Windows Run-key entries and Linux desktop entries
+/// point at the installed path, so the mounted-image failure class doesn't
+/// apply there.
+#[cfg(target_os = "macos")]
+fn running_from_stable_location() -> bool {
+    match std::env::current_exe() {
+        Ok(exe) => path_is_stable(&exe.to_string_lossy()),
+        // Can't resolve our own path ⇒ can't vouch for it. Skip and retry next
+        // launch rather than gamble on pinning a bad target.
+        Err(_) => false,
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn running_from_stable_location() -> bool {
+    true
+}
+
+/// The pure string test behind [`running_from_stable_location`], split out so
+/// it can be unit-tested without a real `current_exe()`.
+#[cfg(target_os = "macos")]
+fn path_is_stable(exe_path: &str) -> bool {
+    !exe_path.starts_with("/Volumes/") && !exe_path.contains("/AppTranslocation/")
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::path_is_stable;
+
+    #[test]
+    fn rejects_transient_locations() {
+        // Mounted DMG (drag-install source) and translocation quarantine.
+        assert!(!path_is_stable(
+            "/Volumes/Meridian/Meridian.app/Contents/MacOS/Meridian"
+        ));
+        assert!(!path_is_stable(
+            "/private/var/folders/ab/xyz/T/AppTranslocation/ABC-123/d/Meridian.app/Contents/MacOS/Meridian"
+        ));
+    }
+
+    #[test]
+    fn accepts_stable_locations() {
+        assert!(path_is_stable(
+            "/Applications/Meridian.app/Contents/MacOS/Meridian"
+        ));
+        assert!(path_is_stable(
+            "/Users/dev/Applications/Meridian.app/Contents/MacOS/Meridian"
+        ));
+    }
+}

--- a/tray/src-tauri/src/capture/screenpipe.rs
+++ b/tray/src-tauri/src/capture/screenpipe.rs
@@ -27,6 +27,7 @@
 //! # Related
 //! - [`super`] — the engine-agnostic boundary ([`CaptureEngine`], [`CapturedFrame`]).
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
@@ -36,6 +37,7 @@ use screenpipe_a11y::tree::{
 use screenpipe_screen::capture_screenshot_by_window::{
     capture_all_visible_windows, CapturedWindow, WindowFilters,
 };
+use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
 use super::drm_detector::{self, StreamingGate};
@@ -53,20 +55,17 @@ const CAPTURE_INTERVAL: Duration = Duration::from_secs(2);
 /// on every 2s tick would be wasted work for content the user isn't looking at.
 const SECONDARY_SCREEN_EVERY_N_TICKS: u32 = 5;
 
-/// How often (in ticks) the monitor list is re-enumerated — 15 × 2s = 30s.
-/// The list is otherwise held across ticks and reused, not re-fetched every
-/// tick: `list_monitors()`/`list_monitors_detailed()` does a full native
-/// enumeration (on macOS with ScreenCaptureKit enabled, a fresh
-/// `SCShareableContent` fetch — a known-flaky OS subsystem best not hammered
-/// on a 2s cadence for content that changes only on hotplug). Mirrors
-/// upstream screenpipe's own split between a slow monitor-watcher and a
-/// cached per-frame capture path (`vision_manager/monitor_watcher.rs` +
-/// `SafeMonitor`'s internal `cached_sck`/`cached_xcap` handles, MIT-era
-/// commit 920bbcfd2a "perf: cache monitor handle... capture retry with
-/// refresh"). A monitor that disconnects mid-window just fails its capture
-/// calls until the next refresh (logged, skipped) — the same graceful
-/// degradation `capture_secondary_screens` already had per-monitor.
-const MONITOR_REFRESH_EVERY_N_TICKS: u32 = 15;
+/// Backstop interval for the monitor-list refresh task when the display
+/// reconfiguration callback registered successfully — the callback fires
+/// immediately on an actual hotplug/resolution/mirror change, so this is
+/// just a safety net for whatever it might miss, not the primary signal.
+const MONITOR_REFRESH_BACKSTOP_WITH_CALLBACK: Duration = Duration::from_secs(60);
+
+/// Backstop interval when the callback failed to register (or isn't
+/// available on this platform, e.g. Windows) — falls back to a shorter
+/// poll-only cadence so hotplug detection doesn't silently regress to
+/// once-a-minute. Matches upstream's `monitor_watcher.rs` fallback.
+const MONITOR_REFRESH_BACKSTOP_NO_CALLBACK: Duration = Duration::from_secs(5);
 
 /// Outcome of the per-tick accessibility-tree walk — decides what (if anything)
 /// the OCR fallback does this tick.
@@ -127,22 +126,41 @@ impl CaptureEngine for ScreenpipeEngine {
         // motivating case). Lives for the whole engine run, single-threaded.
         let mut streaming_gate = StreamingGate::new();
 
-        // Enumerated ONCE here, then held across ticks and only refreshed on
-        // its own slow cadence (MONITOR_REFRESH_EVERY_N_TICKS) — see that
-        // constant's doc comment. `SafeMonitor` is `Clone` and internally
-        // caches its native handle, so reusing the same instances tick after
-        // tick is what actually makes that per-monitor cache do anything;
-        // re-listing every tick (the previous design) silently defeated it.
-        let mut monitors = screenpipe_screen::monitor::list_monitors().await;
+        // Enumerated ONCE here, then held across ticks and only refreshed by
+        // `run_monitor_refresh_task` — see its doc comment. `SafeMonitor` is
+        // `Clone` and internally caches its native handle, so reusing the
+        // same instances tick after tick is what actually makes that
+        // per-monitor cache do anything; re-listing every tick (the original
+        // design) silently defeated it.
+        let shared_monitors: Arc<RwLock<Vec<screenpipe_screen::monitor::SafeMonitor>>> = Arc::new(
+            RwLock::new(screenpipe_screen::monitor::list_monitors().await),
+        );
 
-        // Counts ticks so the secondary-monitor sweep and the monitor-list
-        // refresh each run on their own slower cadence without a second timer.
+        // Event-driven refresh, decoupled from the capture cadence entirely
+        // (see `run_monitor_refresh_task`) — spawned once per `run()` call.
+        // `AbortOnDrop` matters here: the caller (`lib.rs`'s `start_capture`)
+        // cancels this whole `run()` future by racing it against a pause
+        // signal in a `tokio::select!` and dropping whichever loses — it
+        // never runs `run()` to a normal return on pause. A bare
+        // `tokio::spawn` with a discarded `JoinHandle` would keep running
+        // forever after every such drop, since a detached task's lifetime is
+        // independent of the future that spawned it — one leaked forever-loop
+        // calling `list_monitors()` (a real SCK/xcap enumeration) on its own
+        // cadence per pause/resume cycle. Binding the handle to a local guard
+        // ties its lifetime to `run()`'s, so it's aborted on every exit path:
+        // normal return (`tx.is_closed()`) and cancellation alike.
+        screenpipe_screen::monitor_watch::start_display_reconfig_watcher();
+        let _monitor_refresh_task = AbortOnDrop(tokio::spawn(run_monitor_refresh_task(
+            shared_monitors.clone(),
+        )));
+
+        // Counts ticks so the secondary-monitor sweep runs on its own slower
+        // cadence without a second timer.
         let mut tick: u32 = 0;
 
         info!(
             interval_s = CAPTURE_INTERVAL.as_secs(),
             secondary_screen_interval_s = CAPTURE_INTERVAL.as_secs() * SECONDARY_SCREEN_EVERY_N_TICKS as u64,
-            monitor_refresh_interval_s = CAPTURE_INTERVAL.as_secs() * MONITOR_REFRESH_EVERY_N_TICKS as u64,
             capture_secondary_monitors,
             "capture: screenpipe engine started (a11y-tree + OCR fallback + secondary-monitor sweep)"
         );
@@ -151,6 +169,9 @@ impl CaptureEngine for ScreenpipeEngine {
                 info!("capture: consumer gone — stopping engine");
                 return Ok(());
             }
+            // Cheap: a handful of `SafeMonitor`s, cloned once per tick so the
+            // read lock isn't held across the capture calls below.
+            let monitors = shared_monitors.read().await.clone();
             // The AX walk is synchronous (bounded by the walker's walk_timeout)
             // and MUST finish before any await: `&dyn TreeWalkerPlatform` is
             // `Send` but not `Sync`, so the reference cannot cross an await
@@ -192,10 +213,6 @@ impl CaptureEngine for ScreenpipeEngine {
 
             tick = tick.wrapping_add(1);
 
-            if tick.is_multiple_of(MONITOR_REFRESH_EVERY_N_TICKS) {
-                monitors = screenpipe_screen::monitor::list_monitors().await;
-            }
-
             // Only sweep when this tick actually resolved a primary window:
             // `false` means either a privacy Skip (never sweep — see
             // capture_secondary_screens docs) or nothing was captured at all
@@ -214,6 +231,62 @@ impl CaptureEngine for ScreenpipeEngine {
 
             tokio::time::sleep(CAPTURE_INTERVAL).await;
         }
+    }
+}
+
+/// Aborts the wrapped task when dropped. Used to tie a detached
+/// `tokio::spawn`'s lifetime to a local variable's scope — see the doc
+/// comment at `run_monitor_refresh_task`'s spawn site for why that matters
+/// here (the spawning future can be cancelled by an external `select!`
+/// rather than ever reaching a normal `return`).
+struct AbortOnDrop(tokio::task::JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+/// Owns monitor-list refresh for the life of the engine, decoupled from the
+/// capture loop's own cadence — ported from upstream screenpipe's
+/// `vision_manager/monitor_watcher.rs` (same event + backstop `select!`
+/// shape), scoped down to just enumeration since this engine doesn't run
+/// upstream's per-monitor persistent recording tasks to start/stop.
+///
+/// Refreshes immediately when `screenpipe_screen::monitor_watch`'s
+/// `CGDisplayRegisterReconfigurationCallback` watcher fires (a real hotplug
+/// or resolution/mirror change), with a backstop timer as a safety net —
+/// 60s if the callback registered (rare wake, event-driven does the real
+/// work), 5s if it didn't (no macOS callback, e.g. Windows, or registration
+/// failed) so hotplug detection doesn't silently regress to once-a-minute.
+///
+/// On macOS also drains `stream_invalidation` before refreshing: the same
+/// reconfiguration that triggered this refresh may have left a cached
+/// persistent capture handle pointing at a stale/gone monitor.
+async fn run_monitor_refresh_task(
+    shared: Arc<RwLock<Vec<screenpipe_screen::monitor::SafeMonitor>>>,
+) {
+    loop {
+        let backstop = if screenpipe_screen::monitor_watch::display_reconfig_callback_registered() {
+            MONITOR_REFRESH_BACKSTOP_WITH_CALLBACK
+        } else {
+            MONITOR_REFRESH_BACKSTOP_NO_CALLBACK
+        };
+        tokio::select! {
+            _ = screenpipe_screen::monitor_watch::display_reconfig_notify().notified() => {
+                debug!("capture: display reconfiguration event — refreshing monitor list");
+            }
+            _ = tokio::time::sleep(backstop) => {}
+        }
+
+        #[cfg(target_os = "macos")]
+        if screenpipe_screen::stream_invalidation::take() {
+            debug!("capture: invalidating stale persistent capture streams after display reconfiguration");
+            screenpipe_screen::stream_invalidation::invalidate_streams();
+        }
+
+        let fresh = screenpipe_screen::monitor::list_monitors().await;
+        *shared.write().await = fresh;
     }
 }
 

--- a/tray/src-tauri/src/capture/screenpipe.rs
+++ b/tray/src-tauri/src/capture/screenpipe.rs
@@ -53,6 +53,21 @@ const CAPTURE_INTERVAL: Duration = Duration::from_secs(2);
 /// on every 2s tick would be wasted work for content the user isn't looking at.
 const SECONDARY_SCREEN_EVERY_N_TICKS: u32 = 5;
 
+/// How often (in ticks) the monitor list is re-enumerated — 15 × 2s = 30s.
+/// The list is otherwise held across ticks and reused, not re-fetched every
+/// tick: `list_monitors()`/`list_monitors_detailed()` does a full native
+/// enumeration (on macOS with ScreenCaptureKit enabled, a fresh
+/// `SCShareableContent` fetch — a known-flaky OS subsystem best not hammered
+/// on a 2s cadence for content that changes only on hotplug). Mirrors
+/// upstream screenpipe's own split between a slow monitor-watcher and a
+/// cached per-frame capture path (`vision_manager/monitor_watcher.rs` +
+/// `SafeMonitor`'s internal `cached_sck`/`cached_xcap` handles, MIT-era
+/// commit 920bbcfd2a "perf: cache monitor handle... capture retry with
+/// refresh"). A monitor that disconnects mid-window just fails its capture
+/// calls until the next refresh (logged, skipped) — the same graceful
+/// degradation `capture_secondary_screens` already had per-monitor.
+const MONITOR_REFRESH_EVERY_N_TICKS: u32 = 15;
+
 /// Outcome of the per-tick accessibility-tree walk — decides what (if anything)
 /// the OCR fallback does this tick.
 enum A11yOutcome {
@@ -81,12 +96,18 @@ pub struct ScreenpipeEngine {
     /// domain open on a non-focused screen still gets caught, via the fork's
     /// own title-based blocked-URL heuristic.
     pub ignored_urls: Vec<String>,
+    /// On by default (`RuntimeSettings::capture_secondary_monitors`) — a
+    /// second monitor is captured whether or not it's the screen the user is
+    /// actively looking at. Exposed as a Settings → Capture & Privacy toggle
+    /// for anyone who wants to turn it off.
+    pub capture_secondary_monitors: bool,
 }
 
 impl CaptureEngine for ScreenpipeEngine {
     async fn run(self, tx: FrameTx) -> anyhow::Result<()> {
         let pause_on_streaming = self.pause_on_streaming_video;
         let ignored_urls = self.ignored_urls;
+        let capture_secondary_monitors = self.capture_secondary_monitors;
         // Register with TCC + drive both prompts ourselves. Neither library
         // prompts on its own: screen-capture enumeration only PREFLIGHTS, and
         // the AX tree reads nothing until this process is a trusted AX client.
@@ -106,13 +127,23 @@ impl CaptureEngine for ScreenpipeEngine {
         // motivating case). Lives for the whole engine run, single-threaded.
         let mut streaming_gate = StreamingGate::new();
 
-        // Counts ticks so the secondary-monitor sweep runs on its own slower
-        // cadence (see SECONDARY_SCREEN_EVERY_N_TICKS) without a second timer.
+        // Enumerated ONCE here, then held across ticks and only refreshed on
+        // its own slow cadence (MONITOR_REFRESH_EVERY_N_TICKS) — see that
+        // constant's doc comment. `SafeMonitor` is `Clone` and internally
+        // caches its native handle, so reusing the same instances tick after
+        // tick is what actually makes that per-monitor cache do anything;
+        // re-listing every tick (the previous design) silently defeated it.
+        let mut monitors = screenpipe_screen::monitor::list_monitors().await;
+
+        // Counts ticks so the secondary-monitor sweep and the monitor-list
+        // refresh each run on their own slower cadence without a second timer.
         let mut tick: u32 = 0;
 
         info!(
             interval_s = CAPTURE_INTERVAL.as_secs(),
             secondary_screen_interval_s = CAPTURE_INTERVAL.as_secs() * SECONDARY_SCREEN_EVERY_N_TICKS as u64,
+            monitor_refresh_interval_s = CAPTURE_INTERVAL.as_secs() * MONITOR_REFRESH_EVERY_N_TICKS as u64,
+            capture_secondary_monitors,
             "capture: screenpipe engine started (a11y-tree + OCR fallback + secondary-monitor sweep)"
         );
         loop {
@@ -148,6 +179,7 @@ impl CaptureEngine for ScreenpipeEngine {
                 pause_on_streaming,
                 &mut streaming_gate,
                 skip_ocr_for_streaming,
+                &monitors,
             )
             .await
             {
@@ -159,13 +191,22 @@ impl CaptureEngine for ScreenpipeEngine {
             };
 
             tick = tick.wrapping_add(1);
+
+            if tick.is_multiple_of(MONITOR_REFRESH_EVERY_N_TICKS) {
+                monitors = screenpipe_screen::monitor::list_monitors().await;
+            }
+
             // Only sweep when this tick actually resolved a primary window:
             // `false` means either a privacy Skip (never sweep — see
             // capture_secondary_screens docs) or nothing was captured at all
             // (streaming-blocked OCR, no focused window).
-            if tick.is_multiple_of(SECONDARY_SCREEN_EVERY_N_TICKS) && primary_captured {
+            if capture_secondary_monitors
+                && tick.is_multiple_of(SECONDARY_SCREEN_EVERY_N_TICKS)
+                && primary_captured
+            {
                 if let Err(e) =
-                    capture_secondary_screens(&tx, &ignored_urls, skip_ocr_for_streaming).await
+                    capture_secondary_screens(&tx, &monitors, &ignored_urls, skip_ocr_for_streaming)
+                        .await
                 {
                     warn!(error = %e, "capture: secondary-monitor sweep failed (will retry next cycle)");
                 }
@@ -370,6 +411,7 @@ async fn dispatch(
     pause_on_streaming: bool,
     streaming_gate: &mut StreamingGate,
     skip_ocr_for_streaming: bool,
+    monitors: &[screenpipe_screen::monitor::SafeMonitor],
 ) -> anyhow::Result<bool> {
     match outcome {
         A11yOutcome::Frame(frame) => {
@@ -386,7 +428,7 @@ async fn dispatch(
                 );
                 return Ok(false);
             }
-            capture_once_ocr(tx, pause_on_streaming, streaming_gate).await
+            capture_once_ocr(tx, pause_on_streaming, streaming_gate, monitors).await
         }
     }
 }
@@ -397,20 +439,23 @@ async fn dispatch(
 /// meridian's per-app ETL model.
 ///
 /// Returns whether it actually OCR'd and sent at least one window.
+///
+/// `monitors` is the engine's cached list (see `MONITOR_REFRESH_EVERY_N_TICKS`)
+/// — this no longer re-enumerates on every call.
 async fn capture_once_ocr(
     tx: &FrameTx,
     pause_on_streaming: bool,
     streaming_gate: &mut StreamingGate,
+    monitors: &[screenpipe_screen::monitor::SafeMonitor],
 ) -> anyhow::Result<bool> {
-    let monitors = screenpipe_screen::monitor::list_monitors().await;
-    let Some(monitor) = monitors.into_iter().next() else {
+    let Some(monitor) = monitors.first() else {
         anyhow::bail!("no monitors enumerated (Screen Recording not granted yet?)");
     };
 
     // No app/title/url filters; focused window(s) only (`capture_unfocused = false`)
     // — we capture what the user is actively on, not every background window.
     let filters = WindowFilters::new(&[], &[], &[]);
-    let windows = capture_all_visible_windows(&monitor, &filters, false)
+    let windows = capture_all_visible_windows(monitor, &filters, false)
         .await
         .map_err(|e| anyhow::anyhow!("capture_all_visible_windows: {e}"))?;
 
@@ -529,8 +574,12 @@ async fn send_frame(
 /// (`is_title_suggesting_blocked_url`, used for exactly this "unfocused
 /// browser window, no URL available" case) so a known-ignored domain open
 /// on a non-focused screen isn't captured just because it's out of focus.
+///
+/// `monitors` is the engine's cached list (see `MONITOR_REFRESH_EVERY_N_TICKS`)
+/// — this no longer re-enumerates on every sweep.
 async fn capture_secondary_screens(
     tx: &FrameTx,
+    monitors: &[screenpipe_screen::monitor::SafeMonitor],
     ignored_urls: &[String],
     skip_ocr_for_streaming: bool,
 ) -> anyhow::Result<()> {
@@ -541,11 +590,10 @@ async fn capture_secondary_screens(
         return Ok(());
     }
 
-    let monitors = screenpipe_screen::monitor::list_monitors().await;
     let filters = WindowFilters::new(&[], &[], ignored_urls);
     let now = Utc::now();
 
-    for monitor in &monitors {
+    for monitor in monitors {
         let windows = match capture_all_visible_windows(monitor, &filters, false).await {
             Ok(w) => w,
             Err(e) => {

--- a/tray/src-tauri/src/commands/daemon.rs
+++ b/tray/src-tauri/src/commands/daemon.rs
@@ -46,9 +46,9 @@ pub async fn restart_daemon() -> Result<(), String> {
 }
 
 /// Pause (stop) or resume (start) the daemon. On success, raises/clears a
-/// `tray.daemon_paused` notice — same `system.pause` event_key (and
-/// `notify_system_pause` toggle) as [`crate::commands::pause`]'s capture-pause
-/// notice, so quiet-hours/master-switch/per-type policy applies identically.
+/// `tray.daemon_paused` notice — same `system.pause` event_key as
+/// [`crate::commands::pause`]'s capture-pause notice, so quiet-hours/master-
+/// switch policy applies identically.
 ///
 /// Start/stop goes through [`super::daemon_control`] (launchd on macOS, the
 /// scheduled task on Windows) rather than `launchctl` directly.

--- a/tray/src-tauri/src/commands/diagnostics.rs
+++ b/tray/src-tauri/src/commands/diagnostics.rs
@@ -13,7 +13,7 @@
 //!
 //! # Who calls this
 //! `export_diagnostics_bundle` is registered in `lib.rs`'s `invoke_handler!`;
-//! consumed by `ui/components/timeline/settings/AdvancedSection.tsx`'s
+//! consumed by `ui/components/timeline/settings/AccountSection.tsx`'s
 //! "Export Diagnostics" button via `mutate`/`load` in `@/lib/bridge`.
 //!
 //! # Related

--- a/tray/src-tauri/src/commands/pause.rs
+++ b/tray/src-tauri/src/commands/pause.rs
@@ -19,8 +19,8 @@
 //!   this was split from.
 //! - [`crate::state::PauseSource`] — the pause-kind enum these commands set.
 //! - [`meridian::notices`] — the fault-bus the pause/resume notice routes through
-//!   (id `tray.paused`, event_key `system.pause`); quiet-hours/master-switch/the
-//!   `notify_system_pause` toggle are all enforced there, not by these commands.
+//!   (id `tray.paused`, event_key `system.pause`); quiet-hours/master-switch
+//!   policy is all enforced there, not by these commands.
 
 use crate::state::{AppState, PauseSource};
 use chrono::{DateTime, SecondsFormat, Utc};

--- a/tray/src-tauri/src/commands/plan_tasks.rs
+++ b/tray/src-tauri/src/commands/plan_tasks.rs
@@ -171,6 +171,7 @@ pub async fn create_plan_task(body: CreatePlanTaskBody) -> Result<CreatedTask, S
         synced = created.synced,
         "plan-task-create served"
     );
+    tauri::async_runtime::spawn(crate::counter_ping::ping_task_update());
     Ok(created)
 }
 
@@ -195,6 +196,7 @@ pub async fn edit_plan_task(body: EditPlanTaskBody) -> Result<EditResult, String
 
     let res: EditResult = run_meridian_json(&args, WRITE_TIMEOUT, "plan-task-edit").await?;
     tracing::info!(status = %res.status, provider = %res.provider, "plan-task-edit served");
+    tauri::async_runtime::spawn(crate::counter_ping::ping_task_update());
     Ok(res)
 }
 
@@ -215,6 +217,7 @@ pub async fn set_plan_task_done(body: SetPlanTaskDoneBody) -> Result<EditResult,
 
     let res: EditResult = run_meridian_json(&args, WRITE_TIMEOUT, "plan-task-done").await?;
     tracing::info!(status = %res.status, provider = %res.provider, "plan-task-done served");
+    tauri::async_runtime::spawn(crate::counter_ping::ping_task_update());
     Ok(res)
 }
 

--- a/tray/src-tauri/src/commands/plan_tasks.rs
+++ b/tray/src-tauri/src/commands/plan_tasks.rs
@@ -196,7 +196,11 @@ pub async fn edit_plan_task(body: EditPlanTaskBody) -> Result<EditResult, String
 
     let res: EditResult = run_meridian_json(&args, WRITE_TIMEOUT, "plan-task-edit").await?;
     tracing::info!(status = %res.status, provider = %res.provider, "plan-task-edit served");
-    tauri::async_runtime::spawn(crate::counter_ping::ping_task_update());
+    // Only count a real mutation: a `redirected` result wrote nothing (the
+    // tracker has no API for it, so we just hand back a browse URL).
+    if res.status == "applied" {
+        tauri::async_runtime::spawn(crate::counter_ping::ping_task_update());
+    }
     Ok(res)
 }
 
@@ -217,7 +221,11 @@ pub async fn set_plan_task_done(body: SetPlanTaskDoneBody) -> Result<EditResult,
 
     let res: EditResult = run_meridian_json(&args, WRITE_TIMEOUT, "plan-task-done").await?;
     tracing::info!(status = %res.status, provider = %res.provider, "plan-task-done served");
-    tauri::async_runtime::spawn(crate::counter_ping::ping_task_update());
+    // Only count a real mutation: a `redirected` result wrote nothing (the
+    // tracker has no API for it, so we just hand back a browse URL).
+    if res.status == "applied" {
+        tauri::async_runtime::spawn(crate::counter_ping::ping_task_update());
+    }
     Ok(res)
 }
 

--- a/tray/src-tauri/src/commands/settings.rs
+++ b/tray/src-tauri/src/commands/settings.rs
@@ -23,8 +23,8 @@
 //!   installs/manages a local OpenObserve service for them.
 //!
 //! **No UI writes these OTLP-shipping fields anymore** (the config panel was
-//! replaced by the "Export Diagnostics" button in `AdvancedSection.tsx` — see
-//! that component's history). This is intentional: OTLP shipping is a
+//! replaced by the "Export Diagnostics" button, now in `AccountSection.tsx`
+//! — see that component's history). This is intentional: OTLP shipping is a
 //! Dev/Bare-only, engineer-facing debugging feature (a packaged/Canonical
 //! install can never ship, regardless of these fields — see
 //! `is_canonical_install()`), so an engineer who wants their dev daemon to

--- a/tray/src-tauri/src/counter_ping.rs
+++ b/tray/src-tauri/src/counter_ping.rs
@@ -46,6 +46,7 @@ use meridian_core::SqlitePool;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 /// The live counter's public host — the meridiona.com marketing site.
@@ -152,11 +153,40 @@ fn save_state(path: &std::path::Path, state: &CounterPingState) {
     }
 }
 
+/// Single-flight guard for [`check_worklog_posts`]. Each poll tick *spawns* the
+/// check without awaiting it (a slow counter response must not stall the loop),
+/// so on a burst of newly-posted rows — each ping awaits up to 5s — one run can
+/// still be in flight when the next `do_worklogs` tick fires. Two overlapping
+/// runs would load the same on-disk dedup set, both see the same not-yet-pinged
+/// ids, and double-increment the public counter before either writes the set
+/// back. This flag makes the later run skip instead.
+static WORKLOG_CHECK_RUNNING: AtomicBool = AtomicBool::new(false);
+
+/// Clears [`WORKLOG_CHECK_RUNNING`] on drop, so the flag is released even if the
+/// check returns early or panics.
+struct RunningGuard;
+impl Drop for RunningGuard {
+    fn drop(&mut self) {
+        WORKLOG_CHECK_RUNNING.store(false, Ordering::Release);
+    }
+}
+
 /// Diff today's worklogs against the persisted pinged-id set and ping once
 /// per newly `posted` row. Called every poll tick, right after
 /// `poll::refresh::refresh_worklogs` reads the same list.
 #[tracing::instrument(skip(pool))]
 pub(crate) async fn check_worklog_posts(pool: &SqlitePool) {
+    // Skip if a prior tick's check is still running (see WORKLOG_CHECK_RUNNING),
+    // so overlapping runs can't double-count the same worklog ids.
+    if WORKLOG_CHECK_RUNNING
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        tracing::debug!("counter_ping: worklog check already in flight — skipping this tick");
+        return;
+    }
+    let _running = RunningGuard;
+
     let Some(path) = counter_ping_state_path() else {
         return;
     };

--- a/tray/src-tauri/src/counter_ping.rs
+++ b/tray/src-tauri/src/counter_ping.rs
@@ -1,0 +1,243 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Public "worklog/task update" counter — a single fire-and-forget ping to the
+//! meridiona.com website's live counter, incremented once per confirmed
+//! worklog post or personal-task create/update, powering the "N updates
+//! logged and counting" stat on the landing page.
+//!
+//! # What this is
+//! A single POST to `{COUNTER_HOST}/api/counter/increment`, no payload beyond
+//! auth — the website only needs to know "one more happened", not who or
+//! what. Gated to `build_channel() == "prod"` so dev/staging runs never
+//! inflate the public number (mirrors how `analytics.rs` tags every event
+//! with a `channel` property instead — but this endpoint has no room for a
+//! property, so non-prod channels are filtered out entirely rather than sent
+//! and later excluded by a dashboard filter).
+//!
+//! Two call shapes:
+//! - **Personal task create/update** — a direct, one-shot [`ping_task_update`]
+//!   call from the `#[tauri::command]` wrappers in `commands::plan_tasks`,
+//!   right after `run_meridian_json` confirms success. A single command
+//!   invocation IS the event; no dedup needed.
+//! - **Worklog posted to a PM provider** — the state transition happens in
+//!   the daemon process (`src/pm_worklog/post.rs`), a separate OS process the
+//!   tray has no direct hook into. [`check_worklog_posts`] instead diffs
+//!   today's worklogs (already read every poll tick by
+//!   `poll::refresh::refresh_worklogs`) against a persisted set of
+//!   already-pinged ids, so a newly `posted` row is caught within one ~60s
+//!   tick without the daemon needing any analytics wiring of its own.
+//!
+//! **Best-effort, not exactly-once.** Unlike `analytics.rs`'s retry-until-success
+//! bookkeeping, a failed [`ping_task_update`] is simply dropped. The
+//! worklog-diff path is slightly sturdier: an id is only added to the pinged
+//! set on a successful ping, so a network blip retries it next tick. Either
+//! way, a public vanity counter occasionally missing an increment is an
+//! accepted tradeoff — it doesn't justify `daily_usage`-grade retry machinery.
+//!
+//! # Who calls this
+//! - `commands::plan_tasks::{create_plan_task, edit_plan_task, set_plan_task_done}`
+//! - `poll::mod` (via [`check_worklog_posts`], right after `refresh_worklogs`)
+//!
+//! # Related
+//! - [`crate::analytics`] — the sibling PostHog pipeline; same channel-gating
+//!   idea, different endpoint and no per-event identity.
+//! - `crate::commands::version::build_channel`
+
+use meridian_core::SqlitePool;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// The live counter's public host — the meridiona.com marketing site.
+const COUNTER_HOST: &str = "https://meridiona.com";
+
+/// Compiled-in shared secret for the increment endpoint (mirrors
+/// `analytics::DEFAULT_POSTHOG_API_KEY` — a build-time secret via
+/// `MERIDIAN_COUNTER_API_KEY`, empty in a plain source build, which disables
+/// the ping entirely rather than sending an unauthenticated request the
+/// website would reject).
+const DEFAULT_COUNTER_API_KEY: &str = match option_env!("MERIDIAN_COUNTER_API_KEY") {
+    Some(k) => k,
+    None => "",
+};
+
+/// Resolve the shared secret: the `COUNTER_API_KEY` runtime env override
+/// (e.g. set in `~/.meridian/.env` for a source/dev build) if set and
+/// non-blank, else the compiled-in [`DEFAULT_COUNTER_API_KEY`].
+fn counter_api_key() -> String {
+    std::env::var("COUNTER_API_KEY")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_COUNTER_API_KEY.to_string())
+}
+
+/// POST one increment to the public counter. Returns `true` (a no-op success,
+/// so one-shot callers never treat it as a failure worth retrying) on any
+/// non-`prod` channel or a missing key; a real network/non-2xx failure
+/// returns `false`.
+async fn ping_increment(reason: &str) -> bool {
+    if crate::commands::version::build_channel() != "prod" {
+        tracing::debug!(reason, "counter_ping: non-prod channel — skipping");
+        return true;
+    }
+    let key = counter_api_key();
+    if key.is_empty() {
+        tracing::debug!(reason, "counter_ping: no counter key configured — skipping");
+        return true;
+    }
+    let result = reqwest::Client::new()
+        .post(format!("{COUNTER_HOST}/api/counter/increment"))
+        .bearer_auth(key)
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await;
+    match result {
+        Ok(resp) if resp.status().is_success() => {
+            tracing::debug!(reason, "counter_ping: incremented");
+            true
+        }
+        Ok(resp) => {
+            tracing::warn!(reason, status = %resp.status(), "counter_ping: rejected");
+            false
+        }
+        Err(e) => {
+            tracing::warn!(reason, error = %e, "counter_ping: request failed");
+            false
+        }
+    }
+}
+
+/// One-shot ping for a personal-task create/update, called right after the
+/// owning `#[tauri::command]` confirms success. Callers spawn this via
+/// `tauri::async_runtime::spawn` rather than awaiting it inline, so a slow
+/// counter response never delays the command's response to the UI.
+pub(crate) async fn ping_task_update() {
+    ping_increment("task_update").await;
+}
+
+/// Persisted dedup state for [`check_worklog_posts`] — a plain per-day set of
+/// already-pinged `pm_worklogs.id` values, so a tray restart mid-day doesn't
+/// re-ping rows it already reported. Reset whenever the local day rolls over,
+/// since `refresh_worklogs` (and this check) only ever reads today's rows.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct CounterPingState {
+    day: String,
+    #[serde(default)]
+    pinged_worklog_ids: HashSet<i64>,
+}
+
+fn counter_ping_state_path() -> Option<PathBuf> {
+    meridian_core::paths::home_dir().map(|h| h.join(".meridian/counter_ping_state.json"))
+}
+
+/// Load the state file, starting a fresh (empty) set if absent, unparseable,
+/// or stamped for a previous day.
+fn load_state(path: &std::path::Path, today: &str) -> CounterPingState {
+    if let Ok(s) = std::fs::read_to_string(path) {
+        if let Ok(state) = serde_json::from_str::<CounterPingState>(&s) {
+            if state.day == today {
+                return state;
+            }
+        }
+    }
+    CounterPingState {
+        day: today.to_string(),
+        pinged_worklog_ids: HashSet::new(),
+    }
+}
+
+fn save_state(path: &std::path::Path, state: &CounterPingState) {
+    if let Err(e) = meridian_core::fs_utils::atomic_write_json(path, state) {
+        tracing::warn!(error = %e, "counter_ping: could not persist state file");
+    }
+}
+
+/// Diff today's worklogs against the persisted pinged-id set and ping once
+/// per newly `posted` row. Called every poll tick, right after
+/// `poll::refresh::refresh_worklogs` reads the same list.
+#[tracing::instrument(skip(pool))]
+pub(crate) async fn check_worklog_posts(pool: &SqlitePool) {
+    let Some(path) = counter_ping_state_path() else {
+        return;
+    };
+    let today = meridian_core::date::today_string();
+    let mut state = load_state(&path, &today);
+
+    let worklogs = match meridian_core::worklogs::get_worklogs(pool, &today).await {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::warn!(error = %e, "counter_ping: worklogs read failed");
+            return;
+        }
+    };
+
+    let newly_posted: Vec<i64> = worklogs
+        .items
+        .iter()
+        .filter(|i| i.state == "posted" && !state.pinged_worklog_ids.contains(&i.id))
+        .map(|i| i.id)
+        .collect();
+
+    let mut dirty = false;
+    for id in newly_posted {
+        if ping_increment("worklog_posted").await {
+            state.pinged_worklog_ids.insert(id);
+            dirty = true;
+        }
+    }
+
+    if dirty {
+        save_state(&path, &state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A state file written for a previous day must not leak its pinged ids
+    /// into today — otherwise a worklog posted today that happens to reuse an
+    /// id pinged on a prior day (or, more realistically, a stale file left
+    /// behind by a bug) would be silently skipped.
+    #[test]
+    fn load_state_resets_on_day_change() {
+        let path = std::env::temp_dir().join(format!(
+            "meridian_counter_ping_test_{}.json",
+            std::process::id()
+        ));
+        let stale = CounterPingState {
+            day: "2026-01-01".to_string(),
+            pinged_worklog_ids: HashSet::from([1, 2, 3]),
+        };
+        std::fs::write(&path, serde_json::to_string(&stale).unwrap()).unwrap();
+
+        let state = load_state(&path, "2026-01-02");
+
+        assert_eq!(state.day, "2026-01-02");
+        assert!(state.pinged_worklog_ids.is_empty());
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Same-day reload must preserve the already-pinged ids — otherwise a
+    /// tray restart mid-day would re-ping every worklog posted before it.
+    #[test]
+    fn load_state_preserves_same_day_ids() {
+        let path = std::env::temp_dir().join(format!(
+            "meridian_counter_ping_test_same_{}.json",
+            std::process::id()
+        ));
+        let today = CounterPingState {
+            day: "2026-01-02".to_string(),
+            pinged_worklog_ids: HashSet::from([42]),
+        };
+        std::fs::write(&path, serde_json::to_string(&today).unwrap()).unwrap();
+
+        let state = load_state(&path, "2026-01-02");
+
+        assert_eq!(state.day, "2026-01-02");
+        assert!(state.pinged_worklog_ids.contains(&42));
+
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@
 //! - [`counter_ping`] — public "updates logged" live-counter ping (prod channel only).
 
 mod analytics;
+mod autostart;
 mod backend_install;
 #[cfg(feature = "capture")]
 mod capture;
@@ -132,6 +133,18 @@ pub fn run() {
         builder = builder.plugin(tauri_plugin_notifications::init());
     } else {
         tracing::info!("unbundled run — notifications plugin not registered, toasts disabled");
+    }
+    // Launch-at-login (see `autostart.rs`). Bundled only, same rationale as
+    // notifications above: an unbundled `cargo run`/`tauri dev` binary lives
+    // under `target/`, and registering a login item pointing at that path
+    // would be both wrong (dev builds move/vanish) and surprising.
+    if sys::is_bundled() {
+        builder = builder.plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            None,
+        ));
+    } else {
+        tracing::info!("unbundled run — autostart plugin not registered, no login item");
     }
     builder
         .manage(app_state.clone())
@@ -410,6 +423,20 @@ pub fn run() {
             tauri::async_runtime::spawn(async move {
                 poll::run_daemon_watchdog().await;
             });
+
+            // Launch-at-login: self-heal (once ever, see autostart.rs) so the
+            // tray comes back on its own after a reboot/re-login instead of
+            // needing a manual relaunch. Bundled only — the plugin above is
+            // only registered there, so `app.autolaunch()` has no state
+            // otherwise. Spawned off the setup hook like the backend install
+            // below: it does file + `auto_launch` I/O that shouldn't block
+            // tray startup.
+            if sys::is_bundled() {
+                let autostart_handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    autostart::ensure_enabled_once(&autostart_handle).await;
+                });
+            }
 
             // Stage + register the bundled daemon on the self-contained .app DMG
             // path (also retires any leftover a11y-helper agent from an older

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -1111,7 +1111,7 @@ pub(crate) fn start_capture(
     // shared handle, so a Settings change never needs a capture restart.
     let settings = meridian_core::settings::load_runtime_settings();
     let pause_on_streaming_video = settings.pause_on_streaming_video;
-    // Off by default — see the field doc comment on RuntimeSettings.
+    // On by default — see the field doc comment on RuntimeSettings.
     let capture_secondary_monitors = settings.capture_secondary_monitors;
     // Handed to the engine's secondary-monitor sweep (multi-screen capture):
     // unlike the primary a11y/OCR path, those windows are never

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@
 //! - [`sys`]         — shared uid / notify / dashboard-URL helpers.
 //! - [`format`]      — duration formatting for the popover.
 //! - [`analytics`]   — PostHog product-analytics capture (DMG installs only).
+//! - [`counter_ping`] — public "updates logged" live-counter ping (prod channel only).
 
 mod analytics;
 mod backend_install;
@@ -23,6 +24,7 @@ mod capture;
 // it must exist in non-capture builds too (nothing reads it there — harmless).
 mod capture_ignore;
 mod commands;
+mod counter_ping;
 mod deep_link;
 
 /// Lowercase product name as macOS reports it after [`set_process_display_name`].

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -1077,6 +1077,8 @@ pub(crate) fn start_capture(
     // shared handle, so a Settings change never needs a capture restart.
     let settings = meridian_core::settings::load_runtime_settings();
     let pause_on_streaming_video = settings.pause_on_streaming_video;
+    // Off by default — see the field doc comment on RuntimeSettings.
+    let capture_secondary_monitors = settings.capture_secondary_monitors;
     // Handed to the engine's secondary-monitor sweep (multi-screen capture):
     // unlike the primary a11y/OCR path, those windows are never
     // system-focused, so the fork never resolves their `browser_url` for the
@@ -1198,6 +1200,7 @@ pub(crate) fn start_capture(
         let engine = ScreenpipeEngine {
             pause_on_streaming_video,
             ignored_urls,
+            capture_secondary_monitors,
         };
         tokio::select! {
             _ = &mut engine_cancel_rx => {

--- a/tray/src-tauri/src/poll/mod.rs
+++ b/tray/src-tauri/src/poll/mod.rs
@@ -78,6 +78,14 @@ pub async fn run_poll_loop(app: tauri::AppHandle, state: Arc<Mutex<AppState>>) {
             }
             if do_worklogs {
                 refresh_worklogs(pool, &state).await;
+                // Spawned off, not awaited inline: this can make one HTTP call
+                // per newly-posted worklog this tick, and a slow/hanging
+                // counter response (5s timeout each) must not delay the
+                // more user-visible steps below.
+                let counter_pool = pool.clone();
+                tauri::async_runtime::spawn(async move {
+                    crate::counter_ping::check_worklog_posts(&counter_pool).await;
+                });
             }
             if do_health {
                 permissions::check_permissions(&app, pool).await;

--- a/tray/src-tauri/src/poll/plan_auto_open.rs
+++ b/tray/src-tauri/src/poll/plan_auto_open.rs
@@ -12,9 +12,8 @@
 //!    holds a timestamp — `meridian_core::plan_marker` — refreshed when the
 //!    user dismisses the planner, which the daemon reads to hold its plan
 //!    nudge back until an hour after the open/dismissal)
-//! 2. `auto_open_plan` disabled in settings
-//! 3. not onboarded (no `~/.meridian/onboarded` — don't open over the wizard)
-//! 4. today's plan already confirmed/skipped (`daily_plan_meta`) — the marker
+//! 2. not onboarded (no `~/.meridian/onboarded` — don't open over the wizard)
+//! 3. today's plan already confirmed/skipped (`daily_plan_meta`) — the marker
 //!    is written WITHOUT opening, so the day stays settled
 //!
 //! The marker is written BEFORE the window opens: under launchd `KeepAlive` a
@@ -58,17 +57,12 @@ pub(crate) async fn maybe_auto_open_plan(app: &tauri::AppHandle, pool: &meridian
         return;
     }
 
-    // 2. Feature toggle.
-    if !meridian_core::settings::load_runtime_settings().auto_open_plan {
-        return;
-    }
-
-    // 3. Don't open the planner over (or instead of) the first-run wizard.
+    // 2. Don't open the planner over (or instead of) the first-run wizard.
     if !meridian_dir.join("onboarded").exists() {
         return;
     }
 
-    // 4. Day already planned (confirmed or skipped, e.g. via the notification
+    // 3. Day already planned (confirmed or skipped, e.g. via the notification
     //    nudge) — settle the day without opening.
     if meridian_core::plan::plan_handled(pool, &today).await {
         write_marker(&marker, &now);

--- a/tray/src-tauri/src/update.rs
+++ b/tray/src-tauri/src/update.rs
@@ -31,9 +31,9 @@
 //!
 //! # Related
 //! - [`notify_update`] — routes every tray-menu toast through the outbox
-//!   (event_key `system.update`) instead of a direct bypass, so quiet-hours,
-//!   the master switch, and the `notify_system_update` toggle all apply —
-//!   previously these six call sites skipped that policy entirely.
+//!   (event_key `system.update`) instead of a direct bypass, so quiet-hours
+//!   and the master switch all apply — previously these six call sites
+//!   skipped that policy entirely.
 //! - `scripts/package-updater.sh` — the producer of the `Minimum-Version:` notes
 //!   line (reads the optional `tray/minimum-version` file at release time).
 //! - Plan: Obsidian `Decisions/Public distribution + auto-update for the DMG`.
@@ -51,8 +51,8 @@ use tauri_plugin_updater::UpdaterExt;
 /// one-shot event (a check outcome, a download starting), not an ongoing
 /// condition to raise/clear like [`meridian::notices`] models — so this goes
 /// straight to [`meridian::notifications::enqueue`], gated by `system.update`
-/// (master switch + quiet hours + the `notify_system_update` toggle) the same
-/// way every other outbox producer is. `dedup_suffix` only needs to be unique
+/// (master switch + quiet hours) the same way every other outbox producer
+/// is. `dedup_suffix` only needs to be unique
 /// per call (the current timestamp is fine — these are user-triggered or
 /// rare background events, never a tight loop that would spam distinct keys).
 async fn notify_update(app: &AppHandle, dedup_suffix: &str, title: &str, body: &str) {

--- a/tray/src-tauri/src/update.rs
+++ b/tray/src-tauri/src/update.rs
@@ -188,6 +188,40 @@ fn is_packaged() -> bool {
     crate::sys::is_bundled()
 }
 
+/// Marks an `"unsupported"` [`UpdateStatus`] whose `error` field is a reason
+/// code (`"no-platform-asset"`), not an error to alarm the user with — see
+/// [`is_missing_platform_asset`].
+const NO_PLATFORM_ASSET: &str = "no-platform-asset";
+
+/// True for the `tauri-plugin-updater` errors that mean "this platform has no
+/// published update artifact in `latest.json`" rather than a real check
+/// failure. Concretely this is Windows ARM64 today: `scripts/package-updater-windows.sh`
+/// only ever writes the `windows-x86_64` / `windows-x86_64-nsis` keys (the
+/// `.github/workflows/release-build.yml` `windows` job builds on `windows-latest`,
+/// i.e. x86_64, only — there is no ARM64 Windows release job), so an ARM64
+/// install's updater lookup can never match anything the manifest carries.
+///
+/// Surfacing that as `state: "error"` toasts a scary, unactionable "Update
+/// check failed" on *every* check, forever, for every ARM64 Windows install —
+/// there is no retry that fixes it. Bucketing it with `"unsupported"` (the
+/// same state used for an unbundled dev run) makes both the tray toast and the
+/// dashboard banner go quiet instead, same as the DMG updater already does for
+/// npm-installed CLIs.
+///
+/// Deliberately narrow: only `TargetNotFound`/`TargetsNotFound` map here.
+/// Every other error (network, signature, 404 on `latest.json` itself) still
+/// reports `"error"` — CI's `verify-release-bundle.sh` / `compose-updater-manifest.py`
+/// already fail the release loudly if an *expected* platform key (darwin-aarch64,
+/// windows-x86_64, …) goes missing, so a real regression there won't get
+/// silently swallowed by this.
+fn is_missing_platform_asset(e: &tauri_plugin_updater::Error) -> bool {
+    matches!(
+        e,
+        tauri_plugin_updater::Error::TargetNotFound(_)
+            | tauri_plugin_updater::Error::TargetsNotFound(_)
+    )
+}
+
 /// Check the configured endpoint for a newer version. A pure status read — does
 /// NOT download — so it's safe on every popover open / sidebar mount.
 #[tracing::instrument(skip(app))]
@@ -221,6 +255,12 @@ pub async fn check_status(app: &AppHandle) -> UpdateStatus {
         Ok(None) => {
             tracing::info!("update: already up to date");
             UpdateStatus::simple("uptodate", current)
+        }
+        Err(e) if is_missing_platform_asset(&e) => {
+            tracing::info!(error = %e, "update: no published artifact for this platform — reporting unsupported");
+            let mut status = UpdateStatus::simple("unsupported", current);
+            status.error = Some(NO_PLATFORM_ASSET.to_string());
+            status
         }
         Err(e) => {
             tracing::warn!(error = %e, "update: check failed");
@@ -496,13 +536,18 @@ pub fn check_for_updates(app: &AppHandle) {
                 .await;
             }
             "unsupported" => {
-                notify_update(
-                    &app,
-                    "unsupported",
-                    "Updates via npm",
-                    "This build updates with `meridian update`.",
-                )
-                .await;
+                let (title, body) = if status.error.as_deref() == Some(NO_PLATFORM_ASSET) {
+                    (
+                        "Auto-update not available",
+                        "This build doesn't have a published update package yet.",
+                    )
+                } else {
+                    (
+                        "Updates via npm",
+                        "This build updates with `meridian update`.",
+                    )
+                };
+                notify_update(&app, "unsupported", title, body).await;
             }
             _ => {
                 let msg = status
@@ -613,6 +658,36 @@ mod tests {
         let (min, notes) = split_minimum_version("");
         assert_eq!(min, None);
         assert_eq!(notes, None);
+    }
+
+    #[test]
+    fn missing_platform_asset_matches_target_not_found_variants() {
+        // The Windows ARM64 case this exists for: `windows-x86_64`-only
+        // manifests never carry a `windows-aarch64*` key, so the updater
+        // fails with one of these two variants depending on whether it fell
+        // back to a second key before giving up.
+        assert!(is_missing_platform_asset(
+            &tauri_plugin_updater::Error::TargetNotFound("windows-aarch64".to_string())
+        ));
+        assert!(is_missing_platform_asset(
+            &tauri_plugin_updater::Error::TargetsNotFound(vec![
+                "windows-aarch64-nsis".to_string(),
+                "windows-aarch64".to_string(),
+            ])
+        ));
+    }
+
+    #[test]
+    fn other_updater_errors_are_not_treated_as_missing_platform_asset() {
+        // A real failure (unreachable manifest, no endpoints configured) must
+        // still surface as `state: "error"` — only the two lookup-miss
+        // variants above should get swallowed into "unsupported".
+        assert!(!is_missing_platform_asset(
+            &tauri_plugin_updater::Error::EmptyEndpoints
+        ));
+        assert!(!is_missing_platform_asset(
+            &tauri_plugin_updater::Error::ReleaseNotFound
+        ));
     }
 
     /// The comparison `check_status` performs: strictly-below is mandatory,

--- a/ui/__tests__/advanced-tab-hidden.test.ts
+++ b/ui/__tests__/advanced-tab-hidden.test.ts
@@ -1,0 +1,45 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+
+// Guards the "Advanced" settings tab being hidden from the sidebar/modal, and
+// specifically the regression a review caught: hiding it must NOT also hide
+// "Export Diagnostics" — a packaged install's only GUI path to handing a
+// developer a local telemetry bundle (see CLAUDE.md's "Telemetry: local-only
+// capture, dev-only shipping"). That control was moved to AccountSection.tsx,
+// which stays reachable, rather than dropped.
+
+const uiRoot = import.meta.dir + '/..'
+const readSrc = (rel: string): string => readFileSync(uiRoot + '/' + rel, 'utf8')
+
+describe('Advanced tab is hidden, not deleted', () => {
+  it('the sidebar nav entry is commented out, not removed', () => {
+    const src = readSrc('components/timeline/settings/SettingsSidebar.tsx')
+    expect(src).toContain("// { id: 'advanced'")
+    expect(src).not.toMatch(/^\s*\{\s*id:\s*'advanced'/m)
+  })
+
+  it("the modal's render branch is commented out, not removed", () => {
+    const src = readSrc('components/timeline/SettingsModal.tsx')
+    expect(src).toContain("{/* {section === 'advanced' && (")
+    expect(src).not.toMatch(/^\s*\{section === 'advanced' && \(/m)
+  })
+})
+
+describe('Export Diagnostics stays reachable via Account', () => {
+  const accountSrc = readSrc('components/timeline/settings/AccountSection.tsx')
+  const advancedSrc = readSrc('components/timeline/settings/AdvancedSection.tsx')
+
+  it('AccountSection wires the export button through useExportDiagnostics', () => {
+    expect(accountSrc).toContain("import { useExportDiagnostics } from './useExportDiagnostics'")
+    expect(accountSrc).toContain('exportBundle')
+    expect(accountSrc).toContain('Export Diagnostics')
+  })
+
+  it('AdvancedSection no longer duplicates the export button', () => {
+    // A doc comment may still mention it moved; the functional wiring must not.
+    expect(advancedSrc).not.toContain('useExportDiagnostics(')
+    expect(advancedSrc).not.toContain('exportBundle')
+    expect(advancedSrc).not.toContain('<SettingsButton onClick={exportBundle}')
+  })
+})

--- a/ui/__tests__/llm-provider-connection-phase.test.ts
+++ b/ui/__tests__/llm-provider-connection-phase.test.ts
@@ -1,0 +1,129 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// The three states a provider card can be in, and what the user sees for each:
+//
+//   1. NOT INSTALLED AT ALL       — probed.installed === false
+//   2. INSTALLED, NOT AUTHENTICATED — probed.installed === true, but the real "Test" call
+//      (test_llm_provider -> src/llm/detect.rs::test_provider, a genuine live request to the
+//      CLI — this IS the "send a live request and check the response" button) came back
+//      failed. Meridian never claims to know auth state up front (`authenticated` is always
+//      null — see api-types.ts) — "signed in or not" is only ever answered by actually trying
+//      a real call, which is exactly what the Test button does.
+//   3. INSTALLED, AUTHENTICATED, WORKING — the same real call came back `{status: 'ok'}`.
+//
+// `phaseFor` is imported and exercised for real — it is the single place these three states
+// (plus the transient installing/signing/testing ones) collapse into what the card renders.
+// The rest is scanned from source — this repo has no React render harness (see
+// worklog-propose-provider.test.ts).
+
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { phaseFor } from '../components/LlmProviderDetail'
+import type { ProviderStatus, ProviderTestResult } from '../lib/api-types'
+
+const src = (p: string) => readFileSync(join(import.meta.dir, '..', p), 'utf8')
+const detail = src('components/LlmProviderDetail.tsx')
+
+const status = (installed: boolean, path: string | null = null): ProviderStatus => ({
+  id: 'codex',
+  installed,
+  path,
+  authenticated: null,
+  last_test: null,
+})
+
+const testResult = (outcome: ProviderTestResult['outcome']): ProviderTestResult => ({
+  id: 'codex',
+  outcome,
+  elapsed_ms: 1234,
+  tested_at: '2026-07-24T12:00:00Z',
+})
+
+describe('phaseFor — scenario 1: not installed at all', () => {
+  it('is not_installed once probed and absent, with no prior test on record', () => {
+    expect(phaseFor(false, false, false, status(false), null).kind).toBe('not_installed')
+  })
+
+  it('is STILL not_installed even if a stale last_test says ok — a since-uninstalled CLI must not read as working', () => {
+    const stale = testResult({ status: 'ok' })
+    expect(phaseFor(false, false, false, status(false), stale).kind).toBe('not_installed')
+  })
+
+  it('is unknown, not not_installed, when the probe itself has not resolved yet (no false "missing" flash on mount)', () => {
+    expect(phaseFor(false, false, false, undefined, null).kind).toBe('unknown')
+  })
+})
+
+describe('phaseFor — scenario 2: installed, not authenticated', () => {
+  it('is failed once a real Test call comes back failed', () => {
+    const failed = testResult({ status: 'failed', message: 'not authenticated' })
+    const phase = phaseFor(false, false, false, status(true, '/usr/local/bin/codex'), failed)
+    expect(phase.kind).toBe('failed')
+    expect(phase.kind === 'failed' && phase.message).toBe('not authenticated')
+  })
+
+  it('is ready_untested when installed but no Test has been run yet — the state before the user has clicked anything', () => {
+    const phase = phaseFor(false, false, false, status(true, '/usr/local/bin/codex'), null)
+    expect(phase.kind).toBe('ready_untested')
+  })
+
+  it('is rate_limited, not failed, when the account is signed in but temporarily capped — a different fix than "sign in"', () => {
+    const limited = testResult({ status: 'rate_limited', message: 'usage limit' })
+    const phase = phaseFor(false, false, false, status(true), limited)
+    expect(phase.kind).toBe('rate_limited')
+  })
+})
+
+describe('phaseFor — scenario 3: installed, authenticated, working', () => {
+  it('is ok once a real Test call succeeds', () => {
+    const ok = testResult({ status: 'ok' })
+    expect(phaseFor(false, false, false, status(true, '/usr/local/bin/codex'), ok).kind).toBe('ok')
+  })
+})
+
+describe('phaseFor — transient / in-flight states win over any stale result', () => {
+  it('installing beats everything else', () => {
+    const ok = testResult({ status: 'ok' })
+    expect(phaseFor(true, false, false, status(true), ok).kind).toBe('installing')
+  })
+
+  it('signing beats everything else', () => {
+    expect(phaseFor(false, true, false, status(true), null).kind).toBe('signing')
+  })
+
+  it('testing (the Test button, in flight) beats a stale prior result', () => {
+    const failed = testResult({ status: 'failed', message: 'old failure' })
+    expect(phaseFor(false, false, true, status(true), failed).kind).toBe('testing')
+  })
+})
+
+// ── The Test button really does send one real request — not a canned/local check ──────────
+
+it('onTest is wired straight to the real backend test command, not a local heuristic', () => {
+  // detail.tsx takes onTest as a prop and never computes install/auth state itself — the
+  // picker (one level up) owns the actual invoke() call. Assert the prop is threaded through
+  // to both places a user can trigger it, so a future refactor can't quietly stub it out.
+  expect(detail).toMatch(/onTest\s*:\s*\(\)\s*=>\s*void/)
+  expect(detail).toMatch(/onClick=\{onTest\}/)
+})
+
+const picker = src('components/LlmProviderPicker.tsx')
+
+it("the picker's test handler invokes the real Tauri command against the live CLI, not a mock", () => {
+  expect(picker).toMatch(/invoke<ProviderTestResult>\('test_llm_provider'/)
+})
+
+// ── Cursor gets bespoke "not signed in" copy for an unclassified failure; every other ──────
+// ── provider shows the raw message. Both must still originate from the SAME real Test call.
+
+it('the Cursor-specific "not signed in" copy only replaces the DISPLAY, not the trigger — it is still gated on phase.kind === "failed"', () => {
+  const cursorBranch = detail.slice(detail.indexOf("case 'failed':"))
+  expect(cursorBranch).toMatch(/if \(isCursor\)/)
+  expect(cursorBranch).toMatch(/not signed in yet/)
+  expect(cursorBranch).toMatch(/Sign in to Cursor/)
+})
+
+it('every other provider surfaces the real failure message verbatim, not a generic substitute', () => {
+  expect(detail).toMatch(/isn&apos;t responding: \{phase\.message\}/)
+})

--- a/ui/__tests__/lru.test.ts
+++ b/ui/__tests__/lru.test.ts
@@ -87,4 +87,25 @@ describe('LruMap', () => {
     expect(() => new LruMap<string, number>(0)).toThrow()
     expect(() => new LruMap<string, number>(-1)).toThrow()
   })
+
+  it('rejects NaN/Infinity/fractional capacity (they would disable eviction)', () => {
+    // `NaN < 1` and `Infinity < 1` are both false, so a bare `< 1` guard would
+    // accept them and then `size > capacity` never fires — no bound at all.
+    expect(() => new LruMap<string, number>(NaN)).toThrow()
+    expect(() => new LruMap<string, number>(Infinity)).toThrow()
+    expect(() => new LruMap<string, number>(2.5)).toThrow()
+  })
+
+  it('evicts an explicit undefined key like any other (no sentinel confusion)', () => {
+    // An `undefined` key is a valid Map entry; eviction must not skip it just
+    // because it equals the empty-iterator sentinel value.
+    const m = new LruMap<string | undefined, number>(2)
+    m.set(undefined, 1) // oldest
+    m.set('b', 2)
+    m.set('c', 3) // pushes past capacity — the undefined-keyed entry must go
+    expect(m.has(undefined)).toBe(false)
+    expect(m.get('b')).toBe(2)
+    expect(m.get('c')).toBe(3)
+    expect(m.size).toBe(2)
+  })
 })

--- a/ui/__tests__/lru.test.ts
+++ b/ui/__tests__/lru.test.ts
@@ -1,0 +1,90 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import { describe, it, expect } from 'bun:test'
+import { LruMap } from '../lib/lru'
+
+// LruMap backs the module-level webview stores (planStore.ts, useWorklog.ts,
+// app-icons.ts) that live for the whole Tauri session — this is the shared
+// eviction logic added so those stores stop growing by one entry per
+// distinct key forever (memory-leak-audit fix).
+
+describe('LruMap', () => {
+  it('get/set round-trip like a Map for keys within capacity', () => {
+    const m = new LruMap<string, number>(3)
+    m.set('a', 1)
+    m.set('b', 2)
+    expect(m.get('a')).toBe(1)
+    expect(m.get('b')).toBe(2)
+    expect(m.get('missing')).toBeUndefined()
+    expect(m.size).toBe(2)
+  })
+
+  it('stores a value of null distinctly from "not cached" (undefined)', () => {
+    const m = new LruMap<string, string | null>(3)
+    m.set('a', null)
+    expect(m.has('a')).toBe(true)
+    expect(m.get('a')).toBeNull()
+    expect(m.get('never-set')).toBeUndefined()
+  })
+
+  it('evicts the least-recently-used entry once capacity is exceeded', () => {
+    const m = new LruMap<string, number>(2)
+    m.set('a', 1)
+    m.set('b', 2)
+    m.set('c', 3) // capacity 2 — 'a' (oldest, untouched) must be evicted
+
+    expect(m.has('a')).toBe(false)
+    expect(m.get('b')).toBe(2)
+    expect(m.get('c')).toBe(3)
+    expect(m.size).toBe(2)
+  })
+
+  it('a get() on a key protects it from eviction (recency, not insertion order)', () => {
+    const m = new LruMap<string, number>(2)
+    m.set('a', 1)
+    m.set('b', 2)
+    m.get('a') // touch 'a' — now 'b' is the least-recently-used
+    m.set('c', 3)
+
+    expect(m.has('b')).toBe(false)
+    expect(m.get('a')).toBe(1)
+    expect(m.get('c')).toBe(3)
+  })
+
+  it('overwriting an existing key bumps its recency without growing size', () => {
+    const m = new LruMap<string, number>(2)
+    m.set('a', 1)
+    m.set('b', 2)
+    m.set('a', 10) // re-set 'a' — now 'b' is the least-recently-used
+    m.set('c', 3)
+
+    expect(m.size).toBe(2)
+    expect(m.has('b')).toBe(false)
+    expect(m.get('a')).toBe(10)
+  })
+
+  it('never exceeds capacity across many inserts', () => {
+    const m = new LruMap<number, number>(5)
+    for (let i = 0; i < 1000; i++) {
+      m.set(i, i)
+    }
+    expect(m.size).toBe(5)
+    // Only the last 5 keys (995..999) should survive.
+    for (let i = 995; i < 1000; i++) {
+      expect(m.get(i)).toBe(i)
+    }
+    expect(m.get(0)).toBeUndefined()
+  })
+
+  it('delete removes an entry and reduces size', () => {
+    const m = new LruMap<string, number>(3)
+    m.set('a', 1)
+    expect(m.delete('a')).toBe(true)
+    expect(m.has('a')).toBe(false)
+    expect(m.size).toBe(0)
+  })
+
+  it('rejects a non-positive capacity', () => {
+    expect(() => new LruMap<string, number>(0)).toThrow()
+    expect(() => new LruMap<string, number>(-1)).toThrow()
+  })
+})

--- a/ui/__tests__/notifications-settings-simplified.test.ts
+++ b/ui/__tests__/notifications-settings-simplified.test.ts
@@ -1,0 +1,66 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+
+// Guards the simplified Settings → Notifications surface: a master switch and
+// quiet hours only. The per-category toggles (plan nudge, worklog ready,
+// system fault/pause/health/update, summariser digest, board hygiene) and the
+// "Open planner each day" toggle were removed — every event is now gated
+// solely by notifications_enabled + quiet hours, enforced at drain time in
+// meridian-core (see meridian-core/src/notifications/mod.rs::event_allowed).
+
+const uiRoot = import.meta.dir + '/..'
+const readSrc = (rel: string): string => readFileSync(uiRoot + '/' + rel, 'utf8')
+
+const REMOVED_SETTINGS_FIELDS = [
+  'notify_plan_nudge',
+  'notify_worklog_ready',
+  'notify_system_fault',
+  'notify_system_pause',
+  'notify_system_health',
+  'notify_system_update',
+  'notify_summariser_digest',
+  'notify_board_hygiene',
+  'auto_open_plan',
+]
+
+describe('NotificationsSection', () => {
+  const src = readSrc('components/timeline/settings/NotificationsSection.tsx')
+
+  it('exposes only the master switch and quiet hours controls', () => {
+    expect(src).toContain('notifications_enabled')
+    expect(src).toContain('quiet_hours_enabled')
+    expect(src).toContain('quiet_hours_start')
+    expect(src).toContain('quiet_hours_end')
+  })
+
+  it('no longer renders any of the removed per-category toggles', () => {
+    for (const field of REMOVED_SETTINGS_FIELDS) {
+      expect(src).not.toContain(field)
+    }
+  })
+
+  it('the master switch still gates everything below it, quiet hours included', () => {
+    const gateIndex = src.indexOf('{settings.notifications_enabled && (')
+    const quietHoursIndex = src.indexOf('quiet_hours_enabled')
+    expect(gateIndex).toBeGreaterThan(-1)
+    expect(quietHoursIndex).toBeGreaterThan(gateIndex)
+  })
+})
+
+describe('RuntimeSettings (ui/lib/settings.ts)', () => {
+  const src = readSrc('lib/settings.ts')
+
+  it('keeps notifications_enabled and quiet_hours_* in the type and defaults', () => {
+    expect(src).toContain('notifications_enabled: boolean')
+    expect(src).toContain('notifications_enabled: true')
+    expect(src).toContain('quiet_hours_enabled: boolean')
+    expect(src).toContain('quiet_hours_enabled: false')
+  })
+
+  it('no longer declares any of the removed per-category settings fields', () => {
+    for (const field of REMOVED_SETTINGS_FIELDS) {
+      expect(src).not.toContain(field)
+    }
+  })
+})

--- a/ui/__tests__/plan-store.test.ts
+++ b/ui/__tests__/plan-store.test.ts
@@ -100,7 +100,9 @@ describe('planStore.ts is the single source of plan truth', () => {
   it('keys entries by day and hands useSyncExternalStore a STABLE empty snapshot', () => {
     // A fresh object per getSnapshot call re-renders forever.
     expect(store).toContain('useSyncExternalStore')
-    expect(store).toMatch(/^const store = new Map<string, PlanEntry>\(\)/m)
+    // LRU-capped (memory-leak-audit fix) rather than a bare Map — same
+    // get/set semantics, bounded growth over the webview's whole lifetime.
+    expect(store).toMatch(/^const store = new LruMap<string, PlanEntry>\(100\)/m)
     expect(store).toMatch(/^const EMPTY: PlanEntry = /m)
   })
 

--- a/ui/components/LlmProviderDetail.tsx
+++ b/ui/components/LlmProviderDetail.tsx
@@ -19,7 +19,7 @@ import { LLM_RECOMMENDED_BADGE, USAGE_FOOTPRINT_NOTE, type LlmProviderMeta } fro
 import type { InstallOutcome, ProviderStatus, ProviderTestResult } from '@/components/LlmProviderPicker'
 
 /** The connection state we render, derived from install + last-test + in-flight flags. */
-type Phase =
+export type Phase =
   | { kind: 'installing' }
   | { kind: 'signing' }
   | { kind: 'not_installed' }
@@ -30,7 +30,9 @@ type Phase =
   | { kind: 'ready_untested' }
   | { kind: 'unknown' }
 
-function phaseFor(
+/** Exported for `__tests__/llm-provider-connection-phase.test.ts` — pure decision logic, no
+ *  render harness needed (see that suite's header for why). */
+export function phaseFor(
   installing: boolean,
   signing: boolean,
   testing: boolean,

--- a/ui/components/plan/planStore.ts
+++ b/ui/components/plan/planStore.ts
@@ -31,6 +31,7 @@
 import { useSyncExternalStore } from 'react'
 import { load, mutate } from '@/lib/bridge'
 import type { PlanResponse } from '@/lib/api-types'
+import { LruMap } from '@/lib/lru'
 
 /** Vestigial route label the bridge still takes (Tauri-only now). */
 const API = '/api/plan'
@@ -47,7 +48,11 @@ export interface PlanEntry {
 // identity changes on every call.
 const EMPTY: PlanEntry = { data: null, loaded: false }
 
-const store = new Map<string, PlanEntry>()
+// LRU-capped: this webview session never reloads, so an uncapped Map would
+// grow by one entry per distinct day ever viewed for the app's whole
+// lifetime. 100 days is far beyond realistic usage — this is a hygiene bound,
+// not a fix for an observed runaway.
+const store = new LruMap<string, PlanEntry>(100)
 const listeners = new Set<() => void>()
 
 const snapshot = (date: string): PlanEntry => store.get(date) ?? EMPTY

--- a/ui/components/timeline/DayTaskColumn.tsx
+++ b/ui/components/timeline/DayTaskColumn.tsx
@@ -24,7 +24,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { fmtDur, PROVIDER_META } from '@/components/atoms'
 import { ProviderIcon } from '@/components/ProviderIcon'
 import { load } from '@/lib/bridge'
-import type { DayTask, DayTasksResponse, HourStatus } from '@/lib/api-types'
+import type { DayTask, DayTasksResponse, HourStatus, TodayGap } from '@/lib/api-types'
 import { HourTakeover } from './HourBadges'
 import {
   layoutDayTasks,
@@ -33,6 +33,7 @@ import {
   hourClock,
   hourHasWork,
   buildTimelineScale,
+  minutesFromIso,
   type LaidOutTask,
 } from './dayTaskLayout'
 import type { DayTaskDetail } from './DayTaskDetailPanel'
@@ -73,7 +74,7 @@ const META_MIN_PX = 62
 const SUMMARY_MIN_PX = 104
 const SUMMARY_LINE_PX = 17 // approx line height of a preview line
 
-export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, refreshToken = 0, hourStatus = [], capturing = null, isSolo = false }: {
+export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, refreshToken = 0, hourStatus = [], capturing = null, isSolo = false, gaps = [] }: {
   day: string
   isToday: boolean
   // Selection is owned by the shell so the clicked task's detail can render in
@@ -98,6 +99,11 @@ export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, refre
   /** `false` = tracking is paused RIGHT NOW. `null` while unknown. */
   capturing?: boolean | null
   isSolo?: boolean
+  // The day's `gaps` rows (get_today), same source hourStatus/capturing come
+  // from. Only tracking_paused/schedule_paused kinds are drawn — see
+  // pausedBands below. Optional/defaulted for the same reason as hourStatus:
+  // the injected-tasks (LLM Lab) path has no real day to pull gaps from.
+  gaps?: TodayGap[]
 }) {
   const [resp, setResp] = useState<DayTasksResponse | null>(null)
   const [loaded, setLoaded] = useState(false)
@@ -191,6 +197,30 @@ export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, refre
     }
     return out
   }, [firstHour, tickCeiling, toPx, colHeight, laidBase, win])
+
+  // ── Paused-time markers ────────────────────────────────────────────────────
+  // A `tracking_paused`/`schedule_paused` gap is real elapsed time nothing was
+  // captured for — the timeline should say so plainly rather than leaving a
+  // silent, unexplained blank stretch that reads as "nothing happened" rather
+  // than "we weren't watching". Drawn as a single clean divider line (the same
+  // idiom as SegmentList's "break" rule), centred in the gap's own pixel span,
+  // labelled with how long it lasted. Positioned on the same toPx axis as
+  // everything else, so it always sits between the task bands it actually
+  // fell between.
+  const pausedBands = useMemo(() => {
+    const out: { id: number; top: number; durSec: number }[] = []
+    for (const g of gaps) {
+      if (g.kind !== 'tracking_paused' && g.kind !== 'schedule_paused') continue
+      const startMin = minutesFromIso(g.started_at)
+      const endMin = minutesFromIso(g.ended_at)
+      if (startMin == null || endMin == null) continue
+      const lo = Math.max(startMin, win.lo)
+      const hi = Math.min(endMin, win.hi)
+      if (hi <= lo) continue
+      out.push({ id: g.id, top: toPx((lo + hi) / 2), durSec: g.dur })
+    }
+    return out
+  }, [gaps, win, toPx])
 
   const taskCount = laid.length
 
@@ -305,6 +335,26 @@ export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, refre
                 </div>
               )
             })}
+
+            {/* Paused-time dividers — one per tracking_paused/schedule_paused
+                gap, centred in its own span. Same row body as the hour
+                gridlines (starts past the gutter, not at it) so it reads as
+                a peer of those dividers rather than the task-card rail. */}
+            {pausedBands.map(({ id, top, durSec }) => (
+              <div key={`gap-${id}`} className="absolute flex items-center gap-2 pointer-events-none"
+                style={{ top, left: GUTTER + CARD_GUTTER_GAP, right: 6, height: 0 }}>
+                <span className="flex-1 border-t border-dashed"
+                  style={{ borderColor: 'color-mix(in srgb, var(--color-state-pending) 40%, transparent)' }} />
+                <span className="mt-mono-sm shrink-0 -translate-y-1/2" style={{
+                  fontSize: 9.5, fontWeight: 600, letterSpacing: 0.2,
+                  color: 'var(--color-state-pending)', opacity: 0.85,
+                }}>
+                  Paused · {fmtDur(durSec)}
+                </span>
+                <span className="flex-1 border-t border-dashed"
+                  style={{ borderColor: 'color-mix(in srgb, var(--color-state-pending) 40%, transparent)' }} />
+              </div>
+            ))}
 
             {/* Task workstreams — inset further than the rail itself (GUTTER)
                 so the cards read as their own column, not flush against the

--- a/ui/components/timeline/DayTaskColumn.tsx
+++ b/ui/components/timeline/DayTaskColumn.tsx
@@ -212,8 +212,14 @@ export function DayTaskColumn({ day, isToday, selectedId, onSelect, tasks, refre
     for (const g of gaps) {
       if (g.kind !== 'tracking_paused' && g.kind !== 'schedule_paused') continue
       const startMin = minutesFromIso(g.started_at)
-      const endMin = minutesFromIso(g.ended_at)
+      let endMin = minutesFromIso(g.ended_at)
       if (startMin == null || endMin == null) continue
+      // A pause crossing local midnight comes back with `ended_at` on the next
+      // day, so minutesFromIso() (which drops the date) yields endMin < startMin.
+      // `get_today` only returns gaps that STARTED today, so clamp the end to
+      // end-of-day for placement rather than dropping the band entirely — the
+      // real elapsed time is still shown from `g.dur`.
+      if (endMin < startMin) endMin = 1440
       const lo = Math.max(startMin, win.lo)
       const hi = Math.min(endMin, win.hi)
       if (hi <= lo) continue

--- a/ui/components/timeline/MeridianTimelineShell.tsx
+++ b/ui/components/timeline/MeridianTimelineShell.tsx
@@ -229,7 +229,8 @@ export default function MeridianTimelineShell() {
           <DayTaskColumn day={day} isToday={isToday}
             selectedId={selectedDayTask?.id ?? null} onSelect={selectDayTask}
             refreshToken={dayTaskRefresh}
-            hourStatus={data.hourStatus} capturing={data.capturing} isSolo={isSolo} />
+            hourStatus={data.hourStatus} capturing={data.capturing} isSolo={isSolo}
+            gaps={data.today?.gaps} />
 
           {!isSolo && (
             <FloatingDraftsPill count={pendingCount}

--- a/ui/components/timeline/SettingsModal.tsx
+++ b/ui/components/timeline/SettingsModal.tsx
@@ -21,7 +21,7 @@ import { IntelligenceSection } from './settings/IntelligenceSection'
 import { CaptureSection } from './settings/CaptureSection'
 import { NotificationsSection } from './settings/NotificationsSection'
 import { AppearanceSection } from './settings/AppearanceSection'
-import { AdvancedSection } from './settings/AdvancedSection'
+// import { AdvancedSection } from './settings/AdvancedSection'
 import { AccountSection } from './settings/AccountSection'
 import { useRuntimeSettings } from './settings/useRuntimeSettings'
 import { DEFAULT_SETTINGS_SECTION, type SettingsSection } from './settings/types'
@@ -33,7 +33,7 @@ export function SettingsModal({ onClose, initialSection }: {
   const [section, setSection] = useState<SettingsSection>(initialSection ?? DEFAULT_SETTINGS_SECTION)
   const [integrations, setIntegrations] = useState<IntegrationsResponse | null>(null)
   const [integrationsError, setIntegrationsError] = useState(false)
-  const { settings, setSettings, patch, save } = useRuntimeSettings()
+  const { settings, patch, save } = useRuntimeSettings()
 
   const fetchIntegrations = () => {
     load<IntegrationsResponse>('/api/integrations', 'get_integrations')
@@ -79,9 +79,9 @@ export function SettingsModal({ onClose, initialSection }: {
               {section === 'capture' && <CaptureSection settings={settings} patch={patch} save={save} />}
               {section === 'notifications' && <NotificationsSection settings={settings} patch={patch} save={save} />}
               {section === 'appearance' && <AppearanceSection />}
-              {section === 'advanced' && (
+              {/* {section === 'advanced' && (
                 <AdvancedSection settings={settings} setSettings={setSettings} patch={patch} save={save} />
-              )}
+              )} */}
               {section === 'account' && <AccountSection />}
             </>
           )}

--- a/ui/components/timeline/dayTaskLayout.ts
+++ b/ui/components/timeline/dayTaskLayout.ts
@@ -59,6 +59,16 @@ export function clockLabelFromIso(iso: string): string {
   return clockLabel(d.getHours() * 60 + d.getMinutes())
 }
 
+/** An RFC-3339 timestamp -> local minutes-from-midnight (same units as
+ *  `LaidSegment`/`toPx`), or `null` for an unparsable value. Used to place a
+ *  server-timestamped event (e.g. a `gaps` row) on the same minute axis the
+ *  task segments are laid out on. */
+export function minutesFromIso(iso: string): number | null {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return null
+  return d.getHours() * 60 + d.getMinutes()
+}
+
 /** 12-hour label for a whole hour-of-day (`0 -> "12 AM"`, `18 -> "6 PM"`). */
 export function hourClock(hour: number): string {
   const hod = ((hour % 24) + 24) % 24

--- a/ui/components/timeline/settings/AccountSection.tsx
+++ b/ui/components/timeline/settings/AccountSection.tsx
@@ -77,7 +77,7 @@ export function AccountSection() {
             </span>
           )}
         </FieldRow>
-        <FieldRow label="Export Diagnostics" description="Captures your local logs and traces for troubleshooting — nothing leaves your machine until you share this file. Saved to your Downloads folder and revealed in Finder.">
+        <FieldRow label="Export Diagnostics" description="Captures your local logs and traces for troubleshooting. Nothing leaves your machine until you share this file. Saved to your Downloads folder and revealed in your file manager.">
           <SettingsButton onClick={exportBundle} disabled={exportStatus === 'exporting'}>
             {exportStatus === 'exporting' ? 'Exporting…' : 'Export Diagnostics'}
           </SettingsButton>

--- a/ui/components/timeline/settings/AccountSection.tsx
+++ b/ui/components/timeline/settings/AccountSection.tsx
@@ -2,6 +2,13 @@
 //
 // Settings → Account. Migrated 1:1 from the old SettingsView's "Setup &
 // Onboarding" card — the only Account-ish control that existed before.
+//
+// Also hosts "Export Diagnostics" (moved from the now-hidden Advanced tab):
+// the ONLY GUI path a packaged install has to hand a developer a local
+// telemetry bundle (`meridian telemetry export` is the terminal fallback —
+// not realistic mid support-ticket). See CLAUDE.md's "Telemetry: local-only
+// capture, dev-only shipping" section — keep that doc's Settings path in
+// sync if this ever moves again.
 
 'use client'
 
@@ -10,6 +17,7 @@ import { invoke, load, mutate } from '@/lib/bridge'
 import type { AppInfo } from '@/lib/api-types'
 import { AccountAuthControl } from '@/app/setup/signin'
 import { SectionCard, SectionHeader, FieldRow, SettingsButton } from './fields'
+import { useExportDiagnostics } from './useExportDiagnostics'
 
 // Colored only for a non-prod build — a prod dashboard shouldn't draw the eye
 // to its own version line; dev/staging should be unmistakable.
@@ -21,6 +29,7 @@ const CHANNEL_COLOR: Record<AppInfo['channel'], string> = {
 
 export function AccountSection() {
   const [appInfo, setAppInfo] = useState<AppInfo | null>(null)
+  const { status: exportStatus, path: exportPath, errorMsg: exportError, exportBundle } = useExportDiagnostics()
 
   useEffect(() => {
     load<AppInfo>('/api/app-info', 'get_app_info').then(setAppInfo).catch(() => {})
@@ -68,6 +77,17 @@ export function AccountSection() {
             </span>
           )}
         </FieldRow>
+        <FieldRow label="Export Diagnostics" description="Captures your local logs and traces for troubleshooting — nothing leaves your machine until you share this file. Saved to your Downloads folder and revealed in Finder.">
+          <SettingsButton onClick={exportBundle} disabled={exportStatus === 'exporting'}>
+            {exportStatus === 'exporting' ? 'Exporting…' : 'Export Diagnostics'}
+          </SettingsButton>
+        </FieldRow>
+        {exportStatus === 'done' && exportPath && (
+          <span className="text-[12px]" style={{ color: 'var(--color-state-approved)' }}>Saved to {exportPath}</span>
+        )}
+        {exportStatus === 'error' && (
+          <span className="text-[12px]" style={{ color: 'var(--color-state-pending)' }}>{exportError ?? 'Export failed'}</span>
+        )}
       </SectionCard>
     </div>
   )

--- a/ui/components/timeline/settings/AdvancedSection.tsx
+++ b/ui/components/timeline/settings/AdvancedSection.tsx
@@ -1,13 +1,20 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 //
-// Settings → Advanced. Runtime-tuning knobs migrated 1:1 from the old
-// SettingsView: Observability (local capture + log level; export via
-// useExportDiagnostics — the shipped app never installs/runs a local
-// OpenObserve service), ETL Pipeline poll interval, Session Classification
-// thresholds, LLM local-model preference, and the Jira Updater toggle. These
-// don't fit Integrations/Capture/Notifications/Appearance — they're internal
-// daemon behavior, not user-facing product surfaces, so they're grouped here
-// rather than invented a home for each.
+// Settings → Advanced. Currently unreferenced — the nav entry + render
+// branch are commented out in SettingsSidebar.tsx / SettingsModal.tsx, kept
+// for easy re-enable. Runtime-tuning knobs migrated 1:1 from the old
+// SettingsView: Observability (local capture + log level), ETL Pipeline poll
+// interval, Session Classification thresholds, LLM local-model preference,
+// and the Jira Updater toggle. These don't fit
+// Integrations/Capture/Notifications/Appearance — they're internal daemon
+// behavior, not user-facing product surfaces, so they're grouped here rather
+// than invented a home for each.
+//
+// "Export Diagnostics" moved OUT of here to `AccountSection.tsx` (always
+// reachable) when this tab was hidden — a packaged install's only GUI path
+// to handing a developer a telemetry bundle can't live behind a hidden tab.
+// Don't re-add it here if this section is ever re-enabled; it would just
+// duplicate the Account one.
 
 'use client'
 
@@ -16,8 +23,7 @@ import { Select } from '@/components/ui/Select'
 import { Switch } from '@/components/ui/Switch'
 import { NumberStepper } from '@/components/ui/NumberStepper'
 import type { RuntimeSettings } from '@/lib/settings'
-import { SectionCard, SectionHeader, FieldRow, SaveButton, SettingsButton, type SaveStatus } from './fields'
-import { useExportDiagnostics } from './useExportDiagnostics'
+import { SectionCard, SectionHeader, FieldRow, SaveButton, type SaveStatus } from './fields'
 
 const LOG_LEVEL_OPTIONS = [
   { value: 'DEBUG',   label: 'DEBUG' },
@@ -37,7 +43,6 @@ export function AdvancedSection({ settings, setSettings, patch, save }: {
   const [llmStatus, setLlmStatus] = useState<SaveStatus>('idle')
   const [jiraStatus, setJiraStatus] = useState<SaveStatus>('idle')
   const [logLevelStatus, setLogLevelStatus] = useState<SaveStatus>('idle')
-  const { status: exportStatus, path: exportPath, errorMsg: exportError, exportBundle } = useExportDiagnostics()
 
   return (
     <div className="max-w-[640px] flex flex-col gap-5">
@@ -60,17 +65,6 @@ export function AdvancedSection({ settings, setSettings, patch, save }: {
           />
         </FieldRow>
         <SaveButton status={logLevelStatus} onClick={() => save({ log_level: settings.log_level }, setLogLevelStatus)} />
-        <FieldRow label="Export Diagnostics" description="Captures your local logs and traces for troubleshooting — nothing leaves your machine until you share this file. Saved to your Downloads folder and revealed in Finder.">
-          <SettingsButton onClick={exportBundle} disabled={exportStatus === 'exporting'}>
-            {exportStatus === 'exporting' ? 'Exporting…' : 'Export Diagnostics'}
-          </SettingsButton>
-        </FieldRow>
-        {exportStatus === 'done' && exportPath && (
-          <span className="text-[12px]" style={{ color: 'var(--color-state-approved)' }}>Saved to {exportPath}</span>
-        )}
-        {exportStatus === 'error' && (
-          <span className="text-[12px]" style={{ color: 'var(--color-state-pending)' }}>{exportError ?? 'Export failed'}</span>
-        )}
       </SectionCard>
 
       <SectionCard>

--- a/ui/components/timeline/settings/CaptureSection.tsx
+++ b/ui/components/timeline/settings/CaptureSection.tsx
@@ -21,6 +21,7 @@ export function CaptureSection({ settings, patch, save }: {
 }) {
   const [status, setStatus] = useState<SaveStatus>('idle')
   const [streamingStatus, setStreamingStatus] = useState<SaveStatus>('idle')
+  const [secondaryMonitorsStatus, setSecondaryMonitorsStatus] = useState<SaveStatus>('idle')
 
   return (
     <div className="max-w-[640px] flex flex-col gap-5">
@@ -75,6 +76,19 @@ export function CaptureSection({ settings, patch, save }: {
           onClick={() => save({
             pause_on_streaming_video: settings.pause_on_streaming_video,
           }, setStreamingStatus)}
+        />
+      </SectionCard>
+
+      <SectionCard>
+        <SectionHeader>Multiple monitors</SectionHeader>
+        <FieldRow label="Capture other monitors" description="On by default: Meridian glances at every connected monitor every so often, so work on a second screen shows up on your timeline whether or not it's the screen you're actively looking at. Turn this off if a second monitor may show things (a meeting, a personal window) you don't want tracked.">
+          <Switch checked={settings.capture_secondary_monitors} onCheckedChange={v => patch({ capture_secondary_monitors: v })} />
+        </FieldRow>
+        <SaveButton
+          status={secondaryMonitorsStatus}
+          onClick={() => save({
+            capture_secondary_monitors: settings.capture_secondary_monitors,
+          }, setSecondaryMonitorsStatus)}
         />
       </SectionCard>
 

--- a/ui/components/timeline/settings/NotificationsSection.tsx
+++ b/ui/components/timeline/settings/NotificationsSection.tsx
@@ -1,8 +1,7 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 //
-// Settings → Notifications. Migrated 1:1 from the old SettingsView's
-// "Notifications" card: master switch, per-event-type toggles, and the quiet
-// hours window.
+// Settings → Notifications. Deliberately minimal: a master switch and a
+// quiet hours window — no per-event-type toggles.
 
 'use client'
 
@@ -34,38 +33,8 @@ export function NotificationsSection({ settings, patch, save }: {
         <FieldRow label="Notifications" description="Master switch for desktop toasts and in-app banners. Off silences everything below.">
           <Switch checked={settings.notifications_enabled} onCheckedChange={v => patch({ notifications_enabled: v })} />
         </FieldRow>
-        {/* A window behaviour, not a toast — deliberately outside the
-            notifications_enabled gate so silencing toasts doesn't also kill
-            the morning planner. */}
-        <FieldRow label="Open planner each day" description="Once a day, open the dashboard on the Plan view when you start using your machine.">
-          <Switch checked={settings.auto_open_plan} onCheckedChange={v => patch({ auto_open_plan: v })} />
-        </FieldRow>
         {settings.notifications_enabled && (
           <>
-            <FieldRow label="Plan your day reminder" description="If you close the planner without confirming a plan, this reminds you an hour later.">
-              <Switch checked={settings.notify_plan_nudge} onCheckedChange={v => patch({ notify_plan_nudge: v })} />
-            </FieldRow>
-            <FieldRow label="Worklog drafts ready" description="When the daily worklog drafts are ready to review and approve.">
-              <Switch checked={settings.notify_worklog_ready} onCheckedChange={v => patch({ notify_worklog_ready: v })} />
-            </FieldRow>
-            <FieldRow label="System faults" description="When a tracker sync or the classifier stack fails (also shown as a banner).">
-              <Switch checked={settings.notify_system_fault} onCheckedChange={v => patch({ notify_system_fault: v })} />
-            </FieldRow>
-            <FieldRow label="Pause / resume" description="When tracking is paused or resumes, manually or on a schedule.">
-              <Switch checked={settings.notify_system_pause} onCheckedChange={v => patch({ notify_system_pause: v })} />
-            </FieldRow>
-            <FieldRow label="Daemon health" description="When Meridian's background daemon goes quiet or comes back online.">
-              <Switch checked={settings.notify_system_health} onCheckedChange={v => patch({ notify_system_health: v })} />
-            </FieldRow>
-            <FieldRow label="Updates" description="When a new version is available, installing, or fails to install.">
-              <Switch checked={settings.notify_system_update} onCheckedChange={v => patch({ notify_system_update: v })} />
-            </FieldRow>
-            <FieldRow label="Summarisation issues" description="A daily digest if any coding-agent sessions couldn't be summarised.">
-              <Switch checked={settings.notify_summariser_digest} onCheckedChange={v => patch({ notify_summariser_digest: v })} />
-            </FieldRow>
-            <FieldRow label="Board hygiene" description="A daily digest if tickets on your board need attention.">
-              <Switch checked={settings.notify_board_hygiene} onCheckedChange={v => patch({ notify_board_hygiene: v })} />
-            </FieldRow>
             <FieldRow label="Quiet hours" description="Hold back desktop toasts during this window (banners still appear). Wraps past midnight.">
               <Switch checked={settings.quiet_hours_enabled} onCheckedChange={v => patch({ quiet_hours_enabled: v })} />
             </FieldRow>
@@ -82,15 +51,6 @@ export function NotificationsSection({ settings, patch, save }: {
           status={status}
           onClick={() => save({
             notifications_enabled: settings.notifications_enabled,
-            auto_open_plan: settings.auto_open_plan,
-            notify_plan_nudge: settings.notify_plan_nudge,
-            notify_worklog_ready: settings.notify_worklog_ready,
-            notify_system_fault: settings.notify_system_fault,
-            notify_system_pause: settings.notify_system_pause,
-            notify_system_health: settings.notify_system_health,
-            notify_system_update: settings.notify_system_update,
-            notify_summariser_digest: settings.notify_summariser_digest,
-            notify_board_hygiene: settings.notify_board_hygiene,
             quiet_hours_enabled: settings.quiet_hours_enabled,
             quiet_hours_start: settings.quiet_hours_start,
             quiet_hours_end: settings.quiet_hours_end,

--- a/ui/components/timeline/settings/SettingsSidebar.tsx
+++ b/ui/components/timeline/settings/SettingsSidebar.tsx
@@ -23,7 +23,7 @@ const NAV: { id: SettingsSection; label: string; glyph: string }[] = [
   { id: 'capture', label: 'Capture & Privacy', glyph: '◉' },
   { id: 'notifications', label: 'Notifications', glyph: '◔' },
   { id: 'appearance', label: 'Appearance', glyph: '◑' },
-  { id: 'advanced', label: 'Advanced', glyph: '▤' },
+  // { id: 'advanced', label: 'Advanced', glyph: '▤' },
   { id: 'account', label: 'Account', glyph: '◍' },
 ]
 

--- a/ui/components/timeline/useWorklog.ts
+++ b/ui/components/timeline/useWorklog.ts
@@ -24,6 +24,7 @@
 import { useEffect, useState, useSyncExternalStore } from 'react'
 import { load, invoke, mutate } from '@/lib/bridge'
 import type { DayTaskWorklogDraft, ApproveWorklogResponse } from '@/lib/api-types'
+import { LruMap } from '@/lib/lru'
 
 /** Where the flow is right now — drives which footer control the panel shows. */
 export type WorklogPhase = 'loading' | 'idle' | 'generating' | 'approving'
@@ -75,7 +76,13 @@ interface Entry {
 // changes every call).
 const EMPTY: Entry = { draft: null, phase: 'loading', error: null, loaded: false }
 
-const store = new Map<string, Entry>()
+// LRU-capped: this webview session never reloads, so an uncapped Map would
+// grow by one entry per distinct (day, taskId) pair ever opened for the
+// app's whole lifetime. 100 is far beyond realistic usage — a hygiene bound,
+// not a fix for an observed runaway. (An entry mid `generating`/`approving`
+// stays the most-recently-touched one via the `patch`→`store.set` on every
+// state change, so it's never the eviction candidate while active.)
+const store = new LruMap<string, Entry>(100)
 const listeners = new Set<() => void>()
 
 // A space is a safe separator here: `day` is YYYY-MM-DD and `taskId` is T1/T2…,

--- a/ui/lib/app-icons.ts
+++ b/ui/lib/app-icons.ts
@@ -9,10 +9,15 @@
 
 import { useEffect, useState } from 'react'
 import { invoke, assetUrl, isTauri } from '@/lib/bridge'
+import { LruMap } from '@/lib/lru'
 
 type CacheEntry = string | null | Promise<string | null>
 
-const cache = new Map<string, CacheEntry>()
+// LRU-capped: this webview session never reloads, so an uncapped Map would
+// grow by one entry per distinct app name ever seen for the app's whole
+// lifetime. 100 is far beyond realistic usage — a hygiene bound, not a fix
+// for an observed runaway.
+const cache = new LruMap<string, CacheEntry>(100)
 
 function resolve(appName: string): CacheEntry {
   const cached = cache.get(appName)

--- a/ui/lib/lru.ts
+++ b/ui/lib/lru.ts
@@ -1,0 +1,65 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// A minimal LRU-capped Map for module-level webview stores that live for the
+// whole Tauri session (it never reloads) and would otherwise grow by one
+// small entry per distinct key — day, task, app-icon lookup, … — for as long
+// as the app runs. Realistic usage cardinality keeps these well under any
+// sane cap in practice; this is a hygiene bound, not a fix for an observed
+// runaway.
+//
+// Deliberately NOT a full Map re-implementation — just the get/set subset the
+// module-level stores that use this actually need (see planStore.ts,
+// useWorklog.ts, app-icons.ts). Recency is tracked by re-inserting the
+// touched key so the underlying Map's insertion order IS recency order (a
+// well-known JS idiom: Map iterates in insertion order, and re-`set`ting an
+// existing key does NOT move it, so the delete-then-set below is what
+// actually bumps it to "most recent").
+
+export class LruMap<K, V> {
+  private readonly map = new Map<K, V>()
+
+  constructor(private readonly capacity: number) {
+    if (capacity < 1) {
+      throw new Error('LruMap capacity must be >= 1')
+    }
+  }
+
+  /** Reads `key`, marking it most-recently-used. `undefined` means "not
+   *  cached" — a value of `undefined` is never itself stored by any current
+   *  caller, so this is unambiguous for them. */
+  get(key: K): V | undefined {
+    if (!this.map.has(key)) return undefined
+    const value = this.map.get(key) as V
+    // Bump recency: delete + re-set moves the key to the end of iteration
+    // order (Map's order is insertion order; re-setting an existing key
+    // alone would NOT move it).
+    this.map.delete(key)
+    this.map.set(key, value)
+    return value
+  }
+
+  /** Writes `key`, marking it most-recently-used, and evicts the single
+   *  least-recently-used entry if this insert pushed the map past capacity. */
+  set(key: K, value: V): void {
+    this.map.delete(key)
+    this.map.set(key, value)
+    if (this.map.size > this.capacity) {
+      const oldest = this.map.keys().next().value
+      if (oldest !== undefined) {
+        this.map.delete(oldest)
+      }
+    }
+  }
+
+  has(key: K): boolean {
+    return this.map.has(key)
+  }
+
+  delete(key: K): boolean {
+    return this.map.delete(key)
+  }
+
+  get size(): number {
+    return this.map.size
+  }
+}

--- a/ui/lib/lru.ts
+++ b/ui/lib/lru.ts
@@ -19,8 +19,11 @@ export class LruMap<K, V> {
   private readonly map = new Map<K, V>()
 
   constructor(private readonly capacity: number) {
-    if (capacity < 1) {
-      throw new Error('LruMap capacity must be >= 1')
+    // Reject NaN/Infinity/fractional too: `NaN < 1` and `Infinity < 1` are both
+    // false, so a bare `< 1` check would accept them and then `size > capacity`
+    // is never true — the bound would silently never evict.
+    if (!Number.isInteger(capacity) || capacity < 1) {
+      throw new Error('LruMap capacity must be an integer >= 1')
     }
   }
 
@@ -44,9 +47,12 @@ export class LruMap<K, V> {
     this.map.delete(key)
     this.map.set(key, value)
     if (this.map.size > this.capacity) {
-      const oldest = this.map.keys().next().value
-      if (oldest !== undefined) {
-        this.map.delete(oldest)
+      // Use the iterator's `done` flag, not `value !== undefined`: an explicit
+      // `undefined` key is a valid Map entry and would otherwise never evict
+      // (it's indistinguishable from the empty-iterator sentinel).
+      const oldest = this.map.keys().next()
+      if (!oldest.done) {
+        this.map.delete(oldest.value)
       }
     }
   }

--- a/ui/lib/settings.ts
+++ b/ui/lib/settings.ts
@@ -33,26 +33,12 @@ export interface RuntimeSettings {
   llm_budget_pct: number
   // Jira updater
   jira_update_enabled: boolean
-  // Notifications — master switch + per-event-type toggles + quiet hours.
-  // Filtering happens once at the delivery layer (the notification API routes),
-  // never in the producers, so every event flows into the outbox and only the
-  // user's preferences decide whether it surfaces.
+  // Notifications — a master switch + quiet hours. Filtering happens once at
+  // the delivery layer (the notification API routes), never in the
+  // producers, so every event flows into the outbox and only these two
+  // preferences decide whether it surfaces. Deliberately no per-event-type
+  // toggles — kept simple for the user.
   notifications_enabled: boolean
-  notify_plan_nudge: boolean
-  // Daily planner auto-open — the tray opens the dashboard on the Plan modal
-  // once per local day. A window behaviour, not a toast, so NOT gated by
-  // notifications_enabled.
-  auto_open_plan: boolean
-  notify_worklog_ready: boolean
-  notify_system_fault: boolean
-  // Folded from direct tray-side toasts (pause/resume, daemon health,
-  // updates) into the outbox — each has its own toggle.
-  notify_system_pause: boolean
-  notify_system_health: boolean
-  notify_system_update: boolean
-  // Daily batched digests.
-  notify_summariser_digest: boolean
-  notify_board_hygiene: boolean
   quiet_hours_enabled: boolean
   quiet_hours_start: string // 'HH:MM' local time, inclusive
   quiet_hours_end: string   // 'HH:MM' local time, exclusive
@@ -101,15 +87,6 @@ export const SETTINGS_DEFAULTS: RuntimeSettings = {
   llm_budget_pct: 0.5,
   jira_update_enabled: true,
   notifications_enabled: true,
-  notify_plan_nudge: true,
-  auto_open_plan: true,
-  notify_worklog_ready: true,
-  notify_system_fault: true,
-  notify_system_pause: true,
-  notify_system_health: true,
-  notify_system_update: true,
-  notify_summariser_digest: true,
-  notify_board_hygiene: true,
   quiet_hours_enabled: false,
   quiet_hours_start: '22:00',
   quiet_hours_end: '08:00',

--- a/ui/lib/settings.ts
+++ b/ui/lib/settings.ts
@@ -61,6 +61,10 @@ export interface RuntimeSettings {
   work_hours_end: string    // 'HH:MM' local time, exclusive
   work_days: string         // comma-separated 1–7 (Mon=1 … Sun=7), e.g. '1,2,3,4,5'
   pause_on_streaming_video: boolean
+  // On by default — a second monitor is captured whether or not it's the
+  // screen the user is actively looking at. Mirrors
+  // RuntimeSettings.capture_secondary_monitors in meridian-core/src/settings.rs.
+  capture_secondary_monitors: boolean
   // Capture ignore lists — apps (exact app name) and websites (domain) Meridian
   // must never capture. Enforced at the capture frame boundary going forward;
   // history is left untouched. Mirrors RuntimeSettings.ignored_apps/ignored_urls
@@ -115,6 +119,8 @@ export const SETTINGS_DEFAULTS: RuntimeSettings = {
   work_days: '1,2,3,4,5',
   // On by default — must match RuntimeSettings::default() in meridian-core/src/settings.rs.
   pause_on_streaming_video: true,
+  // On by default — must match RuntimeSettings::default() in meridian-core/src/settings.rs.
+  capture_secondary_monitors: true,
   // Nothing ignored by default.
   ignored_apps: [],
   ignored_urls: [],

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meridian-ui",
-  "version": "1.71.0",
+  "version": "1.74.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meridian-ui",
-      "version": "1.71.0",
+      "version": "1.74.0",
       "dependencies": {
         "@clerk/react": "^6.12.2",
         "@hello-pangea/dnd": "^18.0.1",


### PR DESCRIPTION
Promotes the current `pre-main` release train to `main`: **7 merged PRs**, 64 files, +2,883 / −371. Focus areas this cycle are **Windows bring-up** (installers, CLI detection, auto-update, launch-at-login), a **Settings/notifications cleanup**, and a round of **capture + memory-leak hardening** on the daemon and tray.

No new user-facing features gate a migration; all DB changes are additive retention/pagination. Version bump to the next release is intentionally **not** included here — it lands as the usual `chore(release)` commit on `main` after this merge (mirroring `1.78.0`).

---

## 🪟 Windows bring-up

The bulk of this cycle. Meridian's Windows path had several install/update papercuts that made a fresh install look broken.

- **CLI install/detect repair for Claude, Codex & Cursor** (#576) — provider installers now run through the correct shell on Windows (`cmd.exe` for npm-based providers; **`powershell.exe` for Cursor**, which ships a separate PowerShell installer — its Unix `curl | sed | bash` script can't run on stock Windows). Adds a `#[cfg(windows)]` `CURSOR_INSTALL_CMD` (version-pinned via .NET `-replace`) and platform-correct install *hints* so "not found" messages never point Windows users at `curl | bash`. Also fixes a Cursor argv-drop and a Codex slow-fail on sign-in.
- **Quiet the ARM64 "update check failed" toast** (#571) — Windows ARM64 has no published update artifact in `latest.json` (the release job builds x86_64 only), so every check toasted an unactionable error forever. `TargetNotFound`/`TargetsNotFound` lookup-misses are now bucketed as `"unsupported"` (the same quiet path the DMG updater uses for npm CLIs), with a clearer "auto-update not available" message. Every other updater error still surfaces as `"error"`.
- **Self-heal launch-at-login** (#574) — the tray now registers itself as a login item once (bundled runs only) via `tauri-plugin-autostart`, so it returns on its own after a reboot/login. Guarded against pinning the login item while running from a transient path (a mounted DMG `/Volumes/…` or Gatekeeper's `…/AppTranslocation/…`), which would otherwise break self-heal permanently.

## ⚙️ Settings & notifications cleanup

- **Hide the Advanced settings tab** and **keep Export Diagnostics reachable** (#575) — the Advanced tab is hidden from the sidebar/modal (commented out, not deleted, for easy re-enable). Its one user-critical control, **Export Diagnostics** — a packaged install's only GUI path to hand a developer a local telemetry bundle — was relocated to the always-visible **Account** section, with a guard test so it can't silently regress again.
- **Simplify notifications** to a master switch + quiet hours (#575), replacing the previous per-category toggle matrix.

## 📹 Capture & timeline

- **Cache the monitor list & gate secondary-monitor capture** (#572) — avoids re-enumerating monitors every tick; secondary-monitor capture is now flag-gated. Follow-up switches the monitor list to **event-driven refresh** instead of fixed-tick polling.
- **Paused-time marker** on the day-task timeline column so paused spans are visible at a glance.

## 🧹 Memory-leak audit & ETL retention (#566)

A sweep of long-run stability fixes for installs that stay open for days:

- **screenpipe-fork pin bumps** — pick up autorelease-pool fixes and leak-guarded `NSWorkspace` accessors (crash-safe, no panic).
- **Webview store LRU cap** — module-level webview stores are now bounded by a shared LRU helper instead of growing unbounded.
- **MCP sql.js reuse** — cache the `Database` handle instead of reopening it per tool call.
- **Coding-agent summariser** — evict retry-attempt entries on success.
- **ETL retention & pagination** — age + processed-based retention for `capture_*` tables; frame-text reload and session-text rebuild are paginated so a long single-app session close no longer loads everything at once (#573).

## 📈 Analytics & CI

- **Public updates-counter ping** on worklog post and personal-task write (#566 area).
- **CI**: pin the screenpipe-fork by full commit SHA to satisfy the MIT-pin guard.

---

## Merged PRs in this train
| PR | Title |
|----|-------|
| #576 | fix(windows): repair CLI install/detect for Claude, Codex, and Cursor |
| #574 | feat(tray): self-heal launch-at-login |
| #571 | fix(tray): quiet the Windows ARM64 'update check failed' toast |
| #575 | fix(ui): hide the Advanced tab and simplify notification settings |
| #572 | feat(capture): monitor-list cache + secondary-monitor gate |
| #573 | fix(etl): paginate session-text rebuild |
| #566 | fix: memory-leak audit fixes |

## Testing & risk
- Every constituent PR passed the full pre-push suite (fmt · UI build · clippy · UI tests · security audit · cargo test) and CI on merge to `pre-main`.
- DB changes are additive (retention/pagination) — no destructive migration.
- Diverges from `main` only by `main`'s existing `chore(release): 1.78.0` version bump, which pre-main never touched, so the version files merge without conflict.

> Note: PR #577 (Jira OAuth transient-refresh fix) is **not** in this train — it's still an open PR targeting `pre-main` and will ride the next promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional multi-monitor capture control and paused-time dividers to the timeline.
  * Enabled launch-at-login for packaged apps.
  * Improved Cursor Agent install guidance across Windows, macOS, and Linux.
  * Added early detection and guidance when Codex isn’t signed in.
  * Added automatic capture cleanup with retention rules.

* **Improvements**
  * Simplified notifications to a master switch plus quiet hours.
  * Moved “Export Diagnostics” to Settings → Account.
  * Improved update messaging when platform downloads aren’t available.
  * Reduced memory use with bounded caching and faster incremental capture/session text rebuilding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->