### PR TITLE
test(tutorial): drive the worklog-answered failure path for real

### DIFF
--- a/ui/__tests__/tour-worklog-answered.test.ts
+++ b/ui/__tests__/tour-worklog-answered.test.ts
@@ -1,0 +1,122 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//
+// RUNTIME harness for `waitForWorklogAnswered` (components/tutorial/scriptDay.ts) —
+// the tour beat that decides the worklog-time question has been answered.
+//
+// Why this is a real test and not a source scan. The beat has now failed twice,
+// in two different ways, and neither was visible in the shape of the code:
+//
+//   1. `waitForClick` resolved `true` with no observable click of any kind, so
+//      the tour moved on and the time was never saved (PR #849's investigation,
+//      fixed in #852 by polling the setting instead).
+//   2. The poll then mapped "the read FAILED" and "settings say X" onto the same
+//      `null`, so one rejected `get_settings` made the very next successful poll
+//      compare as a change — ending the beat with nothing recorded, i.e. the
+//      exact failure #852 exists to prevent, reached through the error path
+//      (fixed in #854).
+//
+// The guard shipped for (2) asserted on source fragments, which cannot tell the
+// fix apart from a rewrite that reintroduces the bug with different spacing.
+// This drives the real function instead, over the interleaving that broke it.
+//
+// The settings read is injected rather than module-mocked ON PURPOSE: bun's
+// `mock.module` replaces a module for the whole test PROCESS, so stubbing
+// `@/lib/bridge` here broke every other test file that imports `invoke` or
+// `openExternal` from it (11 failures across 6 files, measured). A parameter
+// with a production default touches nothing outside this beat.
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { waitForWorklogAnswered, type SettingsProbe } from '../components/tutorial/scriptDay'
+
+/** The dialog's button. Present = the dialog is up; removing it is itself an
+ *  answer ("Not now" / the backdrop), which the function short-circuits on. */
+const BUTTON = '<button data-tour="worklog-schedule-on">Turn on</button>'
+
+/** A probe that replays `readings` one per call, repeating the last forever.
+ *  `null` means THE READ FAILED (the production probe answers `undefined`).
+ *  Also counts calls, so a test can prove the poll actually ran. */
+function probeOf(readings: Array<string | null>) {
+  const queue = [...readings]
+  const state = { calls: 0 }
+  const probe: SettingsProbe = async () => {
+    state.calls += 1
+    const next = queue.length > 1 ? queue.shift() : queue[0]
+    return next === null ? undefined : next
+  }
+  return { probe, state }
+}
+
+/** A `Stage` with only the two members this function touches.
+ *
+ *  `waitForClick` is called for its fence side effect and its RESULT is
+ *  deliberately ignored by the code under test (#852) — so a never-resolving
+ *  promise is the honest stub: if the function ever starts trusting it again,
+ *  these tests hang instead of passing on a value the real primitive cannot be
+ *  trusted to produce. `pause` is shortened so a bounded poll runs quickly. */
+function stubStage() {
+  return {
+    waitForClick: () => new Promise<boolean>(() => {}),
+    pause: () => new Promise<void>((r) => setTimeout(r, 1)),
+  } as never
+}
+
+beforeAll(() => GlobalRegistrator.register())
+afterAll(() => GlobalRegistrator.unregister())
+
+describe('waitForWorklogAnswered', () => {
+  it('does not treat a recovered read as the user answering', async () => {
+    // THE REGRESSION. The baseline read fails; every later read succeeds and
+    // reports the SAME untouched settings. Nothing was answered, so the beat
+    // must keep waiting and time out — not resolve on the first reading that
+    // happens to arrive after the failure.
+    document.body.innerHTML = BUTTON
+    const { probe, state } = probeOf([null, '18:00:false'])
+
+    expect(await waitForWorklogAnswered(stubStage(), 120, probe)).toBe(false)
+    // Proves it really polled rather than bailing out on the rejection.
+    expect(state.calls).toBeGreaterThan(2)
+  })
+
+  it('adopts the first successful reading as the baseline, then still sees a real change', async () => {
+    // Same failed baseline, but the user answers a few polls later. The
+    // recovered reading must have become the baseline, so the LATER change is
+    // what resolves it — the fix must not overshoot into ignoring real answers.
+    document.body.innerHTML = BUTTON
+    const { probe } = probeOf([null, '18:00:false', '18:00:false', '21:30:true'])
+
+    expect(await waitForWorklogAnswered(stubStage(), 2000, probe)).toBe(true)
+  })
+
+  it('resolves when the setting changes on a healthy read', async () => {
+    document.body.innerHTML = BUTTON
+    const { probe } = probeOf(['18:00:false', '18:00:false', '21:30:true'])
+
+    expect(await waitForWorklogAnswered(stubStage(), 2000, probe)).toBe(true)
+  })
+
+  it('resolves when the dialog leaves the DOM with no settings change', async () => {
+    // "Not now" / the backdrop on a replayed tour writes back identical values,
+    // which no diff would ever see. The dialog closing is itself the answer.
+    document.body.innerHTML = ''
+    const { probe } = probeOf(['18:00:true'])
+
+    expect(await waitForWorklogAnswered(stubStage(), 2000, probe)).toBe(true)
+  })
+
+  it('keeps waiting while nothing changes and the dialog is still up', async () => {
+    document.body.innerHTML = BUTTON
+    const { probe } = probeOf(['18:00:false'])
+
+    expect(await waitForWorklogAnswered(stubStage(), 120, probe)).toBe(false)
+  })
+
+  it('does not resolve on reads that keep failing', async () => {
+    // No baseline is ever established. Timing out is the correct answer; the
+    // alternative — guessing — is what the fix exists to stop.
+    document.body.innerHTML = BUTTON
+    const { probe } = probeOf([null])
+
+    expect(await waitForWorklogAnswered(stubStage(), 120, probe)).toBe(false)
+  })
+})

