### PR TITLE
fix(tray): stop autostart from undoing a deliberate Quit

### DIFF
--- a/tray/src-tauri/src/autostart.rs
+++ b/tray/src-tauri/src/autostart.rs
@@ -1,6 +1,18 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
-//! Launch-at-login **and** morning relaunch registration for the tray, owned
-//! outright rather than delegated to `tauri-plugin-autostart`.
+//! Launch-at-login registration for the tray, owned outright rather than
+//! delegated to `tauri-plugin-autostart`.
+//!
+//! # Login, restart, or a manual start — never a mid-day resurrection
+//! Meridian must come back after the device is turned on or logged into. It
+//! must NOT come back on its own after the user deliberately quits it, before
+//! then — an earlier version of this module got that wrong by relaunching on
+//! OS wake/unlock events (macOS `LaunchEvents`, Windows
+//! `SessionStateChangeTrigger`), which fire many times in an ordinary day, so
+//! Quit did not stick: a user closed Meridian and had it back within minutes,
+//! the next time their screen so much as locked and unlocked. See
+//! [`macos::plist_body`] and the `windows` module docs for the removal and
+//! [`macos::disarm_relaunch`] for clearing an already-armed wake job left by
+//! an older build.
 //!
 //! # Why the tray specifically
 //! Capture runs IN-PROCESS in the tray (`crate::capture`). A tray that isn't
@@ -13,11 +25,11 @@
 //! # Why not `tauri-plugin-autostart`
 //! Two reasons, both structural:
 //!
-//! 1. **It cannot express a morning relaunch.** Verified against
-//!    `auto-launch-0.5.0/src/macos.rs`: `enable()` writes a plist carrying
-//!    `Label` + `ProgramArguments` + `RunAtLoad` and nothing else. There is no
-//!    hook for `StartCalendarInterval`, which is the only thing that brings the
-//!    tray back after the user quits it.
+//! 1. **It cannot coordinate with `SMAppService`.** Verified against
+//!    `auto-launch-0.5.0/src/macos.rs`: `enable()` always writes `RunAtLoad
+//!    true` with no way to turn it off, so on macOS 13+ it would double-launch
+//!    a tray alongside SMAppService's own login item — two processes writing
+//!    one SQLite file.
 //! 2. **It named the plist after `productName`** — `~/Library/LaunchAgents/Meridian.plist`,
 //!    not `com.meridiona.*`. `src/uninstall.rs` asserted in a comment that the
 //!    macOS login item was swept up by its `com.meridiona.*.plist` glob. It was
@@ -41,45 +53,35 @@
 //!
 //! # What gets registered
 //!
-//! - **macOS 13+** — `SMAppService.mainApp` owns LOGIN (see [`login_item`]),
-//!   which is what produces a named, user-togglable "Meridian" entry in System
-//!   Settings → General → Login Items & Extensions. The plist
-//!   `~/Library/LaunchAgents/com.meridiona.tray.plist` is reduced to the WAKE
-//!   relaunch alone: `RunAtLoad` **false** + `LaunchEvents` →
-//!   `com.apple.notifyd.matching` on [`macos::WAKE_NOTIFICATIONS`] (unlock,
-//!   desktop-up, display/power state, clamshell), bootstrapped immediately so
-//!   the trigger is live from the moment of install rather than the next login.
-//!   Below 13 there is no SMAppService, so that plist carries both jobs with
-//!   `RunAtLoad` true. Deliberately **no `KeepAlive`** either way: the user
-//!   asked for Quit to stick, and `KeepAlive` would make quitting impossible.
-//! - **Windows** — one scheduled task with a `LogonTrigger` *and* two
-//!   `SessionStateChangeTrigger`s (`SessionUnlock`, `ConsoleConnect`),
-//!   registered from XML because `schtasks`' command form cannot express
-//!   several triggers. Its `MultipleInstancesPolicy` is `IgnoreNew`, which is
-//!   what stops a wake trigger starting a second tray on top of the one the
-//!   logon trigger already started.
+//! - **macOS 13+** — `SMAppService.mainApp` owns LOGIN, and login alone (see
+//!   [`login_item`]), which is what produces a named, user-togglable
+//!   "Meridian" entry in System Settings → General → Login Items &
+//!   Extensions. This module writes NO plist at all in this case — there is
+//!   nothing left for one to do — and clears any left by an older build (see
+//!   [`macos::ensure_registered`]).
+//! - **Below macOS 13** — there is no SMAppService, so
+//!   `~/Library/LaunchAgents/com.meridiona.tray.plist` carries the login
+//!   trigger itself, with `RunAtLoad` true. Deliberately **no `KeepAlive`**
+//!   either way: the user asked for Quit to stick, and `KeepAlive` would make
+//!   quitting impossible.
+//! - **Windows** — one scheduled task with a `LogonTrigger`, registered from
+//!   XML rather than `schtasks`' command form so it can also carry the
+//!   battery-defaults and execution-time overrides (see the `windows` module
+//!   docs). Its `MultipleInstancesPolicy` is `IgnoreNew`, a defensive dedupe
+//!   against a logon race rather than a second trigger to reconcile.
 //!
 //! There is **no clock in this module** — see the note beside
-//! [`launched_by_autostart`] on why the hardcoded hour was deleted rather than
-//! lowered.
+//! [`launched_by_autostart`] for the removed hardcoded hour, and the `windows`
+//! /  [`macos::plist_body`] docs for the later removal of the wake/unlock
+//! triggers that replaced it.
 //!
-//! # Duplicates are prevented by a guard, not by hoping
-//! The new-day trigger is started by the OS scheduler, and **neither scheduler can
-//! see that the app is already running.** launchd tracks liveness per job
-//! LABEL, so the process macOS's loginwindow started via SMAppService is
-//! invisible to our calendar job; Task Scheduler's `MultipleInstancesPolicy:
-//! IgnoreNew` only dedupes the task's own instances. So the trigger fires daily
-//! into a running app.
-//!
-//! `tauri-plugin-single-instance` is therefore load-bearing, not a nicety: it is
-//! registered FIRST in [`crate::run`]'s builder so the doomed second process
+//! # Duplicates are still guarded against
+//! `tauri-plugin-single-instance` is load-bearing, not a nicety: it is
+//! registered FIRST in [`crate::run`]'s builder so a doomed second process
+//! (a logon race, a stray manual launch while the tray is already running)
 //! exits before it can create a tray icon or a capture writer. Two processes
 //! writing one `meridian.db` is the double-writer condition behind the
 //! `database disk image is malformed` incidents in [`crate::backend_install`].
-//!
-//! An earlier version of this module claimed `RunAtLoad false` alone prevented
-//! the duplicate. It does not — it only prevents one at LOGIN, and moved the
-//! collision to the new-day trigger.
 //!
 //! # Who calls this
 //! [`crate::run`]'s `setup()` hook, once per launch, bundled runs only (see
@@ -141,8 +143,8 @@ use std::sync::atomic::{AtomicU8, Ordering};
 /// continuations and should behave like one.
 pub(crate) const AUTOSTART_FLAG: &str = "--autostart";
 
