### PR TITLE
fix(review): close the mechanical PR #582 findings from other subsystems

### DIFF
--- a/meridian-core/src/db_crypto.rs
+++ b/meridian-core/src/db_crypto.rs
@@ -278,6 +278,29 @@ pub async fn export_plaintext(
     conn.execute("DETACH DATABASE plaintext_export;")
         .await
         .context("export_plaintext: DETACH failed")?;
+
+    // The ATTACH-created file inherits the process umask, typically 0644. This
+    // is the ONE place the SQLCipher rollout deliberately writes a full,
+    // unencrypted copy of the activity database, so leaving it group- and
+    // world-readable would undo — for that file — exactly the local-multi-user
+    // threat the rest of the encryption work exists to cover. It gets the same
+    // 0600 the encrypted original deserves.
+    //
+    // Tightened AFTER the export rather than pre-creating the file: SQLCipher's
+    // ATTACH wants to create it itself, and `remove_file` above deliberately
+    // clears any stale copy first.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(out_path, std::fs::Permissions::from_mode(0o600)).with_context(
+            || {
+                format!(
+                    "export_plaintext: failed to restrict permissions on {}",
+                    out_path.display()
+                )
+            },
+        )?;
+    }
     Ok(())
 }
 
@@ -423,5 +446,19 @@ mod tests {
             .unwrap();
         assert_eq!(row.get::<i64, _>(0), 7);
         pool.close().await;
+
+        // This is the one file the encryption work deliberately writes in
+        // plaintext, so it must not inherit the umask's usual 0644 - that
+        // would leave a full, unencrypted copy of the activity database
+        // readable by every other local account.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&out_path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(
+                mode, 0o600,
+                "plaintext export is readable by others: {mode:o}"
+            );
+        }
     }
 }

--- a/packages/meridian-mcp/src/db-cache.ts
+++ b/packages/meridian-mcp/src/db-cache.ts
@@ -26,6 +26,7 @@ import initSqlJs from "sql.js";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import * as crypto from "crypto";
 import { execFile } from "child_process";
 import { promisify } from "util";
 
@@ -114,9 +115,18 @@ async function resolveReadablePath(dbPath: string): Promise<string> {
         `in this MCP server's environment, matching the key the Meridian tray generated.`,
     );
   }
+  // Hash the WHOLE path. The previous `Buffer.from(dbPath).toString("hex")
+  // .slice(0, 16)` was the hex of only the first EIGHT bytes, so any two DB
+  // paths sharing an 8-byte prefix mapped to the same snapshot file - and
+  // "/Users/a" is exactly eight bytes, which makes `/Users/alice/...` and
+  // `/Users/alison/...` collide. Since the caches key on `dbPath` rather than
+  // on this derived path, two paths can be resolved concurrently, and a
+  // collision lets one database's export overwrite the other between its
+  // export and its read - serving one user's data for a request against
+  // another's.
   const snapshotPath = path.join(
     os.tmpdir(),
-    `meridian-mcp-plaintext-${Buffer.from(dbPath).toString("hex").slice(0, 16)}.db`,
+    `meridian-mcp-plaintext-${crypto.createHash("sha256").update(dbPath).digest("hex").slice(0, 32)}.db`,
   );
   const bin = selectMeridianBinary(meridianCandidates());
   try {

--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -437,7 +437,25 @@ pub(crate) fn upsert_env(
         std::fs::create_dir_all(parent)?;
     }
     let content = format!("{}\n", lines.join("\n"));
-    std::fs::write(path, content)
+    std::fs::write(path, content)?;
+
+    // `std::fs::write` applies the process umask, so this file was typically
+    // 0644 — readable by every other local account. It holds the SQLCipher
+    // database key (`db_key::ensure_key`), tracker API tokens, and OAuth
+    // credentials, and it sits in the same directory as the database that key
+    // protects, so a readable copy defeats encryption-at-rest against the
+    // local-multi-user threat it exists for.
+    //
+    // Tightened here rather than at each caller: this is the single writer of
+    // `~/.meridian/.env`, so doing it once covers every secret that lands in it
+    // now and every one added later. Non-fatal on failure would hide the
+    // problem, so it propagates.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
 }
 
 /// Disconnect a tracker (the ported /api/integrations DELETE). Removes the
