### PR TITLE
fix(providers): retry a truncated GitHub response instead of blaming the token

### DIFF
--- a/src/intelligence/providers/github/fetch.rs
+++ b/src/intelligence/providers/github/fetch.rs
@@ -165,21 +165,14 @@ pub(super) async fn fetch_viewer_login(github: &GitHubConfig) -> Result<String> 
         .send()
         .await
         .context("POST /graphql viewer")?;
-    // Check the status BEFORE parsing. A 500 or a 429 has no `data` field, so
-    // it used to fall through to the parse and surface as "GraphQL viewer
-    // response missing data" — a GitHub outage reported to the user as a
-    // credentials problem. The typed error carries the status so
+    // `read_success_body` checks the status BEFORE we parse. A 500 or a 429 has
+    // no `data` field, so it used to fall through to the parse and surface as
+    // "GraphQL viewer response missing data" — a GitHub outage reported to the
+    // user as a credentials problem. The typed error carries the status so
     // `http::is_transient` can tell an outage from a dead token.
-    let status = resp.status();
-    let text = resp.text().await.unwrap_or_default();
-    if !status.is_success() {
-        return Err(crate::intelligence::providers::http::HttpStatusError::new(
-            status.as_u16(),
-            "GitHub GraphQL viewer",
-            &text,
-        )
-        .into());
-    }
+    let text =
+        crate::intelligence::providers::http::read_success_body(resp, "GitHub GraphQL viewer")
+            .await?;
     let parsed: GqlResponse<ViewerData> =
         serde_json::from_str(&text).context("deserialising viewer response")?;
     parsed
@@ -247,16 +240,8 @@ pub(super) async fn fetch_project_items(
             .await
             .context("POST /graphql project items")?;
 
-        let status = resp.status();
-        let text = resp.text().await.unwrap_or_default();
-        if !status.is_success() {
-            return Err(crate::intelligence::providers::http::HttpStatusError::new(
-                status.as_u16(),
-                "GitHub GraphQL",
-                &text,
-            )
-            .into());
-        }
+        let text =
+            crate::intelligence::providers::http::read_success_body(resp, "GitHub GraphQL").await?;
 
         // Parse once as a Value so each raw item node survives verbatim for
         // the canonical adapter (CDM Stage 3b), then deserialise the typed

--- a/src/intelligence/providers/http/classify.rs
+++ b/src/intelligence/providers/http/classify.rs
@@ -73,6 +73,75 @@ impl std::fmt::Display for HttpStatusError {
 
 impl std::error::Error for HttpStatusError {}
 
+/// A provider answered 2xx, but the body never arrived intact.
+///
+/// A typed error for the same reason [`HttpStatusError`] is one: the fact that
+/// decides transient vs terminal — "the transfer was cut short" — is not
+/// recoverable from the `serde_json` error it would otherwise become. An empty
+/// body parses as `EOF while parsing a value at line 1 column 0`, whose chain
+/// carries neither a status nor a `reqwest::Error`, so [`is_transient`] fell
+/// through to its `false` default and the user was told to reconnect a
+/// credential that was fine.
+///
+/// This is NOT a relaxation of the "a response we could not parse is a contract
+/// mismatch" stance in [`reqwest_is_transient`]. That stance is about a body we
+/// received and could not understand. This is about a body we never received.
+#[derive(Debug)]
+pub struct TruncatedBodyError {
+    /// Human label for the endpoint, e.g. `"GitHub GraphQL"`.
+    endpoint: String,
+    /// The success status the response carried before its body was cut off.
+    status: u16,
+    /// The transport failure, when the read itself errored. `None` when the
+    /// read succeeded and simply returned nothing.
+    source: Option<reqwest::Error>,
+}
+
+impl TruncatedBodyError {
+    /// A 2xx whose body read returned successfully but was empty.
+    pub fn empty(status: u16, endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            status,
+            source: None,
+        }
+    }
+
+    /// A 2xx whose body read failed part-way — a reset connection, an HTTP/2
+    /// GOAWAY, a gzip stream that stopped short, or the request deadline
+    /// firing during the body.
+    pub fn unreadable(status: u16, endpoint: impl Into<String>, source: reqwest::Error) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            status,
+            source: Some(source),
+        }
+    }
+}
+
+impl std::fmt::Display for TruncatedBodyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.source {
+            Some(e) => write!(
+                f,
+                "{} returned {} but its body could not be read: {e}",
+                self.endpoint, self.status
+            ),
+            None => write!(
+                f,
+                "{} returned {} with an empty body",
+                self.endpoint, self.status
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TruncatedBodyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.as_ref().map(|e| e as &dyn std::error::Error)
+    }
+}
+
 /// What a provider sync should DO about a failure.
 ///
 /// Both variants carry `detail` already formatted with `{err:#}` — the full
