### PR TITLE
fix(tray): build the lazy meridian.db pool inside a Tokio runtime

### DIFF
--- a/meridian-core/src/db.rs
+++ b/meridian-core/src/db.rs
@@ -90,9 +90,13 @@ pub async fn open_existing(uri: &str, key: Option<&str>) -> anyhow::Result<Sqlit
 ///
 /// Because no connection is attempted here, a returned `Ok` says nothing about
 /// reachability — use [`ping`] when you want that answer at a point in time.
+///
+/// Must be called from inside a Tokio runtime even though it never awaits — see
+/// [`crate::db_crypto::open_pool_with_key_lazy`] for why building the handle
+/// needs one, and why that requirement is encoded in the signature.
 #[tracing::instrument(skip_all, fields(uri = %uri, encrypted = key.is_some()))]
-pub fn open_existing_lazy(uri: &str, key: Option<&str>) -> anyhow::Result<SqlitePool> {
-    let pool = crate::db_crypto::open_pool_with_key_lazy(uri, key)?;
+pub async fn open_existing_lazy(uri: &str, key: Option<&str>) -> anyhow::Result<SqlitePool> {
+    let pool = crate::db_crypto::open_pool_with_key_lazy(uri, key).await?;
     tracing::info!(
         uri,
         encrypted = key.is_some(),

--- a/meridian-core/src/db_crypto.rs
+++ b/meridian-core/src/db_crypto.rs
@@ -148,10 +148,22 @@ pub async fn open_pool_with_key(
 /// means the pool always keys (or declines to key) against the file as it
 /// actually is when the connection is made.
 ///
-/// Non-async and infallible-to-connect by construction — the only error it can
-/// return is a malformed `uri` or `key_hex`. `create_if_missing` is always
-/// false: the daemon owns creation and migrations (see [`crate::db`]).
-pub fn open_pool_with_key_lazy(uri: &str, key_hex: Option<&str>) -> anyhow::Result<SqlitePool> {
+/// # Must be called from inside a Tokio runtime
+/// `async` even though it never awaits, and that is load-bearing: sqlx's
+/// `connect_lazy_with` spawns the pool's maintenance task while *building* the
+/// handle, so it panics with "this functionality requires a Tokio context" when
+/// constructed outside a runtime. Being `async` forces every caller through an
+/// executor (`block_on` / `.await`) instead of leaving that requirement to a
+/// comment nobody reads — which is exactly how it was first shipped broken, as
+/// a synchronous call in Tauri's `setup()` that panicked the tray on launch.
+///
+/// Infallible-to-connect by construction — the only error it can return is a
+/// malformed `uri` or `key_hex`. `create_if_missing` is always false: the
+/// daemon owns creation and migrations (see [`crate::db`]).
+pub async fn open_pool_with_key_lazy(
+    uri: &str,
+    key_hex: Option<&str>,
+) -> anyhow::Result<SqlitePool> {
     if let Some(k) = key_hex {
         validate_key_hex(k)?;
     }
@@ -829,6 +841,7 @@ mod tests {
         // retry window is itself useful here — a command issued during the
         // first-launch gap tends to succeed rather than error.)
         let pool = open_pool_with_key_lazy(&uri, Some(TEST_KEY))
+            .await
             .expect("building a lazy pool must not require the file to exist");
 
         // The daemon creates and populates the database (encrypted, as it does
@@ -866,7 +879,7 @@ mod tests {
         let db_path = dir.path().join("meridian.db");
         let uri = db_path.display().to_string();
 
-        let pool = open_pool_with_key_lazy(&uri, Some(TEST_KEY)).unwrap();
+        let pool = open_pool_with_key_lazy(&uri, Some(TEST_KEY)).await.unwrap();
 
         // Create it PLAINTEXT after the pool was built (the stuck
         // encrypt-in-place state: key configured, file still in the clear).

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -381,11 +381,21 @@ pub fn run() {
             // restart the tray. A lazy pool connects on first use instead, so
             // the very next command or frame after the daemon creates the file
             // succeeds on its own.
-            let db_pool = meridian_core::open_existing_lazy(&db_path, db_key_hex.as_deref())
-                .map_err(
-                    |e| tracing::error!(error = %e, db_path = %db_path, "meridian.db pool not prepared"),
-                )
-                .ok();
+            // `block_on`, not a bare call: sqlx spawns the pool's maintenance
+            // task while BUILDING the lazy handle, so constructing it outside a
+            // Tokio runtime panics ("this functionality requires a Tokio
+            // context") and takes the whole tray down before the tray icon even
+            // appears. `setup()` is not itself async, so the runtime has to be
+            // entered explicitly here — exactly as the eager open it replaced
+            // already did.
+            let db_pool = tauri::async_runtime::block_on(meridian_core::open_existing_lazy(
+                &db_path,
+                db_key_hex.as_deref(),
+            ))
+            .map_err(
+                |e| tracing::error!(error = %e, db_path = %db_path, "meridian.db pool not prepared"),
+            )
+            .ok();
             // A lazy pool cannot report reachability at build time, and losing
             // that startup signal is how the failure above stayed invisible for
             // a whole session. Probe once, purely to log it — an unreachable DB


### PR DESCRIPTION
## Hotfix — the tray does not launch at all

**Regression from #638, already on `pre-main` and shipped in `1.78.0-staging.15`.** Clicking the app does nothing: the process starts, panics inside Tauri's `setup()`, and exits before the tray icon appears.

```
thread 'main' panicked at sqlx-core-0.7.2/src/pool/inner.rs:503:5:
this functionality requires a Tokio context
```

### Cause

sqlx spawns the pool's maintenance task while **building** the handle, so constructing a pool — lazy or eager — requires an active Tokio runtime. The eager open that #638 replaced was wrapped in `tauri::async_runtime::block_on`, which supplied one:

```rust
// before #638
let db_pool = tauri::async_runtime::block_on(meridian_core::open_existing(...))
```

The lazy replacement was called synchronously, and `setup()` is not async, so nothing provided a context:

```rust
// #638 — panics
let db_pool = meridian_core::open_existing_lazy(&db_path, db_key_hex.as_deref())
```

I removed the wrapper without noticing it was carrying the runtime requirement, not just awaiting a future.

### Why CI passed

It is a runtime panic on a path no test exercises — nothing constructs the tray or runs `setup()`. `cargo clippy` and `cargo test` were green on #638 and are green on the shipped `pre-main`. Worth being explicit about, because it is a structural blind spot: **the tray's startup path has no test coverage at all**, so any panic there ships silently.

### Fix

**1. The call site goes back through `block_on`.** The same `setup()` already does `tauri::async_runtime::block_on(migrate)` for `encrypt_in_place` forty lines earlier, so the context is known-good at exactly that point.

```rust
let db_pool = tauri::async_runtime::block_on(
    meridian_core::open_existing_lazy(&db_path, db_key_hex.as_deref()),
)
```

**2. Both lazy openers become `async`** even though they never await. This is load-bearing, not cosmetic: it forces every caller through an executor, so the runtime requirement is carried by the **signature** rather than by a comment nobody reads. A synchronous call is now a compile error — which is precisely the mistake that shipped.

```rust
pub async fn open_pool_with_key_lazy(...) -> anyhow::Result<SqlitePool>   // db_crypto.rs
pub async fn open_existing_lazy(...)     -> anyhow::Result<SqlitePool>   // db.rs
```

The two existing lazy-pool tests are `#[tokio::test]` already and just gain `.await`.

### Verification

- Reproduced directly: launching the installed `1.78.0-staging.15` tray with stderr captured produces the panic above and an immediate exit.
- `cargo test -p meridian-core --lib db_crypto` run locally on this branch (both lazy-pool tests pass).
- The `block_on` context is proven twice over — by the pre-existing `encrypt_in_place` call in the same function, and by the eager `open_existing` that worked in every release before #638.

### Follow-up worth considering (not in this PR)

The lack of any smoke test around tray startup is what let a launch-blocking panic reach a staging build with fully green CI. Even a minimal test that constructs the managed state the way `setup()` does would have caught this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
