### PR TITLE
fix(tray): repaint the offline banner as soon as the daemon+DB are ready

### DIFF
--- a/tray/src-tauri/src/commands/health.rs
+++ b/tray/src-tauri/src/commands/health.rs
@@ -50,6 +50,22 @@ pub struct HealthResponse {
     pub llm_provider_detail: Option<String>,
 }
 
+/// Whether a [`HealthResponse`] counts as a healthy tray: the DB is open and
+/// the daemon process is running (the two signals the popover's
+/// online/offline banner is actually gated on — LLM-provider availability is
+/// a separate, softer banner and does not factor in here).
+///
+/// Shared between the poll loop's notice-owning
+/// [`crate::poll::refresh_health`] and the startup fast-poll
+/// ([`crate::poll::startup_health`]) so the two can never disagree about what
+/// "healthy" means — this is the one place that decides it.
+///
+/// `database_ready` defaults to unhealthy when unknown; `daemon_running`
+/// defaults to healthy (older schema compat).
+pub fn is_healthy(hr: &HealthResponse) -> bool {
+    hr.database_ready.unwrap_or(false) && hr.daemon_running.unwrap_or(true)
+}
+
 /// Run all three health checks in parallel and return the combined result.
 /// Called by both `get_health` (Tauri command) and `poll::refresh_health` (internal).
 pub async fn check_health() -> HealthResponse {
@@ -247,4 +263,53 @@ pub async fn get_health() -> Result<HealthResponse, String> {
         "health checked"
     );
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hr(database_ready: Option<bool>, daemon_running: Option<bool>) -> HealthResponse {
+        HealthResponse {
+            database_ready,
+            daemon_running,
+            a11y_helper_trusted: None,
+            error: None,
+            llm_provider_ok: None,
+            llm_provider_rate_limited: None,
+            llm_provider_name: None,
+            llm_provider_detail: None,
+        }
+    }
+
+    #[test]
+    fn healthy_when_both_signals_are_true() {
+        assert!(is_healthy(&hr(Some(true), Some(true))));
+    }
+
+    #[test]
+    fn unhealthy_when_the_db_is_not_ready() {
+        assert!(!is_healthy(&hr(Some(false), Some(true))));
+    }
+
+    #[test]
+    fn unhealthy_when_the_daemon_is_not_running() {
+        assert!(!is_healthy(&hr(Some(true), Some(false))));
+    }
+
+    /// `database_ready: None` must read as unhealthy - an unknown DB state is
+    /// never treated as "fine". Older-schema compat only applies to
+    /// `daemon_running` (below), not this field.
+    #[test]
+    fn an_unknown_db_state_is_treated_as_unhealthy() {
+        assert!(!is_healthy(&hr(None, Some(true))));
+    }
+
+    /// `daemon_running: None` defaults to healthy (older schema compat) - the
+    /// mirror image of the DB default, and the one place the two signals
+    /// disagree on how to treat "unknown".
+    #[test]
+    fn an_unknown_daemon_state_defaults_to_healthy() {
+        assert!(is_healthy(&hr(Some(true), None)));
+    }
 }

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -1188,6 +1188,20 @@ pub fn run() {
                 poll::run_daemon_watchdog().await;
             });
 
+            // One-shot: repaint the popover's online/offline banner the moment
+            // the daemon+DB are actually ready, instead of leaving it stuck on
+            // "Meridian is offline" until the poll loop's own next 30/60 s
+            // health tick. Separate from both loops above on purpose — see
+            // `poll::startup_health` for why it must not touch either one's
+            // state.
+            {
+                let app_handle = app.handle().clone();
+                let state_clone = app_state.clone();
+                tauri::async_runtime::spawn(async move {
+                    poll::fast_poll_until_healthy(app_handle, state_clone).await;
+                });
+            }
+
             // Launch-at-login AND morning relaunch: VERIFY-AND-REPAIR on every
             // launch (see autostart.rs), so the tray comes back after a reboot
             // and again the next morning if it was quit. Deliberately not

