### PR TITLE
fix(llm): harden AI provider sign-in detection and interactive draft latency

### DIFF
--- a/src/day_summary/generate.rs
+++ b/src/day_summary/generate.rs
@@ -295,6 +295,7 @@ pub async fn generate(pool: &SqlitePool, day_local: &str) -> Result<DaySummary> 
         schema: Some(prompts::daily_summary_schema()),
         max_tokens: GENERATE_MAX_TOKENS,
         label: format!("daily-summary {day_local}"),
+        interactive: false,
     };
 
     // A failed call is not a failed screen: fall back rather than surfacing an

--- a/src/llm/claude.rs
+++ b/src/llm/claude.rs
@@ -47,6 +47,40 @@ use crate::coding_agent_session_ingest::summariser::run_capture;
 
 use super::{LlmBackend, LlmConfig, LlmError, LlmOutput, LlmProvider, PromptRequest};
 
+/// How long `claude auth status --json` may take — a local credential read, no network round
+/// trip; measured ~0.2s live. Generous ceiling, not a real budget.
+const LOGIN_STATUS_TIMEOUT_S: u64 = 8;
+
+/// Ternary read of `claude auth status --json`'s `loggedIn` field. `Some(true)`/`Some(false)`
+/// are authoritative; `None` means the check itself failed (spawn error, timeout, malformed
+/// output) and must not be trusted either way — see [`super::detect::interactive_login`],
+/// the sole caller: it uses this to confirm an interactive sign-in actually took even when
+/// the spawned `claude auth login` process itself timed out or exited non-zero.
+///
+/// The JSON body also carries the account email/org (`email`, `orgName`) — callers must log
+/// only the boolean this returns, never the raw response.
+pub(crate) async fn login_status_signed_in(meridian_home: &std::path::Path) -> Option<bool> {
+    let cap = run_capture(
+        "claude",
+        &["auth".into(), "status".into(), "--json".into()],
+        "",
+        meridian_home,
+        LOGIN_STATUS_TIMEOUT_S,
+        &[],
+        &[],
+    )
+    .await
+    .ok()?;
+    parse_logged_in(&cap.stdout)
+}
+
+/// The pure parse [`login_status_signed_in`] applies to the captured stdout — split out so
+/// it is unit-testable without spawning a process.
+fn parse_logged_in(stdout: &str) -> Option<bool> {
+    let v: Value = serde_json::from_str(stdout.trim()).ok()?;
+    v.get("loggedIn").and_then(Value::as_bool)
+}
+
 /// The full prompt sent over stdin — see the module doc. `req.user`, when present, follows
 /// `req.system` after a blank line (the same shape [`crate::llm::cursor`]'s `build_prompt`
 /// already uses for its combined single-channel prompt).
