### PR TITLE
fix: address the second review pass on the 1.86 release PR

### DIFF
--- a/.claude/skills/meridian-ui/SKILL.md
+++ b/.claude/skills/meridian-ui/SKILL.md
@@ -33,13 +33,17 @@ npm run typecheck  # tsc --noEmit
 bun test           # dashboard tests
 ```
 
-Two gotchas worth knowing before you debug either:
+Two things worth knowing before you debug either:
 
 - **Never run `next dev` with `NODE_ENV` set** - that is why the script is
-  `env -u NODE_ENV next dev`. A stale `ui/.next` after a branch or config switch
-  produces an `Invalid distDirRoot` panic; `rm -rf ui/.next` clears it.
-- **The popover 404s under `tauri dev`** (next dev does not serve `popover/`). It
-  renders correctly in a packaged build. This is expected, not a bug to chase.
+  `env -u NODE_ENV next dev`. A stale `.next` after a branch or config switch
+  produces an `Invalid distDirRoot` panic; `rm -rf .next` from `ui/` clears it.
+- **The popover works under `tauri dev` too.** `tauri.conf.json`'s
+  `beforeDevCommand` runs `node scripts/sync-popover.mjs dev`, which copies
+  `tray/src/` into `ui/public/popover/`, and `next dev` serves `public/` at the
+  root - so `/popover/index.html` resolves. The build does the same into
+  `out/popover/`. If it 404s, the sync step did not run: start the tray with
+  `npm run tauri dev` from `tray/` rather than starting `next dev` by hand.
 
 ## Reaching data: the bridge, never fetch
 
@@ -109,9 +113,11 @@ a source scan that matches nothing passes vacuously.
 ## Adding a component
 
 1. First line must be the file header:
+
    ```ts
    //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
    ```
+
 2. Typed props, no `any`.
 3. Data through `@/lib/bridge`, types from `@/lib/api-types`.
 4. User-facing strings use a plain hyphen `-`, never an em-dash - see the Hard Rules in
@@ -120,13 +126,22 @@ a source scan that matches nothing passes vacuously.
 ## Common issues
 
 ### `Invalid distDirRoot` panic in dev
-Stale cache after a branch or config switch: `rm -rf ui/.next`.
+
+Stale cache after a branch or config switch. From `ui/`:
+
+```bash
+rm -rf .next
+```
 
 ### An `invoke` silently does nothing
+
 The window label is probably missing from `tray/src-tauri/capabilities/default.json`.
 Un-permitted `invoke`s and events are denied without an error.
 
 ### Build type errors
+
+From `ui/`:
+
 ```bash
-cd ui && npm run typecheck
+npm run typecheck
 ```

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -21,6 +21,11 @@ fi
 
 export SQLX_OFFLINE=true
 echo "Running cargo fmt check..."
-cargo fmt --check || { echo "Run 'cargo fmt' before committing"; exit 1; }
+cargo fmt --all --check || { echo "Run 'cargo fmt --all' before committing"; exit 1; }
+# --workspace, matching pre-push and CI. The repo root is itself a package, so a
+# bare `cargo clippy` lints the daemon ALONE and silently skips meridian-core,
+# meridian-oauth, the tray and the vendored tauri-plugin-clerk - the exact trap
+# CONTRIBUTING.md warns about, which this hook was quietly falling into while
+# that document claimed the hooks covered it.
 echo "Running cargo clippy..."
-cargo clippy -- -D warnings || { echo "Fix clippy warnings before committing"; exit 1; }
+cargo clippy --workspace --all-targets -- -D warnings || { echo "Fix clippy warnings before committing"; exit 1; }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,9 @@
 
 <!-- What did you run? Paste relevant output, screenshots, or test results. -->
 
-- [ ] `cargo test` passes
-- [ ] `cargo clippy -- -D warnings` passes
-- [ ] `cargo fmt --check` passes
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
+- [ ] `cargo fmt --all --check` passes
 - [ ] UI builds (`cd ui && npm run build`)
 - [ ] Manually tested the relevant flow
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,8 +26,14 @@ worse than no feature at all.
 ## The pieces
 
 Meridian is two long-running processes plus two libraries, all on your machine. There
-is no remote server - nothing of yours is hosted anywhere. The MCP server below is a
-local process an AI client starts on demand over stdio; it listens on no port.
+is no remote server: your activity database, captured text, and credentials live on
+disk and are never uploaded. Diagnostics are the exception - a packaged build ships
+redacted, error-level telemetry unless you turn it off, and the summarisation you
+configure sends session text to your chosen LLM provider. `docs/privacy.md` lists
+every outbound path in full.
+
+The MCP server below is a local process an AI client starts on demand over stdio; it
+listens on no port.
 
 ```text
 ┌──────────────────────────────┐        ┌──────────────────────────────┐

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,8 +128,11 @@ meridian/
 > live in `ui/lib/api-types.ts` (moved out of the deleted routes). **Asset layout:** `frontendDist` →
 > `../../ui/out`; the build copies the tray popover into `out/popover/` and the main window loads
 > `popover/index.html`; dashboard/setup windows load `WebviewUrl::App("today"/"setup")` → `out/<route>/index.html`
