### PR TITLE
fix(worklog): ask for a model when the user presses Generate, not after

### DIFF
--- a/ui/__tests__/tutorial-sample-day.test.ts
+++ b/ui/__tests__/tutorial-sample-day.test.ts
@@ -407,8 +407,12 @@ describe('walkthrough structure', () => {
       // Beat 9 now exists only for the case that still needs an answer.
       expect(src).toContain("ai = 'connected-in-tour'")   // connected during the draft beat
       expect(src).toContain("ai = 'already-working'")     // set up before the tour began
-      expect(src).toContain('if (ai === null) {')
-      expect(at('if (ai === null) {')).toBeGreaterThan(at('── 9. AI ask'))
+      // Gated on `aiState`, not on `ctx.ai`. Part two can now connect a provider
+      // itself - the worklog beat takes a user with no model to the picker on the
+      // press - so the closing ask has to read what is true by the time it runs,
+      // not what part one happened to observe.
+      expect(src).toContain('if (aiState === null) {')
+      expect(at('if (aiState === null) {')).toBeGreaterThan(at('── 9. AI ask'))
       // The claim itself is gone, not relocated.
       expect(src).not.toContain('never sits on our servers')
     })
@@ -418,7 +422,9 @@ describe('walkthrough structure', () => {
       // successfully, so the connect card never appears and the old flag stayed
       // false - and the beat told someone already set up to go and pick one.
       const beat9 = src.slice(at('── 9. AI ask'), at('── 10.'))
-      expect(beat9.indexOf('openSettings')).toBeGreaterThan(beat9.indexOf('if (ai === null) {'))
+      const gate = beat9.indexOf('if (aiState === null) {')
+      expect(gate).toBeGreaterThan(-1)   // not merely "not -1 < something"
+      expect(beat9.indexOf('openSettings')).toBeGreaterThan(gate)
     })
   })
 })

--- a/ui/__tests__/tutorial-sample-day.test.ts
+++ b/ui/__tests__/tutorial-sample-day.test.ts
@@ -407,12 +407,12 @@ describe('walkthrough structure', () => {
       // Beat 9 now exists only for the case that still needs an answer.
       expect(src).toContain("ai = 'connected-in-tour'")   // connected during the draft beat
       expect(src).toContain("ai = 'already-working'")     // set up before the tour began
-      // Gated on `aiState`, not on `ctx.ai`. Part two can now connect a provider
-      // itself - the worklog beat takes a user with no model to the picker on the
-      // press - so the closing ask has to read what is true by the time it runs,
-      // not what part one happened to observe.
-      expect(src).toContain('if (aiState === null) {')
-      expect(at('if (aiState === null) {')).toBeGreaterThan(at('── 9. AI ask'))
+      // Read straight from part one. Part two deliberately runs NO second connect
+      // flow - the worklog beat names the model as the one "Draft with AI"
+      // already needed rather than setting up another - so this stays the single
+      // place a user who declined earlier is asked again.
+      expect(src).toContain('if (ai === null) {')
+      expect(at('if (ai === null) {')).toBeGreaterThan(at('── 9. AI ask'))
       // The claim itself is gone, not relocated.
       expect(src).not.toContain('never sits on our servers')
     })
@@ -422,7 +422,7 @@ describe('walkthrough structure', () => {
       // successfully, so the connect card never appears and the old flag stayed
       // false - and the beat told someone already set up to go and pick one.
       const beat9 = src.slice(at('── 9. AI ask'), at('── 10.'))
-      const gate = beat9.indexOf('if (aiState === null) {')
+      const gate = beat9.indexOf('if (ai === null) {')
       expect(gate).toBeGreaterThan(-1)   // not merely "not -1 < something"
       expect(beat9.indexOf('openSettings')).toBeGreaterThan(gate)
     })

