### PR TITLE
fix(setup): size the permissions card to its content and unify the panes

### DIFF
--- a/ui/app/setup/atoms.tsx
+++ b/ui/app/setup/atoms.tsx
@@ -76,12 +76,15 @@ const MAC_PANE_COPY: Record<'accessibility' | 'screen' | 'notifications', { titl
     blurb: 'Allow the applications below to record the content of your screen.',
     others: ['Terminal', 'Google Chrome'],
   },
-  // Kept for the shape of the record, but macOS Notifications no longer renders
-  // through MacSettingsPanePreview - see MacNotificationsPanePreview for why the
-  // app-list layout was the wrong pane entirely.
+  // Notifications does NOT render through MacSettingsPanePreview (see
+  // MacNotificationsPanePreview for why the app-list layout was the wrong pane
+  // entirely) - but it does share `MacPaneChrome`, so its title/blurb still
+  // live here rather than being inlined in the one component that reads them.
+  // The blurb is the per-app page's framing, not the list's, because that is
+  // the page this preview reconstructs.
   notifications: {
     title: 'Notifications',
-    blurb: 'Allow the applications below to send notifications.',
+    blurb: 'Choose how Meridian sends you notifications.',
     others: ['Terminal', 'Google Chrome'],
   },
 }
@@ -93,6 +96,62 @@ function MacToggleOn() {
     }}>
       <span style={{ width: 15, height: 15, borderRadius: 99, background: '#fff', boxShadow: '0 1px 2px rgba(0,0,0,.25)' }} />
     </span>
+  )
+}
+
+/** The window chrome every reconstructed macOS pane shares - the white sheet,
+ *  the back/forward chevrons, the pane title, and the blurb under it. Whatever
+ *  the pane's own body is goes in `children`, filling the remaining height.
+ *
+ *  It exists because the three cards sit side by side and the eye reads them as
+ *  one row: any difference in where the title ends or the blurb starts shows up
+ *  as three misaligned pictures rather than three states of the same picture.
+ *  Two things used to break that alignment, and both are fixed HERE so no pane
+ *  can drift again:
+ *
+ *  1. `Screen & System Audio Recording` wraps to two lines at this width while
+ *     `Accessibility` does not, so every row below it sat a line lower in that
+ *     one card. The title box therefore reserves TWO lines in every pane
+ *     (`minHeight`), centred, so a one-line title simply has air above and
+ *     below it instead of pulling the pane up.
+ *  2. The blurb is one line in some panes and two in others - same fix, same
+ *     reason.
+ *
+ *  Reserving space rather than truncating is deliberate: these are real macOS
+ *  strings and an ellipsis in the middle of `Screen & System Audio…` would make
+ *  the pane harder to recognise, which is the entire job of the picture. */
+function MacPaneChrome({ title, blurb, children }: {
+  title: string; blurb: string; children: ReactNode
+}) {
+  return (
+    <div className="w-full flex flex-col" style={{
+      height: '100%', borderRadius: 10, overflow: 'hidden',
+      border: '0.5px solid var(--t-card-border)', background: '#fff',
+    }}>
+      <div className="flex items-center shrink-0" style={{ gap: 7, padding: '6px 10px', background: '#F0F0F1' }}>
+        <span style={{
+          width: 16, height: 16, borderRadius: 99, background: '#fff', border: '0.5px solid #d2d2d7',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 10, color: '#1d1d1f', lineHeight: 1,
+        }}>‹</span>
+        <span style={{
+          width: 16, height: 16, borderRadius: 99, background: '#fff', border: '0.5px solid #e5e5e7',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 10, color: '#c7c7cc', lineHeight: 1,
+        }}>›</span>
+        <span className="flex items-center" style={{
+          flex: 1, minWidth: 0, marginLeft: 2, minHeight: 32,
+          fontSize: 12.5, lineHeight: 1.25, fontWeight: 700, color: '#1d1d1f',
+        }}>{title}</span>
+      </div>
+
+      {/* Both reserved heights are BORDER-BOX (the global preflight sets
+         `box-sizing: border-box`), so they include the padding: 2 lines of
+         10.5px/1.35 is ~28.4px, plus 9px of vertical padding. */}
+      <p className="shrink-0 flex items-start" style={{
+        minHeight: 38, fontSize: 10.5, lineHeight: 1.35, color: '#48484a', padding: '5px 10px 4px',
+      }}>{blurb}</p>
+
+      {children}
+    </div>
   )
 }
 
