### PR TITLE
fix(tray): stop the daemon before encrypt-in-place so encryption completes on Windows

### DIFF
--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -108,7 +108,12 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
     };
     let marker = home.join(".meridian/backend-version");
     if tokio::fs::read_to_string(&marker).await.ok().as_deref() == Some(bundled_hash.as_str()) {
-        tracing::debug!(hash = %bundled_hash, "backend_install: backend up to date — skipping");
+        tracing::debug!(hash = %bundled_hash, "backend_install: backend up to date — skipping staging");
+        // Staging is current, but the daemon may not be running: the
+        // encrypt-in-place migration stops it earlier this launch (see lib.rs's
+        // setup hook) to unlock meridian.db, and it can also simply crash. Bring
+        // it back so a skipped *staging* never leaves a stopped *daemon*.
+        ensure_daemon_running(&home).await;
         return;
     }
 
@@ -163,6 +168,82 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
         tracing::error!(error = %e, "backend_install: could not write version marker");
     }
     tracing::info!("backend_install: backend installed");
+}
+
+/// Stop the running daemon so the tray's in-place `meridian.db` encryption
+/// migration can rename the file. **Windows-only concern**: a rename of a file
+/// another process holds open fails there with os error 32, which is why
+/// `encrypt_in_place` rolled back every launch while the daemon (autostarted at
+/// login) held the DB open. A no-op on other platforms, where the migration
+/// tolerates the open handle.
+///
+/// Called from the tray's setup hook BEFORE `encrypt_in_place`, and only when a
+/// migration will actually attempt (a key is set and the DB is still plaintext).
+/// The daemon is brought back up afterward by [`ensure_backend_installed`] —
+/// either its normal staging path (on an update) or [`ensure_daemon_running`]
+/// (on the up-to-date path).
+pub(crate) async fn stop_daemon_for_migration() -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        let home = meridian_core::paths::home_dir()
+            .ok_or_else(|| "home directory could not be resolved".to_string())?;
+        let daemon_bin = home.join(".meridian").join("bin").join(DAEMON_FILE);
+        stop_running_daemon_before_stage(&daemon_bin).await
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        Ok(())
+    }
+}
+
+/// Ensure the daemon is running, starting it if it isn't. Called on the
+/// backend-up-to-date path of [`ensure_backend_installed`] (where staging and
+/// [`register_service`] are skipped) so a skipped *staging* never leaves a
+/// *stopped* daemon — in particular after [`stop_daemon_for_migration`] stops it
+/// for the encryption migration, but also if it simply crashed.
+///
+/// **Windows-only work**: prefer the scheduled task, else spawn the binary
+/// directly (the same fallback [`register_service`] uses on policy-locked
+/// machines). On macOS launchd's `KeepAlive` restarts the daemon itself, so this
+/// is a no-op there.
+async fn ensure_daemon_running(home: &Path) {
+    #[cfg(target_os = "windows")]
+    {
+        let daemon_bin = home.join(".meridian").join("bin").join(DAEMON_FILE);
+        if !matching_daemon_pids(&daemon_bin).await.is_empty() {
+            return; // already up — nothing to do
+        }
+        let started_via_task = tokio::process::Command::new("schtasks")
+            .args(["/Run", "/TN", WINDOWS_TASK_NAME])
+            .no_window()
+            .output()
+            .await
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if started_via_task {
+            tracing::info!(
+                task = WINDOWS_TASK_NAME,
+                "backend_install: restarted daemon via scheduled task"
+            );
+            return;
+        }
+        match tokio::process::Command::new(&daemon_bin)
+            .no_window()
+            .spawn()
+        {
+            Ok(_) => {
+                tracing::info!(bin = %daemon_bin.display(), "backend_install: restarted daemon directly")
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, bin = %daemon_bin.display(), "backend_install: could not restart the daemon")
+            }
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        // launchd `KeepAlive` restarts the daemon on its own — nothing to do.
+        let _ = home;
+    }
 }
 
 /// `Meridian.app/Contents/Resources/backend/` when it exists, else `None`.
