### PR TITLE
fix(setup): stop the wizard un-maximizing itself, and skip a step that has nothing to ask

### DIFF
--- a/tray/src-tauri/src/commands/system.rs
+++ b/tray/src-tauri/src/commands/system.rs
@@ -155,6 +155,21 @@ pub async fn resize_setup_window(
         tracing::debug!("setup window is full-screen - resize skipped");
         return Ok(());
     }
+    // Same reasoning for a MAXIMIZED window, which is the shape the hazard
+    // actually takes on Windows: `is_fullscreen()` is false there for a
+    // maximized window (it tracks the borderless-fullscreen state, not the
+    // zoomed one), so the guard above never fired and every step transition
+    // that changed `cardHeight` called `set_size` on a maximized window. Win32
+    // has no "resize while staying maximized": SetWindowPos on a WS_MAXIMIZE
+    // window clears the maximized state, so the window visibly snapped back to
+    // its restored size mid-wizard - the user pressed Continue and the window
+    // un-maximized itself. Nothing needs resizing while maximized anyway: the
+    // card's own `transform: scale(...)` in page.tsx already fills whatever
+    // size the window is.
+    if win.is_maximized().unwrap_or(false) {
+        tracing::debug!("setup window is maximized - resize skipped");
+        return Ok(());
+    }
     let resize = win
         .set_min_size(Some(tauri::LogicalSize::new(width, height)))
         .and_then(|()| win.set_size(tauri::LogicalSize::new(width, height)));

--- a/ui/__tests__/setup-resume-progress.test.ts
+++ b/ui/__tests__/setup-resume-progress.test.ts
@@ -32,11 +32,15 @@ describe('the setup wizard resumes where it left off', () => {
     expect(page).toMatch(/if \(at < 0\) return/)
   })
 
