### PR TITLE
docs(whats-new): refresh release notes and roadmap, mark trackers coming soon

### DIFF
--- a/tray/src-tauri/resources/whats-new.json
+++ b/tray/src-tauri/resources/whats-new.json
@@ -1,6 +1,121 @@
 {
   "releases": [
     {
+      "version": "1.80.0",
+      "date": "2026-07-27",
+      "highlights": [
+        "Meridian can now send error reports to the team automatically, so crashes and failures get fixed without you having to report them. It is on by default and you can turn it off any time in Settings - Capture.",
+        "Everything identifying is stripped on your device before a report is sent - file paths, web addresses, email addresses, and your computer's name. Your screen activity, OCR text, and window titles are never included.",
+        "A new Support ID in Settings - Account. Quote it when you contact us and we can find the errors from your device, without it being linked to your account."
+      ],
+      "fixes": [
+        "Error reports now work on Windows. They were silently never being sent.",
+        "Problems in screen capture and accessibility - the parts that read what is on screen - are now reported, so a device that quietly stops capturing can be spotted instead of just looking like an idle day.",
+        "Error reports now carry the actual reason something failed, instead of only naming the step that failed."
+      ]
+    },
+    {
+      "version": "1.79.0",
+      "date": "2026-07-24",
+      "highlights": [
+        "Claude, Codex, and Cursor now sign in and run on Windows the same way they do on a Mac.",
+        "Meridian restores its own launch-at-login setting if it ever gets cleared, so tracking does not quietly stop after a restart.",
+        "Notification settings are now a single switch plus quiet hours, instead of a list of per-type toggles."
+      ],
+      "fixes": [
+        "Fixed sign-in for Claude, Codex, and Cursor on Windows, including prompts that were being dropped.",
+        "A brief network problem no longer leaves Jira showing a stuck sync error.",
+        "Export Diagnostics is reachable again, now under Settings - Account."
+      ]
+    },
+    {
+      "version": "1.78.0",
+      "date": "2026-07-23",
+      "highlights": [
+        "Meridian notices within about ten seconds if its background service stops, and restarts it for you.",
+        "You can delete personal tasks you created, and dismiss or merge the tasks Meridian infers from your day.",
+        "The daily plan now holds up to 20 tasks, up from 10."
+      ],
+      "fixes": [
+        "Fixed the background service failing to restart on Windows, and a console window that flashed on screen.",
+        "The Tasks board refreshes immediately after you delete a personal task.",
+        "Uninstalling now also clears cached app data and permission grants."
+      ]
+    },
+    {
+      "version": "1.77.0",
+      "date": "2026-07-22",
+      "highlights": [
+        "A rebuilt daily summary, organised around what you planned versus what you actually did, with a progress ring and a single checklist.",
+        "Composing the summary has its own screen now, and it composes itself at the end of the day.",
+        "Worklogs can turn a personal task into a real ticket, and write a tailored update for each ticket you moved forward.",
+        "The date picker is now a proper interactive calendar."
+      ],
+      "fixes": [
+        "Fixed a crash in accessibility capture when the recorder restarted."
+      ]
+    },
+    {
+      "version": "1.76.0",
+      "date": "2026-07-22",
+      "highlights": [
+        "Meridian captures context from secondary monitors, not only the screen you are focused on.",
+        "Connected tracker cards have View tasks and Sync now buttons.",
+        "Jira gets a multi-select project picker, matching the one GitHub already had."
+      ],
+      "fixes": [
+        "Fixed connecting an account not opening a browser on Windows.",
+        "Fixed the task list briefly showing stale results while loading."
+      ]
+    },
+    {
+      "version": "1.75.1",
+      "date": "2026-07-22",
+      "highlights": [],
+      "fixes": [
+        "Fixed Meridian finding and launching your AI provider CLIs on Windows.",
+        "Fixed the popover position, tooltips, onboarding, and setup wizard on Windows.",
+        "Meridian now reads your real Windows notification and permission settings instead of assuming they are off."
+      ]
+    },
+    {
+      "version": "1.75.0",
+      "date": "2026-07-21",
+      "highlights": [
+        "Signing in is now required across the dashboard and the tray popover.",
+        "The plan's task detail can change a task's status, including for personal tasks.",
+        "You can choose which tracker a proposed ticket gets created on.",
+        "A Refresh button on the daily plan once a tracker is connected."
+      ],
+      "fixes": [
+        "Streamlined the GitHub connect flow, including the device-code step and picking projects."
+      ]
+    },
+    {
+      "version": "1.74.0",
+      "date": "2026-07-20",
+      "highlights": [
+        "Worklogs can draft themselves once a day, at a time you choose."
+      ],
+      "fixes": [
+        "Fixed the GitHub project picker not saving after connecting an account.",
+        "Fixed Dock and menu-bar icon rendering."
+      ]
+    },
+    {
+      "version": "1.73.0",
+      "date": "2026-07-20",
+      "highlights": [
+        "Windows support. The full app - background service, tray, notifications, and installer - now runs on Windows.",
+        "Choosing a model is now a picker with a curated list, instead of typing the model name yourself."
+      ],
+      "fixes": [
+        "Fixed screen capture on macOS 26.",
+        "Hardened worklog and activity processing so a failure surfaces instead of passing silently.",
+        "Bounded the memory and time the on-device text model can use."
+      ]
+    },
+    {
       "version": "1.72.0",
       "date": "2026-07-18",
       "highlights": [
@@ -83,14 +198,19 @@
   ],
   "roadmap": [
     {
-      "title": "Choose your own AI provider",
+      "title": "Encrypt your local data at rest",
       "status": "in-progress",
-      "description": "Pick your own Claude, Codex, Cursor, or Copilot CLI subscription (or stay fully on-device) to power worklog generation, switchable anytime from Settings."
+      "description": "Meridian's local database, which holds everything it has captured, encrypted on disk so it stays unreadable to anything else on your machine."
     },
     {
-      "title": "See and install updates from the dashboard",
-      "status": "in-progress",
-      "description": "An update card in the dashboard sidebar, so you don't have to open the tray popover to check for or install a new version."
+      "title": "More trackers - Linear, Trello, and Azure DevOps",
+      "status": "planned",
+      "description": "Meridian already speaks to all three. They are listed as coming soon while we finish testing each one end to end, so the trackers you can connect today are ones we know work."
+    },
+    {
+      "title": "Report crashes in the background service",
+      "status": "planned",
+      "description": "Error reporting currently covers the app itself. Extending it to the background service means a hard crash there gets reported too, rather than only being visible in local logs."
     }
   ]
 }

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -29,7 +29,7 @@ const jetbrainsMono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   title: 'Meridian',
-  description: 'A private daily timeline of your work, plus auto-drafted worklogs for your tasks - ready to review and post to Jira, Linear, or GitHub.',
+  description: 'A private daily timeline of your work, plus auto-drafted worklogs for your tasks - ready to review and post to Jira or GitHub.',
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -11,7 +11,7 @@ import { Btn, Check, DISPLAY, Kicker, PermIcon, Row } from './atoms'
 import { PERMISSIONS } from './data'
 import type { NotifState } from './data'
 import type { IntegrationsResponse } from '@/lib/api-types'
-import { TRACKERS } from '@/lib/integrations'
+import { TRACKERS, availableTrackerNames } from '@/lib/integrations'
 import { llmProvider, LLM_INTRO_BODY, LLM_INTRO_TITLE, type LlmProviderId } from '@/lib/llm-providers'
 import ConnectTrackers from '@/components/IntegrationConnect'
 import LlmProviderPicker, { type InstallOutcome, type ProviderStatus } from '@/components/LlmProviderPicker'
@@ -188,7 +188,7 @@ export function Welcome({ onBegin, steps, ready, error, onRetry }: {
   const points = [
     { t: 'On-device', d: 'Your screen is read and understood locally on your device, never uploaded.' },
     { t: 'Automatic', d: 'Builds an accurate timeline of the tickets you worked on, then drafts the updates for you.' },
-    { t: 'Connected', d: 'Works with Jira, Linear, GitHub, Trello, and Azure DevOps.' },
+    { t: 'Connected', d: `Works with ${availableTrackerNames()}, with more trackers coming soon.` },
   ]
   return (
     <div className="flex flex-col items-center justify-center" style={{ height: '100%', textAlign: 'center', padding: '36px 44px' }}>

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -66,19 +66,27 @@ export default function ConnectTrackers({
           const connected = !!integrations?.[t.id]
           const syncError = integrations?.sync_errors?.[t.id]
           const isOpen = open === t.id
+          // Gate NEW connections only. An already-connected tracker keeps its
+          // full row so a user can still manage or disconnect it - see the
+          // `comingSoon` doc in `@/lib/integrations`.
+          const locked = !!t.comingSoon && !connected
           return (
             <div key={t.id} style={{ borderTop: i > 0 ? '1px solid var(--t-hair)' : undefined }}>
               <button
-                onClick={() => setOpen(isOpen ? null : t.id)}
+                onClick={() => { if (!locked) setOpen(isOpen ? null : t.id) }}
+                disabled={locked}
+                aria-disabled={locked}
                 className="w-full flex items-center gap-3 px-4 py-3 text-left transition-colors"
-                style={{ background: isOpen ? 'var(--t-box)' : 'var(--t-card)', cursor: 'pointer' }}
+                style={{ background: isOpen ? 'var(--t-box)' : 'var(--t-card)', cursor: locked ? 'default' : 'pointer', opacity: locked ? 0.55 : 1 }}
               >
                 <ProviderGlyph provider={t.id} size={22} />
                 <span className="flex flex-col min-w-0">
                   <span className="text-[13px]" style={{ color: 'var(--t-title)' }}>{t.name}</span>
                   {compact && !connected && <span className="text-[11px] truncate" style={{ color: 'var(--t-faint-2)' }}>{t.blurb}</span>}
                 </span>
-                {connected ? (
+                {locked ? (
+                  <span className="ml-auto text-[11px]" style={{ color: 'var(--t-faint-2)' }}>Coming soon</span>
+                ) : connected ? (
                   <span className="ml-auto inline-flex items-center gap-1.5 text-[11px]" style={{ color: syncError ? 'var(--status-warning-dot)' : 'var(--t-muted)' }}>
                     <span className="inline-block w-1.5 h-1.5 rounded-full" style={{ background: syncError ? 'var(--status-warning-dot)' : 'var(--color-state-approved)' }} />
                     {syncError ? 'Sync error' : 'Connected'}

--- a/ui/components/timeline/settings/WorklogSection.tsx
+++ b/ui/components/timeline/settings/WorklogSection.tsx
@@ -18,7 +18,7 @@ import { Switch } from '@/components/ui/Switch'
 import { TextInput } from '@/components/ui/TextInput'
 import type { RuntimeSettings } from '@/lib/settings'
 import type { IntegrationsResponse } from '@/lib/api-types'
-import { TRACKERS } from '@/lib/integrations'
+import { TRACKERS, availableTrackerNames } from '@/lib/integrations'
 import { SectionCard, SectionHeader, FieldRow, SaveButton, type SaveStatus } from './fields'
 
 const PRESETS = [
@@ -63,7 +63,7 @@ export function WorklogSection({ settings, patch, save, integrations }: {
         <SectionCard>
           <SectionHeader>Auto-generate</SectionHeader>
           <p className="mt-body-sm" style={{ color: 'var(--t-muted)' }}>
-            Connect a tracker first - Jira, Linear, GitHub, Trello, or Azure DevOps.
+            Connect a tracker first - {availableTrackerNames()}.
           </p>
         </SectionCard>
       ) : (

--- a/ui/lib/integrations.ts
+++ b/ui/lib/integrations.ts
@@ -57,6 +57,18 @@ export interface Tracker {
   token?: TokenMethod
   /** Azure DevOps uses the bespoke PAT→org→project discovery flow. */
   azure?: boolean
+  /** Listed but not yet offered: the row shows "Coming soon" and cannot be
+   *  expanded to start a NEW connection.
+   *
+   *  This is a product decision about what we support, NOT a gap in the code —
+   *  every one of these has a working connect flow here and a full provider
+   *  implementation in the daemon (`src/pm_worklog/`, `src/intelligence/providers/`).
+   *  Clearing this flag is all that's needed to offer one.
+   *
+   *  An ALREADY-connected tracker keeps its normal row (manage, re-authorize,
+   *  disconnect) — hiding the controls for something a user has already wired up
+   *  would strand them with a connection they cannot remove. */
+  comingSoon?: boolean
 }
 
 export const TRACKERS: Tracker[] = [
@@ -84,6 +96,7 @@ export const TRACKERS: Tracker[] = [
   },
   {
     id: 'linear',
+    comingSoon: true,
     name: 'Linear',
     glyph: 'Li',
     color: '#5E6AD2',
@@ -124,6 +137,7 @@ export const TRACKERS: Tracker[] = [
   },
   {
     id: 'trello',
+    comingSoon: true,
     name: 'Trello',
     glyph: 'Tr',
     color: '#0052CC',
@@ -135,6 +149,7 @@ export const TRACKERS: Tracker[] = [
   },
   {
     id: 'azure_devops',
+    comingSoon: true,
     name: 'Azure DevOps',
     glyph: 'Az',
     color: '#0078D4',
@@ -160,6 +175,21 @@ export function connectedTrackers(integrations: IntegrationsResponse | null): Tr
   if (!integrations) return []
   const int = integrations as unknown as Record<string, boolean>
   return TRACKERS.filter(t => int[t.id])
+}
+
+/** The trackers actually on offer, i.e. not flagged `comingSoon`. */
+export function availableTrackers(): Tracker[] {
+  return TRACKERS.filter((t) => !t.comingSoon)
+}
+
+/** Prose list of the trackers on offer - "Jira and GitHub", "Jira, GitHub and
+ *  Linear". Derived from `TRACKERS` rather than written out at each call site:
+ *  three separate places used to hardcode all five names, so flagging one
+ *  `comingSoon` would have left the UI promising it anyway. */
+export function availableTrackerNames(): string {
+  const names = availableTrackers().map((t) => t.name)
+  if (names.length <= 1) return names[0] ?? ''
+  return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`
 }
 
 /** A provider id's display name (`'azure_devops'` → `'Azure DevOps'`).


### PR DESCRIPTION
Two changes to what the app tells users is available.

## 1. Release notes had drifted seven releases behind

The newest What's New entry was **1.72.0** while **v1.79.0** had shipped. Anyone opening the modal saw nothing about Windows support, the rebuilt daily summary, secondary-monitor capture, auto-drafted worklogs, or compulsory sign-in - most of the last two weeks of user-visible work.

Backfilled **1.73.0 through 1.79.0** from `CHANGELOG.md` and, for 1.78.0/1.79.0 (which the changelog does not cover), the commits between tags. Every bullet is rewritten in user terms per the CLAUDE.md rule rather than pasted from a commit subject.

Two judgement calls worth flagging:
- **1.74.1 and 1.74.2 are omitted.** Both were pure CI fixes to release tagging - nothing a user can observe. Listing them would pad the modal with entries that read as "we fixed something" and say nothing.
- **1.75.1 is kept as a fixes-only entry** (empty `highlights`), since it was substantively the Windows polish pass - CLI discovery, popover position, real permission reads - not a routine patch.

Added **1.80.0** for the release currently staged on `pre-main`: central error reporting, the on-device redaction guarantees, and the new Support ID (#586, #587, #588).

> **Its date is the expected cut date.** `whats-new.json` is compiled into the tray via `include_str!`, so the entry ships with the binary and a user on 1.79.0 cannot see it - but the date should be corrected if the release slips.

### Roadmap

Both existing items have shipped, so they are dropped, following the pattern of the earlier `docs(whats-new): drop the … roadmap item` commits:
- *Choose your own AI provider* - provider picker, curated model registry, in-app sign-in.
- *See and install updates from the dashboard* - `ui/components/timeline/UpdateCard.tsx`.

Replaced with three real ones: local-database encryption (in progress, #585), the remaining trackers, and crash reporting for the background service (the item deferred out of #588).

## 2. Linear, Trello and Azure DevOps marked "Coming soon"

A `comingSoon` flag on the tracker registry. The row shows the label and cannot be expanded to start a new connection.

**An already-connected tracker keeps its normal row.** Hiding the controls for something a user has already wired up would strand them with a connection they cannot manage or remove, which is a worse outcome than the label being briefly inconsistent for that user.

**The flag is a product statement, not a code gap** - and the doc comment says so explicitly, because "coming soon" otherwise reads as unimplemented and someone will eventually "fix" it by building what already exists. All three have working connect flows in the UI and full provider implementations in the daemon (`src/pm_worklog/{linear,trello,azure_devops}.rs`, `src/intelligence/providers/`). Clearing the flag is the whole change needed to offer one.

### The copy that would have contradicted it

Three other places hardcoded all five tracker names and would have kept promising them next to a "Coming soon" label:

| Where | Was |
|---|---|
| Worklogs empty state | "Connect a tracker first - Jira, Linear, GitHub, Trello, or Azure DevOps." |
| Setup wizard bullet | "Works with Jira, Linear, GitHub, Trello, and Azure DevOps." |
| App description (`layout.tsx`) | "…post to Jira, Linear, or GitHub." |

The first two now derive from the registry through `availableTrackerNames()`, so flagging a tracker updates the copy with it rather than leaving a second source of truth to drift. `layout.tsx` is static Next metadata and is edited directly.

## Verification

UI build, typecheck (45 pre-existing `bun:test` type errors on `pre-main`, unchanged), 381 bun tests, and `whats_new_json_parses` in the tray crate - the test that fails the build if this JSON does not match the expected shape.

Independent of #586, #587 and #588; merge in any order. If those three slip past the 1.80.0 release, the 1.80.0 entry's error-reporting bullets should move to whichever release carries them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)