### PR TITLE
chore(config): cut .env.example to what a dev build actually needs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,15 +14,16 @@
 # SETUP.md.
 #
 # What is left is the four identity keys a RELEASE bakes in at compile time from
-# CI secrets. A source checkout has none of them, so the matching connect button
-# is dead until you set one here — or worse, in Clerk's case, quietly points at
-# production.
+# CI secrets. A source checkout has none of them, so each one's connect button is
+# dead until you set it here. All four fail closed — nothing here can misfire
+# against production if you leave it unset.
 
-# SET THIS ONE. It is the only key here that does not fail closed: with no
-# override the tray falls back to the compiled-in PRODUCTION Clerk key, so a dev
-# build signs you in against the real user directory. Read straight out of this
-# file by the tray (`install::env_key_from_path`), not via dotenvy, so no shell
-# export is needed. Get it with `clerk env pull` after
+# Email sign-in. On a source build the compiled-in constant is EMPTY (the CI env
+# var that fills it is only set by the release workflows), so sign-in does not
+# work until you put the DEV instance key here — packaged builds, staging
+# included, always use the production instance. Read straight out of this file by
+# the tray (`install::env_key_from_path`), not via dotenvy, so no shell export is
+# needed. Get it with `clerk env pull` after
 # `clerk link --app app_3GIemyKuI07XdI7jFuYxpBqy9y3`. Publishable key only —
 # never set CLERK_SECRET_KEY, the tray has no server-side use for it.
 # CLERK_PUBLISHABLE_KEY=pk_test_your_publishable_key_here

--- a/.env.example
+++ b/.env.example
@@ -4,20 +4,19 @@
 # one. Never commit the real .env — it contains secrets.
 #
 # NOTHING HERE IS REQUIRED TO BOOT. `bash dev-start.sh` runs the daemon and tray
-# on defaults alone, and the setup wizard writes tracker credentials for you.
+# on defaults alone.
 #
-# Only keys with no working default are listed. Tuning knobs (poll interval,
-# retention, worklog thresholds, distiller and embedder settings, log levels,
-# ports) are not: they all have defaults, and restating a default here just
-# creates a second place for it to go stale. See CLAUDE.md's env table and
+# This file is ONLY for what the app cannot get for you. Connect Jira, GitHub,
+# Linear, Trello or Azure DevOps in the setup wizard or Settings — those
+# credentials are written for you and do not belong here. Tuning knobs (poll
+# interval, retention, worklog thresholds, distiller and embedder settings, log
+# levels, ports) all ship with working defaults; see CLAUDE.md's env table and
 # SETUP.md.
-
-# ===========================================================================
-# SOURCE BUILD
 #
-# A release bakes these in from CI secrets. A checkout has none of them, so the
-# matching feature is dead — or worse, in Clerk's case, points at production.
-# ===========================================================================
+# What is left is the four identity keys a RELEASE bakes in at compile time from
+# CI secrets. A source checkout has none of them, so the matching connect button
+# is dead until you set one here — or worse, in Clerk's case, quietly points at
+# production.
 
 # SET THIS ONE. It is the only key here that does not fail closed: with no
 # override the tray falls back to the compiled-in PRODUCTION Clerk key, so a dev
@@ -28,61 +27,20 @@
 # never set CLERK_SECRET_KEY, the tray has no server-side use for it.
 # CLERK_PUBLISHABLE_KEY=pk_test_your_publishable_key_here
 
-# Jira browser OAuth. Without it, `meridian oauth-login jira` fails with "Jira
-# OAuth requires a client secret..." — ask a Meridiona team member, or use the
-# static API token below instead, which needs nothing baked in.
-# (The matching client id has a working default; override it only for a custom
-# app or Jira Data Center.)
+# Jira's "Connect with browser" button. Without it, `meridian oauth-login jira`
+# fails with "Jira OAuth requires a client secret..." — ask a Meridiona team
+# member. The API-token path in Settings needs nothing baked in, so it works on
+# a checkout either way. (The matching client id has a working default; override
+# it only for a custom app or Jira Data Center.)
 # JIRA_OAUTH_CLIENT_SECRET=your-atlassian-app-client-secret
 
-# GitHub's OAuth device flow (the dashboard's "Browser" connect). Public
-# identifier, no secret. Without it, use a classic PAT as GITHUB_TOKEN below.
+# GitHub's "Connect with browser" button (the OAuth device flow). Public
+# identifier, no secret. Without it, connect with a classic PAT in Settings
+# instead. A custom OAuth App must have "Enable Device Flow" checked.
 # GITHUB_OAUTH_CLIENT_ID=Ov23li_your_oauth_app_client_id
 
-# Trello OAuth. The baked-in default is an EMPTY sentinel
-# (`meridian-oauth/src/trello.rs`), so Trello cannot connect on a checkout at
-# all until this is set. Injected into the bundle by package-release.sh.
+# Trello. The baked-in default is an EMPTY sentinel
+# (`meridian-oauth/src/trello.rs`), and OAuth is Trello's only auth path, so
+# Trello cannot be connected on a checkout at all until this is set. Injected
+# into the bundle by package-release.sh.
 # TRELLO_APP_KEY=
-
-# ===========================================================================
-# TRACKER CREDENTIALS — only for the tracker you actually use
-#
-# The setup wizard writes these for you, and connecting a tracker is optional:
-# skip it and Meridian still records your day, it just has nothing to draft
-# worklogs against. Set them here to configure a tracker without the wizard.
-# ===========================================================================
-
-# Jira — static API token, the alternative to the browser OAuth above.
-# JIRA_BASE_URL is an accepted alias; JIRA_URL wins when both are set.
-# JIRA_URL=https://your-org.atlassian.net
-# JIRA_EMAIL=you@your-org.com
-# JIRA_API_TOKEN=your-api-token-here
-
-# GitHub — classic PAT scopes: `repo`, `read:org`, `read:project`.
-#
-# BOTH are required. Unlike every other tracker's filter, an empty
-# GITHUB_PROJECT_IDS does not mean "all" — it skips the GitHub sync entirely
-# ("no GITHUB_PROJECT_IDS configured — skipping github sync"). List the
-# Projects v2 node IDs to sync:
-#   gh api graphql -f query='{ viewer { projectsV2(first:10){nodes{id title}} } }'
-# GITHUB_TOKEN=ghp_your_personal_access_token
-# GITHUB_PROJECT_IDS=PVT_xxx,PVT_yyy
-
-# Linear — linear.app > Settings > Account > Security & access > Personal API keys.
-# LINEAR_API_KEY=lin_api_your_key_here
-
-# Azure DevOps — paste the project URL from your browser; org and project are
-# auto-detected from any shape (dev.azure.com, *.visualstudio.com, on-prem TFS).
-# PAT: User settings → Personal access tokens, scope Work Items → Read & write.
-# AZURE_DEVOPS_URL=https://dev.azure.com/your-org/your-project
-# AZURE_DEVOPS_PAT=your-pat-here
-
-# ===========================================================================
-# There is deliberately no LLM API key, here or anywhere else.
-#
-# Summarising and task-matching run through the coding-agent CLI you already use
-# (Claude Code, Codex, Cursor, Copilot) on your own subscription, or a cloud
-# endpoint configured in the dashboard. ANTHROPIC_API_KEY is explicitly STRIPPED
-# from the child process (src/llm/claude.rs) so a stray key cannot silently
-# start billing you.
-# ===========================================================================

