### PR TITLE
fix(tray): fail closed when the setup window's state cannot be read

### DIFF
--- a/tray/src-tauri/src/commands/system.rs
+++ b/tray/src-tauri/src/commands/system.rs
@@ -151,8 +151,15 @@ pub async fn resize_setup_window(
     // There's nothing to fix here anyway while full-screen — the card's own
     // `transform: scale(...)` in page.tsx already grows it to fill whatever
     // size the window actually is.
-    if win.is_fullscreen().unwrap_or(false) {
-        tracing::debug!("setup window is full-screen - resize skipped");
+    //
+    // `unwrap_or(TRUE)`, deliberately: the guards fail CLOSED. An errored query
+    // tells us nothing about the window, and the two outcomes are not
+    // symmetric - guessing "not full-screen" performs the very resize the
+    // guard exists to prevent, while guessing "full-screen" skips a resize
+    // that was never needed anyway (the card's `transform: scale(...)` fills
+    // whatever size the window is). Same reasoning on both guards below.
+    if win.is_fullscreen().unwrap_or(true) {
+        tracing::debug!("setup window is full-screen or unreadable - resize skipped");
         return Ok(());
     }
     // Same reasoning for a MAXIMIZED window, which is the shape the hazard
@@ -166,8 +173,8 @@ pub async fn resize_setup_window(
     // un-maximized itself. Nothing needs resizing while maximized anyway: the
     // card's own `transform: scale(...)` in page.tsx already fills whatever
     // size the window is.
-    if win.is_maximized().unwrap_or(false) {
-        tracing::debug!("setup window is maximized - resize skipped");
+    if win.is_maximized().unwrap_or(true) {
+        tracing::debug!("setup window is maximized or unreadable - resize skipped");
         return Ok(());
     }
     let resize = win
@@ -403,6 +410,56 @@ mod tests {
         assert!(!is_openable_url(""));
         // Multibyte content must not panic the scheme check.
         assert!(!is_openable_url("héllo→"));
+    }
+
+    /// `resize_setup_window`'s two skip-guards must fail CLOSED.
+    ///
+    /// They need a live window to exercise, so this is source-scanned - the
+    /// defect is in which way the `Result` collapses, which is visible in the
+    /// text and nowhere a unit test can reach.
+    ///
+    /// THE BUG: both guards read `.unwrap_or(false)`. A failed query therefore
+    /// meant "not maximized, not full-screen" and the resize went ahead - and
+    /// the resize IS the hazard the guards exist to prevent (on Win32,
+    /// `SetWindowPos` on a `WS_MAXIMIZE` window clears the maximized state, so
+    /// the wizard un-maximizes itself mid-step). Guessing wrong in that
+    /// direction costs the exact bug; guessing wrong the other way costs
+    /// nothing, because the card's own `transform: scale(...)` already fills
+    /// whatever size the window is. An unknown window state is not a licence
+    /// to resize it.
+    #[test]
+    fn the_resize_guards_fail_closed_when_the_window_state_is_unknown() {
+        // Truncated at the test module so this scan cannot match its own
+        // literals and pass forever (that trap has been hit here before).
+        let whole = include_str!("system.rs");
+        let src = &whole[..whole
+            .find("#[cfg(test)]")
+            .expect("system.rs lost its test module marker")];
+        let body = src
+            .split_once("pub async fn resize_setup_window(")
+            .expect("resize_setup_window is gone")
+            .1;
+        // Bounded at the function's closing brace. Scanning to end-of-file would
+        // drag in every later fn - `dismiss_popover`'s `is_visible().unwrap_or(false)`
+        // is next, and it gates only a debug log (the `hide()` runs either way), so a
+        // whole-file scan would fail on code that has no such hazard.
+        let body = &body[..body.find("\n}\n").expect("resize_setup_window has no end")];
+
+        for query in ["is_fullscreen()", "is_maximized()"] {
+            let at = body
+                .find(query)
+                .unwrap_or_else(|| panic!("the {query} guard is gone"));
+            let tail = &body[at..];
+            assert!(
+                tail.starts_with(&format!("{query}.unwrap_or(true)")),
+                "{query} must fail closed: an errored query has to skip the \
+                 resize, not perform the one action the guard exists to stop"
+            );
+        }
+        assert!(
+            !body.contains(".unwrap_or(false)"),
+            "a window-state query in resize_setup_window still fails open"
+        );
     }
 
     #[cfg(target_os = "windows")]

--- a/tray/src-tauri/src/reopen.rs
+++ b/tray/src-tauri/src/reopen.rs
@@ -199,8 +199,14 @@ mod reopen_tests {
     #[test]
     fn window_resizes_check_for_full_screen_first() {
         let src = include_str!("commands/system.rs");
+        // The QUERY is what this test is about - that something asks before it
+        // resizes. Which way the query's `Result` collapses is a separate
+        // question, owned by `system.rs`'s own
+        // `the_resize_guards_fail_closed_when_the_window_state_is_unknown`;
+        // pinning the whole expression here meant this test failed when that
+        // one was fixed, on a change it has no stake in.
         assert!(
-            src.contains("win.is_fullscreen().unwrap_or(false)"),
+            src.contains("win.is_fullscreen()"),
             "resize_setup_window lost its full-screen guard - a setContentSize: \
              against a full-screen style mask renders black around the content"
         );


### PR DESCRIPTION
Closes a CodeRabbit finding from #777 (*"Fail closed when window-state queries fail"*, Major) that was left unresolved when that PR was cut. Raising it here rather than letting it lapse.

## The problem

`resize_setup_window` skips the resize while the wizard window is full-screen or maximized, because **resizing in either state is the hazard** - on Win32, `SetWindowPos` on a `WS_MAXIMIZE` window clears the maximized state, so the window visibly un-maximized itself when the user pressed Continue mid-wizard.

Both guards read `.unwrap_or(false)`:

```rust
if win.is_fullscreen().unwrap_or(false) { ... return Ok(()); }
if win.is_maximized().unwrap_or(false) { ... return Ok(()); }
```

So a query that **errored** was treated as "neither full-screen nor maximized" and the resize went ahead - performing the exact action the guards exist to prevent, in the one situation where we have no idea what the window is doing.

## Why fail-closed is free here

The two wrong guesses are not symmetric:

- Guessing **"not maximized"** when it is → the bug, in full.
- Guessing **"maximized"** when it isn't → nothing. The card's own `transform: scale(...)` in `ui/app/setup/page.tsx` already grows it to fill whatever size the window actually is. That is *why* both guards can `return Ok(())` instead of erroring.

An unknown window state is not a licence to resize it. Both guards now read `.unwrap_or(true)`, and the debug lines say "or unreadable" so the skipped-because-errored case is distinguishable in a trace from the skipped-because-maximized one.

## Test

Source-scanned - the guards need a live window, and the defect is in *which way the `Result` collapses*, which no unit test can reach. Two things keep the scan honest:

- **Truncated at `#[cfg(test)]`**, so it cannot match its own literals and pass forever. (That trap has been hit in this repo twice.)
- **Bounded at the function's closing brace**, so it does not drag in the next function - `dismiss_popover`'s `is_visible().unwrap_or(false)` gates only a debug log (the `hide()` runs either way) and is not the same hazard. Without the bound the test failed on innocent code.

Verified in **both** directions: red before the change, and red again when `is_maximized` is mutated back to `unwrap_or(false)`.

## Gates

- `cargo fmt --all --check` - clean
- `cargo clippy --workspace --all-targets -- -D warnings` - clean
- `cargo test --workspace` - **954 pass / 0 fail**

Two lines of behaviour change, one new test.

## One follow-on commit

`reopen.rs`'s `window_resizes_check_for_full_screen_first` pinned the whole expression - `win.is_fullscreen().unwrap_or(false)` - so fixing the unwrap broke a test with no stake in the question. Caught by the pre-push hook.

That test exists to protect that something **asks** before it resizes (the dashboard copies the pattern, which is why it lives in `reopen.rs`). *Which way the answer collapses* is the new test's claim. The needle is now the query alone, so the two tests hold two separate claims and neither fails on the other's change. Verified it still fails when the guard is removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window resizing safeguards when fullscreen or maximized state checks fail.
  * Prevented unintended resizing when the app cannot reliably determine the current window state.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->