### PR TITLE
fix(settings): validate the merged document and serialise every write

### DIFF
--- a/meridian-core/src/settings.rs
+++ b/meridian-core/src/settings.rs
@@ -585,6 +585,49 @@ pub fn write_settings_value(settings: &Value) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Serialise a read-modify-write of `settings.json` against every other one in
+/// this process.
+///
+/// # The race this closes
+/// `settings.json` is a single JSON document, and several commands used to
+/// independently `read_settings_value()`, mutate their own key, and
+/// `write_settings_value()`. Interleave two of those and the later write
+/// persists the document the earlier one read - silently discarding the other's
+/// change. Measured shapes: `request_pm_tool` racing `update_settings` loses
+/// whichever landed first, and the custom-endpoint registry writers race both.
+///
+/// The write itself was already crash-safe (`atomic_write_json` renames over the
+/// target), which is what made this easy to miss: no file is ever corrupted, a
+/// change simply vanishes.
+///
+/// # Scope of the guarantee
+/// Process-wide only. Two Meridian processes writing the same file would still
+/// race, but only one tray ever runs (the daemon does not write settings), so
+/// this covers the real case. A cross-process lock would need its own file and
+/// its own stale-lock story.
+///
+/// The lock is held for the WHOLE read-mutate-write, so `f` must not await or do
+/// anything slow - do that before calling, and keep the closure to the document
+/// edit.
+///
+/// Poisoning is recovered rather than propagated (`into_inner`): a panic in some
+/// other caller's closure must not make settings permanently unwritable for the
+/// rest of the session.
+pub fn mutate_settings_value<F, T>(f: F) -> anyhow::Result<T>
+where
+    F: FnOnce(&mut Value) -> anyhow::Result<T>,
+{
+    static SETTINGS_WRITE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = SETTINGS_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let mut v = read_settings_value();
+    let out = f(&mut v)?;
+    write_settings_value(&v)?;
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -596,6 +639,96 @@ mod tests {
     /// failure looks like a bug in the code under test rather than in the harness.
     /// (Held for the whole test body; `set_var`/`remove_var` inside the guard.)
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Two concurrent read-modify-writes must BOTH survive.
+    ///
+    /// Before `mutate_settings_value`, each caller independently read the whole
+    /// document, changed its own key, and wrote the result - so an interleaved
+    /// pair persisted whatever the LATER writer had read, silently discarding
+    /// the earlier one's change. `atomic_write_json` means no file is ever
+    /// corrupted, which is exactly what made this invisible: a setting simply
+    /// reverts.
+    ///
+    /// Run over many rounds because a lost update is a race: a single pass can
+    /// pass by luck even with no lock at all.
+    #[test]
+    fn concurrent_mutations_do_not_lose_each_other() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!(
+            "meridian-settings-concurrent-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+        with_settings_path(&path);
+
+        for round in 0..25 {
+            let _ = std::fs::remove_file(&path);
+            let (a, b) = (format!("key_a_{round}"), format!("key_b_{round}"));
+            std::thread::scope(|scope| {
+                for key in [&a, &b] {
+                    scope.spawn(move || {
+                        mutate_settings_value(|v| {
+                            if let Some(obj) = v.as_object_mut() {
+                                obj.insert(key.clone(), json!(true));
+                            }
+                            Ok(())
+                        })
+                        .expect("mutation must succeed");
+                    });
+                }
+            });
+
+            let written = read_settings_value();
+            for key in [&a, &b] {
+                assert_eq!(
+                    written.get(key.as_str()),
+                    Some(&json!(true)),
+                    "round {round}: {key} was lost - one writer overwrote the other's document"
+                );
+            }
+        }
+
+        std::env::remove_var("MERIDIAN_SETTINGS_PATH");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The lock must survive a panicking closure - a poisoned mutex would make
+    /// settings permanently unwritable for the rest of the session.
+    #[test]
+    fn a_panicking_mutation_does_not_wedge_later_writers() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!(
+            "meridian-settings-poison-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+        with_settings_path(&path);
+
+        let panicked = std::thread::spawn(|| {
+            let _ = mutate_settings_value(|_v| -> anyhow::Result<()> { panic!("boom") });
+        })
+        .join();
+        assert!(panicked.is_err(), "the closure must actually have panicked");
+
+        mutate_settings_value(|v| {
+            if let Some(obj) = v.as_object_mut() {
+                obj.insert("after_the_panic".into(), json!(true));
+            }
+            Ok(())
+        })
+        .expect("a later writer must still be able to acquire the lock");
+        assert_eq!(
+            read_settings_value().get("after_the_panic"),
+            Some(&json!(true))
+        );
+
+        std::env::remove_var("MERIDIAN_SETTINGS_PATH");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     /// Point settings resolution at a temp file for the duration of a test.
     fn with_settings_path(path: &std::path::Path) {

--- a/tray/src-tauri/src/commands/account.rs
+++ b/tray/src-tauri/src/commands/account.rs
@@ -226,24 +226,28 @@ async fn write_account_pseudonym(email: Option<&str>) -> anyhow::Result<()> {
     let hash = email.map(meridian::telemetry_spool::redact::pseudonymize_account);
     let raw_email = email.map(str::to_string);
     let result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-        let mut v = meridian_core::settings::read_settings_value();
-        if let Some(obj) = v.as_object_mut() {
-            obj.insert(
-                "account_pseudonym".to_string(),
-                match &hash {
-                    Some(h) => serde_json::Value::String(h.clone()),
-                    None => serde_json::Value::Null,
-                },
-            );
-            obj.insert(
-                "account_email".to_string(),
-                match &raw_email {
-                    Some(e) => serde_json::Value::String(e.clone()),
-                    None => serde_json::Value::Null,
-                },
-            );
-        }
-        meridian_core::settings::write_settings_value(&v)
+        // Under the shared settings lock - see
+        // `meridian_core::settings::mutate_settings_value`. Without it a sign-in
+        // racing a Settings save silently discarded one of the two.
+        meridian_core::settings::mutate_settings_value(|v| {
+            if let Some(obj) = v.as_object_mut() {
+                obj.insert(
+                    "account_pseudonym".to_string(),
+                    match &hash {
+                        Some(h) => serde_json::Value::String(h.clone()),
+                        None => serde_json::Value::Null,
+                    },
+                );
+                obj.insert(
+                    "account_email".to_string(),
+                    match &raw_email {
+                        Some(e) => serde_json::Value::String(e.clone()),
+                        None => serde_json::Value::Null,
+                    },
+                );
+            }
+            Ok(())
+        })
     })
     .await
     .context("join settings write task")

--- a/tray/src-tauri/src/commands/pm_tool_request.rs
+++ b/tray/src-tauri/src/commands/pm_tool_request.rs
@@ -65,24 +65,29 @@ pub async fn request_pm_tool(app: tauri::AppHandle, tool_name: String) -> Result
 
     let name = tool_name.clone();
     tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-        let mut v = meridian_core::settings::read_settings_value();
-        // A settings root that is not an object (a corrupt file holding `[]`,
-        // `null`, a bare scalar) used to skip the insert silently and then
-        // report success - the user is told we recorded their request and
-        // nothing was stored. Recover the root instead: the write below is
-        // about to persist it either way, so leaving a non-object in place
-        // would keep breaking every other settings writer too.
-        if !v.is_object() {
-            tracing::warn!("request_pm_tool: settings root was not an object - recovering it");
-            v = serde_json::Value::Object(serde_json::Map::new());
-        }
-        if let Some(obj) = v.as_object_mut() {
-            obj.insert(
-                "requested_pm_tool".to_string(),
-                serde_json::Value::String(name),
-            );
-        }
-        meridian_core::settings::write_settings_value(&v)
+        // Under the shared settings lock: this used to read, mutate and write
+        // independently of `update_settings`, so whichever landed second
+        // persisted the document the FIRST one had read - silently discarding
+        // the other's change. See `meridian_core::settings::mutate_settings_value`.
+        meridian_core::settings::mutate_settings_value(|v| {
+            // A settings root that is not an object (a corrupt file holding `[]`,
+            // `null`, a bare scalar) used to skip the insert silently and then
+            // report success - the user is told we recorded their request and
+            // nothing was stored. Recover the root instead: the write below is
+            // about to persist it either way, so leaving a non-object in place
+            // would keep breaking every other settings writer too.
+            if !v.is_object() {
+                tracing::warn!("request_pm_tool: settings root was not an object - recovering it");
+                *v = serde_json::Value::Object(serde_json::Map::new());
+            }
+            if let Some(obj) = v.as_object_mut() {
+                obj.insert(
+                    "requested_pm_tool".to_string(),
+                    serde_json::Value::String(name),
+                );
+            }
+            Ok(())
+        })
     })
     .await
     .map_err(|e| format!("join settings write task: {e}"))?

--- a/tray/src-tauri/src/commands/settings.rs
+++ b/tray/src-tauri/src/commands/settings.rs
@@ -150,41 +150,56 @@ pub async fn update_settings(
     }
     validate_worklog_auto_generate_time(body_obj)?;
 
-    let current = meridian_core::settings::read_settings_value();
-    let mut updated = current.clone();
-    let obj = updated
-        .as_object_mut()
-        .ok_or("current settings are not an object")?;
-    // { ...current, ...body } — body keys override.
-    for (k, v) in body_obj {
-        obj.insert(k.clone(), v.clone());
-    }
+    // The whole read-modify-write runs under the shared settings lock. It used
+    // to read and write independently of `request_pm_tool`, `save_account_email`
+    // and the custom-endpoint registry, so two overlapping saves persisted the
+    // document whichever one read FIRST - silently discarding the other's
+    // change. The write was always atomic, which is what made this easy to
+    // miss: no file is corrupted, a setting simply reverts.
+    // See `meridian_core::settings::mutate_settings_value`.
+    let mut updated = meridian_core::settings::mutate_settings_value(|updated| {
+        let current = updated.clone();
+        let obj = updated
+            .as_object_mut()
+            .ok_or_else(|| anyhow::anyhow!("current settings are not an object"))?;
+        // { ...current, ...body } — body keys override.
+        for (k, v) in body_obj {
+            obj.insert(k.clone(), v.clone());
+        }
 
-    // Sentinel / empty / absent oo_password → keep the stored value.
-    let sent = body_obj.get("oo_password").and_then(Value::as_str);
-    if sent.is_none_or(|p| p.is_empty() || p == PASSWORD_SENTINEL) {
-        let kept = current
-            .get("oo_password")
-            .cloned()
-            .unwrap_or(Value::String(String::new()));
-        obj.insert("oo_password".into(), kept);
-    }
+        // Sentinel / empty / absent oo_password → keep the stored value.
+        let sent = body_obj.get("oo_password").and_then(Value::as_str);
+        if sent.is_none_or(|p| p.is_empty() || p == PASSWORD_SENTINEL) {
+            let kept = current
+                .get("oo_password")
+                .cloned()
+                .unwrap_or(Value::String(String::new()));
+            obj.insert("oo_password".into(), kept);
+        }
 
-    // Same rule per custom endpoint, matched BY ID (see `redact_custom_keys`). The merge
-    // above is shallow, so a body carrying the registry replaces it wholesale — and the UI's
-    // copy has a sentinel in every row it read back. Without this, saving any unrelated
-    // setting would overwrite every API key with "••••••••".
-    restore_custom_keys(&current, obj)?;
+        // Same rule per custom endpoint, matched BY ID (see `redact_custom_keys`). The merge
+        // above is shallow, so a body carrying the registry replaces it wholesale — and the UI's
+        // copy has a sentinel in every row it read back. Without this, saving any unrelated
+        // setting would overwrite every API key with "••••••••".
+        restore_custom_keys(&current, obj).map_err(|e| anyhow::anyhow!(e))?;
 
-    // The GATE. A custom endpoint may only run the pipeline on measured evidence
-    // (`meridian_core::SchemaRung`), and it is enforced HERE rather than only in the UI:
-    // this command is the sole writer of settings.json, so a hand-edited file or an older
-    // frontend would otherwise route a user's whole day through an endpoint nobody has
-    // shown can hold a schema. An unenforced fold doesn't fail loudly — it drops the hour.
-    enforce_custom_provider_gate(&updated)?;
+        // The GATE. A custom endpoint may only run the pipeline on measured evidence
+        // (`meridian_core::SchemaRung`), and it is enforced HERE rather than only in the UI:
+        // this command is the sole writer of settings.json, so a hand-edited file or an older
+        // frontend would otherwise route a user's whole day through an endpoint nobody has
+        // shown can hold a schema. An unenforced fold doesn't fail loudly — it drops the hour.
+        enforce_custom_provider_gate(updated).map_err(|e| anyhow::anyhow!(e))?;
 
-    meridian_core::settings::write_settings_value(&updated)
-        .map_err(|e| crate::cmd_err!(e, "update_settings: write failed"))?;
+        // LAST gate before the write, and deliberately on the whole document rather
+        // than another named field: everything above validates fields by name, so
+        // anything not on that list could reach disk with the wrong type and take
+        // the ENTIRE file down with it at load time. See
+        // `merged_settings_are_loadable`.
+        merged_settings_are_loadable(updated).map_err(|e| anyhow::anyhow!(e))?;
+
+        Ok(updated.clone())
+    })
+    .map_err(|e| crate::cmd_err!(e, "update_settings: write failed"))?;
 
     // Refresh the live capture ignore list so a Settings change takes effect on
     // the very next captured frame — no capture restart. The frame + UI-event
@@ -297,6 +312,40 @@ fn restore_custom_keys(
 /// daemon's hourly clock check (`pm_worklog::auto_generate`) and the feature
 /// would just never fire — reject it at the door instead of failing quietly
 /// later. Absent or explicit `null` (turning the feature off) both pass.
+/// Reject a merged settings document that `load_runtime_settings` would not be
+/// able to read back.
+///
+/// # Why this is checked on the DOCUMENT and not per field
+/// `update_settings` validated five fields by name and then merged the body
+/// verbatim, so any field nobody listed (`autostart_enabled` was the one found)
+/// could reach `settings.json` with the wrong type. The damage is not scoped to
+/// that field: `RuntimeSettings` carries a struct-level `#[serde(default)]`,
+/// which rescues a MISSING key but not a wrong-TYPED one, so one bad value
+/// fails the whole deserialise. `load_runtime_settings` then returns
+/// `RuntimeSettings::default()` and every unrelated setting - work hours, poll
+/// interval, log level - silently reads as its default until the file is
+/// repaired by hand. `meridian_core::settings`'s
+/// `an_unknown_llm_provider_does_not_reset_every_other_setting` documents that
+/// landmine from the other side.
+///
+/// Checking the merged document closes it for every field at once, including
+/// ones added later that nobody remembers to validate - which is the failure
+/// mode a name-by-name list reproduces every time it is extended.
+///
+/// UNKNOWN keys stay legal: `read_settings_value` deliberately preserves them so
+/// a write can round-trip a file from a newer build, and `RuntimeSettings` has
+/// no `deny_unknown_fields`. Only a wrong TYPE is rejected.
+fn merged_settings_are_loadable(merged: &Value) -> Result<(), String> {
+    serde_json::from_value::<meridian_core::settings::RuntimeSettings>(merged.clone())
+        .map(|_| ())
+        .map_err(|e| {
+            format!(
+                "these settings could not be saved - {e}. Nothing was written, so your \
+                 existing settings are unchanged."
+            )
+        })
+}
+
 fn validate_worklog_auto_generate_time(
     body_obj: &serde_json::Map<String, Value>,
 ) -> Result<(), String> {
@@ -374,6 +423,73 @@ fn str_list(v: &Value, key: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+
+    /// A merged settings document that cannot deserialise must be REJECTED
+    /// rather than written.
+    ///
+    /// `update_settings` validated `otlp_endpoint`, `llm_provider`, the two
+    /// credential fields and `worklog_auto_generate_time` - and then merged the
+    /// body verbatim. `autostart_enabled` had no check, so a non-boolean reached
+    /// `settings.json`.
+    ///
+    /// The blast radius is the whole file, not one field: `RuntimeSettings`
+    /// carries a struct-level `#[serde(default)]`, which covers a MISSING key
+    /// but not a wrong-TYPED one. One bad value therefore fails the whole
+    /// deserialise, `load_runtime_settings` returns `RuntimeSettings::default()`,
+    /// and every unrelated setting - work hours, poll interval, log level -
+    /// silently reads as its default until someone repairs the file by hand.
+    /// `meridian_core::settings`'s own
+    /// `an_unknown_llm_provider_does_not_reset_every_other_setting` documents
+    /// that landmine.
+    ///
+    /// Validating the MERGED DOCUMENT rather than adding an `autostart_enabled`
+    /// check closes it for every field at once, including fields added later
+    /// that nobody remembers to validate.
+    #[test]
+    fn a_wrong_typed_field_is_rejected_before_it_can_reset_the_file() {
+        let mut doc = serde_json::to_value(meridian_core::settings::RuntimeSettings::default())
+            .expect("defaults serialise");
+        doc.as_object_mut()
+            .unwrap()
+            .insert("autostart_enabled".into(), Value::String("yes".into()));
+        assert!(
+            merged_settings_are_loadable(&doc).is_err(),
+            "a non-boolean autostart_enabled must never reach settings.json"
+        );
+    }
+
+    /// The same guard must cover fields nobody thought to validate - that is the
+    /// point of checking the document instead of a field list.
+    #[test]
+    fn the_guard_is_not_specific_to_autostart_enabled() {
+        for (key, bad) in [
+            ("poll_interval_secs", Value::String("soon".into())),
+            ("notifications_enabled", Value::String("maybe".into())),
+            ("error_reporting_enabled", serde_json::json!(3)),
+        ] {
+            let mut doc = serde_json::to_value(meridian_core::settings::RuntimeSettings::default())
+                .expect("defaults serialise");
+            doc.as_object_mut().unwrap().insert(key.into(), bad);
+            assert!(
+                merged_settings_are_loadable(&doc).is_err(),
+                "{key} with a wrong-typed value must be rejected too"
+            );
+        }
+    }
+
+    /// It must NOT reject a document carrying keys the struct does not know.
+    /// `read_settings_value` deliberately preserves unknown keys so a write can
+    /// round-trip them; rejecting those would make every save fail on a file
+    /// written by a newer build.
+    #[test]
+    fn unknown_keys_still_round_trip() {
+        let mut doc = serde_json::to_value(meridian_core::settings::RuntimeSettings::default())
+            .expect("defaults serialise");
+        doc.as_object_mut()
+            .unwrap()
+            .insert("a_key_from_a_newer_build".into(), Value::Bool(true));
+        assert!(merged_settings_are_loadable(&doc).is_ok());
+    }
     use super::*;
     use serde_json::json;
 


### PR DESCRIPTION
Two findings from CodeRabbit's review of #846 (3 of 5).

## 1. One bad field silently reset every other setting 🗄️

`update_settings` validated five fields **by name** (`otlp_endpoint`, `llm_provider`, the two credentials, `worklog_auto_generate_time`) and then merged the body verbatim. Anything not on that list reached `settings.json` with whatever type the caller sent. `autostart_enabled` was the one found.

**The damage is not scoped to that field.** `RuntimeSettings` carries a struct-level `#[serde(default)]`, which rescues a *missing* key but not a wrong-*typed* one. So one bad value fails the whole deserialise → `load_runtime_settings` returns `RuntimeSettings::default()` → work hours, poll interval, log level and everything else silently read as defaults until the file is repaired by hand. `an_unknown_llm_provider_does_not_reset_every_other_setting` already documents that landmine from the other side.

Fixed by validating the **merged document** rather than adding another named check:

```rust
merged_settings_are_loadable(&updated)?;   // last gate before the write
```

That covers every field at once — including fields added later that nobody remembers to validate, which is the failure mode a name list reproduces every time it's extended. Unknown keys stay legal (`read_settings_value` preserves them deliberately, and the struct has no `deny_unknown_fields`), so a file from a newer build still round-trips.

`the_guard_is_not_specific_to_autostart_enabled` pins that it catches `poll_interval_secs`, `notifications_enabled` and `error_reporting_enabled` too.

## 2. Concurrent settings writes silently discarded each other 🗄️

Several commands independently read the whole document, changed their own key, and wrote it back:

- `update_settings`
- `request_pm_tool`
- `save_account_email`

Interleave two and the later write persists the document the **earlier one read**, discarding its change. `atomic_write_json` means no file is ever corrupted — which is exactly what made this invisible: a setting just reverts.

`meridian_core::settings::mutate_settings_value` now serialises the whole read-mutate-write, and all three go through it. Poisoning is recovered rather than propagated, so a panic in one closure can't make settings permanently unwritable for the session.

**`custom_llm`'s four registry writers keep their own `REGISTRY_LOCK`**, which already serialises them against each other. Routing them through the shared lock too is a larger refactor of that module — flagged, not silently skipped.

## The concurrency test was verified to fail without the fix

Temporarily acquiring and immediately dropping the lock (so the static stays used and `-D warnings` still compiles):

```
round 0: key_b_0 was lost - one writer overwrote the other's document
test result: FAILED
```

and with the lock restored, `ok`. It runs 25 rounds because a lost update is a race — a single pass can pass by luck with no lock at all.

I checked rather than assumed because **twice today I shipped a test that could not fail**: the `main.rs` coverage entry in #881, and a blind-edit clobber of my own tests in #880.

## Tests

5 added (3 validation, 2 concurrency incl. lock-poisoning). `cargo test --workspace` green (27 suites), fmt + clippy clean.

Siblings: #880, #881. Autostart correctness and the tour probe deadline to follow.