### PR TITLE
fix(jira): scope the active fetch to work items, sub-tasks included

### DIFF
--- a/src/intelligence/providers/jira/fetch.rs
+++ b/src/intelligence/providers/jira/fetch.rs
@@ -67,28 +67,136 @@ pub(super) async fn discover_start_date_field(ctx: &JiraReqCtx) -> Option<String
 // Fetch
 // ---------------------------------------------------------------------------
 
-/// The active-task scope: everything assigned to you that isn't Done.
+/// The active-task scope: everything assigned to you that isn't Done, except
+/// Epics.
 ///
-/// `Bug` belongs here for the same reason `Task` does — a bug you are assigned
-/// and working on is work, and Meridian's whole job is to notice work and log it
-/// against the right ticket. It was missing, and because this JQL is the ONLY
-/// thing that puts a Jira ticket into `pm_tasks`, a bug was invisible everywhere
-/// downstream: absent from the Tasks page, absent from the worklog matcher's
-/// candidates (so hours spent on it could only ever come back "no match"), and —
-/// worst — a bug filed through the plan composer got mirrored as a `'local'`
-/// shadow row, because `plan_tasks::create` reads "not in pm_tasks after a sync"
-/// as "self-assign failed". That shadow is meant to be temporary, healed by the
-/// next sync's UPSERT; for a bug the heal could never arrive, so a real Jira
-/// ticket sat in Meridian as a personal task forever.
+/// # Why this is a denylist, not an allowlist
 ///
-/// Jira is the only provider that filtered by type at all (Linear/GitHub/Trello
-/// fetch everything assigned to you; Azure's WIQL is `AssignedTo = @me` alone),
-/// so this one clause was the whole discrepancy.
+/// This JQL is the ONLY thing that puts a Jira ticket into `pm_tasks`, which
+/// makes an omission here invisible rather than noisy. A type left off the list
+/// is absent from the Tasks page, absent from the worklog matcher's candidates
+/// (so hours spent on it can only ever come back "no match"), and — worst — a
+/// ticket of that type filed through the plan composer gets mirrored as a
+/// `'local'` shadow row, because `plan_tasks::create` reads "not in pm_tasks
+/// after a sync" as "self-assign failed". That shadow is meant to be temporary,
+/// healed by the next sync's UPSERT; for an unfetchable type the heal can never
+/// arrive, so a real Jira ticket sits in Meridian as a personal task forever.
 ///
