### PR TITLE
fix(windows): load the canonical .env so the daemon can open an encrypted db

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,13 +14,40 @@ use tokio::sync::Notify;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // 1. Load the repo-local .env — the single source of config for the daemon.
-    //    Nothing is read from outside the repo.
-    //    The launchd plist sets WorkingDirectory to the repo root, so
-    //    dotenv_override reads <repo>/.env and its values beat any empty
-    //    defaults injected by the plist. (CLI subcommands invoked from elsewhere
-    //    fall back to built-in defaults, e.g. MERIDIAN_DB → ~/.meridian/meridian.db.)
+    // 1. Load the working-directory .env. `dotenv_override` walks UP from the
+    //    CWD and stops at the first `.env`, so a source/dev run picks up
+    //    <repo>/.env, and on macOS — where the launchd plist sets
+    //    WorkingDirectory — a packaged install picks up ~/.meridian/.env. Its
+    //    values beat any empty defaults injected by the plist. (CLI subcommands
+    //    invoked from elsewhere fall back to built-in defaults, e.g.
+    //    MERIDIAN_DB → ~/.meridian/meridian.db.)
     let _ = dotenvy::dotenv_override();
+
+    // 1a. …but that walk is CWD-dependent, and on Windows NOTHING sets a
+    //     working directory for the daemon. Neither launcher the tray installs
+    //     has one: `schtasks /Create` (see `backend_install.rs`) has no "Start
+    //     in" field, and the Startup-folder fallback calls `WScript.Shell.Run`
+    //     without setting `CurrentDirectory`. Both therefore start the daemon in
+    //     system32, where the walk finds no `.env` at all — so it came up with
+    //     no MERIDIAN_DB_KEY.
+    //
+    //     That stayed invisible for as long as meridian.db was plaintext:
+    //     `key_unless_plaintext` drops the key for a plaintext file, so the open
+    //     succeeded without one. It turns fatal the moment the tray's
+    //     encrypt-in-place completes (which it does as soon as it runs while the
+    //     daemon is not holding the file open) — from then on every connection
+    //     fails in `after_connect`, permanently, with the key sitting in a file
+    //     this process never read.
+    //
+    //     So also load the canonical ~/.meridian/.env, the file the tray writes
+    //     the key and tracker credentials into, regardless of where we were
+    //     started from. `from_path` does NOT override, so anything already set —
+    //     by the real environment or by the repo .env above — still wins: dev
+    //     and macOS behaviour are unchanged, and this only fills the gap left
+    //     when the walk came up empty.
+    if let Some(home) = meridian_core::paths::home_dir() {
+        let _ = dotenvy::from_path(home.join(".meridian").join(".env"));
+    }
 
     // 1b. Subcommand dispatch. `meridian coding-agent-hook` is the Claude Code
     //     SessionEnd hook entry point: one-shot, reads a JSON payload on stdin,

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -20,6 +20,16 @@
 //! agents (screenpipe / a11y-helper / MLX / UI server) are booted out during
 //! [`install`].
 //!
+//! **Windows has no equivalent of that plist key**, and getting it wrong is
+//! silent: `schtasks /Create` has no "Start in" field and the Startup-folder
+//! VBScript defaults to system32, so a daemon launched by either sees no `.env`
+//! — and therefore no `MERIDIAN_DB_KEY`, which is fatal once meridian.db has
+//! been encrypted in place. Every launch path here consequently sets the
+//! working directory to `~/.meridian` explicitly (the VBScript's
+//! `CurrentDirectory`, and `current_dir` on both direct spawns). The daemon
+//! *also* loads that file by absolute path (`src/main.rs`), so this is defence
+//! in depth and the fix for anyone whose task was registered by an older build.
+//!
 //! **The `meridian-a11y-helper` launchd agent is retired** (was
 //! `com.meridiona.a11y-helper`): it existed to poke `AXManualAccessibility`
 //! on Electron/Chromium apps for the old *external* screenpipe process. The
@@ -239,7 +249,10 @@ async fn ensure_daemon_running(home: &Path) {
                 "backend_install: scheduled task ran but the daemon isn't up yet, falling back to a direct spawn"
             );
         }
+        // `current_dir`: the daemon resolves its `.env` relative to the working
+        // directory, and a bare spawn would inherit the tray's instead.
         match tokio::process::Command::new(&daemon_bin)
+            .current_dir(home.join(".meridian"))
             .no_window()
             .spawn()
         {
@@ -405,9 +418,17 @@ async fn register_service(_backend: &Path, home: &Path, daemon_bin: &Path) -> Re
                 error = %e,
                 "backend_install: schtasks registration failed — falling back to a Startup-folder launcher"
             );
-            install_startup_folder_launcher(daemon_bin).await?;
+            let meridian_home = home.join(".meridian");
+            install_startup_folder_launcher(&meridian_home, daemon_bin).await?;
             // Nothing else will start the daemon until next login — start it now.
