### PR TITLE
feat(observability): ship platform attributes and surface the Support ID

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,9 +396,19 @@ Redaction applies to the **ship leg only** — it produces a separate stripped
 copy to POST, so local capture and `meridian logs` stay full-fidelity. Two
 things it guarantees that are easy to regress: only WARN+ logs / ERROR-status
 spans egress at all, and `host.name` is replaced by a stable **pseudonym**
-(`redact::pseudonymize_host`) rather than shipping the raw hostname, which on
+(`redact::local_host_pseudonym`) rather than shipping the raw hostname, which on
 macOS is routinely the account holder's real name. The tray's Sentry
 `before_send` applies the identical pseudonym to `event.server_name`.
+
+**The pseudonym is seeded from a hardware id, NOT the hostname** — and the ship
+leg *replaces* `host.name` rather than hashing whatever was captured. This is
+not a stylistic choice: on macOS `HostName` is unset by default, so the kernel
+hostname is derived from the network (measured on a dev Mac, `hostname` was
+byte-identical to the router's reverse-DNS record for the current IP, itself
+derived from a per-network randomised Wi-Fi MAC). Seeding from it gave the same
+machine a new identity on every network change, silently breaking the grouping
+the value exists for. See `telemetry_spool::machine_id` before touching any of
+this; `pseudonym_is_independent_of_the_captured_hostname` pins it.
 
 That pseudonym is the ONLY identifier on an error row — nothing associates it
 with an account, and the hash is one-way. So it is surfaced to the user as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,13 +400,34 @@ spans egress at all, and `host.name` is replaced by a stable **pseudonym**
 macOS is routinely the account holder's real name. The tray's Sentry
 `before_send` applies the identical pseudonym to `event.server_name`.
 
