### PR TITLE
fix(plan): stop un-skipping a day from un-planning it, and scroll tour targets into view

### DIFF
--- a/meridian-core/src/readers/plan.rs
+++ b/meridian-core/src/readers/plan.rs
@@ -1211,8 +1211,41 @@ pub async fn apply_plan_action(
             tx.commit().await?;
         }
         "reopen" => {
+            // UN-SKIPPING A DAY THAT ALREADY HOLDS TASKS MUST NOT UN-COMMIT THEM.
+            //
+            // `reopen` used to clear `confirmed_at` unconditionally, and skipping
+            // does not delete `daily_plan` rows - so "Skip today" followed by
+            // "Plan today →" left the day holding its tasks with `confirmed_at`
+            // NULL. Every reader gates on that flag, so all of this went wrong at
+            // once while the planner itself still showed the tasks and said
+            // "Saved · 5 tasks":
+            //   * the dashboard's "Today's focus" renders `confirmed ? plan : []`,
+            //     so it showed the "What are you working on today?" nudge over a
+            //     day that had five tasks in it;
+            //   * [`DayPlan::is_planned`] reads it, so `day_evidence` scored the
+            //     day against NO tickets and the daily summary took its
+            //     nothing-was-planned branch with `planned_count` 0;
+            //   * [`plan_handled`] reads it, so the planner AUTO-OPENED again on a
+            //     day that was already planned.
+            // Touching anything in the planner fixed all three, because every edit
+            // routes through "confirm" - which is exactly why this looked like a
+            // display glitch rather than a write bug.
+            //
+            // So the flag follows the rows: reopening a day with tasks in it
+            // re-commits them (`now`, not the original timestamp - it is a fresh
+            // decision), and reopening an empty day leaves it genuinely
+            // uncommitted, which is the state the planner nudge is for. Same
+            // invariant the `add` arm above spells out: rows in `daily_plan` mean
+            // a user put them there, and nothing should hide them afterwards.
             let mut tx = pool.begin().await?;
-            upsert_meta(&mut tx, date, None, 0, now).await?;
+            let has_items: bool = sqlx::query_scalar::<_, i64>(
+                "SELECT 1 FROM daily_plan WHERE plan_date = ? LIMIT 1",
+            )
+            .bind(date)
+            .fetch_optional(&mut *tx)
+            .await?
+            .is_some();
+            upsert_meta(&mut tx, date, has_items.then_some(now), 0, now).await?;
             tx.commit().await?;
         }
         other => return Err(PlanWriteError::UnknownAction(other.to_string()).into()),

