### PR TITLE
ci(release): stop wasting rust-cache quota on unreusable tag-ref saves

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -325,11 +325,23 @@ jobs:
           # on every run; caching the source directory removes the cause.
           cache-directories: |
             ~/.cargo/registry/src
-          # Save from the branches that actually cut releases. A run restores
-          # from its own ref or the DEFAULT branch only — it cannot read a
-          # sibling branch — so main must write its own copy or production
-          # releases can never warm from staging's.
-          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/pre-main' || startsWith(github.ref, 'refs/tags/v') }}
+          # Only ever save from `main`. A run restores from its own ref OR the
+          # default branch — nothing else — so a save on a tag ref is only
+          # ever restorable by a byte-identical re-run of that SAME tag, which
+          # in practice never happens (every release is a brand-new tag).
+          # `startsWith(refs/tags/v)` used to be in this condition on the
+          # theory that "main must write its own copy or releases can never
+          # warm from staging's" — but staging never had one to warm FROM in
+          # the first place, and every tag build was quietly writing a
+          # ~1.5 GB entry nothing could ever read back, which is what pushed
+          # the repo's cache quota (10 GiB, evicted globally by LRU once
+          # crossed) to the point of evicting entries other jobs actually
+          # need. `refs/heads/pre-main` was dead for the same underlying
+          # reason from a different angle: this workflow only ever triggers
+          # on a `v*` tag push or `workflow_dispatch` (see the `on:` block),
+          # never on a push to `pre-main` itself, so that branch of the
+          # condition could never evaluate true.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - uses: actions/setup-node@v4
         with:
@@ -679,7 +691,20 @@ jobs:
           # cache shared across every workflow that compiles this target.
           add-job-id-key: false
           shared-key: windows-release-x86_64-pc-windows-msvc
-          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/pre-main' || startsWith(github.ref, 'refs/tags/v') }}
+          # Only ever save from `main` — see the macOS job's rust-cache step
+          # for the full reasoning. This one in particular had NEVER once
+          # saved to `main` (confirmed via the cache API: every
+          # windows-release-* entry that ever existed was tag-scoped), so
+          # every tag-triggered Windows release build restored nothing and
+          # compiled OpenSSL-from-source + SQLCipher + the daemon/tray from a
+          # stone-cold cache — every single time, not just once. Restoring
+          # `main`'s cache instead of a dead tag copy is what actually makes
+          # this job fast; dropping the tag-ref save alone would only make it
+          # cold forever instead of cold most of the time, so this job's
+          # `main`-scoped cache needs to exist before this change helps —
+          # currently seeded via a one-off `workflow_dispatch` run with branch
+          # context set to `main`.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -95,9 +95,24 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing v*-staging* tag to (re)build and publish"
+        description: "Existing v*-staging* tag to (re)build and publish (or to compile against, if cache_warm_only)"
         required: true
         type: string
+      cache_warm_only:
+        # For seeding the `main`-scoped rust-cache entries the macos/windows
+        # jobs' `save-if` conditions require (see their rust-cache steps) —
+        # a tag push can only ever restore a cache saved on that SAME tag or
+        # on `main`, never a sibling tag, so a `main`-scoped entry has to
+        # exist before any tag build can warm-start. Dispatching this
+        # workflow with branch context = `main` and this input set to true
+        # compiles + saves the cache exactly like a real release build would,
+        # but skips creating/publishing anything — no draft release, no
+        # signing, no notarization, no asset upload. Safe to run against an
+        # already-published tag for exactly that reason.
+        description: "Compile + warm the release rust-cache only. Skips creating/publishing a release entirely. Run with branch context = main."
+        required: false
+        type: boolean
+        default: false
 
 # Serialise releases. Two in flight would fight over the rolling updater tag,
 # the shared caches, and Apple's notarization throughput. Never cancel in
@@ -198,6 +213,7 @@ jobs:
           echo "✓ Cargo.toml version ${manifest} matches the tag"
 
       - name: Create (or reuse) the draft release
+        if: ${{ !inputs.cache_warm_only }}
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.ctx.outputs.tag }}
@@ -442,9 +458,11 @@ jobs:
         # Replaces the stub with the binary the same invocation just produced.
         # `tauri bundle` reads bundle.resources contents at THIS point, so the
         # real file only has to exist now, not at compile time.
+        if: ${{ !inputs.cache_warm_only }}
         run: cp "target/${{ matrix.target }}/release/meridian" target/release/meridian
 
       - name: Import Developer ID certificate + notarization key
+        if: ${{ !inputs.cache_warm_only }}
         uses: ./.github/actions/import-apple-cert
         with:
           apple-certificate: ${{ secrets.APPLE_CERTIFICATE }}
@@ -455,10 +473,12 @@ jobs:
         # Must precede bundling: the daemon is copied into the .app as a
         # resource, and re-signing the enclosing bundle does not sign nested
         # Mach-Os.
+        if: ${{ !inputs.cache_warm_only }}
         run: bash scripts/sign-daemon.sh
 
       - name: Bundle, sign and notarize the app
         working-directory: tray
+        if: ${{ !inputs.cache_warm_only }}
         env:
           CHANNEL: ${{ needs.prepare.outputs.channel }}
         # `tauri bundle` runs ZERO cargo invocations — it packages what is
