### PR TITLE
feat(tray): register the macOS login item via SMAppService

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5233,6 +5233,7 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "objc2-service-management",
  "rand 0.8.6",
  "reqwest 0.12.28",
  "screenpipe-a11y",
@@ -5783,7 +5784,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6184,6 +6185,29 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-service-management"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b213642d6959cc6023ceb1217aa595eaaf09b8094ce95127c103cab611fe65e8"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
 ]
 
 [[package]]
@@ -10346,7 +10370,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5253,6 +5253,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-positioner",
  "tauri-plugin-sentry",
+ "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tempfile",
@@ -10238,6 +10239,22 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -210,7 +210,18 @@ block2 = "0.6"
 # Typed NSWorkspace/NSImage/NSBitmapImageRep bindings for real per-app icon
 # extraction (commands/app_icons.rs) — same generation family as objc2 0.6.
 objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSWorkspace", "NSImage", "NSImageRep", "NSBitmapImageRep", "NSRunningApplication"] }
-objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSString", "NSData", "NSDictionary", "NSGeometry"] }
+objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSString", "NSData", "NSDictionary", "NSGeometry", "NSProcessInfo", "NSError"] }
+# SMAppService — the sanctioned way to register a login item since macOS 13, and
+# the only one that puts a NAMED, user-togglable "Meridian" entry in System
+# Settings → General → Login Items & Extensions. Same objc2 generation (0.3.x)
+# as the app-kit/foundation bindings above, from the same maintainers, so it adds
+# no new FFI style and no new transitive tree — which is why this is preferred
+# over the third-party `smappservice-rs` wrapper (0.1.x, last touched May 2025).
+#
+# Requires macOS 13 at RUNTIME while the app declares LSMinimumSystemVersion
+# 10.13, so every call site is gated on `login_item::available()`. See
+# `autostart/login_item.rs`.
+objc2-service-management = { version = "0.3", default-features = false, features = ["std", "SMAppService", "objc2", "objc2-foundation"] }
 # CoreFoundation/Apple-frameworks bindings. Used ONLY for the in-process
 # Accessibility-trust prompt (`ax::is_process_trusted_with_prompt`) — the AX
 # analogue of `CGRequestScreenCaptureAccess`. Pinned to the same 0.13 line

--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -46,6 +46,26 @@ tauri-plugin-positioner = { version = "2.3", features = ["tray-icon"] }
 # (interactive toasts are packaged-only, same class of limitation as the
 # popover-404 dev caveat).
 tauri-plugin-notifications = { version = "=0.4.6", default-features = false }
+# Single instance. LOAD-BEARING for autostart correctness, not a nicety.
+#
+# The 09:00 morning trigger (`autostart::macos` / `autostart::windows`) starts the
+# tray from the OS scheduler, and neither scheduler can see "the app is already
+# running": launchd tracks liveness per JOB LABEL, so the process macOS's
+# loginwindow started via SMAppService is invisible to our calendar job, and Task
+# Scheduler's `MultipleInstancesPolicy: IgnoreNew` only dedupes the task's own
+# instances. Without this plugin the trigger would fire daily into a running app
+# and produce two processes writing one meridian.db - the double-writer condition
+# behind the `database disk image is malformed` incidents.
+#
+# Both platform impls do exactly what is needed: the SECOND process exits.
+# macOS uses a Unix socket (`/tmp/<identifier>_si.sock`) and `std::process::exit(0)`;
+# Windows uses a named mutex plus `WM_COPYDATA` to a hidden tool window, then
+# `cleanup_before_exit()` + exit. Neither disturbs the running instance.
+#
+# MUST be registered FIRST in lib.rs's builder (upstream requirement) - that is
+# also what keeps the doomed second process from ever creating a tray icon or a
+# capture writer before it exits.
+tauri-plugin-single-instance = "2"
 tauri-plugin-opener = "2"
 # Email sign-in on the setup wizard's Sign-in step (see ui/app/setup/signin.tsx).
 # Community-maintained (Nipsuli/tauri-plugin-clerk) — originally pinned exact

