### PR TITLE
feat(tray): interactive toasts on Windows - buttons, inline reply, retraction

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -41,8 +41,10 @@ UNIQUE      native_at    + response_   consumed_at
 | Response consumer (acts on answers) | `src/notification_responses.rs` |
 | Tray delivery + retraction facade | `tray/src-tauri/src/sys.rs` |
 | Tray drain + expiry sweep (poll tick, ~30 s) | `tray/src-tauri/src/poll/notifications.rs` |
-| Answer write command (`record_notification_response`) | `tray/src-tauri/src/commands/notifications.rs` |
-| Toast action listener (plugin event → command) | `tray/src/app.js` (`armNotificationActions`) |
+| Windows interactive delivery (WinRT: buttons, reply, retraction) | `tray/src-tauri/src/win_toast.rs` |
+| Windows toast XML (escaping, button cap, ordering — tested everywhere) | `tray/src-tauri/src/toast_actions.rs` |
+| Answer write (`record_notification_response` → `apply_response`) | `tray/src-tauri/src/commands/notifications.rs` |
+| Toast action listener, **macOS only** (plugin event → command) | `tray/src/app.js` (`armNotificationActions`) |
 | Schema | migrations `042` (outbox) + `057` (actions/response columns) |
 
 ## Add a plain notification
@@ -156,8 +158,8 @@ macOS has **no per-notification duration API**. What we have:
    `cfg(target_os = "windows")` block: the plugin's backend exists only under
    `cfg(all(desktop, feature = "notify-rust"))` or
    `cfg(all(target_os = "macos", not(feature = "notify-rust")))`, so a Windows
-   build without it matches neither arm and has no backend at all. See #7 for
-   what that costs.
+   build without it matches neither arm and has no backend at all. What that
+   costs, and why the outbox path no longer relies on it, is #7.
 2. The Swift layer needs `-Wl,-rpath,/usr/lib/swift` (tray `build.rs`) or the
    packaged app dies at launch on `libswift_Concurrency.dylib`.
 3. **Extras don't round-trip**: the toast's notification identifier (= outbox
@@ -166,27 +168,52 @@ macOS has **no per-notification duration API**. What we have:
 4. The plugin's init **hard-fails outside a `.app` bundle** — it is registered
    only when bundled; `tauri dev` runs have no toasts at all. Interactive
    behaviour is testable only in packaged builds.
-5. Action events only fire for toasts shown by the **current tray process**
-   (in-memory map) — an answer after a tray restart is dropped; expiry cleans
-   those up.
+5. Action events only fire for toasts shown by the **current tray process** —
+   an in-memory map on macOS, per-process WinRT handlers on Windows — so an
+   answer after a tray restart is dropped on both; expiry cleans those up.
+   (Surviving a restart on Windows would need a COM activator registered
+   against a CLSID, which is exactly the machinery this constraint lets us
+   skip.)
 6. Banners collapse buttons behind a hover "Options" affordance; that's macOS.
-7. **Windows gets plain toasts only — title and body, no buttons, no inline
-   reply, no action events.** That follows from #1: `notify-rust` has no
-   action-button API, which is the whole reason macOS runs the Swift
-   `UNUserNotificationCenter` layer instead.
+7. **Windows outbox toasts do NOT go through the plugin** — they are built and
+   shown against `Windows.UI.Notifications` directly, in
+   `tray/src-tauri/src/win_toast.rs`. This is the fix for what #1 costs, and
+   the reason for it is that `notify-rust` has no action API at all: both
+   `set_click_listener_active` and `remove_active` return a hard
+   `Err("… not supported with notify-rust")`.
 
-   The practical consequence: an **interactive** notification still
-   *delivers* on Windows, but the user has no way to answer it, so its outbox
-   row is only ever resolved by expiry. Producers need no change — policy
-   lives at drain time — but do not design a flow whose only path forward is a
-   toast button and assume every platform can take it.
+   Before that, Windows *delivered* interactive notifications the user could
+   not answer (their rows resolved only by expiry) and could not retract
+   (every expiry logged `toast retraction failed` and left the toast in Action
+   Center with live buttons). Both are closed: buttons, inline reply, taps,
+   dismissals and retraction all work, and answers land on the outbox row
+   through the same `commands::notifications::apply_response` the macOS path
+   uses, so the two platforms write identically.
 
-   Closing this means implementing Windows toasts against
-   `windows-rs`' `Windows.UI.Notifications` (toast XML *does* support actions),
-   behind the existing `notify`/`notify_outbox`/`retract_toast`/
-   `register_notification_categories` facade in `tray/src-tauri/src/sys.rs`.
-   That facade is already the abstraction boundary — no caller in `poll/` or
-   `commands/` would change.
+   Three things to know before touching it:
+
+   - **Plain `sys::notify` toasts still use the plugin.** Only the outbox path
+     moved. Windows therefore runs two toast stacks under the same AUMID (the
+     Tauri bundle identifier), which is why the permission read governs both.
+   - **The category registry is macOS-only.** A Windows toast carries its
+     buttons inline in its own XML, so `register_notification_categories` is a
+     no-op there and `win_toast` reads the same descriptors at delivery time.
+     (Calling the plugin there used to log a `notification category
+     registration failed` ERROR on every launch.)
+   - **Everything runs on the main thread.** WinRT needs an initialised COM
+     apartment and an STA message pump to deliver callbacks; the poll-loop
+     tokio workers have neither, so delivery *and* retraction hop via
+     `run_on_main_thread`.
+
+   Verification is awkward and worth knowing: the WinRT half cannot be
+   compiled from macOS (`cargo check --target x86_64-pc-windows-msvc` on the
+   tray dies in `aws-lc-sys`, whose build needs `windows.h`). So everything
+   with a possible logic bug — escaping, the 5-button cap, `<input>`-before-
+   `<action>` ordering, `hint-inputId` wiring — lives in
+   `tray/src-tauri/src/toast_actions.rs`, which is compiled on every platform
+   and unit-tested by `cargo test -p meridian-tray`. The WinRT call sequence
+   itself is type-checked by mirroring it into a scratch crate that depends
+   only on `windows` and checking *that* for the msvc target.
 8. `is_bundled()` gates plugin registration and means "packaged install, not a
    dev build". On macOS that is a literal `.app` layout check (the Swift layer
    genuinely requires a bundle). Windows has no bundle concept, so it detects

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -225,20 +225,32 @@ cidre = { version = "0.13", features = ["ax"], optional = true }
 # shared `default-features = false` and no Windows override, a Windows build
 # matches neither arm and has no notification backend at all.
 #
