### PR TITLE
ci: test and lint the whole workspace, not just the root package

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -55,7 +55,10 @@ fi
 echo ""
 echo "[wave 2/3] cargo clippy  +  ui tests"
 
-run_check "cargo clippy" cargo clippy -- -D warnings &
+# `--workspace` is REQUIRED, not decorative: `members = [".", ...]` makes the
+# repo root a package, so bare cargo lints/tests that package ALONE and silently
+# skips meridian-core, meridian-oauth and the tray. See .github/workflows/ci.yml.
+run_check "cargo clippy" cargo clippy --workspace --all-targets -- -D warnings &
 W2_CLIPPY=$!
 
 run_check "ui tests" bash -c "cd '$REPO_ROOT/ui' && bun test" &
@@ -103,7 +106,7 @@ else
   echo "  - security audit skipped (claude CLI not found)"
 fi
 
-run_check "cargo test" cargo test &
+run_check "cargo test" cargo test --workspace &
 W3_TEST=$!
 
 wait $W3_TEST || FAIL=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,14 +158,16 @@ jobs:
           mkdir -p target/release
           : > target/release/meridian
 
+      # `--workspace` is load-bearing, NOT redundant — see the note above
+      # `rust-windows` for the trap it closes.
       - name: fmt
         run: cargo fmt --check
 
       - name: clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: test
-        run: cargo test
+        run: cargo test --workspace
 
   # ── Rust gate #2: Windows x86_64 ──────────────────────────────────────────
   # Windows is a shipped platform (NSIS installer, see release-build.yml) but
@@ -174,11 +176,26 @@ jobs:
   # mismatch) shipped all the way to a tagged release before anyone found out.
   # This closes that gap on every PR instead.
   #
-  # A bare `cargo clippy`/`test` from the workspace root (no `-p`) covers the
-  # whole workspace by default — daemon, core, oauth, AND the tray (the
-  # `capture` feature's screenpipe-screen/-a11y stack already supports Windows;
-  # it ships there today) — same as the macOS job. No `fmt` here: it is
-  # platform-independent style, already checked once by the macOS job.
+  # `--workspace` on clippy and test is REQUIRED, and its absence is a silent
+  # coverage hole rather than a style choice.
+  #
+  # A bare `cargo clippy`/`test` covers the whole workspace ONLY when the root
+  # manifest is virtual. Ours is not: `members = [".", ...]` makes the repo root
+  # itself a package, so cargo defaults to *that package alone* and silently
+  # skips meridian-core, meridian-oauth and the tray. Those crates still COMPILE
+  # (the daemon depends on them), which is what makes it convincing — they are
+  # simply never tested and their test code is never linted.
+  #
+  # This comment previously asserted the opposite, and the cost was real:
+  # meridian-core's 269 lib tests had never run here, and two db_crypto tests
+  # sat red for days after PR #655's refactor changed the error wording they
+  # assert on, with every gate green the whole time.
+  #
+  # With `--workspace` the coverage matches what this always claimed: daemon,
+  # core, oauth, AND the tray (the `capture` feature's screenpipe-screen/-a11y
+  # stack already supports Windows; it ships there today) — same as the macOS
+  # job. No `fmt` here: it is platform-independent style, already checked once
+  # by the macOS job.
   rust-windows:
     name: Rust (Windows x86_64)
     needs: changes
@@ -240,11 +257,11 @@ jobs:
       # release-build.yml's Windows job for the full story).
       - name: clippy
         shell: pwsh
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: test
         shell: pwsh
-        run: cargo test
+        run: cargo test --workspace
 
   ui:
     name: UI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,15 +169,24 @@ care.
 # Build (SQLX_OFFLINE=true is set automatically via .cargo/config.toml)
 cargo build --release
 
-# Run all tests
-cargo test
+# Run all tests — `--workspace` is REQUIRED, see the warning below
+cargo test --workspace
 
 # Lint (must pass before committing)
