### PR TITLE
fix(tray): connect meridian.db lazily so a first launch is not dead until restart

### DIFF
--- a/meridian-core/src/db.rs
+++ b/meridian-core/src/db.rs
@@ -13,7 +13,8 @@
 //! rides out the daemon's short write transactions.
 //!
 //! Re-exported at the crate root (`meridian_core::{open_existing,
-//! get_active_session, ActiveSession}`) — `db` is internal organization only.
+//! open_existing_lazy, ping, get_active_session, ActiveSession}`) — `db` is
+//! internal organization only.
 
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
@@ -72,6 +73,50 @@ pub async fn open_existing(uri: &str, key: Option<&str>) -> anyhow::Result<Sqlit
         "opened meridian.db (WAL, 5s busy_timeout)"
     );
     Ok(pool)
+}
+
+/// Same contract as [`open_existing`], but the pool is built **without
+/// connecting** — the first connection is made on demand and every later
+/// acquire retries, so a database that does not exist yet is recovered from
+/// automatically once it appears.
+///
+/// This is what the tray uses at startup. It must not require `meridian.db` to
+/// already exist: on a first launch the tray builds this handle seconds before
+/// it installs and starts the daemon that creates the file, and an eager open
+/// there yields a `None` pool that nothing ever retries — disabling every
+/// DB-backed command and silently discarding every captured frame until the
+/// user restarts the tray. See [`crate::db_crypto::open_pool_with_key_lazy`]
+/// for the full rationale and for why the key decision is per-connection.
+///
+/// Because no connection is attempted here, a returned `Ok` says nothing about
+/// reachability — use [`ping`] when you want that answer at a point in time.
+#[tracing::instrument(skip_all, fields(uri = %uri, encrypted = key.is_some()))]
+pub fn open_existing_lazy(uri: &str, key: Option<&str>) -> anyhow::Result<SqlitePool> {
+    let pool = crate::db_crypto::open_pool_with_key_lazy(uri, key)?;
+    tracing::info!(
+        uri,
+        encrypted = key.is_some(),
+        "prepared meridian.db pool (lazy, WAL, 5s busy_timeout)"
+    );
+    Ok(pool)
+}
+
+/// Acquire one connection and run `SELECT 1`, reporting whether the database is
+/// reachable *right now*.
+///
+/// Exists for [`open_existing_lazy`]'s callers: a lazy pool cannot fail at
+/// build time, so without an explicit probe a tray whose database is
+/// unreachable would produce no startup signal at all — which is precisely how
+/// the first-launch failure this pair replaces stayed invisible for a whole
+/// session. Purely diagnostic: callers log the result and carry on, because the
+/// pool recovers by itself.
+#[tracing::instrument(skip_all)]
+pub async fn ping(pool: &SqlitePool) -> anyhow::Result<()> {
+    sqlx::query("SELECT 1")
+        .execute(pool)
+        .await
+        .context("ping: meridian.db is not reachable")?;
+    Ok(())
 }
 
 /// Read the single active session (the `active_session` row, id = 1), or `None`.

--- a/meridian-core/src/db_crypto.rs
+++ b/meridian-core/src/db_crypto.rs
@@ -54,6 +54,18 @@ fn key_pragma(key_hex: &str) -> String {
     format!("PRAGMA key = \"x'{key_hex}'\"")
 }
 
+/// The standard connection pragmas every read-write `meridian.db` pool applies,
+/// in order, AFTER `PRAGMA key`.
+///
+/// Shared by [`open_pool_with_key`] and [`open_pool_with_key_lazy`] so a pragma
+/// added for one opener can never be silently missed by the other — the two
+/// differ only in *when* they connect, never in how a connection is set up.
+const BASE_PRAGMAS: [&str; 3] = [
+    "PRAGMA journal_mode=WAL;",
+    "PRAGMA synchronous=NORMAL;",
+    "PRAGMA busy_timeout=5000;",
+];
+
 /// Open a pool at `uri`, applying the SQLCipher key (if any) as the FIRST
 /// statement on every new physical connection, before any other pragma.
 ///
