### PR TITLE
fix(settings): make update_settings hold the registry lock too

### DIFF
--- a/tray/src-tauri/src/commands/custom_llm.rs
+++ b/tray/src-tauri/src/commands/custom_llm.rs
@@ -28,13 +28,37 @@ use serde::Serialize;
 use serde_json::Value;
 
 /// Serializes the whole registry read-modify-write across concurrent commands (two
-/// "Test" clicks, an add racing a remove). Each command does read_settings_value →
-/// mutate → write_settings_value, and without this those cycles interleave and
+/// "Test" clicks, an add racing a remove). Each command reads the rows, does its
+/// work, and persists them, and without this those cycles interleave and
 /// lost-update each other — the same bug class 2104c030 fixed for the provider-test
-/// cache. The daemon only READS `custom_llm_providers` (via the resolver), so these
-/// tray commands are the only writers and a tray-process lock is sufficient. It is a
-/// `tokio` mutex because the critical section spans a probe's `.await`.
+/// cache. It is a `tokio` mutex because the critical section spans a probe's
+/// `.await`.
+///
+/// # These commands are NOT the only writers
+/// This doc used to claim they were, and that claim was the bug:
+/// `commands::settings::update_settings` also replaces `custom_llm_providers`
+/// wholesale (the shallow body merge, plus `restore_custom_keys`), and it never
+/// took this lock. So a settings save could land a registry edit in the middle
+/// of a probe, and [`persist_rows`]'s re-read would then overwrite it with the
+/// pre-probe rows - the exact lost update `persist_rows` was added to stop, via
+/// the one writer it did not know about.
+///
+/// Every writer of `custom_llm_providers` must now hold this, which is what
+/// [`registry_guard`] exists for. The daemon only READS the registry (via the
+/// resolver), so a tray-process lock is still sufficient.
+///
+/// Lock ORDER is `REGISTRY_LOCK` then the settings lock inside
+/// `meridian_core::settings::mutate_settings_value`, at every site. Never the
+/// reverse.
 static REGISTRY_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Acquire [`REGISTRY_LOCK`] from outside this module.
+///
+/// `update_settings` needs it whenever its body carries `custom_llm_providers`;
+/// see [`REGISTRY_LOCK`] for why holding only the settings lock is not enough.
+pub(crate) async fn registry_guard() -> tokio::sync::MutexGuard<'static, ()> {
+    REGISTRY_LOCK.lock().await
+}
 
 /// A registry row as the UI sees it: everything except the key, plus the verdicts the UI
 /// must not re-derive (the gate lives in one place — `meridian-core` — and this carries its
@@ -612,6 +636,52 @@ pub async fn list_custom_llm_providers() -> Result<Vec<CustomProviderView>, Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A settings-side registry edit must WAIT for an in-flight custom-provider
+    /// probe rather than landing in the middle of it.
+    ///
+    /// `persist_rows` re-reads the document but replaces `custom_llm_providers`
+    /// with the caller's pre-probe rows. That is safe only if no other writer
+    /// can change the registry during the probe - and `update_settings` could,
+    /// because it replaces the registry wholesale through the settings lock
+    /// while never taking `REGISTRY_LOCK`. So a user saving a settings edit that
+    /// touched a custom provider, while a probe was running, had that edit
+    /// silently discarded when the probe finished.
+    ///
+    /// I asserted the opposite in #887 ("safe because REGISTRY_LOCK is held
+    /// across the whole command") and asked for the reasoning to be checked.
+    /// It was wrong: the lock covered the dedicated registry commands and not
+    /// the settings path.
+    #[tokio::test]
+    async fn a_settings_side_registry_edit_waits_for_an_in_flight_probe() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc as StdArc;
+
+        // A custom-provider command holding the lock across its probe.
+        let probe_guard = registry_guard().await;
+
+        let landed = StdArc::new(AtomicBool::new(false));
+        let landed_in_task = landed.clone();
+        let settings_write = tokio::spawn(async move {
+            // What `update_settings` now does when its body carries the registry.
+            let _g = registry_guard().await;
+            landed_in_task.store(true, Ordering::SeqCst);
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            !landed.load(Ordering::SeqCst),
+            "a settings-side registry edit landed DURING the probe - persist_rows \
+             would overwrite it with the pre-probe rows"
+        );
+
+        drop(probe_guard);
+        settings_write.await.expect("task panicked");
+        assert!(
+            landed.load(Ordering::SeqCst),
+            "the settings-side write must proceed once the probe releases the lock"
+        );
+    }
 
     /// A registry write must not discard a non-registry settings change that
     /// landed while it was probing.