-/// True when this process was started by the login/morning job rather than by
-/// the user. Consulted before anything that puts a window on screen: an
+/// True when this process was started by the login job rather than by the
+/// user. Consulted before anything that puts a window on screen: an
 /// unattended launch must stay in the menu bar and nothing else.
 pub(crate) fn launched_by_autostart() -> bool {
     args_indicate_autostart(std::env::args())
@@ -204,8 +206,11 @@ pub(crate) enum RegistrationAction {
     /// Registered, but pointing at a different executable than the one running
     /// — the app was moved after being registered.
     RepairedPathDrift,
-    /// Registered, but with no morning trigger. This is the upgrade path for
-    /// every install that was registered by `tauri-plugin-autostart`.
+    /// Registered, but missing an expected element of the definition (e.g.
+    /// Windows' `LogonTrigger`). The Windows variant name is a PostHog wire
+    /// contract ([`RegistrationAction::as_str`]) predating the removal of the
+    /// wake-relaunch trigger this originally detected — kept rather than
+    /// renamed so saved fleet queries do not silently break.
     RepairedMissingMorningTrigger,
     /// Registered at the right path, but the definition is not what this build
     /// renders — a field changed that no substring probe would have noticed.
@@ -326,43 +331,35 @@ pub(crate) fn last_action() -> Option<RegistrationAction> {
     RegistrationAction::from_code(LAST_ACTION.load(Ordering::Relaxed))
 }
 
-/// Decide what to do, given only the facts — no filesystem, no launchctl.
+/// Whether registration should be skipped outright, before either platform
+/// gets to its own job-definition check — shared because both skip conditions
+/// are platform-independent facts (a setting, and where the binary is
+/// running from), not anything about the job definition itself.
 ///
-/// `registered` is the current job definition as text (plist XML on macOS, task
-/// XML on Windows) or `None` when nothing is registered. `expected_exe` is the
-/// running executable's path and `morning_trigger_marker` the element name that
-/// proves the definition carries a morning trigger (`StartCalendarInterval` /
-/// `CalendarTrigger`).
+/// Returns `None` when neither applies, meaning the caller should proceed to
+/// its own platform-specific repair check ([`macos::ensure_registered`]'s
+/// exact-body compare, `windows`'s own private `decide_task`).
 ///
-/// Text `contains` rather than a parsed comparison is deliberate. This decides
-/// only whether to REWRITE, and the rewrite is unconditional and idempotent, so
-/// the cost of a false "needs repair" is one file write; a parser would add a
-/// dependency and a new failure mode to answer the same question. Both needles
-/// are specific enough not to collide: an absolute executable path, and an XML
-/// element name that appears nowhere else in either format.
-pub(crate) fn decide(
-    disabled_by_user: bool,
-    stable_path: bool,
-    registered: Option<&str>,
-    expected_exe: &str,
-    morning_trigger_marker: &str,
-) -> RegistrationAction {
+/// # History
+/// This used to be one shared `decide()` that also matched an "expected
+/// executable path" and a "morning trigger marker" substring against the
+/// registered job text, and both platforms called it for their full repair
+/// decision. Windows still needs a marker-based check (Task Scheduler
+/// reformats the XML it hands back, so an exact-body compare there would
+/// report drift on every launch) but no longer expresses it through a shared
+/// helper: a stale task can contain BOTH the expected `LogonTrigger` marker
+/// AND a retired `SessionStateChangeTrigger` that needs stripping, which a
+/// presence-only check cannot see. macOS dropped the marker entirely in
+/// favour of comparing the whole rendered body. So the only still-shared
+/// decision is the skip check below.
+pub(crate) fn decide_skip(disabled_by_user: bool, stable_path: bool) -> Option<RegistrationAction> {
     if disabled_by_user {
-        return RegistrationAction::SkippedDisabledByUser;
+        return Some(RegistrationAction::SkippedDisabledByUser);
     }
     if !stable_path {
-        return RegistrationAction::SkippedTransientPath;
+        return Some(RegistrationAction::SkippedTransientPath);
     }
-    let Some(text) = registered else {
-        return RegistrationAction::RegisteredMissing;
-    };
-    if !text.contains(expected_exe) {
-        return RegistrationAction::RepairedPathDrift;
-    }
-    if !text.contains(morning_trigger_marker) {
-        return RegistrationAction::RepairedMissingMorningTrigger;
-    }
-    RegistrationAction::AlreadyCorrect
+    None
 }
 
 /// True when the user has explicitly turned autostart off.
@@ -391,9 +388,9 @@ async fn clear_legacy_marker() {
     }
 }
 
-/// Verify the tray's login + morning registration and repair it if it has
-/// drifted. Safe to call on every launch; idempotent when everything is
-/// already correct.
+/// Verify the tray's login registration and repair it if it has drifted.
+/// Safe to call on every launch; idempotent when everything is already
+/// correct.
 ///
 /// Never fails: autostart is important but it is not worth crashing the tray
 /// for, so every error path logs and leaves the next launch to retry.
@@ -424,8 +421,8 @@ pub async fn ensure_registered() {
         // is how an install that silently never registers looked identical, in
         // the fleet and in `meridian logs`, to one that was working perfectly.
         // The requirement this module exists to satisfy is "the tray comes back
-        // after a restart, and again the next morning, until uninstalled"; an
-        // install sitting on either of these branches satisfies none of it, and
+        // at login and after a restart, until uninstalled"; an install sitting
+        // on either of these branches satisfies none of it, and
         // that has to be visible without asking the user to run anything.
         //
         // Volume is bounded: a transient path resolves as soon as the app is in
@@ -519,11 +516,14 @@ pub(crate) struct Status {
     /// `enabled`, `requires_approval`, `not_registered`, `not_found`, or
     /// `unavailable` below macOS 13. `None` off macOS.
     ///
-    /// Distinct from [`Self::registered`], which describes the morning-relaunch
-    /// plist. The two are separate mechanisms and can disagree, and the whole
-    /// reason this field exists is that "is Meridian actually in Login Items &
-    /// Extensions" was unanswerable from the fleet — which is exactly the
-    /// question a user asking "why doesn't it start" is really asking.
+    /// Distinct from [`Self::registered`], which on macOS 13+ describes a
+    /// LaunchAgent this module deliberately no longer writes (SMAppService
+    /// owns login there — see [`macos::ensure_registered`]) and below 13
+    /// describes the fallback LaunchAgent that DOES carry login. The two are
+    /// separate mechanisms and can disagree, and the whole reason this field
+    /// exists is that "is Meridian actually in Login Items & Extensions" was
+    /// unanswerable from the fleet — which is exactly the question a user
+    /// asking "why doesn't it start" is really asking.
     pub(crate) login_item: Option<&'static str>,
 }
 
@@ -650,26 +650,22 @@ mod tests {
         }
     }
 
-    const MARKER: &str = "StartCalendarInterval";
-    const EXE: &str = "/Applications/Meridian.app/Contents/MacOS/Meridian";
-
-    fn plist_with(exe: &str, morning: bool) -> String {
-        let trigger = if morning { MARKER } else { "" };
-        format!("<array><string>{exe}</string></array>{trigger}")
-    }
-
-    /// A deliberate opt-out outranks everything, including a missing
-    /// registration - otherwise "turn autostart off" would be undone by the
-    /// very next launch's repair pass, which is the failure mode that made the
-    /// old marker-based gate feel necessary in the first place.
+    /// A deliberate opt-out outranks everything - otherwise "turn autostart
+    /// off" would be undone by the very next launch's repair pass, which is
+    /// the failure mode that made the old marker-based gate feel necessary in
+    /// the first place.
     #[test]
-    fn user_opt_out_wins_over_every_repair() {
-        for registered in [None, Some(""), Some(plist_with(EXE, true).as_str())] {
-            assert_eq!(
-                decide(true, true, registered, EXE, MARKER),
-                RegistrationAction::SkippedDisabledByUser
-            );
-        }
+    fn user_opt_out_wins_the_skip_check() {
+        assert_eq!(
+            decide_skip(true, true),
+            Some(RegistrationAction::SkippedDisabledByUser)
+        );
+        // And it wins even when the path is ALSO unstable - either fact alone
+        // is enough to skip, so the check must not require both.
+        assert_eq!(
+            decide_skip(true, false),
+            Some(RegistrationAction::SkippedDisabledByUser)
+        );
     }
 
     /// A DMG-mounted or translocated launch must not be pinned: the path is
@@ -677,51 +673,17 @@ mod tests {
     #[test]
     fn transient_path_defers_without_writing() {
         assert_eq!(
-            decide(false, false, None, EXE, MARKER),
-            RegistrationAction::SkippedTransientPath
+            decide_skip(false, false),
+            Some(RegistrationAction::SkippedTransientPath)
         );
     }
 
+    /// Neither skip condition applies - the caller must proceed to its own
+    /// platform-specific check rather than treating `None` as any particular
+    /// registration state.
     #[test]
-    fn absent_registration_is_registered_fresh() {
-        assert_eq!(
-            decide(false, true, None, EXE, MARKER),
-            RegistrationAction::RegisteredMissing
-        );
-    }
-
-    /// The defect that made a moved app permanently unable to autostart: the
-    /// old code wrote a marker, never compared paths, and never looked again.
-    #[test]
-    fn a_moved_app_is_detected_and_repointed() {
-        let stale = plist_with(
-            "/Users/x/Downloads/Meridian.app/Contents/MacOS/Meridian",
-            true,
-        );
-        assert_eq!(
-            decide(false, true, Some(&stale), EXE, MARKER),
-            RegistrationAction::RepairedPathDrift
-        );
-    }
-
-    /// The upgrade path for every install registered by
-    /// `tauri-plugin-autostart`: right path, no morning trigger.
-    #[test]
-    fn a_plugin_era_registration_gains_the_morning_trigger() {
-        let old = plist_with(EXE, false);
-        assert_eq!(
-            decide(false, true, Some(&old), EXE, MARKER),
-            RegistrationAction::RepairedMissingMorningTrigger
-        );
-    }
-
-    #[test]
-    fn a_correct_registration_is_left_alone() {
-        let good = plist_with(EXE, true);
-        assert_eq!(
-            decide(false, true, Some(&good), EXE, MARKER),
-            RegistrationAction::AlreadyCorrect
-        );
+    fn neither_skip_condition_defers_to_the_caller() {
+        assert_eq!(decide_skip(false, true), None);
     }
 
     /// Only the variants that mean "autostart was broken until this launch"
@@ -797,6 +759,8 @@ mod tests {
     /// cannot distinguish it from "broken" once it does.
     #[test]
     fn status_never_reports_unknown_as_broken() {
+        const EXE: &str = "/Applications/Meridian.app/Contents/MacOS/Meridian";
+
         let unknown_exe = status_from(Some("<plist/>"), None);
         assert_eq!(unknown_exe.registered, Some(true));
         assert_eq!(unknown_exe.path_ok, None);
@@ -805,7 +769,10 @@ mod tests {
         assert_eq!(absent.registered, Some(false));
         assert_eq!(absent.path_ok, None);
 
-        let ok = status_from(Some(&plist_with(EXE, true)), Some(EXE));
+        let ok = status_from(
+            Some(&format!("<array><string>{EXE}</string></array>")),
+            Some(EXE),
+        );
         assert_eq!(ok.registered, Some(true));
         assert_eq!(ok.path_ok, Some(true));
     }

--- a/tray/src-tauri/src/autostart/macos.rs
+++ b/tray/src-tauri/src/autostart/macos.rs
@@ -1,6 +1,10 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
-//! macOS side of [`crate::autostart`] — a per-user launchd LaunchAgent carrying
-//! both the login trigger and the morning relaunch.
+//! macOS side of [`crate::autostart`] — a per-user launchd LaunchAgent that
+//! covers the LOGIN trigger below macOS 13, where `SMAppService`
+//! ([`super::login_item`]) does not exist. On macOS 13+ this module writes
+//! nothing at all: SMAppService owns login by itself, and there is no
+//! separate wake/morning relaunch any more (see [`plist_body`]'s docs for why
+//! that was removed — it is what made Quit not stick).
 //!
 //! # Who calls this
 //! [`crate::autostart::ensure_registered`] (write path) and
@@ -52,35 +56,6 @@ const LEGACY_PLIST_FILE: &str = "Meridian.plist";
 // because Task Scheduler reformats the XML it hands back, so an exact compare
 // there would report drift on every launch.
 
-/// Darwin notifications that mean "the device just became usable again".
-///
-/// See [`plist_body`] for why this is a SET rather than one name, and for where
-/// each came from. Order is irrelevant; launchd keys the dict by name.
-pub(crate) const WAKE_NOTIFICATIONS: [&str; 7] = [
-    // Unlock. macOS requires a password after sleep by default, so this is the
-    // common path for "opened the laptop". Apple triggers its own
-    // com.apple.contextstored on this exact name.
-    "com.apple.sessionagent.screenIsUnlocked",
-    // Desktop up after login / fast user switch.
-    "com.apple.system.loginwindow.desktopUp",
-    // The display coming back on - the closest thing to "the screen is usable
-    // again" for a machine woken without a password prompt.
-    "com.apple.iokit.hid.displayStatus",
-    // System power state change (sleep/wake). BOTH spellings are listed on
-    // purpose: Apple's own plists use the `com.apple.powermanagement.*` form
-    // while the community-collected list uses `com.apple.system.powermanagement.*`.
-    // One of them is wrong on any given release and neither costs anything -
-    // see `plist_body` for why an unknown name is inert.
-    "com.apple.system.powermanagement.systempowerstate",
-    "com.apple.powermanagement.systempowerstate",
-    // A power event the user actually sees, i.e. a real wake rather than a dark
-    // wake for maintenance.
-    "com.apple.system.powermanagement.uservisiblepowerevent",
-    // The laptop lid - literally "device opened". Fires on close too, which is a
-    // harmless no-op thanks to the single-instance guard.
-    "com.apple.system.powermanagement.clamshellstate",
-];
-
 /// `~/Library/LaunchAgents`, where per-user agents live. `None` when the home
 /// directory cannot be resolved, in which case there is nothing this module can
 /// do.
@@ -102,53 +77,31 @@ fn current_exe() -> Option<PathBuf> {
 /// Pure and separate from the write so every field below is unit-testable
 /// without touching `~/Library/LaunchAgents` on a developer machine.
 ///
-/// # There is no clock in here, deliberately
-/// The requirement is "Meridian is running after the device is turned on or
-/// woken" — an EVENT, not a time. This used to be a `StartCalendarInterval` at a
-/// hardcoded hour, which is the wrong shape for that: it fires when the user
-/// isn't there, and misses them when they are.
+/// # Login only — there is no wake/morning relaunch any more
+/// An earlier version of this plist also carried `LaunchEvents` on a set of
+/// Darwin notifications (unlock, display-on, power-state, clamshell), so
+/// Meridian came back on the OS's own wake events rather than a clock. That
+/// was a deliberate choice (see the removed `WAKE_NOTIFICATIONS`, still in
+/// git history) and it was wrong: those notifications fire many times in a
+/// single day — every screen lock/unlock, every display sleep/wake, every lid
+/// open/close — not once "in the morning". The practical effect was that Quit
+/// did not stick: a user closed Meridian and it was back within minutes, the
+/// next time their screen so much as locked and unlocked, which reads as "I
+/// cannot quit this app".
 ///
-/// launchd has no `wake` or `unlock` trigger among its start keys (`RunAtLoad`,
-/// `StartInterval`, `StartCalendarInterval`, `WatchPaths`, `QueueDirectories`,
-/// `StartOnMount`, `KeepAlive`, `MachServices`, `Sockets`) — but `LaunchEvents`
-/// with the `com.apple.notifyd.matching` stream starts a job on an arbitrary
-/// Darwin notification, which is how Apple's own agents do this. The shape here
-/// is copied from `/System/Library/LaunchDaemons/com.apple.contextstored.plist`,
-/// which triggers on the same unlock notification, and the mechanism was
-/// verified end-to-end on macOS 26: a probe agent did not run on bootstrap and
-/// ran the instant its notification was posted.
-///
-/// # Why SEVERAL notifications rather than the one right one
-/// These names are private, so Apple documents none of them and no single one
-/// can be relied on across releases. That would normally be a reason for
-/// caution; here it is free, for two reasons:
-///
-/// - A notification launchd never receives is simply **inert** — an unknown name
-///   costs nothing and fails silently in the safe direction.
-/// - A notification that fires while the tray is ALREADY running costs a process
-///   that exits in milliseconds, because `tauri-plugin-single-instance` is
-///   registered first (see [`crate::run`]).
-///
-/// So the set is chosen for coverage, not minimality, and no single guess has to
-/// be correct:
-///
-/// See [`WAKE_NOTIFICATIONS`] for the list and what each one covers. Both
-/// spellings of the power-state notification are included because Apple's plists
-/// and the community-collected list disagree, and being wrong about one is free.
-///
-/// **Measured, not assumed** (macOS 26): a plist carrying a deliberately bogus
-/// notification name alongside real ones still bootstrapped cleanly, and the
-/// real notification still started the job. So an unknown or renamed name
-/// degrades to "never fires" rather than breaking the whole registration.
-///
-/// Login itself is NOT here: on macOS 13+ it belongs to `SMAppService`
-/// ([`super::login_item`]), which is what produces a named, user-togglable
-/// "Meridian" entry in Login Items & Extensions.
+/// The requirement is narrower than "always running": Meridian must come back
+/// at **login, restart, or a manual start** — never resurrect itself after a
+/// deliberate Quit before then. On macOS 13+ that is exactly what
+/// `SMAppService` ([`super::login_item`]) already provides, so this plist is
+/// only written at all below macOS 13, where SMAppService does not exist and
+/// nothing else expresses "start Meridian at login". See
+/// [`ensure_registered`] for how the two are coordinated, and
+/// [`disarm_relaunch`] for clearing an already-armed wake job left by an
+/// older build.
 ///
 /// # The rest
-/// - `run_at_load` is the coordination with SMAppService. FALSE when SMAppService
-///   owns login, or both would start a tray at login. Below macOS 13 there is no
-///   SMAppService, so it is true and this plist carries login too.
+/// - `run_at_load` is true whenever this plist is written (only reached below
+///   macOS 13, where it is the sole login mechanism).
 /// - **No `KeepAlive`**, deliberately: with it Quit would be undone within
 ///   seconds and there would be no way to stop Meridian at all. The daemon's
 ///   plist makes the opposite choice because it is headless and has no Quit.
@@ -163,16 +116,6 @@ pub(crate) fn plist_body(exe: &Path, home: &Path, run_at_load: bool) -> String {
     let home = super::xml_escape(&home.to_string_lossy());
     let flag = super::AUTOSTART_FLAG;
     let run_at_load = if run_at_load { "<true/>" } else { "<false/>" };
-    // Rendered from the table rather than hand-written, so adding a trigger is
-    // one entry and the plist cannot drift from the list.
-    let events: String = WAKE_NOTIFICATIONS
-        .iter()
-        .map(|n| {
-            format!(
-                "            <key>{n}</key>\n                             <dict>\n                <key>Notification</key>\n                                 <string>{n}</string>\n            </dict>\n"
-            )
-        })
-        .collect();
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -189,13 +132,6 @@ pub(crate) fn plist_body(exe: &Path, home: &Path, run_at_load: bool) -> String {
 
     <key>RunAtLoad</key>
     {run_at_load}
-
-    <key>LaunchEvents</key>
-    <dict>
-        <key>com.apple.notifyd.matching</key>
-        <dict>
-{events}        </dict>
-    </dict>
 
     <key>StandardOutPath</key>
     <string>{home}/.meridian/logs/tray.log</string>
@@ -248,19 +184,9 @@ pub(crate) async fn ensure_registered() -> RegistrationAction {
     // Skip decisions first, and they apply to BOTH mechanisms: a user who
     // turned autostart off must not get a login item either, and a transient
     // (DMG / translocated) path must not be pinned by anything.
-    let skip = super::decide(
+    if let Some(skip) = super::decide_skip(
         super::disabled_by_user(),
         crate::sys::running_from_stable_location(),
-        // `Some("")` rather than `None`: this call is only being asked about the
-        // two skip conditions, and a `None` here would answer
-        // `RegisteredMissing` before they were consulted.
-        Some(""),
-        "",
-        "",
-    );
-    if matches!(
-        skip,
-        RegistrationAction::SkippedDisabledByUser | RegistrationAction::SkippedTransientPath
     ) {
         // Disabled-by-user: dropping the legacy job IS honouring the "no".
         // Transient path: nothing replaced it, so it stays.
@@ -280,22 +206,53 @@ pub(crate) async fn ensure_registered() -> RegistrationAction {
         login_item::RegisterOutcome::Unavailable | login_item::RegisterOutcome::Failed
     );
 
-    // The MORNING half. `run_at_load` is the inverse of who owns login: if
-    // SMAppService took it, this plist must NOT also start a tray at login, or
-    // both fire and two processes write one SQLite file.
-    let run_at_load_owned_by_plist = !owns_login;
-    let expected = plist_body(&exe, &home, run_at_load_owned_by_plist);
+    if owns_login {
+        // SMAppService alone covers login on macOS 13+, and there is no wake
+        // relaunch to express any more (see `plist_body`'s docs — quitting
+        // must stick until the next login, restart, or manual start). This
+        // plist would therefore have nothing left to do, so it is not written
+        // at all here: remove any copy left by an older build, both the file
+        // (so a future login has nothing to load) and any definition already
+        // loaded into launchd's runtime state (`disarm_relaunch` — a deleted
+        // file alone does NOT stop an already-armed `LaunchEvents` trigger
+        // from firing again before the next logout).
+        let had_stale_file = read_registration().await.is_some();
+        let dest = dir.join(PLIST_FILE);
+        if had_stale_file {
+            if let Err(e) = tokio::fs::remove_file(&dest).await {
+                tracing::warn!(error = %e, plist = %dest.display(), "autostart: could not remove the stale relaunch plist");
+            }
+        }
+        disarm_relaunch().await;
+        // SMAppService already owns login, so the plugin-era job is safe to
+        // drop unconditionally here — nothing further needs to "take over"
+        // first.
+        migrate_off_plugin().await;
+
+        let action = if had_stale_file {
+            RegistrationAction::RepairedStaleDefinition
+        } else {
+            RegistrationAction::AlreadyCorrect
+        };
+        tracing::debug!(
+            login_item = login.as_str(),
+            action = action.as_str(),
+            "autostart: SMAppService owns login - no separate relaunch job needed"
+        );
+        return action;
+    }
+
+    // Below macOS 13: SMAppService is unavailable, so this plist is the only
+    // login mechanism there is, with `RunAtLoad` true.
+    let expected = plist_body(&exe, &home, true);
     let existing = read_registration().await;
 
     // Exact-body comparison, not a substring probe.
     //
-    // The substring version (path present? morning trigger present?) cannot see
-    // a change to a field it does not name — and `RunAtLoad` is exactly such a
-    // field. An install carrying the previous build's `RunAtLoad true` plist
-    // would have passed every substring check while double-launching alongside
-    // the new login item. Comparing the whole rendered body makes every future
-    // field change self-healing for free, and the cost of a false "differs" is
-    // one idempotent file write.
+    // The substring version (path present? marker present?) cannot see a
+    // change to a field it does not name. Comparing the whole rendered body
+    // makes every future field change self-healing for free, and the cost of
+    // a false "differs" is one idempotent file write.
     let action = match existing.as_deref() {
         None => RegistrationAction::RegisteredMissing,
         Some(cur) if cur == expected => RegistrationAction::AlreadyCorrect,
@@ -311,7 +268,7 @@ pub(crate) async fn ensure_registered() -> RegistrationAction {
     if action == RegistrationAction::AlreadyCorrect {
         tracing::debug!(
             login_item = login.as_str(),
-            "autostart: login item and morning trigger both already correct"
+            "autostart: login LaunchAgent already correct"
         );
         // Something correct is already registered, so the legacy job is now
         // redundant AND would double-launch alongside it.
@@ -347,52 +304,51 @@ pub(crate) async fn ensure_registered() -> RegistrationAction {
         migrate_off_plugin().await;
     }
 
-    // NOW bootstrap it, which is safe for the first time.
-    //
-    // This used to be skipped, on the grounds that `bootstrap` honours
-    // `RunAtLoad` and would start a second tray. Two things changed and both
-    // matter:
-    //
-    // 1. On macOS 13+ this plist carries `RunAtLoad false` (SMAppService owns
-    //    login), so bootstrapping loads the calendar trigger WITHOUT launching
-    //    anything at all.
-    // 2. `tauri-plugin-single-instance` now guarantees that even if something
-    //    did launch a second process, it exits before touching the tray or the
-    //    database.
-    //
-    // The gain is not cosmetic: without bootstrapping, launchd only picks the
-    // job up at the next login, so a user who installed and then quit the same
-    // day would NOT come back on the new-day trigger. Bootstrapping closes that gap, so the
-    // morning relaunch works from the moment of install.
-    //
-    // Best-effort: `bootout` first so a re-registration replaces cleanly, and a
-    // failure here only costs the current session (the next login loads it from
-    // disk regardless).
-    let target = format!("gui/{}/{LABEL}", crate::sys::uid_str());
-    if run_at_load_owned_by_plist {
-        // Below macOS 13 this plist DOES carry `RunAtLoad true`, so bootstrapping
-        // it here would start a second tray. The single-instance guard would kill
-        // that duplicate, but relying on a guard to undo a launch we chose to
-        // make is worse than not making it: skip, and let the next login load it.
-        tracing::debug!("autostart: not bootstrapping a RunAtLoad plist from inside the app");
-    } else {
-        let _ = crate::backend_install::launchctl(&["bootout", &target]).await;
-        let _ = crate::backend_install::launchctl(&[
-            "bootstrap",
-            &format!("gui/{}", crate::sys::uid_str()),
-            &dest.to_string_lossy(),
-        ])
-        .await;
-    }
-
+    // Deliberately NOT bootstrapped from here: this plist carries
+    // `RunAtLoad true` (it is the sole login mechanism below macOS 13), so
+    // bootstrapping it now would start a second tray immediately. The
+    // single-instance guard would kill that duplicate, but relying on a guard
+    // to undo a launch we chose to make is worse than not making it — skip,
+    // and let the next login load it.
     tracing::info!(
         plist = %dest.display(),
         action = action.as_str(),
         login_item = login.as_str(),
-        run_at_load = run_at_load_owned_by_plist,
-        "autostart: morning-relaunch LaunchAgent written"
+        "autostart: login LaunchAgent written (below macOS 13 fallback)"
     );
     action
+}
+
+/// Clear any relaunch job already loaded into launchd's runtime state.
+///
+/// Deleting [`PLIST_FILE`] on disk is not enough by itself: once a job with
+/// `LaunchEvents` has been bootstrapped, its triggers stay armed in launchd's
+/// in-memory state until an explicit `bootout` (or logout), regardless of
+/// whether the file that defined them still exists. A machine that had an
+/// older build's
+/// wake-relaunch job loaded before upgrading would otherwise keep coming back
+/// on the next unlock or display wake for the rest of that login session,
+/// even though the new build never re-registers it — which is the exact "I
+/// cannot quit this app" symptom this change exists to fix.
+///
+/// Best-effort and unawaited for confirmation, unlike
+/// [`crate::backend_install::bootout_agent_and_wait`]: this runs on every
+/// launch's startup path and must not add latency waiting for launchd to
+/// confirm the label cleared, since the job is either already gone (the
+/// common case, nothing to do) or about to be — bootout itself is
+/// synchronous with the daemon side effects that matter here.
+///
+/// Safe to call even if the running process happens to be that job's own
+/// child (which can only happen right after upgrading past this change,
+/// mid-relaunch): the process is either not that job's instance at all
+/// (the overwhelmingly common case — a user launch, an updater relaunch, or
+/// SMAppService's own login item, none of which go through this label), or
+/// it is, and `tauri-plugin-single-instance` combined with the app already
+/// starting up makes an unexpected exit here no worse than the exit the user
+/// was trying to cause anyway.
+pub(crate) async fn disarm_relaunch() {
+    let target = format!("gui/{}/{LABEL}", crate::sys::uid_str());
+    let _ = crate::backend_install::launchctl(&["bootout", &target]).await;
 }
 
 /// Delete the plugin-era `Meridian.plist`, so an upgraded install does not end
@@ -442,13 +398,12 @@ async fn migrate_off_plugin() {
 /// in Settings and the app they are looking at quits, because they are running
 /// as the job being booted out.
 ///
-/// The accepted cost is narrow. Our plist DOES carry a morning trigger, and it
-/// stays live until logout, so a user who turns autostart off AND quits later
-/// the same day could still be relaunched once by the new-day trigger. From the
-/// next login on
-/// there is no plist to load and the setting is fully honoured. Relaunching
-/// once beats quitting the app out from under someone who was changing a
-/// preference.
+/// Below macOS 13 this plist carries only `RunAtLoad`, which already fired at
+/// this session's login and never fires again — so deleting the file is
+/// enough to fully honour the setting from this point on, not just from the
+/// next login. (On 13+ this module never wrote a plist at all, so there is
+/// nothing here to remove; [`login_item::unregister`] above is the whole
+/// story.)
 pub(crate) async fn unregister() {
     // The login half first. Unlike `launchctl bootout` this does NOT terminate
     // the running app, so it is safe to call from the Settings toggle while the
@@ -504,10 +459,13 @@ mod tests {
         assert!(LABEL.starts_with("com.meridiona."));
     }
 
-    /// THE double-launch guard. On macOS 13+ SMAppService owns login, so this
-    /// plist must carry `RunAtLoad false` and nothing else may start a tray at
-    /// login. Both firing means two processes writing one SQLite file - the
-    /// double-writer condition behind `database disk image is malformed`.
+    /// `run_at_load` still varies as a property of this pure function, even
+    /// though [`ensure_registered`] only ever calls it with `true` now (the
+    /// `false`/SMAppService-owns-login case no longer writes a plist at all -
+    /// see its docs). Pinned here so a `false` plist can never silently start
+    /// a second tray alongside SMAppService's login item if that changes -
+    /// two processes writing one SQLite file is the double-writer condition
+    /// behind `database disk image is malformed`.
     #[test]
     fn run_at_load_is_false_when_smappservice_owns_login() {
         let with_login_item = body(false);
@@ -519,57 +477,35 @@ mod tests {
         assert!(fallback.contains("<key>RunAtLoad</key>\n    <true/>"));
     }
 
-    /// The wake triggers are this plist's reason to exist in BOTH modes -
-    /// SMAppService cannot express them at all, and there is no clock left.
+    /// **The regression test for "I cannot quit this app".** An earlier
+    /// version of this plist carried `LaunchEvents` on a set of Darwin
+    /// notifications (unlock, display wake, power state, clamshell) so
+    /// Meridian relaunched itself on those events rather than at a fixed
+    /// hour. Those notifications fire many times in an ordinary day - every
+    /// screen lock/unlock, every display sleep/wake - so a user who quit the
+    /// app watched it come back within minutes. The requirement is login,
+    /// restart, or a manual start, never an unattended resurrection before
+    /// then, so this plist must carry neither a clock NOR a wake trigger in
+    /// either mode - it is `RunAtLoad` and nothing else.
     #[test]
-    fn both_modes_carry_every_wake_notification_and_no_clock() {
+    fn plist_carries_no_wake_relaunch_trigger_and_no_clock() {
         for run_at_load in [true, false] {
             let b = body(run_at_load);
             assert!(
-                b.contains("<key>LaunchEvents</key>"),
-                "run_at_load={run_at_load}"
+                !b.contains("LaunchEvents") && !b.contains("notifyd.matching"),
+                "a wake-relaunch trigger came back (run_at_load={run_at_load}) - \
+                 quitting must stick until the next login, not the next unlock"
             );
-            assert!(
-                b.contains("com.apple.notifyd.matching"),
-                "run_at_load={run_at_load}"
-            );
-            for n in WAKE_NOTIFICATIONS {
-                assert!(b.contains(n), "missing {n} (run_at_load={run_at_load})");
-            }
-            assert!(b.contains(super::super::AUTOSTART_FLAG));
-            // The whole point of the rewrite: no hardcoded time survives.
             assert!(
                 !b.contains("StartCalendarInterval") && !b.contains("StartInterval"),
-                "a clock came back - the requirement is an event, not a time"
+                "a clock came back - the requirement is login/restart/start, not a time"
             );
+            assert!(b.contains(super::super::AUTOSTART_FLAG));
         }
-    }
-
-    /// Each notification must appear as its own `{{ Notification: <name> }}` dict
-    /// under `com.apple.notifyd.matching`, which is the shape Apple's own
-    /// `com.apple.contextstored.plist` uses. A flat array silently never fires.
-    #[test]
-    fn each_notification_is_rendered_in_apples_dict_shape() {
-        let b = body(false);
-        for n in WAKE_NOTIFICATIONS {
-            assert!(
-                b.contains(&format!("<key>{n}</key>")),
-                "{n} is not a key in the matching dict"
-            );
-            assert!(
-                b.contains(&format!("<string>{n}</string>")),
-                "{n} has no Notification value"
-            );
-        }
-        assert_eq!(
-            b.matches("<key>Notification</key>").count(),
-            WAKE_NOTIFICATIONS.len(),
-            "one Notification key per notification"
-        );
     }
 
     /// `KeepAlive` would make Quit impossible - the user explicitly wants
-    /// quitting to stick until the next morning, which is the entire reason
+    /// quitting to stick until the next login, which is the entire reason
     /// this plist differs from the daemon's.
     #[test]
     fn plist_must_not_carry_keepalive() {

--- a/tray/src-tauri/src/autostart/windows.rs
+++ b/tray/src-tauri/src/autostart/windows.rs
@@ -1,32 +1,37 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
 //! Windows side of [`crate::autostart`] — one per-user scheduled task carrying
-//! both a logon trigger and a daily trigger.
+//! a logon trigger, and only a logon trigger.
 //!
-//! # The triggers are EVENTS, not a clock
-//! The requirement is "Meridian is running after the device is turned on or
-//! woken". Windows expresses that natively: `SessionStateChangeTrigger` fires on
-//! `SessionUnlock` (the user unlocked the workstation) and `ConsoleConnect` (the
-//! user connected to the session), alongside `LogonTrigger` for sign-in. There
-//! is no hardcoded time anywhere.
+//! # Login/restart/start only — no unlock or reconnect relaunch
+//! An earlier version of this task ALSO carried a `SessionStateChangeTrigger`
+//! on `SessionUnlock` and `ConsoleConnect`, on the reasoning that "Meridian is
+//! running after the device is turned on or woken" should be expressed as
+//! native OS events rather than a fixed-hour `CalendarTrigger`. That reasoning
+//! was sound for the clock but wrong for the trigger choice: unlocking a
+//! session happens many times in an ordinary day, not once "in the morning",
+//! so a user who quit Meridian watched it come back the next time they
+//! unlocked their machine - sometimes within minutes. That reads as "I cannot
+//! quit this app", and it is: the requirement is login, restart, or a manual
+//! start, never an unattended resurrection before then. `LogonTrigger` alone
+//! already covers login and restart (a restart ends in a fresh logon), so the
+//! session-state triggers are gone and there is no replacement for the
+//! "resume after a bare unlock" behaviour - that is the point, not a gap.
 //!
-//! This replaced a daily `CalendarTrigger` at a fixed hour, which was the wrong
-//! shape for the requirement: it fired when the user was not there and missed
-//! them when they were. macOS gets the same treatment through launchd's
-//! `LaunchEvents` (see [`super::macos`]); the two platforms now use each OS's
-//! own event system rather than a clock.
+//! macOS mirrors this (see [`super::macos`]): its `LaunchEvents` wake
+//! notifications are gone too, for the identical reason.
 //!
-//! Firing on every unlock is safe because `tauri-plugin-single-instance` is
+//! Firing on every logon is safe because `tauri-plugin-single-instance` is
 //! registered first, so a launch into an already-running tray exits in
 //! milliseconds.
 //!
 //! # Why XML, not `schtasks /SC`
-//! The command form takes exactly one `/SC`, so a login task and a daily task
-//! would have to be two separate tasks — and two tasks are two independent
-//! instance policies, so the daily trigger would start a second tray on top of the
-//! one the logon task already started. Registering from XML allows one task
-//! with two triggers, and therefore one `MultipleInstancesPolicy` of
-//! `IgnoreNew`, which is what makes the morning trigger a no-op while the tray
-//! is already running. That is the same property launchd gives for free on
+//! Registering from XML rather than the `schtasks` command form is still worth
+//! it with a single trigger: it is the only way to set
+//! `DisallowStartIfOnBatteries`/`StopIfGoingOnBatteries` false (the command
+//! form's defaults would make Meridian desktop-only on a laptop), an
+//! unbounded `ExecutionTimeLimit`, and `MultipleInstancesPolicy` `IgnoreNew`
+//! (a defensive dedupe against a logon race, not a second trigger to
+//! reconcile any more). That is the same property launchd gives for free on
 //! macOS by treating a job as a singleton.
 //!
 //! # Three ways to register, in descending order of fidelity
@@ -34,15 +39,16 @@
 //! all (the same policy [`crate::backend_install`] already works around for the
 //! daemon), so this degrades rather than giving up:
 //!
-//! 1. `schtasks /Create /XML` — logon + unlock + console-connect, `IgnoreNew`.
-//! 2. `schtasks /Create /SC ONLOGON` — logon only. Loses the wake triggers, keeps
-//!    the restart case. The command form takes one `/SC` and cannot express a
-//!    session-state trigger at all.
+//! 1. `schtasks /Create /XML` — logon trigger, `IgnoreNew`, the battery and
+//!    execution-time overrides above.
+//! 2. `schtasks /Create /SC ONLOGON` — logon only, without those overrides
+//!    (notably the battery defaults, which is the loss that matters). The
+//!    command form takes one `/SC` and cannot express the rest of the XML.
 //! 3. A hidden VBScript in the Startup folder — logon only, no Task Scheduler
 //!    involvement at all.
 //!
-//! Each fallback is logged at WARN, so "how many Windows installs cannot wake
-//! Meridian on unlock" is answerable from the fleet rather than guessed at.
+//! Each fallback is logged at WARN, so "how many Windows installs are on a
+//! degraded registration" is answerable from the fleet rather than guessed at.
 //!
 //! # Who calls this
 //! [`crate::autostart::ensure_registered`] and [`crate::autostart::status`].
@@ -56,12 +62,19 @@ use std::path::{Path, PathBuf};
 /// with separate lifecycles, and `src/uninstall.rs` deletes them by name.
 pub(crate) const TASK_NAME: &str = "Meridian Tray";
 
-/// Element that proves the registered task carries the wake triggers. See
-/// [`super::decide`] for why this is a text check.
-///
-/// It is also the upgrade detector for installs registered by an earlier build,
-/// whose task carried a `CalendarTrigger` at a hardcoded hour instead.
-const MORNING_TRIGGER_MARKER: &str = "SessionStateChangeTrigger";
+/// Element that proves the registered task carries the logon trigger. Used by
+/// `decide_task`, which cannot use the shared substring [`super::decide_skip`]
+/// for this part: that helper only checks the two SKIP conditions, and this is
+/// a presence check on the job definition itself — one that also has to be
+/// paired with [`STALE_SESSION_TRIGGER_MARKER`], since a stale task carrying
+/// the retired triggers would still contain this string too.
+const LOGON_TRIGGER_MARKER: &str = "LogonTrigger";
+
+/// Element that proves a registered task still carries the retired
+/// unlock/reconnect relaunch triggers — see the module docs for why those were
+/// removed (they made Quit not stick). A task containing this needs rewriting
+/// even though it already contains [`LOGON_TRIGGER_MARKER`].
+const STALE_SESSION_TRIGGER_MARKER: &str = "SessionStateChangeTrigger";
 
 /// The `HKCU\...\Run` value `tauri-plugin-autostart` used to write, named after
 /// `productName`. Removed on first run so an upgraded install does not start
@@ -95,17 +108,23 @@ fn current_exe() -> Option<PathBuf> {
 /// and CI'd on, which makes the tests the only guard it has.
 ///
 /// The non-obvious settings, each of which has a specific failure it prevents:
-/// - `MultipleInstancesPolicy` `IgnoreNew` — the whole reason for using XML.
+/// - `MultipleInstancesPolicy` `IgnoreNew` — a defensive dedupe against a
+///   logon race (e.g. a fast user switch), not a second trigger to reconcile.
 /// - `DisallowStartIfOnBatteries` / `StopIfGoingOnBatteries` `false` — both
 ///   default to TRUE in Task Scheduler, which on a laptop means the tray never
 ///   starts on battery and is KILLED when the machine unplugs. That default
 ///   would silently make Meridian a desktop-only product.
-/// - `StartWhenAvailable` `true` — runs a missed new-day trigger once the machine
-///   is next awake, matching launchd's behaviour on macOS.
+/// - `StartWhenAvailable` `true` — runs a missed logon trigger once the
+///   machine is next awake (e.g. Task Scheduler was not yet up at sign-in),
+///   matching launchd's behaviour on macOS.
 /// - `ExecutionTimeLimit` `PT0S` — no limit. The default (72 hours) would
 ///   terminate a long-running tray.
 /// - `RunLevel` `LeastPrivilege` — never elevated. An elevated tray would write
 ///   files under `~/.meridian` that the un-elevated one could not then touch.
+///
+/// Deliberately just `LogonTrigger` — no `SessionStateChangeTrigger` on
+/// unlock/reconnect. See the module docs for why: those fire many times a day
+/// and made Quit not stick.
 pub(crate) fn task_xml(exe: &Path) -> String {
     let exe = super::xml_escape(&exe.to_string_lossy());
     let flag = super::xml_escape(super::AUTOSTART_FLAG);
@@ -113,20 +132,12 @@ pub(crate) fn task_xml(exe: &Path) -> String {
         r#"<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <RegistrationInfo>
-    <Description>Starts Meridian in the background at sign-in, and again whenever you unlock or reconnect to this session.</Description>
+    <Description>Starts Meridian in the background at sign-in.</Description>
   </RegistrationInfo>
   <Triggers>
     <LogonTrigger>
       <Enabled>true</Enabled>
     </LogonTrigger>
-    <SessionStateChangeTrigger>
-      <Enabled>true</Enabled>
-      <StateChange>SessionUnlock</StateChange>
-    </SessionStateChangeTrigger>
-    <SessionStateChangeTrigger>
-      <Enabled>true</Enabled>
-      <StateChange>ConsoleConnect</StateChange>
-    </SessionStateChangeTrigger>
   </Triggers>
   <Principals>
     <Principal id="Author">
@@ -234,6 +245,30 @@ fn is_disabled(xml: &str) -> bool {
     xml.contains("<Enabled>false</Enabled>")
 }
 
+/// Windows' own repair check, kept separate from the shared [`super::decide`]:
+/// that helper only checks a marker's PRESENCE, which cannot see a task that
+/// needs REWRITING rather than merely completing. A task carrying the retired
+/// [`STALE_SESSION_TRIGGER_MARKER`] unlock/reconnect triggers still contains
+/// [`LOGON_TRIGGER_MARKER`] too, so a presence-only probe would report it as
+/// already correct forever and never strip them — this checks for that
+/// explicitly, ahead of the presence check.
+///
+/// Pure and separate from the read, like `super::decide`, so both this and
+/// [`ensure_registered`]'s call to it are unit-testable without a Windows host.
+fn decide_task(existing: Option<&str>, expected_exe: &str) -> RegistrationAction {
+    match existing {
+        None => RegistrationAction::RegisteredMissing,
+        Some(text) if !text.contains(expected_exe) => RegistrationAction::RepairedPathDrift,
+        Some(text) if text.contains(STALE_SESSION_TRIGGER_MARKER) => {
+            RegistrationAction::RepairedStaleDefinition
+        }
+        Some(text) if !text.contains(LOGON_TRIGGER_MARKER) => {
+            RegistrationAction::RepairedMissingMorningTrigger
+        }
+        Some(_) => RegistrationAction::AlreadyCorrect,
+    }
+}
+
 /// Verify and, if needed, re-register the task. See
 /// [`crate::autostart::ensure_registered`] for the contract.
 pub(crate) async fn ensure_registered() -> RegistrationAction {
@@ -245,13 +280,19 @@ pub(crate) async fn ensure_registered() -> RegistrationAction {
     // A disabled task counts as absent — see `is_disabled` for why that is what
     // makes the Settings switch reversible rather than one-way.
     let existing = read_registration().await.filter(|xml| !is_disabled(xml));
-    let action = super::decide(
+
+    // Skip decisions first, via the same shared check macOS uses.
+    if let Some(skip) = super::decide_skip(
         super::disabled_by_user(),
         crate::sys::running_from_stable_location(),
-        existing.as_deref(),
-        &exe.to_string_lossy(),
-        MORNING_TRIGGER_MARKER,
-    );
+    ) {
+        if may_drop_legacy(skip, false) {
+            migrate_off_plugin().await;
+        }
+        return skip;
+    }
+
+    let action = decide_task(existing.as_deref(), &exe.to_string_lossy());
     // ORDER MATTERS HERE, and getting it wrong costs an upgraded user their
     // autostart entirely.
     //
@@ -288,14 +329,14 @@ pub(crate) async fn ensure_registered() -> RegistrationAction {
             tracing::info!(
                 task = TASK_NAME,
                 action = action.as_str(),
-                "autostart: scheduled task registered with logon and morning triggers"
+                "autostart: scheduled task registered with the logon trigger"
             );
             true
         }
         Err(e) => {
             tracing::warn!(
                 error = %e,
-                "autostart: XML task registration failed - falling back to a logon-only task (no morning relaunch)"
+                "autostart: XML task registration failed - falling back to a logon-only task without the battery/execution-time overrides"
             );
             fallback_register(&exe).await
         }
@@ -342,8 +383,10 @@ async fn register_from_xml(exe: &Path) -> Result<(), String> {
 }
 
 /// Logon-only registration, then the Startup folder if even that is refused.
-/// Both lose the morning relaunch; both keep the restart case, which is
-/// strictly better than nothing.
+/// Both still cover login/restart (the XML path's only trigger to begin
+/// with); what they lose is the battery-defaults and execution-time overrides
+/// only the XML form can express, which is strictly better than no autostart
+/// at all.
 ///
 /// Returns whether ANYTHING will now start the tray at logon. The caller needs
 /// that answer, not just a log line: it decides whether the plugin-era `Run`
@@ -363,7 +406,7 @@ async fn fallback_register(exe: &Path) -> bool {
         let _ = remove_startup_folder_launcher().await;
         tracing::warn!(
             task = TASK_NAME,
-            "autostart: registered a logon-only task - the morning relaunch is unavailable on this machine"
+            "autostart: registered a logon-only task without the XML battery/execution-time overrides"
         );
         return true;
     }
@@ -503,27 +546,33 @@ mod tests {
 
     const EXE: &str = r"C:\Users\tester\AppData\Local\Meridian\Meridian.exe";
 
-    /// Two triggers on ONE task is the entire reason this uses XML: two tasks
-    /// would have two instance policies, and the morning one would start a
-    /// second tray on top of the running one.
+    /// **The regression test for "I cannot quit this app".** An earlier
+    /// version of this task also carried `SessionStateChangeTrigger` on
+    /// `SessionUnlock`/`ConsoleConnect`, which fire many times in an ordinary
+    /// day - a user who quit Meridian watched it come back the next time they
+    /// merely unlocked their machine. The requirement is login/restart/start,
+    /// never an unattended resurrection before then, so the task must carry
+    /// the logon trigger and nothing else.
     #[test]
-    fn task_carries_logon_and_wake_triggers_on_one_task() {
+    fn task_carries_only_the_logon_trigger() {
         let x = task_xml(Path::new(EXE));
         assert!(x.contains("<LogonTrigger>"));
-        assert!(x.contains(MORNING_TRIGGER_MARKER));
         assert_eq!(x.matches("<Actions").count(), 1, "one action, one task");
-        // Both native wake triggers, and NO clock.
-        assert!(x.contains("<StateChange>SessionUnlock</StateChange>"));
-        assert!(x.contains("<StateChange>ConsoleConnect</StateChange>"));
+        assert!(
+            !x.contains("SessionStateChangeTrigger"),
+            "an unlock/reconnect relaunch trigger came back - quitting must \
+             stick until the next login, not the next unlock"
+        );
         assert!(
             !x.contains("CalendarTrigger"),
-            "a hardcoded daily trigger came back - the requirement is an event, not a time"
+            "a hardcoded daily trigger came back - the requirement is login/restart/start, not a time"
         );
     }
 
-    /// `IgnoreNew` is what makes the morning trigger a no-op while the tray is
-    /// already running. Without it this design produces duplicate trays writing
-    /// to one SQLite file.
+    /// `IgnoreNew` guards against a logon race (e.g. a fast user switch)
+    /// rather than reconciling two triggers now that there is only one.
+    /// Without it this design produces duplicate trays writing to one SQLite
+    /// file.
     #[test]
     fn task_ignores_a_trigger_while_already_running() {
         assert!(task_xml(Path::new(EXE))
@@ -569,8 +618,53 @@ mod tests {
     fn a_freshly_written_task_reads_back_as_already_correct() {
         let x = task_xml(Path::new(EXE));
         assert_eq!(
-            super::super::decide(false, true, Some(&x), EXE, MORNING_TRIGGER_MARKER),
+            decide_task(Some(&x), EXE),
             RegistrationAction::AlreadyCorrect
+        );
+    }
+
+    /// The bug a presence-only marker check would miss: a task carrying the
+    /// retired unlock/reconnect triggers still contains `LogonTrigger`, so it
+    /// must be caught by an explicit stale check rather than read as already
+    /// correct forever.
+    #[test]
+    fn a_task_still_carrying_the_retired_session_triggers_is_repaired() {
+        let stale = task_xml(Path::new(EXE)).replace(
+            "<Triggers>\n    <LogonTrigger>\n      <Enabled>true</Enabled>\n    </LogonTrigger>\n  </Triggers>",
+            "<Triggers>\n    <LogonTrigger>\n      <Enabled>true</Enabled>\n    </LogonTrigger>\n    \
+             <SessionStateChangeTrigger>\n      <Enabled>true</Enabled>\n      \
+             <StateChange>SessionUnlock</StateChange>\n    </SessionStateChangeTrigger>\n  </Triggers>",
+        );
+        assert!(
+            stale.contains("SessionStateChangeTrigger"),
+            "the replace must have matched - fixture drifted from task_xml's shape"
+        );
+        assert_eq!(
+            decide_task(Some(&stale), EXE),
+            RegistrationAction::RepairedStaleDefinition
+        );
+    }
+
+    /// A task missing the logon trigger entirely (a hypothetical future
+    /// format, or a hand-edited one) must still be caught.
+    #[test]
+    fn a_task_missing_the_logon_trigger_is_repaired() {
+        let no_logon_trigger = format!("<Task><Actions><Exec>{EXE}</Exec></Actions></Task>");
+        assert_eq!(
+            decide_task(Some(&no_logon_trigger), EXE),
+            RegistrationAction::RepairedMissingMorningTrigger
+        );
+    }
+
+    /// A moved app is detected and repointed, checked ahead of the
+    /// stale-trigger/marker checks so a moved-AND-stale task still gets
+    /// exactly one rewrite that fixes everything at once.
+    #[test]
+    fn a_moved_app_is_detected_and_repointed() {
+        let elsewhere = task_xml(Path::new(r"C:\Old\Meridian.exe"));
+        assert_eq!(
+            decide_task(Some(&elsewhere), EXE),
+            RegistrationAction::RepairedPathDrift
         );
     }
 
@@ -623,17 +717,12 @@ mod tests {
             "<Enabled>false</Enabled>\n    <Hidden>false</Hidden>",
         );
         assert!(is_disabled(&disabled), "the disabled marker must be found");
-        // What `ensure_registered` does with it: filter to None, so `decide`
-        // reports a fresh registration rather than `already_correct`.
+        // What `ensure_registered` does with it: filter to None, so
+        // `decide_task` reports a fresh registration rather than
+        // `already_correct`.
         let existing = Some(disabled).filter(|xml| !is_disabled(xml));
         assert_eq!(
-            super::super::decide(
-                false,
-                true,
-                existing.as_deref(),
-                EXE,
-                MORNING_TRIGGER_MARKER
-            ),
+            decide_task(existing.as_deref(), EXE),
             RegistrationAction::RegisteredMissing
         );
     }

--- a/ui/components/timeline/settings/CaptureSection.tsx
+++ b/ui/components/timeline/settings/CaptureSection.tsx
@@ -68,7 +68,7 @@ export function CaptureSection({ settings, patch, save }: {
           this key registers or removes that job immediately. */}
       <SectionCard>
         <SectionHeader>Startup</SectionHeader>
-        <FieldRow label="Start Meridian automatically" description="On by default: Meridian starts in your menu bar when you sign in, and comes back whenever you turn your machine on or wake it up. It opens quietly in the background - no window, nothing to dismiss. Meridian only records your work while it is running, so turning this off means days you forget to open it are not tracked.">
+        <FieldRow label="Start Meridian automatically" description="On by default: Meridian starts in your menu bar when you sign in or restart your machine. It opens quietly in the background - no window, nothing to dismiss. Quitting Meridian stops it until you sign in again, so it never starts back up on its own during the day. Meridian only records your work while it is running, so turning this off means days you forget to open it are not tracked.">
           <Switch checked={settings.autostart_enabled} onCheckedChange={v => patch({ autostart_enabled: v })} />
         </FieldRow>
         <SaveButton


### PR DESCRIPTION
## Summary
- The tray was relaunching itself on macOS `LaunchEvents` (screen unlock, display wake, power state, clamshell) and Windows `SessionStateChangeTrigger` (`SessionUnlock`, `ConsoleConnect`). Both fire many times in an ordinary day, so Quit only lasted until the next screen lock/unlock — reported as "I am not able to quit the staging app," and confirmed live: this machine's installed `com.meridiona.tray.plist` carried exactly those `LaunchEvents`, no `KeepAlive`.
- Open at Login now covers **login, restart, or a manual start only** — never an unattended resurrection before then:
  - **macOS 13+**: `SMAppService` alone owns login; the LaunchAgent that used to carry the wake relaunch is no longer written at all. Any copy left by an older build is removed on the next launch, and `disarm_relaunch` also clears the *live* launchd registration — deleting the plist file alone does not disarm an already-bootstrapped `LaunchEvents` trigger, so a machine that had the old job armed before upgrading would otherwise keep coming back for the rest of that login session.
  - **Below macOS 13**: the LaunchAgent keeps `RunAtLoad` as the sole login mechanism, with no wake trigger.
  - **Windows**: the scheduled task keeps only its `LogonTrigger`; the two `SessionStateChangeTrigger`s are gone. An old-format task still carrying them is detected and rewritten — a presence-only marker check couldn't see this, since the stale task still contains `LogonTrigger` too, so a small dedicated check (`decide_task`) replaces the shared substring `decide()` for Windows's repair decision.
- Updated the Settings copy that described the old "comes back whenever you wake it up" behavior, and the docs/tests throughout `autostart.rs`/`macos.rs`/`windows.rs` that argued for the design being removed (several tests inverted rather than deleted, per the repo's regression-test convention).

## Test plan
- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Pre-push hook (fmt + clippy + ui build + ui tests + security audit + `cargo test --workspace`) passed
- [ ] Manual: on a machine with the old build's wake job still armed, confirm the new build clears it on next launch and Quit sticks through a screen lock/unlock cycle