### PR TITLE
fix(ci): update the screenpipe MIT-pin guard's expected rev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,14 @@ jobs:
           #   f13c631c  adityaharishch  fix(a11y): wrap per-click context-capture reads in an autorelease pool
           #   b2e5b268  adityaharishch  fix(a11y): leak NSWorkspace observer guards instead of dropping them
           #   2b7e929f  adityaharishch  feat(screen): expose a display-reconfiguration watcher from screenpipe-screen
-          expected="2b7e929f7168344faa0121c7a646e5758701d19a"
+          #
+          # 2026-07-27, 2b7e929f -> 61332b8a. Three commits, all Meridiona-
+          # (adityaharishch)-authored, no upstream merge:
+          #   2ac29227  adityaharishch  Merge pull request #4 (autorelease-pool leak fixes, ours)
+          #   0c693a1c  adityaharishch  Merge pull request #5 (reconciles with 2b7e929f, already
+          #                             audited above; brings in no new tree content beyond PR #4)
+          #   61332b8a  adityaharishch  fix(screen): redact PII in OCR output before it reaches the frame consumer
+          expected="61332b8a15f09a08876455ad45713eb3b1bfa2df"
           f="tray/src-tauri/Cargo.toml"
           fail=0
           for crate in screenpipe-screen screenpipe-a11y; do


### PR DESCRIPTION
## Summary

The `screenpipe MIT pin` CI check has been broken for every PR into `pre-main` since PR #590 merged — noticed because it was failing on an unrelated PR (#589) that never touches `Cargo.toml` or this workflow.

## Root cause

PR #590 legitimately bumped the `screenpipe-fork` git dependency pin in `tray/src-tauri/Cargo.toml` from `2b7e929f` to `61332b8a` (wiring in OCR PII redaction), but didn't update this guard's hardcoded `expected` rev in the same PR. Since then, the guard compares `Cargo.toml`'s pin against a now-stale value and fails on every push/PR — independent of what that PR actually changes.

## What this does

Follows the guard's own documented audit process:

```
gh api repos/Meridiona/screenpipe-fork/compare/2b7e929f7168344faa0121c7a646e5758701d19a...61332b8a15f09a08876455ad45713eb3b1bfa2df \
  --jq '.commits[] | .sha[0:8] + "  " + .commit.author.name'
```

All 3 commits introduced by the bump are `adityaharishch`-authored, none merge upstream `screenpipe` code past the MIT→Commercial relicense cutoff (0.4.17):
- `2ac29227` — merge of PR #4 (autorelease-pool leak fixes)
- `0c693a1c` — merge reconciling with the already-audited `2b7e929f` tip; brings in no new tree content beyond PR #4
- `61332b8a` — `fix(screen): redact PII in OCR output before it reaches the frame consumer`

Recorded the audit-trail entry in the same format as the prior four, and bumped `expected` to `61332b8a15f09a08876455ad45713eb3b1bfa2df` to match what's already on `pre-main`.

## Testing

Simulated the guard's exact shell logic locally against the current `Cargo.toml` pin — passes. `cargo fmt --check`, `cargo clippy`, and the full `pre-push` suite also passed (this PR only touches the workflow YAML, no Rust changes).
