### PR TITLE
feat(walkthrough): ship the replay control in packaged builds

### DIFF
--- a/ui/__tests__/tutorial-sample-day.test.ts
+++ b/ui/__tests__/tutorial-sample-day.test.ts
@@ -1020,6 +1020,47 @@ describe('the walkthrough points at the way out', () => {
     // both driving one stage and taking turns writing the caption.
     expect(hook).toMatch(/const skipToDay = useCallback\(\(\) => \{\s*finish\(\)\s*replayFromDay\(\)/)
   })
+
+  it('SHIPS the replay control, unlike the pill above', () => {
+    // The two used to share `TOUR_DEV_TOOLS`, and the test above reads as though
+    // that gate protects both. It does not, and the difference is the whole
+    // point: the pill skips a COMPULSORY step and leaves a product that
+    // generates nothing, while a replay just runs the tour again from the top.
+    //
+    // Shipped because a packaged build has no other way in. The button was the
+    // only one, `window.__meridianTour()` needs an inspector, and the tray
+    // enables no `devtools` feature - so a release build had a walkthrough with
+    // no door. Pinned here because deleting a gate is a one-character change
+    // that nothing else would notice.
+    const account = readFileSync(new URL('../components/timeline/settings/AccountSection.tsx', import.meta.url), 'utf8')
+    expect(account).toContain('Show me around')
+    expect(account).not.toContain('{TOUR_DEV_TOOLS && (')
+
+    // Indentation is the assertion, not decoration: the row must sit at the same
+    // depth as the shipped "Re-run Setup" beside it. ANY re-gate - this flag or a
+    // new one - wraps it in a conditional and pushes it two spaces right, so this
+    // catches the class rather than the one variable name. (Checking for the
+    // absence of the word itself does not work: the comment above the row
+    // explains why the gate was removed, and says its name to do so.)
+    expect(account).toContain('\n        <FieldRow label="Replay the walkthrough"')
+
+    // And the pill it sits next to must STILL be gated, by the prop being null
+    // rather than by anything in this file.
+    expect(account).toContain('{onReplayTourFromDay && (')
+  })
+
+  it('does not promise a replay stays off the real timeline', () => {
+    // The copy said "shown over an example day, not your own". That describes
+    // part TWO. Part one runs against the real timeline (script.ts's "PART ONE -
+    // on the user's OWN, empty day"), asks for a real daily plan and drives the
+    // real integrations screen. Fine as a dev note, a false promise once shipped
+    // - so the sentence must not survive the ungate.
+    const account = readFileSync(new URL('../components/timeline/settings/AccountSection.tsx', import.meta.url), 'utf8')
+    const row = account.slice(account.indexOf('Replay the walkthrough'))
+    const desc = row.slice(0, row.indexOf('</FieldRow>'))
+    expect(desc).not.toContain('not your own')
+    expect(desc).not.toContain('Dev only')
+  })
 })
 
 describe('the first-run journey holds together on every branch', () => {

--- a/ui/components/timeline/settings/AccountSection.tsx
+++ b/ui/components/timeline/settings/AccountSection.tsx
@@ -16,7 +16,6 @@ import { useEffect, useState } from 'react'
 import { invoke, load, mutate } from '@/lib/bridge'
 import type { AppInfo } from '@/lib/api-types'
 import { AccountAuthControl } from '@/app/setup/signin'
-import { TOUR_DEV_TOOLS } from '@/components/tutorial/useTutorial'
 import { SectionCard, SectionHeader, FieldRow, SettingsButton } from './fields'
 import { useExportDiagnostics } from './useExportDiagnostics'
 
@@ -100,20 +99,25 @@ export function AccountSection({ onReplayTour, onReplayTourFromDay }: {
             first — the walkthrough drives this very modal in two of its beats,
             so leaving it open would have it opening a modal already open.
 
-            DEV ONLY, same gate as the shortcut below. Replaying is an authoring
-            tool: it exists so the tour can be watched again while it is being
-            edited. For a real user it is a door back into a first-run experience
-            they have finished, over an example day that is not theirs - and it
-            drives their live Settings modal and their real integrations screen
-            on the way through. `window.__meridianTour()` remains for anyone who
-            genuinely needs it in a packaged build (see `useTutorial`). */}
-        {TOUR_DEV_TOOLS && (
-          <FieldRow label="Replay the walkthrough" description="Dev only. Take the guided tour of the timeline, daily summary, and worklog drafts again - shown over an example day, not your own.">
-            <SettingsButton onClick={onReplayTour}>
-              Show me around
-            </SettingsButton>
-          </FieldRow>
-        )}
+            THIS SHIPS. It was `TOUR_DEV_TOOLS &&` on the argument that replaying
+            is an authoring tool, with `window.__meridianTour()` named as the
+            escape hatch for a packaged build. That escape hatch does not exist:
+            the tray enables no `devtools` Cargo feature, so a release build has
+            no inspector to type it into, and the dashboard window has no URL bar
+            for `?tour=1` either. The gate did not make the replay developer-only,
+            it made it UNREACHABLE - a walkthrough with no door, on every build a
+            user actually runs.
+
+            The tradeoff it was protecting against is real and stays real: part
+            one runs on the user's own timeline, asks for a real daily plan and
+            drives their real integrations screen (see `script.ts`'s "PART ONE").
+            That is what the description below now says instead of promising an
+            example day, and Skip is one click away from the first frame. */}
+        <FieldRow label="Replay the walkthrough" description="Take the guided tour again. It starts on your own timeline and asks you to plan your day, the same as the first run, then moves to an example day for the rest. You can skip it at any point.">
+          <SettingsButton onClick={onReplayTour}>
+            Show me around
+          </SettingsButton>
+        </FieldRow>
         {/* DEV ONLY. Part one asks for a daily plan, a tracker connect (an OAuth
             round-trip through a browser) and possibly a CLI install before it
             reaches the example day - three or four minutes, most of it spent


### PR DESCRIPTION
## What

Removes the `TOUR_DEV_TOOLS` gate from **Settings → Account → "Show me around"**, so the walkthrough can be replayed in packaged builds (staging and prod), not only in `next dev`.

## Why

The gate was `process.env.NODE_ENV !== 'production'`. Its comment named `window.__meridianTour()` as the escape hatch for a packaged build:

> `window.__meridianTour()` remains for anyone who genuinely needs it in a packaged build

**That escape hatch does not exist.** `tray/src-tauri/Cargo.toml` enables no `devtools` Cargo feature, so a release build has no inspector to type it into. The dashboard window is opened as `WebviewUrl::App("today")` with no URL bar, so `?tour=1` is unreachable too. The function is in the production bundle and nothing can call it.

So the gate did not make the replay developer-only. It made the walkthrough **unreachable once taken**, on every build a user runs.

## The tradeoff, kept and stated

The gate was also guarding something real, and that has not changed: part one of the tour runs on the user's **own** timeline, asks for a **real** daily plan and drives their **real** integrations screen (`script.ts`, "PART ONE — on the user's OWN, empty day").

The old description said the tour is *"shown over an example day, not your own"* — that describes part **two** only. Shipped as-is it would be a false promise, so the copy now says what actually happens and that it can be skipped.

Two things make this safe to expose:
- **Skip is on screen from the first frame**, on every run (shipped in #755).
- **`finish()` releases the settings lock.** The tour calls `openSettings('integrations', { lock: true })`; Skip closes the modal by setting `activeModal` directly, which does not run `SettingsModal`'s `onClose`. That was already found and fixed — `MeridianTimelineShell.tsx:164` clears the lock off `activeModal` instead, with a comment naming the walkthrough's Skip as the cause. So a skipped replay cannot strand a user in a locked Settings with no devtools to escape it.

## Not changed

The dev-only **"Skip ahead"** pill beside it stays gated. It skips the compulsory AI-connect step and would be a supported way to end up with a product that generates nothing. Its gate is the prop being `null` (`replayFromDay: TOUR_DEV_TOOLS ? replayFromDay : null`), which is untouched.

## Tests

Two new source-scan tests in `tutorial-sample-day.test.ts`, beside the existing one that pins the pill as dev-only — the two now read as a deliberate split rather than a shared gate:

- **`SHIPS the replay control, unlike the pill above`** — asserts the row sits un-wrapped at the same indentation as its shipped `Re-run Setup` sibling. Any re-gate wraps it in a conditional and pushes it two spaces right, so this catches the *class*, not one variable name. (Asserting on the absence of the string `TOUR_DEV_TOOLS` does not work — the comment above the row says the name in order to explain the removal.)
- **`does not promise a replay stays off the real timeline`** — fails if the description reintroduces "not your own" or "Dev only".

**Mutation-verified:** re-gated the row under a *different* flag name (`SOME_OTHER_GATE`) and confirmed the test fails, then restored.

## Verification

- `bun test` — 761 pass, 0 fail (was 759; +2)
- `npx tsc --noEmit` — no errors beyond the pre-existing `bun:test` type noise in `__tests__/`
- `npm run build` — clean
- Confirmed against the **production** export: `grep "Show me around" ui/out/_next/static/chunks/` now hits, where it was empty before this change

### Manual (not yet done)
- [ ] Press "Show me around" in a packaged build and confirm the tour starts
- [ ] Skip mid-tour from a beat that had opened Settings, and confirm Settings reopens unlocked

## Note

This lands in the **next** release. It is not in `v1.86.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)