### PR TITLE
fix(oauth): retry a rotating refresh promptly, never late

### DIFF
--- a/meridian-oauth/src/flow.rs
+++ b/meridian-oauth/src/flow.rs
@@ -754,6 +754,8 @@ fn decode(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
 
     /// `is_transient` must find the [`TokenError`] even under the `.context()`
     /// layers `refresh`/`ensure_fresh` wrap it in — that chain walk is the whole
@@ -932,6 +934,176 @@ mod tests {
         blank.client_secret = Some("   ".to_string());
         with_client_secret(&mut body, &blank);
         assert!(body.get("client_secret").is_none());
+    }
+
+    /// How the token endpoint behaves on one request.
+    enum Reply {
+        /// A normal HTTP response with this status and body.
+        Status(u16, &'static str),
+        /// Read the request, then close the connection without answering — the
+        /// production failure this whole module exists for. The grant was
+        /// delivered; only the answer was lost.
+        Hangup,
+    }
+
+    /// A one-shot scripted token endpoint on loopback. Returns its URL and a
+    /// counter of requests it actually READ (not merely accepted), which is the
+    /// number that matters: every read request is a grant the provider may have
+    /// consumed. `replies` is consumed in order; the last entry repeats.
+    async fn spawn_token_stub(replies: Vec<Reply>) -> (&'static str, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let seen = Arc::new(AtomicUsize::new(0));
+        let counter = seen.clone();
+        tokio::spawn(async move {
+            let mut i = 0usize;
+            while let Ok((mut sock, _)) = listener.accept().await {
+                if !read_http_request(&mut sock).await {
+                    continue;
+                }
+                counter.fetch_add(1, Ordering::SeqCst);
+                let reply = &replies[i.min(replies.len() - 1)];
+                i += 1;
+                match reply {
+                    Reply::Hangup => drop(sock),
+                    Reply::Status(code, body) => {
+                        let resp = format!(
+                            "HTTP/1.1 {code} X\r\nContent-Type: application/json\r\n\
+                             Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                            body.len()
+                        );
+                        let _ = sock.write_all(resp.as_bytes()).await;
+                        let _ = sock.flush().await;
+                    }
+                }
+            }
+        });
+        // `token_url` is `&'static str` on ProviderSpec; a leak is the simplest
+        // way to hand it a per-test port and costs one small string per test.
+        let url: &'static str =
+            Box::leak(format!("http://127.0.0.1:{port}/token").into_boxed_str());
+        (url, seen)
+    }
+
+    /// Read one complete HTTP request (headers + `Content-Length` body) off the
+    /// socket. Returns false if the peer vanished first, so a probe that never
+    /// sends a grant is not counted as one.
+    async fn read_http_request(sock: &mut tokio::net::TcpStream) -> bool {
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 2048];
+        loop {
+            let Ok(n) = sock.read(&mut chunk).await else {
+                return false;
+            };
+            if n == 0 {
+                return false;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+            let Some(head_end) = buf.windows(4).position(|w| w == b"\r\n\r\n") else {
+                continue;
+            };
+            let head = String::from_utf8_lossy(&buf[..head_end]).to_lowercase();
+            let want: usize = head
+                .lines()
+                .find_map(|l| l.strip_prefix("content-length:"))
+                .and_then(|v| v.trim().parse().ok())
+                .unwrap_or(0);
+            if buf.len() >= head_end + 4 + want {
+                return true;
+            }
+        }
+    }
+
+    fn stub_spec(token_url: &'static str) -> ProviderSpec {
+        let mut s = spec();
+        s.token_url = token_url;
+        s
+    }
+
+    /// THE regression test. A response lost after the request was delivered must
+    /// cost exactly ONE request to the token endpoint. The old code sent a second
+    /// one carrying the same refresh token 400 ms later, and Atlassian answered
+    /// the reuse by revoking the grant — five days of dead Jira sync on a real
+    /// install, from one dropped connection.
+    #[tokio::test]
+    async fn a_lost_response_costs_a_rotating_grant_exactly_one_request() {
+        let (url, seen) = spawn_token_stub(vec![Reply::Hangup]).await;
+        let err = refresh("cid", &stub_spec(url), "refresh-token-1")
+            .await
+            .expect_err("a hung-up connection cannot yield tokens");
+        assert_eq!(
+            seen.load(Ordering::SeqCst),
+            1,
+            "the refresh token must be presented once and only once: {err:#}"
+        );
+        // ...and the user must not be told to reconnect, because for all we know
+        // the stored token is still perfectly good.
+        assert!(is_transient(&err), "must not read as a dead grant: {err:#}");
+    }
+
+    /// A 5xx is the same hazard wearing a status code: an edge can answer 502
+    /// after the upstream already rotated the token.
+    #[tokio::test]
+    async fn a_5xx_costs_a_rotating_grant_exactly_one_request() {
+        let (url, seen) = spawn_token_stub(vec![Reply::Status(502, "bad gateway")]).await;
+        let err = refresh("cid", &stub_spec(url), "refresh-token-1")
+            .await
+            .expect_err("502 cannot yield tokens");
+        assert_eq!(seen.load(Ordering::SeqCst), 1, "{err:#}");
+        assert!(is_transient(&err), "{err:#}");
+    }
+
+    /// Retrying is not switched off wholesale — that would trade this bug for a
+    /// sync that gives up on any hiccup. A 429 is refused BEFORE the grant is
+    /// processed, so the retry is safe and must still happen.
+    #[tokio::test]
+    async fn a_rotating_grant_still_retries_a_429_and_succeeds() {
+        let (url, seen) = spawn_token_stub(vec![
+            Reply::Status(429, r#"{"error":"rate_limited"}"#),
+            Reply::Status(
+                200,
+                r#"{"access_token":"at2","refresh_token":"rt2","expires_in":3600}"#,
+            ),
+        ])
+        .await;
+        let out = refresh("cid", &stub_spec(url), "refresh-token-1")
+            .await
+            .expect("the retry after a 429 must succeed");
+        assert_eq!(out.access_token, "at2");
+        assert_eq!(out.refresh_token, "rt2");
+        assert_eq!(seen.load(Ordering::SeqCst), 2);
+    }
+
+    /// The exact response the incident produced. One request, and this one DOES
+    /// tell the user to reconnect — the grant really is gone.
+    #[tokio::test]
+    async fn a_403_is_one_request_and_a_dead_grant() {
+        let (url, seen) = spawn_token_stub(vec![Reply::Status(
+            403,
+            r#"{"error":"unauthorized_client","error_description":"refresh_token is invalid"}"#,
+        )])
+        .await;
+        let err = refresh("cid", &stub_spec(url), "refresh-token-1")
+            .await
+            .expect_err("403 cannot yield tokens");
+        assert_eq!(seen.load(Ordering::SeqCst), 1, "{err:#}");
+        assert!(
+            !is_transient(&err),
+            "a rejected grant must surface the reconnect remedy: {err:#}"
+        );
+    }
+
+    /// An interactive code exchange keeps the old breadth: re-sending it destroys
+    /// nothing durable, and giving up on the first blip would fail logins that
+    /// would have worked.
+    #[tokio::test]
+    async fn an_interactive_exchange_still_retries_a_5xx() {
+        let (url, seen) = spawn_token_stub(vec![Reply::Status(500, "boom")]).await;
+        let body = serde_json::json!({ "grant_type": "authorization_code" });
+        let err = post_token_retrying(url, &body, GrantKind::Interactive)
+            .await
+            .expect_err("500 cannot yield tokens");
+        assert_eq!(seen.load(Ordering::SeqCst), TOKEN_POST_ATTEMPTS, "{err}");
     }
 
     #[test]

--- a/meridian-oauth/src/flow.rs
+++ b/meridian-oauth/src/flow.rs
@@ -386,11 +386,19 @@ pub(crate) const TOKEN_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 /// How long after the first grant left this machine a retry may still re-present
 /// it.
 ///
-/// Atlassian documents a 10-minute "reuse interval" in which exchanging the same
-/// rotating refresh token more than once is forgiven and yields a fresh pair.
-/// We budget a small fraction of it, for two reasons: the provider measures the
-/// interval from when IT processed the first exchange (not when we sent it), and
-/// the interval is a per-app setting we neither control nor can read back.
+/// The number this is a fraction of is not folklore. Atlassian's 3LO docs list
+/// it under "configuration options for a rotating refresh token", verbatim:
+///
+/// > | Reuse interval or leeway | 10 minutes | Within this period, the breach
+/// > detection features don't apply when exchanging a refresh token multiple
+/// > times. This interval helps avoid network concurrency issues. |
+///
+/// <https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/>
+///
+/// Two caveats keep us well inside it. The provider measures the interval from
+/// when IT processed the first exchange, not when we sent it. And "configuration
+/// options" is aspirational: there is no control for either value in the
+/// developer console, so 10 minutes is a default we observe and cannot pin.
 ///
 /// Set at half the documented interval, and deliberately not lower. Every second
 /// of margin we leave unused is a recovery declined: an interruption of two or

--- a/meridian-oauth/src/flow.rs
+++ b/meridian-oauth/src/flow.rs
@@ -6,6 +6,13 @@
 // exact-match redirect URI, so the port is fixed, not ephemeral), exchanges the
 // code for tokens, and refreshes rotating tokens. Provider-specific URLs/scopes
 // are supplied via `ProviderSpec`; everything else here is provider-blind.
+//
+// THE RULE THAT MATTERS HERE: a `refresh_token` grant is NOT idempotent. Atlassian
+// rotates the refresh token on every use and applies reuse detection - presenting a
+// refresh token it has already consumed revokes the whole token family, permanently.
+// So a refresh POST may only be re-sent when we can PROVE the first one never
+// reached the server. `TokenFailure::Ambiguous` and `GrantKind` below are that
+// proof obligation made explicit; `should_retry` is where it is enforced.
 
 use std::time::Duration;
 
@@ -48,19 +55,42 @@ pub struct TokenResponse {
     pub scope: String,
 }
 
-/// Whether a token-endpoint failure is worth retrying, or means the grant is
-/// dead. This is the distinction the background refresh loop needs: a passing
-/// network blip must not be surfaced to the user as "re-authenticate".
+/// What a token-endpoint failure says about (a) whether the user must
+/// re-authenticate and (b) whether the SAME grant may be presented again.
+///
+/// Those are two different questions and conflating them is what broke real
+/// installs: the original two-variant version treated every non-4xx as
+/// "transient, retry immediately", including failures where the request had
+/// already been delivered and acted on. See [`Ambiguous`](Self::Ambiguous).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TokenFailure {
     /// The grant itself was rejected and won't recover on its own — an OAuth 4xx
     /// (`invalid_grant`, a revoked/expired refresh token, a bad client). The
     /// stored refresh token is dead; the user must re-authenticate.
     Terminal,
-    /// A passing condition — a network error, request timeout, HTTP 429, or a
-    /// 5xx from the provider. The stored refresh token is still valid and a
-    /// later retry will succeed.
+    /// A passing condition where the endpoint provably did NOT act on the grant:
+    /// the connection was never established (`reqwest::Error::is_connect()`, which
+    /// covers a connect timeout), or the server refused the request outright with
+    /// a 429 before processing it. The stored refresh token is untouched, so
+    /// re-sending it is safe.
     Transient,
+    /// The connection was made but no usable answer came back — a response
+    /// timeout, a mid-response reset, a 5xx from an edge, or a 2xx whose body
+    /// didn't parse. **We cannot know whether the grant was consumed.**
+    ///
+    /// For a rotating refresh token that is the dangerous case, and it is not
+    /// hypothetical: on 2026-08-20 a laptop woke from sleep, the first refresh
+    /// POST failed with `error sending request`, the automatic retry 400 ms later
+    /// presented the same refresh token, and Atlassian answered
+    /// `403 unauthorized_client: refresh_token is invalid` — the first attempt HAD
+    /// reached Atlassian and rotated the token; only the response was lost. The
+    /// retry turned a recoverable blip into a permanently revoked grant, and the
+    /// user's Jira stayed disconnected until they re-authorised by hand.
+    ///
+    /// Treated as non-terminal for user-facing purposes (the token may well still
+    /// be fine, so no "Reconnect" banner), but never retried for a rotating grant
+    /// — see [`should_retry`].
+    Ambiguous,
 }
 
 /// A classified token-endpoint error. It is threaded into the `anyhow` chain
@@ -79,14 +109,34 @@ impl TokenError {
             detail: detail.into(),
         }
     }
+    /// A failure that happened BEFORE any grant left this machine — today, only
+    /// "a peer process is holding the refresh lock". Exposed (unlike the other
+    /// constructors) so `jira::ensure_fresh` can decline to refresh and still
+    /// have [`is_transient`] answer `true`, keeping the "Reconnect Jira" remedy
+    /// reserved for a grant the provider actually rejected.
+    pub fn unavailable(detail: impl Into<String>) -> Self {
+        Self::transient(detail)
+    }
+
+    fn ambiguous(detail: impl Into<String>) -> Self {
+        Self {
+            failure: TokenFailure::Ambiguous,
+            detail: detail.into(),
+        }
+    }
     fn terminal(detail: impl Into<String>) -> Self {
         Self {
             failure: TokenFailure::Terminal,
             detail: detail.into(),
         }
     }
+    /// "Not a dead grant" — true for both [`TokenFailure::Transient`] and
+    /// [`TokenFailure::Ambiguous`]. This drives the *user-facing* remedy only:
+    /// an ambiguous failure must not tell the user to reconnect, because the
+    /// stored token may still be perfectly valid. Whether the grant may be
+    /// re-sent is a separate question, answered by [`should_retry`].
     fn is_transient(&self) -> bool {
-        matches!(self.failure, TokenFailure::Transient)
+        !matches!(self.failure, TokenFailure::Terminal)
     }
 }
 
