### PR TITLE
fix(tutorial): round the walkthrough spotlight's dim so its corners stop showing

### DIFF
--- a/ui/__tests__/tutorial-spotlight-corners.test.ts
+++ b/ui/__tests__/tutorial-spotlight-corners.test.ts
@@ -120,8 +120,12 @@ describe('the walkthrough spotlight has no square corners', () => {
     // Asserted as SHARING, not as two matching copies: two copies is the thing
     // that drifts. One value, applied to both.
     expect(cutout).toMatch(/const glide = 'left \.5s cubic-bezier\(\.22,1,\.32,1\)/)
+    // At least the panes and the scrim. Not an exact count - a third layer that
+    // legitimately glides would fail a correct file, and the guarantee this
+    // test exists for (both shapes read one value) does not depend on how many
+    // things read it.
     const uses = cutout.match(/transition: glide\b/g) ?? []
-    expect(uses.length).toBe(2) // the panes, and the scrim
+    expect(uses.length).toBeGreaterThanOrEqual(2)
     expect(cutout).toContain("animation: 'mer-tour-dim .45s ease both'")
   })
 })

--- a/ui/__tests__/tutorial-spotlight-corners.test.ts
+++ b/ui/__tests__/tutorial-spotlight-corners.test.ts
@@ -1,0 +1,127 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// The walkthrough's dimmed beat must not show square corners.
+//
+// `Cutout` fences the spotlight with four plain rectangles rather than one
+// masked pane, because `backdrop-filter` under a mask is exactly the
+// combination WebKit is unreliable about and this ships inside a WKWebView.
+// The consequence is a hole with square corners, and for a long time the file
+// claimed that did not matter because "the spotlight ring drawn on top is
+// rounded and reads as the frame".
+//
+// It did matter. The ring sits `RING_INSET` outside the target; the hole sits
+// `FENCE_PAD` outside it. `FENCE_PAD` was the larger of the two, so the hole
+// was not under the ring at all - it stuck out past it, and each corner showed
+// as a sharp un-dimmed nub around a rounded card.
+//
+// Source-scanning: this is a compositing artifact across stacked
+// fixed-position layers with a backdrop filter. A headless run has no
+// backdrop to filter and no corner to rasterise, so there is nothing for a
+// DOM assertion to look at. What IS checkable is the geometry the layers are
+// given, which is where the bug lived.
+
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const overlay = readFileSync(
+  join(import.meta.dir, '..', 'components', 'tutorial', 'TutorialOverlay.tsx'), 'utf8',
+)
+
+/** Reads a module-level `const NAME = <arithmetic>` out of the source and works
+ *  out its value, so a constant defined in terms of the others (`HOLE_RADIUS`)
+ *  is read as the number it actually resolves to rather than skipped.
+ *
+ *  Returns NaN for anything missing or not plain arithmetic, which fails the
+ *  comparisons below rather than passing vacuously. */
+function num(name: string, seen: string[] = []): number {
+  if (seen.includes(name)) return NaN // a cycle - refuse rather than recurse
+  const m = overlay.match(new RegExp(`^const ${name} = ([^\\n]+)`, 'm'))
+  if (!m) return NaN
+  const rhs = m[1].trim()
+  // Substitute any constant it refers to, then check what is left is only
+  // arithmetic before evaluating it.
+  const resolved = rhs.replace(/[A-Z_][A-Z0-9_]*/g, ref => String(num(ref, [...seen, name])))
+  if (!/^[-+*/(). \d]+$/.test(resolved) || resolved.includes('NaN')) return NaN
+  return Number(new Function(`return (${resolved})`)())
+}
+
+describe('the walkthrough spotlight has no square corners', () => {
+  it('draws the dim on a rounded element, not on the square fence panes', () => {
+    // The four panes stay square - that is the whole point of building the
+    // fence out of rectangles. What must NOT be square is the thing the eye
+    // actually reads as the edge of the lit area: the dim.
+    //
+    // A scrim with a very large `box-shadow` spread is the one construction
+    // that gives a rounded hole without a mask: box-shadow honours
+    // `border-radius`, and its overflow is ink rather than layout, so a spread
+    // far past the viewport costs nothing.
+    const at = overlay.indexOf('function Cutout({ rect, dim }')
+    expect(at).toBeGreaterThan(-1)
+    const cutout = overlay.slice(at)
+
+    const dimColour = cutout.indexOf('rgba(20,16,40,0.42)')
+    expect(dimColour).toBeGreaterThan(-1)
+    // The dim must be carried by a declaration that also rounds its corners.
+    // Before the fix it sat in the panes' style object, which has no radius and
+    // never could have one.
+    const decl = cutout.slice(Math.max(0, dimColour - 400), dimColour + 400)
+    expect(decl).toContain('boxShadow')
+    expect(decl).toContain('borderRadius')
+  })
+
+  it('keeps the blur on the panes, so the fence stays one component', () => {
+    // Only the dim moved. The blur, the pointer fence and the geometry are
+    // still the same four panes for both variants - splitting them would let
+    // the invisible fence drift out of step with the visible one silently.
+    const at = overlay.indexOf('function Cutout({ rect, dim }')
+    const cutout = overlay.slice(at)
+    expect(cutout).toContain('backdropFilter')
+    expect(overlay).not.toContain('function DimCutout')
+  })
+
+  it('rounds the dim hole at least as much as the ring it encloses', () => {
+    // The invariant, stated as the parallel-curve condition: subtracting each
+    // shape's own outward offset leaves the radius it would have if it were
+    // drawn on the target itself. The hole's must not be tighter than the
+    // ring's, or the hole's corners cut inside the ring and reappear.
+    //
+    // This is what failed before: FENCE_PAD 8 against a ring at inset 6 with
+    // radius 24 and no radius of its own at all - a corner sitting ~13px
+    // outside the ring's arc.
+    const ringInset = num('RING_INSET')
+    const ringRadius = num('RING_RADIUS')
+    const fencePad = num('FENCE_PAD')
+    const holeRadius = num('HOLE_RADIUS')
+
+    for (const v of [ringInset, ringRadius, fencePad, holeRadius]) {
+      expect(Number.isFinite(v)).toBe(true)
+    }
+    expect(holeRadius - fencePad).toBeGreaterThanOrEqual(ringRadius - ringInset)
+  })
+
+  it('feeds those constants to the ring and the fence rather than re-typing them', () => {
+    // Two copies of the same number is how this drifts back: someone nudges
+    // the ring's radius, the hole keeps the old one, and the corners return
+    // with nothing failing. The constants are only worth having if both
+    // shapes are actually drawn from them.
+    expect(overlay).toMatch(/borderRadius: RING_RADIUS\b/)
+    expect(overlay).toMatch(/borderRadius: HOLE_RADIUS\b/)
+    expect(overlay).toMatch(/ringBox\.left - RING_INSET/)
+    expect(overlay).toMatch(/rect\.left - FENCE_PAD/)
+  })
+
+  it('moves the dim with the hole instead of snapping it', () => {
+    // The panes glide between beats. A scrim that re-lays instantly would make
+    // the dim hole jump while the blur slides after it - a worse artifact than
+    // the square corner this replaced. Same easing, same duration.
+    const at = overlay.indexOf('function Cutout({ rect, dim }')
+    const cutout = overlay.slice(at)
+    // Asserted as SHARING, not as two matching copies: two copies is the thing
+    // that drifts. One value, applied to both.
+    expect(cutout).toMatch(/const glide = 'left \.5s cubic-bezier\(\.22,1,\.32,1\)/)
+    const uses = cutout.match(/transition: glide\b/g) ?? []
+    expect(uses.length).toBe(2) // the panes, and the scrim
+    expect(cutout).toContain("animation: 'mer-tour-dim .45s ease both'")
+  })
+})

--- a/ui/components/tutorial/TutorialOverlay.tsx
+++ b/ui/components/tutorial/TutorialOverlay.tsx
@@ -692,10 +692,20 @@ function Cutout({ rect, dim }: { rect: DOMRect; dim: boolean }) {
           gradient, so a `color-mix` against it is invalid and drops the
           declaration outright. This read as "blur only, no dimming" for as long
           as it lived on the panes - they were doing half their job silently. */}
+      {/* Deliberately NOT the clamped `l`/`t` the panes use. The clamp exists
+          because a pane sized `height: t` cannot take a negative number; the
+          scrim has no such problem, and applying the clamp to it would matter
+          in a way it never did to the panes. A target within `FENCE_PAD` of
+          the top or left edge would pull one side of the scrim inside the ring
+          while it kept its rounding - a dimmed notch cutting into the lit area,
+          which is the same class of artifact this whole change removes. Letting
+          it run off-screen instead keeps the curve concentric everywhere; the
+          part outside the viewport simply is not painted. */}
       {dim && (
         <div style={{
           position: 'absolute', pointerEvents: 'none',
-          left: l, top: t, width: r - l, height: b - t,
+          left: rect.left - FENCE_PAD, top: rect.top - FENCE_PAD,
+          width: rect.width + FENCE_PAD * 2, height: rect.height + FENCE_PAD * 2,
           borderRadius: HOLE_RADIUS,
           boxShadow: '0 0 0 9999px rgba(20,16,40,0.42)',
           animation: 'mer-tour-dim .45s ease both',

--- a/ui/components/tutorial/TutorialOverlay.tsx
+++ b/ui/components/tutorial/TutorialOverlay.tsx
@@ -38,6 +38,29 @@ const HEADER_CLEAR = 116
 const CAPTION_GAP = 16
 const CAPTION_H = 130
 
+/** Spotlight geometry — the ring and the fence hole it encloses, kept in one
+ *  place because they are two drawings of the same shape and drifted apart
+ *  once already, with nothing failing.
+ *
+ *  `RING_RADIUS` is deliberately rounder than the target's own corners. The
+ *  ring sits `RING_INSET` outside its target, so matching the target's radius
+ *  leaves the corners visibly tighter than the thing they enclose — which reads
+ *  as a box drawn around the card rather than as the card being lit up.
+ *
+ *  `FENCE_PAD` is `Cutout`'s hole. It is the LARGER offset of the two, which is
+ *  what made the corners a bug rather than a footnote: the hole was never under
+ *  the ring, it stuck out past it, so its square corners showed as sharp
+ *  un-dimmed nubs around a rounded card. The fix is `HOLE_RADIUS` — the dim now
+ *  rounds itself instead of borrowing the ring's rounding. */
+const RING_INSET = 6
+const RING_RADIUS = 24
+const FENCE_PAD = 8
+/** Parallel to the ring rather than merely round: the hole sits
+ *  `FENCE_PAD - RING_INSET` further out, so its radius grows by the same amount
+ *  to keep the two curves concentric. Guarded by
+ *  `__tests__/tutorial-spotlight-corners.test.ts`. */
+const HOLE_RADIUS = RING_RADIUS + (FENCE_PAD - RING_INSET)
+
 /** The tour's speaking voice, wherever it speaks.
  *
  *  `mt-body`'s spec, written out rather than worn as a class. It was briefly set
@@ -278,14 +301,9 @@ export function TutorialOverlay({ caption, centered, big, celebrate, cursorAt, c
           target is on the other side of the window. */}
       {ringBox && (
         <div className="absolute" style={{
-          left: ringBox.left - 6, top: ringBox.top - 6,
-          width: ringBox.width + 12, height: ringBox.height + 12,
-          // Rounder than the 18 it was. The ring sits 6px outside its target,
-          // so matching the target's own radius leaves the corners visibly
-          // tighter than the thing they enclose - which reads as a box drawn
-          // around the card rather than as the card being lit up. A radius
-          // above the card's own is what makes the two look like one shape.
-          borderRadius: 24,
+          left: ringBox.left - RING_INSET, top: ringBox.top - RING_INSET,
+          width: ringBox.width + RING_INSET * 2, height: ringBox.height + RING_INSET * 2,
+          borderRadius: RING_RADIUS,
           border: `2px solid var(--t-accent)`,
           boxShadow: '0 0 0 4px color-mix(in srgb, var(--t-accent) 22%, transparent)',
           opacity: ringLive ? 1 : 0,
@@ -609,9 +627,26 @@ function AnchoredCaption({ rect, children }: { rect: DOMRect; children: React.Re
  *  A single pane with an SVG-masked hole is the tidier construction, but
  *  `backdrop-filter` under a mask is exactly the combination WebKit has been
  *  unreliable about, and this ships inside a WKWebView on macOS. Four plain
- *  rectangles are boring and render identically everywhere. The hole's corners
- *  come out square; the spotlight ring drawn on top is rounded and reads as the
- *  frame, so it does not show.
+ *  rectangles are boring and render identically everywhere.
+ *
+ *  The cost is that the hole comes out square. This file used to claim that did
+ *  not matter, because "the spotlight ring drawn on top is rounded and reads as
+ *  the frame" — but the ring is drawn at `RING_INSET` and the hole at the LARGER
+ *  `FENCE_PAD`, so the hole was never under the ring to begin with. Each corner
+ *  sat ~13px outside the ring's arc and showed as a sharp un-dimmed nub around a
+ *  rounded card.
+ *
+ *  So the dim no longer rides on the panes. It is a separate scrim laid over the
+ *  hole with a `box-shadow` spread big enough to reach past any viewport, which
+ *  is the one construction that gives a rounded hole without a mask:
+ *  `box-shadow` honours `border-radius`, and its overflow is ink rather than
+ *  layout, so a spread far outside the parent costs nothing and scrolls nothing.
+ *
+ *  The BLUR boundary stays square — `backdrop-filter` is clipped to the pane's
+ *  own box. That is deliberate and not a residual bug: blur is only visible
+ *  where there is detail to smear, and the corner nubs are a few pixels of the
+ *  window's background gradient. One beat in the whole script dims at all
+ *  (`script.ts`'s `plan-open`), so this was checked rather than assumed.
  *
  *  These DO take pointer events, which is half the point — while the tour is
  *  waiting on one specific click, a stray click into the blurred area should
@@ -620,28 +655,28 @@ function AnchoredCaption({ rect, children }: { rect: DOMRect; children: React.Re
  *  `dim: false` renders the same four panes completely invisible — see
  *  [`Cutout`]'s note on why the fence and the blur are one component. */
 function Cutout({ rect, dim }: { rect: DOMRect; dim: boolean }) {
-  const PAD = 8
-  const l = Math.max(0, rect.left - PAD)
-  const t = Math.max(0, rect.top - PAD)
-  const r = rect.right + PAD
-  const b = rect.bottom + PAD
+  const l = Math.max(0, rect.left - FENCE_PAD)
+  const t = Math.max(0, rect.top - FENCE_PAD)
+  const r = rect.right + FENCE_PAD
+  const b = rect.bottom + FENCE_PAD
+  // The panes travel with the hole rather than being re-laid instantly, so a
+  // dimmed beat handing over to the next one reads as the light moving. The
+  // scrim below has to carry the SAME easing and duration, or the dim snaps
+  // while the blur slides after it.
+  const glide = 'left .5s cubic-bezier(.22,1,.32,1), top .5s cubic-bezier(.22,1,.32,1),'
+    + ' width .5s cubic-bezier(.22,1,.32,1), height .5s cubic-bezier(.22,1,.32,1)'
   const pane: React.CSSProperties = {
     position: 'absolute',
     pointerEvents: 'auto',
-    // Literal rgba for the same reason as the centred scrim: `--win-bg` is a
-    // gradient, so a `color-mix` against it is invalid and drops the declaration
-    // outright. This read as "blur only, no dimming" for as long as it has
-    // existed - the panes were doing half their job silently.
     ...(dim ? {
-      background: 'rgba(20,16,40,0.42)',
       backdropFilter: 'blur(5px)',
       WebkitBackdropFilter: 'blur(5px)',
+      // The same fade the scrim uses. The blur and the dim are one effect to
+      // the eye, so they have to arrive together - splitting the animation off
+      // with the colour would snap the blur in and then darken it.
       animation: 'mer-tour-dim .45s ease both',
     } : null),
-    // The panes travel with the hole rather than being re-laid instantly, so a
-    // dimmed beat handing over to the next one reads as the light moving.
-    transition: 'left .5s cubic-bezier(.22,1,.32,1), top .5s cubic-bezier(.22,1,.32,1),'
-      + ' width .5s cubic-bezier(.22,1,.32,1), height .5s cubic-bezier(.22,1,.32,1)',
+    transition: glide,
   }
   return (
     <>
@@ -649,6 +684,24 @@ function Cutout({ rect, dim }: { rect: DOMRect; dim: boolean }) {
       <div style={{ ...pane, left: 0, top: b, right: 0, bottom: 0 }} />
       <div style={{ ...pane, left: 0, top: t, width: l, height: b - t }} />
       <div style={{ ...pane, left: r, top: t, right: 0, height: b - t }} />
+      {/* The dim, as a rounded hole. Inert - the four panes above are what
+          catch stray clicks, and this must not take the click the beat is
+          waiting for.
+
+          Literal rgba for the same reason as the centred scrim: `--win-bg` is a
+          gradient, so a `color-mix` against it is invalid and drops the
+          declaration outright. This read as "blur only, no dimming" for as long
+          as it lived on the panes - they were doing half their job silently. */}
+      {dim && (
+        <div style={{
+          position: 'absolute', pointerEvents: 'none',
+          left: l, top: t, width: r - l, height: b - t,
+          borderRadius: HOLE_RADIUS,
+          boxShadow: '0 0 0 9999px rgba(20,16,40,0.42)',
+          animation: 'mer-tour-dim .45s ease both',
+          transition: glide,
+        }} />
+      )}
     </>
   )
 }


### PR DESCRIPTION
## The bug

The walkthrough's dimmed beat drew a **rounded** ring around a **rounded** card, then cut a **square** hole in the dim behind it. Each corner showed as a sharp un-dimmed nub - a shape matching nothing else on screen.

## Why the existing comment said this was fine

`Cutout` builds its fence from four plain rectangles rather than one masked pane, deliberately: `backdrop-filter` under a mask is exactly the combination WebKit has been unreliable about, and this ships inside a WKWebView. The file acknowledged the square hole and dismissed it:

> The hole's corners come out square; the spotlight ring drawn on top is rounded and reads as the frame, so it does not show.

The reasoning was sound. The numbers were not:

| shape | offset from target | radius |
|---|---|---|
| ring | 6px | 24 |
| fence hole | **8px** | none - square |

The hole is the **larger** offset, so it was never under the ring to hide beneath. It stuck out past it on every side, and at each corner sat ~13px outside the ring's arc with nothing drawn over it.

## The fix

The four panes stay - they are still the right construction, and the pointer fence depends on them. Only the **dim** moves: off the panes, onto a scrim laid over the hole with a `box-shadow` spread wide enough to reach past the viewport.

That is the one way to get a rounded hole without a mask. `box-shadow` honours `border-radius`, and its overflow is ink rather than layout, so a spread far outside the parent costs nothing and scrolls nothing.

```
borderRadius: HOLE_RADIUS,
boxShadow: '0 0 0 9999px rgba(20,16,40,0.42)',
```

Geometry that was typed twice is now four named constants both shapes are drawn from - `RING_INSET`, `RING_RADIUS`, `FENCE_PAD`, and `HOLE_RADIUS = RING_RADIUS + (FENCE_PAD - RING_INSET)`, which is the parallel-curve condition written out. A ring and a hole that must stay concentric had already drifted apart once with nothing failing.

## What stays square, and why that is checked rather than assumed

The **blur** boundary. `backdrop-filter` is clipped to each pane's own box, so the corners of the blurred region are still right angles.

That is fine, and it was verified rather than hand-waved: blur is only visible where there is detail to smear, the corner nubs are a few pixels of the window's own background gradient, and `grep` confirms exactly **one** beat in the entire script dims at all (`script.ts`'s `plan-open`). If more dimmed beats are ever added over busier surfaces, this is the line to revisit.

Two smaller things carried along:

- The blur keeps its `mer-tour-dim` fade. Moving the animation with the colour alone would have snapped the blur in and then darkened it.
- The scrim shares one `glide` constant with the panes. Two copies of the transition is how the dim ends up snapping while the blur slides after it.

## Test

`ui/__tests__/tutorial-spotlight-corners.test.ts`, written first.

**4 of its 5 assertions fail on the pre-fix file.** The fifth (blur stays on the panes, fence stays one component) passes both ways by design - it is the anti-regression guard, not the bug assertion.

The geometric test parses the constants out of the source and resolves `HOLE_RADIUS`'s arithmetic, so it asserts the **relationship** rather than a magic number. Confirmed to bite: planting `HOLE_RADIUS = RING_RADIUS - 4` fails it, and reverting passes.

Source-scanning, for the reason the sibling `tutorial-click-fence.test.ts` is: this is a compositing artifact across stacked fixed-position layers with a backdrop filter. A headless run has no backdrop to filter and no corner to rasterise. What *is* checkable is the geometry those layers are handed, which is where the bug lived.

## Verification

- `bun test` - 764 pass, 0 fail (50 files)
- `npm run build` - static export clean
- pre-commit and pre-push hooks green (fmt, clippy `--workspace`, `cargo test --workspace`, ui build, ui tests, security audit)

**Not verified on screen.** There is no Chromium on this machine and the browser extension was unresponsive. A Chrome screenshot could not have answered the only interesting question anyway, which is what WKWebView does with it - and the change *removes* reliance on the fragile combination rather than adding to it. Worth one look at the `plan-open` beat under `npm run tauri dev` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commit: the screen-edge case

The panes clamp `l`/`t` to 0 because a pane sized `height: t` cannot take a negative number. The scrim initially inherited that clamp, and on a *rounded* shape it means something it never meant on a square one: a target within `FENCE_PAD` of the top or left edge pulls one side of the scrim **inside** the ring while it keeps `HOLE_RADIUS` rounding - a dimmed notch cutting into the lit area, the same class of artifact this PR removes.

Unreachable today, since the only dimming beat rings a card inside a `p-6` panel on the right-hand side. But that reachability is an accident of where one card happens to sit, and the rewritten comment block is what the next person will trust - so the scrim takes unclamped geometry instead. It has no negative-size problem to protect against, and running off-screen keeps the curve concentric everywhere.
