### PR TITLE
fix(tray): restore the Windows recovery fallback and close the -k TOCTOU

### DIFF
--- a/meridian-core/src/fd_limit.rs
+++ b/meridian-core/src/fd_limit.rs
@@ -126,7 +126,13 @@ pub fn raise_fd_limit() {
     };
     // SAFETY: `getrlimit`/`setrlimit` only read/write the `rlimit` we own here.
     if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) } != 0 {
-        eprintln!("meridian: could not read the file-descriptor limit; leaving it unchanged");
+        // `last_os_error()` immediately after the failed call, before anything
+        // else can clobber errno. Without it every failure reads the same, and
+        // support cannot tell a permissions problem from a platform one.
+        eprintln!(
+            "meridian: could not read the file-descriptor limit ({}); leaving it unchanged",
+            std::io::Error::last_os_error()
+        );
         return;
     }
     let (soft, hard) = (rlim.rlim_cur as u64, rlim.rlim_max as u64);
@@ -140,9 +146,10 @@ pub fn raise_fd_limit() {
     if unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) } == 0 {
         eprintln!("meridian: raised the file-descriptor limit {soft} -> {new_soft} (hard={hard})");
     } else {
+        let err = std::io::Error::last_os_error();
         eprintln!(
-            "meridian: FAILED to raise the file-descriptor limit (soft={soft}, hard={hard}, \
-             requested={new_soft}) - SQLite may hit SQLITE_IOERR under load"
+            "meridian: FAILED to raise the file-descriptor limit ({err}) (soft={soft}, \
+             hard={hard}, requested={new_soft}) - SQLite may hit SQLITE_IOERR under load"
         );
     }
 }

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -1262,7 +1262,16 @@ async fn register_agent(label: &str, plist: &Path) -> Result<(), String> {
         return Err(format!("launchctl bootstrap {label} failed"));
     }
     let _ = launchctl(&["enable", &target]).await;
-    let _ = launchctl(&["kickstart", "-k", &target]).await;
+    // `kickstart` WITHOUT `-k`. The agent was just booted out and bootstrapped,
+    // so there is nothing running for `-k` to kill on the happy path — it only
+    // ever bit when `bootout` had NOT cleared (the "proceeding to bootstrap
+    // anyway" branch above), which is exactly when something may still be
+    // running. It also closed a TOCTOU: callers check "is the daemon alive?"
+    // first, and the daemon can start between that check and this line, so a
+    // `-k` here could kill an instance the caller had just decided not to
+    // touch. Dropping the flag makes the worst case a no-op instead of a
+    // SIGTERM mid-WAL-write. See [`crate::poll::watchdog`] for what that cost.
+    let _ = launchctl(&["kickstart", &target]).await;
     tracing::info!(label, "backend_install: launchd agent registered");
     Ok(())
 }

