### PR TITLE
fix(llm): summariser argv/spawn fixes for Codex/Claude on Windows, and Codex crash messaging

### DIFF
--- a/src/coding_agent_session_ingest/summariser/claude.rs
+++ b/src/coding_agent_session_ingest/summariser/claude.rs
@@ -14,12 +14,53 @@
 // spawns. `--no-session-persistence` means no JSONL is written for it either.
 // NOTE: the inherited env must carry HOME/PATH/USER/LOGNAME for the login
 // keychain to unlock (see the auth spike) — the daemon's launchd plist owns that.
+//
+// # The whole prompt goes over stdin, not argv (Windows)
+//
+// `claude` resolves to `claude.cmd` on Windows for an npm install (`npm i -g
+// @anthropic-ai/claude-code`, the exact command `install_command()` runs for this
+// provider) - an npm-generated batch file, not a native exe - and Rust's std library
+// refuses to spawn a `.bat`/`.cmd` target when an argument contains characters it
+// cannot safely escape (the CVE-2024-24576 "BatBadBut" fix), notably embedded
+// newlines. SUMMARY_RULES is sourced from a Markdown rules file, so it is always
+// multi-line - meaning every real call through this function failed to even spawn
+// on Windows with `io::Error { InvalidInput, "batch file arguments are invalid" }`.
+// `crate::llm::claude::ClaudeBackend` (the hourly worklog pipeline / connectivity
+// test) already moved off argv for exactly this reason - this applies the same fix
+// here, which had the identical bug all along. `-p` as a bare flag (no positional
+// value) reads the whole prompt from stdin instead.
 
 use serde_json::Value;
 
 use super::config::SummariserConfig;
 use super::prompts;
 use super::{run_capture, EngineOutput, SummariserError};
+
+/// The instructions + the session transcript, combined into the one blob `claude -p`
+/// reads from stdin now that no positional prompt is passed - see the module doc.
+fn claude_stdin_payload(stdin_text: &str) -> String {
+    let instructions = format!(
+        "{} Summarise the coding-session transcript provided on stdin.",
+        prompts::SUMMARY_RULES
+    );
+    format!("{instructions}\n\n{stdin_text}")
+}
+
+/// The `claude -p` argv - no prompt in here, see the module doc. Split out so the
+/// no-newline invariant this function exists to guarantee is directly testable.
+fn claude_args(model: &str) -> Vec<String> {
+    vec![
+        "-p".into(),
+        "--output-format".into(),
+        "json".into(),
+        "--json-schema".into(),
+        prompts::summary_schema_json(),
+        "--model".into(),
+        model.to_string(),
+        "--no-session-persistence".into(),
+        "--strict-mcp-config".into(), // drop MCP overhead; keeps skills working
+    ]
+}
 
 pub async fn run_claude(
     stdin_text: &str,
@@ -35,27 +76,12 @@ pub async fn run_claude(
              the env var has no effect and can be removed"
         );
     }
-    let prompt = format!(
-        "{} Summarise the coding-session transcript provided on stdin.",
-        prompts::SUMMARY_RULES
-    );
-    let args: Vec<String> = vec![
-        "-p".into(),
-        prompt,
-        "--output-format".into(),
-        "json".into(),
-        "--json-schema".into(),
-        prompts::summary_schema_json(),
-        "--model".into(),
-        cfg.claude_model.clone(),
-        "--no-session-persistence".into(),
-        "--strict-mcp-config".into(), // drop MCP overhead; keeps skills working
-    ];
+    let args = claude_args(&cfg.claude_model);
 
     let cap = run_capture(
         "claude",
         &args,
-        stdin_text,
+        &claude_stdin_payload(stdin_text),
         &cfg.meridian_home,
         cfg.claude_timeout_s,
         &[("MERIDIAN_SUMMARISER", "1")],
@@ -129,4 +155,58 @@ pub async fn run_claude(
         ));
     }
     Ok(EngineOutput { summary })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The premise the whole fix rests on: SUMMARY_RULES is sourced from a Markdown