--- a/.env.example
+++ b/.env.example
@@ -1,35 +1,44 @@
 # ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 #
-# Copy this file to ~/.meridian/.env and fill in your credentials.
+# Copy this file to ~/.meridian/.env and fill in what you need.
 # The daemon loads ~/.meridian/.env automatically at startup.
 # Never commit the real .env — it contains secrets.
+#
+# EVERYTHING HERE IS OPTIONAL. A stock install needs none of it: the setup
+# wizard writes tracker credentials for you, and every value below has a working
+# default (shown after the `=`). Reach for this file to override a default or to
+# configure something the wizard does not cover.
+#
+# Every variable in this file is read by the code. Grep any name to find its
+# reader — if you add one here, add it there first.
 
 # ---------------------------------------------------------------------------
-# Core (optional — defaults shown)
+# Core
 # ---------------------------------------------------------------------------
 
 # MERIDIAN_DB=~/.meridian/meridian.db
 # POLL_INTERVAL_SECS=60
 # RUST_LOG=meridian=info
 
-# Classification and summarisation run through the LLM provider you configure —
-# the coding-agent CLI you already use (Claude Code, Codex, Cursor, Copilot) or a
-# cloud endpoint. There is no on-device generative model and no local inference
-# server; see the LLM provider settings further down.
+# SQLCipher key for meridian.db (64 hex chars). Generated once by the tray, kept
+# in the OS keychain, and mirrored here for the daemon to read. DO NOT set this
+# by hand outside local testing — a wrong value makes the database unreadable.
+# MERIDIAN_DB_KEY=
 
-# Dashboard (Next.js UI) port. Defaults to 3939. Change this and re-run
-# `meridian setup` to move the dashboard.
-# MERIDIAN_UI_PORT=3939
+# Local hours the "office day" spans, used when attributing work to a day.
+# Start is inclusive, end is exclusive.
+# OFFICE_START_HOUR=9
+# OFFICE_END_HOUR=17
 
 # ---------------------------------------------------------------------------
 # Jira — choose ONE auth path:
 #
-#   (A) Browser OAuth (recommended): just run  `meridian oauth-login jira`.
+#   (A) Browser OAuth (recommended): run  `meridian oauth-login jira`.
 #       It opens your browser, you click Accept, and tokens land in
 #       ~/.meridian/oauth/jira.json (auto-refreshed). No env vars, no API
 #       token; the site is discovered automatically. Then `meridian restart`.
 #
-#   (B) Static API token (legacy): set JIRA_BASE_URL + JIRA_EMAIL + JIRA_API_TOKEN.
+#   (B) Static API token (legacy): set JIRA_URL + JIRA_EMAIL + JIRA_API_TOKEN.
 #
 # If both are present, OAuth wins. JIRA_PROJECT_KEYS applies to either.
 # ---------------------------------------------------------------------------
@@ -45,43 +54,18 @@
 # JIRA_OAUTH_REDIRECT_PORT=9123      # must match the app's registered redirect
                                      # http://127.0.0.1:<port>/callback
 
-# (B) Static API token
-# JIRA_BASE_URL=https://your-org.atlassian.net
+# (B) Static API token. JIRA_BASE_URL is accepted as an alias for JIRA_URL;
+#     JIRA_URL wins when both are set, so prefer it and set only one.
+# JIRA_URL=https://your-org.atlassian.net
 # JIRA_EMAIL=you@your-org.com
 # JIRA_API_TOKEN=your-api-token-here
 
 # JIRA_PROJECT_KEYS=KAN,ENG          # optional — comma-separated; empty = all projects
 
-# ---------------------------------------------------------------------------
-# PM worklog (Stage 4) — worklogs from classified sessions, for whichever
-# tracker is configured above (Jira, Linear, or GitHub).
-# Runs inside the Rust daemon: one hour-driven worklog per task per hour,
-# drafted through the LLM provider you configured.
-#
-# How each tracker records a worklog:
-#   Jira   — native worklog API (time spent + comment).
-#   Linear — a structured comment on the issue (Linear has no time-tracking API).
-#   GitHub — a structured comment on the issue (GitHub has no time tracking).
-# ---------------------------------------------------------------------------
-
-# Nothing posts to your tracker automatically. The daemon DRAFTS worklogs every
-# hour; you review, edit, and approve each one in the dashboard (Worklogs view),
-# and the daemon posts approved worklogs within ~60s. Approval is the only gate —
-# there is no auto-post switch.
-
-# Driver cadence in hours (clamped to a 60s floor). Default 1.0.
-# PM_WORKLOG_INTERVAL_HOURS=1.0
-
-# Routing thresholds before a drafted worklog is eligible to post.
-# PM_WORKLOG_MIN_CONFIDENCE=0.65
-# PM_WORKLOG_MIN_COVERAGE=0.80
-
-# A session still settling longer than this many minutes is treated as ready so
-# one stuck row can't deadlock an hour (the readiness aging escape).
-# PM_WORKLOG_READINESS_AGING_MIN=90
-
-# Jira's hard floor — worklogs below this many real seconds are never posted.
-# PM_WORKLOG_MIN_POST_SECONDS=60
+# Periodic refresh of the Jira task cache. Enabled by default whenever Jira is
+# configured; set to 0/false/no/off to stop the refresh without disconnecting.
+# JIRA_UPDATE_ENABLED=1
+# JIRA_UPDATE_INTERVAL_HOURS=4
 
 # ---------------------------------------------------------------------------
 # GitHub (GITHUB_TOKEN required; GITHUB_PROJECT_IDS selects which Projects sync)
@@ -124,7 +108,10 @@
 # real key to source. Users connect with their own Trello account via OAuth;
 # their personal token lands in ~/.meridian/oauth/trello.json.
 # ---------------------------------------------------------------------------
+
 # TRELLO_APP_KEY=                     # injected at package time
+# TRELLO_BOARD_IDS=abc123,def456      # optional — comma-separated; empty = all boards
+# TRELLO_OAUTH_REDIRECT_PORT=9123     # must match the registered redirect
 
 # ---------------------------------------------------------------------------
 # Azure DevOps / VSTS — just two variables needed.
@@ -139,54 +126,61 @@
 # AZURE_DEVOPS_PAT: create at User settings → Personal access tokens → New token.
 #   Required scope: Work Items → Read & write.
 #   Use an org-scoped PAT (global PATs are being retired by Microsoft).
+#
+# AZURE_DEVOPS_ORG / AZURE_DEVOPS_PROJECT / AZURE_DEVOPS_ORG_URL are only for the
+# rare case where the URL cannot be parsed — set them instead of AZURE_DEVOPS_URL.
 # ---------------------------------------------------------------------------
 
 # AZURE_DEVOPS_URL=https://dev.azure.com/your-org/your-project
 # AZURE_DEVOPS_PAT=your-pat-here
 
 # ---------------------------------------------------------------------------
-# PostHog product analytics (tray/DMG build only)
+# PM worklog — worklogs from classified sessions, for whichever tracker is
+# configured above. Runs inside the Rust daemon: one hour-driven worklog per
+# task per hour, drafted through the LLM provider you configured.
 #
