### PR TITLE
feat(telemetry): per-user Support ID + platform prefix for alpha testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,6 +436,20 @@ machine a new identity on every network change, silently breaking the grouping
 the value exists for. See `telemetry_spool::machine_id` before touching any of
 this; `pseudonym_is_independent_of_the_captured_hostname` pins it.
 
+**ALPHA EXCEPTION (until 2026-08-28, `redact::ALPHA_ACCOUNT_OVERRIDE_EXPIRES_UNIX`):**
+while Meridian is in hand-picked-tester alpha, the two paragraphs above and
+below are only true when signed out. While a tester is signed in,
+`local_host_pseudonym` deliberately seeds from a salted hash of their Clerk
+account email instead (`redact::pseudonymize_account`, mirrored into
+`settings.json`'s `account_pseudonym` by the tray on sign-in/out — never the
+raw email) — so support can trace one tester's errors across their Mac and
+Windows machines, at the cost of the pseudonym now being genuinely tied to an
+account rather than only a machine. `redact::support_id_is_account_scoped`
+reports which mode is currently active (surfaced in Settings → Account's
+copy) so this state is never asserted where it isn't true. Past the expiry
+date every install reverts to the per-machine-only behaviour described below,
+automatically, with no deploy required.
+
 That pseudonym is the ONLY identifier on an error row — nothing associates it
 with an account, and the hash is one-way. So it is surfaced to the user as
 **Support ID** (Settings → Account, and `bundle-info.txt` inside an export

--- a/meridian-core/src/settings.rs
+++ b/meridian-core/src/settings.rs
@@ -307,6 +307,21 @@ pub struct RuntimeSettings {
     // at the struct level makes this `false` for every settings.json written before
     // this field existed, which is exactly the "reprompt existing users once" case.
     pub worklog_auto_generate_prompted: bool,
+    // ALPHA TESTING ONLY (hand-picked users, all on the same `stable`
+    // production channel as everyone else — there's no separate alpha
+    // channel to gate on). A salted, one-way hash of the signed-in Clerk
+    // account email — NEVER the raw email — written by the tray's
+    // `commands::account::save_account_email` (cleared on sign-out) and read
+    // by `telemetry_spool::redact::local_host_pseudonym` to seed the Support
+    // ID/shipped `host.name` per-USER instead of per-machine, so support can
+    // trace one alpha tester's errors across their Mac and Windows boxes.
+    // Only takes effect before `redact::ALPHA_ACCOUNT_OVERRIDE_EXPIRES_UNIX`
+    // (2026-08-28) — a hardcoded date, checked against the wall clock, is the
+    // revert here since channel can't distinguish alpha testers from anyone
+    // else on the same build. `None` (not signed in, or past the expiry)
+    // falls back to the pre-existing per-machine hardware-UUID pseudonym.
+    #[serde(default)]
+    pub account_pseudonym: Option<String>,
 }
 
 /// Default surface palette when `settings.json` predates the `theme` key. Must
@@ -366,6 +381,8 @@ impl Default for RuntimeSettings {
             // SETTINGS_DEFAULTS in ui/lib/settings.ts.
             worklog_auto_generate_time: None,
             worklog_auto_generate_prompted: false,
+            // Signed out (or never signed in) until the tray says otherwise.
+            account_pseudonym: None,
         }
     }
 }

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -423,6 +423,29 @@ const HOST_NAME_KEY: &str = "host.name";
 /// the bare hostname computed elsewhere.
 const HOST_PSEUDONYM_SALT: &str = "meridian.host.pseudonym.v1:";
 
+/// Domain-separation prefix for [`pseudonymize_account`] — deliberately
+/// DIFFERENT from [`HOST_PSEUDONYM_SALT`] so the two hash spaces can never be
+/// cross-compared (a candidate email hashed under the wrong salt would never
+/// match a machine pseudonym, and vice versa), even though both go through
+/// the same [`hash_pseudonym`] shape.
+const ACCOUNT_PSEUDONYM_SALT: &str = "meridian.account.pseudonym.v1:";
+
+/// Shared SHA-256-salt-and-truncate shape behind both [`pseudonymize_host`]
+/// and [`pseudonymize_account`]. Truncated to 16 hex chars (8 bytes): ample
+/// against collisions at fleet scale, short enough to read in a dashboard.
+fn hash_pseudonym(salt: &str, seed: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(salt.as_bytes());
+    hasher.update(seed.as_bytes());
+    let digest = hasher.finalize();
+    digest[..8].iter().fold(String::new(), |mut acc, b| {
+        use std::fmt::Write;
+        let _ = write!(acc, "{b:02x}");
+        acc
+    })
+}
+
 /// Replace a hostname with a stable, non-reversible pseudonym.
 ///
 /// Dropping `host.name` outright was the other option, and is what the review
