### PR TITLE
chore: back-merge v1.82.2 into pre-main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## [1.82.2](https://github.com/Meridiona/meridian/compare/v1.82.1...v1.82.2) (2026-07-31)
+
+### 🐛 Bug Fixes
+
+* **health:** drop the stale session-summary skill check and its diagnosis ([7e72cdf](https://github.com/Meridiona/meridian/commit/7e72cdfcc8cd1bedbe396e856ddad238d3b44085))
+* **tray:** build the lazy meridian.db pool inside a Tokio runtime ([be368d4](https://github.com/Meridiona/meridian/commit/be368d4eedcb58b2c2bacf85615d455730e9cfac)), closes [#638](https://github.com/Meridiona/meridian/issues/638)
+* **tray:** connect meridian.db lazily so a first launch is not dead until restart ([d2775f6](https://github.com/Meridiona/meridian/commit/d2775f6698eb5d01318a647d0c5844ba34a9f74f))
+* **tray:** don't flag an empty or truncated db stub as orphaned data ([fba2250](https://github.com/Meridiona/meridian/commit/fba22505ce317d60d45d9612986a49acd7d25b89))
+* **tray:** hide the hover tooltip on mouse-down so right-click can't strand it ([27af9c0](https://github.com/Meridiona/meridian/commit/27af9c00c726eb434a38da3968b10a08a9bbac10))
+* **tray:** refuse to mint a DB key that would orphan an encrypted db ([3703477](https://github.com/Meridiona/meridian/commit/3703477c09c2b995ba60d5d9ebd4ae7294d7f5af))
+* **tray:** treat ERROR_NOT_FOUND from the Windows toast probe as Enabled ([ae3eeb7](https://github.com/Meridiona/meridian/commit/ae3eeb7382ed6dbec9f9b5409389d94ff27b3945))
+* **windows:** load the canonical .env so the daemon can open an encrypted db ([5aa4165](https://github.com/Meridiona/meridian/commit/5aa4165edf55163e8181a9c93755711a2f425db9))
+
+### ♻️ Refactoring
+
+* **cli:** remove the dead coding-agent-install-skill subcommand ([f502b5e](https://github.com/Meridiona/meridian/commit/f502b5ed298b328d7f67b58a33cd17a37ced46d0))
+* **tray:** put the tooltip and popover on the dashboard's type scale ([471863f](https://github.com/Meridiona/meridian/commit/471863f373a4b350208feb833b890086be7f3505))
+
+### ✅ Tests
+
+* **health:** pin the branch-priority fix in root_causes ([f7e7b63](https://github.com/Meridiona/meridian/commit/f7e7b63224dd5d6a3928adca13e88425a0c13cf2))
+
+### 📝 Documentation
+
+* **observability:** address PR [#644](https://github.com/Meridiona/meridian/issues/644) review comments ([2d00b41](https://github.com/Meridiona/meridian/commit/2d00b4155d3262f6228989a76f4aca36d8da4730))
+* **observability:** fix CodeRabbit's second-pass findings on [#644](https://github.com/Meridiona/meridian/issues/644) ([2d458af](https://github.com/Meridiona/meridian/commit/2d458af0fae33f9c441378a9f8f86d9860612cf7))
+* **observability:** how to query central OpenObserve locally ([90dd9fe](https://github.com/Meridiona/meridian/commit/90dd9fe6d3bfa41b5ffb1dd4b8820ed29cae34b0))
+
 ## [1.82.1](https://github.com/Meridiona/meridian/compare/v1.82.0...v1.82.1) (2026-07-29)
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "meridian"
-version = "1.82.1"
+version = "1.82.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ incremental   = false
 
 [package]
 name = "meridian"
-version = "1.82.1"
+version = "1.82.2"
 edition = "2021"
 description = "Meridian — ambient developer-efficiency tool that keeps Jira, GitHub, and Linear in sync"
 authors = ["Meridiona"]

--- a/packages/meridian-mcp/package.json
+++ b/packages/meridian-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meridian-mcp",
-  "version": "1.82.1",
+  "version": "1.82.2",
   "description": "MCP server for Meridian \u2014 query app sessions, focus time, and activity data",
   "main": "dist/index.js",
   "bin": {

--- a/tray/src-tauri/tauri.conf.json
+++ b/tray/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Meridian",
-  "version": "1.82.1",
+  "version": "1.82.2",
   "identifier": "com.meridiona.tray",
   "build": {
     "frontendDist": "../../ui/out",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meridian-ui",
-  "version": "1.82.1",
+  "version": "1.82.2",
   "private": true,
   "scripts": {
     "dev": "env -u NODE_ENV next dev --turbopack -p 3939",


### PR DESCRIPTION
Back-merge of `main` (`v1.82.2`) into `pre-main`. Raised by hand because the automation that would normally do this is still in flight - it lands in #651, is gated on `github.ref_name == 'main'`, and so cannot run until it is on `main`.

**Merge this to unblock #651.** The release PR `pre-main` → `main` currently reports CONFLICTING, and this is the one-step fix.

## Why #651 conflicts

`main` and `pre-main` have **two** merge bases:

| base | |
|---|---|
| `854b8f4a` | `chore(release): 1.82.1` (2026-07-29) |
| `c7d0c4d7` | `Merge pull request #649` (2026-07-31) |

Local git (2.54, `ort`) builds a virtual merge base from both and merges cleanly. GitHub does not use that resolution: merging against `c7d0c4d7` alone - where both sides moved the version lines away from a common `1.77.0` - produces exactly the six conflicts GitHub reports on #651 (`CHANGELOG.md`, `Cargo.lock`, `Cargo.toml`, `packages/meridian-mcp/package.json`, `tray/src-tauri/tauri.conf.json`, `ui/package.json`).

GitHub's "Resolve conflicts" button is not usable there, because #651's head *is* `pre-main` and the web UI would commit straight onto it. Hence this branch.

## What this branch is

`chore/backmerge-v1.82.2`, branched off `pre-main` and merged with `origin/main` - the same shape the new `backmerge` job produces. **Nothing was hand-resolved:** that merge has a single base and applied cleanly with the `ort` strategy.

Verified on the merge result:

```
Cargo.toml                       1.82.2
tray/src-tauri/tauri.conf.json   1.82.2
CHANGELOG.md                     contains the [1.82.2] entry
```

So it lands the correct manifests, not merely a conflict-free set. `main` is now an ancestor of this branch, which collapses the second merge base - `git merge-base --all origin/main chore/backmerge-v1.82.2` returns the single commit `24b641f9` - and `git merge-tree --write-tree origin/main chore/backmerge-v1.82.2` exits 0. With one base, that result is authoritative rather than an artifact of virtual-base resolution, so #651 goes green once this lands.

## Why it matters beyond #651

semantic-release derives the next version from the tags reachable from the branch it runs on. The stable release commit and its tag are created on `main` and never come back on their own, so while `pre-main` is behind, staging keeps being cut from a stale base - and a staging version that sorts below the current stable release is one `tauri-plugin-updater` will not offer to anyone already on stable.

## Checks

Full pre-push suite passed locally against the merge result: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`, `ui build`, `ui tests` (`bun test`), security audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
