### PR TITLE
fix(telemetry): spool prune was stalling the daemon's runtime for 30-100s

### DIFF
--- a/src/telemetry_spool/retention.rs
+++ b/src/telemetry_spool/retention.rs
@@ -8,8 +8,10 @@
 //!
 //! # Who calls this
 //! `shipper::run_tick()`, every `MERIDIAN_TELEMETRY_SHIP_INTERVAL_S` (default
-//! 30s), before the ship-target check: orphan sweep → age-based prune (both
-//! `pending/` and `sent/`) → pending-size cap → (only then) ship attempt.
+//! 30s), before the ship-target check — as ONE [`run_housekeeping`] unit on
+//! `spawn_blocking`, never inline on the runtime: orphan sweep → age-based
+//! prune (both `pending/` and `sent/`, rationed to every 60th tick — see
+//! [`prune_due`]) → pending-size cap → (only then) ship attempt.
 //!
 //! # Related
 //! - `writer.rs` — the `<signal>-<unix_micros>-<seq>.otlp` filename scheme
@@ -99,6 +101,48 @@ pub(super) fn list_pending_oldest_first(dir: &Path) -> Vec<PathBuf> {
 
     files.sort_by_key(|(m, s, _)| (*m, *s));
     files.into_iter().map(|(_, _, p)| p).collect()
+}
+
+/// Should tick `tick` run the age prune? Tick 0, then every 60th tick
+/// (~every 30 min at the default 30 s ship interval).
+///
+/// The prune scans BOTH spool dirs file-by-file, and `sent/` sits at a
+/// ~264k-file steady state (one file per flush x 7-day retention) — measured
+/// at 263,787 files on 2026-08-05, when thread sampling caught the shipper
+/// tick pinned in `prune_by_age -> stat` on a tokio runtime worker while the
+/// daemon's poll timers ran 30-100 s late and its socket greeting starved
+/// (the probe false-negatives behind the tray's status flapping and the old
+/// watchdog storms). A 7-day cutoff needs nothing close to twice-a-minute
+/// precision: every 60th tick bounds the scan cost, and tick 0 still prunes
+/// so a daemon that was stopped for days catches up on its first tick. Same
+/// tick-counter idiom as `etl::capture_retention`'s vacuum cadence.
+pub(super) fn prune_due(tick: u64) -> bool {
+    tick.is_multiple_of(60)
+}
+
+/// The shipper tick's whole filesystem sweep, as one blocking unit: clear
+/// crash-orphaned tmp files, age-prune both dirs (only when `prune` — see
+/// [`prune_due`]), and enforce the pending-size cap.
+///
+/// Exists so `shipper::run_tick` can hand the entire sweep to
+/// `tokio::task::spawn_blocking` and never touch these helpers from async
+/// context itself — every call here walks directories and `stat`s files, and
+/// doing that on a runtime worker is exactly the stall described on
+/// [`prune_due`]. The shipper's source is pinned to this split by
+/// `housekeeping_stays_off_the_async_runtime` in `shipper.rs`.
+pub(super) fn run_housekeeping(
+    pending: &Path,
+    sent: &Path,
+    cutoff_secs: u64,
+    prune: bool,
+) -> Result<()> {
+    sweep_tmp_orphans(pending);
+    if prune {
+        prune_by_age(pending, cutoff_secs)?;
+        prune_by_age(sent, cutoff_secs)?;
+    }
+    crate::telemetry_spool::launchd_log_cap::cap_launchd_logs();
+    enforce_pending_cap(pending)
 }
 
 /// Delete `.otlp` files in `dir` whose mtime is older than `cutoff_secs`.
@@ -252,6 +296,63 @@ mod tests {
             .to_str()
             .unwrap()
             .ends_with("-1.otlp"));
