### PR TITLE
fix(observability): capture OCR/a11y failures and stop dropping error causes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,6 +367,30 @@ supported way to read logs locally, replacing the old JSONL-tailing UI and the
 old bash `meridian logs` (which used to tail launchd-redirected stdout/stderr
 text).
 
+**Two couplings that silently delete error coverage.** Both have bitten once;
+neither fails loudly, and neither is visible from the call site.
+
+1. **The `EnvFilter` decides what is captured at all — before the spool, before
+   severity, before redaction.** `EnvFilter` matches directives against targets
+   by string **prefix**, so the `meridian` directive covers `meridian_core::*`,
+   `meridian_tray_lib::*` and `meridian_oauth::*` for free — but nothing else.
+   Any crate whose target does not start with `meridian` is discarded entirely
+   unless named in `build_default_filter`. That is why `CAPTURE_DIRECTIVES`
+   exists (`screenpipe_screen`/`screenpipe_a11y` — the OCR + accessibility
+   stack, ~48 error sites that were invisible). **Adding a dependency that does
+   real work means adding its target there**, and auditing its `warn!`/`error!`
+   bodies first: third-party crates were written to print to a terminal and may
+   interpolate content that must never egress.
+2. **The attribute allowlist is keyed on the names you actually type.**
+   `tracing::warn!(error = %e, …)` emits the attribute key `error`, not the
+   semconv `error.message`. Anything not on `redact::SAFE_STRING_KEYS` is
+   dropped from the ship leg, so a well-instrumented error can arrive as a bare
+   static string with its cause stripped. When adding a field to a WARN/ERROR
+   site that you would need in order to debug it remotely, check it is on that
+   list — and if it names the user's data (ticket key, file path, app name,
+   window title, hour/day) it must stay off, so put the diagnostic value in the
+   message or an allowlisted key instead.
+
 The only thing this pipeline structurally can't capture is a hard crash
 (panic before `init` runs, segfault, OOM kill) — for that, launchd's own
 stdout/stderr redirect (`~/.meridian/logs/<service>.log` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,12 +375,13 @@ neither fails loudly, and neither is visible from the call site.
    by string **prefix**, so the `meridian` directive covers `meridian_core::*`,
    `meridian_tray_lib::*` and `meridian_oauth::*` for free — but nothing else.
    Any crate whose target does not start with `meridian` is discarded entirely
-   unless named in `build_default_filter`. That is why `CAPTURE_DIRECTIVES`
-   exists (`screenpipe_screen`/`screenpipe_a11y` — the OCR + accessibility
-   stack, ~48 error sites that were invisible). **Adding a dependency that does
-   real work means adding its target there**, and auditing its `warn!`/`error!`
-   bodies first: third-party crates were written to print to a terminal and may
-   interpolate content that must never egress.
+   unless named in `observability::filter`. That is why `CAPTURE_TARGETS` exists
+   (`screenpipe_screen`/`screenpipe_a11y` — the OCR + accessibility stack, ~48
+   error sites that were invisible). **Adding a dependency that does real work
+   means adding its bare crate name to that list** — every log level then picks
+   it up automatically — and auditing its `warn!`/`error!` bodies first:
+   third-party crates were written to print to a terminal and may interpolate
+   content that must never egress.
 2. **The attribute allowlist is keyed on the names you actually type.**
    `tracing::warn!(error = %e, …)` emits the attribute key `error`, not the
    semconv `error.message`. Anything not on `redact::SAFE_STRING_KEYS` is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,13 +400,34 @@ spans egress at all, and `host.name` is replaced by a stable **pseudonym**
 macOS is routinely the account holder's real name. The tray's Sentry
 `before_send` applies the identical pseudonym to `event.server_name`.
 
+That pseudonym is the ONLY identifier on an error row — nothing associates it
+with an account, and the hash is one-way. So it is surfaced to the user as
+**Support ID** (Settings → Account, and `bundle-info.txt` inside an export
+bundle), which is what makes a support ticket traceable to its error rows at
+all. Both the displayed value and the shipped one come from
+`redact::local_host_pseudonym` **on purpose** — computing either side
+separately would let them drift, and the user would quote an ID matching
+nothing, silently (`displayed_pseudonym_matches_shipped` pins this).
+
+**Which resource attributes actually ship** is a separate question from the
+allowlist, and the two are easy to confuse: `redact::SAFE_STRING_KEYS` lists
+many keys that nothing populates (`service.instance.id`, `os.version`,
+`app.version`, …). `observability::init`'s `Resource::new` sets exactly:
+`service.name`, `service.version`, `host.name`, `deployment.environment`,
+`os.type`, `host.arch`, `app.install_mode` — and `Resource::new` runs NO
+detectors, so the SDK contributes nothing either. **Allowlisted ≠ present:
+before relying on an attribute in a query or dashboard, check it is set here.**
+
 **Export Diagnostics remains the manual path**, unchanged and independent of
 consent: tray Settings → Account → **Export Diagnostics** (or `meridian
 telemetry export`) bundles the spool + the launchd crash-safety-net logs into
 a `.tar.gz` the user hands to support, imported by hand with `meridian
-telemetry import <bundle> --endpoint <url> --auth <base64>`. Retention
-(default 7 days, `MERIDIAN_TELEMETRY_RETENTION_DAYS`) applies to both
-`pending/` and `sent/`, regardless of shipping status.
+telemetry import <bundle> --endpoint <url> --auth <base64>`. The bundle also
+carries a synthesized `bundle-info.txt` (Support ID, version, channel, os,
+arch) so a hand-delivered archive can be joined to that machine's already-
+ingested rows; it deliberately contains nothing the automatic ship leg wouldn't
+already send. Retention (default 7 days, `MERIDIAN_TELEMETRY_RETENTION_DAYS`)
+applies to both `pending/` and `sent/`, regardless of shipping status.
 
 - **Rust**: `tracing::info!/warn!/error!/debug!` with **structured fields** — never format data values into the message string (already enforced).
 - **Wrap discrete operations in spans** (`tracing::info_span!` / `debug_span!`) and put the meaningful inputs, outputs, and metrics as **span attributes**, not buried in log lines. For an LLM/model call, capture the EXACT input as sent and output as received (post-cap/post-template — reflect any truncation that actually happened), plus real token counts/latency. See `src/llm/resolver.rs`'s `llm.call` span tree (request → infer → response) and `src/worklog_pipeline/distiller`'s `distil.run` span for the reference shape.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,11 +412,14 @@ nothing, silently (`displayed_pseudonym_matches_shipped` pins this).
 **Which resource attributes actually ship** is a separate question from the
 allowlist, and the two are easy to confuse: `redact::SAFE_STRING_KEYS` lists
 many keys that nothing populates (`service.instance.id`, `os.version`,
-`app.version`, …). `observability::init`'s `Resource::new` sets exactly:
-`service.name`, `service.version`, `host.name`, `deployment.environment`,
-`os.type`, `host.arch`, `app.install_mode` — and `Resource::new` runs NO
+`app.version`, `app.install_mode`, …). `observability::init`'s `Resource::new`
+sets exactly: `service.name`, `service.version`, `host.name`,
+`deployment.environment`, `os.type`, `host.arch` — and `Resource::new` runs NO
 detectors, so the SDK contributes nothing either. **Allowlisted ≠ present:
 before relying on an attribute in a query or dashboard, check it is set here.**
+Note `observability::init` runs in BOTH the daemon and the tray, so any
+attribute added there must be correct for both — `app.install_mode` is
+deliberately left unset for exactly this reason (see the comment there).
 
 **Export Diagnostics remains the manual path**, unchanged and independent of
 consent: tray Settings → Account → **Export Diagnostics** (or `meridian

--- a/src/observability/filter.rs
+++ b/src/observability/filter.rs
@@ -1,0 +1,245 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Which targets get captured at all — the `EnvFilter` the subscriber is built
+//! with, and the hot-reload handle that swaps it at runtime.
+//!
+//! Split out of `observability/mod.rs` (over the repo's 500-line cap once the
+//! capture directives landed), the same way `install_mode.rs` and
+//! `otlp_target.rs` were: "what may be captured" is a self-contained question,
+//! independent of the subscriber/exporter wiring the parent module owns.
+//!
+//! # Why this is load-bearing
+//! This filter runs BEFORE the spool, before the severity filter, and before
+//! redaction. Anything it drops does not exist anywhere: not shipped, not in
+//! `meridian logs`, not in an export bundle. That is not a theoretical concern
+//! — see [`CAPTURE_TARGETS`] for the ~48 OCR/accessibility error sites it was
+//! silently discarding.
+//!
+//! # Who calls this
+//! - `observability::init` — builds the initial filter from `RUST_LOG`, else
+//!   [`build_default_filter`] over `settings.log_level`.
+//! - The daemon poll loop — [`reload_log_level`] when the setting changes.
+
+use std::sync::OnceLock;
+use tracing_subscriber::{reload, EnvFilter};
+
+/// Type alias for the hot-reload handle. The `S = Registry` parameter reflects
+/// that the reload layer is installed directly on `tracing_subscriber::Registry`
+/// (it is the first layer added, before any OTel or fmt layers).
+pub(super) type FilterHandle = reload::Handle<EnvFilter, tracing_subscriber::Registry>;
+
+/// Global handle for hot-reloading the `EnvFilter` without restarting the daemon.
+/// Set once during `init()`; accessed from the poll loop via [`reload_log_level`].
+pub(super) static FILTER_HANDLE: OnceLock<FilterHandle> = OnceLock::new();
+
+/// Third-party crate targets that must be captured explicitly, because nothing
+/// else in the filter reaches them.
+///
+/// # Why these need naming at all
+/// `EnvFilter` matches a directive against a target by string prefix, so the
+/// `meridian` directive happens to cover `meridian_core::*`,
+/// `meridian_tray_lib::*` and `meridian_oauth::*` too — every first-party
+/// target starts with those bytes. The in-process capture crates do NOT
+/// (`screenpipe_screen::*`, `screenpipe_a11y::*`), so every one of their ~48
+/// `warn!`/`error!` sites was discarded at the subscriber. OCR and
+/// accessibility failures — screen-capture bail-outs, Apple Vision handler
+/// creation, `AXObserver`/`CGEventTap` registration, monitor enumeration — were
+/// structurally invisible. Since capture is the daemon's only data source, a
+/// silent failure there looks downstream like "the user did nothing today".
+///
+/// # Privacy
+/// Audited every `warn!`/`error!` site in both crates before enabling: all are
+/// infrastructure failures (monitor ids, image dimensions, word counts, error
+/// `Display`s). None interpolates a window title, app name, URL, or OCR text.
+/// **Re-audit if the fork's revision is bumped** — this is exactly the class of
+/// change that could start shipping captured content.
+///
+/// # Adding to this list
+/// Add the bare target (crate) name here and every log level picks it up
+/// automatically. It is deliberately a list of names rather than a formatted
+/// directive string: the level varies per branch in [`build_default_filter`],
+/// and hardcoding the pairs in each branch is how a new entry silently ends up
+/// with no coverage at one level.
+const CAPTURE_TARGETS: &[&str] = &["screenpipe_screen", "screenpipe_a11y"];
+
+/// Render [`CAPTURE_TARGETS`] as `EnvFilter` directives at `level`.
+fn capture_directives(level: &str) -> String {
+    CAPTURE_TARGETS
+        .iter()
+        .map(|t| format!("{t}={level}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// Map the settings.json `log_level` value (DEBUG/INFO/WARNING/ERROR) to a
+/// tracing `EnvFilter` string. Used at startup and on hot-reload, when
+/// `RUST_LOG` is not set.
+///
+/// The capture stack is pinned at `warn` regardless of the first-party level:
+/// these are third-party crates written for a CLI that printed to a terminal,
+/// so their INFO/DEBUG volume is unaudited and runs at frame cadence — `warn`
+/// takes the failures without the chatter. The one exception is `ERROR`, where
+/// the user has asked for errors only and that is honoured everywhere.
+///
+/// Note `RUST_LOG` REPLACES this wholesale rather than extending it, so an
+/// engineer who sets it also opts out of [`CAPTURE_TARGETS`] and must re-add
+/// them by hand to see capture failures.
+pub(super) fn build_default_filter(log_level: &str) -> String {
+    let (base, capture_level) = match log_level.to_uppercase().as_str() {
+        "DEBUG" => ("meridian=debug,sqlx=warn", "warn"),
+        "WARNING" | "WARN" => ("meridian=warn,sqlx=warn", "warn"),
+        "ERROR" => ("meridian=error,sqlx=error", "error"),
+        // INFO or anything else: keep the previous fixed default with module-level overrides.
+        // `embedder=debug` surfaces the model-load/batch spans (embedder/mod.rs) at the
+        // production default — the same treatment etl/intelligence already get — since
+        // the embedder is on the critical path for every hour's distillation and its
+        // timing is exactly what a `DISTILLER_EMBED_TIMEOUT_SECS` investigation needs.
+        _ => (
+            "meridian=info,meridian::etl=debug,meridian::intelligence=debug,meridian::embedder=debug,sqlx=warn",
+            "warn",
+        ),
+    };
+    format!("{base},{}", capture_directives(capture_level))
+}
+
+/// Hot-reload the log level filter without restarting the daemon.
+///
+/// Called from the poll loop whenever `settings.log_level` changes. Returns
+/// `true` if the filter was updated, `false` if RUST_LOG is set (we don't
+/// fight explicit env-var overrides) or the handle isn't initialised yet.
+pub fn reload_log_level(level: &str) -> bool {
+    // Respect explicit RUST_LOG override — don't fight the user's env var.
+    if std::env::var("RUST_LOG").is_ok() {
+        return false;
+    }
+    let Some(handle) = FILTER_HANDLE.get() else {
+        return false;
+    };
+    let filter_str = build_default_filter(level);
+    match filter_str.parse::<EnvFilter>() {
+        Ok(new_filter) => handle.modify(|f| *f = new_filter).is_ok(),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::{layer::SubscriberExt, Layer};
+
+    /// Records the target of every event the filter lets through.
+    struct Recorder(Arc<Mutex<Vec<String>>>);
+
+    impl<S: tracing::Subscriber> Layer<S> for Recorder {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            self.0
+                .lock()
+                .unwrap()
+                .push(event.metadata().target().to_string());
+        }
+    }
+
+    /// Run `f` under `filter` and return the targets that survived.
+    fn targets_passing(filter: &str, f: impl FnOnce()) -> Vec<String> {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::new(filter))
+            .with(Recorder(Arc::clone(&seen)));
+        tracing::subscriber::with_default(subscriber, f);
+        let out = seen.lock().unwrap().clone();
+        out
+    }
+
+    fn emit_all() {
+        tracing::warn!(target: "screenpipe_screen::core", "ocr failed");
+        tracing::warn!(target: "screenpipe_a11y::observer", "axobserver failed");
+        tracing::info!(target: "meridian::etl::runner", "etl ok");
+        tracing::info!(target: "meridian_core::readers::tasks", "read ok");
+        tracing::info!(target: "meridian_tray_lib::commands::health", "health ok");
+        tracing::warn!(target: "reqwest::connect", "noisy third party");
+    }
+
+    /// The bug this guards: `EnvFilter` matches directives against targets by
+    /// string PREFIX, so `meridian` silently covers `meridian_core` and
+    /// `meridian_tray_lib` — but nothing covered `screenpipe_*`, so every OCR
+    /// and accessibility failure was dropped at the subscriber. Asserts the
+    /// negative on the old filter and the positive on the new one, since the
+    /// whole finding rests on that asymmetry.
+    #[test]
+    fn capture_targets_pass_only_with_the_capture_directives() {
+        let old = "meridian=info,sqlx=warn";
+        let passed = targets_passing(old, emit_all);
+        assert!(
+            !passed.iter().any(|t| t.starts_with("screenpipe")),
+            "regression check is meaningless if the old filter already passed capture: {passed:?}"
+        );
+        // ...while first-party targets DID pass on prefix alone.
+        assert!(passed.iter().any(|t| t.starts_with("meridian_core")));
+        assert!(passed.iter().any(|t| t.starts_with("meridian_tray_lib")));
+
+        let passed = targets_passing(&build_default_filter("INFO"), emit_all);
+        assert!(
+            passed.iter().any(|t| t == "screenpipe_screen::core"),
+            "OCR failures still dropped at the subscriber: {passed:?}"
+        );
+        assert!(
+            passed.iter().any(|t| t == "screenpipe_a11y::observer"),
+            "accessibility failures still dropped at the subscriber: {passed:?}"
+        );
+        // Unrelated third-party crates must stay out — this widens the filter
+        // deliberately and narrowly, not globally.
+        assert!(
+            !passed.iter().any(|t| t.starts_with("reqwest")),
+            "filter widened beyond the capture stack: {passed:?}"
+        );
+    }
+
+    /// EVERY entry in `CAPTURE_TARGETS` must be covered at EVERY log level.
+    ///
+    /// Deliberately iterates the constant rather than naming crates: an earlier
+    /// revision hardcoded the pairs in the `ERROR` branch, so a target added to
+    /// the list would have had no coverage at that one level while working
+    /// everywhere else — and a test written against literal names stays green
+    /// through exactly that drift.
+    #[test]
+    fn every_capture_target_is_covered_at_every_log_level() {
+        for level in ["DEBUG", "INFO", "WARNING", "ERROR", "nonsense"] {
+            let f = build_default_filter(level);
+            for target in CAPTURE_TARGETS {
+                assert!(
+                    f.contains(&format!("{target}=")),
+                    "{level} filter has no directive for {target}: {f}"
+                );
+            }
+            // A directive can be present and still not admit an ERROR (e.g. set
+            // to `off`), so also assert on behaviour, not just on the string.
+            //
+            // These two targets are spelled out because `tracing::error!`
+            // requires a literal target — the loop above is the part that
+            // actually scales with `CAPTURE_TARGETS`, and is what catches a
+            // newly added entry losing coverage at one level.
+            let passed = targets_passing(&f, || {
+                tracing::error!(target: "screenpipe_screen::core", "hard failure");
+                tracing::error!(target: "screenpipe_a11y::observer", "hard failure");
+            });
+            assert_eq!(passed.len(), 2, "{level} dropped a capture ERROR: {f}");
+        }
+    }
+
+    /// At ERROR the user asked for errors only, and that must apply to the
+    /// capture stack too rather than forcing its warnings through.
+    #[test]
+    fn error_level_suppresses_capture_warnings() {
+        let passed = targets_passing(&build_default_filter("ERROR"), || {
+            tracing::warn!(target: "screenpipe_screen::core", "noisy per-frame warn");
+        });
+        assert!(
+            passed.is_empty(),
+            "ERROR level let a WARN through: {passed:?}"
+        );
+    }
+}

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -72,25 +72,18 @@ use opentelemetry_sdk::{
 };
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::OnceLock;
 use tracing_subscriber::{layer::SubscriberExt, reload, util::SubscriberInitExt, EnvFilter};
 
+mod filter;
 mod install_mode;
 mod otlp_target;
+pub use filter::reload_log_level;
+use filter::{build_default_filter, FILTER_HANDLE};
 use install_mode::capture_disabled;
 use otlp_target::DEFAULT_OTLP_ENDPOINT;
 pub use otlp_target::{
     is_otlp_configured, resolve_otlp_endpoint, resolve_otlp_target, AuthCredential, OtlpTarget,
 };
-
-/// Type alias for the hot-reload handle. The `S = Registry` parameter reflects
-/// that the reload layer is installed directly on `tracing_subscriber::Registry`
-/// (it is the first layer added, before any OTel or fmt layers).
-type FilterHandle = reload::Handle<EnvFilter, tracing_subscriber::Registry>;
-
-/// Global handle for hot-reloading the `EnvFilter` without restarting the daemon.
-/// Set once during `init()`; accessed from the poll loop via `reload_log_level()`.
-static FILTER_HANDLE: OnceLock<FilterHandle> = OnceLock::new();
 
 /// RAII guard returned from [`init`]. Holds (when OTel is enabled) the logger
 /// provider for graceful shutdown.
@@ -389,79 +382,6 @@ fn try_build_otel_providers(
     Ok(Some((tracer, tracer_provider, logger_provider)))
 }
 
-/// Capture-stack directives, appended to every filter built below.
-///
-/// # Why these need naming explicitly
-/// `EnvFilter` matches a directive against a target by string prefix, so the
-/// `meridian` directive happens to cover `meridian_core::*`,
-/// `meridian_tray_lib::*` and `meridian_oauth::*` too — every first-party
-/// target starts with those bytes. The in-process capture crates do NOT
-/// (`screenpipe_screen::*`, `screenpipe_a11y::*`), so every one of their ~48
-/// `warn!`/`error!` sites was discarded **at the subscriber**, before the
-/// spool, before the severity filter, before redaction. OCR and accessibility
-/// failures — screen-capture bail-outs, Apple Vision handler creation,
-/// `AXObserver`/`CGEventTap` registration, monitor enumeration — were
-/// structurally invisible: not shipped, not in `meridian logs`, not in an
-/// export bundle. Since capture is the daemon's only data source, a silent
-/// failure there looks downstream like "the user did nothing today".
-///
-/// # Why `warn` and not `debug`
-/// These are third-party crates written for a CLI that printed to a terminal;
-/// their INFO/DEBUG volume is unaudited and runs at frame cadence. `warn`
-/// takes the failures without the chatter.
-///
-/// # Privacy
-/// Audited every `warn!`/`error!` site in both crates before enabling: all are
-/// infrastructure failures (monitor ids, image dimensions, word counts, error
-/// `Display`s). None interpolates a window title, app name, URL, or OCR text.
-/// Re-audit if the fork's revision is bumped — this is exactly the class of
-/// change that could start shipping captured content.
-const CAPTURE_DIRECTIVES: &str = "screenpipe_screen=warn,screenpipe_a11y=warn";
-
-/// Map the settings.json `log_level` value (DEBUG/INFO/WARNING/ERROR) to a
-/// tracing `EnvFilter` string. Used at startup and on hot-reload, when
-/// `RUST_LOG` is not set.
-///
-/// Note `RUST_LOG` REPLACES this wholesale rather than extending it, so an
-/// engineer who sets it also opts out of [`CAPTURE_DIRECTIVES`] and must
-/// re-add them by hand to see capture failures.
-fn build_default_filter(log_level: &str) -> String {
-    let base = match log_level.to_uppercase().as_str() {
-        "DEBUG" => "meridian=debug,sqlx=warn",
-        "WARNING" | "WARN" => "meridian=warn,sqlx=warn",
-        // At ERROR the user has asked for errors only; honour that for the
-        // capture stack too rather than forcing its warnings through.
-        "ERROR" => return "meridian=error,sqlx=error,screenpipe_screen=error,screenpipe_a11y=error".to_string(),
-        // INFO or anything else: keep the previous fixed default with module-level overrides.
-        // `embedder=debug` surfaces the model-load/batch spans (embedder/mod.rs) at the
-        // production default — the same treatment etl/intelligence already get — since
-        // the embedder is on the critical path for every hour's distillation and its
-        // timing is exactly what a `DISTILLER_EMBED_TIMEOUT_SECS` investigation needs.
-        _ => "meridian=info,meridian::etl=debug,meridian::intelligence=debug,meridian::embedder=debug,sqlx=warn",
-    };
-    format!("{base},{CAPTURE_DIRECTIVES}")
-}
-
-/// Hot-reload the log level filter without restarting the daemon.
-///
-/// Called from the poll loop whenever `settings.log_level` changes. Returns
-/// `true` if the filter was updated, `false` if RUST_LOG is set (we don't
-/// fight explicit env-var overrides) or the handle isn't initialised yet.
-pub fn reload_log_level(level: &str) -> bool {
-    // Respect explicit RUST_LOG override — don't fight the user's env var.
-    if std::env::var("RUST_LOG").is_ok() {
-        return false;
-    }
-    let Some(handle) = FILTER_HANDLE.get() else {
-        return false;
-    };
-    let filter_str = build_default_filter(level);
-    match filter_str.parse::<EnvFilter>() {
-        Ok(new_filter) => handle.modify(|f| *f = new_filter).is_ok(),
-        Err(_) => false,
-    }
-}
-
 /// `~/.meridian/logs/` — where launchd redirects each service's raw
 /// stdout/stderr (`daemon.log`, `tray.log`, etc. — see each service's
 /// `com.meridiona.*.plist`). No longer written to by `tracing`/`logging`
@@ -524,99 +444,4 @@ pub fn span_context_from_traceparent(
     let cx = TraceContextPropagator::new().extract(&StringExtractor(traceparent));
     let sc = cx.span().span_context().clone();
     sc.is_valid().then_some(sc)
-}
-
-#[cfg(test)]
-mod filter_tests {
-    use super::*;
-    use std::sync::{Arc, Mutex};
-    use tracing_subscriber::Layer;
-
-    /// Records the target of every event the filter lets through.
-    struct Recorder(Arc<Mutex<Vec<String>>>);
-
-    impl<S: tracing::Subscriber> Layer<S> for Recorder {
-        fn on_event(
-            &self,
-            event: &tracing::Event<'_>,
-            _ctx: tracing_subscriber::layer::Context<'_, S>,
-        ) {
-            self.0
-                .lock()
-                .unwrap()
-                .push(event.metadata().target().to_string());
-        }
-    }
-
-    /// Run `f` under `filter` and return the targets that survived.
-    fn targets_passing(filter: &str, f: impl FnOnce()) -> Vec<String> {
-        let seen = Arc::new(Mutex::new(Vec::new()));
-        let subscriber = tracing_subscriber::registry()
-            .with(EnvFilter::new(filter))
-            .with(Recorder(Arc::clone(&seen)));
-        tracing::subscriber::with_default(subscriber, f);
-        let out = seen.lock().unwrap().clone();
-        out
-    }
-
-    fn emit_all() {
-        tracing::warn!(target: "screenpipe_screen::core", "ocr failed");
-        tracing::warn!(target: "screenpipe_a11y::observer", "axobserver failed");
-        tracing::info!(target: "meridian::etl::runner", "etl ok");
-        tracing::info!(target: "meridian_core::readers::tasks", "read ok");
-        tracing::info!(target: "meridian_tray_lib::commands::health", "health ok");
-        tracing::warn!(target: "reqwest::connect", "noisy third party");
-    }
-
-    /// The bug this guards: `EnvFilter` matches directives against targets by
-    /// string PREFIX, so `meridian` silently covers `meridian_core` and
-    /// `meridian_tray_lib` — but nothing covered `screenpipe_*`, so every OCR
-    /// and accessibility failure was dropped at the subscriber. Asserts the
-    /// negative on the old filter and the positive on the new one, since the
-    /// whole finding rests on that asymmetry.
-    #[test]
-    fn capture_targets_pass_only_with_the_capture_directives() {
-        let old = "meridian=info,sqlx=warn";
-        let passed = targets_passing(old, emit_all);
-        assert!(
-            !passed.iter().any(|t| t.starts_with("screenpipe")),
-            "regression check is meaningless if the old filter already passed capture: {passed:?}"
-        );
-        // ...while first-party targets DID pass on prefix alone.
-        assert!(passed.iter().any(|t| t.starts_with("meridian_core")));
-        assert!(passed.iter().any(|t| t.starts_with("meridian_tray_lib")));
-
-        let passed = targets_passing(&build_default_filter("INFO"), emit_all);
-        assert!(
-            passed.iter().any(|t| t == "screenpipe_screen::core"),
-            "OCR failures still dropped at the subscriber: {passed:?}"
-        );
-        assert!(
-            passed.iter().any(|t| t == "screenpipe_a11y::observer"),
-            "accessibility failures still dropped at the subscriber: {passed:?}"
-        );
-        // Unrelated third-party crates must stay out — this widens the filter
-        // deliberately and narrowly, not globally.
-        assert!(
-            !passed.iter().any(|t| t.starts_with("reqwest")),
-            "filter widened beyond the capture stack: {passed:?}"
-        );
-    }
-
-    /// Capture failures must survive every log level a user can select, or the
-    /// coverage depends on a setting nobody associates with capture.
-    #[test]
-    fn capture_directives_present_at_every_log_level() {
-        for level in ["DEBUG", "INFO", "WARNING", "ERROR", "nonsense"] {
-            let f = build_default_filter(level);
-            assert!(
-                f.contains("screenpipe_screen") && f.contains("screenpipe_a11y"),
-                "{level} filter drops the capture stack: {f}"
-            );
-            let passed = targets_passing(&f, || {
-                tracing::error!(target: "screenpipe_screen::core", "hard failure");
-            });
-            assert_eq!(passed.len(), 1, "{level} dropped a capture ERROR: {f}");
-        }
-    }
 }

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -389,21 +389,57 @@ fn try_build_otel_providers(
     Ok(Some((tracer, tracer_provider, logger_provider)))
 }
 
+/// Capture-stack directives, appended to every filter built below.
+///
+/// # Why these need naming explicitly
+/// `EnvFilter` matches a directive against a target by string prefix, so the
+/// `meridian` directive happens to cover `meridian_core::*`,
+/// `meridian_tray_lib::*` and `meridian_oauth::*` too — every first-party
+/// target starts with those bytes. The in-process capture crates do NOT
+/// (`screenpipe_screen::*`, `screenpipe_a11y::*`), so every one of their ~48
+/// `warn!`/`error!` sites was discarded **at the subscriber**, before the
+/// spool, before the severity filter, before redaction. OCR and accessibility
+/// failures — screen-capture bail-outs, Apple Vision handler creation,
+/// `AXObserver`/`CGEventTap` registration, monitor enumeration — were
+/// structurally invisible: not shipped, not in `meridian logs`, not in an
+/// export bundle. Since capture is the daemon's only data source, a silent
+/// failure there looks downstream like "the user did nothing today".
+///
+/// # Why `warn` and not `debug`
+/// These are third-party crates written for a CLI that printed to a terminal;
+/// their INFO/DEBUG volume is unaudited and runs at frame cadence. `warn`
+/// takes the failures without the chatter.
+///
+/// # Privacy
+/// Audited every `warn!`/`error!` site in both crates before enabling: all are
+/// infrastructure failures (monitor ids, image dimensions, word counts, error
+/// `Display`s). None interpolates a window title, app name, URL, or OCR text.
+/// Re-audit if the fork's revision is bumped — this is exactly the class of
+/// change that could start shipping captured content.
+const CAPTURE_DIRECTIVES: &str = "screenpipe_screen=warn,screenpipe_a11y=warn";
+
 /// Map the settings.json `log_level` value (DEBUG/INFO/WARNING/ERROR) to a
 /// tracing `EnvFilter` string. Used at startup and on hot-reload, when
 /// `RUST_LOG` is not set.
+///
+/// Note `RUST_LOG` REPLACES this wholesale rather than extending it, so an
+/// engineer who sets it also opts out of [`CAPTURE_DIRECTIVES`] and must
+/// re-add them by hand to see capture failures.
 fn build_default_filter(log_level: &str) -> String {
-    match log_level.to_uppercase().as_str() {
-        "DEBUG" => "meridian=debug,sqlx=warn".to_string(),
-        "WARNING" | "WARN" => "meridian=warn,sqlx=warn".to_string(),
-        "ERROR" => "meridian=error,sqlx=error".to_string(),
+    let base = match log_level.to_uppercase().as_str() {
+        "DEBUG" => "meridian=debug,sqlx=warn",
+        "WARNING" | "WARN" => "meridian=warn,sqlx=warn",
+        // At ERROR the user has asked for errors only; honour that for the
+        // capture stack too rather than forcing its warnings through.
+        "ERROR" => return "meridian=error,sqlx=error,screenpipe_screen=error,screenpipe_a11y=error".to_string(),
         // INFO or anything else: keep the previous fixed default with module-level overrides.
         // `embedder=debug` surfaces the model-load/batch spans (embedder/mod.rs) at the
         // production default — the same treatment etl/intelligence already get — since
         // the embedder is on the critical path for every hour's distillation and its
         // timing is exactly what a `DISTILLER_EMBED_TIMEOUT_SECS` investigation needs.
-        _ => "meridian=info,meridian::etl=debug,meridian::intelligence=debug,meridian::embedder=debug,sqlx=warn".to_string(),
-    }
+        _ => "meridian=info,meridian::etl=debug,meridian::intelligence=debug,meridian::embedder=debug,sqlx=warn",
+    };
+    format!("{base},{CAPTURE_DIRECTIVES}")
 }
 
 /// Hot-reload the log level filter without restarting the daemon.
@@ -488,4 +524,99 @@ pub fn span_context_from_traceparent(
     let cx = TraceContextPropagator::new().extract(&StringExtractor(traceparent));
     let sc = cx.span().span_context().clone();
     sc.is_valid().then_some(sc)
+}
+
+#[cfg(test)]
+mod filter_tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::Layer;
+
+    /// Records the target of every event the filter lets through.
+    struct Recorder(Arc<Mutex<Vec<String>>>);
+
+    impl<S: tracing::Subscriber> Layer<S> for Recorder {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            self.0
+                .lock()
+                .unwrap()
+                .push(event.metadata().target().to_string());
+        }
+    }
+
+    /// Run `f` under `filter` and return the targets that survived.
+    fn targets_passing(filter: &str, f: impl FnOnce()) -> Vec<String> {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::new(filter))
+            .with(Recorder(Arc::clone(&seen)));
+        tracing::subscriber::with_default(subscriber, f);
+        let out = seen.lock().unwrap().clone();
+        out
+    }
+
+    fn emit_all() {
+        tracing::warn!(target: "screenpipe_screen::core", "ocr failed");
+        tracing::warn!(target: "screenpipe_a11y::observer", "axobserver failed");
+        tracing::info!(target: "meridian::etl::runner", "etl ok");
+        tracing::info!(target: "meridian_core::readers::tasks", "read ok");
+        tracing::info!(target: "meridian_tray_lib::commands::health", "health ok");
+        tracing::warn!(target: "reqwest::connect", "noisy third party");
+    }
+
+    /// The bug this guards: `EnvFilter` matches directives against targets by
+    /// string PREFIX, so `meridian` silently covers `meridian_core` and
+    /// `meridian_tray_lib` — but nothing covered `screenpipe_*`, so every OCR
+    /// and accessibility failure was dropped at the subscriber. Asserts the
+    /// negative on the old filter and the positive on the new one, since the
+    /// whole finding rests on that asymmetry.
+    #[test]
+    fn capture_targets_pass_only_with_the_capture_directives() {
+        let old = "meridian=info,sqlx=warn";
+        let passed = targets_passing(old, emit_all);
+        assert!(
+            !passed.iter().any(|t| t.starts_with("screenpipe")),
+            "regression check is meaningless if the old filter already passed capture: {passed:?}"
+        );
+        // ...while first-party targets DID pass on prefix alone.
+        assert!(passed.iter().any(|t| t.starts_with("meridian_core")));
+        assert!(passed.iter().any(|t| t.starts_with("meridian_tray_lib")));
+
+        let passed = targets_passing(&build_default_filter("INFO"), emit_all);
+        assert!(
+            passed.iter().any(|t| t == "screenpipe_screen::core"),
+            "OCR failures still dropped at the subscriber: {passed:?}"
+        );
+        assert!(
+            passed.iter().any(|t| t == "screenpipe_a11y::observer"),
+            "accessibility failures still dropped at the subscriber: {passed:?}"
+        );
+        // Unrelated third-party crates must stay out — this widens the filter
+        // deliberately and narrowly, not globally.
+        assert!(
+            !passed.iter().any(|t| t.starts_with("reqwest")),
+            "filter widened beyond the capture stack: {passed:?}"
+        );
+    }
+
+    /// Capture failures must survive every log level a user can select, or the
+    /// coverage depends on a setting nobody associates with capture.
+    #[test]
+    fn capture_directives_present_at_every_log_level() {
+        for level in ["DEBUG", "INFO", "WARNING", "ERROR", "nonsense"] {
+            let f = build_default_filter(level);
+            assert!(
+                f.contains("screenpipe_screen") && f.contains("screenpipe_a11y"),
+                "{level} filter drops the capture stack: {f}"
+            );
+            let passed = targets_passing(&f, || {
+                tracing::error!(target: "screenpipe_screen::core", "hard failure");
+            });
+            assert_eq!(passed.len(), 1, "{level} dropped a capture ERROR: {f}");
+        }
+    }
 }

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -316,6 +316,33 @@ fn try_build_otel_providers(
             "deployment.environment",
             option_env!("MERIDIAN_CHANNEL").unwrap_or("dev"),
         ),
