### PR TITLE
fix: address the CodeRabbit review on the 1.87 release PR

### DIFF
--- a/tray/src-tauri/resources/whats-new.json
+++ b/tray/src-tauri/resources/whats-new.json
@@ -23,6 +23,44 @@
       ]
     },
     {
+      "version": "1.86.0",
+      "date": "2026-08-16",
+      "highlights": [
+        "Setup now picks up where you left off. Closing the wizard part-way through used to mean starting again from the first card.",
+        "Meridian tells you when your daily summary is ready, instead of leaving you to go and look.",
+        "The dashboard opens filling the screen rather than in a small window you have to resize every time."
+      ],
+      "fixes": [
+        "Signing in sticks. Your session was being quietly dropped every time Meridian restarted, so you had to sign in again each launch.",
+        "Settings no longer crashes on builds where sign-in is switched off.",
+        "The vendored sign-in component was writing your session token into Meridian's own logs. It no longer does, and that logging is now switched off by default regardless.",
+        "The wizard's privacy wording now matches what the app actually does. It said Meridian never collects anything - true of a build you compile yourself, but not of the installed app, which sends redacted error reports and product analytics you can switch off. The download page, the privacy document and the wizard all say the same thing now.",
+        "The Notifications permission card in setup now shows the real Notifications pane rather than a stand-in, and the permission cards are highlighted one at a time instead of all at once.",
+        "The setup wizard no longer renders black when the window is in full screen.",
+        "What's New no longer opens on top of you the moment first-run setup finishes.",
+        "The walkthrough survives a stray click, and the tray's own pop-ups no longer interrupt it half way through.",
+        "Connecting GitHub no longer blames your token when GitHub simply cut the response short. Meridian retries instead."
+      ]
+    },
+    {
+      "version": "1.85.0",
+      "date": "2026-08-13",
+      "highlights": [
+        "Meridian shows you around the first time you open it. A guided walkthrough covers planning a day, watching your work get picked up, and having a work log written for you - starting on your own day, then on an example day so you can see a full one end to end.",
+        "Yesterday's unfinished work now moves into today on its own, so you no longer start the morning rebuilding a list you already made.",
+        "Meridian now says when a draft work log has fallen behind the work it describes, rather than letting you post something that stopped being true an hour ago."
+      ],
+      "fixes": [
+        "Uninstalling now removes your data. Some of it survived every uninstall route the app offered, which is not what uninstall means.",
+        "An update already being installed is no longer reported as 'Update failed', and an install that genuinely fails now tells every screen, so nothing is left sitting on a spinner.",
+        "Restarting the background service no longer runs into the limit macOS puts on how often a service may restart, which used to leave it stopped for minutes at a time.",
+        "A work-log draft that the AI failed to produce now points you at the reason rather than ending the flow with nothing.",
+        "Every notification now opens the thing it is about. Some of them went nowhere. The board-hygiene digest, which fired at midnight and which nobody ever acted on, is gone.",
+        "A fresh install opens setup rather than dropping you on an empty dashboard.",
+        "The work-log draft is laid out as a document you can read, and the live hour on your timeline now says which hour it means."
+      ]
+    },
+    {
       "version": "1.84.0",
       "date": "2026-08-07",
       "highlights": [

--- a/tray/src-tauri/resources/whats-new.json
+++ b/tray/src-tauri/resources/whats-new.json
@@ -1,6 +1,28 @@
 {
   "releases": [
     {
+      "version": "1.87.0",
+      "date": "2026-08-16",
+      "highlights": [
+        "Notifications on Windows can now be answered. Buttons and the reply box did nothing there - the only way a question ever closed itself was by expiring - and a notification Meridian tried to take back stayed in the Action Center with buttons that still looked live. Both now work the way they already did on Mac.",
+        "The guided tour can be replayed. Settings - Account - Show me around brings it back. Until now that control existed only in development builds, so once you finished or skipped the tour there was no way to see it again.",
+        "The tour writes your first task for you instead of waiting at an empty box. It used to ask you to invent one before you had watched Meridian draft anything, which is the wrong moment to ask - the step straight after is the one where a scruffy one-liner becomes a titled, described task."
+      ],
+      "fixes": [
+        "On Windows the dashboard no longer opens with no title bar and no taskbar. It covered the whole screen with nothing to click - no minimize, no close - and the only ways out were Alt+F4 and Alt+Tab. It now fills the usable screen with its window controls intact.",
+        "On Windows, pressing Continue in the setup wizard no longer shrinks a maximized window back down to its smaller size.",
+        "The setup wizard no longer stops on the Alerts step when there is nothing to ask. Windows switches notifications on for most apps already, so that step usually opened with its one setting done.",
+        "The setup wizard's Continue button is easier to read - the old fill was pale enough that the button looked half-disabled.",
+        "Installing an update no longer races Meridian's own health check, which could put the background service back while the file it runs from was still being replaced.",
+        "Windows no longer logs a notification error every time Meridian starts.",
+        "Pressing Generate on a work log with no AI connected now takes you somewhere. The Choose a provider button opened Settings behind the card you were still looking at, so the one route the app offers for connecting a model appeared to do nothing.",
+        "The tour no longer demonstrates generating a work log on a machine with no AI set up at all.",
+        "The tour's spotlight no longer shows square corners around a rounded card, and its narration bar no longer covers the first line of what it is talking about.",
+        "Writing a task, being sent off to connect an AI provider, and coming back now returns you to what you were typing rather than to the task list.",
+        "Finishing the tour no longer asks a second time when you want your work log written."
+      ]
+    },
+    {
       "version": "1.84.0",
       "date": "2026-08-07",
       "highlights": [

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -840,29 +840,55 @@ pub(crate) async fn stop_running_daemon_before_stage(daemon_bin: &Path) -> Resul
 /// note in [`stop_running_daemon_before_stage`].
 #[cfg(target_os = "windows")]
 async fn kill_pids(pids: &[u32], daemon_bin: &Path) {
+    // Imported in-body rather than at module scope: this fn is
+    // `cfg(target_os = "windows")` and the trait has no other user here, so a
+    // top-level `use` would be an unused import on macOS - which is a hard
+    // error under `-D warnings`, from a file the macOS build otherwise
+    // compiles fine.
+    use tracing::Instrument;
     for &pid in pids {
-        let out = tokio::process::Command::new("taskkill")
-            .args(["/F", "/PID", &pid.to_string()])
-            .no_window()
-            .output()
-            .await;
-        match out {
-            Ok(o) if o.status.success() => {
-                tracing::info!(pid, path = %daemon_bin.display(), "backend_install: stopped staged daemon process");
-            }
-            Ok(o) => {
-                tracing::warn!(
-                    pid,
-                    path = %daemon_bin.display(),
-                    status = %o.status,
-                    stderr = %String::from_utf8_lossy(&o.stderr).trim(),
-                    "backend_install: taskkill did not stop staged daemon process"
-                );
-            }
-            Err(e) => {
-                tracing::warn!(pid, path = %daemon_bin.display(), error = %e, "backend_install: taskkill spawn failed");
+        // One span PER PID rather than one for the loop: this runs on the
+        // update path, where the interesting question is never "did the stop
+        // work" but "which of these processes refused to die" - and a failure
+        // here is what surfaces later as "cannot overwrite a locked binary",
+        // several steps removed from its cause.
+        async {
+            let out = tokio::process::Command::new("taskkill")
+                .args(["/F", "/PID", &pid.to_string()])
+                .no_window()
+                .output()
+                .await;
+            let s = tracing::Span::current();
+            match out {
+                Ok(o) if o.status.success() => {
+                    tracing::info!(pid, path = %daemon_bin.display(), "backend_install: stopped staged daemon process");
+                }
+                Ok(o) => {
+                    // Span status, not only the log line: the ship leg is
+                    // error-only, so a WARN with no ERROR span is the shape
+                    // that reaches central OO stripped of the context needed
+                    // to act on it.
+                    s.record("otel.status_code", "ERROR");
+                    tracing::warn!(
+                        pid,
+                        path = %daemon_bin.display(),
+                        status = %o.status,
+                        stderr = %String::from_utf8_lossy(&o.stderr).trim(),
+                        "backend_install: taskkill did not stop staged daemon process"
+                    );
+                }
+                Err(e) => {
+                    s.record("otel.status_code", "ERROR");
+                    tracing::warn!(pid, path = %daemon_bin.display(), error = %e, "backend_install: taskkill spawn failed");
+                }
             }
         }
+        .instrument(tracing::debug_span!(
+            "backend_install.taskkill",
+            pid,
+            otel.status_code = tracing::field::Empty,
+        ))
+        .await;
     }
 }
 

--- a/tray/src-tauri/src/commands/notifications.rs
+++ b/tray/src-tauri/src/commands/notifications.rs
@@ -36,6 +36,7 @@
 //! - [`crate::poll`] — emits the `notifications-update` event off the same read.
 
 use tauri::State;
+use tracing::Instrument;
 
 /// The active banner-notification set (the ported /api/notifications/stream
 /// snapshot). Resolves `now` (seconds-precision UTC, matching the route's
@@ -122,10 +123,36 @@ pub(crate) async fn apply_response(
     action: &str,
     text: Option<&str>,
 ) -> Result<(), String> {
+    // Spanned because this is where the two platforms converge and where a lost
+    // answer has to be diagnosed from telemetry alone. `source` distinguishes
+    // them: macOS arrives via the plugin event the popover forwards, Windows
+    // direct from a WinRT handler with no webview in the loop, and "the answer
+    // never arrived" looks identical from the outbox row either way.
+    //
+    // `has_text` rather than the text: an inline reply IS the user's own
+    // writing, and the whole point of the redaction allowlist is that it never
+    // egresses. Whether one was supplied is the diagnostic; its content is not.
+    let span = tracing::info_span!(
+        "notifications.respond",
+        id,
+        action,
+        source = if cfg!(target_os = "windows") {
+            "winrt"
+        } else {
+            "plugin"
+        },
+        has_text = text.is_some(),
+        otel.status_code = tracing::field::Empty,
+    );
+    let _e = span.enter();
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     meridian_core::notifications::record_response(pool, id, action, text, &now)
+        .instrument(tracing::debug_span!("notifications.write.outbox"))
         .await
-        .map_err(|e| crate::cmd_err!(e, id, action, "record_notification_response failed"))?;
+        .map_err(|e| {
+            tracing::Span::current().record("otel.status_code", "ERROR");
+            crate::cmd_err!(e, id, action, "record_notification_response failed")
+        })?;
     tracing::info!(
         id,
         action,

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -74,6 +74,7 @@ pub(super) async fn refresh_health(
         let s = &mut *s;
         let decision = decide_health_notice(
             now_healthy,
+            crate::daemon_lifecycle::is_staging(),
             &mut s.consecutive_health_failures,
             &mut s.daemon_was_healthy,
             &mut s.startup_health_reconciled,
@@ -105,32 +106,20 @@ pub(super) async fn refresh_health(
     // restart needs no DB pool, so it runs even when `pool` is None; only the
     // user-facing notice below does. Best-effort: the result feeds the notice
     // detail when we also notify.
-    // A daemon that is down because the INSTALLER stopped it is not an outage.
+    // A daemon that is down because the INSTALLER stopped it is not an outage -
+    // handled inside `decide_health_notice`, which does not count the failure at
+    // all rather than masking its outputs. See the comment there for why the
+    // difference matters: masking would consume the one-shot `== 2` edge and
+    // delete the recovery attempt instead of deferring it.
     //
-    // Both halves are suppressed, and they have to move together. The restart,
-    // because it would start the process the installer just killed and re-lock
-    // the binary mid-swap — the same hazard the fast watchdog now stands down
-    // for, on the slower 30 s tick (see `daemon_lifecycle::begin_staging`). The
-    // notice, because "Meridian went quiet - tried starting it automatically"
-    // is both alarming and false during a routine update: nothing tried, and
-    // nothing was wrong.
-    //
-    // Gating only the restart would ALSO trip the `notify_down` ⇒
-    // `restart_result.is_some()` debug assert below, which is exactly the
-    // tripwire that invariant was written to be.
-    //
-    // Losing this episode's went-quiet notice costs nothing: if the install
-    // fails it raises `tray.backend_install_failed`, which says more than the
-    // generic notice would, and if it succeeds the daemon is back within
-    // seconds. Applied here rather than inside `decide_health_notice` so the
-    // health state machine keeps advancing normally - only the two outward
-    // actions are held.
-    let staging = crate::daemon_lifecycle::is_staging();
-    let attempt_restart = attempt_restart && !staging;
-    let notify_down = notify_down && !staging;
-    if staging {
-        tracing::debug!("daemon health: install in progress - not restarting or notifying");
-    }
+    // Both outward actions move together either way. The restart, because it
+    // would start the process the installer just killed and re-lock the binary
+    // mid-swap — the same hazard the fast watchdog stands down for, on the
+    // slower 30 s tick (see `daemon_lifecycle::begin_staging`). The notice,
+    // because "Meridian went quiet - tried starting it automatically" is both
+    // alarming and false during a routine update. And structurally: gating only
+    // the restart trips the `notify_down` ⇒ `restart_result.is_some()` debug
+    // assert below, which is exactly the tripwire that invariant exists to be.
     let restart_result = if attempt_restart {
         // Wrap the restart attempt in a span so the health-path recovery is
         // traceable end-to-end, matching the fast watchdog's span.
@@ -325,10 +314,43 @@ struct HealthNoticeDecision {
 /// with that call site.
 fn decide_health_notice(
     now_healthy: bool,
+    staging: bool,
     consecutive_health_failures: &mut u32,
     daemon_was_healthy: &mut bool,
     startup_health_reconciled: &mut bool,
 ) -> HealthNoticeDecision {
+    // A FAILED tick during an install is not an observation - it is the state
+    // the installer asked for - so it is not counted at all.
+    //
+    // This has to suppress the COUNT, not just the outputs. Every outward action
+    // below keys off `*consecutive_health_failures == 2`, an edge that is
+    // consumed the moment it is reached: a tick that increments 1 → 2 and then
+    // has its actions masked leaves the counter at 2, and the next failure takes
+    // it to 3. The edge never comes back. So a suppressed episode did not delay
+    // the restart and the notice, it deleted them - and the case that matters is
+    // exactly the one where deleting them is wrong: `register_service` can
+    // report success on Windows while `/Run` or the fallback spawn quietly did
+    // not bring the daemon back, leaving a permanently down daemon that this
+    // loop had already spent its one recovery attempt on.
+    //
+    // Not counting instead means the episode is DEFERRED. When the guard drops,
+    // a daemon that is genuinely down fails one tick (1), then another (2), and
+    // recovery and the notice fire on their normal edge - at most ~60 s late,
+    // against an install that only needed a few seconds.
+    //
+    // A HEALTHY tick still runs the normal path even mid-install: it clears the
+    // counters and sets `daemon_was_healthy`, which is exactly right when the
+    // daemon comes back before the guard drops, and skipping it would strand a
+    // stale `tray.daemon_quiet` notice with nothing left to observe the
+    // recovery that would clear it.
+    if staging && !now_healthy {
+        return HealthNoticeDecision {
+            attempt_restart: false,
+            notify_down: false,
+            notify_back: false,
+            reconcile_stale: false,
+        };
+    }
     // The 2nd consecutive failure is the "confirmed outage" edge — one miss is a
     // transient blip. Both the recovery attempt and the down-notice key off it,
     // but they diverge on `daemon_was_healthy`: recovery always fires (a
@@ -515,6 +537,11 @@ pub(super) async fn refresh_worklogs(pool: &SqlitePool, state: &Arc<Mutex<AppSta
 mod tests {
     use super::*;
 
+    /// The `staging` argument for every case that is not about an install.
+    /// Named rather than a bare `false`, so a call site reads as "no install in
+    /// progress" instead of an unexplained second boolean.
+    const NOT_STAGING: bool = false;
+
     /// The install-in-progress suppression must hold BOTH outward actions, and
     /// it must hold them together.
     ///
@@ -531,41 +558,88 @@ mod tests {
     /// copy for a restart that never happened. That invariant is asserted, not
     /// merely documented, so the two lines have to move as a pair.
     ///
-    /// Source-scanned rather than driven: the gate lives in `refresh_health`,
-    /// which needs a live `AppHandle` and DB pool, and the decision was
-    /// deliberately placed OUTSIDE the pure `decide_health_notice` so the
-    /// health state machine keeps advancing while only the outward actions are
-    /// held. Same reasoning as `reopen.rs`'s gate tests.
-    ///
-    /// **Scans only the production half of the file.** `include_str!` on the
-    /// module a test lives in also pulls in that test's own body, so the needles
-    /// below would match their own string literals and the assertions could
-    /// never fail — a test that is green whatever the code does. Truncating at
-    /// the first `#[cfg(test)]` (the real attribute, which precedes this module)
-    /// is what makes it actually load-bearing; verified by deleting a gate line
-    /// and watching this go red.
+    /// Driven, not source-scanned: `staging` is a parameter of the pure
+    /// decision, so the suppression is reachable without an `AppHandle` or a
+    /// DB pool. The one thing still scanned is that `refresh_health` actually
+    /// passes the live flag - a decision that takes the right argument and is
+    /// always called with `false` is the failure this cannot otherwise see.
     #[test]
     fn an_install_in_progress_suppresses_both_the_restart_and_the_notice() {
+        // Second consecutive failure - the confirmed-outage edge, and the only
+        // tick on which either action would fire.
+        let (mut fails, mut was_healthy, mut reconciled) = (1, true, true);
+        let d = decide_health_notice(false, true, &mut fails, &mut was_healthy, &mut reconciled);
+        assert!(!d.attempt_restart, "restart raced the installer's swap");
+        assert!(
+            !d.notify_down,
+            "notified a went-quiet the installer caused - and a notice without a \
+             restart trips the `notify_down` => `restart_result.is_some()` assert"
+        );
+    }
+
+    /// **The reason the suppression skips the COUNT rather than the outputs.**
+    ///
+    /// `attempt_restart` fires only on `consecutive_health_failures == 2`, an
+    /// edge consumed the moment it is passed. Masking the outputs of that tick
+    /// still advances 1 → 2, so the next failure reaches 3 and the edge never
+    /// returns: a daemon the install left genuinely down would never be
+    /// recovered by this loop again - and `register_service` CAN report success
+    /// on Windows while `/Run` and the fallback spawn both failed to bring it
+    /// back.
+    #[test]
+    fn a_suppressed_outage_is_deferred_not_deleted() {
+        let (mut fails, mut was_healthy, mut reconciled) = (0, true, true);
+        // Two failed ticks during the install: neither acts, neither counts.
+        for _ in 0..2 {
+            let d =
+                decide_health_notice(false, true, &mut fails, &mut was_healthy, &mut reconciled);
+            assert!(!d.attempt_restart && !d.notify_down);
+        }
+        assert_eq!(fails, 0, "a suppressed tick still burned the one-shot edge");
+
+        // Guard drops, daemon is still down: the normal edge arrives intact.
+        let first =
+            decide_health_notice(false, false, &mut fails, &mut was_healthy, &mut reconciled);
+        assert!(!first.attempt_restart, "one miss is a blip, not an outage");
+        let second =
+            decide_health_notice(false, false, &mut fails, &mut was_healthy, &mut reconciled);
+        assert!(
+            second.attempt_restart && second.notify_down,
+            "the deferred outage never recovered - the install deleted it"
+        );
+    }
+
+    /// A HEALTHY tick mid-install takes the normal path, deliberately.
+    ///
+    /// Suppressing it too would strand a `tray.daemon_quiet` notice raised
+    /// before the install with nothing left to observe the recovery that clears
+    /// it - the same stale-notice bug `reconcile_stale` exists to close.
+    #[test]
+    fn a_healthy_tick_during_an_install_still_clears_the_counters() {
+        let (mut fails, mut was_healthy, mut reconciled) = (2, true, true);
+        let d = decide_health_notice(true, true, &mut fails, &mut was_healthy, &mut reconciled);
+        assert!(d.notify_back, "recovery went unannounced");
+        assert_eq!(fails, 0);
+    }
+
+    /// The wiring. `decide_health_notice` is pure, so every test above passes
+    /// just as well against a caller that hardcodes `false`.
+    ///
+    /// **Scans only the production half of the file.** `include_str!` on the
+    /// module a test lives in also pulls in that test's own body, so the needle
+    /// would match its own string literal and the assertion could never fail.
+    /// Truncating at the first `#[cfg(test)]` is what makes it load-bearing.
+    #[test]
+    fn refresh_health_passes_the_live_staging_flag() {
         let whole = include_str!("refresh.rs");
         let src = &whole[..whole
             .find("#[cfg(test)]")
             .expect("refresh.rs lost its test module marker")];
         assert!(
-            src.contains("let staging = crate::daemon_lifecycle::is_staging();"),
-            "refresh_health no longer reads the staging flag - its restart races \
-             the installer's binary swap, exactly as the watchdog's did"
+            src.contains("crate::daemon_lifecycle::is_staging(),"),
+            "refresh_health no longer passes the staging flag - its restart \
+             races the installer's binary swap, exactly as the watchdog's did"
         );
-        for line in [
-            "let attempt_restart = attempt_restart && !staging;",
-            "let notify_down = notify_down && !staging;",
-        ] {
-            assert!(
-                src.contains(line),
-                "`{line}` is gone - suppressing only one of the two trips the \
-                 `notify_down` => `restart_result.is_some()` debug assert below \
-                 the gate, and makes the notice claim a restart that never ran"
-            );
-        }
     }
 
     /// The exact bug this fix targets: a fresh tray process (all counters at
@@ -580,7 +654,13 @@ mod tests {
         let mut was_healthy = false;
         let mut reconciled = false;
 
-        let d = decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+        let d = decide_health_notice(
+            true,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        );
 
         assert!(!d.attempt_restart, "a healthy tick must not restart");
         assert!(!d.notify_down);
@@ -602,8 +682,20 @@ mod tests {
         let mut was_healthy = false;
         let mut reconciled = false;
 
-        decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
-        let second = decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+        decide_health_notice(
+            true,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        );
+        let second = decide_health_notice(
+            true,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        );
 
         assert!(!second.reconcile_stale);
         assert!(!second.notify_back);
@@ -618,18 +710,33 @@ mod tests {
         let mut was_healthy = true; // already established healthy earlier
         let mut reconciled = true; // startup reconciliation already happened
 
-        let first_fail =
-            decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
+        let first_fail = decide_health_notice(
+            false,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        );
         assert!(!first_fail.notify_down); // only 1 consecutive failure so far
         assert!(!first_fail.attempt_restart); // one blip is not yet an outage
 
-        let second_fail =
-            decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
+        let second_fail = decide_health_notice(
+            false,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        );
         assert!(second_fail.notify_down); // 2nd consecutive failure
         assert!(second_fail.attempt_restart); // …and the recovery attempt fires with it
 
-        let recovered =
-            decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+        let recovered = decide_health_notice(
+            true,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        );
         assert!(recovered.notify_back);
         assert!(!recovered.reconcile_stale);
         assert!(!recovered.attempt_restart);
@@ -648,14 +755,26 @@ mod tests {
         let mut was_healthy = false; // never seen healthy this session
         let mut reconciled = false;
 
-        let f1 = decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
+        let f1 = decide_health_notice(
+            false,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        );
         assert!(
             !f1.attempt_restart,
             "one failure is a blip, not yet a restart"
         );
         assert!(!f1.notify_down);
 
-        let f2 = decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
+        let f2 = decide_health_notice(
+            false,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        );
         assert!(
             f2.attempt_restart,
             "a cold-down daemon MUST be auto-restarted on the 2nd failure"
@@ -666,7 +785,13 @@ mod tests {
         );
 
         // It fires exactly once per episode — no restart loop while it stays down.
-        let f3 = decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
+        let f3 = decide_health_notice(
+            false,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        );
         assert!(
             !f3.attempt_restart,
             "must not re-fire every subsequent failed tick"
@@ -686,20 +811,43 @@ mod tests {
         let mut was_healthy = false; // cold start — never healthy this session
         let mut reconciled = false;
 
-        decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled); // 1
-        let f2 = decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled); // 2
+        decide_health_notice(
+            false,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        ); // 1
+        let f2 = decide_health_notice(
+            false,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        ); // 2
         assert!(f2.attempt_restart, "restart attempted at the 2nd failure");
         assert!(
             !f2.notify_down,
             "cold start stays silent on the went-quiet notice"
         );
         // Daemon stays down (restart failed); the counter keeps climbing.
-        decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled); // 3
+        decide_health_notice(
+            false,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        ); // 3
 
         // Recovery: notify_back must fire so the cold-start-failure notice
         // (raised with the same `tray.daemon_quiet` id) gets cleared.
-        let recovered =
-            decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+        let recovered = decide_health_notice(
+            true,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        );
         assert!(
             recovered.notify_back,
             "recovery must clear the cold-start failure notice"
@@ -716,8 +864,20 @@ mod tests {
         let mut was_healthy = false;
         let mut reconciled = false;
 
-        let f1 = decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
-        let f2 = decide_health_notice(false, &mut failures, &mut was_healthy, &mut reconciled);
+        let f1 = decide_health_notice(
+            false,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        );
+        let f2 = decide_health_notice(
+            false,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        );
         assert!(!f1.notify_down);
         assert!(
             !f2.notify_down,
@@ -727,8 +887,13 @@ mod tests {
         // `cold_down_daemon_is_restarted_even_though_notice_stays_silent`).
         assert!(f2.attempt_restart);
 
-        let recovered =
-            decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+        let recovered = decide_health_notice(
+            true,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        );
         assert!(recovered.notify_back);
         assert!(!recovered.reconcile_stale);
     }
@@ -782,7 +947,13 @@ mod tests {
         let mut failures = 0u32;
         let mut was_healthy = false;
         let mut reconciled = false;
-        let decision = decide_health_notice(true, &mut failures, &mut was_healthy, &mut reconciled);
+        let decision = decide_health_notice(
+            true,
+            NOT_STAGING,
+            &mut failures,
+            &mut was_healthy,
+            &mut reconciled,
+        );
         assert!(
             decision.reconcile_stale,
             "a fresh process's first healthy tick must trigger reconciliation"

--- a/tray/src-tauri/src/poll/watchdog.rs
+++ b/tray/src-tauri/src/poll/watchdog.rs
@@ -303,6 +303,35 @@ pub async fn run_daemon_watchdog() {
                 }
             }
             Action::Start => {
+                // RE-READ the flag at the last instant before acting.
+                //
+                // `decide` was handed a value sampled at the top of this tick,
+                // and between then and here the loop has awaited a socket probe
+                // and, on the path that reaches `Start`, forked a subprocess for
+                // the liveness check - hundreds of milliseconds during which an
+                // install can begin. That is a check-then-act window on the one
+                // decision that must not be wrong, and it is invisible from
+                // `decide`, which is pure and cannot know its input went stale.
+                //
+                // A re-read rather than [`crate::daemon_lifecycle::LIFECYCLE`]:
+                // the mutex would serialise properly, but the watchdog would
+                // then block for the length of an install and start the daemon
+                // the instant it was released, and a 5 s-budgeted `stop_for_quit`
+                // would queue behind the same install. The reasoning is recorded
+                // on `begin_staging`; this closes the window that reasoning left
+                // open rather than reversing it.
+                //
+                // Not airtight, and deliberately so: `begin_staging` can still
+                // land during `start_if_stopped` itself. The installer's own
+                // re-kill loop (`stop_running_daemon_before_stage`) is the
+                // backstop for that residue - it kills anything that appears
+                // mid-wait, which is exactly what this would be.
+                if crate::daemon_lifecycle::is_staging() {
+                    tracing::debug!(
+                        "daemon watchdog: install started during this tick - standing down"
+                    );
+                    continue;
+                }
                 async {
                     tracing::info!("daemon watchdog: daemon not running, starting it");
                     if let Err(e) = crate::commands::daemon_control::start_if_stopped().await {
@@ -416,6 +445,48 @@ mod tests {
                 "no amount of downtime turns an install-held daemon into an outage"
             );
         }
+    }
+
+    /// The half `decide` structurally cannot cover: the flag going true AFTER
+    /// its input was sampled.
+    ///
+    /// `decide` is pure, so it can only ever judge a snapshot. The loop takes
+    /// that snapshot at the top of the tick and then awaits a socket probe,
+    /// plus (on exactly the path that reaches `Start`) a forked subprocess for
+    /// the liveness check - ample time for an install to begin. A verdict of
+    /// `Start` computed before `begin_staging` is therefore not evidence that
+    /// starting is still safe, and nothing inside `decide` can tell.
+    ///
+    /// Source-scanned because the window is between two awaits in
+    /// `run_daemon_watchdog`, which polls a real socket forever - there is no
+    /// seam to drive it through. Truncated at the first `#[cfg(test)]` so the
+    /// needles cannot match their own literals in this module.
+    #[test]
+    fn the_start_arm_re_reads_the_flag_before_acting() {
+        let whole = include_str!("watchdog.rs");
+        let src = &whole[..whole
+            .find("#[cfg(test)]")
+            .expect("watchdog.rs lost its test module marker")];
+        let arm = src
+            .split_once("Action::Start => {")
+            .expect("the Start arm is gone")
+            .1;
+        let arm = &arm[..arm.find("Action::GiveUp").unwrap_or(arm.len())];
+        assert!(
+            arm.contains("if crate::daemon_lifecycle::is_staging() {"),
+            "the Start arm acts on a staging value sampled before two awaits - \
+             an install that begins mid-tick starts the daemon it just killed"
+        );
+        // Standing down must SKIP the start, not merely log before it.
+        let gate = arm
+            .split_once("if crate::daemon_lifecycle::is_staging() {")
+            .expect("gate")
+            .1;
+        let gate = &gate[..gate.find("start_if_stopped").unwrap_or(gate.len())];
+        assert!(
+            gate.contains("continue;"),
+            "the re-read does not skip the start, so it only narrates the race"
+        );
     }
 
     /// Staging is a few seconds inside one install, so the rule must not

--- a/tray/src-tauri/src/toast_actions.rs
+++ b/tray/src-tauri/src/toast_actions.rs
@@ -190,10 +190,40 @@ fn escape_xml(s: &str) -> String {
             '>' => out.push_str("&gt;"),
             '"' => out.push_str("&quot;"),
             '\'' => out.push_str("&apos;"),
-            _ => out.push(c),
+            c if is_xml_char(c) => out.push(c),
+            // DROPPED, not escaped. There is no escape for these: `&#1;` is
+            // just as illegal as a literal U+0001, so a numeric entity would
+            // fail identically. See [`is_xml_char`] for why they get this far.
+            _ => {}
         }
     }
     out
+}
+
+/// Whether a character may appear in an XML 1.0 document at all.
+///
+/// Escaping the five metacharacters is not sufficient on its own. XML 1.0 §2.2
+/// forbids most C0 control characters OUTRIGHT - there is no representation for
+/// them, escaped or otherwise - and `XmlDocument::LoadXml` rejects the whole
+/// document if one appears. That failure looks exactly like the `&` case this
+/// module already guards: **the toast silently never shows**, on a machine no
+/// one can attach a debugger to.
+///
+/// It is reachable because toast text is assembled from the user's own data.
+/// Task titles and worklog bodies come from tracker APIs, editor buffers and
+/// pasted terminal output, all of which carry stray control bytes often enough
+/// to matter - a `\u{1}` in a Jira summary is not exotic, it is what a bad
+/// copy-paste leaves behind.
+///
+/// Tab, newline and carriage return ARE legal and are kept: Windows renders a
+/// newline inside a `<text>` element, and stripping them would reflow a body
+/// the daemon deliberately laid out.
+fn is_xml_char(c: char) -> bool {
+    matches!(c,
+        '\u{9}' | '\u{A}' | '\u{D}'
+        | '\u{20}'..='\u{D7FF}'
+        | '\u{E000}'..='\u{FFFD}'
+        | '\u{10000}'..='\u{10FFFF}')
 }
 
 #[cfg(test)]
@@ -293,6 +323,54 @@ mod tests {
         assert!(xml.contains(r#"arguments="a&amp;b""#), "{xml}");
         // Nothing raw survives past the markup we intended.
         assert!(!xml.contains("R&D"), "{xml}");
+    }
+
+    /// The SAME invisible failure as the `&` case above, from the half of it
+    /// escaping cannot reach.
+    ///
+    /// XML 1.0 has no representation for most C0 controls - `&#1;` is as
+    /// illegal as a literal `\u{1}` - so `LoadXml` rejects the document and the
+    /// toast silently never shows. They arrive with the user's own text: a
+    /// title pasted out of a terminal or returned by a tracker API carries
+    /// stray control bytes often enough to matter.
+    #[test]
+    fn control_characters_cannot_reach_the_document() {
+        let xml = build_toast_xml(
+            "ship \u{1}it\u{7}",
+            "log \u{1b}[31mred\u{1b}[0m",
+            &[plain("go\u{c}", "Do \u{b}it")],
+        );
+        for bad in ['\u{1}', '\u{7}', '\u{b}', '\u{c}', '\u{1b}'] {
+            assert!(!xml.contains(bad), "{bad:?} survived into {xml}");
+        }
+        // Dropped, not mangled into an entity that would fail identically.
+        assert!(!xml.contains("&#"), "{xml}");
+        // The readable text is intact around the hole.
+        assert!(xml.contains("<text>ship it</text>"), "{xml}");
+        assert!(xml.contains(r#"content="Do it""#), "{xml}");
+        assert!(xml.contains(r#"arguments="go""#), "{xml}");
+    }
+
+    /// Tab, newline and carriage return are LEGAL XML and must survive.
+    ///
+    /// Windows renders a newline inside `<text>`, and the daemon lays some
+    /// bodies out deliberately - stripping every control character wholesale
+    /// would reflow them, which is a real regression traded for a fix.
+    #[test]
+    fn the_three_legal_whitespace_controls_survive() {
+        let xml = build_toast_xml("t", "one\ntwo\tthree\r", &[]);
+        assert!(xml.contains("one\ntwo\tthree\r"), "{xml:?}");
+    }
+
+    /// Above the BMP, so the surrogate-range hole in [`is_xml_char`] is
+    /// expressed as a range check rather than as an accidental cut-off. An
+    /// emoji in a task title is ordinary, and dropping it would be a visible
+    /// bug introduced by the fix for an invisible one.
+    #[test]
+    fn astral_characters_are_not_collateral() {
+        let xml = build_toast_xml("done 🎉", "café 日本語", &[]);
+        assert!(xml.contains("done 🎉"), "{xml}");
+        assert!(xml.contains("café 日本語"), "{xml}");
     }
 
     /// The row's own column wins when it has content; the category registry

--- a/tray/src/app.js
+++ b/tray/src/app.js
@@ -491,7 +491,7 @@ if (document.fonts && document.fonts.ready) {
 // listener lives here: each event is forwarded to record_notification_response,
 // which stamps the answer on the outbox row (the daemon's response consumer
 // acts on it) and opens the dashboard for foreground answers.
-function armNotificationActions() {
+async function armNotificationActions() {
   try {
     const ch = new __TAURI__.core.Channel()
     ch.onmessage = (msg) => {
@@ -520,9 +520,16 @@ function armNotificationActions() {
     //   - Windows never registers this listener, because its toasts are WinRT
     //     (tray/src-tauri/src/win_toast.rs) and their handlers record answers
     //     in Rust without a webview hop.
-    invoke('plugin:notifications|register_listener', { event: 'actionPerformed', handler: ch })
-      .then(() => dbg('notification action listener registered'))
-      .catch(() => dbg('notification action listener not registered (dev run, or Windows/WinRT)'))
+    // Nested, so the two outcomes stay distinguishable. The outer catch is for
+    // the channel construction above - a genuine defect. This one is for the
+    // two expected non-failures listed above, which are not errors and must not
+    // be reported as one.
+    try {
+      await invoke('plugin:notifications|register_listener', { event: 'actionPerformed', handler: ch })
+      dbg('notification action listener registered')
+    } catch {
+      dbg('notification action listener not registered (dev run, or Windows/WinRT)')
+    }
   } catch (e) { dbg(`notification listener threw: ${e}`) }
 }
 
@@ -556,7 +563,13 @@ function startLivePopover() {
   invoke('get_status').then((s) => { render(s); resizeToContent() }).catch(() => {})
   checkUpdate()
   loadAppInfo()
-  armNotificationActions()
+  // Fire-and-forget, like every other call in here: nothing in the popover's
+  // startup depends on the listener being armed, and awaiting it would hold the
+  // first render behind an IPC round-trip. `armNotificationActions` handles all
+  // of its own failures, so the rejection this catch guards is one that cannot
+  // happen - it is here so a future edit that lets one escape does not surface
+  // as an unhandled rejection in a webview with no console open.
+  armNotificationActions().catch((e) => dbg(`notification listener threw: ${e}`))
 }
 
 function applyAuthGate(signedIn) {

--- a/ui/__tests__/setup-resume-progress.test.ts
+++ b/ui/__tests__/setup-resume-progress.test.ts
@@ -20,6 +20,7 @@
 import { describe, it, expect } from 'bun:test'
 import { readFileSync } from 'fs'
 import { join } from 'path'
+import { buildSteps, resumeIndex } from '@/app/setup/steps'
 
 const page = readFileSync(join(import.meta.dir, '..', 'app', 'setup', 'page.tsx'), 'utf8')
 
@@ -27,8 +28,8 @@ describe('the setup wizard resumes where it left off', () => {
   it('stores the step ID, not its index', () => {
     expect(page).toContain('JSON.stringify({ stepId })')
     // Restoring resolves that id back to a position in the CURRENT list.
-    expect(page).toContain('steps.findIndex((s) => s.id === savedStepId)')
-    // An id that no longer exists starts from the top rather than guessing.
+    expect(page).toContain('resumeIndex(steps, savedStepId)')
+    // An id with no position to resume to starts from the top rather than guessing.
     expect(page).toMatch(/if \(at < 0\) return/)
   })
 
@@ -61,5 +62,50 @@ describe('the setup wizard resumes where it left off', () => {
     const guarded = page.match(/try \{[^}]*localStorage\.(getItem|setItem|removeItem)/g) ?? []
     expect(touches.length).toBeGreaterThan(0)
     expect(guarded.length).toBe(touches.length)
+  })
+})
+
+// A step that this build DROPS is not the same as a step it does not know, and
+// `findIndex` alone could not tell them apart. Windows drops the Alerts step
+// once notifications are granted - so the user who quits on that step, goes and
+// grants notifications, and comes back is exactly the person whose saved
+// position stopped resolving. Sending them to Welcome loses their place at the
+// one moment they did what the wizard asked.
+describe('resuming onto a step this run dropped', () => {
+  const winDropped = buildSteps('windows', true) // notifications already granted
+  const winFull = buildSteps('windows', false)
+  const mac = buildSteps('darwin', false)
+
+  it('the Alerts step really is dropped, or none of this is reachable', () => {
+    // Guards the premise. If buildSteps stops dropping it, these cases become
+    // vacuous rather than failing, and the whole block would quietly stop
+    // testing anything.
+    expect(winFull.some((s) => s.id === 'permissions')).toBe(true)
+    expect(winDropped.some((s) => s.id === 'permissions')).toBe(false)
+  })
+
+  it('resumes past the dropped step instead of restarting at Welcome', () => {
+    // -1 is the "stay on Welcome" signal in page.tsx. Anything >= 0 is a real
+    // position, which is the whole point.
+    expect(resumeIndex(winDropped, 'permissions')).toBeGreaterThanOrEqual(0)
+  })
+
+  it('and lands on the last step when nothing survives after it', () => {
+    // Permissions is last, so "the step after it" does not exist - the honest
+    // resume is the end of the wizard, whose footer offers Open Dashboard.
+    expect(resumeIndex(winDropped, 'permissions')).toBe(winDropped.length - 1)
+  })
+
+  it('still starts from the top for an id this build has never heard of', () => {
+    // The ORIGINAL behaviour, and the reason the id is stored rather than the
+    // index. A step removed in an older build has no position to infer.
+    expect(resumeIndex(mac, 'mlx-runtime')).toBe(-1)
+    expect(resumeIndex(mac, '')).toBe(-1)
+  })
+
+  it('and resolves a present step to its own position, unchanged', () => {
+    for (const steps of [mac, winFull, winDropped]) {
+      steps.forEach((s, i) => expect(resumeIndex(steps, s.id)).toBe(i))
+    }
   })
 })

--- a/ui/__tests__/tour-caption-clears-modal-body.test.ts
+++ b/ui/__tests__/tour-caption-clears-modal-body.test.ts
@@ -35,17 +35,36 @@ describe("the tour's narration bar does not cover a modal's body", () => {
     // Measured from the live element. A constant would be wrong for most beats:
     // the bar runs one to three lines depending on the caption, and `big`
     // changes its font and padding.
-    expect(src).toMatch(/sayRef\.current\?\.getBoundingClientRect\(\)/)
+    expect(src).toMatch(/el\.getBoundingClientRect\(\)/)
     expect(src).toContain('<div ref={sayRef}')
+  })
+
+  it('and keeps measuring it, rather than only on a caption change', () => {
+    // The caption is NOT the only thing that resizes this bar, and the other
+    // two do not touch a prop: a window narrower than the bar's max-width
+    // re-wraps the text on a plain resize, and `choices` render inside the bar
+    // so a beat can add buttons under an unchanged caption. Keying the
+    // measurement off `[unanchored, caption, big]` published a value that then
+    // went stale until the next say() - and `ModalShell` holds a gap to that
+    // value, so stale is worse than absent.
+    const src = readSrc('components/tutorial/TutorialOverlay.tsx')
+    expect(src).toContain('new ResizeObserver(')
+    expect(src).toContain('ro.observe(el)')
+    expect(src).toContain('ro.disconnect()')
+    // The dependency list must NOT re-acquire the enumeration the observer
+    // exists to replace.
+    expect(src).toContain('}, [unanchored])')
   })
 
   it('and withdraws it, so a stale value cannot outlive the bar', () => {
     const src = readSrc('components/tutorial/TutorialOverlay.tsx')
-    // Twice: the not-showing branch, and the effect cleanup that covers unmount
-    // and every caption change. A published value that survives the tour would
-    // leave every modal in the app permanently padded.
-    const removals = src.split(`removeProperty('${VAR}')`).length - 1
-    expect(removals).toBeGreaterThanOrEqual(2)
+    // Two paths must withdraw it: the not-showing branch, and the effect
+    // cleanup that covers unmount and the bar going away. A published value
+    // that survives the tour would leave every modal in the app permanently
+    // padded, on a screen with no tour running to explain the gap.
+    expect(src).toContain(`const clear = () => root.style.removeProperty('${VAR}')`)
+    const withdrawals = src.split('clear()').length - 1
+    expect(withdrawals).toBeGreaterThanOrEqual(2)
   })
 
   it('ModalShell pads BOTH body branches past it', () => {

--- a/ui/__tests__/worklog-needs-ai.test.ts
+++ b/ui/__tests__/worklog-needs-ai.test.ts
@@ -65,7 +65,15 @@ describe('the walkthrough does not demo a draft the user cannot get', () => {
     // a beat ringing `wl-generate` still has something to ring.
     const at = dialog.indexOf('const attemptGenerate')
     expect(at).toBeGreaterThan(-1)
-    const fn = dialog.slice(at, dialog.indexOf('\n  }', at))
+    // Both ends asserted before anything is read out of the slice. `\n  }` is a
+    // heuristic for where the function closes, and a heuristic that silently
+    // misses turns `slice(at, -1)` into most of the file - which would make the
+    // negative assertion below fire on an `if (isDemo)` belonging to some other
+    // function. A negative assertion over an unverified range is the one shape
+    // that can pass while testing nothing, so the range is checked first.
+    const end = dialog.indexOf('\n  }', at)
+    expect(end).toBeGreaterThan(at)
+    const fn = dialog.slice(at, end)
     expect(fn).not.toMatch(/if \(isDemo\)/)
     expect(fn).toContain("load<HealthStatus>('/api/health', 'get_health')")
     expect(fn).toContain('llm_provider_ok === false')

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -11,7 +11,7 @@
 import { useState, useEffect, useLayoutEffect, useMemo, useCallback, useRef } from 'react'
 import type { ReactNode } from 'react'
 import { invoke, load, mutate, nudgeWindowRepaint, tauri } from '@/lib/bridge'
-import { buildSteps, Welcome } from './steps'
+import { buildSteps, resumeIndex, Welcome } from './steps'
 import type { Wiz } from './steps'
 import type { NotifState } from './data'
 import type { IntegrationsResponse } from '@/lib/api-types'
@@ -92,8 +92,10 @@ export default function SetupWizard() {
   // The step's ID is what gets stored, never its index. `buildSteps` is
   // platform-dependent and the list can change between builds, so an index is
   // only meaningful against the exact list that produced it - restoring `2`
-  // could land on a different step entirely, silently. An id that no longer
-  // exists simply fails to match and starts from the top.
+  // could land on a different step entirely, silently. An id this build has
+  // never heard of starts from the top; an id it knows but has DROPPED (the
+  // Windows Alerts step, once notifications are granted) resumes past it
+  // rather than throwing the position away - see `resumeIndex`.
   //
   // Restore is gated on `platform` having resolved, which preserves the
   // invariant the Welcome screen exists to hold (see `platform` above): the
@@ -113,7 +115,7 @@ export default function SetupWizard() {
       savedStepId = raw ? (JSON.parse(raw) as { stepId?: string }).stepId ?? null : null
     } catch { return /* private mode, or a hand-mangled value - start fresh */ }
     if (!savedStepId) return
-    const at = steps.findIndex((s) => s.id === savedStepId)
+    const at = resumeIndex(steps, savedStepId)
     if (at < 0) return
     setWelcome(false)
     setStep(at)

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -626,3 +626,40 @@ export function buildSteps(platform: string | null, notificationsGranted: boolea
     : ALL_STEPS
   return steps.map((s, i) => ({ ...s, n: String(i + 1).padStart(2, '0') }))
 }
+
+/** Resolve a saved step ID back to a position in the CURRENT step list.
+ *
+ *  `-1` means "no position to resume to" - the caller stays on Welcome.
+ *
+ *  A plain `findIndex` is right for the case the stored ID was designed
+ *  against: the list changes shape between BUILDS, an ID from an older one
+ *  matches nothing, and starting from the top is the honest answer because we
+ *  cannot know where that step used to sit.
+ *
+ *  It is wrong for the case `buildSteps` introduced. On Windows the Alerts step
+ *  is dropped when notifications are already granted - so a user who quits ON
+ *  that step, grants notifications in Windows Settings, and comes back has a
+ *  saved ID that names a step this build knows perfectly well and has simply
+ *  finished with. `findIndex` returns -1 for that too, and the wizard restarts
+ *  at Welcome: the one flow whose entire purpose is not to lose your place,
+ *  losing it at the exact moment the user did the thing it asked for.
+ *
+ *  So a KNOWN id that is absent resumes at the first surviving step after it -
+ *  which is what "you finished that one" means - and falls back to the last
+ *  step when nothing survives it, because a wizard with every remaining step
+ *  behind you is one whose footer should read Open Dashboard. An id this build
+ *  has never heard of keeps the old behaviour exactly. */
+export function resumeIndex(steps: StepMeta[], savedStepId: string): number {
+  if (steps.length === 0) return -1
+  const at = steps.findIndex((s) => s.id === savedStepId)
+  if (at >= 0) return at
+  // Search the FULL list, not the built one - that is the difference between
+  // "dropped from this run" and "never existed".
+  const wasAt = ALL_STEPS.findIndex((s) => s.id === savedStepId)
+  if (wasAt < 0) return -1
+  for (let i = wasAt + 1; i < ALL_STEPS.length; i++) {
+    const next = steps.findIndex((s) => s.id === ALL_STEPS[i].id)
+    if (next >= 0) return next
+  }
+  return steps.length - 1
+}

--- a/ui/components/tutorial/TutorialOverlay.tsx
+++ b/ui/components/tutorial/TutorialOverlay.tsx
@@ -252,27 +252,43 @@ export function TutorialOverlay({ caption, centered, big, celebrate, cursorAt, c
   //
   // Measured, not derived: the bar is one to three lines depending on the beat,
   // and `big` changes its font and padding, so a constant would be wrong for
-  // most captions. Re-measured on every caption change because that is the only
-  // thing that resizes it.
+  // most captions.
+  //
+  // OBSERVED rather than re-measured on a dependency list, because the caption
+  // is not the only thing that changes this height and the other two are the
+  // easy ones to forget. The bar is capped at `maxWidth: big ? 760 : 540`, so a
+  // window narrower than that re-wraps the text on a resize with no prop
+  // changing at all; and `choices` render INSIDE this bar, so a beat that adds
+  // buttons under an unchanged caption grows it too. Either way the published
+  // value would stay stale until the next `say()` - and a stale value is worse
+  // than none, because `ModalShell` pads to it and would hold a gap that no
+  // longer matches anything on screen. A `ResizeObserver` covers all three
+  // sources and the first measurement, so nothing has to be enumerated.
   const sayRef = useRef<HTMLDivElement | null>(null)
   useEffect(() => {
     const root = document.documentElement
-    if (!unanchored) {
-      root.style.removeProperty('--mer-tour-say-bottom')
+    const clear = () => root.style.removeProperty('--mer-tour-say-bottom')
+    const el = sayRef.current
+    if (!unanchored || !el) {
+      clear()
       return
     }
-    // After paint, so the bubble has its final height. The tour is the only
-    // writer of this property, so a stale value cannot outlive it - the cleanup
-    // below runs on unmount and on every caption change.
-    const id = requestAnimationFrame(() => {
-      const box = sayRef.current?.getBoundingClientRect()
-      if (box) root.style.setProperty('--mer-tour-say-bottom', `${Math.round(box.bottom)}px`)
-    })
-    return () => {
-      cancelAnimationFrame(id)
-      root.style.removeProperty('--mer-tour-say-bottom')
+    // `bottom`, not `height`: the property names where the bar ENDS in the
+    // viewport, which is what a modal has to clear. The bar's top is fixed by
+    // CSS, so a size change is the only thing that can move it.
+    const publish = () => {
+      const box = el.getBoundingClientRect()
+      root.style.setProperty('--mer-tour-say-bottom', `${Math.round(box.bottom)}px`)
     }
-  }, [unanchored, caption, big])
+    const ro = new ResizeObserver(publish)
+    ro.observe(el) // fires once immediately, so this is also the initial read
+    return () => {
+      ro.disconnect()
+      // The tour is the only writer of this property, so clearing on the way
+      // out is what stops a finished walkthrough leaving every modal padded.
+      clear()
+    }
+  }, [unanchored])
 
   return (
     <div className="fixed inset-0" style={{ zIndex: 9000, pointerEvents: 'none' }}>

--- a/ui/components/tutorial/useTutorial.tsx
+++ b/ui/components/tutorial/useTutorial.tsx
@@ -446,8 +446,19 @@ export function useTutorial(opts: {
       },
       type: async (sel, text) => {
         const sig = signal()
-        const el = await waitForElement(sel, sig) as HTMLInputElement | HTMLTextAreaElement | null
+        const el = await waitForElement(sel, sig)
         if (!el) return false
+        // NARROWED, not cast. A cast here was unchecked, and the failure it let
+        // through was not a wrong value - it was a `TypeError` out of
+        // `setValue.call` below when the selector resolved to something that is
+        // not a field. That throw is not `Aborted`, so it unwinds past
+        // `runScript` and the catch there tears the ENTIRE walkthrough down over
+        // one mistargeted beat. Every sibling primitive returns `false` for a
+        // target it cannot operate, which is also what `Stage.type` promises in
+        // engine.ts; this restores that contract and removes the cast at once.
+        if (!(el instanceof HTMLInputElement) && !(el instanceof HTMLTextAreaElement)) {
+          return false
+        }
         // THE NATIVE SETTER, not `el.value =`. React tracks the last value it
         // rendered and compares against the DOM node's own property; a plain
         // assignment updates neither its tracker nor its state, so the character


### PR DESCRIPTION
Review fixes for the 1.87.0 release PR (#777), plus the What's New backfill flagged there. Merging this into `pre-main` updates #777 in place.

## Two real defects, both in the install/watchdog interlock #771 added

These are the ones worth reading. Both shipped green - neither is reachable from a macOS test run.

### `refresh.rs` deleted the recovery attempt instead of deferring it

The staging gate suppressed `attempt_restart` and `notify_down` but left the failure **counted**. Every action keys off `consecutive_health_failures == 2`, an edge consumed the moment it is passed: a tick that increments 1 → 2 and has its outputs masked leaves the counter at 2, so the next failure reaches 3 and the edge never returns.

That is only academic if installs always work. They do not - `register_service` can report success on Windows while `/Run` **and** the fallback spawn quietly failed, which leaves a permanently down daemon that this loop had already spent its one recovery attempt on.

Now the suppression skips the **count**, so the episode is deferred rather than deleted: when the guard drops, a daemon that is genuinely down fails one tick, then another, and recovery fires on its normal edge ~60 s late. A *healthy* tick still takes the normal path mid-install - it must, or a `tray.daemon_quiet` notice raised before the install is stranded with nothing left to observe the recovery that clears it.

The gate also moved into `decide_health_notice`, which turned a source-scan into three driven tests.

### The watchdog's `Start` arm acted on a stale flag

`decide` is pure, so it judges a snapshot taken at the top of the tick. Between that and the `Start` arm the loop awaits a socket probe and - on exactly the path that reaches `Start` - forks a subprocess for the liveness check. An install beginning in that window started the daemon it had just killed.

Re-read at the last instant rather than taking `LIFECYCLE`: the mutex would serialise correctly but block the watchdog for the length of an install and queue a 5 s-budgeted `stop_for_quit` behind it - the tradeoff `begin_staging` already documents. Not airtight by design; `stop_running_daemon_before_stage`'s re-kill loop is the backstop for the residue, and the comment says so.

## The rest

| | |
|---|---|
| `toast_actions` | XML 1.0 forbids most C0 controls **outright**, so a stray `\u{1}` from a pasted task title made `LoadXml` reject the document and the toast silently never appeared - the same invisible failure `escape_xml` already guards for `&`, from the half escaping cannot reach. Dropped rather than escaped, because `&#1;` is equally illegal. Tab/LF/CR kept (legal, and the daemon lays some bodies out deliberately). |
| `setup` | A saved position on the Windows Alerts step stopped resolving once notifications were granted: `buildSteps` drops that step, and `findIndex` cannot tell "dropped from this run" from "never existed". The wizard restarted at Welcome at the exact moment the user did the thing it asked for. `resumeIndex` resumes past a known-but-dropped step; an unknown id keeps the old behaviour exactly. |
| `TutorialOverlay` | The published bar height went stale on a window resize (it re-wraps below its max-width) and when a beat added `choices`, neither of which changes a dependency. `ResizeObserver` covers both plus the initial read. Stale is worse than absent here - `ModalShell` holds a gap to whatever was last published. |
| `useTutorial` | `Stage.type` cast `waitForElement`'s result unchecked, so a mistargeted selector threw a `TypeError` out of `runScript` and the catch there tore the **whole walkthrough** down. Narrowed with `instanceof`, restoring the return-`false` contract every sibling primitive keeps. |
| `backend_install` | A span per `taskkill` with ERROR status on failure. The ship leg is error-only, so a WARN with no ERROR span arrives stripped of what you would need to act on it. |
| `notifications` | `apply_response` is where macOS and Windows converge and where a lost answer has to be diagnosed from telemetry alone; spanned with a `source` discriminator. `has_text`, never the reply - an inline reply is the user's own writing. |
| `app.js` | `async`/`await` for the listener registration. The nested catch is load-bearing: it keeps "expected non-failure" (dev run, or Windows/WinRT) distinct from a real one. |
| test fix | `worklog-needs-ai` asserted `not.toContain('if (isDemo)')` over a slice bounded by a heuristic. If the marker missed, the slice ran long and the negative assertion passed vacuously - the exact regression that file exists to catch. The end marker is now asserted before the slice is read. |

## Also here: the What's New backfill

`whats-new.json` was at 1.84.0 - **1.85.0 and 1.86.0 both shipped without an entry**, so anyone updating from 1.84.0 opened a modal that stopped two releases short of what they had installed. Written from each CHANGELOG section in user terms; commit-level entries with no user-visible effect are left out rather than translated. 1.87.0's entry is in the first commit of this branch.

## Declined, with reasons

- **Pin every GitHub Action to a commit SHA** (2 findings, 20 sites). Legitimate supply-chain hardening, but repo-wide work on workflows this release does not touch - doing it inside a release PR means the release rides on 20 unrelated edits to the pipeline that builds it. Worth its own PR.
- **Remove the 1.86.0 CHANGELOG section.** It is already on `main`. GitHub picked the older of two merge bases for #777, so that section shows as added when it is not - see the callout at the top of #777.
- **Rename `BODY_TOP` / `TOUR_BODY_PAD` to camelCase.** Module-level consts in `ui/components` are SCREAMING_CASE throughout (`PROBE_MIN_VISIBLE_MS`, `SHELL_LESS_ROUTES`, `OAUTH_DEADLINE_MS`); renaming two would make the file inconsistent with its neighbours rather than more consistent.

## Verification

`cargo test --workspace` 954 pass · `cargo clippy --workspace --all-targets -D warnings` clean · `bun test` 807 pass.

Each fix was mutation-tested - the fix reverted, the test confirmed red, then restored. The two Rust interlock fixes and the resume fix were verified this way individually.

**Still not verified:** the Windows halves compile only on Windows CI. `kill_pids`'s new span was type-checked against `x86_64-pc-windows-msvc` in isolation, but the WinRT and toast paths get their first real compile on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added release notes covering recent improvements to notifications, onboarding, privacy, reliability, and work logs.
  - Setup now resumes correctly when platform-specific steps change, with clearer “Open Dashboard” completion action.
  - Tutorial overlays adapt smoothly to changing narration and choice content.
- **Bug Fixes**
  - Prevented health checks and service starts from interfering with installations in progress.
  - Improved notification action handling and error recovery.
  - Prevented invalid characters and non-form tutorial targets from causing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->