### PR TITLE
fix(db): the db.corrupt banner must not survive its own repair

### DIFF
--- a/src/db/repair/mod.rs
+++ b/src/db/repair/mod.rs
@@ -558,6 +558,89 @@ mod tests {
         pool.close().await;
     }
 
+    /// A repair fixes exactly the condition the `db.corrupt` notice reports,
+    /// but the table copy carries the notice row into the replacement - so the
+    /// app kept telling the user their database was damaged after it had been
+    /// fixed (observed surviving two real repairs on 2026-08-04, still
+    /// bannering a 05:15 notice at 17:23 over a healthy database). The paired
+    /// toast's dedup row must go with it, or the NEXT corruption is deduped
+    /// away and never notifies. Other notices report faults a repair knows
+    /// nothing about, so they must survive untouched.
+    #[tokio::test]
+    async fn repair_clears_the_corrupt_notice_and_its_toast_but_keeps_others() {
+        let fx = corrupt_db_fixture().await;
+        // Give the damaged source the two tables the scrub touches, shaped
+        // like migrations 037/042 (only the defaultless NOT NULL columns -
+        // the copy intersects column lists, and the rest have defaults).
+        sqlx::query(
+            "CREATE TABLE system_notices (
+                notice_id TEXT PRIMARY KEY, severity TEXT NOT NULL,
+                title TEXT NOT NULL, detail TEXT NOT NULL)",
+        )
+        .execute(&fx.pool)
+        .await
+        .expect("create system_notices");
+        for id in ["db.corrupt", "pm.jira"] {
+            sqlx::query(
+                "INSERT INTO system_notices (notice_id, severity, title, detail)
+                 VALUES (?, 'error', 't', 'd')",
+            )
+            .bind(id)
+            .execute(&fx.pool)
+            .await
+            .expect("insert notice");
+        }
+        sqlx::query(
+            "CREATE TABLE notifications (
+                dedup_key TEXT NOT NULL UNIQUE, event_key TEXT NOT NULL,
+                title TEXT NOT NULL)",
+        )
+        .execute(&fx.pool)
+        .await
+        .expect("create notifications");
+        // `{event_key}:{id}` per notices::clear_typed - db.corrupt is raised
+        // with its own id as the event_key, not the shared system.fault.
+        for key in ["db.corrupt:db.corrupt", "system.fault:pm.jira"] {
+            sqlx::query(
+                "INSERT INTO notifications (dedup_key, event_key, title) VALUES (?, 'e', 't')",
+            )
+            .bind(key)
+            .execute(&fx.pool)
+            .await
+            .expect("insert toast");
+        }
+        fx.pool.close().await;
+        let path = fx.path.clone();
+
+        repair(&path, None).await.expect("repair must succeed");
+
+        let uri = format!("sqlite://{}", path.display());
+        let pool = meridian_core::db_crypto::open_pool_with_key(&uri, None, false, &[])
+            .await
+            .expect("reopen repaired db");
+        let notices: Vec<(String,)> =
+            sqlx::query_as("SELECT notice_id FROM system_notices ORDER BY notice_id")
+                .fetch_all(&pool)
+                .await
+                .expect("read notices");
+        let toasts: Vec<(String,)> =
+            sqlx::query_as("SELECT dedup_key FROM notifications ORDER BY dedup_key")
+                .fetch_all(&pool)
+                .await
+                .expect("read toasts");
+        pool.close().await;
+        assert_eq!(
+            notices,
+            vec![("pm.jira".to_string(),)],
+            "db.corrupt must not survive its own fix; unrelated notices must"
+        );
+        assert_eq!(
+            toasts,
+            vec![("system.fault:pm.jira".to_string(),)],
+            "the stale toast dedup row must go too, or the next corruption never notifies"
+        );
+    }
+
     /// A repair that cannot even build a replacement must leave the original
     /// exactly where it was - the "never lose data" invariant.
     #[tokio::test]

--- a/src/db/repair/rebuild.rs
+++ b/src/db/repair/rebuild.rs
@@ -143,6 +143,31 @@ pub(super) async fn build_replacement(
         Err(e) => tracing::warn!(error = %e, "foreign_key_check could not run"),
     }
 
