### PR TITLE
fix(llm): Cursor summariser argv/Windows fix + health-gate exemption telemetry

### DIFF
--- a/src/coding_agent_session_ingest/summariser/cursor_agent.rs
+++ b/src/coding_agent_session_ingest/summariser/cursor_agent.rs
@@ -2,7 +2,7 @@
 //
 // Run `cursor-agent` to summarise a Cursor session (symmetry with claude.rs /
 // codex.rs / copilot.rs — each agent's transcripts go to its own CLI, with no
-// cross-engine fallback). The transcript rides in the prompt argument, and any
+// cross-engine fallback). The transcript goes over stdin (see below), and any
 // failure leaves the row pending for a later drain (Failed → retried up to
 // primary_attempts, then left pending).
 //
@@ -13,6 +13,19 @@
 // Persistence probed: `-p` runs write to ~/.cursor/chats/, NOT the vscdb we
 // ingest from — so a summariser run cannot re-enter the indexer (the
 // SUMMARY_PROMPT_MARKER guard in sources/mod.rs backstops this anyway).
+//
+// # The whole prompt goes over stdin, not argv (Windows)
+//
+// It used to be `cursor-agent -p <prompt>` (positional argv). `cursor-agent` resolves to
+// `cursor-agent.cmd` on Windows - a batch file, not a native exe - and Rust's std library
+// refuses to spawn a `.bat`/`.cmd` target when an argument contains characters it cannot
+// safely escape (the CVE-2024-24576 "BatBadBut" fix), notably embedded newlines. The prompt
+// (instructions + transcript) is always multi-line, so every real call through this function
+// failed to even spawn on Windows with `io::Error { InvalidInput, "batch file arguments are
+// invalid" }`. `crate::llm::cursor::CursorBackend` (the hourly worklog pipeline / connectivity
+// test) already moved off argv for exactly this reason, "confirmed live" per its own module
+// doc - this applies the identical fix here, which had the identical bug all along.
+// `cursor-agent -p` as a bare flag (no positional value) reads the whole prompt from stdin.
 
 use super::config::SummariserConfig;
 use super::prompts;
@@ -74,6 +87,15 @@ pub async fn run_cursor_agent(
         .await
 }
 
+/// The `cursor-agent -p` argv - no prompt in here, see the module doc. Split out so the
+/// no-newline invariant this function exists to guarantee is directly testable.
+fn cursor_agent_args(safety: Vec<String>) -> Vec<String> {
+    let mut args: Vec<String> = vec!["-p".into()];
+    args.extend(["--output-format".into(), "text".into()]);
+    args.extend(safety);
+    args
+}
+
 /// One `cursor-agent` attempt with the safety argv/environment chosen by the ladder.
 async fn run_once(
     prompt: &str,
@@ -81,16 +103,14 @@ async fn run_once(
     env: Vec<(&'static str, String)>,
     cfg: &SummariserConfig,
 ) -> Result<EngineOutput, SummariserError> {
-    let mut args: Vec<String> = vec!["-p".into(), prompt.to_string()];
-    args.extend(["--output-format".into(), "text".into()]);
-    args.extend(safety);
+    let args = cursor_agent_args(safety);
 
     let env_refs: Vec<(&str, &str)> = env.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
     let cap = run_capture(
         "cursor-agent",
         &args,
-        "", // transcript is embedded in the prompt (stdin support unprobed)
+        prompt, // payload goes over stdin - see the module doc
         // See the note in llm/cursor.rs: a cwd outside $HOME so rule discovery cannot regress.
         &crate::llm::cursor_cli::neutral_workspace(),
         cfg.cursor_timeout_s,
@@ -131,4 +151,47 @@ async fn run_once(
         ));
     }
     Ok(EngineOutput { summary })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The premise the whole fix rests on: the instructions are sourced from a Markdown
+    /// rules file and are always multi-line. If `SKILL.md` ever became single-line, this
+    /// fix would no longer be guarding against anything real - this pins that it still is.
+    #[test]
+    fn the_instructions_prompt_is_multi_line() {
+        assert!(prompts::summary_instruction().contains('\n'));
+    }
+
+    /// The regression this fix exists to close: `cursor-agent -p` argv must never carry the
+    /// prompt (or anything else newline-bearing) - that is exactly what makes Rust's std
+    /// refuse to spawn `cursor-agent.cmd` on Windows. A future edit that reintroduces the
+    /// prompt into `args` fails this test.
+    #[test]
+    fn cursor_agent_args_never_contains_a_newline() {
+        let args = cursor_agent_args(vec!["--allowed-tools".into(), String::new()]);
+        for arg in &args {
+            assert!(!arg.contains('\n'), "argv entry carries a newline: {arg:?}");
+        }
+    }
+
+    /// `-p` must be a bare flag - a positional value right after it would force the prompt
+    /// back through argv.
+    #[test]
+    fn cursor_agent_args_has_no_positional_prompt() {
+        let args = cursor_agent_args(vec![]);
+        assert_eq!(args[0], "-p");
+        assert_eq!(
+            args[1], "--output-format",
+            "the second argv entry must be a flag, not a prompt"
+        );
+    }
+
+    #[test]
+    fn cursor_agent_args_carries_the_safety_flags() {
+        let args = cursor_agent_args(vec!["--force".into()]);
+        assert!(args.contains(&"--force".to_string()));
+    }
 }

--- a/src/llm/resolver.rs
+++ b/src/llm/resolver.rs
@@ -554,7 +554,13 @@ async fn complete_inner(req: &PromptRequest) -> Result<(LlmOutput, LlmProvider),
             return Err(refusal);
         }
         probing = true;