@@ -239,6 +273,28 @@ impl LlmBackend for ClaudeBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Verbatim shape of a live `claude auth status --json` response (signed in).
+    #[test]
+    fn parse_logged_in_reads_a_real_signed_in_response() {
+        let body = r#"{"loggedIn":true,"authMethod":"claude.ai","apiProvider":"firstParty",
+            "email":"user@example.com","orgId":"x","orgName":"x's Organization","subscriptionType":"max"}"#;
+        assert_eq!(parse_logged_in(body), Some(true));
+    }
+
+    #[test]
+    fn parse_logged_in_reads_a_signed_out_response() {
+        assert_eq!(parse_logged_in(r#"{"loggedIn":false}"#), Some(false));
+    }
+
+    /// Malformed/empty output (a crash, an incompatible future CLI version) must be
+    /// inconclusive, never misread as either extreme.
+    #[test]
+    fn parse_logged_in_is_none_on_malformed_output() {
+        assert_eq!(parse_logged_in(""), None);
+        assert_eq!(parse_logged_in("not json"), None);
+        assert_eq!(parse_logged_in("{}"), None);
+    }
 
     /// The regression this exists for: `req.user` used to be piped over stdin ALONGSIDE a
     /// positional `-p <req.system>` argv value — but `claude -p` silently discards piped

--- a/src/llm/codex.rs
+++ b/src/llm/codex.rs
@@ -95,18 +95,43 @@ const LOGIN_STATUS_TIMEOUT_S: u64 = 8;
 /// on every real hourly call too, not just the Test button. `codex login status` answers the
 /// same question in a fraction of a second because it only reads a local credential file.
 async fn signed_out(cfg: &LlmConfig) -> Option<String> {
+    (login_status_signed_in(&cfg.meridian_home).await == Some(false)).then(|| {
+        "Codex isn't signed in yet - run `codex login` in a terminal, then try again.".to_string()
+    })
+}
+
+/// Ternary read of `codex login status`: `Some(true)` = confirmed signed in, `Some(false)` =
+/// confirmed signed out (the same "not logged in" text [`classify_login_status`] already
+/// recognises), `None` = the check itself was inconclusive (spawn/timeout failure, or a
+/// result that matches neither case) and must not be trusted either way.
+///
+/// `pub(crate)`: shared ground truth for two callers that must never disagree - this call's
+/// own [`signed_out`] pre-flight, and `detect::codex_sign_in`'s post-hoc verification of
+/// whether an interactive login actually took, independent of what the spawned CLI process
+/// itself reported (a hung or non-zero-exiting `codex login` doesn't necessarily mean the
+/// OAuth round-trip failed - only this file read does).
+pub(crate) async fn login_status_signed_in(meridian_home: &std::path::Path) -> Option<bool> {
     let cap = run_capture(
         "codex",
         &["login".into(), "status".into()],
         "",
-        &cfg.meridian_home,
+        meridian_home,
         LOGIN_STATUS_TIMEOUT_S,
         &[],
         &[],
     )
     .await
     .ok()?;
-    classify_login_status(cap.success, &cap.stdout, &cap.stderr)
+    ternary_login_status(cap.success, &cap.stdout, &cap.stderr)
+}
+
+/// The pure decision [`login_status_signed_in`] makes from a captured result — split out so
+/// it is unit-testable without spawning a process, matching [`classify_login_status`].
+fn ternary_login_status(success: bool, stdout: &str, stderr: &str) -> Option<bool> {
+    if classify_login_status(success, stdout, stderr).is_some() {
+        return Some(false);
+    }
+    success.then_some(true)
 }
 
 /// The pure classification `signed_out` applies to `codex login status`'s result — split out
@@ -327,6 +352,31 @@ mod tests {
             None
         );
         assert_eq!(classify_login_status(false, "", ""), None);
+    }
+
+    #[test]
+    fn ternary_login_status_reads_the_positive_case() {
+        assert_eq!(ternary_login_status(true, "Logged in as x", ""), Some(true));
+    }
+
+    #[test]
+    fn ternary_login_status_reads_the_confirmed_negative_case() {
+        assert_eq!(
+            ternary_login_status(false, "Not logged in\n", ""),
+            Some(false)
+        );
+    }
+
+    /// An unrecognised failure must stay `None` (inconclusive), never collapse to either
+    /// extreme - the whole reason this returns three states instead of a bool. A caller
+    /// treating this as "confirmed signed out" would report a real sign-in as failed; treating
+    /// it as "confirmed signed in" would report a real failure as success.
+    #[test]
+    fn ternary_login_status_is_inconclusive_on_an_unrecognised_failure() {
+        assert_eq!(
+            ternary_login_status(false, "", "connection reset by peer"),
+            None
+        );
     }
 
     /// The regression this exists for: `req.system` used to go over argv (`codex exec

--- a/src/llm/cursor.rs
+++ b/src/llm/cursor.rs
@@ -40,6 +40,50 @@ use super::{prompts, LlmBackend, LlmConfig, LlmError, LlmOutput, LlmProvider, Pr
 
 const ARG_CAP: usize = 180_000;
 
+/// Above this, a call logs a WARN (not just the routine INFO summary) so a latency
+/// regression is visible in OpenObserve on a packaged install, not just in a local spool
+/// nobody is tailing. Comfortably above the ~6s a warm, hardened call took when measured
+/// live, and below the point where a user watching "Draft with AI" would call it stuck.
+const SLOW_CALL_WARN_THRESHOLD_S: f64 = 30.0;
+
+/// How long `cursor-agent status` may take — a local credential read; measured ~2.3s live
+/// (slower than Codex's/Claude's equivalent, still comfortably sub-second-budget territory).
+/// Generous ceiling, not a real budget.
+const LOGIN_STATUS_TIMEOUT_S: u64 = 15;
+
+/// Ternary read of `cursor-agent status --format json`'s `isAuthenticated` field.
+/// `Some(true)`/`Some(false)` are authoritative; `None` means the check itself failed (spawn
+/// error, timeout, malformed output) and must not be trusted either way — see
+/// [`super::detect::interactive_login`], the sole caller: it uses this to confirm an
+/// interactive sign-in actually took even when the spawned `cursor-agent login` process
+/// itself timed out or exited non-zero.
+///
+/// **The exit code is NOT authoritative here** — measured live: `cursor-agent status` can
+/// exit 1 ("unable to fetch user details") while its own JSON body reports
+/// `isAuthenticated: true`. The body is the only trustworthy signal, which is why this reads
+/// it regardless of `cap.success`.
+pub(crate) async fn login_status_signed_in(meridian_home: &std::path::Path) -> Option<bool> {
+    let cap = run_capture(
+        "cursor-agent",
+        &["status".into(), "--format".into(), "json".into()],
+        "",
+        meridian_home,
+        LOGIN_STATUS_TIMEOUT_S,
+        &[],
+        cursor_cli::ENV_REMOVE,
+    )
+    .await
+    .ok()?;
+    parse_is_authenticated(&cap.stdout)
+}
+
+/// The pure parse [`login_status_signed_in`] applies to the captured stdout — split out so
+/// it is unit-testable without spawning a process.
+fn parse_is_authenticated(stdout: &str) -> Option<bool> {
+    let v: Value = serde_json::from_str(stdout.trim()).ok()?;
+    v.get("isAuthenticated").and_then(Value::as_bool)
+}
+
 pub struct CursorBackend {
     pub cfg: LlmConfig,
 }
@@ -167,13 +211,7 @@ impl LlmBackend for CursorBackend {
         let t0 = std::time::Instant::now();
         let prompt = build_prompt(req);
 
-        // Empty override = the pinned default (deterministic, ZDR). A non-empty override is the
-        // user's explicit choice and is passed through as-is.
-        let model = if self.cfg.model.is_empty() {
-            cursor_cli::DEFAULT_MODEL
-        } else {
-            self.cfg.model.as_str()
-        };
+        let model = resolve_model(&self.cfg.model, req.interactive);
 
         // The degradation ladder lives in `cursor_cli` so the summariser inherits it too.
         let text =
@@ -187,6 +225,18 @@ impl LlmBackend for CursorBackend {
             chars = text.len(),
             "cursor: call complete"
         );
+        // WARN, not INFO: this is the one signal that ships on a packaged install (only
+        // WARN+ egresses - see CLAUDE.md's Observability section), and a Cursor call that
+        // blows past a normal budget is exactly the kind of regression that must be visible
+        // without an engineer already looking at this one machine's local spool.
+        if elapsed_s > SLOW_CALL_WARN_THRESHOLD_S {
+            tracing::warn!(
+                model,
+                elapsed_s,
+                interactive = req.interactive,
+                "cursor: call took longer than expected"
+            );
+        }
         Ok(LlmOutput {
             text,
             // The CLI reports usage in its envelope but not a comparable prompt/completion split;
@@ -195,6 +245,21 @@ impl LlmBackend for CursorBackend {
             output_tokens: 0,
             elapsed_s,
         })
+    }
+}
+
+/// Which model tier this call uses. An explicit user override (`cfg_model` non-empty) always
+/// wins, matching every other provider's "the user's choice is never silently swapped" rule -
+/// [`PromptRequest::interactive`] only ever picks between OUR two pinned tiers, never
+/// overrides what the user chose. Extracted so the choice is testable without spawning a
+/// process — see [`CursorBackend::complete`].
+fn resolve_model(cfg_model: &str, interactive: bool) -> &str {
+    if !cfg_model.is_empty() {
+        cfg_model
+    } else if interactive {
+        cursor_cli::FAST_MODEL
+    } else {
+        cursor_cli::DEFAULT_MODEL
     }
 }
 
@@ -227,6 +292,53 @@ mod tests {
 
     fn req() -> PromptRequest {
         PromptRequest::new("SYSTEM PROMPT", "USER INPUT", "test-label")
+    }
+
+    #[test]
+    fn a_background_call_with_no_override_uses_the_default_tier() {
+        assert_eq!(resolve_model("", false), cursor_cli::DEFAULT_MODEL);
+    }
+
+    #[test]
+    fn an_interactive_call_with_no_override_uses_the_fast_tier() {
+        assert_eq!(resolve_model("", true), cursor_cli::FAST_MODEL);
+    }
+
+    /// THE property that matters: a user's explicit model choice is never silently swapped
+    /// for a faster one just because the call happens to be interactive.
+    #[test]
+    fn an_explicit_override_always_wins_over_the_interactive_hint() {
+        assert_eq!(resolve_model("claude-opus-4-8", true), "claude-opus-4-8");
+        assert_eq!(resolve_model("claude-opus-4-8", false), "claude-opus-4-8");
+    }
+
+    /// THE regression this parse exists for: verbatim shape captured live from
+    /// `cursor-agent status --format json` while genuinely authenticated - the exit code was
+    /// 1 ("unable to fetch user details") but the body says `isAuthenticated: true`. A caller
+    /// that gated on exit code instead of this field would misreport a working sign-in as
+    /// failed.
+    #[test]
+    fn parse_is_authenticated_reads_the_real_authenticated_response_despite_a_nonzero_exit() {
+        let body = r#"{"status":"authenticated","isAuthenticated":true,"hasAccessToken":true,
+            "hasRefreshToken":true,"message":"Logged in (unable to fetch user details)"}"#;
+        assert_eq!(parse_is_authenticated(body), Some(true));
+    }
+
+    #[test]
+    fn parse_is_authenticated_reads_a_signed_out_response() {
+        assert_eq!(
+            parse_is_authenticated(r#"{"isAuthenticated":false}"#),
+            Some(false)
+        );
+    }
+
+    /// Malformed/empty output (a crash, an incompatible future CLI version) must be
+    /// inconclusive, never misread as either extreme.
+    #[test]
+    fn parse_is_authenticated_is_none_on_malformed_output() {
+        assert_eq!(parse_is_authenticated(""), None);
+        assert_eq!(parse_is_authenticated("not json"), None);
+        assert_eq!(parse_is_authenticated("{}"), None);
     }
 
     /// The marker is what cuts the summarise -> ingest -> summarise loop, so the property to

--- a/src/llm/cursor_cli.rs
+++ b/src/llm/cursor_cli.rs
@@ -370,6 +370,33 @@ pub fn looks_unknown_model(msg: &str) -> bool {
             || m.contains("no access"))
 }
 
+/// Did the call fail on a plain network/transport blip rather than anything about the
+/// request itself - a connection dropping mid-stream, a reset, a 5xx from Cursor's own
+/// backend? Worth exactly one bounded retry: unlike the other levers this isn't reacting to
+/// a capability the CLI lacks, it's reacting to noise that a second attempt often doesn't
+/// repeat.
+///
+/// Deliberately does NOT match our own client-side timeout (`"timed out after"`, the exact
+/// wording `run_capture` uses - see `SummariserError::Failed`). Retrying that would double
+/// the worst-case wait on an already-slow call, which is the opposite of what this exists
+/// for; a real timeout should fail promptly and let the caller decide, not silently cost the
+/// user a second full timeout window.
+pub fn looks_transient(msg: &str) -> bool {
+    let m = msg.to_lowercase();
+    if m.contains("timed out") {
+        return false;
+    }
+    m.contains("connection reset")
+        || m.contains("econnreset")
+        || m.contains("stream disconnected")
+        || m.contains("socket hang up")
+        || m.contains("broken pipe")
+        || m.contains("temporarily unavailable")
+        || m.contains("502 bad gateway")
+        || m.contains("503 service unavailable")
+        || m.contains("504 gateway")
+}
+
 /// Pinned model for every Meridian `cursor-agent` call: small, fast, cheap and ZDR-eligible
 /// (Cursor flags non-ZDR models explicitly in `--list-models`; this is not one) - the right
 /// tier for summarise/classify/draft, and deterministic across users unlike the account
@@ -378,6 +405,18 @@ pub fn looks_unknown_model(msg: &str) -> bool {
 /// `-medium` is the effort suffix Cursor displays as plain "GPT-5.4 Mini"; the ladder is
 /// `-none/-low/-medium/-high/-xhigh`.
 pub const DEFAULT_MODEL: &str = "gpt-5.4-mini-medium";
+
+/// Same pinned model, lower reasoning effort — used only for [`PromptRequest::interactive`]
+/// calls that have no explicit user model override (see `CursorBackend::complete`).
+///
+/// A synchronously-watched call (today, only the task composer's "Draft with AI") pays for
+/// `-medium`'s extra reasoning time in perceived latency, not in a better answer: the job is
+/// a three-field JSON extraction from a short note, not analysis. Background jobs
+/// (summarisation, worklog generation, classification) keep [`DEFAULT_MODEL`] - they run
+/// unattended, so slower-but-more-careful is free there and NOT free here.
+///
+/// [`PromptRequest::interactive`]: super::PromptRequest::interactive
+pub const FAST_MODEL: &str = "gpt-5.4-mini-low";
 
 /// Cursor's server-routed default, used only when [`DEFAULT_MODEL`] is not on the account.
 pub const FALLBACK_MODEL: &str = "auto";
@@ -413,6 +452,7 @@ struct Levers {
 /// 1. `--allowed-tools` rejected -> retry without it (fatter context, still works)
 /// 2. auth invisible from the sandbox `HOME` -> retry on the inherited one (carries skills)
 /// 3. model unavailable on this plan -> retry on [`FALLBACK_MODEL`]
+/// 4. a plain transient/network blip -> retry once, unchanged (see [`looks_transient`])
 ///
 /// A rate limit degrades nothing: `degradable_message` returns `None` and the error is
 /// returned immediately, because Cursor limits are account-level and a second call would
@@ -429,6 +469,10 @@ where
     };
     let mut model = model.to_string();
     let mut tried_fallback_model = model == FALLBACK_MODEL;
+    // Not a lever - retrying leaves argv/env unchanged, it just asks the same question
+    // again in case the first answer was noise. Bounded to one shot so a genuinely broken
+    // endpoint still fails promptly rather than doubling every call's worst case.
+    let mut tried_transient_retry = false;
 
     loop {
         let sandbox = if levers.sandbox { sandbox_home() } else { None };
@@ -467,6 +511,12 @@ where
             );
             model = FALLBACK_MODEL.to_string();
             tried_fallback_model = true;
+        } else if !tried_transient_retry && looks_transient(msg) {
+            tracing::warn!(
+                error = %msg,
+                "cursor: transient failure - retrying once unchanged"
+            );
+            tried_transient_retry = true;
         } else {
             // Nothing left to degrade, or a cause no lever addresses.
             return Err(err);
@@ -575,9 +625,53 @@ mod tests {
     /// An unrelated failure is not a licence to strip hardening.
     #[tokio::test]
     async fn an_unrecognised_failure_does_not_degrade() {
-        let (res, seen) = ladder(DEFAULT_MODEL, vec![Some("connection reset by peer")]).await;
+        let (res, seen) = ladder(DEFAULT_MODEL, vec![Some("internal assertion failed")]).await;
         assert!(res.is_err());
         assert_eq!(seen.len(), 1);
+    }
+
+    /// THE regression this lever exists for: a plain network blip - noise, not a capability
+    /// the CLI lacks - gets one retry with the argv/env completely unchanged.
+    #[tokio::test]
+    async fn a_transient_failure_retries_once_unchanged() {
+        let (res, seen) = ladder(DEFAULT_MODEL, vec![Some("connection reset by peer")]).await;
+        assert!(res.is_ok());
+        assert_eq!(seen.len(), 2);
+        assert_eq!(
+            seen[0], seen[1],
+            "a transient retry must not change argv/env - it isn't a lever"
+        );
+    }
+
+    /// Bounded: a second transient failure in a row is not a licence to keep spinning.
+    #[tokio::test]
+    async fn a_second_transient_failure_is_not_retried_again() {
+        let errs = vec![
+            Some("connection reset by peer"),
+            Some("stream disconnected"),
+        ];
+        let (res, seen) = ladder(DEFAULT_MODEL, errs).await;
+        assert!(res.is_err());
+        assert_eq!(seen.len(), 2, "one retry, then give up");
+    }
+
+    /// THE regression the exclusion exists for: retrying our own client-side timeout would
+    /// double the worst-case wait on an already-slow call, which is what this lever must never
+    /// do. `run_capture`'s exact wording (`SummariserError::Failed`) is `"<program> timed out
+    /// after <n>s"`.
+    #[tokio::test]
+    async fn a_timeout_shaped_message_is_not_retried() {
+        let (res, seen) = ladder(
+            DEFAULT_MODEL,
+            vec![Some("cursor-agent timed out after 300s")],
+        )
+        .await;
+        assert!(res.is_err());
+        assert_eq!(
+            seen.len(),
+            1,
+            "a timeout must fail promptly, not double the wait"
+        );
     }
 
     /// Each lever drops at most once, so a persistently failing CLI terminates instead of
@@ -696,6 +790,22 @@ mod tests {
         // Must not mistake a quota problem for an auth problem - that retry would waste a call.
         assert!(!looks_auth_failure("rate/usage limit reached"));
         assert!(!looks_auth_failure("workspace trust required"));
+    }
+
+    #[test]
+    fn transient_failure_detection_drives_the_bounded_retry() {
+        assert!(looks_transient("connection reset by peer"));
+        assert!(looks_transient("Error: socket hang up"));
+        assert!(looks_transient(
+            "cursor-agent exited Some(1): 503 Service Unavailable"
+        ));
+        // Must not mistake our own client-side timeout for noise worth retrying - see the
+        // doc comment on `looks_transient` for why that distinction matters.
+        assert!(!looks_transient("cursor-agent timed out after 300s"));
+        assert!(!looks_transient("Error: request timed out after retries"));
+        // Ordinary failures must not spend the one bounded retry either.
+        assert!(!looks_transient("rate/usage limit reached"));
+        assert!(!looks_transient("Not logged in"));
     }
 
     /// The sandbox must never be the user's real home - that is the whole safety property.

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -1695,6 +1695,10 @@ mod tests {
     // finishing a browser OAuth flow, and using them in a unit test would make the suite
     // take minutes for no extra coverage.
 
+    // Only the (unix-only) tests below call this - see the block comment above. Not gating
+    // it too would make it dead code on Windows and fail `-D warnings` there while looking
+    // perfectly clean on macOS/Linux, which is exactly how this was first missed.
+    #[cfg(unix)]
     fn instant_timing() -> InteractiveLoginTiming {
         InteractiveLoginTiming {
             deadline: Duration::from_millis(500),

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -543,6 +543,7 @@ pub async fn test_provider(
         schema: None,
         max_tokens: PROBE_MAX_TOKENS,
         label: format!("provider-test {id}"),
+        interactive: false,
     };
 
     let outcome = match backend_for(provider, cfg).complete(&req).await {
@@ -980,9 +981,296 @@ async fn warn_if_version_unpinned(provider: LlmProvider, path: &std::path::Path)
     }
 }
 
-/// How long an interactive provider sign-in (Cursor or Codex) may take - a human finishing an
-/// OAuth flow in their browser, so generous, but not unbounded.
+/// How long an interactive provider sign-in (Cursor, Codex or Claude) may take - a human
+/// finishing an OAuth flow in their browser, so generous, but not unbounded.
 const INTERACTIVE_LOGIN_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// How long to let a freshly-spawned login CLI run before the first authoritative status
+/// poll (see [`interactive_login`]) - the local OAuth round-trip legitimately takes a few
+/// seconds even on the happy path, so polling from time zero would just be a wasted extra
+/// process spawn on every sign-in.
+const VERIFY_GRACE_PERIOD: Duration = Duration::from_secs(5);
+
+/// How often to re-poll status once the grace period has elapsed. Short enough that a
+/// browser callback landing early doesn't cost the user the rest of the 180s wait if the
+/// child process itself hangs; long enough that it isn't a second CLI process running
+/// nearly back-to-back with the login itself.
+const VERIFY_POLL_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Spawn a background task that appends each line from `pipe` into a shared buffer, tagged
+/// by `stream` ("stdout"/"stderr") so both streams are distinguishable in traces. Returns
+/// the buffer immediately; empty forever if `pipe` is `None` (nothing to drain).
+///
+/// Draining BOTH streams live (not just via a final `wait_with_output`) is what lets
+/// [`interactive_login`] poll `child.try_wait()` without deadlocking a login CLI that fills
+/// its pipe buffer while we are busy waiting on something else.
+fn drain_lines(
+    pipe: Option<impl tokio::io::AsyncRead + Unpin + Send + 'static>,
+    stream: &'static str,
+) -> std::sync::Arc<std::sync::Mutex<String>> {
+    let seen = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    if let Some(out) = pipe {
+        let seen = seen.clone();
+        tokio::spawn(async move {
+            use tokio::io::{AsyncBufReadExt, BufReader};
+            let mut lines = BufReader::new(out).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                tracing::info!(line = %line, stream, "llm: interactive login output");
+                let mut buf = seen.lock().unwrap_or_else(|e| e.into_inner());
+                buf.push_str(&line);
+                buf.push('\n');
+            }
+        });
+    }
+    seen
+}
+
+/// The last `n` characters buffered by [`drain_lines`], char-safe - see [`tail`].
+fn buffered_tail(buf: &std::sync::Mutex<String>, n: usize) -> String {
+    let s = buf.lock().unwrap_or_else(|e| e.into_inner());
+    tail(&s, n)
+}
+
+/// [`interactive_login`]'s three durations, bundled so a real sign-in and a test can each
+/// supply their own without growing the function's argument count. Production always uses
+/// [`Self::PRODUCTION`]; tests use tiny values so the same race logic exercises in
+/// milliseconds instead of minutes.
+#[derive(Clone, Copy)]
+struct InteractiveLoginTiming {
+    deadline: Duration,
+    grace: Duration,
+    poll_interval: Duration,
+}
+
+impl InteractiveLoginTiming {
+    const PRODUCTION: Self = Self {
+        deadline: INTERACTIVE_LOGIN_TIMEOUT,
+        grace: VERIFY_GRACE_PERIOD,
+        poll_interval: VERIFY_POLL_INTERVAL,
+    };
+}
+
+/// Drive one interactive `<bin> <args…>` login to completion.
+///
+/// # Sign-in detection hardening
+///
+/// Before this existed, [`cursor_sign_in`]/[`codex_sign_in`]/[`claude_sign_in`] trusted
+/// ONLY the spawned CLI child's own exit code (or a bare 180s timeout). That is provably
+/// not the whole story: a browser OAuth round-trip can genuinely complete - the vendor's
+/// own local callback server renders its own "signed in" page - while the CLI process that
+/// owns that server fails to reflect it back to us within the wait window (a hang, a
+/// secondary post-login step exiting non-zero after auth already landed, or our own
+/// `kill_on_drop` racing a credential write that was about to finish). The visible symptom
+/// was exactly what shipped as a bug report: the browser shows success, the app keeps
+/// showing "not signed in".
+///
+/// This function trusts a clean `exit 0` directly (no added latency on the happy path,
+/// which is the overwhelming common case), but treats every OTHER outcome - a non-zero
+/// exit, a spawn/wait error, or the timeout firing - as advisory rather than final: it
+/// re-checks against `verify`, a cheap LOCAL-only ground-truth probe (a cached credential
+/// file / a fast status endpoint - see `codex::login_status_signed_in`,
+/// `cursor::login_status_signed_in`, `claude::login_status_signed_in`), and reports success
+/// anyway if THAT says the user is actually signed in. Both signals are always logged, so a
+/// divergence between "the process said no" and "but you actually are" is visible in
+/// traces rather than silently resolved.
+///
+/// It also polls `verify` periodically WHILE the child is still running (after an initial
+/// grace period), so a browser callback that lands early doesn't force the user to wait out
+/// the rest of a 180s timeout just because the underlying CLI process happens to hang.
+///
+/// `display_name` is the vendor name used in user-facing copy ("Cursor"/"Codex"/"Claude").
+async fn interactive_login<V, VFut>(
+    label: &'static str,
+    bin: &str,
+    args: &[&str],
+    display_name: &str,
+    success_message: String,
+    verify: V,
+    timing: InteractiveLoginTiming,
+) -> InstallOutcome
+where
+    V: Fn() -> VFut,
+    VFut: std::future::Future<Output = Option<bool>>,
+{
+    let Some(path) = resolve_cli(bin).await else {
+        return install_failed(
+            label,
+            format!("{bin} isn't installed yet - install it first"),
+        );
+    };
+
+    tracing::info!(bin, "llm: launching interactive login");
+    let mut cmd = command_for_resolved_cli(&path);
+    cmd.args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .no_window();
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => return install_failed(label, format!("couldn't start {bin}: {e}")),
+    };
+
+    // Both streams are drained live, not just via a final `wait_with_output` - see
+    // `drain_lines`'s doc. stdout carries the verification URL / device code a stuck login
+    // prints while it waits, which is exactly what the user needs to finish it by hand.
+    let stdout_buf = drain_lines(child.stdout.take(), "stdout");
+    let stderr_buf = drain_lines(child.stderr.take(), "stderr");
+
+    enum Ended {
+        Exited(std::process::ExitStatus),
+        WaitError(std::io::Error),
+        TimedOut,
+    }
+
+    /// `None` = still running. Centralised so the loop can re-check right after waking from
+    /// a sleep without duplicating the match - see the loop body for why that second check
+    /// matters (closes a race where the child exits DURING the sleep).
+    fn poll_exit(child: &mut tokio::process::Child) -> Option<Ended> {
+        match child.try_wait() {
+            Ok(Some(status)) => Some(Ended::Exited(status)),
+            Ok(None) => None,
+            Err(e) => Some(Ended::WaitError(e)),
+        }
+    }
+
+    let deadline = tokio::time::Instant::now() + timing.deadline;
+    let mut next_verify = tokio::time::Instant::now() + timing.grace;
+
+    let ended = loop {
+        if let Some(ended) = poll_exit(&mut child) {
+            break ended;
+        }
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            break Ended::TimedOut;
+        }
+        tokio::time::sleep_until(next_verify.min(deadline)).await;
+        // The child may have exited WHILE we slept - a clean exit must never pay for a
+        // verify round-trip it doesn't need, which is exactly what skipping this check
+        // would risk on a fast-exiting CLI and a short grace period.
+        if let Some(ended) = poll_exit(&mut child) {
+            break ended;
+        }
+        if tokio::time::Instant::now() >= next_verify {
+            if verify().await == Some(true) {
+                tracing::info!(
+                    bin,
+                    "llm: sign-in confirmed by status check while the CLI was still running"
+                );
+                return InstallOutcome {
+                    ok: true,
+                    message: success_message,
+                    path: Some(path.display().to_string()),
+                    command: label.to_string(),
+                };
+            }
+            next_verify = tokio::time::Instant::now() + timing.poll_interval;
+        }
+    };
+
+    match ended {
+        Ended::Exited(status) if status.success() => {
+            let span = tracing::Span::current();
+            span.record("ok", true);
+            span.record("cli_path", tracing::field::display(path.display()));
+            tracing::info!(bin, "llm: interactive login succeeded");
+            InstallOutcome {
+                ok: true,
+                message: success_message,
+                path: Some(path.display().to_string()),
+                command: label.to_string(),
+            }
+        }
+        Ended::Exited(status) => {
+            // stderr first (that is where the reason goes), but fall back to what the CLI
+            // printed on stdout - on some failures the URL/device code is the only useful
+            // thing said.
+            let stderr_tail = buffered_tail(&stderr_buf, 400);
+            let reason = if stderr_tail.is_empty() {
+                buffered_tail(&stdout_buf, 300)
+            } else {
+                stderr_tail
+            };
+            let process_message = format!(
+                "{bin} exited {:?}: {}",
+                status.code(),
+                if reason.is_empty() {
+                    "no output".to_string()
+                } else {
+                    reason
+                }
+            );
+            confirm_or_report(label, bin, &path, success_message, &verify, process_message).await
+        }
+        Ended::WaitError(e) => {
+            confirm_or_report(
+                label,
+                bin,
+                &path,
+                success_message,
+                &verify,
+                format!("couldn't run {bin}: {e}"),
+            )
+            .await
+        }
+        Ended::TimedOut => {
+            let printed = buffered_tail(&stdout_buf, 300);
+            let timeout_message = if printed.is_empty() {
+                format!(
+                    "the sign-in wasn't finished in time - click Sign in to {display_name} again"
+                )
+            } else {
+                format!(
+                    "the sign-in wasn't finished in time. Finish it by hand with what \
+                     {bin} printed:\n{printed}"
+                )
+            };
+            confirm_or_report(label, bin, &path, success_message, &verify, timeout_message).await
+        }
+    }
+}
+
+/// The shared tail of every non-happy-path outcome in [`interactive_login`]: give the
+/// process's own report one last chance to be overridden by ground truth before it becomes
+/// what the user sees.
+async fn confirm_or_report<V, VFut>(
+    label: &str,
+    bin: &str,
+    path: &std::path::Path,
+    success_message: String,
+    verify: &V,
+    process_message: String,
+) -> InstallOutcome
+where
+    V: Fn() -> VFut,
+    VFut: std::future::Future<Output = Option<bool>>,
+{
+    if verify().await == Some(true) {
+        // The two signals disagree: the CLI process reported failure/timeout, but a direct
+        // read of the vendor's own auth state says otherwise. Ground truth wins - logged at
+        // WARN (not swallowed as INFO) precisely because a real divergence like this is
+        // worth seeing on a packaged install, not just locally.
+        tracing::warn!(
+            bin,
+            process_outcome = %process_message,
+            "llm: sign-in process reported failure but the status check confirms the user IS \
+             signed in - trusting the status check"
+        );
+        let span = tracing::Span::current();
+        span.record("ok", true);
+        span.record("cli_path", tracing::field::display(path.display()));
+        return InstallOutcome {
+            ok: true,
+            message: success_message,
+            path: Some(path.display().to_string()),
+            command: label.to_string(),
+        };
+    }
+    install_failed(label, process_message)
+}
 
 /// Run the interactive `cursor-agent login` on the user's behalf — the "Sign in to Cursor"
 /// button in the provider detail view.
@@ -993,105 +1281,25 @@ const INTERACTIVE_LOGIN_TIMEOUT: Duration = Duration::from_secs(180);
 /// `NO_OPEN_BROWSER` because it can't ask a human anything; this path is an explicit click, so
 /// opening the browser to finish the sign-in is exactly what's wanted). Once it completes,
 /// cursor-agent persists the auth and every later daemon run just adopts it.
+///
+/// See [`interactive_login`] for the shared race/verify logic this and its two siblings run
+/// through, and `cursor::login_status_signed_in` for Cursor's ground-truth check.
 #[tracing::instrument(skip_all, fields(ok = tracing::field::Empty, cli_path = tracing::field::Empty))]
 pub async fn cursor_sign_in() -> InstallOutcome {
-    let label = "cursor-agent login";
-    let Some(path) = resolve_cli("cursor-agent").await else {
-        return install_failed(
-            label,
-            "cursor-agent isn't installed yet - install it first".into(),
-        );
-    };
-
-    tracing::info!("llm: launching interactive cursor-agent login");
-    let mut cmd = command_for_resolved_cli(&path);
-    cmd.arg("login")
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true)
-        .no_window();
-
-    let mut child = match cmd.spawn() {
-        Ok(c) => c,
-        Err(e) => return install_failed(label, format!("couldn't start cursor-agent: {e}")),
-    };
-
-    // Drain stdout as it arrives rather than only via `wait_with_output`. `cursor-agent login`
-    // prints its verification URL / device code to STDOUT while it waits, and that is precisely
-    // what the user needs when the browser does not open for them (no default browser, wrong
-    // profile, a headless session). Waiting for exit would discard it on the timeout path -
-    // leaving a 180 s spinner followed by an error with no way to finish the sign-in by hand.
-    let seen = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
-    if let Some(out) = child.stdout.take() {
-        let seen = seen.clone();
-        tokio::spawn(async move {
-            use tokio::io::{AsyncBufReadExt, BufReader};
-            let mut lines = BufReader::new(out).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                tracing::info!(line = %line, "cursor-agent login");
-                let mut buf = seen.lock().unwrap_or_else(|e| e.into_inner());
-                buf.push_str(&line);
-                buf.push('\n');
-            }
-        });
-    }
-    let login_output = |seen: &std::sync::Mutex<String>| -> String {
-        let buf = seen.lock().unwrap_or_else(|e| e.into_inner());
-        tail(buf.trim(), 300)
-    };
-
-    let output =
-        match tokio::time::timeout(INTERACTIVE_LOGIN_TIMEOUT, child.wait_with_output()).await {
-            Ok(Ok(out)) => out,
-            Ok(Err(e)) => {
-                return install_failed(label, format!("couldn't run cursor-agent login: {e}"))
-            }
-            Err(_) => {
-                let printed = login_output(&seen);
-                return install_failed(
-                    label,
-                    if printed.is_empty() {
-                        "the sign-in wasn't finished in time - click Sign in to Cursor again".into()
-                    } else {
-                        format!(
-                            "the sign-in wasn't finished in time. Finish it by hand with what \
-                         cursor-agent printed:\n{printed}"
-                        )
-                    },
-                );
-            }
-        };
-
-    if output.status.success() {
-        let span = tracing::Span::current();
-        span.record("ok", true);
-        span.record("cli_path", tracing::field::display(path.display()));
-        tracing::info!("llm: cursor-agent login succeeded");
-        InstallOutcome {
-            ok: true,
-            message: "Signed in to Cursor.".into(),
-            path: Some(path.display().to_string()),
-            command: label.to_string(),
-        }
-    } else {
-        // stderr first (that is where the reason goes), but fall back to what the CLI printed
-        // on stdout - on some failures the URL/device code is the only useful thing said.
-        let reason = tail(String::from_utf8_lossy(&output.stderr).trim(), 400);
-        let reason = if reason.is_empty() {
-            login_output(&seen)
-        } else {
-            reason
-        };
-        install_failed(
-            label,
-            if reason.is_empty() {
-                "cursor-agent login failed".to_string()
-            } else {
-                reason
-            },
-        )
-    }
+    let meridian_home = default_meridian_home();
+    interactive_login(
+        "cursor-agent login",
+        "cursor-agent",
+        &["login"],
+        "Cursor",
+        "Signed in to Cursor.".to_string(),
+        move || {
+            let home = meridian_home.clone();
+            async move { super::cursor::login_status_signed_in(&home).await }
+        },
+        InteractiveLoginTiming::PRODUCTION,
+    )
+    .await
 }
 
 /// Run the interactive `codex login` on the user's behalf — the "Sign in to Codex" button in
@@ -1100,103 +1308,27 @@ pub async fn cursor_sign_in() -> InstallOutcome {
 /// `codex login` (no subcommand) opens the user's browser to sign into their ChatGPT account
 /// and runs a localhost callback server to receive the OAuth redirect; on success it writes
 /// `~/.codex/auth.json` and exits 0, so the summariser then runs on their **ChatGPT
-/// subscription** — no API key, nothing metered. A deliberate mirror of [`cursor_sign_in`]:
-/// the browser is enabled (this is an explicit click, not the daemon's unattended path),
-/// stdout is drained live so the verification URL is surfaced if the browser can't open, and
-/// the wait is bounded by [`INTERACTIVE_LOGIN_TIMEOUT`]. Once it completes, codex persists the
-/// auth and every later run just adopts it — the same "sign in once" model as Cursor.
+/// subscription** — no API key, nothing metered. A deliberate mirror of [`cursor_sign_in`].
+///
+/// See [`interactive_login`] for the shared race/verify logic and `codex::login_status_signed_in`
+/// for Codex's ground-truth check (the same `codex login status` call `codex::signed_out`
+/// already uses as a pre-flight for a real completion call).
 #[tracing::instrument(skip_all, fields(ok = tracing::field::Empty, cli_path = tracing::field::Empty))]
 pub async fn codex_sign_in() -> InstallOutcome {
-    let label = "codex login";
-    let Some(path) = resolve_cli("codex").await else {
-        return install_failed(label, "codex isn't installed yet - install it first".into());
-    };
-
-    tracing::info!("llm: launching interactive codex login");
-    let mut cmd = command_for_resolved_cli(&path);
-    cmd.arg("login")
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true)
-        .no_window();
-
-    let mut child = match cmd.spawn() {
-        Ok(c) => c,
-        Err(e) => return install_failed(label, format!("couldn't start codex: {e}")),
-    };
-
-    // Drain stdout as it arrives - `codex login` prints its verification URL to STDOUT while it
-    // waits, which is exactly what the user needs if the browser doesn't open for them. Same
-    // reasoning as the matching drain in `cursor_sign_in`.
-    let seen = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
-    if let Some(out) = child.stdout.take() {
-        let seen = seen.clone();
-        tokio::spawn(async move {
-            use tokio::io::{AsyncBufReadExt, BufReader};
-            let mut lines = BufReader::new(out).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                tracing::info!(line = %line, "codex login");
-                let mut buf = seen.lock().unwrap_or_else(|e| e.into_inner());
-                buf.push_str(&line);
-                buf.push('\n');
-            }
-        });
-    }
-    let login_output = |seen: &std::sync::Mutex<String>| -> String {
-        let buf = seen.lock().unwrap_or_else(|e| e.into_inner());
-        tail(buf.trim(), 300)
-    };
-
-    let output =
-        match tokio::time::timeout(INTERACTIVE_LOGIN_TIMEOUT, child.wait_with_output()).await {
-            Ok(Ok(out)) => out,
-            Ok(Err(e)) => return install_failed(label, format!("couldn't run codex login: {e}")),
-            Err(_) => {
-                let printed = login_output(&seen);
-                return install_failed(
-                    label,
-                    if printed.is_empty() {
-                        "the sign-in wasn't finished in time - click Sign in to Codex again".into()
-                    } else {
-                        format!(
-                            "the sign-in wasn't finished in time. Finish it by hand with what \
-                             codex printed:\n{printed}"
-                        )
-                    },
-                );
-            }
-        };
-
-    if output.status.success() {
-        let span = tracing::Span::current();
-        span.record("ok", true);
-        span.record("cli_path", tracing::field::display(path.display()));
-        tracing::info!("llm: codex login succeeded");
-        InstallOutcome {
-            ok: true,
-            message: "Signed in to Codex.".into(),
-            path: Some(path.display().to_string()),
-            command: label.to_string(),
-        }
-    } else {
-        // stderr first (that is where the reason goes), but fall back to what the CLI printed on
-        // stdout - on some failures the URL is the only useful thing said.
-        let reason = tail(String::from_utf8_lossy(&output.stderr).trim(), 400);
-        let reason = if reason.is_empty() {
-            login_output(&seen)
-        } else {
-            reason
-        };
-        install_failed(
-            label,
-            if reason.is_empty() {
-                "codex login failed".to_string()
-            } else {
-                reason
-            },
-        )
-    }
+    let meridian_home = default_meridian_home();
+    interactive_login(
+        "codex login",
+        "codex",
+        &["login"],
+        "Codex",
+        "Signed in to Codex.".to_string(),
+        move || {
+            let home = meridian_home.clone();
+            async move { super::codex::login_status_signed_in(&home).await }
+        },
+        InteractiveLoginTiming::PRODUCTION,
+    )
+    .await
 }
 
 /// Run the interactive `claude auth login` on the user's behalf — the "Sign in to Claude"
