### PR TITLE
fix(autostart,pm): stop two paths that silently leave a user with nothing

### DIFF
--- a/src/pm_worklog/create_github.rs
+++ b/src/pm_worklog/create_github.rs
@@ -344,20 +344,41 @@ pub(super) struct GqlError {
     pub message: String,
 }
 
-/// The first GraphQL error in a response, if any.
+/// The GraphQL error worth reporting out of a response, if any.
+///
+/// A scope failure wins over any other entry. A batched board query can come
+/// back with several errors, and taking `first()` blindly would hide the one
+/// whose advice is actionable ("reconnect GitHub") behind, say, a `NOT_FOUND`
+/// for an unrelated stale board id.
 pub(super) fn graphql_error(v: &Value) -> Option<GqlError> {
-    let first = v.get("errors")?.as_array()?.first()?;
-    Some(GqlError {
-        kind: first
-            .get("type")
-            .and_then(Value::as_str)
-            .map(str::to_string),
-        message: first
+    let errors = v.get("errors")?.as_array()?;
+    let read = |e: &Value| GqlError {
+        kind: e.get("type").and_then(Value::as_str).map(str::to_string),
+        message: e
             .get("message")
             .and_then(Value::as_str)
             .unwrap_or("unknown GitHub GraphQL error")
             .to_string(),
-    })
+    };
+    errors
+        .iter()
+        .map(read)
+        .find(is_missing_project_scope)
+        .or_else(|| errors.first().map(read))
+}
+
+/// True when the response carries a `data` payload worth reading despite any
+/// accompanying `errors`.
+///
+/// GitHub reports a board it cannot resolve — a stale `PVT_…` id, or an org
+/// whose SAML SSO this token is not authorised for — as an `errors` entry
+/// **beside a usable `data`**, HTTP 200. Confirmed live: a two-board query with
+/// one bad id returns `{"data":{"p0":{…},"p1":null},"errors":[{"type":"NOT_FOUND",…}]}`.
+/// Treating that as fatal is what would make ONE stale board id block every
+/// create — the exact class of failure issue #843 was about. The same rule is
+/// already applied by `discover_github_projects` in the tray.
+pub(super) fn has_usable_data(v: &Value) -> bool {
+    v.get("data").is_some_and(|d| !d.is_null())
 }
 
 /// True when the token lacks the read-write `project` scope. Worth singling out:
@@ -406,14 +427,25 @@ async fn graphql(
     }
     let v: Value = serde_json::from_str(&body).context("parsing the GitHub GraphQL response")?;
     if let Some(err) = graphql_error(&v) {
-        if is_missing_project_scope(&err) {
-            bail!(
-                "your GitHub connection is missing the project scope - reconnect GitHub in \
-                 Settings > Integrations to grant it ({})",
-                err.message
-            );
+        // Fatal only when nothing usable came back — see [`has_usable_data`].
+        // A partial response is the normal way GitHub reports one unresolvable
+        // board out of several, and `board_repos_from_response` already skips
+        // whichever came back null.
+        if !has_usable_data(&v) {
+            if is_missing_project_scope(&err) {
+                bail!(
+                    "your GitHub connection is missing the project scope - reconnect GitHub in \
+                     Settings > Integrations to grant it ({})",
+                    err.message
+                );
+            }
+            bail!("GitHub GraphQL error: {}", err.message);
         }
-        bail!("GitHub GraphQL error: {}", err.message);
+        tracing::warn!(
+            error = %err.message,
+            kind = err.kind.as_deref().unwrap_or("unknown"),
+            "github create: partial GraphQL errors - continuing with the boards that resolved"
+        );
     }
     Ok(v)
 }
@@ -687,6 +719,72 @@ mod tests {
     /// keying the predicate on `type` rather than on the prose.
     const REAL_INSUFFICIENT_SCOPES_ERROR: &str = r#"{"errors":[{"type":"INSUFFICIENT_SCOPES",
         "message":"Your token has not been granted the required scopes to execute this query. The 'addProjectV2ItemById' field requires one of the following scopes: ['project'], but your token has only been granted the: ['gist', 'read:org', 'read:project', 'repo', 'workflow'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens."}]}"#;
