### PR TITLE
fix(llm): provider install/sign-in detection + dashboard health banners

### DIFF
--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -828,6 +828,116 @@ pub async fn codex_sign_in() -> InstallOutcome {
     }
 }
 
+/// Run the interactive `claude auth login` on the user's behalf — the "Sign in to Claude"
+/// button in the provider detail view.
+///
+/// `claude auth login` (default `--claudeai`) opens the user's browser to sign into their
+/// Anthropic account on their **Claude subscription** — no API key, nothing metered. A
+/// deliberate mirror of [`cursor_sign_in`]/[`codex_sign_in`]: the browser is enabled (this is
+/// an explicit click, not the daemon's unattended path), stdout is drained live so the
+/// verification URL is surfaced if the browser can't open, and the wait is bounded by
+/// [`INTERACTIVE_LOGIN_TIMEOUT`]. Once it completes, Claude Code persists the auth and every
+/// later run just adopts it — the same "sign in once" model as the other two.
+#[tracing::instrument(skip_all, fields(ok = tracing::field::Empty, cli_path = tracing::field::Empty))]
+pub async fn claude_sign_in() -> InstallOutcome {
+    let label = "claude auth login";
+    let Some(path) = resolve_cli("claude").await else {
+        return install_failed(
+            label,
+            "claude isn't installed yet - install it first".into(),
+        );
+    };
+
+    tracing::info!("llm: launching interactive claude auth login");
+    let mut cmd = Command::new(&path);
+    cmd.arg("auth")
+        .arg("login")
+        .arg("--claudeai")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .no_window();
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => return install_failed(label, format!("couldn't start claude: {e}")),
+    };
+
+    // Drain stdout as it arrives - `claude auth login` prints its verification URL to STDOUT
+    // while it waits, which is exactly what the user needs if the browser doesn't open for them.
+    // Same reasoning as the matching drain in `cursor_sign_in`.
+    let seen = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    if let Some(out) = child.stdout.take() {
+        let seen = seen.clone();
+        tokio::spawn(async move {
+            use tokio::io::{AsyncBufReadExt, BufReader};
+            let mut lines = BufReader::new(out).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                tracing::info!(line = %line, "claude auth login");
+                let mut buf = seen.lock().unwrap_or_else(|e| e.into_inner());
+                buf.push_str(&line);
+                buf.push('\n');
+            }
+        });
+    }
+    let login_output = |seen: &std::sync::Mutex<String>| -> String {
+        let buf = seen.lock().unwrap_or_else(|e| e.into_inner());
+        tail(buf.trim(), 300)
+    };
+
+    let output = match tokio::time::timeout(INTERACTIVE_LOGIN_TIMEOUT, child.wait_with_output())
+        .await
+    {
+        Ok(Ok(out)) => out,
+        Ok(Err(e)) => return install_failed(label, format!("couldn't run claude auth login: {e}")),
+        Err(_) => {
+            let printed = login_output(&seen);
+            return install_failed(
+                label,
+                if printed.is_empty() {
+                    "the sign-in wasn't finished in time - click Sign in to Claude again".into()
+                } else {
+                    format!(
+                        "the sign-in wasn't finished in time. Finish it by hand with what \
+                             claude printed:\n{printed}"
+                    )
+                },
+            );
+        }
+    };
+
+    if output.status.success() {
+        let span = tracing::Span::current();
+        span.record("ok", true);
+        span.record("cli_path", tracing::field::display(path.display()));
+        tracing::info!("llm: claude auth login succeeded");
+        InstallOutcome {
+            ok: true,
+            message: "Signed in to Claude.".into(),
+            path: Some(path.display().to_string()),
+            command: label.to_string(),
+        }
+    } else {
+        // stderr first (that is where the reason goes), but fall back to what the CLI printed on
+        // stdout - on some failures the URL is the only useful thing said.
+        let reason = tail(String::from_utf8_lossy(&output.stderr).trim(), 400);
+        let reason = if reason.is_empty() {
+            login_output(&seen)
+        } else {
+            reason
+        };
+        install_failed(
+            label,
+            if reason.is_empty() {
+                "claude auth login failed".to_string()
+            } else {
+                reason
+            },
+        )
+    }
+}
+
 /// The last `n` characters of `s`, char-safe.
 ///
 /// The tail is the useful end of CLI output - npm, curl and cursor-agent all print the real

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -934,13 +934,17 @@ static RESOLVED_BINS: std::sync::OnceLock<std::sync::Mutex<HashMap<String, PathB
 /// the slow shell spawn on macOS whenever the current process's `PATH` is already good (e.g.
 /// the daemon's launchd-configured one, per the `resolve_cli` doc above).
 pub async fn resolve_cli(bin: &str) -> Option<PathBuf> {
-    if let Some(hit) = RESOLVED_BINS
+    // Read the cache under a SCOPED lock and drop the guard on this `let` before the block
+    // below. Holding it across an `if let` body would keep the guard alive through the body
+    // (temporary lifetime), and the re-lock to evict a stale entry would then deadlock on this
+    // same thread — a `std::sync::Mutex` is not re-entrant.
+    let cached = RESOLVED_BINS
         .get_or_init(Default::default)
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .get(bin)
-        .cloned()
-    {
+        .cloned();
+    if let Some(hit) = cached {
         if hit.exists() {
             return Some(hit);
         }

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -499,9 +499,9 @@ async fn warn_if_version_unpinned(provider: LlmProvider, path: &std::path::Path)
     }
 }
 
-/// How long the interactive Cursor sign-in may take - a human finishing an OAuth flow in their
-/// browser, so generous, but not unbounded.
-const CURSOR_LOGIN_TIMEOUT: Duration = Duration::from_secs(180);
+/// How long an interactive provider sign-in (Cursor or Codex) may take - a human finishing an
+/// OAuth flow in their browser, so generous, but not unbounded.
+const INTERACTIVE_LOGIN_TIMEOUT: Duration = Duration::from_secs(180);
 
 /// Run the interactive `cursor-agent login` on the user's behalf — the "Sign in to Cursor"
 /// button in the provider detail view.
@@ -560,26 +560,27 @@ pub async fn cursor_sign_in() -> InstallOutcome {
         tail(buf.trim(), 300)
     };
 
-    let output = match tokio::time::timeout(CURSOR_LOGIN_TIMEOUT, child.wait_with_output()).await {
-        Ok(Ok(out)) => out,
-        Ok(Err(e)) => {
-            return install_failed(label, format!("couldn't run cursor-agent login: {e}"))
-        }
-        Err(_) => {
-            let printed = login_output(&seen);
-            return install_failed(
-                label,
-                if printed.is_empty() {
-                    "the sign-in wasn't finished in time - click Sign in to Cursor again".into()
-                } else {
-                    format!(
-                        "the sign-in wasn't finished in time. Finish it by hand with what \
+    let output =
+        match tokio::time::timeout(INTERACTIVE_LOGIN_TIMEOUT, child.wait_with_output()).await {
+            Ok(Ok(out)) => out,
+            Ok(Err(e)) => {
+                return install_failed(label, format!("couldn't run cursor-agent login: {e}"))
+            }
+            Err(_) => {
+                let printed = login_output(&seen);
+                return install_failed(
+                    label,
+                    if printed.is_empty() {
+                        "the sign-in wasn't finished in time - click Sign in to Cursor again".into()
+                    } else {
+                        format!(
+                            "the sign-in wasn't finished in time. Finish it by hand with what \
                          cursor-agent printed:\n{printed}"
-                    )
-                },
-            );
-        }
-    };
+                        )
+                    },
+                );
+            }
+        };
 
     if output.status.success() {
         let span = tracing::Span::current();
@@ -605,6 +606,111 @@ pub async fn cursor_sign_in() -> InstallOutcome {
             label,
             if reason.is_empty() {
                 "cursor-agent login failed".to_string()
+            } else {
+                reason
+            },
+        )
+    }
+}
+
+/// Run the interactive `codex login` on the user's behalf — the "Sign in to Codex" button in
+/// the provider detail view.
+///
+/// `codex login` (no subcommand) opens the user's browser to sign into their ChatGPT account
+/// and runs a localhost callback server to receive the OAuth redirect; on success it writes
+/// `~/.codex/auth.json` and exits 0, so the summariser then runs on their **ChatGPT
+/// subscription** — no API key, nothing metered. A deliberate mirror of [`cursor_sign_in`]:
+/// the browser is enabled (this is an explicit click, not the daemon's unattended path),
+/// stdout is drained live so the verification URL is surfaced if the browser can't open, and
+/// the wait is bounded by [`INTERACTIVE_LOGIN_TIMEOUT`]. Once it completes, codex persists the
+/// auth and every later run just adopts it — the same "sign in once" model as Cursor.
+#[tracing::instrument(skip_all, fields(ok = tracing::field::Empty, cli_path = tracing::field::Empty))]
+pub async fn codex_sign_in() -> InstallOutcome {
+    let label = "codex login";
+    let Some(path) = resolve_cli("codex").await else {
+        return install_failed(label, "codex isn't installed yet - install it first".into());
+    };
+
+    tracing::info!("llm: launching interactive codex login");
+    let mut cmd = Command::new(&path);
+    cmd.arg("login")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .no_window();
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => return install_failed(label, format!("couldn't start codex: {e}")),
+    };
+
+    // Drain stdout as it arrives - `codex login` prints its verification URL to STDOUT while it
+    // waits, which is exactly what the user needs if the browser doesn't open for them. Same
+    // reasoning as the matching drain in `cursor_sign_in`.
+    let seen = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    if let Some(out) = child.stdout.take() {
+        let seen = seen.clone();
+        tokio::spawn(async move {
+            use tokio::io::{AsyncBufReadExt, BufReader};
+            let mut lines = BufReader::new(out).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                tracing::info!(line = %line, "codex login");
+                let mut buf = seen.lock().unwrap_or_else(|e| e.into_inner());
+                buf.push_str(&line);
+                buf.push('\n');
+            }
+        });
+    }
+    let login_output = |seen: &std::sync::Mutex<String>| -> String {
+        let buf = seen.lock().unwrap_or_else(|e| e.into_inner());
+        tail(buf.trim(), 300)
+    };
+
+    let output =
+        match tokio::time::timeout(INTERACTIVE_LOGIN_TIMEOUT, child.wait_with_output()).await {
+            Ok(Ok(out)) => out,
+            Ok(Err(e)) => return install_failed(label, format!("couldn't run codex login: {e}")),
+            Err(_) => {
+                let printed = login_output(&seen);
+                return install_failed(
+                    label,
+                    if printed.is_empty() {
+                        "the sign-in wasn't finished in time - click Sign in to Codex again".into()
+                    } else {
+                        format!(
+                            "the sign-in wasn't finished in time. Finish it by hand with what \
+                             codex printed:\n{printed}"
+                        )
+                    },
+                );
+            }
+        };
+
+    if output.status.success() {
+        let span = tracing::Span::current();
+        span.record("ok", true);
+        span.record("cli_path", tracing::field::display(path.display()));
+        tracing::info!("llm: codex login succeeded");
+        InstallOutcome {
+            ok: true,
+            message: "Signed in to Codex.".into(),
+            path: Some(path.display().to_string()),
+            command: label.to_string(),
+        }
+    } else {
+        // stderr first (that is where the reason goes), but fall back to what the CLI printed on
+        // stdout - on some failures the URL is the only useful thing said.
+        let reason = tail(String::from_utf8_lossy(&output.stderr).trim(), 400);
+        let reason = if reason.is_empty() {
+            login_output(&seen)
+        } else {
+            reason
+        };
+        install_failed(
+            label,
+            if reason.is_empty() {
+                "codex login failed".to_string()
             } else {
                 reason
             },

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -178,9 +178,15 @@ pub struct InUseProviderHealth {
     /// connectivity test (if any) didn't fail; a cloud endpoint's last test didn't fail. `false`
     /// means the dashboard should warn — summaries are paused or degraded until it's fixed.
     pub ok: bool,
+    /// `true` when the provider is usable (`ok` stays `true`) but its last test was RATE-LIMITED —
+    /// signed in and working, just throttled. Drives a distinct, softer "catching up" notice
+    /// rather than the "unavailable" alarm, because it clears on its own. Mutually exclusive with
+    /// `!ok` (a missing/failed provider is never also "rate-limited").
+    pub rate_limited: bool,
     /// Human name for the banner copy, e.g. "Codex".
     pub name: String,
-    /// Why it's unavailable, when `ok` is false — "not installed", or the last test's own error.
+    /// The reason to show: the failure/"not installed" text when `!ok`, or the rate-limit message
+    /// when `rate_limited`. `None` when the provider is simply fine.
     pub detail: Option<String>,
 }
 
@@ -197,70 +203,75 @@ fn provider_display_name(p: LlmProvider) -> &'static str {
 
 /// Compute [`InUseProviderHealth`] for the provider named in `settings.llm_provider`.
 ///
-/// A "rate-limited" last result is deliberately treated as available: it's a temporary state
-/// that clears on its own (the summariser waits it out), not a "your provider is broken" one —
-/// firing the banner on it would cry wolf. Only an outright `Failed` result, or a missing CLI,
-/// counts as unavailable. A provider with no test on record yet is assumed fine (don't alarm
-/// before we've ever had a reason to).
+/// Three outcomes, in priority order:
+/// - **unavailable** (`ok: false`) — the CLI is missing, or the last test outright `Failed`
+///   (signed out, spawn error). Summaries are paused; the dashboard alarms.
+/// - **rate-limited** (`ok: true, rate_limited: true`) — signed in and working, just throttled.
+///   A softer "catching up" notice, NOT the alarm: it clears on its own (the summariser waits it
+///   out), so treating it as "broken" would cry wolf.
+/// - **fine** (`ok: true`) — installed with an OK/absent last test. A provider with no test on
+///   record yet is assumed fine (don't alarm before we've ever had a reason to).
 pub async fn in_use_provider_health(settings: &RuntimeSettings) -> InUseProviderHealth {
     let Some(provider) = LlmProvider::from_wire(&settings.llm_provider) else {
         // An unrecognised provider string (a downgrade, a hand-edited settings file): don't
         // alarm on something we can't reason about.
         return InUseProviderHealth {
             ok: true,
+            rate_limited: false,
             name: settings.llm_provider.clone(),
             detail: None,
         };
     };
     let name = provider_display_name(provider).to_string();
 
-    // The last real connectivity test on record for this provider, if any.
+    // The last real connectivity test on record for this provider, if any - split into the two
+    // states that matter: an outright failure (unavailable) vs a rate limit (works, throttled).
     let last_outcome = load_test_cache()
         .get(provider.as_str())
         .map(|r| r.outcome.clone());
-    let last_failure = match &last_outcome {
+    let failed_reason = match &last_outcome {
         Some(ProviderTestOutcome::Failed { message }) => Some(message.clone()),
         _ => None,
     };
+    let rate_limited_reason = match &last_outcome {
+        Some(ProviderTestOutcome::RateLimited { message }) => Some(message.clone()),
+        _ => None,
+    };
 
-    match provider.cli_name() {
-        // A CLI-backed provider must be installed AND not have failed its last test.
-        Some(bin) => {
-            if resolve_cli(bin).await.is_none() {
-                InUseProviderHealth {
-                    ok: false,
-                    name: name.clone(),
-                    detail: Some(format!("{name} isn't installed")),
-                }
-            } else if let Some(reason) = last_failure {
-                InUseProviderHealth {
-                    ok: false,
-                    name,
-                    detail: Some(reason),
-                }
-            } else {
-                InUseProviderHealth {
-                    ok: true,
-                    name,
-                    detail: None,
-                }
-            }
+    // A CLI-backed provider must be installed; a cloud endpoint (`Custom`, `cli_name() == None`)
+    // has no binary to probe, so it skips the install gate. After that both share the same
+    // failed → rate-limited → fine ladder.
+    if let Some(bin) = provider.cli_name() {
+        if resolve_cli(bin).await.is_none() {
+            return InUseProviderHealth {
+                ok: false,
+                rate_limited: false,
+                name: name.clone(),
+                detail: Some(format!("{name} isn't installed")),
+            };
         }
-        // A cloud endpoint (`Custom`) has no CLI to probe — only its last test tells us anything.
-        None => {
-            if let Some(reason) = last_failure {
-                InUseProviderHealth {
-                    ok: false,
-                    name,
-                    detail: Some(reason),
-                }
-            } else {
-                InUseProviderHealth {
-                    ok: true,
-                    name,
-                    detail: None,
-                }
-            }
+    }
+
+    if let Some(reason) = failed_reason {
+        InUseProviderHealth {
+            ok: false,
+            rate_limited: false,
+            name,
+            detail: Some(reason),
+        }
+    } else if let Some(reason) = rate_limited_reason {
+        InUseProviderHealth {
+            ok: true,
+            rate_limited: true,
+            name,
+            detail: Some(reason),
+        }
+    } else {
+        InUseProviderHealth {
+            ok: true,
+            rate_limited: false,
+            name,
+            detail: None,
         }
     }
 }

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -166,6 +166,105 @@ pub async fn detect_all() -> Vec<ProviderStatus> {
     futures::future::join_all(futures).await
 }
 
+// ── In-use provider health (dashboard banner) ────────────────────────────────────────
+
+/// Whether the user's CURRENTLY-CHOSEN provider looks usable, for the dashboard's
+/// "provider unavailable" banner. Deliberately CHEAP: an install probe (memoised by
+/// [`resolve_cli`]) plus the on-disk last-test result — never a fresh metered call, so it's
+/// safe to compute on every health poll.
+#[derive(Debug, Clone)]
+pub struct InUseProviderHealth {
+    /// `true` when the chosen provider looks usable: a CLI provider is installed and its last
+    /// connectivity test (if any) didn't fail; a cloud endpoint's last test didn't fail. `false`
+    /// means the dashboard should warn — summaries are paused or degraded until it's fixed.
+    pub ok: bool,
+    /// Human name for the banner copy, e.g. "Codex".
+    pub name: String,
+    /// Why it's unavailable, when `ok` is false — "not installed", or the last test's own error.
+    pub detail: Option<String>,
+}
+
+/// A human display name for the banner — mirrors the chooser tiles in `ui/lib/llm-providers.ts`.
+fn provider_display_name(p: LlmProvider) -> &'static str {
+    match p {
+        LlmProvider::Claude => "Claude Code",
+        LlmProvider::Codex => "Codex",
+        LlmProvider::Cursor => "Cursor",
+        LlmProvider::Copilot => "Copilot",
+        LlmProvider::Custom => "your AI provider",
+    }
+}
+
+/// Compute [`InUseProviderHealth`] for the provider named in `settings.llm_provider`.
+///
+/// A "rate-limited" last result is deliberately treated as available: it's a temporary state
+/// that clears on its own (the summariser waits it out), not a "your provider is broken" one —
+/// firing the banner on it would cry wolf. Only an outright `Failed` result, or a missing CLI,
+/// counts as unavailable. A provider with no test on record yet is assumed fine (don't alarm
+/// before we've ever had a reason to).
+pub async fn in_use_provider_health(settings: &RuntimeSettings) -> InUseProviderHealth {
+    let Some(provider) = LlmProvider::from_wire(&settings.llm_provider) else {
+        // An unrecognised provider string (a downgrade, a hand-edited settings file): don't
+        // alarm on something we can't reason about.
+        return InUseProviderHealth {
+            ok: true,
+            name: settings.llm_provider.clone(),
+            detail: None,
+        };
+    };
+    let name = provider_display_name(provider).to_string();
+
+    // The last real connectivity test on record for this provider, if any.
+    let last_outcome = load_test_cache()
+        .get(provider.as_str())
+        .map(|r| r.outcome.clone());
+    let last_failure = match &last_outcome {
+        Some(ProviderTestOutcome::Failed { message }) => Some(message.clone()),
+        _ => None,
+    };
+
+    match provider.cli_name() {
+        // A CLI-backed provider must be installed AND not have failed its last test.
+        Some(bin) => {
+            if resolve_cli(bin).await.is_none() {
+                InUseProviderHealth {
+                    ok: false,
+                    name: name.clone(),
+                    detail: Some(format!("{name} isn't installed")),
+                }
+            } else if let Some(reason) = last_failure {
+                InUseProviderHealth {
+                    ok: false,
+                    name,
+                    detail: Some(reason),
+                }
+            } else {
+                InUseProviderHealth {
+                    ok: true,
+                    name,
+                    detail: None,
+                }
+            }
+        }
+        // A cloud endpoint (`Custom`) has no CLI to probe — only its last test tells us anything.
+        None => {
+            if let Some(reason) = last_failure {
+                InUseProviderHealth {
+                    ok: false,
+                    name,
+                    detail: Some(reason),
+                }
+            } else {
+                InUseProviderHealth {
+                    ok: true,
+                    name,
+                    detail: None,
+                }
+            }
+        }
+    }
+}
+
 // ── Real connectivity test ───────────────────────────────────────────────────────────
 
 /// A test call is capped far tighter than a real hourly summary (which can legitimately

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -684,6 +684,13 @@ pub fn persist_test_result(result: &ProviderTestResult) {
 /// `claude` while the tray is running would otherwise be told it is missing until they
 /// restart the app. The cost of not caching misses is one login-shell probe per call on a
 /// genuinely absent CLI, bounded by [`PROBE_TIMEOUT`].
+///
+/// A cache HIT is still re-validated with a cheap [`Path::exists`] check in [`resolve_cli`]
+/// before being trusted: a CLI uninstalled (or moved) while this process is running would
+/// otherwise be reported "installed" forever, and the next real invocation would fail with
+/// a raw, unfriendly OS/shell error instead of "not installed" — that was the exact symptom
+/// hit uninstalling `codex`/`cursor-agent` out from under a running tray. `exists()` is a
+/// single stat syscall, not a shell spawn, so this costs nothing on the hot path.
 static RESOLVED_BINS: std::sync::OnceLock<std::sync::Mutex<HashMap<String, PathBuf>>> =
     std::sync::OnceLock::new();
 
@@ -718,7 +725,17 @@ pub async fn resolve_cli(bin: &str) -> Option<PathBuf> {
         .get(bin)
         .cloned()
     {
-        return Some(hit);
+        if hit.exists() {
+            return Some(hit);
+        }
+        // Stale: the CLI was removed (or moved) since we last resolved it. Drop the
+        // entry and fall through to a fresh probe rather than trusting it forever.
+        tracing::debug!(bin, path = %hit.display(), "cached CLI path no longer exists - re-probing");
+        RESOLVED_BINS
+            .get_or_init(Default::default)
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(bin);
     }
 
     let found = match probe_current_path(bin) {
@@ -925,6 +942,42 @@ mod tests {
                 .unwrap()
                 .contains_key(bin),
             "a miss was cached, so installing the CLI later would not be picked up"
+        );
+    }
+
+    /// The regression this exists for: uninstalling `codex`/`cursor-agent` out from under a
+    /// running tray left `RESOLVED_BINS` pointing at a path that no longer existed, and the
+    /// stale hit was trusted forever - reporting "installed" (then failing with a raw OS
+    /// error on the next real invocation) instead of "not installed". A cache hit must be
+    /// re-validated with `exists()` and dropped if it no longer holds.
+    #[tokio::test]
+    async fn resolve_cli_drops_a_stale_cache_entry_whose_path_no_longer_exists() {
+        let bin = "meridian-uninstalled-while-running-xyz";
+        let stale = std::env::temp_dir().join("meridian-definitely-does-not-exist-anymore");
+        assert!(
+            !stale.exists(),
+            "canary path must not exist: {}",
+            stale.display()
+        );
+
+        RESOLVED_BINS
+            .get_or_init(Default::default)
+            .lock()
+            .unwrap()
+            .insert(bin.to_string(), stale.clone());
+
+        assert_eq!(
+            resolve_cli(bin).await,
+            None,
+            "a stale cached path was trusted instead of being re-probed"
+        );
+        assert!(
+            !RESOLVED_BINS
+                .get_or_init(Default::default)
+                .lock()
+                .unwrap()
+                .contains_key(bin),
+            "the stale entry was not evicted from the cache"
         );
     }
 

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -201,17 +201,60 @@ fn provider_display_name(p: LlmProvider) -> &'static str {
     }
 }
 
-/// Compute [`InUseProviderHealth`] for the provider named in `settings.llm_provider`.
-///
-/// Three outcomes, in priority order:
-/// - **unavailable** (`ok: false`) — the CLI is missing, or the last test outright `Failed`
-///   (signed out, spawn error). Summaries are paused; the dashboard alarms.
-/// - **rate-limited** (`ok: true, rate_limited: true`) — signed in and working, just throttled.
-///   A softer "catching up" notice, NOT the alarm: it clears on its own (the summariser waits it
-///   out), so treating it as "broken" would cry wolf.
-/// - **fine** (`ok: true`) — installed with an OK/absent last test. A provider with no test on
-///   record yet is assumed fine (don't alarm before we've ever had a reason to).
+/// How long an [`in_use_provider_health`] result is reused before recomputing. The recurring
+/// health poll (every 60 s) AND every on-demand `get_health` would otherwise re-run the install
+/// probe each tick — and for an UNINSTALLED provider (the exact state the "provider unavailable"
+/// banner exists to surface) that probe can't hit `resolve_cli`'s hit-only cache, so it falls
+/// through to a login-shell spawn on a packaged app every time. A few-minute TTL bounds that to
+/// one probe per window while still clearing/raising the banner promptly relative to the hourly
+/// summary cadence it guards.
+const IN_USE_HEALTH_TTL: Duration = Duration::from_secs(300);
+
+/// Cache of the last computed provider health: `(provider wire id, computed_at, result)`. Keyed
+/// by the provider id so switching the selected provider invalidates it immediately rather than
+/// serving the previous provider's verdict for up to a TTL.
+#[allow(clippy::type_complexity)]
+static IN_USE_HEALTH_CACHE: std::sync::OnceLock<
+    std::sync::Mutex<Option<(String, Instant, InUseProviderHealth)>>,
+> = std::sync::OnceLock::new();
+
+/// Whether the user's CURRENTLY-CHOSEN provider looks usable — [`InUseProviderHealth`] for the
+/// provider named in `settings.llm_provider`, served from a short-TTL cache
+/// ([`IN_USE_HEALTH_TTL`]) so the recurring health poll doesn't re-run the (possibly
+/// login-shell-spawning) install probe on every tick. See [`classify_provider_health`] for the
+/// unavailable → rate-limited → fine decision.
 pub async fn in_use_provider_health(settings: &RuntimeSettings) -> InUseProviderHealth {
+    // Serve a fresh-enough cached result for the SAME provider.
+    {
+        let guard = IN_USE_HEALTH_CACHE
+            .get_or_init(Default::default)
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if let Some((provider, at, health)) = guard.as_ref() {
+            if provider == &settings.llm_provider && at.elapsed() < IN_USE_HEALTH_TTL {
+                return health.clone();
+            }
+        }
+    }
+
+    let health = compute_in_use_provider_health(settings).await;
+
+    let mut guard = IN_USE_HEALTH_CACHE
+        .get_or_init(Default::default)
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    *guard = Some((
+        settings.llm_provider.clone(),
+        Instant::now(),
+        health.clone(),
+    ));
+    health
+}
+
+/// The uncached computation behind [`in_use_provider_health`]: resolve install state (one
+/// [`resolve_cli`] probe for a CLI provider; a cloud `Custom` endpoint has no binary) plus the
+/// last on-disk test result, then hand both to [`classify_provider_health`].
+async fn compute_in_use_provider_health(settings: &RuntimeSettings) -> InUseProviderHealth {
     let Some(provider) = LlmProvider::from_wire(&settings.llm_provider) else {
         // An unrecognised provider string (a downgrade, a hand-edited settings file): don't
         // alarm on something we can't reason about.
@@ -223,56 +266,58 @@ pub async fn in_use_provider_health(settings: &RuntimeSettings) -> InUseProvider
         };
     };
     let name = provider_display_name(provider).to_string();
-
-    // The last real connectivity test on record for this provider, if any - split into the two
-    // states that matter: an outright failure (unavailable) vs a rate limit (works, throttled).
     let last_outcome = load_test_cache()
         .get(provider.as_str())
         .map(|r| r.outcome.clone());
-    let failed_reason = match &last_outcome {
-        Some(ProviderTestOutcome::Failed { message }) => Some(message.clone()),
-        _ => None,
+    // A cloud endpoint (`Custom`, `cli_name() == None`) has no binary to probe, so it's treated
+    // as "installed" here — only its last test can tell us anything.
+    let installed = match provider.cli_name() {
+        Some(bin) => resolve_cli(bin).await.is_some(),
+        None => true,
     };
-    let rate_limited_reason = match &last_outcome {
-        Some(ProviderTestOutcome::RateLimited { message }) => Some(message.clone()),
-        _ => None,
-    };
+    classify_provider_health(name, installed, last_outcome.as_ref())
+}
 
-    // A CLI-backed provider must be installed; a cloud endpoint (`Custom`, `cli_name() == None`)
-    // has no binary to probe, so it skips the install gate. After that both share the same
-    // failed → rate-limited → fine ladder.
-    if let Some(bin) = provider.cli_name() {
-        if resolve_cli(bin).await.is_none() {
-            return InUseProviderHealth {
-                ok: false,
-                rate_limited: false,
-                name: name.clone(),
-                detail: Some(format!("{name} isn't installed")),
-            };
-        }
+/// The pure unavailable → rate-limited → fine decision, split out so the ladder can be unit-tested
+/// without a filesystem probe.
+///
+/// - not installed → **unavailable** (`ok: false`).
+/// - installed + last test `Failed` → **unavailable** (signed out, spawn error, …).
+/// - installed + last test `RateLimited` → **rate-limited** (`ok: true, rate_limited: true`): it
+///   clears on its own, so a softer flag rather than the alarm — alarming would cry wolf.
+/// - installed + `Ok`/no test on record → **fine** (don't alarm before we've had a reason to).
+fn classify_provider_health(
+    name: String,
+    installed: bool,
+    last_outcome: Option<&ProviderTestOutcome>,
+) -> InUseProviderHealth {
+    if !installed {
+        return InUseProviderHealth {
+            ok: false,
+            rate_limited: false,
+            detail: Some(format!("{name} isn't installed")),
+            name,
+        };
     }
-
-    if let Some(reason) = failed_reason {
-        InUseProviderHealth {
+    match last_outcome {
+        Some(ProviderTestOutcome::Failed { message }) => InUseProviderHealth {
             ok: false,
             rate_limited: false,
             name,
-            detail: Some(reason),
-        }
-    } else if let Some(reason) = rate_limited_reason {
-        InUseProviderHealth {
+            detail: Some(message.clone()),
+        },
+        Some(ProviderTestOutcome::RateLimited { message }) => InUseProviderHealth {
             ok: true,
             rate_limited: true,
             name,
-            detail: Some(reason),
-        }
-    } else {
-        InUseProviderHealth {
+            detail: Some(message.clone()),
+        },
+        _ => InUseProviderHealth {
             ok: true,
             rate_limited: false,
             name,
             detail: None,
-        }
+        },
     }
 }
 
@@ -1349,6 +1394,41 @@ mod tests {
         // copy ("Meridian uses your existing login") is a lie and must change with it.
         for s in detect_all().await {
             assert_eq!(s.authenticated, None, "{}", s.id);
+        }
+    }
+
+    /// The dashboard banner's whole meaning rides on this ladder, so pin every rung: not
+    /// installed and an outright `Failed` are UNAVAILABLE (the alarm); a rate limit stays
+    /// available with the softer flag (it self-recovers - alarming would cry wolf); an `Ok` or
+    /// no-test-yet is fine. Pure, so no probe/filesystem needed.
+    #[test]
+    fn classify_provider_health_ranks_unavailable_over_rate_limited_over_fine() {
+        // not installed → unavailable, regardless of any prior test result.
+        let h = classify_provider_health("Codex".into(), false, None);
+        assert!(!h.ok && !h.rate_limited);
+        assert_eq!(h.detail.as_deref(), Some("Codex isn't installed"));
+
+        // installed but last test FAILED → unavailable, surfacing that reason.
+        let failed = ProviderTestOutcome::Failed {
+            message: "not signed in".into(),
+        };
+        let h = classify_provider_health("Codex".into(), true, Some(&failed));
+        assert!(!h.ok && !h.rate_limited);
+        assert_eq!(h.detail.as_deref(), Some("not signed in"));
+
+        // installed + RATE-LIMITED → still available (ok), softer flag set, message surfaced.
+        let rl = ProviderTestOutcome::RateLimited {
+            message: "usage limit".into(),
+        };
+        let h = classify_provider_health("Codex".into(), true, Some(&rl));
+        assert!(h.ok && h.rate_limited);
+        assert_eq!(h.detail.as_deref(), Some("usage limit"));
+
+        // installed + Ok, and installed + no test on record → fine, no banner, no detail.
+        let ok = ProviderTestOutcome::Ok;
+        for last in [Some(&ok), None] {
+            let h = classify_provider_health("Codex".into(), true, last);
+            assert!(h.ok && !h.rate_limited && h.detail.is_none());
         }
     }
 

--- a/tray/src-tauri/src/commands/health.rs
+++ b/tray/src-tauri/src/commands/health.rs
@@ -37,10 +37,15 @@ pub struct HealthResponse {
     /// are paused/degraded until it's fixed. See [`meridian::llm::detect::in_use_provider_health`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub llm_provider_ok: Option<bool>,
+    /// `Some(true)` when the in-use provider is usable but RATE-LIMITED — drives a softer
+    /// "catching up" notice instead of the "unavailable" alarm (it clears on its own).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_provider_rate_limited: Option<bool>,
     /// Human name of the in-use provider for the banner copy (e.g. "Codex").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub llm_provider_name: Option<String>,
-    /// Why the in-use provider is unavailable, when `llm_provider_ok` is `Some(false)`.
+    /// The banner reason — the failure/"not installed" text when unavailable, or the rate-limit
+    /// message when rate-limited.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub llm_provider_detail: Option<String>,
 }
@@ -85,6 +90,7 @@ pub async fn check_health() -> HealthResponse {
         a11y_helper_trusted: trusted,
         daemon_running: daemon,
         llm_provider_ok: Some(provider.ok),
+        llm_provider_rate_limited: Some(provider.rate_limited),
         llm_provider_name: Some(provider.name),
         llm_provider_detail: provider.detail,
     }
@@ -200,6 +206,7 @@ pub async fn get_health() -> Result<HealthResponse, String> {
         a11y = ?result.a11y_helper_trusted,
         llm_provider = ?result.llm_provider_name,
         llm_provider_ok = ?result.llm_provider_ok,
+        llm_provider_rate_limited = ?result.llm_provider_rate_limited,
         llm_provider_detail = ?result.llm_provider_detail,
         "health checked"
     );

--- a/tray/src-tauri/src/commands/health.rs
+++ b/tray/src-tauri/src/commands/health.rs
@@ -32,6 +32,17 @@ pub struct HealthResponse {
     pub a11y_helper_trusted: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Whether the user's CURRENTLY-CHOSEN LLM provider looks usable (installed + last test not
+    /// failed). `Some(false)` drives the dashboard's "provider unavailable" banner — summaries
+    /// are paused/degraded until it's fixed. See [`meridian::llm::detect::in_use_provider_health`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_provider_ok: Option<bool>,
+    /// Human name of the in-use provider for the banner copy (e.g. "Codex").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_provider_name: Option<String>,
+    /// Why the in-use provider is unavailable, when `llm_provider_ok` is `Some(false)`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_provider_detail: Option<String>,
 }
 
 /// Run all three health checks in parallel and return the combined result.
@@ -63,11 +74,19 @@ pub async fn check_health() -> HealthResponse {
 
     let error = if !db.0 { db.1 } else { None };
 
+    // The in-use LLM provider's availability - a cheap install probe + cached last-test read,
+    // no metered call (see `in_use_provider_health`), so it's fine on the 60 s health cadence.
+    let settings = meridian_core::settings::load_runtime_settings();
+    let provider = meridian::llm::detect::in_use_provider_health(&settings).await;
+
     HealthResponse {
         database_ready: Some(db.0),
         error,
         a11y_helper_trusted: trusted,
         daemon_running: daemon,
+        llm_provider_ok: Some(provider.ok),
+        llm_provider_name: Some(provider.name),
+        llm_provider_detail: provider.detail,
     }
 }
 
@@ -179,6 +198,9 @@ pub async fn get_health() -> Result<HealthResponse, String> {
         db = ?result.database_ready,
         daemon = ?result.daemon_running,
         a11y = ?result.a11y_helper_trusted,
+        llm_provider = ?result.llm_provider_name,
+        llm_provider_ok = ?result.llm_provider_ok,
+        llm_provider_detail = ?result.llm_provider_detail,
         "health checked"
     );
     Ok(result)

--- a/tray/src-tauri/src/commands/setup.rs
+++ b/tray/src-tauri/src/commands/setup.rs
@@ -282,6 +282,18 @@ pub async fn cursor_sign_in() -> Result<meridian::llm::detect::InstallOutcome, S
     Ok(outcome)
 }
 
+/// Run the interactive `codex login` - the Codex detail view's "Sign in to Codex" button.
+/// Opens the user's browser to sign into their ChatGPT account, so the summariser runs on their
+/// ChatGPT SUBSCRIPTION (no API key, nothing metered). Only ever on an explicit click; the
+/// daemon's own unattended path never opens a browser. Mirrors [`cursor_sign_in`].
+#[tauri::command]
+#[tracing::instrument]
+pub async fn codex_sign_in() -> Result<meridian::llm::detect::InstallOutcome, String> {
+    let outcome = meridian::llm::detect::codex_sign_in().await;
+    tracing::info!(ok = outcome.ok, "llm: codex sign-in complete");
+    Ok(outcome)
+}
+
 /// Test every currently-installed provider at once - the Intelligence panel's Rescan
 /// action. Each result is persisted as it lands (see
 /// [`meridian::llm::detect::test_all_installed`]), so a slow or hanging CLI can't hold the

--- a/tray/src-tauri/src/commands/setup.rs
+++ b/tray/src-tauri/src/commands/setup.rs
@@ -294,6 +294,18 @@ pub async fn codex_sign_in() -> Result<meridian::llm::detect::InstallOutcome, St
     Ok(outcome)
 }
 
+/// Run the interactive `claude auth login` - the Claude detail view's "Sign in to Claude"
+/// button. Opens the user's browser to sign into their Anthropic account, so the summariser runs
+/// on their Claude SUBSCRIPTION (no API key, nothing metered). Only ever on an explicit click;
+/// the daemon's own unattended path never opens a browser. Mirrors [`cursor_sign_in`].
+#[tauri::command]
+#[tracing::instrument]
+pub async fn claude_sign_in() -> Result<meridian::llm::detect::InstallOutcome, String> {
+    let outcome = meridian::llm::detect::claude_sign_in().await;
+    tracing::info!(ok = outcome.ok, "llm: claude sign-in complete");
+    Ok(outcome)
+}
+
 /// Test every currently-installed provider at once - the Intelligence panel's Rescan
 /// action. Each result is persisted as it lands (see
 /// [`meridian::llm::detect::test_all_installed`]), so a slow or hanging CLI can't hold the

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -617,6 +617,7 @@ pub fn run() {
             commands::test_all_llm_providers,
             commands::install_llm_provider,
             commands::cursor_sign_in,
+            commands::codex_sign_in,
             // Custom cloud endpoints (add/probe/remove). `add` + `probe` spend real metered
             // requests measuring the endpoint — only ever on explicit user action.
             commands::add_custom_llm_provider,

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -618,6 +618,7 @@ pub fn run() {
             commands::install_llm_provider,
             commands::cursor_sign_in,
             commands::codex_sign_in,
+            commands::claude_sign_in,
             // Custom cloud endpoints (add/probe/remove). `add` + `probe` spend real metered
             // requests measuring the endpoint — only ever on explicit user action.
             commands::add_custom_llm_provider,

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -31,6 +31,22 @@ pub(super) async fn refresh_health(
 ) {
     let hr = check_health().await;
 
+    // Surface the in-use LLM provider's health on the poll path too (the `get_health` command
+    // logs it on demand; this catches the background 60 s cadence). A warn when it's unavailable
+    // is genuinely worth having in the log - it means hourly summaries are paused.
+    if hr.llm_provider_ok == Some(false) {
+        tracing::warn!(
+            provider = ?hr.llm_provider_name,
+            detail = ?hr.llm_provider_detail,
+            "in-use LLM provider is unavailable — hourly summaries paused"
+        );
+    } else if hr.llm_provider_rate_limited == Some(true) {
+        tracing::info!(
+            provider = ?hr.llm_provider_name,
+            "in-use LLM provider is rate-limited — summaries will catch up when the limit clears"
+        );
+    }
+
     // Push the health detail to the dashboard webview (the ported
     // `/api/health/stream`). HealthResponse is a superset of the route's payload
     // (it also carries `daemon_running`, which the banner ignores).

--- a/ui/__tests__/llm-provider-connection-phase.test.ts
+++ b/ui/__tests__/llm-provider-connection-phase.test.ts
@@ -114,9 +114,9 @@ it("the picker's test handler invokes the real Tauri command against the live CL
   expect(picker).toMatch(/invoke<ProviderTestResult>\('test_llm_provider'/)
 })
 
-// ── Subscription providers (Cursor, Codex) get bespoke "not signed in" copy with an in-app ──
-// ── sign-in button for an unclassified failure; every other provider shows the raw message. ──
-// ── Both must still originate from the SAME real Test call (a `failed` phase).
+// ── Subscription providers (Cursor, Codex, Claude) get bespoke "not signed in" copy with an ──
+// ── in-app sign-in button for an unclassified failure; every other provider shows the raw ────
+// ── message. Both must still originate from the SAME real Test call (a `failed` phase). ──────
 
 it('the subscription-provider "not signed in" copy only replaces the DISPLAY, not the trigger — it is still gated on phase.kind === "failed"', () => {
   const failedBranch = detail.slice(detail.indexOf("case 'failed':"))
@@ -125,9 +125,10 @@ it('the subscription-provider "not signed in" copy only replaces the DISPLAY, no
   expect(failedBranch).toMatch(/if \(signInProvider\)/)
   expect(failedBranch).toMatch(/not signed in yet/)
   expect(failedBranch).toMatch(/\{signInProvider\.label\}/)
-  // Both Cursor and Codex are covered by the descriptor (each with its own bespoke label).
+  // Cursor, Codex, and Claude are each covered by the descriptor (each with its own label).
   expect(detail).toMatch(/Sign in to Cursor/)
   expect(detail).toMatch(/Sign in to Codex/)
+  expect(detail).toMatch(/Sign in to Claude/)
 })
 
 it('every other provider surfaces the real failure message verbatim, not a generic substitute', () => {

--- a/ui/__tests__/llm-provider-connection-phase.test.ts
+++ b/ui/__tests__/llm-provider-connection-phase.test.ts
@@ -114,14 +114,20 @@ it("the picker's test handler invokes the real Tauri command against the live CL
   expect(picker).toMatch(/invoke<ProviderTestResult>\('test_llm_provider'/)
 })
 
-// ── Cursor gets bespoke "not signed in" copy for an unclassified failure; every other ──────
-// ── provider shows the raw message. Both must still originate from the SAME real Test call.
+// ── Subscription providers (Cursor, Codex) get bespoke "not signed in" copy with an in-app ──
+// ── sign-in button for an unclassified failure; every other provider shows the raw message. ──
+// ── Both must still originate from the SAME real Test call (a `failed` phase).
 
-it('the Cursor-specific "not signed in" copy only replaces the DISPLAY, not the trigger — it is still gated on phase.kind === "failed"', () => {
-  const cursorBranch = detail.slice(detail.indexOf("case 'failed':"))
-  expect(cursorBranch).toMatch(/if \(isCursor\)/)
-  expect(cursorBranch).toMatch(/not signed in yet/)
-  expect(cursorBranch).toMatch(/Sign in to Cursor/)
+it('the subscription-provider "not signed in" copy only replaces the DISPLAY, not the trigger — it is still gated on phase.kind === "failed"', () => {
+  const failedBranch = detail.slice(detail.indexOf("case 'failed':"))
+  // The in-app sign-in UI is gated on the failed phase via the signInProvider descriptor,
+  // showing the "not signed in" copy and that provider's own sign-in button label.
+  expect(failedBranch).toMatch(/if \(signInProvider\)/)
+  expect(failedBranch).toMatch(/not signed in yet/)
+  expect(failedBranch).toMatch(/\{signInProvider\.label\}/)
+  // Both Cursor and Codex are covered by the descriptor (each with its own bespoke label).
+  expect(detail).toMatch(/Sign in to Cursor/)
+  expect(detail).toMatch(/Sign in to Codex/)
 })
 
 it('every other provider surfaces the real failure message verbatim, not a generic substitute', () => {

--- a/ui/components/HealthBanner.tsx
+++ b/ui/components/HealthBanner.tsx
@@ -20,7 +20,12 @@ interface HealthStatus {
 
 export default function HealthBanner() {
   const [health, setHealth] = useState<HealthStatus | null>(null)
-  const [dismissed, setDismissed] = useState(false)
+  // Dismissal is keyed to the SIGNATURE of the banner that was dismissed, not a global boolean,
+  // so dismissing one problem can't suppress a different (or worse) one that arises later - e.g.
+  // dismissing the a11y notice must not hide a subsequent "your provider is unavailable, summaries
+  // paused" banner. When the active problem's signature changes, the old dismissal no longer
+  // matches and the banner reappears.
+  const [dismissedSig, setDismissedSig] = useState<string | null>(null)
 
   useEffect(() => {
     // health-update (Tauri event) in the app, /api/health/stream SSE in a browser.
@@ -39,11 +44,25 @@ export default function HealthBanner() {
     !!health && health.llm_provider_rate_limited === true && health.llm_provider_ok !== false && !showDatabaseError
   const showA11yWarning =
     !!health && health.a11y_helper_trusted === false && !showDatabaseError && !showProviderError && !showProviderRateLimit
-  const anyProblem = showDatabaseError || showProviderError || showProviderRateLimit || showA11yWarning
+  // A signature that identifies the active (highest-priority) banner AND its content, so a
+  // dismissal is scoped to exactly that alert. `null` when there's nothing to show.
+  const pName = health?.llm_provider_name ?? ''
+  const pDetail = health?.llm_provider_detail ?? ''
+  const activeSig = showDatabaseError
+    ? `db:${health?.error ?? 'schema'}`
+    : showProviderError
+      ? `provider-unavailable:${pName}:${pDetail}`
+      : showProviderRateLimit
+        ? `provider-ratelimit:${pName}:${pDetail}`
+        : showA11yWarning
+          ? 'a11y'
+          : null
 
-  if (!health || !anyProblem || dismissed) {
+  if (!health || !activeSig || activeSig === dismissedSig) {
     return null
   }
+
+  const dismiss = () => setDismissedSig(activeSig)
 
   if (showDatabaseError) {
     const isNotFound = health.error?.toLowerCase().includes('not found') ?? false
@@ -71,7 +90,7 @@ export default function HealthBanner() {
           </div>
         </div>
         <button
-          onClick={() => setDismissed(true)}
+          onClick={dismiss}
           className="px-3 py-1 text-xs rounded hover:opacity-70 transition-opacity"
           style={{ color: 'var(--ink-3)', border: '1px solid var(--rule)' }}
         >
@@ -101,7 +120,7 @@ export default function HealthBanner() {
           </div>
         </div>
         <button
-          onClick={() => setDismissed(true)}
+          onClick={dismiss}
           className="px-3 py-1 text-xs rounded hover:opacity-70 transition-opacity"
           style={{ color: 'var(--ink-3)', border: '1px solid var(--rule)' }}
         >
@@ -131,7 +150,7 @@ export default function HealthBanner() {
           </div>
         </div>
         <button
-          onClick={() => setDismissed(true)}
+          onClick={dismiss}
           className="px-3 py-1 text-xs rounded hover:opacity-70 transition-opacity"
           style={{ color: 'var(--ink-3)', border: '1px solid var(--rule)' }}
         >
@@ -161,7 +180,7 @@ export default function HealthBanner() {
         </div>
       </div>
       <button
-        onClick={() => setDismissed(true)}
+        onClick={dismiss}
         className="px-3 py-1 text-xs rounded hover:opacity-70 transition-opacity"
         style={{ color: 'var(--ink-3)', border: '1px solid var(--rule)' }}
       >

--- a/ui/components/HealthBanner.tsx
+++ b/ui/components/HealthBanner.tsx
@@ -8,6 +8,11 @@ interface HealthStatus {
   a11y_helper_trusted?: boolean
   database_ready?: boolean
   error?: string
+  /** Whether the in-use LLM provider is usable. `false` → the provider is missing or failing,
+   *  so summaries are paused/degraded. `llm_provider_name`/`_detail` fill the banner copy. */
+  llm_provider_ok?: boolean
+  llm_provider_name?: string
+  llm_provider_detail?: string
 }
 
 export default function HealthBanner() {
@@ -22,11 +27,15 @@ export default function HealthBanner() {
     })
   }, [])
 
-  // Show banner if database is not ready (critical), or a11y-helper is not trusted, and not dismissed
-  const showDatabaseError = health && health.database_ready === false
-  const showA11yWarning = health && health.a11y_helper_trusted === false && health.database_ready !== false
+  // One banner at a time, in priority order: database not ready (critical) > in-use LLM
+  // provider unavailable (summaries paused) > a11y-helper not trusted (capture degraded).
+  const showDatabaseError = !!health && health.database_ready === false
+  const showProviderError = !!health && health.llm_provider_ok === false && !showDatabaseError
+  const showA11yWarning =
+    !!health && health.a11y_helper_trusted === false && !showDatabaseError && !showProviderError
+  const anyProblem = showDatabaseError || showProviderError || showA11yWarning
 
-  if (!health || (health.a11y_helper_trusted !== false && health.database_ready !== false) || dismissed) {
+  if (!health || !anyProblem || dismissed) {
     return null
   }
 
@@ -52,6 +61,36 @@ export default function HealthBanner() {
             </p>
             <p className="text-xs mt-0.5" style={{ color: 'var(--ink-3)' }}>
               {health.error ?? defaultDetail}
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={() => setDismissed(true)}
+          className="px-3 py-1 text-xs rounded hover:opacity-70 transition-opacity"
+          style={{ color: 'var(--ink-3)', border: '1px solid var(--rule)' }}
+        >
+          Dismiss
+        </button>
+      </div>
+    )
+  }
+
+  if (showProviderError) {
+    const providerName = health.llm_provider_name ?? 'Your AI provider'
+    return (
+      <div
+        className="w-full px-6 py-3.5 flex items-center justify-between border-b"
+        style={{ borderBottomColor: 'var(--rule)', backgroundColor: 'rgba(253, 224, 71, 0.08)' }}
+      >
+        <div className="flex items-center gap-3 flex-1">
+          <span className="text-lg">🤖</span>
+          <div className="flex-1">
+            <p className="text-sm" style={{ color: 'var(--ink-2)' }}>
+              <strong>{providerName} isn&apos;t available</strong>
+            </p>
+            <p className="text-xs mt-0.5" style={{ color: 'var(--ink-3)' }}>
+              {health.llm_provider_detail ? `${health.llm_provider_detail}. ` : ''}
+              Hourly summaries are paused — open Settings → Intelligence to reinstall, sign in, or pick another provider.
             </p>
           </div>
         </div>

--- a/ui/components/HealthBanner.tsx
+++ b/ui/components/HealthBanner.tsx
@@ -11,6 +11,9 @@ interface HealthStatus {
   /** Whether the in-use LLM provider is usable. `false` → the provider is missing or failing,
    *  so summaries are paused/degraded. `llm_provider_name`/`_detail` fill the banner copy. */
   llm_provider_ok?: boolean
+  /** `true` → the provider is usable but rate-limited: a softer "catching up" notice, not the
+   *  "unavailable" alarm (it clears on its own). Only meaningful when `llm_provider_ok !== false`. */
+  llm_provider_rate_limited?: boolean
   llm_provider_name?: string
   llm_provider_detail?: string
 }
@@ -27,13 +30,16 @@ export default function HealthBanner() {
     })
   }, [])
 
-  // One banner at a time, in priority order: database not ready (critical) > in-use LLM
-  // provider unavailable (summaries paused) > a11y-helper not trusted (capture degraded).
+  // One banner at a time, in priority order: database not ready (critical) > in-use LLM provider
+  // unavailable (summaries paused) > provider rate-limited (summaries catching up, soft notice) >
+  // a11y-helper not trusted (capture degraded).
   const showDatabaseError = !!health && health.database_ready === false
   const showProviderError = !!health && health.llm_provider_ok === false && !showDatabaseError
+  const showProviderRateLimit =
+    !!health && health.llm_provider_rate_limited === true && health.llm_provider_ok !== false && !showDatabaseError
   const showA11yWarning =
-    !!health && health.a11y_helper_trusted === false && !showDatabaseError && !showProviderError
-  const anyProblem = showDatabaseError || showProviderError || showA11yWarning
+    !!health && health.a11y_helper_trusted === false && !showDatabaseError && !showProviderError && !showProviderRateLimit
+  const anyProblem = showDatabaseError || showProviderError || showProviderRateLimit || showA11yWarning
 
   if (!health || !anyProblem || dismissed) {
     return null
@@ -91,6 +97,36 @@ export default function HealthBanner() {
             <p className="text-xs mt-0.5" style={{ color: 'var(--ink-3)' }}>
               {health.llm_provider_detail ? `${health.llm_provider_detail}. ` : ''}
               Hourly summaries are paused — open Settings → Intelligence to reinstall, sign in, or pick another provider.
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={() => setDismissed(true)}
+          className="px-3 py-1 text-xs rounded hover:opacity-70 transition-opacity"
+          style={{ color: 'var(--ink-3)', border: '1px solid var(--rule)' }}
+        >
+          Dismiss
+        </button>
+      </div>
+    )
+  }
+
+  if (showProviderRateLimit) {
+    const providerName = health.llm_provider_name ?? 'Your AI provider'
+    return (
+      <div
+        className="w-full px-6 py-3.5 flex items-center justify-between border-b"
+        style={{ borderBottomColor: 'var(--rule)', backgroundColor: 'rgba(59, 130, 246, 0.08)' }}
+      >
+        <div className="flex items-center gap-3 flex-1">
+          <span className="text-lg">⏳</span>
+          <div className="flex-1">
+            <p className="text-sm" style={{ color: 'var(--ink-2)' }}>
+              <strong>{providerName} is rate-limited</strong>
+            </p>
+            <p className="text-xs mt-0.5" style={{ color: 'var(--ink-3)' }}>
+              {health.llm_provider_detail ? `${health.llm_provider_detail}. ` : ''}
+              You&apos;re signed in and nothing is lost — summaries will catch up on their own once the limit resets.
             </p>
           </div>
         </div>

--- a/ui/components/LlmProviderDetail.tsx
+++ b/ui/components/LlmProviderDetail.tsx
@@ -249,13 +249,15 @@ function ConnectionBody({ phase, name, providerId, installHint, installMsg, sign
   // Providers whose CLI authenticates against the user's OWN subscription via a browser OAuth
   // that Meridian can drive in-app (a "Sign in to …" button → the `*_sign_in` tray command).
   // `account`/`subscription` fill the copy; `cmd` is the terminal fallback. `null` for
-  // providers with no in-app sign-in (e.g. Claude/Copilot, or a cloud endpoint).
+  // providers with no in-app sign-in (e.g. Copilot, or a cloud endpoint).
   const signInProvider =
     providerId === 'cursor'
       ? { label: 'Sign in to Cursor', account: 'Cursor', subscription: 'Cursor subscription', cmd: 'cursor-agent login' }
       : providerId === 'codex'
         ? { label: 'Sign in to Codex', account: 'ChatGPT', subscription: 'ChatGPT subscription', cmd: 'codex login' }
-        : null
+        : providerId === 'claude'
+          ? { label: 'Sign in to Claude', account: 'Claude', subscription: 'Claude subscription', cmd: 'claude auth login' }
+          : null
 
   switch (phase.kind) {
     case 'installing':

--- a/ui/components/LlmProviderDetail.tsx
+++ b/ui/components/LlmProviderDetail.tsx
@@ -80,7 +80,8 @@ export interface LlmProviderDetailProps {
   onBack: () => void
   /** Run the vendor installer; resolves with what happened so we can show the message. */
   onInstall: () => Promise<InstallOutcome>
-  /** Run the interactive Cursor sign-in (browser OAuth on their subscription). Cursor-only. */
+  /** Run the interactive browser sign-in for this provider (Cursor or Codex — OAuth on the
+   *  user's own subscription). No-op for providers without an in-app sign-in. */
   onSignIn: () => Promise<InstallOutcome>
   onTest: () => void
   /** Commit this provider as the default. Rejects if the write failed (Settings save). */
@@ -245,7 +246,16 @@ function ConnectionBody({ phase, name, providerId, installHint, installMsg, sign
   onInstall: () => void; onSignIn: () => void; onTest: () => void
 }) {
   const mono = { fontSize: 11, lineHeight: 1.5, color: 'var(--t-key-text)', background: 'var(--t-key-bg)', borderRadius: 6, padding: '6px 9px' } as const
-  const isCursor = providerId === 'cursor'
+  // Providers whose CLI authenticates against the user's OWN subscription via a browser OAuth
+  // that Meridian can drive in-app (a "Sign in to …" button → the `*_sign_in` tray command).
+  // `account`/`subscription` fill the copy; `cmd` is the terminal fallback. `null` for
+  // providers with no in-app sign-in (e.g. Claude/Copilot, or a cloud endpoint).
+  const signInProvider =
+    providerId === 'cursor'
+      ? { label: 'Sign in to Cursor', account: 'Cursor', subscription: 'Cursor subscription', cmd: 'cursor-agent login' }
+      : providerId === 'codex'
+        ? { label: 'Sign in to Codex', account: 'ChatGPT', subscription: 'ChatGPT subscription', cmd: 'codex login' }
+        : null
 
   switch (phase.kind) {
     case 'installing':
@@ -263,7 +273,7 @@ function ConnectionBody({ phase, name, providerId, installHint, installMsg, sign
         <div className="flex items-start" style={{ gap: 9 }}>
           <Spinner />
           <p style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--t-title)' }}>
-            Opening your browser… finish signing in to Cursor, then this updates on its own.
+            Opening your browser… finish signing in to {signInProvider?.account ?? name}, then this updates on its own.
           </p>
         </div>
       )
@@ -341,17 +351,17 @@ function ConnectionBody({ phase, name, providerId, installHint, installMsg, sign
       )
 
     case 'failed':
-      // Cursor's "failure" is almost always just "not signed in yet" - a one-time OAuth on the
-      // user's own Cursor subscription (no API key). Offer it as a one-click browser sign-in,
-      // with the terminal command as a fallback.
-      if (isCursor) {
+      // For providers that sign into the user's own subscription (Cursor, Codex), a "failure"
+      // is almost always just "not signed in yet" - a one-time browser OAuth (no API key).
+      // Offer it as a one-click in-app sign-in, with the terminal command as a fallback.
+      if (signInProvider) {
         return (
           <div className="flex flex-col" style={{ gap: 10 }}>
             <div className="flex items-start" style={{ gap: 9 }}>
               <Dot color="var(--color-state-pending)" />
               <p style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--t-title)' }}>
-                {name} is installed but not signed in yet. Sign in with your Cursor account and it
-                runs on your Cursor subscription - no API key.
+                {name} is installed but not signed in yet. Sign in with your {signInProvider.account} account
+                and it runs on your {signInProvider.subscription} - no API key.
               </p>
             </div>
             <button onClick={onSignIn} className="self-start"
@@ -359,11 +369,11 @@ function ConnectionBody({ phase, name, providerId, installHint, installMsg, sign
                 fontSize: 12.5, fontWeight: 600, padding: '8px 15px', borderRadius: 9, border: 'none',
                 background: 'var(--btn-primary-bg)', color: '#fff', cursor: 'pointer',
               }}>
-              Sign in to Cursor
+              {signInProvider.label}
             </button>
             <p style={{ fontSize: 10.5, lineHeight: 1.5, color: 'var(--t-faint)' }}>
               Opens your browser to finish the sign-in. Prefer the terminal? Run{' '}
-              <code style={{ fontFamily: 'var(--font-mono, ui-monospace)' }}>cursor-agent login</code>, then Test again.
+              <code style={{ fontFamily: 'var(--font-mono, ui-monospace)' }}>{signInProvider.cmd}</code>, then Test again.
             </p>
             {signInMsg && (
               <p style={{ fontSize: 11.5, lineHeight: 1.5, color: 'var(--status-error-dot)' }}>

--- a/ui/components/LlmProviderPicker.tsx
+++ b/ui/components/LlmProviderPicker.tsx
@@ -113,10 +113,21 @@ export function useLlmProviderDetection() {
    *  (`claude_sign_in`). Each tray command drives that vendor's `… login` and opens the browser;
    *  none takes a provider argument, so the id picks the command here. */
   const signIn = useCallback(async (id: string): Promise<InstallOutcome> => {
+    // Explicit per-provider mapping - do NOT fall back to a default command. A missing entry
+    // means a provider was given an in-app sign-in button (its `signInProvider` descriptor in
+    // LlmProviderDetail) without a matching tray command here; fail loudly rather than silently
+    // running the wrong vendor's login (e.g. Cursor's) for it.
+    const SIGN_IN_COMMANDS: Record<string, string> = {
+      cursor: 'cursor_sign_in',
+      codex: 'codex_sign_in',
+      claude: 'claude_sign_in',
+    }
+    const command = SIGN_IN_COMMANDS[id]
+    if (!command) {
+      return { ok: false, message: `No in-app sign-in is wired up for "${id}".`, path: null, command: '' }
+    }
     setSigningIds((prev) => new Set(prev).add(id))
     try {
-      const command =
-        id === 'codex' ? 'codex_sign_in' : id === 'claude' ? 'claude_sign_in' : 'cursor_sign_in'
       const outcome = await invoke<InstallOutcome>(command)
       if (outcome.ok) {
         // `cursor-agent login` exits 0 only AFTER the browser OAuth completes, so this is the

--- a/ui/components/LlmProviderPicker.tsx
+++ b/ui/components/LlmProviderPicker.tsx
@@ -109,13 +109,14 @@ export function useLlmProviderDetection() {
   }, [detect, testOne])
 
   /** Run an interactive browser sign-in for a provider whose CLI authenticates against the
-   *  user's own subscription - Cursor (`cursor_sign_in`) or Codex (`codex_sign_in`). Each tray
-   *  command drives that vendor's `… login` and opens the browser; neither takes a provider
-   *  argument, so the id picks the command here. */
+   *  user's own subscription - Cursor (`cursor_sign_in`), Codex (`codex_sign_in`), or Claude
+   *  (`claude_sign_in`). Each tray command drives that vendor's `… login` and opens the browser;
+   *  none takes a provider argument, so the id picks the command here. */
   const signIn = useCallback(async (id: string): Promise<InstallOutcome> => {
     setSigningIds((prev) => new Set(prev).add(id))
     try {
-      const command = id === 'codex' ? 'codex_sign_in' : 'cursor_sign_in'
+      const command =
+        id === 'codex' ? 'codex_sign_in' : id === 'claude' ? 'claude_sign_in' : 'cursor_sign_in'
       const outcome = await invoke<InstallOutcome>(command)
       if (outcome.ok) {
         // `cursor-agent login` exits 0 only AFTER the browser OAuth completes, so this is the

--- a/ui/components/LlmProviderPicker.tsx
+++ b/ui/components/LlmProviderPicker.tsx
@@ -108,12 +108,15 @@ export function useLlmProviderDetection() {
     }
   }, [detect, testOne])
 
-  /** Run the interactive Cursor sign-in (browser OAuth on the user's own subscription).
-   *  Cursor-only - the tray command takes no provider. */
+  /** Run an interactive browser sign-in for a provider whose CLI authenticates against the
+   *  user's own subscription - Cursor (`cursor_sign_in`) or Codex (`codex_sign_in`). Each tray
+   *  command drives that vendor's `… login` and opens the browser; neither takes a provider
+   *  argument, so the id picks the command here. */
   const signIn = useCallback(async (id: string): Promise<InstallOutcome> => {
     setSigningIds((prev) => new Set(prev).add(id))
     try {
-      const outcome = await invoke<InstallOutcome>('cursor_sign_in')
+      const command = id === 'codex' ? 'codex_sign_in' : 'cursor_sign_in'
+      const outcome = await invoke<InstallOutcome>(command)
       if (outcome.ok) {
         // `cursor-agent login` exits 0 only AFTER the browser OAuth completes, so this is the
         // exact moment the user finished signing in. Flip the panel to "connected" NOW rather


### PR DESCRIPTION
## Summary

Improvements to LLM-provider management on the Intelligence tab: more honest install/sign-in detection, **in-app browser sign-in for all three CLI providers (Cursor, Codex, and Claude)**, and dashboard surfacing when the in-use provider is unavailable or rate-limited.

## Commits

1. **fix(llm): re-validate `resolve_cli` cache hits with `exists()`** — a CLI uninstalled/moved while the tray runs was reported "installed" forever (process-lifetime cache never revalidated), then failed with a raw OS/shell error on the next invocation. Now revalidates a cache hit with a cheap `Path::exists()` and evicts on a miss.
2. **fix(llm): scope the `resolve_cli` cache read to avoid a re-lock deadlock** — the revalidation initially held the `RESOLVED_BINS` mutex guard across the `if let` body, so the eviction re-lock deadlocked on the same thread. Caught by the pre-push `cargo test`; scoped the read so the guard drops first.
3. **feat(llm): in-app Codex browser sign-in** — one-click "Sign in to Codex" button (`codex login`), mirroring Cursor.
4. **feat(health): dashboard banner when the in-use provider is unavailable** — warns when the selected provider's CLI is missing or its last test failed (hourly summaries paused).
5. **feat(health): soft rate-limit notice, distinct from the unavailable alarm** — a rate-limited provider gets a softer "catching up" notice, since it self-recovers.
6. **test(llm): update connection-phase assertions for the `signInProvider` generalization.**
7. **feat(llm): in-app Claude sign-in (parity with Cursor and Codex)** — "Sign in to Claude" button driving `claude auth login --claudeai` (browser OAuth against the user's Anthropic account, on their Claude subscription). Brings Claude to full parity: install, in-app sign-in, availability banner, and bespoke failure handling.
8. **fix(review): probe cadence + banner dismissal + sign-in mapping** — see the review responses below: TTL-cache the provider-health probe so it isn't re-run every 60s tick; per-alert banner dismissal so dismissing one banner can't suppress a later, worse one; explicit `{cursor,codex,claude}` sign-in mapping that fails loudly instead of defaulting to Cursor.

## Scope note

The in-app sign-in is added for **all three** subscription CLIs — Cursor, Codex, **and Claude** (`claude_sign_in` / "Sign in to Claude"). An earlier revision of this description under-stated the Claude piece; it is included and called out here.

## Testing

- **Cursor and Codex:** verified live on Windows end-to-end (install → sign-in → test), including the availability banner firing on a live uninstall and clearing after reinstall/sign-in.
- **Claude:** `claude auth login --claudeai` is confirmed a real invocation against an installed Claude Code CLI (`auth login`/`logout`/`status` are real subcommands; `--claudeai` is the documented default). The code path is a deliberate line-for-line mirror of the live-verified Cursor/Codex flow, compiles, and passes tests. A live end-to-end browser sign-in **for Claude specifically** is still pending — the OAuth completion needs a human at the browser — and I'm happy to drive that pass before merge.
- **Automated:** `resolve_cli` staleness/deadlock tests, the new `classify_provider_health` ladder test, and the full 755-test lib suite pass. All pre-push waves green (`cargo fmt`, `cargo clippy`, ui build, ui tests, `cargo test`, security audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
