### PR TITLE
ci: [DOES NOT WORK] debuginfo cut had no measurable effect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,23 @@ env:
   # a restored cache and compiles once, so the incremental state is never read
   # back — only WRITTEN, inflating target/ and the cache tarball for no reuse.
   CARGO_INCREMENTAL: "0"
+  # Full debug info (the dev/test default, `debug = 2`) is the single most
+  # expensive thing these jobs do that nothing reads. It is emitted for every
+  # workspace crate and then linked into ~20 test binaries; on Windows that
+  # means generating a PDB per binary, and the `test` step there costs 19m
+  # against macOS's 8m for the same work.
+  #
+  # Nothing consumes it. CI never attaches a debugger and never opens a core
+  # dump - the only artefact anyone reads is the panic message and the test
+  # name, and `line-tables-only` keeps backtraces WITH file/line while dropping
+  # the type and variable descriptions that make up the bulk of the cost.
+  #
+  # CI-only on purpose: set here rather than as `[profile.dev]` in Cargo.toml so
+  # local builds keep full debug info for rust-analyzer and lldb. `test`
+  # inherits `dev`, but both are set explicitly - the inheritance is a cargo
+  # implementation detail and this is not the place to be clever.
+  CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
+  CARGO_PROFILE_TEST_DEBUG: "line-tables-only"
   CARGO_NET_RETRY: "3"
   # The tray pulls screenpipe-screen/-a11y from the PRIVATE Meridiona/
   # screenpipe-fork (a git dep). cargo RESOLVES it for the whole workspace, so


### PR DESCRIPTION
## Result: hypothesis falsified. Do not merge.

The theory was that full debug info (`debug = 2`) linked into ~20 test binaries - a PDB each on Windows - was why the `test` step costs 19m there against macOS's 8m. `line-tables-only` should have cut it.

**It changed nothing.**

| step | baseline (warm deps) | this run |
|---|---|---|
| Windows clippy | 808s | 889s |
| Windows **test** | **1186s** | **1193s** |
| macOS clippy | 297s | 479s |
| macOS **test** | **517s** | **520s** |

The `test` step is flat on both platforms. The clippy rise is a separate, expected artefact: changing a profile setting alters every crate's fingerprint, so `rust-cache` restored dependency artifacts that no longer matched and this run rebuilt **dependencies too** (note the cache step: 43s baseline -> 10s here, i.e. a miss). That extra work lands in the first cargo invocation, which is clippy.

So this run did strictly **more** work than the baseline and `test` still took the same time. Debug info is not the bottleneck.

The env var was verified to reach rustc, so this is not a misconfiguration:

```
default:  -C debuginfo=2
override: -C debuginfo=line-tables-only
```

The cost is codegen and linking of the workspace crates themselves - `meridian` is large, and `test` builds every target for real where `clippy` only checks.

## Closing rather than merging

The change is not free: it invalidates the whole dependency cache once, and it degrades backtraces, in exchange for a speedup that does not exist.

## What the data actually points at

`clippy` and `test` are **two separate compiles of the same workspace**, run sequentially in one job. Splitting them into parallel jobs makes wall-clock `max(clippy, test)` instead of the sum:

| | now (sum) | split (max) |
|---|---|---|
| Windows | 808 + 1186 = 33m | **~20m** |
| macOS | 297 + 517 = 14m | **~9m** |

That is arithmetic on measured numbers, not a hypothesis. The trade is runner minutes: four Rust jobs instead of two, and macOS minutes bill at 10x, Windows at 2x. That is a spend decision, so it is not being made unilaterally here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)