### PR TITLE
fix(tray): refuse to mint a DB key that would orphan an encrypted meridian.db

### DIFF
--- a/tray/src-tauri/src/db_key.rs
+++ b/tray/src-tauri/src/db_key.rs
@@ -38,6 +38,16 @@ fn generate_key_hex() -> String {
     hex::encode(bytes)
 }
 
+/// Would minting a brand-new key orphan an already-encrypted `meridian.db`?
+/// True only when `db_path` exists and does not look like a plaintext SQLite
+/// file — i.e. it looks like ciphertext under some key this install can no
+/// longer find in the keychain. A missing file (fresh install) or a
+/// confirmed-plaintext file (nothing encrypted yet — `encrypt_in_place` will
+/// migrate it under the new key) are both safe to proceed on.
+pub(crate) fn would_orphan_existing_db(db_path: &std::path::Path) -> bool {
+    db_path.exists() && !meridian_core::db_crypto::is_plaintext_sqlite(db_path)
+}
+
 /// Get-or-create this machine's `meridian.db` encryption key from the OS
 /// keychain, and ensure it is mirrored into `env_path` as
 /// `MERIDIAN_DB_KEY=<hex>` so the daemon can read it. Returns the key hex.
@@ -45,13 +55,36 @@ fn generate_key_hex() -> String {
 /// Idempotent and safe to call on every tray startup: an existing keychain
 /// entry is reused as-is (never regenerated), and re-mirroring the same value
 /// into `.env` is a no-op write via `upsert_env`.
-pub fn resolve_or_create_key(env_path: &std::path::Path) -> anyhow::Result<String> {
+///
+/// `db_path` exists solely so a missing keychain entry can be checked against
+/// `meridian.db` before minting a replacement — see [`would_orphan_existing_db`].
+/// Without that check, a keychain entry lost for any reason (a keychain
+/// reset, a migration to a new machine, `.env` and the keychain falling out
+/// of sync) silently mints and stores a fresh key while the real data stays
+/// encrypted under the old, now-unreachable one: every future open then fails
+/// with SQLCipher "wrong key" errors (`file is not a database` / `database
+/// disk image is malformed`) instead of a clear, actionable one.
+pub fn resolve_or_create_key(
+    env_path: &std::path::Path,
+    db_path: &std::path::Path,
+) -> anyhow::Result<String> {
     let entry =
         keyring::Entry::new(SERVICE, ACCOUNT).context("db_key: failed to access OS keychain")?;
 
     let key_hex = match entry.get_password() {
         Ok(existing) => existing,
         Err(keyring::Error::NoEntry) => {
+            if would_orphan_existing_db(db_path) {
+                anyhow::bail!(
+                    "no DB encryption key found in the OS keychain, but {} already exists and \
+                     does not look like a plaintext SQLite file - it looks encrypted under a \
+                     key this install can no longer find. Refusing to generate a replacement \
+                     key, which would silently make that data permanently unreadable instead \
+                     of surfacing the problem. If this file is known-safe to discard, remove \
+                     it and restart.",
+                    db_path.display()
+                );
+            }
             let generated = generate_key_hex();
             entry
                 .set_password(&generated)
@@ -84,5 +117,30 @@ mod tests {
         meridian_core::db_crypto::validate_key_hex(&a).unwrap();
         meridian_core::db_crypto::validate_key_hex(&b).unwrap();
         assert_ne!(a, b, "two generated keys should not collide");
+    }
+
+    #[test]
+    fn would_orphan_existing_db_is_false_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        assert!(!db_path.exists());
+        assert!(!would_orphan_existing_db(&db_path));
+    }
+
+    #[test]
+    fn would_orphan_existing_db_is_false_when_plaintext() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        std::fs::write(&db_path, b"SQLite format 3\0rest-of-a-plaintext-file").unwrap();
+        assert!(!would_orphan_existing_db(&db_path));
+    }
+
+    #[test]
+    fn would_orphan_existing_db_is_true_when_not_plaintext() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        // No recognizable SQLite header - stands in for SQLCipher ciphertext.
+        std::fs::write(&db_path, b"not-a-sqlite-header-at-all-just-ciphertext").unwrap();
+        assert!(would_orphan_existing_db(&db_path));
     }
 }

--- a/tray/src-tauri/src/db_key.rs
+++ b/tray/src-tauri/src/db_key.rs
@@ -38,14 +38,66 @@ fn generate_key_hex() -> String {
     hex::encode(bytes)
 }
 
+/// Length of the SQLite file-header magic. A file shorter than this cannot be
+/// probed for it at all — see [`ExistingDb::TooSmallToBeADatabase`].
+const SQLITE_MAGIC_LEN: u64 = 16;
+
+/// What the on-disk `meridian.db` looks like, as far as deciding whether it is
+/// safe to mint a fresh encryption key is concerned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExistingDb {
+    /// No file — a genuine first run.
+    Absent,
+    /// A confirmed plaintext SQLite file. Nothing is encrypted yet, so
+    /// `encrypt_in_place` will migrate it under the newly minted key.
+    Plaintext,
+    /// Present, but shorter than [`SQLITE_MAGIC_LEN`]. SQLCipher's smallest
+    /// page is 512 bytes, so a file this short cannot hold encrypted data
+    /// under any key — it is an empty or truncated leftover (a torn write, a
+    /// disk-full stub), not a database. Nothing is lost by keying a fresh one
+    /// over it, and blocking startup to demand a support ticket for a file
+    /// with no recoverable content would be a false alarm. Carries the
+    /// observed length so the caller can log it without re-stat'ing (and
+    /// without having to invent a value if that second stat were to fail).
+    TooSmallToBeADatabase { bytes: u64 },
+    /// Present, long enough to be real, and carrying no recognizable SQLite
+    /// header — i.e. ciphertext under some key that is not in the keychain.
+    /// This is the case that must never be overwritten.
+    LooksEncrypted,
+}
+
+/// Classify `db_path` into the four states that matter before minting a key.
+///
+/// Note this cannot be answered by [`meridian_core::db_crypto::plaintext_state`]
+/// alone: it collapses *both* "file too short to read a header from" and "file
+/// unreadable" into `None`, which is right for its own callers but would lump a
+/// harmless empty stub in with real ciphertext here. The file length is what
+/// actually separates them, so it is consulted directly.
+///
+/// An existing file whose metadata cannot be read is deliberately classified
+/// [`ExistingDb::LooksEncrypted`] — the conservative direction, since guessing
+/// "harmless" about a file we cannot inspect is the one mistake with an
+/// irreversible outcome.
+pub(crate) fn classify_existing_db(db_path: &std::path::Path) -> ExistingDb {
+    if !db_path.exists() {
+        return ExistingDb::Absent;
+    }
+    if meridian_core::db_crypto::is_plaintext_sqlite(db_path) {
+        return ExistingDb::Plaintext;
+    }
+    match std::fs::metadata(db_path) {
+        Ok(m) if m.len() < SQLITE_MAGIC_LEN => ExistingDb::TooSmallToBeADatabase { bytes: m.len() },
+        _ => ExistingDb::LooksEncrypted,
+    }
+}
+
 /// Would minting a brand-new key orphan an already-encrypted `meridian.db`?
