### PR TITLE
fix(review): address the PR #582 findings in code I authored

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -658,7 +658,11 @@ jobs:
       # explicit setup — same action OpenSSL's own upstream CI uses on
       # Windows.
       - name: Install NASM (for vendored OpenSSL's assembly routines)
-        uses: ilammy/setup-nasm@v1
+        # Pinned to the commit behind v1.5.2, not the mutable `v1` tag: this job
+        # holds the signing key and the release secrets, so a third-party action
+        # that can be re-pointed is a supply-chain path straight into a signed
+        # build. Bump deliberately, re-reading the diff.
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
 
       - name: Install Rust 1.93.1
         uses: dtolnay/rust-toolchain@master

--- a/ops/central-observability/.env.example
+++ b/ops/central-observability/.env.example
@@ -5,7 +5,19 @@
 # the central instance and a developer's local instance behave identically.
 OO_IMAGE=public.ecr.aws/zinclabs/openobserve:v0.90.3
 COLLECTOR_IMAGE=otel/opentelemetry-collector-contrib:0.111.0
-CADDY_IMAGE=caddy:2
+# Pinned like the other two: `caddy:2` is a mutable major tag, so a redeploy
+# could silently pull a new minor into the TLS/basic-auth front door. Bump this
+# deliberately after validating, rather than discovering the change during an
+# unrelated deploy. NOTE: this template does not touch a VM's existing `.env`
+# (scripts/deploy-gateway.sh never copies it), so update the live `.env` by hand
+# to adopt the pin - check the running version first with
+# `docker compose exec caddy caddy version`.
+#
+# 2.11.4 is the current 2.x at time of pinning, so this should be a no-op for
+# the running instance (which was on the floating `caddy:2`). Pinning to an
+# older release would have been worse than not pinning: this container
+# terminates TLS for the whole gateway.
+CADDY_IMAGE=caddy:2.11.4
 
 # ── OpenObserve root credentials — SERVER-SIDE ONLY, never shipped to installs ─
 OO_ROOT_USER_EMAIL=admin@meridiona.com

--- a/ops/central-observability/Caddyfile
+++ b/ops/central-observability/Caddyfile
@@ -13,6 +13,14 @@
 # ingest token, which the collector validates (bearertokenauth/ingest). A
 # basic-auth challenge here would reject every install.
 {$GATEWAY_DOMAIN} {
+	# Cap request bodies before they reach the collector. This host is
+	# world-reachable and the Bearer check happens downstream, so every body -
+	# including an unauthenticated one - is proxied first. 4MB is far above a
+	# real OTLP batch (the shipper spools per-export files, KBs to low MBs) and
+	# well below what makes an unauthenticated flood cheap.
+	request_body {
+		max_size 4MB
+	}
 	reverse_proxy otel-collector:4318
 }
 

--- a/ops/central-observability/docker-compose.yml
+++ b/ops/central-observability/docker-compose.yml
@@ -22,14 +22,23 @@
 #        MERIDIAN_CENTRAL_TELEMETRY_TOKEN = <INGEST_TOKEN>
 #   Rotate the token any time by changing INGEST_TOKEN + `docker compose up -d`;
 #   no app rebuild is needed to change collector redaction/filtering either.
+#
+# Every mandatory variable below uses `${VAR:?message}`, which ABORTS the deploy
+# when it is unset. Plain `${VAR}` only warns and substitutes an empty string,
+# which fails in the worst possible way here: an empty INGEST_TOKEN brings the
+# stack up accepting unauthenticated ingest on a world-reachable endpoint, and
+# an empty OO_UI_PASSWORD_HASH renders the UI basic-auth layer inert - both
+# looking like a healthy deploy. `OO_RETENTION_DAYS` deliberately keeps its
+# `:-90` default instead, since a .env written before that key existed must
+# still deploy.
 
 services:
   openobserve:
-    image: ${OO_IMAGE}
+    image: ${OO_IMAGE:?set OO_IMAGE in .env}
     restart: unless-stopped
     environment:
-      ZO_ROOT_USER_EMAIL: ${OO_ROOT_USER_EMAIL}
-      ZO_ROOT_USER_PASSWORD: ${OO_ROOT_USER_PASSWORD}
+      ZO_ROOT_USER_EMAIL: ${OO_ROOT_USER_EMAIL:?set OO_ROOT_USER_EMAIL in .env}
+      ZO_ROOT_USER_PASSWORD: ${OO_ROOT_USER_PASSWORD:?set OO_ROOT_USER_PASSWORD in .env}
       ZO_DATA_DIR: /data
       ZO_HTTP_PORT: "5080"
       # This instance's OWN product-analytics phone-home to OpenObserve, off.
@@ -49,35 +58,35 @@ services:
     # OpenObserve, over the private compose network. Nothing binds it to the host.
 
   otel-collector:
-    image: ${COLLECTOR_IMAGE}
+    image: ${COLLECTOR_IMAGE:?set COLLECTOR_IMAGE in .env}
     restart: unless-stopped
     command: ["--config=/etc/otelcol/config.yaml"]
     environment:
       # Validated against every install's `Authorization: Bearer <token>`.
-      INGEST_TOKEN: ${INGEST_TOKEN}
+      INGEST_TOKEN: ${INGEST_TOKEN:?set INGEST_TOKEN in .env - an empty one accepts anonymous ingest}
       # Server-side only — the collector authenticates to OpenObserve with these.
-      OO_ROOT_USER_EMAIL: ${OO_ROOT_USER_EMAIL}
-      OO_ROOT_USER_PASSWORD: ${OO_ROOT_USER_PASSWORD}
-      OO_ORG: ${OO_ORG}
+      OO_ROOT_USER_EMAIL: ${OO_ROOT_USER_EMAIL:?set OO_ROOT_USER_EMAIL in .env}
+      OO_ROOT_USER_PASSWORD: ${OO_ROOT_USER_PASSWORD:?set OO_ROOT_USER_PASSWORD in .env}
+      OO_ORG: ${OO_ORG:?set OO_ORG in .env}
     volumes:
       - ./otel-collector-config.yaml:/etc/otelcol/config.yaml:ro
     depends_on:
       - openobserve
 
   caddy:
-    image: ${CADDY_IMAGE}
+    image: ${CADDY_IMAGE:?set CADDY_IMAGE in .env}
     restart: unless-stopped
     ports:
       - "80:80"
       - "443:443"
     environment:
-      GATEWAY_DOMAIN: ${GATEWAY_DOMAIN}
-      OO_UI_DOMAIN: ${OO_UI_DOMAIN}
+      GATEWAY_DOMAIN: ${GATEWAY_DOMAIN:?set GATEWAY_DOMAIN in .env}
+      OO_UI_DOMAIN: ${OO_UI_DOMAIN:?set OO_UI_DOMAIN in .env}
       # Basic auth in front of the OO UI only (see the Caddyfile). The hash
       # MUST be `$`-escaped in .env or compose truncates it — .env.example
       # explains why and how.
-      OO_UI_USER: ${OO_UI_USER}
-      OO_UI_PASSWORD_HASH: ${OO_UI_PASSWORD_HASH}
+      OO_UI_USER: ${OO_UI_USER:?set OO_UI_USER in .env}
+      OO_UI_PASSWORD_HASH: ${OO_UI_PASSWORD_HASH:?set OO_UI_PASSWORD_HASH in .env - an empty hash disables UI auth}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy-data:/data

--- a/src/observability/otlp_target.rs
+++ b/src/observability/otlp_target.rs
@@ -116,6 +116,13 @@ fn is_http(endpoint: &str) -> bool {
     endpoint.starts_with("http://") || endpoint.starts_with("https://")
 }
 
+/// Whether the CENTRAL endpoint may be shipped to. TLS-only, unlike
+/// [`is_http`], which the dev/loopback path uses — see
+/// [`resolve_central_target`] for why the two differ.
+fn central_endpoint_allowed(endpoint: &str) -> bool {
+    endpoint.starts_with("https://")
+}
+
 /// Cheap liveness check used by the health probe — does NOT assemble
 /// credentials. Returns `true` when the DEV/local OTLP export would be
 /// attempted (toggle on + credentials present + not a packaged install).
@@ -193,10 +200,18 @@ fn resolve_central_target(
     }
 
     let endpoint = central_endpoint()?;
-    if !is_http(&endpoint) {
+    // TLS-only, deliberately stricter than the dev path's `is_http`. This
+    // request carries a write-scoped Bearer token for a shared, world-reachable
+    // gateway plus redacted error payloads, over the public internet. A
+    // `MERIDIAN_CENTRAL_OTLP_ENDPOINT` runtime override (or a mis-baked release
+    // constant) pointing at `http://` would put both on the wire in cleartext,
+    // and nothing downstream would notice — the gateway would happily accept
+    // them. The dev path keeps plain `http` because it targets loopback.
+    if !central_endpoint_allowed(&endpoint) {
         tracing::warn!(
             endpoint = %endpoint,
-            "central OTLP endpoint has no http/https scheme — error shipping disabled"
+            "central OTLP endpoint is not https — error shipping disabled rather than \
+             sending the write token in cleartext"
         );
         return None;
     }
@@ -273,4 +288,47 @@ fn resolve_dev_target(settings: &meridian_core::settings::RuntimeSettings) -> Op
         auth,
         redact: false,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The central leg carries a write-scoped Bearer token to a shared,
+    /// world-reachable gateway over the public internet. `http://` there would
+    /// put the token on the wire in cleartext and nothing downstream would
+    /// object, so the check is stricter than the dev path's [`is_http`].
+    #[test]
+    fn central_endpoint_requires_tls() {
+        for ok in [
+            "https://telemetry.meridiona.com/v1/traces",
+            "https://localhost:4318/v1/traces",
+        ] {
+            assert!(central_endpoint_allowed(ok), "should be allowed: {ok}");
+        }
+        for bad in [
+            // The realistic mistakes: a mis-baked release constant, a runtime
+            // override typed without the `s`, and loopback (fine for dev, not
+            // for the central token).
+            "http://telemetry.meridiona.com/v1/traces",
+            "http://localhost:5080/api/default/v1/traces",
+            "telemetry.meridiona.com/v1/traces",
+            "",
+            // Scheme matching is case-sensitive by design: a URL this odd is a
+            // config error, and failing closed is the safe direction.
+            "HTTPS://telemetry.meridiona.com/v1/traces",
+        ] {
+            assert!(!central_endpoint_allowed(bad), "should be refused: {bad:?}");
+        }
+    }
+
+    /// The dev path must keep accepting plain `http` — it targets a loopback
+    /// OpenObserve, and tightening it here would silently break every
+    /// engineer's local shipping.
+    #[test]
+    fn dev_path_still_accepts_plain_http() {
+        assert!(is_http("http://localhost:5080/api/default/v1/traces"));
+        assert!(is_http("https://oo.example.com/v1/traces"));
+        assert!(!is_http("localhost:5080"));
+    }
 }

--- a/src/telemetry_spool/machine_id.rs
+++ b/src/telemetry_spool/machine_id.rs
@@ -57,7 +57,25 @@ const IOREG: &str = "/usr/sbin/ioreg";
 /// one spawn per process, not one per call.
 pub(crate) fn stable_machine_id() -> Option<&'static str> {
     static CACHED: OnceLock<Option<String>> = OnceLock::new();
-    CACHED.get_or_init(read_platform_id).as_deref()
+    CACHED
+        .get_or_init(|| {
+            let id = read_platform_id();
+            // Logged once (inside the OnceLock init), not per call. On macOS a
+            // miss means every pseudonym silently degrades to the unstable
+            // hostname seed - precisely the regression this module exists to
+            // prevent - and nothing else would report it. Elsewhere the
+            // hostname IS the intended seed, so a miss is not a fault.
+            #[cfg(target_os = "macos")]
+            if id.is_none() {
+                tracing::warn!(
+                    probe = "ioreg IOPlatformUUID",
+                    "no stable hardware id; falling back to the hostname, so this machine's \
+                     pseudonym and Support ID may change when it changes network"
+                );
+            }
+            id
+        })
+        .as_deref()
 }
 
 /// macOS: parse `IOPlatformUUID` out of the `IOPlatformExpertDevice` node.

