### PR TITLE
fix(tray): Clerk sign-in parsing, dropped error chains, and orphaned draft timeouts

### DIFF
--- a/tray/src-tauri/src/commands/cli_exec.rs
+++ b/tray/src-tauri/src/commands/cli_exec.rs
@@ -56,12 +56,28 @@ pub(crate) async fn run_meridian(
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
+        // On timeout below, `tokio::time::timeout` drops the output future; without
+        // this the orphaned `meridian <args>` keeps running in the background after
+        // the UI reports a failure — for an LLM-backed call like `plan-task-draft`,
+        // that means the retry the user clicks next spawns a SECOND CLI process
+        // racing the first one for the same provider/DB, which is how a slow draft
+        // compounds into a retry loop that never finishes. See `tasks.rs::sync_tasks`
+        // for the sibling fix this mirrors.
+        .kill_on_drop(true)
         .no_window()
         .output();
 
     let output = match tokio::time::timeout(timeout, child).await {
         Err(_) => {
-            tracing::warn!(bin = %bin, timeout_s = timeout.as_secs(), "{label}: timed out");
+            // `kill_on_drop` reaps the child here, taking its stderr with it, so
+            // this log (bin + cwd, matching the spawn/non-zero arms below) is the
+            // only record a timeout leaves.
+            tracing::warn!(
+                bin = %bin,
+                cwd = %home.display(),
+                timeout_s = timeout.as_secs(),
+                "{label}: timed out"
+            );
             return Err(format!("{label} timed out"));
         }
         Ok(Err(e)) => {
@@ -184,5 +200,41 @@ pub(crate) async fn run_meridian_json<T: for<'de> Deserialize<'de>>(
                 "{label}: {bin} returned no result. It may be older than this app - reinstall or rebuild it."
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Regression guard: on a timeout, `tokio::time::timeout` drops the
+    /// `.output()` future, and without `kill_on_drop(true)` the spawned
+    /// `meridian <args>` keeps running in the background after the caller has
+    /// already reported failure to the user. For an LLM-backed call like
+    /// `plan-task-draft`, that orphan then competes with the next "Try again"
+    /// click's fresh process for the same provider/DB — a plausible reason a
+    /// draft that missed its 150s budget once keeps missing it on retry.
+    ///
+    /// Not runnable as a real spawn-and-verify test: `run_meridian` resolves
+    /// its binary via `crate::install::meridian_bin()`, and overriding that
+    /// via `MERIDIAN_BIN` would mean `std::env::set_var` on a shared test
+    /// binary — exactly what `integrations.rs`'s "avoiding `std::env::set_var`
+    /// on a Tokio worker thread" note warns off. Source-scanned instead,
+    /// mirroring `tasks.rs::sync_tasks`, the sibling call site that already
+    /// carries this fix.
+    #[test]
+    fn run_meridian_kills_the_child_on_timeout() {
+        let src = include_str!("cli_exec.rs");
+        let prod = src.split_once("\n#[cfg(test)]").map_or(src, |(a, _)| a);
+        let spawn = prod
+            .find("tokio::process::Command::new(&bin)")
+            .expect("run_meridian's Command builder moved or was renamed");
+        let output_call = prod[spawn..]
+            .find(".output();")
+            .expect("run_meridian's Command builder no longer ends in .output()");
+        let builder = &prod[spawn..spawn + output_call];
+        assert!(
+            builder.contains(".kill_on_drop(true)"),
+            "run_meridian's spawned child is missing .kill_on_drop(true) — a \
+             timeout will orphan it instead of killing it. Builder was: {builder}"
+        );
     }
 }

--- a/tray/src-tauri/src/commands/cli_exec.rs
+++ b/tray/src-tauri/src/commands/cli_exec.rs
@@ -205,6 +205,9 @@ pub(crate) async fn run_meridian_json<T: for<'de> Deserialize<'de>>(
 
 #[cfg(test)]
 mod tests {
+    use std::process::Stdio;
+    use std::time::Duration;
+
     /// Regression guard: on a timeout, `tokio::time::timeout` drops the
     /// `.output()` future, and without `kill_on_drop(true)` the spawned
     /// `meridian <args>` keeps running in the background after the caller has
@@ -213,13 +216,17 @@ mod tests {
     /// click's fresh process for the same provider/DB — a plausible reason a
     /// draft that missed its 150s budget once keeps missing it on retry.
     ///
-    /// Not runnable as a real spawn-and-verify test: `run_meridian` resolves
-    /// its binary via `crate::install::meridian_bin()`, and overriding that
-    /// via `MERIDIAN_BIN` would mean `std::env::set_var` on a shared test
-    /// binary — exactly what `integrations.rs`'s "avoiding `std::env::set_var`
-    /// on a Tokio worker thread" note warns off. Source-scanned instead,
-    /// mirroring `tasks.rs::sync_tasks`, the sibling call site that already
-    /// carries this fix.
+    /// This can't drive `run_meridian` itself as a real spawn-and-verify test:
+    /// it resolves its binary via `crate::install::meridian_bin()`, and
+    /// overriding that via `MERIDIAN_BIN` would mean `std::env::set_var` on a
+    /// shared test binary — exactly what `integrations.rs`'s "avoiding
+    /// `std::env::set_var` on a Tokio worker thread" note warns off. So this
+    /// is source-scanned, mirroring `tasks.rs::sync_tasks`, the sibling call
+    /// site that already carries this fix. The MECHANISM itself — that
+    /// `kill_on_drop(true)` actually terminates an orphaned child, on this
+    /// platform, with tokio's real process reaping — is verified separately
+    /// below, against a plain `tokio::process::Command` that needs no
+    /// `MERIDIAN_BIN` override at all.
     #[test]
     fn run_meridian_kills_the_child_on_timeout() {
         let src = include_str!("cli_exec.rs");
@@ -235,6 +242,97 @@ mod tests {
             builder.contains(".kill_on_drop(true)"),
             "run_meridian's spawned child is missing .kill_on_drop(true) — a \
              timeout will orphan it instead of killing it. Builder was: {builder}"
+        );
+    }
+
+    /// A process that runs far longer than the timeout below, so the timeout
+    /// always wins the race — the exact shape `run_meridian` puts its child
+    /// in. No dependency on `meridian`/`MERIDIAN_BIN`: `sleep`/`ping` are
+    /// present on every macOS and Windows runner this crate's tests run on
+    /// (see `.github/workflows/ci.yml`'s `windows-latest` + `macos-latest`
+    /// `cargo test --workspace` jobs).
+    #[cfg(unix)]
+    fn long_running_command() -> (&'static str, &'static [&'static str]) {
+        ("sleep", &["30"])
+    }
+    #[cfg(windows)]
+    fn long_running_command() -> (&'static str, &'static [&'static str]) {
+        // `timeout.exe` refuses to run with stdin redirected (no console
+        // handle) — `ping` to loopback is the standard "sleep N seconds"
+        // substitute on Windows and needs no real network.
+        ("ping", &["-n", "30", "127.0.0.1"])
+    }
+
+    #[cfg(unix)]
+    fn process_is_alive(pid: u32) -> bool {
+        std::process::Command::new("ps")
+            .args(["-p", &pid.to_string()])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+    #[cfg(windows)]
+    fn process_is_alive(pid: u32) -> bool {
+        // `tasklist` exits 0 either way, printing "No tasks are running..."
+        // when nothing matches — the pid has to actually appear in the
+        // output, not just a success status.
+        std::process::Command::new("tasklist")
+            .args(["/FI", &format!("PID eq {pid}"), "/NH"])
+            .output()
+            .map(|o| String::from_utf8_lossy(&o.stdout).contains(&pid.to_string()))
+            .unwrap_or(false)
+    }
+
+    /// Proves the MECHANISM `run_meridian_kills_the_child_on_timeout` pins the
+    /// wiring for: that `kill_on_drop(true)` on a `tokio::process::Command`
+    /// actually terminates the child once the future racing it is dropped —
+    /// i.e. that this fix does what its own reasoning claims, not just that
+    /// the flag is textually present.
+    #[tokio::test]
+    async fn kill_on_drop_actually_terminates_the_orphaned_child() {
+        let (bin, args) = long_running_command();
+        let child = tokio::process::Command::new(bin)
+            .args(args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("failed to spawn the long-running test process");
+        let pid = child.id().expect("a just-spawned child must have a pid");
+        assert!(
+            process_is_alive(pid),
+            "test bug: process not observed alive right after spawn"
+        );
+
+        {
+            // Mirrors `run_meridian` exactly: race the child's `.output()`
+            // against a timeout far shorter than the process's own runtime.
+            let output_fut = child.wait_with_output();
+            let result = tokio::time::timeout(Duration::from_millis(50), output_fut).await;
+            assert!(
+                result.is_err(),
+                "test bug: the process exited before the timeout could fire"
+            );
+            // `output_fut` (and the `Child` it consumed) drops here — exactly
+            // what happens when `tokio::time::timeout` drops `run_meridian`'s
+            // `.output()` future on a real timeout.
+        }
+
+        // `kill_on_drop`'s kill is fired from `Drop`, not awaited to
+        // completion — poll briefly rather than asserting instantaneously.
+        let mut still_alive = process_is_alive(pid);
+        for _ in 0..20 {
+            if !still_alive {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            still_alive = process_is_alive(pid);
+        }
+        assert!(
+            !still_alive,
+            "child (pid {pid}) is still running ~2s after being dropped — \
+             kill_on_drop did not terminate it"
         );
     }
 }

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -1041,4 +1041,153 @@ mod tests {
             "reconciling a stale notice must not toast - nothing is being asked of the user"
         );
     }
+
+    /// A pool with the schema MISSING entirely — no `sqlx::migrate!` — so
+    /// `SELECT … FROM active_session` / `… FROM app_sessions` fail with a real
+    /// `no such table` error. This is exactly the shape a genuinely broken
+    /// install (corruption, a stale binary ahead of migrations) produces, and
+    /// it is what let the field incident this fix targets happen: the DB error
+    /// was real, just never logged past its outer context.
+    async fn unmigrated_db() -> meridian_core::SqlitePool {
+        use sqlx::sqlite::SqliteConnectOptions;
+        use std::str::FromStr;
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+            .unwrap()
+            .create_if_missing(true);
+        meridian_core::SqlitePool::connect_with(opts).await.unwrap()
+    }
+
+    /// One captured tracing event: level + `(field name, debug-formatted
+    /// value)` pairs — same shape `commands::setup`'s tests use, so a reader
+    /// who has seen that pattern recognizes this one.
+    #[derive(Debug)]
+    struct CapturedEvent {
+        level: tracing::Level,
+        fields: Vec<(String, String)>,
+    }
+
+    /// Target-scoped to this module, not every event — an unmigrated pool
+    /// also makes `sqlx` itself log the query failure, and without the scope
+    /// this test could pass by matching sqlx's OWN warning instead of the
+    /// `tracing::warn!` this fix touches (see `pm_worklog::post`'s tests,
+    /// which hit the identical hazard for the identical reason).
+    struct Recorder(std::sync::Arc<std::sync::Mutex<Vec<CapturedEvent>>>);
+
+    impl<S: tracing::Subscriber> tracing_subscriber::layer::Layer<S> for Recorder {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if event.metadata().target() != "meridian_tray_lib::poll::refresh" {
+                return;
+            }
+            struct FieldVisitor(Vec<(String, String)>);
+            impl tracing::field::Visit for FieldVisitor {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    self.0
+                        .push((field.name().to_string(), format!("{value:?}")));
+                }
+            }
+            let mut visitor = FieldVisitor(Vec::new());
+            event.record(&mut visitor);
+            self.0.lock().unwrap().push(CapturedEvent {
+                level: *event.metadata().level(),
+                fields: visitor.0,
+            });
+        }
+    }
+
+    /// Runs `f` under a recording subscriber on a CURRENT-THREAD runtime, so
+    /// the thread-local subscriber `with_default` installs stays active
+    /// across every `.await` inside `f` — the same technique
+    /// `pm_worklog::post`'s `levels_during_async` uses, for the same reason
+    /// (a multi-thread runtime could hop the future to a thread where the
+    /// subscriber was never installed).
+    fn capture_async<F: std::future::Future<Output = ()>>(
+        f: impl FnOnce() -> F,
+    ) -> Vec<CapturedEvent> {
+        use tracing_subscriber::layer::SubscriberExt;
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber =
+            tracing_subscriber::registry().with(Recorder(std::sync::Arc::clone(&seen)));
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        tracing::subscriber::with_default(subscriber, || rt.block_on(f()));
+        let events = std::mem::take(&mut *seen.lock().unwrap());
+        events
+    }
+
+    fn field<'a>(event: &'a CapturedEvent, name: &str) -> Option<&'a str> {
+        event
+            .fields
+            .iter()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v.as_str())
+    }
+
+    /// The end-to-end regression the source-scan test above can't reach: not
+    /// just that the code SAYS `chain(&e)`, but that a REAL failure actually
+    /// logs the full cause. Pins the exact field incident `meridian::errors`'
+    /// module doc describes — before this fix, only `error = "active: fetch
+    /// active_session"` would have shipped, with the real cause (there,
+    /// `(code: 11) database disk image is malformed`; here, `no such table`)
+    /// silently discarded.
+    #[test]
+    fn refresh_active_logs_the_cause_not_just_the_outer_context() {
+        let state = Arc::new(Mutex::new(AppState::default()));
+        let events = capture_async(move || {
+            let state = Arc::clone(&state);
+            async move {
+                let pool = unmigrated_db().await;
+                refresh_active(&pool, &state).await;
+            }
+        });
+
+        let warn = events
+            .iter()
+            .find(|e| e.level == tracing::Level::WARN)
+            .expect("refresh_active must warn on a DB read failure");
+        let error = field(warn, "error").expect("expected an `error` field");
+        assert!(
+            error.contains("active: fetch active_session"),
+            "outer context lost: {error}"
+        );
+        assert!(
+            error.contains("no such table"),
+            "the actual cause was dropped — got only: {error}"
+        );
+    }
+
+    #[test]
+    fn refresh_current_task_logs_the_cause_not_just_the_outer_context() {
+        let state = Arc::new(Mutex::new(AppState::default()));
+        let events = capture_async(move || {
+            let state = Arc::clone(&state);
+            async move {
+                let pool = unmigrated_db().await;
+                refresh_current_task(&pool, &state).await;
+            }
+        });
+
+        let warn = events
+            .iter()
+            .find(|e| e.level == tracing::Level::WARN)
+            .expect("refresh_current_task must warn on a DB read failure");
+        let error = field(warn, "error").expect("expected an `error` field");
+        assert!(
+            error.contains("current_task: fetch most recent task session"),
+            "outer context lost: {error}"
+        );
+        assert!(
+            error.contains("no such table"),
+            "the actual cause was dropped — got only: {error}"
+        );
+    }
 }

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -407,7 +407,11 @@ pub(super) async fn refresh_active(pool: &SqlitePool, state: &Arc<Mutex<AppState
         }),
         Ok(None) => None,
         Err(e) => {
-            tracing::warn!(error = %e, "refresh_active failed");
+            // `%e` renders only `e`'s outermost `.context()` — see
+            // `meridian::errors::chain`'s doc for why a bare `%e` here would
+            // drop exactly the cause (e.g. a corrupt DB's SQLite code) that a
+            // reader needs.
+            tracing::warn!(error = %meridian::errors::chain(&e), "refresh_active failed");
             return;
         }
     };
@@ -445,7 +449,9 @@ pub(super) async fn refresh_current_task(pool: &SqlitePool, state: &Arc<Mutex<Ap
                 .as_ref()
                 .and_then(|c| c.estimate_s.map(|e| e.max(0) as u64));
         }
-        Err(e) => tracing::warn!(error = %e, "refresh_current_task failed"),
+        Err(e) => {
+            tracing::warn!(error = %meridian::errors::chain(&e), "refresh_current_task failed")
+        }
     }
 }
 
