### PR TITLE
fix: clear the critical CodeQL alert, harden the grace-row insert, trace the sync-failure path

### DIFF
--- a/src/intelligence/providers/mod.rs
+++ b/src/intelligence/providers/mod.rs
@@ -130,7 +130,50 @@ const TRANSIENT_ESCALATION_HOURS: i64 = 6;
 /// The remedy points at connectivity, NOT credentials: by construction we only
 /// reach here for failures that are not the user's token.
 ///
+/// Write the epoch-sentinel grace row for a provider that has never synced.
+///
+/// # Why `ON CONFLICT DO NOTHING`
+/// The caller's `has_row` check is a SEPARATE statement from this insert, and
+/// `pm_sync_state.provider` is a PRIMARY KEY - so anything that can run two
+/// sync passes for one provider concurrently can have both observe "no row"
+/// and both insert. That is not hypothetical here: `meridian ticket-update`
+/// opens its OWN pool to the same `meridian.db` and calls
+/// `intelligence::run_pm_force_sync` (`src/main.rs`) while the daemon's poll
+/// loop is running `run_pm_sync` against the same file, so the two racers are
+/// separate PROCESSES and no in-process lock would cover them.
+///
+/// Without the clause the loser gets `UNIQUE constraint failed`, which
+/// [`record_sync_failure`] swallows by design - so the grace row would be
+/// silently lost, the next failure would take the same branch again, and the
+/// escalation clock would never start. That is the exact failure this whole
+/// module exists to prevent, reintroduced by a race.
+///
+/// Doing nothing on conflict is the correct resolution rather than a
+/// compromise: the row the winner wrote carries the same epoch sentinel this
+/// one would have written, so both racers leave the state they intended.
+///
+/// Extracted from [`note_transient_sync_failure`] to give the conflict
+/// behaviour a testable seam - the race itself has no deterministic hook, but
+/// "inserting over an existing row is a no-op, not an error" does.
+async fn insert_grace_row(pool: &SqlitePool, provider: &str, detail: &str) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO pm_sync_state (provider, last_synced_at, last_error)
+         VALUES (?, '1970-01-01T00:00:00Z', ?)
+         ON CONFLICT(provider) DO NOTHING",
+    )
+    .bind(provider)
+    .bind(detail)
+    .execute(pool)
+    .await
+    .context("recording the first transient failure for a never-synced provider")?;
+    Ok(())
+}
+
 /// Returns whether it escalated.
