### PR TITLE
fix(release): address CodeRabbit's re-review of PR #815's analytics work (round 3)

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -181,8 +181,11 @@ application names, ticket keys, ticket titles or contents, notification text, su
 text, file paths, or anything about *what* you worked on. Nor anything that names your
 employer: your Jira or Azure DevOps instance URL, project keys, board or team ids,
 workspace names, your AI endpoint's URL or API key, or the text of any tracker sync
-error. Every value above is a count, a yes/no, a date, or an id from a list we defined
-in advance. They describe what Meridian did, not what you did or who you work for.
+error. Every value above is a count, a yes/no, a date, an id from a list we defined in
+advance, or one of the identifiers named earlier in this section - your account email,
+a random per-device UUID, your Support ID, your app version, and, for a known cloud
+endpoint, its model id. They describe what Meridian did, or who is using it, not what
+you did or who you work for.
 
 Analytics are captured through a single plain HTTPS request. Meridian does not embed
 PostHog's browser SDK, so session replay, autocapture, surveys, and feature flags are
@@ -234,8 +237,8 @@ Signing in is optional and is currently used to gate the invite-only alpha. Your
 - **Access** — your data is in SQLite on your own disk; inspect or export it any time.
 - **Delete** — `meridian uninstall` removes Meridian's local data and services. Deleting `~/.meridian/` by hand does the same for data alone.
 - **Portability** — export your activity data and switch tools; there is no lock-in.
