### PR TITLE
fix(uninstall): remove the data that survived every uninstall path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5180,6 +5180,7 @@ dependencies = [
  "hex",
  "http",
  "jsonschema",
+ "keyring",
  "libsqlite3-sys",
  "meridian-core",
  "meridian-oauth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,13 @@ hex = "0.4"
 # Error handling
 anyhow = "1.0.86"
 
+# OS keychain — `meridian uninstall --remove-data/--purge` deletes the SQLCipher
+# key for meridian.db, the one piece of user data that lives nowhere on disk.
+# Version and features are deliberately IDENTICAL to tray/src-tauri/Cargo.toml's
+# (the crate that writes the entry, in db_key.rs) so cargo unifies them into one
+# build and the delete cannot drift from the write.
+keyring = { version = "3", features = ["apple-native", "windows-native"] }
+
 # HTTP client for PM provider APIs (Jira, GitHub, Linear)
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -14,13 +14,19 @@
 //! binaries, the install marker) and **keeps user data**. Three independent,
 //! additive flags widen the scope:
 //! - `--remove-data` — `~/.meridian`'s user data (db, credentials, settings,
-//!   logs, telemetry spool, icon cache, onboarded marker), plus (macOS only)
-//!   the OS-managed WebKit/AppKit caches for the tray's bundle id
-//!   (`com.meridiona.tray`'s `Application Support`/`Caches`/`WebKit`/
-//!   `Saved Application State`/`HTTPStorages`) and a best-effort `tccutil
-//!   reset` of the Accessibility/Screen Recording/Input Monitoring grants —
-//!   none of that lives under `~/.meridian` or the app bundle, so it would
-//!   otherwise survive every uninstall path, including this one, forever.
+//!   logs, telemetry spool, icon cache, onboarded/autostart markers), plus
+//!   everything Meridian leaves OUTSIDE that directory and outside the app
+//!   bundle, which would otherwise survive every uninstall path forever:
+//!   - the **OS keychain entry holding the SQLCipher key** for `meridian.db`
+//!     ([`remove_db_key_from_keychain`]) — the only user data that lives on no
+//!     filesystem path at all;
+//!   - the tray bundle id's OS-managed app data — on **macOS** the
+//!     WebKit/AppKit caches (`Application Support`/`Caches`/`WebKit`/`Saved
+//!     Application State`/`HTTPStorages`), on **Windows** `%LOCALAPPDATA%`/
+//!     `%APPDATA%\com.meridiona.tray`, which is where WebView2 keeps the
+//!     cookies and localStorage the signed-in account session lives in;
+//!   - (macOS) a best-effort `tccutil reset` of the Accessibility/Screen
+//!     Recording/Input Monitoring grants.
 //! - `--remove-runtime` — the downloaded Python + MLX runtime and any venvs.
 //! - `--remove-models` — Meridian's own MLX models from the shared HuggingFace
 //!   cache, allowlisted by exact directory name (never touches a model the user
@@ -332,6 +338,32 @@ fn run_human(plan: &Plan) {
             Ok(o) if o.status.success() => println!("✓ removed login task  Meridian Daemon"),
             _ => println!("✓ login task  Meridian Daemon (not registered)"),
         }
+
+        // The TRAY's launch-at-login is a separate mechanism from the daemon's
+        // scheduled task above: `tauri-plugin-autostart` registers it as an
+        // HKCU Run value, not a task, so the `schtasks /Delete` never touched
+        // it. On macOS the equivalent is a `com.meridiona.*` LaunchAgent plist,
+        // which the plist loop below already sweeps up - Windows had no such
+        // coverage, so the tray kept trying to start at every login with its
+        // executable deleted.
+        //
+        // The value name is the app's productName, which is what the plugin
+        // registers under. Best-effort: `reg delete` exits non-zero when the
+        // value is absent, the normal case on a second uninstall.
+        let out = std::process::Command::new("reg")
+            .args([
+                "delete",
+                r"HKCU\Software\Microsoft\Windows\CurrentVersion\Run",
+                "/V",
+                "Meridian",
+                "/F",
+            ])
+            .no_window()
+            .output();
+        match out {
+            Ok(o) if o.status.success() => println!("✓ removed login item  Meridian"),
+            _ => println!("✓ login item  Meridian (not registered)"),
+        }
     }
 
     let uid = uid_str();
