### PR TITLE
fix(setup): highlight the permission cards one at a time

### DIFF
--- a/ui/__tests__/setup-permission-sequence.test.ts
+++ b/ui/__tests__/setup-permission-sequence.test.ts
@@ -1,0 +1,78 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// The permissions step marks ONE card as "up next" and advances the ring as
+// each grant lands, instead of presenting three equal cards with three equal
+// Open Settings buttons.
+//
+// Source-scanning rather than behavioural, for the usual reason: the thing
+// under test is which card carries an accent ring, and a headless run has no
+// layout to read it off. What CAN be pinned is the shape of the logic that
+// picks it - which is where every regression here would live.
+//
+// The load-bearing assertion is the last one. The obvious way to build a
+// sequence is to disable the later cards, and that is a trap: macOS routinely
+// does not report a TCC grant until the app restarts, so a lagging probe would
+// leave the user staring at two dead buttons with no way to finish the step.
+// The ring must be decoration over a fully live step, never a gate.
+
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const steps = readFileSync(join(import.meta.dir, '..', 'app', 'setup', 'steps.tsx'), 'utf8')
+
+/** Body of `PermCard`, where the per-card styling decisions live. */
+function permCard(): string {
+  const at = steps.indexOf('function PermCard(')
+  if (at < 0) throw new Error('marker not found: function PermCard(')
+  const end = steps.indexOf('\nfunction ', at + 1)
+  if (end < 0) throw new Error('end of PermCard not found')
+  return steps.slice(at, end)
+}
+
+describe('the permissions step reads as a sequence', () => {
+  it('picks the FIRST card that is neither granted nor hidden', () => {
+    // `.find` (not `.filter`/`.some`) is what makes it the first one, and the
+    // spread puts Notifications last - matching the left-to-right order the
+    // three cards actually render in.
+    expect(steps).toContain('const currentId = [...requiredCards, notifCard].find(')
+    expect(steps).toMatch(/!permGranted\(p, wiz\) && !permHidden\(p, wiz\)/)
+    // Nothing pending → no ring anywhere, rather than defaulting to card one
+    // and re-ringing a step the user has already completed.
+    expect(steps).toMatch(/\)\?\.id \?\? null/)
+  })
+
+  it('asks one shared predicate whether a permission is granted', () => {
+    // PermissionsBody picks the current card and PermCard styles itself; if
+    // each inlined its own granted-check they would drift, and the visible
+    // result is a ring sitting on a green card while the genuinely pending one
+    // looks finished.
+    expect(steps).toContain('function permGranted(')
+    expect(steps).toContain('function permHidden(')
+    // The card must CALL it, not re-derive it.
+    expect(permCard()).toContain('const granted = permGranted(p, wiz)')
+    expect(permCard()).not.toMatch(/const granted = notif \?/)
+  })
+
+  it('rings the current card without resizing it', () => {
+    const card = permCard()
+    // A box-shadow ring, not a thicker border: a border that changes width
+    // when the ring turns on would shunt the other two cards sideways every
+    // time the sequence advances.
+    expect(card).toMatch(/boxShadow: current \?/)
+    expect(card).not.toMatch(/border: `?[0-9.]+px solid \$\{current/)
+  })
+
+  it('never disables a permission button', () => {
+    // THE ONE THAT MATTERS. macOS grants frequently are not visible to the
+    // probe until a relaunch, so gating the later cards on the earlier ones
+    // would strand a user who has genuinely granted everything. Highlighting
+    // is allowed to imply an order; it is not allowed to enforce one.
+    const card = permCard()
+    expect(card).not.toContain('disabled')
+    // Both buttons switch variant on `current` - the sequence shows up in the
+    // button too, and that is the whole of what `current` may do to them.
+    const variants = card.match(/variant=\{current \? 'primary' : 'secondary'\}/g) ?? []
+    expect(variants.length).toBe(2)
+  })
+})

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -76,6 +76,18 @@ function PermissionsBody({ wiz }: { wiz: Wiz }) {
   const notifHidden = isWin && wiz.perms.notifications === 'unavailable'
   const notifCard = PERMISSIONS.find((p) => p.id === 'notifications')!
   const requiredCards = PERMISSIONS.filter((p) => p.id !== 'notifications')
+  // Which card is "up next". Three equally-weighted cards, each with its own
+  // Open Settings button, gave no sense of order - so people opened all three
+  // panes at once, lost track of which they had actually granted, and came
+  // back to a step that looked identical to when they left. One ring at a
+  // time turns it into a sequence.
+  //
+  // The ring only MARKS the next one; every card stays clickable. Gating the
+  // later two behind the earlier ones was the other option and is a trap:
+  // macOS grants routinely need a relaunch before the probe sees them, so a
+  // lagging read would lock the user out of the rest of the step with nothing
+  // to click.
+  const currentId = [...requiredCards, notifCard].find((p) => !permGranted(p, wiz) && !permHidden(p, wiz))?.id ?? null
   return (
     // Sized to its own content (no flex:1 stretch) - this step's cards are
     // short, and forcing them to fill the whole card height (as a prior pass
@@ -97,8 +109,8 @@ function PermissionsBody({ wiz }: { wiz: Wiz }) {
          separate full-width row below them. */}
       {!isWin && (
         <div className="flex items-stretch" style={{ gap: 12 }}>
-          {requiredCards.map((p) => <PermCard key={p.id} p={p} wiz={wiz} />)}
-          <PermCard p={notifCard} wiz={wiz} />
+          {requiredCards.map((p) => <PermCard key={p.id} p={p} wiz={wiz} current={p.id === currentId} />)}
+          <PermCard p={notifCard} wiz={wiz} current={notifCard.id === currentId} />
         </div>
       )}
       {/* Windows only ever shows Notifications (no TCC analogue for the other
@@ -117,7 +129,7 @@ function PermissionsBody({ wiz }: { wiz: Wiz }) {
             </div>
           </Row>
         ) : (
-          <PermCard p={notifCard} wiz={wiz} />
+          <PermCard p={notifCard} wiz={wiz} current={notifCard.id === currentId} />
         )
       )}
       <p className="flex items-start" style={{ gap: 7, fontSize: 11, lineHeight: 1.5, color: 'var(--t-muted)', marginTop: 3 }}>
@@ -136,12 +148,30 @@ function PermissionsBody({ wiz }: { wiz: Wiz }) {
 // side (see PermissionsBody) and stretch to fill the step, and a vertical
 // card is what gives the preview room to grow into that height instead of
 // squeezing everything onto one row.
-function PermCard({ p, wiz }: { p: PermissionMeta; wiz: Wiz }) {
+/** Whether `p` has been granted.
+ *
+ *  Extracted so [`PermissionsBody`]'s "which card is next" walk and the card's
+ *  own styling read the same predicate. Two copies of this would drift, and
+ *  the failure is silent and confusing: a ring sitting on an already-green
+ *  card while the genuinely pending one looks finished. */
+function permGranted(p: PermissionMeta, wiz: Wiz): boolean {
+  return p.id === 'notifications' ? wiz.perms.notifications === 'granted' : !!wiz.perms[p.id]
+}
+
+/** Whether `p` renders no card at all - an unbundled run (`tauri dev`) has no
+ *  notification plugin, so there is nothing to grant. Kept next to
+ *  [`permGranted`] because the "next card" walk must skip these: pointing the
+ *  ring at a card that does not exist stalls the sequence on an empty slot. */
+function permHidden(p: PermissionMeta, wiz: Wiz): boolean {
+  return p.id === 'notifications' && wiz.perms.notifications === 'unavailable'
+}
+
+function PermCard({ p, wiz, current }: { p: PermissionMeta; wiz: Wiz; current: boolean }) {
   const notif = p.id === 'notifications'
   // Unbundled runs (`tauri dev`) have no notification plugin at all — nothing
   // to grant, so the card hides rather than dead-ends.
-  if (notif && wiz.perms.notifications === 'unavailable') return null
-  const granted = notif ? wiz.perms.notifications === 'granted' : !!wiz.perms[p.id]
+  if (permHidden(p, wiz)) return null
+  const granted = permGranted(p, wiz)
   const isMac = wiz.platform !== 'windows'
   // The reconstructed macOS pane already carries its own title + description,
   // lifted from the real System Settings copy - repeating our own title/desc
@@ -167,8 +197,12 @@ function PermCard({ p, wiz }: { p: PermissionMeta; wiz: Wiz }) {
       // Granted turns the whole card green - a clear at-a-glance "this one's
       // done", not just a faint accent tint (which used to still read as
       // pending at a glance).
-      border: `0.5px solid ${granted ? 'color-mix(in srgb, var(--color-state-approved) 40%, var(--t-card-border))' : 'var(--t-card-border)'}`,
+      border: `0.5px solid ${granted ? 'color-mix(in srgb, var(--color-state-approved) 40%, var(--t-card-border))' : current ? 'var(--t-accent)' : 'var(--t-card-border)'}`,
       background: granted ? 'color-mix(in srgb, var(--color-state-approved) 9%, var(--t-card))' : 'var(--t-card)',
+      // The ring that says "this one next". A box-shadow, not a thicker
+      // border, so turning it on cannot change the card's box size and shunt
+      // the other two sideways as the sequence advances.
+      boxShadow: current ? '0 0 0 2px color-mix(in srgb, var(--t-accent) 32%, transparent)' : undefined,
     }}>
       {selfDescribing ? (
         <div className="flex justify-end">{badgeEl}</div>
@@ -207,8 +241,12 @@ function PermCard({ p, wiz }: { p: PermissionMeta; wiz: Wiz }) {
             // 'denied' → the OS won't re-prompt, so it opens the Notifications
             // pane directly (grantNotifications skips the pointless re-request
             // when told it's already denied).
-            ? <Btn size="sm" variant="secondary" onClick={() => wiz.grantNotifications(wiz.perms.notifications === 'denied')} style={{ width: '100%' }}>{wiz.perms.notifications === 'denied' ? 'Open Settings' : 'Allow'}</Btn>
-            : <Btn size="sm" variant="secondary" onClick={() => p.id === 'screen' ? wiz.grantScreen() : wiz.openPane(p.pane)} style={{ width: '100%' }}>Open Settings</Btn>}
+            // The current card's action is the solid variant, the rest stay
+            // secondary - so the sequence reads off the buttons themselves and
+            // not just the ring around the card. Still only styling: every
+            // button here is live whether or not it is the current one.
+            ? <Btn size="sm" variant={current ? 'primary' : 'secondary'} onClick={() => wiz.grantNotifications(wiz.perms.notifications === 'denied')} style={{ width: '100%' }}>{wiz.perms.notifications === 'denied' ? 'Open Settings' : 'Allow'}</Btn>
+            : <Btn size="sm" variant={current ? 'primary' : 'secondary'} onClick={() => p.id === 'screen' ? wiz.grantScreen() : wiz.openPane(p.pane)} style={{ width: '100%' }}>Open Settings</Btn>}
         </div>
       )}
     </div>


### PR DESCRIPTION
Issue 1 of 8 from the onboarding review. **Issue 3 (the Notifications card art) stacks on top of this** - both change `ui/app/setup/steps.tsx`, so keeping them independent would just mean resolving the same conflict twice.

## What's broken

Three permission cards, three identical `Open Settings` buttons, no sense of order. People open all three System Settings panes at once, lose track of which they actually granted, and come back to a step that looks exactly as it did when they left.

## Fix

The first card that is neither granted nor hidden is marked **current**: an accent ring, and its action switches to the solid button variant. The ring advances as each grant lands, so the step reads as a sequence.

## The important design call

This is **decoration over a fully live step, never a gate.**

Disabling the later two cards is the obvious way to build a sequence, and it is a trap: macOS routinely does not report a TCC grant until the app restarts, so a lagging probe would strand a user who has genuinely granted everything in front of two dead buttons with no way to finish the step. There is a test asserting no button here ever carries `disabled`, because that is the regression someone will reach for later in the name of "stronger guidance".

## Two smaller calls

- **`permGranted` / `permHidden` extracted as shared predicates.** The "which card is next" walk and the card's own styling have to agree; two inline copies drift, and the failure is quiet and confusing - a ring sitting on an already-green card while the genuinely pending one looks finished.
- **The ring is a `box-shadow`, not a thicker border.** A border that changes width when the ring turns on would resize the card and shunt the other two sideways every time the sequence advances.

Nothing pending means no ring anywhere, rather than defaulting to card one and re-ringing a step the user has already completed.

## Test plan

- [x] New `ui/__tests__/setup-permission-sequence.test.ts` - 4 tests. Source-scanning on purpose: what is under test is *which card carries an accent ring*, and a headless run has no layout to read that off. What it can pin is the shape of the logic that picks it, which is where the regressions live.
- [x] **Mutation-checked** rather than assumed: reverted the card to its own inline granted-check and confirmed the suite fails on exactly that assertion, then restored.
- [x] `bun test` (ui/) - 734 pass, 0 fail (730 + 4 new).
- [x] `tsc --noEmit` clean.
- [x] Full `pre-push` hook passed on push.
- [ ] Not visually verified in a running build - the ring advancing across real TCC grants needs a packaged run and a permission reset. The logic that picks the current card is unit-guarded; what is unverified is purely how the ring looks.