@@ -1204,109 +1336,33 @@ pub async fn codex_sign_in() -> InstallOutcome {
 ///
 /// `claude auth login` (default `--claudeai`) opens the user's browser to sign into their
 /// Anthropic account on their **Claude subscription** — no API key, nothing metered. A
-/// deliberate mirror of [`cursor_sign_in`]/[`codex_sign_in`]: the browser is enabled (this is
-/// an explicit click, not the daemon's unattended path), stdout is drained live so the
-/// verification URL is surfaced if the browser can't open, and the wait is bounded by
-/// [`INTERACTIVE_LOGIN_TIMEOUT`]. Once it completes, Claude Code persists the auth and every
-/// later run just adopts it — the same "sign in once" model as the other two.
+/// deliberate mirror of [`cursor_sign_in`]/[`codex_sign_in`].
+///
+/// See [`interactive_login`] for the shared race/verify logic and `claude::login_status_signed_in`
+/// for Claude's ground-truth check.
 #[tracing::instrument(skip_all, fields(ok = tracing::field::Empty, cli_path = tracing::field::Empty))]
 pub async fn claude_sign_in() -> InstallOutcome {
-    let label = "claude auth login";
-    let Some(path) = resolve_cli("claude").await else {
-        return install_failed(
-            label,
-            "claude isn't installed yet - install it first".into(),
-        );
-    };
+    let meridian_home = default_meridian_home();
+    interactive_login(
+        "claude auth login",
+        "claude",
+        &["auth", "login", "--claudeai"],
+        "Claude",
+        "Signed in to Claude.".to_string(),
+        move || {
+            let home = meridian_home.clone();
+            async move { super::claude::login_status_signed_in(&home).await }
+        },
+        InteractiveLoginTiming::PRODUCTION,
+    )
+    .await
+}
 
-    tracing::info!("llm: launching interactive claude auth login");
-    let mut cmd = command_for_resolved_cli(&path);
-    cmd.arg("auth")
-        .arg("login")
-        .arg("--claudeai")
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true)
-        .no_window();
-
-    let mut child = match cmd.spawn() {
-        Ok(c) => c,
-        Err(e) => return install_failed(label, format!("couldn't start claude: {e}")),
-    };
-
-    // Drain stdout as it arrives - `claude auth login` prints its verification URL to STDOUT
-    // while it waits, which is exactly what the user needs if the browser doesn't open for them.
-    // Same reasoning as the matching drain in `cursor_sign_in`.
-    let seen = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
-    if let Some(out) = child.stdout.take() {
-        let seen = seen.clone();
-        tokio::spawn(async move {
-            use tokio::io::{AsyncBufReadExt, BufReader};
-            let mut lines = BufReader::new(out).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                tracing::info!(line = %line, "claude auth login");
-                let mut buf = seen.lock().unwrap_or_else(|e| e.into_inner());
-                buf.push_str(&line);
-                buf.push('\n');
-            }
-        });
-    }
-    let login_output = |seen: &std::sync::Mutex<String>| -> String {
-        let buf = seen.lock().unwrap_or_else(|e| e.into_inner());
-        tail(buf.trim(), 300)
-    };
-
-    let output = match tokio::time::timeout(INTERACTIVE_LOGIN_TIMEOUT, child.wait_with_output())
-        .await
-    {
-        Ok(Ok(out)) => out,
-        Ok(Err(e)) => return install_failed(label, format!("couldn't run claude auth login: {e}")),
-        Err(_) => {
-            let printed = login_output(&seen);
-            return install_failed(
-                label,
-                if printed.is_empty() {
-                    "the sign-in wasn't finished in time - click Sign in to Claude again".into()
-                } else {
-                    format!(
-                        "the sign-in wasn't finished in time. Finish it by hand with what \
-                             claude printed:\n{printed}"
-                    )
-                },
-            );
-        }
-    };
-
-    if output.status.success() {
-        let span = tracing::Span::current();
-        span.record("ok", true);
-        span.record("cli_path", tracing::field::display(path.display()));
-        tracing::info!("llm: claude auth login succeeded");
-        InstallOutcome {
-            ok: true,
-            message: "Signed in to Claude.".into(),
-            path: Some(path.display().to_string()),
-            command: label.to_string(),
-        }
-    } else {
-        // stderr first (that is where the reason goes), but fall back to what the CLI printed on
-        // stdout - on some failures the URL is the only useful thing said.
-        let reason = tail(String::from_utf8_lossy(&output.stderr).trim(), 400);
-        let reason = if reason.is_empty() {
-            login_output(&seen)
-        } else {
-            reason
-        };
-        install_failed(
-            label,
-            if reason.is_empty() {
-                "claude auth login failed".to_string()
-            } else {
-                reason
-            },
-        )
-    }
+/// `~/.meridian` (or `$MERIDIAN_HOME`), resolved the same way [`LlmConfig::from_settings`]
+/// does - reused here (rather than re-deriving it) so a status-check verifier and a real
+/// backend call never disagree about which credentials directory they're reading.
+fn default_meridian_home() -> PathBuf {
+    LlmConfig::from_settings(&meridian_core::settings::load_runtime_settings()).meridian_home
 }
 
 /// The last `n` characters of `s`, char-safe.
