### PR TITLE
fix(db): checkpoint WAL on shutdown + detect corruption from tray reads

### DIFF
--- a/src/db/meridian.rs
+++ b/src/db/meridian.rs
@@ -128,6 +128,31 @@ pub async fn setup_db(uri: &str) -> anyhow::Result<SqlitePool> {
     Ok(pool)
 }
 
+/// Forces the WAL fully into the main database file and truncates it.
+///
+/// Called from `main.rs`'s shutdown sequence, right before closing the pool.
+/// `pool.close()` alone does not checkpoint: SQLite only auto-checkpoints when
+/// the LAST connection to the file closes, and the tray holds its own
+/// independent, long-lived pool on the same file for its entire process
+/// lifetime (`tray/src-tauri/src/lib.rs`'s `app.manage(db_pool)`) — so from
+/// this pool's point of view there is never a "last connection". Without this,
+/// every daemon restart (a crash, or `reload_daemon`'s SIGHUP, which exits and
+/// relies on launchd/the tray to relaunch it) hands a WAL in whatever
+/// half-written state it happened to be in to a brand-new process, while the
+/// tray's already-open connection keeps its stale view of the file across that
+/// boundary. A clean TRUNCATE checkpoint here gives every restart a
+/// well-defined, empty-WAL starting point instead.
+///
+/// Best-effort by design — callers should log and continue on error rather
+/// than fail shutdown over it.
+pub async fn checkpoint_wal(pool: &SqlitePool) -> anyhow::Result<()> {
+    sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+        .execute(pool)
+        .await
+        .context("WAL checkpoint failed")?;
+    Ok(())
+}
+
 /// Realign `_sqlx_migrations` checksums with the embedded migration files.
 ///
 /// sqlx records a SHA-384 checksum of every applied migration and refuses to
@@ -604,5 +629,58 @@ mod tests {
         reconcile_migration_checksums(&pool, &migrator)
             .await
             .expect("reconcile on fresh db must be a no-op");
+    }
+
+    /// `checkpoint_wal` must actually move committed data out of the `-wal`
+    /// sidecar and truncate it — the entire point of calling it before
+    /// shutdown. `:memory:` can't exercise this (no `-wal` file exists), so
+    /// this uses a real temp-dir-backed database in WAL mode, same technique
+    /// `test_corrupt.rs` uses for byte-level fixtures.
+    #[tokio::test]
+    async fn checkpoint_wal_truncates_the_sidecar_file() {
+        use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
+        use std::str::FromStr;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("checkpoint_test.db");
+        let wal_path = dir.path().join("checkpoint_test.db-wal");
+
+        let opts = SqliteConnectOptions::from_str(&format!("sqlite://{}", path.display()))
+            .unwrap()
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal);
+        // Single connection: a second one competing for the same WAL would
+        // make the size assertions below flaky for reasons unrelated to what
+        // this test is pinning.
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(opts)
+            .await
+            .expect("open WAL-mode db");
+
+        sqlx::query("CREATE TABLE t (v BLOB)")
+            .execute(&pool)
+            .await
+            .expect("create table");
+        // A large-ish payload so the write actually lands in the WAL rather
+        // than being trivially small enough to round to zero either way.
+        sqlx::query("INSERT INTO t (v) VALUES (zeroblob(65536))")
+            .execute(&pool)
+            .await
+            .expect("insert");
+
+        let wal_len_before = std::fs::metadata(&wal_path).map(|m| m.len()).unwrap_or(0);
+        assert!(
+            wal_len_before > 0,
+            "fixture is wrong: nothing landed in the WAL before checkpointing"
+        );
+
+        checkpoint_wal(&pool).await.expect("checkpoint_wal");
+
+        let wal_len_after = std::fs::metadata(&wal_path).map(|m| m.len()).unwrap_or(0);
+        assert_eq!(
+            wal_len_after, 0,
+            "TRUNCATE checkpoint must leave an empty WAL, got {wal_len_after} bytes"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1519,6 +1519,12 @@ async fn main() -> Result<()> {
     // 9. Shutdown
     tracing::info!("shutting down");
     meridian::platform::release_endpoint();
+    // See `db::meridian::checkpoint_wal`'s doc for why this runs before every
+    // close, not just a plain shutdown. Best-effort: a failed checkpoint must
+    // not block shutdown.
+    if let Err(e) = meridian::db::meridian::checkpoint_wal(&meridian).await {
+        tracing::warn!(error = %e, "WAL checkpoint on shutdown failed - continuing anyway");
+    }
     meridian.close().await;
 
     // Flush OTel exporters FIRST, while the runtime is alive — this writes the

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -392,6 +392,47 @@ fn decide_health_notice(
     }
 }
 
+/// If `err` indicates `meridian.db` is corrupt, raise the SAME `db.corrupt`
+/// notice `main.rs`'s `etl_tick` raises on the daemon side - immediately,
+/// from whichever side of the app noticed first.
+///
+/// The daemon already had this covered for its own queries, but the tray
+/// holds its own independent, long-lived pool on the same file (opened once
+/// at startup, `lib.rs`'s `app.manage(db_pool)`) and reads different tables
+/// on this loop's faster (~30 s) cadence than the daemon's ETL/summariser
+/// ticks. In the incident this fixes, the tray's own reads here hit
+/// `(code: 11) database disk image is malformed` a full 5+ minutes before any
+/// daemon-side query happened to touch the same damage - and until this
+/// function existed, that whole window was silent `tracing::warn!` noise with
+/// no banner, because nothing on this side of the process ever called
+/// `raise_typed`. Idempotent (`raise_typed` upserts), so calling this on
+/// every failing tick is safe and cheap - it does not need its own latch the
+/// way the daemon's ETL loop does, because a poll tick that keeps failing
+/// just keeps refreshing the same notice row rather than retrying a query
+/// with side effects.
+async fn raise_if_corrupt(pool: &SqlitePool, err: &anyhow::Error) {
+    if !meridian::db::integrity::is_corrupt_error(err) {
+        return;
+    }
+    let _ = meridian::notices::raise_typed(
+        pool,
+        meridian::notices::Notice {
+            id: meridian::notices::DB_CORRUPT,
+            severity: "error",
+            title: "Meridian's database is damaged",
+            // Full chain, not `err.to_string()` - same reasoning as
+            // `crate::cmd_err!`'s doc comment: `anyhow::Error`'s `Display`
+            // renders only the outermost `.context()` and would otherwise
+            // drop the SQLite code a reader needs.
+            detail: &format!("{err:#}"),
+            remedy: Some("Quit Meridian, then run 'meridian db repair' in a terminal"),
+            event_key: meridian::notices::DB_CORRUPT,
+            deep_link: Some(meridian_core::notifications::deep_links::LOGS),
+        },
+    )
+    .await;
+}
+
 /// Read the active session (direct DB) and store the app name + elapsed seconds.
 /// On a read error we keep the previous value rather than clearing the pill on a
 /// transient blip.
@@ -412,6 +453,7 @@ pub(super) async fn refresh_active(pool: &SqlitePool, state: &Arc<Mutex<AppState
             // drop exactly the cause (e.g. a corrupt DB's SQLite code) that a
             // reader needs.
             tracing::warn!(error = %meridian::errors::chain(&e), "refresh_active failed");
+            raise_if_corrupt(pool, &e).await;
             return;
         }
     };
