### PR TITLE
feat(observability): ship platform attributes and surface the Support ID

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,6 +367,30 @@ supported way to read logs locally, replacing the old JSONL-tailing UI and the
 old bash `meridian logs` (which used to tail launchd-redirected stdout/stderr
 text).
 
+**Two couplings that silently delete error coverage.** Both have bitten once;
+neither fails loudly, and neither is visible from the call site.
+
+1. **The `EnvFilter` decides what is captured at all — before the spool, before
+   severity, before redaction.** `EnvFilter` matches directives against targets
+   by string **prefix**, so the `meridian` directive covers `meridian_core::*`,
+   `meridian_tray_lib::*` and `meridian_oauth::*` for free — but nothing else.
+   Any crate whose target does not start with `meridian` is discarded entirely
+   unless named in `build_default_filter`. That is why `CAPTURE_DIRECTIVES`
+   exists (`screenpipe_screen`/`screenpipe_a11y` — the OCR + accessibility
+   stack, ~48 error sites that were invisible). **Adding a dependency that does
+   real work means adding its target there**, and auditing its `warn!`/`error!`
+   bodies first: third-party crates were written to print to a terminal and may
+   interpolate content that must never egress.
+2. **The attribute allowlist is keyed on the names you actually type.**
+   `tracing::warn!(error = %e, …)` emits the attribute key `error`, not the
+   semconv `error.message`. Anything not on `redact::SAFE_STRING_KEYS` is
+   dropped from the ship leg, so a well-instrumented error can arrive as a bare
+   static string with its cause stripped. When adding a field to a WARN/ERROR
+   site that you would need in order to debug it remotely, check it is on that
+   list — and if it names the user's data (ticket key, file path, app name,
+   window title, hour/day) it must stay off, so put the diagnostic value in the
+   message or an allowlisted key instead.
+
 The only thing this pipeline structurally can't capture is a hard crash
 (panic before `init` runs, segfault, OOM kill) — for that, launchd's own
 stdout/stderr redirect (`~/.meridian/logs/<service>.log` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,13 +400,34 @@ spans egress at all, and `host.name` is replaced by a stable **pseudonym**
 macOS is routinely the account holder's real name. The tray's Sentry
 `before_send` applies the identical pseudonym to `event.server_name`.
 
+That pseudonym is the ONLY identifier on an error row — nothing associates it
+with an account, and the hash is one-way. So it is surfaced to the user as
+**Support ID** (Settings → Account, and `bundle-info.txt` inside an export
+bundle), which is what makes a support ticket traceable to its error rows at
+all. Both the displayed value and the shipped one come from
+`redact::local_host_pseudonym` **on purpose** — computing either side
+separately would let them drift, and the user would quote an ID matching
+nothing, silently (`displayed_pseudonym_matches_shipped` pins this).
+
+**Which resource attributes actually ship** is a separate question from the
+allowlist, and the two are easy to confuse: `redact::SAFE_STRING_KEYS` lists
+many keys that nothing populates (`service.instance.id`, `os.version`,
+`app.version`, …). `observability::init`'s `Resource::new` sets exactly:
+`service.name`, `service.version`, `host.name`, `deployment.environment`,
+`os.type`, `host.arch`, `app.install_mode` — and `Resource::new` runs NO
+detectors, so the SDK contributes nothing either. **Allowlisted ≠ present:
+before relying on an attribute in a query or dashboard, check it is set here.**
+
 **Export Diagnostics remains the manual path**, unchanged and independent of
 consent: tray Settings → Account → **Export Diagnostics** (or `meridian
 telemetry export`) bundles the spool + the launchd crash-safety-net logs into
 a `.tar.gz` the user hands to support, imported by hand with `meridian
-telemetry import <bundle> --endpoint <url> --auth <base64>`. Retention
-(default 7 days, `MERIDIAN_TELEMETRY_RETENTION_DAYS`) applies to both
-`pending/` and `sent/`, regardless of shipping status.
+telemetry import <bundle> --endpoint <url> --auth <base64>`. The bundle also
+carries a synthesized `bundle-info.txt` (Support ID, version, channel, os,
+arch) so a hand-delivered archive can be joined to that machine's already-
+ingested rows; it deliberately contains nothing the automatic ship leg wouldn't
+already send. Retention (default 7 days, `MERIDIAN_TELEMETRY_RETENTION_DAYS`)
+applies to both `pending/` and `sent/`, regardless of shipping status.
 
 - **Rust**: `tracing::info!/warn!/error!/debug!` with **structured fields** — never format data values into the message string (already enforced).
 - **Wrap discrete operations in spans** (`tracing::info_span!` / `debug_span!`) and put the meaningful inputs, outputs, and metrics as **span attributes**, not buried in log lines. For an LLM/model call, capture the EXACT input as sent and output as received (post-cap/post-template — reflect any truncation that actually happened), plus real token counts/latency. See `src/llm/resolver.rs`'s `llm.call` span tree (request → infer → response) and `src/worklog_pipeline/distiller`'s `distil.run` span for the reference shape.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,11 +412,14 @@ nothing, silently (`displayed_pseudonym_matches_shipped` pins this).
 **Which resource attributes actually ship** is a separate question from the
 allowlist, and the two are easy to confuse: `redact::SAFE_STRING_KEYS` lists
 many keys that nothing populates (`service.instance.id`, `os.version`,
-`app.version`, …). `observability::init`'s `Resource::new` sets exactly:
-`service.name`, `service.version`, `host.name`, `deployment.environment`,
-`os.type`, `host.arch`, `app.install_mode` — and `Resource::new` runs NO
+`app.version`, `app.install_mode`, …). `observability::init`'s `Resource::new`
+sets exactly: `service.name`, `service.version`, `host.name`,
+`deployment.environment`, `os.type`, `host.arch` — and `Resource::new` runs NO
 detectors, so the SDK contributes nothing either. **Allowlisted ≠ present:
 before relying on an attribute in a query or dashboard, check it is set here.**
+Note `observability::init` runs in BOTH the daemon and the tray, so any
+attribute added there must be correct for both — `app.install_mode` is
+deliberately left unset for exactly this reason (see the comment there).
 
 **Export Diagnostics remains the manual path**, unchanged and independent of
 consent: tray Settings → Account → **Export Diagnostics** (or `meridian

--- a/src/observability/install_mode.rs
+++ b/src/observability/install_mode.rs
@@ -44,11 +44,28 @@ pub(super) fn is_canonical_install() -> bool {
         return false;
     };
     match std::env::current_exe() {
-        Ok(exe) => exe == meridian_dir.join("bin").join("meridian"),
+        Ok(exe) => exe == meridian_dir.join("bin").join(staged_daemon_file_name()),
         // `current_exe()` failing is rare (permissions, exotic sandboxing) —
         // fall back to the machine-wide marker file rather than guessing.
         Err(_) => meridian_dir.join(".env").exists(),
     }
+}
+
+/// File name the tray stages the daemon under in `~/.meridian/bin/`.
+///
+/// **Must** track `backend_install::DAEMON_FILE` in the tray crate, which is
+/// `meridian.exe` on Windows and `meridian` elsewhere. This was hardcoded to
+/// `"meridian"`, so on Windows the comparison above could never match a real
+/// packaged install: `current_exe()` ends in `.exe`, so `is_canonical_install()`
+/// returned false, `resolve_otlp_target()` fell through to the DEV branch, and
+/// that branch requires `otlp_enabled` + local OpenObserve credentials which a
+/// packaged install never has. Net effect: central error reporting was silently
+/// inert on every Windows install, with no warning on either side.
+///
+/// Derived from `EXE_SUFFIX` rather than a `cfg`-selected constant so it cannot
+/// drift again if another platform is added.
+fn staged_daemon_file_name() -> String {
+    format!("meridian{}", std::env::consts::EXE_SUFFIX)
 }
 
 /// Hard kill switch for OTel capture (spans/logs to the local spool), read from
