### PR TITLE
feat(daemon): report a startup DB-open failure to central telemetry before exiting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -992,7 +992,28 @@ async fn main() -> Result<()> {
     //     an agent CLI) is degraded; ordering it after a preflight that could
     //     block once left machines running a daemon that never created its own
     //     database.
-    let meridian = setup_db(&initial_cfg.meridian_db_uri()).await?;
+    let meridian = match setup_db(&initial_cfg.meridian_db_uri()).await {
+        Ok(pool) => pool,
+        Err(e) => {
+            // The daemon cannot run without its database, and a bare `?` here
+            // would unwind to `main`'s stderr Debug print — invisible to central
+            // OO, because this path dies *before* the telemetry shipper (7f
+            // below) ever starts, so nothing ever drains the spool. Report it
+            // through `tracing` and then flush + one-shot ship (mirroring the
+            // shutdown path at the end of `main`) so a daemon that can't open its
+            // DB — a wrong/absent encryption key, a file another process holds
+            // locked, corruption — is finally diagnosable in central telemetry
+            // instead of crash-looping silently. `shutdown` consumes the guard,
+            // but we exit immediately after, so the success path still owns it.
+            tracing::error!(
+                error = %e,
+                "daemon startup: failed to open the database — the daemon cannot start (wrong/absent encryption key, a locked file, or corruption)"
+            );
+            obs_guard.shutdown().await;
+            meridian::telemetry_spool::shipper::drain_once().await;
+            std::process::exit(1);
+        }
+    };
 
     // 4c. Capture-layer (L1) preflight: surface degraded in-process capture
     //     (revoked Screen Recording / Accessibility permission, the tray not


### PR DESCRIPTION
## What & why

Closes the crash-loop blind spot from the **daemon's own side**, complementing the tray-side offline error in #625.

The daemon's startup opened its DB with a bare:
```rust
let meridian = setup_db(&initial_cfg.meridian_db_uri()).await?;   // src/main.rs
```
So when it **can't open the database** — a wrong/absent SQLCipher key, a file another process holds locked, corruption — the error unwinds to `main() -> Result<()>` and is printed to **stderr only**. It never goes through `tracing`, *and* this path dies **before the telemetry shipper (step 7f) ever starts**, so nothing drains the spool. Net: a daemon crash-looping on DB-open leaves **zero central signal** — the exact case where the tray's auto-restart can report "success" (the spawn worked) while the daemon dies a moment later, so #625's tray-side error wouldn't fire either.

## Change

On that failure the daemon now:
1. emits a structured `tracing::error!` (redaction-safe: the DB error, not paths/PII),
2. `obs_guard.shutdown().await` — flushes the OTel exporters into the spool,
3. `shipper::drain_once().await` — one-shot ships it centrally,

…**mirroring the shutdown path at the end of `main`** (which already does exactly `shutdown()` then `drain_once()`), then `exit(1)`. `shutdown` consumes the guard, but we exit immediately after, so the normal success path still owns it.

## Scope

- **Logging / exit-path only** — no behavior change to a daemon that starts normally.
- The `observability::init` failure just above stays a bare `?` on purpose: it can't self-report (no subscriber exists yet).
- Not unit-tested (it's a `process::exit` path); validated by compile + clippy on both CI Rust jobs. The delivery mechanism (`shutdown` → `drain_once`) is the same one the shutdown path already uses in production.

## Result

Together with #625, a machine that's **paused with a dead daemon** now emits a central-OO error from **both** sides:
- `service.name = meridian-tray` → the tray couldn't restart it (daemon-vs-db, cold-start-vs-crash, restart error),
- `service.name = meridian-rust` → the daemon itself couldn't open the DB (the actual DB error).

Filter OO by the machine's Support ID (`host.name`) and you have the full picture to root-cause and ship a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