@@ -450,7 +492,8 @@ pub(super) async fn refresh_current_task(pool: &SqlitePool, state: &Arc<Mutex<Ap
                 .and_then(|c| c.estimate_s.map(|e| e.max(0) as u64));
         }
         Err(e) => {
-            tracing::warn!(error = %meridian::errors::chain(&e), "refresh_current_task failed")
+            tracing::warn!(error = %meridian::errors::chain(&e), "refresh_current_task failed");
+            raise_if_corrupt(pool, &e).await;
         }
     }
 }
@@ -503,7 +546,10 @@ pub(super) async fn refresh_today(pool: &SqlitePool, state: &Arc<Mutex<AppState>
             s.switch_count = t.switch_count.max(0) as u32;
             s.today = bd;
         }
-        Err(e) => tracing::warn!(error = %e, "refresh_today failed"),
+        Err(e) => {
+            tracing::warn!(error = %meridian::errors::chain(&e), "refresh_today failed");
+            raise_if_corrupt(pool, &e).await;
+        }
     }
 }
 
@@ -535,7 +581,10 @@ pub(super) async fn refresh_worklogs(pool: &SqlitePool, state: &Arc<Mutex<AppSta
             s.drafts_count = count;
             s.logged_s = logged_s;
         }
-        Err(e) => tracing::warn!(error = %e, "refresh_worklogs failed"),
+        Err(e) => {
+            tracing::warn!(error = %meridian::errors::chain(&e), "refresh_worklogs failed");
+            raise_if_corrupt(pool, &e).await;
+        }
     }
 }
 
@@ -944,6 +993,55 @@ mod tests {
         );
         assert!(recovered.notify_back);
         assert!(!recovered.reconcile_stale);
