### PR TITLE
fix(observability): make the span-status records on resize_setup_window actually fire

### DIFF
--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -77,6 +77,10 @@ use tracing_subscriber::{layer::SubscriberExt, reload, util::SubscriberInitExt, 
 mod filter;
 mod install_mode;
 mod otlp_target;
+/// Tests only - it reads the workspace's own source rather than calling
+/// anything, so there is nothing here to compile into a release build.
+#[cfg(test)]
+mod span_status_guard;
 pub use filter::reload_log_level;
 use filter::{build_default_filter, FILTER_HANDLE};
 use install_mode::capture_disabled;

--- a/src/observability/span_status_guard.rs
+++ b/src/observability/span_status_guard.rs
@@ -1,0 +1,272 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//!
+//! Every `record("otel.status_code", …)` must have a span that DECLARED the
+//! field.
+//!
+//! `tracing` resolves `Span::record` against the field set fixed when the span
+//! was created. Recording a name that is not in that set is not an error and
+//! not a warning - it is a silent no-op. So this compiles, runs, and writes
+//! nothing:
+//!
+//! ```ignore
+//! #[tracing::instrument(skip(app))]                    // <- no `fields(…)`
+//! async fn resize(app: AppHandle) -> Result<(), String> {
+//!     …
+//!     tracing::Span::current().record("otel.status_code", "ERROR");  // dropped
+//!     tracing::warn!(error = %e, "resize failed");                   // kept
+//! }
+//! ```
+//!
+//! The WARN still ships, which is what makes it survive review: the failure is
+//! visible in `meridian logs` and in central OO's log stream, so the code looks
+//! instrumented from every angle except the one that matters. What is missing
+//! is the SPAN STATUS, and span status is what an error-only telemetry query
+//! filters on - the exact query someone runs when a user reports a problem and
+//! there is nothing to grep for.
+//!
+//! # Why a derived scan and not a review habit
+//!
+//! This shipped in 1.88.0 in `commands::system::resize_setup_window`, in the
+//! same commit that ADDED the declaration to `poll::permissions::check_permissions`
+//! one file away. Knowing the rule was not enough; neither was a reviewer who
+//! had just applied it. Nothing else could have caught it - it type-checks,
+//! clippy is happy, and no unit test can observe a dropped field without a
+//! subscriber harness around every call site.
+//!
+//! So the list is DERIVED from the source at test time rather than enumerated
+//! here. A site added tomorrow, in a file that does not exist yet, is covered
+//! the day it lands; an enumerated list would have to be remembered, which is
+//! the thing that already failed.
+//!
+//! # What it can and cannot decide
+//!
+//! Recording on a span the current function OWNS is checkable locally: the
+//! declaration has to be right there, in the `#[tracing::instrument]` attribute
+//! or in the `span!` invocation the receiver was bound from.
+//!
+//! Recording on an INHERITED span is not. `Span::current()` inside a function
+//! with no span of its own targets whatever ancestor is on the stack - that is
+//! a deliberate pattern here (`poll::permissions::check_bool_permission` marks
+//! its caller's `check_permissions` span; `commands::setup::mark_span_failed`
+//! exists only to do this), and the declaring span lives in a different
+//! function, sometimes a different file. Those are counted and skipped rather
+//! than guessed at, because a guess would produce false failures on correct
+//! code, and a guard that cries wolf gets deleted.
+//!
+//! At the time of writing that is 19 checkable sites and 23 inherited ones.
+//!
+//! # Related
+//!
+//! - [`crate::observability`] - where the spans this guards are exported from.
+//! - `tray/src-tauri/src/poll/watchdog.rs` - the reference shape for a failure
+//!   boundary: declare the field, record `ERROR`, log a structured `warn!`.
+
+use std::path::{Path, PathBuf};
+
+/// Crate source roots, relative to the workspace root.
+///
+/// `CARGO_MANIFEST_DIR` for this package IS the workspace root (the repo root
+/// is itself a package - see CLAUDE.md's `--workspace` warning), so these paths
+/// need no `../..` climbing and stay correct wherever the checkout lives.
+const ROOTS: [&str; 3] = ["src", "meridian-core/src", "tray/src-tauri/src"];
+
+/// One `record("otel.status_code", …)` call found in the source.
+struct RecordSite {
+    file: String,
+    line: usize,
+    /// The enclosing function's signature line, for the failure message.
+    func: String,
+    /// Whether the span being recorded onto belongs to the enclosing function.
+    /// `false` means an ancestor's span - see the module header.
+    owns_span: bool,
+    /// Whether that span declared `otel.status_code`. Meaningless when
+    /// `owns_span` is false.
+    declared: bool,
+}
+
+fn rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rust_files(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// True when `line` starts a free-function signature at the top level of a
+/// file, in any visibility spelling used in this workspace.
+fn starts_fn(line: &str) -> bool {
+    let rest = line
+        .strip_prefix("pub(crate) ")
+        .or_else(|| line.strip_prefix("pub(super) "))
+        .or_else(|| line.strip_prefix("pub "))
+        .unwrap_or(line);
+    let rest = rest.strip_prefix("async ").unwrap_or(rest);
+    rest.starts_with("fn ")
+}
+
+/// Every record site in the workspace, classified.
+fn record_sites() -> Vec<RecordSite> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut files = Vec::new();
+    for r in ROOTS {
+        rust_files(&root.join(r), &mut files);
+    }
+    files.sort();
+
+    let mut sites = Vec::new();
+    for file in files {
+        // This file quotes the very calls it looks for - in a doc example, in
+        // panic messages, in the classifier's own string literals. Scanning it
+        // would report its own prose as un-instrumented production code. It is
+        // `#[cfg(test)]` in its entirety, so there is no real instrumentation
+        // here to lose by skipping it.
+        if file.ends_with("span_status_guard.rs") {
+            continue;
+        }
+        let whole = std::fs::read_to_string(&file).expect("source file is readable");
+        // Truncate at the test module. Test code quotes these very strings (this
+        // file is the extreme case - it would otherwise scan itself and match
+        // its own examples), and a needle that matches the scanner's own
+        // literals is a guard that can never fail. Same trap as the
+        // `include_str!` self-scans elsewhere in the tree.
+        let src = match whole.find("\n#[cfg(test)]") {
+            Some(at) => &whole[..at],
+            None => &whole[..],
+        };
+        let lines: Vec<&str> = src.lines().collect();
+        let rel = file
+            .strip_prefix(root)
+            .unwrap_or(&file)
+            .to_string_lossy()
+            .into_owned();
+
+        for (i, line) in lines.iter().enumerate() {
+            let Some(at) = line.find(".record(\"otel.status_code\"") else {
+                continue;
+            };
+            // Two receiver shapes: `tracing::Span::current().record(…)`, and a
+            // local bound from a `span!` macro (`span.record(…)`). Only the
+            // second is an identifier, so `Span::current()` is matched on the
+            // whole prefix - reading backwards for a "word" would stop at its
+            // closing paren and mistake it for a named span.
+            let before = &line[..at];
+            let receiver: String = before
+                .chars()
+                .rev()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect();
+
+            let fn_line = (0..=i).rev().find(|&j| starts_fn(lines[j]));
+            let Some(fn_line) = fn_line else {
+                panic!("{rel}:{} is not inside a top-level fn - the scan cannot classify it, so it would be skipped silently", i + 1);
+            };
+            // The contiguous attribute block above the signature.
+            let mut k = fn_line;
+            while k > 0 && !lines[k - 1].trim().is_empty() && !lines[k - 1].starts_with("//") {
+                k -= 1;
+            }
+            let attrs = lines[k..fn_line].join("\n");
+            let body = lines[fn_line..i].join("\n");
+
+            // `let x = tracing::Span::current();` makes `x` an alias for the
+            // current span, so `x.record(…)` is the same case as recording on
+            // `Span::current()` directly - not a span this function declared.
+            let is_alias = body
+                .split("let ")
+                .skip(1)
+                .filter_map(|s| s.split_once(" = tracing::Span::current();"))
+                .any(|(name, _)| name == receiver);
+            let on_current = before.ends_with("Span::current()") || is_alias;
+
+            let (owns_span, declared) = if on_current {
+                // Own span only if this fn is instrumented; otherwise the
+                // record lands on an ancestor's span, declared elsewhere.
+                (
+                    attrs.contains("#[tracing::instrument"),
+                    attrs.contains("otel.status_code"),
+                )
+            } else {
+                // A named receiver was bound from a `span!` invocation in this
+                // body, so the declaration has to be in this body.
+                (
+                    true,
+                    body.contains("otel.status_code = tracing::field::Empty"),
+                )
+            };
+
+            sites.push(RecordSite {
+                file: rel.clone(),
+                line: i + 1,
+                func: lines[fn_line].trim().to_string(),
+                owns_span,
+                declared,
+            });
+        }
+    }
+    sites
+}
+
+/// Sites the scan could find when this was written. A floor, not a target: it
+/// exists so that renaming `record` or `otel.status_code`, or breaking the
+/// walk, fails HERE rather than leaving every assertion below passing over an
+/// empty list - which is the usual way a source scan stops testing anything
+/// without anyone noticing.
+const SITES_WHEN_WRITTEN: usize = 42;
+
+#[test]
+fn every_recorded_span_status_was_declared() {
+    let sites = record_sites();
+    assert!(
+        sites.len() >= SITES_WHEN_WRITTEN,
+        "found only {} record sites, expected at least {SITES_WHEN_WRITTEN} - \
+         the scan itself is broken (renamed field? moved crate root?), and a \
+         broken scan passes every check below",
+        sites.len()
+    );
+
+    let dead: Vec<String> = sites
+        .iter()
+        .filter(|s| s.owns_span && !s.declared)
+        .map(|s| format!("  {}:{}  in `{}`", s.file, s.line, s.func))
+        .collect();
+
+    assert!(
+        dead.is_empty(),
+        "these `record(\"otel.status_code\", …)` calls are SILENT NO-OPS - the \
+         span they record onto never declared the field, so the span status is \
+         never set and an error-only telemetry query cannot see the failure at \
+         all:\n{}\n\nFix: add `fields(otel.status_code = tracing::field::Empty)` \
+         to the fn's `#[tracing::instrument(…)]`, or to the `span!` the \
+         receiver was bound from.",
+        dead.join("\n")
+    );
+}
+
+#[test]
+fn the_scan_still_finds_both_kinds_of_site() {
+    // The check above passes vacuously if the classifier decides every site is
+    // inherited. Both populations are real and neither should empty out
+    // quietly.
+    let sites = record_sites();
+    let owned = sites.iter().filter(|s| s.owns_span).count();
+    let inherited = sites.len() - owned;
+    assert!(
+        owned >= 15,
+        "only {owned} sites classified as owning their span - the classifier \
+         is now skipping work it used to check"
+    );
+    assert!(
+        inherited >= 15,
+        "only {inherited} sites classified as inheriting a caller's span - \
+         suspicious, since that is a deliberate pattern in the tray's poll loop"
+    );
+}

--- a/tray/src-tauri/src/commands/system.rs
+++ b/tray/src-tauri/src/commands/system.rs
@@ -129,7 +129,14 @@ pub async fn open_setup(app: tauri::AppHandle) -> Result<(), String> {
 /// Without a log a Windows-only resize failure would surface as "the wizard looks wrong on
 /// my machine" and nothing else.
 #[tauri::command]
-#[tracing::instrument(skip(app))]
+// `fields(otel.status_code = ...)` is NOT decoration: `Span::current().record`
+// on a field the span never declared is a silent no-op, so without this line
+// all three `record` calls below compile, run, and write nothing. That is how
+// they shipped in 1.88.0 - the WARN lines were there, the span status was not,
+// and nothing in the build or the tests could tell the difference.
+// `observability::span_status_guard` (daemon crate) now derives this rule from
+// the source rather than trusting anyone to remember it.
+#[tracing::instrument(skip(app), fields(otel.status_code = tracing::field::Empty))]
 pub async fn resize_setup_window(
     app: tauri::AppHandle,
     width: f64,
@@ -152,20 +159,21 @@ pub async fn resize_setup_window(
     // `transform: scale(...)` in page.tsx already grows it to fill whatever
     // size the window actually is.
     //
-    // `unwrap_or(TRUE)`, deliberately: the guards fail CLOSED. An errored query
-    // tells us nothing about the window, and the two outcomes are not
-    // symmetric - guessing "not full-screen" performs the very resize the
-    // guard exists to prevent, while guessing "full-screen" skips a resize
-    // that was never needed anyway (the card's `transform: scale(...)` fills
+    // An UNREADABLE state skips the resize too - the guards fail CLOSED. An
+    // errored query tells us nothing about the window, and the two guesses are
+    // not symmetric: guessing "not full-screen" performs the very resize the
+    // guard exists to prevent, while guessing "full-screen" skips a resize that
+    // was never needed anyway (the card's `transform: scale(...)` fills
     // whatever size the window is). Same reasoning on both guards below.
     //
-    // The Err arm is SEPARATED from the true arm rather than folded in by
-    // `unwrap_or`, so the two reasons for skipping are distinguishable in a
-    // trace. Collapsing them emits the same debug line for "the window is
-    // genuinely full-screen" (routine, every wizard step) and "the query
-    // failed" (never expected, and the only clue if this ever misbehaves on a
-    // window manager we have not seen). The BEHAVIOUR is identical - skip
-    // either way, still fail closed - only the reporting differs.
+    // The Err arm is SEPARATED from the `Ok(true)` arm rather than folded into
+    // it by an `unwrap_or(true)`, so the two reasons for skipping are
+    // distinguishable in a trace. Collapsing them emits the same debug line for
+    // "the window is genuinely full-screen" (routine, every wizard step) and
+    // "the query failed" (never expected, and the only clue if this ever
+    // misbehaves on a window manager we have not seen). The BEHAVIOUR is
+    // identical - skip either way, still fail closed - only the reporting
+    // differs.
     match win.is_fullscreen() {
         Ok(true) => {
             tracing::debug!("setup window is full-screen - resize skipped");
@@ -210,6 +218,11 @@ pub async fn resize_setup_window(
             Ok(())
         }
         Err(e) => {
+            // The one failure here that is not a deliberate skip. `instrument`
+            // is not declared with `err`, so a returned `Err` does NOT mark the
+            // span by itself - marking two of the three failure paths and
+            // leaving the only real one clean would be the worst of both.
+            tracing::Span::current().record("otel.status_code", "ERROR");
             tracing::warn!(error = %e, width, height, "setup window resize failed");
             Err(e.to_string())
         }

--- a/tray/src-tauri/src/poll/permissions.rs
+++ b/tray/src-tauri/src/poll/permissions.rs
@@ -239,9 +239,15 @@ const NOTIFICATION_REMEDY: &str =
 /// `None` stays usable, deliberately, and is the opposite case: it means the
 /// probe itself could not answer (plugin absent in an unbundled run, or a
 /// failed WinRT read). Not knowing is not evidence of revocation.
-async fn notification_permission_granted(app: &tauri::AppHandle) -> bool {
+///
+/// Split from the probe below so the RULE is testable on its own. The probe
+/// needs a live `AppHandle` and a bundled plugin, neither of which a unit test
+/// has, which is why this mapping was previously guarded by scanning the
+/// source for variant names — a check that passes just as happily when a
+/// variant is mapped the wrong way round, since the name is present either way.
+fn notifications_usable(state: Option<tauri_plugin_notifications::PermissionState>) -> bool {
     use tauri_plugin_notifications::PermissionState;
-    match crate::sys::notification_permission_state(app).await {
+    match state {
         Some(PermissionState::Granted) => true,
         Some(
             PermissionState::Denied
@@ -251,6 +257,12 @@ async fn notification_permission_granted(app: &tauri::AppHandle) -> bool {
         // Probe failed / plugin absent — see the doc comment.
         None => true,
     }
+}
+
+/// Probe the OS for the notification grant and map it through
+/// [`notifications_usable`].
+async fn notification_permission_granted(app: &tauri::AppHandle) -> bool {
+    notifications_usable(crate::sys::notification_permission_state(app).await)
 }
 
 /// Raise `perm` when it has read off for [`REVOKE_HOLD`], clear it when
@@ -310,7 +322,10 @@ async fn check_bool_permission(
 
 #[cfg(test)]
 mod tests {
-    use super::{PermissionDebounce, Verdict, ACCESSIBILITY, NOTIFICATION_REMEDY, REVOKE_HOLD};
+    use super::{
+        notifications_usable, PermissionDebounce, Verdict, ACCESSIBILITY, NOTIFICATION_REMEDY,
+        REVOKE_HOLD,
+    };
     use std::time::{Duration, Instant};
 
     /// THE regression. On 2026-08-16 both capture permissions read off on the
@@ -445,49 +460,43 @@ mod tests {
     /// Every `PermissionState` that is not `Granted` must read as off, and a
     /// failed probe must not.
     ///
-    /// `notification_permission_granted` needs a live `AppHandle` and a real
-    /// plugin, so the mapping is scanned rather than called - same reason as
-    /// the debounce test above. What is scanned is the exhaustive `match`,
-    /// which is what makes the claim checkable at all: an `if let` or a
-    /// `matches!` over a subset would compile fine while silently treating a
-    /// new variant as usable.
-    ///
     /// THE BUG THIS PINS: only `Denied` counted as off, so `Prompt` /
     /// `PromptWithRationale` - the states where the grant has not been given
     /// and the toast is dropped exactly as it is under `Denied` - read as
     /// "notifications are fine". The user sees no difference between "you said
     /// no" and "you never answered": either way nothing arrives, and nothing
     /// told them why.
+    ///
+    /// Asserted against [`notifications_usable`] directly. This used to SCAN
+    /// the source for each variant name, because the probe needs a live
+    /// `AppHandle`; that check could not fail for the bug it was written for,
+    /// since `PermissionState::Prompt => true` contains the string "Prompt"
+    /// just as `=> false` does. Splitting the pure mapping out gave it
+    /// something real to call.
     #[test]
     fn only_granted_counts_as_usable_notifications() {
-        let whole = include_str!("permissions.rs");
-        let src = &whole[..whole
-            .find("#[cfg(test)]")
-            .expect("permissions.rs lost its test module marker")];
-        let body = src
-            .split_once("async fn notification_permission_granted(")
-            .expect("notification_permission_granted is gone")
-            .1;
-        let body = &body[..body
-            .find("\n}\n")
-            .expect("notification_permission_granted has no end")];
+        use tauri_plugin_notifications::PermissionState;
 
         assert!(
-            body.contains("Some(PermissionState::Granted) => true"),
-            "Granted must be the only state that reads as usable"
+            notifications_usable(Some(PermissionState::Granted)),
+            "a granted permission is the one state where a toast arrives"
         );
-        for variant in ["Denied", "Prompt", "PromptWithRationale"] {
+        for state in [
+            PermissionState::Denied,
+            PermissionState::Prompt,
+            PermissionState::PromptWithRationale,
+        ] {
             assert!(
-                body.contains(variant),
-                "PermissionState::{variant} is unhandled - an ungranted \
-                 permission would read as usable and the user would never be \
-                 told why their notifications stopped"
+                !notifications_usable(Some(state)),
+                "{state:?} means the grant has not been given, so the toast is \
+                 dropped - reading it as usable is what left the user with no \
+                 notifications and no explanation"
             );
         }
         // The probe FAILING is the opposite case and must stay usable: not
         // knowing is not evidence of revocation.
         assert!(
-            body.contains("None => true"),
+            notifications_usable(None),
             "a failed probe must not be treated as a revoked permission"
         );
     }

--- a/ui/__tests__/dmg-install-steps.test.ts
+++ b/ui/__tests__/dmg-install-steps.test.ts
@@ -40,6 +40,22 @@ function steps(): string[] {
   return [...gen.slice(at, end).matchAll(/"([^"]+)"/g)].map(m => m[1])
 }
 
+/** Where the generator draws the step lines, read out of the generator itself.
+ *
+ *  `top` and `pitch` come from the one `draw.text(...)` offset expression, and
+ *  `scale` from the `SCALE` constant the generator multiplies it by - so a
+ *  render at a different resolution moves the band with it instead of leaving
+ *  these tests measuring empty pixels. Parsed once, with a message per value:
+ *  a non-null assertion on a reformatted generator throws a bare `TypeError`
+ *  that says nothing about what changed. */
+function captionGeometry(): { top: number; pitch: number; scale: number } {
+  const offset = gen.match(/\((\d+) \+ n \* (\d+)\) \* SCALE/)
+  expect(offset, 'the generator no longer draws the steps at `(top + n * pitch) * SCALE`').not.toBeNull()
+  const scale = gen.match(/^SCALE = (\d+)/m)
+  expect(scale, 'the generator no longer declares `SCALE` at the top level').not.toBeNull()
+  return { top: Number(offset![1]), pitch: Number(offset![2]), scale: Number(scale![1]) }
+}
+
 /** Read a big-endian u32, since a plain `Uint8Array` has no `readUInt32BE`. */
 function be32(b: Uint8Array, at: number): number {
   return ((b[at] << 24) | (b[at + 1] << 16) | (b[at + 2] << 8) | b[at + 3]) >>> 0
@@ -185,9 +201,7 @@ describe('the DMG tells the user to open the app', () => {
     // (tauri.conf.json's bundle.macOS.dmg), so their bottom edge is 234pt and
     // their labels sit below that. Text placed any higher would be drawn under
     // an icon - invisible, with nothing in the build to notice.
-    const m = gen.match(/\((\d+) \+ n \* \d+\) \* SCALE/)
-    expect(m).not.toBeNull()
-    expect(Number(m![1])).toBeGreaterThan(234)
+    expect(captionGeometry().top).toBeGreaterThan(234)
   })
 
   it('ships a PNG with BOTH lines actually drawn in it', () => {
@@ -226,12 +240,14 @@ describe('the DMG tells the user to open the app', () => {
     // third step and re-rendering correctly still passes. Hard-coding `2` would
     // fail on a correct change and point at the artefact rather than at the
     // stale expectation - which is the wrong place to send the reader.
-    const top = Number(gen.match(/\((\d+) \+ n \* (\d+)\) \* SCALE/)![1])
-    const pitch = Number(gen.match(/\((\d+) \+ n \* (\d+)\) \* SCALE/)![2])
+    const { top, pitch, scale } = captionGeometry()
     const expected = steps().length
-    // 2x scale; one pitch of slack past the last line so a added line is inside
-    // the band rather than clipped by it (which would read as "not drawn").
-    const band = rows.slice(top * 2 - 8, (top + pitch * expected) * 2 + 8)
+    // The band runs one FULL PITCH past the last line's baseline, not to it -
+    // so a third step, drawn one pitch below the second, falls inside the band
+    // and is counted. Ending at the last line would clip an added one, and a
+    // clipped line reads as "not drawn", which is the same failure as a stale
+    // PNG with a completely different cause.
+    const band = rows.slice(top * scale - 8, (top + pitch * expected) * scale + 8)
     expect(countTextLines(band, width)).toBe(expected)
   })
 


### PR DESCRIPTION
Second-pass CodeRabbit review on the release PR (#790) found three things. All three were real; one of them is a bug that shipped in 1.88.0.

## 1. Two span-status records that wrote nothing

`resize_setup_window` marks its span `ERROR` when the window-state query fails:

```rust
#[tracing::instrument(skip(app))]          // <- no fields(...)
pub async fn resize_setup_window(...) {
    ...
    tracing::Span::current().record("otel.status_code", "ERROR");
    tracing::warn!(error = %e, "full-screen state unreadable - resize skipped");
```

`tracing` resolves `record` against the field set fixed when the span was created. A name not in that set is **not an error and not a warning - it is a silent no-op**. Both records were dropped.

What makes this survive review is that the WARN still ships. The failure is visible in `meridian logs` and in central OO's log stream, so the code looks instrumented from every angle except the one that matters. What is missing is the **span status**, which is what an error-only telemetry query filters on - the exact query someone runs when a user reports a problem and there is nothing to grep for.

This went in during the #791 review fixes, **in the same commit that added the declaration to `check_permissions` one file away**.

### So the rule is derived now, not remembered

Knowing the rule did not prevent it and neither did a reviewer who had just applied it, so `src/observability/span_status_guard.rs` walks every crate's source at test time:

- finds all **42** `record("otel.status_code")` sites across `src/`, `meridian-core/src/`, `tray/src-tauri/src/`
- fails on any site that records onto a span its own function never declared
- **skips the 23 that record onto an inherited span** - `check_bool_permission` marking its caller's `check_permissions` span, `commands::setup::mark_span_failed` - because the declaration lives in another function, sometimes another file, and a guess there would fail correct code. A guard that cries wolf gets deleted.
- a second test pins both populations, so the classifier cannot quietly stop checking anything

Deriving rather than listing is what makes it cover a site added tomorrow in a file that does not exist yet. **Verified by reverting the fix**: the guard names all three sites, by file and line.

The third is `set_min_size`/`set_size` failing - the one path in this function that is a real error rather than a deliberate skip, now marked too. `instrument` is not declared with `err`, so a returned `Err` does not mark the span by itself, and marking two of three failure paths would have been the worst of both.

## 2. A regression test that could not fail for its own bug

`only_granted_counts_as_usable_notifications` scanned the source for each `PermissionState` variant name. `Some(PermissionState::Prompt) => true` contains the string `"Prompt"` exactly as `=> false` does - so the test passed against the very mutation it was written to catch.

The scan existed because the probe needs a live `AppHandle` and a bundled plugin. The **rule** needs neither, so it is now `notifications_usable(Option<PermissionState>) -> bool` and each variant is asserted directly.

**Verified**: mapping `Prompt`/`PromptWithRationale` back to usable fails the test now; under the old scan it passed.

## 3. DMG pixel check: derive the render scale

The band coordinates duplicated the caption regex and hard-coded the `2` that the generator declares as `SCALE`. Now parsed once in `captionGeometry()` with a message per value, so a reformatted generator says what changed instead of throwing a bare `TypeError` — verified by breaking the declaration.

Also fixes a comment in `resize_setup_window` still describing the `unwrap_or(true)` that the explicit match arms replaced in #791.

## Gates

`cargo test --workspace` 956+ green · `cargo clippy --workspace --all-targets -D warnings` clean · `cargo fmt` clean · `bun test` 855 pass / 0 fail · `npm run typecheck` clean · `npm run build` clean.

`pre-main` is #790's head, so merging this updates the release PR with no action needed there.


---

## Also: mandatory-update floor raised to 1.88.0

`tray/minimum-version` was `1.84.0`, so 1.87.x installs would have stayed on the consent banner and could decline indefinitely. At `1.88.0` every install below the release force-updates.

This is the strongest setting the packager allows. Its guard fails only when the floor **strictly** exceeds the release version, so floor == release is legal; and `update::enforce_minimum_version` compares `package_info().version < minimum`, so a 1.88.0 install does not force-update itself.

Verified against both rules:

| | |
|---|---|
| packager, release `1.88.0` | ok |
| packager, release `1.88.0-staging.N` | ok (comparison strips the prerelease suffix) |
| installed 1.84.0 / 1.87.0 / 1.87.1 | forced |
| installed 1.88.0 | consent-based |

It ships as a `Minimum-Version: 1.88.0` line inside `latest.json`'s notes, and the staging channel inherits it via `mirror-staging-release.sh`'s verbatim copy. **The floor travels with every release while this file has content** - empty it to go back to consent-based.

## Also: the A -> B -> A draft-refresh race

The remaining unresolved thread on #790 that was a real defect. `refreshDrafts` guarded on `dayRef.current !== day` and on a request number; neither catches paging away from a day and back while a refresh is in flight, because `dayRef` reads the original day again and the request number is untouched (returning to a day starts the day effect's own read, not another `refreshDrafts`). The pre-navigation response then repaints over what the return already painted.

Fixed by bumping the counter on every day transition. Regression case added and confirmed red against the unfixed source first.

All 14 review threads on #790 are now resolved - six were still open, with replies recording what was fixed and what was declined and why.
