### PR TITLE
fix(release): ask the tag, not main, whether a build already started

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,6 +519,20 @@ jobs:
                   "would be pushed and nothing would build, or it would build from "
                   "a cold cache.")
 
+          # The "did the tag push already build?" question is answered by the
+          # workflow files AT THE PUSHED REF - the tag's own tree, i.e. this
+          # checkout - never by the default branch's copy. Reading main's copy
+          # instead inverts the answer on exactly the branch that is dispatch-
+          # only, and skips the dispatch for a tag that auto-built nothing:
+          # tagged, nothing building, no failure anywhere. That shipped once.
+          if "contents/.github/workflows/release-build.yml?ref=main" in prep_src:
+              fail.append(
+                  "release-prepare.yml decides whether to dispatch by reading "
+                  "MAIN's release-build.yml. Trigger evaluation uses the workflow "
+                  "file at the PUSHED REF (the tag's own tree), so this answers the "
+                  "wrong question and can leave a tag with no build at all. Inspect "
+                  "the local .github/workflows/release-build.yml instead.")
+
           if fail:
               for f in fail:
                   print(f"::error::{f}")

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -314,23 +314,32 @@ jobs:
         run: |
           set -euo pipefail
 
-          # ── TRANSITIONAL, AND IT DELETES ITSELF ──────────────────────────────
+          # ── DOES THE TAG PUSH ALREADY BUILD? ASK THE TAG, NOT main. ──────────
           #
-          # This change lands on `pre-main` first and only reaches `main` at the
-          # next release merge. In that window `main` still carries the OLD,
-          # tag-triggered release-build.yml — so the tag this job just pushed has
-          # ALREADY started a build, and dispatching would start a second one.
-          # Both would target the same draft release; the loser fails on "already
-          # published" after burning a full macOS + Windows compile.
+          # The only question here is whether pushing ${TAG} a moment ago ALREADY
+          # started a build, because then dispatching would start a second one
+          # against the same draft release and the loser dies on "already
+          # published" after a full macOS + Windows compile.
           #
-          # `gh workflow run` always runs the workflow file as it exists on the
-          # --ref branch, so what matters is what main has RIGHT NOW, not what
-          # this branch says. Read it and decide. Once main is dispatch-only this
-          # check simply stops matching and the dispatch proceeds every time.
-          main_wf="$(gh api "repos/${GITHUB_REPOSITORY}/contents/.github/workflows/release-build.yml?ref=main" \
-            --jq '.content' | base64 -d 2>/dev/null || true)"
-          if printf '%s' "${main_wf}" | grep -qE '^\s{2}push:'; then
-            echo "::warning::main's release-build.yml is still tag-triggered, so pushing ${TAG} already started the build. Skipping the dispatch to avoid building it twice. This resolves itself once main has the dispatch-only workflow - and until then the build runs from a cold cache, as it always did."
+          # GitHub answers that from the workflow files AT THE PUSHED REF — for a
+          # tag, the tag's own tree, which is this checkout. NOT the default
+          # branch's copy. So the file to inspect is the local one.
+          #
+          # An earlier version of this step read main's copy over the API, on the
+          # reasoning that `gh workflow run --ref main` executes main's file so
+          # main's file must be what matters. That conflates two different
+          # questions. It made this step skip the dispatch precisely when the tag
+          # had NOT auto-built — this branch is dispatch-only, so its tags start
+          # nothing — leaving a tagged release with no build at all: the exact
+          # silent failure this pipeline keeps being bitten by.
+          #
+          # Local file still tag-triggered  -> the push started it; do not double up.
+          # Local file dispatch-only        -> nothing started; dispatch (always).
+          #
+          # Self-deleting: once no release branch carries a `push:` trigger, this
+          # never matches again.
+          if grep -qE '^\s{2}push:' .github/workflows/release-build.yml; then
+            echo "::warning::this branch's release-build.yml is still tag-triggered, so pushing ${TAG} already started the build. Skipping the dispatch to avoid building it twice."
             exit 0
           fi
 


### PR DESCRIPTION
**Merge this before cutting another release.** #709 shipped a transitional guard that would leave a tagged release with **no build at all**.

## The bug

The guard has one job: answer *"did pushing this tag already start a build?"* — because if so, dispatching starts a second one against the same draft release, and the loser dies on `already published` after a full macOS + Windows compile.

It answered by reading **main's** copy of `release-build.yml`, reasoning that `gh workflow run --ref main` executes main's file. That conflates two different questions.

GitHub evaluates triggers from the workflow files **at the pushed ref** — for a tag, [the tag's own tree](https://github.com/orgs/community/discussions/25963), not the default branch. So on `pre-main`, which #709 made dispatch-only:

| | |
|---|---|
| tag pushed from `pre-main` | tag's tree has no `push:` → **nothing starts** |
| guard reads `main` | main still has `push:` → concludes a build is running |
| guard | **skips the dispatch** |
| result | **tagged, nothing built, no failure anywhere** |

Exactly the silent failure class this pipeline keeps getting bitten by, and the one #709 set out to remove.

## The fix

Inspect the **local** file — the tag's own tree, which is what GitHub actually consults:

```
local file still tag-triggered  ->  the push started it; do not double up
local file dispatch-only        ->  nothing started; dispatch
```

Simpler than the API call it replaces, and correct. Self-deleting once no release branch carries a `push:` trigger.

`release-trigger-shape` now fails if that decision ever goes back to reading main's copy. Verified both directions: passes on this branch, **exits 1 against `pre-main` as merged**, naming the fault.

## What this unblocks — no `main` merge needed

Dispatching `--ref main` runs main's **current** release-build.yml. That file already has a `workflow_dispatch` with a `tag` input, and its `save-if: github.ref == 'refs/heads/main'` — which could never be true under a tag trigger — **is finally true when dispatched**.

So the cache becomes self-maintaining without waiting for a `pre-main → main` release merge:

| release | |
|---|---|
| first after this merges | cold (~35 min), **seeds main's entry** |
| every one after | **warm, ~10 min** |

Optionally skip even that first cold one: dispatch `release-build.yml` against `main` with `cache_warm_only: true` against any existing tag. It compiles and saves the cache without creating, signing, notarizing or publishing anything.

## Testing

- All workflows parse.
- `release-trigger-shape` extracted and run locally, both directions.
- Full pre-push suite green. Workflow YAML only.