### PR TITLE
ci: use rust-lld on Windows, auto-prune superseded release caches

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,3 +11,19 @@ incremental = false
 # Harmless for non-git sources (crates.io fetches are unaffected).
 [net]
 git-fetch-with-cli = true
+
+# rust-lld (LLD bundled in rustc's own sysroot, not an external LLVM install)
+# for the MSVC linker. Measured real-world speedup for a workspace this size
+# is modest (~5-10% of total build time, not the "2x" headline number some
+# guides quote — that figure is dominated by link time, and most of this
+# workspace's build time is compilation, not linking), but it's free and
+# nothing in this workspace's native deps (vendored OpenSSL, Sentry's
+# minidump handling, Windows resource embedding, windows-rs/WinRT bindings)
+# is known to conflict with it — verified before adding this.
+#
+# IMPORTANT: a target-specific `rustflags` REPLACES the `[build] rustflags`
+# above rather than merging with it, so `-D warnings` is repeated here — an
+# easy silent regression otherwise (Windows would stop treating warnings as
+# errors, exactly the gap the Windows CI job exists to close).
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-D", "warnings", "-C", "linker=rust-lld"]

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -300,3 +300,57 @@ jobs:
             echo "### Cache warm (Windows)"
             echo "Seeded \`windows-release-x86_64-pc-windows-msvc\` under \`refs/heads/main\`."
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Prune superseded release caches ─────────────────────────────────────────
+  #
+  # GitHub Actions caches are IMMUTABLE per key. Swatinem/rust-cache's key
+  # includes a hash component that shifts over time (toolchain/workspace
+  # fingerprinting), so every run that can't reuse an EXACT prior key writes a
+  # brand-new ~1.4GB entry rather than replacing the old one — the old one
+  # just sits there, unreachable by any future restore, until the repo crosses
+  # its 10GB cache cap and GitHub's LRU eviction removes SOMETHING (not
+  # necessarily the stale one). Measured directly: this repo hit 11.3GB/34
+  # caches once already (fixed by hand), then climbed back to 10.49GB/42 after
+  # a single subsequent warm run. Manual cleanup doesn't scale — this job
+  # automates it.
+  #
+  # Runs after BOTH warm jobs (needs + always()) so it sees whatever they just
+  # saved, keeps the newest cache per platform on `refs/heads/main`, deletes
+  # every older one matching the same prefix. Safe by construction: it only
+  # ever touches `macos-release-*`/`windows-release-*` keys on `main` — never
+  # a tag, PR, or `pre-main` cache, and never the newest entry for either
+  # platform (so a tag-triggered release build always has something to
+  # restore).
+  prune-stale-caches:
+    name: Prune superseded release caches
+    needs: [warm-macos, warm-windows]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Deleting a cache entry via the REST API needs actions:write — kept
+      # scoped to just this job, not the whole workflow.
+      actions: write
+    steps:
+      - name: Delete every cache except the newest per platform on refs/heads/main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          for prefix in \
+            "v0-rust-macos-release-aarch64-apple-darwin" \
+            "v0-rust-windows-release-x86_64-pc-windows-msvc"; do
+            echo "=== ${prefix} ==="
+            stale=$(gh api "repos/${{ github.repository }}/actions/caches?per_page=100&ref=refs/heads/main" \
+              --jq --arg p "$prefix" \
+              '[.actions_caches[] | select(.key | startswith($p))] | sort_by(.created_at) | reverse | .[1:] | .[].id')
+            if [ -z "$stale" ]; then
+              echo "nothing to prune"
+              continue
+            fi
+            for id in $stale; do
+              echo "deleting superseded cache $id"
+              gh api -X DELETE "repos/${{ github.repository }}/actions/caches/${id}" \
+                || echo "::warning::failed to delete cache ${id} (non-fatal, next run will retry)"
+            done
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
               - '**/Cargo.toml'
               - '**/Cargo.lock'
               - 'rust-toolchain.toml'
+              - '.cargo/**'
               - 'src/migrations/**'
               - '.github/workflows/ci.yml'
             ui:


### PR DESCRIPTION
## Summary
- **rust-lld for Windows**: `.cargo/config.toml` now sets `-C linker=rust-lld` for `x86_64-pc-windows-msvc` (bundled in rustc's own sysroot, no external LLVM dependency). Verified before adding — no known conflicts with this workspace's native deps (vendored OpenSSL, Sentry's minidump handling, Windows resource embedding, `windows-rs`/WinRT bindings); the Tauri linker issues found in trackers are all tied to cross-compiling Windows from macOS/Linux, not native `windows-latest` builds. Expect ~5-10% off Windows compile time, not the "2x/5x" headline numbers some guides quote — those are link-time-dominated, and most of this workspace's build time is compilation, not linking.
  - `-D warnings` is repeated in the target-specific `rustflags` block — a target-specific `rustflags` **replaces** rather than merges with `[build] rustflags`, so without this Windows would silently stop treating warnings as errors.
- **Auto-prune superseded release caches** (`cache-warm.yml`): GitHub Actions caches are immutable per key, and `Swatinem/rust-cache`'s key shifts over time, so a run that can't reuse an exact prior key writes a brand-new ~1.4GB entry rather than replacing the old one. Measured directly this session: hit 11.3GB/34 caches once (fixed by hand), climbed back to 10.49GB/42 caches after a single subsequent warm run. New `prune-stale-caches` job runs after both warm jobs, keeps only the newest cache per platform on `refs/heads/main`, deletes every older one matching the same prefix — automating what was manual cleanup.

## Test plan
- [ ] CI passes on this PR (the Windows Rust check exercises the new `rust-lld` config for real)
- [ ] After merge, watch the next `cache-warm.yml` run to confirm the prune job runs and only ever deletes stale/superseded entries, never the newest one