### PR TITLE
chore(readme): swap Product Hunt badge to top-post-badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<a href="https://www.producthunt.com/products/meridian-16?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-meridian-19" target="_blank" rel="noopener noreferrer"><img alt="Meridian - Don't let your work go unnoticed. Get promoted! | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1222691&theme=light&t=1786882777866"></a>
+<a href="https://www.producthunt.com/products/meridian-16?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-meridian-19" target="_blank" rel="noopener noreferrer"><img alt="Meridian - Don't let your work go unnoticed. Get promoted! | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1222691&theme=light&period=daily&t=1787037236493"></a>
 
 <br>
 <br>


### PR DESCRIPTION
## Summary
- Swap the Product Hunt README badge from the `featured` campaign image/link to the `top-post-badge` variant per the latest embed snippet from Product Hunt.

## Test plan
- [x] Rendered the markdown link/image locally to confirm it matches the provided embed snippet