-  it('waits for the platform before restoring', () => {
+  it('waits for every step-list input before restoring', () => {
     // The guard that keeps the step list from reshaping under a restored
     // index - the same invariant the Welcome screen holds for forward
-    // navigation.
-    expect(page).toMatch(/if \(restoredProgress\.current \|\| platform === null\) return/)
+    // navigation. It must cover EVERY input to buildSteps, not just the
+    // platform: the notifications precheck can drop a step, so restoring
+    // before it lands could point `step` into a list about to shrink.
+    expect(page).toMatch(
+      /if \(restoredProgress\.current \|\| platform === null \|\| notifPrecheck === null\) return/,
+    )
     // …and the writer is gated on it too, so a null-platform render cannot
     // persist a position derived from the wrong list.
     expect(page).toMatch(/if \(welcome \|\| platform === null\) return/)

--- a/ui/__tests__/windows-notification-permission.test.ts
+++ b/ui/__tests__/windows-notification-permission.test.ts
@@ -5,9 +5,12 @@ import { readFileSync } from 'fs'
 // Guards the Windows notification onboarding in the setup wizard. Windows has no
 // TCC-style consent for Accessibility/Screen Recording, so those cards are
 // macOS-only — but Notifications IS a real per-app setting on Windows (WinRT
-// ToastNotifier::Setting), so the Permissions step must NOT be dropped there.
-// It is swapped for a notifications-only variant that keeps id:'permissions' so
-// page.tsx's check_notifications poll (gated on that id) still fires. This test
+// ToastNotifier::Setting), so the Permissions step is swapped for a
+// notifications-only variant that keeps id:'permissions' (page.tsx's
+// check_notifications poll is gated on that id) rather than being dropped
+// wholesale. It IS dropped in exactly one case — notifications already granted,
+// where a step whose entire content is one satisfied toggle has nothing to ask —
+// and the assertions below pin that condition rather than the branch. This test
 // is a string-source guard (the same pattern as the Settings → Notifications
 // guard) because steps.tsx pulls in the whole React/Clerk import graph.
 //
@@ -47,12 +50,44 @@ describe('windows notification permission onboarding', () => {
     expect(winStep).toContain('canNext: () => true')
   })
 
-  it('swaps the permissions step for the Windows variant instead of dropping it', () => {
+  it('swaps the permissions step for the Windows variant rather than losing it', () => {
     const build = steps.slice(steps.indexOf('export function buildSteps'))
-    // The Windows branch must reference the variant (a swap)…
     expect(build).toContain('WINDOWS_NOTIFICATIONS_STEP')
-    // …and must NOT filter the step list — the old drop, in any formatting.
-    expect(build).not.toMatch(/\.filter\(/)
+  })
+
+  // The step IS dropped on Windows now — but only when notifications are
+  // ALREADY granted, which is the one case where it has nothing to ask for
+  // (Windows enables toasts for most apps by default). This used to assert the
+  // step could never be dropped at all; that was the right guard when the only
+  // alternative on the table was losing Windows notification onboarding
+  // entirely, and it is the wrong one now. What still must never happen is the
+  // UNCONDITIONAL drop, so this pins the condition instead of forbidding the
+  // branch: not-granted, unavailable, and unresolved all keep the step.
+  it('only drops the Windows step when notifications are already granted', () => {
+    const build = steps.slice(steps.indexOf('export function buildSteps'))
+    expect(build).toContain('notificationsGranted')
+    // The empty-list arm (the drop) must be reachable only through that flag.
+    expect(build).toMatch(/notificationsGranted \? \[\] : \[WINDOWS_NOTIFICATIONS_STEP\]/)
+  })
+
+  // The flag feeding that branch must be a ONE-SHOT read taken before the user
+  // leaves Welcome — not the 2 s poll, which only runs while the Permissions
+  // step is already on screen and so cannot answer whether it should be. And
+  // the wizard must not let the user past Welcome until it has landed, or the
+  // step list could reshape under a step index already navigated to.
+  it('decides from a precheck resolved before Welcome is dismissed', () => {
+    const page = readSrc('app/setup/page.tsx')
+    expect(page).toContain("invoke<NotifState>('check_notifications')")
+    expect(page).toContain('buildSteps(platform, notifPrecheck === \'granted\')')
+    expect(page).toContain('ready={platform !== null && notifPrecheck !== null}')
+  })
+
+  // A failed probe must not read as a grant — that would silently skip
+  // notification onboarding because one IPC call went wrong.
+  it('keeps the step when the precheck fails', () => {
+    const page = readSrc('app/setup/page.tsx')
+    const precheck = page.slice(page.indexOf("invoke<NotifState>('check_notifications')"))
+    expect(precheck.slice(0, 400)).toContain("'unavailable'")
   })
 
   it('keeps a notifications entry the Windows card can render', () => {

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -203,42 +203,44 @@ html.dark {
   --draft-card-bg:   var(--t-accent);
 }
 
-/* Setup wizard CTA — pale lavender, glowing on hover (app/setup/atoms.tsx `Btn`).
+/* Setup wizard CTA — the product accent, glowing on hover (app/setup/atoms.tsx `Btn`).
 
-   The fill is THE HEADLINE'S OWN COLOUR - the same value as --lavender-ink, so
-   the wizard's first sentence and its one action are literally the same lavender
-   rather than two near-misses. It is set as a literal here rather than as
-   var(--lavender-ink) on purpose: they are the same colour today by intent, but
-   they answer to different constraints (one is type on white, one is a fill
-   holding a label), so aliasing them would make any future correction to either
-   silently drag the other along with it.
+   THE FILL IS `--t-accent`'s VALUE (Violet 600, #7C3AED) - the same violet the
+   step's own kicker ("ACCOUNT", "ALERTS") is set in, and the same one every
+   primary action, link and focus ring in the dashboard uses. It is set as a
+   literal here rather than as var(--t-accent) on purpose: they are the same
+   colour today by intent, but they answer to different constraints (one is type
+   on a card, one is a fill holding a label), so aliasing them would make any
+   future correction to either silently drag the other along with it.
 
-   CONTRAST, HONESTLY: this fill sits in the dead zone where neither label colour
-   clears 4.5:1 at 14px - white is ~3.6:1, ink ~4.0:1. White is used because the
-   alternative is barely better and reads worse. Darkening the fill ~8% would
-   take white past 4.5:1 if that trade is ever wanted; it is the one-line fix.
+   It used to be #8877E2 (--lavender-ink, the Welcome headline's colour). Read
+   next to the kicker directly above it, that fill looked washed out - close
+   enough to the accent to read as a failed match rather than a deliberate
+   second tone, and pale enough that the primary action looked half-disabled.
 
-   WHAT WAS TRIED AND REJECTED, so it is not re-tried: a saturated violet fill
-   (#6B4CE8) read as machine-made - high-chroma violet is the note generated
-   interfaces hit. A multi-stop gradient across the face and an always-on
-   breathing halo went with it: a gradient baked into a button is one of the
-   loudest tells, and a halo that never switches off stops being a highlight and
-   just becomes the button's colour.
+   CONTRAST: white on #7C3AED is ~5.4:1, which clears 4.5:1 at 14px. The old
+   pale fill sat in the dead zone where neither label colour cleared it (white
+   ~3.6:1, ink ~4.0:1); this is the "darken the fill" fix that note pointed at.
+
+   WHAT WAS TRIED AND REJECTED, so it is not re-tried: a multi-stop gradient
+   across the face and an always-on breathing halo - a gradient baked into a
+   button is one of the loudest generated-interface tells, and a halo that never
+   switches off stops being a highlight and just becomes the button's colour.
 
    What survives is hover-triggered, and that is the distinction the design turns
    on - effects that ANSWER the pointer read as craft; the same effects running
-   unprompted read as decoration. Flat pale lavender at rest; halo blooms and a
-   sheen travels across on the way in.
+   unprompted read as decoration. Flat violet at rest; halo blooms and a sheen
+   travels across on the way in.
 
-   Theme-independent: a light chip holding ink, which works as-is on `ink`'s dark
-   surfaces (there it reads as a bright accent rather than a tint). */
+   Theme-independent: a saturated fill holding white, which works as-is on
+   `ink`'s dark surfaces. */
 :root {
-  --btn-cta-bg:     #8877E2;
-  --btn-cta-border: #9C8DE8;
+  --btn-cta-bg:     #7C3AED;
+  --btn-cta-border: #8B5CF6;
   --btn-cta-text:   #FFFFFF;
   /* The halo, at the fill's own hue - deep enough to read against a white card,
      which a glow the same value as the surface never would. */
-  --btn-cta-glow:   124, 104, 220;
+  --btn-cta-glow:   124, 58, 237;
   /* Lavender at a depth that can be READ rather than filled with - the setup
      headline. Never body copy: it clears 3:1 (the WCAG large-text threshold,
      >=24px or >=19px bold) and so covers display headings ONLY; at 14px it is

--- a/ui/app/setup/atoms.tsx
+++ b/ui/app/setup/atoms.tsx
@@ -425,13 +425,19 @@ export function Btn({ children, variant = 'primary', size = 'md', disabled, onCl
   const skins: Record<string, CSSProperties> = {
     primary: { fontWeight: 600 },
     secondary: { background: 'var(--t-card)', color: 'var(--t-title)', borderColor: 'var(--t-card-border)' },
-    ghost: { background: 'transparent', color: 'var(--t-faint)' },
+    ghost: { background: 'transparent', color: 'var(--t-muted)' },
     soft: { background: 'color-mix(in srgb, var(--t-accent) 12%, transparent)', color: 'var(--t-accent)' },
   }
   // The brand variant opts OUT of this: fading a dark fill AND its white label
   // toward a white card makes "Preparing setup…" unreadable. It has its own
   // disabled skin in `.mer-btn-cta:disabled` (desaturated, not faded).
-  const dim: CSSProperties | null = disabled && !brand ? { opacity: 0.4, filter: 'saturate(.6)' } : null
+  //
+  // 0.55, not the old 0.4. A disabled control has to still be READABLE - it is
+  // telling the user what the control is and that it is unavailable, and at 0.4
+  // over --t-muted the footer's "‹ Back" on step 1 had faded to roughly the
+  // card's own hairline. Muted enough to read as unavailable, dark enough to
+  // read as a word.
+  const dim: CSSProperties | null = disabled && !brand ? { opacity: 0.55, filter: 'saturate(.7)' } : null
   return (
     <button title={title} onClick={disabled ? undefined : onClick} disabled={disabled}
       className={brand ? 'mer-btn-cta' : undefined}

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -51,7 +51,37 @@ export default function SetupWizard() {
     invoke<string>('get_platform').then(setPlatform).catch(() => setPlatformError(true))
   }, [])
   useEffect(() => { resolvePlatform() }, [resolvePlatform])
-  const steps = useMemo(() => buildSteps(platform), [platform])
+
+  // ── Notifications precheck — decides whether the Alerts step exists at all ──
+  // On Windows the Permissions step is a single optional notifications toggle,
+  // and Windows grants toast notifications to most apps by default - so for most
+  // users it opened already GRANTED, an onboarding screen asking for something
+  // it already had. `buildSteps` drops it when this resolves 'granted'.
+  //
+  // This is a ONE-SHOT read, deliberately separate from the live 2 s poll below:
+  // the poll only runs while the Permissions step is already on screen, which is
+  // circular for a question that decides whether that step is on screen at all.
+  //
+  // Resolved ONCE and never rewritten - `notifPrecheck` is not updated by the
+  // poll, and the `.then` cannot fire twice. That is what keeps `steps` stable
+  // once the user has begun: the same invariant the `platform` note above
+  // describes, and it is why Welcome's "Get started" waits on this too. Someone
+  // who grants notifications mid-wizard (via the step itself) keeps the step
+  // they are standing on rather than having it vanish underfoot.
+  const [notifPrecheck, setNotifPrecheck] = useState<NotifState | null>(null)
+  useEffect(() => {
+    invoke<NotifState>('check_notifications')
+      // A failed probe is NOT a grant: fall through to 'unavailable', which
+      // keeps the step (the wizard's existing behaviour) rather than silently
+      // skipping notification onboarding because one IPC call went wrong.
+      .catch((): NotifState => 'unavailable')
+      .then(setNotifPrecheck)
+  }, [])
+
+  const steps = useMemo(
+    () => buildSteps(platform, notifPrecheck === 'granted'),
+    [platform, notifPrecheck],
+  )
 
   // ── Resume where they left off ───────────────────────────────────────────
   // Quitting mid-setup used to drop the user back on Welcome, re-reading a
@@ -72,7 +102,10 @@ export default function SetupWizard() {
   // reintroduce exactly that bug through the back door.
   const restoredProgress = useRef(false)
   useEffect(() => {
-    if (restoredProgress.current || platform === null) return
+    // Gated on `notifPrecheck` for the same reason as `platform`: it is the
+    // other input to `buildSteps`, so restoring a position before it lands
+    // could point `step` into a list that is about to lose a step.
+    if (restoredProgress.current || platform === null || notifPrecheck === null) return
     restoredProgress.current = true
     let savedStepId: string | null = null
     try {
@@ -84,7 +117,7 @@ export default function SetupWizard() {
     if (at < 0) return
     setWelcome(false)
     setStep(at)
-  }, [platform, steps])
+  }, [platform, notifPrecheck, steps])
 
   // Written on every move once past Welcome. Welcome itself is deliberately
   // not stored: it is the zero state, and "resuming" onto it is the same as
@@ -398,7 +431,9 @@ export default function SetupWizard() {
         {welcome ? (
           <Welcome
             onBegin={() => { setWelcome(false); setStep(0) }}
-            ready={platform !== null}
+            // Both inputs to `buildSteps` must have landed before the step list
+            // can be navigated - see the `platform` and `notifPrecheck` notes.
+            ready={platform !== null && notifPrecheck !== null}
             error={platformError}
             onRetry={resolvePlatform}
           />
@@ -434,8 +469,13 @@ function Footer({ step, last, canNext, err, onBack, onNext }: {
     <div className="flex items-center justify-between" style={{ padding: '16px 28px', borderTop: '1px solid var(--t-hair)', background: 'var(--t-box)' }}>
       <Btn variant="ghost" disabled={step === 0} onClick={onBack}><ArrowL />Back</Btn>
       <span style={{ fontSize: 11, color: 'var(--color-state-pending)', flex: 1, textAlign: 'center', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', padding: '0 12px' }}>{err}</span>
+      {/* "Open Dashboard", not "Finish setup". Both are true of the last step,
+          but only one of them names what happens when it is pressed - `finish()`
+          marks setup complete, opens the dashboard window, and closes this one.
+          "Finish setup" described the bookkeeping and left the user to guess
+          where they were about to land. */}
       <Btn variant="primary" disabled={!canNext} onClick={onNext}>
-        {last ? 'Finish setup' : 'Continue'}{!last && <ArrowR />}
+        {last ? 'Open Dashboard' : 'Continue'}{!last && <ArrowR />}
       </Btn>
     </div>
   )

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -600,11 +600,29 @@ const ALL_STEPS: StepMeta[] = [
 ]
 
 /** Platform-specific step list. On Windows the Permissions step is swapped for
- *  its notifications-only variant (same id, so the poll still fires); the count
- *  is unchanged. `n` is renumbered to position so the rail never shows a gap. */
-export function buildSteps(platform: string | null): StepMeta[] {
-  const steps = platform === 'windows'
-    ? ALL_STEPS.map((s) => (s.id === 'permissions' ? WINDOWS_NOTIFICATIONS_STEP : s))
+ *  its notifications-only variant (same id, so the poll still fires); `n` is
+ *  renumbered to position so the rail never shows a gap.
+ *
+ *  `notificationsGranted` is the ONE-SHOT precheck page.tsx runs before the user
+ *  leaves Welcome (not the live 2 s poll, which only runs while the step is
+ *  already on screen). When it is true on Windows the Alerts step is dropped
+ *  entirely: the whole step is a single optional toggle, and Windows enables
+ *  toast notifications for most apps by default, so the common case was a step
+ *  that opened already GRANTED with nothing to do but press Continue - an
+ *  onboarding screen asking for something it already has. macOS is deliberately
+ *  unaffected: its Permissions step also carries Accessibility and Screen
+ *  Recording, which capture genuinely cannot run without, so it always shows.
+ *
+ *  Dropping a step can leave a ONE-step wizard (sign-in only). That is fine and
+ *  is the intended shape - `page.tsx`'s footer keys "last step" off the list
+ *  length, so the single step correctly offers Open Dashboard. */
+export function buildSteps(platform: string | null, notificationsGranted: boolean): StepMeta[] {
+  const isWin = platform === 'windows'
+  const steps = isWin
+    ? ALL_STEPS.flatMap((s) => {
+        if (s.id !== 'permissions') return [s]
+        return notificationsGranted ? [] : [WINDOWS_NOTIFICATIONS_STEP]
+      })
     : ALL_STEPS
   return steps.map((s, i) => ({ ...s, n: String(i + 1).padStart(2, '0') }))
 }

--- a/ui/lib/bridge.ts
+++ b/ui/lib/bridge.ts
@@ -17,6 +17,11 @@ type TauriBridge = {
       close: () => Promise<void>
       innerSize: () => Promise<{ width: number; height: number }>
       setSize: (size: unknown) => Promise<void>
+      // Read by nudgeWindowRepaint to tell the two "bigger than normal" window
+      // states apart: native full-screen (where the repaint nudge is the whole
+      // point) from merely maximized (where any setSize un-maximizes it).
+      isFullscreen: () => Promise<boolean>
+      isMaximized: () => Promise<boolean>
     }
     // Constructor for the PhysicalSize argument setSize expects — matches
     // what innerSize() returns, so nudgeWindowRepaint never has to reason
@@ -92,6 +97,20 @@ async function runWindowRepaint(): Promise<void> {
   try {
     const win = t.window.getCurrentWindow()
     const { PhysicalSize } = t.window
+    // Never nudge a MAXIMIZED window. The nudge is a real frame-set, and Win32
+    // has no way to resize a WS_MAXIMIZE window without clearing the maximized
+    // state - so on Windows this fired on every wizard step transition and
+    // visibly restored the window down, which is a far worse defect than the
+    // stale-drawable repaint it exists to prevent. Full-screen is deliberately
+    // NOT excluded: that is the macOS case the nudge was written for, and a
+    // macOS window in native full-screen also reports isMaximized() true
+    // (tao maps it to `isZoomed`), so the check has to be the pair, not
+    // isMaximized alone - otherwise this silently disables the fix it guards.
+    const [fullscreen, maximized] = await Promise.all([
+      win.isFullscreen().catch(() => false),
+      win.isMaximized().catch(() => false),
+    ])
+    if (maximized && !fullscreen) return
     const { width, height } = await win.innerSize()
     restore = () => win.setSize(new PhysicalSize(width, height))
     await win.setSize(new PhysicalSize(width + 1, height))


### PR DESCRIPTION
Three Windows-facing defects in the onboarding wizard, reported from a live run.

## 1. Pressing Continue dropped a maximized window back to its restored size

Two call sites resize the setup window on a step transition:

- `resize_setup_window` (`tray/src-tauri/src/commands/system.rs`) — when the card height changes between steps
- `nudgeWindowRepaint` (`ui/lib/bridge.ts`) — on **every** transition, as a macOS WKWebView/wry compositor workaround

Both guarded only against native full-screen. On Windows `is_fullscreen()` is `false` for a maximized window — it tracks the borderless-fullscreen state, not the zoomed one — and Win32 has no "resize while staying maximized": `SetWindowPos` on a `WS_MAXIMIZE` window clears the maximized state. So every Continue press visibly restored the window down.

Both now skip a maximized window. The nudge checks the **pair** (`maximized && !fullscreen`) rather than `isMaximized` alone: a macOS window in native full-screen also reports `isMaximized()` true (tao maps it to `isZoomed`), and full-screen is the exact case the nudge exists for — checking `isMaximized` alone would have silently disabled the fix it guards.

Nothing needs resizing while maximized anyway: the card's own `transform: scale(...)` already fills whatever size the window is.

## 2. The footer read as half-disabled

`--btn-cta-bg` moves `#8877E2` → `#7C3AED`, the product accent — the same violet as the step kicker (`ACCOUNT`, `ALERTS`) directly above it, which the old pale fill near-missed rather than deliberately contrasted. Border and glow follow.

Contrast improves as a side effect: white on `#7C3AED` is ~5.4:1, clearing 4.5:1 at 14px. The old fill sat in the dead zone where neither label colour cleared it (white ~3.6:1, ink ~4.0:1) — this is the "darken the fill" fix the existing comment already pointed at.

Disabled ghost buttons go from `opacity .4` over `--t-faint` to `.55` over `--t-muted`, so `‹ Back` on step 1 still reads as a word rather than fading to roughly the card's own hairline.

> **Reviewer note:** the CSS comment recorded a saturated violet (`#6B4CE8`) as tried-and-rejected for reading "machine-made". `#7C3AED` is the existing product accent — the one every other primary action, link and focus ring in the dashboard already uses — not a new invention, and this was an explicit request. The comment is rewritten so the rejected-alternatives record stays accurate rather than contradicting the code.

## 3. The Alerts step asked for something it already had

Windows enables toast notifications for most apps by default, so the Windows-only Alerts step — whose entire content is one optional toggle — routinely opened already `GRANTED`, with nothing to do but press Continue.

`buildSteps` now takes a `notificationsGranted` flag and drops the step when it is true. The flag comes from a **one-shot** `check_notifications` at mount, deliberately separate from the existing 2 s poll: that poll only runs while the Permissions step is already on screen, which is circular for a question that decides whether the step is on screen at all.

Welcome's "Get started" and the resume-restore both now wait on it, preserving the existing invariant that the step list can never reshape under a `step` index already navigated to. A failed probe resolves `'unavailable'` and **keeps** the step — a broken IPC call must not read as a grant.

macOS is unaffected: its Permissions step also carries Accessibility and Screen Recording, which capture genuinely cannot run without.

This can leave a one-step wizard (sign-in only), which is the intended shape — the footer keys "last step" off list length.

## Also

The last step's button is renamed **"Finish setup" → "Open Dashboard"**. Both are true, but only one names what pressing it does: `finish()` marks setup complete, opens the dashboard window, and closes this one.

## Tests

Three existing guard tests changed, because they pinned the behaviour this PR deliberately changes:

- `windows-notification-permission.test.ts` — the `swaps … instead of dropping it` assertion forbade any `.filter(` in `buildSteps`. That was the right guard when the alternative on the table was losing Windows notification onboarding entirely; it is the wrong one now. It is replaced by assertions that pin the **condition** (drop only when granted, keep on not-granted/unavailable/unresolved) plus two new tests covering the precheck's placement and its failure path.
- `setup-resume-progress.test.ts` — the restore guard must now cover every input to `buildSteps`, not just `platform`.

## Verification

- `cargo fmt --all --check` + `cargo clippy --workspace --all-targets` — exit 0
- `npx tsc --noEmit` — exit 0
- `bun test` (ui/) — 758 pass, 1 fail
- pre-push hook (full suite incl. `cargo test --workspace`, UI build, security audit) — passed

The one `bun test` failure (`accent-token-discipline` flagging `WhatsNewModal.tsx` for `--color-state-proposal`) and the `llm-provider-connection-phase.test.ts` ENOENT (a Windows `new URL('..').pathname` bug producing `/C:/…`) both reproduce identically on `pre-main` — pre-existing and unrelated to this change.

**Not verified:** I have not run the packaged app to see these on screen. The maximize fix in particular is worth a manual pass on Windows — maximize the wizard, then page through every step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
