### PR TITLE
fix(screen): bump screenpipe-fork pin for OCR PII redaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8354,7 +8354,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "screenpipe-a11y"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=61332b8a15f09a08876455ad45713eb3b1bfa2df#61332b8a15f09a08876455ad45713eb3b1bfa2df"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8383,7 +8383,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-config"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=61332b8a15f09a08876455ad45713eb3b1bfa2df#61332b8a15f09a08876455ad45713eb3b1bfa2df"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8395,7 +8395,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-connect"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=61332b8a15f09a08876455ad45713eb3b1bfa2df#61332b8a15f09a08876455ad45713eb3b1bfa2df"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8434,7 +8434,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-core"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=61332b8a15f09a08876455ad45713eb3b1bfa2df#61332b8a15f09a08876455ad45713eb3b1bfa2df"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8474,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-db"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=61332b8a15f09a08876455ad45713eb3b1bfa2df#61332b8a15f09a08876455ad45713eb3b1bfa2df"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8500,7 +8500,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-events"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=61332b8a15f09a08876455ad45713eb3b1bfa2df#61332b8a15f09a08876455ad45713eb3b1bfa2df"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8517,7 +8517,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-screen"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=61332b8a15f09a08876455ad45713eb3b1bfa2df#61332b8a15f09a08876455ad45713eb3b1bfa2df"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8554,7 +8554,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-secrets"
 version = "0.1.0"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=61332b8a15f09a08876455ad45713eb3b1bfa2df#61332b8a15f09a08876455ad45713eb3b1bfa2df"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8572,7 +8572,7 @@ dependencies = [
 [[package]]
 name = "screenpipe-vault"
 version = "0.4.15"
-source = "git+https://github.com/Meridiona/screenpipe-fork?rev=2b7e929f7168344faa0121c7a646e5758701d19a#2b7e929f7168344faa0121c7a646e5758701d19a"
+source = "git+https://github.com/Meridiona/screenpipe-fork?rev=61332b8a15f09a08876455ad45713eb3b1bfa2df#61332b8a15f09a08876455ad45713eb3b1bfa2df"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -132,7 +132,7 @@ tauri-plugin-sentry = "0.5"
 # screen capture + Apple Vision OCR. Optional → only pulled by the `capture`
 # feature (heavy: ScreenCaptureKit/cidre/sck-rs). Private repo: local builds use
 # the user's git credentials; CI needs a deploy token (future).
-screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "2b7e929f7168344faa0121c7a646e5758701d19a", optional = true }
+screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "61332b8a15f09a08876455ad45713eb3b1bfa2df", optional = true }
 # Sibling crate in the same fork: the accessibility-tree walker (slice 3b).
 # `tree::create_tree_walker` walks the focused window's AX tree → structured
 # text — the PRIMARY signal for Electron/Chromium apps (VS Code, Slack), which
@@ -165,7 +165,15 @@ screenpipe-screen = { git = "https://github.com/Meridiona/screenpipe-fork", rev 
 # the CGDisplayRegisterReconfigurationCallback watcher extracted from
 # upstream screenpipe's `screenpipe-engine::sleep_monitor` (its "Thread 4") —
 # see `capture/screenpipe.rs`'s `run_monitor_refresh_task` for the caller.
-screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "2b7e929f7168344faa0121c7a646e5758701d19a", optional = true }
+#
+# Bumped to 61332b8 (screenpipe-screen only): the OCR path (Tesseract/
+# AppleNative/WindowsNative/Custom/cloud) previously had no PII/password
+# redaction at all, unlike screenpipe-a11y's own apply_pii_removal. This
+# wires screenpipe_core::remove_pii/remove_pii_from_text_json into
+# process_window_ocr's single dispatch point so every OCR engine's output
+# is redacted before it reaches the OCR cache or the frame consumer. See
+# Meridiona/screenpipe-fork#6.
+screenpipe-a11y = { git = "https://github.com/Meridiona/screenpipe-fork", rev = "61332b8a15f09a08876455ad45713eb3b1bfa2df", optional = true }
 
 # Raw Objective-C messaging to set NSWindow collectionBehavior directly: tao's
 # `set_visible_on_all_workspaces` only adds CanJoinAllSpaces, never the


### PR DESCRIPTION
## Summary
- The OCR capture path (Tesseract/AppleNative/WindowsNative/Custom/cloud) had no PII/password redaction at all, unlike `screenpipe-a11y`'s own `apply_pii_removal`.
- Fixed upstream in [Meridiona/screenpipe-fork#6](https://github.com/Meridiona/screenpipe-fork/pull/6): wires `screenpipe-core`'s `remove_pii`/`remove_pii_from_text_json` into `process_window_ocr`'s single dispatch point, so every OCR engine's output is redacted before it reaches the OCR cache or the frame consumer.
- This PR bumps `screenpipe-screen` and `screenpipe-a11y` (kept in lockstep) from `2b7e929f` to `61332b8a` to pull that fix into the tray build.

## Test plan
- [x] `cargo check -p meridian-tray` — `screenpipe-screen`/`screenpipe-a11y` resolve to the new commit, clean build.
- [x] `cargo clippy -p meridian-tray -- -D warnings` — clean.
- [x] Pre-push checks (fmt, clippy, ui build/tests, security audit, cargo test) — all passed.
- [x] Upstream PR ([screenpipe-fork#6](https://github.com/Meridiona/screenpipe-fork/pull/6)) has its own new unit test (`ocr_pipeline_redacts_pii_before_coordinate_transform`) plus the full `screenpipe-screen` suite (122 passed) verifying the redaction itself.