@@ -118,24 +177,7 @@ function MacToggleOn() {
 function MacSettingsPanePreview({ permissionId }: { permissionId: 'accessibility' | 'screen' }) {
   const copy = MAC_PANE_COPY[permissionId]
   return (
-    <div className="w-full flex flex-col" style={{
-      height: '100%', borderRadius: 10, overflow: 'hidden',
-      border: '0.5px solid var(--t-card-border)', background: '#fff',
-    }}>
-      <div className="flex items-center shrink-0" style={{ gap: 7, padding: '6px 10px', background: '#F0F0F1' }}>
-        <span style={{
-          width: 16, height: 16, borderRadius: 99, background: '#fff', border: '0.5px solid #d2d2d7',
-          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 10, color: '#1d1d1f', lineHeight: 1,
-        }}>‹</span>
-        <span style={{
-          width: 16, height: 16, borderRadius: 99, background: '#fff', border: '0.5px solid #e5e5e7',
-          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 10, color: '#c7c7cc', lineHeight: 1,
-        }}>›</span>
-        <span style={{ fontSize: 12.5, fontWeight: 700, color: '#1d1d1f', marginLeft: 2 }}>{copy.title}</span>
-      </div>
-
-      <p className="shrink-0" style={{ fontSize: 10.5, lineHeight: 1.35, color: '#48484a', padding: '5px 10px 4px' }}>{copy.blurb}</p>
-
+    <MacPaneChrome title={copy.title} blurb={copy.blurb}>
       <div className="flex flex-col" style={{ flex: 1, margin: '2px 8px 7px', borderRadius: 8, overflow: 'hidden', background: '#F0F0F1' }}>
         {copy.others.map((name) => (
           <div key={name} className="flex items-center shrink-0" style={{
@@ -172,7 +214,7 @@ function MacSettingsPanePreview({ permissionId }: { permissionId: 'accessibility
           }}>{glyph}</span>
         ))}
       </div>
-    </div>
+    </MacPaneChrome>
   )
 }
 
@@ -201,27 +243,18 @@ function MacNotificationsPanePreview() {
   // the real page. Labels are omitted at this size - they render as unreadable
   // 6px text - so these are shape only.
   const placements = ['Desktop', 'Notification Center', 'Lock Screen']
+  const copy = MAC_PANE_COPY.notifications
   return (
-    <div className="w-full flex flex-col" style={{
-      height: '100%', borderRadius: 10, overflow: 'hidden',
-      border: '0.5px solid var(--t-card-border)', background: '#fff',
-    }}>
-      <div className="flex items-center shrink-0" style={{ gap: 7, padding: '6px 10px', background: '#F0F0F1' }}>
-        <span style={{
-          width: 16, height: 16, borderRadius: 99, background: '#fff', border: '0.5px solid #d2d2d7',
-          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 10, color: '#1d1d1f', lineHeight: 1,
-        }}>‹</span>
-        <span style={{
-          width: 16, height: 16, borderRadius: 99, background: '#fff', border: '0.5px solid #e5e5e7',
-          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 10, color: '#c7c7cc', lineHeight: 1,
-        }}>›</span>
-      </div>
-
+    // Same chrome as the sibling pane - it used to draw its own header with no
+    // title at all, which made the third card read as a different KIND of
+    // picture from the two beside it rather than the same picture of a
+    // different pane.
+    <MacPaneChrome title={copy.title} blurb={copy.blurb}>
       {/* THE control. Same sharp + accent-tinted treatment the sibling pane
          gives its Meridian row, for the same reason: it is the one thing on
          this picture the user has to act on. */}
       <div className="flex items-center shrink-0" style={{
-        gap: 9, margin: '6px 8px 0', padding: '7px 10px', borderRadius: 8,
+        gap: 9, margin: '2px 8px 0', padding: '7px 10px', borderRadius: 8,
         background: 'color-mix(in srgb, var(--t-accent) 11%, #fff)',
         boxShadow: 'inset 0 0 0 1.5px color-mix(in srgb, var(--t-accent) 50%, transparent)',
       }}>
@@ -264,7 +297,7 @@ function MacNotificationsPanePreview() {
           </div>
         ))}
       </div>
-    </div>
+    </MacPaneChrome>
   )
 }
 

--- a/ui/app/setup/page.tsx
+++ b/ui/app/setup/page.tsx
@@ -350,36 +350,40 @@ export default function SetupWizard() {
     tauri()?.window.getCurrentWindow().close()
   }
 
-  // Sign in is the one step that genuinely can't be pinned to a magic number
-  // (its content changes size - email phase vs. code phase vs. an error line
-  // appearing) and repeatedly guessing one (490 scrolled, 520 left whitespace,
-  // 512 as a compromise…) for Permissions already proved how brittle that is.
-  // So instead of another hardcoded height, the card measures its OWN actual
-  // rendered height on this step (`cardRef` + ResizeObserver below) and uses
-  // that - never a guess, and it re-measures live if the content inside it
-  // ever changes height.
+  // Sign in and Permissions both refuse to be pinned to a magic number. Sign in
+  // changes size as you move through it (email phase vs. code phase vs. an
+  // error line appearing); Permissions changes with the OS strings and with how
+  // its three panes wrap at the current width, and the guessing game there
+  // (490 scrolled, 520 left whitespace, 512 as a compromise that scrolled
+  // again) is exactly why it is measured now rather than guessed a fourth time.
+  // So on these steps the card is `height: auto`, measures its OWN rendered
+  // height (`cardRef` + ResizeObserver below), and the window follows it - the
+  // content is never the thing that has to fit, so there is nothing to scroll.
+  const autoSized = !welcome && (meta?.id === 'signin' || meta?.id === 'permissions')
   const isSignin = !welcome && meta?.id === 'signin'
   const cardRef = useRef<HTMLDivElement>(null)
-  const [signinHeight, setSigninHeight] = useState<number | null>(null)
+  const [measuredHeight, setMeasuredHeight] = useState<number | null>(null)
+  // Re-runs on every step change so a stale measurement from the previous
+  // auto-sized step can't size this one; `null` while unmeasured falls back to
+  // the neutral height below for the single frame before the observer fires.
   useLayoutEffect(() => {
-    if (!isSignin || !cardRef.current) return
+    setMeasuredHeight(null)
+    if (!autoSized || !cardRef.current) return
     const el = cardRef.current
     const observer = new ResizeObserver(([entry]) => {
-      setSigninHeight(Math.ceil(entry.contentRect.height))
+      setMeasuredHeight(Math.ceil(entry.contentRect.height))
     })
     observer.observe(el)
     return () => observer.disconnect()
-  }, [isSignin])
+  }, [autoSized, meta?.id])
 
