### PR TITLE
fix(plan): make a failed tracker sync say why

### DIFF
--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -1444,10 +1444,21 @@ mod db_encryption_notice_tests {
     }
 }
 
-/// Debug bridge: lets the popover/tooltip JS forward `window.onerror` reports and
-/// the measured card height to the tray's stderr log, so GUI-only faults (a JS
-/// exception, a window/card size mismatch) are diagnosable without devtools. The
-/// injected `window` names the caller and exposes its actual size for comparison.
+/// Debug bridge: lets webview JS forward `window.onerror` reports and the measured
+/// card height to the tray's log, so GUI-only faults (a JS exception, a
+/// window/card size mismatch) are diagnosable without devtools. The injected
+/// `window` names the caller and exposes its actual size for comparison.
+///
+/// **A packaged build has no devtools at all** — there is no `devtools` feature or
+/// config anywhere in this crate — so anything a webview writes to `console.error`
+/// is written to nothing. This command is the only way a JS-side failure reaches
+/// the telemetry spool (and therefore an Export Diagnostics bundle).
+///
+/// # Who calls this
+/// - `tray/src/app.js` and `tray/src/tooltip.js` — the popover's `dbg()` helper.
+/// - The dashboard, via `ui/lib/bridge.ts::reportUiError` — added after a tracker
+///   sync failure proved unrecoverable: the invoke was rejected before dispatch so
+///   there was no span, and the reason existed only in an unopenable console.
 #[tauri::command]
 fn tray_debug(window: tauri::Window, msg: String) {
     tracing::info!(

--- a/ui/__tests__/task-sync-contract.test.ts
+++ b/ui/__tests__/task-sync-contract.test.ts
@@ -18,6 +18,7 @@
 import { describe, expect, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { lastSyncFailure, syncFailureReason } from '@/lib/taskSync'
 
 const read = (p: string) => readFileSync(join(import.meta.dir, '..', p), 'utf8')
 
@@ -27,7 +28,7 @@ const PLAN_VIEW = read('components/plan/PlanView.tsx')
 describe('syncTasks contract', () => {
   test('resolves an outcome rather than void, so a swallowed failure is still reportable', () => {
     expect(TASK_SYNC).toContain('export function syncTasks(): Promise<boolean>')
-    expect(TASK_SYNC).toContain('.then(() => true)')
+    expect(TASK_SYNC).toContain('return true')
     // The failure branch must yield `false` - not `undefined`, which is falsy in
     // the same way and would pass a lazy check while carrying no information.
     expect(TASK_SYNC).toContain('return false')
@@ -106,5 +107,79 @@ describe('a paused store is not a sync failure', () => {
     // the board mid-drag, which is a real bug in the other direction.
     expect(PLAN_VIEW).toContain('const id = setInterval(() => load(false), 30_000)')
     expect(PLAN_STORE).toContain('export function pausePlanRefresh(next: boolean)')
+  })
+})
+
+// A FAILURE WRITTEN ONLY TO THE CONSOLE IS A FAILURE NOBODY CAN READ.
+//
+// Measured on 2026-08-17 against 1.87.0-staging.3, after the planner drew
+// `⚠ Sync failed`: `meridian tasks-sync` by hand exited 0 in 4.7s (76 Jira + 5
+// GitHub issues) from both cwds `install::cli_cwd()` can resolve to,
+// `pm_sync_state.last_error` was NULL for both providers, and `pm_tasks` held 81
+// non-terminal board rows. Nothing about the sync had failed.
+//
+// What the telemetry spool held was worse than a wrong reason - it held none. The
+// whole 7-day retention contained exactly three records mentioning `tasks-sync`,
+// all of them `tasks-sync ok`, none from that day, and ZERO spans anywhere under
+// `meridian_tray_lib::commands::tasks`. The command never ran: the invoke was
+// rejected on the JS side. The only record of why was `console.error` in
+// `syncTasks` - and a packaged build ships no devtools (there is no `devtools`
+// feature or config anywhere in `tray/src-tauri`), while the `tray_debug`
+// JS→Rust bridge is wired into the popover JS only, never the dashboard. So the
+// reason went to a console with no way to open it.
+//
+// That specific rejection is now unrecoverable, and this does not try to guess at
+// it. It pins the thing that made it unrecoverable: a sync failure must leave its
+// reason somewhere a support bundle and the user can both reach.
+describe('a sync failure names itself', () => {
+  const BRIDGE = read('lib/bridge.ts')
+
+  test('the reason survives whatever shape the rejection arrives in', () => {
+    // A Tauri command that rejects with a String reaches JS as a bare string,
+    // and one that rejects with a struct reaches it as an OBJECT (the blanket
+    // Into<InvokeError> serializes it) - so `e.message` alone blanks the reason
+    // for half the cases that actually occur.
+    expect(syncFailureReason('tasks-sync timed out after 30s')).toBe('tasks-sync timed out after 30s')
+    expect(syncFailureReason(new Error('spawn error: No such file'))).toBe('spawn error: No such file')
+    // And the human field wins over the whole body: a chip reading
+    // `{"code":"db.locked","detail":"pool timed out"}` is a crash dump where one
+    // sentence was the entire point.
+    expect(syncFailureReason({ code: 'db.locked', detail: 'pool timed out' })).toBe('pool timed out')
+    expect(syncFailureReason({ message: 'expired token' })).toBe('expired token')
+    // No sentence anywhere - then the body is better than nothing.
+    expect(syncFailureReason({ code: 42 })).toContain('42')
+    // Never empty. An empty reason reads as "no reason recorded", which is the
+    // exact state this exists to end.
+    expect(syncFailureReason(undefined).length).toBeGreaterThan(0)
+    expect(syncFailureReason(null).length).toBeGreaterThan(0)
+  })
+
+  test('nothing has failed yet, so there is no reason to report', () => {
+    expect(lastSyncFailure()).toBeNull()
+  })
+
+  test('the reason is forwarded to the tray log, not just the console', () => {
+    expect(BRIDGE).toContain('export function reportUiError(')
+    // `tray_debug` is the command that already exists for exactly this - it logs
+    // at INFO with the window label, so the line lands in the telemetry spool and
+    // in an Export Diagnostics bundle.
+    expect(BRIDGE).toContain("invoke('tray_debug'")
+    expect(TASK_SYNC).toContain('reportUiError(')
+  })
+
+  test('the reason is readable from the chip itself', () => {
+    // A screenshot of the chip is what a user sends. Hovering it must say why,
+    // rather than making the reason depend on a console they cannot open.
+    expect(TASK_SYNC).toContain('export function lastSyncFailure(): string | null')
+    expect(PLAN_VIEW).toContain('lastSyncFailure()')
+  })
+
+  test('a null reason names the other half rather than shrugging', () => {
+    // The chip is raised by `!synced || !loaded`. `lastFailure` is cleared on a
+    // successful sync, so no reason means the SYNC worked and the re-read did
+    // not - which is a different sentence, not a missing one. "No reason
+    // recorded" here would be the same shrug this whole block exists to remove.
+    expect(TASK_SYNC).toContain('lastFailure = null; return true')
+    expect(PLAN_VIEW).toContain('the tickets synced but the board could not be re-read')
   })
 })

--- a/ui/__tests__/task-sync-contract.test.ts
+++ b/ui/__tests__/task-sync-contract.test.ts
@@ -18,7 +18,8 @@
 import { describe, expect, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { lastSyncFailure, syncFailureReason } from '@/lib/taskSync'
+import { reportUiError } from '@/lib/bridge'
+import { lastSyncFailure, syncFailureReason, syncTasks } from '@/lib/taskSync'
 
 const read = (p: string) => readFileSync(join(import.meta.dir, '..', p), 'utf8')
 
@@ -154,8 +155,86 @@ describe('a sync failure names itself', () => {
     expect(syncFailureReason(null).length).toBeGreaterThan(0)
   })
 
-  test('nothing has failed yet, so there is no reason to report', () => {
-    expect(lastSyncFailure()).toBeNull()
+  // THE WHOLE CHAIN, EXERCISED. A source scan cannot tell a live call from a
+  // commented-out one - checked, and a `// reportUiError(...)` satisfies it - so
+  // the forward has to be observed, not read.
+  //
+  // `bridge.ts` reaches Rust through `window.__TAURI__.core.invoke` and nothing
+  // else, so standing up a fake one is enough to drive `syncTasks` end to end
+  // without mocking a module. Both commands it can emit land in `sent`.
+  type Sent = { cmd: string; args: unknown }
+  // `unknown` cast rather than a global type augmentation: this is a test-local
+  // stand-in for the real bridge, and widening the app's Window type for it would
+  // make the fake look like production surface.
+  const g = globalThis as unknown as { window?: unknown }
+  function withFakeBridge<T>(
+    invoke: (cmd: string, args: unknown) => Promise<unknown>,
+    body: (sent: Sent[]) => Promise<T>,
+  ): Promise<T> {
+    const sent: Sent[] = []
+    const original = g.window
+    g.window = { __TAURI__: { core: { invoke: (cmd: string, args: unknown) => {
+      sent.push({ cmd, args })
+      return invoke(cmd, args)
+    } } } }
+    // Restored even on failure - a leaked fake `window` would silently change how
+    // every later test in this process sees the bridge.
+    return body(sent).finally(() => { g.window = original })
+  }
+
+  // Declared before the failure case so that one's "no reason yet" assertion holds
+  // whatever order these run in: this leaves `lastFailure` null either way.
+  test('a successful sync clears the previous reason', async () => {
+    let broken = true
+    await withFakeBridge(
+      (cmd) => cmd === 'sync_tasks' && broken
+        ? Promise.reject('first attempt failed')
+        : Promise.resolve(null),
+      async (sent) => {
+        expect(await syncTasks()).toBe(false)
+        expect(lastSyncFailure()).toBe('first attempt failed')
+        const reportedOnce = sent.filter(s => s.cmd === 'tray_debug').length
+
+        broken = false
+        expect(await syncTasks()).toBe(true)
+        // A reason left standing after a sync that worked is the same lie the chip
+        // told, only in reverse - and it would be the text on the NEXT failure.
+        expect(lastSyncFailure()).toBeNull()
+        // Nothing to report, so nothing reported: the tray log must not fill with
+        // non-events.
+        expect(sent.filter(s => s.cmd === 'tray_debug').length).toBe(reportedOnce)
+      },
+    )
+  })
+
+  test('a rejected sync resolves false, keeps the reason, and forwards it', () =>
+    // A `Result<_, String>` command rejects with a bare string - the shape
+    // `tasks-sync timed out` actually arrives in.
+    withFakeBridge(
+      (cmd) => cmd === 'sync_tasks'
+        ? Promise.reject('tasks-sync timed out after 30s')
+        : Promise.resolve(null),
+      async (sent) => {
+        expect(lastSyncFailure()).toBeNull()
+        // Never rejects - the contract above - so a caller reads the value.
+        expect(await syncTasks()).toBe(false)
+        expect(lastSyncFailure()).toBe('tasks-sync timed out after 30s')
+        // THE POINT OF ALL OF THIS: the reason reached Rust, so it reaches the
+        // telemetry spool and an Export Diagnostics bundle.
+        const forwarded = sent.find(s => s.cmd === 'tray_debug')
+        expect(forwarded).toBeDefined()
+        expect(JSON.stringify(forwarded?.args)).toContain('tasks-sync timed out after 30s')
+      },
+    ))
+
+  test('reporting a failure can never become a second failure', () => {
+    // Outside Tauri this is a no-op. It runs on an error path, so a throw here
+    // would replace a handled failure with an unhandled one.
+    expect(() => reportUiError('probe')).not.toThrow()
+    // And a rejecting `tray_debug` must not escape either.
+    return withFakeBridge(() => Promise.reject(new Error('ipc down')), async () => {
+      expect(() => reportUiError('probe')).not.toThrow()
+    })
   })
 
   test('the reason is forwarded to the tray log, not just the console', () => {
@@ -165,6 +244,18 @@ describe('a sync failure names itself', () => {
     // in an Export Diagnostics bundle.
     expect(BRIDGE).toContain("invoke('tray_debug'")
     expect(TASK_SYNC).toContain('reportUiError(')
+  })
+
+  test('the command it forwards to is still registered', () => {
+    // `reportUiError` invokes `tray_debug`. Rename it, or drop it from the
+    // `invoke_handler!`, and the forward silently no-ops - reintroducing the exact
+    // silent-loss failure this block exists to end, one refactor later, with every
+    // test still green. Cross-tree scan because the two halves live in different
+    // languages and nothing else couples them.
+    const TRAY_LIB = read('../tray/src-tauri/src/lib.rs')
+    expect(TRAY_LIB).toContain('fn tray_debug(window: tauri::Window, msg: String)')
+    // The registration line inside `generate_handler!`, not merely a mention.
+    expect(TRAY_LIB).toMatch(/^\s*tray_debug,$/m)
   })
 
   test('the reason is readable from the chip itself', () => {

--- a/ui/components/plan/PlanView.tsx
+++ b/ui/components/plan/PlanView.tsx
@@ -25,7 +25,7 @@ import { dayString } from '@/components/timeline/types'
 import type { PlanResponse, IntegrationsResponse } from '@/lib/api-types'
 import { MAX_PLAN_TASKS } from '@/lib/api-types'
 import { load as bridgeLoad } from '@/lib/bridge'
-import { syncTasks } from '@/lib/taskSync'
+import { lastSyncFailure, syncTasks } from '@/lib/taskSync'
 import { availableTrackerNames, connectedTrackers } from '@/lib/integrations'
 import { usePlan, refreshPlan, planAction, pausePlanRefresh } from '@/components/plan/planStore'
 import { isTutorialRunning } from '@/components/tutorial/engine'
@@ -357,7 +357,18 @@ export default function PlanView() {
               <button onClick={handleSync} disabled={syncing}
                 className="mt-body-sm px-2.5 py-1 rounded-md bg-ctrl inline-flex items-center gap-1.5"
                 style={{ border: `1px solid ${syncError ? 'var(--color-state-pending)' : 'var(--t-ctrl-border)'}`, color: syncError ? 'var(--color-state-pending)' : 'var(--t-muted)', opacity: syncing ? 0.6 : 1 }}
-                title="Pull latest tickets from your trackers">
+                // WHY it failed, not just THAT it failed. The chip is what a user
+                // screenshots, and the reason otherwise lives only in a console a
+                // packaged build cannot open - which is exactly how a red chip over
+                // a healthy Jira sync became undiagnosable once already.
+                //
+                // The chip is raised by `!synced || !loaded`, so a null reason is
+                // not "nothing was recorded" - it is precisely the other half:
+                // `lastSyncFailure()` is cleared on a successful sync, so the only
+                // way to be here without one is the re-read having failed.
+                title={syncError
+                  ? `Sync failed - ${lastSyncFailure() ?? 'the tickets synced but the board could not be re-read'}`
+                  : 'Pull latest tickets from your trackers'}>
                 <span style={{ display: 'inline-block', animation: syncing ? 'spin 1s linear infinite' : 'none' }}>{syncError ? '⚠' : '↻'}</span>
                 {syncing ? 'Syncing…' : syncError ? 'Sync failed' : 'Refresh'}
               </button>

--- a/ui/lib/bridge.ts
+++ b/ui/lib/bridge.ts
@@ -135,6 +135,34 @@ export async function invoke<T = unknown>(cmd: string, args?: Record<string, unk
   return t.core.invoke(cmd, args) as Promise<T>
 }
 
+/** Forward a UI-side failure to the tray's log, so it lands in the telemetry
+ *  spool (and therefore in an Export Diagnostics bundle) rather than only in a
+ *  console.
+ *
+ *  THE DASHBOARD HAS NO CONSOLE ANYONE CAN OPEN. A packaged build ships no
+ *  devtools — there is no `devtools` feature or config anywhere in
+ *  `tray/src-tauri` — so `console.error` in the webview is written to nothing.
+ *  That is not a theoretical gap: the planner's Refresh chip drew `⚠ Sync failed`
+ *  on 2026-08-17 while the Jira sync was demonstrably healthy (a hand-run
+ *  `meridian tasks-sync` synced 81 issues, `pm_sync_state.last_error` was NULL),
+ *  and the reason was unrecoverable — the invoke had been rejected on the JS side,
+ *  so there was no Rust span either, and the whole 7-day spool held nothing.
+ *
+ *  `tray_debug` is the command that already exists for this (it was written for
+ *  the popover's `window.onerror`); it logs at INFO with the calling window's
+ *  label, which is what makes a report attributable to a surface.
+ *
+ *  BEST EFFORT, ALWAYS. This is a diagnostic, so it must never turn a handled
+ *  failure into a second one: outside Tauri it is a no-op, and a rejected
+ *  `tray_debug` is swallowed. */
+export function reportUiError(msg: string): void {
+  const t = tauri()
+  if (!t) return
+  // Not `invoke()` above: that one throws outside Tauri, and a diagnostic must
+  // not need a try/catch at every call site.
+  t.core.invoke('tray_debug', { msg }).catch(() => {})
+}
+
 /** True when `href` is an absolute http(s) URL pointing outside `origin` —
  *  i.e. a navigation the Tauri webview cannot perform itself. Exported for
  *  the ExternalLinks interceptor and its tests. */

--- a/ui/lib/taskSync.ts
+++ b/ui/lib/taskSync.ts
@@ -26,12 +26,61 @@
 //
 // # Who calls this
 // - `IntegrationConnect` - on every connect-completed path (warm start).
-// - `PlanView` - the empty-board backstop and the Refresh chip (joins, or starts).
+// - `PlanView` - the empty-board backstop and the Refresh chip (joins, or starts),
+//   and `lastSyncFailure()` for the chip's hover text.
 
-import { mutate } from '@/lib/bridge'
+import { mutate, reportUiError } from '@/lib/bridge'
 
 /** The sync currently running, if any. Cleared when it settles. */
 let inFlight: Promise<boolean> | null = null
+
+/** Why the last sync failed, or `null` if the last one worked (or none has run).
+ *  Module state rather than a return value because the callers that need the
+ *  reason and the caller that starts the sync are not the same component - the
+ *  connect flow fires it, the planner's chip is what has to explain it. */
+let lastFailure: string | null = null
+
+/**
+ * Render an unknown rejection as one diagnostic line.
+ *
+ * THE SHAPE IS NOT PREDICTABLE, and getting it wrong blanks the reason rather
+ * than throwing. A `#[tauri::command]` returning `Result<_, String>` rejects with
+ * a bare **string**; one returning `Result<_, SomeStruct>` rejects with the
+ * serialized **object** (the blanket `Into<InvokeError>` takes that path); the
+ * bridge's own guards reject with an **Error**. Reading `e.message` alone - the
+ * obvious thing - yields `undefined` for two of those three.
+ *
+ * Never returns an empty string. An empty reason renders as "no reason recorded",
+ * which is indistinguishable from the gap this whole mechanism exists to close.
+ */
+export function syncFailureReason(e: unknown): string {
+  if (typeof e === 'string') return e.trim() || 'sync failed with an empty error'
+  if (e instanceof Error) return e.message.trim() || 'sync failed with an empty Error'
+  if (e && typeof e === 'object') {
+    // Prefer the human field. A struct error's whole JSON body on the chip reads
+    // as a crash dump - `{"code":"db.locked","detail":"pool timed out"}` where
+    // "pool timed out" was the entire point - so dump the object only when it
+    // carries no sentence of its own.
+    for (const k of ['message', 'detail', 'error'] as const) {
+      const v = (e as Record<string, unknown>)[k]
+      if (typeof v === 'string' && v.trim()) return v.trim()
+    }
+    try {
+      return JSON.stringify(e)
+    } catch {
+      // A cycle or a BigInt. The shape is already lost; say so rather than throw.
+      return 'sync failed with an unserializable error'
+    }
+  }
+  return 'sync failed with no error value'
+}
+
+/** Why the last sync failed, or `null` if it succeeded / none has run yet.
+ *  Read by `PlanView`'s Refresh chip so hovering it says WHY, rather than the
+ *  reason living only in a console a packaged build cannot open. */
+export function lastSyncFailure(): string | null {
+  return lastFailure
+}
 
 /**
  * Pull the latest tickets from every connected tracker.
@@ -59,13 +108,23 @@ let inFlight: Promise<boolean> | null = null
 export function syncTasks(): Promise<boolean> {
   if (inFlight) return inFlight
   inFlight = mutate('/api/tasks/sync', 'sync_tasks', {})
-    .then(() => true)
+    .then(() => { lastFailure = null; return true })
     .catch((e) => {
-      // The only record this failure leaves. A first import is a real round trip
-      // to Jira or Linear and can fail for ordinary reasons (expired token, rate
-      // limit, tracker down); without this the board just stays empty and there
-      // is nothing anywhere to explain why.
+      // A first import is a real round trip to Jira or Linear and can fail for
+      // ordinary reasons (expired token, rate limit, tracker down); without a
+      // reason recorded somewhere the board just stays empty and nothing explains
+      // why.
+      //
+      // THREE PLACES, because the console alone was measurably not one of them.
+      // On 2026-08-17 the chip showed `⚠ Sync failed` against a Jira sync that was
+      // healthy by every other measure, and the reason could not be recovered from
+      // anything: the rejection happened before the IPC dispatch, so there was no
+      // Rust span, and a packaged build has no devtools to read `console.error`
+      // from. The console line stays for `next dev`; `reportUiError` puts the same
+      // line in the telemetry spool; `lastFailure` puts it on the chip.
+      lastFailure = syncFailureReason(e)
       console.error('[meridian] tracker sync failed', e)
+      reportUiError(`tracker sync failed: ${lastFailure}`)
       return false
     })
     .finally(() => { inFlight = null })


### PR DESCRIPTION
## The report

The planner drew a red `⚠ Sync failed` chip on the Daily plan. Jira was fine.

| Check | Result |
|---|---|
| `meridian tasks-sync` by hand (both cwds `install::cli_cwd()` can resolve to) | exit 0, 4.7 s, `jira: synced 76 task(s)` / `github: synced 5 task(s)` |
| `pm_sync_state` | `jira last_synced_at=2026-08-16T21:01:47Z`, `last_error` **NULL**; same for github |
| `pm_tasks` | 108 rows, **81 non-terminal board tasks** |

## Why the cause could not be recovered - which is the actual defect

`sync_tasks` **never executed on Aug 16 or 17**. Zero records under `meridian_tray_lib::commands::tasks` across the whole 7-day telemetry spool (~157k files), against a working control (`plan_action` spans present, one stamped `date 2026-08-17`). In the entire retention window the command ran three times - Aug 10 x2, Aug 15 x1 - and all three logged `tasks-sync ok`.

So the rejection happened JS-side, before the IPC dispatch, and left no Rust span to read. Its only record was `console.error` in `syncTasks` - and a packaged build ships **no devtools** (there is no `devtools` feature or config anywhere in `tray/src-tauri`), while the `tray_debug` JS→Rust bridge was wired into the popover JS only, never the dashboard. The reason went to a console with no way to open it.

**This PR does not guess at that rejection.** `PlanView`'s `syncError` has exactly one writer and it needs an invoke to fire, so every candidate mechanism contradicts something else that demonstrably worked in the same render (the header rendered `data.date`, and the chip only exists once `get_integrations` returned trackers - the bridge was alive). Fixing that on a hunch would mean a wrong fix *and* a lost diagnostic. This fixes the thing that made it undiagnosable.

## The change

A sync failure now lands in three places instead of one:

- **`bridge.ts::reportUiError`** forwards it through the existing `tray_debug` command, so it reaches the telemetry spool and Export Diagnostics bundles.
- **`taskSync.ts::syncFailureReason`** renders whatever shape the rejection arrives in - a `Result<_, String>` command rejects with a bare string, a `Result<_, Struct>` one with the serialized object, the bridge's own guards with an `Error` - preferring the object's `message`/`detail`/`error` field over dumping its body, since a chip showing raw JSON is a crash dump.
- **The chip's hover text** names the reason. A null reason is not a shrug: `lastFailure` is cleared on a successful sync, so the only way to be there without one is the re-read having failed, and it says exactly that.

`tray_debug`'s doc is updated - it has a second consumer now, and the no-devtools consequence is written down.

## Tests

Test-first: the new assertions failed on import before the fix existed.

The forward is **observed, not source-scanned** - a scan for `reportUiError(` passed against a commented-out call, verified by planting exactly that. `bridge.ts` reaches Rust only through `window.__TAURI__.core.invoke`, so a fake one drives `syncTasks` end to end with no module mocking:

- a rejected sync resolves `false`, keeps the reason, and a `tray_debug` invoke carries it;
- a successful sync clears a previous reason and reports nothing, so a stale line cannot become the text on the next failure;
- `reportUiError` never throws, with or without a bridge, and swallows a rejecting `tray_debug`;
- `tray_debug` is still registered in `invoke_handler!` (rename it and the forward silently no-ops - nothing else couples the two languages).

Each guard was verified by planting its regression - dropping the forward, dropping the clear-on-success, dumping struct errors as raw JSON - and confirming the suite goes red.

Gates: `bun test` 863 pass / 0 fail, `tsc` clean, `next build` clean, `cargo fmt --check` + `clippy -D warnings` + `cargo test --workspace` clean (full pre-push suite passed).

## Two traps worth knowing, found on the way

- `meridian logs` renders sqlx slow-query WARNs with **empty message bodies** (the text lives in `db.statement`) - they read as lost logs. The one at 20:54:44.999 decoded to a 1.67 s `SELECT task_key FROM app_sessions`.
- Grepping the raw spool needs `LC_ALL=C grep -a`. Plain `grep -r` silently matches nothing on `.otlp` files - it reported 0 hits for a string the renderer had just printed.

## Note for the reviewer

Six tray builds ran on Aug 16 (1.85.0, 1.86.0, 1.86.0-staging.2, 1.87.0-staging.1/.2/.3), so the screenshot may predate the current app start. The logging fix stands either way, and the next occurrence will name itself in one step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD4q8ABsM3gWC4AXSWL6T1