### PR TITLE
ci: extend cache pruning to ci.yml's PR-check caches too

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -301,28 +301,32 @@ jobs:
             echo "Seeded \`windows-release-x86_64-pc-windows-msvc\` under \`refs/heads/main\`."
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # ── Prune superseded release caches ─────────────────────────────────────────
+  # ── Prune superseded caches (release AND ci.yml's PR-check caches) ──────────
   #
   # GitHub Actions caches are IMMUTABLE per key. Swatinem/rust-cache's key
   # includes a hash component that shifts over time (toolchain/workspace
   # fingerprinting), so every run that can't reuse an EXACT prior key writes a
-  # brand-new ~1.4GB entry rather than replacing the old one — the old one
-  # just sits there, unreachable by any future restore, until the repo crosses
-  # its 10GB cache cap and GitHub's LRU eviction removes SOMETHING (not
-  # necessarily the stale one). Measured directly: this repo hit 11.3GB/34
-  # caches once already (fixed by hand), then climbed back to 10.49GB/42 after
-  # a single subsequent warm run. Manual cleanup doesn't scale — this job
-  # automates it.
+  # brand-new ~750MB-1.4GB entry rather than replacing the old one — the old
+  # one just sits there, unreachable by any future restore, until the repo
+  # crosses its 10GB cache cap and GitHub's LRU eviction removes SOMETHING
+  # (not necessarily the stale one). Measured directly: this repo hit
+  # 11.3GB/34 caches once (fixed by hand), climbed back to 10.49GB/42 after a
+  # single subsequent warm run — and separately, ci.yml's `ci-macos-silicon`
+  # cache (unrelated to the release caches below, a debug/test profile build
+  # on `pre-main`) was found sitting at FOUR duplicate copies of itself before
+  # this job covered it too. Manual cleanup doesn't scale — this job
+  # automates all of it.
   #
-  # Runs after BOTH warm jobs (needs + always()) so it sees whatever they just
-  # saved, keeps the newest cache per platform on `refs/heads/main`, deletes
-  # every older one matching the same prefix. Safe by construction: it only
-  # ever touches `macos-release-*`/`windows-release-*` keys on `main` — never
-  # a tag, PR, or `pre-main` cache, and never the newest entry for either
-  # platform (so a tag-triggered release build always has something to
-  # restore).
+  # Runs after both warm jobs (needs + always()) so it sees whatever they just
+  # saved, keeps the newest cache per prefix on its OWN ref, deletes every
+  # older one matching that prefix. Safe by construction: each prefix is
+  # paired with the one ref it's ever scoped to (release caches only ever
+  # live on `main`; ci.yml's caches only ever save on `pre-main` — see each
+  # job's own `save-if`), so this never touches a tag or PR cache, and never
+  # deletes the newest entry for any prefix (so a future build always has
+  # something to restore).
   prune-stale-caches:
-    name: Prune superseded release caches
+    name: Prune superseded caches
     needs: [warm-macos, warm-windows]
     if: always()
     runs-on: ubuntu-latest
@@ -332,16 +336,26 @@ jobs:
       # scoped to just this job, not the whole workflow.
       actions: write
     steps:
-      - name: Delete every cache except the newest per platform on refs/heads/main
+      - name: Delete every cache except the newest per prefix on its own ref
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          for prefix in \
-            "v0-rust-macos-release-aarch64-apple-darwin" \
-            "v0-rust-windows-release-x86_64-pc-windows-msvc"; do
-            echo "=== ${prefix} ==="
-            stale=$(gh api "repos/${{ github.repository }}/actions/caches?per_page=100&ref=refs/heads/main" \
+          # prefix|ref pairs. Release caches live on main (this workflow's own
+          # target); ci.yml's caches save on pre-main (see ci.yml's rust/
+          # rust-windows jobs' save-if) — a different ref, so each pair is
+          # queried separately rather than assuming one ref for everything.
+          pairs=(
+            "v0-rust-macos-release-aarch64-apple-darwin|refs/heads/main"
+            "v0-rust-windows-release-x86_64-pc-windows-msvc|refs/heads/main"
+            "v0-rust-ci-macos-silicon|refs/heads/pre-main"
+            "v0-rust-ci-windows|refs/heads/pre-main"
+          )
+          for pair in "${pairs[@]}"; do
+            prefix="${pair%%|*}"
+            ref="${pair##*|}"
+            echo "=== ${prefix} (${ref}) ==="
+            stale=$(gh api "repos/${{ github.repository }}/actions/caches?per_page=100&ref=${ref}" \
               --jq --arg p "$prefix" \
               '[.actions_caches[] | select(.key | startswith($p))] | sort_by(.created_at) | reverse | .[1:] | .[].id')
             if [ -z "$stale" ]; then


### PR DESCRIPTION
## Summary
- The release-cache prune job (added in #622) only covered `macos-release-*`/`windows-release-*` on `main`. Found the identical duplication problem already present in `ci.yml`'s own caches: `ci-macos-silicon` had accumulated **4 copies of itself** on `pre-main` — same root cause, `Swatinem/rust-cache`'s key shifts over time and GitHub caches are immutable per key, so old entries just sit there until the 10GB cap forces an eviction.
- Generalized the prune step to `prefix|ref` pairs instead of assuming everything lives on `main` — release caches stay pruned on `main`, `ci.yml`'s `ci-macos-silicon`/`ci-windows` caches are now pruned on `pre-main` instead, matching each job's actual `save-if` ref.
- Manually deleted the 3 existing stale `ci-macos-silicon` copies as a one-time cleanup — repo was at 42 caches/7.78GB before this, down to 39 now.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, watch the next `cache-warm.yml` run to confirm the prune job correctly sweeps both the release caches (on `main`) and the CI caches (on `pre-main`)