### PR TITLE
feat(analytics): report database integrity to PostHog, joinable to OpenObserve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,8 +384,8 @@ supported way to read logs locally, replacing the old JSONL-tailing UI and the
 old bash `meridian logs` (which used to tail launchd-redirected stdout/stderr
 text).
 
-**Two couplings that silently delete error coverage.** Both have bitten once;
-neither fails loudly, and neither is visible from the call site.
+**Three couplings that silently delete error coverage.** Each has bitten at
+least once; none fails loudly, and none is visible from the call site.
 
 1. **The `EnvFilter` decides what is captured at all — before the spool, before
    severity, before redaction.** `EnvFilter` matches directives against targets
@@ -408,6 +408,32 @@ neither fails loudly, and neither is visible from the call site.
    list — and if it names the user's data (ticket key, file path, app name,
    window title, hour/day) it must stay off, so put the diagnostic value in the
    message or an allowlisted key instead.
+
+   Two corollaries, both measured on 2026-08-24 and both fixed since:
+   **allowlisting is keyed on the exact word you typed, and some words are
+   banned for an unrelated reason.** The clerk plugin logged a
+   `serde_path_to_error` JSON pointer as `path`, reasoned correctly in a comment
+   that a field path is safe to ship — and lost it anyway, because `path` is
+   *deliberately* denied as a filesystem path. It ships now as `json_pointer`.
+   Widening `path` would have traded a real protection for a diagnostic; renaming
+   the field was the cheaper half. Likewise a full binary path (`bin`) stays
+   denied while `bin_source` — a closed set of literals from
+   `install::bin_source` — ships in its place.
+3. **A `u64` field is not shipped as a number.** `tracing-opentelemetry` 0.28's
+   `Visit` impl has no `record_u64`, so `tracing::field::Visit`'s default applies
+   and forwards to `record_debug` — which emits a **StringValue**. The field then
+   misses the allowlist (nobody lists `timeout_s` as a *string* key) and is
+   dropped, while the identical field written as `f64` or `i64` ships fine. In
+   production this meant every `cli_exec.rs` timeout shipped `timeout_s = null`
+   while the distiller's `as_secs_f64()` shipped `210.0` on 3,329 records — same
+   name, same severity, kept or dropped purely by Rust type.
+
+   `redact::is_bare_number` now rescues these: a `StringValue` whose ENTIRE value
+   parses as a finite number is kept. That is a type rescue, not a key exemption —
+   `IntValue`/`DoubleValue` were already kept unconditionally for every key, so
+   this restores the intended semantics rather than widening egress. Requiring the
+   whole value to parse is what still excludes real `record_debug` output
+   (`?args` → `["plan-task-draft", "--note", "…"]`, `?path` → a home directory).
 
 The only thing this pipeline structurally can't capture is a hard crash
 (panic before `init` runs, segfault, OOM kill) — for that, launchd's own

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -139,6 +139,20 @@ mod tests {
                 include_str!("coding_agent_session_ingest/sources/mod.rs"),
             ),
             ("intelligence/mod.rs", include_str!("intelligence/mod.rs")),
