### PR TITLE
fix(observability): stop printing every dev warning and error twice

### DIFF
--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -163,20 +163,30 @@ pub fn init(service_name: &str) -> Result<ObservabilityGuard> {
     // Debug-build-only terminal mirror. `Option<Layer>` itself implements
     // `Layer` (tracing-subscriber's blanket impl), so `.with(fmt_stdout)`
     // below is a no-op layer in a release build — no runtime cost, no output.
+    //
+    // ONE layer, with the writer choosing the stream by level — NOT two layers.
+    // It used to be a stdout layer taking every level plus a second stderr
+    // layer filtered to WARN, which meant every warning and error was printed
+    // TWICE in a dev run (once per layer) while INFO printed once. Two layers
+    // are two subscribers: each one formats and writes the event independently,
+    // so a level filter on the second narrows WHICH events it duplicates, never
+    // whether it duplicates them.
+    //
+    // `with_max_level(WARN)` reads by SEVERITY, not verbosity: it admits WARN
+    // and ERROR (the levels at or above WARN in severity) and rejects
+    // INFO/DEBUG/TRACE. `or_else` then catches exactly what stderr declined, so
+    // the two streams partition the events rather than overlapping — every
+    // event lands on exactly one stream, once.
+    use tracing_subscriber::fmt::writer::MakeWriterExt as _;
     let fmt_stdout = cfg!(debug_assertions).then(|| {
         tracing_subscriber::fmt::layer()
             .with_target(true)
-            .with_writer(std::io::stdout)
+            .with_writer(
+                std::io::stderr
+                    .with_max_level(tracing::Level::WARN)
+                    .or_else(std::io::stdout),
+            )
             .compact()
-    });
-    use tracing_subscriber::filter::LevelFilter;
-    use tracing_subscriber::Layer as _;
-    let fmt_stderr = cfg!(debug_assertions).then(|| {
-        tracing_subscriber::fmt::layer()
-            .with_target(true)
-            .with_writer(std::io::stderr)
-            .compact()
-            .with_filter(LevelFilter::WARN)
     });
 
     // Build OTel providers first (no generic subscriber type involved yet),
@@ -194,7 +204,6 @@ pub fn init(service_name: &str) -> Result<ObservabilityGuard> {
                 tracing_subscriber::registry()
                     .with(rl.take().unwrap())
                     .with(fmt_stdout)
-                    .with(fmt_stderr)
                     .with(trace_layer)
                     .with(log_layer)
                     .init();
@@ -210,7 +219,6 @@ pub fn init(service_name: &str) -> Result<ObservabilityGuard> {
                 tracing_subscriber::registry()
                     .with(rl.take().unwrap())
                     .with(fmt_stdout)
-                    .with(fmt_stderr)
                     .init();
                 (false, None, None)
             }
@@ -219,7 +227,6 @@ pub fn init(service_name: &str) -> Result<ObservabilityGuard> {
                 tracing_subscriber::registry()
                     .with(rl.take().unwrap())
                     .with(fmt_stdout)
-                    .with(fmt_stderr)
                     .init();
                 (false, None, None)
             }


### PR DESCRIPTION
A dev run printed each WARN and ERROR **twice**, while INFO printed once:

```
ERROR meridian::health: health check failed ...
ERROR meridian::health: health check failed ...
WARN  meridian: another meridian daemon already owns this data dir ...
WARN  meridian: another meridian daemon already owns this data dir ...
```

## Cause

The subscriber registered **two** fmt layers - a stdout one taking every level, and a stderr one filtered to `WARN`.

Two layers are two independent subscribers: each formats and writes the event on its own, so the level filter on the second only narrowed *which* events it duplicated, never *whether* it duplicated them. INFO escaped because only one layer accepted it - and that asymmetry is exactly what made the cause findable.

## Fix

One layer whose **writer** picks the stream by level, so the two streams partition the events instead of overlapping:

- `with_max_level(WARN)` reads by **severity** - it admits WARN and ERROR, rejects INFO/DEBUG/TRACE
- `or_else(stdout)` catches precisely what stderr declined

Every event now lands on exactly one stream, once.

## Verified

Captured the streams to separate files (`2>&1 1>/dev/null` is unreliable under zsh's MULTIOS, which tees rather than swaps - that briefly gave me a false reading):

| | INFO | WARN/ERROR |
|---|---|---|
| stdout | 4 | 0 |
| stderr | 0 | 2 |

and no line appears twice in the combined output.

## Scope

Release builds are unaffected either way - both layers were already `debug_assertions`-only, so this mirror is absent there and the telemetry spool remains the sole sink.
