### PR TITLE
fix(ui): fetch the daily plan for solo users too

### DIFF
--- a/ui/components/timeline/OverviewPanel.tsx
+++ b/ui/components/timeline/OverviewPanel.tsx
@@ -107,13 +107,16 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
   // plan_date), so viewing a past date shows THAT day's committed focus and
   // correctly ignores edits to today's plan — and a day with nothing fetched
   // reads EMPTY, so a day switch never flashes the previous day's items.
+  // Fetched for every user, including solo/no-tracker — the empty-TODAY nudge
+  // below is meant to show for them too (PlanView's composer supports a
+  // personal, tracker-free task), and gating the fetch on `isSolo` left it
+  // permanently null for them, so the nudge never rendered.
   const { data: plan } = usePlan(day)
   useEffect(() => {
-    if (isSolo) return
     refreshPlan(day)
     const id = setInterval(() => refreshPlan(day), 30_000)
     return () => clearInterval(id)
-  }, [isSolo, day])
+  }, [day])
   const focusItems = useMemo(() => (plan?.confirmed ? plan.plan : []), [plan])
 
   // Toggle a focus item's done state. This goes through `set_plan_task_done`,


### PR DESCRIPTION
## Summary
- Solo (no PM tracker) users never saw the \"Today's focus\" empty-state nudge (\"Add a few tasks so Meridian can help you stay on track\") on the dashboard, even though it's meant to show for every user.
- Root cause: `OverviewPanel`'s plan-fetch effect had `if (isSolo) return`, so `plan` never got fetched for solo users, and the render gate requires `plan` to be truthy before showing the empty-state nudge.
- Fix: fetch the plan unconditionally; the populated-checklist/edit-plan UI still correctly stays gated behind `!isSolo` in the render logic — only the fetch itself was wrongly gated.

This explains reports of the "Today's focus" card missing after a fresh install of the latest macOS binary — anyone who hasn't connected a tracker yet (the default state right after install) was affected.

## Test plan
- [x] `cd ui && npm run build` — succeeds
- [x] `cd ui && bun test` — 381 pass, 0 fail
- [x] `cargo fmt --check` / `cargo clippy` / `cargo test` via pre-push hook — all pass