### PR TITLE
fix(onboarding): take the skip out of the first-run walkthrough

### DIFF
--- a/ui/__tests__/tutorial-sample-day.test.ts
+++ b/ui/__tests__/tutorial-sample-day.test.ts
@@ -866,6 +866,40 @@ describe('the plan saves itself', () => {
   })
 })
 
+describe('a first run cannot be skipped, a replay can', () => {
+  const hook = readFileSync(new URL('../components/tutorial/useTutorial.tsx', import.meta.url), 'utf8')
+  const overlay = readFileSync(new URL('../components/tutorial/TutorialOverlay.tsx', import.meta.url), 'utf8')
+
+  it('gives the automatic first run no Skip control at all', () => {
+    // An out on the first screen a new user ever sees reads as the recommended
+    // action to anyone unsure - which is everyone at that moment - so it cost
+    // the product's only self-explanation to exactly the people who needed it.
+    expect(hook).toContain('onSkip={explicit ? finish : null}')
+  })
+
+  it('removes the button rather than hiding or disabling it', () => {
+    // Hidden-but-present is how a control comes back by accident, and a disabled
+    // button still tells the user there is a way out and it is denied to them.
+    expect(overlay).toContain('{onSkip && (')
+    expect(overlay).toContain('onSkip: (() => void) | null')
+  })
+
+  it('settles `explicit` at the one moment the run actually starts', () => {
+    // Not in each entry point: three writes can disagree about which run is
+    // starting. One write, next to setRunning, cannot.
+    expect(hook).toContain('setExplicit(explicitRef.current)')
+    expect(hook.indexOf('setExplicit(explicitRef.current)'))
+      .toBeLessThan(hook.indexOf('setRunning(true)\n      // Mirrored'))
+  })
+
+  it('still lets a replay out', () => {
+    // A replay is asked for out loud by someone who has already seen the
+    // product. Trapping them for three minutes is a different bug.
+    expect(hook).toMatch(/const replay = useCallback\(\(\) => \{\s*explicitRef\.current = true/)
+    expect(hook.match(/explicitRef\.current = true/g)?.length).toBe(3)
+  })
+})
+
 describe('the walkthrough points at the way out', () => {
   const src = SCRIPT_SRC
 

--- a/ui/components/tutorial/TutorialIntro.tsx
+++ b/ui/components/tutorial/TutorialIntro.tsx
@@ -88,10 +88,15 @@ export function TutorialIntro({ lines, onDone }: {
 
   return (
     <div
-      // Silent click-through. No label for it: naming an escape hatch on the
-      // opening card invites the user to treat the tour itself as something to
-      // get out of, and the overlay's Skip control is visible from the very next
-      // frame anyway.
+      // Silent click-through — it dismisses the TITLE CARD, not the tour, and
+      // is deliberately unlabelled: naming an escape hatch on the opening card
+      // invites the user to treat the tour itself as something to get out of.
+      //
+      // That reasoning now runs all the way through. This used to add "and the
+      // overlay's Skip control is visible from the very next frame anyway",
+      // which stopped being true when the first-run walkthrough lost its Skip
+      // (see TutorialOverlay). So on a first run this click only skips the
+      // titles and lands on the walkthrough proper.
       onClick={() => setOut(true)}
       className="fixed inset-0 flex flex-col items-center justify-center"
       style={{

--- a/ui/components/tutorial/TutorialOverlay.tsx
+++ b/ui/components/tutorial/TutorialOverlay.tsx
@@ -173,7 +173,10 @@ export function TutorialOverlay({ caption, centered, big, celebrate, cursorAt, c
    *  takes the screen, a one-button "carry on" stays inline. */
   choices: StageChoice[] | null
   onChoose: (value: string) => void
-  onSkip: () => void
+  /** `null` on the FIRST-RUN walkthrough, where there is deliberately no way to
+   *  skip - see the call site in useTutorial. Non-null only for a replay the
+   *  user asked for. */
+  onSkip: (() => void) | null
   /** DEV ONLY: jump to part two. `null` in a packaged build, where the pill is
    *  not rendered - see the button below. */
   onSkipToDay?: (() => void) | null
@@ -434,20 +437,28 @@ export function TutorialOverlay({ caption, centered, big, celebrate, cursorAt, c
         </div>
       )}
 
-      {/* Skip — its own control, NOT inside the caption bubble.
+      {/* Skip — REPLAYS ONLY. `onSkip` is null on the first run, and this
+          renders nothing at all then: the onboarding walkthrough has no out.
+          An escape hatch on the first screen a new user ever sees reads as the
+          recommended action to anyone unsure, which is everyone at that moment.
+          See the call site in useTutorial for the full reasoning.
+
+          When it IS shown it is its own control, NOT inside the caption bubble.
           It used to live in there, which meant it vanished on any beat with an
           empty caption and moved horizontally as the caption's width changed.
           An escape hatch that relocates, or disappears exactly when a confused
           user reaches for it, is not an escape hatch. Fixed top-right, present
           for the entire run. */}
-      <button onClick={onSkip} className="absolute mt-body-sm" style={{
-        top: 14, right: 16, pointerEvents: 'auto',
-        color: 'var(--t-muted)', cursor: 'pointer',
-        padding: '6px 13px', borderRadius: 99,
-        background: 'var(--t-card)',
-        border: '0.5px solid var(--t-card-border)',
-        boxShadow: 'var(--pop-shadow)',
-      }}>Skip tour</button>
+      {onSkip && (
+        <button onClick={onSkip} className="absolute mt-body-sm" style={{
+          top: 14, right: 16, pointerEvents: 'auto',
+          color: 'var(--t-muted)', cursor: 'pointer',
+          padding: '6px 13px', borderRadius: 99,
+          background: 'var(--t-card)',
+          border: '0.5px solid var(--t-card-border)',
+          boxShadow: 'var(--pop-shadow)',
+        }}>Skip tour</button>
+      )}
 
       {/* DEV ONLY - `null` in a packaged build, so this is not rendered at all.
           Jumps straight to part two (the timeline rebuilding itself), because

--- a/ui/components/tutorial/useTutorial.tsx
+++ b/ui/components/tutorial/useTutorial.tsx
@@ -525,6 +525,14 @@ export function useTutorial(opts: {
   // would make the control dead on the only machines it matters on.
   const explicitRef = useRef(false)
 
+  // The same fact as `explicitRef`, but readable during RENDER — a ref is not,
+  // and the overlay needs it to decide whether to show the Skip control at all.
+  //
+  // Set in one place (the start effect, next to `setRunning(true)`) rather than
+  // in each of the three entry points: that is the single moment the answer is
+  // final, so the two can't disagree about the run that is actually starting.
+  const [explicit, setExplicit] = useState(false)
+
   // Replay hook. The walkthrough is a once-ever surface gated on a marker, so
   // without this the only way to see it again is deleting that key from the
   // console — every iteration, for anyone building or QAing it. Three ways in:
@@ -635,6 +643,9 @@ export function useTutorial(opts: {
           .catch(() => false)
         if (!armed || ctrl.signal.aborted) return
       }
+      // Captured at the one moment it is settled, and read by the overlay to
+      // decide whether a Skip control exists for this run. See `explicit` above.
+      setExplicit(explicitRef.current)
       setRunning(true)
       // Mirrored into the module flag so screens BELOW the shell can tell they are
       // being demonstrated rather than used - see `isTutorialRunning`.
@@ -704,7 +715,21 @@ export function useTutorial(opts: {
           ghost={ghost} clicking={clicking}
           spotlight={spotlight} spotlightDim={spotlightDim} awaiting={awaiting}
           choices={choices} onChoose={(v) => choiceRef.current?.(v)}
-          onSkip={finish}
+          // NO SKIP ON THE FIRST RUN. `null` here removes the control entirely
+          // rather than hiding or disabling it.
+          //
+          // The onboarding walkthrough is the one pass where the product gets to
+          // explain itself, and it is three minutes long. An out placed in the
+          // corner of the very first screen is read as the recommended action by
+          // anyone who is unsure - which is everyone, at that exact moment - so
+          // it was costing the explanation to the users who most needed it.
+          //
+          // A REPLAY keeps it. That run is one the user asked for out loud
+          // (Settings, `?tour=1`, or the console hook), by someone who has
+          // already seen the product, so trapping them for three minutes would
+          // be a different bug and not the one being fixed here. `explicit` is
+          // exactly that distinction, captured where the run starts.
+          onSkip={explicit ? finish : null}
           // Null in a packaged build, so the pill is not rendered at all. This
           // jumps PAST the compulsory AI-connect step, which the whole product
           // needs - it is a shortcut for whoever is editing part two, not a way


### PR DESCRIPTION
A new user's very first screen offered **Skip tour** in the corner.

To anyone unsure what they were looking at — which is everyone, at that exact moment — a corner escape hatch reads as the *recommended* action. So the one pass where the product gets to explain itself was being declined by the people who most needed it.

## What changed

`onSkip={explicit ? finish : null}` — and the overlay renders nothing when it's null.

**Removed, not hidden and not disabled.** Hidden-but-present is how a control comes back by accident, and a disabled button still announces there is a way out *and* that it is being withheld from you.

## A replay keeps it

That run is asked for out loud — Settings → "Show me around", `?tour=1`, or the console hook — by someone who has already seen the product. Trapping *them* for three minutes would be a different bug, not the one being fixed.

`explicitRef` already drew that line for the upgrade guard (#707). This adds a render-readable `explicit` beside it, set **once, at the moment the run starts**, rather than in each of the three entry points — three writes can disagree about which run is beginning; one write next to `setRunning` cannot.

## Also

The title card's silent click-through is unchanged — it dismisses the *titles*, never the tour. But its comment claimed the overlay's Skip was "visible from the very next frame anyway", which stopped being true here. Corrected in place rather than left to mislead the next reader.

## Tests

Four new, in `tutorial-sample-day.test.ts`:

- the automatic first run gets no Skip control
- the button is removed rather than hidden or disabled
- `explicit` is settled *before* `setRunning`
- a replay can still leave

`bun test` **708 pass / 0 fail** (was 704), `tsc --noEmit` clean, full pre-push suite green.