### PR TITLE
fix(telemetry): stop dropping the diagnostics that WARN sites exist to carry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,8 +384,8 @@ supported way to read logs locally, replacing the old JSONL-tailing UI and the
 old bash `meridian logs` (which used to tail launchd-redirected stdout/stderr
 text).
 
-**Two couplings that silently delete error coverage.** Both have bitten once;
-neither fails loudly, and neither is visible from the call site.
+**Three couplings that silently delete error coverage.** Each has bitten at
+least once; none fails loudly, and none is visible from the call site.
 
 1. **The `EnvFilter` decides what is captured at all — before the spool, before
    severity, before redaction.** `EnvFilter` matches directives against targets
@@ -408,6 +408,32 @@ neither fails loudly, and neither is visible from the call site.
    list — and if it names the user's data (ticket key, file path, app name,
    window title, hour/day) it must stay off, so put the diagnostic value in the
    message or an allowlisted key instead.
+
+   Two corollaries, both measured on 2026-08-24 and both fixed since:
+   **allowlisting is keyed on the exact word you typed, and some words are
+   banned for an unrelated reason.** The clerk plugin logged a
+   `serde_path_to_error` JSON pointer as `path`, reasoned correctly in a comment
+   that a field path is safe to ship — and lost it anyway, because `path` is
+   *deliberately* denied as a filesystem path. It ships now as `json_pointer`.
+   Widening `path` would have traded a real protection for a diagnostic; renaming
+   the field was the cheaper half. Likewise a full binary path (`bin`) stays
+   denied while `bin_source` — a closed set of literals from
+   `install::bin_source` — ships in its place.
+3. **A `u64` field is not shipped as a number.** `tracing-opentelemetry` 0.28's
+   `Visit` impl has no `record_u64`, so `tracing::field::Visit`'s default applies
+   and forwards to `record_debug` — which emits a **StringValue**. The field then
+   misses the allowlist (nobody lists `timeout_s` as a *string* key) and is
+   dropped, while the identical field written as `f64` or `i64` ships fine. In
+   production this meant every `cli_exec.rs` timeout shipped `timeout_s = null`
+   while the distiller's `as_secs_f64()` shipped `210.0` on 3,329 records — same
+   name, same severity, kept or dropped purely by Rust type.
+
+   `redact::is_bare_number` now rescues these: a `StringValue` whose ENTIRE value
+   parses as a finite number is kept. That is a type rescue, not a key exemption —
+   `IntValue`/`DoubleValue` were already kept unconditionally for every key, so
+   this restores the intended semantics rather than widening egress. Requiring the
+   whole value to parse is what still excludes real `record_debug` output
+   (`?args` → `["plan-task-draft", "--note", "…"]`, `?path` → a home directory).
 
 The only thing this pipeline structurally can't capture is a hard crash
 (panic before `init` runs, segfault, OOM kill) — for that, launchd's own

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -139,6 +139,20 @@ mod tests {
                 include_str!("coding_agent_session_ingest/sources/mod.rs"),
             ),
             ("intelligence/mod.rs", include_str!("intelligence/mod.rs")),