@@ -443,16 +466,23 @@ const HOST_PSEUDONYM_SALT: &str = "meridian.host.pseudonym.v1:";
 /// should actually use — hashing a caller-supplied hostname is exactly the
 /// mistake this module had (see that function's doc).
 pub fn pseudonymize_host(seed: &str) -> String {
-    use sha2::{Digest, Sha256};
-    let mut hasher = Sha256::new();
-    hasher.update(HOST_PSEUDONYM_SALT.as_bytes());
-    hasher.update(seed.as_bytes());
-    let digest = hasher.finalize();
-    digest[..8].iter().fold(String::new(), |mut acc, b| {
-        use std::fmt::Write;
-        let _ = write!(acc, "{b:02x}");
-        acc
-    })
+    hash_pseudonym(HOST_PSEUDONYM_SALT, seed)
+}
+
+/// Hash a signed-in user's email into the same 16-hex shape as
+/// [`pseudonymize_host`], salted separately (see [`ACCOUNT_PSEUDONYM_SALT`]).
+///
+/// ALPHA TESTING ONLY — see [`local_host_pseudonym`]'s doc for the mechanism
+/// this feeds. `pub` because the tray computes this at sign-in
+/// (`tray/src-tauri/src/commands/account.rs::save_account_email`) and writes
+/// ONLY the resulting hash into `settings.json`'s `account_pseudonym` — the
+/// raw email never leaves that command.
+///
+/// Trimmed and lowercased before hashing so `User@Example.com` and
+/// `user@example.com` (the same signed-in person, different capitalisation)
+/// produce the identical pseudonym.
+pub fn pseudonymize_account(email: &str) -> String {
+    hash_pseudonym(ACCOUNT_PSEUDONYM_SALT, &email.trim().to_ascii_lowercase())
 }
 
 /// This machine's pseudonym - the exact value that appears as `host.name` in
