### PR TITLE
fix(telemetry): clear the critical CodeQL alert - the prefixes are domains, not salts

### DIFF
--- a/meridian-core/src/settings.rs
+++ b/meridian-core/src/settings.rs
@@ -309,7 +309,7 @@ pub struct RuntimeSettings {
     pub worklog_auto_generate_prompted: bool,
     // ALPHA TESTING ONLY (hand-picked users, all on the same `stable`
     // production channel as everyone else — there's no separate alpha
-    // channel to gate on). A salted, one-way hash of the signed-in Clerk
+    // channel to gate on). A domain-separated, one-way hash of the signed-in Clerk
     // account email — NEVER the raw email — written by the tray's
     // `commands::account::save_account_email` (cleared on sign-out) and read
     // by `telemetry_spool::redact::local_host_pseudonym` to seed the Support

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,3 +31,9 @@ pub mod pm_worklog;
 pub mod telemetry_spool;
 pub mod uninstall;
 pub mod worklog_pipeline;
+
+/// Test-only. Crate-wide coordination for the process-global
+/// `MERIDIAN_SETTINGS_PATH`, which more than one module's tests manipulate -
+/// see the module docs for the bug that per-module locks caused.
+#[cfg(test)]
+pub(crate) mod test_env;

--- a/src/llm/resolver.rs
+++ b/src/llm/resolver.rs
@@ -438,15 +438,14 @@ async fn complete_inner(req: &PromptRequest) -> Result<(LlmOutput, LlmProvider),
 mod tests {
     use super::*;
 
-    /// `MERIDIAN_SETTINGS_PATH` is process-global and cargo runs tests in parallel.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    use crate::test_env::ScopedSettings;
 
-    fn write_settings(dir: &std::path::Path, provider: &str) -> std::path::PathBuf {
-        std::fs::create_dir_all(dir).unwrap();
-        let path = dir.join("settings.json");
-        std::fs::write(&path, format!(r#"{{"llm_provider":"{provider}"}}"#)).unwrap();
-        std::env::set_var("MERIDIAN_SETTINGS_PATH", &path);
-        path
+    /// `MERIDIAN_SETTINGS_PATH` is process-global, so the lock lives in
+    /// [`crate::test_env`] rather than here. A module-local one used to guard
+    /// these tests, and `telemetry_spool::redact` had its own - two locks over
+    /// one variable, which is the same as none. See that module's docs.
+    fn settings_for(tag: &str, provider: &str) -> ScopedSettings {
+        ScopedSettings::install(tag, &format!(r#"{{"llm_provider":"{provider}"}}"#))
     }
 
     /// THE test for this design. The resolver re-reads settings on every call, so flipping
@@ -454,34 +453,25 @@ mod tests {
     /// reload hook. If someone "optimises" this with a OnceLock, this fails.
     #[test]
     fn resolve_rereads_settings_every_call() {
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Guard FIRST: `clear_backoff` mutates a process-global map the
+        // sibling tests also write, so it must happen under the lock.
+        let settings = settings_for("resolver-rereads", "claude");
         clear_backoff();
-        let dir = std::env::temp_dir().join(format!("meridian-resolver-{}", std::process::id()));
-
-        write_settings(&dir, "claude");
         assert_eq!(resolve().provider(), LlmProvider::Claude);
 
         // Same process, no restart — just a different settings file.
-        write_settings(&dir, "codex");
+        settings.rewrite(r#"{"llm_provider":"codex"}"#);
         assert_eq!(resolve().provider(), LlmProvider::Codex);
 
-        write_settings(&dir, "cursor");
+        settings.rewrite(r#"{"llm_provider":"cursor"}"#);
         assert_eq!(resolve().provider(), LlmProvider::Cursor);
-
-        std::env::remove_var("MERIDIAN_SETTINGS_PATH");
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn an_unknown_provider_resolves_to_the_default() {
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _settings = settings_for("resolver-unknown", "gemini");
         clear_backoff();
-        let dir =
-            std::env::temp_dir().join(format!("meridian-resolver-unknown-{}", std::process::id()));
-        write_settings(&dir, "gemini");
         assert_eq!(resolve().provider(), LlmProvider::default());
-        std::env::remove_var("MERIDIAN_SETTINGS_PATH");
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// A rate limit degrades the TIMING, never the user's choice. With the on-device
@@ -490,11 +480,8 @@ mod tests {
     /// [`resolve`] keeps handing back the provider they picked.
     #[test]
     fn a_rate_limit_backoff_never_rewrites_the_users_choice() {
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let settings = settings_for("resolver-backoff", "claude");
         clear_backoff();
-        let dir =
-            std::env::temp_dir().join(format!("meridian-resolver-backoff-{}", std::process::id()));
-        let path = write_settings(&dir, "claude");
 
         start_backoff("claude", RATE_LIMIT_BACKOFF);
         assert!(
@@ -506,7 +493,7 @@ mod tests {
             LlmProvider::Claude,
             "the factory still reports the user's provider — nothing substitutes for it"
         );
-        let on_disk = std::fs::read_to_string(&path).unwrap();
+        let on_disk = std::fs::read_to_string(settings.path()).unwrap();
         assert!(
             on_disk.contains("claude"),
             "and the stored choice is untouched: {on_disk}"
@@ -514,9 +501,6 @@ mod tests {
 
         clear_backoff();
         assert!(!is_backing_off("claude"), "calls resume once it expires");
-
-        std::env::remove_var("MERIDIAN_SETTINGS_PATH");
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// The fix for the cross-provider backoff bug: a rate limit on ONE provider must not
@@ -525,7 +509,14 @@ mod tests {
     /// tray↔daemon process boundary anyway).
     #[test]
     fn a_backoff_on_one_provider_does_not_stall_another() {
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Takes the lock despite reading no settings. The backoff map is ALSO
+        // process-global, and every sibling test here calls `clear_backoff()` -
+        // so one of them landing between this test's `start_backoff` and its
+        // assertion wipes the entry and fails it. The old module-local
+        // `ENV_LOCK` was quietly doing double duty as the backoff lock too;
+        // dropping it here (this test touches no settings) reintroduced the
+        // race, at roughly 1 run in 15.
+        let _lock = crate::test_env::lock_settings_env();
         clear_backoff();
 
         start_backoff("claude", RATE_LIMIT_BACKOFF);

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -435,22 +435,48 @@ const HOST_NAME_KEY: &str = "host.name";
 
 /// Domain-separation prefix so the digest can't be compared against a hash of
 /// the bare hostname computed elsewhere.
-const HOST_PSEUDONYM_SALT: &str = "meridian.host.pseudonym.v1:";
+const HOST_PSEUDONYM_DOMAIN: &str = "meridian.host.pseudonym.v1:";
 
 /// Domain-separation prefix for [`pseudonymize_account`] — deliberately
-/// DIFFERENT from [`HOST_PSEUDONYM_SALT`] so the two hash spaces can never be
-/// cross-compared (a candidate email hashed under the wrong salt would never
-/// match a machine pseudonym, and vice versa), even though both go through
-/// the same [`hash_pseudonym`] shape.
-const ACCOUNT_PSEUDONYM_SALT: &str = "meridian.account.pseudonym.v1:";
+/// DIFFERENT from [`HOST_PSEUDONYM_DOMAIN`] so the two hash spaces can never
+/// be cross-compared (a candidate email hashed under the wrong domain would
+/// never match a machine pseudonym, and vice versa), even though both go
+/// through the same [`hash_pseudonym`] shape.
+const ACCOUNT_PSEUDONYM_DOMAIN: &str = "meridian.account.pseudonym.v1:";
 
-/// Shared SHA-256-salt-and-truncate shape behind both [`pseudonymize_host`]
+/// Shared SHA-256-prefix-and-truncate shape behind both [`pseudonymize_host`]
 /// and [`pseudonymize_account`]. Truncated to 16 hex chars (8 bytes): ample
 /// against collisions at fleet scale, short enough to read in a dashboard.
-fn hash_pseudonym(salt: &str, seed: &str) -> String {
+///
+/// # `domain`, not `salt`
+/// The first argument is a DOMAIN-SEPARATION prefix and is deliberately not
+/// called a salt, because it is not one and must never be treated as one. A
+/// salt is per-value, unpredictable, and stored beside the digest to stop
+/// precomputation. This is a fixed public label whose only job is to keep two
+/// hash spaces disjoint, so that a hardware UUID and an email can never
+/// collide into the same identifier.
+///
+/// It structurally CANNOT be secret: the pseudonym has to reproduce
+/// byte-identically across every install (that is what makes one machine's
+/// error rows group in the backend) and across a signed-in tester's separate
+/// Macs and Windows boxes — and it ships inside a binary users hold, so a
+/// baked "secret" would be readable anyway. This value provides separation,
+/// NOT secrecy; the non-reversibility of the identifier comes from SHA-256
+/// over a high-entropy seed, not from hiding this string.
+///
+/// The naming is load-bearing rather than cosmetic. While this parameter was
+/// called `salt`, CodeQL's `rust/hard-coded-cryptographic-value` flagged both
+/// constants as critical: its heuristic sink matches a constant passed to a
+/// parameter whose DECLARED name is `password`/`iv`/`nonce`/`salt`. It was
+/// right to, on the evidence it had — code that says "salt" and hardcodes one
+/// is a real vulnerability. The defect was the word, so the word is what
+/// changed; the bytes fed to the hash are untouched, and
+/// `pseudonym_digests_are_pinned_against_an_independent_oracle` holds them to
+/// that. Do not reintroduce `salt` here as a synonym.
+fn hash_pseudonym(domain: &str, seed: &str) -> String {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
-    hasher.update(salt.as_bytes());
+    hasher.update(domain.as_bytes());
     hasher.update(seed.as_bytes());
     let digest = hasher.finalize();
     digest[..8].iter().fold(String::new(), |mut acc, b| {
@@ -480,11 +506,12 @@ fn hash_pseudonym(salt: &str, seed: &str) -> String {
 /// should actually use — hashing a caller-supplied hostname is exactly the
 /// mistake this module had (see that function's doc).
 pub fn pseudonymize_host(seed: &str) -> String {
-    hash_pseudonym(HOST_PSEUDONYM_SALT, seed)
+    hash_pseudonym(HOST_PSEUDONYM_DOMAIN, seed)
 }
 
 /// Hash a signed-in user's email into the same 16-hex shape as
-/// [`pseudonymize_host`], salted separately (see [`ACCOUNT_PSEUDONYM_SALT`]).
+/// [`pseudonymize_host`], separated by its own domain prefix (see
+/// [`ACCOUNT_PSEUDONYM_DOMAIN`]).
 ///
 /// ALPHA TESTING ONLY — see [`local_host_pseudonym`]'s doc for the mechanism
 /// this feeds. `pub` because the tray computes this at sign-in
@@ -496,7 +523,7 @@ pub fn pseudonymize_host(seed: &str) -> String {
 /// `user@example.com` (the same signed-in person, different capitalisation)
 /// produce the identical pseudonym.
 pub fn pseudonymize_account(email: &str) -> String {
-    hash_pseudonym(ACCOUNT_PSEUDONYM_SALT, &email.trim().to_ascii_lowercase())
+    hash_pseudonym(ACCOUNT_PSEUDONYM_DOMAIN, &email.trim().to_ascii_lowercase())
 }
 
 /// This machine's pseudonym - the exact value that appears as `host.name` in
@@ -1190,6 +1217,7 @@ mod tests {
     /// verbatim — on macOS it is routinely the account holder's real name.
     #[test]
     fn host_name_is_pseudonymised_not_shipped_raw() {
+        let _settings = MachineScopedSettings::install("host-name-pseudonymised");
         let mut kv = str_attr("host.name", "Akarshs-MacBook-Pro.local");
         assert!(keep(&mut kv), "host.name should be kept");
         let out = match kv.value.unwrap().value.unwrap() {
@@ -1216,6 +1244,7 @@ mod tests {
     /// Hashing the captured value (the previous behaviour) failed this.
     #[test]
     fn pseudonym_is_independent_of_the_captured_hostname() {
+        let _settings = MachineScopedSettings::install("pseudonym-independent");
         let shipped = |raw: &str| {
             let mut kv = str_attr("host.name", raw);
             assert!(keep(&mut kv));
@@ -1304,6 +1333,7 @@ mod tests {
     /// hostname is read.
     #[test]
     fn displayed_pseudonym_matches_shipped() {
+        let _settings = MachineScopedSettings::install("displayed-matches-shipped");
         let raw = gethostname::gethostname().to_string_lossy().into_owned();
         let mut kv = str_attr("host.name", &raw);
         assert!(keep(&mut kv));
@@ -1355,17 +1385,70 @@ mod tests {
         );
     }
 
-    /// [`pseudonymize_account`] must be salted separately from
+    /// [`pseudonymize_account`] must use a DIFFERENT domain prefix from
     /// [`pseudonymize_host`] — otherwise a hardware UUID and an email could
     /// collide into the same identifier space, and a determined reader who
     /// knows a candidate value of one kind could confirm it against the other.
+    ///
+    /// This is the property the two domain constants exist for, so it is
+    /// pinned separately from the digest values themselves: sharing a prefix
+    /// would leave every other test in this file green.
     #[test]
-    fn account_pseudonym_is_salted_independently_of_host_pseudonym() {
+    fn account_pseudonym_is_domain_separated_from_host_pseudonym() {
         let same_string = "not-actually-an-email-or-a-uuid";
         assert_ne!(
             pseudonymize_host(same_string),
             pseudonymize_account(same_string),
-            "account and host pseudonyms must not share a salt"
+            "account and host pseudonyms must not share a domain prefix"
+        );
+    }
+
+    /// Both pseudonyms are a WIRE FORMAT, and nothing else in this file pins
+    /// them. Every other test here is relational — same input gives the same
+    /// output, different inputs differ, length is 16 — all of which stay green
+    /// if the digest changes wholesale.
+    ///
+    /// That matters because the value's entire purpose is continuity: a
+    /// machine's rows in the central backend are grouped by this string, and
+    /// v1.80.0 has already shipped, so error rows carrying the current digest
+    /// exist today. Change what goes into the hash — reorder the two `update`
+    /// calls, alter a domain constant, switch the truncation — and every
+    /// install silently becomes a NEW machine on upgrade. The old rows are not
+    /// re-keyed, and nothing anywhere fails; support just quietly loses the
+    /// ability to follow one user across a version boundary, and the Support ID
+    /// a user quotes from Settings stops matching the rows filed before it.
+    ///
+    /// So these are hand-computed rather than recorded from the implementation:
+    ///
+    /// ```text
+    /// printf '%s' "meridian.host.pseudonym.v1:2D5462F0-45C1-5987-94E9-5CBAD14E4362" \
+    ///   | shasum -a 256 | cut -c1-16   # 9790585e54e6cdf6
+    /// printf '%s' "meridian.account.pseudonym.v1:alpha.tester@example.com" \
+    ///   | shasum -a 256 | cut -c1-16   # 85ee36b8a62c2aab
+    /// ```
+    ///
+    /// A hash pinned by pasting in whatever the code emitted would pass against
+    /// a broken implementation; these came from an independent tool, so they
+    /// assert the construction is `sha256(domain || seed)[..8]` as documented,
+    /// not merely that it is stable.
+    ///
+    /// If this test fails, do NOT re-record the expected values. Either the
+    /// change is unintended, or it is a deliberate v2 of the identifier — and a
+    /// v2 needs the domain constants bumped (`…v1:` → `…v2:`) plus a decision
+    /// about the orphaned rows, not a new literal here.
+    #[test]
+    fn pseudonym_digests_are_pinned_against_an_independent_oracle() {
+        assert_eq!(
+            pseudonymize_host("2D5462F0-45C1-5987-94E9-5CBAD14E4362"),
+            "9790585e54e6cdf6",
+            "host pseudonym digest changed - this silently re-keys every \
+             machine's error rows on upgrade; see this test's doc"
+        );
+        assert_eq!(
+            pseudonymize_account("alpha.tester@example.com"),
+            "85ee36b8a62c2aab",
+            "account pseudonym digest changed - this silently re-keys every \
+             signed-in tester's error rows; see this test's doc"
         );
     }
 
@@ -1435,7 +1518,12 @@ mod tests {
 
     /// `MERIDIAN_SETTINGS_PATH` is process-global and cargo runs tests in
     /// parallel threads — mirrors `meridian_core::settings`'s own `ENV_LOCK`.
-    static SUPPORT_ID_SETTINGS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    ///
+    /// EVERY test in this module that sets the variable OR calls anything that
+    /// reads settings ([`local_host_pseudonym`], and [`keep_attribute`] via the
+    /// `keep` shim) must hold this. See [`MachineScopedSettings`] for what went
+    /// wrong when they didn't.
+    static SETTINGS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     /// RAII restore for `MERIDIAN_SETTINGS_PATH`.
     ///
@@ -1466,6 +1554,66 @@ mod tests {
         }
     }
 
+    /// Pin settings at an account-free file, so [`local_host_pseudonym`]
+    /// resolves to the per-MACHINE identity for the length of a test.
+    ///
+    /// # The bug this fixes
+    /// Three tests here assert the shipped `host.name` equals
+    /// [`local_host_pseudonym`]. That holds only while NO `account_pseudonym`
+    /// is visible in settings — and settings is reached through a
+    /// process-global env var, which those tests neither set nor locked. So
+    /// they read whatever `MERIDIAN_SETTINGS_PATH` happened to point at when
+    /// their thread ran.
+    ///
+    /// Two ways that bit. A concurrently-running settings test installs a temp
+    /// file carrying an `account_pseudonym`, and these three flip to the
+    /// account-scoped branch mid-run — reproducible today with
+    /// `cargo test --lib pseudonym`, where all three fail against `pre-main`
+    /// while each passes alone. And on a signed-in developer's machine the
+    /// ambient real `settings.json` has the same effect with no concurrency at
+    /// all. The full suite passes only because ~800 other tests make the
+    /// collision unlikely to be scheduled — it is luck, not isolation, and the
+    /// failure surfaces as a wrong-looking pseudonym rather than as anything
+    /// naming the env var.
+    ///
+    /// Worse, two of the three read settings TWICE at different instants (once
+    /// inside `keep`, once directly), so serialising on the lock alone would
+    /// not be enough if the ambient file were account-scoped. Hence hermetic:
+    /// the file is ours and is known to be account-free.
+    struct MachineScopedSettings {
+        _env: SettingsPathGuard,
+        _lock: std::sync::MutexGuard<'static, ()>,
+        dir: std::path::PathBuf,
+    }
+
+    impl MachineScopedSettings {
+        fn install(tag: &str) -> Self {
+            let lock = SETTINGS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let dir = std::env::temp_dir().join(format!(
+                "meridian-redact-{tag}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            std::fs::create_dir_all(&dir).unwrap();
+            let path = dir.join("settings.json");
+            // No `account_pseudonym` key: the machine-scoped branch.
+            std::fs::write(&path, "{}").unwrap();
+            Self {
+                _env: SettingsPathGuard::set(&path),
+                _lock: lock,
+                dir,
+            }
+        }
+    }
+
+    impl Drop for MachineScopedSettings {
+        fn drop(&mut self) {
+            // Runs before the fields, so the env var still points here — safe,
+            // because the lock (dropped after this) is still held.
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
     /// [`support_id_is_account_scoped`] exists so the Settings → Account copy
     /// can never claim something the pseudonym itself isn't doing. Pinned
     /// against [`choose_pseudonym_source`] directly (the same oracle
@@ -1475,9 +1623,7 @@ mod tests {
     /// "true" and breaking the day the alpha window ends.
     #[test]
     fn support_id_is_account_scoped_matches_choose_pseudonym_source() {
-        let _guard = SUPPORT_ID_SETTINGS_ENV_LOCK
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let _guard = SETTINGS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = std::env::temp_dir().join(format!(
             "meridian-redact-support-id-scoped-{}-{:?}",
             std::process::id(),

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -1217,7 +1217,7 @@ mod tests {
     /// verbatim — on macOS it is routinely the account holder's real name.
     #[test]
     fn host_name_is_pseudonymised_not_shipped_raw() {
-        let _settings = MachineScopedSettings::install("host-name-pseudonymised");
+        let _settings = ScopedSettings::machine_scoped("host-name-pseudonymised");
         let mut kv = str_attr("host.name", "Akarshs-MacBook-Pro.local");
         assert!(keep(&mut kv), "host.name should be kept");
         let out = match kv.value.unwrap().value.unwrap() {
@@ -1244,7 +1244,7 @@ mod tests {
     /// Hashing the captured value (the previous behaviour) failed this.
     #[test]
     fn pseudonym_is_independent_of_the_captured_hostname() {
-        let _settings = MachineScopedSettings::install("pseudonym-independent");
+        let _settings = ScopedSettings::machine_scoped("pseudonym-independent");
         let shipped = |raw: &str| {
             let mut kv = str_attr("host.name", raw);
             assert!(keep(&mut kv));
@@ -1333,7 +1333,7 @@ mod tests {
     /// hostname is read.
     #[test]
     fn displayed_pseudonym_matches_shipped() {
-        let _settings = MachineScopedSettings::install("displayed-matches-shipped");
+        let _settings = ScopedSettings::machine_scoped("displayed-matches-shipped");
         let raw = gethostname::gethostname().to_string_lossy().into_owned();
         let mut kv = str_attr("host.name", &raw);
         assert!(keep(&mut kv));
@@ -1516,103 +1516,7 @@ mod tests {
         assert_eq!(choose_pseudonym_source(before_expiry, Some("   ")), None);
     }
 
-    /// `MERIDIAN_SETTINGS_PATH` is process-global and cargo runs tests in
-    /// parallel threads — mirrors `meridian_core::settings`'s own `ENV_LOCK`.
-    ///
-    /// EVERY test in this module that sets the variable OR calls anything that
-    /// reads settings ([`local_host_pseudonym`], and [`keep_attribute`] via the
-    /// `keep` shim) must hold this. See [`MachineScopedSettings`] for what went
-    /// wrong when they didn't.
-    static SETTINGS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    /// RAII restore for `MERIDIAN_SETTINGS_PATH`.
-    ///
-    /// The variable is process-global, so leaking it past this test would leak
-    /// into every later test in the same binary. The manual
-    /// `remove_var`-at-the-end this replaces was correct only on the happy
-    /// path: a failed `assert_eq!` unwinds straight past it, leaving a
-    /// now-deleted temp path installed as the settings location — so the real
-    /// failure would be followed by a cascade of unrelated ones, burying it.
-    /// Restores the PREVIOUS value rather than unconditionally removing, so it
-    /// composes if an outer harness ever sets its own.
-    struct SettingsPathGuard(Option<std::ffi::OsString>);
-
-    impl SettingsPathGuard {
-        fn set(path: &std::path::Path) -> Self {
-            let previous = std::env::var_os("MERIDIAN_SETTINGS_PATH");
-            std::env::set_var("MERIDIAN_SETTINGS_PATH", path);
-            Self(previous)
-        }
-    }
-
-    impl Drop for SettingsPathGuard {
-        fn drop(&mut self) {
-            match self.0.take() {
-                Some(previous) => std::env::set_var("MERIDIAN_SETTINGS_PATH", previous),
-                None => std::env::remove_var("MERIDIAN_SETTINGS_PATH"),
-            }
-        }
-    }
-
-    /// Pin settings at an account-free file, so [`local_host_pseudonym`]
-    /// resolves to the per-MACHINE identity for the length of a test.
-    ///
-    /// # The bug this fixes
-    /// Three tests here assert the shipped `host.name` equals
-    /// [`local_host_pseudonym`]. That holds only while NO `account_pseudonym`
-    /// is visible in settings — and settings is reached through a
-    /// process-global env var, which those tests neither set nor locked. So
-    /// they read whatever `MERIDIAN_SETTINGS_PATH` happened to point at when
-    /// their thread ran.
-    ///
-    /// Two ways that bit. A concurrently-running settings test installs a temp
-    /// file carrying an `account_pseudonym`, and these three flip to the
-    /// account-scoped branch mid-run — reproducible today with
-    /// `cargo test --lib pseudonym`, where all three fail against `pre-main`
-    /// while each passes alone. And on a signed-in developer's machine the
-    /// ambient real `settings.json` has the same effect with no concurrency at
-    /// all. The full suite passes only because ~800 other tests make the
-    /// collision unlikely to be scheduled — it is luck, not isolation, and the
-    /// failure surfaces as a wrong-looking pseudonym rather than as anything
-    /// naming the env var.
-    ///
-    /// Worse, two of the three read settings TWICE at different instants (once
-    /// inside `keep`, once directly), so serialising on the lock alone would
-    /// not be enough if the ambient file were account-scoped. Hence hermetic:
-    /// the file is ours and is known to be account-free.
-    struct MachineScopedSettings {
-        _env: SettingsPathGuard,
-        _lock: std::sync::MutexGuard<'static, ()>,
-        dir: std::path::PathBuf,
-    }
-
-    impl MachineScopedSettings {
-        fn install(tag: &str) -> Self {
-            let lock = SETTINGS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-            let dir = std::env::temp_dir().join(format!(
-                "meridian-redact-{tag}-{}-{:?}",
-                std::process::id(),
-                std::thread::current().id()
-            ));
-            std::fs::create_dir_all(&dir).unwrap();
-            let path = dir.join("settings.json");
-            // No `account_pseudonym` key: the machine-scoped branch.
-            std::fs::write(&path, "{}").unwrap();
-            Self {
-                _env: SettingsPathGuard::set(&path),
-                _lock: lock,
-                dir,
-            }
-        }
-    }
-
-    impl Drop for MachineScopedSettings {
-        fn drop(&mut self) {
-            // Runs before the fields, so the env var still points here — safe,
-            // because the lock (dropped after this) is still held.
-            let _ = std::fs::remove_dir_all(&self.dir);
-        }
-    }
+    use crate::test_env::ScopedSettings;
 
     /// [`support_id_is_account_scoped`] exists so the Settings → Account copy
     /// can never claim something the pseudonym itself isn't doing. Pinned
@@ -1623,22 +1527,15 @@ mod tests {
     /// "true" and breaking the day the alpha window ends.
     #[test]
     fn support_id_is_account_scoped_matches_choose_pseudonym_source() {
-        let _guard = SETTINGS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let dir = std::env::temp_dir().join(format!(
-            "meridian-redact-support-id-scoped-{}-{:?}",
-            std::process::id(),
-            std::thread::current().id()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("settings.json");
-        let _env = SettingsPathGuard::set(&path);
+        // Holds the crate-wide settings lock for the whole loop, so the two
+        // branches can't interleave with another module's env writes. Cleanup
+        // and env restore are the guard's, on an unwinding path too.
+        let settings = ScopedSettings::machine_scoped("support-id-scoped");
 
         for hash in [None, Some("deadbeefcafebabe")] {
             match hash {
-                None => std::fs::write(&path, "{}").unwrap(),
-                Some(h) => {
-                    std::fs::write(&path, format!(r#"{{"account_pseudonym":"{h}"}}"#)).unwrap()
-                }
+                None => settings.rewrite("{}"),
+                Some(h) => settings.rewrite(&format!(r#"{{"account_pseudonym":"{h}"}}"#)),
             }
             let expected = choose_pseudonym_source(now_unix_or_expired(), hash).is_some();
             assert_eq!(
@@ -1647,10 +1544,6 @@ mod tests {
                 "disagreed for account_pseudonym = {hash:?}"
             );
         }
-
-        // `MERIDIAN_SETTINGS_PATH` is restored by `_env`'s Drop, on this path
-        // and on an unwinding one alike.
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Every other free-text case here is Unix-shaped, but Windows installs

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -1,0 +1,160 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Test-only coordination for `MERIDIAN_SETTINGS_PATH`.
+//!
+//! # Why this is crate-level rather than per-module
+//! The variable is PROCESS-global, and `cargo test` runs every test in this
+//! crate inside ONE binary on parallel threads. So the scope that has to agree
+//! on it is the whole crate - but the coordination used to be per-module: both
+//! [`crate::llm::resolver`] and [`crate::telemetry_spool::redact`] declared
+//! their own `ENV_LOCK`, each correctly serialising its own tests and neither
+//! aware of the other.
+//!
+//! Two separate locks over one global is the same as no lock. The failure was
+//! real, deterministic, and reproducible on `pre-main`:
+//!
+//! ```text
+//! cargo test --lib -- telemetry_spool::redact llm::resolver
+//! ---- displayed_pseudonym_matches_shipped ----
+//!   left: "mac_970e5ebf236cb0ce"    <- account-scoped
+//!  right: "mac_9790585e54e6cdf6"    <- machine-scoped
+//! ```
+//!
+//! A resolver test's `remove_var` lands between two settings reads inside one
+//! redact assertion. The var is then UNSET, so the read falls through to the
+//! developer's real `~/.meridian/settings.json` - and on a signed-in machine
+//! that file carries an `account_pseudonym`, flipping the pseudonym to the
+//! account-scoped branch mid-test.
+//!
+//! Note what that means for verification: the collision needs tests from BOTH
+//! modules in the same run, so a filter naming only one (`--lib pseudonym`)
+//! reports green, and so does the full suite, on scheduling luck. Silence here
+//! is not evidence.
+//!
+//! # Who calls this
+//! [`crate::llm::resolver`]'s and [`crate::telemetry_spool::redact`]'s test
+//! modules. Any future test that sets `MERIDIAN_SETTINGS_PATH`, or that calls
+//! anything reading settings (`local_host_pseudonym`, `resolve`), must take
+//! [`SETTINGS_ENV_LOCK`] through one of these guards - not a lock of its own.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+
+/// The single lock arbitrating `MERIDIAN_SETTINGS_PATH` for this whole test
+/// binary. Mirrors `meridian_core::settings`'s own `ENV_LOCK`, which cannot be
+/// reused here because that is a different crate and so a different process
+/// image at test time.
+///
+/// It is in practice the crate's serialisation point for PROCESS-GLOBAL test
+/// state generally, not only the env var. `llm::resolver`'s tests take it to
+/// serialise the global backoff map as well - its predecessor lock was doing
+/// that job silently, and a test excused from the lock on the grounds that it
+/// read no settings started failing about 1 run in 15. If a test mutates
+/// anything process-wide, take this lock even when settings are not involved.
+pub(crate) static SETTINGS_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Acquire [`SETTINGS_ENV_LOCK`], ignoring poisoning.
+///
+/// A panicking test poisons the mutex, and propagating that would turn one real
+/// failure into a cascade of unrelated ones - exactly the burying effect this
+/// module exists to stop.
+pub(crate) fn lock_settings_env() -> MutexGuard<'static, ()> {
+    SETTINGS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// RAII restore for `MERIDIAN_SETTINGS_PATH`.
+///
+/// Restores the PREVIOUS value rather than unconditionally removing, so it
+/// composes if an outer harness sets its own. Restoring on unwind is the point:
+/// a manual `remove_var` at the end of a test is skipped by a failing
+/// assertion, leaving a deleted temp path installed for every test that follows.
+pub(crate) struct SettingsPathGuard(Option<OsString>);
+
+impl SettingsPathGuard {
+    /// Point settings at `path` until this guard drops.
+    ///
+    /// Callers must already hold [`lock_settings_env`] - this type does not
+    /// take the lock itself, because a test typically wants one lock guard
+    /// spanning several path changes (see `resolve_rereads_settings_every_call`,
+    /// which rewrites the file three times inside one critical section).
+    pub(crate) fn set(path: &Path) -> Self {
+        let previous = std::env::var_os("MERIDIAN_SETTINGS_PATH");
+        std::env::set_var("MERIDIAN_SETTINGS_PATH", path);
+        Self(previous)
+    }
+}
+
+impl Drop for SettingsPathGuard {
+    fn drop(&mut self) {
+        match self.0.take() {
+            Some(previous) => std::env::set_var("MERIDIAN_SETTINGS_PATH", previous),
+            None => std::env::remove_var("MERIDIAN_SETTINGS_PATH"),
+        }
+    }
+}
+
+/// A locked, hermetic settings file for the length of a test.
+///
+/// Bundles the lock, the env guard, and a temp directory, so a test gets
+/// isolation by declaring one binding. `contents` is written verbatim, letting
+/// a caller choose the branch under test - `"{}"` for machine-scoped
+/// pseudonyms, an `account_pseudonym` key for account-scoped.
+///
+/// Hermetic rather than merely locked, because holding the lock only excludes
+/// OTHER tests; it does nothing about the developer's real `settings.json`,
+/// which a signed-in machine populates with an `account_pseudonym` and which
+/// would otherwise be what an unset variable resolves to.
+pub(crate) struct ScopedSettings {
+    _env: SettingsPathGuard,
+    _lock: MutexGuard<'static, ()>,
+    dir: PathBuf,
+    path: PathBuf,
+}
+
+impl ScopedSettings {
+    /// Install a settings file containing `contents`, tagged into a unique
+    /// temp dir. Takes the lock; holds it until dropped.
+    pub(crate) fn install(tag: &str, contents: &str) -> Self {
+        let lock = lock_settings_env();
+        let dir = std::env::temp_dir().join(format!(
+            "meridian-test-env-{tag}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp settings dir");
+        let path = dir.join("settings.json");
+        std::fs::write(&path, contents).expect("write temp settings.json");
+        Self {
+            _env: SettingsPathGuard::set(&path),
+            _lock: lock,
+            dir,
+            path,
+        }
+    }
+
+    /// A settings file with no `account_pseudonym`, i.e. the per-MACHINE
+    /// pseudonym branch.
+    pub(crate) fn machine_scoped(tag: &str) -> Self {
+        Self::install(tag, "{}")
+    }
+
+    /// Rewrite the settings file in place, keeping the same lock and path.
+    /// For tests asserting that a value is re-read rather than cached.
+    pub(crate) fn rewrite(&self, contents: &str) {
+        std::fs::write(&self.path, contents).expect("rewrite temp settings.json");
+    }
+
+    /// The settings file's path, for tests that assert on its contents.
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for ScopedSettings {
+    fn drop(&mut self) {
+        // Runs before the fields, so the env var still points at `dir` here -
+        // safe, because `_lock` (dropped after this) is still held, so no other
+        // test can observe the window.
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}

--- a/tray/src-tauri/src/commands/account.rs
+++ b/tray/src-tauri/src/commands/account.rs
@@ -29,7 +29,7 @@
 //!   becomes the event's `distinct_id` directly, never an anonymous id).
 //!
 //! # ALPHA TESTING ONLY — per-user Support ID (expires 2026-08-28)
-//! [`save_account_email`] also derives a salted, one-way hash of the email
+//! [`save_account_email`] also derives a domain-separated, one-way hash of the email
 //! (`meridian::telemetry_spool::redact::pseudonymize_account`) and mirrors
 //! ONLY that hash into `settings.json`'s `account_pseudonym` — never the raw
 //! email, which stays confined to this module's own `account.json`. The
@@ -156,7 +156,7 @@ pub async fn save_account_email(email: String) -> Result<(), String> {
 /// hash, which is all `telemetry_spool::redact::local_host_pseudonym` needs.
 /// Clearing promptly on sign-out matters: a lingering hash would keep
 /// grouping error reports under someone no longer signed in on this machine.
-/// Mirror the account pseudonym (a salted hash, never the raw email) into
+/// Mirror the account pseudonym (a one-way hash, never the raw email) into
 /// `settings.json`, or clear it on sign-out.
 ///
 /// Instrumented because it does real I/O whose failure is otherwise invisible:


### PR DESCRIPTION
**#608 merged with only its first commit.** These two were pushed minutes after that merge, so they were stranded on a merged branch and never reached `pre-main`. Same commits, cherry-picked onto current `pre-main`, re-verified against it (which now also carries #606 and #607).

**#603's CodeQL check is still red without this.**

---

## 1. The critical CodeQL alert (`rust/hard-coded-cryptographic-value`)

**It caught a real defect, and the defect was a single wrong word.**

The rule has two sink mechanisms and only one could have fired here. Modeled sinks come exclusively from `rustcrypto.model.yml`'s `credentials-*` rows; the only crypto calls in `redact.rs` are `Sha256::new`/`update`/`finalize`, modeled as `hasher-input` - a kind this query never reads. That leaves the heuristic, which matches a constant passed to a parameter whose **declared name** is `password`/`iv`/`nonce`/`salt` ([`HardcodedCryptographicValueExtensions.qll`](https://github.com/github/codeql/blob/478878cfb70d100e63386192b12ef4f0e952cf38/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll)):

```ql
f.getParam(argIndex).getPat().(IdentPat).getName().getText() = argName and
( argName = "password" and kind = "password"
  or argName = "iv" and kind = "iv"
  or argName = "nonce" and kind = "nonce"
  or argName = "salt" and kind = "salt"
  // note: matching "key" results in too many false positives
)
```

We had `fn hash_pseudonym(salt: &str, seed: &str)`, and both constants flow into it - which is why **both** `redact.rs:438` and `:445` were flagged, not only the new one.

**This also explains why the alert is new when the bytes are not.** v1.80.0 shipped the identical construction and the identical `…v1:` prefix, but inlined inside `pseudonymize_host` - no parameter named `salt` existed, so the heuristic had nothing to match. Extracting the shared helper in #603 created the sink. The repo's own history is the control experiment.

### Why the name is wrong, not the design

A salt is per-value, unpredictable, and stored beside the digest to defeat precomputation. These are none of those - they are fixed, public domain-separation prefixes keeping the host and account hash spaces disjoint, so a hardware UUID and an email can never collide into one identifier.

They **structurally cannot be secret**: the pseudonym must reproduce byte-identically across every install (that is what groups a machine's rows) and across one tester's Mac and Windows boxes, and it ships inside a binary users hold. Separation, not secrecy; non-reversibility comes from SHA-256 over a high-entropy seed.

So `*_PSEUDONYM_SALT` → `*_PSEUDONYM_DOMAIN`, the parameter `salt` → `domain`, and the same correction to three doc comments elsewhere calling it a "salted hash". **The bytes fed to the hash are untouched.**

### The guard that was missing

Nothing was enforcing that last sentence. Every existing test was *relational* - same input matches, different inputs differ, length 16 - all of which stay green if the digest changes wholesale.

Bad gap for a value whose entire purpose is continuity. v1.80.0 has shipped; rows carrying the current digest exist now. Reorder the two `update` calls, alter a prefix, change the truncation, and every install silently becomes a *new machine* on upgrade - old rows are not re-keyed, nothing fails, and support quietly loses the ability to follow a user across a version boundary.

Added `pseudonym_digests_are_pinned_against_an_independent_oracle`, hand-computed rather than recorded from the implementation:

```
printf '%s' "meridian.host.pseudonym.v1:2D5462F0-45C1-5987-94E9-5CBAD14E4362" | shasum -a 256 | cut -c1-16
printf '%s' "meridian.account.pseudonym.v1:alpha.tester@example.com"          | shasum -a 256 | cut -c1-16
```

A value pasted from whatever the code emitted would pass against a broken implementation. These came from an independent tool, so they assert the construction is `sha256(domain || seed)[..8]` **as documented** - and confirm the rename changed nothing on the wire.

### Verification status - please read

I could **not** verify this against CodeQL empirically: it does not run on PRs targeting `pre-main`, and there is no CodeQL CLI available here. Confidence rests on the quoted predicate plus the v1.80.0 natural experiment.

**#603's check after this merges is the real test.**

---

## 2. One lock for process-global test state

Found while verifying the above, then fixed properly after my first attempt at it proved incomplete.

`MERIDIAN_SETTINGS_PATH` is process-global and the whole crate's tests share one binary, but coordination was per-**module**: `llm::resolver` and `telemetry_spool::redact` each declared their own `ENV_LOCK`. Two locks over one global is the same as none - and crucially, **neither module's own filter can reveal it**:

```
$ cargo test --lib -- telemetry_spool::redact llm::resolver
---- displayed_pseudonym_matches_shipped ----
  left: "mac_970e5ebf236cb0ce"   <- account-scoped
 right: "mac_9790585e54e6cdf6"   <- machine-scoped
```

5 runs, 5 failures against the old code. A resolver test's `remove_var` lands between two settings reads inside one redact assertion; the variable is then **unset**, so the read falls through to the developer's real `~/.meridian/settings.json`, which on a signed-in machine carries an `account_pseudonym`.

A crate-level `test_env` module now owns the single lock, plus `ScopedSettings` bundling lock + env guard + hermetic temp file. Hermetic matters independently: a lock excludes other *tests*, not the ambient `settings.json` an unset variable resolves to.

Chasing it to zero surfaced two more races, both self-inflicted while fixing it:

- That lock was silently doubling as the guard for resolver's process-global **backoff map**. Excusing one test from it ("reads no settings") reintroduced a race at ~1 run in 15.
- Three resolver tests called `clear_backoff()` *before* acquiring the guard, leaving the mutation outside the critical section.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` - **824 lib tests** plus all integration suites green on current `pre-main`. Discriminating filter (the only one that can observe the collision): **15/15 clean** here, 40/40 before the rebase.

I am deliberately **not** citing the full-suite pass as isolation evidence - it was green on the buggy code too, on the scheduling luck this fixes.