### PR TITLE
fix(coding-agent): apply the SQLCipher key in the one-shot CLI pools

### DIFF
--- a/src/coding_agent_session_ingest/hook.rs
+++ b/src/coding_agent_session_ingest/hook.rs
@@ -64,7 +64,16 @@ pub async fn run_hook() {
     let pool = match super::open_meridian_pool().await {
         Ok(p) => p,
         Err(e) => {
-            tracing::error!(error = %e, "coding-agent-hook: failed to open db");
+            // `{e:#}` (the full anyhow context chain), not `%e` — plain Display
+            // renders only the outermost context ("failed to open SQLite at
+            // …"), dropping the cause that actually identifies the fault
+            // (`code: 26, file is not a database`). This hook has no terminal
+            // and exits 0 regardless, so the shipped record is the ONLY evidence
+            // it ever ran; stripping the cause from it defeats the purpose.
+            // `error` is on both SAFE_STRING_KEYS and FREE_TEXT_KEYS, so the
+            // chain is path/URL/token-scrubbed on the ship leg.
+            let detail = format!("{e:#}");
+            tracing::error!(error = %detail, "coding-agent-hook: failed to open db");
             return;
         }
     };

--- a/src/coding_agent_session_ingest/hook.rs
+++ b/src/coding_agent_session_ingest/hook.rs
@@ -12,12 +12,9 @@
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 use chrono::Utc;
 use serde_json::Value;
-use sqlx::sqlite::SqliteConnectOptions;
-use sqlx::SqlitePool;
 
 use super::indexer::register_session;
 
@@ -58,23 +55,16 @@ pub async fn run_hook() {
         }
     };
 
-    let db_path = meridian_db_path();
-    let uri = format!("sqlite://{}", db_path.display());
-    let opts = match SqliteConnectOptions::from_str(&uri) {
-        Ok(o) => o.create_if_missing(false),
-        Err(e) => {
-            tracing::error!(uri, error = %e, "coding-agent-hook: bad db uri");
-            return;
-        }
-    };
-    let pool = match SqlitePool::connect_with(opts).await {
+    // The shared keyed opener, NOT a hand-built pool. This used to be a raw
+    // `SqlitePool::connect_with`, which never applies the SQLCipher key, so on a
+    // packaged (encrypted) install every query failed with "file is not a
+    // database". The hook exits 0 on every path by design (it must never block
+    // Claude), so that failure was completely silent: SessionEnd sealed nothing
+    // and sessions fell through to the indexer's 1 h idle backstop instead.
+    let pool = match super::open_meridian_pool().await {
         Ok(p) => p,
         Err(e) => {
-            tracing::error!(
-                db_path = %db_path.display(),
-                error = %e,
-                "coding-agent-hook: failed to open db"
-            );
+            tracing::error!(error = %e, "coding-agent-hook: failed to open db");
             return;
         }
     };
@@ -131,12 +121,6 @@ fn within_accepted_roots(resolved: &Path) -> bool {
             .map(|r| resolved.starts_with(r))
             .unwrap_or(false)
     })
