### PR TITLE
feat(observability): make a daemon generation identifiable and its quit survivable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1023,8 +1023,26 @@ async fn main() -> Result<()> {
     let initial_cfg = Config::from_env();
     tracing::info!(stage = "config_loaded", "configuration ready");
 
-    // 4. Log startup parameters
+    // 4. Log startup parameters.
+    //
+    //    `pid` is here so a generation can be TOLD APART from the next one.
+    //    Without it, a machine that started three daemons in 35 seconds — which
+    //    is what a quit-then-relaunch during an update looks like — produces
+    //    three identical "meridian daemon starting" lines and a set of signal
+    //    lines that cannot be attributed to any of them. Every corruption
+    //    investigation so far has run aground on exactly that: the events are
+    //    all in the spool, and nothing says which process each belongs to.
+    //
+    //    Logged as `i64`, not the `u32` `std::process::id` returns, and this is
+    //    load-bearing rather than cosmetic. `tracing-opentelemetry` 0.28 has no
+    //    `record_u64`, so a `u32`/`u64` field falls through to `record_debug`
+    //    and is emitted as a STRING — which then has to survive the attribute
+    //    allowlist as a string key to egress at all. An `i64` becomes a real
+    //    `IntValue`, and `redact::keep_attribute`'s first arm keeps every
+    //    `IntValue` unconditionally. See CLAUDE.md's third "coupling that
+    //    silently deletes error coverage".
     tracing::info!(
+        pid = std::process::id() as i64,
         meridian_db = %initial_cfg.meridian_db,
         poll_interval_secs = initial_cfg.poll_interval_secs,
         "meridian daemon starting"
@@ -1526,13 +1544,27 @@ async fn main() -> Result<()> {
     let _ = shutdown_tx.send(true);
 
     // 9. Shutdown
-    tracing::info!("shutting down");
+    tracing::info!(pid = std::process::id() as i64, "shutting down");
     meridian::platform::release_endpoint();
     // See `db::meridian::checkpoint_wal`'s doc for why this runs before every
     // close, not just a plain shutdown. Best-effort: a failed checkpoint must
     // not block shutdown.
-    if let Err(e) = meridian::db::meridian::checkpoint_wal(&meridian).await {
-        tracing::warn!(error = %meridian::errors::chain(&e), "WAL checkpoint on shutdown failed - continuing anyway");
+    //
+    // BOTH outcomes are logged, and the success line is the point. Previously a
+    // failed checkpoint logged a WARN and a successful one logged nothing, so
+    // "no line after `shutting down`" meant either "it worked" or "the process
+    // was killed part-way through" — indistinguishable, and the difference is
+    // the entire question when a `meridian.db` is later found malformed. A
+    // corruption investigation on 2026-08-25 stalled on exactly this ambiguity
+    // and had to withdraw its conclusion. Now silence here means killed.
+    match meridian::db::meridian::checkpoint_wal(&meridian).await {
+        Ok(()) => tracing::info!(
+            pid = std::process::id() as i64,
+            "WAL checkpoint on shutdown complete"
+        ),
+        Err(e) => {
+            tracing::warn!(error = %meridian::errors::chain(&e), "WAL checkpoint on shutdown failed - continuing anyway")
+        }
     }
     meridian.close().await;
 

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -142,6 +142,71 @@ impl ObservabilityGuard {
     }
 }
 
+/// Provider handles kept for [`force_flush`]. Set once by [`init`].
+///
+/// Separate from [`ObservabilityGuard`] because the guard is owned by whoever
+/// called `init` — in the tray that is a local in `run()` — while the code that
+/// needs to flush is somewhere else entirely (an exit handler in a spawned
+/// task). Both providers are `Arc`-backed, so this holds clones rather than
+/// taking anything away from the guard.
+static FLUSH_HANDLES: std::sync::OnceLock<FlushHandles> = std::sync::OnceLock::new();
+
+struct FlushHandles {
+    tracer_provider: Option<TracerProvider>,
+    logger_provider: Option<LoggerProvider>,
+}
+
+/// Push everything currently batched in memory out to the telemetry spool,
+/// WITHOUT shutting the providers down.
+///
+/// # Why this is needed at all
+///
+/// Spans and logs do not reach `~/.meridian/telemetry/pending/` the moment they
+/// are emitted: the batch processors hold them and drain on a timer. A process
+/// that calls `std::process::exit` — which is what `tauri::AppHandle::exit`
+/// does — takes that batch with it. Destructors do not run, so holding an RAII
+/// guard is no protection either.
+///
+/// The practical cost was that the LAST thing a process does is the thing least
+/// likely to be recorded, and for the tray the last thing it does is stop the
+/// daemon on quit. Every `daemon stopped for quit` / `could not stop the daemon
+/// on quit` / `exceeded its budget` line was emitted and then discarded
+/// microseconds later, so the outcome of the operation that most needs
+/// explaining after a corruption report was systematically the one missing from
+/// the spool.
+///
+/// [`ObservabilityGuard::shutdown`] already does this and more, but it consumes
+/// the guard and shuts the providers down; this is the "flush and keep going"
+/// half, callable from anywhere and safe to call more than once.
+///
+/// A no-op when capture is disabled (`MERIDIAN_TELEMETRY_DISABLED`) or before
+/// [`init`] has run, so callers never need to check.
+///
+/// # Who calls this
+/// - `meridian_tray_lib::run`'s `RunEvent::ExitRequested` handler, immediately
+///   before `handle.exit(0)`.
+pub async fn force_flush() {
+    let Some(handles) = FLUSH_HANDLES.get() else {
+        return;
+    };
+    if let Some(tp) = handles.tracer_provider.clone() {
+        let _ = tokio::task::spawn_blocking(move || {
+            for r in tp.force_flush() {
+                if let Err(e) = r {
+                    eprintln!("observability: span force_flush error: {e:?}");
+                }
+            }
+        })
+        .await;
+    }
+    if let Some(lp) = handles.logger_provider.clone() {
+        let _ = tokio::task::spawn_blocking(move || {
+            let _ = lp.force_flush();
+        })
+        .await;
+    }
+}
+
 /// Initialise the layered tracing subscriber.
 ///
 /// `service_name` becomes the OTel `service.name` resource attribute. The
@@ -253,6 +318,14 @@ pub fn init(service_name: &str) -> Result<ObservabilityGuard> {
             "observability initialised (no OTLP exporter)"
         );
     }
+
+    // Clones for `force_flush`, which runs far from whoever owns the guard.
+    // `set` rather than `get_or_init`: a second `init` in one process is a bug,
+    // and silently keeping the first set of handles is the safer failure.
+    let _ = FLUSH_HANDLES.set(FlushHandles {
+        tracer_provider: tracer_provider.clone(),
+        logger_provider: logger_provider.clone(),
+    });
 
     Ok(ObservabilityGuard {
         tracer_provider,

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -210,10 +210,20 @@ pub async fn wait_for_shutdown() {
     let mut sigterm = signal(SignalKind::terminate()).expect("register SIGTERM handler");
     let mut sighup = signal(SignalKind::hangup()).expect("register SIGHUP handler");
 
+    // `pid` on every arm: these lines are the record of WHICH daemon generation
+    // was asked to stop, and during an update or a quit-then-relaunch there are
+    // several within seconds of each other. Without it the signal cannot be
+    // matched to the "meridian daemon starting" line it belongs to, and the
+    // shutdown sequence — the window where the tray and the daemon can overlap
+    // on meridian.db — is unreconstructable after the fact.
+    //
+    // `as i64` deliberately; see the same cast at the startup log in `main.rs`
+    // for why a `u32` would ship as a string, or not at all.
+    let pid = std::process::id() as i64;
     tokio::select! {
-        _ = sigint.recv()  => tracing::info!("SIGINT received"),
-        _ = sigterm.recv() => tracing::info!("SIGTERM received"),
-        _ = sighup.recv()  => tracing::info!("SIGHUP received — reloading (graceful restart)"),
+        _ = sigint.recv()  => tracing::info!(pid, "SIGINT received"),
+        _ = sigterm.recv() => tracing::info!(pid, "SIGTERM received"),
+        _ = sighup.recv()  => tracing::info!(pid, "SIGHUP received — reloading (graceful restart)"),
     }
 }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -209,9 +209,12 @@ pub async fn wait_for_shutdown() {
     let mut close = ctrl_close().expect("register console-close handler");
     let mut shutdown = ctrl_shutdown().expect("register system-shutdown handler");
 
+    // `pid` on every arm, for the same reason as the Unix arm — see
+    // `super::unix::wait_for_shutdown`.
+    let pid = std::process::id() as i64;
     tokio::select! {
-        _ = ctrl_c.recv()   => tracing::info!("Ctrl-C received"),
-        _ = close.recv()    => tracing::info!("console close received"),
-        _ = shutdown.recv() => tracing::info!("system shutdown received"),
+        _ = ctrl_c.recv()   => tracing::info!(pid, "Ctrl-C received"),
+        _ = close.recv()    => tracing::info!(pid, "console close received"),
+        _ = shutdown.recv() => tracing::info!(pid, "system shutdown received"),
     }
 }

--- a/src/telemetry_spool/render.rs
+++ b/src/telemetry_spool/render.rs
@@ -41,6 +41,34 @@ pub struct RenderedRecord {
     pub body: String,
     pub trace_id: String,
     pub span_id: String,
+    /// The record's structured fields, already stringified, in emission order.
+    ///
+    /// These were previously decoded and thrown away, so `meridian logs` showed
+    /// the message of every record and none of its data. That is the opposite
+    /// of how this codebase is instrumented — CLAUDE.md requires values to be
+    /// structured fields and never formatted into the message — so the one
+    /// supported way to read logs locally was systematically hiding the half
+    /// that was written to be machine-readable. A `SIGTERM received` with no
+    /// `pid`, an `ETL run failed` with no `error`.
+    pub attributes: Vec<(String, String)>,
+}
+
+/// Attribute keys `meridian logs` does not print.
+///
+/// Not a privacy filter — this is the local, full-fidelity read path and
+/// nothing here is withheld from the spool or from an export bundle. It is
+/// purely about signal: `opentelemetry-appender-tracing`'s
+/// `experimental_metadata_attributes` feature stamps call-site metadata on
+/// EVERY record, which would triple the width of every line with the one thing
+/// a reader already knows (they can see the message).
+///
+/// Prefix-matched, so `code.filepath`/`code.lineno`/`code.namespace` are all
+/// covered by one entry.
+const UNPRINTED_ATTR_PREFIXES: &[&str] = &["code.", "log.target", "thread.", "busy_ns", "idle_ns"];
+
+/// Is this a call-site metadata key rather than a value the emitter chose?
+fn is_unprinted_attr(key: &str) -> bool {
+    UNPRINTED_ATTR_PREFIXES.iter().any(|p| key.starts_with(p))
 }
 
 /// Decode one spooled file into [`RenderedRecord`]s. The signal (logs vs
@@ -86,6 +114,9 @@ fn decode_logs(bytes: &[u8]) -> Result<Vec<RenderedRecord>> {
                     body: any_value_to_string(lr.body.as_ref()),
                     trace_id: hex::encode(&lr.trace_id),
                     span_id: hex::encode(&lr.span_id),
+                    attributes: collect_attributes(
+                        lr.attributes.iter().map(|kv| (&kv.key, kv.value.as_ref())),
+                    ),
                 });
             }
         }
@@ -109,6 +140,11 @@ fn decode_traces(bytes: &[u8]) -> Result<Vec<RenderedRecord>> {
                     body: span.name,
                     trace_id: hex::encode(&span.trace_id),
                     span_id: hex::encode(&span.span_id),
+                    attributes: collect_attributes(
+                        span.attributes
+                            .iter()
+                            .map(|kv| (&kv.key, kv.value.as_ref())),
+                    ),
                 });
             }
         }
