### PR TITLE
fix: address the review on the 1.86 release PR

### DIFF
--- a/.claude/skills/meridian-ui/SKILL.md
+++ b/.claude/skills/meridian-ui/SKILL.md
@@ -1,133 +1,132 @@
 ---
 name: meridian-ui
-description: "Build, develop, and debug the Meridian Next.js dashboard. Covers component patterns, category system, API routes, and test runner."
+description: "Build, develop, and debug the Meridian dashboard - the Next.js static export that runs inside the Tauri tray webview. Covers the bridge to Rust, component patterns, and the bun test runner."
 allowed-tools: Bash, Read, Edit, Grep, Write
 ---
 
 # Meridian UI Skill
 
-> ⚠️ **Migration in progress (branch `spike/meridian-core`).** The API routes below are
-> being ported to **Rust** so the dashboard can fold into the Tauri app (no Node server at
-> runtime). Shared read queries live in the `meridian-core` crate (single source of truth;
-> the daemon re-exports them, the tray calls them). `/api/active` and `/api/today` are ported
-> (`meridian_core::{get_active_session, today}` + `tray` commands `get_active`/`get_today`),
-> verified byte-identical via golden-compare. This skill still describes the **current Node
-> dashboard** (accurate on `main`); when the migration lands it should be revised/split. See
-> `CLAUDE.md` → "Dashboard → Tauri migration".
+The dashboard is a **Next.js static export** (`output: 'export'` → `ui/out`) that runs
+**inside the Tauri tray webview**. There is no Node server at runtime and there are no
+`/api` route handlers - `ui/app/api/` does not exist, and `better-sqlite3` is not a
+dependency of `ui/`. Everything that used to be a route handler is now Rust reached
+over Tauri `invoke`.
+
+If you are looking for the old route-handler / `@/lib/db` / `@/lib/category-colors`
+world, it was removed in the Next fold. See `CLAUDE.md` → "Dashboard → Tauri fold".
 
 ## Stack
 
-- **Next.js** (App Router) with React Server Components
-- **TypeScript** — strict mode, no `any`
-- **Tailwind CSS 4** — utility classes, no CSS modules
-- **better-sqlite3** — synchronous SQLite, used in server components and API routes
-- **bun:test** — test runner for `ui/__tests__/`
+- **Next.js 16** (App Router), **React 19**
+- **TypeScript** - strict, no `any` without a justifying comment
+- **Tailwind CSS 4** - utility classes, no CSS modules
+- **bun:test** - test runner for `ui/__tests__/`
 
 ## Dev & Build
 
 ```bash
 cd ui
 
-# Development server (http://localhost:3000)
-npm run dev
-
-# Production build (must pass before committing)
-npm run build
-
-# Run UI tests
-bun test
-bun test --watch
+npm run dev        # dev server on :3939 (turbopack; NODE_ENV is unset deliberately)
+npm run build      # production build + copies the tray popover into out/
+npm run typecheck  # tsc --noEmit
+bun test           # dashboard tests
 ```
 
-## Key Files
+Two gotchas worth knowing before you debug either:
+
+- **Never run `next dev` with `NODE_ENV` set** - that is why the script is
+  `env -u NODE_ENV next dev`. A stale `ui/.next` after a branch or config switch
+  produces an `Invalid distDirRoot` panic; `rm -rf ui/.next` clears it.
+- **The popover 404s under `tauri dev`** (next dev does not serve `popover/`). It
+  renders correctly in a packaged build. This is expected, not a bug to chase.
+
+## Reaching data: the bridge, never fetch
+
+All data crosses to Rust through `ui/lib/bridge.ts`:
+
+```ts
+import { load, mutate, subscribe } from '@/lib/bridge'
+
+const today = await load<TodayResponse>('/today', 'get_today')        // read
+await mutate('/settings', 'save_settings', body, 'PATCH')             // write
+const stop = subscribe<Health>('/health', 'get_health', 'health', cb) // live stream
+```
+
+- The first argument is a **vestigial** path that documents the former route; the
+  second is the actual Tauri command name.
+- The browser `fetch` and `EventSource` fallbacks were **removed at cutover** - these
+  are Tauri-only.
+- Response types live in **`ui/lib/api-types.ts`**.
+
+Adding a new data source is a Rust job, not a TypeScript one: DB-backed reads go in
+`meridian-core/src/readers/`, and file/env/process/HTTP work goes in
+`tray/src-tauri/src/commands/`. Follow **CLAUDE.md → Coding Conventions → "Porting a
+dashboard route to Rust"**, which covers placement, docs, tracing, and tests.
+
+## Key files
 
 | File | Purpose |
 |------|---------|