@@ -56,4 +73,29 @@ pub(super) fn is_canonical_install() -> bool {
 pub(super) fn capture_disabled() -> bool {
     std::env::var("MERIDIAN_TELEMETRY_DISABLED")
         .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The daemon and the tray agree on the staged file name only by
+    /// convention — they are separate crates with no shared constant, and a
+    /// mismatch disables central error reporting on that platform silently
+    /// (nothing errors; the shipper simply resolves no target). Pins the name
+    /// to the platform's executable suffix on whichever OS the suite runs.
+    #[test]
+    fn staged_daemon_file_name_carries_the_platform_exe_suffix() {
+        let name = staged_daemon_file_name();
+        assert!(name.starts_with("meridian"), "unexpected stem: {name}");
+        assert!(
+            name.ends_with(std::env::consts::EXE_SUFFIX),
+            "{name} lacks this platform's executable suffix"
+        );
+        if cfg!(target_os = "windows") {
+            assert_eq!(name, "meridian.exe");
+        } else {
+            assert_eq!(name, "meridian");
+        }
+    }
 }

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -389,21 +389,57 @@ fn try_build_otel_providers(
     Ok(Some((tracer, tracer_provider, logger_provider)))
 }
 
+/// Capture-stack directives, appended to every filter built below.
+///
+/// # Why these need naming explicitly
+/// `EnvFilter` matches a directive against a target by string prefix, so the
+/// `meridian` directive happens to cover `meridian_core::*`,
+/// `meridian_tray_lib::*` and `meridian_oauth::*` too — every first-party
+/// target starts with those bytes. The in-process capture crates do NOT
+/// (`screenpipe_screen::*`, `screenpipe_a11y::*`), so every one of their ~48
+/// `warn!`/`error!` sites was discarded **at the subscriber**, before the
+/// spool, before the severity filter, before redaction. OCR and accessibility
+/// failures — screen-capture bail-outs, Apple Vision handler creation,
+/// `AXObserver`/`CGEventTap` registration, monitor enumeration — were
+/// structurally invisible: not shipped, not in `meridian logs`, not in an
+/// export bundle. Since capture is the daemon's only data source, a silent
+/// failure there looks downstream like "the user did nothing today".
+///
+/// # Why `warn` and not `debug`
+/// These are third-party crates written for a CLI that printed to a terminal;
+/// their INFO/DEBUG volume is unaudited and runs at frame cadence. `warn`
+/// takes the failures without the chatter.
+///
+/// # Privacy
+/// Audited every `warn!`/`error!` site in both crates before enabling: all are
+/// infrastructure failures (monitor ids, image dimensions, word counts, error
+/// `Display`s). None interpolates a window title, app name, URL, or OCR text.
+/// Re-audit if the fork's revision is bumped — this is exactly the class of
+/// change that could start shipping captured content.
+const CAPTURE_DIRECTIVES: &str = "screenpipe_screen=warn,screenpipe_a11y=warn";
+
 /// Map the settings.json `log_level` value (DEBUG/INFO/WARNING/ERROR) to a
 /// tracing `EnvFilter` string. Used at startup and on hot-reload, when
 /// `RUST_LOG` is not set.
+///
+/// Note `RUST_LOG` REPLACES this wholesale rather than extending it, so an
+/// engineer who sets it also opts out of [`CAPTURE_DIRECTIVES`] and must
+/// re-add them by hand to see capture failures.
 fn build_default_filter(log_level: &str) -> String {
-    match log_level.to_uppercase().as_str() {
-        "DEBUG" => "meridian=debug,sqlx=warn".to_string(),
-        "WARNING" | "WARN" => "meridian=warn,sqlx=warn".to_string(),
-        "ERROR" => "meridian=error,sqlx=error".to_string(),
+    let base = match log_level.to_uppercase().as_str() {
+        "DEBUG" => "meridian=debug,sqlx=warn",
+        "WARNING" | "WARN" => "meridian=warn,sqlx=warn",
+        // At ERROR the user has asked for errors only; honour that for the
+        // capture stack too rather than forcing its warnings through.
+        "ERROR" => return "meridian=error,sqlx=error,screenpipe_screen=error,screenpipe_a11y=error".to_string(),
         // INFO or anything else: keep the previous fixed default with module-level overrides.
         // `embedder=debug` surfaces the model-load/batch spans (embedder/mod.rs) at the
         // production default — the same treatment etl/intelligence already get — since
         // the embedder is on the critical path for every hour's distillation and its
         // timing is exactly what a `DISTILLER_EMBED_TIMEOUT_SECS` investigation needs.
-        _ => "meridian=info,meridian::etl=debug,meridian::intelligence=debug,meridian::embedder=debug,sqlx=warn".to_string(),
-    }
+        _ => "meridian=info,meridian::etl=debug,meridian::intelligence=debug,meridian::embedder=debug,sqlx=warn",
+    };
+    format!("{base},{CAPTURE_DIRECTIVES}")
 }
 
 /// Hot-reload the log level filter without restarting the daemon.
@@ -488,4 +524,99 @@ pub fn span_context_from_traceparent(
     let cx = TraceContextPropagator::new().extract(&StringExtractor(traceparent));
     let sc = cx.span().span_context().clone();
     sc.is_valid().then_some(sc)
+}
+
+#[cfg(test)]
+mod filter_tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::Layer;
+
+    /// Records the target of every event the filter lets through.
+    struct Recorder(Arc<Mutex<Vec<String>>>);
+
+    impl<S: tracing::Subscriber> Layer<S> for Recorder {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            self.0
+                .lock()
+                .unwrap()
+                .push(event.metadata().target().to_string());
+        }
+    }
+
+    /// Run `f` under `filter` and return the targets that survived.
+    fn targets_passing(filter: &str, f: impl FnOnce()) -> Vec<String> {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::new(filter))
+            .with(Recorder(Arc::clone(&seen)));
+        tracing::subscriber::with_default(subscriber, f);
+        let out = seen.lock().unwrap().clone();
+        out
+    }
+
+    fn emit_all() {
+        tracing::warn!(target: "screenpipe_screen::core", "ocr failed");
+        tracing::warn!(target: "screenpipe_a11y::observer", "axobserver failed");
+        tracing::info!(target: "meridian::etl::runner", "etl ok");
+        tracing::info!(target: "meridian_core::readers::tasks", "read ok");
+        tracing::info!(target: "meridian_tray_lib::commands::health", "health ok");
+        tracing::warn!(target: "reqwest::connect", "noisy third party");
+    }
+
+    /// The bug this guards: `EnvFilter` matches directives against targets by
+    /// string PREFIX, so `meridian` silently covers `meridian_core` and
+    /// `meridian_tray_lib` — but nothing covered `screenpipe_*`, so every OCR
+    /// and accessibility failure was dropped at the subscriber. Asserts the
+    /// negative on the old filter and the positive on the new one, since the
+    /// whole finding rests on that asymmetry.
+    #[test]
+    fn capture_targets_pass_only_with_the_capture_directives() {
+        let old = "meridian=info,sqlx=warn";
+        let passed = targets_passing(old, emit_all);
+        assert!(
+            !passed.iter().any(|t| t.starts_with("screenpipe")),
+            "regression check is meaningless if the old filter already passed capture: {passed:?}"
+        );
+        // ...while first-party targets DID pass on prefix alone.
+        assert!(passed.iter().any(|t| t.starts_with("meridian_core")));
+        assert!(passed.iter().any(|t| t.starts_with("meridian_tray_lib")));
+
+        let passed = targets_passing(&build_default_filter("INFO"), emit_all);
+        assert!(
+            passed.iter().any(|t| t == "screenpipe_screen::core"),
+            "OCR failures still dropped at the subscriber: {passed:?}"
+        );
+        assert!(
+            passed.iter().any(|t| t == "screenpipe_a11y::observer"),
+            "accessibility failures still dropped at the subscriber: {passed:?}"
+        );
+        // Unrelated third-party crates must stay out — this widens the filter
+        // deliberately and narrowly, not globally.
+        assert!(
+            !passed.iter().any(|t| t.starts_with("reqwest")),
+            "filter widened beyond the capture stack: {passed:?}"
+        );
+    }
+
+    /// Capture failures must survive every log level a user can select, or the
+    /// coverage depends on a setting nobody associates with capture.
+    #[test]
+    fn capture_directives_present_at_every_log_level() {
+        for level in ["DEBUG", "INFO", "WARNING", "ERROR", "nonsense"] {
+            let f = build_default_filter(level);
+            assert!(
+                f.contains("screenpipe_screen") && f.contains("screenpipe_a11y"),
+                "{level} filter drops the capture stack: {f}"
+            );
+            let passed = targets_passing(&f, || {
+                tracing::error!(target: "screenpipe_screen::core", "hard failure");
+            });
+            assert_eq!(passed.len(), 1, "{level} dropped a capture ERROR: {f}");
+        }
+    }
 }

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -316,6 +316,33 @@ fn try_build_otel_providers(
             "deployment.environment",
             option_env!("MERIDIAN_CHANNEL").unwrap_or("dev"),
         ),
