### PR TITLE
fix(observability): recognise the packaged Windows install (.exe suffix)

### DIFF
--- a/src/observability/install_mode.rs
+++ b/src/observability/install_mode.rs
@@ -44,11 +44,28 @@ pub(super) fn is_canonical_install() -> bool {
         return false;
     };
     match std::env::current_exe() {
-        Ok(exe) => exe == meridian_dir.join("bin").join("meridian"),
+        Ok(exe) => exe == meridian_dir.join("bin").join(staged_daemon_file_name()),
         // `current_exe()` failing is rare (permissions, exotic sandboxing) —
         // fall back to the machine-wide marker file rather than guessing.
         Err(_) => meridian_dir.join(".env").exists(),
     }
+}
+
+/// File name the tray stages the daemon under in `~/.meridian/bin/`.
+///
+/// **Must** track `backend_install::DAEMON_FILE` in the tray crate, which is
+/// `meridian.exe` on Windows and `meridian` elsewhere. This was hardcoded to
+/// `"meridian"`, so on Windows the comparison above could never match a real
+/// packaged install: `current_exe()` ends in `.exe`, so `is_canonical_install()`
+/// returned false, `resolve_otlp_target()` fell through to the DEV branch, and
+/// that branch requires `otlp_enabled` + local OpenObserve credentials which a
+/// packaged install never has. Net effect: central error reporting was silently
+/// inert on every Windows install, with no warning on either side.
+///
+/// Derived from `EXE_SUFFIX` rather than a `cfg`-selected constant so it cannot
+/// drift again if another platform is added.
+fn staged_daemon_file_name() -> String {
+    format!("meridian{}", std::env::consts::EXE_SUFFIX)
 }
 
 /// Hard kill switch for OTel capture (spans/logs to the local spool), read from
@@ -56,4 +73,29 @@ pub(super) fn is_canonical_install() -> bool {
 pub(super) fn capture_disabled() -> bool {
     std::env::var("MERIDIAN_TELEMETRY_DISABLED")
         .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The daemon and the tray agree on the staged file name only by
+    /// convention — they are separate crates with no shared constant, and a
+    /// mismatch disables central error reporting on that platform silently
+    /// (nothing errors; the shipper simply resolves no target). Pins the name
+    /// to the platform's executable suffix on whichever OS the suite runs.
+    #[test]
+    fn staged_daemon_file_name_carries_the_platform_exe_suffix() {
+        let name = staged_daemon_file_name();
+        assert!(name.starts_with("meridian"), "unexpected stem: {name}");
+        assert!(
+            name.ends_with(std::env::consts::EXE_SUFFIX),
+            "{name} lacks this platform's executable suffix"
+        );
+        if cfg!(target_os = "windows") {
+            assert_eq!(name, "meridian.exe");
+        } else {
+            assert_eq!(name, "meridian");
+        }
+    }
 }

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -977,4 +977,32 @@ mod tests {
         // ...and distinct per machine, or grouping would be meaningless.
         assert_ne!(out, pseudonymize_host("someone-elses-imac.local"));
     }
+
+    /// Every other free-text case here is Unix-shaped, but Windows installs
+    /// ship through the identical scrubber. Two things differ there: the
+    /// username sits under `C:\Users\<name>`, and `\` is absent from the blob
+    /// character class (so backslash-separated paths can't reach the 32-char
+    /// blob threshold the way `/`-separated ones do).
+    #[test]
+    fn windows_paths_are_scrubbed_but_not_mangled() {
+        let msg = r"failed to open C:\Users\akarsh\AppData\Roaming\Meridian\settings.json";
+        let out = scrub_text(msg);
+        assert!(!out.contains("akarsh"), "Windows username leaked: {out}");
+        assert!(out.contains(r"C:\Users\<user>"), "structure lost: {out}");
+        assert!(
+            out.contains("settings.json"),
+            "path mangled by blob rule: {out}"
+        );
+
+        // The light scrub used for allowlisted identifier keys (e.g.
+        // `code.filepath`) must behave the same way.
+        assert!(!scrub_paths(msg).contains("akarsh"));
+
+        // A secret still dies whole even when a Windows path shares the line.
+        let with_secret =
+            r"C:\Users\akarsh\app.log token EXAMPLEKEYNOTAREALSECRETabcdefghijklmnop0123456789";
+        let out = scrub_text(with_secret);
+        assert!(out.contains("<redacted>"), "secret survived: {out}");
+        assert!(!out.contains("akarsh"), "username leaked: {out}");
+    }
 }


### PR DESCRIPTION
Split out of #584 (closed). Standalone and independently mergeable - no dependency on #586 or the error-coverage PR.

## Central error reporting has never worked on Windows

`is_canonical_install()` compared `current_exe()` against a hardcoded path:

```rust
exe == meridian_dir.join("bin").join("meridian")   // no suffix
```

The tray stages the Windows daemon as **`meridian.exe`** (`backend_install::DAEMON_FILE`, correctly cfg-gated on its side). So `current_exe()` ends in `.exe`, the comparison never matched, and `resolve_otlp_target()` fell through to the **DEV** branch - which requires `otlp_enabled` plus local OpenObserve credentials a packaged install never has. It resolved no target, so **no Windows install has ever shipped a single error record.**

Everything else on the Windows path was already correct: the release job bakes `MERIDIAN_CENTRAL_OTLP_ENDPOINT` and `MERIDIAN_CENTRAL_TELEMETRY_TOKEN` into `target/release/meridian.exe` exactly as the macOS job does. It was one absent suffix.

## Why it stayed invisible

Nothing failed loudly at either end. The shipper logs "no OTLP target configured" at `debug!`, spool files aged out under normal retention, and a backend cannot report traffic it never expected. The symptom is indistinguishable from "Windows users hit fewer errors".

It is also only visible reading two crates together - the tray's constant is correct and well-commented, the daemon's looks fine in isolation, they share no constant, and a mismatch is silent.

## Fix

Derived from `std::env::consts::EXE_SUFFIX` rather than a second cfg-selected constant, so the daemon cannot drift from the tray again if a platform is added. `staged_daemon_file_name_carries_the_platform_exe_suffix` pins the name against the platform suffix on whichever OS CI runs.

## Also: Windows coverage for the redaction suite

The suite was entirely Unix-shaped. Behaviour on Windows was already correct, but nothing pinned it, so `windows_paths_are_scrubbed_but_not_mangled` now asserts: `C:\Users\<name>` is scrubbed, the path survives the blob rule intact, and a secret sharing the line still dies whole.

Worth recording *why* it holds - `\` is **not** in the blob character class `[A-Za-z0-9+/=_\-]{32,}`, so backslash-separated paths cannot reach the 32-char threshold that was mangling `/`-separated ones before the #545 review fix. Windows paths are structurally safer here than Unix ones. `looks_like_path` covers drive letters independently.

## Impact

Windows telemetry starts flowing on the first release carrying this. Until then there is no Windows data at all, so on that release the specific thing to verify is that Windows installs appear - which needs `os.type` from #586 to be checkable at all.

## Verification

Daemon `fmt` + `clippy -D warnings` + full test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)