-- **Opt out of error reporting** — one switch at Settings → Capture & Privacy. Product analytics does not yet have an equivalent switch; staying signed out disables it entirely.
-- **No behavioural tracking** — Meridian does not follow you across websites, does not record sessions, and sells or shares nothing with anyone. The only usage data collected is the two events described under [Product analytics](#product-analytics).
+- **Opt out of error reporting or product analytics** — each has its own switch at Settings → Capture & Privacy, and they can be turned off independently. Staying signed out disables product analytics entirely regardless of the switch.
+- **No behavioural tracking** — Meridian does not follow you across websites, does not record sessions, and sells or shares nothing with anyone. The only usage data collected is the three events described under [Product analytics](#product-analytics).
 
 ---
 

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -812,6 +812,7 @@ pub(crate) fn command_for_resolved_cli(path: &std::path::Path) -> Command {
         provider = provider.as_str(),
         ok = tracing::field::Empty,
         cli_path = tracing::field::Empty,
+        otel.status_code = tracing::field::Empty,
     )
 )]
 pub async fn install_provider(provider: LlmProvider) -> InstallOutcome {
@@ -1359,7 +1360,7 @@ where
 ///
 /// See [`interactive_login`] for the shared race/verify logic this and its two siblings run
 /// through, and `cursor::login_status_signed_in` for Cursor's ground-truth check.
-#[tracing::instrument(skip_all, fields(ok = tracing::field::Empty, cli_path = tracing::field::Empty))]
+#[tracing::instrument(skip_all, fields(ok = tracing::field::Empty, cli_path = tracing::field::Empty, otel.status_code = tracing::field::Empty))]
 pub async fn cursor_sign_in() -> InstallOutcome {
     let meridian_home = default_meridian_home();
     interactive_login(
@@ -1388,7 +1389,7 @@ pub async fn cursor_sign_in() -> InstallOutcome {
 /// See [`interactive_login`] for the shared race/verify logic and `codex::login_status_signed_in`
 /// for Codex's ground-truth check (the same `codex login status` call `codex::signed_out`
 /// already uses as a pre-flight for a real completion call).
-#[tracing::instrument(skip_all, fields(ok = tracing::field::Empty, cli_path = tracing::field::Empty))]
+#[tracing::instrument(skip_all, fields(ok = tracing::field::Empty, cli_path = tracing::field::Empty, otel.status_code = tracing::field::Empty))]
 pub async fn codex_sign_in() -> InstallOutcome {
     let meridian_home = default_meridian_home();
     interactive_login(
@@ -1415,7 +1416,7 @@ pub async fn codex_sign_in() -> InstallOutcome {
 ///
 /// See [`interactive_login`] for the shared race/verify logic and `claude::login_status_signed_in`
 /// for Claude's ground-truth check.
-#[tracing::instrument(skip_all, fields(ok = tracing::field::Empty, cli_path = tracing::field::Empty))]
+#[tracing::instrument(skip_all, fields(ok = tracing::field::Empty, cli_path = tracing::field::Empty, otel.status_code = tracing::field::Empty))]
 pub async fn claude_sign_in() -> InstallOutcome {
     let meridian_home = default_meridian_home();
     interactive_login(
@@ -1455,6 +1456,13 @@ fn install_failed(cmd: &str, message: String) -> InstallOutcome {
     // here, so recording on the CURRENT span marks whichever of them is running
     // as failed without threading a handle through a dozen early returns.
     tracing::Span::current().record("ok", false);
+    // Also the OTel-standard span-status field, not just the local `ok` field
+    // above - see `tray/src-tauri/src/daemon_lifecycle.rs` for the established
+    // convention this mirrors. `ok` is this file's own boolean; the standard
+    // field is what marks the span as errored for any trace-status query (e.g.
+    // the redacted ship leg, which egresses ERROR-status spans alongside WARN+
+    // logs).
+    tracing::Span::current().record("otel.status_code", "ERROR");
     // No `message` field: some callers (the interactive-login failure path via
     // `confirm_or_report`) pass the buffered CLI stdout/stderr tail here, which can
     // carry OAuth verification URLs and device codes - the same class of leak

--- a/src/worklog_pipeline/stale.rs
+++ b/src/worklog_pipeline/stale.rs
@@ -254,6 +254,27 @@ mod tests {
         assert_eq!(batch_message(&forward), batch_message(&backward));
     }
 
+    /// The 2-draft case above can't catch a mistake in the 4+ branch, which
+    /// selects the first two SORTED names for "X, Y, and N more" rather than
+    /// naming every draft - an unsorted 4+ batch is the only input that
+    /// exercises which two names that selection actually picks.
+    #[test]
+    fn the_batch_body_is_order_independent_at_four_or_more() {
+        let forward = [
+            draft("T1", "Release notes", 20),
+            draft("T2", "Bug triage", 20),
+            draft("T3", "API docs", 20),
+            draft("T4", "Changelog", 20),
+        ];
+        let backward = [
+            draft("T4", "Changelog", 20),
+            draft("T3", "API docs", 20),
+            draft("T2", "Bug triage", 20),
+            draft("T1", "Release notes", 20),
+        ];
+        assert_eq!(batch_message(&forward), batch_message(&backward));
+    }
+
     #[test]
     fn more_than_three_stale_drafts_are_summarised() {
         let stale = vec![

--- a/tray/src-tauri/src/analytics/daily.rs
+++ b/tray/src-tauri/src/analytics/daily.rs
@@ -51,7 +51,12 @@ pub(super) async fn send_daily_usage(
     let today = match meridian_core::today::get_today(pool, day, &day_end).await {
         Ok(t) => t,
         Err(e) => {
-            tracing::warn!(error = %e, day, "analytics: today read failed for daily_usage — will retry");
+            // `%e` renders only `e`'s outermost `.context()` - see
+            // `meridian::errors::chain`'s doc (and 99dc413b/f1ebebc1, the same
+            // defect fixed on the daemon's DB paths and the tray's poll
+            // refreshers) for why a bare `%e` here would drop exactly the
+            // cause a reader needs to tell a capture failure from a DB failure.
+            tracing::warn!(error = %meridian::errors::chain(&e), day, "analytics: today read failed for daily_usage — will retry");
             return false;
         }
     };
@@ -71,7 +76,7 @@ pub(super) async fn send_daily_usage(
     let worklogs = match meridian_core::worklogs::get_worklogs(pool, day).await {
         Ok(w) => w,
         Err(e) => {
-            tracing::warn!(error = %e, day, "analytics: worklogs read failed for daily_usage — will retry");
+            tracing::warn!(error = %meridian::errors::chain(&e), day, "analytics: worklogs read failed for daily_usage — will retry");
             return false;
         }
     };
@@ -102,7 +107,7 @@ pub(super) async fn send_daily_usage(
     let rollup = match meridian_core::usage_rollup::usage_rollup(pool, day).await {
         Ok(r) => r,
         Err(e) => {
-            tracing::warn!(error = %e, day, "analytics: usage rollup failed for daily_usage — will retry");
+            tracing::warn!(error = %meridian::errors::chain(&e), day, "analytics: usage rollup failed for daily_usage — will retry");
             return false;
         }
     };
@@ -139,8 +144,9 @@ pub(super) async fn send_daily_usage(
     health.write_properties(&mut props);
 
     let mut person = super::base_person_properties(app, email);
-    health.write_person_properties(&mut person);
-    super::attach_person_properties(&mut props, person);
+    let mut unset = Vec::new();
+    health.write_person_properties(&mut person, &mut unset);
+    super::attach_person_properties(&mut props, person, unset);
 
     tracing::info!(
         day,

--- a/tray/src-tauri/src/analytics/health.rs
+++ b/tray/src-tauri/src/analytics/health.rs
@@ -398,7 +398,19 @@ impl HealthSnapshot {
     /// newest value — so "is the daemon running" as a person property would
     /// answer "was it running at the last send", which reads as current fact
     /// and is not one. They stay event properties, where they are timestamped.
-    pub(crate) fn write_person_properties(&self, person: &mut Map<String, Value>) {
+    ///
+    /// `unset` collects the names of any optional field that is `None` on THIS
+    /// snapshot, so the caller can send them as PostHog's `$unset` alongside
+    /// `$set` — see `super::attach_person_properties`. Without it, a user who
+    /// switches away from a custom endpoint (clearing `llm_vendor`/`llm_model`)
+    /// or whose vendor stops resolving would keep their PREVIOUS value forever:
+    /// `$set` only overwrites keys that are present, so an omitted key is not
+    /// "cleared", it is simply never mentioned again.
+    pub(crate) fn write_person_properties(
+        &self,
+        person: &mut Map<String, Value>,
+        unset: &mut Vec<String>,
+    ) {
         person.insert(
             "llm_provider".to_string(),
             Value::String(self.llm_provider.to_string()),
@@ -407,11 +419,17 @@ impl HealthSnapshot {
             "llm_provider_chosen".to_string(),
             Value::Bool(provider_explicitly_chosen()),
         );
-        if let Some(v) = &self.llm_vendor {
-            person.insert("llm_vendor".to_string(), Value::String(v.clone()));
+        match &self.llm_vendor {
+            Some(v) => {
+                person.insert("llm_vendor".to_string(), Value::String(v.clone()));
+            }
+            None => unset.push("llm_vendor".to_string()),
         }
-        if let Some(m) = &self.llm_model {
-            person.insert("llm_model".to_string(), Value::String(m.clone()));
+        match &self.llm_model {
+            Some(m) => {
+                person.insert("llm_model".to_string(), Value::String(m.clone()));
+            }
+            None => unset.push("llm_model".to_string()),
         }
         person.insert(
             "integrations_connected".to_string(),
@@ -825,7 +843,7 @@ mod person_property_tests {
     #[test]
     fn provider_and_trackers_land_on_the_person() {
         let mut person = Map::new();
-        snap().write_person_properties(&mut person);
+        snap().write_person_properties(&mut person, &mut Vec::new());
 
         assert_eq!(
             person.get("llm_provider"),
@@ -852,7 +870,7 @@ mod person_property_tests {
     #[test]
     fn momentary_state_stays_off_the_person() {
         let mut person = Map::new();
-        snap().write_person_properties(&mut person);
+        snap().write_person_properties(&mut person, &mut Vec::new());
 
         for k in [
             "daemon_running",
@@ -877,7 +895,40 @@ mod person_property_tests {
     #[test]
     fn support_id_is_never_a_person_property() {
         let mut person = Map::new();
-        snap().write_person_properties(&mut person);
+        snap().write_person_properties(&mut person, &mut Vec::new());
         assert!(!person.contains_key("support_id"));
+    }
+
+    /// A snapshot WITH a vendor/model must not queue either for unset - only an
+    /// absent value is stale, a present one is not.
+    #[test]
+    fn a_present_vendor_and_model_are_never_queued_for_unset() {
+        let mut person = Map::new();
+        let mut unset = Vec::new();
+        snap().write_person_properties(&mut person, &mut unset);
+        assert!(unset.is_empty());
+    }
+
+    /// The whole point of this fix: a user who moves off a custom endpoint (back
+    /// to a built-in provider, or to one CodeRabbit's earlier fix downgrades to
+    /// `unrecognised`) has `llm_vendor`/`llm_model` go from `Some` to `None`. A
+    /// bare `$set` would leave the PostHog person carrying the stale value
+    /// forever - `write_person_properties` must queue both names for `$unset`.
+    #[test]
+    fn a_cleared_vendor_and_model_are_queued_for_unset() {
+        let snap = HealthSnapshot {
+            llm_vendor: None,
+            llm_model: None,
+            ..snap()
+        };
+        let mut person = Map::new();
+        let mut unset = Vec::new();
+        snap.write_person_properties(&mut person, &mut unset);
+        assert!(!person.contains_key("llm_vendor"));
+        assert!(!person.contains_key("llm_model"));
+        assert_eq!(
+            unset,
+            vec!["llm_vendor".to_string(), "llm_model".to_string()]
+        );
     }
 }

--- a/tray/src-tauri/src/analytics/mod.rs
+++ b/tray/src-tauri/src/analytics/mod.rs
@@ -339,15 +339,25 @@ fn base_person_properties(
     m
 }
 
-/// Attach a `$set` person-property payload to an event's properties.
+/// Attach a `$set` (and, when `unset` is non-empty, `$unset`) person-property
+/// payload to an event's properties.
 ///
-/// PostHog reads `$set` from inside `properties` on the capture endpoint, so
-/// this is a plain nested object rather than a separate request.
+/// PostHog reads both from inside `properties` on the capture endpoint, so
+/// this is plain nested data rather than a separate request. `unset` clears a
+/// PREVIOUSLY-set value that has gone away this send (e.g.
+/// [`health::HealthSnapshot::write_person_properties`]'s `llm_vendor`/
+/// `llm_model` when the user is no longer on a custom endpoint) — `$set`
+/// alone cannot do this, since an omitted key is simply never mentioned
+/// again, not cleared.
 fn attach_person_properties(
     props: &mut serde_json::Map<String, serde_json::Value>,
     person: serde_json::Map<String, serde_json::Value>,
+    unset: Vec<String>,
 ) {
     props.insert("$set".to_string(), serde_json::Value::Object(person));
+    if !unset.is_empty() {
+        props.insert("$unset".to_string(), serde_json::json!(unset));
+    }
 }
 
 /// Whether product analytics may be sent at all: the user hasn't switched it
@@ -420,7 +430,17 @@ pub(crate) async fn maybe_send_daily_tick(app: &tauri::AppHandle, pool: &SqliteP
 
     if !state.install_events_sent.contains(&email) {
         let mut props = base_properties(app, &state.device_id);
-        attach_person_properties(&mut props, base_person_properties(app, &email));
+        // The health snapshot rides here too, not just on `app_active`/`daily_usage`
+        // - `app_installed` fires exactly once per (device, account), so if it were
+        // the ONLY event whose person properties never carried provider/tracker
+        // state, a signed-in user whose tray never survives to the next event would
+        // show up in PostHog with no AI provider or tracker set at all.
+        let mut person = base_person_properties(app, &email);
+        let mut unset = Vec::new();
+        health::snapshot(pool)
+            .await
+            .write_person_properties(&mut person, &mut unset);
+        attach_person_properties(&mut props, person, unset);
         if capture("app_installed", &email, props).await {
             state.install_events_sent.insert(email.clone());
             dirty = true;
@@ -459,10 +479,11 @@ pub(crate) async fn maybe_send_daily_tick(app: &tauri::AppHandle, pool: &SqliteP
         // and permanently unknown if their tray never survives a midnight.
         // `app_active` fires on day one, so these land immediately.
         let mut person = base_person_properties(app, &email);
+        let mut unset = Vec::new();
         health::snapshot(pool)
             .await
-            .write_person_properties(&mut person);
-        attach_person_properties(&mut props, person);
+            .write_person_properties(&mut person, &mut unset);
+        attach_person_properties(&mut props, person, unset);
 
         if capture("app_active", &email, props).await {
             state


### PR DESCRIPTION
## Summary

A fresh CodeRabbit review of #811 (triggered after #815-#817 merged into `pre-main`) surfaced real findings against #815's person-properties/analytics work, plus one against `install_failed`'s span status. This fixes all of them, plus the one remaining trivial nitpick left open from round 2.

### Fixed

- **`docs/privacy.md`** — two internal contradictions introduced when #815 added product analytics' third event and its own switch:
  - The closing claim under "Product analytics" said every value sent is "a count, a yes/no, a date, or an id from a list we defined in advance" — contradicted by the same section's own text (account email, a per-device UUID, a Support ID, an app version, and a model id are none of those).
  - "Your rights" still said Product analytics "does not yet have an equivalent switch" and that only two events are collected — both stale the moment #815 landed.
- **`tray/src-tauri/src/analytics/daily.rs`** — `send_daily_usage`'s three DB-read failure branches used a bare `%e`, which for an `anyhow::Error` renders only the outermost `.context()` — the same defect `99dc413b` and `f1ebebc1` already fixed on the daemon's DB paths and the tray's poll refreshers. Switched to `meridian::errors::chain(&e)`, the established helper.
- **`tray/src-tauri/src/analytics/health.rs` + `mod.rs`** — `write_person_properties` only ever `$set` `llm_vendor`/`llm_model`, so a user moving off a custom endpoint kept their stale PostHog person-property value forever (`$set` doesn't clear an omitted key). Now also fills an `unset` list for each `None` field, and `attach_person_properties` sends it as PostHog's `$unset` alongside `$set`. Also fixed `app_installed`'s person properties — it only ever carried the base four (email/app_version/channel/os), never the health snapshot's provider/tracker state that `app_active` and `daily_usage` already attach, so a user whose tray never survived to a second event showed up in PostHog with no AI provider or tracker set at all.
- **`src/llm/detect.rs`** — `install_failed` (the shared funnel for every install/sign-in failure) recorded a local `ok` field on failure but never the OTel-standard `otel.status_code`, so these spans never counted as ERROR-status for any trace-status query. Added the field declaration to `install_provider` and all three sign-in fns' `#[tracing::instrument]` blocks, and record it alongside the existing `ok` field.
- **`src/worklog_pipeline/stale.rs`** — added the unsorted 4+-draft order-independence test flagged as a nitpick on round 2 (the 2-draft version can't exercise which two names the "X, Y, and N more" branch actually selects).

**Caught mid-fix**: my first `otel.status_code` comment in `detect.rs` quoted the literal `record("otel.status_code", ...)` call shape in prose, which matched this repo's own `span_status_guard` source-scan test (the same self-scan-trap class as `include_str!` self-scans) and produced a false failure. Reworded to describe the pattern without quoting the exact call syntax.

### Left alone

- `src/llm/codex.rs:101` — still the same trivial/low-value dedup nit from round 1, still not worth the risk this close to release.

## Test plan
- [x] TDD: reverted the `$unset` logic, confirmed `a_cleared_vendor_and_model_are_queued_for_unset` fails; restored, all pass
- [x] `cargo test --workspace` — 1008 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Pre-push hook (fmt + clippy + ui build/tests + security audit + `cargo test --workspace`) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)