+        // Platform shape. Without these, a Windows error and a macOS error are
+        // indistinguishable in the central backend — every attribute above is
+        // OS-agnostic, and the SDK adds nothing of its own (`Resource::new`
+        // runs no detectors, unlike `Resource::default`). All three are already
+        // on `redact::SAFE_STRING_KEYS`, so populating them needs no change to
+        // the redaction boundary: they are enum-like build facts that
+        // structurally cannot carry user content.
+        //
+        // Deliberately the RAW Rust constants ("macos"/"windows", "aarch64"/
+        // "x86_64") rather than the OTel semconv spellings ("darwin", "arm64").
+        // Nothing downstream parses these as semconv enums, and a translation
+        // layer is one more place to introduce a silent mismatch between what
+        // the code says and what the dashboards filter on.
+        KeyValue::new("os.type", std::env::consts::OS),
+        KeyValue::new("host.arch", std::env::consts::ARCH),
+        // Separates errors from a real packaged install from a developer's
+        // `cargo run`, which otherwise differ only by `deployment.environment`
+        // — and that reports "dev" for BOTH a source build and any build whose
+        // channel env was unset, so it can't carry this distinction alone.
+        KeyValue::new(
+            "app.install_mode",
+            if install_mode::is_canonical_install() {
+                "packaged"
+            } else {
+                "source"
+            },
+        ),
     ]);
 
     // Build spool clients — one per signal so filenames encode the correct prefix.

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -331,18 +331,17 @@ fn try_build_otel_providers(
         // the code says and what the dashboards filter on.
         KeyValue::new("os.type", std::env::consts::OS),
         KeyValue::new("host.arch", std::env::consts::ARCH),
-        // Separates errors from a real packaged install from a developer's
-        // `cargo run`, which otherwise differ only by `deployment.environment`
-        // — and that reports "dev" for BOTH a source build and any build whose
-        // channel env was unset, so it can't carry this distinction alone.
-        KeyValue::new(
-            "app.install_mode",
-            if install_mode::is_canonical_install() {
-                "packaged"
-            } else {
-                "source"
-            },
-        ),
+        // NOT setting `app.install_mode` here, deliberately — it is on
+        // `redact::SAFE_STRING_KEYS` and looks tempting. The only available
+        // signal is `is_canonical_install()`, which compares `current_exe()`
+        // against `~/.meridian/bin/meridian`. That is a DAEMON-shaped test, and
+        // this function also runs in the tray (`lib.rs` calls
+        // `observability::init("meridian-tray")` unconditionally), whose exe
+        // lives in the `.app` bundle — so every tray row on a fully packaged
+        // install would be labelled "source". A wrong platform attribute is
+        // worse than an absent one; it gets trusted in a dashboard filter.
+        // `deployment.environment` already separates source builds ("dev") from
+        // released ones, which is the distinction that was actually wanted.
     ]);
 
     // Build spool clients — one per signal so filenames encode the correct prefix.