-/// Sub-tasks stay out deliberately — see the note in `CLAUDE.md`/memory: we
-/// track tasks/features/bugs and their epics, never subtasks.
+/// That is not hypothetical — it is exactly what `Bug` being missing from the
+/// old allowlist did. The list was then `(Task, Feature, Bug)`, which still
+/// omitted **`Story`**, the default primary work type in every Jira Scrum
+/// project. Any user on a standard Scrum board was therefore syncing almost
+/// nothing, silently. Fixing that by appending `Story` would have left the same
+/// trap armed for the next custom type someone's board uses.
+///
+/// So the filter names only what must stay OUT. Epics are excluded because they
+/// are containers, not work: they reach Meridian as the `parent_key`/`epic_title`
+/// of their children (see `mod.rs`'s upsert), never as rows of their own.
+///
+/// # `Story` and `Feature` are excluded by product decision, not by principle
+///
+/// Both are `hierarchyLevel: 0` — the SAME rung as Task and Bug. Neither is a
+/// container; Jira treats each as an ordinary work item a person is assigned and
+/// works on, and on a Scrum board `Story` is usually the primary one. They are
+/// excluded because the product owner asked for it, NOT because they fail any
+/// test the included types pass, and NOT because they sit above the work rung —
+/// [`is_work_item`] would happily admit both.
+///
+/// That distinction matters for the next person here, because the two exclusion
+/// mechanisms in this module look alike and are not:
+///
+/// - `type != Epic` is **structural**. Epics are containers; they reach Meridian
+///   as the `parent_key`/`epic_title` of their children (see `mod.rs`'s upsert),
+///   never as rows of their own. Removing it would be a bug.
+/// - `type != Story` / `type != Feature` are **policy**. Nothing breaks if they
+///   are removed; the board simply gets more tickets.
+///
+/// The cost is real and worth restating before anyone reinstates or removes
+/// these casually: what is left is Tasks, Bugs, sub-tasks and custom types. On a
+/// board that uses Stories or Features as its main work type this is close to an
+/// empty board, and an hour spent on one of those tickets can only ever come
+/// back "no match", silently. **If a user reports "my tickets do not show up",
+/// this line is the first thing to check.**
+///
+/// Both are excluded SERVER-side, in the JQL, rather than by a name check next
+/// to [`is_work_item`]. That is deliberate: [`MAX_RESULTS`] is a hard 100-row
+/// ceiling with no pagination, so a type filtered client-side still consumes a
+/// slot and is then thrown away, making truncation strictly worse. Filtered in
+/// the JQL, they never occupy the budget at all.
+///
+/// Safe against a site that has neither type: Jira does not error on an
+/// unrecognised type name in a `!=` clause (verified against a live Cloud site),
+/// unlike an `IN` allowlist.
+///
+/// # Sub-tasks are IN
+///
+/// Reversing the earlier "tasks/features and their epics, never subtasks" rule:
+/// on many boards the subtask IS the unit of work someone spends a day on, and
+/// excluding it meant that day could not be logged against anything. `type !=
+/// Epic` admits them without naming them, which matters because the type's name
+/// is site-specific — Jira ships both `Subtask` and `Sub-task` as defaults, and
+/// custom subtask types are common. (`type IN subtaskIssueTypes()` is the
+/// function that resolves them by NAME-independent category if this ever needs
+/// to select subtasks specifically.)
+///
+/// One consequence to know: for a subtask, Jira's `parent` is its Story/Task,
+/// not its Epic, so `epic_title` holds the parent task's summary. That is
+/// harmless where the value is consumed — `task_triage` uses it only as a
+/// "context anchor" presence check, and a subtask always has a parent, so it
+/// never trips `NoContextAnchor`.
+///
+/// # Consistency
+///
+/// Jira was the only provider that filtered by type at all — Linear, GitHub and
+/// Trello fetch everything assigned to you, and Azure's WIQL is `AssignedTo =
+/// @me` alone. This brings Jira in line with them.
 const ACTIVE_TASK_JQL: &str = "assignee = currentUser() AND statusCategory != Done \
-     AND type IN (Task, Feature, Bug) ORDER BY updated DESC";
+     AND type != Epic AND type != Story AND type != Feature ORDER BY updated DESC";
+
+/// One active-task fetch: the work items to upsert, plus how many rows the
+/// server actually returned before [`is_work_item`] filtered any out.
+///
+/// These two counts must not be conflated, and that is the entire reason this
+/// type exists rather than a bare `Vec`. The caller uses the count to decide
+/// whether the page may have been TRUNCATED at [`MAX_RESULTS`], and it only
+/// prunes `pm_tasks` when it was not — pruning against a partial list deletes
+/// live tickets. Using the post-filter length there would make a full page look
+/// partial the moment a single container row was dropped, silently turning the
+/// truncation guard off on exactly the boards this filter was added for.
+pub(super) struct ActiveFetch {
+    pub(super) issues: Vec<(JiraIssue, serde_json::Value)>,
+    pub(super) returned_by_server: usize,
+}
+
+/// The rung at and above which a Jira issue type is a CONTAINER rather than
+/// work: `1` is Epic, `2`+ are the Premium/Advanced-Roadmaps tiers (Initiative,
+/// Capability, and custom ones an org invents).
+const CONTAINER_HIERARCHY_LEVEL: i64 = 1;
+
+/// Is this issue something a person does work on, as opposed to a bucket that
+/// holds such things?
+///
+/// Filtering on the LEVEL rather than the NAME is the whole point. [`ACTIVE_TASK_JQL`]
+/// can only say `type != Epic`, because JQL has no portable way to express
+/// hierarchy — and a name is not a reliable proxy for a rung. "Feature" is
+/// `hierarchyLevel: 0` (ordinary work) on some boards and a container tier above
+/// Story on others; "Initiative" and "Capability" are containers that the JQL
+/// clause never mentions at all. Without this check those arrive as work items,
+/// which is precisely the category error excluding Epic exists to prevent.
+///
+/// **An unknown level counts as work.** Older Jira Server/Data Center responses
+/// omit `hierarchyLevel` entirely, and the two failure modes are not symmetric:
+/// wrongly including a container puts one extra row on the board, which is
+/// visible and correctable, while wrongly excluding real work makes it
+/// unloggable and silent — the same asymmetry that made the old `type IN (...)`
+/// allowlist so expensive. So `None` is admitted.
+fn is_work_item(issue: &JiraIssue) -> bool {
+    issue
+        .fields
+        .issuetype
+        .hierarchy_level
+        .is_none_or(|level| level < CONTAINER_HIERARCHY_LEVEL)
+}
 
 #[tracing::instrument(
     skip(ctx),
