### PR TITLE
fix(tray): stop the daemon when Meridian quits, and make Pause actually pause

### DIFF
--- a/src/db/repair/marker.rs
+++ b/src/db/repair/marker.rs
@@ -21,6 +21,24 @@
 //!   hand. Recovery tooling must not be able to brick the thing it is
 //!   recovering.
 //!
+//! The tray *does* now automate a bootout, for quit and for the pause toggle
+//! (`tray/src-tauri/src/daemon_lifecycle.rs`). That is not a reversal of the
+//! paragraph above, and repair still does not use it, for two reasons worth
+//! keeping straight:
+//!
+//! - What wedged the plist was `launchctl disable`, an override that persists
+//!   across boots. The tray never calls it, and its bootout goes through a
+//!   helper that waits for the launchd entry to clear before anything tries to
+//!   bootstrap again - which is the specific sequencing that produced the EIO.
+//! - More importantly, the two have different requirements. A quit or a pause
+//!   needs the daemon down *until the tray comes back*, and the tray is the
+//!   thing that brings it back. A repair needs it down across an unbounded
+//!   number of `KeepAlive` relaunches, driven by a tray that may itself be
+//!   crash-looping - which is exactly the case where "the tray will undo this"
+//!   is the assumption that fails. Hence a marker the daemon honours on its own,
+//!   with an expiry, rather than launchd state something has to survive to
+//!   restore.
+//!
 //! So neither side fights launchd. The tray writes a marker; the daemon checks
 //! for it before touching the database and exits cleanly if it is there. A
 //! KeepAlive relaunch is then harmless - the daemon simply stands down again,

--- a/src/db/repair/mod.rs
+++ b/src/db/repair/mod.rs
@@ -206,32 +206,34 @@ pub async fn ensure_no_writers() -> Result<()> {
 /// exact failure this whole feature exists to remove, reintroduced in its own
 /// error path.
 ///
-/// Two things make the real answer non-obvious, which is why it is spelled out
-/// rather than left to the reader:
-/// - **Quitting the tray does not stop the daemon.** They are separate
-///   processes; the daemon is its own launchd agent (`com.meridiona.daemon`) /
-///   scheduled task.
-/// - **Killing the process does not stop it either.** The launchd plist sets
-///   `KeepAlive=true`, so it is relaunched within seconds - and a daemon that
-///   respawns mid-rebuild writes to the file being copied.
+/// **Quitting Meridian is now the answer**, and it did not used to be. The tray
+/// and the daemon are separate processes, and quitting the tray left the daemon
+/// running - so a user who followed the `db.corrupt` notice ("quit Meridian,
+/// then run `meridian db repair`") hit this very error, from the check directly
+/// above. The tray now takes the daemon down with it on quit
+/// (`tray/src-tauri/src/daemon_lifecycle.rs`), which also satisfies
+/// [`tray_is_running`] in one action instead of two.
 ///
-/// Pausing from the tray menu is offered first because it is the supported
-/// control (`tray/src-tauri/src/commands/daemon.rs`'s `toggle_daemon` ->
-/// `daemon_control::set_running`) and it is the same on every platform.
+/// The manual routes stay, because this message is also read on a machine where
+/// the tray is not installed or will not start, and because one thing about the
+/// old text remains true and non-obvious: **killing the process does not stop
+/// it**. The launchd plist sets `KeepAlive=true`, so it is relaunched within
+/// seconds, and a daemon that respawns mid-rebuild writes to the file being
+/// copied. `bootout` is the verb that holds; `stop` is not.
 fn stop_daemon_hint() -> &'static str {
     #[cfg(target_os = "macos")]
     {
-        "pause tracking from the Meridian tray menu, or run: \
-         launchctl bootout gui/$(id -u)/com.meridiona.daemon"
+        "quit Meridian from the tray menu, which now stops the daemon too, \
+         or run: launchctl bootout gui/$(id -u)/com.meridiona.daemon"
     }
     #[cfg(target_os = "windows")]
     {
-        "pause tracking from the Meridian tray menu, or disable the Meridian \
-         scheduled task"
+        "quit Meridian from the tray menu, which now stops the daemon too, \
+         or end the Meridian scheduled task"
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
-        "pause tracking from the Meridian tray menu"
+        "quit Meridian from the tray menu, which now stops the daemon too"
     }
 }
 
@@ -442,8 +444,14 @@ mod tests {
             "hint names a `meridian <verb>` that may not exist: {hint}"
         );
         // ...and it must still tell the user something concrete to do.
+        //
+        // The supported control used to be "pause tracking", which was doubly
+        // wrong: the toggle ran `launchctl stop` and `KeepAlive` undid it, and
+        // the user then had to quit the tray as a second step anyway to get
+        // past `tray_is_running`. Quitting now does both, so that is what the
+        // hint names.
         assert!(
-            hint.contains("pause tracking"),
+            hint.contains("quit Meridian"),
             "hint must name the supported control: {hint}"
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1175,7 +1175,7 @@ async fn main() -> Result<()> {
                                 title: "Meridian's database is damaged",
                                 detail: &problems.join("; "),
                                 remedy: Some(
-                                    "Pause tracking, quit Meridian, then run 'meridian db repair' in a terminal",
+                                    "Quit Meridian, then run 'meridian db repair' in a terminal",
                                 ),
                                 event_key: DB_CORRUPT_NOTICE,
                                 deep_link: Some("/logs"),
@@ -1491,7 +1491,7 @@ async fn etl_tick(meridian: &meridian::db::SqlitePool) -> bool {
                     severity: "error",
                     title: "Meridian's database is damaged",
                     detail: &e.to_string(),
-                    remedy: Some("Pause tracking, quit Meridian, then run 'meridian db repair' in a terminal"),
+                    remedy: Some("Quit Meridian, then run 'meridian db repair' in a terminal"),
                     event_key: DB_CORRUPT_NOTICE,
                     deep_link: Some("/logs"),
                 },

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -124,7 +124,7 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
             tracing::debug!(
                 "backend_install: no bundled backend (dev/source run) — skipping staging"
             );
-            ensure_daemon_running(&home).await;
+            crate::daemon_lifecycle::restore_unless_paused(&home).await;
             return;
         }
     };
@@ -134,7 +134,7 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
         Ok(h) => h,
         Err(e) => {
             tracing::warn!(error = %e, src = %daemon_src.display(), "backend_install: cannot hash bundled daemon");
-            ensure_daemon_running(&home).await;
+            crate::daemon_lifecycle::restore_unless_paused(&home).await;
             return;
         }
     };
@@ -145,7 +145,7 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
         // encrypt-in-place migration stops it earlier this launch (see lib.rs's
         // setup hook) to unlock meridian.db, and it can also simply crash. Bring
         // it back so a skipped *staging* never leaves a stopped *daemon*.
-        ensure_daemon_running(&home).await;
+        crate::daemon_lifecycle::restore_unless_paused(&home).await;
         return;
     }
 
@@ -190,7 +190,7 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
         // last-known-good daemon can usually still be started - and it has to
         // be, because quit boots the agent out and nothing else will bring it
         // back before the next launch (which may fail here again).
