### PR TITLE
fix: address CodeRabbit findings from other recently-merged PRs on #658

### DIFF
--- a/src/db/repair/rebuild.rs
+++ b/src/db/repair/rebuild.rs
@@ -184,7 +184,20 @@ pub(super) async fn build_replacement(
 /// original as unchanged.
 fn ensure_checkpointed(tmp_path: &Path) -> Result<()> {
     let wal = std::path::PathBuf::from(format!("{}-wal", tmp_path.display()));
-    let held = std::fs::metadata(&wal).map(|m| m.len()).unwrap_or(0);
+    // A missing sidecar is the only case that actually means "no WAL held" -
+    // collapsing every stat error into that (the previous `unwrap_or(0)`) let
+    // a permissions problem or another transient I/O error masquerade as a
+    // clean checkpoint on the one check standing between a corrupt swap and a
+    // sound one. Anything other than "not found" fails loud instead.
+    let held = match std::fs::metadata(&wal) {
+        Ok(m) => m.len(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => 0,
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!("could not check for a write-ahead log at {}", wal.display())
+            })
+        }
+    };
     if held > 0 {
         anyhow::bail!(
             "the rebuilt database still has an un-checkpointed write-ahead log \

--- a/src/llm/runtime_health.rs
+++ b/src/llm/runtime_health.rs
@@ -141,10 +141,18 @@ fn clear_streak(id: &str) -> bool {
 pub fn record_success(provider: LlmProvider) {
     let id = provider.as_str().to_string();
     let was_failing = clear_streak(&id);
-    let stale_failure = matches!(
-        load().get(&id).map(|o| &o.outcome),
-        Some(ProviderTestOutcome::Failed { .. }) | Some(ProviderTestOutcome::RateLimited { .. })
-    );
+    // Short-circuited on purpose: `load()` reads and parses the whole record from disk, and
+    // this function runs on EVERY successful call - the common, healthy-provider path. When
+    // the in-memory streak was already non-zero we already know a recovery must be persisted
+    // and don't need the disk to tell us so; the read is only for the one case the streak
+    // can't see - a stale ON-DISK failure/rate-limit with a clean in-memory streak (e.g. right
+    // after a daemon restart, or a rate-limit that doesn't touch the streak).
+    let stale_failure = !was_failing
+        && matches!(
+            load().get(&id).map(|o| &o.outcome),
+            Some(ProviderTestOutcome::Failed { .. })
+                | Some(ProviderTestOutcome::RateLimited { .. })
+        );
     if !was_failing && !stale_failure {
         return;
     }
@@ -254,9 +262,14 @@ pub fn most_recent_outcome(
             t_out.clone()
         }),
         (Some((_, out)), None) | (None, Some((_, out))) => Some(out.clone()),
-        // No usable timestamp anywhere: fall back to the test result's outcome if there is
-        // one at all, so a pre-existing cache with an odd timestamp still counts.
-        (None, None) => last_test.map(|t| t.outcome.clone()),
+        // No usable timestamp on either side that survived to here: fall back to whichever
+        // input actually exists, preferring the test result for consistency with the
+        // tie-break above. Falling all the way to `None` would silently drop a real runtime
+        // observation whenever it is the ONLY input and its timestamp happens to be garbage -
+        // there is no test to lose to, so it should still count.
+        (None, None) => last_test
+            .map(|t| t.outcome.clone())
+            .or_else(|| last_runtime.map(|o| o.outcome.clone())),
     }
 }
 
@@ -367,6 +380,25 @@ mod tests {
         );
         assert!(matches!(
             most_recent_outcome(Some(&test), None),
+            Some(ProviderTestOutcome::Failed { .. })
+        ));
+    }
+
+    /// The mirror of the above and its own bug: a runtime observation with an unparseable
+    /// timestamp and NO competing test result must still report its outcome, not `None`. The
+    /// `(None, None)` match arm used to only ever fall back to `last_test`, silently dropping
+    /// the one input that actually exists whenever it was the runtime side that had the bad
+    /// timestamp.
+    #[test]
+    fn an_unparseable_runtime_timestamp_falls_back_to_the_runtime_outcome() {
+        let runtime = observation(
+            ProviderTestOutcome::Failed {
+                message: "boom".into(),
+            },
+            "not-a-timestamp".into(),
+        );
+        assert!(matches!(
+            most_recent_outcome(None, Some(&runtime)),
             Some(ProviderTestOutcome::Failed { .. })
         ));
     }

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -513,13 +513,21 @@ pub fn run() {
                     // as it was before this span grew a wrapper): the capture
                     // feature is the only later consumer, but the clone itself is
                     // cheap and every build needs a value to return.
+                    let capture_pool = db_pool.clone();
+                    // The encryption-state notice below needs a pool handle before
+                    // db_pool is moved into managed state.
+                    let encryption_notice_pool = db_pool.clone();
+                    app.manage(db_pool);
+
                     // Report the repair now that there is a pool to write a notice
                     // with. Deliberately after `app.manage`: the notice is the
                     // only trace the user sees of an operation that happened
                     // before the window existed, but it must never be able to
-                    // cost them the pool itself.
+                    // cost them the pool itself — so this reads `capture_pool`,
+                    // never the `db_pool` that was just moved above, and the
+                    // pool is already managed by the time this block runs at all.
                     if let Some(outcome) = repair_outcome {
-                        if let Some(p) = db_pool.clone() {
+                        if let Some(p) = capture_pool.clone() {
                             // Own the strings before the task takes them: the
                             // notice borrows its fields, and `outcome` cannot
                             // outlive this scope.
@@ -555,12 +563,6 @@ pub fn run() {
                             });
                         }
                     }
-
-                    let capture_pool = db_pool.clone();
-                    // The encryption-state notice below needs a pool handle before
-                    // db_pool is moved into managed state.
-                    let encryption_notice_pool = db_pool.clone();
-                    app.manage(db_pool);
 
                     // Encryption was intended (a key was resolved) but the on-disk DB is
                     // still plaintext ⇒ encrypt_in_place didn't complete (on Windows the


### PR DESCRIPTION
## Summary

While confirming PR #658 (`pre-main → main`) was ready to merge, CodeRabbit's latest review pass on it surfaced 4 genuinely new, unaddressed findings — on code that landed via other recent PRs (#659 `feat/db-repair-from-tray`, #662 `fix/provider-health-runtime-signal`), not the corruption-recovery work #661 already fixed. This PR closes those.

(Separately: that same review round also re-flagged 7 items as "raised previously and remains unaddressed" — those are stale. The review ran at 18:57 UTC, 8 minutes before #661 actually merged at 19:05 UTC. I verified all 7 directly against current `pre-main` and they're already fixed.)

### Fixed

- **`tray/src-tauri/src/lib.rs`**: the repair-outcome notice block ran *before* `app.manage(db_pool)`, contradicting the comment's claim that it runs after specifically so a failure there "must never be able to cost them the pool itself." Reordered so `app.manage` happens first; the notice block now reads `capture_pool` (already cloned) instead of the `db_pool` that gets moved into `app.manage`.
- **`src/db/repair/rebuild.rs`**: `ensure_checkpointed` collapsed every `stat` error on the `-wal` sidecar into "0 bytes held" via `unwrap_or(0)` — so a permissions problem or other I/O error would masquerade as a clean checkpoint on the one check standing between a corrupt swap and a sound one. Now only a `NotFound` error means "no WAL"; anything else fails loud with context.
- **`src/llm/runtime_health.rs`**: `record_success()` read and parsed the whole runtime-health JSON file from disk on *every* successful LLM call — the common, healthy-provider path — even though the read is only needed to catch a stale on-disk failure when the in-memory streak is already clean. Short-circuited so the disk read only happens when it can actually change the outcome; behaviorally identical, just skips the wasted I/O on the hot path.
- **`src/llm/runtime_health.rs`**: `most_recent_outcome()`'s `(None, None)` arm only ever fell back to the test result's outcome, so a runtime observation with an unparseable timestamp and *no* competing test silently returned `None` instead of the observation's own outcome. Added the missing fallback, plus a regression test (`an_unparseable_runtime_timestamp_falls_back_to_the_runtime_outcome`).

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean on both the root workspace and the `tray/src-tauri` workspace
- [x] `cargo test` — 866 passed in the daemon crate (up 1 for the new regression test), 271 in `meridian-core`, 197 in `meridian-tray` — 0 failures
- [x] Full `pre-push` hook suite (fmt + clippy + UI build + UI tests + `cargo test` + security audit) passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)