### PR TITLE
docs(tray): add the What's New entry for 1.84.0

### DIFF
--- a/tray/src-tauri/resources/whats-new.json
+++ b/tray/src-tauri/resources/whats-new.json
@@ -1,6 +1,23 @@
 {
   "releases": [
     {
+      "version": "1.84.0",
+      "date": "2026-08-07",
+      "highlights": [
+        "Meridian now checks its database when it starts and repairs a damaged one on its own. Until now the offer to repair lived inside the database itself, so the worst damage took the offer down with it - the app simply sat there doing nothing, with no warning and no button to press, and the only way back was a support ticket. That case now heals itself before the app finishes opening.",
+        "Quit now really does stop Meridian. The background service used to keep running after you closed the app: still watching, still holding your data file open, still making network calls. Quitting stops it, and opening Meridian starts it again.",
+        "Pause now actually pauses. The menu switched to 'Disconnected' but the background service was put straight back a few seconds later, so it kept working while the menu said it had stopped."
+      ],
+      "fixes": [
+        "The 'Repair Database' button in the damaged-database banner works again. It had been doing nothing at all since it shipped - the confirmation box it asked for never appeared, and a box nobody answered counted as 'no', so the repair was silently cancelled every time.",
+        "Repairing by hand used to be impossible for the same reason Quit was: the instructions said to close Meridian first, and closing it did not stop the part that had to stop.",
+        "Meridian can no longer get stuck refusing to quit. If something went wrong while shutting down, every later attempt to close the app was ignored and the only way out was to force it.",
+        "If a damaged database cannot be opened at all, Meridian now leaves it alone unless it can confirm the file is genuinely damaged rather than locked. A file it cannot unlock looks identical to a broken one, and the safe assumption is that your data is fine and something else is wrong.",
+        "On Windows, the instructions shown when a database needs repairing now cover installs that start Meridian from the Startup folder, not only those using a scheduled task.",
+        "Pausing while Meridian was still setting itself up no longer leaves it running behind a paused label."
+      ]
+    },
+    {
       "version": "1.83.2",
       "date": "2026-08-05",
       "highlights": [
@@ -303,7 +320,7 @@
     {
       "title": "Track down the last cause of database damage on Mac",
       "status": "in-progress",
-      "description": "Three causes are now fixed: a risky one-time encryption step, running out of file handles, and Meridian restarting its own background service when it was only busy. Damage has still been seen after all three, so at least one cause remains unidentified and we are still looking. In the meantime Meridian detects the damage and can repair it from inside the app."
+      "description": "Four causes are now fixed: a risky one-time encryption step, running out of file handles, Meridian restarting its own background service when it was only busy, and this release closing the gaps where the app and the background service could both write to your data at the same time. Damage has still been seen after the first three, so we are not calling this solved until the machines we are watching stay clean. What has changed is the recovery: Meridian now repairs a damaged database by itself at startup, so a bad one no longer means a dead app."
     },
     {
       "title": "More trackers - Linear, Trello, and Azure DevOps",


### PR DESCRIPTION
Closes checklist item 4 on #698.

Adds the hand-curated 1.84.0 entry to `tray/src-tauri/resources/whats-new.json` (compiled in via `include_str!`, so a rebuild picks it up).

## Why it reads nothing like the commit log

1.84.0 is almost entirely internal plumbing - exit phases, a keychain trust gate, span attributes, a corrected test bound. None of that is something a user experiences. What they experience is three things:

- **An app that used to die silently now fixes itself.** The offer to repair lived inside the database, so the worst damage took the offer down with it: the app sat there doing nothing, with no warning and no button. That is the actual lived experience of the five machines still failing today, and it is the headline.
- **Quit now stops what it says it stops.** The background service kept running after the app closed - still watching, still holding the data file open, still making network calls.
- **Pause now pauses.** The menu said "Disconnected" while the service was put straight back a few seconds later.

## The Repair Database button gets its own line

It has been visibly present and completely inert since it shipped. Anyone who pressed it watched nothing happen, so it is named directly rather than folded into a general "repair improvements" - and the entry says plainly why (the confirmation box never appeared, and an unanswered box counted as "no").

## Roadmap

The database-damage item now reads **four** fixed causes rather than three, since this release closes the two-writer windows. It stays `in-progress` and still says the problem is not solved: damage was observed on five machines today, so claiming otherwise would be false in a place users read.

## Checks

- Parses (`cargo test -p meridian-tray whats_new_json_parses` green).
- Scanned every string in the file for em-dashes, en-dashes and double hyphens per the Hard Rules - none.
- 23 releases, newest-first ordering preserved.

## One thing to confirm

The date is `2026-08-07`, the intended cut date. **If the release slips it needs updating** - this is user-visible text, and a release dated before it shipped is the kind of small wrongness people notice.

## Related

- #698 - the release PR this unblocks