-/// True only when `db_path` exists and does not look like a plaintext SQLite
-/// file — i.e. it looks like ciphertext under some key this install can no
-/// longer find in the keychain. A missing file (fresh install) or a
-/// confirmed-plaintext file (nothing encrypted yet — `encrypt_in_place` will
-/// migrate it under the new key) are both safe to proceed on.
+/// True only for [`ExistingDb::LooksEncrypted`] — a file that exists, is long
+/// enough to be a real database, and is not plaintext, i.e. ciphertext under a
+/// key this install can no longer find. A missing file, a confirmed-plaintext
+/// file, and an empty/truncated stub are all safe to proceed on.
 pub(crate) fn would_orphan_existing_db(db_path: &std::path::Path) -> bool {
-    db_path.exists() && !meridian_core::db_crypto::is_plaintext_sqlite(db_path)
+    matches!(classify_existing_db(db_path), ExistingDb::LooksEncrypted)
 }
 
 /// Get-or-create this machine's `meridian.db` encryption key from the OS
@@ -74,8 +126,8 @@ pub fn resolve_or_create_key(
     let key_hex = match entry.get_password() {
         Ok(existing) => existing,
         Err(keyring::Error::NoEntry) => {
-            if would_orphan_existing_db(db_path) {
-                anyhow::bail!(
+            match classify_existing_db(db_path) {
+                ExistingDb::LooksEncrypted => anyhow::bail!(
                     "no DB encryption key found in the OS keychain, but {} already exists and \
                      does not look like a plaintext SQLite file - it looks encrypted under a \
                      key this install can no longer find. Refusing to generate a replacement \
@@ -83,7 +135,19 @@ pub fn resolve_or_create_key(
                      of surfacing the problem. If this file is known-safe to discard, remove \
                      it and restart.",
                     db_path.display()
-                );
+                ),
+                // Distinct from the bail above on purpose: this file is too
+                // short to hold encrypted data, so it is a leftover stub
+                // rather than orphaned user data. Proceed (a fresh database
+                // gets keyed over it), but say so — silently stepping over a
+                // corrupt file is how the original bug stayed invisible.
+                ExistingDb::TooSmallToBeADatabase { bytes } => {
+                    tracing::warn!(
+                        db_bytes = bytes,
+                        "keying a fresh database over an empty or truncated meridian.db stub - too short to hold encrypted data, so nothing recoverable is being replaced"
+                    );
+                }
+                ExistingDb::Absent | ExistingDb::Plaintext => {}
             }
             let generated = generate_key_hex();
             entry
@@ -124,6 +188,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("meridian.db");
         assert!(!db_path.exists());
+        assert_eq!(classify_existing_db(&db_path), ExistingDb::Absent);
         assert!(!would_orphan_existing_db(&db_path));
     }
 
@@ -132,6 +197,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("meridian.db");
         std::fs::write(&db_path, b"SQLite format 3\0rest-of-a-plaintext-file").unwrap();
+        assert_eq!(classify_existing_db(&db_path), ExistingDb::Plaintext);
         assert!(!would_orphan_existing_db(&db_path));
     }
 
@@ -141,6 +207,50 @@ mod tests {
         let db_path = dir.path().join("meridian.db");
         // No recognizable SQLite header - stands in for SQLCipher ciphertext.
         std::fs::write(&db_path, b"not-a-sqlite-header-at-all-just-ciphertext").unwrap();
+        assert_eq!(classify_existing_db(&db_path), ExistingDb::LooksEncrypted);
+        assert!(would_orphan_existing_db(&db_path));
+    }
+
+    /// A zero-byte `meridian.db` — the shape a torn write or a disk-full stub
+    /// leaves behind. It reads as "not plaintext" (there is no header to read),
+    /// so it must be told apart from real ciphertext explicitly, or a user with
+    /// nothing to lose is sent to support instead of simply being healed.
+    #[test]
+    fn an_empty_stub_is_not_treated_as_encrypted_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        std::fs::write(&db_path, b"").unwrap();
+        assert!(!meridian_core::db_crypto::is_plaintext_sqlite(&db_path));
+        assert_eq!(
+            classify_existing_db(&db_path),
+            ExistingDb::TooSmallToBeADatabase { bytes: 0 }
+        );
+        assert!(!would_orphan_existing_db(&db_path));
+    }
+
+    /// Truncated part-way through the magic — same reasoning as the empty stub:
+    /// too short to hold a SQLCipher page, so there is nothing to orphan.
+    #[test]
+    fn a_truncated_stub_is_not_treated_as_encrypted_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        std::fs::write(&db_path, b"SQLite f").unwrap();
+        assert_eq!(
+            classify_existing_db(&db_path),
+            ExistingDb::TooSmallToBeADatabase { bytes: 8 }
+        );
+        assert!(!would_orphan_existing_db(&db_path));
+    }
+
+    /// The boundary itself: exactly `SQLITE_MAGIC_LEN` bytes of non-header
+    /// content is long enough to probe, so it stays on the conservative side.
+    #[test]
+    fn exactly_magic_length_of_non_header_still_looks_encrypted() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        let contents = vec![0xABu8; SQLITE_MAGIC_LEN as usize];
+        std::fs::write(&db_path, &contents).unwrap();
+        assert_eq!(classify_existing_db(&db_path), ExistingDb::LooksEncrypted);
         assert!(would_orphan_existing_db(&db_path));
     }
 }

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -245,6 +245,11 @@ pub fn run() {
             //    meridian_core::db_crypto::encrypt_in_place's doc comments
             //    for why that's the safe failure mode.
             let db_path = install::meridian_db_path();
+            // Bound once: the same path is re-borrowed as a `Path` several
+            // times below (key resolution, the orphan check, the plaintext
+            // probe, the migration), and `db_path` itself stays a `String`
+            // because the tracing/`open` call sites still want it as one.
+            let db_path_ref = std::path::Path::new(&db_path);
             let install_mode = install::detect_install_mode();
             let existing_key = install_mode
                 .env_path()
@@ -256,7 +261,7 @@ pub fn run() {
                 match install::canonical_env_path() {
                     Some(env_path) => match db_key::resolve_or_create_key(
                         &env_path,
-                        std::path::Path::new(&db_path),
+                        db_path_ref,
                     ) {
                         Ok(key) => Some(key),
                         Err(e) => {
@@ -279,7 +284,7 @@ pub fn run() {
                             // database that's unreadable. A native OS
                             // notification is the only channel left that
                             // doesn't itself depend on meridian.db opening.
-                            if db_key::would_orphan_existing_db(std::path::Path::new(&db_path)) {
+                            if db_key::would_orphan_existing_db(db_path_ref) {
                                 tracing::error!(
                                     error = %e,
                                     "refusing to generate a replacement DB encryption key - meridian.db exists and appears already encrypted under a key this install can no longer find"
@@ -325,7 +330,7 @@ pub fn run() {
             // up by `ensure_backend_installed` later in this same setup hook.
             if !cfg!(debug_assertions)
                 && db_encryption_intended
-                && meridian_core::db_crypto::is_plaintext_sqlite(std::path::Path::new(&db_path))
+                && meridian_core::db_crypto::is_plaintext_sqlite(db_path_ref)
             {
                 if let Err(e) =
                     tauri::async_runtime::block_on(backend_install::stop_daemon_for_migration())
@@ -341,7 +346,7 @@ pub fn run() {
                 match &db_key_hex {
                     Some(key) => {
                         let migrate = meridian_core::db_crypto::encrypt_in_place(
-                            std::path::Path::new(&db_path),
+                            db_path_ref,
                             key,
                         );
                         match tauri::async_runtime::block_on(migrate) {
@@ -392,7 +397,7 @@ pub fn run() {
             if !cfg!(debug_assertions) {
                 if let Some(pool) = encryption_notice_pool.as_ref() {
                     let plaintext = meridian_core::db_crypto::plaintext_state(
-                        std::path::Path::new(&db_path),
+                        db_path_ref,
                     );
                     let action = db_encryption_notice_action(db_encryption_intended, plaintext);
                     // No `db_path` on the span: a home-dir path is user data.

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -254,7 +254,10 @@ pub fn run() {
                 existing_key
             } else if !cfg!(debug_assertions) {
                 match install::canonical_env_path() {
-                    Some(env_path) => match db_key::resolve_or_create_key(&env_path) {
+                    Some(env_path) => match db_key::resolve_or_create_key(
+                        &env_path,
+                        std::path::Path::new(&db_path),
+                    ) {
                         Ok(key) => Some(key),
                         Err(e) => {
                             // `tracing`, not `eprintln!`: observability is
@@ -264,10 +267,34 @@ pub fn run() {
                             // or central error reporting. A silent fallback to
                             // an UNENCRYPTED database is exactly the event
                             // those channels exist to surface.
-                            tracing::error!(
-                                error = %e,
-                                "failed to resolve DB encryption key - continuing unencrypted"
-                            );
+                            //
+                            // `would_orphan_existing_db` is a DIFFERENT, worse
+                            // case than the generic fallback below: the DB
+                            // already exists and is NOT plaintext, so there is
+                            // no unencrypted file to "continue" into - opening
+                            // it further down with no key will just fail, the
+                            // same way it's been failing already. The
+                            // DB-backed notices system (used elsewhere in this
+                            // function) can't carry this one: it's the very
+                            // database that's unreadable. A native OS
+                            // notification is the only channel left that
+                            // doesn't itself depend on meridian.db opening.
+                            if db_key::would_orphan_existing_db(std::path::Path::new(&db_path)) {
+                                tracing::error!(
+                                    error = %e,
+                                    "refusing to generate a replacement DB encryption key - meridian.db exists and appears already encrypted under a key this install can no longer find"
+                                );
+                                sys::notify(
+                                    app.handle(),
+                                    "Meridian can't read your local data",
+                                    "Your local database appears to be encrypted with a key this install can no longer find. Contact support with your Support ID (Settings -> Account) before removing anything.",
+                                );
+                            } else {
+                                tracing::error!(
+                                    error = %e,
+                                    "failed to resolve DB encryption key - continuing unencrypted"
+                                );
+                            }
                             None
                         }
                     },


### PR DESCRIPTION
## Problem

`db_key::resolve_or_create_key` treats **any** `keyring::Error::NoEntry` as "first run" and unconditionally generates + stores a fresh encryption key.

That is correct only when there genuinely is no database yet. If the keychain entry goes missing for any other reason — a keychain reset, a restore onto a new machine, `.env` and the keychain drifting apart — the real `meridian.db` is still encrypted under the old, now-unreachable key. Minting a replacement compounds a recoverable situation into an unrecoverable one, and nothing says so.

## Status of the evidence — please read, an earlier version of this PR was wrong

This PR originally claimed the bug explained an ongoing error storm on two alpha machines (`mac_970e5ebf236cb0ce` / `win_970e5ebf236cb0ce`, ~190k errors in 28h). **That attribution was incorrect and has been retracted.**

Direct inspection of the affected Mac showed:
- the keychain entry is present,
- `.env` carries `MERIDIAN_DB_KEY`,
- and that key **successfully decrypts the database** (verified with `sqlcipher`, read-only: `sqlite_master` reads back 99 objects).

Nothing was orphaned. The real cause there is **page-level corruption in a database that opens fine** — `PRAGMA quick_check` reports a genuine structural fault (`Tree 37 page 669426 cell 9: overflow list length is 4 but should be 8`) plus a long run of freelist inconsistencies. Consistent with the `meridian.db.severely-corrupt-*` / `.pre-repair-backup-*` files already on that disk.

The tell I misread: SQLCipher's wrong-key signature is code 26 (`file is not a database`). The dominant error was code 11 (`database disk image is malformed`), outnumbering code 26 ~85:1 — that is corruption, not a bad key.

**So this bug is real but latent.** It is a hole in the key-resolution path that has not been observed firing in the wild. It is worth closing on its own merits; it is not a fix for the corruption issue, which needs separate work.

## Change

**`db_key.rs`** — classify the on-disk DB before minting:

```rust
enum ExistingDb {
    Absent,                            // genuine first run
    Plaintext,                         // encrypt_in_place migrates it
    TooSmallToBeADatabase { bytes },   // empty/truncated stub - nothing to lose
    LooksEncrypted,                    // ciphertext under a key we cannot find
}
```

Only `LooksEncrypted` bails. `TooSmallToBeADatabase` proceeds with a `WARN` carrying the observed size: a file shorter than the 16-byte magic cannot hold a SQLCipher page (smallest is 512 bytes), so blocking startup there would be a false alarm that sends a user with nothing to lose to support. An existing file whose metadata cannot be read is classified `LooksEncrypted` — failing closed is the only direction here whose mistake is irreversible.

**`lib.rs`** — distinguishes this from the pre-existing generic fallback, which logs "continuing unencrypted" and is wrong here (there is no unencrypted file to continue into). The DB-backed notice system can't carry the warning either, since `meridian.db` is the thing that won't open — so it fires a native OS notification. Best-effort: it silently drops if notification permission was never granted, though the `tracing::error!` still ships to central telemetry.

Also binds `Path::new(&db_path)` once instead of rebuilding it at five call sites.

## Scope

- ✅ Closes a latent path that can turn a recoverable keychain problem into permanent data loss.
- ✅ Makes that failure loud and attributable rather than silent.
- ❌ Does **not** address the corruption issue described above.
- ❌ Cannot recover a database whose key is genuinely gone — nothing can.

## Test plan

- `cargo fmt --check`, `cargo clippy --lib -- -D warnings` — clean
- `cargo test --lib` (tray) — 193/193
- Full pre-push suite (fmt + UI build + clippy + UI tests + security audit + cargo test) — green
- CI: Rust macOS + Windows, CodeQL ×4 — green
- 6 unit tests over the classifier: missing, plaintext, ciphertext, empty stub, truncated stub, exact-magic-length boundary

Not covered: an end-to-end run through `resolve_or_create_key`'s bail path, which needs a real or mocked OS keychain. The extracted classifier carries the logic and is covered directly.

Unrelated pre-existing flake seen once during development: `commands::setup::tests::signin_outcome_success_logs_at_info` — `Arc::try_unwrap(seen).unwrap()` racing subscriber teardown in that module's own `capture()` helper. Passes in isolation and on repeated full runs; untracked, worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)