### PR TITLE
Pre main

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,3 +11,19 @@ incremental = false
 # Harmless for non-git sources (crates.io fetches are unaffected).
 [net]
 git-fetch-with-cli = true
+
+# rust-lld (LLD bundled in rustc's own sysroot, not an external LLVM install)
+# for the MSVC linker. Measured real-world speedup for a workspace this size
+# is modest (~5-10% of total build time, not the "2x" headline number some
+# guides quote — that figure is dominated by link time, and most of this
+# workspace's build time is compilation, not linking), but it's free and
+# nothing in this workspace's native deps (vendored OpenSSL, Sentry's
+# minidump handling, Windows resource embedding, windows-rs/WinRT bindings)
+# is known to conflict with it — verified before adding this.
+#
+# IMPORTANT: a target-specific `rustflags` REPLACES the `[build] rustflags`
+# above rather than merging with it, so `-D warnings` is repeated here — an
+# easy silent regression otherwise (Windows would stop treating warnings as
+# errors, exactly the gap the Windows CI job exists to close).
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-D", "warnings", "-C", "linker=rust-lld"]

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -300,3 +300,57 @@ jobs:
             echo "### Cache warm (Windows)"
             echo "Seeded \`windows-release-x86_64-pc-windows-msvc\` under \`refs/heads/main\`."
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Prune superseded release caches ─────────────────────────────────────────
+  #
+  # GitHub Actions caches are IMMUTABLE per key. Swatinem/rust-cache's key
+  # includes a hash component that shifts over time (toolchain/workspace
+  # fingerprinting), so every run that can't reuse an EXACT prior key writes a
+  # brand-new ~1.4GB entry rather than replacing the old one — the old one
+  # just sits there, unreachable by any future restore, until the repo crosses
+  # its 10GB cache cap and GitHub's LRU eviction removes SOMETHING (not
+  # necessarily the stale one). Measured directly: this repo hit 11.3GB/34
+  # caches once already (fixed by hand), then climbed back to 10.49GB/42 after
+  # a single subsequent warm run. Manual cleanup doesn't scale — this job
+  # automates it.
+  #
+  # Runs after BOTH warm jobs (needs + always()) so it sees whatever they just
+  # saved, keeps the newest cache per platform on `refs/heads/main`, deletes
+  # every older one matching the same prefix. Safe by construction: it only
+  # ever touches `macos-release-*`/`windows-release-*` keys on `main` — never
+  # a tag, PR, or `pre-main` cache, and never the newest entry for either
+  # platform (so a tag-triggered release build always has something to
+  # restore).
+  prune-stale-caches:
+    name: Prune superseded release caches
+    needs: [warm-macos, warm-windows]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Deleting a cache entry via the REST API needs actions:write — kept
+      # scoped to just this job, not the whole workflow.
+      actions: write
+    steps:
+      - name: Delete every cache except the newest per platform on refs/heads/main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          for prefix in \
+            "v0-rust-macos-release-aarch64-apple-darwin" \
+            "v0-rust-windows-release-x86_64-pc-windows-msvc"; do
+            echo "=== ${prefix} ==="
+            stale=$(gh api "repos/${{ github.repository }}/actions/caches?per_page=100&ref=refs/heads/main" \
+              --jq --arg p "$prefix" \
+              '[.actions_caches[] | select(.key | startswith($p))] | sort_by(.created_at) | reverse | .[1:] | .[].id')
+            if [ -z "$stale" ]; then
+              echo "nothing to prune"
+              continue
+            fi
+            for id in $stale; do
+              echo "deleting superseded cache $id"
+              gh api -X DELETE "repos/${{ github.repository }}/actions/caches/${id}" \
+                || echo "::warning::failed to delete cache ${id} (non-fatal, next run will retry)"
+            done
+          done

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -375,9 +375,20 @@ jobs:
             prefix="${pair%%|*}"
             ref="${pair##*|}"
             echo "=== ${prefix} (${ref}) ==="
-            stale=$(gh api "repos/${{ github.repository }}/actions/caches?per_page=100&ref=${ref}" \
+            # --paginate: without it, per_page=100 silently caps this pair at
+            # its first 100 caches with no follow-up page — this repo already
+            # climbed to 42 caches after a single warm run, so a busy prefix
+            # exceeding 100 would hide older stale entries from pruning
+            # entirely, the exact unbounded-growth failure this job exists to
+            # close. `|| true` on the listing itself: a transient gh api
+            # failure (rate limit, etc.) on one pair must not abort the whole
+            # script under set -euo pipefail — skip just this pair and let
+            # the next scheduled run retry it, same tolerance the delete call
+            # below already has.
+            stale=$(gh api --paginate "repos/${{ github.repository }}/actions/caches?per_page=100&ref=${ref}" \
               --jq --arg p "$prefix" \
-              '[.actions_caches[] | select(.key | startswith($p))] | sort_by(.created_at) | reverse | .[1:] | .[].id')
+              '[.actions_caches[] | select(.key | startswith($p))] | sort_by(.created_at) | reverse | .[1:] | .[].id') \
+              || { echo "::warning::failed to list caches for ${prefix} (${ref}), skipping this pair"; continue; }
             if [ -z "$stale" ]; then
               echo "nothing to prune"
               continue

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -83,12 +83,21 @@ env:
   CARGO_INCREMENTAL: "0"
   CARGO_NET_RETRY: "3"
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  # sccache — see release-build.yml's "Set up sccache" step comment for the
+  # full reasoning. Must match release-build.yml's compile jobs for the cache
+  # this workflow warms to actually help them (same principle as the
+  # shared-key comments below).
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   warm-macos:
     name: Warm the aarch64 release cache
     runs-on: macos-26
     timeout-minutes: 60
+    permissions:
+      contents: read
+      actions: write # sccache's GHA cache backend needs this to SAVE entries
     steps:
       - uses: actions/checkout@v4
         with:
@@ -107,6 +116,10 @@ jobs:
         with:
           toolchain: "1.93.1"
           targets: aarch64-apple-darwin
+
+      # See release-build.yml's "Set up sccache" step for the full reasoning.
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -187,6 +200,9 @@ jobs:
     name: Warm the Windows x86_64 release cache
     runs-on: windows-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
+      actions: write # sccache's GHA cache backend needs this to SAVE entries
     defaults:
       run:
         # Same reasoning as release-build.yml's Windows job: every step here
@@ -227,6 +243,10 @@ jobs:
           toolchain: "1.93.1"
           # No explicit target: windows-latest's host triple
           # (x86_64-pc-windows-msvc) is exactly what we ship.
+
+      # See release-build.yml's "Set up sccache" step for the full reasoning.
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -301,28 +301,32 @@ jobs:
             echo "Seeded \`windows-release-x86_64-pc-windows-msvc\` under \`refs/heads/main\`."
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # ── Prune superseded release caches ─────────────────────────────────────────
+  # ── Prune superseded caches (release AND ci.yml's PR-check caches) ──────────
   #
   # GitHub Actions caches are IMMUTABLE per key. Swatinem/rust-cache's key
   # includes a hash component that shifts over time (toolchain/workspace
   # fingerprinting), so every run that can't reuse an EXACT prior key writes a
-  # brand-new ~1.4GB entry rather than replacing the old one — the old one
-  # just sits there, unreachable by any future restore, until the repo crosses
-  # its 10GB cache cap and GitHub's LRU eviction removes SOMETHING (not
-  # necessarily the stale one). Measured directly: this repo hit 11.3GB/34
-  # caches once already (fixed by hand), then climbed back to 10.49GB/42 after
-  # a single subsequent warm run. Manual cleanup doesn't scale — this job
-  # automates it.
+  # brand-new ~750MB-1.4GB entry rather than replacing the old one — the old
+  # one just sits there, unreachable by any future restore, until the repo
+  # crosses its 10GB cache cap and GitHub's LRU eviction removes SOMETHING
+  # (not necessarily the stale one). Measured directly: this repo hit
+  # 11.3GB/34 caches once (fixed by hand), climbed back to 10.49GB/42 after a
+  # single subsequent warm run — and separately, ci.yml's `ci-macos-silicon`
+  # cache (unrelated to the release caches below, a debug/test profile build
+  # on `pre-main`) was found sitting at FOUR duplicate copies of itself before
+  # this job covered it too. Manual cleanup doesn't scale — this job
+  # automates all of it.
   #
-  # Runs after BOTH warm jobs (needs + always()) so it sees whatever they just
-  # saved, keeps the newest cache per platform on `refs/heads/main`, deletes
-  # every older one matching the same prefix. Safe by construction: it only
-  # ever touches `macos-release-*`/`windows-release-*` keys on `main` — never
-  # a tag, PR, or `pre-main` cache, and never the newest entry for either
-  # platform (so a tag-triggered release build always has something to
-  # restore).
+  # Runs after both warm jobs (needs + always()) so it sees whatever they just
+  # saved, keeps the newest cache per prefix on its OWN ref, deletes every
+  # older one matching that prefix. Safe by construction: each prefix is
+  # paired with the one ref it's ever scoped to (release caches only ever
+  # live on `main`; ci.yml's caches only ever save on `pre-main` — see each
+  # job's own `save-if`), so this never touches a tag or PR cache, and never
+  # deletes the newest entry for any prefix (so a future build always has
+  # something to restore).
   prune-stale-caches:
-    name: Prune superseded release caches
+    name: Prune superseded caches
     needs: [warm-macos, warm-windows]
     if: always()
     runs-on: ubuntu-latest
@@ -332,16 +336,26 @@ jobs:
       # scoped to just this job, not the whole workflow.
       actions: write
     steps:
-      - name: Delete every cache except the newest per platform on refs/heads/main
+      - name: Delete every cache except the newest per prefix on its own ref
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          for prefix in \
-            "v0-rust-macos-release-aarch64-apple-darwin" \
-            "v0-rust-windows-release-x86_64-pc-windows-msvc"; do
-            echo "=== ${prefix} ==="
-            stale=$(gh api "repos/${{ github.repository }}/actions/caches?per_page=100&ref=refs/heads/main" \
+          # prefix|ref pairs. Release caches live on main (this workflow's own
+          # target); ci.yml's caches save on pre-main (see ci.yml's rust/
+          # rust-windows jobs' save-if) — a different ref, so each pair is
+          # queried separately rather than assuming one ref for everything.
+          pairs=(
+            "v0-rust-macos-release-aarch64-apple-darwin|refs/heads/main"
+            "v0-rust-windows-release-x86_64-pc-windows-msvc|refs/heads/main"
+            "v0-rust-ci-macos-silicon|refs/heads/pre-main"
+            "v0-rust-ci-windows|refs/heads/pre-main"
+          )
+          for pair in "${pairs[@]}"; do
+            prefix="${pair%%|*}"
+            ref="${pair##*|}"
+            echo "=== ${prefix} (${ref}) ==="
+            stale=$(gh api "repos/${{ github.repository }}/actions/caches?per_page=100&ref=${ref}" \
               --jq --arg p "$prefix" \
               '[.actions_caches[] | select(.key | startswith($p))] | sort_by(.created_at) | reverse | .[1:] | .[].id')
             if [ -z "$stale" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
               - '**/Cargo.toml'
               - '**/Cargo.lock'
               - 'rust-toolchain.toml'
+              - '.cargo/**'
               - 'src/migrations/**'
               - '.github/workflows/ci.yml'
             ui:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -15,12 +15,14 @@ name: Release (build & publish)
 #
 #     v1.75.0            -> stable   (browser-downloaded DMG; notarized;
 #                                     served from `releases/latest`)
-#     v1.72.0-staging.6  -> staging  (updater-only; NOT notarized;
-#                                     served from `updater-staging`)
+#     v1.72.0-staging.6  -> staging  (notarized too — a directly-downloaded
+#                                     staging DMG is quarantined exactly like
+#                                     a stable one, so it needs a ticket just
+#                                     the same; served from `updater-staging`)
 #
-# The two differ in exactly three places, all keyed off `prepare`'s `channel`
-# output: the staging tauri config, whether APPLE_API_* is passed (notarization),
-# and the DMG-notarize step. Everything else — compile, signing, packaging,
+# Both channels are now notarized identically — the one remaining difference
+# keyed off `prepare`'s `channel` output is the staging tauri config (updater
+# endpoint etc). Everything else — compile, signing, notarizing, packaging,
 # verification, publishing — is one shared path.
 #
 # ── SHAPE ────────────────────────────────────────────────────────────────────
@@ -535,50 +537,29 @@ jobs:
         # notarize call at all (tauri-apps/tauri#7533, open since 2023) — hence
         # the separate step below.
         #
-        # ── WHY STAGING UNSETS THE NOTARIZATION CREDENTIALS HERE ──────────────
-        #
-        # Tauri decides to notarize by LOOKING FOR the credentials, and it treats
-        # a defined-but-empty variable as present. So the skip cannot be done by
-        # gating the `env:` block with `cond && secret || ''` — that still defines
-        # the variables, and notarytool then runs with `--issuer ''` and kills the
-        # whole bundle:
-        #
-        #     The value '' is invalid for '--issuer <issuer>': must be a valid UUID
-        #
-        # (v1.72.0-staging.7 died exactly there.) APPLE_API_KEY_PATH makes it
-        # worse: .github/actions/import-apple-cert writes the .p8 and exports the
-        # path UNCONDITIONALLY via GITHUB_ENV, so it is present no matter what the
-        # job env says. `unset` in this shell is therefore the only reliable gate —
-        # it removes them from the environment tauri actually inherits.
-        #
-        # Why skipping is safe on staging and NOT on stable: Gatekeeper enforces
-        # notarization only on a QUARANTINED app, and the quarantine flag is set by
-        # whatever downloaded it — a browser. Staging is delivered exclusively by
-        # tauri-plugin-updater, which unpacks the tarball itself and sets no flag,
-        # so the relaunched app is verified on its Developer ID signature (still
-        # applied below) plus the updater's minisign key, and never consults a
-        # notarization ticket. Stable ships a DMG new users download in a browser —
-        # dropping notarization there would greet every new user with "Apple cannot
-        # check it for malicious software".
-        #
-        # SIGNING is unaffected: APPLE_SIGNING_IDENTITY and the keychain stay in
-        # place, so the .app is still Developer ID signed on every channel.
+        # Notarization now runs on EVERY channel, staging included. It used to be
+        # skipped on staging on the theory that tauri-plugin-updater never sets
+        # the quarantine flag Gatekeeper keys off — true for an in-place update,
+        # but false the moment someone downloads a staging DMG directly (browser,
+        # `gh release download`, Slack link, …), which quarantines it exactly like
+        # a stable DMG and trips "Apple could not verify this app is free of
+        # malware" with no ticket to fall back on. APPLE_API_* are already defined
+        # unconditionally in this job's `env:` (see the note there on why an
+        # Actions `cond && secret || ''` expression is NOT a safe way to gate
+        # them), so nothing needs to change to turn notarization on here — the
+        # credentials were always present, only the staging branch below used to
+        # `unset` them.
         run: |
           set -euo pipefail
-          if [ "${CHANNEL}" != "stable" ]; then
-            unset APPLE_API_KEY APPLE_API_ISSUER APPLE_API_KEY_PATH
-            echo "→ ${CHANNEL}: signing without notarization (updater-only delivery)"
-          else
-            echo "→ stable: signing AND notarizing"
-          fi
+          echo "→ ${CHANNEL}: signing AND notarizing"
           npx tauri bundle --target ${{ matrix.target }} --bundles app,dmg \
             ${{ needs.prepare.outputs.channel == 'staging' && '--config src-tauri/tauri.staging.conf.json' || '' }}
 
       - name: Notarize and staple the DMG
-        # STABLE ONLY — staging is delivered by the updater, which never sets the
-        # quarantine flag, so no notarization ticket is ever consulted. See the
-        # APPLE_API_* note in this job's `env:` for the full reasoning.
-        if: ${{ !inputs.cache_warm_only && needs.prepare.outputs.channel == 'stable' }}
+        # Runs on every channel now — see the note on the bundle step above for
+        # why staging needs this too (a directly-downloaded staging DMG is
+        # quarantined exactly like a stable one).
+        if: ${{ !inputs.cache_warm_only }}
         # A notarization ticket is keyed to the cdhash of what was submitted, so
         # the stapled .app inside does not cover the container. Without this the
         # DMG a user downloads trips "can't check it for malicious software".
@@ -600,11 +581,9 @@ jobs:
         # presence of the updater artifacts. A non-zero exit aborts while the
         # release is still a draft and nothing is publicly reachable.
         #
-        # MERIDIAN_CHANNEL tells the script which assertions apply: on staging
-        # the notarized/stapled checks are skipped (nothing was notarized, by
-        # design) while every SIGNING check still runs — a staging build with a
-        # broken signature must still fail loudly, because the updater's
-        # relaunch depends on it.
+        # Notarized/stapled checks now run on every channel — see
+        # verify-release-bundle.sh's note on why staging needs the same
+        # Gatekeeper guarantees a directly-downloaded DMG would otherwise miss.
         if: ${{ !inputs.cache_warm_only }}
         env:
           VERSION: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -578,8 +578,15 @@ jobs:
         run: |
           set -euo pipefail
           echo "→ ${CHANNEL}: signing AND notarizing"
-          npx tauri bundle --target ${{ matrix.target }} --bundles app,dmg \
-            ${{ needs.prepare.outputs.channel == 'staging' && '--config src-tauri/tauri.staging.conf.json' || '' }}
+          # Uses the already-bound $CHANNEL rather than re-interpolating
+          # ${{ }} into this script a second time — the exact
+          # template-injection shape this file's own convention (see the
+          # RAW_TAG/VERSION binding notes elsewhere) says to avoid.
+          config_flag=""
+          if [ "${CHANNEL}" = "staging" ]; then
+            config_flag="--config src-tauri/tauri.staging.conf.json"
+          fi
+          npx tauri bundle --target ${{ matrix.target }} --bundles app,dmg ${config_flag}
 
       - name: Notarize and staple the DMG
         # Runs on every channel now — see the note on the bundle step above for

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -169,6 +169,11 @@ env:
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  # sccache — see the "Set up sccache" step comment in each compile job for
+  # why this runs alongside rust-cache rather than replacing it. Harmless on
+  # jobs that never invoke cargo (prepare, publish).
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   # ── Stage 1: cheap validation + a draft release for everyone to upload into ──
@@ -297,6 +302,7 @@ jobs:
     timeout-minutes: 60 # a hung `notarytool --wait` otherwise burns 10x-billed minutes indefinitely
     permissions:
       contents: write # uploads assets into the draft
+      actions: write # sccache's GHA cache backend needs this to SAVE entries, not just read
     strategy:
       # One flaky architecture must not kill the other's artifacts — and we want
       # its timing either way.
@@ -358,6 +364,26 @@ jobs:
         with:
           toolchain: "1.93.1"
           targets: ${{ matrix.target }}
+
+      # Complements rust-cache below, doesn't replace it. rust-cache restores
+      # a whole target/ tarball keyed on Cargo.lock — great when it matches
+      # exactly, but a tag-triggered build can only ever restore from ITS OWN
+      # ref or `main` (GitHub's cache scoping), never from `pre-main` directly.
+      # A staging release cut from a `pre-main` that has drifted from `main`
+      # (routine — pre-main accumulates merges between releases) gets a
+      # partially-stale target/, and rust-cache's fingerprint mismatch forces
+      # full recompilation of anything that LOOKS different, even crates whose
+      # actual compiled output would be identical. sccache intercepts at the
+      # individual rustc-invocation level regardless of why cargo decided to
+      # invoke it, so it can still return a hit there. Free GHA cache backend
+      # (SCCACHE_GHA_ENABLED below) — same underlying service as rust-cache,
+      # so still ref-scoped in principle, but per-object rather than
+      # per-tarball, which degrades far more gracefully on drift. Does NOT
+      # cover the vendored-OpenSSL C compile or the Swift static-lib build
+      # (tauri-plugin-notifications) — that's still rust-cache's job via its
+      # cache-directories entry below.
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -652,6 +678,7 @@ jobs:
     timeout-minutes: 60 # same cap as macos — bound a hung build instead of falling back to GitHub's 360-minute default
     permissions:
       contents: write # uploads assets into the draft
+      actions: write # sccache's GHA cache backend needs this to SAVE entries, not just read
     env:
       # Same compile-time constants the macOS job bakes in (see its `env:`
       # comment) — these are cross-platform values (OAuth client ids, public
@@ -732,6 +759,11 @@ jobs:
           # is exactly what we ship, so plain `cargo build --release` already
           # produces it — unlike the macOS job, which cross-arch-targets a
           # single shared runner.
+
+      # See the macOS job's "Set up sccache" step for the full reasoning —
+      # identical here, complements rust-cache rather than replacing it.
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/scripts/verify-release-bundle.sh
+++ b/scripts/verify-release-bundle.sh
@@ -126,45 +126,27 @@ pass "app + bundled daemon: Developer ID (${TEAM_ID}), Hardened Runtime"
 codesign --verify --deep --strict "${APP}" 2>/dev/null || fail "codesign --verify --deep --strict failed on ${APP} — the bundle seal is broken"
 pass "bundle seal verifies (--deep --strict)"
 
-# 3c/3d. Notarization — STABLE ONLY.
+# 3c/3d. Notarization — every channel.
 #
-# Gatekeeper enforces notarization only on a QUARANTINED app, and the quarantine
-# flag is set by whatever downloaded it — a browser. The two channels differ in
-# exactly that:
-#
-#   stable  — ships a DMG that new users download in a browser. Quarantined, so
-#             an un-notarized build gives every new user "Apple cannot check it
-#             for malicious software". Notarization is mandatory.
-#   staging — delivered ONLY by tauri-plugin-updater, which unpacks the tarball
-#             itself and sets no quarantine flag. The relaunched app is verified
-#             on its Developer ID signature (checked above, unconditionally) and
-#             the updater's minisign key. No notarization ticket is ever
-#             consulted, so submitting one costs build time and buys nothing.
-#
-# The SIGNING assertions above run on every channel and are the ones that matter
-# for staging: a broken signature breaks the updater's relaunch.
-if [[ "${MERIDIAN_CHANNEL:-stable}" == "stable" ]]; then
-    # Notarized + stapled: Gatekeeper must accept the app OFFLINE. `spctl`
-    # reports "Notarized Developer ID" only when a stapled ticket is present.
-    _spctl="$(spctl --assess --type exec -vv "${APP}" 2>&1 || true)"
-    grep -q "accepted" <<<"${_spctl}" || fail "Gatekeeper REJECTED ${APP}: ${_spctl}"
-    grep -q "Notarized Developer ID" <<<"${_spctl}" || fail "${APP} is signed but NOT notarized (${_spctl}) — users get a Gatekeeper warning. Check the APPLE_API_* notarization secrets."
-    xcrun stapler validate "${APP}" >/dev/null 2>&1 || fail "no stapled notarization ticket on ${APP} — first launch would need an online Gatekeeper check"
-    pass "notarized + stapled (Gatekeeper accepts offline)"
+# This used to run STABLE ONLY, on the theory that Gatekeeper only enforces
+# notarization on a QUARANTINED app and tauri-plugin-updater (staging's only
+# delivery path) never sets that flag. True for an in-place update — false the
+# moment a staging DMG is downloaded directly (browser, `gh release download`,
+# a shared link), which quarantines it exactly like a stable DMG and produces
+# "Apple could not verify this app is free of malware" with no ticket to fall
+# back on. So both channels now get the same check.
+_spctl="$(spctl --assess --type exec -vv "${APP}" 2>&1 || true)"
+grep -q "accepted" <<<"${_spctl}" || fail "Gatekeeper REJECTED ${APP}: ${_spctl}"
+grep -q "Notarized Developer ID" <<<"${_spctl}" || fail "${APP} is signed but NOT notarized (${_spctl}) — users get a Gatekeeper warning. Check the APPLE_API_* notarization secrets."
+xcrun stapler validate "${APP}" >/dev/null 2>&1 || fail "no stapled notarization ticket on ${APP} — first launch would need an online Gatekeeper check"
+pass "notarized + stapled (Gatekeeper accepts offline)"
 
-    # The DMG users actually download must itself be stapled.
-    if [[ -f "${DMG}" ]]; then
-        xcrun stapler validate "${DMG}" >/dev/null 2>&1 || fail "no stapled notarization ticket on ${DMG} — the downloaded DMG would trip Gatekeeper"
-        pass "DMG stapled: $(basename "${DMG}")"
-    else
-        fail "${DMG} not found — package-updater.sh should have made the stable-named copy"
-    fi
+# The DMG users actually download must itself be stapled.
+if [[ -f "${DMG}" ]]; then
+    xcrun stapler validate "${DMG}" >/dev/null 2>&1 || fail "no stapled notarization ticket on ${DMG} — the downloaded DMG would trip Gatekeeper"
+    pass "DMG stapled: $(basename "${DMG}")"
 else
-    echo "  ~ skipping notarization checks (channel=${MERIDIAN_CHANNEL}) — updater-only delivery sets no quarantine flag"
-    # The DMG must still EXIST even unstapled: package-updater.sh produces the
-    # stable-named copy the manifest and the download link both point at.
-    [[ -f "${DMG}" ]] || fail "${DMG} not found — package-updater.sh should have made the stable-named copy"
-    pass "DMG present (unstapled, staging): $(basename "${DMG}")"
+    fail "${DMG} not found — package-updater.sh should have made the stable-named copy"
 fi
 
 # ── 2. updater artifacts — the silent-no-auto-update guard ───────────────────

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -562,6 +562,31 @@ async fn resolve_installer_binary(cmd: &str) -> String {
     }
 }
 
+/// Build a `Command` for `path`, a CLI already located via [`resolve_cli`], with `path`'s own
+/// directory prepended onto the child's `PATH` — same fix as [`resolve_installer_binary`],
+/// applied to the sign-in flows ([`cursor_sign_in`]/[`codex_sign_in`]/[`claude_sign_in`]),
+/// which spawn the resolved binary directly rather than through a shell.
+///
+/// Those CLIs are still spawned by ABSOLUTE PATH, so the OS doesn't need `PATH` to find `path`
+/// itself — but `codex`/`claude` (unlike `cursor-agent`, a native binary) are `#!/usr/bin/env
+/// node` scripts, and `env` does its own independent `PATH` search for `node` at exec time,
+/// using whatever environment the child inherits. `Command::new` inherits the CURRENT
+/// process's `PATH` by default — the tray's own stripped launchd one on macOS, with no
+/// `/opt/homebrew/bin` — so that inner lookup fails with "env: node: No such file or
+/// directory" exactly like [`resolve_installer_binary`]'s install-time case, even though the
+/// CLI itself was already found and resolved correctly.
+fn command_for_resolved_cli(path: &std::path::Path) -> Command {
+    let mut cmd = Command::new(path);
+    if let Some(dir) = path.parent() {
+        let existing = std::env::var_os("PATH").unwrap_or_default();
+        let mut new_path = std::ffi::OsString::from(dir);
+        new_path.push(":");
+        new_path.push(existing);
+        cmd.env("PATH", new_path);
+    }
+    cmd
+}
+
 #[tracing::instrument(
     skip_all,
     fields(
@@ -790,7 +815,7 @@ pub async fn cursor_sign_in() -> InstallOutcome {
     };
 
     tracing::info!("llm: launching interactive cursor-agent login");
-    let mut cmd = Command::new(&path);
+    let mut cmd = command_for_resolved_cli(&path);
     cmd.arg("login")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -899,7 +924,7 @@ pub async fn codex_sign_in() -> InstallOutcome {
     };
 
     tracing::info!("llm: launching interactive codex login");
-    let mut cmd = Command::new(&path);
+    let mut cmd = command_for_resolved_cli(&path);
     cmd.arg("login")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -1006,7 +1031,7 @@ pub async fn claude_sign_in() -> InstallOutcome {
     };
 
     tracing::info!("llm: launching interactive claude auth login");
-    let mut cmd = Command::new(&path);
+    let mut cmd = command_for_resolved_cli(&path);
     cmd.arg("auth")
         .arg("login")
         .arg("--claudeai")
@@ -1921,6 +1946,51 @@ mod tests {
         let cmd = "meridian-definitely-not-a-real-binary --flag value";
         let resolved = resolve_installer_binary(cmd).await;
         assert_eq!(resolved, cmd);
+    }
+
+    /// The sign-in-flow counterpart to `resolve_installer_binary_fixes_the_env_node_shebang_lookup`:
+    /// `cursor_sign_in`/`codex_sign_in`/`claude_sign_in` spawn the resolved CLI directly
+    /// (`Command::new(&path)`, no shell), so `resolve_installer_binary`'s PATH-prepending fix
+    /// never applied to them — `codex`/`claude` are still `#!/usr/bin/env node` scripts, and a
+    /// directly-spawned child inherits the CURRENT process's `PATH` (the tray's own stripped
+    /// one), not any shell-derived one. Fakes a `#!/usr/bin/env node` CLI with a fake `node`
+    /// alongside it; only passes if `command_for_resolved_cli` actually set `PATH` on the child.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn command_for_resolved_cli_fixes_the_env_node_shebang_lookup() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = std::env::temp_dir().join(format!(
+            "meridian-detect-cmd-resolved-test-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let fake_node = temp_dir.join("node");
+        std::fs::write(&fake_node, "#!/bin/sh\necho FAKE_NODE_RAN\n").unwrap();
+        let fake_cli = temp_dir.join("meridian-fake-cli");
+        std::fs::write(&fake_cli, "#!/usr/bin/env node\n").unwrap();
+        for f in [&fake_node, &fake_cli] {
+            let mut perms = std::fs::metadata(f).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(f, perms).unwrap();
+        }
+
+        let mut cmd = command_for_resolved_cli(&fake_cli);
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let output = cmd
+            .output()
+            .await
+            .expect("command_for_resolved_cli must spawn");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+
+        assert!(output.status.success(), "{output:?}");
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "FAKE_NODE_RAN",
+            "{output:?}"
+        );
     }
 
     /// cursor-agent does not install via npm on Windows (see

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -538,7 +538,24 @@ pub struct InstallOutcome {
 async fn resolve_installer_binary(cmd: &str) -> String {
     match cmd.split_once(' ') {
         Some((installer_bin, rest)) => match resolve_cli(installer_bin).await {
-            Some(resolved) => format!("{} {rest}", resolved.display()),
+            // `npm` (and most CLIs installed by the same tooling) is itself a
+            // `#!/usr/bin/env node` script — the OS execs `env`, and `env` does its OWN
+            // independent PATH search for `node` using the shell's PATH, completely
+            // unaffected by how npm itself was invoked. Substituting only npm's absolute
+            // path fixed the FIRST lookup ("command not found: npm") but not this second,
+            // nested one ("env: node: No such file or directory") — every real npm
+            // install keeps `node` in the exact same directory as `npm` (Homebrew, nvm's
+            // per-version bin/, Volta's shim dir, the official installer), so prepending
+            // that directory onto PATH fixes the shebang lookup the same way resolving
+            // npm itself fixed the first one.
+            Some(resolved) => match resolved.parent() {
+                Some(dir) => format!(
+                    "export PATH=\"{}:$PATH\"; {} {rest}",
+                    dir.display(),
+                    resolved.display()
+                ),
+                None => format!("{} {rest}", resolved.display()),
+            },
             None => cmd.to_string(),
         },
         None => cmd.to_string(),
@@ -1825,8 +1842,74 @@ mod tests {
 
         assert_eq!(
             resolved,
-            format!("{} i -g some-package", fake_bin.display()),
-            "expected the leading binary swapped for its resolved absolute path"
+            format!(
+                "export PATH=\"{}:$PATH\"; {} i -g some-package",
+                bin_dir.display(),
+                fake_bin.display()
+            ),
+            "expected the leading binary swapped for its resolved absolute path, with its \
+             directory prepended onto PATH"
+        );
+    }
+
+    /// The Node-shebang case that motivated prepending PATH, not just resolving the leading
+    /// binary: `npm` is itself a `#!/usr/bin/env node` script, so the OS execs `env`, and `env`
+    /// does its OWN independent PATH search for `node` — resolving npm's own absolute path
+    /// does not help THAT lookup. Fakes an `npm` script with a real `env node` shebang plus a
+    /// fake `node` living alongside it, so this only passes if PATH was actually prepended
+    /// (not just npm's leading token swapped).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn resolve_installer_binary_fixes_the_env_node_shebang_lookup() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = ENV_LOCK.lock().await;
+        let original_home = std::env::var_os("HOME");
+        let temp_home = std::env::temp_dir().join(format!(
+            "meridian-detect-shebang-test-{}",
+            std::process::id()
+        ));
+        let bin_dir = temp_home.join(".local").join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+
+        let fake_node = bin_dir.join("node");
+        std::fs::write(&fake_node, "#!/bin/sh\necho FAKE_NODE_RAN\n").unwrap();
+        let fake_npm = bin_dir.join("meridian-fake-npm");
+        std::fs::write(&fake_npm, "#!/usr/bin/env node\n").unwrap();
+        for f in [&fake_node, &fake_npm] {
+            let mut perms = std::fs::metadata(f).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(f, perms).unwrap();
+        }
+        std::env::set_var("HOME", &temp_home);
+
+        let resolved_cmd = resolve_installer_binary("meridian-fake-npm i -g some-package").await;
+
+        let child = {
+            let mut cmd = installer_command(&resolved_cmd);
+            cmd.stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            cmd.spawn()
+        };
+
+        match original_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+
+        let output = child
+            .expect("installer_command must spawn")
+            .wait_with_output()
+            .await
+            .expect("installer_command must run to completion");
+        let _ = std::fs::remove_dir_all(&temp_home);
+
+        assert!(output.status.success(), "{output:?}");
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "FAKE_NODE_RAN",
+            "{output:?}"
         );
     }
 

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -579,9 +579,11 @@ fn command_for_resolved_cli(path: &std::path::Path) -> Command {
     let mut cmd = Command::new(path);
     if let Some(dir) = path.parent() {
         let existing = std::env::var_os("PATH").unwrap_or_default();
-        let mut new_path = std::ffi::OsString::from(dir);
-        new_path.push(":");
-        new_path.push(existing);
+        // std::env::join_paths/split_paths, not a hardcoded `:` — this is called
+        // on every platform (cursor_sign_in/codex_sign_in/claude_sign_in all use
+        // it directly), and Windows PATH entries are `;`-separated, not `:`.
+        let dirs = std::iter::once(dir.to_path_buf()).chain(std::env::split_paths(&existing));
+        let new_path = std::env::join_paths(dirs).unwrap_or(existing);
         cmd.env("PATH", new_path);
     }
     cmd

--- a/src/main.rs
+++ b/src/main.rs
@@ -992,7 +992,28 @@ async fn main() -> Result<()> {
     //     an agent CLI) is degraded; ordering it after a preflight that could
     //     block once left machines running a daemon that never created its own
     //     database.
-    let meridian = setup_db(&initial_cfg.meridian_db_uri()).await?;
+    let meridian = match setup_db(&initial_cfg.meridian_db_uri()).await {
+        Ok(pool) => pool,
+        Err(e) => {
+            // The daemon cannot run without its database, and a bare `?` here
+            // would unwind to `main`'s stderr Debug print — invisible to central
+            // OO, because this path dies *before* the telemetry shipper (7f
+            // below) ever starts, so nothing ever drains the spool. Report it
+            // through `tracing` and then flush + one-shot ship (mirroring the
+            // shutdown path at the end of `main`) so a daemon that can't open its
+            // DB — a wrong/absent encryption key, a file another process holds
+            // locked, corruption — is finally diagnosable in central telemetry
+            // instead of crash-looping silently. `shutdown` consumes the guard,
+            // but we exit immediately after, so the success path still owns it.
+            tracing::error!(
+                error = %e,
+                "daemon startup: failed to open the database — the daemon cannot start (wrong/absent encryption key, a locked file, or corruption)"
+            );
+            obs_guard.shutdown().await;
+            meridian::telemetry_spool::shipper::drain_once().await;
+            std::process::exit(1);
+        }
+    };
 
     // 4c. Capture-layer (L1) preflight: surface degraded in-process capture
     //     (revoked Screen Recording / Accessibility permission, the tray not

--- a/src/migrations/076_disk_low_pause_gaps.sql
+++ b/src/migrations/076_disk_low_pause_gaps.sql
@@ -1,0 +1,26 @@
+-- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+-- Extend the gaps table to accept a 'disk_low_paused' kind, written by the
+-- tray's disk-space guard (poll::check_disk_space) when capture is
+-- auto-paused because free disk space fell below the low-disk threshold.
+-- SQLite does not support ALTER TABLE … MODIFY COLUMN, so we rebuild the
+-- table, same as migration 051.
+
+CREATE TABLE gaps_new (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    started_at  TEXT    NOT NULL,
+    ended_at    TEXT    NOT NULL,
+    duration_s  INTEGER NOT NULL,
+    kind        TEXT    NOT NULL CHECK(kind IN (
+                    'user_idle', 'system_sleep',
+                    'tracking_paused', 'schedule_paused', 'disk_low_paused'
+                )),
+    etl_run_id  INTEGER,
+    FOREIGN KEY (etl_run_id) REFERENCES etl_runs(id)
+);
+
+INSERT INTO gaps_new SELECT id, started_at, ended_at, duration_s, kind, etl_run_id FROM gaps;
+DROP TABLE gaps;
+ALTER TABLE gaps_new RENAME TO gaps;
+
+CREATE INDEX IF NOT EXISTS idx_gaps_started_at ON gaps(started_at);
+CREATE INDEX IF NOT EXISTS idx_gaps_kind       ON gaps(kind);

--- a/tray/src-tauri/src/autostart.rs
+++ b/tray/src-tauri/src/autostart.rs
@@ -9,6 +9,9 @@
 //!
 //! # Related
 //! - [`crate::backend_install`] — the daemon's equivalent self-heal registration.
+//! - [`crate::relocate`] — runs earlier in `setup()` and actively fixes a
+//!   transient (DMG/translocation) launch instead of just deferring around it
+//!   the way [`ensure_enabled_once`] does.
 
 use tauri_plugin_autostart::ManagerExt;
 
@@ -42,7 +45,7 @@ pub async fn ensure_enabled_once(app: &tauri::AppHandle) {
     // once (marker on success) the broken pin would never self-heal. Deferring
     // — without writing the marker — retries on the next launch, by which time
     // the user has dragged the app into a stable location (e.g. /Applications).
-    if !running_from_stable_location() {
+    if !crate::sys::running_from_stable_location() {
         tracing::info!(
             "autostart: running from a transient location (DMG mount / translocation) — \
              deferring login-item registration until the app is in a stable path"
@@ -66,60 +69,6 @@ pub async fn ensure_enabled_once(app: &tauri::AppHandle) {
     }
 }
 
-/// macOS: `true` unless the running binary sits in a location that won't
-/// survive — a mounted disk image (`/Volumes/…`, read-only and ejected after a
-/// drag-install) or Gatekeeper's App Translocation quarantine
-/// (`…/AppTranslocation/…`, a randomized read-only mount the OS discards). See
-/// [`ensure_enabled_once`] for why pinning a login item from those paths would
-/// silently and permanently break self-heal.
-///
-/// Non-macOS: always `true` — Windows Run-key entries and Linux desktop entries
-/// point at the installed path, so the mounted-image failure class doesn't
-/// apply there.
-#[cfg(target_os = "macos")]
-fn running_from_stable_location() -> bool {
-    match std::env::current_exe() {
-        Ok(exe) => path_is_stable(&exe.to_string_lossy()),
-        // Can't resolve our own path ⇒ can't vouch for it. Skip and retry next
-        // launch rather than gamble on pinning a bad target.
-        Err(_) => false,
-    }
-}
-
-#[cfg(not(target_os = "macos"))]
-fn running_from_stable_location() -> bool {
-    true
-}
-
-/// The pure string test behind [`running_from_stable_location`], split out so
-/// it can be unit-tested without a real `current_exe()`.
-#[cfg(target_os = "macos")]
-fn path_is_stable(exe_path: &str) -> bool {
-    !exe_path.starts_with("/Volumes/") && !exe_path.contains("/AppTranslocation/")
-}
-
-#[cfg(all(test, target_os = "macos"))]
-mod tests {
-    use super::path_is_stable;
-
-    #[test]
-    fn rejects_transient_locations() {
-        // Mounted DMG (drag-install source) and translocation quarantine.
-        assert!(!path_is_stable(
-            "/Volumes/Meridian/Meridian.app/Contents/MacOS/Meridian"
-        ));
-        assert!(!path_is_stable(
-            "/private/var/folders/ab/xyz/T/AppTranslocation/ABC-123/d/Meridian.app/Contents/MacOS/Meridian"
-        ));
-    }
-
-    #[test]
-    fn accepts_stable_locations() {
-        assert!(path_is_stable(
-            "/Applications/Meridian.app/Contents/MacOS/Meridian"
-        ));
-        assert!(path_is_stable(
-            "/Users/dev/Applications/Meridian.app/Contents/MacOS/Meridian"
-        ));
-    }
-}
+// The stable-vs-transient-path check now lives in `crate::sys` — shared with
+// `crate::relocate`, which is the module that actively fixes a transient
+// launch rather than just deferring around it.

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -108,7 +108,12 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
     };
     let marker = home.join(".meridian/backend-version");
     if tokio::fs::read_to_string(&marker).await.ok().as_deref() == Some(bundled_hash.as_str()) {
-        tracing::debug!(hash = %bundled_hash, "backend_install: backend up to date — skipping");
+        tracing::debug!(hash = %bundled_hash, "backend_install: backend up to date — skipping staging");
+        // Staging is current, but the daemon may not be running: the
+        // encrypt-in-place migration stops it earlier this launch (see lib.rs's
+        // setup hook) to unlock meridian.db, and it can also simply crash. Bring
+        // it back so a skipped *staging* never leaves a stopped *daemon*.
+        ensure_daemon_running(&home).await;
         return;
     }
 
@@ -163,6 +168,82 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
         tracing::error!(error = %e, "backend_install: could not write version marker");
     }
     tracing::info!("backend_install: backend installed");
+}
+
+/// Stop the running daemon so the tray's in-place `meridian.db` encryption
+/// migration can rename the file. **Windows-only concern**: a rename of a file
+/// another process holds open fails there with os error 32, which is why
+/// `encrypt_in_place` rolled back every launch while the daemon (autostarted at
+/// login) held the DB open. A no-op on other platforms, where the migration
+/// tolerates the open handle.
+///
+/// Called from the tray's setup hook BEFORE `encrypt_in_place`, and only when a
+/// migration will actually attempt (a key is set and the DB is still plaintext).
+/// The daemon is brought back up afterward by [`ensure_backend_installed`] —
+/// either its normal staging path (on an update) or [`ensure_daemon_running`]
+/// (on the up-to-date path).
+pub(crate) async fn stop_daemon_for_migration() -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        let home = meridian_core::paths::home_dir()
+            .ok_or_else(|| "home directory could not be resolved".to_string())?;
+        let daemon_bin = home.join(".meridian").join("bin").join(DAEMON_FILE);
+        stop_running_daemon_before_stage(&daemon_bin).await
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        Ok(())
+    }
+}
+
+/// Ensure the daemon is running, starting it if it isn't. Called on the
+/// backend-up-to-date path of [`ensure_backend_installed`] (where staging and
+/// [`register_service`] are skipped) so a skipped *staging* never leaves a
+/// *stopped* daemon — in particular after [`stop_daemon_for_migration`] stops it
+/// for the encryption migration, but also if it simply crashed.
+///
+/// **Windows-only work**: prefer the scheduled task, else spawn the binary
+/// directly (the same fallback [`register_service`] uses on policy-locked
+/// machines). On macOS launchd's `KeepAlive` restarts the daemon itself, so this
+/// is a no-op there.
+async fn ensure_daemon_running(home: &Path) {
+    #[cfg(target_os = "windows")]
+    {
+        let daemon_bin = home.join(".meridian").join("bin").join(DAEMON_FILE);
+        if !matching_daemon_pids(&daemon_bin).await.is_empty() {
+            return; // already up — nothing to do
+        }
+        let started_via_task = tokio::process::Command::new("schtasks")
+            .args(["/Run", "/TN", WINDOWS_TASK_NAME])
+            .no_window()
+            .output()
+            .await
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if started_via_task {
+            tracing::info!(
+                task = WINDOWS_TASK_NAME,
+                "backend_install: restarted daemon via scheduled task"
+            );
+            return;
+        }
+        match tokio::process::Command::new(&daemon_bin)
+            .no_window()
+            .spawn()
+        {
+            Ok(_) => {
+                tracing::info!(bin = %daemon_bin.display(), "backend_install: restarted daemon directly")
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, bin = %daemon_bin.display(), "backend_install: could not restart the daemon")
+            }
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        // launchd `KeepAlive` restarts the daemon on its own — nothing to do.
+        let _ = home;
+    }
 }
 
 /// `Meridian.app/Contents/Resources/backend/` when it exists, else `None`.
@@ -953,6 +1034,20 @@ async fn launchctl(args: &[&str]) -> Result<bool, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// On non-Windows, `stop_daemon_for_migration` is an inert no-op that returns
+    /// `Ok` — the encryption migration tolerates an open handle there, so there
+    /// is nothing to stop and the tray's setup hook proceeds straight to
+    /// `encrypt_in_place`. Gated off Windows so the test never kills a real
+    /// daemon; CI runs on macOS, so it executes there.
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn stop_daemon_for_migration_is_a_noop_off_windows() {
+        assert!(
+            stop_daemon_for_migration().await.is_ok(),
+            "off Windows this must be an inert Ok, not attempt to stop anything"
+        );
+    }
 
     /// `migrate_legacy_bundle_env` must: copy the bundle `.env` to the canonical
     /// path when only the bundle exists; **never clobber** an existing canonical

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -213,19 +213,31 @@ async fn ensure_daemon_running(home: &Path) {
         if !matching_daemon_pids(&daemon_bin).await.is_empty() {
             return; // already up — nothing to do
         }
-        let started_via_task = tokio::process::Command::new("schtasks")
+        let queued_via_task = tokio::process::Command::new("schtasks")
             .args(["/Run", "/TN", WINDOWS_TASK_NAME])
             .no_window()
             .output()
             .await
             .map(|o| o.status.success())
             .unwrap_or(false);
-        if started_via_task {
-            tracing::info!(
+        if queued_via_task {
+            // `/Run` success only confirms the task was QUEUED — it's
+            // registered `/SC ONLOGON`, so a successful exit here doesn't
+            // mean the daemon actually launched. Give it a moment, then
+            // verify before trusting it; otherwise fall through to the
+            // direct spawn below rather than leaving the daemon down.
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            if !matching_daemon_pids(&daemon_bin).await.is_empty() {
+                tracing::info!(
+                    task = WINDOWS_TASK_NAME,
+                    "backend_install: restarted daemon via scheduled task"
+                );
+                return;
+            }
+            tracing::warn!(
                 task = WINDOWS_TASK_NAME,
-                "backend_install: restarted daemon via scheduled task"
+                "backend_install: scheduled task ran but the daemon isn't up yet, falling back to a direct spawn"
             );
-            return;
         }
         match tokio::process::Command::new(&daemon_bin)
             .no_window()

--- a/tray/src-tauri/src/commands/pause.rs
+++ b/tray/src-tauri/src/commands/pause.rs
@@ -62,6 +62,7 @@ async fn transition_pause(
         let kind = match prev_src {
             PauseSource::Timed | PauseSource::Indefinite => "tracking_paused",
             PauseSource::Schedule => "schedule_paused",
+            PauseSource::DiskLow => "disk_low_paused",
         };
         let duration_s = now.saturating_sub(prev_started) as i64;
         if duration_s > 0 {
@@ -268,12 +269,34 @@ fn secs_to_iso(secs: u64) -> String {
 
 /// Clear the capture pause, write a gap row, and optionally toast the user.
 /// Shared by manual resume (`seconds = 0`) and auto-resume (timer expiry).
+///
+/// Gated on free disk space first: a nearly-full disk is how a real
+/// `meridian.db` got corrupted (SQLite/SQLCipher torn page allocations under
+/// WAL when a write landed with no room left to grow). If disk is still low
+/// at resume time — for any pause reason, including a manual "Resume now"
+/// click — this refuses to restart the capture engine and instead converts
+/// the pause to [`PauseSource::DiskLow`], so it can only clear once
+/// [`poll::check_disk_space`] sees space recover. The existing
+/// `system.disk_low` daemon notice (raised every poll tick) already tells the
+/// user why, so no separate notification is raised here.
 pub(crate) async fn resume_capture(
     state: &Arc<Mutex<AppState>>,
     pool: Option<&SqlitePool>,
     app: &tauri::AppHandle,
     auto: bool,
 ) {
+    if meridian::health::platform::meridian_data_low_gb().is_some() {
+        tracing::warn!("resume_capture: refusing to resume — disk space still low");
+        let now = now_secs();
+        if let Err(e) = transition_pause(state, pool, now, PauseSource::DiskLow, None).await {
+            tracing::warn!(error = %e, "resume_capture: failed to convert pause to disk-low");
+        }
+        if let Ok(s) = state.lock() {
+            let _ = app.emit("status-update", s.to_payload());
+        }
+        return;
+    }
+
     let (started, source) = {
         let mut s = match state.lock() {
             Ok(s) => s,
@@ -294,6 +317,7 @@ pub(crate) async fn resume_capture(
         let kind = match src {
             PauseSource::Timed | PauseSource::Indefinite => "tracking_paused",
             PauseSource::Schedule => "schedule_paused",
+            PauseSource::DiskLow => "disk_low_paused",
         };
         let now = now_secs();
         let duration_s = now.saturating_sub(started_secs) as i64;

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -42,6 +42,7 @@ pub(crate) const SELF_BINARY_NAME: &str = "meridian-tray";
 pub(crate) mod format;
 mod install;
 mod poll;
+mod relocate;
 mod state;
 mod sys;
 mod tray;
@@ -165,6 +166,18 @@ pub fn run() {
         // openers, pulled by the dashboard shell on mount. See `deep_link`.
         .manage(deep_link::PendingDeepLink(std::sync::Mutex::new(None)))
         .setup(move |app| {
+            // Move-to-Applications self-relocation. Must run before anything
+            // else touches the DB pool or spawns the poll loop: a `true`
+            // return means a replacement process now exists at
+            // `/Applications` and this (transient DMG/translocation)
+            // instance must exit immediately, not continue starting up
+            // alongside it. Bundled only — an unbundled `cargo run`/`tauri
+            // dev` binary under `target/` is never "transient" in the sense
+            // this guards against. See `relocate.rs`.
+            if sys::is_bundled() && relocate::maybe_relocate_to_applications() {
+                std::process::exit(0);
+            }
+
             #[cfg(target_os = "macos")]
             app.set_activation_policy(tauri::ActivationPolicy::Accessory);
             // Dock tooltip, Activity Monitor, and the AX tree all key on the

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -274,6 +274,29 @@ pub fn run() {
             // `!cfg!(debug_assertions)` style.
             let db_encryption_intended = db_key_hex.is_some();
 
+            // On Windows the daemon (autostarted at login) holds meridian.db
+            // open, so `encrypt_in_place`'s rename fails with os error 32 and
+            // rolls back every launch — the migration can never complete while
+            // the daemon is up. Stop it first, but ONLY when a migration will
+            // actually attempt (a key was resolved AND the DB is still
+            // plaintext); once encrypted this never runs again, so the stop is a
+            // one-time cost on the migration launch. A no-op on non-Windows,
+            // where rename tolerates an open handle. The daemon is brought back
+            // up by `ensure_backend_installed` later in this same setup hook.
+            if !cfg!(debug_assertions)
+                && db_encryption_intended
+                && meridian_core::db_crypto::is_plaintext_sqlite(std::path::Path::new(&db_path))
+            {
+                if let Err(e) =
+                    tauri::async_runtime::block_on(backend_install::stop_daemon_for_migration())
+                {
+                    tracing::warn!(
+                        error = %e,
+                        "could not stop the daemon before encrypting the database; encryption may not complete this launch"
+                    );
+                }
+            }
+
             let db_key_hex = if !cfg!(debug_assertions) {
                 match &db_key_hex {
                     Some(key) => {
@@ -351,7 +374,7 @@ pub fn run() {
                                     id: "tray.db_encryption_incomplete",
                                     severity: "warning",
                                     title: "Your data isn't encrypted at rest yet.",
-                                    detail: "Meridian couldn't finish encrypting its local database because another Meridian process was holding it open. Your data is safe but stored unencrypted for now - fully quit Meridian and reopen it to let encryption finish.",
+                                    detail: "Meridian couldn't finish encrypting its local database this time. Your data is safe but stored unencrypted for now - Meridian will retry automatically the next time it restarts.",
                                     remedy: None,
                                     event_key: "system.health",
                                     deep_link: Some("/logs"),

--- a/tray/src-tauri/src/poll/mod.rs
+++ b/tray/src-tauri/src/poll/mod.rs
@@ -161,6 +161,15 @@ pub async fn run_poll_loop(app: tauri::AppHandle, state: Arc<Mutex<AppState>>) {
                 permissions::check_permissions(&app, pool).await;
             }
         }
+        // Disk-space guard: auto-pause capture when free disk space on the
+        // meridian.db volume drops below the low-disk threshold, auto-resume
+        // once it recovers. Checked before work-hours so a low-disk pause
+        // always wins the race to claim `pause_source` first; see
+        // check_disk_space's doc comment for why writing into a nearly-full
+        // disk must stop rather than degrade silently.
+        if let Some(pool) = &pool {
+            check_disk_space(&state, pool).await;
+        }
         // Work-hours schedule enforcement: auto-pause capture outside the
         // configured window, auto-resume when entering it. Only fires when the
         // feature is enabled; never overrides a user-initiated timed pause.
@@ -231,6 +240,119 @@ fn update_tray_icon(app: &tauri::AppHandle, state: &Arc<Mutex<AppState>>) {
     if let Some(id) = tray_id {
         if let Some(tray) = app.tray_by_id(&id) {
             let _ = tray.set_tooltip(Some(&tooltip));
+        }
+    }
+}
+
+/// Auto-pause capture when free disk space on the `meridian.db` volume drops
+/// below the low-disk threshold, auto-resume once it recovers. Runs every
+/// poll tick (30 s), before [`check_work_hours`] so a low-disk pause always
+/// wins the race to claim `pause_source` first.
+///
+/// Writing into a nearly-full disk is exactly how a real `meridian.db` got
+/// corrupted in practice: SQLite/SQLCipher torn page allocations under WAL
+/// when a write landed with the disk critically full, scrambling the
+/// page-allocation bookkeeping for `capture_frames`/`capture_ui_events` and
+/// one `app_sessions` row's overflow chain. The daemon already raises a
+/// `system.disk_low` notice every tick once space runs low
+/// (`meridian::health::daemon`) — this only makes the tray *act* on the same
+/// condition instead of writing blind.
+///
+/// The state machine mirrors [`check_work_hours`]:
+///   - Low disk + not disk-paused → start a disk-low pause (unless a Timed or
+///     Indefinite user pause is already active — never override those; a
+///     schedule pause is preempted, since disk safety is the higher-priority
+///     reason once space runs low and check_disk_space runs first each tick).
+///   - Disk recovered + disk-paused → end the pause, write the gap, resume.
+///
+/// Every OTHER resume path (manual "Resume now", a timed pause's own expiry
+/// timer) is separately gated in [`crate::commands::pause::resume_capture`],
+/// so a still-low disk can't be resumed into from any direction — this
+/// function only owns the disk-low pause's own start/end transition.
+async fn check_disk_space(state: &Arc<Mutex<AppState>>, pool: &meridian_core::SqlitePool) {
+    let low = meridian::health::platform::meridian_data_low_gb().is_some();
+
+    let (pause_source, started_at, capture_paused_flag) = {
+        let s = state.lock().unwrap();
+        (
+            s.pause_source.clone(),
+            s.pause_started_at,
+            s.capture_paused.clone(),
+        )
+    };
+
+    match (low, &pause_source) {
+        (true, None) | (true, Some(PauseSource::Schedule)) => {
+            // Disk low, not paused (or only schedule-paused, which this
+            // preempts) → begin a disk-low pause.
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            {
+                let mut s = state.lock().unwrap();
+                drop(s.engine_cancel.take());
+                drop(s.ui_consumer_cancel.take());
+                capture_paused_flag.store(true, Ordering::Relaxed);
+                s.pause_source = Some(PauseSource::DiskLow);
+                s.pause_started_at = Some(now);
+                s.schedule_resume_at = None;
+            }
+            tracing::warn!("disk-space guard: capture paused — free disk space is low");
+        }
+        (false, Some(PauseSource::DiskLow)) => {
+            // Disk recovered → end the pause and write the gap.
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let duration_s = started_at
+                .map(|s| now.saturating_sub(s) as i64)
+                .unwrap_or(0);
+
+            if let Some(started_secs) = started_at {
+                if duration_s > 0 {
+                    use chrono::{DateTime, SecondsFormat, Utc};
+                    let from = DateTime::<Utc>::from_timestamp(started_secs as i64, 0)
+                        .unwrap_or_else(Utc::now)
+                        .to_rfc3339_opts(SecondsFormat::Millis, true);
+                    let to = DateTime::<Utc>::from_timestamp(now as i64, 0)
+                        .unwrap_or_else(Utc::now)
+                        .to_rfc3339_opts(SecondsFormat::Millis, true);
+                    if let Err(e) = meridian_core::insert_pause_gap(
+                        pool,
+                        &from,
+                        &to,
+                        duration_s,
+                        "disk_low_paused",
+                    )
+                    .await
+                    {
+                        tracing::warn!(error = %e, "disk-space guard: failed to write disk_low_paused gap");
+                    }
+                }
+            }
+
+            {
+                let mut s = state.lock().unwrap();
+                capture_paused_flag.store(false, Ordering::Relaxed);
+                s.pause_source = None;
+                s.pause_started_at = None;
+                s.pause_until = None;
+            }
+            // Restart engine so capture resumes. If this happens to also be
+            // outside work hours, check_work_hours (running right after this,
+            // same tick) immediately re-pauses with Schedule — a harmless,
+            // rare blip (engine starts and stops within the same tick,
+            // capturing nothing) rather than a bug worth cross-checking
+            // schedule state here too.
+            #[cfg(feature = "capture")]
+            crate::start_capture(state.clone(), Some(pool.clone()));
+            tracing::info!(duration_s, "disk-space guard: capture resumed");
+        }
+        _ => {
+            // Still low and already disk-paused, still fine and untouched, or
+            // a Timed/Indefinite user pause is active — leave it alone.
         }
     }
 }

--- a/tray/src-tauri/src/poll/mod.rs
+++ b/tray/src-tauri/src/poll/mod.rs
@@ -273,7 +273,16 @@ async fn check_disk_space(state: &Arc<Mutex<AppState>>, pool: &meridian_core::Sq
     let low = meridian::health::platform::meridian_data_low_gb().is_some();
 
     let (pause_source, started_at, capture_paused_flag) = {
-        let s = state.lock().unwrap();
+        // Degrade gracefully on a poisoned mutex rather than unwrap — this
+        // runs synchronously inside run_poll_loop's loop body (not isolated
+        // in its own task), so a panic here would kill the entire poll loop
+        // for the rest of the process's life (health checks, notifications,
+        // tray icon updates, and this same guard, all silently dead), not
+        // just this one check. Same pattern refresh_health/refresh_active use.
+        let Ok(s) = state.lock() else {
+            tracing::warn!("check_disk_space: state lock poisoned");
+            return;
+        };
         (
             s.pause_source.clone(),
             s.pause_started_at,
@@ -289,8 +298,43 @@ async fn check_disk_space(state: &Arc<Mutex<AppState>>, pool: &meridian_core::Sq
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs();
+
+            // Preempting a Schedule pause must close out its own interval
+            // first — same as pause.rs::transition_pause does for the
+            // command-driven pause paths. Without this, the time already
+            // spent Schedule-paused before disk-low kicked in silently
+            // vanishes from the gaps table, and downstream worklog/analytics
+            // logic (which relies on gaps to exclude paused time) would
+            // treat it as tracked/active time instead.
+            if let (Some(PauseSource::Schedule), Some(prev_started)) = (&pause_source, started_at) {
+                let duration_s = now.saturating_sub(prev_started) as i64;
+                if duration_s > 0 {
+                    use chrono::{DateTime, SecondsFormat, Utc};
+                    let from = DateTime::<Utc>::from_timestamp(prev_started as i64, 0)
+                        .unwrap_or_else(Utc::now)
+                        .to_rfc3339_opts(SecondsFormat::Millis, true);
+                    let to = DateTime::<Utc>::from_timestamp(now as i64, 0)
+                        .unwrap_or_else(Utc::now)
+                        .to_rfc3339_opts(SecondsFormat::Millis, true);
+                    if let Err(e) = meridian_core::insert_pause_gap(
+                        pool,
+                        &from,
+                        &to,
+                        duration_s,
+                        "schedule_paused",
+                    )
+                    .await
+                    {
+                        tracing::warn!(error = %e, "disk-space guard: failed to write preempted schedule_paused gap");
+                    }
+                }
+            }
+
             {
-                let mut s = state.lock().unwrap();
+                let Ok(mut s) = state.lock() else {
+                    tracing::warn!("check_disk_space: state lock poisoned");
+                    return;
+                };
                 drop(s.engine_cancel.take());
                 drop(s.ui_consumer_cancel.take());
                 capture_paused_flag.store(true, Ordering::Relaxed);
@@ -334,7 +378,10 @@ async fn check_disk_space(state: &Arc<Mutex<AppState>>, pool: &meridian_core::Sq
             }
 
             {
-                let mut s = state.lock().unwrap();
+                let Ok(mut s) = state.lock() else {
+                    tracing::warn!("check_disk_space: state lock poisoned");
+                    return;
+                };
                 capture_paused_flag.store(false, Ordering::Relaxed);
                 s.pause_source = None;
                 s.pause_started_at = None;

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -111,8 +111,30 @@ pub(super) async fn refresh_health(
         async {
             let r = crate::commands::daemon_control::restart().await;
             match &r {
-                Err(e) => tracing::warn!(error = %e, "daemon-health auto-restart attempt failed"),
-                Ok(()) => tracing::info!("daemon-health auto-restart attempted"),
+                // ERROR (not WARN) so this line crosses the error-only central
+                // telemetry filter. The went-quiet *notice* is a local DB row
+                // and the watchdog's per-tick retries are WARN, so a
+                // paused/offline daemon the tray also couldn't restart was
+                // previously invisible in central OO — you could see the banner
+                // on the machine but nothing shipped. Edge-triggered
+                // (`attempt_restart` fires once on the 2nd consecutive failure),
+                // so it's one event per down-episode, not per poll. The fields
+                // are what you debug from: `daemon_running` vs `db_ready`
+                // pinpoints which subsystem is down, and `cold_start` (never seen
+                // healthy this run) distinguishes an install/autostart gap from a
+                // crash of a daemon that had been up.
+                Err(e) => tracing::error!(
+                    error = %e,
+                    daemon_running,
+                    db_ready,
+                    cold_start = !notify_down,
+                    "daemon offline and automatic restart failed — the daemon is down with no recovery this episode"
+                ),
+                Ok(()) => tracing::info!(
+                    daemon_running,
+                    db_ready,
+                    "daemon offline — automatic restart attempted"
+                ),
             }
             Some(r)
         }

--- a/tray/src-tauri/src/relocate.rs
+++ b/tray/src-tauri/src/relocate.rs
@@ -1,0 +1,240 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! "Move to Applications" self-relocation for a DMG-mount or App Translocation
+//! launch. Without this, a user who double-clicks the app straight out of the
+//! mounted disk image (instead of dragging it to `/Applications` first) gets
+//! a tray that works for the current session but can never re-open itself
+//! after a reboot — [`crate::autostart::ensure_enabled_once`] correctly
+//! refuses to pin a login item to a path that's about to vanish, and just
+//! keeps deferring forever because nothing ever moves the app out of the way.
+//!
+//! This module is the active fix: on a transient launch it prompts the user,
+//! copies the bundle to `/Applications`, relaunches from there, and exits the
+//! transient process — so relocation plus autostart registration both
+//! complete on the very first launch instead of requiring the user to know
+//! to drag-then-reopen.
+//!
+//! # Who calls this
+//! [`crate::run`]'s `setup()` hook — first thing, before the DB pool opens or
+//! the poll loop spawns, so a relocate-and-exit never leaves half-started
+//! state behind (bundled runs only, see [`crate::sys::is_bundled`]).
+//!
+//! # Related
+//! - [`crate::sys::running_from_stable_location`] — the shared transient-path
+//!   detector both this module and [`crate::autostart`] key off.
+//! - [`crate::autostart`] — registers the login item; only reachable once a
+//!   launch is no longer transient, whether that's because of this module or
+//!   because the user manually moved the app themselves.
+
+use std::path::{Path, PathBuf};
+
+/// Entry point. Returns `true` only when the app was successfully relaunched
+/// from `/Applications` — the caller MUST treat that as "a replacement
+/// process now exists; exit immediately" rather than continuing startup.
+/// Every other outcome (stable launch, declined prompt, copy/relaunch
+/// failure) returns `false` and logs why; normal startup should continue,
+/// and [`crate::autostart::ensure_enabled_once`]'s existing deferral already
+/// handles a still-transient launch safely on the next run.
+#[cfg(target_os = "macos")]
+pub fn maybe_relocate_to_applications() -> bool {
+    if crate::sys::running_from_stable_location() {
+        return false;
+    }
+    let Ok(exe) = std::env::current_exe() else {
+        tracing::warn!("relocate: could not resolve current_exe, skipping");
+        return false;
+    };
+    let Some(bundle) = bundle_root(&exe) else {
+        tracing::warn!(
+            exe = %exe.display(),
+            "relocate: transient launch but couldn't resolve a .app bundle root, skipping"
+        );
+        return false;
+    };
+
+    if !prompt_move_to_applications() {
+        tracing::info!("relocate: user declined the move-to-Applications prompt");
+        return false;
+    }
+
+    let dest = match copy_bundle_to_applications(&bundle) {
+        Ok(dest) => dest,
+        Err(e) => {
+            tracing::warn!(error = %e, "relocate: copy to /Applications failed");
+            return false;
+        }
+    };
+
+    let Some(exe_name) = exe.file_name() else {
+        tracing::warn!("relocate: running exe has no file name, skipping relaunch");
+        return false;
+    };
+    let new_exe = dest.join("Contents/MacOS").join(exe_name);
+    match std::process::Command::new(&new_exe).spawn() {
+        Ok(_) => {
+            tracing::info!(
+                dest = %dest.display(),
+                "relocate: moved to Applications and relaunched — exiting transient instance"
+            );
+            true
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                new_exe = %new_exe.display(),
+                "relocate: copied to /Applications but failed to relaunch from there"
+            );
+            false
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn maybe_relocate_to_applications() -> bool {
+    false
+}
+
+/// The bundle root (`.../Foo.app`) containing `exe`, if `exe` sits in the
+/// standard `Contents/MacOS/` layout. Split out as a pure function so the
+/// path logic is unit-testable without a real `current_exe()`.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn bundle_root(exe: &Path) -> Option<PathBuf> {
+    let macos = exe.parent()?;
+    let contents = macos.parent()?;
+    let bundle = contents.parent()?;
+    (macos.ends_with("MacOS")
+        && contents.ends_with("Contents")
+        && bundle.extension().is_some_and(|e| e == "app"))
+    .then(|| bundle.to_path_buf())
+}
+
+/// Native "Move to Applications Folder?" alert via `osascript` — the same
+/// shell-out pattern already used for AppleScript in
+/// `capture::drm_detector::run_osascript`. Returns `true` only on the
+/// explicit "Move to Applications" button; a dismissed dialog, "Not Now", or
+/// any `osascript` failure (e.g. running headless in CI) all count as "no".
+#[cfg(target_os = "macos")]
+fn prompt_move_to_applications() -> bool {
+    let script = r#"display dialog "Meridian needs to be in your Applications folder to start automatically when you log in. Move it there now?" with title "Move Meridian to Applications?" buttons {"Not Now", "Move to Applications"} default button "Move to Applications""#;
+    std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .output()
+        .is_ok_and(|o| {
+            o.status.success()
+                && String::from_utf8_lossy(&o.stdout).contains("Move to Applications")
+        })
+}
+
+/// Copy `src` (the `.app` bundle) into `/Applications`, replacing any
+/// existing copy there, and return the destination path.
+///
+/// Uses `ditto` — the macOS tool for copying bundles with resource
+/// forks/extended attributes intact, which a plain recursive copy can
+/// silently drop. Tries a plain (non-privileged) copy first since
+/// `/Applications` is group-writable for admin accounts by default; only
+/// falls back to an admin-privileged shell command if that fails (e.g. a
+/// standard, non-admin account).
+#[cfg(target_os = "macos")]
+fn copy_bundle_to_applications(src: &Path) -> Result<PathBuf, String> {
+    let name = src
+        .file_name()
+        .ok_or_else(|| "bundle path has no file name".to_string())?;
+    let dest = Path::new("/Applications").join(name);
+
+    if run_ditto(src, &dest).is_ok_and(|o| o.status.success()) {
+        return Ok(dest);
+    }
+    match run_ditto_privileged(src, &dest) {
+        Ok(o) if o.status.success() => Ok(dest),
+        Ok(o) => Err(format!(
+            "ditto (admin) failed: {}",
+            String::from_utf8_lossy(&o.stderr)
+        )),
+        Err(e) => Err(format!("ditto (admin) spawn failed: {e}")),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn run_ditto(src: &Path, dest: &Path) -> std::io::Result<std::process::Output> {
+    if dest.exists() {
+        std::fs::remove_dir_all(dest)?;
+    }
+    std::process::Command::new("ditto")
+        .arg(src)
+        .arg(dest)
+        .output()
+}
+
+/// Runs `rm -rf <dest>; ditto <src> <dest>` as administrator via
+/// `osascript … with administrator privileges`. The shell command is written
+/// to a temp script and invoked by path rather than inlined into the
+/// AppleScript source, so path contents never need nested shell/AppleScript
+/// quote-escaping.
+#[cfg(target_os = "macos")]
+fn run_ditto_privileged(src: &Path, dest: &Path) -> std::io::Result<std::process::Output> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let script_path =
+        std::env::temp_dir().join(format!("meridian-relocate-{}.sh", std::process::id()));
+    let shell_cmd = format!(
+        "rm -rf {dest} && ditto {src} {dest}",
+        src = shell_quote(src),
+        dest = shell_quote(dest)
+    );
+    std::fs::write(&script_path, format!("#!/bin/sh\nset -e\n{shell_cmd}\n"))?;
+    std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o700))?;
+
+    let quoted_script = script_path
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let out = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(format!(
+            "do shell script \"{quoted_script}\" with administrator privileges"
+        ))
+        .output();
+    let _ = std::fs::remove_file(&script_path);
+    out
+}
+
+/// Single-quote a path for embedding in a `/bin/sh` command, escaping any
+/// literal single quotes it contains.
+#[cfg(target_os = "macos")]
+fn shell_quote(path: &Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', r"'\''"))
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::bundle_root;
+    use std::path::Path;
+
+    #[test]
+    fn resolves_bundle_root_from_dmg_mount() {
+        assert_eq!(
+            bundle_root(Path::new(
+                "/Volumes/Meridian/Meridian.app/Contents/MacOS/Meridian"
+            )),
+            Some(std::path::PathBuf::from("/Volumes/Meridian/Meridian.app"))
+        );
+    }
+
+    #[test]
+    fn resolves_bundle_root_from_translocation() {
+        assert_eq!(
+            bundle_root(Path::new(
+                "/private/var/folders/ab/xyz/T/AppTranslocation/ABC-123/d/Meridian.app/Contents/MacOS/Meridian"
+            )),
+            Some(std::path::PathBuf::from(
+                "/private/var/folders/ab/xyz/T/AppTranslocation/ABC-123/d/Meridian.app"
+            ))
+        );
+    }
+
+    #[test]
+    fn rejects_non_bundle_layout() {
+        assert_eq!(bundle_root(Path::new("/usr/local/bin/meridian-tray")), None);
+    }
+}

--- a/tray/src-tauri/src/state.rs
+++ b/tray/src-tauri/src/state.rs
@@ -25,6 +25,11 @@ pub enum PauseSource {
     /// User paused with no expiry ("Pause indefinitely") — no auto-resume timer;
     /// only a manual "Resume now" clears it. See `commands::pause_indefinitely`.
     Indefinite,
+    /// Auto-paused because free disk space on the `meridian.db` volume fell
+    /// below the low-disk threshold (`meridian::health::platform::meridian_data_low_gb`,
+    /// 2 GB) — writing into a nearly-full disk is how a real `meridian.db` got
+    /// corrupted (torn page allocations under WAL). See `poll::check_disk_space`.
+    DiskLow,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -61,7 +66,7 @@ pub struct StatusPayload {
     /// Unix timestamp (ms) when the current timed pause expires. `None` when
     /// not paused or when paused by a schedule (no fixed end time).
     pub pause_until_ms: Option<u64>,
-    /// `"timed"` | `"schedule"` | `"indefinite"` when capture is actively paused; `None` otherwise.
+    /// `"timed"` | `"schedule"` | `"indefinite"` | `"disk_low"` when capture is actively paused; `None` otherwise.
     pub pause_source: Option<String>,
     /// Display hint for the schedule-paused panel: the work-hours start time
     /// ("09:00"). `None` when not schedule-paused.
@@ -231,6 +236,7 @@ impl AppState {
                 PauseSource::Timed => "timed".to_string(),
                 PauseSource::Schedule => "schedule".to_string(),
                 PauseSource::Indefinite => "indefinite".to_string(),
+                PauseSource::DiskLow => "disk_low".to_string(),
             }),
             schedule_resume_at: self.schedule_resume_at.clone(),
             active_app: active.map(|a| a.app_name.clone()),

--- a/tray/src-tauri/src/sys.rs
+++ b/tray/src-tauri/src/sys.rs
@@ -100,6 +100,66 @@ pub fn is_bundled() -> bool {
     }
 }
 
+/// macOS: `true` unless the running binary sits in a location that won't
+/// survive — a mounted disk image (`/Volumes/…`, read-only and ejected after a
+/// drag-install) or Gatekeeper's App Translocation quarantine
+/// (`…/AppTranslocation/…`, a randomized read-only mount the OS discards).
+///
+/// Shared by two callers that both care about the same failure class:
+/// [`crate::autostart::ensure_enabled_once`] (don't pin a login item to a path
+/// that's about to vanish) and [`crate::relocate::maybe_relocate_to_applications`]
+/// (that's exactly the situation it offers to fix).
+///
+/// Non-macOS: always `true` — Windows Run-key entries and Linux desktop
+/// entries point at the installed path, so the mounted-image failure class
+/// doesn't apply there.
+#[cfg(target_os = "macos")]
+pub(crate) fn running_from_stable_location() -> bool {
+    match std::env::current_exe() {
+        Ok(exe) => path_is_stable(&exe.to_string_lossy()),
+        // Can't resolve our own path ⇒ can't vouch for it.
+        Err(_) => false,
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn running_from_stable_location() -> bool {
+    true
+}
+
+/// The pure string test behind [`running_from_stable_location`], split out so
+/// it can be unit-tested without a real `current_exe()`.
+#[cfg(target_os = "macos")]
+fn path_is_stable(exe_path: &str) -> bool {
+    !exe_path.starts_with("/Volumes/") && !exe_path.contains("/AppTranslocation/")
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod stable_location_tests {
+    use super::path_is_stable;
+
+    #[test]
+    fn rejects_transient_locations() {
+        // Mounted DMG (drag-install source) and translocation quarantine.
+        assert!(!path_is_stable(
+            "/Volumes/Meridian/Meridian.app/Contents/MacOS/Meridian"
+        ));
+        assert!(!path_is_stable(
+            "/private/var/folders/ab/xyz/T/AppTranslocation/ABC-123/d/Meridian.app/Contents/MacOS/Meridian"
+        ));
+    }
+
+    #[test]
+    fn accepts_stable_locations() {
+        assert!(path_is_stable(
+            "/Applications/Meridian.app/Contents/MacOS/Meridian"
+        ));
+        assert!(path_is_stable(
+            "/Users/dev/Applications/Meridian.app/Contents/MacOS/Meridian"
+        ));
+    }
+}
+
 // NOTE: a process-spawning `open_url_detached` (+ its `is_web_url` scheme gate)
 // used to live here for the GitHub device flow's auto-open. That was removed:
 // the device-flow checklist now opens GitHub only when the user clicks its

--- a/tray/src/app.js
+++ b/tray/src/app.js
@@ -148,7 +148,7 @@ function paintOptionHints() {
 function render(status) {
   const healthy = status.ui_reachable && status.healthy
   const hasActive = !!status.active_app
-  const pauseSource = status.pause_source || null // null | 'timed' | 'schedule' | 'indefinite'
+  const pauseSource = status.pause_source || null // null | 'timed' | 'schedule' | 'indefinite' | 'disk_low'
   const isPaused = !!pauseSource
 
   brandMark.classList.toggle('down', !healthy)
@@ -204,6 +204,11 @@ function render(status) {
     statusTitle.textContent = 'Outside work hours'
     const resumeAt = status.schedule_resume_at || ''
     statusSub.textContent = resumeAt ? `Resumes at ${resumeAt}` : 'Work hours not active'
+    primaryBtn.hidden = true
+  } else if (pauseSource === 'disk_low') {
+    daemonUnhealthy = false
+    statusTitle.textContent = 'Capture paused'
+    statusSub.textContent = 'Disk space is low - free up space to resume'
     primaryBtn.hidden = true
   } else if (hasActive) {
     daemonUnhealthy = false

--- a/ui/__tests__/windows-notification-permission.test.ts
+++ b/ui/__tests__/windows-notification-permission.test.ts
@@ -11,6 +11,12 @@ import { readFileSync } from 'fs'
 // is a string-source guard (the same pattern as the Settings → Notifications
 // guard) because steps.tsx pulls in the whole React/Clerk import graph.
 //
+// The assertions are ANCHORED to the specific declaration they guard — an
+// earlier version scanned the whole file with `[\s\S]*` and matched the macOS
+// step's `id: 'permissions'` and the integrations step's `canNext: () => true`,
+// so it passed against the very regressions it named. Each assertion below was
+// verified to FAIL when the invariant it guards is mutated.
+//
 // Related backend: tray/src-tauri/src/commands/setup.rs (check_/request_notifications),
 // tray/src-tauri/src/sys.rs (windows_permission_state), commands/system.rs
 // (open_permission_pane "notifications" → ms-settings:notifications).
@@ -18,33 +24,40 @@ import { readFileSync } from 'fs'
 const uiRoot = import.meta.dir + '/..'
 const readSrc = (rel: string): string => readFileSync(uiRoot + '/' + rel, 'utf8')
 
+/** The body of a top-level `const NAME … = {` declaration: from the declaration
+ *  to the first column-0 `}`. Scoped so an assertion can't match an unrelated
+ *  step elsewhere in the file. */
+function declBlock(src: string, marker: string): string {
+  const start = src.indexOf(marker)
+  if (start < 0) throw new Error(`marker not found: ${marker}`)
+  return src.slice(start).split('\n}')[0]
+}
+
 describe('windows notification permission onboarding', () => {
   const steps = readSrc('app/setup/steps.tsx')
 
-  it('does not drop the whole permissions step on Windows', () => {
-    // The old behaviour filtered the step out entirely — the regression this
-    // feature reverses. If this reappears, Windows loses notification onboarding.
-    expect(steps).not.toContain("filter((s) => s.id !== 'permissions')")
-  })
-
-  it('swaps in a notifications-only variant that keeps id:permissions', () => {
-    expect(steps).toContain('WINDOWS_NOTIFICATIONS_STEP')
-    // buildSteps must map the permissions step to the Windows variant, not remove it.
-    expect(steps).toMatch(/platform === 'windows'[\s\S]*s\.id === 'permissions'[\s\S]*WINDOWS_NOTIFICATIONS_STEP/)
-    // Same id as macOS so the check_notifications poll (page.tsx gates it on
-    // steps[step].id === 'permissions') keeps firing on Windows.
-    expect(steps).toMatch(/WINDOWS_NOTIFICATIONS_STEP[\s\S]*id: 'permissions'/)
+  it('keeps the Windows step under id:permissions so the poll still fires', () => {
+    // page.tsx gates the check_notifications poll on steps[step].id === 'permissions'.
+    const winStep = declBlock(steps, 'const WINDOWS_NOTIFICATIONS_STEP')
+    expect(winStep).toContain("id: 'permissions'")
   })
 
   it('never blocks Continue on the optional Windows notifications card', () => {
-    // Notifications is optional on both OSes; on Windows it is the only card, so
-    // the step must not gate navigation.
-    expect(steps).toMatch(/WINDOWS_NOTIFICATIONS_STEP[\s\S]*canNext: \(\) => true/)
+    const winStep = declBlock(steps, 'const WINDOWS_NOTIFICATIONS_STEP')
+    expect(winStep).toContain('canNext: () => true')
+  })
+
+  it('swaps the permissions step for the Windows variant instead of dropping it', () => {
+    const build = steps.slice(steps.indexOf('export function buildSteps'))
+    // The Windows branch must reference the variant (a swap)…
+    expect(build).toContain('WINDOWS_NOTIFICATIONS_STEP')
+    // …and must NOT filter the step list — the old drop, in any formatting.
+    expect(build).not.toMatch(/\.filter\(/)
   })
 
   it('keeps a notifications entry the Windows card can render', () => {
-    const data = readSrc('app/setup/data.ts')
-    expect(data).toMatch(/id: 'notifications'[\s\S]*pane: 'notifications'/)
-    expect(data).toContain('required: false')
+    const notif = declBlock(readSrc('app/setup/data.ts'), "id: 'notifications'")
+    expect(notif).toContain("pane: 'notifications'")
+    expect(notif).toContain('required: false')
   })
 })

--- a/ui/__tests__/windows-notification-permission.test.ts
+++ b/ui/__tests__/windows-notification-permission.test.ts
@@ -1,0 +1,50 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+
+// Guards the Windows notification onboarding in the setup wizard. Windows has no
+// TCC-style consent for Accessibility/Screen Recording, so those cards are
+// macOS-only — but Notifications IS a real per-app setting on Windows (WinRT
+// ToastNotifier::Setting), so the Permissions step must NOT be dropped there.
+// It is swapped for a notifications-only variant that keeps id:'permissions' so
+// page.tsx's check_notifications poll (gated on that id) still fires. This test
+// is a string-source guard (the same pattern as the Settings → Notifications
+// guard) because steps.tsx pulls in the whole React/Clerk import graph.
+//
+// Related backend: tray/src-tauri/src/commands/setup.rs (check_/request_notifications),
+// tray/src-tauri/src/sys.rs (windows_permission_state), commands/system.rs
+// (open_permission_pane "notifications" → ms-settings:notifications).
+
+const uiRoot = import.meta.dir + '/..'
+const readSrc = (rel: string): string => readFileSync(uiRoot + '/' + rel, 'utf8')
+
+describe('windows notification permission onboarding', () => {
+  const steps = readSrc('app/setup/steps.tsx')
+
+  it('does not drop the whole permissions step on Windows', () => {
+    // The old behaviour filtered the step out entirely — the regression this
+    // feature reverses. If this reappears, Windows loses notification onboarding.
+    expect(steps).not.toContain("filter((s) => s.id !== 'permissions')")
+  })
+
+  it('swaps in a notifications-only variant that keeps id:permissions', () => {
+    expect(steps).toContain('WINDOWS_NOTIFICATIONS_STEP')
+    // buildSteps must map the permissions step to the Windows variant, not remove it.
+    expect(steps).toMatch(/platform === 'windows'[\s\S]*s\.id === 'permissions'[\s\S]*WINDOWS_NOTIFICATIONS_STEP/)
+    // Same id as macOS so the check_notifications poll (page.tsx gates it on
+    // steps[step].id === 'permissions') keeps firing on Windows.
+    expect(steps).toMatch(/WINDOWS_NOTIFICATIONS_STEP[\s\S]*id: 'permissions'/)
+  })
+
+  it('never blocks Continue on the optional Windows notifications card', () => {
+    // Notifications is optional on both OSes; on Windows it is the only card, so
+    // the step must not gate navigation.
+    expect(steps).toMatch(/WINDOWS_NOTIFICATIONS_STEP[\s\S]*canNext: \(\) => true/)
+  })
+
+  it('keeps a notifications entry the Windows card can render', () => {
+    const data = readSrc('app/setup/data.ts')
+    expect(data).toMatch(/id: 'notifications'[\s\S]*pane: 'notifications'/)
+    expect(data).toContain('required: false')
+  })
+})

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -26,8 +26,9 @@ export default function SetupWizard() {
   const [done, setDone] = useState(false)
   const [err, setErr] = useState('')
 
-  // Platform gates which steps exist — Permissions is macOS-only (Windows
-  // capture needs no TCC-style grant; see buildSteps in ./steps.tsx). `null`
+  // Platform shapes the Permissions step — macOS shows the two TCC grants +
+  // notifications, Windows shows notifications only (no TCC analogue there; see
+  // buildSteps in ./steps.tsx). The step count is the same on both. `null`
   // until resolved. The Welcome screen (the only way past `welcome`) blocks
   // "Get started" until this resolves, so `steps` can never change shape
   // out from under a `step` index the user already navigated to — a late
@@ -193,6 +194,7 @@ export default function SetupWizard() {
   }, [])
 
   const wiz: Wiz = {
+    platform,
     perms, openPane, grantScreen, grantNotifications,
     integrations, refetchIntegrations,
     signedInEmail, onSignedIn,

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -64,13 +64,31 @@ export interface Wiz {
 // alone — the two TCC grants have no consent analogue there (see the step-meta
 // note below), so their cards would be permanent always-green no-ops.
 function PermissionsBody({ wiz }: { wiz: Wiz }) {
-  const cards = wiz.platform === 'windows' ? PERMISSIONS.filter((p) => p.id === 'notifications') : PERMISSIONS
+  const isWin = wiz.platform === 'windows'
+  const cards = isWin ? PERMISSIONS.filter((p) => p.id === 'notifications') : PERMISSIONS
   // Only Screen Recording lives locally on the Mac; on Windows the same
   // reassurance holds, just for "this PC".
-  const device = wiz.platform === 'windows' ? 'PC' : 'Mac'
+  const device = isWin ? 'PC' : 'Mac'
+  // On Windows the notifications card IS the whole step, so when PermCard hides
+  // it — no plugin (`unbundled tauri dev`) or a WinRT probe that returned None
+  // in a packaged build — the step would otherwise render blank. Show a
+  // fallback line so there is always something to read. (On macOS the same hide
+  // still leaves the two TCC cards, so no fallback is needed there.)
+  const notifHidden = isWin && wiz.perms.notifications === 'unavailable'
   return (
     <div className="flex flex-col" style={{ gap: 9 }}>
-      {cards.map((p) => <PermCard key={p.id} p={p} wiz={wiz} />)}
+      {notifHidden
+        ? <Row tone="surface">
+            <span className="flex items-center justify-center shrink-0" style={{
+              width: 34, height: 34, borderRadius: 10,
+              background: 'var(--t-box)', color: 'var(--t-faint)', border: '0.5px solid var(--t-card-border)',
+            }}><PermIcon icon="bell" /></span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <span style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--t-title)' }}>Notifications</span>
+              <p style={{ fontSize: 11.5, lineHeight: 1.4, color: 'var(--t-muted)', marginTop: 3 }}>Notification settings aren&apos;t available in this build - you can turn them on later from Windows Settings.</p>
+            </div>
+          </Row>
+        : cards.map((p) => <PermCard key={p.id} p={p} wiz={wiz} />)}
       <p className="flex items-start" style={{ gap: 7, fontSize: 11, lineHeight: 1.5, color: 'var(--t-muted)', marginTop: 3 }}>
         <span style={{ width: 5, height: 5, borderRadius: 99, background: 'var(--color-state-approved)', marginTop: 5, flexShrink: 0 }} />
         Your screen, tasks, and worklogs stay on this {device} and are never uploaded. We send usage stats - daily focus time, app version, and your email once you sign in - to improve Meridian, never your content.
@@ -339,7 +357,9 @@ const PERMISSIONS_STEP: StepMeta = {
 const WINDOWS_NOTIFICATIONS_STEP: StepMeta = {
   id: 'permissions', n: '01', label: 'Notifications', kicker: 'Alerts',
   title: 'Turn on notifications',
-  subtitle: 'Let Meridian nudge you when a worklog draft is ready or your plan needs attention. Optional and quiet by default - you control every type in Settings.',
+  // Carries the WHY; the card below carries the WHAT (which events, quiet-hours)
+  // so the user doesn't read the same sentence twice in one viewport.
+  subtitle: 'Stay in the loop without watching the menu bar. Optional - turn it on now, or anytime from Settings.',
   Body: PermissionsBody,
   status: (s) => notifSummary(s.perms.notifications),
   canNext: () => true,

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -9,7 +9,7 @@
 import type { ReactNode } from 'react'
 import { Btn, Check, DISPLAY, Kicker, PermIcon, Row } from './atoms'
 import { PERMISSIONS } from './data'
-import type { NotifState } from './data'
+import type { NotifState, PermissionMeta } from './data'
 import type { IntegrationsResponse } from '@/lib/api-types'
 import { TRACKERS, availableTrackers, availableTrackerNames } from '@/lib/integrations'
 import { llmProvider, LLM_INTRO_BODY, LLM_INTRO_TITLE, type LlmProviderId } from '@/lib/llm-providers'
@@ -19,6 +19,10 @@ import { SignInWidget } from './signin'
 
 /** The live wizard handle page.tsx builds and threads to every step body. */
 export interface Wiz {
+  // The resolved OS (`get_platform`). Shapes the Permissions step: macOS shows
+  // the two TCC grants + notifications; Windows shows notifications only (see
+  // the step-meta note below and `buildSteps`). `null` until resolved.
+  platform: string | null
   // Step 1 — permissions (live, polled every 2 s). The two TCC grants are
   // booleans; notifications is tri-state (see `NotifState`) because deny and
   // not-yet-asked need different grant actions.
@@ -55,52 +59,72 @@ export interface Wiz {
 }
 
 // ── STEP 1 — Permissions ──────────────────────────────────────────────────────
+// One card per OS permission. macOS shows all three (Accessibility + Screen
+// Recording required, Notifications optional); Windows shows Notifications
+// alone — the two TCC grants have no consent analogue there (see the step-meta
+// note below), so their cards would be permanent always-green no-ops.
 function PermissionsBody({ wiz }: { wiz: Wiz }) {
+  const cards = wiz.platform === 'windows' ? PERMISSIONS.filter((p) => p.id === 'notifications') : PERMISSIONS
+  // Only Screen Recording lives locally on the Mac; on Windows the same
+  // reassurance holds, just for "this PC".
+  const device = wiz.platform === 'windows' ? 'PC' : 'Mac'
   return (
     <div className="flex flex-col" style={{ gap: 9 }}>
-      {PERMISSIONS.map((p) => {
-        const notif = p.id === 'notifications'
-        // Unbundled runs (`tauri dev`) have no notification plugin at all —
-        // nothing to grant, so the card hides rather than dead-ends.
-        if (notif && wiz.perms.notifications === 'unavailable') return null
-        const granted = notif ? wiz.perms.notifications === 'granted' : !!wiz.perms[p.id]
-        return (
-          <Row key={p.id} tone={granted ? 'tint' : 'surface'}>
-            <span className="flex items-center justify-center shrink-0" style={{
-              width: 34, height: 34, borderRadius: 10,
-              background: granted ? 'color-mix(in srgb, var(--color-state-proposal) 12%, transparent)' : 'var(--t-box)',
-              color: granted ? 'var(--color-state-proposal)' : 'var(--t-faint)',
-              border: '0.5px solid var(--t-card-border)',
-            }}><PermIcon icon={p.icon} /></span>
-
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div className="flex items-center" style={{ gap: 8 }}>
-                <span style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--t-title)' }}>{p.name}</span>
-                {!notif && <span className="mt-chip" style={{ color: 'var(--t-muted)', border: '0.5px solid var(--t-card-border)', borderRadius: 4, padding: '1px 5px' }}>{p.required ? 'REQUIRED' : 'OPTIONAL'}</span>}
-              </div>
-              <p style={{ fontSize: 11.5, lineHeight: 1.4, color: 'var(--t-muted)', marginTop: 3 }}>{p.desc}</p>
-            </div>
-
-            <div className="shrink-0">
-              {granted
-                ? <span className="flex items-center" style={{ gap: 6, fontSize: 12, color: 'var(--color-state-approved)', fontWeight: 500 }}><Check size={15} color="var(--color-state-approved)" />Granted</span>
-                : notif
-                  // 'prompt' → the button surfaces the one-shot OS dialog;
-                  // 'denied' → macOS won't re-prompt, so it opens the
-                  // Notifications pane directly (grantNotifications skips the
-                  // pointless re-request when told it's already denied).
-                  ? <Btn size="sm" variant="secondary" onClick={() => wiz.grantNotifications(wiz.perms.notifications === 'denied')}>{wiz.perms.notifications === 'denied' ? 'Open Settings' : 'Allow'}</Btn>
-                  : <Btn size="sm" variant="secondary" onClick={() => p.id === 'screen' ? wiz.grantScreen() : wiz.openPane(p.pane)}>Open Settings</Btn>}
-            </div>
-          </Row>
-        )
-      })}
+      {cards.map((p) => <PermCard key={p.id} p={p} wiz={wiz} />)}
       <p className="flex items-start" style={{ gap: 7, fontSize: 11, lineHeight: 1.5, color: 'var(--t-muted)', marginTop: 3 }}>
         <span style={{ width: 5, height: 5, borderRadius: 99, background: 'var(--color-state-approved)', marginTop: 5, flexShrink: 0 }} />
-        Your screen, tasks, and worklogs stay on this Mac and are never uploaded. We send usage stats - daily focus time, app version, and your email once you sign in - to improve Meridian, never your content.
+        Your screen, tasks, and worklogs stay on this {device} and are never uploaded. We send usage stats - daily focus time, app version, and your email once you sign in - to improve Meridian, never your content.
       </p>
     </div>
   )
+}
+
+// A single OS-permission card, shared by macOS and Windows. Notifications is
+// tri-state (deny and not-yet-asked need different grant actions); the two TCC
+// grants are booleans.
+function PermCard({ p, wiz }: { p: PermissionMeta; wiz: Wiz }) {
+  const notif = p.id === 'notifications'
+  // Unbundled runs (`tauri dev`) have no notification plugin at all — nothing
+  // to grant, so the card hides rather than dead-ends.
+  if (notif && wiz.perms.notifications === 'unavailable') return null
+  const granted = notif ? wiz.perms.notifications === 'granted' : !!wiz.perms[p.id]
+  return (
+    <Row tone={granted ? 'tint' : 'surface'}>
+      <span className="flex items-center justify-center shrink-0" style={{
+        width: 34, height: 34, borderRadius: 10,
+        background: granted ? 'color-mix(in srgb, var(--color-state-proposal) 12%, transparent)' : 'var(--t-box)',
+        color: granted ? 'var(--color-state-proposal)' : 'var(--t-faint)',
+        border: '0.5px solid var(--t-card-border)',
+      }}><PermIcon icon={p.icon} /></span>
+
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div className="flex items-center" style={{ gap: 8 }}>
+          <span style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--t-title)' }}>{p.name}</span>
+          {!notif && <span className="mt-chip" style={{ color: 'var(--t-muted)', border: '0.5px solid var(--t-card-border)', borderRadius: 4, padding: '1px 5px' }}>{p.required ? 'REQUIRED' : 'OPTIONAL'}</span>}
+        </div>
+        <p style={{ fontSize: 11.5, lineHeight: 1.4, color: 'var(--t-muted)', marginTop: 3 }}>{p.desc}</p>
+      </div>
+
+      <div className="shrink-0">
+        {granted
+          ? <span className="flex items-center" style={{ gap: 6, fontSize: 12, color: 'var(--color-state-approved)', fontWeight: 500 }}><Check size={15} color="var(--color-state-approved)" />Granted</span>
+          : notif
+            // 'prompt' → the button surfaces the one-shot OS dialog (macOS only —
+            // Windows reports only granted/denied, never prompt);
+            // 'denied' → the OS won't re-prompt, so it opens the Notifications
+            // pane directly (grantNotifications skips the pointless re-request
+            // when told it's already denied).
+            ? <Btn size="sm" variant="secondary" onClick={() => wiz.grantNotifications(wiz.perms.notifications === 'denied')}>{wiz.perms.notifications === 'denied' ? 'Open Settings' : 'Allow'}</Btn>
+            : <Btn size="sm" variant="secondary" onClick={() => p.id === 'screen' ? wiz.grantScreen() : wiz.openPane(p.pane)}>Open Settings</Btn>}
+      </div>
+    </Row>
+  )
+}
+
+/** Rail/summary label for the optional Notifications card on Windows, where it
+ *  is the whole permissions step. */
+function notifSummary(n: NotifState | null): string {
+  return n === 'granted' ? 'Enabled' : n === 'denied' ? 'Off' : 'Optional'
 }
 
 // ── STEP 2 — Integrations ─────────────────────────────────────────────────────
@@ -236,8 +260,14 @@ export function Welcome({ onBegin, steps, ready, error, onRetry }: {
 export function Completion({ wiz }: { wiz: Wiz }) {
   const connected = TRACKERS.filter((t) => wiz.integrations?.[t.id])
   const grantedCount = [wiz.perms.accessibility, wiz.perms.screen].filter(Boolean).length
+  // macOS summarises the two TCC grants; Windows has no such step — only the
+  // optional Notifications card — so it reports that instead of "2 of 2 granted",
+  // which would count permissions Windows never actually prompts for.
+  const permsLine = wiz.platform === 'windows'
+    ? { k: 'Notifications', v: notifSummary(wiz.perms.notifications) }
+    : { k: 'Permissions', v: `${grantedCount} of 2 granted` }
   const lines = [
-    { k: 'Permissions', v: `${grantedCount} of 2 granted` },
+    permsLine,
     { k: 'Intelligence', v: llmProvider(wiz.provider).name },
     { k: 'Connected', v: connected.length ? connected.map((c) => c.name).join(', ') : 'None yet' },
   ]
@@ -279,24 +309,44 @@ export interface StepMeta {
   canNext: (w: Wiz) => boolean
 }
 
-// Permissions stays first on macOS (capture needs them); the AI-provider
+// Permissions stays first (capture needs the grants on macOS); the AI-provider
 // choice comes last so the user has connected their trackers and signed in
 // before picking which model writes their summaries.
 //
-// Permissions is macOS-only: Windows capture (UIA + WGC) has no TCC-style
-// consent system — screenpipe_a11y::platform::windows reports every grant as
-// already true — so there is nothing for that step to request, and its copy
-// ("Two macOS permissions...") is actively wrong on Windows. `buildSteps`
-// drops it entirely there rather than rendering an always-green no-op card.
+// The step is platform-SHAPED, not platform-dropped. macOS capture needs
+// Accessibility + Screen Recording — TCC grants with no analogue on Windows,
+// where UIA + WGC capture needs no consent (screenpipe_a11y::platform::windows
+// reports every one as already true) — so those two cards, and the "Two macOS
+// permissions…" copy, are macOS-only. Notifications, though, is a real per-app
+// setting on BOTH OSes (macOS UNUserNotificationCenter, Windows WinRT
+// ToastNotifier::Setting), so Windows keeps a notifications-only variant of
+// this step (`WINDOWS_NOTIFICATIONS_STEP`) rather than losing notification
+// onboarding entirely. Both variants keep id:'permissions' so page.tsx's
+// check_notifications poll fires on either.
+const PERMISSIONS_STEP: StepMeta = {
+  id: 'permissions', n: '01', label: 'Permissions', kicker: 'Access',
+  title: 'Let Meridian see your work',
+  subtitle: "Two macOS permissions let Meridian recognise what you're focused on. Read locally, never uploaded.",
+  Body: PermissionsBody,
+  status: (s) => { const g = [s.perms.accessibility, s.perms.screen].filter(Boolean).length; return g ? `${g} granted` : 'Not granted' },
+  canNext: (s) => !!(s.perms.accessibility && s.perms.screen),
+}
+
+// Windows variant: notifications is the only user-settable permission there and
+// it's optional (on by default for most apps), so this never gates Continue.
+// The card, grant action, and deny→Settings recovery are all shared with macOS
+// via PermCard — only the copy and the never-blocking gate differ.
+const WINDOWS_NOTIFICATIONS_STEP: StepMeta = {
+  id: 'permissions', n: '01', label: 'Notifications', kicker: 'Alerts',
+  title: 'Turn on notifications',
+  subtitle: 'Let Meridian nudge you when a worklog draft is ready or your plan needs attention. Optional and quiet by default - you control every type in Settings.',
+  Body: PermissionsBody,
+  status: (s) => notifSummary(s.perms.notifications),
+  canNext: () => true,
+}
+
 const ALL_STEPS: StepMeta[] = [
-  {
-    id: 'permissions', n: '01', label: 'Permissions', kicker: 'Access',
-    title: 'Let Meridian see your work',
-    subtitle: "Two macOS permissions let Meridian recognise what you're focused on. Read locally, never uploaded.",
-    Body: PermissionsBody,
-    status: (s) => { const g = [s.perms.accessibility, s.perms.screen].filter(Boolean).length; return g ? `${g} granted` : 'Not granted' },
-    canNext: (s) => !!(s.perms.accessibility && s.perms.screen),
-  },
+  PERMISSIONS_STEP,
   {
     id: 'integrations', n: '02', label: 'Integrations', kicker: 'Project tools',
     title: 'Connect your trackers',
@@ -327,9 +377,12 @@ const ALL_STEPS: StepMeta[] = [
   },
 ]
 
-/** Platform-specific step list. `n` is renumbered to the filtered position so
- *  the rail never shows a gap (e.g. "02, 03, 04" with only three steps). */
+/** Platform-specific step list. On Windows the Permissions step is swapped for
+ *  its notifications-only variant (same id, so the poll still fires); the count
+ *  is unchanged. `n` is renumbered to position so the rail never shows a gap. */
 export function buildSteps(platform: string | null): StepMeta[] {
-  const steps = platform === 'windows' ? ALL_STEPS.filter((s) => s.id !== 'permissions') : ALL_STEPS
+  const steps = platform === 'windows'
+    ? ALL_STEPS.map((s) => (s.id === 'permissions' ? WINDOWS_NOTIFICATIONS_STEP : s))
+    : ALL_STEPS
   return steps.map((s, i) => ({ ...s, n: String(i + 1).padStart(2, '0') }))
 }


### PR DESCRIPTION
## What does this PR do?

<!-- One paragraph. Why is this change needed? What does it do? -->

## How was it tested?

<!-- What did you run? Paste relevant output, screenshots, or test results. -->

- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo fmt --check` passes
- [ ] UI builds (`cd ui && npm run build`)
- [ ] Manually tested the relevant flow

## Checklist

- [ ] Branch named `type/short-description`
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] New `.rs`/`.ts`/`.tsx` files start with the file-header comment (see CLAUDE.md)
- [ ] New migrations are numbered and don't modify existing ones
- [ ] No secrets, credentials, or `.env` files committed

## Related issues

<!-- Closes #NNN -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Capture now pauses automatically when disk space is low and resumes after space is recovered.
  * Added clear disk-space warnings and pause status in the tray interface.
  * Windows setup now includes optional notification permission onboarding without blocking completion.
* **Bug Fixes**
  * Improved reliability when starting the backend and signing in with CLI-based integrations.
  * Database migration and daemon recovery are more dependable.
* **Release Improvements**
  * Staging macOS builds now receive the same notarization and verification checks as stable builds.
  * Improved cleanup of outdated build caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->