### PR TITLE
fix(release): address CodeRabbit's review of #820's Ollama/Groq work (round 5)

### DIFF
--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -538,6 +538,23 @@ pub struct ProviderTestResult {
 /// failed once could never be re-tested, so the failure that closed the gate would also be
 /// the thing preventing it from ever reopening. It would look like a provider that can
 /// never be reconnected, with a Test button that fails instantly for no visible reason.
+/// Whether testing `provider` must refuse outright because it resolves to the discontinued
+/// Groq endpoint — pulled out of [`test_provider`] as a pure fn so this is unit-testable
+/// without spawning a real CLI.
+///
+/// Gated on `provider == Custom`: `settings.active_custom_provider()` reads the GLOBALLY
+/// selected endpoint, not the one `provider` names. [`super::resolver::complete_inner`] gets
+/// away with the same lookup because it only ever tests the currently-selected provider, but
+/// this fn is parameterized so the UI can test any tile regardless of what's active - without
+/// this guard, testing Claude/Codex/Cursor/Copilot while a Groq endpoint happened to be the
+/// active provider would incorrectly refuse THAT test too.
+fn groq_refusal_for(provider: LlmProvider, settings: &RuntimeSettings) -> Option<LlmError> {
+    if provider != LlmProvider::Custom {
+        return None;
+    }
+    super::resolver::groq_blocked(settings.active_custom_provider().map(|c| c.vendor.as_str()))
+}
+
 pub async fn test_provider(
     provider: LlmProvider,
     settings: &RuntimeSettings,
@@ -558,9 +575,7 @@ pub async fn test_provider(
     // Connection" must never report Groq healthy while the production funnel silently
     // refuses every call to it; that contradiction is exactly what let a stale verdict from
     // one code path outlive the truth in the other.
-    if let Some(refusal) =
-        super::resolver::groq_blocked(settings.active_custom_provider().map(|c| c.vendor.as_str()))
-    {
+    if let Some(refusal) = groq_refusal_for(provider, settings) {
         return finish_test(id, classify_test_outcome(Err(refusal)), t0);
     }
 
@@ -1786,6 +1801,65 @@ fn path_candidate_names(bin: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn groq_custom_provider() -> meridian_core::settings::CustomLlmProvider {
+        meridian_core::settings::CustomLlmProvider {
+            id: "groq1".to_string(),
+            vendor: "groq".to_string(),
+            name: "My Groq endpoint".to_string(),
+            base_url: "https://api.groq.com/openai/v1".to_string(),
+            model: "openai/gpt-oss-120b".to_string(),
+            api_key: "gsk-test".to_string(),
+            rpm: 0,
+            rpd: 0,
+            rungs: Default::default(),
+        }
+    }
+
+    fn settings_with_active_groq() -> RuntimeSettings {
+        RuntimeSettings {
+            llm_provider: "custom".to_string(),
+            llm_provider_custom_id: Some("groq1".to_string()),
+            custom_llm_providers: vec![groq_custom_provider()],
+            ..Default::default()
+        }
+    }
+
+    /// The bug this fn exists to fix: testing the Custom tile while a Groq endpoint is the
+    /// active custom provider must refuse.
+    #[test]
+    fn testing_the_custom_tile_refuses_when_groq_is_active() {
+        let settings = settings_with_active_groq();
+        assert!(groq_refusal_for(LlmProvider::Custom, &settings).is_some());
+    }
+
+    /// The regression itself: testing a DIFFERENT provider's tile while Groq happens to be
+    /// the globally active one must NOT be refused - `settings.active_custom_provider()`
+    /// reads the global selection, not the provider actually under test.
+    #[test]
+    fn testing_a_different_provider_is_unaffected_by_an_active_groq_endpoint() {
+        let settings = settings_with_active_groq();
+        for p in [
+            LlmProvider::Claude,
+            LlmProvider::Codex,
+            LlmProvider::Cursor,
+            LlmProvider::Copilot,
+        ] {
+            assert!(
+                groq_refusal_for(p, &settings).is_none(),
+                "{p:?} must not be refused just because Groq is the active provider"
+            );
+        }
+    }
+
+    /// A Custom tile that ISN'T Groq (e.g. Ollama, or any other preset) must never be
+    /// refused - the block is Groq-specific, not "every custom endpoint".
+    #[test]
+    fn a_non_groq_custom_endpoint_is_never_refused() {
+        let mut settings = settings_with_active_groq();
+        settings.custom_llm_providers[0].vendor = "ollama".to_string();
+        assert!(groq_refusal_for(LlmProvider::Custom, &settings).is_none());
+    }
 
     /// The load-bearing property: whatever `resolve_cli` hands back must be something
     /// `Command::new` can spawn WITHOUT relying on the caller's `PATH` — i.e. an absolute

--- a/src/llm/resolver.rs
+++ b/src/llm/resolver.rs
@@ -222,20 +222,26 @@ const HEALTH_PROBE_INTERVAL: Duration = Duration::from_secs(15 * 60);
 /// (new PATH, fresh credentials, a CLI installed while the daemon was down).
 static LAST_HEALTH_PROBE: Mutex<Option<BTreeMap<String, Instant>>> = Mutex::new(None);
 
-/// Whether `provider` may spend one call re-checking a refusal, stamping the attempt if so.
+/// Whether the backend identified by `key` may spend one call re-checking a refusal,
+/// stamping the attempt if so.
+///
+/// Takes the same [`provider_key`] identity every other per-backend map in this file keys
+/// on, NOT a bare [`LlmProvider`] - see that fn's doc for why: two custom endpoints (e.g.
+/// Groq and Ollama, both `LlmProvider::Custom`) would otherwise share one probe allowance,
+/// so re-checking one endpoint's refusal could silently spend the other's exemption.
 ///
 /// Check and stamp are one operation under one lock on purpose: several pipeline stages can
 /// reach the gate concurrently on the same tick, and a check that did not immediately record
 /// the grant would let all of them through together - turning "one call per interval" into a
 /// small burst against a provider already believed to be failing.
-fn health_probe_is_due(provider: LlmProvider) -> bool {
+fn health_probe_is_due(key: &str) -> bool {
     let mut guard = LAST_HEALTH_PROBE.lock().unwrap_or_else(|e| e.into_inner());
     let map = guard.get_or_insert_with(BTreeMap::new);
     let now = Instant::now();
-    match map.get(provider.as_str()) {
+    match map.get(key) {
         Some(last) if now.duration_since(*last) < HEALTH_PROBE_INTERVAL => false,
         _ => {
-            map.insert(provider.as_str().to_string(), now);
+            map.insert(key.to_string(), now);
             true
         }
     }
@@ -488,7 +494,7 @@ async fn complete_inner(req: &PromptRequest) -> Result<(LlmOutput, LlmProvider),
     let health = super::detect::in_use_provider_health(&s).await;
     let mut probing = false;
     if let Some(refusal) = health_refusal(&health) {
-        if !(health.probeable && health_probe_is_due(chosen)) {
+        if !(health.probeable && health_probe_is_due(&key)) {
             tracing::warn!(
                 provider = chosen.as_str(),
                 label = %req.label,
@@ -715,11 +721,17 @@ mod tests {
     /// than merely long, and nothing tells the user any of it.
     #[test]
     fn a_refused_provider_earns_one_probe_per_interval() {
+        // `LAST_HEALTH_PROBE` is process-global, like the backoff map -
+        // `two_custom_endpoints_earn_independent_probe_allowances` also calls
+        // `clear_health_probes()`, and without this lock the two can interleave and wipe
+        // each other's in-progress state. See `a_backoff_on_one_provider_does_not_stall_another`'s
+        // comment for the same race on the sibling map.
+        let _lock = crate::test_env::lock_settings_env();
         clear_health_probes();
 
         // First refusal after the interval: one call goes through to re-check.
         assert!(
-            health_probe_is_due(LlmProvider::Claude),
+            health_probe_is_due(&provider_key(LlmProvider::Claude, None)),
             "a refused provider must get a chance to prove the verdict wrong"
         );
 
@@ -729,15 +741,42 @@ mod tests {
         // believed to be broken once per stage.
         for _ in 0..5 {
             assert!(
-                !health_probe_is_due(LlmProvider::Claude),
+                !health_probe_is_due(&provider_key(LlmProvider::Claude, None)),
                 "only ONE call per interval may pass the gate"
             );
         }
 
         // Per provider, not global: a broken Claude must not consume Codex's probe.
         assert!(
-            health_probe_is_due(LlmProvider::Codex),
+            health_probe_is_due(&provider_key(LlmProvider::Codex, None)),
             "the allowance is keyed per provider"
+        );
+    }
+
+    /// The whole point of keying on `provider_key` rather than the bare `LlmProvider`: two
+    /// distinct custom endpoints (both `LlmProvider::Custom`) must earn independent probe
+    /// allowances, exactly like the health/test-cache contamination bug this mirrors (see
+    /// `provider_key`'s own doc).
+    #[test]
+    fn two_custom_endpoints_earn_independent_probe_allowances() {
+        // See `a_refused_provider_earns_one_probe_per_interval`'s comment - same
+        // process-global map, same need to serialize against it.
+        let _lock = crate::test_env::lock_settings_env();
+        clear_health_probes();
+        let groq = provider_key(LlmProvider::Custom, Some("groq-endpoint"));
+        let ollama = provider_key(LlmProvider::Custom, Some("ollama-endpoint"));
+
+        assert!(
+            health_probe_is_due(&groq),
+            "the first custom endpoint gets its probe"
+        );
+        assert!(
+            !health_probe_is_due(&groq),
+            "that SAME endpoint is exempt again within the interval"
+        );
+        assert!(
+            health_probe_is_due(&ollama),
+            "a DIFFERENT custom endpoint must not have spent its allowance too"
         );
     }
 

--- a/src/notices.rs
+++ b/src/notices.rs
@@ -208,9 +208,10 @@ pub const GROQ_DEPRECATED: &str = "llm.groq_deprecated";
 /// Idempotent either way (upsert / delete-if-present), so calling it from both places on the
 /// same transition is harmless — whichever call lands first does the work, the other is a
 /// no-op.
+#[tracing::instrument(skip(pool))]
 pub async fn sync_groq_deprecated_notice(pool: &SqlitePool, active_vendor: Option<&str>) {
     if active_vendor == Some("groq") {
-        let _ = raise_typed(
+        if let Err(e) = raise_typed(
             pool,
             Notice {
                 id: GROQ_DEPRECATED,
@@ -225,9 +226,20 @@ pub async fn sync_groq_deprecated_notice(pool: &SqlitePool, active_vendor: Optio
                 deep_link: Some(meridian_core::notifications::deep_links::INTELLIGENCE),
             },
         )
-        .await;
-    } else {
-        let _ = clear_typed(pool, GROQ_DEPRECATED, GROQ_DEPRECATED).await;
+        .await
+        {
+            tracing::warn!(
+                error = %crate::errors::chain(&e),
+                active_vendor,
+                "notices: failed to raise the Groq-deprecated notice"
+            );
+        }
+    } else if let Err(e) = clear_typed(pool, GROQ_DEPRECATED, GROQ_DEPRECATED).await {
+        tracing::warn!(
+            error = %crate::errors::chain(&e),
+            active_vendor,
+            "notices: failed to clear the Groq-deprecated notice"
+        );
     }
 }
 

--- a/tray/src-tauri/resources/whats-new.json
+++ b/tray/src-tauri/resources/whats-new.json
@@ -15,7 +15,8 @@
         "Several worklog drafts falling behind in the same hour now arrive as one notification instead of landing all at once.",
         "Drafting stopped failing with a hidden schema error on some custom AI endpoints.",
         "Coding-agent session summaries no longer silently fail to generate on some setups.",
-        "A database repair that fails on launch now retries automatically within the same session instead of leaving Meridian stuck until you relaunch."
+        "A database repair that fails on launch now retries automatically within the same session instead of leaving Meridian stuck until you relaunch.",
+        "Testing a specific AI provider's connection is more reliable when you have more than one free-tier key configured - it could fail outright, or show one endpoint's result on another's card."
       ]
     },
     {

--- a/tray/src-tauri/src/commands/setup.rs
+++ b/tray/src-tauri/src/commands/setup.rs
@@ -448,6 +448,28 @@ pub async fn detect_llm_providers() -> Result<Vec<meridian::llm::detect::Provide
     Ok(found)
 }
 
+/// Parse `test_llm_provider`'s `id` argument: either a bare wire name ("claude", "custom",
+/// …) or a specific custom endpoint's variant id (`ui/lib/llm-providers.ts::customVariantId`,
+/// `"custom:<id>"`) - the picker addresses one tile per configured endpoint, not one shared
+/// "custom" tile, so [`meridian_core::LlmProvider::from_wire`] alone (which only knows the
+/// bare wire names) rejects the variant form outright with "unknown provider". Pulled out of
+/// the command as a pure fn so the parsing is unit-testable without a `tauri::AppHandle`.
+fn parse_test_provider_id(
+    id: &str,
+) -> Result<(meridian_core::LlmProvider, Option<String>), String> {
+    match id.split_once(':') {
+        Some(("custom", endpoint_id)) if !endpoint_id.is_empty() => Ok((
+            meridian_core::LlmProvider::Custom,
+            Some(endpoint_id.to_string()),
+        )),
+        _ => Ok((
+            meridian_core::LlmProvider::from_wire(id)
+                .ok_or_else(|| format!("unknown provider {id:?}"))?,
+            None,
+        )),
+    }
+}
+
 /// Run one real, trivial call against `id`'s CLI and report + persist what happened - the
 /// Intelligence panel's per-card "Test" button. Spends one real request against the user's
 /// subscription, so this only ever runs on explicit user action, never automatically.
@@ -457,9 +479,16 @@ pub async fn test_llm_provider(
     app: tauri::AppHandle,
     id: String,
 ) -> Result<meridian::llm::detect::ProviderTestResult, String> {
-    let provider = meridian_core::LlmProvider::from_wire(&id)
-        .ok_or_else(|| format!("unknown provider {id:?}"))?;
-    let settings = meridian_core::settings::load_runtime_settings();
+    let (provider, custom_id) = parse_test_provider_id(&id)?;
+    let mut settings = meridian_core::settings::load_runtime_settings();
+    // `test_provider` reads the endpoint to test from `settings.active_custom_provider()`,
+    // which only ever resolves the GLOBALLY selected endpoint - so testing a non-active
+    // endpoint's tile means overriding the selection on this throwaway copy before calling
+    // it, not touching what's actually persisted or globally active.
+    if let Some(custom_id) = custom_id {
+        settings.llm_provider = "custom".to_string();
+        settings.llm_provider_custom_id = Some(custom_id);
+    }
     let result = meridian::llm::detect::test_provider(provider, &settings).await;
     meridian::llm::detect::persist_test_result(&result);
     tracing::info!(
@@ -668,7 +697,7 @@ pub async fn test_all_llm_providers(
 #[cfg(test)]
 mod tests {
     use super::{
-        log_install_outcome, log_signin_outcome, notification_state_label,
+        log_install_outcome, log_signin_outcome, notification_state_label, parse_test_provider_id,
         write_completion_markers, WALKTHROUGH_MARKER,
     };
     use crate::commands::whats_new::has_unseen_release_notes;
@@ -676,6 +705,40 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use tauri_plugin_notifications::PermissionState;
     use tracing_subscriber::{layer::SubscriberExt, registry, Layer};
+
+    /// The bug this fn exists to fix: the picker addresses a specific custom endpoint as
+    /// `"custom:<id>"` (`ui/lib/llm-providers.ts::customVariantId`), which bare
+    /// `LlmProvider::from_wire` rejects outright.
+    #[test]
+    fn a_custom_variant_id_parses_into_custom_plus_its_endpoint_id() {
+        let (provider, custom_id) = parse_test_provider_id("custom:groq1").unwrap();
+        assert_eq!(provider, meridian_core::LlmProvider::Custom);
+        assert_eq!(custom_id, Some("groq1".to_string()));
+    }
+
+    #[test]
+    fn bare_wire_names_still_parse_with_no_endpoint_id() {
+        let (provider, custom_id) = parse_test_provider_id("claude").unwrap();
+        assert_eq!(provider, meridian_core::LlmProvider::Claude);
+        assert_eq!(custom_id, None);
+
+        let (provider, custom_id) = parse_test_provider_id("custom").unwrap();
+        assert_eq!(provider, meridian_core::LlmProvider::Custom);
+        assert_eq!(custom_id, None);
+    }
+
+    #[test]
+    fn an_unknown_provider_name_is_rejected() {
+        assert!(parse_test_provider_id("groq").is_err());
+        assert!(parse_test_provider_id("").is_err());
+    }
+
+    /// `"custom:"` with an empty id names no endpoint - must fail loudly rather than
+    /// silently falling back to whatever happens to be globally active.
+    #[test]
+    fn a_custom_variant_with_an_empty_endpoint_id_is_rejected() {
+        assert!(parse_test_provider_id("custom:").is_err());
+    }
 
     // A fresh install has no `last_seen_version`, and `has_unseen_release_notes`
     // reads a missing marker as "unseen" (`Err(_) => true`) — correct for an

--- a/ui/__tests__/llm-provider-connection-phase.test.ts
+++ b/ui/__tests__/llm-provider-connection-phase.test.ts
@@ -326,7 +326,11 @@ describe('the chooser grid', () => {
     // one vendor, so configuring Groq made Ollama disappear entirely - exactly the confusion
     // a real user hit. Each preset (Groq, Ollama, ...) gets a tile of its own, the same way
     // Claude/Codex/Cursor do.
-    expect(picker).toContain('CLOUD_PRESETS.map((preset) => (')
+    // `gridPresets`, NOT `CLOUD_PRESETS` - the grid also carries an already-configured
+    // vendor that has since stopped being offered (Groq, today), so asserting the wrong
+    // one here would pass by coincidence off `CLOUD_PRESETS.map` appearing elsewhere in
+    // the file (`CloudPresetChooser`'s own grid) rather than actually checking this one.
+    expect(picker).toContain('gridPresets.map((preset) => (')
     expect(picker).toContain('<CloudPresetTile')
     // Clicking a preset's OWN tile already answers which vendor - no chooser in between.
     expect(picker).toContain('vendorRows.length === 0')
@@ -498,7 +502,13 @@ describe('every surface reads the same ladder', () => {
   it('the cloud endpoint is judged like every other provider, not by being selected', () => {
     // `value === 'custom'` may decide what is SELECTED. It may never decide what is LIVE.
     expect(picker).toContain('const phase = selected')
-    expect(picker).toContain('const vendorPhase = selectedRow')
+    // Both call sites share `vendorPhaseFor` - inside it, `phase` depends only on
+    // `selectedRow`, never on `value`, so the two can never disagree.
+    expect(picker).toContain('function vendorPhaseFor(')
+    expect(picker).toContain('const phase = selectedRow')
+    expect(picker).toContain(
+      'phase: vendorPhase } = vendorPhaseFor(vendorRows, selectedCustomId ?? null, status)',
+    )
     expect(picker).toContain('live={!TILE_NOT_LIVE.includes(vendorPhase.kind)}')
     // …and the endpoint card takes that verdict rather than re-deriving one.
     expect(providers).toContain('live: boolean')

--- a/ui/__tests__/llm-provider-gate.test.ts
+++ b/ui/__tests__/llm-provider-gate.test.ts
@@ -71,13 +71,24 @@ describe('the picker routes on the answer', () => {
     expect(picker).toContain("gate ? null : 'subscription'")
   })
 
-  it('sends the free answer to a preset chooser, not straight to one vendor', () => {
-    // With two curated presets, "which free key" is a real question - unlike the old
-    // single-preset days, where a chooser containing one tile would have asked the user to
-    // confirm an answer they had just given.
+  it('sends the free answer straight to the one offered preset, not a chooser of one', () => {
+    // CLOUD_PRESETS is down to one entry (Ollama, since Groq's removal) - a chooser
+    // containing a single tile would be asking the user to confirm an answer they just
+    // gave. The length===1 branch must render CloudKeySetup directly with that one preset.
     expect(picker).toContain("gateAnswer === 'free'")
+    expect(picker).toContain('if (CLOUD_PRESETS.length === 1)')
+    const singlePresetBranch = picker.slice(
+      picker.indexOf('if (CLOUD_PRESETS.length === 1)'),
+      picker.indexOf('return <CloudPresetChooser'),
+    )
+    expect(singlePresetBranch).toContain('<CloudKeySetup')
+    expect(singlePresetBranch).toContain('preset={CLOUD_PRESETS[0]}')
+  })
+
+  it('falls back to a chooser the moment a second preset is offered again', () => {
+    // Nothing here assumes exactly one or exactly two - the chooser still exists as the
+    // fallthrough for whenever CLOUD_PRESETS grows past one again.
     expect(picker).toContain('<CloudPresetChooser')
-    expect(picker).toContain('<CloudKeySetup')
   })
 
   it('hides the bring-your-own tile under the gate', () => {

--- a/ui/components/LlmProviderPicker.tsx
+++ b/ui/components/LlmProviderPicker.tsx
@@ -188,6 +188,28 @@ function ChooserTile({ id, name, rank, selected, subtitle, phase, action, logo, 
   )
 }
 
+/** The selected row (if any) among ONE vendor's own custom-provider rows, and the status
+ *  ladder phase that follows from it. Shared by `CloudPresetTile`'s own tile and the
+ *  opened-detail view below so they can never disagree - two call sites deriving this
+ *  separately is how they used to: the tile said NOT CONNECTED while the card behind it said
+ *  "In use". Reads `status[customVariantId(selectedRow.id)]`, NOT `status.custom` - the Rust
+ *  side files the active endpoint's test/health under its OWN id (`provider_key`) precisely
+ *  because the bare `"custom"` bucket is shared by every configured endpoint: reading it
+ *  directly is what let a real user see Groq's stale rate-limit message rendered on Ollama's
+ *  tile after switching to it. */
+function vendorPhaseFor(
+  rows: CustomProviderView[],
+  selectedCustomId: string | null,
+  status: Record<string, ProviderStatus>,
+) {
+  const selectedRow = rows.find((p) => p.id === selectedCustomId)
+  const activeStatus = selectedRow ? status[customVariantId(selectedRow.id)] : undefined
+  const phase = selectedRow
+    ? phaseFor(false, false, false, activeStatus, activeStatus?.last_test ?? null)
+    : phaseFor(false, false, false, undefined, null)
+  return { selectedRow, phase }
+}
+
 /** One no-subscription preset's OWN tile in the top-level grid - Groq's, or Ollama's, never
  *  a tile shared between them.
  *
@@ -212,12 +234,11 @@ function CloudPresetTile({ preset, value, selectedCustomId, status, custom, onOp
   // these tiles from `gridPresets`, which IS `CLOUD_PRESETS` (see its own comment on why a
   // discontinued vendor like Groq no longer gets a tile at all rather than a "blocked" one).
   const rows = custom.providers.filter((p) => p.vendor === preset.vendor)
-  const selectedRow = rows.find((p) => p.id === selectedCustomId)
+  const { selectedRow, phase: computedPhase } = vendorPhaseFor(rows, selectedCustomId, status)
   const selected = value === 'custom' && !!selectedRow
-  const activeStatus = selectedRow ? status[customVariantId(selectedRow.id)] : undefined
-  const phase = selected
-    ? phaseFor(false, false, false, activeStatus, activeStatus?.last_test ?? null)
-    : phaseFor(false, false, false, undefined, null)
+  // Only a SELECTED row's status ladder answers - an unselected vendor's tile shows the same
+  // untested-neutral phase an unselected CLI tile shows, never borrowed from `selectedRow`.
+  const phase = selected ? computedPhase : phaseFor(false, false, false, undefined, null)
   return (
     <ChooserTile
       id="custom"
@@ -417,16 +438,13 @@ export default function LlmProviderPicker({
         />
       )
     }
-    // Whether the SELECTED row (if any) among this vendor's own rows is answering. Two call
-    // sites deriving this separately is how they used to disagree - the tile said NOT
-    // CONNECTED while the card behind it said "In use". Reads the row's OWN key
-    // (`customVariantId`), not `status.custom` - see `CloudPresetTile`'s comment on why
-    // that shared bucket is wrong the moment more than one endpoint exists.
-    const selectedRow = vendorRows.find((p) => p.id === selectedCustomId)
-    const activeStatus = selectedRow ? status[customVariantId(selectedRow.id)] : undefined
-    const vendorPhase = selectedRow
-      ? phaseFor(false, false, false, activeStatus, activeStatus?.last_test ?? null)
-      : phaseFor(false, false, false, undefined, null)
+    // Whether the SELECTED row (if any) among this vendor's own rows is answering. Shared
+    // with `CloudPresetTile` via `vendorPhaseFor` - two call sites deriving this separately
+    // is how they used to disagree, the tile said NOT CONNECTED while the card behind it
+    // said "In use". Reads the row's OWN key (`customVariantId`), not `status.custom` - see
+    // `vendorPhaseFor`'s comment on why that shared bucket is wrong the moment more than one
+    // endpoint exists.
+    const { selectedRow, phase: vendorPhase } = vendorPhaseFor(vendorRows, selectedCustomId ?? null, status)
     return (
       <CustomDetail
         preset={preset}
@@ -701,10 +719,12 @@ function CustomDetail({
   )
 }
 
-/** The chooser between the curated no-subscription presets (Groq, Ollama) - shown ONLY on the
- *  gate's "free" answer, where there is no tile yet to have already named the vendor. Settings
- *  never reaches this: Groq and Ollama each have their own tile there (`CloudPresetTile`), so
- *  clicking one already answers "which vendor" and skips straight to its wizard or registry.
+/** The chooser between the curated no-subscription presets in `CLOUD_PRESETS` - shown ONLY on
+ *  the gate's "free" answer, where there is no tile yet to have already named the vendor, and
+ *  only when there are two or more presets to choose from (`CLOUD_PRESETS.length === 1` skips
+ *  straight to `CloudKeySetup` instead - see the caller). Settings never reaches this: each
+ *  preset has its own tile there (`CloudPresetTile`), so clicking one already answers "which
+ *  vendor" and skips straight to its wizard or registry.
  *
  *  A dedicated small chooser rather than reusing `<ChooserTile>`: that component is built
  *  around a SELECTED `LlmProviderId`'s live status (IN USE / NOT CONNECTED, a `Phase`) and
@@ -722,7 +742,7 @@ function CloudPresetChooser({ onBack, onPick }: {
           Choose a free provider
         </h2>
         <p style={{ fontSize: 12, lineHeight: 1.5, color: 'var(--t-muted)', marginTop: 5 }}>
-          Both are free, no card required. Meridian sets either one up from a single pasted key.
+          All free, no card required. Meridian sets any of them up from a single pasted key.
         </p>
       </div>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 11 }}>

--- a/ui/components/ui/BackLink.tsx
+++ b/ui/components/ui/BackLink.tsx
@@ -16,8 +16,9 @@
 // louder should use a real button rather than widening this.
 //
 // # Who calls this
-// `LlmProviderPicker` (three times: the gate's "I don't have one", the detail view, and the
-// no-subscription preset chooser), `LlmProviderDetail`, `CloudKeySetup`.
+// `LlmProviderPicker` (four times: the gate's "I don't have one", the opened-vendor detail
+// view, the no-subscription preset chooser, and the unknown-vendor fallback - a vendor string
+// this build has no display data for), `LlmProviderDetail`, `CloudKeySetup`.
 
 import type { ReactNode } from 'react'
 

--- a/ui/public/logos/README.md
+++ b/ui/public/logos/README.md
@@ -16,10 +16,10 @@ path data inline and fills each one from a theme variable holding that brand's o
 selected tile tint them with the Meridian accent: every logo came out violet, which defeats
 the entire point of showing a real logo.
 
-The two that need care are OpenAI and Cursor, whose marks **are** black. Both flip to white
-under the `ink` theme, which is what their own brand guidance says to do on a dark
-background - and is why the fill is a CSS variable rather than a hex baked into the file.
-An `<img>` pointed at these files could not be themed at all.
+The ones that need care are OpenAI, Cursor, and Ollama, whose marks **are** black. All three
+flip to white under the `ink` theme, which is what their own brand guidance says to do on a
+dark background - and is why the fill is a CSS variable rather than a hex baked into the
+file. An `<img>` pointed at these files could not be themed at all.
 
 The same path therefore exists in two places. `__tests__/provider-logos.test.ts` asserts the
 component's copy is byte-identical to the file here, and that every brand variable is


### PR DESCRIPTION
## Summary

A fresh CodeRabbit pass on #811 surfaced 10 findings in #820's Ollama/Groq feature code and its own follow-ups (#824, #825) — none of which the prior four rounds touched, since they're in code I hadn't reviewed before.

### Real bugs, confirmed and fixed

- **`src/llm/resolver.rs`** — `health_probe_is_due` keyed its per-backend probe allowance on the bare `LlmProvider`, not `provider_key` — so two custom endpoints (e.g. Groq and Ollama, both `LlmProvider::Custom`) shared one "one probe per 15 minutes" exemption instead of getting independent ones. The exact contamination bug class #820 itself fixed for health/test-cache reads, just missed here. Fixed the key, added a two-custom-endpoints regression test, and fixed a latent test race on the shared static (unguarded by `crate::test_env::lock_settings_env()`, same class as an already-documented race on a sibling map).
- **`src/llm/detect.rs`** — `test_provider`'s Groq refusal read `settings.active_custom_provider()` unconditionally, which resolves the GLOBALLY selected endpoint, not the provider argument actually being tested. So testing Claude/Codex/Cursor/Copilot's tile while a Groq endpoint happened to be globally active would incorrectly refuse THAT test too. Extracted `groq_refusal_for`, gated on `provider == Custom`, with regression tests for all four affected providers.
- **`tray/src-tauri/src/commands/setup.rs`** — `test_llm_provider` only ever parsed bare wire names, but the picker addresses a specific custom endpoint as `"custom:<id>"`. Testing any non-active custom endpoint's tile failed outright with "unknown provider". Added a parser plus an override on the throwaway settings copy's active endpoint, so `test_provider` tests the actually-requested endpoint.

### Also fixed, matching established conventions

- **`src/notices.rs`** — `sync_groq_deprecated_notice` discarded its DB write's `Result` silently; now logs with the established full-error-chain helper on failure.
- **`ui/components/LlmProviderPicker.tsx`** — extracted the vendor/phase derivation duplicated between two components into a shared `vendorPhaseFor` (two call sites computing it separately is exactly how they used to disagree). Reworded stale "Both are free" copy (`CLOUD_PRESETS` is down to one entry since Groq's removal) and a stale doc comment.
- **`ui/components/ui/BackLink.tsx`, `ui/public/logos/README.md`** — doc-accuracy fixes (BackLink is called 4 times, not 3; Ollama's mark needs the same dark-theme care as OpenAI/Cursor's, not just "the two").
- **Two UI tests** — fixed to check the actual current branching logic instead of passing by coincidence off a duplicated string or unverified source-text presence.

Also updated `whats-new.json`'s 1.89.0 fixes list with a plain-language bullet for the three backend fixes.

## Test plan
- [x] TDD: reverted each of the 3 backend fixes in turn, confirmed the new regression tests fail with a clear message; restored, confirmed green
- [x] `cargo test --workspace` — 1016 passed, 0 failed
- [x] `bun test` — 894 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `npm run typecheck` — clean
- [x] Pre-push hook (fmt + clippy + ui build/tests + security audit + `cargo test --workspace`) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)