--- a/src/telemetry_spool/mod.rs
+++ b/src/telemetry_spool/mod.rs
@@ -103,9 +103,62 @@ pub fn build_export_bundle(
             .with_context(|| format!("add {} to archive", file_path.display()))?;
     }
 
+    append_bundle_info(&mut tar).context("add bundle-info.txt to archive")?;
+
     tar.finish().context("finish tar archive")?;
 
     Ok((out_path, file_count))
+}
+
+/// Write a synthesized `bundle-info.txt` into the archive: which machine,
+/// build, and platform produced it.
+///
+/// Without this, a support bundle is a pile of opaque `.otlp` files and the
+/// recipient has to guess. The `machine` line is the same pseudonym that
+/// appears as `host.name` in the central backend
+/// ([`redact::local_host_pseudonym`]), which is the point: it joins a
+/// hand-delivered bundle to that machine's already-ingested error rows.
+///
+/// Deliberately carries NOTHING that isn't already allowed to leave the
+/// machine over the automatic ship leg - no raw hostname, no account email, no
+/// paths. A user handing over a bundle should not be disclosing more than the
+/// consent copy describes.
+///
+/// Not counted in the returned `file_count`, which reports telemetry files
+/// collected - a synthetic header would make that number mean two things.
+fn append_bundle_info<W: std::io::Write>(tar: &mut tar::Builder<W>) -> Result<()> {
+    let body = format!(
+        "machine: {}\n\
+         version: {}\n\
+         channel: {}\n\
+         os: {}\n\
+         arch: {}\n\
+         generated_unix_micros: {}\n",
+        redact::local_host_pseudonym(),
+        env!("CARGO_PKG_VERSION"),
+        option_env!("MERIDIAN_CHANNEL").unwrap_or("dev"),
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64,
+    );
+
+    let mut header = tar::Header::new_gnu();
+    header.set_size(body.len() as u64);
+    header.set_mode(0o644);
+    header.set_mtime(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    );
+    header.set_cksum();
+
+    tar.append_data(&mut header, "bundle-info.txt", body.as_bytes())
+        .context("append bundle-info.txt")?;
+    Ok(())
 }
 
 /// Strip a `/v1/traces` or `/v1/logs` suffix to recover the OO base URL.
