### PR TITLE
fix(release): address CodeRabbit's re-review of PR #811 (round 4)

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -93,7 +93,7 @@ Nothing *inside* an error report is associated with an account, and the hash can
 
 > **But if product analytics is on, we can still connect the two.** Product-analytics events carry both your account email and the same Support ID, so the pair links your errors to you. That linkage lives entirely on the analytics side - an error report itself never contains your email. Turning off **Product analytics** removes it; see [Product analytics](#product-analytics).
 
-> **Alpha exception, until 31 December 2026.** While Meridian is in invite-only alpha, signing in changes this: the Support ID is instead derived from a salted hash of your account email, so support can follow one tester's errors across their machines. Your raw email address is never sent. Settings → Account states which mode is currently active for you. After that date every install reverts to the hardware-derived pseudonym automatically, and your Support ID changes at that point.
+> **Alpha exception, until 31 December 2026.** While Meridian is in invite-only alpha, signing in changes this: the Support ID is instead derived from a salted hash of your account email, so support can follow one tester's errors across their machines. Your raw email address is not included in the Support ID or in error reports - only the salted hash is. (Product analytics, if you have it on, sends the raw email separately - see [Product analytics](#product-analytics).) Settings → Account states which mode is currently active for you. After that date every install reverts to the hardware-derived pseudonym automatically, and your Support ID changes at that point.
 
 ### Crash reports
 
@@ -123,7 +123,7 @@ different things about you - see [Error reporting](#error-reporting).
 |---|---|---|
 | `app_installed` | Once per device, per signed-in account | Nothing beyond the shared properties below. |
 | `app_active` | Once per calendar day Meridian is running | The shared properties, plus the current-state summary described below (which AI provider and which trackers). It exists so we can tell how many people come back on a given day, and so a brand-new install's setup is visible without waiting for the first `daily_usage`. |
-| `daily_usage` | Once per completed calendar day | Three groups of numbers, listed below. |
+| `daily_usage` | Once per completed calendar day | The categories listed below. |
 
 `daily_usage` carries:
 
@@ -238,7 +238,7 @@ Signing in is optional and is currently used to gate the invite-only alpha. Your
 - **Delete** — `meridian uninstall` removes Meridian's local data and services. Deleting `~/.meridian/` by hand does the same for data alone.
 - **Portability** — export your activity data and switch tools; there is no lock-in.
 - **Opt out of error reporting or product analytics** — each has its own switch at Settings → Capture & Privacy, and they can be turned off independently. Staying signed out disables product analytics entirely regardless of the switch.
-- **No behavioural tracking** — Meridian does not follow you across websites, does not record sessions, and sells or shares nothing with anyone. The only usage data collected is the three events described under [Product analytics](#product-analytics).
+- **No behavioural tracking** — Meridian does not follow you across websites, does not record sessions, and never sells your data or shares it for advertising. It does reach the service providers named throughout this document to do the job each is described for - PostHog for product analytics, Sentry for crash reports, Clerk for sign-in - and nowhere else. The only usage data collected is the three events described under [Product analytics](#product-analytics).
 
 ---
 

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -1234,6 +1234,13 @@ where
                     bin,
                     "llm: sign-in confirmed by status check while the CLI was still running"
                 );
+                // `child` is still running here, and `.kill_on_drop(true)` alone is not
+                // enough: Drop only calls the non-blocking `start_kill`, it never awaits
+                // the exit, so relying on it would leave a killed-but-unreaped zombie for
+                // however long it takes something else to reap it - which may be never,
+                // if nothing else ever calls `.wait()` on this process. `Child::kill`
+                // does both (`start_kill` then `wait().await`) - see tokio's doc on it.
+                let _ = child.kill().await;
                 return InstallOutcome {
                     ok: true,
                     message: success_message,


### PR DESCRIPTION
## Summary

Another CodeRabbit pass on #811, triggered after #819 merged. This time the findings are against docs and code from earlier in this release batch (#804, #809) rather than anything rounds 1-3 touched.

### Fixed

- **`docs/privacy.md`** — three self-consistency fixes, all traceable to #809's privacy-disclosure commit (`6178ca7`):
  - "Your raw email address is never sent" sat inside the alpha-exception paragraph about Support ID derivation, but read unscoped it contradicts the Product analytics section a few lines above, which discloses that product-analytics events DO carry the raw email as PostHog's `distinct_id`. Scoped the claim to the Support ID/error-report path and cross-referenced Product analytics.
  - `daily_usage`'s table entry still said "Three groups of numbers" — stale from before install-health and AI-provider/tracker categories were added; the doc now lists five categories. Replaced the count with "the categories listed below".
  - Softened "sells or shares nothing with anyone" to acknowledge the service providers the doc itself already discloses (PostHog, Sentry, Clerk) — the sentence meant "no sale or ad-sharing", not "no third party ever sees anything."
- **`src/llm/detect.rs`** — `interactive_login`'s mid-wait verify-confirms-success path returned while the child process was still running, relying on `.kill_on_drop(true)` alone. Drop is synchronous and can't `.await`, so `kill_on_drop`'s Drop impl only ever fires a non-blocking `start_kill` — it doesn't guarantee the process is reaped before the function returns, or ever, if nothing else calls `.wait()` on it. Added an explicit `child.kill().await` before the early return — tokio's `Child::kill` is `start_kill()` + `wait().await` together, so this both kills and reaps synchronously. Covered by the existing `verify_confirming_mid_wait_returns_before_the_child_exits_or_times_out` test, which exercises exactly this path.

### Evaluated and left alone

- A suggestion to more strictly isolate `PATH` in `run_capture_fixes_the_env_node_shebang_lookup` (#816's PATH-prepending regression test). Traced `command_for_resolved_cli`: it *prepends* to the existing `PATH` rather than replacing it, and the test already asserts on the fake node's exact stdout (`"FAKE_NODE_RAN"`) — a regression (PATH not prepended) would either fail outright or produce different output, so the existing assertions already catch what the suggestion is aimed at. Real work (isolating PATH inside a shared-mutex async test alongside the existing `HOME` save/restore) for a gap that doesn't appear to exist in practice.
- The drain-task/buffer-cap half of the child-reaping finding. The reaped child's pipes close on kill, which already ends the drain tasks via EOF — no separate abort needed — and the buffers are bounded in practice by a max ~180s login flow between real CLI processes, not an unbounded-adversarial-input scenario.

## Test plan
- [x] `cargo test --workspace` — 1008 passed, 0 failed (including the existing mid-wait-verify test, which exercises the modified `interactive_login` path)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Pre-push hook (fmt + clippy + ui build/tests + security audit + `cargo test --workspace`) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)