### PR TITLE
fix: address CodeRabbit findings on PR #630

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -375,9 +375,20 @@ jobs:
             prefix="${pair%%|*}"
             ref="${pair##*|}"
             echo "=== ${prefix} (${ref}) ==="
-            stale=$(gh api "repos/${{ github.repository }}/actions/caches?per_page=100&ref=${ref}" \
+            # --paginate: without it, per_page=100 silently caps this pair at
+            # its first 100 caches with no follow-up page — this repo already
+            # climbed to 42 caches after a single warm run, so a busy prefix
+            # exceeding 100 would hide older stale entries from pruning
+            # entirely, the exact unbounded-growth failure this job exists to
+            # close. `|| true` on the listing itself: a transient gh api
+            # failure (rate limit, etc.) on one pair must not abort the whole
+            # script under set -euo pipefail — skip just this pair and let
+            # the next scheduled run retry it, same tolerance the delete call
+            # below already has.
+            stale=$(gh api --paginate "repos/${{ github.repository }}/actions/caches?per_page=100&ref=${ref}" \
               --jq --arg p "$prefix" \
-              '[.actions_caches[] | select(.key | startswith($p))] | sort_by(.created_at) | reverse | .[1:] | .[].id')
+              '[.actions_caches[] | select(.key | startswith($p))] | sort_by(.created_at) | reverse | .[1:] | .[].id') \
+              || { echo "::warning::failed to list caches for ${prefix} (${ref}), skipping this pair"; continue; }
             if [ -z "$stale" ]; then
               echo "nothing to prune"
               continue

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -578,8 +578,15 @@ jobs:
         run: |
           set -euo pipefail
           echo "→ ${CHANNEL}: signing AND notarizing"