--- a/meridian-core/tests/readers.rs
+++ b/meridian-core/tests/readers.rs
@@ -514,7 +514,13 @@ async fn plan_write_confirm_then_reopen_roundtrip() {
     // Confirmed tasks aren't re-suggested.
     assert!(resp.suggestions.is_empty());
 
-    // reopen → confirmed cleared, committed rows kept.
+    // reopen → un-skipped, committed rows kept AND still committed.
+    //
+    // This assertion used to read `!resp.confirmed`, pinning the bug rather than
+    // the behaviour: `reopen` cleared `confirmed_at` while leaving the rows, and
+    // every reader gates on that flag. See the `reopen` arm's comment, and
+    // `reopening_a_day_with_tasks_keeps_them_committed` below for the failure it
+    // produced on screen.
     let reopen = meridian_core::plan::PlanBody {
         action: "reopen".to_string(),
         date: Some(date.clone()),
@@ -525,8 +531,13 @@ async fn plan_write_confirm_then_reopen_roundtrip() {
         meridian_core::plan::apply_plan_action(&pool, &reopen, &date, today, &now, avail().await)
             .await
             .unwrap();
-    assert!(!resp.confirmed && !resp.skipped);
+    assert!(!resp.skipped);
     assert_eq!(resp.plan.len(), 2, "reopen keeps the committed rows");
+    assert!(
+        resp.confirmed,
+        "rows survived the reopen, so the day is still planned - clearing the flag \
+         hides them from the dashboard, the summary, and the auto-open gate"
+    );
 
     // remove one → drops just that key.
     let remove = meridian_core::plan::PlanBody {
@@ -541,6 +552,95 @@ async fn plan_write_confirm_then_reopen_roundtrip() {
             .unwrap();
     let plan_keys: Vec<&str> = resp.plan.iter().map(|p| p.task_key.as_str()).collect();
     assert_eq!(plan_keys, vec!["PROJ-B"]);
+}
+
+/// THE BUG: "Skip today" then "Plan today →" left the day holding its tasks with
+/// `confirmed_at` NULL, and every reader gates on that flag - so the dashboard's
+/// "Today's focus" showed the "What are you working on today?" nudge over a plan
+/// with five tasks in it, [`meridian_core::plan::DayPlan::is_planned`] scored the
+/// day against no tickets, and `plan_handled` let the planner auto-open again.
+///
+/// The planner itself kept showing the tasks and saying "Saved", which is what
+/// made it read as a display glitch. Touching anything in it fixed the symptom,
+/// because every planner edit routes through "confirm".
+///
+/// Asserted through `apply_plan_action` rather than by inspecting the meta row:
+/// what matters is the flag every consumer actually reads.
+#[tokio::test]
+async fn reopening_a_day_with_tasks_keeps_them_committed() {
+    let pool = make_plan_pool().await;
+    let today = chrono::Local::now().date_naive();
+    let date = today.format("%Y-%m-%d").to_string();
+    seed_task(&pool, "PROJ-A", "Backlog", Some(&date), 0).await;
+    let now = chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+    let act = |action: &str, keys: Option<Vec<String>>| {
+        let body = meridian_core::plan::PlanBody {
+            action: action.to_string(),
+            date: Some(date.clone()),
+            task_key: None,
+            task_keys: keys,
+        };
+        let pool = &pool;
+        let now = now.clone();
+        let date = date.clone();
+        async move {
+            meridian_core::plan::apply_plan_action(pool, &body, &date, today, &now, Vec::new())
+                .await
+                .unwrap()
+        }
+    };
+
+    act("confirm", Some(vec!["PROJ-A".to_string()])).await;
+    act("skip", None).await;
+    let resp = act("reopen", None).await;
+
+    assert_eq!(resp.plan.len(), 1, "skip/reopen never deletes plan rows");
+    assert!(!resp.skipped, "reopen clears the skip");
+    assert!(
+        resp.confirmed,
+        "the day still holds a task, so it is still planned - a NULL confirmed_at \
+         here is what blanked Today's focus, the summary's planned branch, and the \
+         auto-open gate all at once"
+    );
+}
+
+/// The other half of the same rule: reopening a day with NOTHING in it must leave
+/// it genuinely uncommitted, which is the state the planner nudge exists for.
+/// Stamping unconditionally would silence the nudge on a day nobody has planned.
+#[tokio::test]
+async fn reopening_an_empty_day_leaves_it_unplanned() {
+    let pool = make_plan_pool().await;
+    let today = chrono::Local::now().date_naive();
+    let date = today.format("%Y-%m-%d").to_string();
+    let now = chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+    let body = |action: &str| meridian_core::plan::PlanBody {
+        action: action.to_string(),
+        date: Some(date.clone()),
+        task_key: None,
+        task_keys: None,
+    };
+
+    meridian_core::plan::apply_plan_action(&pool, &body("skip"), &date, today, &now, Vec::new())
+        .await
+        .unwrap();
+    let resp = meridian_core::plan::apply_plan_action(
+        &pool,
+        &body("reopen"),
+        &date,
+        today,
+        &now,
+        Vec::new(),
+    )
+    .await
+    .unwrap();
+
+    assert!(resp.plan.is_empty());
+    assert!(!resp.skipped);
+    assert!(
+        !resp.confirmed,
+        "an empty reopened day has not been planned - marking it committed would \
+         silence the planner nudge for a day with nothing in it"
+    );
 }
 
 #[tokio::test]

--- a/ui/__tests__/overview-focus-section.test.ts
+++ b/ui/__tests__/overview-focus-section.test.ts
@@ -18,7 +18,7 @@
 import { describe, it, expect } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { focusSectionVisible } from '../components/timeline/types'
+import { focusSectionVisible, visibleFocusItems } from '../components/timeline/types'
 
 const src = (p: string) => readFileSync(join(import.meta.dir, '..', p), 'utf8')
 const panel = src('components/timeline/OverviewPanel.tsx')
@@ -143,5 +143,43 @@ describe('the panel uses the shared predicate', () => {
     // Solo genuinely changes other things (greeting copy, the Drafts mini-card,
     // the connect-a-tracker CTA) — those are not part of this bug.
     expect(panel).toContain('isSolo')
+  })
+})
+
+// ── which plan rows the section shows ────────────────────────────────────────
+//
+// Split out as a pure function because the old inline rule (`plan.confirmed ?
+// plan.plan : []`) hid real tasks twice, through two different write paths, and
+// there was nothing to test it with - the rule lived inside a `useMemo` in a
+// component with no render harness.
+describe('visibleFocusItems', () => {
+  const items = [{ task_key: 'KAN-1' }, { task_key: 'KAN-2' }]
+
+  it('shows rows the user committed', () => {
+    expect(visibleFocusItems({ plan: items, skipped: false })).toHaveLength(2)
+  })
+
+  it('shows them even when the day is not marked confirmed', () => {
+    // THE BUG. "Skip today" then "Plan today →" cleared `confirmed_at` and left
+    // the rows, so the dashboard drew "What are you working on today?" over a
+    // plan holding five tasks - while the planner, one click away, still listed
+    // them and said "Saved". Rows in `plan.plan` only ever get there because a
+    // user put them there; suggestions live in a different field.
+    expect(visibleFocusItems({ plan: items, skipped: false, confirmed: false } as never))
+      .toHaveLength(2)
+  })
+
+  it('shows nothing for a day that was skipped', () => {
+    // The other direction, and the reason this cannot simply return `plan.plan`.
+    // Skipping STAMPS `confirmed_at`, so the old `confirmed` gate was true on a
+    // skipped day and rendered whatever rows were left over from before it -
+    // under a day the user had explicitly declined to plan. Rust's `is_planned`
+    // has always checked `!skipped`; this puts the two back on one rule.
+    expect(visibleFocusItems({ plan: items, skipped: true })).toEqual([])
+  })
+
+  it('shows nothing before the plan has loaded', () => {
+    expect(visibleFocusItems(null)).toEqual([])
+    expect(visibleFocusItems(undefined)).toEqual([])
   })
 })

--- a/ui/__tests__/setup-one-typeface.test.ts
+++ b/ui/__tests__/setup-one-typeface.test.ts
@@ -1,0 +1,82 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// The setup wizard is set in ONE typeface, and it is the app's.
+//
+// `--font-sans` is `-apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui,
+// sans-serif` (globals.css), i.e. SF Pro on macOS - and `--font-mono` is an
+// alias of it, so both tokens land on the same face. Everything in the wizard
+// resolves through one of the two, or inherits from `body`.
+//
+// This is guarded rather than assumed because the wizard has drifted twice: the
+// headings were set in Instrument Serif until they were moved onto
+// `var(--font-sans)`, and two `<code>` elements on the sign-in step were still
+// hard-coded to the browser's `monospace` after that - a third face on a screen
+// meant to have one, in the first thing a new user ever sees.
+//
+// A hard-coded family is the specific thing being caught. The tokens are fine;
+// a literal `'monospace'` / `serif` / a named font is not, because it cannot
+// follow the app if the stack ever changes.
+
+import { describe, it, expect } from 'bun:test'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+const setupRoot = join(import.meta.dir, '..', 'app', 'setup')
+
+/** Every source file under `app/setup/`, discovered rather than listed - a step
+ *  file added later is covered the day it lands. */
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else if (/\.tsx?$/.test(name)) out.push(full)
+  }
+  return out
+}
+
+/** `src` with comments removed.
+ *
+ *  Not optional. The first version of this file matched "Instrument Serif" in
+ *  `atoms.tsx`'s own header - a comment RECORDING that the headings were moved
+ *  OFF it. A source scan that reads prose as code either fails on correct code
+ *  (here) or, more often, passes because the needle it wants is sitting in a
+ *  comment; both make the guard worthless. Strings are left intact, since a
+ *  hard-coded family lives in one. */
+function code(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*(\/\/|\*).*$/gm, '')
+}
+
+describe('the setup wizard uses one typeface', () => {
+  const files = walk(setupRoot)
+
+  it('scans the whole wizard', () => {
+    // A walk that finds nothing passes every assertion below in silence.
+    expect(files.length).toBeGreaterThan(4)
+  })
+
+  it('never hard-codes a font family', () => {
+    // `fontFamily: 'inherit'` is allowed and is not a family - it is the opposite,
+    // an explicit refusal to pick one (EmailCodeForm's input uses it so the OTP
+    // boxes match the surrounding card).
+    const offenders: string[] = []
+    for (const f of files) {
+      code(readFileSync(f, 'utf8')).split('\n').forEach((line, i) => {
+        const m = line.match(/fontFamily:\s*'([^']+)'/)
+        if (!m) return
+        const value = m[1]
+        if (value.startsWith('var(--font-') || value === 'inherit') return
+        offenders.push(`${f.slice(setupRoot.length + 1)}:${i + 1}  ${value}`)
+      })
+    }
+    expect(offenders).toEqual([])
+  })
+
+  it('never reaches for a serif', () => {
+    // The wizard's headings were Instrument Serif once. The timeline UI has one
+    // voice and the wizard is the first screen of it.
+    for (const f of files) {
+      const src = code(readFileSync(f, 'utf8'))
+      expect(src, `${f} names a serif`).not.toMatch(/font-serif|Instrument Serif|Georgia/)
+    }
+  })
+})