@@ -488,11 +518,94 @@ pub fn pseudonymize_host(seed: &str) -> String {
 /// is a one-way hash of a low-entropy input, and hostnames are enumerable
 /// (`Akarshs-MacBook-Pro.local` can simply be hashed and compared) where a
 /// 128-bit hardware UUID is not.
+///
+/// # ALPHA TESTING ONLY — per-user override (expires 2026-08-28)
+/// Meridian's alpha runs on a small set of hand-picked testers, several of
+/// whom run Meridian on more than one machine. For that one-month window,
+/// support needs to trace a tester's errors across their devices, so this
+/// seeds from the signed-in account's pseudonym ([`pseudonymize_account`],
+/// mirrored into `settings.json` by `tray/src-tauri/src/commands/account.rs`)
+/// instead of the hardware id, when the tester is signed in. See
+/// [`choose_pseudonym_source`] for the exact rule.
+///
+/// This is gated on a hardcoded expiry date, NOT the release channel — unlike
+/// most temporary behaviour in this codebase, channel-gating doesn't apply
+/// here, because the hand-picked alpha testers install the SAME `stable`
+/// (production) channel build as every other user; there is no separate
+/// alpha channel to distinguish them by. So the automatic revert is time-based
+/// instead: once [`ALPHA_ACCOUNT_OVERRIDE_EXPIRES_UNIX`] passes, EVERY build —
+/// stable included — reverts to the per-machine pseudonym on its own, with no
+/// deploy required. If the alpha window needs to extend, bump that constant;
+/// if it needs to end early, drop it to `0`.
+///
+/// This is a genuine, if temporary, relaxation of "not tied to your account"
+/// (the Settings → Account copy says so explicitly during alpha) — it is NOT
+/// a bug if a Support ID changes on sign-out/sign-in-as-someone-else, unlike
+/// the network-change regression this module was originally written to fix.
+///
+/// The value is also prefixed `mac_`/`win_` ([`platform_prefix`]) so a quoted
+/// Support ID reads its own platform without a separate lookup.
 pub fn local_host_pseudonym() -> String {
+    format!("{}{}", platform_prefix(), pseudonym_body())
+}
+
+/// `mac_` / `win_` / `""` (never built for anything else). Read fresh each
+/// call — a `cfg!` check, not worth caching.
+fn platform_prefix() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "mac_"
+    } else if cfg!(target_os = "windows") {
+        "win_"
+    } else {
+        ""
+    }
+}
+
+/// Unix seconds marking the end of the ALPHA per-user pseudonym window —
+/// 2026-08-28T00:00:00Z, one month out from when this shipped (2026-07-28).
+/// See [`local_host_pseudonym`]'s ALPHA doc for why this is a date, not a
+/// channel check.
+const ALPHA_ACCOUNT_OVERRIDE_EXPIRES_UNIX: u64 = 1_787_875_200;
+
+/// Now, as Unix seconds. Failure (a clock so broken `UNIX_EPOCH` is in the
+/// future) reads as "expired" — `u64::MAX` — rather than "still in the alpha
+/// window", so a clock fault fails CLOSED toward the stricter per-machine
+/// pseudonym instead of silently keeping the relaxed one active forever.
+fn now_unix_or_expired() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(u64::MAX)
+}
+
+/// The pseudonym body (no platform prefix): the ALPHA-only account override
+/// when [`choose_pseudonym_source`] says it applies, else the ordinary
+/// hardware-seeded pseudonym.
+fn pseudonym_body() -> String {
+    let account_pseudonym = crate::config::load_runtime_settings().account_pseudonym;
+    if let Some(hash) = choose_pseudonym_source(now_unix_or_expired(), account_pseudonym.as_deref())
+    {
+        return hash;
+    }
     match machine_id::stable_machine_id() {
         Some(id) => pseudonymize_host(id),
         None => pseudonymize_host(&gethostname::gethostname().to_string_lossy()),
     }
+}
+
+/// The ALPHA per-user rule, isolated as a pure function of `now_unix` so it's
+/// testable without touching `settings.json` or the real system clock: the
+/// account pseudonym applies only before
+/// [`ALPHA_ACCOUNT_OVERRIDE_EXPIRES_UNIX`], and only when one is actually on
+/// record (signed in, non-empty).
+fn choose_pseudonym_source(now_unix: u64, account_pseudonym: Option<&str>) -> Option<String> {
+    if now_unix >= ALPHA_ACCOUNT_OVERRIDE_EXPIRES_UNIX {
+        return None;
+    }
+    account_pseudonym
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
 }
 
 fn is_safe_string_key(key: &str) -> bool {
@@ -1048,7 +1161,12 @@ mod tests {
         };
         assert!(!out.contains("Akarsh"), "raw hostname survived: {out}");
         assert!(!out.contains("MacBook"), "raw hostname survived: {out}");
-        assert_eq!(out.len(), 16, "expected a 16-hex-char pseudonym, got {out}");
+        // 16 hex chars plus whatever platform prefix this build carries.
+        assert_eq!(
+            out.len(),
+            platform_prefix().len() + 16,
+            "expected a 16-hex-char pseudonym (+ platform prefix), got {out}"
+        );
         // This machine's pseudonym, NOT a hash of the captured hostname — the
         // captured value is deliberately ignored (see `keep_attribute`).
         assert_eq!(out, local_host_pseudonym());
@@ -1185,6 +1303,97 @@ mod tests {
             };
             assert_eq!(out, value, "{key} was altered in transit");
         }
