### PR TITLE
fix(ci): make the release build actually restore its warm cache

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -85,17 +85,30 @@ concurrency:
 permissions:
   contents: read
 
+# *** THIS BLOCK IS PART OF THE CACHE KEY. IT MUST MATCH release-build.yml's. ***
+#
+# Not "should" — the cache this whole workflow exists to write is UNREADABLE by
+# release-build.yml unless every CARGO_*/RUSTC_* name AND value here is
+# identical to the block in that file. rust-cache hashes them into the first
+# component of its key, and that component is also its only fallback restore
+# key, so one extra var is indistinguishable from a cold cache.
+#
+# That is not hypothetical: `CARGO_NET_RETRY` was set here and not there, and
+# it silently made every release build in this pipeline's history compile from
+# scratch (~940 crates, 21 min macOS / 36 min Windows) while this workflow
+# faithfully wrote a warm cache nothing could ever read. The full measurement
+# is in release-build.yml's `env:` comment.
+#
+# `cache-key-parity` in ci.yml compares the two blocks and fails if they drift.
+# sccache (RUSTC_WRAPPER/SCCACHE_GHA_ENABLED) used to live here too — removed,
+# see release-build.yml's note above its rust-cache step for why it was making
+# things slower rather than faster.
 env:
   SQLX_OFFLINE: "true"
   CARGO_INCREMENTAL: "0"
   CARGO_NET_RETRY: "3"
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-  # sccache — see release-build.yml's "Set up sccache" step comment for the
-  # full reasoning. Must match release-build.yml's compile jobs for the cache
-  # this workflow warms to actually help them (same principle as the
-  # shared-key comments below).
-  RUSTC_WRAPPER: sccache
-  SCCACHE_GHA_ENABLED: "true"
+  CARGO_TERM_COLOR: always
 
 jobs:
   warm-macos:
@@ -110,7 +123,8 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
-      actions: write # sccache's GHA cache backend needs this to SAVE entries
+      # No `actions: write`: that grant existed only for sccache's GHA cache
+      # backend, now removed. actions/cache saves via ACTIONS_RUNTIME_TOKEN.
     steps:
       - uses: actions/checkout@v4
         with:
@@ -129,10 +143,6 @@ jobs:
         with:
           toolchain: "1.93.1"
           targets: aarch64-apple-darwin
-
-      # See release-build.yml's "Set up sccache" step for the full reasoning.
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -218,7 +228,8 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
-      actions: write # sccache's GHA cache backend needs this to SAVE entries
+      # No `actions: write`: that grant existed only for sccache's GHA cache
+      # backend, now removed. actions/cache saves via ACTIONS_RUNTIME_TOKEN.
     defaults:
       run:
         # Same reasoning as release-build.yml's Windows job: every step here
@@ -259,10 +270,6 @@ jobs:
           toolchain: "1.93.1"
           # No explicit target: windows-latest's host triple
           # (x86_64-pc-windows-msvc) is exactly what we ship.
-
-      # See release-build.yml's "Set up sccache" step for the full reasoning.
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -415,3 +422,41 @@ jobs:
                 || echo "::warning::failed to delete cache ${id} (non-fatal, next run will retry)"
             done
           done
+
+      - name: Reap orphaned sccache objects
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # sccache's GHA backend was removed from this workflow and from
+        # release-build.yml, but the entries it already wrote do not expire for
+        # a week and there are thousands of them. They are not merely clutter:
+        # the repo cache quota is 10 GB repo-wide and GitHub evicts it by LRU
+        # across ALL entries, so a swarm of tiny objects evicts the ~1.4 GB
+        # tarballs the release build depends on. Measured before this landed:
+        # 5288 `sccache/*` entries vs 20 for everything else, 8.8 GB total, and
+        # the `macos-release-aarch64-apple-darwin` tarball already gone hours
+        # after a successful warm run wrote it.
+        #
+        # This deletes them in bulk on the first run and finds nothing on every
+        # run after, at which point it is a no-op that costs one API call. It is
+        # kept (rather than being a one-off manual cleanup) so that re-adding
+        # sccache anywhere cannot quietly recreate the condition — the entries
+        # get reaped nightly and whoever added it sees the deletions in the log.
+        #
+        # Deliberately unbounded by ref: sccache scoped its writes to whatever
+        # ref happened to be building, so these are spread across main, tags and
+        # PR merge refs. `|| true` throughout — reaping is best-effort
+        # housekeeping and must never fail a warm run.
+        run: |
+          set -uo pipefail
+          ids=$(gh api --paginate "repos/${{ github.repository }}/actions/caches?per_page=100" \
+            --jq '.actions_caches[] | select(.key | startswith("sccache/")) | .id' 2>/dev/null) || true
+          if [ -z "${ids}" ]; then
+            echo "no orphaned sccache entries"
+            exit 0
+          fi
+          n=0
+          for id in $ids; do
+            gh api -X DELETE "repos/${{ github.repository }}/actions/caches/${id}" >/dev/null 2>&1 \
+              && n=$((n + 1)) || true
+          done
+          echo "reaped ${n} orphaned sccache cache entries"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,6 +453,98 @@ jobs:
           fi
           echo "OK — no existing migrations were modified, renamed, or deleted."
 