@@ -234,6 +287,50 @@ mod tests {
         // 1 otlp file + daemon.log (a known launchd log name) — the unrelated
         // .txt file must NOT be swept in.
         assert_eq!(count, 2);
+    }
+
+    /// The bundle must carry the machine pseudonym (so support can join it to
+    /// already-ingested error rows) and must NOT carry the raw hostname —
+    /// handing over a bundle should disclose no more than the automatic ship
+    /// leg already does.
+    #[test]
+    fn build_export_bundle_includes_uncounted_bundle_info() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+        std::env::set_var("MERIDIAN_TELEMETRY_DIR", dir.path());
+
+        writer::write_pending(dir.path(), "traces", b"a").unwrap();
+
+        let out = dir.path().join("bundle.tar.gz");
+        let (_, count) = build_export_bundle(Some(&out), None, false).unwrap();
+
+        std::env::remove_var("MERIDIAN_TELEMETRY_DIR");
+
+        // The synthetic header is not counted as a telemetry file.
+        assert_eq!(count, 1);
+
+        let gz = flate2::read::GzDecoder::new(std::fs::File::open(&out).unwrap());
+        let mut archive = tar::Archive::new(gz);
+        let mut info = None;
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            if entry.path().unwrap().to_string_lossy() == "bundle-info.txt" {
+                let mut s = String::new();
+                std::io::Read::read_to_string(&mut entry, &mut s).unwrap();
+                info = Some(s);
+            }
+        }
+
+        let info = info.expect("bundle-info.txt missing from archive");
+        assert!(
+            info.contains(&redact::local_host_pseudonym()),
+            "pseudonym missing, support cannot join this bundle: {info}"
+        );
+        let raw_host = gethostname::gethostname().to_string_lossy().into_owned();
+        assert!(
+            !info.contains(&raw_host),
+            "raw hostname leaked into the bundle: {info}"
+        );
     }
 
     #[test]

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -999,6 +999,34 @@ mod tests {
         assert_ne!(out, pseudonymize_host("someone-elses-imac.local"));
     }
 
