### PR TITLE
fix(dev): make meridian dev actually run a daemon

### DIFF
--- a/dev-start.sh
+++ b/dev-start.sh
@@ -78,15 +78,11 @@ pkill -f 'next dev --turbopack -p 3939' 2>/dev/null || true   # orphaned Next.js
 # then pkill the installed binary BY PATH as a backstop (the dev pkills above only
 # match `target/debug/meridian`, never `~/.meridian/bin/meridian`). Re-enable the
 # installed daemon later with `meridian start`.
-DAEMON_LABEL="gui/$(id -u)/com.meridiona.daemon"
-launchctl disable "$DAEMON_LABEL" 2>/dev/null || true
-launchctl bootout "$DAEMON_LABEL" 2>/dev/null || true
-pkill -f '\.meridian/bin/meridian$' 2>/dev/null || true   # DMG-staged installed daemon
-if pgrep -f '\.meridian/bin/meridian$' >/dev/null 2>&1; then
-    echo "  ⚠ an installed daemon (~/.meridian/bin/meridian) is STILL running — quit the Meridian app and re-run" >&2
-else
-    echo "  ✓ canonical launchd daemon stopped + disabled (re-enable later with: meridian start)"
-fi
+# Lives in scripts/dev-claim-daemon.sh rather than inline, because the DAEMON
+# TAB spawned below has to run it too — see that file's header. Doing it only
+# here fixed nothing the moment the tab was re-run on its own (Up-Enter, or
+# Terminal reopening it at login), which is the common case.
+bash "${REPO_ROOT}/scripts/dev-claim-daemon.sh" || true
 # Also stops the legacy launchd-managed a11y-helper, if present. Capture now runs
 # in-process inside the dev tray binary, so a lingering a11y-helper would be a
 # second, independent capture writer into the same meridian.db capture tables.
@@ -156,7 +152,13 @@ tell application "Terminal"
     activate
 
     -- 1. Rust daemon (cargo watch)
-    do script "echo '=== Rust daemon (cargo watch) ===' && cd '${REPO_ROOT}' && ${DB_ENV}cargo watch ${DAEMON_WATCH} ${FORK_WATCH_FLAG} -x 'run --bin meridian'"
+    -- The claim step runs INSIDE the tab, chained with &&, so it re-runs every
+    -- time this command does — including when the tab is restarted by hand or
+    -- reopened at login, long after this script exited. Without it the dev
+    -- daemon silently exits 0 against an installed daemon that took the socket
+    -- back. `&&` (not `;`) on purpose: if the socket cannot be freed, stop
+    -- rather than start a watcher that can only no-op.
+    do script "echo '=== Rust daemon (cargo watch) ===' && cd '${REPO_ROOT}' && bash scripts/dev-claim-daemon.sh && ${DB_ENV}cargo watch ${DAEMON_WATCH} ${FORK_WATCH_FLAG} -x 'run --bin meridian'"
 
     -- 2. Tauri tray (hot reload — also starts Next.js dev server automatically via beforeDevCommand)
     do script "echo '=== Tauri tray (tauri dev) ===' && cd '${REPO_ROOT}/tray' && ${DB_ENV}npm run tauri dev"

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -161,7 +161,14 @@ tell application "Terminal"
     do script "echo '=== Rust daemon (cargo watch) ===' && cd '${REPO_ROOT}' && bash scripts/dev-claim-daemon.sh && ${DB_ENV}cargo watch ${DAEMON_WATCH} ${FORK_WATCH_FLAG} -x 'run --bin meridian'"
 
     -- 2. Tauri tray (hot reload — also starts Next.js dev server automatically via beforeDevCommand)
