### PR TITLE
fix(walkthrough): give the narration a voice, and round the spotlight

### DIFF
--- a/ui/__tests__/tutorial-sample-day.test.ts
+++ b/ui/__tests__/tutorial-sample-day.test.ts
@@ -723,7 +723,7 @@ describe('the tour overlay draws what it means to', () => {
     expect(overlay.match(/\.\.\.CAPTION_SURFACE/g)?.length).toBe(2)
   })
 
-  it('keeps the narration inverted, at body size', () => {
+  it('keeps the narration inverted, above body size', () => {
     // The tour speaks on its OWN surface: a light card here is a white box on a
     // white page, and inside a modal - which is `--t-card` itself - it vanishes.
     // Tried the other way round once, on the reasoning that light type on a dark
@@ -731,10 +731,27 @@ describe('the tour overlay draws what it means to', () => {
     // reading as the guide and started reading as content, which is worse.
     expect(overlay).toContain("background: 'var(--t-title)'")
     expect(overlay).toContain("color: 'var(--t-card)'")
-    // Body weight and size, not something larger. At 15px/600 the bubble
-    // competes with the headings it is pointing at - and heavier inverted type
-    // is exactly what softens.
-    expect(overlay).toContain("font: '500 13px/1.5 var(--font-sans)'")
+    // ABOVE body size, and this reverses an earlier decision on purpose.
+    //
+    // This used to assert 500 13px, on the reasoning that at 15px/600 the
+    // bubble competes with the headings it points at, and that heavier
+    // inverted type is exactly what softens under macOS font smoothing. Both
+    // observations still hold. The judgement changed: at body weight and body
+    // size the narration read as a caption ON the interface rather than as
+    // someone talking the user through it, and it lost the contest for
+    // attention against real UI text that is denser and that the user is also
+    // reading for the first time. Competing with the headings is the point -
+    // a tour that does not win that contest is not worth taking the window
+    // for.
+    //
+    // So the bloom is a known, accepted cost, not an oversight. If the type
+    // ever looks mushy on a non-Retina display, the lever is the WEIGHT, not
+    // the size - drop toward 600 before giving back any px.
+    expect(overlay).toContain("font: '650 16px/1.45 var(--font-sans)'")
+    // Centred within the bubble. NOT centred on the screen: the bubble stays
+    // parked on its target, because an instruction read in one place and acted
+    // on in another is the failure the anchored variant exists to avoid.
+    expect(overlay).toContain("textAlign: 'center'")
     // Set once, on the shared constant - never per bubble, which is how the two
     // variants ended up disagreeing.
     //

--- a/ui/components/tutorial/TutorialOverlay.tsx
+++ b/ui/components/tutorial/TutorialOverlay.tsx
@@ -53,8 +53,21 @@ const CAPTION_H = 130
  *  Held in one constant because the two variants (anchored beside a target, or
  *  parked at the top) are the same voice and drifted apart once already - one
  *  inverted, one not, at different sizes. */
+// Bigger, heavier, and centred than it was (500 13px, left-aligned). At body
+// weight and body size the tour's narration read as a caption on the UI rather
+// than as someone talking the user through it, and it was competing for
+// attention with the real interface text around it - which is denser, and
+// which the user is also trying to read for the first time. The tour has to
+// win that contest to be worth showing at all.
+//
+// Centred within the bubble, NOT moved to the centre of the screen. The bubble
+// stays parked on its target on purpose (see the anchored variant below): an
+// instruction read in one place and acted on in another is the failure this
+// layout already exists to avoid.
 const CAPTION_FONT: React.CSSProperties = {
-  font: '500 13px/1.5 var(--font-sans)',
+  font: '650 16px/1.45 var(--font-sans)',
+  letterSpacing: '-.011em',
+  textAlign: 'center',
   color: 'var(--t-card)',
 }
 
@@ -247,7 +260,12 @@ export function TutorialOverlay({ caption, centered, big, celebrate, cursorAt, c
         <div className="absolute" style={{
           left: ringBox.left - 6, top: ringBox.top - 6,
           width: ringBox.width + 12, height: ringBox.height + 12,
-          borderRadius: 18,
+          // Rounder than the 18 it was. The ring sits 6px outside its target,
+          // so matching the target's own radius leaves the corners visibly
+          // tighter than the thing they enclose - which reads as a box drawn
+          // around the card rather than as the card being lit up. A radius
+          // above the card's own is what makes the two look like one shape.
+          borderRadius: 24,
           border: `2px solid var(--t-accent)`,
           boxShadow: '0 0 0 4px color-mix(in srgb, var(--t-accent) 22%, transparent)',
           opacity: ringLive ? 1 : 0,

--- a/ui/components/tutorial/script.ts
+++ b/ui/components/tutorial/script.ts
@@ -72,8 +72,17 @@ export function fmtSetupElapsed(secs: number): string {
  *  the user who has Jira open in the next tab and the one chasing an admin for
  *  approval. A promise a first-run screen visibly breaks costs more trust than
  *  the number ever bought. */
+// Opens on the OFFER, not on the transition. "Let's get started" says a thing
+// is beginning without saying what, which spends the first line of the tour on
+// the fact that there is a tour. Naming the day instead frames everything that
+// follows - the first real beat asks what they are working on today, so the
+// opening line is the question that beat answers.
+//
+// Line two is unchanged and load-bearing: a tour that takes the whole window
+// has to say it ends. See the intro tests for why it promises "quick" rather
+// than a number.
 export const INTRO_LINES = [
-  "Let's get started.",
+  'Let me help you with your day.',
   "We'll take you around - it's quick.",
 ]
 


### PR DESCRIPTION
Issue 5 of 8 from the onboarding review. **Issue 7 (blocking clicks that break the flow) stacks on this** - same overlay component.

## Changes

1. **Narration is bigger, heavier, centred** - `650 16px`, was `500 13px` left-aligned.
2. **Spotlight ring is rounder** - radius 18 → 24.
3. **The tour opens on the offer** - "Let me help you with your day." replaces "Let's get started."

## ⚠️ One of these reverses a documented decision - please sanity-check it

The caption size was **not** an oversight. There was a test asserting `500 13px` with this reasoning:

> Body weight and size, not something larger. At 15px/600 the bubble competes with the headings it is pointing at - and heavier inverted type is exactly what softens.

Someone tried larger, and backed it out. Both observations are still true. What changed is the judgement: at body weight and size the narration reads as a *caption on the interface* rather than as someone talking the user through it, and it loses the contest for attention against real UI text - which is denser, and which the user is also reading for the first time. **Competing with the headings is the point.** A tour that does not win that contest is not worth taking the window for.

So the macOS font-smoothing bloom on inverted type is now an *accepted cost*, not a missed one. I rewrote the test to say that explicitly rather than deleting the reasoning, including which lever to pull if it ever looks mushy on a non-Retina display: **drop the weight toward 600 before giving back any px.**

Flagging it because reversing a decision someone reached by trying it is worth a second opinion, and because it will look like vandalism in the diff otherwise.

## One interpretation call

"the text should be big and bold in the center" - I read *in the center* as **centred within the bubble**, and left the bubble parked on its target.

Moving narration to the centre of the screen would undo this, which the overlay documents:

> A bottom-edge bubble makes the user read an instruction in one corner and act in another... Parked directly above the target, the sentence and the thing it names are one glance.

That reasoning still looks right to me, so I did not override it. **If you did mean screen-centre, say so and it's a one-line change** - but it would trade away the instruction and its target being one glance.

## The ring

18 → 24. The ring sits 6px outside its target, so matching the target's own radius leaves the ring's corners visibly *tighter* than the thing they enclose - which reads as a box drawn around the card rather than as the card being lit up.

## Test plan

- [x] `bun test` (ui/) - 730 pass, 0 fail. The one failure this caused was the caption-size assertion above, updated deliberately rather than deleted.
- [x] Intro copy still satisfies its existing constraints - two lines, ≤10 words each, still promises "quick" rather than a number (a first-run screen that breaks a promise in its second sentence costs more than the number buys).
- [x] `tsc --noEmit` clean.
- [x] Full `pre-push` hook passed on push.
- [ ] **Not seen rendered.** All three are visual, and the size change in particular was reverted once by someone who had it on screen. Worth a look on a non-Retina display before merge - that is where the bloom argument bites.