### PR TITLE
fix(release): remove literal expression syntax from a run: comment - broke every release build

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -578,10 +578,14 @@ jobs:
         run: |
           set -euo pipefail
           echo "→ ${CHANNEL}: signing AND notarizing"
-          # Uses the already-bound $CHANNEL rather than re-interpolating
-          # ${{ }} into this script a second time — the exact
+          # Uses the already-bound $CHANNEL rather than re-interpolating an
+          # expression into this script a second time - the exact
           # template-injection shape this file's own convention (see the
-          # RAW_TAG/VERSION binding notes elsewhere) says to avoid.
+          # RAW_TAG/VERSION binding notes elsewhere) says to avoid. (Not
+          # spelled out literally here on purpose: GitHub Actions scans the
+          # WHOLE run: block's raw text for that syntax, even inside a shell
+          # comment, and an empty one fails to parse - this exact line broke
+          # every release build until this comment was reworded.)
           config_flag=""
           if [ "${CHANNEL}" = "staging" ]; then
             config_flag="--config src-tauri/tauri.staging.conf.json"


### PR DESCRIPTION
## Urgent - this is why real releases have been failing

GitHub Actions scans a `run:` block's **entire raw text** for `${{ }}` expressions at parse time, regardless of shell `#` comment syntax — it doesn't know that text is a shell comment, it just looks for that literal pattern anywhere in the string.

A comment I added in #633 (fixing a different, real issue — re-interpolating `${{ }}` when `$CHANNEL` was already bound) quoted the empty pattern literally to describe the anti-pattern it was fixing. GitHub tried to parse that empty expression and failed:

```
unexpected end of input while parsing variable access, function call, null, bool, int, float or string. expecting "IDENT", "(", "INTEGER", "FLOAT", "STRING" [expression]
```

**This broke every `release-build.yml` run since #633 merged — including the real `v1.82.0` production release** (confirmed: `jobs: []`, workflow name fell back to the raw file path — the classic signature GitHub shows for a parse failure). A generic YAML parser doesn't catch this (I checked with `python3 -c "import yaml; ..."` — it parses fine); only a GitHub-Actions-schema-aware linter does. Installed `actionlint` and confirmed: this was the only real blocking error, fixed, verified clean.

## Fix
Reworded the comment to describe the anti-pattern in prose instead of quoting the literal syntax.

## Important - v1.82.0 itself cannot be recovered by this fix alone
The tag's own snapshot already has the broken workflow file baked in immutably (GitHub reads the workflow definition from the ref that triggered the event — the tag itself). A new release needs to be cut once this fix reaches `main`.

## Test plan
- [ ] CI passes on this PR
- [ ] `actionlint` clean (only pre-existing, unrelated shellcheck style notes remain)
- [ ] After merge and reaching `main`, cut a new release and confirm `release-build.yml` actually runs its jobs (not `jobs: []`)