### PR TITLE
fix(pm-sync): give a resumed-after-a-gap provider the same retry grace a new one gets

### DIFF
--- a/src/intelligence/providers/mod.rs
+++ b/src/intelligence/providers/mod.rs
@@ -127,10 +127,30 @@ const TRANSIENT_ESCALATION_HOURS: i64 = 6;
 /// row with an epoch `last_synced_at`, which is not recent, and escalates. One
 /// sync interval of grace, and the persistently-blocked case still surfaces.
 ///
+/// **This same one-retry grace applies to a provider that has synced
+/// successfully before**, not just a brand-new one - see the `is_sentinel`
+/// branch in [`note_transient_sync_failure`]. Without it, a provider whose
+/// `last_synced_at` goes stale because the DAEMON WAS ASLEEP (laptop closed
+/// overnight, a longer Wi-Fi/VPN drop) rather than because it kept failing
+/// escalates on its very first retry after waking - the exact false-positive
+/// this module exists to remove, just triggered by a gap in *time* instead of
+/// a gap in connectivity. The grace row and this ONE mechanism (the epoch
+/// sentinel) cover both cases identically, so the escalation check cannot tell
+/// them apart and does not need to.
+///
 /// The remedy points at connectivity, NOT credentials: by construction we only
 /// reach here for failures that are not the user's token.
 ///
 /// Write the epoch-sentinel grace row for a provider that has never synced.
+///
+/// **Deliberately does NOT write `last_error`** (unlike the escalating write
+/// in [`stamp_sync_error_with_remedy`]): `meridian_core::readers::integrations::sync_errors`
+/// reads `last_error IS NOT NULL` to drive the per-provider "Sync failed"
+/// badge on the Integrations page, independent of whether a system-wide
+/// notice was raised. Setting it here would show that badge during a period
+/// this function is specifically trying to keep quiet - `detail` is still
+/// logged (below) so the attempt is not lost from telemetry, just kept out of
+/// the persisted, user-visible column.
 ///
 /// # Why `ON CONFLICT DO NOTHING`
 /// The caller's `has_row` check is a SEPARATE statement from this insert, and
@@ -156,16 +176,44 @@ const TRANSIENT_ESCALATION_HOURS: i64 = 6;
 /// behaviour a testable seam - the race itself has no deterministic hook, but
 /// "inserting over an existing row is a no-op, not an error" does.
 async fn insert_grace_row(pool: &SqlitePool, provider: &str, detail: &str) -> Result<()> {
+    tracing::debug!(
+        provider,
+        detail,
+        "grace row: recording the attempt without a user-visible error"
+    );
     sqlx::query(
         "INSERT INTO pm_sync_state (provider, last_synced_at, last_error)
-         VALUES (?, '1970-01-01T00:00:00Z', ?)
+         VALUES (?, '1970-01-01T00:00:00Z', NULL)
          ON CONFLICT(provider) DO NOTHING",
     )
     .bind(provider)
-    .bind(detail)
     .execute(pool)
     .await
     .context("recording the first transient failure for a never-synced provider")?;
+    Ok(())
+}
+
+/// Downgrade a STALE-BUT-PREVIOUSLY-SUCCESSFUL provider's `last_synced_at` to
+/// the epoch sentinel, marking its one retry of grace as used - WITHOUT
+/// writing `last_error`, for the same reason [`insert_grace_row`] doesn't (see
+/// its doc comment). Mirrors that function's shape but is an UPDATE, not an
+/// INSERT: the row already exists here, carrying a real (if old) past-success
+/// timestamp that this call intentionally overwrites, so the NEXT failure's
+/// `is_sentinel` check reads it identically to a never-synced provider's grace
+/// row and escalates.
+async fn mark_first_stale_failure(pool: &SqlitePool, provider: &str, detail: &str) -> Result<()> {
+    tracing::debug!(
+        provider,
+        detail,
+        "first transient failure since a genuine past success - staying quiet until the next attempt"
+    );
+    sqlx::query(
+        "UPDATE pm_sync_state SET last_synced_at = '1970-01-01T00:00:00Z' WHERE provider = ?",
+    )
+    .bind(provider)
+    .execute(pool)
+    .await
+    .context("recording a resumed provider's first quiet failure since its last success")?;
     Ok(())
 }
 
