### PR TITLE
fix(summary): re-read the worklog badges after a draft is acted on

### DIFF
--- a/ui/__tests__/summary-draft-badges-refresh.test.ts
+++ b/ui/__tests__/summary-draft-badges-refresh.test.ts
@@ -1,0 +1,97 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// Guards that the daily summary's worklog badges are re-read after the user acts on
+// one, rather than staying frozen at whatever they were when the overlay opened.
+//
+// THE BUG: `DaySummaryOverlay` read `get_day_draft_states` exactly once, inside the
+// day-change effect, and never again for the life of the overlay. Every path that
+// CHANGES a draft's state - approve, post, dismiss, retarget - lives in
+// `SummaryTaskView`, which the summary opens over itself and then returns from. So
+// the user opened a row, posted the update, came back, and the row they had just
+// filed still read DRAFT READY TO POST, in the loud accent treatment reserved for
+// "this needs you". Posting three rows left three rows still shouting.
+//
+// Measured on a real DB while it was happening: `day_task_worklogs` had flipped to
+// `posted` for the rows in question. The write was never the problem - the screen
+// simply never asked again. And because the tint and the `›` chevron key off the
+// same badge, the whole list still looked like a queue of outstanding work.
+//
+// TWO EXIT PATHS, not one. The task view is left by its own Back button AND by
+// Escape (handled in the overlay's own key listener, which nulls `selected`
+// directly). A refresh hung off `onBack` alone would leave the Escape path exactly
+// as broken as before, which is why both must go through one helper.
+//
+// No React render harness in this repo (see summary-plan-row-drafts / plan-store),
+// so this is source-scanned: the assertions are about the wiring, which is the half
+// that was wrong.
+
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+
+const uiRoot = import.meta.dir + '/..'
+const src = readFileSync(uiRoot + '/components/summary/DaySummaryOverlay.tsx', 'utf8')
+
+/** The `refreshDrafts` definition - the single read site for the badge map. */
+function refreshDrafts(): string {
+  const at = src.indexOf('const refreshDrafts = useCallback(')
+  expect(at).toBeGreaterThan(-1)
+  const end = src.indexOf('\n  }, [', at)
+  expect(end).toBeGreaterThan(at)
+  return src.slice(at, end)
+}
+
+/** The `closeTask` definition - the single exit from the task view. */
+function closeTask(): string {
+  const at = src.indexOf('const closeTask = useCallback(')
+  expect(at).toBeGreaterThan(-1)
+  const end = src.indexOf('\n  }, [', at)
+  expect(end).toBeGreaterThan(at)
+  return src.slice(at, end)
+}
+
+/** The Escape key handler. */
+function escapeHandler(): string {
+  const at = src.indexOf('function onKey(')
+  expect(at).toBeGreaterThan(-1)
+  const end = src.indexOf('\n    }', at)
+  expect(end).toBeGreaterThan(at)
+  return src.slice(at, end)
+}
+
+describe('the badge map is re-read after the user acts on a draft', () => {
+  it('has one reusable read, not a read buried in the day effect', () => {
+    // THE REGRESSION: `load(... 'get_day_draft_states' ...)` appeared once, inside
+    // `Promise.allSettled` in the day-change effect, and nowhere else - so the only
+    // way to refresh the badges was to close the overlay and reopen it.
+    expect(refreshDrafts()).toContain("'get_day_draft_states'")
+  })
+
+  it('refuses to write one day\'s badges under another day\'s rows', () => {
+    // A slow read landing after the user paged days would otherwise repaint the new
+    // day's list with the old day's states. `dayRef` already exists for exactly this
+    // (the compose paths use it); the refresh has to honour it too.
+    expect(refreshDrafts()).toContain('dayRef.current')
+  })
+
+  it('is called when the task view is left', () => {
+    expect(closeTask()).toContain('refreshDrafts()')
+    expect(closeTask()).toContain('setSelected(null)')
+  })
+
+  it('routes the Back button through that same close', () => {
+    const at = src.indexOf('<SummaryTaskView')
+    expect(at).toBeGreaterThan(-1)
+    const end = src.indexOf('/>', at)
+    expect(end).toBeGreaterThan(at)
+    expect(src.slice(at, end)).toContain('onBack={closeTask}')
+  })
+
+  it('routes Escape through it too, rather than nulling `selected` itself', () => {
+    // The path that made a one-line `onBack` fix insufficient. Escape is a first-
+    // class way out of the task view and has to refresh for the same reason Back
+    // does - the user posted, then dismissed the view with the keyboard.
+    const body = escapeHandler()
+    expect(body).toContain('closeTask()')
+    expect(body).not.toContain('setSelected(null)')
+  })
+})

--- a/ui/__tests__/summary-draft-badges-refresh.test.ts
+++ b/ui/__tests__/summary-draft-badges-refresh.test.ts
@@ -73,6 +73,27 @@ describe('the badge map is re-read after the user acts on a draft', () => {
     expect(refreshDrafts()).toContain('dayRef.current')
   })
 
