### PR TITLE
fix(tray): cfg-gate the macOS-only reopen import so Windows builds

### DIFF
--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -57,6 +57,16 @@ mod tray_icon;
 mod update;
 mod window_panel;
 
+// Gated to match the ONLY thing that uses these — the `RunEvent::Reopen` arm at
+// the bottom of `run()`, which is `#[cfg(target_os = "macos")]` because Reopen is
+// a Dock/Finder activation that no other platform emits. `reopen.rs` already
+// carries `cfg_attr(not(target_os = "macos"), allow(dead_code))` on all three
+// items, so the definitions were covered; only this import was left unconditional,
+// and an unused import is an ERROR under `-D warnings`.
+//
+// `onboarding_complete` below is deliberately NOT gated: it is called on every
+// platform (the `capture`-gated startup path in `run()`).
+#[cfg(target_os = "macos")]
 use reopen::{is_onboarded, reopen_target, ReopenTarget};
 // Re-exported at the crate root so `tray.rs` and `commands::system` keep calling
 // `crate::onboarding_complete()` — the exact string `reopen::reopen_tests`'

--- a/tray/src-tauri/src/reopen.rs
+++ b/tray/src-tauri/src/reopen.rs
@@ -154,6 +154,43 @@ mod reopen_tests {
         );
     }
 
+    /// `lib.rs`'s import of these three must stay `#[cfg(target_os = "macos")]`.
+    ///
+    /// Their only use site is the `RunEvent::Reopen` arm, which is macOS-only
+    /// because no other platform emits Reopen. The definitions above already
+    /// carry `cfg_attr(not(target_os = "macos"), allow(dead_code))`, so they are
+    /// covered - but an *import* has no such escape hatch: unused, it is an
+    /// ERROR under `-D warnings`, and it broke the Windows clippy AND test jobs
+    /// while every macOS gate stayed green.
+    ///
+    /// That asymmetry is the whole reason this test exists. A macOS developer
+    /// running the full local suite cannot see this class of mistake; it
+    /// surfaces only after a push, on a runner, ~15 minutes later. Scanning the
+    /// source makes it fail here instead.
+    ///
+    /// Checks the preceding line rather than a fixed block of text, so
+    /// reordering the symbols or rewriting the comment above it does not
+    /// produce a spurious failure.
+    #[test]
+    fn the_macos_only_reopen_import_stays_gated() {
+        let lines: Vec<&str> = include_str!("lib.rs").lines().collect();
+        let idx = lines
+            .iter()
+            .position(|l| l.trim_start().starts_with("use reopen::{"))
+            .expect(
+                "lib.rs no longer imports symbols from `reopen` - if the Reopen \
+                     handler moved, move this guard with it",
+            );
+        assert_eq!(
+            lines[idx - 1].trim(),
+            "#[cfg(target_os = \"macos\")]",
+            "lib.rs:{} imports macOS-only `reopen` symbols without a cfg gate - \
+             this compiles on macOS and fails the Windows build with \
+             `unused imports`",
+            idx + 1
+        );
+    }
+
     #[test]
     fn is_onboarded_reflects_the_marker_file() {
         // Use a unique temp dir so parallel test runs don't collide.


### PR DESCRIPTION
Unblocks `pre-main`, which has been red on **`Rust (Windows x86_64) / clippy`** and **`/ test`** since #752's tray-lib split. Every PR targeting `pre-main` inherits it, because GitHub builds PRs as a merge with the base.

```
error: unused imports: `ReopenTarget`, `is_onboarded`, and `reopen_target`
  --> tray\src-tauri\src\lib.rs:60:14
```

## Cause

The only use site is the `RunEvent::Reopen` arm, which is `#[cfg(target_os = "macos")]` because no other platform emits Reopen. Off macOS the import has no consumer, and an unused import is an **error** under `-D warnings`.

Half the trap was already anticipated — `reopen.rs` carries `cfg_attr(not(target_os = "macos"), allow(dead_code))` on all three items, so the *definitions* were covered. An import has no such escape hatch. `cfg_attr(allow(dead_code))` and `cfg(target_os)` look interchangeable and are not: one silences a warning everywhere, the other deletes the code. The fix matches the `window_panel` import five lines below, which has always been gated correctly.

## Reproduced locally, not pushed-and-hoped

Flipping the arm's predicate to `linux` makes macOS compile the same code Windows does. Two iterations, and the first is worth recording:

| Attempt | Result |
|---|---|
| Flip the arm only | Reproduced the error **plus three spurious `never used` errors** — `reopen.rs`'s `not(target_os = "macos")` doesn't flip with it, so the `allow(dead_code)` that fires on real Windows was inactive |
| Flip all three predicates together | **Exactly CI's output**: one error, `lib.rs:60:14`, failing both lib and lib-test — matching the two failing jobs |

With the fix applied under that faithful simulation: clean. Restored to real predicates: `reopen.rs` is byte-for-byte pristine, and macOS `cargo clippy --workspace --all-targets -D warnings` + `cargo test -p meridian-tray` (258 pass) are green.

## Guard added, because the failure mode is worse than the failure

This class of bug **cannot be seen from macOS**. Every local gate passes, the pre-push hook passes, and it surfaces ~15 minutes later on a runner — for whoever pushes next, not necessarily whoever wrote it. That's how it reached `pre-main` and sat there.

`reopen_tests` already source-scans `lib.rs`'s siblings for call sites that units can't reach, so the new test scans for the attribute on the line above the import. It checks the **preceding line** rather than a fixed block of text, so reordering the symbols or rewriting the comment won't fail it spuriously. Confirmed to bite by deleting the gate:

```
assertion `left == right` failed: lib.rs:69 imports macOS-only `reopen` symbols
without a cfg gate - this compiles on macOS and fails the Windows build with `unused imports`
  left: "// platform (the `capture`-gated startup path in `run()`)."
 right: "#[cfg(target_os = \"macos\")]"
```

## Not fixed here

`db::repair::rebuild::tests::sidecars_are_gone_after_the_rebuild` failed once on a macOS PR run (un-checkpointed WAL). It passed 5/5 locally and did not fail on `pre-main`'s own run — a flake in the known timing-sensitive WAL / `pool.close()` area, unrelated to this change. Left alone rather than papered over.

## Merge order

Merging this first turns the Windows jobs green on **#754** and **#757**, which are both otherwise clean and blocked only by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