@@ -95,9 +107,9 @@ pub async fn open_pool_with_key(
                 if let Some(k) = &key_owned {
                     conn.execute(key_pragma(k).as_str()).await?;
                 }
-                conn.execute("PRAGMA journal_mode=WAL;").await?;
-                conn.execute("PRAGMA synchronous=NORMAL;").await?;
-                conn.execute("PRAGMA busy_timeout=5000;").await?;
+                for pragma in BASE_PRAGMAS {
+                    conn.execute(pragma).await?;
+                }
                 for (name, value) in extra_pragmas {
                     conn.execute(format!("PRAGMA {name}={value};").as_str())
                         .await?;
@@ -109,6 +121,63 @@ pub async fn open_pool_with_key(
         .await
         .with_context(|| format!("failed to open SQLite at {uri}"))?;
     Ok(pool)
+}
+
+/// Build a pool at `uri` **without connecting**, applying the same key and
+/// pragmas as [`open_pool_with_key`] on each connection the pool later opens
+/// on demand.
+///
+/// # Why this exists
+/// The tray opens `meridian.db` once during Tauri `setup` and shares the handle
+/// with every DB-backed command and the capture consumers. On a **first
+/// launch** it reaches that point seconds before `ensure_backend_installed`
+/// starts the daemon — and the daemon is what CREATES `meridian.db`. An eager
+/// open therefore fails with "unable to open database file", and because the
+/// tray stores the result as an `Option` there is nothing that ever retries:
+/// the whole process runs to shutdown with `None`, silently returning empty
+/// data from every command and dropping every captured frame on the floor.
+/// Connecting lazily makes that self-healing — the first acquire after the
+/// daemon creates the file succeeds, with no restart and no retry loop.
+///
+/// # Why the key decision moves into `after_connect`
+/// [`key_unless_plaintext`] probes the file header to decide whether the key
+/// applies at all. [`open_pool_with_key`] can evaluate that once up front
+/// because it has just proven the file is openable. A lazy pool has not: at
+/// build time the file routinely does not exist yet, and a decision cached
+/// from that moment would be made against nothing. Re-resolving per connection
+/// means the pool always keys (or declines to key) against the file as it
+/// actually is when the connection is made.
+///
+/// Non-async and infallible-to-connect by construction — the only error it can
+/// return is a malformed `uri` or `key_hex`. `create_if_missing` is always
+/// false: the daemon owns creation and migrations (see [`crate::db`]).
+pub fn open_pool_with_key_lazy(uri: &str, key_hex: Option<&str>) -> anyhow::Result<SqlitePool> {
+    if let Some(k) = key_hex {
+        validate_key_hex(k)?;
+    }
+    let opts = SqliteConnectOptions::from_str(uri)
+        .with_context(|| format!("invalid SQLite URI: {uri}"))?
+        .create_if_missing(false);
+
+    let uri_owned = uri.to_string();
+    let key_owned = key_hex.map(|s| s.to_string());
+    Ok(SqlitePoolOptions::new()
+        .acquire_timeout(std::time::Duration::from_secs(10)) // see open_pool_with_key
+        .after_connect(move |conn, _meta| {
+            let uri_owned = uri_owned.clone();
+            let key_owned = key_owned.clone();
+            Box::pin(async move {
+                // Resolved here, not at build time — see the doc comment above.
+                if let Some(k) = key_unless_plaintext(&uri_owned, key_owned.as_deref()) {
+                    conn.execute(key_pragma(k).as_str()).await?;
+                }
+                for pragma in BASE_PRAGMAS {
+                    conn.execute(pragma).await?;
+                }
+                Ok(())
+            })
+        })
+        .connect_lazy_with(opts))
 }
 
 /// Open a READ-ONLY pool at `uri`, applying the SQLCipher key (if any) as the
@@ -735,6 +804,90 @@ mod tests {
             .unwrap();
         assert_eq!(row.get::<i64, _>(0), 1);
         reopened.close().await;
+    }
+
+    /// The tray's first-launch regression, end to end: a pool built while
+    /// `meridian.db` does not exist yet must NOT be permanently dead. It may
+    /// fail while the file is absent, but the *same handle* has to start
+    /// working once the daemon creates the database — no reopen, no restart.
+    ///
+    /// Guards the bug this opener was added for: the tray built its pool
+    /// seconds before the daemon created the file, cached the failure as
+    /// `None`, and ran its whole session with every DB command returning empty
+    /// and every captured frame discarded.
+    #[tokio::test]
+    async fn lazy_pool_recovers_once_the_database_appears() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        let uri = db_path.display().to_string();
+        assert!(!db_path.exists());
+
+        // Built against nothing — this must still hand back a usable handle.
+        // (Not asserting that a query fails while the file is absent: sqlx
+        // retries a failed connect until the 10s acquire timeout, so such an
+        // assertion would just make this test sleep for ten seconds. That
+        // retry window is itself useful here — a command issued during the
+        // first-launch gap tends to succeed rather than error.)
+        let pool = open_pool_with_key_lazy(&uri, Some(TEST_KEY))
+            .expect("building a lazy pool must not require the file to exist");
+
+        // The daemon creates and populates the database (encrypted, as it does
+        // whenever MERIDIAN_DB_KEY is set).
+        let daemon = open_pool_with_key(&uri, Some(TEST_KEY), true, &[])
+            .await
+            .expect("daemon-side create should succeed");
+        sqlx::query("CREATE TABLE capture_frames (id INTEGER PRIMARY KEY)")
+            .execute(&daemon)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO capture_frames (id) VALUES (7)")
+            .execute(&daemon)
+            .await
+            .unwrap();
+        daemon.close().await;
+
+        // The ORIGINAL handle now works — this is the whole point.
+        let row = sqlx::query("SELECT id FROM capture_frames")
+            .fetch_one(&pool)
+            .await
+            .expect("the lazy pool must connect once the database exists");
+        assert_eq!(row.get::<i64, _>(0), 7);
+        pool.close().await;
+    }
+
+    /// The lazy opener resolves the key/plaintext question per connection, so a
+    /// plaintext database is opened unencrypted even though the pool was built
+    /// with a key — and built before the file existed, so nothing could have
+    /// been probed up front. Same guarantee [`key_unless_plaintext`] gives the
+    /// eager opener, at the point a lazy pool can actually make it.
+    #[tokio::test]
+    async fn lazy_pool_drops_the_key_for_a_plaintext_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        let uri = db_path.display().to_string();
+
+        let pool = open_pool_with_key_lazy(&uri, Some(TEST_KEY)).unwrap();
+
+        // Create it PLAINTEXT after the pool was built (the stuck
+        // encrypt-in-place state: key configured, file still in the clear).
+        let plain = open_pool_with_key(&uri, None, true, &[]).await.unwrap();
+        sqlx::query("CREATE TABLE t (x INTEGER)")
+            .execute(&plain)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO t (x) VALUES (3)")
+            .execute(&plain)
+            .await
+            .unwrap();
+        plain.close().await;
+        assert!(is_plaintext_sqlite(&db_path));
+
+        let row = sqlx::query("SELECT x FROM t")
+            .fetch_one(&pool)
+            .await
+            .expect("a keyed lazy pool must still read a plaintext database");
+        assert_eq!(row.get::<i64, _>(0), 3);
+        pool.close().await;
     }
 
     /// First rename (`path` → `backup`) fails: the encrypted export must be

