### PR TITLE
fix(tray): stop bouncing a healthy daemon on every launch; close review gaps

### DIFF
--- a/meridian-core/src/fd_limit.rs
+++ b/meridian-core/src/fd_limit.rs
@@ -64,16 +64,32 @@ fn target_soft_limit(current_soft: u64, hard: u64, desired: u64) -> Option<u64> 
     (capped > current_soft).then_some(capped)
 }
 
-/// Read `MERIDIAN_FD_LIMIT`, falling back to [`DEFAULT_TARGET`] when unset or
-/// unparseable. A malformed value must not be fatal — this runs on the startup
-/// path of both binaries, and refusing to boot over a typo in an env var would
-/// be a worse outcome than using the default.
+/// Resolve the target from a raw `MERIDIAN_FD_LIMIT` value.
+///
+/// Split from the env read so it is testable without mutating the process
+/// environment, which is racy across Rust's parallel test threads (and unsafe
+/// from the 2024 edition on).
+///
+/// Falls back to [`DEFAULT_TARGET`] when the value is absent, unparseable, **or
+/// below the default**. That last case is the important one: the override is
+/// only ever meant to raise the ceiling for an unusual machine, so a smaller
+/// value has no legitimate use — while `MERIDIAN_FD_LIMIT=0` would make
+/// [`target_soft_limit`] return `None` and silently leave the process on macOS's
+/// default of 256, disabling the very mitigation this module exists to apply.
+/// A malformed value must not be fatal either: this runs on the startup path of
+/// both binaries, and refusing to boot over a typo would be worse than the
+/// default.
+#[cfg_attr(not(unix), allow(dead_code))]
+fn effective_target(raw: Option<&str>) -> u64 {
+    raw.and_then(|s| s.trim().parse::<u64>().ok())
+        .filter(|&v| v >= DEFAULT_TARGET)
+        .unwrap_or(DEFAULT_TARGET)
+}
+
+/// Read `MERIDIAN_FD_LIMIT` and resolve it through [`effective_target`].
 #[cfg_attr(not(unix), allow(dead_code))]
 fn desired_target() -> u64 {
-    std::env::var(TARGET_ENV)
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(DEFAULT_TARGET)
+    effective_target(std::env::var(TARGET_ENV).ok().as_deref())
 }
 
 /// Raise the soft `RLIMIT_NOFILE` toward [`DEFAULT_TARGET`], capped by the hard
@@ -81,9 +97,22 @@ fn desired_target() -> u64 {
 /// the tray does not run the daemon's `main()`, so one call cannot cover both.
 ///
 /// Best-effort and never fatal: a process that cannot raise its limit should
-/// still start, just with the pre-existing corruption exposure. Logs at INFO on
-/// a successful raise so the value is visible in telemetry, and at WARN when the
-/// raise fails, since that leaves the machine in the state that corrupts.
+/// still start, just with the pre-existing corruption exposure.
+///
+/// # Why `eprintln!` and not `tracing!`
+/// This is called as the FIRST statement of both binaries' `main()` — before
+/// `observability::init` installs a subscriber. `tracing` macros with no
+/// subscriber are silently discarded, so the original `info!`/`warn!` here
+/// reached neither the telemetry spool nor a terminal: the one field you would
+/// actually want when diagnosing a corrupted install ("did the limit get
+/// raised, and to what?") was structurally unobservable.
+///
+/// `eprintln!` lands in launchd's stderr redirect
+/// (`~/.meridian/logs/<service>-error.log`), which is size-capped and folded
+/// into diagnostics export bundles — so the value survives to support. Moving
+/// the call after `init` instead would defeat the point of running it before
+/// anything can open a descriptor. The screenpipe fork resolved the identical
+/// ordering problem the same way.
 // `libc::rlim_t` is `u64` on macOS and Linux, so these casts are no-ops on the
 // platforms Meridian ships — but it is NOT `u64` on every Unix target, and this
 // module is gated on `unix`, not on those two. Keeping the casts costs nothing
@@ -97,30 +126,23 @@ pub fn raise_fd_limit() {
     };
     // SAFETY: `getrlimit`/`setrlimit` only read/write the `rlimit` we own here.
     if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) } != 0 {
-        tracing::warn!("could not read the file-descriptor limit; leaving it unchanged");
+        eprintln!("meridian: could not read the file-descriptor limit; leaving it unchanged");
         return;
     }
     let (soft, hard) = (rlim.rlim_cur as u64, rlim.rlim_max as u64);
     let Some(new_soft) = target_soft_limit(soft, hard, desired_target()) else {
-        tracing::debug!(soft, hard, "file-descriptor limit already sufficient");
+        eprintln!("meridian: file-descriptor limit already sufficient (soft={soft}, hard={hard})");
         return;
     };
 
     rlim.rlim_cur = new_soft as libc::rlim_t;
     // SAFETY: as above.
     if unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) } == 0 {
-        tracing::info!(
-            from = soft,
-            to = new_soft,
-            hard,
-            "raised the file-descriptor limit"
-        );
+        eprintln!("meridian: raised the file-descriptor limit {soft} -> {new_soft} (hard={hard})");
     } else {
-        tracing::warn!(
-            soft,
-            hard,
-            requested = new_soft,
-            "failed to raise the file-descriptor limit - SQLite may hit SQLITE_IOERR under load"
+        eprintln!(
+            "meridian: FAILED to raise the file-descriptor limit (soft={soft}, hard={hard}, \
+             requested={new_soft}) - SQLite may hit SQLITE_IOERR under load"
         );
     }
 }