-# A release build bakes the PostHog project API key in at compile time
-# (CI-only, from the POSTHOG_API_KEY repo secret; never committed to source).
-# A LOCAL SOURCE BUILD (cargo run / npm run tauri dev) has no baked-in key, so
-# analytics compiles in silently disabled unless you set POSTHOG_API_KEY below
-# — only needed if you're specifically testing the analytics capture path.
-# ---------------------------------------------------------------------------
-
-# POSTHOG_API_KEY=phc_your_project_api_key_here
-
-# ---------------------------------------------------------------------------
-# Clerk email sign-in (setup wizard's Sign-in step, tray/DMG build only)
+# How each tracker records a worklog:
+#   Jira          — native worklog API (time spent + comment).
+#   Linear        — a structured comment on the issue.
+#   GitHub        — a structured comment on the issue.
+#   Trello        — a comment on the card.
+#   Azure DevOps  — a comment on the work item.
 #
-# A release build bakes the Clerk publishable key in at compile time (CI-only,
-# from the MERIDIAN_CLERK_PUBLISHABLE_KEY repo secret; never committed to
-# source) — see tray/src-tauri/src/commands/account.rs. A LOCAL SOURCE BUILD
-# has no baked-in key, so set CLERK_PUBLISHABLE_KEY below and the tray will
-# pick it up on the next `cargo run`/`npm run tauri dev` — unlike most of this
-# file, the tray reads this ONE key straight out of this file itself (see
-# `install::env_key_from_path`), not via dotenvy auto-load, so no shell
-# export is needed. Get the dev instance's key with `clerk env pull` after
-# `clerk link --app app_3GIemyKuI07XdI7jFuYxpBqy9y3` (publishable key only —
-# this is a public identifier, safe to keep here; never set CLERK_SECRET_KEY,
-# the tray has no server-side use for it).
+# Nothing posts to your tracker automatically. The daemon DRAFTS worklogs every
+# hour; you review, edit, and approve each one in the dashboard (Worklogs view),
+# and the daemon posts approved worklogs within ~60s. Approval is the only gate —
+# there is no auto-post switch.
 # ---------------------------------------------------------------------------
 
-# CLERK_PUBLISHABLE_KEY=pk_test_your_publishable_key_here
+# Driver cadence in hours (clamped to a 60s floor).
+# PM_WORKLOG_INTERVAL_HOURS=1.0
+
+# Routing thresholds before a drafted worklog is eligible to post.
+# PM_WORKLOG_MIN_CONFIDENCE=0.65
+# PM_WORKLOG_MIN_COVERAGE=0.80
+
+# A session still settling longer than this many minutes is treated as ready so
+# one stuck row can't deadlock an hour (the readiness aging escape).
+# PM_WORKLOG_READINESS_AGING_MIN=90
+
+# Jira's hard floor — worklogs below this many real seconds are never posted.
+# PM_WORKLOG_MIN_POST_SECONDS=60
 
 # ---------------------------------------------------------------------------
-# LLM credentials
+# LLM provider
+#
+# Summarising and task-matching run through the coding-agent CLI you already use
+# (Claude Code, Codex, Cursor, Copilot) or a cloud endpoint you configure in the
+# dashboard. There is no on-device generative model and no local inference server.
+#
+# There is deliberately no API-key variable here: the CLI providers authenticate
+# with your own subscription, and ANTHROPIC_API_KEY is explicitly STRIPPED from
+# the child process (src/llm/claude.rs) so a stray key cannot silently start
+# billing you. Cloud-endpoint credentials belong in the dashboard's settings.
 # ---------------------------------------------------------------------------
 
-# ANTHROPIC_API_KEY=sk-ant-...      # used by the coding-agent summariser's Claude path
-
-# Jira — legacy alias. The Rust daemon reads JIRA_BASE_URL above; set both to
-# the same value when Jira is configured.
-# JIRA_URL=https://your-org.atlassian.net
-
-# Hard kill switch for local OTel capture (read by the daemon and the tray —
-# see CLAUDE.md's observability env var table).
-# MERIDIAN_TELEMETRY_DISABLED=0
+# Per-call timeout for a provider CLI, in seconds.
+# LLM_CLI_TIMEOUT_S=300
 
 # ---------------------------------------------------------------------------
 # Coding-agent ingest (optional — all defaults are correct on a stock machine)
@@ -206,19 +200,84 @@
 # ANTIGRAVITY_APP_DIR=~/Library/Application Support/Antigravity
 
 # ---------------------------------------------------------------------------
-# OpenObserve / OpenTelemetry (optional — enables distributed tracing and
-# structured log ingestion into a local OpenObserve instance)
+# Retention
 # ---------------------------------------------------------------------------
 
-# DEPRECATED — ignored everywhere. Set OpenObserve credentials in the dashboard
-# Settings instead (stored in settings.json). Kept only as an installer fallback
-# for old setups.
-# Generate: echo -n "you@your-org.com:yourpassword" | base64
-# MERIDIAN_OO_AUTH=base64encodedcredentials
+# Age floor for the capture_frames / capture_ui_events sweep, in days. Only rows
+# BOTH older than this AND already consumed by the ETL cursor are pruned.
+# MERIDIAN_CAPTURE_RETENTION_DAYS=30
 
-# OTLP/HTTP trace endpoint (Rust daemon)
+# How long spooled telemetry is kept (pending/ and sent/ alike), in days.
+# MERIDIAN_TELEMETRY_RETENTION_DAYS=7
+
+# Size cap for each launchd-redirected raw log file, in MB (copytruncate).
+# MERIDIAN_LAUNCHD_LOG_MAX_MB=10
+
+# ---------------------------------------------------------------------------
+# Session distiller and embedder (advanced — defaults are tuned; change only
+# with a measurement in hand)
+# ---------------------------------------------------------------------------
+
+# Cosine threshold for semantic dedup of session text.
+# DISTILLER_SEM_DEDUP_THR=0.86
+
+# Document-frequency fraction above which a phrase is treated as boilerplate.
+# DISTILLER_DF_FRAC=0.25
+
+# Sessions shorter than this many seconds are skipped.
+# DISTILLER_MIN_SESSION_DUR=15
+
+# Timeout for one embedding batch, in seconds.
+# DISTILLER_EMBED_TIMEOUT_SECS=210
+
+# Where the local embedding weights live, and which repo they come from.
+# MERIDIAN_EMBEDDER_DIR=~/.meridian/models/bge-small-en-v1.5
+# MERIDIAN_EMBEDDER_REPO=BAAI/bge-small-en-v1.5
+# EMBEDDER_BATCH_SIZE=32
+
+# ---------------------------------------------------------------------------
+# Observability
+#
+# Local OTel capture to ~/.meridian/telemetry/ is the sole log/trace sink, and it
+# is a disk write, not a network call — it works with no configuration and never
+# depends on OpenObserve being reachable. Read it back with `meridian logs`.
+#
+# OpenObserve CREDENTIALS are NOT set here: put oo_email / oo_password in the
+# dashboard's Settings (they land in settings.json), which is what both the
+# daemon and the tray read.
+# ---------------------------------------------------------------------------
+
+# Hard kill switch for local OTel capture (read by the daemon and the tray).
+# Disabling it leaves only launchd's raw stdout/stderr crash-safety-net files.
+# MERIDIAN_TELEMETRY_DISABLED=0
+
+# OTLP/HTTP trace endpoint, consulted only on the dev/bare shipping path — a
+# packaged install ships to the release-baked central gateway instead.
 # MERIDIAN_OTLP_ENDPOINT=http://localhost:5080/api/default/v1/traces
 
