### PR TITLE
Release: solo daily-plan visibility fix + main → pre-main back-merge automation

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -297,3 +297,125 @@ jobs:
               echo "No release cut."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Back-merge main → pre-main ──────────────────────────────────────────────
+  #
+  # WHY THIS EXISTS. semantic-release derives the next version from the tags
+  # REACHABLE FROM THE BRANCH it runs on. The stable config's
+  # @semantic-release/git plugin commits the version bump onto `main`, and the
+  # tag points at that commit — so both live only on `main`. Nothing ever
+  # carried them back to `pre-main`, and the release flow is one-way
+  # (pre-main → main), so `pre-main` could not see them either.
+  #
+  # The result was silent and cumulative: measured on 2026-07-31, `main` was at
+  # v1.82.1 while the newest tag reachable from `pre-main` was
+  # v1.78.0-staging.16, and pre-main's own Cargo.toml / tauri.conf.json still
+  # read 1.77.0 — five minor versions of drift across twelve unmerged release
+  # commits. Staging kept incrementing `-staging.N` on a 1.78.0 base forever.
+  #
+  # That is not cosmetic. `1.78.0-staging.16` sorts BELOW `1.82.1` under semver,
+  # so tauri-plugin-updater will not offer a staging build to anyone already on
+  # a current stable install — the staging channel silently stops being
+  # installable by exactly the people meant to test it, and they have to fetch
+  # the asset by hand.
+  #
+  # Merging main back makes its tags reachable, so the next staging cut is
+  # numbered off the real current version and sorts above it again.
+  #
+  # A PR, NOT A DIRECT PUSH. pre-main is the staging branch everything is cut
+  # from; nothing here bypasses its review gate. This job only ever prepares the
+  # merge and opens the PR — a human merges it, exactly like the pre-main → main
+  # release PR. The trade-off is that an unmerged back-merge PR leaves staging
+  # stuck, which is why the PR body says so in as many words.
+  backmerge:
+    name: Back-merge main → pre-main
+    needs: prepare
+    # Stable channel only, and only when a release actually happened. A staging
+    # dispatch on pre-main has nothing to merge back, and a no-op run on main
+    # (semantic-release's own bump commit re-entering this workflow) must not
+    # open an empty PR.
+    if: ${{ github.ref_name == 'main' && needs.prepare.outputs.released == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # pushes the back-merge branch
+      pull-requests: write # opens the PR
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          # The PAT for the same reason the prepare job needs it: a branch
+          # pushed with the default GITHUB_TOKEN does not trigger downstream
+          # workflows, so the back-merge PR would open with no CI on it.
+          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Open the back-merge PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin main pre-main
+
+          # Already contained (e.g. a re-run after the PR was merged): nothing
+          # to do, and opening an empty PR would be noise.
+          if [ "$(git rev-list --count origin/pre-main..origin/main)" = "0" ]; then
+            echo "→ pre-main already contains main; nothing to back-merge"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          branch="chore/backmerge-${TAG}"
+          git checkout -B "${branch}" origin/pre-main
+
+          # Conflicts are a human's call — the version manifests are the likely
+          # site, and guessing at them would corrupt the very numbers this job
+          # exists to keep straight. Fail loudly rather than push something
+          # half-resolved.
+          if ! git merge --no-edit origin/main; then
+            git merge --abort || true
+            echo "::error::main → pre-main back-merge conflicts; resolve it by hand"
+            {
+              echo "### Back-merge needs a human"
+              echo ""
+              echo "Merging \`main\` (\`${TAG}\`) into \`pre-main\` conflicts."
+              echo ""
+              echo '```bash'
+              echo "git checkout pre-main && git pull"
+              echo "git merge main   # resolve, keeping main's version manifests"
+              echo '```'
+              echo ""
+              echo "Until this lands, staging versions keep being cut from a stale"
+              echo "base and sort below the current stable release."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          git push --force-with-lease origin "${branch}"
+
+          if gh pr view "${branch}" --json number >/dev/null 2>&1; then
+            echo "→ PR already open for ${branch}"
+          else
+            gh pr create \
+              --base pre-main --head "${branch}" \
+              --title "chore: back-merge ${TAG} into pre-main" \
+              --body "$(printf '%s\n' \
+                "Automated back-merge of \`main\` (\`${TAG}\`) into \`pre-main\`." \
+                "" \
+                "**Merge this.** semantic-release numbers a staging cut from the tags" \
+                "reachable from \`pre-main\`. The stable release commit and its tag are" \
+                "created on \`main\` and never come back on their own, so until this lands," \
+                "staging keeps being cut from a stale base — and a staging version that" \
+                "sorts below the current stable release is one the updater will not offer" \
+                "to anyone already on stable." \
+                "" \
+                "Opened automatically by \`release-prepare.yml\`.")"
+          fi
+
+          {
+            echo "### Back-merge PR"
+            echo ""
+            echo "Opened \`${branch}\` → \`pre-main\` for \`${TAG}\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -340,18 +340,42 @@ jobs:
       contents: write # pushes the back-merge branch
       pull-requests: write # opens the PR
     steps:
+      # *** THE PAT IS REQUIRED HERE, NOT A PREFERENCE. ***
+      #
+      # GitHub does not trigger workflows for refs pushed with the default
+      # GITHUB_TOKEN (the recursion guard), and a pull_request opened with it
+      # only ever lands in an approval-required state. Either way the
+      # back-merge PR arrives with no CI on it — and pre-main's checks are
+      # what a human merges it on, so it would sit unmergeable and silent,
+      # which is the exact failure mode this job exists to end.
+      #
+      # So there is deliberately NO `|| secrets.GITHUB_TOKEN` fallback below:
+      # a degraded back-merge is worse than a loud one. Fail here, before
+      # anything is pushed, with a message that names the missing secret.
+      - name: Require the release PAT
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::secrets.GH_TOKEN is not available; the back-merge PR would open with no CI on it. Configure the org PAT and re-run."
+            exit 1
+          fi
+          echo "→ GH_TOKEN present"
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
-          # The PAT for the same reason the prepare job needs it: a branch
-          # pushed with the default GITHUB_TOKEN does not trigger downstream
-          # workflows, so the back-merge PR would open with no CI on it.
-          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          # Persisted on purpose: `git push` below reuses this credential, so
+          # it must be the PAT (see the guard step above), not the default
+          # token.
+          persist-credentials: true
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Open the back-merge PR
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           TAG: ${{ needs.prepare.outputs.tag }}
         run: |
           set -euo pipefail

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -67,7 +67,8 @@
     [
       "@semantic-release/changelog",
       {
-        "changelogFile": "CHANGELOG.md"
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# Changelog"
       }
     ],
     [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## [1.82.2](https://github.com/Meridiona/meridian/compare/v1.82.1...v1.82.2) (2026-07-31)
 
 ### 🐛 Bug Fixes
@@ -74,7 +76,7 @@
 * address CodeRabbit review findings on [#603](https://github.com/Meridiona/meridian/issues/603) ([7f76bdd](https://github.com/Meridiona/meridian/commit/7f76bddd7299b98525f2c5579191798728486b46)), closes [#605](https://github.com/Meridiona/meridian/issues/605)
 * address release review findings on [#603](https://github.com/Meridiona/meridian/issues/603) ([2e74e1d](https://github.com/Meridiona/meridian/commit/2e74e1db17629a020f752d0d8be1fa8cca9a328f))
 * **db:** address review — surface plaintext downgrade, harden 2nd rename ([6a3d186](https://github.com/Meridiona/meridian/commit/6a3d186d8a154c85681392250f472aefa2a77afb))
-* **db:** complete the Windows encrypt-in-place migration (close handle, retry rename) ([82aba7b](https://github.com/Meridiona/meridian/commit/82aba7baedd643943c946c81fcae9ad9b041a0d8)), closes [#598](https://github.com/Meridiona/meridian/issues/598) [#598](https://github.com/Meridiona/meridian/issues/598)
+* **db:** complete the Windows encrypt-in-place migration (close handle, retry rename) ([82aba7b](https://github.com/Meridiona/meridian/commit/82aba7baedd643943c946c81fcae9ad9b041a0d8)), closes [#598](https://github.com/Meridiona/meridian/issues/598)
 * **db:** fix review — restore doc block onto finalize_encryption_swap ([53b7a11](https://github.com/Meridiona/meridian/commit/53b7a11a7ea676241e9ee0135a70dbbea78a337c)), closes [#606](https://github.com/Meridiona/meridian/issues/606) [#598](https://github.com/Meridiona/meridian/issues/598)
 * **db:** open plaintext meridian.db as plaintext even when a key is set ([c8d92ca](https://github.com/Meridiona/meridian/commit/c8d92ca445c5c082d5b7bb99c7e04f80666c36d1))
 * **intelligence:** harden the grace-row insert and trace the sync-failure path ([74329cc](https://github.com/Meridiona/meridian/commit/74329cc92dd04db39534909ae814eeb63fd7ef1b))
@@ -94,12 +96,12 @@
 * **tray:** harden Windows daemon-binary install against transient locks ([03fcbb4](https://github.com/Meridiona/meridian/commit/03fcbb477a298b4cdbfc1a787f6a65d06669de9e)), closes [#606](https://github.com/Meridiona/meridian/issues/606)
 * **tray:** log each failed rename attempt during daemon staging ([d000b60](https://github.com/Meridiona/meridian/commit/d000b60de4c2458fdd6186ababca806c87b3ee0e)), closes [#598](https://github.com/Meridiona/meridian/issues/598)
 * **tray:** make failed provider installs and sign-ins visible in traces ([1b24b00](https://github.com/Meridiona/meridian/commit/1b24b00fba23764ac88f1d71febd2697af128541))
-* **tray:** restore a throttled progress breadcrumb during the daemon-exit wait ([18de191](https://github.com/Meridiona/meridian/commit/18de191ae1f53c0ea685027db766c032e89fc339)), closes [#607](https://github.com/Meridiona/meridian/issues/607) [606/#607](https://github.com/606/meridian/issues/607)
+* **tray:** restore a throttled progress breadcrumb during the daemon-exit wait ([18de191](https://github.com/Meridiona/meridian/commit/18de191ae1f53c0ea685027db766c032e89fc339)), closes [#606](https://github.com/Meridiona/meridian/issues/606) [#607](https://github.com/Meridiona/meridian/issues/607)
 * **tray:** ship LLM install/sign-in failures to OpenObserve ([e8fb9a5](https://github.com/Meridiona/meridian/commit/e8fb9a51a2ee921eb63efecd92c90a2c9aba4363))
 
 ### ♻️ Refactoring
 
-* **core:** unify the Windows transient-lock retry into meridian-core ([3802c2d](https://github.com/Meridiona/meridian/commit/3802c2da6c184eeb85d14463f8ed9c0586319c93)), closes [#606](https://github.com/Meridiona/meridian/issues/606) [#607](https://github.com/Meridiona/meridian/issues/607) [#606](https://github.com/Meridiona/meridian/issues/606) [#607](https://github.com/Meridiona/meridian/issues/607)
+* **core:** unify the Windows transient-lock retry into meridian-core ([3802c2d](https://github.com/Meridiona/meridian/commit/3802c2da6c184eeb85d14463f8ed9c0586319c93)), closes [#606](https://github.com/Meridiona/meridian/issues/606) [#607](https://github.com/Meridiona/meridian/issues/607)
 
 ### 🤖 CI
 

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -58,6 +58,71 @@ use tauri::{
     Emitter, Manager,
 };
 
+/// Runs `f`, converting a panic into `None` instead of letting it propagate.
+///
+/// `setup()` runs synchronously inside tao's `did_finish_launching`, itself
+/// invoked by Cocoa across an `extern "C"` boundary. An unwinding panic
+/// cannot cross that boundary — Rust detects it and calls
+/// `panic_cannot_unwind`, aborting the ENTIRE process before the tray icon
+/// exists, regardless of this workspace's `panic = "unwind"` profile
+/// (`Cargo.toml`'s release-profile guard explains why that's chosen
+/// deliberately over `panic = "abort"`: "we ship a data daemon; no"). Stopping
+/// the unwind here, inside ordinary Rust frames well short of that boundary,
+/// is what makes the profile's guarantee actually hold for `setup()`.
+///
+/// `be368d4e` fixed one instance of exactly this failure mode (sqlx's lazy
+/// pool builder panicking outside a Tokio context) by hardening that one call
+/// site. This contains the FAILURE MODE itself, so the next unforeseen panic
+/// inside a wrapped span degrades the tray instead of bricking it — and, for
+/// spans wrapped before `update::enforce_minimum_version` runs later in
+/// `setup()`, keeps that force-update kill switch reachable instead of a
+/// fatal abort taking it down along with everything else. This is NOT
+/// blanket protection for all of `setup()` — only the spans actually passed
+/// through this wrapper (currently the DB key/pool/encryption-notice work;
+/// see its call sites) are covered. A panic in unwrapped code — the tray
+/// menu build, the tray icon, anything after it — still aborts the process.
+///
+/// `what` is folded into the log MESSAGE, not passed as a separate `tracing`
+/// attribute key: an attribute key not on `redact::SAFE_STRING_KEYS` is
+/// stripped from the packaged-build ship leg (see CLAUDE.md's observability
+/// section), which would silently gut the one line telling us a startup
+/// panic happened.
+fn catch_setup_panic<T>(what: &str, f: impl FnOnce() -> T + std::panic::UnwindSafe) -> Option<T> {
+    match std::panic::catch_unwind(f) {
+        Ok(v) => Some(v),
+        Err(payload) => {
+            let msg = payload
+                .downcast_ref::<&str>()
+                .map(|s| s.to_string())
+                .or_else(|| payload.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "non-string panic payload".to_string());
+            tracing::error!(
+                "tray setup panicked during {what}: {msg} — degrading to a disabled state instead of crashing the tray"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod catch_setup_panic_tests {
+    use super::catch_setup_panic;
+
+    #[test]
+    fn returns_the_value_on_success() {
+        assert_eq!(catch_setup_panic("test", || 42), Some(42));
+    }
+
+    /// The actual point of the wrapper: a panic must degrade to `None`, not
+    /// propagate — Rust's default panic hook still prints to stderr for this
+    /// case, which is expected, harmless test noise.
+    #[test]
+    fn returns_none_instead_of_propagating_a_panic() {
+        let result = catch_setup_panic("test", || -> i32 { panic!("boom") });
+        assert_eq!(result, None);
+    }
+}
+
 pub fn run() {
     // Native-crash capture (Phase 2B). MUST be first: `tauri-plugin-sentry`'s
     // minidump reporter relaunches this exe in a special reporter mode that has
@@ -244,250 +309,293 @@ pub fn run() {
             //    rather than blocking tray startup — see db_key.rs and
             //    meridian_core::db_crypto::encrypt_in_place's doc comments
             //    for why that's the safe failure mode.
-            let db_path = install::meridian_db_path();
-            // Bound once: the same path is re-borrowed as a `Path` several
-            // times below (key resolution, the orphan check, the plaintext
-            // probe, the migration), and `db_path` itself stays a `String`
-            // because the tracing/`open` call sites still want it as one.
-            let db_path_ref = std::path::Path::new(&db_path);
-            let install_mode = install::detect_install_mode();
-            let existing_key = install_mode
-                .env_path()
-                .and_then(|p| install::env_key_from_path(p, "MERIDIAN_DB_KEY"));
+            // The whole span through the encryption notice below runs inside
+            // `catch_setup_panic`: it does keychain access, an in-place file
+            // migration, and builds sqlx's lazy pool — the exact operation
+            // `be368d4e` fixed one instance of (see that helper's doc). An
+            // unforeseen panic anywhere in this span now degrades to the SAME
+            // `db_pool: None` state every other failure here already
+            // produces, instead of taking the whole process down.
+            let db_setup_result = catch_setup_panic(
+                "meridian.db key resolution + pool build + encryption notice",
+                std::panic::AssertUnwindSafe(|| {
+                    let db_path = install::meridian_db_path();
+                    // Bound once: the same path is re-borrowed as a `Path` several
+                    // times below (key resolution, the orphan check, the plaintext
+                    // probe, the migration), and `db_path` itself stays a `String`
+                    // because the tracing/`open` call sites still want it as one.
+                    let db_path_ref = std::path::Path::new(&db_path);
+                    let install_mode = install::detect_install_mode();
+                    let existing_key = install_mode
+                        .env_path()
+                        .and_then(|p| install::env_key_from_path(p, "MERIDIAN_DB_KEY"));
 
-            let db_key_hex = if existing_key.is_some() {
-                existing_key
-            } else if !cfg!(debug_assertions) {
-                match install::canonical_env_path() {
-                    Some(env_path) => match db_key::resolve_or_create_key(
-                        &env_path,
-                        db_path_ref,
-                    ) {
-                        Ok(key) => Some(key),
-                        Err(e) => {
-                            // `tracing`, not `eprintln!`: observability is
-                            // already initialised above, and on a packaged
-                            // install stderr goes only to the launchd log -
-                            // never `meridian logs`, the diagnostics bundle,
-                            // or central error reporting. A silent fallback to
-                            // an UNENCRYPTED database is exactly the event
-                            // those channels exist to surface.
-                            //
-                            // `would_orphan_existing_db` is a DIFFERENT, worse
-                            // case than the generic fallback below: the DB
-                            // already exists and is NOT plaintext, so there is
-                            // no unencrypted file to "continue" into - opening
-                            // it further down with no key will just fail, the
-                            // same way it's been failing already. The
-                            // DB-backed notices system (used elsewhere in this
-                            // function) can't carry this one: it's the very
-                            // database that's unreadable. A native OS
-                            // notification is the only channel left that
-                            // doesn't itself depend on meridian.db opening.
-                            if db_key::would_orphan_existing_db(db_path_ref) {
-                                tracing::error!(
-                                    error = %e,
-                                    "refusing to generate a replacement DB encryption key - meridian.db exists and appears already encrypted under a key this install can no longer find"
-                                );
-                                sys::notify(
-                                    app.handle(),
-                                    "Meridian can't read your local data",
-                                    "Your local database appears to be encrypted with a key this install can no longer find. Contact support with your Support ID (Settings -> Account) before removing anything.",
-                                );
-                            } else {
-                                tracing::error!(
-                                    error = %e,
-                                    "failed to resolve DB encryption key - continuing unencrypted"
-                                );
+                    let db_key_hex = if existing_key.is_some() {
+                        existing_key
+                    } else if !cfg!(debug_assertions) {
+                        match install::canonical_env_path() {
+                            Some(env_path) => {
+                                match db_key::resolve_or_create_key(&env_path, db_path_ref) {
+                                    Ok(key) => Some(key),
+                                    Err(e) => {
+                                        // `tracing`, not `eprintln!`: observability is
+                                        // already initialised above, and on a packaged
+                                        // install stderr goes only to the launchd log -
+                                        // never `meridian logs`, the diagnostics bundle,
+                                        // or central error reporting. A silent fallback to
+                                        // an UNENCRYPTED database is exactly the event
+                                        // those channels exist to surface.
+                                        //
+                                        // `would_orphan_existing_db` is a DIFFERENT, worse
+                                        // case than the generic fallback below: the DB
+                                        // already exists and is NOT plaintext, so there is
+                                        // no unencrypted file to "continue" into - opening
+                                        // it further down with no key will just fail, the
+                                        // same way it's been failing already. The
+                                        // DB-backed notices system (used elsewhere in this
+                                        // function) can't carry this one: it's the very
+                                        // database that's unreadable. A native OS
+                                        // notification is the only channel left that
+                                        // doesn't itself depend on meridian.db opening.
+                                        if db_key::would_orphan_existing_db(db_path_ref) {
+                                            tracing::error!(
+                                                error = %e,
+                                                "refusing to generate a replacement DB encryption key - meridian.db exists and appears already encrypted under a key this install can no longer find"
+                                            );
+                                            sys::notify(
+                                                app.handle(),
+                                                "Meridian can't read your local data",
+                                                "Your local database appears to be encrypted with a key this install can no longer find. Contact support with your Support ID (Settings -> Account) before removing anything.",
+                                            );
+                                        } else {
+                                            tracing::error!(
+                                                error = %e,
+                                                "failed to resolve DB encryption key - continuing unencrypted"
+                                            );
+                                        }
+                                        None
+                                    }
+                                }
                             }
-                            None
+                            None => None,
                         }
-                    },
-                    None => None,
-                }
-            } else {
-                None
-            };
-
-            // Whether encryption was intended this launch (a key was resolved).
-            // Re-checked against the on-disk file after the pool opens, to raise
-            // a user-visible notice if the DB is nonetheless still plaintext
-            // (the encrypt-in-place migration didn't complete) — otherwise the
-            // db_crypto plaintext guard keeps operating unencrypted with only a
-            // log line nobody sees. Runtime-gated below (not `#[cfg]`) so it is
-            // always compiled/linted, matching the migration block's own
-            // `!cfg!(debug_assertions)` style.
-            let db_encryption_intended = db_key_hex.is_some();
-
-            // On Windows the daemon (autostarted at login) holds meridian.db
-            // open, so `encrypt_in_place`'s rename fails with os error 32 and
-            // rolls back every launch — the migration can never complete while
-            // the daemon is up. Stop it first, but ONLY when a migration will
-            // actually attempt (a key was resolved AND the DB is still
-            // plaintext); once encrypted this never runs again, so the stop is a
-            // one-time cost on the migration launch. A no-op on non-Windows,
-            // where rename tolerates an open handle. The daemon is brought back
-            // up by `ensure_backend_installed` later in this same setup hook.
-            if !cfg!(debug_assertions)
-                && db_encryption_intended
-                && meridian_core::db_crypto::is_plaintext_sqlite(db_path_ref)
-            {
-                if let Err(e) =
-                    tauri::async_runtime::block_on(backend_install::stop_daemon_for_migration())
-                {
-                    tracing::warn!(
-                        error = %e,
-                        "could not stop the daemon before encrypting the database; encryption may not complete this launch"
-                    );
-                }
-            }
-
-            let db_key_hex = if !cfg!(debug_assertions) {
-                match &db_key_hex {
-                    Some(key) => {
-                        let migrate = meridian_core::db_crypto::encrypt_in_place(
-                            db_path_ref,
-                            key,
-                        );
-                        match tauri::async_runtime::block_on(migrate) {
-                            Ok(()) => Some(key.clone()),
-                            Err(e) => {
-                                tracing::error!(
-                                    error = %e,
-                                    "failed to migrate meridian.db to encrypted storage - continuing unencrypted this run"
-                                );
-                                None
-                            }
-                        }
-                    }
-                    None => None,
-                }
-            } else {
-                db_key_hex
-            };
-
-            // Prepare the meridian.db pool ONCE at startup and share it with
-            // commands via managed state (no migrations — the daemon owns the
-            // schema). `None` only if the path/key is malformed, so reads error
-            // gracefully instead of crashing the tray.
-            //
-            // LAZY on purpose. On a first launch this line runs seconds BEFORE
-            // `ensure_backend_installed` (below) starts the daemon that creates
-            // meridian.db, so an eager open fails — and since the result is
-            // stored as an `Option` that nothing retries, the tray then ran its
-            // entire session against `None`: every DB-backed command silently
-            // returned its empty default and every captured frame was dropped
-            // by the consumers' `else { continue }`, until the user happened to
-            // restart the tray. A lazy pool connects on first use instead, so
-            // the very next command or frame after the daemon creates the file
-            // succeeds on its own.
-            // `block_on`, not a bare call: sqlx spawns the pool's maintenance
-            // task while BUILDING the lazy handle, so constructing it outside a
-            // Tokio runtime panics ("this functionality requires a Tokio
-            // context") and takes the whole tray down before the tray icon even
-            // appears. `setup()` is not itself async, so the runtime has to be
-            // entered explicitly here — exactly as the eager open it replaced
-            // already did.
-            let db_pool = tauri::async_runtime::block_on(meridian_core::open_existing_lazy(
-                &db_path,
-                db_key_hex.as_deref(),
-            ))
-            .map_err(
-                |e| tracing::error!(error = %e, db_path = %db_path, "meridian.db pool not prepared"),
-            )
-            .ok();
-            // A lazy pool cannot report reachability at build time, and losing
-            // that startup signal is how the failure above stayed invisible for
-            // a whole session. Probe once, purely to log it — an unreachable DB
-            // here is expected on a first launch and heals by itself, so this
-            // deliberately gates nothing.
-            //
-            // SPAWNED, never blocked on: sqlx retries a failed connection until
-            // the pool's 10s acquire timeout, so a first launch (file not
-            // created yet) would otherwise freeze the whole `setup` closure —
-            // and with it the tray menu — for ten seconds.
-            if let Some(p) = db_pool.clone() {
-                tauri::async_runtime::spawn(async move {
-                    match meridian_core::ping(&p).await {
-                        Ok(()) => tracing::info!("meridian.db reachable"),
-                        Err(e) => tracing::warn!(
-                            error = %e,
-                            "meridian.db not reachable yet — the pool will connect once the daemon creates it"
-                        ),
-                    }
-                });
-            }
-            // Capture (slice 4a) writes to the SAME read-write pool the commands
-            // use — clone the handle before it's moved into managed state.
-            #[cfg(feature = "capture")]
-            let capture_pool = db_pool.clone();
-            // The encryption-state notice below needs a pool handle before
-            // db_pool is moved into managed state.
-            let encryption_notice_pool = db_pool.clone();
-            app.manage(db_pool);
-
-            // Encryption was intended (a key was resolved) but the on-disk DB is
-            // still plaintext ⇒ encrypt_in_place didn't complete (on Windows the
-            // daemon holds the file open, so its final rename fails every
-            // launch). The db_crypto guard keeps the app working by opening
-            // plaintext — a silent security downgrade otherwise — so surface it
-            // to the user, and clear the notice once the DB is actually
-            // encrypted. Skipped in debug builds, where the migration never runs
-            // and a plaintext dev DB is expected. Best-effort: a notice-write
-            // failure must not block startup.
-            if !cfg!(debug_assertions) {
-                if let Some(pool) = encryption_notice_pool.as_ref() {
-                    let plaintext = meridian_core::db_crypto::plaintext_state(
-                        db_path_ref,
-                    );
-                    let action = db_encryption_notice_action(db_encryption_intended, plaintext);
-                    // No `db_path` on the span: a home-dir path is user data.
-                    let span = tracing::info_span!("tray.db_encryption_notice", ?action);
-                    let _entered = span.enter();
-                    // Deliberately an if/else and NOT an early return: this
-                    // runs inside Tauri's `setup` closure, so returning here
-                    // would skip the tray menu and the whole rest of startup.
-                    if action == DbEncryptionNotice::Leave {
-                        tracing::warn!(
-                            "database encryption state could not be established - leaving any existing notice untouched"
-                        );
                     } else {
-                        let result = tauri::async_runtime::block_on(async {
-                        if action == DbEncryptionNotice::Raise {
-                            meridian::notices::raise_typed(
-                                pool,
-                                meridian::notices::Notice {
-                                    id: "tray.db_encryption_incomplete",
-                                    severity: "warning",
-                                    title: "Your data isn't encrypted at rest yet.",
-                                    detail: "Meridian couldn't finish encrypting its local database this time. Your data is safe but stored unencrypted for now - Meridian will retry automatically the next time it restarts.",
-                                    remedy: None,
-                                    event_key: "system.health",
-                                    deep_link: Some("/logs"),
-                                },
-                            )
-                            .await
-                        } else {
-                            meridian::notices::clear_typed(
-                                pool,
-                                "tray.db_encryption_incomplete",
-                                "system.health",
-                            )
-                            .await
-                        }
-                    });
-                        if let Err(e) = result {
-                            // ERROR, not WARN: this is the failure boundary for
-                            // the one thing that tells a user their data is not
-                            // encrypted, and WARN-level would be easy to lose.
-                            tracing::error!(
+                        None
+                    };
+
+                    // Whether encryption was intended this launch (a key was resolved).
+                    // Re-checked against the on-disk file after the pool opens, to raise
+                    // a user-visible notice if the DB is nonetheless still plaintext
+                    // (the encrypt-in-place migration didn't complete) — otherwise the
+                    // db_crypto plaintext guard keeps operating unencrypted with only a
+                    // log line nobody sees. Runtime-gated below (not `#[cfg]`) so it is
+                    // always compiled/linted, matching the migration block's own
+                    // `!cfg!(debug_assertions)` style.
+                    let db_encryption_intended = db_key_hex.is_some();
+
+                    // On Windows the daemon (autostarted at login) holds meridian.db
+                    // open, so `encrypt_in_place`'s rename fails with os error 32 and
+                    // rolls back every launch — the migration can never complete while
+                    // the daemon is up. Stop it first, but ONLY when a migration will
+                    // actually attempt (a key was resolved AND the DB is still
+                    // plaintext); once encrypted this never runs again, so the stop is a
+                    // one-time cost on the migration launch. A no-op on non-Windows,
+                    // where rename tolerates an open handle. The daemon is brought back
+                    // up by `ensure_backend_installed` later in this same setup hook.
+                    if !cfg!(debug_assertions)
+                        && db_encryption_intended
+                        && meridian_core::db_crypto::is_plaintext_sqlite(db_path_ref)
+                    {
+                        if let Err(e) = tauri::async_runtime::block_on(
+                            backend_install::stop_daemon_for_migration(),
+                        ) {
+                            tracing::warn!(
                                 error = %e,
-                                "db-encryption-state notice update failed"
+                                "could not stop the daemon before encrypting the database; encryption may not complete this launch"
                             );
                         }
                     }
-                }
-            }
+
+                    let db_key_hex = if !cfg!(debug_assertions) {
+                        match &db_key_hex {
+                            Some(key) => {
+                                let migrate =
+                                    meridian_core::db_crypto::encrypt_in_place(db_path_ref, key);
+                                match tauri::async_runtime::block_on(migrate) {
+                                    Ok(()) => Some(key.clone()),
+                                    Err(e) => {
+                                        tracing::error!(
+                                            error = %e,
+                                            "failed to migrate meridian.db to encrypted storage - continuing unencrypted this run"
+                                        );
+                                        None
+                                    }
+                                }
+                            }
+                            None => None,
+                        }
+                    } else {
+                        db_key_hex
+                    };
+
+                    // Prepare the meridian.db pool ONCE at startup and share it with
+                    // commands via managed state (no migrations — the daemon owns the
+                    // schema). `None` only if the path/key is malformed, so reads error
+                    // gracefully instead of crashing the tray.
+                    //
+                    // LAZY on purpose. On a first launch this line runs seconds BEFORE
+                    // `ensure_backend_installed` (below) starts the daemon that creates
+                    // meridian.db, so an eager open fails — and since the result is
+                    // stored as an `Option` that nothing retries, the tray then ran its
+                    // entire session against `None`: every DB-backed command silently
+                    // returned its empty default and every captured frame was dropped
+                    // by the consumers' `else { continue }`, until the user happened to
+                    // restart the tray. A lazy pool connects on first use instead, so
+                    // the very next command or frame after the daemon creates the file
+                    // succeeds on its own.
+                    // `block_on`, not a bare call: sqlx spawns the pool's maintenance
+                    // task while BUILDING the lazy handle, so constructing it outside a
+                    // Tokio runtime panics ("this functionality requires a Tokio
+                    // context") and takes the whole tray down before the tray icon even
+                    // appears. `setup()` is not itself async, so the runtime has to be
+                    // entered explicitly here — exactly as the eager open it replaced
+                    // already did. Should this or any sibling third-party call in this
+                    // span panic outright instead of returning an `Err`,
+                    // `catch_setup_panic` around this whole block is the backstop.
+                    let db_pool = tauri::async_runtime::block_on(meridian_core::open_existing_lazy(
+                        &db_path,
+                        db_key_hex.as_deref(),
+                    ))
+                    .map_err(
+                        |e| tracing::error!(error = %e, db_path = %db_path, "meridian.db pool not prepared"),
+                    )
+                    .ok();
+                    // A lazy pool cannot report reachability at build time, and losing
+                    // that startup signal is how the failure above stayed invisible for
+                    // a whole session. Probe once, purely to log it — an unreachable DB
+                    // here is expected on a first launch and heals by itself, so this
+                    // deliberately gates nothing.
+                    //
+                    // SPAWNED, never blocked on: sqlx retries a failed connection until
+                    // the pool's 10s acquire timeout, so a first launch (file not
+                    // created yet) would otherwise freeze the whole `setup` closure —
+                    // and with it the tray menu — for ten seconds.
+                    if let Some(p) = db_pool.clone() {
+                        tauri::async_runtime::spawn(async move {
+                            match meridian_core::ping(&p).await {
+                                Ok(()) => tracing::info!("meridian.db reachable"),
+                                Err(e) => tracing::warn!(
+                                    error = %e,
+                                    "meridian.db not reachable yet — the pool will connect once the daemon creates it"
+                                ),
+                            }
+                        });
+                    }
+                    // Handed back as this closure's return value below, so the
+                    // caller can guarantee `app.manage` runs even when this whole
+                    // span panicked before reaching it a few lines down — see
+                    // there. Unconditional now (not `#[cfg(feature = "capture")]`
+                    // as it was before this span grew a wrapper): the capture
+                    // feature is the only later consumer, but the clone itself is
+                    // cheap and every build needs a value to return.
+                    let capture_pool = db_pool.clone();
+                    // The encryption-state notice below needs a pool handle before
+                    // db_pool is moved into managed state.
+                    let encryption_notice_pool = db_pool.clone();
+                    app.manage(db_pool);
+
+                    // Encryption was intended (a key was resolved) but the on-disk DB is
+                    // still plaintext ⇒ encrypt_in_place didn't complete (on Windows the
+                    // daemon holds the file open, so its final rename fails every
+                    // launch). The db_crypto guard keeps the app working by opening
+                    // plaintext — a silent security downgrade otherwise — so surface it
+                    // to the user, and clear the notice once the DB is actually
+                    // encrypted. Skipped in debug builds, where the migration never runs
+                    // and a plaintext dev DB is expected. Best-effort: a notice-write
+                    // failure must not block startup.
+                    //
+                    // Contained in its OWN `catch_setup_panic`, separate from the outer
+                    // one wrapping this whole span: `app.manage(db_pool)` above already
+                    // ran by this point, so a panic here must not cost `capture_pool` —
+                    // that's this closure's still-pending return value below, and losing
+                    // it would silently drop every captured frame for the rest of the
+                    // session (`start_capture`'s caller degrades a missing pool exactly
+                    // that quietly) while the DB itself keeps working normally.
+                    let _ = catch_setup_panic(
+                        "meridian.db encryption notice",
+                        std::panic::AssertUnwindSafe(|| {
+                            if !cfg!(debug_assertions) {
+                                if let Some(pool) = encryption_notice_pool.as_ref() {
+                                    let plaintext =
+                                        meridian_core::db_crypto::plaintext_state(db_path_ref);
+                                    let action = db_encryption_notice_action(
+                                        db_encryption_intended,
+                                        plaintext,
+                                    );
+                                    // No `db_path` on the span: a home-dir path is user data.
+                                    let span =
+                                        tracing::info_span!("tray.db_encryption_notice", ?action);
+                                    let _entered = span.enter();
+                                    // Deliberately an if/else and NOT an early return: this
+                                    // runs inside Tauri's `setup` closure, so returning here
+                                    // would skip the tray menu and the whole rest of startup.
+                                    if action == DbEncryptionNotice::Leave {
+                                        tracing::warn!(
+                                            "database encryption state could not be established - leaving any existing notice untouched"
+                                        );
+                                    } else {
+                                        let result = tauri::async_runtime::block_on(async {
+                                            if action == DbEncryptionNotice::Raise {
+                                                meridian::notices::raise_typed(
+                                                    pool,
+                                                    meridian::notices::Notice {
+                                                        id: "tray.db_encryption_incomplete",
+                                                        severity: "warning",
+                                                        title: "Your data isn't encrypted at rest yet.",
+                                                        detail: "Meridian couldn't finish encrypting its local database this time. Your data is safe but stored unencrypted for now - Meridian will retry automatically the next time it restarts.",
+                                                        remedy: None,
+                                                        event_key: "system.health",
+                                                        deep_link: Some("/logs"),
+                                                    },
+                                                )
+                                                .await
+                                            } else {
+                                                meridian::notices::clear_typed(
+                                                    pool,
+                                                    "tray.db_encryption_incomplete",
+                                                    "system.health",
+                                                )
+                                                .await
+                                            }
+                                        });
+                                        if let Err(e) = result {
+                                            // ERROR, not WARN: this is the failure boundary for
+                                            // the one thing that tells a user their data is not
+                                            // encrypted, and WARN-level would be easy to lose.
+                                            tracing::error!(
+                                                error = %e,
+                                                "db-encryption-state notice update failed"
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                        }),
+                    );
+
+                    capture_pool
+                }),
+            )
+            .flatten();
+            // `.manage()` no-ops (returns `false`) when the type is already
+            // managed — see `tauri::Manager::manage`'s doc — so this only takes
+            // effect on the panic path above, where `app.manage(db_pool)` inside
+            // the closure never ran. Guarantees `State<Option<SqlitePool>>>` is
+            // always resolvable, so a command extracting it doesn't panic a
+            // second, unrelated time on missing managed state.
+            app.manage(db_setup_result.clone());
+            #[cfg(feature = "capture")]
+            let capture_pool = db_setup_result;
 
             // Single source of truth for the tray menu lives in `tray.rs`, so the
             // poll loop's health-driven rebuild can't drift out of sync. Initial

--- a/ui/__tests__/overview-focus-section.test.ts
+++ b/ui/__tests__/overview-focus-section.test.ts
@@ -1,0 +1,147 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// OverviewPanel's "Today's focus" visibility rule.
+//
+// The bug: the populated checklist and a past day's note were gated on
+// `!isSolo` while the empty-today nudge was shown to everyone. A solo user was
+// therefore invited to plan, allowed to commit a personal task, and then shown
+// nothing — the section vanished the instant the plan stopped being empty.
+// Reproduced on a real install: daily_plan had one confirmed row for the day
+// (daily_plan_meta.confirmed_at set, skipped=0) and the panel rendered no
+// focus section at all.
+//
+// Two halves are pinned here, because either alone would pass while the other
+// regressed: the predicate's truth table, and the fact that the JSX actually
+// calls it rather than re-deriving a gate inline (this repo has no React
+// render harness — see task-composer.test.ts).
+
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { focusSectionVisible } from '../components/timeline/types'
+
+const src = (p: string) => readFileSync(join(import.meta.dir, '..', p), 'utf8')
+const panel = src('components/timeline/OverviewPanel.tsx')
+
+/** The pre-fix gate, kept verbatim as the reference for the parity checks. */
+function legacyGate(a: {
+  isToday: boolean
+  planLoaded: boolean
+  itemCount: number
+  isSolo: boolean
+}): boolean {
+  return (
+    (a.isToday && a.planLoaded && a.itemCount === 0) ||
+    (!a.isSolo && (a.itemCount > 0 || !a.isToday))
+  )
+}
+
+const BOOLS = [true, false]
+const COUNTS = [0, 1, 3]
+
+describe('today, with a committed plan', () => {
+  it('renders the checklist for a solo user — the reported bug', () => {
+    expect(focusSectionVisible({ isToday: true, planLoaded: true, itemCount: 1 })).toBe(true)
+  })
+
+  it('rendered nothing under the old gate, which is what made it a bug', () => {
+    expect(legacyGate({ isToday: true, planLoaded: true, itemCount: 1, isSolo: true })).toBe(false)
+  })
+
+  it('renders for a connected user too, unchanged', () => {
+    expect(focusSectionVisible({ isToday: true, planLoaded: true, itemCount: 1 })).toBe(true)
+    expect(legacyGate({ isToday: true, planLoaded: true, itemCount: 1, isSolo: false })).toBe(true)
+  })
+})
+
+describe('today, with nothing planned', () => {
+  it('renders the nudge once get_plan has resolved', () => {
+    expect(focusSectionVisible({ isToday: true, planLoaded: true, itemCount: 0 })).toBe(true)
+  })
+
+  it('renders nothing before the first fetch, so the nudge cannot flash', () => {
+    expect(focusSectionVisible({ isToday: true, planLoaded: false, itemCount: 0 })).toBe(false)
+  })
+})
+
+describe('a past date', () => {
+  it('always renders — committed focus, or a quiet empty note', () => {
+    for (const planLoaded of BOOLS) {
+      for (const itemCount of COUNTS) {
+        expect(focusSectionVisible({ isToday: false, planLoaded, itemCount })).toBe(true)
+      }
+    }
+  })
+})
+
+describe('the full truth table', () => {
+  // isToday × planLoaded × itemCount, exhaustively. Written out rather than
+  // derived so a change to the rule has to be stated here deliberately.
+  const cases: Array<[boolean, boolean, number, boolean]> = [
+    // isToday, planLoaded, itemCount, expected
+    [true, true, 0, true], //  nudge
+    [true, false, 0, false], // pre-fetch: nothing, no flash
+    [true, true, 1, true], //  checklist
+    [true, false, 1, true], //  items imply a resolved fetch
+    [false, true, 0, true], //  past, empty note
+    [false, false, 0, true], //  past, empty note
+    [false, true, 1, true], //  past, read-only focus
+    [false, false, 1, true], //  past, read-only focus
+  ]
+
+  for (const [isToday, planLoaded, itemCount, expected] of cases) {
+    it(`isToday=${isToday} planLoaded=${planLoaded} items=${itemCount} → ${expected}`, () => {
+      expect(focusSectionVisible({ isToday, planLoaded, itemCount })).toBe(expected)
+    })
+  }
+})
+
+describe('connected users are unaffected', () => {
+  it('matches the old gate exactly for every non-solo combination', () => {
+    for (const isToday of BOOLS) {
+      for (const planLoaded of BOOLS) {
+        for (const itemCount of COUNTS) {
+          expect(focusSectionVisible({ isToday, planLoaded, itemCount })).toBe(
+            legacyGate({ isToday, planLoaded, itemCount, isSolo: false }),
+          )
+        }
+      }
+    }
+  })
+
+  it('now treats solo and connected identically, which it did not before', () => {
+    const differed = [] as string[]
+    for (const isToday of BOOLS) {
+      for (const planLoaded of BOOLS) {
+        for (const itemCount of COUNTS) {
+          const solo = legacyGate({ isToday, planLoaded, itemCount, isSolo: true })
+          const connected = legacyGate({ isToday, planLoaded, itemCount, isSolo: false })
+          if (solo !== connected) differed.push(`${isToday}/${planLoaded}/${itemCount}`)
+        }
+      }
+    }
+    // The old gate genuinely diverged — if it didn't, this test is guarding nothing.
+    expect(differed.length).toBeGreaterThan(0)
+  })
+})
+
+describe('the panel uses the shared predicate', () => {
+  it('calls focusSectionVisible for the focus section', () => {
+    expect(panel).toContain('focusSectionVisible({')
+    expect(panel).toContain("import { focusSectionVisible")
+  })
+
+  it('does not gate the focus section on isSolo any more', () => {
+    const gate = panel.split('\n').find(l => l.includes('focusSectionVisible({'))
+    expect(gate).toBeDefined()
+    expect(gate).not.toContain('isSolo')
+    // The exact pre-fix expression must not come back.
+    expect(panel).not.toContain('!isSolo && (focusItems.length > 0')
+  })
+
+  it('still uses isSolo elsewhere, so the fix did not over-reach', () => {
+    // Solo genuinely changes other things (greeting copy, the Drafts mini-card,
+    // the connect-a-tracker CTA) — those are not part of this bug.
+    expect(panel).toContain('isSolo')
+  })
+})

--- a/ui/components/timeline/OverviewPanel.tsx
+++ b/ui/components/timeline/OverviewPanel.tsx
@@ -19,7 +19,7 @@ import { fmtDur } from '@/components/atoms'
 import { load as loadData, mutate as mutateData, openExternal } from '@/lib/bridge'
 import { usePlan, refreshPlan } from '@/components/plan/planStore'
 import type { PlanItem, CodingAgentsResponse } from '@/lib/api-types'
-import { formatDayLabel, isPending } from './types'
+import { focusSectionVisible, formatDayLabel, isPending } from './types'
 import { TimeByApp, appTotals } from './TimeByApp'
 import { TimeByCategory, categoryRows } from './TimeByCategory'
 import { UpdateCard } from './UpdateCard'
@@ -214,13 +214,14 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
           past. On a past date the section is read-only: it shows that day's
           committed focus (or a quiet empty note), with no Edit/Add
           affordances. `focusLabel` relabels the heading off "Today's".
-          The empty-TODAY case is shown to every user, including solo/
-          no-tracker (PlanView's composer already supports a personal,
-          tracker-free task, see PlanView.tsx's `boardEmpty` path) — everything
-          else (the populated checklist, and a past day's read-only note)
-          stays tracker-only, unchanged. `plan` gates the empty branch so it
-          never flashes before the first `get_plan` resolves. */}
-      {((isToday && plan && focusItems.length === 0) || (!isSolo && (focusItems.length > 0 || !isToday))) && (
+          Shown to every user, solo/no-tracker included — PlanView's composer
+          supports a personal, tracker-free task (see its `boardEmpty` path),
+          and `toggleDone` below already routes a personal task to our own DB
+          rather than a tracker, so nothing here needs a board. This used to
+          gate everything except the empty-today nudge on `!isSolo`, which meant
+          a solo user was invited to plan and then never shown the plan they
+          committed. See `focusSectionVisible` for the whole rule. */}
+      {focusSectionVisible({ isToday, planLoaded: !!plan, itemCount: focusItems.length }) && (
         <div>
           {focusItems.length === 0 && isToday ? (
             <div>

--- a/ui/components/timeline/types.ts
+++ b/ui/components/timeline/types.ts
@@ -134,3 +134,32 @@ export function itemKey(w: Pick<WorklogItem, 'id' | 'is_proposed'>): string {
 export function isPending(w: WorklogItem): boolean {
   return w.is_proposed ? w.state === 'proposed' : w.state === 'drafted'
 }
+
+// Should OverviewPanel's "Today's focus" section render at all?
+//
+// Deliberately takes NO `isSolo` argument. It used to: the populated checklist
+// and a past day's read-only note were gated on `!isSolo`, while the
+// empty-today nudge was shown to everyone. That combination is incoherent — a
+// solo user was invited to plan (the nudge), PlanView's composer let them
+// commit a personal, tracker-free task, and then the committed plan rendered
+// nowhere, because the moment it stopped being empty the only branch that
+// admitted solo users stopped matching. A confirmed plan disappearing the
+// instant you confirm it is the bug this predicate exists to prevent
+// recurring; a tracker is not what makes a plan worth showing you.
+//
+// `planLoaded` is whether `get_plan` has resolved for this day. It gates the
+// empty case only, so an empty section never flashes before the first fetch —
+// items already imply a resolved fetch.
+export function focusSectionVisible({ isToday, planLoaded, itemCount }: {
+  isToday: boolean
+  planLoaded: boolean
+  itemCount: number
+}): boolean {
+  // A past date always renders: that day's committed focus, or a quiet
+  // "nothing planned" note. Editing affordances are suppressed separately.
+  if (!isToday) return true
+  // Today with a committed plan → the checklist.
+  if (itemCount > 0) return true
+  // Today with nothing planned → the nudge, once the fetch has resolved.
+  return planLoaded
+}


### PR DESCRIPTION
Release PR: `pre-main` → `main`. **Three** changes land: two user-facing fixes and one piece of release automation.

> [!NOTE]
> **The conflict is cleared.** #652 back-merged `1.82.2` into `pre-main` and collapsed the second merge base; this PR now reports `MERGEABLE` and all checks pass. The "Why this conflicts" section at the bottom is kept as the record of what happened and why change 2 exists - it no longer describes current state.

`pre-main` and `main` now agree on every version manifest, so none of them appear in this diff. Nothing in the three changes below touches one.

---

## 1. `fix(ui)`: a solo user's confirmed daily plan was invisible (b760fbe9)

A solo (no-tracker) user could commit a daily plan and then never see it. `OverviewPanel` gated the populated checklist - and a past day's read-only note - on `!isSolo`, while showing the empty-today nudge to everyone:

```tsx
{((isToday && plan && focusItems.length === 0)
  || (!isSolo && (focusItems.length > 0 || !isToday))) && (
```

So the section rendered only while the plan was **empty**. Committing a task made the first branch stop matching, and the second never matched for a solo user - the section vanished at the moment it finally had something to show.

The rest of the flow already supported solo users: the nudge invites them to plan, `PlanView`'s composer supports a personal tracker-free task (its `boardEmpty` path), and `toggleDone` routes a personal task to our own DB rather than to a tracker. Nothing in this path needs a board. Only the visibility gate thought otherwise.

Reproduced on a real install: `daily_plan` held one confirmed row for the day (`daily_plan_meta.confirmed_at` set, `skipped = 0`) and the panel rendered no focus section at all.

**Shape of the fix.** The gate moves into `focusSectionVisible` in `ui/components/timeline/types.ts`, next to the other small pure predicates the panel already imports. It deliberately takes **no** `isSolo` argument - that absence *is* the fix, and the reasoning is recorded at the definition so it does not get re-added later as a "missing" parameter.

**Tests** (`ui/__tests__/overview-focus-section.test.ts`, 19 tests / 39 assertions) pin two halves, since either alone would pass while the other regressed:

- the full `isToday` x `planLoaded` x `itemCount` truth table, written out rather than derived, so changing the rule has to be a deliberate edit;
- that the JSX actually calls the predicate, by source scan (this repo has no React render harness - see `task-composer.test.ts`), including that the gate line no longer mentions `isSolo` and the pre-fix expression cannot return.

Two of those tests exist to avoid self-deception: one asserts parity with the old gate for every **non-solo** combination, proving connected users are unaffected; the other asserts the old gate genuinely diverged between solo and connected, because if it had not, the parity test would be guarding nothing.

## 2. `ci(release)`: automatic `main` → `pre-main` back-merge (2f98bf81)

**Merging this PR is what turns the job on.** It is gated on `github.ref_name == 'main'`, so it only starts running once it is on `main` - from the next stable release onward the drift below closes itself, and `pre-main` stops needing hand-raised back-merges.

**The problem.** semantic-release derives the next version from the tags *reachable from the branch it runs on*. The stable config's `@semantic-release/git` plugin commits the version bump onto `main`, and the tag points at that commit - so both live only on `main`. The release flow is one-way (`pre-main` → `main`), so nothing carried them back.

Measured on 2026-07-31:

| | |
|---|---|
| newest tag reachable from `origin/main` | `v1.82.1` |
| newest tag reachable from `origin/pre-main` | `v1.78.0-staging.16` |
| `v1.82.1` an ancestor of `pre-main`? | no |
| `pre-main` `Cargo.toml` / `tauri.conf.json` | `1.77.0` (main: `1.82.1`) |
| release commits on `main`, not on `pre-main` | 12 |

Staging kept incrementing `-staging.N` on a `1.78.0` base indefinitely.

**Why that is not cosmetic.** `1.78.0-staging.16` sorts **below** `1.82.1` under semver, so `tauri-plugin-updater` will not offer a staging build to anyone already on a current stable install - the staging channel silently stops being installable by exactly the people meant to test it. Observed directly: a tester on `1.82.1` had to download the staging asset by hand, twice.

**What the job does.** Adds a `backmerge` job to `release-prepare.yml`, gated on the stable channel **and** on a release having actually been cut, that merges `main` into a branch off `pre-main` and opens a PR.

- **A PR rather than a direct push.** `pre-main` is the branch every staging build is cut from; nothing here bypasses its review gate - a human merges it, the same way a human merges this PR. The cost of that choice is that an unmerged back-merge leaves staging stuck, so the generated PR body states that outright.
- **Conflicts abort and fail loudly** instead of pushing a half-resolved merge. The version manifests are the likely conflict site, and guessing at them would corrupt the exact numbers the job exists to keep straight.
- Verified before landing: YAML parses, the job graph resolves (`needs`/`if`/`permissions`), and the embedded shell passes `bash -n`.

The existing drift was fixed separately by the two back-merge PRs already on `pre-main` (#646, #647), which is why `pre-main`'s manifests now read `1.82.1` rather than `1.77.0`.


## 3. `fix(tray)`: a panic during DB setup aborted the whole process (3b42fd0b)

Landed on `pre-main` after this PR was opened, so it ships with it.

`setup()` runs synchronously inside tao's `did_finish_launching`, across an `extern "C"` boundary. An unwinding panic cannot cross that, so Rust calls `panic_cannot_unwind` and aborts the **entire process** - killing every spawned task, including the `update::enforce_minimum_version` force-update check that exists precisely to rescue crash-looping installs. A machine bricked this way could not self-heal, which is what today's `staging.15` crash-loop demonstrates.

The workspace already sets `panic = "unwind"` specifically to keep `catch_unwind` usable; containment is the fix that profile choice already implies, just never applied to `setup()`. The DB key / pool / encryption-notice span - where `be368d4e`'s regression lived - is now wrapped in `catch_setup_panic()`, so a panic degrades the tray to the same `db_pool: None` state every other failure in that span already produces, rather than bricking on launch. The encryption-notice sub-block gets its own nested containment: `app.manage(db_pool)` runs before it, so outer-only containment would silently drop the `capture_pool` clone returned afterward - and with it every captured frame for the session - while the DB itself kept working.

Unit-tested for both outcomes, and verified live by temporarily injecting a panic reproducing `be368d4e`'s exact failure mode and confirming the process survived (injection removed before the commit).

**Scope, stated plainly:** this covers the DB-setup span only. A panic in the tray menu build, icon creation, or anything after that span still aborts the process, and the minimum-version kill switch still cannot rescue such a machine. Extending coverage is a separate change.

Checked by hand, since the tray workspace is outside normal CI - `cargo test`: **195 passed, 0 failed**; `cargo clippy --all-targets -- -D warnings`: **clean** (default features, i.e. what ships).

---

## What this cuts

`.releaserc.json` sets no custom `releaseRules`, so default `conventionalcommits` mapping applies: the `fix(ui)` and `fix(tray)` commits make this a **patch** release (`1.82.3`), and the `ci(release)` commit lands under the CI changelog section without itself forcing a bump. Because a release *is* cut, the new `backmerge` job's `needs.prepare.outputs.released == 'true'` gate is satisfied and it will open its first automatic back-merge PR on this run.

## Why this conflicts, and how to clear it

`main` and `pre-main` have **two** merge bases:

| base | |
|---|---|
| `854b8f4a` | `chore(release): 1.82.1` (2026-07-29) |
| `c7d0c4d7` | `Merge pull request #649` (2026-07-31) |

Local git (2.54, `ort`) builds a virtual merge base from both and merges cleanly - `git merge-tree --write-tree origin/main origin/pre-main` exits 0. GitHub does not use that virtual-base resolution: merging against `c7d0c4d7` alone - where both sides moved the version lines away from a common `1.77.0` - produces exactly the six conflicts GitHub reports:

```
CHANGELOG.md, Cargo.lock, Cargo.toml,
packages/meridian-mcp/package.json, tray/src-tauri/tauri.conf.json, ui/package.json
```

Reproduce the two outcomes:

```bash
git merge-tree --write-tree --name-only \
  --merge-base=854b8f4a origin/main origin/pre-main   # exit 0, clean
git merge-tree --write-tree --name-only \
  --merge-base=c7d0c4d7 origin/main origin/pre-main   # exit 1, six conflicts
```

**This is exactly the failure mode change 2 exists to end**, arriving one release too early to have prevented itself: `main`'s release commits do not come back on their own, so the manifests diverge and the next release PR conflicts on them.

**Note that GitHub's "Resolve conflicts" button is not usable here.** This PR's head *is* `pre-main`, so resolving in the web UI would commit straight onto `pre-main` - which `CLAUDE.md` forbids. Hence a branch and a PR.

**To clear it:** back-merge `main` (`1.82.2`) into `pre-main` once - a `chore/backmerge-v1.82.2` branch off `pre-main`, merged with `main`, PR'd into `pre-main`.

**No hand-resolution is involved.** That merge has a single base and is clean locally; the resulting tree (`0cc4154a`) already carries `Cargo.toml = 1.82.2` and a `CHANGELOG.md` containing the `1.82.2` entry. So it lands the correct manifests, not merely a conflict-free one. It collapses the second merge base, and this PR then goes green with no change to either of the two commits above.

From the next stable release onward the `backmerge` job raises that PR automatically. It cannot do this one: the job is gated on `github.ref_name == 'main'` and does not exist on `main` yet - it arrives *in* this PR.

## Reviewer note - staging verification

Per `CLAUDE.md` this PR should follow end-to-end staging verification. Flagging honestly: the staging updater channel was itself unusable over this window - that is precisely what change 2 fixes - and testers were side-loading the asset by hand. The UI fix was reproduced and fixed against a real install, but it has **not** been exercised through the staging auto-update path. Worth a deliberate call before merging rather than an assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stable releases now automatically prepare back-merges and create or update a pull request, with conflicts clearly reported.
  * Solo users can view committed plans and past-day focus details.

* **Bug Fixes**
  * Improved focus-section visibility across empty, loading, and completed plans.
  * Improved startup reliability when database or encryption setup encounters errors.

* **Documentation**
  * Updated changelog formatting and corrected release and issue references.

* **Tests**
  * Added coverage for focus visibility and startup error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
