### PR TITLE
feat(onboarding): let a user ask for an unsupported PM tool

### DIFF
--- a/meridian-core/src/settings.rs
+++ b/meridian-core/src/settings.rs
@@ -355,6 +355,14 @@ pub struct RuntimeSettings {
     // falls back to the pre-existing per-machine hardware-UUID pseudonym.
     #[serde(default)]
     pub account_pseudonym: Option<String>,
+    // The free-text tool name a user typed into `ConnectTrackers`' "I don't
+    // see my tool" row (`tray/src-tauri/src/commands/pm_tool_request.rs`).
+    // Local mirror of the same value a `pm_tool_requested` PostHog event
+    // carries, kept here too so it survives even when product analytics is
+    // off (see [`Self::product_analytics_enabled`]). Last request wins — this
+    // is a demand signal, not a queue, so only the most recent ask matters.
+    #[serde(default)]
+    pub requested_pm_tool: Option<String>,
 }
 
 /// Default surface palette when `settings.json` predates the `theme` key. Must
@@ -423,6 +431,8 @@ impl Default for RuntimeSettings {
             worklog_auto_generate_prompted: false,
             // Signed out (or never signed in) until the tray says otherwise.
             account_pseudonym: None,
+            // Nobody has asked for an unsupported tool by default.
+            requested_pm_tool: None,
         }
     }
 }
@@ -821,6 +831,39 @@ mod tests {
             None,
             "and the resolver degrades it to the default"
         );
