### PR TITLE
fix(doctor): stop reporting false faults on packaged installs

### DIFF
--- a/src/health/contracts.rs
+++ b/src/health/contracts.rs
@@ -63,17 +63,24 @@ fn settings_contract() -> Check {
     let resolved = meridian_core::settings::settings_json_path();
     let ui_exists = ui_settings.is_file();
 
-    // Two spellings of the same file (a symlinked home, a doubled separator, a
-    // `/./`) are not a split-brain — warning there would tell the user to unset
-    // a variable that is causing no harm. Only meaningful when both resolve on
-    // disk; `canonicalize` fails on a path that does not exist, in which case
-    // fall through to the textual comparison below.
-    if let (Ok(a), Ok(b)) = (resolved.canonicalize(), ui_settings.canonicalize()) {
-        if a == b {
-            return Check::ok("settings file", "config", "daemon + dashboard agree");
-        }
+    if same_resolved_file(&resolved, &ui_settings) {
+        return Check::ok("settings file", "config", "daemon + dashboard agree");
     }
     settings_verdict(&resolved, &ui_settings, ui_exists)
+}
+
+/// Whether two paths name the same file on disk.
+///
+/// Two spellings of the same file (a symlinked home, a doubled separator, a
+/// `/./`) are not a split-brain — warning there would tell the user to unset a
+/// variable that is causing no harm. Only answerable when both resolve on disk;
+/// `canonicalize` fails on a path that does not exist, and `false` then lets the
+/// caller fall through to the textual comparison.
+fn same_resolved_file(a: &std::path::Path, b: &std::path::Path) -> bool {
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
 }
 
 /// The decision half of [`settings_contract`], split out so every branch is
@@ -131,7 +138,7 @@ fn dead_poll_env() -> Check {
 
 #[cfg(test)]
 mod tests {
-    use super::{expand, settings_verdict};
+    use super::{expand, same_resolved_file, settings_verdict};
     use std::path::Path;
 
     /// The canonical, correct configuration: the daemon resolves exactly the
@@ -172,6 +179,63 @@ mod tests {
             false,
         );
         assert_eq!(c.severity, crate::health::Severity::Info, "{c:?}");
+    }
+
+    /// Two spellings of the SAME file must not read as a split-brain.
+    ///
+    /// `settings_verdict` compares paths textually, so a symlinked home (common
+    /// on macOS with `/tmp` → `/private/tmp`, and on any setup that symlinks the
+    /// home directory) would warn falsely and tell the user to unset a variable
+    /// that is causing no harm. The wrapper canonicalizes when both paths exist;
+    /// this exercises that with a real symlink, which is the only way to reach it.
+    #[cfg(unix)]
+    #[test]
+    fn two_spellings_of_the_same_settings_file_are_not_a_split_brain() {
+        use crate::health::Severity;
+
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("settings.json");
+        std::fs::write(&real, "{}").unwrap();
+
+        let link_dir = dir.path().join("linked");
+        std::os::unix::fs::symlink(dir.path(), &link_dir).unwrap();
+        let via_link = link_dir.join("settings.json");
+
+        // Textually different, same inode.
+        assert_ne!(real, via_link);
+        assert_eq!(
+            real.canonicalize().unwrap(),
+            via_link.canonicalize().unwrap()
+        );
+
+        // The raw verdict cannot tell — that is exactly why the wrapper
+        // canonicalizes first.
+        assert_eq!(
+            settings_verdict(&real, &via_link, true).severity,
+            Severity::Warn,
+            "precondition: the textual comparison should disagree here"
+        );
+
+        // The canonicalizing path must agree.
+        assert!(
+            same_resolved_file(&real, &via_link),
+            "a symlinked spelling of the same file was treated as a split-brain"
+        );
+    }
+
+    /// ...and genuinely different files must still be distinguishable, so the
+    /// canonicalize step cannot be "simplified" into always-equal.
+    #[test]
+    fn genuinely_different_settings_files_are_not_collapsed() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.json");
+        let b = dir.path().join("b.json");
+        std::fs::write(&a, "{}").unwrap();
+        std::fs::write(&b, "{}").unwrap();
+        assert!(
+            !same_resolved_file(&a, &b),
+            "two distinct files were reported as the same"
+        );
     }
 
     #[test]

--- a/src/health/contracts.rs
+++ b/src/health/contracts.rs
@@ -2,11 +2,11 @@
 //
 // Cross-process config contracts: values multiple processes must agree on, where
 // a silent mismatch masquerades as an AI/runtime fault. Verified against the
-// code: the UI reads MERIDIAN_DB_PATH (not MERIDIAN_DB), and the daemon reads
-// <repo>/settings.json (not the UI's ~/.meridian/settings.json).
+// code: the UI reads MERIDIAN_DB_PATH (not MERIDIAN_DB), and the daemon and the
+// dashboard must resolve the same settings.json (canonically
+// ~/.meridian/settings.json, overridable via MERIDIAN_SETTINGS_PATH).
 
 use crate::config::Config;
-use crate::health::platform::repo_root;
 use crate::health::Check;
 use std::path::PathBuf;
 
@@ -44,23 +44,63 @@ fn db_path_contract(cfg: &Config) -> Check {
     }
 }
 