-# Log level. DEBUG dumps full session text and raw LLM prompts — local only,
-# but avoid it on a machine whose logs you intend to share.
-# LOG_LEVEL=INFO
+# Log level for the TypeScript MCP server (packages/meridian-mcp) only; the Rust
+# daemon uses RUST_LOG above.
+# LOG_LEVEL=info
+
+# ---------------------------------------------------------------------------
+# Local source builds only
+#
+# A release build bakes these in at compile time from CI secrets, so they are
+# never needed on an installed copy. A source build has no baked-in value, so the
+# matching feature compiles in silently disabled until you set one here.
+# ---------------------------------------------------------------------------
+
+# Clerk email sign-in (setup wizard's Sign-in step). The tray reads this ONE key
+# straight out of this file (see `install::env_key_from_path`), not via dotenvy,
+# so no shell export is needed. Publishable key only — it is a public identifier;
+# never set CLERK_SECRET_KEY, the tray has no server-side use for it.
+# CLERK_PUBLISHABLE_KEY=pk_test_your_publishable_key_here
+
+# PostHog product analytics. Only needed if you are specifically testing the
+# analytics capture path.
+# POSTHOG_API_KEY=phc_your_project_api_key_here
+
+# Port for `next dev` / the Tauri devUrl, and the port `meridian doctor` probes
+# for the dashboard's health endpoint. No effect on an installed build — there
+# the dashboard is a static export bundled inside the tray, with no server.
+# MERIDIAN_UI_PORT=3939

--- a/.env.example
+++ b/.env.example
@@ -1,283 +1,149 @@
 # ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 #
-# Copy this file to ~/.meridian/.env and fill in what you need.
-# The daemon loads ~/.meridian/.env automatically at startup.
-# Never commit the real .env — it contains secrets.
+# Copy this file to .env (repo root) for a dev build, or to ~/.meridian/.env for
+# an installed one. Never commit the real .env — it contains secrets.
 #
-# EVERYTHING HERE IS OPTIONAL. A stock install needs none of it: the setup
-# wizard writes tracker credentials for you, and every value below has a working
-# default (shown after the `=`). Reach for this file to override a default or to
-# configure something the wizard does not cover.
+# NOTHING HERE IS REQUIRED TO BOOT. `bash dev-start.sh` runs the daemon and tray
+# on defaults alone, and the setup wizard writes tracker credentials for you.
 #
-# Every variable in this file is read by the code. Grep any name to find its
-# reader — if you add one here, add it there first.
+# What this file is actually for is the gap a SOURCE BUILD has: a release bakes
+# four OAuth/app keys in at compile time from CI secrets, and a source checkout
+# has none of them, so those features are silently dead until you set them here.
+# That is the first section. Everything after it is optional.
+#
+# Tuning knobs (poll interval, retention, worklog thresholds, distiller and
+# embedder settings, log levels, ports) are deliberately NOT listed. They all
+# ship with working defaults, and a commented-out line restating a default is
+# just a second place for it to go stale. See CLAUDE.md's environment-variable
+# table and SETUP.md.
+
+# ===========================================================================
+# SOURCE BUILD — the keys a release bakes in and a checkout does not have
+# ===========================================================================
+
+# Clerk email sign-in (the setup wizard's Sign-in step).
+#
+# SET THIS ONE. Unlike the others it does not fail closed: with no override the
+# tray falls back to the compiled-in PRODUCTION instance key, so a dev build
+# signs you in against the real user directory. Setting the dev instance key
+# here keeps a source checkout pointed at the dev instance instead.
+#
+# The tray reads this key straight out of this file (see
+# `install::env_key_from_path`), not via dotenvy, so no shell export is needed.
+# Get it with `clerk env pull` after
+# `clerk link --app app_3GIemyKuI07XdI7jFuYxpBqy9y3`. Publishable key only — it
+# is a public identifier; never set CLERK_SECRET_KEY, the tray has no
+# server-side use for it.
+# CLERK_PUBLISHABLE_KEY=pk_test_your_publishable_key_here
+
+# Jira browser OAuth (`meridian oauth-login jira`).
+# Without the secret, login fails with "Jira OAuth requires a client secret..."
+# — ask a Meridiona team member for it, or use the static API token path below
+# instead, which needs nothing baked in.
+# JIRA_OAUTH_CLIENT_ID=your-atlassian-app-client-id
+# JIRA_OAUTH_CLIENT_SECRET=your-atlassian-app-client-secret
+
+# GitHub's OAuth device flow (the dashboard's "Browser" connect).
+# Public identifier, no secret. A custom OAuth App must have "Enable Device
+# Flow" checked. Without it, use a classic PAT as GITHUB_TOKEN below.
+# GITHUB_OAUTH_CLIENT_ID=Ov23li_your_oauth_app_client_id
+
+# Trello browser OAuth (`meridian oauth-login trello`).
+# Meridian's Power-Up identity key, like an OAuth client_id. The baked-in
+# default is an EMPTY sentinel (`meridian-oauth/src/trello.rs`), so Trello OAuth
+# cannot work on a source build at all until this is set. Injected into the
+# bundle .env by package-release.sh — never commit the real key.
+# TRELLO_APP_KEY=
+
+# PostHog product analytics. Only needed if you are specifically testing the
+# analytics capture path; otherwise analytics stays silently disabled, which is
+# the right behaviour for a dev build.
+# POSTHOG_API_KEY=phc_your_project_api_key_here
+
+# ===========================================================================
+# OPTIONAL — connecting a tracker by hand
+#
+# The setup wizard does all of this for you, and connecting a tracker is itself
+# optional: skip it and Meridian still records your day, it just has nothing to
+# draft worklogs against. Set these to configure a tracker without the wizard.
+# ===========================================================================
 
 # ---------------------------------------------------------------------------
-# Core
+# Jira — static API token (the alternative to browser OAuth above).
+# JIRA_BASE_URL is accepted as an alias for JIRA_URL; JIRA_URL wins when both
+# are set, so set only one.
 # ---------------------------------------------------------------------------
 
-# MERIDIAN_DB=~/.meridian/meridian.db
-# POLL_INTERVAL_SECS=60
-# RUST_LOG=meridian=info
-
-# SQLCipher key for meridian.db (64 hex chars). Generated once by the tray, kept
-# in the OS keychain, and mirrored here for the daemon to read. DO NOT set this
-# by hand outside local testing — a wrong value makes the database unreadable.
-# MERIDIAN_DB_KEY=
-
-# Local hours the "office day" spans, used when attributing work to a day.
-# Start is inclusive, end is exclusive.
-# OFFICE_START_HOUR=9
-# OFFICE_END_HOUR=17
-
-# ---------------------------------------------------------------------------
-# Jira — choose ONE auth path:
-#
-#   (A) Browser OAuth (recommended): run  `meridian oauth-login jira`.
-#       It opens your browser, you click Accept, and tokens land in
-#       ~/.meridian/oauth/jira.json (auto-refreshed). No env vars, no API
-#       token; the site is discovered automatically. Then `meridian restart`.
-#
-#   (B) Static API token (legacy): set JIRA_URL + JIRA_EMAIL + JIRA_API_TOKEN.
-#
-# If both are present, OAuth wins. JIRA_PROJECT_KEYS applies to either.
-# ---------------------------------------------------------------------------
-
-# (A) OAuth in a RELEASE build needs NO config — Meridian ships a public client id
-#     and bakes the matching client secret in at build time (CI-only; never
-#     committed). A LOCAL SOURCE BUILD (cargo run / npm run tauri dev) has no
-#     baked-in secret, so browser OAuth login always fails there with "Jira
-#     OAuth requires a client secret..." until you set JIRA_OAUTH_CLIENT_SECRET
-#     below (ask a Meridiona team member for it) — or just use (B) instead.
-# JIRA_OAUTH_CLIENT_ID=your-atlassian-app-client-id   # override the baked-in client id
-# JIRA_OAUTH_CLIENT_SECRET=your-atlassian-app-client-secret  # REQUIRED for OAuth on a source build
-# JIRA_OAUTH_REDIRECT_PORT=9123      # must match the app's registered redirect
-                                     # http://127.0.0.1:<port>/callback
-
-# (B) Static API token. JIRA_BASE_URL is accepted as an alias for JIRA_URL;
-#     JIRA_URL wins when both are set, so prefer it and set only one.
 # JIRA_URL=https://your-org.atlassian.net
 # JIRA_EMAIL=you@your-org.com
 # JIRA_API_TOKEN=your-api-token-here
 
