### PR TITLE
fix(tray): send a fresh install to setup, not the dashboard

### DIFF
--- a/tray/src-tauri/src/commands/system.rs
+++ b/tray/src-tauri/src/commands/system.rs
@@ -28,6 +28,20 @@ use tauri_plugin_opener::OpenerExt;
 /// caller (popover, tray menu, notification click) triggered this.
 #[tauri::command]
 pub async fn open_dashboard(app: tauri::AppHandle) -> Result<(), String> {
+    // Same gate as the tray-menu path — see `tray::open_native_dashboard` for the
+    // full reasoning. It is repeated rather than shared because these are two
+    // independent entry points into the same window: this one serves the
+    // popover's button and a notification click, and a fresh install can reach
+    // either while the wizard is still opening.
+    //
+    // Returns Ok, not Err: the caller's request was honoured, just routed to the
+    // window that actually helps. An Err here would surface as a failed action in
+    // the popover for a user who is being sent somewhere useful.
+    if !crate::onboarding_complete() {
+        tracing::info!("dashboard requested before onboarding finished; opening the wizard");
+        crate::tray::open_wizard_window(&app);
+        return Ok(());
+    }
     dismiss_popover(&app);
     if let Some(win) = app.get_webview_window("dashboard") {
         let _ = win.show();

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -1059,9 +1059,11 @@ pub fn run() {
                 let wizard_handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
                     tokio::time::sleep(tokio::time::Duration::from_millis(800)).await;
-                    let onboarded = meridian_core::paths::meridian_dir()
-                        .is_some_and(|dir| dir.join("onboarded").exists());
-                    if !onboarded {
+                    // Same helper the dashboard gate uses, so "is this install
+                    // onboarded" has one answer. This check used to be spelled
+                    // out inline here, which is how it and the dashboard paths
+                    // could have drifted apart.
+                    if !onboarding_complete() {
                         tray::open_wizard_window(&wizard_handle);
                     }
                 });
@@ -1339,6 +1341,26 @@ enum ReopenTarget {
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn is_onboarded(home: &std::path::Path) -> bool {
     home.join(".meridian/onboarded").exists()
+}
+
+/// True when onboarding has completed, resolved against the real home directory.
+///
+/// The single gate every dashboard-opening path consults, so a fresh install
+/// cannot reach the timeline before setup. [`is_onboarded`] above is the same
+/// check as a pure function of a path (kept separate so it stays testable
+/// against a temp dir); this is the one production code calls.
+///
+/// Uses [`meridian_core::paths::meridian_dir`] rather than joining onto a raw
+/// `HOME` read — `HOME` is unset on Windows, where that resolves to a bogus
+/// cwd-relative path and the marker can never be found. Same reasoning as
+/// [`commands::setup::is_first_run`], and the same helper, so the two can never
+/// disagree about whether this install is onboarded.
+///
+/// Unresolvable home → `false` → the wizard. Being wrong in that direction shows
+/// setup to someone who has already done it, which is recoverable in one click;
+/// the other direction hands a brand-new install a dashboard with nothing in it.
+pub(crate) fn onboarding_complete() -> bool {
+    meridian_core::paths::meridian_dir().is_some_and(|dir| dir.join("onboarded").exists())
 }
 
 /// Route an external re-activation: finished onboarding → the dashboard;
@@ -2051,6 +2073,32 @@ mod reopen_tests {
         // Onboarded users land on the dashboard; everyone else resumes the wizard.
         assert_eq!(reopen_target(true), ReopenTarget::Dashboard);
         assert_eq!(reopen_target(false), ReopenTarget::Wizard);
+    }
+
+    /// Every path that can open the dashboard window must be behind the
+    /// onboarding gate, or a fresh install reaches the timeline before setup and
+    /// sees an empty product that reads as broken rather than unconfigured.
+    ///
+    /// Source-scanned via `include_str!` (compile-time, no I/O) because the thing
+    /// being protected is a call site, not a value: both functions build a real
+    /// webview and cannot be driven from a unit test. A behavioural test would be
+    /// better; this is what is actually available, and it fails loudly if either
+    /// gate is deleted or renamed.
+    #[test]
+    fn every_dashboard_path_waits_for_onboarding() {
+        for (name, src) in [
+            ("tray.rs", include_str!("tray.rs")),
+            ("commands/system.rs", include_str!("commands/system.rs")),
+        ] {
+            assert!(
+                src.contains("if !crate::onboarding_complete() {"),
+                "{name} opens the dashboard without checking onboarding_complete() - \
+                 a first-run install would reach the timeline before setup"
+            );
+        }
+        // And the gate must send them somewhere, not just refuse.
+        assert!(include_str!("tray.rs").contains("open_wizard_window(app);"));
+        assert!(include_str!("commands/system.rs").contains("open_wizard_window(&app);"));
     }
 
     #[test]

--- a/tray/src-tauri/src/tray.rs
+++ b/tray/src-tauri/src/tray.rs
@@ -95,6 +95,27 @@ pub(crate) fn handle_menu_event(app: &tauri::AppHandle, id: &str) {
 /// Drafts), independent of the popover's own `invoke('open_dashboard')` button,
 /// so it needs the same fix to avoid leaving the popover stuck on screen.
 pub(crate) fn open_native_dashboard(app: &tauri::AppHandle) {
+    // SETUP COMES FIRST ON A FRESH INSTALL.
+    //
+    // The wizard auto-opens 800 ms after launch, but nothing stopped the user
+    // reaching the dashboard before or instead of it — the tray menu's "Open
+    // Dashboard" and "Review Drafts" are both live from the first second, and
+    // the tray icon is the most obvious thing on screen while the wizard is
+    // still coming up.
+    //
+    // What they got was the real timeline against a database with no capture
+    // permissions granted, no AI provider, and no tracker: an empty product that
+    // looks broken rather than unconfigured, on the one screen that decides
+    // whether they keep it.
+    //
+    // Redirect rather than refuse. The wizard IS what they wanted — a way into
+    // the app — so open it; a disabled menu item or a silent no-op would just
+    // read as the app being broken instead.
+    if !crate::onboarding_complete() {
+        tracing::info!("dashboard requested before onboarding finished; opening the wizard");
+        open_wizard_window(app);
+        return;
+    }
     crate::commands::system::dismiss_popover(app);
     if let Some(win) = app.get_webview_window("dashboard") {
         let _ = win.show();


### PR DESCRIPTION
> "when user first installs the dmg, the timeline ui or dashboard must not come, setup must first come"

## What was actually happening

The wizard **does** auto-open, 800 ms after launch. But nothing stopped the user reaching the dashboard first, or instead:

| path | live from |
|---|---|
| tray menu → **Open Dashboard** | first second |
| tray menu → **Review Drafts** | first second |
| popover's own button | first second |
| notification click | first second |

The tray icon is the most obvious thing on screen while the wizard is still coming up, and it is the natural thing to click.

What they got was the **real timeline** against a database with no capture permissions granted, no AI provider and no tracker — an empty product that reads as *broken* rather than *unconfigured*, on the one screen that decides whether they keep it.

## The change

Both entry points into that window — `tray::open_native_dashboard` (tray menu) and `commands::system::open_dashboard` (popover, notification) — check onboarding first and open the wizard instead.

**Redirect, not refuse.** The wizard is what they actually wanted: a way into the app. A disabled menu item or a silent no-op would read as the app being broken, which is the exact impression this exists to avoid. `open_dashboard` returns `Ok` for the same reason — the request was honoured, just routed to the window that helps.

## One gate, not three

The check is a new `onboarding_complete()`, and **the launch gate in `setup()` now calls it too** rather than spelling the same filesystem read out inline. That duplication is how these could have drifted — one of the two is what the whole feature depends on.

It resolves through `meridian_core::paths::meridian_dir()` rather than joining onto a raw `HOME` read, which is **unset on Windows** (a bug this repo has already been bitten by twice, per the comments on `is_first_run` and the launch gate).

Unresolvable home → `false` → the wizard. Being wrong in that direction shows setup to someone who has already done it: one click. The other direction hands a brand-new install an empty dashboard.

## Testing

`every_dashboard_path_waits_for_onboarding` scans both call sites via `include_str!` — compile-time, no I/O. Both functions build a real webview and cannot be driven from a unit test, so a behavioural test isn't available here; this fails loudly if either gate is deleted or renamed, and also asserts the redirect target rather than just the check.

`cargo test --workspace` green (237 in the tray crate), `cargo clippy --workspace --all-targets -D warnings` clean, `cargo fmt` clean.

## Not changed

The **popover** itself still opens pre-onboarding. It is a small status panel, not the timeline, and blocking it would leave a first-run user with a tray icon that appears to do nothing. Say the word if you want that gated too.