+
+        std::env::remove_var("MERIDIAN_SETTINGS_PATH");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `requested_pm_tool` defaults to `None` on a settings.json that predates
+    /// it, and round-trips through `read_settings_value`/`write_settings_value`
+    /// (the pattern `commands/pm_tool_request.rs` writes through) once set.
+    #[test]
+    fn requested_pm_tool_defaults_none_and_round_trips() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!(
+            "meridian-settings-pmtool-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+        with_settings_path(&path);
+
+        std::fs::write(&path, r#"{"log_level":"DEBUG"}"#).unwrap();
+        let s = load_runtime_settings();
+        assert_eq!(
+            s.requested_pm_tool, None,
+            "predates the field — must default"
+        );
+
+        let mut v = read_settings_value();
+        v["requested_pm_tool"] = json!("Shortcut");
+        write_settings_value(&v).unwrap();
+
+        let s = load_runtime_settings();
+        assert_eq!(s.requested_pm_tool, Some("Shortcut".to_string()));
 
         std::env::remove_var("MERIDIAN_SETTINGS_PATH");
         let _ = std::fs::remove_dir_all(&dir);

--- a/tray/src-tauri/src/analytics/mod.rs
+++ b/tray/src-tauri/src/analytics/mod.rs
@@ -205,7 +205,7 @@ fn posthog_api_key() -> String {
 /// an HTTP 2xx from PostHog; `false` on a missing API key, a request/timeout
 /// error, or a non-2xx response — in every `false` case the caller must
 /// retry, never silently drop the event.
-async fn capture(
+pub(crate) async fn capture(
     event: &str,
     distinct_id: &str,
     mut properties: serde_json::Map<String, serde_json::Value>,
@@ -262,7 +262,7 @@ async fn capture(
 /// (see the module doc). Callers only ever reach this after confirming an
 /// email is present, so identity itself never needs to be threaded through
 /// here.
-fn base_properties(
+pub(crate) fn base_properties(
     app: &tauri::AppHandle,
     device_id: &str,
 ) -> serde_json::Map<String, serde_json::Value> {
@@ -369,7 +369,7 @@ fn attach_person_properties(
 /// in Settings stops the next tick's events without a relaunch. Deliberately
 /// checks `product_analytics_enabled`, NOT `error_reporting_enabled` — see the
 /// module doc's "Consent" section.
-fn analytics_allowed() -> bool {
+pub(crate) fn analytics_allowed() -> bool {
     let killed = std::env::var("MERIDIAN_TELEMETRY_DISABLED")
         .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
     if killed {
@@ -521,5 +521,38 @@ pub(crate) async fn maybe_send_daily_tick(app: &tauri::AppHandle, pool: &SqliteP
 
     if dirty {
         save_state(&path, &state);
+    }
+}
+
+/// Fire a `pm_tool_requested` event for [`crate::commands::pm_tool_request::request_pm_tool`]
+/// — a user typed a PM tool into `ConnectTrackers`' "I don't see my tool" row.
+///
+/// Best-effort and fire-and-forget by design, unlike every other event in
+/// this module: there is no bookkeeping cursor to retry from (this is a
+/// one-off ad hoc action, not a per-day/per-install rollup), so a failed send
+/// is simply lost rather than retried next tick. That is an acceptable
+/// tradeoff for a secondary demand signal — the caller ALSO persists the same
+/// text into `settings.json` (`RuntimeSettings::requested_pm_tool`), which is
+/// what survives regardless of whether this event lands.
+pub(crate) async fn send_pm_tool_requested(app: &tauri::AppHandle, tool_name: &str) {
+    if !analytics_allowed() {
+        return;
+    }
+    let Some(email) = crate::commands::account::read_account_email() else {
+        // Not signed in — no identity to attach the event to (see the module
+        // doc's "No anonymous events, ever").
+        return;
+    };
+    let Some(path) = analytics_state_path() else {
+        return;
+    };
+    let device_id = load_or_init_state(&path).device_id;
+    let mut props = base_properties(app, &device_id);
+    props.insert(
+        "tool_name".to_string(),
+        serde_json::Value::String(tool_name.to_string()),
+    );
+    if capture("pm_tool_requested", &email, props).await {
+        tracing::info!(tool_name, "analytics: pm_tool_requested sent");
     }
 }

--- a/tray/src-tauri/src/commands.rs
+++ b/tray/src-tauri/src/commands.rs
@@ -20,6 +20,8 @@
 //! - [`notices`]   — clear a fault banner (`/api/notices/[id]` DELETE).
 //! - [`notifications`] — the in-app banner dismiss write.
 //! - [`parents`]   — valid parent tickets for the hygiene "link a parent" fix.
+//! - [`pm_tool_request`] — "I don't see my tool" on `ConnectTrackers`: local
+//!   settings mirror + a best-effort PostHog demand signal.
 //! - [`settings`]  — runtime settings read + write (`/api/settings` GET/PUT).
 //! - [`statuses`]  — ticket status list + set (spawns `meridian ticket-statuses`
 //!   / `ticket-set-status`) for the dashboard's status control.
@@ -53,6 +55,7 @@ pub mod notifications;
 pub mod parents;
 pub mod pause;
 pub mod plan_tasks;
+pub mod pm_tool_request;
 pub mod repair;
 pub mod settings;
 pub mod setup;
@@ -86,6 +89,7 @@ pub use notifications::*;
 pub use parents::*;
 pub use pause::*;
 pub use plan_tasks::*;
+pub use pm_tool_request::*;
 pub use settings::*;
 pub use setup::*;
 pub use statuses::*;

--- a/tray/src-tauri/src/commands/pm_tool_request.rs
+++ b/tray/src-tauri/src/commands/pm_tool_request.rs
@@ -1,0 +1,58 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! "I don't see my tool" — the escape hatch on `ConnectTrackers` for a PM tool
+//! outside the five Meridian supports today (Jira/Linear/GitHub/Trello/Azure
+//! DevOps, see `ui/lib/integrations.ts::TRACKERS`).
+//!
+//! Two independent, best-effort effects from one submit:
+//! - a local mirror in `settings.json`'s `RuntimeSettings::requested_pm_tool`
+//!   (survives even with product analytics off, and is what this command's
+//!   `Result` actually reports success/failure for);
+//! - a `pm_tool_requested` PostHog event via [`crate::analytics::send_pm_tool_requested`]
+//!   (aggregate cross-fleet demand — same consent gate as every other event in
+//!   [`crate::analytics`], silently skipped when signed out or opted out).
+//!
+//! # Who calls this
+//! `ui/components/IntegrationConnect.tsx`'s `ConnectTrackers`, via
+//! `ui/lib/bridge.ts`'s `mutate`.
+//!
+//! # Related
+//! - [`crate::analytics`] — the PostHog capture half, and its consent rules.
+//! - `meridian_core::settings` — the read/write-through-JSON pattern this
+//!   mirrors (see `commands::account::write_account_pseudonym` for the sibling
+//!   "one field, best-effort" write).
+
+/// Persist `tool_name` locally and, best-effort, report it to PostHog.
+///
+/// Only the settings write is fallible from the caller's point of view — the
+/// analytics half can never fail this command, matching every other capture
+/// in [`crate::analytics`] (see its module doc's "Nothing is lost on
+/// failure", which does not apply here: this is a one-off ask, not a rollup
+/// with a retry cursor, so a failed send is simply not reported — the local
+/// settings mirror is what's guaranteed).
+#[tauri::command]
+#[tracing::instrument(skip(app))]
+pub async fn request_pm_tool(app: tauri::AppHandle, tool_name: String) -> Result<(), String> {
+    let tool_name = tool_name.trim().to_string();
+    if tool_name.is_empty() {
+        return Err("request_pm_tool: tool name is required".into());
+    }
+
+    let name = tool_name.clone();
+    tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+        let mut v = meridian_core::settings::read_settings_value();
+        if let Some(obj) = v.as_object_mut() {
+            obj.insert(
+                "requested_pm_tool".to_string(),
+                serde_json::Value::String(name),
+            );
+        }
+        meridian_core::settings::write_settings_value(&v)
+    })
+    .await
+    .map_err(|e| format!("join settings write task: {e}"))?
+    .map_err(|e| crate::cmd_err!(e, "request_pm_tool: settings write failed"))?;
+
+    crate::analytics::send_pm_tool_requested(&app, &tool_name).await;
+    tracing::info!("request_pm_tool: recorded");
+    Ok(())
+}

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -1224,6 +1224,7 @@ pub fn run() {
             commands::start_oauth,
             commands::cancel_oauth,
             commands::get_oauth_status,
+            commands::request_pm_tool,
             // OS/window actions
             commands::take_pending_deep_link,
             commands::open_permission_pane,

--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -15,7 +15,7 @@
 //                      `save_integration_token`.
 
 import { useEffect, useRef, useState, type ReactNode } from 'react'
-import { load, mutate, openExternal } from '@/lib/bridge'
+import { invoke, load, mutate, openExternal } from '@/lib/bridge'
 import type { IntegrationsResponse, TaskSummary, TasksResponse } from '@/lib/api-types'
 import { TRACKERS } from '@/lib/integrations'
 import type { Tracker, TokenField } from '@/lib/integrations'
@@ -43,6 +43,9 @@ export default function ConnectTrackers({
   const [open, setOpen] = useState<string | null>(null)
   const [disconnecting, setDisconnecting] = useState<string | null>(null)
   const anyConnected = !!integrations && TRACKERS.some((t) => integrations[t.id])
+  // "I don't see my tool" is a side channel, not a connect flow: it never
+  // gates onboarding and always coexists with the tracker list above it.
+  const [requestingTool, setRequestingTool] = useState(false)
 
   const handleDisconnect = (id: string) => {
     setDisconnecting(id)
@@ -111,6 +114,83 @@ export default function ConnectTrackers({
             </div>
           )
         })}
+        <div style={{ borderTop: '1px solid var(--t-hair)' }}>
+          {requestingTool ? (
+            <RequestToolForm onDone={() => setRequestingTool(false)} />
+          ) : (
+            <button
+              onClick={() => setRequestingTool(true)}
+              className="w-full flex items-center gap-3 px-4 py-3 text-left transition-colors"
+              style={{ background: 'var(--t-card)', cursor: 'pointer' }}>
+              <span className="text-[13px]" style={{ color: 'var(--t-faint)' }}>I don&apos;t see my tool</span>
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── "I don't see my tool" (request_pm_tool — settings mirror + PostHog) ─────
+// A side channel, not a connect flow: submitting neither blocks nor advances
+// onboarding. `request_pm_tool` (Rust) does two independent, best-effort
+// things with the free text - mirrors it into settings.json and fires a
+// `pm_tool_requested` PostHog event - see that command's doc for why both.
+function RequestToolForm({ onDone }: { onDone: () => void }) {
+  const [value, setValue] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const submit = () => {
+    const tool_name = value.trim()
+    if (!tool_name || submitting) return
+    setSubmitting(true); setError(null)
+    // A single top-level scalar param (`tool_name`), not a `body:` struct -
+    // reached via `invoke` directly, per `mutate`'s calling convention (see
+    // `__tests__/mutate-body-contract.test.ts` and `save_account_email`'s
+    // call sites for the same shape).
+    invoke('request_pm_tool', { toolName: tool_name })
+      .then(() => setSubmitted(true))
+      .catch((e) => setError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Could not send'))
+      .finally(() => setSubmitting(false))
+  }
+
+  if (submitted) {
+    return (
+      <div className="px-4 py-3" style={{ background: 'var(--t-box)' }}>
+        <p className="text-[12px]" style={{ color: 'var(--color-state-approved)' }}>
+          Thanks - we&apos;ll let you know if we add it.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="px-4 py-3 space-y-2" style={{ background: 'var(--t-box)' }}>
+      <label className="block">
+        <span className="text-[11px]" style={{ color: 'var(--t-faint)' }}>What tool do you use?</span>
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') submit() }}
+          placeholder="e.g. Shortcut, Height, Basecamp"
+          autoFocus
+          className="mt-1 w-full text-[12px] px-2 py-1.5 rounded-md border"
+          style={{ color: 'var(--t-title)', background: 'var(--t-card)', borderColor: 'var(--t-hair)', outline: 'none' }}
+        />
+      </label>
+      {error && <p className="text-[11px]" style={{ color: 'var(--status-error-dot)' }}>{error}</p>}
+      <div className="flex gap-2">
+        <button onClick={submit} disabled={!value.trim() || submitting}
+          className="text-[12px] px-3 py-1.5 rounded-md font-medium transition-opacity"
+          style={{ background: 'var(--btn-primary-bg)', color: '#fff', opacity: (!value.trim() || submitting) ? 0.5 : 1, cursor: (!value.trim() || submitting) ? 'not-allowed' : 'pointer' }}>
+          {submitting ? 'Sending…' : 'Send'}
+        </button>
+        <button onClick={onDone} className="text-[12px] px-3 py-1.5" style={{ color: 'var(--t-faint-2)', cursor: 'pointer' }}>
+          Cancel
+        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
Item 3 of a 5-item batch: onboarding currently has no way for a user whose PM tool isn't in the supported list (Jira/Linear/GitHub/Trello/Azure DevOps) to say what they actually use.

`ConnectTrackers` (`ui/components/IntegrationConnect.tsx`, shared by the setup wizard and Settings → Integrations) now has an "I don't see my tool" row at the end of the tracker list. Clicking it reveals a plain text field; submitting it does two independent, best-effort things:

- **PostHog**: a new `pm_tool_requested` event (`tool_name` property) via `tray/src-tauri/src/commands/pm_tool_request.rs` → `analytics::send_pm_tool_requested`, gated by the same consent rule as every other capture in `analytics/mod.rs` (signed-in + `product_analytics_enabled`).
- **Local settings**: the same free text is mirrored into `settings.json`'s new `RuntimeSettings::requested_pm_tool: Option<String>` field, so it survives even with analytics off.

Never blocks or gates onboarding — this is a side-channel demand signal, not a connect flow.

## Changes
- `meridian-core/src/settings.rs` — new `requested_pm_tool` field + round-trip test.
- `tray/src-tauri/src/commands/pm_tool_request.rs` (new) — `request_pm_tool` command.
- `tray/src-tauri/src/analytics/mod.rs` — new `send_pm_tool_requested`, widened visibility on `capture`/`base_properties`/`analytics_allowed` to reuse them.
- `tray/src-tauri/src/commands.rs`, `lib.rs` — module registration + invoke_handler wiring.
- `ui/components/IntegrationConnect.tsx` — the new row + inline form.

## Test plan
- [x] `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` — all clean (1016 + 378 + 29 tests, 0 failed).
- [x] `npm run typecheck` and `bun test` in `ui/` — clean (894/894).
- [x] Pre-push hook (fmt + clippy + UI build/tests + security audit + `cargo test --workspace`) passed on push.