--- a/tray/src-tauri/src/analytics/health.rs
+++ b/tray/src-tauri/src/analytics/health.rs
@@ -199,6 +199,16 @@ pub(crate) struct HealthSnapshot {
     /// `app_active` — which is byte-for-byte what a user who walked away looks
     /// like. Without this, the two populations are one number.
     pub autostart_registered: Option<bool>,
+    /// macOS only: SMAppService's view of the LOGIN-item registration —
+    /// `enabled`, `requires_approval`, `not_registered`, `not_found`, or
+    /// `unavailable` below macOS 13. `None` off macOS.
+    ///
+    /// This is the field that answers "is Meridian actually in Login Items &
+    /// Extensions", which was unanswerable from the fleet — and it is the real
+    /// question behind every "why doesn't it start" report. `requires_approval`
+    /// in particular is a state only the USER can clear, so seeing it here is
+    /// the difference between shipping a fix and shipping a prompt.
+    pub autostart_login_item: Option<&'static str>,
     /// The registration points at the executable that is actually running.
     /// `false` means the app was moved after being registered, so it will not
     /// come back at the next login even though something IS registered.
@@ -241,6 +251,7 @@ impl Default for HealthSnapshot {
             notifications_enabled: false,
             error_reporting_enabled: false,
             autostart_registered: None,
+            autostart_login_item: None,
             autostart_path_ok: None,
             autostart_repaired: false,
             autostart_action: None,
@@ -398,6 +409,7 @@ pub(crate) async fn snapshot(pool: &SqlitePool) -> HealthSnapshot {
         notifications_enabled: settings.notifications_enabled,
         error_reporting_enabled: settings.error_reporting_enabled,
         autostart_registered: autostart.registered,
+        autostart_login_item: autostart.login_item,
         autostart_path_ok: autostart.path_ok,
         autostart_repaired: action.is_some_and(|a| a.is_repair()),
         autostart_action: action.map(|a| a.as_str()),
@@ -408,6 +420,7 @@ pub(crate) async fn snapshot(pool: &SqlitePool) -> HealthSnapshot {
     tracing::info!(
         daemon_running = ?snap.daemon_running,
         autostart_registered = ?snap.autostart_registered,
+        autostart_login_item = ?snap.autostart_login_item,
         autostart_path_ok = ?snap.autostart_path_ok,
         autostart_action = ?snap.autostart_action,
         launched_by_autostart = snap.launched_by_autostart,
@@ -584,6 +597,12 @@ impl HealthSnapshot {
         }
         if let Some(b) = self.autostart_path_ok {
             props.insert("health_autostart_path_ok".to_string(), Value::Bool(b));
+        }
+        if let Some(s) = self.autostart_login_item {
+            props.insert(
+                "health_autostart_login_item".to_string(),
+                Value::String(s.to_string()),
+            );
         }
         props.insert(
             "health_autostart_repaired".to_string(),

--- a/tray/src-tauri/src/autostart.rs
+++ b/tray/src-tauri/src/autostart.rs
@@ -352,6 +352,29 @@ pub async fn ensure_registered() {
             action = action.as_str(),
             "autostart: registration was missing or stale - repaired"
         );
+    } else if matches!(
+        action,
+        RegistrationAction::SkippedTransientPath | RegistrationAction::Failed
+    ) {
+        // WARN, because these two mean AUTOSTART IS NOT IN PLACE and the user
+        // does not know it.
+        //
+        // They were previously DEBUG, lumped in with "no change needed" — which
+        // is how an install that silently never registers looked identical, in
+        // the fleet and in `meridian logs`, to one that was working perfectly.
+        // The requirement this module exists to satisfy is "the tray comes back
+        // after a restart, and again the next morning, until uninstalled"; an
+        // install sitting on either of these branches satisfies none of it, and
+        // that has to be visible without asking the user to run anything.
+        //
+        // Volume is bounded: a transient path resolves as soon as the app is in
+        // a stable location (`crate::relocate`), and `Failed` is a real I/O or
+        // API error rather than a routine state. `SkippedDisabledByUser` stays
+        // quiet on purpose — that one is the user's decision, not a fault.
+        tracing::warn!(
+            action = action.as_str(),
+            "autostart: NOT registered - the tray will not come back on its own"
+        );
     } else {
         tracing::debug!(action = action.as_str(), "autostart: no change needed");
     }
@@ -613,6 +636,31 @@ mod tests {
         ] {
             assert!(!a.is_repair(), "{a:?} should not count as a repair");
         }
+    }
+
+    /// The severity split in `ensure_registered`: exactly the actions that mean
+    /// "autostart is not in place" must be loud, because the user cannot tell.
+    ///
+    /// Pinned as a test because it is a one-line `matches!` that reads like
+    /// logging trivia and is not. It was DEBUG once, which made an install that
+    /// silently never registered indistinguishable — in the fleet AND in
+    /// `meridian logs` — from one working perfectly. `SkippedDisabledByUser` is
+    /// deliberately NOT in the loud set: that is the user's decision, not a
+    /// fault, and warning on it would train everyone to ignore the warning.
+    #[test]
+    fn only_the_not_registered_outcomes_are_loud() {
+        let loud = |a: RegistrationAction| {
+            matches!(
+                a,
+                RegistrationAction::SkippedTransientPath | RegistrationAction::Failed
+            )
+        };
+        assert!(loud(RegistrationAction::SkippedTransientPath));
+        assert!(loud(RegistrationAction::Failed));
+        assert!(!loud(RegistrationAction::SkippedDisabledByUser));
+        assert!(!loud(RegistrationAction::AlreadyCorrect));
+        // Repairs are loud too, via `is_repair` on the branch above.
+        assert!(RegistrationAction::RegisteredMissing.is_repair());
     }
 
     /// The analytics wire names are a contract with saved PostHog queries, so

--- a/tray/src-tauri/src/autostart.rs
+++ b/tray/src-tauri/src/autostart.rs
@@ -101,10 +101,18 @@
 // platform APIs, so there is nothing to stop them building anywhere — the same
 // reasoning (and the same `cfg_attr(allow(dead_code))` shape) as
 // [`crate::backend_install`]'s `wait_until_gone`.
-/// SMAppService login-item registration. macOS-only for real (it is an ObjC
-/// framework call, not a string builder), so unlike the two platform modules
-/// this one is genuinely `cfg`-gated.
-#[cfg(target_os = "macos")]
+/// SMAppService login-item registration.
+///
+/// Compiled on every target, like the two platform modules and for the same
+/// reason — but here it is also required, not merely preferable: [`macos`] is
+/// itself compiled everywhere and imports this, so gating the DECLARATION is
+/// what broke the Windows build with `no login_item in autostart`. Gating only
+/// the module's *contents* was not enough; the `mod` item has to exist.
+///
+/// The ObjC calls inside are individually `cfg`-gated and `available()` is a
+/// constant `false` off macOS, so nothing here can message a framework that
+/// isn't there.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub(crate) mod login_item;
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub(crate) mod macos;

--- a/tray/src-tauri/src/autostart.rs
+++ b/tray/src-tauri/src/autostart.rs
@@ -91,6 +91,11 @@
 // platform APIs, so there is nothing to stop them building anywhere — the same
 // reasoning (and the same `cfg_attr(allow(dead_code))` shape) as
 // [`crate::backend_install`]'s `wait_until_gone`.
+/// SMAppService login-item registration. macOS-only for real (it is an ObjC
+/// framework call, not a string builder), so unlike the two platform modules
+/// this one is genuinely `cfg`-gated.
+#[cfg(target_os = "macos")]
+pub(crate) mod login_item;
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub(crate) mod macos;
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
@@ -178,6 +183,12 @@ pub(crate) enum RegistrationAction {
     /// Registered, but with no morning trigger. This is the upgrade path for
     /// every install that was registered by `tauri-plugin-autostart`.
     RepairedMissingMorningTrigger,
+    /// Registered at the right path, but the definition is not what this build
+    /// renders — a field changed that no substring probe would have noticed.
+    /// The case that motivated it: an older build's plist carried
+    /// `RunAtLoad true`, which would double-launch alongside the SMAppService
+    /// login item on macOS 13+.
+    RepairedStaleDefinition,
     /// The registration could not be read or written (permissions, missing
     /// home directory, `schtasks` refused). Retried on the next launch.
     Failed,
@@ -194,6 +205,7 @@ impl RegistrationAction {
             Self::RegisteredMissing => "registered_missing",
             Self::RepairedPathDrift => "repaired_path_drift",
             Self::RepairedMissingMorningTrigger => "repaired_missing_morning_trigger",
+            Self::RepairedStaleDefinition => "repaired_stale_definition",
             Self::Failed => "failed",
         }
     }
@@ -203,7 +215,10 @@ impl RegistrationAction {
     pub(crate) fn is_repair(self) -> bool {
         matches!(
             self,
-            Self::RegisteredMissing | Self::RepairedPathDrift | Self::RepairedMissingMorningTrigger
+            Self::RegisteredMissing
+                | Self::RepairedPathDrift
+                | Self::RepairedMissingMorningTrigger
+                | Self::RepairedStaleDefinition
         )
     }
 
@@ -216,6 +231,7 @@ impl RegistrationAction {
             Self::RepairedPathDrift => 5,
             Self::RepairedMissingMorningTrigger => 6,
             Self::Failed => 7,
+            Self::RepairedStaleDefinition => 8,
         }
     }
 
@@ -228,6 +244,7 @@ impl RegistrationAction {
             5 => Self::RepairedPathDrift,
             6 => Self::RepairedMissingMorningTrigger,
             7 => Self::Failed,
+            8 => Self::RepairedStaleDefinition,
             _ => return None,
         })
     }
@@ -414,6 +431,16 @@ pub(crate) struct Status {
     /// nothing is registered or the check could not run — never `false` for
     /// "we could not tell", per the rule in [`crate::analytics::health`].
     pub(crate) path_ok: Option<bool>,
+    /// macOS only: what SMAppService says about the LOGIN-item registration —
+    /// `enabled`, `requires_approval`, `not_registered`, `not_found`, or
+    /// `unavailable` below macOS 13. `None` off macOS.
+    ///
+    /// Distinct from [`Self::registered`], which describes the morning-relaunch
+    /// plist. The two are separate mechanisms and can disagree, and the whole
+    /// reason this field exists is that "is Meridian actually in Login Items &
+    /// Extensions" was unanswerable from the fleet — which is exactly the
+    /// question a user asking "why doesn't it start" is really asking.
+    pub(crate) login_item: Option<&'static str>,
 }
 
 /// Probe the current registration. Best-effort; every failure degrades to
@@ -449,15 +476,18 @@ pub(crate) fn status_from(registered: Option<&str>, expected_exe: Option<&str>) 
         (None, _) => Status {
             registered: Some(false),
             path_ok: None,
+            login_item: None,
         },
         (Some(text), Some(exe)) => Status {
             registered: Some(true),
             path_ok: Some(text.contains(exe)),
+            login_item: None,
         },
         // Registered, but we cannot resolve our own path to compare against.
         (Some(_), None) => Status {
             registered: Some(true),
             path_ok: None,
+            login_item: None,
         },
     }
 }
@@ -571,6 +601,7 @@ mod tests {
             RegistrationAction::RegisteredMissing,
             RegistrationAction::RepairedPathDrift,
             RegistrationAction::RepairedMissingMorningTrigger,
+            RegistrationAction::RepairedStaleDefinition,
         ] {
             assert!(a.is_repair(), "{a:?} should count as a repair");
         }