@@ -98,11 +206,23 @@ const ACTIVE_TASK_JQL: &str = "assignee = currentUser() AND statusCategory != Do
         status_code = tracing::field::Empty,
     )
 )]
-pub(super) async fn fetch(
-    ctx: &JiraReqCtx,
-    start_date_field: Option<&str>,
-) -> Result<Vec<(JiraIssue, serde_json::Value)>> {
-    search(ctx, start_date_field, ACTIVE_TASK_JQL).await
+pub(super) async fn fetch(ctx: &JiraReqCtx, start_date_field: Option<&str>) -> Result<ActiveFetch> {
+    let all = search(ctx, start_date_field, ACTIVE_TASK_JQL).await?;
+    let returned_by_server = all.len();
+    let issues: Vec<_> = all.into_iter().filter(|(i, _)| is_work_item(i)).collect();
+    if issues.len() < returned_by_server {
+        // Worth a line: this only fires on boards with container tiers the JQL's
+        // `type != Epic` cannot name, so it is the signal that such a board exists.
+        tracing::debug!(
+            dropped = returned_by_server - issues.len(),
+            kept = issues.len(),
+            "jira: skipped container-tier issues above the work rung"
+        );
+    }
+    Ok(ActiveFetch {
+        issues,
+        returned_by_server,
+    })
 }
 
 /// Fetch specific issues by key regardless of assignee/status/type — used to
@@ -237,15 +357,128 @@ mod tests {
     }
 
     /// This JQL is the ONLY door a Jira ticket enters `pm_tasks` through, so a
-    /// type missing from it is invisible everywhere downstream — Tasks page,
-    /// worklog candidates, plan. `Bug` was missing for exactly that reason and
-    /// bugs could never be worklogged. Assert each type explicitly: dropping one
-    /// is a silent, product-wide data loss with no error anywhere.
+    /// type it excludes is invisible everywhere downstream — Tasks page, worklog
+    /// candidates, plan — with no error anywhere. That is why the filter must
+    /// stay a DENYLIST: the allowlist form shipped without `Bug` (bugs could
+    /// never be worklogged) and then without `Story` (the default work type on
+    /// every Scrum board, so those users synced almost nothing).
+    ///
+    /// The regression this guards is someone "tightening" it back into a
+    /// `type IN (...)` list, which reintroduces the same silent data loss for
+    /// whichever type they forget.
     #[test]
-    fn active_task_jql_covers_tasks_features_and_bugs() {
-        assert!(ACTIVE_TASK_JQL.contains("Task"));
-        assert!(ACTIVE_TASK_JQL.contains("Feature"));
-        assert!(ACTIVE_TASK_JQL.contains("Bug"));
+    fn epic_is_excluded_and_the_filter_stays_a_denylist() {
+        assert!(
+            ACTIVE_TASK_JQL.contains("type != Epic"),
+            "epics are containers, not work — they arrive as parent_key/epic_title"
+        );
+        assert!(
+            !ACTIVE_TASK_JQL.contains("type IN"),
+            "must not be an allowlist: a forgotten type is silent, product-wide data loss"
+        );
+    }
+
+    /// `Story` and `Feature` are excluded by product decision, not because they
+    /// fail any test the included types pass — both are `hierarchyLevel: 0`, the
+    /// same rung as Task, and [`is_work_item`] would admit both.
+    ///
+    /// Pinned as its own test so each exclusion stays a deliberate, visible line
+    /// rather than something that quietly disappears in a later edit. If this
+    /// test is ever deleted, deleting it should BE the point of the change.
+    ///
+    /// Excluded in the JQL rather than client-side on purpose: `MAX_RESULTS` is
+    /// a hard 100-row ceiling with no pagination, so a type dropped after the
+    /// fetch still burns a slot.
+    #[test]
+    fn story_and_feature_are_excluded_server_side() {
+        assert!(ACTIVE_TASK_JQL.contains("type != Story"));
+        assert!(ACTIVE_TASK_JQL.contains("type != Feature"));
+    }
+
+    /// The scope after every exclusion: Task, Bug, sub-tasks and custom types.
+    ///
+    /// Asserted as absences because the whole design is a denylist — naming what
+    /// is IN would reintroduce the allowlist trap that hid `Bug` and then
+    /// `Story`. Custom work types are covered precisely BECAUSE they are never
+    /// named anywhere in this string.
+    #[test]
+    fn nothing_else_is_excluded() {
+        for kept in ["Task", "Bug", "Sub-task", "Subtask"] {
+            assert!(
+                !ACTIVE_TASK_JQL.contains(&format!("type != {kept}")),
+                "{kept} must stay in scope"
+            );
+        }
+    }
+
+    /// Builds the minimal `JiraIssue` shape `is_work_item` reads. Deserialised
+    /// from JSON rather than constructed, so the test exercises the same
+    /// `#[serde(rename = "hierarchyLevel")]` path a live response takes — a
+    /// struct literal would pass even if the rename were wrong.
+    fn issue_at_level(level: Option<i64>) -> JiraIssue {
+        let hierarchy = match level {
+            Some(l) => format!(r#","hierarchyLevel":{l}"#),
+            None => String::new(),
+        };
+        serde_json::from_str(&format!(
+            r#"{{"key":"K-1","fields":{{
+                 "summary":"s","status":{{"name":"To Do","statusCategory":{{"key":"new"}}}},
+                 "issuetype":{{"name":"X"{hierarchy}}},"project":{{"key":"K"}},
+                 "updated":"2026-01-01T00:00:00.000+0000"}}}}"#
+        ))
+        .expect("fixture must match the real JiraIssue shape")
+    }
+
+    /// The rungs a person actually works on. Sub-tasks (-1) matter most here:
+    /// they were excluded outright until this change.
+    #[test]
+    fn work_rungs_are_kept() {
+        assert!(is_work_item(&issue_at_level(Some(-1))), "sub-task");
+        assert!(
+            is_work_item(&issue_at_level(Some(0))),
+            "task/story/bug/feature"
+        );
+    }
+
+    /// Epic (1) and the Premium tiers above it (Initiative, Capability, custom)
+    /// are buckets, not work. Level 2 is the case the JQL cannot express at all:
+    /// `type != Epic` never names those types, so without this they would arrive
+    /// as work items.
+    #[test]
+    fn container_rungs_are_dropped() {
+        assert!(!is_work_item(&issue_at_level(Some(1))), "epic");
+        assert!(
+            !is_work_item(&issue_at_level(Some(2))),
+            "initiative/capability"
+        );
+        assert!(!is_work_item(&issue_at_level(Some(3))));
+    }
+
+    /// Jira Server/DC omits the field. Admitting the unknown is the deliberate
+    /// choice: one stray container row is visible and correctable, whereas
+    /// dropping real work makes it unloggable with no error anywhere — the exact
+    /// failure the old allowlist kept producing.
+    #[test]
+    fn an_unknown_rung_is_treated_as_work() {
+        assert!(is_work_item(&issue_at_level(None)));
+    }
+
+    /// Sub-tasks are deliberately IN scope, reversing the older
+    /// "tasks/features and their epics, never subtasks" rule: on many boards the
+    /// subtask is the unit of work someone actually spends a day on.
+    ///
+    /// Asserted via the absence of an exclusion rather than a name, because the
+    /// type's name is site-specific — Jira ships both `Subtask` and `Sub-task`
+    /// as defaults, and custom subtask types are common.
+    #[test]
+    fn active_task_jql_does_not_exclude_subtasks() {
+        let jql = ACTIVE_TASK_JQL.to_lowercase();
+        assert!(
+            !jql.contains("subtask"),
+            "no subtask exclusion may creep back in"
+        );
+        assert!(!jql.contains("sub-task"));
+        assert!(!jql.contains("standardissuetypes"));
     }
 
     /// The scope is "mine, and not finished". Both halves matter: without the

