### PR TITLE
docs(observability): fix CodeRabbit's second-pass findings on #644

### DIFF
--- a/ops/central-observability/LOCAL-ACCESS.md
+++ b/ops/central-observability/LOCAL-ACCESS.md
@@ -62,7 +62,9 @@ gcloud compute ssh --zone "asia-south1-a" "meridian-telemetry" --project "meridi
 cd central-observability
 container_id="$(docker compose ps -q openobserve)"
 test -n "$container_id" || { echo "openobserve service not running"; exit 1; }
-docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$container_id"
+address="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$container_id")"
+test -n "$address" || { echo "container has no network address"; exit 1; }
+echo "$address"
 # e.g. 172.18.0.2
 exit
 ```
@@ -108,7 +110,7 @@ curl --user "$OO_ROOT_USER_EMAIL" \
   -H 'Content-Type: application/json' \
   -d '{
     "query": {
-      "sql": "SELECT * FROM \"default\" WHERE body LIKE '\''%mac_970e5ebf236cb0ce%'\'' ORDER BY _timestamp DESC LIMIT 50",
+      "sql": "SELECT * FROM \"default\" WHERE host_name = '\''mac_970e5ebf236cb0ce'\'' ORDER BY _timestamp DESC LIMIT 50",
       "start_time": '"$start_time"',
       "end_time": '"$end_time"'
     }
@@ -123,10 +125,19 @@ Notes:
   window at run time so it never goes stale. `start_time`/`end_time` in the
   request body only bound the search window — they're independent of any
   `_timestamp` condition inside `sql`.
-- The log stream's actual column is `body`, not `message` — `SELECT * FROM
-  "default"` (or `/api/default/streams`) shows the full schema when unsure.
-  The stream/table name and available columns otherwise depend on what the
-  OTel Collector is configured to write (see `otel-collector-config.yaml`).
+- A Support ID is the pseudonymized `host_name` **resource attribute**, not
+  text inside the log message — filter on `host_name = '<support id>'`
+  (exact match), not a `LIKE` search over `body`. The log message column
+  itself is called `body`, not `message`.
+- If you do need a substring search over `body`, remember `_` and `%` are
+  SQL `LIKE` wildcards — a literal underscore (as in `mac_970e...`) matches
+  any single character unless escaped, e.g. `LIKE '%foo\_bar%' ESCAPE '\'`.
+  `host_name` needs no such escaping since it's an exact-match column, not a
+  pattern.
+- `SELECT * FROM "default"` (or `/api/default/streams`) shows the full
+  schema when unsure what's queryable — the stream/table name and available
+  columns otherwise depend on what the OTel Collector is configured to write
+  (see `otel-collector-config.yaml`).
 
 ## When you're done
 


### PR DESCRIPTION
## Summary
Follow-up to #648 — CodeRabbit's second review pass on #644 found 2 new actionable issues in the fixes #648 just landed:

- **Step 1 discovery snippet** ran `docker inspect` directly without capturing/validating its output — an empty result would silently print nothing instead of failing loudly. Now captures into `$address`, validates non-empty, and echoes it explicitly.
- **The example `_search` query's `LIKE` pattern** contained an unescaped `mac_970e...` — underscore is a SQL wildcard (matches any single character), not a literal.

Rather than just escaping the underscore, I tested against the live OO tunnel and found the query was searching the wrong column entirely: a Support ID is the `host_name` **resource attribute**, not text inside the log `body`. `body LIKE '%mac_970e5ebf236cb0ce%'` (escaped or not) returns zero hits — the string simply isn't in that column. Switched to `WHERE host_name = '<support id>'` (exact match), which returned real hits when tested live. Added a note on `_`/`%` escaping for anyone who does need a genuine `body` substring search later.

## Test plan
- [x] `cargo fmt --check` / `cargo clippy -D warnings` / `cargo test` (pre-push hook)
- [x] Ran the exact doc query (copy-pasted, including the bash variable interpolation) against the live central OO tunnel — confirmed it returns real rows for `mac_970e5ebf236cb0ce`

🤖 Generated with [Claude Code](https://claude.com/claude-code)