--- a/tray/src-tauri/src/commands/settings.rs
+++ b/tray/src-tauri/src/commands/settings.rs
@@ -157,49 +157,68 @@ pub async fn update_settings(
     // change. The write was always atomic, which is what made this easy to
     // miss: no file is corrupted, a setting simply reverts.
     // See `meridian_core::settings::mutate_settings_value`.
-    let mut updated = meridian_core::settings::mutate_settings_value(|updated| {
-        let current = updated.clone();
-        let obj = updated
-            .as_object_mut()
-            .ok_or_else(|| anyhow::anyhow!("current settings are not an object"))?;
-        // { ...current, ...body } — body keys override.
-        for (k, v) in body_obj {
-            obj.insert(k.clone(), v.clone());
-        }
+    //
+    // AND the registry lock, whenever this body carries `custom_llm_providers`.
+    // The settings lock alone is not enough: this command replaces the registry
+    // WHOLESALE (the shallow merge below, plus `restore_custom_keys`), so a save
+    // landing mid-probe would be overwritten by `custom_llm::persist_rows`'s
+    // pre-probe rows when that probe finished. `REGISTRY_LOCK`'s doc used to
+    // claim the custom-provider commands were its only writers; this path is the
+    // writer it did not know about. Order is registry-then-settings at every
+    // site, matching `custom_llm`.
+    //
+    // Scoped to a block so the guard is released before the post-write health
+    // push below, which awaits and has nothing to do with the registry.
+    let mut updated = {
+        let _registry_guard = if body_touches_registry(body_obj) {
+            Some(crate::commands::custom_llm::registry_guard().await)
+        } else {
+            None
+        };
+        meridian_core::settings::mutate_settings_value(|updated| {
+            let current = updated.clone();
+            let obj = updated
+                .as_object_mut()
+                .ok_or_else(|| anyhow::anyhow!("current settings are not an object"))?;
+            // { ...current, ...body } — body keys override.
+            for (k, v) in body_obj {
+                obj.insert(k.clone(), v.clone());
+            }
 
-        // Sentinel / empty / absent oo_password → keep the stored value.
-        let sent = body_obj.get("oo_password").and_then(Value::as_str);
-        if sent.is_none_or(|p| p.is_empty() || p == PASSWORD_SENTINEL) {
-            let kept = current
-                .get("oo_password")
-                .cloned()
-                .unwrap_or(Value::String(String::new()));
-            obj.insert("oo_password".into(), kept);
-        }
+            // Sentinel / empty / absent oo_password → keep the stored value.
+            let sent = body_obj.get("oo_password").and_then(Value::as_str);
+            if sent.is_none_or(|p| p.is_empty() || p == PASSWORD_SENTINEL) {
+                let kept = current
+                    .get("oo_password")
+                    .cloned()
+                    .unwrap_or(Value::String(String::new()));
+                obj.insert("oo_password".into(), kept);
+            }
 
-        // Same rule per custom endpoint, matched BY ID (see `redact_custom_keys`). The merge
-        // above is shallow, so a body carrying the registry replaces it wholesale — and the UI's
-        // copy has a sentinel in every row it read back. Without this, saving any unrelated
-        // setting would overwrite every API key with "••••••••".
-        restore_custom_keys(&current, obj).map_err(|e| anyhow::anyhow!(e))?;
+            // Same rule per custom endpoint, matched BY ID (see `redact_custom_keys`). The merge
+            // above is shallow, so a body carrying the registry replaces it wholesale — and the UI's
+            // copy has a sentinel in every row it read back. Without this, saving any unrelated
+            // setting would overwrite every API key with "••••••••".
+            restore_custom_keys(&current, obj).map_err(|e| anyhow::anyhow!(e))?;
 
-        // The GATE. A custom endpoint may only run the pipeline on measured evidence
-        // (`meridian_core::SchemaRung`), and it is enforced HERE rather than only in the UI:
-        // this command is the sole writer of settings.json, so a hand-edited file or an older
-        // frontend would otherwise route a user's whole day through an endpoint nobody has
-        // shown can hold a schema. An unenforced fold doesn't fail loudly — it drops the hour.
-        enforce_custom_provider_gate(updated).map_err(|e| anyhow::anyhow!(e))?;
+            // The GATE. A custom endpoint may only run the pipeline on measured evidence
+            // (`meridian_core::SchemaRung`), and it is enforced HERE rather than only in the UI:
+            // this command is the sole writer of settings.json, so a hand-edited file or an older
+            // frontend would otherwise route a user's whole day through an endpoint nobody has
+            // shown can hold a schema. An unenforced fold doesn't fail loudly — it drops the hour.
+            enforce_custom_provider_gate(updated).map_err(|e| anyhow::anyhow!(e))?;
 
-        // LAST gate before the write, and deliberately on the whole document rather
-        // than another named field: everything above validates fields by name, so
-        // anything not on that list could reach disk with the wrong type and take
-        // the ENTIRE file down with it at load time. See
-        // `merged_settings_are_loadable`.
-        merged_settings_are_loadable(updated).map_err(|e| anyhow::anyhow!(e))?;
+            // LAST gate before the write, and deliberately on the whole document rather
+            // than another named field: everything above validates fields by name, so
+            // anything not on that list could reach disk with the wrong type and take
+            // the ENTIRE file down with it at load time. See
+            // `merged_settings_are_loadable`.
+            merged_settings_are_loadable(updated).map_err(|e| anyhow::anyhow!(e))?;
 
-        Ok(updated.clone())
-    })
-    .map_err(|e| crate::cmd_err!(e, "update_settings: write failed"))?;
+            Ok(updated.clone())
+        })
+        .map_err(|e| crate::cmd_err!(e, "update_settings: write failed"))?
+    };
 
     // Refresh the live capture ignore list so a Settings change takes effect on
     // the very next captured frame — no capture restart. The frame + UI-event
@@ -335,6 +354,21 @@ fn restore_custom_keys(
 /// UNKNOWN keys stay legal: `read_settings_value` deliberately preserves them so
 /// a write can round-trip a file from a newer build, and `RuntimeSettings` has
 /// no `deny_unknown_fields`. Only a wrong TYPE is rejected.
+/// Does this settings body replace the custom-endpoint registry?
+///
+/// Named rather than inlined because it decides whether `update_settings` takes
+/// `custom_llm::registry_guard`, and getting it wrong is silent: too narrow and
+/// a settings save can be overwritten by an in-flight probe's pre-probe rows;
+/// too broad and every unrelated save serialises behind a probe that can take
+/// seconds.
+///
+/// Keyed on the body, not the merged document - the merged document ALWAYS
+/// carries the registry (it is a stored setting), so checking that would take
+/// the lock on every save.
+fn body_touches_registry(body_obj: &serde_json::Map<String, Value>) -> bool {
+    body_obj.contains_key("custom_llm_providers")
+}
+
 fn merged_settings_are_loadable(merged: &Value) -> Result<(), String> {
     serde_json::from_value::<meridian_core::settings::RuntimeSettings>(merged.clone())
         .map(|_| ())
@@ -423,6 +457,25 @@ fn str_list(v: &Value, key: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+
+    /// The registry lock must be taken for a body that carries the registry, and
+    /// NOT for one that does not - a probe can hold that lock for seconds.
+    #[test]
+    fn only_a_registry_bearing_body_takes_the_registry_lock() {
+        let with_registry = json!({"custom_llm_providers": [], "llm_provider": "claude"});
+        assert!(body_touches_registry(with_registry.as_object().unwrap()));
+
+        for unrelated in [
+            json!({"llm_provider": "claude"}),
+            json!({"autostart_enabled": true}),
+            json!({}),
+        ] {
+            assert!(
+                !body_touches_registry(unrelated.as_object().unwrap()),
+                "an unrelated save must not serialise behind an endpoint probe: {unrelated}"
+            );
+        }
+    }
 
     /// A merged settings document that cannot deserialise must be REJECTED
     /// rather than written.


### PR DESCRIPTION
CodeRabbit's re-review **refuted the safety argument I made in #887** — the one I explicitly asked it to check. I was wrong, and this is the fix.

## What I claimed, and why it was false

#887 said `persist_rows` may keep the caller's pre-probe `rows` while re-reading everything else, *"because `REGISTRY_LOCK` is held across the whole command, so no other registry writer can have changed rows."*

`update_settings` **is** a registry writer, and never took that lock. It replaces `custom_llm_providers` wholesale — the shallow body merge, plus `restore_custom_keys`.

The failing sequence:

1. a custom-provider command holds `REGISTRY_LOCK` and starts `probe_endpoint(...).await`
2. the user saves a settings edit touching a custom provider — `update_settings` writes the changed registry through the **settings lock alone**
3. the probe finishes; `persist_rows` re-reads, then overwrites `custom_llm_providers` with the **pre-probe** rows, discarding that edit

So the mechanism `persist_rows` added to *stop* lost updates reintroduced one, via the single writer it didn't know about.

## The stale comment was part of the bug

`REGISTRY_LOCK`'s doc asserted:

> *"these tray commands are the only writers and a tray-process lock is sufficient"*

That was false when written. It's corrected rather than deleted — the invariant it states is exactly the one every future writer must satisfy, so it's now stated as a requirement with the counter-example named.

## The fix

`registry_guard()` exposes the lock; `update_settings` takes it whenever its body carries `custom_llm_providers`.

**Gated on the body, not the merged document.** The merged document *always* carries the registry (it's a stored setting), so gating on that would serialise every unrelated save behind a probe that can take seconds. `only_a_registry_bearing_body_takes_the_registry_lock` pins both directions.

The guard is scoped to a block, released before the post-write health push. Lock order is registry-then-settings at every site, matching `custom_llm`.

## Test

`a_settings_side_registry_edit_waits_for_an_in_flight_probe` holds the guard as a probe would, spawns the write `update_settings` now performs, and asserts it has **not** landed 50ms later — then that it proceeds once the guard drops. That's the serialisation itself, not a proxy for it.

## Also confirmed in that review, and deliberately not changed

- the unconditional no-op write in `purge_expired_account_email` is **not** a release blocker (one startup read/write, may touch the mtime) — one mutation discipline is worth more than the saved I/O
- **#888** — which merged into this release after the last round — has no issues; the Story/Feature exclusions are documented product policy and the `hierarchyLevel` handling is sound

## Status

`cargo test --workspace` green (27 suites), fmt + clippy clean. All 48 review threads resolved. CI on #846 is now fully green.

Completes: #880, #881, #882, #883, #884, #886, #887.