### PR TITLE
fix(setup): draw the real Notifications pane on its permission card

### DIFF
--- a/ui/__tests__/setup-permission-preview.test.ts
+++ b/ui/__tests__/setup-permission-preview.test.ts
@@ -1,0 +1,56 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// macOS Notifications is a DIFFERENT System Settings pane from Accessibility
+// and Screen Recording, and the wizard's preview art has to say so.
+//
+// Accessibility and Screen Recording are one flat allow-list: a row per app
+// with a toggle is a faithful picture of them. Notifications is two levels
+// deep - the list only gets you to an app, and the switch the user actually
+// has to flip lives on that app's own page under "Allow notifications". The
+// three previews were all rendered from the same app-list component, so the
+// Notifications card showed people a screen they would never land on, and
+// then told them to look for a row that is not on it.
+//
+// Source-scanning: the failure here is visual (wrong picture, right code
+// path), which no headless assertion can see. What it can pin is that the two
+// pane shapes stay distinct - the regression is someone folding them back into
+// one component because they look similar in the source.
+
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const atoms = readFileSync(join(import.meta.dir, '..', 'app', 'setup', 'atoms.tsx'), 'utf8')
+
+describe('the permission preview art matches the pane it names', () => {
+  it('routes macOS Notifications to its own pane component', () => {
+    expect(atoms).toContain('function MacNotificationsPanePreview()')
+    // The branch, not just the component's existence - an orphaned component
+    // would satisfy the line above while every card still rendered the list.
+    expect(atoms).toMatch(/permissionId === 'notifications'\s*\?\s*<MacNotificationsPanePreview \/>/)
+  })
+
+  it('shows the control the user actually has to flip', () => {
+    // "Allow notifications" is the heading on the real per-app page. If this
+    // string goes missing the picture has stopped being that page.
+    expect(atoms).toContain('Allow notifications')
+  })
+
+  it('keeps the app-list pane for the two permissions that really are a list', () => {
+    expect(atoms).toContain('<MacSettingsPanePreview permissionId={permissionId} />')
+    // Accessibility and Screen Recording keep their blurred other-app rows;
+    // that list is what makes THOSE two recognisable.
+    expect(atoms).toMatch(/accessibility: \{[\s\S]*?others: \['Terminal', 'Google Chrome'\]/)
+  })
+
+  it('never presents the blurred scenery as something to click', () => {
+    // Everything below the Allow-notifications row is landmark, not control.
+    // Rendering it sharp would invite clicks on a picture.
+    const at = atoms.indexOf('function MacNotificationsPanePreview()')
+    const end = atoms.indexOf('\n/** The simple single-row preview', at)
+    if (at < 0 || end < 0) throw new Error('MacNotificationsPanePreview bounds not found')
+    const pane = atoms.slice(at, end)
+    expect(pane).toContain("filter: 'blur(2px)'")
+    expect(pane).not.toContain('onClick')
+  })
+})

--- a/ui/app/setup/atoms.tsx
+++ b/ui/app/setup/atoms.tsx
@@ -76,6 +76,9 @@ const MAC_PANE_COPY: Record<'accessibility' | 'screen' | 'notifications', { titl
     blurb: 'Allow the applications below to record the content of your screen.',
     others: ['Terminal', 'Google Chrome'],
   },
+  // Kept for the shape of the record, but macOS Notifications no longer renders
+  // through MacSettingsPanePreview - see MacNotificationsPanePreview for why the
+  // app-list layout was the wrong pane entirely.
   notifications: {
     title: 'Notifications',
     blurb: 'Allow the applications below to send notifications.',
@@ -167,8 +170,90 @@ function MacSettingsPanePreview({ permissionId }: { permissionId: 'accessibility
   )
 }
 
+/** Reconstructed macOS **Notifications** pane - the per-app detail view.
+ *
+ *  Notifications does not live in the same shape as Accessibility and Screen
+ *  Recording. Those two are one flat allow-list of apps, so a row per app with
+ *  a toggle is a faithful picture of them. Notifications is two levels deep:
+ *  the list only gets you to an app, and the switch the user actually has to
+ *  flip lives on that app's OWN page, under the heading `Allow notifications`.
+ *  Rendering it as another app list sent people looking for a row that is not
+ *  on the screen they land on.
+ *
+ *  So this mirrors the real page: the `Allow notifications` header row carrying
+ *  the one meaningful toggle, then the alert-style block and the settings rows
+ *  underneath it - blurred, exactly like the other pane's non-Meridian rows,
+ *  because they are scenery. They earn their place by being the landmarks that
+ *  make the screenshot recognisable as *that* page; without them the header row
+ *  alone could be any toggle in any settings app.
+ *
+ *  Sharp-vs-blurred does different work here than in the sibling pane. There it
+ *  separates Meridian from other apps; here there are no other apps, so it
+ *  separates the control that matters from the ones that do not. */
+function MacNotificationsPanePreview() {
+  // The three alert-placement thumbnails, the most recognisable landmark on
+  // the real page. Labels are omitted at this size - they render as unreadable
+  // 6px text - so these are shape only.
+  const placements = ['Desktop', 'Notification Center', 'Lock Screen']
+  return (
+    <div className="w-full flex flex-col" style={{
+      height: '100%', borderRadius: 10, overflow: 'hidden',
+      border: '0.5px solid var(--t-card-border)', background: '#fff',
+    }}>
+      <div className="flex items-center shrink-0" style={{ gap: 7, padding: '6px 10px', background: '#F0F0F1' }}>
+        <span style={{
+          width: 16, height: 16, borderRadius: 99, background: '#fff', border: '0.5px solid #d2d2d7',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 10, color: '#1d1d1f', lineHeight: 1,
+        }}>‹</span>
+        <span style={{
+          width: 16, height: 16, borderRadius: 99, background: '#fff', border: '0.5px solid #e5e5e7',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 10, color: '#c7c7cc', lineHeight: 1,
+        }}>›</span>
+      </div>
+
+      {/* THE control. Same sharp + accent-tinted treatment the sibling pane
+         gives its Meridian row, for the same reason: it is the one thing on
+         this picture the user has to act on. */}
+      <div className="flex items-center shrink-0" style={{
+        gap: 9, margin: '6px 8px 0', padding: '7px 10px', borderRadius: 8,
+        background: 'color-mix(in srgb, var(--t-accent) 11%, #fff)',
+        boxShadow: 'inset 0 0 0 1.5px color-mix(in srgb, var(--t-accent) 50%, transparent)',
+      }}>
+        <Logo size={19} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <p style={{ fontSize: 12.5, fontWeight: 700, color: '#1d1d1f', lineHeight: 1.2 }}>Allow notifications</p>
+          <p style={{ fontSize: 10, color: '#6e6e73', lineHeight: 1.2, marginTop: 1 }}>Meridian</p>
+        </div>
+        <MacToggleOn />
+      </div>
+
+      {/* Scenery below - blurred for the same reason the other pane blurs its
+         non-Meridian rows: recognisable as the real page, never mistakable for
+         something to click. */}
+      <div className="flex flex-col" style={{ flex: 1, gap: 5, margin: '6px 8px 8px', filter: 'blur(2px)', opacity: 0.5 }}>
+        <div className="flex items-start" style={{ gap: 6, padding: '6px 8px', borderRadius: 8, background: '#F0F0F1' }}>
+          {placements.map((name) => (
+            <div key={name} className="flex flex-col items-center" style={{ flex: 1, gap: 3 }}>
+              <span style={{ width: '100%', height: 22, borderRadius: 3, background: 'linear-gradient(160deg,#6b5b95,#8f7fb8)' }} />
+              <span style={{ width: 7, height: 7, borderRadius: 2, background: '#0A84FF' }} />
+            </div>
+          ))}
+        </div>
+        {['Badge application icon', 'Play sound for notification'].map((label) => (
+          <div key={label} className="flex items-center" style={{
+            gap: 8, padding: '4px 8px', borderRadius: 6, background: '#F0F0F1',
+          }}>
+            <span style={{ flex: 1, fontSize: 9.5, color: '#1d1d1f' }}>{label}</span>
+            <span style={{ width: 20, height: 12, borderRadius: 99, background: '#0A84FF', flexShrink: 0 }} />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 /** The simple single-row preview - used for Notifications on Windows only now
- *  (macOS Notifications uses `MacSettingsPanePreview` like the other two).
+ *  (macOS Notifications uses `MacNotificationsPanePreview`).
  *  Also fills its container height, centering the row vertically, so it
  *  matches whatever height the (equal-height, `items-stretch`) sibling cards
  *  end up at. */
@@ -210,7 +295,11 @@ export function PermissionPreview({ os, permissionId }: {
   permissionId: 'accessibility' | 'screen' | 'notifications'
 }) {
   if (os === 'macos') {
-    return <MacSettingsPanePreview permissionId={permissionId} />
+    // Notifications is a DIFFERENT pane in System Settings, not another entry
+    // in the same list - see MacNotificationsPanePreview.
+    return permissionId === 'notifications'
+      ? <MacNotificationsPanePreview />
+      : <MacSettingsPanePreview permissionId={permissionId} />
   }
   return <SimpleTogglePreview os={os} />
 }


### PR DESCRIPTION
Issue 3 of 8 from the onboarding review.

> **Stacked on #741** (issue 1). Base is `fix/setup-permission-sequence`, not `pre-main` - both change the permissions step, and stacking means the same conflict is not resolved twice. **Merge #741 first**; this one's base retargets to `pre-main` automatically once it does.

## What's broken

All three permission cards rendered their preview from the same app-list component. That is a faithful picture of **Accessibility** and **Screen Recording** - those genuinely are one flat allow-list of apps, so a row per app with a toggle is exactly what the user will see.

It is the wrong screen for **Notifications**. That pane is two levels deep: the list only gets you to an app, and the switch the user actually has to flip lives on that app's *own* page, under the heading `Allow notifications`.

So the card showed people a screen they would never land on, and then told them to look for a row that is not on it.

## Fix

macOS Notifications gets its own pane component, mirroring the real page:

- The **`Allow notifications`** header row carrying the one meaningful toggle - sharp and accent-tinted, the same treatment the sibling pane gives its Meridian row, for the same reason: it is the one thing in the picture the user has to act on.
- The alert-placement thumbnails (Desktop / Notification Center / Lock Screen) and the `Badge application icon` / `Play sound` rows underneath, **blurred**.

The blurred part is not filler. Those are the landmarks that make the image recognisable as *that specific page*; without them the header row alone could be any toggle in any settings app. Labels on the thumbnails are omitted deliberately - at this size they render as unreadable 6px text, so they are shape only.

Worth noting the sharp-vs-blurred split does different work here than in the sibling pane: there it separates Meridian from other apps, here there are no other apps, so it separates the control that matters from the ones that do not.

**Windows is untouched** - its Notifications preview already had its own single-row shape.

## Test plan

- [x] New `ui/__tests__/setup-permission-preview.test.ts` - 4 tests. Source-scanning, because the failure mode is a *wrong picture down a correct code path*: nothing throws, nothing logs, the card renders fine. What can be pinned is that the two pane shapes stay distinct, which is the regression someone introduces by folding them back into one component because they look similar in the source.
- [x] One test asserts the routing branch, not just that the component exists - an orphaned component would satisfy the weaker check while every card still rendered the old list.
- [x] One asserts the scenery carries no `onClick`, so a picture never invites a click.
- [x] `bun test` (ui/) - 738 pass, 0 fail.
- [x] `tsc --noEmit` clean.
- [x] Full `pre-push` hook passed on push.
- [ ] **Not visually verified** - this is art, and I cannot see it rendered. It is built from the screenshot in the issue and follows the existing pane's construction, but someone should eyeball it against real System Settings before merge. That check is the actual acceptance criterion here.