### PR TITLE
fix(tray): address the CodeRabbit review on #698

### DIFF
--- a/src/db/repair/mod.rs
+++ b/src/db/repair/mod.rs
@@ -226,10 +226,20 @@ fn stop_daemon_hint() -> &'static str {
         "quit Meridian from the tray menu, which now stops the daemon too, \
          or run: launchctl bootout gui/$(id -u)/com.meridiona.daemon"
     }
+    // Both Windows launchers are named, because the machines most likely to
+    // read this message are the ones running the fallback. `register_service`
+    // drops a Startup-folder `MeridianDaemon.vbs` whenever `schtasks /Create`
+    // is blocked - the locked-down profiles and antivirus-quarantined installs
+    // where things go wrong in the first place - and on those there is no
+    // scheduled task to end, so the one instruction given would be another
+    // dead end. The tray's own stop path already covers both (it ends matched
+    // PIDs with `taskkill /F /PID`, precisely so the fallback is not missed).
     #[cfg(target_os = "windows")]
     {
         "quit Meridian from the tray menu, which now stops the daemon too, \
-         or end the Meridian scheduled task"
+         or end the Meridian scheduled task - and if this install starts the \
+         daemon from the Startup folder instead, end the meridian.exe process \
+         in Task Manager"
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -1345,9 +1345,31 @@ mod tests {
             .split_once("pub async fn ensure_backend_installed")
             .expect("ensure_backend_installed must exist")
             .1;
-        // Bound the scan to the function: the next `\npub ` / `\nasync fn` at
-        // column 0 starts the following item.
-        let body = body.split("\nasync fn").next().unwrap_or(body);
+        // Bound the scan to the function: whichever item marker at column 0
+        // comes FIRST ends it. Splitting on `"\nasync fn"` alone was wrong -
+        // the next item is `pub(crate) async fn stop_daemon_for_migration`,
+        // which that pattern does not match, so the scan ran on to
+        // `wait_for_db_unheld` and swept a second function into the range.
+        // Harmless only by luck: `stop_daemon_for_migration` returns a
+        // `Result` and so cannot hold a bare `return;`. The next `pub(crate)
+        // fn` added between them would have failed this test with a message
+        // naming `ensure_backend_installed`, which is the worst kind of
+        // red - a true failure pointing at the wrong function.
+        let end = ["\npub ", "\npub(crate) ", "\nasync fn", "\nfn "]
+            .iter()
+            .filter_map(|m| body.find(m))
+            .min()
+            .unwrap_or(body.len());
+        let body = &body[..end];
+
+        // Pins the bound itself. Without it the two assertions below silently
+        // widen as the module grows, and a guard that scans the wrong lines
+        // reports on a function nobody edited.
+        assert!(
+            !body.contains("stop_daemon_for_migration"),
+            "the scan must stop at the end of ensure_backend_installed - it \
+             has run on into the following item"
+        );
 
         // Every `return;` must be preceded by a restore. The one exception is
         // the path where `$HOME` itself could not be resolved - there is no

--- a/tray/src-tauri/src/daemon_lifecycle.rs
+++ b/tray/src-tauri/src/daemon_lifecycle.rs
@@ -172,6 +172,71 @@ pub(crate) fn set_exit_phase(phase: ExitPhase) {
     EXIT_PHASE.store(v, Ordering::SeqCst);
 }
 
+/// Did the daemon actually come back after a resume?
+///
+/// `Some(true)`/`Some(false)` are verified answers; `None` means the platform
+/// has no liveness check wired (Windows - see
+/// [`crate::commands::daemon_control::process_alive`]) and must never be read
+/// as a failure.
+///
+/// Polled rather than asked once: on macOS the restore ends in `launchctl
+/// kickstart`, and the process takes a moment to appear. A single immediate
+/// query would report a healthy resume as failed on a slow machine, which is
+/// the same false-signal problem in the opposite direction.
+async fn verify_daemon_came_back() -> Option<bool> {
+    for attempt in 0..RESUME_VERIFY_ATTEMPTS {
+        match crate::commands::daemon_control::process_alive().await {
+            Some(true) => return Some(true),
+            // Unknown is terminal: it is a property of the platform, not a
+            // timing artefact, so retrying cannot change it.
+            None => return None,
+            Some(false) => {
+                if attempt + 1 < RESUME_VERIFY_ATTEMPTS {
+                    tokio::time::sleep(RESUME_VERIFY_INTERVAL).await;
+                }
+            }
+        }
+    }
+    Some(false)
+}
+
+/// How many times [`verify_daemon_came_back`] asks before calling a resume
+/// failed.
+const RESUME_VERIFY_ATTEMPTS: u32 = 4;
+
+/// Gap between those attempts - ~1.5 s total, comfortably inside the tray's
+/// menu-click responsiveness budget and well under the watchdog's first
+/// opportunity to act.
+const RESUME_VERIFY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// Releases a held exit if the stop task dies without finishing.
+///
+/// [`ExitPhase::Stopping`] holds **every** subsequent `ExitRequested` via
+/// [`ExitAction::Hold`], and only the stop task advances past it. So a panic in
+/// that task - anywhere before its `set_exit_phase(ReadyToExit)` - leaves the
+/// phase at `Stopping` with nothing left alive to move it, and the tray becomes
+/// permanently unquittable: every later quit is held, and no path resets the
+/// phase. The user's only way out is killing the process.
+///
+/// [`stop_for_quit`] is documented as infallible and is bounded by
+/// `QUIT_STOP_BUDGET`, so this needs a panic in the platform stop path to
+/// trigger. It is guarded anyway because the failure is unrecoverable from
+/// inside the app, and the guard costs one `compare_exchange` on the way out.
+///
+/// Deliberately a **conditional** advance: the normal path sets `ReadyToExit`
+/// explicitly right before `exit(0)`, and this must not disturb that (nor
+/// promote a phase that has since been reset to `Running`). Only `Stopping`
+/// - the stuck state - is advanced.
+pub(crate) struct HeldExitGuard;
+
+impl Drop for HeldExitGuard {
+    fn drop(&mut self) {
+        // 1 -> 2, and only 1 -> 2. Fails harmlessly on the normal path, where
+        // the explicit `set_exit_phase(ReadyToExit)` has already stored 2.
+        let _ = EXIT_PHASE.compare_exchange(1, 2, Ordering::SeqCst, Ordering::SeqCst);
+    }
+}
+
 /// Whether the user has paused the daemon from the tray menu.
 ///
 /// A process-global rather than a field on [`crate::state::AppState`] because
@@ -320,8 +385,45 @@ pub(crate) async fn resume_from_pause() -> Result<(), String> {
         let _guard = LIFECYCLE.lock().await;
         DAEMON_PAUSED.store(false, Ordering::Relaxed);
         crate::backend_install::ensure_daemon_running(&home).await;
-        s.record("outcome", "resumed");
-        tracing::info!("daemon resumed from pause");
+
+        // `ensure_daemon_running` returns `()` and swallows its own failures
+        // with `tracing::warn!` - deliberately, because its other callers (the
+        // installer bail-outs, the launch restore) cannot act on one. This
+        // caller can: recording "resumed" on its say-so would report a success
+        // nothing verified, and `toggle_daemon` clears the Paused notice
+        // straight after, so the menu would read Connected over a daemon that
+        // is down.
+        //
+        // The runtime state self-heals - the pause flag is clear, so the
+        // watchdog starts it within STRIKES ticks - but telemetry does not. A
+        // failed resume must not be indistinguishable from a working one in
+        // the exporter.
+        match verify_daemon_came_back().await {
+            Some(true) => {
+                s.record("outcome", "resumed");
+                tracing::info!("daemon resumed from pause");
+            }
+            Some(false) => {
+                // Not an `Err`: the resume itself did what it could, the pause
+                // flag is genuinely clear, and failing the command would tell
+                // the user to retry something the watchdog is already fixing.
+                // The span carries the truth for whoever reads it later.
+                s.record("outcome", "resume_unconfirmed");
+                s.record("otel.status_code", "ERROR");
+                tracing::warn!(
+                    "resumed the daemon but it is not running - leaving it to the watchdog"
+                );
+            }
+            None => {
+                // Windows has no liveness check wired (`process_alive` is
+                // `None` there by design), so this is "cannot tell", not a
+                // failure - and must not be reported as one.
+                s.record("outcome", "resumed_unverified");
+                tracing::info!(
+                    "daemon resume requested - liveness not verifiable on this platform"
+                );
+            }
+        }
         Ok(())
     }
     .instrument(span)
@@ -483,11 +585,17 @@ mod tests {
         );
     }
 
+    /// `EXIT_PHASE` is one process-global, and `cargo test` runs these in
+    /// parallel threads of one process - so the tests that write it must not
+    /// interleave. Without this they pass alone and flake together.
+    static PHASE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// The phase round-trips through its atomic encoding. Cheap, but the
     /// encoding is hand-rolled and a wrong default would silently mean
     /// "Running" forever - i.e. every exit held and then re-stopped.
     #[test]
     fn the_exit_phase_round_trips() {
+        let _serial = PHASE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         for phase in [
             ExitPhase::Stopping,
             ExitPhase::ReadyToExit,
@@ -496,6 +604,49 @@ mod tests {
             set_exit_phase(phase);
             assert_eq!(exit_phase(), phase);
         }
+        set_exit_phase(ExitPhase::Running);
+    }
+
+    /// A panic in the stop task must not leave the app unquittable.
+    ///
+    /// `Stopping` holds every subsequent `ExitRequested`, and only the stop
+    /// task advances past it - so if that task dies mid-stop, nothing else
+    /// ever will, and the tray can no longer be quit at all. The guard runs on
+    /// the unwind path and releases the hold.
+    ///
+    /// Asserted on the guard's drop rather than by panicking a real stop task:
+    /// no unit test can drive a Tauri event loop, and the phase transition IS
+    /// the behaviour that matters.
+    #[test]
+    fn a_dead_stop_task_releases_the_held_exit() {
+        let _serial = PHASE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        set_exit_phase(ExitPhase::Stopping);
+        drop(HeldExitGuard);
+        assert_eq!(
+            exit_phase(),
+            ExitPhase::ReadyToExit,
+            "a stop task that dies while holding the exit must release it, or \
+             every later quit is held forever and the tray cannot be closed"
+        );
+        assert_eq!(
+            decide_exit(None, exit_phase()),
+            ExitAction::Proceed,
+            "and the next quit must actually get through"
+        );
+
+        // Conditional, not unconditional: the normal path has already stored
+        // `ReadyToExit` before this drops, and a phase reset to `Running` must
+        // not be promoted to an exit nobody asked for.
+        set_exit_phase(ExitPhase::Running);
+        drop(HeldExitGuard);
+        assert_eq!(
+            exit_phase(),
+            ExitPhase::Running,
+            "the guard must only ever advance the stuck Stopping phase"
+        );
+
+        set_exit_phase(ExitPhase::Running);
     }
 
     /// The policy above is worth nothing unless something consults it, and no

--- a/tray/src-tauri/src/db_key.rs
+++ b/tray/src-tauri/src/db_key.rs
@@ -116,6 +116,49 @@ pub(crate) fn would_orphan_existing_db(db_path: &std::path::Path) -> bool {
 /// encrypted under the old, now-unreachable one: every future open then fails
 /// with SQLCipher "wrong key" errors (`file is not a database` / `database
 /// disk image is malformed`) instead of a clear, actionable one.
+/// Is `key_hex` the key this machine's OS keychain holds for `meridian.db`?
+///
+/// Read-only and non-minting - deliberately NOT [`resolve_or_create_key`],
+/// which generates and stores a key when the entry is missing. The one caller
+/// ([`crate::repair_boot`]) is deciding whether it may move a database aside;
+/// minting a key there would manufacture the very confidence it is asking
+/// about.
+///
+/// # Why anything needs this
+///
+/// The key that reaches the tray is usually read straight out of `.env`
+/// ([`crate::install::env_key_from_path`]), and the keychain is consulted only
+/// when `.env` has none. So "a key resolved" says nothing about whether that
+/// key *owns* the database - a stale or hand-edited `.env` resolves perfectly
+/// and opens nothing.
+///
+/// That distinction is invisible at the point it matters, because SQLCipher
+/// reports a wrong key and a damaged page 1 identically (code 26, `file is not
+/// a database`). Treating the two the same means a wrong `.env` key can be
+/// read as unrecoverable corruption and a *healthy encrypted database* moved
+/// aside for a fresh one.
+///
+/// Returns `false` when the keychain has no entry or cannot be reached: this
+/// gates a destructive action, so "cannot prove it" must read the same as
+/// "no".
+pub(crate) fn key_matches_keychain(key_hex: &str) -> bool {
+    let entry = match keyring::Entry::new(SERVICE, ACCOUNT) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!(error = %e, "db_key: could not reach the OS keychain to verify the database key");
+            return false;
+        }
+    };
+    match entry.get_password() {
+        Ok(stored) => stored == key_hex,
+        Err(keyring::Error::NoEntry) => false,
+        Err(e) => {
+            tracing::warn!(error = %e, "db_key: could not read the stored database key for verification");
+            false
+        }
+    }
+}
+
 pub fn resolve_or_create_key(
     env_path: &std::path::Path,
     db_path: &std::path::Path,

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -1257,6 +1257,13 @@ pub fn run() {
                         api.prevent_exit();
                         let handle = app.clone();
                         tauri::async_runtime::spawn(async move {
+                            // Held on the unwind path too. `Stopping` blocks
+                            // every later `ExitRequested`, and this task is the
+                            // only thing that advances past it - so a panic
+                            // anywhere below would leave the tray permanently
+                            // unquittable, with no path left to reset the
+                            // phase. See [`daemon_lifecycle::HeldExitGuard`].
+                            let _released = daemon_lifecycle::HeldExitGuard;
                             daemon_lifecycle::stop_for_quit().await;
                             // Immediately before the exit, so the re-entrant
                             // `ExitRequested` this triggers is the one and only

--- a/tray/src-tauri/src/poll/watchdog.rs
+++ b/tray/src-tauri/src/poll/watchdog.rs
@@ -494,6 +494,19 @@ mod tests {
             Action::Wait,
             "on a healthy endpoint, liveness is not consulted"
         );
+        // The combination the loop actually produces while paused. `!paused`
+        // is part of `could_start`, so a paused tick never queries liveness
+        // and always reaches `decide` with `process_alive: None` - the one
+        // skip condition the paused-daemon test above cannot cover, because it
+        // pins `Some(false)` to isolate the pause rule itself.
+        assert_eq!(
+            decide(Inputs {
+                daemon_paused: true,
+                ..unknown
+            }),
+            Action::Wait,
+            "while paused, liveness is not consulted"
+        );
     }
 
     /// The blast-radius cap. Independent of whether any single decision above

--- a/tray/src-tauri/src/repair_boot.rs
+++ b/tray/src-tauri/src/repair_boot.rs
@@ -103,9 +103,15 @@ enum Probe {
     /// place - page 1 is readable, so the salvage can ATTACH it.
     Damaged { problems: Vec<String> },
     /// The keyed open (or first read) fails with SQLITE_NOTADB (code 26) -
-    /// page 1 itself is unreadable. Nothing can read this file, under any
-    /// tool; a plain-corrupt failure (code 11) classifies [`Probe::Damaged`]
-    /// instead, because a file that ATTACHes is still salvageable.
+    /// page 1 is unreadable **under the key that was used**. A plain-corrupt
+    /// failure (code 11) classifies [`Probe::Damaged`] instead, because a file
+    /// that ATTACHes is still salvageable.
+    ///
+    /// This verdict is deliberately NOT "the file is destroyed". SQLCipher
+    /// returns code 26 both for a damaged page 1 and for a perfectly healthy
+    /// database opened with the wrong key, and nothing at this layer can tell
+    /// them apart. That is why acting on it requires [`KeyTrust`] - the
+    /// verdict describes the *pairing* of file and key, not the file.
     Unopenable { error: String },
 }
 
@@ -157,15 +163,80 @@ pub fn run_auto_if_needed(db_path: &Path, key_hex: Option<&str>) -> Option<Outco
         );
         return None;
     }
-    probe_and_heal(db_path, key_hex)
+    probe_and_heal(db_path, key_hex, KeyTrust::of(key_hex))
+}
+
+/// Whether the key in hand is provably this machine's own database key.
+///
+/// The fresh-start branch discards a database, and it fires on a SQLCipher
+/// verdict (code 26) that means *either* "page 1 is damaged" *or* "this is the
+/// wrong key" - SQLCipher cannot tell them apart, and neither can this module.
+/// So the destructive branch is gated on provenance instead: only a key the OS
+/// keychain confirms is allowed to condemn a file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KeyTrust {
+    /// The OS keychain holds exactly this key for `meridian.db`, so an
+    /// unopenable verdict is about the file, not about the key.
+    KeychainVerified,
+    /// A key resolved, but nothing proves it owns this database - typically
+    /// read from `.env`, which a stale mirror, a hand-edit or a copy from
+    /// another machine can populate with a key that opens nothing. An
+    /// unopenable verdict here is indistinguishable from a healthy encrypted
+    /// file being read with the wrong key.
+    Unverified,
+}
+
+impl KeyTrust {
+    /// Classify the key the tray resolved this launch.
+    ///
+    /// Split from [`probe_and_heal`] for the same reason the daemon gate is:
+    /// so tests can drive the destructive path without the developer's real
+    /// keychain deciding the outcome.
+    fn of(key_hex: Option<&str>) -> Self {
+        match key_hex {
+            Some(k) if crate::db_key::key_matches_keychain(k) => Self::KeychainVerified,
+            _ => Self::Unverified,
+        }
+    }
 }
 
 /// The probe + heal body behind [`run_auto_if_needed`]'s daemon gate. Split
 /// out so tests can exercise it without the gate consulting the development
 /// machine's real daemon.
