### PR TITLE
fix(notifications): remove the board hygiene digest toast

### DIFF
--- a/NOTIFICATIONS.md
+++ b/NOTIFICATIONS.md
@@ -249,9 +249,16 @@ registered`, `outbox toast delivered`, `notification action event: {...}`,
 | `system.disk_low` | `system_fault` | View | — (stamp only) — `~/.meridian`'s volume below 2 GB free |
 | `pm_worklog.{provider}` | `system_fault` | View | — (stamp only) — a worklog post to the tracker failed permanently |
 | `summariser.dead_letter` | `generic_link` | Open | — (stamp only) — daily digest of permanently-failed coding-agent summarisation, `dedup_key` scoped per day |
-| `board.hygiene` | `generic_link` | Open | — (stamp only) — daily digest of tickets needing attention, `dedup_key` scoped per day |
 | *(reserved)* | `verify_switch` | Yes · No · Reply… | — (PR 2: task-switch verification) |
 | *(generic)* | `generic_link` | Open | — (stamp only) |
+
+**Removed:** `board.hygiene` (daily digest of tickets needing attention) — its
+only job was to pull the user into the Board Cleanup flow, and that UI is
+disabled (`CleanupModal` is commented out in `MeridianTimelineShell.tsx`), so
+the toast pointed at a surface that no longer opens. Producer deleted from
+`src/intelligence/mod.rs::triage_after_sync`; migration 077 deletes the rows it
+already wrote, since undismissed banner rows never expire on their own.
+Re-enabling Board Cleanup means writing the producer back.
 
 There is no per-type settings toggle for any `event_key` — `event_allowed`
 gates every event the same way, on the master switch alone (plus quiet hours

--- a/src/intelligence/mod.rs
+++ b/src/intelligence/mod.rs
@@ -134,49 +134,88 @@ pub async fn run_pm_sync(meridian: &SqlitePool, config: &Config) -> Result<()> {
 /// Re-triage the cached board into `pm_task_curation` after a sync. Best-effort:
 /// a triage failure must never fail the sync (the board is still usable), so we
 /// log and move on.
+///
+/// This used to also enqueue a once-a-day `board.hygiene` digest toast ("N
+/// tickets on your board need a closer look"). That was removed: its whole
+/// purpose was to drive the user into the Board Cleanup flow, and that UI is
+/// disabled (see the commented-out `CleanupModal` in
+/// `ui/components/timeline/MeridianTimelineShell.tsx`), so the toast nudged
+/// toward a surface that no longer opens — and its deep link (`/tasks`) is not
+/// a route the static-exported dashboard has either. Re-enabling Board Cleanup
+/// means restoring a producer here; migration 077 clears the rows this one left
+/// behind. The triage data itself is untouched — `pm_task_curation` still feeds
+/// the tasks panel and `HygieneDialog`.
 async fn triage_after_sync(meridian: &SqlitePool) {
     match task_triage::run_triage(meridian, chrono::Utc::now()).await {
-        Ok(s) => {
-            tracing::debug!(
-                ready = s.ready,
-                needs_detail = s.needs_detail,
-                looks_stale = s.looks_stale,
-                not_sure = s.not_sure,
-                pruned = s.pruned,
-                "board triaged"
-            );
-            maybe_notify_board_hygiene(meridian, &s).await;
-        }
+        Ok(s) => tracing::debug!(
+            ready = s.ready,
+            needs_detail = s.needs_detail,
+            looks_stale = s.looks_stale,
+            not_sure = s.not_sure,
+            pruned = s.pruned,
+            "board triaged"
+        ),
         Err(e) => tracing::warn!(error = %e, "board triage after sync failed"),
     }
 }
 
-/// Daily digest: if the board has tickets needing attention (not `Ready`),
-/// enqueue one batched notification rather than nudging on every sync tick —
-/// same once-per-day dedup shape as [`crate::daily_plan::maybe_nudge`]. Safe
-/// to call unconditionally on every `triage_after_sync` pass (potentially
-/// several times a day): the outbox's UNIQUE constraint on `dedup_key` makes
-/// a repeat call within the same day a no-op, so no extra gate is needed.
-async fn maybe_notify_board_hygiene(pool: &SqlitePool, s: &task_triage::TriageSummary) {
-    let attention = s.needs_detail + s.looks_stale + s.not_sure;
-    if attention == 0 {
-        return;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn db() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("src/migrations").run(&pool).await.unwrap();
+        pool
     }
-    let today = meridian_core::date::today_string();
-    let dedup = format!("board.hygiene:{today}");
-    let body = format!(
-        "{attention} ticket{} on your board need{} a closer look.",
-        if attention == 1 { "" } else { "s" },
-        if attention == 1 { "s" } else { "" }
-    );
-    let n = crate::notifications::NewNotification::event(
-        &dedup,
-        "board.hygiene",
-        "Board hygiene",
-        &body,
-    )
-    .link("/tasks?integrations=1");
-    if let Err(e) = crate::notifications::enqueue(pool, n).await {
-        tracing::warn!(error = %e, "board hygiene digest enqueue failed");
+
+    /// Board Cleanup is disabled, so triage must stay silent: a board full of
+    /// tickets needing attention triages into `pm_task_curation` (the tasks
+    /// panel still reads it) without enqueueing a `board.hygiene` toast.
+    ///
+    /// The seed mirrors `task_triage::store`'s own fixtures: an empty
+    /// description on an active ticket buckets as `needs_detail`, and an
+    /// untouched-since-January backlog ticket as `looks_stale` — between them
+    /// the two counts the old digest summed over.
+    #[tokio::test]
+    async fn triage_after_sync_enqueues_no_board_hygiene_digest() {
+        let pool = db().await;
+        for (key, status, desc, updated) in [
+            ("THIN-1", "In Progress", "", "2026-06-11T00:00:00Z"),
+            ("STALE-1", "Backlog", "A", "2026-01-01T00:00:00Z"),
+        ] {
+            sqlx::query(
+                "INSERT INTO pm_tasks (task_key, provider, title, description_text, status_raw, \
+                    is_terminal, url, updated_at) \
+                 VALUES (?, 'jira', 'A title that is plenty specific', ?, ?, 0, 'http://x', ?)",
+            )
+            .bind(key)
+            .bind(desc)
+            .bind(status)
+            .bind(updated)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        triage_after_sync(&pool).await;
+
+        let triaged: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM pm_task_curation")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(triaged, 2, "triage itself must still run and persist");
+
+        let queued: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM notifications WHERE event_key = 'board.hygiene'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(queued, 0, "the board hygiene digest producer was removed");
     }
 }

--- a/src/migrations/077_drop_board_hygiene_notifications.sql
+++ b/src/migrations/077_drop_board_hygiene_notifications.sql
@@ -1,0 +1,14 @@
+-- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+--
+-- Retire the `board.hygiene` daily digest ("N tickets on your board need a
+-- closer look"). The producer is gone (src/intelligence/mod.rs), but removing
+-- it only stops FUTURE enqueues: rows already in the outbox stay live because
+-- `active_banners` filters on `banner_dismissed_at IS NULL` with no expiry, so
+-- every past day's digest keeps rendering in the dashboard banner until the
+-- user dismisses each one by hand. Delete them so an upgrade actually clears
+-- the notification the user is seeing.
+--
+-- Safe to run on a DB that never had one (0 rows), and safe against a future
+-- re-introduction: the dedup keys are day-scoped, so a restored producer starts
+-- clean rather than being deduped away by a deleted row.
+DELETE FROM notifications WHERE event_key = 'board.hygiene';


### PR DESCRIPTION
## What

Removes the daily `board.hygiene` notification - *"66 tickets on your board need a closer look."*

## Why

The toast exists to pull the user into the **Board Cleanup** flow. That UI is disabled - `CleanupModal` is commented out in `ui/components/timeline/MeridianTimelineShell.tsx` (both the import and the `'cleanup'` render branch), along with OverviewPanel's CTA. So the notification fires every day pointing at a surface that cannot open. Its deep link (`/tasks?integrations=1`) is dead too - the static-exported dashboard has no `tasks` route.

## Changes

**`src/intelligence/mod.rs`** - deletes `maybe_notify_board_hygiene` and its call from `triage_after_sync`. The doc comment on `triage_after_sync` records why it went and what re-enabling Board Cleanup would need.

**`src/migrations/077_drop_board_hygiene_notifications.sql`** - `DELETE FROM notifications WHERE event_key = 'board.hygiene'`.

This one is load-bearing, not tidiness. Removing the producer only stops *future* enqueues. `meridian_core::notifications::active_banners` selects on `banner_dismissed_at IS NULL` with no expiry filter beyond `expires_at` (which these rows don't set), so **every past day's digest keeps rendering in the dashboard banner** until dismissed one at a time. Without the migration the user installs the fix and still sees the thing they reported.

**`NOTIFICATIONS.md`** - drops the `board.hygiene` row from the producer table and adds a short "Removed" note so the next person doesn't reintroduce it.

## Not changed

`task_triage::run_triage` and `pm_task_curation` stay exactly as they were - the tasks panel and `HygieneDialog` read that data. Only the toast is gone. `generic_link` stays too; `summariser.dead_letter` still uses it.

## Test

`intelligence::tests::triage_after_sync_enqueues_no_board_hygiene_digest` - seeds a board with two attention-needing tickets, runs `triage_after_sync`, asserts triage still persisted 2 curation rows and that 0 `board.hygiene` rows were enqueued.

Verified it actually catches the regression: temporarily restoring an enqueue call makes it fail (`left: 1, right: 0`), and it passes once removed.

`cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test --workspace` green (914 + 276 + 226 + the rest, 0 failures). Pre-push suite (fmt, clippy, UI build, bun tests, cargo test, security audit) passed.

## Adjacent, not fixed here

`src/notices.rs:39` points every `pm.*` notice at the same dead `/tasks?integrations=1` link. Same broken route, different producer - worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)