### PR TITLE
fix(clerk): retry sign-in init on a network failure instead of a dead-end error

### DIFF
--- a/ui/__tests__/clerkNetworkError.test.ts
+++ b/ui/__tests__/clerkNetworkError.test.ts
@@ -1,0 +1,62 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+import { describe, it, expect, afterEach } from 'bun:test'
+import { isLikelyClerkNetworkError } from '../lib/clerkNetworkError'
+
+// Regression coverage for a real report: a staging build showed "Sign-in
+// couldn't start - check CLERK_PUBLISHABLE_KEY and restart" on a Mac right
+// after a machine restart, with a correctly-configured key. Root cause: the
+// tray auto-launches at login before the OS has network up, so `clerk.load()`
+// rejects on a connection failure - `ClerkErrorBoundary` showed the
+// misconfiguration message for what was actually a transient offline window.
+// This classifier is what lets the boundary tell the two apart.
+
+describe('isLikelyClerkNetworkError', () => {
+  afterEach(() => {
+    // @ts-expect-error -- test-only override of a read-only DOM property
+    delete global.navigator
+  })
+
+  it('is true for a reqwest/clerk-fapi-rs connection failure (Rust side)', () => {
+    expect(isLikelyClerkNetworkError(new Error(
+      'error trying to connect: dns error: failed to lookup address information: nodename nor servname provided, or not known',
+    ))).toBe(true)
+  })
+
+  it('is true for a plain "error sending request" reqwest wrapper', () => {
+    expect(isLikelyClerkNetworkError(new Error('error sending request for url (https://clerk.meridiona.com/v1/client)'))).toBe(true)
+  })
+
+  it('is true for the browser fetch failure wording (JS-side Clerk load)', () => {
+    expect(isLikelyClerkNetworkError(new Error('Failed to fetch'))).toBe(true)
+    expect(isLikelyClerkNetworkError(new Error('NetworkError when attempting to fetch resource.'))).toBe(true)
+  })
+
+  it('is true for a Safari-style offline message', () => {
+    expect(isLikelyClerkNetworkError('The Internet connection appears to be offline.')).toBe(true)
+  })
+
+  it('is true for a Chromium net-error code', () => {
+    expect(isLikelyClerkNetworkError(new Error('net::ERR_INTERNET_DISCONNECTED'))).toBe(true)
+  })
+
+  it('is true whenever the browser itself reports offline, regardless of message', () => {
+    // @ts-expect-error -- test-only global override
+    global.navigator = { onLine: false }
+    expect(isLikelyClerkNetworkError(new Error('some completely unrelated error text'))).toBe(true)
+  })
+
+  it('is false for a malformed/wrong-instance publishable key error', () => {
+    expect(isLikelyClerkNetworkError(new Error('Missing publishableKey'))).toBe(false)
+    expect(isLikelyClerkNetworkError(new Error('Clerk: Missing publishable_key'))).toBe(false)
+  })
+
+  it('is false for an unrelated JS error', () => {
+    expect(isLikelyClerkNetworkError(new TypeError('Cannot read properties of undefined'))).toBe(false)
+  })
+
+  it('handles non-Error rejection shapes without throwing', () => {
+    expect(isLikelyClerkNetworkError(undefined)).toBe(false)
+    expect(isLikelyClerkNetworkError(null)).toBe(false)
+    expect(isLikelyClerkNetworkError({ code: 'native_api_disabled' })).toBe(false)
+  })
+})

--- a/ui/app/setup/signin/ClerkErrorBoundary.tsx
+++ b/ui/app/setup/signin/ClerkErrorBoundary.tsx
@@ -3,6 +3,21 @@
 
 import { Component } from 'react'
 import type { ReactNode } from 'react'
