### PR TITLE
fix(notifications): resolve every deep link, quiet the back-online toast (slices 0b + 3)

### DIFF
--- a/NOTIFICATIONS.md
+++ b/NOTIFICATIONS.md
@@ -276,14 +276,15 @@ on. That is why all six `system.update` toasts stay.
 | `plan.nudge` | Ask | `plan_nudge` | Open Plan · Snooze 1h | snooze → re-enqueue +1h |
 | `worklog.ready` | Ask | `worklog_ready` | Open Worklogs · Snooze 1h | snooze → re-enqueue +1h — **registered but no producer fires it yet** (needs its own scoping: worklog generation is currently on-demand/user-clicked, not scheduled) |
 | `system.fault` | Fault | `system_fault` | View | — (stamp only) |
-| `system.pause` | Status | `system_fault` | View | — (stamp only) — pause/resume, folded off the `sys::notify` bypass |
+| `system.pause` | Fault\*\* | `system_fault` | View | — (stamp only) — pause/resume, folded off the `sys::notify` bypass. \*\*The pause notice is a live condition (tracking is off — a Fault). Its "Resumed" toast (`commands/pause.rs`) is structurally identical to the removed back-online toast — one-shot, timestamp dedup, native — but fires ONLY on a manual resume, so it is a response to a click, not unsolicited Status |
 | `system.health` | Fault | `system_fault` | View | — (stamp only) — daemon went quiet, or the tray couldn't finish installing the backend. The paired **"Back online." recovery toast was removed** (Status: it confirmed a recovery the user often never knew about, and fired on Meridian's own restarts); the banner clearing is the recovery signal |
 | `system.update` | Ask/Fault | `system_fault`\* | View\* | — (stamp only) — update check/download/failure, folded off the bypass. \*Discrete one-shot events (not raise/clear state), so these go through `notifications::enqueue` directly rather than `notices::raise_typed` — see `tray/src-tauri/src/update.rs::notify_update` |
 | `system.notif_permission` | Fault | `system_fault` | View | — (stamp only) — notification permission revoked (macOS TCC or, since gotcha #9, Windows' `ToastNotifier::Setting()`); the one notice guaranteed to reach the user via the dashboard banner even when toasts themselves are broken |
 | `system.capture_permission` | Fault | `system_fault` | View | — (stamp only) — Accessibility/Screen Recording revoked mid-session |
 | `system.disk_low` | Fault | `system_fault` | View | — (stamp only) — `~/.meridian`'s volume below 2 GB free |
 | `pm_worklog.{provider}` | Fault | `system_fault` | View | — (stamp only) — a worklog post to the tracker failed permanently |
-| `summariser.dead_letter` | Status | `generic_link` | Open | — (stamp only) — daily digest of permanently-failed coding-agent summarisation, `dedup_key` scoped per day |
+| `summariser.dead_letter` | Fault | `generic_link` | Open | — (stamp only) — daily digest of permanently-failed coding-agent summarisation, `dedup_key` scoped per day. Body asks the user to check their coding-agent CLIs are signed in, so it is a Fault needing action, not Status |
+| `worklog.stale` | Ask | `generic_link` | Open | — (stamp only) — a draft has drifted from the work it describes; links to the worklog review surface |
 | *(reserved)* | Ask | `verify_switch` | Yes · No · Reply… | — (PR 2: task-switch verification) |
 | *(generic)* | — | `generic_link` | Open | — (stamp only) |
 

--- a/NOTIFICATIONS.md
+++ b/NOTIFICATIONS.md
@@ -104,11 +104,17 @@ simple for the user.
    derived from `responded_at`, so a retry is a no-op). Rows not matched by any
    arm are just stamped consumed.
 
-4. **Per-type toggle** — add a field to `RuntimeSettings`
-   (`meridian-core/src/settings.rs`), a match arm in
-   `meridian-core/src/notifications.rs::type_enabled`, and the checkbox in
-   `ui/components/timeline/settings/NotificationsSection.tsx`. Unknown
-   event keys default to enabled, so this step gates opt-out, not delivery.
+4. **Deep link** — if the toast should go somewhere, `.link(deep_links::X)`
+   using a constant from `meridian-core/src/notifications/mod.rs::deep_links`,
+   never a raw path. A new destination means adding the constant AND an arm in
+   `MeridianTimelineShell.tsx`'s `navigate`; two guard tests
+   (`tests/deep_links.rs`, `ui/__tests__/deep-links.test.ts`) fail if you do
+   one without the other.
+
+There is **no step 4 for a per-type settings toggle** — that used to be listed
+here and the machinery (`type_enabled`, the `notify_*` fields) was deleted.
+Every event is gated by the master switch alone; classification and timing are
+decided in code, not handed to the user.
 
 No tray changes are needed — delivery, buttons, response capture, deep-link
 navigation, and expiry all key off the row's columns.