+    }
+
+    /// The prune cadence. Every 30 s ship tick used to age-scan BOTH spool
+    /// dirs, and `sent/` sits at a ~264k-file steady state (one file per
+    /// flush x 7-day retention) - so the daemon issued ~264k blocking `stat`s
+    /// twice a minute on a tokio runtime worker. Caught live by thread
+    /// sampling on 2026-08-05: the shipper tick was pinned in
+    /// `prune_by_age -> stat` while the daemon's 60 s poll timers fired
+    /// 30-100 s late and its socket greeting starved (the probe
+    /// false-negatives behind the status flapping and the old watchdog
+    /// storms). A 7-day cutoff does not need twice-a-minute precision; every
+    /// 60th tick is ample, and the first tick still prunes so a long-stopped
+    /// daemon catches up promptly on start.
+    #[test]
+    fn prune_runs_on_the_first_tick_then_every_60th() {
+        assert!(
+            prune_due(0),
+            "first tick must prune (catch-up after downtime)"
+        );
+        for t in 1..60 {
+            assert!(
+                !prune_due(t),
+                "tick {t} must not prune - the scan is ~264k stats"
+            );
+        }
+        assert!(prune_due(60));
+        assert!(!prune_due(61));
+        assert!(prune_due(120));
+    }
+
+    /// One call owning the whole blocking sweep, so the shipper can hand it to
+    /// `spawn_blocking` as a unit and its own source never touches the
+    /// filesystem helpers directly (pinned by a source-scan in `shipper.rs`).
+    ///
+    /// Asserted on `sent/` only: `pending/` is also subject to
+    /// `enforce_pending_cap`, whose size cap reads an env var that other
+    /// tests mutate - under a parallel run the cap can legitimately drop a
+    /// pending file and turn a gating assertion flaky. Only the age prune
+    /// ever touches `sent/`, so it isolates the gate. (Both-dirs prune
+    /// coverage lives in the `prune_by_age_*` tests above.)
+    #[test]
+    fn run_housekeeping_prunes_only_when_due() {
+        let dir = TempDir::new().unwrap();
+        let pending = pending_dir(dir.path());
+        std::fs::create_dir_all(&pending).unwrap();
+        let sent = dir.path().join("sent");
+        std::fs::create_dir_all(&sent).unwrap();
+        let s = sent.join("traces-1-0.otlp");
+        std::fs::write(&s, b"x").unwrap();
+
+        // Not due: survives a keep-nothing cutoff.
+        run_housekeeping(&pending, &sent, 0, false).unwrap();
+        assert!(s.exists(), "not-due housekeeping must not prune");
+
+        // Due: the 0-second cutoff removes it.
+        run_housekeeping(&pending, &sent, 0, true).unwrap();
+        assert!(!s.exists(), "due housekeeping must prune");
     }
 
     #[test]

--- a/src/telemetry_spool/shipper.rs
+++ b/src/telemetry_spool/shipper.rs
@@ -5,14 +5,20 @@
 // Runs in a tokio background task spawned from main.rs. Every
 // `MERIDIAN_TELEMETRY_SHIP_INTERVAL_S` seconds (default 30):
 //
+// Steps 1-3 are ONE `retention::run_housekeeping` unit handed to
+// `spawn_blocking` — never inline on the runtime, because sent/ sits at a
+// ~264k-file steady state and walking it on a runtime worker stalled the
+// daemon's timers 30-100s (see `retention::prune_due` for the incident):
+//
 //   1. Sweep crash-orphaned .otlp.tmp files.
 //   2. Retention: age-prune BOTH pending/ and sent/ (files older than
-//      MERIDIAN_TELEMETRY_RETENTION_DAYS, default 7) — this runs UNCONDITIONALLY,
-//      before the ship-target check below, so a Canonical/packaged install
-//      (which never ships — see `observability::resolve_otlp_target`) still
-//      enforces retention on the local spool instead of growing it forever.
-//      Also caps the launchd-redirected raw log files (daemon.log etc. — the
-//      crash safety net, unrelated to the OTel spool) at
+//      MERIDIAN_TELEMETRY_RETENTION_DAYS, default 7) — rationed to every 60th
+//      tick (~30 min; tick 0 prunes so a long-stopped daemon catches up), and
+//      independent of the ship-target check below, so a Canonical/packaged
+//      install (which never ships — see `observability::resolve_otlp_target`)
+//      still enforces retention on the local spool instead of growing it
+//      forever. Also caps the launchd-redirected raw log files (daemon.log
+//      etc. — the crash safety net, unrelated to the OTel spool) at
 //      MERIDIAN_LAUNCHD_LOG_MAX_MB (default 10) via copytruncate, since they
 //      have no rotation of their own.
 //   3. Pending cap: drop OLDEST beyond MERIDIAN_TELEMETRY_MAX_PENDING_MB (512) with warn.