@@ -363,6 +395,10 @@ fn run_human(plan: &Plan) {
     if flags.remove_data {
         for f in reset_tcc_grants() {
             eprintln!("⚠ could not reset TCC grant {f}");
+        }
+        match remove_db_key_from_keychain() {
+            None => println!("✓ removed database key from the OS keychain"),
+            Some(reason) => eprintln!("⚠ {reason}"),
         }
     }
     for f in &plan.runtime {
@@ -495,6 +531,11 @@ fn data_items(home: &Path) -> Vec<PathBuf> {
         "walkthrough_armed",
         "icon-cache",
         "daemon.sock",
+        // Written once by the tray after it successfully registers the
+        // launch-at-login item (tray/src-tauri/src/autostart.rs). Left behind,
+        // a reinstall would believe autostart was already configured and never
+        // re-register it, so the app would silently stop starting at login.
+        "autostart_configured",
     ]
     .iter()
     .map(|r| meridian.join(r))
@@ -523,10 +564,103 @@ fn app_cache_items(home: &Path) -> Vec<PathBuf> {
         .filter(|p| p.symlink_metadata().is_ok())
         .collect()
     }
-    #[cfg(not(target_os = "macos"))]
+    // Windows' equivalent: everything WebView2 and Tauri keep OUTSIDE the
+    // install directory, keyed off the same bundle id. `%LOCALAPPDATA%\
+    // com.meridiona.tray` is where WebView2 puts its `EBWebView` profile —
+    // cookies, localStorage, IndexedDB, cache — which is where the signed-in
+    // account session actually lives, so leaving it behind means an uninstall
+    // + reinstall silently comes back still logged in. `%APPDATA%\...` is the
+    // roaming half. Neither is touched by the NSIS uninstaller, which only
+    // removes what it installed.
+    //
+    // Read from the environment rather than composed from `home`: the two are
+    // independently redirectable (roaming profiles, redirected folders), so
+    // deriving them from the home directory would miss the real location on
+    // exactly the machines where it matters.
+    #[cfg(target_os = "windows")]
+    {
+        let _ = home;
+        bundle_dirs_under(
+            ["LOCALAPPDATA", "APPDATA"]
+                .iter()
+                .filter_map(|var| std::env::var_os(var))
+                .map(PathBuf::from),
+        )
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
         let _ = home;
         Vec::new()
+    }
+}
+
+/// Joins the tray's bundle id onto each base directory and keeps only the ones
+/// that exist — the existence filter every other item list here uses, so a
+/// wizard checkbox never advertises removing nothing.
+///
+/// Split out of [`app_cache_items`]'s Windows branch purely so it is testable
+/// WITHOUT mutating `%LOCALAPPDATA%`/`%APPDATA%`: those are process-global, and
+/// Rust runs tests in parallel threads, so a test that set them would race every
+/// other test in the binary. Compiled on non-Windows only under `cfg(test)`, so
+/// the coverage runs on every platform's CI while release builds carry nothing
+/// dead.
+#[cfg(any(target_os = "windows", test))]
+fn bundle_dirs_under(bases: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
+    const BUNDLE_ID: &str = "com.meridiona.tray";
+    bases
+        .into_iter()
+        .map(|base| base.join(BUNDLE_ID))
+        .filter(|p| p.symlink_metadata().is_ok())
+        .collect()
+}
+
+/// Best-effort removal of the SQLCipher key for `meridian.db` from the OS
+/// keychain (macOS Keychain / Windows Credential Manager), written by
+/// `tray/src-tauri/src/db_key.rs`.
+///
+/// This is the one piece of Meridian's user data that lives nowhere on disk, so
+/// no amount of deleting directories reaches it. Left behind it is both a
+/// privacy leak (the key to a database the user asked us to destroy) and a
+/// correctness hazard: a reinstall finds a key in the keychain and assumes the
+/// database it decrypts is its own.
+///
+/// The service/account pair and the `keyring` crate are deliberately the SAME
+/// ones the tray writes with, rather than a hand-rolled `security
+/// delete-generic-password` / `cmdkey /delete` shell-out. Windows' credential
+/// target is an internal `keyring` convention (`{user}.{service}`), so spelling
+/// it out here would silently stop matching the day that crate changes it - and
+/// the failure mode is invisible, which is exactly what this function exists to
+/// prevent.
+///
+/// Non-fatal, and returns a reason when it did NOT clearly succeed: the item
+/// may be ACL-restricted to the tray's code signature, so macOS can refuse or
+/// prompt. A missing entry is a SUCCESS - that is the normal second-uninstall
+/// case, and the desired end state either way.
+fn remove_db_key_from_keychain() -> Option<String> {
+    // Mirrors tray/src-tauri/src/db_key.rs's SERVICE/ACCOUNT.
+    const SERVICE: &str = "Meridian";
+    const ACCOUNT: &str = "db-encryption-key";
+
+    let entry = match keyring::Entry::new(SERVICE, ACCOUNT) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!(error = %e, "uninstall: could not open the OS keychain");
+            return Some(format!("could not open the OS keychain: {e}"));
+        }
+    };
+    match entry.delete_credential() {
+        Ok(()) => {
+            tracing::info!("uninstall: removed the database key from the OS keychain");
+            None
+        }
+        Err(keyring::Error::NoEntry) => {
+            tracing::info!("uninstall: no database key in the OS keychain");
+            None
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "uninstall: could not remove the database key");
+            Some(format!("could not remove the database key: {e}"))
+        }
     }
 }
 

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -583,7 +583,7 @@ fn app_cache_items(home: &Path) -> Vec<PathBuf> {
         bundle_dirs_under(
             ["LOCALAPPDATA", "APPDATA"]
                 .iter()
-                .filter_map(|var| std::env::var_os(var))
+                .filter_map(std::env::var_os)
                 .map(PathBuf::from),
         )
     }