-  // The card is a different fixed height depending on what's showing, each
-  // sized to that screen's actual content instead of one height shared by
-  // everything (which used to leave dead top/bottom whitespace on the
-  // shorter screens): Welcome (520, content only runs to ~372px), Sign in
-  // (measured live, see above), Permissions (512 - the true minimum sits
-  // somewhere between 490, which scrolled, and 520, which didn't; biased
-  // toward the known-safe end rather than re-clipping again), everything else
-  // (628, unchanged - Integrations/Intelligence all still need the room).
-  const cardHeight = welcome ? 520 : isSignin ? (signinHeight ?? 460) : meta?.id === 'permissions' ? 512 : 628
+  // The card is a different height depending on what's showing, each sized to
+  // that screen's actual content instead of one height shared by everything
+  // (which used to leave dead top/bottom whitespace on the shorter screens):
+  // Welcome (520, content only runs to ~372px), Sign in and Permissions
+  // (measured live, see above), everything else (628, unchanged -
+  // Integrations/Intelligence all still need the room).
+  const cardHeight = welcome ? 520 : autoSized ? (measuredHeight ?? 520) : 628
   // Height divisor scaled with the card (700 * cardHeight/628) to keep the
   // same ~26px margin ratio the window was sized for at any height.
   const heightDivisor = Math.round((700 * cardHeight) / 628)
