### PR TITLE
fix(tray): stop the watchdog killing a healthy daemon and corrupting the DB

### DIFF
--- a/tray/src-tauri/src/commands/daemon_control.rs
+++ b/tray/src-tauri/src/commands/daemon_control.rs
@@ -419,6 +419,15 @@ mod tests {
         // A loaded-but-STOPPED service prints no `pid` line at all. That is the
         // case the watchdog's backstop exists for, so it must read as absent
         // rather than as a parse failure that leaves the daemon dead.
+        //
+        // Verified against real `launchctl print` output rather than assumed:
+        // four stopped services on macOS 15 (`launchctl list` entries with a
+        // `-` pid column) each printed `state = not running` and ZERO `pid =`
+        // lines. If this ever changed — a stale or `pid = 0` line on a stopped
+        // service — `process_alive` would answer `Some(true)` forever and the
+        // watchdog would silently become a no-op, including for the one case
+        // launchd's `KeepAlive` does not cover. The fallback would be to key on
+        // `state` instead of the presence of `pid`.
         let stopped = "\tstate = not running\n\tprogram = /usr/bin/x\n\tjob state = stopped\n";
         assert_eq!(parse_launchctl_pid(stopped), None);
 

--- a/tray/src-tauri/src/commands/daemon_control.rs
+++ b/tray/src-tauri/src/commands/daemon_control.rs
@@ -88,6 +88,87 @@ pub async fn restart() -> Result<(), String> {
     launchctl(&["kickstart", "-k", &launchd_target()], "kickstart").await
 }
 
+/// Start the daemon if it is stopped, **without ever signalling a running
+/// instance** — `launchctl kickstart` with no `-k`.
+///
+/// Per `man launchctl`, `-k` is precisely and only what "kill[s] the running
+/// instance before restarting". Dropping it is what makes this safe to call
+/// speculatively: on an already-running daemon it is a no-op instead of a
+/// SIGTERM mid-WAL-write. [`restart`] keeps `-k` because its callers are asking
+/// for a restart explicitly; the watchdog must not.
+///
+/// See [`crate::poll::watchdog`] for the corruption incident this exists to
+/// prevent.
+#[cfg(target_os = "macos")]
+pub async fn start_if_stopped() -> Result<(), String> {
+    launchctl(&["kickstart", &launchd_target()], "kickstart").await
+}
+
+/// Whether the daemon **process** exists, regardless of whether it answered its
+/// endpoint. `None` means "could not determine".
+///
+/// Asks launchd rather than scanning the process table, so this reports on the
+/// service the tray actually manages rather than any binary that happens to
+/// share a name.
+#[cfg(target_os = "macos")]
+pub async fn process_alive() -> Option<bool> {
+    let out = tokio::process::Command::new("launchctl")
+        .args(["print", &launchd_target()])
+        .output()
+        .await
+        .ok()?;
+    // A missing service (`print` exits non-zero) is a definite "not alive"; a
+    // failure to run launchctl at all returned `None` above.
+    if !out.status.success() {
+        return Some(false);
+    }
+    Some(parse_launchctl_pid(&String::from_utf8_lossy(&out.stdout)).is_some())
+}
+
+/// Windows: no launchd equivalent is wired, so liveness is unknown.
+///
+/// Returning `None` ("cannot tell") preserves the pre-existing Windows
+/// behaviour exactly rather than silently disabling the watchdog's backstop
+/// there. The corruption this guard closes is macOS-only (code 11 was 100%
+/// macOS, 0% Windows across the fleet), and the other two guards — no
+/// kill-before-start, and the storm cap — apply on both platforms.
+#[cfg(not(target_os = "macos"))]
+pub async fn process_alive() -> Option<bool> {
+    None
+}
+
+/// Start the daemon if it is stopped, without ending a running instance.
+///
+/// The Windows counterpart of the macOS [`start_if_stopped`]: `schtasks /Run`
+/// alone, deliberately omitting the `/End` that [`restart`] performs first.
+#[cfg(target_os = "windows")]
+pub async fn start_if_stopped() -> Result<(), String> {
+    schtasks(&["/Run", "/TN", TASK_NAME]).await
+}
+
+/// The `pid = N` line out of `launchctl print`'s output, if the service has one.
+///
+/// A loaded-but-stopped service prints a record with **no** `pid` field, which
+/// is exactly the case the watchdog's backstop is for — so the absence of the
+/// line is meaningful, not a parse failure.
+///
+/// Kept free of `cfg` so it compiles and tests on every target, including the
+/// Windows CI job. `cfg`-gated helpers in this tray have twice broken that
+/// build in ways invisible from macOS.
+///
+/// Only the macOS [`process_alive`] calls it, so a non-macOS build sees dead
+/// code and `-D warnings` fails it. `cfg_attr` rather than `cfg`: the latter
+/// would delete the function on Windows and take its test with it, which is the
+/// whole reason it is written portably. Same pattern as
+/// [`classify_run_failure`] below.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn parse_launchctl_pid(output: &str) -> Option<u32> {
+    output.lines().find_map(|line| {
+        let (key, value) = line.split_once('=')?;
+        (key.trim() == "pid").then(|| value.trim().parse().ok())?
+    })
+}
+
 #[cfg(target_os = "macos")]
 pub async fn set_running(running: bool) -> Result<(), String> {
     let verb = if running { "start" } else { "stop" };
@@ -323,6 +404,34 @@ async fn schtasks(args: &[&str]) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The liveness signal the watchdog gates on. Getting this wrong in the
+    /// "running" direction re-enables the restart storm that corrupted
+    /// `meridian.db`, so both directions are pinned against real
+    /// `launchctl print` output.
+    #[test]
+    fn launchctl_pid_is_read_only_from_a_real_pid_line() {
+        // Shape of a real record (tab-indented `key = value`), trimmed.
+        let running =
+            "\tstate = running\n\tprogram = /usr/bin/x\n\tpid = 56397\n\tjob state = running\n";
+        assert_eq!(parse_launchctl_pid(running), Some(56397));
+
+        // A loaded-but-STOPPED service prints no `pid` line at all. That is the
+        // case the watchdog's backstop exists for, so it must read as absent
+        // rather than as a parse failure that leaves the daemon dead.
+        let stopped = "\tstate = not running\n\tprogram = /usr/bin/x\n\tjob state = stopped\n";
+        assert_eq!(parse_launchctl_pid(stopped), None);
+
+        // Keys that merely CONTAIN "pid" must not match - `ppid` in particular
+        // is present on some records and would report a dead service as alive,
+        // which is the direction that silently disables the backstop.
+        let ppid_only = "\tppid = 1\n\tstate = not running\n";
+        assert_eq!(parse_launchctl_pid(ppid_only), None);
+
+        // Junk must not panic or invent a pid.
+        assert_eq!(parse_launchctl_pid(""), None);
+        assert_eq!(parse_launchctl_pid("pid = not-a-number\n"), None);
+    }
 
     #[test]
     fn greeting_parses_pid_and_rejects_junk() {

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -926,8 +926,10 @@ pub fn run() {
             });
 
             // Fast daemon supervisor, separate from the poll loop's slower,
-            // notice-owning health tick: probes every 5 s and restarts a
-            // confirmed-down daemon within ~10 s. See `poll::run_daemon_watchdog`.
+            // notice-owning health tick: probes every 5 s and *starts* a daemon
+            // that is confirmed stopped. It deliberately never signals a running
+            // process — doing so on a slow probe corrupted `meridian.db` on
+            // every macOS install. See `poll::watchdog` before changing it.
             tauri::async_runtime::spawn(async move {
                 poll::run_daemon_watchdog().await;
             });

--- a/tray/src-tauri/src/poll/mod.rs
+++ b/tray/src-tauri/src/poll/mod.rs
@@ -20,6 +20,7 @@ mod notifications;
 mod permissions;
 mod plan_auto_open;
 mod refresh;
+mod watchdog;
 mod whats_new_auto_open;
 
 use crate::state::{AppState, HealthStatus, PauseSource};
@@ -32,78 +33,9 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::{Emitter, Manager};
-use tracing::Instrument;
+pub use watchdog::run_daemon_watchdog;
 
 const TICK: Duration = Duration::from_secs(30);
-
-/// How often the daemon watchdog probes the IPC endpoint. Much tighter than the
-/// 60 s health cadence in [`run_poll_loop`] because recovery latency, unlike the
-/// popover's status readout, is felt directly — a dead daemon means no capture.
-const WATCHDOG_TICK: Duration = Duration::from_secs(5);
-/// Consecutive missed probes before the watchdog treats the daemon as down. Two
-/// (≈10 s) filters a single transient blip without waiting on the slow path.
-const WATCHDOG_STRIKES: u32 = 2;
-/// Quiet window after a restart attempt before the watchdog will fire again. The
-/// daemon needs a few seconds to come up and start serving its endpoint; without
-/// this the next probes would spawn a second (and third…) instance on top of one
-/// that is merely mid-startup. Comfortably longer than a cold start, so a
-/// genuinely crash-looping daemon still retries — just not in a tight loop. (The
-/// daemon's single-instance guard makes an overlapping spawn a harmless no-op
-/// regardless; this simply avoids the churn.)
-const WATCHDOG_COOLDOWN: Duration = Duration::from_secs(45);
-
-/// A fast, self-contained daemon supervisor: probe every [`WATCHDOG_TICK`], and
-/// once the daemon has missed [`WATCHDOG_STRIKES`] probes in a row (~10 s),
-/// restart it — then hold off for [`WATCHDOG_COOLDOWN`] before considering
-/// another attempt.
-///
-/// This is deliberately separate from [`run_poll_loop`]'s `refresh_health`,
-/// which owns the user-facing went-quiet/back-online *notices* on a slower,
-/// debounced cadence. Recovery is split out here so it can react in seconds
-/// without dragging the whole 30 s UI-refresh loop (and its DB reads) down to a
-/// 5 s beat. Both may call `restart()` in the same outage; the daemon's
-/// single-instance guard makes that safe, and the cooldown keeps this side from
-/// stacking attempts. Not gated on any "was healthy" flag — a daemon already
-/// down at startup is exactly the case that most needs bringing back.
-pub async fn run_daemon_watchdog() {
-    let down_after_s = WATCHDOG_STRIKES as u64 * WATCHDOG_TICK.as_secs();
-    let mut consecutive_down: u32 = 0;
-    let mut cooldown_until: Option<Instant> = None;
-
-    loop {
-        tokio::time::sleep(WATCHDOG_TICK).await;
-
-        if crate::commands::daemon_control::probe().await.running {
-            consecutive_down = 0;
-            cooldown_until = None;
-            continue;
-        }
-
-        consecutive_down += 1;
-        if consecutive_down < WATCHDOG_STRIKES {
-            continue;
-        }
-        // Confirmed down. Respect the post-restart quiet window so a daemon
-        // that's still starting up isn't restarted on top of itself.
-        if cooldown_until.is_some_and(|until| Instant::now() < until) {
-            continue;
-        }
-
-        // Wrap the discrete recovery operation in a span so the whole attempt is
-        // traceable end-to-end; `down_after_s` rides on the span as a structured
-        // field (queryable in JSON sinks) rather than baked into a message.
-        async {
-            tracing::info!("daemon watchdog: endpoint down, restarting");
-            if let Err(e) = crate::commands::daemon_control::restart().await {
-                tracing::warn!(error = %e, "daemon watchdog: restart attempt failed");
-            }
-        }
-        .instrument(tracing::info_span!("daemon_watchdog.restart", down_after_s))
-        .await;
-        cooldown_until = Some(Instant::now() + WATCHDOG_COOLDOWN);
-        consecutive_down = 0;
-    }
-}
 
 pub async fn run_poll_loop(app: tauri::AppHandle, state: Arc<Mutex<AppState>>) {
     let mut tick: u32 = 0;

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -109,7 +109,18 @@ pub(super) async fn refresh_health(
         // Wrap the restart attempt in a span so the health-path recovery is
         // traceable end-to-end, matching the fast watchdog's span.
         async {
-            let r = crate::commands::daemon_control::restart().await;
+            // `start_if_stopped`, never `restart`: this path fires on a health
+            // *report* (`database_ready` / `daemon_running` read from the DB),
+            // which a daemon that is alive and merely busy can fail. Restarting
+            // on that signal means SIGTERM to a live process mid-write, which is
+            // the second, slower instance of what corrupted `meridian.db` — see
+            // [`super::watchdog`]. Starting a stopped daemon still works; a
+            // running one is left alone.
+            //
+            // Deliberately still returns a `Result` from the same shape of call,
+            // so the `notify_down` ⇒ `restart_result.is_some()` invariant
+            // asserted below continues to hold.
+            let r = crate::commands::daemon_control::start_if_stopped().await;
             match &r {
                 // ERROR (not WARN) so this line crosses the error-only central
                 // telemetry filter. The went-quiet *notice* is a local DB row

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -144,12 +144,17 @@ pub(super) async fn refresh_health(
                 Ok(()) => tracing::info!(
                     daemon_running,
                     db_ready,
-                    "daemon offline — automatic restart attempted"
+                    "daemon offline — start attempted"
                 ),
             }
             Some(r)
         }
-        .instrument(tracing::info_span!("daemon_watchdog.restart"))
+        // Renamed from `daemon_watchdog.restart`: this is the health path, not
+        // the watchdog, and it no longer restarts anything. Sharing the old name
+        // would have made a central-OO query for restarts silently match only
+        // this span post-#678 and read as "kills stopped" whether or not they
+        // had — a blind spot in the exact signal used to verify that fix.
+        .instrument(tracing::info_span!("daemon_health.start"))
         .await
     } else {
         None

--- a/tray/src-tauri/src/poll/watchdog.rs
+++ b/tray/src-tauri/src/poll/watchdog.rs
@@ -1,0 +1,389 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! The tray's daemon watchdog: decide first, act second.
+//!
+//! # Why this module exists (READ THIS BEFORE RESTORING `-k`)
+//!
+//! This watchdog corrupted `meridian.db` on every macOS install, repeatedly,
+//! for days. The mechanism, measured on 2026-08-04:
+//!
+//! 1. [`crate::commands::daemon_control::probe`] gives the daemon **800 ms** to
+//!    answer on `~/.meridian/daemon.sock`.
+//! 2. A daemon mid-ETL-batch or mid-WAL-checkpoint routinely misses that.
+//! 3. Two consecutive misses (`WATCHDOG_STRIKES = 2`, ≈10 s) were treated as
+//!    "down", and the watchdog ran `launchctl kickstart -k` — **SIGTERM to a
+//!    perfectly healthy process, mid-write**.
+//! 4. `WATCHDOG_COOLDOWN` paced that at one kill every ~45 s, forever: ~80
+//!    hard kills per hour, while the tray stayed attached to the same WAL
+//!    database. Damage landed in the `app_sessions` b-tree tail — the table the
+//!    daemon writes.
+//!
+//! Observed directly: `daemon watchdog: endpoint down, restarting` → `SIGTERM
+//! received` → `meridian daemon starting` **3.4 s later**. It was never
+//! unhealthy. Quitting the tray froze the launchd `runs` counter instantly;
+//! nothing else changed.
+//!
+//! # The three independent guards
+//!
+//! Any one of these stops the incident. All three are here deliberately,
+//! because the failure is silent data corruption and a single mistaken gate
+//! must not be enough to restart the storm.
+//!
+//! 1. **Never signal a live process.** [`decide`] returns [`Action::Wait`]
+//!    whenever the daemon process is known to be alive, however slow it is to
+//!    answer. A slow daemon is a performance problem; killing it mid-write is a
+//!    data-loss problem.
+//! 2. **`kickstart` without `-k`.** Per `man launchctl`, `-k` is precisely and
+//!    only what kills a running instance. Dropping it makes the worst case a
+//!    no-op instead of a SIGTERM. See
+//!    [`crate::commands::daemon_control::start_if_stopped`].
+//! 3. **A storm cap.** At most [`MAX_STARTS_IN_WINDOW`] start attempts per
+//!    [`START_WINDOW`]; past that [`decide`] returns [`Action::GiveUp`] and the
+//!    watchdog stops acting. This bounds the blast radius of *any* future
+//!    mistake in the two guards above — the original incident would have cost
+//!    one restart instead of hundreds.
+//!
+//! # What this watchdog is actually for
+//!
+//! Very little, and that is the honest answer. The daemon's launchd plist sets
+//! `KeepAlive = true`, so **launchd already restarts a dead daemon** without
+//! being asked. This loop is a backstop for the case launchd does not cover —
+//! a service that is loaded but stopped — and a place to notice and report a
+//! daemon that will not come back. It is not, and must not become, a liveness
+//! killer: it has no way to tell "busy" from "wedged", and it proved willing to
+//! act on that ambiguity ~80 times an hour.
+//!
+//! Recovering a genuinely *wedged* (alive but unresponsive) daemon is
+//! deliberately out of scope. Doing it safely needs a signal this loop does not
+//! have — a heartbeat the daemon advances, or a multi-minute unresponsive
+//! window. Note that `etl_runs` is **not** a usable heartbeat: the daemon
+//! latches and stops all ETL when it detects `db.corrupt`, so an `etl_runs`
+//! heartbeat would kill a daemon that is idle on purpose, building a second
+//! corruption path on top of the one this module exists to close.
+//!
+//! # Related
+//! - [`crate::commands::daemon_control`] — [`probe`] and the launchd verbs.
+//! - [`super::refresh`] — the slower, user-facing went-quiet/back-online
+//!   notices. It reports; this module acts.
+
+use std::time::{Duration, Instant};
+use tracing::Instrument;
+
+/// How often the watchdog probes the daemon's IPC endpoint.
+const TICK: Duration = Duration::from_secs(5);
+
+/// Consecutive missed probes before the endpoint is considered unresponsive.
+///
+/// This no longer decides whether anything gets *killed* — [`decide`]'s
+/// liveness gate does — so it is only the "is the socket answering" filter.
+const STRIKES: u32 = 2;
+
+/// Quiet window after a start attempt, so a daemon that is merely mid-startup
+/// is not started on top of itself.
+const COOLDOWN: Duration = Duration::from_secs(45);
+
+/// Ceiling on start attempts within [`START_WINDOW`] before the watchdog stops
+/// acting entirely. Deliberately small: with `KeepAlive = true` doing the real
+/// work, needing more than a handful of nudges an hour means something is wrong
+/// that restarting will not fix.
+const MAX_STARTS_IN_WINDOW: u32 = 5;
+
+/// The rolling window [`MAX_STARTS_IN_WINDOW`] is counted over.
+const START_WINDOW: Duration = Duration::from_secs(3600);
+
+/// What the watchdog should do on this tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Action {
+    /// Do nothing.
+    Wait,
+    /// Ask the service manager to start the daemon if it is stopped. Never
+    /// kills, never signals — see guard 2 in the module docs.
+    Start,
+    /// The storm cap tripped. Stop acting and report instead.
+    GiveUp,
+}
+
+/// Everything [`decide`] is allowed to look at.
+///
+/// A struct rather than positional arguments so that removing a rule from
+/// [`decide`] is a change to its *body*, not its signature — an unused
+/// parameter would otherwise fail the `-D warnings` build before the
+/// regression test could run, masking the very revert the test exists to catch.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Inputs {
+    /// The daemon answered its IPC endpoint this tick.
+    pub probe_ok: bool,
+    /// Whether the daemon *process* exists, independent of whether it answered.
+    /// `None` means "could not determine" — see [`daemon_process_alive`].
+    pub process_alive: Option<bool>,
+    /// Consecutive ticks the endpoint has failed to answer.
+    pub consecutive_failures: u32,
+    /// Start attempts already made inside the current [`START_WINDOW`].
+    pub starts_in_window: u32,
+    /// Whether the post-start quiet window is still open.
+    pub in_cooldown: bool,
+}
+
+/// The whole watchdog policy, as one pure function.
+///
+/// Pure and free of `cfg` on purpose: the policy is identical on every
+/// platform, so it compiles and its tests run everywhere — including the
+/// Windows CI job, where past `cfg`-gated helpers have twice broken the build
+/// in ways invisible from macOS.
+///
+/// Rules, in order:
+/// 1. endpoint answered → nothing to do
+/// 2. **the process is alive → never act** (the guard that closes the
+///    corruption incident; a slow daemon is not a dead one)
+/// 3. not yet [`STRIKES`] consecutive failures → too early to call it
+/// 4. still inside the post-start cooldown → let it finish starting
+/// 5. storm cap reached → [`Action::GiveUp`]
+/// 6. otherwise → [`Action::Start`]
+pub(crate) fn decide(i: Inputs) -> Action {
+    if i.probe_ok {
+        return Action::Wait;
+    }
+    // A live-but-slow process must never be signalled. `None` ("cannot tell")
+    // deliberately does NOT block: on a platform without a liveness check this
+    // preserves the pre-existing behaviour rather than silently disabling the
+    // backstop. Guards 2 and 3 still apply there.
+    if i.process_alive == Some(true) {
+        return Action::Wait;
+    }
+    if i.consecutive_failures < STRIKES {
+        return Action::Wait;
+    }
+    if i.in_cooldown {
+        return Action::Wait;
+    }
+    if i.starts_in_window >= MAX_STARTS_IN_WINDOW {
+        return Action::GiveUp;
+    }
+    Action::Start
+}
+
+/// Whether the daemon process exists, independent of whether it answered.
+///
+/// `None` means "could not determine", which [`decide`] treats as
+/// non-blocking. Kept as the single `cfg`-bearing seam in this module so
+/// [`decide`] itself stays portable.
+async fn daemon_process_alive() -> Option<bool> {
+    crate::commands::daemon_control::process_alive().await
+}
+
+/// Probe every [`TICK`]; act only when [`decide`] says to.
+///
+/// See the module docs for why this is far more conservative than it looks like
+/// it should be.
+pub async fn run_daemon_watchdog() {
+    let mut consecutive_failures: u32 = 0;
+    let mut cooldown_until: Option<Instant> = None;
+    let mut window_started = Instant::now();
+    let mut starts_in_window: u32 = 0;
+    let mut gave_up = false;
+
+    loop {
+        tokio::time::sleep(TICK).await;
+
+        if window_started.elapsed() >= START_WINDOW {
+            window_started = Instant::now();
+            starts_in_window = 0;
+            gave_up = false;
+        }
+
+        let probe_ok = crate::commands::daemon_control::probe().await.running;
+        if probe_ok {
+            consecutive_failures = 0;
+            cooldown_until = None;
+        } else {
+            consecutive_failures = consecutive_failures.saturating_add(1);
+        }
+
+        // Only ask the OS about the process when the endpoint is silent — this
+        // is the rare path, and it keeps a subprocess off every 5 s tick.
+        let process_alive = if probe_ok {
+            None
+        } else {
+            daemon_process_alive().await
+        };
+
+        let action = decide(Inputs {
+            probe_ok,
+            process_alive,
+            consecutive_failures,
+            starts_in_window,
+            in_cooldown: cooldown_until.is_some_and(|until| Instant::now() < until),
+        });
+
+        match action {
+            Action::Wait => {
+                // A silent endpoint on a live process is the case that used to
+                // trigger a kill. Record it — it is a real (performance)
+                // symptom worth seeing in telemetry — but do not act on it.
+                if !probe_ok && process_alive == Some(true) {
+                    tracing::debug!(
+                        consecutive_failures,
+                        "daemon watchdog: endpoint slow but the process is alive - not restarting"
+                    );
+                }
+            }
+            Action::Start => {
+                async {
+                    tracing::info!("daemon watchdog: daemon not running, starting it");
+                    if let Err(e) = crate::commands::daemon_control::start_if_stopped().await {
+                        tracing::warn!(error = %e, "daemon watchdog: start attempt failed");
+                    }
+                }
+                .instrument(tracing::info_span!(
+                    "daemon_watchdog.start",
+                    down_after_s = (consecutive_failures as u64) * TICK.as_secs()
+                ))
+                .await;
+                cooldown_until = Some(Instant::now() + COOLDOWN);
+                consecutive_failures = 0;
+                starts_in_window = starts_in_window.saturating_add(1);
+            }
+            Action::GiveUp => {
+                // Log once per window, not every tick.
+                if !gave_up {
+                    gave_up = true;
+                    tracing::warn!(
+                        starts_in_window,
+                        "daemon watchdog: too many start attempts this hour - giving up until the window resets"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn silent_endpoint() -> Inputs {
+        Inputs {
+            probe_ok: false,
+            process_alive: None,
+            consecutive_failures: STRIKES,
+            starts_in_window: 0,
+            in_cooldown: false,
+        }
+    }
+
+    /// **The regression test for the corruption incident.**
+    ///
+    /// Two consecutive 800 ms probe timeouts against a daemon that is alive and
+    /// merely busy is precisely the state that produced ~80 SIGTERMs an hour
+    /// and corrupted `app_sessions`. It must not produce an action, no matter
+    /// how many probes are missed.
+    #[test]
+    fn a_live_but_slow_daemon_is_never_restarted() {
+        let busy = Inputs {
+            process_alive: Some(true),
+            ..silent_endpoint()
+        };
+        assert_eq!(
+            decide(busy),
+            Action::Wait,
+            "a live daemon that is slow to answer must never be signalled - \
+             this is what corrupted meridian.db"
+        );
+
+        // Still true after a long outage: time does not turn "busy" into
+        // "dead", and this loop has no signal that could tell the difference.
+        for failures in [STRIKES, STRIKES + 10, 1_000] {
+            assert_eq!(
+                decide(Inputs {
+                    consecutive_failures: failures,
+                    ..busy
+                }),
+                Action::Wait,
+                "no number of missed probes justifies signalling a live process"
+            );
+        }
+    }
+
+    /// The backstop must still work, or the fix is just a disabled watchdog.
+    #[test]
+    fn a_dead_daemon_is_still_started() {
+        assert_eq!(
+            decide(Inputs {
+                process_alive: Some(false),
+                ..silent_endpoint()
+            }),
+            Action::Start
+        );
+        // "Cannot tell" preserves the old behaviour rather than disabling the
+        // backstop on platforms without a liveness check.
+        assert_eq!(decide(silent_endpoint()), Action::Start);
+    }
+
+    /// A healthy endpoint short-circuits everything, including the storm cap.
+    #[test]
+    fn a_healthy_endpoint_is_always_left_alone() {
+        assert_eq!(
+            decide(Inputs {
+                probe_ok: true,
+                process_alive: Some(false),
+                consecutive_failures: 99,
+                starts_in_window: MAX_STARTS_IN_WINDOW + 1,
+                in_cooldown: false,
+            }),
+            Action::Wait
+        );
+    }
+
+    /// Debounce and cooldown, unchanged in spirit from the original loop.
+    #[test]
+    fn a_single_blip_and_the_startup_window_are_both_tolerated() {
+        assert_eq!(
+            decide(Inputs {
+                consecutive_failures: STRIKES - 1,
+                process_alive: Some(false),
+                ..silent_endpoint()
+            }),
+            Action::Wait,
+            "one missed probe is a blip, not an outage"
+        );
+        assert_eq!(
+            decide(Inputs {
+                in_cooldown: true,
+                process_alive: Some(false),
+                ..silent_endpoint()
+            }),
+            Action::Wait,
+            "a daemon mid-startup must not be started on top of itself"
+        );
+    }
+
+    /// The blast-radius cap. Independent of whether any single decision above
+    /// is right — this is what would have held the original incident to a
+    /// handful of restarts instead of hundreds per hour.
+    #[test]
+    fn repeated_starts_are_capped_within_the_window() {
+        let dead = Inputs {
+            process_alive: Some(false),
+            ..silent_endpoint()
+        };
+        for n in 0..MAX_STARTS_IN_WINDOW {
+            assert_eq!(
+                decide(Inputs {
+                    starts_in_window: n,
+                    ..dead
+                }),
+                Action::Start,
+                "attempt {n} is within the cap"
+            );
+        }
+        for n in [MAX_STARTS_IN_WINDOW, MAX_STARTS_IN_WINDOW + 50] {
+            assert_eq!(
+                decide(Inputs {
+                    starts_in_window: n,
+                    ..dead
+                }),
+                Action::GiveUp,
+                "past the cap the watchdog must stop acting, not keep trying"
+            );
+        }
+    }
+}

--- a/tray/src-tauri/src/poll/watchdog.rs
+++ b/tray/src-tauri/src/poll/watchdog.rs
@@ -87,7 +87,11 @@ const COOLDOWN: Duration = Duration::from_secs(45);
 /// that restarting will not fix.
 const MAX_STARTS_IN_WINDOW: u32 = 5;
 
-/// The rolling window [`MAX_STARTS_IN_WINDOW`] is counted over.
+/// The window [`MAX_STARTS_IN_WINDOW`] is counted over. **Tumbling, not
+/// rolling**: the count resets wholesale once the window elapses, rather than
+/// ageing out individual attempts. Cruder, but it cannot drift, and the only
+/// consequence of the imprecision is when the cap lifts — never whether a live
+/// process gets signalled.
 const START_WINDOW: Duration = Duration::from_secs(3600);
 
 /// What the watchdog should do on this tick.
@@ -198,12 +202,21 @@ pub async fn run_daemon_watchdog() {
             consecutive_failures = consecutive_failures.saturating_add(1);
         }
 
-        // Only ask the OS about the process when the endpoint is silent — this
-        // is the rare path, and it keeps a subprocess off every 5 s tick.
-        let process_alive = if probe_ok {
-            None
-        } else {
+        let in_cooldown = cooldown_until.is_some_and(|until| Instant::now() < until);
+
+        // `daemon_process_alive` spawns a subprocess, so only ask when the
+        // answer could actually change the outcome — i.e. only when every other
+        // guard would otherwise permit [`Action::Start`]. In every case skipped
+        // here [`decide`] reaches a verdict before it reads `process_alive`
+        // (`probe_ok` → `Wait`; under [`STRIKES`] → `Wait`; in cooldown →
+        // `Wait`; past the cap → `GiveUp`), so passing `None` cannot change the
+        // result. Without this, a daemon left stopped past the storm cap would
+        // fork `launchctl` every 5 s forever.
+        let could_start = !probe_ok && consecutive_failures >= STRIKES && !in_cooldown && !gave_up;
+        let process_alive = if could_start {
             daemon_process_alive().await
+        } else {
+            None
         };
 
         let action = decide(Inputs {
@@ -211,7 +224,7 @@ pub async fn run_daemon_watchdog() {
             process_alive,
             consecutive_failures,
             starts_in_window,
-            in_cooldown: cooldown_until.is_some_and(|until| Instant::now() < until),
+            in_cooldown,
         });
 
         match action {
@@ -353,6 +366,51 @@ mod tests {
             }),
             Action::Wait,
             "a daemon mid-startup must not be started on top of itself"
+        );
+    }
+
+    /// The loop skips the (subprocess-spawning) liveness query whenever another
+    /// guard already settles the tick, and passes `None` instead. That is only
+    /// sound if `None` yields the same verdict in exactly those cases — so pin
+    /// it, because the optimisation would otherwise silently turn into a
+    /// behaviour change the first time [`decide`]'s rule order is edited.
+    #[test]
+    fn skipping_the_liveness_query_cannot_change_the_verdict() {
+        let unknown = Inputs {
+            process_alive: None,
+            ..silent_endpoint()
+        };
+        assert_eq!(
+            decide(Inputs {
+                consecutive_failures: STRIKES - 1,
+                ..unknown
+            }),
+            Action::Wait,
+            "under the strike count, liveness is not consulted"
+        );
+        assert_eq!(
+            decide(Inputs {
+                in_cooldown: true,
+                ..unknown
+            }),
+            Action::Wait,
+            "in cooldown, liveness is not consulted"
+        );
+        assert_eq!(
+            decide(Inputs {
+                starts_in_window: MAX_STARTS_IN_WINDOW,
+                ..unknown
+            }),
+            Action::GiveUp,
+            "past the cap, liveness is not consulted"
+        );
+        assert_eq!(
+            decide(Inputs {
+                probe_ok: true,
+                ..unknown
+            }),
+            Action::Wait,
+            "on a healthy endpoint, liveness is not consulted"
         );
     }
 


### PR DESCRIPTION
## The bug

The tray's daemon watchdog **SIGTERMed a live, healthy daemon roughly every 45 seconds** - ~80 hard kills an hour - and those kills landed mid-WAL-write while the tray stayed attached to the same database. **This is what has been corrupting `meridian.db` on macOS installs.**

Measured chain:

1. `probe()` allows the daemon **800 ms** to answer on `daemon.sock`
2. A daemon mid-ETL-batch or mid-WAL-checkpoint routinely misses that
3. Two consecutive misses (`WATCHDOG_STRIKES = 2`, ~10 s) were treated as "down"
4. The watchdog ran `launchctl kickstart -k` - SIGTERM to a healthy process, mid-write
5. `WATCHDOG_COOLDOWN = 45s` paced that forever

Observed directly in the tray log:

```
04:53:38  daemon watchdog: endpoint down, restarting
04:53:38  SIGTERM received -> shutting down
04:53:41  meridian daemon starting          <- healthy again in 3.4s
04:54:23  daemon watchdog: endpoint down, restarting
```

Quitting the tray froze the launchd `runs` counter instantly (unchanged pid for 2+ min); nothing else changed. Damage consistently landed in the `app_sessions` b-tree tail - the table the daemon writes.

This explains what earlier theories could not: why corruption recurred on staging.7 *with* the fd-limit fix (#676) installed, why it is macOS-only, and why `app_sessions` specifically.

## The fix - three independent guards

Any one stops the incident. All three are here because the failure is **silent data corruption**, and one mistaken gate must not be enough to restart the storm.

1. **Never signal a live process.** The policy moves into a pure, `cfg`-free `decide()` returning `Wait` whenever the daemon process is known alive, however slow it is to answer.
2. **`kickstart` without `-k`.** Per `man launchctl`, `-k` is precisely and only what kills a running instance, so the worst case becomes a no-op instead of a SIGTERM. Explicit `restart()` callers (tray menu, `restart_daemon` command, Windows `reload`) keep `-k` - those are user-initiated.
3. **A storm cap** - at most 5 start attempts per hour, then `GiveUp`. Bounds the blast radius of any future mistake in guards 1-2; the original incident would have cost one restart instead of hundreds.

`refresh_health` had the same bug at a lower rate (edge-triggered once per down-episode, on a DB health report a busy daemon can also fail), so it now calls `start_if_stopped()` too. Swapping the *verb* rather than the control flow keeps the asserted `notify_down => restart_result.is_some()` invariant.

## Worth stating plainly

The daemon's launchd plist sets **`KeepAlive = true`** - launchd already restarts a dead daemon unasked. This watchdog's only observable effect was killing healthy ones.

Recovering a genuinely **wedged** daemon is deliberately out of scope: it needs a signal this loop does not have. Note `etl_runs` is **not** usable as a heartbeat - the daemon latches and stops all ETL on `db.corrupt`, so that would build a second corruption path.

## Tests (TDD, revert-proofed)

`a_live_but_slow_daemon_is_never_restarted` encodes the incident. Removing the liveness gate - a **body-only** change, so an unused parameter cannot fail the build first and mask it - fails that test **alone** while the other four still pass:

```
a_live_but_slow_daemon_is_never_restarted ... FAILED
  a live daemon that is slow to answer must never be signalled -
  this is what corrupted meridian.db
test result: FAILED. 4 passed; 1 failed
```

`parse_launchctl_pid` is pinned in both directions, including that `ppid` must not match - a false "alive" would silently disable the backstop.

## Windows safety

`parse_launchctl_pid` is `cfg_attr`-gated, not `cfg`-gated, so it and its test survive on Windows. The `cfg` structure was type-checked against `aarch64-apple-darwin` and `x86_64-pc-windows-msvc` under `#![deny(warnings)]`, with the negative case confirming the check actually catches the dead-code trap (`cargo check` can't cross-target here - aws-lc-sys needs `windows.h`).

The watchdog moves to its own module; `poll/mod.rs` was 579 lines, over the 500-line guideline.

## Verification

`cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (873 + 380) all green.

**Still needs the real check:** with this installed, relaunch the tray and confirm `launchctl print ... | grep runs` stays flat for 30+ minutes while `meridian db check` stays healthy. The 2-minute frozen-pid observation proved the *cause*; it did not test the fix, because the tray was quit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TCFYB8yahQ2D6Lt7LvCzU