+
+    /// Verbatim body from running the batched board query live with one good id
+    /// and one stale one: HTTP 200, a USABLE `data` (`p0` resolved), `p1` null,
+    /// and a `NOT_FOUND` in `errors`.
+    ///
+    /// This is the shape that made the previous code wrong. `graphql` bailed on
+    /// any `errors` entry, so `fetch_board_repos` failed outright and - with no
+    /// sample key - `create` propagated that. One stale board id made every
+    /// GitHub task creation impossible, which is the failure #843 set out to fix.
+    const REAL_PARTIAL_BOARD_RESPONSE: &str = r#"{"data":{
+        "p0":{"repositories":{"nodes":[{"nameWithOwner":"Meridiona/meridian"}]}},
+        "p1":null},
+        "errors":[{"type":"NOT_FOUND","path":["p1"],
+        "message":"Could not resolve to a node with the global id of 'PVT_stale'"}]}"#;
+
+    #[test]
+    fn a_partial_board_response_is_not_fatal() {
+        let body: Value = serde_json::from_str(REAL_PARTIAL_BOARD_RESPONSE).unwrap();
+        assert!(
+            has_usable_data(&body),
+            "one unresolvable board must not discard the boards that did resolve"
+        );
+        assert_eq!(
+            graphql_error(&body).and_then(|e| e.kind).as_deref(),
+            Some("NOT_FOUND")
+        );
+    }
+
+    /// The end-to-end consequence: the good board still yields its repo, and the
+    /// stale one is skipped rather than blocking the create.
+    #[test]
+    fn a_stale_board_id_does_not_block_creating_the_task() {
+        let body: Value = serde_json::from_str(REAL_PARTIAL_BOARD_RESPONSE).unwrap();
+        let ids = vec!["PVT_good".to_string(), "PVT_stale".to_string()];
+        let boards = board_repos_from_response(&body, &ids);
+        assert_eq!(boards, vec![board("PVT_good", &["Meridiona/meridian"])]);
+        let t = resolve_target(None, ids.first(), &boards).unwrap();
+        assert_eq!(
+            (t.owner.as_str(), t.repo.as_str()),
+            ("Meridiona", "meridian")
+        );
+    }
+
+    /// A response with no usable `data` stays fatal - that is a real failure, not
+    /// a board we can skip.
+    #[test]
+    fn a_response_with_no_usable_data_is_still_fatal() {
+        for body in [
+            json!({ "errors": [{ "message": "boom" }] }),
+            json!({ "data": Value::Null, "errors": [{ "message": "boom" }] }),
+        ] {
+            assert!(!has_usable_data(&body));
+        }
+    }
+
+    /// A mixed response must not hide the one error whose advice the user can
+    /// act on behind an unrelated entry that happens to come first.
+    #[test]
+    fn a_scope_failure_wins_over_an_unrelated_first_error() {
+        let body = json!({ "errors": [
+            { "type": "NOT_FOUND", "message": "Could not resolve to a node" },
+            { "type": "INSUFFICIENT_SCOPES", "message": "needs ['project']" },
+        ]});
+        let err = graphql_error(&body).unwrap();
+        assert!(is_missing_project_scope(&err), "{err:?}");
+    }
 
     #[test]
     fn recognises_a_real_missing_project_scope() {

--- a/tray/src-tauri/src/autostart.rs
+++ b/tray/src-tauri/src/autostart.rs
@@ -44,19 +44,24 @@
 //! - **macOS 13+** — `SMAppService.mainApp` owns LOGIN (see [`login_item`]),
 //!   which is what produces a named, user-togglable "Meridian" entry in System
 //!   Settings → General → Login Items & Extensions. The plist
-//!   `~/Library/LaunchAgents/com.meridiona.tray.plist` is reduced to the morning
-//!   relaunch alone: `RunAtLoad` **false** + `StartCalendarInterval` at
-//!   [`MORNING_HOUR`], bootstrapped immediately so the trigger is live from the
-//!   moment of install rather than the next login. Below 13 there is no
-//!   SMAppService, so that plist carries both jobs with `RunAtLoad` true.
-//!   Deliberately **no `KeepAlive`** either way: the user asked for Quit to
-//!   stick for the rest of the day and be undone the next morning, and
-//!   `KeepAlive` would make quitting impossible.
-//! - **Windows** — one scheduled task with a `LogonTrigger` *and* a daily
-//!   `CalendarTrigger`, registered from XML because `schtasks`' command form
-//!   cannot express two triggers. Its `MultipleInstancesPolicy` is `IgnoreNew`,
-//!   which is what stops the new-day trigger starting a second tray on top of
-//!   the one the logon trigger already started.
+//!   `~/Library/LaunchAgents/com.meridiona.tray.plist` is reduced to the WAKE
+//!   relaunch alone: `RunAtLoad` **false** + `LaunchEvents` →
+//!   `com.apple.notifyd.matching` on [`macos::WAKE_NOTIFICATIONS`] (unlock,
+//!   desktop-up, display/power state, clamshell), bootstrapped immediately so
+//!   the trigger is live from the moment of install rather than the next login.
+//!   Below 13 there is no SMAppService, so that plist carries both jobs with
+//!   `RunAtLoad` true. Deliberately **no `KeepAlive`** either way: the user
+//!   asked for Quit to stick, and `KeepAlive` would make quitting impossible.
+//! - **Windows** — one scheduled task with a `LogonTrigger` *and* two
+//!   `SessionStateChangeTrigger`s (`SessionUnlock`, `ConsoleConnect`),
+//!   registered from XML because `schtasks`' command form cannot express
+//!   several triggers. Its `MultipleInstancesPolicy` is `IgnoreNew`, which is
+//!   what stops a wake trigger starting a second tray on top of the one the
+//!   logon trigger already started.
+//!
+//! There is **no clock in this module** — see the note beside
+//! [`launched_by_autostart`] on why the hardcoded hour was deleted rather than
+//! lowered.
 //!
 //! # Duplicates are prevented by a guard, not by hoping
 //! The new-day trigger is started by the OS scheduler, and **neither scheduler can
@@ -266,6 +271,43 @@ impl RegistrationAction {
             8 => Self::RepairedStaleDefinition,
             _ => return None,
         })
