### PR TITLE
fix(tray): retry a failed db repair within the same boot

### DIFF
--- a/meridian-core/src/lib.rs
+++ b/meridian-core/src/lib.rs
@@ -56,8 +56,11 @@ pub mod capture;
 /// on a console-subsystem child spawn. No-op on every other OS.
 pub mod proc_ext;
 
-/// Bounded linear-backoff retry for transient Windows file-sharing violations,
-/// shared by the tray's backend install and this crate's encrypt-in-place swap.
+/// Bounded linear-backoff retry for transient failures. Originated for
+/// Windows file-sharing violations (the tray's backend install, this crate's
+/// encrypt-in-place swap); also backs the tray's same-boot database-repair
+/// retry (`repair_boot::retry_repair`), where the failure it absorbs is
+/// unconfirmed rather than proven — see that call site's own doc.
 pub mod retry;
 
 /// Raise the process file-descriptor soft limit. Lives here rather than in

--- a/meridian-core/src/retry.rs
+++ b/meridian-core/src/retry.rs
@@ -12,11 +12,18 @@
 //! copy — the shape recurred across the Windows sync-failure fixes and earned a
 //! home in the shared crate.
 //!
-//! On non-Windows platforms these are effectively inert: the guarded ops don't
-//! hit transient sharing violations there, so the first attempt always succeeds.
-//! Keeping them platform-neutral means the logic compiles and is unit-tested on
-//! CI (macOS) — the one platform CI runs tests on — even though the failures
-//! they absorb are Windows-specific.
+//! On the original (file-rename) call sites, this is effectively inert on
+//! non-Windows platforms: the guarded ops don't hit transient sharing
+//! violations there, so the first attempt always succeeds. Keeping them
+//! platform-neutral means the logic compiles and is unit-tested on CI (macOS)
+//! — the one platform CI runs tests on — even though those failures are
+//! Windows-specific.
+//!
+//! A third caller, the tray's same-boot database-repair retry
+//! (`repair_boot::retry_repair`), is different: it wraps a whole `db repair`
+//! rebuild rather than a single rename, on a failure class observed only on
+//! macOS and not conclusively diagnosed as transient — see its own doc for
+//! the fleet evidence and the honest uncertainty about why it helps.
 //!
 //! Each retried attempt emits a `debug`-level trace (`attempt`, `attempts`)
 //! before backing off, so a live `meridian logs` tail shows the retry cadence —

--- a/tray/src-tauri/src/repair_boot.rs
+++ b/tray/src-tauri/src/repair_boot.rs
@@ -79,6 +79,30 @@ const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 /// set-aside file and a loud error, not a new empty database per launch.
 const FRESH_START_GUARD: std::time::Duration = std::time::Duration::from_secs(24 * 60 * 60);
 
+/// How many times [`execute_pending_repair`] retries a failed rebuild before
+/// giving up and reporting [`Outcome::Failed`].
+///
+/// Observed on the 2026-08 fleet incident: the same machine logged `database
+/// repair failed - the original is unchanged` twice within about a minute of
+/// its own repeated auto-repair-at-boot attempts, before a later attempt
+/// (elsewhere, hours afterward) finally succeeded. That is not proof of a
+/// specific transient cause here the way Windows' os-error-32 file lock is
+/// proven in [`meridian_core::retry`] - macOS was the only OS observed in this
+/// pattern, and nothing in `repair()`'s own error path currently distinguishes
+/// a transient failure from a genuinely unsalvageable one. But a bounded,
+/// same-boot retry costs nothing on the common path (a healthy database never
+/// reaches this code at all) and directly narrows the gap this fleet evidence
+/// pointed at: today, giving a corrupt database more than one chance to repair
+/// requires the user (or a relaunch) to reopen the app between every attempt,
+/// which an ordinary user has no reason to know to do.
+const REPAIR_RETRY_ATTEMPTS: u32 = 3;
+
+/// Linear backoff base for [`REPAIR_RETRY_ATTEMPTS`] - `base × attempt`
+/// between tries (2s, then 4s), matching [`meridian_core::retry`]'s schedule.
+/// Small enough that even the worst case (two retries) adds only ~6s to a
+/// boot that was already about to run a multi-table rebuild.
+const REPAIR_RETRY_BASE_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// Outcome, kept plain so `lib.rs` can turn it into a notice once it has a pool
 /// (this runs before one exists).
 pub enum Outcome {
@@ -345,7 +369,7 @@ fn probe_and_heal(db_path: &Path, key_hex: Option<&str>, key_trust: KeyTrust) ->
 fn execute_pending_repair(db_path: &Path, key_hex: Option<&str>) -> Outcome {
     let outcome = tauri::async_runtime::block_on(async move {
         wait_for_daemon_to_stand_down().await;
-        meridian::db::repair::repair(db_path, key_hex).await
+        retry_repair(|| meridian::db::repair::repair(db_path, key_hex)).await
     });
 
     // Clear before reporting: a panic while formatting the summary must not
@@ -373,6 +397,27 @@ fn execute_pending_repair(db_path: &Path, key_hex: Option<&str>) -> Outcome {
             }
         }
     }