-/// C7 — the daemon reads `<repo>/settings.json`; the dashboard writes
-/// `~/.meridian/settings.json`. If only the latter exists, toggles in the UI
-/// never reach the daemon.
+/// C7 — the daemon and the dashboard must read the SAME `settings.json`, or
+/// toggles in the UI never take effect.
+///
+/// The old form of this check asserted the daemon reads `<repo>/settings.json`
+/// and warned whenever only `~/.meridian/settings.json` existed. That premise is
+/// **obsolete**, not mis-implemented: `settings_json_path()` resolves the
+/// canonical `~/.meridian/settings.json` FIRST (a repo/cwd copy is only a
+/// fallback when the canonical is absent), so the configuration it flagged as
+/// broken is the correct one. On every packaged install — where no repo exists
+/// at all — it fired permanently, and the summary escalated it to "UI settings
+/// aren't reaching the daemon" on machines where they demonstrably were.
+///
+/// The one real split-brain left is `MERIDIAN_SETTINGS_PATH` pointing somewhere
+/// other than the file the dashboard writes, so that is what this now checks.
 fn settings_contract() -> Check {
-    let daemon_exists = repo_root()
-        .map(|r| r.join("settings.json").is_file())
-        .unwrap_or(false);
     let ui_settings = home().join(".meridian/settings.json");
-    if ui_settings.is_file() && !daemon_exists {
+    let resolved = meridian_core::settings::settings_json_path();
+    let ui_exists = ui_settings.is_file();
+    settings_verdict(&resolved, &ui_settings, ui_exists)
+}
+
+/// The decision half of [`settings_contract`], split out so every branch is
+/// testable without touching `$HOME`, the real filesystem, or the
+/// process-global `MERIDIAN_SETTINGS_PATH`.
+fn settings_verdict(
+    resolved: &std::path::Path,
+    ui_settings: &std::path::Path,
+    ui_exists: bool,
+) -> Check {
+    if resolved == ui_settings {
+        return Check::ok("settings file", "config", "daemon + dashboard agree");
+    }
+    // Resolution order falls back to `<cwd>/settings.json` when the canonical
+    // file does not exist — and doctor's cwd is not the daemon's cwd, so the
+    // path resolved HERE is not necessarily the one the daemon resolved. Only
+    // claim disagreement when the dashboard's file actually exists (in which
+    // case the canonical rule would have selected it, so something is
+    // overriding); otherwise report what was resolved without asserting a fault.
+    if ui_exists {
         Check::warn(
             "settings file",
             "config",
-            "~/.meridian/settings.json is not read by the daemon",
+            format!(
+                "the daemon resolves {} instead of the dashboard's file",
+                resolved.display()
+            ),
         )
-        .with_remedy("the daemon reads <repo>/settings.json — align them")
+        .with_remedy("unset MERIDIAN_SETTINGS_PATH so both read ~/.meridian/settings.json")
     } else {
-        Check::ok("settings file", "config", "no split-brain")
+        Check::info(
+            "settings file",
+            "config",
+            format!(
+                "no settings.json yet — would resolve {}",
+                resolved.display()
+            ),
+        )
     }
 }
 
@@ -80,7 +120,48 @@ fn dead_poll_env() -> Check {
 
 #[cfg(test)]
 mod tests {
-    use super::expand;
+    use super::{expand, settings_verdict};
+    use std::path::Path;
+
+    /// The canonical, correct configuration: the daemon resolves exactly the
+    /// file the dashboard writes.
+    ///
+    /// This is the case the OLD check flagged as broken. It warned whenever
+    /// `~/.meridian/settings.json` existed without a `<repo>/settings.json`
+    /// beside it — which is every packaged install, and the summary escalated
+    /// it to "UI settings aren't reaching the daemon" on machines where the
+    /// settings were demonstrably being applied.
+    #[test]
+    fn agreeing_paths_are_ok() {
+        let p = Path::new("/home/u/.meridian/settings.json");
+        let c = settings_verdict(p, p, true);
+        assert_eq!(c.severity, crate::health::Severity::Ok, "{c:?}");
+    }
+
+    /// A real split-brain: something (MERIDIAN_SETTINGS_PATH) points the daemon
+    /// elsewhere while the dashboard's file exists, so UI toggles are ignored.
+    #[test]
+    fn an_override_that_shadows_the_dashboard_warns() {
+        let c = settings_verdict(
+            Path::new("/elsewhere/settings.json"),
+            Path::new("/home/u/.meridian/settings.json"),
+            true,
+        );
+        assert_eq!(c.severity, crate::health::Severity::Warn, "{c:?}");
+    }
+
+    /// Nothing written yet. `settings_json_path` falls back to
+    /// `<cwd>/settings.json`, and doctor's cwd is NOT the daemon's cwd, so the
+    /// two can legitimately differ here. Report, do not assert a fault.
+    #[test]
+    fn no_settings_file_yet_is_not_a_fault() {
+        let c = settings_verdict(
+            Path::new("/tmp/settings.json"),
+            Path::new("/home/u/.meridian/settings.json"),
+            false,
+        );
+        assert_eq!(c.severity, crate::health::Severity::Info, "{c:?}");
+    }
 
     #[test]
     fn expand_handles_tilde_and_absolute() {

--- a/src/health/contracts.rs
+++ b/src/health/contracts.rs
@@ -62,6 +62,17 @@ fn settings_contract() -> Check {
     let ui_settings = home().join(".meridian/settings.json");
     let resolved = meridian_core::settings::settings_json_path();
     let ui_exists = ui_settings.is_file();
+
+    // Two spellings of the same file (a symlinked home, a doubled separator, a
+    // `/./`) are not a split-brain — warning there would tell the user to unset
+    // a variable that is causing no harm. Only meaningful when both resolve on
+    // disk; `canonicalize` fails on a path that does not exist, in which case
+    // fall through to the textual comparison below.
+    if let (Ok(a), Ok(b)) = (resolved.canonicalize(), ui_settings.canonicalize()) {
+        if a == b {
+            return Check::ok("settings file", "config", "daemon + dashboard agree");
+        }
+    }
     settings_verdict(&resolved, &ui_settings, ui_exists)
 }
 

--- a/src/health/diagnose.rs
+++ b/src/health/diagnose.rs
@@ -7,6 +7,7 @@
 
 use crate::health::{Report, Severity};
 
+#[derive(Debug)]
 pub struct Diagnosis {
     /// The root cause, one line.
     pub title: String,
@@ -256,5 +257,57 @@ mod tests {
     fn healthy_report_has_no_diagnosis() {
         let report = Report::new(vec![Check::ok("x", "L1", "fine").in_group("system")]);
         assert!(root_causes(&report).is_empty());
+    }
+
+    /// An Info-severity `settings file` check must NOT raise the "UI settings
+    /// aren't reaching the daemon" diagnosis.
+    ///
+    /// This was half the damage on a healthy packaged machine: the check fired
+    /// permanently, and the summary escalated it into a fabricated root cause
+    /// telling the user their toggles had no effect — on machines where the
+    /// settings were demonstrably being applied.
+    ///
+    /// The coupling is `bad`'s `severity >= Severity::Warn` with `Info < Warn`,
+    /// which is exactly the kind of thing that gets "tidied" into `!= Ok` by
+    /// someone who does not know an Info branch depends on it.
+    #[test]
+    fn an_info_settings_check_raises_no_diagnosis() {
+        let report = Report::new(vec![Check::info(
+            "settings file",
+            "config",
+            "no settings.json yet — would resolve /tmp/settings.json",
+        )
+        .in_group("config")]);
+        assert!(
+            root_causes(&report).is_empty(),
+            "an Info check fabricated a root cause: {:?}",
+            root_causes(&report)
+        );
+    }
+
+    /// ...but a genuine split-brain still must. Pins that the fix above is a
+    /// severity change, not a deletion of the diagnosis.
+    #[test]
+    fn a_warning_settings_check_still_raises_the_diagnosis() {
+        let report = Report::new(vec![Check::warn(
+            "settings file",
+            "config",
+            "the daemon resolves /elsewhere/settings.json instead of the dashboard's file",
+        )
+        .in_group("config")]);
+        let dx = root_causes(&report);
+        assert_eq!(
+            dx.len(),
+            1,
+            "real split-brain must still be diagnosed: {dx:?}"
+        );
+        assert!(
+            dx[0].title.contains("UI settings"),
+            "unexpected diagnosis: {dx:?}"
+        );
+        assert!(
+            dx[0].cause.contains("MERIDIAN_SETTINGS_PATH"),
+            "the cause text still describes the obsolete <repo>/settings.json premise: {dx:?}"
+        );
     }
 }

--- a/src/health/diagnose.rs
+++ b/src/health/diagnose.rs
@@ -134,9 +134,9 @@ pub fn root_causes(report: &Report) -> Vec<Diagnosis> {
     if bad("config", "settings file") {
         out.push(Diagnosis {
             title: "UI settings aren't reaching the daemon".into(),
-            cause: "The dashboard writes ~/.meridian/settings.json but the daemon reads <repo>/settings.json, so toggles made in the UI have no effect.".into(),
+            cause: "MERIDIAN_SETTINGS_PATH points the daemon at a different file from the one the dashboard writes (~/.meridian/settings.json), so toggles made in the UI have no effect.".into(),
             contributing: contributing(&[("config", "settings file")]),
-            action: "Align the two files — `meridian doctor --fix` can link them.".into(),
+            action: "Unset MERIDIAN_SETTINGS_PATH so both read ~/.meridian/settings.json.".into(),
         });
     }
 

--- a/src/health/fix.rs
+++ b/src/health/fix.rs
@@ -94,7 +94,7 @@ pub fn fix_for(c: &Check) -> Option<FixAction> {
             manual("regenerate the Jira API token and update JIRA_API_TOKEN in .env")
         }
         ("config", name) if name.contains("settings") => {
-            manual("align <repo>/settings.json with ~/.meridian/settings.json")
+            manual("unset MERIDIAN_SETTINGS_PATH so the daemon reads ~/.meridian/settings.json")
         }
         _ => None,
     }

--- a/src/health/observability.rs
+++ b/src/health/observability.rs
@@ -10,50 +10,68 @@ use crate::config::Config;
 use crate::health::Check;
 use std::time::Duration;
 
-pub async fn checks(_cfg: &Config) -> Vec<Check> {
-    // `is_otlp_configured()` is false for two unrelated reasons, and reporting
-    // them with one message was actively misleading. On a packaged install it is
-    // false BY DESIGN — that path is scoped to the engineer's own OpenObserve,
-    // and a packaged install ships error-only redacted telemetry to the central
-    // gateway instead — so "telemetry not collected" was simply wrong there.
-    // Capture to the local spool is unconditional either way (the only kill
-    // switch is MERIDIAN_TELEMETRY_DISABLED), which is what `meridian logs` and
-    // Export Diagnostics read, so no install is ever truly dark.
-    if crate::observability::is_canonical_install() {
-        // Ask, do not assume. A fixed "errors ship to the central gateway"
-        // string would assert a good state nobody checked — the same fault as
-        // asserting a bad one, and harder to catch because nobody investigates
-        // a green line. Two real machines it would lie to: a user who opted OUT
-        // of error reporting (opt-out, default on, so this is a deliberate
-        // choice), and a locally-built binary staged into ~/.meridian/bin, which
-        // `is_canonical_install()` classifies as canonical but whose
-        // release-injected `option_env!` endpoint/token are unset, so it can
-        // never ship anything.
-        //
-        // `resolve_otlp_target()` already answers this and costs one
-        // settings.json read — the same file the `is_otlp_configured()` call
-        // below would have loaded anyway.
-        return vec![match crate::observability::resolve_otlp_target() {
-            Some(_) => Check::info(
+/// The non-probing half of [`checks`]: everything decidable without a network
+/// call. `Some(check)` short-circuits; `None` means "go probe the dev endpoint".
+///
+/// `is_otlp_configured()` is false for two unrelated reasons, and reporting them
+/// with one message was actively misleading. On a packaged install it is false
+/// BY DESIGN — that path is scoped to the engineer's own OpenObserve, and a
+/// packaged install ships error-only redacted telemetry to the central gateway
+/// instead — so "telemetry not collected" was simply wrong there. Capture to the
+/// local spool is unconditional either way (the only kill switch is
+/// `MERIDIAN_TELEMETRY_DISABLED`), which is what `meridian logs` and Export
+/// Diagnostics read, so no install is ever truly dark.
+///
+/// `central_target_resolves` must be ASKED, not assumed: a fixed "errors ship to
+/// the central gateway" string would assert a good state nobody checked — the
+/// same fault as asserting a bad one, and harder to catch because nobody
+/// investigates a green line. Two real machines it would lie to: a user who
+/// opted OUT of error reporting (opt-out, default on, so a deliberate choice),
+/// and a locally-built binary staged into `~/.meridian/bin`, which
+/// `is_canonical_install()` classifies as canonical but whose release-injected
+/// `option_env!` endpoint and token are unset, so it can never ship anything.
+fn offline_verdict(
+    canonical: bool,
+    central_target_resolves: bool,
+    dev_otlp_configured: bool,
+) -> Option<Check> {
+    if canonical {
+        return Some(if central_target_resolves {
+            Check::info(
                 "openobserve",
                 "obs",
                 "packaged install — captured locally; errors ship to the central gateway",
-            ),
-            None => Check::info(
+            )
+        } else {
+            Check::info(
                 "openobserve",
                 "obs",
                 "packaged install — captured locally; error reporting is off \
                  (or this build has no baked endpoint)",
-            ),
-        }];
+            )
+        });
     }
-    // Use the cheap helpers — the health check never needs the auth credential.
-    if !crate::observability::is_otlp_configured() {
-        return vec![Check::info(
+    if !dev_otlp_configured {
+        return Some(Check::info(
             "openobserve",
             "obs",
             "local OTLP export off (no credentials in Settings) — capture still runs; read it with `meridian logs`",
-        )];
+        ));
+    }
+    None
+}
+
+pub async fn checks(_cfg: &Config) -> Vec<Check> {
+    let canonical = crate::observability::is_canonical_install();
+    // `resolve_otlp_target()` costs one settings.json read — the same file the
+    // `is_otlp_configured()` call would load anyway. Only consulted on the
+    // canonical path, so a dev run pays nothing extra.
+    let central = canonical && crate::observability::resolve_otlp_target().is_some();
+    // Use the cheap helpers — the health check never needs the auth credential.
+    let dev_configured = !canonical && crate::observability::is_otlp_configured();
+
+    if let Some(check) = offline_verdict(canonical, central, dev_configured) {
+        return vec![check];
     }
     let endpoint = crate::observability::resolve_otlp_endpoint()
         .unwrap_or_else(|| "http://localhost:5080/api/default/v1/traces".to_string());
@@ -100,7 +118,68 @@ fn derive_healthz(endpoint: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::derive_healthz;
+    use super::{derive_healthz, offline_verdict};
+    use crate::health::Severity;
+
+    /// A packaged install must never CLAIM its errors are shipping without
+    /// having checked.
+    ///
+    /// The first version returned a fixed "errors ship to the central gateway"
+    /// string. That lies to two real machines: a user who deliberately opted out
+    /// of error reporting (opt-out, default on), and a locally-built binary
+    /// staged into `~/.meridian/bin` — classified canonical by
+    /// `is_canonical_install()`, but with `option_env!` endpoint/token unset, so
+    /// it can never ship anything. Asserting an unverified GOOD state erodes
+    /// trust exactly like asserting a bad one, and is harder to catch because
+    /// nobody investigates a green line.
+    #[test]
+    fn a_packaged_install_reports_shipping_only_when_a_target_resolves() {
+        let shipping = offline_verdict(true, true, false).expect("canonical short-circuits");
+        assert_eq!(shipping.severity, Severity::Info);
+        assert!(
+            shipping.detail.contains("central gateway"),
+            "a resolving target should say so: {shipping:?}"
+        );
+
+        let not_shipping = offline_verdict(true, false, false).expect("canonical short-circuits");
+        assert_eq!(not_shipping.severity, Severity::Info);
+        assert!(
+            !not_shipping.detail.contains("errors ship"),
+            "claims shipping with no resolved target — the exact unverified \
+             assertion this branch exists to avoid: {not_shipping:?}"
+        );
+        // Both cases must still make clear capture is unaffected: the spool is
+        // unconditional, and it is what `meridian logs` and Export Diagnostics read.
+        for c in [&shipping, &not_shipping] {
+            assert!(
+                c.detail.contains("captured locally"),
+                "must not imply telemetry is dark: {c:?}"
+            );
+        }
+    }
+
+    /// The dev/local path is a different question from the packaged one, and
+    /// conflating them is what produced "telemetry not collected" on installs
+    /// that were shipping fine.
+    #[test]
+    fn the_dev_path_is_reported_separately_and_never_claims_telemetry_is_dark() {
+        let c = offline_verdict(false, false, false).expect("unconfigured dev short-circuits");
+        assert_eq!(c.severity, Severity::Info);
+        assert!(
+            !c.detail.contains("not collected"),
+            "capture still runs — only the local export leg is off: {c:?}"
+        );
+        assert!(
+            c.detail.contains("meridian logs"),
+            "should point at how to read what IS captured: {c:?}"
+        );
+
+        // Dev WITH credentials must fall through to the live healthz probe.
+        assert!(
+            offline_verdict(false, false, true).is_none(),
+            "a configured dev install must still be probed, not short-circuited"
+        );
+    }
 
     #[test]
     fn healthz_derived_from_otlp_endpoint() {

--- a/src/health/observability.rs
+++ b/src/health/observability.rs
@@ -20,11 +20,32 @@ pub async fn checks(_cfg: &Config) -> Vec<Check> {
     // switch is MERIDIAN_TELEMETRY_DISABLED), which is what `meridian logs` and
     // Export Diagnostics read, so no install is ever truly dark.
     if crate::observability::is_canonical_install() {
-        return vec![Check::info(
-            "openobserve",
-            "obs",
-            "packaged install — telemetry captured locally; errors ship to the central gateway",
-        )];
+        // Ask, do not assume. A fixed "errors ship to the central gateway"
+        // string would assert a good state nobody checked — the same fault as
+        // asserting a bad one, and harder to catch because nobody investigates
+        // a green line. Two real machines it would lie to: a user who opted OUT
+        // of error reporting (opt-out, default on, so this is a deliberate
+        // choice), and a locally-built binary staged into ~/.meridian/bin, which
+        // `is_canonical_install()` classifies as canonical but whose
+        // release-injected `option_env!` endpoint/token are unset, so it can
+        // never ship anything.
+        //
+        // `resolve_otlp_target()` already answers this and costs one
+        // settings.json read — the same file the `is_otlp_configured()` call
+        // below would have loaded anyway.
+        return vec![match crate::observability::resolve_otlp_target() {
+            Some(_) => Check::info(
+                "openobserve",
+                "obs",
+                "packaged install — captured locally; errors ship to the central gateway",
+            ),
+            None => Check::info(
+                "openobserve",
+                "obs",
+                "packaged install — captured locally; error reporting is off \
+                 (or this build has no baked endpoint)",
+            ),
+        }];
     }
     // Use the cheap helpers — the health check never needs the auth credential.
     if !crate::observability::is_otlp_configured() {

--- a/src/health/observability.rs
+++ b/src/health/observability.rs
@@ -11,12 +11,27 @@ use crate::health::Check;
 use std::time::Duration;
 
 pub async fn checks(_cfg: &Config) -> Vec<Check> {
+    // `is_otlp_configured()` is false for two unrelated reasons, and reporting
+    // them with one message was actively misleading. On a packaged install it is
+    // false BY DESIGN — that path is scoped to the engineer's own OpenObserve,
+    // and a packaged install ships error-only redacted telemetry to the central
+    // gateway instead — so "telemetry not collected" was simply wrong there.
+    // Capture to the local spool is unconditional either way (the only kill
+    // switch is MERIDIAN_TELEMETRY_DISABLED), which is what `meridian logs` and
+    // Export Diagnostics read, so no install is ever truly dark.
+    if crate::observability::is_canonical_install() {
+        return vec![Check::info(
+            "openobserve",
+            "obs",
+            "packaged install — telemetry captured locally; errors ship to the central gateway",
+        )];
+    }
     // Use the cheap helpers — the health check never needs the auth credential.
     if !crate::observability::is_otlp_configured() {
         return vec![Check::info(
             "openobserve",
             "obs",
-            "OTLP export disabled (no credentials in Settings) — telemetry not collected",
+            "local OTLP export off (no credentials in Settings) — capture still runs; read it with `meridian logs`",
         )];
     }
     let endpoint = crate::observability::resolve_otlp_endpoint()

--- a/src/health/platform.rs
+++ b/src/health/platform.rs
@@ -211,32 +211,66 @@ pub fn ui_service() -> Vec<Check> {
 }
 
 pub fn mcp_service() -> Vec<Check> {
-    // The MCP server is built from the repo, so this question only has an answer
-    // in a source checkout. On a packaged install `repo_root()` is None and the
-    // old code folded that into `false` — reporting "not built" with a remedy
-    // (`cd packages/meridian-mcp && ...`) naming a directory the user does not
-    // have. A check that asserts a problem it has not looked for trains people
-    // to ignore the whole report, so say so instead.
-    let Some(repo) = repo_root() else {
-        // Report what was OBSERVED, not an inferred install type. What we
-        // actually know is "no Cargo.toml above current_exe()" — also true of a
-        // `cargo install`ed binary, a release binary copied into ~/bin, or an
-        // .app-embedded one. Claiming "packaged install" here would be the same
-        // conflation this module deliberately avoids for `daemon binary`.
-        return vec![Check::info(
+    let repo = repo_root();
+    let built = repo
+        .as_ref()
+        .map(|r| r.join("packages/meridian-mcp/dist/index.js").is_file());
+    vec![mcp_verdict(built)]
+}
+
+/// The decision half of [`mcp_service`], split out so every branch is testable
+/// without a real filesystem. `None` = no source checkout found at all.
+///
+/// The MCP server is built from the repo, so this question only has an answer in
+/// a source checkout. `repo_root()` is None on a packaged install and the old
+/// code folded that into `false` — reporting "not built" with a remedy
+/// (`cd packages/meridian-mcp && …`) naming a directory the user does not have.
+/// A check that asserts a problem it has not looked for trains people to ignore
+/// the whole report.
+///
+/// The Info wording reports what was OBSERVED, not an inferred install type:
+/// "no Cargo.toml above `current_exe()`" is also true of a `cargo install`ed
+/// binary, a release binary copied into `~/bin`, or an `.app`-embedded one.
+/// Claiming "packaged install" would be the same conflation this module
+/// deliberately avoids for `daemon binary`.
+/// The four-way `.env` truth table, split out so each case is testable without
+/// a real `$HOME` or repo.
+///
+/// BOTH locations count, because `main.rs` loads both: step 1 walks up from the
+/// working directory (a source run finds `<repo>/.env`), and step 1a then
+/// unconditionally loads `~/.meridian/.env` — the canonical file the tray writes
+/// the DB key and tracker credentials into. Checking only the repo copy reported
+/// "missing" on every packaged install, where no repo exists and the canonical
+/// file is the one actually in use.
+///
+/// When both exist, BOTH are named: step 1a's `from_path` does not override, so
+/// for any overlapping key the repo file is the one that wins — reporting only
+/// the canonical path would send a dev chasing a stale value to the wrong file.
+fn env_verdict(repo_env: bool, home_env: bool) -> Check {
+    match (repo_env, home_env) {
+        (true, true) => Check::ok(
+            "config (.env)",
+            "system",
+            "<repo>/.env and ~/.meridian/.env present (repo wins for overlapping keys)",
+        ),
+        (false, true) => Check::ok("config (.env)", "system", "~/.meridian/.env present"),
+        (true, false) => Check::ok("config (.env)", "system", "<repo>/.env present"),
+        (false, false) => Check::warn("config (.env)", "system", "missing")
+            .with_remedy("install the app, or run ./install.sh from a source checkout"),
+    }
+}
+
+fn mcp_verdict(built: Option<bool>) -> Check {
+    match built {
+        None => Check::info(
             "mcp built",
             "system",
             "no source checkout found — the MCP server is built from one",
-        )];
-    };
-    vec![
-        if repo.join("packages/meridian-mcp/dist/index.js").is_file() {
-            Check::ok("mcp built", "system", "dist/index.js present")
-        } else {
-            Check::warn("mcp built", "system", "not built")
-                .with_remedy("cd packages/meridian-mcp && npm run build")
-        },
-    ]
+        ),
+        Some(true) => Check::ok("mcp built", "system", "dist/index.js present"),
+        Some(false) => Check::warn("mcp built", "system", "not built")
+            .with_remedy("cd packages/meridian-mcp && npm run build"),
+    }
 }
 
 // ── system / toolchain ──────────────────────────────────────────────────────
@@ -257,29 +291,9 @@ pub fn system_checks(_cfg: &Config) -> Vec<Check> {
     } else {
         Check::warn("os", "system", "unsupported OS — capture is not available")
     };
-    // BOTH locations count, because `main.rs` loads both: step 1 walks up from
-    // the working directory (a source run finds `<repo>/.env`), and step 1a then
-    // unconditionally loads `~/.meridian/.env` — the canonical file the tray
-    // writes the DB key and tracker credentials into. Checking only the repo
-    // copy reported "missing" on every packaged install, where no repo exists
-    // and the canonical file is the one actually in use.
     let repo_env = repo_root().is_some_and(|r| r.join(".env").is_file());
     let home_env = home().join(".meridian/.env").is_file();
-    let env_check = match (repo_env, home_env) {
-        // Name BOTH when both exist. Step 1 loads the repo copy and step 1a's
-        // `from_path` does NOT override, so for any overlapping key the repo
-        // file is the one that wins — reporting only the canonical path would
-        // send a dev chasing a stale value to the wrong file.
-        (true, true) => Check::ok(
-            "config (.env)",
-            "system",
-            "<repo>/.env and ~/.meridian/.env present (repo wins for overlapping keys)",
-        ),
-        (false, true) => Check::ok("config (.env)", "system", "~/.meridian/.env present"),
-        (true, false) => Check::ok("config (.env)", "system", "<repo>/.env present"),
-        (false, false) => Check::warn("config (.env)", "system", "missing")
-            .with_remedy("install the app, or run ./install.sh from a source checkout"),
-    };
+    let env_check = env_verdict(repo_env, home_env);
     vec![
         os,
         env_check,
@@ -361,6 +375,91 @@ mod tests {
     #[test]
     fn which_returns_none_for_a_binary_that_does_not_exist() {
         assert!(which("meridian-definitely-not-a-real-binary-xyz").is_none());
+    }
+
+    /// The `.env` truth table, all four cases.
+    ///
+    /// The bug: only `<repo>/.env` was checked, so every packaged install — where
+    /// no repo exists and `~/.meridian/.env` is the file actually in use —
+    /// reported "missing". `main.rs` loads BOTH (step 1 walks up from cwd, step
+    /// 1a loads the canonical path unconditionally), so either one satisfies it.
+    #[test]
+    fn env_verdict_covers_every_combination() {
+        use crate::health::Severity;
+
+        // Packaged install: no repo, canonical file present. The regression.
+        let c = env_verdict(false, true);
+        assert_eq!(c.severity, Severity::Ok, "{c:?}");
+        assert!(c.detail.contains("~/.meridian/.env"), "{c:?}");
+
+        // Source checkout with only a repo .env.
+        let c = env_verdict(true, false);
+        assert_eq!(c.severity, Severity::Ok, "{c:?}");
+        assert!(c.detail.contains("<repo>/.env"), "{c:?}");
+
+        // Both present: BOTH must be named, and the precedence stated. Step 1a's
+        // `from_path` does not override, so the repo copy wins for overlapping
+        // keys — naming only the canonical one sends a dev to the wrong file.
+        let c = env_verdict(true, true);
+        assert_eq!(c.severity, Severity::Ok, "{c:?}");
+        assert!(
+            c.detail.contains("<repo>/.env"),
+            "both files must be named: {c:?}"
+        );
+        assert!(
+            c.detail.contains("~/.meridian/.env"),
+            "both files must be named: {c:?}"
+        );
+        assert!(
+            c.detail.contains("repo wins"),
+            "precedence must be stated or a stale key is chased in the wrong file: {c:?}"
+        );
+
+        // Genuinely absent — the only case that should warn.
+        let c = env_verdict(false, false);
+        assert_eq!(c.severity, Severity::Warn, "{c:?}");
+        assert!(
+            c.remedy.is_some(),
+            "a warn without a remedy is not actionable: {c:?}"
+        );
+    }
+
+    /// `mcp built` must not assert a problem it has not looked for.
+    ///
+    /// `repo_root() == None` used to fold into `false`, producing a warn whose
+    /// remedy (`cd packages/meridian-mcp && …`) names a directory a packaged
+    /// user does not have. Info, and worded as what was OBSERVED — "no source
+    /// checkout" is also true of a `cargo install`ed or copied binary, so
+    /// claiming "packaged install" would be the conflation this module rejects
+    /// for `daemon binary`.
+    #[test]
+    fn mcp_verdict_is_info_without_a_checkout_and_never_claims_an_install_type() {
+        use crate::health::Severity;
+
+        let c = mcp_verdict(None);
+        assert_eq!(
+            c.severity,
+            Severity::Info,
+            "no checkout must not be a fault: {c:?}"
+        );
+        assert!(
+            c.remedy.is_none(),
+            "an unanswerable check must not hand out a remedy: {c:?}"
+        );
+        assert!(
+            !c.detail.contains("packaged"),
+            "reports an inferred install type rather than what was observed: {c:?}"
+        );
+
+        assert_eq!(mcp_verdict(Some(true)).severity, Severity::Ok);
+
+        let c = mcp_verdict(Some(false));
+        assert_eq!(
+            c.severity,
+            Severity::Warn,
+            "a real checkout without a build should warn"
+        );
+        assert!(c.remedy.is_some(), "{c:?}");
     }
 
     /// Regression guard: the candidate list probed ONLY the two `install.sh`

--- a/src/health/platform.rs
+++ b/src/health/platform.rs
@@ -155,14 +155,20 @@ fn service_manifest_check(label: &str, name: &'static str) -> Check {
 /// installed on this system". `cargo run -- doctor` on a machine that also has
 /// the DMG installed must still find the staged binary — which is the one
 /// launchd is actually running.
+///
+/// The staged path comes from [`crate::observability::staged_daemon_path`], the
+/// single source shared with `is_canonical_install()`. Assembling it here
+/// independently (as this first did, from a different root — `home()` rather
+/// than `paths::meridian_dir()`) is how the two silently disagree, and a
+/// disagreement means a false CRITICAL.
 fn daemon_binary_candidates() -> Vec<PathBuf> {
-    vec![
-        home()
-            .join(".meridian/bin")
-            .join(format!("meridian{}", std::env::consts::EXE_SUFFIX)),
-        PathBuf::from("/usr/local/bin/meridian-daemon"),
-        home().join(".local/bin/meridian-daemon"),
-    ]
+    crate::observability::staged_daemon_path()
+        .into_iter()
+        .chain([
+            PathBuf::from("/usr/local/bin/meridian-daemon"),
+            home().join(".local/bin/meridian-daemon"),
+        ])
+        .collect()
 }
 
 pub fn daemon_service() -> Vec<Check> {
@@ -212,10 +218,15 @@ pub fn mcp_service() -> Vec<Check> {
     // have. A check that asserts a problem it has not looked for trains people
     // to ignore the whole report, so say so instead.
     let Some(repo) = repo_root() else {
+        // Report what was OBSERVED, not an inferred install type. What we
+        // actually know is "no Cargo.toml above current_exe()" — also true of a
+        // `cargo install`ed binary, a release binary copied into ~/bin, or an
+        // .app-embedded one. Claiming "packaged install" here would be the same
+        // conflation this module deliberately avoids for `daemon binary`.
         return vec![Check::info(
             "mcp built",
             "system",
-            "not applicable on a packaged install (built from a source checkout)",
+            "no source checkout found — the MCP server is built from one",
         )];
     };
     vec![
@@ -252,12 +263,21 @@ pub fn system_checks(_cfg: &Config) -> Vec<Check> {
     // writes the DB key and tracker credentials into. Checking only the repo
     // copy reported "missing" on every packaged install, where no repo exists
     // and the canonical file is the one actually in use.
-    let repo_env = repo_root().map(|r| r.join(".env").is_file());
+    let repo_env = repo_root().is_some_and(|r| r.join(".env").is_file());
     let home_env = home().join(".meridian/.env").is_file();
     let env_check = match (repo_env, home_env) {
-        (_, true) => Check::ok("config (.env)", "system", "~/.meridian/.env present"),
-        (Some(true), false) => Check::ok("config (.env)", "system", "<repo>/.env present"),
-        _ => Check::warn("config (.env)", "system", "missing")
+        // Name BOTH when both exist. Step 1 loads the repo copy and step 1a's
+        // `from_path` does NOT override, so for any overlapping key the repo
+        // file is the one that wins — reporting only the canonical path would
+        // send a dev chasing a stale value to the wrong file.
+        (true, true) => Check::ok(
+            "config (.env)",
+            "system",
+            "<repo>/.env and ~/.meridian/.env present (repo wins for overlapping keys)",
+        ),
+        (false, true) => Check::ok("config (.env)", "system", "~/.meridian/.env present"),
+        (true, false) => Check::ok("config (.env)", "system", "<repo>/.env present"),
+        (false, false) => Check::warn("config (.env)", "system", "missing")
             .with_remedy("install the app, or run ./install.sh from a source checkout"),
     };
     vec![
@@ -353,15 +373,24 @@ mod tests {
     fn daemon_binary_candidates_cover_both_install_types() {
         let candidates = daemon_binary_candidates();
 
-        // The DMG/tray staged path — must track `backend_install::DAEMON_FILE`,
-        // hence the platform executable suffix rather than a bare "meridian".
-        let staged = home()
-            .join(".meridian/bin")
-            .join(format!("meridian{}", std::env::consts::EXE_SUFFIX));
+        // Assert against the SHARED source, not a recomputed copy of the same
+        // expression: the first version of this test rebuilt the path from
+        // `home()` + `format!("meridian{EXE_SUFFIX}")`, so if production drifted
+        // the test drifted with it and stayed green. Whether that shared value
+        // still matches the tray's `DAEMON_FILE` is pinned separately, by
+        // `observability::install_mode`'s cross-crate source scan.
+        let staged =
+            crate::observability::staged_daemon_path().expect("home dir resolves under test");
         assert!(
             candidates.contains(&staged),
             "packaged install path {} missing from {candidates:?}",
             staged.display()
+        );
+        assert_eq!(
+            candidates.first(),
+            Some(&staged),
+            "the staged binary must be probed FIRST — it is the one launchd runs \
+             on a machine that also has source-install symlinks lying around"
         );
 
         // The source-install symlinks `install.sh` creates must survive.

--- a/src/health/platform.rs
+++ b/src/health/platform.rs
@@ -140,17 +140,37 @@ fn service_manifest_check(label: &str, name: &'static str) -> Check {
 
 // ── per-daemon service checks ───────────────────────────────────────────────
 
-pub fn daemon_service() -> Vec<Check> {
-    let bin = [
+/// Every location a daemon binary is installed to, across install types.
+///
+/// `install.sh` symlinks `meridian-daemon` into `/usr/local/bin` or
+/// `~/.local/bin` (source installs). The DMG's tray stages the real binary at
+/// `~/.meridian/bin/meridian{EXE_SUFFIX}` — see `backend_install::DAEMON_FILE`
+/// in the tray crate, and `observability::install_mode` which derives the same
+/// path. Probing only the first pair reported a CRITICAL "not installed" on
+/// every packaged install, while that very binary was the one answering the
+/// check.
+///
+/// Deliberately probes ALL candidates rather than branching on install mode:
+/// "is THIS PROCESS packaged" is a different question from "is a daemon
+/// installed on this system". `cargo run -- doctor` on a machine that also has
+/// the DMG installed must still find the staged binary — which is the one
+/// launchd is actually running.
+fn daemon_binary_candidates() -> Vec<PathBuf> {
+    vec![
+        home()
+            .join(".meridian/bin")
+            .join(format!("meridian{}", std::env::consts::EXE_SUFFIX)),
         PathBuf::from("/usr/local/bin/meridian-daemon"),
         home().join(".local/bin/meridian-daemon"),
     ]
-    .into_iter()
-    .find(|p| is_exec(p));
+}
+
+pub fn daemon_service() -> Vec<Check> {
+    let bin = daemon_binary_candidates().into_iter().find(|p| is_exec(p));
     let bin_check = match bin {
         Some(p) => Check::ok("daemon binary", "system", p.display().to_string()),
         None => Check::critical("daemon binary", "system", "not installed")
-            .with_remedy("run ./install.sh"),
+            .with_remedy("install the app, or run ./install.sh from a source checkout"),
     };
     use crate::platform::ServiceStatus;
     let run_check = match crate::platform::service_status(LABEL_DAEMON) {
@@ -185,15 +205,27 @@ pub fn ui_service() -> Vec<Check> {
 }
 
 pub fn mcp_service() -> Vec<Check> {
-    let built = repo_root()
-        .map(|r| r.join("packages/meridian-mcp/dist/index.js").is_file())
-        .unwrap_or(false);
-    vec![if built {
-        Check::ok("mcp built", "system", "dist/index.js present")
-    } else {
-        Check::warn("mcp built", "system", "not built")
-            .with_remedy("cd packages/meridian-mcp && npm run build")
-    }]
+    // The MCP server is built from the repo, so this question only has an answer
+    // in a source checkout. On a packaged install `repo_root()` is None and the
+    // old code folded that into `false` — reporting "not built" with a remedy
+    // (`cd packages/meridian-mcp && ...`) naming a directory the user does not
+    // have. A check that asserts a problem it has not looked for trains people
+    // to ignore the whole report, so say so instead.
+    let Some(repo) = repo_root() else {
+        return vec![Check::info(
+            "mcp built",
+            "system",
+            "not applicable on a packaged install (built from a source checkout)",
+        )];
+    };
+    vec![
+        if repo.join("packages/meridian-mcp/dist/index.js").is_file() {
+            Check::ok("mcp built", "system", "dist/index.js present")
+        } else {
+            Check::warn("mcp built", "system", "not built")
+                .with_remedy("cd packages/meridian-mcp && npm run build")
+        },
+    ]
 }
 
 // ── system / toolchain ──────────────────────────────────────────────────────
@@ -214,13 +246,19 @@ pub fn system_checks(_cfg: &Config) -> Vec<Check> {
     } else {
         Check::warn("os", "system", "unsupported OS — capture is not available")
     };
-    let env_ok = repo_root()
-        .map(|r| r.join(".env").is_file())
-        .unwrap_or(false);
-    let env_check = if env_ok {
-        Check::ok("config (.env)", "system", "present")
-    } else {
-        Check::warn("config (.env)", "system", "missing").with_remedy("run ./install.sh")
+    // BOTH locations count, because `main.rs` loads both: step 1 walks up from
+    // the working directory (a source run finds `<repo>/.env`), and step 1a then
+    // unconditionally loads `~/.meridian/.env` — the canonical file the tray
+    // writes the DB key and tracker credentials into. Checking only the repo
+    // copy reported "missing" on every packaged install, where no repo exists
+    // and the canonical file is the one actually in use.
+    let repo_env = repo_root().map(|r| r.join(".env").is_file());
+    let home_env = home().join(".meridian/.env").is_file();
+    let env_check = match (repo_env, home_env) {
+        (_, true) => Check::ok("config (.env)", "system", "~/.meridian/.env present"),
+        (Some(true), false) => Check::ok("config (.env)", "system", "<repo>/.env present"),
+        _ => Check::warn("config (.env)", "system", "missing")
+            .with_remedy("install the app, or run ./install.sh from a source checkout"),
     };
     vec![
         os,
@@ -303,6 +341,38 @@ mod tests {
     #[test]
     fn which_returns_none_for_a_binary_that_does_not_exist() {
         assert!(which("meridian-definitely-not-a-real-binary-xyz").is_none());
+    }
+
+    /// Regression guard: the candidate list probed ONLY the two `install.sh`
+    /// symlink paths, so on every packaged install doctor reported a CRITICAL
+    /// "daemon binary — not installed" while the staged binary at
+    /// `~/.meridian/bin/meridian` was the very process answering the check.
+    /// A false CRITICAL on a healthy machine is worse than no check: it trains
+    /// users to ignore the report, and the two real faults sit in the same output.
+    #[test]
+    fn daemon_binary_candidates_cover_both_install_types() {
+        let candidates = daemon_binary_candidates();
+
+        // The DMG/tray staged path — must track `backend_install::DAEMON_FILE`,
+        // hence the platform executable suffix rather than a bare "meridian".
+        let staged = home()
+            .join(".meridian/bin")
+            .join(format!("meridian{}", std::env::consts::EXE_SUFFIX));
+        assert!(
+            candidates.contains(&staged),
+            "packaged install path {} missing from {candidates:?}",
+            staged.display()
+        );
+
+        // The source-install symlinks `install.sh` creates must survive.
+        assert!(
+            candidates.contains(&PathBuf::from("/usr/local/bin/meridian-daemon")),
+            "source-install path missing from {candidates:?}"
+        );
+        assert!(
+            candidates.contains(&home().join(".local/bin/meridian-daemon")),
+            "per-user source-install path missing from {candidates:?}"
+        );
     }
 
     /// Regression guard for the bug where `which` probed only the bare name:

--- a/src/observability/install_mode.rs
+++ b/src/observability/install_mode.rs
@@ -39,7 +39,7 @@
 /// uses (independently — the daemon has no dependency on the tray crate).
 /// Falls back to the old marker-file check only if `current_exe()` itself
 /// fails (should not happen in practice).
-pub(super) fn is_canonical_install() -> bool {
+pub fn is_canonical_install() -> bool {
     let Some(meridian_dir) = meridian_core::paths::meridian_dir() else {
         return false;
     };

--- a/src/observability/install_mode.rs
+++ b/src/observability/install_mode.rs
@@ -44,11 +44,27 @@ pub fn is_canonical_install() -> bool {
         return false;
     };
     match std::env::current_exe() {
-        Ok(exe) => exe == meridian_dir.join("bin").join(staged_daemon_file_name()),
+        Ok(exe) => Some(exe) == staged_daemon_path(),
         // `current_exe()` failing is rare (permissions, exotic sandboxing) —
         // fall back to the machine-wide marker file rather than guessing.
         Err(_) => meridian_dir.join(".env").exists(),
     }
+}
+
+/// Absolute path the tray stages the daemon binary at
+/// (`~/.meridian/bin/meridian{EXE_SUFFIX}`).
+///
+/// The single source of this path. [`is_canonical_install`] compares
+/// `current_exe()` against it, and `health::platform::daemon_binary_candidates`
+/// probes it — those two MUST agree, and before this existed they were assembled
+/// independently, from different roots (`paths::meridian_dir()` vs
+/// `paths::home_dir_or_cwd()`). Drift between them means either a false CRITICAL
+/// in doctor or silently-inert error reporting, which is exactly the failure
+/// [`staged_daemon_file_name`] already documents having shipped once.
+///
+/// `None` only when the home directory cannot be resolved.
+pub fn staged_daemon_path() -> Option<std::path::PathBuf> {
+    meridian_core::paths::meridian_dir().map(|d| d.join("bin").join(staged_daemon_file_name()))
 }
 
 /// File name the tray stages the daemon under in `~/.meridian/bin/`.
@@ -79,11 +95,56 @@ pub(super) fn capture_disabled() -> bool {
 mod tests {
     use super::*;
 
-    /// The daemon and the tray agree on the staged file name only by
-    /// convention — they are separate crates with no shared constant, and a
-    /// mismatch disables central error reporting on that platform silently
-    /// (nothing errors; the shipper simply resolves no target). Pins the name
-    /// to the platform's executable suffix on whichever OS the suite runs.
+    /// The real cross-crate pin.
+    ///
+    /// `staged_daemon_file_name` is a hand-maintained mirror of the tray's
+    /// `backend_install::DAEMON_FILE`, and the daemon crate cannot depend on the
+    /// tray crate to compare them. Every test that recomputes the name from
+    /// `EXE_SUFFIX` therefore drifts along with the production copy and stays
+    /// green — which is worthless against the one failure this mirror has
+    /// already suffered (hardcoded `"meridian"`, so Windows packaged installs
+    /// silently shipped no telemetry at all).
+    ///
+    /// So read the tray's source and assert on the constant itself. Source
+    /// scanning is the repo's sanctioned tactic where a unit test cannot reach
+    /// (the tray cfg audit, the UI's `no-native-dialogs` test).
+    #[test]
+    fn staged_daemon_file_name_matches_the_trays_daemon_file_constant() {
+        const TRAY_SRC: &str = include_str!("../../tray/src-tauri/src/backend_install.rs");
+
+        // Both cfg arms, so this fails on whichever platform the suite runs.
+        let declared: Vec<&str> = TRAY_SRC
+            .lines()
+            .filter_map(|l| {
+                l.trim()
+                    .strip_prefix("pub(crate) const DAEMON_FILE: &str = ")
+            })
+            .map(|v| v.trim().trim_end_matches(';').trim_matches('"'))
+            .collect();
+
+        assert_eq!(
+            declared.len(),
+            2,
+            "expected both cfg arms of DAEMON_FILE in the tray source; found {declared:?} \
+             — if the tray changed shape, update this scan rather than deleting it"
+        );
+        assert!(
+            declared.contains(&"meridian") && declared.contains(&"meridian.exe"),
+            "the tray's DAEMON_FILE values changed to {declared:?}; \
+             staged_daemon_file_name() must be updated to match"
+        );
+        assert!(
+            declared.contains(&staged_daemon_file_name().as_str()),
+            "staged_daemon_file_name() produced {:?}, which is not one of the tray's \
+             DAEMON_FILE values {declared:?} — central error reporting and doctor's \
+             daemon-binary probe both break silently when these drift",
+            staged_daemon_file_name()
+        );
+    }
+
+    /// Complements the cross-crate pin above: that one proves the name matches
+    /// one of the tray's two constants, this one proves it is the RIGHT one for
+    /// the platform the suite is running on.
     #[test]
     fn staged_daemon_file_name_carries_the_platform_exe_suffix() {
         let name = staged_daemon_file_name();

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -80,7 +80,7 @@ mod otlp_target;
 pub use filter::reload_log_level;
 use filter::{build_default_filter, FILTER_HANDLE};
 use install_mode::capture_disabled;
-pub use install_mode::is_canonical_install;
+pub use install_mode::{is_canonical_install, staged_daemon_path};
 use otlp_target::DEFAULT_OTLP_ENDPOINT;
 pub use otlp_target::{
     is_otlp_configured, resolve_otlp_endpoint, resolve_otlp_target, AuthCredential, OtlpTarget,

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -80,6 +80,7 @@ mod otlp_target;
 pub use filter::reload_log_level;
 use filter::{build_default_filter, FILTER_HANDLE};
 use install_mode::capture_disabled;
+pub use install_mode::is_canonical_install;
 use otlp_target::DEFAULT_OTLP_ENDPOINT;
 pub use otlp_target::{
     is_otlp_configured, resolve_otlp_endpoint, resolve_otlp_target, AuthCredential, OtlpTarget,


### PR DESCRIPTION
## What

`health::platform::repo_root()` walks up from `current_exe()` looking for a `Cargo.toml`.
On a DMG install the binary is `~/.meridian/bin/meridian` with no repo above it, so it is
permanently `None` - and **five checks folded that into "broken"**.

Measured on a healthy 1.84.0-staging.2 machine, `meridian doctor` printed
**`✗ critical issues`** plus a **fabricated root-cause diagnosis**. That is worse than no
check: a permanent false CRITICAL trains users to ignore the report, and the two genuine
faults on that machine sit in the same output.

One root cause, five symptoms - hence one PR.

## The five

| Check | Was | Now |
|---|---|---|
| **daemon binary** | `CRITICAL not installed` - probed only the two `install.sh` symlinks (`meridian-daemon`), never the tray's staged `~/.meridian/bin/meridian` | probes all three |
| **config (.env)** | checked only `<repo>/.env` | either that **or** the canonical `~/.meridian/.env`, mirroring what `main.rs` actually loads (step 1 walk + step 1a unconditional) |
| **settings file** | warned that `~/.meridian/settings.json` "is not read by the daemon" | checks for a real `MERIDIAN_SETTINGS_PATH` split-brain |
| **mcp built** | `not built`, remedy naming a directory the user does not have | `Info: not applicable` when there is no repo |
| **openobserve** | `export disabled - telemetry not collected` | distinguishes packaged (ships to the central gateway) from dev-without-credentials |

### On `settings file` - the premise was obsolete, not mis-implemented

`settings_json_path()` resolves the canonical `~/.meridian/settings.json` **first**; a
repo/cwd copy is only a fallback when the canonical is absent. So the layout the check
flagged as broken **is the correct one**, and the summary escalated it to *"UI settings
aren't reaching the daemon"* on machines where they demonstrably were. (Doctor even
contradicted itself, printing `✓ poll interval - from settings.json` two lines below.)

The one real split-brain left is `MERIDIAN_SETTINGS_PATH` shadowing the dashboard's file,
so that is what it now checks - with `diagnose.rs` and the `--fix` hint updated to match.

### Why `daemon binary` is not gated on install mode

"Is THIS PROCESS packaged" (`is_canonical_install`) is a different question from "is a
daemon installed on this system". `cargo run -- doctor` on a machine that also has the DMG
installed must still find the staged binary - which is the one launchd is actually running.
Probing all candidates is correct in both directions.

`openobserve` is the only site that genuinely needs install mode, which is why
`install_mode::is_canonical_install` widens from `pub(super)` to `pub`.

## Verification

Run against the **live packaged install**, both with and without a repo above the binary
(confirmed safe first: the only DB open in `health/` is
`db_crypto::open_pool_with_key_readonly`, so doctor cannot migrate the DB it inspects):

```
before:  ✓ 30 ok  · 5 info  ⊘ 6 warn  ✗ 2 fail   + 2 diagnoses (one fabricated)
after:   ✓ 34 ok  · 5 info  ⊘ 3 warn  ✗ 1 fail   + 1 diagnosis
```

The remaining fail is a genuine, unrelated `capture_coverage` finding.

## Tests

- `daemon_binary_candidates_cover_both_install_types` - pins all three paths, including the
  platform executable suffix (the staged name must track `backend_install::DAEMON_FILE`).
- The settings decision is split into a pure `settings_verdict`, so all three branches are
  covered without touching `$HOME` or the process-global `MERIDIAN_SETTINGS_PATH`.

`cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace`
(1520 passed, 0 failed) all green.

## Out of scope

The `meridian logs` duplicate-line question and the `worklog-status --day` reporting
discrepancy came out of the same investigation but are separate findings, not part of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TCFYB8yahQ2D6Lt7LvCzU