+    /// Every other free-text case here is Unix-shaped, but Windows installs
+    /// ship through the identical scrubber. Two things differ there: the
+    /// username sits under `C:\Users\<name>`, and `\` is absent from the blob
+    /// character class (so backslash-separated paths can't reach the 32-char
+    /// blob threshold the way `/`-separated ones do).
+    #[test]
+    fn windows_paths_are_scrubbed_but_not_mangled() {
+        let msg = r"failed to open C:\Users\akarsh\AppData\Roaming\Meridian\settings.json";
+        let out = scrub_text(msg);
+        assert!(!out.contains("akarsh"), "Windows username leaked: {out}");
+        assert!(out.contains(r"C:\Users\<user>"), "structure lost: {out}");
+        assert!(
+            out.contains("settings.json"),
+            "path mangled by blob rule: {out}"
+        );
+
+        // The light scrub used for allowlisted identifier keys (e.g.
+        // `code.filepath`) must behave the same way.
+        assert!(!scrub_paths(msg).contains("akarsh"));
+
+        // A secret still dies whole even when a Windows path shares the line.
+        let with_secret =
+            r"C:\Users\akarsh\app.log token EXAMPLEKEYNOTAREALSECRETabcdefghijklmnop0123456789";
+        let out = scrub_text(with_secret);
+        assert!(out.contains("<redacted>"), "secret survived: {out}");
+        assert!(!out.contains("akarsh"), "username leaked: {out}");
+    }
+
     /// The support workflow's load-bearing invariant: the pseudonym the tray
     /// shows a user in Settings must equal the one the ship leg writes for
     /// `host.name`, or the ID they quote matches no rows in the backend and

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -113,10 +113,30 @@ const SAFE_STRING_KEYS: &[&str] = &[
     "exception.stacktrace",
     "otel.status_code",
     "otel.status_description",
+    // The bare `error` key, NOT a semconv name — but the one this codebase
+    // actually emits. `tracing::warn!(error = %e, …)` is the convention CLAUDE.md
+    // mandates and 203 of ~419 warn/error sites use it, so while `error.message`
+    // sat on this list, the real error text was dropped from every single
+    // shipped record: the backend received a static message ("summarise attempt
+    // failed") with the cause ("claude timed out after 60s") stripped. Also on
+    // `FREE_TEXT_KEYS` below — an `anyhow` chain splices arbitrary `Display`
+    // output, so it needs the full scrub, not just a path scrub.
+    "error",
+    // Which provider/engine a failure came from. Enum-like values from a fixed
+    // internal set (`claude`, `codex`, `anthropic`, `gemini`, …) — they name
+    // OUR components, never the user's data, and without them an LLM or
+    // summariser failure can't be attributed to a backend at all.
+    "provider",
+    "engine",
     // ── code location (paths scrubbed) ───────────────────────────────────────
     "code.function",
     "code.namespace",
     "code.filepath",
+    // `tracing-opentelemetry` emits this alongside `code.filepath`; it was the
+    // only one of the four missing, so shipped records carried the full path
+    // but not the bare filename. Strictly less sensitive than `code.filepath`,
+    // which is already here.
+    "code.filename",
     "code.lineno",
     "thread.name",
     "target",
@@ -138,6 +158,10 @@ const SAFE_STRING_KEYS: &[&str] = &[
 /// them that a path-only scrub would miss. `status.message` (a span field, not
 /// an attribute) is scrubbed the same way in [`scrub_span_status`].
 const FREE_TEXT_KEYS: &[&str] = &[
+    // See the note on `SAFE_STRING_KEYS`: `error` is the key this codebase
+    // actually emits, and its value is a formatted `anyhow` chain — the single
+    // most likely attribute to carry an interpolated path, URL, or token.
+    "error",
     "error.message",
     "exception.message",
     "exception.stacktrace",
@@ -1025,6 +1049,60 @@ mod tests {
         let out = scrub_text(with_secret);
         assert!(out.contains("<redacted>"), "secret survived: {out}");
         assert!(!out.contains("akarsh"), "username leaked: {out}");
+    }
+
+    /// Modelled on a record decoded from the live staging spool, which shipped
+    /// with its cause stripped:
+    ///
+    /// ```text
+    /// engine = claude | attempt = 2 | error = "claude timed out after 60s"
+    /// ```
+    ///
+    /// `error` is the key the whole codebase emits (CLAUDE.md's convention),
+    /// while only `error.message` was allowlisted — so the diagnostic payload
+    /// was dropped from every shipped record and the backend saw a bare static
+    /// string. Pins that the cause now survives, still scrubbed, and that
+    /// widening stopped where it should: user-data keys stay dropped.
+    #[test]
+    fn error_cause_and_provider_survive_but_user_data_does_not() {
+        let mut kv = str_attr("error", "claude timed out after 60s");
+        assert!(keep_attribute(&mut kv), "error cause was dropped");
+        match kv.value.unwrap().value.unwrap() {
+            Value::StringValue(s) => assert_eq!(s, "claude timed out after 60s"),
+            other => panic!("expected string, got {other:?}"),
+        }
+
+        for (key, value) in [("provider", "anthropic"), ("engine", "claude")] {
+            let mut kv = str_attr(key, value);
+            assert!(keep_attribute(&mut kv), "{key} was dropped");
+        }
+
+        // `error` is FREE TEXT — an anyhow chain routinely splices a path,
+        // URL, or token, so it must get the full scrub, not just a path scrub.
+        let mut kv = str_attr(
+            "error",
+            "post to https://hooks.example.com/T123 failed for akarsh@meridiona.com",
+        );
+        assert!(keep_attribute(&mut kv));
+        let out = match kv.value.unwrap().value.unwrap() {
+            Value::StringValue(s) => s,
+            other => panic!("expected string, got {other:?}"),
+        };
+        assert!(out.contains("<url>") && out.contains("<email>"), "{out}");
+
+        // The boundary did NOT widen to the user's own data. These keys are
+        // emitted at real warn sites and must still be dropped.
+        for key in [
+            "task",
+            "task_key",
+            "file",
+            "path",
+            "app_name",
+            "window_title",
+        ] {
+            let mut kv = str_attr(key, "MER-192");
+            assert!(!keep_attribute(&mut kv), "{key} leaked into the ship leg");
+        }
     }
 
     /// The support workflow's load-bearing invariant: the pseudonym the tray

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -1020,20 +1020,19 @@ mod tests {
         );
     }
 
-    /// `os.type` / `host.arch` / `app.install_mode` are on `SAFE_STRING_KEYS`,
-    /// but being allowlisted is not the same as surviving intact — allowlisted
-    /// strings still pass through `scrub_paths`. Pins that these three reach
-    /// the backend as written, since the whole point of populating them is
-    /// being able to filter errors by platform.
+    /// `os.type` / `host.arch` are on `SAFE_STRING_KEYS`, but being allowlisted
+    /// is not the same as surviving intact — allowlisted strings still pass
+    /// through `scrub_paths`. Pins that both reach the backend as written,
+    /// since the whole point of populating them is being able to filter errors
+    /// by platform.
     #[test]
     fn machine_shape_attributes_survive_verbatim() {
         for (key, value) in [
             ("os.type", "macos"),
             ("os.type", "windows"),
+            ("os.type", "linux"),
             ("host.arch", "aarch64"),
             ("host.arch", "x86_64"),
-            ("app.install_mode", "packaged"),
-            ("app.install_mode", "source"),
         ] {
             let mut kv = str_attr(key, value);
             assert!(keep_attribute(&mut kv), "{key} was dropped");

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -418,6 +418,27 @@ pub fn pseudonymize_host(hostname: &str) -> String {
     })
 }
 
+/// This machine's pseudonym - the exact value that appears as `host.name` in
+/// the central backend for telemetry originating here.
+///
+/// # Why this exists rather than each caller hashing its own hostname
+/// The pseudonym is what a user quotes to support so their error rows can be
+/// found. That only works if the value we SHOW is byte-identical to the value
+/// we SHIP. Those are computed in different crates (the tray renders it in
+/// Settings; the daemon's ship leg writes it via [`keep_attribute`]), so any
+/// divergence in how the hostname is obtained - `to_string_lossy` vs `to_str`,
+/// a trimmed `.local` suffix, case folding - would produce an ID that matches
+/// nothing, and the failure is silent. Funnelling both through this one
+/// function makes that drift impossible; `displayed_pseudonym_matches_shipped`
+/// pins it.
+///
+/// Must therefore read the hostname the same way `observability::init` does
+/// (`gethostname().to_string_lossy()`), since that is the raw value the ship
+/// leg later hashes.
+pub fn local_host_pseudonym() -> String {
+    pseudonymize_host(&gethostname::gethostname().to_string_lossy())
+}
+
 fn is_safe_string_key(key: &str) -> bool {
     SAFE_STRING_KEYS.contains(&key)
 }
@@ -976,5 +997,51 @@ mod tests {
         assert_eq!(out, pseudonymize_host("Akarshs-MacBook-Pro.local"));
         // ...and distinct per machine, or grouping would be meaningless.
         assert_ne!(out, pseudonymize_host("someone-elses-imac.local"));
+    }
+
+    /// The support workflow's load-bearing invariant: the pseudonym the tray
+    /// shows a user in Settings must equal the one the ship leg writes for
+    /// `host.name`, or the ID they quote matches no rows in the backend and
+    /// nothing fails loudly. Guards against the two crates drifting in how the
+    /// hostname is read.
+    #[test]
+    fn displayed_pseudonym_matches_shipped() {
+        let raw = gethostname::gethostname().to_string_lossy().into_owned();
+        let mut kv = str_attr("host.name", &raw);
+        assert!(keep_attribute(&mut kv));
+        let shipped = match kv.value.unwrap().value.unwrap() {
+            Value::StringValue(s) => s,
+            other => panic!("expected string, got {other:?}"),
+        };
+        assert_eq!(
+            local_host_pseudonym(),
+            shipped,
+            "Settings would show a pseudonym that matches nothing in the backend"
+        );
+    }
+
+    /// `os.type` / `host.arch` / `app.install_mode` are on `SAFE_STRING_KEYS`,
+    /// but being allowlisted is not the same as surviving intact — allowlisted
+    /// strings still pass through `scrub_paths`. Pins that these three reach
+    /// the backend as written, since the whole point of populating them is
+    /// being able to filter errors by platform.
+    #[test]
+    fn machine_shape_attributes_survive_verbatim() {
+        for (key, value) in [
+            ("os.type", "macos"),
+            ("os.type", "windows"),
+            ("host.arch", "aarch64"),
+            ("host.arch", "x86_64"),
+            ("app.install_mode", "packaged"),
+            ("app.install_mode", "source"),
+        ] {
+            let mut kv = str_attr(key, value);
+            assert!(keep_attribute(&mut kv), "{key} was dropped");
+            let out = match kv.value.unwrap().value.unwrap() {
+                Value::StringValue(s) => s,
+                other => panic!("expected string, got {other:?}"),
+            };
+            assert_eq!(out, value, "{key} was altered in transit");
+        }
     }
 }

--- a/tray/src-tauri/src/commands/version.rs
+++ b/tray/src-tauri/src/commands/version.rs
@@ -259,25 +259,41 @@ pub(crate) fn build_channel() -> &'static str {
     option_env!("MERIDIAN_CHANNEL").unwrap_or("prod")
 }
 
