### PR TITLE
fix(db,tray): a busy checkpoint is not a clean one, and DbPool must survive a setup panic

### DIFF
--- a/src/db/meridian.rs
+++ b/src/db/meridian.rs
@@ -146,10 +146,29 @@ pub async fn setup_db(uri: &str) -> anyhow::Result<SqlitePool> {
 /// Best-effort by design — callers should log and continue on error rather
 /// than fail shutdown over it.
 pub async fn checkpoint_wal(pool: &SqlitePool) -> anyhow::Result<()> {
-    sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
-        .execute(pool)
-        .await
-        .context("WAL checkpoint failed")?;
+    // `PRAGMA wal_checkpoint(TRUNCATE)` answers with a ROW — `(busy, log,
+    // checkpointed)` — not merely a status. `busy = 1` means another connection
+    // held the file and the checkpoint did NOT truncate anything. `.execute()`
+    // discards that row, so the call reported success on a WAL it had left
+    // exactly as it found it.
+    //
+    // That is not a remote possibility here, it is the expected contention: the
+    // doc above explains this function exists BECAUSE the tray keeps its own
+    // long-lived pool on this same file, and that pool is precisely the reader
+    // that makes `busy` non-zero. Silently succeeding is the worst of the
+    // outcomes — shutdown logs a clean checkpoint and still hands the next
+    // daemon generation the half-written WAL this exists to prevent.
+    let (busy, _log, _checkpointed): (i64, i64, i64) =
+        sqlx::query_as("PRAGMA wal_checkpoint(TRUNCATE)")
+            .fetch_one(pool)
+            .await
+            .context("WAL checkpoint failed")?;
+    if busy != 0 {
+        anyhow::bail!(
+            "WAL checkpoint could not truncate - another connection held the file. \
+             The next daemon generation starts on a non-empty WAL."
+        );
+    }
     Ok(())
 }
 
@@ -682,5 +701,68 @@ mod tests {
             wal_len_after, 0,
             "TRUNCATE checkpoint must leave an empty WAL, got {wal_len_after} bytes"
         );
+    }
+
+    /// The failure this used to report as SUCCESS.
+    ///
+    /// `PRAGMA wal_checkpoint(TRUNCATE)` answers with a row whose first column
+    /// is `busy`; `.execute()` discarded it, so a checkpoint blocked by another
+    /// connection returned `Ok(())` having truncated nothing. The daemon then
+    /// logged a clean shutdown and handed the next generation the very WAL this
+    /// call exists to clear.
+    ///
+    /// The second connection here is not a contrivance - it is the tray's own
+    /// long-lived pool in miniature, which `checkpoint_wal`'s doc names as the
+    /// reason this function has to exist at all.
+    #[tokio::test]
+    async fn checkpoint_wal_reports_a_busy_file_instead_of_claiming_success() {
+        use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
+        use sqlx::Connection;
+        use std::str::FromStr;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("busy_checkpoint.db");
+        let opts = SqliteConnectOptions::from_str(&format!("sqlite://{}", path.display()))
+            .unwrap()
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal);
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(opts.clone())
+            .await
+            .expect("open WAL-mode db");
+        sqlx::query("CREATE TABLE t (v BLOB)")
+            .execute(&pool)
+            .await
+            .expect("create table");
+        sqlx::query("INSERT INTO t (v) VALUES (zeroblob(65536))")
+            .execute(&pool)
+            .await
+            .expect("insert");
+
+        // A separate connection holding an OPEN read transaction, which is what
+        // stops a TRUNCATE checkpoint from resetting the WAL.
+        let mut reader = sqlx::SqliteConnection::connect_with(&opts)
+            .await
+            .expect("second connection");
+        sqlx::query("BEGIN DEFERRED")
+            .execute(&mut reader)
+            .await
+            .expect("begin");
+        sqlx::query("SELECT count(*) FROM t")
+            .fetch_all(&mut reader)
+            .await
+            .expect("read inside the transaction pins the WAL");
+
+        let err = checkpoint_wal(&pool)
+            .await
+            .expect_err("a checkpoint blocked by a live reader must not report success");
+        assert!(
+            err.to_string().contains("could not truncate"),
+            "the error must say the checkpoint did not happen, got: {err}"
+        );
+
+        let _ = sqlx::query("COMMIT").execute(&mut reader).await;
     }
 }

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -895,6 +895,37 @@ pub fn run() {
             // always resolvable, so a command extracting it doesn't panic a
             // second, unrelated time on missing managed state.
             app.manage(db_setup_result.clone());
+            // The SAME guarantee, for the OTHER managed type — and it did not
+            // grow with it. `DbPool` (added when `reload_daemon` needed to
+            // close/reopen around a daemon restart) is registered INSIDE the
+            // closure above, so a panic before that point leaves it unmanaged.
+            // `State<DbPool>` is what every dashboard command and the
+            // notification drain extract, so on the panic path each one fails
+            // extraction or panics on missing state — the very second, unrelated
+            // panic the line above exists to prevent, just for the type that has
+            // since replaced `Option<SqlitePool>` at those call sites.
+            //
+            // Guarded on `try_state` rather than leaning on `manage`'s no-op so
+            // the normal path doesn't re-resolve the path (and re-log it) on
+            // every launch. `meridian_db_path()` is re-read rather than threaded
+            // out of the closure because a panicked closure has, by definition,
+            // no value to hand back — and it is a pure env/.env lookup.
+            //
+            // The key is `None`: an encrypted DB cannot be reopened through this
+            // fallback handle. That is honest about a startup that already
+            // failed — `get()` correctly reports no pool either way — and it
+            // buys back every command's ability to run and say so.
+            if app.try_state::<db_pool::DbPool>().is_none() {
+                tracing::warn!(
+                    "tray setup did not register the database pool - registering an empty \
+                     handle so commands degrade instead of failing state extraction"
+                );
+                app.manage(db_pool::DbPool::new(
+                    None,
+                    install::meridian_db_path(),
+                    None,
+                ));
+            }
             #[cfg(feature = "capture")]
             let capture_pool = db_setup_result;
 


### PR DESCRIPTION
Two findings from the fifth review round on #846, both against #856/#858, both verified against the code and against the previous behaviour.

## 1. `checkpoint_wal` reported success on a checkpoint that did nothing

`PRAGMA wal_checkpoint(TRUNCATE)` answers with a **row** — `(busy, log, checkpointed)` — and `.execute()` threw it away. `busy = 1` means another connection held the file and **nothing was truncated**, so the daemon logged a clean shutdown and handed the next generation exactly the half-written WAL this call exists to prevent.

The sharp part is that this is the *expected* case, not an exotic one. `checkpoint_wal`'s own doc explains it exists **because** the tray keeps a long-lived pool on the same file — and that pool is precisely the reader that makes `busy` non-zero. So the function's stated rationale describes the condition under which it silently failed.

Now reads the row and fails loudly. The contract is unchanged: it is still best-effort and callers already log and continue.

Test added with a second connection holding an open read transaction — the tray's pool in miniature. **Verified it fails against `.execute()`** and passes reading the row, so it is guarding the behaviour rather than the shape.

## 2. A setup panic left `DbPool` unmanaged

`lib.rs` wraps setup in `catch_unwind` and then calls `app.manage(db_setup_result)` **outside** the closure, with a comment saying it "guarantees `State<Option<SqlitePool>>` is always resolvable, so a command extracting it doesn't panic a second, unrelated time on missing managed state."

That net was written for `Option<SqlitePool>`. #858 introduced `DbPool` as a **separate managed type**, registered only *inside* the closure — and `State<DbPool>` is what every dashboard command (`dashboard.rs` has a dozen) and the notification drain now extract. So on the panic path each one fails extraction or panics on missing state: the exact second panic the net exists to stop, for the type that has since replaced the one it covers.

Registers an empty handle on that path. Details worth stating:

- `meridian_db_path()` is **re-resolved** rather than threaded out of the closure — a panicked closure has, by definition, no value to hand back, and it is a pure env/`.env` lookup.
- Guarded on `try_state` rather than leaning on `manage`'s no-op, so the normal path does not re-resolve (and re-log) on every launch.
- The key is `None`. An encrypted DB cannot be reopened through the fallback handle — which is honest about a startup that already failed. `get()` reports no pool either way; this only buys back every command's ability to run and say so.

---

## The Critical finding I did NOT act on — and why it needs your call

`commands/daemon.rs:253`, tagged **Critical**: *"Wait for daemon readiness before publishing the new pool."*

I am not landing this unilaterally, but I do not think it can be dismissed either, because **the two modules #858 added contradict each other on this exact point**:

`db_pool.rs`'s header states the invariant:

> "`reload_daemon` calls `DbPool::close` before signaling and `DbPool::reopen` **once the new daemon process is confirmed up**, so the tray never holds a connection spanning the boundary."

`commands/daemon.rs`'s `reload_with_pool_cycle` does the opposite, and argues for it:

> "Reopen is LAZY … which is what makes this safe to run **immediately after sending the signal rather than polling until the new daemon process is confirmed up** … The first REAL connection happens on whatever read comes next (typically the following poll tick), against whatever the file looks like by then — **a point in time this function does not need to reason about**."

Laziness means no connection is created *at reopen time*. It does not mean no connection is created *before the old generation exits* — the next poll tick will make one, and that connection then spans the boundary. So the invariant the module header claims is not delivered by the implementation, and the reviewer's reading matches the header while the code matches the other comment.

You know why the close/reopen was needed (the 2026-08-24 incident `db_pool.rs` cites), so you are better placed than I am to say which comment is the intended contract. There is already a readiness probe to hand — the macOS path passes `|| async { daemon_control::status().await.running }` — if a barrier is the answer.

## Declined, consistently with earlier rounds

Three of the six findings were "split the oversized file": `src/db/meridian.rs`, `backend_install.rs`/other tray modules, and `tutorial-sample-day.test.ts`. All true, all pre-existing, all Heavy lift. Mechanical refactors of daemon startup, install staging and tour choreography do not belong in a review-response PR — and this is now the third round raising them, so they are worth scheduling deliberately rather than declining forever.

## Tests

`cargo clippy --workspace --all-targets` clean; full workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)