### PR TITLE
fix(tray,ui): serialise the reload cycle and bound every tutorial settings read

### DIFF
--- a/tray/src-tauri/src/commands/daemon.rs
+++ b/tray/src-tauri/src/commands/daemon.rs
@@ -247,10 +247,45 @@ pub(crate) async fn reload_daemon_with(
 /// following poll tick), against whatever the file looks like by then - a
 /// point in time this function does not need to reason about.
 async fn reload_with_pool_cycle(pool: &crate::db_pool::DbPool) -> Result<u32, String> {
-    pool.close().await;
-    let result = super::daemon_control::reload().await;
-    pool.reopen().await;
-    result
+    with_reload_lock(|| async {
+        pool.close().await;
+        let result = super::daemon_control::reload().await;
+        pool.reopen().await;
+        result
+    })
+    .await
+}
+
+/// Run one close → signal → reopen cycle with no other cycle interleaved.
+///
+/// # The interleaving this prevents
+/// `DbPool::close` clears the SHARED handle before awaiting the underlying
+/// close, so two overlapping reloads can cross:
+///
+/// 1. caller A closes - the handle is now `None`, A is still awaiting;
+/// 2. caller B sees `None`, treats it as "nothing to close", signals its own
+///    restart and REOPENS a fresh pool;
+/// 3. A resumes, signals a second restart, and reopens over B's pool -
+///    signalling a daemon restart while a live pool is open across it, which is
+///    precisely what the close/reopen dance exists to prevent.
+///
+/// macOS reached this through `reload_throttled`, which serialises for a
+/// different reason (launchd's `ThrottleInterval`) and so happened to cover it;
+/// the Windows path deliberately skips that throttle and had nothing. The lock
+/// lives HERE rather than at either call site so both platforms get it from one
+/// place, and it nests inside the throttle without any ordering hazard.
+///
+/// Generic over the work so the serialisation itself is testable without
+/// launchctl or a real pool - see `two_reload_cycles_never_interleave`.
+async fn with_reload_lock<F, Fut, T>(work: F) -> T
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = T>,
+{
+    static RELOAD_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+        std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+    let _guard = RELOAD_LOCK.lock().await;
+    work().await
 }
 
 // ── macOS reload rate limit ─────────────────────────────────────────────────
@@ -521,6 +556,54 @@ fn plan_reload(
 
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
+
+    /// Two overlapping reloads must not interleave their close/reopen cycles.
+    ///
+    /// `DbPool::close` clears the shared handle BEFORE awaiting the underlying
+    /// close, so without serialisation a second caller sees `None`, decides
+    /// there is nothing to close, and reopens a pool that the first caller then
+    /// signals a daemon restart across - the exact condition close/reopen
+    /// exists to prevent.
+    ///
+    /// Written against `with_reload_lock` rather than `reload_with_pool_cycle`
+    /// because the latter shells out to launchctl; the property under test is
+    /// the mutual exclusion, and this exercises it directly.
+    #[tokio::test]
+    async fn two_reload_cycles_never_interleave() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc as StdArc;
+
+        let inside = StdArc::new(AtomicUsize::new(0));
+        let max_seen = StdArc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let inside = inside.clone();
+            let max_seen = max_seen.clone();
+            handles.push(tokio::spawn(async move {
+                with_reload_lock(|| async {
+                    let n = inside.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_seen.fetch_max(n, Ordering::SeqCst);
+                    // Yield across the critical section: without the lock this
+                    // is where a second cycle slips in, exactly as
+                    // `close().await` yields in the real one.
+                    tokio::task::yield_now().await;
+                    tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+                    inside.fetch_sub(1, Ordering::SeqCst);
+                })
+                .await;
+            }));
+        }
+        for h in handles {
+            h.await.expect("task panicked");
+        }
+
+        assert_eq!(
+            max_seen.load(Ordering::SeqCst),
+            1,
+            "two reload cycles were inside the critical section at once"
+        );
+    }
     use super::*;
     use std::sync::atomic::{AtomicU32, Ordering};
 

--- a/ui/__tests__/tour-worklog-answered.test.ts
+++ b/ui/__tests__/tour-worklog-answered.test.ts
@@ -120,3 +120,34 @@ describe('waitForWorklogAnswered', () => {
     expect(await waitForWorklogAnswered(stubStage(), 120, probe)).toBe(false)
   })
 })