+    // The copy above has just carried any `db.corrupt` notice row into the
+    // replacement - the exact condition this rebuild fixes - so installing it
+    // unscrubbed keeps the "database is damaged" banner up after its own fix
+    // (observed surviving two real repairs on 2026-08-04, still bannering a
+    // 05:15 notice over a healthy database twelve hours later). Cleared the
+    // same way the daemon would (row + paired toast dedup row, so the NEXT
+    // corruption notifies instead of deduping away); other notices report
+    // faults a repair knows nothing about and are left as copied. On THIS
+    // connection, not the pool - see `clear_typed_on`'s doc and the close
+    // comment below. Never fails the repair: the salvage already succeeded,
+    // and `verify_replacement` judges soundness - precedent in
+    // `carry_sqlite_sequence` above.
+    if let Err(e) = crate::notices::clear_typed_on(
+        &mut conn,
+        crate::notices::DB_CORRUPT,
+        crate::notices::DB_CORRUPT,
+    )
+    .await
+    {
+        tracing::warn!(
+            error = %e,
+            "could not clear the stale db.corrupt notice from the replacement - the banner may outlive the repair"
+        );
+    }
+
     conn.execute("DETACH DATABASE src")
         .await
         .context("detaching the damaged database")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1525,4 +1525,7 @@ async fn etl_tick(meridian: &meridian::db::SqlitePool) -> bool {
 /// already correct. That retry loop is what this whole feature replaces: the
 /// motivating incident spun a failing `get_frames_since` once a minute for
 /// over a day.
-const DB_CORRUPT_NOTICE: &str = "db.corrupt";
+///
+/// The id itself lives in the lib ([`meridian::notices::DB_CORRUPT`]) because
+/// `db::repair` must clear the very same id from a rebuilt database.
+const DB_CORRUPT_NOTICE: &str = meridian::notices::DB_CORRUPT;

--- a/src/notices.rs
+++ b/src/notices.rs
@@ -12,6 +12,16 @@
 use anyhow::{Context, Result};
 use sqlx::SqlitePool;
 
+/// Notice id raised when `meridian.db` is structurally damaged.
+///
+/// Lives here rather than beside the raiser in `main.rs` because THREE parties
+/// must agree on it byte-for-byte: the daemon raises it (latched - see the
+/// usage-site doc in `main.rs`), the UI banners it, and `db::repair` clears it
+/// from the rebuilt file so the banner does not survive its own fix. It is
+/// also its own `event_key` (not the shared `system.fault`), so clearing must
+/// pass it for both.
+pub const DB_CORRUPT: &str = "db.corrupt";
+
 /// Raise (or refresh) a named notice. Idempotent — upserts so repeated calls
 /// from the poll loop don't accumulate duplicate rows. The paired toast is
 /// always stamped `system.fault` — use [`raise_typed`] when the caller needs
@@ -124,14 +134,37 @@ pub async fn clear_typed(pool: &SqlitePool, id: &str, event_key: &str) -> Result
 /// never observe that instance's down→up transition itself) and should only
 /// fire the "back online" toast when something was actually there.
 pub async fn clear_typed_reporting(pool: &SqlitePool, id: &str, event_key: &str) -> Result<bool> {
+    let mut conn = pool.acquire().await.context("acquiring for clear")?;
+    clear_typed_on(&mut conn, id, event_key).await
+}
+
+/// [`clear_typed_reporting`] for callers holding a single `SqliteConnection`
+/// rather than a pool.
+///
+/// Exists for `db::repair`'s rebuild, which must run EVERY write on one
+/// explicitly-closed connection: a pooled acquire there is handed back to the
+/// pool from a spawned task on drop, `pool.close()` does not reliably wait for
+/// that hand-back, and the surviving connection holds the WAL open — tripping
+/// the rebuild's "un-checkpointed write-ahead log" guard and failing the whole
+/// repair (intermittently, under load). See the closing comments in
+/// `db::repair::rebuild::build_replacement`.
+pub async fn clear_typed_on(
+    conn: &mut sqlx::SqliteConnection,
+    id: &str,
+    event_key: &str,
+) -> Result<bool> {
     let result = sqlx::query("DELETE FROM system_notices WHERE notice_id = ?")
         .bind(id)
-        .execute(pool)
+        .execute(&mut *conn)
         .await
         .context("clearing system notice")?;
     // Retract the paired toast so a future re-occurrence of this fault notifies
-    // again instead of being deduped away.
-    let _ = crate::notifications::retract(pool, &format!("{event_key}:{id}")).await;
+    // again instead of being deduped away. Best-effort, matching
+    // `notifications::retract` — same statement, same dedup-key shape.
+    let _ = sqlx::query("DELETE FROM notifications WHERE dedup_key = ?")
+        .bind(format!("{event_key}:{id}"))
+        .execute(&mut *conn)
+        .await;
     Ok(result.rows_affected() > 0)
 }
 

--- a/ui/__tests__/notice-raised-at.test.ts
+++ b/ui/__tests__/notice-raised-at.test.ts
@@ -1,0 +1,53 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// The db.corrupt notice survived its own repair twice on 2026-08-04: the
+// banner showed a 05:15 fault over a healthy database twelve hours later, and
+// nothing on screen distinguished it from a live alarm. The repair now scrubs
+// the notice (src/db/repair/rebuild.rs), and this stamp is the belt to that
+// suspender: a banner that says WHEN it was raised lets a user (and support)
+// spot a stale one at a glance.
+
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { formatSince } from '../lib/notice-time'
+
+describe('formatSince', () => {
+  // Local-time constructors round-tripped through toISOString keep the
+  // instant, so the local-day comparison below is timezone-independent.
+  const now = new Date(2026, 7, 4, 17, 30)
+
+  it('same-day notice shows the time alone', () => {
+    const out = formatSince(new Date(2026, 7, 4, 10, 45).toISOString(), now)
+    expect(out.startsWith('since ')).toBe(true)
+    expect(out).toContain('45')
+    expect(out).not.toContain('Aug')
+  })
+
+  it('an older notice carries the date too', () => {
+    const sameDay = formatSince(new Date(2026, 7, 4, 10, 45).toISOString(), now)
+    const older = formatSince(new Date(2026, 7, 1, 9, 5).toISOString(), now)
+    expect(older.startsWith('since ')).toBe(true)
+    expect(older).toContain('05')
+    // The date must actually be visible - that is the entire point.
+    expect(older.length).toBeGreaterThan(sameDay.length)
+  })
+
+  it('an unparseable timestamp renders nothing rather than "Invalid Date"', () => {
+    expect(formatSince('not-a-time', now)).toBe('')
+    expect(formatSince('', now)).toBe('')
+  })
+
+  it('is user-facing app text: plain hyphens only', () => {
+    const src = readFileSync(join(import.meta.dir, '../lib/notice-time.ts'), 'utf8')
+    expect(src).not.toMatch(/[–—]/)
+  })
+})
+
+describe('NoticeBar renders the stamp', () => {
+  it('imports formatSince and applies it to raised_at', () => {
+    const src = readFileSync(join(import.meta.dir, '../components/NoticeBar.tsx'), 'utf8')
+    expect(src).toMatch(/from '@\/lib\/notice-time'/)
+    expect(src).toContain('formatSince(n.raised_at')
+  })
+})

--- a/ui/components/NoticeBar.tsx
+++ b/ui/components/NoticeBar.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useState } from 'react'
 import { load, subscribe } from '@/lib/bridge'
 import ConfirmDialog from '@/components/ConfirmDialog'