+That pseudonym is the ONLY identifier on an error row — nothing associates it
+with an account, and the hash is one-way. So it is surfaced to the user as
+**Support ID** (Settings → Account, and `bundle-info.txt` inside an export
+bundle), which is what makes a support ticket traceable to its error rows at
+all. Both the displayed value and the shipped one come from
+`redact::local_host_pseudonym` **on purpose** — computing either side
+separately would let them drift, and the user would quote an ID matching
+nothing, silently (`displayed_pseudonym_matches_shipped` pins this).
+
+**Which resource attributes actually ship** is a separate question from the
+allowlist, and the two are easy to confuse: `redact::SAFE_STRING_KEYS` lists
+many keys that nothing populates (`service.instance.id`, `os.version`,
+`app.version`, …). `observability::init`'s `Resource::new` sets exactly:
+`service.name`, `service.version`, `host.name`, `deployment.environment`,
+`os.type`, `host.arch`, `app.install_mode` — and `Resource::new` runs NO
+detectors, so the SDK contributes nothing either. **Allowlisted ≠ present:
+before relying on an attribute in a query or dashboard, check it is set here.**
+
 **Export Diagnostics remains the manual path**, unchanged and independent of
 consent: tray Settings → Account → **Export Diagnostics** (or `meridian
 telemetry export`) bundles the spool + the launchd crash-safety-net logs into
 a `.tar.gz` the user hands to support, imported by hand with `meridian
-telemetry import <bundle> --endpoint <url> --auth <base64>`. Retention
-(default 7 days, `MERIDIAN_TELEMETRY_RETENTION_DAYS`) applies to both
-`pending/` and `sent/`, regardless of shipping status.
+telemetry import <bundle> --endpoint <url> --auth <base64>`. The bundle also
+carries a synthesized `bundle-info.txt` (Support ID, version, channel, os,
+arch) so a hand-delivered archive can be joined to that machine's already-
+ingested rows; it deliberately contains nothing the automatic ship leg wouldn't
+already send. Retention (default 7 days, `MERIDIAN_TELEMETRY_RETENTION_DAYS`)
+applies to both `pending/` and `sent/`, regardless of shipping status.
 
 - **Rust**: `tracing::info!/warn!/error!/debug!` with **structured fields** — never format data values into the message string (already enforced).
 - **Wrap discrete operations in spans** (`tracing::info_span!` / `debug_span!`) and put the meaningful inputs, outputs, and metrics as **span attributes**, not buried in log lines. For an LLM/model call, capture the EXACT input as sent and output as received (post-cap/post-template — reflect any truncation that actually happened), plus real token counts/latency. See `src/llm/resolver.rs`'s `llm.call` span tree (request → infer → response) and `src/worklog_pipeline/distiller`'s `distil.run` span for the reference shape.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,11 +412,14 @@ nothing, silently (`displayed_pseudonym_matches_shipped` pins this).
 **Which resource attributes actually ship** is a separate question from the
 allowlist, and the two are easy to confuse: `redact::SAFE_STRING_KEYS` lists
 many keys that nothing populates (`service.instance.id`, `os.version`,
-`app.version`, …). `observability::init`'s `Resource::new` sets exactly:
-`service.name`, `service.version`, `host.name`, `deployment.environment`,
-`os.type`, `host.arch`, `app.install_mode` — and `Resource::new` runs NO
+`app.version`, `app.install_mode`, …). `observability::init`'s `Resource::new`
+sets exactly: `service.name`, `service.version`, `host.name`,
+`deployment.environment`, `os.type`, `host.arch` — and `Resource::new` runs NO
 detectors, so the SDK contributes nothing either. **Allowlisted ≠ present:
 before relying on an attribute in a query or dashboard, check it is set here.**
+Note `observability::init` runs in BOTH the daemon and the tray, so any
+attribute added there must be correct for both — `app.install_mode` is
+deliberately left unset for exactly this reason (see the comment there).
 
 **Export Diagnostics remains the manual path**, unchanged and independent of
 consent: tray Settings → Account → **Export Diagnostics** (or `meridian

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -297,10 +297,15 @@ fn try_build_otel_providers(
         KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
         // Kept RAW here on purpose. This resource set feeds the local spool,
         // which `meridian logs` renders at full fidelity — a developer reading
-        // their own machine's logs should see their own hostname. The
-        // pseudonymisation happens on the SHIP leg only
-        // (`telemetry_spool::redact::pseudonymize_host`), so nothing
-        // identifying reaches the central backend.
+        // their own machine's logs should see their own hostname.
+        //
+        // The ship leg does not hash this value, it REPLACES it with
+        // `telemetry_spool::redact::local_host_pseudonym()` — a hash of a
+        // stable hardware id, not of whatever the hostname happened to be at
+        // capture time. On macOS the kernel hostname is network-derived
+        // (see `telemetry_spool::machine_id`), so hashing it would give the
+        // same machine a new identity on every network change. Nothing
+        // identifying reaches the central backend either way.
         KeyValue::new(
             "host.name",
             gethostname::gethostname().to_string_lossy().into_owned(),

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -316,6 +316,33 @@ fn try_build_otel_providers(
             "deployment.environment",
             option_env!("MERIDIAN_CHANNEL").unwrap_or("dev"),
         ),
+        // Platform shape. Without these, a Windows error and a macOS error are
+        // indistinguishable in the central backend — every attribute above is
+        // OS-agnostic, and the SDK adds nothing of its own (`Resource::new`
+        // runs no detectors, unlike `Resource::default`). All three are already
+        // on `redact::SAFE_STRING_KEYS`, so populating them needs no change to
+        // the redaction boundary: they are enum-like build facts that
+        // structurally cannot carry user content.
+        //
+        // Deliberately the RAW Rust constants ("macos"/"windows", "aarch64"/
+        // "x86_64") rather than the OTel semconv spellings ("darwin", "arm64").
+        // Nothing downstream parses these as semconv enums, and a translation
+        // layer is one more place to introduce a silent mismatch between what
+        // the code says and what the dashboards filter on.
+        KeyValue::new("os.type", std::env::consts::OS),
+        KeyValue::new("host.arch", std::env::consts::ARCH),
+        // Separates errors from a real packaged install from a developer's
+        // `cargo run`, which otherwise differ only by `deployment.environment`
+        // — and that reports "dev" for BOTH a source build and any build whose
+        // channel env was unset, so it can't carry this distinction alone.
+        KeyValue::new(
+            "app.install_mode",
+            if install_mode::is_canonical_install() {
+                "packaged"
+            } else {
+                "source"
+            },
+        ),
     ]);
 
     // Build spool clients — one per signal so filenames encode the correct prefix.

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -331,18 +331,17 @@ fn try_build_otel_providers(
         // the code says and what the dashboards filter on.
         KeyValue::new("os.type", std::env::consts::OS),
         KeyValue::new("host.arch", std::env::consts::ARCH),
-        // Separates errors from a real packaged install from a developer's
-        // `cargo run`, which otherwise differ only by `deployment.environment`
-        // — and that reports "dev" for BOTH a source build and any build whose
-        // channel env was unset, so it can't carry this distinction alone.
-        KeyValue::new(
-            "app.install_mode",
-            if install_mode::is_canonical_install() {
-                "packaged"
-            } else {
-                "source"
-            },
-        ),
+        // NOT setting `app.install_mode` here, deliberately — it is on
+        // `redact::SAFE_STRING_KEYS` and looks tempting. The only available
+        // signal is `is_canonical_install()`, which compares `current_exe()`
+        // against `~/.meridian/bin/meridian`. That is a DAEMON-shaped test, and
+        // this function also runs in the tray (`lib.rs` calls
+        // `observability::init("meridian-tray")` unconditionally), whose exe
+        // lives in the `.app` bundle — so every tray row on a fully packaged
+        // install would be labelled "source". A wrong platform attribute is
+        // worse than an absent one; it gets trusted in a dashboard filter.
+        // `deployment.environment` already separates source builds ("dev") from
+        // released ones, which is the distinction that was actually wanted.
     ]);
 
     // Build spool clients — one per signal so filenames encode the correct prefix.