-        tracing::info!(
+        // WARN, not INFO: this is the ONLY record that the 15-minute exemption
+        // (`HEALTH_PROBE_INTERVAL`) ever fired at all. Redaction ships WARN+ logs
+        // only (see CLAUDE.md's Observability section), so at INFO this line never
+        // reaches central OO - which is exactly what made a live-in-the-field
+        // "is the exemption even running?" question undiagnosable from telemetry
+        // alone (github.com/Meridiona/meridian/issues/805).
+        tracing::warn!(
             provider = chosen.as_str(),
             label = %req.label,
             error = %refusal,
@@ -663,6 +669,16 @@ async fn complete_inner(req: &PromptRequest) -> Result<(LlmOutput, LlmProvider),
             // which that check cannot see - so it would write nothing and the next call
             // would be refused again by the verdict this one just disproved.
             if probing {
+                // The other half of the exemption's story - see the WARN above where
+                // `probing` was set. Without this, a successful re-check is invisible:
+                // the outage just silently stops appearing in the next refusal log,
+                // which reads identically to "the exemption never got another chance to
+                // fire" from telemetry alone.
+                tracing::warn!(
+                    provider = chosen.as_str(),
+                    label = %req.label,
+                    "llm: provider re-check succeeded - clearing the unavailable verdict"
+                );
                 super::runtime_health::record_probe_success(&key);
             } else {
                 super::runtime_health::record_success(&key);


### PR DESCRIPTION
## Summary

Two fixes from the ongoing #805/#841 investigation, on the same branch:

### 1. Cursor's summariser had the same argv bug as the codex/claude fix in #901

`src/coding_agent_session_ingest/summariser/cursor_agent.rs` was still passing its full, always-multi-line prompt as a positional `cursor-agent -p <prompt>` argv argument. On Windows, `cursor-agent` resolves to `cursor-agent.cmd` - a batch file, not a native exe - and Rust's std refuses to spawn a `.bat`/`.cmd` target with a newline in an argument (CVE-2024-24576, "BatBadBut"). Every real call through this function failed to even spawn on Windows.

This is the exact same bug already fixed in the sibling hourly-pipeline backend (`src/llm/cursor.rs::CursorBackend`, commit `4a83d98f`, 2026-07-24 - "confirmed live" per its own module doc) - just missed in the summariser, identical to the codex/claude miss #901 fixed. Flagged as the highest-confidence remaining gap by the provider-connectivity audit that followed #901.

Fix: no positional prompt on argv anymore; the prompt goes over stdin instead, matching `CursorBackend`'s already-proven shape exactly (`-p` as a bare flag). New tests pin the no-newline invariant, matching the codex/claude test pattern from #901.

### 2. Health-gate re-check exemption's outcome made visible in telemetry

While investigating #805 against live central OpenObserve data (tunneled in with credentials shared for this purpose): confirmed the `codex timed out after 20s` WARN is still firing continuously on the affected host, and the last genuine `llm.infer` trace span for that host is from over a week ago - despite `resolver.rs`'s 15-minute health-probe exemption (`HEALTH_PROBE_INTERVAL`) existing specifically to prevent a stale verdict from staying stuck.

Could not tell from telemetry whether that exemption was ever firing: the "exemption granted" log was `tracing::info!`, and the redacted central ship leg only forwards WARN+ (see CLAUDE.md's Observability section), so it never reached OpenObserve regardless of whether it ran. The success side was worse - completely silent, so a cleared outage and "never got another chance to fire" were indistinguishable.

Fix: bumped the exemption-granted log to `warn!`, and added a matching `warn!` on the success path. Log-only, no behavior change. Next recurrence, this is directly queryable.

(Also ruled out along the way, documented in the investigation but not fixed here: this user's actual 8/18 pipeline traffic was hitting a custom Groq endpoint, not Codex, and a separate "worklog: auto-generate failed" WARN on the same host turned out to be an unrelated "no PM tracker connected" condition - noted so the next person doesn't re-chase either.)

## Test plan

- [x] `cargo test -p meridian --lib coding_agent_session_ingest::summariser::cursor_agent` - 4/4 pass
- [x] `cargo test -p meridian --lib llm::resolver` - 12/12 pass, including `a_refused_provider_earns_one_probe_per_interval`
- [x] `cargo test --workspace` - 1099+ passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` - clean
- [x] `cargo fmt --all --check` - clean
- [x] Full pre-push gate (fmt, ui build, clippy, ui tests, security audit, cargo test) passed on every push