--- a/tray/src-tauri/src/commands/daemon_control.rs
+++ b/tray/src-tauri/src/commands/daemon_control.rs
@@ -112,18 +112,38 @@ pub async fn start_if_stopped() -> Result<(), String> {
 /// share a name.
 #[cfg(target_os = "macos")]
 pub async fn process_alive() -> Option<bool> {
+    let target = launchd_target();
     let out = tokio::process::Command::new("launchctl")
-        .args(["print", &launchd_target()])
+        .args(["print", &target])
         .output()
         .await
         .ok()?;
-    // A missing service (`print` exits non-zero) is a definite "not alive"; a
-    // failure to run launchctl at all returned `None` above.
-    if !out.status.success() {
+    if out.status.success() {
+        return Some(parse_launchctl_pid(&String::from_utf8_lossy(&out.stdout)).is_some());
+    }
+    // Not every non-zero exit means the same thing, and collapsing them all to
+    // "not alive" is how a guard against killing a live daemon quietly stops
+    // guarding. `113` (EBADARCH / "Could not find service") is launchd's answer
+    // for a label that is not loaded — a definite, actionable "not alive", and
+    // the state `stop_daemon_for_migration` deliberately leaves behind. Any
+    // other failure (launchd busy, a transient system error) tells us nothing
+    // about the daemon, so report `None` = unknown rather than inventing a
+    // negative.
+    let code = out.status.code();
+    if code == Some(LAUNCHCTL_NO_SUCH_SERVICE) {
         return Some(false);
     }
-    Some(parse_launchctl_pid(&String::from_utf8_lossy(&out.stdout)).is_some())
+    tracing::warn!(
+        target = %target,
+        exit_code = code.unwrap_or(-1),
+        "launchctl print failed for a reason other than 'no such service' - daemon liveness is unknown"
+    );
+    None
 }
+
+/// launchd's exit status for `print` against a label that is not loaded.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+const LAUNCHCTL_NO_SUCH_SERVICE: i32 = 113;
 
 /// Windows: no launchd equivalent is wired, so liveness is unknown.
 ///
@@ -139,11 +159,17 @@ pub async fn process_alive() -> Option<bool> {
 
 /// Start the daemon if it is stopped, without ending a running instance.
 ///
-/// The Windows counterpart of the macOS [`start_if_stopped`]: `schtasks /Run`
-/// alone, deliberately omitting the `/End` that [`restart`] performs first.
+/// The Windows counterpart of the macOS [`start_if_stopped`]: deliberately
+/// omits the `/End` that [`restart`] performs first, but otherwise takes the
+/// identical path — including the direct-spawn fallback for machines with no
+/// scheduled task. See [`run_task_or_spawn`].
+///
+/// Re-running an already-running daemon is harmless: the daemon's own
+/// single-instance guard (`daemon_already_running`) makes the second process
+/// exit immediately.
 #[cfg(target_os = "windows")]
 pub async fn start_if_stopped() -> Result<(), String> {
-    schtasks(&["/Run", "/TN", TASK_NAME]).await
+    run_task_or_spawn().await
 }
 
 /// The `pid = N` line out of `launchctl print`'s output, if the service has one.
@@ -286,6 +312,21 @@ pub async fn restart() -> Result<(), String> {
     // Task Scheduler has no atomic restart, so end-then-run. `/End` failing is
     // fine (the task may not be running); only `/Run` failing is an error.
     let _ = schtasks(&["/End", "/TN", TASK_NAME]).await;
+    run_task_or_spawn().await
+}
+
+/// `schtasks /Run`, falling back to spawning the staged daemon directly.
+///
+/// Shared by [`restart`] and [`start_if_stopped`] so the two cannot diverge.
+/// Splitting this out fixes a real regression: when the watchdog and
+/// `refresh_health` switched from `restart()` to `start_if_stopped()` (to stop
+/// killing healthy daemons — see [`crate::poll::watchdog`]), the Windows
+/// `start_if_stopped` was a bare `schtasks /Run`. On a machine where
+/// `schtasks /Create` was blocked by policy at install time there IS no task to
+/// run, so **both** automatic recovery paths silently lost their only way back
+/// up, and a crashed daemon would have stayed dead until the next login.
+#[cfg(target_os = "windows")]
+async fn run_task_or_spawn() -> Result<(), String> {
     match schtasks(&["/Run", "/TN", TASK_NAME]).await {
         Ok(()) => Ok(()),
         Err(e) => {

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -121,6 +121,12 @@ pub(super) async fn refresh_health(
             // so the `notify_down` ⇒ `restart_result.is_some()` invariant
             // asserted below continues to hold.
             let r = crate::commands::daemon_control::start_if_stopped().await;
+            if r.is_err() {
+                // Span status ERROR as well as the log below - an error-only
+                // telemetry query filters on the span, and a failed automatic
+                // recovery must not be invisible to it.
+                tracing::Span::current().record("otel.status_code", "ERROR");
+            }
             match &r {
                 // ERROR (not WARN) so this line crosses the error-only central
                 // telemetry filter. The went-quiet *notice* is a local DB row
@@ -139,7 +145,7 @@ pub(super) async fn refresh_health(
                     daemon_running,
                     db_ready,
                     cold_start = !notify_down,
-                    "daemon offline and automatic restart failed — the daemon is down with no recovery this episode"
+                    "daemon offline and the automatic start failed — the daemon is down with no recovery this episode"
                 ),
                 Ok(()) => tracing::info!(
                     daemon_running,
@@ -154,7 +160,10 @@ pub(super) async fn refresh_health(
         // would have made a central-OO query for restarts silently match only
         // this span post-#678 and read as "kills stopped" whether or not they
         // had — a blind spot in the exact signal used to verify that fix.
-        .instrument(tracing::info_span!("daemon_health.start"))
+        .instrument(tracing::info_span!(
+            "daemon_health.start",
+            otel.status_code = tracing::field::Empty
+        ))
         .await
     } else {
         None
@@ -173,9 +182,9 @@ pub(super) async fn refresh_health(
         );
         let detail = match &restart_result {
             Some(Err(_)) => {
-                "Tried to restart it automatically and that failed too. Tap to check what happened."
+                "Tried to start it automatically and that failed too. Tap to check what happened."
             }
-            _ => "Tried restarting it automatically - give it a moment.",
+            _ => "Tried starting it automatically - give it a moment.",
         };
         if let Err(e) = meridian::notices::raise_typed(
             pool,
@@ -212,7 +221,7 @@ pub(super) async fn refresh_health(
                 id: "tray.daemon_quiet",
                 severity: "warning",
                 title: "Meridian went quiet.",
-                detail: "Couldn't restart it automatically. Tap to check what happened.",
+                detail: "Couldn't start it automatically. Tap to check what happened.",
                 remedy: None,
                 event_key: "system.health",
                 deep_link: Some("/logs"),

--- a/tray/src-tauri/src/poll/watchdog.rs
+++ b/tray/src-tauri/src/poll/watchdog.rs
@@ -243,12 +243,18 @@ pub async fn run_daemon_watchdog() {
                 async {
                     tracing::info!("daemon watchdog: daemon not running, starting it");
                     if let Err(e) = crate::commands::daemon_control::start_if_stopped().await {
+                        // Mark the span itself ERROR, not just the log line: a
+                        // failed automatic recovery is the case worth finding in
+                        // OpenObserve, and span status is what an error-only
+                        // query filters on.
+                        tracing::Span::current().record("otel.status_code", "ERROR");
                         tracing::warn!(error = %e, "daemon watchdog: start attempt failed");
                     }
                 }
                 .instrument(tracing::info_span!(
                     "daemon_watchdog.start",
-                    down_after_s = (consecutive_failures as u64) * TICK.as_secs()
+                    down_after_s = (consecutive_failures as u64) * TICK.as_secs(),
+                    otel.status_code = tracing::field::Empty,
                 ))
                 .await;
                 cooldown_until = Some(Instant::now() + COOLDOWN);

--- a/ui/__tests__/no-native-dialogs.test.ts
+++ b/ui/__tests__/no-native-dialogs.test.ts
@@ -69,43 +69,96 @@ const DECLARATION = /\bfunction\s+(?:confirm|alert|prompt)\s*\(/
 // it is worth the extra dozen lines. Walking left to right also stops the
 // inverse error, where an apostrophe inside a comment ("don't") would otherwise
 // open a bogus string literal and blank the code that follows.
+// A `${…}` substitution inside a template literal is NOT string content - it is
+// executable code, so `` `${window.confirm(x)}` `` is a real call and must still
+// be scanned. That needs a context stack rather than a flat loop: `${` pushes
+// back into code mode (where a nested literal is blanked and a nested `${}`
+// recurses), and its closing `}` pops back into the template.
+//
+// Known limit: a regex literal containing a quote (`/'/`) reads as the start of
+// a string. Shipped UI source has none, and the failure would be a loud false
+// positive rather than a silent miss - the direction that is safe to leave.
 function stripCommentsAndStrings(src: string): string {
+  const blank = (c: string) => (c === '\n' ? '\n' : ' ')
+  type Ctx = { kind: 'code' | 'single' | 'double' | 'template'; depth: number }
+  const stack: Ctx[] = [{ kind: 'code', depth: 0 }]
   let out = ''
   let i = 0
-  const blank = (c: string) => (c === '\n' ? '\n' : ' ')
+
   while (i < src.length) {
-    const two = src.slice(i, i + 2)
-    if (two === '//') {
-      while (i < src.length && src[i] !== '\n') out += ' ', i++
-      continue
-    }
-    if (two === '/*') {
-      const end = src.indexOf('*/', i + 2)
-      const stop = end === -1 ? src.length : end + 2
-      for (; i < stop; i++) out += blank(src[i])
-      continue
-    }
-    const q = src[i]
-    if (q === '"' || q === "'" || q === '`') {
-      out += ' '
-      i++
-      while (i < src.length) {
-        if (src[i] === '\\') {
-          out += '  '
-          i += 2
-          continue
-        }
-        if (src[i] === q) {
+    const top = stack[stack.length - 1]
+    const c = src[i]
+
+    if (top.kind === 'code') {
+      const two = src.slice(i, i + 2)
+      if (two === '//') {
+        while (i < src.length && src[i] !== '\n') (out += ' '), i++
+        continue
+      }
+      if (two === '/*') {
+        const end = src.indexOf('*/', i + 2)
+        const stop = end === -1 ? src.length : end + 2
+        for (; i < stop; i++) out += blank(src[i])
+        continue
+      }
+      if (c === "'" || c === '"' || c === '`') {
+        stack.push({ kind: c === "'" ? 'single' : c === '"' ? 'double' : 'template', depth: 0 })
+        out += ' '
+        i++
+        continue
+      }
+      if (c === '{') {
+        top.depth++
+        out += c
+        i++
+        continue
+      }
+      if (c === '}') {
+        // Depth 0 inside a substitution means this `}` ends it.
+        if (stack.length > 1 && top.depth === 0) {
+          stack.pop()
           out += ' '
           i++
-          break
+          continue
         }
+        if (top.depth > 0) top.depth--
+        out += c
+        i++
+        continue
+      }
+      out += c
+      i++
+      continue
+    }
+
+    // Inside a string or template literal.
+    if (c === '\\') {
+      // Blank the backslash, then blank the escaped character SEPARATELY so a
+      // line continuation (`\` + newline) keeps its newline. Consuming both as
+      // spaces dropped a physical line and shifted every offender line number
+      // reported after it.
+      out += ' '
+      i++
+      if (i < src.length) {
         out += blank(src[i])
         i++
       }
       continue
     }
-    out += src[i]
+    if (top.kind === 'template' && c === '$' && src[i + 1] === '{') {
+      stack.push({ kind: 'code', depth: 0 })
+      out += '  '
+      i += 2
+      continue
+    }
+    const closer = top.kind === 'single' ? "'" : top.kind === 'double' ? '"' : '`'
+    if (c === closer) {
+      stack.pop()
+      out += ' '
+      i++
+      continue
+    }
+    out += blank(c)
     i++
   }
   return out
@@ -157,6 +210,29 @@ describe('the source stripper', () => {
     expect(BANNED.test(stripCommentsAndStrings('// never call window.confirm(x)'))).toBe(false)
     expect(BANNED.test(stripCommentsAndStrings('/* alert( is banned */'))).toBe(false)
     expect(BANNED.test(stripCommentsAndStrings("const msg = 'use confirm(…) never'"))).toBe(false)
+  })
+
+  it('scans ${…} substitutions, which are code and not string content', () => {
+    // A template substitution executes. Blanking the whole literal - which the
+    // first version of this stripper did - hid a real call.
+    expect(BANNED.test(stripCommentsAndStrings('const s = `x${window.confirm(1)}y`'))).toBe(true)
+    // Nested one level down, inside an object inside a substitution.
+    expect(BANNED.test(stripCommentsAndStrings('`${ fn({ k: alert(1) }) }`'))).toBe(true)
+    // A nested template inside a substitution still gets scanned.
+    expect(BANNED.test(stripCommentsAndStrings('`${ `${ prompt(1) }` }`'))).toBe(true)
+    // …but ordinary template TEXT is still blanked, so prose cannot trip it.
+    expect(BANNED.test(stripCommentsAndStrings('`call confirm( like this`'))).toBe(false)
+    // And the literal must close correctly, or code after it would be eaten.
+    expect(BANNED.test(stripCommentsAndStrings('`a${b}c`; window.alert(1)'))).toBe(true)
+  })
+
+  it('keeps a line continuation from shifting reported line numbers', () => {
+    // `\` + newline inside a string is a real physical line. Consuming both as
+    // spaces dropped it and shifted every offender reported afterwards.
+    const src = ['const s = "a\\', 'b"', 'window.confirm(1)'].join('\n')
+    const stripped = stripCommentsAndStrings(src)
+    expect(stripped.split('\n').length).toBe(src.split('\n').length)
+    expect(stripped.split('\n').findIndex((l) => BANNED.test(l))).toBe(2)
   })
 
   it('keeps line numbers honest so offender reports point at the real line', () => {


### PR DESCRIPTION
Second CodeRabbit round on the release PR (#677). **Two of these are regressions introduced by my own #678/#679** — which is why they get a real fix rather than a resolve-and-move-on. Targets `pre-main`, so #677 inherits it.

## 1. Windows recovery was silently lost (regression)

When the watchdog and `refresh_health` switched from `restart()` to `start_if_stopped()` — to stop killing healthy daemons — the Windows `start_if_stopped` was a bare `schtasks /Run`. It did **not** carry `restart()`'s direct-spawn fallback.

On a machine where `schtasks /Create` was blocked by policy at install time there is no task to run, so **both automatic recovery paths lost their only way back up**, and a crashed daemon would have stayed dead until the next login.

Extracted into `run_task_or_spawn`, shared by `restart()` and `start_if_stopped()` so they cannot diverge again.

## 2. `register_agent` no longer passes `-k`

This was the last destructive path, and the root of two findings at once:

- **TOCTOU** — callers check "is the daemon alive?", and it can start between that check and the `kickstart -k`
- **Indeterminate liveness** — how bad a wrong `process_alive()` answer is

The agent has just been `bootout`ed and `bootstrap`ped, so there is nothing for `-k` to kill on the happy path. It only ever bit when `bootout` had **not** cleared — which is exactly when something may still be running.

## 3. `process_alive` no longer invents a negative

It mapped *every* non-zero `launchctl print` exit to `Some(false)`. Only **113** (no such service) is a definite negative — the state `stop_daemon_for_migration` deliberately leaves. Anything else (launchd busy, transient system error) says nothing, so it now returns `None` (unknown) and logs `target` + `exit_code`.

Safe precisely because `-k` is gone in §2: `None` can no longer lead to killing anything.

## 4. The dialog guard missed `${…}` (regression)

Template substitutions are **executable code**, not string content — `` `${window.confirm(x)}` `` is a real call, and I was blanking it along with the rest of the literal. A false negative I introduced one commit after fixing a *different* false negative in the same function.

Replaced the flat loop with a context stack, so a substitution is scanned as code including nested objects and nested templates. Also fixed `\` + newline eating a physical line, which shifted every offender line number reported after it.

## 5. Smaller

- **Notice wording** — `refresh_health` still told users Meridian had "restarted" the daemon, after the call became `start_if_stopped()` which can legitimately leave a live daemon untouched. All four messages now say *start*.
- **`fd_limit` errno** — captured at both failure boundaries; without it every failure reads identically and support cannot tell a permissions problem from a platform one.
- **Span status `ERROR`** on failed automatic starts. An error-only telemetry query filters on span status, so a failed recovery was invisible to the stream that exists to surface it.

## Declined

Returning `anyhow::Result` from the new lifecycle helpers. Every platform fn in that module (`probe`/`restart`/`set_running`/`reload`) returns `Result<(), String>` and feeds Tauri commands that serialize to String; converting only the new two would make the module inconsistent.

## Verification

`cargo fmt` · `clippy --workspace -D warnings` · **1493 Rust tests** · **418 UI tests** · cfg structure type-checked for `aarch64-apple-darwin` and `x86_64-pc-windows-msvc`.

New tests cover `${…}` scanning (including nested), line-continuation line numbers, and that ordinary template *text* is still blanked so prose cannot trip the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TCFYB8yahQ2D6Lt7LvCzU