### PR TITLE
fix(notifications): give the persistent fault banner a real click-through link

### DIFF
--- a/meridian-core/src/readers/notices.rs
+++ b/meridian-core/src/readers/notices.rs
@@ -27,7 +27,9 @@ use sqlx::FromRow;
 use tracing::Instrument;
 
 /// One active fault banner (the shape `NoticeBar.tsx` renders). `severity` is
-/// `'error'|'warning'`; `remedy` is the optional fix hint.
+/// `'error'|'warning'`; `remedy` is the optional fix hint. `deep_link` (migration
+/// 081) is the same route-like target the paired native toast carries — `None`
+/// on the great majority of notices, which render with no click-through button.
 #[derive(Debug, Clone, FromRow, serde::Serialize)]
 pub struct Notice {
     pub notice_id: String,
@@ -36,6 +38,7 @@ pub struct Notice {
     pub detail: String,
     pub remedy: Option<String>,
     pub raised_at: String,
+    pub deep_link: Option<String>,
 }
 
 /// All active notices, newest first (port of `notices-store.ts`'s `queryNotices`).
@@ -45,7 +48,7 @@ pub struct Notice {
 #[tracing::instrument(skip(pool))]
 pub async fn read_notices(pool: &SqlitePool) -> Vec<Notice> {
     let rows = sqlx::query_as::<_, Notice>(
-        "SELECT notice_id, severity, title, detail, remedy, raised_at \
+        "SELECT notice_id, severity, title, detail, remedy, raised_at, deep_link \
          FROM system_notices ORDER BY raised_at DESC",
     )
     .fetch_all(pool)
@@ -121,21 +124,26 @@ mod tests {
 
         sqlx::query(
             "CREATE TABLE system_notices (notice_id TEXT PRIMARY KEY, severity TEXT, \
-             title TEXT, detail TEXT, remedy TEXT, raised_at TEXT)",
+             title TEXT, detail TEXT, remedy TEXT, raised_at TEXT, deep_link TEXT)",
         )
         .execute(&pool)
         .await
         .unwrap();
-        for (nid, raised) in [
-            ("pm.jira", "2026-06-18T09:00:00Z"),
-            ("a11y", "2026-06-18T10:00:00Z"),
+        for (nid, raised, deep_link) in [
+            ("pm.jira", "2026-06-18T09:00:00Z", None),
+            (
+                "a11y",
+                "2026-06-18T10:00:00Z",
+                Some("/settings/intelligence"),
+            ),
         ] {
             sqlx::query(
-                "INSERT INTO system_notices (notice_id, severity, title, detail, remedy, raised_at) \
-                 VALUES (?, 'warning', 't', 'd', NULL, ?)",
+                "INSERT INTO system_notices (notice_id, severity, title, detail, remedy, raised_at, deep_link) \
+                 VALUES (?, 'warning', 't', 'd', NULL, ?, ?)",
             )
             .bind(nid)
             .bind(raised)
+            .bind(deep_link)
             .execute(&pool)
             .await
             .unwrap();
@@ -146,5 +154,10 @@ mod tests {
         assert_eq!(notices[0].notice_id, "a11y");
         assert_eq!(notices[1].notice_id, "pm.jira");
         assert!(notices[0].remedy.is_none());
+        assert_eq!(
+            notices[0].deep_link.as_deref(),
+            Some("/settings/intelligence")
+        );
+        assert!(notices[1].deep_link.is_none());
     }
 }

--- a/src/migrations/081_system_notices_deep_link.sql
+++ b/src/migrations/081_system_notices_deep_link.sql
@@ -1,0 +1,13 @@
+-- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+
+-- The persistent fault banner (`system_notices`, read by `NoticeBar.tsx`) had no
+-- click-through target at all — only the transactional `notifications` outbox
+-- (migration 042) carries `deep_link`, which only ever reaches the transient
+-- native OS toast. A banner that outlives its toast (the common case: a toast
+-- disappears in seconds, a banner sits until the fault clears) had nowhere to
+-- send a click. `raise_typed` already threads a `deep_link` through to the paired
+-- toast; this lets it persist the same value onto the banner row too.
+--
+-- Nullable, no default: a notice with no deep link (most of them) simply renders
+-- with no button, exactly as today.
+ALTER TABLE system_notices ADD COLUMN deep_link TEXT;

--- a/src/notices.rs
+++ b/src/notices.rs
@@ -85,13 +85,14 @@ pub struct Notice<'a> {
 /// using the same `event_key` so the retract dedup key matches the enqueue.
 pub async fn raise_typed(pool: &SqlitePool, n: Notice<'_>) -> Result<()> {
     sqlx::query(
-        "INSERT INTO system_notices (notice_id, severity, title, detail, remedy)
-         VALUES (?, ?, ?, ?, ?)
+        "INSERT INTO system_notices (notice_id, severity, title, detail, remedy, deep_link)
+         VALUES (?, ?, ?, ?, ?, ?)
          ON CONFLICT(notice_id) DO UPDATE SET
            severity  = excluded.severity,
            title     = excluded.title,
            detail    = excluded.detail,
            remedy    = excluded.remedy,
+           deep_link = excluded.deep_link,
            raised_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')",
     )
     .bind(n.id)
@@ -99,6 +100,7 @@ pub async fn raise_typed(pool: &SqlitePool, n: Notice<'_>) -> Result<()> {
     .bind(n.title)
     .bind(n.detail)
     .bind(n.remedy)
+    .bind(n.deep_link)
     .execute(pool)
     .await
     .context("raising system notice")?;
@@ -238,6 +240,70 @@ mod tests {
             .await
             .unwrap();
         assert!(!cleared_again);
+    }
+
+    /// THE bug this test exists for: `deep_link` reached the paired native toast
+    /// (`notifications.deep_link`, migration 042) but was silently dropped before it ever
+    /// reached the persistent banner (`system_notices` had no such column at all) - so a
+    /// banner that outlived its toast, which is the common case, had no click-through left.
+    /// Asserts on `system_notices` directly, via the same reader the banner actually uses
+    /// (`meridian_core::notices::read_notices`), not just on what `raise_typed` was asked to
+    /// do - a regression here could pass a Rust-only check on the query and still ship a
+    /// banner with no button if the reader's column list drifted.
+    #[tokio::test]
+    async fn raise_typed_persists_deep_link_onto_the_banner_row() {
+        let pool = fresh_db().await;
+
+        raise_typed(
+            &pool,
+            Notice {
+                id: "llm.groq_deprecated",
+                severity: "error",
+                title: "Groq is disabled",
+                detail: "Switch providers to resume.",
+                remedy: None,
+                event_key: "llm.groq_deprecated",
+                deep_link: Some(meridian_core::notifications::deep_links::INTELLIGENCE),
+            },
+        )
+        .await
+        .unwrap();
+
+        let notices = meridian_core::notices::read_notices(&pool).await;
+        let banner = notices
+            .iter()
+            .find(|n| n.notice_id == "llm.groq_deprecated")
+            .expect("raise_typed must have written the banner row");
+        assert_eq!(
+            banner.deep_link.as_deref(),
+            Some(meridian_core::notifications::deep_links::INTELLIGENCE)
+        );
+
+        // A re-raise (the poll loop's idempotent every-tick call) must not clear it either -
+        // the UPDATE branch of the upsert has its own column list to keep in sync.
+        raise_typed(
+            &pool,
+            Notice {
+                id: "llm.groq_deprecated",
+                severity: "error",
+                title: "Groq is disabled",
+                detail: "Switch providers to resume.",
+                remedy: None,
+                event_key: "llm.groq_deprecated",
+                deep_link: Some(meridian_core::notifications::deep_links::INTELLIGENCE),
+            },
+        )
+        .await
+        .unwrap();
+        let notices = meridian_core::notices::read_notices(&pool).await;
+        let banner = notices
+            .iter()
+            .find(|n| n.notice_id == "llm.groq_deprecated")
+            .unwrap();
+        assert_eq!(
+            banner.deep_link.as_deref(),
+            Some(meridian_core::notifications::deep_links::INTELLIGENCE)
+        );
     }
 
     /// The test above only checks `system_notices` — it would pass even if

--- a/ui/components/NoticeBar.tsx
+++ b/ui/components/NoticeBar.tsx
@@ -149,6 +149,36 @@ export default function NoticeBar() {
                 Reconnect →
               </button>
             )}
+            {/* The generic case, for every OTHER notice carrying a `deep_link` (migration
+                081) - `llm.groq_deprecated` today, any future one tomorrow. Routes through
+                the exact same `meridian:navigate` → `navigate()` switch a toast's [View]
+                button uses (`MeridianTimelineShell.tsx`), so a banner that outlives its toast
+                still lands somewhere real instead of just sitting there unclickable. The `pm.`
+                and `db.corrupt` cases above stay hand-written since they need bespoke buttons
+                ("Reconnect →", the repair flow) rather than a plain "View →". */}
+            {n.deep_link && !n.notice_id.startsWith('pm.') && n.notice_id !== DB_CORRUPT && (
+              <button
+                onClick={() => window.dispatchEvent(
+                  new CustomEvent('meridian:navigate', { detail: n.deep_link })
+                )}
+                style={{
+                  flexShrink: 0,
+                  fontSize: 11,
+                  fontWeight: 600,
+                  color: s.text,
+                  background: 'rgba(0,0,0,0.07)',
+                  border: `1px solid ${s.border}`,
+                  borderRadius: 5,
+                  padding: '3px 8px',
+                  textDecoration: 'none',
+                  whiteSpace: 'nowrap',
+                  alignSelf: 'center',
+                  cursor: 'pointer',
+                }}
+              >
+                View →
+              </button>
+            )}
             {ACKNOWLEDGEABLE.has(n.notice_id) && (
               <DismissButton noticeId={n.notice_id} color={s.text}
                 onDone={() => setNotices(cur => cur.filter(x => x.notice_id !== n.notice_id))} />

--- a/ui/components/timeline/MeridianTimelineShell.tsx
+++ b/ui/components/timeline/MeridianTimelineShell.tsx
@@ -246,7 +246,18 @@ export default function MeridianTimelineShell() {
           setActiveModal(null)
       }
     }
-    return subscribe<string | null>('/deep-link', 'take_pending_deep_link', 'dashboard-navigate', navigate)
+    // Same-window source: a persistent banner's own click-through (`NoticeBar.tsx`'s
+    // deep_link button). Unlike the tray-pushed half below, the window is already open and
+    // the user is already looking at it, so this is a plain same-page event rather than a
+    // round trip through the tray - but it reuses the identical `navigate` switch, so a
+    // banner's deep_link resolves exactly the way the matching toast's [View] button would.
+    const onBannerNavigate = (e: Event) => navigate((e as CustomEvent<string>).detail)
+    window.addEventListener('meridian:navigate', onBannerNavigate)
+    const unsubscribe = subscribe<string | null>('/deep-link', 'take_pending_deep_link', 'dashboard-navigate', navigate)
+    return () => {
+      window.removeEventListener('meridian:navigate', onBannerNavigate)
+      unsubscribe()
+    }
   }, [])
 
   // Changing day resets the selected hour (its detail no longer applies).

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -652,6 +652,11 @@ export interface Notice {
   detail: string
   remedy: string | null
   raised_at: string
+  /** A route-like target (`/settings/intelligence`, …) from `meridian_core::notifications::deep_links`
+   *  — the same value the notice's paired native toast carries, now persisted onto the banner row
+   *  too (migration 081) so a click-through survives past the toast itself. `null` on the great
+   *  majority of notices, which render with no button. */
+  deep_link: string | null
 }
 
 // ── Banner notifications (`get_banner_notifications`) ─────────────────────────

--- a/ui/lib/llm-providers.ts
+++ b/ui/lib/llm-providers.ts
@@ -620,21 +620,20 @@ export const OLLAMA: CloudKeyPreset = {
   vendor: 'ollama',
   name: 'Ollama',
   baseUrl: 'https://ollama.com/v1',
-  // NOT the bare `/settings/keys` address - verified live (this session): visiting that
-  // signed-out redirects to `/signin` with no return path attached at all, so a user who
-  // just created an account lands on ollama.com's general homepage with no obvious way
-  // back to the key screen. `/signin?next=...` carries the destination through their
-  // WorkOS auth redirect instead (confirmed via the `state` param, which base64-decodes to
-  // exactly `/settings/keys`), so sign-up and sign-in both land back here afterward - the
-  // same round-trip Groq's own keys link gives for free.
-  keyUrl: 'https://ollama.com/signin?next=%2Fsettings%2Fkeys',
+  // The direct address, by request - deliberately NOT `/signin?next=%2Fsettings%2Fkeys`,
+  // which carries the destination through Ollama's WorkOS auth redirect and lands a
+  // signed-out user straight back here. Trade-off worth knowing: visiting THIS bare address
+  // signed-out 303s to a generic `/signin` with no return path at all (verified live), so
+  // `keyStepBody` below tells a signed-out user to navigate to Settings → Keys themselves
+  // once they're in, rather than promising an automatic landing.
+  keyUrl: 'https://ollama.com/settings/keys',
   // Spelt out, unlike Groq's: Groq's link opens a page with nothing else on it, but Ollama's
   // settings are a tabbed page, so "create an API key" alone leaves the actual click
   // unnamed. Named explicitly so nobody has to go hunting for it.
   keyStepBody:
     'Sign up with Google or an email address if you have not already - no card is asked for. ' +
-    'You will land on the Keys section of Settings - press Create API key there and copy it, ' +
-    'it is shown once.',
+    'If it does not take you straight there, go to Settings → Keys and press Create API key ' +
+    'there and copy it, it is shown once.',
   privacyUrl: 'https://ollama.com/privacy',
   termsUrl: 'https://ollama.com/terms',
   freeBadge: 'FREE',


### PR DESCRIPTION
## Summary
Follow-up to #820 - the user reported that after updating a machine with Groq as the active provider, the "Groq is disabled" banner eventually appeared but had no working link to the providers page, and no native notification fired.

Root-caused the missing link: `system_notices` (the table the **persistent banner** reads) never had a `deep_link` column at all - only the transient native OS toast carried one, through the separate `notifications` outbox table (migration 042). A banner routinely outlives its own toast (the toast disappears in seconds, the banner sits until the fault clears), so `deep_link: Some(deep_links::INTELLIGENCE)` on the Groq notice only ever worked from the toast - which most users never even see fire before it's gone.

- Adds `deep_link TEXT` to `system_notices` (migration 081).
- `raise_typed`'s insert/upsert now persists it; `read_notices` now selects it.
- `NoticeBar.tsx` gets a generic "View →" button for any notice carrying a `deep_link`, routed through the exact same `navigate()` switch a toast's [View] button already uses, via a new same-window `meridian:navigate` event (`MeridianTimelineShell.tsx`). This benefits every current and future notice with a deep_link, not just Groq's.
- Also switches Ollama's "get a key" link to the direct `https://ollama.com/settings/keys` address (by request) and adjusts the setup copy for the one known trade-off: that address 303s a signed-out visitor to a generic sign-in with no return path, so the copy now tells them to navigate to Settings → Keys themselves afterward.

## Why the banner took >2 minutes to appear (informational, not a bug)
The `llm.groq_deprecated` check lives inside the daemon's recurring poll-loop tick, which only fires after the first full `poll_interval_secs` sleep (default 60s) completes - the immediate startup ETL pass deliberately skips all secondary checks (disk-space, PM-sync digest, and this one included). Staging/restart overhead from the update itself plus daemon boot plus one full poll interval easily clears two minutes. This is pre-existing behavior shared by every notice in that block, not something introduced by #820.

## Test plan
- [x] New Rust test `raise_typed_persists_deep_link_onto_the_banner_row` - asserts the deep_link survives both the initial raise AND a re-raise (the poll loop's idempotent every-tick call), reading it back through the same `meridian_core::notices::read_notices` the banner actually uses
- [x] `cargo fmt --all -- --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` (1011 tests)
- [x] `cd ui && npx tsc --noEmit && bun test && npm run build` (893 tests)
- [x] `git push` pre-push gate (fmt, clippy, ui build/tests, security audit, cargo test) all green