### PR TITLE
fix(install): stop the daemon BEFORE staging its binary on macOS

### DIFF
--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -557,6 +557,34 @@ async fn install(backend: &Path, home: &Path) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     stop_running_daemon_before_stage(&daemon_bin).await?;
 
+    // macOS needs the SAME stop, for the opposite reason, and did not have it.
+    //
+    // Windows FAILS the copy while the daemon holds the exe (os error 32), so
+    // the omission there is loud. macOS lets the rename SUCCEED - the running
+    // daemon simply keeps executing the unlinked inode and keeps writing
+    // meridian.db - so the omission is silent, and what follows is the
+    // double-writer window every `code: 11` report in this fleet has come
+    // through: `register_service` below bootstraps a NEW daemon against the
+    // same database while the old one is still live.
+    //
+    // Measured on a staging install 2026-08-25: `staged binary` at 08:20:37.586
+    // and the old daemon's `SIGTERM received` at 08:20:37.595 - the swap landed
+    // NINE MILLISECONDS before anything asked it to stop, and the stop that did
+    // arrive came from `register_agent`'s bootout, after the fact.
+    //
+    // Reuses the migration path's stop rather than a second implementation:
+    // bootout the launchd job, then prove via `lsof` that NOTHING holds the
+    // database - a dev `cargo run`, a directly-spawned binary and an orphan
+    // from an overlapping install have all been seen here, and a bootout
+    // removes none of them.
+    //
+    // Failing here declines the STAGING, exactly as Windows does: the update
+    // does not apply, the existing daemon keeps running, and the next launch
+    // retries. That is the right asymmetry - a deferred update costs a version,
+    // proceeding costs the user's database.
+    #[cfg(target_os = "macos")]
+    stop_daemon_for_migration(std::path::Path::new(&crate::install::meridian_db_path())).await?;
+
     stage_binary(&backend.join(DAEMON_FILE), &daemon_bin).await?;
 
     register_service(backend, home, &daemon_bin).await
@@ -1433,6 +1461,70 @@ pub(crate) async fn launchctl(args: &[&str]) -> Result<bool, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The daemon must be stopped BEFORE its binary is staged, on BOTH
+    /// platforms.
+    ///
+    /// Windows has always done this and fails loudly if it cannot - the copy
+    /// returns os error 32 while the daemon holds the exe. macOS had no such
+    /// call at all, and there the rename SUCCEEDS: the running daemon keeps
+    /// executing the unlinked inode and keeps writing `meridian.db`, after
+    /// which `register_service` bootstraps a second daemon against the same
+    /// file. That is the double-writer window every `code: 11` report in this
+    /// fleet has come through, and it is silent by construction.
+    ///
+    /// Measured on a staging install 2026-08-25: `staged binary` at
+    /// 08:20:37.586, the old daemon's `SIGTERM received` at 08:20:37.595 - the
+    /// swap landed NINE MILLISECONDS before anything asked it to stop.
+    ///
+    /// Source-scanned because the ordering is the whole behaviour and neither
+    /// `launchctl` nor a real daemon exists in a unit test - the same idiom as
+    /// `every_early_return_still_restores_the_daemon` above and
+    /// `single_instance_check_precedes_setup_db_and_bind_follows_it` in
+    /// `main.rs`.
+    #[test]
+    fn the_daemon_is_stopped_before_its_binary_is_staged() {
+        const SRC: &str = include_str!("backend_install.rs");
+        // Truncate at THIS test module first: the file scans itself, and the
+        // needles below appear in this test's own body. Without this the scan
+        // matches its own source and can never fail.
+        let prod = SRC
+            .split_once("\n#[cfg(test)]")
+            .map_or(SRC, |(before, _)| before);
+
+        let body = prod
+            .split_once("async fn install(backend: &Path, home: &Path)")
+            .expect("install() must exist")
+            .1;
+        let end = ["\npub ", "\npub(crate) ", "\nasync fn", "\nfn "]
+            .iter()
+            .filter_map(|m| body.find(m))
+            .min()
+            .unwrap_or(body.len());
+        let body = &body[..end];
+
+        let stage = body
+            .find("stage_binary(")
+            .expect("install() must stage the binary");
+
+        for (label, needle) in [
+            ("windows", "stop_running_daemon_before_stage("),
+            ("macos", "stop_daemon_for_migration("),
+        ] {
+            let stop = body.find(needle).unwrap_or_else(|| {
+                panic!(
+                    "install() has no {label} stop before staging - on macOS that means the \
+                     binary is swapped under a live daemon that keeps writing meridian.db, \
+                     and register_service then starts a SECOND one against the same file"
+                )
+            });
+            assert!(
+                stop < stage,
+                "the {label} stop must come BEFORE stage_binary, not after it - staging \
+                 first is what makes the window silent. stop at {stop}, stage at {stage}"
+            );
+        }
+    }
 
     /// The branch that bootstraps a launchd agent whose `bootout` never cleared
     /// must report at **WARN**, because WARN+ is the only severity that leaves


