### PR TITLE
fix(tray): close/reopen meridian.db pool around daemon restarts

### DIFF
--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -154,8 +154,8 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
     // `None` only when the DB itself couldn't be opened, in which case there's
     // nowhere to write a notice anyway.
     let pool = app
-        .try_state::<Option<meridian_core::SqlitePool>>()
-        .and_then(|s| s.inner().clone());
+        .try_state::<crate::db_pool::DbPool>()
+        .and_then(|s| s.get());
 
     tracing::info!(hash = %bundled_hash, "backend_install: installing bundled backend");
     if let Err(e) = install(&backend, &home).await {

--- a/tray/src-tauri/src/commands/daemon.rs
+++ b/tray/src-tauri/src/commands/daemon.rs
@@ -23,7 +23,6 @@
 //!   out of this module (CLAUDE.md's 500-line file cap).
 
 use crate::state::{AppState, StatusPayload};
-use meridian_core::SqlitePool;
 use serde::Serialize;
 use std::sync::{Arc, Mutex};
 use tauri::State;
@@ -87,9 +86,9 @@ pub async fn restart_daemon() -> Result<(), String> {
 pub async fn toggle_daemon(
     _app: tauri::AppHandle,
     is_running: bool,
-    db_pool: State<'_, Option<SqlitePool>>,
+    db_pool: State<'_, crate::db_pool::DbPool>,
 ) -> Result<(), String> {
-    let pool = db_pool.inner().clone();
+    let pool = db_pool.get();
     // `is_running` is the CURRENT state, so the useful field is what the user
     // asked for, not what it already was.
     tracing::Span::current().record("action", if is_running { "pause" } else { "resume" });
@@ -177,14 +176,48 @@ pub struct ReloadResponse {
 /// Errors when the daemon isn't running (the route's 503) — callers surface
 /// that as "your change applies when the daemon starts", so it must stay
 /// reachable. See [`plan_reload`] for the macOS rate limit.
+///
+/// Also closes and reopens the tray's own `meridian.db` pool around the
+/// signal (see [`reload_with_pool_cycle`]) — a daemon restart is exactly the
+/// process-generation boundary [`crate::db_pool::DbPool`] exists to keep the
+/// tray's connection from spanning. See that module's header for the
+/// corruption incident this closes off, and [`plan_reload`]'s doc for an
+/// EARLIER, related incident this same reload path caused (repeated SIGHUPs
+/// landing inside launchd's throttle window) — different mechanism, same
+/// underlying shape: a daemon-down window the tray's pool did not know about.
 #[tauri::command]
-#[tracing::instrument]
-pub async fn reload_daemon() -> Result<ReloadResponse, String> {
+#[tracing::instrument(skip(db_pool))]
+pub async fn reload_daemon(
+    db_pool: State<'_, crate::db_pool::DbPool>,
+) -> Result<ReloadResponse, String> {
+    // Owned clone (cheap - `DbPool` is `Arc`-backed): `reload_daemon_with`
+    // needs `'static`, which a borrowed `State<'_, _>` cannot provide.
+    reload_daemon_with(db_pool.inner().clone()).await
+}
+
+/// [`reload_daemon`]'s body, taking an owned pool handle instead of a
+/// `State<'_, _>` so the two OTHER places that reload the daemon after a
+/// credential change (`integrations::save_integration_token`,
+/// `integrations::start_oauth_github_device`'s spawned polling task — see
+/// [`plan_reload`]'s doc: "a single connect flow can trip this on its own")
+/// can share this exact close/reopen + throttle logic instead of calling the
+/// bare `#[tauri::command]` fn, which a `tauri::async_runtime::spawn`'d task
+/// cannot do (it needs `'static`, `State<'_, _>` is borrowed for the
+/// invocation). `db_pool.inner().clone()` is how a command handler bridges
+/// the two - see the call sites in `integrations.rs`.
+pub(crate) async fn reload_daemon_with(
+    pool: crate::db_pool::DbPool,
+) -> Result<ReloadResponse, String> {
     #[cfg(target_os = "macos")]
     {
-        reload_throttled(reload_state(), super::daemon_control::reload, || async {
-            super::daemon_control::status().await.running
-        })
+        reload_throttled(
+            reload_state(),
+            move || {
+                let pool = pool.clone();
+                async move { reload_with_pool_cycle(&pool).await }
+            },
+            || async { super::daemon_control::status().await.running },
+        )
         .await
     }
     // Windows restarts the scheduled task (`schtasks /End` + `/Run`). There is
@@ -193,10 +226,31 @@ pub async fn reload_daemon() -> Result<ReloadResponse, String> {
     // meaning on the platform.
     #[cfg(not(target_os = "macos"))]
     {
-        let pid = super::daemon_control::reload().await?;
+        let pid = reload_with_pool_cycle(&pool).await?;
         tracing::info!(pid, "daemon reload requested");
         Ok(ReloadResponse { ok: true, pid })
     }
+}
+
+/// Closes the tray's `meridian.db` pool before signaling the daemon and
+/// reopens it right after — see [`reload_daemon`]'s doc for why. A `None`
+/// pool inside (the DB was never open, e.g. a fresh install before the
+/// daemon has created it) makes both calls no-ops, matching every other call
+/// site's tolerance for an absent pool.
+///
+/// Reopen is LAZY (`DbPool::reopen` → `open_existing_lazy`), which is what
+/// makes this safe to run immediately after sending the signal rather than
+/// polling until the new daemon process is confirmed up: no physical
+/// connection is made here, only a fresh, empty pool object with no
+/// connections cached from the process generation that just exited. The
+/// first REAL connection happens on whatever read comes next (typically the
+/// following poll tick), against whatever the file looks like by then - a
+/// point in time this function does not need to reason about.
+async fn reload_with_pool_cycle(pool: &crate::db_pool::DbPool) -> Result<u32, String> {
+    pool.close().await;
+    let result = super::daemon_control::reload().await;
+    pool.reopen().await;
+    result
 }
 
 // ── macOS reload rate limit ─────────────────────────────────────────────────

--- a/tray/src-tauri/src/commands/dashboard.rs
+++ b/tray/src-tauri/src/commands/dashboard.rs
@@ -23,13 +23,13 @@ use tauri::State;
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_active(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
 ) -> Result<Option<meridian_core::active::ActiveView>, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let now = chrono::Utc::now().to_rfc3339();
-    meridian_core::active::get_active_view(pool, &now)
+    meridian_core::active::get_active_view(&pool, &now)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_active failed"))
 }
@@ -48,14 +48,14 @@ pub async fn get_active(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_day_draft_states(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     day: Option<String>,
 ) -> Result<Vec<meridian_core::day_task_worklogs::DayDraftState>, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let date = day.unwrap_or_else(meridian_core::date::today_string);
-    let states = meridian_core::day_task_worklogs::day_draft_states(pool, &date)
+    let states = meridian_core::day_task_worklogs::day_draft_states(&pool, &date)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_day_draft_states failed"))?;
     tracing::info!(day = %date, rows = states.len(), "day draft states served");
@@ -70,15 +70,15 @@ pub async fn get_day_draft_states(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_today(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     day: Option<String>,
 ) -> Result<meridian_core::today::TodayResponse, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let date = day.unwrap_or_else(meridian_core::date::today_string);
     let now = chrono::Utc::now().to_rfc3339();
-    meridian_core::today::get_today(pool, &date, &now)
+    meridian_core::today::get_today(&pool, &date, &now)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_today failed"))
 }
@@ -90,14 +90,14 @@ pub async fn get_today(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_day_tasks(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     day: Option<String>,
 ) -> Result<meridian_core::day_tasks::DayTasksResponse, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let date = day.unwrap_or_else(meridian_core::date::today_string);
-    meridian_core::day_tasks::get_day_tasks(pool, &date)
+    meridian_core::day_tasks::get_day_tasks(&pool, &date)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_day_tasks failed"))
 }
@@ -106,13 +106,13 @@ pub async fn get_day_tasks(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_week(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
 ) -> Result<meridian_core::week::WeekResponse, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let now = chrono::Utc::now().to_rfc3339();
-    meridian_core::week::get_week(pool, &now)
+    meridian_core::week::get_week(&pool, &now)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_week failed"))
 }
@@ -129,14 +129,14 @@ pub async fn get_week(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_coding_agents(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     day: Option<String>,
 ) -> Result<meridian_core::coding_agents::CodingAgentsResponse, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let date = day.unwrap_or_else(meridian_core::date::today_string);
-    meridian_core::coding_agents::get_coding_agents(pool, &date)
+    meridian_core::coding_agents::get_coding_agents(&pool, &date)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_coding_agents failed"))
 }
@@ -147,12 +147,12 @@ pub async fn get_coding_agents(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_recent_capture_apps(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
 ) -> Result<Vec<meridian_core::capture_apps::CaptureApp>, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
-    meridian_core::capture_apps::recent_capture_apps(pool, 30, 60)
+    meridian_core::capture_apps::recent_capture_apps(&pool, 30, 60)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_recent_capture_apps failed"))
 }
@@ -162,14 +162,14 @@ pub async fn get_recent_capture_apps(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_task_detail(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     key: String,
 ) -> Result<Option<meridian_core::task_detail::TaskDetail>, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let today = chrono::Local::now().date_naive();
-    meridian_core::task_detail::get_task_detail(pool, &key, today)
+    meridian_core::task_detail::get_task_detail(&pool, &key, today)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_task_detail failed"))
 }
@@ -182,18 +182,19 @@ pub async fn get_task_detail(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_plan(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     date: Option<String>,
 ) -> Result<meridian_core::plan::PlanResponse, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let date = read_date(date);
     let (today, now_ms, recent_since) = plan_clock();
-    let available = meridian_core::plan::build_available(pool, &date, today, now_ms, &recent_since)
-        .await
-        .map_err(|e| crate::cmd_err!(e, "get_plan: build_available failed"))?;
-    meridian_core::plan::build_plan_response(pool, &date, today, available)
+    let available =
+        meridian_core::plan::build_available(&pool, &date, today, now_ms, &recent_since)
+            .await
+            .map_err(|e| crate::cmd_err!(e, "get_plan: build_available failed"))?;
+    meridian_core::plan::build_plan_response(&pool, &date, today, available)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_plan failed"))
 }
@@ -205,10 +206,10 @@ pub async fn get_plan(
 #[tauri::command]
 #[tracing::instrument(skip(pool, body), fields(action = %body.action))]
 pub async fn plan_action(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     body: meridian_core::plan::PlanBody,
 ) -> Result<meridian_core::plan::PlanResponse, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     // Writes must reject a malformed EXPLICIT date (defaulting it to today would
@@ -219,10 +220,11 @@ pub async fn plan_action(
     };
     let (today, now_ms, recent_since) = plan_clock();
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-    let available = meridian_core::plan::build_available(pool, &date, today, now_ms, &recent_since)
-        .await
-        .map_err(|e| crate::cmd_err!(e, "plan_action: build_available failed"))?;
-    meridian_core::plan::apply_plan_action(pool, &body, &date, today, &now, available)
+    let available =
+        meridian_core::plan::build_available(&pool, &date, today, now_ms, &recent_since)
+            .await
+            .map_err(|e| crate::cmd_err!(e, "plan_action: build_available failed"))?;
+    meridian_core::plan::apply_plan_action(&pool, &body, &date, today, &now, available)
         .await
         .map_err(|e| crate::cmd_err!(e, "plan_action failed"))
 }
@@ -259,12 +261,12 @@ pub struct BoardTicket {
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_board_tickets(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
 ) -> Result<Vec<BoardTicket>, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
-    let rows = meridian_core::board::fetch_open_board(pool, false)
+    let rows = meridian_core::board::fetch_open_board(&pool, false)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_board_tickets failed"))?;
     tracing::info!(tickets = rows.len(), "serving the board ticket picker");
@@ -300,13 +302,13 @@ pub struct RetargetBody {
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn retarget_day_task_worklog(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     body: RetargetBody,
 ) -> Result<meridian_core::day_task_worklogs::DayTaskWorklogDraft, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
-    let provider = meridian_core::board::provider_for_key(pool, &body.task_key)
+    let provider = meridian_core::board::provider_for_key(&pool, &body.task_key)
         .await
         .map_err(|e| crate::cmd_err!(e, "retarget: provider lookup failed"))?;
     let Some(provider) = provider else {
@@ -319,7 +321,7 @@ pub async fn retarget_day_task_worklog(
 
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     meridian_core::day_task_worklogs::retarget_draft(
-        pool,
+        &pool,
         &body.day,
         &body.task_id,
         &body.task_key,
@@ -356,10 +358,10 @@ pub struct SetWorklogProviderBody {
 #[tauri::command]
 #[tracing::instrument(skip(pool), err)]
 pub async fn set_worklog_provider(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     body: SetWorklogProviderBody,
 ) -> Result<meridian_core::day_task_worklogs::DayTaskWorklogDraft, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     if !crate::commands::connected_providers().contains(&body.provider.as_str()) {
@@ -372,7 +374,7 @@ pub async fn set_worklog_provider(
 
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     meridian_core::day_task_worklogs::set_draft_provider(
-        pool,
+        &pool,
         &body.day,
         &body.task_id,
         &body.provider,
@@ -399,15 +401,20 @@ pub struct DismissTargetBody {
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn dismiss_worklog_target(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     body: DismissTargetBody,
 ) -> Result<meridian_core::day_task_worklogs::DayTaskWorklogDraft, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
-    meridian_core::day_task_worklogs::dismiss_target(pool, &body.day, &body.task_id, &body.task_key)
-        .await
-        .map_err(|e| crate::cmd_err!(e, "dismiss_worklog_target failed"))
+    meridian_core::day_task_worklogs::dismiss_target(
+        &pool,
+        &body.day,
+        &body.task_id,
+        &body.task_key,
+    )
+    .await
+    .map_err(|e| crate::cmd_err!(e, "dismiss_worklog_target failed"))
 }
 
 /// The body of a [`dismiss_day_task`] / [`restore_day_task`] call.
@@ -431,17 +438,17 @@ pub struct MergeDayTaskBody {
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn dismiss_day_task(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     body: DayTaskCorrectionBody,
 ) -> Result<meridian_core::day_tasks::DayTasksResponse, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let now = chrono::Utc::now().to_rfc3339();
-    meridian_core::day_task_corrections::dismiss_day_task(pool, &body.day, &body.task_id, &now)
+    meridian_core::day_task_corrections::dismiss_day_task(&pool, &body.day, &body.task_id, &now)
         .await
         .map_err(|e| crate::cmd_err!(e, "dismiss_day_task failed"))?;
-    meridian_core::day_tasks::get_day_tasks(pool, &body.day)
+    meridian_core::day_tasks::get_day_tasks(&pool, &body.day)
         .await
         .map_err(|e| crate::cmd_err!(e, "dismiss_day_task: task-list refresh failed"))
 }
@@ -452,15 +459,15 @@ pub async fn dismiss_day_task(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn merge_day_task(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     body: MergeDayTaskBody,
 ) -> Result<meridian_core::day_tasks::DayTasksResponse, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let now = chrono::Utc::now().to_rfc3339();
     meridian_core::day_task_corrections::merge_day_task(
-        pool,
+        &pool,
         &body.day,
         &body.task_id,
         &body.into_task_id,
@@ -468,7 +475,7 @@ pub async fn merge_day_task(
     )
     .await
     .map_err(|e| crate::cmd_err!(e, "merge_day_task failed"))?;
-    meridian_core::day_tasks::get_day_tasks(pool, &body.day)
+    meridian_core::day_tasks::get_day_tasks(&pool, &body.day)
         .await
         .map_err(|e| crate::cmd_err!(e, "merge_day_task: task-list refresh failed"))
 }
@@ -477,17 +484,17 @@ pub async fn merge_day_task(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn restore_day_task(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     body: DayTaskCorrectionBody,
 ) -> Result<meridian_core::day_tasks::DayTasksResponse, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let now = chrono::Utc::now().to_rfc3339();
-    meridian_core::day_task_corrections::restore_day_task(pool, &body.day, &body.task_id, &now)
+    meridian_core::day_task_corrections::restore_day_task(&pool, &body.day, &body.task_id, &now)
         .await
         .map_err(|e| crate::cmd_err!(e, "restore_day_task failed"))?;
-    meridian_core::day_tasks::get_day_tasks(pool, &body.day)
+    meridian_core::day_tasks::get_day_tasks(&pool, &body.day)
         .await
         .map_err(|e| crate::cmd_err!(e, "restore_day_task: task-list refresh failed"))
 }
@@ -564,9 +571,9 @@ fn plan_clock() -> (chrono::NaiveDate, i64, String) {
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_tasks(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
 ) -> Result<meridian_core::tasks::TasksResponse, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let today = meridian_core::date::today_string();
@@ -575,7 +582,7 @@ pub async fn get_tasks(
         .format("%Y-%m-%d")
         .to_string();
     let now_iso = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-    meridian_core::tasks::get_tasks(pool, &today, &week_start, &now_iso)
+    meridian_core::tasks::get_tasks(&pool, &today, &week_start, &now_iso)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_tasks failed"))
 }

--- a/tray/src-tauri/src/commands/day_summary.rs
+++ b/tray/src-tauri/src/commands/day_summary.rs
@@ -109,14 +109,14 @@ pub async fn generate_day_summary_now(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_day_summary(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     day: Option<String>,
 ) -> Result<Option<meridian_core::day_summaries::DaySummary>, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let date = day.unwrap_or_else(meridian_core::date::today_string);
-    meridian_core::day_summaries::get_day_summary(pool, &date)
+    meridian_core::day_summaries::get_day_summary(&pool, &date)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_day_summary failed"))
 }
@@ -145,21 +145,21 @@ pub async fn get_day_summary(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_day_summary_data(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     day: Option<String>,
 ) -> Result<serde_json::Value, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let date = day.unwrap_or_else(meridian_core::date::today_string);
-    let ev = meridian_core::day_evidence::collect(pool, &date)
+    let ev = meridian_core::day_evidence::collect(&pool, &date)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_day_summary_data failed"))?;
 
     // A missing summary is NOT stale: there is nothing to recompose, and the screen
     // shows its own "compose this day" state instead. Only an existing one can go
     // out of date.
-    let stale = match meridian_core::day_summaries::get_day_summary(pool, &date).await {
+    let stale = match meridian_core::day_summaries::get_day_summary(&pool, &date).await {
         Ok(Some(s)) => meridian_core::day_summaries::is_stale(&s.evidence_at, &ev.evidence_at),
         _ => false,
     };

--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -388,7 +388,7 @@ pub fn providers_awaiting_selection() -> Vec<&'static str> {
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_integrations(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
 ) -> Result<IntegrationsResponse, String> {
     let mode = crate::install::detect_install_mode();
     let env = mode.env_path().map(parse_env).unwrap_or_default();
@@ -396,8 +396,8 @@ pub async fn get_integrations(
 
     // Sync errors are best-effort: a missing/uninitialised DB just omits them
     // (matches the route's silent catch).
-    let sync_errors = match pool.inner() {
-        Some(pool) => meridian_core::integrations::sync_errors(pool)
+    let sync_errors = match pool.get() {
+        Some(pool) => meridian_core::integrations::sync_errors(&pool)
             .await
             .unwrap_or_default(),
         None => BTreeMap::new(),
@@ -503,7 +503,7 @@ pub(crate) fn upsert_env(
 #[tracing::instrument(skip(body, pool), fields(provider = %body.provider))]
 pub async fn disconnect_integration(
     body: DisconnectBody,
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
 ) -> Result<serde_json::Value, String> {
     let provider = body.provider.as_str();
     let token_keys = TOKEN_KEYS.iter().find(|(p, _)| *p == provider);
@@ -544,8 +544,8 @@ pub async fn disconnect_integration(
 
     // Best-effort: remove the provider's tasks so they don't linger in the UI.
     // A missing DB or uninitialised tables are logged but never block disconnect.
-    if let Some(p) = pool.inner() {
-        if let Err(e) = meridian_core::integrations::clear_provider_tasks(p, provider).await {
+    if let Some(p) = pool.get() {
+        if let Err(e) = meridian_core::integrations::clear_provider_tasks(&p, provider).await {
             tracing::warn!(error = %e, provider, "could not clear provider tasks from DB");
         }
     }
@@ -577,7 +577,10 @@ pub struct SaveTokenBody {
 /// connect the GET reflects is one the daemon sees on its next reload.
 #[tauri::command]
 #[tracing::instrument(skip(body), fields(provider = %body.provider))]
-pub async fn save_integration_token(body: SaveTokenBody) -> Result<serde_json::Value, String> {
+pub async fn save_integration_token(
+    body: SaveTokenBody,
+    db_pool: State<'_, crate::db_pool::DbPool>,
+) -> Result<serde_json::Value, String> {
     let provider = body.provider.as_str();
     let field_map = TOKEN_FIELD_MAP
         .iter()
@@ -671,7 +674,9 @@ pub async fn save_integration_token(body: SaveTokenBody) -> Result<serde_json::V
     // A down daemon is fine — it reads .env on its next start. `reloaded` is
     // returned to the UI so it can warn the user when the daemon isn't running
     // (common in dev where the daemon isn't launchd-supervised).
-    let reloaded = crate::commands::daemon::reload_daemon().await.is_ok();
+    let reloaded = crate::commands::daemon::reload_daemon_with(db_pool.inner().clone())
+        .await
+        .is_ok();
     if !reloaded {
         tracing::debug!("daemon reload after token save (non-fatal — will pick up on next start)");
     }
@@ -1188,10 +1193,13 @@ pub struct StartOAuthResponse {
 ///   the user never saw the code — and always timed out.
 #[tauri::command]
 #[tracing::instrument(fields(provider = %body.provider))]
-pub async fn start_oauth(body: StartOAuthBody) -> Result<StartOAuthResponse, String> {
+pub async fn start_oauth(
+    body: StartOAuthBody,
+    db_pool: State<'_, crate::db_pool::DbPool>,
+) -> Result<StartOAuthResponse, String> {
     match body.provider.as_str() {
         "jira" | "trello" => start_oauth_in_process(body.provider),
-        "github" => start_oauth_github_device(body.provider).await,
+        "github" => start_oauth_github_device(body.provider, db_pool.inner().clone()).await,
         other => Err(format!("Unknown provider: {other}")),
     }
 }
@@ -1370,7 +1378,10 @@ fn start_oauth_in_process(provider: String) -> Result<StartOAuthResponse, String
 /// gates its "Open GitHub" button on the user first copying the code, and that
 /// button is the sole opener (via `openExternal`). Auto-opening would jump the
 /// user to GitHub before they've copied, contradicting the guided steps.
-async fn start_oauth_github_device(provider: String) -> Result<StartOAuthResponse, String> {
+async fn start_oauth_github_device(
+    provider: String,
+    db_pool: crate::db_pool::DbPool,
+) -> Result<StartOAuthResponse, String> {
     // Resolve the client id: `.env` override wins, else the baked-in default.
     // Reading .env (not process env) matches start_oauth_in_process — the daemon
     // may not have exported it into the tray's environment.
@@ -1447,7 +1458,7 @@ async fn start_oauth_github_device(provider: String) -> Result<StartOAuthRespons
                 }
                 tracing::info!("GitHub device-flow login succeeded");
                 // Best-effort reload so the token takes effect now, not next restart.
-                if let Err(e) = crate::commands::daemon::reload_daemon().await {
+                if let Err(e) = crate::commands::daemon::reload_daemon_with(db_pool).await {
                     tracing::debug!(error = %e, "daemon reload after GitHub connect (non-fatal)");
                 }
             }

--- a/tray/src-tauri/src/commands/llm_lab.rs
+++ b/tray/src-tauri/src/commands/llm_lab.rs
@@ -133,14 +133,14 @@ pub async fn run_llm_experiment(body: RunLlmExperimentBody) -> Result<i64, Strin
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_llm_experiments(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     limit: Option<i64>,
 ) -> Result<Vec<LlmExperimentSummary>, String> {
     dev_only()?;
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
-    meridian_core::llm_experiments::list_experiments(pool, limit.unwrap_or(20))
+    meridian_core::llm_experiments::list_experiments(&pool, limit.unwrap_or(20))
         .await
         .map_err(|e| crate::cmd_err!(e, "get_llm_experiments failed"))
 }
@@ -150,14 +150,14 @@ pub async fn get_llm_experiments(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_llm_experiment(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     id: i64,
 ) -> Result<Option<LlmExperimentDetail>, String> {
     dev_only()?;
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
-    meridian_core::llm_experiments::get_experiment(pool, id)
+    meridian_core::llm_experiments::get_experiment(&pool, id)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_llm_experiment failed"))
 }

--- a/tray/src-tauri/src/commands/notices.rs
+++ b/tray/src-tauri/src/commands/notices.rs
@@ -25,12 +25,12 @@ use tauri::{Emitter, State};
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_notices(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
 ) -> Result<Vec<meridian_core::notices::Notice>, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Ok(Vec::new());
     };
-    let notices = meridian_core::notices::read_notices(pool).await;
+    let notices = meridian_core::notices::read_notices(&pool).await;
     tracing::info!(count = notices.len(), "notices served");
     Ok(notices)
 }
@@ -40,13 +40,13 @@ pub async fn get_notices(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn delete_notice(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     notice_id: String,
 ) -> Result<(), String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
-    meridian_core::notices::delete_notice(pool, &notice_id)
+    meridian_core::notices::delete_notice(&pool, &notice_id)
         .await
         .map_err(|e| crate::cmd_err!(e, notice_id, "delete_notice failed"))
 }

--- a/tray/src-tauri/src/commands/notifications.rs
+++ b/tray/src-tauri/src/commands/notifications.rs
@@ -45,14 +45,14 @@ use tracing::Instrument;
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_banner_notifications(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
 ) -> Result<Vec<meridian_core::notifications::BannerNotification>, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Ok(Vec::new());
     };
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     let settings = meridian_core::settings::load_runtime_settings();
-    let banners = meridian_core::notifications::active_banners(pool, &now, &settings).await;
+    let banners = meridian_core::notifications::active_banners(&pool, &now, &settings).await;
     tracing::info!(count = banners.len(), "banner notifications served");
     Ok(banners)
 }
@@ -63,14 +63,14 @@ pub async fn get_banner_notifications(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn dismiss_notification(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     id: i64,
 ) -> Result<(), String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-    meridian_core::notifications::dismiss_banner(pool, id, &now)
+    meridian_core::notifications::dismiss_banner(&pool, id, &now)
         .await
         .map_err(|e| crate::cmd_err!(e, id, "dismiss_notification failed"))
 }
@@ -92,15 +92,15 @@ pub async fn dismiss_notification(
 #[tracing::instrument(skip(app, pool, text))]
 pub async fn record_notification_response(
     app: tauri::AppHandle,
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     id: i64,
     action: String,
     text: Option<String>,
 ) -> Result<(), String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
-    apply_response(app, pool, id, &action, text.as_deref()).await
+    apply_response(app, &pool, id, &action, text.as_deref()).await
 }
 
 /// The body of [`record_notification_response`], factored out because it has

--- a/tray/src-tauri/src/commands/pause.rs
+++ b/tray/src-tauri/src/commands/pause.rs
@@ -102,9 +102,9 @@ pub async fn pause_for_duration(
     app: tauri::AppHandle,
     seconds: u64,
     state: State<'_, Arc<Mutex<AppState>>>,
-    db_pool: State<'_, Option<SqlitePool>>,
+    db_pool: State<'_, crate::db_pool::DbPool>,
 ) -> Result<(), String> {
-    let pool = db_pool.inner().clone();
+    let pool = db_pool.get();
 
     if seconds == 0 {
         resume_capture(state.inner(), pool.as_ref(), &app, false).await;
@@ -192,9 +192,9 @@ pub async fn pause_for_duration(
 pub async fn pause_indefinitely(
     app: tauri::AppHandle,
     state: State<'_, Arc<Mutex<AppState>>>,
-    db_pool: State<'_, Option<SqlitePool>>,
+    db_pool: State<'_, crate::db_pool::DbPool>,
 ) -> Result<(), String> {
-    let pool = db_pool.inner().clone();
+    let pool = db_pool.get();
     let now = now_secs();
 
     // Same atomic close-out-then-commit as pause_for_duration — see

--- a/tray/src-tauri/src/commands/settings.rs
+++ b/tray/src-tauri/src/commands/settings.rs
@@ -111,7 +111,7 @@ pub async fn get_settings() -> Result<Value, String> {
 #[tracing::instrument(skip(pool, app_state, body))]
 pub async fn update_settings(
     app: tauri::AppHandle,
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     app_state: State<'_, Arc<Mutex<AppState>>>,
     body: Value,
 ) -> Result<Value, String> {
@@ -212,12 +212,12 @@ pub async fn update_settings(
         // tick (`main.rs`) calls the identical `sync_groq_deprecated_notice`, so switching
         // away from Groq here and there converge on the same answer; this just stops the
         // banner from sitting stale for up to a minute after the switch already took effect.
-        if let Some(p) = pool.as_ref() {
+        if let Some(p) = pool.get() {
             let vendor = meridian_core::settings::load_runtime_settings()
                 .active_custom_provider()
                 .map(|c| c.vendor.clone());
-            meridian::notices::sync_groq_deprecated_notice(p, vendor.as_deref()).await;
-            crate::commands::notices::push_notices_update(&app, p).await;
+            meridian::notices::sync_groq_deprecated_notice(&p, vendor.as_deref()).await;
+            crate::commands::notices::push_notices_update(&app, &p).await;
         }
     }
 

--- a/tray/src-tauri/src/commands/statuses.rs
+++ b/tray/src-tauri/src/commands/statuses.rs
@@ -106,7 +106,7 @@ fn local_status_dto(o: &meridian_core::task_create::LocalStatusOption) -> Status
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn list_task_statuses(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     provider: String,
     key: String,
 ) -> Result<StatusListResponse, String> {
@@ -114,10 +114,10 @@ pub async fn list_task_statuses(
         return Err("provider and key are required".to_string());
     }
     if provider == meridian_core::task_create::LOCAL_PROVIDER {
-        let Some(pool) = pool.inner() else {
+        let Some(pool) = pool.get() else {
             return Err("meridian.db is not open yet".to_string());
         };
-        let current = meridian_core::task_create::local_task_current(pool, &key)
+        let current = meridian_core::task_create::local_task_current(&pool, &key)
             .await
             .map_err(|e| e.to_string())?
             .ok_or_else(|| format!("no personal task {key}"))?;
@@ -153,14 +153,14 @@ pub async fn list_task_statuses(
 #[tauri::command]
 #[tracing::instrument(skip(body, pool), fields(provider = %body.provider, key = %body.key, status_id = %body.status_id))]
 pub async fn set_task_status(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     body: SetStatusBody,
 ) -> Result<SetStatusResponse, String> {
     if body.provider.is_empty() || body.key.is_empty() || body.status_id.is_empty() {
         return Err("provider, key and status_id are required".to_string());
     }
     if body.provider == meridian_core::task_create::LOCAL_PROVIDER {
-        let Some(pool) = pool.inner() else {
+        let Some(pool) = pool.get() else {
             return Err("meridian.db is not open yet".to_string());
         };
         let Some(opt) = meridian_core::task_create::resolve_local_status(&body.status_id) else {
@@ -169,7 +169,7 @@ pub async fn set_task_status(
         let now = chrono::Utc::now().to_rfc3339();
         let is_terminal = opt.category == "done";
         let changed = meridian_core::task_create::set_local_status(
-            pool,
+            &pool,
             &body.key,
             opt.name,
             is_terminal,

--- a/tray/src-tauri/src/commands/triage.rs
+++ b/tray/src-tauri/src/commands/triage.rs
@@ -43,15 +43,15 @@ fn now_iso() -> String {
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_triage(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
 ) -> Result<meridian_core::triage::TriageResponse, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     // The triage GET route compares snoozed_until against `new Date().toISOString()`
     // (MILLIS precision) — keep millis here, not the writes' seconds-precision now.
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-    meridian_core::triage::get_triage(pool, &now)
+    meridian_core::triage::get_triage(&pool, &now)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_triage failed"))
 }
@@ -82,10 +82,10 @@ pub struct TriageDecisionAck {
 #[tauri::command]
 #[tracing::instrument(skip(pool, body), fields(task_key = %body.task_key, decision = %body.decision))]
 pub async fn triage_decision(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     body: TriageDecisionBody,
 ) -> Result<TriageDecisionAck, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     if body.task_key.is_empty() {
@@ -106,7 +106,7 @@ pub async fn triage_decision(
     };
 
     meridian_core::triage::record_decision(
-        pool,
+        &pool,
         &body.task_key,
         decision,
         snoozed_until.as_deref(),
@@ -145,10 +145,10 @@ pub struct TriageIgnoreAck {
 #[tauri::command]
 #[tracing::instrument(skip(pool, body), fields(task_key = %body.task_key, code = %body.code))]
 pub async fn triage_ignore(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     body: TriageIgnoreBody,
 ) -> Result<TriageIgnoreAck, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     if body.task_key.is_empty() {
@@ -158,7 +158,7 @@ pub async fn triage_ignore(
         return Err("code required".to_string());
     }
     let ignored = meridian_core::triage::set_ignored(
-        pool,
+        &pool,
         &body.task_key,
         &body.code,
         body.undo.unwrap_or(false),

--- a/tray/src-tauri/src/commands/worklogs.rs
+++ b/tray/src-tauri/src/commands/worklogs.rs
@@ -30,14 +30,14 @@ fn now_iso() -> String {
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_worklogs(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     day: Option<String>,
 ) -> Result<meridian_core::worklogs::WorklogsResponse, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let day = day.unwrap_or_else(meridian_core::date::today_string);
-    meridian_core::worklogs::get_worklogs(pool, &day)
+    meridian_core::worklogs::get_worklogs(&pool, &day)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_worklogs failed"))
 }
@@ -48,15 +48,15 @@ pub async fn get_worklogs(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_hour_text(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     day: Option<String>,
     hour: String,
 ) -> Result<meridian_core::hour_text::HourTextResponse, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let day = day.unwrap_or_else(meridian_core::date::today_string);
-    meridian_core::hour_text::get_hour_text(pool, &day, &hour)
+    meridian_core::hour_text::get_hour_text(&pool, &day, &hour)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_hour_text failed"))
 }
@@ -67,14 +67,14 @@ pub async fn get_hour_text(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_hour_reports(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     day: Option<String>,
 ) -> Result<meridian_core::hour_text::HourReportsResponse, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let day = day.unwrap_or_else(meridian_core::date::today_string);
-    meridian_core::hour_text::get_hour_reports(pool, &day)
+    meridian_core::hour_text::get_hour_reports(&pool, &day)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_hour_reports failed"))
 }
@@ -84,14 +84,14 @@ pub async fn get_hour_reports(
 #[tauri::command]
 #[tracing::instrument(skip(pool))]
 pub async fn get_hour_status(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     day: Option<String>,
 ) -> Result<meridian_core::hour_status::HourStatusResponse, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let day = day.unwrap_or_else(meridian_core::date::today_string);
-    meridian_core::hour_status::get_hour_status(pool, &day)
+    meridian_core::hour_status::get_hour_status(&pool, &day)
         .await
         .map_err(|e| crate::cmd_err!(e, "get_hour_status failed"))
 }
@@ -129,13 +129,13 @@ pub struct WorklogEditBody {
 #[tauri::command]
 #[tracing::instrument(skip(pool, body), fields(id = body.id))]
 pub async fn edit_worklog(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     body: WorklogEditBody,
 ) -> Result<WorklogWriteAck, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
-    let state = meridian_core::worklogs::edit_worklog(pool, body.id, &body.summary, &now_iso())
+    let state = meridian_core::worklogs::edit_worklog(&pool, body.id, &body.summary, &now_iso())
         .await
         .map_err(|e| crate::cmd_err!(e, id = body.id, "edit_worklog failed"))?;
     Ok(WorklogWriteAck {
@@ -159,17 +159,17 @@ pub struct WorklogRematchBody {
 #[tauri::command]
 #[tracing::instrument(skip(pool, body), fields(id = body.id, task_key = %body.task_key))]
 pub async fn rematch_worklog(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     body: WorklogRematchBody,
 ) -> Result<RematchAck, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let task_key = body.task_key.trim();
     if task_key.is_empty() {
         return Err("task key must not be empty".to_string());
     }
-    let outcome = meridian_core::worklogs::rematch_worklog(pool, body.id, task_key, &now_iso())
+    let outcome = meridian_core::worklogs::rematch_worklog(&pool, body.id, task_key, &now_iso())
         .await
         .map_err(|e| crate::cmd_err!(e, id = body.id, "rematch_worklog failed"))?;
     Ok(RematchAck {
@@ -197,17 +197,17 @@ pub struct ProposedTitleBody {
 #[tauri::command]
 #[tracing::instrument(skip(pool, body), fields(id = body.id))]
 pub async fn edit_proposed_title(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     body: ProposedTitleBody,
 ) -> Result<WorklogWriteAck, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let title = body.title.trim();
     if title.is_empty() {
         return Err("title must not be empty".to_string());
     }
-    let ok = meridian_core::proposed::edit_proposed_title(pool, body.id, title, &now_iso())
+    let ok = meridian_core::proposed::edit_proposed_title(&pool, body.id, title, &now_iso())
         .await
         .map_err(|e| crate::cmd_err!(e, id = body.id, "edit_proposed_title failed"))?;
     Ok(WorklogWriteAck {
@@ -222,13 +222,13 @@ pub async fn edit_proposed_title(
 #[tauri::command]
 #[tracing::instrument(skip(pool, body), fields(id = body.id))]
 pub async fn edit_proposed_worklog(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     body: WorklogEditBody,
 ) -> Result<WorklogWriteAck, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
-    let ok = meridian_core::proposed::edit_proposed_worklog(pool, body.id, &body.summary)
+    let ok = meridian_core::proposed::edit_proposed_worklog(&pool, body.id, &body.summary)
         .await
         .map_err(|e| crate::cmd_err!(e, id = body.id, "edit_proposed_worklog failed"))?;
     Ok(WorklogWriteAck {
@@ -251,15 +251,15 @@ pub struct ProposedActionBody {
 #[tauri::command]
 #[tracing::instrument(skip(pool, body), fields(id = body.id, action = %body.action))]
 pub async fn proposed_action(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     body: ProposedActionBody,
 ) -> Result<WorklogWriteAck, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let action = meridian_core::proposed::ProposedAction::parse(&body.action)
         .ok_or("action must be approve|dismiss")?;
-    let state = meridian_core::proposed::proposed_action(pool, body.id, action, &now_iso())
+    let state = meridian_core::proposed::proposed_action(&pool, body.id, action, &now_iso())
         .await
         .map_err(|e| crate::cmd_err!(e, id = body.id, "proposed_action failed"))?
         .ok_or("proposal is missing or already resolved")?;
@@ -289,10 +289,10 @@ pub struct WorklogActionBody {
 #[tauri::command]
 #[tracing::instrument(skip(pool, body), fields(id = body.id, action = %body.action))]
 pub async fn worklog_action(
-    pool: State<'_, Option<meridian_core::SqlitePool>>,
+    pool: State<'_, crate::db_pool::DbPool>,
     body: WorklogActionBody,
 ) -> Result<WorklogWriteAck, String> {
-    let Some(pool) = pool.inner() else {
+    let Some(pool) = pool.get() else {
         return Err("meridian.db is not open yet".to_string());
     };
     let action = meridian_core::worklogs::WorklogAction::parse(&body.action)
@@ -311,7 +311,7 @@ pub async fn worklog_action(
     let corrected_to_untracked = is_reject && body.corrected_to_untracked.unwrap_or(false);
 
     let state = meridian_core::worklogs::worklog_action(
-        pool,
+        &pool,
         body.id,
         action,
         corrected_task_key,

--- a/tray/src-tauri/src/db_pool.rs
+++ b/tray/src-tauri/src/db_pool.rs
@@ -1,0 +1,209 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! The tray's swappable `meridian.db` pool handle.
+//!
+//! Before this module, `meridian.db`'s pool was opened once at tray startup
+//! (`lib.rs`'s `open_existing_lazy` call) and handed to Tauri as bare
+//! `Option<meridian_core::SqlitePool>>` managed state - held for the tray
+//! process's ENTIRE lifetime, including across a daemon restart.
+//! `commands::daemon::reload_daemon` SIGHUPs the daemon (macOS: exits and
+//! relies on launchd, or in a dev session a human, to relaunch it) without the
+//! tray's own connection ever knowing a restart happened - so the tray's pool
+//! spans two different daemon process generations on the same file. That is
+//! the confirmed trigger of a real `meridian.db` corruption incident
+//! (2026-08-24): see PR #856, which fixed the daemon's shutdown to checkpoint
+//! the WAL and made the tray's own reads detect corruption immediately - both
+//! good independent hardening, but neither closes the actual gap.
+//!
+//! [`DbPool`] closes it: `reload_daemon` calls [`DbPool::close`] before
+//! signaling and [`DbPool::reopen`] once the new daemon process is confirmed
+//! up, so the tray never holds a connection spanning the boundary. Every
+//! other call site is unaffected - [`DbPool::get`] returns the exact same
+//! `Option<SqlitePool>` shape `State<Option<SqlitePool>>>::inner()` used to,
+//! just renamed, since "the pool might legitimately be absent right now" was
+//! already part of every caller's contract (a `None` during a first launch,
+//! before the daemon has created the file).
+//!
+//! # Who calls this
+//! - `lib.rs`'s setup hook constructs it and calls `app.manage`.
+//! - `commands::daemon::reload_daemon` calls `close`/`reopen` around the
+//!   signal - the one thing that could not be done through the old bare
+//!   `Option<SqlitePool>>` state.
+//! - Every dashboard/poll read that used to do
+//!   `let Some(pool) = pool.inner() else { ... }` now does the same against
+//!   `pool.get()`.
+
+use meridian_core::SqlitePool;
+use std::sync::{Arc, RwLock};
+
+/// Swappable handle to the tray's `meridian.db` pool, managed as Tauri state
+/// in place of a bare `Option<SqlitePool>>`.
+///
+/// `uri`/`key_hex` are remembered at construction so [`reopen`](Self::reopen)
+/// needs no arguments at its call site - `reload_daemon` has neither the DB
+/// path nor the encryption key on hand, only this handle.
+#[derive(Clone)]
+pub struct DbPool {
+    inner: Arc<RwLock<Option<SqlitePool>>>,
+    uri: String,
+    key_hex: Option<String>,
+}
+
+/// Manual, not derived: several call sites take `DbPool` as a `#[tauri::command]`
+/// parameter without `#[tracing::instrument(skip(...))]`, so a derived `Debug`
+/// would print `key_hex` — the raw SQLCipher key — into a span every time one
+/// of those commands runs. `key_hex.is_some()` is all any log ever needs.
+impl std::fmt::Debug for DbPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DbPool")
+            .field("uri", &self.uri)
+            .field("key_set", &self.key_hex.is_some())
+            .finish()
+    }
+}
+
+impl DbPool {
+    pub fn new(pool: Option<SqlitePool>, uri: String, key_hex: Option<String>) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(pool)),
+            uri,
+            key_hex,
+        }
+    }
+
+    /// The pool, if one is currently open - `None` before the daemon has
+    /// created `meridian.db` yet, or during the brief window between
+    /// [`close`](Self::close) and [`reopen`](Self::reopen) around a daemon
+    /// restart. Cheap: `sqlx::SqlitePool` is itself `Arc`-backed, so this is
+    /// a shallow clone, not a new connection.
+    pub fn get(&self) -> Option<SqlitePool> {
+        self.inner.read().unwrap_or_else(|e| e.into_inner()).clone()
+    }
+
+    /// Close the pool and clear the handle. Called before signaling the
+    /// daemon to restart, so nothing on this side keeps a connection alive
+    /// spanning the old process's shutdown and the new one's startup - see
+    /// this module's header for the corruption this closes off. Every reader
+    /// sees `get() == None` for the duration and behaves exactly as it
+    /// already does on a cold start (empty defaults, no panic).
+    pub async fn close(&self) {
+        let taken = self.inner.write().unwrap_or_else(|e| e.into_inner()).take();
+        if let Some(pool) = taken {
+            pool.close().await;
+        }
+    }
+
+    /// Reopen against the same uri/key this handle was built with. Lazy,
+    /// matching the original startup open - see that call site's doc
+    /// (`lib.rs`) for why eager fails when `meridian.db` briefly does not
+    /// exist. Best-effort: a failure here is logged and leaves `get()`
+    /// returning `None`, same as any other reason the pool isn't open yet;
+    /// the daemon's own re-creation of the file on its next write heals it
+    /// exactly as a lazy pool always has.
+    pub async fn reopen(&self) {
+        match meridian_core::open_existing_lazy(&self.uri, self.key_hex.as_deref()).await {
+            Ok(pool) => {
+                *self.inner.write().unwrap_or_else(|e| e.into_inner()) = Some(pool);
+            }
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    "DbPool::reopen failed - meridian.db stays unavailable until the next reload or tray restart"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn migrated_db(dir: &std::path::Path) -> (String, meridian_core::SqlitePool) {
+        use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+        use std::str::FromStr;
+
+        let path = dir.join("db_pool_test.db");
+        let uri = format!("sqlite://{}", path.display());
+        // `open_existing`/`open_existing_lazy` both set `create_if_missing(false)`
+        // (they assume the daemon already created the file) - a test fixture
+        // needs its own connect path to create one from scratch.
+        let opts = SqliteConnectOptions::from_str(&uri)
+            .unwrap()
+            .create_if_missing(true);
+        let pool = SqlitePoolOptions::new()
+            .connect_with(opts)
+            .await
+            .expect("create db");
+        sqlx::migrate!("../../src/migrations")
+            .run(&pool)
+            .await
+            .expect("migrate");
+        pool.close().await;
+        // Reopen through the same lazy path `DbPool` itself uses, so the
+        // handle under test behaves exactly like production.
+        let pool = meridian_core::open_existing_lazy(&uri, None)
+            .await
+            .expect("reopen lazily");
+        (uri, pool)
+    }
+
+    /// `get()` must return exactly what was passed to `new()`.
+    #[tokio::test]
+    async fn get_returns_the_pool_it_was_built_with() {
+        let dir = tempfile::tempdir().unwrap();
+        let (uri, pool) = migrated_db(dir.path()).await;
+        let handle = DbPool::new(Some(pool), uri, None);
+        assert!(handle.get().is_some());
+    }
+
+    /// A handle built with no pool (e.g. the DB isn't open yet) must behave
+    /// exactly like the old `None` state every caller already handles.
+    #[tokio::test]
+    async fn get_is_none_when_built_empty() {
+        let handle = DbPool::new(None, "sqlite://does-not-matter".to_string(), None);
+        assert!(handle.get().is_none());
+    }
+
+    /// The exact sequence `reload_daemon` runs: close, then a read in
+    /// between must see `None` (nothing races the daemon's restart), then
+    /// reopen brings a working pool back without needing to be told the URI
+    /// again.
+    #[tokio::test]
+    async fn close_then_reopen_restores_a_working_pool() {
+        let dir = tempfile::tempdir().unwrap();
+        let (uri, pool) = migrated_db(dir.path()).await;
+        let handle = DbPool::new(Some(pool), uri, None);
+
+        handle.close().await;
+        assert!(
+            handle.get().is_none(),
+            "a reader between close() and reopen() must see no pool, not a stale one"
+        );
+
+        handle.reopen().await;
+        let reopened = handle.get().expect("reopen must restore a pool");
+        // Prove it's a genuinely live connection, not just a non-None marker.
+        meridian_core::ping(&reopened)
+            .await
+            .expect("reopened pool must actually work");
+    }
+
+    /// `reopen` must not panic on failure, and must leave `get()` at `None`
+    /// rather than propagating the error - `reopen` is deliberately
+    /// best-effort (see its doc), the same shape as any other reason a lazy
+    /// pool isn't open yet. A missing/wrong-shaped file is NOT enough to
+    /// prove this (`open_existing_lazy` defers that check to first use, so
+    /// it would return `Ok` here regardless) - an invalid key is what
+    /// actually fails synchronously, at `validate_key_hex` inside
+    /// `open_existing_lazy` itself, before any connection is attempted.
+    #[tokio::test]
+    async fn reopen_failure_leaves_the_handle_empty_not_panicked() {
+        let handle = DbPool::new(
+            None,
+            "sqlite://does-not-matter".to_string(),
+            Some("not-valid-hex".to_string()),
+        );
+        handle.reopen().await;
+        assert!(handle.get().is_none());
+    }
+}

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -31,6 +31,7 @@ mod counter_ping;
 mod crash;
 mod daemon_lifecycle;
 mod db_key;
+mod db_pool;
 mod deep_link;
 
 /// Lowercase product name as macOS reports it after [`set_process_display_name`].
@@ -668,7 +669,16 @@ pub fn run() {
                     // The encryption-state notice below needs a pool handle before
                     // db_pool is moved into managed state.
                     let encryption_notice_pool = db_pool.clone();
-                    app.manage(db_pool);
+                    // Wrapped so `commands::daemon::reload_daemon` can close and
+                    // reopen it around a daemon restart instead of holding one
+                    // connection across two different daemon process
+                    // generations — see `db_pool::DbPool`'s header for the
+                    // corruption incident this closes off.
+                    app.manage(db_pool::DbPool::new(
+                        db_pool,
+                        db_path.clone(),
+                        db_key_hex.clone(),
+                    ));
 
                     // Report the repair now that there is a pool to write a notice
                     // with. Deliberately after `app.manage`: the notice is the

--- a/tray/src-tauri/src/poll/mod.rs
+++ b/tray/src-tauri/src/poll/mod.rs
@@ -61,8 +61,8 @@ pub async fn run_poll_loop(app: tauri::AppHandle, state: Arc<Mutex<AppState>>) {
         // DB read through it, so the loop has no HTTP dependency on the Next
         // server. `None` only before the DB is first opened.
         let pool = app
-            .try_state::<Option<meridian_core::SqlitePool>>()
-            .and_then(|s| s.inner().clone());
+            .try_state::<crate::db_pool::DbPool>()
+            .and_then(|s| s.get());
 
         if do_health {
             refresh_health(&app, &state, pool.as_ref()).await;

--- a/tray/src-tauri/src/poll/notifications.rs
+++ b/tray/src-tauri/src/poll/notifications.rs
@@ -40,17 +40,17 @@ fn now_iso() -> String {
 /// Alerts style this is what makes a "fleeting" notification possible, and it
 /// makes ignored-until-expiry measurable (vs. never answered at all).
 pub(super) async fn drain_notifications(app: &tauri::AppHandle) {
-    let pool_state = app.state::<Option<meridian_core::SqlitePool>>();
-    let Some(pool) = pool_state.inner() else {
+    let pool_state = app.state::<crate::db_pool::DbPool>();
+    let Some(pool) = pool_state.get() else {
         return; // DB not open yet — nothing to drain
     };
     let settings = meridian_core::settings::load_runtime_settings();
     let now = now_iso();
-    let items = meridian_core::notifications::pending_native(pool, &now, &settings).await;
+    let items = meridian_core::notifications::pending_native(&pool, &now, &settings).await;
 
     for n in items {
         notify_outbox(app, &n);
-        if let Err(e) = meridian_core::notifications::mark_native_delivered(pool, n.id, &now).await
+        if let Err(e) = meridian_core::notifications::mark_native_delivered(&pool, n.id, &now).await
         {
             // Leave the row unacked → re-delivered next tick (at-least-once).
             tracing::warn!(error = %e, id = n.id, "notification delivered-ack failed");
@@ -60,9 +60,9 @@ pub(super) async fn drain_notifications(app: &tauri::AppHandle) {
     // Expiry sweep. Stamp BEFORE retracting: the stamp is what stops the row
     // re-qualifying next tick, and it wins races with a user answering at the
     // same moment (first answer wins via record_response's IS NULL guard).
-    for id in meridian_core::notifications::expired_unanswered(pool, &now).await {
+    for id in meridian_core::notifications::expired_unanswered(&pool, &now).await {
         if let Err(e) =
-            meridian_core::notifications::record_response(pool, id, "expired", None, &now).await
+            meridian_core::notifications::record_response(&pool, id, "expired", None, &now).await
         {
             tracing::warn!(error = %e, id, "expiry stamp failed — will retry next tick");
             continue;

--- a/tray/src-tauri/src/tray.rs
+++ b/tray/src-tauri/src/tray.rs
@@ -165,7 +165,7 @@ fn toggle_from_menu(app: &tauri::AppHandle) {
         drop(state_guard);
         let app_for_notify = app.clone();
         tauri::async_runtime::spawn(async move {
-            let db_pool = app_for_notify.state::<Option<meridian_core::SqlitePool>>();
+            let db_pool = app_for_notify.state::<crate::db_pool::DbPool>();
             let _ =
                 crate::commands::toggle_daemon(app_for_notify.clone(), is_running, db_pool).await;
         });

--- a/tray/src-tauri/src/update.rs
+++ b/tray/src-tauri/src/update.rs
@@ -38,7 +38,6 @@
 //!   line (reads the optional `tray/minimum-version` file at release time).
 //! - Plan: Obsidian `Decisions/Public distribution + auto-update for the DMG`.
 
-use meridian_core::SqlitePool;
 use semver::Version;
 use serde::Serialize;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -57,8 +56,8 @@ use tauri_plugin_updater::UpdaterExt;
 /// rare background events, never a tight loop that would spam distinct keys).
 async fn notify_update(app: &AppHandle, dedup_suffix: &str, title: &str, body: &str) {
     let Some(pool) = app
-        .try_state::<Option<SqlitePool>>()
-        .and_then(|s| s.inner().clone())
+        .try_state::<crate::db_pool::DbPool>()
+        .and_then(|s| s.get())
     else {
         tracing::debug!(title, "notify_update: DB not open yet — toast dropped");
         return;

--- a/tray/src-tauri/src/win_toast.rs
+++ b/tray/src-tauri/src/win_toast.rs
@@ -281,8 +281,8 @@ fn record(app: &tauri::AppHandle, id: i64, action: String, text: Option<String>)
     // Clone the pool out of the managed state before the await — a `State`
     // guard borrows the app and cannot be held across one.
     let pool = app
-        .try_state::<Option<meridian_core::SqlitePool>>()
-        .and_then(|s| s.inner().clone());
+        .try_state::<crate::db_pool::DbPool>()
+        .and_then(|s| s.get());
     let Some(pool) = pool else {
         tracing::warn!(id, action, "toast answer dropped — meridian.db is not open");
         return;


### PR DESCRIPTION
## Summary
Companion to #856, tracked separately as agreed since it's a bigger refactor.

The tray opened its `meridian.db` pool once at startup and held it for the tray process's ENTIRE lifetime, including across every daemon restart triggered by `reload_daemon` (SIGHUP on macOS relying on launchd to relaunch, a scheduled-task restart on Windows). That one long-lived pool spanning two different daemon process generations on the same file is the confirmed trigger of a real corruption incident hit during dev testing today (2026-08-24) - see #856 for the full incident writeup.

While tracing this, `commands/daemon.rs`'s own `plan_reload` doc comment turned up an EARLIER, related incident (1.84.0-staging.7): a stale tray pool returned `(code: 11) database disk image is malformed` during a daemon-down window caused by repeated SIGHUPs landing inside launchd's `ThrottleInterval` - on a file whose `PRAGMA integrity_check` stayed `ok` the whole time. That incident led to the existing rate-limiting wrapper (`reload_throttled`/`plan_reload`), which prevents *repeated* signals from compounding the outage, but doesn't address the structural gap this PR closes: the tray's pool spanning *any* single daemon restart at all, not just repeated ones.

`DbPool` (`tray/src-tauri/src/db_pool.rs`) wraps the pool in an `Arc<RwLock<Option<SqlitePool>>>` so it can be closed and reopened at runtime, replacing the bare `Option<SqlitePool>` Tauri managed state every command previously read via `State<Option<SqlitePool>>::inner()`. `reload_daemon` (and the two other call sites that reload after a credential change - `integrations.rs`'s token save and the GitHub device-flow completion) now closes the pool immediately before signaling and reopens it (lazily - no physical connection made yet) right after, so the tray never holds a connection cached from the process generation being replaced.

Mechanical fallout: every command reading the pool now calls `State<DbPool>::get()` instead of `.inner()` (same `Option<SqlitePool>` shape, just renamed), and a handful of reader calls needed an explicit `&` since `get()` returns an owned clone rather than the borrowed reference match ergonomics used to produce.

## Test plan
- [x] `cargo test --workspace` - 1051+391 tests pass across every crate, including 4 new `db_pool` unit tests (get/close/reopen round-trip against a real WAL-mode temp-dir database, plus a synchronous-failure case)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] End-to-end verification on staging (a daemon reload triggered by an integration token save should no longer leave the tray's dashboard reads seeing stale/corrupt state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)