@@ -953,6 +1034,20 @@ async fn launchctl(args: &[&str]) -> Result<bool, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// On non-Windows, `stop_daemon_for_migration` is an inert no-op that returns
+    /// `Ok` — the encryption migration tolerates an open handle there, so there
+    /// is nothing to stop and the tray's setup hook proceeds straight to
+    /// `encrypt_in_place`. Gated off Windows so the test never kills a real
+    /// daemon; CI runs on macOS, so it executes there.
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn stop_daemon_for_migration_is_a_noop_off_windows() {
+        assert!(
+            stop_daemon_for_migration().await.is_ok(),
+            "off Windows this must be an inert Ok, not attempt to stop anything"
+        );
+    }
 
     /// `migrate_legacy_bundle_env` must: copy the bundle `.env` to the canonical
     /// path when only the bundle exists; **never clobber** an existing canonical

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -274,6 +274,29 @@ pub fn run() {
             // `!cfg!(debug_assertions)` style.
             let db_encryption_intended = db_key_hex.is_some();
 
+            // On Windows the daemon (autostarted at login) holds meridian.db
+            // open, so `encrypt_in_place`'s rename fails with os error 32 and
+            // rolls back every launch — the migration can never complete while
+            // the daemon is up. Stop it first, but ONLY when a migration will
+            // actually attempt (a key was resolved AND the DB is still
+            // plaintext); once encrypted this never runs again, so the stop is a
+            // one-time cost on the migration launch. A no-op on non-Windows,
+            // where rename tolerates an open handle. The daemon is brought back
+            // up by `ensure_backend_installed` later in this same setup hook.
+            if !cfg!(debug_assertions)
+                && db_encryption_intended
+                && meridian_core::db_crypto::is_plaintext_sqlite(std::path::Path::new(&db_path))
+            {
+                if let Err(e) =
+                    tauri::async_runtime::block_on(backend_install::stop_daemon_for_migration())
+                {
+                    tracing::warn!(
+                        error = %e,
+                        "could not stop the daemon before encrypting the database; encryption may not complete this launch"
+                    );
+                }
+            }
+
             let db_key_hex = if !cfg!(debug_assertions) {
                 match &db_key_hex {
                     Some(key) => {
@@ -351,7 +374,7 @@ pub fn run() {
                                     id: "tray.db_encryption_incomplete",
                                     severity: "warning",
                                     title: "Your data isn't encrypted at rest yet.",
-                                    detail: "Meridian couldn't finish encrypting its local database because another Meridian process was holding it open. Your data is safe but stored unencrypted for now - fully quit Meridian and reopen it to let encryption finish.",
+                                    detail: "Meridian couldn't finish encrypting its local database this time. Your data is safe but stored unencrypted for now - Meridian will retry automatically the next time it restarts.",
                                     remedy: None,
                                     event_key: "system.health",
                                     deep_link: Some("/logs"),


### PR DESCRIPTION
## What & why

The encrypt-in-place migration **never completed on Windows**, which is why the "Your data isn't encrypted at rest yet" notice persisted even after #606 shipped in staging.10.

Root cause (diagnosed + hand-remediated on a live staging.10 box): the tray runs `encrypt_in_place` **early at startup**, while the daemon — autostarted at login — still holds `meridian.db` open. On Windows you can't rename a file another process has open, so the migration's rename fails with **os error 32** and rolls back, every launch. #606 fixed the tray releasing its *own* sqlx handle; it did nothing about the concurrently-running **daemon**. And the notice's remedy ("fully quit Meridian and reopen it") is wrong for Windows — that only closes the tray, not the separate daemon.

Ordering constraint that shapes the fix: `encrypt_in_place` **must** stay before the tray opens its own DB pool (else the *tray* would lock the file), so the daemon-stop has to go *before* the migration, not later.

## Changes

1. **Stop the daemon before the migration.** In the tray setup hook, immediately before `encrypt_in_place`, when a migration will actually attempt (`db_encryption_intended && is_plaintext_sqlite(db)`), call new `backend_install::stop_daemon_for_migration()` (reuses the existing `stop_running_daemon_before_stage`). Tightly gated — once the DB is ciphertext this never runs again, so it's a one-time cost on the migration launch. No-op off Windows.

2. **Bring the daemon back afterward.** `ensure_backend_installed`'s backend-up-to-date path previously just `return`ed — so on a non-update launch (staging already installed, encryption still pending — exactly the failing case) the daemon we stopped would stay down. It now calls new `ensure_daemon_running`, which starts the daemon if it isn't up (scheduled task, else direct spawn — the same fallback `register_service` uses). No-op on macOS (launchd `KeepAlive` handles it). Bonus: also revives a daemon that merely crashed.

3. **Fix the notice text** — drop the Windows-wrong "quit and reopen" remedy; state that Meridian retries automatically on the next restart.

## Testing / validation

The daemon stop+start is **Windows-only syscalls**, not exercisable on the macOS CI, so the core is validated on a staging build (the exact live sequence — stop daemon → migrate → restart — was already proven by hand on staging.10: a 2 GB DB encrypted in <2 min, header flipped to ciphertext, daemon reopened it fine). What CI *does* cover: the cross-platform contract (`stop_daemon_for_migration` is an inert `Ok` off Windows) is unit-tested, and the notice-state logic keeps its existing tests. **macOS behavior is unchanged** (macOS already renames open files fine; the new calls are no-ops there).

## Caveats

- The daemon is briefly down during the ~1–2 min migration (one-time, at startup).
- The up-to-date path now runs one `matching_daemon_pids` probe per launch on Windows (off the setup thread) — a small cost that also hardens the daemon lifecycle generally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
