### PR TITLE
fix(observability): render the full error chain on the daemon's DB paths

### DIFF
--- a/src/coding_agent_session_ingest/indexer.rs
+++ b/src/coding_agent_session_ingest/indexer.rs
@@ -119,7 +119,7 @@ pub async fn register_session(
     let start_after = match db::sealed_high_water(pool, &uuid).await {
         Ok(v) => v,
         Err(e) => {
-            tracing::warn!(uuid = %uuid, error = %e, "sealed_high_water failed");
+            tracing::warn!(uuid = %uuid, error = %crate::errors::chain(&e), "sealed_high_water failed");
             return Outcome::Failed;
         }
     };
@@ -140,7 +140,7 @@ pub async fn register_session(
     {
         Ok(segs) => segs,
         Err(e) => {
-            tracing::warn!(uuid = %uuid, error = %e, "parse task panicked");
+            tracing::warn!(uuid = %uuid, error = %e, "parse task panicked"); // not-anyhow: this error has no source chain to walk
             return Outcome::Failed;
         }
     };
@@ -189,7 +189,7 @@ pub async fn register_segments(
             }
             Ok(None) => {} // invalid, or hit an already-sealed row (no-op)
             Err(e) => {
-                tracing::warn!(uuid = %seg.session_uuid, seg = %seg.segment_started_at, error = %e, "upsert failed");
+                tracing::warn!(uuid = %seg.session_uuid, seg = %seg.segment_started_at, error = %crate::errors::chain(&e), "upsert failed");
             }
         }
     }
@@ -216,7 +216,7 @@ pub async fn register_records(
     let start_after = match db::sealed_high_water(pool, session_uuid).await {
         Ok(v) => v,
         Err(e) => {
-            tracing::warn!(uuid = %session_uuid, error = %e, "sealed_high_water failed");
+            tracing::warn!(uuid = %session_uuid, error = %crate::errors::chain(&e), "sealed_high_water failed");
             return Outcome::Failed;
         }
     };
@@ -268,7 +268,7 @@ pub async fn run_tick(
     let mut sealed = match db::seal_stale_open_rows(pool, &now_iso, cfg.seal_idle_seconds).await {
         Ok(n) => n,
         Err(e) => {
-            tracing::warn!(error = %e, "idle seal sweep failed");
+            tracing::warn!(error = %crate::errors::chain(&e), "idle seal sweep failed");
             0
         }
     };
@@ -286,7 +286,9 @@ pub async fn run_tick(
                 }
                 sealed += n;
             }
-            Err(e) => tracing::warn!(error = %e, "hour-boundary force-seal failed"),
+            Err(e) => {
+                tracing::warn!(error = %crate::errors::chain(&e), "hour-boundary force-seal failed")
+            }
         }
     }
 
@@ -359,7 +361,9 @@ async fn seal_finished_cli_sessions(pool: &SqlitePool, now_iso: &str) -> u64 {
                     }
                     sealed += n;
                 }
-                Err(e) => tracing::warn!(source, error = %e, "exited-CLI seal failed"),
+                Err(e) => {
+                    tracing::warn!(source, error = %crate::errors::chain(&e), "exited-CLI seal failed")
+                }
             }
             continue; // nothing left live; superseded pass would be a no-op
         }
@@ -370,7 +374,9 @@ async fn seal_finished_cli_sessions(pool: &SqlitePool, now_iso: &str) -> u64 {
                 }
                 sealed += n;
             }
-            Err(e) => tracing::warn!(source, error = %e, "superseded seal failed"),
+            Err(e) => {
+                tracing::warn!(source, error = %crate::errors::chain(&e), "superseded seal failed")
+            }
         }
     }
     sealed

--- a/src/coding_agent_session_ingest/sources/mod.rs
+++ b/src/coding_agent_session_ingest/sources/mod.rs
@@ -101,7 +101,7 @@ impl AgentSource {
                 })
                 .await
                 .unwrap_or_else(|e| {
-                    tracing::warn!(error = %e, "copilot_cli collect task panicked");
+                    tracing::warn!(error = %e, "copilot_cli collect task panicked"); // not-anyhow: this error has no source chain to walk
                     Vec::new()
                 })
             }
@@ -120,7 +120,7 @@ impl AgentSource {
                 })
                 .await
                 .unwrap_or_else(|e| {
-                    tracing::warn!(error = %e, "copilot_vscode collect task panicked");
+                    tracing::warn!(error = %e, "copilot_vscode collect task panicked"); // not-anyhow: this error has no source chain to walk
                     Vec::new()
                 })
             }
