### PR TITLE
fix(telemetry): ship the fields that say WHICH health check failed

### DIFF
--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -130,6 +130,31 @@ const SAFE_STRING_KEYS: &[&str] = &[
     // summariser failure can't be attributed to a backend at all.
     "provider",
     "engine",
+    // ── health checks (`crate::health::Report::log`) ─────────────────────────
+    // Same failure mode the `error` note below describes, in a different place:
+    // `health check failed` is a static message whose entire diagnostic payload
+    // lives in these fields, so without them the backend received six machines
+    // reporting a CRITICAL fault with no way to tell WHICH check was failing —
+    // or even which subsystem.
+    //
+    // `group`/`layer` are `&'static str` and `check` is a `String` built only
+    // from literals at every call site (`auth`, `daemon running`, `meridian DB`,
+    // `capture.frames`, …) — verified against all of them; none interpolates.
+    // `stage` is likewise a fixed set here and at its one other emitter
+    // (`main.rs`'s `config_loaded`). None of the four can carry user data.
+    "check",
+    "group",
+    "layer",
+    "stage",
+    // `detail` is the exception and is treated accordingly: it is mostly fixed
+    // text ("401 — token expired or invalid", "Jira API unreachable") plus
+    // benign operational numbers (HTTP status, queue depths, GB free, node
+    // version), but a few sites splice an error's `Display` —
+    // `format!("OAuth token refresh failed ({e})")`. That is exactly the shape
+    // of the bare `error` key, so it gets the same answer: also on
+    // `FREE_TEXT_KEYS` below, for the full `scrub_text` + `clamp` rather than a
+    // path scrub alone.
+    "detail",
     // ── code location (paths scrubbed) ───────────────────────────────────────
     "code.function",
     "code.namespace",
@@ -168,6 +193,10 @@ const FREE_TEXT_KEYS: &[&str] = &[
     "exception.message",
     "exception.stacktrace",
     "otel.status_description",
+    // A health check's `detail` splices an error's `Display` at several sites
+    // (see the note on `SAFE_STRING_KEYS`), so it can carry an interpolated
+    // path, URL, or token just as `error` can.
+    "detail",
 ];
 
 /// Known-benign, high-frequency WARN messages dropped from the ship leg even
@@ -1321,6 +1350,52 @@ mod tests {
             "app_name",
             "window_title",
         ] {
+            let mut kv = str_attr(key, "MER-192");
+            assert!(!keep(&mut kv), "{key} leaked into the ship leg");
+        }
+    }
+
+    /// `health check failed` is a static message carrying no diagnostic payload
+    /// of its own — everything that identifies the fault rides on its fields. So
+    /// six machines reported a CRITICAL health failure to the backend with no
+    /// way to tell which check, or even which subsystem, had failed.
+    ///
+    /// Pins that the identifying fields survive, that `detail` is treated as
+    /// free text (it splices an error `Display` at several call sites, so a path
+    /// scrub alone would not be enough), and that widening the boundary for them
+    /// did not also let the user's own data through.
+    #[test]
+    fn health_check_fields_survive_but_stay_scrubbed() {
+        for (key, value) in [
+            ("check", "auth"),
+            ("group", "jira"),
+            ("layer", "L2"),
+            ("stage", "boot"),
+            ("detail", "401 - token expired or invalid"),
+        ] {
+            let mut kv = str_attr(key, value);
+            assert!(keep(&mut kv), "{key} was dropped");
+            match kv.value.unwrap().value.unwrap() {
+                Value::StringValue(s) => assert_eq!(s, value, "{key} was altered"),
+                other => panic!("expected string, got {other:?}"),
+            }
+        }
+
+        // `detail` is FREE TEXT: `format!("OAuth token refresh failed ({e})")`
+        // can splice whatever the error's `Display` carries.
+        let mut kv = str_attr(
+            "detail",
+            "refresh failed for https://id.atlassian.com/oauth (akarsh@meridiona.com)",
+        );
+        assert!(keep(&mut kv));
+        let out = match kv.value.unwrap().value.unwrap() {
+            Value::StringValue(s) => s,
+            other => panic!("expected string, got {other:?}"),
+        };
+        assert!(out.contains("<url>") && out.contains("<email>"), "{out}");
+
+        // Adding these five must not have widened the boundary generally.
+        for key in ["task_key", "path", "window_title", "app_name"] {
             let mut kv = str_attr(key, "MER-192");
             assert!(!keep(&mut kv), "{key} leaked into the ship leg");
         }


### PR DESCRIPTION
## What

`health::Report::log` is properly instrumented — it emits `check`, `group`, `layer`, `stage` and `detail` alongside a deliberately static message. **None of those keys were on `redact::SAFE_STRING_KEYS`**, so the ship leg dropped all five and central OO received:

```
ERROR  health check failed   error=None   (6 machines, last 24h)
```

Six machines are reporting a CRITICAL health fault that cannot be attributed to a check — or even to a subsystem.

This is the same failure the existing note on the bare `error` key records, in a different place: the allowlist is keyed on the attribute names actually typed at the call site, so a well-instrumented error arrives as a bare static string and **nothing anywhere fails loudly**. CLAUDE.md calls this out as one of the two couplings that silently delete error coverage; this is a live instance of it.

## Safety analysis

Each key was checked against every call site, because the allowlist is keyed on *name* — any emitter using that name gets through.

| key | type | verdict |
|---|---|---|
| `group`, `layer` | `&'static str` | compile-time constants |
| `check` | `String` | built from a literal at **every** call site (`auth`, `daemon running`, `meridian DB`, `capture.frames`, …); no `format!` anywhere |
| `stage` | `&str` | fixed set here and at its one other emitter (`main.rs`'s `config_loaded`) |
| `detail` | `String` | **needed judgement — see below** |

`check`, `group`, `layer` and `detail` are emitted *only* by `src/health/`; `stage` additionally by `main.rs` with a static value. Nothing else uses these names.

### `detail`

Mostly fixed text ("401 — token expired or invalid", "Jira API unreachable") plus benign operational numbers (HTTP status, queue depth, GB free, node version) — but a few sites splice an error's `Display`:

```rust
Check::critical("auth", "L2", format!("OAuth token refresh failed ({e})"))
```

That is exactly the shape of the bare `error` key, so it gets the same answer that one already got: **also on `FREE_TEXT_KEYS`**, for the full `scrub_text` + `clamp` rather than a path scrub alone.

## Deliberately NOT allowlisted

While auditing I checked the other frequent structured fields at warn/error sites. These stay off, and the new test pins that they stay off: `task_key` (Jira keys), `path`/`bin`/`file`/`db_path`, `hour`/`day`, `app_name`, `window_title`, and the record identifiers (`uuid`, `task_id`, `row_id`).

⚠️ One caveat for a reviewer: my scan for other affected sites was line-based, so it does **not** see multi-line `tracing::` macros — which is precisely how the health-check site is written. A broader audit for other silently-stripped instrumentation is probably worth doing separately; this PR only fixes the instance the fleet data surfaced.

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test --workspace`: 873 daemon tests + all crates pass.
- New `health_check_fields_survive_but_stay_scrubbed` pins that identifying fields survive intact, `detail` gets URLs/emails scrubbed, and the boundary did not widen to user data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TCFYB8yahQ2D6Lt7LvCzU