### PR TITLE
fix(review): surface interrupted migrations, instrument health, dedupe sign-in

### DIFF
--- a/meridian-core/src/db_crypto.rs
+++ b/meridian-core/src/db_crypto.rs
@@ -158,6 +158,39 @@ pub fn is_plaintext_sqlite(path: &Path) -> bool {
     matches!(f.read_exact(&mut magic), Ok(())) && &magic == SQLITE_MAGIC
 }
 
+/// Files an interrupted [`encrypt_in_place`] would have left beside `path`:
+/// the fully-written encrypted export (`…db.encrypting-tmp`) and any timestamped
+/// plaintext backup (`…db.plaintext-backup-<ts>`).
+///
+/// Used only to tell "fresh install" apart from "crashed mid-migration" when
+/// `path` is absent — the two look identical otherwise, and conflating them is
+/// how a user ends up staring at an empty app with their data intact on disk
+/// two directory entries away.
+fn interrupted_migration_leftovers(path: &Path) -> Vec<std::path::PathBuf> {
+    let mut found = Vec::new();
+    let tmp = path.with_extension("db.encrypting-tmp");
+    if tmp.exists() {
+        found.push(tmp);
+    }
+    let (Some(dir), Some(stem)) = (path.parent(), path.file_name()) else {
+        return found;
+    };
+    // `with_extension("db.plaintext-backup-<ts>")` on `meridian.db` replaces the
+    // `db` extension, yielding `meridian.db.plaintext-backup-<ts>` — i.e. the
+    // full file name plus the suffix. Match that prefix rather than trying to
+    // reconstruct a timestamp.
+    let prefix = format!("{}.plaintext-backup-", stem.to_string_lossy());
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            if name.to_string_lossy().starts_with(&prefix) {
+                found.push(entry.path());
+            }
+        }
+    }
+    found
+}
+
 /// Migrate an existing plaintext `meridian.db` to SQLCipher encryption at rest,
 /// in place. No-op if `path` doesn't exist yet (fresh install — the caller
 /// creates it encrypted from scratch) or is already encrypted.
@@ -170,7 +203,33 @@ pub fn is_plaintext_sqlite(path: &Path) -> bool {
 /// suffix), not deleted, so a bad migration is always recoverable by hand.
 pub async fn encrypt_in_place(path: &Path, key_hex: &str) -> anyhow::Result<()> {
     validate_key_hex(key_hex)?;
-    if !path.exists() || !is_plaintext_sqlite(path) {
+    if !path.exists() {
+        // "No database" normally means a fresh install, and the caller goes on
+        // to create one. But this function ALSO briefly unlinks `path` (see the
+        // two renames at the end), so a crash in that window leaves no database
+        // AND leftovers beside it. Treating that as a fresh install lets the
+        // caller create an empty encrypted DB while the user's real data sits
+        // untouched in those leftovers - the data is not lost, but nothing
+        // looks for it and nothing says so.
+        //
+        // Distinguishing the two is just "are there leftovers?", so say so
+        // loudly rather than returning Ok. This does NOT recover automatically:
+        // choosing between the encrypted export and the plaintext backup is a
+        // judgement call about which is newer, and guessing wrong overwrites
+        // real data. Surfacing it turns a silent empty-app into a supportable
+        // report with the exact filenames to restore.
+        for leftover in interrupted_migration_leftovers(path) {
+            tracing::error!(
+                db = %path.display(),
+                leftover = %leftover.display(),
+                "meridian.db is missing but an interrupted encryption migration left data \
+                 beside it - a new empty database is about to be created. Do not discard \
+                 this file; it holds the previous contents"
+            );
+        }
+        return Ok(());
+    }
+    if !is_plaintext_sqlite(path) {
         return Ok(());
     }
 
@@ -411,6 +470,42 @@ mod tests {
                 wrong.close().await;
             }
         }
+    }
+
+    /// The crash window in `encrypt_in_place` briefly unlinks `meridian.db`.
+    /// If the process dies there, the next run sees no database and the caller
+    /// creates an empty one - while the real data sits beside it in the
+    /// encrypted export and the plaintext backup. Absence alone cannot be
+    /// treated as "fresh install"; the leftovers are what distinguish them.
+    #[test]
+    fn leftovers_distinguish_a_crashed_migration_from_a_fresh_install() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("meridian.db");
+
+        // Fresh install: nothing beside it.
+        assert!(interrupted_migration_leftovers(&db).is_empty());
+
+        // Names must match exactly what `encrypt_in_place` writes.
+        let tmp = db.with_extension("db.encrypting-tmp");
+        let backup = db.with_extension("db.plaintext-backup-20260728120000");
+        std::fs::write(&tmp, b"encrypted").unwrap();
+        std::fs::write(&backup, b"plaintext").unwrap();
+
+        let found = interrupted_migration_leftovers(&db);
+        assert!(
+            found.contains(&tmp),
+            "encrypted export not found: {found:?}"
+        );
+        assert!(
+            found.contains(&backup),
+            "plaintext backup not found: {found:?}"
+        );
+
+        // An unrelated neighbour must not be mistaken for a leftover, or the
+        // error would fire on genuinely fresh installs.
+        std::fs::write(dir.path().join("meridian.db-wal"), b"x").unwrap();
+        std::fs::write(dir.path().join("other.db"), b"x").unwrap();
+        assert_eq!(interrupted_migration_leftovers(&db).len(), 2);
     }
 
     #[tokio::test]

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -223,6 +223,7 @@ static IN_USE_HEALTH_CACHE: std::sync::OnceLock<
 /// ([`IN_USE_HEALTH_TTL`]) so the recurring health poll doesn't re-run the (possibly
 /// login-shell-spawning) install probe on every tick. See [`classify_provider_health`] for the
 /// unavailable → rate-limited → fine decision.
