### PR TITLE
fix(tray): stop the installer and the watchdog fighting over the daemon

### DIFF
--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -529,6 +529,25 @@ async fn install(backend: &Path, home: &Path) -> Result<(), String> {
 
     let daemon_bin = home.join(".meridian").join("bin").join(DAEMON_FILE);
 
+    // HOLD THE STAGING WINDOW ACROSS stop → copy → register.
+    //
+    // The tray supervises the daemon as well as installing it, and until this
+    // guard existed the two halves raced: the stop below killed the daemon, the
+    // watchdog saw a silent endpoint ~10 s later and started it again from the
+    // very path being staged, and the stop's own poll then reported that new
+    // process as an un-killable holder of the binary. The full account is on
+    // [`crate::daemon_lifecycle::begin_staging`].
+    //
+    // Held past `stage_binary` and through `register_service` deliberately:
+    // registering is what legitimately brings the daemon back, and a watchdog
+    // start racing it would spawn a second one against the same DB.
+    //
+    // Not `cfg`-gated even though the lock hazard is Windows-only - the
+    // installer restarting the daemon while the watchdog independently decides
+    // to start it is a double-spawn on any platform, and a flag that exists on
+    // one OS only is the kind of asymmetry that rots.
+    let _staging = crate::daemon_lifecycle::begin_staging();
+
     // Windows keeps a running exe's pages mapped, so overwriting it fails with
     // "the process cannot access the file" (os error 32) — and this isn't just
     // a first-install concern: `ensure_backend_installed` re-stages on every
@@ -724,30 +743,7 @@ pub(crate) async fn stop_running_daemon_before_stage(daemon_bin: &Path) -> Resul
         .output()
         .await;
 
-    for pid in matching_daemon_pids(daemon_bin).await {
-        let out = tokio::process::Command::new("taskkill")
-            .args(["/F", "/PID", &pid.to_string()])
-            .no_window()
-            .output()
-            .await;
-        match out {
-            Ok(o) if o.status.success() => {
-                tracing::info!(pid, path = %daemon_bin.display(), "backend_install: stopped staged daemon process");
-            }
-            Ok(o) => {
-                tracing::warn!(
-                    pid,
-                    path = %daemon_bin.display(),
-                    status = %o.status,
-                    stderr = %String::from_utf8_lossy(&o.stderr).trim(),
-                    "backend_install: taskkill did not stop staged daemon process"
-                );
-            }
-            Err(e) => {
-                tracing::warn!(pid, path = %daemon_bin.display(), error = %e, "backend_install: taskkill spawn failed");
-            }
-        }
-    }
+    kill_daemon_pids(daemon_bin).await;
 
     // Poll until the staged daemon's own processes are gone (the file handle
     // lingers briefly after the kill), then require an empty set — a still-alive
@@ -772,12 +768,29 @@ pub(crate) async fn stop_running_daemon_before_stage(daemon_bin: &Path) -> Resul
             }
             async move {
                 let pids = matching_daemon_pids(daemon_bin).await;
-                if emit && !pids.is_empty() {
-                    tracing::debug!(
-                        path = %daemon_bin.display(),
-                        remaining = pids.len(),
-                        "backend_install: still waiting for the previous daemon to exit"
-                    );
+                if !pids.is_empty() {
+                    if emit {
+                        tracing::debug!(
+                            path = %daemon_bin.display(),
+                            remaining = pids.len(),
+                            "backend_install: still waiting for the previous daemon to exit"
+                        );
+                    }
+                    // RE-KILL, don't just observe. The `taskkill` above ran once,
+                    // against the pid set as it stood before this poll began, so
+                    // anything that appeared afterwards was watched to the end of
+                    // the budget and then reported as an un-killable holder of the
+                    // binary — which is exactly how a daemon respawned two seconds
+                    // into the wait produced "still running after stop attempts".
+                    //
+                    // The staging guard in `install` is what stops the tray's own
+                    // watchdog doing that; this is the backstop for every spawner
+                    // it does not own — a second tray instance, the Startup-folder
+                    // launcher firing on a fast re-login, someone running the
+                    // daemon by hand. Re-killing a pid that is already dying is
+                    // harmless (`taskkill` just reports it gone), and the loop
+                    // still terminates on the same attempt budget.
+                    kill_daemon_pids(daemon_bin).await;
                 }
                 pids
             }
@@ -798,6 +811,44 @@ pub(crate) async fn stop_running_daemon_before_stage(daemon_bin: &Path) -> Resul
         "staged daemon {} still running after stop attempts (pids: {remaining:?}) - cannot overwrite a locked binary",
         daemon_bin.display()
     ))