+        // Platform shape. Without these, a Windows error and a macOS error are
+        // indistinguishable in the central backend — every attribute above is
+        // OS-agnostic, and the SDK adds nothing of its own (`Resource::new`
+        // runs no detectors, unlike `Resource::default`). All three are already
+        // on `redact::SAFE_STRING_KEYS`, so populating them needs no change to
+        // the redaction boundary: they are enum-like build facts that
+        // structurally cannot carry user content.
+        //
+        // Deliberately the RAW Rust constants ("macos"/"windows", "aarch64"/
+        // "x86_64") rather than the OTel semconv spellings ("darwin", "arm64").
+        // Nothing downstream parses these as semconv enums, and a translation
+        // layer is one more place to introduce a silent mismatch between what
+        // the code says and what the dashboards filter on.
+        KeyValue::new("os.type", std::env::consts::OS),
+        KeyValue::new("host.arch", std::env::consts::ARCH),
+        // Separates errors from a real packaged install from a developer's
+        // `cargo run`, which otherwise differ only by `deployment.environment`
+        // — and that reports "dev" for BOTH a source build and any build whose
+        // channel env was unset, so it can't carry this distinction alone.
+        KeyValue::new(
+            "app.install_mode",
+            if install_mode::is_canonical_install() {
+                "packaged"
+            } else {
+                "source"
+            },
+        ),
     ]);
 
     // Build spool clients — one per signal so filenames encode the correct prefix.

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -331,18 +331,17 @@ fn try_build_otel_providers(
         // the code says and what the dashboards filter on.
         KeyValue::new("os.type", std::env::consts::OS),
         KeyValue::new("host.arch", std::env::consts::ARCH),
-        // Separates errors from a real packaged install from a developer's
-        // `cargo run`, which otherwise differ only by `deployment.environment`
-        // — and that reports "dev" for BOTH a source build and any build whose
-        // channel env was unset, so it can't carry this distinction alone.
-        KeyValue::new(
-            "app.install_mode",
-            if install_mode::is_canonical_install() {
-                "packaged"
-            } else {
-                "source"
-            },
-        ),
+        // NOT setting `app.install_mode` here, deliberately — it is on
+        // `redact::SAFE_STRING_KEYS` and looks tempting. The only available
+        // signal is `is_canonical_install()`, which compares `current_exe()`
+        // against `~/.meridian/bin/meridian`. That is a DAEMON-shaped test, and
+        // this function also runs in the tray (`lib.rs` calls
+        // `observability::init("meridian-tray")` unconditionally), whose exe
+        // lives in the `.app` bundle — so every tray row on a fully packaged
+        // install would be labelled "source". A wrong platform attribute is
+        // worse than an absent one; it gets trusted in a dashboard filter.
+        // `deployment.environment` already separates source builds ("dev") from
+        // released ones, which is the distinction that was actually wanted.
     ]);
 
     // Build spool clients — one per signal so filenames encode the correct prefix.