@@ -98,8 +148,11 @@ impl std::fmt::Display for TokenError {
 
 impl std::error::Error for TokenError {}
 
-/// Whether an `anyhow` error from the OAuth flow was a *transient* token-endpoint
-/// failure (retryable — network/timeout/429/5xx) rather than a dead grant.
+/// Whether an `anyhow` error from the OAuth flow was a token-endpoint failure the
+/// user cannot act on (network/timeout/429/5xx — [`TokenFailure::Transient`] or
+/// [`TokenFailure::Ambiguous`]) rather than a dead grant. Note this is NOT the
+/// same as "safe to retry": an ambiguous failure answers `true` here and is still
+/// never re-sent for a rotating grant (see [`should_retry`]).
 /// Walks the whole error chain, so it still finds the [`TokenError`] under the
 /// `.context()` layers `refresh`/`ensure_fresh` add. Defaults to `false` when no
 /// `TokenError` is present, so an unclassified failure still surfaces the
@@ -163,7 +216,7 @@ pub async fn refresh(
         "refresh_token": refresh_token,
     });
     with_client_secret(&mut body, spec);
-    post_token_retrying(spec.token_url, &body)
+    post_token_retrying(spec.token_url, &body, GrantKind::Rotating)
         .await
         .context("refreshing OAuth access token")
 }
@@ -215,7 +268,7 @@ async fn exchange_code(
         "code_verifier": verifier,
     });
     with_client_secret(&mut body, spec);
-    post_token_retrying(spec.token_url, &body)
+    post_token_retrying(spec.token_url, &body, GrantKind::Interactive)
         .await
         .context("exchanging authorization code for tokens")
 }
@@ -230,13 +283,70 @@ fn with_client_secret(body: &mut serde_json::Value, spec: &ProviderSpec) {
     }
 }
 
+/// Which kind of grant a token POST is carrying — the input to [`should_retry`].
+///
+/// The distinction is about what a *re-sent* request costs, not about the
+/// endpoint or the wire format (both are identical).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GrantKind {
+    /// `grant_type=refresh_token` against a provider that ROTATES the token.
+    /// Re-sending a grant the server already consumed is not merely useless: with
+    /// reuse detection (Atlassian has it) it revokes the entire token family, so
+    /// a blip the daemon would have shrugged off next tick becomes a permanent
+    /// disconnection the user must fix by hand. Only ever retried when the
+    /// request provably never reached the server.
+    Rotating,
+    /// `grant_type=authorization_code`. Also single-use, but nothing durable is
+    /// destroyed by re-sending it: the user is standing at the browser, and the
+    /// worst case is one more click. Keeps the original retry breadth so a blip
+    /// mid-consent doesn't fail a login that would have worked.
+    Interactive,
+}
+
+/// Whether a failed attempt may be re-sent with the SAME grant.
+///
+/// The whole point of this function is that it takes [`GrantKind`]: "is this
+/// error passing?" and "may I send this grant again?" are different questions,
+/// and answering the second with the first is what revoked real users' Jira
+/// grants. Pure, so the policy is unit-testable without a network.
+fn should_retry(kind: GrantKind, failure: TokenFailure) -> bool {
+    match (kind, failure) {
+        // A dead grant fails identically every time; retries would only delay
+        // the user's remedy behind seconds of backoff.
+        (_, TokenFailure::Terminal) => false,
+        // Provably not delivered (or explicitly refused unprocessed) — the grant
+        // is untouched, so re-sending it is exactly as safe as sending it once.
+        (_, TokenFailure::Transient) => true,
+        // May already have been consumed and rotated server-side. Re-sending is
+        // the difference between "probably fine next tick" and "revoked".
+        (GrantKind::Rotating, TokenFailure::Ambiguous) => false,
+        (GrantKind::Interactive, TokenFailure::Ambiguous) => true,
+    }
+}
+
 /// Total tries [`post_token_retrying`] gives the token endpoint before it gives
-/// up on a *transient* failure. Three attempts across ~1.6 s of backoff ride out
+/// up on a retry-safe failure. Three attempts across ~1.6 s of backoff ride out
 /// the momentary network blips and provider 5xx/429s that otherwise surfaced a
 /// spurious "re-authenticate" sync error on the very next 30-min poll. A dead
-/// grant (4xx) still fails on the first try — retries are spent only on failures
-/// that can actually clear.
-const TOKEN_POST_ATTEMPTS: usize = 3;
+/// grant (4xx) still fails on the first try, and so does an ambiguous one on a
+/// rotating grant — retries are spent only where [`should_retry`] allows.
+pub(crate) const TOKEN_POST_ATTEMPTS: usize = 3;
+
+/// Per-attempt cap on the entire token request (connect + TLS + request +
+/// response). Deliberately generous. The 8 s this replaced was itself a way to
+/// LOSE a rotated refresh token: Atlassian would process the grant, the response
+/// would miss the cut-off, and the reply carrying the new token was discarded —
+/// indistinguishable, from here, from a request that never landed.
+pub(crate) const TOKEN_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Cap on connection establishment alone. Splitting this out of
+/// [`TOKEN_REQUEST_TIMEOUT`] is what makes "never delivered" distinguishable from
+/// "no usable answer": a connect timeout surfaces as
+/// `reqwest::Error::is_connect()` and is therefore retry-safe, while a response
+/// timeout does not and must not be. Without the split, the single most common
+/// real-world failure — the first request after a laptop wakes, before the
+/// network is up — was classified as retryable when it was not.
+pub(crate) const TOKEN_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Bound an untrusted response body before it goes into a `TokenError` detail
 /// (which is then logged, verbatim, on every retry). A captive-portal or proxy
@@ -255,26 +365,29 @@ fn truncate_body(text: &str) -> String {
     format!("{} (truncated, {} bytes total)", &text[..end], text.len())
 }
 
-/// [`post_token`] with bounded retry-with-backoff for transient failures. Only
-/// [`TokenFailure::Transient`] errors are retried; a terminal rejection returns
-/// immediately so a genuinely dead token isn't hidden behind seconds of backoff.
+/// [`post_token`] with bounded retry-with-backoff, gated by [`should_retry`].
+/// A terminal rejection returns immediately so a genuinely dead token isn't
+/// hidden behind seconds of backoff — and so does an ambiguous failure on a
+/// rotating grant, because re-sending it is what makes the grant dead.
 #[tracing::instrument(skip(body), fields(token_url = %token_url))]
 async fn post_token_retrying(
     token_url: &str,
     body: &serde_json::Value,
+    kind: GrantKind,
 ) -> Result<TokenResponse, TokenError> {
     // One client for the whole retry loop: rebuilding it per attempt would throw
     // away connection pooling/keep-alive, which is exactly what a retry wants.
-    // The 8 s timeout is per request (each `send`), not a total budget.
+    // Both timeouts are per request (each `send`), not a total budget.
     let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(8))