-> (`trailingSlash: true`). **Known limitation:** the popover 404s under `tauri dev` (next dev doesn't serve
-> `popover/`); it renders in a packaged build. **When adding a route, follow the playbook in Coding
+> (`trailingSlash: true`). The popover works in BOTH profiles: `tauri.conf.json`'s
+> `beforeDevCommand` runs `node scripts/sync-popover.mjs dev`, which copies `tray/src/` into
+> `ui/public/popover/` for `next dev` to serve, and the build does the same into `out/popover/`.
+> (This used to be a documented "404s under `tauri dev`" limitation; the sync script closed it.)
+> **When adding a route, follow the playbook in Coding
 > Conventions → "Porting a dashboard route to Rust"**; exemplars: `meridian-core/src/readers/triage.rs`,
 > `tray/src-tauri/src/commands/parents.rs`. The dashboard ships **embedded in the tray binary** (`tauri
 > build` → `generate_context!` bundles `ui/out`); the standalone-Node-server release machinery (the
@@ -354,7 +357,7 @@ The fold replaces every `ui/app/api/*` route with a Rust command the frontend ca
 - UI API routes live in `ui/app/api/`; keep them thin — query, transform, return JSON
 - No `any` types unless unavoidable and justified with a comment
 - **NEVER `window.confirm` / `window.alert` / `window.prompt` — they do nothing in the packaged tray.** WKWebView routes JS dialogs through the host app's `WKUIDelegate`, and nothing in the stack installs one (`wry`, `tauri-runtime-wry`, `tauri`, `tauri-utils` were each grepped for `ConfirmPanel|AlertPanel|WKUIDelegate` — all empty), so `confirm()` always returns `false` and `alert()` is a no-op. The damage is silence: a falsy `confirm()` is indistinguishable from the user clicking Cancel, so the gated action quietly never runs while every log, gate and test still passes. That is how the `db.corrupt` **Repair Database** button shipped dead in 1.83.0 — recovery had to be driven by hand from a terminal. Use `@/components/ConfirmDialog` (`ConfirmDialog` for consent, `AlertDialog` for failures). `__tests__/no-native-dialogs.test.ts` fails the build if they come back. `tauri-plugin-dialog` would also work but is not a dependency, and adding one costs a capability grant for a box the webview can render itself.
-- **Spawning the `meridian` binary from a UI route: ALWAYS use `selectMeridianBinary(meridianCandidates())` from `@/lib/meridian-bin`.** Never spawn a bare `'meridian'` (relies on `$PATH`), and never hand-roll a candidate list. The dashboard runs under **launchd**, whose PATH lacks Homebrew's `node`, so the `#!/usr/bin/env node` wrapper at `~/.local/bin/meridian` dies with `env: node: No such file or directory`. The helper probes the **native binary first** (`~/.meridian/app/bin/meridian`, no runtime deps → works under launchd), so it behaves identically in dev and installed. This bug is invisible in `dev-start` (dev installs a bash wrapper, not a node one) — it only surfaces on bundle/npm installs. `__tests__/meridian-bin.test.ts` guards the ordering. The one sanctioned exception is launching `meridian` in a user Terminal (`open -a Terminal …`, e.g. `api/update`), where an interactive login shell *does* have node/PATH.
+- **Spawning the `meridian` binary: ALWAYS use `crate::install::meridian_bin()` (Rust), never a bare `"meridian"` and never a hand-rolled candidate list.** This moved: `@/lib/meridian-bin` and its `selectMeridianBinary(meridianCandidates())` no longer exist — the dashboard is a static export with no server-side process spawning, so every shell-out is a tray command now. The ordering rationale carried over intact and is why the helper exists: a process started under **launchd** has a minimal PATH without Homebrew's `node`, so the `#!/usr/bin/env node` wrapper at `~/.local/bin/meridian` dies with `env: node: No such file or directory`. `meridian_bin()` therefore probes the **native staged binary first** (`~/.meridian/bin/meridian`, no runtime deps), falls back to the user-local wrapper, and only then to bare `meridian` on `$PATH`. `MERIDIAN_BIN` overrides everything (logged; ignored with a warning if it points at nothing). On Windows the staged name is `meridian.exe` — the candidate list must match exactly or every shell-out silently falls through to the `$PATH` last resort, which is usually empty on a per-user install.
 
 ### SQL migrations
 
@@ -514,7 +517,7 @@ applies to both `pending/` and `sent/`, regardless of shipping status.
 1. Read `src/db/meridian.rs` or `src/db/screenpipe.rs`
 2. Follow the `sqlx::query_as` + `.context("description")` pattern
 3. Export from `src/db/mod.rs` if needed
-4. Run `cargo clippy -- -D warnings && cargo test`
+4. Run `cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace`
 
 ### Add a new ETL extraction signal
 
@@ -539,9 +542,10 @@ files, env, a process, or external HTTP becomes a `#[tauri::command]` under
 `tray/src-tauri/src/commands/`; the frontend reaches it through `ui/lib/bridge.ts`
 (`load`/`mutate`/`subscribe`), and its response type goes in `ui/lib/api-types.ts`.
 
-The `selectMeridianBinary(meridianCandidates())` rule still applies wherever the
-`meridian` binary is spawned — that code now lives in tray commands rather than route
-handlers.
+Spawning the `meridian` binary is a Rust concern now: use
+`crate::install::meridian_bin()`, never a bare `"meridian"`. It is the Rust port of the
+old Node helper and keeps the same ordering rationale (native staged binary first,
+because it has no runtime deps and survives launchd's minimal PATH).
 
 ### Add a notification (plain toast or interactive nudge)
 
@@ -681,7 +685,7 @@ fixtures that produce genuinely corrupt files live in `src/db/test_corrupt.rs`
 
 - Commit message style: `type(scope): short description` — e.g. `fix(etl): detect sleep gaps that span ETL run boundaries`
 - `commit-msg` hook validates conventional commits format — fix message before retrying
-- `pre-commit` hook runs `cargo fmt --check` and `cargo clippy -- -D warnings`
+- `pre-commit` hook runs `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings`
 - `pre-push` hook runs the full suite: `cargo fmt` + `cargo clippy --workspace` + UI build + UI tests + security audit (claude CLI) + `cargo test --workspace`
 - Never skip hooks with `--no-verify`
 - Install hooks after cloning: `bash scripts/setup-hooks.sh`

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -305,7 +305,8 @@ exactly two notification controls: the master switch and quiet hours.
 Deferred (same rails, thin slices when needed): task-switch verify producer +
 rate cap (PR 2), goal check-in / distraction producers, LLM-generated copy
 (routed through the chosen CLI provider, `src/llm/`), APNs/phone delivery, a
-`worklog.ready` producer (needs a decision: build a real scheduler for
-unattended draft generation, or repoint the event at something already
-autonomous), an onboarding-stuck reminder (needs a resumable wizard-progress
+`worklog.ready` producer (the scheduler half is **done** — `pm_worklog::auto_generate`
+drafts unattended at `worklog_auto_generate_time`, and `day_summary.ready` already
+notifies off that same gate; what is left is purely the scoping decision: which drafts
+are worth a toast, and one per day or one per draft), an onboarding-stuck reminder (needs a resumable wizard-progress
 timestamp — today's `~/.meridian/onboarded` flag is one-shot).

--- a/src/day_summary/auto.rs
+++ b/src/day_summary/auto.rs
@@ -90,6 +90,10 @@ pub async fn maybe_auto_summarise(pool: &SqlitePool, day_local: &str) {
         day = day_local,
         chosen_time = Empty,
         gate = Empty,
+        // Every failure on this path is swallowed by design - a background nicety
+        // must not fail its caller. That makes the span the ONLY place a failed run
+        // is distinguishable from a skipped one, since the return type cannot say.
+        otel.status_code = Empty,
     );
     run(pool, day_local).instrument(span).await
 }
@@ -123,6 +127,8 @@ async fn run(pool: &SqlitePool, day_local: &str) {
         }
         Ok(_) => {}
         Err(e) => {
+            cur.record("gate", "summary_read_failed");
+            cur.record("otel.status_code", "ERROR");
             tracing::warn!(day = day_local, error = %e, "day summary: auto existing-check failed - skipping");
             return;
         }
@@ -137,6 +143,8 @@ async fn run(pool: &SqlitePool, day_local: &str) {
         }
         Ok(_) => {}
         Err(e) => {
+            cur.record("gate", "day_task_read_failed");
+            cur.record("otel.status_code", "ERROR");
             tracing::warn!(day = day_local, error = %e, "day summary: auto day-task read failed - skipping");
             return;
         }
@@ -154,10 +162,13 @@ async fn run(pool: &SqlitePool, day_local: &str) {
             );
             notify_ready(pool, day_local, &s).await;
         }
-        Err(e) => tracing::warn!(
-            day = day_local, error = %e,
-            "day summary: auto-compose failed - the user can still compose it manually"
-        ),
+        Err(e) => {
+            cur.record("otel.status_code", "ERROR");
+            tracing::warn!(
+                day = day_local, error = %e,
+                "day summary: auto-compose failed - the user can still compose it manually"
+            );
+        }
     }
 }
 