@@ -122,6 +158,18 @@ fn resource_service_name(resource: Option<&Resource>) -> String {
         .map(|kv| any_value_to_string(kv.value.as_ref()))
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Stringify a record's attributes for display, dropping call-site metadata
+/// and anything with an empty value (a field that was recorded but never set —
+/// printing `outcome=` adds width and no information).
+fn collect_attributes<'a>(
+    kvs: impl Iterator<Item = (&'a String, Option<&'a AnyValue>)>,
+) -> Vec<(String, String)> {
+    kvs.filter(|(k, _)| !is_unprinted_attr(k))
+        .map(|(k, v)| (k.clone(), any_value_to_string(v)))
+        .filter(|(_, v)| !v.is_empty())
+        .collect()
 }
 
 fn any_value_to_string(v: Option<&AnyValue>) -> String {
@@ -177,6 +225,11 @@ pub fn format_line(r: &RenderedRecord) -> String {
     .unwrap_or_else(|| "?".to_string());
 
     let mut line = format!("{ts} {:>7} [{}] {}", r.severity, r.service_name, r.body);
+    // After the message, before `trace_id`: the fields are what the message is
+    // about, and the trace id is a join key nobody reads inline.
+    for (k, v) in &r.attributes {
+        line.push_str(&format!(" {k}={v}"));
+    }
     if !r.trace_id.is_empty() {
         line.push_str(&format!(" trace_id={}", r.trace_id));
     }
@@ -421,6 +474,126 @@ mod tests {
             }],
         };
         req.encode_to_vec()
