### PR TITLE
fix(tray): report a stuck launchd bootout at WARN, not DEBUG

### DIFF
--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -1356,13 +1356,26 @@ async fn register_agent(label: &str, plist: &Path) -> Result<(), String> {
     // wait loop and carry on regardless). Only the migration path treats a stuck
     // entry as fatal — see `bootout_agent_and_wait`'s doc comment.
     //
-    // DEBUG, not WARN: this path was previously silent, and WARN+ is what egresses
-    // to central telemetry. A slow-clearing entry here is recoverable and common
-    // enough on an install/update that warning would add fleet noise to the very
-    // stream used to spot real failures — while the case that actually matters
-    // (the migration) still surfaces, through its caller.
+    // WARN, not DEBUG. This used to be `debug!` on the reasoning that WARN+ is
+    // what egresses to central telemetry and a slow-clearing entry is common
+    // enough on an install/update that warning would add fleet noise. The noise
+    // half of that does not hold, and the cost of it was severe.
+    //
+    // What this branch means: the installer is about to bootstrap the daemon
+    // while the previous one may still be running — the double-writer
+    // precondition behind the recurring `database disk image is malformed`
+    // (`code: 11`), which as of 2026-08-17 had damaged the databases of 8 hosts,
+    // every one of them macOS. Nothing else records that moment, so the one
+    // condition worth catching was the one condition that could not leave the
+    // machine.
+    //
+    // On volume: this runs only during staging, and staging only runs on a
+    // version change. Measured over the same week, the whole fleet logged 38
+    // version transitions across 28 hosts — so the ceiling here is ~38 records
+    // a week, against the ~800k `code: 11` errors a single damaged host emits
+    // in the same window. There is no noise problem to trade against.
     if let Err(e) = bootout_agent_and_wait(label).await {
-        tracing::debug!(error = %e, label, "backend_install: proceeding to bootstrap anyway");
+        tracing::warn!(error = %e, label, "backend_install: proceeding to bootstrap anyway");
     }
 
     let _ = launchctl(&["enable", &target]).await;
@@ -1415,6 +1428,46 @@ async fn launchctl(args: &[&str]) -> Result<bool, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The branch that bootstraps a launchd agent whose `bootout` never cleared
+    /// must report at **WARN**, because WARN+ is the only severity that leaves
+    /// the machine.
+    ///
+    /// That branch is the one moment the installer knowingly proceeds while the
+    /// previous daemon may still be alive - the double-writer precondition
+    /// behind the recurring `database disk image is malformed`. It was logged at
+    /// `debug!` to keep central telemetry quiet, which meant the condition could
+    /// never be observed on any of the affected machines. See the call site for
+    /// the measurement that retired that concern.
+    ///
+    /// Scanned from source rather than executed: reaching the branch needs a
+    /// stuck `launchctl` domain entry, which cannot be staged in a unit test.
+    /// Same tactic as the sibling scans in this module.
+    #[test]
+    fn a_stuck_bootout_is_reported_at_warn() {
+        const SRC: &str = include_str!("backend_install.rs");
+        // Truncate at the test module FIRST. This file scans itself, so the
+        // needle below also appears in this very function - without the cut the
+        // assertion would match its own source and could never fail.
+        let prod = SRC.split_once("\n#[cfg(test)]").map_or(SRC, |(a, _)| a);
+        let body = prod
+            .split_once("async fn register_agent")
+            .expect("register_agent must exist")
+            .1;
+        const NEEDLE: &str = "proceeding to bootstrap anyway";
+        let line = body
+            .lines()
+            .find(|l| l.contains(NEEDLE) && !l.trim_start().starts_with("//"))
+            .unwrap_or_else(|| panic!("the stuck-bootout branch should still log \"{NEEDLE}\""));
+        assert!(
+            line.contains("tracing::warn!"),
+            "the stuck-bootout branch must log at WARN, not `{}`. Only WARN+ \
+             egresses to central OpenObserve, so any lower level makes the \
+             double-writer precondition invisible on exactly the machines \
+             whose databases are being corrupted.",
+            line.trim()
+        );
+    }
 
     /// Every path out of [`ensure_backend_installed`] that could leave a daemon
     /// down must call [`crate::daemon_lifecycle::restore_unless_paused`] first.


### PR DESCRIPTION
## What

One log level, in `register_agent` (`tray/src-tauri/src/backend_install.rs`):

```diff
 if let Err(e) = bootout_agent_and_wait(label).await {
-    tracing::debug!(error = %e, label, "backend_install: proceeding to bootstrap anyway");
+    tracing::warn!(error = %e, label, "backend_install: proceeding to bootstrap anyway");
 }
```

## Why this branch specifically

It is the one moment the installer knowingly bootstraps the daemon while the
**previous** daemon may still be alive - the double-writer precondition behind
the recurring `(code: 11) database disk image is malformed`.

Only WARN+ egresses to central OpenObserve. So the single condition worth
catching was the only one that could never leave the machine.

Measured in central OO on 2026-08-17, 7-day window:

| Class | Meaning | Hosts |
|---|---|---|
| `code: 11` malformed | real b-tree damage | **8 - all macOS, zero Windows** |
| `code: 26` not a database | SQLCipher page-1 / key profile | 4, incl. the only Windows host |

Two of those hosts emit >700k errors each. Nothing in the fleet data can say
whether this branch fired on any of them, because it cannot.

## The noise trade-off it was chosen for does not hold

The original comment traded visibility away to keep central telemetry quiet.
Staging only runs on a **version change**, and over the same week the entire
fleet logged **38 version transitions across 28 hosts**. So the ceiling here is
~38 records/week fleet-wide, against ~800k from a single damaged host. There is
no noise problem to trade against, and the comment now records that measurement
so the next person does not re-litigate it from intuition.

## Context - and what this PR deliberately is not

While chasing the `backend_install` / `tauri dev` corruption lead I found the
related asymmetry at `backend_install.rs:557`: the running daemon is stopped
before staging on **Windows only** (for a file-locking reason - os error 32 -
not a database one). On macOS nothing stops the writer before the binary is
swapped.

**This PR does not change that behaviour.** I could not establish the update
path as the fleet cause, because the daemon strips error causes before they
egress (`error = %e` at 135 sites vs 56 rendering the full chain), which makes
fleet corruption undatable - a separate PR follows. Changing install ordering on
a hypothesis I cannot yet test would be the wrong move; making the condition
observable is the right one, and is correct either way.

## Test

`a_stuck_bootout_is_reported_at_warn` - a source scan, because reaching the
branch needs a stuck `launchctl` domain entry that cannot be staged in a unit
test. It bounds the scan to `register_agent` and truncates at `#[cfg(test)]`
first, so the self-scan cannot match its own literals.

Confirmed failing against `debug!` before the change:

```
the stuck-bootout branch must log at WARN, not
`tracing::debug!(error = %e, label, "backend_install: proceeding to bootstrap anyway");`
```

`cargo test -p meridian-tray`: 303 passed. Full pre-push suite green.

Note: the push initially failed on `llm::detect::tests::a_cached_verdict_is_readable_back_for_a_provider_with_no_cli`,
which is a pre-existing flake on `pre-main` (passes 3/3 on re-run, and this
commit touches only the tray crate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD4q8ABsM3gWC4AXSWL6T1