+import { isLikelyClerkNetworkError } from '@/lib/clerkNetworkError'
+import { Btn } from '../atoms'
+
+type Props = {
+  children: ReactNode
+  /** Re-mounts the gated subtree with a fresh `initClerk()` call - see
+   *  `ClerkGate`, which passes a `key`-bumping callback so this boundary's own
+   *  `failed` state resets along with it. */
+  onRetry: () => void
+  /** Reported so `ClerkGate` can schedule an automatic retry (backoff timer +
+   *  an `online` listener) when the failure looks like "no network yet"
+   *  rather than a real misconfiguration - that orchestration needs to
+   *  survive across remounts of this boundary, so it lives one level up. */
+  onError: (error: unknown) => void
+}
 
 /** Catches `initClerk()` rejecting inside `ClerkGate`'s `use()` call and shows a
  *  message instead of leaving Suspense's child throw uncaught, which would
@@ -12,23 +27,39 @@ import type { ReactNode } from 'react'
  *  NOTE the "no key at all" case does NOT reach here: `sign_in_required`
  *  (`commands::account`) reports false for a debug build with no key, and the
  *  gates skip Clerk entirely rather than mounting a `ClerkGate` that is certain
- *  to fail. So what lands here is a key that IS configured and still didn't
- *  init — malformed, or the wrong instance — which is why the copy points at
- *  the value being bad rather than missing. */
-export class ClerkErrorBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
-  state: { failed: boolean } = { failed: false }
+ *  to fail. So what lands here is either a key that IS configured and still
+ *  didn't init, or a transient network failure - see `isLikelyClerkNetworkError`
+ *  for how those two are told apart, and why they need different copy: a real
+ *  misconfiguration needs a rebuild, but a login-item launch that raced the
+ *  OS's own network bring-up just needs a moment (v1.90.0 staging report:
+ *  `docs/vision.md`-adjacent - this is the exact "worked after I reconnected"
+ *  case, not a bad key). */
+export class ClerkErrorBoundary extends Component<Props, { failed: boolean; networkIssue: boolean }> {
+  state: { failed: boolean; networkIssue: boolean } = { failed: false, networkIssue: false }
 
-  static getDerivedStateFromError() {
-    return { failed: true }
+  static getDerivedStateFromError(error: unknown) {
+    return { failed: true, networkIssue: isLikelyClerkNetworkError(error) }
   }
 
   componentDidCatch(error: unknown) {
     // eslint-disable-next-line no-console -- surfaced nowhere else; this is a dev/misconfiguration signal
     console.error('setup: Clerk sign-in unavailable', error)
+    this.props.onError(error)
   }
 
   render() {
     if (this.state.failed) {
+      if (this.state.networkIssue) {
+        return (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, alignItems: 'flex-start' }}>
+            <p style={{ fontSize: 12.5, color: 'var(--t-muted)' }}>
+              Sign-in couldn&apos;t reach the network. Meridian will retry automatically once
+              you&apos;re back online.
+            </p>
+            <Btn variant="secondary" size="sm" onClick={this.props.onRetry}>Retry now</Btn>
+          </div>
+        )
+      }
       return (
         <p style={{ fontSize: 12.5, color: 'var(--t-muted)' }}>
           Sign-in couldn&apos;t start - check CLERK_PUBLISHABLE_KEY and restart.

--- a/ui/app/setup/signin/ClerkGate.tsx
+++ b/ui/app/setup/signin/ClerkGate.tsx
@@ -9,12 +9,13 @@
 // about the bootstrap is identical, so it lives here once instead of being
 // duplicated across both widgets.
 
-import { Suspense, use, useState } from 'react'
+import { Suspense, use, useCallback, useEffect, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import { ClerkProvider } from '@clerk/react'
 // eslint-disable-next-line @typescript-eslint/no-var-requires -- no type defs shipped for this community plugin
 import { initClerk } from 'tauri-plugin-clerk'
 import { isTauri } from '@/lib/bridge'
+import { isLikelyClerkNetworkError } from '@/lib/clerkNetworkError'
 import { ClerkErrorBoundary } from './ClerkErrorBoundary'
 
 // The initialised clerk instance's type isn't exported by this community
@@ -32,22 +33,68 @@ function ClerkResolve({ clerkPromise, children }: {
   )
 }
 
+const INITIAL_RETRY_MS = 5_000
+const MAX_RETRY_MS = 60_000
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see ClerkResolve
+type Attempt = { key: number; clerkPromise: Promise<any> | null }
+
+function freshAttempt(key: number): Attempt {
+  return { key, clerkPromise: isTauri() ? initClerk() : null }
+}
+
 export function ClerkGate({ notInTauriMessage, fallback, children }: {
   notInTauriMessage: string
   fallback: ReactNode
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see ClerkResolve
   children: (clerk: any) => ReactNode
 }) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see ClerkResolve
-  const [clerkPromise] = useState<Promise<any> | null>(() => (isTauri() ? initClerk() : null))
+  // `retry()` replaces BOTH the promise `use()` resolves and the boundary's
+  // `key` in one update, so a retry always means a genuinely new
+  // `initClerk()` call feeding a freshly-mounted (failed: false) boundary -
+  // not the same already-rejected promise re-thrown forever.
+  const [attempt, setAttempt] = useState<Attempt>(() => freshAttempt(0))
+  const retry = useCallback(() => setAttempt((prev) => freshAttempt(prev.key + 1)), [])
 
-  if (!clerkPromise) {
+  const backoffMs = useRef(INITIAL_RETRY_MS)
+  const pending = useRef<{ timer: ReturnType<typeof setTimeout> | null; onlineListener: (() => void) | null }>({
+    timer: null,
+    onlineListener: null,
+  })
+
+  const clearPending = useCallback(() => {
+    if (pending.current.timer) clearTimeout(pending.current.timer)
+    if (pending.current.onlineListener) window.removeEventListener('online', pending.current.onlineListener)
+    pending.current = { timer: null, onlineListener: null }
+  }, [])
+
+  // Only a NETWORK-looking failure gets auto-retried - a bad key won't fix
+  // itself on a timer, so that case is left to the boundary's static message
+  // (see ClerkErrorBoundary's doc). Two independent triggers race to whichever
+  // fires first: the browser's `online` event (instant once connectivity is
+  // back) and a backoff timer (a floor for browsers/WKWebViews that don't fire
+  // `online` reliably in a login-item's background window).
+  const handleError = useCallback((error: unknown) => {
+    if (!isLikelyClerkNetworkError(error)) return
+    clearPending()
+    const onlineListener = () => { clearPending(); retry() }
+    pending.current.onlineListener = onlineListener
+    window.addEventListener('online', onlineListener)
+    pending.current.timer = setTimeout(() => { clearPending(); retry() }, backoffMs.current)
+    backoffMs.current = Math.min(backoffMs.current * 2, MAX_RETRY_MS)
+  }, [clearPending, retry])
+
+  const manualRetry = useCallback(() => { clearPending(); retry() }, [clearPending, retry])
+
+  useEffect(() => clearPending, [clearPending])
+
+  if (!attempt.clerkPromise) {
     return <p style={{ fontSize: 12.5, color: 'var(--t-muted)' }}>{notInTauriMessage}</p>
   }
   return (
-    <ClerkErrorBoundary>
+    <ClerkErrorBoundary key={attempt.key} onRetry={manualRetry} onError={handleError}>
       <Suspense fallback={fallback}>
-        <ClerkResolve clerkPromise={clerkPromise}>{children}</ClerkResolve>
+        <ClerkResolve clerkPromise={attempt.clerkPromise}>{children}</ClerkResolve>
       </Suspense>
     </ClerkErrorBoundary>
   )

--- a/ui/lib/clerkNetworkError.ts
+++ b/ui/lib/clerkNetworkError.ts
@@ -1,0 +1,61 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+
+// Classifies why `tauri-plugin-clerk`'s `initClerk()` rejected: a machine with
+// no network yet (the login-item auto-launch races the OS's own network
+// bring-up, so `clerk.load()`'s live-API fetch has nothing to reach) versus an
+// actual misconfiguration (a malformed/wrong-instance publishable key).
+// `ClerkErrorBoundary` uses this to pick copy that matches the real cause -
+// "check CLERK_PUBLISHABLE_KEY" is true for the second case and actively wrong
+// for the first, since the key is fine and the fix is just waiting for a
+// connection.
+//
+// The Rust side (`clerk.load()` via clerk-fapi-rs -> reqwest) and the JS side
+// (`@clerk/clerk-js`'s own fetch, and the CDN fetch for prebuilt UI) can each
+// be the one that rejects, on either OS, so this matches substrings from both
+// stacks rather than one platform's wording. False negatives (a network error
+// misread as "other") just fall back to the pre-existing generic message, so
+// the list is kept broad on purpose.
+const NETWORK_ERROR_PATTERNS = [
+  'error trying to connect',
+  'error sending request',
+  'dns error',
+  'failed to lookup address',
+  'connection refused',
+  'network is unreachable',
+  'network is down',
+  'could not connect',
+  'timed out',
+  'operation timed out',
+  'failed to fetch',
+  'load failed',
+  'networkerror',
+  'internet connection appears to be offline',
+  'err_internet_disconnected',
+  'err_network_changed',
+  'err_name_not_resolved',
+]
+
+function errorText(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  if (error === null || error === undefined) return ''
+  try {
+    // JSON.stringify returns `undefined` (not a string) for values like a bare
+    // function, which would otherwise crash the caller's .toLowerCase().
+    return JSON.stringify(error) ?? String(error)
+  } catch {
+    return String(error)
+  }
+}
+
+/** True when `initClerk()`'s rejection looks like "no network yet", not a bad
+ *  key. Combines two independent signals: the browser's own connectivity flag
+ *  (unavailable outside a browser-like runtime, hence the `typeof` guard) and
+ *  substring-matching the error text against known network-failure wording
+ *  from reqwest, `@clerk/clerk-js`'s fetch, and Chromium's net-error codes. */
+export function isLikelyClerkNetworkError(error: unknown): boolean {
+  const offline = typeof navigator !== 'undefined' && navigator.onLine === false
+  if (offline) return true
+  const text = errorText(error).toLowerCase()
+  return NETWORK_ERROR_PATTERNS.some((pattern) => text.includes(pattern))
+}


### PR DESCRIPTION
## Summary
- On a v1.90.0 staging Mac, a machine restart showed a permanent "Sign-in couldn't start - check CLERK_PUBLISHABLE_KEY and restart" error, with the key correctly configured and the app fully blocked behind sign-in.
- Root cause: the tray auto-launches at OS login/restart via the login item, often before the network is up. `initClerk()` rejects with no working fallback, and `ClerkErrorBoundary` showed a static misconfiguration message with no retry - the only recovery was a manual force-quit/relaunch, by which point the network happened to be back.
- Adds `isLikelyClerkNetworkError` (`ui/lib/clerkNetworkError.ts`) to classify a rejection as "no network yet" (via `navigator.onLine` + known connection-failure text from both the Rust/reqwest stack and the JS fetch stack) vs. a genuine misconfiguration.
- `ClerkGate`/`ClerkErrorBoundary` now show a clearer message for the network case ("will retry automatically once you're back online" + a manual "Retry now" button) and auto-retry via the browser's `online` event or a capped backoff timer (5s→60s). A non-network failure keeps the original message. All three call sites (`RequireSignIn`, `SignInWidget`, `AccountAuthControl`) inherit this through `ClerkGate` with no changes needed.

## Test plan
- [x] `bun test __tests__/clerkNetworkError.test.ts` - 9/9 new tests pass, including a real bug the TDD pass caught (an `undefined` rejection crashed the first implementation)
- [x] `bun test` (full ui suite) - 914/914 pass
- [x] `npm run build` (ui) - typecheck + lint + static export all clean
- [x] `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` - all clean via the pre-push hook