@@ -1627,6 +1683,128 @@ mod tests {
         let found = resolve_cli("cmd").await.expect("cmd must resolve");
         assert!(found.is_absolute(), "not absolute: {}", found.display());
         assert!(found.exists(), "does not exist: {}", found.display());
+    }
+
+    // ── interactive_login: sign-in race/verify logic ─────────────────────────────────────
+    //
+    // Exercised against a REAL spawned `sh -c "…"` (unix-only - POSIX guarantees `sh` at an
+    // absolute path, same reasoning as `resolve_cli_returns_an_absolute_existing_path` above)
+    // rather than a mock Child, so the actual `try_wait`/`kill_on_drop`/pipe-draining
+    // machinery is what's under test, not a stand-in for it. `InteractiveLoginTiming` is
+    // always overridden to millisecond scale here - the real constants exist for a human
+    // finishing a browser OAuth flow, and using them in a unit test would make the suite
+    // take minutes for no extra coverage.
+
+    fn instant_timing() -> InteractiveLoginTiming {
+        InteractiveLoginTiming {
+            deadline: Duration::from_millis(500),
+            grace: Duration::from_millis(5),
+            poll_interval: Duration::from_millis(15),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_clean_exit_is_trusted_without_ever_calling_verify() {
+        let called = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let called2 = called.clone();
+        let out = interactive_login(
+            "test login",
+            "sh",
+            &["-c", "exit 0"],
+            "Test",
+            "Signed in to Test.".to_string(),
+            move || {
+                called2.store(true, std::sync::atomic::Ordering::SeqCst);
+                async { Some(true) }
+            },
+            instant_timing(),
+        )
+        .await;
+        assert!(out.ok);
+        assert!(
+            !called.load(std::sync::atomic::Ordering::SeqCst),
+            "the happy path must not pay the extra verify round-trip"
+        );
+    }
+
+    /// THE regression this whole refactor exists for: a process that reports failure is
+    /// overridden by a ground-truth check that says the user really is signed in.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_failed_process_is_overridden_by_a_confirming_verify() {
+        let out = interactive_login(
+            "test login",
+            "sh",
+            &["-c", "exit 1"],
+            "Test",
+            "Signed in to Test.".to_string(),
+            || async { Some(true) },
+            instant_timing(),
+        )
+        .await;
+        assert!(
+            out.ok,
+            "verify's confirmation must win over the process exit code"
+        );
+        assert_eq!(out.message, "Signed in to Test.");
+    }
+
+    /// The mirror case: a failed process AND an inconclusive (or negative) verify must still
+    /// report the original failure - ground truth can only ever promote a result to success,
+    /// never invent a more specific failure than what actually happened.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_failed_process_with_an_inconclusive_verify_reports_the_process_failure() {
+        let out = interactive_login(
+            "test login",
+            "sh",
+            &["-c", "echo boom 1>&2; exit 1"],
+            "Test",
+            "Signed in to Test.".to_string(),
+            || async { None },
+            instant_timing(),
+        )
+        .await;
+        assert!(!out.ok);
+        assert!(out.message.contains("boom"), "got: {}", out.message);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_confirmed_negative_verify_does_not_override_a_failed_process() {
+        let out = interactive_login(
+            "test login",
+            "sh",
+            &["-c", "exit 1"],
+            "Test",
+            "Signed in to Test.".to_string(),
+            || async { Some(false) },
+            instant_timing(),
+        )
+        .await;
+        assert!(!out.ok);
+    }
+
+    /// A browser callback landing early must not force the user to wait out the whole
+    /// process: once `verify` confirms sign-in WHILE the child is still running, this
+    /// returns immediately rather than waiting for the child to exit or the deadline to
+    /// fire. Proven by a child that sleeps far longer than `instant_timing`'s deadline -
+    /// the test only completes because the early return actually fires.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn verify_confirming_mid_wait_returns_before_the_child_exits_or_times_out() {
+        let out = interactive_login(
+            "test login",
+            "sh",
+            &["-c", "sleep 30"],
+            "Test",
+            "Signed in to Test.".to_string(),
+            || async { Some(true) },
+            instant_timing(),
+        )
+        .await;
+        assert!(out.ok);
     }
 
     /// A miss must be `None` rather than a bare-name `PathBuf`. `run_capture` treats

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -154,6 +154,14 @@ pub struct PromptRequest {
     pub max_tokens: u32,
     /// Trace label (the hour, e.g. "2026-07-10T13") — for spans and logs, never the model.
     pub label: String,
+    /// This call is being watched synchronously by a user right now (e.g. the task
+    /// composer's "Draft with AI"), as opposed to a background job (summarisation,
+    /// worklog generation) where a slower, more capable model costs nothing perceptible.
+    ///
+    /// A backend MAY use this to pick a faster model tier when the user has not pinned
+    /// an explicit override — see `CursorBackend::complete`, the only backend that does
+    /// today. Defaults to `false`; only [`crate::plan_tasks::draft::draft`] sets it.
+    pub interactive: bool,
 }
 
 impl PromptRequest {
@@ -164,6 +172,7 @@ impl PromptRequest {
             schema: None,
             max_tokens: 2048,
             label: label.into(),
+            interactive: false,
         }
     }
 