+  # ── The release cache is only warm if two env blocks stay identical ─────────
+  #
+  # cache-warm.yml exists to compile on `main` and leave a ~1.4 GB rust-cache
+  # tarball a tag-triggered release build can restore. Swatinem/rust-cache
+  # derives the first component of its cache key from the NAMES AND VALUES of
+  # every env var matching CARGO_*/RUSTC_*/RUST_*, and that same component is
+  # its only fallback restore key. So if the two workflows' env blocks differ by
+  # a single variable, the release build computes a key nothing has ever written
+  # and starts stone cold.
+  #
+  # Nothing about that failure is visible. The warm job succeeds, the cache is
+  # written, the release build succeeds — it just logs "No cache found." in a
+  # collapsed group and then compiles ~940 crates. It ran that way for this
+  # pipeline's entire history over one variable (`CARGO_NET_RETRY`, set in one
+  # file and not the other), costing ~21 min on macOS and ~36 min on Windows per
+  # release, while every status check stayed green.
+  #
+  # A comment saying "these must match" is what was already there, in both
+  # files, and it did not hold. This job is the version that fails.
+  cache-key-parity:
+    name: Release cache key parity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Assert cache-warm.yml and release-build.yml hash the same env
+        run: |
+          python3 - <<'PY'
+          import sys
+
+          # The top-level `env:` block only: column-0 `env:`, then its indented
+          # body up to the next column-0 key. Deliberately NOT a YAML parse —
+          # this needs no dependency, and a job-level `env:` (indented) must not
+          # be picked up, since rust-cache reads the process environment the
+          # step actually runs with and both files put the shared vars at top
+          # level.
+          def top_level_env(path):
+              out, inside = {}, False
+              for line in open(path):
+                  if not inside:
+                      if line.rstrip("\n") == "env:":
+                          inside = True
+                      continue
+                  if line.strip() == "" or line.lstrip().startswith("#"):
+                      continue
+                  if not line.startswith((" ", "\t")):
+                      break
+                  k, _, v = line.strip().partition(":")
+                  out[k.strip()] = v.strip().strip('"').strip("'")
+              return out
+
+          # Exactly what rust-cache feeds into its key hash.
+          def keyed(env):
+              return {k: v for k, v in env.items()
+                      if k.startswith(("CARGO_", "RUSTC_", "RUST_"))}
+
+          files = {
+              "cache-warm.yml": ".github/workflows/cache-warm.yml",
+              "release-build.yml": ".github/workflows/release-build.yml",
+          }
+          got = {}
+          for name, path in files.items():
+              got[name] = keyed(top_level_env(path))
+              if not got[name]:
+                  sys.exit(f"::error file={path}::no top-level CARGO_*/RUSTC_* env "
+                           f"found - did the `env:` block move or get indented? "
+                           f"This guard cannot protect what it cannot find.")
+
+          warm, rel = got["cache-warm.yml"], got["release-build.yml"]
+          if warm == rel:
+              print("OK - both workflows hash an identical env into the cache key:")
+              for k in sorted(warm):
+                  print(f"    {k}={warm[k]}")
+              sys.exit(0)
+
+          lines = []
+          for k in sorted(set(warm) | set(rel)):
+              a, b = warm.get(k), rel.get(k)
+              if a != b:
+                  lines.append(f"    {k}: cache-warm={a!r}  release-build={b!r}")
+          print("::error::cache-warm.yml and release-build.yml no longer hash the "
+                "same environment, so every release build will restore NO cache "
+                "and compile the whole workspace from scratch (~21 min macOS, "
+                "~36 min Windows). Make the two top-level `env:` blocks identical "
+                "for every CARGO_*/RUSTC_*/RUST_* variable.")
+          print("Differences:")
+          print("\n".join(lines))
+          sys.exit(1)
+          PY
+
   # screenpipe relicensed MIT → Commercial on 2026-06-10. Meridian ships zero
   # screenpipe code, so staying pinned to the last MIT-based fork rev keeps the
   # install license-clean. Enforce the pin server-side so it can't silently

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -164,16 +164,37 @@ concurrency:
 permissions:
   contents: read
 