-    do script "echo '=== Tauri tray (tauri dev) ===' && cd '${REPO_ROOT}/tray' && ${DB_ENV}npm run tauri dev"
+    -- MERIDIAN_DEV_DAEMON=1 tells the tray that a DEV daemon owns
+    -- ~/.meridian/daemon.sock, so its launch-time restore stands down
+    -- (daemon_lifecycle::restore_unless_paused). Without it this tab's tray
+    -- reached the dev/source bail-out in ensure_backend_installed, re-registered
+    -- and kickstarted the INSTALLED launchd daemon, and that daemon took the
+    -- socket back from the tab above - which then exited on the single-instance
+    -- guard with status 0, looking healthy while running nothing.
+    do script "echo '=== Tauri tray (tauri dev) ===' && cd '${REPO_ROOT}/tray' && MERIDIAN_DEV_DAEMON=1 ${DB_ENV}npm run tauri dev"
 end tell
 APPLESCRIPT
 

--- a/scripts/dev-claim-daemon.sh
+++ b/scripts/dev-claim-daemon.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+#
+# Claim ~/.meridian/daemon.sock for a DEV daemon by stopping the canonical
+# launchd-managed one (com.meridiona.daemon) if a packaged install is present.
+#
+# WHY THIS IS ITS OWN FILE, CALLED FROM THE TERMINAL TAB
+#
+# dev-start.sh already did this — but it did it in the SCRIPT, while the thing
+# that actually runs the daemon is a Terminal tab it spawns via `osascript`.
+# Those have different lifetimes. The tab's command outlives the script, and it
+# gets re-run constantly: pressing Up-Enter in that window, reopening Terminal
+# with "reopen windows on login", or simply starting the tab again the next
+# morning. Every one of those paths ran `cargo watch` with NO teardown, so if
+# the installed daemon had come back in the meantime (a `meridian start`, a
+# login, reinstalling the app) it still owned the socket.
+#
+# The dev daemon then hit the single-instance guard and exited — with status 0,
+# because for the canonical daemon that is correct: a non-zero exit would make
+# launchd's KeepAlive restart-loop it. So `cargo watch` printed
+# "[Finished running. Exit status: 0]" and sat there looking healthy while the
+# daemon was not running at all. Days of edits can go un-exercised that way,
+# and nothing in the output says so.
+#
+# Making the tab call this first means the precondition travels WITH the thing
+# that needs it, instead of living in a parent process that may have exited
+# hours ago.
+#
+# Deliberately NOT part of the daemon itself: a dev build silently booting out
+# the installed daemon on startup would be action at a distance, and the guard
+# is load-bearing — two daemons on one meridian.db both fire the clock-aligned
+# HH:03 worklog trigger and double-run the hour.
+#
+# Re-enable the installed daemon afterwards with: meridian start
+set -euo pipefail
+
+DAEMON_LABEL="gui/$(id -u)/com.meridiona.daemon"
+INSTALLED_RE='\.meridian/bin/meridian$'
+
+# `disable` so launchd will not re-launch it at login or on kickstart, `bootout`
+# to stop the live one, then pkill BY PATH as a backstop — bootout can miss if
+# KeepAlive respawns at the wrong instant. The path anchor is what keeps this
+# from ever matching the DEV binary (target/debug/meridian) we are about to run.
+launchctl disable "${DAEMON_LABEL}" 2>/dev/null || true
+launchctl bootout "${DAEMON_LABEL}" 2>/dev/null || true
+pkill -f "${INSTALLED_RE}" 2>/dev/null || true
+
+# Give the socket a moment to be released before the caller binds it.
+for _ in 1 2 3 4 5; do
+    pgrep -f "${INSTALLED_RE}" >/dev/null 2>&1 || break
+    sleep 0.4
+done
+
+if pgrep -f "${INSTALLED_RE}" >/dev/null 2>&1; then
+    # Fail LOUD and stop the chain. The whole point of this file is that the
+    # silent version of this failure is indistinguishable from success, so
+    # returning 0 here would reintroduce exactly the bug it exists to prevent.
+    echo "✗ an installed daemon (~/.meridian/bin/meridian) is STILL running and owns" >&2
+    echo "  ~/.meridian/daemon.sock, so the dev daemon would start and immediately" >&2
+    echo "  exit via the single-instance guard." >&2
+    echo "  Quit the Meridian app from the menubar, then re-run." >&2
+    exit 1
+fi
+
+echo "✓ daemon socket is free (installed daemon stopped + disabled; re-enable with: meridian start)"
+
+# A RUNNING TRAY UNDOES ALL OF THE ABOVE, so say so rather than let it look
+# flaky. `backend_install::register_agent` runs `launchctl enable` +
+# `bootstrap` + `kickstart -k`, so a tray that decides the daemon is missing
+# re-enables the very service just disabled and hands it the socket back —
+# observed here as `print-disabled` reporting "enabled" barely a minute after a
+# successful `disable`, which reads as the disable silently failing when it did
+# not. dev-start.sh kills the tray before calling this, so the full flow is
+# unaffected; only re-running the daemon tab alone hits it.
+if pgrep -f 'target/(debug|release)/meridian-tray$' >/dev/null 2>&1; then
+    echo "  ⚠ a dev tray is running and may re-register the installed daemon" >&2
+    echo "    (backend_install::register_agent re-enables + kickstarts it)." >&2
+    echo "    If the daemon exits on the single-instance guard again, quit the tray" >&2
+    echo "    or use dev-start.sh, which stops both in the right order." >&2
+fi

