### PR TITLE
fix(tutorial): stop narrating a finished sync, remove stray title ring, drop redundant closing card

### DIFF
--- a/ui/components/tutorial/script.ts
+++ b/ui/components/tutorial/script.ts
@@ -105,8 +105,18 @@ const BOARD_CARD = '[data-tour="plan-board"] [data-plan-card]'
  * an empty board. By the time this runs the tickets are usually already there and it
  * returns immediately. It stays because the hand-back's hold is capped, and because
  * a board can be empty for reasons that never went near a connect.
+ *
+ * CHECKED BEFORE NARRATING, not after. `appeared(sel, 0)` reads the DOM once with no
+ * wait, so the common case - the hand-back already held the screen until the board
+ * had cards - sees them and returns immediately without saying anything. Saying "the
+ * first sync takes a moment" AFTER the screen has already moved to a board full of
+ * tickets contradicts what the user is looking at: the plan they were just handed
+ * back to reads as already done, and a line claiming otherwise reads as the tour
+ * having lost track of what just happened. The line is reserved for the genuine
+ * backstop case, where the board is still empty when this beat runs.
  */
 async function waitForTickets(s: Stage): Promise<boolean> {
+  if (await s.appeared(BOARD_CARD, 0)) return true
   s.say('Pulling your tickets in - the first sync takes a moment.')
   const got = await s.appeared(BOARD_CARD, 25000)
   s.say('')
@@ -530,7 +540,7 @@ export async function runScript(s: Stage): Promise<void> {
       // stalls a user who now feels they are supposed to find something to fix.
       // The fields are plainly editable - they are two text boxes with a cursor in
       // them - and nothing later depends on the user knowing it here.
-      s.spotlight('[data-tour="task-title"]')
+      s.spotlight(null)
       await s.waitForValue('[data-tour="task-title"]', { fallbackMs: 90000, settled: true })
       // AND the description, because Add to today needs BOTH - `canCreate` in
       // useTaskComposer.ts requires a title of MIN_TITLE_WORDS *and* a

--- a/ui/components/tutorial/scriptDay.ts
+++ b/ui/components/tutorial/scriptDay.ts
@@ -468,14 +468,13 @@ export async function runDayHalf(s: Stage, ctx: DayHalfContext): Promise<void> {
   s.showWorklogSchedule(false)
   await s.pause(600)
 
-  // ── 11. Running, and you can stop looking at it ─────────────────────────
-  // The reassurance the whole product depends on and the one a demo cannot
-  // demonstrate: nothing more is required of them. Said plainly, with the
-  // notification promise attached, because the alternative reading of an ambient
-  // tool is that it needs minding.
-  await s.next(
-    "You are set up. Close this window - Meridian keeps going, and tells you when something is ready.",
-    'One last thing', { center: true })
+  // ── 11. (was: "Running, and you can stop looking at it") ────────────────
+  // GONE. A standalone "you are set up, close this window" card, shown right
+  // after the worklog-time question and before the handoff below - which
+  // already says the same thing at the actual moment it becomes true (the
+  // example day is about to disappear and hand back to the user's own,
+  // empty one). A second "you're done" card one beat earlier than the real
+  // one reads as the tour finishing twice.
 
   // ── 12. (was: the off switch, on a drawn tray) ──────────────────────────
   // GONE. Three beats used to drive a REPLICA of the tray popover - click the


### PR DESCRIPTION
## Summary
- `waitForTickets` (`ui/components/tutorial/script.ts`) now checks the board once, with no wait, before narrating "Pulling your tickets in - the first sync takes a moment." Previously it said this line unconditionally, even after the Settings hand-back had already held the screen open until the board was full - so it ran on top of a plan the user had just been handed back, contradicting what they were looking at. It's now reserved for the genuine backstop case where the board is still empty.
- Removed the spotlight ring the "Draft with AI" beat put on the (still-empty) title field the instant the button was clicked - before the AI draft had actually landed. The step already correctly waited on the title/description fields settling before advancing to the next beat; only the visible ring was jumping ahead.
- Removed the standalone "You are set up. Close this window - Meridian keeps going, and tells you when something is ready." closing card in the example-day walkthrough (`scriptDay.ts`) - it repeated the same message as the real handoff/finish beat one step later, making the tour appear to finish twice.

## Test plan
- [ ] Run the onboarding walkthrough end-to-end against a real tracker connect and confirm no "Pulling your tickets in" flash appears once the board already shows tickets
- [ ] Confirm the backstop message still appears and works if the board is genuinely still empty when that beat runs
- [ ] Click "Draft with AI" in the tutorial and confirm no ring lands on the title field before the draft text appears
- [ ] Run the full example-day tutorial to confirm only one closing/finish card is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)