-| `ui/app/page.tsx` | Dashboard home — active session, stats, category breakdown, timeline |
-| `ui/app/sessions/page.tsx` | Session list with pagination |
-| `ui/app/apps/page.tsx` | Per-app stats with focus donut |
-| `ui/app/api/active/route.ts` | Active session API |
-| `ui/app/api/sessions/route.ts` | Sessions list API |
-| `ui/app/api/stats/route.ts` | Daily stats API |
-| `ui/app/api/timeline/route.ts` | Timeline segments API |
-| `ui/lib/category-colors.ts` | 10-category palette, `getCategoryMeta()`, `CATEGORY_META` |
-| `ui/lib/format.ts` | `formatDuration`, `formatDateLabel`, `toLocalDateString` |
-| `ui/lib/types.ts` | Shared types: `SessionRow`, `ActiveSessionRow`, `StatsResponse` |
-| `ui/components/CategoryBadge.tsx` | Pill badge with emoji + label + optional confidence |
-| `ui/components/CategoryBreakdown.tsx` | Horizontal bar chart by category |
-| `ui/components/DayTimeline.tsx` | Day timeline — segments colored by category |
-| `ui/components/ActiveSessionCard.tsx` | Currently-active session card |
-| `ui/components/SessionCard.tsx` | Completed session card |
-| `ui/__tests__/` | Unit tests for format utilities and category system |
+| `ui/app/page.tsx` | Entry point; renders the timeline shell |
+| `ui/app/setup/` | First-run wizard (its own window) |
+| `ui/app/uninstall/` | Uninstall flow |
+| `ui/lib/bridge.ts` | The only path to Rust - `load` / `mutate` / `subscribe` |
+| `ui/lib/api-types.ts` | Response types for every command |
+| `ui/lib/theme.ts`, `theme-context.tsx` | Surface palettes and theme plumbing |
+| `ui/components/timeline/MeridianTimelineShell.tsx` | Top-level shell; owns modals, day state, and deep-link `navigate` |
+| `ui/components/ConfirmDialog.tsx` | `ConfirmDialog` / `AlertDialog` - see the hard rule below |
 
-## Category System
+## Hard rule: no native dialogs
 
-10 fixed categories with a locked color palette:
+**Never `window.confirm` / `window.alert` / `window.prompt`.** WKWebView routes JS
+dialogs through a `WKUIDelegate` that nothing in the stack installs, so `confirm()`
+always returns `false` and `alert()` is a silent no-op in the packaged tray. The damage
+is silence - a falsy `confirm()` is indistinguishable from the user clicking Cancel, so
+the gated action never runs while every log and test still passes. That is how the
+Repair Database button shipped dead.
 
-```ts
-import { getCategoryMeta, CATEGORY_META } from '@/lib/category-colors'
-
-const meta = getCategoryMeta(session.category)
-// meta.color  → '#4F7BE8'
-// meta.bg     → '#EEF2FD'
-// meta.emoji  → '💻'
-// meta.label  → 'Coding'
-```
-
-Categories: `coding`, `code_review`, `meeting`, `communication`, `design`,
-`documentation`, `planning`, `deployment_devops`, `research`, `idle_personal`.
-
-Unknown strings fall back to `idle_personal`.
-
-## DB Queries (better-sqlite3 pattern)
-
-```ts
-import getDb from '@/lib/db'
-
-const db = getDb()
-const rows = db.prepare(`
-  SELECT id, app_name, category, confidence, duration_s
-  FROM app_sessions
-  WHERE started_at >= ? AND started_at < ?
-  ORDER BY started_at DESC
-`).all(start, end)
-```
+Use `@/components/ConfirmDialog` instead. `__tests__/no-native-dialogs.test.ts` fails
+the build if they come back.
 
 ## Tests
 
 ```bash
-# Run all UI tests
-cd ui && bun test
-
-# Run a specific file
-bun test __tests__/format.test.ts
-bun test __tests__/category-colors.test.ts
+cd ui
+bun test                              # everything
+bun test __tests__/deep-links.test.ts # one file
 ```
 
-Tests live in `ui/__tests__/`. Use `bun:test` imports (`describe`, `it`, `expect`).
+Tests live in `ui/__tests__/` and use `bun:test` imports (`describe`, `it`, `expect`).
 
-## Adding a New Component
+Many are **source-scanning rather than behavioural** - they read the `.tsx` and assert
+on what it contains. That is deliberate: it is the only available guard for things a
+headless run cannot exercise (which element carries a ring, whether a `localStorage`
+touch is wrapped, whether a deep link has a `navigate` arm). When adding one, assert
+the invariant you actually mean, and confirm it fails against a deliberate regression -
+a source scan that matches nothing passes vacuously.
 
-1. Create `ui/components/MyComponent.tsx` with the file header:
+## Adding a component
+
+1. First line must be the file header:
    ```ts
    //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
    ```
-2. Accept typed props — no `any`
-3. Use `getCategoryMeta()` for any category coloring
-4. Import from `@/lib/format` for duration/date formatting
+2. Typed props, no `any`.
+3. Data through `@/lib/bridge`, types from `@/lib/api-types`.
+4. User-facing strings use a plain hyphen `-`, never an em-dash - see the Hard Rules in
+   `CLAUDE.md`.
 
-## Common Issues
+## Common issues
 
-### `better-sqlite3` not found
-```bash
-cd ui && npm install
-```
+### `Invalid distDirRoot` panic in dev
+Stale cache after a branch or config switch: `rm -rf ui/.next`.
+
+### An `invoke` silently does nothing
+The window label is probably missing from `tray/src-tauri/capabilities/default.json`.
+Un-permitted `invoke`s and events are denied without an error.
 
 ### Build type errors
 ```bash
-cd ui && npm run build 2>&1 | head -50
+cd ui && npm run typecheck
 ```
-
-### Category colors test fails
-The palette is locked. If you change `CATEGORY_META` colors, update the hardcoded
-assertions in `__tests__/category-colors.test.ts` to match.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,9 +26,10 @@ worse than no feature at all.
 ## The pieces
 
 Meridian is two long-running processes plus two libraries, all on your machine. There
-is no server.
+is no remote server - nothing of yours is hosted anywhere. The MCP server below is a
+local process an AI client starts on demand over stdio; it listens on no port.
 
