### PR TITLE
fix(update): stop reporting a concurrent install as "Update failed"

### DIFF
--- a/tray/src-tauri/src/commands/version.rs
+++ b/tray/src-tauri/src/commands/version.rs
@@ -331,11 +331,17 @@ pub async fn check_update(app: tauri::AppHandle) -> crate::update::UpdateStatus 
 }
 
 /// Download + install the available DMG update, then relaunch. Emits
-/// `update-progress` events the banners render as a bar. Returns `Err(String)`
-/// only on a pre-relaunch failure (success never returns — the app re-execs).
+/// `update-progress` events the banners render as a bar. Returns `Err` only on
+/// a pre-relaunch outcome (success never returns — the app re-execs).
+///
+/// The error is [`crate::update::UpdateError`], not a bare string, because the
+/// banners must tell a real failure from `kind: "inProgress"` — the
+/// single-flight refusal raised when the *other* surface already started this
+/// install. Rendering the two the same way is what put "Update failed" on
+/// screen during a download that was working.
 #[tauri::command]
 #[tracing::instrument(skip(app))]
-pub async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
+pub async fn install_update(app: tauri::AppHandle) -> Result<(), crate::update::UpdateError> {
     crate::update::download_and_apply(&app).await
 }
 

--- a/tray/src-tauri/src/update.rs
+++ b/tray/src-tauri/src/update.rs
@@ -112,8 +112,10 @@ pub enum UpdateErrorKind {
 /// frontend gets `{ kind, message }` rather than a bare string it would have to
 /// pattern-match on prose. `message` stays human-readable for logs and for the
 /// dashboard's diagnostic text.
+// No `rename_all` here on purpose: `kind` and `message` are already single
+// lowercase words, so it would be a no-op — and carrying one next to the enum's
+// (where it IS load-bearing) invites the reader to believe this one matters too.
 #[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct UpdateError {
     pub kind: UpdateErrorKind,
     pub message: String,
@@ -364,8 +366,42 @@ pub async fn check_status(app: &AppHandle) -> UpdateStatus {
 /// apart: [`UpdateErrorKind::InProgress`] means another surface's install is
 /// already running (benign — that one will relaunch), while
 /// [`UpdateErrorKind::Failed`] is a real fault worth showing and retrying.
-#[tracing::instrument(skip(app))]
+#[tracing::instrument(skip(app), fields(otel.status_code = tracing::field::Empty))]
 pub async fn download_and_apply(app: &AppHandle) -> Result<(), UpdateError> {
+    let result = install_now(app).await;
+
+    // Broadcast a TERMINAL failure so the surface that did NOT get this `Err`
+    // stops waiting on an install that is never going to finish.
+    //
+    // Only `Failed` qualifies. A surface that lost the single-flight race parks
+    // itself in the installing state on purpose (it tracks the winner's
+    // `update-progress` and relaunches with it), and nothing else would ever
+    // wake it: `download_and_apply` returns the error to the *winner* alone. So
+    // if the winner dies — dropped connection, signature mismatch, a write that
+    // did not take — the loser's banner would sit inert until the app is
+    // relaunched, with its retry button disabled. That is a worse failure than
+    // the mislabel this module was written to fix.
+    //
+    // `InProgress` must NOT emit: it is not a terminal outcome, it is the
+    // refusal itself, and the install it refers to is still running.
+    if let Err(e) = &result {
+        if e.kind == UpdateErrorKind::Failed {
+            // A real fault: mark the span ERROR so it is visible in the traces
+            // (and, on a packaged install, is one of the few things the redacted
+            // ship leg lets out at all). The InProgress refusal deliberately
+            // does NOT — it is a normal outcome of two open surfaces, and
+            // flagging it would make a routine double-click look like a fault.
+            tracing::Span::current().record("otel.status_code", "ERROR");
+            tracing::warn!(error = %e, "update: install failed");
+            let _ = app.emit("update-finished", serde_json::json!({ "ok": false }));
+        }
+    }
+    result
+}
+
+/// The install proper. Split out so [`download_and_apply`] owns the terminal
+/// broadcast on every error path without repeating it at each `?`.
+async fn install_now(app: &AppHandle) -> Result<(), UpdateError> {
     // Single-flight: refuse a concurrent install. On the happy path `restart()`
     // re-execs the process so the slot's reset never matters; on every error
     // path dropping it clears the slot so a failed install can be retried.
@@ -563,24 +599,33 @@ pub fn enforce_minimum_version(app: &AppHandle) {
                 notified = true;
             }
             if let Err(e) = download_and_apply(&app).await {
-                due = Deadline::after(retry);
                 // A user-initiated install holding the slot is not a failed
                 // enforcement — that install lands the same bytes and relaunches
                 // the app, satisfying the floor. Logging it as a failure sent
                 // support chasing an update path that was working.
+                //
+                // It must not pay a failure's PENALTY either. `next_retry`
+                // doubles (2m → 4m → 8m …, capped at ENFORCE_INTERVAL), so a
+                // couple of concurrent banner clicks would push a *mandatory*
+                // update — the kill-switch for releases that must not keep
+                // running — minutes further out, and further still if that
+                // concurrent install then fails. Re-check at the base delay and
+                // leave the escalating backoff untouched for real faults.
                 if e.kind == UpdateErrorKind::InProgress {
+                    due = Deadline::after(ENFORCE_RETRY_BASE);
                     tracing::info!(
-                        retry_s = retry.as_secs(),
+                        retry_s = ENFORCE_RETRY_BASE.as_secs(),
                         "update: forced install deferred - a user-initiated install is already running"
                     );
                 } else {
+                    due = Deadline::after(retry);
                     tracing::warn!(
                         error = %e,
                         retry_s = retry.as_secs(),
                         "update: forced install failed - retrying"
                     );
+                    retry = next_retry(retry);
                 }
-                retry = next_retry(retry);
             } else {
                 due = Deadline::after(ENFORCE_INTERVAL);
             }
@@ -603,13 +648,20 @@ pub fn check_for_updates(app: &AppHandle) {
         match status.state.as_str() {
             "available" => {
                 let v = status.version.clone().unwrap_or_default();
-                notify_update(
-                    &app,
-                    "downloading",
-                    "Updating Meridian",
-                    &format!("Downloading v{v}…"),
-                )
-                .await;
+                // Don't promise a download the single-flight guard is about to
+                // refuse: one menu click otherwise toasted "Downloading v1.84.0…"
+                // and then immediately "Update already in progress". The slot can
+                // still be taken between here and the call — the cost of losing
+                // that race is one skipped toast, never a wrong one.
+                if !INSTALLING.load(Ordering::SeqCst) {
+                    notify_update(
+                        &app,
+                        "downloading",
+                        "Updating Meridian",
+                        &format!("Downloading v{v}…"),
+                    )
+                    .await;
+                }
                 if let Err(e) = download_and_apply(&app).await {
                     // Same distinction the banners make: a refusal from the
                     // single-flight guard means a banner click already started
@@ -625,7 +677,9 @@ pub fn check_for_updates(app: &AppHandle) {
                         )
                         .await;
                     } else {
-                        tracing::warn!(error = %e, "update: install failed");
+                        // The failure itself is logged (and the span marked
+                        // ERROR) by `download_and_apply`, which owns it — this
+                        // arm only owns the user-facing toast.
                         notify_update(
                             &app,
                             "failed",

--- a/tray/src-tauri/src/update.rs
+++ b/tray/src-tauri/src/update.rs
@@ -84,6 +84,92 @@ static CHECKING: AtomicBool = AtomicBool::new(false);
 /// attempts would race.
 static INSTALLING: AtomicBool = AtomicBool::new(false);
 
+/// Why an install attempt came back instead of relaunching.
+///
+/// The distinction exists because losing it shipped a bug: every surface
+/// rendered any [`download_and_apply`] rejection as "Update failed", so the
+/// single-flight refusal below — which means *the install is running fine, just
+/// not on this button* — was displayed as a failed update, alongside an offer
+/// to retry that could only be refused again. See [`UpdateError`].
+///
+/// `rename_all` is load-bearing: `inProgress` is the exact token both banners
+/// match on (`tray/src/app.js`, `ui/components/timeline/UpdateCard.tsx`), and
+/// `ui/__tests__/update-in-progress.test.ts` pins all three spellings together.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum UpdateErrorKind {
+    /// Another surface already holds the install slot. Not a failure: that
+    /// install is still running and will relaunch the app when it lands.
+    InProgress,
+    /// A genuine pre-relaunch failure — unreachable manifest, signature
+    /// mismatch, a write that didn't take.
+    Failed,
+}
+
+/// A failed [`download_and_apply`], as the banners receive it.
+///
+/// Serialised straight across the `install_update` command's `Err`, so the
+/// frontend gets `{ kind, message }` rather than a bare string it would have to
+/// pattern-match on prose. `message` stays human-readable for logs and for the
+/// dashboard's diagnostic text.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateError {
+    pub kind: UpdateErrorKind,
+    pub message: String,
+}
+
+impl UpdateError {
+    /// The single-flight refusal — an install is already under way elsewhere.
+    fn in_progress() -> Self {
+        Self {
+            kind: UpdateErrorKind::InProgress,
+            message: "An update is already being installed.".to_string(),
+        }
+    }
+
+    /// A real failure, from whatever stage produced it.
+    fn failed(message: impl Into<String>) -> Self {
+        Self {
+            kind: UpdateErrorKind::Failed,
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for UpdateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+/// RAII holder of the single-flight install slot. Dropping it frees the slot, so
+/// every early return in [`download_and_apply`] leaves a failed install
+/// retryable; the happy path never drops it because `restart()` re-execs first.
+///
+/// `Debug` is only for `expect_err` in the slot test — a `Result<InstallSlot, _>`
+/// cannot report its error without it.
+#[derive(Debug)]
+struct InstallSlot;
+
+impl Drop for InstallSlot {
+    fn drop(&mut self) {
+        INSTALLING.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Take the install slot, or report that someone else holds it.
+///
+/// Split out of [`download_and_apply`] purely so the refusal is reachable from
+/// a unit test — the function it guards needs a live `AppHandle` and a network,
+/// and the refusal is the half that was rendering wrong in the field.
+fn acquire_install_slot() -> Result<InstallSlot, UpdateError> {
+    if INSTALLING.swap(true, Ordering::SeqCst) {
+        return Err(UpdateError::in_progress());
+    }
+    Ok(InstallSlot)
+}
+
 /// Structured result of an update check, for the in-app banners. Deliberately
 /// NOT a `Result` — a failed check is data (`state = "error"` + `error`) the UI
 /// renders, not a thrown command that the banner would have to swallow. `state`
@@ -271,30 +357,28 @@ pub async fn check_status(app: &AppHandle) -> UpdateStatus {
 
 /// Download → verify → install the available update, emitting `update-progress`
 /// `{ downloaded, contentLength }` events so the banners can show a bar, then
-/// relaunch into the new version. Returns `Err` only on a pre-relaunch failure —
+/// relaunch into the new version. Returns `Err` only on a pre-relaunch outcome —
 /// the success path never returns (`restart()` re-execs the app).
+///
+/// Two of those outcomes are not the same thing, and the caller must tell them
+/// apart: [`UpdateErrorKind::InProgress`] means another surface's install is
+/// already running (benign — that one will relaunch), while
+/// [`UpdateErrorKind::Failed`] is a real fault worth showing and retrying.
 #[tracing::instrument(skip(app))]
-pub async fn download_and_apply(app: &AppHandle) -> Result<(), String> {
+pub async fn download_and_apply(app: &AppHandle) -> Result<(), UpdateError> {
     // Single-flight: refuse a concurrent install. On the happy path `restart()`
-    // re-execs the process so the guard's reset never matters; on every error
-    // path the drop guard clears it so a failed install can be retried.
-    if INSTALLING.swap(true, Ordering::SeqCst) {
-        return Err("An update is already being installed.".to_string());
-    }
-    struct ResetOnDrop;
-    impl Drop for ResetOnDrop {
-        fn drop(&mut self) {
-            INSTALLING.store(false, Ordering::SeqCst);
-        }
-    }
-    let _reset = ResetOnDrop;
+    // re-execs the process so the slot's reset never matters; on every error
+    // path dropping it clears the slot so a failed install can be retried.
+    let _slot = acquire_install_slot()?;
 
-    let updater = app.updater().map_err(|e| e.to_string())?;
+    let updater = app
+        .updater()
+        .map_err(|e| UpdateError::failed(e.to_string()))?;
     let update = updater
         .check()
         .await
-        .map_err(|e| e.to_string())?
-        .ok_or_else(|| "No update available".to_string())?;
+        .map_err(|e| UpdateError::failed(e.to_string()))?
+        .ok_or_else(|| UpdateError::failed("No update available"))?;
 
     let emitter = app.clone();
     let mut downloaded: usize = 0;
@@ -310,7 +394,7 @@ pub async fn download_and_apply(app: &AppHandle) -> Result<(), String> {
             || tracing::info!("update: download finished, installing"),
         )
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| UpdateError::failed(e.to_string()))?;
 
     tracing::info!("update: installed — restarting");
     app.restart();
@@ -480,11 +564,22 @@ pub fn enforce_minimum_version(app: &AppHandle) {
             }
             if let Err(e) = download_and_apply(&app).await {
                 due = Deadline::after(retry);
-                tracing::warn!(
-                    error = %e,
-                    retry_s = retry.as_secs(),
-                    "update: forced install failed - retrying"
-                );
+                // A user-initiated install holding the slot is not a failed
+                // enforcement — that install lands the same bytes and relaunches
+                // the app, satisfying the floor. Logging it as a failure sent
+                // support chasing an update path that was working.
+                if e.kind == UpdateErrorKind::InProgress {
+                    tracing::info!(
+                        retry_s = retry.as_secs(),
+                        "update: forced install deferred - a user-initiated install is already running"
+                    );
+                } else {
+                    tracing::warn!(
+                        error = %e,
+                        retry_s = retry.as_secs(),
+                        "update: forced install failed - retrying"
+                    );
+                }
                 retry = next_retry(retry);
             } else {
                 due = Deadline::after(ENFORCE_INTERVAL);
@@ -516,14 +611,29 @@ pub fn check_for_updates(app: &AppHandle) {
                 )
                 .await;
                 if let Err(e) = download_and_apply(&app).await {
-                    tracing::warn!(error = %e, "update: install failed");
-                    notify_update(
-                        &app,
-                        "failed",
-                        "Update failed",
-                        "The update couldn't be installed.",
-                    )
-                    .await;
+                    // Same distinction the banners make: a refusal from the
+                    // single-flight guard means a banner click already started
+                    // this install, so telling the user it failed would be a
+                    // plain lie about a download that is running.
+                    if e.kind == UpdateErrorKind::InProgress {
+                        tracing::info!("update: menu install skipped - one is already running");
+                        notify_update(
+                            &app,
+                            "in_progress",
+                            "Update already in progress",
+                            "Meridian is installing the update now and will restart when it's ready.",
+                        )
+                        .await;
+                    } else {
+                        tracing::warn!(error = %e, "update: install failed");
+                        notify_update(
+                            &app,
+                            "failed",
+                            "Update failed",
+                            "The update couldn't be installed.",
+                        )
+                        .await;
+                    }
                 }
             }
             "uptodate" => {
@@ -688,6 +798,56 @@ mod tests {
         assert!(!is_missing_platform_asset(
             &tauri_plugin_updater::Error::ReleaseNotFound
         ));
+    }
+
+    /// Regression guard for the 1.84.0-staging.7 field incident: the popover
+    /// and the dashboard card were both open, both were clicked, and the
+    /// loser's single-flight refusal rendered as "Update failed" while the
+    /// winner's install completed and relaunched the app 36 s later.
+    ///
+    /// The refusal has to be *distinguishable* from a real fault, which is what
+    /// this pins — the kind, and the exact wire spelling both banners match on.
+    ///
+    /// One test owns the whole slot lifecycle on purpose: `INSTALLING` is a
+    /// process-global, and `cargo test` runs tests in parallel threads, so
+    /// splitting this across cases would race.
+    #[test]
+    fn a_concurrent_install_is_refused_as_in_progress_not_as_a_failure() {
+        let first = acquire_install_slot().expect("an idle slot must be takeable");
+
+        let refused = acquire_install_slot().expect_err("a second install must be refused");
+        assert_eq!(
+            refused.kind,
+            UpdateErrorKind::InProgress,
+            "the refusal must not masquerade as a failed install"
+        );
+
+        // `inProgress` is the token `tray/src/app.js` and `UpdateCard.tsx` test
+        // for. If serde ever stopped renaming, both banners would silently fall
+        // back to rendering this as a failure again — the original bug.
+        let wire = serde_json::to_string(&refused).expect("serialises for the command boundary");
+        assert!(
+            wire.contains("\"kind\":\"inProgress\""),
+            "wire shape drifted from what the banners match on: {wire}"
+        );
+
+        drop(first);
+        // A failed install must leave the slot retryable, not wedged.
+        assert!(
+            acquire_install_slot().is_ok(),
+            "dropping the slot must free it"
+        );
+    }
+
+    /// The other half of the discriminant: everything that isn't the
+    /// single-flight refusal stays a failure, so a genuinely broken update path
+    /// still shows up as broken.
+    #[test]
+    fn real_faults_keep_the_failed_kind_and_their_message() {
+        let e = UpdateError::failed("signature verification failed");
+        assert_eq!(e.kind, UpdateErrorKind::Failed);
+        // `Display` is what the `%e` log sites render — it must carry the cause.
+        assert_eq!(e.to_string(), "signature verification failed");
     }
 
     /// The comparison `check_status` performs: strictly-below is mandatory,

--- a/tray/src/app.js
+++ b/tray/src/app.js
@@ -400,6 +400,17 @@ listen('update-progress', (e) => {
     updText.textContent = `Downloading… ${Math.round((d.downloaded / d.contentLength) * 100)}%`
   }
 })
+// A terminal failure of the install THIS banner is tracking. Emitted by
+// download_and_apply for the whole app, so the surface that lost the
+// single-flight race (and therefore never got the Err back) also learns the
+// install died — otherwise it stays disabled on 'Update in progress…' until the
+// app is relaunched, with its retry button dead. Also covers the case where the
+// winner's download reports no contentLength, so no progress event ever lands.
+listen('update-finished', (e) => {
+  if ((e.payload || {}).ok) return
+  installing = false
+  updText.textContent = 'Update failed'
+})
 // `install_update` rejects with UpdateError { kind, message } (update.rs). Only
 // `failed` is a real fault: `inProgress` means the dashboard card's click won
 // the single-flight race, so an install IS running — it just isn't ours. Both

--- a/tray/src/app.js
+++ b/tray/src/app.js
@@ -400,15 +400,32 @@ listen('update-progress', (e) => {
     updText.textContent = `Downloading… ${Math.round((d.downloaded / d.contentLength) * 100)}%`
   }
 })
+// `install_update` rejects with UpdateError { kind, message } (update.rs). Only
+// `failed` is a real fault: `inProgress` means the dashboard card's click won
+// the single-flight race, so an install IS running — it just isn't ours. Both
+// surfaces are routinely open, so this is the common case, not an edge one, and
+// calling it "Update failed" (as this did) reports a failure over a download
+// that goes on to succeed. Anything that isn't our error object — an IPC-level
+// throw — stays a failure; guessing otherwise would hide a broken updater.
+const isInstallInProgress = (err) =>
+  typeof err === 'object' && err !== null && err.kind === 'inProgress'
 upd.addEventListener('click', () => {
   if (installing) return
   installing = true
   updText.textContent = 'Starting…'
   // Resolves only on failure — success re-execs the app (the relaunch).
   invoke('install_update').catch((err) => {
+    if (isInstallInProgress(err)) {
+      // Stay in the installing state: `update-progress` is emitted to every
+      // window, so this banner keeps painting the winning install's percentage
+      // and both surfaces relaunch together. Dropping out would strand it.
+      updText.textContent = 'Update in progress…'
+      dbg('update install already running on another surface - tracking it')
+      return
+    }
     installing = false
     updText.textContent = 'Update failed'
-    dbg(`update install failed: ${err}`)
+    dbg(`update install failed: ${err && err.message ? err.message : err}`)
   })
 })
 

--- a/ui/__tests__/update-in-progress.test.ts
+++ b/ui/__tests__/update-in-progress.test.ts
@@ -61,15 +61,36 @@ function popoverBody(): string {
 const pauseUtilsSrc = readFileSync(trayDir + '/pause-utils.js', 'utf8')
 const appSrc = readFileSync(trayDir + '/app.js', 'utf8')
 
+/** Dashboard source, for the assertions that can only be made by scanning. */
+const readSrc = (rel: string): string =>
+  readFileSync(import.meta.dir + '/../' + rel, 'utf8')
+
 type InvokeImpl = (cmd: string, args?: unknown) => Promise<unknown>
 let invokeImpl: InvokeImpl = async () => null
 
+// The popover's `listen()` registrations, captured so a test can deliver the
+// events the Rust side really emits (`update-progress`, `update-finished`).
+// A no-op `listen` would make every event-driven behaviour untestable — which
+// is how the wedge below shipped unnoticed in the first place.
+type Listener = (e: { payload: unknown }) => void
+let listeners: Record<string, Listener[]> = {}
+
+function emitEvent(name: string, payload: unknown) {
+  for (const cb of listeners[name] || []) cb({ payload })
+}
+
 function loadPopover() {
   document.body.innerHTML = popoverBody()
+  listeners = {}
   ;(globalThis as Record<string, unknown>).__MERIDIAN_POPOVER_TEST__ = true
   ;(globalThis as Record<string, unknown>).__TAURI__ = {
     core: { invoke: (cmd: string, args?: unknown) => invokeImpl(cmd, args) },
-    event: { listen: async () => () => {} },
+    event: {
+      listen: async (name: string, cb: Listener) => {
+        ;(listeners[name] ||= []).push(cb)
+        return () => {}
+      },
+    },
     window: {
       getCurrentWindow: () => ({ setSize: async () => {} }),
       LogicalSize: class {
@@ -88,9 +109,10 @@ const updText = () => document.getElementById('upd-text')?.textContent
 /** Click the banner and let the rejected `install_update` promise settle. */
 async function clickUpdate() {
   document.getElementById('upd')?.dispatchEvent(new Event('click'))
-  // Two turns: one for the invoke promise, one for the .catch handler.
-  await Promise.resolve()
-  await Promise.resolve()
+  // Drain the microtask queue via a macrotask rather than counting `await`s:
+  // a fixed number of turns silently stops covering the handler the moment an
+  // extra `.then` is added to the chain.
+  await new Promise((resolve) => setTimeout(resolve, 0))
 }
 
 beforeAll(() => GlobalRegistrator.register())
@@ -119,9 +141,11 @@ describe('popover update banner', () => {
     expect(updText()?.toLowerCase()).toContain('in progress')
   })
 
-  it('keeps tracking the running install so progress events still land', async () => {
+  it('keeps tracking the running install and does not re-issue the install', async () => {
+    let installCalls = 0
     invokeImpl = async (cmd) => {
       if (cmd === 'install_update') {
+        installCalls++
         throw { kind: 'inProgress', message: 'An update is already being installed.' }
       }
       return null
@@ -133,9 +157,56 @@ describe('popover update banner', () => {
     // popover's listener is gated on that flag. Dropping out of it would
     // freeze this banner on a stale label for the whole download.
     expect(document.getElementById('upd')?.textContent).not.toContain('failed')
+
     await clickUpdate()
-    // A second click must not re-issue the install while one is known to run.
+    // Assert the COMMAND wasn't re-issued. Re-reading the label proves nothing
+    // here - it reads the same whether or not the click was suppressed.
+    expect(installCalls).toBe(1)
     expect(updText()?.toLowerCase()).toContain('in progress')
+
+    // The point of staying in the installing state: the winner's progress is
+    // broadcast to every window, so this banner keeps painting it.
+    emitEvent('update-progress', { downloaded: 25, contentLength: 100 })
+    expect(updText()).toContain('25%')
+  })
+
+  // The regression this whole recovery path exists for. Staying "installing"
+  // is only safe while the winning install is alive; if it dies, the surface
+  // that never received the Err must still be able to retry.
+  it('recovers when the winning install fails, instead of wedging forever', async () => {
+    let installCalls = 0
+    invokeImpl = async (cmd) => {
+      if (cmd === 'install_update') {
+        installCalls++
+        throw { kind: 'inProgress', message: 'An update is already being installed.' }
+      }
+      return null
+    }
+    await clickUpdate()
+    expect(installCalls).toBe(1)
+
+    // download_and_apply broadcasts this on its terminal `Failed` path.
+    emitEvent('update-finished', { ok: false })
+    expect(updText()).toBe('Update failed')
+
+    // …and crucially the banner is live again: without this the retry button
+    // is dead until the app is relaunched.
+    await clickUpdate()
+    expect(installCalls).toBe(2)
+  })
+
+  it('ignores a successful update-finished rather than flashing a failure', async () => {
+    // The success path re-execs the app, so this should not normally be seen -
+    // but an `ok: true` must never paint "Update failed".
+    invokeImpl = async (cmd) => {
+      if (cmd === 'install_update') {
+        throw { kind: 'inProgress', message: 'An update is already being installed.' }
+      }
+      return null
+    }
+    await clickUpdate()
+    emitEvent('update-finished', { ok: true })
+    expect(updText()).not.toBe('Update failed')
   })
 
   it('still reports a genuine pre-relaunch failure as a failure', async () => {
@@ -191,19 +262,33 @@ describe('isInstallInProgress', () => {
 // ── Both surfaces must agree on the discriminant ─────────────────────────────
 
 describe('the two surfaces stay in lockstep', () => {
-  it('both match on the same `inProgress` kind the Rust guard emits', () => {
-    // The popover is plain JS and cannot import from `ui/lib`, so the check is
-    // necessarily written twice. This is the guard against the copies drifting
-    // apart — and against either drifting from the Rust `UpdateErrorKind`.
-    expect(appSrc).toContain("'inProgress'")
-
-    const rustSrc = readFileSync(
-      import.meta.dir + '/../../tray/src-tauri/src/update.rs',
-      'utf8',
-    )
-    // `#[serde(rename_all = "camelCase")]` on the enum is what makes the
-    // variant serialise as `inProgress`; without it both surfaces go blind.
-    expect(rustSrc).toContain('enum UpdateErrorKind')
-    expect(rustSrc).toMatch(/rename_all = "camelCase"\)\]\s*pub enum UpdateErrorKind/)
+  it('the dashboard card also recovers from a terminal failure', () => {
+    // The card is React and this suite tests it through pure helpers rather
+    // than rendering, so the subscription itself is guarded by source scan -
+    // the same convention as `no-native-dialogs.test.ts`. Without it the card
+    // is the surface left wedged, exactly as the popover was.
+    const card = readSrc('components/timeline/UpdateCard.tsx')
+    expect(card).toContain("'update-finished'")
+    const handler = card.slice(card.indexOf("'update-finished'"))
+    expect(handler).toContain('setInstalling(false)')
+    expect(handler).toContain('setElsewhere(false)')
   })
+
+  it('the popover discriminates on the same `inProgress` kind, not on prose', () => {
+    // The popover is plain JS and cannot import from `ui/lib`, so the check is
+    // necessarily written twice. This guards the copies against drifting apart.
+    //
+    // Matching the full comparison, not the bare string: `'inProgress'` alone
+    // also appears in the explanatory comment above the predicate, so it would
+    // still pass with the actual check deleted.
+    expect(appSrc).toContain("kind === 'inProgress'")
+  })
+
+  // The Rust half of the contract is pinned where it can be asserted on the
+  // real value rather than on source text: `update.rs`'s
+  // `a_concurrent_install_is_refused_as_in_progress_not_as_a_failure` serialises
+  // the error and asserts `"kind":"inProgress"`. A source regex over the
+  // `rename_all` attribute was tried here and removed - any attribute added
+  // between it and the enum (a `#[cfg]`, `#[non_exhaustive]`, a rustfmt reflow)
+  // failed it while the wire shape was perfectly intact.
 })

--- a/ui/__tests__/update-in-progress.test.ts
+++ b/ui/__tests__/update-in-progress.test.ts
@@ -1,0 +1,209 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Regression guard for the "Update failed" label that isn't a failure.
+//
+// # The field incident (1.84.0-staging.5 → .7, 2026-08-09)
+// The DMG updater is driven from TWO surfaces that are routinely open at the
+// same time: the tray popover's `.upd` banner and the dashboard sidebar's
+// UpdateCard. Both call the same `install_update` command, which is guarded by
+// a single-flight `INSTALLING` swap in `tray/src-tauri/src/update.rs` — so
+// clicking the second surface while the first is downloading returns
+// `Err(kind: inProgress)`.
+//
+// Both surfaces treated *any* rejection as a failed install. The measured
+// result: the popover rendered "Update failed" and the dashboard offered
+// "Click to try again", while the install those two clicks had actually
+// started completed fine and relaunched the app 36 s later. The user sees a
+// failure that did not happen, and the retry it invites can only be rejected
+// again for as long as the real install runs.
+//
+// # What this locks in
+// A rejection carrying `kind === 'inProgress'` must NEVER render as a failure
+// on either surface — it means "someone else is already installing", so the
+// banner tracks that install instead. A rejection of any other shape (a real
+// pre-relaunch error, or an IPC-level throw that isn't our error object at
+// all) must still render as a failure, or a genuinely broken update would go
+// silent.
+//
+// # Why a DOM harness for the popover
+// The popover is plain HTML+JS in a menu-bar NSPanel; there is no WebDriver
+// path to it on macOS. So, exactly as `popover-health-panel.test.ts` does, the
+// REAL `tray/src/app.js` is loaded into happy-dom over the REAL markup from
+// `index.html`, with a mocked `__TAURI__` bridge. The click handler is
+// registered at module scope, above the `boot()` guard, so it is live under
+// the test flag without booting the ticker.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test'
+import { readFileSync } from 'fs'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { isInstallInProgress } from '../components/timeline/UpdateCard'
+
+const trayDir = import.meta.dir + '/../../tray/src'
+
+// Same extraction as popover-health-panel.test.ts: the real markup, minus the
+// <script> tags we load by hand.
+function stripScriptTags(html: string): string {
+  let out = html
+  let prev: string
+  do {
+    prev = out
+    out = out.replace(/<script\b[^>]*>[\s\S]*?<\/script(?:\s+[^>]*)?\s*>/gi, '')
+  } while (out !== prev)
+  return out
+}
+
+function popoverBody(): string {
+  const html = readFileSync(trayDir + '/index.html', 'utf8')
+  const m = html.match(/<body[^>]*>([\s\S]*)<\/body>/i)
+  return stripScriptTags(m ? m[1] : '')
+}
+
+const pauseUtilsSrc = readFileSync(trayDir + '/pause-utils.js', 'utf8')
+const appSrc = readFileSync(trayDir + '/app.js', 'utf8')
+
+type InvokeImpl = (cmd: string, args?: unknown) => Promise<unknown>
+let invokeImpl: InvokeImpl = async () => null
+
+function loadPopover() {
+  document.body.innerHTML = popoverBody()
+  ;(globalThis as Record<string, unknown>).__MERIDIAN_POPOVER_TEST__ = true
+  ;(globalThis as Record<string, unknown>).__TAURI__ = {
+    core: { invoke: (cmd: string, args?: unknown) => invokeImpl(cmd, args) },
+    event: { listen: async () => () => {} },
+    window: {
+      getCurrentWindow: () => ({ setSize: async () => {} }),
+      LogicalSize: class {
+        constructor(
+          public w: number,
+          public h: number,
+        ) {}
+      },
+    },
+  }
+  ;(0, eval)(pauseUtilsSrc + '\n' + appSrc)
+}
+
+const updText = () => document.getElementById('upd-text')?.textContent
+
+/** Click the banner and let the rejected `install_update` promise settle. */
+async function clickUpdate() {
+  document.getElementById('upd')?.dispatchEvent(new Event('click'))
+  // Two turns: one for the invoke promise, one for the .catch handler.
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+beforeAll(() => GlobalRegistrator.register())
+afterAll(() => GlobalRegistrator.unregister())
+
+beforeEach(() => {
+  invokeImpl = async () => null
+  loadPopover()
+})
+
+// ── The popover banner ───────────────────────────────────────────────────────
+
+describe('popover update banner', () => {
+  it('does NOT say "Update failed" when another surface is already installing', async () => {
+    invokeImpl = async (cmd) => {
+      if (cmd === 'install_update') {
+        // Exactly what the Rust single-flight guard rejects with.
+        throw { kind: 'inProgress', message: 'An update is already being installed.' }
+      }
+      return null
+    }
+    await clickUpdate()
+
+    // The install is real and running; calling that a failure is the bug.
+    expect(updText()).not.toBe('Update failed')
+    expect(updText()?.toLowerCase()).toContain('in progress')
+  })
+
+  it('keeps tracking the running install so progress events still land', async () => {
+    invokeImpl = async (cmd) => {
+      if (cmd === 'install_update') {
+        throw { kind: 'inProgress', message: 'An update is already being installed.' }
+      }
+      return null
+    }
+    await clickUpdate()
+
+    // The banner must stay in the installing state: the winning surface's
+    // `update-progress` events are broadcast to every window, and the
+    // popover's listener is gated on that flag. Dropping out of it would
+    // freeze this banner on a stale label for the whole download.
+    expect(document.getElementById('upd')?.textContent).not.toContain('failed')
+    await clickUpdate()
+    // A second click must not re-issue the install while one is known to run.
+    expect(updText()?.toLowerCase()).toContain('in progress')
+  })
+
+  it('still reports a genuine pre-relaunch failure as a failure', async () => {
+    invokeImpl = async (cmd) => {
+      if (cmd === 'install_update') {
+        throw { kind: 'failed', message: 'signature verification failed' }
+      }
+      return null
+    }
+    await clickUpdate()
+    expect(updText()).toBe('Update failed')
+  })
+
+  it('treats a non-object rejection (IPC-level throw) as a failure', async () => {
+    // If the bridge itself dies the rejection is an Error, not our shape.
+    // Defaulting that to "in progress" would hide a broken updater.
+    invokeImpl = async (cmd) => {
+      if (cmd === 'install_update') throw new Error('ipc closed')
+      return null
+    }
+    await clickUpdate()
+    expect(updText()).toBe('Update failed')
+  })
+})
+
+// ── The dashboard card's discriminator ───────────────────────────────────────
+//
+// UpdateCard is a React component; following this suite's convention
+// (`staleAmount`, `phaseFor`, `canPickProposalProvider`), the decision is
+// extracted as a pure predicate and tested directly rather than rendered.
+
+describe('isInstallInProgress', () => {
+  it('recognises the single-flight rejection', () => {
+    expect(
+      isInstallInProgress({ kind: 'inProgress', message: 'An update is already being installed.' }),
+    ).toBe(true)
+  })
+
+  it('rejects a real failure, so it still surfaces as one', () => {
+    expect(isInstallInProgress({ kind: 'failed', message: 'boom' })).toBe(false)
+  })
+
+  it('rejects shapes it does not understand rather than guessing', () => {
+    // Anything that isn't our error object gets the safe reading: a failure.
+    expect(isInstallInProgress(new Error('ipc closed'))).toBe(false)
+    expect(isInstallInProgress('An update is already being installed.')).toBe(false)
+    expect(isInstallInProgress(null)).toBe(false)
+    expect(isInstallInProgress(undefined)).toBe(false)
+    expect(isInstallInProgress({})).toBe(false)
+  })
+})
+
+// ── Both surfaces must agree on the discriminant ─────────────────────────────
+
+describe('the two surfaces stay in lockstep', () => {
+  it('both match on the same `inProgress` kind the Rust guard emits', () => {
+    // The popover is plain JS and cannot import from `ui/lib`, so the check is
+    // necessarily written twice. This is the guard against the copies drifting
+    // apart — and against either drifting from the Rust `UpdateErrorKind`.
+    expect(appSrc).toContain("'inProgress'")
+
+    const rustSrc = readFileSync(
+      import.meta.dir + '/../../tray/src-tauri/src/update.rs',
+      'utf8',
+    )
+    // `#[serde(rename_all = "camelCase")]` on the enum is what makes the
+    // variant serialise as `inProgress`; without it both surfaces go blind.
+    expect(rustSrc).toContain('enum UpdateErrorKind')
+    expect(rustSrc).toMatch(/rename_all = "camelCase"\)\]\s*pub enum UpdateErrorKind/)
+  })
+})

--- a/ui/components/timeline/UpdateCard.tsx
+++ b/ui/components/timeline/UpdateCard.tsx
@@ -16,13 +16,39 @@
 
 import { useEffect, useState } from 'react'
 import { invoke, isTauri, subscribe } from '@/lib/bridge'
-import type { UpdateProgress, UpdateStatus } from '@/lib/api-types'
+import type { UpdateError, UpdateProgress, UpdateStatus } from '@/lib/api-types'
+
+/**
+ * True when `install_update` was refused because an install is ALREADY running
+ * (the Rust single-flight guard), rather than because one failed.
+ *
+ * The card and the tray popover can both be open, and both drive the same
+ * command - so the second one clicked always loses this race. Treating that
+ * loss as a failure is what showed "Update failed / Click to try again" over a
+ * download that went on to succeed.
+ *
+ * Anything that isn't the exact `{ kind: 'inProgress' }` object gets the safe
+ * reading - a failure. An IPC-level throw arrives as an `Error`, and guessing
+ * "in progress" there would hide a genuinely broken updater behind a reassuring
+ * label. Exported for `ui/__tests__/update-in-progress.test.ts`.
+ */
+export function isInstallInProgress(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as Partial<UpdateError>).kind === 'inProgress'
+  )
+}
 
 export function UpdateCard() {
   const [status, setStatus] = useState<UpdateStatus | null>(null)
   const [installing, setInstalling] = useState(false)
   const [pct, setPct] = useState<number | null>(null)
   const [failed, setFailed] = useState(false)
+  // Set when *another* surface owns the running install. Stays in the installing
+  // state (so the shared `update-progress` events keep painting this card) but
+  // labels itself honestly until the first percentage lands.
+  const [elsewhere, setElsewhere] = useState(false)
 
   // Check once on mount; only keep an *available* result (up-to-date / error /
   // unsupported stay silent, same as the popover).
@@ -53,9 +79,17 @@ export function UpdateCard() {
     if (installing) return
     setInstalling(true)
     setFailed(false)
+    setElsewhere(false)
     setPct(null)
     // Resolves only on failure - success re-execs the app (the relaunch).
-    invoke('install_update').catch(() => {
+    invoke('install_update').catch((err) => {
+      if (isInstallInProgress(err)) {
+        // The other surface got there first. Stay installing: its progress
+        // events are broadcast to every window, so this card keeps tracking the
+        // real download and the app relaunches under both of them.
+        setElsewhere(true)
+        return
+      }
       setInstalling(false)
       setFailed(true)
     })
@@ -74,7 +108,9 @@ export function UpdateCard() {
     : installing
       ? pct !== null
         ? `Downloading... ${pct}%`
-        : 'Starting...'
+        : elsewhere
+          ? 'Already in progress...'
+          : 'Starting...'
       : `v${status.currentVersion} → v${status.version}`
 
   return (

--- a/ui/components/timeline/UpdateCard.tsx
+++ b/ui/components/timeline/UpdateCard.tsx
@@ -73,6 +73,22 @@ export function UpdateCard() {
     })
   }, [])
 
+  // Terminal failure of the install this card is tracking. Broadcast app-wide by
+  // download_and_apply, because the surface that LOST the single-flight race
+  // never receives that Err itself - without this it stays disabled on
+  // "Already in progress..." forever when the winning install dies, which is a
+  // worse outcome than the mislabel this component was fixed for.
+  useEffect(() => {
+    if (!isTauri()) return
+    return subscribe<{ ok: boolean }>('/api/update/finished', null, 'update-finished', (d) => {
+      if (d?.ok) return
+      setInstalling(false)
+      setElsewhere(false)
+      setPct(null)
+      setFailed(true)
+    })
+  }, [])
+
   if (!status) return null
 
   const onInstall = () => {

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -778,6 +778,19 @@ export interface UpdateProgress {
   contentLength: number | null
 }
 
+// What `install_update` rejects with — mirrors `update.rs`'s `UpdateError`.
+//
+// `kind` exists so a banner can tell a broken update from a busy one. Both
+// surfaces can be open at once and both call the same command, so clicking the
+// second while the first downloads hits the Rust single-flight guard and gets
+// `inProgress` back. That is not a failure: the install is running and will
+// relaunch the app. Rendering it as one (and inviting a retry that can only be
+// refused again) is the bug `update-in-progress.test.ts` guards.
+export interface UpdateError {
+  kind: 'inProgress' | 'failed'
+  message: string
+}
+
 // ── What's New (`get_whats_new`) ───────────────────────────────────────────────
 
 export interface ReleaseNote {


### PR DESCRIPTION
## The bug

The DMG updater is driven from two surfaces that are routinely open at the same
time - the tray popover's `.upd` banner and the dashboard sidebar's `UpdateCard`.
Both call the same `install_update` command, which is guarded by a single-flight
`INSTALLING` swap. Clicking the second surface while the first is downloading
therefore gets a refusal back.

Both surfaces rendered **any** rejection as `Update failed`.

Observed on 1.84.0-staging.5 -> .7 this morning, reconstructed from the telemetry
spool:

```
16:26:04  check_update            -> "newer version available"  (popover + card both mount)
16:27:04  install_update           (click 1 - wins the slot, starts downloading)
16:27:05  update install failed: An update is already being installed.   (click 2 - refused)
16:27:40  /Applications/Meridian.app replaced; tray relaunches into staging.7
```

The update **succeeded**. The user saw `Update failed` and, on the dashboard,
`Click to try again` - a retry that can only be refused again for as long as the
real install runs. The screenshots that prompted this were the dying pre-relaunch
process, which is also why the popover footer still read staging.5.

## The fix

`download_and_apply` now returns a typed `UpdateError { kind, message }` instead
of a bare `String`, so callers can tell the single-flight refusal
(`kind: "inProgress"`) from a real pre-relaunch fault (`kind: "failed"`).

Four call sites were mislabelling the refusal; all four now branch on `kind`:

- **Tray popover** (`tray/src/app.js`) - shows `Update in progress...`
- **Dashboard card** (`ui/components/timeline/UpdateCard.tsx`) - stays in the
  installing state instead of flipping to failed
- **Tray menu** "Check for Updates..." (`update.rs`) - toasts
  `Update already in progress` rather than `Update failed`
- **Mandatory-update enforcement** (`update.rs`) - logs the deferral at INFO
  instead of `forced install failed - retrying` at WARN. This one only ever hit
  the logs, but it is the same defect and it sends support chasing an update path
  that was working.

### Two things worth reviewing as decisions, not as bug fixes

1. **The losing surface now stays in the installing state** rather than dropping
   out. `update-progress` is emitted to every window, so the loser keeps painting
   the winner's percentage and both relaunch together. The alternative (go idle,
   re-enable the button) invites the refused retry that caused this report.
2. **A new `system.update` dedup key `in_progress`** for the tray-menu toast,
   alongside the existing `failed` / `uptodate` / `unsupported` keys.

## Anything that isn't our error object stays a failure

An IPC-level throw arrives as an `Error`, not `{ kind }`. Defaulting that to
"in progress" would hide a genuinely broken updater behind a reassuring label, so
the predicate is strict and everything it does not recognise reads as a failure.

## Tests

Written before the fix; the four popover cases were a genuine red against the
unmodified `app.js` (they rendered `Update failed`).

- `ui/__tests__/update-in-progress.test.ts` (new, 8 cases) - drives the **real**
  `tray/src/app.js` in happy-dom over the real `index.html` markup with a mocked
  `__TAURI__` bridge (same harness as `popover-health-panel.test.ts`, since a
  menu-bar NSPanel has no WebDriver path on macOS). Covers: in-progress is not a
  failure, the banner keeps tracking the running install, a real fault still
  reads as a failure, a non-object throw still reads as a failure, and a lockstep
  guard that the JS, TSX and Rust spellings of `inProgress` cannot drift apart.
- `update.rs` - `a_concurrent_install_is_refused_as_in_progress_not_as_a_failure`
  pins the kind **and** the serialised wire shape `"kind":"inProgress"` that both
  banners match on; `real_faults_keep_the_failed_kind_and_their_message`.

Verified in an isolated worktree off `pre-main`:

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings` - clean
- `cargo fmt --all -- --check` - clean
- `bun test` in `ui/` - 716 pass

## One thing the tests structurally cannot cover

This is the first `#[tauri::command]` in the repo to return a non-`String` error,
so the JS side depends on Tauri delivering the struct as an object rather than
stringifying it. Confirmed by reading `tauri-2.11.2/src/ipc/mod.rs`:
`InvokeResponse::from(Result<T, E>)` takes the `Err(err) => Self::Err(err.into())`
arm, which resolves to the blanket `impl<T: Serialize> From<T> for InvokeError`
(`serde_json::to_value`). The stringifying `InvokeError::from_error` path applies
only to an Ok-body serialisation failure.

The unit tests mock the rejection shape, so they would pass either way - a
packaged-build click-both-surfaces smoke test is the real confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VcBjYEVA8pzFD9JhTs32ya


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved update installation feedback when an installation is already in progress elsewhere.
  - The tray and dashboard now remain in progress mode and continue displaying shared progress updates.
  - Added an informational message for concurrent installation attempts.

- **Bug Fixes**
  - Genuine update failures continue to display clear error states and messages.
  - Improved consistency in update error handling across the tray and dashboard.

- **Tests**
  - Added coverage for concurrent installations, failure handling, error serialization, and progress-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->