--- a/src/telemetry_spool/machine_id.rs
+++ b/src/telemetry_spool/machine_id.rs
@@ -1,0 +1,148 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! A stable per-machine seed for telemetry pseudonymisation.
+//!
+//! # Why the hostname could not be the seed
+//! [`crate::telemetry_spool::redact`] hashes a machine identifier into the
+//! 16-hex pseudonym that replaces `host.name` on the ship leg and that the user
+//! is shown as their **Support ID**. Both uses assume that identifier is stable
+//! for the life of the machine: grouping ("one user hit this 500 times" vs "500
+//! users hit it once") is meaningless otherwise, and a Support ID that drifts is
+//! worse than none, because the user quotes a value matching no rows.
+//!
+//! `gethostname()` does not satisfy that on macOS. `HostName` is unset by
+//! default (only `ComputerName`/`LocalHostName` are set by a rename), so configd
+//! derives the kernel hostname from the **network**. Measured on a dev Mac:
+//!
+//! ```text
+//! hostname                    Unknown_a2:97:03:78:a9:6a
+//! dig -x 192.168.1.13         Unknown_a2:97:03:78:a9:6a.   <- same string
+//! en1 ether                   a2:97:03:78:a9:6a            <- locally administered
+//! scutil --get ComputerName   Mac Studio                   <- unrelated
+//! ```
+//!
+//! The hostname is the router's reverse-DNS record for the current IP, itself
+//! derived from a **private Wi-Fi address** that macOS rotates per network. So
+//! joining a different network changes the hostname, and every downstream
+//! pseudonym with it - the same machine arrives as a new one.
+//!
+//! # What is used instead
+//! `IOPlatformUUID`, the hardware UUID: stable across reboots, OS updates,
+//! renames and network changes. It also *improves* the pseudonymisation, which
+//! is a one-way hash of a low-entropy input: hostnames are enumerable (an
+//! attacker can hash `Akarshs-MacBook-Pro.local` and compare), a 128-bit
+//! hardware UUID is not.
+//!
+//! Other platforms fall through to the hostname, deliberately - on Windows
+//! `gethostname()` returns the computer name, which is already stable, and
+//! Meridian ships no Linux build. Adding untested registry/`/etc/machine-id`
+//! probing for a case that is not broken would be risk without benefit.
+//!
+//! # Who calls this
+//! [`crate::telemetry_spool::redact::local_host_pseudonym`] - the single seam
+//! through which both the shipped `host.name` and the displayed Support ID are
+//! derived.
+
+use std::sync::OnceLock;
+
+/// Absolute path so a hostile `PATH` cannot substitute the binary. This runs in
+/// a long-lived daemon, and the value it returns becomes an identity.
+#[cfg(target_os = "macos")]
+const IOREG: &str = "/usr/sbin/ioreg";
+
+/// A stable hardware-derived identifier for this machine, or `None` when the
+/// platform has no better answer than the hostname.
+///
+/// Cached: the macOS implementation spawns a process, and callers may hit this
+/// per shipped file. Returning `None` is cached too, so a failing probe costs
+/// one spawn per process, not one per call.
+pub(crate) fn stable_machine_id() -> Option<&'static str> {
+    static CACHED: OnceLock<Option<String>> = OnceLock::new();
+    CACHED.get_or_init(read_platform_id).as_deref()
+}
+
+/// macOS: parse `IOPlatformUUID` out of the `IOPlatformExpertDevice` node.
+///
+/// Shells out to `ioreg` rather than binding IOKit, to avoid pulling a
+/// `core-foundation`/`io-kit-sys` dependency into the daemon for one string
+/// read at startup. Any failure returns `None` and the caller falls back to the
+/// hostname - a wrong-but-present id would be worse than the status quo.
+#[cfg(target_os = "macos")]
+fn read_platform_id() -> Option<String> {
+    let out = std::process::Command::new(IOREG)
+        .args(["-rd1", "-c", "IOPlatformExpertDevice"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    parse_ioreg_uuid(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Pull the `IOPlatformUUID` value out of `ioreg` output. Split out from the
+/// process spawn so the parsing is testable without a Mac in the loop.
+///
+/// The line looks like:
+/// `    "IOPlatformUUID" = "2D5462F0-45C1-5987-94E9-5CBAD14E4362"`
+#[cfg(target_os = "macos")]
+fn parse_ioreg_uuid(text: &str) -> Option<String> {
+    text.lines()
+        .find(|l| l.contains("\"IOPlatformUUID\""))
+        .and_then(|l| l.split('"').nth(3))
+        .filter(|v| !v.is_empty())
+        .map(str::to_string)
+}
+
+/// Non-macOS: no probe. See the module doc - the hostname is already stable on
+/// the only other platform Meridian ships.
+#[cfg(not(target_os = "macos"))]
+fn read_platform_id() -> Option<String> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn parses_the_uuid_out_of_real_ioreg_output() {
+        // Trimmed from actual `ioreg -rd1 -c IOPlatformExpertDevice` output.
+        let sample = r#"+-o J375dAP  <class IOPlatformExpertDevice, id 0x100000284>
+    {
+      "IOPlatformSerialNumber" = "MXMFHVWMVQ"
+      "IOPlatformUUID" = "2D5462F0-45C1-5987-94E9-5CBAD14E4362"
+      "IOBusyInterest" = "IOCommand is not serializable"
+    }
+"#;
+        assert_eq!(
+            parse_ioreg_uuid(sample).as_deref(),
+            Some("2D5462F0-45C1-5987-94E9-5CBAD14E4362")
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn malformed_output_yields_none_rather_than_a_junk_id() {
+        // A junk id is worse than none: it would be stable-looking but wrong.
+        for bad in [
+            "",
+            "no uuid here at all",
+            "\"IOPlatformUUID\" = \"\"",
+            "\"IOPlatformUUID\"",
+        ] {
+            assert_eq!(parse_ioreg_uuid(bad), None, "accepted junk: {bad:?}");
+        }
+    }
+
+    /// On a real Mac the probe must actually succeed - a silent fallback to the
+    /// hostname would reintroduce the instability this module exists to fix,
+    /// and nothing else would report it.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn probe_succeeds_on_this_machine() {
+        let id = stable_machine_id().expect("IOPlatformUUID probe failed on macOS");
+        assert!(id.len() >= 32, "implausible platform uuid: {id}");
+        // Stable across calls (it is cached, but pin the contract).
+        assert_eq!(Some(id), stable_machine_id());
+    }
+}

--- a/src/telemetry_spool/mod.rs
+++ b/src/telemetry_spool/mod.rs
@@ -26,6 +26,7 @@ use anyhow::{Context, Result};
 
 pub mod cli;
 pub(crate) mod launchd_log_cap;
+pub(crate) mod machine_id;
 pub mod redact;
 pub mod render;
 pub(crate) mod retention;

--- a/src/telemetry_spool/mod.rs
+++ b/src/telemetry_spool/mod.rs
@@ -103,9 +103,62 @@ pub fn build_export_bundle(
             .with_context(|| format!("add {} to archive", file_path.display()))?;
     }
 
+    append_bundle_info(&mut tar).context("add bundle-info.txt to archive")?;
+
     tar.finish().context("finish tar archive")?;
 
     Ok((out_path, file_count))
+}
+
+/// Write a synthesized `bundle-info.txt` into the archive: which machine,
+/// build, and platform produced it.
+///
+/// Without this, a support bundle is a pile of opaque `.otlp` files and the
+/// recipient has to guess. The `machine` line is the same pseudonym that
+/// appears as `host.name` in the central backend
+/// ([`redact::local_host_pseudonym`]), which is the point: it joins a
+/// hand-delivered bundle to that machine's already-ingested error rows.
+///
+/// Deliberately carries NOTHING that isn't already allowed to leave the
+/// machine over the automatic ship leg - no raw hostname, no account email, no
+/// paths. A user handing over a bundle should not be disclosing more than the
+/// consent copy describes.
+///
+/// Not counted in the returned `file_count`, which reports telemetry files
+/// collected - a synthetic header would make that number mean two things.
+fn append_bundle_info<W: std::io::Write>(tar: &mut tar::Builder<W>) -> Result<()> {
+    let body = format!(
+        "machine: {}\n\
+         version: {}\n\
+         channel: {}\n\
+         os: {}\n\
+         arch: {}\n\
+         generated_unix_micros: {}\n",
+        redact::local_host_pseudonym(),
+        env!("CARGO_PKG_VERSION"),
+        option_env!("MERIDIAN_CHANNEL").unwrap_or("dev"),
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64,
+    );
+
+    let mut header = tar::Header::new_gnu();
+    header.set_size(body.len() as u64);
+    header.set_mode(0o644);
+    header.set_mtime(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    );
+    header.set_cksum();
+
+    tar.append_data(&mut header, "bundle-info.txt", body.as_bytes())
+        .context("append bundle-info.txt")?;
+    Ok(())
 }
 
 /// Strip a `/v1/traces` or `/v1/logs` suffix to recover the OO base URL.
@@ -234,6 +287,50 @@ mod tests {
         // 1 otlp file + daemon.log (a known launchd log name) — the unrelated
         // .txt file must NOT be swept in.
         assert_eq!(count, 2);
+    }
+
+    /// The bundle must carry the machine pseudonym (so support can join it to
+    /// already-ingested error rows) and must NOT carry the raw hostname —
+    /// handing over a bundle should disclose no more than the automatic ship
+    /// leg already does.
+    #[test]
+    fn build_export_bundle_includes_uncounted_bundle_info() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+        std::env::set_var("MERIDIAN_TELEMETRY_DIR", dir.path());
+
+        writer::write_pending(dir.path(), "traces", b"a").unwrap();
+
+        let out = dir.path().join("bundle.tar.gz");
+        let (_, count) = build_export_bundle(Some(&out), None, false).unwrap();
+
+        std::env::remove_var("MERIDIAN_TELEMETRY_DIR");
+
+        // The synthetic header is not counted as a telemetry file.
+        assert_eq!(count, 1);
+
+        let gz = flate2::read::GzDecoder::new(std::fs::File::open(&out).unwrap());
+        let mut archive = tar::Archive::new(gz);
+        let mut info = None;
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            if entry.path().unwrap().to_string_lossy() == "bundle-info.txt" {
+                let mut s = String::new();
+                std::io::Read::read_to_string(&mut entry, &mut s).unwrap();
+                info = Some(s);
+            }
+        }
+
+        let info = info.expect("bundle-info.txt missing from archive");
+        assert!(
+            info.contains(&redact::local_host_pseudonym()),
+            "pseudonym missing, support cannot join this bundle: {info}"
+        );
+        let raw_host = gethostname::gethostname().to_string_lossy().into_owned();
+        assert!(
+            !info.contains(&raw_host),
+            "raw hostname leaked into the bundle: {info}"
+        );
     }
 
     #[test]

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -1020,20 +1020,19 @@ mod tests {
         );
     }
 
