### PR TITLE
fix: address CodeRabbit review on #651

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -340,18 +340,42 @@ jobs:
       contents: write # pushes the back-merge branch
       pull-requests: write # opens the PR
     steps:
+      # *** THE PAT IS REQUIRED HERE, NOT A PREFERENCE. ***
+      #
+      # GitHub does not trigger workflows for refs pushed with the default
+      # GITHUB_TOKEN (the recursion guard), and a pull_request opened with it
+      # only ever lands in an approval-required state. Either way the
+      # back-merge PR arrives with no CI on it — and pre-main's checks are
+      # what a human merges it on, so it would sit unmergeable and silent,
+      # which is the exact failure mode this job exists to end.
+      #
+      # So there is deliberately NO `|| secrets.GITHUB_TOKEN` fallback below:
+      # a degraded back-merge is worse than a loud one. Fail here, before
+      # anything is pushed, with a message that names the missing secret.
+      - name: Require the release PAT
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::secrets.GH_TOKEN is not available; the back-merge PR would open with no CI on it. Configure the org PAT and re-run."
+            exit 1
+          fi
+          echo "→ GH_TOKEN present"
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
-          # The PAT for the same reason the prepare job needs it: a branch
-          # pushed with the default GITHUB_TOKEN does not trigger downstream
-          # workflows, so the back-merge PR would open with no CI on it.
-          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          # Persisted on purpose: `git push` below reuses this credential, so
+          # it must be the PAT (see the guard step above), not the default
+          # token.
+          persist-credentials: true
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Open the back-merge PR
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           TAG: ${{ needs.prepare.outputs.tag }}
         run: |
           set -euo pipefail

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -67,7 +67,8 @@
     [
       "@semantic-release/changelog",
       {
-        "changelogFile": "CHANGELOG.md"
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# Changelog"
       }
     ],
     [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## [1.82.2](https://github.com/Meridiona/meridian/compare/v1.82.1...v1.82.2) (2026-07-31)
 
 ### 🐛 Bug Fixes
@@ -74,7 +76,7 @@
 * address CodeRabbit review findings on [#603](https://github.com/Meridiona/meridian/issues/603) ([7f76bdd](https://github.com/Meridiona/meridian/commit/7f76bddd7299b98525f2c5579191798728486b46)), closes [#605](https://github.com/Meridiona/meridian/issues/605)
 * address release review findings on [#603](https://github.com/Meridiona/meridian/issues/603) ([2e74e1d](https://github.com/Meridiona/meridian/commit/2e74e1db17629a020f752d0d8be1fa8cca9a328f))
 * **db:** address review — surface plaintext downgrade, harden 2nd rename ([6a3d186](https://github.com/Meridiona/meridian/commit/6a3d186d8a154c85681392250f472aefa2a77afb))
-* **db:** complete the Windows encrypt-in-place migration (close handle, retry rename) ([82aba7b](https://github.com/Meridiona/meridian/commit/82aba7baedd643943c946c81fcae9ad9b041a0d8)), closes [#598](https://github.com/Meridiona/meridian/issues/598) [#598](https://github.com/Meridiona/meridian/issues/598)
+* **db:** complete the Windows encrypt-in-place migration (close handle, retry rename) ([82aba7b](https://github.com/Meridiona/meridian/commit/82aba7baedd643943c946c81fcae9ad9b041a0d8)), closes [#598](https://github.com/Meridiona/meridian/issues/598)
 * **db:** fix review — restore doc block onto finalize_encryption_swap ([53b7a11](https://github.com/Meridiona/meridian/commit/53b7a11a7ea676241e9ee0135a70dbbea78a337c)), closes [#606](https://github.com/Meridiona/meridian/issues/606) [#598](https://github.com/Meridiona/meridian/issues/598)
 * **db:** open plaintext meridian.db as plaintext even when a key is set ([c8d92ca](https://github.com/Meridiona/meridian/commit/c8d92ca445c5c082d5b7bb99c7e04f80666c36d1))
 * **intelligence:** harden the grace-row insert and trace the sync-failure path ([74329cc](https://github.com/Meridiona/meridian/commit/74329cc92dd04db39534909ae814eeb63fd7ef1b))
@@ -94,12 +96,12 @@
 * **tray:** harden Windows daemon-binary install against transient locks ([03fcbb4](https://github.com/Meridiona/meridian/commit/03fcbb477a298b4cdbfc1a787f6a65d06669de9e)), closes [#606](https://github.com/Meridiona/meridian/issues/606)
 * **tray:** log each failed rename attempt during daemon staging ([d000b60](https://github.com/Meridiona/meridian/commit/d000b60de4c2458fdd6186ababca806c87b3ee0e)), closes [#598](https://github.com/Meridiona/meridian/issues/598)
 * **tray:** make failed provider installs and sign-ins visible in traces ([1b24b00](https://github.com/Meridiona/meridian/commit/1b24b00fba23764ac88f1d71febd2697af128541))
-* **tray:** restore a throttled progress breadcrumb during the daemon-exit wait ([18de191](https://github.com/Meridiona/meridian/commit/18de191ae1f53c0ea685027db766c032e89fc339)), closes [#607](https://github.com/Meridiona/meridian/issues/607) [606/#607](https://github.com/606/meridian/issues/607)
+* **tray:** restore a throttled progress breadcrumb during the daemon-exit wait ([18de191](https://github.com/Meridiona/meridian/commit/18de191ae1f53c0ea685027db766c032e89fc339)), closes [#606](https://github.com/Meridiona/meridian/issues/606) [#607](https://github.com/Meridiona/meridian/issues/607)
 * **tray:** ship LLM install/sign-in failures to OpenObserve ([e8fb9a5](https://github.com/Meridiona/meridian/commit/e8fb9a51a2ee921eb63efecd92c90a2c9aba4363))
 
 ### ♻️ Refactoring
 
-* **core:** unify the Windows transient-lock retry into meridian-core ([3802c2d](https://github.com/Meridiona/meridian/commit/3802c2da6c184eeb85d14463f8ed9c0586319c93)), closes [#606](https://github.com/Meridiona/meridian/issues/606) [#607](https://github.com/Meridiona/meridian/issues/607) [#606](https://github.com/Meridiona/meridian/issues/606) [#607](https://github.com/Meridiona/meridian/issues/607)
+* **core:** unify the Windows transient-lock retry into meridian-core ([3802c2d](https://github.com/Meridiona/meridian/commit/3802c2da6c184eeb85d14463f8ed9c0586319c93)), closes [#606](https://github.com/Meridiona/meridian/issues/606) [#607](https://github.com/Meridiona/meridian/issues/607)
 
 ### 🤖 CI
 


### PR DESCRIPTION
Clears the CodeRabbit review on #651 (the `pre-main` → `main` release PR). #651's head *is* `pre-main`, so the fixes cannot be committed onto it directly - they land here and #651 picks them up.

Five threads were raised. Three are fixed here, one is fixed properly (not as suggested), one is declined with reasoning.

---

## 1. Back-merge job accepted a token that makes it useless - `ci(release)` (e6b895f8)

`secrets.GH_TOKEN || secrets.GITHUB_TOKEN` reads like a safe degradation. It is not one. GitHub does not trigger workflows for refs pushed with the default token, and a `pull_request` opened with it only ever reaches an approval-required state. Either way the back-merge PR arrives **with no CI on it** - and `pre-main`'s checks are what a human merges it on, so it sits unmergeable and quiet. That is the exact failure this job exists to end, reintroduced one layer down.

So the fallback is gone rather than merely checked around: a first step fails with a message naming the missing secret, before anything is pushed. `persist-credentials: true` is now explicit, because the `git push` reuses that credential and it has to be the PAT - which also answers zizmor's `artipacked` flag honestly instead of leaving it unaddressed. The comment block above the checkout was rewritten; it previously documented the fallback as acceptable, and leaving that prose next to the opposite behaviour is the drift that makes the next reader trust the wrong thing.

Verified: YAML parses, the `backmerge` job graph still resolves (`needs`/`if`/`permissions`), and both embedded shell bodies pass `bash -n`.

## 2. Changelog heading - `docs(changelog)` (1a26f033)

`CHANGELOG.md` opened with `##`, tripping markdownlint MD041. **Adding the heading alone would not have survived one release.** `@semantic-release/changelog` strips and re-emits a title only when it is configured with one; otherwise it prepends the new notes above everything, so the next release would have buried a hand-added `# Changelog` under a version entry - a fix that silently undoes itself.

So `changelogTitle: "# Changelog"` is set in `.releaserc.json` alongside the heading. Read from the plugin's own `prepare.js` rather than assumed: it matches the title by exact string prefix and re-writes it on top. Simulated a `1.82.3` release against the edited file - one `# Changelog` line, notes below it, prior entries intact.

## 3. Duplicate and malformed issue references - same commit

Three generated artefacts of malformed commit footers: a doubled `#598`, a doubled `#606`/`#607` pair, and `[606/#607](https://github.com/606/meridian/issues/607)` - a link into a `github.com/606/meridian` repository that does not exist. Corrected in place; the substitutions were asserted unique before applying, so nothing else in the file moved.

## 4. Pin `actions/checkout` to a commit SHA - declined

The repo uses `actions/checkout@v4` at **14 call sites across 5 workflows**, including the `prepare` job in this same file. Pinning one of them to a SHA does not make the release path safer; it makes one line inconsistent with every other, and the next reader cannot tell whether the difference is meaningful. SHA-pinning is a repo-wide policy change with an update process attached - worth doing deliberately, in its own PR, not smuggled into a release fix.

## 5. Run the tray crate checks manually - done, and it found something

The tray workspace is outside normal CI, so this was run by hand in `tray/src-tauri`:

| mode | `cargo test` | `cargo clippy --all-targets -- -D warnings` |
|---|---|---|
| default (`capture` on - what ships) | **195 passed, 0 failed** | **clean** |
| `--no-default-features` | blocked by the same denials | **4 `dead_code` denials** |

Those denials stop compilation before the `cfg(not(feature = "capture"))` `db_setup_result` binding is ever type-checked, so getting past them matters for the thing you actually asked to cover. With `RUSTFLAGS="-A dead_code"` (which replaces the repo-wide `-D warnings` from `.cargo/config.toml`), `cargo clippy --no-default-features --all-targets` **finishes clean, exit 0** - the capture-off path compiles and lints clean, and the only blocker in that mode is the pre-existing dead-code set below.

The `--no-default-features` failures are `capture_ignore.rs`'s `apps`/`domains` fields, `should_drop_app`/`should_drop_frame`/`host_matches`, and `state.rs`'s `ui_recorder_thread` - all unused once `capture` is off.

**This is pre-existing, not from #651.** Both files are byte-identical to `origin/main` (`git diff origin/main HEAD -- tray/src-tauri/src/capture_ignore.rs tray/src-tauri/src/state.rs` is empty), and #651 touches neither. It went unnoticed because ubuntu CI never compiles this crate and no job builds that feature mode. `Cargo.toml` advertises `--no-default-features` as the way to build a lean capture-free tray, so it is a real gap - but a separate one, and gating those items correctly is a behaviour change that does not belong in a release fix.

---

Once this lands on `pre-main`, #651 picks it up with no change to either of its own commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