+#[tracing::instrument(
+    skip(pool, detail),
+    fields(provider, escalated = tracing::field::Empty)
+)]
 pub async fn note_transient_sync_failure(
     pool: &SqlitePool,
     provider: &str,
@@ -154,6 +197,7 @@ pub async fn note_transient_sync_failure(
     .context("checking sync recency for transient-failure escalation")?;
 
     if recently_synced != 0 {
+        tracing::Span::current().record("escalated", false);
         return Ok(false);
     }
 
@@ -163,19 +207,12 @@ pub async fn note_transient_sync_failure(
         // connected seconds ago that hits one blip must not immediately show a
         // fault. The epoch sentinel is deliberate - it is not a recent sync, so
         // the next failure takes the escalation branch below.
-        sqlx::query(
-            "INSERT INTO pm_sync_state (provider, last_synced_at, last_error)
-             VALUES (?, '1970-01-01T00:00:00Z', ?)",
-        )
-        .bind(provider)
-        .bind(detail)
-        .execute(pool)
-        .await
-        .context("recording the first transient failure for a never-synced provider")?;
+        insert_grace_row(pool, provider, detail).await?;
         tracing::debug!(
             provider,
             "first transient failure on a never-synced provider - staying quiet until the next attempt"
         );
+        tracing::Span::current().record("escalated", false);
         return Ok(false);
     }
 
@@ -195,6 +232,7 @@ pub async fn note_transient_sync_failure(
         Some("Check your internet connection, VPN, or proxy settings"),
     )
     .await?;
+    tracing::Span::current().record("escalated", true);
     Ok(true)
 }
 
@@ -234,12 +272,30 @@ pub async fn note_transient_sync_failure(
 /// chain is emitted BEFORE the write, so the provider error reaches the logs and
 /// the telemetry backend either way, and the persistence failure is logged
 /// beside it rather than swallowed.
+///
+/// # Telemetry
+/// Instrumented because this is where a provider failure becomes user-visible
+/// state, and the outcome is not derivable from the provider's own spans: the
+/// same `anyhow::Error` can end as a silent retry or a raised notice depending
+/// on [`http::classify`]. `outcome` records which, and `otel.status_code` marks
+/// the span ERROR only on the terminal path - a retryable blip is an expected
+/// outcome, not a fault, and marking it would drown the real ones.
+#[tracing::instrument(
+    skip(pool, err),
+    fields(
+        provider,
+        stage,
+        outcome = tracing::field::Empty,
+        otel.status_code = tracing::field::Empty,
+    )
+)]
 pub async fn record_sync_failure(
     pool: &SqlitePool,
     provider: &str,
     stage: &str,
     err: &anyhow::Error,
 ) {
+    let span = tracing::Span::current();
     match http::classify(err) {
         http::SyncFault::Retry { detail } => {
             tracing::warn!(
@@ -248,14 +304,31 @@ pub async fn record_sync_failure(
                 error = %detail,
                 "provider unreachable - keeping stale cache, will retry next sync"
             );
-            if let Err(e) = note_transient_sync_failure(pool, provider, &detail).await {
-                tracing::warn!(provider, stage, error = %e, "recording transient sync failure failed");
-            }
+            match note_transient_sync_failure(pool, provider, &detail).await {
+                Ok(escalated) => {
+                    span.record(
+                        "outcome",
+                        if escalated {
+                            "transient_escalated"
+                        } else {
+                            "transient_quiet"
+                        },
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(provider, stage, error = %e, "recording transient sync failure failed");
+                    span.record("outcome", "transient_record_failed");
+                    span.record("otel.status_code", "ERROR");
+                }
+            };
         }
         http::SyncFault::Report { detail } => {
             tracing::warn!(provider, stage, error = %detail, "provider sync failed");
+            span.record("outcome", "reported");
+            span.record("otel.status_code", "ERROR");
             if let Err(e) = stamp_sync_error(pool, provider, &detail).await {
                 tracing::warn!(provider, stage, error = %e, "recording sync failure failed");
+                span.record("outcome", "report_record_failed");
             }
         }
     }

--- a/src/intelligence/providers/sync_failure_tests.rs
+++ b/src/intelligence/providers/sync_failure_tests.rs
@@ -123,6 +123,75 @@ async fn a_never_synced_provider_gets_one_retry_before_escalating() {
     assert!(notice(&pool, "pm.github").await.is_some());
 }
 
+/// The grace-row insert races a concurrent one across PROCESSES: `meridian
+/// ticket-update` force-syncs through its own pool on the same `meridian.db`
+/// while the daemon polls. Both can observe "no row" and both insert against
+/// the `provider` PRIMARY KEY.
+///
+/// Without `ON CONFLICT DO NOTHING` the loser gets a UNIQUE violation, which
+/// `record_sync_failure` swallows by design - so the grace row vanishes, the
+/// next failure takes the never-synced branch again, and the escalation clock
+/// never starts. A provider blocked forever would then stay silent forever,
+/// which is the failure mode this module exists to prevent.
+///
+/// The race has no deterministic hook, so this pins the property that makes
+/// the race survivable: inserting over an existing row is a no-op, not an
+/// error, and the first writer's row is left intact.
+#[tokio::test]
+async fn a_racing_grace_row_insert_is_a_no_op_not_an_error() {
+    let pool = make_db().await;
+
+    insert_grace_row(&pool, "github", "first writer")
+        .await
+        .unwrap();
+    insert_grace_row(&pool, "github", "second writer")
+        .await
+        .expect("a concurrent grace-row insert must not error");
+
+    let (count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM pm_sync_state WHERE provider = 'github'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(count, 1, "the racing insert must not duplicate the row");
+
+    let (last, detail): (String, Option<String>) = sqlx::query_as(
+        "SELECT last_synced_at, last_error FROM pm_sync_state WHERE provider = 'github'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(
+        last.starts_with("1970"),
+        "the sentinel must survive the race, or escalation stalls: {last}"
+    );
+    assert_eq!(
+        detail.as_deref(),
+        Some("first writer"),
+        "DO NOTHING must leave the winner's row untouched"
+    );
+}
+
+/// A provider that HAS synced before must still escalate normally after a
+/// grace row lands - i.e. the conflict-tolerant insert did not change the
+/// contract the escalation clock reads.
+#[tokio::test]
+async fn a_grace_row_from_a_race_still_escalates_on_the_next_failure() {
+    let pool = make_db().await;
+    insert_grace_row(&pool, "github", "first writer")
+        .await
+        .unwrap();
+
+    let escalated = note_transient_sync_failure(&pool, "github", "dns error")
+        .await
+        .unwrap();
+    assert!(
+        escalated,
+        "the epoch sentinel is not a recent sync, so the next failure must surface"
+    );
+    assert!(notice(&pool, "pm.github").await.is_some());
+}
+
 /// The grace is exactly one retry, not an open-ended reprieve: the row the
 /// first failure writes must carry the epoch sentinel, or it would read as
 /// a recent sync and suppress escalation forever.

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -1437,6 +1437,35 @@ mod tests {
     /// parallel threads — mirrors `meridian_core::settings`'s own `ENV_LOCK`.
     static SUPPORT_ID_SETTINGS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    /// RAII restore for `MERIDIAN_SETTINGS_PATH`.
+    ///
+    /// The variable is process-global, so leaking it past this test would leak
+    /// into every later test in the same binary. The manual
+    /// `remove_var`-at-the-end this replaces was correct only on the happy
+    /// path: a failed `assert_eq!` unwinds straight past it, leaving a
+    /// now-deleted temp path installed as the settings location — so the real
+    /// failure would be followed by a cascade of unrelated ones, burying it.
+    /// Restores the PREVIOUS value rather than unconditionally removing, so it
+    /// composes if an outer harness ever sets its own.
+    struct SettingsPathGuard(Option<std::ffi::OsString>);
+
+    impl SettingsPathGuard {
+        fn set(path: &std::path::Path) -> Self {
+            let previous = std::env::var_os("MERIDIAN_SETTINGS_PATH");
+            std::env::set_var("MERIDIAN_SETTINGS_PATH", path);
+            Self(previous)
+        }
+    }
+
+    impl Drop for SettingsPathGuard {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(previous) => std::env::set_var("MERIDIAN_SETTINGS_PATH", previous),
+                None => std::env::remove_var("MERIDIAN_SETTINGS_PATH"),
+            }
+        }
+    }
+
     /// [`support_id_is_account_scoped`] exists so the Settings → Account copy
     /// can never claim something the pseudonym itself isn't doing. Pinned
     /// against [`choose_pseudonym_source`] directly (the same oracle
@@ -1456,7 +1485,7 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("settings.json");
-        std::env::set_var("MERIDIAN_SETTINGS_PATH", &path);
+        let _env = SettingsPathGuard::set(&path);
 
         for hash in [None, Some("deadbeefcafebabe")] {
             match hash {
@@ -1473,7 +1502,8 @@ mod tests {
             );
         }
 
-        std::env::remove_var("MERIDIAN_SETTINGS_PATH");
+        // `MERIDIAN_SETTINGS_PATH` is restored by `_env`'s Drop, on this path
+        // and on an unwinding one alike.
         let _ = std::fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
Two commits. The second clears the critical CodeQL alert blocking #603's checks; the first handles CodeRabbit's second review round.

---

# 1. The critical CodeQL alert (`rust/hard-coded-cryptographic-value`)

**It caught a real defect, and the defect was a wrong word.**

The rule has two sink mechanisms. The one that fired is the heuristic, which matches a constant passed to a parameter whose **declared name** is `password`/`iv`/`nonce`/`salt` ([`HardcodedCryptographicValueExtensions.qll`](https://github.com/github/codeql/blob/478878cfb70d100e63386192b12ef4f0e952cf38/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll)):

```ql
f.getParam(argIndex).getPat().(IdentPat).getName().getText() = argName and
( argName = "password" and kind = "password"
  or argName = "iv" and kind = "iv"
  or argName = "nonce" and kind = "nonce"
  or argName = "salt" and kind = "salt"
  // note: matching "key" results in too many false positives
)
```

We had `fn hash_pseudonym(salt: &str, seed: &str)`, and both constants flow into it - which is why **both** `redact.rs:438` and `:445` were flagged, not just the new one.

**This also explains why the alert is new when the bytes are not.** v1.80.0 shipped the identical construction and the identical `…v1:` prefix, but inlined it inside `pseudonymize_host` - so no parameter named `salt` existed and the heuristic had nothing to match. Extracting the shared `hash_pseudonym` helper in this PR is what created the sink. The repo's own history is the control experiment.

## Why it is the name that is wrong, not the design

A salt is per-value, unpredictable, and stored beside the digest to defeat precomputation. These are none of those. They are fixed, public domain-separation prefixes whose only job is to keep the host and account hash spaces disjoint, so a hardware UUID and an email can never collide into one identifier.

They **structurally cannot be secret**. The pseudonym has to reproduce byte-identically across every install - that is precisely what makes one machine's error rows group in the backend - and across a signed-in tester's separate Mac and Windows machines. And it ships inside a binary users hold, so a baked "secret" is readable anyway. The value provides *separation*, not *secrecy*; non-reversibility comes from SHA-256 over a high-entropy seed.

So: `*_PSEUDONYM_SALT` → `*_PSEUDONYM_DOMAIN`, the parameter `salt` → `domain`, and the same correction to three doc comments elsewhere that described it as a "salted hash". **The bytes fed to the hash are untouched.**

## The guard that was missing

That last sentence is load-bearing, and nothing was enforcing it. Every existing test was *relational* - same input matches, different inputs differ, length is 16 - all of which stay green if the digest changes wholesale.

That is a bad gap for a value whose entire purpose is continuity. v1.80.0 has shipped; rows carrying the current digest exist now. Reorder the two `update` calls, alter a prefix, change the truncation, and every install silently becomes a *new machine* on upgrade - old rows are not re-keyed, nothing fails, and support just quietly loses the ability to follow a user across a version boundary.

Added `pseudonym_digests_are_pinned_against_an_independent_oracle`, hand-computed rather than recorded from the implementation:

```
printf '%s' "meridian.host.pseudonym.v1:2D5462F0-45C1-5987-94E9-5CBAD14E4362" | shasum -a 256 | cut -c1-16
printf '%s' "meridian.account.pseudonym.v1:alpha.tester@example.com"          | shasum -a 256 | cut -c1-16
```

A value pasted in from whatever the code emitted would pass against a broken implementation. These came from an independent tool, so they assert the construction is `sha256(domain || seed)[..8]` **as documented** - and they confirm the rename changed nothing on the wire.

## A pre-existing test-isolation bug, found while verifying the above

Three tests assert the shipped `host.name` equals `local_host_pseudonym()`. That holds only when no `account_pseudonym` is visible - but settings is reached through a **process-global env var** these tests neither set nor locked, so they read whatever `MERIDIAN_SETTINGS_PATH` happened to point at.

```
$ git stash && cargo test --lib pseudonym     # on pre-main, unmodified
test result: FAILED. 6 passed; 3 failed
```

Each passes alone. The full suite passes because ~800 other tests make the collision unlikely to be *scheduled* - that is luck, not isolation. A signed-in developer's real `settings.json` breaks the same three with no concurrency at all. And the symptom is a wrong-looking pseudonym, naming nothing about an env var.

`MachineScopedSettings` now pins an account-free file under the shared lock (renamed `SETTINGS_ENV_LOCK`, since it is no longer one test's concern). Two of the three read settings *twice at different instants*, so serialising alone would not have been sufficient - hence hermetic.

**This is the half of CodeRabbit's finding I declined as hygiene in commit 1.** It was a live bug; that call was wrong.

## Verification status - please read

I could **not** verify this against CodeQL empirically. CodeQL runs only on PRs targeting the default branch, so #608 gets no CodeQL check, and there is no CodeQL CLI on this machine. Confidence rests on the quoted predicate plus the v1.80.0 natural experiment - strong, but it is inference.

**The check on #603 is the real test.** If it still fails after this merges, the sink is the modeled kind rather than the heuristic, and the next move is dismissal on `main`, not more code changes.

Note `hasher.update()` is *not* implicated either way: it is modeled as sink kind `hasher-input`, which only feeds the separate CWE-327 weak-hashing query, never this one.

---

# 2. CodeRabbit's second review round

Ten findings: three fixed, two declined with evidence, five deferred to #609. The line used to split them is **"did this PR introduce it"** - not "how big is the fix". That is what makes it principled: the spans got written *because* this PR created those paths; the file splits got deferred *because* this PR did not create those files' size.

**Grace-row insert races across processes.** The `has_row` check is a separate statement from the insert, and the racer is cross-**process**: `meridian ticket-update` opens its own pool to the same `meridian.db` and calls `run_pm_force_sync` while the daemon poll loop runs `run_pm_sync`. No in-process lock would cover it.

Without `ON CONFLICT(provider) DO NOTHING` the loser hit `UNIQUE constraint failed`, which `record_sync_failure` swallows **by design** - so the grace row vanished, the next failure took the never-synced branch again, and the escalation clock never started. A provider blocked forever would stay silent forever: the exact failure this module exists to prevent, reintroduced by a race. Extracted as `insert_grace_row` for a test seam; removing the clause fails the new test with `UNIQUE constraint failed: pm_sync_state.provider`.

**Spans** on `record_sync_failure` and `note_transient_sync_failure`. `outcome` is worth a field because the classification is not derivable from the provider's own spans - the same error ends as a silent retry or a raised notice. `otel.status_code=ERROR` only on the terminal path, so blips do not drown real faults.

**RAII env guard** on the Support ID test (the first half of the finding whose second half is fixed above).

### Declined

- **`write_account_pseudonym` skipping non-object settings** - false positive. `read_settings_value()` starts from `to_value(RuntimeSettings::default())` (a struct, always an object) and falls back to `Value::Object`. The branch is unreachable.
- **account.rs sign-in atomicity** - the split state is real and I am not claiming otherwise. The *direction* is deliberate and already documented in the sign-out path: it fails toward the per-machine Support ID, never toward "still grouped under the old account". Rollback would move the divergence, not remove it - deleting `account.json` would show signed-out while Clerk's session is live.

---

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` - **824 lib tests** plus all integration suites green. Tray workspace (`tray/src-tauri`) `cargo fmt --check` and `cargo check` clean, since a doc comment there changed.