@@ -640,6 +646,48 @@ mod tests {
             "refresh_health no longer passes the staging flag - its restart \
              races the installer's binary swap, exactly as the watchdog's did"
         );
+    }
+
+    /// Regression guard: a bare `error = %e` on an `anyhow::Error` renders only
+    /// its outermost `.context()` and drops the actual cause — see
+    /// `meridian::errors::chain`'s doc for the field incident this same defect
+    /// caused on the daemon side. This is exactly how, in the field,
+    /// `refresh_active failed` / `refresh_current_task failed` arrived on over
+    /// half of one day's new installs as bare context strings
+    /// (`"active: fetch active_session"` / `"current_task: fetch most recent
+    /// task session"`) with no underlying DB error visible anywhere.
+    ///
+    /// Scoped to just these two functions' bodies, not the whole file: the
+    /// other `%e` sites here (`refresh_health`'s notice paths, `refresh_today`,
+    /// `refresh_worklogs`) are a separate, unverified sweep — see
+    /// `meridian::errors::chain`'s own doc on why converting everything at
+    /// once would bury the fix this guard is pinning.
+    #[test]
+    fn refresh_active_and_current_task_render_the_full_error_chain() {
+        let whole = include_str!("refresh.rs");
+        for func in ["refresh_active", "refresh_current_task"] {
+            let start = whole
+                .find(&format!("pub(super) async fn {func}"))
+                .unwrap_or_else(|| panic!("{func} not found in refresh.rs"));
+            let body = &whole[start..];
+            let end = body[1..]
+                .find("\npub(super) async fn ")
+                .map(|i| i + 1)
+                .or_else(|| body.find("\n#[cfg(test)]"))
+                .unwrap_or(body.len());
+            let offenders: Vec<&str> = body[..end]
+                .lines()
+                .filter(|l| l.contains("error = %e") && !l.trim_start().starts_with("//"))
+                .map(str::trim)
+                .collect();
+            assert!(
+                offenders.is_empty(),
+                "{func} logs a bare `error = %e`, which drops everything under the \
+                 outermost .context() before it can be logged or shipped — use \
+                 `error = %meridian::errors::chain(&e)` instead. Offending line(s): \
+                 {offenders:#?}"
+            );
+        }
     }
 
     /// The exact bug this fix targets: a fresh tray process (all counters at

