### PR TITLE
fix(autostart): stop reading escaped paths as drift, and never boot out ourselves

### DIFF
--- a/tray/src-tauri/src/autostart.rs
+++ b/tray/src-tauri/src/autostart.rs
@@ -165,10 +165,19 @@ where
 //
 // A hardcoded relaunch hour was the wrong shape for the requirement ("Meridian is
 // running after the device is turned on or woken"): it fires when the user is not
-// there and misses them when they are. Both platforms now trigger on the OS's own
-// events instead - launchd `LaunchEvents` on wake/unlock notifications
-// ([`macos::WAKE_NOTIFICATIONS`]) and Windows `SessionStateChangeTrigger` on
-// `SessionUnlock`/`ConsoleConnect`. There is no clock left in this module.
+// there and misses them when they are.
+//
+// The wake/unlock triggers that briefly replaced it are ALSO gone - launchd
+// `LaunchEvents` on wake notifications, and Windows'
+// `SessionStateChangeTrigger` on `SessionUnlock`/`ConsoleConnect`. They made
+// Quit not stick: the app the user had just closed came back on the next unlock.
+// See this module's doc header for that history, and
+// `windows::task_carries_only_the_logon_trigger`, which asserts the Windows
+// trigger is absent.
+//
+// What remains is login and nothing else: SMAppService on macOS 13+, a
+// `RunAtLoad` plist below it, and a single logon trigger on Windows. There is no
+// clock and no session-event trigger left in this module.
 
 /// Marker recording that the user deliberately turned autostart OFF.
 ///
@@ -553,6 +562,26 @@ pub(crate) async fn status() -> Status {
     }
 }
 
+/// Does a registered job definition reference `exe`?
+///
+/// # Why this is not `text.contains(exe)`
+/// Both writers put the path through [`xml_escape`] - it is element text in a
+/// plist or a scheduled-task XML, and a user directory can legitimately contain
+/// `&`. Every comparison site then searched for the RAW `current_exe()` string,
+/// so for a path containing any of the five XML predefined entities the two
+/// forms never matched and the job read as drifted forever.
+///
+/// On Windows that was a loop rather than a cosmetic error: `decide_task` has no
+/// byte-equality fast path, so an affected install returned
+/// `RepairedPathDrift` and re-registered its scheduled task on EVERY launch.
+///
+/// Both spellings are accepted on purpose. A definition written by a build from
+/// before the escaping was added carries the raw path, and rejecting those would
+/// make this fix itself report drift for one upgrade cycle.
+pub(crate) fn job_references_exe(text: &str, exe: &str) -> bool {
+    text.contains(exe) || text.contains(&xml_escape(exe))
+}
+
 /// Shared by both platform modules: compare a job definition against the
 /// running executable, tolerating the "could not tell" cases.
 pub(crate) fn status_from(registered: Option<&str>, expected_exe: Option<&str>) -> Status {
@@ -564,7 +593,7 @@ pub(crate) fn status_from(registered: Option<&str>, expected_exe: Option<&str>) 
         },
         (Some(text), Some(exe)) => Status {
             registered: Some(true),
-            path_ok: Some(text.contains(exe)),
+            path_ok: Some(job_references_exe(text, exe)),
             login_item: None,
         },
         // Registered, but we cannot resolve our own path to compare against.