--- a/ui/__tests__/tutorial-reveals-offscreen-targets.test.ts
+++ b/ui/__tests__/tutorial-reveals-offscreen-targets.test.ts
@@ -1,0 +1,137 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// The tour must bring a target into view before it asks the user to click it.
+//
+// THE BUG: the composer's "Where" choice - keep the task personal, or file a
+// real ticket your team can see - sits at the bottom of an `overflow-y-auto`
+// panel in `TaskComposer`. On a short window it renders below the fold. The tour
+// rang it, flew the cursor to it, said "Pick either - you can change it per
+// task", and then sat on `waitForClick(..., 120000)` waiting for a click on
+// radios the user could not see, let alone press. Two minutes later the beat
+// timed out and moved on as though the choice had been made.
+//
+// That choice is the one decision in the composer with a consequence OUTSIDE
+// Meridian - one option files a real ticket onto a shared board - so silently
+// skipping past it is the worst beat in the script to lose.
+//
+// Nothing in the tutorial scrolled, anywhere. The engine measured targets with
+// `getBoundingClientRect` and placed a ring at those coordinates, which is
+// perfectly happy to draw a ring at a position no user can reach.
+//
+// Guarded in two halves, because the two failure modes are different:
+//   1. the ENGINE's reveal rule, tested as a pure decision (below);
+//   2. the CALL SITES - a correct rule nothing invokes is not a fix.
+
+import { describe, it, expect, afterEach } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = join(import.meta.dir, '..')
+const engineSrc = readFileSync(join(root, 'components/tutorial/engine.ts'), 'utf8')
+const hookSrc = readFileSync(join(root, 'components/tutorial/useTutorial.tsx'), 'utf8')
+
+// ── the reveal decision, exercised for real ──────────────────────────────────
+//
+// `revealTarget` reads the DOM and calls `scrollIntoView`, neither of which
+// exists under bun. Both are stubbed so the DECISION - scroll, or leave it
+// alone - can be asserted directly rather than scanned for.
+
+type Box = { top: number; bottom: number; left: number; right: number }
+
+const originals = {
+  document: (globalThis as Record<string, unknown>).document,
+  window: (globalThis as Record<string, unknown>).window,
+}
+
+/** Install a fake target with `box`, and return what `revealTarget` did. */
+async function reveal(box: Box | null, viewport = { w: 1200, h: 800 }): Promise<boolean> {
+  let scrolled = false
+  const el = box && {
+    getBoundingClientRect: () => ({
+      ...box, width: box.right - box.left, height: box.bottom - box.top,
+    }),
+    scrollIntoView: () => { scrolled = true },
+  }
+  const g = globalThis as Record<string, unknown>
+  // Only the TARGET selector resolves. `tourTarget` first looks up the tour
+  // surface and, finding one, queries inside it - a stub that answers every
+  // selector hands back a fake "surface" with no `querySelector` of its own.
+  const target = '[data-tour="task-where"]'
+  g.document = { querySelector: (sel: string) => (sel === target ? el ?? null : null) }
+  g.window = { innerWidth: viewport.w, innerHeight: viewport.h }
+  // Imported inside so the stubs are in place when the module reads them.
+  const { revealTarget } = await import('../components/tutorial/engine')
+  revealTarget('[data-tour="task-where"]')
+  return scrolled
+}
+
+afterEach(() => {
+  const g = globalThis as Record<string, unknown>
+  g.document = originals.document
+  g.window = originals.window
+})
+
+describe('the tour scrolls a target into view before pointing at it', () => {
+  it('scrolls when the target is below the fold', async () => {
+    // THE REPORTED CASE: the "Where" radios sit past the bottom edge of the
+    // composer's scroller, so their rect is below the viewport.
+    expect(await reveal({ top: 820, bottom: 910, left: 400, right: 800 })).toBe(true)
+  })
+
+  it('scrolls when the target is above the fold', async () => {
+    expect(await reveal({ top: -40, bottom: 30, left: 400, right: 800 })).toBe(true)
+  })
+
+  it('leaves a fully visible target alone', async () => {
+    // Scrolling unconditionally would make every beat twitch, including the
+    // many that ring something already centred on screen.
+    expect(await reveal({ top: 300, bottom: 360, left: 400, right: 800 })).toBe(false)
+  })
+
+  it('scrolls a target sitting flush against the edge', async () => {
+    // Visible, and still not usable: the caption parks above or below the ring,
+    // so a target 10px off the bottom has nowhere to put the sentence that
+    // explains it. `REVEAL_MARGIN` is a required clearance for that reason,
+    // rather than a plain on-screen test.
+    expect(await reveal({ top: 300, bottom: 790, left: 400, right: 800 })).toBe(true)
+  })
+
+  it('does nothing when the target is missing or has no box', async () => {
+    // Beats point at things that render conditionally (the "Where" section only
+    // exists with a tracker connected). A missing target must be a no-op, not a
+    // crash inside the tour's own step runner.
+    expect(await reveal(null)).toBe(false)
+    expect(await reveal({ top: 0, bottom: 0, left: 0, right: 0 })).toBe(false)
+  })
+})
+
+describe('the reveal is actually wired into the tour', () => {
+  // A correct rule nothing calls is not a fix, and this is exactly the shape of
+  // guard that has passed vacuously before: assert the CALL, not the import.
+  const body = (name: string) => {
+    const at = hookSrc.indexOf(`      ${name}: `)
+    expect(at, `${name} is gone from the stage API`).toBeGreaterThan(-1)
+    const end = hookSrc.indexOf('\n      },', at)
+    expect(end).toBeGreaterThan(at)
+    return hookSrc.slice(at, end)
+  }
+
+  it('runs when a beat rings something', () => {
+    expect(body('spotlight')).toContain('revealTarget(sel)')
+  })
+
+  it('runs when a beat points without ringing', () => {
+    // `point` is used on its own in several beats. The cursor flying to a
+    // coordinate off the bottom of a scroller is no more useful than a ring
+    // drawn there.
+    expect(body('point')).toContain('revealTarget(sel)')
+  })
+
+  it('centres rather than doing the minimum scroll', () => {
+    // `block: 'nearest'` would satisfy "is it on screen" while leaving the
+    // target flush against an edge - where the caption, which parks above or
+    // below the ring, has nowhere sensible to go. The two constraints are not
+    // the same and only centring meets both.
+    expect(engineSrc).toContain("block: 'center'")
+  })
+})

