### PR TITLE
test(llm): cover the reported install command on both CI platforms

### DIFF
--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -1860,6 +1860,46 @@ mod tests {
         );
     }
 
+    /// `ProviderStatus` must report the installer THIS build will actually run, for every
+    /// provider that has one. The frontend renders this instead of its own static
+    /// `installHint`, which is a single string compiled for both platforms and therefore
+    /// wrong on one of them — and which doubles as the "run it yourself" fallback after a
+    /// failed install.
+    ///
+    /// Deliberately NOT `#[cfg]`-gated: it asserts the field tracks
+    /// `LlmProvider::install_command` rather than any particular command text, so it is
+    /// meaningful on macOS and Windows alike and runs in BOTH CI Rust jobs.
+    #[tokio::test]
+    async fn provider_status_reports_this_platforms_install_command() {
+        for provider in LlmProvider::builtins() {
+            let status = detect(provider).await;
+            assert_eq!(
+                status.install_command.as_deref(),
+                provider.install_command(),
+                "{provider:?} must report the command this platform installs with"
+            );
+            assert!(
+                status.install_command.is_some(),
+                "{provider:?} is a CLI provider and must have an installer"
+            );
+        }
+    }
+
+    /// The wire contract with `ui/lib/api-types.ts`'s `ProviderStatus`: the field must
+    /// actually reach the frontend under the name the UI reads. A `#[serde(skip)]` or a
+    /// rename would leave `probed?.install_command` permanently `undefined`, silently
+    /// reverting the UI to the platform-wrong static hint with no test failing.
+    #[tokio::test]
+    async fn provider_status_serialises_install_command_for_the_frontend() {
+        let status = detect(LlmProvider::Claude).await;
+        let json = serde_json::to_value(&status).expect("ProviderStatus must serialise");
+        assert_eq!(
+            json.get("install_command").and_then(|v| v.as_str()),
+            LlmProvider::Claude.install_command(),
+            "the frontend reads `install_command` — got {json:?}"
+        );
+    }
+
     /// The regression this exists for: an npm-based install (`npm i -g @openai/codex`, etc.)
     /// failed with "command not found: npm" on any Mac where nvm's init block lives only in
     /// `~/.zshrc` — `installer_command`'s `-l` (login, non-interactive) shell never sources

--- a/ui/__tests__/llm-provider-connection-phase.test.ts
+++ b/ui/__tests__/llm-provider-connection-phase.test.ts
@@ -150,6 +150,32 @@ it('every in-app sign-in provider carries BOTH its copy and its tray command in 
   expect(picker).toMatch(/llmSignIn\(id\)\?\.trayCommand/)
 })
 
+// ── The displayed install command must come from the PROBE, not the static meta hint ────────
+//
+// `LlmProviderMeta.installHint` is one string compiled into a dashboard that ships to macOS
+// AND Windows, so it cannot be correct on both: it names the npm command, while Windows
+// installs natively (see meridian-core/src/llm_provider.rs). It is also the "run it yourself"
+// fallback shown AFTER a failed install — so sourcing it statically told a Windows user to run
+// the exact command that cannot work there. `ProviderStatus.install_command` is the command
+// the running backend will actually execute, so it is right on every platform by construction.
+
+it('the install hint shown to the user comes from the probe, falling back to the static meta hint only until it resolves', () => {
+  expect(detail).toMatch(/installHint=\{probed\?\.install_command \?\? p\.installHint\}/)
+})
+
+it('ProviderStatus carries the install command, so the UI never has to guess the platform', () => {
+  const apiTypes = src('lib/api-types.ts')
+  const block = apiTypes.slice(apiTypes.indexOf('export interface ProviderStatus'))
+  expect(block.slice(0, block.indexOf('\n}'))).toMatch(/install_command: string \| null/)
+})
+
+it('the detail view does not fall back to the static hint anywhere else — one source, no second path', () => {
+  // Every other `p.installHint` read would reintroduce the platform-wrong string. The single
+  // permitted use is the `??` fallback asserted above.
+  const reads = detail.match(/p\.installHint/g) ?? []
+  expect(reads.length).toBe(1)
+})
+
 it('every other provider surfaces the real failure message verbatim, not a generic substitute', () => {
   expect(detail).toMatch(/isn&apos;t responding: \{phase\.message\}/)
 })