--- a/tray/src-tauri/vendor/tauri-plugin-clerk/src/json_backfill.rs
+++ b/tray/src-tauri/vendor/tauri-plugin-clerk/src/json_backfill.rs
@@ -79,11 +79,31 @@ const TIMESTAMP_KEYS: &[&str] = &[
     "last_used_at",
 ];
 
+/// guest-js serializes the client's in-flight `sign_in`/`sign_up` resources
+/// with the short JS-side object name (`"sign_in"` / `"sign_up"`) instead of
+/// clerk-js's real `object` value. `clerk-fapi-rs`'s generated `ClientSignIn`/
+/// `ClientSignUp` models each type `object` as a single-variant enum that only
+/// accepts `"sign_in_attempt"` / `"sign_up_attempt"` (see
+/// `client_sign_in.rs`/`client_sign_up.rs` upstream), so the mismatch fails
+/// deserialization with `unknown variant "sign_in", expected "sign_in_attempt"`
+/// on every real sign-in — a fresh sibling of the missing-field bug this module
+/// otherwise fixes, but on a key that IS present rather than absent, so
+/// `defaults_for`'s `entry(..).or_insert(..)` can never reach it; the value
+/// has to be rewritten in place instead.
+fn canonical_object_type(raw: &str) -> &str {
+    match raw {
+        "sign_in" => "sign_in_attempt",
+        "sign_up" => "sign_up_attempt",
+        other => other,
+    }
+}
+
 /// Recursively normalize a Clerk `client` JSON tree (or any subtree of one)
 /// so it deserializes cleanly into `clerk-fapi-rs`'s models. Mutates in
 /// place; safe to call on an already-well-formed payload (every backfill is
 /// an `entry(..).or_insert(..)` and every timestamp rewrite is a no-op on an