-```
+```text
 ┌──────────────────────────────┐        ┌──────────────────────────────┐
 │  Tray  (Tauri, Rust + web)   │        │  Daemon  (Rust, headless)    │
 │                              │        │                              │
@@ -58,7 +59,11 @@ is no server.
 | **MCP server** | `packages/meridian-mcp/` | TypeScript. Exposes the same data to AI clients over the Model Context Protocol. |
 | **OAuth** | `meridian-oauth/` | Browser-based OAuth flows for Jira and Trello. |
 
-The Rust workspace is `[".", "meridian-core", "meridian-oauth", "tray/src-tauri"]`.
+The Rust workspace is `[".", "meridian-core", "meridian-oauth", "tray/src-tauri",
+"tray/src-tauri/vendor/tauri-plugin-clerk"]`. That last one is a patched copy of a
+third-party crate, and it is a member rather than excluded precisely so its regression
+tests run - see `tray/src-tauri/vendor/tauri-plugin-clerk/README.md`.
+
 Because the repo root is itself a package, **`cargo test` and `cargo clippy` must be
 run with `--workspace`** or they silently test only the daemon. This is the single
 most common way to get a green run that proves nothing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -490,8 +490,13 @@ a `.tar.gz` the user hands to support, imported by hand with `meridian
 telemetry import <bundle> --endpoint <url> --auth <base64>`. The bundle also
 carries a synthesized `bundle-info.txt` (Support ID, version, channel, os,
 arch) so a hand-delivered archive can be joined to that machine's already-
-ingested rows; it deliberately contains nothing the automatic ship leg wouldn't
-already send. Retention (default 7 days, `MERIDIAN_TELEMETRY_RETENTION_DAYS`)
+ingested rows. **The bundle is NOT redacted, and it is a superset of what the
+automatic ship leg sends** — `build_export_bundle` copies `pending/` and `sent/`
+verbatim, and the spool is captured at full fidelity, so the archive carries
+INFO/DEBUG records and unredacted attributes that the WARN+-only, redacted ship
+leg strips. (An earlier version of this line claimed the opposite; it was wrong,
+and `docs/privacy.md` now tells users to inspect the archive before sending it.)
+Retention (default 7 days, `MERIDIAN_TELEMETRY_RETENTION_DAYS`)
 applies to both `pending/` and `sent/`, regardless of shipping status.
 
 - **Rust**: `tracing::info!/warn!/error!/debug!` with **structured fields** — never format data values into the message string (already enforced).
@@ -520,12 +525,23 @@ applies to both `pending/` and `sent/`, regardless of shipping status.
 5. Add a migration if the signal needs its own column; otherwise store as JSON in `signals`
 6. Add an integration test in `tests/integration_etl.rs`
 
-### Add a new UI API route
+### Add a new dashboard data source (there are no UI API routes)
 
-1. Create `ui/app/api/<name>/route.ts`
-2. Query `meridian.db` using `better-sqlite3` (see existing routes for the pattern)
-3. Return a typed JSON response; define the response type inline
-4. If the route shells out to the `meridian` binary, resolve it with `selectMeridianBinary(meridianCandidates())` from `@/lib/meridian-bin` — never a bare `'meridian'` or an ad-hoc candidate list (see the launchd/node-wrapper note under Coding Conventions → TypeScript / Next.js)
+**`ui/app/api/` does not exist.** The Next-fold deleted every route handler: the
+dashboard is a static export inside the tray webview, with no Node server to host
+them. There is nowhere to put a `route.ts`, and `better-sqlite3` is not a dependency
+of `ui/`.
+
+Follow **Coding Conventions → "Porting a dashboard route to Rust"** instead — the
+same playbook applies to a brand-new reader, not just a ported one. In short: a
+DB-backed read becomes a module under `meridian-core/src/readers/`; anything touching
+files, env, a process, or external HTTP becomes a `#[tauri::command]` under
+`tray/src-tauri/src/commands/`; the frontend reaches it through `ui/lib/bridge.ts`
+(`load`/`mutate`/`subscribe`), and its response type goes in `ui/lib/api-types.ts`.
+
+The `selectMeridianBinary(meridianCandidates())` rule still applies wherever the
+`meridian` binary is spawned — that code now lives in tray commands rather than route
+handlers.
 
 ### Add a notification (plain toast or interactive nudge)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,15 +114,19 @@ Run the same checks CI runs — all must pass:
 cargo fmt                                              # format
 cargo clippy --workspace --all-targets -- -D warnings  # lint — warnings are errors
 cargo test --workspace                                 # Rust unit + integration tests
-cargo build --release                                  # verify release build
+cargo build --workspace --release                      # verify release build
 