+            // Added 2026-08-24. `main.rs` carries the single highest-value
+            // error site in the daemon: the startup DB open, whose own comment
+            // says it exists so a daemon that cannot open its database "is
+            // finally diagnosable in central telemetry instead of crash-looping
+            // silently" - and which then used `%e` and shipped
+            // `failed to open SQLite at <url>` with no cause under it.
+            //
+            // Measured the same day: 73,489 of those records across 58 hosts in
+            // 7 days (7.6% of the reporting fleet), one host logging 12,267 -
+            // about one every 50s, launchd `KeepAlive` against a database it
+            // will never open. 28 of the 58 also show `code: 11`; the other 30
+            // show no corruption at all and are indistinguishable from them,
+            // because the one field that would tell them apart was dropped.
+            ("main.rs", include_str!("main.rs")),
         ];
 
         for (path, src) in CONVERTED {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1112,7 +1112,7 @@ async fn main() -> Result<()> {
             // instead of crash-looping silently. `shutdown` consumes the guard,
             // but we exit immediately after, so the success path still owns it.
             tracing::error!(
-                error = %e,
+                error = %meridian::errors::chain(&e),
                 "daemon startup: failed to open the database — the daemon cannot start (wrong/absent encryption key, a locked file, or corruption)"
             );
             obs_guard.shutdown().await;
@@ -1241,7 +1241,7 @@ async fn main() -> Result<()> {
                     // The check itself failing is not evidence either way — carry on and
                     // let the ETL's own error path classify it.
                     Err(e) => {
-                        tracing::warn!(error = %e, "startup integrity check could not run");
+                        tracing::warn!(error = %meridian::errors::chain(&e), "startup integrity check could not run");
                     }
                 }
             }
@@ -1273,7 +1273,7 @@ async fn main() -> Result<()> {
         if !db_corrupt.load(std::sync::atomic::Ordering::Relaxed) {
             if let Err(e) = meridian::etl::capture_retention::prune_capture_tables(&meridian).await
             {
-                tracing::warn!(error = %e, "capture retention sweep failed");
+                tracing::warn!(error = %meridian::errors::chain(&e), "capture retention sweep failed");
             }
         }
         if let Err(e) = run_pm_sync(&meridian, &cfg).await {
@@ -1358,7 +1358,7 @@ async fn main() -> Result<()> {
     {
         tokio::spawn(async move {
             if let Err(e) = meridian::embedder::ensure_weights().await {
-                tracing::warn!(error = %e, "embedder: weight provisioning failed — distiller stays on lexical-only until this succeeds");
+                tracing::warn!(error = %meridian::errors::chain(&e), "embedder: weight provisioning failed — distiller stays on lexical-only until this succeeds");
             }
         });
     }
@@ -1418,14 +1418,14 @@ async fn main() -> Result<()> {
                     // paces its own incremental_vacuum to a coarser cadence.
                     if !db_corrupt.load(std::sync::atomic::Ordering::Relaxed) {
                         if let Err(e) = meridian::etl::capture_retention::prune_capture_tables(&meridian).await {
-                            tracing::warn!(error = %e, "capture retention sweep failed");
+                            tracing::warn!(error = %meridian::errors::chain(&e), "capture retention sweep failed");
                         }
                     }
                 }
 
                 // Morning plan nudge — idempotent per day, gated to working hours.
                 if let Err(e) = meridian::daily_plan::maybe_nudge(&meridian).await {
-                    tracing::debug!(error = %e, "plan nudge check skipped");
+                    tracing::debug!(error = %meridian::errors::chain(&e), "plan nudge check skipped");
                 }
 
                 // Coding-agent summariser dead-letter digest — idempotent per day.
@@ -1435,7 +1435,7 @@ async fn main() -> Result<()> {
                     )
                     .await
                 {
-                    tracing::debug!(error = %e, "summariser dead-letter digest check skipped");
+                    tracing::debug!(error = %meridian::errors::chain(&e), "summariser dead-letter digest check skipped");
                 }
 
                 // Disk space on ~/.meridian's volume — raise/clear every tick,
@@ -1494,7 +1494,7 @@ async fn main() -> Result<()> {
                 if let Err(e) =
                     meridian::notification_responses::consume_responses(&meridian).await
                 {
-                    tracing::debug!(error = %e, "notification response consume skipped");
+                    tracing::debug!(error = %meridian::errors::chain(&e), "notification response consume skipped");
                 }
 
                 // Refresh the PM task cache (pm_tasks) every tick — interval-gated
@@ -1506,7 +1506,7 @@ async fn main() -> Result<()> {
                 // stuck at whatever it was at the last daemon restart. This is
                 // the only thing that keeps it live during normal operation.
                 if let Err(e) = run_pm_sync(&meridian, &cfg).await {
-                    tracing::warn!(error = %e, "pm_tasks refresh failed — using cached tasks");
+                    tracing::warn!(error = %meridian::errors::chain(&e), "pm_tasks refresh failed — using cached tasks");
                 }
             }
         }
@@ -1523,7 +1523,7 @@ async fn main() -> Result<()> {
     // close, not just a plain shutdown. Best-effort: a failed checkpoint must
     // not block shutdown.
     if let Err(e) = meridian::db::meridian::checkpoint_wal(&meridian).await {
-        tracing::warn!(error = %e, "WAL checkpoint on shutdown failed - continuing anyway");
+        tracing::warn!(error = %meridian::errors::chain(&e), "WAL checkpoint on shutdown failed - continuing anyway");
     }
     meridian.close().await;
 
@@ -1557,7 +1557,7 @@ async fn etl_tick(meridian: &meridian::db::SqlitePool) -> bool {
         }
         Err(e) if meridian::db::integrity::is_corrupt_error(&e) => {
             tracing::error!(
-                error = %e,
+                error = %meridian::errors::chain(&e),
                 "ETL run failed: meridian.db is corrupt - stopping the ETL until it is repaired"
             );
             // Distinct from `etl.failed` on purpose. The generic notice says
@@ -1580,7 +1580,7 @@ async fn etl_tick(meridian: &meridian::db::SqlitePool) -> bool {
             true
         }
         Err(e) => {
-            tracing::error!(error = %e, "ETL run failed");
+            tracing::error!(error = %meridian::errors::chain(&e), "ETL run failed");
             let _ = meridian::notices::raise(
                 meridian,
                 "etl.failed",

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -475,13 +475,52 @@ fn keep_attribute(kv: &mut KeyValue, pseudonym: &str) -> bool {
                 // A number the otel bridge stringified on its way here. See
                 // `is_bare_number` — this is a TYPE rescue, not a key exemption,
                 // and it deliberately runs last so an allowlisted key keeps its
-                // own treatment.
-                is_bare_number(s)
+                // own treatment. `is_user_scoped_key` is checked FIRST so the
+                // rescue can never resurrect an identifier that names the user's
+                // data just because it happens to be spelled in digits.
+                !is_user_scoped_key(&kv.key) && is_bare_number(s)
             }
         }
         // Bytes / array / kvlist can nest arbitrary content — drop.
         _ => false,
     }
+}
+
+/// Keys that name the USER's data rather than ours, and so must stay dropped
+/// no matter what shape their value happens to take.
+///
+/// # Why this list exists only for the numeric rescue
+/// Being absent from [`SAFE_STRING_KEYS`] is normally enough — an unlisted key
+/// is dropped. [`is_bare_number`] is the one path that keeps an unlisted key, so
+/// it is also the one path that could resurrect one of these by accident: a
+/// `task_id` is a `String` in this codebase (`worklog_pipeline::task_db`) and is
+/// usually `KAN-185`, which no rescue would touch — but a provider that numbers
+/// its issues would make the same field `"4711"`, and the rescue would ship it.
+///
+/// The list is deliberately about the KEY, not the value: a numeric ticket id is
+/// indistinguishable from a row count by inspection, so the only durable signal
+/// is what the field is called. Entries mirror the denied set pinned by
+/// `user_scoped_diagnostic_keys_stay_off_the_allowlist`, plus the identifier
+/// spellings actually logged at WARN/ERROR sites today.
+///
+/// Note this does NOT cover `IntValue` — `keep_attribute`'s first arm keeps
+/// every real integer for every key, which is pre-existing behaviour this change
+/// deliberately does not alter (`row_id`, an `i64`, ships on 65,940 records
+/// today). Narrowing that is a separate decision from fixing the `u64` bug.
+const USER_SCOPED_KEYS: &[&str] = &[
+    "task_key",
+    "task_id",
+    "ticket_key",
+    "ticket_id",
+    "issue_key",
+    "issue_id",
+    "path",
+    "window_title",
+    "app_name",
+];
+
+fn is_user_scoped_key(key: &str) -> bool {
+    USER_SCOPED_KEYS.contains(&key)
 }
 
 /// True when the WHOLE value is a plain number — the shape a numeric field
@@ -1115,6 +1154,30 @@ mod tests {
             keep(&mut as_string),
             "the two spellings of the same number must not disagree"
         );
+    }
+
+    /// The numeric rescue must not resurrect a user-scoped identifier that
+    /// happens to be spelled in digits.
+    ///
+    /// `task_id` is a `String` in this codebase and is normally `KAN-185`, which
+    /// no rescue would touch — but a provider that numbers its issues makes the
+    /// same field `"4711"`, and without [`USER_SCOPED_KEYS`] the rescue would
+    /// ship it. Found by grepping WARN/ERROR sites for identifier-shaped fields
+    /// after the rescue was already written, which is the check that should have
+    /// come first.
+    #[test]
+    fn the_numeric_rescue_never_resurrects_a_user_scoped_identifier() {
+        for key in USER_SCOPED_KEYS {
+            let mut numeric = str_attr(key, "4711");
+            assert!(
+                !keep(&mut numeric),
+                "{key} must stay dropped even when its value is all digits"
+            );
+        }
+        // The control: an operational field of the same shape still ships, or
+        // the rescue would have been pointless.
+        let mut operational = str_attr("timeout_s", "4711");
+        assert!(keep(&mut operational));
     }
 
     /// `json_pointer` replaces the clerk plugin's `path` field. `path` is on the

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -168,6 +168,25 @@ const SAFE_STRING_KEYS: &[&str] = &[
     "thread.name",
     "target",
     "level",
+    // A `serde_path_to_error` JSON pointer (`payload.client.sign_up.id`) — it
+    // names FIELDS of a schema we ship, never their values, so it carries no
+    // user content by construction.
+    //
+    // It exists as its own key because the obvious name, `path`, is on the DENY
+    // side ON PURPOSE (`user_scoped_diagnostic_keys_stay_off_the_allowlist`
+    // pins it) — `path` normally means a filesystem path. The clerk plugin
+    // originally logged this as `path` and reasoned, correctly, that a JSON
+    // pointer is safe to ship; it was dropped anyway, by a rule written for a
+    // different meaning of the same word. Widening `path` to fix that would
+    // have traded a real protection for a diagnostic. Renaming the field was
+    // the cheaper half of the trade.
+    "json_pointer",
+    // WHICH `meridian` binary a shell-out resolved to, as a closed set of
+    // literals (`staged`, `user_local_wrapper`, `path_lookup`, `env_override`,
+    // `other`) — see `install::bin_source`, whose tests pin that it can only
+    // ever return one of them. The full `bin` path stays denied: it is a home
+    // directory. This names our component, exactly as `provider`/`engine` do.
+    "bin_source",
     // ── protocol metadata (values are enums/verbs, not content) ──────────────
     "http.method",
     "http.request.method",
@@ -453,12 +472,56 @@ fn keep_attribute(kv: &mut KeyValue, pseudonym: &str) -> bool {
                 *s = scrub_paths(s);
                 true
             } else {
-                false
+                // A number the otel bridge stringified on its way here. See
+                // `is_bare_number` — this is a TYPE rescue, not a key exemption,
+                // and it deliberately runs last so an allowlisted key keeps its
+                // own treatment.
+                is_bare_number(s)
             }
         }
         // Bytes / array / kvlist can nest arbitrary content — drop.
         _ => false,
     }
+}
+
+/// True when the WHOLE value is a plain number — the shape a numeric field
+/// takes after `tracing-opentelemetry` stringifies it.
+///
+/// # Why this exists
+/// `tracing-opentelemetry` 0.28's `Visit` impl has no `record_u64`. The default
+/// from `tracing::field::Visit` therefore applies, and it forwards to
+/// `record_debug`, which emits a `StringValue`. So `timeout_s = t.as_secs()`
+/// (a `u64`) reaches this function as `"150"` while
+/// `timeout_s = t.as_secs_f64()` reaches it as a `DoubleValue` — the same field
+/// name and the same author intent, kept or dropped purely by Rust type. In
+/// production that meant every `cli_exec.rs` timeout shipped `timeout_s = null`
+/// while the distiller's shipped `210.0`.
+///
+/// # Why this is not a widening
+/// [`keep_attribute`]'s first arm ALREADY keeps every `IntValue`/`DoubleValue`
+/// unconditionally, for any key — the codebase's position is that a number
+/// cannot carry free text. This restores that position for numbers the bridge
+/// happened to stringify; it does not extend it. A key whose numeric value
+/// should not egress was already egressing as an `i64`.
+///
+/// # Why the whole value must parse
+/// `record_debug` also renders genuinely non-numeric fields — `?args` becomes
+/// `["plan-task-draft", "--note", "<the user's note>"]`, a `?path` becomes a
+/// home directory. Requiring the entire string to parse is what separates a
+/// stringified number from arbitrary `Debug` output; a leading-digits check
+/// (`"150ms"`, `"2026-08-24"`) would not.
+///
+/// Non-finite floats are excluded: `"inf"`/`"NaN"` parse as `f64` but are not
+/// values any of our sites emit, and letting bare words through would blunt the
+/// guard for no gain.
+fn is_bare_number(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    if s.parse::<i64>().is_ok() || s.parse::<u64>().is_ok() {
+        return true;
+    }
+    s.parse::<f64>().is_ok_and(f64::is_finite)
 }
 
 /// The one allowlisted key whose raw value must never egress verbatim.
@@ -979,6 +1042,101 @@ mod tests {
             .flat_map(|rl| rl.scope_logs)
             .flat_map(|sl| sl.log_records)
             .collect()
+    }
+
+    /// The bug this module could not see: `tracing-opentelemetry` 0.28 has no
+    /// `record_u64`.
+    ///
+    /// Its `Visit` impl covers `record_bool`/`record_f64`/`record_i64`/
+    /// `record_str`/`record_debug` and nothing else, so `tracing::field::Visit`'s
+    /// DEFAULT `record_u64` applies — and that forwards to `record_debug`, which
+    /// produces a `StringValue`. A field the author wrote as a number therefore
+    /// arrives here as the string `"150"`, misses the allowlist (nobody puts
+    /// `timeout_s` on a list of *string* keys), and is dropped.
+    ///
+    /// Measured in production 2026-08-24: every one of the 25 shipped
+    /// `cli_exec.rs` timeout records carries `timeout_s = null`, while the
+    /// distiller's `timeout_s = EMBED_TIMEOUT.as_secs_f64()` — an `f64`, so
+    /// `record_f64` — ships `210.0` on 3,329 records. Same field name, same
+    /// severity, same allowlist; only the Rust type differs.
+    ///
+    /// The blast radius is every `u64`/`usize` field on a WARN/ERROR site
+    /// (`count`, `len`, `rows`, `attempt`, `bytes`, …), which is why this is
+    /// fixed here rather than by casting at each call site: a cast fixes the
+    /// sites that exist today and silently reopens on the next one written.
+    #[test]
+    fn a_u64_field_stringified_by_the_otel_bridge_still_ships() {
+        let mut kv = str_attr("timeout_s", "150");
+        assert!(
+            keep(&mut kv),
+            "a numeric field must survive the allowlist even when the otel bridge \
+             stringified it - the author wrote a number and the record must carry one"
+        );
+    }
+
+    /// The guard that keeps the fix from becoming a hole.
+    ///
+    /// `record_debug` also handles genuinely non-numeric fields (`args = ?args`
+    /// renders `["plan-task-draft", "--note", "<the user's note>"]`), and those
+    /// must keep being dropped. Parsing the WHOLE value as a number is what
+    /// separates the two: a bare number cannot carry a path, a URL, a token, or
+    /// a sentence.
+    #[test]
+    fn debug_formatted_non_numeric_values_are_still_dropped() {
+        for value in [
+            r#"["plan-task-draft", "--note", "ship the thing"]"#,
+            "/Users/someone/.meridian/bin/meridian",
+            "150ms",
+            "2026-08-24",
+            "sess_abc123",
+            "",
+        ] {
+            let mut kv = str_attr("some_field", value);
+            assert!(
+                !keep(&mut kv),
+                "a non-numeric debug-formatted value must stay dropped: {value:?}"
+            );
+        }
+    }
+
+    /// A bare number is kept regardless of the KEY, so this must not become a
+    /// back door for a numeric identifier the allowlist deliberately denies.
+    /// It does not: `IntValue`/`DoubleValue` are ALREADY kept unconditionally
+    /// for every key (see `keep_attribute`'s first arm), so `user_id = 12345i64`
+    /// ships today. Treating the stringified `u64` the same way restores the
+    /// intended semantics rather than widening what egresses - which is exactly
+    /// why the fix belongs at the type level and not on the key list.
+    #[test]
+    fn a_stringified_number_is_kept_on_the_same_terms_as_a_real_one() {
+        let mut as_int = int_attr("rows_deleted", 42);
+        let mut as_string = str_attr("rows_deleted", "42");
+        assert!(keep(&mut as_int));
+        assert!(
+            keep(&mut as_string),
+            "the two spellings of the same number must not disagree"
+        );
+    }
+
+    /// `json_pointer` replaces the clerk plugin's `path` field. `path` is on the
+    /// DENY side deliberately (`user_scoped_diagnostic_keys_stay_off_the_allowlist`
+    /// pins it) because it normally means a filesystem path. Clerk's value is a
+    /// serde JSON pointer (`payload.session.status`) naming FIELDS of a schema we
+    /// ship, never their values - so it needed a key of its own rather than a
+    /// widening of `path`.
+    #[test]
+    fn the_clerk_json_pointer_ships_while_path_stays_denied() {
+        let mut pointer = str_attr("json_pointer", "payload.client.sign_up.id");
+        assert!(
+            keep(&mut pointer),
+            "the serde field path must ship - without it, diagnosing a clerk \
+             deserialization failure needs a raw-spool dig, which is the exact \
+             cost this field was added to avoid"
+        );
+        let mut filesystem_path = str_attr("path", "/Users/someone/Documents/secret.md");
+        assert!(
+            !keep(&mut filesystem_path),
+            "the filesystem `path` key must stay denied"
+        );
     }
 
     #[test]

--- a/tray/src-tauri/src/analytics/health.rs
+++ b/tray/src-tauri/src/analytics/health.rs
@@ -158,7 +158,29 @@ pub(crate) struct HealthSnapshot {
     /// The daemon process is alive.
     pub daemon_running: Option<bool>,
     /// `meridian.db` opened and answered a probe query.
+    ///
+    /// Deliberately NOT renamed or repurposed - existing dashboards read it,
+    /// and it answers a different question to [`HealthSnapshot::db_integrity`]:
+    /// this is "could we read it just now", which a database that is quietly
+    /// corrupting still answers `true` to.
     pub database_ready: Option<bool>,
+    /// The last startup integrity verdict: `verified`, `damaged`,
+    /// `unopenable`, `absent`, `inconclusive`, or `unknown`.
+    ///
+    /// Read from a sidecar file beside the database
+    /// ([`crate::repair_boot::last_probe_verdict`]), never from a row inside
+    /// it - the verdict that matters most describes a database that cannot be
+    /// opened, so storing it in that database would make it unreachable
+    /// exactly when it is worth having. That is the same trap that keeps the
+    /// `db.corrupt` NOTICE invisible on the machines it best describes, and
+    /// why `active_notice_ids` alone could not answer this.
+    ///
+    /// `unknown` is the honest and COMMON value: the tray only probes when no
+    /// daemon answers (`quick_check` reads every page, so scanning on every
+    /// healthy boot would tax the machines that need nothing). A working
+    /// install is therefore read from `database_ready: true` plus the ABSENCE
+    /// of `db.corrupt` in `active_notice_ids`, not from this field.
+    pub db_integrity: &'static str,
     /// The user's chosen LLM provider looks usable (installed, last test OK).
     pub llm_provider_ok: Option<bool>,
     /// That provider is usable but currently rate-limited — a soft,
@@ -240,6 +262,7 @@ impl Default for HealthSnapshot {
         Self {
             daemon_running: None,
             database_ready: None,
+            db_integrity: crate::repair_boot::VERDICT_UNKNOWN,
             llm_provider_ok: None,
             llm_provider_rate_limited: None,
             llm_provider: UNRECOGNISED_PROVIDER,
@@ -398,6 +421,10 @@ pub(crate) async fn snapshot(pool: &SqlitePool) -> HealthSnapshot {
     let snap = HealthSnapshot {
         daemon_running: h.daemon_running,
         database_ready: h.database_ready,
+        db_integrity: crate::repair_boot::last_probe_verdict(std::path::Path::new(
+            &crate::install::meridian_db_path(),
+        ))
+        .unwrap_or(crate::repair_boot::VERDICT_UNKNOWN),
         llm_provider_ok: h.llm_provider_ok,
         llm_provider_rate_limited: h.llm_provider_rate_limited,
         llm_provider: resolve_provider(&settings),
@@ -496,6 +523,24 @@ impl HealthSnapshot {
             }
             None => unset.push("llm_model".to_string()),
         }
+        // The ONE health field that belongs on the person rather than only on
+        // the event, and the reason is the rule this doc states above rather
+        // than an exception to it: `daemon_running` is excluded because it
+        // changes hour to hour, so "newest value only" would misread as
+        // current fact. Database damage is the opposite - it LATCHES. It
+        // cannot clear without an operator running a repair, so the newest
+        // value IS the current fact, for weeks at a time.
+        //
+        // It has to be here to be useful at all. A damaged install often
+        // cannot send `daily_usage` (that event needs a DB read, and
+        // `analytics::daily` returns early when it fails), so the event-only
+        // copy never arrives from exactly the machines worth finding.
+        // `app_active` carries person properties and needs no DB read, so this
+        // is the value that actually escapes a broken install.
+        person.insert(
+            "db_integrity".to_string(),
+            Value::String(self.db_integrity.to_string()),
+        );
         person.insert(
             "integrations_connected".to_string(),
             serde_json::json!(self.integrations_connected),
@@ -527,6 +572,13 @@ impl HealthSnapshot {
         props.insert(
             "health_observed_on".to_string(),
             Value::String(meridian_core::date::today_string()),
+        );
+        // Also a person property (see `write_person_properties`); kept here too
+        // so a query can see WHEN the verdict changed, which the person copy
+        // cannot show - it keeps only the newest value.
+        props.insert(
+            "health_db_integrity".to_string(),
+            Value::String(self.db_integrity.to_string()),
         );
         let mut put_bool = |k: &str, v: Option<bool>| {
             if let Some(b) = v {
@@ -987,12 +1039,70 @@ mod person_property_tests {
                 "{k} is momentary and must stay an event property"
             );
         }
+
+        // `db_integrity` IS on the person, and the distinction is the rule
+        // above rather than an exception to it: database damage LATCHES - it
+        // cannot clear without an operator running a repair - so "the newest
+        // value" is the current fact for weeks, unlike `daemon_running`.
+        // `database_ready` stays off precisely because it is the momentary
+        // half of the same subject: it answers "could we read it just now".
+        assert!(person.contains_key("db_integrity"));
+        assert!(!person.contains_key("database_ready"));
     }
 
     /// `support_id` must never become a person property. It legitimately
     /// changes (a second machine, a re-seed, the alpha window ending), and a
     /// person property keeps only the newest — which would silently orphan
     /// every error row recorded under the previous one. As an event property a
+    /// The verdict must reach PostHog as a PERSON property, not only as an
+    /// event property.
+    ///
+    /// A damaged install often cannot send `daily_usage` at all - that event
+    /// needs a DB read and `analytics::daily` returns early when it fails - so
+    /// the event-only copy never arrives from exactly the machines worth
+    /// finding. `app_active` carries person properties and needs no DB read.
+    /// If this ever moves to event-only, corrupt installs go silent again.
+    #[test]
+    fn db_integrity_reaches_posthog_as_a_person_property() {
+        let snap = HealthSnapshot {
+            db_integrity: crate::repair_boot::VERDICT_DAMAGED,
+            ..Default::default()
+        };
+        let mut person = Map::new();
+        let mut unset = Vec::new();
+        snap.write_person_properties(&mut person, &mut unset);
+        assert_eq!(
+            person.get("db_integrity").and_then(Value::as_str),
+            Some(crate::repair_boot::VERDICT_DAMAGED),
+            "a damaged install must be findable on the PostHog Persons list"
+        );
+
+        // And on the event too, where it is timestamped by health_observed_on.
+        let mut props = Map::new();
+        snap.write_properties(&mut props);
+        assert_eq!(
+            props.get("health_db_integrity").and_then(Value::as_str),
+            Some(crate::repair_boot::VERDICT_DAMAGED)
+        );
+    }
+
+    /// An install nobody scanned must not read as verified-healthy.
+    #[test]
+    fn an_unprobed_install_reports_unknown_not_healthy() {
+        let snap = HealthSnapshot::default();
+        let mut person = Map::new();
+        let mut unset = Vec::new();
+        snap.write_person_properties(&mut person, &mut unset);
+        assert_eq!(
+            person.get("db_integrity").and_then(Value::as_str),
+            Some(crate::repair_boot::VERDICT_UNKNOWN)
+        );
+        assert_ne!(
+            person.get("db_integrity").and_then(Value::as_str),
+            Some(crate::repair_boot::VERDICT_VERIFIED)
+        );
+    }
+
     /// DISTINCT recovers the full set.
     #[test]
     fn support_id_is_never_a_person_property() {

--- a/tray/src-tauri/src/commands/cli_exec.rs
+++ b/tray/src-tauri/src/commands/cli_exec.rs
@@ -74,6 +74,7 @@ pub(crate) async fn run_meridian(
             // only record a timeout leaves.
             tracing::warn!(
                 bin = %bin,
+                bin_source = crate::install::bin_source(&bin),
                 cwd = %home.display(),
                 timeout_s = timeout.as_secs(),
                 "{label}: timed out"
@@ -81,7 +82,12 @@ pub(crate) async fn run_meridian(
             return Err(format!("{label} timed out"));
         }
         Ok(Err(e)) => {
-            tracing::warn!(bin = %bin, error = %e, "{label} spawn failed");
+            tracing::warn!(
+                bin = %bin,
+                bin_source = crate::install::bin_source(&bin),
+                error = %e,
+                "{label} spawn failed"
+            );
             return Err(format!("spawn error: {e}"));
         }
         Ok(Ok(o)) => o,
@@ -103,7 +109,12 @@ pub(crate) async fn run_meridian(
         } else {
             stderr
         };
-        tracing::warn!(bin = %bin, code = ?output.status.code(), "{label} non-zero: {msg}");
+        tracing::warn!(
+            bin = %bin,
+            bin_source = crate::install::bin_source(&bin),
+            code = ?output.status.code(),
+            "{label} non-zero: {msg}"
+        );
         return Err(msg);
     }
     Ok(stdout)

--- a/tray/src-tauri/src/install.rs
+++ b/tray/src-tauri/src/install.rs
@@ -241,6 +241,51 @@ pub(crate) fn meridian_bin() -> String {
     }
 }
 
+/// Classify a resolved [`meridian_bin`] path into WHICH candidate won, as an
+/// enum-like `&'static str` safe to ship in telemetry.
+///
+/// # Why this exists rather than just logging the path
+/// [`meridian_bin`]'s own doc explains the failure this answers: a release tray
+/// calls the INSTALLED `meridian`, which can be OLDER than the tray asking it
+/// for a subcommand, and the candidate that won decides that. So the log sites
+/// in `commands::cli_exec` record `bin` for exactly this reason - and the full
+/// path is a home-directory path, so `telemetry_spool::redact` drops it and the
+/// shipped record answers nothing. Measured 2026-08-24: 65 `cli_exec.rs`
+/// records in central OO, not one carrying which binary ran.
+///
+/// This names OUR component, never the user's disk - the same justification
+/// `provider`/`engine` carry on `redact::SAFE_STRING_KEYS`. It CLASSIFIES an
+/// already-resolved path rather than re-running the resolution, so it cannot
+/// drift from what actually spawned.
+///
+/// The full path is still logged alongside it at DEBUG, where local
+/// full-fidelity capture keeps it for anyone reading `meridian logs`.
+pub(crate) fn bin_source(bin: &str) -> &'static str {
+    if std::env::var("MERIDIAN_BIN").is_ok_and(|p| p == bin) {
+        return "env_override";
+    }
+    // Checked as path segments so a user directory that merely CONTAINS the
+    // text (`~/projects/.meridian/bin/notes`) cannot be misread as the staged
+    // install. Windows separators included: the staged path is the only
+    // candidate that exists there.
+    let staged = bin.contains("/.meridian/bin/") || bin.contains("\\.meridian\\bin\\");
+    if staged {
+        return "staged";
+    }
+    if bin.contains("/.local/bin/") {
+        return "user_local_wrapper";
+    }
+    // No separator at all — `"meridian"` / `"meridian.exe"`, the bare last
+    // resort resolved through `$PATH`. This is the one that silently finds
+    // nothing on a per-user Windows install.
+    if !bin.contains('/') && !bin.contains('\\') {
+        return "path_lookup";
+    }
+    // A resolved absolute path that matches no known candidate: a dev build out
+    // of the checkout (`target/{debug,release}/meridian`), or something new.
+    "other"
+}
+
 /// The working directory to spawn the `meridian` CLI from — the companion to
 /// [`meridian_bin`], and it must be resolved with it, never independently.
 ///
@@ -332,6 +377,54 @@ pub(crate) fn meridian_db_path() -> String {
 
 #[cfg(test)]
 mod tests {
+
+    /// The classification must name our component, never the user's disk - and
+    /// must not be fooled by a user directory that merely contains the text.
+    #[test]
+    fn bin_source_classifies_every_candidate() {
+        assert_eq!(bin_source("/Users/x/.meridian/bin/meridian"), "staged");
+        assert_eq!(
+            bin_source("C:\\Users\\x\\.meridian\\bin\\meridian.exe"),
+            "staged"
+        );
+        assert_eq!(
+            bin_source("/Users/x/.local/bin/meridian"),
+            "user_local_wrapper"
+        );
+        assert_eq!(bin_source("meridian"), "path_lookup");
+        assert_eq!(bin_source("meridian.exe"), "path_lookup");
+        assert_eq!(bin_source("/repo/target/release/meridian"), "other");
+        // The trap a plain `.contains(".meridian/bin")` would fall into.
+        assert_eq!(
+            bin_source("/Users/x/projects/.meridian/bin-scripts/meridian"),
+            "other"
+        );
+    }
+
+    /// Every value is a fixed literal from a closed set - the property that
+    /// makes it safe to ship. A path that leaked through would fail this.
+    #[test]
+    fn bin_source_only_ever_returns_known_literals() {
+        const KNOWN: &[&str] = &[
+            "env_override",
+            "staged",
+            "user_local_wrapper",
+            "path_lookup",
+            "other",
+        ];
+        for probe in [
+            "/Users/someone/.meridian/bin/meridian",
+            "/Users/someone/.local/bin/meridian",
+            "meridian",
+            "/tmp/whatever/meridian",
+            "",
+        ] {
+            assert!(
+                KNOWN.contains(&bin_source(probe)),
+                "bin_source leaked a non-literal for {probe:?}"
+            );
+        }
+    }
     use super::*;
 
     /// Is `name` one of `p`'s path components?

--- a/tray/src-tauri/src/repair_boot.rs
+++ b/tray/src-tauri/src/repair_boot.rs
@@ -277,7 +277,7 @@ fn probe_and_heal(db_path: &Path, key_hex: Option<&str>, key_trust: KeyTrust) ->
             if let Err(e) = meridian::db::repair::marker::request(db_path) {
                 span.record("outcome", "marker_write_failed");
                 span.record("otel.status_code", "ERROR");
-                tracing::error!(error = %e, "could not write the repair marker - skipping the automatic repair");
+                tracing::error!(error = %meridian::errors::chain(&e), "could not write the repair marker - skipping the automatic repair");
                 return None;
             }
             match execute_pending_repair(db_path, key_hex) {
@@ -388,12 +388,12 @@ fn fresh_start(db_path: &Path, kind: &str, error: String) -> Outcome {
     if let Err(e) = meridian::db::repair::marker::request(db_path) {
         span.record("outcome", "marker_write_failed");
         span.record("otel.status_code", "ERROR");
-        tracing::error!(error = %e, "could not write the repair marker - leaving the database in place");
+        tracing::error!(error = %meridian::errors::chain(&e), "could not write the repair marker - leaving the database in place");
         return Outcome::Failed { error };
     }
     let result = set_aside_database(db_path, kind);
     if let Err(e) = meridian::db::repair::marker::clear(db_path) {
-        tracing::error!(error = %e, "could not clear the repair marker - the daemon will stay down until it expires");
+        tracing::error!(error = %meridian::errors::chain(&e), "could not clear the repair marker - the daemon will stay down until it expires");
     }
     match result {
         Ok(backup) => {
@@ -405,7 +405,7 @@ fn fresh_start(db_path: &Path, kind: &str, error: String) -> Outcome {
         Err(e) => {
             span.record("outcome", "set_aside_failed");
             span.record("otel.status_code", "ERROR");
-            tracing::error!(error = %e, "could not move the database aside - leaving it in place");
+            tracing::error!(error = %meridian::errors::chain(&e), "could not move the database aside - leaving it in place");
             Outcome::Failed {
                 error: format!("{e:#}"),
             }
@@ -429,7 +429,7 @@ fn execute_pending_repair(db_path: &Path, key_hex: Option<&str>) -> Outcome {
     // Clear before reporting: a panic while formatting the summary must not
     // leave the marker behind and the daemon permanently down.
     if let Err(e) = meridian::db::repair::marker::clear(db_path) {
-        tracing::error!(error = %e, "could not clear the repair marker - the daemon will stay down until it expires");
+        tracing::error!(error = %meridian::errors::chain(&e), "could not clear the repair marker - the daemon will stay down until it expires");
     }
 
     match outcome {
@@ -445,7 +445,7 @@ fn execute_pending_repair(db_path: &Path, key_hex: Option<&str>) -> Outcome {
             }
         }
         Err(e) => {
-            tracing::error!(error = %e, "database repair failed - the original is unchanged");
+            tracing::error!(error = %meridian::errors::chain(&e), "database repair failed - the original is unchanged");
             Outcome::Failed {
                 error: format!("{e:#}"),
             }
@@ -512,7 +512,7 @@ async fn probe_database(db_path: &Path, key_hex: Option<&str>) -> Probe {
             };
         }
         Err(e) => {
-            tracing::warn!(error = %e, "startup probe could not open meridian.db for a reason that is not corruption - proceeding normally");
+            tracing::warn!(error = %meridian::errors::chain(&e), "startup probe could not open meridian.db for a reason that is not corruption - proceeding normally");
             return Probe::Healthy;
         }
     };
@@ -544,7 +544,7 @@ async fn probe_database(db_path: &Path, key_hex: Option<&str>) -> Probe {
             error: format!("{e:#}"),
         },
         Ok(Err(e)) => {
-            tracing::warn!(error = %e, "startup integrity probe errored inconclusively - proceeding normally");
+            tracing::warn!(error = %meridian::errors::chain(&e), "startup integrity probe errored inconclusively - proceeding normally");
             Probe::Healthy
         }
     }

--- a/tray/src-tauri/src/repair_boot.rs
+++ b/tray/src-tauri/src/repair_boot.rs
@@ -117,13 +117,119 @@ pub enum Outcome {
     FreshStart { backup: String },
 }
 
+/// `quick_check` ran and found nothing wrong. The ONLY positive health verdict
+/// this module can produce.
+pub(crate) const VERDICT_VERIFIED: &str = "verified";
+/// No database file yet - a fresh install.
+pub(crate) const VERDICT_ABSENT: &str = "absent";
+/// The probe ran but could not conclude (timeout, or a non-corruption error).
+pub(crate) const VERDICT_INCONCLUSIVE: &str = "inconclusive";
+/// `quick_check` reported structural damage, or a read failed with SQLITE_CORRUPT
+/// (code 11). Page 1 is readable, so the file still ATTACHes and is repairable.
+pub(crate) const VERDICT_DAMAGED: &str = "damaged";
+/// A read failed with SQLITE_NOTADB (code 26) - page 1 is unreadable UNDER THE
+/// KEY THAT WAS USED.
+///
+/// Kept distinct from [`VERDICT_DAMAGED`] on purpose, and deliberately not
+/// called "corrupt": SQLCipher returns code 26 both for a damaged page 1 and
+/// for a perfectly healthy database opened with the WRONG KEY, and nothing at
+/// this layer can tell them apart (see [`Probe::Unopenable`]). Collapsing the
+/// two into one "corrupt" label would rebuild exactly the ambiguity this
+/// telemetry exists to remove - measured 2026-08-24, 58 fleet installs could
+/// not open their database and only 28 showed code 11, leaving 30 whose cause
+/// is still unknown.
+pub(crate) const VERDICT_UNOPENABLE: &str = "unopenable";
+
+/// No verdict was ever recorded - the COMMON case, because
+/// [`run_auto_if_needed`] only probes when no daemon answers, so a machine
+/// whose daemon starts normally never scans its database at all. Distinct from
+/// [`VERDICT_INCONCLUSIVE`], which means a probe ran and could not decide.
+pub(crate) const VERDICT_UNKNOWN: &str = "unknown";
+
+/// The closed set every persisted verdict must belong to. Read back through
+/// [`last_probe_verdict`], which returns one of THESE `&'static str`s rather
+/// than the file's contents - so a corrupted or hand-edited sidecar can never
+/// put arbitrary text into a telemetry property.
+const VERDICTS: &[&str] = &[
+    VERDICT_VERIFIED,
+    VERDICT_ABSENT,
+    VERDICT_INCONCLUSIVE,
+    VERDICT_DAMAGED,
+    VERDICT_UNOPENABLE,
+];
+
+/// Where the last verdict is persisted: beside the database, never inside it.
+///
+/// That placement is the whole point. The verdict that matters most describes a
+/// database that could not be opened at all, so anywhere inside `meridian.db`
+/// is unreachable exactly when the value is worth having - the same trap that
+/// makes the `db.corrupt` NOTICE (a row in that database) invisible on the
+/// machines it most needs to describe.
+fn verdict_path(db_path: &Path) -> PathBuf {
+    db_path.with_extension("db.probe")
+}
+
+/// Persist the probe verdict. Best-effort: a failure here must never affect
+/// whether the database gets healed, so it logs at DEBUG and moves on.
+fn record_probe_verdict(db_path: &Path, verdict: &str) {
+    let path = verdict_path(db_path);
+    if let Err(e) = std::fs::write(&path, verdict) {
+        tracing::debug!(
+            error = %e,
+            verdict,
+            "could not persist the startup probe verdict - analytics will report it as unknown"
+        );
+    }
+}
+
+/// The last persisted startup probe verdict, or `None` if none was ever
+/// written (the common case: [`run_auto_if_needed`] only probes when no daemon
+/// answers, so a machine whose daemon starts normally never scans).
+///
+/// Returns a `&'static str` from [`VERDICTS`] rather than the file's bytes, so
+/// a truncated, corrupted, or hand-edited sidecar reads as `None` instead of
+/// putting arbitrary text into a shipped telemetry property.
+pub(crate) fn last_probe_verdict(db_path: &Path) -> Option<&'static str> {
+    let raw = std::fs::read_to_string(verdict_path(db_path)).ok()?;
+    let raw = raw.trim();
+    VERDICTS.iter().copied().find(|v| *v == raw)
+}
+
+/// Why a probe concluded "do not repair".
+///
+/// The HEALING decision is identical for all three - leave the file alone - so
+/// [`probe_database`] deliberately collapses them for that purpose. The
+/// ANALYTICS answer is not identical, and collapsing them there would report a
+/// database we never scanned as verified-healthy. Only [`NoAction::Verified`]
+/// is evidence of health; the other two are evidence of nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NoAction {
+    /// `quick_check` ran to completion and returned no problems.
+    Verified,
+    /// No database file exists yet - a fresh install the daemon has not
+    /// created its database for.
+    Absent,
+    /// The probe could not reach a verdict: it timed out, or failed with an
+    /// error that is not a corruption signature. **Not** evidence of health.
+    Inconclusive,
+}
+
+impl NoAction {
+    fn verdict(self) -> &'static str {
+        match self {
+            Self::Verified => VERDICT_VERIFIED,
+            Self::Absent => VERDICT_ABSENT,
+            Self::Inconclusive => VERDICT_INCONCLUSIVE,
+        }
+    }
+}
+
 /// What the startup probe concluded about the on-disk `meridian.db`.
 #[derive(Debug)]
 enum Probe {
-    /// Opens and passes `quick_check` - or is absent, or the probe could not
-    /// tell (inconclusive errors and timeouts deliberately land here; see
-    /// [`probe_database`]).
-    Healthy,
+    /// Nothing to repair - see [`NoAction`] for which of the three reasons,
+    /// which matters to analytics even though it does not matter to healing.
+    Healthy(NoAction),
     /// Opens, but `quick_check` reports structural damage. Repairable in
     /// place - page 1 is readable, so the salvage can ATTACH it.
     Damaged { problems: Vec<String> },
@@ -248,17 +354,18 @@ fn probe_and_heal(db_path: &Path, key_hex: Option<&str>, key_trust: KeyTrust) ->
     let _enter = span.enter();
 
     let probe = tauri::async_runtime::block_on(probe_database(db_path, key_hex));
-    span.record(
-        "verdict",
-        match &probe {
-            Probe::Healthy => "healthy",
-            Probe::Damaged { .. } => "damaged",
-            Probe::Unopenable { .. } => "unopenable",
-        },
-    );
+    let verdict = match &probe {
+        Probe::Healthy(reason) => reason.verdict(),
+        Probe::Damaged { .. } => VERDICT_DAMAGED,
+        Probe::Unopenable { .. } => VERDICT_UNOPENABLE,
+    };
+    span.record("verdict", verdict);
+    // Persisted beside the database so the analytics snapshot can report it
+    // even when the database itself cannot be opened - see `verdict_path`.
+    record_probe_verdict(db_path, verdict);
 
     match probe {
-        Probe::Healthy => {
+        Probe::Healthy(_) => {
             span.record("outcome", "none");
             None
         }
@@ -490,7 +597,7 @@ where
 )]
 async fn probe_database(db_path: &Path, key_hex: Option<&str>) -> Probe {
     if !db_path.exists() {
-        return Probe::Healthy; // fresh install - the daemon will create it
+        return Probe::Healthy(NoAction::Absent); // the daemon will create it
     }
     let uri = format!("sqlite://{}", db_path.display());
     let pool = match meridian_core::db_crypto::open_pool_with_key_readonly(&uri, key_hex).await {
@@ -513,7 +620,7 @@ async fn probe_database(db_path: &Path, key_hex: Option<&str>) -> Probe {
         }
         Err(e) => {
             tracing::warn!(error = %meridian::errors::chain(&e), "startup probe could not open meridian.db for a reason that is not corruption - proceeding normally");
-            return Probe::Healthy;
+            return Probe::Healthy(NoAction::Inconclusive);
         }
     };
     let checked = tokio::time::timeout(
@@ -528,9 +635,9 @@ async fn probe_database(db_path: &Path, key_hex: Option<&str>) -> Probe {
                 timeout_secs = PROBE_TIMEOUT.as_secs(),
                 "startup integrity probe timed out - proceeding normally rather than blocking the tray"
             );
-            Probe::Healthy
+            Probe::Healthy(NoAction::Inconclusive)
         }
-        Ok(Ok(problems)) if problems.is_empty() => Probe::Healthy,
+        Ok(Ok(problems)) if problems.is_empty() => Probe::Healthy(NoAction::Verified),
         Ok(Ok(problems)) => Probe::Damaged { problems },
         Ok(Err(e)) if meridian::db::integrity::is_corrupt_error(&e) => Probe::Damaged {
             problems: vec![format!("{e:#}")],
@@ -545,7 +652,7 @@ async fn probe_database(db_path: &Path, key_hex: Option<&str>) -> Probe {
         },
         Ok(Err(e)) => {
             tracing::warn!(error = %meridian::errors::chain(&e), "startup integrity probe errored inconclusively - proceeding normally");
-            Probe::Healthy
+            Probe::Healthy(NoAction::Inconclusive)
         }
     }
 }
@@ -734,10 +841,16 @@ mod probe_tests {
     async fn probe_reports_healthy_for_absent_and_sound_databases() {
         let dir = tempfile::tempdir().unwrap();
         let db = dir.path().join("meridian.db");
-        assert!(matches!(probe_database(&db, None).await, Probe::Healthy));
+        assert!(matches!(
+            probe_database(&db, None).await,
+            Probe::Healthy(..)
+        ));
 
         create_sound_db(&db).await;
-        assert!(matches!(probe_database(&db, None).await, Probe::Healthy));
+        assert!(matches!(
+            probe_database(&db, None).await,
+            Probe::Healthy(..)
+        ));
     }
 
     /// A file that cannot even be opened under the configured key is the
@@ -1047,6 +1160,79 @@ mod probe_tests {
 #[cfg(test)]
 mod tests {
     use meridian::db::repair::{RepairReport, TableOutcome};
+
+    /// A verdict written by one release must still read back on the next, and
+    /// nothing outside the closed set may ever reach a telemetry property.
+    #[test]
+    fn a_persisted_verdict_round_trips_and_rejects_anything_unrecognised() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("meridian.db");
+
+        // Never probed - the common case on a machine whose daemon starts fine.
+        assert_eq!(super::last_probe_verdict(&db), None);
+
+        for verdict in super::VERDICTS {
+            super::record_probe_verdict(&db, verdict);
+            assert_eq!(super::last_probe_verdict(&db), Some(*verdict));
+        }
+
+        // A truncated, hand-edited or corrupted sidecar must read as "never
+        // recorded", NOT as arbitrary text shipped to PostHog as a property.
+        for junk in [
+            "",
+            "corrupt",
+            "healthy",
+            "../../etc/passwd",
+            "verified\u{0}x",
+        ] {
+            std::fs::write(db.with_extension("db.probe"), junk).expect("write");
+            assert_eq!(
+                super::last_probe_verdict(&db),
+                None,
+                "unrecognised sidecar content must not reach telemetry: {junk:?}"
+            );
+        }
+    }
+
+    /// The sidecar must live beside the database, never inside it - the whole
+    /// point is to survive a database that cannot be opened.
+    #[test]
+    fn the_verdict_sidecar_is_a_separate_file_from_the_database() {
+        let db = std::path::Path::new("/tmp/x/meridian.db");
+        let sidecar = super::verdict_path(db);
+        assert_ne!(sidecar, db);
+        assert_eq!(sidecar.parent(), db.parent());
+        assert_eq!(sidecar.file_name().unwrap(), "meridian.db.probe");
+    }
+
+    /// Only a completed `quick_check` may report health. An absent file and an
+    /// inconclusive probe both mean "do not repair", and collapsing them into
+    /// the positive verdict is exactly how a never-scanned database would come
+    /// to read as verified-healthy in PostHog.
+    #[test]
+    fn only_a_completed_check_reports_the_positive_verdict() {
+        assert_eq!(super::NoAction::Verified.verdict(), super::VERDICT_VERIFIED);
+        assert_eq!(super::NoAction::Absent.verdict(), super::VERDICT_ABSENT);
+        assert_eq!(
+            super::NoAction::Inconclusive.verdict(),
+            super::VERDICT_INCONCLUSIVE
+        );
+        assert_ne!(super::NoAction::Absent.verdict(), super::VERDICT_VERIFIED);
+        assert_ne!(
+            super::NoAction::Inconclusive.verdict(),
+            super::VERDICT_VERIFIED
+        );
+    }
+
+    /// `damaged` (code 11) and `unopenable` (code 26) must stay distinct.
+    /// Code 26 is returned both for a damaged page 1 AND for a healthy database
+    /// opened with the wrong key, so folding them into one "corrupt" label
+    /// rebuilds the ambiguity this telemetry exists to remove.
+    #[test]
+    fn the_two_failure_verdicts_are_never_the_same_value() {
+        assert_ne!(super::VERDICT_DAMAGED, super::VERDICT_UNOPENABLE);
+        assert!(!super::VERDICTS.contains(&"corrupt"));
+    }
 
     fn outcome(table: &str, copied: u64, unreadable: u64, empty: bool) -> TableOutcome {
         TableOutcome {

--- a/tray/src-tauri/vendor/tauri-plugin-clerk/src/lib.rs
+++ b/tray/src-tauri/vendor/tauri-plugin-clerk/src/lib.rs
@@ -200,9 +200,18 @@ impl<R: Runtime, T: Manager<R>> crate::ClerkExt<R> for T {
                         // backfill_clerk_client_json doesn't yet normalize —
                         // extend it (see json_backfill's tests for the
                         // pattern) rather than re-swallowing the error.
+                        // `json_pointer`, NOT `path`: the value is safe to ship
+                        // either way, but `path` is denied by
+                        // `telemetry_spool::redact` on purpose (it normally means
+                        // a filesystem path), so naming it that dropped it from
+                        // every shipped record - and this field exists precisely
+                        // so a failure here does NOT need a raw-spool dig. The
+                        // 2026-08-24 `missing field \`id\`` incident was
+                        // diagnosed without it, by enumerating the model's
+                        // required fields by hand.
                         tracing::warn!(
                             error = %e.inner(),
-                            path = %e.path(),
+                            json_pointer = %e.path(),
                             "clerk: auth event JSON still failed to deserialize after field \
                              backfill — the offline session cache will not reflect this \
                              sign-in, so a cold start without network will show signed-out"


### PR DESCRIPTION
> **Stacked on #871** — it needs that PR's `repair_boot.rs` changes, so the diff here shows both until #871 merges. Review the last commit (`2246e789`) for this change.

Makes "is this install's database corrupt or healthy" answerable from PostHog, and traceable from there into the OO error logs.

## Why the existing signals could not answer it

| signal | why it falls short |
|---|---|
| `database_ready` | only "did a read succeed just now" - a database that is quietly corrupting still answers `true` |
| `db.corrupt` in `active_notice_ids` | the notice is a **row in the broken database**, so it cannot be raised on the machines it best describes |
| `daily_usage` health snapshot | that event needs a DB read; `analytics::daily` returns early when it fails, so a broken install sends **nothing at all** |

That last one is the trap: the machines worth finding are exactly the ones that go silent. Measured 2026-08-24 — 58 of 758 reporting hosts cannot open their database, and one logged 12,267 crash-loop records in 7 days without ever sending a `daily_usage`.

## What this does

`repair_boot`'s startup probe already computed a verdict and threw it away. It is now persisted to a sidecar file **beside** the database (`meridian.db.probe`) — never inside it, since the verdict that matters most describes a database that cannot be opened — and shipped as `db_integrity`.

**It rides as a PERSON property as well as an event property**, which is what makes it reach you: `app_active` carries person properties, fires daily, and needs no DB read.

That is an addition to the module's *"momentary state stays off the person"* rule rather than an exception, and the distinction is the rule itself: `daemon_running` is excluded because it changes hour to hour, so "newest value only" misreads as current fact. Database damage **latches** — it cannot clear without an operator running a repair — so the newest value *is* the current fact, for weeks. `database_ready` stays off the person precisely because it is the momentary half of the same subject. `momentary_state_stays_off_the_person` now asserts both directions explicitly.

## Three things it deliberately does not do

**It does not claim health it has not measured.** `Probe::Healthy` collapsed four situations — verified clean, file absent, probe timed out, inconclusive error — because the *healing* decision is the same for all four. The analytics answer is not, so `NoAction` splits them and only a completed `quick_check` reports `verified`. An install nobody scanned reports `unknown`, which is the **common** case (the tray only probes when no daemon answers, because `quick_check` reads every page) and is the honest one. A working install is read from `database_ready: true` plus the absence of `db.corrupt`, not from this field.

**It does not collapse code 11 and code 26 into "corrupt".** Code 26 is returned both for a damaged page 1 **and for a healthy database opened with the wrong key**, and nothing at this layer distinguishes them. That distinction is the 58/28/30 fleet split; folding it away would rebuild the exact ambiguity this exists to remove. They ship as `damaged` and `unopenable`, and `the_two_failure_verdicts_are_never_the_same_value` asserts `"corrupt"` is not in the set.

**It ships only the discriminant.** `Probe::Damaged { problems }` carries `quick_check` output (page numbers, table names) and `Unopenable { error }` can carry a path — the same rule the module already states for notices. `last_probe_verdict` returns a `&'static str` from a closed set rather than the file's bytes, so a truncated, corrupted or hand-edited sidecar reads as `unknown` instead of putting arbitrary text into a shipped property.

## The OO join needed no work

Every PostHog event already carries `support_id` — the same `local_host_pseudonym` value that is `host_name` in OpenObserve. So:

```
PostHog: person where db_integrity = 'damaged'  →  copy support_id
OO:      SELECT * FROM default WHERE host_name = '<support_id>'
```

With #871 landed, those OO rows now carry the SQLite cause rather than a bare `failed to open SQLite at <url>`, which is what makes the second half of the request work.

## Tests

6 added: verdict round-trip and rejection of unrecognised sidecar content, sidecar-is-a-separate-file, only-a-completed-check-reports-health, the two failure verdicts staying distinct, person-property delivery, and unprobed-reports-unknown. `cargo test --workspace` green (27 suites), fmt + clippy clean.

## Note

`unknown` will dominate at first — most installs never probe. If you want a positive `verified` from healthy machines too, that needs the daemon's own startup `quick_check` (`main.rs:1216`, runs on every daemon start) to write the same sidecar. Deliberately left out: it is a second writer to that file and wants its own think, and the corrupt-install case you asked about is fully covered without it.