@@ -234,23 +240,52 @@ Swift → Rust → JS chain is visible in stderr. Look for
 registered`, `outbox toast delivered`, `notification action event: {...}`,
 `notification response recorded`, `notification responses consumed`.
 
+## Is it notification-worthy? Ask / Fault / Status
+
+Before adding a producer, decide which of three things it is. This is an
+engineering decision, not a user preference — there is still exactly one user
+knob (the master switch, plus quiet hours), and nothing here adds another.
+
+| Class | Means | Channel | Expiry |
+|---|---|---|---|
+| **Ask** | A question only the user can answer; Meridian is worse off until they do | native + banner, inside working hours | ends when the answer stops mattering |
+| **Fault** | Something is broken and the user must act. Fires at any hour | native + banner, once per *raise* (not per detection) | cleared by recovery |
+| **Status** | State changed; nothing is being asked | banner or tray only — **never a toast** | short, self-expiring |
+
+`plan.nudge` is the reference Ask, and it is the only event with a meaningful
+answer rate (35 of 36 on a real install over five weeks; every other event key
+sat near zero). The difference is that it asks something, at a sane hour, and
+expires.
+
+**Status is the trap.** An internal state transition feels notification-worthy
+to the person writing it and is noise to everyone else. `system.health`'s
+"Back online." fired 18 times in five weeks for one interaction before it was
+removed — see the comment above `refresh_health`'s `notify_back` arm for the
+full post-mortem, including why "confirm the recovery" was the wrong instinct.
+
+A confirmation of something the **user just clicked** is not Status — it is the
+response to their action, and the tray menu has no other surface to render one
+on. That is why all six `system.update` toasts stay.
+
 ## Current producers & categories
 
-| event_key | category | buttons | consumer arm |
-|---|---|---|---|
-| `plan.nudge` | `plan_nudge` | Open Plan · Snooze 1h | snooze → re-enqueue +1h |
-| `worklog.ready` | `worklog_ready` | Open Worklogs · Snooze 1h | snooze → re-enqueue +1h — **registered but no producer fires it yet** (needs its own scoping: worklog generation is currently on-demand/user-clicked, not scheduled) |
-| `system.fault` | `system_fault` | View | — (stamp only) |
-| `system.pause` | `system_fault` | View | — (stamp only) — pause/resume, folded off the `sys::notify` bypass |
-| `system.health` | `system_fault` | View | — (stamp only) — daemon went-quiet/back-online, folded off the bypass |
-| `system.update` | `system_fault`\* | View\* | — (stamp only) — update check/download/failure, folded off the bypass. \*Discrete one-shot events (not raise/clear state), so these go through `notifications::enqueue` directly rather than `notices::raise_typed` — see `tray/src-tauri/src/update.rs::notify_update` |
-| `system.notif_permission` | `system_fault` | View | — (stamp only) — notification permission revoked (macOS TCC or, since gotcha #9, Windows' `ToastNotifier::Setting()`); the one notice guaranteed to reach the user via the dashboard banner even when toasts themselves are broken |
-| `system.capture_permission` | `system_fault` | View | — (stamp only) — Accessibility/Screen Recording revoked mid-session |
-| `system.disk_low` | `system_fault` | View | — (stamp only) — `~/.meridian`'s volume below 2 GB free |
-| `pm_worklog.{provider}` | `system_fault` | View | — (stamp only) — a worklog post to the tracker failed permanently |
-| `summariser.dead_letter` | `generic_link` | Open | — (stamp only) — daily digest of permanently-failed coding-agent summarisation, `dedup_key` scoped per day |
-| *(reserved)* | `verify_switch` | Yes · No · Reply… | — (PR 2: task-switch verification) |
-| *(generic)* | `generic_link` | Open | — (stamp only) |
+`class` is the taxonomy above.
+
+| event_key | class | category | buttons | consumer arm |
+|---|---|---|---|---|
+| `plan.nudge` | Ask | `plan_nudge` | Open Plan · Snooze 1h | snooze → re-enqueue +1h |
+| `worklog.ready` | Ask | `worklog_ready` | Open Worklogs · Snooze 1h | snooze → re-enqueue +1h — **registered but no producer fires it yet** (needs its own scoping: worklog generation is currently on-demand/user-clicked, not scheduled) |
+| `system.fault` | Fault | `system_fault` | View | — (stamp only) |
+| `system.pause` | Status | `system_fault` | View | — (stamp only) — pause/resume, folded off the `sys::notify` bypass |
+| `system.health` | Fault | `system_fault` | View | — (stamp only) — daemon went quiet, or the tray couldn't finish installing the backend. The paired **"Back online." recovery toast was removed** (Status: it confirmed a recovery the user often never knew about, and fired on Meridian's own restarts); the banner clearing is the recovery signal |
+| `system.update` | Ask/Fault | `system_fault`\* | View\* | — (stamp only) — update check/download/failure, folded off the bypass. \*Discrete one-shot events (not raise/clear state), so these go through `notifications::enqueue` directly rather than `notices::raise_typed` — see `tray/src-tauri/src/update.rs::notify_update` |
+| `system.notif_permission` | Fault | `system_fault` | View | — (stamp only) — notification permission revoked (macOS TCC or, since gotcha #9, Windows' `ToastNotifier::Setting()`); the one notice guaranteed to reach the user via the dashboard banner even when toasts themselves are broken |
+| `system.capture_permission` | Fault | `system_fault` | View | — (stamp only) — Accessibility/Screen Recording revoked mid-session |
+| `system.disk_low` | Fault | `system_fault` | View | — (stamp only) — `~/.meridian`'s volume below 2 GB free |
+| `pm_worklog.{provider}` | Fault | `system_fault` | View | — (stamp only) — a worklog post to the tracker failed permanently |
+| `summariser.dead_letter` | Status | `generic_link` | Open | — (stamp only) — daily digest of permanently-failed coding-agent summarisation, `dedup_key` scoped per day |
+| *(reserved)* | Ask | `verify_switch` | Yes · No · Reply… | — (PR 2: task-switch verification) |
+| *(generic)* | — | `generic_link` | Open | — (stamp only) |
 
 **Removed:** `board.hygiene` (daily digest of tickets needing attention) — its
 only job was to pull the user into the Board Cleanup flow, and that UI is

--- a/meridian-core/src/notifications/mod.rs
+++ b/meridian-core/src/notifications/mod.rs
@@ -165,8 +165,12 @@ pub mod deep_links {
     pub const LEGACY: [&str; 2] = ["/tasks?integrations=1", "/health"];
 
     /// Whether `link` is a value the shell is expected to resolve — current
-    /// vocabulary or legacy. Used by the guard test and by producers that
-    /// accept a caller-supplied link.
+    /// vocabulary or legacy.
+    ///
+    /// Used by `tests/deep_links.rs`. Deliberately NOT called by producers: a
+    /// runtime check would fire on the user's machine long after the mistake
+    /// was made, whereas the static scan fails the build. If a producer ever
+    /// takes a caller-supplied link (none does today), this is the gate for it.
     pub fn is_known(link: &str) -> bool {
         ALL.contains(&link) || LEGACY.contains(&link)
     }

--- a/meridian-core/src/notifications/mod.rs
+++ b/meridian-core/src/notifications/mod.rs
@@ -98,6 +98,80 @@ pub mod categories {
     }
 }
 
+/// The fixed `deep_link` vocabulary — every value a producer may put on a
+/// notification or notice, and nothing else.
+///
+/// These are NOT URLs. The dashboard is a static export whose only real routes
+/// are `/`, `/setup` and `/uninstall`; a deep link is a *navigation intent*
+/// the shell resolves to a modal or a settings section
+/// (`MeridianTimelineShell.tsx`'s `navigate`). The path-like spelling is
+/// historical — they are the former Next route paths, kept because rows
+/// carrying them are already in users' outboxes.
+///
+/// Why this module exists: `navigate` used to handle three values with no
+/// `else` arm, while producers emitted seven. The other four — including the
+/// `[View]` button on every fault toast — silently opened the dashboard's
+/// default view instead of the thing the notification was about, and
+/// `/tasks?integrations=1` went on being emitted for months after the `/tasks`
+/// route was deleted. Nothing failed, because nothing checked. [`ALL`] is what
+/// the two guard tests check against: `deep_link_literals_are_all_known`
+/// (Rust, every literal in a producer is listed here) and
+/// `deep-links.test.ts` (bun, `navigate` handles every entry here).
+///
+/// **Adding one means updating `navigate` in the same change** — the bun guard
+/// fails otherwise. Legacy spellings stay handled by `navigate` forever (old
+/// rows never rewrite themselves) but must not be used by new producers, which
+/// is why they live in [`LEGACY`] rather than here.
+pub mod deep_links {
+    /// The daily planner.
+    pub const PLAN: &str = "/plan";
+    /// Worklog review.
+    pub const WORKLOGS: &str = "/worklogs";
+    /// The What's New modal.
+    pub const WHATS_NEW: &str = "/whats-new";
+    /// The dashboard's own default view (dismisses any open modal).
+    pub const TODAY: &str = "/today";
+    /// Settings, at its default section.
+    pub const SETTINGS: &str = "/settings";
+    /// Settings → Integrations — where a tracker is (re)connected.
+    pub const INTEGRATIONS: &str = "/settings/integrations";
+    /// Settings → Account, which holds the Support ID and Export Diagnostics.
+    /// This is where a fault sends the user: there is no in-app log viewer, so
+    /// the actionable response to "something broke" is exporting diagnostics
+    /// and quoting the Support ID. The `/logs` spelling predates that being
+    /// true and is kept only because outbox rows carry it.
+    pub const LOGS: &str = "/logs";
+
+    /// Every link a producer may emit.
+    pub const ALL: [&str; 7] = [
+        PLAN,
+        WORKLOGS,
+        WHATS_NEW,
+        TODAY,
+        SETTINGS,
+        INTEGRATIONS,
+        LOGS,
+    ];
+
+    /// Spellings retired from the producer side but still resolvable, because
+    /// undelivered rows and older installs carry them. `navigate` must keep
+    /// handling these; new code must not emit them.
+    ///
+    /// - `/tasks?integrations=1` — the pre-fold Next route for the tracker
+    ///   panel, emitted by every `pm.*` sync fault until it moved to
+    ///   [`INTEGRATIONS`]. The `/tasks` route itself no longer exists.
+    /// - `/health` — an early daemon-health target; observed on rows in the
+    ///   wild, no longer emitted anywhere.
+    pub const LEGACY: [&str; 2] = ["/tasks?integrations=1", "/health"];
+
+    /// Whether `link` is a value the shell is expected to resolve — current
+    /// vocabulary or legacy. Used by the guard test and by producers that
+    /// accept a caller-supplied link.
+    pub fn is_known(link: &str) -> bool {
+        ALL.contains(&link) || LEGACY.contains(&link)
+    }
+}
+
 /// A native notification ready to fire (the shape the tray delivers + the route
 /// returns). `category`/`actions` are `None` on plain rows AND on a pre-057 DB
 /// (the columns are selected only when present), so the tray falls back to a

--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -822,7 +822,7 @@ pub async fn maybe_notify_dead_letters(pool: &SqlitePool) -> anyhow::Result<()> 
             "Some coding sessions weren't summarised",
             &body,
         )
-        .link("/settings"),
+        .link(meridian_core::notifications::deep_links::SETTINGS),
     )
     .await?;
     Ok(())

--- a/src/daily_plan.rs
+++ b/src/daily_plan.rs
@@ -113,7 +113,7 @@ pub async fn maybe_nudge(pool: &SqlitePool) -> Result<()> {
         "Plan your day",
         "Pick what you're working on today so Meridian can match your work to the right tickets.",
     )
-    .link("/plan")
+    .link(meridian_core::notifications::deep_links::PLAN)
     .interactive(categories::PLAN_NUDGE);
     if let Some(exp) = expires.as_deref() {
         nudge = nudge.expiring(exp);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1202,7 +1202,7 @@ async fn main() -> Result<()> {
                                     "Quit Meridian, then run 'meridian db repair' in a terminal",
                                 ),
                                 event_key: DB_CORRUPT_NOTICE,
-                                deep_link: Some("/logs"),
+                                deep_link: Some(meridian_core::notifications::deep_links::LOGS),
                             },
                         )
                         .await;
@@ -1517,7 +1517,7 @@ async fn etl_tick(meridian: &meridian::db::SqlitePool) -> bool {
                     detail: &e.to_string(),
                     remedy: Some("Quit Meridian, then run 'meridian db repair' in a terminal"),
                     event_key: DB_CORRUPT_NOTICE,
-                    deep_link: Some("/logs"),
+                    deep_link: Some(meridian_core::notifications::deep_links::LOGS),
                 },
             )
             .await;

--- a/src/notices.rs
+++ b/src/notices.rs
@@ -35,10 +35,18 @@ pub async fn raise(
     detail: &str,
     remedy: Option<&str>,
 ) -> Result<()> {
+    // A tracker fault is fixed by reconnecting the tracker, which is what this
+    // notice's own `remedy` tells the user ("Reconnect X in Settings →
+    // Integrations") — so the click-through goes there. It used to point at
+    // `/tasks?integrations=1`, the pre-fold Next route, which the shell stopped
+    // resolving when that route was deleted and silently opened the default
+    // view instead. Everything else has no specific destination, so it goes to
+    // the Support ID / Export Diagnostics section (see `deep_links::LOGS`).
+    use meridian_core::notifications::deep_links;
     let link = if id.starts_with("pm.") {
-        Some("/tasks?integrations=1")
+        Some(deep_links::INTEGRATIONS)
     } else {
-        Some("/logs")
+        Some(deep_links::LOGS)
     };
     raise_typed(
         pool,
@@ -214,7 +222,7 @@ mod tests {
                 detail: "Tap to check what happened.",
                 remedy: None,
                 event_key: "system.health",
-                deep_link: Some("/logs"),
+                deep_link: Some(meridian_core::notifications::deep_links::LOGS),
             },
         )
         .await
@@ -252,7 +260,7 @@ mod tests {
                 detail: "Tap to check what happened.",
                 remedy: None,
                 event_key: "system.health",
-                deep_link: Some("/logs"),
+                deep_link: Some(meridian_core::notifications::deep_links::LOGS),
             },
         )
         .await

--- a/src/worklog_pipeline/stale.rs
+++ b/src/worklog_pipeline/stale.rs
@@ -69,7 +69,7 @@ pub async fn notify_stale_drafts(pool: &SqlitePool, day_local: &str) {
             "Your worklog draft is out of date",
             &body,
         )
-        .link("/today");
+        .link(meridian_core::notifications::deep_links::TODAY);
         if let Err(e) = notifications::enqueue(pool, n).await {
             tracing::warn!(
                 day = day_local,

--- a/src/worklog_pipeline/stale.rs
+++ b/src/worklog_pipeline/stale.rs
@@ -69,7 +69,11 @@ pub async fn notify_stale_drafts(pool: &SqlitePool, day_local: &str) {
             "Your worklog draft is out of date",
             &body,
         )
-        .link(meridian_core::notifications::deep_links::TODAY);
+        // The draft is edited in the worklog review surface, not on the
+        // timeline. `/today` merely closed any open modal, which resolved but
+        // landed nowhere useful — the one ALL entry whose handler was still
+        // behaviourally a no-op.
+        .link(meridian_core::notifications::deep_links::WORKLOGS);
         if let Err(e) = notifications::enqueue(pool, n).await {
             tracing::warn!(
                 day = day_local,

--- a/tests/deep_links.rs
+++ b/tests/deep_links.rs
@@ -108,11 +108,15 @@ fn deep_link_literals(code: &str) -> Vec<String> {
         // Advance past this anchor regardless of what we find, so overlapping
         // matches (`deep_link` contains `link`) can't loop forever.
         cursor = at + 1;
-        let end = (at + LOOKAHEAD).min(code.len());
         // Respect char boundaries — source files carry non-ASCII (em-dashes in
-        // comments), and slicing mid-codepoint would panic.
-        if !code.is_char_boundary(at) || !code.is_char_boundary(end) {
-            continue;
+        // comments) and slicing mid-codepoint would panic. Walk the END down to
+        // the nearest boundary rather than skipping the window: `continue` here
+        // would silently drop every literal in that anchor's range, quietly
+        // reducing coverage in exactly the way this guard exists to prevent.
+        // (`at` is a match offset, so it is always a boundary already.)
+        let mut end = (at + LOOKAHEAD).min(code.len());
+        while end > at && !code.is_char_boundary(end) {
+            end -= 1;
         }
         let mut rest = &code[at..end];
         while let Some(i) = rest.find('"') {

--- a/tests/deep_links.rs
+++ b/tests/deep_links.rs
@@ -1,0 +1,213 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Static regression guard for the notification/notice `deep_link` vocabulary.
+//!
+//! # The incident
+//! `MeridianTimelineShell.tsx`'s `navigate` resolved exactly three targets
+//! (`/plan`, `/worklogs`, `/whats-new`) with **no `else` arm**, while producers
+//! emitted seven. The other four fell through in silence and opened the
+//! dashboard's default view — so the `[View]` button on every fault toast went
+//! nowhere in particular. Worse, `/tasks?integrations=1` kept being emitted by
+//! all five `pm.*` sync faults long after the `/tasks` route was deleted in the
+//! Next fold, because a link that resolves to nothing is indistinguishable from
+//! a link that resolves correctly: no error, no log, no failing test.
+//!
+//! # What this locks
+//! Every `deep_link` literal a Rust producer emits is a value
+//! [`meridian_core::notifications::deep_links`] declares. The other half of the
+//! contract — that the shell actually handles each declared value — is
+//! `ui/__tests__/deep-links.test.ts`, which reads the same constants. Both are
+//! needed: this one alone would happily pass while `navigate` ignored the lot.
+//!
+//! Placed in the root crate for the same reason as `tray_assets.rs` — it only
+//! reads files by path, so it runs under the pre-push hook and CI without any
+//! of the tray's macOS/capture dependencies.
+
+use meridian_core::notifications::deep_links;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Source trees that contain notification/notice producers.
+const PRODUCER_DIRS: &[&str] = &["src", "tray/src-tauri/src", "meridian-core/src"];
+
+/// Collect every `.rs` file under `dir`, recursively.
+fn rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for e in entries.flatten() {
+        let p = e.path();
+        if p.is_dir() {
+            rust_files(&p, out);
+        } else if p.extension().is_some_and(|x| x == "rs") {
+            out.push(p);
+        }
+    }
+}
+
+/// How far past a `link` / `navigate` mention a path literal still counts as
+/// that mention's argument. Generous enough to cross the line break in
+///
+/// ```ignore
+/// let link = if id.starts_with("pm.") {
+///     Some("/tasks?integrations=1")
+/// ```
+///
+/// and tight enough that an unrelated path later in the function doesn't get
+/// attributed to it.
+const LOOKAHEAD: usize = 200;
+
+/// The four shapes that actually attach a deep link to something, lowercase.
+///
+/// Anchoring on these rather than on the bare word `link` is not fussiness: a
+/// looser rule flagged `pm_worklog/trello.rs`'s `parse_short_link`, a URL
+/// parser that mentions `/c/` and has nothing to do with notifications. The
+/// anchors are, in order: the struct/builder field (`Notice { deep_link: … }`,
+/// `NewNotification.deep_link`, `(…).then_some(…)` assigned to it), the builder
+/// method, the tray's non-outbox navigation call, and the local binding in
+/// `notices.rs::raise` that computes a link before handing it over.
+const ANCHORS: [&str; 4] = ["deep_link", ".link(", "navigate_dashboard", "let link"];
+
+/// Pull every path-shaped string literal that sits near a link/navigate mention.
+///
+/// # Why it scans a window rather than a line
+/// Two earlier drafts of this test passed while catching nothing, and both
+/// failures are instructive:
+///
+/// 1. Matching exact call shapes (`deep_link: Some(`, `.link(`, `then_some(`)
+///    missed the single most important site in the repo — `notices.rs`'s
+///    `let link = if id.starts_with("pm.") { Some("…") }`, a bare `Some(`
+///    bound to a variable, which is where the dead `/tasks?integrations=1`
+///    actually lived.
+/// 2. Widening to "any `"/…"` on a line mentioning link" *still* missed it,
+///    because `let link =` and the literal are on **different lines**.
+///
+/// So the rule is: find each `link`/`navigate` mention, then look ahead
+/// [`LOOKAHEAD`] bytes — across newlines — for path literals. A guard that only
+/// recognises the shapes its author thought of is how the original bug survived
+/// for months; verify any future change to this function against a deliberate
+/// regression, not just against a clean tree.
+///
+/// Only *literal* arguments are returned; a constant reference
+/// (`deep_links::LOGS`) yields nothing. That is the point — the remediation is
+/// that producers reference constants, so a clean scan means "no raw paths were
+/// reintroduced" as much as "every path is known".
+fn deep_link_literals(code: &str) -> Vec<String> {
+    let lower = code.to_ascii_lowercase();
+    let mut out = Vec::new();
+    let mut cursor = 0usize;
+    while cursor < lower.len() {
+        // Next anchor from `cursor`.
+        let next = ANCHORS
+            .iter()
+            .filter_map(|k| lower[cursor..].find(k).map(|i| cursor + i))
+            .min();
+        let Some(at) = next else { break };
+        // Advance past this anchor regardless of what we find, so overlapping
+        // matches (`deep_link` contains `link`) can't loop forever.
+        cursor = at + 1;
+        let end = (at + LOOKAHEAD).min(code.len());
+        // Respect char boundaries — source files carry non-ASCII (em-dashes in
+        // comments), and slicing mid-codepoint would panic.
+        if !code.is_char_boundary(at) || !code.is_char_boundary(end) {
+            continue;
+        }
+        let mut rest = &code[at..end];
+        while let Some(i) = rest.find('"') {
+            let body = &rest[i + 1..];
+            let Some(q) = body.find('"') else { break };
+            let lit = &body[..q];
+            if lit.starts_with('/') {
+                out.push(lit.to_string());
+            }
+            rest = &body[q + 1..];
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// GUARD: no producer emits a deep link the shell has never heard of.
+///
+/// A failure means one of two things, and the fix differs:
+///   * you added a genuinely new destination → add it to `deep_links::ALL`
+///     AND teach `navigate` to resolve it (the bun guard enforces the second
+///     half);
+///   * you hardcoded a path that already has a constant → use the constant.
+#[test]
+fn deep_link_literals_are_all_known() {
+    let root = repo_root();
+    let mut files = Vec::new();
+    for dir in PRODUCER_DIRS {
+        rust_files(&root.join(dir), &mut files);
+    }
+    assert!(
+        files.len() > 50,
+        "producer scan found only {} files — the paths are probably wrong, and a \
+         scan that reads nothing passes vacuously",
+        files.len()
+    );
+
+    let mut offenders = Vec::new();
+    for f in &files {
+        // This test's own doc comments name the retired spellings.
+        if f.ends_with("tests/deep_links.rs") {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(f) else {
+            continue;
+        };
+        // Doc/line comments are stripped first: they discuss retired spellings
+        // by name (this module's own header does), and a prose mention is not
+        // an emission. Only whole-line comments go — a trailing `//` cannot be
+        // removed safely without a real lexer, since `"https://…"` contains one.
+        let code: String = text
+            .lines()
+            .map(|l| {
+                if l.trim_start().starts_with("//") {
+                    ""
+                } else {
+                    l
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        for lit in deep_link_literals(&code) {
+            if !deep_links::is_known(&lit) {
+                offenders.push(format!(
+                    "{} emits unknown deep_link {lit:?}",
+                    f.strip_prefix(&root).unwrap_or(f).display(),
+                ));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "deep links not in `meridian_core::notifications::deep_links`:\n  {}",
+        offenders.join("\n  ")
+    );
+}
+
+/// GUARD: the retired spellings stay resolvable.
+///
+/// Rows carrying `/tasks?integrations=1` are sitting in users' outboxes right
+/// now (they were still being written until this change). Dropping them from
+/// `LEGACY` because no producer emits them any more would strand exactly those
+/// rows — the same "the producer stopped, the data didn't" trap that left 22
+/// dead board-hygiene banners behind.
+#[test]
+fn legacy_spellings_remain_resolvable() {
+    for legacy in deep_links::LEGACY {
+        assert!(
+            deep_links::is_known(legacy),
+            "{legacy} dropped out of the resolvable set"
+        );
+        assert!(
+            !deep_links::ALL.contains(&legacy),
+            "{legacy} is retired — it must not be offered to new producers"
+        );
+    }
+}

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -177,7 +177,7 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
                     detail: &e,
                     remedy: None,
                     event_key: "system.health",
-                    deep_link: Some("/logs"),
+                    deep_link: Some(meridian_core::notifications::deep_links::LOGS),
                 },
             )
             .await

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -658,7 +658,7 @@ pub fn run() {
                                             // event_key mirrors id so each outcome's
                                             // OS toast dedupes independently.
                                             event_key: id,
-                                            deep_link: (!fault_cleared).then_some("/logs"),
+                                            deep_link: (!fault_cleared).then_some(meridian_core::notifications::deep_links::LOGS),
                                         },
                                     )
                                     .await
@@ -729,7 +729,7 @@ pub fn run() {
                                                         detail: "Meridian couldn't finish encrypting its local database this time. Your data is safe but stored unencrypted for now - Meridian will retry automatically the next time it restarts.",
                                                         remedy: None,
                                                         event_key: "system.health",
-                                                        deep_link: Some("/logs"),
+                                                        deep_link: Some(meridian_core::notifications::deep_links::LOGS),
                                                     },
                                                 )
                                                 .await

--- a/tray/src-tauri/src/poll/permissions.rs
+++ b/tray/src-tauri/src/poll/permissions.rs
@@ -119,7 +119,7 @@ async fn check_bool_permission(
                 detail,
                 remedy: Some(remedy),
                 event_key,
-                deep_link: Some("/settings"),
+                deep_link: Some(meridian_core::notifications::deep_links::SETTINGS),
             },
         )
         .await

--- a/tray/src-tauri/src/poll/plan_auto_open.rs
+++ b/tray/src-tauri/src/poll/plan_auto_open.rs
@@ -76,7 +76,7 @@ pub(crate) async fn maybe_auto_open_plan(app: &tauri::AppHandle, pool: &meridian
     // picks; parking both ways would leave a stale target for a later manual
     // open) — then open/focus the window.
     write_marker(&marker, &now);
-    crate::deep_link::navigate_dashboard(app, "/plan");
+    crate::deep_link::navigate_dashboard(app, meridian_core::notifications::deep_links::PLAN);
     crate::tray::open_native_dashboard(app);
     tracing::info!(%today, "plan auto-open: opened dashboard on the Plan view");
 }

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -195,7 +195,7 @@ pub(super) async fn refresh_health(
                 detail,
                 remedy: None,
                 event_key: "system.health",
-                deep_link: Some("/logs"),
+                deep_link: Some(meridian_core::notifications::deep_links::LOGS),
             },
         )
         .await
@@ -224,7 +224,7 @@ pub(super) async fn refresh_health(
                 detail: "Couldn't start it automatically. Tap to check what happened.",
                 remedy: None,
                 event_key: "system.health",
-                deep_link: Some("/logs"),
+                deep_link: Some(meridian_core::notifications::deep_links::LOGS),
             },
         )
         .await
@@ -686,7 +686,7 @@ mod tests {
                 detail: "Tap to check what happened.",
                 remedy: None,
                 event_key: "system.health",
-                deep_link: Some("/logs"),
+                deep_link: Some(meridian_core::notifications::deep_links::LOGS),
             },
         )
         .await

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -237,38 +237,44 @@ pub(super) async fn refresh_health(
         {
             tracing::warn!(error = %e, "daemon-health notice clear failed");
         }
-        send_back_online_toast(pool).await;
+        tracing::info!("daemon recovered - went-quiet notice cleared");
     } else if reconcile_stale {
         match meridian::notices::clear_typed_reporting(pool, "tray.daemon_quiet", "system.health")
             .await
         {
-            // A notice really was sitting there from a prior process instance —
-            // confirm the recovery the same way the normal path does.
-            Ok(true) => send_back_online_toast(pool).await,
+            Ok(true) => {
+                tracing::info!("cleared a went-quiet notice left by a prior process instance")
+            }
             Ok(false) => {}
             Err(e) => tracing::warn!(error = %e, "daemon-health stale notice reconcile failed"),
         }
     }
 }
 