@@ -174,6 +183,12 @@ impl PromptRequest {
 
     pub fn with_max_tokens(mut self, n: u32) -> Self {
         self.max_tokens = n;
+        self
+    }
+
+    /// Mark this call as synchronously watched by a user — see the field doc.
+    pub fn interactive(mut self) -> Self {
+        self.interactive = true;
         self
     }
 }

--- a/src/llm/openai_compat.rs
+++ b/src/llm/openai_compat.rs
@@ -573,6 +573,7 @@ mod tests {
             schema: Some(crate::llm::prompts::workstream_schema()),
             max_tokens: 2048,
             label: "test".into(),
+            interactive: false,
         }
     }
 
@@ -657,6 +658,7 @@ mod tests {
             schema: None,
             max_tokens: 512,
             label: "t".into(),
+            interactive: false,
         };
         apply_schema(&mut body, &req, &ep(SchemaRung::Strict));
         assert!(body["response_format"].is_null());
@@ -870,6 +872,7 @@ mod tests {
             schema: Some(crate::llm::prompts::workstream_schema()),
             max_tokens: 2048,
             label: "live workstream".into(),
+            interactive: false,
         };
 
         let out = OpenAiCompatBackend { cfg }

--- a/src/llm/probe.rs
+++ b/src/llm/probe.rs
@@ -267,6 +267,7 @@ async fn attempt(
         schema: Some(schema.clone()),
         max_tokens: PROBE_MAX_TOKENS,
         label: format!("probe {rung:?}"),
+        interactive: false,
     };
     let out = OpenAiCompatBackend { cfg }.complete(&req).await?;
     match super::parse_json_object(&out.text) {

--- a/src/llm_experiment/request.rs
+++ b/src/llm_experiment/request.rs
@@ -232,6 +232,7 @@ pub fn from_snapshot(
             schema,
             max_tokens,
             label,
+            interactive: false,
         },
         render_ctx,
     ))

