### PR TITLE
fix(onboarding): auto-advance past the gated PM-tool step on decline

### DIFF
--- a/ui/components/IntegrationConnect.tsx
+++ b/ui/components/IntegrationConnect.tsx
@@ -34,11 +34,15 @@ import type { GithubProject, JiraProject } from '@/components/integrationConnect
 
 // ── Main list ─────────────────────────────────────────────────────────────────
 export default function ConnectTrackers({
-  integrations, onChanged, compact,
+  integrations, onChanged, compact, onDecline,
 }: {
   integrations: IntegrationsResponse | null
   onChanged?: () => void
   compact?: boolean
+  /** Only meaningful when this list is rendered as the onboarding gate
+   *  (`IntegrationsSection`'s `gate` prop) — see `RequestToolForm`'s doc for
+   *  why submitting "I don't see my tool" also fires this. */
+  onDecline?: () => void
 }) {
   const [open, setOpen] = useState<string | null>(null)
   const [disconnecting, setDisconnecting] = useState<string | null>(null)
@@ -116,7 +120,7 @@ export default function ConnectTrackers({
         })}
         <div style={{ borderTop: '1px solid var(--t-hair)' }}>
           {requestingTool ? (
-            <RequestToolForm onDone={() => setRequestingTool(false)} />
+            <RequestToolForm onDone={() => setRequestingTool(false)} onDecline={onDecline} />
           ) : (
             <button
               onClick={() => setRequestingTool(true)}
@@ -132,11 +136,22 @@ export default function ConnectTrackers({
 }
 
 // ── "I don't see my tool" (request_pm_tool — settings mirror + PostHog) ─────
-// A side channel, not a connect flow: submitting neither blocks nor advances
-// onboarding. `request_pm_tool` (Rust) does two independent, best-effort
-// things with the free text - mirrors it into settings.json and fires a
-// `pm_tool_requested` PostHog event - see that command's doc for why both.
-function RequestToolForm({ onDone }: { onDone: () => void }) {
+// A side channel outside the gate: submitting there neither blocks nor
+// advances anything, since there is nothing to advance. `request_pm_tool`
+// (Rust) does two independent, best-effort things with the free text -
+// mirrors it into settings.json and fires a `pm_tool_requested` PostHog
+// event - see that command's doc for why both.
+//
+// UNDER the onboarding gate, though, naming a tool IS the same answer as
+// clicking "I don't use a project tool": the user does not have one of the
+// five we support, so a successful submit also fires `onDecline` (passed
+// through from `IntegrationsSection`'s own decline handler) to release the
+// tour's lock exactly the way the explicit skip button does - the walkthrough
+// then narrates the same "let's write this one by hand instead" beat rather
+// than leaving the user stranded on the connect screen after telling us they
+// have no match here. `onDecline` is `undefined` outside the gate, so this is
+// a no-op there.
+function RequestToolForm({ onDone, onDecline }: { onDone: () => void; onDecline?: () => void }) {
   const [value, setValue] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [submitted, setSubmitted] = useState(false)
@@ -151,7 +166,7 @@ function RequestToolForm({ onDone }: { onDone: () => void }) {
     // `__tests__/mutate-body-contract.test.ts` and `save_account_email`'s
     // call sites for the same shape).
     invoke('request_pm_tool', { toolName: tool_name })
-      .then(() => setSubmitted(true))
+      .then(() => { setSubmitted(true); onDecline?.() })
       .catch((e) => setError(typeof e === 'string' ? e : e instanceof Error ? e.message : 'Could not send'))
       .finally(() => setSubmitting(false))
   }

--- a/ui/components/timeline/settings/IntegrationsSection.tsx
+++ b/ui/components/timeline/settings/IntegrationsSection.tsx
@@ -71,7 +71,7 @@ export function IntegrationsSection({ integrations, onChanged, gate = false, onD
       )}
 
       <div className="mt-5">
-        <ConnectTrackers integrations={integrations} onChanged={onChanged} />
+        <ConnectTrackers integrations={integrations} onChanged={onChanged} onDecline={gate ? onDecline : undefined} />
       </div>
 
       {/* THE WAY OUT. A required step with five providers and no exit assumes every


### PR DESCRIPTION
## What broke

PR #834 added the "I don't see my tool" request form to the gated onboarding
step, but never wired its submit path to the step's own advance mechanism.
Declining via the dedicated button worked; submitting the request form left
the user on the same locked screen with no indication anything happened.

This was supposed to ship as part of #834 but the fix only ever existed as
uncommitted local edits during testing and never made it into that PR before
it merged.

## Fix

`RequestToolForm` already accepted an `onDone` callback; wire it into the same
`onDecline` the "I don't use a project tool" button uses, so submitting the
form advances the wizard exactly like declining does.

## Test plan
- [x] `bun test` (ui/): 896 pass, 0 fail
- [ ] Manual: onboarding gated step → "I don't see my tool" → submit → wizard advances automatically