### PR TITLE
fix(release): address CodeRabbit's re-review of PR #811 (round 2)

### DIFF
--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -1445,7 +1445,17 @@ fn install_failed(cmd: &str, message: String) -> InstallOutcome {
     // here, so recording on the CURRENT span marks whichever of them is running
     // as failed without threading a handle through a dozen early returns.
     tracing::Span::current().record("ok", false);
-    tracing::warn!(%cmd, %message, "llm: provider install failed");
+    // No `message` field: some callers (the interactive-login failure path via
+    // `confirm_or_report`) pass the buffered CLI stdout/stderr tail here, which can
+    // carry OAuth verification URLs and device codes - the same class of leak
+    // already fixed at `drain_lines`/`probe_with_retry`/`confirm_or_report`'s own
+    // WARN sites in this file. `install_failed` has no way to tell a safe static
+    // message from raw CLI output, so it must treat every message as unsafe.
+    tracing::warn!(
+        cmd,
+        message_len = message.len(),
+        "llm: provider install failed"
+    );
     InstallOutcome {
         ok: false,
         message,

--- a/src/worklog_pipeline/stale.rs
+++ b/src/worklog_pipeline/stale.rs
@@ -158,7 +158,14 @@ fn batch_message(stale: &[meridian_core::day_task_worklogs::StaleDraft]) -> (Str
     }
 
     let title = format!("{} worklog drafts are out of date", stale.len());
-    let names: Vec<&str> = stale.iter().map(|d| d.title.as_str()).collect();
+    // Sorted for the same reason `batch_dedup_key` sorts its parts: `stale`'s row
+    // order isn't part of the contract (it's whatever the hourly fold's query
+    // happened to return), but `batch_dedup_key` already treats the SET as the
+    // identity, not the order - a body built from the unsorted order would
+    // silently vary run to run for the identical set, and for a batch of 4+ it
+    // decides which two names actually get named, not just their order.
+    let mut names: Vec<&str> = stale.iter().map(|d| d.title.as_str()).collect();
+    names.sort_unstable();
     let listed = match names.as_slice() {
         [a, b] => format!("\"{a}\" and \"{b}\""),
         [a, b, c] => format!("\"{a}\", \"{b}\", and \"{c}\""),
@@ -226,7 +233,25 @@ mod tests {
             draft("T2", "Bug triage", 40),
         ]);
         assert_eq!(title, "2 worklog drafts are out of date");
-        assert!(body.contains("\"Release notes\" and \"Bug triage\""));
+        // Alphabetical, not input order - see the sort in `batch_message`.
+        assert!(body.contains("\"Bug triage\" and \"Release notes\""));
+    }
+
+    /// The whole point of sorting: the SAME stale set, folded in a different row
+    /// order (e.g. a different query plan, or a task's `stale_minutes` landing it
+    /// earlier/later in whatever produced `stale`), must produce the identical
+    /// notification body - not just the identical dedup key.
+    #[test]
+    fn the_batch_body_is_order_independent() {
+        let forward = [
+            draft("T1", "Release notes", 20),
+            draft("T2", "Bug triage", 40),
+        ];
+        let backward = [
+            draft("T2", "Bug triage", 40),
+            draft("T1", "Release notes", 20),
+        ];
+        assert_eq!(batch_message(&forward), batch_message(&backward));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

After #813 merged into pre-main, CodeRabbit re-reviewed #811 and LGTM'd every prior fix, but surfaced 2 more findings against code that predates this release batch (both "outside diff range" — flagged against the file overall, not a specific PR's diff hunk):

- **`worklog_pipeline/stale.rs`** — `batch_message` built its displayed names list in `stale`'s row order, while its sibling `batch_dedup_key` (same input) sorts its parts before hashing. So the dedup key and the visible notification text could disagree on what "the same set" looks like: same underlying set, different row order → same dedup key, different displayed text — and for a 4+ batch, a different pair of names actually gets named as the "first two." Sorted `names` the same way `batch_dedup_key` sorts.
- **`llm/detect.rs`** — `install_failed` (the shared funnel every install/sign-in failure path returns through) logged its `message` argument verbatim at `WARN`. Most callers pass a plain static string, but the interactive-login failure path (`confirm_or_report`, fixed for its OWN warn call in #813) passes the buffered CLI stdout/stderr tail through `install_failed` too — the same OAuth-URL/device-code leak, one hop further down the call chain than #813 caught. `install_failed` has no way to tell a safe message from raw CLI output, so it now logs `cmd` + length only, matching its siblings.

## Test plan
- [x] TDD: reverted both fixes, confirmed `the_batch_body_is_order_independent` and `two_stale_drafts_are_both_named` fail without the sort; restored, confirmed green
- [x] `cargo test --workspace` — 1006 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Pre-push hook (fmt + clippy + ui build/tests + security audit + `cargo test --workspace`) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)