### PR TITLE
feat(tray): open the dashboard in native full screen

### DIFF
--- a/tray/src-tauri/src/commands/system.rs
+++ b/tray/src-tauri/src/commands/system.rs
@@ -66,6 +66,11 @@ pub async fn open_dashboard(app: tauri::AppHandle) -> Result<(), String> {
         .build()
     {
         Ok(win) => {
+            // `.maximized(true)` above is not dependable on macOS — see
+            // `sys::fill_work_area` for the tao/AppKit early-return that makes
+            // it a silent no-op. Kept anyway so the window still reports the
+            // right state to the OS.
+            crate::sys::fill_work_area(&win);
             // Revert to Accessory (no dock icon) when the dashboard is closed
             // so the tray-only UX is restored.
             crate::sys::revert_to_accessory_on_close(&app, &win);

--- a/tray/src-tauri/src/commands/system.rs
+++ b/tray/src-tauri/src/commands/system.rs
@@ -66,11 +66,12 @@ pub async fn open_dashboard(app: tauri::AppHandle) -> Result<(), String> {
         .build()
     {
         Ok(win) => {
-            // `.maximized(true)` above is not dependable on macOS — see
-            // `sys::fill_work_area` for the tao/AppKit early-return that makes
-            // it a silent no-op. Kept anyway so the window still reports the
-            // right state to the OS.
-            crate::sys::fill_work_area(&win);
+            // Fills the screen, then enters native full-screen. The builder's
+            // `.maximized(true)` above is a silent no-op on macOS — see
+            // `sys::open_full_screen` for the tao/AppKit early-return behind
+            // that, and for the resize hazard the full-screen style mask
+            // carries.
+            crate::sys::open_full_screen(&win);
             // Revert to Accessory (no dock icon) when the dashboard is closed
             // so the tray-only UX is restored.
             crate::sys::revert_to_accessory_on_close(&app, &win);

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -2101,6 +2101,32 @@ mod reopen_tests {
         assert!(include_str!("commands/system.rs").contains("open_wizard_window(&app);"));
     }
 
+    /// Both dashboard openers must size the window to the monitor work area
+    /// after building it.
+    ///
+    /// `.maximized(true)` is on both builders and is NOT enough on macOS: tao's
+    /// `set_maximized` early-returns when `is_zoomed()` already equals the
+    /// requested state, so the zoom is skipped with no error, the flag still
+    /// set, and `is_maximized()` still reporting `true`. That is why this
+    /// shipped looking correct. `sys::fill_work_area` is the deterministic
+    /// half; the builder flag alone must never be trusted to satisfy this.
+    ///
+    /// Source-scanned for the same reason as the test above - both functions
+    /// build a real webview and cannot be driven from a unit test.
+    #[test]
+    fn every_dashboard_path_fills_the_work_area() {
+        for (name, src) in [
+            ("tray.rs", include_str!("tray.rs")),
+            ("commands/system.rs", include_str!("commands/system.rs")),
+        ] {
+            assert!(
+                src.contains("crate::sys::fill_work_area(&win);"),
+                "{name} opens the dashboard without calling fill_work_area - \
+                 `.maximized(true)` alone is a silent no-op on macOS"
+            );
+        }
+    }
+
     #[test]
     fn is_onboarded_reflects_the_marker_file() {
         // Use a unique temp dir so parallel test runs don't collide.

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -2101,30 +2101,51 @@ mod reopen_tests {
         assert!(include_str!("commands/system.rs").contains("open_wizard_window(&app);"));
     }
 
-    /// Both dashboard openers must size the window to the monitor work area
-    /// after building it.
+    /// Both dashboard openers must take the window full-screen after building
+    /// it.
     ///
     /// `.maximized(true)` is on both builders and is NOT enough on macOS: tao's
     /// `set_maximized` early-returns when `is_zoomed()` already equals the
     /// requested state, so the zoom is skipped with no error, the flag still
     /// set, and `is_maximized()` still reporting `true`. That is why this
-    /// shipped looking correct. `sys::fill_work_area` is the deterministic
-    /// half; the builder flag alone must never be trusted to satisfy this.
+    /// shipped looking correct. `sys::open_full_screen` is the explicit half;
+    /// the builder flag alone must never be trusted to satisfy this.
     ///
     /// Source-scanned for the same reason as the test above - both functions
     /// build a real webview and cannot be driven from a unit test.
     #[test]
-    fn every_dashboard_path_fills_the_work_area() {
+    fn every_dashboard_path_opens_full_screen() {
         for (name, src) in [
             ("tray.rs", include_str!("tray.rs")),
             ("commands/system.rs", include_str!("commands/system.rs")),
         ] {
             assert!(
-                src.contains("crate::sys::fill_work_area(&win);"),
-                "{name} opens the dashboard without calling fill_work_area - \
-                 `.maximized(true)` alone is a silent no-op on macOS"
+                src.contains("crate::sys::open_full_screen(&win);"),
+                "{name} opens the dashboard without calling open_full_screen - \
+                 a builder flag alone is a silent no-op on macOS"
             );
         }
+    }
+
+    /// Nothing may resize the dashboard window without checking `is_fullscreen`
+    /// first.
+    ///
+    /// The dashboard now carries the full-screen style mask, and tao's
+    /// `set_inner_size` calls `NSWindow::setContentSize:` unconditionally
+    /// against it - shrinking the rendered content while the Space stays
+    /// screen-sized and leaving a black surround. That is exactly the setup
+    /// wizard bug, and `resize_setup_window` guards against it by name.
+    ///
+    /// This pins that the guard is still there, because the wizard's guard is
+    /// now also the pattern the dashboard depends on being copied.
+    #[test]
+    fn window_resizes_check_for_full_screen_first() {
+        let src = include_str!("commands/system.rs");
+        assert!(
+            src.contains("win.is_fullscreen().unwrap_or(false)"),
+            "resize_setup_window lost its full-screen guard - a setContentSize: \
+             against a full-screen style mask renders black around the content"
+        );
     }
 
     #[test]

--- a/tray/src-tauri/src/sys.rs
+++ b/tray/src-tauri/src/sys.rs
@@ -529,21 +529,55 @@ pub fn register_notification_categories(app: &tauri::AppHandle) {
 /// occupies. Setting position and size to it cannot be skipped by a state
 /// guard.
 ///
-/// Native full-screen (`.fullscreen(true)`) is deliberately NOT what this
-/// does. That is the separate-Space, auto-hiding-chrome mode, and it is the
-/// mode that produced the black-screen setup wizard bug — a resize while the
-/// window carries the full-screen style mask shrinks the rendered content
-/// while the Space stays screen-sized. Filling the work area keeps an ordinary
-/// window that the user can still move, resize, and un-maximize.
+/// Then it enters **native macOS full-screen** — own Space, auto-hiding menu
+/// bar and Dock — which is the requested behaviour for the dashboard.
 ///
-/// Failures are logged and swallowed: a dashboard at its default size is worse
-/// than one filling the screen, but it is not a broken dashboard, and no user
-/// action should fail over window geometry.
+/// The work-area fill is not redundant once full-screen is requested: macOS
+/// restores the PRE-full-screen frame when the user leaves full-screen, so
+/// without it the green button would drop them back to a 1100x760 window. The
+/// fill is what makes that exit land on a screen-filling window instead.
+///
+/// # The hazard this mode carries
+///
+/// A window in native full-screen carries the full-screen style mask, and
+/// tao's `set_inner_size` calls `NSWindow::setContentSize:` unconditionally
+/// against it — shrinking the rendered content while the Space stays
+/// screen-sized, leaving a black surround. That is the setup-wizard bug
+/// (`commands::system::resize_setup_window` guards against it explicitly).
+///
+/// The dashboard is safe today because nothing resizes it: `nudgeWindowRepaint`
+/// in `ui/lib/bridge.ts` is the only frontend caller of `setSize`, and it runs
+/// only from the setup wizard. **Anything that starts resizing the dashboard
+/// window must check `is_fullscreen()` first**, the same way the wizard's
+/// resize command does.
+///
+/// Failures are logged and swallowed: a dashboard that opened windowed is
+/// worse than one that opened full-screen, but it is not a broken dashboard,
+/// and no user action should fail over window geometry.
 ///
 /// # Who calls this
 /// Both dashboard openers, right after `build()`: [`crate::tray`]'s tray-menu
 /// opener and [`crate::commands::system::open_dashboard`].
-pub(crate) fn fill_work_area(win: &tauri::WebviewWindow) {
+pub(crate) fn open_full_screen(win: &tauri::WebviewWindow) {
+    fill_work_area(win);
+    // Requested AFTER the window exists rather than via the builder's
+    // `.fullscreen(true)`, for the same reason `.maximized(true)` is not
+    // trusted above: a builder flag that does nothing fails silently, while an
+    // explicit call has a Result to log. It also avoids asking AppKit to
+    // animate a window into a new Space before that window is on screen.
+    if let Err(e) = win.set_fullscreen(true) {
+        tracing::warn!(error = %e, "dashboard: could not enter full-screen - staying windowed");
+        return;
+    }
+    tracing::info!("dashboard: entered native full-screen");
+}
+
+/// Size a window to fill the screen it opened on, as an ordinary window.
+///
+/// Kept separate from [`open_full_screen`] because it is also the fallback
+/// geometry: see that function for why the frame is set before full-screen is
+/// requested.
+fn fill_work_area(win: &tauri::WebviewWindow) {
     let monitor = match win.current_monitor() {
         Ok(Some(m)) => m,
         Ok(None) => {

--- a/tray/src-tauri/src/sys.rs
+++ b/tray/src-tauri/src/sys.rs
@@ -504,6 +504,73 @@ pub fn register_notification_categories(app: &tauri::AppHandle) {
 /// closure: [`crate::tray`]'s tray-menu opener and
 /// [`crate::commands::system::open_dashboard`].
 ///
+/// Size a freshly built window to fill the screen it opened on.
+///
+/// # Why not just `.maximized(true)` on the builder
+///
+/// Both dashboard openers already pass it, and the dashboard still opens as a
+/// 1100x760 window. The flag reaches tao's macOS `set_maximized`, which opens
+/// with:
+///
+/// ```ignore
+/// let is_zoomed = self.is_zoomed();
+/// if is_zoomed == maximized { return; }
+/// ```
+///
+/// and `is_zoomed` is answered by AppKit's `NSWindow.isZoomed`, which compares
+/// the frame against a *standard frame* AppKit derives on its own. A window
+/// whose frame already matches that derivation is reported as zoomed and the
+/// zoom is skipped — silently, with the builder flag still set and
+/// `is_maximized()` still reporting `true`. There is no error and nothing to
+/// log, which is why this looked like it worked.
+///
+/// The work area answers the same question deterministically: the screen minus
+/// the menu bar and the Dock, which is exactly the region a maximized window
+/// occupies. Setting position and size to it cannot be skipped by a state
+/// guard.
+///
+/// Native full-screen (`.fullscreen(true)`) is deliberately NOT what this
+/// does. That is the separate-Space, auto-hiding-chrome mode, and it is the
+/// mode that produced the black-screen setup wizard bug — a resize while the
+/// window carries the full-screen style mask shrinks the rendered content
+/// while the Space stays screen-sized. Filling the work area keeps an ordinary
+/// window that the user can still move, resize, and un-maximize.
+///
+/// Failures are logged and swallowed: a dashboard at its default size is worse
+/// than one filling the screen, but it is not a broken dashboard, and no user
+/// action should fail over window geometry.
+///
+/// # Who calls this
+/// Both dashboard openers, right after `build()`: [`crate::tray`]'s tray-menu
+/// opener and [`crate::commands::system::open_dashboard`].
+pub(crate) fn fill_work_area(win: &tauri::WebviewWindow) {
+    let monitor = match win.current_monitor() {
+        Ok(Some(m)) => m,
+        Ok(None) => {
+            tracing::warn!("dashboard: no current monitor - leaving the window at its built size");
+            return;
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "dashboard: could not resolve the current monitor");
+            return;
+        }
+    };
+    let area = *monitor.work_area();
+    if let Err(e) = win.set_position(area.position) {
+        tracing::warn!(error = %e, "dashboard: could not move the window to the work area");
+        return;
+    }
+    if let Err(e) = win.set_size(area.size) {
+        tracing::warn!(error = %e, "dashboard: could not size the window to the work area");
+        return;
+    }
+    tracing::info!(
+        width = area.size.width,
+        height = area.size.height,
+        "dashboard: filled the monitor work area"
+    );
+}
+
 /// # Related
 /// - [`crate::commands::system::dismiss_popover_on_focus`] — the other
 ///   window-event hook the dashboard openers install.

--- a/tray/src-tauri/src/tray.rs
+++ b/tray/src-tauri/src/tray.rs
@@ -138,11 +138,12 @@ pub(crate) fn open_native_dashboard(app: &tauri::AppHandle) {
             .build()
         {
             Ok(win) => {
-                // `.maximized(true)` above is not dependable on macOS — see
-                // `sys::fill_work_area` for the tao/AppKit early-return that
-                // makes it a silent no-op. Kept anyway so the window still
-                // reports the right state to the OS.
-                crate::sys::fill_work_area(&win);
+                // Fills the screen, then enters native full-screen. The
+                // builder's `.maximized(true)` above is a silent no-op on
+                // macOS — see `sys::open_full_screen` for the tao/AppKit
+                // early-return behind that, and for the resize hazard the
+                // full-screen style mask carries.
+                crate::sys::open_full_screen(&win);
                 // Revert to Accessory (no dock icon) when the dashboard is closed
                 // so the tray-only UX is restored.
                 crate::sys::revert_to_accessory_on_close(app, &win);

--- a/tray/src-tauri/src/tray.rs
+++ b/tray/src-tauri/src/tray.rs
@@ -138,6 +138,11 @@ pub(crate) fn open_native_dashboard(app: &tauri::AppHandle) {
             .build()
         {
             Ok(win) => {
+                // `.maximized(true)` above is not dependable on macOS — see
+                // `sys::fill_work_area` for the tao/AppKit early-return that
+                // makes it a silent no-op. Kept anyway so the window still
+                // reports the right state to the OS.
+                crate::sys::fill_work_area(&win);
                 // Revert to Accessory (no dock icon) when the dashboard is closed
                 // so the tray-only UX is restored.
                 crate::sys::revert_to_accessory_on_close(app, &win);


### PR DESCRIPTION
Issue 4 of 8 from the onboarding review. Independent - not part of either stack.

> **Updated:** this originally maximized to screen bounds. Per follow-up, it now enters **native macOS full screen** - own Space, auto-hiding menu bar and Dock.

## Two commits, and the first one is the interesting bug

### 1. `.maximized(true)` was already there and did nothing

Both dashboard openers already passed it, and the dashboard still opened as a 1100x760 window. The flag was not being ignored by our code - it never took effect.

It reaches tao's macOS `set_maximized`, which opens with:

```rust
let is_zoomed = self.is_zoomed();
if is_zoomed == maximized { return; }
```

and `is_zoomed` is answered by AppKit's `NSWindow.isZoomed`, which compares the frame against a *standard frame* AppKit derives on its own. A window whose frame already matches it is reported as already zoomed and the zoom is skipped - **silently, with the builder flag still set and `is_maximized()` still returning `true`.** No error, no log, and the state reads correct if you go looking. That is why this shipped looking done.

### 2. Then it goes full screen

`sys::open_full_screen` fills the monitor work area and then calls `set_fullscreen(true)`.

**The work-area fill is not redundant.** macOS restores the *pre-full-screen* frame when the user leaves full screen, so without it the green button would drop them back to 1100x760. Filling first is what makes that exit land on a screen-filling window.

**Full screen is requested after the window exists**, not via the builder's `.fullscreen(true)` - same reasoning as above: a builder flag that does nothing fails silently, while an explicit call has a `Result` to log. It also avoids asking AppKit to animate a window into a new Space before that window is on screen.

## The hazard this mode carries - please read before merging

A window with the full-screen style mask meets tao's `set_inner_size`, which calls `NSWindow::setContentSize:` **unconditionally**: it shrinks the rendered content while the Space stays screen-sized, leaving a black surround. **That is exactly the setup-wizard bug fixed in #732.**

The dashboard is safe today because nothing resizes it - `nudgeWindowRepaint` in `ui/lib/bridge.ts` is the only frontend caller of `setSize`, and it runs only from the setup wizard. I checked this rather than assumed it.

Because that safety is a property of what happens to call it, there is now a test pinning that `resize_setup_window` keeps its `is_fullscreen` guard: that guard is no longer just the wizard's business, it is the pattern anything touching the dashboard's size has to copy.

## Trade-off you are accepting

The dashboard switches activation policy to `Regular` so Meridian appears in the **Dock** while it is open, and reverts to `Accessory` on close. Native full screen hides the Dock - so that icon is not visible until the user leaves full screen. Worth knowing, since the dock icon was a deliberate feature.

## Test plan

- [x] Source-scanning test asserting **both** openers call `open_full_screen` - added next to the existing `every_dashboard_path_waits_for_onboarding`, which already scans these same two files for the same reason: both functions build a real webview and cannot be driven from a unit test.
- [x] Second test pinning the wizard's `is_fullscreen` resize guard, for the reason above.
- [x] Failure messages name the trap, so the next person does not "simplify" the call away on the reasonable-looking grounds that the builder already asks for it.
- [x] `cargo test -p meridian-tray` - 251 pass, 0 fail.
- [x] `cargo clippy -p meridian-tray --all-targets -- -D warnings`, `cargo fmt --check` clean.
- [x] Full `pre-push` hook passed on push.
- [ ] **Not verified on a running build**, and this one needs it. The diagnosis above is read off tao's source, not observed in a debugger. Things to check: it actually enters full screen; leaving full screen lands on a screen-filling window rather than a small one; and nothing renders black. On a second display too - `current_monitor()` is per-window, so it should fill whichever screen it opens on.