### PR TITLE
fix(infra): stop an unknown argument from triggering a production deploy

### DIFF
--- a/scripts/deploy-gateway.sh
+++ b/scripts/deploy-gateway.sh
@@ -140,6 +140,42 @@ verify_public_endpoints_authenticate() {
 	return "${failed}"
 }
 
+# ── Argument dispatch ────────────────────────────────────────────────────────
+#
+# Every argument is either recognised or an ERROR. This used to be two
+# `if [ "$1" = "--flag" ]` blocks with no else, so ANY other argument fell
+# straight through to the deploy: `--help`, `--dry-run`, `-n`, or a typo like
+# `--selftest` all pushed config to the production gateway and restarted it.
+# The two safest-sounding things a person types when they are unsure what a
+# script does were the two most dangerous.
+#
+# A deploy now requires exactly zero arguments. Anything unrecognised prints
+# usage and exits 2 without touching the VM.
+case "${1:-}" in
+--verify-only | --self-test | "") ;;
+-h | --help)
+	cat <<-USAGE
+		usage: deploy-gateway.sh [--verify-only | --self-test]
+
+		  (no arguments)   deploy ops/central-observability/ to the gateway VM,
+		                   then assert both public hostnames reject
+		                   unauthenticated callers
+		  --verify-only    run only that assertion, against the live gateway,
+		                   deploying nothing
+		  --self-test      offline check of the status classifier
+
+		env: GATEWAY_VM GATEWAY_ZONE GATEWAY_PROJECT GATEWAY_DOMAIN
+		     OO_UI_DOMAIN PROBE_TIMEOUT_S PROBE_INTERVAL_S
+	USAGE
+	exit 0
+	;;
+*)
+	echo "deploy-gateway.sh: unknown argument '${1}'" >&2
+	echo "run with --help for usage; a deploy takes NO arguments" >&2
+	exit 2
+	;;
+esac
+
 # Run the auth assertion on its own, without deploying anything. Two uses: an
 # operator re-checking a gateway they did not just deploy, and testing a change
 # to the probes themselves — the alternative is running a production deploy to


### PR DESCRIPTION
Follow-up to #902. **Self-found while re-reading my own merged code, not from a review comment.**

## The bug I shipped

The flag handling in #902 was two bare `if` blocks with no `else`:

```sh
if [ "${1:-}" = "--verify-only" ]; then … fi
if [ "${1:-}" = "--self-test" ];   then … fi

echo "==> deploying …"     # <- everything else lands here
```

So **any** argument that was not exactly one of those two fell through to the deploy. `--help`, `--dry-run`, `-n`, and a typo like `--selftest` all scp'd config to the production gateway and restarted the stack.

The two safest-sounding things a person types when they are unsure what a script does — `--help` and `--dry-run` — were the two most dangerous.

## The fix

An explicit `case`: a deploy requires exactly **zero** arguments, `--help` prints usage, anything unrecognised exits 2 without touching the VM.

## Verified

| argument | before | after |
|---|---|---|
| `--dry-run` | **deploys** | exit 2, no gcloud call |
| `--selftest` (typo) | **deploys** | exit 2, no gcloud call |
| `-n` | **deploys** | exit 2, no gcloud call |
| `--deploy` | **deploys** | exit 2, no gcloud call |
| `--help` | **deploys** | exit 0, usage |
| `--self-test` | ok | ok |
| `--verify-only` | ok | ok (still 401 on all four probes against the live gateway) |

`bash -n` clean.

## Note

Worth saying plainly: #902 added a guard against an unauthenticated gateway and, in the same change, made it easier to deploy to that gateway by accident. Both halves were mine. This is the sort of thing the `pre-main` review gap does not catch — #902 merged with a green CodeRabbit check that was actually `Review skipped: reviews are disabled for this base branch`.