### PR TITLE
fix(llm): fix the env node shebang lookup in sign-in flows too

### DIFF
--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -562,6 +562,31 @@ async fn resolve_installer_binary(cmd: &str) -> String {
     }
 }
 
+/// Build a `Command` for `path`, a CLI already located via [`resolve_cli`], with `path`'s own
+/// directory prepended onto the child's `PATH` — same fix as [`resolve_installer_binary`],
+/// applied to the sign-in flows ([`cursor_sign_in`]/[`codex_sign_in`]/[`claude_sign_in`]),
+/// which spawn the resolved binary directly rather than through a shell.
+///
+/// Those CLIs are still spawned by ABSOLUTE PATH, so the OS doesn't need `PATH` to find `path`
+/// itself — but `codex`/`claude` (unlike `cursor-agent`, a native binary) are `#!/usr/bin/env
+/// node` scripts, and `env` does its own independent `PATH` search for `node` at exec time,
+/// using whatever environment the child inherits. `Command::new` inherits the CURRENT
+/// process's `PATH` by default — the tray's own stripped launchd one on macOS, with no
+/// `/opt/homebrew/bin` — so that inner lookup fails with "env: node: No such file or
+/// directory" exactly like [`resolve_installer_binary`]'s install-time case, even though the
+/// CLI itself was already found and resolved correctly.
+fn command_for_resolved_cli(path: &std::path::Path) -> Command {
+    let mut cmd = Command::new(path);
+    if let Some(dir) = path.parent() {
+        let existing = std::env::var_os("PATH").unwrap_or_default();
+        let mut new_path = std::ffi::OsString::from(dir);
+        new_path.push(":");
+        new_path.push(existing);
+        cmd.env("PATH", new_path);
+    }
+    cmd
+}
+
 #[tracing::instrument(
     skip_all,
     fields(
@@ -790,7 +815,7 @@ pub async fn cursor_sign_in() -> InstallOutcome {
     };
 
     tracing::info!("llm: launching interactive cursor-agent login");
-    let mut cmd = Command::new(&path);
+    let mut cmd = command_for_resolved_cli(&path);
     cmd.arg("login")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -899,7 +924,7 @@ pub async fn codex_sign_in() -> InstallOutcome {
     };
 
     tracing::info!("llm: launching interactive codex login");
-    let mut cmd = Command::new(&path);
+    let mut cmd = command_for_resolved_cli(&path);
     cmd.arg("login")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -1006,7 +1031,7 @@ pub async fn claude_sign_in() -> InstallOutcome {
     };
 
     tracing::info!("llm: launching interactive claude auth login");
-    let mut cmd = Command::new(&path);
+    let mut cmd = command_for_resolved_cli(&path);
     cmd.arg("auth")
         .arg("login")
         .arg("--claudeai")
@@ -1921,6 +1946,51 @@ mod tests {
         let cmd = "meridian-definitely-not-a-real-binary --flag value";
         let resolved = resolve_installer_binary(cmd).await;
         assert_eq!(resolved, cmd);
+    }
+
+    /// The sign-in-flow counterpart to `resolve_installer_binary_fixes_the_env_node_shebang_lookup`:
+    /// `cursor_sign_in`/`codex_sign_in`/`claude_sign_in` spawn the resolved CLI directly
+    /// (`Command::new(&path)`, no shell), so `resolve_installer_binary`'s PATH-prepending fix
+    /// never applied to them — `codex`/`claude` are still `#!/usr/bin/env node` scripts, and a
+    /// directly-spawned child inherits the CURRENT process's `PATH` (the tray's own stripped
+    /// one), not any shell-derived one. Fakes a `#!/usr/bin/env node` CLI with a fake `node`
+    /// alongside it; only passes if `command_for_resolved_cli` actually set `PATH` on the child.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn command_for_resolved_cli_fixes_the_env_node_shebang_lookup() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = std::env::temp_dir().join(format!(
+            "meridian-detect-cmd-resolved-test-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let fake_node = temp_dir.join("node");
+        std::fs::write(&fake_node, "#!/bin/sh\necho FAKE_NODE_RAN\n").unwrap();
+        let fake_cli = temp_dir.join("meridian-fake-cli");
+        std::fs::write(&fake_cli, "#!/usr/bin/env node\n").unwrap();
+        for f in [&fake_node, &fake_cli] {
+            let mut perms = std::fs::metadata(f).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(f, perms).unwrap();
+        }
+
+        let mut cmd = command_for_resolved_cli(&fake_cli);
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let output = cmd
+            .output()
+            .await
+            .expect("command_for_resolved_cli must spawn");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+
+        assert!(output.status.success(), "{output:?}");
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "FAKE_NODE_RAN",
+            "{output:?}"
+        );
     }
 
     /// cursor-agent does not install via npm on Windows (see


### PR DESCRIPTION
## Summary
Reported on real hardware: after #623 fixed the npm install itself, "Codex is installed but not signed in yet" → clicking "Sign in to Codex" failed with the exact same **"env: node: No such file or directory"**.

`cursor_sign_in`/`codex_sign_in`/`claude_sign_in` all resolve the CLI's absolute path via `resolve_cli` (fine), but then spawn it directly with `Command::new(&path)` — no shell at all. That inherits the CURRENT process's `PATH` (the tray's own stripped launchd one, no `/opt/homebrew/bin`), not any shell-derived one. `codex`/`claude` (unlike `cursor-agent`, a native binary) are still `#!/usr/bin/env node` scripts, so `env`'s independent PATH search for `node` fails there too — the exact same root cause as #623, just a second call site that was never routed through the fix (`resolve_installer_binary` only applies to the *install* command, spawned through a shell).

`command_for_resolved_cli()` prepends the resolved binary's own directory onto the child's `PATH` before spawning, and all three sign-in flows now use it instead of a bare `Command::new(&path)`.

## Test plan
- [x] `command_for_resolved_cli_fixes_the_env_node_shebang_lookup` — fakes a `#!/usr/bin/env node` CLI with a fake `node` alongside it, spawned directly (not through a shell); only passes if `PATH` was actually set on the child
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo test` (full suite) both pass
- [x] pre-push hook (fmt + clippy + cargo test + UI build/tests + security audit) passed