--- a/tray/src-tauri/resources/whats-new.json
+++ b/tray/src-tauri/resources/whats-new.json
@@ -200,7 +200,7 @@
     {
       "title": "Encrypt your local data at rest",
       "status": "in-progress",
-      "description": "Meridian's local database, which holds everything it has captured, encrypted on disk so it stays unreadable to anything else on your machine."
+      "description": "Meridian's local database, which holds everything it has captured, is encrypted on disk so it stays unreadable to anything else on your machine."
     },
     {
       "title": "More trackers - Linear, Trello, and Azure DevOps",

--- a/tray/src-tauri/src/commands/version.rs
+++ b/tray/src-tauri/src/commands/version.rs
@@ -288,7 +288,12 @@ pub fn get_app_info(app: tauri::AppHandle) -> AppInfo {
     let version = app.package_info().version.to_string();
     let channel = build_channel().to_string();
     let support_id = meridian::telemetry_spool::redact::local_host_pseudonym();
-    tracing::info!(%version, %channel, %support_id, "app info served");
+    // `support_id` is deliberately NOT a field here. It is a machine
+    // identifier, and it is already available where it is actually needed - the
+    // command's return value, Settings → Account, and `bundle-info.txt` in an
+    // export bundle - so logging it adds no diagnostic value and only widens
+    // where an identifier is written.
+    tracing::info!(%version, %channel, "app info served");
     AppInfo {
         version,
         channel,

--- a/tray/src-tauri/src/crash.rs
+++ b/tray/src-tauri/src/crash.rs
@@ -120,5 +120,22 @@ fn scrub_event(mut event: Event<'static>) -> Option<Event<'static>> {
     // pseudonym and silently decorrelate a crash from that machine's error
     // logs. Also covers the case where `sentry-contexts` left it unset.
     event.server_name = Some(local_host_pseudonym().into());
+
+    // Free-text carriers that `send_default_pii: false` does NOT suppress.
+    // Nothing populates these today, so CLEARING costs nothing — and clearing
+    // beats scrubbing here because the failure mode is additive: the day
+    // someone adds a breadcrumb or an `extra` with a window title or a file
+    // path, it would otherwise egress having never passed a scrubber. This way
+    // the default for anything new is "does not ship", matching the OTLP
+    // allowlist's fail-closed stance.
+    event.breadcrumbs = Default::default();
+    event.extra.clear();
+    for exc in event.exception.values.iter_mut() {
+        if let Some(st) = exc.stacktrace.as_mut() {
+            for frame in st.frames.iter_mut() {
+                frame.vars.clear();
+            }
+        }
+    }
     Some(event)
 }

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -11,7 +11,7 @@ import { Btn, Check, DISPLAY, Kicker, PermIcon, Row } from './atoms'
 import { PERMISSIONS } from './data'
 import type { NotifState } from './data'
 import type { IntegrationsResponse } from '@/lib/api-types'
-import { TRACKERS, availableTrackerNames } from '@/lib/integrations'
+import { TRACKERS, availableTrackers, availableTrackerNames } from '@/lib/integrations'
 import { llmProvider, LLM_INTRO_BODY, LLM_INTRO_TITLE, type LlmProviderId } from '@/lib/llm-providers'
 import ConnectTrackers from '@/components/IntegrationConnect'
 import LlmProviderPicker, { type InstallOutcome, type ProviderStatus } from '@/components/LlmProviderPicker'
@@ -188,7 +188,9 @@ export function Welcome({ onBegin, steps, ready, error, onRetry }: {
   const points = [
     { t: 'On-device', d: 'Your screen is read and understood locally on your device, never uploaded.' },
     { t: 'Automatic', d: 'Builds an accurate timeline of the tickets you worked on, then drafts the updates for you.' },
-    { t: 'Connected', d: `Works with ${availableTrackerNames()}, with more trackers coming soon.` },
+    { t: 'Connected', d: availableTrackers().length
+        ? `Works with ${availableTrackerNames()}, with more trackers coming soon.`
+        : 'Tracker integrations are coming soon.' },
   ]
   return (
     <div className="flex flex-col items-center justify-center" style={{ height: '100%', textAlign: 'center', padding: '36px 44px' }}>

--- a/ui/components/HealthBanner.tsx
+++ b/ui/components/HealthBanner.tsx
@@ -115,7 +115,7 @@ export default function HealthBanner() {
             </p>
             <p className="text-xs mt-0.5" style={{ color: 'var(--ink-3)' }}>
               {health.llm_provider_detail ? `${health.llm_provider_detail}. ` : ''}
-              Hourly summaries are paused — open Settings → Intelligence to reinstall, sign in, or pick another provider.
+              Hourly summaries are paused. Open Settings → Intelligence to reinstall, sign in, or pick another provider.
             </p>
           </div>
         </div>
@@ -145,7 +145,7 @@ export default function HealthBanner() {
             </p>
             <p className="text-xs mt-0.5" style={{ color: 'var(--ink-3)' }}>
               {health.llm_provider_detail ? `${health.llm_provider_detail}. ` : ''}
-              You&apos;re signed in and nothing is lost — summaries will catch up on their own once the limit resets.
+              You&apos;re signed in and nothing is lost - summaries will catch up on their own once the limit resets.
             </p>
           </div>
         </div>

--- a/ui/components/timeline/settings/WorklogSection.tsx
+++ b/ui/components/timeline/settings/WorklogSection.tsx
@@ -18,7 +18,7 @@ import { Switch } from '@/components/ui/Switch'
 import { TextInput } from '@/components/ui/TextInput'
 import type { RuntimeSettings } from '@/lib/settings'
 import type { IntegrationsResponse } from '@/lib/api-types'
-import { TRACKERS, availableTrackerNames } from '@/lib/integrations'
+import { TRACKERS, availableTrackers, availableTrackerNames } from '@/lib/integrations'
 import { SectionCard, SectionHeader, FieldRow, SaveButton, type SaveStatus } from './fields'
 
 const PRESETS = [
@@ -63,7 +63,9 @@ export function WorklogSection({ settings, patch, save, integrations }: {
         <SectionCard>
           <SectionHeader>Auto-generate</SectionHeader>
           <p className="mt-body-sm" style={{ color: 'var(--t-muted)' }}>
-            Connect a tracker first - {availableTrackerNames()}.
+            {availableTrackers().length
+              ? `Connect a tracker first - ${availableTrackerNames()}.`
+              : 'Tracker connections are coming soon.'}
           </p>
         </SectionCard>
       ) : (

--- a/ui/lib/integrations.ts
+++ b/ui/lib/integrations.ts
@@ -182,10 +182,16 @@ export function availableTrackers(): Tracker[] {
   return TRACKERS.filter((t) => !t.comingSoon)
 }
 
-/** Prose list of the trackers on offer - "Jira and GitHub", "Jira, GitHub and
- *  Linear". Derived from `TRACKERS` rather than written out at each call site:
- *  three separate places used to hardcode all five names, so flagging one
- *  `comingSoon` would have left the UI promising it anyway. */
+/** Prose list of the trackers on offer - today "Jira and GitHub", and
+ *  "Jira, GitHub and Linear" were a third un-flagged. Derived from `TRACKERS`
+ *  rather than written out at each call site: three separate places used to
+ *  hardcode all five names, so flagging one `comingSoon` would have left the UI
+ *  promising it anyway.
+ *
+ *  Returns `''` when every tracker is flagged. Callers must handle that rather
+ *  than interpolating blindly, or the copy reads "Works with , with more
+ *  coming soon" - see `availableTrackers().length` guards at the two call
+ *  sites. */
 export function availableTrackerNames(): string {
   const names = availableTrackers().map((t) => t.name)
   if (names.length <= 1) return names[0] ?? ''


### PR DESCRIPTION
Addresses **13 of the 22** CodeRabbit findings on the release PR #582.

> **Why this is a separate PR.** #582's head branch is `pre-main`, which CLAUDE.md forbids pushing to directly. This targets `pre-main`, so #582 picks the fixes up once merged - nobody should wait for a push to #582 itself.

## Fixed

**Central OTLP endpoint is TLS-only** (`otlp_target.rs`) - the most consequential of the set. The scheme check was shared with the dev path, so `http://` was accepted. A runtime `MERIDIAN_CENTRAL_OTLP_ENDPOINT` override or a mis-baked release constant would have put the write-scoped Bearer token *and* the redacted error payloads on the public internet in cleartext, and the gateway would have accepted them without complaint. Split into `central_endpoint_allowed`; the dev path keeps plain `http` for loopback. Tests cover both directions, including that the dev path did not tighten.

**Sentry `before_send` clears breadcrumbs, `extra`, stack-frame `vars`** (`crash.rs`) - `send_default_pii: false` does not suppress these. Nothing populates them today, so clearing costs nothing, and clearing beats scrubbing because the failure mode is additive: the day someone adds a breadcrumb carrying a window title, the default becomes "does not ship" rather than "egresses having never met a scrubber".

**`stable_machine_id` logs its fallback** (`machine_id.rs`) - a failed `ioreg` probe silently degraded every pseudonym to the unstable hostname seed, the exact regression that module exists to prevent. Warned once inside the `OnceLock` init, and only on macOS: elsewhere the hostname is the intended seed, so a miss is not a fault.

**Dropped `support_id` from the `app info served` log** (`version.rs`) - redundant with the command's return value, Settings, and `bundle-info.txt`.

**Gateway hardening** (`ops/central-observability/`):
- Mandatory compose variables now use `${VAR:?...}`. A missing `INGEST_TOKEN` aborts the deploy instead of bringing the stack up accepting **anonymous ingest on a world-reachable endpoint**; an empty `OO_UI_PASSWORD_HASH` can no longer render UI auth inert. `OO_RETENTION_DAYS` keeps its `:-90` default so an older `.env` still deploys.
- Caddy pinned off the mutable `caddy:2`, to **2.11.4** - the current 2.x. The reviewer's point stands, but pinning to an old release would be worse than not pinning for the container that terminates TLS for the whole gateway; 2.11.4 should be a no-op for the running instance, which was on floating `caddy:2`.
- Ingest request bodies capped at 4MB - well above a real OTLP batch, well below what makes an unauthenticated flood cheap.

Verified with `docker compose config`, including that it now **fails loudly** with no `.env`:
```
error while interpolating services.openobserve.image: required variable OO_IMAGE is missing a value
```

**Supply chain** - `ilammy/setup-nasm@v1` pinned to the commit behind v1.5.2 (`72793074…`). That job holds the signing key and release secrets, so a re-pointable third-party action is a path straight into a signed build.

**Em-dashes** removed from the two user-facing `HealthBanner` strings.

## Declined, with reasoning

**[Do not emit a hostname-derived support ID] - half accepted.** Dropping the log field: done. The other half, "make the helper return no identifier when stable hardware identity is unavailable", is declined: it deletes machine grouping for **every Windows install** to fix a macOS-only failure mode. `gethostname()` on Windows *is* the stable computer name, which is why the `ioreg` probe is macOS-scoped. The premise also overstates the exposure - the value is a salted, truncated SHA-256, never a hostname. The correct form of this concern is the `machine_id.rs` finding, which is accepted above.

**[Em-dashes in `poll/refresh.rs`] - declined.** Those are `tracing` log messages, not displayed app text. CLAUDE.md scopes that rule to "any string the user reads" - window titles, UI copy, button labels, notification bodies - and exempts comments and docs. `HealthBanner.tsx` is unambiguously user-facing and is fixed.

## Deferred to their owning PRs

Nine findings are in subsystems written by others and are answered in-thread rather than guessed at on a release branch:

| Finding | File | Why deferred |
|---|---|---|
| `encrypt_in_place` crash window | `db_crypto.rs` | Database rewrite ordering. `hard_link` also fails on some filesystems and changes what a crash leaves behind - wrong here corrupts user data. |
| Plaintext export permissions | `db_crypto.rs` | Same subsystem; real finding, wants its author. |
| Snapshot filename collision | `db-cache.ts` | Correct finding (hex of the first 8 bytes, not a hash). MCP-owned. |
| WAL not checkpointed on plain-copy | `main.rs:298` | Real staleness bug, SQLCipher rollout. |
| Key in world-readable `.env` | `db_key.rs` | Same. |
| Encryption degradation on stderr | `lib.rs:249` | Same. |
| Stale staging sweep age check | `backend_install.rs` | Update-handoff race, not mine. |
| Provider-health probe instrumentation | `detect.rs` | LLM health PR. |
| Duplicate sign-in metadata | `LlmProviderDetail.tsx` | LLM provider UI PR. |

Two of these (the `encrypt_in_place` window and the plaintext-export mode) look genuinely important and worth resolving before this release ships, not after.

## Verification

Daemon `clippy -D warnings` + 783 tests. Tray `clippy -D warnings` + 164 tests. UI build + 381 bun tests. `docker compose config` both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)