--- a/src/uninstall/json.rs
+++ b/src/uninstall/json.rs
@@ -108,6 +108,15 @@ pub(super) fn run_json(plan: &Plan) {
         for f in reset_tcc_grants() {
             report.errors.push(format!("tccutil reset {f}"));
         }
+        // The database key in the OS keychain lives on no filesystem path, so
+        // it cannot ride the `plan` loops above and has to be removed here too
+        // — this is the path the tray's uninstall WIZARD drives, which is how
+        // most users uninstall, so omitting it would leave the key behind on
+        // exactly the common route.
+        match super::remove_db_key_from_keychain() {
+            None => report.removed.push("OS keychain: database key".to_string()),
+            Some(reason) => report.errors.push(reason),
+        }
     }
     // `--purge` only: nuke anything left under ~/.meridian the itemized lists
     // above didn't name. Mirrors the human path's `--purge`-only gate — see the

--- a/src/uninstall/tests.rs
+++ b/src/uninstall/tests.rs
@@ -132,6 +132,40 @@ fn data_items_includes_app_caches_when_present() {
         .any(|p| p.ends_with("com.meridiona.tray.savedState")));
 }
 
+/// The launch-at-login marker must be removed with the rest of the user data.
+/// Left behind, a reinstall reads it, believes autostart is already configured,
+/// and never re-registers the login item — so the app silently stops starting
+/// at login and nothing reports an error.
+#[test]
+fn data_items_includes_the_autostart_marker() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path();
+    let meridian = home.join(".meridian");
+    std::fs::create_dir_all(&meridian).unwrap();
+    std::fs::write(meridian.join("autostart_configured"), "").unwrap();
+
+    assert!(data_items(home).contains(&meridian.join("autostart_configured")));
+}
+
+/// The Windows branch of [`app_cache_items`]: `%LOCALAPPDATA%`/`%APPDATA%`'s
+/// `com.meridiona.tray` directories are where WebView2 keeps the cookies and
+/// localStorage the signed-in session lives in, so an uninstall that skipped
+/// them would come back still logged in. Exercised through `bundle_dirs_under`
+/// on every platform rather than through the env vars, which are process-global
+/// and would race the other tests.
+#[test]
+fn bundle_dirs_are_listed_only_when_they_exist() {
+    let tmp = TempDir::new().unwrap();
+    let local = tmp.path().join("Local");
+    let roaming = tmp.path().join("Roaming");
+    std::fs::create_dir_all(local.join("com.meridiona.tray")).unwrap();
+    // `roaming` deliberately has no bundle dir — must not be listed.
+    std::fs::create_dir_all(&roaming).unwrap();
+
+    let found = bundle_dirs_under([local.clone(), roaming.clone()]);
+    assert_eq!(found, vec![local.join("com.meridiona.tray")]);
+}
+
 /// `model_items` only returns catalog entries that exist on disk, and never
 /// invents a path for a model that isn't in [`MODEL_CATALOG`].
 #[test]