+# *** THIS BLOCK IS PART OF THE CACHE KEY. IT MUST MATCH cache-warm.yml's. ***
+#
+# Swatinem/rust-cache hashes the NAMES AND VALUES of every env var matching
+# CARGO_*/RUSTC_*/RUST_* into the first component of its cache key, and its only
+# fallback restore key is `<shared-key>-<runner>-<that hash>`. So a var that
+# cannot possibly affect a compiled byte still decides whether a release build
+# starts warm or compiles ~940 crates from scratch.
+#
+# It had already broken, silently, for every release ever cut on this pipeline.
+# `CARGO_NET_RETRY` was set in cache-warm.yml and NOT here — nothing else
+# differed, same toolchain, same Cargo.lock (both keys ended `-049b9ef7`) — and
+# that alone moved the hash:
+#
+#     cache-warm.yml  writes  v0-rust-macos-release-…-Darwin-arm64-92908ebe-049b9ef7
+#     release-build   wants   v0-rust-macos-release-…-Darwin-arm64-11b475d7-049b9ef7
+#
+# Measured on run 31305072099, the last release before this was fixed: rust-cache
+# logged "No cache found." on BOTH platforms, sccache reported a Rust hit rate of
+# 0.00%, and the compile steps ran 20.9 min (macOS) and 35.7 min (Windows).
+# Notarization — the part everyone assumes is the slow bit — was 1.5 min.
+#
+# So: adding, renaming or removing ANY CARGO_*/RUSTC_* var here means making the
+# identical change in cache-warm.yml. The `cache-key-parity` job in ci.yml fails
+# the build if the two blocks drift, because nothing else notices — the build
+# still passes, it just quietly takes half an hour.
 env:
   SQLX_OFFLINE: "true"
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  CARGO_NET_RETRY: "3"
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  # sccache — see the "Set up sccache" step comment in each compile job for
-  # why this runs alongside rust-cache rather than replacing it. Harmless on
-  # jobs that never invoke cargo (prepare, publish).
-  RUSTC_WRAPPER: sccache
-  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   # ── Stage 1: cheap validation + a draft release for everyone to upload into ──
@@ -302,7 +323,11 @@ jobs:
     timeout-minutes: 60 # a hung `notarytool --wait` otherwise burns 10x-billed minutes indefinitely
     permissions:
       contents: write # uploads assets into the draft
-      actions: write # sccache's GHA cache backend needs this to SAVE entries, not just read
+      # No `actions: write` — that grant existed ONLY for sccache's GHA cache
+      # backend, which this job no longer uses (see the note above the
+      # rust-cache step). actions/cache saves via ACTIONS_RUNTIME_TOKEN and
+      # needs no such permission, so dropping it costs nothing and keeps a job
+      # that holds the signing key at least privilege.
     strategy:
       # One flaky architecture must not kill the other's artifacts — and we want
       # its timing either way.
@@ -365,26 +390,31 @@ jobs:
           toolchain: "1.93.1"
           targets: ${{ matrix.target }}
 
