### PR TITLE
fix(clerk): trace the backfill's silent rewrites of cached auth state

### DIFF
--- a/tray/src-tauri/vendor/tauri-plugin-clerk/src/json_backfill.rs
+++ b/tray/src-tauri/vendor/tauri-plugin-clerk/src/json_backfill.rs
@@ -122,6 +122,27 @@ fn carry_over_has_password(canonical: &str, map: &mut serde_json::Map<String, Va
         .get("has_password")
         .and_then(Value::as_bool)
         .unwrap_or(false);
+    // Observability: the SHAPE, never the payload. `carried` is one bit of
+    // account state and `had_key` says only whether a key was present — no
+    // email, no token, no field values. Worth recording because this is a
+    // silent rewrite of cached auth state, and because a `present_but_unusable`
+    // hit means guest-js sent a type we did not expect, which is the leading
+    // indicator for the next incident in this module's history.
+    let present_but_unusable = map.contains_key("password_enabled");
+    if present_but_unusable {
+        tracing::warn!(
+            object = "sign_up_attempt",
+            carried,
+            "clerk backfill: password_enabled present but not a boolean - normalized"
+        );
+    } else {
+        tracing::debug!(
+            object = "sign_up_attempt",
+            carried,
+            had_has_password = map.contains_key("has_password"),
+            "clerk backfill: password_enabled filled in"
+        );
+    }
     map.insert("password_enabled".to_string(), json!(carried));
 }
 
@@ -137,6 +158,7 @@ fn carry_over_has_password(canonical: &str, map: &mut serde_json::Map<String, Va
 /// Populated entries are preserved; only the absent keys get a `null`.
 fn complete_sign_up_verifications(map: &mut serde_json::Map<String, Value>) {
     let mut filled = empty_sign_up_verifications();
+    let mut carried_over = 0usize;
     if let (Value::Object(required), Some(Value::Object(existing))) =
         (&mut filled, map.get("verifications"))
     {
@@ -144,8 +166,21 @@ fn complete_sign_up_verifications(map: &mut serde_json::Map<String, Value>) {
         // so a key guest-js omitted is present-and-null rather than missing.
         for (key, value) in existing {
             required.insert(key.clone(), value.clone());
+            carried_over += 1;
         }
     }
+    // COUNTS ONLY. A verification entry carries the email address or phone
+    // number being verified, so the keys and values stay out of the record
+    // entirely - `carried_over` and `filled_in` are enough to tell "guest-js
+    // sent a partial object" from "it sent nothing", which is the whole
+    // diagnostic question here.
+    let total = filled.as_object().map_or(0, serde_json::Map::len);
+    tracing::debug!(
+        object = "sign_up_attempt",
+        carried_over,
+        filled_in = total.saturating_sub(carried_over),
+        "clerk backfill: sign_up verifications completed"
+    );
     map.insert("verifications".to_string(), filled);
 }
 


### PR DESCRIPTION
Closes the last actionable review finding on #846 — the one I dropped without recording it. When I triaged the clerk comments I wrote "3 findings including 2 Major" and then acted only on the two Major ones. This is the third.

## The finding

Both functions #848 added to `json_backfill.rs` mutate the cached Clerk session payload and emit nothing. The repo's own rule is that a changed code path doing real work must emit structured logs and traces, and these are the paths that decide whether the offline session cache deserializes at all.

I went looking for a reason to decline it and did not find one. The plausible argument was that a vendored crate's target would be dropped by the `EnvFilter` before reaching the spool — but `tauri_plugin_clerk` **is** in `observability::filter`'s `CAPTURE_TARGETS`, alongside `screenpipe_screen`/`screenpipe_a11y`. So events here are captured, and their absence was a real gap rather than a no-op.

## What it emits, and what it deliberately does not

**Shape only, never payload.** `carried` is a single bit of account state. The verifications site emits **counts** (`carried_over` / `filled_in`) rather than keys, because a verification entry carries the email address or phone number being verified — exactly the kind of value CLAUDE.md's allowlist section says must stay off the record. Counts still answer the only diagnostic question that matters here: did guest-js send a partial object, or nothing at all.

**The non-boolean branch is WARN, not DEBUG.** A present-but-unusable `password_enabled` means guest-js sent a type we did not expect. That is the leading indicator for the next incident in this module's history — three so far, each one a silently unusable cached session — and WARN is also the floor for egress on a packaged install, so it is the level at which this becomes visible remotely rather than only in a diagnostics bundle.

## Where the other two open threads on #846 stand

- **`settings.rs:368`** — already fixed in #848; line 359 reads "through 2026-12-31". The thread is open only because nobody clicked resolve, not because anything is outstanding.
- **`scriptDay.ts:542`** ("split the 616-line file") — declined deliberately, reasoning in #850. Still correctly open.

## Tests

`cargo clippy --workspace --all-targets` clean; full workspace suite green (37 clerk tests included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)