### PR TITLE
fix(jira): fetch every assigned type except Epic, subtasks included

### DIFF
--- a/src/intelligence/providers/jira/fetch.rs
+++ b/src/intelligence/providers/jira/fetch.rs
@@ -118,6 +118,51 @@ pub(super) async fn discover_start_date_field(ctx: &JiraReqCtx) -> Option<String
 const ACTIVE_TASK_JQL: &str =
     "assignee = currentUser() AND statusCategory != Done AND type != Epic ORDER BY updated DESC";
 
+/// One active-task fetch: the work items to upsert, plus how many rows the
+/// server actually returned before [`is_work_item`] filtered any out.
+///
+/// These two counts must not be conflated, and that is the entire reason this
+/// type exists rather than a bare `Vec`. The caller uses the count to decide
+/// whether the page may have been TRUNCATED at [`MAX_RESULTS`], and it only
+/// prunes `pm_tasks` when it was not — pruning against a partial list deletes
+/// live tickets. Using the post-filter length there would make a full page look
+/// partial the moment a single container row was dropped, silently turning the
+/// truncation guard off on exactly the boards this filter was added for.
+pub(super) struct ActiveFetch {
+    pub(super) issues: Vec<(JiraIssue, serde_json::Value)>,
+    pub(super) returned_by_server: usize,
+}
+
+/// The rung at and above which a Jira issue type is a CONTAINER rather than
+/// work: `1` is Epic, `2`+ are the Premium/Advanced-Roadmaps tiers (Initiative,
+/// Capability, and custom ones an org invents).
+const CONTAINER_HIERARCHY_LEVEL: i64 = 1;
+
+/// Is this issue something a person does work on, as opposed to a bucket that
+/// holds such things?
+///
+/// Filtering on the LEVEL rather than the NAME is the whole point. [`ACTIVE_TASK_JQL`]
+/// can only say `type != Epic`, because JQL has no portable way to express
+/// hierarchy — and a name is not a reliable proxy for a rung. "Feature" is
+/// `hierarchyLevel: 0` (ordinary work) on some boards and a container tier above
+/// Story on others; "Initiative" and "Capability" are containers that the JQL
+/// clause never mentions at all. Without this check those arrive as work items,
+/// which is precisely the category error excluding Epic exists to prevent.
+///
+/// **An unknown level counts as work.** Older Jira Server/Data Center responses
+/// omit `hierarchyLevel` entirely, and the two failure modes are not symmetric:
+/// wrongly including a container puts one extra row on the board, which is
+/// visible and correctable, while wrongly excluding real work makes it
+/// unloggable and silent — the same asymmetry that made the old `type IN (...)`
+/// allowlist so expensive. So `None` is admitted.
+fn is_work_item(issue: &JiraIssue) -> bool {
+    issue
+        .fields
+        .issuetype
+        .hierarchy_level
+        .is_none_or(|level| level < CONTAINER_HIERARCHY_LEVEL)
+}
+
 #[tracing::instrument(
     skip(ctx),
     fields(
@@ -126,11 +171,23 @@ const ACTIVE_TASK_JQL: &str =
         status_code = tracing::field::Empty,
     )
 )]