@@ -141,6 +210,14 @@ pub fn is_transient(err: &anyhow::Error) -> bool {
     for cause in err.chain() {
         if let Some(status) = cause.downcast_ref::<HttpStatusError>() {
             return status.is_transient();
+        }
+        // BEFORE the `reqwest::Error` arm, and deliberately so: a body read cut
+        // short surfaces as `Kind::Decode`, which `reqwest_is_transient` answers
+        // `false` for. That answer is right for its own question (a body we
+        // parsed and did not understand) and wrong for this one (a body that
+        // never finished arriving), so this arm has to win.
+        if cause.downcast_ref::<TruncatedBodyError>().is_some() {
+            return true;
         }
         if let Some(e) = cause.downcast_ref::<reqwest::Error>() {
             return reqwest_is_transient(e);

--- a/src/intelligence/providers/http/mod.rs
+++ b/src/intelligence/providers/http/mod.rs
@@ -63,7 +63,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 mod classify;
-pub use classify::{chain, classify, is_transient, HttpStatusError, SyncFault};
+pub use classify::{chain, classify, is_transient, HttpStatusError, SyncFault, TruncatedBodyError};
 
 /// Total deadline for one provider request, from connect to body complete.
 ///
@@ -130,6 +130,58 @@ fn build_client(request_timeout: Duration, connect_timeout: Duration) -> reqwest
         })
 }
 
+/// Read a provider response body, rejecting a non-success status first and an
+/// incomplete transfer second.
+///
+/// Every provider fetch path repeats this dance — capture the status, read the
+/// body, turn a non-2xx into a typed [`HttpStatusError`] — and each hand-rolled
+/// copy is a place the classification can silently regress. `endpoint` is the
+/// human label both typed errors carry.
+///
+/// # Why the body read is not `unwrap_or_default()`
+/// That is what every call site did, and it is a silent evidence-destroying
+/// step: a reset connection, an HTTP/2 GOAWAY, or the request deadline firing
+/// mid-body all produce a `reqwest::Error` that was replaced with `""`, which
+/// then reached `serde_json` and failed as "EOF while parsing a value at line 1
+/// column 0". By then nothing in the chain identified the failure as a network
+/// one, so [`classify`] reported it terminally and the user was told to
+/// reconnect a working GitHub token. The error is preserved as a
+/// [`TruncatedBodyError`] instead — and an empty body on a 2xx gets the same
+/// treatment, because a provider that returns no bytes at all has not answered.
+///
+/// **On a non-2xx the body read is still best-effort.** The status is what
+/// classifies there, and a status error with an unread body is strictly better
+/// than losing the status to a body-read failure.
+///
+/// # Only for endpoints that MUST return a body
+/// The empty check treats no bytes as a failure, so this is wrong for anything
+/// that can legitimately answer `204 No Content` — which several of the
+/// `ticket_update` write paths can. Those need a variant that tolerates an
+/// empty success; adopt this one only on reads that always expect a payload.
+///
+/// # Who calls this
+/// [`crate::intelligence::providers::github::fetch`]'s viewer and project-item
+/// walks. The other provider fetch paths still inline the same steps, complete
+/// with `unwrap_or_default()`, and should adopt this.
+pub async fn read_success_body(resp: reqwest::Response, endpoint: &str) -> anyhow::Result<String> {
+    let status = resp.status();
+    let code = status.as_u16();
+
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(HttpStatusError::new(code, endpoint, &body).into());
+    }
+
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| TruncatedBodyError::unreadable(code, endpoint, e))?;
+    if text.is_empty() {
+        return Err(TruncatedBodyError::empty(code, endpoint).into());
+    }
+    Ok(text)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -165,6 +217,98 @@ mod tests {
             is_transient(&err),
             "a timeout must be retried, not reported"
         );