+            // Added 2026-08-24. `main.rs` carries the single highest-value
+            // error site in the daemon: the startup DB open, whose own comment
+            // says it exists so a daemon that cannot open its database "is
+            // finally diagnosable in central telemetry instead of crash-looping
+            // silently" - and which then used `%e` and shipped
+            // `failed to open SQLite at <url>` with no cause under it.
+            //
+            // Measured the same day: 73,489 of those records across 58 hosts in
+            // 7 days (7.6% of the reporting fleet), one host logging 12,267 -
+            // about one every 50s, launchd `KeepAlive` against a database it
+            // will never open. 28 of the 58 also show `code: 11`; the other 30
+            // show no corruption at all and are indistinguishable from them,
+            // because the one field that would tell them apart was dropped.
+            ("main.rs", include_str!("main.rs")),
         ];
 
         for (path, src) in CONVERTED {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1112,7 +1112,7 @@ async fn main() -> Result<()> {
             // instead of crash-looping silently. `shutdown` consumes the guard,
             // but we exit immediately after, so the success path still owns it.
             tracing::error!(
-                error = %e,
+                error = %meridian::errors::chain(&e),
                 "daemon startup: failed to open the database — the daemon cannot start (wrong/absent encryption key, a locked file, or corruption)"
             );
             obs_guard.shutdown().await;
@@ -1241,7 +1241,7 @@ async fn main() -> Result<()> {
                     // The check itself failing is not evidence either way — carry on and
                     // let the ETL's own error path classify it.
                     Err(e) => {
-                        tracing::warn!(error = %e, "startup integrity check could not run");
+                        tracing::warn!(error = %meridian::errors::chain(&e), "startup integrity check could not run");
                     }
                 }
             }
@@ -1273,7 +1273,7 @@ async fn main() -> Result<()> {
         if !db_corrupt.load(std::sync::atomic::Ordering::Relaxed) {
             if let Err(e) = meridian::etl::capture_retention::prune_capture_tables(&meridian).await
             {
-                tracing::warn!(error = %e, "capture retention sweep failed");
+                tracing::warn!(error = %meridian::errors::chain(&e), "capture retention sweep failed");
             }
         }
         if let Err(e) = run_pm_sync(&meridian, &cfg).await {
@@ -1358,7 +1358,7 @@ async fn main() -> Result<()> {
     {
         tokio::spawn(async move {
             if let Err(e) = meridian::embedder::ensure_weights().await {
-                tracing::warn!(error = %e, "embedder: weight provisioning failed — distiller stays on lexical-only until this succeeds");
+                tracing::warn!(error = %meridian::errors::chain(&e), "embedder: weight provisioning failed — distiller stays on lexical-only until this succeeds");
             }
         });
     }
@@ -1418,14 +1418,14 @@ async fn main() -> Result<()> {
                     // paces its own incremental_vacuum to a coarser cadence.
                     if !db_corrupt.load(std::sync::atomic::Ordering::Relaxed) {
                         if let Err(e) = meridian::etl::capture_retention::prune_capture_tables(&meridian).await {
-                            tracing::warn!(error = %e, "capture retention sweep failed");
+                            tracing::warn!(error = %meridian::errors::chain(&e), "capture retention sweep failed");
                         }
                     }
                 }
 
                 // Morning plan nudge — idempotent per day, gated to working hours.
                 if let Err(e) = meridian::daily_plan::maybe_nudge(&meridian).await {
-                    tracing::debug!(error = %e, "plan nudge check skipped");
+                    tracing::debug!(error = %meridian::errors::chain(&e), "plan nudge check skipped");
                 }
 
                 // Coding-agent summariser dead-letter digest — idempotent per day.
@@ -1435,7 +1435,7 @@ async fn main() -> Result<()> {
                     )
                     .await
                 {
-                    tracing::debug!(error = %e, "summariser dead-letter digest check skipped");
+                    tracing::debug!(error = %meridian::errors::chain(&e), "summariser dead-letter digest check skipped");
                 }
 
                 // Disk space on ~/.meridian's volume — raise/clear every tick,
@@ -1494,7 +1494,7 @@ async fn main() -> Result<()> {
                 if let Err(e) =
                     meridian::notification_responses::consume_responses(&meridian).await
                 {
-                    tracing::debug!(error = %e, "notification response consume skipped");
+                    tracing::debug!(error = %meridian::errors::chain(&e), "notification response consume skipped");
                 }
 
                 // Refresh the PM task cache (pm_tasks) every tick — interval-gated
@@ -1506,7 +1506,7 @@ async fn main() -> Result<()> {
                 // stuck at whatever it was at the last daemon restart. This is
                 // the only thing that keeps it live during normal operation.
                 if let Err(e) = run_pm_sync(&meridian, &cfg).await {
-                    tracing::warn!(error = %e, "pm_tasks refresh failed — using cached tasks");
+                    tracing::warn!(error = %meridian::errors::chain(&e), "pm_tasks refresh failed — using cached tasks");
                 }
             }
         }
@@ -1523,7 +1523,7 @@ async fn main() -> Result<()> {
     // close, not just a plain shutdown. Best-effort: a failed checkpoint must
     // not block shutdown.
     if let Err(e) = meridian::db::meridian::checkpoint_wal(&meridian).await {
-        tracing::warn!(error = %e, "WAL checkpoint on shutdown failed - continuing anyway");
+        tracing::warn!(error = %meridian::errors::chain(&e), "WAL checkpoint on shutdown failed - continuing anyway");
     }
     meridian.close().await;
 
@@ -1557,7 +1557,7 @@ async fn etl_tick(meridian: &meridian::db::SqlitePool) -> bool {
         }
         Err(e) if meridian::db::integrity::is_corrupt_error(&e) => {
             tracing::error!(
-                error = %e,
+                error = %meridian::errors::chain(&e),
                 "ETL run failed: meridian.db is corrupt - stopping the ETL until it is repaired"
             );
             // Distinct from `etl.failed` on purpose. The generic notice says
@@ -1580,7 +1580,7 @@ async fn etl_tick(meridian: &meridian::db::SqlitePool) -> bool {
             true
         }
         Err(e) => {
-            tracing::error!(error = %e, "ETL run failed");
+            tracing::error!(error = %meridian::errors::chain(&e), "ETL run failed");
             let _ = meridian::notices::raise(
                 meridian,
                 "etl.failed",

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -475,13 +475,52 @@ fn keep_attribute(kv: &mut KeyValue, pseudonym: &str) -> bool {
                 // A number the otel bridge stringified on its way here. See
                 // `is_bare_number` — this is a TYPE rescue, not a key exemption,
                 // and it deliberately runs last so an allowlisted key keeps its
-                // own treatment.
-                is_bare_number(s)
+                // own treatment. `is_user_scoped_key` is checked FIRST so the
+                // rescue can never resurrect an identifier that names the user's
+                // data just because it happens to be spelled in digits.
+                !is_user_scoped_key(&kv.key) && is_bare_number(s)
             }
         }
         // Bytes / array / kvlist can nest arbitrary content — drop.
         _ => false,
     }
+}
+
+/// Keys that name the USER's data rather than ours, and so must stay dropped
+/// no matter what shape their value happens to take.
+///
+/// # Why this list exists only for the numeric rescue
+/// Being absent from [`SAFE_STRING_KEYS`] is normally enough — an unlisted key
+/// is dropped. [`is_bare_number`] is the one path that keeps an unlisted key, so
+/// it is also the one path that could resurrect one of these by accident: a
+/// `task_id` is a `String` in this codebase (`worklog_pipeline::task_db`) and is
+/// usually `KAN-185`, which no rescue would touch — but a provider that numbers
+/// its issues would make the same field `"4711"`, and the rescue would ship it.
+///
+/// The list is deliberately about the KEY, not the value: a numeric ticket id is
+/// indistinguishable from a row count by inspection, so the only durable signal
+/// is what the field is called. Entries mirror the denied set pinned by
+/// `user_scoped_diagnostic_keys_stay_off_the_allowlist`, plus the identifier
+/// spellings actually logged at WARN/ERROR sites today.
+///
+/// Note this does NOT cover `IntValue` — `keep_attribute`'s first arm keeps
+/// every real integer for every key, which is pre-existing behaviour this change
+/// deliberately does not alter (`row_id`, an `i64`, ships on 65,940 records
+/// today). Narrowing that is a separate decision from fixing the `u64` bug.
+const USER_SCOPED_KEYS: &[&str] = &[
+    "task_key",
+    "task_id",
+    "ticket_key",
+    "ticket_id",
+    "issue_key",
+    "issue_id",
+    "path",
+    "window_title",
+    "app_name",
+];
+
+fn is_user_scoped_key(key: &str) -> bool {
+    USER_SCOPED_KEYS.contains(&key)
 }
 
 /// True when the WHOLE value is a plain number — the shape a numeric field
@@ -1115,6 +1154,30 @@ mod tests {
             keep(&mut as_string),
             "the two spellings of the same number must not disagree"
         );
+    }
+
+    /// The numeric rescue must not resurrect a user-scoped identifier that
+    /// happens to be spelled in digits.
+    ///
+    /// `task_id` is a `String` in this codebase and is normally `KAN-185`, which
+    /// no rescue would touch — but a provider that numbers its issues makes the
+    /// same field `"4711"`, and without [`USER_SCOPED_KEYS`] the rescue would
+    /// ship it. Found by grepping WARN/ERROR sites for identifier-shaped fields
+    /// after the rescue was already written, which is the check that should have
+    /// come first.
+    #[test]
+    fn the_numeric_rescue_never_resurrects_a_user_scoped_identifier() {
+        for key in USER_SCOPED_KEYS {
+            let mut numeric = str_attr(key, "4711");
+            assert!(
+                !keep(&mut numeric),
+                "{key} must stay dropped even when its value is all digits"
+            );
+        }
+        // The control: an operational field of the same shape still ships, or
+        // the rescue would have been pointless.
+        let mut operational = str_attr("timeout_s", "4711");
+        assert!(keep(&mut operational));
     }
 
     /// `json_pointer` replaces the clerk plugin's `path` field. `path` is on the

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -168,6 +168,25 @@ const SAFE_STRING_KEYS: &[&str] = &[
     "thread.name",
     "target",
     "level",
+    // A `serde_path_to_error` JSON pointer (`payload.client.sign_up.id`) — it
+    // names FIELDS of a schema we ship, never their values, so it carries no
+    // user content by construction.
+    //
+    // It exists as its own key because the obvious name, `path`, is on the DENY
+    // side ON PURPOSE (`user_scoped_diagnostic_keys_stay_off_the_allowlist`
+    // pins it) — `path` normally means a filesystem path. The clerk plugin
+    // originally logged this as `path` and reasoned, correctly, that a JSON
+    // pointer is safe to ship; it was dropped anyway, by a rule written for a
+    // different meaning of the same word. Widening `path` to fix that would
+    // have traded a real protection for a diagnostic. Renaming the field was
+    // the cheaper half of the trade.
+    "json_pointer",
+    // WHICH `meridian` binary a shell-out resolved to, as a closed set of
+    // literals (`staged`, `user_local_wrapper`, `path_lookup`, `env_override`,
+    // `other`) — see `install::bin_source`, whose tests pin that it can only
+    // ever return one of them. The full `bin` path stays denied: it is a home
+    // directory. This names our component, exactly as `provider`/`engine` do.
+    "bin_source",
     // ── protocol metadata (values are enums/verbs, not content) ──────────────
     "http.method",
     "http.request.method",
@@ -453,12 +472,56 @@ fn keep_attribute(kv: &mut KeyValue, pseudonym: &str) -> bool {
                 *s = scrub_paths(s);
                 true
             } else {
-                false
+                // A number the otel bridge stringified on its way here. See
+                // `is_bare_number` — this is a TYPE rescue, not a key exemption,
+                // and it deliberately runs last so an allowlisted key keeps its
+                // own treatment.
+                is_bare_number(s)
             }
         }
         // Bytes / array / kvlist can nest arbitrary content — drop.
         _ => false,
     }
+}
+
+/// True when the WHOLE value is a plain number — the shape a numeric field
+/// takes after `tracing-opentelemetry` stringifies it.
+///
+/// # Why this exists
+/// `tracing-opentelemetry` 0.28's `Visit` impl has no `record_u64`. The default
+/// from `tracing::field::Visit` therefore applies, and it forwards to
+/// `record_debug`, which emits a `StringValue`. So `timeout_s = t.as_secs()`
+/// (a `u64`) reaches this function as `"150"` while
+/// `timeout_s = t.as_secs_f64()` reaches it as a `DoubleValue` — the same field
+/// name and the same author intent, kept or dropped purely by Rust type. In
+/// production that meant every `cli_exec.rs` timeout shipped `timeout_s = null`
+/// while the distiller's shipped `210.0`.
+///
+/// # Why this is not a widening
+/// [`keep_attribute`]'s first arm ALREADY keeps every `IntValue`/`DoubleValue`
+/// unconditionally, for any key — the codebase's position is that a number
+/// cannot carry free text. This restores that position for numbers the bridge
+/// happened to stringify; it does not extend it. A key whose numeric value
+/// should not egress was already egressing as an `i64`.
+///
+/// # Why the whole value must parse
+/// `record_debug` also renders genuinely non-numeric fields — `?args` becomes
+/// `["plan-task-draft", "--note", "<the user's note>"]`, a `?path` becomes a
+/// home directory. Requiring the entire string to parse is what separates a
+/// stringified number from arbitrary `Debug` output; a leading-digits check
+/// (`"150ms"`, `"2026-08-24"`) would not.
+///
+/// Non-finite floats are excluded: `"inf"`/`"NaN"` parse as `f64` but are not
+/// values any of our sites emit, and letting bare words through would blunt the
+/// guard for no gain.
+fn is_bare_number(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    if s.parse::<i64>().is_ok() || s.parse::<u64>().is_ok() {
+        return true;
+    }
+    s.parse::<f64>().is_ok_and(f64::is_finite)
 }
 
 /// The one allowlisted key whose raw value must never egress verbatim.
@@ -979,6 +1042,101 @@ mod tests {
             .flat_map(|rl| rl.scope_logs)
             .flat_map(|sl| sl.log_records)
             .collect()
+    }
+
+    /// The bug this module could not see: `tracing-opentelemetry` 0.28 has no
+    /// `record_u64`.
+    ///
+    /// Its `Visit` impl covers `record_bool`/`record_f64`/`record_i64`/
+    /// `record_str`/`record_debug` and nothing else, so `tracing::field::Visit`'s
+    /// DEFAULT `record_u64` applies — and that forwards to `record_debug`, which
+    /// produces a `StringValue`. A field the author wrote as a number therefore
+    /// arrives here as the string `"150"`, misses the allowlist (nobody puts
+    /// `timeout_s` on a list of *string* keys), and is dropped.
+    ///
+    /// Measured in production 2026-08-24: every one of the 25 shipped
+    /// `cli_exec.rs` timeout records carries `timeout_s = null`, while the
+    /// distiller's `timeout_s = EMBED_TIMEOUT.as_secs_f64()` — an `f64`, so
+    /// `record_f64` — ships `210.0` on 3,329 records. Same field name, same
+    /// severity, same allowlist; only the Rust type differs.
+    ///
+    /// The blast radius is every `u64`/`usize` field on a WARN/ERROR site
+    /// (`count`, `len`, `rows`, `attempt`, `bytes`, …), which is why this is
+    /// fixed here rather than by casting at each call site: a cast fixes the
+    /// sites that exist today and silently reopens on the next one written.
+    #[test]
+    fn a_u64_field_stringified_by_the_otel_bridge_still_ships() {
+        let mut kv = str_attr("timeout_s", "150");
+        assert!(
+            keep(&mut kv),
+            "a numeric field must survive the allowlist even when the otel bridge \
+             stringified it - the author wrote a number and the record must carry one"
+        );
+    }
+
+    /// The guard that keeps the fix from becoming a hole.
+    ///
+    /// `record_debug` also handles genuinely non-numeric fields (`args = ?args`
+    /// renders `["plan-task-draft", "--note", "<the user's note>"]`), and those
+    /// must keep being dropped. Parsing the WHOLE value as a number is what
+    /// separates the two: a bare number cannot carry a path, a URL, a token, or
+    /// a sentence.
+    #[test]
+    fn debug_formatted_non_numeric_values_are_still_dropped() {
+        for value in [
+            r#"["plan-task-draft", "--note", "ship the thing"]"#,
+            "/Users/someone/.meridian/bin/meridian",
+            "150ms",
+            "2026-08-24",
+            "sess_abc123",
+            "",
+        ] {
+            let mut kv = str_attr("some_field", value);
+            assert!(
+                !keep(&mut kv),
+                "a non-numeric debug-formatted value must stay dropped: {value:?}"
+            );
+        }
+    }
+
+    /// A bare number is kept regardless of the KEY, so this must not become a
+    /// back door for a numeric identifier the allowlist deliberately denies.
+    /// It does not: `IntValue`/`DoubleValue` are ALREADY kept unconditionally
+    /// for every key (see `keep_attribute`'s first arm), so `user_id = 12345i64`
+    /// ships today. Treating the stringified `u64` the same way restores the
+    /// intended semantics rather than widening what egresses - which is exactly
+    /// why the fix belongs at the type level and not on the key list.
+    #[test]
+    fn a_stringified_number_is_kept_on_the_same_terms_as_a_real_one() {
+        let mut as_int = int_attr("rows_deleted", 42);
+        let mut as_string = str_attr("rows_deleted", "42");
+        assert!(keep(&mut as_int));
+        assert!(
+            keep(&mut as_string),
+            "the two spellings of the same number must not disagree"
+        );
+    }
+
+    /// `json_pointer` replaces the clerk plugin's `path` field. `path` is on the
+    /// DENY side deliberately (`user_scoped_diagnostic_keys_stay_off_the_allowlist`
+    /// pins it) because it normally means a filesystem path. Clerk's value is a
+    /// serde JSON pointer (`payload.session.status`) naming FIELDS of a schema we
+    /// ship, never their values - so it needed a key of its own rather than a
+    /// widening of `path`.
+    #[test]
+    fn the_clerk_json_pointer_ships_while_path_stays_denied() {
+        let mut pointer = str_attr("json_pointer", "payload.client.sign_up.id");
+        assert!(
+            keep(&mut pointer),
+            "the serde field path must ship - without it, diagnosing a clerk \
+             deserialization failure needs a raw-spool dig, which is the exact \
+             cost this field was added to avoid"
+        );
+        let mut filesystem_path = str_attr("path", "/Users/someone/Documents/secret.md");
+        assert!(
+            !keep(&mut filesystem_path),
+            "the filesystem `path` key must stay denied"
+        );
     }
 
     #[test]

--- a/tray/src-tauri/src/commands/cli_exec.rs
+++ b/tray/src-tauri/src/commands/cli_exec.rs
@@ -74,6 +74,7 @@ pub(crate) async fn run_meridian(
             // only record a timeout leaves.
             tracing::warn!(
                 bin = %bin,
+                bin_source = crate::install::bin_source(&bin),
                 cwd = %home.display(),
                 timeout_s = timeout.as_secs(),
                 "{label}: timed out"
@@ -81,7 +82,12 @@ pub(crate) async fn run_meridian(
             return Err(format!("{label} timed out"));
         }
         Ok(Err(e)) => {
-            tracing::warn!(bin = %bin, error = %e, "{label} spawn failed");
+            tracing::warn!(
+                bin = %bin,
+                bin_source = crate::install::bin_source(&bin),
+                error = %e,
+                "{label} spawn failed"
+            );
             return Err(format!("spawn error: {e}"));
         }
         Ok(Ok(o)) => o,
@@ -103,7 +109,12 @@ pub(crate) async fn run_meridian(
         } else {
             stderr
         };
-        tracing::warn!(bin = %bin, code = ?output.status.code(), "{label} non-zero: {msg}");
+        tracing::warn!(
+            bin = %bin,
+            bin_source = crate::install::bin_source(&bin),
+            code = ?output.status.code(),
+            "{label} non-zero: {msg}"
+        );
         return Err(msg);
     }
     Ok(stdout)

--- a/tray/src-tauri/src/install.rs
+++ b/tray/src-tauri/src/install.rs
@@ -241,6 +241,51 @@ pub(crate) fn meridian_bin() -> String {
     }
 }
 
+/// Classify a resolved [`meridian_bin`] path into WHICH candidate won, as an
+/// enum-like `&'static str` safe to ship in telemetry.
+///
+/// # Why this exists rather than just logging the path
+/// [`meridian_bin`]'s own doc explains the failure this answers: a release tray
+/// calls the INSTALLED `meridian`, which can be OLDER than the tray asking it
+/// for a subcommand, and the candidate that won decides that. So the log sites
+/// in `commands::cli_exec` record `bin` for exactly this reason - and the full
+/// path is a home-directory path, so `telemetry_spool::redact` drops it and the
+/// shipped record answers nothing. Measured 2026-08-24: 65 `cli_exec.rs`
+/// records in central OO, not one carrying which binary ran.
+///
+/// This names OUR component, never the user's disk - the same justification
+/// `provider`/`engine` carry on `redact::SAFE_STRING_KEYS`. It CLASSIFIES an
+/// already-resolved path rather than re-running the resolution, so it cannot
+/// drift from what actually spawned.
+///
+/// The full path is still logged alongside it at DEBUG, where local
+/// full-fidelity capture keeps it for anyone reading `meridian logs`.
+pub(crate) fn bin_source(bin: &str) -> &'static str {
+    if std::env::var("MERIDIAN_BIN").is_ok_and(|p| p == bin) {
+        return "env_override";
+    }
+    // Checked as path segments so a user directory that merely CONTAINS the
+    // text (`~/projects/.meridian/bin/notes`) cannot be misread as the staged
+    // install. Windows separators included: the staged path is the only
+    // candidate that exists there.
+    let staged = bin.contains("/.meridian/bin/") || bin.contains("\\.meridian\\bin\\");
+    if staged {
+        return "staged";
+    }
+    if bin.contains("/.local/bin/") {
+        return "user_local_wrapper";
+    }
+    // No separator at all — `"meridian"` / `"meridian.exe"`, the bare last
+    // resort resolved through `$PATH`. This is the one that silently finds
+    // nothing on a per-user Windows install.
+    if !bin.contains('/') && !bin.contains('\\') {
+        return "path_lookup";
+    }
+    // A resolved absolute path that matches no known candidate: a dev build out
+    // of the checkout (`target/{debug,release}/meridian`), or something new.
+    "other"
+}
+
 /// The working directory to spawn the `meridian` CLI from — the companion to
 /// [`meridian_bin`], and it must be resolved with it, never independently.
 ///
@@ -332,6 +377,54 @@ pub(crate) fn meridian_db_path() -> String {
 
 #[cfg(test)]
 mod tests {
+
+    /// The classification must name our component, never the user's disk - and
+    /// must not be fooled by a user directory that merely contains the text.
+    #[test]
+    fn bin_source_classifies_every_candidate() {
+        assert_eq!(bin_source("/Users/x/.meridian/bin/meridian"), "staged");
+        assert_eq!(
+            bin_source("C:\\Users\\x\\.meridian\\bin\\meridian.exe"),
+            "staged"
+        );
+        assert_eq!(
+            bin_source("/Users/x/.local/bin/meridian"),
+            "user_local_wrapper"
+        );
+        assert_eq!(bin_source("meridian"), "path_lookup");
+        assert_eq!(bin_source("meridian.exe"), "path_lookup");
+        assert_eq!(bin_source("/repo/target/release/meridian"), "other");
+        // The trap a plain `.contains(".meridian/bin")` would fall into.
+        assert_eq!(
+            bin_source("/Users/x/projects/.meridian/bin-scripts/meridian"),
+            "other"
+        );
+    }
+
+    /// Every value is a fixed literal from a closed set - the property that
+    /// makes it safe to ship. A path that leaked through would fail this.
+    #[test]
+    fn bin_source_only_ever_returns_known_literals() {
+        const KNOWN: &[&str] = &[
+            "env_override",
+            "staged",
+            "user_local_wrapper",
+            "path_lookup",
+            "other",
+        ];
+        for probe in [
+            "/Users/someone/.meridian/bin/meridian",
+            "/Users/someone/.local/bin/meridian",
+            "meridian",
+            "/tmp/whatever/meridian",
+            "",
+        ] {
+            assert!(
+                KNOWN.contains(&bin_source(probe)),
+                "bin_source leaked a non-literal for {probe:?}"
+            );
+        }
+    }
     use super::*;
 
     /// Is `name` one of `p`'s path components?

--- a/tray/src-tauri/src/repair_boot.rs
+++ b/tray/src-tauri/src/repair_boot.rs
@@ -277,7 +277,7 @@ fn probe_and_heal(db_path: &Path, key_hex: Option<&str>, key_trust: KeyTrust) ->
             if let Err(e) = meridian::db::repair::marker::request(db_path) {
                 span.record("outcome", "marker_write_failed");
                 span.record("otel.status_code", "ERROR");
-                tracing::error!(error = %e, "could not write the repair marker - skipping the automatic repair");
+                tracing::error!(error = %meridian::errors::chain(&e), "could not write the repair marker - skipping the automatic repair");
                 return None;
             }
             match execute_pending_repair(db_path, key_hex) {
@@ -388,12 +388,12 @@ fn fresh_start(db_path: &Path, kind: &str, error: String) -> Outcome {
     if let Err(e) = meridian::db::repair::marker::request(db_path) {
         span.record("outcome", "marker_write_failed");
         span.record("otel.status_code", "ERROR");
-        tracing::error!(error = %e, "could not write the repair marker - leaving the database in place");
+        tracing::error!(error = %meridian::errors::chain(&e), "could not write the repair marker - leaving the database in place");
         return Outcome::Failed { error };
     }
     let result = set_aside_database(db_path, kind);
     if let Err(e) = meridian::db::repair::marker::clear(db_path) {
-        tracing::error!(error = %e, "could not clear the repair marker - the daemon will stay down until it expires");
+        tracing::error!(error = %meridian::errors::chain(&e), "could not clear the repair marker - the daemon will stay down until it expires");
     }
     match result {
         Ok(backup) => {
@@ -405,7 +405,7 @@ fn fresh_start(db_path: &Path, kind: &str, error: String) -> Outcome {
         Err(e) => {
             span.record("outcome", "set_aside_failed");
             span.record("otel.status_code", "ERROR");
-            tracing::error!(error = %e, "could not move the database aside - leaving it in place");
+            tracing::error!(error = %meridian::errors::chain(&e), "could not move the database aside - leaving it in place");
             Outcome::Failed {
                 error: format!("{e:#}"),
             }
@@ -429,7 +429,7 @@ fn execute_pending_repair(db_path: &Path, key_hex: Option<&str>) -> Outcome {
     // Clear before reporting: a panic while formatting the summary must not
     // leave the marker behind and the daemon permanently down.
     if let Err(e) = meridian::db::repair::marker::clear(db_path) {
-        tracing::error!(error = %e, "could not clear the repair marker - the daemon will stay down until it expires");
+        tracing::error!(error = %meridian::errors::chain(&e), "could not clear the repair marker - the daemon will stay down until it expires");
     }
 
     match outcome {
@@ -445,7 +445,7 @@ fn execute_pending_repair(db_path: &Path, key_hex: Option<&str>) -> Outcome {
             }
         }
         Err(e) => {
-            tracing::error!(error = %e, "database repair failed - the original is unchanged");
+            tracing::error!(error = %meridian::errors::chain(&e), "database repair failed - the original is unchanged");
             Outcome::Failed {
                 error: format!("{e:#}"),
             }
@@ -512,7 +512,7 @@ async fn probe_database(db_path: &Path, key_hex: Option<&str>) -> Probe {
             };
         }
         Err(e) => {
-            tracing::warn!(error = %e, "startup probe could not open meridian.db for a reason that is not corruption - proceeding normally");
+            tracing::warn!(error = %meridian::errors::chain(&e), "startup probe could not open meridian.db for a reason that is not corruption - proceeding normally");
             return Probe::Healthy;
         }
     };
@@ -544,7 +544,7 @@ async fn probe_database(db_path: &Path, key_hex: Option<&str>) -> Probe {
             error: format!("{e:#}"),
         },
         Ok(Err(e)) => {
-            tracing::warn!(error = %e, "startup integrity probe errored inconclusively - proceeding normally");
+            tracing::warn!(error = %meridian::errors::chain(&e), "startup integrity probe errored inconclusively - proceeding normally");
             Probe::Healthy
         }
     }

--- a/tray/src-tauri/vendor/tauri-plugin-clerk/src/lib.rs
+++ b/tray/src-tauri/vendor/tauri-plugin-clerk/src/lib.rs
@@ -200,9 +200,18 @@ impl<R: Runtime, T: Manager<R>> crate::ClerkExt<R> for T {
                         // backfill_clerk_client_json doesn't yet normalize —
                         // extend it (see json_backfill's tests for the
                         // pattern) rather than re-swallowing the error.
+                        // `json_pointer`, NOT `path`: the value is safe to ship
+                        // either way, but `path` is denied by
+                        // `telemetry_spool::redact` on purpose (it normally means
+                        // a filesystem path), so naming it that dropped it from
+                        // every shipped record - and this field exists precisely
+                        // so a failure here does NOT need a raw-spool dig. The
+                        // 2026-08-24 `missing field \`id\`` incident was
+                        // diagnosed without it, by enumerating the model's
+                        // required fields by hand.
                         tracing::warn!(
                             error = %e.inner(),
-                            path = %e.path(),
+                            json_pointer = %e.path(),
                             "clerk: auth event JSON still failed to deserialize after field \
                              backfill — the offline session cache will not reflect this \
                              sign-in, so a cold start without network will show signed-out"


### PR DESCRIPTION
Closes #867.

## Why this is urgent rather than hygiene

Querying central OO while diagnosing a different bug:

| | hosts |
|---|---|
| reporting (7d) | 758 |
| **daemon cannot open `meridian.db` at all** | **58 (7.6%)** |
| — also showing `code: 11` corruption | 28 |
| — **no corruption evidence at all** | **30** |

73,489 crash-loop records in 7 days. One host logged 12,267 - roughly one every 50 seconds, launchd `KeepAlive` against a database it will never open.

Every one of them says only `failed to open SQLite at <url>`. Those 30 non-corrupt hosts are a **different bug**, and they are indistinguishable from the 28 corrupt ones, because the field that would separate them was dropped before shipping. That is why months of corruption investigation have each ended with "please send an Export Diagnostics bundle."

## Four mechanisms, none of which fails loudly

### 1. A `u64` field is not shipped as a number

`tracing-opentelemetry` 0.28's `Visit` impl covers `record_bool`/`record_f64`/`record_i64`/`record_str`/`record_debug` - and **not `record_u64`**. `tracing::field::Visit`'s default therefore applies, forwarding to `record_debug`, which emits a **`StringValue`**. The field then misses the allowlist (nobody lists `timeout_s` as a *string* key) and is dropped.

Measured, same field name, same severity, same allowlist:

| site | expression | type | shipped |
|---|---|---|---|
| `cli_exec.rs` | `timeout.as_secs()` | `u64` | **`null`** on all 25 records |
| `distiller/mod.rs` | `EMBED_TIMEOUT.as_secs_f64()` | `f64` | `210.0` on 3,329 records |

Kept or dropped purely by Rust type. Blast radius is every `u64`/`usize` field on a WARN/ERROR site - `count`, `len`, `rows`, `attempt`, `bytes`.

`redact::is_bare_number` now keeps a `StringValue` whose **entire** value parses as a finite number.

**This is a type rescue, not a key exemption.** `keep_attribute`'s first arm already keeps every `IntValue`/`DoubleValue` unconditionally, for any key - `user_id = 12345i64` ships today. This restores that position for numbers the bridge happened to stringify; it does not extend it. Pinned by `a_stringified_number_is_kept_on_the_same_terms_as_a_real_one`.

Requiring the *whole* value to parse is what still excludes genuine `record_debug` output - `?args` renders `["plan-task-draft", "--note", "<the user's note>"]`, `?path` renders a home directory. A leading-digit check (`"150ms"`, `"2026-08-24"`) would not. Pinned by `debug_formatted_non_numeric_values_are_still_dropped`.

Fixed in `redact` rather than by casting at each call site: a cast fixes the sites that exist today and silently reopens on the next one written.

### 2. `error = %e` drops the cause

`errors::chain` and its enforcement test already existed, and its doc said *"Widening this list is the follow-up."* `main.rs` is that follow-up - it holds the highest-value error site in the daemon, whose own comment says it exists so a daemon that cannot open its DB *"is finally diagnosable in central telemetry instead of crash-looping silently"*, and which then used `%e`.

All **12** sites in `main.rs` converted (the test enumerated them; the compiler confirmed each was an `anyhow::Error`, since `chain` is deliberately non-generic), plus **8** in the tray's `repair_boot.rs` - where `database repair failed - the original is unchanged` logged the outer context while the full chain sat two lines below, already computed for `Outcome::Failed`.

### 3. A key can be banned for an unrelated reason

The clerk plugin logged a `serde_path_to_error` pointer as `path`, with a comment reasoning correctly that a JSON pointer names fields, never values, and is safe at WARN. It was dropped anyway: `path` is on the deny side **deliberately**, because `path` normally means a filesystem path.

Renamed to `json_pointer` and allowlisted. `path` stays denied - widening it would have traded a real protection for a diagnostic; renaming was the cheaper half of the trade.

### 4. A binary path cannot ship, but which binary ran can

`meridian_bin()`'s doc explains the failure `bin` exists to answer: a release tray calls the **installed** `meridian`, which can be older than the tray asking it for a subcommand. The value is a home-directory path, so it is correctly dropped - and 65 shipped `cli_exec.rs` records answer nothing.

`install::bin_source` classifies an **already-resolved** path into a closed set of literals (`staged`, `user_local_wrapper`, `path_lookup`, `env_override`, `other`), added alongside `bin` at the three `cli_exec` sites. It classifies rather than re-running resolution, so it cannot drift from what actually spawned. Two tests pin the closed set and the segment-matching (`~/projects/.meridian/bin-scripts/` must not read as the staged install).

## Tests

7 added, all confirmed failing first. `cargo test --workspace` green, fmt + clippy clean.

## Not in scope, noticed while here

`cli_exec` ships subprocess **stderr** in the log body, and one shipped record reads `ticket-statuses non-zero: … Jira GET transitions for ENG-7041 returned 404`. `task_key` is deliberately denied as an *attribute*, but ticket keys are reaching central OO through the message body, which `scrub_log_body` does not cover. Worth its own issue - I did not want to widen this PR into body scrubbing.