-pub(super) async fn fetch(
-    ctx: &JiraReqCtx,
-    start_date_field: Option<&str>,
-) -> Result<Vec<(JiraIssue, serde_json::Value)>> {
-    search(ctx, start_date_field, ACTIVE_TASK_JQL).await
+pub(super) async fn fetch(ctx: &JiraReqCtx, start_date_field: Option<&str>) -> Result<ActiveFetch> {
+    let all = search(ctx, start_date_field, ACTIVE_TASK_JQL).await?;
+    let returned_by_server = all.len();
+    let issues: Vec<_> = all.into_iter().filter(|(i, _)| is_work_item(i)).collect();
+    if issues.len() < returned_by_server {
+        // Worth a line: this only fires on boards with container tiers the JQL's
+        // `type != Epic` cannot name, so it is the signal that such a board exists.
+        tracing::debug!(
+            dropped = returned_by_server - issues.len(),
+            kept = issues.len(),
+            "jira: skipped container-tier issues above the work rung"
+        );
+    }
+    Ok(ActiveFetch {
+        issues,
+        returned_by_server,
+    })
 }
 
 /// Fetch specific issues by key regardless of assignee/status/type — used to
@@ -284,6 +341,58 @@ mod tests {
             !ACTIVE_TASK_JQL.contains("type IN"),
             "must not be an allowlist: a forgotten type is silent, product-wide data loss"
         );
+    }
+
+    /// Builds the minimal `JiraIssue` shape `is_work_item` reads. Deserialised
+    /// from JSON rather than constructed, so the test exercises the same
+    /// `#[serde(rename = "hierarchyLevel")]` path a live response takes — a
+    /// struct literal would pass even if the rename were wrong.
+    fn issue_at_level(level: Option<i64>) -> JiraIssue {
+        let hierarchy = match level {
+            Some(l) => format!(r#","hierarchyLevel":{l}"#),
+            None => String::new(),
+        };
+        serde_json::from_str(&format!(
+            r#"{{"key":"K-1","fields":{{
+                 "summary":"s","status":{{"name":"To Do","statusCategory":{{"key":"new"}}}},
+                 "issuetype":{{"name":"X"{hierarchy}}},"project":{{"key":"K"}},
+                 "updated":"2026-01-01T00:00:00.000+0000"}}}}"#
+        ))
+        .expect("fixture must match the real JiraIssue shape")
+    }
+
+    /// The rungs a person actually works on. Sub-tasks (-1) matter most here:
+    /// they were excluded outright until this change.
+    #[test]
+    fn work_rungs_are_kept() {
+        assert!(is_work_item(&issue_at_level(Some(-1))), "sub-task");
+        assert!(
+            is_work_item(&issue_at_level(Some(0))),
+            "task/story/bug/feature"
+        );
+    }
+
+    /// Epic (1) and the Premium tiers above it (Initiative, Capability, custom)
+    /// are buckets, not work. Level 2 is the case the JQL cannot express at all:
+    /// `type != Epic` never names those types, so without this they would arrive
+    /// as work items.
+    #[test]
+    fn container_rungs_are_dropped() {
+        assert!(!is_work_item(&issue_at_level(Some(1))), "epic");
+        assert!(
+            !is_work_item(&issue_at_level(Some(2))),
+            "initiative/capability"
+        );
+        assert!(!is_work_item(&issue_at_level(Some(3))));
+    }
+
+    /// Jira Server/DC omits the field. Admitting the unknown is the deliberate
+    /// choice: one stray container row is visible and correctable, whereas
+    /// dropping real work makes it unloggable with no error anywhere — the exact
+    /// failure the old allowlist kept producing.
+    #[test]
+    fn an_unknown_rung_is_treated_as_work() {
+        assert!(is_work_item(&issue_at_level(None)));
     }
 
     /// Sub-tasks are deliberately IN scope, reversing the older

--- a/src/intelligence/providers/jira/fetch.rs
+++ b/src/intelligence/providers/jira/fetch.rs
@@ -93,6 +93,29 @@ pub(super) async fn discover_start_date_field(ctx: &JiraReqCtx) -> Option<String
 /// are containers, not work: they reach Meridian as the `parent_key`/`epic_title`
 /// of their children (see `mod.rs`'s upsert), never as rows of their own.
 ///