-      # Complements rust-cache below, doesn't replace it. rust-cache restores
-      # a whole target/ tarball keyed on Cargo.lock — great when it matches
-      # exactly, but a tag-triggered build can only ever restore from ITS OWN
-      # ref or `main` (GitHub's cache scoping), never from `pre-main` directly.
-      # A staging release cut from a `pre-main` that has drifted from `main`
-      # (routine — pre-main accumulates merges between releases) gets a
-      # partially-stale target/, and rust-cache's fingerprint mismatch forces
-      # full recompilation of anything that LOOKS different, even crates whose
-      # actual compiled output would be identical. sccache intercepts at the
-      # individual rustc-invocation level regardless of why cargo decided to
-      # invoke it, so it can still return a hit there. Free GHA cache backend
-      # (SCCACHE_GHA_ENABLED below) — same underlying service as rust-cache,
-      # so still ref-scoped in principle, but per-object rather than
-      # per-tarball, which degrades far more gracefully on drift. Does NOT
-      # cover the vendored-OpenSSL C compile or the Swift static-lib build
-      # (tauri-plugin-notifications) — that's still rust-cache's job via its
-      # cache-directories entry below.
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
-
+      # *** DO NOT RE-ADD sccache HERE. IT MADE RELEASES SLOWER, MEASURABLY. ***
+      #
+      # A `Set up sccache` step (mozilla-actions/sccache-action, GHA backend)
+      # used to sit here, on the theory that it degrades more gracefully than
+      # rust-cache when a tag build's target/ is partially stale — per-object
+      # instead of per-tarball. The theory was sound; the accounting was not.
+      #
+      # sccache's GHA backend writes ONE CACHE ENTRY PER COMPILED OBJECT, into
+      # the same 10 GB repo-wide pool rust-cache lives in, which GitHub evicts
+      # by LRU. Measured directly against the cache API: 5288 sccache entries
+      # holding ~3 GB of an 8.8 GB total, against 20 entries for everything
+      # else — and by then the `macos-release-aarch64-apple-darwin` tarball had
+      # ALREADY been evicted, hours after a warm run wrote it. So the fallback
+      # was evicting the primary.
+      #
+      # And it did not even pay for itself: on that same release build sccache
+      # reported `Cache hits rate (Rust) 0.00%` on both platforms — 942 Rust
+      # compilations, zero hits. Its only real hits were C/C++ (vendored
+      # OpenSSL/SQLCipher), which rust-cache's target/ + `~/.cargo/registry/src`
+      # entry already covers once it actually restores.
+      #
+      # It also broke the prune job below: listing caches by ref had to paginate
+      # 50+ pages, and `Prune superseded caches` logged "failed to list caches
+      # for v0-rust-macos-release-aarch64-apple-darwin" — so stale entries
+      # stopped being reaped too, feeding the same eviction.
       - uses: Swatinem/rust-cache@v2
         with:
           # shared-key REPLACES rust-cache's automatic job-based key. That
@@ -689,7 +719,11 @@ jobs:
     timeout-minutes: 60 # same cap as macos — bound a hung build instead of falling back to GitHub's 360-minute default
     permissions:
       contents: write # uploads assets into the draft
-      actions: write # sccache's GHA cache backend needs this to SAVE entries, not just read
+      # No `actions: write` — that grant existed ONLY for sccache's GHA cache
+      # backend, which this job no longer uses (see the note above the
+      # rust-cache step). actions/cache saves via ACTIONS_RUNTIME_TOKEN and
+      # needs no such permission, so dropping it costs nothing and keeps a job
+      # that holds the signing key at least privilege.
     env:
       # Same compile-time constants the macOS job bakes in (see its `env:`
       # comment) — these are cross-platform values (OAuth client ids, public
@@ -771,11 +805,9 @@ jobs:
           # produces it — unlike the macOS job, which cross-arch-targets a
           # single shared runner.
 
-      # See the macOS job's "Set up sccache" step for the full reasoning —
-      # identical here, complements rust-cache rather than replacing it.
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
-
+      # sccache was removed here too — see the macOS job's note above the
+      # equivalent step for the measurement (5288 cache entries evicting the
+      # tarball that actually matters, for a 0.00% Rust hit rate).
       - uses: Swatinem/rust-cache@v2
         with:
           # Keyed by triple only, same reasoning as the macOS job — one warm


### PR DESCRIPTION
A release currently takes **30-37 minutes**. Almost all of it is one bug.

## What is actually slow