--- a/tray/src-tauri/src/poll/mod.rs
+++ b/tray/src-tauri/src/poll/mod.rs
@@ -12,6 +12,10 @@
 //!   server-side per row).
 //! - [`live`] — the live data → Tauri events that replace the dashboard's SSE
 //!   streams: `notices-update`, `notifications-update`.
+//! - [`startup_health`] — a separate, faster one-shot loop (spawned
+//!   alongside this one, not called from inside it) that repaints the
+//!   displayed health status the moment the daemon+DB are ready, instead of
+//!   waiting for this loop's next 30/60 s-cadenced health tick.
 //!
 //! The tray-sync helpers (emit / tooltip / menu) stay here, coupled to the loop.
 
@@ -20,6 +24,7 @@ mod notifications;
 mod permissions;
 mod plan_auto_open;
 mod refresh;
+mod startup_health;
 mod watchdog;
 mod whats_new_auto_open;
 
@@ -29,6 +34,7 @@ use notifications::drain_notifications;
 use refresh::{
     refresh_active, refresh_current_task, refresh_health, refresh_today, refresh_worklogs,
 };
+pub use startup_health::fast_poll_until_healthy;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};

--- a/tray/src-tauri/src/poll/refresh.rs
+++ b/tray/src-tauri/src/poll/refresh.rs
@@ -52,11 +52,13 @@ pub(super) async fn refresh_health(
     // (it also carries `daemon_running`, which the banner ignores).
     let _ = app.emit("health-update", &hr);
 
-    // db_ready and daemon_running both default true when absent (older schema compat).
+    // db_ready defaults unhealthy when unknown; daemon_running defaults healthy
+    // (older schema compat) — kept as locals for the log fields below, but the
+    // classification itself goes through `is_healthy` (see there for why).
     let db_ready = hr.database_ready.unwrap_or(false);
     let daemon_running = hr.daemon_running.unwrap_or(true);
 
-    let new_health = if db_ready && daemon_running {
+    let new_health = if crate::commands::health::is_healthy(&hr) {
         HealthStatus::Healthy
     } else {
         HealthStatus::Unhealthy

--- a/tray/src-tauri/src/poll/startup_health.rs
+++ b/tray/src-tauri/src/poll/startup_health.rs
@@ -1,0 +1,82 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! A one-shot fast health repaint for the first seconds after tray launch.
+//!
+//! # The problem this closes
+//! The poll loop's [`super::refresh::refresh_health`] only runs on ticks
+//! 0, 2, 4, … — every 60 s — because that cadence also drives the went-quiet
+//! / back-online *notice* and the auto-restart decision
+//! (`decide_health_notice`), both deliberately debounced so a genuine outage
+//! doesn't flap. Tick 0 fires within moments of launch, before the daemon has
+//! necessarily finished starting or the DB pool has opened, so a cold start
+//! correctly reports Unhealthy at that instant — and then the popover's
+//! "Meridian is offline" banner just sits there, stale, for up to 60 s even
+//! once the daemon and DB are both actually ready, because nothing repaints
+//! the DISPLAYED status in between. Observed live: the health panel's
+//! on-demand rows ("Daemon: Running", "Database: Ready") already show the
+//! true state the moment it opens, while the banner above it still says
+//! offline — two reads of the same underlying signal, one fresh, one stale.
+//!
+//! # What this does and does not touch
+//! This loop only repaints [`AppState::health`] / `ui_reachable` and re-emits
+//! `status-update` — it never touches `consecutive_health_failures`,
+//! `daemon_was_healthy` or `startup_health_reconciled`, so it cannot affect
+//! the went-quiet notice or trigger an auto-restart; those stay solely owned
+//! by `refresh_health`. It runs at most once per process, stops the instant
+//! it observes a healthy check, and gives up silently after [`CEILING`],
+//! letting the normal cadence take over — it must never spin forever on a
+//! machine that is genuinely down.
+//!
+//! It also does not change what "healthy" MEANS — it shares
+//! [`crate::commands::health::is_healthy`] with `refresh_health`, so the two
+//! can never disagree, and this fix is scoped to the display lag only, not a
+//! new readiness signal.
+//!
+//! # Related
+//! - [`super::refresh::refresh_health`] — the slower, notice-owning check
+//!   this repaints ahead of.
+//! - [`super::watchdog`] — the same "separate fast loop, narrow job" shape,
+//!   for starting a stopped daemon rather than painting the UI.
+
+use crate::commands::health::{check_health, is_healthy};
+use crate::state::{AppState, HealthStatus};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tauri::Emitter;
+
+/// How often to recheck while not yet healthy.
+const TICK: Duration = Duration::from_secs(3);
+
+/// Give up after this long. Matches the worst-case wait this loop replaces
+/// (the normal cadence's 60 s), so a genuinely broken install is never worse
+/// off than before this loop existed — just never better, past this point.
+const CEILING: Duration = Duration::from_secs(60);
+
+/// Poll [`check_health`] every [`TICK`] until the tray is healthy (or
+/// [`CEILING`] elapses), repainting the displayed status the moment it is.
+/// Intended to be spawned once, at tray startup, alongside the main poll
+/// loop — see `lib.rs`.
+pub async fn fast_poll_until_healthy(app: tauri::AppHandle, state: Arc<Mutex<AppState>>) {
+    let deadline = tokio::time::Instant::now() + CEILING;
+    loop {
+        let hr = check_health().await;
+        if is_healthy(&hr) {
+            let payload = {
+                let Ok(mut s) = state.lock() else {
+                    return;
+                };
+                // A concurrent `refresh_health` tick may already have painted
+                // this by the time we get here — overwriting it with the same
+                // (now also fresh) verdict is harmless.
+                s.health = HealthStatus::Healthy;
+                s.ui_reachable = true;
+                s.to_payload()
+            };
+            let _ = app.emit("status-update", payload);
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return;
+        }
+        tokio::time::sleep(TICK).await;
+    }
+}


### PR DESCRIPTION
## Summary

Reported: the popover shows "Meridian is offline / Not recording - restart the daemon" for a while after starting, even though expanding the health panel shows Daemon: Running and Database: Ready at the same moment - i.e. the banner is stale, not actually reflecting an unready system.

## Root cause

The poll loop's health tick (`refresh_health`) only runs every 60s (ticks 0, 2, 4, ...) - deliberately, because that same cadence drives the went-quiet/back-online *notice* and the auto-restart decision, both debounced on purpose so a genuine outage doesn't flap.

Tick 0 fires within moments of tray launch - before the daemon has necessarily finished starting or the DB pool has opened - so a cold start correctly reports Unhealthy at that instant. But nothing repaints the DISPLAYED status again until tick 2, a full 60s later. If the daemon+DB become ready at, say, t=5s (typical), the banner still says "offline" until t=60s even though everything is actually fine - which is exactly what the screenshots show: the on-demand health-panel rows (fetched fresh when the panel opens) show the true state while the banner above them, driven by the last periodic tick, is stale.

## Fix

- Factored the `db_ready && daemon_running` classification out of `refresh_health` into a shared `commands::health::is_healthy()` predicate (tested).
- Added a separate one-shot fast-poll (`poll::startup_health`, 3s interval, 60s ceiling) that repaints `AppState::health`/`ui_reachable` and re-emits `status-update` the instant the daemon+DB are ready, then stops permanently for the process's lifetime.
- It shares `is_healthy()` with `refresh_health` so the two can never disagree about what "healthy" means - this doesn't change the readiness bar, it just stops the DISPLAY from lagging behind it.
- Deliberately does **not** touch `consecutive_health_failures` / `daemon_was_healthy` / `startup_health_reconciled` - the went-quiet notice and auto-restart decision stay solely owned by the slower, debounced `refresh_health` tick. Same "separate fast loop, narrow job" shape as the existing `poll::watchdog` (see its module docs).

## Test plan
- [x] New unit tests for `is_healthy()` (both-healthy, DB-not-ready, daemon-not-running, unknown-DB-defaults-unhealthy, unknown-daemon-defaults-healthy)
- [x] Existing `poll::refresh` tests still pass unchanged (confirms the refactor is behavior-preserving)
- [x] `cargo test --workspace` - all suites green, 1079+ passed, 0 failed
- [x] full pre-push gate (fmt, clippy --workspace, ui build, ui tests, security audit, cargo test --workspace) - all green