### PR TITLE
fix: upgrade-safe walkthrough, honest founding-user copy, and a de-AI'd contact modal

### DIFF
--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -489,6 +489,10 @@ fn data_items(home: &Path) -> Vec<PathBuf> {
         "logs",
         "telemetry",
         "onboarded",
+        // The wizard's two companion markers: when it was opened, and whether the
+        // dashboard walkthrough that follows it has been armed (commands/setup.rs).
+        "setup_started",
+        "walkthrough_armed",
         "icon-cache",
         "daemon.sock",
     ]

--- a/tray/src-tauri/src/commands/setup.rs
+++ b/tray/src-tauri/src/commands/setup.rs
@@ -78,7 +78,12 @@ pub async fn setup_elapsed_secs() -> Option<u64> {
     u64::try_from(secs).ok()
 }
 
-/// Write `~/.meridian/onboarded` (RFC-3339 timestamp) to mark wizard completion.
+/// Name of the marker that ARMS the dashboard walkthrough — written when the wizard
+/// completes, read by [`walkthrough_is_armed`].
+const WALKTHROUGH_MARKER: &str = "walkthrough_armed";
+
+/// Write `~/.meridian/onboarded` (RFC-3339 timestamp) to mark wizard completion,
+/// and arm the dashboard walkthrough that follows it.
 /// Future tray launches skip the auto-open. Idempotent — safe to call more than once.
 #[tauri::command]
 #[tracing::instrument]
@@ -91,8 +96,43 @@ pub async fn mark_setup_complete() -> Result<(), String> {
     tokio::fs::write(dir.join("onboarded"), chrono::Local::now().to_rfc3339())
         .await
         .map_err(|e| format!("write onboarded: {e}"))?;
-    tracing::info!("setup: onboarded flag written");
+    // The walkthrough is the second half of onboarding, so finishing the wizard is
+    // what earns it. See [`walkthrough_is_armed`] for why it needs its own marker
+    // rather than reading `onboarded`.
+    tokio::fs::write(
+        dir.join(WALKTHROUGH_MARKER),
+        chrono::Local::now().to_rfc3339(),
+    )
+    .await
+    .map_err(|e| format!("write {WALKTHROUGH_MARKER}: {e}"))?;
+    tracing::info!("setup: onboarded flag written, walkthrough armed");
     Ok(())
+}
+
+/// Whether this install finished the wizard on a build that has the walkthrough —
+/// the one thing that entitles the dashboard to take the screen over on load.
+///
+/// # Why this is not `!is_first_run()`
+///
+/// The walkthrough's own "have you seen it" marker is a localStorage key, which no
+/// install predating it can possibly hold — so on its own it reads every existing
+/// user as brand new and hands a months-old install a full-screen tour of a product
+/// they already use. `onboarded` cannot fix that either: it is set for the existing
+/// user AND for the new one who just finished the wizard seconds ago, so it cannot
+/// tell them apart. This marker can, because only [`mark_setup_complete`] writes it
+/// and no upgrade back-fills it: absent means "onboarded before the walkthrough
+/// existed", which is exactly the population that must not see it.
+///
+/// Deliberately NOT consumed on read. Clearing it here would mean quitting mid-tour
+/// loses the walkthrough for good; the once-ever guarantee is the localStorage
+/// marker's job, written when the user finishes or skips.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn walkthrough_is_armed() -> bool {
+    match meridian_core::paths::meridian_dir() {
+        Some(dir) => dir.join(WALKTHROUGH_MARKER).exists(),
+        None => false,
+    }
 }
 
 /// The current OS, for the wizard to adapt its copy/steps — e.g. the

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -1196,6 +1196,7 @@ pub fn run() {
             commands::mark_setup_started,
             commands::setup_elapsed_secs,
             commands::mark_setup_complete,
+            commands::walkthrough_is_armed,
             commands::get_platform,
             commands::save_account_email,
             commands::get_account_email,

--- a/ui/__tests__/tutorial-sample-day.test.ts
+++ b/ui/__tests__/tutorial-sample-day.test.ts
@@ -1665,3 +1665,43 @@ describe('the closing asks: a delivery time, and the off switch', () => {
     expect(close).toContain('Close this window - Meridian keeps going')
   })
 })
