### PR TITLE
fix(tray): hide the hover tooltip on mouse-down so right-click can't strand it

### DIFF
--- a/tests/tray_assets.rs
+++ b/tests/tray_assets.rs
@@ -339,3 +339,31 @@ fn js_element_id_contract_holds() {
     assert_ids_present("tray/src/app.js", "tray/src/index.html");
     assert_ids_present("tray/src/tooltip.js", "tray/src/tooltip.html");
 }
+
+/// GUARD: the tray must hide the hover tooltip on mouse-DOWN, not only on Up.
+///
+/// tray-icon's `rightMouseDown:` emits a Down click event and then calls
+/// `performClick`, which runs the NSMenu in a modal tracking loop. That loop
+/// swallows `rightMouseUp:`, so an Up-only handler never fires for a
+/// right-click and the tooltip strands on screen behind the context menu
+/// (`Leave` doesn't fire either while the menu holds the run loop). A previous
+/// fix added a right-button branch but left it inside the Up arm, so it could
+/// never run - hence this guard is on the Down arm specifically.
+///
+/// Static source assertion because tray-icon events need a real menu-bar click
+/// and a running event loop, which CI has no way to drive.
+#[test]
+fn tray_hides_tooltip_on_mouse_down() {
+    let src = read_text("tray/src-tauri/src/lib.rs");
+    let down_arm = src.find("button_state: MouseButtonState::Down").expect(
+        "tray click handler must match MouseButtonState::Down - without it a \
+                 right-click leaves the hover tooltip stranded (the NSMenu tracking \
+                 loop swallows rightMouseUp:, so the Up arm never fires)",
+    );
+    let rest = &src[down_arm..];
+    let arm_end = rest.find("MouseButtonState::Up").unwrap_or(rest.len());
+    assert!(
+        rest[..arm_end].contains("tray-tooltip") && rest[..arm_end].contains("hide()"),
+        "the MouseButtonState::Down arm must hide the tray-tooltip window",
+    );
+}

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -471,6 +471,26 @@ pub fn run() {
                 .on_tray_icon_event(|tray_handle, event| {
                     let app = tray_handle.app_handle();
                     match &event {
+                        // Hide the tooltip on mouse-DOWN, which is the only click event
+                        // a right-click reliably delivers. tray-icon's `rightMouseDown:`
+                        // emits Down and then calls performClick, which runs the NSMenu
+                        // in a modal tracking loop; that loop swallows `rightMouseUp:`,
+                        // so the Up arm below never fires for a right-click, and `Leave`
+                        // doesn't either while the menu holds the run loop. Hiding here
+                        // is what actually stops the tooltip stranding behind the menu —
+                        // the Up arm's hide alone could never run for a right-click.
+                        // Left-click hides here too and is harmless: the Up arm then
+                        // takes over and toggles the popover.
+                        TrayIconEvent::Click {
+                            button,
+                            button_state: MouseButtonState::Down,
+                            ..
+                        } => {
+                            tracing::info!(?button, "tray.event: Click(Down) — hiding tooltip");
+                            if let Some(tt) = app.get_webview_window("tray-tooltip") {
+                                let _ = tt.hide();
+                            }
+                        }
                         TrayIconEvent::Click {
                             button,
                             button_state: MouseButtonState::Up,
@@ -478,10 +498,9 @@ pub fn run() {
                             ..
                         } => {
                             tracing::info!(?button, "tray.event: Click");
-                            // Hide the hover tooltip on ANY click — left (popover takes
-                            // over) or right (native menu takes over). Right-click was
-                            // previously unhandled here, leaving the tooltip stuck
-                            // visible behind the context menu.
+                            // Belt-and-braces for the left-click path (and any platform
+                            // that delivers Up without a preceding Down) — the Down arm
+                            // above is what covers right-click.
                             if let Some(tt) = app.get_webview_window("tray-tooltip") {
                                 let _ = tt.hide();
                             }

--- a/tray/src/style.css
+++ b/tray/src/style.css
@@ -35,6 +35,24 @@
      .font-mono below). */
   --font-sans: -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, "Segoe UI", helvetica, sans-serif;
   --font-mono: var(--font-sans);
+
+  /* Type scale — hand-synced with the .mt-* classes in ui/app/globals.css.
+     The tray popover and tooltip are plain webviews with no Tailwind and no
+     import path to the dashboard's stylesheet, so the VALUES are mirrored here
+     as tokens rather than the classes being shared. Consume with the `font`
+     shorthand (`font: var(--mt-body-sm)`); letter-spacing is separate because the
+     shorthand can't carry it — the paired --mt-*-tracking tokens supply it.
+     Before these existed, every rule below hand-rolled its own size/weight,
+     which is how the tooltip title ended up at weight 450 — a weight that
+     appears nowhere in the dashboard. Keep in sync when globals.css changes.
+     Only the steps these two surfaces actually use are mirrored; add more from
+     globals.css's .mt-* block as new surfaces need them. */
+  --mt-card-title: 700 13.5px var(--font-sans);
+  --mt-body-sm:    500 12px/1.45 var(--font-sans);
+  --mt-body-xs:    500 11.5px/1.45 var(--font-sans);
+  --mt-label:      700 11px var(--font-sans);
+  --mt-card-title-tracking: -0.01em;
+  --mt-label-tracking:      0.08em;
 }
 
 *, *::before, *::after {
@@ -110,8 +128,8 @@ button:focus-visible {
 }
 
 .kicker {
-  font: 700 10.5px var(--font-sans);
-  letter-spacing: 0.07em;
+  font: var(--mt-label);
+  letter-spacing: var(--mt-label-tracking);
   color: var(--ink-3);
 }
 
@@ -145,7 +163,7 @@ button:focus-visible {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font: 600 11px var(--font-sans);
+  font: var(--mt-body-xs);
   color: var(--ink-3);
   margin-top: 1px;
   overflow: hidden;
@@ -200,11 +218,11 @@ button:focus-visible {
 .health-dot[data-state="bad"]  { background: #e53e3e; }
 .health-label {
   flex: 1;
-  font: 600 11.5px var(--font-sans);
+  font: var(--mt-body-xs);
   color: var(--ink-2);
 }
 .health-val {
-  font: 500 11px var(--font-sans);
+  font: var(--mt-body-xs);
   color: var(--ink-3);
   font-variant-numeric: tabular-nums;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
@@ -256,14 +274,15 @@ button:focus-visible {
 
 .status-text { flex: 1; min-width: 0; }
 .status-title {
-  font: 700 13.5px var(--font-sans);
+  font: var(--mt-card-title);
+  letter-spacing: var(--mt-card-title-tracking);
   letter-spacing: -0.01em;
   color: #0F7A54;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .status-card.paused .status-title { color: #B4690E; }
 .status-sub {
-  font: 600 11.5px var(--font-sans);
+  font: var(--mt-body-xs);
   color: #4FA383;
   margin-top: 1px;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
@@ -401,7 +420,7 @@ button:focus-visible {
 }
 .privacy-line svg { flex: none; color: #8B7FB8; }
 .privacy-line span {
-  font: 600 10.5px/1.35 var(--font-sans);
+  font: var(--mt-body-xs);
   flex: 1;
 }
 
@@ -423,7 +442,7 @@ button:focus-visible {
   flex-shrink: 0; width: 18px; height: 18px; border-radius: 6px;
   font-size: 12px; font-weight: 700; color: #fff; background: var(--accent);
 }
-.upd-text { font-size: 12px; color: var(--ink); font-weight: 500; white-space: nowrap; }
+.upd-text { font: var(--mt-body-sm); color: var(--ink); white-space: nowrap; }
 .upd-ver {
   font-family: var(--font-mono); font-size: 10px; color: var(--ink-3);
   flex-shrink: 0; white-space: nowrap;

--- a/tray/src/tooltip.css
+++ b/tray/src/tooltip.css
@@ -42,9 +42,8 @@ body {
 }
 
 .tt-key {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 600;
+  font: var(--mt-label);
+  letter-spacing: var(--mt-label-tracking);
   color: var(--ink);
   background: var(--surface-2);
   border: 0.5px solid var(--rule-2);
@@ -55,7 +54,7 @@ body {
 }
 
 .tt-status {
-  font-size: 11.5px;
+  font: var(--mt-body-sm);
   color: var(--ink-3);
   flex: 1;
   min-width: 0;
@@ -65,8 +64,7 @@ body {
 }
 
 .tt-priority {
-  font-size: 11px;
-  font-weight: 500;
+  font: var(--mt-body-xs);
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -76,8 +74,8 @@ body {
 
 /* ── Title ── */
 .tt-title {
-  font-size: 13.5px;
-  font-weight: 450;
+  font: var(--mt-card-title);
+  letter-spacing: var(--mt-card-title-tracking);
   line-height: 1.35;
   color: var(--ink);
   margin-bottom: 11px;
@@ -96,15 +94,15 @@ body {
 }
 
 .tt-time {
-  font-family: var(--font-mono);
-  font-size: 12px;
+  font: var(--mt-body-sm);
+  font-variant-numeric: tabular-nums;
   color: var(--ink-2);
 }
 
 .tt-pct {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  font-weight: 600;
+  font: var(--mt-body-sm);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
   color: var(--accent);
 }
 
@@ -132,8 +130,7 @@ body {
 }
 
 .tt-ctx {
-  font-family: var(--font-mono);
-  font-size: 10.5px;
+  font: var(--mt-body-xs);
   color: var(--ink-3);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -143,7 +140,7 @@ body {
 }
 
 .tt-hint {
-  font-size: 10.5px;
+  font: var(--mt-body-xs);
   color: var(--ink-4);
   white-space: nowrap;
   flex-shrink: 0;


### PR DESCRIPTION
Recovers two commits from `fix/tray-tooltip-dismiss` (Jul 18) that were never landed. Both cherry-pick cleanly onto current `pre-main` despite ~915 lines of drift in `lib.rs` since.

## The bug (still live on `pre-main`)

Right-clicking the tray icon leaves the hover tooltip stranded on screen behind the native context menu.

An earlier attempt (`#42e67ce3`) tried to fix this by hiding the tooltip for any button, but put the hide inside the `MouseButtonState::Up` arm — where it can never run for a right-click:

tray-icon's `rightMouseDown:` emits a **Down** click event and then calls `performClick`, which runs the NSMenu in a modal tracking loop. That loop swallows `rightMouseUp:`, so the `Up` arm never fires — and `Leave` doesn't either, since the menu holds the run loop. The tooltip therefore has no path to hide until the next unrelated event.

Confirmed still unfixed upstream: `MouseButtonState::Down` appears **0 times** in `pre-main`'s `lib.rs`.

## The fix

Hide from a new **Down** arm, the one click event a right-click reliably delivers. Left-click hides there too and is harmless — the `Up` arm still toggles the popover, and keeps its own hide for the left-click path and for any platform that delivers `Up` without a preceding `Down`.

Second commit puts the tooltip and popover on the dashboard's shared `.mt-*` type scale, replacing inline one-offs.

## Test plan

- [x] `cargo test --test tray_assets` — 13 passed, including the new `tray_hides_tooltip_on_mouse_down` guard
- [x] `cargo test --lib` (tray) — 193 passed
- [x] `cargo clippy --lib -- -D warnings` + `cargo fmt --check` — clean
- [x] Full pre-push suite (fmt + UI build + clippy + UI tests + security audit + cargo test) — green
- [ ] **Manual verification not done** — right-click behaviour needs a real menu-bar click and a running event loop, which CI cannot drive. That is precisely why the commit ships a static source assertion in `tests/tray_assets.rs` instead (the original author verified it fails against the pre-fix source). The CSS commit is likewise unverified visually.

## Provenance

Original commits by @Akarsh-Hegde, 2026-07-18, cherry-picked unmodified (`c0fce126`, `42ba1747`). Authorship and messages preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)