@@ -600,6 +629,71 @@ pub(crate) fn xml_escape(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    /// A path containing an XML metacharacter must not read as permanently
+    /// drifted.
+    ///
+    /// `task_xml` and the macOS plist body both write the executable path
+    /// through [`xml_escape`] - `xml_escape_covers_a_path_with_an_ampersand`
+    /// pins that. Every comparison site then searched the registered job text
+    /// for the RAW `current_exe()` string. For a path containing `&`, `<`, `>`,
+    /// `"` or `'` the two forms differ, `contains` never matches, and the job
+    /// reads as drifted forever.
+    ///
+    /// Windows profile directories can legally contain `&`, and `decide_task`
+    /// has no byte-equality fast path - so an affected install re-registered its
+    /// scheduled task on EVERY launch, and reported
+    /// `health_autostart_path_ok: false` for good measure.
+    #[test]
+    fn a_path_with_xml_metacharacters_is_not_read_as_drifted() {
+        for exe in [
+            r"C:\Users\A&B\AppData\Local\Meridian\Meridian.exe",
+            "/Users/a&b/Applications/Meridian.app/Contents/MacOS/Meridian",
+            "/Users/o'brien/Meridian.app/Contents/MacOS/Meridian",
+            "/Users/a<b>c/Meridian",
+        ] {
+            let registered = format!("<string>{}</string>", xml_escape(exe));
+            assert!(
+                job_references_exe(&registered, exe),
+                "escaped-on-write must match raw-on-read for {exe:?}"
+            );
+        }
+    }
+
+    /// A definition written by an older build carries the RAW path. Those must
+    /// keep matching too, or this fix would itself register drift on every
+    /// launch for exactly one upgrade cycle.
+    #[test]
+    fn a_pre_escape_definition_still_matches() {
+        let exe = "/Users/a&b/Meridian";
+        assert!(job_references_exe(&format!("<string>{exe}</string>"), exe));
+    }
+
+    /// A genuinely moved app must still be detected - the tolerance above must
+    /// not become "always matches".
+    #[test]
+    fn a_genuinely_different_path_is_still_drift() {
+        let registered = format!(
+            "<string>{}</string>",
+            xml_escape("/Applications/Meridian.app/Contents/MacOS/Meridian")
+        );
+        assert!(!job_references_exe(
+            &registered,
+            "/Users/tester/Downloads/Meridian.app/Contents/MacOS/Meridian"
+        ));
+    }
+
+    /// The analytics half of the same defect: `status_from` reported
+    /// `path_ok: false` for a correctly registered job.
+    #[test]
+    fn status_reports_path_ok_for_an_escaped_registration() {
+        let exe = "/Users/a&b/Meridian.app/Contents/MacOS/Meridian";
+        let registered = format!("<string>{}</string>", xml_escape(exe));
+        assert_eq!(
+            status_from(Some(&registered), Some(exe)).path_ok,
+            Some(true)
+        );
+    }
     use super::*;
 
     /// The rule both platforms now share. It lived in `windows.rs` and applied

--- a/tray/src-tauri/src/autostart/macos.rs
+++ b/tray/src-tauri/src/autostart/macos.rs
@@ -259,7 +259,7 @@ pub(crate) async fn ensure_registered() -> RegistrationAction {
         // Distinguish the two repairs that matter for the fleet: a moved app is
         // a different problem from a definition this build simply renders
         // differently.
-        Some(cur) if !cur.contains(exe.to_string_lossy().as_ref()) => {
+        Some(cur) if !super::job_references_exe(cur, exe.to_string_lossy().as_ref()) => {
             RegistrationAction::RepairedPathDrift
         }
         Some(_) => RegistrationAction::RepairedStaleDefinition,
@@ -348,7 +348,61 @@ pub(crate) async fn ensure_registered() -> RegistrationAction {
 /// was trying to cause anyway.
 pub(crate) async fn disarm_relaunch() {
     let target = format!("gui/{}/{LABEL}", crate::sys::uid_str());
+    // REFUSE to boot ourselves out. `bootout` unloads a job AND terminates its
+    // processes, our plist deliberately carries no `KeepAlive`, and SMAppService
+    // only supplies a FUTURE login launch - so if this process IS that job's
+    // instance, the bootout makes the app vanish for the rest of the session
+    // with nothing to bring it back.
+    //
+    // `migrate_off_plugin` already documents this hazard for the plugin-era
+    // label and avoids it by never booting out at all. The same hazard applies
+    // here, and the justification originally written above ("no worse than the
+    // exit the user was trying to cause") only holds on the DISABLE path -
+    // the macOS 13+ startup path calls this while the user has asked for
+    // nothing of the sort.
+    //
+    // Skipping is cheap. The bootout only exists to stop an already-armed
+    // `LaunchEvents` trigger firing once more before the next logout; if it
+    // does fire, `tauri-plugin-single-instance` turns the second launch into a
+    // no-op. A spurious relaunch attempt is strictly better than a dead tray.
+    if job_is_running_this_process(&target).await {
+        tracing::info!(
+            label = LABEL,
+            "autostart: skipping bootout - this process IS that job's instance, and \
+             booting it out would terminate the tray with nothing to restart it"
+        );
+        return;
+    }
     let _ = crate::backend_install::launchctl(&["bootout", &target]).await;
+}
+
+/// Does `target`'s launchd job currently own THIS process?
+async fn job_is_running_this_process(target: &str) -> bool {
+    let Ok(out) = tokio::process::Command::new("launchctl")
+        .args(["print", target])
+        .output()
+        .await
+    else {
+        // Cannot tell. Fail SAFE - assume it might be us and skip the bootout,
+        // because the cost of a wrong "no" (a dead tray) far exceeds the cost of
+        // a wrong "yes" (one `LaunchEvents` trigger fires and single-instance
+        // absorbs it).
+        return true;
+    };
+    let text = String::from_utf8_lossy(&out.stdout);
+    job_pid_from_print(&text) == Some(std::process::id())
+}
+
+/// The `pid = N` a `launchctl print` block reports for a running job.
+///
+/// `None` when the job is loaded but not running (no `pid` line), when the label
+/// is unknown (launchctl errors and prints nothing), or when the field is not a
+/// number.
+fn job_pid_from_print(text: &str) -> Option<u32> {
+    text.lines()
+        .map(str::trim)
+        .find_map(|l| l.strip_prefix("pid = "))
+        .and_then(|v| v.trim().parse().ok())
 }
 
 /// Delete the plugin-era `Meridian.plist`, so an upgraded install does not end
@@ -440,6 +494,40 @@ pub(crate) async fn status() -> Status {
 
 #[cfg(test)]
 mod tests {
+
+    /// `disarm_relaunch` must never terminate the tray it is running inside.
+    ///
+    /// `bootout` unloads a job AND kills its processes; our plist carries no
+    /// `KeepAlive`; SMAppService only arranges a FUTURE login launch. So booting
+    /// out our own label makes the app vanish for the session. The macOS 13+
+    /// startup path calls this while the user has asked for nothing, which is
+    /// where the original justification ("no worse than the exit the user was
+    /// trying to cause") stops applying.
+    #[test]
+    fn the_running_jobs_pid_is_read_from_launchctl_print() {
+        let sample = "\
+com.meridiona.tray = {
+\tactive count = 1
+\tpath = /Users/t/Library/LaunchAgents/com.meridiona.tray.plist
+\tstate = running
+\tpid = 4711
+\tprogram = /Applications/Meridian.app/Contents/MacOS/Meridian
+}";
+        assert_eq!(job_pid_from_print(sample), Some(4711));
+    }
+
+    /// A loaded-but-not-running job, an unknown label, and a malformed field
+    /// must all read as "no pid" rather than a wrong one.
+    #[test]
+    fn a_job_with_no_running_instance_reports_no_pid() {
+        assert_eq!(job_pid_from_print("state = not running\n"), None);
+        assert_eq!(job_pid_from_print(""), None);
+        assert_eq!(job_pid_from_print("pid = notanumber"), None);
+        assert_eq!(
+            job_pid_from_print("last exit code = 0\nactive count = 0"),
+            None
+        );
+    }
     use super::*;
 
     fn body(run_at_load: bool) -> String {

--- a/tray/src-tauri/src/autostart/windows.rs
+++ b/tray/src-tauri/src/autostart/windows.rs
@@ -194,7 +194,7 @@ pub(crate) fn utf16le_with_bom(s: &str) -> Vec<u8> {
 /// the console code page depending on the Windows build and how the process was
 /// launched.
 ///
-/// This only ever feeds a `contains` check ([`super::decide`]), so a
+/// This only ever feeds a `contains` check ([`super::job_references_exe`]), so a
 /// best-effort decode is sufficient and a wrong guess costs one redundant
 /// rewrite. Guessing by counting NUL bytes rather than trusting the BOM
 /// alone: BOM-less UTF-16 output is real, and decoding it as UTF-8 yields a
@@ -245,7 +245,8 @@ fn is_disabled(xml: &str) -> bool {
     xml.contains("<Enabled>false</Enabled>")
 }
 
-/// Windows' own repair check, kept separate from the shared [`super::decide`]:
+/// Windows' own repair check, kept separate from the shared
+/// [`super::decide_skip`]:
 /// that helper only checks a marker's PRESENCE, which cannot see a task that
 /// needs REWRITING rather than merely completing. A task carrying the retired
 /// [`STALE_SESSION_TRIGGER_MARKER`] unlock/reconnect triggers still contains
@@ -253,12 +254,14 @@ fn is_disabled(xml: &str) -> bool {
 /// already correct forever and never strip them — this checks for that
 /// explicitly, ahead of the presence check.
 ///
-/// Pure and separate from the read, like `super::decide`, so both this and
+/// Pure and separate from the read, like [`super::decide_skip`], so both this and
 /// [`ensure_registered`]'s call to it are unit-testable without a Windows host.
 fn decide_task(existing: Option<&str>, expected_exe: &str) -> RegistrationAction {
     match existing {
         None => RegistrationAction::RegisteredMissing,
-        Some(text) if !text.contains(expected_exe) => RegistrationAction::RepairedPathDrift,
+        Some(text) if !super::job_references_exe(text, expected_exe) => {
+            RegistrationAction::RepairedPathDrift
+        }
         Some(text) if text.contains(STALE_SESSION_TRIGGER_MARKER) => {
             RegistrationAction::RepairedStaleDefinition
         }

--- a/tray/src-tauri/src/install.rs
+++ b/tray/src-tauri/src/install.rs
@@ -264,21 +264,27 @@ pub(crate) fn bin_source(bin: &str) -> &'static str {
     if std::env::var("MERIDIAN_BIN").is_ok_and(|p| p == bin) {
         return "env_override";
     }
-    // Checked as path segments so a user directory that merely CONTAINS the
-    // text (`~/projects/.meridian/bin/notes`) cannot be misread as the staged
-    // install. Windows separators included: the staged path is the only
-    // candidate that exists there.
-    let staged = bin.contains("/.meridian/bin/") || bin.contains("\\.meridian\\bin\\");
-    if staged {
+    // NORMALISE FIRST. `PathBuf::join` on Windows separates the base with `\`
+    // while the joined literal (`".meridian/bin/meridian.exe"`) keeps its own
+    // `/`, so the real resolved path is MIXED:
+    // `C:\Users\x\.meridian/bin/meridian.exe`. Matching pure-`/` or pure-`\`
+    // forms missed it, and every Windows staged install classified as `other` -
+    // invisible from macOS, and invisible to a test written with tidy paths.
+    let bin_slashed = bin.replace('\\', "/");
+
+    // Checked as path SEGMENTS so a user directory that merely contains the text
+    // (`~/projects/.meridian/bin-scripts/…`) cannot be misread as the staged
+    // install.
+    if bin_slashed.contains("/.meridian/bin/") {
         return "staged";
     }
-    if bin.contains("/.local/bin/") {
+    if bin_slashed.contains("/.local/bin/") {
         return "user_local_wrapper";
     }
     // No separator at all — `"meridian"` / `"meridian.exe"`, the bare last
     // resort resolved through `$PATH`. This is the one that silently finds
     // nothing on a per-user Windows install.
-    if !bin.contains('/') && !bin.contains('\\') {
+    if !bin_slashed.contains('/') {
         return "path_lookup";
     }
     // A resolved absolute path that matches no known candidate: a dev build out
@@ -394,6 +400,22 @@ mod tests {
         assert_eq!(bin_source("meridian"), "path_lookup");
         assert_eq!(bin_source("meridian.exe"), "path_lookup");
         assert_eq!(bin_source("/repo/target/release/meridian"), "other");
+        // The shape `PathBuf::join` ACTUALLY produces on Windows: the base uses
+        // `\\`, the joined literal keeps its own `/`. Neither pure-separator
+        // branch matched it, so every Windows staged install reported "other".
+        // The original test used only pure-`/` and pure-`\\` paths and passed.
+        assert_eq!(
+            bin_source("C:\\Users\\x\\.meridian/bin/meridian.exe"),
+            "staged"
+        );
+        assert_eq!(
+            bin_source("C:/Users/x\\.meridian\\bin\\meridian.exe"),
+            "staged"
+        );
+        assert_eq!(
+            bin_source("C:\\Users\\x\\.local/bin/meridian"),
+            "user_local_wrapper"
+        );
         // The trap a plain `.contains(".meridian/bin")` would fall into.
         assert_eq!(
             bin_source("/Users/x/projects/.meridian/bin-scripts/meridian"),


### PR DESCRIPTION
Five findings from CodeRabbit's review of #846 (4 of 5).

## 1. XML-escaped on write, compared raw on read 🎯

`task_xml` and the macOS plist body both run the executable path through `xml_escape` — it is element text, and a user directory can legitimately contain `&`. All three comparison sites then searched the registered job text for the **unescaped** `current_exe()`.

| site | consequence |
|---|---|
| `windows.rs` `decide_task` | no byte-equality fast path → `RepairedPathDrift` and a **task rewrite on every launch** |
| `macos.rs` drift arm | `cur == expected` hides it until the definition changes for another reason, then reports a stale definition as a moved app |
| `autostart.rs` `status_from` | `health_autostart_path_ok: false` for a healthy install |

`job_references_exe` accepts **either** spelling. Both are needed: a definition written before the escaping was added carries the raw path, so rejecting it would make this fix itself report drift for one upgrade cycle.

## 2. `bin_source` classified every Windows staged install as `other` 🎯

`home.join(".meridian/bin/meridian.exe")` produces a **mixed**-separator path — the base uses `\`, the joined literal keeps its `/`:

```
C:\Users\x\.meridian/bin/meridian.exe
```

Neither of my pure-separator branches matched it. Normalised before matching.

My original tests used tidy pure-`/` and pure-`\` paths and passed, which is exactly why this shipped in #871. The mixed shape is now in them, and it reproduced (`left: "other", right: "staged"`) before the fix.

## 3. `disarm_relaunch` could terminate the tray it runs inside 🩺

`bootout` unloads a job **and kills its processes**. Our plist deliberately carries no `KeepAlive`, and SMAppService only arranges a *future* login launch — so booting out our own label makes the app vanish for the rest of the session with nothing to bring it back.

`migrate_off_plugin` already documents this precise hazard for the plugin-era label and avoids it by never booting out at all. The justification written above `disarm_relaunch` —

> *"no worse than the exit the user was trying to cause anyway"*

— holds on the **disable** path, but the macOS 13+ startup path calls it while the user has asked for nothing of the sort. That gap is the finding.

It now checks whether that job owns this pid and skips if so, **failing safe** when launchctl can't be read: a wrong "no" costs a dead tray, a wrong "yes" costs one `LaunchEvents` trigger that `tauri-plugin-single-instance` absorbs. The bootout only exists to stop an already-armed trigger firing once more before the next logout, so skipping it is cheap.

## 4 & 5. Two stale docs 📐

- The `MORNING_HOUR` NOTE still described the wake/unlock triggers as current. Those were removed too — they made Quit not stick, since the app the user had just closed came back on the next unlock. Rewritten to say what's actually left.
- Three doc links pointed at `super::decide`, replaced long ago by `decide_skip`. Rustdoc treats an unresolved intra-doc link as an error under `-D warnings`; `cargo doc` is now clean.

## Tests

7 added (4 escape/drift, 2 launchctl pid parsing, 3 mixed-separator cases). `cargo test --workspace` green (27 suites), fmt + clippy + `cargo doc` clean.

Siblings: #880, #881, #882. Remaining: `repair_boot.rs:410`, `daemon.rs:253`, `scriptDay.ts:175`.