@@ -161,6 +183,45 @@ mod tests {
     /// zero or a panic: this runs before the database opens in both binaries, so
     /// a typo in an env var must not brick startup or, worse, "successfully"
     /// lower the limit to 0.
+    /// `MERIDIAN_FD_LIMIT` must never be able to LOWER the target.
+    ///
+    /// A value below the default silently defeats the mitigation rather than
+    /// failing loudly: `target_soft_limit(256, hard, 0)` returns `None`, so the
+    /// process stays on macOS's default of 256 — the exact state that produces
+    /// `SQLITE_IOERR` (522) and then `database disk image is malformed` (11).
+    /// The override exists only to RAISE the ceiling on an unusual machine.
+    #[test]
+    fn an_undersized_env_override_cannot_disable_the_mitigation() {
+        for raw in ["0", "1", "256", "8191", "-5", "", "   ", "not-a-number"] {
+            assert_eq!(
+                effective_target(Some(raw)),
+                DEFAULT_TARGET,
+                "{raw:?} must fall back to the default, never lower the target"
+            );
+        }
+        assert_eq!(effective_target(None), DEFAULT_TARGET, "unset → default");
+
+        // A legitimate raise is still honoured, and the boundary counts as valid.
+        assert_eq!(effective_target(Some("65536")), 65_536);
+        assert_eq!(
+            effective_target(Some(" 65536 ")),
+            65_536,
+            "whitespace tolerated"
+        );
+        assert_eq!(
+            effective_target(Some("8192")),
+            DEFAULT_TARGET,
+            "equal is valid"
+        );
+
+        // End-to-end: the rejected value must not leave a macOS GUI process at 256.
+        assert_eq!(
+            target_soft_limit(256, 1_048_576, effective_target(Some("0"))),
+            Some(DEFAULT_TARGET),
+            "a rejected override must still raise the limit"
+        );
+    }
+
     #[test]
     fn a_bad_env_override_falls_back_to_the_default() {
         assert_eq!(

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -1878,9 +1878,15 @@ mod tests {
                 provider.install_command(),
                 "{provider:?} must report the command this platform installs with"
             );
+            // Non-empty, not merely present: the UI renders this string as the
+            // "how to install" hint, so `Some("")` would pass an `is_some()`
+            // check and still show the user a blank instruction.
             assert!(
-                status.install_command.is_some(),
-                "{provider:?} is a CLI provider and must have an installer"
+                status
+                    .install_command
+                    .as_deref()
+                    .is_some_and(|c| !c.trim().is_empty()),
+                "{provider:?} is a CLI provider and must have a non-empty installer command"
             );
         }
     }

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -364,8 +364,13 @@ async fn bootout_agent_and_wait(label: &str) -> Result<(), String> {
 /// resurrect one that [`stop_daemon_for_migration`] `bootout`ed, which is the
 /// whole point of using `bootout` there. Leaving this a no-op on macOS would
 /// therefore trade the corruption bug for a permanently dead daemon on every
-/// machine that ran the encryption migration. Idempotent, so the ordinary
-/// "daemon is already up" path re-bootstraps harmlessly.
+/// machine that ran the encryption migration.
+///
+/// It is **not** idempotent, which an earlier version of this comment claimed:
+/// [`register_agent`] finishes with `launchctl kickstart -k`, and `-k` is
+/// precisely what kills a running instance. Both platforms therefore return
+/// early when the daemon is already up, or an ordinary launch would SIGTERM a
+/// healthy daemon mid-write.
 async fn ensure_daemon_running(home: &Path) {
     #[cfg(target_os = "windows")]
     {
@@ -420,6 +425,29 @@ async fn ensure_daemon_running(home: &Path) {
         if !plist.is_file() {
             // Nothing staged yet (first launch); `install` renders the plist and
             // registers the agent itself, so there is nothing to restore here.
+            return;
+        }
+        // Already up — leave it alone. `register_agent` ends in
+        // `launchctl kickstart -k`, which KILLS a running instance, so calling
+        // it unconditionally bounced a healthy daemon on every ordinary tray
+        // launch. That is a fourth path to the macOS `meridian.db` corruption
+        // (see `crate::poll::watchdog` for the measured one): a SIGTERM
+        // mid-WAL-write, landing at app start when the daemon is busiest.
+        // Windows has always returned early here for exactly this reason; macOS
+        // is only now matching it.
+        //
+        // This deliberately does NOT break the case the function exists for.
+        // `stop_daemon_for_migration` `bootout`s the agent, and a booted-out
+        // label is not loaded at all: `launchctl print` exits non-zero, so
+        // `process_alive()` reports `Some(false)` and registration still runs.
+        // Verified across all three states — booted-out (exit 113), loaded but
+        // stopped (exit 0, no `pid` line), and running (exit 0, `pid` present);
+        // only the last one returns `Some(true)`.
+        if crate::commands::daemon_control::process_alive().await == Some(true) {
+            tracing::debug!(
+                label = DAEMON_LABEL,
+                "backend_install: daemon already running — not re-registering"
+            );
             return;
         }
         if let Err(e) = register_agent(DAEMON_LABEL, &plist).await {
@@ -1831,15 +1859,30 @@ mod tests {
         let mut macos_only: Vec<String> = Vec::new();
         let mut always_compiled: Vec<(String, usize, usize)> = Vec::new();
 
+        // Everything from `mod tests` onward is the test module, whose items are
+        // `cfg`-gated on purpose and never called from non-test code.
+        //
+        // Excluded by POSITION, not by a name prefix. The previous guard was
+        // `!name.starts_with("test_")`, and no test in this file carries that
+        // prefix — they read as sentences
+        // (`migration_bootout_targets_the_daemon_in_the_user_gui_domain`) — so
+        // the condition was always true, the exclusion never fired, and test
+        // items were counted toward the `macos_only` floor below. That left the
+        // floor unable to do its one job: prove the scanner still recognises the
+        // PRODUCTION items it exists to guard.
+        let tests_start = lines
+            .iter()
+            .position(|l| l.trim_start().starts_with("mod tests"))
+            .unwrap_or(lines.len());
+
         for (i, line) in lines.iter().enumerate() {
             let t = line.trim();
+            if i >= tests_start {
+                break;
+            }
             if t == MACOS_ONLY {
-                if let Some((name, at)) = item_name_after(&lines, i + 1) {
-                    // Skip the test module's own items — they are `cfg`-gated on
-                    // purpose and never called from non-test code.
-                    if !lines[at].contains("fn ") || !name.starts_with("test_") {
-                        macos_only.push(name);
-                    }
+                if let Some((name, _at)) = item_name_after(&lines, i + 1) {
+                    macos_only.push(name);
                 }
             } else if t == ALWAYS {
                 if let Some((name, at)) = item_name_after(&lines, i + 1) {

--- a/ui/__tests__/no-native-dialogs.test.ts
+++ b/ui/__tests__/no-native-dialogs.test.ts
@@ -55,16 +55,60 @@ const BANNED = /(?<![.\w])(?:(?:window|globalThis|self)\.)?(?:confirm|alert|prom
 // enough that the rule is worth keeping tight rather than exhaustive.
 const DECLARATION = /\bfunction\s+(?:confirm|alert|prompt)\s*\(/
 
-// Blanks out comments so prose about the ban does not trip it - including JSX
-// `{/* … */}` blocks, whose continuation lines start with neither `//` nor `*`.
-// Newlines are preserved so reported line numbers stay honest. Naive about `//`
-// inside string literals (a URL truncates the rest of that line), which can only
-// cause a false negative on a line that also calls a banned global - not a
-// false positive, and the tighter parse is not worth a tokeniser here.
-function stripComments(src: string): string {
-  return src
-    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
-    .replace(/\/\/[^\n]*/g, '')
+// Blanks out comments AND string/template literals so prose about the ban does
+// not trip it - including JSX `{/* … */}` blocks, whose continuation lines start
+// with neither `//` nor `*`. Newlines are preserved so reported line numbers stay
+// honest.
+//
+// One left-to-right pass rather than two regex replaces, because the two
+// constructs can hide each other and a regex cannot see that: a `//` inside a
+// string literal (`'https://…'`) used to blank the rest of that real line of
+// code, so a `window.confirm(` after it on the same line would go unreported.
+// That is a false NEGATIVE in the one guard standing between us and another
+// silently-dead button - precisely the failure this file exists to prevent - so
+// it is worth the extra dozen lines. Walking left to right also stops the
+// inverse error, where an apostrophe inside a comment ("don't") would otherwise
+// open a bogus string literal and blank the code that follows.
+function stripCommentsAndStrings(src: string): string {
+  let out = ''
+  let i = 0
+  const blank = (c: string) => (c === '\n' ? '\n' : ' ')
+  while (i < src.length) {
+    const two = src.slice(i, i + 2)
+    if (two === '//') {
+      while (i < src.length && src[i] !== '\n') out += ' ', i++
+      continue
+    }
+    if (two === '/*') {
+      const end = src.indexOf('*/', i + 2)
+      const stop = end === -1 ? src.length : end + 2
+      for (; i < stop; i++) out += blank(src[i])
+      continue
+    }
+    const q = src[i]
+    if (q === '"' || q === "'" || q === '`') {
+      out += ' '
+      i++
+      while (i < src.length) {
+        if (src[i] === '\\') {
+          out += '  '
+          i += 2
+          continue
+        }
+        if (src[i] === q) {
+          out += ' '
+          i++
+          break
+        }
+        out += blank(src[i])
+        i++
+      }
+      continue
+    }
+    out += src[i]
+    i++
+  }
+  return out
 }
 
 describe('native browser dialogs are never used', () => {
@@ -77,7 +121,7 @@ describe('native browser dialogs are never used', () => {
   it('no window.confirm / alert / prompt anywhere in shipped UI source', () => {
     const offenders: string[] = []
     for (const file of files) {
-      stripComments(readFileSync(file, 'utf8'))
+      stripCommentsAndStrings(readFileSync(file, 'utf8'))
         .split('\n')
         .forEach((line, i) => {
           if (DECLARATION.test(line)) return
@@ -87,6 +131,39 @@ describe('native browser dialogs are never used', () => {
         })
     }
     expect(offenders).toEqual([])
+  })
+})
+
+// The sweep above is only as trustworthy as its stripper: every hole here is a
+// silent false negative, which is the same failure mode as the dead button this
+// file guards against. So the stripper is tested directly rather than trusted.
+describe('the source stripper', () => {
+  it('does not let a // inside a string hide a banned call on the same line', () => {
+    // The regression. The previous two-regex stripper blanked from the `//` in
+    // the URL to the end of the line, so the confirm() after it vanished and the
+    // sweep reported the file clean.
+    const src = `const help = 'https://meridiona.com/docs'; if (window.confirm('go')) run()`
+    expect(BANNED.test(stripCommentsAndStrings(src))).toBe(true)
+  })
+
+  it('does not let an apostrophe in a comment blank the code after it', () => {
+    // The inverse error: a naive string-blanking pass would treat the `'` in
+    // "don't" as opening a literal and swallow the real call below.
+    const src = ["// we don't ever want this", "window.confirm('really?')"].join('\n')
+    expect(BANNED.test(stripCommentsAndStrings(src))).toBe(true)
+  })
+
+  it('still ignores prose about the banned globals', () => {
+    expect(BANNED.test(stripCommentsAndStrings('// never call window.confirm(x)'))).toBe(false)
+    expect(BANNED.test(stripCommentsAndStrings('/* alert( is banned */'))).toBe(false)
+    expect(BANNED.test(stripCommentsAndStrings("const msg = 'use confirm(…) never'"))).toBe(false)
+  })
+
+  it('keeps line numbers honest so offender reports point at the real line', () => {
+    const src = ['/* a\n   multi\n   line */', "const s = 'x\\ny'", 'window.alert(1)'].join('\n')
+    const stripped = stripCommentsAndStrings(src)
+    expect(stripped.split('\n').length).toBe(src.split('\n').length)
+    expect(stripped.split('\n').findIndex((l) => BANNED.test(l))).toBe(4)
   })
 })
 


### PR DESCRIPTION
Resolves the actionable findings from the CodeRabbit review on the `pre-main → main` release PR (#677). Targets `pre-main`, so **#677 inherits this automatically**.

## 1. A fourth path to the macOS DB corruption (the important one)

`ensure_daemon_running` called `register_agent` unconditionally on macOS — and `register_agent` ends in **`launchctl kickstart -k`**, which per `man launchctl` is precisely and only what kills a running instance.

So **an ordinary tray launch SIGTERMed a healthy daemon mid-write**, at app start, when it is busiest. Windows has always returned early when the daemon is already up; macOS now matches it.

The doc comment actively asserted the opposite — *"Idempotent, so the ordinary 'daemon is already up' path re-bootstraps harmlessly"* — and is corrected.

**This preserves the case the function exists for.** After `stop_daemon_for_migration` `bootout`s the agent it is not loaded at all, so `launchctl print` exits non-zero → `process_alive()` reports `Some(false)` → registration still runs. Verified across all three states:

| agent state | `launchctl print` | `process_alive()` | action |
|---|---|---|---|
| booted-out (migration case) | exit 113 | `Some(false)` | registers ✅ still resurrects |
| loaded but stopped | exit 0, no `pid` line | `Some(false)` | registers ✅ |
| **loaded + running** | exit 0, `pid` present | `Some(true)` | **early return** ← the fix |

## 2. Guards that were silently not guarding

- **`backend_install` macOS scanner** — excluded test items via `!name.starts_with("test_")`, but no test in the file uses that prefix (they read as sentences). The exclusion never fired, test items counted toward the `macos_only.len() >= 3` floor, and the floor could no longer prove the scanner still sees the production items it guards. Now keyed on the `mod tests` boundary.
- **`fd_limit`** — `MERIDIAN_FD_LIMIT=0` made `target_soft_limit` return `None`, silently leaving the process on macOS's default of **256**: the exact state that produces `SQLITE_IOERR` (522) → `malformed` (11). Values below `DEFAULT_TARGET` are now rejected. Policy split into a pure `effective_target(Option<&str>)` so the test needs no env mutation.
- **`no-native-dialogs`** — the stripper blanked comments but not strings, so a `//` inside a URL blanked the rest of that **real line of code** and a `window.confirm(` after it went unreported. A false negative in the one guard between us and another silently-dead button. Replaced with a single left-to-right pass.

  It also fixes the inverse, which my old comment wrongly claimed was impossible: a banned name inside a string literal was a false **positive**.

## 3. Observability

`fd_limit` logged via `tracing!`, but it runs as the **first statement of both `main()`s — before `observability::init` installs a subscriber**, so every `info!`/`warn!` was silently discarded. The one fact worth having when diagnosing a corrupted install ("did the limit get raised, and to what?") was structurally unobservable. Switched to `eprintln!`, which reaches launchd's stderr redirect and is folded into diagnostics bundles.

## Declined, with reasons

- **CLAUDE.md split, `src/main.rs` split, move `detect.rs` tests, tracing span on a Windows-only query** — refactors. Churn on a release PR holding a fleet-wide corruption fix; worth doing, not now.
- **Move `raise_fd_limit()` after `dotenv`** — running it before anything can open a descriptor is the point. The override is a process-env knob, and its effect is now observable via the `eprintln!` above.

## Tests

Every fix is revert-proofed — reverting the code fails the new test and only that test:

- `an_undersized_env_override_cannot_disable_the_mitigation` — removing the `.filter()` fails it
- the stripper tests — restoring the old two-regex version fails 2 of them
- the macOS scanner still passes with test items excluded, so ≥3 production items remain

`cargo fmt` · `clippy --workspace -D warnings` · **1493 Rust tests** · **416 UI tests** · cfg structure type-checked for `aarch64-apple-darwin` and `x86_64-pc-windows-msvc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TCFYB8yahQ2D6Lt7LvCzU