--- a/src/plan_tasks/draft.rs
+++ b/src/plan_tasks/draft.rs
@@ -118,6 +118,11 @@ pub async fn draft(note: &str) -> Result<TaskDraft> {
             schema: Some(prompts::plan_task_draft_schema()),
             max_tokens: DRAFT_MAX_TOKENS,
             label: "plan-task-draft".to_string(),
+            // The one call in this backend that a user is watching synchronously — see
+            // `PromptRequest::interactive`'s doc. Lets `CursorBackend` pick a faster
+            // model tier for this call specifically, without touching the pinned
+            // default that summarisation/worklog generation rely on for quality.
+            interactive: true,
         };
 
         let (out, provider) = match llm::complete(&req).await {

--- a/src/pm_worklog/generate.rs
+++ b/src/pm_worklog/generate.rs
@@ -627,6 +627,7 @@ pub(crate) async fn generate_request(
         schema: Some(prompts::worklog_generate_schema()),
         max_tokens: GENERATE_MAX_TOKENS,
         label: format!("worklog-generate {day_local} {task_id}"),
+        interactive: false,
     };
     Ok((req, candidates.len()))
 }
@@ -658,6 +659,7 @@ pub(crate) async fn generate_request_from_task(
         schema: Some(prompts::worklog_generate_schema()),
         max_tokens: GENERATE_MAX_TOKENS,
         label: format!("worklog-generate {day_local} (inline)"),
+        interactive: false,
     };
     Ok((req, candidates.len()))
 }

