### PR TITLE
docs(whats-new): backfill 1.82.0 through 1.83.2 and refresh the roadmap

### DIFF
--- a/tray/src-tauri/resources/whats-new.json
+++ b/tray/src-tauri/resources/whats-new.json
@@ -1,19 +1,91 @@
 {
   "releases": [
     {
+      "version": "1.83.2",
+      "date": "2026-08-05",
+      "highlights": [
+        "Meridian no longer reports its own background service as stopped when it is merely busy. The popover said 'Daemon: Not running' and offered a Restart button while recording carried on normally - and restarting at that moment is one of the ways the database gets damaged.",
+        "The 'database is damaged' banner now clears itself once a repair succeeds. It used to survive the very repair that fixed it, so people saw a warning about a problem that no longer existed - in one case twelve hours and two repairs later."
+      ],
+      "fixes": [
+        "Every notice banner now shows when it was raised, so a warning left over from this morning is obvious at a glance.",
+        "Fixed the background service's health check shutting down for good after one momentary error. Every screen then reported the service as stopped, next to a Restart button, while it was in fact still recording, and only restarting it cleared that.",
+        "Versions older than this one now install this update on their own rather than waiting for you to click, so a machine left on an affected build does not stay there."
+      ]
+    },
+    {
       "version": "1.83.1",
       "date": "2026-08-04",
       "highlights": [
         "The Repair Database button now actually works. In the last version, clicking through it did nothing at all - the confirmation box it relied on is invisible in the app, so repairing a damaged database meant using a terminal.",
-        "Two causes of database damage on Mac are fixed. One could strike while Meridian upgraded your data to encrypted storage; the other on any busy day, once Meridian ran out of the file handles macOS allows it.",
+        "Three causes of database damage on Mac are fixed. One could strike while Meridian upgraded your data to encrypted storage, one on any busy day once Meridian ran out of the file handles macOS allows it, and one when Meridian restarted its own background service in the middle of a write because a health check mistook 'busy' for 'stopped'.",
         "When a work log action fails, Meridian now tells you why. Approving, rejecting, posting and editing used to fail silently - the row simply snapped back to its old value with no explanation."
       ],
       "fixes": [
         "Fixed the one-time encryption upgrade running while the background service was still writing to your data, which could leave the database damaged. Meridian now stops the service first, checks nothing else is still using the file, and leaves your data alone entirely if it cannot.",
         "Fixed Meridian running out of file handles on Mac, which could damage the database in the middle of a write. It now asks the system for enough at startup.",
+        "Fixed Meridian restarting its own background service roughly every 45 seconds on a busy machine. The service was healthy every time; the check that judged it simply gave up waiting too early.",
         "On Windows machines where company policy blocks scheduled tasks, restarting no longer reports a failure every single time. The backup method was already working - only the false alarm is gone.",
         "Error reports now say which health check failed, rather than only that one did.",
         "Fixed the Windows build of the app, which had been broken by the database fixes above."
+      ]
+    },
+    {
+      "version": "1.83.0",
+      "date": "2026-08-03",
+      "highlights": [
+        "Meridian now notices when its own database has been damaged and can rebuild it from inside the app, with no terminal needed. Your data is salvaged into a fresh file, the damaged copy is kept as a backup and never deleted, and the background service stands down while the work happens.",
+        "A banner tells you when the database is damaged, and offers the repair right there rather than leaving you to find it."
+      ],
+      "fixes": [
+        "The Install button for Claude and Codex now works on Windows. It used to report that the installer had finished and the tool was still missing, when in fact nothing had been installed at all.",
+        "The 'provider unavailable' banner now catches an assistant that is installed, tested fine an hour ago, and has been failing every request since. Before, your day could quietly stay empty while the banner insisted everything was fine."
+      ]
+    },
+    {
+      "version": "1.82.3",
+      "date": "2026-08-01",
+      "highlights": [],
+      "fixes": [
+        "A failure while Meridian was starting up no longer takes the whole app down with it. It now reports the problem and carries on.",
+        "Solo users can see their confirmed daily plan again."
+      ]
+    },
+    {
+      "version": "1.82.2",
+      "date": "2026-07-31",
+      "highlights": [
+        "A brand-new install now works on its very first launch. Meridian used to look for its database moments before the background service had created it, then never look again - so the dashboard stayed empty and nothing was recorded until you quit and reopened the app."
+      ],
+      "fixes": [
+        "Meridian no longer claims your data is encrypted under a lost key when the file is actually empty or cut short. That warning told people to contact support before removing anything, when deleting the leftover stub was all that was needed.",
+        "Meridian now refuses to create a new encryption key while your existing data is still encrypted under an older one - which would have made that data permanently unreadable. It stops and explains instead of quietly locking you out.",
+        "The tray tooltip no longer gets stranded on screen after a right-click.",
+        "Windows: notifications are no longer reported as blocked when the system simply has no record of them yet.",
+        "Windows: the background service can now open an encrypted database, instead of failing to find the settings it needed.",
+        "Dropped a health check that kept reporting a problem which no longer exists."
+      ]
+    },
+    {
+      "version": "1.82.1",
+      "date": "2026-07-29",
+      "highlights": [],
+      "fixes": [
+        "A behind-the-scenes release - build and packaging fixes only, with no change to how Meridian works day to day."
+      ]
+    },
+    {
+      "version": "1.82.0",
+      "date": "2026-07-29",
+      "highlights": [
+        "If you open Meridian straight from the disk image without dragging it to Applications first, it now offers to move itself there and reopen. Before, it worked for that session but could never start itself again after a restart.",
+        "Windows setup now includes a notification permission step, so reminders work from the start rather than silently doing nothing.",
+        "Meridian pauses capture when your disk is nearly full instead of writing into it. Doing so is a known way for the database to end up damaged."
+      ],
+      "fixes": [
+        "Signing in to Claude and Codex no longer fails with 'env: node: No such file or directory'.",
+        "Windows: the one-time encryption of your existing data now runs to completion, instead of being blocked by the background service still holding the file open.",
+        "If the background service cannot start at all, that now reaches the team as an error report. It used to be completely invisible from our side."
       ]
     },
     {
@@ -229,9 +301,9 @@
   ],
   "roadmap": [
     {
-      "title": "Finish fixing database damage on Mac",
+      "title": "Track down the last cause of database damage on Mac",
       "status": "in-progress",
-      "description": "This release closes two causes. A third remains: Meridian's own health check can decide the background service has stopped responding when it is merely busy, and restart it mid-write. Until that lands, a damaged database is still possible on a heavy day."
+      "description": "Three causes are now fixed: a risky one-time encryption step, running out of file handles, and Meridian restarting its own background service when it was only busy. Damage has still been seen after all three, so at least one cause remains unidentified and we are still looking. In the meantime Meridian detects the damage and can repair it from inside the app."
     },
     {
       "title": "More trackers - Linear, Trello, and Azure DevOps",


### PR DESCRIPTION
Fills the six-release hole in the What's New modal and brings the roadmap back in line
with reality. One file, **+75/−3**.

Before this, the modal jumped **1.81.0 → 1.83.1** — so 1.82.0, 1.82.1, 1.82.2, 1.82.3,
1.83.0 and the 1.83.2 this batch cuts had never been shown to anyone. Each entry is
written from that tag range's merged PRs and rewritten in user terms, never a pasted
commit subject.

*(To be clear on scope: this is `whats-new.json`, the hand-curated user-facing notes.
`CHANGELOG.md` is semantic-release-generated and commit-level by design — hand edits there
would just be overwritten.)*

## What each entry covers

| Version | Lead item |
|---|---|
| **1.83.2** | False "Daemon: Not running" beside a Restart button while recording carried on; the damage banner now clears itself when a repair succeeds |
| **1.83.0** | Detect and repair a damaged database from inside the app; Windows Install button for Claude/Codex; the provider banner catching an assistant that fails *after* a good test |
| **1.82.3** | A startup failure no longer takes the whole app down; solo users see their confirmed plan |
| **1.82.2** | A brand-new install working on its first launch, rather than staying empty until you quit and reopen |
| **1.82.1** | Nothing user-visible — see below |
| **1.82.0** | Self-relocate to /Applications from a DMG launch; Windows notification permission step; capture pauses on a nearly-full disk |

## Three judgement calls

**1.82.1 gets an entry saying it was build-and-packaging only, rather than being skipped.**
A gap in the version list reads as a release being hidden; one honest line reads as a quiet
week. Its `highlights` array is empty, which the modal renders as nothing at all — both
sections are gated on `length > 0`.

**The 1.83.1 entry is corrected, not merely preceded.** It was written while #677 was still
open, and **#678 — the watchdog killing a healthy daemon mid-write every ~45 s — landed in
that same release afterwards.** The entry claimed *two* causes of database damage were
fixed when three were, and omitted the one most likely to have actually hit the reader. A
history that undercounts its own fixes is worse than none.

**The roadmap item is rewritten** for the same reason: it described the watchdog cause as
still to come, and that shipped in 1.83.1. It now says three causes are fixed, that damage
was **still seen after all three**, and that a cause therefore remains unidentified. That
is the current state per #684, and it is not a comfortable thing to leave vague on the one
screen users read about their own data.

### Deliberately not re-litigated

1.83.0's entry describes the repair feature as shipped without noting that its button was
inert. The 1.83.1 entry directly above it already says the button did nothing and now
works — saying it twice reads as apology rather than history.

## Verification

- `cargo test -p meridian-tray whats_new` → **4 passed**, including
  `whats_new_json_parses`, which CLAUDE.md requires for any edit to this file.
- **The three deleted lines are exactly** the 1.83.1 highlight and the two roadmap fields
  rewritten above — `json.dumps(indent=2)` round-trips the rest byte-for-byte, so no
  existing entry moved.
- Release ordering is asserted newest-first before writing; out of order would put the
  "latest" badge on the wrong row.
- Checked for em-dash / en-dash / double-hyphen before writing, per the hard rule on
  user-facing app text. Plain hyphens only.
- Full pre-push suite green: `cargo fmt` · `cargo clippy --workspace` · `cargo test
  --workspace` · UI build · UI tests · security audit.

## Sequencing

Targets `pre-main`, so it wants to land **before** release PR #688 merges if 1.83.2 is to
ship with its own notes. #688 does not depend on it — merging #688 first just means 1.83.2
ships without a What's New entry and this lands in the following release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
