### PR TITLE
feat(walkthrough): type the first task instead of waiting for the user to invent one

### DIFF
--- a/ui/__tests__/tutorial-types-first-task.test.ts
+++ b/ui/__tests__/tutorial-types-first-task.test.ts
@@ -1,0 +1,131 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// The planner's first beat writes the note itself instead of waiting for the
+// user to invent one.
+//
+// It used to ring an empty box and wait up to three minutes. Nothing has
+// happened by that point in the tour: the user has not seen Meridian draft
+// anything, does not know what a scruffy one-liner buys them over a title, and
+// is being asked to make up an example in a field whose format they are
+// guessing at - before the tour will move at all.
+//
+// Typing it is not cosmetic. The beat straight after asks them to press "Draft
+// with AI", and that press is the first time the product does anything: one
+// scruffy line becoming a titled, described task. A user stuck at the blank box
+// never reaches it.
+//
+// Source-scanning: driving a React-controlled field from outside React is the
+// kind of thing that fails by doing NOTHING - the character lands for one frame
+// and the next render wipes it, with no error anywhere. There is no DOM here to
+// assert against, and a mocked one would not have React's value tracker, which
+// is the exact part that breaks.
+
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const read = (...p: string[]) => readFileSync(join(import.meta.dir, '..', ...p), 'utf8')
+
+const script = read('components', 'tutorial', 'script.ts')
+const engine = read('components', 'tutorial', 'engine.ts')
+const hook = read('components', 'tutorial', 'useTutorial.tsx')
+const composer = read('components', 'plan', 'TaskComposer.tsx')
+
+describe('the walkthrough writes the first task rather than waiting for one', () => {
+  it('types into the note instead of waiting on the user', () => {
+    expect(script).toMatch(/await s\.type\('\[data-tour="task-note"\]', FIRST_TASK_NOTE\)/)
+    // The old three-minute wait is gone, not merely bypassed. Left in place it
+    // would sit after the typing and block on a field that is already full.
+    expect(script).not.toMatch(/waitForValue\('\[data-tour="task-note"\]'/)
+  })
+
+  it('writes a real task, not the field\'s own placeholder', () => {
+    // This lands in the user's REAL plan - part one runs against their own day,
+    // not the example - so a fiction leaves a made-up task on a real board. And
+    // echoing the placeholder would make the whole beat read as a canned demo.
+    const note = script.match(/^const FIRST_TASK_NOTE = '([^']+)'/m)?.[1]
+    expect(note).toBeTruthy()
+    const placeholder = composer.match(/placeholder="([^"]*login[^"]*)"/)?.[1] ?? 'fix the flaky login test…'
+    expect(note).not.toBe(placeholder.replace('…', ''))
+    expect(note!.toLowerCase()).toContain('meridian')
+  })
+
+  it('gives the model enough to draft a title that clears the floor', () => {
+    // `canCreate` needs MIN_TITLE_WORDS (4). Beat 2c-2 handles a short drafted
+    // title gracefully - it names what is missing and waits on the real gate -
+    // but that branch asks for exactly the typing this change removed. While
+    // every user wrote their own note, landing on it was a per-user lottery;
+    // with ONE note it is all-or-nothing for the whole fleet, and the example
+    // recorded in that beat is an onboarding note drafting down to two words.
+    //
+    // The model's output cannot be asserted here. The INPUT's substance can, and
+    // that is the thing a future edit would quietly erode.
+    const note = script.match(/^const FIRST_TASK_NOTE = '([^']+)'/m)![1]
+    const words = note.trim().split(/\s+/).filter(Boolean)
+    const filler = new Set(['and', 'the', 'a', 'an', 'through', 'to', 'of', 'on', 'my', 'with', 'for', 'in'])
+    const content = words.filter(w => !filler.has(w.toLowerCase()))
+    // Comfortably clear of the four-word floor even after a faithful title drops
+    // the filler - not a padding check, a "do not shorten this to two words" one.
+    expect(content.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it('still hands the Draft press to the user', () => {
+    // The typing removes a wait the user gained nothing from. It must not remove
+    // the press they gain everything from - that click is the first time they
+    // see the product do work.
+    const typed = script.indexOf("s.type('[data-tour=\"task-note\"]'")
+    const draft = script.indexOf("await s.waitForClick('[data-tour=\"task-draft\"]'")
+    expect(typed).toBeGreaterThan(-1)
+    expect(draft).toBeGreaterThan(typed)
+    // Not clicked FOR them anywhere in that stretch.
+    expect(script.slice(typed, draft)).not.toContain('s.click()')
+  })
+})
+
+describe('the typing drives the real field', () => {
+  const start = hook.indexOf('type: async (sel, text)')
+  const end = hook.indexOf('value: (sel)', start)   // searched FROM the start, so
+  // a reorder that put `value:` above `type:` fails here instead of silently
+  // widening the slice to most of the file and passing on anything.
+  if (start < 0 || end < start) throw new Error('type/value primitives not found in expected order')
+  const impl = hook.slice(start, end)
+  /** The same slice with `//` comments dropped. The comments here NAME the
+   *  anti-pattern they exist to warn about, so a check for it reading the raw
+   *  text fails on a correct file. */
+  const code = impl.replace(/^\s*\/\/.*$/gm, '')
+
+  it('goes through the native setter, not a plain assignment', () => {
+    // React tracks the last value it rendered and compares it against the node's
+    // own property. `el.value = x` updates neither its tracker nor its state, so
+    // the text shows for one frame, `onChange` never fires, and the next render
+    // wipes it. Silently - which is why this is pinned.
+    expect(impl).toContain("Object.getOwnPropertyDescriptor(proto, 'value')?.set")
+    expect(impl).toContain("new Event('input', { bubbles: true })")
+    expect(code).not.toMatch(/\bel\.value\s*=/)
+  })
+
+  it('does not reach into the composer store instead', () => {
+    // `setNote` from useTaskComposer would be one line and would quietly stop
+    // being a demonstration - the same reasoning that has `demoDrag` pressing the
+    // product's own "+ Add" rather than editing the plan.
+    expect(hook).not.toContain('setNote')
+    expect(engine).toContain('type(selector: string, text: string): Promise<boolean>')
+  })
+
+  it('types a character at a time, and can be skipped mid-sentence', () => {
+    // One assignment lands the sentence in a single frame, which looks like a
+    // pre-filled form - and a pre-filled form teaches nothing about where the
+    // words go.
+    expect(impl).toMatch(/for \(let i = 1; i <= text\.length; i\+\+\)/)
+    // `sleep(ms, sig)` rejects Aborted, so Skip unwinds the script from inside
+    // the loop exactly as it does from any other await. A bare timeout would
+    // keep typing into a walkthrough the user has already left.
+    expect(impl).toMatch(/await sleep\(TYPE_MS, sig\)/)
+  })
+
+  it('answers false for a field that is not there', () => {
+    // Same contract as every other primitive that targets an element. Throwing
+    // would abort the whole tour over one missing box.
+    expect(impl).toMatch(/if \(!el\) return false/)
+  })
+})

--- a/ui/components/tutorial/engine.ts
+++ b/ui/components/tutorial/engine.ts
@@ -74,6 +74,25 @@ export interface Stage {
    *  reacting to. Same fallback contract as `waitForClick`: resolves `false`
    *  rather than stranding anyone. */
   waitForValue(selector: string, opts?: { fallbackMs?: number; settled?: boolean }): Promise<boolean>
+  /** TYPE `text` into the input/textarea at `selector`, a character at a time,
+   *  as though the tour were at the keyboard. Resolves `false` if the field is
+   *  not on screen - same contract as every other primitive that targets one.
+   *
+   *  For the beats where waiting on the user costs more than it teaches. The
+   *  planner's first beat used to hand over a blank box and wait: a first-time
+   *  user who has not yet seen the product do anything is asked to invent an
+   *  example of a thing they have not been shown, in a field whose format they
+   *  are guessing at, before the tour will move. Typing it instead spends four
+   *  seconds and leaves them with a filled form and a button to press.
+   *
+   *  IT DRIVES THE REAL FIELD, not the store behind it. React owns `value`, so a
+   *  plain assignment is discarded on the next render and no `onChange` fires -
+   *  hence the prototype's native setter plus a bubbling `input` event, which is
+   *  the pair React's synthetic layer actually reads. Going around it to the
+   *  composer's own `setNote` would be shorter and would quietly stop being a
+   *  demonstration: the same reasoning as `demoDrag`, which presses the product's
+   *  real "+ Add" rather than reaching into the plan. */
+  type(selector: string, text: string): Promise<boolean>
   /** Synchronous read of the input/textarea at `selector`'s current value, or
    *  `''` if it is not on screen.
    *

--- a/ui/components/tutorial/script.ts
+++ b/ui/components/tutorial/script.ts
@@ -91,6 +91,37 @@ export const INTRO_LINES = [
  *  addresses it structurally. */
 const BOARD_CARD = '[data-tour="plan-board"] [data-plan-card]'
 
+/** The first task the tour writes into the planner on the user's behalf.
+ *
+ *  DELIBERATELY THE THING THEY ARE DOING. This lands in their REAL plan - part
+ *  one runs against their own day, not the example - so it cannot be a fiction
+ *  like "fix the flaky login test" without leaving a made-up task on a real
+ *  board. Setting Meridian up is what this person is genuinely spending the
+ *  next few minutes on, which makes it the one sentence that is both a good
+ *  demonstration and true.
+ *
+ *  Written the way the field asks to be written - lowercase, unpunctuated, the
+ *  shape of something said rather than filed - because the beat after it is the
+ *  model turning exactly that into a titled task. A tidy sentence here would
+ *  make the draft look like formatting.
+ *
+ *  AND IT IS LOAD-BEARING ON `MIN_TITLE_WORDS`. Beat 2c-2 exists because a
+ *  drafted title can land under the four-word floor `canCreate` enforces, and
+ *  the example recorded there is an onboarding note ("Testing onboarding" →
+ *  "Test onboarding") - the same subject as this one. While every user wrote
+ *  their own note that was a per-user lottery; with one sentence feeding every
+ *  first run, whatever the model does with THIS input it does for everyone. A
+ *  terse note would put the whole fleet on the "this title's a little thin"
+ *  branch, which asks for exactly the typing this beat removed, at a worse
+ *  moment.
+ *
+ *  So it carries two verbs and two objects on purpose - enough for a faithful
+ *  title to clear the floor without padding. Shortening it is not a copy edit;
+ *  check the drafted title still clears four words first. The branch degrades
+ *  gracefully either way (it names what is missing and waits on the real gate),
+ *  so this is a quality floor, not a correctness one. */
+const FIRST_TASK_NOTE = 'setting up meridian and going through onboarding'
+
 /**
  * Wait for the user's tickets to land in the planner, narrating the wait.
  *
@@ -435,13 +466,34 @@ export async function runScript(s: Stage): Promise<void> {
     // teaches nothing and delays the one that does. Every beat in here points at
     // exactly one thing to type or press, and says only what that thing is for.
     //
-    // 2a. The note. `waitForValue`, not `waitForClick`: nothing here is
-    // clickable until they have typed something, so a click wait would sit
-    // silently through the one part of the tour they are meant to do.
-    s.say("Write your first task here - however you'd say it out loud.")
+    // 2a. The note. THE TOUR TYPES IT, and this is a reversal worth recording.
+    //
+    // It used to ring the empty box and wait (`waitForValue`, up to three
+    // minutes) for the user to write their own first task. The reasoning was
+    // that a plan made of their real work is worth more than a demo of one, and
+    // that is true - but it asked for the wrong thing at the wrong moment.
+    // Nothing has happened yet: the user has not seen Meridian draft anything,
+    // has no idea what "however you'd say it out loud" buys them over a title,
+    // and is being asked to invent an example in a field whose format they are
+    // guessing at, before the tour will move at all. The commonest outcomes are
+    // a placeholder-shaped non-answer and a three-minute stall.
+    //
+    // So the tour writes one, and it writes the task the user is ACTUALLY doing:
+    // they are setting Meridian up, right now, and that is a real first task
+    // rather than a fiction. The beats that follow are unchanged and the user
+    // still presses every button - what changes is that they now watch the
+    // product turn one scruffy line into a titled task, which is the thing this
+    // stretch exists to show and which no amount of waiting was going to teach.
+    //
+    // The field is theirs afterwards: it is a textarea holding text, and every
+    // later beat edits rather than dictates.
+    s.say('Your first task goes here - one line, however you would say it out loud.')
     s.spotlight('[data-tour="task-note"]')
     await s.point('[data-tour="task-note"]')
-    const typed = await s.waitForValue('[data-tour="task-note"]', { fallbackMs: 180000 })
+    const typed = await s.type('[data-tour="task-note"]', FIRST_TASK_NOTE)
+    // A moment to read it back before the next ring moves. Typing that lands and
+    // is immediately covered by the next instruction reads as a flicker.
+    if (typed) await s.pause(900)
 
     if (typed) {
       // 2b. The AI draft — the first time they see the model do anything.

--- a/ui/components/tutorial/useTutorial.tsx
+++ b/ui/components/tutorial/useTutorial.tsx
@@ -83,6 +83,14 @@ const SAMPLE_TASKS = sampleTasks()
 const SAMPLE_OVERVIEW = sampleOverview()
 const NO_TASKS: typeof SAMPLE_TASKS = []
 
+/** Milliseconds between characters when the tour types into a field.
+ *
+ *  Fast enough not to be a wait (a 33-character sentence lands in about a second
+ *  and a half), slow enough to read as typing rather than as a form that was
+ *  already filled in. The distinction is the whole reason it is not one
+ *  assignment: the user has to see WHERE the words go. */
+const TYPE_MS = 45
+
 export interface TutorialHandle {
   running: boolean
   /** The opaque tutorial surface (an example day), or null. Rendered by the
@@ -435,6 +443,36 @@ export function useTutorial(opts: {
         parkCursor()
         if (sig.aborted) throw new Aborted()
         return got
+      },
+      type: async (sel, text) => {
+        const sig = signal()
+        const el = await waitForElement(sel, sig) as HTMLInputElement | HTMLTextAreaElement | null
+        if (!el) return false
+        // THE NATIVE SETTER, not `el.value =`. React tracks the last value it
+        // rendered and compares against the DOM node's own property; a plain
+        // assignment updates neither its tracker nor its state, so the character
+        // appears for one frame and is wiped by the next render, with `onChange`
+        // never firing. Reaching the prototype's setter writes the property React
+        // reads, and a bubbling `input` event is what its synthetic listener is
+        // attached to - together they are indistinguishable from a keystroke.
+        const proto = el instanceof HTMLTextAreaElement
+          ? HTMLTextAreaElement.prototype
+          : HTMLInputElement.prototype
+        const setValue = Object.getOwnPropertyDescriptor(proto, 'value')?.set
+        if (!setValue) return false
+        el.focus()
+        // Character at a time, because the point is that it reads as typing. A
+        // single assignment lands the whole sentence in one frame, which looks
+        // like the form was pre-filled - and a pre-filled form teaches nothing
+        // about where the words go.
+        for (let i = 1; i <= text.length; i++) {
+          setValue.call(el, text.slice(0, i))
+          el.dispatchEvent(new Event('input', { bubbles: true }))
+          // Rejects `Aborted` if the user skips mid-sentence, which unwinds the
+          // whole script exactly as every other await in here does.
+          await sleep(TYPE_MS, sig)
+        }
+        return true
       },
       value: (sel) => (tourTarget(sel) as HTMLInputElement | HTMLTextAreaElement | null)?.value ?? '',
       waitForMinWords: async (sel, minWords, o) => {


### PR DESCRIPTION
The planner's opening beat rang an empty box and waited - up to three minutes - for the user to write their own first task.

The reasoning was sound: a plan made of their real work beats a demo of one. But it asked for the wrong thing at the wrong moment. **Nothing has happened yet.** The user has not watched Meridian draft anything, does not know what a scruffy one-liner buys them over a title, and is being asked to invent an example in a field whose format they are guessing at - before the tour will move at all. The likely outcomes are a placeholder-shaped non-answer and a stall.

The beat straight after is the one that matters: pressing **Draft with AI** and watching one line become a titled, described task. A user parked at the blank box never reaches it.

So the tour types the note and hands over at the button, which is where the product actually does something. Every later beat is unchanged - they still press Draft, still choose where it goes, still press Add.

## What it types is not a fiction

```
const FIRST_TASK_NOTE = 'setting up meridian and going through onboarding'
```

This lands in the user's **real** plan - part one runs against their own day, not the example day - so `fix the flaky login test` would leave a made-up task on a real board. Setting Meridian up is what this person is genuinely doing, which makes it the one sentence that is both a good demonstration and true.

Written lowercase and unpunctuated, the way the field asks to be written, because the next beat is the model turning exactly that into a titled task. A tidy sentence would make the draft look like formatting.

## The primitive drives the real field

`Stage.type` writes through the prototype's native value setter and dispatches a bubbling `input` event.

That is not incidental ceremony. React tracks the last value it rendered and compares it against the node's own property - `el.value = x` updates neither its tracker nor its state, so **the text shows for one frame, `onChange` never fires, and the next render wipes it.** Silently, with no error anywhere.

Going around to the composer's own `setNote` would be one line and would quietly stop being a demonstration - the same reasoning that has `demoDrag` pressing the product's real "+ Add" rather than reaching into the plan.

Typed a character at a time (45ms) so it reads as typing rather than as a pre-filled form - the user has to see *where* the words go. The per-character sleep takes the abort signal, so Skip unwinds from mid-sentence like every other await in the script.

## One coupling this creates, which is worth knowing

**The note is now load-bearing on `MIN_TITLE_WORDS`.**

Beat 2c-2 exists because a drafted title can land under the four-word floor `canCreate` enforces - and the example recorded in that comment is an onboarding note: *"Testing onboarding" → "Test onboarding"*. Same subject as this one.

While every user wrote their own note, landing on that branch was a per-user lottery. With **one** sentence feeding every first run, whatever the model does with this input it does for everyone. All-or-nothing, not occasional.

I checked the failure mode rather than betting on the phrasing: the branch **degrades gracefully** - it names what is missing ("This title's a little thin - add a few more words") and waits on the real gate, and a timeout falls through to "No rush - finish it whenever you like" and rings the close button. Nothing strands.

So this is a quality floor, not a correctness one - but the note carries two verbs and two objects on purpose, and shortening it is not a copy edit. Both the constant's docstring and a test say so.

## Tests

`ui/__tests__/tutorial-types-first-task.test.ts`. **Nothing pinned the old behaviour**, so rather than claim coverage I planted the two regressions that matter and confirmed each fails:

| plant | caught by |
|---|---|
| `setValue.call(el, …)` → `el.value = …` | *goes through the native setter* |
| `waitForClick(task-draft)` → `s.click()` | *still hands the Draft press to the user* |

The model's output cannot be asserted here, but the input's substance can - so there is a test on the note having enough content words to survive a faithful title, which is the thing a future edit would quietly erode.

- `bun test` - 774 pass, 0 fail
- `npm run build` - static export clean
- pre-commit and pre-push hooks green

## Interaction with #769 (open)

`typed` is now effectively always true, so beat 2b's AI-connect detour runs on every first run rather than only when the user typed something. That means **a provider gets connected in part one far more often**, which makes #769's worklog-Generate detour the rarer path rather than the common one. No file overlap between the branches, so no conflict - context for whoever reviews both.

## Not verified on screen

Same caveat as #767 and #769: no Chromium here and the browser extension was unresponsive. Worth watching the planner beat once under `npm run tauri dev` - the typing animation is the part source cannot show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