--- a/ui/__tests__/tutorial-sample-day.test.ts
+++ b/ui/__tests__/tutorial-sample-day.test.ts
@@ -1812,29 +1812,11 @@ describe('the closing asks: a delivery time, and the off switch', () => {
     expect(beat).toContain('s.point(\'[data-tour="worklog-schedule-on"]\')')
   })
 
-  it('does not read a failed settings fetch as the user answering', () => {
-    // `waitForWorklogAnswered` decides the beat is over when the SETTING
-    // changes, because the click primitive could not be trusted here (#852).
-    // Its first version mapped both "the read failed" and "settings say X" to
-    // the same value, so one rejected `get_settings` left `baseline` null, the
-    // next successful poll compared as a change, and the beat ended instantly
-    // with nothing recorded - reinstating the exact bug it was written to fix,
-    // through the error path.
-    //
-    // Guarded by source scan because the function is module-private and the
-    // failure needs a rejecting bridge plus a live DOM to reproduce.
-    const fn = between(
-      SCRIPT_SRC,
-      'async function waitForWorklogAnswered',
-      'export async function runDayHalf',
-    )
-    // A failed read must be its own state, and the baseline must be adopted
-    // rather than compared when it is missing.
-    expect(fn).toContain('baseline === undefined')
-    // The shape that caused it: treating a non-null reading as a change while
-    // the baseline is the same null a failed read produces.
-    expect(fn).not.toContain('current !== null && current !== baseline')
-  })
+  // `waitForWorklogAnswered`'s failed-read handling was guarded here by a source
+  // scan, which could not distinguish the fix from a rewrite that reintroduced
+  // the bug with different spacing. It is now driven for real - a rejecting
+  // bridge, a real document, the interleaving that actually broke it - in
+  // `__tests__/tour-worklog-answered.test.ts`.
 
   it('names both things that time sets off, not just the worklogs', () => {
     // It said "Worklogs" and "Auto-draft your worklogs". The same pass composes

--- a/ui/components/tutorial/scriptDay.ts
+++ b/ui/components/tutorial/scriptDay.ts
@@ -125,22 +125,40 @@ async function hasBoard(usesTracker: string | null): Promise<boolean> {
  *  This still doesn't trust the click primitive's RESULT (the mystery this
  *  investigation never closed), but its mere presence keeps the fence down
  *  while the real answer is confirmed by polling. */
-async function waitForWorklogAnswered(s: Stage, timeoutMs: number): Promise<boolean> {
-  void s.waitForClick('[data-tour="worklog-schedule-on"]', timeoutMs)
-  // `undefined` means the READ FAILED and `string` means "this is what settings
-  // say". Collapsing those two - as returning `null` for both did - is what let
-  // a failed baseline read end the beat instantly: `baseline` was `null`, the
-  // next successful poll was a non-null string, that compared as a change, and
-  // the tour moved on having recorded nothing. Which is the bug this whole
-  // function was written to fix, reintroduced through the error path.
-  const read = async (): Promise<string | undefined> => {
-    try {
-      const v = await load<RuntimeSettings>('/api/settings', 'get_settings')
-      return `${v.worklog_auto_generate_time}:${v.worklog_auto_generate_prompted}`
-    } catch {
-      return undefined
-    }
+/** One reading of the two settings this beat watches, as a comparable string.
+ *
+ *  `undefined` means the READ FAILED and a `string` means "settings say this".
+ *  Collapsing those two - as returning `null` for both did - is what let a
+ *  failed baseline read end the beat instantly: `baseline` was `null`, the next
+ *  successful poll was a non-null string, that compared as a change, and the
+ *  tour moved on having recorded nothing. Which is the bug this whole function
+ *  was written to fix, reintroduced through the error path. */
+export type SettingsProbe = () => Promise<string | undefined>
+
+const readWorklogSettings: SettingsProbe = async () => {
+  try {
+    const v = await load<RuntimeSettings>('/api/settings', 'get_settings')
+    return `${v.worklog_auto_generate_time}:${v.worklog_auto_generate_prompted}`
+  } catch {
+    return undefined
   }
+}
+
+// EXPORTED, with an injectable `probe`, for the test harness - nothing else
+// passes the third argument and production always takes the default. The
+// behaviour that matters is an ERROR PATH (a rejected `get_settings`)
+// interleaved with a poll: a source scan cannot prove it, and no other seam in
+// this module reaches it. A parameter is the seam rather than `mock.module`
+// because bun replaces a mocked module for the WHOLE test process - stubbing
+// `@/lib/bridge` here broke every other file that imports `invoke`/
+// `openExternal` from it. See `__tests__/tour-worklog-answered.test.ts`.
+export async function waitForWorklogAnswered(
+  s: Stage,
+  timeoutMs: number,
+  probe: SettingsProbe = readWorklogSettings,
+): Promise<boolean> {
+  void s.waitForClick('[data-tour="worklog-schedule-on"]', timeoutMs)
+  const read = probe
   let baseline = await read()
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {


### PR DESCRIPTION
Review finding on #846, against the guard I added in #854. It was right, so this replaces it.

## The criticism, and why it lands

#854's guard asserted on source fragments:

```ts
expect(fn).toContain('baseline === undefined')
expect(fn).not.toContain('current !== null && current !== baseline')
```

I did verify it failed against the old code, which is more than most source scans get. But the reviewer's point stands: it proves the **text**, not the behaviour. A rewrite that reintroduces the bug with different spacing, or puts `baseline === undefined` in an unrelated branch, passes it.

## What replaces it

A runtime harness driving the real function over the interleaving that actually broke it: **baseline read rejects, later reads succeed with unchanged settings** → it must keep waiting, not report an answer nobody gave.

Verified the guard bites: removing the baseline-adoption branch makes that case fail (`Expected: false, Received: true`); restoring it passes. The source-scan test in `tutorial-sample-day.test.ts` is removed, with a pointer left where it was.

It also covers what a too-narrow fix would break — because "never resolve after a failed read" would pass the regression test and be wrong:

- a real change *after* a recovered read still resolves
- the dialog leaving the DOM still short-circuits (the re-declined-replay case)
- reads that never recover time out rather than guess

## Why the read is injected, not module-mocked

I tried `mock.module('@/lib/bridge', …)` first. It is the wrong tool here and the failure is worth recording: **bun replaces a mocked module for the entire test process**, so a stub exporting only `load`/`mutate`/`subscribe` broke every other file importing `invoke` or `openExternal` from the real bridge — **11 failures across 6 files, none of them in the code under test**.

So `waitForWorklogAnswered` takes a `SettingsProbe` with a production default. Nothing else passes the third argument, and the seam touches nothing outside this beat. That matches how this repo already reasons about testability (`insert_grace_row` is documented as "extracted to give the conflict behaviour a testable seam").

One deliberate detail: the stub `Stage`'s `waitForClick` returns a **never-resolving** promise. #852 established that primitive cannot be trusted here, and the code ignores its result on purpose — so if anyone ever starts awaiting it again, these tests hang rather than passing on a value the real primitive does not reliably produce.

## Tests

903 UI tests green (up from 897: +6 new, −1 removed source scan, and the file count is +1), `tsc --noEmit` clean.

## Still outstanding on #846, unchanged by this PR

`src/main.rs:1093` — single-instance acquisition is not atomic. Still the most substantive open finding, still deliberately routed to its own change rather than patched under release pressure. The guard at line 1087 only probes for a listener; the bind is at 1144, with `setup_db` and migrations in between, so two daemons starting together can both run migrations on the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)