+    }
+}
+
+/// Whether the plugin-era registration (Windows' `HKCU\…\Run` value, macOS'
+/// `Meridian.plist`) may be deleted, given the verdict and whether a
+/// replacement actually got registered.
+///
+/// # Why this is shared, and why it is a pure predicate
+/// On an install upgrading across the move off `tauri-plugin-autostart`, the
+/// plugin-era registration IS the working autostart. Deleting it before a
+/// replacement exists leaves the user with none at all — and because capture
+/// runs in-process in the tray, a tray that never starts records nothing, so
+/// the cost is every day's data until the user happens to open the app by
+/// hand. The bug has no local symptom; it surfaces only as someone saying
+/// Meridian stopped starting.
+///
+/// Windows encoded this rule and macOS did not: `macos::ensure_registered`
+/// called `migrate_off_plugin()` unconditionally and FIRST, ahead of the
+/// transient-path skip and both hard-failure returns. The two platforms
+/// disagreeing is what made it invisible, so the rule now lives in ONE place
+/// that both call rather than in a comment each side restates differently.
+///
+/// Keeping it a pure predicate is deliberate: the sequencing inside each
+/// `ensure_registered` is the whole safety property and is invisible at the
+/// call site, so the table is what the tests below pin.
+pub(crate) fn may_drop_legacy(action: RegistrationAction, registered: bool) -> bool {
+    match action {
+        // Removing it IS honouring the user's "no": left behind, the stale
+        // registration keeps starting the tray and the setting reads as ignored.
+        RegistrationAction::SkippedDisabledByUser => true,
+        // Something correct is already registered, so it is redundant.
+        RegistrationAction::AlreadyCorrect => true,
+        // A repair was attempted — only safe if it actually took.
+        a if a.is_repair() => registered,
+        // Transient path, or a hard failure: nothing took over, so the legacy
+        // registration is the only autostart the user has. Keep it.
+        _ => false,
     }
 }
 
