### PR TITLE
fix: address round 2 of the CodeRabbit review on #698

### DIFF
--- a/src/coding_agent_session_ingest/hook.rs
+++ b/src/coding_agent_session_ingest/hook.rs
@@ -21,6 +21,26 @@ use super::indexer::register_session;
 /// Run the hook. Always returns (never errors out): a SessionEnd hook that
 /// returned non-zero or panicked could disrupt Claude, so we swallow every
 /// failure to stderr and let the caller exit 0.
+///
+/// # Observability
+///
+/// Because every path exits 0 and there is no terminal to read, the emitted
+/// span IS the only record that this ran at all - so it carries the outcome
+/// rather than leaving it to be reconstructed from log lines. Both fields are
+/// declared here on purpose: `Span::record` on a field the macro did not
+/// declare is a silent no-op, which would drop exactly the error status the
+/// failure paths below record.
+///
+/// `skip_all` because nothing in scope is safe or useful to attach - the
+/// payload is untrusted stdin and the resolved path names the user's project.
+#[tracing::instrument(
+    name = "coding_agent.hook",
+    skip_all,
+    fields(
+        outcome = tracing::field::Empty,
+        otel.status_code = tracing::field::Empty,
+    )
+)]
 pub async fn run_hook() {
     let mut raw = String::new();
     let _ = std::io::stdin().read_to_string(&mut raw);
@@ -29,6 +49,7 @@ pub async fn run_hook() {
     let jsonl_path = match extract_jsonl_path(&payload) {
         Some(p) => p,
         None => {
+            tracing::Span::current().record("outcome", "no_transcript_path");
             tracing::warn!("coding-agent-hook: could not determine JSONL path from payload");
             return;
         }
@@ -44,6 +65,7 @@ pub async fn run_hook() {
                 jsonl_path = %resolved.display(),
                 "coding-agent-hook: transcript path outside accepted roots"
             );
+            tracing::Span::current().record("outcome", "path_rejected");
             return;
         }
         Err(_) => {
@@ -51,6 +73,7 @@ pub async fn run_hook() {
                 jsonl_path = %jsonl_path.display(),
                 "coding-agent-hook: transcript not found"
             );
+            tracing::Span::current().record("outcome", "transcript_missing");
             return;
         }
     };
@@ -61,9 +84,29 @@ pub async fn run_hook() {
     // database". The hook exits 0 on every path by design (it must never block
     // Claude), so that failure was completely silent: SessionEnd sealed nothing
     // and sessions fell through to the indexer's 1 h idle backstop instead.
-    let pool = match super::open_meridian_pool().await {
-        Ok(p) => p,
-        Err(e) => {
+    //
+    // Bounded, because "never block Claude" is a latency contract and not just
+    // an exit-code one. `open_pool_with_key` fails a keyless open of an
+    // encrypted file by STALLING to its ~10 s acquire timeout rather than
+    // erroring - so the exact misconfiguration this hook is most likely to
+    // meet (a key that did not reach the CLI's environment) would hang the
+    // user's editor for ten seconds at the end of every session. The hook has
+    // nothing useful to do after that budget anyway: the indexer's idle
+    // backstop seals the session regardless, so a timeout costs a delayed
+    // seal, never a lost one.
+    let pool = match tokio::time::timeout(DB_OPEN_BUDGET, super::open_meridian_pool()).await {
+        Err(_) => {
+            let span = tracing::Span::current();
+            span.record("outcome", "db_open_timeout");
+            span.record("otel.status_code", "ERROR");
+            tracing::error!(
+                budget_ms = DB_OPEN_BUDGET.as_millis() as u64,
+                "coding-agent-hook: opening the database exceeded its budget - leaving this session to the indexer's idle backstop"
+            );
+            return;
+        }
+        Ok(Ok(p)) => p,
+        Ok(Err(e)) => {
             // `{e:#}` (the full anyhow context chain), not `%e` — plain Display
             // renders only the outermost context ("failed to open SQLite at
             // …"), dropping the cause that actually identifies the fault
@@ -73,6 +116,9 @@ pub async fn run_hook() {
             // `error` is on both SAFE_STRING_KEYS and FREE_TEXT_KEYS, so the
             // chain is path/URL/token-scrubbed on the ship leg.
             let detail = format!("{e:#}");
+            let span = tracing::Span::current();
+            span.record("outcome", "db_open_failed");
+            span.record("otel.status_code", "ERROR");
             tracing::error!(error = %detail, "coding-agent-hook: failed to open db");
             return;
         }
@@ -80,12 +126,22 @@ pub async fn run_hook() {
 
     let outcome = register_session(&pool, &jsonl_path, true, Utc::now()).await;
     pool.close().await;
+    tracing::Span::current().record("outcome", "registered");
     tracing::info!(
         outcome = ?outcome,
         jsonl_path = %jsonl_path.display(),
         "coding-agent-hook: session registered"
     );
 }
+
+/// Ceiling on opening `meridian.db` inside the SessionEnd hook.
+///
+/// Sized against what it is protecting: this runs synchronously in Claude's
+/// hook path, so the number the user feels is this one. Comfortably above a
+/// healthy open (milliseconds - the daemon has already created and migrated
+/// the file) and well below `open_pool_with_key`'s own ~10 s acquire timeout,
+/// which is the stall this exists to cut short.
+const DB_OPEN_BUDGET: std::time::Duration = std::time::Duration::from_secs(3);
 
 /// Tease the JSONL path out of the payload (mirrors `_extract_jsonl_path`):
 /// `transcript_path` / `jsonl_path` directly, else construct from
@@ -134,4 +190,50 @@ fn within_accepted_roots(resolved: &Path) -> bool {
 
 fn expand(p: &str) -> PathBuf {
     PathBuf::from(shellexpand::tilde(p).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The budget must stay comfortably under the acquire timeout it exists to
+    /// pre-empt. If it ever drifts above it the wrapper still compiles, still
+    /// looks correct, and does nothing at all - the inner stall wins and the
+    /// hook blocks Claude for the full ~10 s again.
+    #[test]
+    fn the_db_open_budget_stays_under_the_acquire_timeout() {
+        // `open_pool_with_key`'s acquire timeout, the stall being cut short.
+        const ACQUIRE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+        assert!(
+            DB_OPEN_BUDGET < ACQUIRE_TIMEOUT,
+            "a budget at or above the acquire timeout never fires, and the hook \
+             is back to hanging the editor for the full stall"
+        );
+        // And not so tight that a cold cache on a loaded machine trips it: a
+        // spurious timeout costs a delayed seal on every single session.
+        assert!(
+            DB_OPEN_BUDGET >= std::time::Duration::from_secs(2),
+            "too tight - healthy opens would start timing out"
+        );
+    }
+
+    /// The open must actually be wrapped. Scanned from source because
+    /// `run_hook` reads stdin and opens the real `MERIDIAN_DB`, so no unit test
+    /// can drive it - the same tactic `daemon_lifecycle` and `backend_install`
+    /// use for their own unreachable invariants.
+    ///
+    /// Bounded to the production half so the reference in this test module
+    /// cannot vouch for the call site, and matched on the call itself rather
+    /// than the constant name, which also appears in prose above it.
+    #[test]
+    fn the_hook_bounds_its_database_open() {
+        const SRC: &str = include_str!("hook.rs");
+        let production = SRC.split("#[cfg(test)]").next().expect("split yields one");
+        assert!(
+            production.contains("timeout(DB_OPEN_BUDGET, super::open_meridian_pool())"),
+            "run_hook must bound the database open - an unbounded one stalls to \
+             the acquire timeout on a key misconfiguration and blocks Claude at \
+             the end of every session"
+        );
+    }
 }

--- a/src/coding_agent_session_ingest/mod.rs
+++ b/src/coding_agent_session_ingest/mod.rs
@@ -30,8 +30,26 @@ pub fn meridian_db_path() -> PathBuf {
     PathBuf::from(shellexpand::tilde(&raw).into_owned())
 }
 
-/// Open a short-lived pool against the meridian DB (the daemon already created +
-/// migrated it; we never migrate here). Used by the one-shot CLI subcommands.
+/// Open a short-lived pool against this machine's `meridian.db`, for the
+/// one-shot CLI subcommands (`coding-agent-hook`, `coding-agent-summarise`).
+///
+/// Resolves the path from `MERIDIAN_DB` via [`meridian_db_path`] and the
+/// SQLCipher key from `MERIDIAN_DB_KEY`, then defers to
+/// [`open_meridian_pool_at`] - which is where the behaviour worth knowing
+/// lives. In particular:
+///
+/// - **The database is never created.** `create_if_missing` is false, so a
+///   missing file is an error rather than an empty database. The daemon owns
+///   creation and migrations; a CLI that conjured one would report a nonsense
+///   "0 pending" instead of saying the database is not there.
+/// - **A missing key is not an error.** An absent `MERIDIAN_DB_KEY` is normal
+///   on a dev/source install, and the keyed opener drops the key anyway when
+///   the file on disk is plaintext. It only fails later, on first use, when
+///   the file *is* encrypted - and not quickly (see the timeout note on
+///   [`open_meridian_pool_at`]).
+///
+/// Returns a pool the caller should treat as short-lived: these are one-shot
+/// commands, and the daemon is usually holding the same file.
 pub async fn open_meridian_pool() -> anyhow::Result<sqlx::SqlitePool> {
     let path = meridian_db_path();
     let uri = format!("sqlite://{}", path.display());
@@ -52,6 +70,20 @@ pub async fn open_meridian_pool() -> anyhow::Result<sqlx::SqlitePool> {
 /// `create_if_missing` is false: the daemon owns creation and migrations, and a
 /// one-shot CLI that silently conjured an empty DB would report a nonsense
 /// "0 pending" instead of an error.
+///
+/// # Parameters and result
+///
+/// - `uri` - a full `sqlite://<path>` URI, not a bare path. Callers build it
+///   from [`meridian_db_path`]; the shape is exercised directly by
+///   `opens_an_encrypted_db`.
+/// - `key_hex` - the 64-hex-char SQLCipher key, or `None` on an install with
+///   no encryption. `None` against an *encrypted* file does not fail fast:
+///   the pool builds, and the first query stalls until the acquire timeout
+///   (~10 s). Callers on a latency budget must impose their own deadline -
+///   [`crate::coding_agent_session_ingest::hook`] does exactly this, because
+///   it runs inside Claude's SessionEnd hook.
+/// - Returns a pool whose connections have already had the key applied; an
+///   `Err` only for a malformed URI or a missing file.
 pub async fn open_meridian_pool_at(
     uri: &str,
     key_hex: Option<&str>,
@@ -177,6 +209,67 @@ mod tests {
         src.split("#[cfg(test)]").next().expect("split yields one")
     }
 
+    /// The premise behind `hook::DB_OPEN_BUDGET`: a keyless open of an
+    /// ENCRYPTED database does not fail fast, it stalls.
+    ///
+    /// This is the misconfiguration the SessionEnd hook is most likely to meet
+    /// (the key never reached the CLI's environment), and if it errored
+    /// promptly the timeout wrapper would be pointless. Pinned because the
+    /// wrapper's justification rests entirely on this behaviour - if a future
+    /// sqlx or db_crypto change made it fail fast, the budget could be dropped,
+    /// and if it silently got LONGER the hook would be blocking Claude again.
+    #[tokio::test]
+    async fn a_keyless_open_of_an_encrypted_db_stalls_rather_than_erroring() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("meridian.db");
+        let uri = format!("sqlite://{}", db_path.display());
+
+        let seed = meridian_core::db_crypto::open_pool_with_key(&uri, Some(TEST_KEY), true, &[])
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE app_sessions (id INTEGER PRIMARY KEY)")
+            .execute(&seed)
+            .await
+            .unwrap();
+        seed.close().await;
+
+        // Deliberately short: this asserts "did NOT resolve quickly", so the
+        // bound only has to be well under the acquire timeout. Keeping it at
+        // 1 s costs the suite a second rather than the full stall.
+        let stalled = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            open_meridian_pool_at(&uri, None),
+        )
+        .await;
+        assert!(
+            stalled.is_err(),
+            "a keyless open of an encrypted database is expected to stall - if              it now fails fast, hook::DB_OPEN_BUDGET is protecting nothing and              its rationale needs rewriting"
+        );
+    }
+
+    /// The ban list must reject every pool constructor that skips the key, not
+    /// just the ones that happened to be tried. `connect_lazy` was the hole:
+    /// it takes the URI directly like `connect(`, and nothing matched it.
+    #[test]
+    fn the_ban_list_covers_the_lazy_constructor() {
+        let banned = |l: &str| {
+            l.contains("connect_with(")
+                || l.contains("connect_lazy_with(")
+                || l.contains("SqlitePool::connect(")
+                || l.contains("SqlitePool::connect_lazy(")
+        };
+        assert!(
+            banned("    let pool = SqlitePool::connect_lazy(&uri)?;"),
+            "SqlitePool::connect_lazy skips the SQLCipher key and must be banned"
+        );
+        assert!(banned("SqlitePool::connect(&uri).await?"));
+        assert!(banned("SqlitePoolOptions::new().connect_with(opts).await?"));
+        assert!(
+            !banned("open_meridian_pool_at(&uri, key).await?"),
+            "the sanctioned opener must not be caught by the ban list"
+        );
+    }
+
     #[test]
     fn one_shot_clis_do_not_hand_build_a_pool() {
         for (name, src) in [
@@ -199,6 +292,13 @@ mod tests {
                     l.contains("connect_with(")
                         || l.contains("connect_lazy_with(")
                         || l.contains("SqlitePool::connect(")
+                        // `connect_lazy` was the hole this ban list still had:
+                        // it takes the URI directly, so it skips the key setup
+                        // exactly like `connect(` does, and nothing here
+                        // matched it. The lazy variant is the easier one to
+                        // reach for in a CLI, too - it does not need an await
+                        // at construction.
+                        || l.contains("SqlitePool::connect_lazy(")
                 })
                 .collect::<Vec<_>>();
             assert!(

--- a/src/health/observability.rs
+++ b/src/health/observability.rs
@@ -61,6 +61,26 @@ fn offline_verdict(
     None
 }
 
+/// The `openobserve` health check.
+///
+/// Always returns exactly one [`Check`], so callers can splice it into a report
+/// without length handling. [`offline_verdict`] answers everything decidable
+/// from configuration alone; only a **non-canonical** install with OTLP
+/// credentials configured falls through to the live `/healthz` probe below.
+///
+/// That asymmetry is the non-obvious part and it is deliberate: a packaged
+/// install ships to the release-baked central gateway, whose reachability is
+/// not the user's problem and must never be reported to them as a fault. A dev
+/// checkout ships to the engineer's own OpenObserve, where "is it up?" is
+/// exactly the question worth asking.
+///
+/// `_cfg` is unused - the answer comes from `settings.json` and the install
+/// mode, not the daemon config - and is kept for signature parity with the
+/// other `checks` functions in this module's siblings.
+///
+/// Never fails: every error path (client build, request, non-2xx) is folded
+/// into an Info or Warn [`Check`], because a health probe that errors out
+/// takes the whole report down with it.
 pub async fn checks(_cfg: &Config) -> Vec<Check> {
     let canonical = crate::observability::is_canonical_install();
     // `resolve_otlp_target()` costs one settings.json read — the same file the

--- a/src/health/platform.rs
+++ b/src/health/platform.rs
@@ -218,21 +218,6 @@ pub fn mcp_service() -> Vec<Check> {
     vec![mcp_verdict(built)]
 }
 
-/// The decision half of [`mcp_service`], split out so every branch is testable
-/// without a real filesystem. `None` = no source checkout found at all.
-///
-/// The MCP server is built from the repo, so this question only has an answer in
-/// a source checkout. `repo_root()` is None on a packaged install and the old
-/// code folded that into `false` — reporting "not built" with a remedy
-/// (`cd packages/meridian-mcp && …`) naming a directory the user does not have.
-/// A check that asserts a problem it has not looked for trains people to ignore
-/// the whole report.
-///
-/// The Info wording reports what was OBSERVED, not an inferred install type:
-/// "no Cargo.toml above `current_exe()`" is also true of a `cargo install`ed
-/// binary, a release binary copied into `~/bin`, or an `.app`-embedded one.
-/// Claiming "packaged install" would be the same conflation this module
-/// deliberately avoids for `daemon binary`.
 /// The four-way `.env` truth table, split out so each case is testable without
 /// a real `$HOME` or repo.
 ///
@@ -260,6 +245,21 @@ fn env_verdict(repo_env: bool, home_env: bool) -> Check {
     }
 }
 
+/// The decision half of [`mcp_service`], split out so every branch is testable
+/// without a real filesystem. `None` = no source checkout found at all.
+///
+/// The MCP server is built from the repo, so this question only has an answer in
+/// a source checkout. `repo_root()` is None on a packaged install and the old
+/// code folded that into `false` — reporting "not built" with a remedy
+/// (`cd packages/meridian-mcp && …`) naming a directory the user does not have.
+/// A check that asserts a problem it has not looked for trains people to ignore
+/// the whole report.
+///
+/// The Info wording reports what was OBSERVED, not an inferred install type:
+/// "no Cargo.toml above `current_exe()`" is also true of a `cargo install`ed
+/// binary, a release binary copied into `~/bin`, or an `.app`-embedded one.
+/// Claiming "packaged install" would be the same conflation this module
+/// deliberately avoids for `daemon binary`.
 fn mcp_verdict(built: Option<bool>) -> Check {
     match built {
         None => Check::info(

--- a/src/observability/install_mode.rs
+++ b/src/observability/install_mode.rs
@@ -44,11 +44,43 @@ pub fn is_canonical_install() -> bool {
         return false;
     };
     match std::env::current_exe() {
-        Ok(exe) => Some(exe) == staged_daemon_path(),
+        Ok(exe) => paths_are_same(&exe, staged_daemon_path().as_deref()),
         // `current_exe()` failing is rare (permissions, exotic sandboxing) —
         // fall back to the machine-wide marker file rather than guessing.
         Err(_) => meridian_dir.join(".env").exists(),
     }
+}
+
+/// Do these two paths name the same file, allowing for symlinks?
+///
+/// A plain `==` was wrong in one direction that matters: `current_exe()`
+/// resolves symlinks on macOS and Linux, while [`staged_daemon_path`] is
+/// assembled textually from [`meridian_core::paths::meridian_dir`] and is not
+/// resolved. A `$HOME` containing a symlink anywhere in it — a relocated home
+/// directory, `/tmp` → `/private/tmp` on macOS, an admin-managed mount — makes
+/// the two strings differ for a genuinely packaged install.
+///
+/// The consequence is silent and precisely the one [`is_canonical_install`]
+/// exists to prevent: the install reads as non-canonical, so central error
+/// reporting never ships and `health::observability::offline_verdict` reports
+/// the dev branch. A machine in that state is invisible to exactly the fleet
+/// telemetry it should be feeding.
+///
+/// Canonicalisation is attempted on both sides and falls back to the raw path
+/// when it fails — the staged path legitimately may not exist yet on a source
+/// build, and a missing file must read as "not canonical", not as an error.
+/// `health::platform::repo_root` canonicalises `current_exe()` for the same
+/// reason.
+fn paths_are_same(exe: &std::path::Path, staged: Option<&std::path::Path>) -> bool {
+    let Some(staged) = staged else {
+        return false;
+    };
+    if exe == staged {
+        return true;
+    }
+    let resolve =
+        |p: &std::path::Path| std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+    resolve(exe) == resolve(staged)
 }
 
 /// Absolute path the tray stages the daemon binary at
@@ -158,5 +190,59 @@ mod tests {
         } else {
             assert_eq!(name, "meridian");
         }
+    }
+
+    /// A symlinked `$HOME` must not read as a non-canonical install.
+    ///
+    /// `current_exe()` resolves symlinks; the staged path does not. Comparing
+    /// them raw made a genuinely packaged install look like a dev build
+    /// whenever anything in the path was a link - which silently disables
+    /// central error reporting, so the machines most worth hearing from go
+    /// quiet. This is the one failure mode with no visible symptom on the
+    /// affected machine at all.
+    #[test]
+    #[cfg(unix)]
+    fn a_symlinked_path_still_matches_the_staged_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        let exe = real.join("meridian");
+        std::fs::write(&exe, b"#!/bin/sh\n").unwrap();
+
+        // The shape of a relocated or symlinked home: same file, different
+        // spelling. `current_exe()` would hand us the resolved side.
+        let link = dir.path().join("linked");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        let staged_via_link = link.join("meridian");
+
+        assert_ne!(
+            exe, staged_via_link,
+            "the test is meaningless unless the two spellings differ"
+        );
+        assert!(
+            paths_are_same(&exe, Some(&staged_via_link)),
+            "a symlinked staged path must still match the running executable - \
+             treating it as a mismatch silently disables error reporting on a \
+             packaged install"
+        );
+    }
+
+    /// The other direction: genuinely different binaries must stay different,
+    /// and a missing staged path must read as "not canonical" rather than
+    /// erroring or matching.
+    #[test]
+    fn unrelated_or_absent_paths_do_not_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        std::fs::write(&a, b"a").unwrap();
+        std::fs::write(&b, b"b").unwrap();
+        assert!(!paths_are_same(&a, Some(&b)));
+        assert!(!paths_are_same(&a, None));
+        assert!(
+            !paths_are_same(&a, Some(&dir.path().join("never-existed"))),
+            "an unresolvable staged path must not match - a source build has \
+             no staged binary, and that is exactly the non-canonical case"
+        );
     }
 }

--- a/tray/src-tauri/src/daemon_lifecycle.rs
+++ b/tray/src-tauri/src/daemon_lifecycle.rs
@@ -702,5 +702,48 @@ mod tests {
             hold_arm.contains("prevent_exit"),
             "the ExitAction::Hold arm must call prevent_exit; found: {hold_arm:?}"
         );
+
+        // And the stop task must take the guard that releases a held exit if
+        // it dies. `a_dead_stop_task_releases_the_held_exit` drops the guard
+        // itself, so it proves the guard WORKS but not that anything HOLDS one
+        // - deleting the binding in `lib.rs` leaves every test green and the
+        // tray permanently unquittable after a panic. This is the only place
+        // that can catch it, for the same reason the assertions above live
+        // here: no unit test can reach `RunEvent::ExitRequested`.
+        //
+        // Bounded to the HoldAndStop arm rather than the whole file, on the
+        // same reasoning as the Hold arm above: a file-wide check would pass
+        // on the `use` line or a doc reference and never notice the binding
+        // itself had gone.
+        let stop_arm = LIB_SRC
+            .split_once("ExitAction::HoldAndStop =>")
+            .expect("the handler must have an ExitAction::HoldAndStop arm")
+            .1;
+        let stop_arm = stop_arm
+            .split_once("\n            }")
+            .map(|(arm, _)| arm)
+            .unwrap_or(stop_arm);
+        // Narrowed twice more, both times because a looser check was verified
+        // to stay green against a real regression:
+        //
+        // 1. Match the BINDING, not the bare type name - the arm carries a
+        //    comment naming the guard, so `contains("HeldExitGuard")` passes
+        //    on the prose after the binding is deleted.
+        // 2. Scan the SPAWNED TASK's body, not the whole arm. A guard bound in
+        //    the arm but outside the task is not a weaker version of this, it
+        //    is a broken one: it would drop when the synchronous handler
+        //    returns - immediately, while the stop is still in flight -
+        //    releasing the hold it exists to maintain and letting the process
+        //    tear down mid-stop. That is the original bug, restored.
+        let spawn_body = stop_arm
+            .split_once("spawn(async move {")
+            .expect("the HoldAndStop arm must spawn the stop task")
+            .1;
+        assert!(
+            spawn_body.contains("= daemon_lifecycle::HeldExitGuard;"),
+            "the spawned stop task must BIND a daemon_lifecycle::HeldExitGuard \
+             INSIDE the task, or a panic mid-stop leaves the exit held forever \
+             and the app cannot be quit at all; found: {spawn_body:?}"
+        );
     }
 }


### PR DESCRIPTION
Addresses all 7 findings from CodeRabbit's second review on #698. All verified against current code; none skipped.

The full-review pass reached code the first round never saw - #695, #696 and #697 landed on `pre-main` while round 1 was being fixed.

## The two with real consequences

**A symlinked `$HOME` silently disabled central error reporting** - `src/observability/install_mode.rs`

`current_exe()` resolves symlinks; `staged_daemon_path()` is assembled textually from `paths::meridian_dir()` and does not. Any link anywhere in the path - a relocated home directory, `/tmp` → `/private/tmp` on macOS, an admin-managed mount - makes the two strings differ for a **genuinely packaged install**. `is_canonical_install()` then returns `false`, error reporting never ships, and `health::observability::offline_verdict` reports the dev branch.

The affected machine shows no symptom at all. It simply goes quiet - which makes this the one failure mode that hides itself from the very telemetry meant to catch it, on a fleet we are currently using that telemetry to investigate.

Both sides are canonicalised now, falling back to the raw path when either does not resolve, so a not-yet-staged binary still correctly reads as non-canonical. `health::platform::repo_root` already did this for the same reason.

**The SessionEnd hook could hang Claude for ten seconds** - `src/coding_agent_session_ingest/hook.rs`

`open_pool_with_key` answers a keyless open of an *encrypted* file by **stalling to its ~10 s acquire timeout**, not by erroring - and that is precisely the misconfiguration this hook is most likely to meet (the key never reaching the CLI's environment). "Never block Claude" is a latency contract, not only an exit-code one.

The open is now bounded at 3 s. A timeout costs a *delayed* seal, never a lost one - the indexer's idle backstop seals the session regardless. The hook also now carries a span with a declared `outcome`/`otel.status_code`, since every path exits 0 and the span is the only evidence it ran at all.

## The rest

- **`HeldExitGuard` was not pinned to its call site.** The round-1 test drops the guard directly, so it proved the guard *works* but not that anything *takes* one. Narrowed twice, each time after verifying the looser version stayed green against a real regression: match the **binding** rather than the type name (the arm's own comment satisfies a name check), and scan the **spawned task's body** rather than the whole arm - a guard bound in the arm but outside the task is not a weaker version, it is a broken one, dropping the moment the synchronous handler returns and releasing the hold mid-stop.
- **The pool ban list missed `SqlitePool::connect_lazy(`** - it takes the URI directly and skips the SQLCipher key exactly like `connect(` does, and is the easier variant to reach for in a CLI since it needs no await.
- **`mcp_verdict`'s doc block was fused to the one above it**, so rustdoc rendered the MCP explanation on `env_verdict` and `mcp_verdict` had no docs at all.
- **Missing `///`** on `open_meridian_pool`, on `open_meridian_pool_at`'s parameters, and on `health::observability::checks`.

## Regression tests

Per the request on #698, each fix carries one, and the behavioural ones were proven red:

| Test | What it pins | Proven red by |
|---|---|---|
| `a_symlinked_path_still_matches_the_staged_binary` | packaged install stays canonical through a symlink | disabling canonicalisation |
| `the_exit_handler_is_actually_wired_into_run` (extended) | the guard is bound **inside** the spawned task | moving the guard outside the task |
| `a_keyless_open_of_an_encrypted_db_stalls_rather_than_erroring` | the stall the hook budget exists to cut | n/a - pins the premise |
| `the_db_open_budget_stays_under_the_acquire_timeout` | a budget above the timeout never fires | n/a - invariant |
| `the_hook_bounds_its_database_open` | the wrapper is actually at the call site | n/a - source scan |
| `the_ban_list_covers_the_lazy_constructor` | every key-skipping constructor is banned | n/a - table |
| `unrelated_or_absent_paths_do_not_match` | the fix does not over-match | n/a - negative case |

Two of these deserve a note. The stall test pins a **premise, not a behaviour of ours**: the hook's entire budget rationale collapses if a future sqlx or `db_crypto` change made that open fail fast, and nothing else in the suite would notice. And the budget invariant exists because a budget at or above the acquire timeout still compiles, still reads correctly, and does nothing whatsoever.

`cargo test --workspace`: **1551 passed**. `cargo clippy --workspace --all-targets`: clean. Full pre-push suite passed.

## Related

- #698 - the release PR these findings were raised on
- #700 - round 1 of the same review