-          npx tauri bundle --target ${{ matrix.target }} --bundles app,dmg \
-            ${{ needs.prepare.outputs.channel == 'staging' && '--config src-tauri/tauri.staging.conf.json' || '' }}
+          # Uses the already-bound $CHANNEL rather than re-interpolating
+          # ${{ }} into this script a second time — the exact
+          # template-injection shape this file's own convention (see the
+          # RAW_TAG/VERSION binding notes elsewhere) says to avoid.
+          config_flag=""
+          if [ "${CHANNEL}" = "staging" ]; then
+            config_flag="--config src-tauri/tauri.staging.conf.json"
+          fi
+          npx tauri bundle --target ${{ matrix.target }} --bundles app,dmg ${config_flag}
 
       - name: Notarize and staple the DMG
         # Runs on every channel now — see the note on the bundle step above for

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -579,9 +579,11 @@ fn command_for_resolved_cli(path: &std::path::Path) -> Command {
     let mut cmd = Command::new(path);
     if let Some(dir) = path.parent() {
         let existing = std::env::var_os("PATH").unwrap_or_default();
-        let mut new_path = std::ffi::OsString::from(dir);
-        new_path.push(":");
-        new_path.push(existing);
+        // std::env::join_paths/split_paths, not a hardcoded `:` — this is called
+        // on every platform (cursor_sign_in/codex_sign_in/claude_sign_in all use
+        // it directly), and Windows PATH entries are `;`-separated, not `:`.
+        let dirs = std::iter::once(dir.to_path_buf()).chain(std::env::split_paths(&existing));
+        let new_path = std::env::join_paths(dirs).unwrap_or(existing);
         cmd.env("PATH", new_path);
     }
     cmd

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -213,19 +213,31 @@ async fn ensure_daemon_running(home: &Path) {
         if !matching_daemon_pids(&daemon_bin).await.is_empty() {
             return; // already up — nothing to do
         }
-        let started_via_task = tokio::process::Command::new("schtasks")
+        let queued_via_task = tokio::process::Command::new("schtasks")
             .args(["/Run", "/TN", WINDOWS_TASK_NAME])
             .no_window()
             .output()
             .await
             .map(|o| o.status.success())
             .unwrap_or(false);
-        if started_via_task {
-            tracing::info!(
+        if queued_via_task {
+            // `/Run` success only confirms the task was QUEUED — it's
+            // registered `/SC ONLOGON`, so a successful exit here doesn't
+            // mean the daemon actually launched. Give it a moment, then
+            // verify before trusting it; otherwise fall through to the
+            // direct spawn below rather than leaving the daemon down.
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            if !matching_daemon_pids(&daemon_bin).await.is_empty() {
+                tracing::info!(
+                    task = WINDOWS_TASK_NAME,
+                    "backend_install: restarted daemon via scheduled task"
+                );
+                return;
+            }
+            tracing::warn!(
                 task = WINDOWS_TASK_NAME,
-                "backend_install: restarted daemon via scheduled task"
+                "backend_install: scheduled task ran but the daemon isn't up yet, falling back to a direct spawn"
             );
-            return;
         }
         match tokio::process::Command::new(&daemon_bin)
             .no_window()

--- a/tray/src-tauri/src/poll/mod.rs
+++ b/tray/src-tauri/src/poll/mod.rs
@@ -273,7 +273,16 @@ async fn check_disk_space(state: &Arc<Mutex<AppState>>, pool: &meridian_core::Sq
     let low = meridian::health::platform::meridian_data_low_gb().is_some();
 
     let (pause_source, started_at, capture_paused_flag) = {
-        let s = state.lock().unwrap();
+        // Degrade gracefully on a poisoned mutex rather than unwrap — this
+        // runs synchronously inside run_poll_loop's loop body (not isolated
+        // in its own task), so a panic here would kill the entire poll loop
+        // for the rest of the process's life (health checks, notifications,
+        // tray icon updates, and this same guard, all silently dead), not
+        // just this one check. Same pattern refresh_health/refresh_active use.
+        let Ok(s) = state.lock() else {
+            tracing::warn!("check_disk_space: state lock poisoned");
+            return;
+        };
         (
             s.pause_source.clone(),
             s.pause_started_at,
@@ -289,8 +298,43 @@ async fn check_disk_space(state: &Arc<Mutex<AppState>>, pool: &meridian_core::Sq
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs();
+
+            // Preempting a Schedule pause must close out its own interval
+            // first — same as pause.rs::transition_pause does for the
+            // command-driven pause paths. Without this, the time already
+            // spent Schedule-paused before disk-low kicked in silently
+            // vanishes from the gaps table, and downstream worklog/analytics
+            // logic (which relies on gaps to exclude paused time) would
+            // treat it as tracked/active time instead.
+            if let (Some(PauseSource::Schedule), Some(prev_started)) = (&pause_source, started_at) {
+                let duration_s = now.saturating_sub(prev_started) as i64;
+                if duration_s > 0 {
+                    use chrono::{DateTime, SecondsFormat, Utc};
+                    let from = DateTime::<Utc>::from_timestamp(prev_started as i64, 0)
+                        .unwrap_or_else(Utc::now)
+                        .to_rfc3339_opts(SecondsFormat::Millis, true);
+                    let to = DateTime::<Utc>::from_timestamp(now as i64, 0)
+                        .unwrap_or_else(Utc::now)
+                        .to_rfc3339_opts(SecondsFormat::Millis, true);
+                    if let Err(e) = meridian_core::insert_pause_gap(
+                        pool,
+                        &from,
+                        &to,
+                        duration_s,
+                        "schedule_paused",
+                    )
+                    .await
+                    {
+                        tracing::warn!(error = %e, "disk-space guard: failed to write preempted schedule_paused gap");
+                    }
+                }
+            }
+
             {
-                let mut s = state.lock().unwrap();
+                let Ok(mut s) = state.lock() else {
+                    tracing::warn!("check_disk_space: state lock poisoned");
+                    return;
+                };
                 drop(s.engine_cancel.take());
                 drop(s.ui_consumer_cancel.take());
                 capture_paused_flag.store(true, Ordering::Relaxed);
@@ -334,7 +378,10 @@ async fn check_disk_space(state: &Arc<Mutex<AppState>>, pool: &meridian_core::Sq
             }
 
             {
-                let mut s = state.lock().unwrap();
+                let Ok(mut s) = state.lock() else {
+                    tracing::warn!("check_disk_space: state lock poisoned");
+                    return;
+                };
                 capture_paused_flag.store(false, Ordering::Relaxed);
                 s.pause_source = None;
                 s.pause_started_at = None;


### PR DESCRIPTION
## Summary

Fixes 6 of the 8 issues CodeRabbit flagged on PR #630's diff. Skipped 1 deliberately (see below); the 8th (a code-style/`anyhow::Result` convention note) is folded into the "skipped" explanation since fixing it in isolation would create inconsistency.

**`cache-warm.yml`** — the new `prune-stale-caches` job (from #626/#629):
- Guard the cache-listing `gh api` call the same way the delete call already is. Under `set -euo pipefail`, an unguarded transient failure on one prefix/ref pair aborted the whole prune job before later pairs were ever processed.
- Add `--paginate`. `per_page=100` silently capped each pair at 100 entries with no follow-up page, hiding older stale caches from pruning once a prefix exceeded that — the exact unbounded-growth failure this job exists to close (already measured hitting 42 caches after a single warm run).

**`release-build.yml`**:
- The bundle/notarize step already binds `CHANNEL` via `env:` and uses `$CHANNEL`, but re-interpolated the raw `${{ needs.prepare.outputs.channel == ... }}` expression directly into the same `run:` script anyway — the exact template-injection shape this file's own convention says to avoid (and what `zizmor` flagged). Now built via a shell conditional on the already-bound `$CHANNEL`.

**`src/llm/detect.rs`**:
- `command_for_resolved_cli` hardcoded `:` as the PATH separator when prepending a resolved CLI's directory, even though it's called on every platform (`cursor_sign_in`/`codex_sign_in`/`claude_sign_in`). Windows PATH entries are `;`-separated. Now uses `std::env::join_paths`/`split_paths`.

**`tray/src-tauri/src/backend_install.rs`**:
- `ensure_daemon_running` treated `schtasks /Run` exit-success as proof the daemon restarted, but the task is registered `/SC ONLOGON` — `/Run` success only confirms the request was *queued*, not that the daemon actually launched. Now waits briefly and re-checks `matching_daemon_pids` before trusting it, falling back to the direct spawn otherwise.

**`tray/src-tauri/src/poll/mod.rs`** (`check_disk_space`):
- Three `state.lock().unwrap()` calls could panic and kill the entire poll loop task on a poisoned mutex (health checks, notifications, tray icon updates, and this same guard, all silently dead for the rest of the process's life) — this runs synchronously in `run_poll_loop`'s loop body, not isolated. Now degrades gracefully with the same `let Ok(mut s) = state.lock() else { ...; return }` pattern `refresh_health`/`refresh_active` already use.
- Preempting a `Schedule` pause with `DiskLow` silently dropped the schedule-paused interval — state was overwritten directly with no `insert_pause_gap` call for the time already spent under `Schedule`, unlike `pause.rs::transition_pause`, which always closes out the pause it's replacing. That lost interval would read as tracked/active time to any worklog/analytics logic relying on gaps to exclude paused time. Now writes the preempted `schedule_paused` gap before installing the `DiskLow` pause.

**Skipped deliberately**: `stop_daemon_for_migration`'s `Result<(), String>` vs `anyhow::Result` — its sibling `stop_running_daemon_before_stage` (which it directly wraps) uses the same `String`-error convention throughout the same file; changing just one would create inconsistency for a change CodeRabbit itself flagged as trivial/low-value.

## Test plan
- [x] `cargo test` (workspace root): 831 passed, 0 failed
- [x] `cargo test` (tray crate): 186 passed, 1 pre-existing unrelated flake (`commands::setup::tests::install_outcome_success_logs_at_info`, confirmed passing in isolation, untouched by this change)
- [x] `cargo clippy --all-targets -- -D warnings`: clean on both
- [ ] CI passes on this PR