--- a/src/worklog_pipeline/hour.rs
+++ b/src/worklog_pipeline/hour.rs
@@ -100,6 +100,7 @@ pub(crate) fn report_request(report_input: String, label: &str) -> PromptRequest
         schema: None,
         max_tokens: REPORT_MAX_TOKENS,
         label: format!("activity-report {label}"),
+        interactive: false,
     }
 }
 

--- a/src/worklog_pipeline/workstream.rs
+++ b/src/worklog_pipeline/workstream.rs
@@ -65,6 +65,7 @@ pub(crate) fn workstream_request(
         schema: Some(prompts::workstream_schema()),
         max_tokens: WORKSTREAM_MAX_TOKENS,
         label: format!("workstream {hour_label}"),
+        interactive: false,
     }
 }
 

--- a/ui/__tests__/llm-provider-connection-phase.test.ts
+++ b/ui/__tests__/llm-provider-connection-phase.test.ts
@@ -140,6 +140,36 @@ it('the subscription-provider "not signed in" copy only replaces the DISPLAY, no
   expect(registry).toMatch(/Sign in to Claude/)
 })
 
+// ── A failure is never a dead end: fixing THIS provider is never the only way forward ────────
+//
+// The dashboard's own Draft-with-AI failure path (`AiEngineNotice`) already shows the
+// engine's real error plus a one-click route back to the picker. The wizard/Settings detail
+// view had the same underlying data but only a "‹ All providers" link at the very top of the
+// screen — reachable, but not right next to the failure a user is actually reading. Both
+// failure branches (the subscription-provider "sign in" card AND the generic "isn't
+// responding" branch, for Copilot/custom endpoints) must offer the same one-click way out.
+
+it('a failed subscription-provider sign-in offers a one-click way to try a different provider', () => {
+  // `case 'failed':` also appears in `statusPill`'s switch - scope to `ConnectionBody`'s,
+  // the one that actually renders the card.
+  const connectionBody = detail.slice(detail.indexOf('function ConnectionBody'))
+  const failedBranch = connectionBody.slice(
+    connectionBody.indexOf("case 'failed':"),
+    connectionBody.indexOf("case 'ready_untested':"),
+  )
+  expect(failedBranch).toMatch(/onSwitchProvider/)
+  // Both the signInProvider branch and the generic fallback branch render it - not just one.
+  expect(failedBranch.match(/<SwitchProvider/g)?.length).toBe(2)
+})
+
+it('the switch-provider affordance is wired to the same destination as the top-of-screen back link', () => {
+  // `ConnectionBody` has no navigation of its own — it must be handed the real `onBack`
+  // callback from `LlmProviderDetail`, the same one `<BackLink>` already uses, or the button
+  // would need its own (and inevitably drifting) notion of "back to the picker".
+  expect(detail).toMatch(/onSwitchProvider=\{onBack\}/)
+  expect(detail).toMatch(/onSwitchProvider:\s*\(\)\s*=>\s*void/)
+})
+
 // The button copy and the tray command it fires used to live in two files - a provider added
 // to one and not the other got a sign-in button wired to nothing, or (worse) to another
 // vendor's login. One record now carries both, so they cannot desync.

--- a/ui/__tests__/task-composer.test.ts
+++ b/ui/__tests__/task-composer.test.ts
@@ -158,6 +158,21 @@ describe('the composer never blocks on the AI', () => {
   })
 })
 