@@ -595,6 +626,7 @@ mod tests {
             RegistrationAction::RegisteredMissing,
             RegistrationAction::RepairedPathDrift,
             RegistrationAction::RepairedMissingMorningTrigger,
+            RegistrationAction::RepairedStaleDefinition,
             RegistrationAction::Failed,
         ] {
             assert_eq!(RegistrationAction::from_code(a.code()), Some(a));

--- a/tray/src-tauri/src/autostart.rs
+++ b/tray/src-tauri/src/autostart.rs
@@ -40,13 +40,17 @@
 //! (`autostart_disabled`).
 //!
 //! # What gets registered
-//! One job per platform, carrying both triggers, so the OS's own
-//! single-job-instance semantics do the de-duplication:
 //!
-//! - **macOS** — `~/Library/LaunchAgents/com.meridiona.tray.plist` with
-//!   `RunAtLoad` (login) + `StartCalendarInterval` at [`MORNING_HOUR`] (the
-//!   morning relaunch), and deliberately **no `KeepAlive`**: the user asked for
-//!   Quit to stick for the rest of the day and be undone the next morning, and
+//! - **macOS 13+** — `SMAppService.mainApp` owns LOGIN (see [`login_item`]),
+//!   which is what produces a named, user-togglable "Meridian" entry in System
+//!   Settings → General → Login Items & Extensions. The plist
+//!   `~/Library/LaunchAgents/com.meridiona.tray.plist` is reduced to the morning
+//!   relaunch alone: `RunAtLoad` **false** + `StartCalendarInterval` at
+//!   [`MORNING_HOUR`], bootstrapped immediately so the trigger is live from the
+//!   moment of install rather than the next login. Below 13 there is no
+//!   SMAppService, so that plist carries both jobs with `RunAtLoad` true.
+//!   Deliberately **no `KeepAlive`** either way: the user asked for Quit to
+//!   stick for the rest of the day and be undone the next morning, and
 //!   `KeepAlive` would make quitting impossible.
 //! - **Windows** — one scheduled task with a `LogonTrigger` *and* a daily
 //!   `CalendarTrigger`, registered from XML because `schtasks`' command form
@@ -54,17 +58,23 @@
 //!   which is what stops the 09:00 trigger starting a second tray on top of the
 //!   one the logon trigger already started.
 //!
-//! # Deliberately not bootstrapped on macOS
-//! [`macos::ensure_registered`] writes the plist but does not
-//! `launchctl bootstrap` it. `bootstrap` honours `RunAtLoad`, so bootstrapping
-//! our own job from inside the running tray would immediately start a SECOND
-//! tray — two processes writing `capture_frames` to one SQLite file. launchd
-//! loads `~/Library/LaunchAgents` at session start, so login coverage and the
-//! calendar trigger both work from the next login onward. The cost is precise
-//! and bounded: in the single session where the plist was first written, the
-//! calendar trigger is not yet live, so a user who installs and then quits on
-//! the same day waits until their next login rather than until 09:00. Every
-//! later session behaves fully.
+//! # Duplicates are prevented by a guard, not by hoping
+//! The 09:00 trigger is started by the OS scheduler, and **neither scheduler can
+//! see that the app is already running.** launchd tracks liveness per job
+//! LABEL, so the process macOS's loginwindow started via SMAppService is
+//! invisible to our calendar job; Task Scheduler's `MultipleInstancesPolicy:
+//! IgnoreNew` only dedupes the task's own instances. So the trigger fires daily
+//! into a running app.
+//!
+//! `tauri-plugin-single-instance` is therefore load-bearing, not a nicety: it is
+//! registered FIRST in [`crate::run`]'s builder so the doomed second process
+//! exits before it can create a tray icon or a capture writer. Two processes
+//! writing one `meridian.db` is the double-writer condition behind the
+//! `database disk image is malformed` incidents in [`crate::backend_install`].
+//!
+//! An earlier version of this module claimed `RunAtLoad false` alone prevented
+//! the duplicate. It does not — it only prevents one at LOGIN, and moved the
+//! collision to 09:00.
 //!
 //! # Who calls this
 //! [`crate::run`]'s `setup()` hook, once per launch, bundled runs only (see

--- a/tray/src-tauri/src/autostart/login_item.rs
+++ b/tray/src-tauri/src/autostart/login_item.rs
@@ -42,10 +42,28 @@
 //! [`super::macos::ensure_registered`] / [`super::macos::unregister`], and
 //! [`super::status`] via [`status`].
 
+// The ObjC bindings are a macOS-only dependency (see this crate's
+// `[target.'cfg(target_os = "macos")'.dependencies]`), so the imports — and only
+// the four functions that actually message Objective-C — are gated. Everything
+// else in this module is pure and compiles on every target ON PURPOSE, for the
+// same reason `super::macos` and `super::windows` do: CI runs on macOS and
+// Linux, and a type whose wire names are a contract with saved fleet queries
+// should be linted and tested everywhere, not only where it can run.
+//
+// This gate is also what broke the Windows build once: `super::macos` is
+// compiled on every target and imports this module, so making the WHOLE module
+// macOS-only left Windows with an unresolved import.
+#[cfg(target_os = "macos")]
 use objc2_foundation::NSProcessInfo;
+#[cfg(target_os = "macos")]
 use objc2_service_management::{SMAppService, SMAppServiceStatus};
 
 /// Lowest macOS major version that has `SMAppService`.
+///
+/// `isize` to match `NSOperatingSystemVersion`'s field type. Read by
+/// `available()` on macOS and pinned by a test on every target, so it is never
+/// dead code.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 const MIN_MACOS_MAJOR: isize = 13;
 
 /// Whether `SMAppService` can be called on this system at all.
@@ -54,12 +72,21 @@ const MIN_MACOS_MAJOR: isize = 13;
 /// for the class, because the answer is also worth logging and reporting: an
 /// install stuck on the fallback path is a fact about the machine, not a
 /// mystery.
+#[cfg(target_os = "macos")]
 pub(crate) fn available() -> bool {
     // `processInfo` is a singleton accessor and `operatingSystemVersion` a
     // plain struct read; objc2-foundation exposes both as safe, and they exist
     // on every macOS version this app can run on.
     let version = NSProcessInfo::processInfo().operatingSystemVersion();
     version.majorVersion >= MIN_MACOS_MAJOR
+}
+
+/// Off macOS there is no ServiceManagement framework at all, so the honest
+/// answer is a flat no — and every entry point below short-circuits on it,
+/// which is what lets the rest of this module stay platform-neutral.
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn available() -> bool {
+    false
 }
 
 /// What the system currently thinks of our login-item registration.
@@ -108,7 +135,8 @@ impl LoginItemStatus {
     }
 }
 
-/// Current registration status. `Unavailable` below macOS 13.
+/// Current registration status. `Unavailable` below macOS 13, and off macOS.
+#[cfg(target_os = "macos")]
 pub(crate) fn status() -> LoginItemStatus {
     if !available() {
         return LoginItemStatus::Unavailable;
@@ -128,6 +156,12 @@ pub(crate) fn status() -> LoginItemStatus {
         // fleet as itself instead of being silently folded into "fine".
         LoginItemStatus::NotFound
     }
+}
+
+/// No ServiceManagement framework off macOS.
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn status() -> LoginItemStatus {
+    LoginItemStatus::Unavailable
 }
 
 /// Result of a registration attempt.
@@ -176,8 +210,15 @@ pub(crate) fn register() -> RegisterOutcome {
         );
         return RegisterOutcome::AlreadySettled;
     }
+    register_main_app()
+}
 