+    }
+
+    /// The tray's own reads must raise `db.corrupt` the moment THEY hit
+    /// corruption, not wait for a daemon-side query to stumble onto the same
+    /// damage minutes later — the gap this fix closes. Real corrupted bytes on
+    /// disk aren't needed: `raise_if_corrupt` only inspects the error, and
+    /// `db::integrity::is_corrupt_error` (the classifier it delegates to) is
+    /// already pinned against the real field-incident shape elsewhere.
+    #[tokio::test]
+    async fn raise_if_corrupt_writes_the_notice_on_a_corrupt_error() {
+        let pool = fresh_db().await;
+        let err = anyhow::anyhow!(
+            "error returned from database: (code: 11) database disk image is malformed"
+        )
+        .context("current_task: fetch most recent task session");
+
+        raise_if_corrupt(&pool, &err).await;
+
+        let row: (String, String) =
+            sqlx::query_as("SELECT severity, detail FROM system_notices WHERE notice_id = ?")
+                .bind(meridian::notices::DB_CORRUPT)
+                .fetch_one(&pool)
+                .await
+                .expect("db.corrupt notice must be written");
+        assert_eq!(row.0, "error");
+        assert!(
+            row.1.contains("database disk image is malformed"),
+            "notice detail dropped the actual cause: {}",
+            row.1
+        );
+    }
+
+    /// Every other read failure (a lock, a missing table, a network blip on an
+    /// unrelated call) must NOT raise the corruption banner — that would train
+    /// the user to run `db repair` for faults it can't fix.
+    #[tokio::test]
+    async fn raise_if_corrupt_is_silent_on_unrelated_errors() {
+        let pool = fresh_db().await;
+        let err = anyhow::anyhow!("database is locked").context("today: fetch sessions");
+
+        raise_if_corrupt(&pool, &err).await;
+
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM system_notices WHERE notice_id = ?")
+                .bind(meridian::notices::DB_CORRUPT)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(count, 0, "an unrelated error must not raise db.corrupt");
     }
 
     async fn fresh_db() -> meridian_core::SqlitePool {


### PR DESCRIPTION
## Summary
Root-caused a real `meridian.db` corruption incident hit during dev testing today (2026-08-24, ~11:37 IST): the tray holds its own independent, long-lived SQLite pool on `meridian.db` for its entire process lifetime (`app.manage(db_pool)`, opened once at startup). A daemon restart - a crash, or `reload_daemon`'s SIGHUP (fired e.g. by saving an integration token) - never triggers SQLite's auto-checkpoint-on-last-close, because the tray's pool is still attached. The WAL is handed off in whatever half-written state it was in to the brand-new daemon process, while the tray's already-open connection keeps its stale view of the file across that boundary.

Timeline from the incident: `reload_daemon` SIGHUP → daemon exits → daemon restarted → 5 minutes of clean operation → tray's own poll-loop reads hit `(code: 11) database disk image is malformed` → 6 more minutes before the daemon's own (slower-cadence) queries happened to touch the same damage and raised the existing `db.corrupt` notice. The whole 5-6 minute window in between was silent `tracing::warn!` noise - no banner, because nothing on the tray side of the process ever called `raise_typed`.

Two independent fixes:
1. **`checkpoint_wal()`** (`src/db/meridian.rs`) - forces `PRAGMA wal_checkpoint(TRUNCATE)` as the last step of the daemon's graceful shutdown (`main.rs`), so every restart hands off a well-defined, empty WAL instead of an open one.
2. **Tray-side corruption detection** (`tray/src-tauri/src/poll/refresh.rs`) - the poll loop's direct DB reads (`refresh_active`/`refresh_current_task`/`refresh_today`/`refresh_worklogs`) now recognize `is_corrupt_error` and immediately raise the same `db.corrupt` notice the daemon's ETL path already raises, instead of retrying silently forever.

A third fix from the same investigation - closing the tray's pool across a daemon restart instead of holding it open throughout, which is the more structurally complete fix - is a bigger refactor (`Option<SqlitePool>` state is read at 56 call sites across 18 files) and is tracked as a separate PR.

## Test plan
- [x] `cargo test -p meridian db::meridian::tests` - new `checkpoint_wal_truncates_the_sidecar_file` test passes (real WAL-mode temp-dir-backed db, asserts the `-wal` sidecar is actually truncated to 0 bytes)
- [x] `cd tray/src-tauri && cargo test --lib poll::refresh` - 16/16 pass, including new `raise_if_corrupt_writes_the_notice_on_a_corrupt_error` / `raise_if_corrupt_is_silent_on_unrelated_errors`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [ ] End-to-end verification on staging (this incident is dev-daemon-specific in trigger timing, but the underlying "tray pool spans a daemon restart" hazard is present in production too, just with a much smaller window under launchd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)