### PR TITLE
fix(tutorial): stop a failed settings read ending the worklog-time beat

### DIFF
--- a/ui/__tests__/tutorial-sample-day.test.ts
+++ b/ui/__tests__/tutorial-sample-day.test.ts
@@ -1812,6 +1812,30 @@ describe('the closing asks: a delivery time, and the off switch', () => {
     expect(beat).toContain('s.point(\'[data-tour="worklog-schedule-on"]\')')
   })
 
+  it('does not read a failed settings fetch as the user answering', () => {
+    // `waitForWorklogAnswered` decides the beat is over when the SETTING
+    // changes, because the click primitive could not be trusted here (#852).
+    // Its first version mapped both "the read failed" and "settings say X" to
+    // the same value, so one rejected `get_settings` left `baseline` null, the
+    // next successful poll compared as a change, and the beat ended instantly
+    // with nothing recorded - reinstating the exact bug it was written to fix,
+    // through the error path.
+    //
+    // Guarded by source scan because the function is module-private and the
+    // failure needs a rejecting bridge plus a live DOM to reproduce.
+    const fn = between(
+      SCRIPT_SRC,
+      'async function waitForWorklogAnswered',
+      'export async function runDayHalf',
+    )
+    // A failed read must be its own state, and the baseline must be adopted
+    // rather than compared when it is missing.
+    expect(fn).toContain('baseline === undefined')
+    // The shape that caused it: treating a non-null reading as a change while
+    // the baseline is the same null a failed read produces.
+    expect(fn).not.toContain('current !== null && current !== baseline')
+  })
+
   it('names both things that time sets off, not just the worklogs', () => {
     // It said "Worklogs" and "Auto-draft your worklogs". The same pass composes
     // the daily summary too, so "Not now" was also switching off the screen the

--- a/ui/components/tutorial/scriptDay.ts
+++ b/ui/components/tutorial/scriptDay.ts
@@ -100,6 +100,13 @@ async function hasBoard(usesTracker: string | null): Promise<boolean> {
  *  earlier run, which would otherwise read as "already answered" before the
  *  user has touched anything this time.
  *
+ *  A FAILED read is not a value, and the two must not share a representation.
+ *  When the baseline read itself fails there is nothing to compare against, so
+ *  the first reading that succeeds becomes the baseline rather than counting as
+ *  the change - otherwise one rejected `get_settings` ends the beat on the very
+ *  next poll, with nothing recorded, which is precisely the failure this
+ *  function exists to prevent.
+ *
  *  ALSO resolves on the dialog leaving the DOM even with no settings change -
  *  a replayed tour that already has `prompted: true` and gets declined again
  *  ("Not now"/backdrop/×) writes back the SAME values, which the diff above
@@ -120,14 +127,33 @@ async function hasBoard(usesTracker: string | null): Promise<boolean> {
  *  while the real answer is confirmed by polling. */
 async function waitForWorklogAnswered(s: Stage, timeoutMs: number): Promise<boolean> {
   void s.waitForClick('[data-tour="worklog-schedule-on"]', timeoutMs)
-  const key = (v: Partial<RuntimeSettings> | null) =>
-    v ? `${v.worklog_auto_generate_time}:${v.worklog_auto_generate_prompted}` : null
-  const baseline = key(await load<RuntimeSettings>('/api/settings', 'get_settings').catch(() => null))
+  // `undefined` means the READ FAILED and `string` means "this is what settings
+  // say". Collapsing those two - as returning `null` for both did - is what let
+  // a failed baseline read end the beat instantly: `baseline` was `null`, the
+  // next successful poll was a non-null string, that compared as a change, and
+  // the tour moved on having recorded nothing. Which is the bug this whole
+  // function was written to fix, reintroduced through the error path.
+  const read = async (): Promise<string | undefined> => {
+    try {
+      const v = await load<RuntimeSettings>('/api/settings', 'get_settings')
+      return `${v.worklog_auto_generate_time}:${v.worklog_auto_generate_prompted}`
+    } catch {
+      return undefined
+    }
+  }
+  let baseline = await read()
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     if (!document.querySelector('[data-tour="worklog-schedule-on"]')) return true
-    const current = key(await load<RuntimeSettings>('/api/settings', 'get_settings').catch(() => null))
-    if (current !== null && current !== baseline) return true
+    const current = await read()
+    if (baseline === undefined) {
+      // The baseline read failed, so there is nothing to compare against yet.
+      // Adopt the first reading that succeeds instead of counting it as the
+      // answer - a recovered read is not a user response.
+      baseline = current
+    } else if (current !== undefined && current !== baseline) {
+      return true
+    }
     await s.pause(400)
   }
   return false


### PR DESCRIPTION
Review finding on #846, against #852's `waitForWorklogAnswered`. Confirmed by reading the code, and the regression guard was verified to fail against the previous version.

## The bug

```ts
const key = (v: Partial<RuntimeSettings> | null) => v ? `${…}:${…}` : null
const baseline = key(await load(…).catch(() => null))
…
const current = key(await load(…).catch(() => null))
if (current !== null && current !== baseline) return true
```

`key()` returns `null` **both** for "the read failed" and as a value. So if the baseline `get_settings` rejects - one blip, a slow first paint, anything - `baseline` is `null`, and the very next successful poll yields a non-null string. That compares as a change, `waitForWorklogAnswered` returns `true`, the caller hides the dialog, and nothing has been written.

The user never answered, and the time never gets saved. **Which is precisely the failure #852 was written to fix** - reached through the error path rather than the click path this time.

It also fails in the direction that hides itself: the beat appears to complete normally, so the tour finishes looking correct while the setting is untouched, exactly the symptom #852's investigation chased through PR #849.

## The fix

A failed read is now its own state - `undefined` - distinct from any value:

- Baseline read succeeded → compare as before.
- Baseline read **failed** → there is nothing to compare against, so the first reading that *succeeds* becomes the baseline. A recovered read is not a user response.

Everything #852 established is preserved: the un-awaited `waitForClick` still runs for its fence side effect, and the dialog-left-the-DOM check still short-circuits a re-declined replay.

## Test

`waitForWorklogAnswered` is module-private and reproducing the failure needs a rejecting bridge plus a live DOM, so this is guarded by source scan - in `tutorial-sample-day.test.ts`'s existing style, using its `between()` marker-slicing helper (which throws on a missing marker, so it cannot silently degrade into the one-character assertion that file documents as a real past incident).

I verified the guard actually catches it: restored the old block, the test fails; restored the fix, it passes. 898 UI tests green, `tsc --noEmit` clean.

## The other three findings in this review

- **`src/main.rs:1093` - "make single-instance acquisition atomic" (Major).** **Valid, and I think it matters more than anything else in this review - but it is not mine to land here.** The guard at line 1087 only *probes* whether anything is listening; the actual bind is deliberately deferred to line 1144 so health is not advertised before the DB is usable. `setup_db` + migrations run in between. Two daemons starting together can both pass the probe and both run migrations on the same file, and the loser only stands down at the bind - after the window. The code's own comment defends this with "both single-threaded up to the poll loop", which is about one process's threads, not two racing processes. Given this repo's history of `database disk image is malformed` incidents attributed to two writers, this is a plausible mechanism and deserves its own change with a real design (an exclusive OS lock taken before `setup_db`, released on exit, on both platforms). Not a drive-by in a release-blocking PR - getting it wrong stops the daemon starting at all.
- **`CLAUDE.md:21` - "enforce all public-gateway controls before deployment" (Major, Heavy lift).** A re-raise of the 401 point after #850 corrected the wording to say the check is manual. The doc is now accurate; what remains is asking for real enforcement in `deploy-gateway.sh`, which is untested-against-the-live-VM code in a script that deploys production. Same decline as #850, same reason.
- **`src/main.rs:1094` - split the oversized files (Heavy lift).** True: `main.rs` is 1668 lines and `scriptDay.ts` is 666, both over the 500-line rule. Pre-existing and growing, but a mechanical refactor of daemon startup and tour choreography does not belong in a review-response PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)