-/// "Back online" is a discrete confirmation, not a state to leave sitting as a
-/// banner once the fault it answers is already cleared.
-async fn send_back_online_toast(pool: &SqlitePool) {
-    let dedup = format!(
-        "system.health:back_online:{}",
-        chrono::Utc::now().timestamp()
-    );
-    let n = meridian::notifications::NewNotification::event(
-        &dedup,
-        "system.health",
-        "Back online.",
-        "Picking up where you left off.",
-    )
-    .via(meridian::notifications::CHANNEL_NATIVE);
-    if let Err(e) = meridian::notifications::enqueue(pool, n).await {
-        tracing::warn!(error = %e, "back-online notification enqueue failed");
-    }
-}
+// A recovery used to also fire a "Back online. / Picking up where you left off."
+// toast (`send_back_online_toast`). It was removed, and the reasoning is worth
+// keeping because "confirm the recovery" sounds obviously right:
+//
+//   * It asks nothing and reports no action the user can take - it is state,
+//     and state belongs in the tray icon/tooltip, which the poll loop already
+//     syncs every tick. Measured on a real install: 18 fired in ~5 weeks and
+//     exactly one was ever interacted with.
+//   * Much of the time it arrived with no context. The went-quiet notice's own
+//     toast row is DELETED by `clear_typed` on recovery, so a down->up cycle
+//     shorter than the tray's 30 s drain retracts the warning before it is
+//     ever shown - and the user gets a bare "Back online." for an outage they
+//     never saw. The `reconcile_stale` branch is worse: it fires for a notice
+//     raised by a PREVIOUS process instance, i.e. an outage that by definition
+//     happened while this tray was not running.
+//   * Meridian restarts its own daemon routinely - updates, the watchdog, a
+//     manual restart - so this fired as a side effect of ordinary lifecycle
+//     events, not just real faults. Five of those 18 landed after the watchdog
+//     restart-storm fix (#678), two of them minutes after an auto-update
+//     installed.
+//
+// The went-quiet banner disappearing is the recovery signal. If a confirmation
+// is ever wanted again, it belongs on the banner channel attached to the
+// original fault, not as a fresh interruptive toast.
 
 /// The actions a health tick can trigger. Among the three *notice* actions
 /// (`notify_down` / `notify_back` / `reconcile_stale`) at most one is ever true.