Per-step timing from run [31305072099](https://github.com/Meridiona/meridian/actions/runs/31305072099), the last release before this branch:

| step | macOS | Windows |
|---|---|---|
| **compile** | **20.9 min** | **35.7 min** |
| bundle + sign + notarize | 1.1 min | - |
| notarize + staple DMG | 0.4 min | - |
| npm ci + UI build | 0.6 min | 1.1 min |
| everything else | ~0 | ~0 |

Notarization - the part usually blamed - is 1.5 min. The compile is the build.

## Why the compile was cold

`cache-warm.yml` does its job: the nightly run logs a full cache hit and finishes in 4-9 min, leaving a ~1.4 GB tarball on `main` for tag builds to restore. The release build then computed a *different* key and logged `No cache found.` on **both** platforms, with sccache reporting `Cache hits rate (Rust) 0.00%`.

`Swatinem/rust-cache` hashes the names and values of every `CARGO_*`/`RUSTC_*` variable into the first component of its key, and that component is also its only fallback restore key. `CARGO_NET_RETRY` was set in one workflow and not the other:

|  | cache-warm.yml | release-build.yml |
|---|---|---|
| rustc versions | identical | identical |
| lockfile hash | `049b9ef7` | `049b9ef7` |
| env considered | …, **CARGO_NET_RETRY**, CARGO_TERM_COLOR, RUSTC_WRAPPER | …, CARGO_TERM_COLOR, RUSTC_WRAPPER |
| **key hash** | **`92908ebe`** | **`11b475d7`** |

Same toolchain, same `Cargo.lock`. One network-retry count decided whether the release compiled ~940 crates from scratch.

## Changes

1. **Match the env blocks.** `CARGO_NET_RETRY` into `release-build.yml`, `CARGO_TERM_COLOR` into `cache-warm.yml`.

2. **Drop sccache from both.** Its GHA backend writes one cache entry *per compiled object*: **5288 entries holding ~3 GB of an 8.8 GB total, against 20 entries for everything else**, in a 10 GB pool GitHub evicts by LRU. It had already evicted the `macos-release-aarch64-apple-darwin` tarball hours after a warm run wrote it, and it broke `prune-stale-caches` (listing by ref paginated 50+ pages and failed with `failed to list caches for v0-rust-macos-release-aarch64-apple-darwin`). It returned **0.00% on Rust**; its only real hits were C/C++, which rust-cache's `target/` + `~/.cargo/registry/src` already covers. A new reap step deletes the entries it left behind.

3. **Add `cache-key-parity` to ci.yml.** Both files already carried a comment saying the blocks must match byte for byte. The comment did not hold for the pipeline's entire history. This is the version that fails the build - verified both ways: it passes on this branch and exits 1 against `pre-main` naming the exact two variables.

Also restores `CARGO_INCREMENTAL=0` in both files, which had drifted to `1` on this working tree - incremental state is written and never read back on a runner, so it only inflates `target/` and the cache tarball.

## Expected result

The warm jobs already show what a hit looks like end to end, including npm and the UI build: **macOS 6 min, Windows 9 min**. Adding sign/notarize/upload puts a release at roughly **8-11 min wall clock** (the two platforms run in parallel), against 30-37 today.

Not one minute - that would mean not compiling Rust at all. The floor here is a warm incremental compile of the workspace crates plus Apple's notary queue.

## Rollout

This does not take effect the moment it merges. `cache-warm.yml` must run **on `main`** once under the new env to write a cache under the new key. So:

1. merge to `pre-main`
2. on the `pre-main → main` release merge, `cache-warm` fires on `main` automatically - or dispatch it manually against `main`
3. the next tag build restores it

Until then releases stay cold, exactly as they are now - nothing regresses.

**Cache quota:** the 5288 orphaned sccache entries are reaped automatically by the new step on the first `cache-warm` run. They can be cleared sooner by hand if PR caches keep getting evicted in the meantime.

## Testing

- All four workflows parse (`yaml.safe_load`).
- `cache-key-parity` extracted and run locally: passes on this branch, exits 1 against `pre-main` reporting `CARGO_NET_RETRY` and `CARGO_TERM_COLOR`.
- Full pre-push suite green (fmt, clippy `--workspace`, `cargo test --workspace`, UI build, UI tests, security audit).
- No Rust, TS or migration changes - workflow YAML only.