--- a/ui/app/setup/steps.tsx
+++ b/ui/app/setup/steps.tsx
@@ -306,7 +306,13 @@ function SignInBody({ wiz }: { wiz: Wiz }) {
             <p style={{ fontSize: 14.5, fontWeight: 600, color: 'var(--t-title)' }}>Sign-in disabled</p>
             <p style={{ fontSize: 12, color: 'var(--t-muted)', marginTop: 3 }}>
               This is a source build with no Clerk publishable key configured.<br />
-              Set <code style={{ fontFamily: 'monospace', fontSize: 11 }}>CLERK_PUBLISHABLE_KEY</code> in <code style={{ fontFamily: 'monospace', fontSize: 11 }}>.env</code> to enable sign-in.
+              {/* `var(--font-mono)`, not the browser's `monospace`: the wizard has ONE
+                  voice (SF Pro, via `--font-sans`, which `--font-mono` aliases), and
+                  these two `<code>`s were the only things in the whole setup flow
+                  still rendering in a different typeface. Kept as `<code>` because
+                  they name a literal env var and a literal filename - that is what
+                  the element is for; only the family was wrong. */}
+              Set <code style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>CLERK_PUBLISHABLE_KEY</code> in <code style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>.env</code> to enable sign-in.
             </p>
           </div>
         </div>

--- a/ui/components/timeline/OverviewPanel.tsx
+++ b/ui/components/timeline/OverviewPanel.tsx
@@ -19,7 +19,7 @@ import { fmtDur } from '@/components/atoms'
 import { load as loadData, mutate as mutateData, openExternal } from '@/lib/bridge'
 import { usePlan, refreshPlan } from '@/components/plan/planStore'
 import type { PlanItem, CodingAgentsResponse } from '@/lib/api-types'
-import { focusSectionVisible, formatDayLabel, isPending } from './types'
+import { focusSectionVisible, formatDayLabel, isPending, visibleFocusItems } from './types'
 import { TimeByApp, appTotals } from './TimeByApp'
 import { TimeByCategory, categoryRows } from './TimeByCategory'
 import { UpdateCard } from './UpdateCard'
@@ -118,7 +118,7 @@ export function OverviewPanel({ data, onOpen, onOpenTask, onOpenSettings }: {
     const id = setInterval(() => refreshPlan(day), 30_000)
     return () => clearInterval(id)
   }, [day])
-  const focusItems = useMemo(() => (plan?.confirmed ? plan.plan : []), [plan])
+  const focusItems = useMemo(() => visibleFocusItems(plan), [plan])
 
   // Toggle a focus item's done state. This goes through `set_plan_task_done`,
   // NOT `apply_ticket_fix` — the latter only knows real trackers, so ticking a

--- a/ui/components/timeline/types.ts
+++ b/ui/components/timeline/types.ts
@@ -150,6 +150,38 @@ export function isPending(w: WorklogItem): boolean {
 // `planLoaded` is whether `get_plan` has resolved for this day. It gates the
 // empty case only, so an empty section never flashes before the first fetch —
 // items already imply a resolved fetch.
+/** Which of a day's plan rows "Today's focus" should show.
+ *
+ *  ROWS IN THE PLAN MEAN A USER PUT THEM THERE. Suggestions live in
+ *  `plan.suggestions` / `plan.available`, never in `plan.plan`, so a non-empty
+ *  `plan` is by construction a committed one. This used to read
+ *  `plan.confirmed ? plan.plan : []`, and that gate has now hidden real tasks
+ *  twice through two different write paths:
+ *
+ *    1. the composer's `add`, which wrote rows without stamping
+ *       `daily_plan_meta` at all (fixed in the Rust `add` arm);
+ *    2. `reopen`, which CLEARED the stamp while leaving the rows - so "Skip
+ *       today" then "Plan today →" left five tasks on screen in the planner and
+ *       the "What are you working on today?" nudge on the dashboard.
+ *
+ *  Both were write-side bugs and both are fixed there. Reading the rows rather
+ *  than the flag means a third one cannot blank this screen: the worst a missing
+ *  stamp can now do is affect surfaces that genuinely need to know whether the
+ *  ritual was performed, not hide work the user can see elsewhere in the app.
+ *
+ *  `skipped` IS still honoured, and this is where the old gate was wrong in the
+ *  other direction: skipping stamps `confirmed_at`, so `confirmed` was true on a
+ *  skipped day and leftover rows rendered under a day the user had explicitly
+ *  declined to plan. Matching Rust's [`DayPlan::is_planned`] - not skipped, and
+ *  actually holding something - puts the dashboard and the daily summary back on
+ *  one rule. */
+export function visibleFocusItems<T>(
+  plan: { plan: T[]; skipped: boolean } | null | undefined,
+): T[] {
+  if (!plan || plan.skipped) return []
+  return plan.plan
+}
+
 export function focusSectionVisible({ isToday, planLoaded, itemCount }: {
   isToday: boolean
   planLoaded: boolean

--- a/ui/components/tutorial/engine.ts
+++ b/ui/components/tutorial/engine.ts
@@ -444,6 +444,48 @@ export function tourTarget(selector: string): Element | null {
   return surface?.querySelector(selector) ?? document.querySelector(selector)
 }
 
+/** Clearance a target needs from every viewport edge before the tour treats it
+ *  as comfortably in view.
+ *
+ *  A requirement, not a tolerance: an element flush against an edge is visible
+ *  but has nowhere for the caption to park (it goes above or below the ring), so
+ *  "technically on screen" is not the test worth running. 24px is wide enough to
+ *  catch a target sitting on the boundary and narrow enough that the many beats
+ *  ringing something mid-screen never scroll at all. */
+const REVEAL_MARGIN = 24
+
+/** Bring `selector` into view before the tour rings or points at it.
+ *
+ *  THE BUG THIS FIXES: a beat can only be answered if the user can SEE what it
+ *  is asking about, and nothing here scrolled. The composer's "Where" choice -
+ *  keep the task personal, or file a real ticket your team can see - sits at the
+ *  bottom of a `overflow-y-auto` panel, so on a short window the tour rang it,
+ *  flew the cursor to it, said "Pick either", and then waited up to two minutes
+ *  on a click the user could not make: the radios were below the fold of a
+ *  container the tour had no idea it was inside.
+ *
+ *  It is not specific to that beat. Every ringed target inside a scrollable
+ *  panel had the same latent failure, which is why this lives in the engine
+ *  rather than as a scroll call in one place in the script.
+ *
+ *  `block: 'center'` rather than `'nearest'`: the caption parks above or below
+ *  the ring, so a target flush against the top or bottom edge of its scroller is
+ *  in view and still leaves the bubble nowhere sensible to go. Centring gives
+ *  both room. Smooth, because the ring and the cursor track their target per
+ *  animation frame and will follow it across rather than jumping. */
+export function revealTarget(selector: string): void {
+  const el = tourTarget(selector)
+  if (!el) return
+  const r = el.getBoundingClientRect()
+  if (r.width === 0 && r.height === 0) return
+  const hidden = r.top < REVEAL_MARGIN
+    || r.bottom > window.innerHeight - REVEAL_MARGIN
+    || r.left < REVEAL_MARGIN
+    || r.right > window.innerWidth - REVEAL_MARGIN
+  if (!hidden) return
+  el.scrollIntoView({ block: 'center', inline: 'nearest', behavior: 'smooth' })
+}
+
 /** Centre point of `selector` in viewport coordinates, or `null` if it is not
  *  on screen. Used to fly the cursor and to place the spotlight ring. */
 export function centreOf(selector: string): { x: number; y: number } | null {

--- a/ui/components/tutorial/useTutorial.tsx
+++ b/ui/components/tutorial/useTutorial.tsx
@@ -27,7 +27,7 @@ import { invoke, load } from '@/lib/bridge'
 import { connectedTrackers } from '@/lib/integrations'
 import type { IntegrationsResponse } from '@/lib/api-types'
 import {
-  Aborted, setTutorialRunning, sleep, tourTarget, tween, waitForElement,
+  Aborted, revealTarget, setTutorialRunning, sleep, tourTarget, tween, waitForElement,
   type GhostCard, type Stage, type StageChoice, type StageModal,
 } from './engine'
 import { runScript } from './script'
@@ -316,6 +316,11 @@ export function useTutorial(opts: {
       get aborted() { return abortRef.current?.signal.aborted ?? true },
       say: (t) => { setCaption(t); setCentered(false) },
       spotlight: (sel, o) => {
+        // Ringing something the user cannot see is the same as not ringing it.
+        // A target inside a scrollable panel (the composer's "Where" choice is
+        // the one that bit) can sit below the fold, and the beat then waits on a
+        // click nobody can make. See `revealTarget`.
+        if (sel) revealTarget(sel)
         setSpotlight(sel)
         // Clearing the spotlight always clears the dim with it — a blur left
         // fenced around nothing would lock the whole window.
@@ -650,6 +655,10 @@ export function useTutorial(opts: {
         // querying immediately would race React's commit.
         const el = await waitForElement(sel, sig)
         if (!el) return
+        // Beats that point WITHOUT ringing get the same treatment - the cursor
+        // flying to a coordinate off the bottom of a scroller is no more useful
+        // than a ring there.
+        revealTarget(sel)
         setCursorPoint(null)
         setCursorAt(sel)
         await sleep(900, sig)


### PR DESCRIPTION
Three reported bugs. The first turned out to be a **write** bug that had been silently breaking three separate surfaces, not the display glitch it looked like.

## 1. "Today's focus" showed the empty-state nudge over a day holding five tasks

`reopen` cleared `daily_plan_meta.confirmed_at` unconditionally, and skipping never deletes the `daily_plan` rows. So **Skip today → "Plan today →"** left the day holding its tasks with the flag NULL - and every reader gates on that flag:

| surface | what it read | what the user got |
|---|---|---|
| dashboard "Today's focus" | `confirmed ? plan : []` | the "What are you working on today?" CTA over a populated plan |
| `DayPlan::is_planned` → `day_evidence` | `confirmed && !skipped && !items.is_empty()` | the day scored against **no tickets**; daily summary took its nothing-was-planned branch, `planned_count` 0 |
| `plan_handled` → `plan_auto_open` | `confirmed_at.is_some() \|\| skipped` | the planner **auto-opened again** on an already-planned day |

Touching anything in the planner fixed all three at once, because every planner edit routes through `confirm` - which is exactly why this read as a rendering problem.

**Fixed at the write boundary.** Reopening a day that holds tasks re-commits them (`now`, a fresh decision); reopening an empty day stays uncommitted, which is the state the nudge is for.

`plan_write_confirm_then_reopen_roundtrip` **asserted the old behaviour** (`assert!(!resp.confirmed)`) - it is corrected in place with the reasoning rather than quietly flipped, plus two dedicated tests for the two halves of the rule.

**Also hardened on the read side.** `visibleFocusItems` replaces the inline `plan.confirmed ? plan.plan : []`. Rows only reach `plan.plan` because a user put them there - suggestions live in `plan.suggestions` / `plan.available` - so reading the rows rather than the flag means a third missing stamp cannot blank the screen. This is the *second* time that gate has hidden real tasks; the `add` arm had the same bug and its fix comment says so.

That gate was **also wrong in the other direction**: skipping *stamps* `confirmed_at`, so `confirmed` was true on a skipped day and leftover rows rendered under a day the user had explicitly declined to plan. The new predicate matches Rust's `is_planned`, putting the dashboard and the summary back on one rule.

## 2. The tour rang a choice the user could not see

The composer's **Where** choice - keep it personal, or file a real ticket your team can see - sits at the bottom of an `overflow-y-auto` panel. On a short window it renders below the fold. The tour rang it, flew the cursor to it, said "Pick either", then sat on `waitForClick(..., 120000)` waiting for a click on radios the user could not reach - and after two minutes moved on as though the choice had been made.

That is the one decision in the composer with a consequence **outside** Meridian, so silently skipping it is the worst beat in the script to lose.

**Nothing in the tutorial scrolled, anywhere.** The engine measured targets with `getBoundingClientRect` and was perfectly happy to draw a ring at a position no user could reach. `revealTarget` now scrolls a target into view from both `spotlight` and `point`, so every ringed target inside a scroller is covered - not just this beat.

`block: 'center'` rather than `'nearest'`: the caption parks above or below the ring, so a target flush against an edge satisfies "is it on screen" and is still unusable.

## 3. Onboarding typeface

The wizard was already SF Pro throughout (`var(--font-sans)`); the headings moved off Instrument Serif previously. The only divergence left was two `<code>` elements on the sign-in step hard-coded to the browser's `monospace` - now `var(--font-mono)` (an alias of `--font-sans`), with a guard so a hard-coded family cannot come back.

**Note on Windows:** `--font-sans` is `-apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif`, which resolves to SF Pro on macOS and correctly falls through to Segoe UI on Windows. Apple's license does not permit shipping SF Pro in a Windows app, so "everything is SF Pro" is true on macOS and structurally cannot be on Windows. Making the two match would mean adopting a different vendored face app-wide - a design decision, deliberately not taken here.

## Verification

Every fix mutation-checked - reverting each one makes its own test fail:

- reopen: `assert!(resp.confirmed)` fails without the arm change
- `visibleFocusItems`: the skipped-day and unconfirmed-day cases both fail against the old rule
- `revealTarget`: removing the `spotlight` call site fails the wiring test; the below-fold / above-fold / flush-to-edge decisions are exercised against a stubbed DOM rather than scanned for
- typeface: restoring `'monospace'` fails the guard

One guard needed fixing mid-flight: the serif check matched `atoms.tsx`'s own comment *recording* that the headings were moved off Instrument Serif, so it now scans comment-stripped source.

## Gates

`cargo test --workspace` 956+ green across 26 suites · `cargo clippy --workspace --all-targets -D warnings` clean · `cargo fmt` clean · `bun test` 879 pass / 0 fail · `npm run typecheck` clean · `npm run build` clean.