-# JIRA_PROJECT_KEYS=KAN,ENG          # optional — comma-separated; empty = all projects
-
-# Periodic refresh of the Jira task cache. Enabled by default whenever Jira is
-# configured; set to 0/false/no/off to stop the refresh without disconnecting.
-# JIRA_UPDATE_ENABLED=1
-# JIRA_UPDATE_INTERVAL_HOURS=4
+# Restrict the sync to these projects. Omit to sync all of them.
+# JIRA_PROJECT_KEYS=KAN,ENG
 
 # ---------------------------------------------------------------------------
-# GitHub (GITHUB_TOKEN required; GITHUB_PROJECT_IDS selects which Projects sync)
-# Syncs the OPEN issues assigned to you from the listed GitHub Projects v2 (read
-# via the GraphQL API); logs worklogs as structured issue comments (GitHub has no
-# native time tracking).
-# Token: easiest is the dashboard's "Browser" connect — it runs GitHub's OAuth
-# device flow (shows a one-time code, no PAT, no CLI) and writes GITHUB_TOKEN
-# here for you. Otherwise create a classic PAT with the `repo`, `read:org`,
-# `read:project` scopes (read:project reads Projects; repo posts worklog comments).
+# GitHub — syncs the OPEN issues assigned to you from the listed Projects v2,
+# and logs worklogs as structured issue comments (no native time tracking).
+#
+# Classic PAT scopes: `repo`, `read:org`, `read:project` (read:project reads
+# Projects; repo posts the worklog comments).
+#
 # GITHUB_PROJECT_IDS: comma-separated Projects v2 node IDs (PVT_xxx). Find them:
 #   gh api graphql -f query='{ viewer { projectsV2(first:10){nodes{id title}} } }'
-#
-# GITHUB_OAUTH_CLIENT_ID: overrides the baked-in OAuth App client id used by the
-# device flow (public identifier, no secret). Only needed for a SOURCE build (a
-# release bakes it in from the GH_OAUTH_CLIENT_ID repo secret via
-# MERIDIAN_GITHUB_OAUTH_CLIENT_ID) or a custom OAuth App — the app must have
-# "Enable Device Flow" checked.
 # ---------------------------------------------------------------------------
 
 # GITHUB_TOKEN=ghp_your_personal_access_token
 # GITHUB_PROJECT_IDS=PVT_xxx,PVT_yyy
-# GITHUB_OAUTH_CLIENT_ID=Ov23li_your_oauth_app_client_id
 
 # ---------------------------------------------------------------------------
-# Linear (LINEAR_API_KEY required to enable the Linear connector)
-# Syncs the issues assigned to you; logs worklogs as structured issue comments
-# (Linear has no native time-tracking API).
+# Linear — syncs the issues assigned to you; worklogs are issue comments.
 # Key: linear.app > Settings > Account > Security & access > Personal API keys.
 # Sent raw in the Authorization header (no "Bearer" prefix).
 # ---------------------------------------------------------------------------
 
 # LINEAR_API_KEY=lin_api_your_key_here
-# LINEAR_TEAM_IDS=ENG,DESIGN          # optional — comma-separated team KEY or id; empty = all teams
+
+# Restrict the sync to these teams (KEY or id). Omit to sync all of them.
+# LINEAR_TEAM_IDS=ENG,DESIGN
 
 # ---------------------------------------------------------------------------
-# Trello — browser OAuth (`meridian oauth-login trello`).
-# TRELLO_APP_KEY is Meridian's Power-Up identity key (like an OAuth client_id).
-# It is injected into the bundle .env by package-release.sh — never commit the
-# real key to source. Users connect with their own Trello account via OAuth;
-# their personal token lands in ~/.meridian/oauth/trello.json.
+# Trello — the personal token comes from OAuth (see TRELLO_APP_KEY above) and
+# lands in ~/.meridian/oauth/trello.json. Only the board filter is set here.
 # ---------------------------------------------------------------------------
 
-# TRELLO_APP_KEY=                     # injected at package time
-# TRELLO_BOARD_IDS=abc123,def456      # optional — comma-separated; empty = all boards
-# TRELLO_OAUTH_REDIRECT_PORT=9123     # must match the registered redirect
+# Restrict the sync to these boards. Omit to sync all of them.
+# TRELLO_BOARD_IDS=abc123,def456
 
 # ---------------------------------------------------------------------------
-# Azure DevOps / VSTS — just two variables needed.
+# Azure DevOps / VSTS
 #
-# AZURE_DEVOPS_URL: copy the project URL from your browser address bar.
-#   Works for all URL shapes — meridian auto-detects org and project:
+# AZURE_DEVOPS_URL: copy the project URL from your browser address bar. Works
+# for all URL shapes — Meridian auto-detects org and project:
 #
 #   Cloud (standard):  https://dev.azure.com/mycompany/MyProject
 #   Cloud (legacy):    https://mycompany.visualstudio.com/MyProject
 #   On-premises:       https://tfs.corp.com/DefaultCollection/MyProject
 #
-# AZURE_DEVOPS_PAT: create at User settings → Personal access tokens → New token.
+# AZURE_DEVOPS_PAT: User settings → Personal access tokens → New token.
 #   Required scope: Work Items → Read & write.
 #   Use an org-scoped PAT (global PATs are being retired by Microsoft).
 #
-# AZURE_DEVOPS_ORG / AZURE_DEVOPS_PROJECT / AZURE_DEVOPS_ORG_URL are only for the
-# rare case where the URL cannot be parsed — set them instead of AZURE_DEVOPS_URL.
+# If a URL shape ever fails to parse, set AZURE_DEVOPS_ORG and
+# AZURE_DEVOPS_PROJECT instead of AZURE_DEVOPS_URL.
 # ---------------------------------------------------------------------------
 
 # AZURE_DEVOPS_URL=https://dev.azure.com/your-org/your-project
 # AZURE_DEVOPS_PAT=your-pat-here
 
 # ---------------------------------------------------------------------------