@@ -713,8 +719,6 @@ mod tests {
             cleared,
             "a real stale notice must report as actually cleared"
         );
-        send_back_online_toast(&pool).await;
-
         let remaining: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM system_notices WHERE notice_id = 'tray.daemon_quiet'",
         )
@@ -723,14 +727,20 @@ mod tests {
         .unwrap();
         assert_eq!(remaining, 0, "the banner's backing row must be gone");
 
-        let toast_count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM notifications WHERE event_key = 'system.health' AND title = 'Back online.'")
-                .fetch_one(&pool)
-                .await
-                .unwrap();
+        // Clearing the banner is the WHOLE recovery signal. This branch used to
+        // also enqueue a "Back online." toast; it fired for an outage that
+        // happened while this process was not running, so the user was told
+        // something recovered without ever being told it broke. See the comment
+        // above `refresh_health`'s notify_back arm.
+        let toast_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM notifications WHERE event_key = 'system.health'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
         assert_eq!(
-            toast_count, 1,
-            "a back-online toast must confirm the recovery"
+            toast_count, 0,
+            "reconciling a stale notice must not toast - nothing is being asked of the user"
         );
     }
 }

--- a/tray/src-tauri/src/poll/whats_new_auto_open.rs
+++ b/tray/src-tauri/src/poll/whats_new_auto_open.rs
@@ -69,7 +69,7 @@ pub(crate) async fn maybe_auto_open_whats_new(app: &tauri::AppHandle) {
     if let Err(e) = whats_new::mark_whats_new_seen(home, &current_version) {
         tracing::warn!(error = %e, "whats-new auto-open: marker write failed");
     }
-    crate::deep_link::navigate_dashboard(app, "/whats-new");
+    crate::deep_link::navigate_dashboard(app, meridian_core::notifications::deep_links::WHATS_NEW);
     crate::tray::open_native_dashboard(app);
     tracing::info!(version = %current_version, "whats-new auto-open: opened dashboard on the What's New view");
 }