+  it('refuses to let an older refresh land on top of a newer one', () => {
+    // `dayRef` does NOT cover this: two refreshes for the SAME day can overlap (close
+    // a task, open another, act on it, close it - all faster than one read resolving),
+    // and nothing orders the responses. The older one landing last would restore
+    // exactly the badges the newer one just corrected - this file's own bug, through
+    // a different door.
+    const body = refreshDrafts()
+    expect(body).toContain('++draftRequest.current')
+    expect(body).toContain('req !== draftRequest.current')
+  })
+
+  it('keeps the badges it already has when a refresh read fails', () => {
+    // The opposite of the first-paint rule, deliberately. On a refresh there is
+    // already an answer on screen, so a failed read must leave it: blanking every
+    // badge would tell the user their drafts had vanished. Only the day effect - the
+    // FIRST answer for a day - is allowed to render badgeless.
+    const body = refreshDrafts()
+    expect(body).toContain('.catch(() => null)')
+    expect(body).toContain('if (rows) setDrafts(')
+  })
+
   it('is called when the task view is left', () => {
     expect(closeTask()).toContain('refreshDrafts()')
     expect(closeTask()).toContain('setSelected(null)')

--- a/ui/components/summary/DaySummaryOverlay.tsx
+++ b/ui/components/summary/DaySummaryOverlay.tsx
@@ -188,9 +188,18 @@ export function DaySummaryOverlay({ day, isToday, onShiftDay, onClose, onOpenSet
   // Guarded on `dayRef` for the same reason the compose paths are: the user can page
   // days while this is in flight, and one day's badges under another day's rows is a
   // worse answer than the stale ones.
+  //
+  // And guarded on a request number, which `dayRef` does NOT cover: two refreshes for
+  // the SAME day can be in flight at once (close a task, open another, act on it,
+  // close it - all faster than one DB read resolving), and nothing makes them resolve
+  // in the order they were sent. The older response landing last would restore exactly
+  // the badges the newer one had just corrected, which is the bug this file is fixing,
+  // reappearing through a different door.
+  const draftRequest = useRef(0)
   const refreshDrafts = useCallback(async () => {
+    const req = ++draftRequest.current
     const rows = await load<DayDraftState[]>(API, 'get_day_draft_states', { day }).catch(() => null)
-    if (dayRef.current !== day) return
+    if (dayRef.current !== day || req !== draftRequest.current) return
     // A failed read leaves the previous map alone rather than clearing every badge:
     // on a refresh we already have an answer, and last known beats none.
     if (rows) setDrafts(new Map(rows.map((r) => [r.task_id, r])))

--- a/ui/components/summary/DaySummaryOverlay.tsx
+++ b/ui/components/summary/DaySummaryOverlay.tsx
@@ -174,6 +174,36 @@ export function DaySummaryOverlay({ day, isToday, onShiftDay, onClose, onOpenSet
   // synchronously, before React has re-rendered.
   const composing = useRef(false)
 
+  // Re-read which rows still have a worklog waiting. Cheap (one local DB read, no
+  // model call), so it is worth doing on every return from the task view rather than
+  // trying to guess from the outcome which rows moved.
+  //
+  // THIS USED TO HAPPEN ONCE. The map was read inside the day-change effect and
+  // nowhere else, but every path that changes a draft's state - approve, post,
+  // dismiss, retarget - is in `SummaryTaskView`, which opens over this screen and
+  // returns to it. So the user posted an update, came back, and the row they had just
+  // filed still read DRAFT READY TO POST in the loud treatment reserved for work that
+  // needs them. The write was fine; the screen never asked again.
+  //
+  // Guarded on `dayRef` for the same reason the compose paths are: the user can page
+  // days while this is in flight, and one day's badges under another day's rows is a
+  // worse answer than the stale ones.
+  const refreshDrafts = useCallback(async () => {
+    const rows = await load<DayDraftState[]>(API, 'get_day_draft_states', { day }).catch(() => null)
+    if (dayRef.current !== day) return
+    // A failed read leaves the previous map alone rather than clearing every badge:
+    // on a refresh we already have an answer, and last known beats none.
+    if (rows) setDrafts(new Map(rows.map((r) => [r.task_id, r])))
+  }, [day])
+
+  // The one way out of the task view, because there are two ways INTO leaving it -
+  // the Back button and Escape - and only routing both through here keeps the
+  // keyboard path from being exactly as stale as the bug above.
+  const closeTask = useCallback(() => {
+    setSelected(null)
+    void refreshDrafts()
+  }, [refreshDrafts])
+
   // Escape closes, as it does on every other overlay here (ModalShell's own
   // convention). When the nested ticket-detail dialog is open, Escape backs out of
   // THAT first (it has no Escape handling of its own) rather than closing the whole
@@ -181,12 +211,12 @@ export function DaySummaryOverlay({ day, isToday, onShiftDay, onClose, onOpenSet
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (e.key !== 'Escape') return
-      if (selected) { setSelected(null); return }
+      if (selected) { closeTask(); return }
       onClose()
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [onClose, selected])
+  }, [onClose, selected, closeTask])
 
   // Recompose the prose only (Regenerate on an existing summary, and the quiet
   // staleness refresh). The deterministic ledger binds to whatever worklogs are
@@ -255,6 +285,12 @@ export function DaySummaryOverlay({ day, isToday, onShiftDay, onClose, onOpenSet
       // fetched alongside the rest rather than after, so the badges are on the rows in
       // the first paint - arriving late would move the list under someone reading it.
       // Failure is not fatal: no map means no badges, and the rows are still correct.
+      //
+      // Deliberately not `refreshDrafts()`, which is the same read with the opposite
+      // failure rule: this is the FIRST answer for a day, so a failure must leave the
+      // rows badgeless rather than showing the previous day's states, and it has to
+      // sit in this batch to land with everything else. The refresh already has an
+      // answer on screen and keeps it. One read, two honest behaviours.
       load<DayDraftState[]>(API, 'get_day_draft_states', { day }),
     ]).then(([s, d, t, w]) => {
       if (cancelled) return
@@ -395,7 +431,7 @@ export function DaySummaryOverlay({ day, isToday, onShiftDay, onClose, onOpenSet
             {selected ? (
               <SummaryTaskView
                 detail={selected}
-                onBack={() => setSelected(null)}
+                onBack={closeTask}
                 onOpenSettings={onOpenSettings}
                 onOpenTask={onOpenTask}
               />


### PR DESCRIPTION
## The bug

Post a worklog from a Today's Plan row, come back to the list, and the row you just
filed still reads **DRAFT READY TO POST** - in the loud accent treatment reserved for
"this needs you", with the tinted surface and the `›` chevron that go with it. Post
three and the list still looks like a queue of three outstanding drafts.

## What was actually wrong

`DaySummaryOverlay` read `get_day_draft_states` **exactly once**, inside the
day-change effect, and never again for the life of the overlay:

```ts
useEffect(() => {
  Promise.allSettled([ ..., load<DayDraftState[]>(API, 'get_day_draft_states', { day }) ])
    .then(([s, d, t, w]) => { ...; setDrafts(...) })
}, [day, generate])
```

But every path that **changes** a draft's state - approve, post, dismiss, retarget -
lives in `SummaryTaskView`, which the summary opens over itself and then returns from.
The overlay is not remounted on that round trip, so the badge map stayed frozen at
whatever it was when the overlay opened.

Closing and reopening the summary fixed it, which is the giveaway: a snapshot that is
never refreshed.

## Confirming it was the read, not the write

Checked against the live DB (read-only) while the screen was showing the wrong thing:

| task | state | drafted_minutes | updated |
|---|---|---|---|
| T1 | **posted** | 144 | 18:07:56 |
| T2 | **posted** | 94 | 18:07:37 |
| T3 | drafted | 109 | 12:38:37 |
| T6 | **posted** | 33 | 18:11:02 |
| T7 | **posted** | 61 | 18:08:19 |

`day_task_worklogs` had flipped to `posted` at the moment each was posted. The write
path is fine. The screen simply never asked again.

## The fix

**`refreshDrafts`** - the same read, extracted and reusable. Two details it carries:

- **Guarded on `dayRef`**, like `generate`/`generateNow` already are. The user can page
  days while it is in flight, and painting one day's badges under another day's rows is
  worse than leaving the stale ones.
- **Keeps the previous map on a failed read.** On a refresh there is already an answer
  on screen and last-known beats none. That is the *opposite* of the first-paint rule -
  where a failure must leave the rows badgeless rather than show a stale day - which is
  why the day effect deliberately keeps its own inline read instead of calling this. The
  comment there says so, so it does not read as an oversight later.

**`closeTask`** - the single exit from the task view. There are **two** ways out, and
this is the part a one-line `onBack` fix would have missed:

```ts
// before
if (selected) { setSelected(null); return }   // Escape, in the overlay's own key listener
onBack={() => setSelected(null)}              // the Back button
```

Escape is a first-class way to leave the task view - post, then dismiss with the
keyboard - and it nulled `selected` directly. Both now route through `closeTask`.

## Tests

`ui/__tests__/summary-draft-badges-refresh.test.ts` - written first, **failed 5/5**
before the fix. Source-scanned, like its sibling `summary-plan-row-drafts.test.ts`:
there is no React render harness in this repo, and the wiring is the half that was
wrong. It pins the reusable read, the `dayRef` guard, and *both* exit paths - including
`expect(escapeHandler()).not.toContain('setSelected(null)')`, so the keyboard path
cannot quietly regress back to the direct call.

- `bun test` - **831 pass / 0 fail** (58 files)
- `tsc --noEmit` - clean

## Scope

One component and one new test file. No Rust, no schema, no reader changes - the
backend was already returning the right answer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Draft badges now refresh when closing a task and returning to the day summary.
  - Back-button and Escape-key navigation now provide consistent task-closing behavior.
  - Initial draft-state loading and subsequent refreshes are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->