### PR TITLE
chore(release): note the two Clerk follow-ups and the plan-save fix in 1.90.0

### DIFF
--- a/tray/src-tauri/resources/whats-new.json
+++ b/tray/src-tauri/resources/whats-new.json
@@ -15,6 +15,8 @@
         "The end-of-day time dialog no longer appears twice if you skip the tour while it is opening, and it now asks you to pick a time before it will save.",
         "Meridian no longer reports your project tool as failing to sync just because your laptop was asleep. A gap in time was being treated the same as a run of failures, so the first attempt after waking raised a warning about a tracker that was working fine.",
         "Signing in sticks across a relaunch. A session that was still loading reported an empty status, which Meridian read as a failed sign-in and quietly dropped, so you were shown the sign-in screen again.",
+        "The sign-in fix above didn't catch every case - a couple of background fields your session carries could still arrive missing or blank and break the same offline check. Both are handled now.",
+        "Today's focus no longer shows \"What are you working on today?\" after you've already saved a plan. It used to need one extra edit in the planner before it noticed the plan was there.",
         "Several fixes that protect your database around a restart: the write-ahead log is now flushed cleanly when the daemon stops, damage is spotted from Meridian's own reads rather than waiting for a scan, an automatic repair that fails now falls back to a fresh start instead of leaving you stuck, and Meridian no longer holds a connection open across a daemon restart.",
         "On Windows, an automatic repair no longer gives up when a file is briefly locked by another process, and updating your start-at-login setting no longer closes Meridian while it does so.",
         "The tray popover has a cleaner edge - the window is clipped to its own rounded corners and no longer draws a second shadow behind it."


### PR DESCRIPTION
## Summary

`tray/src-tauri/resources/whats-new.json`'s `1.90.0` entry was written by #865 before #868, #869 and #874 merged, so the changelog a user actually reads doesn't mention any of them - even though they're all already on `pre-main` and shipping in the same still-unreleased version.

Adds two bullets to the *existing* `1.90.0` entry (no version bump - this is pre-release iteration on a version that hasn't reached `main` yet, not a new release):

- Folds #868 + #874 together as one bullet, right after the existing "Signing in sticks across a relaunch" line (#829) - to a user these are indistinguishable further hardening of the same offline sign-in cache bug, not three separate stories.
- #869 (Today's focus not reflecting a saved daily plan until you touch it) gets its own bullet - a distinct, user-visible issue.

## Test plan
- [x] `python3 -c "import json; json.load(...)"` - valid JSON
- [x] `cargo test -p meridian-tray whats_new` - `whats_new_json_parses` passes
- [x] full pre-push gate (fmt, clippy --workspace, ui build, ui tests, security audit, cargo test --workspace) - all green