### PR TITLE
docs(readme): add Product Hunt badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 <div align="center">
 
+<a href="https://www.producthunt.com/products/meridian-16?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-meridian-19" target="_blank" rel="noopener noreferrer"><img alt="Meridian - Don't let your work go unnoticed. Get promoted! | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1222691&theme=light&t=1786882777866"></a>
+
+<br>
+<br>
+
 <img src="docs/images/banner.png" alt="Meridian - Stop letting your work go unnoticed." width="420" />
 
 <br>


### PR DESCRIPTION
## Summary
- Adds the Product Hunt "featured" embed badge to the very top of the README, above the banner.

Exception to the usual contributor rule (feature branches target `pre-main`, not `main`): this is a docs-only README change matching the same pattern as PR #763/#765, applied to both `main` and `pre-main` to keep them in sync per prior direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Product Hunt featured badge link to the README.
  * Improved spacing beneath the README header for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->