-# The cost is that Windows gets plain title+body toasts only — notify-rust has
-# no action buttons or inline reply, which is exactly why macOS keeps the Swift
-# UNUserNotificationCenter layer instead. Interactive toasts on Windows need a
-# `windows-rs` Windows.UI.Notifications implementation behind the existing
-# `sys.rs` facade; tracked as a follow-up, documented in docs/notifications.md.
+# notify-rust has no action buttons, no inline reply and no retraction, which
+# is exactly why macOS keeps the Swift UNUserNotificationCenter layer instead.
+# It is therefore NOT the outbox delivery path on Windows any more: `win_toast.rs`
+# drives Windows.UI.Notifications directly for every toast that needs a button
+# or a tag. What is still served from here is the plain title+body
+# `sys::notify` toast (pause/update/health), which has neither.
 tauri-plugin-notifications = { version = "=0.4.6", default-features = false, features = ["notify-rust"] }
-# Real notification-permission read for the Windows probe (`sys::notification_permission_state`).
-# The plugin's notify-rust backend has no permission API of its own — `permission_state()` /
-# `request_permission()` are hardcoded to return `Granted` (see the doc comment on the probe) —
-# so this queries WinRT directly via `ToastNotificationManager::CreateToastNotifierWithId` +
-# `ToastNotifier::Setting()`. Already a transitive dependency (pulled in by notify-rust's own
-# `tauri-winrt-notification` backend), so this adds no new dependency, just our own direct use of
-# it; version kept in the same 0.61 line Cargo already resolves so there's no duplicate build.
-windows = { version = "0.61", features = ["UI_Notifications"] }
+# Direct WinRT access, for two things the plugin cannot do on Windows:
+#  1. The notification-permission read (`sys::notification_permission_state`). The plugin's
+#     notify-rust backend has no permission API of its own — `permission_state()` /
+#     `request_permission()` are hardcoded to return `Granted` (see the doc comment on the
+#     probe) — so this queries `ToastNotificationManager::CreateToastNotifierWithId` +
+#     `ToastNotifier::Setting()`.
+#  2. Interactive toasts (`win_toast.rs`): buttons, inline reply, action events and
+#     retraction, none of which notify-rust exposes.
+# Already a transitive dependency (pulled in by notify-rust's own `tauri-winrt-notification`
+# backend), so this adds no new dependency, just our own direct use of it; version kept in the
+# same 0.61 line Cargo already resolves so there's no duplicate build.
+# The added features are what `win_toast.rs` needs beyond the permission read: the toast XML
+# document, the event handler + IPropertyValue (inline-reply text), and the ValueSet it lives in.
+windows = { version = "0.61", features = [
+    "UI_Notifications",
+    "Data_Xml_Dom",
+    "Foundation",
+    "Foundation_Collections",
+] }
 
 [features]
 # In-process screen capture is ON by default (Gap-2 Bucket 2 cutover): the

--- a/tray/src-tauri/src/commands/notifications.rs
+++ b/tray/src-tauri/src/commands/notifications.rs
@@ -9,7 +9,10 @@
 //! - [`record_notification_response`] — the interactive-toast answer write: the
 //!   popover's `actionPerformed` listener forwards each button press / tap /
 //!   inline reply here, which stamps it on the outbox row for the daemon's
-//!   response consumer and routes foreground actions to the dashboard.
+//!   response consumer and routes foreground actions to the dashboard. That
+//!   listener is **macOS only**; Windows toasts are WinRT
+//!   ([`crate::win_toast`]) and their handlers call [`apply_response`] in Rust,
+//!   with no webview hop. Both platforms therefore share one write path.
 //!
 //! The sibling *delivered* ack (`/api/notifications/:id/delivered`) is NOT a
 //! command — it's an internal poll-loop write now (see [`crate::poll`]'s