-    // SAFETY: guarded by `available()`. `registerAndReturnError` maps the
+/// The one line that actually messages Objective-C, isolated so the policy above
+/// it (availability gate, idempotence check, logging) stays platform-neutral and
+/// reviewable in one place.
+#[cfg(target_os = "macos")]
+fn register_main_app() -> RegisterOutcome {
+    // SAFETY: callers gate on `available()`. `registerAndReturnError` maps the
     // ObjC out-error to a Rust `Result`, so there is no raw pointer handling.
     match unsafe { SMAppService::mainAppService().registerAndReturnError() } {
         Ok(()) => {
@@ -207,19 +248,29 @@ pub(crate) fn register() -> RegisterOutcome {
     }
 }
 
+/// Unreachable off macOS: `available()` is a constant `false` there, so
+/// `register` returns before this. Present only so the module compiles on every
+/// target — see the import gate at the top for why that matters.
+#[cfg(not(target_os = "macos"))]
+fn register_main_app() -> RegisterOutcome {
+    RegisterOutcome::Unavailable
+}
+
 /// Unregister the login item, honouring a user who turned autostart off.
 ///
 /// Unlike `launchctl bootout`, this does NOT terminate the running app — it only
 /// removes the launch-at-login registration — so it is safe to call from the
 /// Settings toggle while the user is looking at the window.
 pub(crate) fn unregister() {
-    if !available() {
+    if !available() || status() == LoginItemStatus::NotRegistered {
         return;
     }
-    if status() == LoginItemStatus::NotRegistered {
-        return;
-    }
-    // SAFETY: guarded by `available()`; same shape as `register` above.
+    unregister_main_app();
+}
+
+#[cfg(target_os = "macos")]
+fn unregister_main_app() {
+    // SAFETY: callers gate on `available()`; same shape as `register_main_app`.
     match unsafe { SMAppService::mainAppService().unregisterAndReturnError() } {
         Ok(()) => tracing::info!("autostart: login item unregistered"),
         Err(e) => {
@@ -229,6 +280,10 @@ pub(crate) fn unregister() {
     }
 }
 
+/// Unreachable off macOS — see [`register_main_app`]'s non-macOS twin.
+#[cfg(not(target_os = "macos"))]
+fn unregister_main_app() {}
+
 /// Open System Settings → Login Items, for a UI affordance that walks a user to
 /// the approval toggle instead of describing where it is.
 ///
@@ -236,11 +291,11 @@ pub(crate) fn unregister() {
 /// only the user can clear, and this is the one-call way to take them there.
 #[allow(dead_code)]
 pub(crate) fn open_system_settings() {
-    if !available() {
-        return;
+    #[cfg(target_os = "macos")]
+    if available() {
+        // SAFETY: guarded by `available()`; takes no arguments, returns nothing.
+        unsafe { SMAppService::openSystemSettingsLoginItems() };
     }
-    // SAFETY: guarded by `available()`; takes no arguments and returns nothing.
-    unsafe { SMAppService::openSystemSettingsLoginItems() };
 }
 
 /// The plist name is unused for `mainApp` registration, but the constant

--- a/tray/src-tauri/src/autostart/login_item.rs
+++ b/tray/src-tauri/src/autostart/login_item.rs
@@ -1,0 +1,304 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! macOS login item via **SMAppService** — the sanctioned API since macOS 13,
+//! and the only one that puts a NAMED, user-togglable "Meridian" entry in
+//! System Settings → General → Login Items & Extensions.
+//!
+//! # Why this exists at all
+//! Writing a plist into `~/Library/LaunchAgents/` does register with macOS's
+//! Background Task Management database — measured, not assumed: a probe plist
+//! that was never `launchctl bootstrap`ped still appeared in `sfltool dumpbtm`.
+//! So the raw-plist approach is not invisible. What it cannot do is present
+//! itself as the APP: a legacy agent shows up under "Allow in the Background"
+//! keyed on the plist, whereas `SMAppService.mainApp` produces an "Open at
+//! Login" entry attributed to the signed bundle. That difference is the whole
+//! point — a user looking for "Meridian" in that pane should find "Meridian".
+//!
+//! # Why it is only for the LOGIN half
+//! `SMAppService.mainApp` registers "launch this app when the user logs in" and
+//! nothing more: there is no way to attach a `StartCalendarInterval` to it. The
+//! morning relaunch therefore stays on our own plist, which is written with
+//! **`RunAtLoad` false** on macOS 13+ precisely so the two mechanisms cannot
+//! both start a tray at login. See [`super::macos`] for that coordination —
+//! getting it wrong is a double-launch, i.e. two processes writing one SQLite
+//! file.
+//!
+//! # Version gating is mandatory, not defensive
+//! The app declares `LSMinimumSystemVersion` 10.13 while `SMAppService` is
+//! macOS 13+. Sending these selectors on an older system is an
+//! unrecognized-selector crash, not a graceful failure, so **every** entry
+//! point here goes through [`available`] first.
+//!
+//! # Signing
+//! SMAppService validates the caller's code signature and refuses an unsigned
+//! or ad-hoc-signed bundle. Meridian's release builds are Developer ID signed
+//! and notarized (`release-build.yml` imports the certificate and notarizes both
+//! channels; verified on a shipped `.app` with `spctl -a -vvv` reporting
+//! `source=Notarized Developer ID`), so the precondition
+//! `backend_install.rs` documented for adopting SMAppService is already met.
+//! An unsigned local `cargo build` will get [`RegisterOutcome::Failed`] — which
+//! is why this is bundled-only and why the fallback path still exists.
+//!
+//! # Who calls this
+//! [`super::macos::ensure_registered`] / [`super::macos::unregister`], and
+//! [`super::status`] via [`status`].
+
+use objc2_foundation::NSProcessInfo;
+use objc2_service_management::{SMAppService, SMAppServiceStatus};
+
+/// Lowest macOS major version that has `SMAppService`.
+const MIN_MACOS_MAJOR: isize = 13;
+
+/// Whether `SMAppService` can be called on this system at all.
+///
+/// Checked through `NSProcessInfo`'s structured version rather than by probing
+/// for the class, because the answer is also worth logging and reporting: an
+/// install stuck on the fallback path is a fact about the machine, not a
+/// mystery.
+pub(crate) fn available() -> bool {
+    // `processInfo` is a singleton accessor and `operatingSystemVersion` a
+    // plain struct read; objc2-foundation exposes both as safe, and they exist
+    // on every macOS version this app can run on.
+    let version = NSProcessInfo::processInfo().operatingSystemVersion();
+    version.majorVersion >= MIN_MACOS_MAJOR
+}
+
+/// What the system currently thinks of our login-item registration.
+///
+/// Deliberately mirrors `SMAppServiceStatus` rather than collapsing to a bool:
+/// `RequiresApproval` is the one state that looks like failure and is not — the
+/// registration succeeded and macOS is waiting on the user in System Settings.
+/// Treating it as "broken" would make the app re-register in a loop and never
+/// tell the user the one thing that would fix it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LoginItemStatus {
+    /// SMAppService is not available on this macOS version.
+    Unavailable,
+    /// Registered and eligible to launch at login.
+    Enabled,
+    /// Registered, but the user has to allow it in System Settings.
+    RequiresApproval,
+    /// Never registered, or unregistered since.
+    NotRegistered,
+    /// The system could not find a matching service.
+    NotFound,
+}
+
+impl LoginItemStatus {
+    /// Stable wire name for analytics — kept separate from the `Debug`
+    /// spelling so renaming a variant cannot break a saved query.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Unavailable => "unavailable",
+            Self::Enabled => "enabled",
+            Self::RequiresApproval => "requires_approval",
+            Self::NotRegistered => "not_registered",
+            Self::NotFound => "not_found",
+        }
+    }
+
+    /// True when nothing more needs doing: either it is working, or the only
+    /// remaining step belongs to the user.
+    ///
+    /// `RequiresApproval` counts as settled ON PURPOSE. Re-registering does not
+    /// clear it — only the user can, in System Settings — so treating it as
+    /// unsettled would mean writing the same registration on every launch
+    /// forever and reporting a repair every time.
+    pub(crate) fn is_settled(self) -> bool {
+        matches!(self, Self::Enabled | Self::RequiresApproval)
+    }
+}
+
+/// Current registration status. `Unavailable` below macOS 13.
+pub(crate) fn status() -> LoginItemStatus {
+    if !available() {
+        return LoginItemStatus::Unavailable;
+    }
+    // SAFETY: guarded by `available()`; `mainAppService` is a class accessor and
+    // `status` a property read, neither of which can fail or block.
+    let raw = unsafe { SMAppService::mainAppService().status() };
+    if raw == SMAppServiceStatus::Enabled {
+        LoginItemStatus::Enabled
+    } else if raw == SMAppServiceStatus::RequiresApproval {
+        LoginItemStatus::RequiresApproval
+    } else if raw == SMAppServiceStatus::NotRegistered {
+        LoginItemStatus::NotRegistered
+    } else {
+        // Covers NotFound and any status a future macOS adds — reported as
+        // `not_found` rather than guessed at, so a new state shows up in the
+        // fleet as itself instead of being silently folded into "fine".
+        LoginItemStatus::NotFound
+    }
+}
+
+/// Result of a registration attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RegisterOutcome {
+    /// Not attempted — SMAppService needs macOS 13+.
+    Unavailable,
+    /// Already `Enabled` or `RequiresApproval`; nothing was written.
+    AlreadySettled,
+    /// Newly registered by this call.
+    Registered,
+    /// The call failed. The error is logged at WARN with its description.
+    Failed,
+}
+
+impl RegisterOutcome {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Unavailable => "unavailable",
+            Self::AlreadySettled => "already_settled",
+            Self::Registered => "registered",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+/// Register the app as a login item, idempotently.
+///
+/// Checks [`status`] first and returns early when already settled: Apple's API
+/// can error on a redundant `register` of an enabled service, so "register
+/// unconditionally and ignore the error" would turn a healthy install into a
+/// WARN on every launch and make the real failures unfindable.
+pub(crate) fn register() -> RegisterOutcome {
+    if !available() {
+        tracing::debug!(
+            min_macos = MIN_MACOS_MAJOR,
+            "autostart: SMAppService needs a newer macOS - using the LaunchAgent fallback"
+        );
+        return RegisterOutcome::Unavailable;
+    }
+    let current = status();
+    if current.is_settled() {
+        tracing::debug!(
+            status = current.as_str(),
+            "autostart: login item already set"
+        );
+        return RegisterOutcome::AlreadySettled;
+    }
+
+    // SAFETY: guarded by `available()`. `registerAndReturnError` maps the
+    // ObjC out-error to a Rust `Result`, so there is no raw pointer handling.
+    match unsafe { SMAppService::mainAppService().registerAndReturnError() } {
+        Ok(()) => {
+            // Re-read rather than assuming `Enabled`: a first registration on a
+            // modern macOS commonly lands on `RequiresApproval`, and reporting
+            // it as enabled would hide the one thing the user must do.
+            let after = status();
+            tracing::info!(
+                status = after.as_str(),
+                "autostart: registered as a login item via SMAppService"
+            );
+            RegisterOutcome::Registered
+        }
+        Err(e) => {
+            let reason = e.localizedDescription();
+            // WARN, not ERROR: the LaunchAgent fallback still covers the user,
+            // so this is degraded rather than broken. WARN is also the lowest
+            // severity that leaves the machine, and "SMAppService refused" is
+            // exactly the fleet signal worth having — an unsigned or relocated
+            // bundle is the usual cause.
+            tracing::warn!(
+                error = %reason,
+                "autostart: SMAppService registration failed - falling back to the LaunchAgent"
+            );
+            RegisterOutcome::Failed
+        }
+    }
+}
+
+/// Unregister the login item, honouring a user who turned autostart off.
+///
+/// Unlike `launchctl bootout`, this does NOT terminate the running app — it only
+/// removes the launch-at-login registration — so it is safe to call from the
+/// Settings toggle while the user is looking at the window.
+pub(crate) fn unregister() {
+    if !available() {
+        return;
+    }
+    if status() == LoginItemStatus::NotRegistered {
+        return;
+    }
+    // SAFETY: guarded by `available()`; same shape as `register` above.
+    match unsafe { SMAppService::mainAppService().unregisterAndReturnError() } {
+        Ok(()) => tracing::info!("autostart: login item unregistered"),
+        Err(e) => {
+            let reason = e.localizedDescription();
+            tracing::warn!(error = %reason, "autostart: SMAppService unregistration failed");
+        }
+    }
+}
+
+/// Open System Settings → Login Items, for a UI affordance that walks a user to
+/// the approval toggle instead of describing where it is.
+///
+/// Unused today; kept because `RequiresApproval` is a real, reachable state that
+/// only the user can clear, and this is the one-call way to take them there.
+#[allow(dead_code)]
+pub(crate) fn open_system_settings() {
+    if !available() {
+        return;
+    }
+    // SAFETY: guarded by `available()`; takes no arguments and returns nothing.
+    unsafe { SMAppService::openSystemSettingsLoginItems() };
+}
+
+/// The plist name is unused for `mainApp` registration, but the constant
+/// documents the relationship for anyone reaching for `agentServiceWithPlistName`
+/// later. See the module doc for why the agent variant was not used: its plist
+/// must live inside the signed bundle at `Contents/Library/LaunchAgents/`, which
+/// Tauri's `bundle.resources` cannot target (it maps into `Contents/Resources/`)
+/// and which would have to be injected before the CI signing step.
+#[allow(dead_code)]
+pub(crate) const BUNDLED_AGENT_PLIST: &str = "com.meridiona.tray.plist";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Wire names are a contract with saved fleet queries.
+    #[test]
+    fn status_and_outcome_wire_names_are_stable() {
+        assert_eq!(LoginItemStatus::Unavailable.as_str(), "unavailable");
+        assert_eq!(LoginItemStatus::Enabled.as_str(), "enabled");
+        assert_eq!(
+            LoginItemStatus::RequiresApproval.as_str(),
+            "requires_approval"
+        );
+        assert_eq!(LoginItemStatus::NotRegistered.as_str(), "not_registered");
+        assert_eq!(LoginItemStatus::NotFound.as_str(), "not_found");
+
+        assert_eq!(RegisterOutcome::Unavailable.as_str(), "unavailable");
+        assert_eq!(RegisterOutcome::AlreadySettled.as_str(), "already_settled");
+        assert_eq!(RegisterOutcome::Registered.as_str(), "registered");
+        assert_eq!(RegisterOutcome::Failed.as_str(), "failed");
+    }
+
+    /// `RequiresApproval` must count as settled: re-registering cannot clear it
+    /// (only the user can, in System Settings), so treating it as unsettled
+    /// would re-register on every launch and report a repair every time.
+    #[test]
+    fn requires_approval_is_settled_but_not_registered_is_not() {
+        assert!(LoginItemStatus::Enabled.is_settled());
+        assert!(LoginItemStatus::RequiresApproval.is_settled());
+        assert!(!LoginItemStatus::NotRegistered.is_settled());
+        assert!(!LoginItemStatus::NotFound.is_settled());
+        assert!(!LoginItemStatus::Unavailable.is_settled());
+    }
+
+    /// Calling SMAppService below macOS 13 is an unrecognized-selector crash,
+    /// and the app ships with LSMinimumSystemVersion 10.13 - so this constant
+    /// is load-bearing, not documentation.
+    #[test]
+    fn the_version_gate_matches_smappservice_availability() {
+        assert_eq!(MIN_MACOS_MAJOR, 13);
+    }
+
+    /// Runs on whatever macOS the test host has. Asserts only the invariant that
+    /// holds either way: `available()` and `status()` must agree about whether
+    /// SMAppService can be used, so a gated call site can trust either one.
+    #[test]
+    fn status_reports_unavailable_exactly_when_the_api_is_unavailable() {
+        assert_eq!(status() == LoginItemStatus::Unavailable, !available());
+    }
+}

--- a/tray/src-tauri/src/autostart/macos.rs
+++ b/tray/src-tauri/src/autostart/macos.rs
@@ -20,7 +20,7 @@
 //!   binary. It is worth knowing about on a developer machine, where the visible
 //!   effect is that `KeepAlive` stops resurrecting the tray.
 
-use super::{RegistrationAction, Status};
+use super::{login_item, RegistrationAction, Status};
 use std::path::{Path, PathBuf};
 
 /// launchd label, matching the `com.meridiona.*` convention that
@@ -44,9 +44,13 @@ const LEGACY_PLIST_FILE: &str = "Meridian.plist";
 // owns the one place a bootout of that label is safe, because there the app is
 // meant to stop.
 
-/// Element that proves a plist carries the morning relaunch. See
-/// [`super::decide`] for why this is a text check.
-const MORNING_TRIGGER_MARKER: &str = "StartCalendarInterval";
+// NOTE: there is no MORNING_TRIGGER_MARKER here any more. `ensure_registered`
+// compares the rendered plist body EXACTLY rather than probing for substrings,
+// because a substring check cannot see a change to a field it does not name —
+// and `RunAtLoad` is precisely such a field now that SMAppService owns the login
+// half on macOS 13+. Windows still uses the substring form (`super::decide`),
+// because Task Scheduler reformats the XML it hands back, so an exact compare
+// there would report drift on every launch.
 
 /// `~/Library/LaunchAgents`, where per-user agents live. `None` when the home
 /// directory cannot be resolved, in which case there is nothing this module can
@@ -69,7 +73,21 @@ fn current_exe() -> Option<PathBuf> {
 /// Pure and separate from the write so every field below is unit-testable
 /// without touching `~/Library/LaunchAgents` on a developer machine.
 ///
-/// - `RunAtLoad` covers login (and therefore reboot).
+/// # `run_at_load` is the coordination with SMAppService, not a preference
+/// On macOS 13+ the login half is owned by
+/// [`super::login_item`] (`SMAppService.mainApp`), which is what produces a
+/// named, user-togglable "Meridian" entry in Login Items & Extensions. This
+/// plist is then reduced to its ONE remaining job — the morning relaunch — and
+/// must be written with `run_at_load` **false**. Leaving it true would mean two
+/// independent mechanisms both starting a tray at login: two processes writing
+/// one SQLite file, which is the double-writer condition behind the
+/// `database disk image is malformed` incidents documented in
+/// `backend_install.rs`.
+///
+/// Below macOS 13 SMAppService does not exist, so this plist carries both jobs
+/// and `run_at_load` is true.
+///
+/// The rest:
 /// - `StartCalendarInterval` covers "the user quit; bring it back tomorrow
 ///   morning". launchd runs a missed calendar job when the machine wakes, so a
 ///   laptop asleep at [`super::MORNING_HOUR`] still gets it.
@@ -85,11 +103,12 @@ fn current_exe() -> Option<PathBuf> {
 ///   `CLAUDE.md`'s observability section — the one thing the OTel spool cannot
 ///   capture. `src/telemetry_spool/launchd_log_cap.rs` already size-caps these
 ///   exact paths.
-pub(crate) fn plist_body(exe: &Path, home: &Path) -> String {
+pub(crate) fn plist_body(exe: &Path, home: &Path, run_at_load: bool) -> String {
     let exe = super::xml_escape(&exe.to_string_lossy());
     let home = super::xml_escape(&home.to_string_lossy());
     let flag = super::AUTOSTART_FLAG;
     let hour = super::MORNING_HOUR;
+    let run_at_load = if run_at_load { "<true/>" } else { "<false/>" };
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -105,7 +124,7 @@ pub(crate) fn plist_body(exe: &Path, home: &Path) -> String {
     </array>
 
     <key>RunAtLoad</key>
-    <true/>
+    {run_at_load}
 
     <key>StartCalendarInterval</key>
     <array>
@@ -155,20 +174,68 @@ pub(crate) async fn ensure_registered() -> RegistrationAction {
         return RegistrationAction::Failed;
     };
 
-    let existing = read_registration().await;
-    let action = super::decide(
+    // Skip decisions first, and they apply to BOTH mechanisms: a user who
+    // turned autostart off must not get a login item either, and a transient
+    // (DMG / translocated) path must not be pinned by anything.
+    let skip = super::decide(
         super::disabled_by_user(),
         crate::sys::running_from_stable_location(),
-        existing.as_deref(),
-        &exe.to_string_lossy(),
-        MORNING_TRIGGER_MARKER,
+        // `Some("")` rather than `None`: this call is only being asked about the
+        // two skip conditions, and a `None` here would answer
+        // `RegisteredMissing` before they were consulted.
+        Some(""),
+        "",
+        "",
     );
-    if !matches!(
-        action,
-        RegistrationAction::RegisteredMissing
-            | RegistrationAction::RepairedPathDrift
-            | RegistrationAction::RepairedMissingMorningTrigger
+    if matches!(
+        skip,
+        RegistrationAction::SkippedDisabledByUser | RegistrationAction::SkippedTransientPath
     ) {
+        return skip;
+    }
+
+    // The LOGIN half. On macOS 13+ this is SMAppService, which is the only way
+    // to appear in Login Items & Extensions as "Meridian" rather than as an
+    // anonymous legacy agent. Below 13 it reports `Unavailable` and the plist
+    // below carries the login trigger instead.
+    let login = login_item::register();
+    let owns_login = !matches!(
+        login,
+        login_item::RegisterOutcome::Unavailable | login_item::RegisterOutcome::Failed
+    );
+
+    // The MORNING half. `run_at_load` is the inverse of who owns login: if
+    // SMAppService took it, this plist must NOT also start a tray at login, or
+    // both fire and two processes write one SQLite file.
+    let expected = plist_body(&exe, &home, !owns_login);
+    let existing = read_registration().await;
+
+    // Exact-body comparison, not a substring probe.
+    //
+    // The substring version (path present? morning trigger present?) cannot see
+    // a change to a field it does not name — and `RunAtLoad` is exactly such a
+    // field. An install carrying the previous build's `RunAtLoad true` plist
+    // would have passed every substring check while double-launching alongside
+    // the new login item. Comparing the whole rendered body makes every future
+    // field change self-healing for free, and the cost of a false "differs" is
+    // one idempotent file write.
+    let action = match existing.as_deref() {
+        None => RegistrationAction::RegisteredMissing,
+        Some(cur) if cur == expected => RegistrationAction::AlreadyCorrect,
+        // Distinguish the two repairs that matter for the fleet: a moved app is
+        // a different problem from a definition this build simply renders
+        // differently.
+        Some(cur) if !cur.contains(exe.to_string_lossy().as_ref()) => {
+            RegistrationAction::RepairedPathDrift
+        }
+        Some(_) => RegistrationAction::RepairedStaleDefinition,
+    };
+
+    if action == RegistrationAction::AlreadyCorrect {
+        tracing::debug!(
+            login_item = login.as_str(),
+            "autostart: login item and morning trigger both already correct"
+        );
         return action;
     }
 
@@ -177,19 +244,23 @@ pub(crate) async fn ensure_registered() -> RegistrationAction {
         return RegistrationAction::Failed;
     }
     let dest = dir.join(PLIST_FILE);
-    if let Err(e) = tokio::fs::write(&dest, plist_body(&exe, &home)).await {
+    if let Err(e) = tokio::fs::write(&dest, &expected).await {
         tracing::warn!(error = %e, plist = %dest.display(), "autostart: could not write the plist");
         return RegistrationAction::Failed;
     }
 
-    // NOT bootstrapped - see the module docs on `crate::autostart`. launchd
-    // loads this directory at session start, so the job is live from the next
-    // login onward; bootstrapping it here would honour `RunAtLoad` and start a
-    // second tray against the same SQLite file.
+    // NOT bootstrapped - see the module docs on `crate::autostart`. Measured, so
+    // the cost is known rather than assumed: a probe plist that was never
+    // bootstrapped still appeared in `sfltool dumpbtm`, so the entry IS visible
+    // in Login Items & Extensions immediately. What waits for the next login is
+    // only the job becoming live, which is why bootstrapping here (and starting
+    // a second tray via `RunAtLoad`) buys nothing.
     tracing::info!(
         plist = %dest.display(),
         action = action.as_str(),
-        "autostart: LaunchAgent written - live from the next login"
+        login_item = login.as_str(),
+        run_at_load = !owns_login,
+        "autostart: morning-relaunch LaunchAgent written"
     );
     action
 }
@@ -248,6 +319,12 @@ async fn migrate_off_plugin() {
 /// once beats quitting the app out from under someone who was changing a
 /// preference.
 pub(crate) async fn unregister() {
+    // The login half first. Unlike `launchctl bootout` this does NOT terminate
+    // the running app, so it is safe to call from the Settings toggle while the
+    // user is looking at the window — which is the whole reason the plist below
+    // is deleted rather than booted out.
+    login_item::unregister();
+
     let Some(plist) = launch_agents_dir().map(|d| d.join(PLIST_FILE)) else {
         return;
     };
@@ -263,22 +340,27 @@ pub(crate) async fn unregister() {
 
 /// Live registration state for analytics. See [`super::Status`].
 pub(crate) async fn status() -> Status {
-    super::status_from(
+    // The plist half, then the login half folded on top: they are independent
+    // mechanisms and either can be broken while the other is fine.
+    let mut status = super::status_from(
         read_registration().await.as_deref(),
         current_exe()
             .map(|p| p.to_string_lossy().into_owned())
             .as_deref(),
-    )
+    );
+    status.login_item = Some(login_item::status().as_str());
+    status
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn body() -> String {
+    fn body(run_at_load: bool) -> String {
         plist_body(
             Path::new("/Applications/Meridian.app/Contents/MacOS/Meridian"),
             Path::new("/Users/tester"),
+            run_at_load,
         )
     }
 
@@ -291,23 +373,40 @@ mod tests {
         assert!(LABEL.starts_with("com.meridiona."));
     }
 
+    /// THE double-launch guard. On macOS 13+ SMAppService owns login, so this
+    /// plist must carry `RunAtLoad false` and nothing else may start a tray at
+    /// login. Both firing means two processes writing one SQLite file - the
+    /// double-writer condition behind `database disk image is malformed`.
     #[test]
-    fn plist_carries_both_triggers_and_the_autostart_flag() {
-        let b = body();
-        assert!(b.contains("<key>RunAtLoad</key>"), "login trigger missing");
-        assert!(
-            b.contains(MORNING_TRIGGER_MARKER),
-            "morning trigger missing"
-        );
-        assert!(
-            b.contains(&format!(
-                "<integer>{}</integer>",
-                super::super::MORNING_HOUR
-            )),
-            "morning hour missing"
-        );
-        assert!(b.contains(super::super::AUTOSTART_FLAG));
-        assert!(b.contains("/Applications/Meridian.app/Contents/MacOS/Meridian"));
+    fn run_at_load_is_false_when_smappservice_owns_login() {
+        let with_login_item = body(false);
+        assert!(with_login_item.contains("<key>RunAtLoad</key>\n    <false/>"));
+        assert!(!with_login_item.contains("<true/>"));
+
+        // And true on the fallback path, where nothing else covers login.
+        let fallback = body(true);
+        assert!(fallback.contains("<key>RunAtLoad</key>\n    <true/>"));
+    }
+
+    /// The morning trigger is this plist's reason to exist in BOTH modes -
+    /// SMAppService cannot express a calendar interval at all.
+    #[test]
+    fn both_modes_keep_the_morning_trigger() {
+        for run_at_load in [true, false] {
+            let b = body(run_at_load);
+            assert!(
+                b.contains("StartCalendarInterval"),
+                "run_at_load={run_at_load}"
+            );
+            assert!(
+                b.contains(&format!(
+                    "<integer>{}</integer>",
+                    super::super::MORNING_HOUR
+                )),
+                "run_at_load={run_at_load}"
+            );
+            assert!(b.contains(super::super::AUTOSTART_FLAG));
+        }
     }
 
     /// `KeepAlive` would make Quit impossible - the user explicitly wants
@@ -315,29 +414,17 @@ mod tests {
     /// this plist differs from the daemon's.
     #[test]
     fn plist_must_not_carry_keepalive() {
-        assert!(!body().contains("KeepAlive"));
+        assert!(!body(true).contains("KeepAlive"));
+        assert!(!body(false).contains("KeepAlive"));
     }
 
     /// The log paths are the crash safety net `telemetry_spool::launchd_log_cap`
     /// size-caps by exact name; a rename here would silently uncap them.
     #[test]
     fn plist_redirects_to_the_capped_log_paths() {
-        let b = body();
+        let b = body(true);
         assert!(b.contains("/Users/tester/.meridian/logs/tray.log"));
         assert!(b.contains("/Users/tester/.meridian/logs/tray-error.log"));
-    }
-
-    /// A plist this module wrote must be recognised as correct by the very
-    /// decision function that decides whether to rewrite it - otherwise every
-    /// launch would rewrite and report a repair forever.
-    #[test]
-    fn a_freshly_written_plist_reads_back_as_already_correct() {
-        let exe = "/Applications/Meridian.app/Contents/MacOS/Meridian";
-        let b = plist_body(Path::new(exe), Path::new("/Users/tester"));
-        assert_eq!(
-            super::super::decide(false, true, Some(&b), exe, MORNING_TRIGGER_MARKER),
-            RegistrationAction::AlreadyCorrect
-        );
     }
 
     /// An `&` in a user's home directory name would otherwise produce a plist
@@ -348,8 +435,18 @@ mod tests {
         let b = plist_body(
             Path::new("/Users/a&b/Meridian.app/Contents/MacOS/Meridian"),
             Path::new("/Users/a&b"),
+            true,
         );
         assert!(b.contains("/Users/a&amp;b/Meridian.app"));
         assert!(!b.contains("/Users/a&b"));
+    }
+
+    /// The two modes must render DIFFERENTLY, which is what makes the exact-body
+    /// comparison in `ensure_registered` able to detect a stale definition. If
+    /// they were byte-identical, an install carrying the old `RunAtLoad true`
+    /// plist would never be repaired and would double-launch forever.
+    #[test]
+    fn the_two_modes_are_distinguishable_by_an_exact_compare() {
+        assert_ne!(body(true), body(false));
     }
 }

--- a/tray/src-tauri/src/autostart/macos.rs
+++ b/tray/src-tauri/src/autostart/macos.rs
@@ -207,7 +207,8 @@ pub(crate) async fn ensure_registered() -> RegistrationAction {
     // The MORNING half. `run_at_load` is the inverse of who owns login: if
     // SMAppService took it, this plist must NOT also start a tray at login, or
     // both fire and two processes write one SQLite file.
-    let expected = plist_body(&exe, &home, !owns_login);
+    let run_at_load_owned_by_plist = !owns_login;
+    let expected = plist_body(&exe, &home, run_at_load_owned_by_plist);
     let existing = read_registration().await;
 
     // Exact-body comparison, not a substring probe.
@@ -249,17 +250,49 @@ pub(crate) async fn ensure_registered() -> RegistrationAction {
         return RegistrationAction::Failed;
     }
 
-    // NOT bootstrapped - see the module docs on `crate::autostart`. Measured, so
-    // the cost is known rather than assumed: a probe plist that was never
-    // bootstrapped still appeared in `sfltool dumpbtm`, so the entry IS visible
-    // in Login Items & Extensions immediately. What waits for the next login is
-    // only the job becoming live, which is why bootstrapping here (and starting
-    // a second tray via `RunAtLoad`) buys nothing.
+    // NOW bootstrap it, which is safe for the first time.
+    //
+    // This used to be skipped, on the grounds that `bootstrap` honours
+    // `RunAtLoad` and would start a second tray. Two things changed and both
+    // matter:
+    //
+    // 1. On macOS 13+ this plist carries `RunAtLoad false` (SMAppService owns
+    //    login), so bootstrapping loads the calendar trigger WITHOUT launching
+    //    anything at all.
+    // 2. `tauri-plugin-single-instance` now guarantees that even if something
+    //    did launch a second process, it exits before touching the tray or the
+    //    database.
+    //
+    // The gain is not cosmetic: without bootstrapping, launchd only picks the
+    // job up at the next login, so a user who installed and then quit the same
+    // day would NOT come back at 09:00. Bootstrapping closes that gap, so the
+    // morning relaunch works from the moment of install.
+    //
+    // Best-effort: `bootout` first so a re-registration replaces cleanly, and a
+    // failure here only costs the current session (the next login loads it from
+    // disk regardless).
+    let target = format!("gui/{}/{LABEL}", crate::sys::uid_str());
+    if run_at_load_owned_by_plist {
+        // Below macOS 13 this plist DOES carry `RunAtLoad true`, so bootstrapping
+        // it here would start a second tray. The single-instance guard would kill
+        // that duplicate, but relying on a guard to undo a launch we chose to
+        // make is worse than not making it: skip, and let the next login load it.
+        tracing::debug!("autostart: not bootstrapping a RunAtLoad plist from inside the app");
+    } else {
+        let _ = crate::backend_install::launchctl(&["bootout", &target]).await;
+        let _ = crate::backend_install::launchctl(&[
+            "bootstrap",
+            &format!("gui/{}", crate::sys::uid_str()),
+            &dest.to_string_lossy(),
+        ])
+        .await;
+    }
+
     tracing::info!(
         plist = %dest.display(),
         action = action.as_str(),
         login_item = login.as_str(),
-        run_at_load = !owns_login,
+        run_at_load = run_at_load_owned_by_plist,
         "autostart: morning-relaunch LaunchAgent written"
     );
     action

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -159,6 +159,70 @@ mod catch_setup_panic_tests {
     }
 }
 
+#[cfg(test)]
+mod single_instance_tests {
+    /// The second-instance callback must never open or focus a window.
+    ///
+    /// Source-scanned because the thing being asserted is "nothing appeared",
+    /// which a headless test has no window to observe — the same reasoning as
+    /// `ui/__tests__/no-native-dialogs.test.ts`. What it protects is specific:
+    /// every single-instance example on the internet focuses the main window,
+    /// so the natural "improvement" to this callback is precisely the bug. The
+    /// common caller is the 09:00 morning trigger on a machine nobody touched.
+    #[test]
+    fn the_second_instance_callback_opens_nothing() {
+        let src = include_str!("lib.rs");
+        // Newline-anchored so it matches the DEFINITION and not the string
+        // literal on this very line — searching for the bare name found this
+        // test first and made it fail against its own forbidden-word list.
+        let start = src
+            .find("\nfn on_second_instance(")
+            .expect("callback renamed - re-check this test's needles");
+        let body_end = src[start..]
+            .find("\npub fn run()")
+            .expect("callback is expected to sit directly above run()");
+        let body = &src[start..start + body_end];
+        for forbidden in [
+            "open_native_dashboard",
+            "open_wizard_window",
+            "set_focus",
+            ".show()",
+        ] {
+            assert!(
+                !body.contains(forbidden),
+                "on_second_instance must not call {forbidden} - an unattended \
+                 relaunch would put a window on screen"
+            );
+        }
+    }
+}
+
+/// What the surviving instance does when a second one was blocked: **nothing
+/// but log**.
+///
+/// This is a deliberate departure from every single-instance example, which
+/// focuses or shows the main window. Doing that here would be actively wrong:
+/// the overwhelmingly common caller is the 09:00 morning trigger passing
+/// `--autostart`, i.e. the OS starting Meridian on a machine nobody touched. A
+/// window appearing then is exactly the annoyance that makes people disable
+/// autostart, which costs us the capture the tray exists to perform.
+///
+/// A user-initiated activation does NOT arrive here. Clicking the app in
+/// Finder, Spotlight or the Dock goes through LaunchServices, which activates
+/// the running instance and fires `RunEvent::Reopen` — handled separately by
+/// [`reopen`], which opens the dashboard. This callback only sees a direct
+/// re-exec of the binary, which on this app means a scheduler.
+///
+/// So the correct behaviour is to let the second process die quietly and carry
+/// on. Logged at DEBUG rather than INFO because on a machine left running for
+/// weeks this fires once a day, forever, and says nothing new each time.
+fn on_second_instance(_app: &tauri::AppHandle, args: Vec<String>, _cwd: String) {
+    tracing::debug!(
+        unattended = autostart::args_indicate_autostart(args.iter().map(String::as_str)),
+        "single-instance: a second launch was blocked - staying as we are"
+    );
+}
+
 pub fn run() {
     // Native-crash capture (Phase 2B). MUST be first: `tauri-plugin-sentry`'s
     // minidump reporter relaunches this exe in a special reporter mode that has
@@ -205,6 +269,26 @@ pub fn run() {
     let app_state = Arc::new(Mutex::new(AppState::default()));
 
     let mut builder = tauri::Builder::default()
+        // SINGLE INSTANCE MUST BE FIRST. Two reasons, and the second is ours.
+        //
+        // Upstream requires it so the plugin runs before anything else can
+        // interfere. For Meridian it is also what guarantees the doomed second
+        // process exits BEFORE it can create a tray icon or, far worse, a
+        // capture writer against `meridian.db`.
+        //
+        // Why a second process happens at all: the 09:00 morning trigger
+        // (`autostart`) is started by the OS scheduler, and neither scheduler can
+        // see that the app is already running. launchd tracks liveness per job
+        // LABEL, so the process macOS's loginwindow started via SMAppService is
+        // invisible to our calendar job; Task Scheduler's
+        // `MultipleInstancesPolicy: IgnoreNew` only dedupes the task's own
+        // instances. So the trigger fires daily into a running app, and without
+        // this the result is two processes writing one SQLite file — the
+        // double-writer condition behind `database disk image is malformed`.
+        //
+        // The callback runs in the FIRST (surviving) instance. It deliberately
+        // does nothing but log — see `on_second_instance`.
+        .plugin(tauri_plugin_single_instance::init(on_second_instance))
         .plugin(tauri_plugin_positioner::init())
         .plugin(tauri_plugin_opener::init())
         // DMG auto-update: reads endpoint + minisign pubkey from tauri.conf.json.


### PR DESCRIPTION
Meridian did not appear in System Settings → General → Login Items & Extensions on a current staging build. The raw-plist approach could never have made it appear **as Meridian**.

## Two things I measured before changing anything, because both were being assumed

**1. A plist in `~/Library/LaunchAgents` DOES register with macOS's Background Task Management database.** A probe plist that was never `launchctl bootstrap`ped still showed up in `sfltool dumpbtm`, alongside a bootstrapped control. So the old approach was not invisible, and my earlier theory that it needed bootstrapping was **wrong**.

**2. The app IS Developer ID signed and notarized.** On a shipped `.app`:

```
source=Notarized Developer ID
origin=Developer ID Application: Meridiona LLP (AQTYN9PZ83)
stapler validate: The validate action worked!
```

`release-build.yml:26` notarizes both channels. So the precondition `backend_install.rs` recorded for adopting SMAppService — *"only matters once the app is Developer-ID-signed"* — was **already met when the fallback was written**. I had previously claimed the opposite, from grepping a workflow file that does not exist.

## What actually needed to change

A legacy agent cannot present itself as the *app*: it lands under "Allow in the Background" keyed on the plist, whereas `SMAppService.mainApp` produces an **"Open at Login" entry attributed to the signed bundle**. A user looking for "Meridian" should find "Meridian".

So the **login half** moves to SMAppService, and the plist keeps its one remaining job: the 09:00 relaunch, which SMAppService cannot express at all.

Bindings are **`objc2-service-management` 0.3** — same objc2 generation and maintainers as the `objc2-foundation`/`objc2-app-kit` already used by `commands/app_icons.rs`. Preferred over the third-party `smappservice-rs` (0.1.x, untouched since May 2025) because it adds no new FFI style and no new transitive tree.

## The dangerous part is the coordination

`plist_body` now takes `run_at_load`, and it is **false** whenever SMAppService owns login. Otherwise both mechanisms start a tray at login — two processes writing one SQLite file, the double-writer condition behind the `database disk image is malformed` incidents.

That forced the drift check to change too. The substring probe (*path present? calendar trigger present?*) **structurally cannot see a change to a field it does not name**, and `RunAtLoad` is exactly such a field — an install carrying the previous build's plist would have passed every check while double-launching. macOS now compares the whole rendered body, so every future field change is self-healing and a false "differs" costs one idempotent write. Windows keeps the substring form, because Task Scheduler reformats the XML it returns and an exact compare there would report drift forever. New action: `repaired_stale_definition`.

## Version gating is mandatory, not defensive

The app declares `LSMinimumSystemVersion` **10.13**; SMAppService is **13+**. Sending these selectors on an older system is an unrecognized-selector *crash*, not a graceful failure. Every entry point goes through `login_item::available()`, and below 13 the plist carries both jobs exactly as before.

## `RequiresApproval` is treated as settled

Re-registering cannot clear it — only the user can, in System Settings — so treating it as unsettled would re-register on every launch forever and report a repair every time. It ships on `daily_usage` as `health_autostart_login_item`, because "is Meridian actually in Login Items" was unanswerable from the fleet, and it is the real question behind every "why doesn't it start" report.

## Verification

Both plist variants pass `plutil -lint`, and `plutil -p` confirms `RunAtLoad` true/false respectively, the calendar trigger present in both, and **no `KeepAlive`** in either. 383 tests in the tray crate; 27 workspace suites green.

**Not verifiable from here:** SMAppService refuses an unsigned bundle, so the registration path only exercises on a signed packaged build. This needs a staging DMG and a reboot before it is trusted — and given #828 was merged before its own reboot check happened, that is worth doing this time.

## Still open

This does not explain why the plist was missing on the reporting machine. `meridian logs --service meridian-tray | grep autostart` names the branch that ran; if it says `skipped_*` or `failed` there is a second bug here, and this PR does not fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)