-# PM worklog — worklogs from classified sessions, for whichever tracker is
-# configured above. Runs inside the Rust daemon: one hour-driven worklog per
-# task per hour, drafted through the LLM provider you configured.
-#
-# How each tracker records a worklog:
-#   Jira          — native worklog API (time spent + comment).
-#   Linear        — a structured comment on the issue.
-#   GitHub        — a structured comment on the issue.
-#   Trello        — a comment on the card.
-#   Azure DevOps  — a comment on the work item.
-#
-# Nothing posts to your tracker automatically. The daemon DRAFTS worklogs every
-# hour; you review, edit, and approve each one in the dashboard (Worklogs view),
-# and the daemon posts approved worklogs within ~60s. Approval is the only gate —
-# there is no auto-post switch.
-# ---------------------------------------------------------------------------
-
-# Driver cadence in hours (clamped to a 60s floor).
-# PM_WORKLOG_INTERVAL_HOURS=1.0
-
-# Routing thresholds before a drafted worklog is eligible to post.
-# PM_WORKLOG_MIN_CONFIDENCE=0.65
-# PM_WORKLOG_MIN_COVERAGE=0.80
-
-# A session still settling longer than this many minutes is treated as ready so
-# one stuck row can't deadlock an hour (the readiness aging escape).
-# PM_WORKLOG_READINESS_AGING_MIN=90
-
-# Jira's hard floor — worklogs below this many real seconds are never posted.
-# PM_WORKLOG_MIN_POST_SECONDS=60
-
-# ---------------------------------------------------------------------------
-# LLM provider
+# LLM provider — nothing to set, here or anywhere else in this file.
 #
 # Summarising and task-matching run through the coding-agent CLI you already use
 # (Claude Code, Codex, Cursor, Copilot) or a cloud endpoint you configure in the
-# dashboard. There is no on-device generative model and no local inference server.
+# dashboard. There is no on-device generative model.
 #
-# There is deliberately no API-key variable here: the CLI providers authenticate
-# with your own subscription, and ANTHROPIC_API_KEY is explicitly STRIPPED from
-# the child process (src/llm/claude.rs) so a stray key cannot silently start
-# billing you. Cloud-endpoint credentials belong in the dashboard's settings.
+# There is deliberately no API-key variable: the CLI providers authenticate with
+# your own subscription, and ANTHROPIC_API_KEY is explicitly STRIPPED from the
+# child process (src/llm/claude.rs) so a stray key cannot silently start billing
+# you. Cloud-endpoint credentials belong in the dashboard's settings.
 # ---------------------------------------------------------------------------
-
-# Per-call timeout for a provider CLI, in seconds.
-# LLM_CLI_TIMEOUT_S=300
-
-# ---------------------------------------------------------------------------
-# Coding-agent ingest (optional — all defaults are correct on a stock machine)
-# ---------------------------------------------------------------------------
-
-# Let the daemon install the cursor-agent CLI when a Cursor session needs
-# summarising and the CLI is missing. The installer is unpinned remote code
-# (curl https://cursor.com/install | bash), so this is an explicit opt-in;
-# when off, a Cursor session is left pending until the CLI is available.
-# CURSOR_AGENT_AUTO_INSTALL=0
-
-# Source-store location overrides (only needed for non-standard installs).
-# COPILOT_SESSION_STATE_DIR=~/.copilot/session-state
-# VSCODE_USER_DIR=~/Library/Application Support/Code/User
-# CURSOR_STATE_VSCDB=~/Library/Application Support/Cursor/User/globalStorage/state.vscdb
-# CURSOR_CLI_CHATS_DIR=~/.cursor/chats
-# ANTIGRAVITY_APP_DIR=~/Library/Application Support/Antigravity
-
-# ---------------------------------------------------------------------------
-# Retention
-# ---------------------------------------------------------------------------
-
-# Age floor for the capture_frames / capture_ui_events sweep, in days. Only rows
-# BOTH older than this AND already consumed by the ETL cursor are pruned.
-# MERIDIAN_CAPTURE_RETENTION_DAYS=30
-
-# How long spooled telemetry is kept (pending/ and sent/ alike), in days.
-# MERIDIAN_TELEMETRY_RETENTION_DAYS=7
-
-# Size cap for each launchd-redirected raw log file, in MB (copytruncate).
-# MERIDIAN_LAUNCHD_LOG_MAX_MB=10
-
-# ---------------------------------------------------------------------------
-# Session distiller and embedder (advanced — defaults are tuned; change only
-# with a measurement in hand)
-# ---------------------------------------------------------------------------
-
-# Cosine threshold for semantic dedup of session text.
-# DISTILLER_SEM_DEDUP_THR=0.86
-
-# Document-frequency fraction above which a phrase is treated as boilerplate.
-# DISTILLER_DF_FRAC=0.25
-
-# Sessions shorter than this many seconds are skipped.
-# DISTILLER_MIN_SESSION_DUR=15
-
-# Timeout for one embedding batch, in seconds.
-# DISTILLER_EMBED_TIMEOUT_SECS=210
-
-# Where the local embedding weights live, and which repo they come from.
-# MERIDIAN_EMBEDDER_DIR=~/.meridian/models/bge-small-en-v1.5
-# MERIDIAN_EMBEDDER_REPO=BAAI/bge-small-en-v1.5
-# EMBEDDER_BATCH_SIZE=32
-
-# ---------------------------------------------------------------------------
-# Observability
-#
-# Local OTel capture to ~/.meridian/telemetry/ is the sole log/trace sink, and it
-# is a disk write, not a network call — it works with no configuration and never
-# depends on OpenObserve being reachable. Read it back with `meridian logs`.
-#
-# OpenObserve CREDENTIALS are NOT set here: put oo_email / oo_password in the
-# dashboard's Settings (they land in settings.json), which is what both the
-# daemon and the tray read.
-# ---------------------------------------------------------------------------
-
-# Hard kill switch for local OTel capture (read by the daemon and the tray).
-# Disabling it leaves only launchd's raw stdout/stderr crash-safety-net files.
-# MERIDIAN_TELEMETRY_DISABLED=0
-
-# OTLP/HTTP trace endpoint, consulted only on the dev/bare shipping path — a
-# packaged install ships to the release-baked central gateway instead.
-# MERIDIAN_OTLP_ENDPOINT=http://localhost:5080/api/default/v1/traces
-
-# Log level for the TypeScript MCP server (packages/meridian-mcp) only; the Rust
-# daemon uses RUST_LOG above.
-# LOG_LEVEL=info
-
-# ---------------------------------------------------------------------------
-# Local source builds only
-#
-# A release build bakes these in at compile time from CI secrets, so they are
-# never needed on an installed copy. A source build has no baked-in value, so the
-# matching feature compiles in silently disabled until you set one here.
-# ---------------------------------------------------------------------------
-
-# Clerk email sign-in (setup wizard's Sign-in step). The tray reads this ONE key
-# straight out of this file (see `install::env_key_from_path`), not via dotenvy,
-# so no shell export is needed. Publishable key only — it is a public identifier;
-# never set CLERK_SECRET_KEY, the tray has no server-side use for it.
-# CLERK_PUBLISHABLE_KEY=pk_test_your_publishable_key_here
-
-# PostHog product analytics. Only needed if you are specifically testing the
-# analytics capture path.
-# POSTHOG_API_KEY=phc_your_project_api_key_here
-
-# Port for `next dev` / the Tauri devUrl, and the port `meridian doctor` probes
-# for the dashboard's health endpoint. No effect on an installed build — there
-# the dashboard is a static export bundled inside the tray, with no server.
-# MERIDIAN_UI_PORT=3939

--- a/.env.example
+++ b/.env.example
@@ -1,149 +1,88 @@
 # ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 #
