### PR TITLE
fix(llm): set additionalProperties:false on every strict-schema object node

### DIFF
--- a/src/llm/schema.rs
+++ b/src/llm/schema.rs
@@ -88,6 +88,23 @@ pub(crate) fn strictify(v: &Value) -> Value {
                 "required".into(),
                 Value::Array(keys.into_iter().map(Value::String).collect()),
             );
+            // The other half of OpenAI's strict-mode contract, and the one Meridian's
+            // shared schemas didn't all carry by hand: every object node needs
+            // `additionalProperties: false`, not just `properties`-complete `required`.
+            // `placements.items` had it (authored explicitly in prompts.rs) so the
+            // existing test above only ever proved it *survives* the rewrite; every OTHER
+            // object node in every shared schema silently lacked it. Groq's endpoint
+            // validates this directly (unlike `codex exec --output-schema`, which appears
+            // to inject it before the API ever sees the request - see this fn's own doc on
+            // why a CLI-observed rung can hide a gap a direct API exposes), and rejects the
+            // whole request with a 400 before the model runs: "invalid JSON schema for
+            // response_format: 'answer': additionalProperties:false must be set on every
+            // object" - observed live across dozens of accounts, the single most common
+            // Groq-path failure in production telemetry (2026-08-19). Setting it here,
+            // unconditionally, closes the gap for every current and future shared schema
+            // at the one place that already owns strict-mode compliance, rather than
+            // relying on each hand-authored schema to remember it on every nested object.
+            out.insert("additionalProperties".into(), Value::Bool(false));
             Value::Object(out)
         }
         Value::Array(a) => Value::Array(a.iter().map(strictify).collect()),
@@ -140,6 +157,14 @@ mod tests {
                     "key {k} missing from required"
                 );
             }
+            // The other half of the contract - see this test's own comment for why
+            // `strictify_preserves_other_keywords` alone didn't catch this being absent
+            // everywhere ELSE it was needed.
+            assert_eq!(
+                v["additionalProperties"],
+                json!(false),
+                "an object node with properties is missing additionalProperties:false"
+            );
         }
         match v {
             Value::Object(m) => m.values().for_each(assert_strict),


### PR DESCRIPTION
## Summary
Root-caused live from production telemetry (central OpenObserve, SSH tunnel to `meridian-telemetry`, last 7 days of the `default` logs stream, `body LIKE '%custom provider%'`):

| Failure (body) | Count | Distinct hosts |
|---|---|---|
| `custom provider returned an error` | 1263 | 29 |
| `custom provider rate-limited` (genuine 429, correctly handled already) | 480 | 21 |
| `custom provider returned no content` | 158 | 18 |
| `custom provider unreachable` | 48 | 6 |

Breaking down the 1263 non-rate-limit errors by `detail`, the single largest bucket (184 hits, by far the most common individual failure) was:

```
invalid JSON schema for response_format: 'answer': `additionalProperties:false` must be set on every object
```

Every one of these calls (Meridian's free-tier default path, Groq's `openai/gpt-oss-120b`) failed outright with a 400 **before the model ever ran** — a pure client-side schema bug, not a rate limit or account issue.

## Root cause
`strictify()` (`src/llm/schema.rs`) rewrites Meridian's shared, provider-agnostic schemas into OpenAI's strict dialect. It correctly makes every `properties` key `required` (the first half of the strict-mode contract), but never *set* `additionalProperties: false` itself — it only ever *preserved* the value on nodes where a shared schema in `prompts.rs` happened to hand-author it already. `codex exec --output-schema` apparently injects/tolerates its absence (the function's own doc already flagged this CLI-vs-direct-API gap as a risk), so it was invisible there. Groq's endpoint validates the raw schema directly and rejects the whole request when any object node lacks it.

## Fix
Set `additionalProperties: false` unconditionally on every object node `strictify` already touches (same block that computes `required`), rather than depending on each shared schema to remember it on every nested object — closing the gap for every current and future schema at the one place that already owns strict-mode compliance.

Also extended the existing `assert_strict` test helper to check this on every node (previously only `strictify_preserves_other_keywords` checked one specific hand-authored node, which is why this passed CI while failing in production) — so a future shared schema missing it fails loudly in tests instead of silently 400ing for real users.

## Test plan
- [x] `cargo test --lib llm::schema::` — 5/5
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 991 passed, 0 failed
- [x] pre-push hook (fmt + clippy + ui build/tests + security audit + cargo test) — all green