### PR TITLE
fix(pm-sync): stop reporting network blips as credential failures

### DIFF
--- a/src/daily_plan.rs
+++ b/src/daily_plan.rs
@@ -236,7 +236,19 @@ mod tests {
 
     #[test]
     fn nudge_hold_back_covers_the_grace_hour_only() {
-        let now = Local::now();
+        // Anchored to local midday rather than `Local::now()`. The `stamp_ago`
+        // offsets below reach up to AUTO_OPEN_GRACE_SECS (1 h) into the past, so
+        // with the real clock every run between 00:00 and 01:00 local put those
+        // stamps on the PREVIOUS day - where `nudge_held_back` correctly reports
+        // "not held" for a prior-day marker, failing the assertions. The subject
+        // under test takes `now` as a parameter precisely so it need not depend
+        // on the wall clock; this uses that.
+        let now = Local::now()
+            .with_hour(12)
+            .and_then(|t| t.with_minute(0))
+            .and_then(|t| t.with_second(0))
+            .and_then(|t| t.with_nanosecond(0))
+            .expect("local midday exists on every date");
         let today = now.format("%Y-%m-%d").to_string();
         let stamp_ago =
             |secs: i64| meridian_core::plan_marker::stamp(&(now - chrono::Duration::seconds(secs)));

--- a/src/intelligence/mod.rs
+++ b/src/intelligence/mod.rs
@@ -123,7 +123,7 @@ pub async fn run_pm_sync(meridian: &SqlitePool, config: &Config) -> Result<()> {
                 // win. Anything still reaching here is a genuine infra error
                 // (a DB write, say), which classifies as terminal by default and
                 // now carries its whole cause chain.
-                let _ = providers::record_sync_failure(meridian, name, "refresh", &e).await;
+                providers::record_sync_failure(meridian, name, "refresh", &e).await;
             }
         }
     }

--- a/src/intelligence/mod.rs
+++ b/src/intelligence/mod.rs
@@ -47,9 +47,10 @@ pub async fn run_pm_force_sync(meridian: &SqlitePool, config: &Config) -> Result
             PmProviderConfig::Linear(cfg) => providers::linear::force_refresh(meridian, cfg).await,
             PmProviderConfig::Trello(cfg) => providers::trello::force_refresh(meridian, cfg).await,
             PmProviderConfig::AzureDevOps(cfg) => {
-                providers::azure_devops::force_refresh(meridian, cfg)
-                    .await
-                    .map(Some)
+                // No `.map(Some)`: azure_devops now returns `Option` like the
+                // other four, so a failure it already classified arrives as
+                // `Ok(None)` instead of an `Err` this loop would re-report.
+                providers::azure_devops::force_refresh(meridian, cfg).await
             }
         };
         match result {
@@ -59,8 +60,12 @@ pub async fn run_pm_force_sync(meridian: &SqlitePool, config: &Config) -> Result
                 println!("{name}: synced {} task(s)", keys.len());
             }
             Err(e) => {
-                tracing::warn!(provider = name, error = %e, "force sync failed");
-                eprintln!("{name}: sync failed: {e}");
+                // `{e:#}` - the full cause chain. A bare `{e}` printed only the
+                // outermost context, so the operator running a force sync saw
+                // "POST /graphql viewer" with the actual cause discarded.
+                let detail = providers::http::chain(&e);
+                tracing::warn!(provider = name, error = %detail, "force sync failed");
+                eprintln!("{name}: sync failed: {detail}");
             }
         }
     }
@@ -110,8 +115,15 @@ pub async fn run_pm_sync(meridian: &SqlitePool, config: &Config) -> Result<()> {
                 let _ = providers::clear_sync_error(meridian, name).await;
             }
             Err(e) => {
-                tracing::warn!(provider = name, error = %e, "provider refresh failed");
-                let _ = providers::stamp_sync_error(meridian, name, &e.to_string()).await;
+                // Was `stamp_sync_error(name, &e.to_string())`: unconditionally
+                // terminal, and `{e}` rather than `{e:#}` — both of the bugs the
+                // provider-level fix removes. That made this a silent undo
+                // button, since a provider could classify its own failure
+                // correctly and then have this generic write land on top and
+                // win. Anything still reaching here is a genuine infra error
+                // (a DB write, say), which classifies as terminal by default and
+                // now carries its whole cause chain.
+                let _ = providers::record_sync_failure(meridian, name, "refresh", &e).await;
             }
         }
     }

--- a/src/intelligence/providers/azure_devops/db.rs
+++ b/src/intelligence/providers/azure_devops/db.rs
@@ -109,26 +109,19 @@ pub(super) async fn stamp_sync(pool: &SqlitePool) -> Result<()> {
     Ok(())
 }
 
+/// Record a terminal Azure DevOps sync failure.
+///
+/// Delegates to the shared [`crate::intelligence::providers::stamp_sync_error`]
+/// rather than writing its own row, which fixes a silent bug: this used to
+/// stamp `last_synced_at = now` on a first-ever failure. Because
+/// `refresh_if_stale` skips the whole fetch while that column is recent, a
+/// failure suppressed its OWN next retry — and it would have made the
+/// transient-escalation clock (keyed on the same column) permanently
+/// unreachable. The shared helper writes the epoch sentinel instead;
+/// `no_provider_records_an_error_as_a_fresh_sync` pins it for every provider.
+///
+/// The title and remedy now come from the shared registry, so Azure DevOps is
+/// no longer the one provider whose notice copy lives somewhere else.
 pub(super) async fn stamp_error(pool: &SqlitePool, error: &str) -> Result<()> {
-    let now = chrono::Utc::now().to_rfc3339();
-    sqlx::query(
-        "INSERT INTO pm_sync_state (provider, last_synced_at, last_error)
-         VALUES ('azure_devops', ?, ?)
-         ON CONFLICT(provider) DO UPDATE SET last_error = excluded.last_error",
-    )
-    .bind(&now)
-    .bind(error)
-    .execute(pool)
-    .await
-    .context("recording azure_devops sync error")?;
-    let _ = crate::notices::raise(
-        pool,
-        "pm.azure_devops",
-        "error",
-        "Azure DevOps sync failing",
-        error,
-        Some("Set AZURE_DEVOPS_PAT in .env"),
-    )
-    .await;
-    Ok(())
+    super::super::stamp_sync_error(pool, "azure_devops", error).await
 }

--- a/src/intelligence/providers/azure_devops/db.rs
+++ b/src/intelligence/providers/azure_devops/db.rs
@@ -4,7 +4,7 @@
 //! Split from the connector root purely for file size.
 //!
 //! # Who calls this
-//! [`super::force_refresh`], via `db::{prune, stamp_sync, stamp_error}`.
+//! [`super::force_refresh`], via `db::{prune, stamp_sync}`.
 
 use anyhow::{Context, Result};
 use sqlx::SqlitePool;
@@ -107,21 +107,4 @@ pub(super) async fn stamp_sync(pool: &SqlitePool) -> Result<()> {
     .context("updating azure_devops sync state")?;
     let _ = crate::notices::clear(pool, "pm.azure_devops").await;
     Ok(())
-}
-
-/// Record a terminal Azure DevOps sync failure.
-///
-/// Delegates to the shared [`crate::intelligence::providers::stamp_sync_error`]
-/// rather than writing its own row, which fixes a silent bug: this used to
-/// stamp `last_synced_at = now` on a first-ever failure. Because
-/// `refresh_if_stale` skips the whole fetch while that column is recent, a
-/// failure suppressed its OWN next retry — and it would have made the
-/// transient-escalation clock (keyed on the same column) permanently
-/// unreachable. The shared helper writes the epoch sentinel instead;
-/// `no_provider_records_an_error_as_a_fresh_sync` pins it for every provider.
-///
-/// The title and remedy now come from the shared registry, so Azure DevOps is
-/// no longer the one provider whose notice copy lives somewhere else.
-pub(super) async fn stamp_error(pool: &SqlitePool, error: &str) -> Result<()> {
-    super::super::stamp_sync_error(pool, "azure_devops", error).await
 }

