### PR TITLE
fix(ci): make the cache prune actually prune

### DIFF
--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -86,9 +86,14 @@ jobs:
             "v0-rust-ci-macos-silicon|refs/heads/pre-main"
             "v0-rust-ci-windows|refs/heads/pre-main"
           )
+          # Counts so a SYSTEMATIC failure is loud. Every pair failing used to
+          # look identical to a quiet, healthy run: see the `--jq` note below.
+          attempted=0
+          failed=0
           for pair in "${pairs[@]}"; do
             prefix="${pair%%|*}"
             ref="${pair##*|}"
+            attempted=$((attempted + 1))
             echo "=== ${prefix} (${ref}) ==="
             # --paginate: without it, per_page=100 silently caps this pair at
             # its first 100 caches with no follow-up page — this repo already
@@ -100,10 +105,22 @@ jobs:
             # script under set -euo pipefail — skip just this pair and let
             # the next scheduled run retry it, same tolerance the delete call
             # below already has.
-            stale=$(gh api --paginate "repos/${{ github.repository }}/actions/caches?per_page=100&ref=${ref}" \
-              --jq --arg p "$prefix" \
-              '[.actions_caches[] | select(.key | startswith($p))] | sort_by(.created_at) | reverse | .[1:] | .[].id') \
-              || { echo "::warning::failed to list caches for ${prefix} (${ref}), skipping this pair"; continue; }
+            #
+            # The prefix reaches jq through the ENVIRONMENT, not `--arg`.
+            # `gh api --jq` takes exactly one argument, the filter — it is not
+            # jq's CLI and does not forward jq's flags. Written as
+            # `--jq --arg p "$prefix" '<filter>'` it parsed as four arguments
+            # and gh rejected the call with "accepts 1 arg(s), received 4",
+            # EVERY time, for every pair. The `|| { warning; continue; }` below
+            # then swallowed it into a `::warning::` — which does not fail a
+            # run and which nobody reads — so this job reported success while
+            # deleting nothing at all, for its entire history. That is why the
+            # pool kept climbing to 8-11 GB and had to be cleared by hand.
+            # `env.PREFIX` also cannot inject into the filter the way string
+            # interpolation could.
+            stale=$(PREFIX="$prefix" gh api --paginate "repos/${{ github.repository }}/actions/caches?per_page=100&ref=${ref}" \
+              --jq '[.actions_caches[] | select(.key | startswith(env.PREFIX))] | sort_by(.created_at) | reverse | .[1:] | .[].id') \
+              || { failed=$((failed + 1)); echo "::warning::failed to list caches for ${prefix} (${ref}), skipping this pair"; continue; }
             if [ -z "$stale" ]; then
               echo "nothing to prune"
               continue
@@ -114,6 +131,15 @@ jobs:
                 || echo "::warning::failed to delete cache ${id} (non-fatal, next run will retry)"
             done
           done
+
+          # One pair failing is a transient blip worth tolerating; ALL of them
+          # failing is the listing call being broken, which is the exact
+          # condition that hid for this job's whole history behind a warning
+          # nobody reads. Fail loudly so it cannot happen silently twice.
+          if [ "${failed}" -eq "${attempted}" ] && [ "${attempted}" -gt 0 ]; then
+            echo "::error::every prefix failed to list (${failed}/${attempted}) — the listing call itself is broken, not a transient API error. Nothing was pruned."
+            exit 1
+          fi
 
       - name: Reap caches no run can ever restore
         env:


### PR DESCRIPTION
**The per-prefix prune has never deleted a single cache.** It reported success every time.

## Cause

`gh api --jq` takes exactly **one** argument, the filter. It is not jq's CLI and does not forward jq's flags, so this:

```bash
gh api --paginate "..." --jq --arg p "$prefix" '<filter>'
```

parsed as four arguments and gh rejected the call outright:

```
accepts 1 arg(s), received 4
```

every run, for every one of the four prefixes. The `|| { ...; continue; }` guard then swallowed each failure into a `::warning::` - which does not fail a run, and which nobody reads. So the job printed its four prefix headers and exited **green**, having done nothing.

## Why this matters

This is the missing explanation for the file's own documented history: the pool climbing to *"11.3 GB across 34 caches once (cleared by hand)"*, and *"`ci-macos-silicon` found sitting at FOUR duplicate copies of itself"*. The job written to prevent exactly that was never running.

It also means the 10 GiB cap has been defended only by GitHub's LRU, which evicts the **oldest** entry rather than the most useless one - so the ~1.2 GB release tarballs a warm build depends on were always in the firing line.

## Fix

The prefix now reaches jq through the environment as `env.PREFIX`, which as a bonus cannot inject into the filter the way interpolating the shell variable could.

## Verified against the live API before committing

Ran the extracted script with the DELETE neutralised:

```
=== v0-rust-macos-release-aarch64-apple-darwin (refs/heads/main) ===
nothing to prune
=== v0-rust-windows-release-x86_64-pc-windows-msvc (refs/heads/main) ===
WOULD-DELETE .../6391613756
=== v0-rust-ci-macos-silicon (refs/heads/pre-main) ===
WOULD-DELETE .../6456105755
=== v0-rust-ci-windows (refs/heads/pre-main) ===
nothing to prune
```

Correct on both sides: it leaves the two single-entry prefixes alone and identifies the two genuinely superseded caches - about **2.7 GB**, including a 1208 MB `windows-release` entry from 2026-08-06 that had been unreachable for four days.

## Guard so it cannot go silent twice

The step now **fails** when *every* prefix fails to list. One pair failing is a transient blip worth tolerating; all of them failing means the listing call itself is broken - precisely the condition that hid here behind a warning.