--- a/meridian-core/src/lib.rs
+++ b/meridian-core/src/lib.rs
@@ -61,7 +61,7 @@ pub mod proc_ext;
 pub mod retry;
 
 // ── Curated public API: flat module paths, stable across file moves ──────────
-pub use db::{get_active_session, open_existing, ActiveSession};
+pub use db::{get_active_session, open_existing, open_existing_lazy, ping, ActiveSession};
 
 pub use capture::{
     insert_capture_frame, insert_capture_secondary_screen, insert_capture_ui_event,

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -366,16 +366,47 @@ pub fn run() {
                 db_key_hex
             };
 
-            // Open meridian.db ONCE at startup and share it with commands via
-            // managed state (no migrations — the daemon owns the schema). `None`
-            // if the DB can't be opened yet, so reads error gracefully instead
-            // of crashing the tray.
-            let db_pool = tauri::async_runtime::block_on(meridian_core::open_existing(
-                &db_path,
-                db_key_hex.as_deref(),
-            ))
-            .map_err(|e| tracing::error!(error = %e, db_path = %db_path, "meridian.db not opened"))
-            .ok();
+            // Prepare the meridian.db pool ONCE at startup and share it with
+            // commands via managed state (no migrations — the daemon owns the
+            // schema). `None` only if the path/key is malformed, so reads error
+            // gracefully instead of crashing the tray.
+            //
+            // LAZY on purpose. On a first launch this line runs seconds BEFORE
+            // `ensure_backend_installed` (below) starts the daemon that creates
+            // meridian.db, so an eager open fails — and since the result is
+            // stored as an `Option` that nothing retries, the tray then ran its
+            // entire session against `None`: every DB-backed command silently
+            // returned its empty default and every captured frame was dropped
+            // by the consumers' `else { continue }`, until the user happened to
+            // restart the tray. A lazy pool connects on first use instead, so
+            // the very next command or frame after the daemon creates the file
+            // succeeds on its own.
+            let db_pool = meridian_core::open_existing_lazy(&db_path, db_key_hex.as_deref())
+                .map_err(
+                    |e| tracing::error!(error = %e, db_path = %db_path, "meridian.db pool not prepared"),
+                )
+                .ok();
+            // A lazy pool cannot report reachability at build time, and losing
+            // that startup signal is how the failure above stayed invisible for
+            // a whole session. Probe once, purely to log it — an unreachable DB
+            // here is expected on a first launch and heals by itself, so this
+            // deliberately gates nothing.
+            //
+            // SPAWNED, never blocked on: sqlx retries a failed connection until
+            // the pool's 10s acquire timeout, so a first launch (file not
+            // created yet) would otherwise freeze the whole `setup` closure —
+            // and with it the tray menu — for ten seconds.
+            if let Some(p) = db_pool.clone() {
+                tauri::async_runtime::spawn(async move {
+                    match meridian_core::ping(&p).await {
+                        Ok(()) => tracing::info!("meridian.db reachable"),
+                        Err(e) => tracing::warn!(
+                            error = %e,
+                            "meridian.db not reachable yet — the pool will connect once the daemon creates it"
+                        ),
+                    }
+                });
+            }
             // Capture (slice 4a) writes to the SAME read-write pool the commands
             // use — clone the handle before it's moved into managed state.
             #[cfg(feature = "capture")]


### PR DESCRIPTION
## The bug

On a **fresh install** the tray runs its entire session unable to touch `meridian.db`, and says almost nothing about it.

`tray/src-tauri/src/lib.rs` opened the database eagerly during Tauri `setup` and stored the result as an `Option` that nothing ever retried. That line runs **seconds before** `ensure_backend_installed` starts the daemon - and the daemon is what *creates* `meridian.db`. So the open fails, `db_pool` is `None`, and it stays `None` until the user happens to restart the tray.

Observed on a 1.82.1 Windows install, ~12 h uptime:

```
18:28:02.967  INFO   generated new local database encryption key
18:28:02.970  SPAN   open_existing
18:28:02.976  ERROR  meridian.db not opened          <- file did not exist yet
18:28:03.068  INFO   backend_install: installing bundled backend
18:28:06      (daemon starts, creates meridian.db)
```

Everything hanging off that pool silently no-ops:

- **Every DB-backed command** shares the same `State<'_, Option<SqlitePool>>` (47 call sites across 12 files) and hits `let Some(pool) = pool.inner() else` -> returns its empty default. The dashboard shows nothing, with no error.
- **Both capture consumers** hit `let Some(p) = consumer_pool.as_ref() else { continue }` -> every frame discarded. `capture_frames` stayed empty, ETL cursor never left 0, and the daemon logged `worklog: insufficient activity - skipping hour` all day.

After the single startup ERROR nothing above DEBUG is emitted, so the pipeline looks healthy while producing nothing.

Not Windows-specific in the code - it is a launch-ordering race - but every fresh install runs the tray-before-daemon sequence, so new installs are the ones that hit it.

## The fix

Build the pool with `connect_lazy_with`. The handle exists immediately and connects on first use, so the first command or captured frame after the daemon creates the file succeeds on its own - no restart, no retry loop. sqlx also retries a failed connect until the acquire timeout, which covers the launch gap outright rather than merely recovering after it.

- `meridian-core/src/db_crypto.rs` - new `open_pool_with_key_lazy`. The **key/plaintext decision moves into `after_connect`**: `key_unless_plaintext` probes the file header, and a lazy pool is routinely built before there is any file to probe, so that answer must be resolved per connection rather than cached from a moment when it would have been made against nothing. The eager `open_pool_with_key` is behaviourally untouched; both now share `BASE_PRAGMAS` so the two openers cannot drift.
- `meridian-core/src/db.rs` - `open_existing_lazy` (lazy sibling of `open_existing`) and `ping`, the reachability signal a lazy pool cannot give at build time. Losing that signal is exactly how this failure stayed invisible.
- `tray/src-tauri/src/lib.rs` - uses the lazy pool for both managed state and the capture pool. `ping` is **spawned, never blocked on**: sqlx retries until the 10 s acquire timeout, so a synchronous probe would freeze `setup` - and the tray menu - for ten seconds on a first launch.

No call sites change - the managed `Option<SqlitePool>` type is untouched.

## Tests

Two regression tests in `db_crypto.rs`:

- `lazy_pool_recovers_once_the_database_appears` - pool built with no file present; the daemon then creates and populates an encrypted DB; the **original handle** reads it. This is the regression itself.
- `lazy_pool_drops_the_key_for_a_plaintext_database` - a keyed lazy pool still reads a plaintext DB, i.e. the `key_unless_plaintext` guarantee survives the move into `after_connect`.

## Reviewer notes

- **Not compiled locally** - the machine that found this has no Rust toolchain (no cargo/rustc, no MSVC build tools), so CI is the first real build. The API most worth a second pair of eyes is `PoolOptions::connect_lazy_with` returning `Pool` directly rather than `Result` on sqlx 0.7.
- This fixes *new* installs. An already-running tray still holds the dead `None` pool and needs one restart, independent of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)