### PR TITLE
fix(coding-agent): prepend PATH when spawning a resolved CLI via run_capture

### DIFF
--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -110,7 +110,6 @@ pub(crate) async fn run_capture(
     // only ever surfaced in the tray. Falls back to the bare name so a process that
     // does have a working `PATH` behaves exactly as before.
     let resolved = crate::llm::detect::resolve_cli(program).await;
-    let target = resolved.as_deref().unwrap_or_else(|| Path::new(program));
     // `claude`, `codex`, etc. install as npm-shimmed `.cmd`/`.bat` files on
     // Windows, not PE executables. Do NOT hand-wrap these in `cmd.exe /C` —
     // `Command::new(target)` already detects a `.bat`/`.cmd` target and routes
@@ -119,7 +118,20 @@ pub(crate) async fn run_capture(
     // manual `cmd.arg("/C").arg(target)` wrapper bypasses that safe escaping —
     // `args` below can carry session-derived prompt text, so a hand-rolled
     // wrapper reopens exactly the injection std's built-in handling closes.
-    let mut cmd = Command::new(target);
+    //
+    // Resolving `program`'s own absolute path is not enough on macOS: `codex`/`claude`
+    // are `#!/usr/bin/env node` shims, and `env` does its OWN independent `PATH` search
+    // for `node` at exec time, using whatever the CHILD inherits — which under the
+    // packaged tray is launchd's stripped default with no `/opt/homebrew/bin`. Use
+    // `command_for_resolved_cli`, the same fix already applied to the sign-in flows
+    // (`cursor_sign_in`/`codex_sign_in`/`claude_sign_in`), so a resolved CLI's own
+    // directory is prepended onto the child's `PATH` here too — see its doc comment for
+    // the live incident this closes (a clean `codex login` followed by a `codex exec`
+    // that failed with `env: node: No such file or directory`).
+    let mut cmd = match resolved.as_deref() {
+        Some(path) => crate::llm::detect::command_for_resolved_cli(path),
+        None => Command::new(program),
+    };
     cmd.args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -771,8 +771,9 @@ async fn resolve_installer_binary(cmd: &str) -> String {
 
 /// Build a `Command` for `path`, a CLI already located via [`resolve_cli`], with `path`'s own
 /// directory prepended onto the child's `PATH` — same fix as [`resolve_installer_binary`],
-/// applied to the sign-in flows ([`cursor_sign_in`]/[`codex_sign_in`]/[`claude_sign_in`]),
-/// which spawn the resolved binary directly rather than through a shell.
+/// applied to the sign-in flows ([`cursor_sign_in`]/[`codex_sign_in`]/[`claude_sign_in`]) AND
+/// to [`crate::coding_agent_session_ingest::summariser::run_capture`], which spawn the
+/// resolved binary directly rather than through a shell.
 ///
 /// Those CLIs are still spawned by ABSOLUTE PATH, so the OS doesn't need `PATH` to find `path`
 /// itself — but `codex`/`claude` (unlike `cursor-agent`, a native binary) are `#!/usr/bin/env
@@ -782,7 +783,16 @@ async fn resolve_installer_binary(cmd: &str) -> String {
 /// `/opt/homebrew/bin` — so that inner lookup fails with "env: node: No such file or
 /// directory" exactly like [`resolve_installer_binary`]'s install-time case, even though the
 /// CLI itself was already found and resolved correctly.
-fn command_for_resolved_cli(path: &std::path::Path) -> Command {
+///
+/// `pub(crate)`: `run_capture` used to build its own bare `Command::new(target)` without this
+/// — which is why a completed `codex login` (via [`interactive_login`], which already called
+/// this) could be followed seconds later by a failed `codex exec` (via `run_capture`, which
+/// didn't): same binary, same shim, but only one spawn path carried a working `PATH`. Observed
+/// live 2026-08-19 (staging build `1.89.0-staging.2`): sign-in traced clean end-to-end, then
+/// the immediate post-sign-in confirmation call failed with `code: Some(127)`, `stderr: "env:
+/// node: No such file or directory"` — which the UI rendered as "not signed in yet",
+/// misdirecting the report as an auth bug rather than a PATH bug.
+pub(crate) fn command_for_resolved_cli(path: &std::path::Path) -> Command {
     let mut cmd = Command::new(path);
     if let Some(dir) = path.parent() {
         let existing = std::env::var_os("PATH").unwrap_or_default();
@@ -2835,6 +2845,67 @@ mod tests {
             "FAKE_NODE_RAN",
             "{output:?}"
         );
+    }
+
+    /// The `run_capture` counterpart to `command_for_resolved_cli_fixes_the_env_node_shebang_lookup`:
+    /// the summariser's shared subprocess runner (`codex exec`/`claude -p`/`cursor-agent`/
+    /// `copilot`, `src/coding_agent_session_ingest/summariser/mod.rs::run_capture`) used to
+    /// resolve a CLI's absolute path via `resolve_cli` but then spawn it with a bare
+    /// `Command::new(target)`, never prepending PATH — so a `#!/usr/bin/env node` CLI that
+    /// `resolve_cli` found (via a candidate dir, exactly as here) still failed once actually
+    /// run. Live incident, 2026-08-19 (staging `1.89.0-staging.2`): a `codex login` — which DOES
+    /// go through `command_for_resolved_cli` via `interactive_login` — traced clean end-to-end,
+    /// then the very next `codex exec` (via `run_capture`) failed 5ms later with `code:
+    /// Some(127)`, `stderr: "env: node: No such file or directory"`, which the UI then rendered
+    /// as "not signed in yet". Only passes now that `run_capture` spawns through
+    /// `command_for_resolved_cli` too.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_capture_fixes_the_env_node_shebang_lookup() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = ENV_LOCK.lock().await;
+        let original_home = std::env::var_os("HOME");
+        let temp_home = std::env::temp_dir().join(format!(
+            "meridian-detect-run-capture-shebang-test-{}",
+            std::process::id()
+        ));
+        let bin_dir = temp_home.join(".local").join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+
+        let fake_node = bin_dir.join("node");
+        std::fs::write(&fake_node, "#!/bin/sh\necho FAKE_NODE_RAN\n").unwrap();
+        // `resolve_cli` only ever caches SUCCESSES (see `RESOLVED_BINS`'s doc), so a name
+        // unique to this test can never collide with another test's cached resolution.
+        let fake_cli = bin_dir.join("meridian-fake-run-capture-cli");
+        std::fs::write(&fake_cli, "#!/usr/bin/env node\n").unwrap();
+        for f in [&fake_node, &fake_cli] {
+            let mut perms = std::fs::metadata(f).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(f, perms).unwrap();
+        }
+        std::env::set_var("HOME", &temp_home);
+
+        let result = crate::coding_agent_session_ingest::summariser::run_capture(
+            "meridian-fake-run-capture-cli",
+            &[],
+            "",
+            &temp_home,
+            5,
+            &[],
+            &[],
+        )
+        .await;
+
+        match original_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        let _ = std::fs::remove_dir_all(&temp_home);
+
+        let cap = result.unwrap_or_else(|e| panic!("run_capture must succeed: {e}"));
+        assert!(cap.success, "code={:?} stderr={}", cap.code, cap.stderr);
+        assert_eq!(cap.stdout.trim(), "FAKE_NODE_RAN");
     }
 
     /// cursor-agent does not install via npm on Windows (see


### PR DESCRIPTION
## Summary
- `codex`/`claude` install as `#!/usr/bin/env node` shims. `resolve_cli()` correctly finds the CLI's own absolute path (via a login-shell/candidate-dir probe), but `run_capture()` — the shared subprocess runner behind every summariser engine (`codex exec`/`claude -p`/`cursor-agent`/`copilot`) — spawned it with a bare `Command::new(target)` that never augmented the child's `PATH`. Under the packaged tray's launchd-stripped `PATH`, the shebang's own `env node` lookup failed with exit 127 (`env: node: No such file or directory`), even though the CLI itself resolved fine.
- This is the same class of bug already fixed for the sign-in flows via `command_for_resolved_cli()` (`cursor_sign_in`/`codex_sign_in`/`claude_sign_in`) — which is exactly why a `codex login` could succeed while the very next `codex exec` (via `run_capture`) failed seconds later.
- Root-caused live: on staging `1.89.0-staging.2`, `meridian logs` traced a clean `codex login` → `llm: sign-in complete`, then 5ms later the immediate post-sign-in confirmation test hit `code: Some(127)`, `stderr: "env: node: No such file or directory"` (recovered from the raw OTLP spool since `meridian logs`' renderer doesn't print structured attributes). The UI rendered that failure as "ACTION NEEDED - Sign in to ChatGPT", misdirecting the report as an auth bug rather than a PATH bug.
- Fix: made `command_for_resolved_cli()` `pub(crate)` and reused it in `run_capture()`, so every CLI spawn path prepends the resolved binary's own directory onto the child's `PATH`.

## Test plan
- [x] New regression test `run_capture_fixes_the_env_node_shebang_lookup` (`src/llm/detect.rs`) — fakes a `#!/usr/bin/env node` CLI + fake `node` in a HOME-relative candidate dir, calls `run_capture` end-to-end, asserts the child actually ran. Verified it fails on the pre-fix code (reverted the fix in-memory, confirmed red, restored).
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (1007 passed in the main lib, 0 failed)
- [ ] Manual: verify a real `codex exec`/`claude -p` call succeeds from the packaged tray right after sign-in on the next staging build (this fix targets exactly the scenario reported live on `1.89.0-staging.2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)