@@ -159,7 +159,7 @@ pub async fn sweep(pool: &SqlitePool, now: DateTime<Utc>) -> (u64, u64) {
     let endpoints = match super::db::fetch_session_endpoints(pool).await {
         Ok(e) => e,
         Err(e) => {
-            tracing::warn!(error = %e, "source sweep: fetch endpoints failed");
+            tracing::warn!(error = %crate::errors::chain(&e), "source sweep: fetch endpoints failed");
             return (0, 0);
         }
     };

--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -426,7 +426,7 @@ async fn summarise_one_inner(
                 Err(e) => {
                     tracing::warn!(
                         row_id = row.id,
-                        error = %e,
+                        error = %e,  // not-anyhow: this error has no source chain to walk
                         "summariser fallback provider failed — leaving the row pending"
                     );
                     errors.push(format!("fallback: {e}"));
@@ -568,7 +568,7 @@ pub async fn run_loop(
     }
     let cfg = SummariserConfig::from_env();
     if let Err(e) = db::ensure_summary_source_column(&pool).await {
-        tracing::warn!(error = %e, "summariser: could not ensure summary_source column");
+        tracing::warn!(error = %crate::errors::chain(&e), "summariser: could not ensure summary_source column");
     }
     tracing::info!(
         sweep_s = cfg.sweep_interval_secs,
@@ -646,7 +646,7 @@ async fn drain(
     let rows = match db::fetch_pending(pool, cfg, cfg.batch_per_tick, &days).await {
         Ok(r) => r,
         Err(e) => {
-            tracing::warn!(error = %e, "summariser: fetch_pending failed");
+            tracing::warn!(error = %crate::errors::chain(&e), "summariser: fetch_pending failed");
             return false;
         }
     };
@@ -696,7 +696,7 @@ async fn drain(
                 .expect("record_attempt(.., written=false) always returns Some");
             if tries >= MAX_ROW_ATTEMPTS {
                 if let Err(e) = db::write_dead_letter(pool, row.id).await {
-                    tracing::error!(row_id = row.id, error = %e, "failed to dead-letter row");
+                    tracing::error!(row_id = row.id, error = %crate::errors::chain(&e), "failed to dead-letter row");
                 }
                 tracing::warn!(
                     row_id = outcome.row_id,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,165 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+
+//! One way to render an error for a log line: its **full `anyhow` source chain**.
+//!
+//! # Why this exists
+//! `tracing::warn!(error = %e, …)` renders only the **outermost** `.context()`.
+//! Everything under it - the actual cause - is dropped before the record is
+//! written, and therefore before the redacted WARN+ ship leg sends it anywhere.
+//! On a developer's machine that is a readability annoyance. On the fleet it
+//! deletes the only evidence there is, because `meridian logs` and central
+//! OpenObserve both read what `tracing` recorded, not what the error contained.
+//!
+//! Measured on 2026-08-17 while trying to date a recurring
+//! `(code: 11) database disk image is malformed` across 8 affected hosts: the
+//! daemon's DB failures arrived as bare context strings - `fetch pending
+//! summaries` x27,591, `upsert coding-agent segment` x29,159 - with no SQLite
+//! code anywhere. It was impossible to tell corruption from a missing table
+//! from a locked file, and impossible to say when any host's corruption began.
+//! One host read as a clean "corrupted with no update" case purely because a
+//! *different* component (the tray, which does render chains) happened to start
+//! reporting on a later day.
+//!
+//! This is the daemon-side counterpart of the tray's `cmd_err!` /`with_causes`
+//! (PR #704), which fixed exactly this defect for `#[tauri::command]` results.
+//! The daemon was never covered.
+//!
+//! # Who calls this
+//! Every daemon site that logs a failed database operation. The rule is enforced
+//! for the converted modules by `no_bare_error_display_in_db_paths` in
+//! `src/errors.rs`'s test module.
+//!
+//! # Related
+//! [`crate::intelligence::providers::http::classify::chain`] - the original,
+//! provider-scoped version this generalises; it now delegates here so there is
+//! still exactly one place `{e:#}` is written.
+
+/// Format an error as its FULL `anyhow` source chain.
+///
+/// Use in place of a bare `%e` wherever the cause is what a reader would need:
+///
+/// ```ignore
+/// // before - renders "fetch pending summaries", cause discarded
+/// tracing::warn!(error = %e, "summariser: fetch_pending failed");
+/// // after  - renders "fetch pending summaries: (code: 11) database disk image is malformed"
+/// tracing::warn!(error = %chain(&e), "summariser: fetch_pending failed");
+/// ```
+///
+/// Takes `&anyhow::Error` rather than a generic `impl Display` deliberately: the
+/// whole point is the `chain()` walk, and a generic would silently accept a
+/// `sqlx::Error` or a `String` and format it identically to `%e`, reintroducing
+/// the bug at a call site that looks fixed.
+pub fn chain(err: &anyhow::Error) -> String {
+    format!("{err:#}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Context;
+
+    /// The whole point: a `.context()` layer must not hide what it wraps.
+    #[test]
+    fn the_cause_survives_a_context_layer() {
+        let err = Err::<(), _>(anyhow::anyhow!(
+            "(code: 11) database disk image is malformed"
+        ))
+        .context("fetch pending summaries")
+        .unwrap_err();
+
+        // What the old `%e` rendered, and why it was useless on the fleet.
+        assert_eq!(format!("{err}"), "fetch pending summaries");
+
+        let rendered = chain(&err);
+        assert!(
+            rendered.contains("fetch pending summaries")
+                && rendered.contains("(code: 11) database disk image is malformed"),
+            "the chain must carry BOTH the context and its cause, got {rendered:?}"
+        );
+    }
+
+    /// Deeper nesting is what the DB paths actually produce - sqlx error inside
+    /// a query context inside a caller context.
+    #[test]
+    fn every_layer_of_a_deep_chain_survives() {
+        let err = Err::<(), _>(anyhow::anyhow!("disk I/O error"))
+            .context("read pm_worklog_hours")
+            .context("worklog: hour rollup")
+            .unwrap_err();
+
+        let rendered = chain(&err);
+        for layer in [
+            "worklog: hour rollup",
+            "read pm_worklog_hours",
+            "disk I/O error",
+        ] {
+            assert!(
+                rendered.contains(layer),
+                "{layer:?} missing from {rendered:?}"
+            );
+        }
+    }
+
+    /// The database modules converted by this change must not reintroduce an
+    /// **unjustified** bare `%e`, which is how the fleet lost its corruption
+    /// evidence in the first place.
+    ///
+    /// `%e` is still correct where the value is not an `anyhow::Error` - a
+    /// `JoinError`, a `sqlx::Error`, a typed enum - because there is no source
+    /// chain to walk and `%e` already renders the whole thing. Those sites carry
+    /// a `not-anyhow:` marker stating so, which is the only exemption. That is
+    /// deliberate: an unexplained `%e` is indistinguishable from the bug, so the
+    /// marker forces whoever writes one to have made the distinction on purpose.
+    /// [`chain`] takes `&anyhow::Error` rather than `impl Display` for the same
+    /// reason - the compiler finds these sites instead of formatting them
+    /// identically to the bug.
+    ///
+    /// Scoped to the DB paths rather than the whole crate on purpose: ~120 sites
+    /// elsewhere (the LLM probes, the telemetry spool, uninstall) still use
+    /// `%e`, and failing the build on those would force an unrelated sweep into
+    /// this change. Widening this list is the follow-up.
+    ///
+    /// Source-scanned because the defect is invisible at runtime - the record is
+    /// emitted, well-formed, just missing its cause. Nothing observes it.
+    #[test]
+    fn no_bare_error_display_in_db_paths() {
+        // (path, source) pairs. `include_str!` needs a literal, so this cannot
+        // be a directory walk.
+        const CONVERTED: &[(&str, &str)] = &[
+            (
+                "coding_agent_session_ingest/indexer.rs",
+                include_str!("coding_agent_session_ingest/indexer.rs"),
+            ),
+            (
+                "coding_agent_session_ingest/summariser/mod.rs",
+                include_str!("coding_agent_session_ingest/summariser/mod.rs"),
+            ),
+            (
+                "coding_agent_session_ingest/sources/mod.rs",
+                include_str!("coding_agent_session_ingest/sources/mod.rs"),
+            ),
+            ("intelligence/mod.rs", include_str!("intelligence/mod.rs")),
+        ];
+
+        for (path, src) in CONVERTED {
+            // Truncate at the test module: a converted file's own tests may
+            // legitimately format errors, and this file scans itself.
+            let prod = src.split_once("\n#[cfg(test)]").map_or(*src, |(a, _)| a);
+            let offenders: Vec<&str> = prod
+                .lines()
+                .filter(|l| l.contains("error = %e") && !l.trim_start().starts_with("//"))
+                .filter(|l| !l.contains("not-anyhow:"))
+                .map(str::trim)
+                .collect();
+            assert!(
+                offenders.is_empty(),
+                "{path} logs a bare `error = %e`, which renders only the outermost \
+                 .context() and drops the cause before it can egress. Use \
+                 `error = %crate::errors::chain(&e)` - or, if the value is not an \
+                 `anyhow::Error` and so has no chain to walk, keep `%e` and say why \
+                 with a `// not-anyhow: …` comment on the same line. \
+                 Offending line(s): {offenders:#?}"
+            );
+        }
+    }
+}

--- a/src/intelligence/mod.rs
+++ b/src/intelligence/mod.rs
@@ -28,7 +28,7 @@ pub async fn pm_tasks_present(pool: &SqlitePool) -> bool {
     {
         Ok(n) => n > 0,
         Err(e) => {
-            tracing::warn!(error = %e, "pm_tasks count failed — treating tracker as not ready");
+            tracing::warn!(error = %e, "pm_tasks count failed — treating tracker as not ready"); // not-anyhow: this error has no source chain to walk
             false
         }
     }
@@ -155,7 +155,9 @@ async fn triage_after_sync(meridian: &SqlitePool) {
             pruned = s.pruned,
             "board triaged"
         ),
-        Err(e) => tracing::warn!(error = %e, "board triage after sync failed"),
+        Err(e) => {
+            tracing::warn!(error = %crate::errors::chain(&e), "board triage after sync failed")
+        }
     }
 }
 

--- a/src/intelligence/providers/http/classify.rs
+++ b/src/intelligence/providers/http/classify.rs
@@ -184,7 +184,7 @@ impl SyncFault {
 /// goes through here so the truncation this module exists to fix cannot come
 /// back one call site at a time.
 pub fn chain(err: &anyhow::Error) -> String {
-    format!("{err:#}")
+    crate::errors::chain(err)
 }
 
 /// Decide what to do about a provider-sync failure, and format its detail.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod daily_plan;
 pub mod day_summary;
 pub mod db;
 pub mod embedder;
+pub mod errors;
 pub mod etl;
 pub mod health;
 pub mod intelligence;


### PR DESCRIPTION
## The defect

`tracing::warn!(error = %e, …)` renders only the **outermost** `.context()`.
Everything under it is dropped before the record is written — and therefore
before the redacted WARN+ ship leg can send it anywhere.

This is the same defect PR #704 fixed for `#[tauri::command]` results. The
daemon was never covered.

## Why it is worse than a readability problem

Trying to date a recurring `(code: 11) database disk image is malformed` across
**8 affected hosts** (all macOS), the daemon's DB failures arrived in central OO
looking like this:

```
WARN  fetch pending summaries              ×27,591
WARN  upsert coding-agent segment          ×29,159
WARN  seal stale open coding-agent rows
```

No SQLite code anywhere. Corruption, a missing table and a locked file are
indistinguishable, and **no host's onset can be dated**.

That is not hypothetical. `mac_10823f44b46d9214` read as a clean "corrupted with
no version change" case — a genuine counter-example to the `backend_install`
corruption lead — purely because a component that *does* render chains (the
tray) started reporting on a later day. Its daemon had been failing for three
days before that with cause-free strings. I built one argument **for** the lead
and one **against** it on those timestamps and had to withdraw both.

Until this lands, any fleet analysis keyed on the `code: 11` string is measuring
log formatting rather than the database.

## The change

Promotes the existing `chain()` — until now scoped inside
`intelligence/providers/http/classify.rs`, where a DB path could not reasonably
reach for it — to `crate::errors`, and points the provider copy at it so there
is still exactly one place `{e:#}` is written.

```diff
-tracing::warn!(error = %e, "summariser: fetch_pending failed");
+tracing::warn!(error = %crate::errors::chain(&e), "summariser: fetch_pending failed");
```

renders `fetch pending summaries: (code: 11) database disk image is malformed`
instead of `fetch pending summaries`.

## The signature is the safety mechanism

`chain` takes `&anyhow::Error`, **not** `impl Display`. That is what made the
conversion safe: the compiler located the 5 sites whose value is a `JoinError`,
`SummariserError` or `sqlx::Error` — no chain to walk, already rendering in
full. Those keep `%e` and carry a `// not-anyhow:` marker saying why.

A generic signature would have accepted all five silently and formatted them
identically to the bug, behind a call site that looked fixed.

## Scope

12 sites across the coding-agent indexer, summariser, source sweep, and
intelligence — the paths that actually produce the corruption signal.

**~120 `%e` sites elsewhere are untouched** (LLM probes, telemetry spool,
uninstall). Sweeping them here would bury the change in noise; widening the
guard's module list is the follow-up.

## Tests

- `the_cause_survives_a_context_layer` — pins the actual defect, including
  `assert_eq!(format!("{err}"), "fetch pending summaries")` so the old
  behaviour is documented rather than described.
- `every_layer_of_a_deep_chain_survives` — the shape the DB paths produce.
- `no_bare_error_display_in_db_paths` — source scan over the converted modules,
  rejecting an unjustified `%e`. Source-scanned because the defect is invisible
  at runtime: the record is emitted, well-formed, just missing its cause.

Confirmed failing before the conversion, and re-confirmed afterwards by
stripping a `not-anyhow:` marker and watching it go red.

`cargo test -p meridian --lib`: 959 passed. `cargo clippy --workspace
--all-targets -D warnings` clean.

## Companion

#794 promotes the stuck-launchd-bootout log from DEBUG to WARN — the other half
of "the corruption is happening where nothing can see it".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD4q8ABsM3gWC4AXSWL6T1