### PR TITLE
fix(tray): stop trapping Windows users in a borderless dashboard

### DIFF
--- a/tray/src-tauri/src/reopen.rs
+++ b/tray/src-tauri/src/reopen.rs
@@ -133,6 +133,51 @@ mod reopen_tests {
         }
     }
 
+    /// …but `set_fullscreen` itself must be macOS-only.
+    ///
+    /// THE ONE THIS EXISTS FOR. On macOS full-screen is a first-class window
+    /// mode with its own exit: the menu bar drops down on hover, the green
+    /// button is there, `Ctrl+Cmd+F` works. On Windows the same call means
+    /// `Fullscreen::Borderless`, and tao does three separate things with it
+    /// (`platform_impl/windows/window.rs`): sets `MARKER_BORDERLESS_FULLSCREEN`,
+    /// which strips the title bar and with it minimize/maximize/close; sizes to
+    /// `monitor.size()`, the FULL monitor rect rather than the work area, so the
+    /// taskbar is covered; and calls `taskbar_mark_fullscreen(hwnd, true)` to ask
+    /// the shell to yield. Nothing in this app binds F11 or Escape on that
+    /// window, so the result is a dashboard a Windows user cannot leave except
+    /// with Alt+F4.
+    ///
+    /// `fill_work_area` stays on both platforms and is already right for
+    /// Windows - it reads `work_area()`, which excludes the taskbar.
+    ///
+    /// Source-scanned rather than unit-tested because the defect is a window
+    /// STATE on another OS: it compiles cleanly, passes every macOS test, and is
+    /// invisible until someone runs the build on Windows.
+    #[test]
+    fn full_screen_is_requested_on_macos_only() {
+        let src = include_str!("sys.rs");
+        let at = src
+            .find("set_fullscreen(true)")
+            .expect("sys.rs no longer requests full-screen at all");
+        // The gate must be the nearest thing above the call, not merely present
+        // somewhere in the file.
+        let before = &src[..at];
+        let gate = before
+            .rfind("#[cfg(target_os = \"macos\")]")
+            .expect("set_fullscreen(true) is not behind a macOS cfg gate");
+        assert!(
+            !before[gate..].contains("\nfn ") && !before[gate..].contains("\npub(crate) fn "),
+            "the nearest macOS cfg gate is on a different item, so set_fullscreen \
+             still runs on Windows and traps the user in a borderless window"
+        );
+        // And the geometry that Windows relies on is NOT gated with it.
+        assert!(
+            src.contains("fn open_full_screen")
+                && src[src.find("fn open_full_screen").unwrap()..].contains("fill_work_area(win);"),
+            "open_full_screen must still size the window on every platform"
+        );
+    }
+
     /// Nothing may resize the dashboard window without checking `is_fullscreen`
     /// first.
     ///

