### PR TITLE
feat(analytics): person properties, plus fixes found testing the staging build

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -122,7 +122,7 @@ different things about you - see [Error reporting](#error-reporting).
 | Event | When | What it contains |
 |---|---|---|
 | `app_installed` | Once per device, per signed-in account | Nothing beyond the shared properties below. |
-| `app_active` | Once per calendar day Meridian is running | Nothing beyond the shared properties. It exists only so we can tell how many people come back on a given day. |
+| `app_active` | Once per calendar day Meridian is running | The shared properties, plus the current-state summary described below (which AI provider and which trackers). It exists so we can tell how many people come back on a given day, and so a brand-new install's setup is visible without waiting for the first `daily_usage`. |
 | `daily_usage` | Once per completed calendar day | Three groups of numbers, listed below. |
 
 `daily_usage` carries:
@@ -139,10 +139,12 @@ different things about you - see [Error reporting](#error-reporting).
   never their text).
 - **Which AI provider you use, and whether it works** - the provider's name from our own
   fixed list (`claude`, `codex`, `cursor`, `copilot`, `custom`), whether it is currently
-  usable or rate-limited, and for a cloud endpoint the preset it came from (`openai`,
+  usable or rate-limited, whether you actually chose that provider or are still on the
+  default, and for a cloud endpoint the vendor it came from (one of `groq`, `openai`,
   `gemini`, `openrouter`, `other`) and the model id. If you entered your own endpoint by
-  hand, the **model id is not sent** - it can name an internal deployment. Your endpoint
-  URL and API key are never sent under any setting.
+  hand, the **model id is not sent** - it can name an internal deployment. A vendor value
+  we don't recognise is replaced with `unrecognised` rather than sent as-is. Your
+  endpoint URL and API key are never sent under any setting.
 - **Which trackers you connect, and whether they sync** - the tracker's name from our
   fixed list (`jira`, `linear`, `github`, `trello`, `azure_devops`) and a one-word status
   for each: syncing fine, stale, failing, never synced, or waiting for you to pick a
@@ -156,6 +158,15 @@ disabled on every event.
 **These events identify you by your account email.** It is used directly as the PostHog
 `distinct_id`, which is why nothing is sent before sign-in. This path is identified, not
 pseudonymous, and we would rather say so plainly than bury it.
+
+**A small current-state record is kept against your account**, updated on each of the
+events above rather than accumulating one row per day: your email, app version, release
+channel, OS, which AI provider and model you are on, and which trackers you have
+connected. It exists so we can answer "what is this user's setup" without replaying
+their history. It is a subset of what the events above already carry - nothing is
+collected for it that is not listed here - and it is overwritten each time, so it always
+reflects your current setup rather than a trail. Your Support ID is deliberately kept
+out of it.
 
 **And they carry your Support ID, which links this to your error reports.** Error
 reports and crash reports are pseudonymous on their own - they identify a machine, not

--- a/tray/src-tauri/src/analytics/daily.rs
+++ b/tray/src-tauri/src/analytics/daily.rs
@@ -130,9 +130,17 @@ pub(super) async fn send_daily_usage(
     write_rollup_properties(&rollup, &mut props);
 
     // ── Group 3: install health ──────────────────────────────────────────────
-    super::health::snapshot(pool)
-        .await
-        .write_properties(&mut props);
+    // One snapshot, used twice: as timestamped EVENT properties (the full
+    // point-in-time picture, stamped with `health_observed_on`) and as the
+    // slowly-changing PERSON properties. `app_active` refreshes the person
+    // properties too, so they are never more than a day stale even for a user
+    // whose tray rarely survives a midnight.
+    let health = super::health::snapshot(pool).await;
+    health.write_properties(&mut props);
+
+    let mut person = super::base_person_properties(app, email);
+    health.write_person_properties(&mut person);
+    super::attach_person_properties(&mut props, person);
 
     tracing::info!(
         day,
@@ -143,7 +151,11 @@ pub(super) async fn send_daily_usage(
         tickets_updated = rollup.tickets_updated,
         "analytics: sending daily_usage"
     );
-    super::capture("daily_usage", email, props).await
+    let sent = super::capture("daily_usage", email, props).await;
+    if sent {
+        tracing::info!(event = "daily_usage", day, "analytics: event sent");
+    }
+    sent
 }
 
 /// Fold [`meridian_core::usage_rollup::UsageRollup`] into the event properties.

--- a/tray/src-tauri/src/analytics/health.rs
+++ b/tray/src-tauri/src/analytics/health.rs
@@ -272,6 +272,36 @@ fn resolve_custom_vendor_and_model(
     (Some(c.vendor.clone()), model)
 }
 
+/// Whether the user has ever actually CHOSEN an AI provider, as opposed to
+/// silently inheriting the default.
+///
+/// # Why this can't be inferred from `llm_provider`
+/// [`meridian_core::settings::RuntimeSettings::default`] sets `llm_provider` to
+/// `claude`, and `load_runtime_settings` merges the file over those defaults.
+/// So a user who has never opened the provider picker reports exactly the same
+/// value as one who deliberately picked Claude — and on a fleet dashboard the
+/// first group is large, newly-installed, and the population you most want to
+/// find, because "provider = claude, provider_ok = false" is usually "never set
+/// up" rather than "Claude is broken".
+///
+/// The only place that distinction survives is the raw settings file: the key
+/// is present iff something wrote it. So this reads the file directly rather
+/// than going through [`meridian_core::settings::read_settings_value`], which
+/// has already merged the defaults in and cannot tell the two apart.
+///
+/// An unreadable or unparseable file reads as "not chosen" — the same answer a
+/// fresh install gives, and the safer of the two when we cannot tell.
+fn provider_explicitly_chosen() -> bool {
+    let path = meridian_core::settings::settings_json_path();
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    serde_json::from_str::<serde_json::Value>(&raw)
+        .ok()
+        .and_then(|v| v.get("llm_provider").cloned())
+        .is_some_and(|v| v.is_string())
+}
+
 /// Probe every health source and assemble the snapshot.
 ///
 /// Never fails: each source already degrades to "unknown"/empty on error, and
@@ -353,6 +383,44 @@ impl HealthSnapshot {
             .values()
             .filter(|s| **s != IntegrationStatus::Ok)
             .count()
+    }
+
+    /// The subset of this snapshot that belongs on the PERSON rather than the
+    /// event: slowly-changing current state — which AI provider, which
+    /// trackers — that you want as a sortable column on the Persons list
+    /// rather than as something recoverable only by querying each person's
+    /// latest event. See [`super::base_person_properties`] for the general
+    /// rule, and for why `support_id` is excluded from this treatment.
+    ///
+    /// Deliberately NOT included: anything momentary (`daemon_running`,
+    /// `database_ready`, rate-limit state, active notices, per-tracker sync
+    /// status). Those change hour to hour, and a person property keeps only the
+    /// newest value — so "is the daemon running" as a person property would
+    /// answer "was it running at the last send", which reads as current fact
+    /// and is not one. They stay event properties, where they are timestamped.
+    pub(crate) fn write_person_properties(&self, person: &mut Map<String, Value>) {
+        person.insert(
+            "llm_provider".to_string(),
+            Value::String(self.llm_provider.to_string()),
+        );
+        person.insert(
+            "llm_provider_chosen".to_string(),
+            Value::Bool(provider_explicitly_chosen()),
+        );
+        if let Some(v) = &self.llm_vendor {
+            person.insert("llm_vendor".to_string(), Value::String(v.clone()));
+        }
+        if let Some(m) = &self.llm_model {
+            person.insert("llm_model".to_string(), Value::String(m.clone()));
+        }
+        person.insert(
+            "integrations_connected".to_string(),
+            serde_json::json!(self.integrations_connected),
+        );
+        person.insert(
+            "integrations_count".to_string(),
+            serde_json::json!(self.integrations_connected.len()),
+        );
     }
 
     /// Fold the snapshot into an event's property map under a `health_` prefix,
@@ -728,5 +796,88 @@ mod tests {
             !props.contains_key("health_llm_model"),
             "but the model must not"
         );
+    }
+}
+
+#[cfg(test)]
+mod person_property_tests {
+    //! What lands on the PostHog Person rather than the event. These pin the
+    //! split, because getting it wrong is silent: a momentary value promoted to
+    //! a person property reads as current fact forever, and a changing value
+    //! promoted there loses its own history.
+    use super::*;
+
+    fn snap() -> HealthSnapshot {
+        HealthSnapshot {
+            llm_provider: "custom",
+            llm_vendor: Some("groq".to_string()),
+            llm_model: Some("openai/gpt-oss-120b".to_string()),
+            integrations_connected: vec!["jira".into(), "github".into()],
+            daemon_running: Some(false),
+            database_ready: Some(true),
+            ..Default::default()
+        }
+    }
+
+    /// The provider and tracker set are the whole point: they must be person
+    /// properties so PostHog shows them as a column, not values you have to dig
+    /// out of each person's most recent event.
+    #[test]
+    fn provider_and_trackers_land_on_the_person() {
+        let mut person = Map::new();
+        snap().write_person_properties(&mut person);
+
+        assert_eq!(
+            person.get("llm_provider"),
+            Some(&Value::String("custom".to_string()))
+        );
+        assert_eq!(
+            person.get("llm_vendor"),
+            Some(&Value::String("groq".to_string()))
+        );
+        assert_eq!(
+            person.get("integrations_connected"),
+            Some(&serde_json::json!(["jira", "github"]))
+        );
+        assert_eq!(
+            person.get("integrations_count"),
+            Some(&serde_json::json!(2))
+        );
+    }
+
+    /// Momentary state must NOT be promoted to the person. A person property
+    /// keeps only the newest value, so `daemon_running` there would answer
+    /// "was it up at the last send" while reading as "is it up" — the kind of
+    /// wrong that looks right on a dashboard.
+    #[test]
+    fn momentary_state_stays_off_the_person() {
+        let mut person = Map::new();
+        snap().write_person_properties(&mut person);
+
+        for k in [
+            "daemon_running",
+            "database_ready",
+            "llm_provider_rate_limited",
+            "active_notices",
+            "integrations_status",
+            "health_observed_on",
+        ] {
+            assert!(
+                !person.contains_key(k),
+                "{k} is momentary and must stay an event property"
+            );
+        }
+    }
+
+    /// `support_id` must never become a person property. It legitimately
+    /// changes (a second machine, a re-seed, the alpha window ending), and a
+    /// person property keeps only the newest — which would silently orphan
+    /// every error row recorded under the previous one. As an event property a
+    /// DISTINCT recovers the full set.
+    #[test]
+    fn support_id_is_never_a_person_property() {
+        let mut person = Map::new();
+        snap().write_person_properties(&mut person);
+        assert!(!person.contains_key("support_id"));
     }
 }

--- a/tray/src-tauri/src/analytics/mod.rs
+++ b/tray/src-tauri/src/analytics/mod.rs
@@ -7,7 +7,8 @@
 //! - `app_installed`, once per (signed-in email, device) pair;
 //! - `app_active`, once per local calendar day the tray is actually running —
 //!   the return-rate signal (see [`state::day_active_action`] for why `daily_usage`
-//!   cannot serve as one);
+//!   cannot serve as one), and the event that keeps the person properties
+//!   fresh (see [`base_person_properties`]);
 //! - `daily_usage`, once per COMPLETED local calendar day, carrying engagement
 //!   hours, product-action counts ([`meridian_core::usage_rollup`]) and an
 //!   install-health snapshot ([`health`]) — assembled in [`daily`].
@@ -43,6 +44,19 @@
 //! each time, silently orphaning every historical error row. As an event
 //! property the full set is recoverable with a `DISTINCT` over the user's
 //! events, across devices and across any re-seed.
+//!
+//! **Person properties.** Alongside the event properties, each event carries a
+//! `$set` payload ([`base_person_properties`] +
+//! [`health::HealthSnapshot::write_person_properties`]) holding the user's
+//! slowly-changing CURRENT state: which AI provider and model, which trackers,
+//! app version, channel, OS, and the email itself (so `person.email` is
+//! filterable — it is already the `distinct_id`, so this adds no new data).
+//! These exist because "which provider is each of my users on" is otherwise
+//! answerable only by finding every person's latest `daily_usage` and reading
+//! it, one query per person; as person properties it is a sortable column.
+//! Momentary state (daemon up, notices, per-tracker sync status) stays on the
+//! EVENT, where it is timestamped — a person property keeps only the newest
+//! value and would read as current fact while answering "at the last send".
 //!
 //! **No anonymous events, ever.** The PostHog `distinct_id` for all events IS
 //! the signed-in account email ([`crate::commands::account::read_account_email`])
@@ -279,6 +293,63 @@ fn base_properties(
     m
 }
 
+/// PostHog **person** properties — the `$set` payload.
+///
+/// # Why these exist alongside the event properties
+/// Everything else here is an event property, which is right for anything that
+/// describes a moment. But "which AI provider is this user on" and "which
+/// trackers do they have" are *current state* of a person, and as event
+/// properties they are only answerable by finding that person's latest
+/// `daily_usage` and reading it — per person, in HogQL. As person properties
+/// they become a column on the Persons list, sortable and breakdown-able in one
+/// click. Being overwritten on every send is exactly the wanted behaviour.
+///
+/// **`support_id` is deliberately NOT here.** It is the one value where being
+/// overwritten is harmful rather than helpful: the pseudonym legitimately
+/// changes over an install's life, and a person property would keep only the
+/// newest, silently orphaning every error row recorded under the previous one.
+/// It stays an event property so a `DISTINCT` recovers the full set — see the
+/// module doc's "The join key".
+///
+/// `email` is included even though it is already the `distinct_id`, because
+/// PostHog cannot filter on `person.email` unless the property exists. It adds
+/// no new data: the address is the identity of every one of these events
+/// already.
+fn base_person_properties(
+    app: &tauri::AppHandle,
+    email: &str,
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut m = serde_json::Map::new();
+    m.insert(
+        "email".to_string(),
+        serde_json::Value::String(email.to_string()),
+    );
+    m.insert(
+        "app_version".to_string(),
+        serde_json::Value::String(app.package_info().version.to_string()),
+    );
+    m.insert(
+        "channel".to_string(),
+        serde_json::Value::String(crate::commands::version::build_channel().to_string()),
+    );
+    m.insert(
+        "os".to_string(),
+        serde_json::Value::String(std::env::consts::OS.to_string()),
+    );
+    m
+}
+
+/// Attach a `$set` person-property payload to an event's properties.
+///
+/// PostHog reads `$set` from inside `properties` on the capture endpoint, so
+/// this is a plain nested object rather than a separate request.
+fn attach_person_properties(
+    props: &mut serde_json::Map<String, serde_json::Value>,
+    person: serde_json::Map<String, serde_json::Value>,
+) {
+    props.insert("$set".to_string(), serde_json::Value::Object(person));
+}
+
 /// Whether product analytics may be sent at all: the user hasn't switched it
 /// off, and the hard kill switch is clear.
 ///
@@ -347,16 +418,22 @@ pub(crate) async fn maybe_send_daily_tick(app: &tauri::AppHandle, pool: &SqliteP
     let mut state = load_or_init_state(&path);
     let mut dirty = false;
 
-    if !state.install_events_sent.contains(&email)
-        && capture(
-            "app_installed",
-            &email,
-            base_properties(app, &state.device_id),
-        )
-        .await
-    {
-        state.install_events_sent.insert(email.clone());
-        dirty = true;
+    if !state.install_events_sent.contains(&email) {
+        let mut props = base_properties(app, &state.device_id);
+        attach_person_properties(&mut props, base_person_properties(app, &email));
+        if capture("app_installed", &email, props).await {
+            state.install_events_sent.insert(email.clone());
+            dirty = true;
+            // INFO, not DEBUG: this fires once per (device, account) ever, so
+            // it costs nothing, and without it a successful send leaves NO
+            // trace in the logs at all — the on-disk cursor is the only
+            // evidence. Failures already log at WARN, so "no WARN" was the
+            // only available proof of success, which is an inference rather
+            // than a record. Measured on a real staging install: 1500 log
+            // records covering the exact minute of a confirmed send contained
+            // zero analytics lines.
+            tracing::info!(event = "app_installed", "analytics: event sent");
+        }
     }
 
     let today = meridian_core::date::today_string();
@@ -373,11 +450,26 @@ pub(crate) async fn maybe_send_daily_tick(app: &tauri::AppHandle, pool: &SqliteP
     ) {
         let mut props = base_properties(app, &state.device_id);
         props.insert("date".to_string(), serde_json::Value::String(today.clone()));
+
+        // The health snapshot rides here as PERSON properties, not just on
+        // `daily_usage`. That matters for exactly the question this data is
+        // for: `daily_usage` needs a local-midnight rollover, so attaching the
+        // provider and tracker set only there means a brand-new user's AI
+        // provider and PM tool are unknown until their second calendar day —
+        // and permanently unknown if their tray never survives a midnight.
+        // `app_active` fires on day one, so these land immediately.
+        let mut person = base_person_properties(app, &email);
+        health::snapshot(pool)
+            .await
+            .write_person_properties(&mut person);
+        attach_person_properties(&mut props, person);
+
         if capture("app_active", &email, props).await {
             state
                 .last_active_day_by_email
                 .insert(email.clone(), today.clone());
             dirty = true;
+            tracing::info!(event = "app_active", day = %today, "analytics: event sent");
         }
     }
 


### PR DESCRIPTION
Follow-ups from running the staging build (`1.89.0-staging.1`) on a real install and checking what actually got captured.

## What this adds

**Person properties (`$set`).** Provider and tracker set were event properties only, so *"which AI provider is each of my 200 users on"* meant finding every person's latest `daily_usage` and reading it - one query per person. They now also ride as person properties, so they become a sortable column on the Persons list and a one-click breakdown. Overwrite-on-send is exactly right for current state.

Includes `email`, because PostHog cannot filter on `person.email` unless the property exists. It is already the `distinct_id`, so this adds no new data.

**Two things deliberately kept OFF the person**, both pinned by tests:
- `support_id` - it legitimately changes (second machine, re-seed, alpha window ending) and a person property keeps only the newest, silently orphaning every error row recorded under the previous one. As an event property a `DISTINCT` recovers the full set.
- Momentary state (daemon up, notices, per-tracker sync status) - as a person property it would read as current fact while actually answering "at the last send".

**Person properties ride on `app_active`, not just `daily_usage`.** `daily_usage` needs a local-midnight rollover, so attaching setup info only there means a new user's provider and PM tool are unknown until their second calendar day - and permanently unknown if their tray never survives a midnight.

Verified on the real install: `app_installed` and `app_active` both delivered, and PostHog had **no** provider or tracker data at all.

**Successful sends now log at INFO.** `app_installed` and `app_active` logged only at DEBUG on success, so at the default `meridian=info` filter a successful send left no trace at all - the on-disk cursor was the only evidence. Measured on the same install: **1500 log records covering the exact minute of a confirmed send contained zero analytics lines.** Failures already logged at WARN, so "no WARN" was the only available proof of success - an inference, not a record.

**`llm_provider_chosen`.** `RuntimeSettings::default()` sets `llm_provider` to `claude`, so a user who never opened the provider picker is indistinguishable from one who deliberately picked Claude. That first group is large, newly-installed, and exactly who you want to find - `claude` + `provider_ok: false` is usually "never set up", not "Claude is broken". The raw settings file is the only place the distinction survives (the key exists iff something wrote it), so this reads it directly rather than through `read_settings_value`, which has already merged the defaults in.

## Docs

`docs/privacy.md` now lists **`groq`** in the vendor set. It was omitted, and it is the only vendor the current UI can create - the preset machinery for `openai`/`gemini`/`openrouter` was removed (`llm-providers.ts:456`), so the published list excluded the only value a current user can actually have. Also notes the `unrecognised` downgrade added in #811, corrects `app_active`'s row now that it carries the setup summary, and discloses the current-state record kept per account.

## Testing

1806 Rust tests + 883 UI tests pass; workspace clippy clean. New tests cover the person/event split in both directions and the `support_id` exclusion.