### PR TITLE
fix(release): address CodeRabbit findings from the pre-main → main promotion (PR #811)

### DIFF
--- a/meridian-core/src/readers/usage_rollup.rs
+++ b/meridian-core/src/readers/usage_rollup.rs
@@ -46,6 +46,7 @@
 //! - `tray/src-tauri/src/analytics/health.rs` — the sibling *point-in-time*
 //!   health snapshot; this module is strictly per-day counters.
 
+use anyhow::Context;
 use std::collections::{BTreeMap, HashSet};
 
 use serde::{Deserialize, Serialize};
@@ -220,15 +221,29 @@ impl UsageRollup {
 #[tracing::instrument(skip(pool))]
 pub async fn usage_rollup(pool: &SqlitePool, day: &str) -> anyhow::Result<UsageRollup> {
     let (day_start, day_end) = crate::date::local_day_bounds(day);
-    let tables = existing_tables(pool).await?;
+    let tables = existing_tables(pool)
+        .await
+        .context("usage_rollup: reading sqlite_master")?;
     let mut r = UsageRollup::default();
 
-    read_ticket_actions(pool, &tables, &day_start, &day_end, &mut r).await?;
-    read_worklog_states(pool, &tables, day, &mut r).await?;
-    read_plan(pool, &tables, day, &mut r).await?;
-    read_day_tasks(pool, &tables, day, &mut r).await?;
-    read_personal_and_agents(pool, &tables, day, &day_start, &day_end, &mut r).await?;
-    read_notifications(pool, &tables, &day_start, &day_end, &mut r).await?;
+    read_ticket_actions(pool, &tables, &day_start, &day_end, &mut r)
+        .await
+        .context("usage_rollup: reading ticket actions")?;
+    read_worklog_states(pool, &tables, day, &mut r)
+        .await
+        .context("usage_rollup: reading worklog states")?;
+    read_plan(pool, &tables, day, &mut r)
+        .await
+        .context("usage_rollup: reading daily plan")?;
+    read_day_tasks(pool, &tables, day, &mut r)
+        .await
+        .context("usage_rollup: reading day tasks")?;
+    read_personal_and_agents(pool, &tables, day, &day_start, &day_end, &mut r)
+        .await
+        .context("usage_rollup: reading personal tasks and coding-agent sessions")?;
+    read_notifications(pool, &tables, &day_start, &day_end, &mut r)
+        .await
+        .context("usage_rollup: reading notifications")?;
 
     tracing::info!(
         day,
@@ -354,7 +369,9 @@ async fn read_worklog_states(
     if !have(tables, &["pm_worklogs", "pm_tasks"]) {
         return Ok(());
     }
-    let w = crate::worklogs::get_worklogs(pool, day).await?;
+    let w = crate::worklogs::get_worklogs(pool, day)
+        .await
+        .context("usage_rollup: reading worklogs via the dashboard reader")?;
     for item in &w.items {
         match (item.is_proposed, item.state.as_str()) {
             (true, "proposed") => r.proposals_pending += 1,

--- a/src/coding_agent_session_ingest/summariser/cursor_agent.rs
+++ b/src/coding_agent_session_ingest/summariser/cursor_agent.rs
@@ -101,8 +101,8 @@ async fn run_once(
 
     if !cap.success {
         let blob = format!("{}\n{}", cap.stderr, cap.stdout);
-        if prompts::looks_rate_limited(&blob) {
-            let msg = prompts::rate_limited_line(&blob)
+        if prompts::looks_rate_limited_cursor(&blob) {
+            let msg = prompts::rate_limited_line_cursor(&blob)
                 .unwrap_or_else(|| prompts::first_line(&cap.stderr));
             return Err(SummariserError::RateLimited(if msg.is_empty() {
                 "cursor-agent usage limit".into()

--- a/src/coding_agent_session_ingest/summariser/prompts.rs
+++ b/src/coding_agent_session_ingest/summariser/prompts.rs
@@ -44,19 +44,8 @@ pub fn summary_schema_json() -> String {
 }
 
 /// Substrings that mark a subscription usage/rate limit in CLI stderr/output —
-/// for Claude (`claude -p`), Codex (`codex exec`), and `cursor-agent` alike.
-///
-/// `resource_exhausted` / `retriableerror` are Cursor's own vocabulary, not a
-/// generic phrase like the rest of this list — its backend is gRPC-flavoured and
-/// reports a free-plan quota wall as `RetriableError: [resource_exhausted] Error`,
-/// wrapped in cursor-agent's own connection-retry banner ("Connection lost,
-/// reconnecting..." x3) that reads exactly like a network blip. Without this
-/// marker a resource-exhausted account never returns `LlmError::RateLimited`
-/// (`degradable_message` -> `None`, no further retry) - it falls through as a
-/// plain `Failed`, which both `resolver::complete_inner` AND
-/// `cursor_cli::run_hardened`'s transient lever then retry, burning more calls
-/// against an already-exhausted quota and taking 20-30s+ per attempt to fail
-/// again the same way. Observed live on a free-plan account 2026-08-19.
+/// generic across every engine (Claude `claude -p`, Codex `codex exec`,
+/// Copilot, and `cursor-agent`).
 const RATE_LIMIT_MARKERS: &[&str] = &[
     "usage limit",
     "rate limit",
@@ -68,13 +57,42 @@ const RATE_LIMIT_MARKERS: &[&str] = &[
     "resets at",
     "try again at",
     "upgrade to plus",
-    "resource_exhausted",
-    "resource exhausted",
 ];
 
-pub fn looks_rate_limited(text: &str) -> bool {
+/// `cursor-agent`-ONLY vocabulary — deliberately NOT in [`RATE_LIMIT_MARKERS`].
+///
+/// `resource_exhausted` is not a generic phrase like the rest of that list: it is
+/// gRPC's own `RESOURCE_EXHAUSTED` status, which Cursor's backend uses to report a
+/// free-plan quota wall (`RetriableError: [resource_exhausted] Error`, wrapped in
+/// cursor-agent's own connection-retry banner that reads exactly like a network
+/// blip) — but the same gRPC code also covers non-quota resource failures (out of
+/// memory, a message-size limit) that have nothing to do with a rate limit. Mixed
+/// into the shared list it would let Claude/Codex/Copilot's genuinely transient
+/// resource errors get misclassified as `RateLimited`, which skips
+/// `resolver::complete_inner`'s and `cursor_cli::run_hardened`'s transient retry —
+/// exactly backwards for an error that WOULD have recovered on its own. Scoped to
+/// cursor-agent alone via [`looks_rate_limited_cursor`], whose only caller is
+/// `summariser/cursor_agent.rs`. Without this marker a resource-exhausted Cursor
+/// account never returns `LlmError::RateLimited` and instead retries against an
+/// already-exhausted quota, taking 20-30s+ per attempt to fail again the same way.
+/// Observed live on a free-plan account 2026-08-19.
+const CURSOR_RATE_LIMIT_MARKERS: &[&str] = &["resource_exhausted", "resource exhausted"];
+
+fn matches_any_marker(text: &str, markers: &[&str]) -> bool {
     let low = text.to_lowercase();
-    RATE_LIMIT_MARKERS.iter().any(|m| low.contains(m))
+    markers.iter().any(|m| low.contains(m))
+}
+
+/// Generic rate-limit check, safe for every engine. Does NOT match Cursor's
+/// gRPC `resource_exhausted` vocabulary — see [`looks_rate_limited_cursor`].
+pub fn looks_rate_limited(text: &str) -> bool {
+    matches_any_marker(text, RATE_LIMIT_MARKERS)
+}
+
+/// `cursor-agent`-only: the generic check, plus Cursor's own gRPC vocabulary. See
+/// [`CURSOR_RATE_LIMIT_MARKERS`] for why this must not be the default.
+pub fn looks_rate_limited_cursor(text: &str) -> bool {
+    looks_rate_limited(text) || matches_any_marker(text, CURSOR_RATE_LIMIT_MARKERS)
 }
 
 /// The first line that actually matched a rate-limit marker, capped to 200
@@ -82,9 +100,21 @@ pub fn looks_rate_limited(text: &str) -> bool {
 /// additional input from stdin..."), so quoting `first_line` puts the wrong
 /// text in the fallback WARN log — quote the matching line instead.
 pub fn rate_limited_line(text: &str) -> Option<String> {
+    rate_limited_line_matching(text, looks_rate_limited)
+}
+
+/// [`rate_limited_line`], but scoped to [`looks_rate_limited_cursor`] — must be
+/// paired with it (see `summariser/cursor_agent.rs`), or a line that only matched
+/// via [`CURSOR_RATE_LIMIT_MARKERS`] silently falls through to `first_line`
+/// instead of being quoted.
+pub fn rate_limited_line_cursor(text: &str) -> Option<String> {
+    rate_limited_line_matching(text, looks_rate_limited_cursor)
+}
+
+fn rate_limited_line_matching(text: &str, matches: impl Fn(&str) -> bool) -> Option<String> {
     text.lines()
         .map(str::trim)
-        .find(|line| !line.is_empty() && looks_rate_limited(line))
+        .find(|line| !line.is_empty() && matches(line))
         .map(|line| line.chars().take(200).collect())
 }
 
@@ -178,9 +208,25 @@ mod tests {
                      (attempt 1)...\nRetry attempt 1...\nConnection lost, reconnecting to \
                      https://agentn.global.api5.cursor.sh (attempt 2)...\nRetry attempt 2...\n\
                      RetriableError: [resource_exhausted] Error";
-        assert!(looks_rate_limited(blob));
-        let line = rate_limited_line(blob).unwrap();
+        assert!(looks_rate_limited_cursor(blob));
+        let line = rate_limited_line_cursor(blob).unwrap();
         assert!(line.contains("resource_exhausted"));
+    }
+
+    /// The whole point of scoping `resource_exhausted` to Cursor: the SAME gRPC
+    /// status also covers non-quota resource failures for other engines (out of
+    /// memory, a message-size limit), and misreading one as a rate limit would
+    /// skip the transient retry that would have recovered it. Generic
+    /// `looks_rate_limited`/`rate_limited_line` (what Claude/Codex/Copilot call)
+    /// must never match Cursor's vocabulary.
+    #[test]
+    fn a_non_cursor_resource_exhausted_message_is_not_a_rate_limit() {
+        let blob = "request failed: resource exhausted while allocating worker memory";
+        assert!(!looks_rate_limited(blob));
+        assert!(rate_limited_line(blob).is_none());
+        // But it IS still Cursor's business - the cursor-scoped check must still
+        // catch a resource-exhausted message even without the retry-banner dressing.
+        assert!(looks_rate_limited_cursor(blob));
     }
 
     /// A bare "connection lost" with no exhaustion signal must NOT be read as a

--- a/src/llm/cursor_cli.rs
+++ b/src/llm/cursor_cli.rs
@@ -565,10 +565,11 @@ where
             model = FALLBACK_MODEL.to_string();
             tried_fallback_model = true;
         } else if !tried_transient_retry && looks_transient(msg) {
-            tracing::warn!(
-                error = %msg,
-                "cursor: transient failure - retrying once unchanged"
-            );
+            // No raw `msg` field here (unlike the other levers, which only ever attach safe
+            // structured state) - it's the vendor CLI's own stderr/stdout text, and WARN is the
+            // level that leaves a packaged install. See the coding-conventions note on
+            // `CAPTURE_TARGETS`/`SAFE_STRING_KEYS` in CLAUDE.md's Observability section.
+            tracing::warn!(model = %model, "cursor: transient failure - retrying once unchanged");
             tried_transient_retry = true;
         } else {
             // Nothing left to degrade, or a cause no lever addresses.

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -602,9 +602,11 @@ where
     let outcome = classify_test_outcome(complete().await);
     match &outcome {
         ProviderTestOutcome::Failed { message } if looks_like_a_probe_timeout(message) => {
+            // No `message` field - it's the CLI's own timeout text, and WARN is the level
+            // that leaves a packaged install. `looks_like_a_probe_timeout` already pins the
+            // shape this matched, so the classification itself is the useful signal.
             tracing::warn!(
                 provider = %id,
-                error = %message,
                 "llm: connectivity probe timed out - retrying once before reporting failure"
             );
             classify_test_outcome(complete().await)
@@ -1072,7 +1074,11 @@ fn drain_lines(
             use tokio::io::{AsyncBufReadExt, BufReader};
             let mut lines = BufReader::new(out).lines();
             while let Ok(Some(line)) = lines.next_line().await {
-                tracing::info!(line = %line, stream, "llm: interactive login output");
+                // No `line` field - login CLI output carries OAuth verification URLs and
+                // device codes, short-lived credentials with no reason to sit in the local
+                // spool. `buffered_tail` below already retains the buffer itself for the
+                // user-facing message, so the length is all this log needs.
+                tracing::debug!(stream, chars = line.len(), "llm: interactive login output");
                 let mut buf = seen.lock().unwrap_or_else(|e| e.into_inner());
                 buf.push_str(&line);
                 buf.push('\n');
@@ -1309,10 +1315,12 @@ where
         // The two signals disagree: the CLI process reported failure/timeout, but a direct
         // read of the vendor's own auth state says otherwise. Ground truth wins - logged at
         // WARN (not swallowed as INFO) precisely because a real divergence like this is
-        // worth seeing on a packaged install, not just locally.
+        // worth seeing on a packaged install, not just locally. No `process_message` field -
+        // it's built from the drained CLI stderr/stdout tail (see the `printed` interpolation
+        // above), which is raw vendor CLI text and must not egress via WARN.
         tracing::warn!(
             bin,
-            process_outcome = %process_message,
+            verify_overrode = true,
             "llm: sign-in process reported failure but the status check confirms the user IS \
              signed in - trusting the status check"
         );

--- a/src/llm/schema.rs
+++ b/src/llm/schema.rs
@@ -55,60 +55,83 @@ pub(crate) fn strictify(v: &Value) -> Value {
                 .map(|(k, val)| (k.clone(), strictify(val)))
                 .collect();
 
-            // Only an object node with `properties` carries the rule; `properties`'
-            // own children are schemas in their own right and were handled above.
-            let Some(keys) = out
+            // Whether THIS node is an object-type schema at all - checked on `type`,
+            // not on "does it have a `properties` key". `properties` itself is a bag
+            // of field-name -> schema mappings, not a schema node, and recursion walks
+            // into it too (see the `.iter().map` above); testing `type` instead of
+            // `properties`' mere presence is what keeps this from misfiring on that
+            // bag, while still catching a `{"type":"object"}` with no `properties` at
+            // all, or a `["object","null"]` union - both of which the old
+            // `out.get("properties")`-gated early return skipped past silently,
+            // leaving them without `additionalProperties:false` (see below).
+            if !declares_object_type(&out) {
+                return Value::Object(out);
+            }
+
+            let keys = out
                 .get("properties")
                 .and_then(Value::as_object)
                 .map(|p| p.keys().cloned().collect::<Vec<_>>())
-            else {
-                return Value::Object(out);
-            };
-
-            let required: Vec<String> = out
-                .get("required")
-                .and_then(Value::as_array)
-                .map(|a| {
-                    a.iter()
-                        .filter_map(|x| x.as_str().map(str::to_string))
-                        .collect()
-                })
                 .unwrap_or_default();
 
-            // A key the schema didn't require kept its "absent" meaning in the answer;
-            // it can only keep it under strict mode by being nullable.
-            if let Some(props) = out.get_mut("properties").and_then(Value::as_object_mut) {
-                for k in keys.iter().filter(|k| !required.contains(k)) {
-                    if let Some(p) = props.get_mut(k) {
-                        make_nullable(p);
+            if !keys.is_empty() {
+                let required: Vec<String> = out
+                    .get("required")
+                    .and_then(Value::as_array)
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|x| x.as_str().map(str::to_string))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                // A key the schema didn't require kept its "absent" meaning in the
+                // answer; it can only keep it under strict mode by being nullable.
+                if let Some(props) = out.get_mut("properties").and_then(Value::as_object_mut) {
+                    for k in keys.iter().filter(|k| !required.contains(k)) {
+                        if let Some(p) = props.get_mut(k) {
+                            make_nullable(p);
+                        }
                     }
                 }
+                out.insert(
+                    "required".into(),
+                    Value::Array(keys.into_iter().map(Value::String).collect()),
+                );
             }
-            out.insert(
-                "required".into(),
-                Value::Array(keys.into_iter().map(Value::String).collect()),
-            );
             // The other half of OpenAI's strict-mode contract, and the one Meridian's
-            // shared schemas didn't all carry by hand: every object node needs
-            // `additionalProperties: false`, not just `properties`-complete `required`.
-            // `placements.items` had it (authored explicitly in prompts.rs) so the
-            // existing test above only ever proved it *survives* the rewrite; every OTHER
-            // object node in every shared schema silently lacked it. Groq's endpoint
-            // validates this directly (unlike `codex exec --output-schema`, which appears
-            // to inject it before the API ever sees the request - see this fn's own doc on
-            // why a CLI-observed rung can hide a gap a direct API exposes), and rejects the
+            // shared schemas didn't all carry by hand: every object-type node needs
+            // `additionalProperties: false`, whether or not it declares `properties` -
+            // an empty object (`{"type":"object"}`, no `properties` at all) and an
+            // `["object","null"]` union both still need it. `placements.items` had it
+            // (authored explicitly in prompts.rs) so the existing test above only ever
+            // proved it *survives* the rewrite; every OTHER object node in every shared
+            // schema silently lacked it. Groq's endpoint validates this directly
+            // (unlike `codex exec --output-schema`, which appears to inject it before
+            // the API ever sees the request - see this fn's own doc on why a
+            // CLI-observed rung can hide a gap a direct API exposes), and rejects the
             // whole request with a 400 before the model runs: "invalid JSON schema for
             // response_format: 'answer': additionalProperties:false must be set on every
             // object" - observed live across dozens of accounts, the single most common
             // Groq-path failure in production telemetry (2026-08-19). Setting it here,
-            // unconditionally, closes the gap for every current and future shared schema
-            // at the one place that already owns strict-mode compliance, rather than
-            // relying on each hand-authored schema to remember it on every nested object.
+            // unconditionally for every object-type node, closes the gap for every
+            // current and future shared schema at the one place that already owns
+            // strict-mode compliance, rather than relying on each hand-authored schema
+            // to remember it on every nested object.
             out.insert("additionalProperties".into(), Value::Bool(false));
             Value::Object(out)
         }
         Value::Array(a) => Value::Array(a.iter().map(strictify).collect()),
         _ => v.clone(),
+    }
+}
+
+/// Whether a schema node's `type` names (or includes, in a union) `"object"`.
+fn declares_object_type(map: &serde_json::Map<String, Value>) -> bool {
+    match map.get("type") {
+        Some(Value::String(t)) => t == "object",
+        Some(Value::Array(types)) => types.iter().any(|t| t.as_str() == Some("object")),
+        _ => false,
     }
 }
 
@@ -165,6 +188,14 @@ mod tests {
                 json!(false),
                 "an object node with properties is missing additionalProperties:false"
             );
+        } else if let Value::Object(m) = v {
+            if declares_object_type(m) {
+                assert_eq!(
+                    v["additionalProperties"],
+                    json!(false),
+                    "an object-type node WITHOUT properties is missing additionalProperties:false"
+                );
+            }
         }
         match v {
             Value::Object(m) => m.values().for_each(assert_strict),
@@ -225,6 +256,46 @@ mod tests {
             out["properties"]["propose"]["type"],
             json!(["object", "null"])
         );
+    }
+
+    /// An object schema with no `properties` at all - previously skipped entirely by the
+    /// old `out.get("properties")`-gated early return, so it never picked up
+    /// `additionalProperties:false` and Groq's endpoint would 400 on it.
+    #[test]
+    fn strictify_sets_additional_properties_false_on_an_empty_object() {
+        let out = strictify(&json!({"type": "object"}));
+        assert_eq!(out["additionalProperties"], json!(false));
+    }
+
+    /// Same gap, via the union form real schemas actually use (see `propose` in
+    /// `worklog_generate_schema`) — an `["object","null"]` node with no `properties`.
+    #[test]
+    fn strictify_sets_additional_properties_false_on_an_object_null_union_with_no_properties() {
+        let out = strictify(&json!({"type": ["object", "null"]}));
+        assert_eq!(out["additionalProperties"], json!(false));
+    }
+
+    /// A non-object node (a bare string schema) must never gain
+    /// `additionalProperties` - the field means nothing outside an object type.
+    #[test]
+    fn strictify_never_adds_additional_properties_to_a_non_object_node() {
+        let out = strictify(&json!({"type": "string"}));
+        assert!(out.get("additionalProperties").is_none());
+    }
+
+    /// The `properties` bag itself is a map of field-name -> schema, walked by the same
+    /// recursion as every other node - it must never be mistaken for an object-type
+    /// schema and gain a spurious `additionalProperties`/`required` key of its own,
+    /// which would show up as a bogus field named "additionalProperties" in the schema.
+    #[test]
+    fn strictify_does_not_stamp_the_properties_bag_itself() {
+        let out = strictify(&json!({
+            "type": "object",
+            "properties": {"x": {"type": "string"}},
+            "required": ["x"]
+        }));
+        assert!(out["properties"].get("additionalProperties").is_none());
+        assert!(out["properties"].get("required").is_none());
     }
 
     /// The other shared schemas must survive the same walk — Codex can carry any of them.

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -632,8 +632,12 @@ fn platform_prefix() -> &'static str {
 }
 
 /// Unix seconds marking the end of the ALPHA per-user pseudonym window —
-/// 2026-12-31T00:00:00Z. Originally 2026-08-28 (one month out from when this
-/// shipped, 2026-07-28); extended because the alpha is still running at ~200
+/// 2027-01-01T00:00:00Z, i.e. the override stays active THROUGH the whole of
+/// 2026-12-31 (the check below is `now_unix >= this`, so the boundary itself
+/// must be the instant AFTER the last day the override should hold — using
+/// 2026-12-31T00:00:00Z here would have disabled it at the START of that day
+/// instead). Originally 2026-08-28 (one month out from when this shipped,
+/// 2026-07-28); extended because the alpha is still running at ~200
 /// hand-picked testers, several on more than one machine.
 ///
 /// **Extending is not cosmetic — the value CHANGES at this instant.** Every
@@ -649,7 +653,7 @@ fn platform_prefix() -> &'static str {
 ///
 /// See [`local_host_pseudonym`]'s ALPHA doc for why this is a date, not a
 /// channel check.
-const ALPHA_ACCOUNT_OVERRIDE_EXPIRES_UNIX: u64 = 1_798_675_200;
+const ALPHA_ACCOUNT_OVERRIDE_EXPIRES_UNIX: u64 = 1_798_761_600;
 
 /// Now, as Unix seconds. Failure (a clock so broken `UNIX_EPOCH` is in the
 /// future) reads as "expired" — `u64::MAX` — rather than "still in the alpha

--- a/src/worklog_pipeline/stale.rs
+++ b/src/worklog_pipeline/stale.rs
@@ -265,6 +265,17 @@ mod tests {
     }
 
     #[test]
+    fn the_batch_dedup_key_changes_when_a_task_is_added() {
+        let before = vec![draft("T1", "A", 20)];
+        let after = vec![draft("T1", "A", 20), draft("T2", "B", 20)];
+        assert_ne!(
+            batch_dedup_key("2026-08-19", &before),
+            batch_dedup_key("2026-08-19", &after),
+            "a newly-stale task joining the batch must produce a fresh notification"
+        );
+    }
+
+    #[test]
     fn reads_as_minutes_below_the_hour() {
         let b = stale_body("Fixing the login bug", 18);
         assert!(b.contains("18 more minutes"), "{b}");

--- a/tray/src-tauri/src/analytics/health.rs
+++ b/tray/src-tauri/src/analytics/health.rs
@@ -227,6 +227,51 @@ fn resolve_provider(settings: &meridian_core::settings::RuntimeSettings) -> &'st
         .map_or(UNRECOGNISED_PROVIDER, |p| p.as_str())
 }
 
+/// Every vendor preset [`meridian_core::settings::CustomLlmProvider::vendor`] can
+/// legitimately hold — see that field's doc. Unlike `llm_provider`, this field is a
+/// plain `String` with no `from_wire`-style parser, because it is provenance/display
+/// only; behaviour never branches on it. That also means nothing stops a hand-edited
+/// settings file (or a future bug in the UI's preset picker) from putting arbitrary
+/// text here, and this list is what stands between that text and an analytics event —
+/// see the module doc's fourth rule ("the model id ships only for a known vendor
+/// preset").
+const KNOWN_CUSTOM_VENDORS: [&str; 5] = ["groq", "openai", "gemini", "openrouter", "other"];
+
+/// The value shipped when a configured custom endpoint's `vendor` is not one of
+/// [`KNOWN_CUSTOM_VENDORS`] — mirrors [`UNRECOGNISED_PROVIDER`]'s reasoning. Never the
+/// raw string.
+const UNRECOGNISED_VENDOR: &str = "unrecognised";
+
+/// The `(llm_vendor, llm_model)` pair for the snapshot, given the active custom
+/// endpoint (if any) and the built-in-provider model override that applies when
+/// there isn't one. Pulled out of [`snapshot`] as a pure function purely so this
+/// validation is unit-testable without a pool/settings file.
+fn resolve_custom_vendor_and_model(
+    custom: Option<&meridian_core::settings::CustomLlmProvider>,
+    builtin_provider_model: Option<String>,
+) -> (Option<String>, Option<String>) {
+    let Some(c) = custom else {
+        // No custom endpoint active: `builtin_provider_model` is the model override
+        // for the built-in CLI provider `resolve_provider` resolved, not a
+        // custom-vendor fallback — see `llm_provider_model`'s doc in
+        // meridian-core/src/settings.rs.
+        return (None, builtin_provider_model);
+    };
+    if !KNOWN_CUSTOM_VENDORS.contains(&c.vendor.as_str()) {
+        // Unknown vendor text: the vendor itself downgrades (never the raw hand-
+        // edited string) and the model ships even less - it's exactly as
+        // untrustworthy as `other`'s, just not spelled that way.
+        return (Some(UNRECOGNISED_VENDOR.to_string()), None);
+    }
+    let model = if c.vendor == "other" {
+        // A hand-entered endpoint's model can name an internal deployment.
+        None
+    } else {
+        Some(c.model.clone())
+    };
+    (Some(c.vendor.clone()), model)
+}
+
 /// Probe every health source and assemble the snapshot.
 ///
 /// Never fails: each source already degrades to "unknown"/empty on error, and
@@ -264,13 +309,8 @@ pub(crate) async fn snapshot(pool: &SqlitePool) -> HealthSnapshot {
     // A custom endpoint's vendor and model. The base URL and API key on this
     // same struct must never be touched here — see the module doc.
     let custom = settings.active_custom_provider();
-    let llm_vendor = custom.map(|c| c.vendor.clone());
-    let llm_model = match custom {
-        // A hand-entered endpoint's model can name an internal deployment.
-        Some(c) if c.vendor == "other" => None,
-        Some(c) => Some(c.model.clone()),
-        None => settings.llm_provider_model.clone(),
-    };
+    let (llm_vendor, llm_model) =
+        resolve_custom_vendor_and_model(custom, settings.llm_provider_model.clone());
 
     let snap = HealthSnapshot {
         daemon_running: h.daemon_running,
@@ -509,6 +549,69 @@ mod tests {
             resolve_provider(&bogus),
             UNRECOGNISED_PROVIDER,
             "an unparseable provider must never pass its raw string through"
+        );
+    }
+
+    fn custom_provider(vendor: &str, model: &str) -> meridian_core::settings::CustomLlmProvider {
+        meridian_core::settings::CustomLlmProvider {
+            id: "cust1".to_string(),
+            vendor: vendor.to_string(),
+            name: "My endpoint".to_string(),
+            base_url: "https://example.com/v1".to_string(),
+            model: model.to_string(),
+            api_key: "sk-should-never-appear-in-this-test".to_string(),
+            rpm: 0,
+            rpd: 0,
+            rungs: Default::default(),
+        }
+    }
+
+    /// A known preset ships both its vendor and its model.
+    #[test]
+    fn a_known_vendor_ships_vendor_and_model() {
+        let p = custom_provider("groq", "openai/gpt-oss-120b");
+        assert_eq!(
+            resolve_custom_vendor_and_model(Some(&p), None),
+            (
+                Some("groq".to_string()),
+                Some("openai/gpt-oss-120b".to_string())
+            )
+        );
+    }
+
+    /// A hand-entered (`other`) endpoint's model can name an internal deployment,
+    /// so only the vendor survives - the vendor id itself is still a closed-set
+    /// preset value.
+    #[test]
+    fn a_hand_entered_vendor_ships_no_model() {
+        let p = custom_provider("other", "acme-internal-gpt4");
+        assert_eq!(
+            resolve_custom_vendor_and_model(Some(&p), None),
+            (Some("other".to_string()), None)
+        );
+    }
+
+    /// The whole point of this fix: a vendor string that is not one of
+    /// KNOWN_CUSTOM_VENDORS - a hand-edited settings file, or a future UI bug that
+    /// lets free text through - must never reach the analytics event, neither as
+    /// itself nor via the model it would otherwise unlock.
+    #[test]
+    fn an_unrecognised_vendor_ships_neither_vendor_nor_model() {
+        let p = custom_provider("totally-made-up-vendor", "some-internal-model-name");
+        assert_eq!(
+            resolve_custom_vendor_and_model(Some(&p), None),
+            (Some(UNRECOGNISED_VENDOR.to_string()), None),
+            "an unrecognised vendor must downgrade, not pass its raw string or model through"
+        );
+    }
+
+    /// No custom endpoint active: the built-in provider's own model override ships
+    /// instead, and no vendor does (there is no custom vendor to report).
+    #[test]
+    fn no_custom_endpoint_falls_back_to_the_builtin_providers_model() {
+        assert_eq!(
+            resolve_custom_vendor_and_model(None, Some("claude-sonnet-5".to_string())),
+            (None, Some("claude-sonnet-5".to_string()))
         );
     }
 

--- a/tray/src-tauri/src/analytics/state.rs
+++ b/tray/src-tauri/src/analytics/state.rs
@@ -122,9 +122,26 @@ pub(super) fn day_rollover_action(
 ) -> Option<Option<String>> {
     match last_sent_day {
         None => Some(None),
-        Some(prev) if prev != today => Some(Some(prev.to_string())),
+        // The closed day to report is always `today`'s own yesterday, never the stale
+        // cursor - `last_sent_day` only marks "the tick that last ran", not "the day
+        // whose usage is outstanding" (the caller advances it to `today` on send, see
+        // `maybe_send_daily_tick`). Using the cursor value directly here used to
+        // report an arbitrarily stale day after a multi-day gap instead of the one
+        // day this function's own doc promises - see `yesterday`'s doc.
+        Some(prev) if prev != today => Some(Some(yesterday(today))),
         _ => None,
     }
+}
+
+/// `today - 1 day`, as a local `'YYYY-MM-DD'` string. Falls back to `today` itself
+/// on an unparseable input (should be unreachable — `today` always comes from
+/// [`meridian_core::date::today_string`] — but this must never panic on a tick).
+fn yesterday(today: &str) -> String {
+    chrono::NaiveDate::parse_from_str(today, "%Y-%m-%d")
+        .ok()
+        .and_then(|d| d.pred_opt())
+        .map(|d| d.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| today.to_string())
 }
 
 /// Whether to send an `app_active` heartbeat this tick: true on the first tick
@@ -215,13 +232,20 @@ mod day_rollover_tests {
 
     #[test]
     fn multi_day_gap_reports_only_the_last_closed_day() {
-        // A gap of several days (tray closed then reopened) still reports
-        // only the most recent `last_sent_day` — intervening days are never
-        // backfilled (see the doc comment on `day_rollover_action`).
+        // A gap of several days (tray closed then reopened) still reports only
+        // the SINGLE most recently closed day - 2026-07-08, one day before
+        // `today` - never the stale cursor (2026-07-01) and never a backfill of
+        // every day in between (see the doc comment on `day_rollover_action`).
         assert_eq!(
             day_rollover_action(Some("2026-07-01"), "2026-07-09"),
-            Some(Some("2026-07-01".to_string()))
+            Some(Some("2026-07-08".to_string()))
         );
+    }
+
+    #[test]
+    fn yesterday_crosses_a_month_and_year_boundary() {
+        assert_eq!(super::yesterday("2026-03-01"), "2026-02-28");
+        assert_eq!(super::yesterday("2027-01-01"), "2026-12-31");
     }
 }
 

--- a/ui/__tests__/llm-provider-connection-phase.test.ts
+++ b/ui/__tests__/llm-provider-connection-phase.test.ts
@@ -338,6 +338,21 @@ describe('the chooser grid', () => {
     expect(hook).toContain('await floor')
     expect(picker).toContain("animation: 'spin 0.7s linear infinite'")
   })
+
+  it('re-tests a failed sign-in sequentially, not concurrently with detect()', () => {
+    // `detect()` REPLACES the whole status map with `last_test: null` for every provider
+    // (see `setStatus(Object.fromEntries(...))` above). Racing it against `testOne()` via
+    // `Promise.all` could let `detect()` resolve second and silently discard the just-spent
+    // probe's result, right back to a stale FAILED badge - the exact bug this path exists to
+    // fix. Must stay sequenced like `install()` already does.
+    const hook = src('components/useLlmProviderDetection.ts')
+    expect(hook).not.toContain('Promise.all([detect(), testOne')
+    const signInFailureBranch = hook.slice(hook.indexOf('} else {', hook.indexOf('const signIn =')))
+    expect(signInFailureBranch).toContain('await detect()')
+    expect(signInFailureBranch.indexOf('await detect()')).toBeLessThan(
+      signInFailureBranch.indexOf('await testOne(id'),
+    )
+  })
 })
 
 describe('an already-working provider still releases the connect flow', () => {

--- a/ui/__tests__/task-composer.test.ts
+++ b/ui/__tests__/task-composer.test.ts
@@ -168,8 +168,12 @@ describe('the composer never blocks on the AI', () => {
 // seconds"). Fixed by dropping the override entirely.
 describe('the drafting spinner does not promise a latency it cannot keep', () => {
   it('does not override GeneratingBar\'s note with an inaccurate "few seconds" claim', () => {
-    const generatingBarBlock = composer.slice(composer.indexOf('<GeneratingBar'))
-    expect(generatingBarBlock).not.toMatch(/note=/)
+    const generatingBarStart = composer.indexOf('<GeneratingBar')
+    expect(generatingBarStart).toBeGreaterThanOrEqual(0)
+    const generatingBarEnd = composer.indexOf('/>', generatingBarStart)
+    expect(generatingBarEnd).toBeGreaterThan(generatingBarStart)
+    const generatingBarBlock = composer.slice(generatingBarStart, generatingBarEnd)
+    expect(generatingBarBlock).not.toMatch(/\bnote\s*=/)
   })
 })
 

--- a/ui/components/timeline/settings/CaptureSection.tsx
+++ b/ui/components/timeline/settings/CaptureSection.tsx
@@ -128,7 +128,7 @@ export function CaptureSection({ settings, patch, save }: {
 
       <SectionCard>
         <SectionHeader>Product analytics</SectionHeader>
-        <FieldRow label="Send usage stats" description="Once a day Meridian sends a count of what it did for you - tickets updated, plans confirmed, summaries written, notifications delivered - so we can tell whether the product is working. It is counts only: never your screen activity, window titles, ticket names, or anything you wrote. Sent under your account email. On by default; turn it off here any time.">
+        <FieldRow label="Send usage stats" description="Once a day Meridian sends a count of what it did for you - tickets updated, plans confirmed, summaries written, notifications delivered - plus a health snapshot: whether the daemon and your AI provider are working, which trackers are connected and syncing, and your notification and error-reporting settings. It's counts and status only: never your screen activity, window titles, ticket names, or anything you wrote. Sent under your account email. On by default; turn it off here any time.">
           <Switch checked={settings.product_analytics_enabled} onCheckedChange={v => patch({ product_analytics_enabled: v })} />
         </FieldRow>
         <SaveButton

--- a/ui/components/useLlmProviderDetection.ts
+++ b/ui/components/useLlmProviderDetection.ts
@@ -155,7 +155,12 @@ export function useLlmProviderDetection() {
         // remount 60s+ later. Re-test (silently - the user is already watching the sign-in
         // flow, this isn't a background surprise) rather than only refreshing install state,
         // so a sign-in that quietly resolved itself a moment later is reflected right away.
-        await Promise.all([detect(), testOne(id, { silent: true })])
+        // Sequenced, not concurrent: `detect()` REPLACES the whole status map (the backend
+        // reports `last_test: null` for every provider), so if `testOne()` settled first,
+        // `Promise.all`'s unordered resolution could let the later `detect()` overwrite the
+        // merged result and discard the just-spent probe. Same order `install()` above uses.
+        await detect()
+        await testOne(id, { silent: true })
       }
       return outcome
     } catch (e) {


### PR DESCRIPTION
## Summary

CodeRabbit review of #811 (the pre-main → main release PR). #811 started at 7 PRs / 11 actionable comments; while replying to those, PR #812 merged into pre-main and brought two more files (`src/llm/schema.rs`, `src/coding_agent_session_ingest/summariser/prompts.rs`) into #811's diff, surfacing 2 more comments — 13 total, 11 fixed here, 2 left alone with reasons below.

### Fixed

- **`usage_rollup.rs`** — added `.context()` to every DB read in the orchestration path, so a failure identifies which of the six read groups broke (matches the project's `anyhow::Context` convention for DB calls).
- **`cursor_cli.rs` / `detect.rs`** — dropped raw vendor CLI stderr/stdout text from three `WARN` fields (transient-retry, probe-timeout, sign-in divergence). `WARN` is the level that leaves a packaged install, and this text was never reviewed for redaction. Also downgraded `drain_lines`' per-line CLI output log from `info` (full line, including OAuth URLs and device codes) to `debug` (stream + length only) — the buffer is already retained elsewhere for the user-facing message.
- **`redact.rs`** — fixed an off-by-one in `ALPHA_ACCOUNT_OVERRIDE_EXPIRES_UNIX`: the `>=` check meant the override disabled at the *start* of 2026-12-31 instead of after it, one day short of the stated extension.
- **`worklog_pipeline/stale.rs`** — added the missing regression test for the batch dedup key changing when a new task joins the batch (only escalation and ordering were covered before).
- **`analytics/health.rs`** — a custom endpoint's `vendor` field is free-form storage (a `String`, not a parsed enum), and only its model was being gated on `vendor == "other"`. Added a `KNOWN_CUSTOM_VENDORS` allowlist so an unrecognised vendor (hand-edited settings file, or a future UI bug) can't reach an analytics event as raw text, and pulled the derivation into a testable pure function.
- **`analytics/state.rs`** — real correctness bug: after a multi-day gap, `day_rollover_action` reported the *stale cursor day* instead of the actual most-recently-closed day (`today - 1`), directly contradicting its own doc comment ("only the single most-recently-closed day is ever reported... not backfilled"). The existing test's name already said the right thing; its assertion didn't match.
- **`CaptureSection.tsx`** — the "Send usage stats" consent copy said the event was "counts only," but the same event also carries a health/status snapshot (daemon/provider up, tracker sync status, notification settings). Updated the copy to say so.
- **`useLlmProviderDetection.ts`** — sequenced `detect()` before `testOne()` in the sign-in-failure re-test path instead of `Promise.all`-ing them. `detect()` fully replaces the status map with `last_test: null`; racing it against `testOne()`'s merge could silently discard the just-spent probe result — undermining the exact bug #804 was hardening against.
- **`summariser/prompts.rs` / `cursor_agent.rs`** — PR #812 added `resource_exhausted`/`resource exhausted` (Cursor's own gRPC vocabulary) to the SHARED `RATE_LIMIT_MARKERS` list used by Claude/Codex/Copilot/Cursor alike, but that gRPC status also covers non-quota resource failures unrelated to a rate limit — misclassifying one on the other three engines would skip their legitimate transient retry. Split into a generic list (unchanged) and a Cursor-only `CURSOR_RATE_LIMIT_MARKERS`, exposed via `looks_rate_limited_cursor`/`rate_limited_line_cursor` (only `cursor_agent.rs` calls them).
- **`schema.rs`** — also from #812: `strictify()`'s early return was gated on the node having a `properties` key, so an empty `{"type":"object"}` or an `["object","null"]` union with no properties skipped past without ever getting `additionalProperties:false` — the exact contract this function exists to enforce (Groq 400s on any object node missing it). Replaced the `properties`-presence proxy with an explicit `declares_object_type` check on `type`. TDD-verified: reverted to the old gate, confirmed the two new regression tests fail, restored the fix.

### Left alone

- A `classify_login_status`/`NOT_SIGNED_IN_MSG` dedup nit in `codex.rs`, marked trivial/low-value by CodeRabbit itself. The sign-in path was just hardened in #804; a cosmetic refactor there isn't worth the risk this close to a release.

### Corrected mid-flight

I initially told the `prompts.rs` thread it was out of scope (the file wasn't in #811's diff when I checked). #812 merged into pre-main a few minutes later and brought it in — posted a correction on that thread and fixed it here instead.

## Test plan
- [x] `cargo test --workspace` — 1005 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `npm run typecheck` / `npm run build` — clean
- [x] `bun test` — 883 passed, 0 failed
- [x] Pre-push hook (fmt + clippy + ui build/tests + security audit + `cargo test --workspace`) — all green, on every pushed commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
