### PR TITLE
docs(summary): point the standup comments at migration 080, not 078

### DIFF
--- a/meridian-core/src/readers/day_summaries.rs
+++ b/meridian-core/src/readers/day_summaries.rs
@@ -230,7 +230,7 @@ struct RawSummaryRow {
     plan_json: String,
     adherence_json: String,
     themes_json: String,
-    /// `Option` purely as belt-and-braces, like `evidence_at` above. Migration 078
+    /// `Option` purely as belt-and-braces, like `evidence_at` above. Migration 080
     /// declares this `NOT NULL DEFAULT '[]'`, so a migrated DB never yields NULL and
     /// an UN-migrated one fails the whole SELECT on the unknown column (which
     /// [`get_day_summary`] already degrades to `None`). It costs nothing and means a
@@ -396,7 +396,7 @@ mod tests {
     use super::*;
     use sqlx::sqlite::SqlitePoolOptions;
 
-    /// The post-078 table, as the migrations leave it.
+    /// The post-080 table, as the migrations leave it.
     async fn pool_with_summaries() -> SqlitePool {
         let pool = SqlitePoolOptions::new()
             .max_connections(1)
@@ -501,7 +501,7 @@ mod tests {
         assert!(!got.fallback);
     }
 
-    /// Migration 078 backfills every existing row with `'[]'`, which is exactly what
+    /// Migration 080 backfills every existing row with `'[]'`, which is exactly what
     /// a pre-080 summary should read back as: no standup, so the block does not
     /// render. The same path covers a column whose JSON has rotted - one field
     /// degrades, never the row, matching this module's stated tolerance.

--- a/ui/components/summary/DaySummaryOverlay.tsx
+++ b/ui/components/summary/DaySummaryOverlay.tsx
@@ -464,7 +464,7 @@ export function DaySummaryOverlay({ day, isToday, onShiftDay, onClose, onOpenSet
                 happened, and what you will say about it tomorrow - and reading one
                 straight after the other is what makes the second believable.
                 The standup renders nothing when the model gave no lines (the
-                fallback path, or a pre-078 row), so the grid collapses to the list
+                fallback path, or a pre-080 row), so the grid collapses to the list
                 alone rather than leaving an empty captioned box beside it. */}
             <div
               className="grid gap-3 mt-6"

--- a/ui/components/summary/Standup.tsx
+++ b/ui/components/summary/Standup.tsx
@@ -17,7 +17,7 @@
 //
 // It renders NOTHING when there are no lines, which covers the fallback path (the
 // LLM call failed, so the deterministic half of the screen is all that is true) and
-// every summary composed before migration 078. An empty bordered box captioned
+// every summary composed before migration 080. An empty bordered box captioned
 // "standup" would be a promise the screen could not keep.
 //
 // # Who calls this

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -880,7 +880,7 @@ export interface DaySummary {
    *  bullet, so the Copy button joins them with newlines rather than the screen
    *  guessing where the model meant to break a paragraph.
    *
-   *  Empty on the fallback path and on rows written before migration 078; the block
+   *  Empty on the fallback path and on rows written before migration 080; the block
    *  simply does not render. */
   standup: string[]
   /** One verdict per planned ticket; empty when the day had no plan. */


### PR DESCRIPTION
Resolves the "stale migration references" finding from the review on #728. Comment-only, no behaviour change.

## The problem

Six doc comments describing the `standup_json` column cite **migration 078**. There is no 078 - the number is skipped in this repo (noted in #728's description), and the column is added by `080_day_summary_standup.sql`.

Both spellings already sat side by side in one file, which is what gives the renumber away:

| `meridian-core/src/readers/day_summaries.rs` | says |
|---|---|
| :184 | "before migration **080**" ✅ |
| :233 | "Migration **078**" ❌ |
| :399 | "The post-**078** table" ❌ |
| :504 | "Migration **078** backfills" ❌ |
| :505 | "a pre-**080** summary" ✅ |

## Wider than the review found

The review flagged the three Rust sites. Grepping the whole tree for the same string turned up three more in TypeScript that a Rust-only read would not reach:

- `ui/components/summary/DaySummaryOverlay.tsx:467` - "a pre-078 row"
- `ui/components/summary/Standup.tsx:20` - "before migration 078"
- `ui/lib/api-types.ts:883` - "rows written before migration 078"

All six corrected. The only remaining `078` matches in the tree are SVG path coordinates and CHANGELOG commit hashes.

## Why bother with comments

A reader who greps `migration 078` to find out what fills this column finds **nothing** - the comment actively sends them somewhere that does not exist, which is worse than no comment. This repo has been bitten by stale migration numbering twice before, once badly enough to crash-loop databases created before the renumber.

## Verification

- `bun test`: **730 pass / 0 fail**
- Full pre-push suite green - `cargo fmt`, `cargo clippy --workspace`, `cargo test --workspace`, ui build, ui tests, security audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbX4WUhDMekZpBnP5aS7dD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration references across day summary and standup documentation.
  * Clarified fallback behavior for records created before migration 080.
  * No runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->