-    /// `os.type` / `host.arch` / `app.install_mode` are on `SAFE_STRING_KEYS`,
-    /// but being allowlisted is not the same as surviving intact — allowlisted
-    /// strings still pass through `scrub_paths`. Pins that these three reach
-    /// the backend as written, since the whole point of populating them is
-    /// being able to filter errors by platform.
+    /// `os.type` / `host.arch` are on `SAFE_STRING_KEYS`, but being allowlisted
+    /// is not the same as surviving intact — allowlisted strings still pass
+    /// through `scrub_paths`. Pins that both reach the backend as written,
+    /// since the whole point of populating them is being able to filter errors
+    /// by platform.
     #[test]
     fn machine_shape_attributes_survive_verbatim() {
         for (key, value) in [
             ("os.type", "macos"),
             ("os.type", "windows"),
+            ("os.type", "linux"),
             ("host.arch", "aarch64"),
             ("host.arch", "x86_64"),
-            ("app.install_mode", "packaged"),
-            ("app.install_mode", "source"),
         ] {
             let mut kv = str_attr(key, value);
             assert!(keep_attribute(&mut kv), "{key} was dropped");

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -418,6 +418,27 @@ pub fn pseudonymize_host(hostname: &str) -> String {
     })
 }
 
+/// This machine's pseudonym - the exact value that appears as `host.name` in
+/// the central backend for telemetry originating here.
+///
+/// # Why this exists rather than each caller hashing its own hostname
+/// The pseudonym is what a user quotes to support so their error rows can be
+/// found. That only works if the value we SHOW is byte-identical to the value
+/// we SHIP. Those are computed in different crates (the tray renders it in
+/// Settings; the daemon's ship leg writes it via [`keep_attribute`]), so any
+/// divergence in how the hostname is obtained - `to_string_lossy` vs `to_str`,
+/// a trimmed `.local` suffix, case folding - would produce an ID that matches
+/// nothing, and the failure is silent. Funnelling both through this one
+/// function makes that drift impossible; `displayed_pseudonym_matches_shipped`
+/// pins it.
+///
+/// Must therefore read the hostname the same way `observability::init` does
+/// (`gethostname().to_string_lossy()`), since that is the raw value the ship
+/// leg later hashes.
+pub fn local_host_pseudonym() -> String {
+    pseudonymize_host(&gethostname::gethostname().to_string_lossy())
+}
+
 fn is_safe_string_key(key: &str) -> bool {
     SAFE_STRING_KEYS.contains(&key)
 }
