### PR TITLE
feat(setup): resume the wizard where the user left off

### DIFF
--- a/ui/__tests__/setup-resume-progress.test.ts
+++ b/ui/__tests__/setup-resume-progress.test.ts
@@ -1,0 +1,61 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// The setup wizard resumes where the user left off after a quit.
+//
+// Three properties matter here, and two of them are the kind that break
+// silently - the wizard still opens, just on the wrong screen, which reads as
+// "it forgot" rather than as a bug:
+//
+// 1. Progress is keyed by step ID, never by index. `buildSteps` is
+//    platform-dependent and the list changes between builds, so an index is
+//    only meaningful against the exact list that produced it. Restoring `2`
+//    against a different list lands on a different step with no error.
+// 2. Restore waits for `platform` to resolve. page.tsx already documents why:
+//    the step list must never change shape underneath a `step` index that has
+//    been navigated to. Restoring early reintroduces that bug from the other
+//    side.
+// 3. Finishing clears the key, or Re-run Setup opens on the last step of the
+//    run that just ended.
+
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const page = readFileSync(join(import.meta.dir, '..', 'app', 'setup', 'page.tsx'), 'utf8')
+
+describe('the setup wizard resumes where it left off', () => {
+  it('stores the step ID, not its index', () => {
+    expect(page).toContain('JSON.stringify({ stepId })')
+    // Restoring resolves that id back to a position in the CURRENT list.
+    expect(page).toContain('steps.findIndex((s) => s.id === savedStepId)')
+    // An id that no longer exists starts from the top rather than guessing.
+    expect(page).toMatch(/if \(at < 0\) return/)
+  })
+
+  it('waits for the platform before restoring', () => {
+    // The guard that keeps the step list from reshaping under a restored
+    // index - the same invariant the Welcome screen holds for forward
+    // navigation.
+    expect(page).toMatch(/if \(restoredProgress\.current \|\| platform === null\) return/)
+    // …and the writer is gated on it too, so a null-platform render cannot
+    // persist a position derived from the wrong list.
+    expect(page).toMatch(/if \(welcome \|\| platform === null\) return/)
+  })
+
+  it('clears progress when setup finishes', () => {
+    const at = page.indexOf('const finish = async () => {')
+    if (at < 0) throw new Error('marker not found: const finish')
+    const end = page.indexOf('\n  }', at)
+    expect(page.slice(at, end)).toContain('localStorage.removeItem(PROGRESS_KEY)')
+  })
+
+  it('never lets a storage failure take the wizard down', () => {
+    // Private mode throws on localStorage access. The wizard opening is worth
+    // more than remembering a position, so every touch is guarded - a throw
+    // here would blank the whole setup window.
+    const touches = page.match(/localStorage\.(getItem|setItem|removeItem)/g) ?? []
+    const guarded = page.match(/try \{[^}]*localStorage\.(getItem|setItem|removeItem)/g) ?? []
+    expect(touches.length).toBeGreaterThan(0)
+    expect(guarded.length).toBe(touches.length)
+  })
+})

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -20,6 +20,16 @@ import { DEFAULT_LLM_PROVIDER, providerChoiceFields, type LlmProviderId } from '
 import { useLlmProviderDetection } from '@/components/LlmProviderPicker'
 import { Btn, DISPLAY, Kicker } from './atoms'
 
+/** Where the wizard stores how far the user got, so quitting mid-setup resumes
+ *  rather than restarting. Holds a step ID (see the restore effect for why an
+ *  index would be wrong), and is cleared on finish so a later Re-run Setup
+ *  opens on Welcome instead of resuming a run that is already over.
+ *
+ *  Versioned in the key, matching `meridian.walkthrough.seen.v1`: the stored
+ *  shape is read by a build that may not be the one that wrote it, and a `.v2`
+ *  is how that gets changed without having to parse a legacy shape. */
+const PROGRESS_KEY = 'meridian.setup.progress.v1'
+
 export default function SetupWizard() {
   const [welcome, setWelcome] = useState(true)
   const [step, setStep] = useState(0)
@@ -41,6 +51,49 @@ export default function SetupWizard() {
   }, [])
   useEffect(() => { resolvePlatform() }, [resolvePlatform])
   const steps = useMemo(() => buildSteps(platform), [platform])
