### PR TITLE
docs(observability): address PR #644 review comments

### DIFF
--- a/ops/central-observability/LOCAL-ACCESS.md
+++ b/ops/central-observability/LOCAL-ACCESS.md
@@ -36,6 +36,15 @@ straight to OpenObserve's container port, entirely bypassing Caddy.
   calls. Ask whoever deployed the stack, or read them off the VM directly —
   never copy them into a file in this repo.
 
+  **Root is a stopgap, not the sanctioned end state.** The SSH tunnel bypasses
+  Caddy entirely, so "read-only" here is enforced only by the convention of
+  this doc — root can do anything the API allows, not just `_search`. Prefer
+  authenticating as a dedicated **Viewer**-role OpenObserve user (Settings ->
+  Users in the UI, or the `/api/{org}/users` endpoint) once one exists for
+  this org; ask whoever administers the instance to provision it. Provisioning
+  and rotating that account is tracked as follow-up work, not done as part of
+  this doc.
+
 **Run every command below in a real terminal on your own machine — not Google
 Cloud Shell.** Cloud Shell is a separate, ephemeral environment; the SSH
 tunnel's local port-forward has to bind on *your* machine, and running it in
@@ -49,17 +58,19 @@ because there's nothing local there to serve it to.
 ```bash
 gcloud compute ssh --zone "asia-south1-a" "meridian-telemetry" --project "meridiona-observability"
 
-# once on the VM:
-cd central-observability   # wherever docker-compose.yml lives on this VM
-docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \
-  central-observability-openobserve-1
+# once on the VM, in the directory with docker-compose.yml:
+cd central-observability
+container_id="$(docker compose ps -q openobserve)"
+test -n "$container_id" || { echo "openobserve service not running"; exit 1; }
+docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$container_id"
 # e.g. 172.18.0.2
 exit
 ```
 