--- a/ui/app/uninstall/page.tsx
+++ b/ui/app/uninstall/page.tsx
@@ -30,9 +30,16 @@ export default function UninstallWizard() {
   const [phase, setPhase] = useState<Phase>('loading')
   const [plan, setPlan] = useState<UninstallPlan>(EMPTY_PLAN)
   const [result, setResult] = useState<UninstallResult | null>(null)
-  const [removeData, setRemoveData] = useState(false)
-  const [removeRuntime, setRemoveRuntime] = useState(false)
-  const [removeModels, setRemoveModels] = useState(false)
+  // All three default to CHECKED: "uninstall" means remove the product, and
+  // leaving them off shipped an uninstall that kept the activity database, the
+  // tracker credentials and the signed-in account - so the app was gone but the
+  // user's data, and their Jira/Linear tokens, quietly stayed on the machine.
+  // Every item is still listed and individually unticked, so the narrower
+  // "remove the app, keep my data" path is one click away rather than the
+  // silent default.
+  const [removeData, setRemoveData] = useState(true)
+  const [removeRuntime, setRemoveRuntime] = useState(true)
+  const [removeModels, setRemoveModels] = useState(true)
   const [runErr, setRunErr] = useState('')
 
   useEffect(() => {
@@ -192,7 +199,7 @@ function SelectStep({
       <OptionRow
         checked={removeData} onToggle={() => setRemoveData(!removeData)}
         title="Meridian data"
-        subtitle="Activity database, tracker credentials, settings, logs, and telemetry"
+        subtitle="Activity database and its encryption key, your sign-in, tracker credentials, settings, logs, and telemetry"
         items={plan.data}
       />
       <OptionRow


### PR DESCRIPTION
Uninstalling left the user **signed in**, with their **tracker credentials**, their **activity database and its encryption key** still on the machine.

## The four holes

Each was invisible, because nothing reported them.

**1. The OS keychain entry holding the SQLCipher key for `meridian.db` was never touched.** It lives on no filesystem path, so no amount of deleting directories reached it - both a privacy leak (the key to a database the user asked us to destroy) and a correctness hazard, since a reinstall finds a key and assumes the database it decrypts is its own.

It is now deleted through the **same `keyring` crate and service/account pair the tray writes it with**, rather than a hand-rolled `security delete-generic-password` / `cmdkey /delete`. Windows' credential target is an internal `keyring` convention (`{user}.{service}`), so spelling it out here would silently stop matching the day that crate changes it - and the failure would be invisible, which is the exact class of bug this PR is about.

**2. On Windows nothing removed `%LOCALAPPDATA%`/`%APPDATA%\com.meridiona.tray`** - where WebView2 keeps the cookies and localStorage the signed-in session actually lives in. Uninstall + reinstall came back **still logged in**. macOS already had the equivalent sweep; Windows had none.

**3. The tray's launch-at-login is an HKCU `Run` value**, a different mechanism from the daemon's scheduled task, so `schtasks /Delete` never touched it - the tray kept trying to start at every login with its executable deleted. macOS was already covered by the `com.meridiona.*` LaunchAgent sweep.

**4. The `autostart_configured` marker was not in the data list**, so a reinstall read it, believed autostart was already set up, and never re-registered the login item. The app silently stopped starting at login.

## The default that made it reachable

The wizard's three checkboxes **defaulted to unchecked**. Clicking through "uninstall" removed the app and kept the database, the Jira/Linear tokens and the account - which is what was actually being hit in practice.

They now default to **checked**, with every item still listed and individually unticked, so "remove the app, keep my data" is one click away instead of the silent default.

Keychain removal is wired into **both** the human path and the `--json` path, since the `--json` one is what the tray's wizard drives and is how most users uninstall.

## Tests

`bundle_dirs_under` is split out of the Windows branch specifically so it is testable **without** mutating `%LOCALAPPDATA%`/`%APPDATA%` - those are process-global and Rust runs tests in parallel threads, so a test that set them would race every other test in the binary. It compiles on non-Windows only under `cfg(test)`, so the coverage runs on every platform's CI while release builds carry nothing dead.

- `data_items_includes_the_autostart_marker`
- `bundle_dirs_are_listed_only_when_they_exist`
- 10 uninstall tests pass, 711 UI tests pass, clippy and fmt clean.

## Still open, deliberately not fixed here

**Uninstalling via Windows' Add or Remove Programs runs no Meridian code at all** - there is no NSIS uninstall hook - so that route still leaves everything behind. A hook is the fix, but Tauri runs the previous version's uninstaller during an **upgrade** too, so a hook that purges data risks **wiping the database on every auto-update**. That needs a real Windows install/upgrade test before it ships, which I could not do here.