@@ -96,8 +99,31 @@ pub async fn record_notification_response(
     let Some(pool) = pool.inner() else {
         return Err("meridian.db is not open yet".to_string());
     };
+    apply_response(app, pool, id, &action, text.as_deref()).await
+}
+
+/// The body of [`record_notification_response`], factored out because it has
+/// **two** callers on Windows.
+///
+/// macOS answers arrive as a plugin event the popover JS forwards back through
+/// the command. Windows has no such event: [`crate::win_toast`] registers a
+/// WinRT `Activated`/`Dismissed` handler and is handed the answer directly, in
+/// Rust, with no webview in the loop. Routing both through one function is what
+/// keeps the two platforms' write, logging, and click-through behaviour
+/// identical — the alternative is a second copy of this logic that drifts the
+/// first time either half changes.
+///
+/// Errors are returned as a `String` because the `#[tauri::command]` caller
+/// needs one; the WinRT caller logs it.
+pub(crate) async fn apply_response(
+    app: tauri::AppHandle,
+    pool: &meridian_core::SqlitePool,
+    id: i64,
+    action: &str,
+    text: Option<&str>,
+) -> Result<(), String> {
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-    meridian_core::notifications::record_response(pool, id, &action, text.as_deref(), &now)
+    meridian_core::notifications::record_response(pool, id, action, text, &now)
         .await
         .map_err(|e| crate::cmd_err!(e, id, action, "record_notification_response failed"))?;
     tracing::info!(
@@ -113,7 +139,7 @@ pub async fn record_notification_response(
     // parked for a fresh window's mount-time pull, or emitted to an
     // already-open one) so the click actually lands on the linked view (e.g.
     // the Plan modal), not just the default timeline.
-    if matches!(action.as_str(), "tap" | "open" | "view") {
+    if matches!(action, "tap" | "open" | "view") {
         if let Some(link) = meridian_core::notifications::notification_deep_link(pool, id).await {
             crate::deep_link::navigate_dashboard(&app, &link);
             if let Err(e) = crate::commands::open_dashboard(app).await {

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -52,9 +52,15 @@ mod reopen;
 mod repair_boot;
 mod state;
 mod sys;
+// Toast-XML construction for the Windows interactive path. Compiled on every
+// platform on purpose so its escaping/ordering/cap logic is unit-tested from a
+// macOS dev machine; only `win_toast`'s WinRT calls are Windows-gated.
+mod toast_actions;
 mod tray;
 mod tray_icon;
 mod update;
+#[cfg(target_os = "windows")]
+mod win_toast;
 mod window_panel;
 
 // Gated to match the ONLY thing that uses these — the `RunEvent::Reopen` arm at

--- a/tray/src-tauri/src/reopen.rs
+++ b/tray/src-tauri/src/reopen.rs
@@ -156,8 +156,13 @@ mod reopen_tests {
     #[test]
     fn full_screen_is_requested_on_macos_only() {
         let src = include_str!("sys.rs");
+        // Anchor on the CALL (`win.` prefixed), not the bare name: the first
+        // bare occurrence in the file is a doc comment explaining what the call
+        // means on Windows, so scanning from there measured the distance from a
+        // paragraph of prose and passed or failed on whichever functions
+        // happened to sit in between.
         let at = src
-            .find("set_fullscreen(true)")
+            .find("win.set_fullscreen(true)")
             .expect("sys.rs no longer requests full-screen at all");
         // The gate must be the nearest thing above the call, not merely present
         // somewhere in the file.
@@ -166,7 +171,9 @@ mod reopen_tests {
             .rfind("#[cfg(target_os = \"macos\")]")
             .expect("set_fullscreen(true) is not behind a macOS cfg gate");
         assert!(
-            !before[gate..].contains("\nfn ") && !before[gate..].contains("\npub(crate) fn "),
+            !before[gate..].contains("\nfn ")
+                && !before[gate..].contains("\npub fn ")
+                && !before[gate..].contains("\npub(crate) fn "),
             "the nearest macOS cfg gate is on a different item, so set_fullscreen \
              still runs on Windows and traps the user in a borderless window"
         );

--- a/tray/src-tauri/src/sys.rs
+++ b/tray/src-tauri/src/sys.rs
@@ -9,16 +9,23 @@
 //! (real `UNUserNotificationCenter` on macOS: action buttons + inline reply).
 //! Everything above this module talks only to [`notify`] /
 //! [`notify_outbox`], so if the plugin disappoints it can be swapped for
-//! in-house `objc2-user-notifications` bindings without touching callers.
-//! The plugin requires a packaged `.app` bundle ([`is_bundled`]); in an
-//! unbundled run (`tauri dev`, `cargo run`) it is not registered at all and
-//! both facades degrade to a logged no-op — interactive toasts are verified on
-//! packaged builds only.
+//! in-house bindings without touching callers — which is exactly what happened
+//! on Windows: the plugin's `notify-rust` backend there has no button, action
+//! or retraction API, so [`notify_outbox`] and [`retract_toast`] delegate to
+//! `Windows.UI.Notifications` via [`crate::win_toast`], while plain [`notify`]
+//! stays on the plugin. That split is the abstraction paying off; no caller in
+//! `poll/` or `commands/` knows about it.
+//!
+//! Delivery on both platforms is gated on [`is_bundled`] — the plugin's init
+//! hard-fails outside a `.app`, and Windows keeps the same gate for symmetry —
+//! so an unbundled run (`tauri dev`, `cargo run`) degrades to a logged no-op
+//! and interactive toasts are verified on packaged builds only.
 //!
 //! # Related
 //! - [`crate::poll`] — the loop that toasts via [`notify`] / [`notify_outbox`].
 //! - [`crate::commands::notifications`] — records the user's answer
 //!   (`record_notification_response`) that [`notify_outbox`]'s buttons produce.
+//! - [`crate::toast_actions`] — the Windows button/XML translation.
 //! - [`crate::install`] — install-mode + path resolution (a separate concern from these).
 
 use tauri::Manager;
@@ -208,11 +215,42 @@ pub fn notify(app: &tauri::AppHandle, title: &str, body: &str) {
 /// resolves everything else (deep_link) from the DB row. It also means the OS
 /// collapses a re-delivered row onto the same toast instead of duplicating it.
 ///
-/// Known limitation: the plugin's `actionPerformed` only fires for toasts shown
-/// by the CURRENT tray process (its notification map is in-memory), so an
-/// answer given after a tray restart is dropped. Expiries keep stale
-/// interactive toasts rare; a v2 could reconcile via `notificationClicked`.
+/// Known limitation: action events only fire for toasts shown by the CURRENT
+/// tray process — the plugin's notification map is in-memory on macOS, and the
+/// WinRT handlers on Windows belong to this process — so an answer given after
+/// a tray restart is dropped. Expiries keep stale interactive toasts rare; a v2
+/// could reconcile via `notificationClicked`.
+///
+/// **Windows takes a different route entirely** ([`crate::win_toast`]): its
+/// plugin backend is `notify-rust`, which has no button, action-event or
+/// retraction API at all, so outbox toasts are built and shown against
+/// `Windows.UI.Notifications` directly. That path does not use the plugin and
+/// so must not be gated on it — it is gated on [`is_bundled`] instead, which is
+/// what the plugin's own registration is gated on in `lib.rs`, so a dev build
+/// stays silent on both platforms exactly as before.
 pub fn notify_outbox(
+    app: &tauri::AppHandle,
+    n: &meridian_core::notifications::PendingNotification,
+) {
+    #[cfg(target_os = "windows")]
+    {
+        if !is_bundled() {
+            tracing::debug!(id = n.id, "notify_outbox: dev build — toast dropped");
+            return;
+        }
+        crate::win_toast::show(app, n);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        notify_outbox_via_plugin(app, n);
+    }
+}
+
+/// The macOS delivery path: the plugin's Swift `UNUserNotificationCenter`
+/// layer, addressed by category id.
+#[cfg(not(target_os = "windows"))]
+fn notify_outbox_via_plugin(
     app: &tauri::AppHandle,
     n: &meridian_core::notifications::PendingNotification,
 ) {
@@ -257,17 +295,35 @@ pub fn notify_outbox(
 /// Same effect as the user pressing ✕, minus the user. Best-effort: a failure
 /// leaves a stale toast on screen but the row is stamped regardless, so it is
 /// never re-delivered.
+///
+/// **On Windows this used to be dead code that always failed**: the plugin's
+/// `notify-rust` backend answers `remove_active` with a hard
+/// `Err("Removing active notifications is not supported with notify-rust")`, so
+/// every expiry logged `toast retraction failed` and left the toast sitting in
+/// Action Center with live buttons. It now goes through [`crate::win_toast`],
+/// which removes it by tag + group + AUMID.
 pub fn retract_toast(app: &tauri::AppHandle, id: i64) {
-    let Some(nf) = notifier(app) else {
-        return; // unbundled run — nothing was ever shown
-    };
-    let Ok(toast_id) = i32::try_from(id) else {
-        return; // uncorrelated delivery (see notify_outbox) — nothing to target
-    };
-    if let Err(e) = nf.remove_active(vec![toast_id]) {
-        tracing::warn!(error = %e, id, "toast retraction failed");
-    } else {
-        tracing::info!(id, "expired toast retracted");
+    #[cfg(target_os = "windows")]
+    {
+        if !is_bundled() {
+            return; // dev build — nothing was ever shown
+        }
+        crate::win_toast::retract(app, id);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let Some(nf) = notifier(app) else {
+            return; // unbundled run — nothing was ever shown
+        };
+        let Ok(toast_id) = i32::try_from(id) else {
+            return; // uncorrelated delivery (see notify_outbox) — nothing to target
+        };
+        if let Err(e) = nf.remove_active(vec![toast_id]) {
+            tracing::warn!(error = %e, id, "toast retraction failed");
+        } else {
+            tracing::info!(id, "expired toast retracted");
+        }
     }
 }
 
@@ -449,7 +505,28 @@ pub fn screen_recording_trusted() -> bool {
 /// startup from `lib.rs` on bundled runs; a failure downgrades every
 /// interactive toast to plain title+body (macOS ignores an unknown
 /// `action_type_id`), so it's logged loudly but never fatal.
+///
+/// **Windows has no analogue and this is a no-op there.** A pre-registered
+/// category set is a `UNUserNotificationCenter` concept; a Windows toast
+/// carries its buttons inline in its own XML, so [`crate::win_toast`] reads the
+/// same descriptors at delivery time instead. Calling the plugin here on
+/// Windows was not merely useless — its `notify-rust` backend rejects the call
+/// ("Action types are not supported with notify-rust"), which surfaced as a
+/// `notification category registration failed` ERROR on every single launch.
 pub fn register_notification_categories(app: &tauri::AppHandle) {
+    #[cfg(target_os = "windows")]
+    {
+        let _ = app;
+        tracing::debug!("category registration is macOS-only — Windows carries actions per toast");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    register_categories_with_plugin(app);
+}
+
+/// The macOS half of [`register_notification_categories`].
+#[cfg(not(target_os = "windows"))]
+fn register_categories_with_plugin(app: &tauri::AppHandle) {
     use meridian_core::notifications::categories;
     let Some(nf) = notifier(app) else {
         tracing::debug!("category registration skipped — plugin absent (unbundled run)");
@@ -820,5 +897,44 @@ mod tests {
     fn non_macos_accessibility_and_screen_recording_are_not_applicable_so_report_true() {
         assert!(super::accessibility_trusted());
         assert!(super::screen_recording_trusted());
+    }
+
+    /// Source scan, because the behaviour it guards cannot be executed from a
+    /// macOS dev machine or a CI runner without a desktop session.
+    ///
+    /// The Windows outbox path MUST NOT be gated on the notification plugin.
+    /// `notifier()` returns the plugin state, and on Windows that plugin is the
+    /// `notify-rust` backend, which cannot show a button, report an action or
+    /// remove a toast — [`super::notify_outbox`] delegates to
+    /// [`crate::win_toast`] instead and is gated on [`super::is_bundled`].
+    ///
+    /// Re-introducing a `notifier()` gate there would compile, pass every test,
+    /// and silently stop interactive notifications on Windows — the exact class
+    /// of failure this whole module exists to end. So the delegation is pinned
+    /// as text.
+    #[test]
+    fn the_windows_outbox_path_bypasses_the_plugin() {
+        let src = include_str!("sys.rs");
+        for delegate in ["crate::win_toast::show", "crate::win_toast::retract"] {
+            assert!(
+                src.contains(delegate),
+                "the Windows outbox path no longer delegates to {delegate} — \
+                 notify-rust cannot show buttons or retract, so this silently \
+                 breaks interactive toasts on Windows"
+            );
+        }
+        // The delegation must sit behind is_bundled(), not notifier(): a dev
+        // build stays silent (as it always has), but an installed one must not
+        // depend on a plugin it no longer uses for this path.
+        let windows_arm = src
+            .split("#[cfg(target_os = \"windows\")]")
+            .find(|s| s.contains("crate::win_toast::show"))
+            .expect("no Windows arm around the win_toast delegation");
+        let arm = &windows_arm[..windows_arm.find("crate::win_toast::show").unwrap()];
+        assert!(arm.contains("is_bundled()"), "Windows arm lost its gate");
+        assert!(
+            !arm.contains("notifier("),
+            "the Windows outbox path was re-gated on the plugin"
+        );
     }
 }

--- a/tray/src-tauri/src/toast_actions.rs
+++ b/tray/src-tauri/src/toast_actions.rs
@@ -1,0 +1,349 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Toast-XML construction for the Windows interactive-notification path — the
+//! pure half of [`crate::win_toast`], deliberately compiled on every platform.
+//!
+//! macOS carries interactive toasts as pre-registered `UNNotificationCategory`
+//! objects: the button set is declared once at startup
+//! ([`crate::sys::register_notification_categories`]) and each toast merely
+//! names its category. Windows has no such registry — a toast's buttons live
+//! **inline in that toast's XML payload** — so the same category descriptors
+//! have to be translated to markup at delivery time. That translation is what
+//! this module does, and it is the whole reason the two platforms diverge in
+//! [`crate::sys::notify_outbox`].
+//!
+//! It lives outside the `cfg(target_os = "windows")` module on purpose. WinRT
+//! code cannot be compiled, run, or tested from a macOS dev machine, so
+//! everything that could be a logic bug — escaping, the button cap, element
+//! ordering, `hint-inputId` wiring — is kept here where `cargo test` reaches it
+//! on any host. What remains in [`crate::win_toast`] is only the WinRT calls
+//! themselves.
+//!
+//! # Who calls this
+//! [`crate::win_toast::show`], which loads the returned string into an
+//! `XmlDocument` and hands it to `ToastNotificationManager`.
+//!
+//! # Related
+//! - [`meridian_core::notifications::categories`] — the shared JSON descriptors
+//!   this parses; the same bytes the daemon stamps into the outbox `actions`
+//!   column and macOS registers as categories.
+//! - [`crate::sys::notify_outbox`] — the delivery fork that calls this on Windows.
+//! - `docs/notifications.md` — the lifecycle these buttons answer into.
+
+// Off Windows nothing calls this - `win_toast` is the only consumer - but the
+// module is still COMPILED everywhere so its tests run on a macOS dev machine.
+// `cfg_attr(allow(dead_code))` is what expresses that; a bare `cfg` would
+// delete the module off Windows and take the tests with it (see the
+// backend_install.rs cfg-vs-cfg_attr note - mixing the two is how a Windows
+// build breaks invisibly from here).
+#![cfg_attr(not(target_os = "windows"), allow(dead_code))]
+
+use serde::Deserialize;
+
+/// Windows renders at most 5 buttons on a toast; extras are dropped by the
+/// platform, silently. macOS's own budget is 4, so no shipped category is near
+/// either limit - this is a guard against a future one, not a live trim.
+pub const MAX_ACTIONS: usize = 5;
+
+/// One button from a category descriptor.
+///
+/// Field names match the plugin's `ActionType` JSON (the macOS side
+/// deserializes the identical bytes into its own struct), so the two platforms
+/// can never disagree about what a category contains. Unknown fields
+/// (`destructive`, `foreground`) are ignored rather than rejected: they are
+/// macOS presentation hints with no Windows analogue.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct ToastAction {
+    /// The action id echoed back on activation - becomes `response_action` on
+    /// the outbox row, so it must round-trip byte-for-byte.
+    pub id: String,
+    /// The button label the user reads.
+    pub title: String,
+    /// Whether pressing this button should collect a line of text first.
+    #[serde(default)]
+    pub input: bool,
+    /// Label for the send button of an inline-reply field.
+    #[serde(default, rename = "inputButtonTitle")]
+    pub input_button_title: Option<String>,
+    /// Greyed-out prompt inside an empty inline-reply field.
+    #[serde(default, rename = "inputPlaceholder")]
+    pub input_placeholder: Option<String>,
+}
+
+/// Parse a category's JSON descriptor into its button set.
+///
+/// Returns an empty vec for malformed or absent JSON rather than failing:
+/// a plain title+body toast is a strictly better outcome than no toast at all,
+/// and the caller logs the miss. Over-long sets are truncated to
+/// [`MAX_ACTIONS`] here so the truncation is visible to tests instead of
+/// happening inside Windows.
+pub fn parse_actions(json: &str) -> Vec<ToastAction> {
+    let mut actions: Vec<ToastAction> = serde_json::from_str(json).unwrap_or_default();
+    actions.truncate(MAX_ACTIONS);
+    actions
+}
+
+/// The button set for an outbox row: its own `actions` column first, the
+/// category registry as a fallback.
+///
+/// The column is the more truthful source — it is what the daemon decided when
+/// it enqueued the row, and it survives a category being edited afterwards —
+/// but rows predating the column carry only a category, and those must stay
+/// interactive. A row with neither still delivers, as plain title+body.
+///
+/// Takes the two strings rather than a `PendingNotification` so it stays here,
+/// on the platform-independent side, where `cargo test` reaches it.
+pub fn resolve_actions(actions_json: Option<&str>, category: Option<&str>) -> Vec<ToastAction> {
+    if let Some(json) = actions_json {
+        let parsed = parse_actions(json);
+        if !parsed.is_empty() {
+            return parsed;
+        }
+    }
+    category
+        .and_then(meridian_core::notifications::categories::actions_json)
+        .map(parse_actions)
+        .unwrap_or_default()
+}
+
+/// Build the complete toast payload for a notification.
+///
+/// The shape is Windows' `ToastGeneric` template. Three details are
+/// load-bearing and easy to get wrong:
+///
+/// - **`launch="tap"`** makes a click on the toast body activate with the
+///   argument `tap`, which is the same vocabulary macOS reports for a body tap
+///   and what [`crate::commands::record_notification_response`] matches on to
+///   route a click-through.
+/// - **`<input>` must precede `<action>`** inside `<actions>`. The toast schema
+///   is ordered, and Windows rejects the whole document if it isn't - which
+///   surfaces as a toast that simply never appears.
+/// - **`hint-inputId` binds a button to a field.** The input's id is the
+///   action's own id, so the activation handler can read the typed text back
+///   out of `UserInput` keyed by the action id it was just handed, with no
+///   second lookup table to keep in sync.
+///
+/// `duration="long"` is applied only when the toast has buttons: an
+/// interactive toast the user is meant to answer gets the ~25 s banner rather
+/// than the ~7 s default. It is the closest Windows equivalent to the
+/// persistent Alerts style macOS uses for the same notifications; either way
+/// the toast lands in Action Center afterwards with its buttons live, which is
+/// what expiry ([`crate::sys::retract_toast`]) exists to clean up.
+pub fn build_toast_xml(title: &str, body: &str, actions: &[ToastAction]) -> String {
+    let duration = if actions.is_empty() {
+        ""
+    } else {
+        r#" duration="long""#
+    };
+    let mut xml = format!(
+        r#"<toast activationType="foreground" launch="tap"{duration}><visual><binding template="ToastGeneric"><text>{}</text><text>{}</text></binding></visual>"#,
+        escape_xml(title),
+        escape_xml(body),
+    );
+
+    if !actions.is_empty() {
+        xml.push_str("<actions>");
+        // Inputs first - the schema demands it (see the doc comment).
+        for a in actions.iter().filter(|a| a.input) {
+            xml.push_str(&format!(
+                r#"<input id="{}" type="text" placeHolderContent="{}"/>"#,
+                escape_xml(&a.id),
+                escape_xml(a.input_placeholder.as_deref().unwrap_or("")),
+            ));
+        }
+        for a in actions {
+            let label = if a.input {
+                a.input_button_title.as_deref().unwrap_or(&a.title)
+            } else {
+                &a.title
+            };
+            let bind = if a.input {
+                format!(r#" hint-inputId="{}""#, escape_xml(&a.id))
+            } else {
+                String::new()
+            };
+            xml.push_str(&format!(
+                r#"<action content="{}" arguments="{}" activationType="foreground"{bind}/>"#,
+                escape_xml(label),
+                escape_xml(&a.id),
+            ));
+        }
+        xml.push_str("</actions>");
+    }
+
+    xml.push_str("</toast>");
+    xml
+}
+
+/// Escape the five XML metacharacters.
+///
+/// Not cosmetic: toast bodies are assembled from user data (task titles, app
+/// names, branch names), and a single `&` produces a document `XmlDocument::
+/// LoadXml` rejects - which manifests as a toast that silently never shows,
+/// on a machine no one can attach a debugger to. Attribute values need `"`
+/// and `'` escaped too, so one function covers both positions.
+fn escape_xml(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plain(id: &str, title: &str) -> ToastAction {
+        ToastAction {
+            id: id.to_string(),
+            title: title.to_string(),
+            input: false,
+            input_button_title: None,
+            input_placeholder: None,
+        }
+    }
+
+    /// Every shipped category must survive the round-trip - this is the guard
+    /// that a category added for macOS doesn't silently render button-less on
+    /// Windows.
+    #[test]
+    fn every_shipped_category_parses_into_buttons() {
+        use meridian_core::notifications::categories;
+        for id in categories::ALL {
+            let json = categories::actions_json(id)
+                .unwrap_or_else(|| panic!("category {id} has no actions JSON"));
+            let actions = parse_actions(json);
+            assert!(
+                !actions.is_empty(),
+                "category {id} parsed to zero buttons on Windows"
+            );
+            assert!(
+                actions.len() <= MAX_ACTIONS,
+                "category {id} exceeds the cap"
+            );
+        }
+    }
+
+    /// The inline-reply category is the one that exercises every branch, so it
+    /// is pinned end to end rather than by field.
+    #[test]
+    fn verify_switch_renders_input_before_actions_and_binds_it() {
+        use meridian_core::notifications::categories;
+        let actions = parse_actions(categories::actions_json(categories::VERIFY_SWITCH).unwrap());
+        let xml = build_toast_xml("Still on the same task?", "You switched apps.", &actions);
+
+        let input_at = xml.find("<input ").expect("no input element rendered");
+        let first_action_at = xml.find("<action ").expect("no action element rendered");
+        assert!(
+            input_at < first_action_at,
+            "Windows rejects a toast whose <input> follows an <action>: {xml}"
+        );
+        assert!(xml.contains(r#"<input id="reply" type="text""#), "{xml}");
+        assert!(xml.contains(r#"hint-inputId="reply""#), "{xml}");
+        // The input action's button carries its inputButtonTitle, not its title.
+        assert!(xml.contains(r#"content="Send""#), "{xml}");
+        // ...and the plain buttons keep their own labels and ids.
+        assert!(
+            xml.contains(r#"content="Yes, new task" arguments="yes""#),
+            "{xml}"
+        );
+    }
+
+    #[test]
+    fn body_tap_is_reported_as_the_tap_action() {
+        let xml = build_toast_xml("t", "b", &[]);
+        assert!(xml.contains(r#"launch="tap""#), "{xml}");
+    }
+
+    /// A toast with no buttons must not carry an empty `<actions/>` block, and
+    /// gets the default (short) banner duration.
+    #[test]
+    fn a_plain_toast_has_no_actions_block_and_default_duration() {
+        let xml = build_toast_xml("Title", "Body", &[]);
+        assert!(!xml.contains("<actions>"), "{xml}");
+        assert!(!xml.contains("duration="), "{xml}");
+        assert!(xml.contains("<text>Title</text><text>Body</text>"), "{xml}");
+    }
+
+    #[test]
+    fn an_interactive_toast_gets_the_long_banner() {
+        let xml = build_toast_xml("T", "B", &[plain("open", "Open")]);
+        assert!(xml.contains(r#"duration="long""#), "{xml}");
+    }
+
+    /// The failure this prevents is invisible: an unescaped `&` makes
+    /// `LoadXml` reject the document and the toast never appears.
+    #[test]
+    fn metacharacters_in_content_are_escaped() {
+        let xml = build_toast_xml(
+            "R&D <urgent>",
+            r#"He said "it's fine""#,
+            &[plain("a&b", "Fix & ship")],
+        );
+        assert!(xml.contains("<text>R&amp;D &lt;urgent&gt;</text>"), "{xml}");
+        assert!(xml.contains("&quot;it&apos;s fine&quot;"), "{xml}");
+        assert!(xml.contains(r#"content="Fix &amp; ship""#), "{xml}");
+        assert!(xml.contains(r#"arguments="a&amp;b""#), "{xml}");
+        // Nothing raw survives past the markup we intended.
+        assert!(!xml.contains("R&D"), "{xml}");
+    }
+
+    /// The row's own column wins when it has content; the category registry
+    /// covers rows that predate the column; neither is a plain toast, not a
+    /// dropped one.
+    #[test]
+    fn the_rows_actions_column_wins_over_the_category_registry() {
+        use meridian_core::notifications::categories;
+
+        let from_row = resolve_actions(
+            Some(r#"[{"id":"only","title":"Only"}]"#),
+            Some(categories::VERIFY_SWITCH),
+        );
+        assert_eq!(from_row, vec![plain("only", "Only")]);
+
+        // No column (old row) -> the registry keeps it interactive.
+        let from_registry = resolve_actions(None, Some(categories::VERIFY_SWITCH));
+        assert!(from_registry.len() > 1, "{from_registry:?}");
+
+        // An unusable column falls back rather than delivering button-less.
+        assert_eq!(
+            resolve_actions(Some("[]"), Some(categories::VERIFY_SWITCH)),
+            from_registry
+        );
+
+        // Neither -> a plain toast.
+        assert!(resolve_actions(None, None).is_empty());
+        assert!(resolve_actions(None, Some("no_such_category")).is_empty());
+    }
+
+    #[test]
+    fn malformed_or_empty_descriptors_degrade_to_a_plain_toast() {
+        assert!(parse_actions("not json").is_empty());
+        assert!(parse_actions("[]").is_empty());
+        assert!(parse_actions(r#"{"id":"x"}"#).is_empty());
+    }
+
+    #[test]
+    fn more_than_five_buttons_are_capped() {
+        let json = r#"[{"id":"1","title":"a"},{"id":"2","title":"b"},{"id":"3","title":"c"},
+                       {"id":"4","title":"d"},{"id":"5","title":"e"},{"id":"6","title":"f"}]"#;
+        let actions = parse_actions(json);
+        assert_eq!(actions.len(), MAX_ACTIONS);
+        assert_eq!(actions.last().unwrap().id, "5");
+    }
+
+    /// macOS-only presentation hints must not break the shared descriptor.
+    #[test]
+    fn unknown_macos_fields_are_ignored() {
+        let actions =
+            parse_actions(r#"[{"id":"x","title":"X","destructive":true,"foreground":true}]"#);
+        assert_eq!(actions, vec![plain("x", "X")]);
+    }
+}

--- a/tray/src-tauri/src/win_toast.rs
+++ b/tray/src-tauri/src/win_toast.rs
@@ -1,0 +1,248 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Windows interactive toasts - buttons, inline reply, and retraction - via
+//! `Windows.UI.Notifications` directly.
+//!
+//! # Why this exists at all
+//!
+//! `tauri-plugin-notifications` implements its desktop backend as either
+//! `cfg(all(desktop, feature = "notify-rust"))` or `cfg(all(target_os =
+//! "macos", not(feature = "notify-rust")))`. macOS takes the second arm (a real
+//! Swift `UNUserNotificationCenter` layer: categories, buttons, inline reply,
+//! action events). Windows has to take the first, because with the feature off
+//! it matches neither arm and has no notification backend whatsoever. And
+//! `notify-rust` has no action API — `set_click_listener_active` and
+//! `remove_active` both return a hard `Err("… not supported with notify-rust")`.
+//!
+//! So on Windows the outbox previously *delivered* interactive notifications
+//! that could not be answered (their rows resolved only by expiry) and could
+//! not be retracted (every expiry logged `toast retraction failed` and left the
+//! toast on screen). None of that is a Windows limitation: toast XML has
+//! supported `<actions>` and `<input>` for years. It was a backend limitation,
+//! and this module routes around it.
+//!
+//! # Two toast stacks on Windows, deliberately
+//!
+//! Only the OUTBOX path moves here. Plain [`crate::sys::notify`] toasts
+//! (pause/update/health) still go through the plugin: they have no id, no
+//! buttons, no tag and nothing to retract, so rewriting them would risk a
+//! working path to buy nothing. Both stacks deliver under the same AUMID (the
+//! Tauri bundle identifier), so Windows treats them as one app and the setting
+//! [`crate::sys::notification_permission_state`] reads governs both. Do not
+//! "unify" them without re-reading this paragraph.
+//!
+//! # Everything runs on the main thread
+//!
+//! WinRT calls need an initialised COM apartment, and STA event callbacks are
+//! delivered by a message pump. The tray's main thread has both (tao
+//! `OleInitialize`s it and pumps it); the poll-loop tokio workers that call
+//! [`crate::sys::notify_outbox`] / [`crate::sys::retract_toast`] have neither.
+//! So both entry points hop via `run_on_main_thread` — delivery AND retraction.
+//! Registering a handler off the pump would leave the buttons dead.
+//!
+//! # What is testable and what is not
+//!
+//! Nothing here can be compiled or run from the macOS dev machines this is
+//! written on, so the module is kept as thin as it can be: every decision with
+//! a possible logic bug (escaping, the button cap, element ordering,
+//! `hint-inputId` wiring) lives in [`crate::toast_actions`], which compiles and
+//! tests everywhere. What is left is WinRT plumbing, type-checked from macOS by
+//! copying the call sequence into a scratch crate depending only on `windows`
+//! and running `cargo check --target x86_64-pc-windows-msvc` (a full
+//! cross-target check of the tray is not possible — it dies in `aws-lc-sys`,
+//! whose build needs `windows.h`).
+//!
+//! # Who calls this
+//! [`crate::sys::notify_outbox`] and [`crate::sys::retract_toast`], on their
+//! Windows arms only.
+//!
+//! # Related
+//! - [`crate::toast_actions`] — the XML this hands to WinRT.
+//! - [`crate::commands::notifications::apply_response`] — where an answer lands
+//!   (shared with the macOS plugin path, so both platforms write identically).
+//! - `docs/notifications.md` — the outbox → deliver → respond → expire lifecycle.
+
+use tauri::Manager;
+use windows::core::{IInspectable, Interface, Ref, HSTRING};
+use windows::Data::Xml::Dom::XmlDocument;
+use windows::Foundation::{IPropertyValue, TypedEventHandler};
+use windows::UI::Notifications::{
+    ToastActivatedEventArgs, ToastDismissalReason, ToastDismissedEventArgs, ToastNotification,
+    ToastNotificationManager,
+};
+
+/// WinRT group for every toast this module delivers.
+///
+/// Retraction on an unpackaged (non-MSIX) app has to name the tag, the group
+/// AND the AUMID — `ToastNotificationHistory::RemoveGroupedTagWithId` — so a
+/// constant group is not decoration, it is half the address of the toast we
+/// need to be able to withdraw.
+const GROUP: &str = "meridian";
+
+/// The action id reported when the user clicks the toast body rather than a
+/// button. Matches what macOS reports, and what
+/// [`crate::commands::notifications::apply_response`] treats as a
+/// click-through.
+const TAP: &str = "tap";
+
+/// Deliver an outbox notification as a toast, with its category's buttons.
+///
+/// The outbox row id becomes the toast's WinRT **tag**, which is this
+/// platform's equivalent of the macOS notification identifier: the correlation
+/// that comes back on activation and the handle [`retract`] targets. Unlike
+/// macOS (whose plugin id is an `i32`), a tag is a string, so the full `i64`
+/// round-trips and there is no clamping case to degrade.
+///
+/// Buttons come from the row's own `actions` JSON — the bytes the daemon
+/// stamped when it enqueued — falling back to the category registry if the
+/// column is empty. A row with neither still delivers, as plain title+body.
+pub fn show(app: &tauri::AppHandle, n: &meridian_core::notifications::PendingNotification) {
+    let actions =
+        crate::toast_actions::resolve_actions(n.actions.as_deref(), n.category.as_deref());
+    let xml = crate::toast_actions::build_toast_xml(&n.title, &n.body, &actions);
+    let aumid = app.config().identifier.clone();
+    let id = n.id;
+    let buttons = actions.len();
+    let category = n.category.clone();
+
+    let handle = app.clone();
+    let dispatched =
+        app.run_on_main_thread(move || match show_on_main(&handle, id, &aumid, &xml) {
+            Ok(()) => tracing::info!(id, buttons, category = ?category, "outbox toast delivered"),
+            Err(e) => tracing::warn!(error = %e, id, "notify_outbox: toast delivery failed"),
+        });
+    if let Err(e) = dispatched {
+        tracing::warn!(error = %e, id, "notify_outbox: main-thread dispatch failed");
+    }
+}
+
+/// Withdraw a delivered toast from the screen and Action Center - the delivery
+/// half of expiry. Best-effort, exactly like the macOS path: the outbox row is
+/// stamped regardless, so a failure leaves a stale toast but never a
+/// re-delivery.
+pub fn retract(app: &tauri::AppHandle, id: i64) {
+    let aumid = app.config().identifier.clone();
+    let dispatched = app.run_on_main_thread(move || {
+        let removed = ToastNotificationManager::History().and_then(|h| {
+            h.RemoveGroupedTagWithId(
+                &HSTRING::from(id.to_string()),
+                &HSTRING::from(GROUP),
+                &HSTRING::from(&aumid),
+            )
+        });
+        match removed {
+            Ok(()) => tracing::info!(id, "expired toast retracted"),
+            Err(e) => tracing::warn!(error = %e, id, "toast retraction failed"),
+        }
+    });
+    if let Err(e) = dispatched {
+        tracing::warn!(error = %e, id, "retract_toast: main-thread dispatch failed");
+    }
+}
+
+/// Build, wire and show the toast. Main thread only (see the module header).
+fn show_on_main(
+    app: &tauri::AppHandle,
+    id: i64,
+    aumid: &str,
+    xml: &str,
+) -> windows::core::Result<()> {
+    let doc = XmlDocument::new()?;
+    // A rejected document is the failure mode escaping exists to prevent; it
+    // surfaces here rather than as a toast that silently never appears.
+    doc.LoadXml(&HSTRING::from(xml))?;
+
+    let toast = ToastNotification::CreateToastNotification(&doc)?;
+    toast.SetTag(&HSTRING::from(id.to_string()))?;
+    toast.SetGroup(&HSTRING::from(GROUP))?;
+
+    let activated_app = app.clone();
+    toast.Activated(&TypedEventHandler::<ToastNotification, IInspectable>::new(
+        move |_, args| {
+            let (action, text) = read_activation(args);
+            record(&activated_app, id, action, text);
+            Ok(())
+        },
+    ))?;
+
+    let dismissed_app = app.clone();
+    toast.Dismissed(&TypedEventHandler::<
+        ToastNotification,
+        ToastDismissedEventArgs,
+    >::new(move |_, args| {
+        // ONLY a real user dismissal counts. `ApplicationHidden` is what our
+        // own `retract` raises, and recording 'dismiss' for it would race the
+        // 'expired' stamp for the same row; `TimedOut` just means the banner
+        // rolled into Action Center, where its buttons are still live and the
+        // user has not answered anything.
+        let reason = args
+            .ok()
+            .ok()
+            .and_then(|a| a.Reason().ok())
+            .unwrap_or(ToastDismissalReason::ApplicationHidden);
+        if reason == ToastDismissalReason::UserCanceled {
+            record(&dismissed_app, id, "dismiss".to_string(), None);
+        }
+        Ok(())
+    }))?;
+
+    ToastNotificationManager::CreateToastNotifierWithId(&HSTRING::from(aumid))?.Show(&toast)
+}
+
+/// Extract the pressed action id and any inline-reply text from an activation.
+///
+/// `Arguments()` carries what the XML put in `arguments=` — an action id, or
+/// [`TAP`] from the toast's `launch` for a body click. The typed text is keyed
+/// in `UserInput` by the input's id, which [`crate::toast_actions`] sets to the
+/// action's own id precisely so this lookup needs no second mapping.
+///
+/// Every failure degrades to a bare tap rather than dropping the answer: a
+/// recorded response with a less specific action still resolves the outbox row,
+/// while no response leaves it hanging until expiry.
+fn read_activation(args: Ref<'_, IInspectable>) -> (String, Option<String>) {
+    // `Ref::ok()` yields a `windows::core::Result`, hence the second `.ok()`
+    // to reach a plain Option.
+    let Some(args) = args
+        .ok()
+        .ok()
+        .and_then(|a| a.cast::<ToastActivatedEventArgs>().ok())
+    else {
+        return (TAP.to_string(), None);
+    };
+    let action = match args.Arguments() {
+        Ok(a) if !a.is_empty() => a.to_string_lossy(),
+        _ => TAP.to_string(),
+    };
+    let text = args.UserInput().ok().and_then(|inputs| {
+        let value = inputs.Lookup(&HSTRING::from(&action)).ok()?;
+        let typed = value.cast::<IPropertyValue>().ok()?.GetString().ok()?;
+        let typed = typed.to_string_lossy();
+        (!typed.is_empty()).then_some(typed)
+    });
+    (action, text)
+}
+
+/// Stamp the answer onto the outbox row, off the message pump.
+///
+/// The write is async and touches the DB pool, so it is spawned rather than
+/// awaited: this runs inside a WinRT callback on the main thread, and blocking
+/// there stalls the pump that delivers every other toast event.
+fn record(app: &tauri::AppHandle, id: i64, action: String, text: Option<String>) {
+    // Clone the pool out of the managed state before the await — a `State`
+    // guard borrows the app and cannot be held across one.
+    let pool = app
+        .try_state::<Option<meridian_core::SqlitePool>>()
+        .and_then(|s| s.inner().clone());
+    let Some(pool) = pool else {
+        tracing::warn!(id, action, "toast answer dropped — meridian.db is not open");
+        return;
+    };
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) =
+            crate::commands::notifications::apply_response(app, &pool, id, &action, text.as_deref())
+                .await
+        {
+            tracing::warn!(error = %e, id, action, "toast answer could not be recorded");
+        }
+    });
+}

--- a/tray/src/app.js
+++ b/tray/src/app.js
@@ -514,11 +514,15 @@ function armNotificationActions() {
         text: msg.inputValue == null ? null : String(msg.inputValue),
       }).catch((e) => dbg(`notification response failed: ${e}`))
     }
-    // Plugin absent in an unbundled run (tauri dev) — interactive toasts are
-    // packaged-only, so a registration failure is expected there, not an error.
+    // Two expected non-failures here, neither an error:
+    //   - an unbundled run (tauri dev) has no plugin at all — interactive
+    //     toasts are packaged-only;
+    //   - Windows never registers this listener, because its toasts are WinRT
+    //     (tray/src-tauri/src/win_toast.rs) and their handlers record answers
+    //     in Rust without a webview hop.
     invoke('plugin:notifications|register_listener', { event: 'actionPerformed', handler: ch })
       .then(() => dbg('notification action listener registered'))
-      .catch(() => dbg('notification action listener not registered (unbundled run?)'))
+      .catch(() => dbg('notification action listener not registered (dev run, or Windows/WinRT)'))
   } catch (e) { dbg(`notification listener threw: ${e}`) }
 }
 


### PR DESCRIPTION
## What

Windows toasts were plain title+body. An **interactive** notification delivered but could not be answered - its outbox row was only ever resolved by expiry - and retraction always failed, leaving the toast in Action Center with live buttons.

That was never a Windows limitation: toast XML has supported `<actions>` and `<input>` for years. It came from the plugin's `notify-rust` backend, the only arm a Windows build can match, whose `set_click_listener_active` and `remove_active` both return a hard `Err("... not supported with notify-rust")`.

So the **outbox path** now drives `Windows.UI.Notifications` directly. Buttons, inline reply, taps, dismissals and retraction all work, and answers land on the outbox row through the same `apply_response` the macOS plugin path uses - so both platforms write identically.

## Two bugs closed, not one

1. **No way to answer an interactive toast** (the headline).
2. **`retract_toast` never worked on Windows** - `remove_active` is a hard `Err`, so every expiry logged `toast retraction failed` and left the toast up. Discovered while reading the backend, not from a report.

Plus a spurious `notification category registration failed` **ERROR on every Windows launch**: `register_notification_categories` was calling a plugin that rejects it. Categories are a `UNUserNotificationCenter` concept; a Windows toast carries its buttons inline, so it is now a documented no-op there.

## Shape of the change

| File | Role |
|---|---|
| `win_toast.rs` (new) | WinRT delivery + retraction. Toast **tag** = outbox row id (a string, so the full `i64` round-trips - no `i32` clamp case like macOS). |
| `toast_actions.rs` (new) | The XML build: escaping, 5-button cap, `<input>`-before-`<action>` ordering, `hint-inputId` wiring, row-column-vs-registry fallback. |
| `sys.rs` | `notify_outbox` / `retract_toast` fork to `win_toast` on Windows, gated on `is_bundled()` rather than plugin presence. |

Three decisions worth reviewing:

- **Plain `sys::notify` toasts stay on the plugin.** Only the outbox path moved. Windows therefore runs two toast stacks under the same AUMID, which is why one permission read still governs both. The module header says so explicitly, so nobody "unifies" them later without the context.
- **Everything runs on the main thread.** WinRT needs an initialised COM apartment, and STA callbacks are delivered by a message pump. The poll-loop tokio workers have neither, so delivery *and* retraction hop via `run_on_main_thread`.
- **No COM activator.** `INotificationActivationCallback` + CLSID registration is only needed to activate the app when it is *not running*, and the existing constraint already accepts that answers after a tray restart are dropped (true on macOS too). In-process handlers are behavioural parity, not a degradation.

## Verification, and its honest limit

macOS gates are green: `fmt`, `clippy --workspace -D warnings`, `test --workspace` (283 tray tests), and all three pre-push waves.

**The WinRT half cannot be compiled here.** `cargo check --target x86_64-pc-windows-msvc` on the tray dies in `aws-lc-sys`, whose build needs `windows.h`. So:

- Everything with a possible logic bug lives in `toast_actions.rs`, which is compiled on **every** platform (`cfg_attr(allow(dead_code))`, never `cfg`) and unit-tested from macOS - 10 tests.
- The WinRT call sequence **and** the Windows-only cross-module call boundaries (into `toast_actions`, into `apply_response`) were type-checked by mirroring them into a scratch crate depending only on `windows` and checking that for `x86_64-pc-windows-msvc`. I proved that mirror is not vacuous by planting a signature mismatch (`Option<&str>` -> `Option<String>`) and confirming it fails.
- Both new guards were checked the same way: planting a regression against the escaping test and against the "Windows outbox path bypasses the plugin" source scan makes each fail its own test and nothing else.

**This code is type-checked but has never been executed.** Nobody has run it on Windows. CI's Windows job is the first real compile; a packaged Windows build is the first real toast. Suggested manual check: trigger a `verify_switch` nudge, confirm three buttons + a working reply field, then let one expire and confirm it leaves Action Center.

## Unrelated fix, included because this change exposed it

`reopen.rs`'s `full_screen_is_requested_on_macos_only` anchored on the first `set_fullscreen(true)` in `sys.rs` - which is a **doc-comment mention**, not the call - so it was measuring its cfg-gate distance from prose. A new function landing between the two tripped it. It now anchors on `win.set_fullscreen(true)`; I verified with a script that the corrected logic passes on both `HEAD` and this branch, so it was not a vacuous pass being papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