-cargo clippy -- -D warnings
+cargo clippy --workspace --all-targets -- -D warnings
 
 # Format (must pass before committing)
 cargo fmt
 ```
+
+> **Always pass `--workspace`.** `members = [".", "meridian-core",
+> "meridian-oauth", "tray/src-tauri"]` makes the repo root itself a package, so
+> a bare `cargo test` / `cargo clippy` runs against **that package alone** and
+> silently skips the other three. They still *compile* (the daemon depends on
+> them), which is what makes the omission so convincing — they are simply never
+> tested and their test code is never linted. This hid two red `db_crypto` tests
+> for days with every gate green; CI and the pre-push hook now pass
+> `--workspace` for exactly this reason.
 
 Rust toolchain is pinned to **1.93.1** via `rust-toolchain.toml`.
 
@@ -654,7 +663,7 @@ fixtures that produce genuinely corrupt files live in `src/db/test_corrupt.rs`
 - Commit message style: `type(scope): short description` — e.g. `fix(etl): detect sleep gaps that span ETL run boundaries`
 - `commit-msg` hook validates conventional commits format — fix message before retrying
 - `pre-commit` hook runs `cargo fmt --check` and `cargo clippy -- -D warnings`
-- `pre-push` hook runs the full suite: `cargo fmt` + `cargo clippy` + UI build + UI tests + security audit (claude CLI) + `cargo test`
+- `pre-push` hook runs the full suite: `cargo fmt` + `cargo clippy --workspace` + UI build + UI tests + security audit (claude CLI) + `cargo test --workspace`
 - Never skip hooks with `--no-verify`
 - Install hooks after cloning: `bash scripts/setup-hooks.sh`
 - Never amend a commit that has already been pushed to `main` or `pre-main`

--- a/meridian-core/src/db_crypto.rs
+++ b/meridian-core/src/db_crypto.rs
@@ -344,6 +344,22 @@ fn interrupted_migration_leftovers(path: &Path) -> Vec<std::path::PathBuf> {
     found
 }
 
+/// Renders `path` as a SQLite string literal, doubling any single quote.
+///
+/// `ATTACH DATABASE` takes its filename as a **literal** and sqlx cannot bind a
+/// parameter there, so the path has to be interpolated - which means a path
+/// containing `'` would otherwise close the literal early and leave the rest to
+/// be parsed as SQL. Doubling the quote is SQLite's own escape.
+///
+/// This is not a remote-attack surface: the path comes from the user's own
+/// config and install layout, never from a wire. But an apostrophe in a macOS
+/// account name is ordinary enough - `/Users/o'brien/…` - and unescaped it
+/// turns into a baffling SQL syntax error in the middle of a database
+/// migration, on the one machine whose owner cannot avoid it.
+fn sql_quoted_path(path: &Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', "''"))
+}
+
 /// `std::fs::rename` with a short bounded retry (~1s of linear backoff across 5
 /// attempts) via the shared [`crate::retry::retry_transient_blocking`]. On
 /// Windows a rename fails with os error 32 ("used by another process") while
@@ -526,8 +542,8 @@ pub async fn encrypt_in_place(path: &Path, key_hex: &str) -> anyhow::Result<()> 
     let _ = std::fs::remove_file(&tmp_path); // best-effort cleanup of a prior interrupted attempt
 
     let attach_sql = format!(
-        "ATTACH DATABASE '{}' AS encrypted_export KEY \"x'{}'\";",
-        tmp_path.display(),
+        "ATTACH DATABASE {} AS encrypted_export KEY \"x'{}'\";",
+        sql_quoted_path(&tmp_path),
         key_hex
     );
     conn.execute(attach_sql.as_str())
@@ -597,8 +613,8 @@ pub async fn export_plaintext(
 
     let _ = std::fs::remove_file(out_path);
     let attach_sql = format!(
-        "ATTACH DATABASE '{}' AS plaintext_export KEY '';",
-        out_path.display()
+        "ATTACH DATABASE {} AS plaintext_export KEY '';",
+        sql_quoted_path(out_path)
     );
     conn.execute(attach_sql.as_str())
         .await
@@ -936,9 +952,14 @@ mod tests {
             b"ORIGINAL-PLAINTEXT",
             "plaintext original must be left intact"
         );
+        let msg = format!("{err:#}");
         assert!(
-            format!("{err:#}").contains("move plaintext original aside"),
-            "unexpected error: {err:#}"
+            msg.contains("failed to move the original database aside"),
+            "unexpected error: {msg}"
+        );
+        assert!(
+            msg.starts_with("encrypt_in_place:"),
+            "the error must name the calling operation: {msg}"
         );
     }
 