+        .connect_timeout(TOKEN_CONNECT_TIMEOUT)
+        .timeout(TOKEN_REQUEST_TIMEOUT)
         .build()
         .map_err(|e| TokenError::transient(format!("building HTTP client: {e}")))?;
     let mut backoff = Duration::from_millis(400);
     for attempt in 1..=TOKEN_POST_ATTEMPTS {
         match post_token(&client, token_url, body).await {
             Ok(resp) => return Ok(resp),
-            Err(e) if e.is_transient() && attempt < TOKEN_POST_ATTEMPTS => {
+            Err(e) if should_retry(kind, e.failure) && attempt < TOKEN_POST_ATTEMPTS => {
                 tracing::warn!(
                     attempt,
                     max = TOKEN_POST_ATTEMPTS,
@@ -284,7 +397,22 @@ async fn post_token_retrying(
                 tokio::time::sleep(backoff).await;
                 backoff *= 3; // 400ms → 1200ms
             }
-            Err(e) => return Err(e),
+            Err(e) => {
+                // The case worth being able to find in the fleet: the grant may
+                // have been consumed server-side and the rotated token lost with
+                // the response. We deliberately do NOT retry (that is what
+                // revokes the family), so the next scheduled attempt either
+                // succeeds with the stored token or returns a clean 4xx.
+                if kind == GrantKind::Rotating && e.failure == TokenFailure::Ambiguous {
+                    tracing::warn!(
+                        attempt,
+                        error = %e,
+                        "OAuth refresh got no usable response - the provider may have already \
+                         rotated the refresh token; NOT retrying (a retry would revoke the grant)"
+                    );
+                }
+                return Err(e);
+            }
         }
     }
     // The `attempt < TOKEN_POST_ATTEMPTS` guard means the final attempt always
@@ -292,9 +420,41 @@ async fn post_token_retrying(
     unreachable!("post_token_retrying loop returns on the last attempt")
 }
 
-/// POST a grant to the token endpoint once and classify any failure as transient
-/// or terminal (see [`TokenError`]). Takes a shared `client` (built once by
-/// [`post_token_retrying`]) whose 8 s timeout applies per attempt.
+/// Classify a `reqwest` send failure by whether the request can have been
+/// delivered. `is_connect()` is the only signal that answers "no" — it covers a
+/// refused connection, a DNS failure, a TLS handshake failure and a connect
+/// timeout, all of which happen strictly before any bytes of the grant are sent.
+/// Everything else (response timeout, connection reset mid-flight, body error)
+/// leaves the question open, so it is [`TokenFailure::Ambiguous`].
+fn classify_send_error(e: &reqwest::Error) -> TokenFailure {
+    if e.is_connect() {
+        TokenFailure::Transient
+    } else {
+        TokenFailure::Ambiguous
+    }
+}
+
+/// Classify a non-2xx token-endpoint status.
+///
+/// 429 is the one non-2xx we know was refused WITHOUT the grant being processed,
+/// so it stays retry-safe. A 5xx is not that: an edge or gateway can answer 502
+/// after the upstream already consumed and rotated the token, so it downgrades to
+/// [`TokenFailure::Ambiguous`] rather than the blanket "transient" it used to be.
+/// Every other non-2xx is a real rejection: a 4xx `invalid_grant` / bad client /
+/// revoked-or-rotated refresh token the user must act on.
+fn classify_status(status: reqwest::StatusCode) -> TokenFailure {
+    if status.as_u16() == 429 {
+        TokenFailure::Transient
+    } else if status.is_server_error() {
+        TokenFailure::Ambiguous
+    } else {
+        TokenFailure::Terminal
+    }
+}
+
+/// POST a grant to the token endpoint once and classify any failure (see
+/// [`TokenFailure`]). Takes a shared `client` (built once by
+/// [`post_token_retrying`]) whose timeouts apply per attempt.
 async fn post_token(
     client: &reqwest::Client,
     token_url: &str,
@@ -308,9 +468,16 @@ async fn post_token(
         .await
     {
         Ok(r) => r,
-        // Connect refused, DNS failure, TLS error, or the 8 s timeout — the
-        // endpoint was unreachable, which says nothing about the token's validity.
-        Err(e) => return Err(TokenError::transient(format!("POST {token_url}: {e}"))),
+        // Says nothing about the token's VALIDITY either way — but it does say
+        // something about whether the grant may have been spent, which is what
+        // `classify_send_error` reads off the error.
+        Err(e) => {
+            let detail = format!("POST {token_url}: {e}");
+            return Err(match classify_send_error(&e) {
+                TokenFailure::Transient => TokenError::transient(detail),
+                _ => TokenError::ambiguous(detail),
+            });
+        }
     };
     let status = resp.status();
     let text = resp.text().await.unwrap_or_default();
@@ -319,20 +486,19 @@ async fn post_token(
             "token endpoint {token_url} → {status}: {}",
             truncate_body(&text)
         );
-        // 429 (rate limited) and 5xx are the provider briefly faltering — retry.
-        // Every other non-2xx is a real rejection: a 4xx `invalid_grant` / bad
-        // client / revoked-or-rotated refresh token the user must act on.
-        return Err(if status.as_u16() == 429 || status.is_server_error() {
-            TokenError::transient(detail)
-        } else {
-            TokenError::terminal(detail)
+        return Err(match classify_status(status) {
+            TokenFailure::Transient => TokenError::transient(detail),
+            TokenFailure::Ambiguous => TokenError::ambiguous(detail),
+            TokenFailure::Terminal => TokenError::terminal(detail),
         });
     }
     // A 2xx whose body isn't valid JSON is almost always a proxy or captive-portal
-    // interstitial standing in for the real payload, not a malformed token grant —
-    // treat it as transient so a later retry (off the hostile network) can succeed.
+    // interstitial standing in for the real payload, not a malformed token grant.
+    // AMBIGUOUS, not transient: we cannot tell an interstitial (grant untouched)
+    // from a real 2xx we failed to read (grant spent, rotated token lost), and
+    // for a rotating grant the second reading is the one that must win.
     serde_json::from_str(&text).map_err(|e| {
-        TokenError::transient(format!(
+        TokenError::ambiguous(format!(
             "parsing token response: {e}: {}",
             truncate_body(&text)
         ))
@@ -607,6 +773,114 @@ mod tests {
         // No TokenError in the chain → default to terminal (surface the remedy).
         let unclassified = anyhow::anyhow!("disk error").context("loading token store");
         assert!(!is_transient(&unclassified));
+    }
+
+    /// An ambiguous failure must NOT tell the user to reconnect. The stored
+    /// refresh token may well still be valid (a lost response says nothing about
+    /// it), so the remedy is "wait for the next tick", exactly as for a plain
+    /// transient. This is the half of the split that faces the user.
+    #[test]
+    fn ambiguous_failures_are_not_surfaced_as_dead_grants() {
+        let ambiguous = anyhow::Error::new(TokenError::ambiguous("response timed out"))
+            .context("refreshing OAuth access token");
+        assert!(is_transient(&ambiguous));
+    }
+
+    /// The half of the split that faces the PROVIDER, and the one that regressed
+    /// in production: a rotating refresh grant may only be re-sent when the
+    /// request provably never landed. Re-sending after a lost response is what
+    /// trips Atlassian's refresh-token reuse detection and revokes the family.
+    #[test]
+    fn a_rotating_grant_is_never_retried_after_an_ambiguous_failure() {
+        assert!(!should_retry(GrantKind::Rotating, TokenFailure::Ambiguous));
+        // Provably-undelivered and explicitly-refused-unprocessed stay retryable,
+        // so a genuine network blip still doesn't cost a sync cycle.
+        assert!(should_retry(GrantKind::Rotating, TokenFailure::Transient));
+        // A dead grant fails identically every time — don't bury the remedy.
+        assert!(!should_retry(GrantKind::Rotating, TokenFailure::Terminal));
+    }
+
+    /// An interactive code exchange keeps the wider retry breadth: nothing
+    /// durable is destroyed by re-sending it, and the user is at the browser.
+    #[test]
+    fn an_interactive_grant_still_retries_ambiguous_failures() {
+        assert!(should_retry(
+            GrantKind::Interactive,
+            TokenFailure::Ambiguous
+        ));
+        assert!(should_retry(
+            GrantKind::Interactive,
+            TokenFailure::Transient
+        ));
+        assert!(!should_retry(
+            GrantKind::Interactive,
+            TokenFailure::Terminal
+        ));
+    }
+
+    /// 429 means the request was refused BEFORE the grant was processed, so it
+    /// stays retry-safe. A 5xx does not carry that guarantee — an edge can answer
+    /// 502 after the upstream already rotated the token — so it must not be
+    /// retried for a rotating grant. 4xx stays terminal.
+    #[test]
+    fn status_classification_separates_429_from_5xx() {
+        use reqwest::StatusCode;
+        assert_eq!(
+            classify_status(StatusCode::TOO_MANY_REQUESTS),
+            TokenFailure::Transient
+        );
+        assert_eq!(
+            classify_status(StatusCode::BAD_GATEWAY),
+            TokenFailure::Ambiguous
+        );
+        assert_eq!(
+            classify_status(StatusCode::INTERNAL_SERVER_ERROR),
+            TokenFailure::Ambiguous
+        );
+        // The exact status the revoked-grant incident returned.
+        assert_eq!(
+            classify_status(StatusCode::FORBIDDEN),
+            TokenFailure::Terminal
+        );
+        assert_eq!(
+            classify_status(StatusCode::UNAUTHORIZED),
+            TokenFailure::Terminal
+        );
+        assert_eq!(
+            classify_status(StatusCode::BAD_REQUEST),
+            TokenFailure::Terminal
+        );
+        // ...and 5xx must not be retried for a rotating grant, which is the
+        // behaviour change this classification exists to produce.
+        assert!(!should_retry(
+            GrantKind::Rotating,
+            classify_status(StatusCode::BAD_GATEWAY)
+        ));
+    }
+
+    /// A connection that was never established cannot have delivered the grant,
+    /// so it is retry-safe; anything else leaves the question open. Built from a
+    /// real `reqwest` error (a connect failure to a closed port) rather than a
+    /// hand-made one, so this pins the actual `is_connect()` behaviour of the
+    /// version we ship, not our belief about it.
+    #[tokio::test]
+    async fn a_refused_connection_is_retry_safe() {
+        // Port 1 on loopback: nothing listens, and the connection is refused
+        // during connect — no request bytes are ever written.
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(2))
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap();
+        let err = client
+            .post("http://127.0.0.1:1/oauth/token")
+            .json(&serde_json::json!({"grant_type": "refresh_token"}))
+            .send()
+            .await
+            .expect_err("nothing listens on 127.0.0.1:1");
+        assert!(err.is_connect(), "expected a connect error, got: {err}");
+        assert_eq!(classify_send_error(&err), TokenFailure::Transient);
+        assert!(should_retry(GrantKind::Rotating, classify_send_error(&err)));
     }
 
     fn spec() -> ProviderSpec {

--- a/meridian-oauth/src/flow.rs
+++ b/meridian-oauth/src/flow.rs
@@ -7,14 +7,22 @@
 // code for tokens, and refreshes rotating tokens. Provider-specific URLs/scopes
 // are supplied via `ProviderSpec`; everything else here is provider-blind.
 //
-// THE RULE THAT MATTERS HERE: a `refresh_token` grant is NOT idempotent. Atlassian
-// rotates the refresh token on every use and applies reuse detection - presenting a
-// refresh token it has already consumed revokes the whole token family, permanently.
-// So a refresh POST may only be re-sent when we can PROVE the first one never
-// reached the server. `TokenFailure::Ambiguous` and `GrantKind` below are that
-// proof obligation made explicit; `should_retry` is where it is enforced.
+// THE RULE THAT MATTERS HERE: a `refresh_token` grant is NOT idempotent, and the
+// provider forgives that only for a bounded time. Atlassian rotates the refresh
+// token on every use, but documents a REUSE INTERVAL (10 min by default) during
+// which exchanging the same token again is explicitly allowed - "this interval
+// helps avoid network concurrency issues" - and returns a fresh, valid pair.
+// Outside it, the identical request trips breach detection and revokes the whole
+// token family, permanently.
+//
+// So the correct policy is not "never re-send a refresh grant"; it is "re-send it
+// only while the provider is still forgiving reuse". Inside the window a retry
+// RECOVERS a lost response; outside it, a retry is what destroys the grant.
+// `REUSE_GRACE_BUDGET` and `should_retry` are that rule; `wall_elapsed_since`
+// is the measurement, and it must be a wall clock - see its doc for why a
+// monotonic one silently fails exactly when this matters.
 
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use anyhow::{anyhow, bail, Context, Result};
 use serde::Deserialize;
@@ -56,40 +64,50 @@ pub struct TokenResponse {
 }
 
 /// What a token-endpoint failure says about (a) whether the user must
-/// re-authenticate and (b) whether the SAME grant may be presented again.
+/// re-authenticate and (b) whether the grant may already have been spent.
 ///
-/// Those are two different questions and conflating them is what broke real
-/// installs: the original two-variant version treated every non-4xx as
-/// "transient, retry immediately", including failures where the request had
-/// already been delivered and acted on. See [`Ambiguous`](Self::Ambiguous).
+/// Those are different questions, and the original two-variant version answered
+/// the second with the first: every non-4xx read as "transient, retry
+/// immediately", including failures where the request had already been delivered
+/// and acted on. See [`Ambiguous`](Self::Ambiguous).
+///
+/// Note this enum does NOT by itself decide retries — [`should_retry`] combines
+/// it with how long ago the grant was sent, because for a rotating token the
+/// permission to re-send expires. This is the diagnosis; the clock is the other
+/// half.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TokenFailure {
     /// The grant itself was rejected and won't recover on its own — an OAuth 4xx
     /// (`invalid_grant`, a revoked/expired refresh token, a bad client). The
     /// stored refresh token is dead; the user must re-authenticate.
     Terminal,
-    /// A passing condition where the endpoint provably did NOT act on the grant:
+    /// A passing condition where THIS attempt provably did NOT act on the grant:
     /// the connection was never established (`reqwest::Error::is_connect()`, which
     /// covers a connect timeout), or the server refused the request outright with
-    /// a 429 before processing it. The stored refresh token is untouched, so
-    /// re-sending it is safe.
+    /// a 429 before processing it. The stored refresh token is untouched by this
+    /// attempt — though an earlier one in the same ladder may have spent it,
+    /// which is why [`should_retry`] still checks the clock.
     Transient,
     /// The connection was made but no usable answer came back — a response
     /// timeout, a mid-response reset, a 5xx from an edge, or a 2xx whose body
     /// didn't parse. **We cannot know whether the grant was consumed.**
     ///
-    /// For a rotating refresh token that is the dangerous case, and it is not
-    /// hypothetical: on 2026-08-20 a laptop woke from sleep, the first refresh
-    /// POST failed with `error sending request`, the automatic retry 400 ms later
-    /// presented the same refresh token, and Atlassian answered
-    /// `403 unauthorized_client: refresh_token is invalid` — the first attempt HAD
-    /// reached Atlassian and rotated the token; only the response was lost. The
-    /// retry turned a recoverable blip into a permanently revoked grant, and the
-    /// user's Jira stayed disconnected until they re-authorised by hand.
+    /// For a rotating refresh token this is the case the provider's reuse
+    /// interval exists to rescue — and the case that destroys the grant when the
+    /// rescue arrives too late. It is not hypothetical: on 2026-08-20 a refresh
+    /// POST left at 18:26:55, the laptop suspended mid-request, and the attempt
+    /// did not fail until 18:55:29. The retry 400 ms after THAT re-presented a
+    /// refresh token Atlassian had rotated 29 minutes earlier — far outside its
+    /// 10-minute reuse interval — and Atlassian answered
+    /// `403 unauthorized_client: refresh_token is invalid`, revoking the grant.
+    /// The user's Jira stayed dead for five days until they re-authorised by hand.
     ///
-    /// Treated as non-terminal for user-facing purposes (the token may well still
-    /// be fine, so no "Reconnect" banner), but never retried for a rotating grant
-    /// — see [`should_retry`].
+    /// Had that same retry fired seconds after the send, the reuse would have
+    /// been forgiven and returned the pair whose delivery was lost. Hence
+    /// [`should_retry`]: retry promptly, never late.
+    ///
+    /// Treated as non-terminal for user-facing purposes either way (the stored
+    /// token may well still be fine, so no "Reconnect" banner).
     Ambiguous,
 }
 
@@ -305,31 +323,40 @@ enum GrantKind {
 
 /// Whether a failed attempt may be re-sent with the SAME grant.
 ///
-/// The whole point of this function is that it takes [`GrantKind`]: "is this
-/// error passing?" and "may I send this grant again?" are different questions,
-/// and answering the second with the first is what revoked real users' Jira
-/// grants. Pure, so the policy is unit-testable without a network.
-fn should_retry(kind: GrantKind, failure: TokenFailure) -> bool {
+/// Takes [`GrantKind`] because "is this error passing?" and "may I send this
+/// grant again?" are different questions, and `wall_elapsed` because for a
+/// rotating grant the answer to the second one EXPIRES. Pure, so the policy is
+/// unit-testable without a network or a clock.
+fn should_retry(kind: GrantKind, failure: TokenFailure, wall_elapsed: Duration) -> bool {
     match (kind, failure) {
         // A dead grant fails identically every time; retries would only delay
         // the user's remedy behind seconds of backoff.
         (_, TokenFailure::Terminal) => false,
-        // Provably not delivered (or explicitly refused unprocessed) — the grant
-        // is untouched, so re-sending it is exactly as safe as sending it once.
-        (_, TokenFailure::Transient) => true,
-        // May already have been consumed and rotated server-side. Re-sending is
-        // the difference between "probably fine next tick" and "revoked".
-        (GrantKind::Rotating, TokenFailure::Ambiguous) => false,
-        (GrantKind::Interactive, TokenFailure::Ambiguous) => true,
+        // An authorization code destroys nothing durable when re-sent: the user
+        // is standing at the browser and the worst case is one more click. Keep
+        // the full breadth so a blip mid-consent doesn't fail a working login.
+        (GrantKind::Interactive, _) => true,
+        // This attempt may have been delivered and acted on, so the retry is a
+        // reuse. Allowed only while the provider is still forgiving reuse - in
+        // which case it does not merely avoid harm, it RECOVERS: the provider
+        // answers with the fresh pair whose first delivery we lost.
+        (GrantKind::Rotating, TokenFailure::Ambiguous) => wall_elapsed < REUSE_GRACE_BUDGET,
+        // This attempt provably did not spend the grant - but an EARLIER attempt
+        // in the same ladder may have, and once a suspend has moved the wall
+        // clock we can no longer tell the two apart. Gate it identically rather
+        // than reason about which attempt we are on; at the first attempt
+        // `wall_elapsed` is ~0, so this never blocks a legitimate prompt retry.
+        (GrantKind::Rotating, TokenFailure::Transient) => wall_elapsed < REUSE_GRACE_BUDGET,
     }
 }
 
 /// Total tries [`post_token_retrying`] gives the token endpoint before it gives
-/// up on a retry-safe failure. Three attempts across ~1.6 s of backoff ride out
-/// the momentary network blips and provider 5xx/429s that otherwise surfaced a
-/// spurious "re-authenticate" sync error on the very next 30-min poll. A dead
-/// grant (4xx) still fails on the first try, and so does an ambiguous one on a
-/// rotating grant — retries are spent only where [`should_retry`] allows.
+/// up. Three attempts across ~1.6 s of backoff ride out the momentary network
+/// blips and provider 5xx/429s that otherwise surfaced a spurious
+/// "re-authenticate" sync error on the very next 30-min poll — and, for a
+/// rotating grant whose response was lost, those same attempts are the recovery.
+/// A dead grant (4xx) still fails on the first try, and [`should_retry`] can end
+/// the ladder early on the clock regardless of the count.
 pub(crate) const TOKEN_POST_ATTEMPTS: usize = 3;
 
 /// Per-attempt cap on the entire token request (connect + TLS + request +
@@ -338,6 +365,43 @@ pub(crate) const TOKEN_POST_ATTEMPTS: usize = 3;
 /// would miss the cut-off, and the reply carrying the new token was discarded —
 /// indistinguishable, from here, from a request that never landed.
 pub(crate) const TOKEN_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long after the first grant left this machine a retry may still re-present
+/// it.
+///
+/// Atlassian documents a 10-minute "reuse interval" in which exchanging the same
+/// rotating refresh token more than once is forgiven and yields a fresh pair.
+/// We budget a small fraction of it, for two reasons: the provider measures the
+/// interval from when IT processed the first exchange (not when we sent it), and
+/// the interval is a per-app setting we neither control nor can read back.
+///
+/// 60 s sits between the two timescales that matter. Every prompt retry is far
+/// under it (the whole backoff ladder is ~1.6 s), and the one thing that
+/// realistically pushes a retry past the window is far over it: the machine
+/// suspending mid-request. That is not hypothetical. On 2026-08-20 a refresh
+/// POST left at 18:26:55, the laptop slept, and the attempt did not fail until
+/// 18:55:29, 28 minutes later. The retry 400 ms after THAT was a reuse 29
+/// minutes stale, and Atlassian revoked the grant.
+pub(crate) const REUSE_GRACE_BUDGET: Duration = Duration::from_secs(60);
+
+/// Wall-clock time elapsed since `started`, saturating at zero.
+///
+/// Deliberately `SystemTime` and NOT `Instant`. A monotonic clock does not
+/// advance while the machine is suspended (macOS `CLOCK_UPTIME_RAW`, Linux
+/// `CLOCK_MONOTONIC`), and tokio's timers are built on it - which is why the old
+/// 8 s per-request timeout did NOT fire on the request that spanned a 28-minute
+/// sleep, and why an `Instant`-based version of this check would have reported
+/// that request as having taken milliseconds and cheerfully retried it. The
+/// clock we need is the one the provider is using, and that is a wall clock.
+///
+/// `SystemTime` can jump (NTP). Forward: we skip a retry, which is the safe
+/// direction. Backward: we saturate to zero and treat the retry as prompt, which
+/// is what it almost certainly was.
+fn wall_elapsed_since(started: SystemTime) -> Duration {
+    SystemTime::now()
+        .duration_since(started)
+        .unwrap_or(Duration::ZERO)
+}
 
 /// Cap on connection establishment alone. Splitting this out of
 /// [`TOKEN_REQUEST_TIMEOUT`] is what makes "never delivered" distinguishable from
@@ -366,9 +430,12 @@ fn truncate_body(text: &str) -> String {
 }
 
 /// [`post_token`] with bounded retry-with-backoff, gated by [`should_retry`].
-/// A terminal rejection returns immediately so a genuinely dead token isn't
-/// hidden behind seconds of backoff — and so does an ambiguous failure on a
-/// rotating grant, because re-sending it is what makes the grant dead.
+///
+/// The retry ladder is checked against the WALL CLOCK on both sides of the
+/// backoff, not just once: `tokio::time::sleep` is a monotonic timer, so a
+/// suspend during the backoff can turn a 400 ms wait into a half-hour one
+/// without the timer noticing. Re-checking after the sleep is what stops the
+/// resumed process from firing a stale reuse the instant it wakes.
 #[tracing::instrument(skip(body), fields(token_url = %token_url))]
 async fn post_token_retrying(
     token_url: &str,
@@ -383,41 +450,54 @@ async fn post_token_retrying(
         .timeout(TOKEN_REQUEST_TIMEOUT)
         .build()
         .map_err(|e| TokenError::transient(format!("building HTTP client: {e}")))?;
+    // Captured before the first grant leaves the machine: the provider's reuse
+    // window starts when IT processes that request, so this is the earliest
+    // instant we can honestly call the start of the window.
+    let first_sent_at = SystemTime::now();
     let mut backoff = Duration::from_millis(400);
-    for attempt in 1..=TOKEN_POST_ATTEMPTS {
-        match post_token(&client, token_url, body).await {
+    let mut attempt = 0usize;
+    loop {
+        attempt += 1;
+        let err = match post_token(&client, token_url, body).await {
             Ok(resp) => return Ok(resp),
-            Err(e) if should_retry(kind, e.failure) && attempt < TOKEN_POST_ATTEMPTS => {
-                tracing::warn!(
-                    attempt,
-                    max = TOKEN_POST_ATTEMPTS,
-                    error = %e,
-                    "OAuth token endpoint transient failure - retrying after backoff"
-                );
-                tokio::time::sleep(backoff).await;
-                backoff *= 3; // 400ms → 1200ms
-            }
-            Err(e) => {
-                // The case worth being able to find in the fleet: the grant may
-                // have been consumed server-side and the rotated token lost with
-                // the response. We deliberately do NOT retry (that is what
-                // revokes the family), so the next scheduled attempt either
-                // succeeds with the stored token or returns a clean 4xx.
-                if kind == GrantKind::Rotating && e.failure == TokenFailure::Ambiguous {
-                    tracing::warn!(
-                        attempt,
-                        error = %e,
-                        "OAuth refresh got no usable response - the provider may have already \
-                         rotated the refresh token; NOT retrying (a retry would revoke the grant)"
-                    );
-                }
-                return Err(e);
-            }
+            Err(e) => e,
+        };
+        let out_of_attempts = attempt >= TOKEN_POST_ATTEMPTS;
+        if out_of_attempts || !should_retry(kind, err.failure, wall_elapsed_since(first_sent_at)) {
+            report_exhausted(kind, &err, attempt, first_sent_at);
+            return Err(err);
+        }
+        tracing::warn!(
+            attempt,
+            max = TOKEN_POST_ATTEMPTS,
+            error = %err,
+            "OAuth token endpoint transient failure - retrying after backoff"
+        );
+        tokio::time::sleep(backoff).await;
+        backoff *= 3; // 400ms → 1200ms
+        if !should_retry(kind, err.failure, wall_elapsed_since(first_sent_at)) {
+            report_exhausted(kind, &err, attempt, first_sent_at);
+            return Err(err);
         }
     }
-    // The `attempt < TOKEN_POST_ATTEMPTS` guard means the final attempt always
-    // takes a return arm above.
-    unreachable!("post_token_retrying loop returns on the last attempt")
+}
+
+/// Log the give-up, loudly enough to find in the fleet when a rotating grant may
+/// have been spent without us learning its replacement — the state that ends in
+/// a user having to reconnect by hand, and the one worth being able to count.
+fn report_exhausted(kind: GrantKind, err: &TokenError, attempt: usize, first_sent_at: SystemTime) {
+    if kind != GrantKind::Rotating || err.failure == TokenFailure::Terminal {
+        return;
+    }
+    let elapsed_s = wall_elapsed_since(first_sent_at).as_secs_f64();
+    tracing::warn!(
+        attempt,
+        elapsed_s,
+        error = %err,
+        "OAuth refresh gave up without a usable response - the provider may have rotated \
+         the refresh token to one we never received. Not re-presenting the old token: \
+         outside the provider's reuse window that revokes the grant outright."
+    );
 }
 
 /// Classify a `reqwest` send failure by whether the request can have been
@@ -788,35 +868,78 @@ mod tests {
         assert!(is_transient(&ambiguous));
     }
 
-    /// The half of the split that faces the PROVIDER, and the one that regressed
-    /// in production: a rotating refresh grant may only be re-sent when the
-    /// request provably never landed. Re-sending after a lost response is what
-    /// trips Atlassian's refresh-token reuse detection and revokes the family.
+    const PROMPT: Duration = Duration::from_secs(2);
+    /// Longer than [`REUSE_GRACE_BUDGET`] — what a retry looks like on the far
+    /// side of a suspend.
+    const STALE: Duration = Duration::from_secs(29 * 60);
+
+    /// A prompt retry of a rotating grant is not merely tolerated, it is the
+    /// RECOVERY: inside the provider's reuse interval the same refresh token
+    /// yields the fresh pair whose first delivery we lost. Refusing to retry
+    /// here would leave the user disconnected just as surely as retrying late.
     #[test]
-    fn a_rotating_grant_is_never_retried_after_an_ambiguous_failure() {
-        assert!(!should_retry(GrantKind::Rotating, TokenFailure::Ambiguous));
-        // Provably-undelivered and explicitly-refused-unprocessed stay retryable,
-        // so a genuine network blip still doesn't cost a sync cycle.
-        assert!(should_retry(GrantKind::Rotating, TokenFailure::Transient));
+    fn a_rotating_grant_retries_promptly_and_recovers() {
+        assert!(should_retry(
+            GrantKind::Rotating,
+            TokenFailure::Ambiguous,
+            PROMPT
+        ));
+        assert!(should_retry(
+            GrantKind::Rotating,
+            TokenFailure::Transient,
+            PROMPT
+        ));
         // A dead grant fails identically every time — don't bury the remedy.
-        assert!(!should_retry(GrantKind::Rotating, TokenFailure::Terminal));
+        assert!(!should_retry(
+            GrantKind::Rotating,
+            TokenFailure::Terminal,
+            PROMPT
+        ));
     }
 
-    /// An interactive code exchange keeps the wider retry breadth: nothing
-    /// durable is destroyed by re-sending it, and the user is at the browser.
+    /// The regression itself. Once the wall clock has moved past the reuse
+    /// window — which on a laptop means "the machine slept mid-request" — the
+    /// same retry stops being a recovery and becomes the thing that revokes the
+    /// grant. Both failure classes are gated: a connect error proves only that
+    /// THIS attempt didn't spend the token, not that an earlier one didn't.
     #[test]
-    fn an_interactive_grant_still_retries_ambiguous_failures() {
+    fn a_rotating_grant_is_never_retried_once_the_reuse_window_has_passed() {
+        assert!(!should_retry(
+            GrantKind::Rotating,
+            TokenFailure::Ambiguous,
+            STALE
+        ));
+        assert!(!should_retry(
+            GrantKind::Rotating,
+            TokenFailure::Transient,
+            STALE
+        ));
+        assert!(!should_retry(
+            GrantKind::Rotating,
+            TokenFailure::Terminal,
+            STALE
+        ));
+    }
+
+    /// An interactive code exchange keeps the wider retry breadth regardless of
+    /// age: nothing durable is destroyed by re-sending it, and the user is at
+    /// the browser.
+    #[test]
+    fn an_interactive_grant_retries_regardless_of_age() {
         assert!(should_retry(
             GrantKind::Interactive,
-            TokenFailure::Ambiguous
+            TokenFailure::Ambiguous,
+            STALE
         ));
         assert!(should_retry(
             GrantKind::Interactive,
-            TokenFailure::Transient
+            TokenFailure::Transient,
+            STALE
         ));
         assert!(!should_retry(
             GrantKind::Interactive,
-            TokenFailure::Terminal
+            TokenFailure::Terminal,
+            STALE
         ));
     }
 
@@ -852,11 +975,17 @@ mod tests {
             classify_status(StatusCode::BAD_REQUEST),
             TokenFailure::Terminal
         );
-        // ...and 5xx must not be retried for a rotating grant, which is the
-        // behaviour change this classification exists to produce.
+        // ...and a 5xx is retryable while the reuse window is open, but not
+        // after it has closed - the distinction this whole module turns on.
+        assert!(should_retry(
+            GrantKind::Rotating,
+            classify_status(StatusCode::BAD_GATEWAY),
+            PROMPT
+        ));
         assert!(!should_retry(
             GrantKind::Rotating,
-            classify_status(StatusCode::BAD_GATEWAY)
+            classify_status(StatusCode::BAD_GATEWAY),
+            STALE
         ));
     }
 
@@ -882,7 +1011,11 @@ mod tests {
             .expect_err("nothing listens on 127.0.0.1:1");
         assert!(err.is_connect(), "expected a connect error, got: {err}");
         assert_eq!(classify_send_error(&err), TokenFailure::Transient);
-        assert!(should_retry(GrantKind::Rotating, classify_send_error(&err)));
+        assert!(should_retry(
+            GrantKind::Rotating,
+            classify_send_error(&err),
+            PROMPT
+        ));
     }
 
     fn spec() -> ProviderSpec {
@@ -1020,37 +1153,61 @@ mod tests {
         s
     }
 
-    /// THE regression test. A response lost after the request was delivered must
-    /// cost exactly ONE request to the token endpoint. The old code sent a second
-    /// one carrying the same refresh token 400 ms later, and Atlassian answered
-    /// the reuse by revoking the grant — five days of dead Jira sync on a real
-    /// install, from one dropped connection.
+    /// THE recovery test, and the shape of the incident. The endpoint reads the
+    /// grant then hangs up — request delivered, answer lost, exactly what a
+    /// dropped connection looks like from here. A prompt retry re-presents the
+    /// same refresh token INSIDE the provider's reuse interval, which is what
+    /// that interval is for, and comes back with the pair we lost. The user
+    /// never learns anything happened.
     #[tokio::test]
-    async fn a_lost_response_costs_a_rotating_grant_exactly_one_request() {
+    async fn a_lost_response_is_recovered_by_a_prompt_retry() {
+        let (url, seen) = spawn_token_stub(vec![
+            Reply::Hangup,
+            Reply::Status(
+                200,
+                r#"{"access_token":"at2","refresh_token":"rt2","expires_in":3600}"#,
+            ),
+        ])
+        .await;
+        let out = refresh("cid", &stub_spec(url), "refresh-token-1")
+            .await
+            .expect("a prompt reuse is inside the grace window and must recover");
+        assert_eq!(out.refresh_token, "rt2");
+        assert_eq!(seen.load(Ordering::SeqCst), 2);
+    }
+
+    /// When the retries cannot recover either, the grant may have been spent —
+    /// but the user must NOT be told to reconnect on that suspicion alone. The
+    /// stored token may be untouched, and a false "Reconnect Jira" for a passing
+    /// network fault is its own bug.
+    #[tokio::test]
+    async fn a_lost_response_that_stays_lost_is_not_reported_as_a_dead_grant() {
         let (url, seen) = spawn_token_stub(vec![Reply::Hangup]).await;
         let err = refresh("cid", &stub_spec(url), "refresh-token-1")
             .await
             .expect_err("a hung-up connection cannot yield tokens");
-        assert_eq!(
-            seen.load(Ordering::SeqCst),
-            1,
-            "the refresh token must be presented once and only once: {err:#}"
-        );
-        // ...and the user must not be told to reconnect, because for all we know
-        // the stored token is still perfectly good.
+        assert_eq!(seen.load(Ordering::SeqCst), TOKEN_POST_ATTEMPTS, "{err:#}");
         assert!(is_transient(&err), "must not read as a dead grant: {err:#}");
     }
 
-    /// A 5xx is the same hazard wearing a status code: an edge can answer 502
-    /// after the upstream already rotated the token.
+    /// A 5xx is the same hazard wearing a status code - an edge can answer 502
+    /// after the upstream already rotated the token - so it gets the same
+    /// treatment: retried while the window is open, and the retry recovers.
     #[tokio::test]
-    async fn a_5xx_costs_a_rotating_grant_exactly_one_request() {
-        let (url, seen) = spawn_token_stub(vec![Reply::Status(502, "bad gateway")]).await;
-        let err = refresh("cid", &stub_spec(url), "refresh-token-1")
+    async fn a_5xx_is_retried_inside_the_window_and_recovers() {
+        let (url, seen) = spawn_token_stub(vec![
+            Reply::Status(502, "bad gateway"),
+            Reply::Status(
+                200,
+                r#"{"access_token":"at2","refresh_token":"rt2","expires_in":3600}"#,
+            ),
+        ])
+        .await;
+        let out = refresh("cid", &stub_spec(url), "refresh-token-1")
             .await
-            .expect_err("502 cannot yield tokens");
-        assert_eq!(seen.load(Ordering::SeqCst), 1, "{err:#}");
-        assert!(is_transient(&err), "{err:#}");
+            .expect("a 502 inside the reuse window must be retried");
+        assert_eq!(out.refresh_token, "rt2");
+        assert_eq!(seen.load(Ordering::SeqCst), 2);
     }
 
     /// Retrying is not switched off wholesale — that would trade this bug for a

--- a/meridian-oauth/src/flow.rs
+++ b/meridian-oauth/src/flow.rs
@@ -392,14 +392,24 @@ pub(crate) const TOKEN_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 /// interval from when IT processed the first exchange (not when we sent it), and
 /// the interval is a per-app setting we neither control nor can read back.
 ///
-/// 60 s sits between the two timescales that matter. Every prompt retry is far
-/// under it (the whole backoff ladder is ~1.6 s), and the one thing that
-/// realistically pushes a retry past the window is far over it: the machine
-/// suspending mid-request. That is not hypothetical. On 2026-08-20 a refresh
-/// POST left at 18:26:55, the laptop slept, and the attempt did not fail until
-/// 18:55:29, 28 minutes later. The retry 400 ms after THAT was a reuse 29
-/// minutes stale, and Atlassian revoked the grant.
-pub(crate) const REUSE_GRACE_BUDGET: Duration = Duration::from_secs(60);
+/// Set at half the documented interval, and deliberately not lower. Every second
+/// of margin we leave unused is a recovery declined: an interruption of two or
+/// three minutes — a short lid-close, a slow restart, a network that drops and
+/// comes back — is squarely inside what the provider forgives, and refusing to
+/// retry there abandons a grant that one request would have restored. Five
+/// minutes still leaves five in hand, and the two clocks err the safe way: we
+/// start counting when we SEND, the provider when it PROCESSES, so our elapsed
+/// is never the smaller of the two.
+///
+/// What it must exclude is the case that cannot be forgiven, and the real one is
+/// not subtle. On 2026-08-20 a refresh POST left at 18:26:55, the laptop
+/// suspended, and the attempt did not fail until 18:55:29 — 28 minutes later. A
+/// retry there is a reuse half an hour stale.
+///
+/// Note this bounds only WHETHER a retry may happen, not how long the ladder can
+/// run: [`TOKEN_POST_ATTEMPTS`] does that, and it is the smaller bound in every
+/// realistic case.
+pub(crate) const REUSE_GRACE_BUDGET: Duration = Duration::from_secs(5 * 60);
 
 /// Wall-clock time elapsed since `started`, saturating at zero.
 ///
@@ -886,6 +896,10 @@ mod tests {
     }
 
     const PROMPT: Duration = Duration::from_secs(2);
+    /// A short interruption — a lid-close or a slow restart. Inside what the
+    /// provider forgives, so it must still be retried: this is a recovery the
+    /// budget exists to permit, not one it exists to block.
+    const SHORT_INTERRUPTION: Duration = Duration::from_secs(3 * 60);
     /// Longer than [`REUSE_GRACE_BUDGET`] — what a retry looks like on the far
     /// side of a suspend.
     const STALE: Duration = Duration::from_secs(29 * 60);
@@ -919,6 +933,18 @@ mod tests {
     /// same retry stops being a recovery and becomes the thing that revokes the
     /// grant. Both failure classes are gated: a connect error proves only that
     /// THIS attempt didn't spend the token, not that an earlier one didn't.
+    /// An interruption of a few minutes is exactly what the provider's reuse
+    /// interval is there to absorb. Declining it would trade a recoverable blip
+    /// for a manual reconnect just as surely as retrying a stale one does.
+    #[test]
+    fn a_short_interruption_is_still_inside_the_window() {
+        assert!(should_retry(
+            GrantKind::Rotating,
+            TokenFailure::Ambiguous,
+            SHORT_INTERRUPTION
+        ));
+    }
+
     #[test]
     fn a_rotating_grant_is_never_retried_once_the_reuse_window_has_passed() {
         assert!(!should_retry(

--- a/meridian-oauth/src/flow.rs
+++ b/meridian-oauth/src/flow.rs
@@ -166,6 +166,23 @@ impl std::fmt::Display for TokenError {
 
 impl std::error::Error for TokenError {}
 
+/// Whether an `anyhow` error from the OAuth flow left the grant possibly SPENT —
+/// i.e. carries a [`TokenFailure::Ambiguous`]. The request reached the provider
+/// and no usable answer came back, so a rotating refresh token may have been
+/// consumed and its replacement lost with the response.
+///
+/// Distinct from [`is_transient`], which answers the user-facing question. This
+/// one answers a bookkeeping question: whether an in-flight marker must be left
+/// standing so a later run can try to repair the exchange inside the provider's
+/// reuse window (see `jira::recover_interrupted_refresh`). Defaults to `false`
+/// when no [`TokenError`] is present — an unclassified failure never reached the
+/// token endpoint through this module at all.
+pub fn may_have_spent_the_grant(err: &anyhow::Error) -> bool {
+    err.chain()
+        .find_map(|cause| cause.downcast_ref::<TokenError>())
+        .is_some_and(|e| e.failure == TokenFailure::Ambiguous)
+}
+
 /// Whether an `anyhow` error from the OAuth flow was a token-endpoint failure the
 /// user cannot act on (network/timeout/429/5xx — [`TokenFailure::Transient`] or
 /// [`TokenFailure::Ambiguous`]) rather than a dead grant. Note this is NOT the

--- a/meridian-oauth/src/jira.rs
+++ b/meridian-oauth/src/jira.rs
@@ -312,23 +312,59 @@ pub async fn ensure_fresh() -> Result<OAuthTokens> {
     if !resp.scope.is_empty() {
         t.scopes = resp.scope;
     }
-    // Save the rotated tokens. If save fails (disk full, permissions), log a
-    // critical error and return the in-memory tokens anyway — the access token
-    // is valid for ~1h so the current request succeeds. On the next expiry the
-    // stored (now-invalid) refresh token will cause a 401 and the user must
-    // re-authenticate. A critical log surfaces this before it happens.
-    match store::save(&t) {
-        Ok(()) => {}
-        Err(e) => {
-            tracing::error!(
-                error = %e,
-                "CRITICAL: failed to persist rotated Jira refresh token — access token \
-                 valid for ~1h but re-authentication required after expiry. Fix \
-                 permissions at ~/.meridian/oauth/ then re-run `meridian oauth-login jira`."
-            );
+    save_rotated(&t).await;
+    Ok(t)
+}
+
+/// How many times [`save_rotated`] tries to write the rotated tokens down.
+const SAVE_ATTEMPTS: usize = 3;
+
+/// Persist the freshly rotated tokens, retrying briefly before giving up.
+///
+/// This is the disk-side twin of the wire-side hazard `flow` guards against, and
+/// it deserves the same seriousness: the refresh token in `t` is now the ONLY one
+/// the provider will accept, and the one on disk is already spent. Failing to
+/// write it costs the user exactly what losing it on the wire costs — a manual
+/// re-authorisation — just an hour later, when the access token expires. So a
+/// single `write` returning an error is not something to shrug at and move on
+/// from, which is what this used to do.
+///
+/// Retrying is worth the two extra attempts because the realistic causes are
+/// often momentary: on Windows the `rename` into place fails with a sharing
+/// violation while an indexer or antivirus has the file open, and a full disk can
+/// free up between attempts. A genuinely unwritable store (bad permissions) fails
+/// all three and we fall through to the same loud error as before.
+///
+/// Deliberately does NOT propagate the failure: the access token in hand is good
+/// for ~1 h, so the caller's Jira request should still succeed. Failing here
+/// would break sync NOW on top of breaking it later.
+async fn save_rotated(t: &OAuthTokens) {
+    let mut backoff = std::time::Duration::from_millis(200);
+    for attempt in 1..=SAVE_ATTEMPTS {
+        match store::save(t) {
+            Ok(()) => return,
+            Err(e) if attempt < SAVE_ATTEMPTS => {
+                tracing::warn!(
+                    attempt,
+                    max = SAVE_ATTEMPTS,
+                    error = %e,
+                    "could not persist the rotated Jira refresh token - retrying"
+                );
+                tokio::time::sleep(backoff).await;
+                backoff *= 3; // 200ms → 600ms
+            }
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    "CRITICAL: failed to persist rotated Jira refresh token after \
+                     retries - the access token is valid for ~1h, but the stored \
+                     refresh token is already spent, so re-authentication will be \
+                     required once it expires. Fix permissions at ~/.meridian/oauth/ \
+                     then reconnect Jira in Settings - Integrations."
+                );
+            }
         }
     }
-    Ok(t)
 }
 
 /// Resolved per-request auth context. OAuth and basic auth differ in BOTH the API

--- a/meridian-oauth/src/jira.rs
+++ b/meridian-oauth/src/jira.rs
@@ -231,6 +231,8 @@ pub async fn login(client_id: &str, client_secret: &str, port: u16) -> Result<St
         scopes: tokens.scope,
         cloud_id,
         site_url: site_url.clone(),
+        // A fresh authorisation supersedes anything that was outstanding.
+        refresh_in_flight_at: 0,
     };
     store::save(&stored).context("persisting Jira OAuth tokens")?;
     Ok(site_url)
@@ -299,11 +301,27 @@ pub async fn ensure_fresh() -> Result<OAuthTokens> {
     }
 
     tracing::debug!("jira OAuth access token expired — refreshing");
-    let resp = flow::refresh(&t.client_id, &spec(), &t.refresh_token)
-        .await
-        .context(
-            "refreshing Jira OAuth token — re-run `meridian oauth-login jira` if this persists",
-        )?;
+    // Record that a grant is about to leave, BEFORE it does. If this process is
+    // killed between here and the response — an app update restarting the
+    // daemon, a laptop suspending — the marker is the only evidence that the
+    // provider may be holding a rotated token we never received, and the only
+    // way a later start knows to repair it while the reuse window is still open.
+    mark_refresh_in_flight(&mut t);
+    let resp = match flow::refresh(&t.client_id, &spec(), &t.refresh_token).await {
+        Ok(resp) => resp,
+        Err(e) => {
+            // Clear the marker for the outcomes that resolve it: a 4xx means the
+            // grant is dead (nothing outstanding to repair) and a connect failure
+            // means it never left. Only an AMBIGUOUS failure leaves it standing —
+            // that is precisely the "may have been spent" state it exists for.
+            if !flow::may_have_spent_the_grant(&e) {
+                clear_refresh_in_flight(&mut t);
+            }
+            return Err(e).context(
+                "refreshing Jira OAuth token — re-run `meridian oauth-login jira` if this persists",
+            );
+        }
+    };
     t.access_token = resp.access_token;
     if !resp.refresh_token.is_empty() {
         t.refresh_token = resp.refresh_token; // Atlassian rotates the refresh token
@@ -312,8 +330,73 @@ pub async fn ensure_fresh() -> Result<OAuthTokens> {
     if !resp.scope.is_empty() {
         t.scopes = resp.scope;
     }
+    t.refresh_in_flight_at = 0; // resolved — saved together with the new tokens
     save_rotated(&t).await;
     Ok(t)
+}
+
+/// Stamp the in-flight marker and flush it to disk before the grant is sent.
+///
+/// Best-effort on purpose: a store we cannot write is already in trouble, but
+/// refusing to refresh because the *marker* would not persist would turn a
+/// diagnostic aid into an outage. Worst case we lose the ability to repair an
+/// interruption, which is exactly where we were before the marker existed.
+fn mark_refresh_in_flight(t: &mut OAuthTokens) {
+    t.refresh_in_flight_at = now_unix();
+    if let Err(e) = store::save(t) {
+        tracing::warn!(error = %e, "could not record the in-flight Jira refresh marker");
+    }
+}
+
+/// Clear the marker for an outcome that resolved it, and flush.
+fn clear_refresh_in_flight(t: &mut OAuthTokens) {
+    t.refresh_in_flight_at = 0;
+    if let Err(e) = store::save(t) {
+        tracing::warn!(error = %e, "could not clear the in-flight Jira refresh marker");
+    }
+}
+
+/// Repair a refresh exchange this machine started and never saw finish.
+///
+/// Call once, early, on process start. The case it exists for is mundane and
+/// was permanent before it: an app update stops the daemon while a refresh POST
+/// is on the wire. The provider completes the exchange, rotates the token, and
+/// answers into a socket belonging to a process that no longer exists. On disk
+/// we are left holding a spent refresh token.
+///
+/// The repair is that the provider forgives this — but only briefly. Inside its
+/// reuse interval, re-presenting the spent token returns the pair whose delivery
+/// we lost, and the user never learns anything happened. The reason this needs
+/// its own entry point rather than falling out of ordinary operation is timing:
+/// the daemon refreshes lazily, when a sync finds its task cache stale, which can
+/// be up to `SYNC_INTERVAL_MINS` away. An update that interrupts a refresh five
+/// minutes after a successful sync would otherwise get its next attempt twenty-
+/// five minutes later — past the window, and by then the grant is gone for good.
+///
+/// Never errors out of the caller's startup: a failure here is reported by the
+/// ordinary sync path moments later, with the ordinary user-facing remedy.
+pub async fn recover_interrupted_refresh() {
+    let Ok(t) = store::load("jira") else {
+        return; // no Jira OAuth on this install
+    };
+    if t.refresh_in_flight_at == 0 {
+        return;
+    }
+    let age_s = now_unix().saturating_sub(t.refresh_in_flight_at);
+    tracing::info!(
+        age_s,
+        "found an unfinished Jira token refresh from a previous run - retrying now while the \
+         provider may still forgive the reuse"
+    );
+    match ensure_fresh().await {
+        Ok(_) => tracing::info!(age_s, "recovered the interrupted Jira token refresh"),
+        Err(e) => tracing::warn!(
+            age_s,
+            error = %e,
+            "could not recover the interrupted Jira token refresh - if the provider had already \
+             rotated the token, reconnecting Jira is the only remedy"
+        ),
+    }
 }
 
 /// How many times [`save_rotated`] tries to write the rotated tokens down.
@@ -428,6 +511,58 @@ impl JiraReqCtx {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The in-flight marker's whole job is to survive a process that dies
+    /// between sending a grant and learning what happened to it, so the test
+    /// that matters is that it round-trips through the file a restarted process
+    /// would read. A default-constructed store (and, by `#[serde(default)]`, a
+    /// file written before the field existed) must read as "nothing
+    /// outstanding" — the correct interpretation, since the alternative would
+    /// have every existing install repair an exchange that never happened.
+    #[test]
+    fn the_in_flight_marker_round_trips_and_defaults_to_absent() {
+        let _env = crate::env_test_guard();
+        let dir =
+            std::env::temp_dir().join(format!("meridian_oauth_marker_{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        std::env::set_var("HOME", &dir);
+
+        let mut t = OAuthTokens {
+            provider: "jira".into(),
+            client_id: "cid".into(),
+            access_token: "at".into(),
+            refresh_token: "rt".into(),
+            expires_at: 0,
+            scopes: String::new(),
+            cloud_id: "c".into(),
+            site_url: "https://acme.atlassian.net".into(),
+            refresh_in_flight_at: 0,
+        };
+        store::save(&t).unwrap();
+        assert_eq!(store::load("jira").unwrap().refresh_in_flight_at, 0);
+
+        // A token file predating the field must load as "nothing outstanding"
+        // rather than failing to parse or inventing an exchange to repair.
+        let path = store::path("jira").unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let mut v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        v.as_object_mut().unwrap().remove("refresh_in_flight_at");
+        std::fs::write(&path, serde_json::to_string(&v).unwrap()).unwrap();
+        assert_eq!(store::load("jira").unwrap().refresh_in_flight_at, 0);
+
+        // And once stamped, it is what a restarted process finds.
+        mark_refresh_in_flight(&mut t);
+        assert_ne!(t.refresh_in_flight_at, 0);
+        assert_eq!(
+            store::load("jira").unwrap().refresh_in_flight_at,
+            t.refresh_in_flight_at,
+            "a process that dies here must leave the marker behind"
+        );
+
+        clear_refresh_in_flight(&mut t);
+        assert_eq!(store::load("jira").unwrap().refresh_in_flight_at, 0);
+        std::fs::remove_dir_all(&dir).ok();
+    }
 
     fn oauth_ctx() -> JiraReqCtx {
         JiraReqCtx::OAuth {

--- a/meridian-oauth/src/jira.rs
+++ b/meridian-oauth/src/jira.rs
@@ -256,16 +256,36 @@ pub async fn ensure_fresh() -> Result<OAuthTokens> {
 
     // Slow path: enter the cross-process critical section. A peer (a second daemon,
     // the tray's in-process refresh) may be rotating the SAME refresh token right
-    // now. Best-effort — if the lock can't be taken we log and proceed rather than
-    // turn the lock itself into a new way for Jira auth to fail.
+    // now.
+    //
+    // Failing to take the lock means we must NOT refresh. This used to log and
+    // proceed anyway, on the reasoning that the lock shouldn't become a new way
+    // for Jira auth to fail — but the two outcomes are not comparable. Skipping a
+    // refresh costs one sync cycle and self-heals on the next tick; refreshing
+    // while a peer holds the lock double-spends the rotating token, and Atlassian
+    // answers a reused refresh token by revoking the whole family — a permanent
+    // disconnection only a manual re-authorisation clears.
     let _flock = match store::lock_provider("jira").await {
-        Ok(g) => Some(g),
+        Ok(g) => g,
         Err(e) => {
+            // The peer we were waiting on may have finished between our last
+            // check and its timeout, so re-read before giving up on the tick.
+            let t = store::load("jira")?;
+            if !t.is_expired(now_unix(), 120) {
+                tracing::debug!(
+                    "jira token refreshed by another process while we waited for the lock"
+                );
+                return Ok(t);
+            }
             tracing::warn!(
                 error = %e,
-                "could not acquire OAuth refresh lock — proceeding without cross-process serialisation"
+                "could not acquire the OAuth refresh lock - skipping this refresh rather than \
+                 double-spending the rotating token; will retry on the next cycle"
             );
-            None
+            return Err(anyhow::Error::new(flow::TokenError::unavailable(format!(
+                "another Meridian process is holding the Jira OAuth refresh lock: {e}"
+            )))
+            .context("refreshing Jira OAuth token"));
         }
     };
 

--- a/meridian-oauth/src/jira.rs
+++ b/meridian-oauth/src/jira.rs
@@ -248,11 +248,26 @@ pub async fn login(client_id: &str, client_secret: &str, port: u16) -> Result<St
 /// adopts the peer's freshly-refreshed token instead of POSTing again with the
 /// now-consumed one (the old single-process-mutex behaviour caused that 401 loop).
 pub async fn ensure_fresh() -> Result<OAuthTokens> {
+    ensure_fresh_within(REFRESH_SKEW_SECS).await
+}
+
+/// The default "how close to expiry counts as expired" margin, used by every
+/// on-demand caller. Small on purpose: an on-demand refresh happens because
+/// something needs a token NOW, so there is nothing to gain by doing it earlier.
+pub const REFRESH_SKEW_SECS: i64 = 120;
+
+/// [`ensure_fresh`] with an explicit expiry margin.
+///
+/// The margin exists so a caller that is not blocked on the token can choose to
+/// rotate it EARLY, at a moment of its choosing, rather than leaving it to
+/// whichever background tick happens to find the token dead. See
+/// [`top_up_while_awake`] for why that moment matters.
+pub async fn ensure_fresh_within(skew_secs: i64) -> Result<OAuthTokens> {
     let _guard = refresh_lock().lock().await; // intra-process serialisation
 
     // Fast path: a still-fresh token needs neither a refresh nor the file lock.
     let t = store::load("jira")?;
-    if !t.is_expired(now_unix(), 120) {
+    if !t.is_expired(now_unix(), skew_secs) {
         return Ok(t);
     }
 
@@ -273,7 +288,7 @@ pub async fn ensure_fresh() -> Result<OAuthTokens> {
             // The peer we were waiting on may have finished between our last
             // check and its timeout, so re-read before giving up on the tick.
             let t = store::load("jira")?;
-            if !t.is_expired(now_unix(), 120) {
+            if !t.is_expired(now_unix(), skew_secs) {
                 tracing::debug!(
                     "jira token refreshed by another process while we waited for the lock"
                 );
@@ -295,7 +310,7 @@ pub async fn ensure_fresh() -> Result<OAuthTokens> {
     // adopt their token instead of refreshing again with the dead one. This
     // double-check is what actually breaks the race.
     let mut t = store::load("jira")?;
-    if !t.is_expired(now_unix(), 120) {
+    if !t.is_expired(now_unix(), skew_secs) {
         tracing::debug!("jira token already refreshed by another process — adopting it");
         return Ok(t);
     }
@@ -353,6 +368,58 @@ fn clear_refresh_in_flight(t: &mut OAuthTokens) {
     t.refresh_in_flight_at = 0;
     if let Err(e) = store::save(t) {
         tracing::warn!(error = %e, "could not clear the in-flight Jira refresh marker");
+    }
+}
+
+/// How much of an access token's life may be left when [`top_up_while_awake`]
+/// rotates it early.
+///
+/// This is a rate/safety trade and the direction is not obvious, so: a shorter
+/// token life means MORE refreshes, and every refresh is another opportunity to
+/// be interrupted mid-exchange. Ten minutes off a one-hour token is about a 20%
+/// increase in rotations, bought in exchange for nearly all of them landing at a
+/// moment we have evidence is safe. Widening it further would buy less and cost
+/// more; the temptation to "refresh more often to be safe" is exactly backwards.
+pub const TOP_UP_SKEW_SECS: i64 = 10 * 60;
+
+/// Rotate the token early, while the caller can vouch that this machine is awake
+/// and staying awake.
+///
+/// The problem this solves is one of TIMING, not of correctness. A refresh is a
+/// non-idempotent exchange with a remote server, and the one thing that makes it
+/// unrecoverable is being interrupted mid-flight for longer than the provider's
+/// reuse window — which in practice means the machine suspending. Left to
+/// itself, the daemon refreshes lazily, whenever a background tick first finds
+/// the token dead. That tick is not uniformly distributed: a laptop's background
+/// work clusters around wake and dark-wake moments, which are precisely the
+/// moments it is about to sleep again. On 2026-08-20 that is exactly what
+/// happened — a poll tick fired, the refresh POST left, and the machine
+/// suspended within the second.
+///
+/// So the caller passes `awake`: its own evidence that a person is at this
+/// machine right now (Meridian has that evidence already — it is a capture
+/// tool). A machine someone is actively using does not suspend mid-request.
+///
+/// Deliberately returns nothing and never propagates an error. This is
+/// opportunistic: if it cannot rotate the token now, the ordinary on-demand path
+/// does it later and reports any real failure with the ordinary remedy. Adding a
+/// second reporting path for the same fault is how a banner ends up flapping.
+pub async fn top_up_while_awake(awake: bool) {
+    if !awake || !store::exists("jira") {
+        return;
+    }
+    // Cheap pre-check before taking any lock: almost every call lands here.
+    match store::load("jira") {
+        Ok(t) if !t.is_expired(now_unix(), TOP_UP_SKEW_SECS) => return,
+        Ok(_) => {}
+        Err(_) => return, // unreadable store — the on-demand path reports it
+    }
+    match ensure_fresh_within(TOP_UP_SKEW_SECS).await {
+        Ok(_) => tracing::debug!("rotated the Jira token early, while the machine is in use"),
+        Err(e) => tracing::debug!(
+            error = %e,
+            "early Jira token top-up did not succeed - leaving it to the on-demand path"
+        ),
     }
 }
 

--- a/meridian-oauth/src/store.rs
+++ b/meridian-oauth/src/store.rs
@@ -33,6 +33,27 @@ pub struct OAuthTokens {
     /// The site base URL (e.g. `https://acme.atlassian.net`) for building browse links.
     #[serde(default)]
     pub site_url: String,
+    /// Unix seconds at which a refresh exchange was STARTED and whose outcome we
+    /// never learned. `0` means no exchange is outstanding.
+    ///
+    /// This is a crash-and-suspend marker, and it exists because the dangerous
+    /// state is invisible without it. A refresh POST that is sent and then never
+    /// answered — the process killed by an app update, the machine suspended
+    /// mid-request — leaves the provider holding a rotated token we did not
+    /// receive and this file holding one that is already spent. Nothing else on
+    /// disk distinguishes that from "we simply haven't refreshed lately".
+    ///
+    /// It matters because the repair has a deadline: inside the provider's reuse
+    /// interval, re-presenting the spent token is forgiven and returns the pair
+    /// we lost, so a process that starts up and acts on this marker IMMEDIATELY
+    /// recovers, where one that waits for its ordinary 30-minute sync cadence
+    /// arrives after the window has shut and the grant is gone for good. See
+    /// `jira::recover_interrupted_refresh`.
+    ///
+    /// `#[serde(default)]` so a token file written before this field existed
+    /// loads as "nothing outstanding", which is the correct reading of it.
+    #[serde(default)]
+    pub refresh_in_flight_at: i64,
 }
 
 impl OAuthTokens {
@@ -301,6 +322,7 @@ mod tests {
             scopes: String::new(),
             cloud_id: String::new(),
             site_url: String::new(),
+            refresh_in_flight_at: 0,
         };
         // 60s before expiry, with a 60s skew → treated as expired.
         assert!(t.is_expired(940, 60));
@@ -322,6 +344,7 @@ mod tests {
             scopes: "read:jira-work offline_access".into(),
             cloud_id: "cloud-1".into(),
             site_url: "https://acme.atlassian.net".into(),
+            refresh_in_flight_at: 0,
         };
         save(&t).unwrap();
         assert!(exists("jira"));

--- a/meridian-oauth/src/store.rs
+++ b/meridian-oauth/src/store.rs
@@ -202,10 +202,10 @@ fn lock_path(provider: &str) -> Result<PathBuf> {
 /// How long [`lock_provider`] waits for a peer to finish before giving up.
 ///
 /// This MUST comfortably exceed the worst case of a full refresh, because that
-/// is what the holder is doing. `flow`'s retry ladder self-limits on the wall
-/// clock at `REUSE_GRACE_BUDGET`, but the attempt permitted at the last instant
-/// before that expires still gets a whole `TOKEN_REQUEST_TIMEOUT` to run — so
-/// the bound is their SUM, not either alone.
+/// is what the holder is doing: every attempt in `flow`'s ladder can run a whole
+/// `TOKEN_REQUEST_TIMEOUT`, and there can be `TOKEN_POST_ATTEMPTS` of them with
+/// backoff in between. (`REUSE_GRACE_BUDGET` also caps the ladder, but on the
+/// wall clock and at a larger figure, so the attempt count is what binds here.)
 ///
 /// A timeout shorter than that turns a slow-but-succeeding peer refresh into a
 /// second process deciding the lock is stuck, and that process must then decline
@@ -374,10 +374,11 @@ mod tests {
     /// so the drift fails the build instead of the field.
     #[test]
     fn lock_wait_outlasts_the_worst_case_refresh() {
-        // The ladder stops issuing retries once the wall clock passes
-        // REUSE_GRACE_BUDGET, but an attempt started a moment before that still
-        // runs its full request timeout — so the holder can be busy for the sum.
-        let worst = crate::flow::REUSE_GRACE_BUDGET + crate::flow::TOKEN_REQUEST_TIMEOUT;
+        // Every attempt may run the full request timeout, plus the 400ms +
+        // 1200ms backoff between them. REUSE_GRACE_BUDGET caps the ladder too,
+        // but on the wall clock and higher, so it is not the binding constraint.
+        let worst = crate::flow::TOKEN_REQUEST_TIMEOUT * crate::flow::TOKEN_POST_ATTEMPTS as u32
+            + std::time::Duration::from_millis(1600);
         assert!(
             LOCK_WAIT > worst,
             "LOCK_WAIT ({LOCK_WAIT:?}) must outlast the worst-case refresh ({worst:?})"

--- a/meridian-oauth/src/store.rs
+++ b/meridian-oauth/src/store.rs
@@ -181,15 +181,19 @@ fn lock_path(provider: &str) -> Result<PathBuf> {
 /// How long [`lock_provider`] waits for a peer to finish before giving up.
 ///
 /// This MUST comfortably exceed the worst case of a full refresh, because that
-/// is what the holder is doing: `flow`'s per-attempt budget is a 10 s connect
-/// cap inside a 30 s request cap, and a retry-safe failure may be attempted
-/// three times with backoff — roughly 32 s worst case. A timeout shorter than
-/// that turns a slow-but-succeeding peer refresh into a second process deciding
-/// the lock is stuck, and the caller must then NOT refresh anyway (see
-/// `jira::ensure_fresh`), so the only thing a short timeout buys is a skipped
-/// sync cycle. It was 10 s while the request cap was 8 s; both moved together
-/// and must keep moving together.
-const LOCK_WAIT: std::time::Duration = std::time::Duration::from_secs(60);
+/// is what the holder is doing. `flow`'s retry ladder self-limits on the wall
+/// clock at `REUSE_GRACE_BUDGET`, but the attempt permitted at the last instant
+/// before that expires still gets a whole `TOKEN_REQUEST_TIMEOUT` to run — so
+/// the bound is their SUM, not either alone.
+///
+/// A timeout shorter than that turns a slow-but-succeeding peer refresh into a
+/// second process deciding the lock is stuck, and that process must then decline
+/// to refresh anyway (see `jira::ensure_fresh`), so a short timeout buys nothing
+/// but a skipped sync cycle. It was 10 s while the request cap was 8 s; these
+/// numbers move together, and `lock_wait_outlasts_the_worst_case_refresh`
+/// recomputes the bound from flow's own constants so they cannot drift apart in
+/// silence.
+const LOCK_WAIT: std::time::Duration = std::time::Duration::from_secs(150);
 
 /// Acquire the exclusive cross-process advisory lock for `provider`'s token store,
 /// blocking (async) until it's free or [`LOCK_WAIT`] elapses.
@@ -347,16 +351,10 @@ mod tests {
     /// so the drift fails the build instead of the field.
     #[test]
     fn lock_wait_outlasts_the_worst_case_refresh() {
-        use std::time::Duration;
-        // A rotating grant only ever retries a CONNECT failure (flow::should_retry),
-        // so its worst case is `TOKEN_POST_ATTEMPTS` connect timeouts plus the
-        // 400ms + 1200ms backoff...
-        let retried_connects = crate::flow::TOKEN_CONNECT_TIMEOUT
-            * crate::flow::TOKEN_POST_ATTEMPTS as u32
-            + Duration::from_millis(1600);
-        // ...or one single attempt that runs the full request budget, whichever
-        // is longer.
-        let worst = retried_connects.max(crate::flow::TOKEN_REQUEST_TIMEOUT);
+        // The ladder stops issuing retries once the wall clock passes
+        // REUSE_GRACE_BUDGET, but an attempt started a moment before that still
+        // runs its full request timeout — so the holder can be busy for the sum.
+        let worst = crate::flow::REUSE_GRACE_BUDGET + crate::flow::TOKEN_REQUEST_TIMEOUT;
         assert!(
             LOCK_WAIT > worst,
             "LOCK_WAIT ({LOCK_WAIT:?}) must outlast the worst-case refresh ({worst:?})"

--- a/meridian-oauth/src/store.rs
+++ b/meridian-oauth/src/store.rs
@@ -178,8 +178,21 @@ fn lock_path(provider: &str) -> Result<PathBuf> {
     Ok(oauth_dir()?.join(format!("{provider}.lock")))
 }
 
+/// How long [`lock_provider`] waits for a peer to finish before giving up.
+///
+/// This MUST comfortably exceed the worst case of a full refresh, because that
+/// is what the holder is doing: `flow`'s per-attempt budget is a 10 s connect
+/// cap inside a 30 s request cap, and a retry-safe failure may be attempted
+/// three times with backoff — roughly 32 s worst case. A timeout shorter than
+/// that turns a slow-but-succeeding peer refresh into a second process deciding
+/// the lock is stuck, and the caller must then NOT refresh anyway (see
+/// `jira::ensure_fresh`), so the only thing a short timeout buys is a skipped
+/// sync cycle. It was 10 s while the request cap was 8 s; both moved together
+/// and must keep moving together.
+const LOCK_WAIT: std::time::Duration = std::time::Duration::from_secs(60);
+
 /// Acquire the exclusive cross-process advisory lock for `provider`'s token store,
-/// blocking (async) until it's free or a 10 s safety timeout elapses.
+/// blocking (async) until it's free or [`LOCK_WAIT`] elapses.
 ///
 /// This serialises the rotating-refresh-token read-modify-write across EVERY
 /// Meridian process — a second daemon, the tray's in-process refresh, the daemon's
@@ -190,11 +203,12 @@ fn lock_path(provider: &str) -> Result<PathBuf> {
 /// AFTER acquiring this, so a process that waited adopts the peer's fresh token
 /// instead of refreshing again with the now-dead one.
 pub async fn lock_provider(provider: &str) -> Result<ProviderLock> {
-    lock_provider_with_timeout(provider, std::time::Duration::from_secs(10)).await
+    lock_provider_with_timeout(provider, LOCK_WAIT).await
 }
 
-/// [`lock_provider`] with an explicit timeout (the public fn fixes it at 10 s;
-/// tests pass a short one to exercise contention without a real wait).
+/// [`lock_provider`] with an explicit timeout (the public fn fixes it at
+/// [`LOCK_WAIT`]; tests pass a short one to exercise contention without a real
+/// wait).
 async fn lock_provider_with_timeout(
     provider: &str,
     timeout: std::time::Duration,
@@ -322,6 +336,31 @@ mod tests {
             assert_eq!(mode & 0o777, 0o600, "token file must be 0600");
         }
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The lock timeout and `flow`'s request budget are one coupled pair, and
+    /// nothing else connects them: raise a timeout in `flow` without raising this
+    /// and a second process starts deciding a slow-but-healthy peer refresh is a
+    /// stuck lock. That does not corrupt anything by itself — `ensure_fresh`
+    /// declines to refresh without the lock — but it silently converts every slow
+    /// refresh into a skipped sync cycle. Recomputed here from the real constants
+    /// so the drift fails the build instead of the field.
+    #[test]
+    fn lock_wait_outlasts_the_worst_case_refresh() {
+        use std::time::Duration;
+        // A rotating grant only ever retries a CONNECT failure (flow::should_retry),
+        // so its worst case is `TOKEN_POST_ATTEMPTS` connect timeouts plus the
+        // 400ms + 1200ms backoff...
+        let retried_connects = crate::flow::TOKEN_CONNECT_TIMEOUT
+            * crate::flow::TOKEN_POST_ATTEMPTS as u32
+            + Duration::from_millis(1600);
+        // ...or one single attempt that runs the full request budget, whichever
+        // is longer.
+        let worst = retried_connects.max(crate::flow::TOKEN_REQUEST_TIMEOUT);
+        assert!(
+            LOCK_WAIT > worst,
+            "LOCK_WAIT ({LOCK_WAIT:?}) must outlast the worst-case refresh ({worst:?})"
+        );
     }
 
     #[test]

--- a/meridian-oauth/src/trello.rs
+++ b/meridian-oauth/src/trello.rs
@@ -81,6 +81,7 @@ pub async fn login(app_key: &str, port: u16) -> Result<()> {
         scopes: "read,write".to_string(),
         cloud_id: String::new(),
         site_url: String::new(),
+        refresh_in_flight_at: 0,
     };
     store::save(&tokens).context("saving Trello token")?;
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -575,6 +575,7 @@ mod tests {
             scopes: String::new(),
             cloud_id: "c".into(),
             site_url: "https://acme.atlassian.net".into(),
+            refresh_in_flight_at: 0,
         })
         .unwrap();
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1181,6 +1181,22 @@ async fn main() -> Result<()> {
         ),
     }
 
+    // 7a-ter. Same shape again, for a Jira token refresh interrupted by whatever
+    //     ended the last run — most often this very restart, since an app update
+    //     stops the daemon whenever it likes. The provider completes an exchange
+    //     it has already received and answers into a socket that no longer has a
+    //     process behind it, leaving a spent refresh token on disk.
+    //
+    //     This has to happen HERE, before the first sync, rather than being left
+    //     to fall out of ordinary operation: the repair only works inside the
+    //     provider's reuse interval, and the ordinary path refreshes lazily when
+    //     a sync finds its task cache stale — up to SYNC_INTERVAL_MINS away, by
+    //     which time the window has shut and the grant is unrecoverable.
+    //
+    //     Cheap when there is nothing to do (one file read) and silent on an
+    //     install with no Jira OAuth at all.
+    meridian::intelligence::oauth::jira::recover_interrupted_refresh().await;
+
     // 7b. Shared handles the poll loop uses to signal ETL ticks to observers.
     let etl_notify: Arc<Notify> = Arc::new(Notify::new());
     let etl_tick_span: Arc<std::sync::Mutex<Option<tracing::Span>>> =

--- a/src/main.rs
+++ b/src/main.rs
@@ -1533,6 +1533,21 @@ async fn main() -> Result<()> {
                 if let Err(e) = run_pm_sync(&meridian, &cfg).await {
                     tracing::warn!(error = %meridian::errors::chain(&e), "pm_tasks refresh failed — using cached tasks");
                 }
+
+                // Rotate the Jira OAuth token EARLY, but only while someone is
+                // demonstrably at this machine. See `top_up_while_awake` for the
+                // reasoning; the short version is that the refresh exchange is
+                // only unrecoverable when it is interrupted by a suspend, and
+                // leaving it to whichever tick first finds the token dead aims it
+                // squarely at wake/dark-wake moments — the ones just before the
+                // machine sleeps again. A machine being typed at does not.
+                //
+                // Ordered after `run_pm_sync` on purpose: if that just refreshed
+                // the token on demand, this finds it fresh and does nothing.
+                meridian::intelligence::oauth::jira::top_up_while_awake(
+                    machine_is_in_use(&meridian).await,
+                )
+                .await;
             }
         }
     }
@@ -1563,6 +1578,35 @@ async fn main() -> Result<()> {
     let _ = shipper_shutdown_tx.send(true);
 
     Ok(())
+}
+
+/// How far back to look for evidence that a person is at this machine.
+///
+/// Capture frames stop when the display sleeps, so a frame in the last few
+/// minutes is a good proxy for "awake and in use" — and, importantly, a poor
+/// match for a dark wake, where background work runs but nothing is captured.
+/// Five minutes is long enough to survive an ordinary pause in capture and short
+/// enough that it cannot be satisfied by a machine that has since gone to sleep.
+const IN_USE_LOOKBACK_MINS: i64 = 5;
+
+/// Whether this machine looks like it is being used right now.
+///
+/// Answers with capture frames, which Meridian is already collecting — no extra
+/// platform APIs, no power-management assertions, no polling of idle timers.
+/// Errs toward `false`: the only caller uses this to decide whether to do
+/// something EARLY that will otherwise happen on demand later, so a false
+/// negative costs nothing and a false positive is the thing worth avoiding.
+async fn machine_is_in_use(pool: &sqlx::SqlitePool) -> bool {
+    let now = chrono::Utc::now();
+    let since = now - chrono::Duration::minutes(IN_USE_LOOKBACK_MINS);
+    let fmt = |t: chrono::DateTime<chrono::Utc>| t.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    match meridian::db::screenpipe::count_frames_in_window(pool, &fmt(since), &fmt(now)).await {
+        Ok((total, _idle)) => total > 0,
+        Err(e) => {
+            tracing::debug!(error = %meridian::errors::chain(&e), "in-use probe failed");
+            false
+        }
+    }
 }
 
 /// Runs one ETL pass and maps the outcome onto the notice bus.

--- a/src/notices.rs
+++ b/src/notices.rs
@@ -107,10 +107,9 @@ pub async fn raise_typed(pool: &SqlitePool, n: Notice<'_>) -> Result<()> {
 
     // Promote the fault to an OS-level toast (the dashboard banner already comes
     // from this table, so the notification is native-only to avoid a double
-    // banner). Deduped on `<event_key>:<id>` → one toast per fault, cleared below
-    // when the fault recovers so a later re-occurrence toasts again. Best-effort:
-    // never let notification delivery break the fault-bus write.
-    let dedup = format!("{}:{}", n.event_key, n.id);
+    // banner). Best-effort: never let notification delivery break the fault-bus
+    // write.
+    let dedup = toast_dedup_key(n.event_key, n.id);
     // Native-only (the dashboard banner already comes from this table).
     // `.interactive()` pairs category + actions from the one source of truth, so
     // the [View] button set can't drift from the other producers.
@@ -123,6 +122,32 @@ pub async fn raise_typed(pool: &SqlitePool, n: Notice<'_>) -> Result<()> {
     note.deep_link = n.deep_link;
     let _ = crate::notifications::enqueue(pool, note).await;
     Ok(())
+}
+
+/// The dedup key for a notice's paired toast.
+///
+/// For most faults this is `<event_key>:<id>` — one toast, ever, until the fault
+/// clears and the row is retracted.
+///
+/// A TRACKER fault (`pm.*`) additionally carries the local date, so it toasts
+/// again once a day for as long as it lasts. That is a deliberate exception, and
+/// it is there because "notify once" quietly failed the case it most needed to
+/// handle. A dead OAuth grant is not a condition that resolves itself: it stays
+/// until the user reconnects, and until they do, every hour of their work goes
+/// unlogged. A single toast on day one is trivially missed — dismissed while
+/// busy, fired during a meeting, delivered to a machine that was locked. One
+/// tester's Jira stayed dead for five days with a banner and a toast both
+/// technically present the whole time.
+///
+/// Daily, not hourly: this is a nag with a real remedy attached, and it has to
+/// stay on the right side of the line between "reminder" and "the thing that
+/// made me turn notifications off".
+fn toast_dedup_key(event_key: &str, id: &str) -> String {
+    if id.starts_with("pm.") {
+        format!("{event_key}:{id}:{}", meridian_core::date::today_string())
+    } else {
+        format!("{event_key}:{id}")
+    }
 }
 
 /// Clear a notice raised via [`raise`] — called when the daemon recovers from
@@ -177,17 +202,34 @@ pub async fn clear_typed_on(
         .await
         .context("clearing system notice")?;
     // Retract the paired toast so a future re-occurrence of this fault notifies
-    // again instead of being deduped away. Best-effort, matching
-    // `notifications::retract` — same statement, same dedup-key shape.
-    if let Err(e) = sqlx::query("DELETE FROM notifications WHERE dedup_key = ?")
-        .bind(format!("{event_key}:{id}"))
-        .execute(&mut *conn)
-        .instrument(tracing::debug_span!("notices.clear.notifications"))
-        .await
+    // again instead of being deduped away. Matches BOTH dedup-key shapes
+    // `toast_dedup_key` can produce: the bare `<event_key>:<id>`, and the
+    // date-suffixed rows a `pm.*` fault accumulates one per day. Missing the
+    // suffixed ones would leave an undelivered toast for today's date sitting in
+    // the outbox after the user has already fixed the fault.
+    //
+    // `\` escapes LIKE's own wildcards so an id containing `_` (which LIKE reads
+    // as "any single character") cannot widen the match to a different notice.
+    if let Err(e) =
+        sqlx::query("DELETE FROM notifications WHERE dedup_key = ? OR dedup_key LIKE ? ESCAPE '\\'")
+            .bind(format!("{event_key}:{id}"))
+            .bind(format!("{}:{}:%", like_escape(event_key), like_escape(id)))
+            .execute(&mut *conn)
+            .instrument(tracing::debug_span!("notices.clear.notifications"))
+            .await
     {
         tracing::warn!(id, event_key, error = %e, "notices: best-effort notification retract failed");
     }
     Ok(result.rows_affected() > 0)
+}
+
+/// Escape SQL `LIKE`'s wildcards (`%`, `_`) and the escape character itself, so
+/// a literal id can be used as a prefix pattern without matching more than it
+/// should. Paired with `ESCAPE '\'` at the call site.
+fn like_escape(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
 }
 
 /// This notice's id — shared with its own `event_key` (see [`raise_typed`]'s doc on that
@@ -245,6 +287,39 @@ pub async fn sync_groq_deprecated_notice(pool: &SqlitePool, active_vendor: Optio
 
 #[cfg(test)]
 mod tests {
+
+    /// A tracker fault must produce a NEW dedup key each local day, so the toast
+    /// fires again for a fault that is still unresolved. Everything else keeps
+    /// the once-only key — a daily nag is right for "reconnect Jira", which no
+    /// amount of waiting fixes, and wrong for faults the daemon may clear on its
+    /// own.
+    #[test]
+    fn only_tracker_faults_get_a_daily_toast_key() {
+        let today = meridian_core::date::today_string();
+        assert_eq!(
+            super::toast_dedup_key("system.fault", "pm.jira"),
+            format!("system.fault:pm.jira:{today}")
+        );
+        assert_eq!(
+            super::toast_dedup_key("system.fault", "db.corrupt"),
+            "system.fault:db.corrupt"
+        );
+        assert_eq!(
+            super::toast_dedup_key("system.fault", "etl.failed"),
+            "system.fault:etl.failed"
+        );
+    }
+
+    /// The clear path deletes by LIKE prefix, so an id carrying a LIKE wildcard
+    /// must not widen the match onto a neighbouring notice. `_` is the dangerous
+    /// one: unescaped, a `pm_x` id would also match `pm.x`.
+    #[test]
+    fn like_escape_neutralises_wildcards() {
+        assert_eq!(super::like_escape("pm.jira"), "pm.jira");
+        assert_eq!(super::like_escape("pm_jira"), r"pm\_jira");
+        assert_eq!(super::like_escape("a%b"), r"a\%b");
+        assert_eq!(super::like_escape(r"a\b"), r"a\\b");
+    }
     use super::*;
     use sqlx::sqlite::SqliteConnectOptions;
     use std::str::FromStr;
@@ -394,6 +469,90 @@ mod tests {
         sync_groq_deprecated_notice(&pool, None).await;
         let notices = meridian_core::notices::read_notices(&pool).await;
         assert!(!notices.iter().any(|n| n.notice_id == GROQ_DEPRECATED));
+    }
+
+    /// A tracker fault toasts once per day, so by the time the user fixes it
+    /// there may be several days' rows in the outbox — including one for today
+    /// that has not been delivered yet. Clearing must take all of them: leaving
+    /// today's behind means the user reconnects Jira and is then told, minutes
+    /// later, that Jira sync is failing.
+    #[tokio::test]
+    async fn clearing_a_tracker_fault_retracts_every_day_it_toasted() {
+        let pool = fresh_db().await;
+
+        // Today's row, via the real producer.
+        raise_typed(
+            &pool,
+            Notice {
+                id: "pm.jira",
+                severity: "error",
+                title: "Jira sync failing",
+                detail: "auth failed",
+                remedy: Some("Reconnect Jira in Settings - Integrations"),
+                event_key: "system.fault",
+                deep_link: Some(meridian_core::notifications::deep_links::INTEGRATIONS),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Two earlier days, as the outbox would already hold them.
+        for day in ["2026-08-20", "2026-08-21"] {
+            crate::notifications::enqueue(
+                &pool,
+                crate::notifications::NewNotification::event(
+                    &format!("system.fault:pm.jira:{day}"),
+                    "system.fault",
+                    "Jira sync failing",
+                    "auth failed",
+                ),
+            )
+            .await
+            .unwrap();
+        }
+
+        // A different tracker must not be swept up by the prefix match.
+        crate::notifications::enqueue(
+            &pool,
+            crate::notifications::NewNotification::event(
+                "system.fault:pm.linear:2026-08-21",
+                "system.fault",
+                "Linear sync failing",
+                "unrelated",
+            ),
+        )
+        .await
+        .unwrap();
+
+        let jira_before: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM notifications WHERE dedup_key LIKE 'system.fault:pm.jira%'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(jira_before, 3, "today plus the two backdated rows");
+
+        let mut conn = pool.acquire().await.unwrap();
+        clear_typed_on(&mut conn, "pm.jira", "system.fault")
+            .await
+            .unwrap();
+        drop(conn);
+
+        let jira_after: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM notifications WHERE dedup_key LIKE 'system.fault:pm.jira%'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(jira_after, 0, "every day's toast must be retracted");
+
+        let linear_after: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM notifications WHERE dedup_key = 'system.fault:pm.linear:2026-08-21'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(linear_after, 1, "another tracker's toast must survive");
     }
 
     /// The test above only checks `system_notices` — it would pass even if


### PR DESCRIPTION
## The bug

A Jira connection dies **permanently** - no user action, no way back except a manual re-authorisation:

> Jira sync failing - `403 Forbidden: {"error":"unauthorized_client","error_description":"refresh_token is invalid"}`

## Root cause

The daemon's own trace, from an affected install:

```
18:26:55.197  SPAN  post_token_retrying         <- the refresh POST leaves
18:55:29.574  WARN  ...error sending request    <- 28m34s later
18:55:31.675  WARN  403 unauthorized_client: refresh_token is invalid
```

The first attempt didn't fail fast. It hung for **28 and a half minutes**, because the laptop suspended mid-request. The 8 s timeout never fired: tokio's timers are monotonic, and a monotonic clock doesn't advance while the machine is asleep. So the retry 400 ms after the wake re-presented a refresh token Atlassian had rotated 29 minutes earlier.

That distance is the whole bug. [Atlassian documents a **reuse interval**](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/) (10 min by default) in which exchanging the same rotating refresh token again is explicitly forgiven - *"this interval helps avoid network concurrency issues"* - and returns a fresh, valid pair. **Inside** it, that retry would have recovered the lost response and nobody would have noticed. **Outside** it, the identical request is breach detection's textbook signal.

A laptop suspending, or an app update restarting the daemon, while a background refresh is in flight is ordinary - which is why this is hitting many installs rather than a few.

## The fix

Retrying **is** the recovery mechanism, so switching it off would have left this user just as disconnected - the token was already spent and the ladder that could have retrieved its replacement would be gone. The rule is the window, not the failure class: **retry promptly, never late.**

- **`REUSE_GRACE_BUDGET` (5 min)** bounds how long after the first send a retry may still re-present the grant - half of Atlassian's documented interval. Deliberately not lower: the 1-5 minute band is where the ordinary interruptions land (a short lid-close, a slow restart), all of them forgiven, and declining those abandons grants one request would have restored. The clocks err safely - we count from *send*, the provider from *process*, so our elapsed is never the smaller.
- **`should_retry(kind, failure, wall_elapsed)`** - open window: retry (recovery). Closed: never (protection). Terminal never retries; interactive code exchanges are unaffected.
- **`wall_elapsed_since` uses `SystemTime`, not `Instant`.** An `Instant` would report that 28-minute request as milliseconds and wave the stale retry straight through - the same blindness that stopped the timeout firing. The clock we need is the one the provider is using.
- **The ladder re-checks the window after its backoff sleep**, since `tokio::time::sleep` is monotonic too.
- **Timeouts split:** one 8 s per-request cap becomes a 10 s connect cap inside a 30 s request cap. The old cap was its own way to lose a rotated token, and splitting connect out is what makes "never delivered" classifiable at all.
- **`ensure_fresh` no longer refreshes without the cross-process lock** - proceeding anyway double-spends the token. `LOCK_WAIT` 10 s -> 150 s, bounded by the ladder's own worst case and pinned by a test that recomputes it from flow's constants.
- **A failed `store::save` is no longer shrugged at.** The token in hand is the only one the provider accepts and the one on disk is already spent, so losing it costs the same reconnect an hour later. `save_rotated` retries first.

### Recovering an interrupted exchange (`refresh_in_flight_at`)

The above fixes the case where our process is alive to retry. It isn't always - an app update stops the daemon whenever it likes, and the provider then completes an exchange and answers into a socket with no process behind it.

That is repairable inside the reuse window, but nothing was reaching for it in time: the daemon refreshes **lazily**, when a sync finds its task cache stale, up to `SYNC_INTERVAL_MINS` away. An update interrupting a refresh five minutes after a successful sync got its next attempt twenty-five minutes later - past the window, grant gone.

- `OAuthTokens::refresh_in_flight_at` is stamped and flushed **before** the grant leaves, so a process that dies mid-exchange leaves evidence. Cleared on any outcome that resolves it (a 4xx: dead, nothing to repair; a connect failure: it never left). Only an *ambiguous* failure leaves it standing. `#[serde(default)]`, so every existing token file reads as "nothing outstanding".
- `flow::may_have_spent_the_grant` is the bookkeeping question, separate from `is_transient`'s user-facing one.
- `jira::recover_interrupted_refresh()` runs once at daemon startup, before the first sync, beside the two crash-recovery steps it's a sibling of. One file read when there's nothing to do.

## Tests

36 in `meridian-oauth`, all hermetic. The wire ones drive a scripted loopback token endpoint that counts requests it fully read, because the property that matters is how many times the grant reaches the provider.

- `a_lost_response_is_recovered_by_a_prompt_retry` - stub reads the grant then hangs up; the retry returns the pair whose first delivery was lost. **This is the case the incident should have been.**
- `a_rotating_grant_is_never_retried_once_the_reuse_window_has_passed` - the incident as it happened
- `a_short_interruption_is_still_inside_the_window` - the recoveries the budget must not decline
- `a_5xx_is_retried_inside_the_window_and_recovers`, `a_rotating_grant_still_retries_a_429_and_succeeds`
- `a_403_is_one_request_and_a_dead_grant` - the literal response, and the one case that *does* surface the reconnect remedy
- `a_lost_response_that_stays_lost_is_not_reported_as_a_dead_grant` - no false "Reconnect Jira" for a passing network fault
- `a_refused_connection_is_retry_safe` - a real `reqwest` connect error against a closed port, pinning the shipped version's `is_connect()` rather than our belief about it
- `the_in_flight_marker_round_trips_and_defaults_to_absent` - including a token file predating the field
- `lock_wait_outlasts_the_worst_case_refresh`

`cargo test -p meridian -p meridian-core -p meridian-oauth`: 1079 + all suites green. `cargo clippy` on the three, `-D warnings`, clean.

`cargo clippy --workspace` / `cargo test --workspace` can't run on this machine - `cidre`'s build script needs full Xcode, not Command Line Tools. Verified pre-existing: identical failure on a stashed tree.

## What this does and doesn't cover

Covered, silently, with no user involvement: a lost response with the process alive; an exchange interrupted by an app update, restart or crash; a double-spend between daemon and tray; a failed token write.

**Not covered: grants already revoked.** Those installs need one Reconnect in Settings - Integrations, and nothing shipped in an update can change that - OAuth requires the user's browser session to mint a new grant. (`prompt=none` was probed against `auth.atlassian.com`: with no live session it 302s to `id.atlassian.com/login` rather than returning `error=login_required` to the callback, so a "silent" re-auth attempt can strand a user on a login page we can't close. Worse than the banner.)

**Also not covered: a suspend that outlasts the reuse window** while a refresh is in flight - no code of ours runs while the machine is asleep. Eliminating that class entirely means refreshing server-side, which is a product decision, not a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pw24sztR6WcCF1JEedMjzt