--- a/tray/src-tauri/src/daemon_lifecycle.rs
+++ b/tray/src-tauri/src/daemon_lifecycle.rs
@@ -430,7 +430,24 @@ pub(crate) async fn resume_from_pause() -> Result<(), String> {
     .await
 }
 
-/// The launch-time restore, refusing while the daemon is deliberately paused.
+/// Whether a local dev daemon owns this data dir, set by `dev-start.sh` in the
+/// tabs it spawns.
+///
+/// An explicit opt-in env var rather than sniffing for a `target/debug/meridian`
+/// process: the tray and the dev daemon race at startup (both tabs open at
+/// once), so a process probe would report "no dev daemon" purely because it ran
+/// a second too early — the same timing bug this exists to close. It is also
+/// inert in packaged builds, which never set it, so the shipped restore
+/// behaviour cannot change.
+fn dev_daemon_owns_data_dir() -> bool {
+    matches!(
+        std::env::var("MERIDIAN_DEV_DAEMON").as_deref(),
+        Ok("1") | Ok("true")
+    )
+}
+
+/// The launch-time restore, refusing while the daemon is deliberately paused
+/// **or** while a dev daemon owns the data dir.
 ///
 /// Every bail-out in [`crate::backend_install::ensure_backend_installed`] calls
 /// this rather than `ensure_daemon_running` directly. Both halves matter:
@@ -451,6 +468,29 @@ pub(crate) async fn restore_unless_paused(home: &std::path::Path) {
         if DAEMON_PAUSED.load(Ordering::Relaxed) {
             s.record("outcome", "skipped_paused");
             tracing::info!("skipping the launch-time daemon restore - the user paused it");
+            return;
+        }
+        // A DEV DAEMON OWNS THIS DATA DIR — do not resurrect the installed one.
+        //
+        // `dev-start.sh` opens two Terminal tabs at once: one claims
+        // ~/.meridian/daemon.sock for a `cargo run` daemon, the other starts
+        // `tauri dev`. This tray then reached the dev/source bail-out in
+        // `ensure_backend_installed`, which calls straight through to here, and
+        // re-registered + kickstarted the INSTALLED launchd daemon seconds
+        // later. That daemon took the socket back, and the dev daemon exited on
+        // the single-instance guard with status 0 — so `cargo watch` printed
+        // "Exit status: 0" and looked healthy while running nothing.
+        //
+        // Checked HERE rather than in `ensure_daemon_running`, which is the
+        // shared choke point but is also what the tray menu's Resume calls: a
+        // user who explicitly resumes must still get a daemon. This is only the
+        // automatic launch-time restore, which is the one that must stand down.
+        if dev_daemon_owns_data_dir() {
+            s.record("outcome", "skipped_dev_daemon");
+            tracing::info!(
+                "skipping the launch-time daemon restore - MERIDIAN_DEV_DAEMON is set, \
+                 so a dev daemon owns this data dir"
+            );
             return;
         }
         s.record("outcome", "restored");


### PR DESCRIPTION
`meridian dev` looked healthy while running **no daemon at all**:

```
[Running 'cargo run --bin meridian']
WARN meridian: another meridian daemon already owns this data dir — exiting (single-instance guard)
[Finished running. Exit status: 0]
```

Two independent causes, in sequence. The first fix was necessary but not sufficient - the second only became visible after it landed.

## 1. The teardown was in the script, not the tab

`dev-start.sh` already stopped the installed daemon - but in the **script**, while the thing that runs the daemon is a Terminal **tab** it spawns via `osascript`. Those have different lifetimes.

The tab's command outlives the script and gets re-run constantly: Up-Enter in that window, Terminal reopening it at login, starting it again the next morning. Every one of those ran `cargo watch` with **no teardown**, so if the installed daemon had come back since, it still owned `~/.meridian/daemon.sock`.

The dev daemon then hit the single-instance guard and exited **with status 0** - correct for the canonical daemon, since a non-zero exit would make launchd's KeepAlive restart-loop it. So `cargo watch` printed `Exit status: 0` and sat there looking fine.

**Fix:** the teardown moves to `scripts/dev-claim-daemon.sh`, which the *tab* runs, chained with `&&` so a socket that cannot be freed stops the chain rather than starting a watcher that can only no-op. `dev-start.sh` calls the same script instead of keeping its own copy. The precondition now travels with the thing that needs it.

## 2. The dev tray resurrects the installed daemon

With the socket freed, the daemon started - and died anyway:

```
✓ daemon socket is free (installed daemon stopped + disabled; …)
WARN meridian: another meridian daemon already owns this data dir — exiting
```

`dev-start.sh` opens both tabs at once. The daemon tab claims the socket; the tray tab then starts `tauri dev`, and that tray reaches the dev/source bail-out in `ensure_backend_installed`, which calls straight through to `daemon_lifecycle::restore_unless_paused`. That re-registers and kickstarts the **installed** launchd daemon, which takes the socket back seconds later.

Measured: tray up 44s, installed daemon up 30s with PPID 1, and `launchctl print-disabled` flipping from `disabled` back to `enabled` - which reads exactly like the `disable` had silently failed, when it had not.

**Fix:** the restore is not removable (it exists so one dev quit does not leave the daemon permanently booted out), so it stands down when `MERIDIAN_DEV_DAEMON=1`, which `dev-start.sh` sets in the tray tab.

Checked in `restore_unless_paused` rather than the shared `ensure_daemon_running` choke point **on purpose**: the latter is also what the tray menu's **Resume** calls, and a user who explicitly resumes must still get a daemon. Only the automatic launch-time restore stands down.

An env var rather than a `target/debug/meridian` process probe: the tray and the dev daemon race at startup (both tabs open together), so a probe could report "no dev daemon" purely because it ran a second early - the same timing bug this closes. Packaged builds never set it, so shipped restore behaviour is unchanged.

## Why this appeared "suddenly"

Machine state, not a code change:

```
~/.meridian/bin/meridian                           Aug 9 23:31:19
~/Library/LaunchAgents/com.meridiona.daemon.plist  Aug 9 23:32:31
```

A staging DMG install staged the canonical daemon and registered its launchd agent. Before that there was no installed daemon for the dev tray to resurrect.

## Deliberately not done

Having the daemon boot out its installed twin on startup. That is action at a distance, and the guard is load-bearing: two daemons on one `meridian.db` both fire the clock-aligned HH:03 worklog trigger and double-run the hour.

## Verified

- `cargo run --bin meridian` stays up past 30s and boots its full stack (telemetry shipper, summariser, embedder, coding-agent indexer) instead of exiting in under a second
- `scripts/dev-claim-daemon.sh` is idempotent on re-run
- **Full two-tab `dev-start.sh` run confirmed working by the reporter**

## Note

The first commit's message says the installed daemon had owned the socket for "22h48m". That was a misread of `ps -o etime`, whose format is `[[DD-]hh:]mm:ss` - 22 *minutes*, not hours. Corrected in the second commit's message rather than by rewriting a pushed commit.