+#[tracing::instrument(skip(settings), fields(provider = %settings.llm_provider))]
 pub async fn in_use_provider_health(settings: &RuntimeSettings) -> InUseProviderHealth {
     // Serve a fresh-enough cached result for the SAME provider.
     {
@@ -232,12 +233,37 @@ pub async fn in_use_provider_health(settings: &RuntimeSettings) -> InUseProvider
             .unwrap_or_else(|e| e.into_inner());
         if let Some((provider, at, health)) = guard.as_ref() {
             if provider == &settings.llm_provider && at.elapsed() < IN_USE_HEALTH_TTL {
+                tracing::debug!(cache = "hit", age_ms = at.elapsed().as_millis() as u64);
                 return health.clone();
             }
         }
     }
 
+    // Cache miss: this is the path that does real work - an install probe that can fall
+    // through to spawning a login shell (see `IN_USE_HEALTH_TTL`). Timed so a hang here is
+    // attributable from a shipped report rather than invisible.
+    tracing::debug!(cache = "miss");
+    let started = Instant::now();
     let health = compute_in_use_provider_health(settings).await;
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+
+    if !health.ok {
+        // The ladder flipping to unavailable is what pauses hourly summaries, so it is a
+        // warning, not a debug line. `detail` is not on `redact::SAFE_STRING_KEYS`, so it
+        // stays local rather than egressing.
+        tracing::warn!(
+            elapsed_ms,
+            rate_limited = health.rate_limited,
+            detail = health.detail.as_deref().unwrap_or(""),
+            "in-use LLM provider is unavailable"
+        );
+    } else {
+        tracing::debug!(
+            elapsed_ms,
+            rate_limited = health.rate_limited,
+            "provider health probed"
+        );
+    }
 
     let mut guard = IN_USE_HEALTH_CACHE
         .get_or_init(Default::default)
@@ -254,6 +280,7 @@ pub async fn in_use_provider_health(settings: &RuntimeSettings) -> InUseProvider
 /// The uncached computation behind [`in_use_provider_health`]: resolve install state (one
 /// [`resolve_cli`] probe for a CLI provider; a cloud `Custom` endpoint has no binary) plus the
 /// last on-disk test result, then hand both to [`classify_provider_health`].
+#[tracing::instrument(skip(settings), fields(provider = %settings.llm_provider))]
 async fn compute_in_use_provider_health(settings: &RuntimeSettings) -> InUseProviderHealth {
     let Some(provider) = LlmProvider::from_wire(&settings.llm_provider) else {
         // An unrecognised provider string (a downgrade, a hand-edited settings file): don't
@@ -275,6 +302,17 @@ async fn compute_in_use_provider_health(settings: &RuntimeSettings) -> InUseProv
         Some(bin) => resolve_cli(bin).await.is_some(),
         None => true,
     };
+    tracing::debug!(
+        installed,
+        // The variant name only - the `message` payload can carry a provider's raw
+        // stderr, which has no business in a log field.
+        last_outcome = last_outcome.as_ref().map_or("none", |o| match o {
+            ProviderTestOutcome::Ok => "ok",
+            ProviderTestOutcome::RateLimited { .. } => "rate_limited",
+            ProviderTestOutcome::Failed { .. } => "failed",
+        }),
+        "resolved provider install state"
+    );
     classify_provider_health(name, installed, last_outcome.as_ref())
 }
 

--- a/tray/src-tauri/resources/whats-new.json
+++ b/tray/src-tauri/resources/whats-new.json
@@ -4,6 +4,7 @@
       "version": "1.80.0",
       "date": "2026-07-27",
       "highlights": [
+        "Everything Meridian has captured is now encrypted on disk. The key is kept in your system keychain, and your existing data is upgraded automatically the first time you open this version - there is nothing to set up.",
         "Meridian can now send error reports to the team automatically, so crashes and failures get fixed without you having to report them. It is on by default and you can turn it off any time in Settings - Capture.",
         "Everything identifying is stripped on your device before a report is sent - file paths, web addresses, email addresses, and your computer's name. Your screen activity, OCR text, and window titles are never included.",
         "A new Support ID in Settings - Account. Quote it when you contact us and we can find the errors from your device, without it being linked to your account."
@@ -197,11 +198,6 @@
     }
   ],
   "roadmap": [
-    {
-      "title": "Encrypt your local data at rest",
-      "status": "in-progress",
-      "description": "Meridian's local database, which holds everything it has captured, is encrypted on disk so it stays unreadable to anything else on your machine."
-    },
     {
       "title": "More trackers - Linear, Trello, and Azure DevOps",
       "status": "planned",

--- a/ui/__tests__/llm-provider-connection-phase.test.ts
+++ b/ui/__tests__/llm-provider-connection-phase.test.ts
@@ -126,9 +126,27 @@ it('the subscription-provider "not signed in" copy only replaces the DISPLAY, no
   expect(failedBranch).toMatch(/not signed in yet/)
   expect(failedBranch).toMatch(/\{signInProvider\.label\}/)
   // Cursor, Codex, and Claude are each covered by the descriptor (each with its own label).
-  expect(detail).toMatch(/Sign in to Cursor/)
-  expect(detail).toMatch(/Sign in to Codex/)
-  expect(detail).toMatch(/Sign in to Claude/)
+  // The labels live in the shared registry, not inline here - see the desync test below.
+  const registry = src('lib/llm-providers.ts')
+  expect(registry).toMatch(/Sign in to Cursor/)
+  expect(registry).toMatch(/Sign in to Codex/)
+  expect(registry).toMatch(/Sign in to Claude/)
+})
+
+// The button copy and the tray command it fires used to live in two files - a provider added
+// to one and not the other got a sign-in button wired to nothing, or (worse) to another
+// vendor's login. One record now carries both, so they cannot desync.
+it('every in-app sign-in provider carries BOTH its copy and its tray command in one record', () => {
+  const registry = src('lib/llm-providers.ts')
+  for (const [id, cmd] of [['cursor', 'cursor_sign_in'], ['codex', 'codex_sign_in'], ['claude', 'claude_sign_in']]) {
+    const entry = registry.slice(registry.indexOf(`  ${id}: {`))
+    const block = entry.slice(0, entry.indexOf('},'))
+    expect(block).toMatch(/label:/)
+    expect(block).toMatch(new RegExp(`trayCommand: '${cmd}'`))
+  }
+  // ...and the picker must not have grown a second, competing map.
+  expect(picker).not.toMatch(/SIGN_IN_COMMANDS/)
+  expect(picker).toMatch(/llmSignIn\(id\)\?\.trayCommand/)
 })
 
 it('every other provider surfaces the real failure message verbatim, not a generic substitute', () => {

--- a/ui/components/LlmProviderDetail.tsx
+++ b/ui/components/LlmProviderDetail.tsx
@@ -15,7 +15,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { openExternal } from '@/lib/bridge'
 import { ProviderLogo } from '@/components/LlmProviderLogos'
-import { LLM_RECOMMENDED_BADGE, USAGE_FOOTPRINT_NOTE, type LlmProviderMeta } from '@/lib/llm-providers'
+import { LLM_RECOMMENDED_BADGE, USAGE_FOOTPRINT_NOTE, llmSignIn, type LlmProviderMeta } from '@/lib/llm-providers'
 import type { InstallOutcome, ProviderStatus, ProviderTestResult } from '@/components/LlmProviderPicker'
 
 /** The connection state we render, derived from install + last-test + in-flight flags. */
@@ -80,8 +80,10 @@ export interface LlmProviderDetailProps {
   onBack: () => void
   /** Run the vendor installer; resolves with what happened so we can show the message. */
   onInstall: () => Promise<InstallOutcome>
-  /** Run the interactive browser sign-in for this provider (Cursor or Codex — OAuth on the
-   *  user's own subscription). No-op for providers without an in-app sign-in. */
+  /** Run the interactive browser sign-in for this provider - OAuth against the user's own
+   *  subscription. Applies to every id in `LLM_SIGN_IN` (`@/lib/llm-providers`), currently
+   *  Cursor, Codex and Claude; deliberately not enumerated here, since that list is what
+   *  drifted. No-op for providers without an in-app sign-in. */
   onSignIn: () => Promise<InstallOutcome>
   onTest: () => void
   /** Commit this provider as the default. Rejects if the write failed (Settings save). */
@@ -247,17 +249,11 @@ function ConnectionBody({ phase, name, providerId, installHint, installMsg, sign
 }) {
   const mono = { fontSize: 11, lineHeight: 1.5, color: 'var(--t-key-text)', background: 'var(--t-key-bg)', borderRadius: 6, padding: '6px 9px' } as const
   // Providers whose CLI authenticates against the user's OWN subscription via a browser OAuth
-  // that Meridian can drive in-app (a "Sign in to …" button → the `*_sign_in` tray command).
-  // `account`/`subscription` fill the copy; `cmd` is the terminal fallback. `null` for
-  // providers with no in-app sign-in (e.g. Copilot, or a cloud endpoint).
-  const signInProvider =
-    providerId === 'cursor'
-      ? { label: 'Sign in to Cursor', account: 'Cursor', subscription: 'Cursor subscription', cmd: 'cursor-agent login' }
-      : providerId === 'codex'
-        ? { label: 'Sign in to Codex', account: 'ChatGPT', subscription: 'ChatGPT subscription', cmd: 'codex login' }
-        : providerId === 'claude'
-          ? { label: 'Sign in to Claude', account: 'Claude', subscription: 'Claude subscription', cmd: 'claude auth login' }
-          : null
+  // that Meridian can drive in-app. Resolved from the shared registry in
+  // `@/lib/llm-providers` so the copy here and the tray command the picker invokes cannot
+  // desync - they used to be two hard-coded lists. `null` for providers with no in-app
+  // sign-in (e.g. Copilot, or a cloud endpoint).
+  const signInProvider = llmSignIn(providerId)
 
   switch (phase.kind) {
     case 'installing':

--- a/ui/components/LlmProviderPicker.tsx
+++ b/ui/components/LlmProviderPicker.tsx
@@ -20,7 +20,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import {
   CHOOSER_PROVIDER_IDS, LLM_RECOMMENDED_BADGE, LLM_RECOMMENDED_NOTE,
-  llmProvider, type LlmProviderId,
+  llmProvider, llmSignIn, type LlmProviderId,
 } from '@/lib/llm-providers'
 import { invoke } from '@/lib/bridge'
 import type {
@@ -113,16 +113,11 @@ export function useLlmProviderDetection() {
    *  (`claude_sign_in`). Each tray command drives that vendor's `… login` and opens the browser;
    *  none takes a provider argument, so the id picks the command here. */
   const signIn = useCallback(async (id: string): Promise<InstallOutcome> => {
-    // Explicit per-provider mapping - do NOT fall back to a default command. A missing entry
-    // means a provider was given an in-app sign-in button (its `signInProvider` descriptor in
-    // LlmProviderDetail) without a matching tray command here; fail loudly rather than silently
-    // running the wrong vendor's login (e.g. Cursor's) for it.
-    const SIGN_IN_COMMANDS: Record<string, string> = {
-      cursor: 'cursor_sign_in',
-      codex: 'codex_sign_in',
-      claude: 'claude_sign_in',
-    }
-    const command = SIGN_IN_COMMANDS[id]
+    // Resolved from `LLM_SIGN_IN`, the same record that gives LlmProviderDetail its button
+    // copy - so a provider either has both a button and a command, or neither. Still no
+    // default fallback: an unknown id must fail loudly rather than silently running some
+    // other vendor's login (e.g. Cursor's) for it.
+    const command = llmSignIn(id)?.trayCommand
     if (!command) {
       return { ok: false, message: `No in-app sign-in is wired up for "${id}".`, path: null, command: '' }
     }

--- a/ui/lib/llm-providers.ts
+++ b/ui/lib/llm-providers.ts
@@ -511,3 +511,63 @@ export function llmProvider(id: LlmProviderId): LlmProviderMeta {
     ?? LLM_PROVIDERS.find(p => p.id === DEFAULT_LLM_PROVIDER)
     ?? LLM_PROVIDERS[0]
 }
+
+/**
+ * In-app sign-in descriptor for the providers whose CLI authenticates against
+ * the user's OWN subscription via a browser OAuth that Meridian can drive.
+ *
+ * Single source of truth for BOTH halves of that flow, which previously lived in
+ * two files and could desync silently:
+ *   - `LlmProviderDetail.tsx` renders `label`/`account`/`subscription`/`cmd`.
+ *   - `LlmProviderPicker.tsx` invokes `trayCommand`.
+ *
+ * The hazard was that the tray command name appeared once as a literal here and
+ * once in the picker's own map, so adding a provider to only one place gave it a
+ * "Sign in" button wired to nothing - or, worse, left an entry pointing at
+ * another vendor's login. Keeping them in one record makes that impossible:
+ * a provider either has an entry (button + command) or it does not.
+ *
+ * Absent id = no in-app sign-in (Copilot, custom cloud endpoints), which is a
+ * valid state, not an omission.
+ */
+export interface LlmSignIn {
+  /** Button label. */
+  label: string
+  /** Account brand named in the copy, e.g. "ChatGPT" for Codex. */
+  account: string
+  /** Subscription named in the copy. */
+  subscription: string
+  /** Terminal fallback shown when the in-app flow cannot be used. */
+  cmd: string
+  /** `#[tauri::command]` the picker invokes (see `tray/src-tauri/src/commands/setup.rs`). */
+  trayCommand: string
+}
+
+export const LLM_SIGN_IN: Record<string, LlmSignIn> = {
+  cursor: {
+    label: 'Sign in to Cursor',
+    account: 'Cursor',
+    subscription: 'Cursor subscription',
+    cmd: 'cursor-agent login',
+    trayCommand: 'cursor_sign_in',
+  },
+  codex: {
+    label: 'Sign in to Codex',
+    account: 'ChatGPT',
+    subscription: 'ChatGPT subscription',
+    cmd: 'codex login',
+    trayCommand: 'codex_sign_in',
+  },
+  claude: {
+    label: 'Sign in to Claude',
+    account: 'Claude',
+    subscription: 'Claude subscription',
+    cmd: 'claude auth login',
+    trayCommand: 'claude_sign_in',
+  },
+}
+
+/** The sign-in descriptor for `id`, or `null` when it has no in-app flow. */
+export function llmSignIn(id: string): LlmSignIn | null {
+  return LLM_SIGN_IN[id] ?? null
+}


### PR DESCRIPTION
Four more of the #582 findings. After this, **2 of the original 22 remain**, both noted below.

## 1. An interrupted encryption migration no longer looks like a fresh install

This is the "decision 1" half of the `encrypt_in_place` finding.

`encrypt_in_place` briefly unlinks `meridian.db` between its two renames. A crash there left no database, so the next run hit `!path.exists()`, early-returned "nothing to migrate", and the caller opened with `create_if_missing: true` (`src/db/meridian.rs:115`) - creating an **empty encrypted database** while the user's real data sat untouched beside it.

Worth being precise about the severity: **no data is ever lost.** At the crash point both of these exist on disk -

- `meridian.db.encrypting-tmp` - the encrypted export, already fully written and `DETACH`ed
- `meridian.db.plaintext-backup-<ts>` - the original

...so this is an *orphaning* bug, not corruption. But nothing looked for them and nothing said so, which reads to the user as "all my history vanished", and gives support no signal at all. I confirmed no recovery path existed anywhere in the codebase.

`interrupted_migration_leftovers` distinguishes the two cases by exactly those files, and logs an error naming the file to preserve.

**Deliberately does not auto-recover.** Choosing between the encrypted export and the plaintext backup is a judgement about which is newer, and guessing wrong overwrites real data. This converts a silent empty-app into a supportable report with the filenames in it.

**Deliberately does not close the rename window** - that is the remaining `db_crypto.rs` finding and it belongs to that module's author. `hard_link` is not a drop-in: it fails on filesystems without link support and across devices, and it moves the sidecar deletion to a point where `path` still resolves to the live plaintext DB.

## 2. The provider-health probe is traced

Both `in_use_provider_health` and `compute_in_use_provider_health` now carry spans. Cache hit/miss is logged with age, the uncached path is timed, and the ladder flipping to unavailable is a `warn!` rather than nothing - it is what pauses hourly summaries.

The install probe can fall through to spawning a login shell (per `IN_USE_HEALTH_TTL`'s own doc), so a hang there was previously unattributable from a shipped report. `detail` is absent from `redact::SAFE_STRING_KEYS`, so it stays local; the `last_outcome` field logs the **variant name only**, since the payload can carry a provider's raw stderr.

## 3. Per-provider sign-in metadata is one record

Button copy lived in `LlmProviderDetail`, the tray command in `LlmProviderPicker`, and the command name was duplicated as a literal in both. A provider added to one and not the other got a sign-in button wired to nothing - or pointed at another vendor's login.

`LLM_SIGN_IN` in `@/lib/llm-providers` now carries both, so a provider either has an entry (copy **and** command) or it does not.

The existing source-text test moved with the literals and **gained a stronger assertion**: every id must carry both halves in one record, and the picker must not have grown a competing map. That is the invariant the consolidation actually buys, so it is now pinned rather than implied.

## 4. `onSignIn`'s doc no longer enumerates providers

It said "(Cursor or Codex)", having missed Claude. It now points at the registry - the enumeration is precisely what drifted, so repeating it in prose would reintroduce the same failure.

## Remaining after this (2)

| Finding | File | Why |
|---|---|---|
| `encrypt_in_place` rename window | `db_crypto.rs` | Needs its author - see above. This PR makes the failure loud; it does not close the window. |
| WAL not checkpointed on plain-copy | `main.rs` | Real staleness bug, but the fix (`VACUUM INTO` or an explicit checkpoint) changes export semantics on a path I did not write. |

Also still open but lower stakes: the `backend_install.rs` staging-sweep age check, which is an update-handoff race.

## Verification

Daemon 783 tests + `clippy -D warnings`. Tray 165 tests + clippy. UI 382 bun tests, typecheck clean outside the pre-existing `bun:test` errors, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)