### PR TITLE
Release: pre-main → main

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -572,12 +572,9 @@ if [[ "${NO_DAEMON}" -eq 0 ]]; then
     # to your tracker (Jira/Linear/GitHub) only after you approve them in the
     # dashboard (Worklogs view).
 
-    info "Installing session-summary Claude Code command..."
-    if run "${MERIDIAN_BIN}" coding-agent-install-skill; then
-        ok "session-summary command → ~/.claude/commands/session-summary.md"
-    else
-        warn "session-summary command install skipped — run 'meridian coding-agent-install-skill' later"
-    fi
+    # No session-summary Claude Code command is installed any more: the Claude
+    # summariser embeds its prompt inline in `claude -p`, so the file this step
+    # used to write was never read. See src/coding_agent_session_ingest/summariser/claude.rs.
 
     # Coding-agent summariser engines (informational): each agent's sessions are
     # summarised by its OWN CLI when present. There is no fallback — a missing CLI

--- a/meridian-core/src/db.rs
+++ b/meridian-core/src/db.rs
@@ -90,9 +90,13 @@ pub async fn open_existing(uri: &str, key: Option<&str>) -> anyhow::Result<Sqlit
 ///
 /// Because no connection is attempted here, a returned `Ok` says nothing about
 /// reachability — use [`ping`] when you want that answer at a point in time.
+///
+/// Must be called from inside a Tokio runtime even though it never awaits — see
+/// [`crate::db_crypto::open_pool_with_key_lazy`] for why building the handle
+/// needs one, and why that requirement is encoded in the signature.
 #[tracing::instrument(skip_all, fields(uri = %uri, encrypted = key.is_some()))]