+}
+
+/// Runs `repair_fn` up to [`REPAIR_RETRY_ATTEMPTS`] times with
+/// [`REPAIR_RETRY_BASE_DELAY`] linear backoff, via the shared
+/// [`meridian_core::retry::retry_transient`] - see [`REPAIR_RETRY_ATTEMPTS`]'s
+/// doc for why this exists. `repair()` never modifies the original database
+/// until its final successful swap, so retrying a failed attempt costs
+/// nothing beyond time: each attempt either fails having changed nothing, or
+/// the whole operation succeeds.
+///
+/// Split out (rather than inlined into [`execute_pending_repair`]) so the
+/// retry/backoff wiring is testable with a fake fallible closure, the same
+/// way [`KeyTrust::of`] and [`probe_and_heal`] are split from their real I/O
+/// for the same reason.
+async fn retry_repair<F, Fut>(repair_fn: F) -> anyhow::Result<meridian::db::repair::RepairReport>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<meridian::db::repair::RepairReport>>,
+{
+    meridian_core::retry::retry_transient(REPAIR_RETRY_ATTEMPTS, REPAIR_RETRY_BASE_DELAY, repair_fn)
+        .await
 }
 
 /// Classifies the on-disk database. Read-only and safe against a live daemon:
@@ -776,6 +821,65 @@ mod probe_tests {
             .join("meridian.db.unopenable-backup-20260805000000");
         std::fs::write(&fresh, b"new damage").unwrap();
         assert_eq!(recent_unopenable_backup(&db), Some(fresh));
+    }
+
+    /// A repair that fails on its first attempts but succeeds within
+    /// [`REPAIR_RETRY_ATTEMPTS`] must recover, not report [`Outcome::Failed`]
+    /// - the whole point of [`REPAIR_RETRY_ATTEMPTS`]'s hardening: giving a
+    /// transient failure a same-boot second chance instead of requiring the
+    /// user to relaunch the app between every attempt.
+    #[tokio::test(start_paused = true)]
+    async fn retry_repair_recovers_within_the_attempt_budget() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let calls = AtomicU32::new(0);
+        let result = retry_repair(|| {
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if n + 1 < REPAIR_RETRY_ATTEMPTS {
+                    Err(anyhow::anyhow!("transient failure"))
+                } else {
+                    Ok(meridian::db::repair::RepairReport::default())
+                }
+            }
+        })
+        .await;
+        assert!(result.is_ok(), "must recover within the retry budget");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            REPAIR_RETRY_ATTEMPTS,
+            "no extra attempt past the success"
+        );
+    }
+
+    /// A repair that never succeeds must still give up after exactly
+    /// [`REPAIR_RETRY_ATTEMPTS`] tries and surface the last error - a
+    /// genuinely unsalvageable database must not retry forever.
+    #[tokio::test(start_paused = true)]
+    async fn retry_repair_gives_up_after_exhausting_the_attempt_budget() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let calls = AtomicU32::new(0);
+        let result = retry_repair(|| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Err(anyhow::anyhow!("still broken")) }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), REPAIR_RETRY_ATTEMPTS);
+    }
+
+    /// The common path - success on the very first attempt - must not pay any
+    /// backoff or retry cost at all.
+    #[tokio::test]
+    async fn retry_repair_returns_on_first_success_without_retrying() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let calls = AtomicU32::new(0);
+        let result = retry_repair(|| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Ok(meridian::db::repair::RepairReport::default()) }
+        })
+        .await;
+        assert!(result.is_ok());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 }
 


### PR DESCRIPTION
## Summary

Fleet evidence (central OpenObserve, last 60 days): **29 of 492 active machines** hit `database disk image is malformed` / `meridian.db is corrupt` — every OS-attributable hit was **macOS, zero Windows**. On one machine's worst incident, the tray's auto-repair-at-boot (`repair_boot::run_auto_if_needed`) logged `database repair failed - the original is unchanged` **twice within about a minute** before a later attempt (hours afterward, via a separate invocation) finally succeeded.

Today, giving a failed repair another chance requires the user to **relaunch the app between every attempt** — an ordinary user has no reason to know to do that, and a machine that fails its first auto-repair attempt stays hard-down until something (a relaunch, an update, a human running `meridian db repair` by hand) happens to trigger a retry.

This PR is **not** a confirmed root-cause fix — I could not pin down a specific transient failure mechanism the way Windows' `os error 32` file-lock case (the original motivation for `meridian_core::retry`) is proven. Nothing in `repair()`'s error path currently distinguishes a transient cause from a genuinely unsalvageable one, and macOS was the only OS observed in this pattern. But `repair()` never modifies the original database until its final successful swap, so retrying a failed attempt costs nothing beyond a few bounded seconds — and the common (healthy database) path never reaches this code at all.

## What changed

- `tray/src-tauri/src/repair_boot.rs`: `execute_pending_repair`'s `repair()` call is now wrapped in the existing `meridian_core::retry::retry_transient` primitive — 3 attempts, 2s linear backoff (worst case ~6s added to a boot that was already about to run a multi-table rebuild). Reuses the already-tested primitive rather than growing a parallel retry loop.
- `meridian-core/src/retry.rs` + `meridian-core/src/lib.rs`: module docs updated to honestly describe the new, less-certain macOS use case alongside the original, proven Windows one.
- Explicitly **out of scope**: the `Probe::FreshStart` path is untouched (it already has its own dedicated 24h guard against repeated destructive fresh-starts — a different scenario, "nothing in it is salvageable," not a transient one). This PR does **not** touch `tray/minimum-version` or propose a forced fleet-wide update — that decision needs a maintainer once this is verified on staging.

## Test plan

- [x] New tests: `retry_repair_recovers_within_the_attempt_budget`, `retry_repair_gives_up_after_exhausting_the_attempt_budget`, `retry_repair_returns_on_first_success_without_retrying` — all use `#[tokio::test(start_paused = true)]` so the retry backoff is exercised deterministically with zero real wall-clock delay.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (1008 passed, 0 failed)
- [x] Full pre-push gate (fmt, ui build, ui tests, clippy, security audit, cargo test) — all green
- [ ] Manual: verify on the next staging build that a repair failure is retried within the same boot rather than requiring a relaunch (hard to reproduce a real corrupt DB on demand — the unit tests cover the retry wiring itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)