+import { formatSince } from '@/lib/notice-time'
 import type { Notice, RepairPreview } from '@/lib/api-types'
 
 // The one notice that can be acted on in-app rather than in a terminal.
@@ -45,6 +46,10 @@ export default function NoticeBar() {
     <div style={{ position: 'sticky', top: 0, zIndex: 50 }}>
       {notices.map((n) => {
         const s = SEVERITY_STYLES[n.severity] ?? SEVERITY_STYLES.error
+        // When the fault was raised. A notice can outlive its cause (the
+        // db.corrupt banner once survived its own repair), and the stamp is
+        // what lets a user tell a stale alarm from a live one.
+        const since = formatSince(n.raised_at)
         return (
           <div
             key={n.notice_id}
@@ -75,6 +80,11 @@ export default function NoticeBar() {
               <span style={{ fontSize: 12, color: s.text, marginLeft: 8, opacity: 0.85 }}>
                 {n.detail}
               </span>
+              {since && (
+                <span style={{ fontSize: 11, color: s.text, marginLeft: 8, opacity: 0.6, whiteSpace: 'nowrap' }}>
+                  {since}
+                </span>
+              )}
               {n.remedy && n.notice_id !== DB_CORRUPT && (
                 <div style={{ marginTop: 2, fontSize: 11, color: s.text, opacity: 0.7 }}>
                   Fix: <code style={{ fontFamily: 'var(--font-mono)', background: 'rgba(0,0,0,0.06)', padding: '1px 4px', borderRadius: 3 }}>{n.remedy}</code>

--- a/ui/lib/notice-time.ts
+++ b/ui/lib/notice-time.ts
@@ -1,0 +1,26 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Renders a system notice's `raised_at` as a short "since …" stamp for
+// NoticeBar. Exists because the db.corrupt banner outlived its own repair
+// twice on 2026-08-04 - a 05:15 fault still showing over a healthy database
+// twelve hours later - and nothing on screen said the alarm was stale. The
+// repair now clears that notice on success; this stamp is the visible check
+// on every notice that remains.
+//
+// Pure and exported for `__tests__/notice-raised-at.test.ts`.
+
+/** "since 10:45 AM" for a notice raised today, "since Aug 1, 9:05 AM" for an
+ * older one, '' when `raisedAt` does not parse (never "Invalid Date" in the
+ * banner). `now` is injectable for tests. */
+export function formatSince(raisedAt: string, now: Date = new Date()): string {
+  const d = new Date(raisedAt)
+  if (Number.isNaN(d.getTime())) return ''
+  const sameDay =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate()
+  const time = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+  if (sameDay) return `since ${time}`
+  const day = d.toLocaleDateString([], { month: 'short', day: 'numeric' })
+  return `since ${day}, ${time}`
+}


### PR DESCRIPTION
## What

Two fixes from today's corruption episode (#3), where the "database is damaged" banner outlived two successful repairs - still showing a 05:15 fault over a healthy database at 17:23.

1. **`db repair` now clears the `db.corrupt` notice in the rebuilt file.** The table copy was carrying the row across, so the banner survived the exact operation that fixes the condition it reports. The paired toast dedup row (`db.corrupt:db.corrupt`) is retracted too - otherwise the NEXT corruption is deduped away and never notifies. Other notices report faults a repair knows nothing about and are copied untouched.
2. **Every notice banner now shows when it was raised** ("since 10:45 AM", date included once older than today), so a stale alarm is distinguishable from a live one at a glance.

## How

- The notice id moves to `notices::DB_CORRUPT` (lib) so the raiser (`main.rs`), the banner, and the new clearer cannot drift.
- The scrub runs on the rebuild's single explicitly-closed connection via the new `notices::clear_typed_on` (which `clear_typed_reporting` now delegates to). A pooled acquire there races `pool.close()`'s hand-back and leaves a surviving `-wal`, which `ensure_checkpointed` rightly fails - my first version had exactly that bug and it flaked ~1-in-3 under parallel tests before ever shipping.
- `ui/lib/notice-time.ts` is a pure, injectable-clock formatter; unparseable timestamps render nothing rather than "Invalid Date".

## Tests (TDD - both written first and proven failing)

- `repair_clears_the_corrupt_notice_and_its_toast_but_keeps_others`: corrupt fixture with migration-shaped `system_notices` + `notifications` tables; failing output before the fix was `[("db.corrupt",), ("pm.jira",)]`. Run 8x parallel to confirm the WAL race is gone.
- `ui/__tests__/notice-raised-at.test.ts`: same-day vs older formatting (timezone-independent construction), invalid-input, hyphen-only copy, and a source-scan pinning NoticeBar renders the stamp.
- `cargo test --workspace` green, `bun test` 423/423, UI production build clean.

## Not in scope

This does NOT fix the corruption itself - investigation continues (leading evidence: the main DB file losing its tail relative to the b-tree, see forensics from 2026-08-04). `tray/minimum-version` deliberately stays at 1.82.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TCFYB8yahQ2D6Lt7LvCzU