@@ -969,9 +990,14 @@ mod tests {
             !backup.exists(),
             "backup should have been renamed back to path"
         );
+        let msg = format!("{err:#}");
         assert!(
-            format!("{err:#}").contains("restored the plaintext original"),
-            "unexpected error: {err:#}"
+            msg.contains("restored the original"),
+            "unexpected error: {msg}"
+        );
+        assert!(
+            msg.starts_with("encrypt_in_place:"),
+            "the error must name the calling operation: {msg}"
         );
     }
 
@@ -1051,6 +1077,48 @@ mod tests {
             .unwrap();
         pool.close().await;
         assert!(!is_plaintext_sqlite(&enc_path));
+    }
+
+    /// An apostrophe in the path must survive the `ATTACH DATABASE` literal.
+    ///
+    /// Runs the real migration rather than asserting on [`sql_quoted_path`] in
+    /// isolation: the bug this guards is that an unescaped quote closes the
+    /// literal early, which only shows up once SQLite actually parses the
+    /// statement. `/Users/o'brien/…` is an ordinary macOS home directory.
+    #[tokio::test]
+    async fn encrypt_in_place_handles_an_apostrophe_in_the_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let odd = dir.path().join("o'brien");
+        std::fs::create_dir(&odd).unwrap();
+        let db_path = odd.join("meridian.db");
+
+        let pool = open_pool_with_key(&db_path.display().to_string(), None, true, &[])
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE t (x INTEGER)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO t (x) VALUES (7)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        pool.close().await;
+
+        encrypt_in_place(&db_path, TEST_KEY)
+            .await
+            .expect("an apostrophe in the path must not break the ATTACH literal");
+        assert!(!is_plaintext_sqlite(&db_path));
+
+        let pool = open_pool_with_key(&db_path.display().to_string(), Some(TEST_KEY), false, &[])
+            .await
+            .unwrap();
+        let row = sqlx::query("SELECT x FROM t")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(row.get::<i64, _>(0), 7, "data must survive the migration");
+        pool.close().await;
     }
 
     #[tokio::test]