@@ -1782,6 +1800,32 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("meridian-int-test-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         dir.join(name)
+    }
+
+    /// `.env` holds the SQLCipher database key, tracker API tokens and OAuth
+    /// credentials, and sits beside the database that key protects - so the
+    /// default-umask 0644 this used to inherit made encryption-at-rest useless
+    /// against the local-multi-user threat it exists for.
+    #[cfg(unix)]
+    #[test]
+    fn upsert_env_writes_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let path = tmp_env("upsert-perms.env");
+        let _ = std::fs::remove_file(&path);
+
+        let mut updates = BTreeMap::new();
+        updates.insert("MERIDIAN_DB_KEY".to_string(), "a".repeat(64));
+        upsert_env(&path, &updates).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "new .env is group/world readable: {mode:o}");
+
+        // ...and a pre-existing loose file is tightened rather than left alone,
+        // which is the case that actually matters: every install that has run
+        // before this fix already has a 0644 file on disk.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        upsert_env(&path, &updates).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "existing loose .env not tightened: {mode:o}");
     }
 
     #[test]

--- a/tray/src-tauri/src/commands/setup.rs
+++ b/tray/src-tauri/src/commands/setup.rs
@@ -278,7 +278,13 @@ pub async fn install_llm_provider(
 #[tracing::instrument]
 pub async fn cursor_sign_in() -> Result<meridian::llm::detect::InstallOutcome, String> {
     let outcome = meridian::llm::detect::cursor_sign_in().await;
-    tracing::info!(ok = outcome.ok, "llm: cursor sign-in complete");
+    // WARN on failure so a "sign-in doesn't work" report is greppable by
+    // level, without having to know to filter on the `ok` field.
+    if outcome.ok {
+        tracing::info!("llm: cursor sign-in complete");
+    } else {
+        tracing::warn!(detail = %outcome.message, "llm: cursor sign-in failed");
+    }
     Ok(outcome)
 }
 
@@ -290,7 +296,13 @@ pub async fn cursor_sign_in() -> Result<meridian::llm::detect::InstallOutcome, S
 #[tracing::instrument]
 pub async fn codex_sign_in() -> Result<meridian::llm::detect::InstallOutcome, String> {
     let outcome = meridian::llm::detect::codex_sign_in().await;
-    tracing::info!(ok = outcome.ok, "llm: codex sign-in complete");
+    // WARN on failure so a "sign-in doesn't work" report is greppable by
+    // level, without having to know to filter on the `ok` field.
+    if outcome.ok {
+        tracing::info!("llm: codex sign-in complete");
+    } else {
+        tracing::warn!(detail = %outcome.message, "llm: codex sign-in failed");
+    }
     Ok(outcome)
 }
 
@@ -302,7 +314,13 @@ pub async fn codex_sign_in() -> Result<meridian::llm::detect::InstallOutcome, St
 #[tracing::instrument]
 pub async fn claude_sign_in() -> Result<meridian::llm::detect::InstallOutcome, String> {
     let outcome = meridian::llm::detect::claude_sign_in().await;
-    tracing::info!(ok = outcome.ok, "llm: claude sign-in complete");
+    // WARN on failure so a "sign-in doesn't work" report is greppable by
+    // level, without having to know to filter on the `ok` field.
+    if outcome.ok {
+        tracing::info!("llm: claude sign-in complete");
+    } else {
+        tracing::warn!(detail = %outcome.message, "llm: claude sign-in failed");
+    }
     Ok(outcome)
 }
 

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -244,7 +244,17 @@ pub fn run() {
                     Some(env_path) => match db_key::resolve_or_create_key(&env_path) {
                         Ok(key) => Some(key),
                         Err(e) => {
-                            eprintln!("tray: failed to resolve DB encryption key, continuing unencrypted: {e}");
+                            // `tracing`, not `eprintln!`: observability is
+                            // already initialised above, and on a packaged
+                            // install stderr goes only to the launchd log -
+                            // never `meridian logs`, the diagnostics bundle,
+                            // or central error reporting. A silent fallback to
+                            // an UNENCRYPTED database is exactly the event
+                            // those channels exist to surface.
+                            tracing::error!(
+                                error = %e,
+                                "failed to resolve DB encryption key - continuing unencrypted"
+                            );
                             None
                         }
                     },
@@ -264,8 +274,9 @@ pub fn run() {
                         match tauri::async_runtime::block_on(migrate) {
                             Ok(()) => Some(key.clone()),
                             Err(e) => {
-                                eprintln!(
-                                    "tray: failed to migrate meridian.db to encrypted storage, continuing unencrypted this run: {e}"
+                                tracing::error!(
+                                    error = %e,
+                                    "failed to migrate meridian.db to encrypted storage - continuing unencrypted this run"
                                 );
                                 None
                             }
@@ -285,7 +296,7 @@ pub fn run() {
                 &db_path,
                 db_key_hex.as_deref(),
             ))
-            .map_err(|e| eprintln!("tray: meridian.db not opened ({db_path}): {e}"))
+            .map_err(|e| tracing::error!(error = %e, db_path = %db_path, "meridian.db not opened"))
             .ok();
             // Capture (slice 4a) writes to the SAME read-write pool the commands
             // use — clone the handle before it's moved into managed state.


### PR DESCRIPTION
Closes **5 of the 11** findings left open on the release PR #582. Follows #594, which handled the 13 in code I authored.

Each of these is additive or a one-line substitution with no dependence on invariants I would be guessing at.

> **Deliberately NOT here: the two `db_crypto.rs` rename-ordering findings.** The `encrypt_in_place` crash window is real, but the suggested `hard_link` fix is not a drop-in - it fails on filesystems without link support and across devices, and it changes what a crash leaves behind, since the plaintext original then survives at both paths until the final rename. Getting that wrong corrupts user databases. It needs its author.

## Fixed

**Plaintext export was world-readable** (`db_crypto.rs`) - the ATTACH-created file inherited the umask, typically `0644`. This is the *one* file the SQLCipher work deliberately writes unencrypted, so leaving it group/world-readable undid, for that file, the local-multi-user threat the rest of the encryption exists to cover. Now `0600`, tightened after the export because ATTACH wants to create the file itself. Asserted in the existing roundtrip test.

**`.env` was world-readable** (`upsert_env`) - fixed at the **single writer** rather than at the `db_key` call site the review pointed at. That file holds the SQLCipher key, tracker API tokens *and* OAuth credentials, and it sits in the same directory as the database the key protects. Doing it once covers every secret in it now and every one added later.

The test covers both a fresh write and **tightening a pre-existing loose file** - which is the case that actually matters, since every install predating this already has a `0644` file on disk.

**Encryption degradation was invisible** (`lib.rs`) - three `eprintln!` sites are now structured `tracing::error!`. On a packaged install stderr reaches only the launchd log, never `meridian logs`, the diagnostics bundle, or central error reporting. "Continuing unencrypted" was invisible to exactly the people who need to know.

**MCP snapshot filename collided across databases** (`db-cache.ts`) - the review's analysis is exactly right:

```
Buffer.from(dbPath).toString("hex").slice(0, 16)   // hex of the first EIGHT bytes
"/Users/a"                                          // ...which is exactly eight
```

So `/Users/alice/.meridian/meridian.db` and `/Users/alison/.meridian/meridian.db` mapped to one snapshot file. Because `_dbCache`/`_dbLoadInFlight` key on `dbPath` rather than the derived path, two paths can resolve concurrently, and a collision lets one database's export overwrite the other between its export and its read - serving one user's data for a request against another's. Now a SHA-256 of the whole path.

**Sign-in failures logged at `info`** (`setup.rs`) - split by outcome across all three providers, so a "sign-in doesn't work" report is greppable by level. The failure detail rides on a `detail` field, which is **absent from `redact::SAFE_STRING_KEYS`** and therefore dropped at the ship leg - an installer's stderr tail stays local, which is where it belongs.

## Still open after this (6)

| Finding | File | Why |
|---|---|---|
| `encrypt_in_place` crash window | `db_crypto.rs` | See above - needs its author. |
| WAL not checkpointed on plain-copy | `main.rs` | Real staleness bug; the fix is `VACUUM INTO` or an explicit checkpoint, but it changes export semantics. |
| Stale staging sweep age check | `backend_install.rs` | Update-handoff race. |
| Provider-health instrumentation | `detect.rs` | Wants spans designed with the probe's own author. |
| Duplicate sign-in metadata x2 | `LlmProviderDetail.tsx` | Consolidation across two components. |

## Verification

Daemon 783 tests + `clippy -D warnings`. `meridian-core` db_crypto suite (4 tests). Tray 164 tests + clippy. UI build. MCP `tsc`.

Incidental: `packages/meridian-mcp/dist/` is **gitignored**, despite CLAUDE.md describing `dist/index.js` as committed. Only the TypeScript source is tracked, so the built output is not in this diff. Flagging rather than fixing the doc here, to keep a release-fix branch focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)