### PR TITLE
fix(hooks): fail fast with instructions when the tray bundle resource is missing

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -31,6 +31,60 @@ echo ""
 echo "=== pre-push checks ==="
 echo ""
 
+# ── Preflight: the tray's bundle resource must exist ────────────────────────
+#
+# `tray/src-tauri/tauri.conf.json` declares the daemon binary under
+# `bundle.resources`, and `tauri-build` (the tray's build.rs) STATS every
+# declared resource whenever the tray compiles - including a mere `clippy` or
+# `test`, which never read the file. A missing one fails the build with
+# "resource path `../../target/release/meridian` doesn't exist".
+#
+# This only started biting locally when the hook moved to `--workspace`: before
+# that, bare cargo never compiled the tray at all, so a fresh clone could push
+# without ever producing this file.
+#
+# Checked FIRST, before any wave, because the alternative is discovering it
+# several minutes into clippy.
+#
+# Deliberately fails rather than creating the placeholder itself. CI can stub it
+# safely because CI never packages, but a stub on a developer machine is a live
+# footgun: `tauri build` bundles whatever sits at that path, so a forgotten
+# 0-byte file ships a `.app` whose daemon is an empty file. Making that an
+# explicit, informed choice keeps the real binary the default answer.
+require_tray_bundle_resource() {
+  local bin="target/release/meridian"
+  case "$(uname -s)" in
+    MINGW* | MSYS* | CYGWIN*) bin="target/release/meridian.exe" ;;
+  esac
+  [[ -e "$REPO_ROOT/$bin" ]] && return 0
+
+  cat >&2 <<EOF
+  ✗ tray bundle resource missing: $bin
+
+    The tray declares this in tauri.conf.json's bundle.resources, and
+    tauri-build stats it whenever the tray compiles - which the workspace-wide
+    clippy and test below both do. Without it they fail with:
+
+        resource path \`../../$bin\` doesn't exist
+
+    Build the real daemon (what a packaged build actually needs):
+
+        cargo build --release -p meridian --bin meridian
+
+    Or, if you only intend to lint and test, an empty placeholder is enough:
+
+        mkdir -p target/release && : > $bin
+
+    WARNING on the placeholder: \`tauri build\` bundles whatever is at that
+    path. Leave a 0-byte file there and you will package a .app whose daemon is
+    an empty file, with no error. Build the real binary before packaging.
+
+EOF
+  return 1
+}
+
+require_tray_bundle_resource || exit 1
+
 # ── Wave 1: fmt + UI build (fully independent, run in parallel) ─────────────
 echo "[wave 1/3] cargo fmt --check  +  ui build"
 


### PR DESCRIPTION
## The problem

Since the pre-push hook moved to `--workspace` (#660) it compiles the tray, and `tauri-build` **stats** every path in `tauri.conf.json`'s `bundle.resources` even for a clippy or test build that never reads them.

A fresh clone or `git worktree` has never produced `target/release/meridian`, so the first push dies **several minutes into clippy** with:

```
resource path `../../target/release/meridian` doesn't exist
```

That says nothing about what to do, and arrives long after the wait began. Before `--workspace`, bare cargo never compiled the tray, so this could not happen outside CI.

## The fix

A preflight before wave 1 - the whole point is failing in milliseconds rather than minutes - naming both ways out:

```
  ✗ tray bundle resource missing: target/release/meridian

    Build the real daemon (what a packaged build actually needs):
        cargo build --release -p meridian --bin meridian

    Or, if you only intend to lint and test, an empty placeholder is enough:
        mkdir -p target/release && : > target/release/meridian

    WARNING on the placeholder: `tauri build` bundles whatever is at that
    path. Leave a 0-byte file there and you will package a .app whose daemon is
    an empty file, with no error. Build the real binary before packaging.
```

**It deliberately does not create the placeholder itself.** CI can stub it safely because CI never packages; on a developer machine it is a live footgun, since `tauri build` bundles whatever sits at that path. A forgotten 0-byte file packages a `.app` whose daemon is an empty file, silently. Keeping it an explicit, informed choice keeps the real binary as the default answer, rather than planting a stub on every machine that nobody knows is there.

Resolves the Windows name too (`meridian.exe`, per `tauri.windows.conf.json`), since the hook runs under Git Bash there.

## Verified

Ran the hook the way git runs it (cwd at the worktree root, push info on stdin), both ways:

- resource missing -> exits 1 with the guidance above, before wave 1
- resource present -> proceeds into wave 1 normally

## Unrelated finding worth knowing

While testing this I found `core.hooksPath` on my machine had drifted to an **absolute** path into the main checkout, so **every worktree was running the main checkout's hooks at whatever branch that checkout happened to be on** - which is why a push from a worktree ran a pre-#660 hook with no `--workspace` at all.

`scripts/setup-hooks.sh` sets it **relative** (`git config core.hooksPath .githooks`), which git resolves per-worktree, so the script is right and only the local config had drifted. Fixed locally by re-running what the script prescribes; no repo change needed. Flagging it because the symptom is silent: hooks appear to pass while running a different version than the branch you are on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)