### PR TITLE
feat(tray): trigger the relaunch on the OS's own wake events, not a hardcoded hour

### DIFF
--- a/tray/src-tauri/Cargo.toml
+++ b/tray/src-tauri/Cargo.toml
@@ -48,7 +48,7 @@ tauri-plugin-positioner = { version = "2.3", features = ["tray-icon"] }
 tauri-plugin-notifications = { version = "=0.4.6", default-features = false }
 # Single instance. LOAD-BEARING for autostart correctness, not a nicety.
 #
-# The 09:00 morning trigger (`autostart::macos` / `autostart::windows`) starts the
+# The new-day relaunch trigger (`autostart::macos` / `autostart::windows`) starts the
 # tray from the OS scheduler, and neither scheduler can see "the app is already
 # running": launchd tracks liveness per JOB LABEL, so the process macOS's
 # loginwindow started via SMAppService is invisible to our calendar job, and Task

--- a/tray/src-tauri/src/autostart.rs
+++ b/tray/src-tauri/src/autostart.rs
@@ -55,11 +55,11 @@
 //! - **Windows** — one scheduled task with a `LogonTrigger` *and* a daily
 //!   `CalendarTrigger`, registered from XML because `schtasks`' command form
 //!   cannot express two triggers. Its `MultipleInstancesPolicy` is `IgnoreNew`,
-//!   which is what stops the 09:00 trigger starting a second tray on top of the
-//!   one the logon trigger already started.
+//!   which is what stops the new-day trigger starting a second tray on top of
+//!   the one the logon trigger already started.
 //!
 //! # Duplicates are prevented by a guard, not by hoping
-//! The 09:00 trigger is started by the OS scheduler, and **neither scheduler can
+//! The new-day trigger is started by the OS scheduler, and **neither scheduler can
 //! see that the app is already running.** launchd tracks liveness per job
 //! LABEL, so the process macOS's loginwindow started via SMAppService is
 //! invisible to our calendar job; Task Scheduler's `MultipleInstancesPolicy:
@@ -74,7 +74,7 @@
 //!
 //! An earlier version of this module claimed `RunAtLoad false` alone prevented
 //! the duplicate. It does not — it only prevents one at LOGIN, and moved the
-//! collision to 09:00.
+//! collision to the new-day trigger.
 //!
 //! # Who calls this
 //! [`crate::run`]'s `setup()` hook, once per launch, bundled runs only (see
@@ -154,13 +154,49 @@ where
     args.into_iter().any(|a| a.as_ref() == AUTOSTART_FLAG)
 }
 
-/// Local hour the morning relaunch fires, on both platforms.
+/// Local hour the NEW-DAY relaunch fires, on both platforms.
+///
+/// # The requirement is "whenever they next start", not a clock time
+/// If the user quits, Meridian must be back by the time they next sit down —
+/// the next morning, whenever that is. A fixed hour is a crude way to express
+/// that, so the hour is chosen to make the OS's own missed-trigger behaviour do
+/// the work:
+///
+/// - **Machine asleep overnight.** launchd coalesces missed
+///   `StartCalendarInterval` fires and runs them **on wake** (Apple's
+///   "Scheduling Timed Jobs"); Windows does the same via the task's
+///   `StartWhenAvailable`. So for any wake after this hour, the trigger fires
+///   *at the moment they open the laptop* — exactly the requirement, with no
+///   activity detection at all.
+/// - **Machine powered off overnight.** The calendar miss is irrelevant: powering
+///   on means logging in, and the LOGIN trigger covers that.
+/// - **Machine left on overnight.** This is the only case where a clock time is
+///   really a clock time, and it is why the hour is 06:00 rather than just after
+///   midnight.
+///
+/// # Why 06:00 specifically
+/// It has to be before anyone's workday starts, or they arrive to a tray that is
+/// still quit. It also has to be late enough that a machine left running is not
+/// woken back into capturing someone's evening: `work_hours_enabled` defaults to
+/// **false**, so capture is NOT paused outside work hours by default, and a
+/// 00:05 relaunch would mean quitting at 20:00 and being watched again from just
+/// after midnight. Someone who quits deliberately should not get that.
+///
+/// 06:00 sits in the gap: after essentially all late-night use, before
+/// essentially every workday. A machine left on is idle or locked then, so the
+/// relaunch captures nothing meaningful; a machine asleep gets it on wake.
+///
+/// # The residual gap, stated plainly
+/// Someone who genuinely starts before 06:00 on a machine that never slept
+/// waits until 06:00. Nothing here fixes that, and the exact fix would be an
+/// activity probe (macOS `HIDIdleTime`, Windows `GetLastInputInfo`) driven by the
+/// always-running daemon — real machinery, for an edge this does not justify yet.
 ///
 /// A constant, not a setting: a settings field would need a UI, a migration and