-fn probe_and_heal(db_path: &Path, key_hex: Option<&str>) -> Option<Outcome> {
-    match tauri::async_runtime::block_on(probe_database(db_path, key_hex)) {
-        Probe::Healthy => None,
+/// # Observability
+///
+/// This is the least observable path in the tray and the one with the largest
+/// consequence - it can move a user's database aside and start an empty one -
+/// so the verdict, the trust decision and the outcome are span attributes
+/// rather than log lines to be grepped back together, and every failure
+/// boundary marks the span `ERROR`. All fields are declared up front:
+/// `Span::record` on an undeclared field is a silent no-op, so a status
+/// recorded later would never reach the exporter.
+fn probe_and_heal(db_path: &Path, key_hex: Option<&str>, key_trust: KeyTrust) -> Option<Outcome> {
+    let span = tracing::info_span!(
+        "repair_boot.probe_and_heal",
+        verdict = tracing::field::Empty,
+        key_trust = ?key_trust,
+        outcome = tracing::field::Empty,
+        otel.status_code = tracing::field::Empty,
+    );
+    let _enter = span.enter();
+
+    let probe = tauri::async_runtime::block_on(probe_database(db_path, key_hex));
+    span.record(
+        "verdict",
+        match &probe {
+            Probe::Healthy => "healthy",
+            Probe::Damaged { .. } => "damaged",
+            Probe::Unopenable { .. } => "unopenable",
+        },
+    );
+
+    match probe {
+        Probe::Healthy => {
+            span.record("outcome", "none");
+            None
+        }
         Probe::Damaged { problems } => {
             tracing::warn!(
                 problems = ?problems,
@@ -179,22 +250,41 @@ fn probe_and_heal(db_path: &Path, key_hex: Option<&str>) -> Option<Outcome> {
             // race such a relaunch - skip, and let the daemon's own latch
             // report the corruption.
             if let Err(e) = meridian::db::repair::marker::request(db_path) {
+                span.record("outcome", "marker_write_failed");
+                span.record("otel.status_code", "ERROR");
                 tracing::error!(error = %e, "could not write the repair marker - skipping the automatic repair");
                 return None;
             }
-            Some(execute_pending_repair(db_path, key_hex))
+            let outcome = execute_pending_repair(db_path, key_hex);
+            span.record(
+                "outcome",
+                match &outcome {
+                    Outcome::Repaired { .. } => "repaired",
+                    Outcome::Failed { .. } => "repair_failed",
+                    Outcome::FreshStart { .. } => "fresh_start",
+                },
+            );
+            if matches!(outcome, Outcome::Failed { .. }) {
+                span.record("otel.status_code", "ERROR");
+            }
+            Some(outcome)
         }
         Probe::Unopenable { error } => {
-            if key_hex.is_none() {
-                // Without a keychain-verified key, "file is not a database"
-                // is exactly what a healthy encrypted file looks like. This is
-                // a key-resolution problem, not corruption - moving the file
-                // aside here would discard data a recovered key could still
-                // open.
+            // Both arms of one rule: only a key the keychain vouches for may
+            // condemn a file. `key_hex.is_none()` alone was never enough -
+            // the key usually comes from `.env`, so "a key resolved" can mean
+            // a stale mirror that opens nothing, and every healthy encrypted
+            // database reads as `file is not a database` under the wrong key.
+            // Acting on that would discard exactly the data this path exists
+            // to protect. See [`KeyTrust`].
+            if key_hex.is_none() || key_trust != KeyTrust::KeychainVerified {
                 tracing::error!(
                     error = %error,
-                    "meridian.db cannot be opened and no encryption key was resolved - leaving the file alone (a key problem, not corruption)"
+                    key_resolved = key_hex.is_some(),
+                    "meridian.db cannot be opened and the key in hand is not confirmed by the OS keychain - leaving the file alone (a key problem is indistinguishable from corruption here, and only one of the two is safe to act on)"
                 );
+                span.record("outcome", "left_alone_key_unverified");
+                span.record("otel.status_code", "ERROR");
                 return None;
             }
             if let Some(previous) = recent_unopenable_backup(db_path) {
@@ -203,6 +293,8 @@ fn probe_and_heal(db_path: &Path, key_hex: Option<&str>) -> Option<Outcome> {
                     previous_backup = %previous.display(),
                     "meridian.db is unopenable again within a day of being replaced - refusing a second fresh start; something is damaging databases faster than they can be replaced"
                 );
+                span.record("outcome", "refused_repeat_fresh_start");
+                span.record("otel.status_code", "ERROR");
                 return Some(Outcome::Failed { error });
             }
             tracing::error!(
@@ -214,6 +306,8 @@ fn probe_and_heal(db_path: &Path, key_hex: Option<&str>) -> Option<Outcome> {
             // KeepAlive relaunch out of the window while the file moves.
             // (No `set_running` call - there is provably nothing to stop.)
             if let Err(e) = meridian::db::repair::marker::request(db_path) {
+                span.record("outcome", "marker_write_failed");
+                span.record("otel.status_code", "ERROR");
                 tracing::error!(error = %e, "could not write the repair marker - leaving the unopenable database in place");
                 return Some(Outcome::Failed { error });
             }
@@ -222,10 +316,15 @@ fn probe_and_heal(db_path: &Path, key_hex: Option<&str>) -> Option<Outcome> {
                 tracing::error!(error = %e, "could not clear the repair marker - the daemon will stay down until it expires");
             }
             match result {
-                Ok(backup) => Some(Outcome::FreshStart {
-                    backup: backup.display().to_string(),
-                }),
+                Ok(backup) => {
+                    span.record("outcome", "fresh_start");
+                    Some(Outcome::FreshStart {
+                        backup: backup.display().to_string(),
+                    })
+                }
                 Err(e) => {
+                    span.record("outcome", "set_aside_failed");
+                    span.record("otel.status_code", "ERROR");
                     tracing::error!(error = %e, "could not move the unopenable database aside - leaving it in place");
                     Some(Outcome::Failed {
                         error: format!("{e:#}"),
@@ -283,6 +382,13 @@ fn execute_pending_repair(db_path: &Path, key_hex: Option<&str>) -> Outcome {
 /// on uncertainty would stop the daemon and rebuild a database over an error
 /// that may have been a transient lock. Only the two positively-identified
 /// corruption signatures trigger action.
+#[tracing::instrument(
+    name = "repair_boot.probe_database",
+    // `skip_all`, not a field list: `key_hex` IS the database encryption key
+    // and must never reach a span, and `db_path` carries the user's home
+    // directory. The verdict is recorded by the caller's span instead.
+    skip_all
+)]
 async fn probe_database(db_path: &Path, key_hex: Option<&str>) -> Probe {
     if !db_path.exists() {
         return Probe::Healthy; // fresh install - the daemon will create it
@@ -349,6 +455,7 @@ async fn probe_database(db_path: &Path, key_hex: Option<&str>) -> Probe {
 /// timestamped name, so a fresh one can be created at the canonical path. The
 /// file is preserved, never deleted - it is the only copy of whatever a future
 /// offline-salvage attempt might still extract.
+#[tracing::instrument(name = "repair_boot.set_aside_unopenable", skip_all)]
 fn set_aside_unopenable(db_path: &Path) -> anyhow::Result<PathBuf> {
     use anyhow::Context;
     let backup = db_path.with_extension(format!(
@@ -562,7 +669,7 @@ mod probe_tests {
         std::fs::write(&db, vec![0xABu8; 8192]).unwrap();
         std::fs::write(format!("{}-wal", db.display()), b"stale wal").unwrap();
 
-        let outcome = probe_and_heal(&db, Some(TEST_KEY));
+        let outcome = probe_and_heal(&db, Some(TEST_KEY), KeyTrust::KeychainVerified);
         let Some(Outcome::FreshStart { backup }) = outcome else {
             panic!("an unopenable file with a key must produce a fresh start");
         };
@@ -581,7 +688,7 @@ mod probe_tests {
         std::fs::write(&db, vec![0xCDu8; 8192]).unwrap();
         assert!(
             matches!(
-                probe_and_heal(&db, Some(TEST_KEY)),
+                probe_and_heal(&db, Some(TEST_KEY), KeyTrust::KeychainVerified),
                 Some(Outcome::Failed { .. })
             ),
             "a second unopenable verdict inside the guard window must not mint another database"
@@ -599,10 +706,47 @@ mod probe_tests {
         let db = dir.path().join("meridian.db");
         std::fs::write(&db, vec![0xABu8; 8192]).unwrap();
 
-        assert!(probe_and_heal(&db, None).is_none());
+        assert!(probe_and_heal(&db, None, KeyTrust::Unverified).is_none());
         assert!(
             db.exists(),
             "a possibly-just-locked-out file must never be moved"
+        );
+    }
+
+    /// The same protection, for the case that actually reaches users: a key
+    /// that resolved but is not the one this machine's keychain holds.
+    ///
+    /// This is not hypothetical. The key normally comes from `.env`, and the
+    /// keychain is consulted only when `.env` has none - so a stale mirror, a
+    /// hand-edited file, or a `.env` copied between machines all produce a key
+    /// that resolves and opens nothing. SQLCipher then reports the healthy
+    /// encrypted database as `file is not a database`, identically to real
+    /// page-1 damage.
+    ///
+    /// Before [`KeyTrust`], the gate was `key_hex.is_none()` - which this case
+    /// passes - so a wrong `.env` key was enough to move a perfectly good
+    /// database aside and start an empty one in its place. It also takes the
+    /// daemon down with it (same wrong key, same failure), so the
+    /// daemon-unreachable gate does not catch it either.
+    #[test] // sync for the same block_on reason as the set-aside test above
+    fn unopenable_under_an_unverified_key_is_left_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("meridian.db");
+        std::fs::write(&db, vec![0xABu8; 8192]).unwrap();
+
+        assert!(
+            probe_and_heal(&db, Some(TEST_KEY), KeyTrust::Unverified).is_none(),
+            "an unopenable verdict under an unconfirmed key must not condemn \
+             the file - it is what a healthy encrypted database looks like \
+             through the wrong key"
+        );
+        assert!(
+            db.exists(),
+            "the database must still be there for a recovered key to open"
+        );
+        assert!(
+            !meridian::db::repair::marker::pending(&db),
+            "and no repair marker may be left behind holding the daemon down"
         );
     }
 


### PR DESCRIPTION
Addresses all 7 findings from the CodeRabbit review on #698 (6 inline + 1 outside-diff). All 7 were verified against current code before being acted on; none were skipped.

The findings are against code already merged to `pre-main` from #693/#694, so the fixes land here and reach #698 when this merges.

## The two that could bite a user

**1. A wrong `.env` key could discard a healthy database** - `repair_boot.rs` (Major, Data Integrity)

The fresh-start branch gated on `key_hex.is_none()`, treating "a key resolved" as "the key is right". It isn't: the key is normally read from `.env` (`install::env_key_from_path`), and the keychain is consulted only when `.env` has none. A stale mirror, a hand-edit, or a `.env` copied between machines all resolve perfectly and open nothing.

SQLCipher reports a wrong key and a damaged page 1 **identically** (code 26, `file is not a database`). So a healthy encrypted database looked exactly like unrecoverable corruption - and got moved aside for an empty one. The daemon-unreachable gate does not catch this: the daemon reads the same wrong `.env` key and is equally down, which is what makes the gate pass.

Now gated on provenance via `KeyTrust`: only a key the OS keychain confirms may condemn a file. `db_key::key_matches_keychain` is read-only and **never mints** (deliberately not `resolve_or_create_key`, which would manufacture the very confidence being asked about), and fails closed when the keychain cannot be reached.

Also corrected the `Probe::Unopenable` doc, which claimed "Nothing can read this file, under any tool". That sentence is what a future reader would trust when deciding whether this path is safe; it now says the verdict describes the file/key *pairing*, not the file.

**2. A panic in the stop task made the app permanently unquittable** - `lib.rs` (Minor, Stability)

`ExitPhase::Stopping` holds every subsequent `ExitRequested`, and only the stop task advances past it. A panic anywhere before `set_exit_phase(ReadyToExit)` left the phase stuck with nothing alive to move it: every later quit held, no path to reset, the user's only way out killing the process.

`HeldExitGuard` advances it on the unwind path. Deliberately **conditional** (`compare_exchange(Stopping, ReadyToExit)`) so the normal path's explicit `ReadyToExit` before `exit(0)` is untouched, and a phase reset to `Running` is never promoted to an exit nobody asked for.

## The rest

- **A guard test was scanning two functions** (`backend_install.rs`). `every_early_return_still_restores_the_daemon` split on `"\nasync fn"`, which does not match the `pub(crate) async fn stop_daemon_for_migration` that actually follows - so the scan ran on to `wait_for_db_unheld` and swept a second function into range. Harmless only by luck: that function returns a `Result` and cannot hold a bare `return;`. The next `pub(crate) fn` added between them would have failed the test with a message naming `ensure_backend_installed` - a true failure pointing at the wrong function. Bounded at the first item marker, and **the bound itself is now asserted**.
- **`resume_from_pause` recorded success it could not verify** (`daemon_lifecycle.rs`). `ensure_daemon_running` returns `()` and swallows failures with `warn!` - deliberately, since its other callers cannot act on one. This caller can: recording "resumed" on its say-so meant a resume that started nothing was indistinguishable in the exporter from one that worked, while `toggle_daemon` cleared the Paused notice over a dead daemon. Now verified with a bounded liveness poll. `None` (Windows, where `process_alive` has no check wired) stays `resumed_unverified` rather than becoming a false failure. Left `ensure_daemon_running`'s signature alone on purpose - making it `Result` would invite `let _ =` at three call sites that genuinely cannot act, a worse contract than today.
- **Spans on the probe/heal path** (`repair_boot.rs`). This was the least observable path in the tray and the one with the largest consequence. One span now carries verdict, key trust and outcome, with `otel.status_code = ERROR` at every failure boundary; all fields declared up front, since `Span::record` on an undeclared field is a silent no-op. `skip_all` on `probe_database` - `key_hex` is the database encryption key and must never reach a span, and `db_path` carries the user's home directory.
- **The Windows repair hint named only the scheduled task** (`db/repair/mod.rs`). `register_service` falls back to a Startup-folder `MeridianDaemon.vbs` when `schtasks /Create` is blocked - i.e. on the locked-down and antivirus-quarantined machines most likely to be reading this message, where there is no task to end. Both launchers are named now.
- **Watchdog skip-set test gap** (outside-diff finding). `!paused` is part of `could_start`, so a paused tick always reaches `decide` with `process_alive: None` - the one skip condition no test covered (`a_paused_daemon_is_never_started` pins `Some(false)` to isolate the pause rule). Added.

## Tests

Every finding with a testable claim got one, and **each was proven red before the fix**:

| Test | Proven red by |
|---|---|
| the scan bound assertion | restoring the old `"\nasync fn"` split |
| `a_dead_stop_task_releases_the_held_exit` | disabling the guard's `compare_exchange` |
| `unopenable_under_an_unverified_key_is_left_alone` | neutralising the `KeyTrust` check |
| watchdog paused + `process_alive: None` | disabling the `daemon_paused` rule in `decide` |

Also added a `PHASE_LOCK` around the two tests that write the process-global `EXIT_PHASE` - they pass alone and would have flaked together under `cargo test`'s parallelism.

`cargo test --workspace` green (883 + 276 + 226 + …, 0 failed); `cargo clippy --workspace --all-targets` clean; full pre-push suite passed.

## Note on the review threads

The 6 inline threads on #698 are left **unresolved** on purpose. These fixes are not on #698's head until this PR merges into `pre-main`, and resolving them earlier would mark findings addressed on a head that does not contain them. Each thread has a reply pointing here.

## Related

- #698 - the release PR these findings were raised on
- #699 - update floor to 1.84.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpjbL7YGMNpSvP94V5HEgX
