### PR TITLE
fix(plan): commit the day when a task is authored into it

### DIFF
--- a/meridian-core/src/readers/plan.rs
+++ b/meridian-core/src/readers/plan.rs
@@ -1137,6 +1137,46 @@ pub async fn apply_plan_action(
                     return Err(PlanWriteError::TooManyTasks(MAX_PLAN_TASKS + 1).into());
                 }
             }
+
+            // AUTHORING A TASK FOR A DAY IS COMMITTING TO IT.
+            //
+            // Every other arm that puts rows in `daily_plan` also writes
+            // `daily_plan_meta`; this one did not, and `confirmed_at` stayed
+            // NULL. That matters because `confirmed` is what every reader gates
+            // on — the dashboard's "Today's focus" renders
+            // `plan.confirmed ? plan.plan : []` — so a task added this way was
+            // written to the database correctly and then displayed nowhere.
+            //
+            // It hit hardest exactly where the product is trying hardest to make
+            // a good impression:
+            //   * the onboarding walkthrough, whose planner beat is driven
+            //     entirely by the composer. It says "Saved" and "today's tasks
+            //     are in", and then the dashboard it hands over to was empty.
+            //   * every solo / no-tracker user, for whom the composer is the ONLY
+            //     way to build a plan (there is no board to drag from), so their
+            //     plan never appeared at all.
+            // Dragging a board ticket across was unaffected, which is why this
+            // survived: that path goes through "confirm".
+            //
+            // `confirmed_at` is only stamped when NULL, so re-adding to a day
+            // that was committed hours ago does not move its timestamp. `skipped`
+            // is cleared unconditionally: authoring a task for a day you had
+            // skipped is an explicit change of mind, and leaving the flag set
+            // would hide the task behind the same gate again.
+            sqlx::query(
+                r#"INSERT INTO daily_plan_meta (plan_date, confirmed_at, skipped, created_at, updated_at)
+                   VALUES (?, ?, 0, ?, ?)
+                   ON CONFLICT(plan_date) DO UPDATE SET
+                     confirmed_at = COALESCE(daily_plan_meta.confirmed_at, excluded.confirmed_at),
+                     skipped      = 0,
+                     updated_at   = excluded.updated_at"#,
+            )
+            .bind(date)
+            .bind(now)
+            .bind(now)
+            .bind(now)
+            .execute(pool)
+            .await?;
         }
         "remove" => {
             let key = body

--- a/meridian-core/tests/readers.rs
+++ b/meridian-core/tests/readers.rs
@@ -544,6 +544,103 @@ async fn plan_write_confirm_then_reopen_roundtrip() {
 }
 
 #[tokio::test]
+async fn adding_a_task_commits_the_day_so_the_dashboard_shows_it() {
+    // `add` is what `meridian plan-task-create` runs, i.e. the planner's task
+    // composer. It used to write `daily_plan` and leave `daily_plan_meta`
+    // untouched, so `confirmed` stayed false - and every reader gates on that
+    // (the dashboard renders `plan.confirmed ? plan.plan : []`). The row existed
+    // and was shown nowhere.
+    //
+    // That is the ONLY way a solo/no-tracker user can build a plan, and it is the
+    // path the onboarding walkthrough drives, so it broke precisely the first-run
+    // experience: "Saved - today's tasks are in", followed by an empty dashboard.
+    let pool = make_plan_pool().await;
+    let today = chrono::Local::now().date_naive();
+    let date = today.format("%Y-%m-%d").to_string();
+    seed_task(&pool, "PROJ-A", "Backlog", Some(&date), 0).await;
+    let now = chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+
+    let add = meridian_core::plan::PlanBody {
+        action: "add".to_string(),
+        date: Some(date.clone()),
+        task_key: Some("PROJ-A".to_string()),
+        task_keys: None,
+    };
+    let resp = meridian_core::plan::apply_plan_action(&pool, &add, &date, today, &now, Vec::new())
+        .await
+        .unwrap();
+    assert!(
+        resp.confirmed,
+        "authoring a task for the day must commit the day, or it renders nowhere"
+    );
+    assert!(!resp.skipped);
+    let keys: Vec<&str> = resp.plan.iter().map(|p| p.task_key.as_str()).collect();
+    assert_eq!(keys, vec!["PROJ-A"]);
+
+    // A second add must NOT move the original commit time - the day was committed
+    // when it was first committed, and later edits are edits, not re-commits.
+    let first: Option<String> =
+        sqlx::query_scalar("SELECT confirmed_at FROM daily_plan_meta WHERE plan_date = ?")
+            .bind(&date)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    seed_task(&pool, "PROJ-B", "Backlog", Some(&date), 0).await;
+    let later = "2099-01-01T00:00:00Z";
+    let add_b = meridian_core::plan::PlanBody {
+        action: "add".to_string(),
+        date: Some(date.clone()),
+        task_key: Some("PROJ-B".to_string()),
+        task_keys: None,
+    };
+    meridian_core::plan::apply_plan_action(&pool, &add_b, &date, today, later, Vec::new())
+        .await
+        .unwrap();
+    let second: Option<String> =
+        sqlx::query_scalar("SELECT confirmed_at FROM daily_plan_meta WHERE plan_date = ?")
+            .bind(&date)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(first, second, "a later add must not restamp confirmed_at");
+}
+
+#[tokio::test]
+async fn adding_a_task_to_a_skipped_day_un_skips_it() {
+    // Authoring a task for a day you had skipped is an explicit change of mind.
+    // Leaving `skipped` set would hide the task behind the same gate that hid it
+    // before, which reads as the Add button doing nothing.
+    let pool = make_plan_pool().await;
+    let today = chrono::Local::now().date_naive();
+    let date = today.format("%Y-%m-%d").to_string();
+    seed_task(&pool, "PROJ-A", "Backlog", Some(&date), 0).await;
+    let now = chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+
+    let skip = meridian_core::plan::PlanBody {
+        action: "skip".to_string(),
+        date: Some(date.clone()),
+        task_key: None,
+        task_keys: None,
+    };
+    let resp = meridian_core::plan::apply_plan_action(&pool, &skip, &date, today, &now, Vec::new())
+        .await
+        .unwrap();
+    assert!(resp.skipped);
+
+    let add = meridian_core::plan::PlanBody {
+        action: "add".to_string(),
+        date: Some(date.clone()),
+        task_key: Some("PROJ-A".to_string()),
+        task_keys: None,
+    };
+    let resp = meridian_core::plan::apply_plan_action(&pool, &add, &date, today, &now, Vec::new())
+        .await
+        .unwrap();
+    assert!(!resp.skipped, "adding a task un-skips the day");
+    assert!(resp.confirmed);
+}
+
+#[tokio::test]
 async fn plan_write_rejects_missing_keys_and_unready_storage() {
     let pool = make_plan_pool().await;
     let today = chrono::Local::now().date_naive();


### PR DESCRIPTION
> "when users add today's task in the tutorial, when finished with the onboarding and tutorial, that today's task must reflect in their dashboard"

It was being saved correctly and then displayed nowhere. The cause is one missing write, and it is broader than onboarding.

## The gap

Every reader gates on `confirmed`. The dashboard's "Today's focus" is literally:

```ts
const focusItems = useMemo(() => (plan?.confirmed ? plan.plan : []), [plan])
```

and `confirmed` is `daily_plan_meta.confirmed_at IS NOT NULL`.

In `apply_plan_action`, the `confirm` and `skip` arms write that table. The **`add`** arm — what `meridian plan-task-create` runs, i.e. the planner's task composer — wrote only `daily_plan` and left `confirmed_at` NULL.

Dragging a board ticket into Today was unaffected: that path goes through `confirm`. **That is why this survived** — the developer flow has a board to drag from.

## Who it hit

- **The onboarding walkthrough.** Its planner beat is driven entirely by the composer. It says "Saved", then *"Nice - today's tasks are in"*, and hands over to a dashboard with an empty focus list.
- **Every solo / no-tracker user.** With no board there is nothing to drag, so the composer is the *only* way to build a plan — and their plan never appeared at all.

## The fix

`add` now stamps `confirmed_at` when it is NULL:

- **`COALESCE`, not overwrite** — a later add to a day committed hours ago must not move the original timestamp. The day was committed when it was committed; later edits are edits, not re-commits.
- **`skipped` cleared unconditionally** — authoring a task for a day you had skipped is an explicit change of mind. Leaving the flag set hides the task behind the same gate again, which reads as the Add button doing nothing.

The semantics this asserts: **authoring a task for a day is committing to it.** That already matches the UI, whose own comment says *"a confirmed plan is just a saved one... There is no locked state left to be in"*.

`add` has exactly one caller (`plan_tasks/create.rs`), so the blast radius is the composer path only.

## Tests

Two new in `meridian-core/tests/readers.rs`, **both verified to fail without the change** (stashed the fix, watched them go red, restored):

- `adding_a_task_commits_the_day_so_the_dashboard_shows_it` — includes the no-restamp assertion for a second add
- `adding_a_task_to_a_skipped_day_un_skips_it`

`cargo test --workspace` green (48 in the readers suite), `cargo clippy --workspace --all-targets -D warnings` clean.