-/// a re-registration path on change, to serve a preference nobody has asked
-/// for. Widening this to several times a day is one more entry in the plist's
-/// `StartCalendarInterval` array / the task's `Triggers`.
-pub(crate) const MORNING_HOUR: u32 = 9;
+/// a re-registration path on change. Widening it is one more entry in the plist's
+/// `StartCalendarInterval` array / the task's `Triggers`, and the single-instance
+/// guard makes extra fires harmless no-ops.
+pub(crate) const MORNING_HOUR: u32 = 6;
 
 /// Marker recording that the user deliberately turned autostart OFF.
 ///

--- a/tray/src-tauri/src/autostart.rs
+++ b/tray/src-tauri/src/autostart.rs
@@ -154,49 +154,14 @@ where
     args.into_iter().any(|a| a.as_ref() == AUTOSTART_FLAG)
 }
 
-/// Local hour the NEW-DAY relaunch fires, on both platforms.
-///
-/// # The requirement is "whenever they next start", not a clock time
-/// If the user quits, Meridian must be back by the time they next sit down —
-/// the next morning, whenever that is. A fixed hour is a crude way to express
-/// that, so the hour is chosen to make the OS's own missed-trigger behaviour do
-/// the work:
-///
-/// - **Machine asleep overnight.** launchd coalesces missed
-///   `StartCalendarInterval` fires and runs them **on wake** (Apple's
-///   "Scheduling Timed Jobs"); Windows does the same via the task's
-///   `StartWhenAvailable`. So for any wake after this hour, the trigger fires
-///   *at the moment they open the laptop* — exactly the requirement, with no
-///   activity detection at all.
-/// - **Machine powered off overnight.** The calendar miss is irrelevant: powering
-///   on means logging in, and the LOGIN trigger covers that.
-/// - **Machine left on overnight.** This is the only case where a clock time is
-///   really a clock time, and it is why the hour is 06:00 rather than just after
-///   midnight.
-///
-/// # Why 06:00 specifically
-/// It has to be before anyone's workday starts, or they arrive to a tray that is
-/// still quit. It also has to be late enough that a machine left running is not
-/// woken back into capturing someone's evening: `work_hours_enabled` defaults to
-/// **false**, so capture is NOT paused outside work hours by default, and a
-/// 00:05 relaunch would mean quitting at 20:00 and being watched again from just
-/// after midnight. Someone who quits deliberately should not get that.
-///
-/// 06:00 sits in the gap: after essentially all late-night use, before
-/// essentially every workday. A machine left on is idle or locked then, so the
-/// relaunch captures nothing meaningful; a machine asleep gets it on wake.
-///
-/// # The residual gap, stated plainly
-/// Someone who genuinely starts before 06:00 on a machine that never slept
-/// waits until 06:00. Nothing here fixes that, and the exact fix would be an
-/// activity probe (macOS `HIDIdleTime`, Windows `GetLastInputInfo`) driven by the
-/// always-running daemon — real machinery, for an edge this does not justify yet.
-///
-/// A constant, not a setting: a settings field would need a UI, a migration and
-/// a re-registration path on change. Widening it is one more entry in the plist's
-/// `StartCalendarInterval` array / the task's `Triggers`, and the single-instance
-/// guard makes extra fires harmless no-ops.
-pub(crate) const MORNING_HOUR: u32 = 6;
+// NOTE: there is no MORNING_HOUR any more, and that removal is the point.
+//
+// A hardcoded relaunch hour was the wrong shape for the requirement ("Meridian is
+// running after the device is turned on or woken"): it fires when the user is not
+// there and misses them when they are. Both platforms now trigger on the OS's own
+// events instead - launchd `LaunchEvents` on wake/unlock notifications
+// ([`macos::WAKE_NOTIFICATIONS`]) and Windows `SessionStateChangeTrigger` on
+// `SessionUnlock`/`ConsoleConnect`. There is no clock left in this module.
 
 /// Marker recording that the user deliberately turned autostart OFF.
 ///