-/// already-integral value).
+/// already-integral value, and `canonical_object_type` is a no-op on an
+/// already-canonical `object`).
 pub(crate) fn backfill_clerk_client_json(value: &mut Value) {
     match value {
         Value::Array(items) => {
@@ -97,7 +117,11 @@ pub(crate) fn backfill_clerk_client_json(value: &mut Value) {
                 // Borrow-check: collect the (owned) defaults before touching
                 // `map` again, since `object_type` borrows from it.
                 let object_type = object_type.to_string();
-                for (key, default) in defaults_for(&object_type) {
+                let canonical = canonical_object_type(&object_type).to_string();
+                if canonical != object_type {
+                    map.insert("object".to_string(), json!(canonical));
+                }
+                for (key, default) in defaults_for(&canonical) {
                     map.entry(*key).or_insert_with(default);
                 }
             }
@@ -277,5 +301,78 @@ mod tests {
         backfill_clerk_client_json(&mut value);
         assert_eq!(value["created_at"], json!(100));
         assert_eq!(value["sessions"][0]["created_at"], json!(200));
+    }
+
+    /// A client's in-flight sign-in, shaped exactly as guest-js emits it: the
+    /// `object` discriminator is the short JS resource name `"sign_in"`, not
+    /// clerk-fapi-rs's `"sign_in_attempt"`. Every other field is present and
+    /// well-typed — this is purely the discriminator mismatch production hit.
+    fn guest_js_shaped_sign_in_json() -> Value {
+        json!({
+            "object": "sign_in",
+            "id": "sign_in_abc123",
+            "status": "needs_first_factor",
+            "supported_identifiers": ["email_address"],
+            "supported_first_factors": null,
+            "supported_second_factors": null,
+            "first_factor_verification": null,
+            "second_factor_verification": null,
+            "identifier": "user@example.com",
+            "user_data": null,
+            "created_session_id": null,
+            "abandon_at": 1719765690
+        })
+    }
+
+    /// Pins the production bug: `unknown variant "sign_in", expected
+    /// "sign_in_attempt"`, hit by every real user with an in-flight sign-in.
+    #[test]
+    fn without_the_fix_guest_js_sign_in_object_type_fails_to_deserialize() {
+        let value = guest_js_shaped_sign_in_json();
+        assert!(
+            serde_json::from_value::<clerk_fapi_rs::models::ClientSignIn>(value).is_err(),
+            "fixture no longer reproduces the upstream mismatch — if clerk-fapi-rs \
+             relaxed its schema, this test (not the fix) should be revisited"
+        );
+    }
+
+    #[test]
+    fn backfill_canonicalizes_the_sign_in_object_type() {
+        let mut value = guest_js_shaped_sign_in_json();
+        backfill_clerk_client_json(&mut value);
+        assert_eq!(value["object"], json!("sign_in_attempt"));
+        serde_json::from_value::<clerk_fapi_rs::models::ClientSignIn>(value).expect(
+            "backfilled sign_in payload must deserialize into clerk-fapi-rs's ClientSignIn",
+        );
+    }
+
+    /// The same rewrite applied recursively, inside a whole client tree —
+    /// not just when `ClientSignIn` is deserialized standalone.
+    #[test]
+    fn backfill_canonicalizes_sign_in_nested_inside_a_client() {
+        let mut value = json!({
+            "object": "client",
+            "sign_in": guest_js_shaped_sign_in_json(),
+            "sign_up": null,
+        });
+        backfill_clerk_client_json(&mut value);
+        assert_eq!(value["sign_in"]["object"], json!("sign_in_attempt"));
+    }
+
+    /// `sign_up` carries the identical bug class (`"sign_up"` vs
+    /// `"sign_up_attempt"`) — covered at the canonicalizer level since a full
+    /// `ClientSignUp` fixture needs a `verifications` sub-object this bug has
+    /// nothing to do with.
+    #[test]
+    fn canonicalizes_sign_up_the_same_way_as_sign_in() {
+        assert_eq!(canonical_object_type("sign_up"), "sign_up_attempt");
+    }
+
+    /// An already-canonical `object` must not be touched — only the two known
+    /// guest-js short names are remapped.
+    #[test]
+    fn canonical_object_type_is_a_no_op_on_correct_and_unrelated_values() {
+        assert_eq!(canonical_object_type("sign_in_attempt"), "sign_in_attempt");
+        assert_eq!(canonical_object_type("user"), "user");
     }
 }

--- a/tray/src-tauri/vendor/tauri-plugin-clerk/src/json_backfill.rs
+++ b/tray/src-tauri/vendor/tauri-plugin-clerk/src/json_backfill.rs
@@ -375,4 +375,121 @@ mod tests {
         assert_eq!(canonical_object_type("sign_in_attempt"), "sign_in_attempt");
         assert_eq!(canonical_object_type("user"), "user");
     }
+
+    /// A client's in-flight sign-up, shaped as guest-js emits it — the
+    /// `sign_up` counterpart to `guest_js_shaped_sign_in_json`. `verifications`
+    /// is the one field `ClientSignUp` requires that `ClientSignIn` does not
+    /// (each of its four sub-fields is `Option::deserialize`, so `null` is
+    /// valid but the KEY must be present).
+    fn guest_js_shaped_sign_up_json() -> Value {
+        json!({
+            "object": "sign_up",
+            "id": "sign_up_abc123",
+            "status": "missing_requirements",
+            "required_fields": ["email_address"],
+            "optional_fields": [],
+            "missing_fields": ["email_address"],
+            "unverified_fields": [],
+            "verifications": {
+                "email_address": null,
+                "phone_number": null,
+                "web3_wallet": null,
+                "external_account": null
+            },
+            "username": null,
+            "email_address": "user@example.com",
+            "phone_number": null,
+            "web3_wallet": null,
+            "password_enabled": true,
+            "first_name": null,
+            "last_name": null,
+            "custom_action": false,
+            "external_id": null,
+            "created_session_id": null,
+            "created_user_id": null,
+            "abandon_at": 1719765690,
+            "legal_accepted_at": null
+        })
+    }
+
+    /// The `sign_up` counterpart to `without_the_fix_guest_js_sign_in_object_type_fails_to_deserialize`
+    /// — pins that the discriminator mismatch is not sign_in-specific.
+    #[test]
+    fn without_the_fix_guest_js_sign_up_object_type_fails_to_deserialize() {
+        let value = guest_js_shaped_sign_up_json();
+        assert!(
+            serde_json::from_value::<clerk_fapi_rs::models::ClientSignUp>(value).is_err(),
+            "fixture no longer reproduces the upstream mismatch — if clerk-fapi-rs \
+             relaxed its schema, this test (not the fix) should be revisited"
+        );
+    }
+
+    #[test]
+    fn backfill_canonicalizes_the_sign_up_object_type() {
+        let mut value = guest_js_shaped_sign_up_json();
+        backfill_clerk_client_json(&mut value);
+        assert_eq!(value["object"], json!("sign_up_attempt"));
+        serde_json::from_value::<clerk_fapi_rs::models::ClientSignUp>(value).expect(
+            "backfilled sign_up payload must deserialize into clerk-fapi-rs's ClientSignUp",
+        );
+    }
+
+    #[test]
+    fn backfill_canonicalizes_sign_up_nested_inside_a_client() {
+        let mut value = json!({
+            "object": "client",
+            "sign_in": null,
+            "sign_up": guest_js_shaped_sign_up_json(),
+        });
+        backfill_clerk_client_json(&mut value);
+        assert_eq!(value["sign_up"]["object"], json!("sign_up_attempt"));
+    }
+
+    /// Idempotency across the REWRITE path specifically — the existing
+    /// `backfill_is_idempotent_on_an_already_well_formed_payload` only covers
+    /// the original fixture, whose `sign_in`/`sign_up` are `null` and so never
+    /// touch `canonical_object_type` at all.
+    #[test]
+    fn backfill_is_idempotent_after_canonicalizing_a_populated_sign_in() {
+        let mut value = json!({
+            "object": "client",
+            "sign_in": guest_js_shaped_sign_in_json(),
+            "sign_up": null,
+        });
+        backfill_clerk_client_json(&mut value);
+        let once = value.clone();
+        backfill_clerk_client_json(&mut value);
+        assert_eq!(
+            once, value,
+            "a second pass over an already-canonicalized sign_in must be a no-op"
+        );
+    }
+
+    /// The full end-to-end case none of the standalone `ClientSignIn` tests
+    /// reach: a whole `ClientClient` with a LIVE (non-null) `sign_in`, shaped
+    /// exactly as guest-js emits it end to end, deserializing successfully
+    /// after backfill — not just the `object` field in isolation. This is the
+    /// actual shape `set_client` receives in production the moment a user is
+    /// mid-sign-in (MFA prompt, etc.) rather than already fully signed in.
+    #[test]
+    fn backfill_makes_a_client_with_a_live_sign_in_deserialize() {
+        let mut value = json!({
+            "object": "client",
+            "id": "client_abc123",
+            "sessions": [],
+            "sign_in": guest_js_shaped_sign_in_json(),
+            "sign_up": null,
+            "last_active_session_id": null,
+            "cookie_expires_at": null,
+            "captcha_bypass": false,
+            "created_at": 1719765600,
+            "updated_at": 1719765690
+        });
+        backfill_clerk_client_json(&mut value);
+        let client = serde_json::from_value::<ClientClient>(value).expect(
+            "a client with a live sign_in must deserialize into ClientClient after backfill",
+        );
+        let sign_in = client.sign_in.expect("sign_in must survive the round trip");
+        assert_eq!(sign_in.id, "sign_in_abc123");
+    }
 }


### PR DESCRIPTION
## Summary

Three bugs found while investigating new-user-signup issues in OpenObserve (fleet telemetry from the last 30 days, with a focus on the 124 hosts that signed up on 2026-08-17):

- **Clerk sign-in JSON parse failure** (`tray/src-tauri/vendor/tauri-plugin-clerk/src/json_backfill.rs`) — guest-js emits `"object": "sign_in"` / `"sign_up"` for the client's in-flight sign-in/sign-up resources, but `clerk-fapi-rs`'s generated models only accept `"sign_in_attempt"` / `"sign_up_attempt"`. Every real sign-in failed to deserialize, so the offline session cache never reflected it. **Hit 119 of 124 (96%) of one day's new signups.**
- **Dropped error chains in `refresh_active`/`refresh_current_task`** (`tray/src-tauri/src/poll/refresh.rs`) — a bare `%e` on an `anyhow::Error` renders only the outermost `.context()`, so these warnings shipped with no actual cause (DB corruption, missing table, lock contention — all indistinguishable). **Hit 72 of 124 (58%) of the same cohort.** Same defect `99dc413b` already fixed on the daemon's DB paths; the tray's poll loop was never covered.
- **Orphaned CLI processes on timeout in `run_meridian`** (`tray/src-tauri/src/commands/cli_exec.rs`) — missing `kill_on_drop(true)`, so a timed-out `meridian <args>` child (e.g. `plan-task-draft`) keeps running after the UI reports failure. Clicking "Try again" spawns a second process racing the orphaned first one for the same LLM provider/DB. Reported by a user as "AI drafting keeps timing out after running for 1-2 minutes"; confirmed on fleet telemetry — one host hit `plan-task-draft: timed out` 5 times in a row over 20 minutes. Same fix `tasks.rs::sync_tasks` already carries; `run_meridian` (the shared helper behind `plan_tasks`/`worklog_generate`/`statuses`/`llm_lab`) was never updated.

## Test plan
- [x] `cargo fmt --all` / `cargo clippy --workspace --all-targets -- -D warnings`
- [x] New regression tests for all three: reproduces each production failure and proves the fix (`json_backfill`'s tests deserialize the exact guest-js shape; `cli_exec`'s test was manually verified to fail without `kill_on_drop` and pass with it)
- [x] `cargo test --workspace` (full suite, via pre-push hook)
- [x] Cross-checked all three against live OpenObserve fleet data to confirm the fix targets the actual reported failure mode, not just a plausible one

🤖 Generated with [Claude Code](https://claude.com/claude-code)