+    }
+
+    /// Build one log record carrying the given attributes, so the rendering of
+    /// structured fields can be exercised without a live subscriber.
+    fn make_log_bytes_with_attrs(body: &str, attrs: &[(&str, any_value::Value)]) -> Vec<u8> {
+        let req = ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs {
+                resource: Some(Resource {
+                    attributes: vec![KeyValue {
+                        key: "service.name".to_string(),
+                        value: Some(AnyValue {
+                            value: Some(any_value::Value::StringValue("test-svc".to_string())),
+                        }),
+                    }],
+                    dropped_attributes_count: 0,
+                }),
+                scope_logs: vec![ScopeLogs {
+                    scope: Some(InstrumentationScope::default()),
+                    log_records: vec![LogRecord {
+                        time_unix_nano: 1_700_000_000_000_000_000,
+                        severity_text: "INFO".to_string(),
+                        body: Some(AnyValue {
+                            value: Some(any_value::Value::StringValue(body.to_string())),
+                        }),
+                        attributes: attrs
+                            .iter()
+                            .map(|(k, v)| KeyValue {
+                                key: (*k).to_string(),
+                                value: Some(AnyValue {
+                                    value: Some(v.clone()),
+                                }),
+                            })
+                            .collect(),
+                        ..Default::default()
+                    }],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+        req.encode_to_vec()
+    }
+
+    /// A record's structured fields must reach the rendered line.
+    ///
+    /// They were decoded and discarded before, which made `meridian logs` show
+    /// the message of every record and none of its data — so `SIGTERM received`
+    /// could not be attributed to a process and `ETL run failed` did not carry
+    /// its error. `pid` is the concrete case this was added for: an `i64`, which
+    /// must render as a plain number rather than a debug-formatted string.
+    #[test]
+    fn structured_fields_are_rendered_not_discarded() {
+        let bytes = make_log_bytes_with_attrs(
+            "SIGTERM received",
+            &[("pid", any_value::Value::IntValue(4321))],
+        );
+        let records = decode_logs(&bytes).unwrap();
+        let r = &records[0];
+        assert_eq!(
+            r.attributes,
+            vec![("pid".to_string(), "4321".to_string())],
+            "the log's structured fields must survive decoding"
+        );
+        let line = format_line(r);
+        assert!(
+            line.contains("SIGTERM received pid=4321"),
+            "the fields must appear on the rendered line, right after the \
+             message; got {line:?}"
+        );
+    }
+
+    /// Call-site metadata is stamped on EVERY record by
+    /// `experimental_metadata_attributes`. Printing it would bury the fields
+    /// that were chosen deliberately under three that never vary in usefulness.
+    #[test]
+    fn call_site_metadata_is_not_printed() {
+        let bytes = make_log_bytes_with_attrs(
+            "shutting down",
+            &[
+                (
+                    "code.filepath",
+                    any_value::Value::StringValue("src/main.rs".into()),
+                ),
+                ("code.lineno", any_value::Value::IntValue(1547)),
+                (
+                    "code.namespace",
+                    any_value::Value::StringValue("meridian".into()),
+                ),
+                (
+                    "log.target",
+                    any_value::Value::StringValue("meridian".into()),
+                ),
+                ("pid", any_value::Value::IntValue(99)),
+            ],
+        );
+        let r = &decode_logs(&bytes).unwrap()[0];
+        assert_eq!(
+            r.attributes,
+            vec![("pid".to_string(), "99".to_string())],
+            "only the emitter's own fields should survive; got {:?}",
+            r.attributes
+        );
+    }
+
+    /// A field declared on a span but never recorded arrives as an empty value.
+    /// Rendering `outcome=` costs width and carries nothing.
+    #[test]
+    fn unset_fields_are_omitted() {
+        let bytes = make_log_bytes_with_attrs(
+            "daemon_lifecycle.stop",
+            &[
+                ("outcome", any_value::Value::StringValue(String::new())),
+                ("reason", any_value::Value::StringValue("quit".to_string())),
+            ],
+        );
+        let r = &decode_logs(&bytes).unwrap()[0];
+        assert_eq!(
+            r.attributes,
+            vec![("reason".to_string(), "quit".to_string())]
+        );
     }
 
     #[test]

--- a/tray/src-tauri/src/daemon_lifecycle.rs
+++ b/tray/src-tauri/src/daemon_lifecycle.rs
@@ -922,5 +922,41 @@ mod tests {
              INSIDE the task, or a panic mid-stop leaves the exit held forever \
              and the app cannot be quit at all; found: {spawn_body:?}"
         );
+
+        // `stop_for_quit`'s verdict must be FLUSHED before the process exits.
+        //
+        // `handle.exit` is `std::process::exit`: no destructors, and whatever
+        // the OTel batch processors are still holding dies with the process.
+        // What they are holding at that moment is the line describing how
+        // stopping the daemon went - `daemon stopped for quit`, `could not stop
+        // the daemon on quit`, or `exceeded its budget`. Those are the most
+        // useful records that exist for a corruption report, because quit is
+        // when the tray and the daemon are most likely to overlap on
+        // meridian.db, and every one of them was being discarded microseconds
+        // after being emitted.
+        //
+        // Ordering is asserted, not mere presence: a flush placed BEFORE
+        // `stop_for_quit` compiles, runs, logs nothing unusual, and preserves
+        // exactly the records that were never in danger while still losing the
+        // one that was.
+        let stop_pos = spawn_body
+            .find("stop_for_quit().await")
+            .expect("the spawned task must call stop_for_quit");
+        let flush_pos = spawn_body
+            .find("observability::force_flush().await")
+            .expect(
+                "the spawned stop task must flush telemetry before exiting, or \
+                 stop_for_quit's outcome never reaches the spool",
+            );
+        let exit_pos = spawn_body
+            .find("handle.exit(")
+            .expect("the spawned task must exit the app");
+        assert!(
+            stop_pos < flush_pos && flush_pos < exit_pos,
+            "the telemetry flush must sit BETWEEN stop_for_quit and \
+             handle.exit: before the stop it flushes a verdict that has not \
+             been reached yet, and after the exit it does not run at all. \
+             Found stop at {stop_pos}, flush at {flush_pos}, exit at {exit_pos}."
+        );
     }
 }

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -1458,6 +1458,18 @@ pub fn run() {
                             // phase. See [`daemon_lifecycle::HeldExitGuard`].
                             let _released = daemon_lifecycle::HeldExitGuard;
                             daemon_lifecycle::stop_for_quit().await;
+                            // Push `stop_for_quit`'s verdict to the spool BEFORE
+                            // exiting. `handle.exit` is `std::process::exit`, so
+                            // it runs no destructors and takes whatever the OTel
+                            // batch processors are still holding with it — and
+                            // what they are holding at this instant is the line
+                            // that just described how stopping the daemon went.
+                            //
+                            // That line is the single most useful record for a
+                            // corruption report (quit is when the tray and the
+                            // daemon are most likely to overlap on meridian.db),
+                            // and it was the one guaranteed never to survive.
+                            meridian::observability::force_flush().await;
                             // Immediately before the exit, so the re-entrant
                             // `ExitRequested` this triggers is the one and only
                             // one allowed through.


### PR DESCRIPTION
Refs #861. Independent of #902 and #903 - different functions, no ordering dependency.

## Why

Three corruption mechanisms were fixed this month (#886, #894, #861) and **none was confirmed from field data**. Each was reasoned from code, because the telemetry cannot answer the questions an incident actually raises. This closes the gaps that made that true, so the *next* incident is explainable rather than argued.

## 1. One daemon generation could not be told from the next

A quit-then-relaunch during an update starts three daemons inside 35 seconds. All three logged an identical `meridian daemon starting`, and the SIGTERMs between them named nobody. An investigation on 2026-08-25 ran aground on exactly this and had to withdraw its conclusion.

`pid` now rides on `meridian daemon starting`, on every arm of `wait_for_shutdown` (both platforms), and on `shutting down`.

**Logged as `i64`, not the `u32` `std::process::id()` returns** - load-bearing, not style. `tracing-opentelemetry` 0.28 has no `record_u64`, so a `u32` falls through to `record_debug` and is emitted as a **string**, which then has to survive the attribute allowlist as a string key to egress at all. An `i64` becomes a real `IntValue`, kept unconditionally by `redact::keep_attribute`'s first arm. Same trap as CLAUDE.md's third documented coupling - the one that shipped `timeout_s = null` on every `cli_exec` timeout.

## 2. A successful WAL checkpoint logged nothing

A **failed** checkpoint warned; a **successful** one was silent. So "no line after `shutting down`" meant either *it completed* or *the process was killed part-way through* - indistinguishable, and that distinction is the whole question when a `meridian.db` is later found malformed.

Both outcomes log now. **Silence after `shutting down` means killed.**

## 3. The quit verdict was systematically discarded

`handle.exit(0)` is `std::process::exit`: no destructors run, and whatever the OTel batch processors still hold dies with the process. What they hold at that instant is the line describing how stopping the daemon went - `daemon stopped for quit`, `could not stop the daemon on quit`, `exceeded its budget`.

Quit is when the tray and the daemon are most likely to overlap on `meridian.db`. So the single most useful record for a corruption report was the one guaranteed never to survive.

`observability::force_flush()` is the "flush and keep going" half of `ObservabilityGuard::shutdown` - callable from anywhere, idempotent, a no-op before `init` or with capture disabled. The exit handler calls it between `stop_for_quit` and `handle.exit`.

## 4. `meridian logs` was discarding every structured field

Found while verifying the above, and the reason the pid alone would not have been enough.

`RenderedRecord` decoded attributes and **threw them away**. The one supported local read path showed the message of every record and none of its data: `SIGTERM received` with no pid, `ETL run failed` with no error. That is the exact inverse of the structured-field discipline CLAUDE.md mandates, and it is why the 25th's investigation was reading messages only.

Fields now render after the message. Call-site metadata (`code.*`, `log.target`, `thread.*` - stamped on every record by `experimental_metadata_attributes`) and unset fields are skipped, so lines gain signal rather than width. **Display only** - the spool and export bundles were always full-fidelity, so nothing newly egresses.

## Verified end to end

Real daemon, isolated `HOME`, SIGTERM, read back through `meridian logs`:

```
INFO [meridian-rust] meridian daemon starting pid=11174 meridian_db=… poll_interval_secs=60
INFO [meridian-rust] SIGTERM received pid=11174
INFO [meridian-rust] shutting down pid=11174
INFO [meridian-rust] WAL checkpoint on shutdown complete pid=11174
```

`pid` matches the shell-reported pid. The whole lifecycle is attributable to one process - precisely what was missing on the 25th. I also confirmed the `pid` key is present in the raw OTLP payload, not just in the renderer.

## Tests

The flush's **order** is asserted, not its presence: a flush placed before `stop_for_quit` compiles, runs, logs nothing unusual, and preserves exactly the records that were never at risk while still losing the one that was.

| mutation | result |
|---|---|
| flush moved before `stop_for_quit` | red - `must sit BETWEEN stop_for_quit and handle.exit` |
| flush deleted | red - `never reaches the spool` |

Attribute rendering has three tests: an `i64` field renders as a plain number, call-site metadata is suppressed, unset fields are omitted.

`clippy --workspace --all-targets -D warnings` clean; `cargo test --workspace` fully green.

## What this does not do

It does not fix anything. It makes the next `database disk image is malformed` report answerable instead of a reconstruction - which, given three unconfirmed fixes, is the more valuable thing right now.