### PR TITLE
fix(review): address PR #688's CodeRabbit findings

### DIFF
--- a/src/notices.rs
+++ b/src/notices.rs
@@ -11,6 +11,7 @@
 
 use anyhow::{Context, Result};
 use sqlx::SqlitePool;
+use tracing::Instrument;
 
 /// Notice id raised when `meridian.db` is structurally damaged.
 ///
@@ -141,6 +142,12 @@ pub async fn clear_typed_reporting(pool: &SqlitePool, id: &str, event_key: &str)
 /// [`clear_typed_reporting`] for callers holding a single `SqliteConnection`
 /// rather than a pool.
 ///
+/// Deletes the `system_notices` row for `id` and best-effort retracts the
+/// paired notification keyed `{event_key}:{id}`. Returns `true` only when the
+/// `system_notices` row existed and was deleted — the paired notification
+/// delete is best-effort (logged, never propagated) and does not affect the
+/// return value.
+///
 /// Exists for `db::repair`'s rebuild, which must run EVERY write on one
 /// explicitly-closed connection: a pooled acquire there is handed back to the
 /// pool from a spawned task on drop, `pool.close()` does not reliably wait for
@@ -156,15 +163,20 @@ pub async fn clear_typed_on(
     let result = sqlx::query("DELETE FROM system_notices WHERE notice_id = ?")
         .bind(id)
         .execute(&mut *conn)
+        .instrument(tracing::debug_span!("notices.clear.system_notices"))
         .await
         .context("clearing system notice")?;
     // Retract the paired toast so a future re-occurrence of this fault notifies
     // again instead of being deduped away. Best-effort, matching
     // `notifications::retract` — same statement, same dedup-key shape.
-    let _ = sqlx::query("DELETE FROM notifications WHERE dedup_key = ?")
+    if let Err(e) = sqlx::query("DELETE FROM notifications WHERE dedup_key = ?")
         .bind(format!("{event_key}:{id}"))
         .execute(&mut *conn)
-        .await;
+        .instrument(tracing::debug_span!("notices.clear.notifications"))
+        .await
+    {
+        tracing::warn!(id, event_key, error = %e, "notices: best-effort notification retract failed");
+    }
     Ok(result.rows_affected() > 0)
 }
 

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -233,12 +233,39 @@ mod tests {
     #[test]
     fn an_accept_error_must_not_end_the_health_listener() {
         let src = include_str!("unix.rs");
-        let arm = src
+        // Brace-matched rather than a fixed byte window: a window can either
+        // truncate before `continue` (a false failure on an untouched arm) or
+        // run past this arm's closing brace into whatever follows (a `break`
+        // anywhere later in the file would then fail this test for the wrong
+        // reason). Capturing the exact `Err(e) => { ... }` body is immune to
+        // both as the arm grows or shrinks.
+        let arm_start = src
+            .find("Err(e) => {")
+            .expect("the accept-error match arm exists")
+            + "Err(e) => {".len();
+        let mut depth = 1i32;
+        let mut arm_end = None;
+        for (i, c) in src[arm_start..].char_indices() {
+            match c {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        arm_end = Some(arm_start + i);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let arm = &src[arm_start..arm_end.expect("the accept-error arm's closing brace")];
+        // The policy is what runs AFTER the warn log, not the arm's leading
+        // explanatory comment - which itself narrates the old `break` bug in
+        // prose and would trip a naive `contains("break")` over the whole arm.
+        let policy = arm
             .split("daemon.sock accept error")
             .nth(1)
-            .expect("the accept-error arm exists");
-        // The policy lives in the ~120 chars after the warn line.
-        let policy = &arm[..arm.len().min(120)];
+            .expect("the warn log is inside the matched arm");
         assert!(
             !policy.contains("break"),
             "the accept-error arm breaks the loop - one transient error would \


### PR DESCRIPTION
Addresses CodeRabbit's review on release PR #688 — 3 of 5 findings fixed, 2 answered on
the thread rather than applied as suggested.

## Fixed

**`src/notices.rs` — `clear_typed_on`'s doc contract** ([comment](https://github.com/Meridiona/meridian/pull/688#discussion_r0)) — the doc comment now
states what `id`/`event_key` mean and that the `bool` return reports the
`system_notices` deletion specifically, not the paired notification.

**`src/notices.rs` — instrument the two DELETEs** — added `.instrument(debug_span!(...))`
to both queries, matching `worklog_pipeline::{hour_db,task_db}`'s exact convention
(static span name, no dynamic fields on the span). The notification retract's failure —
previously a bare `let _ =`, fully silent — now logs a `warn!` with the error. It stays
best-effort and still doesn't affect the return value: a repair must not fail over a
toast dedup row.

**`src/platform/unix.rs` — test brittleness on the accept-error arm** — the test now
brace-matches the `Err(e) => { ... }` arm instead of asserting over a fixed 120-byte
window after the log line. The window happened to fit today, but could equally truncate
before `continue` (failing on an untouched arm) or run past this arm's own closing brace
into unrelated code (a `break` anywhere later in the file would then fail this test for
the wrong reason). Verified against the regression this test exists to catch, not just
the current pass: reverting the fix to `break` (the pre-#686 bug) fails it, same as
before.

## Not applied — answered on the thread instead

**Classify `accept()` errors into recoverable-vs-terminal, break on the latter.** No
reachable terminal case exists for this fd: it's owned solely by this task and never
closed elsewhere, so there's no "listener became invalid" scenario to detect. The whole
point of the commit this arm belongs to was removing exactly this kind of premature
termination on a transient error (see PR #686 / the incident it fixed — the health
endpoint used to die permanently on one EMFILE/ECONNABORTED). Implementing the suggestion
as written risks reintroducing that.

**Wrap the accept loop in a span with `otel.status_code = ERROR`.** No `.set_status()`
call exists anywhere in this codebase — there's no established convention to follow, and
wrapping an infinite loop in a single span isn't standard OTel practice (it would never
close under normal operation). The existing `warn!(error = %e, "daemon.sock accept
error")` already carries everything needed to diagnose this specific failure.

## Verification

- `cargo fmt` clean, `cargo clippy --workspace --all-targets -D warnings` clean.
- Both touched test modules green (`platform::`, `notices::`).
- The unix.rs test fix was verified against the regression, not just the fix: reverting
  to `break` reproduces the original failure.
- Full pre-push suite green: `cargo fmt` · `cargo clippy --workspace` · `cargo test
  --workspace` · UI build · UI tests · security audit.

Targets `pre-main`, so it flows into #688 once merged, same as the other PRs in this
batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
