### PR TITLE
fix(tray): stop warning on every restart when no scheduled task exists

### DIFF
--- a/tray/src-tauri/src/commands/daemon_control.rs
+++ b/tray/src-tauri/src/commands/daemon_control.rs
@@ -176,10 +176,36 @@ pub async fn restart() -> Result<(), String> {
             // `register_service` already does for a fresh install; the daemon's
             // own single-instance guard (`daemon_already_running`) makes this
             // safe to attempt even if the task turns out to still be alive.
-            tracing::warn!(
-                error = %e,
-                "schtasks /Run failed - falling back to spawning the staged daemon directly"
-            );
+            //
+            // Which of those two situations this is decides the log level, and
+            // the difference matters more than it looks. On a policy-locked
+            // machine the task will NEVER exist, so warning here reports a
+            // permanent, already-handled configuration as if it were a fresh
+            // transient failure — once per restart attempt, forever. WARN+ is
+            // what egresses to central telemetry, and one such machine shipped
+            // ~3.9k of these in three days, burying real failures in the stream
+            // that exists to surface them.
+            //
+            // Distinguished by `/Query`'s EXIT CODE rather than by matching
+            // `/Run`'s stderr: Windows localizes those messages ("The system
+            // cannot find the file specified" is English-only), so text
+            // matching would silently classify every non-English machine as the
+            // unexpected case — the exact population most likely to be
+            // policy-locked in the first place.
+            if schtasks(&["/Query", "/TN", TASK_NAME]).await.is_ok() {
+                // The task exists but would not run — genuinely unexpected, and
+                // the direct spawn below is papering over something. Keep it at
+                // WARN so it stays visible in telemetry.
+                tracing::warn!(
+                    error = %e,
+                    "schtasks /Run failed though the task exists - falling back to spawning the staged daemon directly"
+                );
+            } else {
+                tracing::debug!(
+                    error = %e,
+                    "no scheduled task on this machine (schtasks /Create was blocked at install) - spawning the staged daemon directly"
+                );
+            }
             spawn_staged_daemon().map_err(|spawn_err| {
                 format!("schtasks /Run failed ({e}); direct spawn also failed: {spawn_err}")
             })

--- a/tray/src-tauri/src/commands/daemon_control.rs
+++ b/tray/src-tauri/src/commands/daemon_control.rs
@@ -157,6 +157,49 @@ pub async fn probe() -> Probe {
 #[cfg(target_os = "windows")]
 const TASK_NAME: &str = "Meridian Daemon";
 
+/// Why a `schtasks /Run` failed, which decides how loudly [`restart`] reports it.
+/// Both variants still fall back to the direct spawn — only the reporting differs.
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+enum RunFallback {
+    /// No such task. On a machine where `schtasks /Create` was blocked by policy
+    /// at install time this is permanent and by design — the Startup-folder
+    /// launcher is the registered mechanism — so it is not a fault to report.
+    NoTaskExpected,
+    /// The task exists but would not run. Genuinely unexpected: the direct spawn
+    /// is papering over something real, so it stays visible.
+    TaskExistsUnexpected,
+}
+
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+impl RunFallback {
+    /// Whether this deserves WARN (and therefore egress to central telemetry)
+    /// rather than DEBUG.
+    fn is_noteworthy(&self) -> bool {
+        matches!(self, RunFallback::TaskExistsUnexpected)
+    }
+}
+
+/// Classify a failed `/Run` from whether `schtasks /Query` found the task.
+///
+/// Split out from [`restart`] so the decision is testable: `restart` itself is
+/// `cfg(target_os = "windows")` and unreachable from any check a macOS developer
+/// runs, which is how the reporting bug this fixes went unnoticed.
+///
+/// Keyed on `/Query`'s **exit code**, never on `/Run`'s stderr text: Windows
+/// localizes those messages ("The system cannot find the file specified" is
+/// English-only), so matching text would misclassify every non-English machine
+/// as the unexpected case — the population most likely to be policy-locked to
+/// begin with.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn classify_run_failure(task_exists: bool) -> RunFallback {
+    if task_exists {
+        RunFallback::TaskExistsUnexpected
+    } else {
+        RunFallback::NoTaskExpected
+    }
+}
+
 #[cfg(target_os = "windows")]
 pub async fn restart() -> Result<(), String> {
     // Task Scheduler has no atomic restart, so end-then-run. `/End` failing is
@@ -186,16 +229,10 @@ pub async fn restart() -> Result<(), String> {
             // ~3.9k of these in three days, burying real failures in the stream
             // that exists to surface them.
             //
-            // Distinguished by `/Query`'s EXIT CODE rather than by matching
-            // `/Run`'s stderr: Windows localizes those messages ("The system
-            // cannot find the file specified" is English-only), so text
-            // matching would silently classify every non-English machine as the
-            // unexpected case — the exact population most likely to be
-            // policy-locked in the first place.
-            if schtasks(&["/Query", "/TN", TASK_NAME]).await.is_ok() {
-                // The task exists but would not run — genuinely unexpected, and
-                // the direct spawn below is papering over something. Keep it at
-                // WARN so it stays visible in telemetry.
+            // See `classify_run_failure` for why this asks `/Query` rather than
+            // reading `/Run`'s stderr.
+            let task_exists = schtasks(&["/Query", "/TN", TASK_NAME]).await.is_ok();
+            if classify_run_failure(task_exists).is_noteworthy() {
                 tracing::warn!(
                     error = %e,
                     "schtasks /Run failed though the task exists - falling back to spawning the staged daemon directly"
@@ -295,5 +332,41 @@ mod tests {
 
         assert!(!parse_greeting(b"").running);
         assert!(!parse_greeting(b"not json").running);
+    }
+
+    /// On a machine where `schtasks /Create` was blocked by policy at install
+    /// time, no "Meridian Daemon" task will EVER exist — the Startup-folder
+    /// launcher is the registered mechanism. `/Run` therefore fails on every
+    /// restart attempt, forever, and warning about it reports a permanent,
+    /// already-handled configuration as a fresh transient fault.
+    ///
+    /// `WARN`+ is what egresses to central telemetry: one machine shipped ~3.9k
+    /// of these in three days, out of ~6.6k fleet-wide, burying real failures in
+    /// the stream that exists to surface them.
+    ///
+    /// Both cases must still fall back to the direct spawn — only the reporting
+    /// differs. The classifier is deliberately platform-independent so this can
+    /// be verified on macOS; the `restart()` that consumes it is
+    /// `cfg(target_os = "windows")` and otherwise unreachable from any local
+    /// check a macOS developer runs.
+    #[test]
+    fn a_missing_scheduled_task_is_expected_and_must_not_warn() {
+        assert_eq!(
+            classify_run_failure(false),
+            RunFallback::NoTaskExpected,
+            "no task exists (schtasks /Create was blocked at install) - this is \
+             the designed fallback path and must not reach WARN"
+        );
+        assert!(!classify_run_failure(false).is_noteworthy());
+
+        // The inverse keeps the classifier honest: a task that EXISTS but will
+        // not run is genuinely unexpected, and the direct spawn is papering over
+        // something real. That one must stay visible.
+        assert_eq!(
+            classify_run_failure(true),
+            RunFallback::TaskExistsUnexpected,
+            "the task exists but would not run - that is a real fault"
+        );
+        assert!(classify_run_failure(true).is_noteworthy());
     }
 }


### PR DESCRIPTION
## What

On a Windows machine where `schtasks /Create` was blocked by policy at install time, `register_service` correctly falls back to a Startup-folder launcher and the daemon starts fine. But `restart()` still tries `schtasks /Run` on every attempt — and on such a machine **that task will never exist**. A permanent, already-handled configuration was reported as a fresh transient failure, once per restart, forever.

## Why it matters

`WARN`+ is what egresses to central telemetry. Measured over 30 days:

| | machines | events |
|---|---|---|
| `schtasks /Run failed …` | 7 | 6,665 |
| — worst single machine | 1 | **3,908 in 3 days** |

The per-host pattern is `CREATE-denied` **once**, then `RUN-notfound` thousands of times. Still firing on 1.83.0 today. This buries real failures in the stream that exists to surface them — it's the same stream that turned up the macOS DB corruption in #671.

**The recovery path itself was already correct and is unchanged.** The daemon does start via the direct-spawn fallback. Only the reporting changes.

## Approach

`/Query`'s **exit code** decides which case this is, rather than matching `/Run`'s stderr. Windows localizes those messages — "The system cannot find the file specified" is English-only — so text matching would misclassify every non-English machine as the unexpected case, and those are precisely the machines most likely to be policy-locked in the first place.

A task that *exists* but refuses to run keeps its `WARN`: the direct spawn is papering over something real in that case.

## Test plan

- macOS: clippy clean, 197 tray tests pass (this path is `cfg(target_os = "windows")`, so unaffected there).
- ⚠️ **Not verified locally.** A cross-target `cargo check --target x86_64-pc-windows-msvc` from macOS fails in `aws-lc-sys` (needs `windows.h`), so this rests on CI's Windows job. Worth a reviewer eye on the `cfg(windows)` block.

## Context

Found while triaging central OpenObserve after #671. Also confirmed in the same pass, and **not** needing a fix: the Windows `code 26 file is not a database` volume (5 machines, 77k events) was already fixed by `5aa4165e fix(windows): load the canonical .env …` in 1.82.2 — every occurrence is on 1.82.1 or older staging builds, from machines that hadn't updated yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TCFYB8yahQ2D6Lt7LvCzU