### PR TITLE
fix(onboarding): stop What's New firing at the end of first-run setup

### DIFF
--- a/tray/src-tauri/src/commands/setup.rs
+++ b/tray/src-tauri/src/commands/setup.rs
@@ -85,27 +85,53 @@ const WALKTHROUGH_MARKER: &str = "walkthrough_armed";
 /// Write `~/.meridian/onboarded` (RFC-3339 timestamp) to mark wizard completion,
 /// and arm the dashboard walkthrough that follows it.
 /// Future tray launches skip the auto-open. Idempotent — safe to call more than once.
+///
+/// Also stamps `~/.meridian/last_seen_version` with the running version, so the
+/// "What's New" modal starts with the *next* release instead of announcing the
+/// one the user just installed (see [`write_completion_markers`]). Note this
+/// applies to Settings → Account → Re-run Setup too: re-running the wizard
+/// marks the current release's notes as seen, which is the intended reading —
+/// they have just been walked through the product on that version.
 #[tauri::command]
-#[tracing::instrument]
-pub async fn mark_setup_complete() -> Result<(), String> {
-    let dir = meridian_core::paths::meridian_dir()
+#[tracing::instrument(skip(app))]
+pub async fn mark_setup_complete(app: tauri::AppHandle) -> Result<(), String> {
+    let home = meridian_core::paths::home_dir()
         .ok_or_else(|| "could not resolve home directory".to_string())?;
-    tokio::fs::create_dir_all(&dir)
-        .await
-        .map_err(|e| format!("create ~/.meridian: {e}"))?;
-    tokio::fs::write(dir.join("onboarded"), chrono::Local::now().to_rfc3339())
-        .await
-        .map_err(|e| format!("write onboarded: {e}"))?;
+    // Read the version off the AppHandle rather than `env!("CARGO_PKG_VERSION")`
+    // so it is byte-identical to what `poll::whats_new_auto_open` compares the
+    // marker against — the two are only equal by construction, and a marker
+    // written in a format the reader never matches would silently do nothing.
+    let version = app.package_info().version.to_string();
+    write_completion_markers(&home, &version).map_err(|e| format!("write setup markers: {e}"))?;
+    tracing::info!(version = %version, "setup: onboarded flag written, walkthrough armed");
+    Ok(())
+}
+
+/// The filesystem half of [`mark_setup_complete`], split out so it is reachable
+/// from a test without an `AppHandle` (see this module's tests).
+///
+/// `home` is the HOME directory, not `~/.meridian` — matching
+/// [`crate::commands::whats_new`]'s readers, which do their own `.meridian`
+/// join. Sync `std::fs` rather than `tokio::fs`: three small writes, and it
+/// matches the sibling marker helpers in `whats_new`, which are already called
+/// straight from the async poll loop.
+fn write_completion_markers(home: &std::path::Path, version: &str) -> std::io::Result<()> {
+    let dir = home.join(".meridian");
+    std::fs::create_dir_all(&dir)?;
+    let now = chrono::Local::now().to_rfc3339();
+    std::fs::write(dir.join("onboarded"), &now)?;
     // The walkthrough is the second half of onboarding, so finishing the wizard is
     // what earns it. See [`walkthrough_is_armed`] for why it needs its own marker
     // rather than reading `onboarded`.
-    tokio::fs::write(
-        dir.join(WALKTHROUGH_MARKER),
-        chrono::Local::now().to_rfc3339(),
-    )
-    .await
-    .map_err(|e| format!("write {WALKTHROUGH_MARKER}: {e}"))?;
-    tracing::info!("setup: onboarded flag written, walkthrough armed");
+    std::fs::write(dir.join(WALKTHROUGH_MARKER), &now)?;
+    // Stamp the running version as already seen, so "What's New" starts
+    // announcing the NEXT release rather than firing the instant the wizard
+    // closes. `has_unseen_release_notes` reads a missing marker as unseen —
+    // right for an update, wrong for a first run, where the notes describe a
+    // release the user has never not been on. `poll::whats_new_auto_open`'s
+    // `onboarded` gate only defers that to the moment onboarding ends, so the
+    // suppression has to be a written marker, not another gate.
+    crate::commands::whats_new::mark_whats_new_seen(home, version)?;
     Ok(())
 }
 
@@ -559,11 +585,55 @@ pub async fn test_all_llm_providers(
 
 #[cfg(test)]
 mod tests {
-    use super::{log_install_outcome, log_signin_outcome, notification_state_label};
+    use super::{
+        log_install_outcome, log_signin_outcome, notification_state_label,
+        write_completion_markers, WALKTHROUGH_MARKER,
+    };
+    use crate::commands::whats_new::has_unseen_release_notes;
     use meridian::llm::detect::InstallOutcome;
     use std::sync::{Arc, Mutex};
     use tauri_plugin_notifications::PermissionState;
     use tracing_subscriber::{layer::SubscriberExt, registry, Layer};
+
+    // A fresh install has no `last_seen_version`, and `has_unseen_release_notes`
+    // reads a missing marker as "unseen" (`Err(_) => true`) — correct for an
+    // update, wrong for a first run. `poll::whats_new_auto_open`'s only other
+    // guard is the `onboarded` flag, so the modal was suppressed for exactly as
+    // long as the wizard was open and then fired the moment it closed: a brand
+    // new user's first sight of the dashboard was a changelog for a release
+    // they had never run.
+    //
+    // Finishing the wizard is therefore what stamps the running version as
+    // seen. This asserts the whole three-way contract, because getting the
+    // version string right matters as much as writing the file at all.
+    #[test]
+    fn finishing_the_wizard_marks_the_running_version_as_already_seen() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path();
+
+        // Fresh install: nothing seen yet, so the auto-open would fire.
+        assert!(
+            has_unseen_release_notes(home, "1.85.1"),
+            "precondition: a fresh install has no last_seen_version marker"
+        );
+
+        write_completion_markers(home, "1.85.1").expect("write markers");
+
+        // 1. The version they onboarded on is NOT new to them.
+        assert!(
+            !has_unseen_release_notes(home, "1.85.1"),
+            "What's New must not auto-open for the version the user just onboarded on"
+        );
+        // 2. The NEXT release still is — this is the whole point of the modal,
+        //    and a fix that suppressed it forever would pass assertion 1 too.
+        assert!(
+            has_unseen_release_notes(home, "1.86.0"),
+            "the next release must still auto-open"
+        );
+        // 3. The markers this function already owned are untouched.
+        assert!(home.join(".meridian").join("onboarded").exists());
+        assert!(home.join(".meridian").join(WALKTHROUGH_MARKER).exists());
+    }
 
     // The wizard's card branches on these exact strings (grant button action:
     // prompt → request dialog, denied → System Settings pane), so the mapping


### PR DESCRIPTION
Issue 8 of 8 from the onboarding review. Independent of the others - not part of either stack.

## What's broken

A brand new user's first sight of the dashboard is a changelog for a release they have never *not* been on. Reported with a screenshot showing the What's New modal open over the dashboard immediately after finishing the wizard.

## Why

`has_unseen_release_notes` (`commands/whats_new.rs`) reads a missing `~/.meridian/last_seen_version` marker as "unseen":

```rust
Err(_) => true,
```

That is correct for an update - no marker means you have not seen the current notes. It is wrong for a **fresh install**, where the marker is absent because the user has never run any version, not because they missed one.

`poll::whats_new_auto_open` looks like it already covers this - gate 2 is "not onboarded → return". But that gate only **defers**: it suppresses the modal for exactly as long as the wizard is open, then lets it fire the instant onboarding completes. So the suppression has to be a written marker, not another gate.

## Fix

Finishing the wizard stamps the running version as seen, so What's New starts announcing the **next** release.

One deliberate detail: the version is read off the `AppHandle` (`app.package_info().version`) rather than `env!("CARGO_PKG_VERSION")`, so it is byte-identical to what the poll loop compares the marker against. The two agree only by construction, and a marker written in a format the reader never matches would silently do nothing - the same class of bug as the one being fixed.

The filesystem half is split into `write_completion_markers` so it is reachable from a test without an `AppHandle`.

## Scope note

This applies to Settings → Account → **Re-run Setup** as well: re-running the wizard marks the current release's notes as seen. That reads as intended - the user has just been walked through the product on that version - but it is a behaviour change worth knowing about, so it is documented on `mark_setup_complete`.

Existing installs are unaffected: they already have `onboarded`, and this only writes at wizard completion.

## Test plan

- [x] Regression test written **first** and confirmed failing on the right assertion before the fix existed:
      `panicked at setup.rs:609: What's New must not auto-open for the version the user just onboarded on`
- [x] It asserts the three-way contract, not just the symptom - the onboarded version is not new, **the next release still is** (a fix that suppressed the modal forever would pass the first assertion alone), and the two markers this function already owned are untouched.
- [x] `cargo test -p meridian-tray` - 250 pass (249 + this one), 0 fail.
- [x] `cargo clippy -p meridian-tray --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] Full `pre-push` hook (fmt + clippy + UI build + UI tests + `cargo test --workspace` + security audit) passed on push.
- [ ] Not verified on a live fresh install - that needs a wiped `~/.meridian` and a packaged build. The unit test covers the marker contract; what it cannot cover is the poll loop actually reading it, which is one `has_unseen_release_notes` call away and shared with the already-working update path.