+    }
+
+    /// Serve one canned HTTP/1.1 response on loopback and return its URL.
+    ///
+    /// Deliberately raw bytes rather than a server crate: the cases under test
+    /// are malformed-at-the-wire (a body that stops short of its declared
+    /// `Content-Length`), which a well-behaved server will not produce.
+    async fn serve_once(raw: &'static [u8]) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                use tokio::io::AsyncWriteExt;
+                let _ = stream.write_all(raw).await;
+                let _ = stream.flush().await;
+                // Close immediately — for the truncated case this is what makes
+                // the body read fail rather than hang until the timeout.
+            }
+        });
+        format!("http://{addr}/")
+    }
+
+    /// THE regression. GitHub answered 200 with nothing in it, and the sync
+    /// raised a terminal "Reconnect GitHub in Settings - Integrations" banner
+    /// for a credential that was never broken.
+    ///
+    /// The empty body reached `serde_json::from_str`, which failed with "EOF
+    /// while parsing a value at line 1 column 0" — an error chain carrying
+    /// neither a status nor a transport error, so [`is_transient`] fell through
+    /// to its `false` default and [`classify`] reported it. An empty 2xx is a
+    /// truncated transfer; it must retry.
+    #[tokio::test]
+    async fn an_empty_body_on_success_is_transient() {
+        let url = serve_once(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n").await;
+        let resp = client().get(&url).send().await.expect("request");
+        let err = read_success_body(resp, "GitHub GraphQL")
+            .await
+            .expect_err("an empty 200 body must not be handed back as success");
+        assert!(
+            is_transient(&err),
+            "an empty 200 must retry, not raise a credentials banner: {err:#}"
+        );
+    }
+
+    /// The other half, and the one a plain `?` does not fix: the connection
+    /// dies part-way through the body. `reqwest` reports that as `Kind::Decode`,
+    /// which `classify::reqwest_is_transient` excludes ON PURPOSE — a
+    /// body we cannot PARSE is a contract mismatch worth surfacing. A body we
+    /// could not READ is not; it is the same truncated transfer as above.
+    #[tokio::test]
+    async fn a_truncated_body_on_success_is_transient() {
+        let url = serve_once(b"HTTP/1.1 200 OK\r\nContent-Length: 4096\r\n\r\n{\"data\":").await;
+        let resp = client().get(&url).send().await.expect("request");
+        let err = read_success_body(resp, "GitHub GraphQL")
+            .await
+            .expect_err("a body that stops short of Content-Length must fail");
+        assert!(
+            is_transient(&err),
+            "a truncated body read must retry: {err:#}"
+        );
+    }
+
+    /// The status path must be untouched by the above: a dead credential still
+    /// has to reach the user, and its body still has to reach the banner.
+    #[tokio::test]
+    async fn a_non_success_status_still_reports_with_its_body() {
+        let url =
+            serve_once(b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 15\r\n\r\nBad credentials")
+                .await;
+        let resp = client().get(&url).send().await.expect("request");
+        let err = read_success_body(resp, "GitHub GraphQL viewer")
+            .await
+            .expect_err("a 401 must not be handed back as success");
+        assert!(!is_transient(&err), "a 401 must stay terminal: {err:#}");
+        let detail = chain(&err);
+        assert!(detail.contains("401"), "status lost: {detail}");
+        assert!(detail.contains("Bad credentials"), "body lost: {detail}");
+    }
+
+    /// An ordinary 200 is still just its body — the empty/truncated guards must
+    /// not start rejecting healthy responses.
+    #[tokio::test]
+    async fn a_normal_success_body_is_returned_verbatim() {
+        let url =
+            serve_once(b"HTTP/1.1 200 OK\r\nContent-Length: 16\r\n\r\n{\"data\":{\"x\":1}}").await;
+        let resp = client().get(&url).send().await.expect("request");
+        let body = read_success_body(resp, "GitHub GraphQL")
+            .await
+            .expect("a healthy 200 must be returned");
+        assert_eq!(body, "{\"data\":{\"x\":1}}");
     }
 
     /// The timeouts must stay bounded and ordered. A zero value disables the

--- a/src/intelligence/providers/http/mod.rs
+++ b/src/intelligence/providers/http/mod.rs
@@ -224,6 +224,17 @@ mod tests {
     /// Deliberately raw bytes rather than a server crate: the cases under test
     /// are malformed-at-the-wire (a body that stops short of its declared
     /// `Content-Length`), which a well-behaved server will not produce.
+    ///
+    /// # The request MUST be drained before answering
+    /// Closing a socket that still has unread bytes in its receive buffer is an
+    /// ABORTIVE close on Windows — the peer gets an RST and the client fails
+    /// with `WSAECONNABORTED (10053)` at `.send()`, before it can read a single
+    /// byte of the canned response. POSIX is more forgiving and delivers the
+    /// buffered response first, so an undrained fixture passes on macOS/Linux
+    /// and fails only on the Windows runner. Reading the request first, then
+    /// shutting down gracefully, is what makes the close a FIN on every
+    /// platform — and a FIN is precisely what the truncated case needs, since
+    /// an RST would fail the whole request instead of cutting the body short.
     async fn serve_once(raw: &'static [u8]) -> String {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
@@ -231,11 +242,20 @@ mod tests {
         let addr = listener.local_addr().expect("local addr");
         tokio::spawn(async move {
             if let Ok((mut stream, _)) = listener.accept().await {
-                use tokio::io::AsyncWriteExt;
+                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                // Drain the request. These are single small GETs, so stop at the
+                // end of the headers rather than waiting for a close the client
+                // has no reason to send.
+                let mut buf = [0u8; 4096];
+                while let Ok(n) = stream.read(&mut buf).await {
+                    if n == 0 || buf[..n].windows(4).any(|w| w == b"\r\n\r\n") {
+                        break;
+                    }
+                }
                 let _ = stream.write_all(raw).await;
                 let _ = stream.flush().await;
-                // Close immediately — for the truncated case this is what makes
-                // the body read fail rather than hang until the timeout.
+                // Graceful FIN rather than a drop — see the note above.
+                let _ = stream.shutdown().await;
             }
         });
         format!("http://{addr}/")


### PR DESCRIPTION
## The report

A GitHub sync raised a red banner and then cleared itself a few minutes later:

> **GitHub sync failing** — deserialising project items: EOF while parsing a value at line 1 column 0
> Fix: Reconnect GitHub in Settings - Integrations

The token was fine. The remedy was unfollowable.

## Diagnosis

The error text locates the failure exactly, without needing the logs:

- a `.send()` failure would render `POST /graphql project items: …` (`fetch.rs`)
- a non-2xx would render `GitHub GraphQL returned NNN: …` (`HttpStatusError`'s `Display`)

Neither prefix is present, so the response **passed `status.is_success()`** and then had an empty body by the time `serde_json` saw it. `EOF while parsing a value at line 1 column 0` is serde's error for an empty string.

Both GitHub fetch paths read the body as:

```rust
let text = resp.text().await.unwrap_or_default();
```

That silently destroys evidence. A reset connection, an HTTP/2 GOAWAY, a gzip stream that stopped short, or the 60 s request deadline firing mid-body all produce a `reqwest::Error` that gets replaced with `""`. The chain that reached `http::is_transient` then carried neither an `HttpStatusError` nor a `reqwest::Error`, so it hit the documented `false` default and `classify` reported it terminally — a network blip rendered as a credentials problem, which is the exact bug `providers/http` was created to kill.

It cleared on its own because GitHub syncs every 5 minutes and a completed pass ends with `clear_sync_error`. That self-healing is itself the proof it should never have been terminal.

## Why `?` alone is not the fix

reqwest 0.12's `text()` surfaces a short read as `Kind::Decode`, and `reqwest_is_transient` excludes `is_decode()`/`is_body()` **on purpose** — a body we received and could not parse is a contract mismatch worth surfacing. Just propagating the error would still raise the same wrong banner for a reset mid-body.

So this adds a separate condition instead of relaxing that stance. A body we never finished receiving is not a contract mismatch:

- **`TruncatedBodyError`** (`classify.rs`) carries the success status and, when the read itself failed, the transport error as its `source`. `is_transient` matches it **before** the `reqwest::Error` arm, which would otherwise answer `false` for the same decode error.
- **`http::read_success_body`** replaces the hand-rolled status-check + body-read in both GitHub fetch paths, preserving the read error and treating an empty 2xx body the same way. The non-2xx path keeps its best-effort body read, because the status is what classifies there.

Failures now route to `note_transient_sync_failure` — quiet through a blip, still escalating if GitHub has not synced successfully in 6 hours.

## Tests

Written first, and red for the right reasons — both the empty and the truncated 200 were being handed back as `Ok("")`:

| Test | Guards |
|---|---|
| `an_empty_body_on_success_is_transient` | the reported bug: an empty 200 must retry, not raise a banner |
| `a_truncated_body_on_success_is_transient` | the case `?` alone misses — a body that stops short of `Content-Length` |
| `a_non_success_status_still_reports_with_its_body` | a 401 stays terminal and keeps its status + body in the banner |
| `a_normal_success_body_is_returned_verbatim` | the new guards do not start rejecting healthy responses |

Fixtures are raw bytes on loopback — the cases are malformed-at-the-wire, which a well-behaved server will not produce. No network.

`cargo fmt` + `cargo clippy --workspace --all-targets -D warnings` + `cargo test --workspace` all pass.

## Scope left out, deliberately

The viewer fetch had the identical bug and is fixed here. The other **~35** `resp.text().await.unwrap_or_default()` sites across the provider and ticket-update paths carry the same hazard and are **not** touched — that is a follow-up, and the helper's docs note it is only correct for endpoints that must return a body, since several ticket-update writes can legitimately answer `204`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)