+
+  // ── Resume where they left off ───────────────────────────────────────────
+  // Quitting mid-setup used to drop the user back on Welcome, re-reading a
+  // screen they had already read and re-walking steps that were already done
+  // (permissions granted, tracker connected - the work survives, only the
+  // position in the flow was lost).
+  //
+  // The step's ID is what gets stored, never its index. `buildSteps` is
+  // platform-dependent and the list can change between builds, so an index is
+  // only meaningful against the exact list that produced it - restoring `2`
+  // could land on a different step entirely, silently. An id that no longer
+  // exists simply fails to match and starts from the top.
+  //
+  // Restore is gated on `platform` having resolved, which preserves the
+  // invariant the Welcome screen exists to hold (see `platform` above): the
+  // step list must never change shape underneath a `step` index that has
+  // already been navigated to. Doing this before the platform resolves would
+  // reintroduce exactly that bug through the back door.
+  const restoredProgress = useRef(false)
+  useEffect(() => {
+    if (restoredProgress.current || platform === null) return
+    restoredProgress.current = true
+    let savedStepId: string | null = null
+    try {
+      const raw = localStorage.getItem(PROGRESS_KEY)
+      savedStepId = raw ? (JSON.parse(raw) as { stepId?: string }).stepId ?? null : null
+    } catch { return /* private mode, or a hand-mangled value - start fresh */ }
+    if (!savedStepId) return
+    const at = steps.findIndex((s) => s.id === savedStepId)
+    if (at < 0) return
+    setWelcome(false)
+    setStep(at)
+  }, [platform, steps])
+
+  // Written on every move once past Welcome. Welcome itself is deliberately
+  // not stored: it is the zero state, and "resuming" onto it is the same as
+  // not resuming.
+  useEffect(() => {
+    if (welcome || platform === null) return
+    const stepId = steps[step]?.id
+    if (!stepId) return
+    try { localStorage.setItem(PROGRESS_KEY, JSON.stringify({ stepId })) } catch { /* private mode */ }
+  }, [welcome, step, steps, platform])
 
   // Stamp when onboarding BEGAN. Completion has always been timestamped
   // (`~/.meridian/onboarded`) but the start was not, so the elapsed time — shown
@@ -245,6 +298,10 @@ export default function SetupWizard() {
     // of re-running onboarding (and matches `mark_setup_started`, which likewise
     // treats a re-run as a fresh run rather than preserving the original).
     try { localStorage.removeItem('meridian.walkthrough.seen.v1') } catch { /* private mode */ }
+    // Onboarding is over, so there is no position left to resume to. Without
+    // this, Settings → Re-run Setup would open on the last step of the run
+    // that just completed rather than at the beginning.
+    try { localStorage.removeItem(PROGRESS_KEY) } catch { /* private mode */ }
     try {
       await invoke('open_dashboard')
     } catch { /* ignore if dashboard fails to open */ }


### PR DESCRIPTION
Issue 2 of 8 from the onboarding review. Independent - not part of either stack.

## What's broken

Quitting mid-setup drops the user back on Welcome. The work itself survives - permissions stay granted, trackers stay connected - but their *position* in the flow is lost, which is the part that makes it feel like starting over: re-reading a screen they already read, re-walking steps that are already done.

## Fix

The wizard writes its current step to `localStorage` on every move past Welcome, and restores it on open.

## Two details that are load-bearing

**It stores the step's ID, never its index.** `buildSteps` is platform-dependent (Permissions differs on macOS vs Windows) and the list can change between builds, so an index is only meaningful against the exact list that produced it. Restoring `2` against a different list lands on a *different step* - silently, with no error, and looking for all the world like the resume worked. An id that no longer matches simply falls through and starts from the top.

**Restore waits for `platform` to resolve.** page.tsx already documents why the Welcome screen blocks "Get started" until then:

> a late resolve reshaping the list AFTER the user has begun would otherwise let `step` point at the wrong step or past the end of a now-shorter list

Restoring before the platform resolves reintroduces exactly that bug from the other direction. The writer is gated on it too, so a null-platform render cannot persist a position derived from the wrong list.

## Smaller calls

- **Finishing clears the key.** Without it, Settings → Re-run Setup would open on the last step of the run that just completed rather than at the beginning.
- **Welcome is deliberately not stored.** It is the zero state, and resuming onto it is the same as not resuming.
- **Every `localStorage` touch is wrapped.** Private mode throws on access, and the wizard opening is worth more than remembering a position - an unguarded throw here blanks the entire setup window.

## Test plan

- [x] New `ui/__tests__/setup-resume-progress.test.ts` - 4 tests covering the id-not-index choice, both platform gates, the clear-on-finish, and the storage guards.
- [x] The storage-guard test compares the *count* of `localStorage` touches against the count of guarded ones, so an unguarded touch added later fails rather than silently becoming a crash path.
- [x] `bun test` (ui/) - 734 pass, 0 fail.
- [x] `tsc --noEmit` clean.
- [x] Full `pre-push` hook passed on push.
- [ ] **Not verified end to end** - that needs a packaged build, quitting mid-wizard and reopening. Worth checking one case in particular: quit on the Sign in step, since that is the step whose card measures its own height, and a restore lands on it without having passed through the steps before it.

## Note on scope

I read "the page where we left off" as the setup wizard, since that is what the rest of this batch is about. If you also meant the dashboard remembering its last view, say so and I will do that separately - it is a different store and a different lifetime.