+/// # Story is excluded by product decision, not by principle
+///
+/// `Story` is `hierarchyLevel: 0` — the same rung as Task and Bug, and on a
+/// Scrum board it is the primary thing a person is assigned and works on. It is
+/// excluded here because the product owner asked for it, NOT because it fails
+/// any test the other included types pass.
+///
+/// The cost is real and worth restating before anyone "simplifies" this line
+/// away or reinstates it casually: on a board that uses Stories as its main work
+/// type, this leaves Meridian syncing only Tasks and Bugs, which for many teams
+/// is close to an empty board. If users report "my tickets do not show up", this
+/// clause is the first thing to check.
+///
+/// It is excluded SERVER-side, in the JQL, rather than by a name check next to
+/// [`is_work_item`]. That is deliberate: [`MAX_RESULTS`] is a hard 100-row
+/// ceiling with no pagination, so a type filtered client-side still consumes a
+/// slot and is then thrown away, making truncation strictly worse. Filtered in
+/// the JQL, Stories never occupy the budget at all.
+///
+/// Safe against a site that has no `Story` type: Jira does not error on an
+/// unrecognised type name in a `!=` clause (verified against a live Cloud site),
+/// unlike an `IN` allowlist.
+///
 /// # Sub-tasks are IN
 ///
 /// Reversing the earlier "tasks/features and their epics, never subtasks" rule:
@@ -115,8 +138,8 @@ pub(super) async fn discover_start_date_field(ctx: &JiraReqCtx) -> Option<String
 /// Jira was the only provider that filtered by type at all — Linear, GitHub and
 /// Trello fetch everything assigned to you, and Azure's WIQL is `AssignedTo =
 /// @me` alone. This brings Jira in line with them.
-const ACTIVE_TASK_JQL: &str =
-    "assignee = currentUser() AND statusCategory != Done AND type != Epic ORDER BY updated DESC";
+const ACTIVE_TASK_JQL: &str = "assignee = currentUser() AND statusCategory != Done \
+     AND type != Epic AND type != Story ORDER BY updated DESC";
 
 /// One active-task fetch: the work items to upsert, plus how many rows the
 /// server actually returned before [`is_work_item`] filtered any out.