--- a/ui/__tests__/deep-links.test.ts
+++ b/ui/__tests__/deep-links.test.ts
@@ -1,0 +1,84 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+// Guards the consumer half of the `deep_link` contract.
+//
+// A notification's deep link crosses a language boundary: Rust producers stamp
+// a string onto an outbox row, and `MeridianTimelineShell.tsx`'s `navigate`
+// turns it into a modal or a settings section. Nothing type-checks that hop.
+// When the Next fold deleted the `/tasks` route, `navigate` quietly stopped
+// resolving `/tasks?integrations=1` while all five `pm.*` sync faults kept
+// emitting it — no error, no log, no failing test, just a [View] button that
+// opened the default view for months.
+//
+// So the vocabulary is declared once, in Rust
+// (`meridian_core::notifications::deep_links`), and checked from both ends:
+//   - `tests/deep_links.rs` — no producer emits a value outside the vocabulary.
+//   - this file           — `navigate` resolves every value in the vocabulary.
+// Either alone passes vacuously: producers could all agree on a link the shell
+// ignores, or the shell could handle links nobody sends.
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+
+const repoRoot = import.meta.dir + '/../..'
+const read = (rel: string): string => readFileSync(repoRoot + '/' + rel, 'utf8')
+
+const CONSTANTS = 'meridian-core/src/notifications/mod.rs'
+const SHELL = 'ui/components/timeline/MeridianTimelineShell.tsx'
+
+// Pull `pub const NAME: &str = "value";` out of the `deep_links` module, and
+// the `LEGACY` array's entries. Parsing the Rust rather than restating the
+// values here is the whole point - a copy would drift silently, which is the
+// class of bug this guards.
+function parseDeepLinks(src: string): { all: string[]; legacy: string[] } {
+  const modStart = src.indexOf('pub mod deep_links {')
+  expect(modStart).toBeGreaterThan(-1)
+  const body = src.slice(modStart)
+
+  const all: string[] = []
+  for (const m of body.matchAll(/pub const [A-Z_]+: &str = "([^"]+)";/g)) all.push(m[1])
+
+  const legacyDecl = body.match(/pub const LEGACY: \[&str; \d+\] = \[([\s\S]*?)\];/)
+  expect(legacyDecl).not.toBeNull()
+  const legacy = [...legacyDecl![1].matchAll(/"([^"]+)"/g)].map(m => m[1])
+
+  // The scalar consts include the LEGACY strings only if they were declared as
+  // consts, which they are not - LEGACY is an inline array. So `all` is exactly
+  // the current vocabulary.
+  return { all, legacy }
+}
+
+describe('deep-link vocabulary', () => {
+  const { all, legacy } = parseDeepLinks(read(CONSTANTS))
+  const shell = read(SHELL)
+
+  it('parses a non-empty vocabulary out of the Rust constants', () => {
+    // A parser that silently matched nothing would make every assertion below
+    // pass over an empty list.
+    expect(all.length).toBeGreaterThanOrEqual(7)
+    expect(legacy.length).toBeGreaterThanOrEqual(2)
+    expect(all).toContain('/plan')
+    expect(all).toContain('/settings/integrations')
+  })
+
+  it('navigate() handles every current deep link', () => {
+    for (const link of all) {
+      expect(shell.includes(`case '${link}':`)).toBe(true)
+    }
+  })
+
+  it('navigate() still handles the retired spellings', () => {
+    // Undelivered rows and older installs carry these. A producer change does
+    // not rewrite rows already in the outbox - the same lesson as the 22 dead
+    // board-hygiene banners that needed their own migration.
+    for (const link of legacy) {
+      expect(shell.includes(`case '${link}':`)).toBe(true)
+    }
+  })
+
+  it('navigate() has a default arm, so an unknown target is never silent', () => {
+    // The absence of this is the root cause of the original bug: a target that
+    // matched nothing did nothing, indistinguishably from success.
+    const nav = shell.slice(shell.indexOf('const navigate ='))
+    expect(nav).toContain('default:')
+    expect(nav).toContain('console.warn')
+  })
+})

--- a/ui/__tests__/deep-links.test.ts
+++ b/ui/__tests__/deep-links.test.ts
@@ -28,10 +28,26 @@ const SHELL = 'ui/components/timeline/MeridianTimelineShell.tsx'
 // the `LEGACY` array's entries. Parsing the Rust rather than restating the
 // values here is the whole point - a copy would drift silently, which is the
 // class of bug this guards.