+}
+
+/// `taskkill /F` every process currently running the staged daemon binary.
+///
+/// Killing by PID — not by `/IM` image name — is what keeps an unrelated
+/// `meridian.exe` (an interactive CLI run, a different tool sharing the image
+/// name) alive. Best-effort per pid: a failure is logged and the next one is
+/// still attempted, because the caller's post-kill poll is what actually
+/// decides whether the stop succeeded.
+///
+/// Called both before the wait and on every probe inside it — see the re-kill
+/// note in [`stop_running_daemon_before_stage`].
+#[cfg(target_os = "windows")]
+async fn kill_daemon_pids(daemon_bin: &Path) {
+    for pid in matching_daemon_pids(daemon_bin).await {
+        let out = tokio::process::Command::new("taskkill")
+            .args(["/F", "/PID", &pid.to_string()])
+            .no_window()
+            .output()
+            .await;
+        match out {
+            Ok(o) if o.status.success() => {
+                tracing::info!(pid, path = %daemon_bin.display(), "backend_install: stopped staged daemon process");
+            }
+            Ok(o) => {
+                tracing::warn!(
+                    pid,
+                    path = %daemon_bin.display(),
+                    status = %o.status,
+                    stderr = %String::from_utf8_lossy(&o.stderr).trim(),
+                    "backend_install: taskkill did not stop staged daemon process"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(pid, path = %daemon_bin.display(), error = %e, "backend_install: taskkill spawn failed");
+            }
+        }
+    }
 }
 
 /// PIDs of running processes whose executable is exactly the staged daemon

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -743,7 +743,7 @@ pub(crate) async fn stop_running_daemon_before_stage(daemon_bin: &Path) -> Resul
         .output()
         .await;
 
-    kill_daemon_pids(daemon_bin).await;
+    kill_pids(&matching_daemon_pids(daemon_bin).await, daemon_bin).await;
 
     // Poll until the staged daemon's own processes are gone (the file handle
     // lingers briefly after the kill), then require an empty set — a still-alive
@@ -790,7 +790,15 @@ pub(crate) async fn stop_running_daemon_before_stage(daemon_bin: &Path) -> Resul
                     // daemon by hand. Re-killing a pid that is already dying is
                     // harmless (`taskkill` just reports it gone), and the loop
                     // still terminates on the same attempt budget.
-                    kill_daemon_pids(daemon_bin).await;
+                    //
+                    // Kills the pids THIS probe just enumerated rather than
+                    // re-querying: `matching_daemon_pids` spawns a whole
+                    // `powershell -Command Get-CimInstance`, which costs far
+                    // more than the `taskkill`s it feeds. Re-querying here
+                    // would pay that twice on every one of the up-to-40
+                    // attempts, stretching the stop on exactly the slow,
+                    // loaded machines where this path is reached at all.
+                    kill_pids(&pids, daemon_bin).await;
                 }
                 pids
             }
@@ -813,7 +821,14 @@ pub(crate) async fn stop_running_daemon_before_stage(daemon_bin: &Path) -> Resul
     ))
 }
 
-/// `taskkill /F` every process currently running the staged daemon binary.
+/// `taskkill /F` each of `pids`. `daemon_bin` is only for the log lines.
+///
+/// Takes an already-enumerated pid list rather than looking one up itself:
+/// both callers have just run [`matching_daemon_pids`], and that spawns an
+/// entire `powershell -Command Get-CimInstance`, which dwarfs the `taskkill`s
+/// it feeds. Re-querying inside here would pay it twice per poll attempt, up
+/// to 40 times, on precisely the loaded machines slow enough to reach the
+/// later attempts at all.
 ///
 /// Killing by PID — not by `/IM` image name — is what keeps an unrelated
 /// `meridian.exe` (an interactive CLI run, a different tool sharing the image
