### PR TITLE
feat(tray): ship a central-telemetry error when the daemon is offline and can't be restarted

### DIFF
--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -111,8 +111,30 @@ pub(super) async fn refresh_health(
         async {
             let r = crate::commands::daemon_control::restart().await;
             match &r {
-                Err(e) => tracing::warn!(error = %e, "daemon-health auto-restart attempt failed"),
-                Ok(()) => tracing::info!("daemon-health auto-restart attempted"),
+                // ERROR (not WARN) so this line crosses the error-only central
+                // telemetry filter. The went-quiet *notice* is a local DB row
+                // and the watchdog's per-tick retries are WARN, so a
+                // paused/offline daemon the tray also couldn't restart was
+                // previously invisible in central OO — you could see the banner
+                // on the machine but nothing shipped. Edge-triggered
+                // (`attempt_restart` fires once on the 2nd consecutive failure),
+                // so it's one event per down-episode, not per poll. The fields
+                // are what you debug from: `daemon_running` vs `db_ready`
+                // pinpoints which subsystem is down, and `cold_start` (never seen
+                // healthy this run) distinguishes an install/autostart gap from a
+                // crash of a daemon that had been up.
+                Err(e) => tracing::error!(
+                    error = %e,
+                    daemon_running,
+                    db_ready,
+                    cold_start = !notify_down,
+                    "daemon offline and automatic restart failed — the daemon is down with no recovery this episode"
+                ),
+                Ok(()) => tracing::info!(
+                    daemon_running,
+                    db_ready,
+                    "daemon offline — automatic restart attempted"
+                ),
             }
             Some(r)
         }


### PR DESCRIPTION
## What & why

When a machine sits **paused with the daemon down**, central OpenObserve gets **no signal** — so you can't debug it from OO. The tray's went-quiet handling (`poll/refresh.rs`) is deliberately local:

- flips `HealthStatus` → `Unhealthy` (state, not a log),
- raises a **`warning`-severity** in-app notice `tray.daemon_quiet` (the banner),
- logs the failed auto-restart at **`tracing::warn!`**.

The packaged **central path is error-only** (redacted), so every bit of that is filtered out before it ships. You can see the banner on the box, but nothing reaches OO. A daemon that won't start on a fresh machine therefore leaves no central breadcrumb.

## Change

Promote the **once-per-down-episode auto-restart *failure*** from `warn!` to `error!` so it crosses the central filter. It's edge-triggered (`attempt_restart` fires only on the 2nd consecutive failed probe — verified against `decide_health_notice`), so it's **one event per down-episode, not per poll**. The fields make it debuggable from OO alone:

- `daemon_running` vs `db_ready` — which subsystem is actually down;
- `cold_start` (never seen healthy this run) — an **install/autostart gap** vs a **crash** of a daemon that had been up;
- `error` — why the automatic restart failed.

## Deliberately scoped to avoid noise

- Only the **failure** path ships (`error!`); a restart that succeeds stays `info!` (self-healed blip, no need to alarm central).
- The **5-second watchdog** retry loop (`poll/mod.rs`) and the went-quiet **notice** stay `warn!`/`warning` — promoting those would flood OO every tick while down.

Redaction-safe: it uses the same error-only central path the `backend_install` errors already ship through. **Logging-level only — no behavior change.** Validated on both CI Rust jobs (macOS + Windows).

## How you'll use it

Next time a machine is paused with a dead daemon, filter OO by that machine's `host.name` (Support ID) for `service.name = meridian-tray`, severity ERROR — you'll get one line per outage telling you daemon-vs-db, cold-start-vs-crash, and the restart error. From there it's a targeted fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
