### PR TITLE
fix: address the fresh CodeRabbit review's findings on PR #658

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -56,7 +56,7 @@ require_tray_bundle_resource() {
   case "$(uname -s)" in
     MINGW* | MSYS* | CYGWIN*) bin="target/release/meridian.exe" ;;
   esac
-  [[ -e "$REPO_ROOT/$bin" ]] && return 0
+  [[ -f "$REPO_ROOT/$bin" ]] && return 0
 
   cat >&2 <<EOF
   ✗ tray bundle resource missing: $bin

--- a/meridian-core/src/db_crypto.rs
+++ b/meridian-core/src/db_crypto.rs
@@ -461,9 +461,29 @@ pub fn swap_database_file(
              (is meridian.db still open by the daemon or the tray?)"
         ));
     }
-    for suffix in ["-wal", "-shm"] {
-        let sidecar = std::path::PathBuf::from(format!("{}{}", path.display(), suffix));
-        let _ = std::fs::remove_file(sidecar); // checkpointed to empty; safe to drop
+    // The original's WAL is safe to drop ONLY when it has already been checkpointed to
+    // empty - true for `encrypt_in_place` (it checkpoints before ever calling this
+    // function), but NOT for `db repair`: that caller reads a damaged source through
+    // `ATTACH` and never checkpoints it, so a non-empty WAL there still holds committed
+    // rows the main file doesn't have yet. Deleting it would make the preserved "damaged
+    // original" backup - the one copy of what a repair couldn't salvage - WORSE than the
+    // live database was. Move each sidecar to sit beside `backup_path` under the same base
+    // name instead, so opening `backup_path` later still finds - and can recover - whatever
+    // the WAL held. A missing sidecar (the common, already-checkpointed case) is not an
+    // error.
+    let sidecar_paths: Vec<(std::path::PathBuf, std::path::PathBuf)> = ["-wal", "-shm"]
+        .iter()
+        .map(|suffix| {
+            (
+                std::path::PathBuf::from(format!("{}{}", path.display(), suffix)),
+                std::path::PathBuf::from(format!("{}{}", backup_path.display(), suffix)),
+            )
+        })
+        .collect();
+    for (sidecar, kept) in &sidecar_paths {
+        if sidecar.exists() {
+            let _ = std::fs::rename(sidecar, kept);
+        }
     }
     if let Err(e) = rename_with_retry(tmp_path, path, RENAME_ATTEMPTS_EXPENSIVE) {
         // `path` was already moved to `backup_path` above; put it back so we
@@ -471,6 +491,15 @@ pub fn swap_database_file(
         match rename_with_retry(backup_path, path, RENAME_ATTEMPTS_EXPENSIVE) {
             Ok(()) => {
                 let _ = std::fs::remove_file(tmp_path);
+                // The sidecars moved beside `backup_path` above belong with the main
+                // file wherever it ends up - move them back so the restored original
+                // is exactly as it was before this swap was attempted, not just the
+                // same bytes with its WAL stranded under the backup's name.
+                for (sidecar, kept) in &sidecar_paths {
+                    if kept.exists() {
+                        let _ = std::fs::rename(kept, sidecar);
+                    }
+                }
                 tracing::error!(
                     error = %e,
                     stage = "move_replacement_into_place",
@@ -1096,6 +1125,62 @@ mod tests {
             "plaintext backup preserved"
         );
         assert!(!tmp.exists(), "tmp consumed by the rename");
+    }
+
+    /// The bug this guards: `db repair`'s source is never checkpointed (unlike
+    /// `encrypt_in_place`'s), so a non-empty `-wal` on the original can hold committed rows
+    /// the main file doesn't have yet. It must be preserved, not deleted, and it must end up
+    /// alongside `backup_path` under the SAME base name so opening the backup later still
+    /// finds it.
+    #[test]
+    fn finalize_swap_preserves_a_non_empty_wal_beside_the_backup() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("meridian.db");
+        let tmp = dir.path().join("meridian.db.rebuilding-tmp");
+        let backup = dir.path().join("meridian.db.corrupt-backup-x");
+
+        std::fs::write(&path, b"DAMAGED-ORIGINAL").unwrap();
+        std::fs::write(format!("{}-wal", path.display()), b"UNCHECKPOINTED-ROWS").unwrap();
+        std::fs::write(&tmp, b"REBUILT-REPLACEMENT").unwrap();
+
+        swap_database_file(&path, &tmp, &backup, "db repair").unwrap();
+
+        assert!(
+            !std::path::PathBuf::from(format!("{}-wal", path.display())).exists(),
+            "the replacement's own directory must not inherit the original's stale WAL"
+        );
+        assert_eq!(
+            std::fs::read(format!("{}-wal", backup.display())).unwrap(),
+            b"UNCHECKPOINTED-ROWS",
+            "the WAL must survive beside the backup, not be deleted"
+        );
+    }
+
+    /// The rollback mirror of the above: if the swap has to restore the original, its WAL
+    /// (parked beside the backup name during the swap) must move back with it - otherwise a
+    /// human who removed the "damaged" backup after a successful-looking repair would also
+    /// discard rows the rollback was supposed to have kept intact.
+    #[test]
+    fn finalize_swap_restores_the_wal_alongside_the_original_on_rollback() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("meridian.db");
+        let backup = dir.path().join("meridian.db.corrupt-backup-x");
+        let tmp = dir.path().join("does-not-exist.tmp"); // rename(tmp, path) → ENOENT
+
+        std::fs::write(&path, b"DAMAGED-ORIGINAL").unwrap();
+        std::fs::write(format!("{}-wal", path.display()), b"UNCHECKPOINTED-ROWS").unwrap();
+
+        swap_database_file(&path, &tmp, &backup, "db repair").unwrap_err();
+
+        assert_eq!(
+            std::fs::read(format!("{}-wal", path.display())).unwrap(),
+            b"UNCHECKPOINTED-ROWS",
+            "the WAL must be restored alongside the rolled-back original"
+        );
+        assert!(
+            !std::path::PathBuf::from(format!("{}-wal", backup.display())).exists(),
+            "the WAL must not be left stranded under the (rolled-back) backup name"
+        );
     }
 
     #[test]

--- a/src/llm/runtime_health.rs
+++ b/src/llm/runtime_health.rs
@@ -93,12 +93,32 @@ fn record_path() -> PathBuf {
 
 /// Read the whole record. A missing/corrupt/foreign-format file degrades to "nothing
 /// observed" rather than failing the banner — the next call repopulates it.
+///
+/// ALWAYS a real disk read, deliberately: this file has exactly one writer per install (this
+/// process's own [`persist`] calls), but it has readers in TWO processes (see the module
+/// header - the daemon writes, the tray's `in_use_provider_health` reads via [`latest_for`]),
+/// and a tray-side cache with no invalidation would go stale forever after its first read,
+/// since the tray never calls `persist` to refresh one. [`record_success`]'s hot path uses
+/// [`RECORD_MIRROR`] instead of this function precisely so that a daemon-only optimisation
+/// can't leak into the cross-process reader.
 fn load() -> HashMap<String, RuntimeObservation> {
     let Ok(raw) = std::fs::read_to_string(record_path()) else {
         return HashMap::new();
     };
     serde_json::from_str(&raw).unwrap_or_default()
 }
+
+/// This process's own mirror of the record, lazily populated by [`record_success`]'s first
+/// call and kept in sync by every successful [`persist`] afterward.
+///
+/// Consulting this instead of a fresh [`load()`] is safe ONLY because this file has exactly
+/// one writer for the life of the process holding it - this process itself, via `persist`
+/// (called solely from `record_success`/`record_failure`, both daemon-only per the module
+/// header). A single-instance daemon guard (`main.rs`) rules out a second writer racing this
+/// one, so nothing outside this process can change the file between the lazy read and the
+/// next `persist`. It is deliberately NOT used by [`load()`]/[`latest_for`] - see that
+/// function's doc for why a reader shared with the tray must not cache this way.
+static RECORD_MIRROR: Mutex<Option<HashMap<String, RuntimeObservation>>> = Mutex::new(None);
 
 /// Serialises the read-modify-write below. Concurrent pipeline stages (the hourly report and
 /// the workstream fold can overlap across hours) would otherwise lose each other's entries —
@@ -111,8 +131,13 @@ fn persist(observation: RuntimeObservation) {
     let _guard = WRITE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let mut all = load();
     all.insert(observation.id.clone(), observation);
-    if let Err(e) = meridian_core::fs_utils::atomic_write_json(&record_path(), &all) {
-        tracing::warn!(error = %e, "failed to persist runtime provider health");
+    match meridian_core::fs_utils::atomic_write_json(&record_path(), &all) {
+        Ok(()) => {
+            *RECORD_MIRROR.lock().unwrap_or_else(|e| e.into_inner()) = Some(all);
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to persist runtime provider health");
+        }
     }
 }
 
@@ -132,6 +157,22 @@ fn clear_streak(id: &str) -> bool {
     map.insert(id.to_string(), 0).unwrap_or(0) > 0
 }
 
+/// True when `mirror` (populated via `loader` if empty) records `id` as `Failed` or
+/// `RateLimited`. Pulled out of [`record_success`] as a pure function of its inputs so the
+/// "populate once, then never call `loader` again" contract - the whole point of
+/// [`RECORD_MIRROR`] - is unit-testable without a real file or the global statics.
+fn has_unresolved_failure(
+    id: &str,
+    mirror: &mut Option<HashMap<String, RuntimeObservation>>,
+    loader: impl FnOnce() -> HashMap<String, RuntimeObservation>,
+) -> bool {
+    let map = mirror.get_or_insert_with(loader);
+    matches!(
+        map.get(id).map(|o| &o.outcome),
+        Some(ProviderTestOutcome::Failed { .. }) | Some(ProviderTestOutcome::RateLimited { .. })
+    )
+}
+
 /// Record that `provider` answered a real call.
 ///
 /// Clears the failure streak and stamps an `Ok` observation, so a recovered provider drops
@@ -141,18 +182,17 @@ fn clear_streak(id: &str) -> bool {
 pub fn record_success(provider: LlmProvider) {
     let id = provider.as_str().to_string();
     let was_failing = clear_streak(&id);
-    // Short-circuited on purpose: `load()` reads and parses the whole record from disk, and
-    // this function runs on EVERY successful call - the common, healthy-provider path. When
-    // the in-memory streak was already non-zero we already know a recovery must be persisted
-    // and don't need the disk to tell us so; the read is only for the one case the streak
-    // can't see - a stale ON-DISK failure/rate-limit with a clean in-memory streak (e.g. right
-    // after a daemon restart, or a rate-limit that doesn't touch the streak).
-    let stale_failure = !was_failing
-        && matches!(
-            load().get(&id).map(|o| &o.outcome),
-            Some(ProviderTestOutcome::Failed { .. })
-                | Some(ProviderTestOutcome::RateLimited { .. })
-        );
+    // Reads [`RECORD_MIRROR`], not a fresh `load()`: this function runs on EVERY successful
+    // call - the common, healthy-provider path - and a real disk read+parse there on every
+    // single call was the actual hot-path cost (a `was_failing`-only short circuit still hit
+    // disk every time for an already-healthy provider, which is the overwhelmingly common
+    // case). The mirror costs at most one real read per process, on whichever call happens
+    // to run first, and stays accurate afterward because `persist` is this file's only writer
+    // and updates the mirror in lockstep with the disk.
+    let stale_failure = !was_failing && {
+        let mut guard = RECORD_MIRROR.lock().unwrap_or_else(|e| e.into_inner());
+        has_unresolved_failure(&id, &mut guard, load)
+    };
     if !was_failing && !stale_failure {
         return;
     }
@@ -248,6 +288,13 @@ pub fn most_recent_outcome(
             .map(|t| t.with_timezone(&chrono::Utc))
     };
 
+    // Tracked separately from `runtime` below so the `(None, None)` fallback can tell WHY
+    // there's nothing to compare against. `runtime` collapses "garbage timestamp" and
+    // "parsed fine but past `OBSERVATION_MAX_AGE_HOURS`" into the same `None` - conflating
+    // them in the fallback would resurrect an expired observation just because no test
+    // exists to out-rank it, defeating the whole point of the expiry.
+    let runtime_timestamp_unparseable =
+        last_runtime.is_some_and(|o| parse(&o.observed_at).is_none());
     let runtime = last_runtime.and_then(|o| {
         let at = parse(&o.observed_at)?;
         let age = now.signed_duration_since(at);
@@ -262,14 +309,15 @@ pub fn most_recent_outcome(
             t_out.clone()
         }),
         (Some((_, out)), None) | (None, Some((_, out))) => Some(out.clone()),
-        // No usable timestamp on either side that survived to here: fall back to whichever
-        // input actually exists, preferring the test result for consistency with the
-        // tie-break above. Falling all the way to `None` would silently drop a real runtime
-        // observation whenever it is the ONLY input and its timestamp happens to be garbage -
-        // there is no test to lose to, so it should still count.
-        (None, None) => last_test
-            .map(|t| t.outcome.clone())
-            .or_else(|| last_runtime.map(|o| o.outcome.clone())),
+        // No usable timestamp on either side that survived to here: fall back to the test
+        // result first (consistent with the tie-break above), then to the runtime
+        // observation but ONLY when its timestamp was genuinely unparseable - never when it
+        // simply expired, which must stay dropped.
+        (None, None) => last_test.map(|t| t.outcome.clone()).or_else(|| {
+            runtime_timestamp_unparseable
+                .then(|| last_runtime.map(|o| o.outcome.clone()))
+                .flatten()
+        }),
     }
 }
 
@@ -401,6 +449,73 @@ mod tests {
             most_recent_outcome(None, Some(&runtime)),
             Some(ProviderTestOutcome::Failed { .. })
         ));
+    }
+
+    /// The regression the fix above almost introduced: an EXPIRED runtime observation (a
+    /// parseable timestamp older than `OBSERVATION_MAX_AGE_HOURS`) must stay dropped even
+    /// with no competing test - the `(None, None)` fallback must not resurrect it just
+    /// because there's nothing to lose to. Only a genuinely unparseable timestamp should
+    /// fall back to the observation's outcome.
+    #[test]
+    fn an_expired_runtime_observation_is_not_resurrected_by_the_fallback() {
+        let runtime = observation(
+            ProviderTestOutcome::Failed {
+                message: "long gone".into(),
+            },
+            ago(OBSERVATION_MAX_AGE_HOURS + 1),
+        );
+        assert!(most_recent_outcome(None, Some(&runtime)).is_none());
+    }
+
+    /// An empty mirror populates itself from the loader and reports what the loader gave it.
+    #[test]
+    fn unresolved_failure_check_populates_an_empty_mirror_from_the_loader() {
+        let mut mirror = None;
+        let loaded = HashMap::from([(
+            "claude".to_string(),
+            observation(
+                ProviderTestOutcome::Failed {
+                    message: "boom".into(),
+                },
+                "irrelevant".into(),
+            ),
+        )]);
+        assert!(has_unresolved_failure("claude", &mut mirror, || loaded.clone()));
+        assert!(mirror.is_some(), "the loader's result must be cached");
+    }
+
+    /// The whole point of the mirror: once populated, the loader must never run again, even
+    /// if what it WOULD return has since diverged (simulating the file changing on disk after
+    /// the mirror was filled - which, per the module's safety argument, cannot happen from
+    /// another process, but must also not spuriously re-trigger from this one).
+    #[test]
+    fn unresolved_failure_check_never_calls_the_loader_once_populated() {
+        let mut mirror = Some(HashMap::from([(
+            "claude".to_string(),
+            observation(ProviderTestOutcome::Ok, "irrelevant".into()),
+        )]));
+        let result = has_unresolved_failure("claude", &mut mirror, || {
+            panic!("loader must not run when the mirror is already populated")
+        });
+        assert!(!result, "a healthy cached entry must not read as a failure");
+    }
+
+    /// A rate limit counts as unresolved too - `record_success` must clear it just like a
+    /// hard failure.
+    #[test]
+    fn unresolved_failure_check_counts_a_rate_limit() {
+        let mut mirror = Some(HashMap::from([(
+            "claude".to_string(),
+            observation(
+                ProviderTestOutcome::RateLimited {
+                    message: "quota".into(),
+                },
+                "irrelevant".into(),
+            ),
+        )]));
+        assert!(has_unresolved_failure("claude", &mut mirror, || {
+            panic!("mirror already populated")
+        }));
     }
 
     /// The debounce: a transient must not raise the banner, and the streak must survive

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use meridian::etl::run_etl;
 use meridian::intelligence::{run_pm_force_sync, run_pm_sync};
 use meridian::observability;
 use tokio::sync::Notify;
+use tracing::Instrument;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -1142,39 +1143,46 @@ async fn main() -> Result<()> {
     {
         let meridian = meridian.clone();
         let db_corrupt = db_corrupt.clone();
-        tokio::spawn(async move {
-            match meridian::db::integrity::quick_check(&meridian, 20).await {
-                Ok(problems) if problems.is_empty() => {}
-                Ok(problems) => {
-                    tracing::error!(
-                        problem_count = problems.len(),
-                        first = %problems.first().map(String::as_str).unwrap_or_default(),
-                        "meridian.db failed its integrity check at startup — the ETL will not run until it is repaired"
-                    );
-                    let _ = meridian::notices::raise_typed(
-                        &meridian,
-                        meridian::notices::Notice {
-                            id: DB_CORRUPT_NOTICE,
-                            severity: "error",
-                            title: "Meridian's database is damaged",
-                            detail: &problems.join("; "),
-                            remedy: Some(
-                                "Pause tracking, quit Meridian, then run 'meridian db repair' in a terminal",
-                            ),
-                            event_key: DB_CORRUPT_NOTICE,
-                            deep_link: Some("/logs"),
-                        },
-                    )
-                    .await;
-                    db_corrupt.store(true, std::sync::atomic::Ordering::Relaxed);
-                }
-                // The check itself failing is not evidence either way — carry on and
-                // let the ETL's own error path classify it.
-                Err(e) => {
-                    tracing::warn!(error = %e, "startup integrity check could not run");
+        // Wrapped in its own span rather than relying on the startup_tick span below: this
+        // task is detached (spawned, not awaited) and can still be running once that span
+        // has closed, so nesting under it would attribute the check's duration/failure to a
+        // span that may already have ended.
+        tokio::spawn(
+            async move {
+                match meridian::db::integrity::quick_check(&meridian, 20).await {
+                    Ok(problems) if problems.is_empty() => {}
+                    Ok(problems) => {
+                        tracing::error!(
+                            problem_count = problems.len(),
+                            first = %problems.first().map(String::as_str).unwrap_or_default(),
+                            "meridian.db failed its integrity check at startup — the ETL will not run until it is repaired"
+                        );
+                        let _ = meridian::notices::raise_typed(
+                            &meridian,
+                            meridian::notices::Notice {
+                                id: DB_CORRUPT_NOTICE,
+                                severity: "error",
+                                title: "Meridian's database is damaged",
+                                detail: &problems.join("; "),
+                                remedy: Some(
+                                    "Pause tracking, quit Meridian, then run 'meridian db repair' in a terminal",
+                                ),
+                                event_key: DB_CORRUPT_NOTICE,
+                                deep_link: Some("/logs"),
+                            },
+                        )
+                        .await;
+                        db_corrupt.store(true, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    // The check itself failing is not evidence either way — carry on and
+                    // let the ETL's own error path classify it.
+                    Err(e) => {
+                        tracing::warn!(error = %e, "startup integrity check could not run");
+                    }
                 }
             }
-        });
+            .instrument(tracing::info_span!("startup_db_integrity_check")),
+        );
     }
 
     // 7c. Run ETL once immediately before entering the loop.

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -543,7 +543,22 @@ pub fn run() {
                                 if repaired {
                                     // The fault is gone; drop the banner that
                                     // sent the user here in the first place.
-                                    let _ = meridian::notices::clear(&p, "db.corrupt").await;
+                                    //
+                                    // `clear_typed`, NOT the plain `clear` (which
+                                    // hardcodes `event_key = "system.fault"`): the
+                                    // daemon raised this with `event_key:
+                                    // "db.corrupt"` (see `DB_CORRUPT_NOTICE` in
+                                    // `src/main.rs`), and `notices::raise_typed`
+                                    // dedupes its OS toast on `<event_key>:<id>`.
+                                    // Clearing with the wrong event_key deletes the
+                                    // banner row (that DELETE matches by id alone)
+                                    // but retracts the wrong toast dedup key, so a
+                                    // future corruption would silently never toast
+                                    // again — deduped against a delivery that was
+                                    // never actually retracted.
+                                    let _ =
+                                        meridian::notices::clear_typed(&p, "db.corrupt", "db.corrupt")
+                                            .await;
                                 }
                                 let _ = meridian::notices::raise_typed(
                                     &p,


### PR DESCRIPTION
## Summary

Requested a fresh `@coderabbitai full review` on #658 after #665 merged, to get an authoritative read on whether everything raised so far was actually resolved. It found one **regression in my own prior fix**, one **incomplete prior fix**, and **two new findings on shared code**. Fixes all of them here.

### Fixed

- **`src/llm/runtime_health.rs` — regression in my own #665 fix.** `most_recent_outcome()`'s `(None, None)` fallback used the raw `last_runtime` input, which resurrected an EXPIRED-but-parseable observation the age gate (`OBSERVATION_MAX_AGE_HOURS`) had deliberately excluded. Now only a genuinely unparseable timestamp falls back to the observation's outcome; added `an_expired_runtime_observation_is_not_resurrected_by_the_fallback` to pin it.
- **`src/llm/runtime_health.rs` — my earlier "fix" was incomplete.** The `!was_failing` short-circuit I added in #665 only skipped the disk read in the rare "just recovered from a streak" case. The actual hot path — a perpetually-healthy provider — has `was_failing == false` on every call too, so it kept hitting disk every single time, which was the real complaint. Added a process-local mirror (`RECORD_MIRROR`), populated once and kept in sync by every successful `persist()`, used only by `record_success` (daemon-only). `load()`/`latest_for()` — read cross-process by the tray — stay uncached on purpose: a tray-side cache would go stale forever since the tray never calls `persist()` to refresh it. Extracted the mirror-or-populate logic into `has_unresolved_failure` so it's unit-testable without real files or the global statics (3 new tests).
- **`meridian-core/src/db_crypto.rs` — new, Major, data-integrity.** `swap_database_file` deleted the original's `-wal`/`-shm` sidecars on the assumption they were "checkpointed to empty." True for `encrypt_in_place` (it checkpoints before calling this). **Not true for `db repair`**, which reads a damaged source through `ATTACH` and never checkpoints it — a non-empty WAL there holds committed rows the preserved "damaged original" backup would otherwise silently lose, making the backup worse than the live corrupt file was. Now moves the sidecars beside `backup_path` (same base name, so opening the backup later still finds them) instead of deleting them, and moves them back on rollback. Two new tests pin both directions.
- **`tray/src-tauri/src/lib.rs` — new, Major.** The repair-outcome notice block cleared `"db.corrupt"` via the plain `notices::clear`, which hardcodes `event_key = "system.fault"` — not the `"db.corrupt"` event_key the daemon actually raised it with (`DB_CORRUPT_NOTICE` in `src/main.rs`). The notice row still deleted fine (matched by id alone), but the OS toast's dedup key (`<event_key>:<id>`) never got retracted, so a *future* corruption could silently never toast again — deduped against a delivery that was never actually cleared. Switched to `clear_typed` with the matching event_key.
- **`.githooks/pre-push` — trivial.** The daemon-resource preflight used `-e` (any path type) instead of `-f` (regular file only).
- **`src/main.rs` — trivial.** Wrapped the backgrounded startup integrity check (from #661) in its own span, since it's detached and can outlive the `startup_tick` span it would otherwise silently run outside of.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean on both the root workspace and `tray/src-tauri`
- [x] `cargo test` — 870 passed in the daemon crate, 273 in `meridian-core` (+2 new sidecar tests), 197 in `meridian-tray` — 0 failures
- [x] `bash -n .githooks/pre-push` — syntax check on the shell hook
- [x] Full `pre-push` hook suite (fmt + clippy + UI build + UI tests + `cargo test` + security audit) passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)