@@ -559,6 +601,54 @@ pub(crate) fn xml_escape(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The rule both platforms now share. It lived in `windows.rs` and applied
+    /// to Windows alone, while `macos::ensure_registered` deleted the
+    /// plugin-era plist unconditionally and FIRST - ahead of the transient-path
+    /// skip and both hard-failure returns - so an upgrading Mac could finish a
+    /// launch with no autostart at all. Pinned here, once, for both.
+    #[test]
+    fn the_legacy_registration_survives_until_something_replaces_it() {
+        // The three paths that used to lose a working autostart outright.
+        assert!(
+            !may_drop_legacy(RegistrationAction::RegisteredMissing, false),
+            "a failed registration must not delete the only autostart that works"
+        );
+        assert!(
+            !may_drop_legacy(RegistrationAction::Failed, false),
+            "a hard failure must not delete the only autostart that works"
+        );
+        assert!(
+            !may_drop_legacy(RegistrationAction::SkippedTransientPath, false),
+            "deferring must not delete the only autostart that works"
+        );
+
+        // The paths where dropping it is correct.
+        assert!(may_drop_legacy(RegistrationAction::RegisteredMissing, true));
+        assert!(may_drop_legacy(RegistrationAction::RepairedPathDrift, true));
+        assert!(may_drop_legacy(
+            RegistrationAction::RepairedStaleDefinition,
+            true
+        ));
+        assert!(may_drop_legacy(RegistrationAction::AlreadyCorrect, false));
+        assert!(
+            may_drop_legacy(RegistrationAction::SkippedDisabledByUser, false),
+            "a user who turned autostart off must not keep being started by the stale registration"
+        );
+
+        // Every repair variant follows the same "only if it took" rule, so a
+        // new one cannot silently default to dropping the legacy registration.
+        for a in [
+            RegistrationAction::RegisteredMissing,
+            RegistrationAction::RepairedPathDrift,
+            RegistrationAction::RepairedMissingMorningTrigger,
+            RegistrationAction::RepairedStaleDefinition,
+        ] {
+            assert!(a.is_repair());
+            assert!(!may_drop_legacy(a, false), "{a:?} must wait for a success");
+            assert!(may_drop_legacy(a, true), "{a:?} may drop once registered");
+        }
+    }
 
     const MARKER: &str = "StartCalendarInterval";
     const EXE: &str = "/Applications/Meridian.app/Contents/MacOS/Meridian";

--- a/tray/src-tauri/src/autostart/macos.rs
+++ b/tray/src-tauri/src/autostart/macos.rs
@@ -220,12 +220,22 @@ async fn read_registration() -> Option<String> {
 /// Verify and, if needed, rewrite the LaunchAgent. See
 /// [`crate::autostart::ensure_registered`] for the contract.
 pub(crate) async fn ensure_registered() -> RegistrationAction {
-    // Best-effort and first: an upgraded install has the plugin's plist too,
-    // and leaving it would mean two jobs both starting a tray at login. Done
-    // even when the decision below turns out to be a skip, because the legacy
-    // job is wrong in every one of those cases as well.
-    migrate_off_plugin().await;
-
+    // ORDER MATTERS — see [`super::may_drop_legacy`].
+    //
+    // This used to call `migrate_off_plugin()` unconditionally and FIRST, on
+    // the reasoning that the legacy job is wrong in every case anyway. It is
+    // not: on an install upgrading across this change the plugin's plist IS
+    // the working autostart, and three paths below return WITHOUT writing a
+    // replacement — the transient-path skip, and the two hard failures
+    // (`create_dir_all`, the plist write). Deleting it first meant the user
+    // ended those launches with no macOS autostart at all, and capture runs
+    // in-process in the tray, so that is every day's data until they open the
+    // app by hand.
+    //
+    // Windows already gated exactly this behind `may_drop_legacy`; its doc
+    // warned that hoisting the call back to the top would reintroduce the bug.
+    // macOS was the platform still doing it. The delete now happens only where
+    // that shared table says it is safe.
     let (Some(dir), Some(home), Some(exe)) = (
         launch_agents_dir(),
         meridian_core::paths::home_dir(),
@@ -252,6 +262,11 @@ pub(crate) async fn ensure_registered() -> RegistrationAction {
         skip,
         RegistrationAction::SkippedDisabledByUser | RegistrationAction::SkippedTransientPath
     ) {
+        // Disabled-by-user: dropping the legacy job IS honouring the "no".
+        // Transient path: nothing replaced it, so it stays.
+        if super::may_drop_legacy(skip, false) {
+            migrate_off_plugin().await;
+        }
         return skip;
     }
 
@@ -298,17 +313,38 @@ pub(crate) async fn ensure_registered() -> RegistrationAction {
             login_item = login.as_str(),
             "autostart: login item and morning trigger both already correct"
         );
+        // Something correct is already registered, so the legacy job is now
+        // redundant AND would double-launch alongside it.
+        if super::may_drop_legacy(action, false) {
+            migrate_off_plugin().await;
+        }
         return action;
     }
 
     if let Err(e) = tokio::fs::create_dir_all(&dir).await {
-        tracing::warn!(error = %e, dir = %dir.display(), "autostart: could not create LaunchAgents");
+        tracing::warn!(
+            error = %e,
+            dir = %dir.display(),
+            "autostart: could not create LaunchAgents - KEEPING the plugin-era plist so an \
+             upgraded install is not left with no autostart at all"
+        );
         return RegistrationAction::Failed;
     }
     let dest = dir.join(PLIST_FILE);
     if let Err(e) = tokio::fs::write(&dest, &expected).await {
-        tracing::warn!(error = %e, plist = %dest.display(), "autostart: could not write the plist");
+        tracing::warn!(
+            error = %e,
+            plist = %dest.display(),
+            "autostart: could not write the plist - KEEPING the plugin-era plist so an \
+             upgraded install is not left with no autostart at all"
+        );
         return RegistrationAction::Failed;
+    }
+
+    // The replacement is on disk, so the legacy job is now safe to remove -
+    // and MUST be, or both would start a tray at the next login.
+    if super::may_drop_legacy(action, true) {
+        migrate_off_plugin().await;
     }
 
     // NOW bootstrap it, which is safe for the first time.

--- a/tray/src-tauri/src/autostart/windows.rs
+++ b/tray/src-tauri/src/autostart/windows.rs
@@ -47,7 +47,7 @@
 //! # Who calls this
 //! [`crate::autostart::ensure_registered`] and [`crate::autostart::status`].
 
-use super::{RegistrationAction, Status};
+use super::{may_drop_legacy, RegistrationAction, Status};
 use meridian_core::proc_ext::NoWindow;
 use std::path::{Path, PathBuf};
 
@@ -232,31 +232,6 @@ async fn read_registration() -> Option<String> {
 /// truth for whether autostart is wanted, and OS-level drift gets repaired.
 fn is_disabled(xml: &str) -> bool {
     xml.contains("<Enabled>false</Enabled>")
-}
-
-/// Whether the plugin-era `HKCU\…\Run` value may be deleted, given the
-/// verdict and whether a replacement got registered.
-///
-/// A pure predicate, and used by [`ensure_registered`] rather than restated
-/// there, so the test below pins the real rule: the sequencing
-/// in `ensure_registered` is the whole safety property, it is invisible at
-/// the call site, and a refactor that hoists `migrate_off_plugin` back to
-/// the top of the function would silently reintroduce "upgraded Windows
-/// install ends up with no autostart at all" — a bug with no local symptom,
-/// visible only as a user saying it stopped starting.
-fn may_drop_legacy(action: RegistrationAction, registered: bool) -> bool {
-    match action {
-        // Removing it IS honouring the user's "no": left behind, the stale
-        // value keeps starting the tray and the setting reads as ignored.
-        RegistrationAction::SkippedDisabledByUser => true,
-        // Something correct is already registered, so it is redundant.
-        RegistrationAction::AlreadyCorrect => true,
-        // A repair was attempted — only safe if it actually took.
-        a if a.is_repair() => registered,
-        // Transient path, or a hard failure: nothing took over, so the
-        // legacy value is the only autostart the user has. Keep it.
-        _ => false,
-    }
 }
 
 /// Verify and, if needed, re-register the task. See
@@ -663,31 +638,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn the_legacy_run_value_survives_until_something_replaces_it() {
-        // The two paths that used to lose a working autostart outright.
-        assert!(
-            !may_drop_legacy(RegistrationAction::RegisteredMissing, false),
-            "a failed registration must not delete the only autostart that works"
-        );
-        assert!(
-            !may_drop_legacy(RegistrationAction::Failed, false),
-            "a hard failure must not delete the only autostart that works"
-        );
-        assert!(
-            !may_drop_legacy(RegistrationAction::SkippedTransientPath, false),
-            "deferring must not delete the only autostart that works"
-        );
-
-        // The paths where dropping it is correct.
-        assert!(may_drop_legacy(RegistrationAction::RegisteredMissing, true));
-        assert!(may_drop_legacy(RegistrationAction::RepairedPathDrift, true));
-        assert!(may_drop_legacy(RegistrationAction::AlreadyCorrect, false));
-        assert!(
-            may_drop_legacy(RegistrationAction::SkippedDisabledByUser, false),
-            "a user who turned autostart off must not keep being started by the stale value"
-        );
-    }
+    // `the_legacy_registration_survives_until_something_replaces_it` moved to
+    // `super::super`'s tests when `may_drop_legacy` became shared - the rule is
+    // not Windows-specific, and macOS was the platform breaking it.
 
     /// The tray's task and launcher names must not collide with the daemon's
     /// (`Meridian Daemon` / `MeridianDaemon.vbs`) - registering over each other


### PR DESCRIPTION
Release-blocking findings from the review on #846. Both were verified against the real thing, not inferred from reading.

## 1. macOS could finish a launch with no autostart at all

`macos::ensure_registered` called `migrate_off_plugin()` **unconditionally and first**. On an install upgrading across the move off `tauri-plugin-autostart`, that plist **is** the working autostart - and three paths below return without ever writing a replacement:

- the `SkippedTransientPath` return (DMG / Gatekeeper translocation - `relocate` narrows this window but can itself fail)
- `create_dir_all` failing
- the plist write failing

On any of those the user ends the launch with **no macOS autostart**. Capture runs in-process in the tray, so that is every day's data lost until they happen to open the app by hand - and per this module's own header, that state is invisible to us and indistinguishable from churn in PostHog.

**Windows already had this exact rule**, encoded as `may_drop_legacy(action, registered)` with four documented cases. Its doc comment even warned that hoisting `migrate_off_plugin` back to the top of the function "would silently reintroduce *upgraded install ends up with no autostart at all* - a bug with no local symptom." macOS was the platform still doing it.

Rather than move the call and invent a third ordering, `may_drop_legacy` moves to the shared parent module and **both platforms call the one decision table**. That matters because the distinction is not just "do it last": `SkippedDisabledByUser → true` is load-bearing (deleting the legacy job *is* honouring the user's "no"), as is `AlreadyCorrect → true` (leaving it would double-launch). Its test moves with it - the rule was never Windows-specific, and the platform that broke it had no coverage.

Checked while doing this: macOS `migrate_off_plugin` only unlinks the file and deliberately does **not** `bootout` (documented there - booting the label out from inside the running tray would kill the tray). So "registered" cleanly means "a replacement plist is on disk", with no live-job subtlety.

## 2. A stale board id made every GitHub task creation impossible

`graphql` bailed on **any** `errors` entry. But GitHub reports a board it cannot resolve - a stale `PVT_…` id, or an org whose SAML SSO the token is not authorised for - as an `errors` entry **beside a usable `data`**, HTTP 200. Verified live, two boards, one bad id:

```json
{"data":{"p0":{"repositories":{"nodes":[{"nameWithOwner":"Meridiona/meridian"}]}},"p1":null},
 "errors":[{"type":"NOT_FOUND","path":["p1"],"message":"Could not resolve to a node …"}]}
```

So one stale id failed the whole walk, and with no sample key `create` propagated that - a user with one dead board and one good one could not create a GitHub task. That is the same class of failure #843 set out to fix, reintroduced through a different door.

Worse, the board-skip behaviour I documented and tested (`skips_a_board_that_did_not_resolve`) **could never happen in production** - `graphql` bailed before `board_repos_from_response` ever ran. The test passed only because it calls the pure function directly. That is the "test that cannot fail" trap, and it is mine.

Now:
- fatal only when no usable `data` came back (`has_usable_data`), matching the rule `discover_github_projects` already applies in the tray; a partial response warns and continues
- `graphql_error` prefers an `INSUFFICIENT_SCOPES` entry over an unrelated first one, so a mixed response cannot hide the one error whose advice ("reconnect GitHub") is actionable behind a `NOT_FOUND`

The real partial body above is pinned as `REAL_PARTIAL_BOARD_RESPONSE`, with a test driving it end-to-end through `board_repos_from_response` → `resolve_target`.

## Also

Corrects `autostart.rs`'s header, which still described the `StartCalendarInterval` at `MORNING_HOUR` that #839 deleted - a **broken intra-doc link** directly contradicting a note 100 lines further down (`there is no MORNING_HOUR any more, and that removal is the point`). Now describes the wake-event triggers both platforms actually register.

## Explicitly not done

`redact.rs:646` was flagged as carrying the same stale `2026-08-28` date. It does not - that line reads "Originally 2026-08-28 … extended because the alpha is still running", which is accurate historical prose about a value that *was* changed. Recording it here so it does not get re-filed.

The remaining review findings (stale dates in `settings.rs`/`account.rs`, the analytics `device_id`, `scriptDay.ts`, `providers/mod.rs`, the clerk backfill, `CLAUDE.md`) are real but none block shipping; they follow in a separate PR so this one stays readable.

## Tests

`cargo clippy --workspace --all-targets` clean, full workspace suite green (1040 daemon + 387 tray + core/oauth), `cargo doc` no longer reports the unresolved `MORNING_HOUR` link. 4 new tests in `create_github`, and `may_drop_legacy`'s table now covers every repair variant so a new one cannot silently default to dropping the legacy registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)