+/** Slice from `start` to the brace that closes the block opening at `start`. */
+function braceBlock(src: string, start: number): string {
+  const open = src.indexOf('{', start)
+  let depth = 0
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1)
+  }
+  return src.slice(start)
+}
+
 function parseDeepLinks(src: string): { all: string[]; legacy: string[] } {
   const modStart = src.indexOf('pub mod deep_links {')
   expect(modStart).toBeGreaterThan(-1)
-  const body = src.slice(modStart)
+  // Brace-matched, NOT sliced to EOF. Slicing to the end of the file worked
+  // only because `deep_links` happens to be the last thing declaring a
+  // `pub const X: &str`; one unrelated const below it would be absorbed into
+  // `all`, and this suite would then demand a navigate() arm for it and fail
+  // pointing at the wrong thing entirely.
+  const body = braceBlock(src, modStart)
 
   const all: string[] = []
   for (const m of body.matchAll(/pub const [A-Z_]+: &str = "([^"]+)";/g)) all.push(m[1])
@@ -77,7 +93,13 @@ describe('deep-link vocabulary', () => {
   it('navigate() has a default arm, so an unknown target is never silent', () => {
     // The absence of this is the root cause of the original bug: a target that
     // matched nothing did nothing, indistinguishably from success.
-    const nav = shell.slice(shell.indexOf('const navigate ='))
+    //
+    // Bounded to navigate's own body. Slicing to EOF would be satisfied by a
+    // `default:` or `console.warn` anywhere in the remaining ~300 lines of the
+    // shell - passing by coincidence of file ordering, which is the failure
+    // mode this whole suite exists to rule out.
+    const nav = braceBlock(shell, shell.indexOf('const navigate ='))
+    expect(nav.length).toBeLessThan(3000) // it really is bounded
     expect(nav).toContain('default:')
     expect(nav).toContain('console.warn')
   })

--- a/ui/__tests__/mutate-body-contract.test.ts
+++ b/ui/__tests__/mutate-body-contract.test.ts
@@ -1,0 +1,142 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+// Guards the calling convention of `bridge.mutate`.
+//
+// `mutate(apiPath, command, body)` does NOT forward `body` as the command's
+// arguments - it wraps them: `invoke(command, { body })` (bridge.ts). So a
+// command reached through `mutate` MUST declare a single `body:` parameter.
+// Most write commands do; a few older ones take their args at the top level
+// (`delete_notice(notice_id: String)`) and must be reached with `invoke`
+// directly instead.
+//
+// Getting this wrong produces the worst possible failure: Tauri fails argument
+// deserialization, the promise rejects, and a `.catch()` on the call site
+// swallows it. The control renders, is clickable, and does nothing - no error,
+// no log, no failing test. That is how the NoticeBar dismiss button shipped
+// dead in its first draft, and it is the same shape as the `window.confirm`
+// Repair Database button that shipped dead in 1.83.0 (see CLAUDE.md).
+//
+// There is no type checking across the JS -> Rust hop, so this scan is the only
+// thing standing between a mismatched call and a silently inert control.
+import { describe, it, expect } from 'bun:test'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { resolve } from 'path'
+
+// `resolve`, not string concatenation. An unnormalised `dir + '/../..'` keeps
+// the `/__tests__/` segment in every descendant path, so the "skip test files"
+// filter below silently discarded ALL 204 sources and the main assertion
+// passed over an empty list. The `sites.length > 10` floor is what caught it.
+const repoRoot = resolve(import.meta.dir, '../..')
+
+function walk(dir: string, ext: string[], out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name === '.next' || name === 'out') continue
+    const p = dir + '/' + name
+    if (statSync(p).isDirectory()) walk(p, ext, out)
+    else if (ext.some(e => name.endsWith(e))) out.push(p)
+  }
+  return out
+}
+
+/** Every `mutate(…, 'command', …)` call site in the dashboard. */
+function mutateCallSites(): { file: string; command: string }[] {
+  const out: { file: string; command: string }[] = []
+  for (const f of walk(repoRoot + '/ui', ['.ts', '.tsx'])) {
+    if (f.includes('/__tests__/')) continue
+    const src = readFileSync(f, 'utf8')
+    for (const m of src.matchAll(/\bmutate(?:<[^>]*>)?\(\s*'[^']*'\s*,\s*'([^']+)'/g)) {
+      out.push({ file: f.slice(repoRoot.length + 1), command: m[1] })
+    }
+  }
+  return out
+}
+
+// Parameter types Tauri injects itself rather than reading from the JS call.
+// They are invisible to the caller, so they do not affect whether `mutate`
+// works. `State<…>` covers the DB pool; AppHandle/Window/WebviewWindow cover
+// the handle-taking commands.
+const INJECTED = /^(?:_?\w+\s*:\s*)?(?:tauri::)?(?:State\s*<|AppHandle|Window|WebviewWindow)/
+
+/**
+ * Commands the tray exposes → the names of the arguments they expect *from JS*.
+ *
+ * The distinction matters: `mutate` sends exactly one key, `body`. A command
+ * with no JS-facing args at all (`sync_tasks()`) is fine, because Tauri ignores
+ * the surplus key. A command with a JS-facing arg that is not `body`
+ * (`delete_notice(notice_id)`) fails deserialization.
+ */
+function commandJsArgs(): Map<string, string[]> {
+  const map = new Map<string, string[]>()
+  for (const f of walk(repoRoot + '/tray/src-tauri/src', ['.rs'])) {
+    const src = readFileSync(f, 'utf8')
+    // `pub async fn name(` … up to the closing paren of the signature.
+    for (const m of src.matchAll(/pub (?:async )?fn ([a-z0-9_]+)\s*\(([\s\S]*?)\)\s*->/g)) {
+      const [, name, params] = m
+      if (map.has(name)) continue
+      const jsArgs = splitParams(params)
+        .filter(p => p.trim() && !INJECTED.test(p.trim()))
+        .map(p => p.split(':')[0].trim())
+      map.set(name, jsArgs)
+    }
+  }
+  return map
+}
+
+/** Split a Rust parameter list on top-level commas (generics contain commas). */
+function splitParams(params: string): string[] {
+  const out: string[] = []
+  let depth = 0
+  let cur = ''
+  for (const ch of params) {
+    if (ch === '<' || ch === '(' || ch === '[') depth++
+    else if (ch === '>' || ch === ')' || ch === ']') depth--
+    if (ch === ',' && depth === 0) { out.push(cur); cur = '' } else cur += ch
+  }
+  if (cur.trim()) out.push(cur)
+  return out
+}
+
+describe('bridge.mutate body contract', () => {
+  const sites = mutateCallSites()
+  const jsArgs = commandJsArgs()
+
+  it('finds the call sites and the command signatures at all', () => {
+    // Both parsers failing would make the assertion below pass over nothing —
+    // and one of them did exactly that on the first draft (see repoRoot).
+    expect(sites.length).toBeGreaterThan(10)
+    expect(jsArgs.size).toBeGreaterThan(50)
+    expect(jsArgs.get('update_settings')).toEqual(['body'])
+    // The two shapes that are legitimately reachable via mutate despite having
+    // no `body`: no JS args at all, and only an injected AppHandle.
+    expect(jsArgs.get('sync_tasks')).toEqual([])
+    expect(jsArgs.get('open_setup')).toEqual([])
+    // …and the shape that is not.
+    expect(jsArgs.get('delete_notice')).toEqual(['notice_id'])
+  })
+
+  it('no mutate() call reaches a command expecting a non-body argument', () => {
+    const offenders = sites
+      .filter(s => {
+        const args = jsArgs.get(s.command)
+        // Unknown command → not our business (may live outside the scanned tree).
+        if (!args) return false
+        return args.some(a => a !== 'body')
+      })
+      .map(s => `${s.file} calls mutate(…, '${s.command}', …), but ${s.command} expects ${jsArgs.get(s.command)!.join(', ')} at the top level - mutate only ever sends { body }, so use invoke() directly`)
+    expect(offenders).toEqual([])
+  })
+
+  it('the NoticeBar dismiss button reaches delete_notice the working way', () => {
+    // Pinned specifically: this is the site that shipped dead, and the generic
+    // scan above would stop covering it the moment someone renames the param.
+    const src = readFileSync(repoRoot + '/ui/components/NoticeBar.tsx', 'utf8')
+    expect(src).toContain("invoke('delete_notice'")
+    expect(src).not.toContain("mutate('/api/notices'")
+  })
+
+  it('the dismiss failure path is not silent', () => {
+    // `catch {}` on a write is what made the dead button invisible locally.
+    const src = readFileSync(repoRoot + '/ui/components/NoticeBar.tsx', 'utf8')
+    const btn = src.slice(src.indexOf('function DismissButton'))
+    expect(btn).toContain('console.error')
+  })
+})

--- a/ui/components/LayoutBanners.tsx
+++ b/ui/components/LayoutBanners.tsx
@@ -19,8 +19,17 @@
 import { usePathname } from 'next/navigation'
 import NoticeBar from '@/components/NoticeBar'
 
+// Routes with no MeridianTimelineShell mounted. NoticeBar's action buttons
+// ("Reconnect →", "Fix in Tasks") reach the shell through window events, so on
+// these routes they render, click, and do nothing — the same silent-dead-control
+// failure the notification work is cleaning up. Neither banner is actionable
+// mid-onboard or mid-uninstall anyway (and db.corrupt's Repair button restarts
+// the app, which would be actively wrong during an uninstall), so gate the whole
+// bar rather than individual buttons.
+const SHELL_LESS_ROUTES = ['/setup', '/uninstall']
+
 export default function LayoutBanners() {
   const pathname = usePathname()
-  if (pathname?.startsWith('/setup')) return null
+  if (SHELL_LESS_ROUTES.some(r => pathname?.startsWith(r))) return null
   return <NoticeBar />
 }

--- a/ui/components/NoticeBar.tsx
+++ b/ui/components/NoticeBar.tsx
@@ -1,20 +1,38 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 //
 // Global fault banner. Subscribes to the `notices-update` Tauri event (via
-// bridge.subscribe) and renders a banner for each active system notice. Banners auto-disappear when
-// the daemon clears the fault — no manual dismiss needed. Placed in the root
-// layout so it appears on every page.
+// bridge.subscribe) and renders a banner for each active system notice. Placed
+// in the root layout so it appears on every page.
+//
+// Most banners auto-disappear when the daemon clears the fault, and those have
+// no dismiss control on purpose — hiding a live fault would only make it
+// invisible, not fixed. The exception is ACKNOWLEDGEABLE (below): notices that
+// report a past EVENT rather than a current condition. Nothing can ever
+// "recover" from them, so without a dismiss they sit on screen forever.
 
 'use client'
 
 import { useEffect, useState } from 'react'
-import { load, subscribe } from '@/lib/bridge'
+import { load, mutate, subscribe } from '@/lib/bridge'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import { formatSince } from '@/lib/notice-time'
 import type { Notice, RepairPreview } from '@/lib/api-types'
 
 // The one notice that can be acted on in-app rather than in a terminal.
 const DB_CORRUPT = 'db.corrupt'
+
+// Notices the user dismisses, because nothing else will.
+//
+// Both are raised once by the tray's boot-time repair (`lib.rs`) to report what
+// it did to the database. They describe something that already happened, so no
+// code path clears them — and NoticeBar had no dismiss — which meant any
+// machine that ever ran a boot repair carried the banner permanently. Same
+// shape as the 22 undismissable board-hygiene banners: a producer with no
+// matching consumer.
+//
+// A live fault must NOT be added here. If a notice can clear itself when the
+// condition passes, let it.
+const ACKNOWLEDGEABLE = new Set(['db.repaired', 'db.reset'])
 
 // Palette lives in globals.css (--status-*).
 const SEVERITY_STYLES: Record<string, { bg: string; border: string; text: string; dot: string }> = {
@@ -92,9 +110,16 @@ export default function NoticeBar() {
               )}
             </div>
             {n.notice_id === DB_CORRUPT && <RepairButton color={s.text} border={s.border} />}
+            {/* A tracker fault is fixed by reconnecting the tracker. This used
+                to say "Fix in Tasks →" and open the Tasks modal, which
+                disagreed with both this notice's own remedy text ("Reconnect X
+                in Settings → Integrations") and its toast's click-through -
+                three surfaces for one fault, two destinations. */}
             {n.notice_id.startsWith('pm.') && (
               <button
-                onClick={() => window.dispatchEvent(new CustomEvent('meridian:open-tasks'))}
+                onClick={() => window.dispatchEvent(
+                  new CustomEvent('meridian:open-settings', { detail: 'integrations' })
+                )}
                 style={{
                   flexShrink: 0,
                   fontSize: 11,
@@ -107,15 +132,64 @@ export default function NoticeBar() {
                   textDecoration: 'none',
                   whiteSpace: 'nowrap',
                   alignSelf: 'center',
+                  cursor: 'pointer',
                 }}
               >
-                Fix in Tasks →
+                Reconnect →
               </button>
+            )}
+            {ACKNOWLEDGEABLE.has(n.notice_id) && (
+              <DismissButton noticeId={n.notice_id} color={s.text}
+                onDone={() => setNotices(cur => cur.filter(x => x.notice_id !== n.notice_id))} />
             )}
           </div>
         )
       })}
     </div>