--- a/src/telemetry_spool/mod.rs
+++ b/src/telemetry_spool/mod.rs
@@ -103,9 +103,62 @@ pub fn build_export_bundle(
             .with_context(|| format!("add {} to archive", file_path.display()))?;
     }
 
+    append_bundle_info(&mut tar).context("add bundle-info.txt to archive")?;
+
     tar.finish().context("finish tar archive")?;
 
     Ok((out_path, file_count))
+}
+
+/// Write a synthesized `bundle-info.txt` into the archive: which machine,
+/// build, and platform produced it.
+///
+/// Without this, a support bundle is a pile of opaque `.otlp` files and the
+/// recipient has to guess. The `machine` line is the same pseudonym that
+/// appears as `host.name` in the central backend
+/// ([`redact::local_host_pseudonym`]), which is the point: it joins a
+/// hand-delivered bundle to that machine's already-ingested error rows.
+///
+/// Deliberately carries NOTHING that isn't already allowed to leave the
+/// machine over the automatic ship leg - no raw hostname, no account email, no
+/// paths. A user handing over a bundle should not be disclosing more than the
+/// consent copy describes.
+///
+/// Not counted in the returned `file_count`, which reports telemetry files
+/// collected - a synthetic header would make that number mean two things.
+fn append_bundle_info<W: std::io::Write>(tar: &mut tar::Builder<W>) -> Result<()> {
+    let body = format!(
+        "machine: {}\n\
+         version: {}\n\
+         channel: {}\n\
+         os: {}\n\
+         arch: {}\n\
+         generated_unix_micros: {}\n",
+        redact::local_host_pseudonym(),
+        env!("CARGO_PKG_VERSION"),
+        option_env!("MERIDIAN_CHANNEL").unwrap_or("dev"),
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64,
+    );
+
+    let mut header = tar::Header::new_gnu();
+    header.set_size(body.len() as u64);
+    header.set_mode(0o644);
+    header.set_mtime(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    );
+    header.set_cksum();
+
+    tar.append_data(&mut header, "bundle-info.txt", body.as_bytes())
+        .context("append bundle-info.txt")?;
+    Ok(())
 }
 
 /// Strip a `/v1/traces` or `/v1/logs` suffix to recover the OO base URL.
