### PR TITLE
docs(readme): swap the demo video for the Product Hunt cut

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Not a time tracker you fill out. It's a private timeline of your day - browse it
 
 ## Demo
 
-https://github.com/user-attachments/assets/501f41e6-aa89-404b-b430-a0b8b59c198e
+https://github.com/user-attachments/assets/5cc26036-3842-4748-85c8-097a8b71f20d
 
 <!-- SCREENSHOTS: uncomment once docs/images/timeline.png and docs/images/approval.png exist.
      See docs/images/README.md for what to capture. Do not uncomment before the files land -


### PR DESCRIPTION
Swaps the June demo video for the Product Hunt cut, ahead of launch. One line of README changes.

```diff
-https://github.com/user-attachments/assets/501f41e6-aa89-404b-b430-a0b8b59c198e
+https://github.com/user-attachments/assets/5cc26036-3842-4748-85c8-097a8b71f20d
```

## Not a file swap

The video is a `user-attachments` upload, not a repo file — same as the one it replaces, and for the reason PR #287 gave when it added the original: *"inline player, `user-attachments` asset — no repo bloat."* Confirmed no video has ever been committed to this repo on any branch.

The URL has to stay a **bare URL alone on its own line with blank lines around it** — that is the form GitHub substitutes an inline `<video>` player for. Link syntax or a `<video>` tag renders as text instead. That shape is unchanged here.

## Re-encoded before upload

74 MiB @ 8.8 Mbps → **3.3 MiB @ 270 kb/s** (h264 crf 26, yuv420p, `+faststart`). A 22x reduction sounds destructive but this is a flat-colour motion graphic, which compresses extremely well — I pulled a mid-video frame to check rather than assume, and UI text, ticket keys and timings are all still crisp.

`+faststart` matters more than the size: it moves the index ahead of the payload so the video streams rather than making a reader wait on a full download.

## The URL was verified live before committing

GitHub answers a registered attachment with a `302` to its signed S3 object; an unregistered one `404`s on the first hop. Checked against the existing working asset as a control:

| URL | First hop |
|---|---|
| Old (working) | `302` → S3 |
| **New** | `302` → S3, `response-content-type=video/mp4` |

Worth recording, because it cost a round trip: **the first URL minted for this video 404'd.** It was uploaded into an issue form that was never submitted, and GitHub does not keep an attachment that was never attached — it hands back a URL and then discards the asset. The fix is to drop the file into a comment and actually post it. Anyone doing this swap again should check for the `302` before merging; a dead embed produces no error, it just looks broken to every visitor.

The old asset is left alone — unreferenced now, not deletable, and costs nothing.

## CI note

This branch is cut from `pre-main`, which is **currently red on `Rust (Windows x86_64) / clippy` and `/ test`** — an unused-import error at `tray/src-tauri/src/lib.rs:60` (`ReopenTarget`, `is_onboarded`, `reopen_target`) introduced by #752's tray-lib split. Those symbols are used only under `cfg(target_os = "macos")`, so the import is unused on Windows and `-D warnings` rejects it. Inherited, not caused by this change — a README edit cannot affect a Rust build — and it will clear once pre-main is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