--- a/tray/src-tauri/src/autostart/macos.rs
+++ b/tray/src-tauri/src/autostart/macos.rs
@@ -90,7 +90,7 @@ fn current_exe() -> Option<PathBuf> {
 /// The rest:
 /// - `StartCalendarInterval` covers "the user quit; bring it back tomorrow
 ///   morning". launchd runs a missed calendar job when the machine wakes, so a
-///   laptop asleep at [`super::MORNING_HOUR`] still gets it.
+///   laptop asleep at [`super::MORNING_HOUR`] (06:00) still gets it.
 /// - **No `KeepAlive`**, deliberately: with it, Quit would be undone within
 ///   seconds and there would be no way to stop Meridian for the afternoon. The
 ///   daemon's plist makes the opposite choice because it is headless and has no
@@ -265,7 +265,7 @@ pub(crate) async fn ensure_registered() -> RegistrationAction {
     //
     // The gain is not cosmetic: without bootstrapping, launchd only picks the
     // job up at the next login, so a user who installed and then quit the same
-    // day would NOT come back at 09:00. Bootstrapping closes that gap, so the
+    // day would NOT come back on the new-day trigger. Bootstrapping closes that gap, so the
     // morning relaunch works from the moment of install.
     //
     // Best-effort: `bootout` first so a re-registration replaces cleanly, and a
@@ -347,7 +347,8 @@ async fn migrate_off_plugin() {
 ///
 /// The accepted cost is narrow. Our plist DOES carry a morning trigger, and it
 /// stays live until logout, so a user who turns autostart off AND quits later
-/// the same day could still be relaunched once at 09:00. From the next login on
+/// the same day could still be relaunched once by the new-day trigger. From the
+/// next login on
 /// there is no plist to load and the setting is fully honoured. Relaunching
 /// once beats quitting the app out from under someone who was changing a
 /// preference.

--- a/tray/src-tauri/src/autostart/macos.rs
+++ b/tray/src-tauri/src/autostart/macos.rs
@@ -52,6 +52,35 @@ const LEGACY_PLIST_FILE: &str = "Meridian.plist";
 // because Task Scheduler reformats the XML it hands back, so an exact compare
 // there would report drift on every launch.
 
+/// Darwin notifications that mean "the device just became usable again".
+///
+/// See [`plist_body`] for why this is a SET rather than one name, and for where
+/// each came from. Order is irrelevant; launchd keys the dict by name.
+pub(crate) const WAKE_NOTIFICATIONS: [&str; 7] = [
+    // Unlock. macOS requires a password after sleep by default, so this is the
+    // common path for "opened the laptop". Apple triggers its own
+    // com.apple.contextstored on this exact name.
+    "com.apple.sessionagent.screenIsUnlocked",
+    // Desktop up after login / fast user switch.
+    "com.apple.system.loginwindow.desktopUp",
+    // The display coming back on - the closest thing to "the screen is usable
+    // again" for a machine woken without a password prompt.
+    "com.apple.iokit.hid.displayStatus",
+    // System power state change (sleep/wake). BOTH spellings are listed on
+    // purpose: Apple's own plists use the `com.apple.powermanagement.*` form
+    // while the community-collected list uses `com.apple.system.powermanagement.*`.
+    // One of them is wrong on any given release and neither costs anything -
+    // see `plist_body` for why an unknown name is inert.
+    "com.apple.system.powermanagement.systempowerstate",
+    "com.apple.powermanagement.systempowerstate",
+    // A power event the user actually sees, i.e. a real wake rather than a dark
+    // wake for maintenance.
+    "com.apple.system.powermanagement.uservisiblepowerevent",
+    // The laptop lid - literally "device opened". Fires on close too, which is a
+    // harmless no-op thanks to the single-instance guard.
+    "com.apple.system.powermanagement.clamshellstate",
+];
+
 /// `~/Library/LaunchAgents`, where per-user agents live. `None` when the home
 /// directory cannot be resolved, in which case there is nothing this module can
 /// do.
@@ -73,42 +102,77 @@ fn current_exe() -> Option<PathBuf> {
 /// Pure and separate from the write so every field below is unit-testable
 /// without touching `~/Library/LaunchAgents` on a developer machine.
 ///
-/// # `run_at_load` is the coordination with SMAppService, not a preference
-/// On macOS 13+ the login half is owned by
-/// [`super::login_item`] (`SMAppService.mainApp`), which is what produces a
-/// named, user-togglable "Meridian" entry in Login Items & Extensions. This
-/// plist is then reduced to its ONE remaining job — the morning relaunch — and
-/// must be written with `run_at_load` **false**. Leaving it true would mean two
-/// independent mechanisms both starting a tray at login: two processes writing
-/// one SQLite file, which is the double-writer condition behind the
-/// `database disk image is malformed` incidents documented in
-/// `backend_install.rs`.
+/// # There is no clock in here, deliberately
+/// The requirement is "Meridian is running after the device is turned on or
+/// woken" — an EVENT, not a time. This used to be a `StartCalendarInterval` at a
+/// hardcoded hour, which is the wrong shape for that: it fires when the user
+/// isn't there, and misses them when they are.
 ///
-/// Below macOS 13 SMAppService does not exist, so this plist carries both jobs
-/// and `run_at_load` is true.
+/// launchd has no `wake` or `unlock` trigger among its start keys (`RunAtLoad`,
+/// `StartInterval`, `StartCalendarInterval`, `WatchPaths`, `QueueDirectories`,
+/// `StartOnMount`, `KeepAlive`, `MachServices`, `Sockets`) — but `LaunchEvents`
+/// with the `com.apple.notifyd.matching` stream starts a job on an arbitrary
+/// Darwin notification, which is how Apple's own agents do this. The shape here
+/// is copied from `/System/Library/LaunchDaemons/com.apple.contextstored.plist`,
+/// which triggers on the same unlock notification, and the mechanism was
+/// verified end-to-end on macOS 26: a probe agent did not run on bootstrap and
+/// ran the instant its notification was posted.
 ///
-/// The rest:
-/// - `StartCalendarInterval` covers "the user quit; bring it back tomorrow
-///   morning". launchd runs a missed calendar job when the machine wakes, so a
-///   laptop asleep at [`super::MORNING_HOUR`] (06:00) still gets it.
-/// - **No `KeepAlive`**, deliberately: with it, Quit would be undone within
-///   seconds and there would be no way to stop Meridian for the afternoon. The
-///   daemon's plist makes the opposite choice because it is headless and has no
-///   Quit.
-/// - [`super::AUTOSTART_FLAG`] is passed so the tray knows this launch was
-///   unattended and must not open a window.
-/// - `ProcessType` `Interactive` keeps launchd from throttling a job that owns
-///   UI.
+/// # Why SEVERAL notifications rather than the one right one
+/// These names are private, so Apple documents none of them and no single one
+/// can be relied on across releases. That would normally be a reason for
+/// caution; here it is free, for two reasons:
+///
+/// - A notification launchd never receives is simply **inert** — an unknown name
+///   costs nothing and fails silently in the safe direction.
+/// - A notification that fires while the tray is ALREADY running costs a process
+///   that exits in milliseconds, because `tauri-plugin-single-instance` is
+///   registered first (see [`crate::run`]).
+///
+/// So the set is chosen for coverage, not minimality, and no single guess has to
+/// be correct:
+///
+/// See [`WAKE_NOTIFICATIONS`] for the list and what each one covers. Both
+/// spellings of the power-state notification are included because Apple's plists
+/// and the community-collected list disagree, and being wrong about one is free.
+///
+/// **Measured, not assumed** (macOS 26): a plist carrying a deliberately bogus
+/// notification name alongside real ones still bootstrapped cleanly, and the
+/// real notification still started the job. So an unknown or renamed name
+/// degrades to "never fires" rather than breaking the whole registration.
+///
+/// Login itself is NOT here: on macOS 13+ it belongs to `SMAppService`
+/// ([`super::login_item`]), which is what produces a named, user-togglable
+/// "Meridian" entry in Login Items & Extensions.
+///
+/// # The rest
+/// - `run_at_load` is the coordination with SMAppService. FALSE when SMAppService
+///   owns login, or both would start a tray at login. Below macOS 13 there is no
+///   SMAppService, so it is true and this plist carries login too.
+/// - **No `KeepAlive`**, deliberately: with it Quit would be undone within
+///   seconds and there would be no way to stop Meridian at all. The daemon's
+///   plist makes the opposite choice because it is headless and has no Quit.
+/// - [`super::AUTOSTART_FLAG`] tells the tray this launch was unattended, so it
+///   opens no window (`crate::poll::whats_new_auto_open`).
+/// - `ProcessType` `Interactive` keeps launchd from throttling a job that owns UI.
 /// - The stdout/stderr redirects are the OS-level crash safety net described in
 ///   `CLAUDE.md`'s observability section — the one thing the OTel spool cannot
-///   capture. `src/telemetry_spool/launchd_log_cap.rs` already size-caps these
-///   exact paths.
+///   capture. `src/telemetry_spool/launchd_log_cap.rs` size-caps these exact paths.
 pub(crate) fn plist_body(exe: &Path, home: &Path, run_at_load: bool) -> String {
     let exe = super::xml_escape(&exe.to_string_lossy());
     let home = super::xml_escape(&home.to_string_lossy());
     let flag = super::AUTOSTART_FLAG;
-    let hour = super::MORNING_HOUR;
     let run_at_load = if run_at_load { "<true/>" } else { "<false/>" };
+    // Rendered from the table rather than hand-written, so adding a trigger is
+    // one entry and the plist cannot drift from the list.
+    let events: String = WAKE_NOTIFICATIONS
+        .iter()
+        .map(|n| {
+            format!(
+                "            <key>{n}</key>\n                             <dict>\n                <key>Notification</key>\n                                 <string>{n}</string>\n            </dict>\n"
+            )
+        })
+        .collect();
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -126,15 +190,12 @@ pub(crate) fn plist_body(exe: &Path, home: &Path, run_at_load: bool) -> String {
     <key>RunAtLoad</key>
     {run_at_load}
 
-    <key>StartCalendarInterval</key>
-    <array>
+    <key>LaunchEvents</key>
+    <dict>
+        <key>com.apple.notifyd.matching</key>
         <dict>
-            <key>Hour</key>
-            <integer>{hour}</integer>
-            <key>Minute</key>
-            <integer>0</integer>
-        </dict>
-    </array>
+{events}        </dict>
+    </dict>
 
     <key>StandardOutPath</key>
     <string>{home}/.meridian/logs/tray.log</string>
@@ -422,25 +483,53 @@ mod tests {
         assert!(fallback.contains("<key>RunAtLoad</key>\n    <true/>"));
     }
 
-    /// The morning trigger is this plist's reason to exist in BOTH modes -
-    /// SMAppService cannot express a calendar interval at all.
+    /// The wake triggers are this plist's reason to exist in BOTH modes -
+    /// SMAppService cannot express them at all, and there is no clock left.
     #[test]
-    fn both_modes_keep_the_morning_trigger() {
+    fn both_modes_carry_every_wake_notification_and_no_clock() {
         for run_at_load in [true, false] {
             let b = body(run_at_load);
             assert!(
-                b.contains("StartCalendarInterval"),
+                b.contains("<key>LaunchEvents</key>"),
                 "run_at_load={run_at_load}"
             );
             assert!(
-                b.contains(&format!(
-                    "<integer>{}</integer>",
-                    super::super::MORNING_HOUR
-                )),
+                b.contains("com.apple.notifyd.matching"),
                 "run_at_load={run_at_load}"
             );
+            for n in WAKE_NOTIFICATIONS {
+                assert!(b.contains(n), "missing {n} (run_at_load={run_at_load})");
+            }
             assert!(b.contains(super::super::AUTOSTART_FLAG));
+            // The whole point of the rewrite: no hardcoded time survives.
+            assert!(
+                !b.contains("StartCalendarInterval") && !b.contains("StartInterval"),
+                "a clock came back - the requirement is an event, not a time"
+            );
         }
+    }
+
+    /// Each notification must appear as its own `{{ Notification: <name> }}` dict
+    /// under `com.apple.notifyd.matching`, which is the shape Apple's own
+    /// `com.apple.contextstored.plist` uses. A flat array silently never fires.
+    #[test]
+    fn each_notification_is_rendered_in_apples_dict_shape() {
+        let b = body(false);
+        for n in WAKE_NOTIFICATIONS {
+            assert!(
+                b.contains(&format!("<key>{n}</key>")),
+                "{n} is not a key in the matching dict"
+            );
+            assert!(
+                b.contains(&format!("<string>{n}</string>")),
+                "{n} has no Notification value"
+            );
+        }
+        assert_eq!(
+            b.matches("<key>Notification</key>").count(),
+            WAKE_NOTIFICATIONS.len(),
+            "one Notification key per notification"
+        );
     }
 
     /// `KeepAlive` would make Quit impossible - the user explicitly wants

--- a/tray/src-tauri/src/autostart/windows.rs
+++ b/tray/src-tauri/src/autostart/windows.rs
@@ -2,6 +2,23 @@
 //! Windows side of [`crate::autostart`] — one per-user scheduled task carrying
 //! both a logon trigger and a daily trigger.
 //!
+//! # The triggers are EVENTS, not a clock
+//! The requirement is "Meridian is running after the device is turned on or
+//! woken". Windows expresses that natively: `SessionStateChangeTrigger` fires on
+//! `SessionUnlock` (the user unlocked the workstation) and `ConsoleConnect` (the
+//! user connected to the session), alongside `LogonTrigger` for sign-in. There
+//! is no hardcoded time anywhere.
+//!
+//! This replaced a daily `CalendarTrigger` at a fixed hour, which was the wrong
+//! shape for the requirement: it fired when the user was not there and missed
+//! them when they were. macOS gets the same treatment through launchd's
+//! `LaunchEvents` (see [`super::macos`]); the two platforms now use each OS's
+//! own event system rather than a clock.
+//!
+//! Firing on every unlock is safe because `tauri-plugin-single-instance` is
+//! registered first, so a launch into an already-running tray exits in
+//! milliseconds.
+//!
 //! # Why XML, not `schtasks /SC`
 //! The command form takes exactly one `/SC`, so a login task and a daily task
 //! would have to be two separate tasks — and two tasks are two independent
@@ -17,14 +34,15 @@
 //! all (the same policy [`crate::backend_install`] already works around for the
 //! daemon), so this degrades rather than giving up:
 //!
-//! 1. `schtasks /Create /XML` — logon + morning, `IgnoreNew`.
-//! 2. `schtasks /Create /SC ONLOGON` — logon only. Loses the morning relaunch,
-//!    keeps the restart case.
+//! 1. `schtasks /Create /XML` — logon + unlock + console-connect, `IgnoreNew`.
+//! 2. `schtasks /Create /SC ONLOGON` — logon only. Loses the wake triggers, keeps
+//!    the restart case. The command form takes one `/SC` and cannot express a
+//!    session-state trigger at all.
 //! 3. A hidden VBScript in the Startup folder — logon only, no Task Scheduler
 //!    involvement at all.
 //!
-//! Each fallback is logged at WARN, so "how many Windows installs cannot have a
-//! morning relaunch" is answerable from the fleet rather than guessed at.
+//! Each fallback is logged at WARN, so "how many Windows installs cannot wake
+//! Meridian on unlock" is answerable from the fleet rather than guessed at.
 //!
 //! # Who calls this
 //! [`crate::autostart::ensure_registered`] and [`crate::autostart::status`].
@@ -38,9 +56,12 @@ use std::path::{Path, PathBuf};
 /// with separate lifecycles, and `src/uninstall.rs` deletes them by name.
 pub(crate) const TASK_NAME: &str = "Meridian Tray";
 
-/// Element that proves the registered task carries the morning trigger. See
+/// Element that proves the registered task carries the wake triggers. See
 /// [`super::decide`] for why this is a text check.
-const MORNING_TRIGGER_MARKER: &str = "CalendarTrigger";
+///
+/// It is also the upgrade detector for installs registered by an earlier build,
+/// whose task carried a `CalendarTrigger` at a hardcoded hour instead.
+const MORNING_TRIGGER_MARKER: &str = "SessionStateChangeTrigger";
 
 /// The `HKCU\...\Run` value `tauri-plugin-autostart` used to write, named after
 /// `productName`. Removed on first run so an upgraded install does not start
@@ -88,11 +109,6 @@ fn current_exe() -> Option<PathBuf> {
 pub(crate) fn task_xml(exe: &Path) -> String {
     let exe = super::xml_escape(&exe.to_string_lossy());
     let flag = super::xml_escape(super::AUTOSTART_FLAG);
-    let hour = super::MORNING_HOUR;
-    // The date component of `StartBoundary` only establishes when the schedule
-    // begins; with `ScheduleByDay` the time of day is what recurs. A fixed past
-    // date keeps this function pure - deriving "today" would make the generated
-    // XML differ on every launch and so read as drift.
     format!(
         r#"<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
@@ -103,13 +119,14 @@ pub(crate) fn task_xml(exe: &Path) -> String {
     <LogonTrigger>
       <Enabled>true</Enabled>
     </LogonTrigger>
-    <CalendarTrigger>
-      <StartBoundary>2020-01-01T{hour:02}:00:00</StartBoundary>
+    <SessionStateChangeTrigger>
       <Enabled>true</Enabled>
-      <ScheduleByDay>
-        <DaysInterval>1</DaysInterval>
-      </ScheduleByDay>
-    </CalendarTrigger>
+      <StateChange>SessionUnlock</StateChange>
+    </SessionStateChangeTrigger>
+    <SessionStateChangeTrigger>
+      <Enabled>true</Enabled>
+      <StateChange>ConsoleConnect</StateChange>
+    </SessionStateChangeTrigger>
   </Triggers>
   <Principals>
     <Principal id="Author">
@@ -515,12 +532,18 @@ mod tests {
     /// would have two instance policies, and the morning one would start a
     /// second tray on top of the running one.
     #[test]
-    fn task_carries_both_triggers_on_one_task() {
+    fn task_carries_logon_and_wake_triggers_on_one_task() {
         let x = task_xml(Path::new(EXE));
         assert!(x.contains("<LogonTrigger>"));
         assert!(x.contains(MORNING_TRIGGER_MARKER));
         assert_eq!(x.matches("<Actions").count(), 1, "one action, one task");
-        assert!(x.contains(&format!("T{:02}:00:00", super::super::MORNING_HOUR)));
+        // Both native wake triggers, and NO clock.
+        assert!(x.contains("<StateChange>SessionUnlock</StateChange>"));
+        assert!(x.contains("<StateChange>ConsoleConnect</StateChange>"));
+        assert!(
+            !x.contains("CalendarTrigger"),
+            "a hardcoded daily trigger came back - the requirement is an event, not a time"
+        );
     }
 
     /// `IgnoreNew` is what makes the morning trigger a no-op while the tray is

--- a/tray/src-tauri/src/autostart/windows.rs
+++ b/tray/src-tauri/src/autostart/windows.rs
@@ -5,7 +5,7 @@
 //! # Why XML, not `schtasks /SC`
 //! The command form takes exactly one `/SC`, so a login task and a daily task
 //! would have to be two separate tasks — and two tasks are two independent
-//! instance policies, so the 09:00 task would start a second tray on top of the
+//! instance policies, so the daily trigger would start a second tray on top of the
 //! one the logon task already started. Registering from XML allows one task
 //! with two triggers, and therefore one `MultipleInstancesPolicy` of
 //! `IgnoreNew`, which is what makes the morning trigger a no-op while the tray
@@ -79,7 +79,7 @@ fn current_exe() -> Option<PathBuf> {
 ///   default to TRUE in Task Scheduler, which on a laptop means the tray never
 ///   starts on battery and is KILLED when the machine unplugs. That default
 ///   would silently make Meridian a desktop-only product.
-/// - `StartWhenAvailable` `true` — runs a missed 09:00 trigger once the machine
+/// - `StartWhenAvailable` `true` — runs a missed new-day trigger once the machine
 ///   is next awake, matching launchd's behaviour on macOS.
 /// - `ExecutionTimeLimit` `PT0S` — no limit. The default (72 hours) would
 ///   terminate a long-running tray.

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -168,7 +168,7 @@ mod single_instance_tests {
     /// `ui/__tests__/no-native-dialogs.test.ts`. What it protects is specific:
     /// every single-instance example on the internet focuses the main window,
     /// so the natural "improvement" to this callback is precisely the bug. The
-    /// common caller is the 09:00 morning trigger on a machine nobody touched.
+    /// common caller is the new-day relaunch trigger on a machine nobody touched.
     #[test]
     fn the_second_instance_callback_opens_nothing() {
         let src = include_str!("lib.rs");
@@ -202,7 +202,7 @@ mod single_instance_tests {
 ///
 /// This is a deliberate departure from every single-instance example, which
 /// focuses or shows the main window. Doing that here would be actively wrong:
-/// the overwhelmingly common caller is the 09:00 morning trigger passing
+/// the overwhelmingly common caller is the new-day relaunch trigger passing
 /// `--autostart`, i.e. the OS starting Meridian on a machine nobody touched. A
 /// window appearing then is exactly the annoyance that makes people disable
 /// autostart, which costs us the capture the tray exists to perform.
@@ -276,7 +276,7 @@ pub fn run() {
         // process exits BEFORE it can create a tray icon or, far worse, a
         // capture writer against `meridian.db`.
         //
-        // Why a second process happens at all: the 09:00 morning trigger
+        // Why a second process happens at all: the new-day relaunch trigger
         // (`autostart`) is started by the OS scheduler, and neither scheduler can
         // see that the app is already running. launchd tracks liveness per job
         // LABEL, so the process macOS's loginwindow started via SMAppService is

--- a/ui/components/timeline/settings/CaptureSection.tsx
+++ b/ui/components/timeline/settings/CaptureSection.tsx
@@ -68,7 +68,7 @@ export function CaptureSection({ settings, patch, save }: {
           this key registers or removes that job immediately. */}
       <SectionCard>
         <SectionHeader>Startup</SectionHeader>
-        <FieldRow label="Start Meridian automatically" description="On by default: Meridian starts in your menu bar when you sign in, and comes back the next morning if you quit it - as soon as you open your laptop or start your day. It opens quietly in the background - no window, nothing to dismiss. Meridian only records your work while it is running, so turning this off means days you forget to open it are not tracked.">
+        <FieldRow label="Start Meridian automatically" description="On by default: Meridian starts in your menu bar when you sign in, and comes back whenever you turn your machine on or wake it up. It opens quietly in the background - no window, nothing to dismiss. Meridian only records your work while it is running, so turning this off means days you forget to open it are not tracked.">
           <Switch checked={settings.autostart_enabled} onCheckedChange={v => patch({ autostart_enabled: v })} />
         </FieldRow>
         <SaveButton

--- a/ui/components/timeline/settings/CaptureSection.tsx
+++ b/ui/components/timeline/settings/CaptureSection.tsx
@@ -68,7 +68,7 @@ export function CaptureSection({ settings, patch, save }: {
           this key registers or removes that job immediately. */}
       <SectionCard>
         <SectionHeader>Startup</SectionHeader>
-        <FieldRow label="Start Meridian automatically" description="On by default: Meridian starts in your menu bar when you sign in, and again at 9am if you quit it. It opens quietly in the background - no window, nothing to dismiss. Meridian only records your work while it is running, so turning this off means days you forget to open it are not tracked.">
+        <FieldRow label="Start Meridian automatically" description="On by default: Meridian starts in your menu bar when you sign in, and comes back the next morning if you quit it - as soon as you open your laptop or start your day. It opens quietly in the background - no window, nothing to dismiss. Meridian only records your work while it is running, so turning this off means days you forget to open it are not tracked.">
           <Switch checked={settings.autostart_enabled} onCheckedChange={v => patch({ autostart_enabled: v })} />
         </FieldRow>
         <SaveButton


### PR DESCRIPTION
Follow-up to #837, which merged before these two commits landed. v1.90.0-staging.1
therefore ships the SMAppService login item and the single-instance guard, but still
carries a hardcoded `StartCalendarInterval` hour - the part this replaces.

## What changes

The next-day relaunch no longer runs off a clock. macOS gets `LaunchEvents` ->
`com.apple.notifyd.matching` on the notifications the OS already posts when the machine
becomes usable (unlock, desktop-up, display/power state, clamshell), so Meridian comes
back whenever the user actually starts - not at a time we picked for them, and not
never because the laptop was shut at that time. Windows mirrors it with `LogonTrigger`
plus two `SessionStateChangeTrigger`s (`SessionUnlock`, `ConsoleConnect`).

`MORNING_HOUR` is deleted rather than lowered.

Safe to fire on every unlock only because #837 landed the single-instance guard first:
a second launch exits immediately instead of stacking trays.

## Verified locally (macOS 26)

- a probe agent starts on `notifyd` post and only then;
- an unrecognised notification name leaves the plist valid and the real trigger still
  fires - which is what makes a broad notification set free rather than risky;
- the real generated plist passes `plutil -lint`, bootstraps, and starts its job on
  `com.apple.sessionagent.screenIsUnlocked`.

## Not verified

The Windows XML is documentation-derived; no Windows machine was available. The macOS
notification *names* are proven inert-when-wrong, not proven to fire on every wake path.