+  )
+}
+
+// Acknowledge a notice that reports a past event (see ACKNOWLEDGEABLE).
+//
+// Optimistic: the row is dropped locally the moment the write succeeds rather
+// than waiting for the next `notices-update` push, so the banner does not
+// linger for a poll interval after the click. A failed write leaves the banner
+// up - which is the honest outcome, since the notice really is still there.
+function DismissButton({ noticeId, color, onDone }: {
+  noticeId: string
+  color: string
+  onDone: () => void
+}) {
+  const [busy, setBusy] = useState(false)
+  return (
+    <button
+      aria-label="Dismiss"
+      title="Dismiss"
+      disabled={busy}
+      onClick={async () => {
+        setBusy(true)
+        try {
+          await mutate('/api/notices', 'delete_notice', { noticeId }, 'DELETE')
+          onDone()
+        } catch {
+          setBusy(false)
+        }
+      }}
+      style={{
+        flexShrink: 0,
+        alignSelf: 'center',
+        background: 'transparent',
+        border: 'none',
+        color,
+        opacity: busy ? 0.4 : 0.6,
+        fontSize: 14,
+        lineHeight: 1,
+        padding: '2px 6px',
+        cursor: busy ? 'default' : 'pointer',
+      }}
+    >
+      ✕
+    </button>
   )
 }
 

--- a/ui/components/NoticeBar.tsx
+++ b/ui/components/NoticeBar.tsx
@@ -13,7 +13,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { load, mutate, subscribe } from '@/lib/bridge'
+import { load, invoke, subscribe } from '@/lib/bridge'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import { formatSince } from '@/lib/notice-time'
 import type { Notice, RepairPreview } from '@/lib/api-types'
@@ -47,6 +47,17 @@ const SEVERITY_STYLES: Record<string, { bg: string; border: string; text: string
     border: 'var(--status-warning-border)',
     text: 'var(--status-warning-text)',
     dot: 'var(--status-warning-dot)',
+  },
+  // `info` was missing, and the lookup below falls back to `error` — so
+  // "Database repaired", raised with severity "info" (tray lib.rs), rendered in
+  // full red error styling: a successful recovery that looks like a failure.
+  // Nothing surfaced info-severity notices before ACKNOWLEDGEABLE made this one
+  // dismissable, which is why it went unnoticed.
+  info: {
+    bg: 'var(--status-info-bg)',
+    border: 'var(--status-info-border)',
+    text: 'var(--status-info-text)',
+    dot: 'var(--status-info-dot)',
   },
 }
 