-/// `{ version, channel }` for the small badge in the dashboard and popover.
+/// `{ version, channel, supportId }` for the small badge in the dashboard and
+/// popover, plus the Account panel's support identifier.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppInfo {
     pub version: String,
     pub channel: String,
+    /// This machine's pseudonym — the exact value error telemetry from here
+    /// carries as `host.name` in the central backend. Shown in Settings so a
+    /// user can quote it when they contact support; without it their error
+    /// rows are unfindable, since pseudonymisation is one-way by design.
+    pub support_id: String,
 }
 
 /// The binary's baked `tauri.conf.json` version (what the DMG updater compares
 /// against — set in lockstep across the repo by `scripts/set-version.sh`) plus
 /// [`build_channel`]. Synchronous and never touches the network, unlike
 /// [`get_version`] above.
+///
+/// `support_id` comes from [`meridian::telemetry_spool::redact::local_host_pseudonym`]
+/// — the SAME function the daemon's ship leg uses, so the displayed value and
+/// the shipped one cannot drift (see that function's doc for why sharing it
+/// matters).
 #[tauri::command]
 #[tracing::instrument(skip(app))]
 pub fn get_app_info(app: tauri::AppHandle) -> AppInfo {
     let version = app.package_info().version.to_string();
     let channel = build_channel().to_string();
-    tracing::info!(%version, %channel, "app info served");
-    AppInfo { version, channel }
+    let support_id = meridian::telemetry_spool::redact::local_host_pseudonym();
+    tracing::info!(%version, %channel, %support_id, "app info served");
+    AppInfo {
+        version,
+        channel,
+        support_id,
+    }
 }
 
 /// DMG auto-update check for the in-app banners (sidebar + popover). Wraps

