### PR TITLE
fix(tray): pause capture when disk space runs low

### DIFF
--- a/src/migrations/076_disk_low_pause_gaps.sql
+++ b/src/migrations/076_disk_low_pause_gaps.sql
@@ -1,0 +1,26 @@
+-- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- Extend the gaps table to accept a 'disk_low_paused' kind, written by the
+-- tray's disk-space guard (poll::check_disk_space) when capture is
+-- auto-paused because free disk space fell below the low-disk threshold.
+-- SQLite does not support ALTER TABLE … MODIFY COLUMN, so we rebuild the
+-- table, same as migration 051.
+
+CREATE TABLE gaps_new (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    started_at  TEXT    NOT NULL,
+    ended_at    TEXT    NOT NULL,
+    duration_s  INTEGER NOT NULL,
+    kind        TEXT    NOT NULL CHECK(kind IN (
+                    'user_idle', 'system_sleep',
+                    'tracking_paused', 'schedule_paused', 'disk_low_paused'
+                )),
+    etl_run_id  INTEGER,
+    FOREIGN KEY (etl_run_id) REFERENCES etl_runs(id)
+);
+
+INSERT INTO gaps_new SELECT id, started_at, ended_at, duration_s, kind, etl_run_id FROM gaps;
+DROP TABLE gaps;
+ALTER TABLE gaps_new RENAME TO gaps;
+
+CREATE INDEX IF NOT EXISTS idx_gaps_started_at ON gaps(started_at);
+CREATE INDEX IF NOT EXISTS idx_gaps_kind       ON gaps(kind);