-pub fn open_existing_lazy(uri: &str, key: Option<&str>) -> anyhow::Result<SqlitePool> {
-    let pool = crate::db_crypto::open_pool_with_key_lazy(uri, key)?;
+pub async fn open_existing_lazy(uri: &str, key: Option<&str>) -> anyhow::Result<SqlitePool> {
+    let pool = crate::db_crypto::open_pool_with_key_lazy(uri, key).await?;
     tracing::info!(
         uri,
         encrypted = key.is_some(),

--- a/meridian-core/src/db.rs
+++ b/meridian-core/src/db.rs
@@ -13,7 +13,8 @@
 //! rides out the daemon's short write transactions.
 //!
 //! Re-exported at the crate root (`meridian_core::{open_existing,
-//! get_active_session, ActiveSession}`) — `db` is internal organization only.
+//! open_existing_lazy, ping, get_active_session, ActiveSession}`) — `db` is
+//! internal organization only.
 
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
@@ -72,6 +73,50 @@ pub async fn open_existing(uri: &str, key: Option<&str>) -> anyhow::Result<Sqlit
         "opened meridian.db (WAL, 5s busy_timeout)"
     );
     Ok(pool)
+}
+
+/// Same contract as [`open_existing`], but the pool is built **without
+/// connecting** — the first connection is made on demand and every later
+/// acquire retries, so a database that does not exist yet is recovered from
+/// automatically once it appears.
+///
+/// This is what the tray uses at startup. It must not require `meridian.db` to
+/// already exist: on a first launch the tray builds this handle seconds before
+/// it installs and starts the daemon that creates the file, and an eager open
+/// there yields a `None` pool that nothing ever retries — disabling every
+/// DB-backed command and silently discarding every captured frame until the
+/// user restarts the tray. See [`crate::db_crypto::open_pool_with_key_lazy`]
+/// for the full rationale and for why the key decision is per-connection.
+///
+/// Because no connection is attempted here, a returned `Ok` says nothing about
+/// reachability — use [`ping`] when you want that answer at a point in time.
+#[tracing::instrument(skip_all, fields(uri = %uri, encrypted = key.is_some()))]
+pub fn open_existing_lazy(uri: &str, key: Option<&str>) -> anyhow::Result<SqlitePool> {
+    let pool = crate::db_crypto::open_pool_with_key_lazy(uri, key)?;
+    tracing::info!(
+        uri,
+        encrypted = key.is_some(),
+        "prepared meridian.db pool (lazy, WAL, 5s busy_timeout)"
+    );
+    Ok(pool)
+}
+
+/// Acquire one connection and run `SELECT 1`, reporting whether the database is
+/// reachable *right now*.
+///
+/// Exists for [`open_existing_lazy`]'s callers: a lazy pool cannot fail at
+/// build time, so without an explicit probe a tray whose database is
+/// unreachable would produce no startup signal at all — which is precisely how
+/// the first-launch failure this pair replaces stayed invisible for a whole
+/// session. Purely diagnostic: callers log the result and carry on, because the
+/// pool recovers by itself.
+#[tracing::instrument(skip_all)]
+pub async fn ping(pool: &SqlitePool) -> anyhow::Result<()> {
+    sqlx::query("SELECT 1")
+        .execute(pool)
+        .await
+        .context("ping: meridian.db is not reachable")?;
+    Ok(())
 }
 
 /// Read the single active session (the `active_session` row, id = 1), or `None`.

--- a/meridian-core/src/db_crypto.rs
+++ b/meridian-core/src/db_crypto.rs
@@ -148,10 +148,22 @@ pub async fn open_pool_with_key(
 /// means the pool always keys (or declines to key) against the file as it
 /// actually is when the connection is made.
 ///
-/// Non-async and infallible-to-connect by construction — the only error it can
-/// return is a malformed `uri` or `key_hex`. `create_if_missing` is always
-/// false: the daemon owns creation and migrations (see [`crate::db`]).
-pub fn open_pool_with_key_lazy(uri: &str, key_hex: Option<&str>) -> anyhow::Result<SqlitePool> {
+/// # Must be called from inside a Tokio runtime
+/// `async` even though it never awaits, and that is load-bearing: sqlx's
+/// `connect_lazy_with` spawns the pool's maintenance task while *building* the
+/// handle, so it panics with "this functionality requires a Tokio context" when
+/// constructed outside a runtime. Being `async` forces every caller through an
+/// executor (`block_on` / `.await`) instead of leaving that requirement to a
+/// comment nobody reads — which is exactly how it was first shipped broken, as
+/// a synchronous call in Tauri's `setup()` that panicked the tray on launch.
+///
+/// Infallible-to-connect by construction — the only error it can return is a
+/// malformed `uri` or `key_hex`. `create_if_missing` is always false: the
+/// daemon owns creation and migrations (see [`crate::db`]).
+pub async fn open_pool_with_key_lazy(
+    uri: &str,
+    key_hex: Option<&str>,
+) -> anyhow::Result<SqlitePool> {
     if let Some(k) = key_hex {
         validate_key_hex(k)?;
     }
@@ -829,6 +841,7 @@ mod tests {
         // retry window is itself useful here — a command issued during the
         // first-launch gap tends to succeed rather than error.)
         let pool = open_pool_with_key_lazy(&uri, Some(TEST_KEY))
+            .await
             .expect("building a lazy pool must not require the file to exist");
 
         // The daemon creates and populates the database (encrypted, as it does
@@ -866,7 +879,7 @@ mod tests {
         let db_path = dir.path().join("meridian.db");
         let uri = db_path.display().to_string();
 
-        let pool = open_pool_with_key_lazy(&uri, Some(TEST_KEY)).unwrap();
+        let pool = open_pool_with_key_lazy(&uri, Some(TEST_KEY)).await.unwrap();
 
         // Create it PLAINTEXT after the pool was built (the stuck
         // encrypt-in-place state: key configured, file still in the clear).

--- a/meridian-core/src/db_crypto.rs
+++ b/meridian-core/src/db_crypto.rs
@@ -54,6 +54,18 @@ fn key_pragma(key_hex: &str) -> String {
     format!("PRAGMA key = \"x'{key_hex}'\"")
 }
 
+/// The standard connection pragmas every read-write `meridian.db` pool applies,
+/// in order, AFTER `PRAGMA key`.
+///
+/// Shared by [`open_pool_with_key`] and [`open_pool_with_key_lazy`] so a pragma
+/// added for one opener can never be silently missed by the other — the two
+/// differ only in *when* they connect, never in how a connection is set up.
+const BASE_PRAGMAS: [&str; 3] = [
+    "PRAGMA journal_mode=WAL;",
+    "PRAGMA synchronous=NORMAL;",
+    "PRAGMA busy_timeout=5000;",
+];
+
 /// Open a pool at `uri`, applying the SQLCipher key (if any) as the FIRST
 /// statement on every new physical connection, before any other pragma.
 ///
@@ -95,9 +107,9 @@ pub async fn open_pool_with_key(
                 if let Some(k) = &key_owned {
                     conn.execute(key_pragma(k).as_str()).await?;
                 }
-                conn.execute("PRAGMA journal_mode=WAL;").await?;
-                conn.execute("PRAGMA synchronous=NORMAL;").await?;
-                conn.execute("PRAGMA busy_timeout=5000;").await?;
+                for pragma in BASE_PRAGMAS {
+                    conn.execute(pragma).await?;
+                }
                 for (name, value) in extra_pragmas {
                     conn.execute(format!("PRAGMA {name}={value};").as_str())
                         .await?;
@@ -109,6 +121,63 @@ pub async fn open_pool_with_key(
         .await
         .with_context(|| format!("failed to open SQLite at {uri}"))?;
     Ok(pool)
+}
+
+/// Build a pool at `uri` **without connecting**, applying the same key and
+/// pragmas as [`open_pool_with_key`] on each connection the pool later opens
+/// on demand.
+///
+/// # Why this exists
+/// The tray opens `meridian.db` once during Tauri `setup` and shares the handle
+/// with every DB-backed command and the capture consumers. On a **first
+/// launch** it reaches that point seconds before `ensure_backend_installed`
+/// starts the daemon — and the daemon is what CREATES `meridian.db`. An eager
+/// open therefore fails with "unable to open database file", and because the
+/// tray stores the result as an `Option` there is nothing that ever retries:
+/// the whole process runs to shutdown with `None`, silently returning empty
+/// data from every command and dropping every captured frame on the floor.
+/// Connecting lazily makes that self-healing — the first acquire after the
+/// daemon creates the file succeeds, with no restart and no retry loop.
+///
+/// # Why the key decision moves into `after_connect`
+/// [`key_unless_plaintext`] probes the file header to decide whether the key
+/// applies at all. [`open_pool_with_key`] can evaluate that once up front
+/// because it has just proven the file is openable. A lazy pool has not: at
+/// build time the file routinely does not exist yet, and a decision cached
+/// from that moment would be made against nothing. Re-resolving per connection
+/// means the pool always keys (or declines to key) against the file as it
+/// actually is when the connection is made.
+///
+/// Non-async and infallible-to-connect by construction — the only error it can
+/// return is a malformed `uri` or `key_hex`. `create_if_missing` is always
+/// false: the daemon owns creation and migrations (see [`crate::db`]).
+pub fn open_pool_with_key_lazy(uri: &str, key_hex: Option<&str>) -> anyhow::Result<SqlitePool> {
+    if let Some(k) = key_hex {
+        validate_key_hex(k)?;
+    }
+    let opts = SqliteConnectOptions::from_str(uri)
+        .with_context(|| format!("invalid SQLite URI: {uri}"))?
+        .create_if_missing(false);
+
+    let uri_owned = uri.to_string();
+    let key_owned = key_hex.map(|s| s.to_string());
+    Ok(SqlitePoolOptions::new()
+        .acquire_timeout(std::time::Duration::from_secs(10)) // see open_pool_with_key
+        .after_connect(move |conn, _meta| {
+            let uri_owned = uri_owned.clone();
+            let key_owned = key_owned.clone();
+            Box::pin(async move {
+                // Resolved here, not at build time — see the doc comment above.
+                if let Some(k) = key_unless_plaintext(&uri_owned, key_owned.as_deref()) {
+                    conn.execute(key_pragma(k).as_str()).await?;
+                }
+                for pragma in BASE_PRAGMAS {
+                    conn.execute(pragma).await?;
+                }
+                Ok(())
+            })
+        })
+        .connect_lazy_with(opts))
 }
 
 /// Open a READ-ONLY pool at `uri`, applying the SQLCipher key (if any) as the
@@ -735,6 +804,90 @@ mod tests {
             .unwrap();
         assert_eq!(row.get::<i64, _>(0), 1);
         reopened.close().await;
+    }
+
+    /// The tray's first-launch regression, end to end: a pool built while
+    /// `meridian.db` does not exist yet must NOT be permanently dead. It may
+    /// fail while the file is absent, but the *same handle* has to start
+    /// working once the daemon creates the database — no reopen, no restart.
+    ///
+    /// Guards the bug this opener was added for: the tray built its pool
+    /// seconds before the daemon created the file, cached the failure as
+    /// `None`, and ran its whole session with every DB command returning empty
+    /// and every captured frame discarded.
+    #[tokio::test]
+    async fn lazy_pool_recovers_once_the_database_appears() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        let uri = db_path.display().to_string();
+        assert!(!db_path.exists());
+
+        // Built against nothing — this must still hand back a usable handle.
+        // (Not asserting that a query fails while the file is absent: sqlx
+        // retries a failed connect until the 10s acquire timeout, so such an
+        // assertion would just make this test sleep for ten seconds. That
+        // retry window is itself useful here — a command issued during the
+        // first-launch gap tends to succeed rather than error.)
+        let pool = open_pool_with_key_lazy(&uri, Some(TEST_KEY))
+            .expect("building a lazy pool must not require the file to exist");
+
+        // The daemon creates and populates the database (encrypted, as it does
+        // whenever MERIDIAN_DB_KEY is set).
+        let daemon = open_pool_with_key(&uri, Some(TEST_KEY), true, &[])
+            .await
+            .expect("daemon-side create should succeed");
+        sqlx::query("CREATE TABLE capture_frames (id INTEGER PRIMARY KEY)")
+            .execute(&daemon)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO capture_frames (id) VALUES (7)")
+            .execute(&daemon)
+            .await
+            .unwrap();
+        daemon.close().await;
+
+        // The ORIGINAL handle now works — this is the whole point.
+        let row = sqlx::query("SELECT id FROM capture_frames")
+            .fetch_one(&pool)
+            .await
+            .expect("the lazy pool must connect once the database exists");
+        assert_eq!(row.get::<i64, _>(0), 7);
+        pool.close().await;
+    }
+
+    /// The lazy opener resolves the key/plaintext question per connection, so a
+    /// plaintext database is opened unencrypted even though the pool was built
+    /// with a key — and built before the file existed, so nothing could have
+    /// been probed up front. Same guarantee [`key_unless_plaintext`] gives the
+    /// eager opener, at the point a lazy pool can actually make it.
+    #[tokio::test]
+    async fn lazy_pool_drops_the_key_for_a_plaintext_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        let uri = db_path.display().to_string();
+
+        let pool = open_pool_with_key_lazy(&uri, Some(TEST_KEY)).unwrap();
+
+        // Create it PLAINTEXT after the pool was built (the stuck
+        // encrypt-in-place state: key configured, file still in the clear).
+        let plain = open_pool_with_key(&uri, None, true, &[]).await.unwrap();
+        sqlx::query("CREATE TABLE t (x INTEGER)")
+            .execute(&plain)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO t (x) VALUES (3)")
+            .execute(&plain)
+            .await
+            .unwrap();
+        plain.close().await;
+        assert!(is_plaintext_sqlite(&db_path));
+
+        let row = sqlx::query("SELECT x FROM t")
+            .fetch_one(&pool)
+            .await
+            .expect("a keyed lazy pool must still read a plaintext database");
+        assert_eq!(row.get::<i64, _>(0), 3);
+        pool.close().await;
     }
 
     /// First rename (`path` → `backup`) fails: the encrypted export must be

--- a/meridian-core/src/lib.rs
+++ b/meridian-core/src/lib.rs
@@ -61,7 +61,7 @@ pub mod proc_ext;
 pub mod retry;
 
 // ── Curated public API: flat module paths, stable across file moves ──────────
-pub use db::{get_active_session, open_existing, ActiveSession};
+pub use db::{get_active_session, open_existing, open_existing_lazy, ping, ActiveSession};
 
 pub use capture::{
     insert_capture_frame, insert_capture_secondary_screen, insert_capture_ui_event,

--- a/ops/central-observability/LOCAL-ACCESS.md
+++ b/ops/central-observability/LOCAL-ACCESS.md
@@ -62,7 +62,9 @@ gcloud compute ssh --zone "asia-south1-a" "meridian-telemetry" --project "meridi
 cd central-observability
 container_id="$(docker compose ps -q openobserve)"
 test -n "$container_id" || { echo "openobserve service not running"; exit 1; }
-docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$container_id"
+address="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$container_id")"
+test -n "$address" || { echo "container has no network address"; exit 1; }
+echo "$address"
 # e.g. 172.18.0.2
 exit
 ```
@@ -108,7 +110,7 @@ curl --user "$OO_ROOT_USER_EMAIL" \
   -H 'Content-Type: application/json' \
   -d '{
     "query": {
-      "sql": "SELECT * FROM \"default\" WHERE body LIKE '\''%mac_970e5ebf236cb0ce%'\'' ORDER BY _timestamp DESC LIMIT 50",
+      "sql": "SELECT * FROM \"default\" WHERE host_name = '\''mac_970e5ebf236cb0ce'\'' ORDER BY _timestamp DESC LIMIT 50",
       "start_time": '"$start_time"',
       "end_time": '"$end_time"'
     }
@@ -123,10 +125,19 @@ Notes:
   window at run time so it never goes stale. `start_time`/`end_time` in the
   request body only bound the search window — they're independent of any
   `_timestamp` condition inside `sql`.
-- The log stream's actual column is `body`, not `message` — `SELECT * FROM
-  "default"` (or `/api/default/streams`) shows the full schema when unsure.
-  The stream/table name and available columns otherwise depend on what the
-  OTel Collector is configured to write (see `otel-collector-config.yaml`).
+- A Support ID is the pseudonymized `host_name` **resource attribute**, not
+  text inside the log message — filter on `host_name = '<support id>'`
+  (exact match), not a `LIKE` search over `body`. The log message column
+  itself is called `body`, not `message`.
+- If you do need a substring search over `body`, remember `_` and `%` are
+  SQL `LIKE` wildcards — a literal underscore (as in `mac_970e...`) matches
+  any single character unless escaped, e.g. `LIKE '%foo\_bar%' ESCAPE '\'`.
+  `host_name` needs no such escaping since it's an exact-match column, not a
+  pattern.
+- `SELECT * FROM "default"` (or `/api/default/streams`) shows the full
+  schema when unsure what's queryable — the stream/table name and available
+  columns otherwise depend on what the OTel Collector is configured to write
+  (see `otel-collector-config.yaml`).
 
 ## When you're done
 

--- a/ops/central-observability/LOCAL-ACCESS.md
+++ b/ops/central-observability/LOCAL-ACCESS.md
@@ -36,6 +36,15 @@ straight to OpenObserve's container port, entirely bypassing Caddy.
   calls. Ask whoever deployed the stack, or read them off the VM directly —
   never copy them into a file in this repo.
 
+  **Root is a stopgap, not the sanctioned end state.** The SSH tunnel bypasses
+  Caddy entirely, so "read-only" here is enforced only by the convention of
+  this doc — root can do anything the API allows, not just `_search`. Prefer
+  authenticating as a dedicated **Viewer**-role OpenObserve user (Settings ->
+  Users in the UI, or the `/api/{org}/users` endpoint) once one exists for
+  this org; ask whoever administers the instance to provision it. Provisioning
+  and rotating that account is tracked as follow-up work, not done as part of
+  this doc.
+
 **Run every command below in a real terminal on your own machine — not Google
 Cloud Shell.** Cloud Shell is a separate, ephemeral environment; the SSH
 tunnel's local port-forward has to bind on *your* machine, and running it in
@@ -49,17 +58,19 @@ because there's nothing local there to serve it to.
 ```bash
 gcloud compute ssh --zone "asia-south1-a" "meridian-telemetry" --project "meridiona-observability"
 
-# once on the VM:
-cd central-observability   # wherever docker-compose.yml lives on this VM
-docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \
-  central-observability-openobserve-1
+# once on the VM, in the directory with docker-compose.yml:
+cd central-observability
+container_id="$(docker compose ps -q openobserve)"
+test -n "$container_id" || { echo "openobserve service not running"; exit 1; }
+docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$container_id"
 # e.g. 172.18.0.2
 exit
 ```
 
-This only needs to be redone if the stack is redeployed and the container gets
-recreated (compose's private network typically hands out the same IP, but
-don't assume it).
+Resolving through the Compose service name (rather than a hardcoded container
+name) means this keeps working across a redeploy. Still re-run it after any
+redeploy though — the bridge IP is only stable for the container currently
+running; don't cache it.
 
 **2. Open the tunnel** (from your own terminal, not Cloud Shell):
 
@@ -75,20 +86,31 @@ session.
 **3. Verify:**
 
 ```bash
-curl http://127.0.0.1:5080/healthz   # expect 200 OK
+curl -fsS -o /dev/null -w 'HTTP %{http_code}\n' http://127.0.0.1:5080/healthz
 ```
+
+`-f` makes curl exit non-zero on a 4xx/5xx instead of silently reporting
+success on a transfer that completed but returned an error status.
 
 **4. Query `_search` directly:**
 
 ```bash
-curl -s -u '<OO_ROOT_USER_EMAIL>:<OO_ROOT_USER_PASSWORD>' \
+export OO_ROOT_USER_EMAIL='<from the VM .env>'
+# Give curl the user only, not "user:password" — it then prompts for the
+# password interactively, which keeps it out of shell history and `ps` output
+# (a literal '<user>:<password>' on the command line ends up in both).
+
+end_time=$(( $(date +%s) * 1000000 ))
+start_time=$(( end_time - 30 * 86400 * 1000000 ))   # last 30 days; adjust as needed
+
+curl --user "$OO_ROOT_USER_EMAIL" \
   -X POST 'http://127.0.0.1:5080/api/default/_search' \
   -H 'Content-Type: application/json' \
   -d '{
     "query": {
-      "sql": "SELECT * FROM \"default\" WHERE message LIKE '\''%mac_970e5ebf236cb0ce%'\'' ORDER BY _timestamp DESC LIMIT 50",
-      "start_time": 1735689600000000,
-      "end_time": 1753900800000000
+      "sql": "SELECT * FROM \"default\" WHERE body LIKE '\''%mac_970e5ebf236cb0ce%'\'' ORDER BY _timestamp DESC LIMIT 50",
+      "start_time": '"$start_time"',
+      "end_time": '"$end_time"'
     }
   }'
 ```
@@ -97,12 +119,14 @@ Notes:
 - Org is `default` (matches `OO_ORG` in `.env.example`) unless the deploy was
   changed.
 - `start_time`/`end_time` are **microsecond epoch timestamps** — `0` is
-  rejected with `invalid time range`. Compute a real window, e.g. in Python:
-  `int(time.time() * 1_000_000)` for "now", and subtract
-  `N * 86_400 * 1_000_000` for N days back.
-- The stream/table name and available columns depend on what the OTel
-  Collector is configured to write (see `otel-collector-config.yaml`) — when
-  unsure what's queryable, `SHOW STREAMS` or hit `/api/default/streams` first.
+  rejected with `invalid time range`; the snippet above computes a real
+  window at run time so it never goes stale. `start_time`/`end_time` in the
+  request body only bound the search window — they're independent of any
+  `_timestamp` condition inside `sql`.
+- The log stream's actual column is `body`, not `message` — `SELECT * FROM
+  "default"` (or `/api/default/streams`) shows the full schema when unsure.
+  The stream/table name and available columns otherwise depend on what the
+  OTel Collector is configured to write (see `otel-collector-config.yaml`).
 
 ## When you're done
 

--- a/ops/central-observability/LOCAL-ACCESS.md
+++ b/ops/central-observability/LOCAL-ACCESS.md
@@ -1,0 +1,111 @@
+# Querying the central OpenObserve instance locally (for Claude / ad-hoc debugging)
+
+How to pull data out of the central error-observability stack (`docker-compose.yml`
+in this directory) from your own machine, for one-off debugging — e.g. asking
+Claude Code to investigate a specific Support ID's errors. This is a
+read-only, ad-hoc path, not a persistent integration.
+
+## Why not just use the OpenObserve MCP server or the public HTTPS UI?
+
+- **MCP server**: OpenObserve's `/api/<org>/mcp` endpoint is an **Enterprise**
+  feature. Confirmed directly against this instance:
+  `{"error":"MCP server is only available in enterprise edition"}`. We run the
+  OSS image (`OO_IMAGE` in `.env.example`), so this path is closed — there is
+  no code fix, only an upgrade path we haven't taken.
+- **Public HTTPS UI/API** (`OO_UI_DOMAIN`, e.g. `observe.meridiona.com`): the
+  Caddyfile puts **two independent auth layers** in front of OpenObserve on
+  purpose (see the Caddyfile's comment) — Caddy basic auth, then OpenObserve's
+  own root login. A single `Authorization` header can't satisfy both at once,
+  so scripting `_search` calls straight against the public domain doesn't
+  work cleanly. That's deliberate defense-in-depth for a world-reachable
+  subdomain fronting customer error telemetry — **don't loosen it** to make
+  scripting easier.
+
+The sanctioned way around both of these for ad-hoc debugging is an SSH tunnel
+straight to OpenObserve's container port, entirely bypassing Caddy.
+
+## Prerequisites
+
+- `gcloud` CLI installed and authenticated against the `meridiona-observability`
+  GCP project (`brew install --cask google-cloud-sdk`, then `gcloud init` /
+  `gcloud auth login` if you haven't already).
+- SSH access to the `meridian-telemetry` VM (zone `asia-south1-a`) — the same
+  account that can `gcloud compute ssh` into it.
+- The OpenObserve root credentials (`OO_ROOT_USER_EMAIL` / `OO_ROOT_USER_PASSWORD`
+  from that VM's `.env`, not this repo's `.env.example`) to authenticate `_search`
+  calls. Ask whoever deployed the stack, or read them off the VM directly —
+  never copy them into a file in this repo.
+
+**Run every command below in a real terminal on your own machine — not Google
+Cloud Shell.** Cloud Shell is a separate, ephemeral environment; the SSH
+tunnel's local port-forward has to bind on *your* machine, and running it in
+Cloud Shell fails with `bind [::1]:5080: Cannot assign requested address`
+because there's nothing local there to serve it to.
+
+## Steps
+
+**1. Find OpenObserve's internal container IP** (SSH into the VM first):
+
+```bash
+gcloud compute ssh --zone "asia-south1-a" "meridian-telemetry" --project "meridiona-observability"
+
+# once on the VM:
+cd central-observability   # wherever docker-compose.yml lives on this VM
+docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \
+  central-observability-openobserve-1
+# e.g. 172.18.0.2
+exit
+```
+
+This only needs to be redone if the stack is redeployed and the container gets
+recreated (compose's private network typically hands out the same IP, but
+don't assume it).
+
+**2. Open the tunnel** (from your own terminal, not Cloud Shell):
+
+```bash
+gcloud compute ssh --zone "asia-south1-a" "meridian-telemetry" \
+  --project "meridiona-observability" -- -N -L 5080:172.18.0.2:5080
+```
+
+Replace `172.18.0.2` with whatever step 1 returned. This blocks (that's `-N`)
+— leave it running in its own terminal/tab for the duration of your debugging
+session.
+
+**3. Verify:**
+
+```bash
+curl http://127.0.0.1:5080/healthz   # expect 200 OK
+```
+
+**4. Query `_search` directly:**
+
+```bash
+curl -s -u '<OO_ROOT_USER_EMAIL>:<OO_ROOT_USER_PASSWORD>' \
+  -X POST 'http://127.0.0.1:5080/api/default/_search' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "query": {
+      "sql": "SELECT * FROM \"default\" WHERE message LIKE '\''%mac_970e5ebf236cb0ce%'\'' ORDER BY _timestamp DESC LIMIT 50",
+      "start_time": 1735689600000000,
+      "end_time": 1753900800000000
+    }
+  }'
+```
+
+Notes:
+- Org is `default` (matches `OO_ORG` in `.env.example`) unless the deploy was
+  changed.
+- `start_time`/`end_time` are **microsecond epoch timestamps** — `0` is
+  rejected with `invalid time range`. Compute a real window, e.g. in Python:
+  `int(time.time() * 1_000_000)` for "now", and subtract
+  `N * 86_400 * 1_000_000` for N days back.
+- The stream/table name and available columns depend on what the OTel
+  Collector is configured to write (see `otel-collector-config.yaml`) — when
+  unsure what's queryable, `SHOW STREAMS` or hit `/api/default/streams` first.
+
+## When you're done
+
+Kill the tunnel (`Ctrl-C` in the terminal running the `gcloud compute ssh -N -L …`
+command). Nothing on the VM needs cleanup — the tunnel is purely local
+port-forwarding, it doesn't change anything server-side.

--- a/scripts/meridian-cli.sh
+++ b/scripts/meridian-cli.sh
@@ -587,7 +587,7 @@ case "$CMD" in
     uninstall)        cmd_uninstall ;;
     permissions)      cmd_permissions ;;
     version|--version|-v) cat "${REPO_ROOT}/VERSION" 2>/dev/null || echo "unknown" ;;
-    worklog-status|coding-agent-hook|coding-agent-summarise|coding-agent-install-skill|oauth-login|tasks-sync|ticket-update|ticket-parents|ticket-statuses|ticket-set-status|worklog-generate|worklog-generate-get|worklog-generate-approve|worklog-post-approved) cmd_daemon_passthrough "$CMD" "$@" ;;
+    worklog-status|coding-agent-hook|coding-agent-summarise|oauth-login|tasks-sync|ticket-update|ticket-parents|ticket-statuses|ticket-set-status|worklog-generate|worklog-generate-get|worklog-generate-approve|worklog-post-approved) cmd_daemon_passthrough "$CMD" "$@" ;;
     --help|-h|help|"") cmd_help ;;
     *) err "unknown command: ${CMD}"; echo; cmd_help; exit 1 ;;
 esac

--- a/src/coding_agent_session_ingest/summariser/README.md
+++ b/src/coding_agent_session_ingest/summariser/README.md
@@ -145,7 +145,7 @@ standalone poll).
 | `SUMMARISER_SWEEP_S` | `30` | catch-up sweep cadence |
 | `SUMMARISER_BATCH_PER_TICK` | `8` | rows per drain pass |
 | `SUMMARISER_MODEL` | `claude-haiku-4-5-20251001` | Claude model |
-| `SUMMARISER_SKILL` | `session-summary` | skill name |
+| `SUMMARISER_SKILL` | `session-summary` | **DEPRECATED — no effect.** The Claude engine embeds `SUMMARY_RULES` inline in `claude -p`; it has not invoked a slash-skill since. Setting this to anything else only logs a warning. |
 | `SUMMARISER_CLAUDE_TIMEOUT_S` | `240` | `claude -p` timeout |
 | `SUMMARISER_CODEX_MODEL` | (empty → codex default) | Codex model |
 | `SUMMARISER_CODEX_TIMEOUT_S` | `240` | `codex exec` timeout |

--- a/src/coding_agent_session_ingest/summariser/README.md
+++ b/src/coding_agent_session_ingest/summariser/README.md
@@ -36,8 +36,9 @@ A fallback summary is recorded as `summary_source = "fallback:<provider>"`, so a
 summary written by a substitute is never mistaken for one the agent that did the
 work produced.
 
-- **Claude sessions → `claude -p`** (`claude.rs`) — loads the `session-summary`
-  skill, structured output. Runs on the user's Claude subscription;
+- **Claude sessions → `claude -p`** (`claude.rs`) — `SUMMARY_RULES` embedded
+  directly in the `-p` prompt (no slash-skill invocation), structured output.
+  Runs on the user's Claude subscription;
   `ANTHROPIC_API_KEY` is dropped from the child env so a stray key can't switch
   to metered billing. `MERIDIAN_SUMMARISER=1` makes the indexer hook ignore the
   throwaway session, and `--no-session-persistence` means no JSONL is written.
@@ -57,8 +58,8 @@ work produced.
   runs persist to `~/.cursor/chats/` — see "Self-ingest guard" below.
 
 All engines target the same `SUMMARY_SCHEMA` and share `SUMMARY_RULES`
-(`prompts.rs`): Claude via the skill's `SKILL.md`, the others via the prompt —
-kept in one place so they can't drift.
+(`prompts.rs`), embedded inline in each engine's own prompt (no slash-skill
+invocation for any of them) — kept in one place so they can't drift.
 
 ### Self-ingest guard
 

--- a/src/coding_agent_session_ingest/summariser/claude.rs
+++ b/src/coding_agent_session_ingest/summariser/claude.rs
@@ -1,6 +1,10 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 //
-// Run `claude -p` with the session-summary skill + structured output. Returns
+// Run `claude -p` with the summary rules embedded inline + structured output.
+// (It does NOT invoke a `/session-summary` slash-skill — that was replaced by
+// the inline SUMMARY_RULES prompt below, and `SUMMARISER_SKILL` is deprecated.
+// This comment claiming otherwise is what kept a stale doctor check alive.)
+// Returns
 // the validated {summary}, or RateLimited / Failed — both leave the row pending
 // for a later drain (no cross-engine fallback).
 //

--- a/src/health/codingagent.rs
+++ b/src/health/codingagent.rs
@@ -14,9 +14,6 @@ use std::path::PathBuf;
 pub fn checks(_cfg: &Config) -> Vec<Check> {
     let home = meridian_core::paths::home_dir_or_cwd();
 
-    let claude_present = which("claude").is_some();
-    let skill_path = home.join(".claude/commands/session-summary.md");
-
     let mut out = vec![
         cli("claude", "Claude Code"),
         cli("codex", "Codex"),
@@ -32,27 +29,19 @@ pub fn checks(_cfg: &Config) -> Vec<Check> {
         ),
     ];
 
-    // The session-summary skill must exist for `claude -p /session-summary` to
-    // work. Without it the command returns "Unknown command" and every Claude
-    // Code session fails to summarise and is left pending.
-    if claude_present {
-        if skill_path.exists() {
-            out.push(Check::ok(
-                "session-summary skill",
-                "L2",
-                "~/.claude/commands/session-summary.md present",
-            ));
-        } else {
-            out.push(
-                Check::warn(
-                    "session-summary skill",
-                    "L2",
-                    "~/.claude/commands/session-summary.md missing — claude summariser fails for every session (left pending)",
-                )
-                .with_remedy("meridian doctor --fix  (or: meridian coding-agent-install-skill)"),
-            );
-        }
-    }
+    // There is deliberately NO "session-summary skill" check here any more.
+    //
+    // It asserted that a missing ~/.claude/commands/session-summary.md meant
+    // "claude summariser fails for every session", which stopped being true
+    // when the Claude engine moved to embedding SUMMARY_RULES inline in
+    // `claude -p` (see `crate::coding_agent_session_ingest::summariser::claude`
+    // — `SUMMARISER_SKILL` is deprecated there and now only drives a warning).
+    // Nothing reads that file, so its absence diagnosed a failure that could
+    // not happen, escalated it to a critical Diagnosis, and offered a `doctor
+    // --fix` that wrote a file no code path opens.
+    //
+    // A genuinely stalled summariser is caught by "summariser queue" in
+    // `crate::health::daemon`, which measures the thing that actually matters.
 
     // Cursor: sidebar/IDE-agent transcripts are ingested from state.vscdb and
     // cursor-agent CLI chats from ~/.cursor/chats. Summaries use the

--- a/src/health/diagnose.rs
+++ b/src/health/diagnose.rs
@@ -49,14 +49,14 @@ pub fn root_causes(report: &Report) -> Vec<Diagnosis> {
 
     // 1. Coding-agent summariser cascade — sealed sessions must be summarised
     //    (via each agent's own CLI) before they reach the classifier and worklog.
-    if bad("coding-agent", "session-summary skill") {
-        out.push(Diagnosis {
-            title: "session-summary Claude Code command is missing".into(),
-            cause: "The `claude -p /session-summary` invocation that produces transcript summaries returns 'Unknown command' because ~/.claude/commands/session-summary.md doesn't exist, so Claude Code sessions can't be summarised.".into(),
-            contributing: contributing(&[("coding-agent", "session-summary skill")]),
-            action: "`meridian doctor --fix`  (or: `meridian coding-agent-install-skill`)".into(),
-        });
-    } else if bad("meridian daemon", "summariser queue") {
+    //
+    //    There used to be a higher-priority branch here for a missing
+    //    ~/.claude/commands/session-summary.md. It was stale: the Claude engine
+    //    embeds SUMMARY_RULES inline in `claude -p` and has not invoked a
+    //    slash-skill since (see `summariser::claude`), so the file's absence
+    //    means nothing — but this diagnosis outranked the queue check below,
+    //    which is the one that actually detects a stalled summariser.
+    if bad("meridian daemon", "summariser queue") {
         out.push(Diagnosis {
             title: "Coding-agent summariser is stalled".into(),
             cause: "Sealed sessions aren't being summarised, so they never reach the classifier and the worklog hour-ledger backs up behind them.".into(),

--- a/src/health/diagnose.rs
+++ b/src/health/diagnose.rs
@@ -220,6 +220,38 @@ mod tests {
         assert_eq!(dx[0].contributing.len(), 2);
     }
 
+    /// The branch-priority regression, pinned.
+    ///
+    /// `root_causes` used to test a "session-summary skill" check FIRST, in an
+    /// `if/else if` chain ahead of "summariser queue". That check fired on any
+    /// machine missing `~/.claude/commands/session-summary.md` — a file nothing
+    /// reads — so a genuinely stalled summariser was reported as a phantom
+    /// skill problem and the real diagnosis never ran at all.
+    ///
+    /// This deliberately feeds in BOTH signals rather than asserting the queue
+    /// branch works alone (`summariser_backlog_chains_to_one_root_cause`
+    /// already covers that): the bug was only ever visible when something else
+    /// in the chain outranked it. Any future higher-priority branch that
+    /// swallows a real stall the same way fails here.
+    #[test]
+    fn a_coding_agent_warning_does_not_mask_a_real_summariser_stall() {
+        let report = Report::new(vec![
+            Check::warn("session-summary skill", "L2", "missing").in_group("coding-agent"),
+            Check::warn("summariser queue", "L2", "293 backed up").in_group("meridian daemon"),
+        ]);
+        let dx = root_causes(&report);
+        let titles: Vec<&str> = dx.iter().map(|d| d.title.as_str()).collect();
+        assert!(
+            titles.iter().any(|t| t.contains("summariser")),
+            "a real summariser stall must still be diagnosed, got: {titles:?}"
+        );
+        // …and the removed check must never come back as a diagnosis of its own.
+        assert!(
+            !titles.iter().any(|t| t.contains("session-summary")),
+            "the deleted session-summary skill check must not diagnose anything, got: {titles:?}"
+        );
+    }
+
     #[test]
     fn healthy_report_has_no_diagnosis() {
         let report = Report::new(vec![Check::ok("x", "L1", "fine").in_group("system")]);

--- a/src/health/fix.rs
+++ b/src/health/fix.rs
@@ -62,11 +62,10 @@ pub fn fix_for(c: &Check) -> Option<FixAction> {
         ("jira", name) if name.contains("ticket sync") => {
             guided("refresh the Jira ticket cache", &["meridian", "restart"])
         }
-        // Missing session-summary skill → write the file (safe, idempotent).
-        ("coding-agent", name) if name.contains("session-summary skill") => auto(
-            "install the session-summary Claude Code command",
-            &["meridian", "coding-agent-install-skill"],
-        ),
+        // (No arm for "session-summary skill": the check that produced it is
+        // gone — the Claude engine embeds its prompt inline and never invokes a
+        // slash-skill, so `coding-agent-install-skill` wrote a file nothing
+        // read. See `summariser::claude`.)
         // Summariser backlog → drain it (mutates data → guided).
         ("meridian daemon", name) if name.contains("summariser queue") => guided(
             "drain the summariser queue",

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,13 +14,40 @@ use tokio::sync::Notify;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // 1. Load the repo-local .env — the single source of config for the daemon.
-    //    Nothing is read from outside the repo.
-    //    The launchd plist sets WorkingDirectory to the repo root, so
-    //    dotenv_override reads <repo>/.env and its values beat any empty
-    //    defaults injected by the plist. (CLI subcommands invoked from elsewhere
-    //    fall back to built-in defaults, e.g. MERIDIAN_DB → ~/.meridian/meridian.db.)
+    // 1. Load the working-directory .env. `dotenv_override` walks UP from the
+    //    CWD and stops at the first `.env`, so a source/dev run picks up
+    //    <repo>/.env, and on macOS — where the launchd plist sets
+    //    WorkingDirectory — a packaged install picks up ~/.meridian/.env. Its
+    //    values beat any empty defaults injected by the plist. (CLI subcommands
+    //    invoked from elsewhere fall back to built-in defaults, e.g.
+    //    MERIDIAN_DB → ~/.meridian/meridian.db.)
     let _ = dotenvy::dotenv_override();
+
+    // 1a. …but that walk is CWD-dependent, and on Windows NOTHING sets a
+    //     working directory for the daemon. Neither launcher the tray installs
+    //     has one: `schtasks /Create` (see `backend_install.rs`) has no "Start
+    //     in" field, and the Startup-folder fallback calls `WScript.Shell.Run`
+    //     without setting `CurrentDirectory`. Both therefore start the daemon in
+    //     system32, where the walk finds no `.env` at all — so it came up with
+    //     no MERIDIAN_DB_KEY.
+    //
+    //     That stayed invisible for as long as meridian.db was plaintext:
+    //     `key_unless_plaintext` drops the key for a plaintext file, so the open
+    //     succeeded without one. It turns fatal the moment the tray's
+    //     encrypt-in-place completes (which it does as soon as it runs while the
+    //     daemon is not holding the file open) — from then on every connection
+    //     fails in `after_connect`, permanently, with the key sitting in a file
+    //     this process never read.
+    //
+    //     So also load the canonical ~/.meridian/.env, the file the tray writes
+    //     the key and tracker credentials into, regardless of where we were
+    //     started from. `from_path` does NOT override, so anything already set —
+    //     by the real environment or by the repo .env above — still wins: dev
+    //     and macOS behaviour are unchanged, and this only fills the gap left
+    //     when the walk came up empty.
+    if let Some(home) = meridian_core::paths::home_dir() {
+        let _ = dotenvy::from_path(home.join(".meridian").join(".env"));
+    }
 
     // 1b. Subcommand dispatch. `meridian coding-agent-hook` is the Claude Code
     //     SessionEnd hook entry point: one-shot, reads a JSON payload on stdin,

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,47 +99,15 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    // `meridian coding-agent-install-skill` — write the session-summary Claude
-    // Code command file so `claude -p /session-summary` works. Idempotent; safe
-    // to run any number of times. Also called by `meridian doctor --fix`.
-    if std::env::args().nth(1).as_deref() == Some("coding-agent-install-skill") {
-        let home = meridian_core::paths::home_dir_or_cwd();
-        let commands_dir = home.join(".claude/commands");
-        let skill_path = commands_dir.join("session-summary.md");
-        // Keep in sync with assets/skills/coding-agent/session-summary/SKILL.md.
-        // install.sh runs this command; it is also the fallback for
-        // `meridian doctor --fix` and direct `meridian coding-agent-install-skill`.
-        let content = concat!(
-            "---\n",
-            "description: Summarise a coding-agent session transcript for a Jira work-log.\n",
-            "---\n\n",
-            "You summarise ONE work-burst of a developer's coding-agent session for a Jira ",
-            "work-log. The transcript is timestamped as `[<ISO ts>] [role] <message>`. Write ",
-            "a factual prose summary of 10-40 sentences: name the files edited, commands run, ",
-            "errors hit, decisions made, tests/validations performed, and any rework. ",
-            "State ONLY what is in the transcript — never invent files, tickets, ",
-            "commands, or outcomes. No preamble, no markdown headings, no bullet lists — just ",
-            "clear paragraphs. If an 'EARLIER IN THIS SESSION' section is present, do not ",
-            "repeat it; summarise only this burst.\n\n",
-            "Return JSON with `summary` (the prose).\n"
-        );
-        if let Err(e) = std::fs::create_dir_all(&commands_dir) {
-            eprintln!("coding-agent-install-skill: create dir: {e}");
-            return Ok(());
-        }
-        if skill_path.exists() {
-            println!(
-                "coding-agent-install-skill: already present at {}",
-                skill_path.display()
-            );
-        } else {
-            match std::fs::write(&skill_path, content) {
-                Ok(()) => println!("coding-agent-install-skill: wrote {}", skill_path.display()),
-                Err(e) => eprintln!("coding-agent-install-skill: write: {e}"),
-            }
-        }
-        return Ok(());
-    }
+    // (`meridian coding-agent-install-skill` used to live here. It wrote
+    // ~/.claude/commands/session-summary.md so `claude -p /session-summary`
+    // would resolve — an invocation the summariser no longer makes: the Claude
+    // engine embeds SUMMARY_RULES inline (see
+    // `coding_agent_session_ingest::summariser::claude`), so nothing has read
+    // that file since. It also kept a hand-copied duplicate of
+    // assets/skills/coding-agent/session-summary/SKILL.md in sync by comment
+    // only — while `summariser::prompts` `include_str!`s the real file. The
+    // asset stays; only the dead writer is gone.)
 
     // `meridian oauth-login <provider> [--client-id ID] [--port N]` — interactive
     // browser OAuth flow for a PM provider. Opens the system browser, captures

--- a/tests/tray_assets.rs
+++ b/tests/tray_assets.rs
@@ -339,3 +339,31 @@ fn js_element_id_contract_holds() {
     assert_ids_present("tray/src/app.js", "tray/src/index.html");
     assert_ids_present("tray/src/tooltip.js", "tray/src/tooltip.html");
 }
+
+/// GUARD: the tray must hide the hover tooltip on mouse-DOWN, not only on Up.
+///
+/// tray-icon's `rightMouseDown:` emits a Down click event and then calls
+/// `performClick`, which runs the NSMenu in a modal tracking loop. That loop
+/// swallows `rightMouseUp:`, so an Up-only handler never fires for a
+/// right-click and the tooltip strands on screen behind the context menu
+/// (`Leave` doesn't fire either while the menu holds the run loop). A previous
+/// fix added a right-button branch but left it inside the Up arm, so it could
+/// never run - hence this guard is on the Down arm specifically.
+///
+/// Static source assertion because tray-icon events need a real menu-bar click
+/// and a running event loop, which CI has no way to drive.
+#[test]
+fn tray_hides_tooltip_on_mouse_down() {
+    let src = read_text("tray/src-tauri/src/lib.rs");
+    let down_arm = src.find("button_state: MouseButtonState::Down").expect(
+        "tray click handler must match MouseButtonState::Down - without it a \
+                 right-click leaves the hover tooltip stranded (the NSMenu tracking \
+                 loop swallows rightMouseUp:, so the Up arm never fires)",
+    );
+    let rest = &src[down_arm..];
+    let arm_end = rest.find("MouseButtonState::Up").unwrap_or(rest.len());
+    assert!(
+        rest[..arm_end].contains("tray-tooltip") && rest[..arm_end].contains("hide()"),
+        "the MouseButtonState::Down arm must hide the tray-tooltip window",
+    );
+}

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -20,6 +20,16 @@
 //! agents (screenpipe / a11y-helper / MLX / UI server) are booted out during
 //! [`install`].
 //!
+//! **Windows has no equivalent of that plist key**, and getting it wrong is
+//! silent: `schtasks /Create` has no "Start in" field and the Startup-folder
+//! VBScript defaults to system32, so a daemon launched by either sees no `.env`
+//! — and therefore no `MERIDIAN_DB_KEY`, which is fatal once meridian.db has
+//! been encrypted in place. Every launch path here consequently sets the
+//! working directory to `~/.meridian` explicitly (the VBScript's
+//! `CurrentDirectory`, and `current_dir` on both direct spawns). The daemon
+//! *also* loads that file by absolute path (`src/main.rs`), so this is defence
+//! in depth and the fix for anyone whose task was registered by an older build.
+//!
 //! **The `meridian-a11y-helper` launchd agent is retired** (was
 //! `com.meridiona.a11y-helper`): it existed to poke `AXManualAccessibility`
 //! on Electron/Chromium apps for the old *external* screenpipe process. The
@@ -239,7 +249,10 @@ async fn ensure_daemon_running(home: &Path) {
                 "backend_install: scheduled task ran but the daemon isn't up yet, falling back to a direct spawn"
             );
         }
+        // `current_dir`: the daemon resolves its `.env` relative to the working
+        // directory, and a bare spawn would inherit the tray's instead.
         match tokio::process::Command::new(&daemon_bin)
+            .current_dir(home.join(".meridian"))
             .no_window()
             .spawn()
         {
@@ -405,9 +418,17 @@ async fn register_service(_backend: &Path, home: &Path, daemon_bin: &Path) -> Re
                 error = %e,
                 "backend_install: schtasks registration failed — falling back to a Startup-folder launcher"
             );
-            install_startup_folder_launcher(daemon_bin).await?;
+            let meridian_home = home.join(".meridian");
+            install_startup_folder_launcher(&meridian_home, daemon_bin).await?;
             // Nothing else will start the daemon until next login — start it now.
-            if let Err(e) = tokio::process::Command::new(daemon_bin).no_window().spawn() {
+            // `current_dir` for the same reason the launcher sets it: the daemon
+            // resolves its `.env` relative to the working directory, and this
+            // spawn inherits the tray's otherwise.
+            if let Err(e) = tokio::process::Command::new(daemon_bin)
+                .current_dir(&meridian_home)
+                .no_window()
+                .spawn()
+            {
                 tracing::warn!(
                     error = %e,
                     bin = %daemon_bin.display(),
@@ -684,19 +705,35 @@ fn startup_folder() -> Result<PathBuf, String> {
 
 /// Write the hidden-launch VBScript to the Startup folder. Idempotent:
 /// overwrites unconditionally, same as `schtasks /Create /F`.
+///
+/// `meridian_home` is the daemon's working directory (`~/.meridian`), the
+/// Windows counterpart of the macOS plist's `WorkingDirectory`.
 #[cfg(target_os = "windows")]
-async fn install_startup_folder_launcher(daemon_bin: &Path) -> Result<(), String> {
+async fn install_startup_folder_launcher(
+    meridian_home: &Path,
+    daemon_bin: &Path,
+) -> Result<(), String> {
     let dir = startup_folder()?;
     tokio::fs::create_dir_all(&dir)
         .await
         .map_err(|e| format!("mkdir {}: {e}", dir.display()))?;
     let script = dir.join(STARTUP_LAUNCHER_NAME);
+    // `CurrentDirectory` is set for parity with the macOS plist's
+    // `WorkingDirectory`: the daemon's `dotenvy` walk starts at the CWD, and a
+    // launcher that leaves it at system32 gives the daemon no `.env` — and so
+    // no MERIDIAN_DB_KEY — which is fatal once meridian.db is encrypted. The
+    // daemon also resolves ~/.meridian/.env by absolute path (`src/main.rs`),
+    // so this is defence in depth rather than the sole fix.
+    //
     // VBScript has no backslash-escaping to worry about — only `"` needs
     // doubling to embed a literal quote, wrapping the path so a space
     // anywhere in it (a differently-named Windows profile, say) can't split
     // `Run`'s argument.
     let contents = format!(
-        "CreateObject(\"WScript.Shell\").Run \"\"\"{}\"\"\", 0, False\r\n",
+        "Set sh = CreateObject(\"WScript.Shell\")\r\n\
+         sh.CurrentDirectory = \"{}\"\r\n\
+         sh.Run \"\"\"{}\"\"\", 0, False\r\n",
+        meridian_home.display(),
         daemon_bin.display()
     );
     tokio::fs::write(&script, contents)

--- a/tray/src-tauri/src/commands/daemon_control.rs
+++ b/tray/src-tauri/src/commands/daemon_control.rs
@@ -198,7 +198,13 @@ fn spawn_staged_daemon() -> Result<(), String> {
     if !daemon_bin.exists() {
         return Err(format!("no staged daemon at {}", daemon_bin.display()));
     }
+    // `current_dir` is load-bearing, not cosmetic: the daemon resolves its
+    // `.env` relative to the working directory, so a bare spawn inherits the
+    // tray's and the daemon comes up without MERIDIAN_DB_KEY — fatal once
+    // meridian.db is encrypted. Matches every other daemon launch path (see
+    // `crate::backend_install`'s module docs).
     std::process::Command::new(&daemon_bin)
+        .current_dir(home.join(".meridian"))
         .no_window()
         .spawn()
         .map(|_| ())

--- a/tray/src-tauri/src/db_key.rs
+++ b/tray/src-tauri/src/db_key.rs
@@ -38,6 +38,16 @@ fn generate_key_hex() -> String {
     hex::encode(bytes)
 }
 
+/// Would minting a brand-new key orphan an already-encrypted `meridian.db`?
+/// True only when `db_path` exists and does not look like a plaintext SQLite
+/// file — i.e. it looks like ciphertext under some key this install can no
+/// longer find in the keychain. A missing file (fresh install) or a
+/// confirmed-plaintext file (nothing encrypted yet — `encrypt_in_place` will
+/// migrate it under the new key) are both safe to proceed on.
+pub(crate) fn would_orphan_existing_db(db_path: &std::path::Path) -> bool {
+    db_path.exists() && !meridian_core::db_crypto::is_plaintext_sqlite(db_path)
+}
+
 /// Get-or-create this machine's `meridian.db` encryption key from the OS
 /// keychain, and ensure it is mirrored into `env_path` as
 /// `MERIDIAN_DB_KEY=<hex>` so the daemon can read it. Returns the key hex.
@@ -45,13 +55,36 @@ fn generate_key_hex() -> String {
 /// Idempotent and safe to call on every tray startup: an existing keychain
 /// entry is reused as-is (never regenerated), and re-mirroring the same value
 /// into `.env` is a no-op write via `upsert_env`.
-pub fn resolve_or_create_key(env_path: &std::path::Path) -> anyhow::Result<String> {
+///
+/// `db_path` exists solely so a missing keychain entry can be checked against
+/// `meridian.db` before minting a replacement — see [`would_orphan_existing_db`].
+/// Without that check, a keychain entry lost for any reason (a keychain
+/// reset, a migration to a new machine, `.env` and the keychain falling out
+/// of sync) silently mints and stores a fresh key while the real data stays
+/// encrypted under the old, now-unreachable one: every future open then fails
+/// with SQLCipher "wrong key" errors (`file is not a database` / `database
+/// disk image is malformed`) instead of a clear, actionable one.
+pub fn resolve_or_create_key(
+    env_path: &std::path::Path,
+    db_path: &std::path::Path,
+) -> anyhow::Result<String> {
     let entry =
         keyring::Entry::new(SERVICE, ACCOUNT).context("db_key: failed to access OS keychain")?;
 
     let key_hex = match entry.get_password() {
         Ok(existing) => existing,
         Err(keyring::Error::NoEntry) => {
+            if would_orphan_existing_db(db_path) {
+                anyhow::bail!(
+                    "no DB encryption key found in the OS keychain, but {} already exists and \
+                     does not look like a plaintext SQLite file - it looks encrypted under a \
+                     key this install can no longer find. Refusing to generate a replacement \
+                     key, which would silently make that data permanently unreadable instead \
+                     of surfacing the problem. If this file is known-safe to discard, remove \
+                     it and restart.",
+                    db_path.display()
+                );
+            }
             let generated = generate_key_hex();
             entry
                 .set_password(&generated)
@@ -84,5 +117,30 @@ mod tests {
         meridian_core::db_crypto::validate_key_hex(&a).unwrap();
         meridian_core::db_crypto::validate_key_hex(&b).unwrap();
         assert_ne!(a, b, "two generated keys should not collide");
+    }
+
+    #[test]
+    fn would_orphan_existing_db_is_false_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        assert!(!db_path.exists());
+        assert!(!would_orphan_existing_db(&db_path));
+    }
+
+    #[test]
+    fn would_orphan_existing_db_is_false_when_plaintext() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        std::fs::write(&db_path, b"SQLite format 3\0rest-of-a-plaintext-file").unwrap();
+        assert!(!would_orphan_existing_db(&db_path));
+    }
+
+    #[test]
+    fn would_orphan_existing_db_is_true_when_not_plaintext() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        // No recognizable SQLite header - stands in for SQLCipher ciphertext.
+        std::fs::write(&db_path, b"not-a-sqlite-header-at-all-just-ciphertext").unwrap();
+        assert!(would_orphan_existing_db(&db_path));
     }
 }

--- a/tray/src-tauri/src/db_key.rs
+++ b/tray/src-tauri/src/db_key.rs
@@ -38,14 +38,66 @@ fn generate_key_hex() -> String {
     hex::encode(bytes)
 }
 
+/// Length of the SQLite file-header magic. A file shorter than this cannot be
+/// probed for it at all — see [`ExistingDb::TooSmallToBeADatabase`].
+const SQLITE_MAGIC_LEN: u64 = 16;
+
+/// What the on-disk `meridian.db` looks like, as far as deciding whether it is
+/// safe to mint a fresh encryption key is concerned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExistingDb {
+    /// No file — a genuine first run.
+    Absent,
+    /// A confirmed plaintext SQLite file. Nothing is encrypted yet, so
+    /// `encrypt_in_place` will migrate it under the newly minted key.
+    Plaintext,
+    /// Present, but shorter than [`SQLITE_MAGIC_LEN`]. SQLCipher's smallest
+    /// page is 512 bytes, so a file this short cannot hold encrypted data
+    /// under any key — it is an empty or truncated leftover (a torn write, a
+    /// disk-full stub), not a database. Nothing is lost by keying a fresh one
+    /// over it, and blocking startup to demand a support ticket for a file
+    /// with no recoverable content would be a false alarm. Carries the
+    /// observed length so the caller can log it without re-stat'ing (and
+    /// without having to invent a value if that second stat were to fail).
+    TooSmallToBeADatabase { bytes: u64 },
+    /// Present, long enough to be real, and carrying no recognizable SQLite
+    /// header — i.e. ciphertext under some key that is not in the keychain.
+    /// This is the case that must never be overwritten.
+    LooksEncrypted,
+}
+
+/// Classify `db_path` into the four states that matter before minting a key.
+///
+/// Note this cannot be answered by [`meridian_core::db_crypto::plaintext_state`]
+/// alone: it collapses *both* "file too short to read a header from" and "file
+/// unreadable" into `None`, which is right for its own callers but would lump a
+/// harmless empty stub in with real ciphertext here. The file length is what
+/// actually separates them, so it is consulted directly.
+///
+/// An existing file whose metadata cannot be read is deliberately classified
+/// [`ExistingDb::LooksEncrypted`] — the conservative direction, since guessing
+/// "harmless" about a file we cannot inspect is the one mistake with an
+/// irreversible outcome.
+pub(crate) fn classify_existing_db(db_path: &std::path::Path) -> ExistingDb {
+    if !db_path.exists() {
+        return ExistingDb::Absent;
+    }
+    if meridian_core::db_crypto::is_plaintext_sqlite(db_path) {
+        return ExistingDb::Plaintext;
+    }
+    match std::fs::metadata(db_path) {
+        Ok(m) if m.len() < SQLITE_MAGIC_LEN => ExistingDb::TooSmallToBeADatabase { bytes: m.len() },
+        _ => ExistingDb::LooksEncrypted,
+    }
+}
+
 /// Would minting a brand-new key orphan an already-encrypted `meridian.db`?
-/// True only when `db_path` exists and does not look like a plaintext SQLite
-/// file — i.e. it looks like ciphertext under some key this install can no
-/// longer find in the keychain. A missing file (fresh install) or a
-/// confirmed-plaintext file (nothing encrypted yet — `encrypt_in_place` will
-/// migrate it under the new key) are both safe to proceed on.
+/// True only for [`ExistingDb::LooksEncrypted`] — a file that exists, is long
+/// enough to be a real database, and is not plaintext, i.e. ciphertext under a
+/// key this install can no longer find. A missing file, a confirmed-plaintext
+/// file, and an empty/truncated stub are all safe to proceed on.
 pub(crate) fn would_orphan_existing_db(db_path: &std::path::Path) -> bool {
-    db_path.exists() && !meridian_core::db_crypto::is_plaintext_sqlite(db_path)
+    matches!(classify_existing_db(db_path), ExistingDb::LooksEncrypted)
 }
 
 /// Get-or-create this machine's `meridian.db` encryption key from the OS
@@ -74,8 +126,8 @@ pub fn resolve_or_create_key(
     let key_hex = match entry.get_password() {
         Ok(existing) => existing,
         Err(keyring::Error::NoEntry) => {
-            if would_orphan_existing_db(db_path) {
-                anyhow::bail!(
+            match classify_existing_db(db_path) {
+                ExistingDb::LooksEncrypted => anyhow::bail!(
                     "no DB encryption key found in the OS keychain, but {} already exists and \
                      does not look like a plaintext SQLite file - it looks encrypted under a \
                      key this install can no longer find. Refusing to generate a replacement \
@@ -83,7 +135,19 @@ pub fn resolve_or_create_key(
                      of surfacing the problem. If this file is known-safe to discard, remove \
                      it and restart.",
                     db_path.display()
-                );
+                ),
+                // Distinct from the bail above on purpose: this file is too
+                // short to hold encrypted data, so it is a leftover stub
+                // rather than orphaned user data. Proceed (a fresh database
+                // gets keyed over it), but say so — silently stepping over a
+                // corrupt file is how the original bug stayed invisible.
+                ExistingDb::TooSmallToBeADatabase { bytes } => {
+                    tracing::warn!(
+                        db_bytes = bytes,
+                        "keying a fresh database over an empty or truncated meridian.db stub - too short to hold encrypted data, so nothing recoverable is being replaced"
+                    );
+                }
+                ExistingDb::Absent | ExistingDb::Plaintext => {}
             }
             let generated = generate_key_hex();
             entry
@@ -124,6 +188,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("meridian.db");
         assert!(!db_path.exists());
+        assert_eq!(classify_existing_db(&db_path), ExistingDb::Absent);
         assert!(!would_orphan_existing_db(&db_path));
     }
 
@@ -132,6 +197,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("meridian.db");
         std::fs::write(&db_path, b"SQLite format 3\0rest-of-a-plaintext-file").unwrap();
+        assert_eq!(classify_existing_db(&db_path), ExistingDb::Plaintext);
         assert!(!would_orphan_existing_db(&db_path));
     }
 
@@ -141,6 +207,50 @@ mod tests {
         let db_path = dir.path().join("meridian.db");
         // No recognizable SQLite header - stands in for SQLCipher ciphertext.
         std::fs::write(&db_path, b"not-a-sqlite-header-at-all-just-ciphertext").unwrap();
+        assert_eq!(classify_existing_db(&db_path), ExistingDb::LooksEncrypted);
+        assert!(would_orphan_existing_db(&db_path));
+    }
+
+    /// A zero-byte `meridian.db` — the shape a torn write or a disk-full stub
+    /// leaves behind. It reads as "not plaintext" (there is no header to read),
+    /// so it must be told apart from real ciphertext explicitly, or a user with
+    /// nothing to lose is sent to support instead of simply being healed.
+    #[test]
+    fn an_empty_stub_is_not_treated_as_encrypted_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        std::fs::write(&db_path, b"").unwrap();
+        assert!(!meridian_core::db_crypto::is_plaintext_sqlite(&db_path));
+        assert_eq!(
+            classify_existing_db(&db_path),
+            ExistingDb::TooSmallToBeADatabase { bytes: 0 }
+        );
+        assert!(!would_orphan_existing_db(&db_path));
+    }
+
+    /// Truncated part-way through the magic — same reasoning as the empty stub:
+    /// too short to hold a SQLCipher page, so there is nothing to orphan.
+    #[test]
+    fn a_truncated_stub_is_not_treated_as_encrypted_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        std::fs::write(&db_path, b"SQLite f").unwrap();
+        assert_eq!(
+            classify_existing_db(&db_path),
+            ExistingDb::TooSmallToBeADatabase { bytes: 8 }
+        );
+        assert!(!would_orphan_existing_db(&db_path));
+    }
+
+    /// The boundary itself: exactly `SQLITE_MAGIC_LEN` bytes of non-header
+    /// content is long enough to probe, so it stays on the conservative side.
+    #[test]
+    fn exactly_magic_length_of_non_header_still_looks_encrypted() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        let contents = vec![0xABu8; SQLITE_MAGIC_LEN as usize];
+        std::fs::write(&db_path, &contents).unwrap();
+        assert_eq!(classify_existing_db(&db_path), ExistingDb::LooksEncrypted);
         assert!(would_orphan_existing_db(&db_path));
     }
 }

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -366,16 +366,47 @@ pub fn run() {
                 db_key_hex
             };
 
-            // Open meridian.db ONCE at startup and share it with commands via
-            // managed state (no migrations — the daemon owns the schema). `None`
-            // if the DB can't be opened yet, so reads error gracefully instead
-            // of crashing the tray.
-            let db_pool = tauri::async_runtime::block_on(meridian_core::open_existing(
-                &db_path,
-                db_key_hex.as_deref(),
-            ))
-            .map_err(|e| tracing::error!(error = %e, db_path = %db_path, "meridian.db not opened"))
-            .ok();
+            // Prepare the meridian.db pool ONCE at startup and share it with
+            // commands via managed state (no migrations — the daemon owns the
+            // schema). `None` only if the path/key is malformed, so reads error
+            // gracefully instead of crashing the tray.
+            //
+            // LAZY on purpose. On a first launch this line runs seconds BEFORE
+            // `ensure_backend_installed` (below) starts the daemon that creates
+            // meridian.db, so an eager open fails — and since the result is
+            // stored as an `Option` that nothing retries, the tray then ran its
+            // entire session against `None`: every DB-backed command silently
+            // returned its empty default and every captured frame was dropped
+            // by the consumers' `else { continue }`, until the user happened to
+            // restart the tray. A lazy pool connects on first use instead, so
+            // the very next command or frame after the daemon creates the file
+            // succeeds on its own.
+            let db_pool = meridian_core::open_existing_lazy(&db_path, db_key_hex.as_deref())
+                .map_err(
+                    |e| tracing::error!(error = %e, db_path = %db_path, "meridian.db pool not prepared"),
+                )
+                .ok();
+            // A lazy pool cannot report reachability at build time, and losing
+            // that startup signal is how the failure above stayed invisible for
+            // a whole session. Probe once, purely to log it — an unreachable DB
+            // here is expected on a first launch and heals by itself, so this
+            // deliberately gates nothing.
+            //
+            // SPAWNED, never blocked on: sqlx retries a failed connection until
+            // the pool's 10s acquire timeout, so a first launch (file not
+            // created yet) would otherwise freeze the whole `setup` closure —
+            // and with it the tray menu — for ten seconds.
+            if let Some(p) = db_pool.clone() {
+                tauri::async_runtime::spawn(async move {
+                    match meridian_core::ping(&p).await {
+                        Ok(()) => tracing::info!("meridian.db reachable"),
+                        Err(e) => tracing::warn!(
+                            error = %e,
+                            "meridian.db not reachable yet — the pool will connect once the daemon creates it"
+                        ),
+                    }
+                });
+            }
             // Capture (slice 4a) writes to the SAME read-write pool the commands
             // use — clone the handle before it's moved into managed state.
             #[cfg(feature = "capture")]

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -381,11 +381,21 @@ pub fn run() {
             // restart the tray. A lazy pool connects on first use instead, so
             // the very next command or frame after the daemon creates the file
             // succeeds on its own.
-            let db_pool = meridian_core::open_existing_lazy(&db_path, db_key_hex.as_deref())
-                .map_err(
-                    |e| tracing::error!(error = %e, db_path = %db_path, "meridian.db pool not prepared"),
-                )
-                .ok();
+            // `block_on`, not a bare call: sqlx spawns the pool's maintenance
+            // task while BUILDING the lazy handle, so constructing it outside a
+            // Tokio runtime panics ("this functionality requires a Tokio
+            // context") and takes the whole tray down before the tray icon even
+            // appears. `setup()` is not itself async, so the runtime has to be
+            // entered explicitly here — exactly as the eager open it replaced
+            // already did.
+            let db_pool = tauri::async_runtime::block_on(meridian_core::open_existing_lazy(
+                &db_path,
+                db_key_hex.as_deref(),
+            ))
+            .map_err(
+                |e| tracing::error!(error = %e, db_path = %db_path, "meridian.db pool not prepared"),
+            )
+            .ok();
             // A lazy pool cannot report reachability at build time, and losing
             // that startup signal is how the failure above stayed invisible for
             // a whole session. Probe once, purely to log it — an unreachable DB

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -471,6 +471,26 @@ pub fn run() {
                 .on_tray_icon_event(|tray_handle, event| {
                     let app = tray_handle.app_handle();
                     match &event {
+                        // Hide the tooltip on mouse-DOWN, which is the only click event
+                        // a right-click reliably delivers. tray-icon's `rightMouseDown:`
+                        // emits Down and then calls performClick, which runs the NSMenu
+                        // in a modal tracking loop; that loop swallows `rightMouseUp:`,
+                        // so the Up arm below never fires for a right-click, and `Leave`
+                        // doesn't either while the menu holds the run loop. Hiding here
+                        // is what actually stops the tooltip stranding behind the menu —
+                        // the Up arm's hide alone could never run for a right-click.
+                        // Left-click hides here too and is harmless: the Up arm then
+                        // takes over and toggles the popover.
+                        TrayIconEvent::Click {
+                            button,
+                            button_state: MouseButtonState::Down,
+                            ..
+                        } => {
+                            tracing::info!(?button, "tray.event: Click(Down) — hiding tooltip");
+                            if let Some(tt) = app.get_webview_window("tray-tooltip") {
+                                let _ = tt.hide();
+                            }
+                        }
                         TrayIconEvent::Click {
                             button,
                             button_state: MouseButtonState::Up,
@@ -478,10 +498,9 @@ pub fn run() {
                             ..
                         } => {
                             tracing::info!(?button, "tray.event: Click");
-                            // Hide the hover tooltip on ANY click — left (popover takes
-                            // over) or right (native menu takes over). Right-click was
-                            // previously unhandled here, leaving the tooltip stuck
-                            // visible behind the context menu.
+                            // Belt-and-braces for the left-click path (and any platform
+                            // that delivers Up without a preceding Down) — the Down arm
+                            // above is what covers right-click.
                             if let Some(tt) = app.get_webview_window("tray-tooltip") {
                                 let _ = tt.hide();
                             }

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -245,6 +245,11 @@ pub fn run() {
             //    meridian_core::db_crypto::encrypt_in_place's doc comments
             //    for why that's the safe failure mode.
             let db_path = install::meridian_db_path();
+            // Bound once: the same path is re-borrowed as a `Path` several
+            // times below (key resolution, the orphan check, the plaintext
+            // probe, the migration), and `db_path` itself stays a `String`
+            // because the tracing/`open` call sites still want it as one.
+            let db_path_ref = std::path::Path::new(&db_path);
             let install_mode = install::detect_install_mode();
             let existing_key = install_mode
                 .env_path()
@@ -256,7 +261,7 @@ pub fn run() {
                 match install::canonical_env_path() {
                     Some(env_path) => match db_key::resolve_or_create_key(
                         &env_path,
-                        std::path::Path::new(&db_path),
+                        db_path_ref,
                     ) {
                         Ok(key) => Some(key),
                         Err(e) => {
@@ -279,7 +284,7 @@ pub fn run() {
                             // database that's unreadable. A native OS
                             // notification is the only channel left that
                             // doesn't itself depend on meridian.db opening.
-                            if db_key::would_orphan_existing_db(std::path::Path::new(&db_path)) {
+                            if db_key::would_orphan_existing_db(db_path_ref) {
                                 tracing::error!(
                                     error = %e,
                                     "refusing to generate a replacement DB encryption key - meridian.db exists and appears already encrypted under a key this install can no longer find"
@@ -325,7 +330,7 @@ pub fn run() {
             // up by `ensure_backend_installed` later in this same setup hook.
             if !cfg!(debug_assertions)
                 && db_encryption_intended
-                && meridian_core::db_crypto::is_plaintext_sqlite(std::path::Path::new(&db_path))
+                && meridian_core::db_crypto::is_plaintext_sqlite(db_path_ref)
             {
                 if let Err(e) =
                     tauri::async_runtime::block_on(backend_install::stop_daemon_for_migration())
@@ -341,7 +346,7 @@ pub fn run() {
                 match &db_key_hex {
                     Some(key) => {
                         let migrate = meridian_core::db_crypto::encrypt_in_place(
-                            std::path::Path::new(&db_path),
+                            db_path_ref,
                             key,
                         );
                         match tauri::async_runtime::block_on(migrate) {
@@ -392,7 +397,7 @@ pub fn run() {
             if !cfg!(debug_assertions) {
                 if let Some(pool) = encryption_notice_pool.as_ref() {
                     let plaintext = meridian_core::db_crypto::plaintext_state(
-                        std::path::Path::new(&db_path),
+                        db_path_ref,
                     );
                     let action = db_encryption_notice_action(db_encryption_intended, plaintext);
                     // No `db_path` on the span: a home-dir path is user data.

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -254,7 +254,10 @@ pub fn run() {
                 existing_key
             } else if !cfg!(debug_assertions) {
                 match install::canonical_env_path() {
-                    Some(env_path) => match db_key::resolve_or_create_key(&env_path) {
+                    Some(env_path) => match db_key::resolve_or_create_key(
+                        &env_path,
+                        std::path::Path::new(&db_path),
+                    ) {
                         Ok(key) => Some(key),
                         Err(e) => {
                             // `tracing`, not `eprintln!`: observability is
@@ -264,10 +267,34 @@ pub fn run() {
                             // or central error reporting. A silent fallback to
                             // an UNENCRYPTED database is exactly the event
                             // those channels exist to surface.
-                            tracing::error!(
-                                error = %e,
-                                "failed to resolve DB encryption key - continuing unencrypted"
-                            );
+                            //
+                            // `would_orphan_existing_db` is a DIFFERENT, worse
+                            // case than the generic fallback below: the DB
+                            // already exists and is NOT plaintext, so there is
+                            // no unencrypted file to "continue" into - opening
+                            // it further down with no key will just fail, the
+                            // same way it's been failing already. The
+                            // DB-backed notices system (used elsewhere in this
+                            // function) can't carry this one: it's the very
+                            // database that's unreadable. A native OS
+                            // notification is the only channel left that
+                            // doesn't itself depend on meridian.db opening.
+                            if db_key::would_orphan_existing_db(std::path::Path::new(&db_path)) {
+                                tracing::error!(
+                                    error = %e,
+                                    "refusing to generate a replacement DB encryption key - meridian.db exists and appears already encrypted under a key this install can no longer find"
+                                );
+                                sys::notify(
+                                    app.handle(),
+                                    "Meridian can't read your local data",
+                                    "Your local database appears to be encrypted with a key this install can no longer find. Contact support with your Support ID (Settings -> Account) before removing anything.",
+                                );
+                            } else {
+                                tracing::error!(
+                                    error = %e,
+                                    "failed to resolve DB encryption key - continuing unencrypted"
+                                );
+                            }
                             None
                         }
                     },

--- a/tray/src-tauri/src/sys.rs
+++ b/tray/src-tauri/src/sys.rs
@@ -272,7 +272,38 @@ fn windows_notification_setting(
     use windows::core::HSTRING;
     use windows::UI::Notifications::ToastNotificationManager;
     let aumid = HSTRING::from(&app.config().identifier);
-    ToastNotificationManager::CreateToastNotifierWithId(&aumid)?.Setting()
+    let raw = ToastNotificationManager::CreateToastNotifierWithId(&aumid).and_then(|n| n.Setting());
+    resolve_notification_setting(raw)
+}
+
+/// Fold the "AUMID not registered yet" probe error into the benign default.
+/// `ToastNotifier::Setting()` throws `ERROR_NOT_FOUND` (`0x80070490`) when this
+/// app has no identity Windows can read a setting for — it has never delivered a
+/// toast and no Start Menu shortcut carries its AUMID, so there is no app record
+/// to answer for. That is the *pre-registration default*, NOT a denial: the
+/// first toast registers the app and Windows defaults its toast delivery to
+/// `Enabled` (verified live — a single `Toast::show()` re-creates the
+/// `Notifications\Settings\<AUMID>` entry and the setting then reads `Enabled`).
+/// So map it to `Enabled`; otherwise the error bubbles to `None` in
+/// [`notification_permission_state`] and the wizard renders a spurious
+/// "notifications unavailable" on a perfectly healthy machine that simply hasn't
+/// toasted yet — observed in the field as `windows notification setting probe
+/// failed` / `Element not found (0x80070490)`. Every other error is a genuine
+/// probe failure and propagates unchanged (the caller logs it and reports
+/// `None`). Pure/free-standing so the `ERROR_NOT_FOUND` rule is unit-testable
+/// without a live WinRT call.
+#[cfg(target_os = "windows")]
+fn resolve_notification_setting(
+    raw: windows::core::Result<windows::UI::Notifications::NotificationSetting>,
+) -> windows::core::Result<windows::UI::Notifications::NotificationSetting> {
+    use windows::core::HRESULT;
+    use windows::UI::Notifications::NotificationSetting;
+    // HRESULT_FROM_WIN32(ERROR_NOT_FOUND) — the unregistered-AUMID sentinel.
+    const ERROR_NOT_FOUND: HRESULT = HRESULT(0x8007_0490u32 as i32);
+    match raw {
+        Err(e) if e.code() == ERROR_NOT_FOUND => Ok(NotificationSetting::Enabled),
+        other => other,
+    }
 }
 
 /// Map WinRT's `NotificationSetting` to the plugin's `PermissionState` so the
@@ -538,6 +569,52 @@ mod tests {
                 "{setting:?} must not be reported as Granted"
             );
         }
+    }
+
+    /// Regression guard for the field bug where a fresh Windows machine that
+    /// has never delivered a toast shows a spurious "notifications unavailable"
+    /// in the setup wizard: `ToastNotifier::Setting()` throws `ERROR_NOT_FOUND`
+    /// because the AUMID isn't registered yet, which is the benign default, not
+    /// a denial — it must resolve to `Enabled` (→ `Granted`) so the wizard stays
+    /// green. Observed in telemetry as `windows notification setting probe
+    /// failed` / `Element not found (0x80070490)`.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn error_not_found_probe_resolves_to_enabled() {
+        use windows::core::{Error, HRESULT};
+        use windows::UI::Notifications::NotificationSetting;
+        let not_found = Error::from(HRESULT(0x8007_0490u32 as i32));
+        assert_eq!(
+            super::resolve_notification_setting(Err(not_found)).unwrap(),
+            NotificationSetting::Enabled,
+        );
+    }
+
+    /// A genuine probe failure (anything other than `ERROR_NOT_FOUND`) must stay
+    /// an error, not be laundered into a false `Granted` — the caller logs it and
+    /// reports `None`/`unavailable`, the correct signal for a real WinRT fault.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn other_probe_errors_propagate() {
+        use windows::core::{Error, HRESULT};
+        // E_ACCESSDENIED — a real fault, unrelated to the unregistered-AUMID case.
+        let denied = Error::from(HRESULT(0x8007_0005u32 as i32));
+        assert!(super::resolve_notification_setting(Err(denied)).is_err());
+    }
+
+    /// A successfully-read setting passes through untouched — the
+    /// `ERROR_NOT_FOUND` special-case must not perturb the normal
+    /// `Enabled`/`Disabled*` readings that [`super::windows_permission_state`]
+    /// then maps.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn a_real_setting_passes_through_unchanged() {
+        use windows::UI::Notifications::NotificationSetting;
+        assert_eq!(
+            super::resolve_notification_setting(Ok(NotificationSetting::DisabledForApplication))
+                .unwrap(),
+            NotificationSetting::DisabledForApplication,
+        );
     }
 
     /// Regression guard: these two must report `true` on Windows (see the

--- a/tray/src/style.css
+++ b/tray/src/style.css
@@ -35,6 +35,24 @@
      .font-mono below). */
   --font-sans: -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, "Segoe UI", helvetica, sans-serif;
   --font-mono: var(--font-sans);
+
+  /* Type scale — hand-synced with the .mt-* classes in ui/app/globals.css.
+     The tray popover and tooltip are plain webviews with no Tailwind and no
+     import path to the dashboard's stylesheet, so the VALUES are mirrored here
+     as tokens rather than the classes being shared. Consume with the `font`
+     shorthand (`font: var(--mt-body-sm)`); letter-spacing is separate because the
+     shorthand can't carry it — the paired --mt-*-tracking tokens supply it.
+     Before these existed, every rule below hand-rolled its own size/weight,
+     which is how the tooltip title ended up at weight 450 — a weight that
+     appears nowhere in the dashboard. Keep in sync when globals.css changes.
+     Only the steps these two surfaces actually use are mirrored; add more from
+     globals.css's .mt-* block as new surfaces need them. */
+  --mt-card-title: 700 13.5px var(--font-sans);
+  --mt-body-sm:    500 12px/1.45 var(--font-sans);
+  --mt-body-xs:    500 11.5px/1.45 var(--font-sans);
+  --mt-label:      700 11px var(--font-sans);
+  --mt-card-title-tracking: -0.01em;
+  --mt-label-tracking:      0.08em;
 }
 
 *, *::before, *::after {
@@ -110,8 +128,8 @@ button:focus-visible {
 }
 
 .kicker {
-  font: 700 10.5px var(--font-sans);
-  letter-spacing: 0.07em;
+  font: var(--mt-label);
+  letter-spacing: var(--mt-label-tracking);
   color: var(--ink-3);
 }
 
@@ -145,7 +163,7 @@ button:focus-visible {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font: 600 11px var(--font-sans);
+  font: var(--mt-body-xs);
   color: var(--ink-3);
   margin-top: 1px;
   overflow: hidden;
@@ -200,11 +218,11 @@ button:focus-visible {
 .health-dot[data-state="bad"]  { background: #e53e3e; }
 .health-label {
   flex: 1;
-  font: 600 11.5px var(--font-sans);
+  font: var(--mt-body-xs);
   color: var(--ink-2);
 }
 .health-val {
-  font: 500 11px var(--font-sans);
+  font: var(--mt-body-xs);
   color: var(--ink-3);
   font-variant-numeric: tabular-nums;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
@@ -256,14 +274,15 @@ button:focus-visible {
 
 .status-text { flex: 1; min-width: 0; }
 .status-title {
-  font: 700 13.5px var(--font-sans);
+  font: var(--mt-card-title);
+  letter-spacing: var(--mt-card-title-tracking);
   letter-spacing: -0.01em;
   color: #0F7A54;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .status-card.paused .status-title { color: #B4690E; }
 .status-sub {
-  font: 600 11.5px var(--font-sans);
+  font: var(--mt-body-xs);
   color: #4FA383;
   margin-top: 1px;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
@@ -401,7 +420,7 @@ button:focus-visible {
 }
 .privacy-line svg { flex: none; color: #8B7FB8; }
 .privacy-line span {
-  font: 600 10.5px/1.35 var(--font-sans);
+  font: var(--mt-body-xs);
   flex: 1;
 }
 
@@ -423,7 +442,7 @@ button:focus-visible {
   flex-shrink: 0; width: 18px; height: 18px; border-radius: 6px;
   font-size: 12px; font-weight: 700; color: #fff; background: var(--accent);
 }
-.upd-text { font-size: 12px; color: var(--ink); font-weight: 500; white-space: nowrap; }
+.upd-text { font: var(--mt-body-sm); color: var(--ink); white-space: nowrap; }
 .upd-ver {
   font-family: var(--font-mono); font-size: 10px; color: var(--ink-3);
   flex-shrink: 0; white-space: nowrap;

--- a/tray/src/style.css
+++ b/tray/src/style.css
@@ -276,7 +276,6 @@ button:focus-visible {
 .status-title {
   font: var(--mt-card-title);
   letter-spacing: var(--mt-card-title-tracking);
-  letter-spacing: -0.01em;
   color: #0F7A54;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }

--- a/tray/src/tooltip.css
+++ b/tray/src/tooltip.css
@@ -42,9 +42,8 @@ body {
 }
 
 .tt-key {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 600;
+  font: var(--mt-label);
+  letter-spacing: var(--mt-label-tracking);
   color: var(--ink);
   background: var(--surface-2);
   border: 0.5px solid var(--rule-2);
@@ -55,7 +54,7 @@ body {
 }
 
 .tt-status {
-  font-size: 11.5px;
+  font: var(--mt-body-sm);
   color: var(--ink-3);
   flex: 1;
   min-width: 0;
@@ -65,8 +64,7 @@ body {
 }
 
 .tt-priority {
-  font-size: 11px;
-  font-weight: 500;
+  font: var(--mt-body-xs);
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -76,8 +74,8 @@ body {
 
 /* ── Title ── */
 .tt-title {
-  font-size: 13.5px;
-  font-weight: 450;
+  font: var(--mt-card-title);
+  letter-spacing: var(--mt-card-title-tracking);
   line-height: 1.35;
   color: var(--ink);
   margin-bottom: 11px;
@@ -96,15 +94,15 @@ body {
 }
 
 .tt-time {
-  font-family: var(--font-mono);
-  font-size: 12px;
+  font: var(--mt-body-sm);
+  font-variant-numeric: tabular-nums;
   color: var(--ink-2);
 }
 
 .tt-pct {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  font-weight: 600;
+  font: var(--mt-body-sm);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
   color: var(--accent);
 }
 
@@ -132,8 +130,7 @@ body {
 }
 
 .tt-ctx {
-  font-family: var(--font-mono);
-  font-size: 10.5px;
+  font: var(--mt-body-xs);
   color: var(--ink-3);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -143,7 +140,7 @@ body {
 }
 
 .tt-hint {
-  font-size: 10.5px;
+  font: var(--mt-body-xs);
   color: var(--ink-4);
   white-space: nowrap;
   flex-shrink: 0;


### PR DESCRIPTION
## Release: pre-main → main

Everything below has landed on `pre-main`, gone through staging (including the staging DMG auto-update channel), and is ready to cut into production. 8 PRs, 26 commits.

## Windows encryption / daemon-connectivity chain (#636, #639, #638, #643)

These four land together because #638 and #639 are two independent bugs hit by the *same* Windows encryption rollout, and #643 is a same-day regression fix for #638 — none of the four make sense read in isolation from the others.

- **#636 — `fix(tray): refuse to mint a DB key that would orphan an encrypted meridian.db`**
  `db_key::resolve_or_create_key` treated *any* `keyring::Error::NoEntry` as "first run" and minted a fresh key unconditionally. If the keychain entry goes missing for any other reason (keychain reset, restore onto a new machine, `.env`/keychain drift), the real database is still encrypted under the old key — minting a replacement turns a recoverable situation into an unrecoverable one. Fixed to distinguish "no db file yet" from "db exists but key is gone." Note: an earlier version of this PR misattributed a live alpha error storm to this bug; that attribution was retracted after direct inspection showed the real cause was unrelated page-level DB corruption, not a bad key. The key-resolution hole is real and worth closing on its own merits, but is **not** a fix for that corruption issue (separate, unresolved).

- **#639 — `fix(windows): load the canonical .env so the daemon can open an encrypted db`**
  On Windows the daemon starts with no `MERIDIAN_DB_KEY` and, once `meridian.db` is encrypted, is locked out of its own database permanently. `dotenvy::dotenv_override()` walks up from the working directory looking for `.env`; macOS gets this for free because launchd sets `WorkingDirectory` to `~/.meridian`, but neither Windows launch path (`schtasks /Create`, nor the Startup-folder `WScript.Shell.Run` fallback) sets an equivalent working directory, so the daemon starts in `system32` and never finds it. Stayed invisible as long as `meridian.db` was plaintext (`key_unless_plaintext` just drops the key); became fatal the moment the tray's `encrypt_in_place` ran. Fixed by loading the canonical `.env` path directly instead of relying on directory-walk discovery.

- **#638 — `fix(tray): connect meridian.db lazily so a first launch is not dead until restart`**
  On a fresh install, the tray opened `meridian.db` eagerly during Tauri `setup()` — seconds *before* `ensure_backend_installed` starts the daemon, which is what creates the file. The open fails, the pool is stored as `None`, and nothing ever retries: every DB-backed command (47 call sites) and both capture consumers silently no-op for the rest of the session, with no visible error. Fixed by connecting lazily on first real use instead of once at startup.

- **#643 — `fix(tray): build the lazy meridian.db pool inside a Tokio runtime`** (hotfix for #638, same day, already caught on `pre-main`/staging before reaching this PR)
  The lazy pool from #638 panicked on every launch — `this functionality requires a Tokio context` — because sqlx spawns the pool's maintenance task at construction time regardless of eager/lazy, and the eager path being replaced happened to run inside `tauri::async_runtime::block_on`. The lazy call ran synchronously with nothing supplying a runtime context. Fixed by giving the lazy construction the same Tokio context.

## Tray UX fixes (#637, #640)

- **#637 — `fix(tray): treat ERROR_NOT_FOUND from the Windows toast probe as Enabled`**
  Setup wizard's Notifications card showed a false "unavailable" on healthy Windows machines. `ToastNotifier::Setting()` returns `ERROR_NOT_FOUND` (`0x80070490`) when the app's AUMID has never delivered a toast yet and has no registered identity — a benign pre-registration default, not a denial (confirmed live: a single `Toast::show()` re-creates the registry entry and the probe then reads `Enabled`). Folded that specific error into `Enabled` via a new `resolve_notification_setting` helper; every other WinRT error still propagates as a real failure.

- **#640 — `fix(tray): hide the hover tooltip on mouse-down so right-click can't strand it`**
  Right-clicking the tray icon left the hover tooltip stranded on screen behind the native context menu. Recovers two commits from an earlier attempt (`fix/tray-tooltip-dismiss`, never landed) that cherry-picked cleanly onto current `pre-main` despite ~915 lines of drift. Root cause: tray-icon's right-click delivers a `Down` event and then runs the context menu in a modal loop that swallows the corresponding `Up`/`Leave` events, so a hide wired only to `Up` never fires for a right-click. Fixed by hiding from the `Down` arm instead. Also folds the tooltip/popover onto the dashboard's shared `.mt-*` type scale, replacing inline one-off styling.

## Health / doctor cleanup (#642)

- **#642 — `fix(health): drop the stale session-summary skill check and its diagnosis`**
  `meridian doctor` reported a critical failure — missing `~/.claude/commands/session-summary.md` — on every machine with Claude Code installed, on the theory that its absence broke summarisation via a `/session-summary` slash-skill invocation. That stopped being true when the Claude summariser moved to embedding `SUMMARY_RULES` inline in the `claude -p` prompt; nothing has read that file since. Worse, the stale check was the *first* branch in `diagnose.rs`'s root-cause chain, so it could mask a genuinely stalled summariser (the "summariser queue" check) behind a phantom critical. Removed the check, its `Diagnosis` branch, and its `--fix` arm; promoted the real "summariser queue" check to primary. Follow-up commits (added after review) removed the now-dead `coding-agent-install-skill` CLI subcommand entirely and added a regression test pinning that the summariser-queue diagnosis still fires correctly with the skill check gone.

## Docs (#641)

- **#641 — `docs(observability): how to query central OpenObserve locally`**
  Adds `ops/central-observability/LOCAL-ACCESS.md` documenting how to reach the central OpenObserve instance from a local machine for debugging (SSH tunnel + `curl http://127.0.0.1:5080/healthz` health check, etc.). No code changes.

## Test plan

- All eight PRs merged to `pre-main` individually through the normal `pre-commit`/`pre-push` hook gate (`cargo fmt`, `cargo clippy -D warnings`, `cargo test`, UI build/tests).
- `pre-main` has been running on the staging channel (staging DMG auto-update) and exercised end-to-end there, per the project's release gate.
- No new migrations in this batch; no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for delayed database availability, allowing first-launch setup to complete without restarting the tray.
  - Startup now loads the canonical configuration file even when launched from another directory.
  - Added documentation for read-only local observability queries.

- **Bug Fixes**
  - Prevented encrypted databases from being orphaned when generating keys.
  - Fixed tray tooltips remaining visible after right-click interactions.
  - Improved Windows notification-permission handling and launcher behavior.

- **Changes**
  - Removed the legacy session-summary skill and related installation and health-check steps.
  - Standardized typography across the tray interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->