-cd ui && npm ci && npm run build                       # dashboard builds
-cd ui && bun test                                      # dashboard tests (bun, not npm)
+(cd ui && npm ci && npm run build)                     # dashboard builds
+(cd ui && bun test)                                    # dashboard tests (bun, not npm)
 ```
+
+The two `ui` lines are wrapped in subshells so the block can be pasted as a whole - a
+bare `cd ui` on both would put the second one in `ui/ui`.
 
 > **`--workspace` is not optional.** The repo root is itself a package, so a bare
 > `cargo test` or `cargo clippy` runs against the daemon **alone** and silently skips
-> `meridian-core`, `meridian-oauth`, and the tray. They still compile, which is what
+> `meridian-core`, `meridian-oauth`, the tray, and the vendored `tauri-plugin-clerk`
+> (a workspace member so its regression tests run). They still compile, which is what
 > makes the omission so convincing - they are simply never tested. CI and the git hooks
 > pass `--workspace` for exactly this reason.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ But everything needed to do it already exists in what you just did — the code 
 
 1. **Capture** — Meridian bounds your activity into clean, app-based work sessions, accurate across sleep, idle, and restarts.
 2. **Classify** — Meridian labels each session and links it to the specific ticket it belongs to, using what's on screen, the branch you're on, and the tools in play. The matching runs through the AI CLI you already use (or a cloud LLM you configure).
-3. **Sync** — the matching ticket in Jira / GitHub Issues / Linear is updated for you. **Nothing posts without your approval.**
+3. **Sync** — the matching ticket in whichever tracker you connected is updated for you. **Nothing posts without your approval.**
 
 A dashboard inside the Meridian app (open it from the menu-bar tray icon) shows your day as a timeline and per-app breakdown. A built-in [MCP server](SETUP.md#mcp-server) makes the same data available to AI tools like Claude and Cursor.
 

--- a/docs/images/README.md
+++ b/docs/images/README.md
@@ -8,7 +8,7 @@ the files first, then uncomment.
 
 The GitHub social preview - 1280x640, the size GitHub renders link cards at. Committed
 so the asset is versioned, but **the repo file is not what GitHub serves**: it has to be
-uploaded by hand at Settings - Options - Social preview. Re-upload after any change here.
+uploaded by hand at Settings - General - Social preview. Re-upload after any change here.
 
 The light treatment - spirograph mark, wordmark, tagline. It is **generated**, not a
 pasted export: `tray/src-tauri/icons/meridiona-mark.png` (1024x1024) is composited onto

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -6,15 +6,19 @@
 
 ## Overview
 
-Meridian is a local-first developer tool that turns your activity into structured work sessions and keeps your project management in sync. Screen capture, OCR, and session structuring run entirely on your machine and are stored in an encrypted local database. Your screen content, window titles, and captured text never leave your device.
+Meridian is a local-first developer tool that turns your activity into structured work sessions and keeps your project management in sync. Screen capture, OCR, and session structuring run entirely on your machine, and what they produce is stored in an encrypted local database. Meridiana never receives your screen content, your window titles, or the text captured from your screen.
 
-Meridian does make network calls. There are exactly three kinds, and you control all of them:
+Meridian does make network calls. There are **five kinds**, listed here in full:
 
 1. **Ticket updates you approve** — sent directly from your machine to the trackers you connect.
-2. **AI summarisation** — session text sent to the LLM provider you choose.
+2. **AI summarisation** — session text, including text captured from your screen, sent to the LLM provider you choose. **This is the one path on which your captured content leaves the device**, and it goes to a provider you pick and configure, never to Meridiana. It is described in [LLM provider](#llm-provider-summarisation--ticket-matching).
 3. **Error reports** — redacted, error-only diagnostics sent to Meridiana. **On by default in packaged installs; one switch turns it off.**
 4. **Product analytics** — two events, and only once you sign in: that you installed, and a daily count of hours and drafts. **No screen content. Currently no off switch** — see [Product analytics](#product-analytics).
-5. **A public counter ping** — one anonymous "+1" to meridiona.com each time you post a worklog, powering the counter on the landing page. No payload.
+5. **A public counter ping** — one anonymous "+1" to meridiona.com each time you post a worklog **or update a personal task**, powering the counter on the landing page. No payload. Sent only from release builds, and it has **no off switch** either.
+
+**How much of this you control:** 1 and 2 happen only because you connected a tracker
+and chose a provider; 3 has a switch in Settings. 4 and 5 do not currently have one.
+Saying "you control all of them" would be simpler and would not be true.
 
 Each is described in full below. If you only read two sections, read
 [Error reporting](#error-reporting) and [Product analytics](#product-analytics).
@@ -93,7 +97,9 @@ Packaged builds also send crash reports (via Sentry) so we learn about crashes t
 
 ### Sending diagnostics manually
 
-**Settings → Account → Export Diagnostics** (or `meridian telemetry export`) bundles your local logs into a `.tar.gz` you can inspect and send to support by hand. This is independent of the switch above, it only happens when you ask for it, and it contains nothing the automatic path would not already send.
+**Settings → Account → Export Diagnostics** (or `meridian telemetry export`) bundles your local logs into a `.tar.gz` you can inspect and send to support by hand. It is independent of the switch above and only happens when you ask for it.
+
+**Treat this archive as more sensitive than an automatic error report, and look inside before you send it.** The two are not the same content. Automatic reports are filtered to warnings and errors and are redacted on your machine before they leave; the export is a copy of your **raw local spool**, which is captured at full fidelity. That means it can contain `INFO` and `DEBUG` records, and diagnostic detail, that the automatic path deliberately strips or never sends. It is a `.tar.gz` of ordinary files - `meridian logs` renders the same data if you would rather read it that way first.
 
 ---
 

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -9,9 +9,9 @@ chmod +x .githooks/pre-push
 chmod +x .githooks/post-push
 
 echo "Git hooks installed:"
-echo "  commit-msg  — conventional commits format check"
-echo "  pre-commit  — cargo fmt + clippy"
-echo "  pre-push    — cargo fmt + clippy + UI build + UI tests + security audit + cargo test"
-echo "  post-push   — sync ops/openobserve-dashboards/ → local OpenObserve"
+echo "  commit-msg  - conventional commits format check"
+echo "  pre-commit  - cargo fmt + clippy"
+echo "  pre-push    - cargo fmt + clippy + UI build + UI tests + security audit + cargo test"
+echo "  post-push   - sync ops/openobserve-dashboards/ → local OpenObserve"
 echo ""
 echo "Commit format: feat|fix|docs|refactor|perf|chore|ci(scope): description"

--- a/tray/src-tauri/src/commands/walkthrough.rs
+++ b/tray/src-tauri/src/commands/walkthrough.rs
@@ -181,13 +181,28 @@ fn disarm(home: &Path) -> std::io::Result<()> {
 /// unseen" from "armed and long since taken", and [`tour_owed`] would hold both
 /// auto-opens back until [`ARMED_MAX_AGE_SECS`] expired.
 #[tauri::command]
-#[tracing::instrument]
+#[tracing::instrument(fields(otel.status_code = tracing::field::Empty))]
 pub async fn disarm_walkthrough() -> Result<(), String> {
-    let home = meridian_core::paths::home_dir()
-        .ok_or_else(|| "could not resolve home directory".to_string())?;
-    disarm(&home).map_err(|e| format!("clear {ARMED_MARKER}: {e}"))?;
-    tracing::info!("walkthrough: entitlement cleared - the tour is done");
-    Ok(())
+    use anyhow::Context;
+
+    let result = meridian_core::paths::home_dir()
+        .context("resolve the home directory")
+        .and_then(|home| disarm(&home).with_context(|| format!("clear the {ARMED_MARKER} marker")));
+
+    match result {
+        Ok(()) => {
+            tracing::info!("walkthrough: entitlement cleared - the tour is done");
+            Ok(())
+        }
+        Err(e) => {
+            tracing::Span::current().record("otel.status_code", "ERROR");
+            Err(crate::cmd_err!(
+                level: error,
+                e,
+                "walkthrough: could not clear the entitlement"
+            ))
+        }
+    }
 }
 
 /// Raise or clear the walkthrough marker.
@@ -195,24 +210,51 @@ pub async fn disarm_walkthrough() -> Result<(), String> {
 /// Called with `true` as the tour starts and `false` as it finishes, skips, or
 /// unwinds. Clearing a marker that is not there is not an error.
 #[tauri::command]
-#[tracing::instrument]
+#[tracing::instrument(fields(otel.status_code = tracing::field::Empty))]
 pub async fn set_walkthrough_running(running: bool) -> Result<(), String> {
-    let dir = meridian_core::paths::meridian_dir()
-        .ok_or_else(|| "could not resolve home directory".to_string())?;
+    write_running_marker(running).await.map_err(|e| {
+        tracing::Span::current().record("otel.status_code", "ERROR");
+        crate::cmd_err!(
+            level: error,
+            e,
+            running,
+            "walkthrough: could not update the running marker"
+        )
+    })
+}
+
+/// The filesystem half of [`set_walkthrough_running`], as `anyhow` so each step
+/// carries its own context.
+///
+/// Split out for one reason: `Result<(), String>` has to stay at the Tauri
+/// boundary (it is what crosses IPC), but a `String` built with `{e}` renders
+/// only the outermost message. Keeping the work in `anyhow` and rendering once,
+/// at the boundary, with `cmd_err!` is what preserves the chain — the same
+/// failure this repo already hit when a corrupt-database error reached the
+/// dashboard as a bare `tasks: today presence`.
+///
+/// Clearing a marker that is not there stays a success: the frontend calls this
+/// with `false` on every unwind path, including ones where the tour never
+/// started, and those are not failures.
+async fn write_running_marker(running: bool) -> anyhow::Result<()> {
+    use anyhow::Context;
+
+    let dir = meridian_core::paths::meridian_dir().context("resolve the Meridian directory")?;
     let path = dir.join(RUNNING_MARKER);
+
     if running {
         tokio::fs::create_dir_all(&dir)
             .await
-            .map_err(|e| format!("create ~/.meridian: {e}"))?;
+            .with_context(|| format!("create {}", dir.display()))?;
         tokio::fs::write(&path, chrono::Local::now().to_rfc3339())
             .await
-            .map_err(|e| format!("write {RUNNING_MARKER}: {e}"))?;
+            .with_context(|| format!("write {}", path.display()))?;
         tracing::info!("walkthrough: started - auto-opens held back");
     } else {
         match tokio::fs::remove_file(&path).await {
             Ok(()) => tracing::info!("walkthrough: finished - auto-opens released"),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => return Err(format!("clear {RUNNING_MARKER}: {e}")),
+            Err(e) => return Err(e).with_context(|| format!("clear {}", path.display())),
         }
     }
     Ok(())

--- a/tray/src-tauri/src/reopen.rs
+++ b/tray/src-tauri/src/reopen.rs
@@ -193,21 +193,26 @@ mod reopen_tests {
 
     #[test]
     fn is_onboarded_reflects_the_marker_file() {
-        // Use a unique temp dir so parallel test runs don't collide.
-        let dir = std::env::temp_dir().join(format!("meridian-reopen-{}", std::process::id()));
+        // `tempfile` rather than a PID-named directory. A PID is unique among
+        // LIVE processes, not over time: if a run panicked between the two
+        // assertions below, the `onboarded` marker it wrote survived, and the
+        // next run that happened to draw the same PID failed on the first
+        // assertion - because `create_dir_all` is happy with an existing
+        // directory and does not clear what is in it. `tempdir()` removes the
+        // whole tree on drop, panics included.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
         let meridian = dir.join(".meridian");
         std::fs::create_dir_all(&meridian).unwrap();
 
         // No marker yet → not onboarded → the reopen handler would open the wizard.
-        assert!(!is_onboarded(&dir));
-        assert_eq!(reopen_target(is_onboarded(&dir)), ReopenTarget::Wizard);
+        assert!(!is_onboarded(dir));
+        assert_eq!(reopen_target(is_onboarded(dir)), ReopenTarget::Wizard);
 
         // Marker present (mark_setup_complete writes an RFC-3339 stamp here) →
         // onboarded → the handler would open the dashboard.
         std::fs::write(meridian.join("onboarded"), "2026-07-07T00:00:00Z").unwrap();
-        assert!(is_onboarded(&dir));
-        assert_eq!(reopen_target(is_onboarded(&dir)), ReopenTarget::Dashboard);
-
-        let _ = std::fs::remove_dir_all(&dir);
+        assert!(is_onboarded(dir));
+        assert_eq!(reopen_target(is_onboarded(dir)), ReopenTarget::Dashboard);
     }
 }

--- a/tray/src-tauri/src/window_panel.rs
+++ b/tray/src-tauri/src/window_panel.rs
@@ -37,7 +37,8 @@
 /// setups) from placing the window past the monitor's right or bottom edge.
 ///
 /// Pure and platform-independent so it's unit-testable without a live window —
-/// same rationale as [`is_onboarded`] / [`reopen_target`] above.
+/// same rationale as [`crate::reopen::is_onboarded`] / [`crate::reopen::reopen_target`],
+/// which moved to their own module in the same split that created this one.
 pub(crate) fn tray_anchor_position(
     icon_pos: (i32, i32),
     icon_size: (i32, i32),

--- a/ui/__tests__/tutorial-click-fence.test.ts
+++ b/ui/__tests__/tutorial-click-fence.test.ts
@@ -61,10 +61,18 @@ describe('the walkthrough fences off stray clicks', () => {
     // If the fence ever moves below them it swallows Skip, and a user who
     // cannot reach the target also cannot leave.
     const fence = overlay.indexOf('<Cutout rect={ring} dim={false} />')
-    const skip = overlay.indexOf('onSkip')
+    // The RENDER site, not the prop. `indexOf('onSkip')` finds the destructuring
+    // in the component signature ~340 lines earlier, which sits before the fence
+    // no matter where the button is painted - so comparing against it would fail
+    // a correct file and pass a broken one. Anchor on the JSX that actually
+    // paints.
+    const skip = overlay.indexOf('<button onClick={onSkip}')
     const caption = overlay.indexOf("pointerEvents: 'auto', maxWidth:")
     expect(fence).toBeGreaterThan(-1)
     expect(caption).toBeGreaterThan(fence)
-    expect(skip).toBeGreaterThan(-1)
+    // Skip must paint AFTER the fence, not merely exist. The old `skip > -1` let
+    // the fence move below the Skip button - the one arrangement this test is
+    // here to forbid - without failing.
+    expect(skip).toBeGreaterThan(fence)
   })
 })

--- a/ui/app/setup/atoms.tsx
+++ b/ui/app/setup/atoms.tsx
@@ -109,7 +109,13 @@ function MacToggleOn() {
  *  equal height (`items-stretch` in PermissionsBody), so without this the
  *  pane itself would end up a different visible size in each card depending
  *  on how much text its title/blurb wrapped to. */
-function MacSettingsPanePreview({ permissionId }: { permissionId: 'accessibility' | 'screen' | 'notifications' }) {
+// The union deliberately EXCLUDES 'notifications'. That pane is a different
+// screen in System Settings and has its own component; routing it here is the
+// exact defect this split fixed, and a type that still accepted it would let a
+// future edit reintroduce it silently. Narrowing it means the compiler rejects
+// that call instead - and `PermissionPreview`'s ternary narrows `permissionId`
+// to the remaining two for free.
+function MacSettingsPanePreview({ permissionId }: { permissionId: 'accessibility' | 'screen' }) {
   const copy = MAC_PANE_COPY[permissionId]
   return (
     <div className="w-full flex flex-col" style={{
@@ -229,8 +235,18 @@ function MacNotificationsPanePreview() {
 
       {/* Scenery below - blurred for the same reason the other pane blurs its
          non-Meridian rows: recognisable as the real page, never mistakable for
-         something to click. */}
-      <div className="flex flex-col" style={{ flex: 1, gap: 5, margin: '6px 8px 8px', filter: 'blur(2px)', opacity: 0.5 }}>
+         something to click.
+
+         `aria-hidden` because blur is a purely visual "ignore this" and a
+         screen reader gets none of it. `PermCard` sets `selfDescribing = isMac`,
+         so on macOS the card renders no title or description of its own and
+         this preview carries the only text in it - which means "Badge
+         application icon" and "Play sound for notification" were being read out
+         as if they were the instruction. They are decoration for a pane the user
+         is not even on yet. The sharp "Allow notifications" row above stays
+         readable: that one IS the instruction. Matches `SimpleTogglePreview`,
+         which already hides its decorative toggle. */}
+      <div aria-hidden="true" className="flex flex-col" style={{ flex: 1, gap: 5, margin: '6px 8px 8px', filter: 'blur(2px)', opacity: 0.5 }}>
         <div className="flex items-start" style={{ gap: 6, padding: '6px 8px', borderRadius: 8, background: '#F0F0F1' }}>
           {placements.map((name) => (
             <div key={name} className="flex flex-col items-center" style={{ flex: 1, gap: 3 }}>

--- a/ui/components/tutorial/engine.ts
+++ b/ui/components/tutorial/engine.ts
@@ -85,8 +85,11 @@ export interface Stage {
   /** Hand control to the user and resolve once the input/textarea at
    *  `selector` holds at least `minWords` whitespace-separated words —
    *  checked on arrival, then on every change, until it clears the floor or
-   *  `fallbackMs` elapses. Resolves `false` on timeout, same contract as
-   *  `waitForClick`/`waitForValue`.
+   *  `fallbackMs` elapses. Resolves `false` on timeout, and also `false` if the
+   *  field disappears (the composer closed) - same contract as
+   *  `waitForClick`/`waitForValue`, which answer `false` for a target that is
+   *  not there. Only a title that actually cleared the floor resolves `true`,
+   *  because callers gate "the task can be saved" on this.
    *
    *  `waitForValue`'s `settled` only asks "is there SOMETHING here" — the
    *  composer's `canCreate` asks "is there ENOUGH here" (`MIN_TITLE_WORDS`),

--- a/ui/components/tutorial/useTutorial.tsx
+++ b/ui/components/tutorial/useTutorial.tsx
@@ -433,12 +433,19 @@ export function useTutorial(opts: {
           }
           function onAbort() { settle(false) }
           const timer = setTimeout(() => settle(false), o?.fallbackMs ?? 90000)
-          // Same target-vanished handling as waitForValue/waitForClick: the
-          // composer closing out from under this wait is the step ending, not
-          // a miss, so it counts as done rather than burning the fallback.
+          // A vanished target settles FALSE, not true. It settles immediately
+          // either way - the point of noticing is to avoid burning the fallback
+          // on a field that is gone - but the answer this returns is "did the
+          // title clear the floor", and a composer that closed did not. `true`
+          // there made the script take its titleReady branch and narrate
+          // "Saved." over a task that was never created: the exact false claim
+          // the word-count check was added to stop, coming back through a
+          // different door. `false` is also what `waitForClick` answers when its
+          // target never rendered, so this is the sibling primitives' contract
+          // rather than a special case.
           let raf = requestAnimationFrame(function tick() {
             const node = tourTarget(sel) as HTMLInputElement | HTMLTextAreaElement | null
-            if (!node) { settle(true); return }
+            if (!node) { settle(false); return }
             if (words(node.value) >= minWords) { settle(true); return }
             raf = requestAnimationFrame(tick)
           })

--- a/ui/lib/bridge.ts
+++ b/ui/lib/bridge.ts
@@ -57,18 +57,54 @@ export function isTauri(): boolean {
  *  Two physical pixels, immediately reverted, is enough to trigger that
  *  without a perceptible flash. No-op outside Tauri; failures are swallowed
  *  since this is a cosmetic repaint fix, not something a user action should
- *  ever fail on. */
-export async function nudgeWindowRepaint(): Promise<void> {
+ *  ever fail on.
+ *
+ *  Swallowing failures is not the same as leaking them. Two things this must
+ *  never do, both of which leave the window permanently WRONG rather than
+ *  merely un-repainted:
+ *
+ *  1. **Grow and not shrink back.** The grow and the restore are two awaits, and
+ *     the old shape put both in one `try` — so a restore that threw left the
+ *     window a pixel wider for the rest of the session, silently. The restore
+ *     now runs from `finally`, with its own catch.
+ *  2. **Restore a size another call is mid-way through changing.** Callers are
+ *     step transitions, which can overlap; two concurrent nudges could each read
+ *     `innerSize()` while the other had it grown, and then "restore" to that
+ *     inflated number. The window creeps a pixel wider every time. Calls are
+ *     therefore serialised through one chain, so a nudge always measures a
+ *     settled window. */
+let repaintQueue: Promise<void> = Promise.resolve()
+
+export function nudgeWindowRepaint(): Promise<void> {
+  // `then(run, run)` rather than `.finally(run)`: the next nudge must run whether
+  // or not the previous one settled cleanly, and must not inherit its rejection.
+  const next = repaintQueue.then(runWindowRepaint, runWindowRepaint)
+  repaintQueue = next
+  return next
+}
+
+async function runWindowRepaint(): Promise<void> {
   const t = tauri()
   if (!t) return
+  // Captured as a closure the moment the original size is known, so `finally`
+  // can restore without re-reading a size that is currently perturbed.
+  let restore: null | (() => Promise<void>) = null
   try {
     const win = t.window.getCurrentWindow()
-    const { width, height } = await win.innerSize()
     const { PhysicalSize } = t.window
+    const { width, height } = await win.innerSize()
+    restore = () => win.setSize(new PhysicalSize(width, height))
     await win.setSize(new PhysicalSize(width + 1, height))
-    await win.setSize(new PhysicalSize(width, height))
   } catch {
     // cosmetic only
+  } finally {
+    if (restore) {
+      try {
+        await restore()
+      } catch {
+        // cosmetic only
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Addresses the CodeRabbit review that left **#748** (the 1.86 release PR) at `CHANGES_REQUESTED`. Targets `pre-main`, so #748 picks it up automatically.

**20 of 22 open threads fixed. 2 rejected with reasons** rather than silently skipped — and one of the "fixes" needed correcting because the suggested change was itself wrong.

## Correctness

- **`waitForMinWords` reported success for a removed field.** It resolved `true` when its target vanished, so a composer closed mid-wait made the script take its `titleReady` branch and narrate **"Saved." over a task that was never created** — the exact false claim the word-count check was added to stop, returning through a different door. Now `false`, which is also what `waitForClick` answers for a target that isn't there, so this is the sibling primitives' contract rather than a special case. The honest "No rush - finish it whenever you like" branch already existed and now actually runs.
- **`nudgeWindowRepaint` could strand the window a pixel wider.** Grow and restore were two awaits in one `try`, so a restore that threw left it enlarged for the session, silently. Restore moved to `finally` with its own catch. Calls are now serialised too: they come from step transitions, which overlap, and two concurrent nudges could each measure while the other had the window grown, then "restore" to that inflated number — a pixel of creep per pair.

## Privacy docs — wrong in the direction that matters

- The overview claimed **"exactly three kinds"** of network call above a list of **five**, and **"you control all of them"** when analytics and the counter ping have no off switch. Both corrected; the counter entry now also mentions personal-task updates, which trigger it.
- It claimed captured text never leaves the device while listing AI summarisation, which sends exactly that to the configured provider. Reworded so the claim actually made — Meridiana never receives it — is the true one.
- **Export Diagnostics was described as containing "nothing the automatic path would not already send".** Verified false: `build_export_bundle` copies `pending/` and `sent/` **verbatim with no redaction**, and the spool is captured at full fidelity, so the archive carries `INFO`/`DEBUG` records and unredacted attributes that the WARN+-only redacted ship leg strips. Users are now told to inspect it before sending. **CLAUDE.md carried the identical false claim** and is corrected too.

## Stale docs

- `CLAUDE.md`'s "Add a new UI API route" told contributors to create `ui/app/api/<name>/route.ts` with better-sqlite3. That directory doesn't exist and better-sqlite3 isn't a `ui/` dependency. Replaced with a pointer to the Tauri-command playbook.
- `.claude/skills/meridian-ui/SKILL.md` was worse — a "migration in progress" banner for a migration that landed, and a Key Files table naming `ui/app/sessions/`, `ui/app/apps/`, `@/lib/db`, `@/lib/category-colors`, none of which exist. Patching would have left most of it wrong, so it's **rewritten against the current tree, verified file by file** (including checking the `load`/`mutate`/`subscribe` signatures I documented).
- Workspace inventories listed 4 members; `Cargo.toml` has 5 since the clerk plugin was vendored.
- `cargo build --release` builds the root package alone and never touches the tray → `--workspace`, matching the note directly below it.
- Two consecutive `cd ui` lines in a copyable block put the second in `ui/ui`.
- Social preview path → Settings - General. README named 3 trackers in step 3 and 5 in the intro.

## Code quality

- **`walkthrough.rs`** built error strings with `{e}`, which renders only the outermost message. Marker I/O moved into `anyhow` helpers with per-step context, rendered once at the Tauri boundary through `cmd_err!` — the pattern #704 added after a corrupt database reached the dashboard as a bare `tasks: today presence`. Both commands now record `otel.status_code = ERROR`.
- **`reopen.rs`** test used a PID-named directory. A PID is unique among *live* processes, not over time: a panic mid-test left an `onboarded` marker that `create_dir_all` won't clear, so a later run drawing the same PID failed on the first assertion. `tempfile::tempdir()` cleans up on drop.
- **`window_panel.rs`** had intra-doc links to `is_onboarded`/`reopen_target` as if they were still in that file.
- **`atoms.tsx`**: blurred pane scenery is now `aria-hidden`. `PermCard` sets `selfDescribing = isMac`, so on macOS the preview carries the card's only text and a screen reader was announcing "Badge application icon" as the instruction. `MacSettingsPanePreview` also no longer accepts `'notifications'` — routing that pane there is the defect the split fixed, and a type still allowing it could let it back in silently.
- **`setup-hooks.sh`** em dashes — all four lines, not just the one this release touched, since fixing one would leave the block inconsistent.

## One correction to the review itself

`tutorial-click-fence.test.ts` **did** under-assert: `skip > -1` allowed the fence to move below the Skip button, the single arrangement the test exists to forbid. But the suggested `indexOf('onSkip')` comparison finds the **props destructuring at line 149**, ~340 lines above the fence — so it fails a correct file and would pass a broken one. Confirmed empirically: applying it as suggested failed at `7689` vs `14810`, while the actual render sits at line 494. Anchored on `<button onClick={onSkip}` instead.

## Rejected, with reasons

| Thread | Why not |
|---|---|
| `docs/privacy.md` — "use `macOS`, not `macos`" | The backticked value is the **literal telemetry property**: `std::env::consts::OS`, which is `"macos"`. Capitalising it would make the privacy doc misstate what is actually transmitted. |
| `.env.example` — Trello/Jira contradiction | Obsolete (thread is already flagged outdated). Neither `JIRA_OAUTH_CLIENT_SECRET` nor `TRELLO_APP_KEY` appears in the file any more. |

## Verification

`cargo fmt` · `cargo clippy --workspace --all-targets -- -D warnings` · `cargo test --workspace` · `bun test` **759 pass / 0 fail** · `tsc --noEmit` clean · full pre-push suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