--- a/tray/src-tauri/src/install.rs
+++ b/tray/src-tauri/src/install.rs
@@ -334,21 +334,33 @@ pub(crate) fn meridian_db_path() -> String {
 mod tests {
     use super::*;
 
+    /// Is `name` one of `p`'s path components?
+    ///
+    /// These assertions used to spell paths as string literals with `/` in
+    /// them, which quietly meant two different things per platform: a real
+    /// check on Unix, and a check that could never fail on Windows (where the
+    /// separator is `\`, so `contains("/.meridian/")` is always false). Two of
+    /// them failed outright the first time the tray was ever tested on Windows.
+    /// Comparing components is separator-agnostic and says what is meant.
+    fn has_component(p: &std::path::Path, name: &str) -> bool {
+        p.components().any(|c| c.as_os_str() == name)
+    }
+
     /// The rule itself, asserted end-to-end: these tests ARE a debug build, so
     /// every resolver must answer from the checkout and name `~/.meridian` for
     /// nothing. The DB is the one sanctioned exception, pinned separately below.
     #[test]
     fn a_dev_build_reaches_into_the_installed_package_for_nothing() {
         let repo = dev_root();
-        let installed = "/.meridian/";
 
         let bin = meridian_bin();
+        let bin_path = std::path::Path::new(&bin);
         assert!(
-            bin.starts_with(&*repo.to_string_lossy()) && bin.ends_with("target/debug/meridian"),
+            bin_path.starts_with(&repo) && bin_path.ends_with("target/debug/meridian"),
             "dev must spawn the CLI it was built beside, got: {bin}"
         );
         assert!(
-            !bin.contains(installed),
+            !has_component(bin_path, ".meridian"),
             "dev must not spawn the package CLI"
         );
 
@@ -357,9 +369,9 @@ mod tests {
             cwd, repo,
             "the cwd picks the .env - it must be the checkout"
         );
-        assert!(!cwd.to_string_lossy().contains(installed));
+        assert!(!has_component(&cwd, ".meridian"));
         assert!(
-            !cwd.to_string_lossy().contains(".."),
+            !has_component(&cwd, ".."),
             "hand the child a real path, not one with /../.. in it"
         );
 
@@ -382,9 +394,10 @@ mod tests {
         if std::env::var("MERIDIAN_DB").is_ok() {
             return;
         }
+        let db = meridian_db_path();
         assert!(
-            meridian_db_path().ends_with("/.meridian/meridian.db"),
-            "the shared DB stays in ~/.meridian"
+            std::path::Path::new(&db).ends_with(".meridian/meridian.db"),
+            "the shared DB stays in ~/.meridian, got: {db}"
         );
     }
 


### PR DESCRIPTION
## The hole

`Cargo.toml` declares `members = [".", "meridian-core", "meridian-oauth", "tray/src-tauri"]`. Because the repo root is **itself a package**, a bare `cargo test` / `cargo clippy` runs against **that package alone** — cargo only defaults to every member when the root manifest is *virtual*, and ours is not.

The other three crates still **compile** (the daemon depends on them), which is what makes the omission so convincing. They are simply never tested, and their test code is never linted.

Two `ci.yml` comments asserted the opposite — *"covers the whole workspace by default — daemon, core, oauth, AND the tray"*. Proven false on this branch rather than argued:

```
$ cargo test finalize_swap          # at the workspace root
running 0 tests ... 852 filtered out          <- daemon suites only

$ cargo test -p meridian-core --lib
FAILED. 266 passed; 2 failed
```

## What it cost

Those two `db_crypto` tests had been **red since #655 merged** — that PR's refactor changed the error wording they assert on. Every gate was green the entire time. Nothing in CI, and nothing in the pre-push hook, could have caught it.

## What changes

| | before | after |
|---|---|---|
| `ci.yml` (macOS + Windows) | `cargo test` / `cargo clippy --all-targets` | `--workspace` on both |
| `.githooks/pre-push` | `cargo test` / `cargo clippy` | `--workspace` on both |
| `CLAUDE.md` | `cargo test` | `--workspace`, plus a warning explaining the trap |

Roughly **527 previously ungated tests** now run: `meridian-core`'s 268 lib + `readers.rs` (43) + `today_smoke.rs` (21), `meridian-oauth`, and the tray's 195. The two stale assertions are fixed so the branch is green; locally `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` both pass with no other fixes needed.

The misleading comments are replaced with an explanation of *why* `--workspace` is load-bearing, so this cannot be "tidied up" back into a silent hole.

## One unrelated fix, forced by the hook

The pre-push security audit flagged `ATTACH DATABASE '{path}'` in `db_crypto.rs` the moment that file entered a diff — it has carried this since long before this branch. sqlx cannot bind a parameter in that position, so the path must be interpolated, and an unescaped `'` closes the literal early.

Not a remote-attack surface (the path is the user's own config, never from a wire), but `/Users/o'brien/…` is an ordinary macOS home directory and would have failed **mid-migration** with a baffling SQL syntax error. Fixed with a quoting helper, and covered by a test that runs the **real migration** under an apostrophe path rather than asserting on the helper in isolation.

`src/db/repair/rebuild.rs` has the same pattern and is deliberately left alone — #659 owns that file right now.

## Cost, stated plainly

**The tray has never actually been compiled in CI.** The "Stub the tray bundle resource" step in both Rust jobs has been a **no-op since it was written**, because bare cargo never built the tray. `--workspace` makes that step load-bearing for the first time, and both jobs now build Tauri plus the screenpipe-fork capture stack.

**Measured over two runs** (both cold for the newly-built crates — `rust-cache` only saves on `pre-main`, which has no tray build cached yet):

| job | before | run 1 | run 2 | run 3 (post-merge) |
|---|---|---|---|---|
| Rust (Windows x86_64) | ~15m | 35m17s | 34m02s | **34m17s** |
| Rust (macOS Apple Silicon) | ~8m | 13m01s | 14m04s | **24m58s** |

Windows is consistently ~34m — roughly double. macOS is the noisier figure: 13-14m on the first two runs, 25m on the third. That run followed #659 merging into `pre-main`, so it restored a base-branch cache that no longer matched; treat 13-14m as the warm-ish case and 25m as a cache-miss ceiling, not as drift. That is the real cost of this PR and the thing to decide on. Caching softens the steady state — `rust-cache` saves on `pre-main`, so after one cold run there PRs restore warm — but the cold number is what a cache miss costs.

If that is too slow, the fallback is `-p meridian -p meridian-core -p meridian-oauth`, keeping the tray out of the per-PR jobs (it is still built by `release-build.yml`). That would still capture **all** of the value described above except tray coverage, at close to the current job time.

## What the first run already found

The Windows job failed — on exactly the crate that had never been compiled there:

```
install::tests::a_dev_build_reaches_into_the_installed_package_for_nothing
  dev must spawn the CLI it was built beside, got:
    \\?\D:\a\meridian\meridian\target\debug\meridian
install::tests::the_database_is_the_one_thing_a_dev_run_still_shares
  the shared DB stays in ~/.meridian
```

Both are **test** bugs, not Windows bugs — fixed in the second commit. The assertions spelled paths as string literals containing `/`, which quietly meant two different things per platform:

- `ends_with("target/debug/meridian")` — a real check on Unix, a guaranteed failure on Windows.
- `contains("/.meridian/")` — a real check on Unix, and on Windows **always false**, so `"dev must not spawn the package CLI"` was asserting *nothing at all*.

The second one is the interesting half: that assertion would have passed on Windows no matter how badly the code misbehaved. Comparing components says what was meant on both platforms.

Production paths are fine and deliberately unchanged — `PathBuf::push` normalises `/` to `\` when extending a verbatim `\\?\` path, and `meridian_bin` already resolves `meridian.exe` on the release path.

Everything else passed on Windows first time, including `meridian-core`'s 273 lib tests, `readers.rs`, `today_smoke.rs`, and the new apostrophe-path test.

## Checked, not assumed

- **The paths filter still fires.** `rust` matches `**/*.rs` and `**/Cargo.toml` — repo-wide globs — so a PR touching *only* `meridian-core/` or `tray/src-tauri/` does trigger these jobs. Had it been scoped to `src/**`, `--workspace` would have bought nothing for exactly the crates it protects.
- **The tray's Windows build is feasible.** `release-build.yml` already builds it on `windows-latest`, and `tauri.windows.conf.json` nulls the macOS-only bundle resources. The icons the tray needs at compile time (including `icon.ico`) are committed.

## Conflict with #659 - resolved

#659 merged first, so this branch carries a merge of `pre-main`. Both sides kept: `sql_quoted_path` from here, `RENAME_ATTEMPTS_CHEAP`/`_EXPENSIVE` and the `rename_with_retry(.., attempts)` signature from `pre-main`. The duplicated assertion fixes were textually identical and merged themselves.

One correction made inside the conflicted block: `RENAME_ATTEMPTS_EXPENSIVE`'s doc claimed *"one second demonstrably was not enough, on a loaded Windows CI runner"*, attributing #659's Windows failure to the retry budget. #659 went on to prove that wrong - the rebuilt file was still held open by a connection `pool.close()` had not closed, fixed at the source in `db::repair::rebuild`. Left standing, that comment is evidence for a lock nobody has observed, and would justify padding the budget again the next time someone hits a rename failure. It now says the budget is defence in depth and points at the real cause.

Post-merge CI is green on both platforms, so `--workspace` is now also exercising #659's repair code on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