@@ -234,6 +287,50 @@ mod tests {
         // 1 otlp file + daemon.log (a known launchd log name) — the unrelated
         // .txt file must NOT be swept in.
         assert_eq!(count, 2);
+    }
+
+    /// The bundle must carry the machine pseudonym (so support can join it to
+    /// already-ingested error rows) and must NOT carry the raw hostname —
+    /// handing over a bundle should disclose no more than the automatic ship
+    /// leg already does.
+    #[test]
+    fn build_export_bundle_includes_uncounted_bundle_info() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+        std::env::set_var("MERIDIAN_TELEMETRY_DIR", dir.path());
+
+        writer::write_pending(dir.path(), "traces", b"a").unwrap();
+
+        let out = dir.path().join("bundle.tar.gz");
+        let (_, count) = build_export_bundle(Some(&out), None, false).unwrap();
+
+        std::env::remove_var("MERIDIAN_TELEMETRY_DIR");
+
+        // The synthetic header is not counted as a telemetry file.
+        assert_eq!(count, 1);
+
+        let gz = flate2::read::GzDecoder::new(std::fs::File::open(&out).unwrap());
+        let mut archive = tar::Archive::new(gz);
+        let mut info = None;
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            if entry.path().unwrap().to_string_lossy() == "bundle-info.txt" {
+                let mut s = String::new();
+                std::io::Read::read_to_string(&mut entry, &mut s).unwrap();
+                info = Some(s);
+            }
+        }
+
+        let info = info.expect("bundle-info.txt missing from archive");
+        assert!(
+            info.contains(&redact::local_host_pseudonym()),
+            "pseudonym missing, support cannot join this bundle: {info}"
+        );
+        let raw_host = gethostname::gethostname().to_string_lossy().into_owned();
+        assert!(
+            !info.contains(&raw_host),
+            "raw hostname leaked into the bundle: {info}"
+        );
     }
 
     #[test]

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -113,10 +113,30 @@ const SAFE_STRING_KEYS: &[&str] = &[
     "exception.stacktrace",
     "otel.status_code",
     "otel.status_description",
+    // The bare `error` key, NOT a semconv name — but the one this codebase
+    // actually emits. `tracing::warn!(error = %e, …)` is the convention CLAUDE.md
+    // mandates and 203 of ~419 warn/error sites use it, so while `error.message`
+    // sat on this list, the real error text was dropped from every single
+    // shipped record: the backend received a static message ("summarise attempt
+    // failed") with the cause ("claude timed out after 60s") stripped. Also on
+    // `FREE_TEXT_KEYS` below — an `anyhow` chain splices arbitrary `Display`
+    // output, so it needs the full scrub, not just a path scrub.
+    "error",
+    // Which provider/engine a failure came from. Enum-like values from a fixed
+    // internal set (`claude`, `codex`, `anthropic`, `gemini`, …) — they name
+    // OUR components, never the user's data, and without them an LLM or
+    // summariser failure can't be attributed to a backend at all.
+    "provider",
+    "engine",
     // ── code location (paths scrubbed) ───────────────────────────────────────
     "code.function",
     "code.namespace",
     "code.filepath",
+    // `tracing-opentelemetry` emits this alongside `code.filepath`; it was the
+    // only one of the four missing, so shipped records carried the full path
+    // but not the bare filename. Strictly less sensitive than `code.filepath`,
+    // which is already here.
+    "code.filename",
     "code.lineno",
     "thread.name",
     "target",
@@ -138,6 +158,10 @@ const SAFE_STRING_KEYS: &[&str] = &[
 /// them that a path-only scrub would miss. `status.message` (a span field, not
 /// an attribute) is scrubbed the same way in [`scrub_span_status`].
 const FREE_TEXT_KEYS: &[&str] = &[
+    // See the note on `SAFE_STRING_KEYS`: `error` is the key this codebase
+    // actually emits, and its value is a formatted `anyhow` chain — the single
+    // most likely attribute to carry an interpolated path, URL, or token.
+    "error",
     "error.message",
     "exception.message",
     "exception.stacktrace",
@@ -997,6 +1021,60 @@ mod tests {
         assert_eq!(out, pseudonymize_host("Akarshs-MacBook-Pro.local"));
         // ...and distinct per machine, or grouping would be meaningless.
         assert_ne!(out, pseudonymize_host("someone-elses-imac.local"));
+    }
+
+    /// Modelled on a record decoded from the live staging spool, which shipped
+    /// with its cause stripped:
+    ///
+    /// ```text
+    /// engine = claude | attempt = 2 | error = "claude timed out after 60s"
+    /// ```
+    ///
+    /// `error` is the key the whole codebase emits (CLAUDE.md's convention),
+    /// while only `error.message` was allowlisted — so the diagnostic payload
+    /// was dropped from every shipped record and the backend saw a bare static
+    /// string. Pins that the cause now survives, still scrubbed, and that
+    /// widening stopped where it should: user-data keys stay dropped.
+    #[test]
+    fn error_cause_and_provider_survive_but_user_data_does_not() {
+        let mut kv = str_attr("error", "claude timed out after 60s");
+        assert!(keep_attribute(&mut kv), "error cause was dropped");
+        match kv.value.unwrap().value.unwrap() {
+            Value::StringValue(s) => assert_eq!(s, "claude timed out after 60s"),
+            other => panic!("expected string, got {other:?}"),
+        }
+
+        for (key, value) in [("provider", "anthropic"), ("engine", "claude")] {
+            let mut kv = str_attr(key, value);
+            assert!(keep_attribute(&mut kv), "{key} was dropped");
+        }
+
+        // `error` is FREE TEXT — an anyhow chain routinely splices a path,
+        // URL, or token, so it must get the full scrub, not just a path scrub.
+        let mut kv = str_attr(
+            "error",
+            "post to https://hooks.example.com/T123 failed for akarsh@meridiona.com",
+        );
+        assert!(keep_attribute(&mut kv));
+        let out = match kv.value.unwrap().value.unwrap() {
+            Value::StringValue(s) => s,
+            other => panic!("expected string, got {other:?}"),
+        };
+        assert!(out.contains("<url>") && out.contains("<email>"), "{out}");
+
+        // The boundary did NOT widen to the user's own data. These keys are
+        // emitted at real warn sites and must still be dropped.
+        for key in [
+            "task",
+            "task_key",
+            "file",
+            "path",
+            "app_name",
+            "window_title",
+        ] {
+            let mut kv = str_attr(key, "MER-192");
+            assert!(!keep_attribute(&mut kv), "{key} leaked into the ship leg");
+        }
     }
 
     /// The support workflow's load-bearing invariant: the pseudonym the tray

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -1020,20 +1020,19 @@ mod tests {
         );
     }
 
-    /// `os.type` / `host.arch` / `app.install_mode` are on `SAFE_STRING_KEYS`,
-    /// but being allowlisted is not the same as surviving intact — allowlisted
-    /// strings still pass through `scrub_paths`. Pins that these three reach
-    /// the backend as written, since the whole point of populating them is
-    /// being able to filter errors by platform.
+    /// `os.type` / `host.arch` are on `SAFE_STRING_KEYS`, but being allowlisted
+    /// is not the same as surviving intact — allowlisted strings still pass
+    /// through `scrub_paths`. Pins that both reach the backend as written,
+    /// since the whole point of populating them is being able to filter errors
+    /// by platform.
     #[test]
     fn machine_shape_attributes_survive_verbatim() {
         for (key, value) in [
             ("os.type", "macos"),
             ("os.type", "windows"),
+            ("os.type", "linux"),
             ("host.arch", "aarch64"),
             ("host.arch", "x86_64"),
-            ("app.install_mode", "packaged"),
-            ("app.install_mode", "source"),
         ] {
             let mut kv = str_attr(key, value);
             assert!(keep_attribute(&mut kv), "{key} was dropped");

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -418,6 +418,27 @@ pub fn pseudonymize_host(hostname: &str) -> String {
     })
 }
 
+/// This machine's pseudonym - the exact value that appears as `host.name` in
+/// the central backend for telemetry originating here.
+///
+/// # Why this exists rather than each caller hashing its own hostname
+/// The pseudonym is what a user quotes to support so their error rows can be
+/// found. That only works if the value we SHOW is byte-identical to the value
+/// we SHIP. Those are computed in different crates (the tray renders it in
+/// Settings; the daemon's ship leg writes it via [`keep_attribute`]), so any
+/// divergence in how the hostname is obtained - `to_string_lossy` vs `to_str`,
+/// a trimmed `.local` suffix, case folding - would produce an ID that matches
+/// nothing, and the failure is silent. Funnelling both through this one
+/// function makes that drift impossible; `displayed_pseudonym_matches_shipped`
+/// pins it.
+///
+/// Must therefore read the hostname the same way `observability::init` does
+/// (`gethostname().to_string_lossy()`), since that is the raw value the ship
+/// leg later hashes.
+pub fn local_host_pseudonym() -> String {
+    pseudonymize_host(&gethostname::gethostname().to_string_lossy())
+}
+
 fn is_safe_string_key(key: &str) -> bool {
     SAFE_STRING_KEYS.contains(&key)
 }
@@ -976,5 +997,51 @@ mod tests {
         assert_eq!(out, pseudonymize_host("Akarshs-MacBook-Pro.local"));
         // ...and distinct per machine, or grouping would be meaningless.
         assert_ne!(out, pseudonymize_host("someone-elses-imac.local"));
+    }
+
+    /// The support workflow's load-bearing invariant: the pseudonym the tray
+    /// shows a user in Settings must equal the one the ship leg writes for
+    /// `host.name`, or the ID they quote matches no rows in the backend and
+    /// nothing fails loudly. Guards against the two crates drifting in how the
+    /// hostname is read.
+    #[test]
+    fn displayed_pseudonym_matches_shipped() {
+        let raw = gethostname::gethostname().to_string_lossy().into_owned();
+        let mut kv = str_attr("host.name", &raw);
+        assert!(keep_attribute(&mut kv));
+        let shipped = match kv.value.unwrap().value.unwrap() {
+            Value::StringValue(s) => s,
+            other => panic!("expected string, got {other:?}"),
+        };
+        assert_eq!(
+            local_host_pseudonym(),
+            shipped,
+            "Settings would show a pseudonym that matches nothing in the backend"
+        );
+    }
+
+    /// `os.type` / `host.arch` / `app.install_mode` are on `SAFE_STRING_KEYS`,
+    /// but being allowlisted is not the same as surviving intact — allowlisted
+    /// strings still pass through `scrub_paths`. Pins that these three reach
+    /// the backend as written, since the whole point of populating them is
+    /// being able to filter errors by platform.
+    #[test]
+    fn machine_shape_attributes_survive_verbatim() {
+        for (key, value) in [
+            ("os.type", "macos"),
+            ("os.type", "windows"),
+            ("host.arch", "aarch64"),
+            ("host.arch", "x86_64"),
+            ("app.install_mode", "packaged"),
+            ("app.install_mode", "source"),
+        ] {
+            let mut kv = str_attr(key, value);
+            assert!(keep_attribute(&mut kv), "{key} was dropped");
+            let out = match kv.value.unwrap().value.unwrap() {
+                Value::StringValue(s) => s,
+                other => panic!("expected string, got {other:?}"),
+            };
+            assert_eq!(out, value, "{key} was altered in transit");
+        }
     }
 }

--- a/tray/src-tauri/src/commands/version.rs
+++ b/tray/src-tauri/src/commands/version.rs
@@ -259,25 +259,41 @@ pub(crate) fn build_channel() -> &'static str {
     option_env!("MERIDIAN_CHANNEL").unwrap_or("prod")
 }
 