@@ -180,18 +228,27 @@ pub async fn note_transient_sync_failure(
     detail: &str,
 ) -> Result<bool> {
     let threshold = format!("-{TRANSIENT_ESCALATION_HOURS} hours");
-    let (has_row, recently_synced): (i64, i64) = sqlx::query_as(
+    let (has_row, recently_synced, is_sentinel, has_error): (i64, i64, i64, i64) = sqlx::query_as(
         "SELECT
              EXISTS(SELECT 1 FROM pm_sync_state WHERE provider = ?),
              EXISTS(
                  SELECT 1 FROM pm_sync_state
                  WHERE provider = ?
                    AND last_synced_at > strftime('%Y-%m-%dT%H:%M:%SZ', 'now', ?)
+             ),
+             EXISTS(
+                 SELECT 1 FROM pm_sync_state
+                 WHERE provider = ? AND last_synced_at = '1970-01-01T00:00:00Z'
+             ),
+             EXISTS(
+                 SELECT 1 FROM pm_sync_state WHERE provider = ? AND last_error IS NOT NULL
              )",
     )
     .bind(provider)
     .bind(provider)
     .bind(&threshold)
+    .bind(provider)
+    .bind(provider)
     .fetch_one(pool)
     .await
     .context("checking sync recency for transient-failure escalation")?;
@@ -212,6 +269,22 @@ pub async fn note_transient_sync_failure(
             provider,
             "first transient failure on a never-synced provider - staying quiet until the next attempt"
         );
+        tracing::Span::current().record("escalated", false);
+        return Ok(false);
+    }
+
+    // Not recently synced, and the provider HAS synced before. Give it the
+    // SAME one retry of grace a never-synced provider gets, unless there is
+    // already something to weigh against staying quiet: `is_sentinel` covers
+    // "the grace tick already ran" (this branch set `last_synced_at` to the
+    // sentinel with no `last_error`, and a SECOND consecutive failure now
+    // finds it), and `has_error` covers "a fault is already recorded here"
+    // (a terminal failure elsewhere already wrote `last_error` and raised its
+    // own notice - nothing is gained by staying quiet on top of that). Only a
+    // row that has synced before, has since gone stale, and carries neither
+    // signal - a clean transition into staleness - gets the grace write.
+    if has_error == 0 && is_sentinel == 0 {
+        mark_first_stale_failure(pool, provider, detail).await?;
         tracing::Span::current().record("escalated", false);
         return Ok(false);
     }

--- a/src/intelligence/providers/sync_failure_tests.rs
+++ b/src/intelligence/providers/sync_failure_tests.rs
@@ -66,10 +66,25 @@ async fn a_blip_on_a_healthy_provider_stays_silent() {
 /// And the counterweight: silence must be BOUNDED. A provider blocked by a
 /// proxy or firewall fails on every tick forever, and going quiet would
 /// leave the board silently stale - worse than the banner we removed.
+///
+/// The FIRST failure after `last_synced_at` goes stale gets one retry of
+/// grace too (same mechanism a never-synced provider gets - see
+/// `a_provider_resuming_after_a_long_gap_gets_one_retry_before_escalating`),
+/// so this simulates genuine persistence with a SECOND consecutive failure,
+/// matching how `a_never_synced_provider_gets_one_retry_before_escalating`
+/// proves the same property for a brand-new connection.
 #[tokio::test]
 async fn a_persistently_unreachable_provider_stops_being_silent() {
     let pool = make_db().await;
     set_last_sync(&pool, "jira", "-7 hours").await;
+
+    let first = note_transient_sync_failure(&pool, "jira", "connection timed out")
+        .await
+        .unwrap();
+    assert!(
+        !first,
+        "the first failure after going stale must stay silent"
+    );
 
     let escalated = note_transient_sync_failure(&pool, "jira", "connection timed out")
         .await
@@ -123,6 +138,82 @@ async fn a_never_synced_provider_gets_one_retry_before_escalating() {
     assert!(notice(&pool, "pm.github").await.is_some());
 }
 
+/// THE REGRESSION THIS MODULE WAS MISSING: a provider that synced
+/// successfully hours ago - laptop asleep overnight, a longer Wi-Fi/VPN drop,
+/// reconnecting after being away - has `last_synced_at` go stale for a reason
+/// that has NOTHING to do with repeated failed attempts. Before this test
+/// existed, the very first retry after such a gap escalated immediately (zero
+/// grace), while a never-synced provider got one retry first. If the network
+/// is actually back up moments later, the next attempt succeeds and clears
+/// the notice within seconds - a flash-then-clear banner that never should
+/// have shown. This provider must get the SAME one-retry grace a never-synced
+/// provider gets, and the grace attempt must not touch `last_error` either
+/// (see `a_racing_grace_row_insert_is_a_no_op_not_an_error` for the same
+/// guarantee on the never-synced path).
+#[tokio::test]
+async fn a_provider_resuming_after_a_long_gap_gets_one_retry_before_escalating() {
+    let pool = make_db().await;
+    set_last_sync(&pool, "jira", "-9 hours").await;
+
+    let first = note_transient_sync_failure(&pool, "jira", "dns error")
+        .await
+        .unwrap();
+    assert!(
+        !first,
+        "the first failure after a long gap must stay silent, same as a never-synced provider"
+    );
+    assert!(
+        notice(&pool, "pm.jira").await.is_none(),
+        "no banner on the very first retry after waking up"
+    );
+    let (last_error,): (Option<String>,) =
+        sqlx::query_as("SELECT last_error FROM pm_sync_state WHERE provider = 'jira'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        last_error, None,
+        "the grace attempt must not make the Integrations page show \"Sync failed\""
+    );
+
+    let second = note_transient_sync_failure(&pool, "jira", "dns error")
+        .await
+        .unwrap();
+    assert!(
+        second,
+        "a second consecutive failure means it is not just a blip"
+    );
+    assert!(notice(&pool, "pm.jira").await.is_some());
+}
+
+/// Grace is per-gap, not a one-time allowance for the provider's lifetime: a
+/// genuine intervening success must reset it, or a provider that recovers and
+/// later fails again would skip straight to escalation.
+#[tokio::test]
+async fn a_real_success_between_gaps_resets_the_grace() {
+    let pool = make_db().await;
+    set_last_sync(&pool, "jira", "-9 hours").await;
+
+    assert!(
+        !note_transient_sync_failure(&pool, "jira", "dns error")
+            .await
+            .unwrap(),
+        "first failure after the first gap: grace"
+    );
+
+    // A real success lands - e.g. the network came back for a while.
+    set_last_sync(&pool, "jira", "-0 hours").await;
+
+    // Then a second, later gap starts.
+    set_last_sync(&pool, "jira", "-9 hours").await;
+    assert!(
+        !note_transient_sync_failure(&pool, "jira", "dns error")
+            .await
+            .unwrap(),
+        "first failure after the SECOND gap must get grace again, not skip to escalation"
+    );
+}
+
 /// The grace-row insert races a concurrent one across PROCESSES: `meridian
 /// ticket-update` force-syncs through its own pool on the same `meridian.db`
 /// while the daemon polls. Both can observe "no row" and both insert against
@@ -166,9 +257,8 @@ async fn a_racing_grace_row_insert_is_a_no_op_not_an_error() {
         "the sentinel must survive the race, or escalation stalls: {last}"
     );
     assert_eq!(
-        detail.as_deref(),
-        Some("first writer"),
-        "DO NOTHING must leave the winner's row untouched"
+        detail, None,
+        "a grace row must never carry a user-visible last_error, from either writer"
     );
 }
 
@@ -245,10 +335,16 @@ async fn the_escalation_window_holds_on_both_sides() {
 
     set_last_sync(&pool, "jira", "-7 hours").await;
     assert!(
+        !note_transient_sync_failure(&pool, "jira", "blip")
+            .await
+            .unwrap(),
+        "the first failure outside the window still gets one retry of grace"
+    );
+    assert!(
         note_transient_sync_failure(&pool, "jira", "blip")
             .await
             .unwrap(),
-        "outside the window must escalate"
+        "the second consecutive failure outside the window must escalate"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes a false-positive "Jira/GitHub sync failing" banner that flashes and then clears itself shortly after — found via real fleet OpenObserve telemetry (hosts recording `note_transient_sync_failure` escalations, then a successful sync clearing the notice moments later).

### Bug 1 (primary): no grace on resume-after-a-gap

`note_transient_sync_failure` already gives a **never-synced** provider one retry of grace before escalating (`insert_grace_row`) — a tracker connected seconds ago that hits one DNS hiccup shouldn't show a fault. But a provider that **has** synced successfully before got **zero** grace once `last_synced_at` aged past the 6-hour escalation window: the very first retry after any gap that long (laptop asleep overnight, a longer Wi-Fi/VPN drop, reconnecting after being away) escalated immediately — writing `pm_sync_state.last_error` and raising the notice. If the network was actually back up moments later, the next attempt succeeded and cleared it within seconds: a flash-then-clear banner that never should have shown.

Fix: a resumed provider now gets the same one-retry grace, using the existing epoch-sentinel `last_synced_at` trick to track "grace already used" — unless there's already an active fault recorded (`has_error`), in which case escalating immediately is still correct (e.g. a 401 already raised its own notice; nothing is gained by staying quiet on top of that).

### Bug 2: the grace attempt itself wasn't quiet everywhere

`insert_grace_row` (the never-synced grace path) was writing `last_error` even during its supposedly-quiet attempt. `meridian-core`'s `sync_errors()` reads `last_error IS NOT NULL` to drive the per-provider "Sync failed" badge on the Integrations page — independent of whether the system-wide notice fired. So a quiet grace attempt still showed a false "Sync failed" badge there. Both grace paths now leave `last_error` NULL until an actual escalation happens.

## Changes

- `src/intelligence/providers/mod.rs`: `note_transient_sync_failure` now distinguishes four states instead of two (recently synced / never synced / grace-already-used / first-failure-since-a-real-success) via a new `mark_first_stale_failure` helper; `insert_grace_row` no longer writes `last_error`.
- `src/intelligence/providers/sync_failure_tests.rs`: two new tests covering the resume-after-a-gap grace and the intervening-real-success reset; three existing tests updated to reflect the new one-retry-of-grace behavior (`a_persistently_unreachable_provider_stops_being_silent`, `the_escalation_window_holds_on_both_sides`, `a_racing_grace_row_insert_is_a_no_op_not_an_error`).

## Test plan

- [x] TDD: reverted the `mod.rs` fix, confirmed the 5 new/updated tests fail for the expected reason, restored the fix, confirmed all pass
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all green)
- [x] full pre-push hook suite (fmt, clippy, ui build, ui tests, security audit, cargo test) — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)