### PR TITLE
test(notices): pin clear_typed_on's notification retract

### DIFF
--- a/src/notices.rs
+++ b/src/notices.rs
@@ -231,4 +231,82 @@ mod tests {
             .unwrap();
         assert!(!cleared_again);
     }
+
+    /// The test above only checks `system_notices` — it would pass even if
+    /// `clear_typed_on`'s second DELETE (the paired notification retract)
+    /// were broken or missing entirely. Exercises `clear_typed_on` directly,
+    /// since that is the connection-scoped API `db::repair::rebuild` actually
+    /// calls, and asserts on the `notifications` table itself: the matching
+    /// `dedup_key` row is gone, and an unrelated one is untouched — proving
+    /// the DELETE is scoped to `{event_key}:{id}`, not a blanket wipe.
+    #[tokio::test]
+    async fn clear_typed_on_retracts_only_the_matching_notification() {
+        let pool = fresh_db().await;
+
+        raise_typed(
+            &pool,
+            Notice {
+                id: "tray.daemon_quiet",
+                severity: "warning",
+                title: "Meridian went quiet.",
+                detail: "Tap to check what happened.",
+                remedy: None,
+                event_key: "system.health",
+                deep_link: Some("/logs"),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Unrelated dedup key — must survive the clear below.
+        crate::notifications::enqueue(
+            &pool,
+            crate::notifications::NewNotification::event(
+                "system.fault:other.fault",
+                "system.fault",
+                "Unrelated fault",
+                "should not be touched",
+            ),
+        )
+        .await
+        .unwrap();
+
+        let matching = "system.health:tray.daemon_quiet";
+        let matching_before: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM notifications WHERE dedup_key = ?")
+                .bind(matching)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            matching_before, 1,
+            "raise_typed must have enqueued the paired toast"
+        );
+
+        let mut conn = pool.acquire().await.unwrap();
+        let cleared = clear_typed_on(&mut conn, "tray.daemon_quiet", "system.health")
+            .await
+            .unwrap();
+        drop(conn);
+        assert!(cleared);
+
+        let matching_after: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM notifications WHERE dedup_key = ?")
+                .bind(matching)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            matching_after, 0,
+            "clear_typed_on must retract the paired notification, not just system_notices"
+        );
+
+        let unrelated: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM notifications WHERE dedup_key = ?")
+                .bind("system.fault:other.fault")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(unrelated, 1, "an unrelated dedup key must not be touched");
+    }
 }


### PR DESCRIPTION
Addresses one CodeRabbit finding from #688's re-review (the other was a stale-PR-body
claim, not a code issue — see below). One file, +78/−0.

## Fixed

**`src/notices.rs` — `clear_typed_on`'s test only checked half of what it does.**
`clear_typed_reporting_is_true_only_when_a_row_actually_existed` asserts on the `bool`
return value only. It can pass even if `clear_typed_on`'s second DELETE — the paired
`notifications` retract — were broken or missing entirely, because nothing in that test
ever queries the `notifications` table.

Added `clear_typed_on_retracts_only_the_matching_notification`: seeds a matching AND an
unrelated dedup key, calls `clear_typed_on` directly (the connection-scoped API
`db::repair::rebuild` actually calls, not `clear_typed_reporting`), and asserts on
`notifications` itself — the matching row is gone, the unrelated one survives. That last
part matters: it proves the DELETE is scoped to `{event_key}:{id}`, not a blanket wipe.

Verified test-first, per this repo's convention: simulated the bug by removing the
retract DELETE entirely. The new test fails with `left: 1, right: 0` on exactly the
assertion it's meant to guard; the *original* test stays green throughout — confirming
CodeRabbit's premise that the existing coverage genuinely cannot see this failure mode.

## Not a code fix — the other finding was about a stale PR description

CodeRabbit also flagged that `whats-new.json`'s 1.83.2 entry contradicts #688's own PR
body, which says "No What's New entry for 1.83.2" under Known Gaps. That line predates
#689 (which added the entry as part of backfilling 1.82.0–1.83.2) — the PR body was never
updated after #689 merged into `pre-main`. The fix is updating that stale line in #688's
description, not deleting the entry: the missing entry was the actual gap being closed,
not a constraint to uphold. Updating #688's body separately; no code change here.

## Verification

- `cargo fmt` clean, `cargo clippy --workspace --all-targets -D warnings` clean.
- `notices::` tests: 2 passed.
- Full pre-push suite green: `cargo fmt` · `cargo clippy --workspace` · `cargo test
  --workspace` · UI build · UI tests · security audit.

Targets `pre-main`, flows into #688 once merged, same pattern as the rest of this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