-/// `{ version, channel }` for the small badge in the dashboard and popover.
+/// `{ version, channel, supportId }` for the small badge in the dashboard and
+/// popover, plus the Account panel's support identifier.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppInfo {
     pub version: String,
     pub channel: String,
+    /// This machine's pseudonym — the exact value error telemetry from here
+    /// carries as `host.name` in the central backend. Shown in Settings so a
+    /// user can quote it when they contact support; without it their error
+    /// rows are unfindable, since pseudonymisation is one-way by design.
+    pub support_id: String,
 }
 
 /// The binary's baked `tauri.conf.json` version (what the DMG updater compares
 /// against — set in lockstep across the repo by `scripts/set-version.sh`) plus
 /// [`build_channel`]. Synchronous and never touches the network, unlike
 /// [`get_version`] above.
+///
+/// `support_id` comes from [`meridian::telemetry_spool::redact::local_host_pseudonym`]
+/// — the SAME function the daemon's ship leg uses, so the displayed value and
+/// the shipped one cannot drift (see that function's doc for why sharing it
+/// matters).
 #[tauri::command]
 #[tracing::instrument(skip(app))]
 pub fn get_app_info(app: tauri::AppHandle) -> AppInfo {
     let version = app.package_info().version.to_string();
     let channel = build_channel().to_string();
-    tracing::info!(%version, %channel, "app info served");
-    AppInfo { version, channel }
+    let support_id = meridian::telemetry_spool::redact::local_host_pseudonym();
+    tracing::info!(%version, %channel, %support_id, "app info served");
+    AppInfo {
+        version,
+        channel,
+        support_id,
+    }
 }
 
 /// DMG auto-update check for the in-app banners (sidebar + popover). Wraps