+
+// ── A probe that never settles ─────────────────────────────────────────────
+// The tour awaited `probe()` with no deadline, so a Tauri `get_settings` that
+// never resolves blocked INSIDE the loop - the `Date.now() < deadline` test
+// never ran again, and the tutorial could neither close the dialog nor finish.
+// A hang is invisible to a source scan and to every other test here, all of
+// which use probes that resolve.
+describe('waitForWorklogAnswered with a probe that never settles', () => {
+  it('still returns false at the deadline instead of hanging forever', async () => {
+    const stage = stubStage()
+    const started = Date.now()
+    const neverSettles = () => new Promise<string | undefined>(() => {})
+
+    const answered = await waitForWorklogAnswered(stage, 300, neverSettles)
+
+    expect(answered).toBe(false)
+    // Bounded by the deadline, not by the probe. Generous upper bound so this
+    // cannot flake on a loaded CI box; the point is that it RETURNS.
+    expect(Date.now() - started).toBeLessThan(5000)
+  })
+
+  it('a probe that settles only after the deadline does not count as an answer', async () => {
+    const stage = stubStage()
+    const slow = () =>
+      new Promise<string | undefined>((resolve) => setTimeout(() => resolve('19:00:1'), 2000))
+
+    const answered = await waitForWorklogAnswered(stage, 250, slow)
+
+    expect(answered).toBe(false)
+  })
+})

--- a/ui/components/tutorial/scriptDay.ts
+++ b/ui/components/tutorial/scriptDay.ts
@@ -144,6 +144,25 @@ const readWorklogSettings: SettingsProbe = async () => {
   }
 }
 
+/// Resolve `p`, or `undefined` if `ms` elapses first.
+///
+/// The timer is always cleared, so a fast read does not keep the process alive
+/// for the rest of the window - which matters here because `timeoutMs` on this
+/// path is five minutes.
+async function within<T>(p: Promise<T>, ms: number): Promise<T | undefined> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      p,
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => resolve(undefined), ms)
+      }),
+    ])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}
+
 // EXPORTED, with an injectable `probe`, for the test harness - nothing else
 // passes the third argument and production always takes the default. The
 // behaviour that matters is an ERROR PATH (a rejected `get_settings`)
@@ -158,9 +177,18 @@ export async function waitForWorklogAnswered(
   probe: SettingsProbe = readWorklogSettings,
 ): Promise<boolean> {
   void s.waitForClick('[data-tour="worklog-schedule-on"]', timeoutMs)
-  const read = probe
-  let baseline = await read()
   const deadline = Date.now() + timeoutMs
+  // Every read is raced against the REMAINING deadline. Awaiting `probe()`
+  // bare is what made this hang: a Tauri call that never settles blocks inside
+  // the loop, so the `Date.now() < deadline` test below never runs again and
+  // the tour can neither close the dialog nor finish - the same class of
+  // unbounded wait this function was written to remove, one level down.
+  //
+  // A timed-out read is reported as `undefined`, which is already the "read
+  // failed" case the comparison below handles: it is not evidence the user
+  // answered, so the loop keeps waiting rather than advancing.
+  const read = () => within(probe(), Math.max(0, deadline - Date.now()))
+  let baseline = await read()
   while (Date.now() < deadline) {
     if (!document.querySelector('[data-tour="worklog-schedule-on"]')) return true
     const current = await read()


### PR DESCRIPTION
Two findings from CodeRabbit's review of #846 (5 of 5 for the mechanical fixes; `repair_boot.rs:410` is a design call and follows separately).

## 1. Two overlapping daemon reloads could interleave 🗄️

`DbPool::close` clears the **shared handle before awaiting** the underlying close, so:

1. caller A closes — the handle is now `None`, A is still awaiting
2. caller B sees `None`, treats it as "nothing to close", signals its own restart and **reopens** a fresh pool
3. A resumes, signals a second restart, and reopens over B's pool

That leaves a daemon restart signalled while a live pool spans it — precisely what the close/reopen dance exists to prevent, and the condition `db_pool.rs`'s header cites a corruption incident for.

macOS reached this through `reload_throttled` and so happened to be covered by a lock that exists for a completely different reason (launchd's `ThrottleInterval`). **Windows deliberately skips that throttle and had nothing.**

`with_reload_lock` puts the guarantee in one place for both platforms, nested inside the throttle with no ordering hazard, and is generic over the work so the mutual exclusion is testable without launchctl or a real pool.

## 2. The tutorial could hang forever on a settings read 🩺

`waitForWorklogAnswered` awaited `probe()` with no deadline, twice — the baseline read and each poll. A Tauri `get_settings` that never settles blocks **inside** the loop, so `Date.now() < deadline` never runs again and the tour can neither close the dialog nor finish.

That is the same unbounded-wait class this function was written to remove, one level down.

Each read is now raced against the **remaining** deadline. A timed-out read reports `undefined`, which is already the "read failed" case the comparison handles — correctly *not* counted as a user answer, since a recovered read is not a response.

## Both regression tests were verified to fail without their fix

```
two reload cycles were inside the critical section at once
```
```
^ this test timed out after 5000ms
```

and both pass with the fix restored.

I checked rather than assumed because **every test in this series that could not fail was found by CodeRabbit, not by me** — the `main.rs` coverage entry (#881) and a blind-edit clobber (#880). The interleaving one runs 8 concurrent tasks and yields across the critical section, because a race that only sometimes reproduces is worse than no test.

## Tests

3 added. `cargo test --workspace` green (27 suites), `bun test` green (905 tests / 63 files), fmt + clippy clean.

Siblings: #880, #881, #882, #883.