+    /// rules file and is always multi-line. If `SKILL.md` ever became single-line, this
+    /// fix would no longer be guarding against anything real - this pins that it still is.
+    #[test]
+    fn summary_rules_is_multi_line() {
+        assert!(prompts::SUMMARY_RULES.contains('\n'));
+    }
+
+    /// The regression this fix exists to close: `claude -p` argv must never carry the
+    /// instructions prompt (or anything else newline-bearing) - that is exactly what
+    /// makes Rust's std refuse to spawn `claude.cmd` on Windows. A future edit that
+    /// reintroduces the prompt into `args` fails this test.
+    #[test]
+    fn claude_args_never_contains_a_newline() {
+        let args = claude_args("claude-opus-5");
+        for arg in &args {
+            assert!(!arg.contains('\n'), "argv entry carries a newline: {arg:?}");
+        }
+    }
+
+    /// `claude -p` must be a bare flag - a positional value right after it would force
+    /// the prompt back through argv.
+    #[test]
+    fn claude_args_has_no_positional_prompt() {
+        let args = claude_args("claude-opus-5");
+        assert_eq!(args[0], "-p");
+        assert_eq!(
+            args[1], "--output-format",
+            "the second argv entry must be a flag, not a prompt"
+        );
+    }
+
+    #[test]
+    fn claude_args_carries_the_model() {
+        let args = claude_args("claude-opus-5");
+        let i = args
+            .iter()
+            .position(|a| a == "--model")
+            .expect("--model flag present");
+        assert_eq!(args[i + 1], "claude-opus-5");
+    }
+
+    #[test]
+    fn claude_stdin_payload_carries_both_the_instructions_and_the_transcript() {
+        let payload = claude_stdin_payload("the transcript");
+        assert!(payload.contains("the transcript"));
+        assert!(payload.starts_with(&prompts::SUMMARY_RULES[..40]));
+    }
 }

--- a/src/coding_agent_session_ingest/summariser/codex.rs
+++ b/src/coding_agent_session_ingest/summariser/codex.rs
@@ -5,6 +5,20 @@
 // `--ephemeral` (no session file → indexer won't re-pick it), `--output-schema`
 // + `-o FILE` to capture the structured final message. Port of
 // the former Python summariser/codex_runner.py.
+//
+// # The whole prompt goes over stdin, not argv (Windows)
+//
+// `codex` resolves to `codex.cmd` on Windows - an npm-generated batch file, not a
+// native exe - and Rust's std library refuses to spawn a `.bat`/`.cmd` target when an
+// argument contains characters it cannot safely escape (the CVE-2024-24576 "BatBadBut"
+// fix), notably embedded newlines. The instructions prompt is sourced from a Markdown
+// rules file (`SUMMARY_RULES`), so it is always multi-line - meaning every real call
+// through this function failed to even spawn on Windows with `io::Error { InvalidInput,
+// "batch file arguments are invalid" }` (confirmed live:
+// github.com/Meridiona/meridian/issues/805). `crate::llm::codex::CodexBackend` (the
+// hourly worklog pipeline / connectivity test) already moved off argv for exactly this
+// reason - this applies the same fix here, which had the identical bug all along.
+// `codex exec` with no positional prompt reads the whole prompt from stdin instead.
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -13,15 +27,48 @@ use super::config::SummariserConfig;
 use super::prompts;
 use super::{run_capture, EngineOutput, SummariserError};
 