--- a/tray/src-tauri/src/sys.rs
+++ b/tray/src-tauri/src/sys.rs
@@ -529,15 +529,26 @@ pub fn register_notification_categories(app: &tauri::AppHandle) {
 /// occupies. Setting position and size to it cannot be skipped by a state
 /// guard.
 ///
-/// Then it enters **native macOS full-screen** — own Space, auto-hiding menu
-/// bar and Dock — which is the requested behaviour for the dashboard.
+/// **On macOS only**, it then enters native full-screen — own Space, auto-hiding
+/// menu bar and Dock — which is the requested behaviour for the dashboard.
 ///
 /// The work-area fill is not redundant once full-screen is requested: macOS
 /// restores the PRE-full-screen frame when the user leaves full-screen, so
 /// without it the green button would drop them back to a 1100x760 window. The
 /// fill is what makes that exit land on a screen-filling window instead.
 ///
-/// # The hazard this mode carries
+/// # Windows stops at the fill, deliberately
+///
+/// The same `set_fullscreen(true)` there means `Fullscreen::Borderless`, which
+/// strips the title bar (and with it minimize/maximize/close), sizes to the full
+/// monitor rect rather than the work area so the taskbar is covered, and marks
+/// the window full-screen to the shell. macOS supplies an exit for that state;
+/// Windows does not, and nothing here binds F11 or Escape — so it shipped as a
+/// dashboard the user could only leave with Alt+F4. The fill alone gives Windows
+/// the intended result, because `work_area()` already excludes the taskbar.
+/// Pinned by `reopen::reopen_tests::full_screen_is_requested_on_macos_only`.
+///
+/// # The hazard this mode carries (macOS)
 ///
 /// A window in native full-screen carries the full-screen style mask, and
 /// tao's `set_inner_size` calls `NSWindow::setContentSize:` unconditionally
@@ -559,17 +570,38 @@ pub fn register_notification_categories(app: &tauri::AppHandle) {
 /// Both dashboard openers, right after `build()`: [`crate::tray`]'s tray-menu
 /// opener and [`crate::commands::system::open_dashboard`].
 pub(crate) fn open_full_screen(win: &tauri::WebviewWindow) {
+    // Every platform gets the geometry. On Windows this is the WHOLE answer -
+    // `work_area()` already excludes the taskbar, so the window fills the usable
+    // screen while keeping its title bar.
     fill_work_area(win);
+
+    // macOS ONLY, and the gate is the point.
+    //
+    // Here, full-screen is a first-class window mode that comes with its own way
+    // out: the menu bar drops down on hover, the green button is in it,
+    // `Ctrl+Cmd+F` works. On Windows the identical call means
+    // `Fullscreen::Borderless`, and tao (`platform_impl/windows/window.rs`) then
+    // does three things that together have no counterpart here — it sets
+    // `MARKER_BORDERLESS_FULLSCREEN`, which strips the title bar and with it
+    // minimize/maximize/close; it sizes to `monitor.size()`, the full monitor
+    // rect rather than the work area, so the taskbar is covered; and it calls
+    // `taskbar_mark_fullscreen(hwnd, true)` to ask the shell to yield. Nothing
+    // in this app binds F11 or Escape on the dashboard window, so a Windows user
+    // was left in a screen they could only leave with Alt+F4.
+    //
     // Requested AFTER the window exists rather than via the builder's
     // `.fullscreen(true)`, for the same reason `.maximized(true)` is not
     // trusted above: a builder flag that does nothing fails silently, while an
     // explicit call has a Result to log. It also avoids asking AppKit to
     // animate a window into a new Space before that window is on screen.
-    if let Err(e) = win.set_fullscreen(true) {
-        tracing::warn!(error = %e, "dashboard: could not enter full-screen - staying windowed");
-        return;
+    #[cfg(target_os = "macos")]
+    {
+        if let Err(e) = win.set_fullscreen(true) {
+            tracing::warn!(error = %e, "dashboard: could not enter full-screen - staying windowed");
+            return;
+        }
+        tracing::info!("dashboard: entered native full-screen");
     }
-    tracing::info!("dashboard: entered native full-screen");
 }
 
 /// Size a window to fill the screen it opened on, as an ordinary window.


### PR DESCRIPTION
## The report

The Windows dashboard opens with **no title bar and no taskbar** - no minimize, no close, nothing to click. Reported with a screenshot.

## Cause - #743, unguarded

`sys::open_full_screen` called `set_fullscreen(true)` with no platform gate. On macOS that is native full-screen, which is the requested behaviour and which comes with its own exit: the menu bar drops down on hover, the green button is in it, `Ctrl+Cmd+F` works.

On Windows the identical call means `Fullscreen::Borderless`, and tao 0.35.3 (`platform_impl/windows/window.rs`) then does three things that have no counterpart there:

```rust
f.set(WindowFlags::MARKER_BORDERLESS_FULLSCREEN, ...)   // strips the title bar
let size: (u32, u32) = monitor.size().into();           // FULL monitor rect, not work_area
SetWindowPos(hwnd, None, position.0, position.1, size.0, size.1, ...)
taskbar_mark_fullscreen(hwnd, true);                    // asks the shell to yield
```

Both symptoms, exactly. And nothing in this app binds F11 or Escape on the dashboard window (grepped), so the only ways out are Alt+F4 or Alt+Tab. **That is the real defect** - not the appearance, the fact that the window cannot be left.

The macOS decision was made looking at macOS; nobody asked what the call meant on Windows. It is a window *state*, so it compiles cleanly and passes every macOS test - CI could not have caught it.

## Fix

Gate the full-screen request to macOS. `fill_work_area` stays on both platforms and is **already the right answer for Windows** - it reads `work_area()`, which excludes the taskbar - so Windows gets a window filling the usable screen with its chrome intact. macOS is unchanged.

```rust
pub(crate) fn open_full_screen(win: &tauri::WebviewWindow) {
    fill_work_area(win);          // both platforms

    #[cfg(target_os = "macos")]
    {
        if let Err(e) = win.set_fullscreen(true) { ...; return }
        tracing::info!("dashboard: entered native full-screen");
    }
}
```

## Test

Written first, confirmed failing with `the nearest macOS cfg gate is on a different item, so set_fullscreen still runs on Windows and traps the user in a borderless window`.

Source-scanning, because the defect is a window state on another OS. Two things it pins that a looser check would miss:

- the gate is the **nearest item above** the call, not merely present somewhere in the file
- `fill_work_area` is **not** gated with it - otherwise Windows would lose its geometry entirely and the test would still pass

`cargo test --workspace` green, `bun test` 759 green, clippy/fmt clean, full pre-push suite passed. Windows CI is the real verifier here.

## Manual verification wanted

1. **Windows**: dashboard opens filling the screen, title bar present, taskbar visible, minimize/close work.
2. **macOS**: unchanged - still enters native full-screen, green button exits to a screen-filling window.
3. Windows multi-monitor: opens filled on the monitor it was invoked from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)