+    }
+
+    /// The Support ID / shipped `host.name` names its own platform so support
+    /// doesn't need a separate lookup to tell a Mac tester's row from a
+    /// Windows one.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn support_id_carries_the_platform_prefix() {
+        assert!(
+            local_host_pseudonym().starts_with("mac_"),
+            "expected a mac_ prefix: {}",
+            local_host_pseudonym()
+        );
+    }
+
+    /// [`pseudonymize_account`] must be salted separately from
+    /// [`pseudonymize_host`] — otherwise a hardware UUID and an email could
+    /// collide into the same identifier space, and a determined reader who
+    /// knows a candidate value of one kind could confirm it against the other.
+    #[test]
+    fn account_pseudonym_is_salted_independently_of_host_pseudonym() {
+        let same_string = "not-actually-an-email-or-a-uuid";
+        assert_ne!(
+            pseudonymize_host(same_string),
+            pseudonymize_account(same_string),
+            "account and host pseudonyms must not share a salt"
+        );
+    }
+
+    /// Case and incidental whitespace must not fork one person's Support ID
+    /// across their devices — Clerk emails aren't guaranteed to arrive
+    /// byte-identical from every call site.
+    #[test]
+    fn account_pseudonym_ignores_case_and_whitespace() {
+        assert_eq!(
+            pseudonymize_account("Alpha.Tester@Example.com"),
+            pseudonymize_account("  alpha.tester@example.com  ")
+        );
+        assert_ne!(
+            pseudonymize_account("alpha.tester@example.com"),
+            pseudonymize_account("someone.else@example.com")
+        );
+        assert_eq!(pseudonymize_account("alpha.tester@example.com").len(), 16);
+    }
+
+    /// The ALPHA per-user rule ([`choose_pseudonym_source`]), pinned as a pure
+    /// function of `now_unix` so it's testable without depending on the real
+    /// system clock. Alpha testers install the same `stable` channel as
+    /// everyone else, so this is gated on the expiry date, not the channel —
+    /// see [`ALPHA_ACCOUNT_OVERRIDE_EXPIRES_UNIX`].
+    #[test]
+    fn account_pseudonym_only_overrides_before_the_expiry() {
+        let hash = "deadbeefcafebabe";
+        let expiry = ALPHA_ACCOUNT_OVERRIDE_EXPIRES_UNIX;
+        assert_eq!(
+            choose_pseudonym_source(expiry, Some(hash)),
+            None,
+            "at the expiry instant, must already have reverted"
+        );
+        assert_eq!(
+            choose_pseudonym_source(expiry + 1, Some(hash)),
+            None,
+            "after expiry, must never take the per-user path, even when signed in"
+        );
+        assert_eq!(
+            choose_pseudonym_source(expiry - 1, Some(hash)),
+            Some(hash.to_string()),
+            "before expiry, signed in, must use the per-user pseudonym"
+        );
+    }
+
+    /// A clock fault (`now_unix_or_expired`'s `u64::MAX` sentinel) must fail
+    /// CLOSED — toward the stricter per-machine pseudonym — never toward
+    /// silently keeping the relaxed alpha behaviour active forever.
+    #[test]
+    fn a_broken_clock_reads_as_expired_not_as_still_in_the_window() {
+        assert_eq!(
+            choose_pseudonym_source(u64::MAX, Some("deadbeefcafebabe")),
+            None
+        );
+    }
+
+    /// Not signed in (or a corrupt/empty settings value) must fall back to the
+    /// ordinary per-machine pseudonym rather than propagating an empty string
+    /// through as a Support ID.
+    #[test]
+    fn account_pseudonym_absent_or_empty_falls_back_to_machine() {
+        let before_expiry = ALPHA_ACCOUNT_OVERRIDE_EXPIRES_UNIX - 1;
+        assert_eq!(choose_pseudonym_source(before_expiry, None), None);
+        assert_eq!(choose_pseudonym_source(before_expiry, Some("")), None);
+        assert_eq!(choose_pseudonym_source(before_expiry, Some("   ")), None);
     }
 
     /// Every other free-text case here is Unix-shaped, but Windows installs

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -593,6 +593,22 @@ fn pseudonym_body() -> String {
     }
 }
 
+/// Whether the Support ID [`local_host_pseudonym`] returns RIGHT NOW is the
+/// ALPHA per-user one rather than the per-machine one — i.e. whether it's
+/// currently fair to tell the user it identifies their account.
+///
+/// This exists so the Settings → Account copy can describe reality instead of
+/// a hardcoded, date-blind claim: calling [`choose_pseudonym_source`] with the
+/// exact same inputs [`pseudonym_body`] uses means the displayed explanation
+/// and the actual pseudonym can never disagree — signed out, it's `false` the
+/// same way `pseudonym_body` already falls back to the machine id; past
+/// [`ALPHA_ACCOUNT_OVERRIDE_EXPIRES_UNIX`], it's `false` for every install with
+/// no code change needed, the same automatic revert the pseudonym itself gets.
+pub fn support_id_is_account_scoped() -> bool {
+    let account_pseudonym = crate::config::load_runtime_settings().account_pseudonym;
+    choose_pseudonym_source(now_unix_or_expired(), account_pseudonym.as_deref()).is_some()
+}
+
 /// The ALPHA per-user rule, isolated as a pure function of `now_unix` so it's
 /// testable without touching `settings.json` or the real system clock: the
 /// account pseudonym applies only before
