### PR TITLE
fix(ui): derive discontinued-vendor recovery copy from CLOUD_PRESETS (round 6)

### DIFF
--- a/ui/components/LlmProviderPicker.tsx
+++ b/ui/components/LlmProviderPicker.tsx
@@ -582,7 +582,8 @@ export default function LlmProviderPicker({
       {usingHiddenCloud && activeRow && (
         <p style={{ fontSize: 11, lineHeight: 1.45, color: 'var(--color-state-pending)' }}>
           You&apos;re currently using {activeRow.name}, which is discontinued - Meridian isn&apos;t
-          sending it any requests. Add a free Ollama key above to resume summaries.
+          sending it any requests. Add a free {CLOUD_PRESETS.map((p) => p.name).join(' or ')} key
+          above to resume summaries.
         </p>
       )}
 


### PR DESCRIPTION
## Summary

Closes the last real gap from CodeRabbit's review of #811. Two things surfaced in the latest pass:

1. **`ui/components/LlmProviderPicker.tsx`** — round 5 fixed half of a consolidated finding (the "Both are free" copy) but left the sibling site: the Groq-discontinued banner's "Add a free Ollama key above to resume summaries" still hardcoded "Ollama" while every surrounding branch reads `CLOUD_PRESETS`. Harmless today (`CLOUD_PRESETS` is exactly `[OLLAMA]`, so the rendered text is byte-identical), but the same staleness risk as the sibling — the next change to the offered preset list makes this string wrong with nothing failing. Fixed by deriving the name(s) from `CLOUD_PRESETS`.
2. **`src/llm/resolver.rs:570`** — CodeRabbit re-flagged a finding whose description ("`test_all_installed` calls `test_provider` for each installed CLI provider... this branch returns the Groq refusal for Claude, Codex, Cursor, and Copilot") describes the exact bug round 5 already fixed in `src/llm/detect.rs` (`groq_refusal_for`, gated on `provider == Custom`). Verified against current `pre-main`: `test_provider` already uses the fixed helper, so `test_all_installed`'s loop is already safe. The line-number attribution (`resolver.rs:570`, where `groq_blocked` isn't even called) appears stale/mis-filed — no code change needed here, noted for the record.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `bun test` — 894 passed, 0 failed
- [x] Pre-push hook (fmt + clippy + ui build/tests + security audit + `cargo test --workspace`) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)