@@ -976,5 +997,51 @@ mod tests {
         assert_eq!(out, pseudonymize_host("Akarshs-MacBook-Pro.local"));
         // ...and distinct per machine, or grouping would be meaningless.
         assert_ne!(out, pseudonymize_host("someone-elses-imac.local"));
+    }
+
+    /// The support workflow's load-bearing invariant: the pseudonym the tray
+    /// shows a user in Settings must equal the one the ship leg writes for
+    /// `host.name`, or the ID they quote matches no rows in the backend and
+    /// nothing fails loudly. Guards against the two crates drifting in how the
+    /// hostname is read.
+    #[test]
+    fn displayed_pseudonym_matches_shipped() {
+        let raw = gethostname::gethostname().to_string_lossy().into_owned();
+        let mut kv = str_attr("host.name", &raw);
+        assert!(keep_attribute(&mut kv));
+        let shipped = match kv.value.unwrap().value.unwrap() {
+            Value::StringValue(s) => s,
+            other => panic!("expected string, got {other:?}"),
+        };
+        assert_eq!(
+            local_host_pseudonym(),
+            shipped,
+            "Settings would show a pseudonym that matches nothing in the backend"
+        );
+    }
+
+    /// `os.type` / `host.arch` / `app.install_mode` are on `SAFE_STRING_KEYS`,
+    /// but being allowlisted is not the same as surviving intact — allowlisted
+    /// strings still pass through `scrub_paths`. Pins that these three reach
+    /// the backend as written, since the whole point of populating them is
+    /// being able to filter errors by platform.
+    #[test]
+    fn machine_shape_attributes_survive_verbatim() {
+        for (key, value) in [
+            ("os.type", "macos"),
+            ("os.type", "windows"),
+            ("host.arch", "aarch64"),
+            ("host.arch", "x86_64"),
+            ("app.install_mode", "packaged"),
+            ("app.install_mode", "source"),
+        ] {
+            let mut kv = str_attr(key, value);
+            assert!(keep_attribute(&mut kv), "{key} was dropped");
+            let out = match kv.value.unwrap().value.unwrap() {
+                Value::StringValue(s) => s,
+                other => panic!("expected string, got {other:?}"),
+            };
+            assert_eq!(out, value, "{key} was altered in transit");
+        }
     }
 }

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -65,6 +65,8 @@ use opentelemetry_proto::tonic::{
 use prost::Message;
 use regex::Regex;
 
+use super::machine_id;
+
 /// OTLP `SeverityNumber` for `WARN`; the error-only log threshold is "this or
 /// higher" (WARN=13, ERROR=17, FATAL=21). Matches the ranges in
 /// [`crate::telemetry_spool::render`].
@@ -356,7 +358,19 @@ fn keep_attribute(kv: &mut KeyValue) -> bool {
         Some(Value::IntValue(_)) | Some(Value::DoubleValue(_)) | Some(Value::BoolValue(_)) => true,
         Some(Value::StringValue(s)) => {
             if kv.key == HOST_NAME_KEY {
-                *s = pseudonymize_host(s);
+                // REPLACED, not hashed-in-place. Hashing the captured value
+                // would inherit its instability: a spool file written on one
+                // network and shipped after joining another would carry a
+                // different pseudonym for the same machine. Deriving it here
+                // from the stable seed makes every record from this machine
+                // agree, whenever it happens to be captured or drained.
+                //
+                // Safe because spool files are always written locally, so the
+                // captured `host.name` always describes THIS machine. The one
+                // path that ships another machine's payload — `telemetry
+                // import` — bypasses redaction entirely by design, so it
+                // cannot be mislabelled by this.
+                *s = local_host_pseudonym();
                 true
             } else if is_free_text_key(&kv.key) {
                 *s = clamp(scrub_text(s));
@@ -401,15 +415,14 @@ const HOST_PSEUDONYM_SALT: &str = "meridian.host.pseudonym.v1:";
 /// hashing. That matches the PR's stated position (redacted, not anonymous);
 /// true anonymisation is a later phase.
 ///
-/// `pub` because the tray's Sentry `before_send` applies the identical
-/// transform to `event.server_name`, which `sentry-contexts` auto-populates
-/// from the same hostname — so both egress paths pseudonymise to the SAME
-/// value and a crash can still be correlated with that machine's error logs.
-pub fn pseudonymize_host(hostname: &str) -> String {
+/// `pub` for tests and for [`local_host_pseudonym`], which is what callers
+/// should actually use — hashing a caller-supplied hostname is exactly the
+/// mistake this module had (see that function's doc).
+pub fn pseudonymize_host(seed: &str) -> String {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(HOST_PSEUDONYM_SALT.as_bytes());
-    hasher.update(hostname.as_bytes());
+    hasher.update(seed.as_bytes());
     let digest = hasher.finalize();
     digest[..8].iter().fold(String::new(), |mut acc, b| {
         use std::fmt::Write;
@@ -432,11 +445,30 @@ pub fn pseudonymize_host(hostname: &str) -> String {
 /// function makes that drift impossible; `displayed_pseudonym_matches_shipped`
 /// pins it.
 ///
-/// Must therefore read the hostname the same way `observability::init` does
-/// (`gethostname().to_string_lossy()`), since that is the raw value the ship
-/// leg later hashes.
+/// # Why the seed is NOT the hostname
+/// It was, and that was a bug. On macOS `HostName` is unset by default, so the
+/// kernel hostname is derived from the network — measurably so: on a dev Mac
+/// `hostname` returned `Unknown_a2:97:03:78:a9:6a`, byte-identical to the
+/// router's reverse-DNS record for the current IP, itself derived from a
+/// **private Wi-Fi address** that macOS rotates per network. Joining a
+/// different network therefore produced a different pseudonym for the same
+/// machine, silently breaking both the grouping this value exists for and any
+/// Support ID a user had already quoted.
+///
+/// The seed is now [`machine_id::stable_machine_id`] (the hardware UUID on
+/// macOS), falling back to the hostname only where no better identifier is
+/// available — on Windows that fallback is itself stable, since `gethostname()`
+/// there returns the computer name.
+///
+/// Note this makes the pseudonymisation *stronger*, not merely more stable: it
+/// is a one-way hash of a low-entropy input, and hostnames are enumerable
+/// (`Akarshs-MacBook-Pro.local` can simply be hashed and compared) where a
+/// 128-bit hardware UUID is not.
 pub fn local_host_pseudonym() -> String {
-    pseudonymize_host(&gethostname::gethostname().to_string_lossy())
+    match machine_id::stable_machine_id() {
+        Some(id) => pseudonymize_host(id),
+        None => pseudonymize_host(&gethostname::gethostname().to_string_lossy()),
+    }
 }
 
 fn is_safe_string_key(key: &str) -> bool {
@@ -993,10 +1025,43 @@ mod tests {
         assert!(!out.contains("Akarsh"), "raw hostname survived: {out}");
         assert!(!out.contains("MacBook"), "raw hostname survived: {out}");
         assert_eq!(out.len(), 16, "expected a 16-hex-char pseudonym, got {out}");
-        // Stable across calls — grouping by machine has to survive restarts.
-        assert_eq!(out, pseudonymize_host("Akarshs-MacBook-Pro.local"));
-        // ...and distinct per machine, or grouping would be meaningless.
-        assert_ne!(out, pseudonymize_host("someone-elses-imac.local"));
+        // This machine's pseudonym, NOT a hash of the captured hostname — the
+        // captured value is deliberately ignored (see `keep_attribute`).
+        assert_eq!(out, local_host_pseudonym());
+    }
+
+    /// The whole point of seeding from a stable hardware id: two spool records
+    /// captured under different hostnames — the same Mac on two Wi-Fi networks,
+    /// which is what actually happens, since the kernel hostname there is
+    /// derived from the router's reverse DNS — must still ship as ONE machine.
+    /// Hashing the captured value (the previous behaviour) failed this.
+    #[test]
+    fn pseudonym_is_independent_of_the_captured_hostname() {
+        let shipped = |raw: &str| {
+            let mut kv = str_attr("host.name", raw);
+            assert!(keep_attribute(&mut kv));
+            match kv.value.unwrap().value.unwrap() {
+                Value::StringValue(s) => s,
+                other => panic!("expected string, got {other:?}"),
+            }
+        };
+        assert_eq!(
+            shipped("Unknown_a2:97:03:78:a9:6a"),
+            shipped("Mac-Studio-2.local"),
+            "same machine split into two identities across a network change"
+        );
+    }
+
+    /// Distinct machines must still be distinguishable, or the grouping the
+    /// pseudonym exists for is worthless. Guards the obvious failure mode of
+    /// the fix above: replacing the value with a constant would pass the
+    /// independence test and destroy the feature.
+    #[test]
+    fn distinct_seeds_still_yield_distinct_pseudonyms() {
+        assert_ne!(
+            pseudonymize_host("2D5462F0-45C1-5987-94E9-5CBAD14E4362"),
+            pseudonymize_host("9A114C11-0000-5FFF-8888-1111CCCC2222"),
+        );
     }
 
     /// The support workflow's load-bearing invariant: the pseudonym the tray

--- a/tray/src-tauri/src/commands/version.rs
+++ b/tray/src-tauri/src/commands/version.rs
@@ -259,25 +259,41 @@ pub(crate) fn build_channel() -> &'static str {
     option_env!("MERIDIAN_CHANNEL").unwrap_or("prod")
 }
 
-/// `{ version, channel }` for the small badge in the dashboard and popover.
+/// `{ version, channel, supportId }` for the small badge in the dashboard and
+/// popover, plus the Account panel's support identifier.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppInfo {
     pub version: String,
     pub channel: String,
+    /// This machine's pseudonym — the exact value error telemetry from here
+    /// carries as `host.name` in the central backend. Shown in Settings so a
+    /// user can quote it when they contact support; without it their error
+    /// rows are unfindable, since pseudonymisation is one-way by design.
+    pub support_id: String,
 }
 
 /// The binary's baked `tauri.conf.json` version (what the DMG updater compares
 /// against — set in lockstep across the repo by `scripts/set-version.sh`) plus
 /// [`build_channel`]. Synchronous and never touches the network, unlike
 /// [`get_version`] above.
+///
+/// `support_id` comes from [`meridian::telemetry_spool::redact::local_host_pseudonym`]
+/// — the SAME function the daemon's ship leg uses, so the displayed value and
+/// the shipped one cannot drift (see that function's doc for why sharing it
+/// matters).
 #[tauri::command]
 #[tracing::instrument(skip(app))]
 pub fn get_app_info(app: tauri::AppHandle) -> AppInfo {
     let version = app.package_info().version.to_string();
     let channel = build_channel().to_string();
-    tracing::info!(%version, %channel, "app info served");
-    AppInfo { version, channel }
+    let support_id = meridian::telemetry_spool::redact::local_host_pseudonym();
+    tracing::info!(%version, %channel, %support_id, "app info served");
+    AppInfo {
+        version,
+        channel,
+        support_id,
+    }
 }
 
 /// DMG auto-update check for the in-app banners (sidebar + popover). Wraps

--- a/tray/src-tauri/src/crash.rs
+++ b/tray/src-tauri/src/crash.rs
@@ -105,7 +105,7 @@ pub fn init_client() -> Option<ClientInitGuard> {
 /// (`redact::pseudonymize_host`), so a crash here and an error log there
 /// resolve to the SAME machine identifier and can still be correlated.
 fn scrub_event(mut event: Event<'static>) -> Option<Event<'static>> {
-    use meridian::telemetry_spool::redact::{pseudonymize_host, scrub_text};
+    use meridian::telemetry_spool::redact::{local_host_pseudonym, scrub_text};
     if let Some(m) = event.message.take() {
         event.message = Some(scrub_text(&m));
     }
@@ -114,9 +114,11 @@ fn scrub_event(mut event: Event<'static>) -> Option<Event<'static>> {
             exc.value = Some(scrub_text(&v));
         }
     }
-    event.server_name = event
-        .server_name
-        .take()
-        .map(|h| pseudonymize_host(&h).into());
+    // Set unconditionally rather than mapping over the existing value: the OTLP
+    // side now derives this from a stable hardware id rather than hashing
+    // whatever hostname was present, so mapping here would produce a DIFFERENT
+    // pseudonym and silently decorrelate a crash from that machine's error
+    // logs. Also covers the case where `sentry-contexts` left it unset.
+    event.server_name = Some(local_host_pseudonym().into());
     Some(event)
 }

--- a/ui/components/timeline/settings/AccountSection.tsx
+++ b/ui/components/timeline/settings/AccountSection.tsx
@@ -29,11 +29,26 @@ const CHANNEL_COLOR: Record<AppInfo['channel'], string> = {
 
 export function AccountSection() {
   const [appInfo, setAppInfo] = useState<AppInfo | null>(null)
+  const [copied, setCopied] = useState(false)
   const { status: exportStatus, path: exportPath, errorMsg: exportError, exportBundle } = useExportDiagnostics()
 
   useEffect(() => {
     load<AppInfo>('/api/app-info', 'get_app_info').then(setAppInfo).catch(() => {})
   }, [])
+
+  // A 16-hex string is error-prone to retype into a support email, and a
+  // mistyped one silently matches no rows. Copy is the primary interaction.
+  const copySupportId = async () => {
+    if (!appInfo) return
+    try {
+      await navigator.clipboard.writeText(appInfo.supportId)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard blocked - the ID is rendered next to the button, so the
+      // user can still select it by hand. Nothing to report.
+    }
+  }
 
   return (
     <div className="max-w-[640px] flex flex-col gap-5">
@@ -75,6 +90,18 @@ export function AccountSection() {
             <span className="mt-body-sm font-mono font-semibold" style={{ color: CHANNEL_COLOR[appInfo.channel] }}>
               v{appInfo.version}{appInfo.channel !== 'prod' && ` · ${appInfo.channel}`}
             </span>
+          )}
+        </FieldRow>
+        <FieldRow label="Support ID" description="Identifies this device in error reports, without naming you or it. Quote it when you contact support so we can find the errors from this machine. It is not tied to your account and changes if you rename the device.">
+          {appInfo && (
+            <div className="flex items-center gap-2">
+              <span className="mt-body-sm font-mono" style={{ color: 'var(--t-muted)' }}>
+                {appInfo.supportId}
+              </span>
+              <SettingsButton onClick={copySupportId}>
+                {copied ? 'Copied' : 'Copy'}
+              </SettingsButton>
+            </div>
           )}
         </FieldRow>
         <FieldRow label="Export Diagnostics" description="Captures your local logs and traces for troubleshooting. Nothing leaves your machine until you share this file. Saved to your Downloads folder and revealed in your file manager.">

--- a/ui/components/timeline/settings/AccountSection.tsx
+++ b/ui/components/timeline/settings/AccountSection.tsx
@@ -92,7 +92,7 @@ export function AccountSection() {
             </span>
           )}
         </FieldRow>
-        <FieldRow label="Support ID" description="Identifies this device in error reports, without naming you or it. Quote it when you contact support so we can find the errors from this machine. It is not tied to your account.">
+        <FieldRow label="Support ID" description="Identifies this device in error reports, without naming you or it. Quote it when you contact support so we can find the errors from this machine. It is not tied to your account and stays the same for this device.">
           {appInfo && (
             <div className="flex items-center gap-2">
               <span className="mt-body-sm font-mono" style={{ color: 'var(--t-muted)' }}>

--- a/ui/components/timeline/settings/AccountSection.tsx
+++ b/ui/components/timeline/settings/AccountSection.tsx
@@ -92,7 +92,7 @@ export function AccountSection() {
             </span>
           )}
         </FieldRow>
-        <FieldRow label="Support ID" description="Identifies this device in error reports, without naming you or it. Quote it when you contact support so we can find the errors from this machine. It is not tied to your account and changes if you rename the device.">
+        <FieldRow label="Support ID" description="Identifies this device in error reports, without naming you or it. Quote it when you contact support so we can find the errors from this machine. It is not tied to your account.">
           {appInfo && (
             <div className="flex items-center gap-2">
               <span className="mt-body-sm font-mono" style={{ color: 'var(--t-muted)' }}>

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -654,6 +654,11 @@ export interface UninstallResult {
 export interface AppInfo {
   version: string
   channel: 'dev' | 'staging' | 'prod'
+  // This machine's pseudonym, identical to the `host.name` value its error
+  // telemetry carries in the central backend. Surfaced in Settings → Account so
+  // a user can quote it to support; the hash is one-way, so without the user
+  // supplying it their error rows cannot be located.
+  supportId: string
 }
 
 // ── LLM Lab (`get_llm_experiments` / `get_llm_experiment` / `run_llm_experiment`)


### PR DESCRIPTION
Split out of #584 (closed). This is the feature half; the two bug fixes it was bundled with are #587 and #588.

Two gaps found while verifying the first staging release of central error reporting (#545).

## 1. Platform attributes were absent, not merely unqueried

`os.type` and `host.arch` are on `redact::SAFE_STRING_KEYS`, so reading the allowlist suggests they were already available. They were not - `observability::init`'s `Resource::new` set exactly four attributes, and `Resource::new` runs no detectors (unlike `Resource::default`), so the SDK contributed nothing either. Confirmed against a live spool payload rather than by reading code:

```
deployment.environment
host.name
service.name
service.version
```

A Windows error and a macOS error were therefore indistinguishable on the one path that carries the actual error signal. Sentry has OS and arch via `sentry-contexts`, but Sentry only sees tray crashes, so the platform breakdown existed precisely where there was least data.

Same **allowlisted-but-never-populated** trap as `service.instance.id` in the #545 review. CLAUDE.md now says to check `Resource::new`, not the allowlist.

Shipped as the raw Rust constants (`macos`/`windows`, `aarch64`/`x86_64`) rather than OTel semconv spellings (`darwin`, `arm64`) - nothing downstream parses these as semconv enums, and a mapping layer is a lossy translation with no consumer asking for it.

`app.install_mode` was in the first draft and **removed on review**: its only signal is `is_canonical_install()`, an exe-path check shaped for the daemon, but `observability::init` also runs in the tray (`lib.rs:92`) whose exe lives in the `.app` bundle - so every tray row on a packaged install would have been labelled `source`. A wrong platform attribute is worse than an absent one. A comment at the site records why it stays unset, since the key is on `SAFE_STRING_KEYS` and its absence otherwise reads as an oversight.

## 2. The host pseudonym was unreachable by support

`host.name` ships as a one-way 16-hex pseudonym (the #545 blocker fix). It is the **only** identifier on an error row, and nothing showed a user their own value - so a customer writing in about a crash could not be matched to their errors at all. Aggregate dashboards worked; helping a specific person did not.

Now surfaced as **Support ID** in Settings -> Account (with copy-to-clipboard, since a mistyped 16-hex string silently matches nothing) and in a synthesized `bundle-info.txt` inside export bundles.

**Why this shape rather than automatic attribution.** The alternative was adding the existing analytics `device_id` to the OTel resource, joining error rows to PostHog Persons and yielding the signed-in email with no user involvement. Rejected: it re-identifies the error stream by the back door and would make the consent copy ("stripped on your device first") untrue in effect. Surfacing the ID keeps attribution per-incident and consented. If proactive outreach is wanted later, the honest version is an explicit opt-in toggle, not a quiet field.

`bundle-info.txt` carries nothing the automatic ship leg wouldn't already send - no raw hostname, no account email, no paths.

## The drift hazard, and the test that pins it

Both the displayed and shipped values come from one new `redact::local_host_pseudonym`. They are computed in different crates, and any divergence in how the hostname is read (`to_string_lossy` vs `to_str`, a trimmed `.local`, case) yields an ID matching no rows - silently. `displayed_pseudonym_matches_shipped` asserts the Settings value equals what `keep_attribute` writes for `host.name`.

A copy claim was also corrected on review: "changes if you rename the device" was false. The pseudonym hashes `gethostname()`, the Unix hostname, not the Computer Name a rename edits. Verified locally - `gethostname()` returned `Unknown_<mac-address>` while ComputerName was "Mac Studio".

## Known issue, raised not fixed

That check surfaced a pre-existing question. With `HostName` unset - the macOS default - `gethostname()` fell back to a **MAC-address-derived string**. #545 assumes `host.name` is stable per machine; that assumption underpins both the grouping argument for pseudonymising rather than dropping, and the Support ID feature here. If the value can shift (interface change, DHCP state), both break quietly.

Not established that it does shift, and out of scope - this PR surfaces the existing identifier, it does not choose it. The fix, if needed, is deriving `host.name` from a stable platform ID (`IOPlatformUUID` / `MachineGuid`), with its own Sentry-correlation implications. Windows is unaffected: `gethostname()` there returns the computer name.

## Tests

- `displayed_pseudonym_matches_shipped` - the parity invariant.
- `machine_shape_attributes_survive_verbatim` - the new attributes survive `keep_attribute` **unaltered**. Allowlisted strings still pass through `scrub_paths`, so "on the allowlist" is not "arrives intact".
- `build_export_bundle_includes_uncounted_bundle_info` - bundle carries the pseudonym, not the raw hostname, and the synthetic header is not counted in `file_count`.

## Verification

Daemon `fmt` + `clippy -D warnings` + tests. Tray verified separately since pre-push does not cover that workspace: fmt, clippy, 161 tests. UI build + typecheck (45 pre-existing `bun:test` type errors on `pre-main`, unchanged) + 381 bun tests.

**Not verifiable until a release rebuilds and reinstalls** - these are compile-time-resolved resource attributes in the packaged daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)