-This only needs to be redone if the stack is redeployed and the container gets
-recreated (compose's private network typically hands out the same IP, but
-don't assume it).
+Resolving through the Compose service name (rather than a hardcoded container
+name) means this keeps working across a redeploy. Still re-run it after any
+redeploy though — the bridge IP is only stable for the container currently
+running; don't cache it.
 
 **2. Open the tunnel** (from your own terminal, not Cloud Shell):
 
@@ -75,20 +86,31 @@ session.
 **3. Verify:**
 
 ```bash
-curl http://127.0.0.1:5080/healthz   # expect 200 OK
+curl -fsS -o /dev/null -w 'HTTP %{http_code}\n' http://127.0.0.1:5080/healthz
 ```
+
+`-f` makes curl exit non-zero on a 4xx/5xx instead of silently reporting
+success on a transfer that completed but returned an error status.
 
 **4. Query `_search` directly:**
 
 ```bash
-curl -s -u '<OO_ROOT_USER_EMAIL>:<OO_ROOT_USER_PASSWORD>' \
+export OO_ROOT_USER_EMAIL='<from the VM .env>'
+# Give curl the user only, not "user:password" — it then prompts for the
+# password interactively, which keeps it out of shell history and `ps` output
+# (a literal '<user>:<password>' on the command line ends up in both).
+
+end_time=$(( $(date +%s) * 1000000 ))
+start_time=$(( end_time - 30 * 86400 * 1000000 ))   # last 30 days; adjust as needed
+
+curl --user "$OO_ROOT_USER_EMAIL" \
   -X POST 'http://127.0.0.1:5080/api/default/_search' \
   -H 'Content-Type: application/json' \
   -d '{
     "query": {
-      "sql": "SELECT * FROM \"default\" WHERE message LIKE '\''%mac_970e5ebf236cb0ce%'\'' ORDER BY _timestamp DESC LIMIT 50",
-      "start_time": 1735689600000000,
-      "end_time": 1753900800000000
+      "sql": "SELECT * FROM \"default\" WHERE body LIKE '\''%mac_970e5ebf236cb0ce%'\'' ORDER BY _timestamp DESC LIMIT 50",
+      "start_time": '"$start_time"',
+      "end_time": '"$end_time"'
     }
   }'
 ```
@@ -97,12 +119,14 @@ Notes:
 - Org is `default` (matches `OO_ORG` in `.env.example`) unless the deploy was
   changed.
 - `start_time`/`end_time` are **microsecond epoch timestamps** — `0` is
-  rejected with `invalid time range`. Compute a real window, e.g. in Python:
-  `int(time.time() * 1_000_000)` for "now", and subtract
-  `N * 86_400 * 1_000_000` for N days back.
-- The stream/table name and available columns depend on what the OTel
-  Collector is configured to write (see `otel-collector-config.yaml`) — when
-  unsure what's queryable, `SHOW STREAMS` or hit `/api/default/streams` first.
+  rejected with `invalid time range`; the snippet above computes a real
+  window at run time so it never goes stale. `start_time`/`end_time` in the
+  request body only bound the search window — they're independent of any
+  `_timestamp` condition inside `sql`.
+- The log stream's actual column is `body`, not `message` — `SELECT * FROM
+  "default"` (or `/api/default/streams`) shows the full schema when unsure.
+  The stream/table name and available columns otherwise depend on what the
+  OTel Collector is configured to write (see `otel-collector-config.yaml`).
 
 ## When you're done
 

--- a/src/coding_agent_session_ingest/summariser/README.md
+++ b/src/coding_agent_session_ingest/summariser/README.md
@@ -36,8 +36,9 @@ A fallback summary is recorded as `summary_source = "fallback:<provider>"`, so a
 summary written by a substitute is never mistaken for one the agent that did the
 work produced.
 
-- **Claude sessions → `claude -p`** (`claude.rs`) — loads the `session-summary`
-  skill, structured output. Runs on the user's Claude subscription;
+- **Claude sessions → `claude -p`** (`claude.rs`) — `SUMMARY_RULES` embedded
+  directly in the `-p` prompt (no slash-skill invocation), structured output.
+  Runs on the user's Claude subscription;
   `ANTHROPIC_API_KEY` is dropped from the child env so a stray key can't switch
   to metered billing. `MERIDIAN_SUMMARISER=1` makes the indexer hook ignore the
   throwaway session, and `--no-session-persistence` means no JSONL is written.
@@ -57,8 +58,8 @@ work produced.
   runs persist to `~/.cursor/chats/` — see "Self-ingest guard" below.
 
 All engines target the same `SUMMARY_SCHEMA` and share `SUMMARY_RULES`
-(`prompts.rs`): Claude via the skill's `SKILL.md`, the others via the prompt —
-kept in one place so they can't drift.
+(`prompts.rs`), embedded inline in each engine's own prompt (no slash-skill
+invocation for any of them) — kept in one place so they can't drift.
 
 ### Self-ingest guard
 

--- a/tray/src/style.css
+++ b/tray/src/style.css
@@ -276,7 +276,6 @@ button:focus-visible {
 .status-title {
   font: var(--mt-card-title);
   letter-spacing: var(--mt-card-title-tracking);
-  letter-spacing: -0.01em;
   color: #0F7A54;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
Resolves CodeRabbit's review comments on #644 (the pre-main → main release PR):

- **`ops/central-observability/LOCAL-ACCESS.md`**
  - Documents that the root credentials are a stopgap and recommends a dedicated Viewer-role account as follow-up work (the tunnel bypasses Caddy, so "read-only" was only enforced by convention).
  - Resolves the OpenObserve container via `docker compose ps -q openobserve` instead of a hardcoded container name, so it survives a redeploy.
  - The `healthz` check now uses `-fsS -w` so it actually fails on 4xx/5xx instead of reporting success on any completed transfer.
  - The `_search` curl command no longer takes the password inline (shell history / `ps` exposure) — it prompts interactively via `--user`.
  - The example query's `start_time`/`end_time` are now computed at run time instead of hardcoded to a static 2025 date range.
  - **Bonus fix, found by actually running this doc's own query today**: the log stream's real column is `body`, not `message` — the old example errors with `Search field not found: no field named message`.
- **`src/coding_agent_session_ingest/summariser/README.md`** — two sentences still described Claude invoking the `session-summary` slash-skill; the engine has embedded `SUMMARY_RULES` directly in the `-p` prompt since an earlier change. Updated to match.
- **`tray/src/style.css`** — removed a literal `letter-spacing: -0.01em` immediately overriding `var(--mt-card-title-tracking)` on `.status-title`.

## Test plan
- [x] `cargo fmt --check` / `cargo clippy -D warnings` / `cargo test` (pre-push hook)
- [x] UI build + UI tests (pre-push hook)
- [x] Manually re-ran the corrected `_search` curl command against the live central OO tunnel — confirms the `body` column fix and the dynamic time window both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)