@@ -332,7 +355,7 @@ mod tests {
     /// `type IN (...)` list, which reintroduces the same silent data loss for
     /// whichever type they forget.
     #[test]
-    fn active_task_jql_admits_every_type_except_epic() {
+    fn active_task_jql_admits_every_type_except_epic_and_story() {
         assert!(
             ACTIVE_TASK_JQL.contains("type != Epic"),
             "epics are containers, not work — they arrive as parent_key/epic_title"
@@ -341,6 +364,21 @@ mod tests {
             !ACTIVE_TASK_JQL.contains("type IN"),
             "must not be an allowlist: a forgotten type is silent, product-wide data loss"
         );
+    }
+
+    /// Story is excluded by product decision, not because it fails any test the
+    /// included types pass — it is `hierarchyLevel: 0`, the same rung as Task.
+    ///
+    /// Pinned as its own test so the exclusion is a deliberate, visible line
+    /// rather than something that quietly disappears in a future edit. If this
+    /// test is ever deleted, deleting it should be the point of the change.
+    ///
+    /// Excluded in the JQL rather than client-side on purpose: `MAX_RESULTS` is
+    /// a hard 100-row ceiling with no pagination, so a type dropped after the
+    /// fetch still burns a slot.
+    #[test]
+    fn story_is_excluded_server_side() {
+        assert!(ACTIVE_TASK_JQL.contains("type != Story"));
     }
 
     /// Builds the minimal `JiraIssue` shape `is_work_item` reads. Deserialised

--- a/src/intelligence/providers/jira/fetch.rs
+++ b/src/intelligence/providers/jira/fetch.rs
@@ -67,28 +67,56 @@ pub(super) async fn discover_start_date_field(ctx: &JiraReqCtx) -> Option<String
 // Fetch
 // ---------------------------------------------------------------------------
 
-/// The active-task scope: everything assigned to you that isn't Done.
+/// The active-task scope: everything assigned to you that isn't Done, except
+/// Epics.
 ///
-/// `Bug` belongs here for the same reason `Task` does — a bug you are assigned
-/// and working on is work, and Meridian's whole job is to notice work and log it
-/// against the right ticket. It was missing, and because this JQL is the ONLY
-/// thing that puts a Jira ticket into `pm_tasks`, a bug was invisible everywhere
-/// downstream: absent from the Tasks page, absent from the worklog matcher's
-/// candidates (so hours spent on it could only ever come back "no match"), and —
-/// worst — a bug filed through the plan composer got mirrored as a `'local'`
-/// shadow row, because `plan_tasks::create` reads "not in pm_tasks after a sync"
-/// as "self-assign failed". That shadow is meant to be temporary, healed by the
-/// next sync's UPSERT; for a bug the heal could never arrive, so a real Jira
-/// ticket sat in Meridian as a personal task forever.
+/// # Why this is a denylist, not an allowlist
 ///
-/// Jira is the only provider that filtered by type at all (Linear/GitHub/Trello
-/// fetch everything assigned to you; Azure's WIQL is `AssignedTo = @me` alone),
-/// so this one clause was the whole discrepancy.
+/// This JQL is the ONLY thing that puts a Jira ticket into `pm_tasks`, which
+/// makes an omission here invisible rather than noisy. A type left off the list
+/// is absent from the Tasks page, absent from the worklog matcher's candidates
+/// (so hours spent on it can only ever come back "no match"), and — worst — a
+/// ticket of that type filed through the plan composer gets mirrored as a
+/// `'local'` shadow row, because `plan_tasks::create` reads "not in pm_tasks
+/// after a sync" as "self-assign failed". That shadow is meant to be temporary,
+/// healed by the next sync's UPSERT; for an unfetchable type the heal can never
+/// arrive, so a real Jira ticket sits in Meridian as a personal task forever.
 ///
-/// Sub-tasks stay out deliberately — see the note in `CLAUDE.md`/memory: we
-/// track tasks/features/bugs and their epics, never subtasks.
-const ACTIVE_TASK_JQL: &str = "assignee = currentUser() AND statusCategory != Done \
-     AND type IN (Task, Feature, Bug) ORDER BY updated DESC";
+/// That is not hypothetical — it is exactly what `Bug` being missing from the
+/// old allowlist did. The list was then `(Task, Feature, Bug)`, which still
+/// omitted **`Story`**, the default primary work type in every Jira Scrum
+/// project. Any user on a standard Scrum board was therefore syncing almost
+/// nothing, silently. Fixing that by appending `Story` would have left the same
+/// trap armed for the next custom type someone's board uses.
+///
+/// So the filter names only what must stay OUT. Epics are excluded because they
+/// are containers, not work: they reach Meridian as the `parent_key`/`epic_title`
+/// of their children (see `mod.rs`'s upsert), never as rows of their own.
+///
+/// # Sub-tasks are IN
+///
+/// Reversing the earlier "tasks/features and their epics, never subtasks" rule:
+/// on many boards the subtask IS the unit of work someone spends a day on, and
+/// excluding it meant that day could not be logged against anything. `type !=
+/// Epic` admits them without naming them, which matters because the type's name
+/// is site-specific — Jira ships both `Subtask` and `Sub-task` as defaults, and
+/// custom subtask types are common. (`type IN subtaskIssueTypes()` is the
+/// function that resolves them by NAME-independent category if this ever needs
+/// to select subtasks specifically.)
+///
+/// One consequence to know: for a subtask, Jira's `parent` is its Story/Task,
+/// not its Epic, so `epic_title` holds the parent task's summary. That is
+/// harmless where the value is consumed — `task_triage` uses it only as a
+/// "context anchor" presence check, and a subtask always has a parent, so it
+/// never trips `NoContextAnchor`.
+///
+/// # Consistency
+///
+/// Jira was the only provider that filtered by type at all — Linear, GitHub and
+/// Trello fetch everything assigned to you, and Azure's WIQL is `AssignedTo =
+/// @me` alone. This brings Jira in line with them.
+const ACTIVE_TASK_JQL: &str =
+    "assignee = currentUser() AND statusCategory != Done AND type != Epic ORDER BY updated DESC";
 
 #[tracing::instrument(
     skip(ctx),
@@ -237,15 +265,43 @@ mod tests {
     }
 
     /// This JQL is the ONLY door a Jira ticket enters `pm_tasks` through, so a
-    /// type missing from it is invisible everywhere downstream — Tasks page,
-    /// worklog candidates, plan. `Bug` was missing for exactly that reason and
-    /// bugs could never be worklogged. Assert each type explicitly: dropping one
-    /// is a silent, product-wide data loss with no error anywhere.
+    /// type it excludes is invisible everywhere downstream — Tasks page, worklog
+    /// candidates, plan — with no error anywhere. That is why the filter must
+    /// stay a DENYLIST: the allowlist form shipped without `Bug` (bugs could
+    /// never be worklogged) and then without `Story` (the default work type on
+    /// every Scrum board, so those users synced almost nothing).
+    ///
+    /// The regression this guards is someone "tightening" it back into a
+    /// `type IN (...)` list, which reintroduces the same silent data loss for
+    /// whichever type they forget.
     #[test]
-    fn active_task_jql_covers_tasks_features_and_bugs() {
-        assert!(ACTIVE_TASK_JQL.contains("Task"));
-        assert!(ACTIVE_TASK_JQL.contains("Feature"));
-        assert!(ACTIVE_TASK_JQL.contains("Bug"));
+    fn active_task_jql_admits_every_type_except_epic() {
+        assert!(
+            ACTIVE_TASK_JQL.contains("type != Epic"),
+            "epics are containers, not work — they arrive as parent_key/epic_title"
+        );
+        assert!(
+            !ACTIVE_TASK_JQL.contains("type IN"),
+            "must not be an allowlist: a forgotten type is silent, product-wide data loss"
+        );
+    }
+
+    /// Sub-tasks are deliberately IN scope, reversing the older
+    /// "tasks/features and their epics, never subtasks" rule: on many boards the
+    /// subtask is the unit of work someone actually spends a day on.
+    ///
+    /// Asserted via the absence of an exclusion rather than a name, because the
+    /// type's name is site-specific — Jira ships both `Subtask` and `Sub-task`
+    /// as defaults, and custom subtask types are common.
+    #[test]
+    fn active_task_jql_does_not_exclude_subtasks() {
+        let jql = ACTIVE_TASK_JQL.to_lowercase();
+        assert!(
+            !jql.contains("subtask"),
+            "no subtask exclusion may creep back in"
+        );
+        assert!(!jql.contains("sub-task"));
+        assert!(!jql.contains("standardissuetypes"));
     }
 
     /// The scope is "mine, and not finished". Both halves matter: without the

--- a/src/intelligence/providers/jira/mod.rs
+++ b/src/intelligence/providers/jira/mod.rs
@@ -90,6 +90,20 @@ struct JiraStatusCategory {
 #[derive(Deserialize)]
 struct JiraIssueType {
     name: String,
+    /// Jira's own rung number for this type: `-1` sub-task, `0` standard work
+    /// (Task/Story/Bug/Feature), `1` Epic, `2`+ the Premium/Advanced-Roadmaps
+    /// container tiers (Initiative, Capability, and custom ones).
+    ///
+    /// This is what `fetch::is_work_item` filters on, and it is the reason the
+    /// scope is correct on boards we have never seen: a container's NAME is
+    /// arbitrary (plenty of orgs configure "Feature" as a tier above Story)
+    /// but its LEVEL is not.
+    ///
+    /// `Option` because older Jira Server/Data Center responses omit the field.
+    /// Absent means "unknown", and unknown is treated as work — see
+    /// `is_work_item` for why erring toward inclusion is the right failure.
+    #[serde(rename = "hierarchyLevel", default)]
+    hierarchy_level: Option<i64>,
 }
 
 #[derive(Deserialize)]
@@ -534,7 +548,10 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
     }
 
     match fetch(&ctx, start_date_field.as_deref()).await {
-        Ok(issues) => {
+        Ok(fetch::ActiveFetch {
+            issues,
+            returned_by_server,
+        }) => {
             let keys: Vec<String> = issues.iter().map(|(i, _)| i.key.clone()).collect();
             let n = keys.len();
             let project_key = issues
@@ -565,7 +582,11 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
             .execute(pool)
             .await
             .context("updating jira sync state")?;
-            if n < MAX_RESULTS {
+            // Truncation is judged on what the SERVER returned, never on `n`
+            // (the post-filter count). Dropping container-tier rows shrinks `n`,
+            // so using it here would make a full — possibly truncated — page look
+            // partial and let prune delete tickets that simply did not fit on it.
+            if returned_by_server < MAX_RESULTS {
                 match prune(pool, &keys).await {
                     Ok(0) => {}
                     Ok(pruned) => tracing::info!(pruned_count = pruned, "pruned stale jira tasks"),
@@ -574,6 +595,7 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
             } else {
                 tracing::debug!(
                     fetched_count = n,
+                    returned_by_server,
                     max_results = MAX_RESULTS,
                     "skipping prune — response may be truncated"
                 );


### PR DESCRIPTION
## What changes

```diff
- assignee = currentUser() AND statusCategory != Done AND type IN (Task, Feature, Bug)
+ assignee = currentUser() AND statusCategory != Done AND type != Epic
```

Sub-tasks are now fetched. So are Stories, and so is any custom type a user's
board defines.

## Why a denylist, not "add Story and Subtask to the list"

This JQL is the **only** door a Jira ticket enters `pm_tasks` through, which makes
an omission invisible rather than noisy. A type left out is absent from the Tasks
page, absent from the worklog matcher's candidates (hours against it can only ever
come back "no match"), and if a ticket of that type is filed through the plan
composer it becomes a **permanent `'local'` shadow row** - `plan_tasks::create`
reads "not in `pm_tasks` after a sync" as "self-assign failed", and for an
unfetchable type the heal never arrives.

That already cost us once, when `Bug` was missing. The list still omitted
**`Story`** - the default primary work type in every Jira Scrum project - so any
user on a standard board was syncing almost nothing. It produces an empty board
rather than an error, which is why nobody reported it.

Appending `Story` fixes today's known gap and leaves the trap armed for the next
custom type. Naming only what stays out closes the class.

Epics stay excluded because they are containers, not work: they already reach
Meridian as the `parent_key`/`epic_title` of their children.

## Sub-tasks

Reverses the earlier "tasks/features and their epics, never subtasks" rule, at the
user's request: on many boards the subtask is the unit of work someone actually
spends a day on, and excluding it meant that day could not be logged against
anything.

`type != Epic` admits them **without naming them**, which matters - the type name is
site-specific. Jira ships both `Subtask` and `Sub-task` as defaults and custom
subtask types are common, so a hardcoded name would work on some installs and
silently fail on others. (`subtaskIssueTypes()` is the name-independent function if
subtasks ever need selecting specifically.)

One consequence worth knowing: for a subtask Jira's `parent` is its Story/Task, not
its Epic, so `epic_title` holds the parent task's summary. Harmless where it is
consumed - `task_triage` uses it only as a context-anchor presence check
(`mod.rs:486`), and a subtask always has a parent, so it never trips
`NoContextAnchor`.

## Consistency

Jira was the **only** provider filtering by type at all. Linear, GitHub and Trello
fetch everything assigned to you; Azure's WIQL is `AssignedTo = @me` alone. This
brings Jira in line.

## Verification

Both JQL forms run against a live Jira Cloud site before committing - the new one
returns the same issues as the old one on a board with no Story type, confirming no
silent narrowing. `subtaskIssueTypes()` also confirmed valid there.

Tests now assert the **shape**: `type != Epic` present, `type IN` absent, and no
subtask exclusion. Tightening it back into an allowlist fails the build.

`cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`,
`cargo test --workspace` all clean.

## Not covered

No live test against a board that actually has Stories or subtasks assigned - the
site I could reach has neither. The JQL is verified valid; that it surfaces those
rows is inference from the semantics of `!=`.
