### PR TITLE
ci: add sccache alongside rust-cache to degrade more gracefully on drift

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -83,12 +83,21 @@ env:
   CARGO_INCREMENTAL: "0"
   CARGO_NET_RETRY: "3"
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  # sccache — see release-build.yml's "Set up sccache" step comment for the
+  # full reasoning. Must match release-build.yml's compile jobs for the cache
+  # this workflow warms to actually help them (same principle as the
+  # shared-key comments below).
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   warm-macos:
     name: Warm the aarch64 release cache
     runs-on: macos-26
     timeout-minutes: 60
+    permissions:
+      contents: read
+      actions: write # sccache's GHA cache backend needs this to SAVE entries
     steps:
       - uses: actions/checkout@v4
         with:
@@ -107,6 +116,10 @@ jobs:
         with:
           toolchain: "1.93.1"
           targets: aarch64-apple-darwin
+
+      # See release-build.yml's "Set up sccache" step for the full reasoning.
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -187,6 +200,9 @@ jobs:
     name: Warm the Windows x86_64 release cache
     runs-on: windows-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
+      actions: write # sccache's GHA cache backend needs this to SAVE entries
     defaults:
       run:
         # Same reasoning as release-build.yml's Windows job: every step here
@@ -227,6 +243,10 @@ jobs:
           toolchain: "1.93.1"
           # No explicit target: windows-latest's host triple
           # (x86_64-pc-windows-msvc) is exactly what we ship.
+
+      # See release-build.yml's "Set up sccache" step for the full reasoning.
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -169,6 +169,11 @@ env:
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  # sccache — see the "Set up sccache" step comment in each compile job for
+  # why this runs alongside rust-cache rather than replacing it. Harmless on
+  # jobs that never invoke cargo (prepare, publish).
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   # ── Stage 1: cheap validation + a draft release for everyone to upload into ──
@@ -297,6 +302,7 @@ jobs:
     timeout-minutes: 60 # a hung `notarytool --wait` otherwise burns 10x-billed minutes indefinitely
     permissions:
       contents: write # uploads assets into the draft
+      actions: write # sccache's GHA cache backend needs this to SAVE entries, not just read
     strategy:
       # One flaky architecture must not kill the other's artifacts — and we want
       # its timing either way.
@@ -358,6 +364,26 @@ jobs:
         with:
           toolchain: "1.93.1"
           targets: ${{ matrix.target }}
+
+      # Complements rust-cache below, doesn't replace it. rust-cache restores
+      # a whole target/ tarball keyed on Cargo.lock — great when it matches
+      # exactly, but a tag-triggered build can only ever restore from ITS OWN
+      # ref or `main` (GitHub's cache scoping), never from `pre-main` directly.
+      # A staging release cut from a `pre-main` that has drifted from `main`
+      # (routine — pre-main accumulates merges between releases) gets a
+      # partially-stale target/, and rust-cache's fingerprint mismatch forces
+      # full recompilation of anything that LOOKS different, even crates whose
+      # actual compiled output would be identical. sccache intercepts at the
+      # individual rustc-invocation level regardless of why cargo decided to
+      # invoke it, so it can still return a hit there. Free GHA cache backend
+      # (SCCACHE_GHA_ENABLED below) — same underlying service as rust-cache,
+      # so still ref-scoped in principle, but per-object rather than
+      # per-tarball, which degrades far more gracefully on drift. Does NOT
+      # cover the vendored-OpenSSL C compile or the Swift static-lib build
+      # (tauri-plugin-notifications) — that's still rust-cache's job via its
+      # cache-directories entry below.
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -652,6 +678,7 @@ jobs:
     timeout-minutes: 60 # same cap as macos — bound a hung build instead of falling back to GitHub's 360-minute default
     permissions:
       contents: write # uploads assets into the draft
+      actions: write # sccache's GHA cache backend needs this to SAVE entries, not just read
     env:
       # Same compile-time constants the macOS job bakes in (see its `env:`
       # comment) — these are cross-platform values (OAuth client ids, public
@@ -732,6 +759,11 @@ jobs:
           # is exactly what we ship, so plain `cargo build --release` already
           # produces it — unlike the macOS job, which cross-arch-targets a
           # single shared runner.
+
+      # See the macOS job's "Set up sccache" step for the full reasoning —
+      # identical here, complements rust-cache rather than replacing it.
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary
- Adds sccache (`mozilla-actions/sccache-action` v0.0.11, latest stable) to `release-build.yml`'s macOS/Windows compile jobs and `cache-warm.yml`'s equivalent warm jobs, alongside the existing `rust-cache` setup (not replacing it).
- **Why**: `rust-cache` restores a whole `target/` tarball keyed on `Cargo.lock` — great when it matches exactly, but a tag-triggered build can only ever restore from its own ref or `main` (GitHub's cache scoping), never `pre-main` directly. A staging release cut from a `pre-main` that has drifted from `main` (routine, since `pre-main` accumulates merges between releases) gets a partially-stale `target/`, and `rust-cache`'s fingerprint mismatch forces full recompilation of anything that *looks* different — even crates whose actual compiled output would be identical. sccache intercepts at the individual `rustc`-invocation level regardless of why cargo decided to invoke it, so it can still return a hit on top of a partially-stale `rust-cache` restore.
- **Why not replace `rust-cache`**: it still covers things sccache structurally cannot touch — the vendored-OpenSSL C compile and the Swift static-lib build (`tauri-plugin-notifications`). Removing it would be a real regression.
- **Honest caveat**: using the free GHA cache backend, which is still bound by the same ref-scoping as `rust-cache` underneath (own ref or `main` only) — this helps because it's per-object rather than per-tarball (degrades gracefully instead of all-or-nothing), but does **not** fully eliminate the `pre-main`-vs-`main` staleness problem the way a ref-independent remote backend (S3/R2) would. That tradeoff was discussed explicitly and the free backend chosen deliberately (no new cost/infra).
- Added `actions: write` permission to the relevant jobs — sccache's GHA backend needs it to *save* cache entries, not just read them.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, watch the next release build (staging or stable) to confirm sccache actually reports cache hits (check the job summary/logs for sccache stats) and observe whether drift-affected builds compile noticeably faster than before