@@ -418,7 +422,7 @@ export default function SetupWizard() {
       background: 'radial-gradient(130% 130% at 50% 0%, color-mix(in srgb, var(--t-card) 34%, var(--t-panel)) 0%, var(--t-panel) 62%)',
     }}>
       <div ref={cardRef} className="rise" style={{
-        width: 948, height: isSignin ? 'auto' : cardHeight, borderRadius: 18, background: 'var(--t-card)',
+        width: 948, height: autoSized ? 'auto' : cardHeight, borderRadius: 18, background: 'var(--t-card)',
         border: '0.5px solid var(--t-card-border)', overflow: 'hidden', color: 'var(--t-title)',
         boxShadow: 'var(--pop-shadow)',
         // Grow the whole card proportionally as the window grows (macOS
@@ -450,7 +454,12 @@ export default function SetupWizard() {
                 textWrap: 'pretty',
               }}>{meta.subtitle}</p>
             </div>
-            <div className="nice-scroll flex flex-col" style={{ flex: 1, overflowY: 'auto', padding: '4px 32px 22px' }}>
+            {/* Scrolls only on the FIXED-height steps. On an auto-sized step the
+               card already grew to whatever the body needs, so leaving this
+               `auto` would do nothing except let a sub-pixel rounding difference
+               between the measured height and the laid-out content produce a
+               1px scrollbar over content that fits. */}
+            <div className="nice-scroll flex flex-col" style={{ flex: 1, overflowY: autoSized ? 'visible' : 'auto', padding: '4px 32px 22px' }}>
               <meta.Body wiz={wiz} />
             </div>
             <Footer step={step} last={last} canNext={meta.canNext(wiz)} err={err}


### PR DESCRIPTION
## Problem

Two things on the setup wizard's Permissions step, both visible in one screenshot:

1. **The step scrolled.** The card was pinned to a hardcoded `512` px - the third guess after 490 (scrolled) and 520 (left whitespace) - so it clipped again as soon as the content grew.
2. **The three permission cards didn't look like each other.** `Screen & System Audio Recording` wraps to two lines where `Accessibility` doesn't, dropping that card's blurb, app list, and Meridian row a line below its neighbour; and the Notifications pane drew its own header with **no title at all**, just the two chevrons.

## Fix

**`page.tsx` - the card sizes itself.** Permissions joins Sign in on the measure-yourself path: `height: 'auto'`, a `ResizeObserver` reads the real rendered height, and `resize_setup_window` follows it. The content is never the thing that has to fit, so there is nothing to scroll and no fourth magic number to guess.

- The observer effect resets to `null` and re-runs on `meta?.id`, so a measurement from the previous auto-sized step can't size the next one.
- The body wrapper's `overflowY` is `visible` on auto-sized steps (was unconditionally `auto`) - otherwise a sub-pixel rounding difference between the measured height and the laid-out content can produce a 1px scrollbar over content that fits.

**`atoms.tsx` - one pane geometry.** Extracted `MacPaneChrome` (white sheet + chevrons + title + blurb); both previews render through it. The title box reserves **two lines** and the blurb reserves two lines in every pane, so a one-line title gets air above and below instead of pulling its pane up. Notifications gained its title plus a per-app-page blurb, living in `MAC_PANE_COPY` alongside the other two.

Reserving rather than truncating is deliberate: these are real macOS strings, and an ellipsis in the middle of `Screen & System Audio…` would make the pane harder to recognise - which is the entire job of the picture.

## Verification

- `npx tsc --noEmit` - clean for `app/` (the `__tests__` `bun:test`/`import.meta.dir` errors are pre-existing)
- `npm run build` - passes
- `bun test` - 859 pass, 0 fail
- pre-push suite (fmt, clippy, ui build, ui tests, cargo test, security audit) - all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)