### PR TITLE
fix(daemon): close the double-writer window in daemon startup ordering

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1053,6 +1053,45 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    // 4a-ter. Single-instance guard — CHECKED here, before `setup_db`, even
+    //     though the listener isn't bound until 5b below.
+    //
+    //     ~/.meridian/daemon.sock: a successful connect that gets a greeting
+    //     means ANOTHER daemon already owns this data dir. That happens
+    //     routinely — a leftover packaged install's launchd agent
+    //     (KeepAlive=true) respawning next to a dev build, two `meridian`
+    //     invocations racing — and, the case that motivated moving this check
+    //     ahead of `setup_db`, a version-update restart where
+    //     `backend_install::register_agent` bootstraps the new daemon after a
+    //     15s best-effort wait for the old launchd entry to clear, and
+    //     proceeds anyway (logged at WARN) if it doesn't. Previously this
+    //     check ran AFTER `setup_db` (4b) and the capture preflight (4c), so a
+    //     daemon that was always going to lose this race still opened a pool
+    //     and ran migrations — including a live `ALTER TABLE` — against a
+    //     file the winning daemon could simultaneously be writing to or
+    //     checkpointing. Checking before `setup_db` means a losing daemon
+    //     never touches meridian.db at all.
+    //
+    //     Only a stale socket (no listener) is removed, and only right before
+    //     THIS process binds its own — see the bind site below. Whoever starts
+    //     second bows out; dev-start.sh stops the installed daemon first so
+    //     the dev build wins, and any KeepAlive respawn self-terminates here,
+    //     repeating every ~30s (ThrottleInterval) until the winner's listener
+    //     goes away — the same non-crash stand-down cadence as the repair-
+    //     marker check above, not a crash loop (`KeepAlive` is unconditional
+    //     in the shipped plist, so both an `exit(1)` and this `return Ok(())`
+    //     relaunch regardless).
+    //
+    //     The endpoint itself is OS-specific (a socket file on Unix, a named
+    //     pipe on Windows) — see `meridian::platform`.
+    if meridian::platform::daemon_already_running().await {
+        tracing::warn!(
+            endpoint = %meridian::platform::endpoint_display(),
+            "another meridian daemon already owns this data dir — exiting (single-instance guard)"
+        );
+        return Ok(());
+    }
+
     // 4b. Open / create meridian pool and run migrations FIRST — before any
     //     preflight that can block or fail. The UI and MCP server read this DB
     //     directly, so it must exist even when an optional component (capture,