-        ensure_daemon_running(&home).await;
+        crate::daemon_lifecycle::restore_unless_paused(&home).await;
         return;
     }
     if let Some(p) = pool.as_ref() {
@@ -1325,7 +1325,7 @@ mod tests {
     use super::*;
 
     /// Every path out of [`ensure_backend_installed`] that could leave a daemon
-    /// down must call [`ensure_daemon_running`] first.
+    /// down must call [`crate::daemon_lifecycle::restore_unless_paused`] first.
     ///
     /// This is the other half of "quit stops the daemon"
     /// ([`crate::daemon_lifecycle`]) and it is the half with no natural failure
@@ -1351,7 +1351,7 @@ mod tests {
 
         // Every `return;` must be preceded by a restore. The one exception is
         // the path where `$HOME` itself could not be resolved - there is no
-        // `home` to hand `ensure_daemon_running`, and nothing it could do.
+        // `home` to hand the restore, and nothing it could do.
         let lines: Vec<&str> = body.lines().collect();
         let mut unguarded: Vec<usize> = Vec::new();
         for (i, line) in lines.iter().enumerate() {
@@ -1360,7 +1360,7 @@ mod tests {
             }
             let window = lines[i.saturating_sub(6)..i].join("\n");
             let guarded =
-                window.contains("ensure_daemon_running") || window.contains("cannot stage backend");
+                window.contains("restore_unless_paused") || window.contains("cannot stage backend");
             if !guarded {
                 unguarded.push(i);
             }
@@ -1368,9 +1368,9 @@ mod tests {
         assert!(
             unguarded.is_empty(),
             "every bail-out from ensure_backend_installed must call \
-             ensure_daemon_running first, or a quit leaves the daemon \
-             permanently down - a `bootout` survives both KeepAlive and the \
-             next login. Unguarded `return;` at body lines {unguarded:?}"
+             daemon_lifecycle::restore_unless_paused first, or a quit leaves \
+             the daemon permanently down - a `bootout` survives both KeepAlive \
+             and the next login. Unguarded `return;` at body lines {unguarded:?}"
         );
 
         // And the dev/source path specifically, since that is the one that
@@ -1381,8 +1381,19 @@ mod tests {
             .1;
         let dev_arm = dev_arm.split_once("};").map(|(a, _)| a).unwrap_or(dev_arm);
         assert!(
-            dev_arm.contains("ensure_daemon_running"),
+            dev_arm.contains("restore_unless_paused"),
             "the dev/source bail-out must restore the daemon before returning"
+        );
+
+        // ...and it must go through the pause gate, never call the raw start
+        // directly. A restore that skips the gate can start a daemon the user
+        // just paused, leaving a running daemon under a Paused label that the
+        // watchdog will not correct - because the pause flag is exactly what
+        // tells it to stand down.
+        assert!(
+            !body.contains("ensure_daemon_running(&home)"),
+            "restores must route through daemon_lifecycle::restore_unless_paused, \
+             not call ensure_daemon_running directly"
         );
     }
 

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -134,6 +134,7 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
         Ok(h) => h,
         Err(e) => {
             tracing::warn!(error = %e, src = %daemon_src.display(), "backend_install: cannot hash bundled daemon");
+            ensure_daemon_running(&home).await;
             return;
         }
     };
@@ -184,6 +185,12 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
                 tracing::warn!(error = %notice_err, "backend-install-failure notice raise failed");
             }
         }
+        // A failed *staging* must not also mean a stopped *daemon*. The
+        // previously staged binary and its plist are still on disk, so the
+        // last-known-good daemon can usually still be started - and it has to
+        // be, because quit boots the agent out and nothing else will bring it
+        // back before the next launch (which may fail here again).
+        ensure_daemon_running(&home).await;
         return;
     }
     if let Some(p) = pool.as_ref() {
@@ -1342,12 +1349,28 @@ mod tests {
         // column 0 starts the following item.
         let body = body.split("\nasync fn").next().unwrap_or(body);
 
-        let restores = body.matches("ensure_daemon_running(&home).await").count();
+        // Every `return;` must be preceded by a restore. The one exception is
+        // the path where `$HOME` itself could not be resolved - there is no
+        // `home` to hand `ensure_daemon_running`, and nothing it could do.
+        let lines: Vec<&str> = body.lines().collect();
+        let mut unguarded: Vec<usize> = Vec::new();
+        for (i, line) in lines.iter().enumerate() {
+            if line.trim() != "return;" {
+                continue;
+            }
+            let window = lines[i.saturating_sub(6)..i].join("\n");
+            let guarded =
+                window.contains("ensure_daemon_running") || window.contains("cannot stage backend");
+            if !guarded {
+                unguarded.push(i);
+            }
+        }
         assert!(
-            restores >= 2,
-            "ensure_backend_installed must restore the daemon on BOTH bail-out \
-             paths - the up-to-date one and the dev/source one - or a quit \
-             leaves the daemon permanently down; found {restores}"
+            unguarded.is_empty(),
+            "every bail-out from ensure_backend_installed must call \
+             ensure_daemon_running first, or a quit leaves the daemon \
+             permanently down - a `bootout` survives both KeepAlive and the \
+             next login. Unguarded `return;` at body lines {unguarded:?}"
         );
 
         // And the dev/source path specifically, since that is the one that

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -71,7 +71,7 @@ fn sha256_hex_of(path: &Path) -> std::io::Result<String> {
 /// [`AGENTS`] because [`stop_daemon_for_migration`] and [`ensure_daemon_running`]
 /// address this one agent directly rather than iterating the table.
 #[cfg(target_os = "macos")]
-const DAEMON_LABEL: &str = "com.meridiona.daemon";
+pub(crate) const DAEMON_LABEL: &str = "com.meridiona.daemon";
 #[cfg(target_os = "macos")]
 const DAEMON_PLIST: &str = "com.meridiona.daemon.plist";
 
@@ -83,9 +83,9 @@ const AGENTS: &[(&str, &str)] = &[(DAEMON_LABEL, DAEMON_PLIST)];
 /// staged destination. Windows needs the `.exe` suffix to be runnable at all;
 /// `tauri.windows.conf.json`'s resource map bundles it under that name.
 #[cfg(target_os = "windows")]
-const DAEMON_FILE: &str = "meridian.exe";
+pub(crate) const DAEMON_FILE: &str = "meridian.exe";
 #[cfg(not(target_os = "windows"))]
-const DAEMON_FILE: &str = "meridian";
+pub(crate) const DAEMON_FILE: &str = "meridian";
 
 /// Stage the bundled backend and register its launchd agent — idempotent and
 /// non-fatal.
@@ -99,19 +99,32 @@ const DAEMON_FILE: &str = "meridian";
 /// **only after** the agent bootstraps, so a partial failure retries next launch.
 #[tracing::instrument(skip(app))]
 pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
-    let backend = match bundled_backend_dir(app) {
-        Some(d) => d,
-        None => {
-            tracing::debug!("backend_install: no bundled backend (dev/source run) — skipping");
-            return;
-        }
-    };
     let home = match meridian_core::paths::home_dir() {
         Some(h) => h,
         None => {
             tracing::warn!(
                 "backend_install: home directory could not be resolved — cannot stage backend"
             );
+            return;
+        }
+    };
+    let backend = match bundled_backend_dir(app) {
+        Some(d) => d,
+        None => {
+            // Nothing to STAGE on a dev/source run - but the daemon may still
+            // need STARTING, and this is the only place that does it. Quit now
+            // stops the daemon (`crate::daemon_lifecycle`), and a `bootout`
+            // cannot be undone by `KeepAlive` or by `RunAtLoad` at the next
+            // login: the job is no longer loaded for either to act on. Bailing
+            // here without this call is what would turn one dev quit into a
+            // permanently dead daemon.
+            //
+            // Safe on every path: the macOS arm no-ops when no plist is
+            // installed (a fresh clone) and when the daemon is already up.
+            tracing::debug!(
+                "backend_install: no bundled backend (dev/source run) — skipping staging"
+            );
+            ensure_daemon_running(&home).await;
             return;
         }
     };
@@ -335,7 +348,7 @@ pub(crate) fn may_swap_database(stop_outcome: Option<&Result<(), String>>) -> bo
 /// and merely allowed to be dead, so a `cfg`-gated callee vanishes underneath
 /// them and breaks the Windows build even though nothing there can call it.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-async fn bootout_agent_and_wait(label: &str) -> Result<(), String> {
+pub(crate) async fn bootout_agent_and_wait(label: &str) -> Result<(), String> {
     let target = agent_target(label);
     let _ = launchctl(&["bootout", &target]).await; // ok if not loaded
     for _ in 0..15 {
@@ -371,7 +384,7 @@ async fn bootout_agent_and_wait(label: &str) -> Result<(), String> {
 /// precisely what kills a running instance. Both platforms therefore return
 /// early when the daemon is already up, or an ordinary launch would SIGTERM a
 /// healthy daemon mid-write.
-async fn ensure_daemon_running(home: &Path) {
+pub(crate) async fn ensure_daemon_running(home: &Path) {
     #[cfg(target_os = "windows")]
     {
         let daemon_bin = home.join(".meridian").join("bin").join(DAEMON_FILE);
@@ -696,7 +709,7 @@ where
 /// still holds open would fail with os error 32, and the caller must surface
 /// that as an install failure rather than silently continuing.
 #[cfg(target_os = "windows")]
-async fn stop_running_daemon_before_stage(daemon_bin: &Path) -> Result<(), String> {
+pub(crate) async fn stop_running_daemon_before_stage(daemon_bin: &Path) -> Result<(), String> {
     // Targets our task by name — safe regardless of what else is named meridian.exe.
     let _ = tokio::process::Command::new("schtasks")
         .args(["/End", "/TN", WINDOWS_TASK_NAME])
@@ -1303,6 +1316,52 @@ async fn launchctl(args: &[&str]) -> Result<bool, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every path out of [`ensure_backend_installed`] that could leave a daemon
+    /// down must call [`ensure_daemon_running`] first.
+    ///
+    /// This is the other half of "quit stops the daemon"
+    /// ([`crate::daemon_lifecycle`]) and it is the half with no natural failure
+    /// signal. A `bootout` is not reversed by `KeepAlive`, and not by
+    /// `RunAtLoad` at the next login either — the job is no longer loaded for
+    /// either to act on — so dropping this call does not break a test or raise
+    /// a notice. It just means the daemon never comes back, and the symptom
+    /// (no sessions, ever) surfaces hours later somewhere else entirely.
+    ///
+    /// Scanned from source rather than executed: the function needs a live
+    /// `AppHandle` and would shell out to `launchctl` against the developer's
+    /// own daemon. Same tactic as the `cfg` audit further down this module.
+    #[test]
+    fn every_early_return_still_restores_the_daemon() {
+        const SRC: &str = include_str!("backend_install.rs");
+        let body = SRC
+            .split_once("pub async fn ensure_backend_installed")
+            .expect("ensure_backend_installed must exist")
+            .1;
+        // Bound the scan to the function: the next `\npub ` / `\nasync fn` at
+        // column 0 starts the following item.
+        let body = body.split("\nasync fn").next().unwrap_or(body);
+
+        let restores = body.matches("ensure_daemon_running(&home).await").count();
+        assert!(
+            restores >= 2,
+            "ensure_backend_installed must restore the daemon on BOTH bail-out \
+             paths - the up-to-date one and the dev/source one - or a quit \
+             leaves the daemon permanently down; found {restores}"
+        );
+
+        // And the dev/source path specifically, since that is the one that
+        // returned without ever reaching the restore before this change.
+        let dev_arm = body
+            .split_once("no bundled backend")
+            .expect("the dev/source bail-out must still be identifiable")
+            .1;
+        let dev_arm = dev_arm.split_once("};").map(|(a, _)| a).unwrap_or(dev_arm);
+        assert!(
+            dev_arm.contains("ensure_daemon_running"),
+            "the dev/source bail-out must restore the daemon before returning"
+        );
+    }
 
     /// The launchd target `stop_daemon_for_migration` boots out must address the
     /// daemon in the CURRENT user's GUI domain. A malformed target makes

--- a/tray/src-tauri/src/commands/daemon.rs
+++ b/tray/src-tauri/src/commands/daemon.rs
@@ -27,6 +27,7 @@ use meridian_core::SqlitePool;
 use serde::Serialize;
 use std::sync::{Arc, Mutex};
 use tauri::State;
+use tracing::Instrument;
 
 /// The cached tray status (health + active session + today totals), read from
 /// the poll-loop-maintained [`AppState`]. Synchronous — just locks and snapshots.
@@ -65,14 +66,19 @@ pub async fn restart_daemon() -> Result<(), String> {
 /// installer's launch-time restore will start a daemon they believe is down.
 /// Sequencing them from the command would leave both races open.
 #[tauri::command]
+#[tracing::instrument(skip(_app, db_pool), fields(action))]
 pub async fn toggle_daemon(
     _app: tauri::AppHandle,
     is_running: bool,
     db_pool: State<'_, Option<SqlitePool>>,
 ) -> Result<(), String> {
     let pool = db_pool.inner().clone();
+    // `is_running` is the CURRENT state, so the useful field is what the user
+    // asked for, not what it already was.
+    tracing::Span::current().record("action", if is_running { "pause" } else { "resume" });
 
-    // `is_running` is the CURRENT state, so pausing means "make it not running".
+    // The OS work and its own spans live in `daemon_lifecycle`; this command
+    // owns the request boundary and the notice write.
     if is_running {
         crate::daemon_lifecycle::stop_for_pause().await?;
     } else {
@@ -93,14 +99,18 @@ pub async fn toggle_daemon(
                     deep_link: None,
                 },
             )
+            .instrument(tracing::debug_span!("daemon.toggle.write.notices"))
             .await
         } else {
-            meridian::notices::clear_typed(p, "tray.daemon_paused", "system.pause").await
+            meridian::notices::clear_typed(p, "tray.daemon_paused", "system.pause")
+                .instrument(tracing::debug_span!("daemon.toggle.write.notices"))
+                .await
         };
         if let Err(e) = result {
             tracing::warn!(error = %e, is_running, "daemon toggle notice write failed");
         }
     }
+    tracing::info!(is_running, "daemon toggled");
     Ok(())
 }
 

--- a/tray/src-tauri/src/commands/daemon.rs
+++ b/tray/src-tauri/src/commands/daemon.rs
@@ -25,8 +25,9 @@
 use crate::state::{AppState, StatusPayload};
 use meridian_core::SqlitePool;
 use serde::Serialize;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
-use tauri::State;
+use tauri::{Manager, State};
 
 /// The cached tray status (health + active session + today totals), read from
 /// the poll-loop-maintained [`AppState`]. Synchronous — just locks and snapshots.
@@ -50,18 +51,46 @@ pub async fn restart_daemon() -> Result<(), String> {
 /// [`crate::commands::pause`]'s capture-pause notice, so quiet-hours/master-
 /// switch policy applies identically.
 ///
-/// Start/stop goes through [`super::daemon_control`] (launchd on macOS, the
-/// scheduled task on Windows) rather than `launchctl` directly.
+/// Start/stop goes through [`crate::daemon_lifecycle`], **not**
+/// [`super::daemon_control::set_running`]. That is the fix for a toggle that
+/// never actually paused anything: `set_running(false)` runs `launchctl stop`,
+/// and the daemon's plist sets `KeepAlive=true`, so launchd restarted it after
+/// `ThrottleInterval` (30 s) while the menu went on reading "Disconnected ○".
+/// The same trap is documented from the other side in
+/// [`meridian::db::repair::marker`].
+///
+/// `AppState::daemon_paused` is set **before** the stop and cleared **before**
+/// the start, both on purpose. A paused daemon is `bootout`ed and so is
+/// indistinguishable from a crashed one, and [`crate::poll::watchdog`] probes
+/// every 5 s — flipping the flag second would leave a window in which the
+/// watchdog reads a deliberate pause as an outage and starts the daemon back up.
+/// A failed pause rolls the flag back rather than leaving the watchdog blinded
+/// to a daemon that is, in fact, still running.
 #[tauri::command]
 pub async fn toggle_daemon(
-    _app: tauri::AppHandle,
+    app: tauri::AppHandle,
     is_running: bool,
     db_pool: State<'_, Option<SqlitePool>>,
 ) -> Result<(), String> {
     let pool = db_pool.inner().clone();
+    let paused_flag = app
+        .state::<Arc<Mutex<AppState>>>()
+        .lock()
+        .map_err(|e| e.to_string())?
+        .daemon_paused
+        .clone();
 
     // `is_running` is the CURRENT state, so pausing means "make it not running".
-    super::daemon_control::set_running(!is_running).await?;
+    if is_running {
+        paused_flag.store(true, Ordering::Relaxed);
+        if let Err(e) = crate::daemon_lifecycle::stop_for_pause().await {
+            paused_flag.store(false, Ordering::Relaxed);
+            return Err(e);
+        }
+    } else {
+        paused_flag.store(false, Ordering::Relaxed);
+        crate::daemon_lifecycle::resume_from_pause().await?;
+    }
 
     if let Some(p) = pool.as_ref() {
         let result = if is_running {

--- a/tray/src-tauri/src/commands/daemon.rs
+++ b/tray/src-tauri/src/commands/daemon.rs
@@ -25,9 +25,8 @@
 use crate::state::{AppState, StatusPayload};
 use meridian_core::SqlitePool;
 use serde::Serialize;
-use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
-use tauri::{Manager, State};
+use tauri::State;
 
 /// The cached tray status (health + active session + today totals), read from
 /// the poll-loop-maintained [`AppState`]. Synchronous — just locks and snapshots.
@@ -59,36 +58,24 @@ pub async fn restart_daemon() -> Result<(), String> {
 /// The same trap is documented from the other side in
 /// [`meridian::db::repair::marker`].
 ///
-/// `AppState::daemon_paused` is set **before** the stop and cleared **before**
-/// the start, both on purpose. A paused daemon is `bootout`ed and so is
-/// indistinguishable from a crashed one, and [`crate::poll::watchdog`] probes
-/// every 5 s — flipping the flag second would leave a window in which the
-/// watchdog reads a deliberate pause as an outage and starts the daemon back up.
-/// A failed pause rolls the flag back rather than leaving the watchdog blinded
-/// to a daemon that is, in fact, still running.
+/// The paused flag and the OS call are sequenced inside
+/// [`crate::daemon_lifecycle`], under its lifecycle guard, rather than here.
+/// That matters: a paused daemon is `bootout`ed and so is indistinguishable
+/// from a crashed one, and both [`crate::poll::watchdog`] (every 5 s) and the
+/// installer's launch-time restore will start a daemon they believe is down.
+/// Sequencing them from the command would leave both races open.
 #[tauri::command]
 pub async fn toggle_daemon(
-    app: tauri::AppHandle,
+    _app: tauri::AppHandle,
     is_running: bool,
     db_pool: State<'_, Option<SqlitePool>>,
 ) -> Result<(), String> {
     let pool = db_pool.inner().clone();
-    let paused_flag = app
-        .state::<Arc<Mutex<AppState>>>()
-        .lock()
-        .map_err(|e| e.to_string())?
-        .daemon_paused
-        .clone();
 
     // `is_running` is the CURRENT state, so pausing means "make it not running".
     if is_running {
-        paused_flag.store(true, Ordering::Relaxed);
-        if let Err(e) = crate::daemon_lifecycle::stop_for_pause().await {
-            paused_flag.store(false, Ordering::Relaxed);
-            return Err(e);
-        }
+        crate::daemon_lifecycle::stop_for_pause().await?;
     } else {
-        paused_flag.store(false, Ordering::Relaxed);
         crate::daemon_lifecycle::resume_from_pause().await?;
     }
 

--- a/tray/src-tauri/src/daemon_lifecycle.rs
+++ b/tray/src-tauri/src/daemon_lifecycle.rs
@@ -50,26 +50,32 @@
 //! daemon down permanently - `RunAtLoad` cannot fire for a job that is no longer
 //! loaded, so not even the next login would recover it.
 //!
-//! Pause state is process-local ([`crate::state::AppState::daemon_paused`]) and
-//! deliberately not persisted, matching the capture pause in
-//! [`crate::commands::pause`]: relaunching the tray resumes the daemon. The
-//! alternative - a pause that outlives the process that set it - is the failure
-//! mode `repair::marker` had to grow an expiry to escape.
+//! Pause state is process-local ([`DAEMON_PAUSED`]) and deliberately not
+//! persisted, matching the capture pause in [`crate::commands::pause`]:
+//! relaunching the tray resumes the daemon. The alternative - a pause that
+//! outlives the process that set it - is the failure mode `repair::marker` had
+//! to grow an expiry to escape.
 //!
 //! # Who calls this
 //!
-//! - [`stop_for_quit`] - [`crate::run`]'s `RunEvent::ExitRequested` handler.
+//! - [`decide_exit`] / [`stop_for_quit`] - [`crate::run`]'s
+//!   `RunEvent::ExitRequested` handler.
+//! - [`restore_unless_paused`] - every bail-out in
+//!   [`crate::backend_install::ensure_backend_installed`].
 //! - [`stop_for_pause`] / [`resume_from_pause`] - [`crate::commands::daemon::toggle_daemon`],
 //!   behind the tray menu's Connected / Disconnected item.
 //!
 //! # Related
 //!
 //! - [`crate::backend_install`] - owns the OS mechanics and the restore half.
-//! - [`crate::poll::watchdog`] - must not fight a pause; its `decide` takes
-//!   `daemon_paused` for that reason.
+//! - [`crate::poll::watchdog`] - must not fight a pause; it reads
+//!   [`is_paused`] each tick and its `decide` takes `daemon_paused` for that
+//!   reason.
 //! - [`crate::commands::daemon_control`] - the probe and the launchd verbs.
 
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::time::Duration;
+use tracing::Instrument;
 
 /// How long a quit waits for the daemon to go down before giving up and exiting
 /// anyway.
@@ -80,33 +86,118 @@ use std::time::Duration;
 /// the next launch reconciles the daemon regardless.
 const QUIT_STOP_BUDGET: Duration = Duration::from_secs(5);
 
-/// Whether an exit should take the daemon down with it.
+/// Where the app is in its exit sequence.
 ///
-/// Pure and free of `cfg` so the policy is pinned by tests on every platform -
-/// the same discipline as [`crate::poll::watchdog::decide`] and
+/// The quit path is not atomic - the daemon stop is async and the exit is not -
+/// so "are we exiting?" is a three-state question, not a boolean. An earlier
+/// version used a single `already_stopping` latch and got this wrong: a second
+/// `ExitRequested` arriving mid-stop found the latch set, declined to prevent
+/// the exit, and Tauri tore the process down with the stop task still in
+/// flight. That is not a hypothetical - the quit appears to hang for a moment,
+/// which is exactly when a user presses Quit or Cmd+Q again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExitPhase {
+    /// No exit in progress.
+    Running,
+    /// The daemon stop is in flight; every exit must be held.
+    Stopping,
+    /// The stop is done and the internal `exit()` is about to fire. The one
+    /// phase in which an exit is allowed straight through.
+    ReadyToExit,
+}
+
+/// What the `RunEvent::ExitRequested` handler should do this time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExitAction {
+    /// Let the exit proceed untouched.
+    Proceed,
+    /// Hold the exit and start the daemon stop.
+    HoldAndStop,
+    /// Hold the exit. A stop is already running and will finish the job.
+    Hold,
+}
+
+/// The exit policy.
+///
+/// Pure and free of `cfg` so it is pinned by tests on every platform - the same
+/// discipline as [`crate::poll::watchdog::decide`] and
 /// [`crate::commands::daemon_control`]'s `status_running`, and for the same
-/// reason: everything around it shells out to the OS and cannot be tested at
-/// all.
+/// reason: everything around it shells out to the OS or needs a live event
+/// loop, and cannot be tested at all.
 ///
-/// - `code` is `RunEvent::ExitRequested`'s: `None` for a user-driven quit
-///   (the tray menu item, macOS Cmd+Q), `Some` when something called
-///   `AppHandle::exit` or `AppHandle::restart`.
-/// - `already_stopping` is the re-entry latch. The handler exits by calling
-///   `exit()` again, which fires a second `ExitRequested`; without the latch
-///   that would spawn another stop and never terminate.
+/// `code` is `RunEvent::ExitRequested`'s: `None` for a user-driven quit (the
+/// tray menu item, macOS Cmd+Q), `Some` when something called
+/// `AppHandle::exit` (the popover's Quit button, and our own internal exit) or
+/// `AppHandle::restart`.
 ///
-/// [`tauri::RESTART_EXIT_CODE`] is the one code that must NOT stop the daemon.
-/// Both `update.rs`'s post-install relaunch and `commands::repair`'s
+/// [`tauri::RESTART_EXIT_CODE`] is never held and never stops the daemon. Both
+/// `update.rs`'s post-install relaunch and `commands::repair`'s
 /// restart-into-`repair_boot` call `AppHandle::restart`, which routes through
 /// this event from a command thread. The app is coming straight back in both
 /// cases, so a bootout would be pure latency on the update path - and on the
-/// repair path it would fight the marker handshake that is already holding the
-/// daemon off.
-pub(crate) fn should_stop_daemon(code: Option<i32>, already_stopping: bool) -> bool {
-    if already_stopping {
-        return false;
+/// repair path it would fight the marker handshake already holding the daemon
+/// off. Holding a restart would be worse still: the pending stop finishes with
+/// `exit(0)`, which would silently turn the user's restart into a plain quit.
+pub(crate) fn decide_exit(code: Option<i32>, phase: ExitPhase) -> ExitAction {
+    if phase == ExitPhase::ReadyToExit || code == Some(tauri::RESTART_EXIT_CODE) {
+        return ExitAction::Proceed;
     }
-    code != Some(tauri::RESTART_EXIT_CODE)
+    match phase {
+        ExitPhase::Running => ExitAction::HoldAndStop,
+        ExitPhase::Stopping => ExitAction::Hold,
+        ExitPhase::ReadyToExit => ExitAction::Proceed,
+    }
+}
+
+/// [`ExitPhase`], as a process-global the event-loop closure can reach without
+/// captured state.
+static EXIT_PHASE: AtomicU8 = AtomicU8::new(0);
+
+/// The current exit phase.
+pub(crate) fn exit_phase() -> ExitPhase {
+    match EXIT_PHASE.load(Ordering::SeqCst) {
+        1 => ExitPhase::Stopping,
+        2 => ExitPhase::ReadyToExit,
+        _ => ExitPhase::Running,
+    }
+}
+
+/// Advance the exit phase.
+pub(crate) fn set_exit_phase(phase: ExitPhase) {
+    let v = match phase {
+        ExitPhase::Running => 0,
+        ExitPhase::Stopping => 1,
+        ExitPhase::ReadyToExit => 2,
+    };
+    EXIT_PHASE.store(v, Ordering::SeqCst);
+}
+
+/// Whether the user has paused the daemon from the tray menu.
+///
+/// A process-global rather than a field on [`crate::state::AppState`] because
+/// two unrelated callers need it and neither has an `AppHandle` in hand: the
+/// watchdog runs on its own bare task, and the installer's restore reaches it
+/// several call frames below `ensure_backend_installed`. There is exactly one
+/// daemon per tray process, so a global is the honest shape.
+static DAEMON_PAUSED: AtomicBool = AtomicBool::new(false);
+
+/// Serializes every daemon lifecycle transition against every other one.
+///
+/// The flag alone is not enough. Without this the installer can read "not
+/// paused", the user can pause and complete a bootout, and the installer can
+/// then register the agent anyway - leaving a running daemon behind a UI that
+/// says Paused, which the watchdog will not correct precisely because the pause
+/// flag is set. The window is small and the resulting state is stuck until the
+/// user toggles again, which is the worst combination.
+///
+/// A `tokio` mutex, not a `std` one: it is held across `await` points that
+/// shell out to `launchctl` for seconds at a time.
+static LIFECYCLE: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Whether the daemon is deliberately paused. Read by
+/// [`crate::poll::watchdog`], which must not "recover" a pause.
+pub(crate) fn is_paused() -> bool {
+    DAEMON_PAUSED.load(Ordering::Relaxed)
 }
 
 /// Take the daemon down because the app is quitting.
@@ -115,42 +206,129 @@ pub(crate) fn should_stop_daemon(code: Option<i32>, already_stopping: bool) -> b
 /// path logs and returns, because the caller's next act is to exit and a quit
 /// the user cannot complete is a worse bug than a daemon that outlives it. The
 /// next launch reconciles either way.
+///
+/// The budget covers acquiring [`LIFECYCLE`] as well as the stop itself - an
+/// install in progress can hold it for longer than the whole quit is allowed to
+/// take.
 pub(crate) async fn stop_for_quit() {
-    match tokio::time::timeout(QUIT_STOP_BUDGET, stop_daemon()).await {
-        Ok(Ok(())) => tracing::info!("daemon stopped for quit"),
-        Ok(Err(e)) => {
-            tracing::warn!(error = %e, "could not stop the daemon on quit - exiting anyway")
+    let span = tracing::info_span!(
+        "daemon_lifecycle.stop",
+        reason = "quit",
+        outcome = tracing::field::Empty,
+        otel.status_code = tracing::field::Empty,
+    );
+    async {
+        let work = async {
+            let _guard = LIFECYCLE.lock().await;
+            stop_daemon().await
+        };
+        let s = tracing::Span::current();
+        match tokio::time::timeout(QUIT_STOP_BUDGET, work).await {
+            Ok(Ok(())) => {
+                s.record("outcome", "stopped");
+                tracing::info!("daemon stopped for quit");
+            }
+            Ok(Err(e)) => {
+                s.record("outcome", "failed");
+                s.record("otel.status_code", "ERROR");
+                tracing::warn!(error = %e, "could not stop the daemon on quit - exiting anyway");
+            }
+            Err(_) => {
+                s.record("outcome", "timeout");
+                s.record("otel.status_code", "ERROR");
+                tracing::warn!(
+                    budget_s = QUIT_STOP_BUDGET.as_secs(),
+                    "stopping the daemon on quit exceeded its budget - exiting anyway"
+                );
+            }
         }
-        Err(_) => tracing::warn!(
-            budget_s = QUIT_STOP_BUDGET.as_secs(),
-            "stopping the daemon on quit exceeded its budget - exiting anyway"
-        ),
     }
+    .instrument(span)
+    .await
 }
 
 /// Take the daemon down because the user paused it from the tray menu.
 ///
 /// Unbounded, unlike [`stop_for_quit`]: nothing is waiting on this to finish,
 /// and the caller reports the outcome to the user rather than swallowing it.
+///
+/// The paused flag is set **inside** the guard and before the OS call, so no
+/// concurrent restore can observe "not paused" and start the daemon back up. A
+/// failed stop rolls it back rather than leaving the watchdog blind to a daemon
+/// that is, in fact, still running.
 pub(crate) async fn stop_for_pause() -> Result<(), String> {
-    stop_daemon().await.inspect(|()| {
-        tracing::info!("daemon stopped for pause");
-    })
+    let span = tracing::info_span!(
+        "daemon_lifecycle.stop",
+        reason = "pause",
+        outcome = tracing::field::Empty,
+        otel.status_code = tracing::field::Empty,
+    );
+    async {
+        let s = tracing::Span::current();
+        let _guard = LIFECYCLE.lock().await;
+        DAEMON_PAUSED.store(true, Ordering::Relaxed);
+        match stop_daemon().await {
+            Ok(()) => {
+                s.record("outcome", "stopped");
+                tracing::info!("daemon stopped for pause");
+                Ok(())
+            }
+            Err(e) => {
+                DAEMON_PAUSED.store(false, Ordering::Relaxed);
+                s.record("outcome", "failed");
+                s.record("otel.status_code", "ERROR");
+                tracing::warn!(error = %e, "could not pause the daemon");
+                Err(e)
+            }
+        }
+    }
+    .instrument(span)
+    .await
 }
 
 /// Bring a paused daemon back.
 ///
-/// Delegates to [`crate::backend_install::ensure_daemon_running`], which is the
-/// same call the tray makes on launch - so resuming and relaunching converge on
-/// one code path rather than two that can drift. It returns early when the
-/// daemon is already up, so a double-click cannot `kickstart -k` a healthy
-/// daemon mid-write.
+/// Delegates to [`crate::backend_install::ensure_daemon_running`], the same call
+/// the tray makes on launch, so resuming and relaunching converge on one code
+/// path rather than two that can drift. It returns early when the daemon is
+/// already up, so a double-click cannot `kickstart -k` a healthy daemon
+/// mid-write.
 pub(crate) async fn resume_from_pause() -> Result<(), String> {
-    let home = meridian_core::paths::home_dir()
-        .ok_or_else(|| "home directory could not be resolved".to_string())?;
-    crate::backend_install::ensure_daemon_running(&home).await;
-    tracing::info!("daemon resumed from pause");
-    Ok(())
+    let span = tracing::info_span!("daemon_lifecycle.resume", outcome = tracing::field::Empty);
+    async {
+        let home = meridian_core::paths::home_dir()
+            .ok_or_else(|| "home directory could not be resolved".to_string())?;
+        let _guard = LIFECYCLE.lock().await;
+        DAEMON_PAUSED.store(false, Ordering::Relaxed);
+        crate::backend_install::ensure_daemon_running(&home).await;
+        tracing::Span::current().record("outcome", "resumed");
+        tracing::info!("daemon resumed from pause");
+        Ok(())
+    }
+    .instrument(span)
+    .await
+}
+
+/// The launch-time restore, refusing while the daemon is deliberately paused.
+///
+/// Every bail-out in [`crate::backend_install::ensure_backend_installed`] calls
+/// this rather than `ensure_daemon_running` directly. Both halves matter:
+///
+/// - **The pause check.** The installer runs off the setup hook and can still be
+///   working seconds into the session, by which time the user can have paused
+///   from the tray menu. Restoring then would leave a running daemon under a
+///   Paused label, and the watchdog would not fix it because the pause flag is
+///   what tells it to stand down.
+/// - **The guard.** Checking the flag without holding [`LIFECYCLE`] would only
+///   narrow that race, not close it - the pause could land between the check and
+///   the `launchctl` call.
+pub(crate) async fn restore_unless_paused(home: &std::path::Path) {
+    let _guard = LIFECYCLE.lock().await;
+    if DAEMON_PAUSED.load(Ordering::Relaxed) {
+        tracing::info!("skipping the launch-time daemon restore - the user paused it");
+        return;
+    }
+    crate::backend_install::ensure_daemon_running(home).await;
 }
 
 /// The OS mechanics, shared by quit and pause.
@@ -198,41 +376,99 @@ mod tests {
     /// Cmd+Q once the dashboard has switched the activation policy to
     /// `Regular`, must take the daemon down.
     #[test]
-    fn a_user_quit_stops_the_daemon() {
-        assert!(
-            should_stop_daemon(None, false),
+    fn a_user_quit_holds_the_exit_and_stops_the_daemon() {
+        assert_eq!(
+            decide_exit(None, ExitPhase::Running),
+            ExitAction::HoldAndStop,
             "a user-driven quit must stop the daemon - leaving it up is what \
              made 'meridian db repair' unreachable"
         );
     }
 
-    /// `tray::handle_menu_event`'s "quit" arm calls `app.exit(0)`, which arrives
-    /// here as `Some(0)` rather than `None`. Keying on "is it a restart" instead
-    /// of "is it programmatic" is what keeps that path covered.
+    /// `tray::handle_menu_event`'s "quit" arm and the popover's Quit button both
+    /// call `app.exit(0)`, which arrives here as `Some(0)` rather than `None`.
+    /// Keying on "is it a restart" instead of "is it programmatic" is what keeps
+    /// those paths covered.
     #[test]
     fn a_programmatic_exit_stops_the_daemon_too() {
-        assert!(should_stop_daemon(Some(0), false));
-        assert!(should_stop_daemon(Some(1), false));
-    }
-
-    /// A relaunch must leave the daemon alone. `update.rs` restarts into the
-    /// newly installed version and `commands::repair` restarts into
-    /// `repair_boot`; the app is returning immediately in both cases, and the
-    /// repair path is relying on its marker rather than on launchd state.
-    #[test]
-    fn a_restart_does_not_stop_the_daemon() {
-        assert!(
-            !should_stop_daemon(Some(tauri::RESTART_EXIT_CODE), false),
-            "an auto-update or repair relaunch must not bootout the daemon"
+        assert_eq!(
+            decide_exit(Some(0), ExitPhase::Running),
+            ExitAction::HoldAndStop
+        );
+        assert_eq!(
+            decide_exit(Some(1), ExitPhase::Running),
+            ExitAction::HoldAndStop
         );
     }
 
-    /// The handler re-enters by calling `exit()` again. Without the latch that
-    /// second pass would spawn another stop, which would exit again, forever.
+    /// A relaunch must leave the daemon alone AND must not be held.
+    ///
+    /// Holding it would be the worse bug of the two: the pending stop ends with
+    /// `exit(0)`, so a held restart would silently become a plain quit - the
+    /// user's app would simply not come back.
     #[test]
-    fn the_second_pass_is_a_no_op() {
-        assert!(!should_stop_daemon(None, true));
-        assert!(!should_stop_daemon(Some(0), true));
+    fn a_restart_is_never_held_and_never_stops_the_daemon() {
+        for phase in [
+            ExitPhase::Running,
+            ExitPhase::Stopping,
+            ExitPhase::ReadyToExit,
+        ] {
+            assert_eq!(
+                decide_exit(Some(tauri::RESTART_EXIT_CODE), phase),
+                ExitAction::Proceed,
+                "an auto-update or repair relaunch must pass straight through \
+                 (phase {phase:?})"
+            );
+        }
+    }
+
+    /// **The regression test for the double-quit window.**
+    ///
+    /// A quit takes up to [`QUIT_STOP_BUDGET`], during which the app looks
+    /// hung - which is exactly when a user hits Quit or Cmd+Q a second time.
+    /// The previous single-latch version answered "already stopping, do
+    /// nothing", so the handler skipped `prevent_exit` and Tauri tore the
+    /// process down with the stop still in flight: the daemon survived, which
+    /// is the bug this whole module exists to fix.
+    #[test]
+    fn a_second_quit_mid_stop_is_still_held() {
+        assert_eq!(
+            decide_exit(None, ExitPhase::Stopping),
+            ExitAction::Hold,
+            "a second quit during the stop must still be prevented, or the \
+             process exits and drops the shutdown task"
+        );
+        assert_eq!(decide_exit(Some(0), ExitPhase::Stopping), ExitAction::Hold);
+    }
+
+    /// ...and exactly one phase lets an exit through, or the app could never
+    /// close at all. The stop task sets `ReadyToExit` immediately before its own
+    /// `exit(0)`.
+    #[test]
+    fn the_internal_exit_is_the_one_that_proceeds() {
+        assert_eq!(
+            decide_exit(None, ExitPhase::ReadyToExit),
+            ExitAction::Proceed
+        );
+        assert_eq!(
+            decide_exit(Some(0), ExitPhase::ReadyToExit),
+            ExitAction::Proceed
+        );
+    }
+
+    /// The phase round-trips through its atomic encoding. Cheap, but the
+    /// encoding is hand-rolled and a wrong default would silently mean
+    /// "Running" forever - i.e. every exit held and then re-stopped.
+    #[test]
+    fn the_exit_phase_round_trips() {
+        for phase in [
+            ExitPhase::Stopping,
+            ExitPhase::ReadyToExit,
+            ExitPhase::Running,
+        ] {
+            set_exit_phase(phase);
+            assert_eq!(exit_phase(), phase);
+        }
     }
 
     /// The policy above is worth nothing unless something consults it, and no
@@ -257,9 +493,36 @@ mod tests {
             "the ExitRequested handler must call stop_for_quit"
         );
         assert!(
+            LIB_SRC.contains("ExitPhase::ReadyToExit"),
+            "the handler must mark ReadyToExit before its internal exit, or the \
+             app can never actually close"
+        );
+        assert!(
             LIB_SRC.contains("prevent_exit"),
             "the stop is async, so the handler must defer the exit with \
              prevent_exit rather than racing the process teardown"
+        );
+
+        // [`ExitAction::Hold`] is worthless if the handler treats it as "do
+        // nothing" - that IS the single-latch bug, restated. Pin the arm
+        // itself, not just that `prevent_exit` appears somewhere in the file:
+        // the `HoldAndStop` arm also contains it, so a file-wide check stays
+        // green while a second quit tears the process down mid-stop.
+        let hold_arm = LIB_SRC
+            .split_once("ExitAction::Hold =>")
+            .expect("the handler must have an ExitAction::Hold arm")
+            .1;
+        // Bounded at the NEXT arm, not by a character count. `HoldAndStop`
+        // follows immediately and calls `prevent_exit` itself, so any fixed
+        // window wide enough to be useful also reads into it and passes on
+        // borrowed evidence.
+        let hold_arm = hold_arm
+            .split_once("ExitAction::")
+            .map(|(arm, _)| arm)
+            .unwrap_or(hold_arm);
+        assert!(
+            hold_arm.contains("prevent_exit"),
+            "the ExitAction::Hold arm must call prevent_exit; found: {hold_arm:?}"
         );
     }
 }

--- a/tray/src-tauri/src/daemon_lifecycle.rs
+++ b/tray/src-tauri/src/daemon_lifecycle.rs
@@ -294,14 +294,33 @@ pub(crate) async fn stop_for_pause() -> Result<(), String> {
 /// already up, so a double-click cannot `kickstart -k` a healthy daemon
 /// mid-write.
 pub(crate) async fn resume_from_pause() -> Result<(), String> {
-    let span = tracing::info_span!("daemon_lifecycle.resume", outcome = tracing::field::Empty);
+    // Both fields must be declared here, even though only one is ever set on a
+    // given run: `Span::record` on a field the macro did not declare is a
+    // silent no-op, so an `otel.status_code` recorded later would never reach
+    // the exporter and the failure would look like a success that stopped
+    // logging.
+    let span = tracing::info_span!(
+        "daemon_lifecycle.resume",
+        outcome = tracing::field::Empty,
+        otel.status_code = tracing::field::Empty,
+    );
     async {
-        let home = meridian_core::paths::home_dir()
-            .ok_or_else(|| "home directory could not be resolved".to_string())?;
+        let s = tracing::Span::current();
+        // Handled long-hand rather than with `?`: this is the failure boundary,
+        // and a bare `?` would return an error the span never records - leaving
+        // a resume that silently did nothing indistinguishable, in telemetry,
+        // from one that never ran.
+        let Some(home) = meridian_core::paths::home_dir() else {
+            let e = "home directory could not be resolved".to_string();
+            s.record("outcome", "failed");
+            s.record("otel.status_code", "ERROR");
+            tracing::warn!(error = %e, "could not resume the daemon");
+            return Err(e);
+        };
         let _guard = LIFECYCLE.lock().await;
         DAEMON_PAUSED.store(false, Ordering::Relaxed);
         crate::backend_install::ensure_daemon_running(&home).await;
-        tracing::Span::current().record("outcome", "resumed");
+        s.record("outcome", "resumed");
         tracing::info!("daemon resumed from pause");
         Ok(())
     }
@@ -323,12 +342,20 @@ pub(crate) async fn resume_from_pause() -> Result<(), String> {
 ///   narrow that race, not close it - the pause could land between the check and
 ///   the `launchctl` call.
 pub(crate) async fn restore_unless_paused(home: &std::path::Path) {
-    let _guard = LIFECYCLE.lock().await;
-    if DAEMON_PAUSED.load(Ordering::Relaxed) {
-        tracing::info!("skipping the launch-time daemon restore - the user paused it");
-        return;
+    let span = tracing::info_span!("daemon_lifecycle.restore", outcome = tracing::field::Empty);
+    async {
+        let s = tracing::Span::current();
+        let _guard = LIFECYCLE.lock().await;
+        if DAEMON_PAUSED.load(Ordering::Relaxed) {
+            s.record("outcome", "skipped_paused");
+            tracing::info!("skipping the launch-time daemon restore - the user paused it");
+            return;
+        }
+        s.record("outcome", "restored");
+        crate::backend_install::ensure_daemon_running(home).await;
     }
-    crate::backend_install::ensure_daemon_running(home).await;
+    .instrument(span)
+    .await
 }
 
 /// The OS mechanics, shared by quit and pause.

--- a/tray/src-tauri/src/daemon_lifecycle.rs
+++ b/tray/src-tauri/src/daemon_lifecycle.rs
@@ -1,0 +1,265 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Taking the daemon down when the user says so - on quit, and on the tray
+//! menu's Connected / Disconnected toggle.
+//!
+//! # Why this exists
+//!
+//! The daemon is a separate OS process under launchd (macOS) or the Task
+//! Scheduler (Windows), so quitting the tray never touched it. That was wrong
+//! in three ways at once:
+//!
+//! - **`meridian db repair` was unreachable.** The `db.corrupt` notice tells
+//!   the user to quit Meridian and run it, but [`meridian::db::repair`]'s
+//!   `ensure_no_writers` checks the daemon first and refuses while it is up. The
+//!   documented recovery dead-ended on its own instruction, and the last
+//!   incident had to be driven by hand with `launchctl bootout`.
+//! - **"Quit" was not honest.** Capture runs in *this* process, so quitting
+//!   already stopped tracking - but the surviving daemon kept polling, kept
+//!   `meridian.db` open, and kept the summariser spawning third-party LLM CLIs
+//!   and making network calls after the user had closed the app.
+//! - **"Pause" did nothing.** It ran `daemon_control::set_running(false)` =
+//!   `launchctl stop`, and the plist sets `KeepAlive=true`, so launchd put the
+//!   daemon straight back after `ThrottleInterval` (30 s). The menu read
+//!   "Disconnected ○" over a running daemon.
+//!
+//! # `bootout`, not `stop`
+//!
+//! `launchctl stop` cannot hold a `KeepAlive` job down; `bootout` removes it
+//! from the domain, and nothing resurrects it until something bootstraps it
+//! again. [`crate::backend_install::stop_daemon_for_migration`] already relies
+//! on exactly that, for exactly that reason.
+//!
+//! [`meridian::db::repair::marker`]'s header warns that *automating* a bootout
+//! risks the wedge that once left a plist needing a hand reinstall. That warning
+//! is about `launchctl disable`, an override that persists across boots and is
+//! the thing that actually wedged (a screenpipe plist, historically). We never
+//! call it. The bootout here goes through
+//! [`crate::backend_install::bootout_agent_and_wait`], which polls until the
+//! launchd entry has genuinely cleared - the wait that prevents a following
+//! `bootstrap` from returning EIO, and the same path `register_agent` takes on
+//! every single install. The marker remains the right tool for *repair*, whose
+//! requirement is different: the daemon must stay down across an unbounded
+//! number of relaunches by a tray that may itself be crash-looping.
+//!
+//! # The invariant that makes this safe
+//!
+//! **The tray restores the daemon on launch.** A stop here is only ever "until
+//! the tray comes back", and [`crate::backend_install::ensure_backend_installed`]
+//! re-registers a booted-out agent on every start, on the packaged and the
+//! dev/source path alike. Without that half, a single quit would leave the
+//! daemon down permanently - `RunAtLoad` cannot fire for a job that is no longer
+//! loaded, so not even the next login would recover it.
+//!
+//! Pause state is process-local ([`crate::state::AppState::daemon_paused`]) and
+//! deliberately not persisted, matching the capture pause in
+//! [`crate::commands::pause`]: relaunching the tray resumes the daemon. The
+//! alternative - a pause that outlives the process that set it - is the failure
+//! mode `repair::marker` had to grow an expiry to escape.
+//!
+//! # Who calls this
+//!
+//! - [`stop_for_quit`] - [`crate::run`]'s `RunEvent::ExitRequested` handler.
+//! - [`stop_for_pause`] / [`resume_from_pause`] - [`crate::commands::daemon::toggle_daemon`],
+//!   behind the tray menu's Connected / Disconnected item.
+//!
+//! # Related
+//!
+//! - [`crate::backend_install`] - owns the OS mechanics and the restore half.
+//! - [`crate::poll::watchdog`] - must not fight a pause; its `decide` takes
+//!   `daemon_paused` for that reason.
+//! - [`crate::commands::daemon_control`] - the probe and the launchd verbs.
+
+use std::time::Duration;
+
+/// How long a quit waits for the daemon to go down before giving up and exiting
+/// anyway.
+///
+/// The bootout itself is near-instant; this covers launchd taking its time to
+/// clear the entry. Bounded because a quit that hangs is worse than a daemon
+/// that outlives it by a few seconds: the user asked for the app to close, and
+/// the next launch reconciles the daemon regardless.
+const QUIT_STOP_BUDGET: Duration = Duration::from_secs(5);
+
+/// Whether an exit should take the daemon down with it.
+///
+/// Pure and free of `cfg` so the policy is pinned by tests on every platform -
+/// the same discipline as [`crate::poll::watchdog::decide`] and
+/// [`crate::commands::daemon_control`]'s `status_running`, and for the same
+/// reason: everything around it shells out to the OS and cannot be tested at
+/// all.
+///
+/// - `code` is `RunEvent::ExitRequested`'s: `None` for a user-driven quit
+///   (the tray menu item, macOS Cmd+Q), `Some` when something called
+///   `AppHandle::exit` or `AppHandle::restart`.
+/// - `already_stopping` is the re-entry latch. The handler exits by calling
+///   `exit()` again, which fires a second `ExitRequested`; without the latch
+///   that would spawn another stop and never terminate.
+///
+/// [`tauri::RESTART_EXIT_CODE`] is the one code that must NOT stop the daemon.
+/// Both `update.rs`'s post-install relaunch and `commands::repair`'s
+/// restart-into-`repair_boot` call `AppHandle::restart`, which routes through
+/// this event from a command thread. The app is coming straight back in both
+/// cases, so a bootout would be pure latency on the update path - and on the
+/// repair path it would fight the marker handshake that is already holding the
+/// daemon off.
+pub(crate) fn should_stop_daemon(code: Option<i32>, already_stopping: bool) -> bool {
+    if already_stopping {
+        return false;
+    }
+    code != Some(tauri::RESTART_EXIT_CODE)
+}
+
+/// Take the daemon down because the app is quitting.
+///
+/// Bounded by [`QUIT_STOP_BUDGET`] and **infallible by design**: every failure
+/// path logs and returns, because the caller's next act is to exit and a quit
+/// the user cannot complete is a worse bug than a daemon that outlives it. The
+/// next launch reconciles either way.
+pub(crate) async fn stop_for_quit() {
+    match tokio::time::timeout(QUIT_STOP_BUDGET, stop_daemon()).await {
+        Ok(Ok(())) => tracing::info!("daemon stopped for quit"),
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, "could not stop the daemon on quit - exiting anyway")
+        }
+        Err(_) => tracing::warn!(
+            budget_s = QUIT_STOP_BUDGET.as_secs(),
+            "stopping the daemon on quit exceeded its budget - exiting anyway"
+        ),
+    }
+}
+
+/// Take the daemon down because the user paused it from the tray menu.
+///
+/// Unbounded, unlike [`stop_for_quit`]: nothing is waiting on this to finish,
+/// and the caller reports the outcome to the user rather than swallowing it.
+pub(crate) async fn stop_for_pause() -> Result<(), String> {
+    stop_daemon().await.inspect(|()| {
+        tracing::info!("daemon stopped for pause");
+    })
+}
+
+/// Bring a paused daemon back.
+///
+/// Delegates to [`crate::backend_install::ensure_daemon_running`], which is the
+/// same call the tray makes on launch - so resuming and relaunching converge on
+/// one code path rather than two that can drift. It returns early when the
+/// daemon is already up, so a double-click cannot `kickstart -k` a healthy
+/// daemon mid-write.
+pub(crate) async fn resume_from_pause() -> Result<(), String> {
+    let home = meridian_core::paths::home_dir()
+        .ok_or_else(|| "home directory could not be resolved".to_string())?;
+    crate::backend_install::ensure_daemon_running(&home).await;
+    tracing::info!("daemon resumed from pause");
+    Ok(())
+}
+
+/// The OS mechanics, shared by quit and pause.
+///
+/// macOS: `bootout` (never `stop` - see the module docs) via the same
+/// clearance-waiting helper `register_agent` and the encryption migration use.
+///
+/// Windows: the Task Scheduler path already written for staging an update,
+/// which ends the task and then waits for the process to actually go. Note that
+/// it escalates to `taskkill /F` for stragglers, which is a `TerminateProcess`
+/// with no clean pool shutdown. That is reused rather than softened on purpose:
+/// it is the only stop mechanism this repo has on Windows, it already runs on
+/// every update, and there is no graceful signal wired to the daemon there (the
+/// `SIGTERM` handler is a Unix path). SQLite survives a killed writer; the
+/// corruption profile that hurt this codebase was *two* writers sharing a WAL,
+/// which is the thing being removed here.
+async fn stop_daemon() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        crate::backend_install::bootout_agent_and_wait(crate::backend_install::DAEMON_LABEL).await
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let home = meridian_core::paths::home_dir()
+            .ok_or_else(|| "home directory could not be resolved".to_string())?;
+        let daemon_bin = home
+            .join(".meridian")
+            .join("bin")
+            .join(crate::backend_install::DAEMON_FILE);
+        crate::backend_install::stop_running_daemon_before_stage(&daemon_bin).await
+    }
+    // No service manager is wired on other targets, so there is nothing to stop
+    // and nothing to report - the tray does not manage a daemon there at all.
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The bug this module exists for: quitting from the tray menu, or via
+    /// Cmd+Q once the dashboard has switched the activation policy to
+    /// `Regular`, must take the daemon down.
+    #[test]
+    fn a_user_quit_stops_the_daemon() {
+        assert!(
+            should_stop_daemon(None, false),
+            "a user-driven quit must stop the daemon - leaving it up is what \
+             made 'meridian db repair' unreachable"
+        );
+    }
+
+    /// `tray::handle_menu_event`'s "quit" arm calls `app.exit(0)`, which arrives
+    /// here as `Some(0)` rather than `None`. Keying on "is it a restart" instead
+    /// of "is it programmatic" is what keeps that path covered.
+    #[test]
+    fn a_programmatic_exit_stops_the_daemon_too() {
+        assert!(should_stop_daemon(Some(0), false));
+        assert!(should_stop_daemon(Some(1), false));
+    }
+
+    /// A relaunch must leave the daemon alone. `update.rs` restarts into the
+    /// newly installed version and `commands::repair` restarts into
+    /// `repair_boot`; the app is returning immediately in both cases, and the
+    /// repair path is relying on its marker rather than on launchd state.
+    #[test]
+    fn a_restart_does_not_stop_the_daemon() {
+        assert!(
+            !should_stop_daemon(Some(tauri::RESTART_EXIT_CODE), false),
+            "an auto-update or repair relaunch must not bootout the daemon"
+        );
+    }
+
+    /// The handler re-enters by calling `exit()` again. Without the latch that
+    /// second pass would spawn another stop, which would exit again, forever.
+    #[test]
+    fn the_second_pass_is_a_no_op() {
+        assert!(!should_stop_daemon(None, true));
+        assert!(!should_stop_daemon(Some(0), true));
+    }
+
+    /// The policy above is worth nothing unless something consults it, and no
+    /// unit test can reach `RunEvent::ExitRequested` - it needs a live Tauri
+    /// event loop. So scan the source, the way `backend_install`'s `cfg` audit
+    /// and the UI's `no-native-dialogs` test do for their own unreachable-in-a-
+    /// unit-test invariants.
+    ///
+    /// This is the regression guard for the original bug: before this change
+    /// `run`'s event closure handled only `RunEvent::Reopen`, so quitting the
+    /// tray left the daemon running.
+    #[test]
+    fn the_exit_handler_is_actually_wired_into_run() {
+        const LIB_SRC: &str = include_str!("lib.rs");
+        assert!(
+            LIB_SRC.contains("RunEvent::ExitRequested"),
+            "run()'s event closure must handle ExitRequested, or quitting the \
+             tray silently leaves the daemon running - the bug this module fixes"
+        );
+        assert!(
+            LIB_SRC.contains("daemon_lifecycle::stop_for_quit"),
+            "the ExitRequested handler must call stop_for_quit"
+        );
+        assert!(
+            LIB_SRC.contains("prevent_exit"),
+            "the stop is async, so the handler must defer the exit with \
+             prevent_exit rather than racing the process teardown"
+        );
+    }
+}

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -1202,11 +1202,13 @@ pub fn run() {
             // cold start, so this only matters for warm activation.
             //
             // `RunEvent::Reopen` is a macOS-only enum variant (it doesn't exist
-            // on other targets), so the whole arm is cfg-gated — on Linux/Windows
-            // the closure is a no-op and the params stay underscore-prefixed to
-            // avoid unused warnings. The routing decision lives in the
-            // platform-independent [`reopen_target`] / [`is_onboarded`] so it is
-            // unit-testable without a live Tauri app (see the tests below).
+            // on other targets), so this arm alone is cfg-gated. The closure
+            // itself is no longer a no-op off macOS — the `ExitRequested` arm
+            // above runs on every platform, which is why `app` and `event` are
+            // plain names rather than underscore-prefixed. The routing decision
+            // lives in the platform-independent [`reopen_target`] /
+            // [`is_onboarded`] so it is unit-testable without a live Tauri app
+            // (see the tests below).
             //
             // `has_visible_windows` is intentionally ignored (`{ .. }`): both
             // openers already reuse an existing dashboard/wizard window via

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -931,12 +931,8 @@ pub fn run() {
             // that is confirmed stopped. It deliberately never signals a running
             // process — doing so on a slow probe corrupted `meridian.db` on
             // every macOS install. See `poll::watchdog` before changing it.
-            let watchdog_paused = {
-                let s = app_state.lock().expect("app state mutex poisoned");
-                s.daemon_paused.clone()
-            };
             tauri::async_runtime::spawn(async move {
-                poll::run_daemon_watchdog(watchdog_paused).await;
+                poll::run_daemon_watchdog().await;
             });
 
             // Launch-at-login: self-heal (once ever, see autostart.rs) so the
@@ -1168,24 +1164,31 @@ pub fn run() {
             // policy to `Regular`). The first two call `AppHandle::exit`, which
             // routes through this same event.
             //
-            // The stop is async and the exit is not, hence `prevent_exit` +
-            // re-entry: `exit(0)` fires a second `ExitRequested`, which the
-            // latch lets through. See [`daemon_lifecycle`] for the rest,
-            // including why a restart must be exempt.
+            // The stop is async and the exit is not, so the exit is held with
+            // `prevent_exit` and re-issued once the stop finishes. That makes
+            // "are we exiting?" three-state rather than a boolean - see
+            // [`daemon_lifecycle::ExitPhase`] for why a single latch was wrong,
+            // and why a restart must pass straight through.
             if let tauri::RunEvent::ExitRequested { code, api, .. } = &event {
-                // This closure only ever runs on the event-loop thread, so the
-                // load/store pair cannot interleave with itself.
-                static STOPPING_DAEMON: std::sync::atomic::AtomicBool =
-                    std::sync::atomic::AtomicBool::new(false);
-                let already = STOPPING_DAEMON.load(std::sync::atomic::Ordering::SeqCst);
-                if daemon_lifecycle::should_stop_daemon(*code, already) {
-                    STOPPING_DAEMON.store(true, std::sync::atomic::Ordering::SeqCst);
-                    api.prevent_exit();
-                    let handle = app.clone();
-                    tauri::async_runtime::spawn(async move {
-                        daemon_lifecycle::stop_for_quit().await;
-                        handle.exit(0);
-                    });
+                use daemon_lifecycle::{ExitAction, ExitPhase};
+                match daemon_lifecycle::decide_exit(*code, daemon_lifecycle::exit_phase()) {
+                    ExitAction::Proceed => {}
+                    // Something else is already stopping the daemon and will
+                    // issue the real exit. Just don't let this one through.
+                    ExitAction::Hold => api.prevent_exit(),
+                    ExitAction::HoldAndStop => {
+                        daemon_lifecycle::set_exit_phase(ExitPhase::Stopping);
+                        api.prevent_exit();
+                        let handle = app.clone();
+                        tauri::async_runtime::spawn(async move {
+                            daemon_lifecycle::stop_for_quit().await;
+                            // Immediately before the exit, so the re-entrant
+                            // `ExitRequested` this triggers is the one and only
+                            // one allowed through.
+                            daemon_lifecycle::set_exit_phase(ExitPhase::ReadyToExit);
+                            handle.exit(0);
+                        });
+                    }
                 }
             }
 

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ mod capture_ignore;
 mod commands;
 mod counter_ping;
 mod crash;
+mod daemon_lifecycle;
 mod db_key;
 mod deep_link;
 
@@ -930,8 +931,12 @@ pub fn run() {
             // that is confirmed stopped. It deliberately never signals a running
             // process — doing so on a slow probe corrupted `meridian.db` on
             // every macOS install. See `poll::watchdog` before changing it.
+            let watchdog_paused = {
+                let s = app_state.lock().expect("app state mutex poisoned");
+                s.daemon_paused.clone()
+            };
             tauri::async_runtime::spawn(async move {
-                poll::run_daemon_watchdog().await;
+                poll::run_daemon_watchdog(watchdog_paused).await;
             });
 
             // Launch-at-login: self-heal (once ever, see autostart.rs) so the
@@ -1146,7 +1151,44 @@ pub fn run() {
         ])
         .build(tauri::generate_context!())
         .expect("error running meridian tray")
-        .run(|_app, _event| {
+        .run(|app, event| {
+            // Quitting Meridian takes the daemon with it.
+            //
+            // It is a separate launchd/Task Scheduler process, so before this
+            // handler existed "Quit" left it polling, holding `meridian.db`
+            // open, and running the summariser's third-party LLM CLIs after the
+            // user had closed the app - and, worse, made the `db.corrupt`
+            // notice's own instructions impossible to follow, because
+            // `meridian db repair` refuses to run while the daemon is up.
+            //
+            // Handled here rather than in the menu item's "quit" arm so every
+            // way out is covered by one rule: the tray menu, the popover
+            // footer's Quit button (`commands::system::quit_app`), and macOS
+            // Cmd+Q (reachable once the dashboard has switched the activation
+            // policy to `Regular`). The first two call `AppHandle::exit`, which
+            // routes through this same event.
+            //
+            // The stop is async and the exit is not, hence `prevent_exit` +
+            // re-entry: `exit(0)` fires a second `ExitRequested`, which the
+            // latch lets through. See [`daemon_lifecycle`] for the rest,
+            // including why a restart must be exempt.
+            if let tauri::RunEvent::ExitRequested { code, api, .. } = &event {
+                // This closure only ever runs on the event-loop thread, so the
+                // load/store pair cannot interleave with itself.
+                static STOPPING_DAEMON: std::sync::atomic::AtomicBool =
+                    std::sync::atomic::AtomicBool::new(false);
+                let already = STOPPING_DAEMON.load(std::sync::atomic::Ordering::SeqCst);
+                if daemon_lifecycle::should_stop_daemon(*code, already) {
+                    STOPPING_DAEMON.store(true, std::sync::atomic::Ordering::SeqCst);
+                    api.prevent_exit();
+                    let handle = app.clone();
+                    tauri::async_runtime::spawn(async move {
+                        daemon_lifecycle::stop_for_quit().await;
+                        handle.exit(0);
+                    });
+                }
+            }
+
             // macOS: fires when the user re-activates the app externally
             // (Spotlight, dock click, `open -a Meridian`). The tray runs as an
             // Accessory app so there is no dock icon most of the time; without
@@ -1170,13 +1212,13 @@ pub fn run() {
             // flag would only matter if we wanted different behaviour for
             // "windows visible" vs "all minimised", which we don't.
             #[cfg(target_os = "macos")]
-            if let tauri::RunEvent::Reopen { .. } = _event {
+            if let tauri::RunEvent::Reopen { .. } = event {
                 let home = std::env::var("HOME").unwrap_or_default();
                 let onboarded = is_onboarded(std::path::Path::new(&home));
                 tracing::info!(onboarded, "app.reopen: routing external activation");
                 match reopen_target(onboarded) {
-                    ReopenTarget::Dashboard => tray::open_native_dashboard(_app),
-                    ReopenTarget::Wizard => tray::open_wizard_window(_app),
+                    ReopenTarget::Dashboard => tray::open_native_dashboard(app),
+                    ReopenTarget::Wizard => tray::open_wizard_window(app),
                 }
             }
         });

--- a/tray/src-tauri/src/poll/watchdog.rs
+++ b/tray/src-tauri/src/poll/watchdog.rs
@@ -196,12 +196,9 @@ async fn daemon_process_alive() -> Option<bool> {
 
 /// Probe every [`TICK`]; act only when [`decide`] says to.
 ///
-/// `daemon_paused` is `AppState::daemon_paused`, read fresh each tick so a
-/// pause or resume takes effect on the next one.
-///
 /// See the module docs for why this is far more conservative than it looks like
 /// it should be.
-pub async fn run_daemon_watchdog(daemon_paused: std::sync::Arc<std::sync::atomic::AtomicBool>) {
+pub async fn run_daemon_watchdog() {
     let mut consecutive_failures: u32 = 0;
     let mut cooldown_until: Option<Instant> = None;
     let mut window_started = Instant::now();
@@ -217,7 +214,8 @@ pub async fn run_daemon_watchdog(daemon_paused: std::sync::Arc<std::sync::atomic
             gave_up = false;
         }
 
-        let paused = daemon_paused.load(std::sync::atomic::Ordering::Relaxed);
+        // Read fresh each tick, so a pause or resume takes effect on the next.
+        let paused = crate::daemon_lifecycle::is_paused();
 
         let probe_ok = crate::commands::daemon_control::probe().await.running;
         if probe_ok {

--- a/tray/src-tauri/src/poll/watchdog.rs
+++ b/tray/src-tauri/src/poll/watchdog.rs
@@ -125,6 +125,15 @@ pub(crate) struct Inputs {
     pub starts_in_window: u32,
     /// Whether the post-start quiet window is still open.
     pub in_cooldown: bool,
+    /// Whether the user has deliberately paused the daemon from the tray menu.
+    ///
+    /// A paused daemon is `bootout`ed, so it looks exactly like a dead one to
+    /// every other input here: the endpoint is silent and the process is gone.
+    /// Without this flag the watchdog would spend its whole start budget
+    /// `kickstart`ing a label launchd no longer has loaded, then report a
+    /// daemon that "will not come back" - about a daemon the user switched off
+    /// on purpose.
+    pub daemon_paused: bool,
 }
 
 /// The whole watchdog policy, as one pure function.
@@ -142,7 +151,18 @@ pub(crate) struct Inputs {
 /// 4. still inside the post-start cooldown → let it finish starting
 /// 5. storm cap reached → [`Action::GiveUp`]
 /// 6. otherwise → [`Action::Start`]
+///
+/// Rule 0 sits above all of them: a daemon the user paused is off *by
+/// instruction*, and no evidence this loop can gather outranks that.
 pub(crate) fn decide(i: Inputs) -> Action {
+    // Ahead of the endpoint check, and ahead of the storm cap, on purpose.
+    // Pause `bootout`s the agent, so a paused daemon presents exactly as a
+    // crashed one; every rule below would read it as an outage to recover
+    // from, and rule 5 would eventually escalate it to a user-visible "gave
+    // up" notice. Returning here is what keeps `Pause` meaning something.
+    if i.daemon_paused {
+        return Action::Wait;
+    }
     if i.probe_ok {
         return Action::Wait;
     }
@@ -176,9 +196,12 @@ async fn daemon_process_alive() -> Option<bool> {
 
 /// Probe every [`TICK`]; act only when [`decide`] says to.
 ///
+/// `daemon_paused` is `AppState::daemon_paused`, read fresh each tick so a
+/// pause or resume takes effect on the next one.
+///
 /// See the module docs for why this is far more conservative than it looks like
 /// it should be.
-pub async fn run_daemon_watchdog() {
+pub async fn run_daemon_watchdog(daemon_paused: std::sync::Arc<std::sync::atomic::AtomicBool>) {
     let mut consecutive_failures: u32 = 0;
     let mut cooldown_until: Option<Instant> = None;
     let mut window_started = Instant::now();
@@ -193,6 +216,8 @@ pub async fn run_daemon_watchdog() {
             starts_in_window = 0;
             gave_up = false;
         }
+
+        let paused = daemon_paused.load(std::sync::atomic::Ordering::Relaxed);
 
         let probe_ok = crate::commands::daemon_control::probe().await.running;
         if probe_ok {
@@ -212,7 +237,12 @@ pub async fn run_daemon_watchdog() {
         // `Wait`; past the cap → `GiveUp`), so passing `None` cannot change the
         // result. Without this, a daemon left stopped past the storm cap would
         // fork `launchctl` every 5 s forever.
-        let could_start = !probe_ok && consecutive_failures >= STRIKES && !in_cooldown && !gave_up;
+        // `!paused` belongs in this set for the same reason as the rest: while
+        // paused [`decide`] returns before it reads `process_alive`, so asking
+        // would only fork `launchctl` every 5 s for an answer that cannot
+        // change the verdict.
+        let could_start =
+            !paused && !probe_ok && consecutive_failures >= STRIKES && !in_cooldown && !gave_up;
         let process_alive = if could_start {
             daemon_process_alive().await
         } else {
@@ -225,6 +255,7 @@ pub async fn run_daemon_watchdog() {
             consecutive_failures,
             starts_in_window,
             in_cooldown,
+            daemon_paused: paused,
         });
 
         match action {
@@ -286,6 +317,7 @@ mod tests {
             consecutive_failures: STRIKES,
             starts_in_window: 0,
             in_cooldown: false,
+            daemon_paused: false,
         }
     }
 
@@ -347,8 +379,54 @@ mod tests {
                 consecutive_failures: 99,
                 starts_in_window: MAX_STARTS_IN_WINDOW + 1,
                 in_cooldown: false,
+                daemon_paused: false,
             }),
             Action::Wait
+        );
+    }
+
+    /// A paused daemon must be left alone, however dead it looks.
+    ///
+    /// Pause `bootout`s the agent, which is indistinguishable from a crash on
+    /// every other input: silent endpoint, no process, and (unlike a crash)
+    /// nothing that will ever bring it back on its own. So this is the one
+    /// state where the backstop is exactly wrong - it would undo the user's
+    /// explicit "stop working" the moment [`STRIKES`] elapsed, and `Pause`
+    /// would go back to being the no-op it was when it ran `launchctl stop`.
+    #[test]
+    fn a_paused_daemon_is_never_started() {
+        let paused = Inputs {
+            process_alive: Some(false),
+            daemon_paused: true,
+            ..silent_endpoint()
+        };
+        assert_eq!(
+            decide(paused),
+            Action::Wait,
+            "the watchdog must not resurrect a daemon the user paused"
+        );
+
+        // And it must not merely delay: no amount of elapsed outage turns a
+        // deliberate pause into something to recover from.
+        for failures in [STRIKES, STRIKES + 10, 1_000] {
+            assert_eq!(
+                decide(Inputs {
+                    consecutive_failures: failures,
+                    ..paused
+                }),
+                Action::Wait
+            );
+        }
+
+        // Nor may it burn the start budget and then report the pause as a
+        // failure to come back - `GiveUp` is a notice-raising state.
+        assert_eq!(
+            decide(Inputs {
+                starts_in_window: MAX_STARTS_IN_WINDOW + 1,
+                ..paused
+            }),
+            Action::Wait,
+            "a pause must not surface as the watchdog giving up"
         );
     }
 

--- a/tray/src-tauri/src/state.rs
+++ b/tray/src-tauri/src/state.rs
@@ -114,19 +114,6 @@ pub struct AppState {
     /// `capture_frames`. The flag is unconditional (not feature-gated) so the
     /// `pause_for_duration` command can always reference `AppState` cleanly.
     pub capture_paused: Arc<AtomicBool>,
-    /// Whether the user has paused the *daemon* from the tray's Connected /
-    /// Disconnected toggle. Distinct from [`Self::capture_paused`], which stops
-    /// the tray's own capture engine and leaves the daemon alone.
-    ///
-    /// An `Arc<AtomicBool>` rather than a plain field because the daemon
-    /// watchdog reads it every 5 s on its own task and must not contend for
-    /// (or be poisoned by) the `AppState` mutex to do it - the same reason
-    /// `capture_paused` is shaped this way for the capture consumers.
-    ///
-    /// Process-local and deliberately not persisted, matching the capture
-    /// pause: relaunching the tray resumes the daemon. See
-    /// [`crate::daemon_lifecycle`] for why.
-    pub daemon_paused: Arc<AtomicBool>,
     /// The user's capture ignore list (apps + website domains). Shared with the
     /// capture frame + UI-event consumers, which drop a matching frame before it
     /// is written to `capture_frames`/`capture_ui_events`. Unconditional (not
@@ -197,7 +184,6 @@ impl Default for AppState {
             tray_id: None,
             health: HealthStatus::Unknown,
             capture_paused: Arc::new(AtomicBool::new(false)),
-            daemon_paused: Arc::new(AtomicBool::new(false)),
             capture_ignore: Arc::new(Mutex::new(CaptureIgnore::default())),
             pause_until: None,
             pause_source: None,

--- a/tray/src-tauri/src/state.rs
+++ b/tray/src-tauri/src/state.rs
@@ -114,6 +114,19 @@ pub struct AppState {
     /// `capture_frames`. The flag is unconditional (not feature-gated) so the
     /// `pause_for_duration` command can always reference `AppState` cleanly.
     pub capture_paused: Arc<AtomicBool>,
+    /// Whether the user has paused the *daemon* from the tray's Connected /
+    /// Disconnected toggle. Distinct from [`Self::capture_paused`], which stops
+    /// the tray's own capture engine and leaves the daemon alone.
+    ///
+    /// An `Arc<AtomicBool>` rather than a plain field because the daemon
+    /// watchdog reads it every 5 s on its own task and must not contend for
+    /// (or be poisoned by) the `AppState` mutex to do it - the same reason
+    /// `capture_paused` is shaped this way for the capture consumers.
+    ///
+    /// Process-local and deliberately not persisted, matching the capture
+    /// pause: relaunching the tray resumes the daemon. See
+    /// [`crate::daemon_lifecycle`] for why.
+    pub daemon_paused: Arc<AtomicBool>,
     /// The user's capture ignore list (apps + website domains). Shared with the
     /// capture frame + UI-event consumers, which drop a matching frame before it
     /// is written to `capture_frames`/`capture_ui_events`. Unconditional (not
@@ -184,6 +197,7 @@ impl Default for AppState {
             tray_id: None,
             health: HealthStatus::Unknown,
             capture_paused: Arc::new(AtomicBool::new(false)),
+            daemon_paused: Arc::new(AtomicBool::new(false)),
             capture_ignore: Arc::new(Mutex::new(CaptureIgnore::default())),
             pause_until: None,
             pause_source: None,

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meridian-ui",
-  "version": "1.74.0",
+  "version": "1.83.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meridian-ui",
-      "version": "1.74.0",
+      "version": "1.83.1",
       "dependencies": {
         "@clerk/react": "^6.12.2",
         "@hello-pangea/dnd": "^18.0.1",


### PR DESCRIPTION
## Why

The tray and the daemon are separate processes - the daemon is its own launchd agent / scheduled task - so **quitting Meridian never stopped it**. `tray.rs`'s Quit arm was a bare `app.exit(0)`, and the plist sets `KeepAlive=true`.

That broke three things at once:

**1. `meridian db repair` was unreachable.** The `db.corrupt` notice tells the user (`src/main.rs:1178`, `:1494`):

> "Pause tracking, quit Meridian, then run `meridian db repair` in a terminal"

Follow it literally and repair refuses, because `ensure_no_writers()` checks the daemon **first** and bails. The documented recovery dead-ended on its own instruction - which is why the last corruption incident had to be driven by hand with `launchctl bootout`.

**2. "Quit" was not honest.** Capture runs in the tray, so quitting already stopped tracking - but the surviving daemon kept polling, kept `meridian.db` open, and kept the summariser spawning third-party LLM CLIs and making network calls after the user closed the app. For a tool positioned on privacy that is the wrong default.

**3. "Pause" did nothing.** `toggle_daemon` ran `launchctl stop`, which `KeepAlive` undoes after `ThrottleInterval` (30 s). The menu read "Disconnected ○" over a running daemon. Already documented at `commands/repair.rs:96` and in `db/repair/marker.rs` - never fixed.

## What changed

**`bootout`, not `stop`.** `stop` cannot hold a `KeepAlive` job down. The bootout goes through `backend_install::bootout_agent_and_wait`, which polls until the launchd entry actually clears - the same helper `stop_daemon_for_migration` and every install already use, and that clearance wait is what prevents the `bootstrap`-returns-EIO wedge. We never call `launchctl disable`, the override that historically wedged a plist.

- **New `tray/src-tauri/src/daemon_lifecycle.rs`** - owns quit/pause/resume plus a pure, cfg-free `should_stop_daemon` policy fn (the `watchdog::decide` precedent: everything around it shells out to the OS and can't be tested).
- **`RunEvent::ExitRequested` in `lib.rs`** - covers the tray menu, the popover's Quit button (`commands::system::quit_app`) and macOS Cmd+Q in one place. Bounded to 5 s and **never blocks the exit**: a quit the user can't complete is worse than a daemon that outlives it by a moment.
- **`RESTART_EXIT_CODE` is exempt.** Both `update.rs:316` and `commands/repair.rs:104` call `app.restart()` from a command thread, which routes through this event. Booting the daemon out during an auto-update relaunch is pure latency; during a repair restart it would fight the marker handshake already holding the daemon off.
- **Pause/Resume** now use the same primitives, with `AppState.daemon_paused` set *before* the stop and cleared *before* the start - the watchdog probes every 5 s, so flipping the flag second leaves a window where it reads a deliberate pause as an outage.
- **`watchdog::decide` gains `daemon_paused` → `Wait`.** A paused daemon is bootout-ed and so is indistinguishable from a crashed one; without this the watchdog burns its 5-start budget kickstarting a label launchd no longer has loaded, then escalates to a user-visible "gave up" notice about a daemon the user switched off on purpose.

### The half that makes it safe

**`ensure_backend_installed` now restores the daemon on every bail-out**, including the dev/source path (which returned before ever reaching `ensure_daemon_running`), an unreadable bundled binary, and a failed staging/install.

This is not optional. A `bootout` is undone by neither `KeepAlive` **nor `RunAtLoad` at the next login** - the job is no longer loaded for either to act on. Without the restore, one quit would leave the daemon down permanently, and the symptom is not an error but silence: no sessions, ever, surfacing hours later somewhere unrelated. The second commit closes two bail-outs the first one missed.

### Text that was false

- The `db.corrupt` remedy → `"Quit Meridian, then run 'meridian db repair' in a terminal"` - now literally true, and one action instead of two.
- `repair::stop_daemon_hint()` - its doc asserted "**Quitting the tray does not stop the daemon**"; the manual `launchctl bootout` route stays for machines where the tray isn't installed or won't start.
- `marker.rs`'s "automating bootout is another matter" paragraph - the tray now does automate it, and the note explains why repair still shouldn't (repair needs the daemon down across unbounded relaunches driven by a tray that may itself be crash-looping, which is exactly when "the tray will undo this" fails).

## Tests

Written first and each proven red before implementing:

| Test | Pins |
|---|---|
| `a_paused_daemon_is_never_started` | red as `Start`; the watchdog must not resurrect a pause, at any outage length, and must not escalate one to `GiveUp` |
| `a_user_quit_stops_the_daemon` / `a_programmatic_exit_stops_the_daemon_too` / `a_restart_does_not_stop_the_daemon` / `the_second_pass_is_a_no_op` | the exit policy, on every platform |
| `the_exit_handler_is_actually_wired_into_run` | red by construction (`lib.rs` had zero `RunEvent::ExitRequested`); source-scanned because no unit test can reach a live Tauri event loop |
| `every_early_return_still_restores_the_daemon` | enumerates every `return;` in `ensure_backend_installed` and requires a restore before each; verified red by deleting one, twice |
| `stop_hint_does_not_name_a_nonexistent_subcommand` | existing test, updated - it caught its own "pause tracking" assertion going stale |

`cargo fmt` · `cargo clippy --workspace --all-targets -D warnings` · `cargo test --workspace` (879 + 216 tray) · UI build + tests · security audit - all green via the pre-push suite.

## Not verified by CI

End-to-end behaviour needs a packaged build and would stop the daemon on whatever machine runs it, so it is **not** covered here:

```bash
launchctl print gui/$(id -u)/com.meridiona.daemon | grep pid   # before
# quit from the tray, then:
launchctl print gui/$(id -u)/com.meridiona.daemon              # expect 113, no such service
meridian db check                                              # expect: runs, no "daemon is still running"
# relaunch the tray:
launchctl print gui/$(id -u)/com.meridiona.daemon | grep pid   # expect: back, new pid
```
Plus: Pause stays down past 60 s (today it returns after ~30 s), Resume brings it back, and an update check does **not** bootout.

## Risks

- **Tray fails to launch after a clean quit** → daemon stays down until the next successful launch. This is the one behaviour genuinely traded away; launchd starts the tray at login, which bounds it.
- **Tray crashes** (not a clean quit) → daemon survives, exactly as today. Fail-safe direction.
- **Windows** reuses `stop_running_daemon_before_stage`, which escalates to `taskkill /F`. Reused rather than softened on purpose: it is the only stop mechanism the repo has there, it already runs on every update, and no graceful signal is wired to the daemon on Windows. SQLite survives a killed writer; the corruption profile that hurt this codebase was *two* writers sharing a WAL - which is what this removes.
- Pause is process-local and not persisted, matching the existing capture pause: relaunching the tray resumes the daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TCFYB8yahQ2D6Lt7LvCzU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quitting Meridian now stops both the tray application and its background daemon.
  * Pausing tracking cleanly pauses daemon activity without triggering restarts or watchdog alerts.
  * Resuming tracking restores daemon activity automatically.
  * Daemon installation and updates now recover the last working version when setup fails.

* **Bug Fixes**
  * Improved handling of daemon startup, shutdown, crashes, and repeated relaunches.
  * Updated repair and database-corruption instructions to guide users to quit Meridian when required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->