@@ -824,8 +839,8 @@ pub(crate) async fn stop_running_daemon_before_stage(daemon_bin: &Path) -> Resul
 /// Called both before the wait and on every probe inside it — see the re-kill
 /// note in [`stop_running_daemon_before_stage`].
 #[cfg(target_os = "windows")]
-async fn kill_daemon_pids(daemon_bin: &Path) {
-    for pid in matching_daemon_pids(daemon_bin).await {
+async fn kill_pids(pids: &[u32], daemon_bin: &Path) {
+    for &pid in pids {
         let out = tokio::process::Command::new("taskkill")
             .args(["/F", "/PID", &pid.to_string()])
             .no_window()

--- a/tray/src-tauri/src/daemon_lifecycle.rs
+++ b/tray/src-tauri/src/daemon_lifecycle.rs
@@ -265,6 +265,76 @@ pub(crate) fn is_paused() -> bool {
     DAEMON_PAUSED.load(Ordering::Relaxed)
 }
 
+/// Set while the installer is stopping the daemon in order to replace its
+/// binary — see [`begin_staging`].
+static DAEMON_STAGING: AtomicBool = AtomicBool::new(false);
+
+/// Whether the installer is mid-swap of the daemon binary. Read by
+/// [`crate::poll::watchdog`] and [`crate::poll::refresh`], both of which start a
+/// daemon they find stopped and must not do so while the installer is
+/// deliberately holding it down.
+///
+/// SEPARATE FROM [`is_paused`] on purpose, though both make the watchdog stand
+/// down. Pause is the user's instruction and persists until they revoke it;
+/// this is a few seconds of internal exclusion the user never sees, and
+/// borrowing the pause flag for it would surface "Paused" in the tray menu
+/// during every update — and, worse, leave the daemon genuinely paused if the
+/// installer died before clearing it.
+pub(crate) fn is_staging() -> bool {
+    DAEMON_STAGING.load(Ordering::Relaxed)
+}
+
+/// Claim the staging window, clearing it when the returned guard drops.
+///
+/// # Why this exists
+///
+/// The tray is BOTH the daemon's installer and — on Windows, where there is no
+/// launchd `KeepAlive` — its only supervisor, and the two halves used to fight
+/// each other with no interlock at all:
+///
+/// 1. `ensure_backend_installed` kills the running daemon so it can overwrite
+///    `~/.meridian/bin/meridian.exe` (Windows keeps a running exe's pages
+///    mapped, so the copy fails with os error 32 otherwise).
+/// 2. Roughly 10 s later — [`crate::poll::watchdog`]'s `TICK` × `STRIKES` — the
+///    watchdog notices the endpoint has gone silent and starts the daemon back
+///    up, from the very path being staged.
+/// 3. The installer's post-kill poll then finds a live process holding the
+///    binary, and fails the whole install with "still running after stop
+///    attempts (pids: […]) - cannot overwrite a locked binary".
+///
+/// The daemon it reported as un-killable was its own supervisor's child,
+/// spawned seconds earlier. The watchdog's existing liveness guard does not
+/// help: `process_alive()` is `None` on Windows, which [`crate::poll::watchdog::decide`]
+/// treats as non-blocking by design.
+///
+/// This only bites on an UPDATE — a first install has no running daemon to
+/// stop, returns immediately, and never wakes the watchdog. That is why the
+/// failure looked intermittent while being, on the update path, reliable.
+///
+/// # Shape
+///
+/// An `AtomicBool` + RAII guard rather than [`LIFECYCLE`]. The mutex would also
+/// serialise the two, but the watchdog would then block on it for the length of
+/// an install and start the daemon the instant it was released — correct, but it
+/// makes a 5 s-budgeted [`stop_for_quit`] queue behind a multi-second install,
+/// and a flag keeps [`crate::poll::watchdog::decide`] a pure function that can
+/// be tested for this exact case. The guard is what makes an early `?` return
+/// or a panic mid-install clear the flag rather than wedging the watchdog off
+/// for the rest of the session.
+pub(crate) fn begin_staging() -> StagingGuard {
+    DAEMON_STAGING.store(true, Ordering::Relaxed);
+    StagingGuard
+}
+
+/// Clears the [`begin_staging`] flag on drop.
+pub(crate) struct StagingGuard;
+
+impl Drop for StagingGuard {
+    fn drop(&mut self) {
+        DAEMON_STAGING.store(false, Ordering::Relaxed);
+    }
+}
+
 /// Take the daemon down because the app is quitting.
 ///
 /// Bounded by [`QUIT_STOP_BUDGET`] and **infallible by design**: every failure
@@ -540,6 +610,74 @@ async fn stop_daemon() -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The staging flag must be self-clearing on EVERY exit from the install,
+    /// not just the happy one.
+    ///
+    /// `install()` bails with `?` on a failed stop, a failed copy, and a failed
+    /// registration, and it runs on a spawned task where a panic unwinds rather
+    /// than aborting. A flag left set by any of those paths disables the
+    /// watchdog for the rest of the session — and on Windows the watchdog is
+    /// the only supervisor there is, so the daemon would stay down until the
+    /// next launch with nothing reporting why. That is a strictly worse
+    /// outcome than the install race this flag was added to fix, which is why
+    /// it is an RAII guard rather than a set/clear pair.
+    #[test]
+    fn the_staging_flag_clears_on_every_exit_path() {
+        assert!(!is_staging(), "must start clear");
+
+        // Normal scope exit.
+        {
+            let _g = begin_staging();
+            assert!(is_staging(), "the guard sets it for its lifetime");
+        }
+        assert!(!is_staging(), "dropping the guard clears it");
+
+        // Early return — the `?` bail-outs in `install()`.
+        fn bails_out() -> Result<(), ()> {
+            let _g = begin_staging();
+            assert!(is_staging());
+            Err(())
+        }
+        assert!(bails_out().is_err());
+        assert!(!is_staging(), "an early return must still clear it");
+
+        // Panic — the install runs on a spawned task, so this unwinds.
+        // Panic — the install runs on a spawned task, so this unwinds. The hook
+        // is muted around it so a deliberate panic doesn't print a scary
+        // backtrace into an otherwise-passing test run.
+        let hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let panicked = std::panic::catch_unwind(|| {
+            let _g = begin_staging();
+            panic!("install blew up");
+        });
+        std::panic::set_hook(hook);
+        assert!(panicked.is_err());
+        assert!(!is_staging(), "unwinding must still clear it");
+
+        // Pause and staging both make the watchdog stand down, but they must
+        // stay SEPARATE flags: staging is internal and lasts seconds, pause is
+        // the user's instruction and persists. Reusing the pause flag for
+        // staging would show "Paused" in the tray during every update, and
+        // would leave the daemon genuinely paused if an install died mid-swap.
+        //
+        // Asserted in THIS test rather than its own: both touch the same
+        // process-global, and `cargo test` runs test fns on parallel threads,
+        // so two functions racing over `DAEMON_STAGING` would flake. One test
+        // owns the flag.
+        let paused_before = is_paused();
+        {
+            let _g = begin_staging();
+            assert!(is_staging());
+            assert_eq!(
+                is_paused(),
+                paused_before,
+                "staging must not move the user-visible pause flag"
+            );
+        }
+        assert!(!is_staging());
+    }
 
     /// The bug this module exists for: quitting from the tray menu, or via
     /// Cmd+Q once the dashboard has switched the activation policy to

--- a/tray/src-tauri/src/daemon_lifecycle.rs
+++ b/tray/src-tauri/src/daemon_lifecycle.rs
@@ -642,7 +642,6 @@ mod tests {
         assert!(bails_out().is_err());
         assert!(!is_staging(), "an early return must still clear it");
 
-        // Panic — the install runs on a spawned task, so this unwinds.
         // Panic — the install runs on a spawned task, so this unwinds. The hook
         // is muted around it so a deliberate panic doesn't print a scary
         // backtrace into an otherwise-passing test run.

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -105,6 +105,32 @@ pub(super) async fn refresh_health(
     // restart needs no DB pool, so it runs even when `pool` is None; only the
     // user-facing notice below does. Best-effort: the result feeds the notice
     // detail when we also notify.
+    // A daemon that is down because the INSTALLER stopped it is not an outage.
+    //
+    // Both halves are suppressed, and they have to move together. The restart,
+    // because it would start the process the installer just killed and re-lock
+    // the binary mid-swap — the same hazard the fast watchdog now stands down
+    // for, on the slower 30 s tick (see `daemon_lifecycle::begin_staging`). The
+    // notice, because "Meridian went quiet - tried starting it automatically"
+    // is both alarming and false during a routine update: nothing tried, and
+    // nothing was wrong.
+    //
+    // Gating only the restart would ALSO trip the `notify_down` ⇒
+    // `restart_result.is_some()` debug assert below, which is exactly the
+    // tripwire that invariant was written to be.
+    //
+    // Losing this episode's went-quiet notice costs nothing: if the install
+    // fails it raises `tray.backend_install_failed`, which says more than the
+    // generic notice would, and if it succeeds the daemon is back within
+    // seconds. Applied here rather than inside `decide_health_notice` so the
+    // health state machine keeps advancing normally - only the two outward
+    // actions are held.
+    let staging = crate::daemon_lifecycle::is_staging();
+    let attempt_restart = attempt_restart && !staging;
+    let notify_down = notify_down && !staging;
+    if staging {
+        tracing::debug!("daemon health: install in progress - not restarting or notifying");
+    }
     let restart_result = if attempt_restart {
         // Wrap the restart attempt in a span so the health-path recovery is
         // traceable end-to-end, matching the fast watchdog's span.

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -515,6 +515,59 @@ pub(super) async fn refresh_worklogs(pool: &SqlitePool, state: &Arc<Mutex<AppSta
 mod tests {
     use super::*;
 
+    /// The install-in-progress suppression must hold BOTH outward actions, and
+    /// it must hold them together.
+    ///
+    /// `refresh_health` is the slow (30 s) half of the same interlock
+    /// [`super::watchdog::decide`] implements on the 5 s tick: while
+    /// `daemon_lifecycle::begin_staging` is held, the installer has deliberately
+    /// killed the daemon to overwrite its binary, and starting it back up
+    /// re-locks the file mid-swap and fails the install outright.
+    ///
+    /// Gating only `attempt_restart` would ALSO break the `notify_down` ⇒
+    /// `restart_result.is_some()` debug assert a few lines below the gate —
+    /// `restart_result` would be `None` while `notify_down` stayed true, so the
+    /// went-quiet notice would render the "tried starting it automatically"
+    /// copy for a restart that never happened. That invariant is asserted, not
+    /// merely documented, so the two lines have to move as a pair.
+    ///
+    /// Source-scanned rather than driven: the gate lives in `refresh_health`,
+    /// which needs a live `AppHandle` and DB pool, and the decision was
+    /// deliberately placed OUTSIDE the pure `decide_health_notice` so the
+    /// health state machine keeps advancing while only the outward actions are
+    /// held. Same reasoning as `reopen.rs`'s gate tests.
+    ///
+    /// **Scans only the production half of the file.** `include_str!` on the
+    /// module a test lives in also pulls in that test's own body, so the needles
+    /// below would match their own string literals and the assertions could
+    /// never fail — a test that is green whatever the code does. Truncating at
+    /// the first `#[cfg(test)]` (the real attribute, which precedes this module)
+    /// is what makes it actually load-bearing; verified by deleting a gate line
+    /// and watching this go red.
+    #[test]
+    fn an_install_in_progress_suppresses_both_the_restart_and_the_notice() {
+        let whole = include_str!("refresh.rs");
+        let src = &whole[..whole
+            .find("#[cfg(test)]")
+            .expect("refresh.rs lost its test module marker")];
+        assert!(
+            src.contains("let staging = crate::daemon_lifecycle::is_staging();"),
+            "refresh_health no longer reads the staging flag - its restart races \
+             the installer's binary swap, exactly as the watchdog's did"
+        );
+        for line in [
+            "let attempt_restart = attempt_restart && !staging;",
+            "let notify_down = notify_down && !staging;",
+        ] {
+            assert!(
+                src.contains(line),
+                "`{line}` is gone - suppressing only one of the two trips the \
+                 `notify_down` => `restart_result.is_some()` debug assert below \
+                 the gate, and makes the notice claim a restart that never ran"
+            );
+        }
+    }
+
     /// The exact bug this fix targets: a fresh tray process (all counters at
     /// their `AppState::default()` values) whose very first health check is
     /// already healthy — e.g. the daemon recovered from an overnight sleep

--- a/tray/src-tauri/src/poll/watchdog.rs
+++ b/tray/src-tauri/src/poll/watchdog.rs
@@ -134,6 +134,14 @@ pub(crate) struct Inputs {
     /// daemon that "will not come back" - about a daemon the user switched off
     /// on purpose.
     pub daemon_paused: bool,
+    /// Whether the installer is mid-swap of the daemon binary
+    /// ([`crate::daemon_lifecycle::is_staging`]).
+    ///
+    /// Like `daemon_paused`, the daemon is down *by instruction* — the
+    /// installer killed it so it could overwrite the file, and starting it back
+    /// up re-locks the very binary being written. Unlike a pause it lasts
+    /// seconds, not until the user says otherwise.
+    pub staging_in_progress: bool,
 }
 
 /// The whole watchdog policy, as one pure function.
@@ -152,8 +160,9 @@ pub(crate) struct Inputs {
 /// 5. storm cap reached → [`Action::GiveUp`]
 /// 6. otherwise → [`Action::Start`]
 ///
-/// Rule 0 sits above all of them: a daemon the user paused is off *by
-/// instruction*, and no evidence this loop can gather outranks that.
+/// Rule 0 sits above all of them: a daemon that is down *by instruction* — the
+/// user paused it, or the installer is replacing its binary — stays down, and
+/// no evidence this loop can gather outranks that.
 pub(crate) fn decide(i: Inputs) -> Action {
     // Ahead of the endpoint check, and ahead of the storm cap, on purpose.
     // Pause `bootout`s the agent, so a paused daemon presents exactly as a
@@ -161,6 +170,19 @@ pub(crate) fn decide(i: Inputs) -> Action {
     // from, and rule 5 would eventually escalate it to a user-visible "gave
     // up" notice. Returning here is what keeps `Pause` meaning something.
     if i.daemon_paused {
+        return Action::Wait;
+    }
+    // Same shape, different instruction: the installer stopped the daemon so it
+    // could overwrite `~/.meridian/bin/meridian.exe`, and a silent endpoint is
+    // the INTENDED state for those few seconds. Starting it here re-locks the
+    // binary mid-swap and fails the install outright - see
+    // [`crate::daemon_lifecycle::begin_staging`] for the incident this closes.
+    //
+    // It must sit above the `process_alive` guard, not below it: that guard is
+    // `None` on Windows (`daemon_control::process_alive`), which `decide`
+    // treats as non-blocking, so on the one platform where this race actually
+    // occurs there is nothing further down that would stop it.
+    if i.staging_in_progress {
         return Action::Wait;
     }
     if i.probe_ok {
@@ -216,6 +238,9 @@ pub async fn run_daemon_watchdog() {
 
         // Read fresh each tick, so a pause or resume takes effect on the next.
         let paused = crate::daemon_lifecycle::is_paused();
+        // Likewise fresh: the staging window opens and closes inside a single
+        // install, so a value cached across ticks would be wrong for most of it.
+        let staging = crate::daemon_lifecycle::is_staging();
 
         let probe_ok = crate::commands::daemon_control::probe().await.running;
         if probe_ok {
@@ -239,8 +264,16 @@ pub async fn run_daemon_watchdog() {
         // paused [`decide`] returns before it reads `process_alive`, so asking
         // would only fork `launchctl` every 5 s for an answer that cannot
         // change the verdict.
-        let could_start =
-            !paused && !probe_ok && consecutive_failures >= STRIKES && !in_cooldown && !gave_up;
+        // `!staging` joins this set for the same reason as `!paused`: while it
+        // is set `decide` returns before it reads `process_alive`, so asking
+        // would only fork a subprocess for an answer that cannot change the
+        // verdict.
+        let could_start = !paused
+            && !staging
+            && !probe_ok
+            && consecutive_failures >= STRIKES
+            && !in_cooldown
+            && !gave_up;
         let process_alive = if could_start {
             daemon_process_alive().await
         } else {
@@ -254,6 +287,7 @@ pub async fn run_daemon_watchdog() {
             starts_in_window,
             in_cooldown,
             daemon_paused: paused,
+            staging_in_progress: staging,
         });
 
         match action {
@@ -316,7 +350,87 @@ mod tests {
             starts_in_window: 0,
             in_cooldown: false,
             daemon_paused: false,
+            staging_in_progress: false,
         }
+    }
+
+    /// **The regression test for the broken-Windows-update incident.**
+    ///
+    /// The installer kills the daemon to overwrite `meridian.exe`, which takes
+    /// long enough for this loop to strike out and start it again — from the
+    /// very path being staged. The installer's post-kill poll then reported
+    /// that process as an un-killable holder of the binary and failed the whole
+    /// install ("still running after stop attempts"), so every Windows update
+    /// after the first install died here.
+    ///
+    /// `silent_endpoint()` is deliberately the base: `process_alive: None` is
+    /// the Windows reality (`daemon_control::process_alive`), and `decide`
+    /// treats `None` as non-blocking — so on the one platform where this race
+    /// happens, this rule is the ONLY thing standing between the watchdog and
+    /// the installer.
+    #[test]
+    fn a_daemon_the_installer_stopped_is_never_started() {
+        let staging = Inputs {
+            staging_in_progress: true,
+            ..silent_endpoint()
+        };
+        // The control: without the flag this exact input starts the daemon,
+        // which is what made the race possible. So the assertion below is
+        // testing the rule and not some other guard that happens to cover it.
+        assert_eq!(
+            decide(silent_endpoint()),
+            Action::Start,
+            "sanity: a silent endpoint with no liveness answer does start"
+        );
+        assert_eq!(
+            decide(staging),
+            Action::Wait,
+            "starting the daemon mid-swap re-locks the binary and fails the install"
+        );
+
+        // A long install must not wear the rule down - staging outranks the
+        // failure count, the cooldown, and the storm cap alike. Every one of
+        // these reaches a verdict AFTER the staging check, so if the rule is
+        // ever moved below them this fails.
+        for extra in [
+            Inputs {
+                consecutive_failures: 1_000,
+                ..staging
+            },
+            Inputs {
+                in_cooldown: true,
+                ..staging
+            },
+            Inputs {
+                starts_in_window: MAX_STARTS_IN_WINDOW,
+                ..staging
+            },
+            Inputs {
+                process_alive: Some(false),
+                ..staging
+            },
+        ] {
+            assert_eq!(
+                decide(extra),
+                Action::Wait,
+                "no amount of downtime turns an install-held daemon into an outage"
+            );
+        }
+    }
+
+    /// Staging is a few seconds inside one install, so the rule must not
+    /// outlive it — a flag that stuck would leave the machine with no
+    /// supervisor at all on Windows, which is a worse failure than the one it
+    /// was added to fix (there, this loop IS the KeepAlive).
+    #[test]
+    fn the_backstop_returns_the_moment_staging_ends() {
+        assert_eq!(
+            decide(Inputs {
+                staging_in_progress: false,
+                ..silent_endpoint()
+            }),
+            Action::Start
+        );
     }
 
     /// **The regression test for the corruption incident.**
@@ -378,6 +492,7 @@ mod tests {
                 starts_in_window: MAX_STARTS_IN_WINDOW + 1,
                 in_cooldown: false,
                 daemon_paused: false,
+                staging_in_progress: false,
             }),
             Action::Wait
         );


### PR DESCRIPTION
## The failure

Windows updates fail with:

```
Meridian couldn't finish installing. staged daemon ... still running after
stop attempts (pids: [N]) - cannot overwrite a locked binary
```

The process it calls un-killable is **its own supervisor's child**, spawned seconds earlier by the same tray.

The tray is both the daemon's installer and - on Windows, where there is no launchd `KeepAlive` - its only supervisor, and the two halves had no interlock. `lib.rs` spawns the watchdog (`:1036`) and `ensure_backend_installed` (`:1063`) as concurrent tasks:

1. `install()` kills the daemon so it can overwrite `meridian.exe` (Windows keeps a running exe's pages mapped; the copy fails with os error 32 otherwise).
2. ~10s later - watchdog `TICK` 5s x `STRIKES` 2 - the watchdog sees a silent endpoint and starts the daemon from the very path being staged. Its liveness guard does not help: `process_alive()` is `None` on Windows, which `decide` treats as non-blocking by design.
3. The installer's post-kill poll finds that process and reports it as an un-killable holder of the binary. `install()` aborts before `stage_binary` **and** before `register_service`, so the new binary is never staged and the scheduled task is never created - which is why the respawn came from the `spawn_staged_daemon` fallback and showed up as a child of `meridian-tray.exe`.

Only the **update** path is affected: a first install has no daemon to stop, returns immediately, and never wakes the watchdog. That is why this looked intermittent while being, on updates, reliable.

## The fix

**An RAII staging window.** `daemon_lifecycle::begin_staging()` sets a process-global flag and returns a guard that `install()` holds across stop -> copy -> register. `watchdog::decide` returns `Wait` while it is set, placed **above** the `process_alive` guard because that guard is inert on Windows. The health poll's recovery path (`refresh.rs`) is gated on the same flag, along with its went-quiet notice - suppressing only the restart would trip the `notify_down` => `restart_result.is_some()` debug assert and make the notice claim a restart that never happened.

RAII rather than set/clear: `install()` bails with `?` on three paths and runs on a spawned task where a panic unwinds. A stuck flag would leave Windows with no supervisor at all - worse than the bug.

**Re-kill on every probe.** `taskkill` ran once, against the pid set as it stood before the poll, so anything appearing afterwards was watched to the end of the budget and then reported. This is the backstop for spawners the tray does not own (a second instance, the Startup-folder launcher on a fast re-login, a hand-run daemon). It kills the pids the probe just enumerated rather than re-querying - `matching_daemon_pids` spawns a whole `powershell -Command Get-CimInstance`, and paying that twice per attempt across up to 40 attempts would stretch the stop on exactly the loaded machines that reach the later attempts.

## Why the race is closed, not just narrowed

The watchdog needs two consecutive failed probes before it starts anything, and the daemon only dies *after* the flag is set - so the first failing probe is always after the flag. There is no ordering where the watchdog is past the check and still reaches `Start`.

The OS-level supervisor cannot defeat it either: the scheduled task is `/SC ONLOGON` with no repetition trigger, and its `schtasks /Run` fires inside the guard.

## Tests

- `watchdog`: a staging input stays `Wait` against 1000 consecutive failures, an active cooldown, a maxed storm cap, and `process_alive: Some(false)` - each of which reaches its verdict *after* the staging check, so moving the rule below any of them fails. Plus a control asserting the same input **does** `Start` without the flag.
- `daemon_lifecycle`: the guard clears on scope exit, on an early `?` return, and on unwind.
- `refresh`: source-scans that both `attempt_restart` and `notify_down` are gated, scanning only the file's production half - `include_str!` on a test's own module otherwise matches the needles against their own string literals, and the assertion can never fail. Verified by deleting the production gate line and watching it go red.

## Verification

`cargo test --workspace` (26 targets green) and `cargo clippy --workspace --all-targets -D warnings` clean on macOS.

**macOS cannot compile the code this actually changes.** `kill_pids`, the re-kill closure and `stop_running_daemon_before_stage` are all `cfg(target_os = "windows")`, so the green run above says nothing about them - Windows CI on this PR is their first compile. Worth a real Windows update test before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)