### PR TITLE
fix(llm): make the provider Install button work on Windows

### DIFF
--- a/meridian-core/src/lib.rs
+++ b/meridian-core/src/lib.rs
@@ -79,7 +79,10 @@ pub use readers::{
 
 pub use canonical_task::{CanonicalTask, PersonRef, Priority, Provider, StatusCategory, TaskKind};
 
-pub use llm_provider::{LlmProvider, CURSOR_CLI_VERSION, CURSOR_INSTALL_CMD, CURSOR_INSTALL_HINT};
+pub use llm_provider::{
+    LlmProvider, CLAUDE_INSTALL_CMD, CODEX_INSTALL_CMD, CURSOR_CLI_VERSION, CURSOR_INSTALL_CMD,
+    CURSOR_INSTALL_HINT,
+};
 /// The custom-endpoint registry types. `CustomLlmProvider` carries the API key and is the
 /// STORAGE form — see its docs before serialising one anywhere.
 pub use settings::{CustomLlmProvider, SchemaRung};

--- a/meridian-core/src/llm_provider.rs
+++ b/meridian-core/src/llm_provider.rs
@@ -151,10 +151,17 @@ impl LlmProvider {
     /// (`crate::llm::detect::install_provider` in the daemon crate). The strings are fixed
     /// literals, never interpolated with user input, so running them through a login shell is
     /// safe. Each is the vendor's own official, non-interactive installer.
+    ///
+    /// Three of the four are PLATFORM-SPLIT constants rather than inline literals, because
+    /// the command that works on macOS is not the command that works on Windows - see
+    /// [`CLAUDE_INSTALL_CMD`], [`CODEX_INSTALL_CMD`] and [`CURSOR_INSTALL_CMD`]. Copilot is
+    /// still npm-only: it has no native installer, and it is deliberately absent from the
+    /// picker (`CHOOSER_PROVIDER_IDS` in `ui/lib/llm-providers.ts`), so nothing in the UI can
+    /// reach this arm today.
     pub fn install_command(self) -> Option<&'static str> {
         match self {
-            LlmProvider::Claude => Some("npm i -g @anthropic-ai/claude-code"),
-            LlmProvider::Codex => Some("npm i -g @openai/codex"),
+            LlmProvider::Claude => Some(CLAUDE_INSTALL_CMD),
+            LlmProvider::Codex => Some(CODEX_INSTALL_CMD),
             LlmProvider::Cursor => Some(CURSOR_INSTALL_CMD),
             LlmProvider::Copilot => Some("npm i -g @github/copilot"),
             LlmProvider::Custom => None,
@@ -243,6 +250,65 @@ pub const CURSOR_INSTALL_CMD: &str = concat!(
     "'; iex $s"
 );
 
+/// Claude Code's installer.
+///
+/// # Unix
+/// npm, unchanged - the path this has always shipped and been tested on.
+///
+/// # Windows
+/// Anthropic's own native installer, which needs NEITHER node NOR npm: it downloads a
+/// self-contained `claude.exe` and delegates placement to the binary's own `claude
+/// install`, landing it in `~/.local/bin` (already a [`crate`]-side candidate dir, so the
+/// post-install probe finds it). `https://claude.ai/install.ps1` 302s to
+/// `downloads.claude.ai/claude-code-releases/bootstrap.ps1`.
+///
+/// Switching away from npm here is not a preference - it is the only form that WORKS. Three
+/// independent reasons, each fatal on its own:
+///
+/// 1. **`@anthropic-ai/claude-code` requires node >=22.** A Windows box whose PATH node is
+///    older installs a package that cannot run. Node lands on the SYSTEM PATH (the
+///    `C:\Program Files\nodejs` MSI), which always precedes the User PATH where a newer
+///    per-user node (winget, nvm) would sit - so the stale one wins and the user cannot fix
+///    it without admin.
+/// 2. **The npm form is what trips `llm::detect::resolve_installer_binary`.** A leading token
+///    that resolves to a real binary is precisely what triggers the POSIX `export PATH=…`
+///    rewrite; `irm` is a PowerShell alias, not a file on PATH, so this form is immune the
+///    same way [`CURSOR_INSTALL_CMD`]'s `$s = …` is.
+/// 3. **It reports failure honestly.** bootstrap.ps1 `exit`s non-zero on arch, version and
+///    manifest errors and propagates the inner installer's code - so a failed install cannot
+///    present as a success (see `llm::detect::installer_command`'s exit-code handling).
+#[cfg(not(windows))]
+pub const CLAUDE_INSTALL_CMD: &str = "npm i -g @anthropic-ai/claude-code";
+
+/// See [`CLAUDE_INSTALL_CMD`]'s Windows doc above. Plain PowerShell script text with no
+/// enclosing `powershell -Command "…"` wrapper - `llm::detect::installer_command` supplies
+/// that, exactly as it does for [`CURSOR_INSTALL_CMD`].
+#[cfg(windows)]
+pub const CLAUDE_INSTALL_CMD: &str = "irm https://claude.ai/install.ps1 | iex";
+
+/// Codex's installer.
+///
+/// # Unix
+/// npm, unchanged - as with [`CLAUDE_INSTALL_CMD`].
+///
+/// # Windows
+/// OpenAI's own standalone installer, which needs neither node nor npm (it downloads a
+/// pre-compiled binary and will even remove a conflicting npm/bun-managed Codex).
+/// `https://chatgpt.com/codex/install.ps1` 302s to `releases.openai.com/codex/install.ps1`.
+///
+/// **Coupled to `llm::detect::candidate_dirs`:** this installer lands `codex.exe` in
+/// `%LOCALAPPDATA%\Programs\OpenAI\Codex\bin` and writes the USER PATH, which does not
+/// affect the already-running tray process. So the post-install probe can only find it via
+/// a candidate dir - that entry MUST stay in `candidate_dirs` or a perfectly successful
+/// install reports itself as failed, the identical bug `%LOCALAPPDATA%\cursor-agent` was
+/// added there to prevent.
+#[cfg(not(windows))]
+pub const CODEX_INSTALL_CMD: &str = "npm i -g @openai/codex";
+
+/// See [`CODEX_INSTALL_CMD`]'s Windows doc above.
+#[cfg(windows)]
+pub const CODEX_INSTALL_CMD: &str = "irm https://chatgpt.com/codex/install.ps1 | iex";
+
 #[cfg(test)]
 mod install_pin_tests {
     use super::*;
@@ -289,6 +355,65 @@ mod install_pin_tests {
         assert!(CURSOR_INSTALL_CMD.contains("iex "));
         assert!(!CURSOR_INSTALL_CMD.contains("curl"));
         assert!(!CURSOR_INSTALL_CMD.contains("bash"));
+    }
+
+    /// Unix keeps npm for Claude and Codex - the path that has always shipped there. Pins it
+    /// so a future Windows-motivated edit can't quietly retarget the platform that works.
+    #[cfg(not(windows))]
+    #[test]
+    fn unix_claude_and_codex_install_via_npm() {
+        assert_eq!(
+            LlmProvider::Claude.install_command(),
+            Some("npm i -g @anthropic-ai/claude-code")
+        );
+        assert_eq!(
+            LlmProvider::Codex.install_command(),
+            Some("npm i -g @openai/codex")
+        );
+    }
+
+    /// The Windows fix, pinned. `npm i -g` cannot be the Windows form for either provider:
+    /// Claude's package needs node >=22 (routinely absent, and unfixable without admin when
+    /// a stale node sits on the SYSTEM PATH), and an npm leading token is exactly what makes
+    /// `llm::detect::resolve_installer_binary` rewrite the command into POSIX `export PATH=…`
+    /// syntax that PowerShell cannot parse. Both native installers are node-free.
+    #[cfg(windows)]
+    #[test]
+    fn windows_claude_and_codex_install_natively_without_npm() {
+        for cmd in [CLAUDE_INSTALL_CMD, CODEX_INSTALL_CMD] {
+            assert!(cmd.contains("irm "), "{cmd}");
+            assert!(cmd.contains("iex"), "{cmd}");
+            assert!(!cmd.contains("npm"), "{cmd}");
+            // The leading token must NOT be a resolvable binary name - that is what keeps
+            // `resolve_installer_binary` from rewriting it. `irm` is a PowerShell alias.
+            assert!(cmd.starts_with("irm "), "{cmd}");
+        }
+        assert_eq!(
+            LlmProvider::Claude.install_command(),
+            Some(CLAUDE_INSTALL_CMD)
+        );
+        assert_eq!(
+            LlmProvider::Codex.install_command(),
+            Some(CODEX_INSTALL_CMD)
+        );
+    }
+
+    /// Every installer Meridian runs on Windows must be PowerShell-executable. `curl`/`bash`/
+    /// `sed` are absent from stock Windows, and the POSIX `export` builtin does not exist in
+    /// PowerShell at all - a command containing any of them fails with
+    /// `CommandNotFoundException` before the vendor's installer is ever reached.
+    #[cfg(windows)]
+    #[test]
+    fn no_windows_install_command_uses_posix_shell_syntax() {
+        for p in [LlmProvider::Claude, LlmProvider::Codex, LlmProvider::Cursor] {
+            let cmd = p.install_command().expect("built-in CLI has an installer");
+            for posix in ["curl ", "bash", "sed ", "export "] {
+                assert!(
+                    !cmd.contains(posix),
+                    "{p:?}'s Windows installer contains POSIX-only `{posix}`: {cmd}"
+                );
+            }
+        }
     }
 }
 

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -75,8 +75,22 @@ fn candidate_dirs() -> Vec<PathBuf> {
         }
         if let Ok(local_appdata) = std::env::var("LOCALAPPDATA") {
             dirs.push(
-                PathBuf::from(local_appdata)
+                PathBuf::from(&local_appdata)
                     .join("cursor-agent")
+                    .to_string_lossy()
+                    .into_owned(),
+            );
+            // Where OpenAI's native installer puts `codex.exe`
+            // ([`meridian_core::CODEX_INSTALL_CMD`]'s Windows form). It writes the USER
+            // PATH, which an already-running tray cannot see, so without this entry a
+            // SUCCESSFUL install reports itself as failed - the same trap `cursor-agent`
+            // above exists for. Keep the two in lockstep with those install commands.
+            dirs.push(
+                PathBuf::from(&local_appdata)
+                    .join("Programs")
+                    .join("OpenAI")
+                    .join("Codex")
+                    .join("bin")
                     .to_string_lossy()
                     .into_owned(),
             );
@@ -115,6 +129,18 @@ pub struct ProviderStatus {
     /// the on-disk cache, never freshly run by [`detect`]/[`detect_all`] themselves. `None`
     /// means "never tested", not "failed".
     pub last_test: Option<ProviderTestResult>,
+    /// The installer this platform will actually run
+    /// ([`meridian_core::LlmProvider::install_command`]), or `None` for a provider with
+    /// nothing to install.
+    ///
+    /// Reported to the frontend because the UI's own `installHint`
+    /// (`ui/lib/llm-providers.ts`) is a single static string compiled into a dashboard that
+    /// runs on BOTH platforms, so it cannot be right on both: it names the npm command,
+    /// while Windows installs natively. That mattered beyond cosmetics — the hint doubles as
+    /// the "run this yourself" fallback shown when an install fails, so a Windows user was
+    /// told to run the exact command that cannot work there. Sourcing it from here makes the
+    /// displayed command the one that ran, on every platform, by construction.
+    pub install_command: Option<String>,
 }
 
 /// Probe one provider. A provider with no CLI binary (only `Custom`, a cloud endpoint) has
@@ -122,6 +148,7 @@ pub struct ProviderStatus {
 /// registry), so this early-return is not reached in practice.
 pub async fn detect(provider: LlmProvider) -> ProviderStatus {
     let id = provider.as_str().to_string();
+    let install_command = provider.install_command().map(str::to_string);
     let Some(bin) = provider.cli_name() else {
         return ProviderStatus {
             id,
@@ -129,6 +156,7 @@ pub async fn detect(provider: LlmProvider) -> ProviderStatus {
             path: None,
             authenticated: None,
             last_test: None,
+            install_command,
         };
     };
 
@@ -137,6 +165,7 @@ pub async fn detect(provider: LlmProvider) -> ProviderStatus {
         id,
         installed: found.is_some(),
         path: found.map(|p| p.display().to_string()),
+        install_command,
         authenticated: None,
         last_test: None,
     }
@@ -535,6 +564,34 @@ pub struct InstallOutcome {
 /// can find one — see [`install_provider`]'s "leading binary" doc section for why. Returns
 /// `cmd` unchanged (not an `Option`) so every caller has a command to run either way; the
 /// resolution is best-effort by design.
+///
+/// # Windows: deliberately a no-op
+///
+/// Every reason above is a macOS/Linux reason, and the rewrite it produces is POSIX shell
+/// text - `export PATH="…:$PATH"; <abs path> …` - which [`installer_command`] feeds to
+/// **PowerShell**, where it is not merely suboptimal but unrunnable:
+///
+/// - `export` is not a PowerShell command (`$env:PATH` is, and entries are `;`-separated,
+///   not `:`), and `$PATH` is an undefined variable there.
+/// - The substituted absolute path is interpolated unquoted and without the `&` call
+///   operator, so a perfectly ordinary `C:\Program Files\nodejs\npm.cmd` is parsed as the
+///   command `C:\Program`.
+///
+/// Both fail with `CommandNotFoundException` before the vendor's installer runs at all. The
+/// premise doesn't hold here either: Windows has no Finder/launchd PATH stripping (see
+/// [`resolve_cli`]'s doc), so the current process's `PATH` already sees what a terminal
+/// does, and PowerShell resolves `npm` → `npm.cmd` itself via `PATHEXT`. Passing `cmd`
+/// through untouched is therefore both correct and sufficient.
+///
+/// This was a live bug: it made the Install button fail for every npm-based provider on
+/// Windows, and - because the leading token is what triggers the rewrite - Cursor was
+/// unaffected purely by accident, its command starting with `$s`.
+#[cfg(windows)]
+async fn resolve_installer_binary(cmd: &str) -> String {
+    cmd.to_string()
+}
+
+#[cfg(not(windows))]
 async fn resolve_installer_binary(cmd: &str) -> String {
     match cmd.split_once(' ') {
         Some((installer_bin, rest)) => match resolve_cli(installer_bin).await {
@@ -713,11 +770,34 @@ pub async fn install_provider(provider: LlmProvider) -> InstallOutcome {
 /// (`npm i -g …`) run identically well under `-Command` as they did under `cmd /C`.
 /// `-ExecutionPolicy Bypass` is defensive: inline `-Command` text isn't normally subject to
 /// the script-file execution policy, but a locked-down machine's policy could still be
-/// stricter than default, and there is no `.ps1` file here to sign. `; exit $LASTEXITCODE`
-/// guarantees the process's own exit code reflects the command's success/failure — relying on
-/// PowerShell's implicit propagation for the LAST statement in a `-Command` script is not
-/// documented behaviour and would silently report a failed `npm i -g …` as a successful
-/// install.
+/// stricter than default, and there is no `.ps1` file here to sign.
+///
+/// # Why the exit-code epilogue is more than `; exit $LASTEXITCODE`
+///
+/// Propagating the exit code explicitly is necessary — relying on PowerShell's implicit
+/// propagation for the LAST statement in a `-Command` script is not documented behaviour.
+/// But `; exit $LASTEXITCODE` ALONE is not sufficient, and its insufficiency is silent:
+///
+/// **`$LASTEXITCODE` is only ever set by a NATIVE executable.** If the command dies before
+/// reaching one — a `CommandNotFoundException` from a malformed command, a parse error — the
+/// variable is still `$null`, and `exit $null` exits **0**. [`install_provider`] then reads
+/// `status.success()` as true, skips the branch that surfaces stderr, and reports the
+/// generic "installer finished but the CLI still isn't on your PATH". That message sends the
+/// user to debug their PATH over what is really a broken install command, and the actual
+/// error — sitting in stderr — is discarded unread.
+///
+/// So the epilogue distinguishes three cases:
+///
+/// 1. A native exe ran → trust its code verbatim, exactly as before.
+/// 2. No native exe ran AND a command name failed to resolve → exit 127 (the conventional
+///    "command not found"), so the real stderr reaches the user.
+/// 3. Anything else → exit 0.
+///
+/// Case 2 keys on `CommandNotFoundException` specifically rather than "`$Error` is
+/// non-empty" on purpose: a vendor installer that raises and HANDLES a non-terminating error
+/// still leaves it in `$Error`, and failing on that would break installs that work today
+/// (Cursor's `iex`-ed script is pure PowerShell and may never set `$LASTEXITCODE` at all).
+/// An unresolvable command name, by contrast, is never a recoverable condition.
 #[cfg(windows)]
 pub(crate) fn installer_command(cmd: &str) -> Command {
     let mut command = Command::new("powershell");
@@ -726,9 +806,26 @@ pub(crate) fn installer_command(cmd: &str) -> Command {
         .arg("-ExecutionPolicy")
         .arg("Bypass")
         .arg("-Command")
-        .arg(format!("{cmd}; exit $LASTEXITCODE"));
+        .arg(format!("$Error.Clear(); {cmd}; {EXIT_EPILOGUE}"));
     command
 }
+
+/// The exit-code epilogue appended to every Windows installer command — see
+/// [`installer_command`]'s "Why the exit-code epilogue is more than `; exit $LASTEXITCODE`".
+///
+/// Split out as a named constant rather than inlined into the `format!` so the three-case
+/// logic is readable on its own, and so there is exactly one definition of it to change.
+/// Its BEHAVIOUR is pinned by `installer_command_reports_an_unrunnable_command_as_failed`
+/// and `installer_command_tolerates_a_handled_powershell_error`, which run the real shell
+/// rather than string-matching this text - a match on the text would pass just as happily
+/// for an epilogue that PowerShell rejects.
+#[cfg(windows)]
+pub(crate) const EXIT_EPILOGUE: &str = concat!(
+    "if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE }; ",
+    "if ($Error | Where-Object { $_.FullyQualifiedErrorId -like 'CommandNotFound*' }) ",
+    "{ exit 127 }; ",
+    "exit 0"
+);
 
 #[cfg(not(windows))]
 pub(crate) fn installer_command(cmd: &str) -> Command {
@@ -1657,6 +1754,105 @@ mod tests {
         let output = cmd.output().await.expect("installer_command must spawn");
         assert!(!output.status.success());
         assert_eq!(output.status.code(), Some(7));
+    }
+
+    /// The measured Windows regression, pinned end to end: a command that dies before
+    /// reaching any native executable must be reported as FAILED, with its real error on
+    /// stderr.
+    ///
+    /// This is the exact shape `resolve_installer_binary` used to hand PowerShell — POSIX
+    /// `export` plus an unquoted space-bearing path — and every part of the old epilogue's
+    /// failure is reproduced here: PowerShell raises `CommandNotFoundException` twice, no
+    /// native exe ever runs, so `$LASTEXITCODE` stays `$null` and the old `exit $LASTEXITCODE`
+    /// exited **0**. `install_provider` read that as success, never looked at stderr, and told
+    /// the user their PATH was wrong.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn installer_command_reports_an_unrunnable_command_as_failed() {
+        let mut cmd = installer_command(
+            r#"export PATH="C:\Some Dir\bin:$PATH"; C:\Some Dir\bin\npm.cmd i -g some-package"#,
+        );
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let output = cmd.output().await.expect("installer_command must spawn");
+        assert!(
+            !output.status.success(),
+            "a command that never reached a native exe must not report success: {output:?}"
+        );
+        assert_eq!(output.status.code(), Some(127), "{output:?}");
+        // The cause must survive to stderr — `install_provider` only reads it on !success(),
+        // so reporting this as success is what silently discarded it.
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("not recognized"),
+            "the real error must reach stderr: {output:?}"
+        );
+    }
+
+    /// The other half of that fix, and the reason it keys on `CommandNotFoundException`
+    /// rather than "`$Error` is non-empty": a pure-PowerShell installer that raises and
+    /// HANDLES an error still leaves it in `$Error` and may never set `$LASTEXITCODE` at all.
+    /// Cursor's `iex`-ed script is exactly that shape, and it installs correctly today —
+    /// failing it would be a regression caused by the fix.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn installer_command_tolerates_a_handled_powershell_error() {
+        let mut cmd = installer_command(
+            r#"try { Get-Item 'C:\meridian\definitely\missing' -ErrorAction Stop } catch { }"#,
+        );
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let output = cmd.output().await.expect("installer_command must spawn");
+        assert!(
+            output.status.success(),
+            "a handled non-terminating error must not fail the install: {output:?}"
+        );
+    }
+
+    /// `resolve_installer_binary` must leave the command ALONE on Windows. Its rewrite is
+    /// POSIX shell text (`export PATH="…:$PATH"; <abs path> …`) which PowerShell cannot run,
+    /// and the premise doesn't hold here anyway — see the fn's Windows doc. Uses `cmd`, which
+    /// always resolves on Windows (`C:\Windows\System32\cmd.exe`), so this only passes
+    /// because the fn is a no-op, not because resolution happened to fail.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn resolve_installer_binary_is_a_no_op_on_windows() {
+        let original = "cmd /c exit 0";
+        assert_eq!(
+            resolve_installer_binary(original).await,
+            original,
+            "Windows must pass the installer command through untouched"
+        );
+    }
+
+    /// OpenAI's native installer writes the USER PATH, which an already-running tray cannot
+    /// see, so `%LOCALAPPDATA%\Programs\OpenAI\Codex\bin` is the ONLY way the post-install
+    /// probe finds `codex.exe`. Dropping it turns a successful install into a reported
+    /// failure — the same bug `%LOCALAPPDATA%\cursor-agent` was added to prevent.
+    #[cfg(windows)]
+    #[test]
+    fn candidate_dirs_covers_the_native_codex_install_dir() {
+        // Same pattern as `candidate_dirs_includes_the_cursor_agent_install_root`: the lock
+        // and a pinned value are load-bearing, because a sibling test removes `LOCALAPPDATA`
+        // and these run in parallel.
+        let _guard = ENV_LOCK.blocking_lock();
+        let original = std::env::var_os("LOCALAPPDATA");
+        std::env::set_var("LOCALAPPDATA", r"C:\Users\meridian-test\AppData\Local");
+
+        let dirs = candidate_dirs();
+
+        match original {
+            Some(v) => std::env::set_var("LOCALAPPDATA", v),
+            None => std::env::remove_var("LOCALAPPDATA"),
+        }
+
+        assert!(
+            dirs.contains(&PathBuf::from(
+                r"C:\Users\meridian-test\AppData\Local\Programs\OpenAI\Codex\bin"
+            )),
+            "{dirs:?}"
+        );
     }
 
     /// The regression this exists for: an npm-based install (`npm i -g @openai/codex`, etc.)

--- a/ui/__tests__/llm-provider-connection-phase.test.ts
+++ b/ui/__tests__/llm-provider-connection-phase.test.ts
@@ -31,6 +31,7 @@ const status = (installed: boolean, path: string | null = null): ProviderStatus 
   path,
   authenticated: null,
   last_test: null,
+  install_command: 'npm i -g @openai/codex',
 })
 
 const testResult = (outcome: ProviderTestResult['outcome']): ProviderTestResult => ({

--- a/ui/components/LlmProviderDetail.tsx
+++ b/ui/components/LlmProviderDetail.tsx
@@ -181,11 +181,15 @@ export default function LlmProviderDetail({
         gap: 10, padding: '14px 15px', borderRadius: 12,
         background: 'var(--t-card)', border: '1px solid var(--t-ctrl-border)',
       }}>
+        {/* installHint: the probe reports the command THIS platform actually runs. The static
+            meta hint is a single string compiled for both platforms and names the npm command,
+            which is wrong on Windows - and it doubles as the "run it yourself" fallback after a
+            failed install. Fall back to it only while the probe is still in flight. */}
         <ConnectionBody
           phase={phase}
           name={p.name}
           providerId={p.id}
-          installHint={p.installHint}
+          installHint={probed?.install_command ?? p.installHint}
           installMsg={installMsg}
           signInMsg={signInMsg}
           onInstall={install}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -922,6 +922,14 @@ export interface ProviderStatus {
   authenticated: boolean | null
   /** The last real connectivity test on record, if any. `null` means never tested — not failed. */
   last_test: ProviderTestResult | null
+  /** The installer THIS platform will actually run, or null when there is nothing to install.
+   *
+   *  Prefer this over `LlmProviderMeta.installHint` whenever it is present. That hint is one
+   *  static string in a dashboard that ships to both macOS and Windows, so it cannot be
+   *  correct on both — it names the npm command, while Windows installs natively. Since the
+   *  hint is also the "run it yourself" fallback shown after a failed install, using it on
+   *  Windows told the user to run the one command that cannot work there. */
+  install_command: string | null
 }
 
 // ── install / sign-in outcome ───────────────────────────────────────────────


### PR DESCRIPTION
﻿## What

The provider **Install button does not work on Windows**. Clicking "Install Claude Code" or "Install Codex" reports:

> That didn't work: the installer finished but the CLI still isn't on your PATH - try running it in a terminal

and **nothing is installed at all** - `%APPDATA%\npm` stays empty and `npm ls -g` reports nothing. Reproduced on Windows 11, and traced to three separate defects, each of which hid the next.

Cursor is unaffected, which is why this went unnoticed - but only by accident, explained below.

## The three defects

### 1. `resolve_installer_binary` emitted POSIX shell text on every platform

It is not `#[cfg]`-split, unlike its neighbours `candidate_dirs` and `installer_command`. On Windows it built:

```
export PATH="C:\Program Files\nodejs:$PATH"; C:\Program Files\nodejs\npm.cmd i -g @anthropic-ai/claude-code
```

and handed it to `powershell -NoProfile -ExecutionPolicy Bypass -Command`. Running that exact string produces two `CommandNotFoundException`s:

- `export` is not a PowerShell command (`$env:PATH` is, entries are `;`-separated, and `$PATH` is undefined)
- the substituted absolute path is interpolated **unquoted and without the `&` call operator**, so `C:\Program Files\nodejs\npm.cmd` parses as the command `C:\Program`

npm is never reached.

**Fix:** a no-op on Windows. The premise - Finder/launchd PATH stripping - is macOS-only, and PowerShell resolves `npm` to `npm.cmd` itself via `PATHEXT`.

Note the doc claimed this rewrite was best-effort and "can only ever help, never break an install that already worked". On Windows that is false: *successful* resolution is precisely what breaks it. **Cursor escaped only because its Windows command starts with `$s`**, which resolves to nothing, so the rewrite never fired.

### 2. The failure reported itself as success

`installer_command` appended `; exit $LASTEXITCODE`. But `$LASTEXITCODE` is set **only by a native executable** - when the command dies before reaching one, it is `$null`, and `exit $null` exits **0**.

So `install_provider`'s `output.status.success()` passed, the branch that surfaces stderr was skipped, and the generic "isn't on your PATH" message was emitted instead. The user is sent to debug their PATH over what is really a broken install command, and the actual `CommandNotFoundException` sitting in stderr is discarded unread.

**Fix:** the epilogue now distinguishes three cases - a native exe ran (trust its code, unchanged), no native exe ran and a command name failed to resolve (`exit 127`), anything else (`0`).

It keys on `CommandNotFoundException` specifically rather than "`$Error` is non-empty" **on purpose**: Cursor's `iex`-ed installer is pure PowerShell, may never set `$LASTEXITCODE` at all, and can leave handled non-terminating errors in `$Error`. Failing on those would break an install that works today. There is a test for exactly that.

### 3. npm was the wrong channel on Windows regardless

`@anthropic-ai/claude-code` requires **node >=22**. On Windows, node typically sits on the **SYSTEM** PATH (`C:\Program Files\nodejs`), which always precedes the **User** PATH where a newer per-user node (winget, nvm) would live - so a stale node wins and the user cannot fix it without admin. On the repro machine this was node v16.13.1 from 2021, with an unreachable v24.18.1 sitting in the User PATH.

Both vendors ship **native, node-free Windows installers**, verified by reading the actual scripts:

| | installer | needs node? | lands in |
|---|---|---|---|
| Claude | `irm https://claude.ai/install.ps1 \| iex` | no | `~/.local/bin` (already a candidate dir) |
| Codex | `irm https://chatgpt.com/codex/install.ps1 \| iex` | no | `%LOCALAPPDATA%\Programs\OpenAI\Codex\bin` |

Claude's redirects to `downloads.claude.ai/claude-code-releases/bootstrap.ps1` and propagates exit codes properly (`exit 1` on arch/version/manifest failure, `exit $installExitCode` otherwise). Codex's redirects to `releases.openai.com/codex/install.ps1` and will even remove a conflicting npm/bun-managed Codex.

**Fix:** `install_command()` is now platform-split for Claude and Codex, following the shape `CURSOR_INSTALL_CMD` already established. **Unix keeps npm, unchanged.** As a bonus these commands start with `irm` - a PowerShell alias, not a file on PATH - so they are immune to defect 1 the same way Cursor is.

## Two couplings that would have reintroduced bugs

**`candidate_dirs` must cover the Codex bin dir.** Codex's installer writes the **User PATH**, which an already-running tray process cannot see. So the post-install probe can only find `codex.exe` via a candidate dir. Without that entry, a *perfectly successful* install reports itself as failed - the identical bug `%LOCALAPPDATA%\cursor-agent` was added there to prevent, per the comment already in that function. Added, with a test.

**The UI's `installHint` cannot be right on both platforms.** It is one static string in `ui/lib/llm-providers.ts`, compiled into a dashboard that ships to macOS and Windows alike, and it names the npm command. It also doubles as the "run this yourself" fallback shown *after* a failed install - so on Windows it told the user to run the exact command that cannot work there. `ProviderStatus` now carries `install_command`, the command this platform actually runs, and the detail view prefers it.

## Note on Copilot

`LlmProvider::Copilot` stays on npm. It has no native installer, and it is deliberately absent from `CHOOSER_PROVIDER_IDS`, so nothing in the UI can reach its install path today. Documented on `install_command` so the next person doesn't assume it was an oversight.

## Testing

- `installer_command_reports_an_unrunnable_command_as_failed` - feeds the **exact** old broken POSIX shape through the real shell, asserts exit 127 and that the cause reaches stderr
- `installer_command_tolerates_a_handled_powershell_error` - the Cursor-safety case; a handled non-terminating error must **not** fail the install
- `resolve_installer_binary_is_a_no_op_on_windows` - uses `cmd`, which always resolves, so it passes only because the fn is a no-op, not because resolution failed
- `candidate_dirs_covers_the_native_codex_install_dir`
- `windows_claude_and_codex_install_natively_without_npm`, `no_windows_install_command_uses_posix_shell_syntax`, `unix_claude_and_codex_install_via_npm`

The behavioural tests run the real PowerShell rather than string-matching the epilogue - a text match would pass just as happily for an epilogue PowerShell rejects.

Verified: `cargo fmt --check` clean; workspace `cargo clippy --all-targets -- -D warnings` exit 0; `llm::detect` 26/26; `bun test` 405/405; `next build` succeeds.

## Not fixed here (pre-existing, flagged)

- `meridian-core`'s `db_crypto::tests::finalize_swap_cleans_up_when_first_rename_fails` and `..._rolls_back_when_second_rename_fails` fail on Windows (`os error 5` / `os error 2`). Confirmed identical on clean `pre-main` with these changes stashed - they assume POSIX rename semantics. Out of scope, but they will block `cargo test` on any Windows dev box.
- `ui`'s `npm run build` needs node >=20.9, so it fails on a PATH node 16 - the same SYSTEM-vs-User PATH situation described in defect 3.

## Verification on macOS still needed

Every behavioural test above is `#[cfg(windows)]`, and I could only run the Unix paths' existing suite, not the macOS install flow end to end. The Unix side is unchanged by design (`install_command` still returns the same npm strings, pinned by `unix_claude_and_codex_install_via_npm`), but a macOS smoke test of the Install button before merge would be worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Correction (added after merge)

The "Not fixed here (pre-existing, flagged)" note above misdiagnosed the two
`db_crypto` failures. Correcting it for the record:

- **They do not "assume POSIX rename semantics", and they are not Windows-specific.**
  Commit `62776b96` renamed two error-context strings, and the assertions kept checking
  the old text - `move plaintext original aside` and `restored the plaintext original`,
  neither of which appears anywhere in the production code. That fails on every platform,
  not just Windows.
- **They were already fixed on `pre-main`** by `9d648d11`, which updated the assertions to
  `msg.contains("failed to move the original database aside")`. The local tree that
  produced the observation was 15 commits behind `pre-main`; the failures were never
  reachable from this PR's merge base, which is why CI was green on both Rust jobs.

The observation that the tests failed locally was accurate. The stated cause and the
claim that they "will block `cargo test` on any Windows dev box" were both wrong.

One local Windows failure is genuine but environmental, and worth recording:
`llm::cursor_cli::tests::build_sandbox_is_idempotent_and_neutralises_skill_dirs` fails on
a non-elevated Windows shell, because `link()` uses `std::os::windows::fs::symlink_*` and
Windows requires `SeCreateSymbolicLinkPrivilege` (administrator, or Developer Mode) to
create a symlink. `link()` swallows the error at `trace!` level, so `build_sandbox`
returns `Ok(())` having linked nothing and the assertion fails. GitHub's `windows-latest`
runners execute as administrator, so CI is unaffected - but a contributor on a normal
Windows account will see this fail and it is not their change that broke it.