### PR DESCRIPTION
Not part of the #846 release. Found while investigating a live corruption + database-reset on a staging install this morning.

## The bug

```rust
#[cfg(target_os = "windows")]
stop_running_daemon_before_stage(&daemon_bin).await?;   // Windows ONLY

stage_binary(&backend.join(DAEMON_FILE), &daemon_bin).await?;   // both platforms
```

`stop_running_daemon_before_stage` is `#[cfg(target_os = "windows")]` — it does not even compile on macOS. So on macOS **the binary is swapped under a live daemon**, and the stop arrives afterwards from `register_agent`'s bootout.

## Why it stayed hidden

The asymmetry is the whole story:

| | on staging over a live daemon |
|---|---|
| **Windows** | the copy **fails** — os error 32 while the daemon holds the exe. Loud. Fixed long ago. |
| **macOS** | the rename **succeeds**. The daemon keeps executing the unlinked inode and keeps writing `meridian.db`, then `register_service` bootstraps a **second** daemon against the same file. Silent. |

That is the window this module's own comment already names:

> *"the installer is about to bootstrap the daemon while the previous one may still be running — the double-writer precondition behind the recurring `database disk image is malformed` (`code: 11`), which as of 2026-08-17 had damaged the databases of 8 hosts, **every one of them macOS**."*

## Measured, from the local spool

```
08:20:37.529  backend_install: installing bundled backend
08:20:37.586  backend_install: staged binary        ← the swap
08:20:37.595  daemon SIGTERM received               ← NINE MILLISECONDS later
08:20:38.603  daemon booted out
08:20:39.854  new daemon starting
```

The swap landed before anything asked the daemon to stop.

## The fix

Reuses `stop_daemon_for_migration` rather than writing a second implementation. It does both halves that matter:

1. `bootout_agent_and_wait` — removes the launchd job
2. `wait_for_db_unheld` — proves via `lsof` that **nothing** holds the database

The second half is not redundant. A bootout removes only the launchd-managed daemon; a dev `cargo run`, a directly-spawned binary, and an orphan from an overlapping install have all been seen on one machine here, and the bootout removes none of them. It also **fails closed** — an `lsof` it cannot run counts as *still held*.

**Failing here declines the staging**, exactly as Windows does: the update doesn't apply, the existing daemon keeps running, the next launch retries. A deferred update costs a version; proceeding costs the user's database.

## Test

Source-scanning, because the ordering *is* the behaviour and neither `launchctl` nor a real daemon exists in a unit test — same idiom as `every_early_return_still_restores_the_daemon` here and `single_instance_check_precedes_setup_db_and_bind_follows_it` in `main.rs`, with the same self-scan truncation guard (the file scans itself, and the needles appear in the test's own body).

Verified to fail with the exact diagnostic when the macOS stop is removed:

```
install() has no macos stop before staging - on macOS that means the binary is
swapped under a live daemon that keeps writing meridian.db, and register_service
then starts a SECOND one against the same file
```

It asserts the ordering on **both** platforms, so the Windows half can't silently regress either.

## What this does NOT claim

It is **not proven** to be the cause of any specific incident. Damage is progressive and detection lags it by many minutes — this morning's corruption surfaced ~28 minutes after this window. What is confirmed: a real ordering bug, on the only platform reporting `code: 11`, inside the window the code already names as the precondition.

Three other hypotheses were ruled out along the way and are worth recording so nobody re-chases them: the encryption migration is **not** involved (the database header is encrypted, so `is_plaintext_sqlite` is false); the bootout-failed-and-bootstrapped-anyway branch has **never** fired in this machine's entire spool; and `register_agent`'s `process_alive()` guard works correctly — of five firings today, three were real installs and two the legitimate restore-after-quit path.

`cargo test --workspace` green (27 suites), fmt + clippy clean.