@@ -155,6 +166,16 @@ export default function NoticeBar() {
 // than waiting for the next `notices-update` push, so the banner does not
 // linger for a poll interval after the click. A failed write leaves the banner
 // up - which is the honest outcome, since the notice really is still there.
+//
+// `invoke`, NOT `mutate`. `mutate` wraps its body — `invoke(command, { body })`
+// — and `delete_notice` takes `notice_id` at the top level rather than a
+// `body:` struct, so `mutate` fails argument deserialization. The first draft
+// of this button used it and was therefore dead on arrival: it rendered, it
+// was clickable, and the rejected promise died in the catch. That is the exact
+// failure this whole PR is about, and the same shape as the `window.confirm`
+// Repair Database button below, which shipped inert in 1.83.0.
+// `__tests__/mutate-body-contract.test.ts` now fails the build for any
+// mutate() call whose command has no `body:` param.
 function DismissButton({ noticeId, color, onDone }: {
   noticeId: string
   color: string
@@ -169,9 +190,11 @@ function DismissButton({ noticeId, color, onDone }: {
       onClick={async () => {
         setBusy(true)
         try {
-          await mutate('/api/notices', 'delete_notice', { noticeId }, 'DELETE')
+          await invoke('delete_notice', { noticeId })
           onDone()
-        } catch {
+        } catch (e) {
+          // Never swallow: a silent catch is what hid the broken call above.
+          console.error('[NoticeBar] dismissing notice failed', noticeId, e)
           setBusy(false)
         }
       }}

--- a/ui/components/timeline/MeridianTimelineShell.tsx
+++ b/ui/components/timeline/MeridianTimelineShell.tsx
@@ -140,8 +140,19 @@ export default function MeridianTimelineShell() {
   // props.
   useEffect(() => {
     const openTasks = () => setActiveModal('tasks')
+    // NoticeBar's pm.* "Reconnect →" button, which sends the user to the same
+    // place that fault's remedy text and its toast click-through do.
+    const openSettings = (e: Event) => {
+      const section = (e as CustomEvent<SettingsSection>).detail
+      setSettingsSection(section)
+      setActiveModal('settings')
+    }
     window.addEventListener('meridian:open-tasks', openTasks)
-    return () => window.removeEventListener('meridian:open-tasks', openTasks)
+    window.addEventListener('meridian:open-settings', openSettings)
+    return () => {
+      window.removeEventListener('meridian:open-tasks', openTasks)
+      window.removeEventListener('meridian:open-settings', openSettings)
+    }
   }, [])
 
 
@@ -162,15 +173,62 @@ export default function MeridianTimelineShell() {
   // its listener is the push half (`dashboard-navigate`, for a window that is
   // already open and won't remount). Targets are the former route paths the
   // notification producers still use as `deep_link`s.
+  //
+  // EVERY value in `meridian_core::notifications::deep_links::ALL` must have an
+  // arm here, plus the retired spellings in `LEGACY` (rows already sitting in
+  // users' outboxes still carry those, and a producer change never rewrites
+  // them). `ui/__tests__/deep-links.test.ts` reads those Rust constants and
+  // fails the build if one is unhandled.
+  //
+  // This used to be three arms with no `else`, while producers emitted seven.
+  // The missing four just fell through — so the [View] button on every fault
+  // toast opened the default view, and `/tasks?integrations=1` went on being
+  // emitted for months after that route was deleted. Nothing failed, because a
+  // link that resolves to nothing looks exactly like one that works. Hence the
+  // `else`: an unrecognised target is now loud, and still lands somewhere sane.
   useEffect(() => {
     const navigate = (target: string | null) => {
-      if (target === '/plan') {
-        setActiveModal('plan')
-      } else if (target === '/worklogs') {
-        setReviewFocusKey(null)
-        setActiveModal('review')
-      } else if (target === '/whats-new') {
-        setActiveModal('whats-new')
+      if (target === null) return
+      // `undefined` means "whatever Settings defaults to" — see the
+      // settingsSection state declaration.
+      const openSettings = (section?: SettingsSection) => {
+        setSettingsSection(section)
+        setActiveModal('settings')
+      }
+      switch (target) {
+        case '/plan':
+          setActiveModal('plan')
+          break
+        case '/worklogs':
+          setReviewFocusKey(null)
+          setActiveModal('review')
+          break
+        case '/whats-new':
+          setActiveModal('whats-new')
+          break
+        case '/today':
+          // The dashboard itself — close whatever is covering it.
+          setActiveModal(null)
+          break
+        case '/settings':
+          openSettings()
+          break
+        // Both spellings mean "reconnect a tracker". `/tasks?integrations=1`
+        // is the pre-fold route every pm.* sync fault used to emit.
+        case '/settings/integrations':
+        case '/tasks?integrations=1':
+          openSettings('integrations')
+          break
+        // There is no in-app log viewer. What a user can actually do about a
+        // fault is quote their Support ID and export diagnostics, both of which
+        // live in Account. `/health` is an older spelling of the same intent.
+        case '/logs':
+        case '/health':
+          openSettings('account')
+          break
+        default:
+          console.warn(`[deep-link] unhandled target ${target} - opening the dashboard`)
+          setActiveModal(null)
       }
     }
     return subscribe<string | null>('/deep-link', 'take_pending_deep_link', 'dashboard-navigate', navigate)

--- a/ui/components/timeline/MeridianTimelineShell.tsx
+++ b/ui/components/timeline/MeridianTimelineShell.tsx
@@ -135,24 +135,23 @@ export default function MeridianTimelineShell() {
     setShowWorklogPrompt(true)
   }, [worklogPrompted])
 
-  // NoticeBar lives at the root layout, outside this tree, so its
-  // "Fix in Tasks" CTA reaches the Tasks modal via a window event instead of
-  // props.
+  // NoticeBar lives at the root layout, outside this tree, so its pm.* CTA
+  // reaches this shell through a window event rather than props.
+  //
+  // The event used to be `meridian:open-tasks` (a "Fix in Tasks →" button).
+  // That button now says "Reconnect →" and opens Settings → Integrations,
+  // which is where the same notice's own `remedy` text and its toast's
+  // click-through both send the user. The old listener was removed with its
+  // last dispatcher — a listener kept alive by a comment asserting it is live
+  // is the same drift this change is cleaning up.
   useEffect(() => {
-    const openTasks = () => setActiveModal('tasks')
-    // NoticeBar's pm.* "Reconnect →" button, which sends the user to the same
-    // place that fault's remedy text and its toast click-through do.
     const openSettings = (e: Event) => {
       const section = (e as CustomEvent<SettingsSection>).detail
       setSettingsSection(section)
       setActiveModal('settings')
     }
-    window.addEventListener('meridian:open-tasks', openTasks)
     window.addEventListener('meridian:open-settings', openSettings)
-    return () => {
-      window.removeEventListener('meridian:open-tasks', openTasks)
-      window.removeEventListener('meridian:open-settings', openSettings)
-    }
+    return () => window.removeEventListener('meridian:open-settings', openSettings)
   }, [])
 
 
@@ -281,7 +280,7 @@ export default function MeridianTimelineShell() {
   // rather than taking a callback, because it is rendered two modals deep
   // (PlanModal → PlanView → TaskComposer) and threading an opener through both
   // would put a Settings concern in two components that have nothing to do with
-  // Settings. Same window-event pattern as `meridian:open-tasks` above.
+  // Settings. Same window-event pattern as `meridian:open-settings` above.
   useEffect(() => {
     const connectAi = () => {
       setSettingsSection('intelligence')

--- a/ui/components/timeline/TaskDetailDialog.tsx
+++ b/ui/components/timeline/TaskDetailDialog.tsx
@@ -144,7 +144,7 @@ export function TaskDetailDialog({
    *  surface, so its own already-fetched list would otherwise stay stale after a
    *  successful delete. `onDeleted` covers the one caller that wires it
    *  (PlanView); the `meridian:task-deleted` window event (same pattern as
-   *  NoticeBar's `meridian:open-tasks`) is the broadcast every OTHER list-owning
+   *  NoticeBar's `meridian:open-settings`) is the broadcast every OTHER list-owning
    *  surface listens for instead of threading a callback through every opener. */
   function deleteTask() {
     if (deleting) return


### PR DESCRIPTION
Slices 0b and 3 of the notification restructure. Follows #705 (board hygiene).

## Slice 0b - deep links actually go where they say

`navigate()` in `MeridianTimelineShell.tsx` resolved **3** targets (`/plan`, `/worklogs`, `/whats-new`) with **no `else` arm**. Producers emit **7**. The missing four fell through in silence, so the `[View]` button on every fault toast opened the dashboard's default view - and `/tasks?integrations=1` kept being emitted by all five `pm.*` sync faults long after the `/tasks` route was deleted in the Next fold. Nothing failed, because a link that resolves to nothing is indistinguishable from one that works.

- **New `meridian_core::notifications::deep_links`** - the fixed vocabulary (`ALL`) plus retired spellings undelivered outbox rows still carry (`LEGACY`). Every producer now references a constant; `navigate()` handles all of `ALL`, both `LEGACY` entries, and has a `default:` that warns.
- **`pm.*` faults link to Settings → Integrations**, which is what their own `remedy` text already told the user to do. `NoticeBar`'s button changed from "Fix in Tasks →" (Tasks modal) to "Reconnect →" (same destination) - one fault, one place to go, across banner + toast + remedy.
- **`db.repaired` / `db.reset` are dismissible.** Both are raised by the tray's boot repair and cleared by *nothing anywhere in the codebase*, and `NoticeBar` had no dismiss by design - so a machine that ever ran a boot repair carried the banner permanently. They report a past event, not a live condition, so the user acknowledges them (via the already-registered, previously-unused `delete_notice`). Live faults deliberately remain non-dismissable.

## Slice 3 - Status events stop being toasts

**Removed the `system.health` "Back online. / Picking up where you left off." toast.** Measured on a real install: 18 fired in five weeks, one was ever interacted with. Beyond the volume, it was frequently incoherent:

- the went-quiet notice's own toast row is `DELETE`d by `clear_typed` on recovery, so any outage shorter than the tray's 30 s drain retracted the warning before it was shown - the user got a bare "Back online." for an outage they never saw;
- the `reconcile_stale` path fired for a notice raised by a **previous process instance**, i.e. an outage that by definition happened while that tray was not running;
- Meridian restarts its own daemon routinely (updates, watchdog, manual), so this fired on ordinary lifecycle events. Five of the 18 landed *after* the watchdog restart-storm fix (#678), two within minutes of an auto-update.

The went-quiet banner disappearing is the recovery signal. The full post-mortem is a comment at the removal site.

**`system.update` is deliberately left alone.** My earlier read of this data was wrong and I corrected it before building: all six toasts come from `check_for_updates` (reachable only from the tray menu - a user click, and the menu has no other surface for a result) or from `enforce_minimum_version` announcing a restart. They are responses to actions, not unsolicited noise, and a low answer rate on a confirmation toast measures nothing.

## Guards - both halves, both verified against real regressions

The contract crosses a language boundary and nothing type-checks the hop, so it is checked from both ends:

- **`tests/deep_links.rs`** - no producer emits a value outside the vocabulary.
- **`ui/__tests__/deep-links.test.ts`** - `navigate()` resolves every value in it (parsed out of the Rust, not restated).

Either alone passes vacuously. Worth flagging: **the first two drafts of the Rust scanner passed while catching nothing.** Matching exact call shapes missed the actual bug site (`notices.rs`'s `let link = … Some("…")`, a bare `Some` bound to a variable), and widening to "any path on a line mentioning link" still missed it because the keyword and the literal are on different lines. It is now anchored + cross-line, and verified to fail against a deliberate regression in **all four** shapes a deep link is attached by, plus the three ways the bun guard can be broken. A clean-tree pass was never treated as evidence.

## Docs

`NOTIFICATIONS.md` gains the **Ask / Fault / Status** taxonomy with a class per producer, and the "Status is the trap" note. Also removes step 4's per-type-toggle instructions - `type_enabled` and the `notify_*` fields were deleted a while ago and the doc still told people to add them.

## Verification

`cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test --workspace` 943 + all crates green; `bun test` 712 pass / 0 fail. Full pre-push suite passed (fmt, clippy, UI build, bun, cargo test, security audit).

Built in a separate git worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbX4WUhDMekZpBnP5aS7dD