### PR DESCRIPTION
## What

Follow-up to #663 (merged), which fixed the provider Install button on Windows. That PR shipped tests for every behavioural change it made, but the last piece added to it - `ProviderStatus.install_command`, the field the frontend renders **instead of** its own static `installHint` - went in with no test coverage at all. This adds it.

No production code changes; tests only.

## Why this field needs guarding specifically

`LlmProviderMeta.installHint` (`ui/lib/llm-providers.ts`) is a single string compiled into a dashboard that ships to macOS **and** Windows, so it cannot be correct on both: it names the npm command, while Windows now installs natively. It is also the "run it yourself" fallback shown *after* a failed install - so before #663 a Windows user was told to run the exact command that cannot work there.

`ProviderStatus.install_command` fixes that by reporting the command the running backend will actually execute. The failure mode if it silently regresses is the point: `probed?.install_command` becomes `undefined`, the UI falls back to `p.installHint`, and it renders the platform-wrong command again **with nothing failing**. That is precisely the kind of regression that needs a test rather than review attention.

## Rust — deliberately not `cfg`-gated

`ci.yml` runs Rust on two platforms (`rust` on `macos-latest`, `rust-windows` on `windows-latest`), and #663's behavioural tests are all `#[cfg(windows)]`, so only one job exercises them. These two assert that the field tracks `LlmProvider::install_command` rather than any particular command text, so they are meaningful on both platforms and run in **both** jobs:

- **`provider_status_reports_this_platforms_install_command`** - every builtin provider reports this platform's installer.
- **`provider_status_serialises_install_command_for_the_frontend`** - the serde wire contract with `ui/lib/api-types.ts`. A `#[serde(skip)]` or a rename would break the frontend silently; this fails instead.

They depend only on `provider.install_command()`, not on `PATH`/`HOME` or `resolve_cli`'s result, so they cannot race the env-mutating tests in that module. `detect()` reads no shared cache (only `detect_all_with_cache()` does), and the existing `detect_all_covers_every_builtin_exactly_once` already pays the same probe cost.

## UI (ubuntu job)

Three source-level tests, matching the idiom already used in that suite (this repo has no React render harness):

- the detail view reads the probe's command, with the static hint only as an until-it-resolves fallback
- `api-types.ts` still declares `install_command: string | null`
- **exactly one** `p.installHint` read remains in the detail view - a second one would reintroduce the platform-wrong string by another path

## Testing

`llm::detect` 28/28 (was 26). UI provider suite 18/18 (was 15). `cargo fmt --check` clean.

## Note on #663's body

I appended a correction to #663 after merge. Its "pre-existing, flagged" note misdiagnosed two `db_crypto` test failures as assuming POSIX rename semantics and claimed they would block `cargo test` on any Windows dev box. Both were wrong: the assertions were checking error-context strings that `62776b96` had renamed (so they failed on every platform, not just Windows), and `9d648d11` had **already fixed them** on `pre-main`. The local tree behind that observation was 15 commits stale, which is why CI was green on both Rust jobs throughout.

One genuine local-Windows failure is recorded there instead: `llm::cursor_cli::tests::build_sandbox_is_idempotent_and_neutralises_skill_dirs` fails on a non-elevated Windows shell, because `link()` uses `std::os::windows::fs::symlink_*` and Windows needs `SeCreateSymbolicLinkPrivilege` (administrator, or Developer Mode). `link()` swallows the error at `trace!`, so `build_sandbox` returns `Ok(())` having linked nothing. GitHub's `windows-latest` runners are administrator, so CI is unaffected - but a contributor on a normal Windows account will hit it and it is not their change that caused it. Not fixed here; flagging it as a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