--- a/ui/components/timeline/settings/AccountSection.tsx
+++ b/ui/components/timeline/settings/AccountSection.tsx
@@ -29,11 +29,26 @@ const CHANNEL_COLOR: Record<AppInfo['channel'], string> = {
 
 export function AccountSection() {
   const [appInfo, setAppInfo] = useState<AppInfo | null>(null)
+  const [copied, setCopied] = useState(false)
   const { status: exportStatus, path: exportPath, errorMsg: exportError, exportBundle } = useExportDiagnostics()
 
   useEffect(() => {
     load<AppInfo>('/api/app-info', 'get_app_info').then(setAppInfo).catch(() => {})
   }, [])
+
+  // A 16-hex string is error-prone to retype into a support email, and a
+  // mistyped one silently matches no rows. Copy is the primary interaction.
+  const copySupportId = async () => {
+    if (!appInfo) return
+    try {
+      await navigator.clipboard.writeText(appInfo.supportId)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard blocked - the ID is rendered next to the button, so the
+      // user can still select it by hand. Nothing to report.
+    }
+  }
 
   return (
     <div className="max-w-[640px] flex flex-col gap-5">
@@ -75,6 +90,18 @@ export function AccountSection() {
             <span className="mt-body-sm font-mono font-semibold" style={{ color: CHANNEL_COLOR[appInfo.channel] }}>
               v{appInfo.version}{appInfo.channel !== 'prod' && ` · ${appInfo.channel}`}
             </span>
+          )}
+        </FieldRow>
+        <FieldRow label="Support ID" description="Identifies this device in error reports, without naming you or it. Quote it when you contact support so we can find the errors from this machine. It is not tied to your account and changes if you rename the device.">
+          {appInfo && (
+            <div className="flex items-center gap-2">
+              <span className="mt-body-sm font-mono" style={{ color: 'var(--t-muted)' }}>
+                {appInfo.supportId}
+              </span>
+              <SettingsButton onClick={copySupportId}>
+                {copied ? 'Copied' : 'Copy'}
+              </SettingsButton>
+            </div>
           )}
         </FieldRow>
         <FieldRow label="Export Diagnostics" description="Captures your local logs and traces for troubleshooting. Nothing leaves your machine until you share this file. Saved to your Downloads folder and revealed in your file manager.">

--- a/ui/components/timeline/settings/AccountSection.tsx
+++ b/ui/components/timeline/settings/AccountSection.tsx
@@ -92,7 +92,7 @@ export function AccountSection() {
             </span>
           )}
         </FieldRow>
-        <FieldRow label="Support ID" description="Identifies this device in error reports, without naming you or it. Quote it when you contact support so we can find the errors from this machine. It is not tied to your account and changes if you rename the device.">
+        <FieldRow label="Support ID" description="Identifies this device in error reports, without naming you or it. Quote it when you contact support so we can find the errors from this machine. It is not tied to your account.">
           {appInfo && (
             <div className="flex items-center gap-2">
               <span className="mt-body-sm font-mono" style={{ color: 'var(--t-muted)' }}>

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -654,6 +654,11 @@ export interface UninstallResult {
 export interface AppInfo {
   version: string
   channel: 'dev' | 'staging' | 'prod'
+  // This machine's pseudonym, identical to the `host.name` value its error
+  // telemetry carries in the central backend. Surfaced in Settings → Account so
+  // a user can quote it to support; the hash is one-way, so without the user
+  // supplying it their error rows cannot be located.
+  supportId: string
 }
 
 // ── LLM Lab (`get_llm_experiments` / `get_llm_experiment` / `run_llm_experiment`)


### PR DESCRIPTION
Two gaps found while verifying the first staging release of central error reporting (#545).

## 1. Platform attributes were absent, not merely unqueried

`os.type`, `host.arch` and `app.install_mode` are all on `redact::SAFE_STRING_KEYS`, so reading the allowlist suggests they were already available. They were not — `observability::init`'s `Resource::new` set exactly four attributes, and `Resource::new` runs no detectors (unlike `Resource::default`), so the SDK contributed nothing either. Confirmed against a live spool payload, not just by reading the code:

```
deployment.environment
host.name
service.name
service.version
```

A Windows error and a macOS error were therefore indistinguishable in the backend — on the one path that carries the actual error signal. Sentry has OS and arch via `sentry-contexts`, but Sentry only sees tray crashes, so the platform breakdown existed precisely where there was least data.

This is the same **allowlisted-but-never-populated** trap as `service.instance.id` in the #545 review. Documented in CLAUDE.md so the next person checks `Resource::new` rather than the allowlist.

Populating these needs no change to the redaction boundary — they are enum-like build facts that structurally cannot carry user content.

Shipped as the raw Rust constants (`macos`/`windows`, `aarch64`/`x86_64`) rather than the OTel semconv spellings (`darwin`, `arm64`). Nothing downstream parses them as semconv enums, and a mapping layer is a lossy translation with no consumer asking for it.

## 2. The host pseudonym was unreachable by support

`host.name` ships as a one-way 16-hex pseudonym (the #545 blocker fix). It is the **only** identifier on an error row, and nothing in the app showed a user their own value — so a customer writing in about a crash could not be matched to their errors at all. Aggregate dashboards worked; helping a specific person did not.

Now surfaced as **Support ID** in Settings → Account (with copy-to-clipboard, since a mistyped 16-hex string silently matches nothing) and in a synthesized `bundle-info.txt` inside export bundles.

**Why this shape rather than automatic attribution.** The alternative considered was adding the existing analytics `device_id` to the OTel resource, which would join error rows to PostHog Persons and out falls the signed-in email, with no user involvement. Rejected: it re-identifies the error stream by the back door, defeats the pseudonymisation entirely, and would make the consent copy ("stripped on your device first") describe something no longer true in effect. Surfacing the ID keeps attribution per-incident and consented. If proactive outreach is wanted later, the honest version is an explicit opt-in toggle, not a quiet field.

`bundle-info.txt` deliberately carries nothing the automatic ship leg wouldn't already send — no raw hostname, no account email, no paths.

## The drift hazard, and the test that pins it

Both the displayed and the shipped value now come from one new `redact::local_host_pseudonym`. This is the load-bearing part: they are computed in different crates, and any divergence in how the hostname is read (`to_string_lossy` vs `to_str`, a trimmed `.local`, case) yields an ID that matches no rows — and nothing fails loudly. `displayed_pseudonym_matches_shipped` asserts the Settings value equals what `keep_attribute` writes for `host.name`.

## Tests

- `displayed_pseudonym_matches_shipped` — the parity invariant above.
- `machine_shape_attributes_survive_verbatim` — the three new attributes survive `keep_attribute` **unaltered**. Allowlisted strings still pass through `scrub_paths`, so "on the allowlist" is not the same as "arrives intact" — the same shape of trap as the one this PR fixes.
- `build_export_bundle_includes_uncounted_bundle_info` — the bundle carries the pseudonym, does **not** carry the raw hostname, and the synthetic header is not counted in `file_count` (which reports telemetry files collected).

## Verification

Daemon `cargo fmt` + `clippy -D warnings` + 770 tests. Tray verified separately since pre-push does not cover that workspace: fmt, clippy, 161 tests. UI build + typecheck (45 pre-existing `bun:test` type errors on `pre-main`, unchanged) + 381 bun tests.

**Not verifiable until a release rebuilds and reinstalls** — these are compile-time-resolved resource attributes in the packaged daemon, so the current staging install will not show them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)