### PR TITLE
chore(release): update the 1.89.0 What's New entry for Ollama/Groq and DB-repair retry

### DIFF
--- a/tray/src-tauri/resources/whats-new.json
+++ b/tray/src-tauri/resources/whats-new.json
@@ -2,8 +2,9 @@
   "releases": [
     {
       "version": "1.89.0",
-      "date": "2026-08-19",
+      "date": "2026-08-20",
       "highlights": [
+        "Ollama Cloud joins the setup wizard as a free, no-subscription way to draft with AI, and is now the one we recommend if you don't already have a subscription. Groq is being retired from active use - if you're currently on it, Settings will show a notice pointing you to Ollama, and your configuration stays exactly as you left it until you switch.",
         "Settings now shows exactly what daily usage reporting sends - a health snapshot alongside the counts, never your screen activity or anything you wrote - and a new switch lets you turn it off separately from error reporting, without losing crash reports."
       ],
       "fixes": [
@@ -12,8 +13,9 @@
         "Draft with AI on Cursor no longer takes up to a minute when it usually takes seconds.",
         "A brief network or provider hiccup no longer flips your AI provider to unavailable and stops your day from being written - Meridian retries once before giving up.",
         "Several worklog drafts falling behind in the same hour now arrive as one notification instead of landing all at once.",
-        "Drafting stopped failing with a hidden schema error on some Groq models.",
-        "Coding-agent session summaries no longer silently fail to generate on some setups."
+        "Drafting stopped failing with a hidden schema error on some custom AI endpoints.",
+        "Coding-agent session summaries no longer silently fail to generate on some setups.",
+        "A database repair that fails on launch now retries automatically within the same session instead of leaving Meridian stuck until you relaunch."
       ]
     },
     {


### PR DESCRIPTION
## Summary

Three more PRs landed on `pre-main` since the 1.89.0 What's New entry was first written (#818 perf metrics, #820 Ollama/Groq, #821 DB-repair retry), and one of them made an existing bullet stale.

- Added a highlight for **#820**: Ollama Cloud as the new free provider, Groq retired from production use (existing Groq users see a Settings notice, their configuration is preserved).
- Reworded the Groq-specific schema-error fix bullet to be endpoint-generic ("some custom AI endpoints") — the underlying `additionalProperties` fix (#812) applies to any custom OpenAI-compatible endpoint, not just Groq, and leading with "we fixed Groq" right next to "Groq is retired" read backwards.
- Added a fixes bullet for **#821**: a failed DB auto-repair now retries within the same boot instead of requiring a relaunch.
- **#818 (perf metrics) intentionally gets no mention** — not user-facing, and shipping now (rather than waiting for its author's planned baseline period) was an explicit call to accept as-is rather than gate.
- Bumped the entry's date to today, since the promotion still hasn't been cut.

## Test plan
- [x] `whats_new_json_parses` test — passes
- [x] `whats-new.json` validated as well-formed JSON
- [x] Plain-hyphen-only check on the new/edited copy (no em-dash/en-dash)
- [x] Pre-push hook (fmt + clippy + ui build/tests + security audit + `cargo test --workspace`) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)