-            if let Err(e) = tokio::process::Command::new(daemon_bin).no_window().spawn() {
+            // `current_dir` for the same reason the launcher sets it: the daemon
+            // resolves its `.env` relative to the working directory, and this
+            // spawn inherits the tray's otherwise.
+            if let Err(e) = tokio::process::Command::new(daemon_bin)
+                .current_dir(&meridian_home)
+                .no_window()
+                .spawn()
+            {
                 tracing::warn!(
                     error = %e,
                     bin = %daemon_bin.display(),
@@ -684,19 +705,35 @@ fn startup_folder() -> Result<PathBuf, String> {
 
 /// Write the hidden-launch VBScript to the Startup folder. Idempotent:
 /// overwrites unconditionally, same as `schtasks /Create /F`.
+///
+/// `meridian_home` is the daemon's working directory (`~/.meridian`), the
+/// Windows counterpart of the macOS plist's `WorkingDirectory`.
 #[cfg(target_os = "windows")]
-async fn install_startup_folder_launcher(daemon_bin: &Path) -> Result<(), String> {
+async fn install_startup_folder_launcher(
+    meridian_home: &Path,
+    daemon_bin: &Path,
+) -> Result<(), String> {
     let dir = startup_folder()?;
     tokio::fs::create_dir_all(&dir)
         .await
         .map_err(|e| format!("mkdir {}: {e}", dir.display()))?;
     let script = dir.join(STARTUP_LAUNCHER_NAME);
+    // `CurrentDirectory` is set for parity with the macOS plist's
+    // `WorkingDirectory`: the daemon's `dotenvy` walk starts at the CWD, and a
+    // launcher that leaves it at system32 gives the daemon no `.env` — and so
+    // no MERIDIAN_DB_KEY — which is fatal once meridian.db is encrypted. The
+    // daemon also resolves ~/.meridian/.env by absolute path (`src/main.rs`),
+    // so this is defence in depth rather than the sole fix.
+    //
     // VBScript has no backslash-escaping to worry about — only `"` needs
     // doubling to embed a literal quote, wrapping the path so a space
     // anywhere in it (a differently-named Windows profile, say) can't split
     // `Run`'s argument.
     let contents = format!(
-        "CreateObject(\"WScript.Shell\").Run \"\"\"{}\"\"\", 0, False\r\n",
+        "Set sh = CreateObject(\"WScript.Shell\")\r\n\
+         sh.CurrentDirectory = \"{}\"\r\n\
+         sh.Run \"\"\"{}\"\"\", 0, False\r\n",
+        meridian_home.display(),
         daemon_bin.display()
     );
     tokio::fs::write(&script, contents)

--- a/tray/src-tauri/src/commands/daemon_control.rs
+++ b/tray/src-tauri/src/commands/daemon_control.rs
@@ -198,7 +198,13 @@ fn spawn_staged_daemon() -> Result<(), String> {
     if !daemon_bin.exists() {
         return Err(format!("no staged daemon at {}", daemon_bin.display()));
     }
+    // `current_dir` is load-bearing, not cosmetic: the daemon resolves its
+    // `.env` relative to the working directory, so a bare spawn inherits the
+    // tray's and the daemon comes up without MERIDIAN_DB_KEY — fatal once
+    // meridian.db is encrypted. Matches every other daemon launch path (see
+    // `crate::backend_install`'s module docs).
     std::process::Command::new(&daemon_bin)
+        .current_dir(home.join(".meridian"))
         .no_window()
         .spawn()
         .map(|_| ())


### PR DESCRIPTION
## The bug

On Windows the daemon starts with **no `MERIDIAN_DB_KEY`**, and once `meridian.db` has been encrypted that locks it out of its own database permanently.

`src/main.rs` loads config with `dotenvy::dotenv_override()`, which walks **up from the working directory** and stops at the first `.env`. On macOS that works because the launchd plist sets `WorkingDirectory` to `~/.meridian`. **Windows has no equivalent, and neither launcher the tray installs sets one:**

- `schtasks /Create` (`backend_install.rs::register_scheduled_task`) has no *Start in* field
- the Startup-folder fallback calls `WScript.Shell.Run` without setting `CurrentDirectory`

Both therefore launch the daemon in `system32`, where the walk finds nothing.

### Why it stayed hidden

For as long as `meridian.db` was plaintext this was harmless: `key_unless_plaintext` drops the key for a plaintext file, so the open succeeded *without* one. The daemon looked completely healthy.

It turns fatal the moment the tray's `encrypt_in_place` completes - which it does as soon as the tray runs while the daemon is not holding the file open. From then on there is no recovery: the key is sitting in a file this process never reads.

### Observed

On a 1.82.1 Windows install, encryption completed during a tray restart. The daemon immediately went into:

```
06:51:40.407  INFO   meridian daemon starting
06:51:40.603  ERROR  error returned from after_connect
06:51:40.661  ERROR  error returned from after_connect
06:51:40.673  ERROR  error returned from after_connect
          ... every tick, forever
```

Starting the same binary with `--WorkingDirectory ~/.meridian` fixed it instantly - ETL cursor moved from 0 to 100 within one poll.

## The fix

Two layers, because they repair different populations:

1. **`src/main.rs` also loads `~/.meridian/.env` by absolute path**, after the existing walk. `dotenvy::from_path` does **not** override, so the real environment and a repo `.env` still win - dev/source and macOS behaviour are byte-for-byte unchanged, and this only fills the gap where the CWD walk came up empty. This is the layer that **repairs already-installed machines**, whose scheduled task was registered by an older build and will keep launching with no working directory.

2. **Every Windows daemon launch path now sets the working directory explicitly** to `~/.meridian`, for parity with the plist: the Startup VBScript gains `CurrentDirectory`, and both direct spawns gain `current_dir` (`backend_install`'s fallback start, and `commands/daemon_control::spawn_staged_daemon`, the tray's Restart Daemon). Defence in depth for new installs.

## Not done here

`schtasks /Create` still registers a task with no *Start in*, because setting one means switching to `/XML` task registration - a bigger change than this fix warrants now that layer 1 makes the daemon independent of its working directory. Worth doing separately if we ever want the CWD to be authoritative.

## Reviewer notes

- **Not compiled locally** - the machine this was found on has no Rust toolchain (no cargo/rustc, no MSVC build tools), so CI is the first real build.
- No test added: the change is three lines of process-env glue, and asserting on it would mean mutating global process env inside the test harness. The behaviour that matters (`from_path` not overriding) is dotenvy's own documented contract.
- Related but independent: #638 fixes the tray-side first-launch pool race found in the same investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