+// This file's own header already says drafting "can take most of a minute" - but the
+// component used to override <GeneratingBar>'s honest default note ("this might take a
+// minute or so", the same wording WorklogDraftDialog and SummaryTaskView show) with a
+// hardcoded "this usually takes a few seconds". Cursor in particular can legitimately take
+// closer to a minute on a cold or hardened-ladder-retried call, so that override was a
+// promise the button could not keep for every provider - confirmed live (a single hardened
+// cursor-agent call measured ~6s; a call that has to retry can run well past "a few
+// seconds"). Fixed by dropping the override entirely.
+describe('the drafting spinner does not promise a latency it cannot keep', () => {
+  it('does not override GeneratingBar\'s note with an inaccurate "few seconds" claim', () => {
+    const generatingBarBlock = composer.slice(composer.indexOf('<GeneratingBar'))
+    expect(generatingBarBlock).not.toMatch(/note=/)
+  })
+})
+
 describe('composer state survives the plan modal closing mid-draft', () => {
   it('the store is module-level and exposed via useSyncExternalStore', () => {
     expect(store.includes('useSyncExternalStore')).toBe(true)

--- a/ui/components/LlmProviderDetail.tsx
+++ b/ui/components/LlmProviderDetail.tsx
@@ -164,6 +164,20 @@ function TestAgain({ onTest, label = 'Test again' }: { onTest: () => void; label
   )
 }
 
+/** Offered ONLY on a failure - fixing this provider is never the only way forward. Plain
+ *  text-link weight (quieter than `TestAgain`'s bordered box) because retrying the SAME
+ *  provider is the more likely next move; this is the escape hatch, not a peer action. */
+function SwitchProvider({ onClick }: { onClick: () => void }) {
+  return (
+    <button onClick={onClick} className="self-start underline" style={{
+      ...T.hint, color: 'var(--t-accent)', background: 'none', border: 'none',
+      padding: 0, cursor: 'pointer', textAlign: 'left',
+    }}>
+      Try a different provider
+    </button>
+  )
+}
+
 const Mono = ({ children }: { children: React.ReactNode }) =>
   <code style={{ fontFamily: 'var(--font-mono, ui-monospace)', fontSize: '0.94em' }}>{children}</code>
 
@@ -296,6 +310,7 @@ export default function LlmProviderDetail({
             onInstall={install}
             onSignIn={signIn}
             onTest={onTest}
+            onSwitchProvider={onBack}
           />
         </div>
       </div>
@@ -361,10 +376,19 @@ export default function LlmProviderDetail({
 }
 
 /** The body of the step card — one heading, one explanation, at most one primary button. */
-function ConnectionBody({ phase, name, providerId, installHint, installMsg, signInMsg, onInstall, onSignIn, onTest }: {
+function ConnectionBody({
+  phase, name, providerId, installHint, installMsg, signInMsg, onInstall, onSignIn, onTest,
+  onSwitchProvider,
+}: {
   phase: Phase; name: string; providerId: string
   installHint?: string; installMsg: string | null; signInMsg: string | null
   onInstall: () => void; onSignIn: () => void; onTest: () => void
+  /** Back to the chooser grid - offered on a failure so getting THIS provider working is
+   *  never the only way forward. Same destination `<BackLink>` already reaches from the
+   *  top of the screen; this just puts it one click closer to where the failure is read,
+   *  matching `<AiEngineNotice>`'s "Check your provider" pattern on the dashboard's own
+   *  Draft-with-AI failure path. */
+  onSwitchProvider: () => void
 }) {
   // Providers whose CLI authenticates against the user's OWN subscription via a browser OAuth
   // Meridian can drive in-app. From the shared registry in `@/lib/llm-providers`, so the copy
@@ -467,6 +491,7 @@ function ConnectionBody({ phase, name, providerId, installHint, installMsg, sign
                 Prefer the terminal? Run <Mono>{signInProvider.cmd}</Mono>, then test again.
               </p>
             </div>
+            <SwitchProvider onClick={onSwitchProvider} />
           </>
         )
       }
@@ -475,6 +500,7 @@ function ConnectionBody({ phase, name, providerId, installHint, installMsg, sign
           <span style={T.step}>{name} isn&apos;t responding</span>
           <p style={T.body}>{phase.message}</p>
           <TestAgain onTest={onTest} />
+          <SwitchProvider onClick={onSwitchProvider} />
         </>
       )
 

--- a/ui/components/plan/TaskComposer.tsx
+++ b/ui/components/plan/TaskComposer.tsx
@@ -311,11 +311,16 @@ export function TaskComposer({ day, trackers, onDone, onCancel, hero = false }: 
 
         {drafting && (
           <div className="mt-3">
+            {/* No `note` override - the AI engine behind this call is whatever the user
+                picked (Cursor's default reasoning-effort model runs well under a minute,
+                but not "a few seconds"), so `<GeneratingBar>`'s own honest default
+                ("this might take a minute or so", same wording WorklogDraftDialog and
+                SummaryTaskView already use) is the one claim this button can actually
+                keep for every provider. */}
             <GeneratingBar
               hue="var(--t-accent)"
               label="Drafting your task…"
               detail="Shaping your note into a title and description - they land in the fields below, yours to edit."
-              note="this usually takes a few seconds"
             />
           </div>
         )}

--- a/ui/components/useLlmProviderDetection.ts
+++ b/ui/components/useLlmProviderDetection.ts
@@ -146,8 +146,16 @@ export function useLlmProviderDetection() {
         })
         void testOne(id, { silent: true })
       } else {
-        // Sign-in didn't complete - refresh at least the install state.
-        await detect()
+        // Sign-in didn't complete, at least according to the CLI process itself - but the
+        // backend now double-checks that against a real status read before giving up (see
+        // `interactive_login` in `src/llm/detect.rs`), so `ok: false` here is not the whole
+        // story either: a stale FAILED `last_test` from an earlier real attempt could still
+        // be sitting on this provider from before the browser tab was even opened, and
+        // without a fresh test it would keep reading as broken until the panel happens to
+        // remount 60s+ later. Re-test (silently - the user is already watching the sign-in
+        // flow, this isn't a background surprise) rather than only refreshing install state,
+        // so a sign-in that quietly resolved itself a moment later is reflected right away.
+        await Promise.all([detect(), testOne(id, { silent: true })])
       }
       return outcome
     } catch (e) {


### PR DESCRIPTION
## Summary

Two real problems reported during onboarding's "Connect your AI engine" step:

1. **Codex**: the browser OAuth flow visibly succeeds ("Signed in to Codex. You may now close this page.") but the app keeps showing `ACTION NEEDED — Sign in to ChatGPT`.
2. **Cursor**: the provider tests as connected and IN USE, but "Draft with AI" takes ~1 minute instead of the "usually takes a few seconds" the UI promised.

Root cause (confirmed via code reading + live CLI probes, not guesswork): `codex_sign_in`/`cursor_sign_in`/`claude_sign_in` (`src/llm/detect.rs`) trusted *only* the spawned CLI child's own exit code / a 180s timeout. The frontend's failure branch (`useLlmProviderDetection.ts`) never re-tested on that path either, so a stale cached failure could sit indefinitely even after the real sign-in resolved. Live-tested that `cursor-agent status --format json` can report `isAuthenticated: true` while **exiting code 1** — an exit-code-only check is unreliable for Cursor specifically.

## What changed

- **Sign-in detection hardening** (`src/llm/detect.rs`, `codex.rs`, `cursor.rs`, `claude.rs`): extracted a shared `interactive_login()` helper. It trusts a clean exit 0 directly (no added latency on the happy path), but on any other outcome (non-zero exit, spawn/wait error, timeout) it re-verifies against each vendor's own cheap, local-only ground-truth check (`codex login status`, `cursor-agent status --format json`, `claude auth status --json`) before reporting failure — and polls that check while the child is still running so an early browser callback doesn't force the full 180s wait. Both signals are always logged so a divergence is visible in traces.
- **Frontend**: `useLlmProviderDetection.ts`'s sign-in failure branch now re-tests (silently) instead of only re-detecting install state, so a stale cached failure self-corrects.
- **Cursor "Draft with AI" latency**: fixed a confirmed UI-copy bug (`TaskComposer.tsx` overrode `<GeneratingBar>`'s honest default with an inaccurate "usually takes a few seconds"); added a faster model tier (`gpt-5.4-mini-low`) for this one interactive, synchronously-watched call via a new `PromptRequest::interactive()` hint (explicit user model overrides are never touched); added a bounded one-shot retry in the Cursor hardening ladder for genuinely transient/network failures (never for our own client-side timeout, which would double the worst-case wait); added slow-call WARN telemetry.
- **Onboarding recovery UX**: added an inline "Try a different provider" link on the setup wizard's failed sign-in card, matching the pattern already proven on the dashboard's Draft-with-AI failure path (`AiEngineNotice.tsx`).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (980 passed in the daemon lib alone; 303 in the tray; zero failures workspace-wide)
- [x] `cd ui && npm run typecheck && npm run build && bun test` (882 passed)
- [x] Pre-push hook (fmt, ui build, clippy, ui tests, security audit, cargo test) — all green
- [ ] Manual smoke test on a packaged/dev build: real browser OAuth for Codex and Cursor, and a real "Draft with AI" timing comparison — headless CI can't exercise a live browser round-trip or a paid subscription call, so this needs a human pass before merge.

New/updated unit tests cover: the ternary status-check parsers for all three vendors (including a regression pin for Cursor's exit-code-vs-body divergence), the `interactive_login` race/verify logic against a real spawned `sh` process (happy path never calls verify; a failed process is overridden by a confirming verify; a confirmed-negative or inconclusive verify does not override a failure; a mid-wait confirmation returns early), the new transient-retry lever in the Cursor degradation ladder (including that a timeout-shaped message is explicitly *not* retried), the fast-model-tier selection logic, and the new switch-provider UI affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)