-# Copy this file to .env (repo root) for a dev build, or to ~/.meridian/.env for
-# an installed one. Never commit the real .env — it contains secrets.
+# Copy to .env (repo root) for a dev build, or ~/.meridian/.env for an installed
+# one. Never commit the real .env — it contains secrets.
 #
 # NOTHING HERE IS REQUIRED TO BOOT. `bash dev-start.sh` runs the daemon and tray
 # on defaults alone, and the setup wizard writes tracker credentials for you.
 #
-# What this file is actually for is the gap a SOURCE BUILD has: a release bakes
-# four OAuth/app keys in at compile time from CI secrets, and a source checkout
-# has none of them, so those features are silently dead until you set them here.
-# That is the first section. Everything after it is optional.
-#
-# Tuning knobs (poll interval, retention, worklog thresholds, distiller and
-# embedder settings, log levels, ports) are deliberately NOT listed. They all
-# ship with working defaults, and a commented-out line restating a default is
-# just a second place for it to go stale. See CLAUDE.md's environment-variable
-# table and SETUP.md.
+# Only keys with no working default are listed. Tuning knobs (poll interval,
+# retention, worklog thresholds, distiller and embedder settings, log levels,
+# ports) are not: they all have defaults, and restating a default here just
+# creates a second place for it to go stale. See CLAUDE.md's env table and
+# SETUP.md.
 
 # ===========================================================================
-# SOURCE BUILD — the keys a release bakes in and a checkout does not have
+# SOURCE BUILD
+#
+# A release bakes these in from CI secrets. A checkout has none of them, so the
+# matching feature is dead — or worse, in Clerk's case, points at production.
 # ===========================================================================
 
-# Clerk email sign-in (the setup wizard's Sign-in step).
-#
-# SET THIS ONE. Unlike the others it does not fail closed: with no override the
-# tray falls back to the compiled-in PRODUCTION instance key, so a dev build
-# signs you in against the real user directory. Setting the dev instance key
-# here keeps a source checkout pointed at the dev instance instead.
-#
-# The tray reads this key straight out of this file (see
-# `install::env_key_from_path`), not via dotenvy, so no shell export is needed.
-# Get it with `clerk env pull` after
-# `clerk link --app app_3GIemyKuI07XdI7jFuYxpBqy9y3`. Publishable key only — it
-# is a public identifier; never set CLERK_SECRET_KEY, the tray has no
-# server-side use for it.
+# SET THIS ONE. It is the only key here that does not fail closed: with no
+# override the tray falls back to the compiled-in PRODUCTION Clerk key, so a dev
+# build signs you in against the real user directory. Read straight out of this
+# file by the tray (`install::env_key_from_path`), not via dotenvy, so no shell
+# export is needed. Get it with `clerk env pull` after
+# `clerk link --app app_3GIemyKuI07XdI7jFuYxpBqy9y3`. Publishable key only —
+# never set CLERK_SECRET_KEY, the tray has no server-side use for it.
 # CLERK_PUBLISHABLE_KEY=pk_test_your_publishable_key_here
 
-# Jira browser OAuth (`meridian oauth-login jira`).
-# Without the secret, login fails with "Jira OAuth requires a client secret..."
-# — ask a Meridiona team member for it, or use the static API token path below
-# instead, which needs nothing baked in.
-# JIRA_OAUTH_CLIENT_ID=your-atlassian-app-client-id
+# Jira browser OAuth. Without it, `meridian oauth-login jira` fails with "Jira
+# OAuth requires a client secret..." — ask a Meridiona team member, or use the
+# static API token below instead, which needs nothing baked in.
+# (The matching client id has a working default; override it only for a custom
+# app or Jira Data Center.)
 # JIRA_OAUTH_CLIENT_SECRET=your-atlassian-app-client-secret
 
-# GitHub's OAuth device flow (the dashboard's "Browser" connect).
-# Public identifier, no secret. A custom OAuth App must have "Enable Device
-# Flow" checked. Without it, use a classic PAT as GITHUB_TOKEN below.
+# GitHub's OAuth device flow (the dashboard's "Browser" connect). Public
+# identifier, no secret. Without it, use a classic PAT as GITHUB_TOKEN below.
 # GITHUB_OAUTH_CLIENT_ID=Ov23li_your_oauth_app_client_id
 
-# Trello browser OAuth (`meridian oauth-login trello`).
-# Meridian's Power-Up identity key, like an OAuth client_id. The baked-in
-# default is an EMPTY sentinel (`meridian-oauth/src/trello.rs`), so Trello OAuth
-# cannot work on a source build at all until this is set. Injected into the
-# bundle .env by package-release.sh — never commit the real key.
+# Trello OAuth. The baked-in default is an EMPTY sentinel
+# (`meridian-oauth/src/trello.rs`), so Trello cannot connect on a checkout at
+# all until this is set. Injected into the bundle by package-release.sh.
 # TRELLO_APP_KEY=
 
-# PostHog product analytics. Only needed if you are specifically testing the
-# analytics capture path; otherwise analytics stays silently disabled, which is
-# the right behaviour for a dev build.
-# POSTHOG_API_KEY=phc_your_project_api_key_here
-
 # ===========================================================================
-# OPTIONAL — connecting a tracker by hand
+# TRACKER CREDENTIALS — only for the tracker you actually use
 #
-# The setup wizard does all of this for you, and connecting a tracker is itself
-# optional: skip it and Meridian still records your day, it just has nothing to
-# draft worklogs against. Set these to configure a tracker without the wizard.
+# The setup wizard writes these for you, and connecting a tracker is optional:
+# skip it and Meridian still records your day, it just has nothing to draft
+# worklogs against. Set them here to configure a tracker without the wizard.
 # ===========================================================================
 
-# ---------------------------------------------------------------------------
-# Jira — static API token (the alternative to browser OAuth above).
-# JIRA_BASE_URL is accepted as an alias for JIRA_URL; JIRA_URL wins when both
-# are set, so set only one.
-# ---------------------------------------------------------------------------
-
+# Jira — static API token, the alternative to the browser OAuth above.
+# JIRA_BASE_URL is an accepted alias; JIRA_URL wins when both are set.
 # JIRA_URL=https://your-org.atlassian.net
 # JIRA_EMAIL=you@your-org.com
 # JIRA_API_TOKEN=your-api-token-here
 
-# Restrict the sync to these projects. Omit to sync all of them.
-# JIRA_PROJECT_KEYS=KAN,ENG
-
-# ---------------------------------------------------------------------------
-# GitHub — syncs the OPEN issues assigned to you from the listed Projects v2,
-# and logs worklogs as structured issue comments (no native time tracking).
+# GitHub — classic PAT scopes: `repo`, `read:org`, `read:project`.
 #
-# Classic PAT scopes: `repo`, `read:org`, `read:project` (read:project reads
-# Projects; repo posts the worklog comments).
-#
-# GITHUB_PROJECT_IDS: comma-separated Projects v2 node IDs (PVT_xxx). Find them:
+# BOTH are required. Unlike every other tracker's filter, an empty
+# GITHUB_PROJECT_IDS does not mean "all" — it skips the GitHub sync entirely
+# ("no GITHUB_PROJECT_IDS configured — skipping github sync"). List the
+# Projects v2 node IDs to sync:
 #   gh api graphql -f query='{ viewer { projectsV2(first:10){nodes{id title}} } }'
-# ---------------------------------------------------------------------------
-
 # GITHUB_TOKEN=ghp_your_personal_access_token
 # GITHUB_PROJECT_IDS=PVT_xxx,PVT_yyy
 
