### PR TITLE
fix(tray): stage the daemon binary via atomic rename, not in-place overwrite

### DIFF
--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -179,6 +179,13 @@ async fn install(backend: &Path, home: &Path) -> Result<(), String> {
             .await
             .map_err(|e| format!("mkdir {}: {e}", p.display()))?;
     }
+
+    // A staging attempt killed between `stage_binary`'s copy and its rename
+    // (tray crash, force-quit, OOM) leaves an orphaned
+    // `<DAEMON_FILE>.staging-<pid>` temp file behind — nothing else ever
+    // scans for these, so sweep them here before staging runs again.
+    cleanup_stale_staging_files(&home.join(".meridian/bin")).await;
+
     // Purge leftovers from a pre-cutover **bundle** install before staging the
     // in-process backend. macOS-only by construction: Windows has no install
     // history to migrate from, so there is nothing to boot out and no legacy
@@ -721,6 +728,51 @@ async fn stage_binary(src: &Path, dest: &Path) -> Result<(), String> {
     Ok(())
 }
 
+/// Remove any `<DAEMON_FILE>.staging-<pid>` leftovers in `bin_dir` from a
+/// staging attempt that [`stage_binary`] never finished (killed between its
+/// copy and its rename) — see that function's doc comment for why the temp
+/// file exists. Best-effort and non-fatal: a listing or removal failure is
+/// only logged, since a lingering temp file is harmless clutter, not a
+/// correctness problem, and must never block `install()`.
+async fn cleanup_stale_staging_files(bin_dir: &Path) {
+    let prefix = format!("{DAEMON_FILE}.staging-");
+    let mut entries = match tokio::fs::read_dir(bin_dir).await {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::debug!(
+                dir = %bin_dir.display(), error = %e,
+                "backend_install: could not list bin dir for stale staging sweep"
+            );
+            return;
+        }
+    };
+    loop {
+        let entry = match entries.next_entry().await {
+            Ok(Some(e)) => e,
+            Ok(None) => return,
+            Err(e) => {
+                tracing::debug!(error = %e, "backend_install: stale staging sweep readdir error");
+                return;
+            }
+        };
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if !name.starts_with(&prefix) {
+            continue;
+        }
+        let path = entry.path();
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => {
+                tracing::info!(path = %path.display(), "backend_install: removed stale staging temp file")
+            }
+            Err(e) => {
+                tracing::debug!(path = %path.display(), error = %e, "backend_install: could not remove stale staging temp file")
+            }
+        }
+    }
+}
+
 /// `chmod u+rwx,go+rx` (0755) on a freshly staged binary.
 #[cfg(unix)]
 async fn set_executable(path: &Path) -> Result<(), String> {
@@ -933,9 +985,8 @@ mod tests {
     #[tokio::test]
     async fn stage_binary_does_not_disturb_a_reader_of_the_old_file() {
         let dir = std::env::temp_dir().join(format!(
-            "meridian-stage-binary-{}-{}",
-            std::process::id(),
-            "norace"
+            "meridian-stage-binary-reader-{}",
+            std::process::id()
         ));
         let _ = tokio::fs::remove_dir_all(&dir).await;
         tokio::fs::create_dir_all(&dir).await.unwrap();
@@ -965,6 +1016,50 @@ mod tests {
             tokio::fs::read(&dest).await.unwrap(),
             b"new binary bytes, much longer than the old one",
             "a fresh read of the path after staging must see the new content"
+        );
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    /// `cleanup_stale_staging_files` must remove only leftover
+    /// `<DAEMON_FILE>.staging-<pid>` temp files — the orphan a killed
+    /// `stage_binary` can leave behind — and must never touch the real staged
+    /// binary or anything else sharing the directory.
+    #[tokio::test]
+    async fn cleanup_stale_staging_files_removes_only_staging_leftovers() {
+        let dir = std::env::temp_dir().join(format!(
+            "meridian-stage-binary-sweep-{}",
+            std::process::id()
+        ));
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        let stale = dir.join(format!("{DAEMON_FILE}.staging-12345"));
+        let daemon = dir.join(DAEMON_FILE);
+        let unrelated = dir.join("some-other-file");
+        tokio::fs::write(&stale, b"orphaned temp copy")
+            .await
+            .unwrap();
+        tokio::fs::write(&daemon, b"the real staged binary")
+            .await
+            .unwrap();
+        tokio::fs::write(&unrelated, b"not ours").await.unwrap();
+
+        cleanup_stale_staging_files(&dir).await;
+
+        assert!(
+            tokio::fs::metadata(&stale).await.is_err(),
+            "stale staging temp file should have been removed"
+        );
+        assert_eq!(
+            tokio::fs::read(&daemon).await.unwrap(),
+            b"the real staged binary",
+            "the real staged binary must be untouched"
+        );
+        assert_eq!(
+            tokio::fs::read(&unrelated).await.unwrap(),
+            b"not ours",
+            "unrelated files must be untouched"
         );
 
         let _ = tokio::fs::remove_dir_all(&dir).await;

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -672,6 +672,23 @@ async fn migrate_legacy_bundle_env(home: &Path) {
 
 /// Copy `src` → `dest` only when the bytes differ, then `chmod 0755`.
 /// Skipping an identical copy keeps the code hash (and any TCC grant) stable.
+///
+/// Stages via a temp file in `dest`'s own directory + atomic rename, **not**
+/// an in-place overwrite — `dest` (`~/.meridian/bin/meridian`) is often still
+/// the executable image of a previous version of the daemon, still running
+/// (`ensure_backend_installed` re-stages on every app update, before the
+/// caller's `register_service` stops/relaunches it via launchd). An in-place
+/// `tokio::fs::copy` truncates and rewrites that same inode; on macOS the
+/// hardened-runtime code-signing monitor validates executable pages against
+/// the on-disk signature as they're demand-paged in, so the live process gets
+/// SIGKILL'd (`EXC_BAD_ACCESS`, `CODESIGNING`/"Invalid Page") the next time it
+/// faults in a page that no longer matches — which can happen anywhere from
+/// immediately to hours later, well after this function returns. `rename(2)`
+/// instead swaps the directory entry without touching the old inode's
+/// content, so an already-running process keeps executing its original,
+/// still-valid pages undisturbed; only a fresh exec of `dest` picks up the
+/// new binary. The temp file must be on the same filesystem as `dest` for the
+/// rename to be atomic — using `dest`'s own directory guarantees that.
 async fn stage_binary(src: &Path, dest: &Path) -> Result<(), String> {
     let same = match (tokio::fs::read(src).await, tokio::fs::read(dest).await) {
         (Ok(a), Ok(b)) => a == b,
@@ -682,10 +699,24 @@ async fn stage_binary(src: &Path, dest: &Path) -> Result<(), String> {
         tracing::debug!(dest = %dest.display(), "backend_install: binary unchanged");
         return Ok(());
     }
-    tokio::fs::copy(src, dest)
-        .await
-        .map_err(|e| format!("copy {} → {}: {e}", src.display(), dest.display()))?;
-    set_executable(dest).await?;
+
+    let tmp = dest.with_file_name(format!("{DAEMON_FILE}.staging-{}", std::process::id()));
+    if let Err(e) = tokio::fs::copy(src, &tmp).await {
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return Err(format!("copy {} → {}: {e}", src.display(), tmp.display()));
+    }
+    if let Err(e) = set_executable(&tmp).await {
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return Err(e);
+    }
+    if let Err(e) = tokio::fs::rename(&tmp, dest).await {
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return Err(format!(
+            "rename {} → {}: {e}",
+            tmp.display(),
+            dest.display()
+        ));
+    }
     tracing::info!(dest = %dest.display(), "backend_install: staged binary");
     Ok(())
 }
@@ -889,6 +920,54 @@ mod tests {
         );
 
         let _ = tokio::fs::remove_dir_all(&home).await;
+    }
+
+    /// `stage_binary` must never truncate `dest` in place — a reader that
+    /// opened `dest` before staging began (standing in for a still-running
+    /// daemon with `dest` mapped as its executable image) must still see the
+    /// complete, unmodified OLD content afterward, not a mix of old/new bytes
+    /// or a truncated file. This is the property the codesigning SIGKILL loop
+    /// (see the doc comment on `stage_binary`) depends on: a live process is
+    /// only ever affected by future execs of the (now-renamed) path, never by
+    /// its own already-open file/mapping.
+    #[tokio::test]
+    async fn stage_binary_does_not_disturb_a_reader_of_the_old_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "meridian-stage-binary-{}-{}",
+            std::process::id(),
+            "norace"
+        ));
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        let src = dir.join("src-daemon");
+        let dest = dir.join(DAEMON_FILE);
+        tokio::fs::write(&src, b"new binary bytes, much longer than the old one")
+            .await
+            .unwrap();
+        tokio::fs::write(&dest, b"old binary bytes").await.unwrap();
+
+        // Hold `dest`'s original inode open across the stage, mirroring a
+        // running process's already-mapped executable.
+        let mut reader = std::fs::File::open(&dest).unwrap();
+
+        stage_binary(&src, &dest).await.unwrap();
+
+        use std::io::Read;
+        let mut held = Vec::new();
+        reader.read_to_end(&mut held).unwrap();
+        assert_eq!(
+            held, b"old binary bytes",
+            "a handle opened before staging must still see the intact old content"
+        );
+
+        assert_eq!(
+            tokio::fs::read(&dest).await.unwrap(),
+            b"new binary bytes, much longer than the old one",
+            "a fresh read of the path after staging must see the new content"
+        );
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Diagnosed the macOS "the app crashes and can't reopen" reports by pulling this dev machine's own crash reports from `~/Library/Logs/DiagnosticReports/`. Found a real, reproducible daemon crash-loop and fixed its root cause.

## What was happening

Every recent `meridian` (daemon) crash on this machine — 8 reports spanning 2026-07-20 through 2026-07-27, roughly one every 1-2 days — has the **identical** signature:

```
"type": "EXC_BAD_ACCESS", "signal": "SIGKILL (Code Signature Invalid)"
"termination": {"namespace": "CODESIGNING", "indicator": "Invalid Page"}
```

That's macOS's hardened-runtime code-signing monitor killing a *running* process because a page of its executable image no longer matches the signature it was validated against at launch.

## Root cause

`backend_install::ensure_backend_installed` re-stages `~/.meridian/bin/meridian` from the bundled `Resources/backend/meridian` on every app update — **before** `register_service` stops/relaunches the daemon via launchd. `stage_binary` did this with `tokio::fs::copy(src, dest)`.

On Unix, `fs::copy` opens the destination with `O_TRUNC` and writes into the **same inode** — it does not unlink-and-recreate. If the previous daemon process is still running (it usually is: `register_agent`'s `launchctl bootout` happens *after* staging, not before), that process has `dest` mapped as its executable text segment. Truncating and rewriting the file corrupts those pages out from under it. macOS's code-signing enforcement validates pages on demand as they're faulted in, so the process gets `SIGKILL`ed the next time it touches an affected page — which can be immediately or, per the observed reports, up to ~26 minutes later (matches a case where the binary was re-staged at 03:13 and the daemon was killed at 03:39).

The code already had a mirror-image guard for this — `stop_running_daemon_before_stage` — but it's `#[cfg(target_os = "windows")]`-only, because Windows fails loudly (file locked, copy errors out) where macOS fails silently and asynchronously (the copy "succeeds," the crash happens later, disconnected in time from the update). The comment on that function frames the underlying problem as Windows-specific ("Windows keeps a running exe's pages mapped"), which is the misconception this PR corrects — Unix has the equivalent problem with a different failure shape.

## Fix

`stage_binary` now copies into a temp file in `dest`'s own directory, `chmod`s it, then `rename(2)`s it into place. `rename` swaps the directory entry without touching the old inode's content, so a process that already has `dest` open/mapped keeps running against its original, untouched pages — only a *fresh* exec of the path picks up the new binary. No macOS-side "stop first" dance needed; this is the standard safe pattern for replacing an executable that might be live.

Windows is unaffected — `stop_running_daemon_before_stage` still runs first there (rename-over-a-running-exe fails on Windows same as a direct copy would), this is purely additive.

## Testing

- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (tray crate) — all pass.
- New regression test `stage_binary_does_not_disturb_a_reader_of_the_old_file`: opens `dest` before staging (standing in for a running process's mapped executable), stages a longer replacement, and asserts the already-open handle still reads back the complete, unmodified old content while a fresh read of the path sees the new content. This fails against the old `tokio::fs::copy` implementation (truncates the held-open file) and passes against the rename-based one.
- Full `pre-push` suite (fmt + clippy + ui build/tests + security audit + cargo test) passed locally.

## Note: this doesn't cover everything in the original report

This fixes the **daemon**'s crash-loop, which is real and reproducible. It does **not** fully explain the *tray's* "unexpectedly quit while reopening windows" dialog — the daemon is a windowless LaunchAgent, so killing it can't be what shows that dialog. A separate, single `meridian-tray` crash report on this machine (2026-07-23) shows an unrelated bug: a double-free in `screenpipe_a11y::platform::macos::run_app_observer`'s `NotificationGuard` drop path (libmalloc `BUG_IN_CLIENT_OF_LIBMALLOC`), which lives in the `Meridiona/screenpipe-fork` git dependency, not this repo — needs a separate fix there. Flagging for follow-up; not blocking this fix.
