### PR TITLE
fix(notifications): clear/raise the Groq banner the instant the provider changes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1447,40 +1447,16 @@ async fn main() -> Result<()> {
                 // manageable, still selectable) so the user isn't locked out of their own
                 // settings, but the moment Groq is active this banner says plainly that
                 // nothing is being sent to it. Raise/clear every tick, same idempotent
-                // pattern as disk-space above. Scoped to `vendor == "groq"` specifically, so
-                // Claude/Codex/Cursor/Copilot/Ollama users see nothing.
-                match cfg.runtime.active_custom_provider().map(|p| p.vendor.as_str()) {
-                    Some("groq") => {
-                        let _ = meridian::notices::raise_typed(
-                            &meridian,
-                            meridian::notices::Notice {
-                                id: "llm.groq_deprecated",
-                                severity: "error",
-                                title: "Groq is disabled",
-                                detail: "Groq's free tier can't reliably serve Meridian's \
-                                    hourly summaries, so Meridian no longer sends it any \
-                                    requests. Hourly summaries are paused until you switch \
-                                    providers.",
-                                remedy: Some(
-                                    "Add a free Ollama key in Settings - Intelligence to resume.",
-                                ),
-                                event_key: "llm.groq_deprecated",
-                                deep_link: Some(
-                                    meridian_core::notifications::deep_links::INTELLIGENCE,
-                                ),
-                            },
-                        )
-                        .await;
-                    }
-                    _ => {
-                        let _ = meridian::notices::clear_typed(
-                            &meridian,
-                            "llm.groq_deprecated",
-                            "llm.groq_deprecated",
-                        )
-                        .await;
-                    }
-                }
+                // pattern as disk-space above. This is the steady-state driver; the tray's
+                // `update_settings` calls the SAME function the instant the provider changes,
+                // so switching away from Groq clears the banner immediately rather than
+                // leaving it up for up to a minute after the fix already took effect — see
+                // `sync_groq_deprecated_notice`'s doc for why both call it.
+                meridian::notices::sync_groq_deprecated_notice(
+                    &meridian,
+                    cfg.runtime.active_custom_provider().map(|p| p.vendor.as_str()),
+                )
+                .await;
 
                 // Interactive-notification responses — act on the user's answers
                 // (snooze re-enqueues an hour out). Idempotent end-to-end, so the

--- a/src/notices.rs
+++ b/src/notices.rs
@@ -190,6 +190,47 @@ pub async fn clear_typed_on(
     Ok(result.rows_affected() > 0)
 }
 
+/// This notice's id — shared with its own `event_key` (see [`raise_typed`]'s doc on that
+/// pairing), so both this module and any other caller name it identically.
+pub const GROQ_DEPRECATED: &str = "llm.groq_deprecated";
+
+/// Raise or clear [`GROQ_DEPRECATED`] to match whether Groq is the currently active custom
+/// provider — the single source of truth for this banner's condition, called from TWO
+/// places that must never answer differently:
+///
+/// - the daemon's poll tick (`main.rs`), every ~60 s, the steady-state driver;
+/// - the tray's `update_settings` command, the INSTANT `llm_provider`/`llm_provider_custom_id`
+///   changes — mirroring `push_health_update`'s existing "don't make a fresh pick wait out
+///   the poll interval" fix for `llm_provider_ok`. Before this existed, switching away from
+///   Groq left the banner up for up to a minute after the fix had already taken effect,
+///   which reads as "did that actually work?" at the exact moment a user is checking.
+///
+/// Idempotent either way (upsert / delete-if-present), so calling it from both places on the
+/// same transition is harmless — whichever call lands first does the work, the other is a
+/// no-op.
+pub async fn sync_groq_deprecated_notice(pool: &SqlitePool, active_vendor: Option<&str>) {
+    if active_vendor == Some("groq") {
+        let _ = raise_typed(
+            pool,
+            Notice {
+                id: GROQ_DEPRECATED,
+                severity: "error",
+                title: "Groq is disabled",
+                detail: "Groq's free tier can't reliably serve Meridian's \
+                    hourly summaries, so Meridian no longer sends it any \
+                    requests. Hourly summaries are paused until you switch \
+                    providers.",
+                remedy: Some("Add a free Ollama key in Settings - Intelligence to resume."),
+                event_key: GROQ_DEPRECATED,
+                deep_link: Some(meridian_core::notifications::deep_links::INTELLIGENCE),
+            },
+        )
+        .await;
+    } else {
+        let _ = clear_typed(pool, GROQ_DEPRECATED, GROQ_DEPRECATED).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -304,6 +345,43 @@ mod tests {
             banner.deep_link.as_deref(),
             Some(meridian_core::notifications::deep_links::INTELLIGENCE)
         );
+    }
+
+    /// THE function two different processes (the daemon's poll tick and the tray's
+    /// `update_settings`) both call and must agree on. Exercises both directions plus the
+    /// idempotent double-call each caller relies on (the daemon re-syncs every tick; the tray
+    /// syncs once on a settings write — either could run twice for the same state).
+    #[tokio::test]
+    async fn sync_groq_deprecated_notice_raises_for_groq_and_clears_for_everything_else() {
+        let pool = fresh_db().await;
+
+        sync_groq_deprecated_notice(&pool, Some("groq")).await;
+        let notices = meridian_core::notices::read_notices(&pool).await;
+        assert!(notices.iter().any(|n| n.notice_id == GROQ_DEPRECATED));
+
+        // Re-syncing the SAME state (the daemon's next tick, or a redundant tray call) must
+        // not error or duplicate the row.
+        sync_groq_deprecated_notice(&pool, Some("groq")).await;
+        let notices = meridian_core::notices::read_notices(&pool).await;
+        assert_eq!(
+            notices
+                .iter()
+                .filter(|n| n.notice_id == GROQ_DEPRECATED)
+                .count(),
+            1
+        );
+
+        // Switching to Ollama (or any other vendor) clears it immediately - no dependence on
+        // a poll interval.
+        sync_groq_deprecated_notice(&pool, Some("ollama")).await;
+        let notices = meridian_core::notices::read_notices(&pool).await;
+        assert!(!notices.iter().any(|n| n.notice_id == GROQ_DEPRECATED));
+
+        // `None` (a CLI provider, or nothing configured) clears it too.
+        sync_groq_deprecated_notice(&pool, Some("groq")).await;
+        sync_groq_deprecated_notice(&pool, None).await;
+        let notices = meridian_core::notices::read_notices(&pool).await;
+        assert!(!notices.iter().any(|n| n.notice_id == GROQ_DEPRECATED));
     }
 
     /// The test above only checks `system_notices` — it would pass even if

--- a/tray/src-tauri/src/commands/notices.rs
+++ b/tray/src-tauri/src/commands/notices.rs
@@ -18,7 +18,7 @@
 //!   ([`meridian_core::notices::read_notices`] / [`meridian_core::notices::delete_notice`]).
 //! - [`crate::poll`] — emits the `notices-update` event off the same read.
 
-use tauri::State;
+use tauri::{Emitter, State};
 
 /// The live notice set (the ported /api/notices/stream snapshot). No open DB →
 /// empty (matches the route's `catch → []`), so the banner just shows nothing.
@@ -49,4 +49,24 @@ pub async fn delete_notice(
     meridian_core::notices::delete_notice(pool, &notice_id)
         .await
         .map_err(|e| crate::cmd_err!(e, notice_id, "delete_notice failed"))
+}
+
+/// Push a fresh `notices-update` NOW, unconditionally — the on-demand counterpart to
+/// `crate::commands::health::push_health_update`, for the same reason: `poll::live::emit_notices`
+/// only runs on the tray's own 30 s tick and only when its dedup snapshot changed, so a banner
+/// this process just raised/cleared directly (see `update_settings`'s Groq sync) would
+/// otherwise sit unrefreshed in the webview for up to another 30 s. Unlike `emit_notices` this
+/// never checks a `last`-snapshot cache — it is called rarely (a settings write), never from
+/// the hot poll loop, so an occasional duplicate identical push costs nothing.
+///
+/// Placed LAST in this file, not between two `#[tauri::command]`s: this has no `-> ReturnType`
+/// (a plain `()` return), and `__tests__/mutate-body-contract.test.ts` parses this file's
+/// commands with a regex that lazily scans for the next `) ->` — sitting between two commands
+/// it would swallow the SECOND one's signature whole, exactly the failure mode
+/// `push_health_update` (the same no-arrow shape) avoids by being last in `health.rs` too.
+pub async fn push_notices_update(app: &tauri::AppHandle, pool: &meridian_core::SqlitePool) {
+    let notices = meridian_core::notices::read_notices(pool).await;
+    if let Err(e) = app.emit("notices-update", &notices) {
+        tracing::warn!(error = %e, "notices update emit failed - banner stays stale until the next poll tick");
+    }
 }

--- a/tray/src-tauri/src/commands/settings.rs
+++ b/tray/src-tauri/src/commands/settings.rs
@@ -115,9 +115,6 @@ pub async fn update_settings(
     app_state: State<'_, Arc<Mutex<AppState>>>,
     body: Value,
 ) -> Result<Value, String> {
-    // `pool` is unused (settings live in a file, not the DB) but kept in the
-    // signature for a uniform command shape; touch it so it isn't a dead param.
-    let _ = pool;
     let Some(body_obj) = body.as_object() else {
         return Err("settings body must be an object".to_string());
     };
@@ -210,6 +207,18 @@ pub async fn update_settings(
     // provider health alone and shouldn't pay for a health check.
     if body_obj.contains_key("llm_provider") || body_obj.contains_key("llm_provider_custom_id") {
         crate::commands::health::push_health_update(&app).await;
+
+        // Same fix, for the SAME reason, applied to `llm.groq_deprecated` - the daemon's poll
+        // tick (`main.rs`) calls the identical `sync_groq_deprecated_notice`, so switching
+        // away from Groq here and there converge on the same answer; this just stops the
+        // banner from sitting stale for up to a minute after the switch already took effect.
+        if let Some(p) = pool.as_ref() {
+            let vendor = meridian_core::settings::load_runtime_settings()
+                .active_custom_provider()
+                .map(|c| c.vendor.clone());
+            meridian::notices::sync_groq_deprecated_notice(p, vendor.as_deref()).await;
+            crate::commands::notices::push_notices_update(&app, p).await;
+        }
     }
 
     redact_password(&mut updated);


### PR DESCRIPTION
## Summary
Follow-up to #824 - user reported that after adding an Ollama key (switching away from Groq), the "Groq is disabled" banner didn't clear immediately.

Root cause: `sync_groq_deprecated_notice` was only ever called from the daemon's poll tick (~60s cadence), so switching providers left the banner up for up to a minute after the switch had already taken effect - the exact "is that bad code?" moment a user notices.

`update_settings` already has this exact fix for `llm_provider_ok` (`push_health_update`, called the instant `llm_provider`/`llm_provider_custom_id` changes - added for the identical reason, per its own comment). This applies the same pattern to the Groq notice:

- Extracted the raise/clear logic into `notices::sync_groq_deprecated_notice`, called by both the daemon's poll tick (steady-state) and the tray's `update_settings` (instant, on the actual write).
- Added `push_notices_update` (tray), mirroring `push_health_update` - reads `system_notices` and emits a fresh `notices-update` event unconditionally, bypassing the tray's own 30s dedup-based poll tick.
- Both are idempotent, so calling the sync from two processes on the same transition is harmless (whichever lands first does the work).

One gotcha caught by CI: a no-return-arrow helper (`push_notices_update`) placed between two `#[tauri::command]`s broke `mutate-body-contract.test.ts`'s regex-based Rust scanner (it lazily hunts for the next `) ->` and swallows the following command's signature whole). `push_health_update` has the identical shape and avoids this by being the last function in its file - moved `push_notices_update` to match.

## Test plan
- [x] New Rust test `sync_groq_deprecated_notice_raises_for_groq_and_clears_for_everything_else` - both directions, plus idempotent double-calls
- [x] `cargo fmt --all -- --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` (1012 tests)
- [x] `cd ui && bun test` (893 tests, including the previously-broken `mutate-body-contract.test.ts`)
- [x] `git push` pre-push gate (fmt, clippy, ui build/tests, security audit, cargo test) all green