@@ -175,14 +186,20 @@ async fn run(pool: &SqlitePool, day_local: &str) {
 /// Best-effort, like everything else on this path - a failed enqueue is logged and
 /// swallowed, because the summary itself was composed successfully and that is the
 /// part that matters.
-#[tracing::instrument(skip(pool, s))]
+#[tracing::instrument(
+    skip(pool, s),
+    fields(dedup_key = Empty, expires_at = Empty, outcome = Empty, otel.status_code = Empty)
+)]
 async fn notify_ready(pool: &SqlitePool, day_local: &str, s: &DaySummary) {
+    let cur = tracing::Span::current();
     if s.fallback {
+        cur.record("outcome", "skipped_fallback");
         tracing::debug!(day = day_local, "day summary: fallback - not notifying");
         return;
     }
 
     let dedup = format!("day_summary.ready:{day_local}");
+    cur.record("dedup_key", dedup.as_str());
     let body = summary_body(s.adherence.done, s.adherence.planned);
     let mut n = NewNotification::event(
         &dedup,
@@ -193,26 +210,40 @@ async fn notify_ready(pool: &SqlitePool, day_local: &str, s: &DaySummary) {
     .link(meridian_core::notifications::deep_links::SUMMARY)
     .interactive(meridian_core::notifications::categories::GENERIC_LINK);
 
-    // Expiry is the next local midnight - the moment the day it reviews stops
-    // being today. `None` only on a calendar edge; the enqueue still goes out
-    // without one, since a summary notification that outlives its day is a far
-    // smaller problem than one that never arrives.
+    // Expiry is the next local midnight - the moment the day it reviews stops being
+    // today. `next_local_midnight_utc` walks a DST gap rather than surrendering to it,
+    // so `None` here means the calendar itself ran out (the last representable date).
+    // The enqueue still goes out: a notification that outlives its day is a smaller
+    // problem than one that never arrives. It is recorded on the span, because the
+    // banner half of this row only self-clears if an expiry is present.
     let expires = next_local_midnight_utc(&Local::now());
-    if let Some(exp) = expires.as_deref() {
-        n = n.expiring(exp);
+    match expires.as_deref() {
+        Some(exp) => {
+            cur.record("expires_at", exp);
+            n = n.expiring(exp);
+        }
+        None => tracing::warn!(
+            day = day_local,
+            "day summary: no expiry could be computed - the banner will need dismissing"
+        ),
     }
 
     match notifications::enqueue(pool, n).await {
         // Logged at INFO because "was the user actually told?" is the first
         // question any report about this feature raises, and the answer is
         // otherwise only visible as a row in the outbox.
-        Ok(()) => tracing::info!(
-            day = day_local,
-            expires = expires.as_deref().unwrap_or(""),
-            "day summary: ready notification enqueued"
-        ),
+        Ok(()) => {
+            cur.record("outcome", "enqueued");
+            tracing::info!(
+                day = day_local,
+                expires = expires.as_deref().unwrap_or(""),
+                "day summary: ready notification enqueued"
+            );
+        }
         Err(e) => {
-            tracing::warn!(day = day_local, error = %e, "day summary: ready notification failed to enqueue")
+            cur.record("outcome", "enqueue_failed");
+            cur.record("otel.status_code", "ERROR");
+            tracing::warn!(day = day_local, error = %e, "day summary: ready notification failed to enqueue");
         }
     }
 }
@@ -246,17 +277,46 @@ fn utc_iso(t: &DateTime<Local>) -> String {
         .to_string()
 }
 
-/// First instant of the next local day, as a UTC ISO string. `None` only on
-/// calendar edges (last representable date, a DST transition swallowing midnight).
+/// First instant of the next local day, as a UTC ISO string.
 ///
 /// A deliberate local twin of `daily_plan.rs`'s same-named helper rather than a
 /// shared one: both producers happen to expire at midnight today, but that is a
 /// per-notification policy choice, and hoisting it would make a later change to one
 /// silently retime the other.
+///
+/// # Midnight does not exist everywhere
+/// Several zones start DST at 00:00, so the clock jumps 23:59:59 → 01:00:00 and the
+/// local time `00:00` simply has no instant that night (Chile, Cuba, Iran, Lord Howe,
+/// parts of Brazil historically). `from_local_datetime(...).earliest()` correctly
+/// answers `None` there, and the old code let that `None` fall through to "no expiry".
+///
+/// That is the worst possible outcome for this producer rather than a harmless edge:
+/// the row also goes to the BANNER channel, `active_banners` only filters rows whose
+/// `expires_at` has passed, and a NULL never passes — so on those nights the summary
+/// banner would sit in the dashboard forever, exactly the `board.hygiene` failure that
+/// needed migration 077 to clean up. So the gap is walked instead of surrendered to.
 fn next_local_midnight_utc(now: &DateTime<Local>) -> Option<String> {
     let midnight = now.date_naive().succ_opt()?.and_hms_opt(0, 0, 0)?;
-    let local = Local.from_local_datetime(&midnight).earliest()?;
+    let local = first_existing_local(midnight, |n| Local.from_local_datetime(&n).earliest())?;
     Some(utc_iso(&local))
+}
+
+/// Step forward from `from` until `resolve` yields an instant that actually exists.
+///
+/// Generic over the resolver purely so the DST gap is testable: `Local` reads the
+/// host's zone, and this repo has no `chrono-tz`, so a real spring-forward cannot be
+/// reproduced in a unit test without mutating process-global `TZ`. A stub resolver
+/// exercises the identical walk deterministically.
+///
+/// 15-minute steps over a 6-hour window: every real transition is 30 or 60 minutes and
+/// aligned to a quarter hour, so this lands exactly on the instant the clock jumps to.
+/// Bounded rather than unbounded because "no valid time in the next six hours" means
+/// something is wrong with the zone data, and a loop is a worse answer than `None`.
+fn first_existing_local<T>(
+    from: chrono::NaiveDateTime,
+    resolve: impl Fn(chrono::NaiveDateTime) -> Option<T>,
+) -> Option<T> {
+    (0..=24).find_map(|step| resolve(from + chrono::Duration::minutes(15 * step)))
 }
 
 #[cfg(test)]
@@ -311,6 +371,46 @@ mod tests {
         );
         assert!(expiry.ends_with('Z') && !expiry.contains('.'), "{expiry}");
         assert_eq!(expiry.len(), 20, "{expiry} is not YYYY-MM-DDTHH:MM:SSZ");
+    }
+
+    /// A zone that starts DST at midnight has no 00:00 that night, and the naive
+    /// answer (`earliest()` -> `None` -> no expiry) is the worst one available: this
+    /// row also goes to the banner channel, `active_banners` only drops rows whose
+    /// `expires_at` has passed, and a NULL never passes - so the banner would sit in
+    /// the dashboard forever.
+    ///
+    /// Driven through a stub resolver rather than a real zone: `Local` reads the host
+    /// timezone, and with no `chrono-tz` in the workspace a genuine spring-forward
+    /// cannot be reproduced without mutating process-global `TZ`, which would leak
+    /// into every other test in this binary.
+    #[test]
+    fn a_skipped_midnight_still_yields_an_expiry() {
+        let midnight = chrono::NaiveDate::from_ymd_opt(2026, 9, 6)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        // Chile-style: the clock jumps 23:59:59 -> 01:00:00, so nothing in
+        // [00:00, 01:00) exists.
+        let gap_of_one_hour = |n: chrono::NaiveDateTime| {
+            (n.time() >= chrono::NaiveTime::from_hms_opt(1, 0, 0).unwrap()).then_some(n)
+        };
+
+        let resolved = first_existing_local(midnight, gap_of_one_hour)
+            .expect("the walk must clear a one-hour gap");
+        assert_eq!(
+            resolved.time(),
+            chrono::NaiveTime::from_hms_opt(1, 0, 0).unwrap(),
+            "must land on the instant the clock jumps to, not later"
+        );
+
+        // The ordinary case is untouched: a midnight that exists resolves to itself.
+        assert_eq!(first_existing_local(midnight, Some), Some(midnight));
+
+        // And it gives up rather than looping when nothing in the window resolves.
+        assert_eq!(
+            first_existing_local(midnight, |_: chrono::NaiveDateTime| None::<()>),
+            None
+        );
     }
 
     /// An in-memory stand-in for the outbox: `enqueue` needs `dedup_key` UNIQUE for

--- a/tray/src-tauri/src/commands/setup.rs
+++ b/tray/src-tauri/src/commands/setup.rs
@@ -110,8 +110,9 @@ pub async fn mark_setup_complete(app: tauri::AppHandle) -> Result<(), String> {
     // marker against — the two are only equal by construction, and a marker
     // written in a format the reader never matches would silently do nothing.
     let version = app.package_info().version.to_string();
-    let first_run = write_completion_markers(&home, &version)
-        .map_err(|e| format!("write setup markers: {e}"))?;
+    let first_run = write_completion_markers(&home, &version).map_err(
+        |e| crate::cmd_err!(level: error, e, "setup: could not write the completion markers"),
+    )?;
     // `first_run` is the whole story of this call and is not derivable after the
     // fact — the marker it keys off has just been overwritten — so it goes on the
     // log line. Without it, a re-run and a genuine first run are indistinguishable
@@ -136,15 +137,29 @@ pub async fn mark_setup_complete(app: tauri::AppHandle) -> Result<(), String> {
 /// Returns whether this was a FIRST RUN — the caller logs it, and it is not
 /// recoverable afterwards because the marker it is read from has by then been
 /// overwritten.
-fn write_completion_markers(home: &std::path::Path, version: &str) -> std::io::Result<bool> {
+fn write_completion_markers(home: &std::path::Path, version: &str) -> anyhow::Result<bool> {
+    use anyhow::Context;
+
     let dir = home.join(".meridian");
-    std::fs::create_dir_all(&dir)?;
+    std::fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
     // Read BEFORE the write below overwrites it. This is the ONE moment "setup"
     // and "onboarding" are distinguishable, and everything that separates them
     // hangs off this line — see the two `first_run` branches below.
     let first_run = !dir.join("onboarded").exists();
     let now = chrono::Local::now().to_rfc3339();
-    std::fs::write(dir.join("onboarded"), &now)?;
+    // ORDER IS LOAD-BEARING: the first-run markers are written BEFORE `onboarded`,
+    // and `onboarded` only once they have all succeeded.
+    //
+    // `onboarded` is the flag that makes the NEXT call read `first_run == false`.
+    // Writing it first meant a partial failure here — a full disk, a permission
+    // fault, anything — left the install permanently marked as onboarded while the
+    // two markers that first run owed it were never written. The next attempt then
+    // looks like a re-run and takes neither branch, so the user never gets the
+    // walkthrough and What's New fires the moment the wizard closes: both of the
+    // bugs these markers exist to prevent, arriving together and silently.
+    //
+    // Written last, a failure leaves `onboarded` absent, the run is still a first
+    // run next time, and the whole thing retries.
     if first_run {
         // The walkthrough is the second half of ONBOARDING, so a first run is what
         // earns it. See [`walkthrough_is_armed`] for why it needs its own marker
@@ -158,7 +173,8 @@ fn write_completion_markers(home: &std::path::Path, version: &str) -> std::io::R
         // in practice is a relaunch after an app update. That is the exact
         // scenario this marker was introduced to prevent, arriving through the
         // one door nobody checked. See `rerunning_setup_does_not_rearm_the_walkthrough`.
-        std::fs::write(dir.join(WALKTHROUGH_MARKER), &now)?;
+        std::fs::write(dir.join(WALKTHROUGH_MARKER), &now)
+            .with_context(|| format!("write {WALKTHROUGH_MARKER}"))?;
         // Stamp the running version as already seen, so "What's New" starts
         // announcing the NEXT release rather than firing the instant the wizard
         // closes. `has_unseen_release_notes` reads a missing marker as unseen —
@@ -170,8 +186,12 @@ fn write_completion_markers(home: &std::path::Path, version: &str) -> std::io::R
         // Also first-run only, and for the mirror-image reason: someone re-running
         // setup on a release whose notes they have NOT read is owed that
         // announcement, and swallowing it here would be silent.
-        crate::commands::whats_new::mark_whats_new_seen(home, version)?;
+        crate::commands::whats_new::mark_whats_new_seen(home, version)
+            .context("stamp the running version as seen")?;
     }
+    // Last, and only once every first-run marker above landed. See the comment on
+    // `first_run` for why this ordering is the whole point of the function.
+    std::fs::write(dir.join("onboarded"), &now).context("write the onboarded marker")?;
     Ok(first_run)
 }
 

--- a/ui/components/tutorial/useTutorial.tsx
+++ b/ui/components/tutorial/useTutorial.tsx
@@ -45,6 +45,28 @@ import { TutorialScreen } from './TutorialScreen'
  *  not lost user data. */
 const SEEN_KEY = 'meridian.walkthrough.seen.v1'
 
+/** Raise or clear the tray's "walkthrough is on screen" marker, in call order.
+ *
+ *  Serialised through one chain rather than fired independently, because the two
+ *  callers can run back to back within a single tick: `skipToDay` calls `finish`
+ *  (which clears the marker) and then `replayFromDay`, whose new run raises it.
+ *  Two independent `invoke()` calls have no ordering guarantee, so the older
+ *  CLEAR could land after the newer RAISE and delete the marker belonging to the
+ *  run that had just started - handing the tray's auto-opens permission to open
+ *  the daily planner over a live tour, which is the exact interruption the marker
+ *  exists to prevent.
+ *
+ *  Still fire-and-forget from the caller's side, and still swallowing failures:
+ *  losing this marker costs a possible interruption, never the tour. */
+let walkthroughMarkerQueue: Promise<void> = Promise.resolve()
+
+function setWalkthroughRunning(running: boolean): void {
+  const send = () => invoke('set_walkthrough_running', { running }).then(() => {}, () => {})
+  // `then(send, send)`: the next update must go out whether or not the previous
+  // one settled cleanly, and must not inherit its rejection.
+  walkthroughMarkerQueue = walkthroughMarkerQueue.then(send, send)
+}
+
 /** DEV ONLY: set to `'day'` to start the walkthrough at part two. Read by
  *  `runScript`'s `devDayHalfOnly`, which is itself gated on a non-production
  *  build - so this key does nothing in a packaged app. Kept in localStorage
@@ -160,7 +182,7 @@ export function useTutorial(opts: {
     // the marker carries its start time and goes stale on its own, so quitting
     // or crashing mid-tour cannot suppress the daily planner forever (see
     // commands/walkthrough.rs).
-    invoke('set_walkthrough_running', { running: false }).catch(() => {})
+    setWalkthroughRunning(false)
     setCaption('')
     setCentered(false)
     setCursorAt(null)
@@ -710,7 +732,7 @@ export function useTutorial(opts: {
       // waiting on, and the tour then waits out a timeout measured in minutes.
       // Fire-and-forget: failing to raise the marker costs a possible
       // interruption, never the tour.
-      invoke('set_walkthrough_running', { running: true }).catch(() => {})
+      setWalkthroughRunning(true)
       try {
         await runScript(stageRef.current)
       } catch (e) {


### PR DESCRIPTION
Second CodeRabbit pass on **#748**. **11 of 12 threads fixed, 1 deferred with a reason.** Targets `pre-main`, so #748 picks it up.

Several are on my own previous round — including two claims I introduced *while fixing other people's inaccurate claims*.

## Ordering bugs (the two that matter)

**`write_completion_markers` wrote `onboarded` first.** That flag is what makes the next call read `first_run == false`, so a partial failure — full disk, permission fault — left the install permanently marked onboarded with **neither** first-run marker written. The user then never gets the walkthrough **and** What's New fires the moment the wizard closes: both of the bugs those markers exist to prevent, arriving together and silently. Now written last, so a failure leaves the whole thing retryable. Helper returns `anyhow::Result` with per-step context, rendered once at the boundary via `cmd_err!`.

**`set_walkthrough_running` had no ordering guarantee.** Two independent `invoke()`s, and `skipToDay` calls `finish()` (clear) then immediately starts a replay (raise). The stale CLEAR could land after the new RAISE and delete the marker for the run that had just begun — handing the tray's auto-opens permission to open the planner over a live tour, the exact interruption the marker exists to prevent. Serialised through one chain, same shape as the `nudgeWindowRepaint` fix.

## Midnight that does not exist

`next_local_midnight_utc` used `from_local_datetime(..).earliest()`, which correctly answers `None` in zones that start DST at 00:00 (Chile, Cuba, Iran, Lord Howe) — and that `None` fell through to **no expiry**.

That is the worst available outcome, not a harmless edge: the row also goes to the **banner** channel, `active_banners` only drops rows whose `expires_at` has passed, and a NULL never passes. On those nights the summary banner would sit in the dashboard forever — the `board.hygiene` failure that needed migration 077 to clean up. The gap is now walked in 15-minute steps over a bounded 6-hour window, landing exactly on the instant the clock jumps to.

Tested through a stub resolver rather than a real zone: `Local` reads the host timezone, there's no `chrono-tz` in the workspace, and mutating process-global `TZ` would leak into every other test in the binary.

## Two claims I got wrong last round

- **ARCHITECTURE.md**: I wrote *"nothing of yours is hosted anywhere"* while fixing privacy overclaims elsewhere — which is itself one. Packaged builds ship redacted error telemetry, and summarisation sends session text to the configured provider. Qualified, pointing at `docs/privacy.md`.
- **The popover does not 404 under `tauri dev`.** `beforeDevCommand` runs `sync-popover.mjs dev`, copying `tray/src/` into `ui/public/popover/` for next dev to serve. I copied that claim from CLAUDE.md's "Known limitation" note, which the sync script had already made obsolete. Both corrected.

## Stale, verified against the tree

- `@/lib/meridian-bin`, `selectMeridianBinary` and `__tests__/meridian-bin.test.ts` **do not exist** — zero references in `ui/`. CLAUDE.md described the helper as the rule in two places. Rust resolves with `crate::install::meridian_bin()`; the ordering rationale (native staged binary first, because launchd's PATH has no `node`) carried over and is now documented where it lives.
- `docs/notifications.md`'s deferred list still said `worklog.ready` needs a scheduler built — contradicted by the table two paragraphs above it and by this release's own `day_summary.ready`.

## `--workspace`, actually

CONTRIBUTING.md claims *"CI and the git hooks pass `--workspace` for exactly this reason."* **The pre-commit hook did not** — bare `cargo clippy -- -D warnings`, which lints the daemon alone and skips `meridian-core`, `meridian-oauth`, the tray, and the vendored clerk plugin. The document asserted the trap was covered while the hook was falling into it. Hook, CLAUDE.md's two root-level command lines, and the PR-template checkboxes all corrected. Slower per commit; correct.

## Also

`otel.status_code` on `day_summary.auto.run` and `notify_ready`, recording `ERROR` on every swallowed failure — everything on that path is swallowed by design, so the span is the only place a failed run is distinguishable from a skipped one. `notify_ready` also carries `dedup_key`, `expires_at` and `outcome`, and warns when no expiry could be computed. Plus markdown lint (MD022/MD031/MD040) and the `cd ui` / `rm -rf ui/.next` mismatch in the skill file I rewrote last round.

## Deferred, not skipped

`setup.rs` is **1023 lines** against the 500-line rule, and the suggestion is to extract its tests. Agreed in principle, not done here: it is a pre-existing violation this release did not create, and the extraction means `setup.rs` → `setup/mod.rs` plus a tests module — structural churn inside a release PR whose other changes are all small and reviewable. Worth its own PR where a mistake would be visible.

## Verification

`cargo fmt` · `clippy --workspace --all-targets -- -D warnings` · `cargo test --workspace` · `bun test` **759 pass / 0 fail** · `tsc --noEmit` clean · `markdownlint-cli2` clean for the flagged rules · full pre-push suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