-}
-
-fn meridian_db_path() -> PathBuf {
-    let raw =
-        std::env::var("MERIDIAN_DB").unwrap_or_else(|_| "~/.meridian/meridian.db".to_string());
-    expand(&raw)
 }
 
 fn expand(p: &str) -> PathBuf {

--- a/src/coding_agent_session_ingest/mod.rs
+++ b/src/coding_agent_session_ingest/mod.rs
@@ -18,7 +18,6 @@ pub mod sources;
 pub mod summariser;
 
 use std::path::PathBuf;
-use std::str::FromStr;
 
 pub use segment::{
     iso_utc, norm_iso, parse_iso, parse_session_segments, Segment, SegmentParams, SessionMeta,
@@ -36,6 +35,120 @@ pub fn meridian_db_path() -> PathBuf {
 pub async fn open_meridian_pool() -> anyhow::Result<sqlx::SqlitePool> {
     let path = meridian_db_path();
     let uri = format!("sqlite://{}", path.display());
-    let opts = sqlx::sqlite::SqliteConnectOptions::from_str(&uri)?.create_if_missing(false);
-    Ok(sqlx::SqlitePool::connect_with(opts).await?)
+    let key = std::env::var("MERIDIAN_DB_KEY").ok();
+    open_meridian_pool_at(&uri, key.as_deref()).await
+}
+
+/// The env-free half of [`open_meridian_pool`], so the key handling is testable
+/// without mutating process-global environment variables.
+///
+/// Goes through [`meridian_core::db_crypto::open_pool_with_key`] — the same
+/// opener the daemon uses — rather than building the pool by hand. That helper
+/// applies the SQLCipher key as the first statement on every new connection,
+/// and its `key_unless_plaintext` guard drops the key when the file on disk is
+/// plaintext, so a dev/source install (no key, or a key left over from a
+/// half-finished `encrypt_in_place`) keeps working unchanged.
+///
+/// `create_if_missing` is false: the daemon owns creation and migrations, and a
+/// one-shot CLI that silently conjured an empty DB would report a nonsense
+/// "0 pending" instead of an error.
+pub async fn open_meridian_pool_at(
+    uri: &str,
+    key_hex: Option<&str>,
+) -> anyhow::Result<sqlx::SqlitePool> {
+    meridian_core::db_crypto::open_pool_with_key(uri, key_hex, false, &[]).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_KEY: &str = "3a15689f73412c29d7ed3b902a01e33dbd5f767dc37b792e19ac9e2366bf2cd2";
+
+    /// The one-shot CLI subcommands (`coding-agent-summarise`,
+    /// `coding-agent-hook`) must be able to read an ENCRYPTED meridian.db.
+    ///
+    /// Regression: this pool was built with a raw `SqlitePool::connect_with`,
+    /// which never applies the SQLCipher key, so every query failed on a
+    /// packaged install — surfacing as the unactionable
+    /// `summarise: ensure column: check summary_source column`. The daemon's own
+    /// summariser was unaffected (it uses the keyed opener), so the only casualty
+    /// was the CLI — which is the ONLY documented way to drain the historical
+    /// summariser backlog, since `drain()` deliberately sweeps yesterday+today.
+    #[tokio::test]
+    async fn opens_an_encrypted_db() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        let uri = db_path.display().to_string();
+
+        // Seed an encrypted DB the way the daemon would.
+        let seed = meridian_core::db_crypto::open_pool_with_key(&uri, Some(TEST_KEY), true, &[])
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE app_sessions (id INTEGER PRIMARY KEY, summary_source TEXT)")
+            .execute(&seed)
+            .await
+            .unwrap();
+        seed.close().await;
+
+        // The CLI opener must read it back. Bounded, because a keyless open of an
+        // encrypted file does not fail fast — it stalls until the acquire timeout.
+        let pool = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            open_meridian_pool_at(&uri, Some(TEST_KEY)),
+        )
+        .await
+        .expect("opening an encrypted db must not stall")
+        .expect("the CLI pool must apply the SQLCipher key");
+
+        let n: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM pragma_table_info('app_sessions') WHERE name = 'summary_source'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("the exact query cli_summarise fails on today");
+        assert_eq!(n, 1);
+        pool.close().await;
+    }
+
+    /// Neither one-shot CLI may hand-build its pool again.
+    ///
+    /// The behavioural test above only covers `open_meridian_pool_at`. This
+    /// covers the regression CLASS: `hook.rs` carried an independent copy of the
+    /// same raw `SqlitePool::connect_with`, and because the hook exits 0 on every
+    /// path it failed in total silence. A unit test cannot reach it (it reads
+    /// stdin and the real `MERIDIAN_DB`), so scan the source — the same tactic as
+    /// the tray's cfg audit and the UI's `no-native-dialogs` test.
+    #[test]
+    fn one_shot_clis_do_not_hand_build_a_pool() {
+        for (name, src) in [
+            ("hook.rs", include_str!("hook.rs")),
+            ("mod.rs", include_str!("mod.rs")),
+        ] {
+            // Scan production code only — this test's own assertion strings
+            // contain the very pattern being banned, so a whole-file scan would
+            // match itself and fail for the wrong reason.
+            let src = src.split("#[cfg(test)]").next().unwrap_or(src);
+            let offenders = src
+                .lines()
+                .filter(|l| !l.trim_start().starts_with("//"))
+                .filter(|l| {
+                    l.contains("SqlitePool::connect_with")
+                        || l.contains("SqlitePool::connect(")
+                        || l.contains("connect_lazy_with")
+                })
+                .collect::<Vec<_>>();
+            assert!(
+                offenders.is_empty(),
+                "{name} builds a SQLite pool directly, which skips the SQLCipher key \
+                 — route it through open_meridian_pool/open_meridian_pool_at instead. \
+                 Offending lines: {offenders:?}"
+            );
+        }
+        // And the seam really does delegate to the keyed opener.
+        assert!(
+            include_str!("mod.rs").contains("db_crypto::open_pool_with_key("),
+            "open_meridian_pool_at must go through meridian_core::db_crypto::open_pool_with_key"
+        );
+    }
 }

--- a/src/coding_agent_session_ingest/mod.rs
+++ b/src/coding_agent_session_ingest/mod.rs
@@ -79,7 +79,9 @@ mod tests {
     async fn opens_an_encrypted_db() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("meridian.db");
-        let uri = db_path.display().to_string();
+        // The `sqlite://` form `open_meridian_pool` actually builds, so the test
+        // exercises the production string shape rather than a bare path.
+        let uri = format!("sqlite://{}", db_path.display());
 
         // Seed an encrypted DB the way the daemon would.
         let seed = meridian_core::db_crypto::open_pool_with_key(&uri, Some(TEST_KEY), true, &[])
@@ -119,23 +121,84 @@ mod tests {
     /// path it failed in total silence. A unit test cannot reach it (it reads
     /// stdin and the real `MERIDIAN_DB`), so scan the source — the same tactic as
     /// the tray's cfg audit and the UI's `no-native-dialogs` test.
+    /// The other half of the compatibility claim: a dev/source install must be
+    /// unchanged by this fix.
+    ///
+    /// That claim rests entirely on `open_pool_with_key`'s `key_unless_plaintext`
+    /// guard, and nothing else here exercises it. This is a real configuration,
+    /// not a contrived one: a dev machine with `MERIDIAN_DB_KEY` still set in a
+    /// leftover `.env` while `meridian.db` on disk is not encrypted (also the
+    /// state a half-finished `encrypt_in_place` leaves behind). Without the
+    /// guard, SQLCipher stalls on the first pragma until the acquire timeout
+    /// rather than failing fast — so this asserts a bounded, successful read.
+    #[tokio::test]
+    async fn opens_a_plaintext_db_even_with_a_key_configured() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        let uri = format!("sqlite://{}", db_path.display());
+
+        // Seed WITHOUT a key — a plaintext file.
+        let seed = meridian_core::db_crypto::open_pool_with_key(&uri, None, true, &[])
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE app_sessions (id INTEGER PRIMARY KEY, summary_source TEXT)")
+            .execute(&seed)
+            .await
+            .unwrap();
+        seed.close().await;
+
+        // Open it WITH a key configured. Must drop the key and succeed.
+        let pool = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            open_meridian_pool_at(&uri, Some(TEST_KEY)),
+        )
+        .await
+        .expect("a plaintext file with a key set must not stall")
+        .expect("the key must be dropped for a plaintext file");
+
+        let n: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM pragma_table_info('app_sessions') WHERE name = 'summary_source'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("dev/source installs must keep working");
+        assert_eq!(n, 1);
+        pool.close().await;
+    }
+
+    /// Production half of a source file — everything before its test module.
+    ///
+    /// Both checks below must scan ONLY this. The test module names the very
+    /// patterns being banned (and calls the keyed opener itself, to seed a
+    /// fixture), so a whole-file scan either matches itself and fails for the
+    /// wrong reason, or passes on its own text no matter what production code
+    /// does. `split` always yields at least one item, hence the bare `next()`.
+    fn production_half(src: &str) -> &str {
+        src.split("#[cfg(test)]").next().expect("split yields one")
+    }
+
     #[test]
     fn one_shot_clis_do_not_hand_build_a_pool() {
         for (name, src) in [
             ("hook.rs", include_str!("hook.rs")),
             ("mod.rs", include_str!("mod.rs")),
         ] {
-            // Scan production code only — this test's own assertion strings
-            // contain the very pattern being banned, so a whole-file scan would
-            // match itself and fail for the wrong reason.
-            let src = src.split("#[cfg(test)]").next().unwrap_or(src);
+            let src = production_half(src);
+            // Bare-substring bans, deliberately. The first version of this test
+            // matched only `SqlitePool::connect_with`, which let the MOST likely
+            // regression straight through: `SqlitePoolOptions::new()…
+            // .connect_with(opts)` — the shape you land on by copying the
+            // daemon's own pool construction (`db_crypto`, `db/meridian.rs`) and
+            // forgetting the key. Verified: with such a pool live in hook.rs the
+            // old assertions still passed. Post-fix neither file legitimately
+            // calls any of these, so banning the bare method names is safe.
             let offenders = src
                 .lines()
                 .filter(|l| !l.trim_start().starts_with("//"))
                 .filter(|l| {
-                    l.contains("SqlitePool::connect_with")
+                    l.contains("connect_with(")
+                        || l.contains("connect_lazy_with(")
                         || l.contains("SqlitePool::connect(")
-                        || l.contains("connect_lazy_with")
                 })
                 .collect::<Vec<_>>();
             assert!(
@@ -145,9 +208,13 @@ mod tests {
                  Offending lines: {offenders:?}"
             );
         }
-        // And the seam really does delegate to the keyed opener.
+        // And the seam really does delegate to the keyed opener. Scanned against
+        // the production half for the same reason: `opens_an_encrypted_db` calls
+        // `db_crypto::open_pool_with_key` to seed its fixture, so a whole-file
+        // read finds this substring even if `open_meridian_pool_at` stops
+        // delegating entirely.
         assert!(
-            include_str!("mod.rs").contains("db_crypto::open_pool_with_key("),
+            production_half(include_str!("mod.rs")).contains("db_crypto::open_pool_with_key("),
             "open_meridian_pool_at must go through meridian_core::db_crypto::open_pool_with_key"
         );
     }

--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -751,8 +751,13 @@ fn record_attempt(attempts: &mut HashMap<i64, u32>, row_id: i64, written: bool) 
 /// Summarise (or dry-run) the pending queue for a day — manual backfill / eval.
 pub async fn cli_summarise(pool: &SqlitePool, dry_run: bool, day: Option<&str>, limit: i64) {
     let cfg = SummariserConfig::from_env();
+    // `{e:#}` — anyhow's alternate form, which prints the whole context chain.
+    // Plain `{e}` renders only the outermost `.context(...)`, which is how this
+    // reported an unkeyed-pool failure as the bare, unactionable
+    // "ensure column: check summary_source column" while the real cause
+    // (SQLite code 26, "file is not a database") was thrown away.
     if let Err(e) = db::ensure_summary_source_column(pool).await {
-        eprintln!("summarise: ensure column: {e}");
+        eprintln!("summarise: ensure column: {e:#}");
         return;
     }
     let day = day
@@ -761,7 +766,7 @@ pub async fn cli_summarise(pool: &SqlitePool, dry_run: bool, day: Option<&str>, 
     let rows = match db::fetch_pending(pool, &cfg, limit, std::slice::from_ref(&day)).await {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("summarise: fetch_pending: {e}");
+            eprintln!("summarise: fetch_pending: {e:#}");
             return;
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,7 @@ async fn main() -> Result<()> {
         let day = flag("--day");
         let limit: i64 = flag("--limit").and_then(|v| v.parse().ok()).unwrap_or(8);
         let obs_guard = observability::init("meridian-rust").ok();
+        let mut open_failed = false;
         match meridian::coding_agent_session_ingest::open_meridian_pool().await {
             Ok(pool) => {
                 meridian::coding_agent_session_ingest::summariser::cli_summarise(
@@ -102,10 +103,33 @@ async fn main() -> Result<()> {
                 .await;
                 pool.close().await;
             }
-            Err(e) => tracing::error!(error = %e, "coding-agent-summarise: failed to open db"),
+            Err(e) => {
+                // `eprintln!`, not just `tracing`. Both `fmt` layers in
+                // `observability::init` are `cfg!(debug_assertions)`-gated and
+                // the spool is the only persisted sink, so in a RELEASE build —
+                // the only place the unkeyed pool ever failed — the tracing line
+                // below reaches no terminal at all, and this arm then returned
+                // `Ok(())`. An operator running the documented backlog-drain
+                // command against a bad or missing key saw an empty screen and
+                // exit 0: the same silent-failure class this commit fixes, one
+                // frame further out, and the frame the operator stands in.
+                //
+                // `{e:#}` is anyhow's alternate form (the full context chain);
+                // plain `%e` renders only the outermost context and would drop
+                // the actual SQLite cause from the shipped record too.
+                let detail = format!("{e:#}");
+                eprintln!("summarise: open db: {detail}");
+                tracing::error!(error = %detail, "coding-agent-summarise: failed to open db");
+                open_failed = true;
+            }
         }
         if let Some(g) = obs_guard {
             g.shutdown().await;
+        }
+        // Non-zero so `meridian doctor --fix` — which runs this as a guided fix
+        // and checks `.success()` — reports the failure instead of a false pass.
+        if open_failed {
+            std::process::exit(1);
         }
         return Ok(());
     }


### PR DESCRIPTION
## What

`open_meridian_pool` and the SessionEnd hook built their pools with a raw
`SqlitePool::connect_with`, which **never applies the SQLCipher key**. On a packaged
(encrypted) install every query failed with SQLite code 26, `file is not a database`.

Found while diagnosing a real machine: the daemon was healthy but 330 coding-agent
sessions were backed up with no way to drain them.

## Two casualties, both silent

| CLI | Effect |
|---|---|
| `meridian coding-agent-summarise` | Died on its first read, reporting only `ensure column: check summary_source column`. This is the **only** documented way to drain the historical backlog - `drain()` deliberately sweeps yesterday+today and leaves older days to an operator. |
| `meridian coding-agent-hook` | Failed to open the DB and sealed nothing. It exits 0 on every path by design, so nothing surfaced - sessions fell through to the indexer's 1 h idle backstop instead of sealing at SessionEnd. |

## Fix

Both route through `meridian_core::db_crypto::open_pool_with_key`, the same opener the
daemon uses. Its `key_unless_plaintext` guard drops the key for a plaintext file, so
dev/source installs are unchanged. `create_if_missing` stays false - the daemon owns
creation and migrations.

- Split the env read from the open (`open_meridian_pool_at`) so key handling is testable
  without mutating process-global env vars.
- `hook.rs` carried a duplicate private copy of `meridian_db_path` - removed.
- CLI error paths now print anyhow's full context chain (`{e:#}`). Plain `{e}` renders only
  the outermost context, which is exactly what reduced this to an unactionable one-liner
  and threw away the real SQLite error.

## Tests

Both written first and **proven red**, per the repo's TDD-for-bug-fixes convention:

- `opens_an_encrypted_db` - seeds an encrypted DB and reads it back through the CLI opener.
  Failed pre-fix with `SqliteError { code: 26, message: "file is not a database" }`, which
  is the error the `eprintln!` had been swallowing.
- `one_shot_clis_do_not_hand_build_a_pool` - source-scan guard covering the regression
  **class** in both one-shot CLIs (a unit test cannot reach the hook: it reads stdin and the
  real `MERIDIAN_DB`). Verified red against a planted regression, and scoped to the
  non-test portion of each file so it cannot match its own assertion strings.

`cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, and
`cargo test --workspace` (1518 passed, 0 failed) all green.

## Note

This does not by itself drain the existing backlog - it makes the command that drains it
work. Two follow-ups from the same investigation are coming as separate PRs: `meridian
doctor` misreporting on packaged installs, and backoff for the `missing_provider` worklog
warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TCFYB8yahQ2D6Lt7LvCzU