--- a/ui/__tests__/worklog-needs-ai.test.ts
+++ b/ui/__tests__/worklog-needs-ai.test.ts
@@ -1,0 +1,177 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Drafting a worklog needs a model. Two things stood between a user and that
+// fact, and they compounded.
+//
+// 1. THE WAY OUT WAS INVISIBLE. Press Generate with no provider and the dialog
+//    answers with "Connect an AI provider ... Choose a provider". That button
+//    calls `onOpenSettings`, which opens `SettingsModal` inside `ModalShell` at
+//    `absolute inset-0 z-40` - while the draft dialog the user is still looking
+//    at is `fixed inset-0 z-50`, portalled to `document.body`. The shell's root
+//    is `relative` with no z-index, so it opens no stacking context and the two
+//    compete directly: z-50 wins. Settings opened BEHIND the dialog. Nothing
+//    appeared to happen, which is the worst possible answer to "how do I fix
+//    this?".
+//
+// 2. THE WALKTHROUGH SKIPPED THE CHECK ENTIRELY. `attemptGenerate` returned
+//    early on `isDemo`, so the first-run tour demonstrated Generate producing a
+//    finished worklog on a machine with no AI set up at all - teaching a flow
+//    that cannot work, to precisely the audience least able to tell.
+//
+// Source-scanning: both failures are a surface not appearing. There is no
+// exception, no rejected promise and no state to read - the assertion a unit
+// test would make ("Settings opened") is true in the DOM in the broken case
+// too. What can be checked is the wiring that decides it.
+
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const read = (...p: string[]) => readFileSync(join(import.meta.dir, '..', ...p), 'utf8')
+
+const dialog = read('components', 'timeline', 'WorklogDraftDialog.tsx')
+const actions = read('components', 'timeline', 'WorklogActions.tsx')
+const scriptDay = read('components', 'tutorial', 'scriptDay.ts')
+
+describe('the way out of a blocked worklog draft is visible', () => {
+  it('closes the draft before sending the user to Settings', () => {
+    // The order is the whole fix. `onOpenSettings` alone leaves a z-50 dialog
+    // sitting on top of the z-40 modal it just opened.
+    const at = dialog.indexOf('onConnectProvider=')
+    expect(at).toBeGreaterThan(-1)
+    const handler = dialog.slice(at, at + 200)
+    expect(handler).toContain('onClose()')
+    expect(handler).toContain("onOpenSettings('intelligence')")
+    expect(handler.indexOf('onClose()')).toBeLessThan(handler.indexOf("onOpenSettings('intelligence')"))
+  })
+
+  it('gives the connect button a tour hook', () => {
+    // The walkthrough rings this button, so it needs a stable handle. Without
+    // one the tour's detour has nothing to point at and stalls on a timeout.
+    const at = actions.indexOf('Choose a provider')
+    expect(at).toBeGreaterThan(-1)
+    const button = actions.slice(Math.max(0, at - 500), at)
+    expect(button).toContain('data-tour="wl-connect-provider"')
+  })
+})
+
+describe('the walkthrough does not demo a draft the user cannot get', () => {
+  it('runs the real provider check even when the worklog is scripted', () => {
+    // The bypass. `isDemo` skipping straight to `generate()` is what let the
+    // tour show a finished worklog on a machine with no model.
+    //
+    // Removing it is safe for the tour because the control does NOT get swapped
+    // out - the button keeps its name and the reason appears underneath it - so
+    // a beat ringing `wl-generate` still has something to ring.
+    const at = dialog.indexOf('const attemptGenerate')
+    expect(at).toBeGreaterThan(-1)
+    const fn = dialog.slice(at, dialog.indexOf('\n  }', at))
+    expect(fn).not.toMatch(/if \(isDemo\)/)
+    expect(fn).toContain("load<HealthStatus>('/api/health', 'get_health')")
+    expect(fn).toContain('llm_provider_ok === false')
+  })
+
+  it('still fails OPEN when the probe itself fails', () => {
+    // A health read that does not come back must not block drafting. That
+    // failure has nothing to do with the model and is strictly worse than the
+    // dead end it would prevent - and it is now the tour's safety net too: no
+    // card appears, so the detour never arms and the tour carries on.
+    const at = dialog.indexOf('const attemptGenerate')
+    const fn = dialog.slice(at, dialog.indexOf('\n  }', at))
+    const rescue = fn.slice(fn.indexOf('} catch {'))
+    expect(rescue).toContain('setProviderDown(false)')
+    expect(rescue).toContain('generate()')
+  })
+})
+
+describe('the walkthrough routes a blocked Generate to the AI setup', () => {
+  const flow = scriptDay.slice(scriptDay.indexOf("s.spotlight('[data-tour=\"wl-open\"]')"))
+
+  it('detours between the press and the draft, not after the tour', () => {
+    // Order: they press Generate, they are told why it cannot run, they connect,
+    // and only then does the draft arrive. An AI ask parked at the end of the
+    // tour is an ask AFTER the feature it is required for has been demonstrated
+    // working - which is the thing that made this wrong.
+    const press = flow.indexOf("await s.waitForClick('[data-tour=\"wl-generate\"]'")
+    const connect = flow.indexOf('wl-connect-provider')
+    const draft = flow.indexOf("s.appeared('[data-tour=\"draft-targets\"]'")
+    expect(press).toBeGreaterThan(-1)
+    expect(connect).toBeGreaterThan(press)
+    expect(draft).toBeGreaterThan(connect)
+  })
+
+  it('arms on the card actually appearing, never on a prediction', () => {
+    // The same shape the composer's detour uses. Predicting from a flag would
+    // strand the tour on both sides: a wait for a card that never came, or a
+    // silent skip past one that did.
+    expect(flow).toMatch(/await s\.appeared\('\[data-tour="wl-connect-provider"\]'/)
+  })
+
+  it('waits for EITHER outcome rather than a window sized for the card', () => {
+    // The card and the draft hang off the same health read. A fixed wait long
+    // enough to catch the card parks that many silent seconds in front of every
+    // user who is already set up - and if their draft lands inside it, the line
+    // after this narrates work that has already finished.
+    const both = flow.indexOf('[data-tour="wl-connect-provider"], [data-tour="draft-targets"]')
+    expect(both).toBeGreaterThan(-1)
+    // …and the which-one probe comes after it, cheap rather than another wait.
+    const probe = flow.indexOf('\'[data-tour="wl-connect-provider"]\', 250')
+    expect(probe).toBeGreaterThan(both)
+  })
+
+  it('comes back and presses Generate again', () => {
+    // The draft dialog closes itself on the way to Settings, so returning to a
+    // ringed `wl-generate` would ring a control that is no longer rendered.
+    const connect = flow.indexOf('wl-connect-provider')
+    const after = flow.slice(connect)
+    expect(after.indexOf('wl-open')).toBeGreaterThan(-1)
+    expect(after.indexOf('wl-open')).toBeLessThan(after.indexOf("s.appeared('[data-tour=\"draft-targets\"]'"))
+  })
+
+  it('checks the connect actually took, and does not claim it did', () => {
+    // Settings here is UNLOCKED on purpose - the locked variant hands back to the
+    // PLANNER on success, which is the wrong place to land from a worklog - so ×
+    // is available throughout and closing it proves nothing. Someone who opens
+    // the picker, finds their provider needs a CLI installed, and backs out comes
+    // back to the same card.
+    const connect = flow.indexOf('wl-connect-provider')
+    const after = flow.slice(connect)
+    // The re-probe exists, AFTER the second press.
+    const rePress = after.indexOf("await s.waitForClick('[data-tour=\"wl-generate\"]'")
+    expect(rePress).toBeGreaterThan(-1)
+    // Searched from AFTER the press: `let blocked = …` (the first probe, before
+    // the detour) contains this same text, so a plain indexOf would match that
+    // one and pass on a file with no re-probe at all.
+    const reProbe = after.indexOf('blocked = await s.appeared', rePress)
+    expect(reProbe).toBeGreaterThan(rePress)
+    // Nothing between the picker and that probe asserts a connection happened.
+    expect(after.slice(0, reProbe)).not.toContain('Connected.')
+  })
+
+  it('puts the closing ask back when the connect did not take', () => {
+    // Skipping it is right for someone who visited the picker and answered. It is
+    // wrong once the tour can SEE that they did not - that user would otherwise
+    // finish the walkthrough with a Meridian that cannot write anything, and
+    // nothing having said so.
+    expect(flow).toMatch(/if \(blocked\) aiState = null/)
+  })
+
+  it('does not narrate a draft that is not there', () => {
+    // The beats that follow all describe a document: reading the work, a 90%
+    // match, approve, posted. On a still-blocked dialog they narrate a screen
+    // saying the opposite, then stall waiting for targets that never arrive.
+    expect(flow).toMatch(/if \(!blocked\) \{/)
+    const guard = flow.indexOf('if (!blocked) {')
+    const narration = flow.indexOf("s.say('Reading the work")
+    expect(narration).toBeGreaterThan(guard)
+  })
+
+  it('does not march them into the picker a second time at the end', () => {
+    // The closing beat runs on "no evidence of a provider". Once the detour has
+    // taken them to the picker, that is no longer true, and asking again reads
+    // as the tour not having noticed what they just did.
+    expect(scriptDay).not.toMatch(/^\s*if \(ai === null\) \{/m)
+    expect(scriptDay).toMatch(/if \(aiState === null\) \{/)
+    expect(scriptDay).toMatch(/aiState = 'connected-in-tour'/)
+  })
+})

--- a/ui/__tests__/worklog-needs-ai.test.ts
+++ b/ui/__tests__/worklog-needs-ai.test.ts
@@ -84,26 +84,39 @@ describe('the walkthrough does not demo a draft the user cannot get', () => {
   })
 })
 
-describe('the walkthrough routes a blocked Generate to the AI setup', () => {
-  const flow = scriptDay.slice(scriptDay.indexOf("s.spotlight('[data-tour=\"wl-open\"]')"))
+describe('the walkthrough leans on the AI step it already has', () => {
+  // BOUNDED to the worklog stretch. Slicing to the end of the file would sweep in
+  // beat 9 - the closing AI ask - whose `openSettings` is exactly the thing this
+  // block is here to say should happen ONCE, and somewhere else.
+  const flowStart = scriptDay.indexOf("s.spotlight('[data-tour=\"wl-open\"]')")
+  const flowEnd = scriptDay.indexOf('── 6. The daily summary', flowStart)
+  if (flowStart < 0 || flowEnd < flowStart) throw new Error('worklog stretch not found')
+  const flow = scriptDay.slice(flowStart, flowEnd)
 
-  it('detours between the press and the draft, not after the tour', () => {
-    // Order: they press Generate, they are told why it cannot run, they connect,
-    // and only then does the draft arrive. An AI ask parked at the end of the
-    // tour is an ask AFTER the feature it is required for has been demonstrated
-    // working - which is the thing that made this wrong.
+  it('runs no second connect flow of its own', () => {
+    // "Draft with AI" in part one needs the SAME provider and raises the SAME
+    // connect card (`ai-connect`), and it happens first - on the user's own task,
+    // at the moment the requirement first means anything. A second Settings trip
+    // here teaches that these are two separate AI features with two setups,
+    // which is the opposite of true.
+    expect(flow).not.toContain("s.openSettings('intelligence')")
+    // …and it does not ring the connect card either. DETECTING it is the point;
+    // making it the start of another picker walk is not.
+    expect(flow).not.toMatch(/spotlight\('\[data-tour="wl-connect-provider"\]'\)/)
+  })
+
+  it('names the model as the one they already connected', () => {
+    // Without this the beat reads as a second, separate AI feature - and a user
+    // who found connecting one a chore braces for another round of it.
     const press = flow.indexOf("await s.waitForClick('[data-tour=\"wl-generate\"]'")
-    const connect = flow.indexOf('wl-connect-provider')
-    const draft = flow.indexOf("s.appeared('[data-tour=\"draft-targets\"]'")
-    expect(press).toBeGreaterThan(-1)
-    expect(connect).toBeGreaterThan(press)
-    expect(draft).toBeGreaterThan(connect)
+    const same = flow.toLowerCase().indexOf('same ai')
+    expect(same).toBeGreaterThan(-1)
+    expect(same).toBeLessThan(press)   // said BEFORE the press, not after it
   })
 
   it('arms on the card actually appearing, never on a prediction', () => {
-    // The same shape the composer's detour uses. Predicting from a flag would
-    // strand the tour on both sides: a wait for a card that never came, or a
-    // silent skip past one that did.
+    // Predicting from what part one observed strands the tour on both sides: a
+    // wait for a card that never came, or a silent skip past one that did.
     expect(flow).toMatch(/await s\.appeared\('\[data-tour="wl-connect-provider"\]'/)
   })
 
@@ -119,59 +132,28 @@ describe('the walkthrough routes a blocked Generate to the AI setup', () => {
     expect(probe).toBeGreaterThan(both)
   })
 
-  it('comes back and presses Generate again', () => {
-    // The draft dialog closes itself on the way to Settings, so returning to a
-    // ringed `wl-generate` would ring a control that is no longer rendered.
-    const connect = flow.indexOf('wl-connect-provider')
-    const after = flow.slice(connect)
-    expect(after.indexOf('wl-open')).toBeGreaterThan(-1)
-    expect(after.indexOf('wl-open')).toBeLessThan(after.indexOf("s.appeared('[data-tour=\"draft-targets\"]'"))
-  })
-
-  it('checks the connect actually took, and does not claim it did', () => {
-    // Settings here is UNLOCKED on purpose - the locked variant hands back to the
-    // PLANNER on success, which is the wrong place to land from a worklog - so ×
-    // is available throughout and closing it proves nothing. Someone who opens
-    // the picker, finds their provider needs a CLI installed, and backs out comes
-    // back to the same card.
-    const connect = flow.indexOf('wl-connect-provider')
-    const after = flow.slice(connect)
-    // The re-probe exists, AFTER the second press.
-    const rePress = after.indexOf("await s.waitForClick('[data-tour=\"wl-generate\"]'")
-    expect(rePress).toBeGreaterThan(-1)
-    // Searched from AFTER the press: `let blocked = …` (the first probe, before
-    // the detour) contains this same text, so a plain indexOf would match that
-    // one and pass on a file with no re-probe at all.
-    const reProbe = after.indexOf('blocked = await s.appeared', rePress)
-    expect(reProbe).toBeGreaterThan(rePress)
-    // Nothing between the picker and that probe asserts a connection happened.
-    expect(after.slice(0, reProbe)).not.toContain('Connected.')
-  })
-
-  it('puts the closing ask back when the connect did not take', () => {
-    // Skipping it is right for someone who visited the picker and answered. It is
-    // wrong once the tour can SEE that they did not - that user would otherwise
-    // finish the walkthrough with a Meridian that cannot write anything, and
-    // nothing having said so.
-    expect(flow).toMatch(/if \(blocked\) aiState = null/)
-  })
-
   it('does not narrate a draft that is not there', () => {
     // The beats that follow all describe a document: reading the work, a 90%
-    // match, approve, posted. On a still-blocked dialog they narrate a screen
-    // saying the opposite, then stall waiting for targets that never arrive.
+    // match, approve, posted. On a blocked dialog they narrate a screen saying
+    // the opposite, then stall waiting for targets that never arrive.
     expect(flow).toMatch(/if \(!blocked\) \{/)
     const guard = flow.indexOf('if (!blocked) {')
     const narration = flow.indexOf("s.say('Reading the work")
     expect(narration).toBeGreaterThan(guard)
   })
 
-  it('does not march them into the picker a second time at the end', () => {
-    // The closing beat runs on "no evidence of a provider". Once the detour has
-    // taken them to the picker, that is no longer true, and asking again reads
-    // as the tour not having noticed what they just did.
-    expect(scriptDay).not.toMatch(/^\s*if \(ai === null\) \{/m)
-    expect(scriptDay).toMatch(/if \(aiState === null\) \{/)
-    expect(scriptDay).toMatch(/aiState = 'connected-in-tour'/)
+  it('points a blocked user back at the button they already met', () => {
+    // Not a fresh instruction - a pointer to the step they have already been
+    // through. That is what makes it one requirement rather than two.
+    const alt = flow.slice(flow.indexOf('} else {', flow.indexOf('if (!blocked) {')))
+    expect(alt).toContain('Draft with AI')
+  })
+
+  it('leaves the closing ask exactly where it was', () => {
+    // Part two changes nothing about what we know, so the gate stays `ctx.ai`.
+    // That closing beat is now the ONE place a user who declined in part one is
+    // asked again - which is the right number of times.
+    expect(scriptDay).toMatch(/if \(ai === null\) \{/)
+    expect(scriptDay).not.toMatch(/\baiState\b/)
   })
 })

--- a/ui/components/timeline/WorklogActions.tsx
+++ b/ui/components/timeline/WorklogActions.tsx
@@ -225,7 +225,11 @@ export function GenerateCta({ hue, trackers, disabled, checking, blocked, onGene
             Connect an AI provider to generate worklogs. Meridian needs a model to turn
             this work into an update - the one you picked isn&apos;t answering.
           </p>
-          <button onClick={onConnectProvider}
+          {/* data-tour: the first-run walkthrough rings this. Its Generate beat
+              runs the same real check as everywhere else, so a user with no
+              model set up meets this card mid-tour and is taken from here to
+              the picker - see `tutorial/scriptDay.ts`. */}
+          <button data-tour="wl-connect-provider" onClick={onConnectProvider}
             className="mt-body-sm rounded-lg px-3 py-1.5 mt-2.5"
             style={{ fontWeight: 700, fontSize: 12.5, color: '#fff', background: hue, border: 'none', cursor: 'pointer' }}>
             Choose a provider

--- a/ui/components/timeline/WorklogDraftDialog.tsx
+++ b/ui/components/timeline/WorklogDraftDialog.tsx
@@ -261,10 +261,19 @@ export function WorklogDraftDialog({
   // button between one glance and the next. Ask for the thing you want, and be
   // told why it cannot happen yet.
   //
-  // SKIPPED WHEN THE WORKLOG IS SCRIPTED (the first-run walkthrough): that flow
-  // never reaches a model, so the user's real provider health says nothing about
-  // whether its Generate button can work, and letting it swap the control out
-  // would strand the tour on a beat waiting for one that is no longer rendered.
+  // RUN FOR THE SCRIPTED WORKLOG TOO (the first-run walkthrough). It used to be
+  // skipped there, on the reasoning that the tour never reaches a model so real
+  // provider health says nothing about whether its Generate button can work.
+  // True mechanically, and wrong for the user: the tour then demonstrated
+  // Generate producing a finished worklog on a machine with no AI set up at all,
+  // which is the one audience least able to tell that the flow they just watched
+  // cannot happen for them yet. The tour now meets the same card everyone else
+  // does and takes them to the picker from it - see `tutorial/scriptDay.ts`.
+  //
+  // The original worry - stranding a beat waiting on a control that is no longer
+  // rendered - belonged to the FIRST design, which swapped the button out. This
+  // one keeps the button and puts the reason underneath it, so a beat ringing
+  // `wl-generate` still has something to ring either way.
   const [checking, setChecking] = useState(false)
   const [providerDown, setProviderDown] = useState(false)
 
@@ -275,7 +284,6 @@ export function WorklogDraftDialog({
    *  notice below sends them to exactly that screen), and telling someone to set up
    *  a thing they just set up is worse than the original dead end. */
   const attemptGenerate = async () => {
-    if (isDemo) { generate(); return }
     setChecking(true)
     try {
       const h = await load<HealthStatus>('/api/health', 'get_health')
@@ -441,7 +449,24 @@ export function WorklogDraftDialog({
                 ? <ConnectTrackerCta hue={hue} onConnect={() => onOpenSettings('integrations')} />
                 : <GenerateCta hue={hue} trackers={trackers} checking={checking}
                     disabled={busy || phase === 'loading' || checking} onGenerate={attemptGenerate}
-                    blocked={providerDown} onConnectProvider={() => onOpenSettings('intelligence')} />
+                    blocked={providerDown}
+                    // CLOSES ITSELF FIRST, and the order is the whole point.
+                    // Settings renders inside `ModalShell` at `absolute inset-0
+                    // z-40`; this dialog is `fixed inset-0 z-50` portalled to
+                    // `document.body`, and the shell's root is `relative` with no
+                    // z-index, so it opens no stacking context and the two compete
+                    // directly. Opening Settings from under here put it BEHIND the
+                    // dialog the user was still looking at: the button appeared to
+                    // do nothing at all, which is the worst available answer to
+                    // "how do I fix this?" - and it was the answer on the one path
+                    // the product itself offers for connecting a model.
+                    //
+                    // Closing rather than raising a z-index: this dialog is about
+                    // one task's update and Settings is about the whole install, so
+                    // stacking them was never right even when it was visible. The
+                    // draft is one press away again afterwards, and nothing is lost
+                    // - there was no draft to lose, which is why this card is up.
+                    onConnectProvider={() => { onClose(); onOpenSettings('intelligence') }} />
             ) : picking ? (
               <WorklogTicketPicker current={draft.targets[0]?.task_key ?? null} busy={busy}
                 tickets={boardTickets} onPick={retarget} onCancel={() => setPicking(false)} />

--- a/ui/components/tutorial/scriptDay.ts
+++ b/ui/components/tutorial/scriptDay.ts
@@ -87,6 +87,11 @@ async function hasBoard(usesTracker: string | null): Promise<boolean> {
 export async function runDayHalf(s: Stage, ctx: DayHalfContext): Promise<void> {
   const { ai, usesTracker } = ctx
   const board = await hasBoard(usesTracker)
+  // What we know about their provider, which this half can now CHANGE: the
+  // worklog beat takes a user with no model to the picker on the spot, and the
+  // closing beat must not ask them again. `ctx.ai` is what part one observed and
+  // stays read-only; this is that plus anything learned since.
+  let aiState = ai
 
   // ── 3. The timeline, BUILT rather than shown ────────────────────────────
   // The half of the product that happens while the user is not looking, which is
@@ -226,44 +231,149 @@ export async function runDayHalf(s: Stage, ctx: DayHalfContext): Promise<void> {
     await s.point('[data-tour="wl-generate"]')
     await s.waitForClick('[data-tour="wl-generate"]', 120000)
     s.spotlight(null)
-    s.say('Reading the work, comparing it against the tasks you planned this morning, writing the update.')
-    await s.appeared('[data-tour="draft-targets"]', 12000)
-    await s.pause(600)
 
-    // 5a. THE MATCH, WITH ITS NUMBER SHOWING. The confidence is the honest part:
-    // it says the model made a judgement rather than looked something up, which
-    // is what makes the override in the next line make sense.
-    s.spotlight('[data-tour="draft-targets"]')
-    await s.next('It matched this to a ticket on today\'s plan - 90%')
-    s.spotlight(null)
-    // NO BEAT ON THE RE-MATCH CONTROL. It used to ring it here and explain that
-    // the call is always yours - a good sentence about the wrong moment. The
-    // match on screen is a strong one the tour has just called out at 90%, so
-    // "matched the wrong one?" answers a doubt nobody watching this has, and it
-    // puts a detour in front of the only thing this stretch is here to land:
-    // approve, and it posts. The override is one visible control away for anyone
-    // who ever needs it, and beat 7 teaches picking a target properly - on the
-    // off-plan task, where the choice is real.
+    // 5-i. …except on a machine with no model, which is most first runs that got
+    // this far without one. The press runs the REAL provider check (the scripted
+    // worklog no longer bypasses it - see `WorklogDraftDialog`), so what comes
+    // back is the product's own "Connect an AI provider" card rather than a
+    // draft. Carrying on with "reading the work, writing the update" would be
+    // narrating a screen the user is not looking at, about a feature they cannot
+    // have yet.
+    //
+    // THE ORDER IS THE POINT. This ask used to sit at the very end of the tour,
+    // after the worklog had been demonstrated working - so the one thing the
+    // whole product is bought for was shown running on a machine that could not
+    // run it, and the requirement arrived as an afterthought. Asked here, it is
+    // the answer to a button the user just pressed.
+    //
+    // ARMED ON THE CARD APPEARING, never on a flag. Predicting from what part one
+    // observed strands the tour on both sides: a wait for a card that never came,
+    // or a silent skip past one that did. It also means a failed health probe
+    // needs no special case - the dialog generates anyway, no card appears, and
+    // this whole block is skipped.
+    //
+    // WAITS FOR EITHER OUTCOME, then asks which. Both hang off the same health
+    // read, so a fixed window sized for the card would park that many silent
+    // seconds in front of every user who IS set up - and if their draft landed
+    // inside it, the next line ("reading the work, writing the update") would
+    // narrate work that had already finished.
+    await s.appeared('[data-tour="wl-connect-provider"], [data-tour="draft-targets"]', 15000)
+    // Zero-ish: a "which one is on screen right now" probe, not a wait.
+    let blocked = await s.appeared('[data-tour="wl-connect-provider"]', 250)
+    if (blocked) {
+      // Recorded as connected EVEN IF THEY BACK OUT of the picker. This flag only
+      // decides whether the closing beat asks again, and a user who was just
+      // walked to the provider screen and chose not to finish has answered that
+      // question - asking a second time three beats later is nagging, not help.
+      aiState = 'connected-in-tour'
+      // Let the card arrive and be read first. They pressed a button and got an
+      // unexpected answer; a spotlight landing on it in the same second is a
+      // second surprise.
+      await s.pause(1200)
+      s.say('Writing the update needs an AI engine of your own - you pick which. Connect one and we will come straight back to this.')
+      s.spotlight('[data-tour="wl-connect-provider"]')
+      await s.point('[data-tour="wl-connect-provider"]')
+      await s.waitForClick('[data-tour="wl-connect-provider"]', 120000)
+      s.spotlight(null)
+      // The draft dialog closes ITSELF on that press (see `WorklogDraftDialog`),
+      // so Settings is not about to open behind it. Opening Settings is left to
+      // the script rather than the panel's own handler because in here that
+      // handler is deliberately inert - `TutorialScreen` passes a no-op, on the
+      // same reasoning as `onOpenPlan`: the script owns which surface is up.
+      s.openSettings('intelligence')
+      await s.pause(1000)
+      s.say('Pick a provider - Meridian installs it and signs you in here. Change it any time.')
+      await s.waitForClick('[data-tour="modal-close"]', 300000)
+      s.openModal(null)
+      await s.pause(700)
+      // BACK TO THE DRAFT, from the top. The dialog closed on the way out, so the
+      // entry row is what is on screen - ringing `wl-generate` here would ring a
+      // control that is not rendered, and the tour would sit on it until it timed
+      // out. Same two presses as the first time round, which is also the honest
+      // shape of doing this for real.
+      // NOT "connected" - nothing here knows that yet. Settings closing means the
+      // modal closed, not that a provider was picked: it is deliberately unlocked
+      // (the locked variant hands back to the PLANNER on success, which is the
+      // wrong place from here), so × is available the whole time. The press below
+      // is what finds out, and the line has to still be true if the answer is no.
+      s.say('Back to it - ask for that update again.')
+      s.spotlight('[data-tour="wl-open"]')
+      await s.point('[data-tour="wl-open"]')
+      await s.waitForClick('[data-tour="wl-open"]', 120000)
+      s.spotlight(null)
+      await s.appeared('[data-tour="wl-generate"]', 4000)
+      await s.pause(400)
+      s.spotlight('[data-tour="wl-generate"]')
+      await s.point('[data-tour="wl-generate"]')
+      await s.waitForClick('[data-tour="wl-generate"]', 120000)
+      s.spotlight(null)
 
-    // 5b. Approve, then confirm. TWO presses, deliberately: this is the one place
-    // work leaves Meridian and lands somewhere other people can see it.
-    s.say('Nothing leaves Meridian until you approve it. Send this one.')
-    s.spotlight('[data-tour="wl-approve"]')
-    await s.point('[data-tour="wl-approve"]')
-    await s.waitForClick('[data-tour="wl-approve"]', 120000)
-    s.spotlight(null)
-    await s.pause(500)
-    s.say('It names the ticket before it posts, every time.')
-    s.spotlight('[data-tour="wl-confirm"]')
-    await s.point('[data-tour="wl-confirm"]')
-    await s.waitForClick('[data-tour="wl-confirm"]', 120000)
-    s.spotlight(null)
-    await s.appeared('[data-tour="wl-posted"]', 8000)
-    await s.pause(600)
-    // AND IT SAYS THE POST WAS FAKE. Left unsaid, the tick is a lie the user
-    // finds out about by opening their board - exactly the moment the product
-    // most needs to have been straight with them.
-    await s.next('Posted to the ticket, without opening your board. Example day, so nothing really went out.')
+      // DID IT ACTUALLY TAKE? Settings closing proves only that the modal closed.
+      // Someone who opened the picker, found the provider they wanted needs a CLI
+      // installed, and pressed × arrives back here with the same card - and
+      // without this probe the tour would carry straight on into "reading the
+      // work, comparing it against the tasks you planned", narrating a draft that
+      // does not exist, over a card that says the opposite. Then a 12s stall and a
+      // beat about a 90% match nobody can see. That is the precise failure this
+      // whole stretch of comments exists to prevent, landing on exactly the users
+      // this change is for.
+      await s.appeared('[data-tour="wl-connect-provider"], [data-tour="draft-targets"]', 15000)
+      blocked = await s.appeared('[data-tour="wl-connect-provider"]', 250)
+      // And the closing ask goes back on. Skipping it was right while the picker
+      // had been visited and answered; it is wrong once we can see that it was
+      // not - a tour that stays quiet here leaves them finished, with a Meridian
+      // that cannot write anything and nothing having said so.
+      if (blocked) aiState = null
+    }
+
+    // EVERYTHING FROM HERE DESCRIBES A DRAFT. It runs only when there is one -
+    // which is every user who had a model, plus everyone who just connected one.
+    if (!blocked) {
+      s.say('Reading the work, comparing it against the tasks you planned this morning, writing the update.')
+      await s.appeared('[data-tour="draft-targets"]', 12000)
+      await s.pause(600)
+
+      // 5a. THE MATCH, WITH ITS NUMBER SHOWING. The confidence is the honest part:
+      // it says the model made a judgement rather than looked something up, which
+      // is what makes the override in the next line make sense.
+      s.spotlight('[data-tour="draft-targets"]')
+      await s.next('It matched this to a ticket on today\'s plan - 90%')
+      s.spotlight(null)
+      // NO BEAT ON THE RE-MATCH CONTROL. It used to ring it here and explain that
+      // the call is always yours - a good sentence about the wrong moment. The
+      // match on screen is a strong one the tour has just called out at 90%, so
+      // "matched the wrong one?" answers a doubt nobody watching this has, and it
+      // puts a detour in front of the only thing this stretch is here to land:
+      // approve, and it posts. The override is one visible control away for anyone
+      // who ever needs it, and beat 7 teaches picking a target properly - on the
+      // off-plan task, where the choice is real.
+
+      // 5b. Approve, then confirm. TWO presses, deliberately: this is the one place
+      // work leaves Meridian and lands somewhere other people can see it.
+      s.say('Nothing leaves Meridian until you approve it. Send this one.')
+      s.spotlight('[data-tour="wl-approve"]')
+      await s.point('[data-tour="wl-approve"]')
+      await s.waitForClick('[data-tour="wl-approve"]', 120000)
+      s.spotlight(null)
+      await s.pause(500)
+      s.say('It names the ticket before it posts, every time.')
+      s.spotlight('[data-tour="wl-confirm"]')
+      await s.point('[data-tour="wl-confirm"]')
+      await s.waitForClick('[data-tour="wl-confirm"]', 120000)
+      s.spotlight(null)
+      await s.appeared('[data-tour="wl-posted"]', 8000)
+      await s.pause(600)
+      // AND IT SAYS THE POST WAS FAKE. Left unsaid, the tick is a lie the user
+      // finds out about by opening their board - exactly the moment the product
+      // most needs to have been straight with them.
+      await s.next('Posted to the ticket, without opening your board. Example day, so nothing really went out.')
+    } else {
+      // They went to the picker and came back without one. Said plainly and
+      // moved past: the rest of the tour does not need a draft, and stopping to
+      // press the point on someone who has just declined twice is the one thing
+      // that would make them close it. The closing beat asks again, once.
+      await s.next('No model connected, so there is nothing to write the update with yet. Connect one and this is the same two presses - ask, then approve.')
+    }
   } else {
     await s.next('Connect a board and it writes the ticket update too - matched, and posted once you approve.')
   }
@@ -431,7 +541,9 @@ export async function runDayHalf(s: Stage, ctx: DayHalfContext): Promise<void> {
   // touches our servers - a claim that reads as a claim, arriving at the point
   // in the tour where the user is counting the beats left. Nothing is being
   // asked of them, so there is nothing to stop for.
-  if (ai === null) {
+  // `aiState`, not `ctx.ai`: the worklog beat may have taken them to this very
+  // screen already, in which case there is nothing left to ask.
+  if (aiState === null) {
     await s.next('Last thing: pick the AI that does the writing. It runs through your own CLI.', 'Pick a model')
     s.openSettings('intelligence')
     await s.pause(1000)

--- a/ui/components/tutorial/scriptDay.ts
+++ b/ui/components/tutorial/scriptDay.ts
@@ -87,11 +87,6 @@ async function hasBoard(usesTracker: string | null): Promise<boolean> {
 export async function runDayHalf(s: Stage, ctx: DayHalfContext): Promise<void> {
   const { ai, usesTracker } = ctx
   const board = await hasBoard(usesTracker)
-  // What we know about their provider, which this half can now CHANGE: the
-  // worklog beat takes a user with no model to the picker on the spot, and the
-  // closing beat must not ask them again. `ctx.ai` is what part one observed and
-  // stays read-only; this is that plus anything learned since.
-  let aiState = ai
 
   // ── 3. The timeline, BUILT rather than shown ────────────────────────────
   // The half of the product that happens while the user is not looking, which is
@@ -227,24 +222,38 @@ export async function runDayHalf(s: Stage, ctx: DayHalfContext): Promise<void> {
     s.spotlight(null)
     await s.appeared('[data-tour="wl-generate"]', 4000)
     await s.pause(400)
+    // NAMES THE MODEL AS THE ONE THEY ALREADY CONNECTED. Part one had them press
+    // "Draft with AI" on their own task, and that button raises the same connect
+    // card and runs the same provider - so by the time this beat is reached the
+    // requirement has been met, once, at the moment it first mattered. Saying so
+    // is worth a clause: without it this reads as a second, separate AI feature,
+    // and a user who found connecting one a chore braces for another round of it.
+    s.say('Same AI that drafted your task this morning - now on a whole afternoon of work.')
     s.spotlight('[data-tour="wl-generate"]')
     await s.point('[data-tour="wl-generate"]')
     await s.waitForClick('[data-tour="wl-generate"]', 120000)
     s.spotlight(null)
 
-    // 5-i. …except on a machine with no model, which is most first runs that got
-    // this far without one. The press runs the REAL provider check (the scripted
-    // worklog no longer bypasses it - see `WorklogDraftDialog`), so what comes
-    // back is the product's own "Connect an AI provider" card rather than a
-    // draft. Carrying on with "reading the work, writing the update" would be
-    // narrating a screen the user is not looking at, about a feature they cannot
-    // have yet.
+    // 5-i. …unless there is no model, in which case the press returns the
+    // product's own "Connect an AI provider" card instead of a draft. The
+    // scripted worklog no longer bypasses that check (see `WorklogDraftDialog`),
+    // so what is on screen here is the truth rather than a demo of it.
     //
-    // THE ORDER IS THE POINT. This ask used to sit at the very end of the tour,
-    // after the worklog had been demonstrated working - so the one thing the
-    // whole product is bought for was shown running on a machine that could not
-    // run it, and the requirement arrived as an afterthought. Asked here, it is
-    // the answer to a button the user just pressed.
+    // NO SECOND CONNECT DETOUR, and this is the correction worth recording. An
+    // earlier version of this beat ran the full flow again from here: ring the
+    // card, open Settings, pick a provider, come back, re-open the draft,
+    // re-press Generate. That duplicated a flow the tour already has. "Draft
+    // with AI" in part one needs the SAME provider, raises the SAME connect card
+    // (`ai-connect`), and already walks the user through picking one - and it
+    // happens first, on their own task, at the moment the requirement first
+    // means anything. Running it twice teaches that these are two separate AI
+    // features with two setups, which is the opposite of true.
+    //
+    // So the requirement is introduced where it is first hit, and this beat only
+    // has to be honest about what it is looking at. Reaching here blocked means
+    // they declined it in part one, or never opened the planner at all - asking
+    // a second time three beats later is nagging, and the closing beat asks
+    // once more anyway.
     //
     // ARMED ON THE CARD APPEARING, never on a flag. Predicting from what part one
     // observed strands the tour on both sides: a wait for a card that never came,
@@ -259,75 +268,13 @@ export async function runDayHalf(s: Stage, ctx: DayHalfContext): Promise<void> {
     // narrate work that had already finished.
     await s.appeared('[data-tour="wl-connect-provider"], [data-tour="draft-targets"]', 15000)
     // Zero-ish: a "which one is on screen right now" probe, not a wait.
-    let blocked = await s.appeared('[data-tour="wl-connect-provider"]', 250)
-    if (blocked) {
-      // Recorded as connected EVEN IF THEY BACK OUT of the picker. This flag only
-      // decides whether the closing beat asks again, and a user who was just
-      // walked to the provider screen and chose not to finish has answered that
-      // question - asking a second time three beats later is nagging, not help.
-      aiState = 'connected-in-tour'
-      // Let the card arrive and be read first. They pressed a button and got an
-      // unexpected answer; a spotlight landing on it in the same second is a
-      // second surprise.
-      await s.pause(1200)
-      s.say('Writing the update needs an AI engine of your own - you pick which. Connect one and we will come straight back to this.')
-      s.spotlight('[data-tour="wl-connect-provider"]')
-      await s.point('[data-tour="wl-connect-provider"]')
-      await s.waitForClick('[data-tour="wl-connect-provider"]', 120000)
-      s.spotlight(null)
-      // The draft dialog closes ITSELF on that press (see `WorklogDraftDialog`),
-      // so Settings is not about to open behind it. Opening Settings is left to
-      // the script rather than the panel's own handler because in here that
-      // handler is deliberately inert - `TutorialScreen` passes a no-op, on the
-      // same reasoning as `onOpenPlan`: the script owns which surface is up.
-      s.openSettings('intelligence')
-      await s.pause(1000)
-      s.say('Pick a provider - Meridian installs it and signs you in here. Change it any time.')
-      await s.waitForClick('[data-tour="modal-close"]', 300000)
-      s.openModal(null)
-      await s.pause(700)
-      // BACK TO THE DRAFT, from the top. The dialog closed on the way out, so the
-      // entry row is what is on screen - ringing `wl-generate` here would ring a
-      // control that is not rendered, and the tour would sit on it until it timed
-      // out. Same two presses as the first time round, which is also the honest
-      // shape of doing this for real.
-      // NOT "connected" - nothing here knows that yet. Settings closing means the
-      // modal closed, not that a provider was picked: it is deliberately unlocked
-      // (the locked variant hands back to the PLANNER on success, which is the
-      // wrong place from here), so × is available the whole time. The press below
-      // is what finds out, and the line has to still be true if the answer is no.
-      s.say('Back to it - ask for that update again.')
-      s.spotlight('[data-tour="wl-open"]')
-      await s.point('[data-tour="wl-open"]')
-      await s.waitForClick('[data-tour="wl-open"]', 120000)
-      s.spotlight(null)
-      await s.appeared('[data-tour="wl-generate"]', 4000)
-      await s.pause(400)
-      s.spotlight('[data-tour="wl-generate"]')
-      await s.point('[data-tour="wl-generate"]')
-      await s.waitForClick('[data-tour="wl-generate"]', 120000)
-      s.spotlight(null)
+    const blocked = await s.appeared('[data-tour="wl-connect-provider"]', 250)
 
-      // DID IT ACTUALLY TAKE? Settings closing proves only that the modal closed.
-      // Someone who opened the picker, found the provider they wanted needs a CLI
-      // installed, and pressed × arrives back here with the same card - and
-      // without this probe the tour would carry straight on into "reading the
-      // work, comparing it against the tasks you planned", narrating a draft that
-      // does not exist, over a card that says the opposite. Then a 12s stall and a
-      // beat about a 90% match nobody can see. That is the precise failure this
-      // whole stretch of comments exists to prevent, landing on exactly the users
-      // this change is for.
-      await s.appeared('[data-tour="wl-connect-provider"], [data-tour="draft-targets"]', 15000)
-      blocked = await s.appeared('[data-tour="wl-connect-provider"]', 250)
-      // And the closing ask goes back on. Skipping it was right while the picker
-      // had been visited and answered; it is wrong once we can see that it was
-      // not - a tour that stays quiet here leaves them finished, with a Meridian
-      // that cannot write anything and nothing having said so.
-      if (blocked) aiState = null
-    }
-
-    // EVERYTHING FROM HERE DESCRIBES A DRAFT. It runs only when there is one -
-    // which is every user who had a model, plus everyone who just connected one.
+    // EVERYTHING FROM HERE DESCRIBES A DRAFT, so it runs only when there is one.
+    // Narrating "reading the work, comparing it against the tasks you planned"
+    // over a card saying the opposite is the single most confusing thing a
+    // walkthrough can do - and it would then stall 12s waiting for targets that
+    // never arrive, and describe a 90% match nobody can see.
     if (!blocked) {
       s.say('Reading the work, comparing it against the tasks you planned this morning, writing the update.')
       await s.appeared('[data-tour="draft-targets"]', 12000)
@@ -368,11 +315,12 @@ export async function runDayHalf(s: Stage, ctx: DayHalfContext): Promise<void> {
       // most needs to have been straight with them.
       await s.next('Posted to the ticket, without opening your board. Example day, so nothing really went out.')
     } else {
-      // They went to the picker and came back without one. Said plainly and
-      // moved past: the rest of the tour does not need a draft, and stopping to
-      // press the point on someone who has just declined twice is the one thing
-      // that would make them close it. The closing beat asks again, once.
-      await s.next('No model connected, so there is nothing to write the update with yet. Connect one and this is the same two presses - ask, then approve.')
+      // No model. Said plainly, tied back to the button they already met, and
+      // moved past - the rest of the tour does not need a draft, and stopping to
+      // press the point on someone who has already declined it once is what
+      // makes them close the window. Nothing here touches `ctx.ai`, so the
+      // closing beat asks once more - the right number of times.
+      await s.next('This needs the same AI as "Draft with AI" earlier, and there is none connected yet. Set one up and this is two presses - ask, then approve.')
     }
   } else {
     await s.next('Connect a board and it writes the ticket update too - matched, and posted once you approve.')
@@ -541,9 +489,10 @@ export async function runDayHalf(s: Stage, ctx: DayHalfContext): Promise<void> {
   // touches our servers - a claim that reads as a claim, arriving at the point
   // in the tour where the user is counting the beats left. Nothing is being
   // asked of them, so there is nothing to stop for.
-  // `aiState`, not `ctx.ai`: the worklog beat may have taken them to this very
-  // screen already, in which case there is nothing left to ask.
-  if (aiState === null) {
+  // `ctx.ai`, straight from part one, because part two never changes it: the
+  // worklog beat deliberately does NOT run a second connect flow (see 5-i), so
+  // this stays the one place a user who declined earlier is asked again.
+  if (ai === null) {
     await s.next('Last thing: pick the AI that does the writing. It runs through your own CLI.', 'Pick a model')
     s.openSettings('intelligence')
     await s.pause(1000)


### PR DESCRIPTION
Reported from the walkthrough: **Generate worklog is offered before AI is set up.** It is, and two separate failures compounded into it.

## 1. The way out was invisible

Press Generate with no provider and the dialog already answers correctly - *"Connect an AI provider ... Choose a provider"*. That button was the problem:

| layer | position | z |
|---|---|---|
| `SettingsModal` (in `ModalShell`) | `absolute inset-0` | **40** |
| `WorklogDraftDialog` | `fixed inset-0`, portalled to `document.body` | **50** |

`MeridianTimelineShell`'s root is `relative` with no `z-index`, so it opens no stacking context and the two compete directly. **z-50 wins - Settings opened behind the dialog the user was still looking at.** The button appeared to do nothing, on the one path the product itself offers for connecting a model.

Fixed by closing the draft first, rather than raising a z-index globally: this dialog is about one task's update and Settings is about the whole install, so stacking them was never right even when it was visible. Nothing is lost - there was no draft to lose, which is why that card was up.

## 2. The walkthrough skipped the check entirely

```
const attemptGenerate = async () => {
  if (isDemo) { generate(); return }   // ← removed
```

So the first-run tour demonstrated Generate producing a finished worklog on a machine with no AI set up at all - teaching a flow that cannot happen, to the audience least able to tell.

The reasoning behind the bypass was sound mechanically (the scripted worklog never reaches a model) and wrong for the user. Its stated worry - stranding a beat on a control that is no longer rendered - belonged to an **earlier** design that swapped the button out. The current one keeps the button and puts the reason underneath it, so a beat ringing `wl-generate` still has something to ring either way.

## The beat, and where the AI ask actually belongs

The first cut of this PR ran a full second connect flow from the worklog: ring the card, open Settings, pick a provider, come back, re-open the draft, re-press Generate. **Review caught that this duplicates a flow the tour already has**, and the correction is the more interesting half of the change.

**"Draft with AI" in part one needs the same provider and raises the same connect card** (`ai-connect`), and beat 2b-i already walks the user through picking one - on their own task, at the moment the requirement first means anything, and *before* the worklog. Running it again teaches that these are two separate AI features with two setups, which is the opposite of true. It is also the more annoying half: the second walk lands on someone who has already declined once.

So the requirement stays where it is first hit, and this beat does two things.

**Says whose model it is.** One clause before the press - *"Same AI that drafted your task this morning - now on a whole afternoon of work"* - which is the connection the user would otherwise have to make themselves, and would mostly make wrongly.

**Is honest when there is none.** The blocked branch points back at the button they already met - *"This needs the same AI as 'Draft with AI' earlier"* - and moves on, leaving the closing beat as the **one** place a user who declined earlier is asked again.

## What the detection still has to get right

**Armed on the DOM, never on a flag.** It waits for the connect card *or* the draft targets - both hang off the same health read - then asks which arrived. A fixed window sized for the card would park those seconds in front of every user who *is* set up, and if their draft landed inside it, the next line would narrate work that had already finished. A failed health probe needs no special case either: the dialog generates anyway, no card appears, the block is skipped.

**Nothing after it narrates a draft that is not there.** Those beats describe a document - reading the work, a 90% match, approve, posted. Over a card saying the opposite they would stall 12s waiting for targets that never arrive, then describe a match nobody can see.

## Checked, not assumed

**Beat 7 needs none of this.** Its header says "the same two presses the first worklog took", which reads like a second Generate - it is not. It operates an already-drafted off-plan update inside the summary card (`wl-rematch` / `wl-approve`) and never presses Generate, so the removed bypass cannot strand it.

## Tests

`ui/__tests__/worklog-needs-ai.test.ts`. The two product invariants were written first - 7 of 8 assertions failed on the old files, the survivor being the "must keep failing open" guard that has to pass both ways.

The tour assertions were rewritten with the beat. The new invariant is **`runs no second connect flow of its own`**, confirmed by planting an `openSettings` inside the blocked branch and watching it fail. Its slice is bounded to the worklog stretch so it can neither be satisfied nor broken by beat 9's legitimate one.

- `bun test` - 772 pass, 0 fail
- `npm run build` - static export clean
- pre-commit and pre-push hooks green

Source-scanning, for the reason the sibling walkthrough tests are: both product failures are a surface **not appearing**. There is no exception, no rejected promise, and no state to read - the assertion a unit test would make ("Settings opened") is true in the DOM in the broken case too. What is checkable is the wiring that decides it.

## Not verified on screen

Same caveat as #767: no Chromium here and the browser extension was unresponsive, and the interesting question is what WKWebView does anyway. Worth walking the tour once with no provider connected before merging - that is the path this changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