+
+// The walkthrough auto-starts on a dashboard the user may have been running for
+// months, so the question "is this install entitled to it" has to be answered by
+// something an upgrade cannot get wrong. It was answered by a localStorage key
+// alone, which no existing install can hold - so every user who updated got a
+// full-screen tour of a product they already use, once, on first launch. Nothing
+// about that fails a build or logs a warning; it just happens to everybody at once.
+describe('the walkthrough does not ambush an install that predates it', () => {
+  const hook = readFileSync(new URL('../components/tutorial/useTutorial.tsx', import.meta.url), 'utf8')
+  const setup = readFileSync(new URL('../../tray/src-tauri/src/commands/setup.rs', import.meta.url), 'utf8')
+
+  it('gates the automatic start on the wizard-written marker, not just localStorage', () => {
+    expect(hook).toContain("'walkthrough_is_armed'")
+    // Before the surface is shown, not after - the check is worthless if the tour
+    // has already claimed the screen by the time it resolves.
+    expect(hook.indexOf("'walkthrough_is_armed'")).toBeLessThan(hook.indexOf('setRunning(true)\n      // Mirrored'))
+  })
+
+  it('treats an unanswerable check as NOT armed', () => {
+    // The two failure directions are not symmetric: a missed walkthrough is one
+    // menu item away, an unwanted one takes the whole screen.
+    expect(hook).toContain('.catch(() => false)')
+  })
+
+  it('only the wizard arms it, so no upgrade can back-fill the marker', () => {
+    expect(setup).toContain('const WALKTHROUGH_MARKER: &str = "walkthrough_armed"')
+    // Touched in exactly two places - written by completion, read by the gate.
+    // A third would mean something other than finishing the wizard can arm it,
+    // and "absent means this install predates the walkthrough" stops being true.
+    expect(setup.match(/dir\.join\(WALKTHROUGH_MARKER\)/g)?.length).toBe(2)
+  })
+
+  it('still lets someone ASK for it - the control exists for exactly these installs', () => {
+    // `explicitRef` is what separates "the app decided to show you this" from
+    // "you pressed Show me around". Gating the second on the marker would make
+    // the control dead on every pre-walkthrough install.
+    expect(hook).toContain('if (!explicitRef.current) {')
+    expect(hook.match(/explicitRef\.current = true/g)?.length).toBe(3)
+  })
+})

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -128,6 +128,36 @@ html.dark {
    (Toolbar.tsx's MeridianMark, ui/public/meridian-logo.png), not a token. */
 :root {
   --mer-pill-bg:       linear-gradient(135deg,#332A63,#241C49);
+  /* Meridian's own backdrop, for the surfaces that ARE the app rather than a
+     panel inside it and carry white content — so they cannot follow --win-bg
+     into lilac/blush, where it turns near-white and the text disappears.
+     Consumer: ReportModal's hero.
+
+     The base is ink's --win-bg ramp (deep indigo → near-black, same family, so
+     the modal reads as Meridian and not as a stray dark box). What sits on top
+     of it is the part that matters: three wide, low-alpha radial washes, none
+     of them centred and none of them fully inside the box. A single linear ramp
+     is flat — every pixel on a given scanline is the same colour — and flat is
+     what makes a dark header look like 2013 chrome. Off-centre radials give the
+     light a SOURCE, so the surface has a near corner and a far one.
+
+     Cool, deliberately. The washes are indigo and cyan, NOT violet: violet on a
+     Meridian surface means a model wrote it (see --draft-card-bg), and this is
+     the screen where a person reads your message. The one warm-leaning stop is
+     kept under 8% alpha and low in the box, where it reads as depth.
+
+     Alphas are low on purpose (.30 / .16 / .55 over a dark base) — a wash you
+     can NAME as a shape is a blob; these should only register as the surface
+     being unevenly lit. */
+  --mer-brand-bg:
+    radial-gradient(115% 85% at 8% -15%,  rgba(129,150,255,.30) 0%, rgba(129,150,255,0) 58%),
+    radial-gradient(95% 75% at 96% 2%,    rgba(86,201,255,.16)  0%, rgba(86,201,255,0)  62%),
+    radial-gradient(90% 115% at 72% 118%, rgba(72,58,158,.55)   0%, rgba(72,58,158,0)   64%),
+    linear-gradient(165deg,#3A3178 0%,#241E52 46%,#171331 78%,#100D24 100%);
+  /* The hairline of light along the top edge of that surface, and the shadow it
+     casts into the content below. Both are what stop a filled rectangle from
+     looking pasted on: real materials catch light on their top edge. */
+  --mer-brand-edge:    inset 0 1px 0 rgba(255,255,255,.14), 0 1px 0 rgba(0,0,0,.20);
   --mer-pill-border:   rgba(255,255,255,.12);
   --mer-pill-shadow:   0 14px 32px -12px rgba(50,30,110,.5), inset 0 1px 0 rgba(255,255,255,.1);
   /* Generating-hour takeover card accents (ring behind the icon, typing-dot

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -146,18 +146,32 @@ html.dark {
      the screen where a person reads your message. The one warm-leaning stop is
      kept under 8% alpha and low in the box, where it reads as depth.
 
-     Alphas are low on purpose (.30 / .16 / .55 over a dark base) — a wash you
-     can NAME as a shape is a blob; these should only register as the surface
-     being unevenly lit. */
+     Alphas are low on purpose — a wash you can NAME as a shape is a blob; these
+     should only register as the surface being unevenly lit. The base ramp is
+     kept ABOVE near-black (#100D24 was the old floor and made the lower third
+     read as a dead band); ending at #191542 keeps the whole panel luminous, and
+     the depth comes from the washes rather than from draining the colour out. */
   --mer-brand-bg:
-    radial-gradient(115% 85% at 8% -15%,  rgba(129,150,255,.30) 0%, rgba(129,150,255,0) 58%),
-    radial-gradient(95% 75% at 96% 2%,    rgba(86,201,255,.16)  0%, rgba(86,201,255,0)  62%),
-    radial-gradient(90% 115% at 72% 118%, rgba(72,58,158,.55)   0%, rgba(72,58,158,0)   64%),
-    linear-gradient(165deg,#3A3178 0%,#241E52 46%,#171331 78%,#100D24 100%);
+    radial-gradient(120% 95% at 6% -20%,  rgba(150,168,255,.38) 0%, rgba(150,168,255,0) 60%),
+    radial-gradient(85%  70% at 98% -6%,  rgba(94,214,255,.20)  0%, rgba(94,214,255,0)  58%),
+    radial-gradient(95% 110% at 78% 125%, rgba(96,78,196,.46)   0%, rgba(96,78,196,0)   66%),
+    linear-gradient(158deg,#4A3F92 0%,#332A70 40%,#241E56 72%,#191542 100%);
   /* The hairline of light along the top edge of that surface, and the shadow it
      casts into the content below. Both are what stop a filled rectangle from
      looking pasted on: real materials catch light on their top edge. */
-  --mer-brand-edge:    inset 0 1px 0 rgba(255,255,255,.14), 0 1px 0 rgba(0,0,0,.20);
+  --mer-brand-edge:    inset 0 1px 0 rgba(255,255,255,.16), 0 1px 0 rgba(0,0,0,.22);
+
+  /* The CTA that belongs to that surface — same indigo family, compressed into
+     a button-sized ramp. NOT --btn-primary-bg (flat --t-accent violet): the
+     modal's whole correction was getting the AI colour off a screen about
+     reaching a person, and leaving the one filled control in it undid that at
+     the exact moment the user acts. Lit top-left to bottom-right so it agrees
+     with the hero's light source rather than fighting it, with the same
+     top-edge highlight the hero carries and a shadow in its own hue so it lifts
+     off the panel instead of casting grey. */
+  --mer-cta-bg:        linear-gradient(135deg,#5A4CC4 0%,#453AA0 52%,#332B7C 100%);
+  --mer-cta-bg-hover:  linear-gradient(135deg,#6555D8 0%,#4E42B4 52%,#3B318C 100%);
+  --mer-cta-shadow:    inset 0 1px 0 rgba(255,255,255,.20), 0 6px 16px -8px rgba(48,38,120,.75);
   --mer-pill-border:   rgba(255,255,255,.12);
   --mer-pill-shadow:   0 14px 32px -12px rgba(50,30,110,.5), inset 0 1px 0 rgba(255,255,255,.1);
   /* Generating-hour takeover card accents (ring behind the icon, typing-dot
@@ -825,6 +839,27 @@ html.density-comfy   .density-pad { padding-top: 1.25rem; padding-bottom: 1.25re
 .mt-card-hover.mt-card-selected {
   transform: translateY(-2px);
   box-shadow: 0 16px 32px -12px rgba(40, 30, 90, 0.32);
+}
+
+/* Meridian's filled CTA — the gradient counterpart to --btn-primary-bg's flat
+   fill, in the same indigo family as --mer-brand-bg so a button sitting under
+   that surface belongs to it. A real CSS rule for the same reason as
+   .mt-card-hover above: the fill and its hover cannot be inline, because an
+   inline background always beats :hover and would silently kill the hover
+   state. Consumer: ReportModal's "Suggest a feature". */
+.mt-cta {
+  background: var(--mer-cta-bg);
+  box-shadow: var(--mer-cta-shadow);
+  transition: background 0.18s, box-shadow 0.18s, transform 0.18s;
+}
+.mt-cta:hover {
+  background: var(--mer-cta-bg-hover);
+  transform: translateY(-1px);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.24), 0 10px 22px -9px rgba(48,38,120,.85);
+}
+.mt-cta:active {
+  transform: translateY(0);
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.28);
 }
 
 /* Plain list-row hover (candidate pickers etc) — same reasoning as

--- a/ui/app/setup/data.ts
+++ b/ui/app/setup/data.ts
@@ -30,11 +30,14 @@ export interface PermissionMeta {
   required: boolean
 }
 
-// ── Welcome screen — early-customer badge ─────────────────────────────────────
-// Hand-updated placeholder, not a live counter: no shared signup-count source
-// exists yet (no users table, no waitlist API - Clerk's frontend SDK can't
-// report a total). Bump this by hand as the customer base grows.
-export const EARLY_CUSTOMER_NUMBER = 42
+// The welcome screen's early-customer count lived here as a hand-edited constant
+// (42) and was rendered twice: as "No. 042" beside the Founding user mark, and
+// inside "one of the first 42 people". Neither was true — nothing counts signups
+// (no users table, no waitlist API, and Clerk's frontend SDK cannot report a
+// total), so every user was told the same number and the first of the two told
+// them it was their own position. Removed rather than made accurate: the welcome
+// screen reads fine without a count, and this is the wrong layer to reintroduce
+// one at. If a real figure is ever wanted, it needs a live source, not a literal.
 
 export const PERMISSIONS: PermissionMeta[] = [
   {

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -8,7 +8,7 @@
 
 import type { ReactNode } from 'react'
 import { Btn, Check, DISPLAY, Logo, PermIcon, PermissionPreview, Row } from './atoms'
-import { EARLY_CUSTOMER_NUMBER, PERMISSIONS } from './data'
+import { PERMISSIONS } from './data'
 import type { NotifState, PermissionMeta } from './data'
 import type { IntegrationsResponse } from '@/lib/api-types'
 import { TRACKERS } from '@/lib/integrations'
@@ -347,22 +347,19 @@ export function Welcome({ onBegin, ready, error, onRetry }: {
             <span style={{ fontFamily: 'var(--font-sans)', fontWeight: 700, fontSize: 29, lineHeight: 1, letterSpacing: '-.02em', color: 'var(--t-title)' }}>Meridian</span>
           </div>
 
-          {/* A NUMBERED EDITION, not a badge. This is a real fact about this
-             person - they are the Nth user - and a fact reads as true when it is
-             stated plainly and as marketing when it is put in a coloured capsule
-             with a glow under it. So: no fill, no shadow, no radius; the label
-             small and quiet, the number in mono at title weight because the
-             NUMBER is the thing worth keeping. A hairline on the left ties it to
-             the brand row without drawing a box around it. */}
+          {/* A MARK, not a numbered edition. This carried "No. 042" beside it,
+             which read as a real fact about the person holding the screen - their
+             place in the queue - and was not one: the number was a hand-edited
+             constant, so every user was told they were the 42nd. A number that
+             specific is exactly the kind a reader checks the rest of the product
+             against, so a false one costs more than it ever bought. What is left
+             is true of everyone who sees it. No fill, no shadow, no radius; a
+             hairline on the left ties it to the brand row without drawing a box
+             around it. */}
           <div className="mer-pop shrink-0 flex items-baseline" style={{
-            gap: 9, paddingLeft: 16, borderLeft: '1px solid var(--t-hair)',
+            paddingLeft: 16, borderLeft: '1px solid var(--t-hair)',
           }}>
             <span className="mt-chip" style={{ color: 'var(--t-faint)', letterSpacing: '.08em' }}>Founding user</span>
-            <span className="font-mono" style={{
-              fontSize: 17, fontWeight: 700, letterSpacing: '.02em', color: 'var(--t-title)',
-            }}>
-              No. {String(EARLY_CUSTOMER_NUMBER).padStart(3, '0')}
-            </span>
           </div>
         </div>
 
@@ -386,8 +383,8 @@ export function Welcome({ onBegin, ready, error, onRetry }: {
         </h1>
 
         <p style={{ fontSize: 14, lineHeight: 1.65, color: 'var(--t-muted)', marginTop: 16, maxWidth: 560, textWrap: 'pretty' }}>
-          You&apos;re one of the first <span style={{ fontWeight: 600, color: 'var(--t-title)' }}>{EARLY_CUSTOMER_NUMBER}</span> people
-          helping us build Meridian. We hope it makes a real difference for you, too.
+          You&apos;re one of the first people helping us build Meridian. We hope it
+          makes a real difference for you, too.
         </p>
 
         {/* WHAT IT DOES, as three plain lines. They were chips - filled circular

--- a/ui/components/timeline/ReportModal.tsx
+++ b/ui/components/timeline/ReportModal.tsx
@@ -161,14 +161,20 @@ export function ReportModal({ onClose }: { onClose: () => void }) {
             prefilled form. */}
         <div style={{ padding: '8px 22px 22px' }}>
           <div className="flex gap-2">
+            {/* --t-title, not --t-muted: this is one of two equal-weight
+                actions, and muted grey made it read as the disabled twin of the
+                one beside it. --t-title rather than a literal #000 so it stays
+                the theme's own strongest text colour - near-black in
+                lilac/blush, near-white in ink, where a hardcoded black on a
+                dark control would be unreadable. */}
             <a href={ISSUE_URL('bug_report.yml')} target="_blank" rel="noopener noreferrer"
-              className="flex-1 text-center no-underline"
-              style={{ border: '1px solid var(--t-ctrl-border)', background: 'var(--t-ctrl)', color: 'var(--t-muted)', borderRadius: 12, padding: 11, font: "700 12.5px var(--font-sans)" }}>
+              className="mt-card-hover flex-1 text-center no-underline"
+              style={{ border: '1px solid var(--t-ctrl-border)', background: 'var(--t-ctrl)', color: 'var(--t-title)', borderRadius: 12, padding: 11, font: "700 12.5px var(--font-sans)" }}>
               Report a bug
             </a>
             <a href={ISSUE_URL('feature_request.yml')} target="_blank" rel="noopener noreferrer"
-              className="flex-1 text-center no-underline"
-              style={{ border: 'none', background: 'var(--btn-primary-bg)', color: '#fff', borderRadius: 12, padding: 11, font: "700 12.5px var(--font-sans)" }}>
+              className="mt-cta flex-1 text-center no-underline"
+              style={{ border: 'none', color: '#fff', borderRadius: 12, padding: 11, font: "700 12.5px var(--font-sans)" }}>
               Suggest a feature
             </a>
           </div>

--- a/ui/components/timeline/ReportModal.tsx
+++ b/ui/components/timeline/ReportModal.tsx
@@ -3,9 +3,9 @@
 // "Report" / get-in-touch modal, ported from the Meridian Timeline design
 // mock (Claude Design project b8656e29-ae04-4f69-b17f-d5fab4d00f3a, the
 // REPORT / GET IN TOUCH MODAL block) opened from the toolbar nav pill's
-// "Report" item (see Toolbar.tsx's MeridianNavPill). The gradient hero header
-// is a fixed brand treatment — deliberately independent of the light/blush/ink
-// surface theme, same rule the nav pill's dark lockup follows — everything
+// "Report" item (see Toolbar.tsx's MeridianNavPill). The hero header IS the nav
+// pill's dark lockup (`--mer-pill-bg`) — deliberately independent of the
+// light/blush/ink surface theme — everything
 // below it (channel cards, buttons, footer) uses the live `--t-*` tokens so it
 // matches whichever theme is active. Overlay/backdrop/Escape-to-close mirrors
 // ModalShell; the hero header replaces ModalShell's plain title bar so this
@@ -15,6 +15,23 @@
 
 import { useEffect } from 'react'
 
+import { MeridianMark } from './Toolbar'
+
+/** The public repo the in-app links point at - issues, releases, and the two
+ *  report buttons below. One constant so the four call sites cannot drift onto
+ *  different orgs, which is how the old `github.com/meridiona` (no repo, wrong
+ *  case) survived. */
+const REPO = 'https://github.com/Meridiona/meridian'
+
+/** Deep link to a prefilled new-issue form. `template` is a file name under
+ *  `.github/ISSUE_TEMPLATE/`. */
+const ISSUE_URL = (template: string) => `${REPO}/issues/new?template=${template}`
+
+// TWO CHANNELS, NOT FOUR. Discord (`discord.gg/meridiona`) and X
+// (`@meridionaapp`) were listed before either existed, so both links landed on
+// a dead invite and an empty profile - a contact screen whose whole promise is
+// "a person reads every message" is the worst place in the product to have a
+// link that goes nowhere. They come back when there is something behind them.
 const CHANNELS: {
   name: string
   handle: string
@@ -23,8 +40,8 @@ const CHANNELS: {
 }[] = [
   {
     name: 'Email',
-    handle: 'hey@meridiona.com',
-    href: 'mailto:hey@meridiona.com',
+    handle: 'company@meridiona.com',
+    href: 'mailto:company@meridiona.com',
     icon: (
       <svg width="17" height="17" viewBox="0 0 24 24" fill="none">
         <rect x="2.5" y="5" width="19" height="14" rx="3" stroke="#EA4335" strokeWidth="1.8" />
@@ -33,32 +50,12 @@ const CHANNELS: {
     ),
   },
   {
-    name: 'Discord',
-    handle: 'Join the community',
-    href: 'https://discord.gg/meridiona',
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="#5865F2">
-        <path d="M19.5 5.6A16 16 0 0 0 15.5 4.4l-.2.4a12 12 0 0 1 3.4 1.7 11 11 0 0 0-9.4 0 12 12 0 0 1 3.4-1.7l-.2-.4A16 16 0 0 0 4.5 5.6 16.5 16.5 0 0 0 1.7 17a16 16 0 0 0 4.9 2.5l.6-1a10.5 10.5 0 0 1-1.7-.8l.4-.3a11.5 11.5 0 0 0 10.2 0l.4.3a10.5 10.5 0 0 1-1.7.8l.6 1A16 16 0 0 0 22.3 17 16.5 16.5 0 0 0 19.5 5.6ZM8.6 14.4c-.9 0-1.7-.9-1.7-1.9s.8-1.9 1.7-1.9 1.7.9 1.7 1.9-.8 1.9-1.7 1.9Zm6.8 0c-.9 0-1.7-.9-1.7-1.9s.8-1.9 1.7-1.9 1.7.9 1.7 1.9-.8 1.9-1.7 1.9Z" />
-      </svg>
-    ),
-  },
-  {
     name: 'GitHub',
     handle: 'Issues & releases',
-    href: 'https://github.com/meridiona',
+    href: `${REPO}/issues`,
     icon: (
       <svg width="18" height="18" viewBox="0 0 24 24" style={{ fill: 'var(--t-title)' }}>
         <path d="M12 2A10 10 0 0 0 8.8 21.5c.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.3-3.4-1.3-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.5 2.3 1.1 2.9.8.1-.6.3-1.1.6-1.3-2.2-.3-4.6-1.1-4.6-4.9 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.6 0 0 .8-.3 2.7 1a9.4 9.4 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.3.2 2.3.1 2.6.6.7 1 1.6 1 2.7 0 3.8-2.4 4.6-4.6 4.9.3.3.6.9.6 1.8v2.7c0 .3.2.6.7.5A10 10 0 0 0 12 2Z" />
-      </svg>
-    ),
-  },
-  {
-    name: 'X',
-    handle: '@meridionaapp',
-    href: 'https://x.com/meridionaapp',
-    icon: (
-      <svg width="15" height="15" viewBox="0 0 24 24" style={{ fill: 'var(--t-title)' }}>
-        <path d="M18.2 2.5h3.3l-7.2 8.2 8.5 11.3h-6.7l-5.2-6.9-6 6.9H1.6l7.7-8.8L1.2 2.5H8l4.7 6.3 5.5-6.3Zm-1.2 17.8h1.8L7.1 4.3H5.2l11.8 16Z" />
       </svg>
     ),
   },
@@ -77,22 +74,50 @@ export function ReportModal({ onClose }: { onClose: () => void }) {
       <div className="w-full rounded-[22px] overflow-hidden bg-card"
         style={{ maxWidth: 500, maxHeight: '92%', boxShadow: '0 44px 90px -34px rgba(20,10,60,0.6)' }}
         onClick={e => e.stopPropagation()}>
-        {/* hero header — fixed brand gradient, theme-independent */}
+        {/* Hero header - Meridian's own backdrop (--mer-brand-bg), theme-independent.
+            NOT --draft-card-bg, which this used to be. That token is the fill of
+            an AI-drafted card, and in Meridian violet has one meaning: a model
+            wrote this. Painting "get in touch with the team" in it said the
+            opposite of what the screen is for - the whole point of the copy is
+            that a person reads every message.
+
+            THE TWO WHITE DISCS ARE GONE. This carried a 130px and a 120px flat
+            white circle bled off opposite corners at 14% and 10% - the standard
+            2015 "decorated header" move, and the reason the panel looked dated
+            even after the colour was fixed. They are flat (one alpha edge to
+            edge), they are hard-edged (a disc you can trace is decoration, not
+            light), and they fought the gradient underneath instead of belonging
+            to it. The lighting now lives in the token as soft off-centre
+            radials, so it reads as a lit surface rather than a rectangle with
+            shapes stuck on it. */}
         <div className="relative text-center overflow-hidden"
-          style={{ padding: '28px 26px 24px', background: 'var(--draft-card-bg)' }}>
-          <div className="absolute rounded-full pointer-events-none"
-            style={{ left: -30, top: -30, width: 130, height: 130, background: 'rgba(255,255,255,.14)' }} />
-          <div className="absolute rounded-full pointer-events-none"
-            style={{ right: -24, bottom: -40, width: 120, height: 120, background: 'rgba(255,255,255,.1)' }} />
+          style={{
+            padding: '30px 26px 26px',
+            background: 'var(--mer-brand-bg)',
+            boxShadow: 'var(--mer-brand-edge)',
+          }}>
           <button onClick={onClose} aria-label="Close"
-            className="absolute inline-flex items-center justify-center rounded-full"
-            style={{ right: 16, top: 16, width: 30, height: 30, border: 'none', background: 'rgba(255,255,255,.22)', color: '#fff', zIndex: 2 }}>
+            className="mt-card-hover absolute inline-flex items-center justify-center rounded-full"
+            style={{ right: 16, top: 16, width: 30, height: 30, border: '1px solid rgba(255,255,255,.16)', background: 'rgba(255,255,255,.10)', color: '#fff', zIndex: 2 }}>
             <span className="text-[15px] leading-none">×</span>
           </button>
           <div className="relative">
-            <div className="mx-auto rounded-[17px] flex items-center justify-center"
-              style={{ width: 56, height: 56, background: 'rgba(255,255,255,.16)', border: '1px solid rgba(255,255,255,.28)', fontSize: 26, color: '#fff' }}>
-              ✦
+            {/* Glass, not a flat white square: a translucent fill under a
+                brighter top-edge highlight, so the chip picks up the same light
+                the surface behind it does. The mark is the app logo rather than
+                a ✦ - a sparkle is this product's AI signifier, and it was
+                sitting at the top of the one screen that is explicitly about
+                reaching a human. Via MeridianMark, not a raw <img>: the source
+                PNG carries app-icon safe-area padding, so anything that does not
+                apply its 166% crop renders a mark floating in dead space. */}
+            <div className="mx-auto rounded-[17px] flex items-center justify-center overflow-hidden"
+              style={{
+                width: 56, height: 56,
+                background: 'rgba(255,255,255,.10)',
+                border: '1px solid rgba(255,255,255,.20)',
+                boxShadow: 'inset 0 1px 0 rgba(255,255,255,.22), 0 8px 20px -10px rgba(0,0,0,.6)',
+              }}>
+              <MeridianMark size={30} />
             </div>
             <p className="mt-modal-title mt-4" style={{ color: '#fff' }}>You&apos;re shaping Meridian</p>
             <p className="mt-body-sm mx-auto mt-2" style={{ color: 'rgba(255,255,255,.9)', maxWidth: 360 }}>
@@ -124,20 +149,31 @@ export function ReportModal({ onClose }: { onClose: () => void }) {
           </div>
         </div>
 
-        {/* quick report */}
+        {/* Quick report. These two open the REPO'S OWN issue forms
+            (.github/ISSUE_TEMPLATE/), not a mailto - the templates already exist
+            and already ask the questions a useful report needs, which an empty
+            mail draft does not. It also means a report is searchable, dedupes
+            against the ones already filed, and the person who filed it can
+            follow the fix; a mail thread gives none of that and has to be
+            triaged by hand. Keep these template file names in step with that
+            directory - GitHub silently falls back to the template CHOOSER on an
+            unknown `template=`, which still works but drops the label and the
+            prefilled form. */}
         <div style={{ padding: '8px 22px 22px' }}>
           <div className="flex gap-2">
-            <a href="mailto:hey@meridiona.com?subject=Bug%20report" className="flex-1 text-center no-underline"
+            <a href={ISSUE_URL('bug_report.yml')} target="_blank" rel="noopener noreferrer"
+              className="flex-1 text-center no-underline"
               style={{ border: '1px solid var(--t-ctrl-border)', background: 'var(--t-ctrl)', color: 'var(--t-muted)', borderRadius: 12, padding: 11, font: "700 12.5px var(--font-sans)" }}>
               Report a bug
             </a>
-            <a href="mailto:hey@meridiona.com?subject=Feature%20suggestion" className="flex-1 text-center no-underline"
+            <a href={ISSUE_URL('feature_request.yml')} target="_blank" rel="noopener noreferrer"
+              className="flex-1 text-center no-underline"
               style={{ border: 'none', background: 'var(--btn-primary-bg)', color: '#fff', borderRadius: 12, padding: 11, font: "700 12.5px var(--font-sans)" }}>
               Suggest a feature
             </a>
           </div>
           <p className="text-center" style={{ font: "500 10.5px var(--font-sans)", color: 'var(--t-faint-2)', marginTop: 12 }}>
-            Thank you for helping Meridian get better · we usually reply within a day 💜
+            Thank you for helping Meridian get better · we usually reply within a day
           </p>
         </div>
       </div>

--- a/ui/components/tutorial/useTutorial.tsx
+++ b/ui/components/tutorial/useTutorial.tsx
@@ -516,6 +516,15 @@ export function useTutorial(opts: {
   // Start once, on the first ready render for a user who has not seen it.
   const startedRef = useRef(false)
 
+  // Set by the three explicit entry points below, and read by the start effect to
+  // skip the "is this install entitled to the walkthrough" check.
+  //
+  // That check exists for the AUTOMATIC start only. Someone who pressed "Show me
+  // around" has asked for the tour in so many words, and an install that predates
+  // the walkthrough is precisely the one most likely to press it — refusing them
+  // would make the control dead on the only machines it matters on.
+  const explicitRef = useRef(false)
+
   // Replay hook. The walkthrough is a once-ever surface gated on a marker, so
   // without this the only way to see it again is deleting that key from the
   // console — every iteration, for anyone building or QAing it. Three ways in:
@@ -525,6 +534,7 @@ export function useTutorial(opts: {
   //   window.__meridianTour() from the console (no reload)
   const [replayNonce, setReplayNonce] = useState(0)
   const replay = useCallback(() => {
+    explicitRef.current = true
     try { localStorage.removeItem(SEEN_KEY) } catch { /* private mode */ }
     // Clear the dev jump too, so the ordinary Replay always means the WHOLE
     // walkthrough. Without this, one use of the shortcut latches the tour into
@@ -537,6 +547,7 @@ export function useTutorial(opts: {
   }, [])
 
   const replayFromDay = useCallback(() => {
+    explicitRef.current = true
     try { localStorage.setItem(DEV_FROM_KEY, 'day') } catch { /* private mode */ }
     try { localStorage.removeItem(SEEN_KEY) } catch { /* private mode */ }
     startedRef.current = false
@@ -570,8 +581,11 @@ export function useTutorial(opts: {
     return () => { delete w.__meridianTour; delete w.__meridianTourDay }
   }, [replay, replayFromDay])
 
+  // Declared BEFORE the start effect on purpose: effects run in declaration order,
+  // so `explicitRef` is already set by the time the start effect reads it.
   useEffect(() => {
     if (!new URLSearchParams(window.location.search).has('tour')) return
+    explicitRef.current = true
     try { localStorage.removeItem(SEEN_KEY) } catch { /* private mode */ }
   }, [])
 
@@ -603,12 +617,28 @@ export function useTutorial(opts: {
 
     const ctrl = new AbortController()
     abortRef.current = ctrl
-    setRunning(true)
-    // Mirrored into the module flag so screens BELOW the shell can tell they are
-    // being demonstrated rather than used - see `isTutorialRunning`.
-    setTutorialRunning(true)
     ;(async () => {
       if (ctrl.signal.aborted) return
+      // THE UPGRADE GUARD. `SEEN_KEY` above answers "has this browser profile been
+      // shown the walkthrough", and for every install that predates the walkthrough
+      // the honest answer is no - so on its own it hands a full-screen tour of the
+      // product to someone who has been using it for months, on the first launch
+      // after an update. `walkthrough_is_armed` is the missing half: it is written
+      // only by the wizard's own completion, so absent means "onboarded before this
+      // existed" and the tour stays out of the way.
+      //
+      // Failure is treated as NOT armed. The cost of being wrong in that direction
+      // is a walkthrough the user can still reach from Settings; the other way it is
+      // an unskippable-looking takeover of a working dashboard.
+      if (!explicitRef.current) {
+        const armed = await load<boolean>('/api/walkthrough-armed', 'walkthrough_is_armed')
+          .catch(() => false)
+        if (!armed || ctrl.signal.aborted) return
+      }
+      setRunning(true)
+      // Mirrored into the module flag so screens BELOW the shell can tell they are
+      // being demonstrated rather than used - see `isTutorialRunning`.
+      setTutorialRunning(true)
       try {
         await runScript(stageRef.current)
       } catch (e) {


### PR DESCRIPTION
Four fixes found while auditing what existing DMG users hit when they update onto the #706 changes, plus the contact-modal pass that came out of it.

## 1. The walkthrough ambushed every existing user

`useTutorial` gated its automatic start on a localStorage key alone (`meridian.walkthrough.seen.v1`). No install that predates the walkthrough can hold one, so the honest answer to "has this user seen it" was **no for every existing user** - and the first launch after updating opened a full-screen tour of a product they had been using for months.

`~/.meridian/onboarded` cannot separate the two populations: it is set both for the existing user and for the new one who finished the wizard seconds ago. So wizard completion now writes its own marker, `~/.meridian/walkthrough_armed`, read by a new `walkthrough_is_armed` command. Nothing back-fills it on upgrade, so **absent means "onboarded before this existed"** - exactly the group that must not be shown it.

- Covers the **automatic** start only. "Show me around", `?tour=1` and the console entry point set `explicitRef` and bypass it, because a pre-walkthrough install is the one most likely to press that control.
- Runs **before** `setRunning(true)`, so the tour never claims the screen and then retreats.
- An unanswerable check reads as **not armed**: a missed walkthrough is one menu item away, an unwanted one takes the whole screen.
- Uninstall now also removes `walkthrough_armed` and `setup_started`; the latter had been left behind since that marker was added.

## 2. The founding-user number was invented

The welcome screen rendered `No. 042` beside the Founding user mark and "one of the first 42 people" below it, both from a hand-edited constant. Nothing counts signups, so the number was identical for everyone - and the first of the two presented it as *this reader's own position in the queue*.

Removed rather than corrected: the screen reads fine without a count, and a real figure needs a live source, not a literal in a data file. The `Founding user` mark stays; it is true of everyone who sees the screen.

## 3. The get-in-touch modal was painted in the AI colour

`ReportModal`'s hero used `--draft-card-bg` - the fill of an AI-drafted card. Violet has one meaning on a Meridian surface: a model wrote this. It sat at the top of the one screen whose entire promise is that a person reads every message.

- New theme-independent `--mer-brand-bg`: the app's own backdrop under three wide off-centre radial washes, so the surface has a light source instead of one flat scanline colour. Washes are indigo and cyan, never violet.
- The two flat white discs bled off the corners are gone - a disc you can trace is decoration, not light, and they were most of why the panel read as dated after the hue was fixed.
- `✦` becomes the real brand mark via `MeridianMark`, so it gets the 166% safe-area crop instead of floating in the source PNG's padding. A sparkle is this product's AI signifier and had no business here either.
- "Suggest a feature" moves off `--btn-primary-bg` (the same flat violet) onto new `--mer-cta-*` gradient tokens in the hero's family. Real `.mt-cta` class, not inline - an inline background always beats `:hover` and would silently kill the hover state.
- "Report a bug" moves from `--t-muted` to `--t-title`; muted grey beside a filled button read as its disabled twin. The token rather than a literal black, so it stays near-white in `ink`.

## 4. Contact channels that went nowhere

Discord (`discord.gg/meridiona`) and X (`@meridionaapp`) were listed before either existed, so a screen promising a reply linked to a dead invite and an empty profile. Both removed until there is something behind them.

Email is now `company@meridiona.com`. GitHub points at `Meridiona/meridian/issues` (was `github.com/meridiona` - no repo, wrong case), and **Report a bug / Suggest a feature open the repo's own issue forms** rather than an empty mail draft: the templates already ask what a useful report needs, and an issue is searchable, dedupes against what is already filed, and lets the reporter follow the fix.

## Also checked, no change needed

Migrations 077/079/080 are additive and each reasons explicitly about the pre-migration row; the gap at 078 is harmless (sqlx applies by version, not contiguity) and `reconcile_migration_checksums` covers the renumber. The tray stops, restages and restarts the daemon on version bump, and every reader that touches a new column degrades to empty rather than erroring in the seconds before it lands. `LlmProviderGate` only renders behind the `gate` prop, so Settings never re-interviews anyone. Copilot is out of the chooser but remains a valid stored value with a banner.

## Follow-ups not done here

- `.github/ISSUE_TEMPLATE/config.yml` still routes privacy questions to a personal address.
- The bug form asks the user to type version / OS / chip, which the app already knows. GitHub issue forms prefill from query params keyed on field `id`, so the in-app button could hand those over - plus a Support ID field, which is the only thing joining a report to that machine's error rows.

## Tests

- 4 new source-scanning tests pinning the walkthrough gate, the fail-closed catch, the two-and-only-two marker touch points, and the explicit-request bypass
- `cargo clippy --workspace --all-targets -- -D warnings` clean; **1614** Rust tests pass
- **704** UI tests pass; `tsc --noEmit` and `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)