### PR TITLE
fix(onboarding): let the walkthrough play after a re-onboard

### DIFF
--- a/ui/__tests__/tutorial-sample-day.test.ts
+++ b/ui/__tests__/tutorial-sample-day.test.ts
@@ -866,6 +866,35 @@ describe('the plan saves itself', () => {
   })
 })
 
+describe('finishing setup entitles this onboarding to the walkthrough', () => {
+  const page = readFileSync(new URL('../app/setup/page.tsx', import.meta.url), 'utf8')
+  const hook = readFileSync(new URL('../components/tutorial/useTutorial.tsx', import.meta.url), 'utf8')
+
+  it('clears the seen key when the wizard completes', () => {
+    // The auto-start needs BOTH `~/.meridian/walkthrough_armed` (a file) and an
+    // absent `meridian.walkthrough.seen.v1` (localStorage). Those stores have
+    // different lifetimes: wiping ~/.meridian cannot touch localStorage, so a
+    // machine that ever finished the walkthrough kept that key forever and a
+    // reinstall ran setup again but silently never played the tour.
+    expect(page).toContain("localStorage.removeItem('meridian.walkthrough.seen.v1')")
+  })
+
+  it('clears it only after the marker is actually written', () => {
+    // Clearing first would leave a machine entitled to the tour with no arm
+    // marker if mark_setup_complete then failed - the wizard reopens next launch
+    // and the tour cannot run, which is the worse of the two orderings.
+    expect(page.indexOf("await invoke('mark_setup_complete')"))
+      .toBeLessThan(page.indexOf("localStorage.removeItem('meridian.walkthrough.seen.v1')"))
+  })
+
+  it('still gates the auto-start on both halves', () => {
+    // The fix must not have loosened the upgrade guard - an install predating the
+    // walkthrough has no arm marker and must still be left alone.
+    expect(hook).toContain("const armed = await load<boolean>('/api/walkthrough-armed', 'walkthrough_is_armed')")
+    expect(hook).toContain('if (seen) return')
+  })
+})
+
 describe('a first run cannot be skipped, a replay can', () => {
   const hook = readFileSync(new URL('../components/tutorial/useTutorial.tsx', import.meta.url), 'utf8')
   const overlay = readFileSync(new URL('../components/tutorial/TutorialOverlay.tsx', import.meta.url), 'utf8')

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -224,6 +224,27 @@ export default function SetupWizard() {
       setErr(String(e))
       return
     }
+    // FINISHING THE WIZARD IS WHAT ENTITLES THIS ONBOARDING TO THE WALKTHROUGH,
+    // so clear the "already seen it" key here.
+    //
+    // The walkthrough auto-starts on two conditions that live in two different
+    // stores with two different lifetimes: `~/.meridian/walkthrough_armed`, which
+    // the command above just wrote, and `meridian.walkthrough.seen.v1` in the
+    // webview's localStorage. Wiping `~/.meridian` does not touch localStorage —
+    // nothing outside the webview can — so a machine that has ever completed the
+    // walkthrough kept that key forever.
+    //
+    // The result: reinstall, or delete ~/.meridian to start over, and setup runs
+    // again (correctly) but the walkthrough silently never plays. Nothing fails,
+    // nothing logs, the dashboard just opens. That is what happened on the first
+    // real test of this flow.
+    //
+    // Clearing it here makes wizard completion the single authority: you finished
+    // onboarding, so this onboarding has not been shown the walkthrough. It also
+    // makes Settings → Re-run Setup replay the tour, which is the honest reading
+    // of re-running onboarding (and matches `mark_setup_started`, which likewise
+    // treats a re-run as a fresh run rather than preserving the original).
+    try { localStorage.removeItem('meridian.walkthrough.seen.v1') } catch { /* private mode */ }
     try {
       await invoke('open_dashboard')
     } catch { /* ignore if dashboard fails to open */ }


### PR DESCRIPTION
Found on your first real end-to-end test of `staging.8`: setup correctly reappeared, then **the dashboard opened and the walkthrough never played**. No error, no log line.

## Cause

The auto-start needs two conditions, and they live in two stores with two different lifetimes:

| condition | where |
|---|---|
| `walkthrough_armed` | `~/.meridian/` — a file |
| `meridian.walkthrough.seen.v1` **absent** | the webview's localStorage |

`rm -rf ~/.meridian` — the obvious way to test a fresh install, and effectively what uninstall/reinstall does — clears the first and **cannot** touch the second. Nothing outside the webview can.

So the arm marker said *"new onboarding"* while localStorage still said *"already seen it"*, and the tour stayed suppressed. Permanently, on any machine that had ever finished it once.

This is not just a testing artifact: any user who reinstalls, or wipes `~/.meridian` to start clean, gets setup again and then silently no walkthrough.

## Fix

Wizard completion clears the seen key. That makes it the single authority: *you finished onboarding, so this onboarding has not been shown the walkthrough.*

**Ordered after `mark_setup_complete` succeeds** — the reverse leaves a machine entitled to the tour with no arm marker if that write fails, so the wizard reopens next launch and the tour can never run. That's the worse of the two orderings, and a test pins the order.

## Deliberate side effect

Settings → **Re-run Setup** now replays the walkthrough. That's the honest reading of re-running onboarding, and it matches `mark_setup_started`, which already treats a re-run as a fresh run rather than preserving the original timestamp.

## Not loosened

The upgrade guard from #707 is untouched — an install that predates the walkthrough still has no arm marker and is still left alone. A test asserts **both** halves of the gate survive, so this fix can't quietly become "always play".

## Tests

Three new: the key is cleared, it's cleared *after* the marker write, and both gate halves remain. `bun test` 711 pass / 0 fail, `tsc --noEmit` clean.