@@ -1090,27 +1129,18 @@ async fn main() -> Result<()> {
     meridian::health::Report::new(meridian::health::capture::checks(&meridian).await)
         .log("startup");
 
-    // 5b. Unix domain socket — health endpoint for the tray / UI, AND the
-    //     single-instance guard. ~/.meridian/daemon.sock: a successful connect that
-    //     gets a greeting means ANOTHER daemon already owns this data dir. That
-    //     happens routinely — a leftover packaged install's launchd agent
-    //     (KeepAlive=true) respawning next to a dev build, two `meridian` invocations
-    //     racing — and two daemons on one meridian.db double every ETL pass and fire
-    //     the worklog trigger twice (near-duplicate day_tasks, clobbering folds). So
-    //     if one is already answering, exit cleanly here rather than delete its socket
-    //     and become a second writer. Only a stale socket (no listener) is removed
-    //     before we bind our own. Whoever starts second bows out; dev-start.sh stops
-    //     the installed daemon first so the dev build wins, and any KeepAlive respawn
-    //     self-terminates on the next line.
-    //     The endpoint itself is OS-specific (a socket file on Unix, a named
-    //     pipe on Windows) — see `meridian::platform`.
-    if meridian::platform::daemon_already_running().await {
-        tracing::warn!(
-            endpoint = %meridian::platform::endpoint_display(),
-            "another meridian daemon already owns this data dir — exiting (single-instance guard)"
-        );
-        return Ok(());
-    }
+    // 5b. Bind the health-endpoint socket now that the pool is open and
+    //     migrations have run. The single-instance CHECK already happened
+    //     above (4a-ter), before `setup_db` — deliberately not moved down
+    //     here with the bind: binding only now means the greeting
+    //     (`{"running":true}`) is never advertised until the database is
+    //     actually usable. Binding it back at the earlier check site instead
+    //     would let a daemon that's about to `exit(1)` on a locked or corrupt
+    //     database falsely tell the tray's watchdog it's healthy for the
+    //     brief window before that failure surfaces. Safe to bind
+    //     unconditionally here: the check above already established nothing
+    //     else is listening, and nothing between there and here binds it out
+    //     from under us (both single-threaded up to the poll loop).
     meridian::platform::spawn_health_listener()?;
     tracing::info!(endpoint = %meridian::platform::endpoint_display(), "daemon health endpoint ready");
 
@@ -1573,3 +1603,66 @@ async fn etl_tick(meridian: &meridian::db::SqlitePool) -> bool {
 /// The id itself lives in the lib ([`meridian::notices::DB_CORRUPT`]) because
 /// `db::repair` must clear the very same id from a rebuilt database.
 const DB_CORRUPT_NOTICE: &str = meridian::notices::DB_CORRUPT;
+
+#[cfg(test)]
+mod startup_order_tests {
+    /// The single-instance guard's CHECK must run before `setup_db` opens the
+    /// pool and runs migrations, and the health-endpoint BIND must run after.
+    ///
+    /// This is the whole fix: a daemon that is about to lose the
+    /// single-instance race must never touch `meridian.db` — see the comment
+    /// at the check's call site (4a-ter) for the fleet-correlated corruption
+    /// this closes. Regressing either half reopens a real hazard:
+    /// - check moved back after `setup_db` → a losing daemon runs migrations
+    ///   (including a live `ALTER TABLE`) against a file the winning daemon
+    ///   may be concurrently writing to or checkpointing — the double-writer
+    ///   window this change exists to close.
+    /// - bind moved up alongside the check → the health socket can advertise
+    ///   `{"running":true}` for a daemon that is about to `exit(1)` on a
+    ///   locked/corrupt database, feeding the tray's watchdog a false-healthy
+    ///   signal.
+    ///
+    /// `main()` shells out to `launchctl`/binds real OS sockets and can't be
+    /// unit-tested directly, so — matching the established idiom in
+    /// `backend_install.rs` (`a_stuck_bootout_is_reported_at_warn`,
+    /// `every_early_return_still_restores_the_daemon`) — this scans the
+    /// source for the three call sites and asserts their relative order.
+    #[test]
+    fn single_instance_check_precedes_setup_db_and_bind_follows_it() {
+        const SRC: &str = include_str!("main.rs");
+        // Truncate at THIS test module first — the file scans itself, and the
+        // needles below (`daemon_already_running`, `setup_db(&initial_cfg`)
+        // both appear again in this doc comment / this very module, so an
+        // untruncated scan could match its own source and never fail. Same
+        // trap noted in `backend_install.rs`'s self-scanning tests.
+        let prod = SRC
+            .split_once("\n#[cfg(test)]")
+            .map_or(SRC, |(before, _)| before);
+
+        let check_pos = prod
+            .find("meridian::platform::daemon_already_running().await")
+            .expect("the single-instance guard's check call must exist in main()");
+        let setup_db_pos = prod
+            .find("setup_db(&initial_cfg.meridian_db_uri()).await")
+            .expect("the setup_db() call must exist in main()");
+        let bind_pos = prod
+            .find("meridian::platform::spawn_health_listener()?;")
+            .expect("the health-listener bind call must exist in main()");
+
+        assert!(
+            check_pos < setup_db_pos,
+            "the single-instance guard must be CHECKED before setup_db() opens \
+             the pool and runs migrations — a daemon that will lose that race \
+             must never touch meridian.db. Found check at byte {check_pos}, \
+             setup_db at byte {setup_db_pos}."
+        );
+        assert!(
+            setup_db_pos < bind_pos,
+            "the health-endpoint listener must be BOUND only after setup_db() \
+             succeeds — binding earlier would let a daemon that is about to \
+             exit(1) on a locked/corrupt database advertise {{\"running\":true}} \
+             to the tray's watchdog. Found setup_db at byte {setup_db_pos}, \
+             bind at byte {bind_pos}."
+        );
+    }
+}


### PR DESCRIPTION
## What broke

v1.89.0 (shipped 2026-08-20) included PR #821, which hardened `repair_boot.rs`'s
auto-repair-at-boot retry (3 attempts, 2s backoff) for the long-standing
"database disk image is malformed" (SQLite code 11) corruption bug. That PR's
own investigation could not pin down a definitive root-cause race in
`backend_install.rs`'s binary staging/swap sequence.

A fresh pass over central OpenObserve fleet telemetry (comparing the ~9 hours
before vs. after the v1.89.0 release) found something new and concrete:

**12 hosts hit corruption on release day. 6 of them were completely healthy for
the prior 7 days** (clean telemetry) **and started corrupting within hours of
updating to v1.89.0.** All 6 show an identical log sequence around their first
corruption event:

1. Host running v1.88.0 normally.
2. `meridian-tray` relaunches on v1.89.0 (the update swap).
3. Within the same second or two, `meridian-rust` (the daemon) also restarts
   onto v1.89.0.
4. The tray immediately starts logging
   `notices: read failed, treating as empty | err=error returned from database: (code: 1) no such column: deep_link`,
   repeating every ~15-30s.
5. That state persists for **30 seconds to ~2.5 minutes** (varies per host).
6. Within seconds of that window closing (sometimes at the exact same
   timestamp as the last "no such column" log), `database disk image is
   malformed` (code: 11) fires for the first time ever on that host, and stays
   corrupt from then on — including through the v1.89.0-hardened repair_boot
   retry, which in at least 2 of the 6 cases (`mac_b89fa61b8bc65cf7`,
   `mac_c5abcaaeeb774bb2`) ran and logged `database repair failed - the
   original is unchanged` — a terminal failure, not a "needs more retries."

The `deep_link` column is migration `081_system_notices_deep_link.sql` — a
plain, nullable `ALTER TABLE system_notices ADD COLUMN deep_link TEXT;` shipped
in this same release (PR #824). By itself this is a trivial, near-instantaneous
migration. Only the daemon runs migrations (`setup_db()` in
`src/db/meridian.rs`); the tray never does (`open_existing_lazy`, no
migrator) — confirmed by reading both paths.

## What actually causes the stall (and, I believe, the corruption)

The "no such column" stall is **not migration execution time** — `setup_db()`
(pool open + migrate) runs *before every other preflight* in `main()`,
specifically so DB creation never waits on anything slower (see the existing
comment at `main.rs`'s step 4b). A single `ALTER TABLE ADD COLUMN` completes in
well under a second once a daemon process actually reaches that line.

What the 30s-2.5min variability actually tracks is **time-to-a-successful
daemon start**, and the reason a daemon can fail to start (or fail
repeatedly) is a genuine double-writer race that was already half-diagnosed in
this codebase's own comments, just never fully closed:

1. **`backend_install.rs`'s `register_agent`** (used for every version-update
   restart, not just the SQLCipher-migration path) already does a `bootout` +
   15s poll waiting for the *old* daemon's launchd entry to clear — but if
   that wait times out, it logs a WARN ("proceeding to bootstrap anyway") and
   **bootstraps + kickstarts the new daemon regardless**. The comment at that
   call site literally names this "the double-writer precondition behind the
   recurring `database disk image is malformed`", already observed on 8 macOS
   hosts as of 2026-08-17. It was made *visible* (WARN, so it egresses to
   central telemetry) but never *prevented*.
2. **The bigger gap, and the one this PR fixes:** even when the *new* daemon
   starts up completely normally (old one gone, no launchd weirdness), the
   daemon's own single-instance guard — the mechanism specifically designed to
   stop two daemons ever touching one `meridian.db` — runs in the *wrong
   order* in `src/main.rs`. `setup_db()` (open pool, run migrations) is step
   4b; the single-instance check (`daemon_already_running()` against
   `~/.meridian/daemon.sock`) was step 5b, *after* `setup_db` **and** the
   capture-layer preflight. So on every ordinary restart where the old
   daemon hasn't fully relinquished the socket yet (a normal, non-error
   condition during a `KeepAlive` bootout/relaunch — see below), the *new*
   daemon still opens a pool and **runs a live `ALTER TABLE` against
   `meridian.db` while the old daemon may still be an active writer/checkpointer
   on the very same WAL**, only discovering "someone else already owns this"
   *after* touching the file, at which point it exits cleanly — leaving no
   trace that a two-writer window happened at all except for the fleet
   correlation above.

This lines up with prior corruption incidents already tracked in this repo's
history ("WAL checkpoint + two writers", "overlapping installs stage the wrong
daemon") — this is the same failure mode, reproduced by the routine update
path via a startup-ordering bug rather than a swap-sequence bug.

It also explains the 30s-2.5min variability directly: the shipped launchd
plist (`scripts/com.meridiona.daemon.plist`) sets `KeepAlive=true` (unconditional)
and `ThrottleInterval=30`. If the new daemon's `setup_db()` (or anything after
it) fails while racing the old daemon — a `SQLITE_BUSY` past the 5s
`busy_timeout`, a schema-cookie conflict, or the single-instance guard finally
catching up and exiting — the daemon exits, and launchd relaunches it no
sooner than 30s later. Repeated failed/losing attempts land at ~30s
multiples, matching the observed range far better than "migration is slow."

## What I could **not** fully close the loop on

I have not instrumented or reproduced the exact SQLite-internals mechanism
that turns this two-writer window into page-level corruption (I don't have a
repro host, and doing this safely would need strace/dtrace on a real
double-writer collision against a copy of a genuinely affected machine's DB).
I'm confident the window is real and load-bearing from the code + comments +
fleet correlation, but I want to be explicit: **this PR closes a demonstrated
double-writer race, not a proven single point of corruption.** It is possible
there is an additional contributing factor I haven't found. I'd treat this as
a strong, well-reasoned partial fix, not a closed case.

I also want to flag plainly: the tray-side "no such column: deep_link" log
lines are a **correlated symptom, not the cause**. `read_notices()`
(`meridian-core/src/readers/notices.rs`) is explicitly designed to tolerate a
pre-migration schema — `unwrap_or_else` → empty vec, by design, exactly for
this window. That code path is not what's broken; it just happens to be highly
visible during the same window the real bug lives in.

## The fix

One surgical reorder in `src/main.rs`: move the single-instance guard's
**check** (`daemon_already_running()`) to run *before* `setup_db()`, so a
daemon that is going to lose the single-instance race now **never opens a
pool or runs migrations** against a file another instance may still be
writing to. The **bind** (`spawn_health_listener()`) deliberately stays where
it was — after `setup_db` succeeds — so the health socket never advertises
`{"running":true}` for a daemon that's about to `exit(1)` on a locked/corrupt
database (that would feed the tray's watchdog a false-healthy signal).

```
4a-bis. repair-marker check         (unchanged position)
4a-ter. single-instance CHECK       (NEW position — before setup_db)
4b.     setup_db (pool + migrate)
4c.     capture preflight
5b.     single-instance BIND        (unchanged position — after setup_db)
```

Both platforms are covered — `daemon_already_running()` / `endpoint()` /
`spawn_health_listener()` have matching Unix (`daemon.sock`) and Windows
(named pipe) implementations, and neither depends on `Config`/the DB path, so
moving the check earlier is safe on both.

I verified `KeepAlive` is unconditional in the shipped plist, so this reorder
doesn't change failure-mode semantics: a losing daemon already exited cleanly
via this same guard before my change, just later (after touching the DB) —
launchd already retries it every ~30s either way. The only change is that the
retries in between wins are now side-effect-free instead of dangerous.

### Deliberately NOT included in this PR (identified, deferred)

- **`register_agent`'s "proceed anyway" branch** (`backend_install.rs`): making
  a stuck bootout fatal (refuse to bootstrap the new daemon at all) is a
  different fix with a different risk profile — it can leave the daemon
  permanently down if a launchd entry genuinely never clears, which is exactly
  the tradeoff that comment documents on purpose. Worth a follow-up, but it's
  a separate, riskier decision that deserves its own PR and its own review.
- **`wait_for_db_unheld`** (the lsof-based file-lock check used only by the
  SQLCipher-encryption migration path) is not wired into the routine restart
  path either. The single-instance-guard reorder in this PR is a cheaper,
  lower-risk way to close the same class of window for the *routine update*
  case specifically; `wait_for_db_unheld` remains the right tool for a
  process that holds the file open **without** answering the health socket
  (a stray `cargo run`, an orphan from an overlapping install) — that case is
  still unguarded on this path and is out of scope here.
- Did not touch `tray/minimum-version` or propose any forced update — that's
  the maintainer's call.

## Verification

- `cargo +1.93.1 fmt --all -- --check` — clean.
- `cargo +1.93.1 clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo +1.93.1 test --workspace` — all workspace suites pass, 0 failed:
  root `meridian` lib 1016 passed (4 ignored), root `meridian` bin 1 passed
  (the new ordering test), tray lib 378 passed, `tauri-plugin-clerk` 29
  passed, plus doctests.
- New regression test: `startup_order_tests::single_instance_check_precedes_setup_db_and_bind_follows_it`
  in `src/main.rs`. `main()` shells out to `launchctl`/binds real OS sockets
  and can't be unit-tested directly, so — matching this file's own existing
  idiom for exactly this problem (`backend_install.rs`'s
  `a_stuck_bootout_is_reported_at_warn` / `every_early_return_still_restores_the_daemon`)
  — it's a source-scan asserting the check precedes `setup_db` and the bind
  follows it, truncated at `\n#[cfg(test)]` to avoid the self-matching trap
  those existing tests already guard against. Verified TDD-style: temporarily
  reintroduced the old (buggy) ordering and confirmed this test fails with
  the expected message before reverting to the fix.
- Full pre-push hook (all 3 waves — fmt+ui build, clippy+ui tests,
  security audit+cargo test) — all green; see push output on this PR's branch.

## Files changed

- `src/main.rs` — reordered the single-instance guard's check ahead of
  `setup_db`; added the regression test.