-# ---------------------------------------------------------------------------
-# Linear — syncs the issues assigned to you; worklogs are issue comments.
-# Key: linear.app > Settings > Account > Security & access > Personal API keys.
-# Sent raw in the Authorization header (no "Bearer" prefix).
-# ---------------------------------------------------------------------------
-
+# Linear — linear.app > Settings > Account > Security & access > Personal API keys.
 # LINEAR_API_KEY=lin_api_your_key_here
 
-# Restrict the sync to these teams (KEY or id). Omit to sync all of them.
-# LINEAR_TEAM_IDS=ENG,DESIGN
-
-# ---------------------------------------------------------------------------
-# Trello — the personal token comes from OAuth (see TRELLO_APP_KEY above) and
-# lands in ~/.meridian/oauth/trello.json. Only the board filter is set here.
-# ---------------------------------------------------------------------------
-
-# Restrict the sync to these boards. Omit to sync all of them.
-# TRELLO_BOARD_IDS=abc123,def456
-
-# ---------------------------------------------------------------------------
-# Azure DevOps / VSTS
-#
-# AZURE_DEVOPS_URL: copy the project URL from your browser address bar. Works
-# for all URL shapes — Meridian auto-detects org and project:
-#
-#   Cloud (standard):  https://dev.azure.com/mycompany/MyProject
-#   Cloud (legacy):    https://mycompany.visualstudio.com/MyProject
-#   On-premises:       https://tfs.corp.com/DefaultCollection/MyProject
-#
-# AZURE_DEVOPS_PAT: User settings → Personal access tokens → New token.
-#   Required scope: Work Items → Read & write.
-#   Use an org-scoped PAT (global PATs are being retired by Microsoft).
-#
-# If a URL shape ever fails to parse, set AZURE_DEVOPS_ORG and
-# AZURE_DEVOPS_PROJECT instead of AZURE_DEVOPS_URL.
-# ---------------------------------------------------------------------------
-
+# Azure DevOps — paste the project URL from your browser; org and project are
+# auto-detected from any shape (dev.azure.com, *.visualstudio.com, on-prem TFS).
+# PAT: User settings → Personal access tokens, scope Work Items → Read & write.
 # AZURE_DEVOPS_URL=https://dev.azure.com/your-org/your-project
 # AZURE_DEVOPS_PAT=your-pat-here
 
-# ---------------------------------------------------------------------------
-# LLM provider — nothing to set, here or anywhere else in this file.
+# ===========================================================================
+# There is deliberately no LLM API key, here or anywhere else.
 #
 # Summarising and task-matching run through the coding-agent CLI you already use
-# (Claude Code, Codex, Cursor, Copilot) or a cloud endpoint you configure in the
-# dashboard. There is no on-device generative model.
-#
-# There is deliberately no API-key variable: the CLI providers authenticate with
-# your own subscription, and ANTHROPIC_API_KEY is explicitly STRIPPED from the
-# child process (src/llm/claude.rs) so a stray key cannot silently start billing
-# you. Cloud-endpoint credentials belong in the dashboard's settings.
-# ---------------------------------------------------------------------------
+# (Claude Code, Codex, Cursor, Copilot) on your own subscription, or a cloud
+# endpoint configured in the dashboard. ANTHROPIC_API_KEY is explicitly STRIPPED
+# from the child process (src/llm/claude.rs) so a stray key cannot silently
+# start billing you.
+# ===========================================================================


### PR DESCRIPTION
## What

Rebuilt `.env.example` around one question: **what must be in `.env` to run Meridian from source?**

Answer: nothing, to boot. `dev-start.sh` runs the daemon and tray on defaults, and connecting a tracker is itself optional - the wizard's own copy says *"skip it and Meridian still tracks your day"*. So the file is now only the things that have no useful default.

**38 keys → 17. 224 lines → 149.**

## Dropped every knob that only restated a shipped default

`POLL_INTERVAL_SECS`, `MERIDIAN_DB`, `RUST_LOG`, `OFFICE_START_HOUR`/`_END_HOUR`, all five `PM_WORKLOG_*`, the four `DISTILLER_*`, the embedder trio, the three retention caps, `LLM_CLI_TIMEOUT_S`, `CURSOR_AGENT_AUTO_INSTALL`, the coding-agent store paths, both OAuth redirect ports, the telemetry switches, `LOG_LEVEL`, `MERIDIAN_UI_PORT`, `MERIDIAN_DB_KEY`.

A commented-out line restating a default is a second place for that default to go stale. These are documented in CLAUDE.md's environment-variable table and SETUP.md, which the header now points at.

## What's left

**The four keys a release bakes in from CI secrets and a checkout does not have** - the actual source-build gap - plus optional by-hand tracker credentials.

Two of those four are worth calling out, because they fail in opposite directions:

- **`CLERK_PUBLISHABLE_KEY` is the one to actually set.** It does *not* fail closed: with no override `clerk_publishable_key()` falls through to the compiled-in **production** instance key, so a dev build signs you in against the real user directory instead of erroring. That is a quiet wrong-environment bug, not a missing-feature one.
- **`TRELLO_APP_KEY` is the opposite** - `meridian-oauth/src/trello.rs`'s `DEFAULT_APP_KEY` is an empty sentinel, so Trello OAuth cannot work on a source build *at all* until it is set.

## Removed as wrong, not just noisy

- **`ANTHROPIC_API_KEY`** - the old file said it was "used by the coding-agent summariser's Claude path". Exactly backwards: `src/llm/claude.rs` and `summariser/claude.rs` pass `&["ANTHROPIC_API_KEY"]` to **strip** it from the child env, so a stray key can't move you off your Claude subscription onto metered billing. The file was advertising a setting whose entire purpose is to not exist. The LLM section now explains why there is no key variable.
- **`MERIDIAN_OO_AUTH`** - deprecated and ignored everywhere; the old file admitted this in its own comment.
- **`JIRA_BASE_URL`** - now documented as an alias in prose, since `JIRA_URL` wins when both are set.

## A note on auditing this file

A literal `env::var("...")` grep is **not** sufficient here. `config.rs`, `pm_worklog/config.rs` and the distiller read through `env_list` / `env_parse` / `env_num` helpers:

```rust
project_keys: env_list("JIRA_PROJECT_KEYS"),
min_coverage: env_parse("PM_WORKLOG_MIN_COVERAGE", 0.80),
```

That makes 14 live variables look dead. Nine of them - `JIRA_PROJECT_KEYS`, `GITHUB_PROJECT_IDS`, `LINEAR_TEAM_IDS` and all five `PM_WORKLOG_*` - were on my delete list until I checked the helper call sites. Worth knowing before the next person trims this file.

## Test

- All 17 remaining keys traced to a reader in `.rs`/`.ts` source
- `cp .env.example .env` (CONTRIBUTING.md's first dev step) yields **zero active assignments**, so the copy is a no-op on behaviour
- `meridian` boots and loads config (`pm_providers=["jira"]`)
- pre-commit + pre-push suites green

## Local `.env` (not in this PR - it's gitignored)

Pruned three genuinely dead keys while here: `CLASSIFIER_BACKEND`, `MLX_SERVER_PORT`, `MERIDIAN_OO_EXPORT` - zero source references, leftovers from the removed Python/MLX stack. All seven surviving values including `MERIDIAN_DB_KEY` verified byte-identical, mode `0600` preserved, backup at `~/.meridian/.env.backup-<ts>`.