### PR TITLE
fix(ui): show a confirmed daily plan to solo users

### DIFF
--- a/ui/__tests__/overview-focus-section.test.ts
+++ b/ui/__tests__/overview-focus-section.test.ts
@@ -1,0 +1,147 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// OverviewPanel's "Today's focus" visibility rule.
+//
+// The bug: the populated checklist and a past day's note were gated on
+// `!isSolo` while the empty-today nudge was shown to everyone. A solo user was
+// therefore invited to plan, allowed to commit a personal task, and then shown
+// nothing — the section vanished the instant the plan stopped being empty.
+// Reproduced on a real install: daily_plan had one confirmed row for the day
+// (daily_plan_meta.confirmed_at set, skipped=0) and the panel rendered no
+// focus section at all.
+//
+// Two halves are pinned here, because either alone would pass while the other
+// regressed: the predicate's truth table, and the fact that the JSX actually
+// calls it rather than re-deriving a gate inline (this repo has no React
+// render harness — see task-composer.test.ts).
+
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { focusSectionVisible } from '../components/timeline/types'
+
+const src = (p: string) => readFileSync(join(import.meta.dir, '..', p), 'utf8')
+const panel = src('components/timeline/OverviewPanel.tsx')
+
+/** The pre-fix gate, kept verbatim as the reference for the parity checks. */
+function legacyGate(a: {
+  isToday: boolean
+  planLoaded: boolean
+  itemCount: number
+  isSolo: boolean
+}): boolean {
+  return (
+    (a.isToday && a.planLoaded && a.itemCount === 0) ||
+    (!a.isSolo && (a.itemCount > 0 || !a.isToday))
+  )
+}
+
+const BOOLS = [true, false]
+const COUNTS = [0, 1, 3]
+
+describe('today, with a committed plan', () => {
+  it('renders the checklist for a solo user — the reported bug', () => {
+    expect(focusSectionVisible({ isToday: true, planLoaded: true, itemCount: 1 })).toBe(true)
+  })
+
+  it('rendered nothing under the old gate, which is what made it a bug', () => {
+    expect(legacyGate({ isToday: true, planLoaded: true, itemCount: 1, isSolo: true })).toBe(false)
+  })
+
+  it('renders for a connected user too, unchanged', () => {
+    expect(focusSectionVisible({ isToday: true, planLoaded: true, itemCount: 1 })).toBe(true)
+    expect(legacyGate({ isToday: true, planLoaded: true, itemCount: 1, isSolo: false })).toBe(true)
+  })
+})
+
+describe('today, with nothing planned', () => {
+  it('renders the nudge once get_plan has resolved', () => {
+    expect(focusSectionVisible({ isToday: true, planLoaded: true, itemCount: 0 })).toBe(true)
+  })
+
+  it('renders nothing before the first fetch, so the nudge cannot flash', () => {
+    expect(focusSectionVisible({ isToday: true, planLoaded: false, itemCount: 0 })).toBe(false)
+  })
+})
+
+describe('a past date', () => {
+  it('always renders — committed focus, or a quiet empty note', () => {
+    for (const planLoaded of BOOLS) {
+      for (const itemCount of COUNTS) {
+        expect(focusSectionVisible({ isToday: false, planLoaded, itemCount })).toBe(true)
+      }
+    }
+  })
+})
+
+describe('the full truth table', () => {
+  // isToday × planLoaded × itemCount, exhaustively. Written out rather than
+  // derived so a change to the rule has to be stated here deliberately.
+  const cases: Array<[boolean, boolean, number, boolean]> = [
+    // isToday, planLoaded, itemCount, expected
+    [true, true, 0, true], //  nudge
+    [true, false, 0, false], // pre-fetch: nothing, no flash
+    [true, true, 1, true], //  checklist
+    [true, false, 1, true], //  items imply a resolved fetch
+    [false, true, 0, true], //  past, empty note
+    [false, false, 0, true], //  past, empty note
+    [false, true, 1, true], //  past, read-only focus
+    [false, false, 1, true], //  past, read-only focus
+  ]
+
+  for (const [isToday, planLoaded, itemCount, expected] of cases) {
+    it(`isToday=${isToday} planLoaded=${planLoaded} items=${itemCount} → ${expected}`, () => {
+      expect(focusSectionVisible({ isToday, planLoaded, itemCount })).toBe(expected)
+    })
+  }
+})
+
+describe('connected users are unaffected', () => {
+  it('matches the old gate exactly for every non-solo combination', () => {
+    for (const isToday of BOOLS) {
+      for (const planLoaded of BOOLS) {
+        for (const itemCount of COUNTS) {
+          expect(focusSectionVisible({ isToday, planLoaded, itemCount })).toBe(
+            legacyGate({ isToday, planLoaded, itemCount, isSolo: false }),
+          )
+        }
+      }
+    }
+  })
+
+  it('now treats solo and connected identically, which it did not before', () => {
+    const differed = [] as string[]
+    for (const isToday of BOOLS) {
+      for (const planLoaded of BOOLS) {
+        for (const itemCount of COUNTS) {
+          const solo = legacyGate({ isToday, planLoaded, itemCount, isSolo: true })
+          const connected = legacyGate({ isToday, planLoaded, itemCount, isSolo: false })
+          if (solo !== connected) differed.push(`${isToday}/${planLoaded}/${itemCount}`)
+        }
+      }
+    }
+    // The old gate genuinely diverged — if it didn't, this test is guarding nothing.
+    expect(differed.length).toBeGreaterThan(0)
+  })
+})
+
+describe('the panel uses the shared predicate', () => {
+  it('calls focusSectionVisible for the focus section', () => {
+    expect(panel).toContain('focusSectionVisible({')
+    expect(panel).toContain("import { focusSectionVisible")
+  })
+
+  it('does not gate the focus section on isSolo any more', () => {
+    const gate = panel.split('\n').find(l => l.includes('focusSectionVisible({'))
+    expect(gate).toBeDefined()
+    expect(gate).not.toContain('isSolo')
+    // The exact pre-fix expression must not come back.
+    expect(panel).not.toContain('!isSolo && (focusItems.length > 0')
+  })
+
+  it('still uses isSolo elsewhere, so the fix did not over-reach', () => {
+    // Solo genuinely changes other things (greeting copy, the Drafts mini-card,
+    // the connect-a-tracker CTA) — those are not part of this bug.
+    expect(panel).toContain('isSolo')
+  })
+})