@@ -1394,6 +1410,50 @@ mod tests {
         assert_eq!(choose_pseudonym_source(before_expiry, None), None);
         assert_eq!(choose_pseudonym_source(before_expiry, Some("")), None);
         assert_eq!(choose_pseudonym_source(before_expiry, Some("   ")), None);
+    }
+
+    /// `MERIDIAN_SETTINGS_PATH` is process-global and cargo runs tests in
+    /// parallel threads — mirrors `meridian_core::settings`'s own `ENV_LOCK`.
+    static SUPPORT_ID_SETTINGS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// [`support_id_is_account_scoped`] exists so the Settings → Account copy
+    /// can never claim something the pseudonym itself isn't doing. Pinned
+    /// against [`choose_pseudonym_source`] directly (the same oracle
+    /// `pseudonym_body` uses) rather than a hardcoded expected bool, so this
+    /// test stays meaningful — and keeps passing — on either side of
+    /// [`ALPHA_ACCOUNT_OVERRIDE_EXPIRES_UNIX`], instead of quietly asserting
+    /// "true" and breaking the day the alpha window ends.
+    #[test]
+    fn support_id_is_account_scoped_matches_choose_pseudonym_source() {
+        let _guard = SUPPORT_ID_SETTINGS_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!(
+            "meridian-redact-support-id-scoped-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+        std::env::set_var("MERIDIAN_SETTINGS_PATH", &path);
+
+        for hash in [None, Some("deadbeefcafebabe")] {
+            match hash {
+                None => std::fs::write(&path, "{}").unwrap(),
+                Some(h) => {
+                    std::fs::write(&path, format!(r#"{{"account_pseudonym":"{h}"}}"#)).unwrap()
+                }
+            }
+            let expected = choose_pseudonym_source(now_unix_or_expired(), hash).is_some();
+            assert_eq!(
+                support_id_is_account_scoped(),
+                expected,
+                "disagreed for account_pseudonym = {hash:?}"
+            );
+        }
+
+        std::env::remove_var("MERIDIAN_SETTINGS_PATH");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Every other free-text case here is Unix-shaped, but Windows installs

--- a/tray/src-tauri/src/commands/account.rs
+++ b/tray/src-tauri/src/commands/account.rs
@@ -28,11 +28,26 @@
 //!   PostHog event is sent at all until this returns `Some` (the email
 //!   becomes the event's `distinct_id` directly, never an anonymous id).
 //!
+//! # ALPHA TESTING ONLY — per-user Support ID (expires 2026-08-28)
+//! [`save_account_email`] also derives a salted, one-way hash of the email
+//! (`meridian::telemetry_spool::redact::pseudonymize_account`) and mirrors
+//! ONLY that hash into `settings.json`'s `account_pseudonym` — never the raw
+//! email, which stays confined to this module's own `account.json`. The
+//! daemon has no other way to see who's signed in (`settings.json` is the one
+//! file both processes read), and it's what
+//! `telemetry_spool::redact::local_host_pseudonym` reads to seed the Support
+//! ID/shipped `host.name` per account instead of per machine, until that
+//! function's hardcoded expiry passes. [`clear_account_email`] clears it back
+//! out on sign-out. See that function's doc for the full rationale — this is
+//! gated on the wall clock, NOT the release channel, because the hand-picked
+//! alpha testers install the same `stable` build as everyone else.
+//!
 //! # Related
 //! - `crate::analytics` — the PostHog capture this feeds (email = `distinct_id`).
 //! - `commands::setup` — `mark_setup_complete`/`is_first_run`, the same
 //!   `~/.meridian/*` marker-file pattern this module follows.
 
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -122,7 +137,42 @@ pub async fn save_account_email(email: String) -> Result<(), String> {
         .map_err(|e| format!("join account write task: {e}"))?
         .map_err(|e| format!("persist account file: {e:#}"))?;
     tracing::info!("account: email captured");
+
+    // ALPHA TESTING ONLY — see the module doc. Mirrors ONLY the hash, never
+    // the email, into settings.json for the daemon to seed the per-user
+    // Support ID from.
+    write_account_pseudonym(Some(&email))
+        .await
+        .map_err(|e| format!("persist account pseudonym: {e:#}"))?;
+
     Ok(())
+}
+
+/// ALPHA TESTING ONLY (revert target: ~1 month from 2026-07-28) — mirror the
+/// signed-in account's hashed pseudonym into `settings.json`'s
+/// `account_pseudonym`, or clear it (`email = None`) on sign-out. Never
+/// writes the raw email — only
+/// [`meridian::telemetry_spool::redact::pseudonymize_account`]'s one-way
+/// hash, which is all `telemetry_spool::redact::local_host_pseudonym` needs.
+/// Clearing promptly on sign-out matters: a lingering hash would keep
+/// grouping error reports under someone no longer signed in on this machine.
+async fn write_account_pseudonym(email: Option<&str>) -> anyhow::Result<()> {
+    let hash = email.map(meridian::telemetry_spool::redact::pseudonymize_account);
+    tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+        let mut v = meridian_core::settings::read_settings_value();
+        if let Some(obj) = v.as_object_mut() {
+            obj.insert(
+                "account_pseudonym".to_string(),
+                match &hash {
+                    Some(h) => serde_json::Value::String(h.clone()),
+                    None => serde_json::Value::Null,
+                },
+            );
+        }
+        meridian_core::settings::write_settings_value(&v)
+    })
+    .await
+    .context("join settings write task")?
 }
 
 /// Read the persisted account email, if any. `None` before the sign-in step
@@ -154,6 +204,14 @@ pub async fn get_account_email() -> Option<String> {
 #[tauri::command]
 #[tracing::instrument]
 pub async fn clear_account_email() -> Result<(), String> {
+    // ALPHA TESTING ONLY (see module doc) — clear the mirrored pseudonym
+    // FIRST, so a crash between the two writes fails toward "back to the
+    // per-machine Support ID", never toward "still grouped under the old
+    // account" with no email left to explain why.
+    write_account_pseudonym(None)
+        .await
+        .map_err(|e| format!("clear account pseudonym: {e:#}"))?;
+
     let Some(path) = account_path() else {
         return Ok(());
     };

--- a/tray/src-tauri/src/commands/version.rs
+++ b/tray/src-tauri/src/commands/version.rs
@@ -266,10 +266,13 @@ pub(crate) fn build_channel() -> &'static str {
 pub struct AppInfo {
     pub version: String,
     pub channel: String,
-    /// This machine's pseudonym — the exact value error telemetry from here
-    /// carries as `host.name` in the central backend. Shown in Settings so a
-    /// user can quote it when they contact support; without it their error
-    /// rows are unfindable, since pseudonymisation is one-way by design.
+    /// This machine's pseudonym (ALPHA TESTING, until 2026-08-28: while
+    /// signed in, the signed-in account's pseudonym instead — see
+    /// `meridian::telemetry_spool::redact::local_host_pseudonym`'s doc) — the
+    /// exact value error telemetry from here carries as `host.name` in the
+    /// central backend. Shown in Settings so a user can quote it when they
+    /// contact support; without it their error rows are unfindable, since
+    /// pseudonymisation is one-way by design.
     pub support_id: String,
 }
 

--- a/tray/src-tauri/src/commands/version.rs
+++ b/tray/src-tauri/src/commands/version.rs
@@ -274,6 +274,17 @@ pub struct AppInfo {
     /// contact support; without it their error rows are unfindable, since
     /// pseudonymisation is one-way by design.
     pub support_id: String,
+    /// Whether `support_id` above is CURRENTLY the ALPHA per-user pseudonym
+    /// rather than the per-machine one — i.e. whether it's accurate to tell
+    /// the user it identifies their account right now. Backs the Settings →
+    /// Account copy (`AccountSection.tsx`), which switches wording based on
+    /// this instead of asserting it unconditionally: `false` while signed out
+    /// (still the per-machine id) and `false` again, automatically, once
+    /// `redact::ALPHA_ACCOUNT_OVERRIDE_EXPIRES_UNIX` passes — see
+    /// `redact::support_id_is_account_scoped`'s doc for why deriving this from
+    /// the same decision the pseudonym itself uses is what keeps the copy from
+    /// drifting out of sync with reality.
+    pub support_id_is_account_scoped: bool,
 }
 
 /// The binary's baked `tauri.conf.json` version (what the DMG updater compares
@@ -291,6 +302,8 @@ pub fn get_app_info(app: tauri::AppHandle) -> AppInfo {
     let version = app.package_info().version.to_string();
     let channel = build_channel().to_string();
     let support_id = meridian::telemetry_spool::redact::local_host_pseudonym();
+    let support_id_is_account_scoped =
+        meridian::telemetry_spool::redact::support_id_is_account_scoped();
     // `support_id` is deliberately NOT a field here. It is a machine
     // identifier, and it is already available where it is actually needed - the
     // command's return value, Settings → Account, and `bundle-info.txt` in an
@@ -301,6 +314,7 @@ pub fn get_app_info(app: tauri::AppHandle) -> AppInfo {
         version,
         channel,
         support_id,
+        support_id_is_account_scoped,
     }
 }
 

--- a/ui/components/timeline/settings/AccountSection.tsx
+++ b/ui/components/timeline/settings/AccountSection.tsx
@@ -92,7 +92,14 @@ export function AccountSection() {
             </span>
           )}
         </FieldRow>
-        <FieldRow label="Support ID" description="Identifies you in error reports during alpha testing, so we can trace issues across your devices. Quote it when you contact support so we can find the errors from your account.">
+        <FieldRow
+          label="Support ID"
+          description={
+            appInfo?.supportIdIsAccountScoped
+              ? 'Identifies you in error reports during alpha testing, so we can trace issues across your devices. Quote it when you contact support so we can find the errors from your account.'
+              : 'Identifies this device in error reports, without naming you or it. Quote it when you contact support so we can find the errors from this machine. It is not tied to your account and stays the same for this device.'
+          }
+        >
           {appInfo && (
             <div className="flex items-center gap-2">
               <span className="mt-body-sm font-mono" style={{ color: 'var(--t-muted)' }}>

--- a/ui/components/timeline/settings/AccountSection.tsx
+++ b/ui/components/timeline/settings/AccountSection.tsx
@@ -92,7 +92,7 @@ export function AccountSection() {
             </span>
           )}
         </FieldRow>
-        <FieldRow label="Support ID" description="Identifies this device in error reports, without naming you or it. Quote it when you contact support so we can find the errors from this machine. It is not tied to your account and stays the same for this device.">
+        <FieldRow label="Support ID" description="Identifies you in error reports during alpha testing, so we can trace issues across your devices. Quote it when you contact support so we can find the errors from your account.">
           {appInfo && (
             <div className="flex items-center gap-2">
               <span className="mt-body-sm font-mono" style={{ color: 'var(--t-muted)' }}>

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -659,6 +659,12 @@ export interface AppInfo {
   // a user can quote it to support; the hash is one-way, so without the user
   // supplying it their error rows cannot be located.
   supportId: string
+  // Whether `supportId` above is CURRENTLY the alpha-testing per-user
+  // pseudonym rather than the per-machine one — false while signed out, and
+  // false again automatically once the alpha window ends. Drives which
+  // Support ID description AccountSection.tsx shows, so that copy can't
+  // outlive what the pseudonym is actually doing.
+  supportIdIsAccountScoped: boolean
 }
 
 // ── LLM Lab (`get_llm_experiments` / `get_llm_experiment` / `run_llm_experiment`)


### PR DESCRIPTION
## Summary
- Hand-picked alpha testers run Meridian across multiple machines, and support needs to trace one person's errors across their devices for the next month.
- `local_host_pseudonym()` now prefixes `mac_`/`win_`, and — while signed in — seeds from a salted hash of the account email instead of the hardware UUID. The tray mirrors *only that hash* into `settings.json`'s new `account_pseudonym` field (never the raw email), and clears it on sign-out.
- Gated on a hardcoded expiry (`ALPHA_ACCOUNT_OVERRIDE_EXPIRES_UNIX`, 2026-08-28), not release channel — alpha testers install the same `stable`/production build as everyone else, so channel can't distinguish them. Past the expiry, every build reverts to the per-machine pseudonym automatically with no deploy needed; a broken clock fails closed toward that same stricter behavior.
- Updated the Settings → Account copy, which previously promised the Support ID was "not tied to your account" — true again once the alpha window ends.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (daemon + `meridian-core` + tray crates)
- [x] `cargo test` — 27 tests in `telemetry_spool::redact` (including new coverage for the platform prefix, account-hash salting/case-insensitivity, and the expiry-date gate + clock-fault-fails-closed case), plus `meridian-core::settings`
- [x] `npx tsc --noEmit` on `ui/` — no new errors
- [x] Full `pre-push` suite (fmt, clippy, UI build/tests, security audit, `cargo test`) passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)