--- a/src/intelligence/providers/jira/mod.rs
+++ b/src/intelligence/providers/jira/mod.rs
@@ -90,6 +90,20 @@ struct JiraStatusCategory {
 #[derive(Deserialize)]
 struct JiraIssueType {
     name: String,
+    /// Jira's own rung number for this type: `-1` sub-task, `0` standard work
+    /// (Task/Story/Bug/Feature), `1` Epic, `2`+ the Premium/Advanced-Roadmaps
+    /// container tiers (Initiative, Capability, and custom ones).
+    ///
+    /// This is what `fetch::is_work_item` filters on, and it is the reason the
+    /// scope is correct on boards we have never seen: a container's NAME is
+    /// arbitrary (plenty of orgs configure "Feature" as a tier above Story)
+    /// but its LEVEL is not.
+    ///
+    /// `Option` because older Jira Server/Data Center responses omit the field.
+    /// Absent means "unknown", and unknown is treated as work — see
+    /// `is_work_item` for why erring toward inclusion is the right failure.
+    #[serde(rename = "hierarchyLevel", default)]
+    hierarchy_level: Option<i64>,
 }
 
 #[derive(Deserialize)]
@@ -316,6 +330,26 @@ async fn upsert(
 /// item from the plan checkbox doesn't delete the very row its Undo (reopen)
 /// needs — see `src/plan_tasks/done.rs`.
 async fn prune(pool: &SqlitePool, fetched_keys: &[String]) -> Result<usize> {
+    // Nothing fetched → prune nothing, deliberately.
+    //
+    // The tempting reading is "the active scope returned no tickets, so every
+    // jira row is stale" — and that would delete the user's whole board. An
+    // empty result has two causes we cannot tell apart here: the user really has
+    // nothing open, and a transient scope/permission problem that answers 200
+    // with zero issues. Wrongly deleting is expensive and looks like data loss;
+    // wrongly keeping leaves stale rows that the next sync clears. So we keep.
+    //
+    // It is also a correctness fix, not only a policy one: an empty slice
+    // renders `NOT IN ()`, which SQLite rejects. The old code relied on the
+    // caller to gate (`tests::prune_with_empty_fetched_keys_is_a_no_op` says as
+    // much) and the caller never did — so this ran, failed, and was swallowed as
+    // a warning. The filtering in `fetch` widened the ways to reach it: `keys`
+    // is now empty whenever every returned row was a container tier, not just
+    // when the user has no open work.
+    if fetched_keys.is_empty() {
+        tracing::debug!("jira: active fetch returned no work items — skipping prune");
+        return Ok(0);
+    }
     let placeholders = fetched_keys
         .iter()
         .map(|_| "?")
@@ -534,7 +568,10 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
     }
 
     match fetch(&ctx, start_date_field.as_deref()).await {
-        Ok(issues) => {
+        Ok(fetch::ActiveFetch {
+            issues,
+            returned_by_server,
+        }) => {
             let keys: Vec<String> = issues.iter().map(|(i, _)| i.key.clone()).collect();
             let n = keys.len();
             let project_key = issues
@@ -565,7 +602,11 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
             .execute(pool)
             .await
             .context("updating jira sync state")?;
-            if n < MAX_RESULTS {
+            // Truncation is judged on what the SERVER returned, never on `n`
+            // (the post-filter count). Dropping container-tier rows shrinks `n`,
+            // so using it here would make a full — possibly truncated — page look
+            // partial and let prune delete tickets that simply did not fit on it.
+            if returned_by_server < MAX_RESULTS {
                 match prune(pool, &keys).await {
                     Ok(0) => {}
                     Ok(pruned) => tracing::info!(pruned_count = pruned, "pruned stale jira tasks"),
@@ -574,6 +615,7 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
             } else {
                 tracing::debug!(
                     fetched_count = n,
+                    returned_by_server,
                     max_results = MAX_RESULTS,
                     "skipping prune — response may be truncated"
                 );

--- a/src/intelligence/providers/jira/tests.rs
+++ b/src/intelligence/providers/jira/tests.rs
@@ -282,24 +282,57 @@ async fn prune_deletes_embedding_before_pm_task() {
 
 #[tokio::test]
 async fn prune_with_empty_fetched_keys_is_a_no_op() {
-    // prune() is only called when fetched_count > 0, but the SQL must not
-    // blow up when called with an empty slice — it would produce
-    // "NOT IN ()" which is invalid SQL. The guard below mirrors what a
-    // caller should do; we verify the guard is sufficient.
+    // An empty fetch must NOT be read as "everything is stale" — that would
+    // delete the user's whole board on a transient scope/permission blip that
+    // answers 200 with zero issues, which is indistinguishable from genuinely
+    // having nothing open.
+    //
+    // This used to be enforced by nothing at all. The comment here claimed
+    // "callers must gate on non-empty fetched_keys", the caller in
+    // `refresh_if_stale` did not, and the empty slice rendered `NOT IN ()` —
+    // invalid SQL — so prune errored and the error was swallowed as a warning.
+    // Right outcome, entirely by accident. prune() now owns the guard, so the
+    // real function is called here rather than a hand-rolled stand-in.
     let pool = make_db().await;
 
     insert_jira_task(&pool, "KAN-30").await;
+    insert_embedding(&pool, "KAN-30").await;
 
-    // An empty IN-list is syntactically invalid in SQLite; callers must
-    // gate on non-empty fetched_keys before calling prune — so prune is
-    // intentionally NOT called here. The task must survive untouched.
+    let deleted = super::prune(&pool, &[])
+        .await
+        .expect("prune must not error");
 
-    // Task must still be present — no prune was called.
+    assert_eq!(deleted, 0, "an empty fetch must delete nothing");
     assert_eq!(
         task_count(&pool, "KAN-30").await,
         1,
-        "task must survive when prune is not called for empty set"
+        "the board must survive an empty fetch"
     );
+    assert_eq!(
+        embedding_count(&pool, "KAN-30").await,
+        1,
+        "embeddings must survive too — they cascade with the task row"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Test: an empty fetch must not flag retained rows off-board either
+// -----------------------------------------------------------------------
+
+/// The sibling half of the guard above. `mark_retained_offboard` is shared by
+/// all five providers, and carried the same `NOT IN ()` defect, so an empty
+/// fetch raised an error there too rather than doing nothing on purpose.
+#[tokio::test]
+async fn empty_fetch_does_not_flag_retained_tasks_off_board() {
+    let pool = make_db().await;
+
+    insert_jira_task(&pool, "KAN-31").await;
+
+    let flagged = crate::intelligence::providers::mark_retained_offboard(&pool, "jira", &[])
+        .await
+        .expect("must not error on an empty fetch");
+
+    assert_eq!(flagged, 0, "an empty fetch must flag nothing off-board");
 }
 
 // -----------------------------------------------------------------------

--- a/src/intelligence/providers/mod.rs
+++ b/src/intelligence/providers/mod.rs
@@ -493,6 +493,19 @@ pub async fn mark_retained_offboard(
     provider: &str,
     fetched_keys: &[String],
 ) -> Result<u64> {
+    // An empty fetch is NOT "everything is stale". Two things produce it — the
+    // user genuinely has nothing open, and a scope/permission blip that returns
+    // 200 with zero issues — and they are indistinguishable from here. Flagging
+    // the whole board off-board on the second one is a bad trade against leaving
+    // it alone on the first, which self-heals on the next sync.
+    //
+    // This also stopped an outright bug: an empty slice renders `NOT IN ()`,
+    // which is invalid SQL, so this path previously raised an error that every
+    // caller swallowed as a warning. It behaved correctly only by accident, and
+    // only as long as nobody looked at the log.
+    if fetched_keys.is_empty() {
+        return Ok(0);
+    }
     let placeholders = fetched_keys
         .iter()
         .map(|_| "?")


### PR DESCRIPTION
Replaces #885, which was closed - this is the same work reviewed end to end, squashed
into one commit, with two latent bugs the review turned up.

## Scope

```
assignee = currentUser() AND statusCategory != Done
  AND type != Epic AND type != Story AND type != Feature
```

| | |
|---|---|
| **In** | Task, Bug, **sub-tasks**, and any **custom** work type |
| **Out** | Epic, Story, Feature |

## Why a denylist

The old filter was `type IN (Task, Feature, Bug)`. This JQL is the **only** door a
ticket enters `pm_tasks` through, so an omission is invisible rather than noisy: the
type is absent from the Tasks page, absent from the worklog matcher's candidates, and
if filed through the plan composer becomes a **permanent `'local'` shadow row** -
`plan_tasks::create` reads "not in `pm_tasks` after a sync" as "self-assign failed",
and the heal never arrives.

That already cost us once, when `Bug` was missing. Naming only what stays out closes
the class, and custom types are covered precisely because they are never named.

Sub-tasks are now in scope, reversing the earlier "never subtasks" rule at the product
owner's request: on many boards the sub-task is the unit of work someone spends a day
on, and excluding it meant that day could not be logged against anything.

## Story and Feature are policy, not principle

Both are `hierarchyLevel: 0` - the same rung as Task - and `is_work_item` would admit
both. They are excluded because the product owner asked, and the code says exactly
that at the definition, because the two kinds of exclusion here look alike and are not:

- `type != Epic` is **structural**. Epics are containers; they arrive as
  `parent_key`/`epic_title` on their children. Removing it would be a bug.
- `type != Story` / `!= Feature` are **policy**. Nothing breaks if they go; the board
  just gets more tickets.

**Known cost, stated so nobody rediscovers it:** on a board that uses Stories or
Features as its main work type, this leaves Meridian syncing Tasks and Bugs only,
which for many teams is close to an empty board. If a user reports "my tickets don't
show up", this line is the first thing to check.

## Containers decided by rung, not name

`type != Epic` discriminates by name, and a name is not a reliable proxy for a rung -
"Feature" is level 0 on some boards and a container tier on others, and
Initiative/Capability are containers the JQL never mentions. So `is_work_item` drops
`hierarchyLevel >= 1` after the fetch, using a field every response already carries in
the `issuetype` object we already request and were discarding.

An **absent** level counts as work (old Jira Server/DC omits it). The failure modes
are not symmetric: a stray container row is visible and correctable, dropping real
work is silent and unloggable.

## Two bugs found in review

**1. The prune truncation guard would have been silently disabled.** Prune only runs
when the page was not truncated, because pruning against a partial list deletes live
tickets. The guard read the fetched-issue count - which client-side filtering shrinks.
One dropped container row on a full 100-row page would make a truncated page look
partial and switch the guard off, on exactly the boards this filter targets. `fetch`
now returns `ActiveFetch { issues, returned_by_server }` so the counts cannot be
conflated; the struct exists for that reason and its doc says so.

**2. `NOT IN ()` on an empty fetch.** `prune` and the shared `mark_retained_offboard`
(**all five providers**) render an empty key list as `NOT IN ()`, which SQLite rejects.
Both relied on callers gating on non-empty; `refresh_if_stale` never did - so the path
ran, failed, and was swallowed as a warning. Right outcome, entirely by accident. The
existing test "verified" this by not calling `prune` at all.

Both now own the guard and return `Ok(0)`, and the test calls the real function.
Skipping is also the correct policy: an empty result cannot be distinguished here from
a scope blip answering 200 with zero issues, and wrongly deleting a board is far worse
than leaving stale rows the next sync clears.

## Verified

- Both JQL forms run against a live Jira Cloud site.
- Confirmed Jira does **not** error on an unrecognised type name in a `!=` clause
  (unlike an `IN` allowlist) - that is what makes excluding Story/Feature server-side
  safe on sites lacking those types.
- Server-side matters: `MAX_RESULTS` is a hard 100-row ceiling with **no pagination**,
  so a type filtered client-side still burns a slot.
- Hierarchy tests deserialise fixtures from JSON rather than building structs, so they
  exercise the `#[serde(rename = "hierarchyLevel")]` path a real response takes - a
  struct literal would pass even if the rename were wrong.
- `cargo fmt`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace`
  (27 suites) all clean.

## Not covered

No live board with tiers above Epic, so the level-2 case is fixture-tested only.

## Known follow-up, not in this PR

`MAX_RESULTS = 100` with no pagination is a pre-existing ceiling that this change makes
easier to hit. Past 100 assigned open tickets, the remainder never sync AND prune stops
entirely (the truncation guard). Worth its own PR.