--- a/tray/src-tauri/src/commands/pause.rs
+++ b/tray/src-tauri/src/commands/pause.rs
@@ -62,6 +62,7 @@ async fn transition_pause(
         let kind = match prev_src {
             PauseSource::Timed | PauseSource::Indefinite => "tracking_paused",
             PauseSource::Schedule => "schedule_paused",
+            PauseSource::DiskLow => "disk_low_paused",
         };
         let duration_s = now.saturating_sub(prev_started) as i64;
         if duration_s > 0 {
@@ -268,12 +269,34 @@ fn secs_to_iso(secs: u64) -> String {
 
 /// Clear the capture pause, write a gap row, and optionally toast the user.
 /// Shared by manual resume (`seconds = 0`) and auto-resume (timer expiry).
+///
+/// Gated on free disk space first: a nearly-full disk is how a real
+/// `meridian.db` got corrupted (SQLite/SQLCipher torn page allocations under
+/// WAL when a write landed with no room left to grow). If disk is still low
+/// at resume time — for any pause reason, including a manual "Resume now"
+/// click — this refuses to restart the capture engine and instead converts
+/// the pause to [`PauseSource::DiskLow`], so it can only clear once
+/// [`poll::check_disk_space`] sees space recover. The existing
+/// `system.disk_low` daemon notice (raised every poll tick) already tells the
+/// user why, so no separate notification is raised here.
 pub(crate) async fn resume_capture(
     state: &Arc<Mutex<AppState>>,
     pool: Option<&SqlitePool>,
     app: &tauri::AppHandle,
     auto: bool,
 ) {
+    if meridian::health::platform::meridian_data_low_gb().is_some() {
+        tracing::warn!("resume_capture: refusing to resume — disk space still low");
+        let now = now_secs();
+        if let Err(e) = transition_pause(state, pool, now, PauseSource::DiskLow, None).await {
+            tracing::warn!(error = %e, "resume_capture: failed to convert pause to disk-low");
+        }
+        if let Ok(s) = state.lock() {
+            let _ = app.emit("status-update", s.to_payload());
+        }
+        return;
+    }
+
     let (started, source) = {
         let mut s = match state.lock() {
             Ok(s) => s,
@@ -294,6 +317,7 @@ pub(crate) async fn resume_capture(
         let kind = match src {
             PauseSource::Timed | PauseSource::Indefinite => "tracking_paused",
             PauseSource::Schedule => "schedule_paused",
+            PauseSource::DiskLow => "disk_low_paused",
         };
         let now = now_secs();
         let duration_s = now.saturating_sub(started_secs) as i64;

--- a/tray/src-tauri/src/poll/mod.rs
+++ b/tray/src-tauri/src/poll/mod.rs
@@ -161,6 +161,15 @@ pub async fn run_poll_loop(app: tauri::AppHandle, state: Arc<Mutex<AppState>>) {
                 permissions::check_permissions(&app, pool).await;
             }
         }
+        // Disk-space guard: auto-pause capture when free disk space on the
+        // meridian.db volume drops below the low-disk threshold, auto-resume
+        // once it recovers. Checked before work-hours so a low-disk pause
+        // always wins the race to claim `pause_source` first; see
+        // check_disk_space's doc comment for why writing into a nearly-full
+        // disk must stop rather than degrade silently.
+        if let Some(pool) = &pool {
+            check_disk_space(&state, pool).await;
+        }
         // Work-hours schedule enforcement: auto-pause capture outside the
         // configured window, auto-resume when entering it. Only fires when the
         // feature is enabled; never overrides a user-initiated timed pause.
@@ -231,6 +240,119 @@ fn update_tray_icon(app: &tauri::AppHandle, state: &Arc<Mutex<AppState>>) {
     if let Some(id) = tray_id {
         if let Some(tray) = app.tray_by_id(&id) {
             let _ = tray.set_tooltip(Some(&tooltip));
+        }
+    }
+}
+
+/// Auto-pause capture when free disk space on the `meridian.db` volume drops
+/// below the low-disk threshold, auto-resume once it recovers. Runs every
+/// poll tick (30 s), before [`check_work_hours`] so a low-disk pause always
+/// wins the race to claim `pause_source` first.
+///
+/// Writing into a nearly-full disk is exactly how a real `meridian.db` got
+/// corrupted in practice: SQLite/SQLCipher torn page allocations under WAL
+/// when a write landed with the disk critically full, scrambling the
+/// page-allocation bookkeeping for `capture_frames`/`capture_ui_events` and
+/// one `app_sessions` row's overflow chain. The daemon already raises a
+/// `system.disk_low` notice every tick once space runs low
+/// (`meridian::health::daemon`) — this only makes the tray *act* on the same
+/// condition instead of writing blind.
+///
+/// The state machine mirrors [`check_work_hours`]:
+///   - Low disk + not disk-paused → start a disk-low pause (unless a Timed or
+///     Indefinite user pause is already active — never override those; a
+///     schedule pause is preempted, since disk safety is the higher-priority
+///     reason once space runs low and check_disk_space runs first each tick).
+///   - Disk recovered + disk-paused → end the pause, write the gap, resume.
+///
+/// Every OTHER resume path (manual "Resume now", a timed pause's own expiry
+/// timer) is separately gated in [`crate::commands::pause::resume_capture`],
+/// so a still-low disk can't be resumed into from any direction — this
+/// function only owns the disk-low pause's own start/end transition.
+async fn check_disk_space(state: &Arc<Mutex<AppState>>, pool: &meridian_core::SqlitePool) {
+    let low = meridian::health::platform::meridian_data_low_gb().is_some();
+
+    let (pause_source, started_at, capture_paused_flag) = {
+        let s = state.lock().unwrap();
+        (
+            s.pause_source.clone(),
+            s.pause_started_at,
+            s.capture_paused.clone(),
+        )
+    };
+
+    match (low, &pause_source) {
+        (true, None) | (true, Some(PauseSource::Schedule)) => {
+            // Disk low, not paused (or only schedule-paused, which this
+            // preempts) → begin a disk-low pause.
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            {
+                let mut s = state.lock().unwrap();
+                drop(s.engine_cancel.take());
+                drop(s.ui_consumer_cancel.take());
+                capture_paused_flag.store(true, Ordering::Relaxed);
+                s.pause_source = Some(PauseSource::DiskLow);
+                s.pause_started_at = Some(now);
+                s.schedule_resume_at = None;
+            }
+            tracing::warn!("disk-space guard: capture paused — free disk space is low");
+        }
+        (false, Some(PauseSource::DiskLow)) => {
+            // Disk recovered → end the pause and write the gap.
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let duration_s = started_at
+                .map(|s| now.saturating_sub(s) as i64)
+                .unwrap_or(0);
+
+            if let Some(started_secs) = started_at {
+                if duration_s > 0 {
+                    use chrono::{DateTime, SecondsFormat, Utc};
+                    let from = DateTime::<Utc>::from_timestamp(started_secs as i64, 0)
+                        .unwrap_or_else(Utc::now)
+                        .to_rfc3339_opts(SecondsFormat::Millis, true);
+                    let to = DateTime::<Utc>::from_timestamp(now as i64, 0)
+                        .unwrap_or_else(Utc::now)
+                        .to_rfc3339_opts(SecondsFormat::Millis, true);
+                    if let Err(e) = meridian_core::insert_pause_gap(
+                        pool,
+                        &from,
+                        &to,
+                        duration_s,
+                        "disk_low_paused",
+                    )
+                    .await
+                    {
+                        tracing::warn!(error = %e, "disk-space guard: failed to write disk_low_paused gap");
+                    }
+                }
+            }
+
+            {
+                let mut s = state.lock().unwrap();
+                capture_paused_flag.store(false, Ordering::Relaxed);
+                s.pause_source = None;
+                s.pause_started_at = None;
+                s.pause_until = None;
+            }
+            // Restart engine so capture resumes. If this happens to also be
+            // outside work hours, check_work_hours (running right after this,
+            // same tick) immediately re-pauses with Schedule — a harmless,
+            // rare blip (engine starts and stops within the same tick,
+            // capturing nothing) rather than a bug worth cross-checking
+            // schedule state here too.
+            #[cfg(feature = "capture")]
+            crate::start_capture(state.clone(), Some(pool.clone()));
+            tracing::info!(duration_s, "disk-space guard: capture resumed");
+        }
+        _ => {
+            // Still low and already disk-paused, still fine and untouched, or
+            // a Timed/Indefinite user pause is active — leave it alone.
         }
     }
 }

--- a/tray/src-tauri/src/state.rs
+++ b/tray/src-tauri/src/state.rs
@@ -25,6 +25,11 @@ pub enum PauseSource {
     /// User paused with no expiry ("Pause indefinitely") — no auto-resume timer;
     /// only a manual "Resume now" clears it. See `commands::pause_indefinitely`.
     Indefinite,
+    /// Auto-paused because free disk space on the `meridian.db` volume fell
+    /// below the low-disk threshold (`meridian::health::platform::meridian_data_low_gb`,
+    /// 2 GB) — writing into a nearly-full disk is how a real `meridian.db` got
+    /// corrupted (torn page allocations under WAL). See `poll::check_disk_space`.
+    DiskLow,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -61,7 +66,7 @@ pub struct StatusPayload {
     /// Unix timestamp (ms) when the current timed pause expires. `None` when
     /// not paused or when paused by a schedule (no fixed end time).
     pub pause_until_ms: Option<u64>,
-    /// `"timed"` | `"schedule"` | `"indefinite"` when capture is actively paused; `None` otherwise.
+    /// `"timed"` | `"schedule"` | `"indefinite"` | `"disk_low"` when capture is actively paused; `None` otherwise.
     pub pause_source: Option<String>,
     /// Display hint for the schedule-paused panel: the work-hours start time
     /// ("09:00"). `None` when not schedule-paused.
@@ -231,6 +236,7 @@ impl AppState {
                 PauseSource::Timed => "timed".to_string(),
                 PauseSource::Schedule => "schedule".to_string(),
                 PauseSource::Indefinite => "indefinite".to_string(),
+                PauseSource::DiskLow => "disk_low".to_string(),
             }),
             schedule_resume_at: self.schedule_resume_at.clone(),
             active_app: active.map(|a| a.app_name.clone()),

--- a/tray/src/app.js
+++ b/tray/src/app.js
@@ -148,7 +148,7 @@ function paintOptionHints() {
 function render(status) {
   const healthy = status.ui_reachable && status.healthy
   const hasActive = !!status.active_app
-  const pauseSource = status.pause_source || null // null | 'timed' | 'schedule' | 'indefinite'
+  const pauseSource = status.pause_source || null // null | 'timed' | 'schedule' | 'indefinite' | 'disk_low'
   const isPaused = !!pauseSource
 
   brandMark.classList.toggle('down', !healthy)
@@ -204,6 +204,11 @@ function render(status) {
     statusTitle.textContent = 'Outside work hours'
     const resumeAt = status.schedule_resume_at || ''
     statusSub.textContent = resumeAt ? `Resumes at ${resumeAt}` : 'Work hours not active'
+    primaryBtn.hidden = true
+  } else if (pauseSource === 'disk_low') {
+    daemonUnhealthy = false
+    statusTitle.textContent = 'Capture paused'
+    statusSub.textContent = 'Disk space is low - free up space to resume'
     primaryBtn.hidden = true
   } else if (hasActive) {
     daemonUnhealthy = false


### PR DESCRIPTION
## Summary

A dev machine's `meridian.db` was found corrupted today: `capture_frames`/`capture_ui_events`'s indexes and one `app_sessions` row's overflow chain had torn page allocations, traced back to writes landing while the disk was at 99% full. Recovery required manual SQLCipher surgery (schema removal + table rebuild). This PR closes the gap that let it happen: the daemon already raises a `system.disk_low` notice every poll tick once free space drops below the existing 2 GB threshold (`meridian::health::platform::meridian_data_low_gb`), but nothing acted on it — capture kept writing into the nearly-full disk regardless.

- Adds `PauseSource::DiskLow`, checked once per tray poll tick (`poll::check_disk_space`, mirrors the existing `check_work_hours` pattern) — auto-pauses capture when disk space is low, auto-resumes once it recovers.
- Every resume path is gated so capture can never restart into a still-low-disk condition: manual "Resume now", a timed pause's own expiry timer, and the disk guard's own resume are all funneled through the same check in `resume_capture`.
- A low-disk pause preempts an active schedule pause (disk safety takes priority) but never overrides a user's explicit Timed/Indefinite pause.
- Migration 076 adds `'disk_low_paused'` to the `gaps.kind` CHECK constraint, matching migration 051's pattern for `tracking_paused`/`schedule_paused`.
- Popover gets a `disk_low` panel: "Capture paused — Disk space is low - free up space to resume".

No new notification is raised — the daemon's existing `system.disk_low` notice already tells the user why.

## Test plan

- [x] `cargo fmt --check` + `cargo clippy -- -D warnings` clean (workspace root + `tray/src-tauri`)
- [x] `cargo test --tests` — 826 passed, 0 failed (workspace root, includes the new migration via `make_meridian_db()`)
- [x] `cargo test` — 183 passed, 0 failed (`tray/src-tauri`)
- [x] Full pre-push hook (fmt/clippy/UI build/UI tests/security audit/cargo test) passed
- [ ] Manual verification on a real low-disk machine (not done — recommend testing by temporarily lowering `DISK_LOW_THRESHOLD_GB` or filling a test volume before shipping)

🤖 Generated with [Claude Code](https://claude.ai/code)