### PR TITLE
fix(walkthrough): stop stray clicks breaking the tour (re-land #746)

### DIFF
--- a/ui/__tests__/tutorial-click-fence.test.ts
+++ b/ui/__tests__/tutorial-click-fence.test.ts
@@ -1,0 +1,70 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// While the walkthrough is waiting on one specific click, everything outside
+// the spotlight must stop taking clicks.
+//
+// Before the fence, the only beat that protected itself was the dimmed one -
+// and it did so by accident, because blocking was a side effect of the blur
+// panes rather than anything anyone had asked for. Every other beat left the
+// whole app live behind a decorative ring, including the close X on whatever
+// modal the tour had just opened.
+//
+// That failure is silent and it strands the user. Clicking the X does not
+// error: the modal closes, the tour goes on waiting for a click on a target
+// that is no longer on screen, and the user reads an instruction about a
+// window they cannot see until the beat's timeout expires - which is measured
+// in minutes.
+//
+// Source-scanning: pointer-event routing across a stack of fixed-position
+// layers is not something a headless run can resolve, and the failure is a
+// click landing one layer too deep rather than an exception.
+
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const overlay = readFileSync(
+  join(import.meta.dir, '..', 'components', 'tutorial', 'TutorialOverlay.tsx'), 'utf8',
+)
+
+describe('the walkthrough fences off stray clicks', () => {
+  it('fences every spotlight beat it is blocked on, not only the dimmed one', () => {
+    // The dimmed beat keeps its blur; every other awaited beat gets the same
+    // panes with nothing drawn on them.
+    expect(overlay).toContain('{ring && spotlightDim && <Cutout rect={ring} dim />}')
+    expect(overlay).toContain('{ring && !spotlightDim && awaiting && <Cutout rect={ring} dim={false} />}')
+  })
+
+  it('builds both fences from one component', () => {
+    // The blur and the fence are the same four panes. Two components would
+    // drift, and the drift is invisible: the visible one would keep looking
+    // right while the invisible one stopped covering the same area.
+    expect(overlay).toContain('function Cutout({ rect, dim }')
+    expect(overlay).not.toContain('function DimCutout')
+    // Only the paint is conditional. Geometry and pointer-events are not.
+    const at = overlay.indexOf('function Cutout({ rect, dim }')
+    const pane = overlay.slice(at, overlay.indexOf('\n}', overlay.indexOf('return (', at)))
+    expect(pane).toContain("pointerEvents: 'auto'")
+    expect(pane).toMatch(/\.\.\.\(dim \? \{/)
+  })
+
+  it('only fences while the tour is genuinely blocked on the user', () => {
+    // `awaiting` is the gate. A fence during narration beats would make the app
+    // feel frozen for reasons the user cannot see - that is trapping, not
+    // guiding.
+    expect(overlay).toMatch(/!spotlightDim && awaiting &&/)
+  })
+
+  it('keeps the way out clickable', () => {
+    // The fence is rendered BEFORE the caption, the choice buttons and Skip, so
+    // those later siblings paint over it and keep their own pointerEvents.
+    // If the fence ever moves below them it swallows Skip, and a user who
+    // cannot reach the target also cannot leave.
+    const fence = overlay.indexOf('<Cutout rect={ring} dim={false} />')
+    const skip = overlay.indexOf('onSkip')
+    const caption = overlay.indexOf("pointerEvents: 'auto', maxWidth:")
+    expect(fence).toBeGreaterThan(-1)
+    expect(caption).toBeGreaterThan(fence)
+    expect(skip).toBeGreaterThan(-1)
+  })
+})

--- a/ui/__tests__/tutorial-sample-day.test.ts
+++ b/ui/__tests__/tutorial-sample-day.test.ts
@@ -717,7 +717,7 @@ describe('the tour overlay draws what it means to', () => {
     // Both bubbles take the SAME surface constant, and neither styles its own.
     // They drifted apart once already - one inverted, one not, at different
     // sizes - which is how the tour ended up with two voices.
-    const anchored = between(overlay, 'function AnchoredCaption', 'function DimCutout')
+    const anchored = between(overlay, 'function AnchoredCaption', 'function Cutout')
     expect(anchored).toContain('...CAPTION_SURFACE')
     expect(anchored).not.toContain('background:')
     expect(overlay.match(/\.\.\.CAPTION_SURFACE/g)?.length).toBe(2)

--- a/ui/components/tutorial/TutorialOverlay.tsx
+++ b/ui/components/tutorial/TutorialOverlay.tsx
@@ -244,7 +244,27 @@ export function TutorialOverlay({ caption, centered, big, celebrate, cursorAt, c
       {/* The dimmed variant: four blurred panels fenced around the target,
           leaving it sharp, lit and the only clickable thing on screen.
           Rendered BEFORE the ring and cursor so those stay crisp on top. */}
-      {ring && spotlightDim && <DimCutout rect={ring} />}
+      {/* THE FENCE. While the tour is waiting on one specific click, everything
+          outside the spotlight stops taking clicks.
+
+          Without it the only beat that protected itself was the dimmed one,
+          because blocking was a side effect of the blur rather than a thing
+          anyone had asked for. Every other beat left the whole app live behind
+          a ring - including the close X on whatever modal the tour had just
+          opened. Clicking it does not fail: the modal closes, the tour keeps
+          waiting for a click on a target that is no longer on screen, and the
+          user is left reading an instruction about a window they cannot see.
+
+          Gated on `awaiting` on purpose. A fence that stands during narration
+          beats would make the app feel frozen for reasons the user cannot see;
+          one that stands only while the tour is genuinely blocked on them is
+          the difference between guiding and trapping.
+
+          Rendered BEFORE the caption, the choice buttons and Skip, so those
+          later siblings paint on top and keep their own `pointerEvents:'auto'`.
+          The way out is always one click away. */}
+      {ring && spotlightDim && <Cutout rect={ring} dim />}
+      {ring && !spotlightDim && awaiting && <Cutout rect={ring} dim={false} />}
 
       {/* Spotlight — a ring around the real control. On its own (the default)
           it adds no scrim at all: the target stays fully interactive because
@@ -591,8 +611,11 @@ function AnchoredCaption({ rect, children }: { rect: DOMRect; children: React.Re
  *
  *  These DO take pointer events, which is half the point — while the tour is
  *  waiting on one specific click, a stray click into the blurred area should
- *  land on nothing rather than on some control the user cannot see clearly. */
-function DimCutout({ rect }: { rect: DOMRect }) {
+ *  land on nothing rather than on some control the user cannot see clearly.
+ *
+ *  `dim: false` renders the same four panes completely invisible — see
+ *  [`Cutout`]'s note on why the fence and the blur are one component. */
+function Cutout({ rect, dim }: { rect: DOMRect; dim: boolean }) {
   const PAD = 8
   const l = Math.max(0, rect.left - PAD)
   const t = Math.max(0, rect.top - PAD)
@@ -605,14 +628,16 @@ function DimCutout({ rect }: { rect: DOMRect }) {
     // gradient, so a `color-mix` against it is invalid and drops the declaration
     // outright. This read as "blur only, no dimming" for as long as it has
     // existed - the panes were doing half their job silently.
-    background: 'rgba(20,16,40,0.42)',
-    backdropFilter: 'blur(5px)',
-    WebkitBackdropFilter: 'blur(5px)',
+    ...(dim ? {
+      background: 'rgba(20,16,40,0.42)',
+      backdropFilter: 'blur(5px)',
+      WebkitBackdropFilter: 'blur(5px)',
+      animation: 'mer-tour-dim .45s ease both',
+    } : null),
     // The panes travel with the hole rather than being re-laid instantly, so a
     // dimmed beat handing over to the next one reads as the light moving.
     transition: 'left .5s cubic-bezier(.22,1,.32,1), top .5s cubic-bezier(.22,1,.32,1),'
       + ' width .5s cubic-bezier(.22,1,.32,1), height .5s cubic-bezier(.22,1,.32,1)',
-    animation: 'mer-tour-dim .45s ease both',
   }
   return (
     <>


### PR DESCRIPTION
**Re-lands #746, whose content never reached `pre-main`.**

## What happened

#746 was stacked on #745 with base `fix/walkthrough-spotlight-voice`. #745 merged to `pre-main` at **15:18:57**; #746 merged under three minutes later, before GitHub had retargeted the stacked base. So #746 merged into its now-stale base branch instead of `pre-main`.

GitHub reports it `MERGED` - true, just not into the branch anyone wanted. `v1.86.0-staging.1` shipped without it.

The same thing happened to #742 (sibling recovery PR #751). Both of the two stacked PRs hit it; none of the six independent ones did.

## How this was caught

Not by the PR state, which is green and misleading. By grepping the staging tag for a symbol from each of the eight fixes - six present, two missing.

## How the content was recovered

**File by file** from the branch that received the merge, never as a wholesale diff. A two-dot diff of that stale branch against current `pre-main` would have **reverted the six PRs that did land** - 711 deletions across the tray, the setup wizard and the walkthrough. Only the three files #746 owned were taken, and the resulting delta against `pre-main` was checked to be exactly #746 and nothing else.

Note `tutorial-sample-day.test.ts` is in that set for a one-line marker rename (`DimCutout` -> `Cutout`). It was safe to take wholesale here because the stacked branch already carried #745, which is on `pre-main` - the file differed by exactly that one line. The equivalent file was deliberately NOT taken for #751, whose branch predates #745.

Content is byte-identical to what was reviewed on #746.

## Test plan

- [x] Delta vs `pre-main` verified as exactly the 3 files from #746 - 103 insertions, 8 deletions.
- [x] `bun test` (ui/) - 742 pass, 0 fail, including the 4 click-fence tests.
- [x] `tsc --noEmit` clean.
- [x] Full `pre-push` hook passed on push.
- [ ] Still not verified live - the check carries over from #746: Skip and the choice buttons must stay clickable while the fence is up.

## After merging

`v1.86.0-staging.1` is missing this and the Notifications pane art, so it needs a new staging release once both land.