--- a/ui/components/timeline/settings/AccountSection.tsx
+++ b/ui/components/timeline/settings/AccountSection.tsx
@@ -29,11 +29,26 @@ const CHANNEL_COLOR: Record<AppInfo['channel'], string> = {
 
 export function AccountSection() {
   const [appInfo, setAppInfo] = useState<AppInfo | null>(null)
+  const [copied, setCopied] = useState(false)
   const { status: exportStatus, path: exportPath, errorMsg: exportError, exportBundle } = useExportDiagnostics()
 
   useEffect(() => {
     load<AppInfo>('/api/app-info', 'get_app_info').then(setAppInfo).catch(() => {})
   }, [])
+
+  // A 16-hex string is error-prone to retype into a support email, and a
+  // mistyped one silently matches no rows. Copy is the primary interaction.
+  const copySupportId = async () => {
+    if (!appInfo) return
+    try {
+      await navigator.clipboard.writeText(appInfo.supportId)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard blocked - the ID is rendered next to the button, so the
+      // user can still select it by hand. Nothing to report.
+    }
+  }
 
   return (
     <div className="max-w-[640px] flex flex-col gap-5">
@@ -75,6 +90,18 @@ export function AccountSection() {
             <span className="mt-body-sm font-mono font-semibold" style={{ color: CHANNEL_COLOR[appInfo.channel] }}>
               v{appInfo.version}{appInfo.channel !== 'prod' && ` · ${appInfo.channel}`}
             </span>
+          )}
+        </FieldRow>
+        <FieldRow label="Support ID" description="Identifies this device in error reports, without naming you or it. Quote it when you contact support so we can find the errors from this machine. It is not tied to your account and changes if you rename the device.">
+          {appInfo && (
+            <div className="flex items-center gap-2">
+              <span className="mt-body-sm font-mono" style={{ color: 'var(--t-muted)' }}>
+                {appInfo.supportId}
+              </span>
+              <SettingsButton onClick={copySupportId}>
+                {copied ? 'Copied' : 'Copy'}
+              </SettingsButton>
+            </div>
           )}
         </FieldRow>
         <FieldRow label="Export Diagnostics" description="Captures your local logs and traces for troubleshooting. Nothing leaves your machine until you share this file. Saved to your Downloads folder and revealed in your file manager.">

--- a/ui/components/timeline/settings/AccountSection.tsx
+++ b/ui/components/timeline/settings/AccountSection.tsx
@@ -92,7 +92,7 @@ export function AccountSection() {
             </span>
           )}
         </FieldRow>
-        <FieldRow label="Support ID" description="Identifies this device in error reports, without naming you or it. Quote it when you contact support so we can find the errors from this machine. It is not tied to your account and changes if you rename the device.">
+        <FieldRow label="Support ID" description="Identifies this device in error reports, without naming you or it. Quote it when you contact support so we can find the errors from this machine. It is not tied to your account.">
           {appInfo && (
             <div className="flex items-center gap-2">
               <span className="mt-body-sm font-mono" style={{ color: 'var(--t-muted)' }}>

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -654,6 +654,11 @@ export interface UninstallResult {
 export interface AppInfo {
   version: string
   channel: 'dev' | 'staging' | 'prod'
+  // This machine's pseudonym, identical to the `host.name` value its error
+  // telemetry carries in the central backend. Surfaced in Settings → Account so
+  // a user can quote it to support; the hash is one-way, so without the user
+  // supplying it their error rows cannot be located.
+  supportId: string
 }
 
 // ── LLM Lab (`get_llm_experiments` / `get_llm_experiment` / `run_llm_experiment`)


### PR DESCRIPTION
Split out of #584 (closed).

> **Stacked on #586.** Its two commits are included here because this PR's test anchors on one they add. Review only `fbc3cf3b`; merge #586 first and this diff collapses to that commit alone. #587 is independent of both.

Audit of end-to-end error coverage after the first staging release, prompted by "is every operation's error actually reaching the backend". Answer was no, in two independent ways.

## 🔴 1. The OCR + accessibility stack was never captured at all

`EnvFilter` matches directives against targets by **string prefix**. `meridian=info` therefore covers `meridian_core::*`, `meridian_tray_lib::*` and `meridian_oauth::*` for free - every first-party target starts with those bytes. The in-process capture crates do not:

| target | matched a directive? |
|---|---|
| `meridian_core::readers::tasks` | yes, via `meridian` prefix |
| `meridian_tray_lib::commands::health` | yes, via `meridian` prefix |
| `screenpipe_screen::*` | **no** |
| `screenpipe_a11y::*` | **no** |

All ~48 `warn!`/`error!` sites in those crates were discarded **at the subscriber** - before the spool, before the severity filter, before redaction. Not shipped, not in `meridian logs`, not in an export bundle. Screen-capture bail-outs, Apple Vision OCR handler failures, `AXObserver`/`CGEventTap` registration failures, monitor enumeration errors: all structurally invisible.

This is the worse of the two, because capture is the daemon's **only data source**. A silent failure there is indistinguishable downstream from "the user did nothing today" - exactly the support case that is currently undiagnosable.

Fixed with `CAPTURE_DIRECTIVES` at `warn`, dropping to `error` when the user selects ERROR.

**Privacy audit done before enabling.** These are third-party crates written to print to a terminal, so this is the one fix in the set that could *create* a leak. Every `warn!`/`error!` body in both crates is an infrastructure failure - monitor ids, image dimensions, word-range indices, error `Display`s. **None** interpolates a window title, app name, URL, or OCR text. Noted at the constant that bumping the fork revision requires re-auditing, since that is precisely the change that could start shipping captured content.

The tests assert the **negative** too - that the old filter did not pass capture targets, or the regression check would be vacuous - and that unrelated third-party targets (`reqwest`) stay out, so this is a narrow widening rather than a global one.

## 🔴 2. Every shipped error arrived with its cause stripped

`SAFE_STRING_KEYS` carried `error.message`. The key this codebase actually emits is bare **`error`** - CLAUDE.md's own mandated convention, used by **203 of ~419** warn/error sites. The allowlist dropped it.

Decoded from the live staging spool:

```
engine  = claude
attempt = 2
error   = "claude timed out after 60s"
```

What reached the backend: the static message, plus `attempt` (numeric, kept unconditionally). Not the engine. Not the cause. Every AI-provider failure, summariser failure and ETL failure has been shipping as a bare string.

Allowlisted `error` as **free text** - an `anyhow` chain splices arbitrary `Display` output, so it needs the full URL/email/token scrub, not just the path scrub - plus `provider` and `engine`, enum-like values naming our own components.

**Deliberately stopped there.** The census also surfaced `task`/`task_key` (ticket ids), `file`/`path`, `app_name`, `hour`/`day`. Those are the user's data, are not needed to diagnose a failure, and stay dropped - a test asserts they still are, so the widening cannot quietly grow by precedent.

Also allowlists `code.filename`, the only one of the four `code.*` attributes missing, so records carried the full path but not the bare filename.

## Follow-ups, with assessment rather than a list

**Daemon panics never reach the backend** - real, deliberately not fixed here. The tray has Sentry with the `panic` feature; the daemon has nothing, so a panic reaches only launchd's stderr file. A `panic::set_hook` emitting `tracing::error!` would *look* like coverage but largely isn't: `SpoolClient::send` defers the write via `spawn_blocking`, and the OTel batch processor batches before that, so a panicking process is unlikely to flush. The honest fix is Sentry in the daemon (new dep, DSN wiring, redaction parity) - worth doing, not worth faking.

**`let _ =` sites: 84 hits, not a finding.** Sampled twelve: `remove_dir_all` on temp dirs, `stdout().flush()`, `launchctl` during uninstall, `stamp_sync_error` (already recording an error), `force_flush` on shutdown. Best-effort cleanup where the error is genuinely uninteresting. No evidence of swallowed operational failures; reporting the count without the sample would have been misleading.

## Volume needs one staging round before prod

Enabling 48 new WARN sites on a stack that runs at frame cadence is the flood risk. Two candidates to watch: `"Apple Vision OCR skipped {} words with missing bounding boxes"` and `"tesseract: OCR failed"`. If either is per-frame it belongs in `NOISE_SUBSTRINGS`. Staging is the right place to measure that - check record counts grouped by body on the first release rather than assuming.

## Verification

Daemon `fmt` + `clippy -D warnings` + 773 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)