### PR TITLE
fix(tutorial): handle a drafted task title landing under MIN_TITLE_WORDS

### DIFF
--- a/ui/components/tutorial/engine.ts
+++ b/ui/components/tutorial/engine.ts
@@ -74,6 +74,30 @@ export interface Stage {
    *  reacting to. Same fallback contract as `waitForClick`: resolves `false`
    *  rather than stranding anyone. */
   waitForValue(selector: string, opts?: { fallbackMs?: number; settled?: boolean }): Promise<boolean>
+  /** Synchronous read of the input/textarea at `selector`'s current value, or
+   *  `''` if it is not on screen.
+   *
+   *  A one-off peek for a beat that needs to BRANCH on what a field already
+   *  holds rather than wait on it — e.g. checking whether a drafted title
+   *  already clears a length floor before deciding whether to say anything
+   *  about it. Not a substitute for `waitForValue`: this never waits. */
+  value(selector: string): string
+  /** Hand control to the user and resolve once the input/textarea at
+   *  `selector` holds at least `minWords` whitespace-separated words —
+   *  checked on arrival, then on every change, until it clears the floor or
+   *  `fallbackMs` elapses. Resolves `false` on timeout, same contract as
+   *  `waitForClick`/`waitForValue`.
+   *
+   *  `waitForValue`'s `settled` only asks "is there SOMETHING here" — the
+   *  composer's `canCreate` asks "is there ENOUGH here" (`MIN_TITLE_WORDS`),
+   *  and the two can disagree: a drafted title is non-empty the moment it
+   *  lands, but the model is not guaranteed to hit the word floor its own
+   *  prompt asks for. Pointing at "Add to today" over a title that is short
+   *  rings a button a click can never satisfy. This waits on the actual gate
+   *  instead — polling rather than an input-event listener for the same
+   *  reason `waitForValue` does: a programmatic edit (the model still
+   *  revising) does not reliably fire the same event a keystroke does. */
+  waitForMinWords(selector: string, minWords: number, opts?: { fallbackMs?: number }): Promise<boolean>
   /** Resolve true if `selector` shows up within `timeoutMs`, false if it never
    *  does.
    *

--- a/ui/components/tutorial/script.ts
+++ b/ui/components/tutorial/script.ts
@@ -36,6 +36,7 @@
 // - `./scriptDay.ts` — part two, which this hands off to at the seam
 
 import { availableTrackerNames } from '@/lib/integrations'
+import { MIN_TITLE_WORDS, titleWords } from '@/components/plan/useTaskComposer'
 import { consumeLockOutcome, type Stage } from './engine'
 import { runDayHalf } from './scriptDay'
 
@@ -554,35 +555,62 @@ export async function runScript(s: Stage): Promise<void> {
       await s.pause(500)
       s.spotlight(null)
 
-      // 2d. WHERE IT GOES - the one decision on this form with a consequence
-      // outside Meridian, and the only one the tour stops for.
-      //
-      // Renders only with a tracker connected (TaskComposer's `boardProvider`), so
-      // it is probed rather than assumed - a solo user has no choice to make and
-      // gets no beat. Left undiscovered, this is how someone files a real ticket
-      // onto a shared board by accident, or writes three days of personal notes
-      // wondering why their team never sees them. Both are cheap to prevent here
-      // and expensive to explain afterwards.
-      //
-      // No spotlight on either option and no recommendation: which one is right
-      // depends entirely on what they just wrote, and the tour has no view on it.
-      if (await s.appeared('[data-tour="task-where"]', 1200)) {
-        s.say('One choice: keep it to yourself, or file it as a real ticket your team can see. Pick either - you can change it per task.')
-        s.spotlight('[data-tour="task-where"]')
-        await s.point('[data-tour="task-where"]')
-        await s.waitForClick('[data-tour="task-where"] [role="radio"]', 120000)
+      // 2c-2. EDGE CASE: a drafted title can still land short. `canCreate` in
+      // useTaskComposer.ts requires MIN_TITLE_WORDS regardless of whether the
+      // title got there by hand or by the model, and the model - however well
+      // its prompt is worded - is not guaranteed to hit that floor on a terse
+      // note ("Testing onboarding" drafted down to the two-word "Test
+      // onboarding" is what surfaced this). The beat below used to skip
+      // straight to "That is the task. Add it to today." and point at a
+      // button that stays disabled for the rest of its 90s fallback, then
+      // said "Saved." regardless of whether anything was. Checked explicitly
+      // instead: name what's missing, and wait on the real gate rather than
+      // assume the draft cleared it.
+      let titleReady = titleWords(s.value('[data-tour="task-title"]')) >= MIN_TITLE_WORDS
+      if (!titleReady) {
+        s.spotlight('[data-tour="task-title"]')
+        s.say("This title's a little thin - add a few more words about the work before you can save it.")
+        await s.point('[data-tour="task-title"]')
+        titleReady = await s.waitForMinWords('[data-tour="task-title"]', MIN_TITLE_WORDS, { fallbackMs: 120000 })
         s.spotlight(null)
-        await s.pause(600)
       }
 
-      // 2e. Commit it.
-      s.say('That is the task. Add it to today.')
-      s.spotlight('[data-tour="task-add"]')
-      await s.point('[data-tour="task-add"]')
-      await s.waitForClick('[data-tour="task-add"]', 90000)
-      s.spotlight(null)
-      await s.pause(700)
-      s.say('Saved. Add as many as you like - each one saves itself - then close this when you are done.')
+      if (titleReady) {
+        // 2d. WHERE IT GOES - the one decision on this form with a consequence
+        // outside Meridian, and the only one the tour stops for.
+        //
+        // Renders only with a tracker connected (TaskComposer's `boardProvider`), so
+        // it is probed rather than assumed - a solo user has no choice to make and
+        // gets no beat. Left undiscovered, this is how someone files a real ticket
+        // onto a shared board by accident, or writes three days of personal notes
+        // wondering why their team never sees them. Both are cheap to prevent here
+        // and expensive to explain afterwards.
+        //
+        // No spotlight on either option and no recommendation: which one is right
+        // depends entirely on what they just wrote, and the tour has no view on it.
+        if (await s.appeared('[data-tour="task-where"]', 1200)) {
+          s.say('One choice: keep it to yourself, or file it as a real ticket your team can see. Pick either - you can change it per task.')
+          s.spotlight('[data-tour="task-where"]')
+          await s.point('[data-tour="task-where"]')
+          await s.waitForClick('[data-tour="task-where"] [role="radio"]', 120000)
+          s.spotlight(null)
+          await s.pause(600)
+        }
+
+        // 2e. Commit it.
+        s.say('That is the task. Add it to today.')
+        s.spotlight('[data-tour="task-add"]')
+        await s.point('[data-tour="task-add"]')
+        await s.waitForClick('[data-tour="task-add"]', 90000)
+        s.spotlight(null)
+        await s.pause(700)
+        s.say('Saved. Add as many as you like - each one saves itself - then close this when you are done.')
+      } else {
+        // They never lengthened it. Same honesty as the "never typed" branch
+        // below: say what's true and let them close it, rather than claim a
+        // save that never happened.
+        s.say('No rush - finish it whenever you like. Close this when you are ready.')
+      }
     } else {
       // They never typed. Say what the form was for and let them close it;
       // pressing on with "now click Draft" would point at a disabled button.

--- a/ui/components/tutorial/useTutorial.tsx
+++ b/ui/components/tutorial/useTutorial.tsx
@@ -399,6 +399,41 @@ export function useTutorial(opts: {
         if (sig.aborted) throw new Aborted()
         return got
       },
+      value: (sel) => (tourTarget(sel) as HTMLInputElement | HTMLTextAreaElement | null)?.value ?? '',
+      waitForMinWords: async (sel, minWords, o) => {
+        const sig = signal()
+        const el = await waitForElement(sel, sig)
+        if (!el) return false
+        const words = (v: string) => v.trim().split(/\s+/).filter(Boolean).length
+        setAwaiting(true)
+        const got = await new Promise<boolean>((resolve) => {
+          let done = false
+          const settle = (v: boolean) => {
+            if (done) return
+            done = true
+            sig.removeEventListener('abort', onAbort)
+            clearTimeout(timer)
+            cancelAnimationFrame(raf)
+            resolve(v)
+          }
+          function onAbort() { settle(false) }
+          const timer = setTimeout(() => settle(false), o?.fallbackMs ?? 90000)
+          // Same target-vanished handling as waitForValue/waitForClick: the
+          // composer closing out from under this wait is the step ending, not
+          // a miss, so it counts as done rather than burning the fallback.
+          let raf = requestAnimationFrame(function tick() {
+            const node = tourTarget(sel) as HTMLInputElement | HTMLTextAreaElement | null
+            if (!node) { settle(true); return }
+            if (words(node.value) >= minWords) { settle(true); return }
+            raf = requestAnimationFrame(tick)
+          })
+          sig.addEventListener('abort', onAbort, { once: true })
+        })
+        setAwaiting(false)
+        parkCursor()
+        if (sig.aborted) throw new Aborted()
+        return got
+      },
       appeared: async (sel, timeoutMs = 3000) => !!(await waitForElement(sel, signal(), timeoutMs)),
       demoDrag: async (from, to) => {
         const sig = signal()


### PR DESCRIPTION
## The edge case

Screenshot: the first-run walkthrough's task-drafting beat, stuck. The tooltip says "That is the task. Add it to today." pointing at the Add button, while the composer shows a validation line underneath saying more words are needed — the button is disabled and can't be clicked.

## Root cause

The beat waits for the title and description fields to fill (`waitForValue(..., { settled: true })`) and then unconditionally proceeds to point at "Add to today" — on the assumption that a drafted title satisfies `canCreate`'s `MIN_TITLE_WORDS` floor (4 words) just because it's non-empty. It doesn't always: the note in the screenshot was "Testing onboarding", and the model drafted it down to the two-word title "Test onboarding" — non-empty, so `waitForValue` is satisfied, but still short of 4 words, so the button stays disabled.

`useTaskComposer.ts`'s own doc comment on `MIN_TITLE_WORDS` says the same floor is written into the draft prompt "so the AI and the manual path agree" — but a model can't be guaranteed to follow that on every input, and the walkthrough had no fallback for when it doesn't. The `waitForClick` on the Add button then burns its full 90s fallback (a disabled button never fires a click), after which the script moves on and says "Saved." regardless of whether anything was.

## Fix

Two small additions to the tour engine (`engine.ts` + `useTutorial.tsx`), following the same pattern as the existing `waitForValue`/`waitForClick`:

- `value(selector)` — synchronous read of a field's current content, for a beat that needs to check state rather than wait on it.
- `waitForMinWords(selector, minWords, opts)` — the word-count analogue of `waitForValue`'s `settled`: polls until the field clears the floor or the fallback elapses. Same resolve-false-on-timeout contract as its siblings.

`script.ts`: after both fields settle, check the title. If it already clears `MIN_TITLE_WORDS`, nothing changes. If not, name what's missing ("This title's a little thin - add a few more words about the work before you can save it."), point at the title, and wait on the real gate. If it clears the floor, the walkthrough proceeds exactly as before (the "where it goes" step, then "Add to today"). If the user never lengthens it, the walkthrough says so honestly ("No rush - finish it whenever you like.") instead of a false "Saved.", and falls through to the existing close-button beat unchanged.

## Verification

- `bun test`: 730 pass, 0 fail (including `tutorial-sample-day.test.ts`'s source-scanning assertions on this exact region — the `task-where` → `task-add` selector ordering it checks is preserved).
- `tsc --noEmit`: clean.
- Full pre-push suite (fmt, clippy, ui build, ui tests, cargo test, security audit) passed on push.

No Rust changes in this PR — TypeScript only, all inside `ui/components/tutorial/`.

Not merging this myself — leaving that to a human reviewer.