@@ -512,7 +532,7 @@ jobs:
         # STABLE ONLY — staging is delivered by the updater, which never sets the
         # quarantine flag, so no notarization ticket is ever consulted. See the
         # APPLE_API_* note in this job's `env:` for the full reasoning.
-        if: needs.prepare.outputs.channel == 'stable'
+        if: ${{ !inputs.cache_warm_only && needs.prepare.outputs.channel == 'stable' }}
         # A notarization ticket is keyed to the cdhash of what was submitted, so
         # the stapled .app inside does not cover the container. Without this the
         # DMG a user downloads trips "can't check it for malicious software".
@@ -524,6 +544,7 @@ jobs:
         run: bash scripts/notarize-dmg.sh "$VERSION"
 
       - name: Package the updater artifacts
+        if: ${{ !inputs.cache_warm_only }}
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
         run: bash scripts/package-updater.sh "$VERSION"
@@ -538,12 +559,14 @@ jobs:
         # design) while every SIGNING check still runs — a staging build with a
         # broken signature must still fail loudly, because the updater's
         # relaunch depends on it.
+        if: ${{ !inputs.cache_warm_only }}
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
           MERIDIAN_CHANNEL: ${{ needs.prepare.outputs.channel }}
         run: bash scripts/verify-release-bundle.sh "$VERSION"
 
       - name: Upload this architecture's assets into the draft
+        if: ${{ !inputs.cache_warm_only }}
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.prepare.outputs.tag }}
@@ -776,11 +799,13 @@ jobs:
           }
 
       - name: Package the updater artifacts
+        if: ${{ !inputs.cache_warm_only }}
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
         run: bash scripts/package-updater-windows.sh "$VERSION"
 
       - name: Upload this platform's assets into the draft
+        if: ${{ !inputs.cache_warm_only }}
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.prepare.outputs.tag }}
@@ -813,6 +838,11 @@ jobs:
   publish:
     name: Compose manifest + publish
     needs: [prepare, macos, windows]
+    # Skipped entirely on a cache_warm_only dispatch — there is no draft
+    # release (prepare skipped creating one) and nothing was uploaded (macos/
+    # windows skipped their upload steps), so composing/publishing a manifest
+    # here would have nothing valid to compose from.
+    if: ${{ !inputs.cache_warm_only }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- `release-build.yml`'s rust-cache steps (macOS + Windows) had `save-if` write a copy on every `v*` tag push. A tag ref is one-shot — GitHub Actions cache restore only reaches the same ref or the default branch, so a tag-scoped save is only ever restorable by a byte-identical re-run of that exact tag, which never happens in practice.
- Confirmed via the cache API: `windows-release-x86_64-pc-windows-msvc` had **never once** been saved to `main` — only to throwaway tag refs — so every Windows release build compiled OpenSSL-from-source + SQLCipher + the daemon/tray against a stone-cold cache, every single run (checked 4 historical runs pre-dating the SQLCipher change too — always ~34-38 min, not a one-off).
- Those dead tag-ref entries (~1.4-1.5 GB each, accumulating release after release) are what pushed the repo's cache usage to ~9.8 GiB of the ~10 GiB cap, triggering GitHub's global LRU eviction across *all* caches in the repo, not just the stale ones.
- Also dropped the `refs/heads/pre-main` clause from `save-if` — this workflow only triggers on `v*` tag push or `workflow_dispatch` (see the `on:` block), never on a push to `pre-main` itself, so that clause could never evaluate true.
- New condition: `save-if: ${{ github.ref == 'refs/heads/main' }}`. Both channels (stable `vX.Y.Z` and staging `vX.Y.Z-staging.N`) run through the same build jobs off the same target-keyed shared-key, so both benefit equally once `main` holds a warm entry.

## `cache_warm_only` dispatch input (added)
`windows-release-x86_64-pc-windows-msvc` needs a one-time seed on `main` before the `save-if` change above actually speeds anything up — otherwise Windows goes from "cold most of the time" to "cold always", since nothing has ever populated a `main`-scoped entry for it.

Seeding that means running this workflow with branch context = `main`. Doing that with a plain `workflow_dispatch` would drag the whole `prepare` → `build` → `publish` pipeline along — including re-uploading assets and flipping an already-published release back through the draft/publish path, against a *real, already-shipped* tag. Added a `cache_warm_only` boolean input instead:

- `prepare`: still derives tag/version/channel (needed by the build jobs' env), but skips creating/reusing a draft release.
- `macos` / `windows`: compile, then skip every step after (staging the daemon, signing, notarizing, packaging, uploading).
- `publish`: skipped entirely (job-level `if`) — there's nothing valid to compose a manifest from.

To seed the Windows cache: Actions → this workflow → Run workflow → branch `main`, `tag` = any existing released tag (just needs a valid Cargo.lock to compile against), `cache_warm_only` = true.

## Test plan
- [x] `cargo fmt --check` / `cargo clippy` / `cargo test` via pre-push hook (workflow-only change, no Rust code touched)
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] A `cache_warm_only` dispatch on `main` produces a `windows-release-*` cache entry scoped to `refs/heads/main` and does NOT touch the existing release/assets for the tag it compiled against
- [ ] Subsequent tag-triggered release builds (staging and stable) restore from that `main` entry instead of building cold