+/// The instructions + the session transcript, combined into the one blob `codex exec`
+/// reads from stdin now that no positional prompt is passed - see the module doc.
+fn codex_stdin_payload(stdin_text: &str) -> String {
+    let instructions = format!(
+        "{} Summarise the coding-session transcript provided on stdin.",
+        prompts::summary_instruction()
+    );
+    format!("{instructions}\n\n<stdin>\n{stdin_text}\n</stdin>\n")
+}
+
+/// The `codex exec` argv - no prompt in here, see the module doc. Split out so the
+/// no-newline invariant this function exists to guarantee is directly testable.
+fn codex_args(
+    schema_path: &std::path::Path,
+    out_path: &std::path::Path,
+    home: String,
+    model: &str,
+) -> Vec<String> {
+    let mut args: Vec<String> = vec![
+        "exec".into(),
+        "-s".into(),
+        "read-only".into(),
+        "--skip-git-repo-check".into(),
+        "--ephemeral".into(),
+        "--output-schema".into(),
+        schema_path.display().to_string(),
+        "-o".into(),
+        out_path.display().to_string(),
+        "-C".into(),
+        home,
+    ];
+    if !model.is_empty() {
+        args.push("-m".into());
+        args.push(model.to_string());
+    }
+    args
+}
+
 pub async fn run_codex(
     stdin_text: &str,
     cfg: &SummariserConfig,
 ) -> Result<EngineOutput, SummariserError> {
-    let prompt = format!(
-        "{} Summarise the coding-session transcript provided on stdin.",
-        prompts::summary_instruction()
-    );
-
     // Unique scratch dir for the schema + captured final message. Avoids the
     // time/random APIs (banned in some contexts) via pid + a static counter.
     static SEQ: AtomicU64 = AtomicU64::new(0);
@@ -36,34 +83,22 @@ pub async fn run_codex(
     let _guard = TempDirGuard(td.clone());
     let schema_path = td.join("schema.json");
     let out_path = td.join("last_message.txt");
-    if let Err(e) = std::fs::write(&schema_path, prompts::summary_schema_json()) {
+    // `strictify`: matches `crate::llm::codex::CodexBackend`, which applies the same
+    // transform before handing a schema to codex - without it, codex's own strict
+    // dialect check can reject the schema with `invalid_json_schema` (see that
+    // module's test fixture, a live 400 from exactly this).
+    let schema = crate::llm::schema::strictify(&prompts::summary_schema_value());
+    if let Err(e) = std::fs::write(&schema_path, schema.to_string()) {
         return Err(SummariserError::Failed(format!("codex: write schema: {e}")));
     }
 
     let home = cfg.meridian_home.display().to_string();
-    let mut args: Vec<String> = vec![
-        "exec".into(),
-        prompt,
-        "-s".into(),
-        "read-only".into(),
-        "--skip-git-repo-check".into(),
-        "--ephemeral".into(),
-        "--output-schema".into(),
-        schema_path.display().to_string(),
-        "-o".into(),
-        out_path.display().to_string(),
-        "-C".into(),
-        home,
-    ];
-    if !cfg.codex_model.is_empty() {
-        args.push("-m".into());
-        args.push(cfg.codex_model.clone());
-    }
+    let args = codex_args(&schema_path, &out_path, home, &cfg.codex_model);
 
     let cap = run_capture(
         "codex",
         &args,
-        stdin_text,
+        &codex_stdin_payload(stdin_text),
         &cfg.meridian_home,
         cfg.codex_timeout_s,
         &[("MERIDIAN_SUMMARISER", "1")],
@@ -109,5 +144,86 @@ struct TempDirGuard(PathBuf);
 impl Drop for TempDirGuard {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    /// The premise the whole fix rests on: the instructions are sourced from a Markdown
+    /// rules file and are always multi-line. If `SKILL.md` ever became single-line, this
+    /// fix would no longer be guarding against anything real - this pins that it still is.
+    #[test]
+    fn the_instructions_prompt_is_multi_line() {
+        assert!(prompts::summary_instruction().contains('\n'));
+    }
+
+    /// The regression this fix exists to close: `codex exec` argv must never carry the
+    /// instructions prompt (or anything else newline-bearing) - that is exactly what makes
+    /// Rust's std refuse to spawn `codex.cmd` on Windows. A future edit that reintroduces
+    /// the prompt into `args` fails this test.
+    #[test]
+    fn codex_args_never_contains_a_newline() {
+        let args = codex_args(
+            Path::new("/tmp/schema.json"),
+            Path::new("/tmp/out.txt"),
+            "/tmp/home".into(),
+            "gpt-5.5",
+        );
+        for arg in &args {
+            assert!(!arg.contains('\n'), "argv entry carries a newline: {arg:?}");
+        }
+    }
+
+    #[test]
+    fn codex_args_omits_the_model_flag_when_unset() {
+        let args = codex_args(
+            Path::new("/tmp/schema.json"),
+            Path::new("/tmp/out.txt"),
+            "/tmp/home".into(),
+            "",
+        );
+        assert!(!args.contains(&"-m".to_string()));
+    }
+
+    #[test]
+    fn codex_args_carries_the_model_flag_when_set() {
+        let args = codex_args(
+            Path::new("/tmp/schema.json"),
+            Path::new("/tmp/out.txt"),
+            "/tmp/home".into(),
+            "gpt-5.5",
+        );
+        let i = args
+            .iter()
+            .position(|a| a == "-m")
+            .expect("-m flag present");
+        assert_eq!(args[i + 1], "gpt-5.5");
+    }
+
+    /// `codex exec`'s argv must carry NO positional prompt - the instructions now live
+    /// entirely in the stdin payload built by `codex_stdin_payload`.
+    #[test]
+    fn codex_args_has_no_positional_prompt() {
+        let args = codex_args(
+            Path::new("/tmp/schema.json"),
+            Path::new("/tmp/out.txt"),
+            "/tmp/home".into(),
+            "",
+        );
+        assert_eq!(args[0], "exec");
+        assert_eq!(
+            args[1], "-s",
+            "the second argv entry must be a flag, not a prompt"
+        );
+    }
+
+    #[test]
+    fn codex_stdin_payload_carries_both_the_instructions_and_the_transcript() {
+        let payload = codex_stdin_payload("the transcript");
+        assert!(payload.contains("the transcript"));
+        assert!(payload.starts_with(&prompts::summary_instruction()[..40]));
     }
 }

--- a/src/coding_agent_session_ingest/summariser/copilot.rs
+++ b/src/coding_agent_session_ingest/summariser/copilot.rs
@@ -14,6 +14,16 @@
 //   analysis.
 // * No `--json-schema`, so the JSON contract rides in the prompt and
 //   `extract` tolerates fenced/prose-wrapped objects (codex pattern).
+//
+// KNOWN WINDOWS GAP: `copilot` is also npm-installed (`npm i -g @github/copilot`),
+// so it resolves to `copilot.cmd` on Windows the same as `codex`/`claude` - and this
+// prompt is always multi-line (it embeds `prompts::summary_instruction()` plus the
+// transcript), which is exactly what makes Rust's std refuse to spawn a `.bat`/`.cmd`
+// target (the CVE-2024-24576 "BatBadBut" fix; see `codex.rs`'s/`claude.rs`'s module
+// docs for the confirmed-live error). Unlike codex/claude, this one can't simply move
+// to stdin - `-p` ignores it, per the first divergence above. Left unfixed here; a
+// real fix needs a different mechanism (e.g. a temp-file prompt, if copilot supports
+// reading one) - not yet designed.
 
 use super::config::SummariserConfig;
 use super::prompts;

--- a/src/coding_agent_session_ingest/summariser/copilot.rs
+++ b/src/coding_agent_session_ingest/summariser/copilot.rs
@@ -14,16 +14,6 @@
 //   analysis.
 // * No `--json-schema`, so the JSON contract rides in the prompt and
 //   `extract` tolerates fenced/prose-wrapped objects (codex pattern).
-//
-// KNOWN WINDOWS GAP: `copilot` is also npm-installed (`npm i -g @github/copilot`),
-// so it resolves to `copilot.cmd` on Windows the same as `codex`/`claude` - and this
-// prompt is always multi-line (it embeds `prompts::summary_instruction()` plus the
-// transcript), which is exactly what makes Rust's std refuse to spawn a `.bat`/`.cmd`
-// target (the CVE-2024-24576 "BatBadBut" fix; see `codex.rs`'s/`claude.rs`'s module
-// docs for the confirmed-live error). Unlike codex/claude, this one can't simply move
-// to stdin - `-p` ignores it, per the first divergence above. Left unfixed here; a
-// real fix needs a different mechanism (e.g. a temp-file prompt, if copilot supports
-// reading one) - not yet designed.
 
 use super::config::SummariserConfig;
 use super::prompts;

--- a/src/coding_agent_session_ingest/summariser/prompts.rs
+++ b/src/coding_agent_session_ingest/summariser/prompts.rs
@@ -5,7 +5,7 @@
 // `session-summary` skill (same rules, in SKILL.md); Codex/Copilot/cursor-agent
 // get SUMMARY_INSTRUCTION as their prompt. All target SUMMARY_SCHEMA.
 
-use serde_json::json;
+use serde_json::{json, Value};
 
 /// Fingerprint of the summariser's own prompt. The source sweep refuses to
 /// ingest any conversation whose first user message carries this marker, so a
@@ -30,9 +30,10 @@ pub fn summary_instruction() -> String {
     )
 }
 
-/// Structured-output contract, serialized for `claude --json-schema` /
-/// `codex --output-schema`. `summary` is the prose we store.
-pub fn summary_schema_json() -> String {
+/// Structured-output contract, as a value - `codex --output-schema` needs the raw
+/// `Value` so `crate::llm::schema::strictify` can be applied to it before writing.
+/// `summary` is the prose we store.
+pub fn summary_schema_value() -> Value {
     json!({
         "type": "object",
         "properties": {
@@ -40,7 +41,14 @@ pub fn summary_schema_json() -> String {
         },
         "required": ["summary"],
     })
-    .to_string()
+}
+
+/// Structured-output contract, serialized for `claude --json-schema`. Claude's schema
+/// validation doesn't need OpenAI's strict dialect (unlike codex - see
+/// `crate::llm::claude::ClaudeBackend`, which also passes its schema through raw), so
+/// this stays the plain, un-strictified form.
+pub fn summary_schema_json() -> String {
+    summary_schema_value().to_string()
 }
 
 /// Substrings that mark a subscription usage/rate limit in CLI stderr/output —

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -785,6 +785,17 @@ pub struct InstallOutcome {
 /// This was a live bug: it made the Install button fail for every npm-based provider on
 /// Windows, and - because the leading token is what triggers the rewrite - Cursor was
 /// unaffected purely by accident, its command starting with `$s`.
+/// POSIX single-quote a string for safe interpolation into the shell text
+/// [`resolve_installer_binary`] builds. `dir`/`resolved` come from a local
+/// filesystem path resolution (`resolve_cli`), not a fixed literal like
+/// `rest` - an attacker able to plant a maliciously-named file in a PATH
+/// directory could otherwise inject shell syntax into the installer command
+/// this builds.
+#[cfg(not(windows))]
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
 #[cfg(windows)]
 async fn resolve_installer_binary(cmd: &str) -> String {
     cmd.to_string()
@@ -806,11 +817,11 @@ async fn resolve_installer_binary(cmd: &str) -> String {
             // npm itself fixed the first one.
             Some(resolved) => match resolved.parent() {
                 Some(dir) => format!(
-                    "export PATH=\"{}:$PATH\"; {} {rest}",
-                    dir.display(),
-                    resolved.display()
+                    "export PATH={}:$PATH; {} {rest}",
+                    shell_quote(&dir.display().to_string()),
+                    shell_quote(&resolved.display().to_string())
                 ),
-                None => format!("{} {rest}", resolved.display()),
+                None => format!("{} {rest}", shell_quote(&resolved.display().to_string())),
             },
             None => cmd.to_string(),
         },
@@ -1866,6 +1877,24 @@ mod tests {
         assert!(node_crash_message("codex", "codex 1.2.3 (Node.js v22.1.0)").is_none());
     }
 
+    #[cfg(not(windows))]
+    #[test]
+    fn shell_quote_wraps_an_ordinary_path_unchanged() {
+        assert_eq!(shell_quote("/opt/homebrew/bin"), "'/opt/homebrew/bin'");
+    }
+
+    /// The finding this exists to close: an embedded single quote must not let the string
+    /// escape its own quoting and inject shell syntax.
+    #[cfg(not(windows))]
+    #[test]
+    fn shell_quote_escapes_an_embedded_single_quote() {
+        let malicious = "/tmp/evil'; rm -rf ~; echo '";
+        let quoted = shell_quote(malicious);
+        // Every character of the input must appear only inside a quoted segment -
+        // reassembling the escape sequence proves it round-trips back to the original.
+        assert_eq!(quoted, r"'/tmp/evil'\''; rm -rf ~; echo '\'''");
+    }
+
     fn groq_custom_provider() -> meridian_core::settings::CustomLlmProvider {
         meridian_core::settings::CustomLlmProvider {
             id: "groq1".to_string(),
@@ -2909,9 +2938,9 @@ mod tests {
         assert_eq!(
             resolved,
             format!(
-                "export PATH=\"{}:$PATH\"; {} i -g some-package",
-                bin_dir.display(),
-                fake_bin.display()
+                "export PATH={}:$PATH; {} i -g some-package",
+                shell_quote(&bin_dir.display().to_string()),
+                shell_quote(&fake_bin.display().to_string())
             ),
             "expected the leading binary swapped for its resolved absolute path, with its \
              directory prepended onto PATH"

--- a/src/llm/detect.rs
+++ b/src/llm/detect.rs
@@ -1154,6 +1154,33 @@ fn buffered_tail(buf: &std::sync::Mutex<String>, n: usize) -> String {
     tail(&s, n)
 }
 
+/// Recognize a Node.js uncaught-exception crash during the CLI's own module
+/// load (as opposed to an auth failure the CLI reported cleanly) and swap the
+/// raw, multi-line internal stack trace for plain-language copy.
+///
+/// `codex`/`claude`/`cursor-agent` are all `#!/usr/bin/env node` scripts,
+/// and a crash while Node is still loading the entrypoint - not running its
+/// own logic - always ends its report with a bare `Node.js vX.Y.Z` line and
+/// names `internal/modules/esm`/`ModuleJob.run` in the stack. That signature
+/// is what was dumped verbatim into Settings: `codex exited Some(1):
+/// .../codex.js:105:9) ... at ModuleJob.run (node:internal/modules/esm/
+/// module_job:437:25) ... Node.js v25.9.0`. Anything not matching this exact
+/// shape returns `None` and the caller falls back to the raw tail unchanged -
+/// this only replaces a message we can say something more specific about, it
+/// never hides one.
+fn node_crash_message(bin: &str, stderr_tail: &str) -> Option<String> {
+    if stderr_tail.contains("Node.js v")
+        && (stderr_tail.contains("internal/modules/esm") || stderr_tail.contains("ModuleJob.run"))
+    {
+        return Some(format!(
+            "{bin} crashed on startup instead of signing in - this usually means the installed \
+             {bin} isn't compatible with your current Node.js version. Try updating {bin} to its \
+             latest version, or switching to a different Node.js version, then sign in again."
+        ));
+    }
+    None
+}
+
 /// [`interactive_login`]'s three durations, bundled so a real sign-in and a test can each
 /// supply their own without growing the function's argument count. Production always uses
 /// [`Self::PRODUCTION`]; tests use tiny values so the same race logic exercises in
@@ -1324,15 +1351,20 @@ where
             } else {
                 stderr_tail
             };
-            let process_message = format!(
-                "{bin} exited {:?}: {}",
-                status.code(),
-                if reason.is_empty() {
-                    "no output".to_string()
-                } else {
-                    reason
-                }
-            );
+            let process_message = if let Some(friendly) = node_crash_message(bin, &reason) {
+                tracing::debug!(bin, raw_tail = %reason, "sign-in CLI crashed at Node module load, showing a friendlier message");
+                friendly
+            } else {
+                format!(
+                    "{bin} exited {:?}: {}",
+                    status.code(),
+                    if reason.is_empty() {
+                        "no output".to_string()
+                    } else {
+                        reason
+                    }
+                )
+            };
             confirm_or_report(label, bin, &path, success_message, &verify, process_message).await
         }
         Ended::WaitError(e) => {
@@ -1801,6 +1833,38 @@ fn path_candidate_names(bin: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const NODE_ESM_CRASH_TAIL: &str = "///opt/homebrew/lib/node_modules/@openai/codex/bin/codex.js:105:9)\n    at ModuleJob.run (node:internal/modules/esm/module_job:437:25)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:639:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)\n\nNode.js v25.9.0";
+
+    /// The exact signature from the reported crash: a friendlier message replaces the raw
+    /// Node internal stack trace.
+    #[test]
+    fn recognizes_a_node_esm_loader_crash() {
+        let msg = node_crash_message("codex", NODE_ESM_CRASH_TAIL).expect("should recognize crash");
+        assert!(msg.contains("codex"));
+        assert!(msg.contains("Node.js version"));
+        assert!(
+            !msg.contains("ModuleJob.run"),
+            "raw stack trace must not leak into the friendly message"
+        );
+    }
+
+    /// An ordinary auth failure (no Node crash signature) must fall through unchanged - this
+    /// must never mask a real, different failure reason.
+    #[test]
+    fn leaves_an_unrelated_failure_untouched() {
+        assert!(
+            node_crash_message("codex", "Error: invalid device code, please try again").is_none()
+        );
+        assert!(node_crash_message("codex", "").is_none());
+    }
+
+    /// "Node.js v" alone (e.g. a version banner some CLIs print on success) is not enough by
+    /// itself - only the module-loader signature counts as a crash.
+    #[test]
+    fn requires_the_module_loader_signature_not_just_a_node_version_string() {
+        assert!(node_crash_message("codex", "codex 1.2.3 (Node.js v22.1.0)").is_none());
+    }
 
     fn groq_custom_provider() -> meridian_core::settings::CustomLlmProvider {
         meridian_core::settings::CustomLlmProvider {


### PR DESCRIPTION
## Summary

Started as a fix for the reported Codex sign-in crash message, and turned up a bigger, confirmed root cause behind github.com/Meridiona/meridian/issues/805 and part of #841 while investigating. Three commits:

### 1. Friendlier Codex sign-in crash message

Settings was showing a raw, multi-line Node.js internal stack trace as the sign-in failure message:

```
Sign-in didn't complete: codex exited Some(1): ///opt/homebrew/lib/node_modules/@openai/codex/bin/codex.js:105:9)
    at ModuleJob.run (node:internal/modules/esm/module_job:437:25)
    ...
Node.js v25.9.0
```

`node_crash_message()` recognizes that signature (`Node.js vX.Y.Z` + `internal/modules/esm`/`ModuleJob.run`) and replaces it with plain, actionable copy. Anything else falls through unchanged.

### 2. Shell-quote resolved paths in the installer command builder

Incidental: the pre-push security audit flagged a pre-existing, unrelated finding in the same file - `resolve_installer_binary` interpolated a locally-resolved CLI path into shell text without quoting. Fixed with a small `shell_quote()` helper since it was blocking the push.

### 3. The real fix: move the coding-agent summariser's Codex/Claude prompt off argv onto stdin

I pulled the diagnostics bundle attached to #805 (`MERIDIAN_TELEMETRY_DIR` pointed at the extracted bundle + a throwaway OTLP attribute dumper) and found **165 occurrences** of `codex spawn failed: batch file arguments are invalid` across dozens of coding-agent session rows on that Windows machine.

Root cause: `src/coding_agent_session_ingest/summariser/{codex,claude}.rs` pass their full instructions prompt - always multi-line, sourced from `assets/skills/coding-agent/session-summary/SKILL.md` - as a **positional argv argument** to `codex exec`/`claude -p`. On Windows both resolve to npm-generated `.cmd` batch files, and Rust's std refuses to spawn a `.bat`/`.cmd` target when an argument contains a character it can't safely escape - notably an embedded newline (the CVE-2024-24576 "BatBadBut" fix). So every real summarization call on Windows failed to even spawn.

This is the *exact* bug already found and fixed in the sibling `src/llm/{codex,claude}.rs` (the hourly-worklog-pipeline / connectivity-test backends) back in `a2a31c19` (2026-07-24) - moving the prompt to stdin instead. That fix never reached the coding-agent summariser, which has carried the identical bug since it was written. This applies the same fix here, mirroring each engine's already-fixed stdin shape exactly. Codex's schema is also now run through `strictify` before being written, matching the already-fixed `CodexBackend` path, since unblocking the spawn means codex's own strict-schema validation is now reachable too.

**Scope, precisely:**
- Closes: the "batch file arguments are invalid" class of failure, which is very likely why #841 reported "yesterday it failed to write any tasks/summaries for the full day."
- Does **NOT** close: #805's headline `test_llm_provider ... timed out after 20s` symptom - that's a different code path (`src/llm/codex.rs::signed_out`'s slow-fail case), not touched here.
- Does **NOT** close: #841's Claude-losing-sign-in symptom - that reporter is on macOS, where this Windows-only argv/batch-file issue can't be the cause. Needs separate investigation.
- `src/coding_agent_session_ingest/summariser/copilot.rs` has the same npm-`.cmd` exposure on Windows but can't take the same fix (`copilot -p` ignores stdin, documented in-file) - confirmed still actively used (both Copilot ingestion sources are unconditionally registered), left as a known gap for a follow-up, not fixed here.

## Test plan

- [x] `cargo test -p meridian --lib llm::detect` and `coding_agent_session_ingest::summariser` - all new tests pass (node-crash message classifier, shell_quote escaping, argv-never-contains-newline regression guards for both codex and claude, stdin-payload shape)
- [x] `cargo test --workspace` - 1095+ passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` - clean
- [x] `cargo fmt --all --check` - clean
- [x] Full pre-push gate (fmt, ui build, clippy, ui tests, security audit, cargo test) passed on every push