--- a/ui/components/timeline/OverviewPanel.tsx
+++ b/ui/components/timeline/OverviewPanel.tsx
@@ -19,7 +19,7 @@ import { fmtDur } from '@/components/atoms'
 import { load as loadData, mutate as mutateData, openExternal } from '@/lib/bridge'
 import { usePlan, refreshPlan } from '@/components/plan/planStore'
 import type { PlanItem, CodingAgentsResponse } from '@/lib/api-types'
-import { formatDayLabel, isPending } from './types'
+import { focusSectionVisible, formatDayLabel, isPending } from './types'
 import { TimeByApp, appTotals } from './TimeByApp'
 import { TimeByCategory, categoryRows } from './TimeByCategory'
 import { UpdateCard } from './UpdateCard'
@@ -214,13 +214,14 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
           past. On a past date the section is read-only: it shows that day's
           committed focus (or a quiet empty note), with no Edit/Add
           affordances. `focusLabel` relabels the heading off "Today's".
-          The empty-TODAY case is shown to every user, including solo/
-          no-tracker (PlanView's composer already supports a personal,
-          tracker-free task, see PlanView.tsx's `boardEmpty` path) — everything
-          else (the populated checklist, and a past day's read-only note)
-          stays tracker-only, unchanged. `plan` gates the empty branch so it
-          never flashes before the first `get_plan` resolves. */}
-      {((isToday && plan && focusItems.length === 0) || (!isSolo && (focusItems.length > 0 || !isToday))) && (
+          Shown to every user, solo/no-tracker included — PlanView's composer
+          supports a personal, tracker-free task (see its `boardEmpty` path),
+          and `toggleDone` below already routes a personal task to our own DB
+          rather than a tracker, so nothing here needs a board. This used to
+          gate everything except the empty-today nudge on `!isSolo`, which meant
+          a solo user was invited to plan and then never shown the plan they
+          committed. See `focusSectionVisible` for the whole rule. */}
+      {focusSectionVisible({ isToday, planLoaded: !!plan, itemCount: focusItems.length }) && (
         <div>
           {focusItems.length === 0 && isToday ? (
             <div>

--- a/ui/components/timeline/types.ts
+++ b/ui/components/timeline/types.ts
@@ -134,3 +134,32 @@ export function itemKey(w: Pick<WorklogItem, 'id' | 'is_proposed'>): string {
 export function isPending(w: WorklogItem): boolean {
   return w.is_proposed ? w.state === 'proposed' : w.state === 'drafted'
 }
+
+// Should OverviewPanel's "Today's focus" section render at all?
+//
+// Deliberately takes NO `isSolo` argument. It used to: the populated checklist
+// and a past day's read-only note were gated on `!isSolo`, while the
+// empty-today nudge was shown to everyone. That combination is incoherent — a
+// solo user was invited to plan (the nudge), PlanView's composer let them
+// commit a personal, tracker-free task, and then the committed plan rendered
+// nowhere, because the moment it stopped being empty the only branch that
+// admitted solo users stopped matching. A confirmed plan disappearing the
+// instant you confirm it is the bug this predicate exists to prevent
+// recurring; a tracker is not what makes a plan worth showing you.
+//
+// `planLoaded` is whether `get_plan` has resolved for this day. It gates the
+// empty case only, so an empty section never flashes before the first fetch —
+// items already imply a resolved fetch.
+export function focusSectionVisible({ isToday, planLoaded, itemCount }: {
+  isToday: boolean
+  planLoaded: boolean
+  itemCount: number
+}): boolean {
+  // A past date always renders: that day's committed focus, or a quiet
+  // "nothing planned" note. Editing affordances are suppressed separately.
+  if (!isToday) return true
+  // Today with a committed plan → the checklist.
+  if (itemCount > 0) return true
+  // Today with nothing planned → the nudge, once the fetch has resolved.
+  return planLoaded
+}


### PR DESCRIPTION
## The bug

A solo (no-tracker) user could commit a daily plan and then **never see it**. The plan was saved correctly — it just rendered nowhere.

`OverviewPanel.tsx` gated the populated checklist, and a past day's read-only note, on `!isSolo`, while showing the empty-today nudge to everyone:

```tsx
{((isToday && plan && focusItems.length === 0)
  || (!isSolo && (focusItems.length > 0 || !isToday))) && (
```

For a solo user on today, that is visible **only while the plan is empty**. Committing a task makes `focusItems.length === 0` false, so the first branch stops matching; the second never matched for them. The section disappeared at the exact moment it finally had something to show.

### Three halves of the flow disagreed

- the **nudge** deliberately invites solo users to plan (its own comment said so),
- **PlanView's composer** supports a personal, tracker-free task (its `boardEmpty` path),
- **`toggleDone`** already routes a personal task to our own DB rather than to a tracker.

Nothing in the section needs a board. Only the visibility gate thought otherwise.

### Reproduced on a real install

```
daily_plan       plan_date=2026-07-31  task_key=LOCAL-1  "Setup Meridian on Windows"  origin=manual
daily_plan_meta  plan_date=2026-07-31  confirmed_at=2026-07-31T10:27:21Z  skipped=0
```

Confirmed plan, one item, and the panel rendered no focus section at all. `isSolo` was independently confirmed from the same screenshot: the heading read *"Your day, in progress"*, which `OverviewPanel.tsx:151` only produces when `isSolo` is true.

## The fix

The gate moves into a named predicate in `components/timeline/types.ts` — the module that already exists for "small pure predicates" and that `OverviewPanel` already imports from:

```ts
export function focusSectionVisible({ isToday, planLoaded, itemCount }): boolean {
  if (!isToday) return true      // past day: committed focus, or a quiet empty note
  if (itemCount > 0) return true // today with a plan: the checklist
  return planLoaded              // today, nothing planned: the nudge, post-fetch
}
```

It takes **no `isSolo` argument**. That absence is the fix, and the reasoning is recorded at the definition so it isn't re-added later as a "missing" parameter.

`isSolo` is untouched everywhere it legitimately applies — the greeting copy, the Drafts mini-card, the connect-a-tracker CTA.

## Tests — 19 tests, 39 assertions

`ui/__tests__/overview-focus-section.test.ts` pins **two halves**, because either alone would pass while the other regressed:

1. **The truth table** — all 8 combinations of `isToday × planLoaded × itemCount`, written out explicitly rather than derived, so changing the rule has to be stated deliberately here.
2. **That the JSX actually calls the predicate** — by source scan, since this repo has no React render harness (see `task-composer.test.ts`). It asserts the gate line contains `focusSectionVisible({`, does *not* contain `isSolo`, and that the exact pre-fix expression `!isSolo && (focusItems.length > 0` cannot return.

Two tests exist specifically to stop me fooling myself:

- **Parity for connected users** — across every combination, the new predicate must equal the old gate with `isSolo: false`. Connected users get byte-identical behaviour; this only stops punishing solo ones.
- **A guard on the guard** — asserts the *old* gate genuinely diverged between solo and connected. If it hadn't, the parity test would be guarding nothing and I'd have "fixed" a non-bug.

The pre-fix expression is kept verbatim in the test as `legacyGate`, so the regression is reproducible rather than merely described.

## Verification

`bun test __tests__/overview-focus-section.test.ts` → **19 pass, 0 fail, 39 expect() calls**, run locally.

## Scope note

This is a product decision as much as a bug fix: it makes the daily plan a feature solo users can actually use, rather than one that silently requires a connected tracker. That reading follows from the nudge and composer already supporting them — but if the intent was genuinely tracker-only, the correct fix is the opposite one (hide the nudge from solo users too), and this PR should be rejected in favour of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