--- a/src/telemetry_spool/shipper.rs
+++ b/src/telemetry_spool/shipper.rs
@@ -32,7 +32,7 @@
 
 use std::{
     path::Path,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
     time::Duration,
 };
 
@@ -43,11 +43,8 @@ use crate::{
     observability::{resolve_otlp_endpoint, resolve_otlp_target},
     telemetry_spool::{
         derive_base_url,
-        launchd_log_cap::cap_launchd_logs,
         redact::{redact_and_filter, Redacted},
-        retention::{
-            enforce_pending_cap, list_pending_oldest_first, prune_by_age, sweep_tmp_orphans,
-        },
+        retention::{list_pending_oldest_first, prune_due, run_housekeeping},
         ship_one,
         writer::{
             pending_dir, quarantine_dir, resolve_telemetry_dir, sent_dir, signal_from_filename,
@@ -61,6 +58,11 @@ const DEFAULT_RETENTION_DAYS: u64 = 7;
 
 /// One-time guard so "export enabled but no credentials" warns once, not every tick.
 static WARNED_NO_CREDS: AtomicBool = AtomicBool::new(false);
+
+/// Tick counter driving the prune cadence (see `retention::prune_due`).
+/// Process-lifetime only — resetting on restart just means the first tick
+/// prunes again, which is the desired catch-up behaviour.
+static TICK_COUNT: AtomicU64 = AtomicU64::new(0);
 
 fn ship_interval() -> Duration {
     let secs = std::env::var("MERIDIAN_TELEMETRY_SHIP_INTERVAL_S")
@@ -114,21 +116,28 @@ async fn run_tick() -> Result<()> {
     let sent = sent_dir(&base);
     let quarantine = quarantine_dir(&base);
 
-    // Clear crash-orphaned `.otlp.tmp` files first so they can't accumulate
-    // unbounded (they're invisible to both the cap and the lister otherwise).
-    sweep_tmp_orphans(&pending);
-
-    // Retention: age-prune BOTH dirs UNCONDITIONALLY — before any ship-target
-    // check. A Canonical/packaged install never ships (resolve_otlp_target()
-    // always returns None for it), so pending/ is the only place spooled
-    // telemetry ever lives; retention must not depend on delivery happening.
-    let retention_secs = retention_days() * 24 * 3600;
-    prune_by_age(&pending, retention_secs)?;
-    prune_by_age(&sent, retention_secs)?;
-    cap_launchd_logs();
-
-    // Enforce pending cap BEFORE trying to ship so we don't OOM on a long OO outage.
-    enforce_pending_cap(&pending)?;
+    // The whole filesystem sweep (tmp-orphan clear, age prune, launchd log
+    // cap, pending cap) runs as ONE unit on the BLOCKING pool, with the age
+    // prune rationed to every 60th tick. Both halves are load-bearing:
+    // `sent/` sits at a ~264k-file steady state and the prune `stat`s every
+    // one, so running it inline on a runtime worker twice a minute stalled
+    // the daemon's timers 30-100 s and starved its socket greeting - the
+    // probe false-negatives behind the tray's status flapping and the old
+    // watchdog storms (thread-sampled live, 2026-08-05; the whole story is on
+    // `retention::prune_due`). Retention itself stays UNCONDITIONAL relative
+    // to shipping - it must run before any ship-target check, because a
+    // Canonical/packaged install never ships and pending/ is its only spool.
+    let tick = TICK_COUNT.fetch_add(1, Ordering::Relaxed);
+    {
+        let pending = pending.clone();
+        let sent = sent.clone();
+        let retention_secs = retention_days() * 24 * 3600;
+        tokio::task::spawn_blocking(move || {
+            run_housekeeping(&pending, &sent, retention_secs, prune_due(tick))
+        })
+        .await
+        .context("telemetry housekeeping task")??;
+    }
 
     // Resolve ship target — None means OO not configured, leave files.
     let Some(target) = resolve_otlp_target() else {
@@ -311,6 +320,36 @@ mod tests {
     use super::*;
     use crate::telemetry_spool::writer::write_pending;
     use tempfile::TempDir;
+
+    /// The shipper's filesystem sweep must reach the disk ONLY through
+    /// `retention::run_housekeeping` handed to `spawn_blocking` - calling the
+    /// per-step helpers inline from this async module is exactly the ~264k
+    /// blocking `stat`s per tick that stalled the daemon's timers and starved
+    /// its socket greeting (see `retention::prune_due`). Nothing at a call
+    /// site would look wrong in review, so the split is pinned at the source
+    /// level.
+    #[test]
+    fn housekeeping_stays_off_the_async_runtime() {
+        let src = include_str!("shipper.rs");
+        assert!(
+            src.contains("spawn_blocking"),
+            "the housekeeping sweep must run on the blocking pool"
+        );
+        // Needles assembled at runtime so this test's own source (included in
+        // the scan) cannot match them.
+        for helper in [
+            format!("prune_by_{}", "age"),
+            format!("sweep_tmp_{}", "orphans"),
+            format!("enforce_pending_{}", "cap"),
+            format!("cap_launchd_{}", "logs"),
+        ] {
+            assert!(
+                !src.contains(&helper),
+                "{helper} called directly from the async shipper - route it \
+                 through retention::run_housekeeping inside spawn_blocking"
+            );
+        }
+    }
 
     /// Verifies that a pending file is moved to sent/ when the HTTP call would
     /// succeed.  We simulate a successful "ship" by calling the move logic


### PR DESCRIPTION
## The investigation

Follow-up to #686's open question: why do the daemon's 60 s ETL ticks stretch to 89-164 s? Answered by catching a stall live: a monitor probed the daemon's socket every 2 s and ran `sample` (thread stacks) the instant a probe missed. The stalled thread, pinned at 74% CPU:

```
shipper::run_tick
  -> telemetry_spool::retention::prune_by_age
      -> std::fs::ReadDir::next -> __getdirentries64   (376 samples)
      -> std::fs::metadata      -> stat                (1,958 samples)
```

`sent/` sits at a **~264k-file steady state** (one file per flush x 7-day retention; measured 263,787), and every **30 s** shipper tick re-scanned all of it - blocking `read_dir` + per-file `stat`, inline on a tokio runtime worker. During the walks the daemon's poll timers fired 30-100 s late and its socket greeting starved: the alive-but-slow-to-greet false negative behind the status flapping (#686) and, pre-#678, the watchdog restart storms. One cause, three symptoms.

## The fix

1. **The whole filesystem sweep moves to the blocking pool** as one `retention::run_housekeeping` unit - the runtime never blocks on it again.
2. **The age prune is rationed to every 60th tick** (~30 min at the default interval; tick 0 still prunes so a long-stopped daemon catches up). A 7-day cutoff does not need twice-a-minute precision.

## Tests (TDD, proven failing first)

- `prune_runs_on_the_first_tick_then_every_60th` + `run_housekeeping_prunes_only_when_due` - E0425 before the fns existed; the latter asserts on `sent/` only because `pending/` is subject to the env-configured cap that parallel tests mutate (found as a real 1-in-N flake during development)
- `housekeeping_stays_off_the_async_runtime` - source-scan: the async shipper must not call any fs helper directly; needles assembled at runtime so the test cannot match its own source

`cargo test --workspace` green (23 suites), clippy `-D warnings` clean.

## Verification after it ships

On staging: ETL tick gaps should pin to ~60 s (was 4-10 stretched ticks/hour), and the popover/badge should hold steady even before #686's second opinion - #686 stays correct regardless (any future slow-to-greet moment must still not read as an outage).

## Follow-up deliberately not here

`sent/` holding a quarter-million files is itself worth fixing (day-sharded subdirs or batched spool files) - this PR makes the scan harmless, not the file count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TCFYB8yahQ2D6Lt7LvCzU