### PR TITLE
fix(daemon): catch the other cause-dropping spelling, and the failed board add

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -100,6 +100,57 @@ mod tests {
         }
     }
 
+    /// Does this source line log an error in a way that DROPS its cause?
+    ///
+    /// Extracted from the scan so the scan's own coverage is testable. That is
+    /// not ceremony: the previous version matched only `error = %e`, `main.rs`
+    /// was added to `CONVERTED` while three of its sites used a positional
+    /// format placeholder instead, and the test passed - recording coverage it
+    /// did not provide. A predicate nothing exercises is indistinguishable from
+    /// one that works.
+    ///
+    /// Two spellings, both rendering only the outermost `.context()`:
+    /// - `error = %e`
+    /// - `tracing::error!("… failed: {}", e)` - which also breaks the repo's
+    ///   "structured fields, no format strings for data values" rule.
+    ///
+    /// Only the POSITIONAL `{}` form counts. Inline named captures
+    /// (`"{label}: timed out"`) are pervasive, usually name one of our own
+    /// static labels, and sweeping them belongs in its own change.
+    fn drops_the_cause(line: &str) -> bool {
+        if line.trim_start().starts_with("//") {
+            return false;
+        }
+        line.contains("error = %e") || (line.contains("tracing::") && line.contains("{}\", "))
+    }
+
+    /// The scan must catch BOTH spellings, and must not fire on the fixed form.
+    #[test]
+    fn the_scan_catches_every_cause_dropping_spelling() {
+        assert!(drops_the_cause(
+            r#"tracing::warn!(error = %e, "fetch failed");"#
+        ));
+        assert!(drops_the_cause(
+            r#"tracing::error!("cleanup_incomplete_runs failed: {}", e),"#
+        ));
+        assert!(
+            drops_the_cause(
+                r#"        Err(e) => tracing::error!("intelligence run failed: {}", e),"#
+            ),
+            "the exact spelling that slipped past the original scan"
+        );
+
+        // The fixed form, and things that must not trip it.
+        assert!(!drops_the_cause(
+            r#"tracing::warn!(error = %meridian::errors::chain(&e), "fetch failed");"#
+        ));
+        assert!(!drops_the_cause(r#"// tracing::warn!(error = %e, "…");"#));
+        assert!(
+            !drops_the_cause(r#"tracing::warn!(bin = %bin, "{label}: timed out");"#),
+            "inline named captures are out of scope - see drops_the_cause's doc"
+        );
+    }
+
     /// The database modules converted by this change must not reintroduce an
     /// **unjustified** bare `%e`, which is how the fleet lost its corruption
     /// evidence in the first place.
@@ -161,7 +212,8 @@ mod tests {
             let prod = src.split_once("\n#[cfg(test)]").map_or(*src, |(a, _)| a);
             let offenders: Vec<&str> = prod
                 .lines()
-                .filter(|l| l.contains("error = %e") && !l.trim_start().starts_with("//"))
+                .filter(|l| !l.trim_start().starts_with("//"))
+                .filter(|l| drops_the_cause(l))
                 .filter(|l| !l.contains("not-anyhow:"))
                 .map(str::trim)
                 .collect();
@@ -171,7 +223,11 @@ mod tests {
                  .context() and drops the cause before it can egress. Use \
                  `error = %crate::errors::chain(&e)` - or, if the value is not an \
                  `anyhow::Error` and so has no chain to walk, keep `%e` and say why \
-                 with a `// not-anyhow: …` comment on the same line. \
+                 with a `// not-anyhow: …` comment on the same line. This scan \
+                 matches BOTH spellings - `error = %e` and a positional `{{}}` \
+                 format placeholder - because `main.rs` was added to this list \
+                 while three of its sites used the second one, so the entry \
+                 recorded coverage the scan did not provide. \
                  Offending line(s): {offenders:#?}"
             );
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1157,7 +1157,10 @@ async fn main() -> Result<()> {
             deleted_partial_sessions = n,
             "cleaned up incomplete ETL run"
         ),
-        Err(e) => tracing::error!("cleanup_incomplete_runs failed: {}", e),
+        Err(e) => tracing::error!(
+            error = %meridian::errors::chain(&e),
+            "cleanup_incomplete_runs failed"
+        ),
     }
 
     // 7a-bis. Same recovery, for the worklog pipeline's own ledger: an hour left
@@ -1172,7 +1175,10 @@ async fn main() -> Result<()> {
             reset_count = n,
             "reset worklog hour(s) stuck in generating from a previous crash"
         ),
-        Err(e) => tracing::error!("reset_stuck_generating_hours failed: {}", e),
+        Err(e) => tracing::error!(
+            error = %meridian::errors::chain(&e),
+            "reset_stuck_generating_hours failed"
+        ),
     }
 
     // 7b. Shared handles the poll loop uses to signal ETL ticks to observers.
@@ -1277,7 +1283,10 @@ async fn main() -> Result<()> {
             }
         }
         if let Err(e) = run_pm_sync(&meridian, &cfg).await {
-            tracing::error!("intelligence run failed: {}", e);
+            tracing::error!(
+                error = %meridian::errors::chain(&e),
+                "intelligence run failed"
+            );
         }
     }
 

--- a/src/pm_worklog/create_github.rs
+++ b/src/pm_worklog/create_github.rs
@@ -403,6 +403,39 @@ pub(super) fn is_missing_project_scope(err: &GqlError) -> bool {
 
 // ── Network calls ────────────────────────────────────────────────────────────
 
+/// Whether a response carrying BOTH `data` and `errors` may be accepted.
+///
+/// [`has_usable_data`] answers "did anything come back", which was the right
+/// question for ONE caller and was then applied to all three. GitHub reports an
+/// unresolvable board out of several as a partial response, and
+/// `board_repos_from_response` already skips the nulls - so that query must
+/// tolerate it. A single-subject query or a MUTATION must not: there, a partial
+/// response means the one thing asked for did not happen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Partial {
+    /// The multi-board query. One null board among several is normal.
+    Tolerate,
+    /// Everything else, including every mutation.
+    Reject,
+}
+
+/// The pure policy decision, split out so it is testable without HTTP.
+pub(super) fn partial_is_acceptable(partial: Partial, v: &Value) -> bool {
+    partial == Partial::Tolerate && has_usable_data(v)
+}
+
+/// Did `addProjectV2ItemById` actually return an item?
+///
+/// Checked in addition to [`partial_is_acceptable`] rather than instead of it:
+/// the policy gate only fires when GitHub sends an `errors` array, and a 200
+/// with no errors and a null item would otherwise still read as success. The
+/// mutation asks for `{ item { id } }`, so a real add always carries an id.
+pub(super) fn board_item_was_added(v: &Value) -> bool {
+    v.pointer("/data/addProjectV2ItemById/item/id")
+        .and_then(Value::as_str)
+        .is_some_and(|id| !id.is_empty())
+}
+
 /// POST a GraphQL `payload`, returning the parsed body. Surfaces a GraphQL-level
 /// `errors` entry as a real error — see [`graphql_error`] on why HTTP status is
 /// not enough.
@@ -410,6 +443,7 @@ async fn graphql(
     github: &GitHubConfig,
     client: &reqwest::Client,
     payload: &Value,
+    partial: Partial,
 ) -> Result<Value> {
     let resp = client
         .post(GRAPHQL_URL)
@@ -431,7 +465,7 @@ async fn graphql(
         // A partial response is the normal way GitHub reports one unresolvable
         // board out of several, and `board_repos_from_response` already skips
         // whichever came back null.
-        if !has_usable_data(&v) {
+        if !partial_is_acceptable(partial, &v) {
             if is_missing_project_scope(&err) {
                 bail!(
                     "your GitHub connection is missing the project scope - reconnect GitHub in \
@@ -452,7 +486,13 @@ async fn graphql(
 
 /// The authenticated user's login, for the create's `assignees`.
 async fn fetch_viewer_login(github: &GitHubConfig, client: &reqwest::Client) -> Result<String> {
-    let v = graphql(github, client, &json!({ "query": "{ viewer { login } }" })).await?;
+    let v = graphql(
+        github,
+        client,
+        &json!({ "query": "{ viewer { login } }" }),
+        Partial::Reject,
+    )
+    .await?;
     v.pointer("/data/viewer/login")
         .and_then(Value::as_str)
         .map(str::to_string)
@@ -468,7 +508,10 @@ async fn fetch_board_repos(
         return Ok(Vec::new());
     }
     let payload = json!({ "query": board_repos_query(&github.project_ids) });
-    let v = graphql(github, client, &payload).await?;
+    // The ONE caller partial tolerance was written for: GitHub reports an
+    // unresolvable board among several this way, and `board_repos_from_response`
+    // skips whichever came back null.
+    let v = graphql(github, client, &payload, Partial::Tolerate).await?;
     let boards = board_repos_from_response(&v, &github.project_ids);
     tracing::debug!(
         boards = boards.len(),
@@ -485,18 +528,89 @@ async fn add_to_board(
     project_id: &str,
     content_id: &str,
 ) -> Result<()> {
-    graphql(
+    let v = graphql(
         github,
         client,
         &add_to_board_payload(project_id, content_id),
+        Partial::Reject,
     )
     .await?;
+    // Belt and braces. `Partial::Reject` covers the case where GitHub sends an
+    // `errors` array; this covers a 200 with no errors and a null item, which
+    // would otherwise still be read as a successful add.
+    if !board_item_was_added(&v) {
+        bail!(
+            "GitHub accepted the request but returned no board item - the issue was created \
+             but not added to the project board"
+        );
+    }
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The board MUTATION must not inherit the multi-board query's tolerance
+    /// for a partial response.
+    ///
+    /// GitHub answers a failed `addProjectV2ItemById` with HTTP 200, a non-null
+    /// `data` object whose `addProjectV2ItemById` is null, and an `errors`
+    /// entry. `has_usable_data` sees the non-null `data` and says "usable" -
+    /// correct for the boards query it was written for (one unresolvable board
+    /// out of several, and `board_repos_from_response` skips the nulls), and
+    /// exactly wrong here: `add_to_board` discarded the result, so the create
+    /// flow logged success for an issue that was never added to the board.
+    ///
+    /// That is the same defect this module was written to fix, reintroduced on
+    /// the mutation path.
+    #[test]
+    fn a_failed_board_mutation_is_not_treated_as_a_partial_success() {
+        let failed: Value = serde_json::from_str(
+            r#"{
+                "data": { "addProjectV2ItemById": null },
+                "errors": [{
+                    "type": "FORBIDDEN",
+                    "message": "Resource not accessible by personal access token"
+                }]
+            }"#,
+        )
+        .unwrap();
+
+        // The old gate says "usable" - which is why this shipped.
+        assert!(
+            has_usable_data(&failed),
+            "fixture must reproduce the shape that fooled has_usable_data"
+        );
+        // The policy gate is what must reject it.
+        assert!(!partial_is_acceptable(Partial::Reject, &failed));
+        assert!(partial_is_acceptable(Partial::Tolerate, &failed));
+
+        // And the mutation's own result check must fail on it.
+        assert!(!board_item_was_added(&failed));
+    }
+
+    /// A genuine success must still pass both gates, or every board add breaks.
+    #[test]
+    fn a_successful_board_mutation_passes() {
+        let ok: Value = serde_json::from_str(
+            r#"{"data":{"addProjectV2ItemById":{"item":{"id":"PVTI_abc123"}}}}"#,
+        )
+        .unwrap();
+        assert!(board_item_was_added(&ok));
+    }
+
+    /// A 200 with no `errors` at all but a null item is still not an add.
+    /// Belt and braces: the policy gate only fires when `errors` is present.
+    #[test]
+    fn a_silently_empty_mutation_result_is_not_an_add() {
+        let empty: Value =
+            serde_json::from_str(r#"{"data":{"addProjectV2ItemById":null}}"#).unwrap();
+        assert!(!board_item_was_added(&empty));
+        let no_id: Value =
+            serde_json::from_str(r#"{"data":{"addProjectV2ItemById":{"item":{}}}}"#).unwrap();
+        assert!(!board_item_was_added(&no_id));
+    }
 
     fn board(id: &str, repos: &[&str]) -> BoardRepos {
         BoardRepos {


### PR DESCRIPTION
Two findings from CodeRabbit's review of #846 (2 of 5). Both are defects I introduced.

## 1. The coverage test recorded coverage it did not provide 📐

`no_bare_error_display_in_db_paths` matched only the literal `error = %e`. I added `main.rs` to its `CONVERTED` list — while three of its sites interpolate the error through a **positional format placeholder** instead:

```rust
tracing::error!("cleanup_incomplete_runs failed: {}", e)
tracing::error!("reset_stuck_generating_hours failed: {}", e)
tracing::error!("intelligence run failed: {}", e)
```

`{}` renders the same outermost-`.context()`-only string and drops the cause identically. So the entry advertised coverage that did not exist — **the exact failure mode the test exists to prevent, occurring in the test itself.** That spelling also breaks the repo's "structured fields, no format strings for data values" rule.

All three converted to `error = %meridian::errors::chain(&e)`.

**The scan now matches both spellings, and the widening is itself tested.** The predicate is extracted as `drops_the_cause` and asserted directly against the spelling that slipped through:

```rust
assert!(drops_the_cause(r#"Err(e) => tracing::error!("intelligence run failed: {}", e),"#));
```

That mattered here: simply widening the filter and watching the suite go green would have looked identical to the broken state, since the broken state was also green. A predicate nothing exercises is indistinguishable from one that works.

Inline named captures (`"{label}: timed out"`) are deliberately out of scope — pervasive, usually naming one of our own static labels, and a sweep of their own.

## 2. A failed board add was reported as success 🗄️

`has_usable_data` was written for **one** caller and then applied to all three. GitHub answers a failed `addProjectV2ItemById` with:

```json
{ "data": { "addProjectV2ItemById": null },
  "errors": [{ "type": "FORBIDDEN", "message": "Resource not accessible by personal access token" }] }
```

HTTP 200, non-null `data` → the gate said "usable" → `add_to_board` discarded the result → the create flow logged success for an issue **never added to the board**.

That is the defect this module was written to fix, reintroduced on the mutation path.

`Partial::{Tolerate,Reject}` makes the policy explicit per call site:

| call site | policy | why |
|---|---|---|
| multi-board query | `Tolerate` | GitHub reports one unresolvable board among several this way, and `board_repos_from_response` already skips the nulls — this is what the tolerance was for |
| viewer query | `Reject` | single subject; partial means it failed |
| `addProjectV2ItemById` | `Reject` | a mutation that partially happened did not happen |

`board_item_was_added` additionally validates the mutation's own result, because the policy gate only fires when an `errors` array is present — a 200 with no errors and a null item would otherwise still read as success.

## Tests

6 added, all confirmed failing first. The fixture asserts `has_usable_data` still says "usable" on the failing shape, so it provably reproduces what fooled the old gate. `cargo test --workspace` green (27 suites), fmt + clippy clean.

Siblings: #880 (telemetry egress), plus settings write safety, autostart correctness, and the tour probe deadline to follow.