--- a/src/intelligence/providers/azure_devops/fetch.rs
+++ b/src/intelligence/providers/azure_devops/fetch.rs
@@ -88,12 +88,22 @@ pub(super) async fn run_wiql(
     let status = resp.status();
     if !status.is_success() {
         let text = resp.text().await.unwrap_or_default();
+        // The 401/403 guidance is kept verbatim as the error body, so a dead or
+        // under-scoped PAT still tells the user exactly what to do. Carrying the
+        // status in a typed error (rather than only in prose) is what lets
+        // `http::classify` retry a 429/5xx quietly while these two still raise a
+        // banner - they are the cases nothing self-heals.
         let msg = match status.as_u16() {
-            401 => "permission_error: PAT is invalid or expired — regenerate it in Azure DevOps User settings → Personal access tokens".to_string(),
-            403 => "permission_error: PAT lacks required scope — create a token with Work Items → Read & write scope".to_string(),
-            _ => format!("sync_error: HTTP {status}: {text}"),
+            401 => "permission_error: PAT is invalid or expired - regenerate it in Azure DevOps User settings, Personal access tokens".to_string(),
+            403 => "permission_error: PAT lacks required scope - create a token with Work Items Read & write scope".to_string(),
+            _ => text,
         };
-        anyhow::bail!("{msg}");
+        return Err(crate::intelligence::providers::http::HttpStatusError::new(
+            status.as_u16(),
+            "Azure DevOps WIQL",
+            &msg,
+        )
+        .into());
     }
     let wiql: WiqlResponse = resp.json().await.context("parsing WIQL response")?;
     Ok(wiql.work_items.iter().map(|w| w.id).collect())
@@ -139,7 +149,12 @@ pub(super) async fn fetch_batch(
     let status = resp.status();
     if !status.is_success() {
         let text = resp.text().await.unwrap_or_default();
-        anyhow::bail!("Azure DevOps work items batch returned {status}: {text}");
+        return Err(crate::intelligence::providers::http::HttpStatusError::new(
+            status.as_u16(),
+            "Azure DevOps work items batch",
+            &text,
+        )
+        .into());
     }
     let text = resp.text().await.context("reading batch response body")?;
     // Parse once as a Value so each raw work item survives verbatim for the

--- a/src/intelligence/providers/azure_devops/mod.rs
+++ b/src/intelligence/providers/azure_devops/mod.rs
@@ -20,6 +20,7 @@ use sqlx::SqlitePool;
 use std::collections::HashMap;
 
 use crate::config::AzureDevOpsConfig;
+use crate::intelligence::providers::http::SyncFault;
 
 mod db;
 mod fetch;
@@ -190,17 +191,30 @@ pub async fn refresh_if_stale(
 /// Unconditionally refresh the Azure DevOps task cache.
 #[tracing::instrument(skip(pool, cfg), fields(provider = "azure_devops"))]
 pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result<Vec<String>> {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .context("building HTTP client")?;
+    // The shared client: same timeouts as every other provider, plus a connect
+    // deadline this one never had (it set a total timeout only, so a hung
+    // connect still consumed the full 30 s).
+    let client = super::http::client();
 
     // 1. WIQL: all work items assigned to me.
     let all_ids = match run_wiql(&client, cfg).await {
         Ok(ids) => ids,
         Err(e) => {
-            let msg = e.to_string();
-            stamp_error(pool, &msg).await?;
+            // `e.to_string()` printed only the outermost context, dropping the
+            // cause - the same truncation the other providers had.
+            match super::http::classify(&e) {
+                SyncFault::Retry { detail } => {
+                    tracing::warn!(
+                        error = %detail,
+                        "azure devops unreachable - keeping stale cache, will retry next sync"
+                    );
+                    let _ = super::note_transient_sync_failure(pool, "azure_devops", &detail).await;
+                }
+                SyncFault::Report { detail } => {
+                    tracing::warn!(error = %detail, "azure devops WIQL failed");
+                    stamp_error(pool, &detail).await?;
+                }
+            }
             return Err(e);
         }
     };

--- a/src/intelligence/providers/azure_devops/mod.rs
+++ b/src/intelligence/providers/azure_devops/mod.rs
@@ -20,14 +20,13 @@ use sqlx::SqlitePool;
 use std::collections::HashMap;
 
 use crate::config::AzureDevOpsConfig;
-use crate::intelligence::providers::http::SyncFault;
 
 mod db;
 mod fetch;
 #[cfg(test)]
 mod tests;
 
-use db::{prune, stamp_error, stamp_sync};
+use db::{prune, stamp_sync};
 use fetch::{fetch_batch, fetch_state_categories, run_wiql, BATCH_SIZE};
 
 const SYNC_INTERVAL_MINS: i64 = 5;
@@ -185,41 +184,30 @@ pub async fn refresh_if_stale(
             }
         }
     }
-    force_refresh(pool, cfg).await.map(Some)
-}
-
-/// Record a sync failure against the shared classification.
-///
-/// Every fatal stage of [`force_refresh`] must go through this, not just the
-/// first one. The stage that fails is invisible to the user - what matters is
-/// that a retryable failure stays quiet while still feeding the escalation
-/// clock, and a terminal one raises the notice. A stage that propagates its
-/// error without calling this produces a log line and nothing durable: no
-/// notice, and no escalation however long it keeps failing.
-///
-/// `stage` names the failing step for the log only; the user-facing text comes
-/// from the classified detail.
-async fn record_sync_failure(pool: &SqlitePool, stage: &str, e: &anyhow::Error) -> Result<()> {
-    match super::http::classify(e) {
-        SyncFault::Retry { detail } => {
-            tracing::warn!(
-                stage,
-                error = %detail,
-                "azure devops unreachable - keeping stale cache, will retry next sync"
-            );
-            let _ = super::note_transient_sync_failure(pool, "azure_devops", &detail).await;
-        }
-        SyncFault::Report { detail } => {
-            tracing::warn!(stage, error = %detail, "azure devops sync failed");
-            stamp_error(pool, &detail).await?;
-        }
-    }
-    Ok(())
+    force_refresh(pool, cfg).await
 }
 
 /// Unconditionally refresh the Azure DevOps task cache.
+///
+/// # Why `Option`, like the other four providers
+/// This used to return `Result<Vec<String>>` and propagate `Err` after already
+/// recording a classified failure. That `Err` reached
+/// `intelligence::run_pm_sync`'s generic catch-all, which wrote a SECOND,
+/// unclassified, truncated notice on top of the correct one — so a transient
+/// Azure DevOps blip still raised "Reconnect Azure DevOps in Settings", and this
+/// provider's fix was undone by its own call site.
+///
+/// The other four providers never hit that because their `refresh_if_stale`
+/// resolves to `Ok(None)` once it has handled a provider failure itself. This
+/// now matches them: `Ok(None)` means "failed, already recorded, do not
+/// re-report". Returning `Ok(Some(vec![]))` instead would be wrong — the caller
+/// treats any `Ok(Some(_))` as success and calls `clear_sync_error`, wiping the
+/// notice we just raised.
 #[tracing::instrument(skip(pool, cfg), fields(provider = "azure_devops"))]
-pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result<Vec<String>> {
+pub async fn force_refresh(
+    pool: &SqlitePool,
+    cfg: &AzureDevOpsConfig,
+) -> Result<Option<Vec<String>>> {
     // The shared client: same timeouts as every other provider, plus a connect
     // deadline this one never had (it set a total timeout only, so a hung
     // connect still consumed the full 30 s).
@@ -232,8 +220,12 @@ pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result
             // Was `stamp_error(pool, &e.to_string())`, which both reported every
             // network blip as a credentials fault AND printed only the outermost
             // context, dropping the cause.
-            record_sync_failure(pool, "wiql", &e).await?;
-            return Err(e);
+            super::record_sync_failure(pool, "azure_devops", "wiql", &e).await?;
+            // NOT `Err(e)`: already recorded and classified. Propagating it
+            // would reach `run_pm_sync`'s generic catch-all, which reports
+            // unconditionally and truncates - overwriting this with the very
+            // bug this branch removes.
+            return Ok(None);
         }
     };
     tracing::debug!(count = all_ids.len(), "azure_devops: WIQL returned IDs");
@@ -241,7 +233,7 @@ pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result
     if all_ids.is_empty() {
         prune(pool, &[]).await?;
         stamp_sync(pool).await?;
-        return Ok(vec![]);
+        return Ok(Some(vec![]));
     }
 
     // 2. Batch-fetch full detail (≤BATCH_SIZE per request). `raw_by_id` is the
@@ -257,8 +249,8 @@ pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result
         let batch = match fetch_batch(&client, cfg, chunk).await {
             Ok(b) => b,
             Err(e) => {
-                record_sync_failure(pool, "work_item_batch", &e).await?;
-                return Err(e);
+                super::record_sync_failure(pool, "azure_devops", "work_item_batch", &e).await?;
+                return Ok(None);
             }
         };
         for (detail, raw) in batch {
@@ -496,7 +488,7 @@ pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result
         active = kept.len(),
         "azure_devops tasks refreshed"
     );
-    Ok(kept)
+    Ok(Some(kept))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/intelligence/providers/azure_devops/mod.rs
+++ b/src/intelligence/providers/azure_devops/mod.rs
@@ -220,7 +220,7 @@ pub async fn force_refresh(
             // Was `stamp_error(pool, &e.to_string())`, which both reported every
             // network blip as a credentials fault AND printed only the outermost
             // context, dropping the cause.
-            super::record_sync_failure(pool, "azure_devops", "wiql", &e).await?;
+            super::record_sync_failure(pool, "azure_devops", "wiql", &e).await;
             // NOT `Err(e)`: already recorded and classified. Propagating it
             // would reach `run_pm_sync`'s generic catch-all, which reports
             // unconditionally and truncates - overwriting this with the very
@@ -249,7 +249,7 @@ pub async fn force_refresh(
         let batch = match fetch_batch(&client, cfg, chunk).await {
             Ok(b) => b,
             Err(e) => {
-                super::record_sync_failure(pool, "azure_devops", "work_item_batch", &e).await?;
+                super::record_sync_failure(pool, "azure_devops", "work_item_batch", &e).await;
                 return Ok(None);
             }
         };

--- a/src/intelligence/providers/azure_devops/mod.rs
+++ b/src/intelligence/providers/azure_devops/mod.rs
@@ -188,6 +188,35 @@ pub async fn refresh_if_stale(
     force_refresh(pool, cfg).await.map(Some)
 }
 
+/// Record a sync failure against the shared classification.
+///
+/// Every fatal stage of [`force_refresh`] must go through this, not just the
+/// first one. The stage that fails is invisible to the user - what matters is
+/// that a retryable failure stays quiet while still feeding the escalation
+/// clock, and a terminal one raises the notice. A stage that propagates its
+/// error without calling this produces a log line and nothing durable: no
+/// notice, and no escalation however long it keeps failing.
+///
+/// `stage` names the failing step for the log only; the user-facing text comes
+/// from the classified detail.
+async fn record_sync_failure(pool: &SqlitePool, stage: &str, e: &anyhow::Error) -> Result<()> {
+    match super::http::classify(e) {
+        SyncFault::Retry { detail } => {
+            tracing::warn!(
+                stage,
+                error = %detail,
+                "azure devops unreachable - keeping stale cache, will retry next sync"
+            );
+            let _ = super::note_transient_sync_failure(pool, "azure_devops", &detail).await;
+        }
+        SyncFault::Report { detail } => {
+            tracing::warn!(stage, error = %detail, "azure devops sync failed");
+            stamp_error(pool, &detail).await?;
+        }
+    }
+    Ok(())
+}
+
 /// Unconditionally refresh the Azure DevOps task cache.
 #[tracing::instrument(skip(pool, cfg), fields(provider = "azure_devops"))]
 pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result<Vec<String>> {
@@ -200,21 +229,10 @@ pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result
     let all_ids = match run_wiql(&client, cfg).await {
         Ok(ids) => ids,
         Err(e) => {
-            // `e.to_string()` printed only the outermost context, dropping the
-            // cause - the same truncation the other providers had.
-            match super::http::classify(&e) {
-                SyncFault::Retry { detail } => {
-                    tracing::warn!(
-                        error = %detail,
-                        "azure devops unreachable - keeping stale cache, will retry next sync"
-                    );
-                    let _ = super::note_transient_sync_failure(pool, "azure_devops", &detail).await;
-                }
-                SyncFault::Report { detail } => {
-                    tracing::warn!(error = %detail, "azure devops WIQL failed");
-                    stamp_error(pool, &detail).await?;
-                }
-            }
+            // Was `stamp_error(pool, &e.to_string())`, which both reported every
+            // network blip as a credentials fault AND printed only the outermost
+            // context, dropping the cause.
+            record_sync_failure(pool, "wiql", &e).await?;
             return Err(e);
         }
     };
@@ -233,7 +251,16 @@ pub async fn force_refresh(pool: &SqlitePool, cfg: &AzureDevOpsConfig) -> Result
     let mut details: Vec<WorkItemDetail> = Vec::with_capacity(all_ids.len());
     let mut raw_by_id: HashMap<u64, serde_json::Value> = HashMap::with_capacity(all_ids.len());
     for chunk in all_ids.chunks(BATCH_SIZE) {
-        let batch = fetch_batch(&client, cfg, chunk).await?;
+        // Classified like the WIQL stage above rather than a bare `?`. A batch
+        // failure is just as fatal to the sync, and propagating it unrecorded
+        // meant a provider failing consistently HERE escalated never.
+        let batch = match fetch_batch(&client, cfg, chunk).await {
+            Ok(b) => b,
+            Err(e) => {
+                record_sync_failure(pool, "work_item_batch", &e).await?;
+                return Err(e);
+            }
+        };
         for (detail, raw) in batch {
             raw_by_id.insert(detail.id, raw);
             details.push(detail);

--- a/src/intelligence/providers/github/fetch.rs
+++ b/src/intelligence/providers/github/fetch.rs
@@ -160,12 +160,26 @@ fn post_graphql(
 // ---------------------------------------------------------------------------
 
 pub(super) async fn fetch_viewer_login(github: &GitHubConfig) -> Result<String> {
-    let client = reqwest::Client::new();
+    let client = crate::intelligence::providers::http::client();
     let resp = post_graphql(&client, github, json!({ "query": "{ viewer { login } }" }))
         .send()
         .await
         .context("POST /graphql viewer")?;
+    // Check the status BEFORE parsing. A 500 or a 429 has no `data` field, so
+    // it used to fall through to the parse and surface as "GraphQL viewer
+    // response missing data" — a GitHub outage reported to the user as a
+    // credentials problem. The typed error carries the status so
+    // `http::is_transient` can tell an outage from a dead token.
+    let status = resp.status();
     let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(crate::intelligence::providers::http::HttpStatusError::new(
+            status.as_u16(),
+            "GitHub GraphQL viewer",
+            &text,
+        )
+        .into());
+    }
     let parsed: GqlResponse<ViewerData> =
         serde_json::from_str(&text).context("deserialising viewer response")?;
     parsed
@@ -236,7 +250,12 @@ pub(super) async fn fetch_project_items(
         let status = resp.status();
         let text = resp.text().await.unwrap_or_default();
         if !status.is_success() {
-            anyhow::bail!("GitHub GraphQL → {}: {}", status, text);
+            return Err(crate::intelligence::providers::http::HttpStatusError::new(
+                status.as_u16(),
+                "GitHub GraphQL",
+                &text,
+            )
+            .into());
         }
 
         // Parse once as a Value so each raw item node survives verbatim for

--- a/src/intelligence/providers/github/mod.rs
+++ b/src/intelligence/providers/github/mod.rs
@@ -188,10 +188,13 @@ pub async fn refresh_if_stale(
             // used to raise "GitHub auth failed / Set GITHUB_TOKEN in .env",
             // telling the user to redo a token that was never broken.
             match super::http::classify(&e) {
-                SyncFault::Retry { detail } => tracing::warn!(
-                    error = %detail,
-                    "github unreachable - keeping stale cache, will retry next sync"
-                ),
+                SyncFault::Retry { detail } => {
+                    tracing::warn!(
+                        error = %detail,
+                        "github unreachable - keeping stale cache, will retry next sync"
+                    );
+                    let _ = super::note_transient_sync_failure(pool, "github", &detail).await;
+                }
                 SyncFault::Report { detail } => {
                     tracing::warn!(
                         error = %detail,
@@ -261,10 +264,15 @@ pub async fn refresh_if_stale(
             // `failures` is never empty here (a non-empty project list that
             // produced no successes produced errors), so this is the
             // all-retryable case.
-            None => tracing::warn!(
-                projects = failures.len(),
-                "github unreachable for every project - keeping stale cache, will retry next sync"
-            ),
+            None => {
+                let detail = failures.first().map(super::http::chain).unwrap_or_default();
+                tracing::warn!(
+                    projects = failures.len(),
+                    error = %detail,
+                    "github unreachable for every project - keeping stale cache, will retry next sync"
+                );
+                let _ = super::note_transient_sync_failure(pool, "github", &detail).await;
+            }
             Some(detail) => {
                 tracing::warn!(
                     error = %detail,

--- a/src/intelligence/providers/github/mod.rs
+++ b/src/intelligence/providers/github/mod.rs
@@ -8,6 +8,7 @@ use meridian_core::adapters::github::GithubAdapter;
 use sqlx::SqlitePool;
 
 use crate::config::GitHubConfig;
+use crate::intelligence::providers::http::SyncFault;
 
 mod fetch;
 #[cfg(test)]
@@ -183,14 +184,32 @@ pub async fn refresh_if_stale(
     let viewer_login = match fetch_viewer_login(github).await {
         Ok(l) => l,
         Err(e) => {
-            tracing::warn!(error = %e, "github viewer fetch failed — keeping stale cache");
-            let _ =
-                super::stamp_sync_error(pool, "github", &format!("GitHub auth failed — {e}")).await;
+            // A connect failure here is the network, not the credential. It
+            // used to raise "GitHub auth failed / Set GITHUB_TOKEN in .env",
+            // telling the user to redo a token that was never broken.
+            match super::http::classify(&e) {
+                SyncFault::Retry { detail } => tracing::warn!(
+                    error = %detail,
+                    "github unreachable - keeping stale cache, will retry next sync"
+                ),
+                SyncFault::Report { detail } => {
+                    tracing::warn!(
+                        error = %detail,
+                        "github viewer fetch failed - keeping stale cache"
+                    );
+                    let _ = super::stamp_sync_error(
+                        pool,
+                        "github",
+                        &format!("GitHub sync failed: {detail}"),
+                    )
+                    .await;
+                }
+            }
             return Ok(None);
         }
     };
 
-    let client = reqwest::Client::new();
+    let client = super::http::client();
 
     // Each project is an independent paginated GraphQL walk — fetch them all
     // concurrently, then fold the results preserving any_ok/all_ok semantics.
@@ -205,6 +224,9 @@ pub async fn refresh_if_stale(
     let mut all_tasks: Vec<(GhTask, serde_json::Value)> = Vec::new();
     let mut any_ok = false;
     let mut all_ok = true;
+    // Kept (not just counted) so the all-failed branch below can ask whether
+    // every project failed for a retryable reason.
+    let mut failures: Vec<anyhow::Error> = Vec::new();
     for (project_id, result) in github.project_ids.iter().zip(results) {
         match result {
             Ok(tasks) => {
@@ -213,20 +235,49 @@ pub async fn refresh_if_stale(
                 any_ok = true;
             }
             Err(e) => {
-                tracing::warn!(project_id, error = %e, "github project fetch failed — skipping");
+                let chain = format!("{e:#}");
+                tracing::warn!(project_id, error = %chain, "github project fetch failed - skipping");
+                failures.push(e);
                 all_ok = false;
             }
         }
     }
 
     if !any_ok {
-        tracing::warn!("all github project fetches failed — keeping stale cache");
-        let _ = super::stamp_sync_error(
-            pool,
-            "github",
-            "GitHub sync failed — all project fetches failed",
-        )
-        .await;
+        // One network outage hits every concurrent project fetch identically,
+        // so "all of them failed, all for a retryable reason" is the signature
+        // of an unreachable network rather than a broken board or credential.
+        // Stay quiet and retry; a mixed or terminal set still reaches the user.
+        // Report the first TERMINAL failure if there is one; stay quiet only
+        // when every single failure was retryable.
+        let terminal = failures
+            .iter()
+            .map(super::http::classify)
+            .find_map(|f| match f {
+                SyncFault::Report { detail } => Some(detail),
+                SyncFault::Retry { .. } => None,
+            });
+        match terminal {
+            // `failures` is never empty here (a non-empty project list that
+            // produced no successes produced errors), so this is the
+            // all-retryable case.
+            None => tracing::warn!(
+                projects = failures.len(),
+                "github unreachable for every project - keeping stale cache, will retry next sync"
+            ),
+            Some(detail) => {
+                tracing::warn!(
+                    error = %detail,
+                    "all github project fetches failed - keeping stale cache"
+                );
+                let _ = super::stamp_sync_error(
+                    pool,
+                    "github",
+                    &format!("GitHub sync failed - every project fetch failed: {detail}"),
+                )
+                .await;
+            }
+        }
         return Ok(None);
     }
 

--- a/src/intelligence/providers/http.rs
+++ b/src/intelligence/providers/http.rs
@@ -1,0 +1,504 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Shared HTTP client and transient-failure classification for PM provider sync.
+//!
+//! Two concerns that look separate but are the same concern: how we talk to a
+//! provider's API, and how we decide whether a failed conversation is the
+//! user's problem or the network's.
+//!
+//! # Why this exists
+//! Every provider sync used to build `reqwest::Client::new()` per call and then
+//! treat ANY failure as a terminal, user-facing fault. Both halves were wrong:
+//!
+//! 1. **No timeouts.** `reqwest`'s defaults are `timeout: no timeout` and
+//!    `connect_timeout: None`, so a connect that hung never came back and the
+//!    provider simply stopped syncing with no error at all.
+//! 2. **No transient/terminal distinction.** A DNS blip, a captive portal, a
+//!    laptop resuming from sleep mid-tick — each raised a persistent
+//!    "GitHub sync failing / Set GITHUB_TOKEN in .env" banner that told the
+//!    user to re-do credentials that were never broken. [`crate::intelligence::providers::jira`]'s
+//!    OAuth-refresh path already learned this (see the `is_transient` guard in
+//!    `jira::refresh_if_stale` and the comment above it: raising a terminal
+//!    fault for a network blip is "exactly what made this fault flap on and off
+//!    at random"). That guard was only ever applied to refreshing the token,
+//!    never to using it — so every data-fetch path kept the original bug.
+//!
+//! [`is_transient`] is the shared answer, and unlike
+//! [`meridian_oauth::flow::is_transient`] — which only recognises a
+//! `TokenError` from the token endpoint and returns `false` for everything else
+//! — it classifies the transport errors a data fetch actually produces. The two
+//! are complementary, not interchangeable: dropping the OAuth one onto a fetch
+//! path compiles, runs, and returns `false` every single time.
+//!
+//! # The deliberate trade-off
+//! A transient failure raises NO user-facing notice; the stale cache is kept and
+//! the next tick retries. So a provider that is unreachable *forever* now goes
+//! quiet rather than showing a (misleading) credentials banner. That is the
+//! same trade-off `jira::refresh_if_stale` already shipped, and this matches it
+//! on purpose rather than inventing a second policy. Escalating after N
+//! consecutive transient failures would need persisted state (a `pm_sync_state`
+//! column, so a migration) and is left as a follow-up.
+//!
+//! # Who calls this
+//! - [`crate::intelligence::providers::github`] — `refresh_if_stale` (viewer
+//!   fetch + all-projects-failed) and `fetch::{fetch_viewer_login, fetch_project_items}`.
+//! - [`crate::intelligence::providers::jira`] — `refresh_if_stale` (fetch
+//!   failure) and `fetch::search`.
+//!
+//! # Related
+//! - [`crate::intelligence::providers::stamp_sync_error`] — what we call only
+//!   once a failure is classified terminal.
+//! - [`meridian_oauth::flow::is_transient`] — the OAuth-token-endpoint sibling.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// Total deadline for one provider request, from connect to body complete.
+///
+/// Generous on purpose: this exists to bound a hang, not to police latency. A
+/// large Jira JQL search over a slow link is a legitimate slow request and must
+/// not be cut off, so this is set well above any observed healthy call.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Deadline for the connect phase alone. Much tighter than [`REQUEST_TIMEOUT`]
+/// because a connect that has not completed in this long is not slow, it is
+/// broken — the DNS/captive-portal/unreachable-host cases this module exists
+/// for. Failing fast here turns a silent stall into a classified transient
+/// error that retries on the next tick.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// How long an idle pooled connection may linger before being dropped.
+///
+/// Only relevant because the client is now SHARED across ticks (it previously
+/// was not, so every tick started with an empty pool and this could not
+/// happen). A pooled connection that a NAT, proxy, or the server has silently
+/// closed fails on reuse; bounding idle lifetime well below the multi-minute
+/// sync interval means a fresh connection is established each tick instead.
+const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// `SO_KEEPALIVE` interval — surfaces a dead peer rather than blocking until
+/// [`REQUEST_TIMEOUT`]. Paired with [`POOL_IDLE_TIMEOUT`] against the same
+/// silently-dropped-connection failure mode.
+const TCP_KEEPALIVE: Duration = Duration::from_secs(30);
+
+/// The process-wide client for PM provider sync.
+///
+/// Cloning a `reqwest::Client` is cheap (it is an `Arc` internally) and shares
+/// the connection pool, so callers should call this per request rather than
+/// caching the returned value.
+///
+/// Note this deliberately does NOT disable proxy detection: a user behind a
+/// corporate proxy needs reqwest's env/system proxy support to reach the
+/// provider at all.
+pub fn client() -> reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| build_client(REQUEST_TIMEOUT, CONNECT_TIMEOUT))
+        .clone()
+}
+
+/// Build a provider client with explicit timeouts. Split out from [`client`] so
+/// tests can drive the same builder with short deadlines — if the `.timeout()`
+/// wiring is ever dropped, `request_timeout_is_wired_and_classified_transient`
+/// fails rather than every install silently regaining unbounded hangs.
+///
+/// Falls back to `Client::new()` if the builder fails (only possible on TLS
+/// backend init failure): an un-timeouted client is strictly better than no
+/// sync at all, and the failure is logged.
+fn build_client(request_timeout: Duration, connect_timeout: Duration) -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(request_timeout)
+        .connect_timeout(connect_timeout)
+        .pool_idle_timeout(POOL_IDLE_TIMEOUT)
+        .tcp_keepalive(TCP_KEEPALIVE)
+        .build()
+        .unwrap_or_else(|e| {
+            tracing::error!(error = %e, "provider HTTP client builder failed - falling back to defaults (no timeouts)");
+            reqwest::Client::new()
+        })
+}
+
+/// A provider answered, but with a non-success status.
+///
+/// A typed error rather than a formatted string because the STATUS is what
+/// decides transient vs terminal, and a `bail!("... → {status}: {body}")` throws
+/// that away — leaving [`is_transient`] nothing to match on but prose.
+#[derive(Debug)]
+pub struct HttpStatusError {
+    /// The HTTP status code the provider returned.
+    pub status: u16,
+    /// Response body, clamped to [`Self::BODY_CLAMP`]. Provider error bodies are
+    /// echoed into a user-facing notice and into telemetry, so an unbounded
+    /// body is both a UI and an egress problem.
+    pub body: String,
+    /// Human label for the endpoint, e.g. `"Jira /search/jql"`.
+    endpoint: String,
+}
+
+impl HttpStatusError {
+    /// Maximum retained response-body length.
+    const BODY_CLAMP: usize = 200;
+
+    /// Build from a status, endpoint label, and raw response body.
+    pub fn new(status: u16, endpoint: impl Into<String>, body: impl AsRef<str>) -> Self {
+        let body = body.as_ref();
+        // Clamp on a char boundary — provider error bodies are arbitrary UTF-8
+        // and slicing mid-codepoint would panic.
+        let clamped: String = body.chars().take(Self::BODY_CLAMP).collect();
+        Self {
+            status,
+            body: clamped,
+            endpoint: endpoint.into(),
+        }
+    }
+
+    /// Whether this status is worth retrying rather than reporting.
+    ///
+    /// `5xx` is server-side and by definition not something the user's
+    /// credentials caused. `429` is rate limiting, `408`/`425` are the server
+    /// asking for a retry. Everything else — notably `401`/`403` (dead or
+    /// unscoped credentials) and `404` (a board that no longer exists) — is
+    /// terminal and SHOULD reach the user, because nothing self-heals.
+    pub fn is_transient(&self) -> bool {
+        matches!(self.status, 408 | 425 | 429) || (500..=599).contains(&self.status)
+    }
+}
+
+impl std::fmt::Display for HttpStatusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} returned {}: {}",
+            self.endpoint, self.status, self.body
+        )
+    }
+}
+
+impl std::error::Error for HttpStatusError {}
+
+/// What a provider sync should DO about a failure.
+///
+/// Both variants carry `detail` already formatted with `{err:#}` — the full
+/// `anyhow` source chain. That formatting lives here, in one place, on purpose:
+/// with a plain `{err}` only the outermost `.context()` survives, so a connect
+/// failure reached the user and the telemetry backend as the bare string
+/// `"POST /graphql viewer"` with the real cause stripped. Four call sites each
+/// doing their own `format!` could each regress that independently;
+/// [`classify`] cannot.
+#[derive(Debug)]
+pub enum SyncFault {
+    /// Retryable. Log it, keep the stale cache, raise NOTHING — the next tick
+    /// will very likely succeed.
+    Retry {
+        /// Full `anyhow` chain, for the log line only.
+        detail: String,
+    },
+    /// Terminal. Raise a user-facing notice; nothing here self-heals.
+    Report {
+        /// Full `anyhow` chain, for the log line and the notice body.
+        detail: String,
+    },
+}
+
+impl SyncFault {
+    /// Force [`SyncFault::Retry`] for a failure a DIFFERENT classifier already
+    /// judged retryable — specifically [`meridian_oauth::is_transient`], which
+    /// understands token-endpoint failures this module cannot see. Keeps detail
+    /// formatting inside this module so the guarantee above still holds.
+    pub fn retry(err: &anyhow::Error) -> Self {
+        Self::Retry {
+            detail: format!("{err:#}"),
+        }
+    }
+}
+
+/// Decide what to do about a provider-sync failure, and format its detail.
+///
+/// This is the single entry point the provider sync paths should use; prefer it
+/// over calling [`is_transient`] directly, so the chain formatting cannot drift.
+pub fn classify(err: &anyhow::Error) -> SyncFault {
+    if is_transient(err) {
+        SyncFault::retry(err)
+    } else {
+        SyncFault::Report {
+            detail: format!("{err:#}"),
+        }
+    }
+}
+
+/// Whether a provider-sync failure is worth retrying quietly rather than
+/// raising a user-facing fault.
+///
+/// Walks the whole `anyhow` chain, so it still finds the cause under the
+/// `.context()` layers the fetch paths add. **Defaults to `false`**: an error
+/// this cannot classify surfaces to the user rather than being silently
+/// swallowed, matching [`meridian_oauth::flow::is_transient`]'s stance.
+pub fn is_transient(err: &anyhow::Error) -> bool {
+    for cause in err.chain() {
+        if let Some(status) = cause.downcast_ref::<HttpStatusError>() {
+            return status.is_transient();
+        }
+        if let Some(e) = cause.downcast_ref::<reqwest::Error>() {
+            return reqwest_is_transient(e);
+        }
+    }
+    false
+}
+
+/// Classify a `reqwest` transport error.
+///
+/// `is_builder()` is checked FIRST and is always terminal: it means we failed to
+/// construct the request, which in practice is a credential containing a byte
+/// that is illegal in an HTTP header (a trailing `\r` from a hand-edited
+/// `.env`). That never fixes itself by retrying, and it is precisely the case
+/// where "check your token" is the correct remedy — so it must not be swallowed
+/// as a network blip.
+///
+/// `is_decode()` and `is_body()` are deliberately absent: a response we could
+/// not parse is a contract mismatch worth surfacing, not a retry.
+fn reqwest_is_transient(e: &reqwest::Error) -> bool {
+    if e.is_builder() {
+        return false;
+    }
+    e.is_timeout() || e.is_connect() || e.is_request()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── status classification ────────────────────────────────────────────────
+
+    #[test]
+    fn server_errors_and_rate_limits_are_transient() {
+        for status in [500, 502, 503, 504, 599, 429, 408, 425] {
+            let e = HttpStatusError::new(status, "GitHub GraphQL", "boom");
+            assert!(e.is_transient(), "{status} should be transient");
+        }
+    }
+
+    /// The other half of the contract, and the one that actually protects the
+    /// user: a dead credential MUST still raise a notice. If this ever flips,
+    /// a revoked token silently stops syncing forever with no indication.
+    #[test]
+    fn auth_and_client_errors_stay_terminal() {
+        for status in [400, 401, 403, 404, 410, 422, 200, 302] {
+            let e = HttpStatusError::new(status, "Jira /search/jql", "nope");
+            assert!(!e.is_transient(), "{status} must stay terminal");
+        }
+    }
+
+    #[test]
+    fn status_error_is_found_through_context_layers() {
+        let err = anyhow::Error::new(HttpStatusError::new(503, "Jira /search/jql", "down"))
+            .context("POST /search/jql")
+            .context("jira fetch failed");
+        assert!(is_transient(&err), "chain walk must reach the status error");
+    }
+
+    #[test]
+    fn terminal_status_is_found_through_context_layers() {
+        let err = anyhow::Error::new(HttpStatusError::new(401, "GitHub GraphQL", "bad creds"))
+            .context("POST /graphql viewer");
+        assert!(!is_transient(&err));
+    }
+
+    /// Guards the clamp AND the char-boundary handling — a multi-byte body
+    /// sliced by byte index would panic in production on any non-ASCII error
+    /// page.
+    #[test]
+    fn body_is_clamped_on_a_char_boundary() {
+        let long = "é".repeat(500);
+        let e = HttpStatusError::new(500, "endpoint", &long);
+        assert_eq!(e.body.chars().count(), HttpStatusError::BODY_CLAMP);
+        assert!(e.to_string().contains("500"));
+    }
+
+    // ── the truncation regression ────────────────────────────────────────────
+
+    /// THE regression guard. `format!("{e}")` on an `anyhow` error prints only
+    /// the outermost `.context()`, so the real cause never reached the user or
+    /// OpenObserve — a GitHub connect failure arrived as the bare, useless
+    /// string "POST /graphql viewer". If anyone reverts [`classify`] to `{e}`,
+    /// this fails.
+    #[test]
+    fn detail_carries_the_whole_cause_chain_not_just_the_outer_context() {
+        let err = anyhow::Error::new(HttpStatusError::new(503, "Jira /search/jql", "maintenance"))
+            .context("POST /search/jql");
+        let SyncFault::Retry { detail } = classify(&err) else {
+            panic!("503 must be classified Retry");
+        };
+        assert!(detail.contains("POST /search/jql"), "outer context lost");
+        assert!(
+            detail.contains("503"),
+            "root-cause status lost - `{{e}}` truncation has regressed: {detail}"
+        );
+        assert!(detail.contains("maintenance"), "root-cause body lost");
+    }
+
+    /// Same guarantee on the terminal side: a user who IS being shown a banner
+    /// must be shown the cause, not just the endpoint we happened to be calling.
+    #[test]
+    fn a_reported_fault_also_carries_the_whole_chain() {
+        let err = anyhow::Error::new(HttpStatusError::new(
+            401,
+            "GitHub GraphQL viewer",
+            "Bad credentials",
+        ))
+        .context("POST /graphql viewer");
+        let SyncFault::Report { detail } = classify(&err) else {
+            panic!("401 must be classified Report");
+        };
+        assert!(detail.contains("POST /graphql viewer"));
+        assert!(detail.contains("401"), "status lost from the banner text");
+        assert!(
+            detail.contains("Bad credentials"),
+            "cause lost from the banner text"
+        );
+    }
+
+    /// The production symptom, end to end, with a REAL transport error rather
+    /// than a hand-built chain: the reported bug was a banner whose entire body
+    /// was the context string.
+    #[tokio::test]
+    async fn a_real_connect_failure_reports_more_than_its_context() {
+        const CONTEXT: &str = "POST /graphql viewer";
+        let err = connect_refused_error().await;
+        let SyncFault::Retry { detail } = classify(&err) else {
+            panic!("a refused connection must be classified Retry");
+        };
+        assert!(detail.contains(CONTEXT), "outer context lost: {detail}");
+        assert!(
+            detail.len() > CONTEXT.len() + 5,
+            "detail is just the context - the cause chain was dropped: {detail}"
+        );
+    }
+
+    /// `SyncFault::retry` is the escape hatch for `meridian_oauth`-classified
+    /// failures; it must format identically or the Jira auth path silently
+    /// regains the truncation.
+    #[test]
+    fn the_forced_retry_constructor_formats_the_same_chain() {
+        let err = anyhow::Error::new(HttpStatusError::new(500, "token endpoint", "oops"))
+            .context("refreshing jira token");
+        let (SyncFault::Retry { detail } | SyncFault::Report { detail }) = SyncFault::retry(&err);
+        assert!(detail.contains("refreshing jira token"));
+        assert!(detail.contains("500"), "forced retry lost the cause chain");
+    }
+
+    // ── default stance ───────────────────────────────────────────────────────
+
+    /// An error carrying neither a status nor a `reqwest::Error` must surface.
+    /// This is what stops a future refactor from making every unclassified
+    /// failure invisible.
+    #[test]
+    fn an_unclassified_error_is_terminal_by_default() {
+        let err = anyhow::anyhow!("something went wrong").context("jira fetch failed");
+        assert!(!is_transient(&err));
+    }
+
+    /// The regression this module exists to prevent: `meridian_oauth`'s
+    /// classifier only recognises its own `TokenError`, so it answers `false`
+    /// for every transport error. Wiring IT onto a fetch path would look like a
+    /// fix and be a no-op. If someone ever "consolidates" the two, this fails.
+    #[tokio::test]
+    async fn the_oauth_classifier_does_not_cover_transport_errors() {
+        let err = connect_refused_error().await;
+        assert!(
+            !meridian_oauth::is_transient(&err),
+            "if this now returns true the two classifiers may be merged"
+        );
+        assert!(is_transient(&err), "ours must still classify it");
+    }
+
+    // ── real transport errors (offline: loopback only) ───────────────────────
+
+    /// Produce a genuine `reqwest::Error` from a refused connection. Port 1 on
+    /// loopback has no listener, so this needs no network and no fixture.
+    async fn connect_refused_error() -> anyhow::Error {
+        let err = client()
+            .get("http://127.0.0.1:1/")
+            .send()
+            .await
+            .expect_err("connecting to a closed loopback port must fail");
+        anyhow::Error::new(err).context("POST /graphql viewer")
+    }
+
+    #[tokio::test]
+    async fn a_refused_connection_is_transient() {
+        let err = connect_refused_error().await;
+        assert!(
+            is_transient(&err),
+            "connect failure must not raise a credentials banner: {err:#}"
+        );
+    }
+
+    /// A credential with a byte that is illegal in a header value fails at
+    /// request-BUILD time and surfaces from `.send()` looking exactly like a
+    /// transport failure. It must stay terminal — this is the one case where
+    /// "check your token" is the right advice.
+    #[tokio::test]
+    async fn a_malformed_credential_is_terminal_not_transient() {
+        let err = client()
+            .get("http://127.0.0.1:1/")
+            // A trailing CR is what a hand-edited or CRLF `.env` produces.
+            .header("Authorization", "Bearer ghp_token\r")
+            .send()
+            .await
+            .expect_err("an invalid header value must fail the request");
+        assert!(err.is_builder(), "expected a builder error, got: {err}");
+        let err = anyhow::Error::new(err).context("POST /graphql viewer");
+        assert!(
+            !is_transient(&err),
+            "a malformed credential must still reach the user"
+        );
+    }
+
+    /// Proves `.timeout()` is actually wired into [`build_client`]: the peer
+    /// accepts the TCP connection and then says nothing, so only a request
+    /// timeout can end this. Without the timeout the test hangs rather than
+    /// failing, which is itself the signal.
+    #[tokio::test]
+    async fn request_timeout_is_wired_and_classified_transient() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        // Accept and hold the socket open without ever responding.
+        tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                held.push(stream);
+            }
+        });
+
+        let short = Duration::from_millis(150);
+        let err = build_client(short, short)
+            .get(format!("http://{addr}/"))
+            .send()
+            .await
+            .expect_err("a peer that never responds must time out");
+        assert!(err.is_timeout(), "expected a timeout, got: {err}");
+
+        let err = anyhow::Error::new(err).context("POST /search/jql");
+        assert!(
+            is_transient(&err),
+            "a timeout must be retried, not reported"
+        );
+    }
+
+    /// The timeouts must stay bounded and ordered. A zero value disables the
+    /// timeout in reqwest, which would silently restore the unbounded-hang bug.
+    #[test]
+    fn timeout_constants_are_bounded_and_ordered() {
+        assert!(!REQUEST_TIMEOUT.is_zero(), "zero disables the timeout");
+        assert!(!CONNECT_TIMEOUT.is_zero(), "zero disables the timeout");
+        assert!(
+            CONNECT_TIMEOUT < REQUEST_TIMEOUT,
+            "connect deadline must fit inside the total deadline"
+        );
+        assert!(
+            REQUEST_TIMEOUT <= Duration::from_secs(120),
+            "an unbounded-in-practice timeout defeats the purpose"
+        );
+    }
+}

--- a/src/intelligence/providers/http/classify.rs
+++ b/src/intelligence/providers/http/classify.rs
@@ -1,121 +1,19 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
-//! Shared HTTP client and transient-failure classification for PM provider sync.
+//! Deciding whether a failed provider sync is the user's problem or the
+//! network's — and formatting the cause once, in one place.
 //!
-//! Two concerns that look separate but are the same concern: how we talk to a
-//! provider's API, and how we decide whether a failed conversation is the
-//! user's problem or the network's.
-//!
-//! # Why this exists
-//! Every provider sync used to build `reqwest::Client::new()` per call and then
-//! treat ANY failure as a terminal, user-facing fault. Both halves were wrong:
-//!
-//! 1. **No timeouts.** `reqwest`'s defaults are `timeout: no timeout` and
-//!    `connect_timeout: None`, so a connect that hung never came back and the
-//!    provider simply stopped syncing with no error at all.
-//! 2. **No transient/terminal distinction.** A DNS blip, a captive portal, a
-//!    laptop resuming from sleep mid-tick — each raised a persistent
-//!    "GitHub sync failing / Set GITHUB_TOKEN in .env" banner that told the
-//!    user to re-do credentials that were never broken. [`crate::intelligence::providers::jira`]'s
-//!    OAuth-refresh path already learned this (see the `is_transient` guard in
-//!    `jira::refresh_if_stale` and the comment above it: raising a terminal
-//!    fault for a network blip is "exactly what made this fault flap on and off
-//!    at random"). That guard was only ever applied to refreshing the token,
-//!    never to using it — so every data-fetch path kept the original bug.
-//!
-//! [`is_transient`] is the shared answer, and unlike
-//! [`meridian_oauth::flow::is_transient`] — which only recognises a
-//! `TokenError` from the token endpoint and returns `false` for everything else
-//! — it classifies the transport errors a data fetch actually produces. The two
-//! are complementary, not interchangeable: dropping the OAuth one onto a fetch
-//! path compiles, runs, and returns `false` every single time.
-//!
-//! # The deliberate trade-off
-//! A transient failure raises NO user-facing notice; the stale cache is kept and
-//! the next tick retries. So a provider that is unreachable *forever* now goes
-//! quiet rather than showing a (misleading) credentials banner. That is the
-//! same trade-off `jira::refresh_if_stale` already shipped, and this matches it
-//! on purpose rather than inventing a second policy. Escalating after N
-//! consecutive transient failures would need persisted state (a `pm_sync_state`
-//! column, so a migration) and is left as a follow-up.
+//! Split from [`super`] (which owns the shared client) purely on size; the two
+//! halves are one concern. See the parent module's docs for WHY this exists.
 //!
 //! # Who calls this
-//! - [`crate::intelligence::providers::github`] — `refresh_if_stale` (viewer
-//!   fetch + all-projects-failed) and `fetch::{fetch_viewer_login, fetch_project_items}`.
-//! - [`crate::intelligence::providers::jira`] — `refresh_if_stale` (fetch
-//!   failure) and `fetch::search`.
+//! Re-exported from [`super`], so call sites use `providers::http::classify`.
+//! The four provider paths that need it are listed in the parent's docs.
 //!
 //! # Related
-//! - [`crate::intelligence::providers::stamp_sync_error`] — what we call only
-//!   once a failure is classified terminal.
-//! - [`meridian_oauth::flow::is_transient`] — the OAuth-token-endpoint sibling.
-
-use std::sync::OnceLock;
-use std::time::Duration;
-
-/// Total deadline for one provider request, from connect to body complete.
-///
-/// Generous on purpose: this exists to bound a hang, not to police latency. A
-/// large Jira JQL search over a slow link is a legitimate slow request and must
-/// not be cut off, so this is set well above any observed healthy call.
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
-
-/// Deadline for the connect phase alone. Much tighter than [`REQUEST_TIMEOUT`]
-/// because a connect that has not completed in this long is not slow, it is
-/// broken — the DNS/captive-portal/unreachable-host cases this module exists
-/// for. Failing fast here turns a silent stall into a classified transient
-/// error that retries on the next tick.
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
-
-/// How long an idle pooled connection may linger before being dropped.
-///
-/// Only relevant because the client is now SHARED across ticks (it previously
-/// was not, so every tick started with an empty pool and this could not
-/// happen). A pooled connection that a NAT, proxy, or the server has silently
-/// closed fails on reuse; bounding idle lifetime well below the multi-minute
-/// sync interval means a fresh connection is established each tick instead.
-const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
-
-/// `SO_KEEPALIVE` interval — surfaces a dead peer rather than blocking until
-/// [`REQUEST_TIMEOUT`]. Paired with [`POOL_IDLE_TIMEOUT`] against the same
-/// silently-dropped-connection failure mode.
-const TCP_KEEPALIVE: Duration = Duration::from_secs(30);
-
-/// The process-wide client for PM provider sync.
-///
-/// Cloning a `reqwest::Client` is cheap (it is an `Arc` internally) and shares
-/// the connection pool, so callers should call this per request rather than
-/// caching the returned value.
-///
-/// Note this deliberately does NOT disable proxy detection: a user behind a
-/// corporate proxy needs reqwest's env/system proxy support to reach the
-/// provider at all.
-pub fn client() -> reqwest::Client {
-    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-    CLIENT
-        .get_or_init(|| build_client(REQUEST_TIMEOUT, CONNECT_TIMEOUT))
-        .clone()
-}
-
-/// Build a provider client with explicit timeouts. Split out from [`client`] so
-/// tests can drive the same builder with short deadlines — if the `.timeout()`
-/// wiring is ever dropped, `request_timeout_is_wired_and_classified_transient`
-/// fails rather than every install silently regaining unbounded hangs.
-///
-/// Falls back to `Client::new()` if the builder fails (only possible on TLS
-/// backend init failure): an un-timeouted client is strictly better than no
-/// sync at all, and the failure is logged.
-fn build_client(request_timeout: Duration, connect_timeout: Duration) -> reqwest::Client {
-    reqwest::Client::builder()
-        .timeout(request_timeout)
-        .connect_timeout(connect_timeout)
-        .pool_idle_timeout(POOL_IDLE_TIMEOUT)
-        .tcp_keepalive(TCP_KEEPALIVE)
-        .build()
-        .unwrap_or_else(|e| {
-            tracing::error!(error = %e, "provider HTTP client builder failed - falling back to defaults (no timeouts)");
-            reqwest::Client::new()
-        })
-}
+//! - [`crate::intelligence::providers::note_transient_sync_failure`] — what a
+//!   [`SyncFault::Retry`] is handed to; bounds how long silence may last.
+//! - [`meridian_oauth::flow::is_transient`] — the token-endpoint sibling
+//!   classifier, which by design cannot see transport errors.
 
 /// A provider answered, but with a non-success status.
 ///
@@ -186,10 +84,12 @@ impl std::error::Error for HttpStatusError {}
 /// [`classify`] cannot.
 #[derive(Debug)]
 pub enum SyncFault {
-    /// Retryable. Log it, keep the stale cache, raise NOTHING — the next tick
-    /// will very likely succeed.
+    /// Retryable. Log it, keep the stale cache, and hand it to
+    /// [`crate::intelligence::providers::note_transient_sync_failure`] — which
+    /// stays quiet while the provider is merely flaky, but escalates once the
+    /// last SUCCESSFUL sync gets old enough that "blip" stops being credible.
     Retry {
-        /// Full `anyhow` chain, for the log line only.
+        /// Full `anyhow` chain, for the log line and the escalation notice.
         detail: String,
     },
     /// Terminal. Raise a user-facing notice; nothing here self-heals.
@@ -205,10 +105,17 @@ impl SyncFault {
     /// understands token-endpoint failures this module cannot see. Keeps detail
     /// formatting inside this module so the guarantee above still holds.
     pub fn retry(err: &anyhow::Error) -> Self {
-        Self::Retry {
-            detail: format!("{err:#}"),
-        }
+        Self::Retry { detail: chain(err) }
     }
+}
+
+/// Format an error as its FULL `anyhow` source chain.
+///
+/// The single place `{err:#}` is written. Everything that needs a cause string
+/// goes through here so the truncation this module exists to fix cannot come
+/// back one call site at a time.
+pub fn chain(err: &anyhow::Error) -> String {
+    format!("{err:#}")
 }
 
 /// Decide what to do about a provider-sync failure, and format its detail.
@@ -219,9 +126,7 @@ pub fn classify(err: &anyhow::Error) -> SyncFault {
     if is_transient(err) {
         SyncFault::retry(err)
     } else {
-        SyncFault::Report {
-            detail: format!("{err:#}"),
-        }
+        SyncFault::Report { detail: chain(err) }
     }
 }
 
@@ -264,6 +169,7 @@ fn reqwest_is_transient(e: &reqwest::Error) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::super::client;
     use super::*;
 
     // ── status classification ────────────────────────────────────────────────
@@ -450,55 +356,6 @@ mod tests {
         assert!(
             !is_transient(&err),
             "a malformed credential must still reach the user"
-        );
-    }
-
-    /// Proves `.timeout()` is actually wired into [`build_client`]: the peer
-    /// accepts the TCP connection and then says nothing, so only a request
-    /// timeout can end this. Without the timeout the test hangs rather than
-    /// failing, which is itself the signal.
-    #[tokio::test]
-    async fn request_timeout_is_wired_and_classified_transient() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind loopback");
-        let addr = listener.local_addr().expect("local addr");
-        // Accept and hold the socket open without ever responding.
-        tokio::spawn(async move {
-            let mut held = Vec::new();
-            while let Ok((stream, _)) = listener.accept().await {
-                held.push(stream);
-            }
-        });
-
-        let short = Duration::from_millis(150);
-        let err = build_client(short, short)
-            .get(format!("http://{addr}/"))
-            .send()
-            .await
-            .expect_err("a peer that never responds must time out");
-        assert!(err.is_timeout(), "expected a timeout, got: {err}");
-
-        let err = anyhow::Error::new(err).context("POST /search/jql");
-        assert!(
-            is_transient(&err),
-            "a timeout must be retried, not reported"
-        );
-    }
-
-    /// The timeouts must stay bounded and ordered. A zero value disables the
-    /// timeout in reqwest, which would silently restore the unbounded-hang bug.
-    #[test]
-    fn timeout_constants_are_bounded_and_ordered() {
-        assert!(!REQUEST_TIMEOUT.is_zero(), "zero disables the timeout");
-        assert!(!CONNECT_TIMEOUT.is_zero(), "zero disables the timeout");
-        assert!(
-            CONNECT_TIMEOUT < REQUEST_TIMEOUT,
-            "connect deadline must fit inside the total deadline"
-        );
-        assert!(
-            REQUEST_TIMEOUT <= Duration::from_secs(120),
-            "an unbounded-in-practice timeout defeats the purpose"
         );
     }
 }

--- a/src/intelligence/providers/http/mod.rs
+++ b/src/intelligence/providers/http/mod.rs
@@ -41,10 +41,18 @@
 //! `pm_sync_state.last_synced_at` already records exactly that.
 //!
 //! # Who calls this
+//! All five PM connectors, at both their client construction and their sync
+//! failure paths:
 //! - [`crate::intelligence::providers::github`] — `refresh_if_stale` (viewer
 //!   fetch + all-projects-failed) and `fetch::{fetch_viewer_login, fetch_project_items}`.
-//! - [`crate::intelligence::providers::jira`] — `refresh_if_stale` (fetch
-//!   failure) and `fetch::search`.
+//! - [`crate::intelligence::providers::jira`] — `refresh_if_stale` (auth
+//!   resolve + fetch failure) and `fetch::search`.
+//! - [`crate::intelligence::providers::linear`] — `refresh_if_stale` and its
+//!   GraphQL fetch.
+//! - [`crate::intelligence::providers::trello`] — `refresh_if_stale` and its
+//!   cards fetch.
+//! - [`crate::intelligence::providers::azure_devops`] — `force_refresh` (WIQL
+//!   failure) and `fetch::{run_wiql, fetch_batch}`.
 //!
 //! # Related
 //! - [`crate::intelligence::providers::stamp_sync_error`] — what we call only

--- a/src/intelligence/providers/http/mod.rs
+++ b/src/intelligence/providers/http/mod.rs
@@ -1,0 +1,177 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Shared HTTP client and transient-failure classification for PM provider sync.
+//!
+//! Two concerns that look separate but are the same concern: how we talk to a
+//! provider's API, and how we decide whether a failed conversation is the
+//! user's problem or the network's.
+//!
+//! # Why this exists
+//! Every provider sync used to build `reqwest::Client::new()` per call and then
+//! treat ANY failure as a terminal, user-facing fault. Both halves were wrong:
+//!
+//! 1. **No timeouts.** `reqwest`'s defaults are `timeout: no timeout` and
+//!    `connect_timeout: None`, so a connect that hung never came back and the
+//!    provider simply stopped syncing with no error at all.
+//! 2. **No transient/terminal distinction.** A DNS blip, a captive portal, a
+//!    laptop resuming from sleep mid-tick — each raised a persistent
+//!    "GitHub sync failing / Set GITHUB_TOKEN in .env" banner that told the
+//!    user to re-do credentials that were never broken. [`crate::intelligence::providers::jira`]'s
+//!    OAuth-refresh path already learned this (see the `is_transient` guard in
+//!    `jira::refresh_if_stale` and the comment above it: raising a terminal
+//!    fault for a network blip is "exactly what made this fault flap on and off
+//!    at random"). That guard was only ever applied to refreshing the token,
+//!    never to using it — so every data-fetch path kept the original bug.
+//!
+//! [`is_transient`] is the shared answer, and unlike
+//! [`meridian_oauth::flow::is_transient`] — which only recognises a
+//! `TokenError` from the token endpoint and returns `false` for everything else
+//! — it classifies the transport errors a data fetch actually produces. The two
+//! are complementary, not interchangeable: dropping the OAuth one onto a fetch
+//! path compiles, runs, and returns `false` every single time.
+//!
+//! # Silence is bounded, deliberately
+//! Suppressing a transient failure outright would trade one bug for a worse
+//! one: a provider blocked by a corporate proxy or a TLS-intercepting firewall
+//! is unreachable *persistently*, and the user would get no signal at all while
+//! their board quietly went stale — strictly worse than the wrong-but-visible
+//! banner they get today. So [`SyncFault::Retry`] is not "stay silent", it is
+//! "ask [`crate::intelligence::providers::note_transient_sync_failure`]", which
+//! escalates once the last successful sync is old enough that "blip" is no
+//! longer a credible explanation. No migration needed:
+//! `pm_sync_state.last_synced_at` already records exactly that.
+//!
+//! # Who calls this
+//! - [`crate::intelligence::providers::github`] — `refresh_if_stale` (viewer
+//!   fetch + all-projects-failed) and `fetch::{fetch_viewer_login, fetch_project_items}`.
+//! - [`crate::intelligence::providers::jira`] — `refresh_if_stale` (fetch
+//!   failure) and `fetch::search`.
+//!
+//! # Related
+//! - [`crate::intelligence::providers::stamp_sync_error`] — what we call only
+//!   once a failure is classified terminal.
+//! - [`meridian_oauth::flow::is_transient`] — the OAuth-token-endpoint sibling.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+mod classify;
+pub use classify::{chain, classify, is_transient, HttpStatusError, SyncFault};
+
+/// Total deadline for one provider request, from connect to body complete.
+///
+/// Generous on purpose: this exists to bound a hang, not to police latency. A
+/// large Jira JQL search over a slow link is a legitimate slow request and must
+/// not be cut off, so this is set well above any observed healthy call.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Deadline for the connect phase alone. Much tighter than [`REQUEST_TIMEOUT`]
+/// because a connect that has not completed in this long is not slow, it is
+/// broken — the DNS/captive-portal/unreachable-host cases this module exists
+/// for. Failing fast here turns a silent stall into a classified transient
+/// error that retries on the next tick.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// How long an idle pooled connection may linger before being dropped.
+///
+/// Only relevant because the client is now SHARED across ticks (it previously
+/// was not, so every tick started with an empty pool and this could not
+/// happen). A pooled connection that a NAT, proxy, or the server has silently
+/// closed fails on reuse; bounding idle lifetime well below the multi-minute
+/// sync interval means a fresh connection is established each tick instead.
+const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// `SO_KEEPALIVE` interval — surfaces a dead peer rather than blocking until
+/// [`REQUEST_TIMEOUT`]. Paired with [`POOL_IDLE_TIMEOUT`] against the same
+/// silently-dropped-connection failure mode.
+const TCP_KEEPALIVE: Duration = Duration::from_secs(30);
+
+/// The process-wide client for PM provider sync.
+///
+/// Cloning a `reqwest::Client` is cheap (it is an `Arc` internally) and shares
+/// the connection pool, so callers should call this per request rather than
+/// caching the returned value.
+///
+/// Note this deliberately does NOT disable proxy detection: a user behind a
+/// corporate proxy needs reqwest's env/system proxy support to reach the
+/// provider at all.
+pub fn client() -> reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| build_client(REQUEST_TIMEOUT, CONNECT_TIMEOUT))
+        .clone()
+}
+
+/// Build a provider client with explicit timeouts. Split out from [`client`] so
+/// tests can drive the same builder with short deadlines — if the `.timeout()`
+/// wiring is ever dropped, `request_timeout_is_wired_and_classified_transient`
+/// fails rather than every install silently regaining unbounded hangs.
+///
+/// Falls back to `Client::new()` if the builder fails (only possible on TLS
+/// backend init failure): an un-timeouted client is strictly better than no
+/// sync at all, and the failure is logged.
+fn build_client(request_timeout: Duration, connect_timeout: Duration) -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(request_timeout)
+        .connect_timeout(connect_timeout)
+        .pool_idle_timeout(POOL_IDLE_TIMEOUT)
+        .tcp_keepalive(TCP_KEEPALIVE)
+        .build()
+        .unwrap_or_else(|e| {
+            tracing::error!(error = %e, "provider HTTP client builder failed - falling back to defaults (no timeouts)");
+            reqwest::Client::new()
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Proves `.timeout()` is actually wired into [`build_client`]: the peer
+    /// accepts the TCP connection and then says nothing, so only a request
+    /// timeout can end this. Without the timeout the test hangs rather than
+    /// failing, which is itself the signal.
+    #[tokio::test]
+    async fn request_timeout_is_wired_and_classified_transient() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        // Accept and hold the socket open without ever responding.
+        tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                held.push(stream);
+            }
+        });
+
+        let short = Duration::from_millis(150);
+        let err = build_client(short, short)
+            .get(format!("http://{addr}/"))
+            .send()
+            .await
+            .expect_err("a peer that never responds must time out");
+        assert!(err.is_timeout(), "expected a timeout, got: {err}");
+
+        let err = anyhow::Error::new(err).context("POST /search/jql");
+        assert!(
+            is_transient(&err),
+            "a timeout must be retried, not reported"
+        );
+    }
+
+    /// The timeouts must stay bounded and ordered. A zero value disables the
+    /// timeout in reqwest, which would silently restore the unbounded-hang bug.
+    #[test]
+    fn timeout_constants_are_bounded_and_ordered() {
+        assert!(!REQUEST_TIMEOUT.is_zero(), "zero disables the timeout");
+        assert!(!CONNECT_TIMEOUT.is_zero(), "zero disables the timeout");
+        assert!(
+            CONNECT_TIMEOUT < REQUEST_TIMEOUT,
+            "connect deadline must fit inside the total deadline"
+        );
+        assert!(
+            REQUEST_TIMEOUT <= Duration::from_secs(120),
+            "an unbounded-in-practice timeout defeats the purpose"
+        );
+    }
+}

--- a/src/intelligence/providers/jira/fetch.rs
+++ b/src/intelligence/providers/jira/fetch.rs
@@ -38,7 +38,7 @@ struct JiraFieldMeta {
 ///
 /// Returns None if no match or if the request fails.
 pub(super) async fn discover_start_date_field(ctx: &JiraReqCtx) -> Option<String> {
-    let client = reqwest::Client::new();
+    let client = crate::intelligence::providers::http::client();
     let url = ctx.api_url("/rest/api/3/field");
     let resp = ctx.apply(client.get(&url)).send().await.ok()?;
     if !resp.status().is_success() {
@@ -140,7 +140,7 @@ async fn search(
     start_date_field: Option<&str>,
     jql: &str,
 ) -> Result<Vec<(JiraIssue, serde_json::Value)>> {
-    let client = reqwest::Client::new();
+    let client = crate::intelligence::providers::http::client();
     let url = ctx.api_url("/rest/api/3/search/jql");
 
     let mut fields = vec![
@@ -185,7 +185,16 @@ async fn search(
 
     if !status.is_success() {
         let text = resp.text().await.unwrap_or_default();
-        anyhow::bail!("Jira /search/jql → {}: {}", status, text);
+        // Typed rather than formatted: the STATUS decides whether the caller
+        // raises a "Reconnect Jira" banner (401/403) or stays quiet and retries
+        // (429/5xx). A `bail!` string throws that away — see
+        // `crate::intelligence::providers::http::HttpStatusError`.
+        return Err(crate::intelligence::providers::http::HttpStatusError::new(
+            status.as_u16(),
+            "Jira /search/jql",
+            &text,
+        )
+        .into());
     }
 
     // Parse once as a Value so we can keep each raw issue object verbatim for

--- a/src/intelligence/providers/jira/mod.rs
+++ b/src/intelligence/providers/jira/mod.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 
 use crate::config::JiraConfig;
 use crate::intelligence::oauth::jira::JiraReqCtx;
+use crate::intelligence::providers::http::SyncFault;
 
 mod fetch;
 #[cfg(test)]
@@ -468,25 +469,37 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
             // exactly what made this fault flap on and off at random. Keep the
             // stale cache and stay quiet; the notice is reserved for a terminal
             // auth failure the user actually has to act on.
-            if meridian_oauth::is_transient(&e) {
-                tracing::warn!(
-                    error = %e,
-                    "jira auth temporarily unavailable - keeping stale cache, will retry next sync"
-                );
-                return Ok(None);
-            }
-            tracing::warn!(error = %e, "jira auth unavailable - keeping stale cache");
-            let msg = format!("Jira auth failed: {e}");
-            // Basic-auth (JIRA_API_TOKEN/JIRA_BASE_URL) and OAuth are mutually
-            // exclusive here — has_basic_auth() mirrors resolve()'s own choice —
-            // so the remedy must match whichever path this failure came from,
-            // not always point at the .env fields.
-            let remedy = if crate::intelligence::oauth::jira::has_basic_auth(jira) {
-                "Set JIRA_API_TOKEN and JIRA_BASE_URL in .env"
+            // `meridian_oauth::is_transient` only recognises a `TokenError` from
+            // the token endpoint and answers `false` for anything else, so a raw
+            // transport failure escaping the refresh would still land here as
+            // terminal. Falling back to `http::classify` closes that hole
+            // without ever making a genuinely dead grant look retryable.
+            let fault = if meridian_oauth::is_transient(&e) {
+                SyncFault::retry(&e)
             } else {
-                "Run: meridian oauth-login jira"
+                super::http::classify(&e)
             };
-            let _ = super::stamp_sync_error_with_remedy(pool, "jira", &msg, Some(remedy)).await;
+            match fault {
+                SyncFault::Retry { detail } => tracing::warn!(
+                    error = %detail,
+                    "jira auth temporarily unavailable - keeping stale cache, will retry next sync"
+                ),
+                SyncFault::Report { detail } => {
+                    tracing::warn!(error = %detail, "jira auth unavailable - keeping stale cache");
+                    let msg = format!("Jira auth failed: {detail}");
+                    // Basic-auth (JIRA_API_TOKEN/JIRA_BASE_URL) and OAuth are
+                    // mutually exclusive here - has_basic_auth() mirrors
+                    // resolve()'s own choice - so the remedy must match whichever
+                    // path this failure came from, not always point at .env.
+                    let remedy = if crate::intelligence::oauth::jira::has_basic_auth(jira) {
+                        "Set JIRA_API_TOKEN and JIRA_BASE_URL in .env"
+                    } else {
+                        "Reconnect Jira in Settings - Integrations"
+                    };
+                    let _ =
+                        super::stamp_sync_error_with_remedy(pool, "jira", &msg, Some(remedy)).await;
+                }
+            }
             return Ok(None);
         }
     };
@@ -561,9 +574,25 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
             Ok(Some(keys))
         }
         Err(e) => {
-            tracing::warn!(error = %e, "jira fetch failed — keeping stale cache");
-            let msg = format!("Jira sync failed — {e}");
-            let _ = super::stamp_sync_error(pool, "jira", &msg).await;
+            // The gap that left Jira users flapping: the transient guard on the
+            // resolve path above covers REFRESHING the token, never USING it. An
+            // Atlassian 5xx or a network blip during the search raised exactly
+            // the terminal banner that path was fixed to suppress.
+            match super::http::classify(&e) {
+                SyncFault::Retry { detail } => tracing::warn!(
+                    error = %detail,
+                    "jira unreachable - keeping stale cache, will retry next sync"
+                ),
+                SyncFault::Report { detail } => {
+                    tracing::warn!(error = %detail, "jira fetch failed - keeping stale cache");
+                    let _ = super::stamp_sync_error(
+                        pool,
+                        "jira",
+                        &format!("Jira sync failed: {detail}"),
+                    )
+                    .await;
+                }
+            }
             Ok(None)
         }
     }

--- a/src/intelligence/providers/jira/mod.rs
+++ b/src/intelligence/providers/jira/mod.rs
@@ -480,10 +480,13 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
                 super::http::classify(&e)
             };
             match fault {
-                SyncFault::Retry { detail } => tracing::warn!(
-                    error = %detail,
-                    "jira auth temporarily unavailable - keeping stale cache, will retry next sync"
-                ),
+                SyncFault::Retry { detail } => {
+                    tracing::warn!(
+                        error = %detail,
+                        "jira auth temporarily unavailable - keeping stale cache, will retry next sync"
+                    );
+                    let _ = super::note_transient_sync_failure(pool, "jira", &detail).await;
+                }
                 SyncFault::Report { detail } => {
                     tracing::warn!(error = %detail, "jira auth unavailable - keeping stale cache");
                     let msg = format!("Jira auth failed: {detail}");
@@ -579,10 +582,13 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
             // Atlassian 5xx or a network blip during the search raised exactly
             // the terminal banner that path was fixed to suppress.
             match super::http::classify(&e) {
-                SyncFault::Retry { detail } => tracing::warn!(
-                    error = %detail,
-                    "jira unreachable - keeping stale cache, will retry next sync"
-                ),
+                SyncFault::Retry { detail } => {
+                    tracing::warn!(
+                        error = %detail,
+                        "jira unreachable - keeping stale cache, will retry next sync"
+                    );
+                    let _ = super::note_transient_sync_failure(pool, "jira", &detail).await;
+                }
                 SyncFault::Report { detail } => {
                     tracing::warn!(error = %detail, "jira fetch failed - keeping stale cache");
                     let _ = super::stamp_sync_error(

--- a/src/intelligence/providers/linear/mod.rs
+++ b/src/intelligence/providers/linear/mod.rs
@@ -17,6 +17,7 @@ use serde::Deserialize;
 use sqlx::SqlitePool;
 
 use crate::config::LinearConfig;
+use crate::intelligence::providers::http::SyncFault;
 
 const LINEAR_GRAPHQL_URL: &str = "https://api.linear.app/graphql";
 const MAX_RESULTS: usize = 100;
@@ -174,7 +175,7 @@ async fn fetch(linear: &LinearConfig) -> Result<Vec<(LinearIssue, serde_json::Va
     );
     let body = serde_json::json!({ "query": query });
 
-    let client = reqwest::Client::new();
+    let client = super::http::client();
     let resp = client
         .post(LINEAR_GRAPHQL_URL)
         .header("Authorization", &linear.api_key)
@@ -188,7 +189,11 @@ async fn fetch(linear: &LinearConfig) -> Result<Vec<(LinearIssue, serde_json::Va
     tracing::Span::current().record("status_code", status.as_u16() as i64);
     let text = resp.text().await.unwrap_or_default();
     if !status.is_success() {
-        anyhow::bail!("Linear GraphQL → {}: {}", status, text);
+        // Typed rather than formatted: the STATUS is what decides whether the
+        // caller raises a banner (401/403) or stays quiet and retries (429/5xx).
+        return Err(
+            super::http::HttpStatusError::new(status.as_u16(), "Linear GraphQL", &text).into(),
+        );
     }
 
     // Parse once as a Value so the raw issue nodes survive verbatim for the
@@ -472,9 +477,24 @@ pub async fn refresh_if_stale(
             Ok(Some(kept))
         }
         Err(e) => {
-            tracing::warn!(error = %e, "linear fetch failed — keeping stale cache");
-            let _ =
-                super::stamp_sync_error(pool, "linear", &format!("Linear sync failed — {e}")).await;
+            match super::http::classify(&e) {
+                SyncFault::Retry { detail } => {
+                    tracing::warn!(
+                        error = %detail,
+                        "linear unreachable - keeping stale cache, will retry next sync"
+                    );
+                    let _ = super::note_transient_sync_failure(pool, "linear", &detail).await;
+                }
+                SyncFault::Report { detail } => {
+                    tracing::warn!(error = %detail, "linear fetch failed - keeping stale cache");
+                    let _ = super::stamp_sync_error(
+                        pool,
+                        "linear",
+                        &format!("Linear sync failed: {detail}"),
+                    )
+                    .await;
+                }
+            }
             Ok(None)
         }
     }

--- a/src/intelligence/providers/mod.rs
+++ b/src/intelligence/providers/mod.rs
@@ -187,12 +187,27 @@ pub async fn note_transient_sync_failure(
 ///
 /// `stage` names the failing step for the log only; the user-facing text is the
 /// classified detail.
+///
+/// # Best-effort by construction
+/// Returns `()`, not `Result`, so a failure to PERSIST the record can never
+/// replace the provider error that caused it. With a `Result` the callers wrote
+/// `record_sync_failure(...).await?`, which meant a transient `pm_sync_state`
+/// write failure turned a classified provider failure into an sqlx error — and
+/// in `azure_devops` that error then propagated back into
+/// `intelligence::run_pm_sync`'s catch-all, so the user would be shown a
+/// DATABASE error instead of "Azure DevOps sync failing". The classified outcome
+/// has to stay authoritative.
+///
+/// Nothing diagnostic is lost: the `tracing::warn!` carrying the full cause
+/// chain is emitted BEFORE the write, so the provider error reaches the logs and
+/// the telemetry backend either way, and the persistence failure is logged
+/// beside it rather than swallowed.
 pub async fn record_sync_failure(
     pool: &SqlitePool,
     provider: &str,
     stage: &str,
     err: &anyhow::Error,
-) -> Result<()> {
+) {
     match http::classify(err) {
         http::SyncFault::Retry { detail } => {
             tracing::warn!(
@@ -201,14 +216,17 @@ pub async fn record_sync_failure(
                 error = %detail,
                 "provider unreachable - keeping stale cache, will retry next sync"
             );
-            note_transient_sync_failure(pool, provider, &detail).await?;
+            if let Err(e) = note_transient_sync_failure(pool, provider, &detail).await {
+                tracing::warn!(provider, stage, error = %e, "recording transient sync failure failed");
+            }
         }
         http::SyncFault::Report { detail } => {
             tracing::warn!(provider, stage, error = %detail, "provider sync failed");
-            stamp_sync_error(pool, provider, &detail).await?;
+            if let Err(e) = stamp_sync_error(pool, provider, &detail).await {
+                tracing::warn!(provider, stage, error = %e, "recording sync failure failed");
+            }
         }
     }
-    Ok(())
 }
 
 /// Clear the last error for a provider after a successful sync.
@@ -530,9 +548,7 @@ mod tests {
         let pool = make_db().await;
         set_last_sync(&pool, "azure_devops", "-5 minutes").await;
 
-        record_sync_failure(&pool, "azure_devops", "wiql", &status_err(503, "down"))
-            .await
-            .unwrap();
+        record_sync_failure(&pool, "azure_devops", "wiql", &status_err(503, "down")).await;
 
         assert!(
             notice(&pool, "pm.azure_devops").await.is_none(),
@@ -550,8 +566,7 @@ mod tests {
             "wiql",
             &status_err(401, "permission_error: PAT is invalid"),
         )
-        .await
-        .unwrap();
+        .await;
 
         let (title, detail, _) = notice(&pool, "pm.azure_devops")
             .await
@@ -580,13 +595,9 @@ mod tests {
         let pool = make_db().await;
         let err = status_err(401, "permission_error: PAT is invalid");
 
-        record_sync_failure(&pool, "azure_devops", "wiql", &err)
-            .await
-            .unwrap();
+        record_sync_failure(&pool, "azure_devops", "wiql", &err).await;
         let first = notice(&pool, "pm.azure_devops").await.expect("first write");
-        record_sync_failure(&pool, "azure_devops", "refresh", &err)
-            .await
-            .unwrap();
+        record_sync_failure(&pool, "azure_devops", "refresh", &err).await;
         let second = notice(&pool, "pm.azure_devops")
             .await
             .expect("second write");
@@ -603,17 +614,33 @@ mod tests {
         set_last_sync(&pool, "azure_devops", "-5 minutes").await;
         let err = status_err(503, "down");
 
-        record_sync_failure(&pool, "azure_devops", "wiql", &err)
-            .await
-            .unwrap();
-        record_sync_failure(&pool, "azure_devops", "refresh", &err)
-            .await
-            .unwrap();
+        record_sync_failure(&pool, "azure_devops", "wiql", &err).await;
+        record_sync_failure(&pool, "azure_devops", "refresh", &err).await;
 
         assert!(
             notice(&pool, "pm.azure_devops").await.is_none(),
             "a re-reported blip must stay silent"
         );
+    }
+
+    /// A failure to PERSIST the record must never take the provider error down
+    /// with it. The `()` return makes that structural - it cannot propagate -
+    /// and this checks it also survives the write actually failing rather than
+    /// panicking. A dead pool is the cheapest way to force that.
+    ///
+    /// The case this protects: with the old `Result` signature and
+    /// `record_sync_failure(...).await?`, a transient DB error turned a
+    /// classified provider failure into an sqlx error, which in `azure_devops`
+    /// then propagated back into `run_pm_sync`'s catch-all - so the user was
+    /// shown a DATABASE error instead of "Azure DevOps sync failing".
+    #[tokio::test]
+    async fn a_persistence_failure_never_replaces_the_provider_error() {
+        let pool = make_db().await;
+        pool.close().await;
+
+        // Both branches, against a pool that cannot serve either write.
+        record_sync_failure(&pool, "azure_devops", "wiql", &status_err(503, "down")).await;
+        record_sync_failure(&pool, "azure_devops", "wiql", &status_err(401, "bad")).await;
     }
 
     /// The GitHub remedy must not name an unfollowable action: GitHub connects

--- a/src/intelligence/providers/mod.rs
+++ b/src/intelligence/providers/mod.rs
@@ -77,6 +77,81 @@ pub async fn stamp_sync_error_with_remedy(
     Ok(())
 }
 
+/// How stale the last SUCCESSFUL sync may get before a run of otherwise-
+/// suppressed transient failures is escalated to a user-facing notice.
+///
+/// Comfortably longer than any provider's sync interval, so an ordinary flaky
+/// hour never trips it — but short enough that a persistently blocked provider
+/// surfaces the same working day.
+const TRANSIENT_ESCALATION_HOURS: i64 = 6;
+
+/// Record a transient (retryable) sync failure.
+///
+/// Normally raises NOTHING — [`http::SyncFault::Retry`] exists precisely so a
+/// network blip stops producing a "check your credentials" banner for
+/// credentials that are fine.
+///
+/// But silence has to be BOUNDED. A provider blocked persistently (corporate
+/// proxy, TLS interception, a firewall rule) is unreachable on every tick
+/// forever, and suppressing that outright would leave the user's board silently
+/// going stale with no signal at all — strictly worse than the misleading banner
+/// this change removes. So the failure escalates to a normal sync notice once
+/// the provider has not synced successfully within
+/// [`TRANSIENT_ESCALATION_HOURS`].
+///
+/// **A provider that has NEVER synced escalates immediately**, deliberately:
+/// now that transient failures no longer call [`stamp_sync_error`], a machine
+/// that has never once reached the provider has no `pm_sync_state` row at all,
+/// so an age test alone would no-op on exactly the installs that most need it —
+/// someone who just connected and whose network blocks the provider outright.
+/// `EXISTS` is false for a missing row, which buys that case for free.
+///
+/// The remedy points at connectivity, NOT credentials: by construction we only
+/// reach here for failures that are not the user's token.
+///
+/// Returns whether it escalated.
+pub async fn note_transient_sync_failure(
+    pool: &SqlitePool,
+    provider: &str,
+    detail: &str,
+) -> Result<bool> {
+    let threshold = format!("-{TRANSIENT_ESCALATION_HOURS} hours");
+    let (recently_synced,): (i64,) = sqlx::query_as(
+        "SELECT EXISTS(
+             SELECT 1 FROM pm_sync_state
+             WHERE provider = ?
+               AND last_synced_at > strftime('%Y-%m-%dT%H:%M:%SZ', 'now', ?)
+         )",
+    )
+    .bind(provider)
+    .bind(&threshold)
+    .fetch_one(pool)
+    .await
+    .context("checking sync recency for transient-failure escalation")?;
+
+    if recently_synced != 0 {
+        return Ok(false);
+    }
+
+    tracing::warn!(
+        provider,
+        hours = TRANSIENT_ESCALATION_HOURS,
+        "provider unreachable with no recent successful sync - escalating to a notice"
+    );
+    // The title already names the provider, so the body only has to say what is
+    // wrong and carry the cause.
+    let msg =
+        format!("No successful sync in the last {TRANSIENT_ESCALATION_HOURS} hours - {detail}");
+    stamp_sync_error_with_remedy(
+        pool,
+        provider,
+        &msg,
+        Some("Check your internet connection, VPN, or proxy settings"),
+    )
+    .await?;
+    Ok(true)
+}
+
 /// Clear the last error for a provider after a successful sync.
 pub async fn clear_sync_error(pool: &SqlitePool, provider: &str) -> Result<()> {
     sqlx::query("UPDATE pm_sync_state SET last_error = NULL WHERE provider = ?")
@@ -148,4 +223,190 @@ pub async fn mark_retained_offboard(
         .await
         .with_context(|| format!("flagging retained off-board {provider} tasks"))?;
     Ok(result.rows_affected())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqliteConnectOptions;
+    use std::str::FromStr;
+
+    async fn make_db() -> SqlitePool {
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+            .unwrap()
+            .create_if_missing(true);
+        let pool = SqlitePool::connect_with(opts).await.unwrap();
+        sqlx::migrate!("src/migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    /// Stamp a last-successful-sync time relative to now, e.g. `"-7 hours"`.
+    async fn set_last_sync(pool: &SqlitePool, provider: &str, modifier: &str) {
+        sqlx::query(
+            "INSERT INTO pm_sync_state (provider, last_synced_at)
+             VALUES (?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now', ?))
+             ON CONFLICT(provider) DO UPDATE SET last_synced_at = excluded.last_synced_at",
+        )
+        .bind(provider)
+        .bind(modifier)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn notice(pool: &SqlitePool, id: &str) -> Option<(String, String, Option<String>)> {
+        sqlx::query_as("SELECT title, detail, remedy FROM system_notices WHERE notice_id = ?")
+            .bind(id)
+            .fetch_optional(pool)
+            .await
+            .unwrap()
+    }
+
+    /// The whole point of suppressing transient failures: an ordinary blip on a
+    /// provider that is otherwise working must raise NOTHING. This is the bug
+    /// the user reported - a banner telling them to redo working credentials.
+    #[tokio::test]
+    async fn a_blip_on_a_healthy_provider_stays_silent() {
+        let pool = make_db().await;
+        set_last_sync(&pool, "github", "-5 minutes").await;
+
+        let escalated = note_transient_sync_failure(&pool, "github", "dns error")
+            .await
+            .unwrap();
+
+        assert!(!escalated);
+        assert!(
+            notice(&pool, "pm.github").await.is_none(),
+            "a network blip must not raise a user-facing fault"
+        );
+    }
+
+    /// And the counterweight: silence must be BOUNDED. A provider blocked by a
+    /// proxy or firewall fails on every tick forever, and going quiet would
+    /// leave the board silently stale - worse than the banner we removed.
+    #[tokio::test]
+    async fn a_persistently_unreachable_provider_stops_being_silent() {
+        let pool = make_db().await;
+        set_last_sync(&pool, "jira", "-7 hours").await;
+
+        let escalated = note_transient_sync_failure(&pool, "jira", "connection timed out")
+            .await
+            .unwrap();
+
+        assert!(escalated);
+        let (title, detail, remedy) = notice(&pool, "pm.jira").await.expect("notice raised");
+        assert_eq!(title, "Jira sync failing");
+        assert!(
+            detail.contains("connection timed out"),
+            "the cause must survive into the notice: {detail}"
+        );
+        let remedy = remedy.expect("remedy set");
+        assert!(
+            remedy.contains("connection") || remedy.contains("proxy"),
+            "an unreachable provider is a connectivity remedy, not a credentials one: {remedy}"
+        );
+        assert!(
+            !remedy.contains("TOKEN"),
+            "must not tell the user to redo credentials that are fine: {remedy}"
+        );
+    }
+
+    /// The trap this fix has to survive: transient failures no longer call
+    /// `stamp_sync_error`, so a machine that has NEVER reached the provider has
+    /// no `pm_sync_state` row at all. An age test alone would no-op on exactly
+    /// the installs that need it most - someone who just connected behind a
+    /// blocking proxy. `EXISTS` is false for a missing row, which covers it.
+    #[tokio::test]
+    async fn a_provider_that_has_never_synced_escalates_immediately() {
+        let pool = make_db().await;
+
+        let escalated = note_transient_sync_failure(&pool, "github", "dns error")
+            .await
+            .unwrap();
+
+        assert!(
+            escalated,
+            "no pm_sync_state row means never-synced, which must not be silent"
+        );
+        assert!(notice(&pool, "pm.github").await.is_some());
+    }
+
+    /// A row left by an earlier TERMINAL failure carries the epoch sentinel
+    /// (`stamp_sync_error` inserts `1970-01-01`), which is a row but not a
+    /// success. It must not be mistaken for one.
+    #[tokio::test]
+    async fn an_epoch_sentinel_row_is_not_a_recent_success() {
+        let pool = make_db().await;
+        stamp_sync_error(&pool, "github", "bad credentials")
+            .await
+            .unwrap();
+
+        let escalated = note_transient_sync_failure(&pool, "github", "dns error")
+            .await
+            .unwrap();
+
+        assert!(escalated, "an epoch last_synced_at is not a success");
+    }
+
+    /// The window itself, from both sides.
+    #[tokio::test]
+    async fn the_escalation_window_holds_on_both_sides() {
+        let pool = make_db().await;
+
+        set_last_sync(&pool, "jira", "-1 hours").await;
+        assert!(
+            !note_transient_sync_failure(&pool, "jira", "blip")
+                .await
+                .unwrap(),
+            "inside the window must stay silent"
+        );
+
+        set_last_sync(&pool, "jira", "-7 hours").await;
+        assert!(
+            note_transient_sync_failure(&pool, "jira", "blip")
+                .await
+                .unwrap(),
+            "outside the window must escalate"
+        );
+    }
+
+    /// The escalation must self-heal: once the provider is reachable again the
+    /// next successful sync clears it, with no user action.
+    #[tokio::test]
+    async fn a_successful_sync_clears_an_escalated_notice() {
+        let pool = make_db().await;
+        note_transient_sync_failure(&pool, "github", "dns error")
+            .await
+            .unwrap();
+        assert!(notice(&pool, "pm.github").await.is_some());
+
+        clear_sync_error(&pool, "github").await.unwrap();
+
+        assert!(
+            notice(&pool, "pm.github").await.is_none(),
+            "escalation must clear itself once the provider is reachable"
+        );
+    }
+
+    /// The GitHub remedy must not name an unfollowable action: GitHub connects
+    /// via the in-app browser device flow, so a user who clicked Connect has
+    /// never seen a `GITHUB_TOKEN` to set.
+    #[tokio::test]
+    async fn the_github_remedy_points_somewhere_the_user_can_actually_go() {
+        let pool = make_db().await;
+        stamp_sync_error(&pool, "github", "bad credentials")
+            .await
+            .unwrap();
+
+        let (_, _, remedy) = notice(&pool, "pm.github").await.expect("notice raised");
+        let remedy = remedy.expect("remedy set");
+        assert!(
+            remedy.contains("Settings"),
+            "remedy must name a place in the app: {remedy}"
+        );
+        assert!(
+            !remedy.contains(".env"),
+            "a browser-connected user cannot edit .env: {remedy}"
+        );
+    }
 }

--- a/src/intelligence/providers/mod.rs
+++ b/src/intelligence/providers/mod.rs
@@ -166,6 +166,51 @@ pub async fn note_transient_sync_failure(
     Ok(true)
 }
 
+/// Record a provider sync failure against the shared classification.
+///
+/// The one place an `anyhow::Error` from a provider becomes user-visible state.
+/// A retryable failure stays quiet (while still feeding the escalation clock);
+/// a terminal one raises the notice. Both carry the FULL cause chain, because
+/// [`http::classify`] formats it.
+///
+/// # Why this is shared rather than inlined
+/// `intelligence::run_pm_sync`'s catch-all used to do
+/// `stamp_sync_error(name, &e.to_string())` for ANY propagated error —
+/// unconditionally terminal, and `{e}` rather than `{e:#}`, i.e. both of the
+/// bugs this module exists to fix. That made it a silent undo button: a provider
+/// could classify its own failure correctly and then have a second, generic,
+/// truncated write land on top of it and win. `azure_devops` hit exactly that,
+/// because it is the one provider whose `force_refresh` propagated `Err` after
+/// already recording. Routing both the provider and the catch-all through this
+/// function means there is no longer a path that reports a failure WITHOUT
+/// classifying it.
+///
+/// `stage` names the failing step for the log only; the user-facing text is the
+/// classified detail.
+pub async fn record_sync_failure(
+    pool: &SqlitePool,
+    provider: &str,
+    stage: &str,
+    err: &anyhow::Error,
+) -> Result<()> {
+    match http::classify(err) {
+        http::SyncFault::Retry { detail } => {
+            tracing::warn!(
+                provider,
+                stage,
+                error = %detail,
+                "provider unreachable - keeping stale cache, will retry next sync"
+            );
+            note_transient_sync_failure(pool, provider, &detail).await?;
+        }
+        http::SyncFault::Report { detail } => {
+            tracing::warn!(provider, stage, error = %detail, "provider sync failed");
+            stamp_sync_error(pool, provider, &detail).await?;
+        }
+    }
+    Ok(())
+}
+
 /// Clear the last error for a provider after a successful sync.
 pub async fn clear_sync_error(pool: &SqlitePool, provider: &str) -> Result<()> {
     sqlx::query("UPDATE pm_sync_state SET last_error = NULL WHERE provider = ?")
@@ -461,6 +506,114 @@ mod tests {
                 "{provider} recorded a failure as a sync at {last}"
             );
         }
+    }
+
+    // ── the generic catch-all ────────────────────────────────────────────────
+    //
+    // `intelligence::run_pm_sync`'s error arm reports ANY propagated failure.
+    // It used to do so unconditionally and with `{e}`, which made it a silent
+    // undo button: a provider could classify its own failure correctly and then
+    // have this second, generic, truncated write land on top and win. It now
+    // routes through `record_sync_failure`, so these pin its behaviour.
+
+    fn status_err(status: u16, body: &str) -> anyhow::Error {
+        anyhow::Error::new(http::HttpStatusError::new(
+            status,
+            "Azure DevOps WIQL",
+            body,
+        ))
+        .context("Azure DevOps WIQL request")
+    }
+
+    #[tokio::test]
+    async fn a_transient_failure_at_the_catch_all_raises_no_notice() {
+        let pool = make_db().await;
+        set_last_sync(&pool, "azure_devops", "-5 minutes").await;
+
+        record_sync_failure(&pool, "azure_devops", "wiql", &status_err(503, "down"))
+            .await
+            .unwrap();
+
+        assert!(
+            notice(&pool, "pm.azure_devops").await.is_none(),
+            "a 503 reaching the catch-all must not raise a credentials banner"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_terminal_failure_at_the_catch_all_carries_the_whole_chain() {
+        let pool = make_db().await;
+
+        record_sync_failure(
+            &pool,
+            "azure_devops",
+            "wiql",
+            &status_err(401, "permission_error: PAT is invalid"),
+        )
+        .await
+        .unwrap();
+
+        let (title, detail, _) = notice(&pool, "pm.azure_devops")
+            .await
+            .expect("a 401 must still reach the user");
+        assert_eq!(title, "Azure DevOps sync failing");
+        assert!(
+            detail.contains("Azure DevOps WIQL request"),
+            "outer context lost: {detail}"
+        );
+        assert!(
+            detail.contains("401"),
+            "cause chain truncated - the `{{e}}` bug is back: {detail}"
+        );
+        assert!(
+            detail.contains("PAT is invalid"),
+            "cause body lost: {detail}"
+        );
+    }
+
+    /// The specific shape the review caught: a provider records its own failure,
+    /// then the error propagates and the catch-all records it again. Both writes
+    /// now go through the same classifier, so the second cannot downgrade the
+    /// first into an unclassified, truncated notice.
+    #[tokio::test]
+    async fn recording_the_same_failure_twice_cannot_degrade_it() {
+        let pool = make_db().await;
+        let err = status_err(401, "permission_error: PAT is invalid");
+
+        record_sync_failure(&pool, "azure_devops", "wiql", &err)
+            .await
+            .unwrap();
+        let first = notice(&pool, "pm.azure_devops").await.expect("first write");
+        record_sync_failure(&pool, "azure_devops", "refresh", &err)
+            .await
+            .unwrap();
+        let second = notice(&pool, "pm.azure_devops")
+            .await
+            .expect("second write");
+
+        assert_eq!(first.1, second.1, "second write changed the detail");
+        assert!(second.1.contains("401"), "second write truncated the cause");
+    }
+
+    /// And the transient half of the same shape: a re-report must not turn a
+    /// suppressed blip into a banner.
+    #[tokio::test]
+    async fn re_reporting_a_transient_failure_still_raises_nothing() {
+        let pool = make_db().await;
+        set_last_sync(&pool, "azure_devops", "-5 minutes").await;
+        let err = status_err(503, "down");
+
+        record_sync_failure(&pool, "azure_devops", "wiql", &err)
+            .await
+            .unwrap();
+        record_sync_failure(&pool, "azure_devops", "refresh", &err)
+            .await
+            .unwrap();
+
+        assert!(
+            notice(&pool, "pm.azure_devops").await.is_none(),
+            "a re-reported blip must stay silent"
+        );
     }
 
     /// The GitHub remedy must not name an unfollowable action: GitHub connects

--- a/src/intelligence/providers/mod.rs
+++ b/src/intelligence/providers/mod.rs
@@ -40,14 +40,28 @@ pub async fn stamp_sync_error_with_remedy(
     .await?;
 
     let (title, remedy): (&str, Option<&str>) = match provider {
+        // The DEFAULT, used by every Jira path that does not know which auth
+        // method is in play (notably the fetch failure). It has to be the answer
+        // that is right for both, which is Settings - the `.env` wording is kept
+        // only as an explicit override on the resolve path, where
+        // `has_basic_auth()` has actually established the user configured it
+        // that way.
         "jira" => (
             "Jira sync failing",
-            Some("Set JIRA_API_TOKEN and JIRA_BASE_URL in .env"),
+            Some("Reconnect Jira in Settings - Integrations"),
         ),
-        "linear" => ("Linear sync failing", Some("Set LINEAR_API_KEY in .env")),
+        // Every remedy below names a place in the app rather than a file or a
+        // CLI command. All five trackers are connected through Settings ->
+        // Integrations, so a user who has only ever clicked Connect has no
+        // `.env` to edit and no terminal to run `meridian oauth-login` in.
+        // `every_remedy_is_followable_from_the_app` pins this.
+        "linear" => (
+            "Linear sync failing",
+            Some("Reconnect Linear in Settings - Integrations"),
+        ),
         "trello" => (
             "Trello sync failing",
-            Some("Run: meridian oauth-login trello"),
+            Some("Reconnect Trello in Settings - Integrations"),
         ),
         // NOT "Set GITHUB_TOKEN in .env": GitHub connects via the in-app browser
         // device flow, which writes `GITHUB_TOKEN` to `.env` itself (see
@@ -60,7 +74,7 @@ pub async fn stamp_sync_error_with_remedy(
         ),
         "azure_devops" => (
             "Azure DevOps sync failing",
-            Some("Set AZURE_DEVOPS_PAT in .env"),
+            Some("Reconnect Azure DevOps in Settings - Integrations"),
         ),
         _ => ("PM sync failing", None),
     };
@@ -388,6 +402,67 @@ mod tests {
         );
     }
 
+    /// The coupling that makes escalation reachable at all: recording an error
+    /// must NEVER write a fresh `last_synced_at`.
+    ///
+    /// Every provider gates its whole fetch on that column being recent, and
+    /// [`note_transient_sync_failure`] keys its escalation clock on the SAME
+    /// column. So stamping `now` here would do two invisible things at once:
+    /// suppress the next tick's retry, and reset the escalation clock on every
+    /// failure so the threshold is never reached. The provider would go silent
+    /// permanently, which is the exact regression this whole change exists to
+    /// prevent. `azure_devops` had precisely this bug in its own `stamp_error`.
+    #[tokio::test]
+    async fn recording_an_error_never_looks_like_a_successful_sync() {
+        let pool = make_db().await;
+
+        // First-ever failure: the inserted row must carry the epoch sentinel,
+        // not "now".
+        stamp_sync_error(&pool, "jira", "boom").await.unwrap();
+        let (last,): (String,) =
+            sqlx::query_as("SELECT last_synced_at FROM pm_sync_state WHERE provider = 'jira'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(
+            last.starts_with("1970"),
+            "an error must not be recorded as a sync: {last}"
+        );
+
+        // And on a row that already holds a real (old) success, recording a
+        // failure must leave the clock alone rather than pushing it forward.
+        set_last_sync(&pool, "github", "-10 hours").await;
+        stamp_sync_error(&pool, "github", "boom").await.unwrap();
+        assert!(
+            note_transient_sync_failure(&pool, "github", "unreachable")
+                .await
+                .unwrap(),
+            "recording an error must not reset the escalation clock"
+        );
+    }
+
+    /// Every provider that has a `stamp_error`-shaped path must share the one
+    /// above. Enumerated rather than spot-checked because the failure is silent:
+    /// a provider writing its own row with `last_synced_at = now` looks fine in
+    /// review and simply stops retrying and escalating forever.
+    #[tokio::test]
+    async fn no_provider_records_an_error_as_a_fresh_sync() {
+        for provider in ["jira", "github", "linear", "trello", "azure_devops"] {
+            let pool = make_db().await;
+            stamp_sync_error(&pool, provider, "boom").await.unwrap();
+            let (last,): (String,) =
+                sqlx::query_as("SELECT last_synced_at FROM pm_sync_state WHERE provider = ?")
+                    .bind(provider)
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            assert!(
+                last.starts_with("1970"),
+                "{provider} recorded a failure as a sync at {last}"
+            );
+        }
+    }
+
     /// The GitHub remedy must not name an unfollowable action: GitHub connects
     /// via the in-app browser device flow, so a user who clicked Connect has
     /// never seen a `GITHUB_TOKEN` to set.
@@ -408,5 +483,33 @@ mod tests {
             !remedy.contains(".env"),
             "a browser-connected user cannot edit .env: {remedy}"
         );
+    }
+
+    /// Generalises the test above to every tracker. All five are connected
+    /// through Settings -> Integrations, so a default remedy naming a file or a
+    /// terminal command is unfollowable for the people who actually see it.
+    ///
+    /// Scoped to the DEFAULT registry: `stamp_sync_error_with_remedy` overrides
+    /// still exist for genuinely env-configured installs (Jira basic auth), and
+    /// those are correct precisely because that user did edit `.env`.
+    #[tokio::test]
+    async fn every_default_remedy_names_a_place_in_the_app() {
+        for provider in ["jira", "github", "linear", "trello", "azure_devops"] {
+            let pool = make_db().await;
+            stamp_sync_error(&pool, provider, "boom").await.unwrap();
+
+            let (_, _, remedy) = notice(&pool, &format!("pm.{provider}"))
+                .await
+                .unwrap_or_else(|| panic!("{provider} raised no notice"));
+            let remedy = remedy.unwrap_or_else(|| panic!("{provider} has no remedy"));
+            assert!(
+                remedy.contains("Settings"),
+                "{provider} remedy does not name a place in the app: {remedy}"
+            );
+            assert!(
+                !remedy.contains(".env") && !remedy.contains("meridian "),
+                "{provider} remedy asks for a file edit or a CLI command: {remedy}"
+            );
+        }
     }
 }

--- a/src/intelligence/providers/mod.rs
+++ b/src/intelligence/providers/mod.rs
@@ -3,6 +3,7 @@
 pub mod azure_devops;
 pub mod cdm;
 pub mod github;
+pub mod http;
 pub mod jira;
 pub mod linear;
 pub mod status;
@@ -48,7 +49,15 @@ pub async fn stamp_sync_error_with_remedy(
             "Trello sync failing",
             Some("Run: meridian oauth-login trello"),
         ),
-        "github" => ("GitHub sync failing", Some("Set GITHUB_TOKEN in .env")),
+        // NOT "Set GITHUB_TOKEN in .env": GitHub connects via the in-app browser
+        // device flow, which writes `GITHUB_TOKEN` to `.env` itself (see
+        // `intelligence::oauth`). So the variable name is accurate and the
+        // instruction is unfollowable — a user who clicked Connect has never
+        // seen a token. Settings covers both that flow and the PAT one.
+        "github" => (
+            "GitHub sync failing",
+            Some("Reconnect GitHub in Settings - Integrations"),
+        ),
         "azure_devops" => (
             "Azure DevOps sync failing",
             Some("Set AZURE_DEVOPS_PAT in .env"),

--- a/src/intelligence/providers/trello.rs
+++ b/src/intelligence/providers/trello.rs
@@ -15,6 +15,7 @@ use sqlx::SqlitePool;
 
 use crate::config::TrelloConfig;
 use crate::intelligence::oauth::trello as oauth_trello;
+use crate::intelligence::providers::http::SyncFault;
 
 const TRELLO_BASE: &str = "https://api.trello.com/1";
 const MAX_RESULTS: usize = 100;
@@ -92,7 +93,7 @@ async fn fetch(trello: &TrelloConfig) -> Result<Vec<(TrelloCard, serde_json::Val
         trello.app_key, token,
     );
 
-    let client = reqwest::Client::new();
+    let client = super::http::client();
     let resp = client
         .get(&url)
         .header("Accept", "application/json")
@@ -104,7 +105,9 @@ async fn fetch(trello: &TrelloConfig) -> Result<Vec<(TrelloCard, serde_json::Val
     tracing::Span::current().record("status_code", status.as_u16() as i64);
     let text = resp.text().await.unwrap_or_default();
     if !status.is_success() {
-        anyhow::bail!("Trello API → {}: {}", status, text);
+        // Typed rather than formatted: the STATUS is what decides whether the
+        // caller raises a banner (401/403) or stays quiet and retries (429/5xx).
+        return Err(super::http::HttpStatusError::new(status.as_u16(), "Trello API", &text).into());
     }
 
     // Parse once as a Value so each raw card survives verbatim for the
@@ -323,9 +326,24 @@ pub async fn refresh_if_stale(
             Ok(Some(kept))
         }
         Err(e) => {
-            tracing::warn!(error = %e, "trello fetch failed — keeping stale cache");
-            let _ =
-                super::stamp_sync_error(pool, "trello", &format!("Trello sync failed — {e}")).await;
+            match super::http::classify(&e) {
+                SyncFault::Retry { detail } => {
+                    tracing::warn!(
+                        error = %detail,
+                        "trello unreachable - keeping stale cache, will retry next sync"
+                    );
+                    let _ = super::note_transient_sync_failure(pool, "trello", &detail).await;
+                }
+                SyncFault::Report { detail } => {
+                    tracing::warn!(error = %detail, "trello fetch failed - keeping stale cache");
+                    let _ = super::stamp_sync_error(
+                        pool,
+                        "trello",
+                        &format!("Trello sync failed: {detail}"),
+                    )
+                    .await;
+                }
+            }
             Ok(None)
         }
     }


### PR DESCRIPTION
## The bug

Users saw `GitHub sync failing / Set GITHUB_TOKEN in .env`, randomly, on some machines. Same symptom on Jira. The banner told them to redo credentials that were never broken.

The reported error body was `GitHub auth failed - POST /graphql viewer`. That string is the `.context()` on `.send()`, which only fails for a **transport** problem or a malformed request - never for a rejected token. A genuinely bad credential returns `Ok(401)` and lands on a different message entirely. So the message mislabelled the network as an auth failure, and the remedy pointed at the wrong thing.

## Why it reached every provider

`jira::refresh_if_stale` already diagnosed this - its comment says raising a terminal fault for a network blip is *"exactly what made this fault flap on and off at random"*. But that guard was only applied to **refreshing** the token, never to **using** it, so every data-fetch path kept the original bug.

Its classifier can't be reused: `meridian_oauth::is_transient` only recognises a `TokenError` from the token endpoint and returns `false` for everything else. Wiring it onto a fetch path compiles, runs, and is a no-op. A test pins that so the two don't get "consolidated" later.

## What changed

**`providers::http`** - the missing half, now used by **all five** connectors:

- `classify() -> SyncFault::{Retry, Report}`. Transient (timeout, connect, request, 408/425/429/5xx) is logged and retried silently. Terminal (401/403/404, malformed credential, decode) still reaches the user. `is_builder()` is explicitly terminal - that's the CR-in-the-token case, the one time "check your token" is correct.
- `HttpStatusError`, a typed status error. Non-2xx used to `bail!` a formatted string, discarding the status the decision depends on. `fetch_viewer_login` didn't check status at all, so a GitHub 5xx surfaced as `GraphQL viewer response missing data` - an outage reported as an auth failure.
- A **shared client with real timeouts**. reqwest defaults to *no* request timeout and *no* connect timeout ([docs](https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html)), so a hung connect stalled sync indefinitely with no error at all.

**Silence is bounded.** Suppressing transient failures outright would be worse than the bug: a provider blocked by a proxy or firewall fails every tick forever and would raise nothing while the board went stale. `SyncFault::Retry` feeds `note_transient_sync_failure`, which escalates after 6 hours without a successful sync. No migration - `last_synced_at` already records it. A provider that has **never** synced escalates immediately, which needed explicit handling: transient failures no longer call `stamp_sync_error`, so such a machine has no row at all and an age test alone would no-op on exactly the installs that need it most.

**`azure_devops` needed more than the others.** Its own `db::stamp_error` wrote `last_synced_at = now` on a first-ever failure - and since `refresh_if_stale` skips the fetch while that column is recent, a failure suppressed its **own** next retry, and would have made the escalation clock permanently unreachable. It now delegates to the shared helper. Its client also only set a total timeout, so a hung connect still burned the full 30 s. The 401/403 PAT guidance is preserved verbatim. And only its WIQL stage was classified at first - the work-item batch loop used a bare `?`, so a failure on the second page propagated with nothing durable recorded; both fatal HTTP stages now share one `record_sync_failure`.

**Cause chains.** `detail` is formatted `{e:#}` inside `classify()`, in one place. With plain `{e}` only the outermost `.context()` survived, so a connect failure reached both the banner and OpenObserve as the bare string `POST /graphql viewer` with the cause stripped. `src/main.rs:322` already documents this for the CLI paths.

**Remedies that name a followable action.** All five trackers are connected through Settings, so `.env` edits and `meridian oauth-login` are unfollowable for the people who see these banners. The `.env` wording survives only as an explicit override on Jira's resolve path, where `has_basic_auth()` has established the user really did configure it that way.

## Tests - 25 new

**Classification (15)** including *real* `reqwest` errors raised over loopback, no network: a refused connect, a request timeout against a peer that accepts and never answers, and a CR-bearing credential.

**Escalation and coupling (10, DB-backed).** The important ones: **recording an error must never write a fresh `last_synced_at`**, asserted for every provider. That failure mode is silent - it looks fine in review and simply stops retrying and escalating forever, which is exactly the bug `azure_devops` had. Also: a blip on a healthy provider stays silent; a persistently unreachable one doesn't; never-synced escalates immediately; the window holds on both sides; the notice self-heals.

The remedy test earned its keep immediately - it caught that Jira's **default** remedy still read `.env` while the fetch path uses that default regardless of how the user connected.

`cargo test` green (808 lib + integration), `clippy -D warnings` clean, full pre-push suite passed.

## Also in this branch

One unrelated commit: `nudge_hold_back_covers_the_grace_hour_only` built its markers from `Local::now()` and reaches an hour into the past, so it failed **deterministically for the whole hour after local midnight** - and blocked the pre-push hook. It now anchors to local midday, using the `now` parameter the function already takes for exactly this reason.

## Scope - what this does NOT cover

- **The wiring is unit-tested, not end-to-end.** Tests exercise `providers::http` and `note_transient_sync_failure` directly. Nothing asserts that a given provider's path actually calls `classify`, or that `stamp_sync_error` is *not* called on the transient branch - the API URLs are consts, so pointing a fetch at a local server would need an override.
- **The ~130 other `error = %e` sites** across the daemon have the same truncation. Separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of provider connection failures, authentication issues, and server errors across Jira, Linear, GitHub, Trello, and Azure DevOps.
  * Retryable outages now preserve cached data and avoid premature error alerts.
  * Persistent failures now provide clearer reconnection guidance in Settings.
  * Improved HTTP error messages include more accurate status and response details.
  * Stabilized a time-sensitive daily-plan test to prevent intermittent failures.
* **Performance**
  * Added shared HTTP connections with consistent timeout and keepalive settings for provider synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->