### PR TITLE
fix(sync): make the daemon the sole owner of the rotating Jira OAuth token

### DIFF
--- a/meridian-core/src/lib.rs
+++ b/meridian-core/src/lib.rs
@@ -44,6 +44,10 @@ pub mod settings;
 /// Notification delivery policy + native pending queue (ported from lib/notifications.ts).
 pub mod notifications;
 
+/// Single-owner PM sync request outbox (migration 082) - producers ask, the daemon
+/// alone services them, so the rotating Jira OAuth token has exactly one writer.
+pub mod pm_sync_requests;
+
 /// The `~/.meridian/plan_auto_opened` marker format — written by the tray's
 /// daily planner auto-open, read by the daemon's plan-nudge hold-back.
 pub mod plan_marker;

--- a/meridian-core/src/pm_sync_requests/mod.rs
+++ b/meridian-core/src/pm_sync_requests/mod.rs
@@ -1,0 +1,279 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Single-owner PM sync: the request side of the outbox (`pm_sync_requests`,
+//! migration 082).
+//!
+//! # Why sync is a request instead of an action
+//!
+//! An Atlassian OAuth refresh token is single-use and rotating. The old token dies
+//! the instant the new one is issued, so a lost response leaves the grant
+//! recoverable only inside a 10-minute window and permanently dead after it. That
+//! makes the token a resource with exactly ONE safe writer.
+//!
+//! It had several: the tray refreshed in-process, the daemon refreshed on its poll
+//! loop, and the tray spawned fresh `meridian pm-sync` / `tasks-sync` processes that
+//! each refreshed too. The advisory file lock meant to serialise them could not
+//! actually do it - its 10 s timeout is shorter than the ~26 s a refresh can take
+//! (3 attempts x 8 s plus backoff), and on timeout the code proceeded WITHOUT the
+//! lock rather than backing off. So two processes could spend the same token, and
+//! the only thing preventing corruption was Atlassian's grace window handing the
+//! loser the current pair.
+//!
+//! Producers now write a row here and the **daemon is the sole consumer**, so the
+//! credential is held by one process by construction rather than by lock discipline.
+//!
+//! # Who calls this
+//! - Producers: `tray/src-tauri/src/commands/tasks.rs` (window opens, tracker
+//!   connect, "Sync now"), and the `meridian tasks-sync` / `pm-sync` CLIs when a
+//!   daemon is running.
+//! - Consumer: the daemon's sync-request watcher (`src/intelligence/sync_requests.rs`).
+//!
+//! # Related
+//! - [`crate::notifications`] - the outbox pattern this mirrors.
+
+use anyhow::{Context, Result};
+use sqlx::SqlitePool;
+
+/// The all-providers request every current producer writes. A specific provider
+/// name scopes a request to one board, reserved for a future caller that needs it.
+pub const ALL_PROVIDERS: &str = "*";
+
+/// Whether the daemon should honour the per-provider staleness window or bypass it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncMode {
+    /// Honour the staleness window - the cheap common case (a window opening).
+    Gated,
+    /// Bypass it: the user explicitly asked (connected a tracker, pressed "Sync
+    /// now", ran a CLI).
+    Force,
+}
+
+impl SyncMode {
+    /// The stored discriminant. Kept as text so the row is readable in `sqlite3`
+    /// during support work.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SyncMode::Gated => "gated",
+            SyncMode::Force => "force",
+        }
+    }
+
+    /// Parse a stored discriminant, defaulting to the SAFER option. An unknown or
+    /// corrupt value must never silently become a `Force` that bypasses the
+    /// staleness gate and hammers the provider's API.
+    pub fn from_str_or_gated(s: &str) -> Self {
+        match s {
+            "force" => SyncMode::Force,
+            _ => SyncMode::Gated,
+        }
+    }
+}
+
+/// One pending request, as claimed by the daemon.
+#[derive(Debug, Clone)]
+pub struct SyncRequest {
+    pub provider: String,
+    pub mode: SyncMode,
+    pub reason: String,
+}
+
+/// Ask the daemon to sync PM tasks. Idempotent and coalescing: repeated calls
+/// collapse into the single pending row rather than queueing, so opening the
+/// dashboard ten times means "a sync is wanted", not ten syncs.
+///
+/// `mode` **escalates only**. A `Force` landing on a pending `Gated` upgrades it,
+/// because a user who just connected a tracker must not have that downgraded by a
+/// passing window focus; a `Gated` landing on a pending `Force` leaves the `Force`
+/// intact. Writing a new request also clears any previous completion stamps, so the
+/// row unambiguously represents work still to do.
+///
+/// `reason` is a producer tag for tracing only (`"dashboard_open"`,
+/// `"token_connected"`). Never pass user content - it is read back into logs.
+#[tracing::instrument(skip(pool))]
+pub async fn request(
+    pool: &SqlitePool,
+    provider: &str,
+    mode: SyncMode,
+    reason: &str,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO pm_sync_requests
+             (provider, mode, reason, requested_at, claimed_at, completed_at, error, synced_count)
+         VALUES (?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), NULL, NULL, NULL, NULL)
+         ON CONFLICT(provider) DO UPDATE SET
+             -- Escalate to 'force', never back down from it while still pending.
+             --
+             -- The `completed_at IS NULL` half is load-bearing: the row is kept after a
+             -- sync finishes (so \"Sync now\" can read its result), so without it a
+             -- SPENT 'force' would be inherited forever and every later gated request
+             -- would silently escalate. One tracker connect would then make every
+             -- planner open bypass the staleness gate and hit the provider for real -
+             -- reinstating the constant polling this whole design removes, and
+             -- multiplying exactly the token refreshes it exists to reduce.
+             mode = CASE
+                 WHEN excluded.mode = 'force'
+                   OR (pm_sync_requests.mode = 'force'
+                       AND pm_sync_requests.completed_at IS NULL)
+                      THEN 'force'
+                 ELSE excluded.mode
+             END,
+             reason       = excluded.reason,
+             requested_at = excluded.requested_at,
+             -- A fresh request re-opens the row: drop the in-flight and completion
+             -- marks so the watcher sees pending work again.
+             claimed_at   = NULL,
+             completed_at = NULL,
+             error        = NULL,
+             synced_count = NULL",
+    )
+    .bind(provider)
+    .bind(mode.as_str())
+    .bind(reason)
+    .execute(pool)
+    .await
+    .context("writing a PM sync request")?;
+    tracing::debug!(provider, mode = mode.as_str(), reason, "PM sync requested");
+    Ok(())
+}
+
+/// Claim the pending request for `provider`, if there is one, marking it in-flight
+/// so a second watcher tick can't pick up the same work.
+///
+/// The claim is a conditional UPDATE (`WHERE claimed_at IS NULL AND completed_at IS
+/// NULL`) rather than a read-then-write, so two daemons racing on the same file -
+/// which the single-instance guard makes unlikely but not impossible during a
+/// restart overlap - cannot both claim it. SQLite serialises the statement, so
+/// exactly one sees a non-zero `rows_affected`.
+#[tracing::instrument(skip(pool))]
+pub async fn claim(pool: &SqlitePool, provider: &str) -> Result<Option<SyncRequest>> {
+    let claimed = sqlx::query(
+        "UPDATE pm_sync_requests
+            SET claimed_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+          WHERE provider = ?
+            AND claimed_at IS NULL
+            AND completed_at IS NULL",
+    )
+    .bind(provider)
+    .execute(pool)
+    .await
+    .context("claiming a PM sync request")?;
+
+    if claimed.rows_affected() == 0 {
+        return Ok(None);
+    }
+
+    let row: Option<(String, String)> =
+        sqlx::query_as("SELECT mode, reason FROM pm_sync_requests WHERE provider = ?")
+            .bind(provider)
+            .fetch_optional(pool)
+            .await
+            .context("reading the claimed PM sync request")?;
+
+    Ok(row.map(|(mode, reason)| SyncRequest {
+        provider: provider.to_string(),
+        mode: SyncMode::from_str_or_gated(&mode),
+        reason,
+    }))
+}
+
+/// Record the outcome of a serviced request in place. The row is deliberately kept
+/// rather than deleted so `"Sync now"` can read a real result without holding the
+/// credential, and so support has a content-free view of the last attempt.
+///
+/// Writes only if the row is still the one that was claimed. The guard is
+/// **`claimed_at IS NOT NULL`**, and that specific predicate is the whole point:
+/// [`request`] resets `claimed_at` to `NULL`, so a request that arrived mid-sync
+/// makes this UPDATE match nothing. Guarding on `completed_at IS NULL` alone would
+/// NOT work - the fresh request leaves that NULL too, so the older sync's outcome
+/// would stamp the new request as done without it ever being serviced, and the
+/// user's "Sync now" would report success for a sync that never ran.
+#[tracing::instrument(skip(pool))]
+pub async fn complete(
+    pool: &SqlitePool,
+    provider: &str,
+    synced_count: Option<i64>,
+    error: Option<&str>,
+) -> Result<()> {
+    sqlx::query(
+        "UPDATE pm_sync_requests
+            SET completed_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'),
+                error        = ?,
+                synced_count = ?
+          WHERE provider = ?
+            AND claimed_at IS NOT NULL
+            AND completed_at IS NULL",
+    )
+    .bind(error)
+    .bind(synced_count)
+    .bind(provider)
+    .execute(pool)
+    .await
+    .context("completing a PM sync request")?;
+    Ok(())
+}
+
+/// Release claims left in flight by a daemon that died mid-sync, so the request
+/// becomes claimable again. Call once at watcher startup.
+///
+/// Without this a crash, a `meridian restart`, or a SIGKILL between [`claim`] and
+/// [`complete`] strands the row **claimed but never completed** - and since [`claim`]
+/// requires `claimed_at IS NULL`, no future tick would ever pick it up. PM sync
+/// would then be silently dead until the next new request happened to reset the row.
+/// Same reasoning as the daemon's `cleanup_incomplete_runs` for partial ETL runs.
+///
+/// Only ever widens what is claimable, so it is safe to run unconditionally on every
+/// boot: a genuinely in-flight sync cannot exist yet, because the only consumer is
+/// the watcher this runs before.
+#[tracing::instrument(skip(pool))]
+pub async fn reset_stale_claims(pool: &SqlitePool) -> Result<u64> {
+    let res = sqlx::query(
+        "UPDATE pm_sync_requests
+            SET claimed_at = NULL
+          WHERE claimed_at IS NOT NULL
+            AND completed_at IS NULL",
+    )
+    .execute(pool)
+    .await
+    .context("resetting stale PM sync request claims")?;
+    let n = res.rows_affected();
+    if n > 0 {
+        tracing::info!(
+            reset = n,
+            "released PM sync claims stranded by a previous daemon exit"
+        );
+    }
+    Ok(n)
+}
+
+/// The outcome of the last request for `provider`, for a producer that wants to
+/// show one ("Sync now"). `None` while the request is still pending or in flight,
+/// so a caller can poll this until it turns `Some`.
+pub async fn outcome(pool: &SqlitePool, provider: &str) -> Result<Option<SyncOutcome>> {
+    let row: Option<(Option<String>, Option<String>, Option<i64>)> = sqlx::query_as(
+        "SELECT completed_at, error, synced_count FROM pm_sync_requests WHERE provider = ?",
+    )
+    .bind(provider)
+    .fetch_optional(pool)
+    .await
+    .context("reading the PM sync outcome")?;
+
+    Ok(match row {
+        Some((Some(_completed), error, synced_count)) => Some(SyncOutcome {
+            error,
+            synced_count,
+        }),
+        // No row, or a row still pending / in flight.
+        _ => None,
+    })
+}
+
+/// A completed request's result.
+#[derive(Debug, Clone)]
+pub struct SyncOutcome {
+    /// `None` on success, the failure detail otherwise.
+    pub error: Option<String>,
+    /// Tasks refreshed, when the daemon reported a count.
+    pub synced_count: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests;

--- a/meridian-core/src/pm_sync_requests/tests.rs
+++ b/meridian-core/src/pm_sync_requests/tests.rs
@@ -1,0 +1,266 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Tests for the PM sync request outbox.
+//!
+//! Split out of `mod.rs` purely for the 500-line file cap; they are the module's own
+//! unit tests and belong to it. Each one pins a race or a policy that is invisible
+//! from the SQL alone - read them alongside the doc comment on the function they
+//! exercise.
+
+use super::*;
+use sqlx::sqlite::SqliteConnectOptions;
+use std::str::FromStr;
+
+async fn db() -> SqlitePool {
+    let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+        .unwrap()
+        .create_if_missing(true);
+    let pool = SqlitePool::connect_with(opts).await.unwrap();
+    sqlx::query(
+        "CREATE TABLE pm_sync_requests (
+             provider TEXT NOT NULL PRIMARY KEY,
+             mode TEXT NOT NULL DEFAULT 'gated',
+             reason TEXT NOT NULL DEFAULT '',
+             requested_at TEXT NOT NULL,
+             claimed_at TEXT,
+             completed_at TEXT,
+             error TEXT,
+             synced_count INTEGER
+         )",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    pool
+}
+
+/// Repeated requests must COALESCE into one pending row. Ten planner opens
+/// mean "a sync is wanted", not ten syncs.
+#[tokio::test]
+async fn repeated_requests_coalesce_into_one_row() {
+    let pool = db().await;
+    for _ in 0..10 {
+        request(&pool, ALL_PROVIDERS, SyncMode::Gated, "dashboard_open")
+            .await
+            .unwrap();
+    }
+    let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM pm_sync_requests")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(n, 1);
+}
+
+/// A user action must not be downgraded by a passing window focus.
+#[tokio::test]
+async fn force_survives_a_later_gated_request() {
+    let pool = db().await;
+    request(&pool, ALL_PROVIDERS, SyncMode::Force, "token_connected")
+        .await
+        .unwrap();
+    request(&pool, ALL_PROVIDERS, SyncMode::Gated, "dashboard_open")
+        .await
+        .unwrap();
+
+    let req = claim(&pool, ALL_PROVIDERS).await.unwrap().expect("pending");
+    assert_eq!(req.mode, SyncMode::Force);
+}
+
+/// ...and a user action must be able to escalate a pending gated request.
+#[tokio::test]
+async fn gated_escalates_to_force() {
+    let pool = db().await;
+    request(&pool, ALL_PROVIDERS, SyncMode::Gated, "dashboard_open")
+        .await
+        .unwrap();
+    request(&pool, ALL_PROVIDERS, SyncMode::Force, "sync_now")
+        .await
+        .unwrap();
+
+    let req = claim(&pool, ALL_PROVIDERS).await.unwrap().expect("pending");
+    assert_eq!(req.mode, SyncMode::Force);
+}
+
+/// A *spent* force must NOT be inherited. The row survives completion so "Sync
+/// now" can read its result, so escalation has to be scoped to a still-pending
+/// row - otherwise one tracker connect leaves `mode = 'force'` set forever and
+/// every later planner open bypasses the staleness gate and hits the provider
+/// for real, multiplying the token refreshes this design exists to reduce.
+#[tokio::test]
+async fn a_completed_force_does_not_escalate_the_next_gated_request() {
+    let pool = db().await;
+    request(&pool, ALL_PROVIDERS, SyncMode::Force, "token_connected")
+        .await
+        .unwrap();
+    claim(&pool, ALL_PROVIDERS).await.unwrap();
+    complete(&pool, ALL_PROVIDERS, Some(4), None).await.unwrap();
+
+    // A later window open wants the cheap, gated behaviour.
+    request(&pool, ALL_PROVIDERS, SyncMode::Gated, "dashboard_open")
+        .await
+        .unwrap();
+
+    let req = claim(&pool, ALL_PROVIDERS).await.unwrap().expect("pending");
+    assert_eq!(
+        req.mode,
+        SyncMode::Gated,
+        "a spent force must not escalate later gated requests"
+    );
+}
+
+/// The in-flight case still escalates: a force that is claimed but not completed
+/// will have its outcome discarded by `complete`'s guard and be re-serviced, so
+/// the force intent must survive into that re-run.
+#[tokio::test]
+async fn an_in_flight_force_still_survives_a_gated_request() {
+    let pool = db().await;
+    request(&pool, ALL_PROVIDERS, SyncMode::Force, "sync_now")
+        .await
+        .unwrap();
+    claim(&pool, ALL_PROVIDERS).await.unwrap();
+
+    request(&pool, ALL_PROVIDERS, SyncMode::Gated, "dashboard_open")
+        .await
+        .unwrap();
+
+    let req = claim(&pool, ALL_PROVIDERS).await.unwrap().expect("pending");
+    assert_eq!(req.mode, SyncMode::Force);
+}
+
+/// A claim is exclusive: the second attempt sees nothing, so two watcher ticks
+/// can never run the same sync twice.
+#[tokio::test]
+async fn claim_is_exclusive() {
+    let pool = db().await;
+    request(&pool, ALL_PROVIDERS, SyncMode::Gated, "dashboard_open")
+        .await
+        .unwrap();
+    assert!(claim(&pool, ALL_PROVIDERS).await.unwrap().is_some());
+    assert!(
+        claim(&pool, ALL_PROVIDERS).await.unwrap().is_none(),
+        "a claimed request must not be claimable again"
+    );
+}
+
+/// Nothing pending is a quiet `None`, not an error - the watcher ticks on this
+/// constantly.
+#[tokio::test]
+async fn claim_with_no_request_is_none() {
+    let pool = db().await;
+    assert!(claim(&pool, ALL_PROVIDERS).await.unwrap().is_none());
+}
+
+/// A daemon killed between claim and complete must not strand PM sync forever.
+/// Without the reset the row stays claimed, `claim` requires `claimed_at IS
+/// NULL`, and no future tick could ever service it.
+#[tokio::test]
+async fn stale_claims_are_released_on_startup() {
+    let pool = db().await;
+    request(&pool, ALL_PROVIDERS, SyncMode::Force, "sync_now")
+        .await
+        .unwrap();
+    claim(&pool, ALL_PROVIDERS).await.unwrap();
+    // ... daemon dies here, no `complete` ever runs.
+
+    assert!(
+        claim(&pool, ALL_PROVIDERS).await.unwrap().is_none(),
+        "precondition: a stranded claim blocks re-claiming"
+    );
+
+    assert_eq!(reset_stale_claims(&pool).await.unwrap(), 1);
+
+    let req = claim(&pool, ALL_PROVIDERS)
+        .await
+        .unwrap()
+        .expect("the request must be serviceable again after the reset");
+    assert_eq!(req.mode, SyncMode::Force);
+}
+
+/// The reset must not disturb a request that already completed - that would
+/// re-run finished work on every daemon boot.
+#[tokio::test]
+async fn reset_leaves_completed_requests_alone() {
+    let pool = db().await;
+    request(&pool, ALL_PROVIDERS, SyncMode::Gated, "dashboard_open")
+        .await
+        .unwrap();
+    claim(&pool, ALL_PROVIDERS).await.unwrap();
+    complete(&pool, ALL_PROVIDERS, Some(2), None).await.unwrap();
+
+    assert_eq!(reset_stale_claims(&pool).await.unwrap(), 0);
+    assert!(
+        claim(&pool, ALL_PROVIDERS).await.unwrap().is_none(),
+        "a completed request must stay completed"
+    );
+}
+
+/// The outcome is invisible until the daemon finishes, so a producer polling it
+/// can tell "still working" from "done".
+#[tokio::test]
+async fn outcome_is_none_until_completed() {
+    let pool = db().await;
+    request(&pool, ALL_PROVIDERS, SyncMode::Force, "sync_now")
+        .await
+        .unwrap();
+    assert!(outcome(&pool, ALL_PROVIDERS).await.unwrap().is_none());
+
+    claim(&pool, ALL_PROVIDERS).await.unwrap();
+    assert!(
+        outcome(&pool, ALL_PROVIDERS).await.unwrap().is_none(),
+        "in-flight must still read as pending"
+    );
+
+    complete(&pool, ALL_PROVIDERS, Some(7), None).await.unwrap();
+    let out = outcome(&pool, ALL_PROVIDERS).await.unwrap().expect("done");
+    assert_eq!(out.synced_count, Some(7));
+    assert!(out.error.is_none());
+}
+
+/// A failure is reported, not swallowed.
+#[tokio::test]
+async fn outcome_carries_the_error() {
+    let pool = db().await;
+    request(&pool, ALL_PROVIDERS, SyncMode::Force, "sync_now")
+        .await
+        .unwrap();
+    claim(&pool, ALL_PROVIDERS).await.unwrap();
+    complete(&pool, ALL_PROVIDERS, None, Some("401 unauthorized"))
+        .await
+        .unwrap();
+
+    let out = outcome(&pool, ALL_PROVIDERS).await.unwrap().expect("done");
+    assert_eq!(out.error.as_deref(), Some("401 unauthorized"));
+}
+
+/// THE RACE THIS GUARDS: a request arriving mid-sync resets the row, and the
+/// older sync's outcome must NOT stamp it complete - that would mark the new
+/// request done without ever servicing it.
+#[tokio::test]
+async fn completion_does_not_clobber_a_request_that_arrived_mid_sync() {
+    let pool = db().await;
+    request(&pool, ALL_PROVIDERS, SyncMode::Gated, "dashboard_open")
+        .await
+        .unwrap();
+    claim(&pool, ALL_PROVIDERS).await.unwrap();
+
+    // A new request lands while the first sync is still running.
+    request(&pool, ALL_PROVIDERS, SyncMode::Force, "sync_now")
+        .await
+        .unwrap();
+
+    // The in-flight sync finishes and tries to report. This must be a NO-OP:
+    // the new request cleared `claimed_at`, so the guard rejects it.
+    complete(&pool, ALL_PROVIDERS, Some(3), None).await.unwrap();
+
+    assert!(
+        outcome(&pool, ALL_PROVIDERS).await.unwrap().is_none(),
+        "the older sync's outcome must NOT mark the new request complete - \
+         that would report success for a sync that never ran"
+    );
+
+    let req = claim(&pool, ALL_PROVIDERS)
+        .await
+        .unwrap()
+        .expect("the mid-sync request must still be pending");
+    assert_eq!(req.mode, SyncMode::Force);
+    assert_eq!(req.reason, "sync_now");
+}

--- a/meridian-oauth/src/jira/mod.rs
+++ b/meridian-oauth/src/jira/mod.rs
@@ -236,8 +236,58 @@ pub async fn login(client_id: &str, client_secret: &str, port: u16) -> Result<St
     Ok(site_url)
 }
 
+/// Seconds of margin before `expires_at` at which the access token is treated as
+/// expired. Stops a request being issued with a token that expires while it is
+/// still in flight.
+pub const EXPIRY_SKEW_SECS: i64 = 120;
+
+/// The stored tokens IF the access token is still usable — never a network call,
+/// never a refresh. `None` means "no store, unreadable store, or the access token
+/// has expired", and the caller must NOT interpret that as an error.
+///
+/// # Why this exists
+///
+/// Spending the rotating refresh token is only safe when a human is present. The
+/// POST is a single-use exchange: Atlassian retires the old token the moment it
+/// issues the replacement, so if the reply is lost the grant is dead, recoverable
+/// only inside Atlassian's 10-minute reuse-leeway window. A refresh fired from a
+/// background timer can therefore be destroyed by a laptop lid closing, with
+/// nobody watching and nothing to retry against — which is exactly how a
+/// production install lost its Jira grant permanently (a refresh POST at 18:26:55
+/// straddled a 28-minute suspend; the retry, instant on wake at 18:55:29, was 18
+/// minutes outside the window).
+///
+/// So the rule this function enforces: **unattended code may USE a valid access
+/// token but must never MINT one.** Anything on a clock — the worklog drafting
+/// sweep, retention passes, any future scheduled job — calls this. Anything on
+/// the path of a real user action calls [`ensure_fresh`] instead, where the
+/// machine is provably awake and in use because someone just clicked something.
+///
+/// Deferring costs nothing in practice: an unattended sweep that finds an expired
+/// token is, by definition, running while nobody is at the machine, and the next
+/// attended request refreshes properly.
+///
+/// # Related
+/// - [`ensure_fresh`] — the attended counterpart, which may refresh.
+/// - [`crate::store::OAuthTokens::is_expired`] — the expiry predicate used here.
+pub fn current_if_valid() -> Option<OAuthTokens> {
+    let t = store::load("jira").ok()?;
+    if t.is_expired(now_unix(), EXPIRY_SKEW_SECS) {
+        tracing::debug!(
+            "jira access token expired - unattended caller deferring rather than refreshing"
+        );
+        return None;
+    }
+    Some(t)
+}
+
 /// Load the stored tokens, refreshing the access token if it's within 120 s of
 /// expiry. Persists the rotated refresh token. Returns ready-to-use tokens.
+///
+/// **Only call this on the path of a real user action.** Spending the rotating
+/// refresh token from a background timer is what permanently kills a grant when
+/// the machine suspends mid-request; see [`current_if_valid`] for the full
+/// reasoning and the unattended alternative.
 ///
 /// Refreshes are serialised on TWO levels so the rotating refresh token is never
 /// double-spent: a static mutex within this process, and an advisory FILE lock
@@ -250,7 +300,7 @@ pub async fn ensure_fresh() -> Result<OAuthTokens> {
 
     // Fast path: a still-fresh token needs neither a refresh nor the file lock.
     let t = store::load("jira")?;
-    if !t.is_expired(now_unix(), 120) {
+    if !t.is_expired(now_unix(), EXPIRY_SKEW_SECS) {
         return Ok(t);
     }
 
@@ -273,7 +323,7 @@ pub async fn ensure_fresh() -> Result<OAuthTokens> {
     // adopt their token instead of refreshing again with the dead one. This
     // double-check is what actually breaks the race.
     let mut t = store::load("jira")?;
-    if !t.is_expired(now_unix(), 120) {
+    if !t.is_expired(now_unix(), EXPIRY_SKEW_SECS) {
         tracing::debug!("jira token already refreshed by another process — adopting it");
         return Ok(t);
     }
@@ -370,50 +420,4 @@ impl JiraReqCtx {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn oauth_ctx() -> JiraReqCtx {
-        JiraReqCtx::OAuth {
-            token: "tok".into(),
-            cloud_id: "cloud-xyz".into(),
-            site_url: "https://acme.atlassian.net".into(),
-        }
-    }
-
-    fn basic_ctx() -> JiraReqCtx {
-        JiraReqCtx::Basic {
-            base_url: "https://acme.atlassian.net/".into(),
-            email: "a@b.com".into(),
-            api_token: "tok".into(),
-        }
-    }
-
-    #[test]
-    fn oauth_api_url_uses_gateway() {
-        assert_eq!(
-            oauth_ctx().api_url("/rest/api/3/search/jql"),
-            "https://api.atlassian.com/ex/jira/cloud-xyz/rest/api/3/search/jql"
-        );
-    }
-
-    #[test]
-    fn basic_api_url_uses_site_and_trims_slash() {
-        assert_eq!(
-            basic_ctx().api_url("/rest/api/3/search/jql"),
-            "https://acme.atlassian.net/rest/api/3/search/jql"
-        );
-    }
-
-    #[test]
-    fn browse_url_uses_site_in_both_modes() {
-        assert_eq!(
-            oauth_ctx().browse_url("KAN-1"),
-            "https://acme.atlassian.net/browse/KAN-1"
-        );
-        assert_eq!(
-            basic_ctx().browse_url("KAN-1"),
-            "https://acme.atlassian.net/browse/KAN-1"
-        );
-    }
-}
+mod tests;

--- a/meridian-oauth/src/jira/tests.rs
+++ b/meridian-oauth/src/jira/tests.rs
@@ -1,0 +1,121 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Tests for the Jira OAuth flow and token handling.
+//!
+//! Split out of `mod.rs` for the 500-line file cap; they are this module's own unit
+//! tests. The `current_if_valid` cases pin the attended/unattended split - the rule
+//! that unattended code may USE a valid access token but must never MINT one, which
+//! is what stops a background refresh being destroyed by a laptop suspend.
+
+use super::*;
+
+fn oauth_ctx() -> JiraReqCtx {
+    JiraReqCtx::OAuth {
+        token: "tok".into(),
+        cloud_id: "cloud-xyz".into(),
+        site_url: "https://acme.atlassian.net".into(),
+    }
+}
+
+fn basic_ctx() -> JiraReqCtx {
+    JiraReqCtx::Basic {
+        base_url: "https://acme.atlassian.net/".into(),
+        email: "a@b.com".into(),
+        api_token: "tok".into(),
+    }
+}
+
+#[test]
+fn oauth_api_url_uses_gateway() {
+    assert_eq!(
+        oauth_ctx().api_url("/rest/api/3/search/jql"),
+        "https://api.atlassian.com/ex/jira/cloud-xyz/rest/api/3/search/jql"
+    );
+}
+
+#[test]
+fn basic_api_url_uses_site_and_trims_slash() {
+    assert_eq!(
+        basic_ctx().api_url("/rest/api/3/search/jql"),
+        "https://acme.atlassian.net/rest/api/3/search/jql"
+    );
+}
+
+#[test]
+fn browse_url_uses_site_in_both_modes() {
+    assert_eq!(
+        oauth_ctx().browse_url("KAN-1"),
+        "https://acme.atlassian.net/browse/KAN-1"
+    );
+    assert_eq!(
+        basic_ctx().browse_url("KAN-1"),
+        "https://acme.atlassian.net/browse/KAN-1"
+    );
+}
+
+/// Seed a jira token store under a private `$HOME` with `expires_at` at
+/// `now + offset_secs`. Returns the guard that keeps `$HOME` stable for the
+/// duration of the test.
+fn seed_store(tag: &str, offset_secs: i64) -> std::sync::MutexGuard<'static, ()> {
+    let guard = crate::env_test_guard();
+    let dir = std::env::temp_dir().join(format!("meridian_oauth_civ_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::env::set_var("HOME", &dir);
+    store::save(&OAuthTokens {
+        provider: "jira".into(),
+        client_id: "cid".into(),
+        access_token: "access".into(),
+        refresh_token: "refresh".into(),
+        expires_at: now_unix() + offset_secs,
+        scopes: String::new(),
+        cloud_id: "cloud-xyz".into(),
+        site_url: "https://acme.atlassian.net".into(),
+    })
+    .expect("seeding the token store should succeed");
+    guard
+}
+
+/// A comfortably-valid access token is handed straight back, so an unattended
+/// sweep can still refresh the ticket cache without touching the network.
+#[test]
+fn current_if_valid_returns_a_live_token() {
+    let _g = seed_store("live", 3600);
+    let t = current_if_valid().expect("a token an hour from expiry must be usable");
+    assert_eq!(t.access_token, "access");
+    assert_eq!(t.cloud_id, "cloud-xyz");
+}
+
+/// THE POINT OF THE FUNCTION: an expired token yields `None` rather than
+/// triggering a refresh. Spending the rotating refresh token unattended is what
+/// permanently kills a grant when the machine suspends mid-POST, so a
+/// clock-driven caller must defer instead.
+#[test]
+fn current_if_valid_refuses_to_mint_when_expired() {
+    let _g = seed_store("expired", -10);
+    assert!(
+        current_if_valid().is_none(),
+        "an expired token must NOT be returned - the caller would use it and 401, \
+         and the whole point is to defer to the next attended request"
+    );
+}
+
+/// The skew is applied, not just raw expiry: a token inside the margin counts as
+/// expired so a request can't be issued with one that dies mid-flight.
+#[test]
+fn current_if_valid_applies_the_expiry_skew() {
+    let _g = seed_store("skew", EXPIRY_SKEW_SECS - 10);
+    assert!(
+        current_if_valid().is_none(),
+        "a token inside the {EXPIRY_SKEW_SECS}s skew must be treated as expired"
+    );
+}
+
+/// No store at all is a `None`, never a panic or an error — an install that has
+/// never connected Jira must sweep quietly.
+#[test]
+fn current_if_valid_handles_a_missing_store() {
+    let _g = crate::env_test_guard();
+    let dir = std::env::temp_dir().join(format!("meridian_oauth_civ_none_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::env::set_var("HOME", &dir);
+    assert!(current_if_valid().is_none());
+}

--- a/src/health/jira.rs
+++ b/src/health/jira.rs
@@ -5,15 +5,22 @@
 // collapses both into a silent warn. Sync freshness + candidate count come from
 // meridian.db (content-free). Creds are read from the env (loaded via dotenv at
 // startup), so this works without reaching into Config internals.
+//
+// `sync_freshness` is outcome-driven (`pm_sync_state.last_error`), not
+// elapsed-time-driven. Syncing is on-demand now (the daily plan, the match-to-ticket
+// picker, connecting a tracker, a board write, manual "Sync now") rather than a
+// background poller ticking every ~5 minutes forever — so a quiet period with no sync
+// attempt is normal, not a symptom. A laptop shut overnight is the everyday case: it
+// wakes with a cache many hours old and nothing wrong. `last_error` reflects the actual outcome of the last attempted fetch
+// (set by `intelligence::providers::record_sync_failure`, cleared by
+// `clear_sync_error` on the next success), which stays correct however long that
+// was ago.
 
 use crate::config::Config;
 use crate::health::Check;
 use crate::intelligence::oauth::{jira as oauth_jira, store as oauth_store};
 use sqlx::SqlitePool;
 use std::time::Duration;
-
-/// Cache older than this (2× the 30-min sync interval) ⇒ fetch likely failing.
-const SYNC_STALE_SECS: f64 = 3600.0;
 
 pub async fn checks(_cfg: &Config, pool: Option<&SqlitePool>) -> Vec<Check> {
     let mut out = Vec::new();
@@ -133,28 +140,29 @@ async fn classify_auth(send: reqwest::Result<reqwest::Response>) -> Check {
 }
 
 async fn sync_freshness(pool: &SqlitePool) -> Check {
-    match sqlx::query_scalar::<_, Option<f64>>(
-        "SELECT (julianday('now') - julianday(MAX(last_synced_at))) * 86400.0
+    match sqlx::query_as::<_, (Option<String>, Option<f64>)>(
+        "SELECT last_error, (julianday('now') - julianday(last_synced_at)) * 86400.0
          FROM pm_sync_state WHERE provider = 'jira'",
     )
-    .fetch_one(pool)
+    .fetch_optional(pool)
     .await
     {
-        Ok(Some(age)) if age > SYNC_STALE_SECS => Check::warn(
+        // A recorded failure is the real signal — the last attempted fetch didn't
+        // work, regardless of how long ago that was. Never a warn from elapsed time
+        // alone: a long quiet period between on-demand syncs is expected now.
+        Ok(Some((Some(err), _))) => {
+            Check::warn("ticket sync", "L3", format!("sync failing: {err}")).with_remedy(
+                "check the auth row above, or Reconnect Jira in Settings - Integrations",
+            )
+        }
+        Ok(Some((None, Some(age)))) => Check::ok(
             "ticket sync",
             "L3",
-            format!(
-                "cache {:.0}m stale — fetch may be failing silently",
-                age / 60.0
-            ),
-        )
-        .with_remedy("check the auth row above; the daemon refreshes every 30m"),
-        Ok(Some(age)) => Check::ok(
-            "ticket sync",
-            "L3",
-            format!("fresh ({:.0}m ago)", age / 60.0),
+            format!("last synced {:.0}m ago, no errors", age / 60.0),
         ),
-        Ok(None) => Check::info("ticket sync", "L3", "no Jira sync recorded yet"),
+        Ok(Some((None, None))) | Ok(None) => {
+            Check::info("ticket sync", "L3", "no Jira sync recorded yet")
+        }
         Err(e) => Check::warn(
             "ticket sync",
             "L3",
@@ -186,5 +194,74 @@ async fn candidate_count(pool: &SqlitePool) -> Check {
             "L3",
             format!("could not count pm_tasks ({e})"),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::health::Severity;
+    use sqlx::sqlite::SqliteConnectOptions;
+    use std::str::FromStr;
+
+    async fn make_db() -> SqlitePool {
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+            .unwrap()
+            .create_if_missing(true);
+        let pool = SqlitePool::connect_with(opts).await.unwrap();
+        sqlx::migrate!("src/migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    async fn seed(pool: &SqlitePool, synced_modifier: &str, last_error: Option<&str>) {
+        sqlx::query(
+            "INSERT INTO pm_sync_state (provider, last_synced_at, last_error)
+             VALUES ('jira', strftime('%Y-%m-%dT%H:%M:%SZ', 'now', ?), ?)",
+        )
+        .bind(synced_modifier)
+        .bind(last_error)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// The false positive this rewrite exists to fix: a sync that hasn't run in
+    /// hours, with no recorded error, must NOT warn — on-demand syncing means a
+    /// long quiet period is expected, not a symptom.
+    #[tokio::test]
+    async fn sync_freshness_ok_when_stale_but_no_error() {
+        let pool = make_db().await;
+        seed(&pool, "-6 hours", None).await;
+
+        let check = sync_freshness(&pool).await;
+
+        assert_eq!(check.severity, Severity::Ok, "detail was: {}", check.detail);
+    }
+
+    /// A recorded fetch failure is the real signal, regardless of how recent it is.
+    #[tokio::test]
+    async fn sync_freshness_warns_on_recorded_error() {
+        let pool = make_db().await;
+        seed(&pool, "-2 minutes", Some("401 unauthorized")).await;
+
+        let check = sync_freshness(&pool).await;
+
+        assert_eq!(check.severity, Severity::Warn);
+        assert!(
+            check.detail.contains("401 unauthorized"),
+            "detail was: {}",
+            check.detail
+        );
+    }
+
+    /// A tracker that has never synced (fresh connect, or one that's never
+    /// fetched successfully) reports as informational, not a warning.
+    #[tokio::test]
+    async fn sync_freshness_info_when_never_synced() {
+        let pool = make_db().await;
+
+        let check = sync_freshness(&pool).await;
+
+        assert_eq!(check.severity, Severity::Info);
     }
 }

--- a/src/intelligence/mod.rs
+++ b/src/intelligence/mod.rs
@@ -3,13 +3,36 @@
 pub mod oauth;
 pub mod providers;
 pub mod session_categorizer;
+/// Producer side of the `pm_sync_requests` outbox for short-lived CLI processes — how
+/// `plan-task-*`, `ticket-update` and `worklog-generate` refresh the board without
+/// becoming a second writer of the rotating Jira OAuth token.
+pub mod sync_delegate;
+/// Daemon-side consumer of the `pm_sync_requests` outbox — the reason the daemon is
+/// the only process that ever holds the rotating Jira OAuth token.
+pub mod sync_requests;
 pub mod task_triage;
 pub mod ticket_update;
 
 use anyhow::Result;
 use sqlx::SqlitePool;
+use std::sync::OnceLock;
+use tokio::sync::Mutex;
 
 use crate::config::{Config, PmProviderConfig};
+
+/// In-process serialisation for [`run_pm_sync`]. Now that syncing is triggered from
+/// several independent on-demand call sites (the daily plan, worklog drafting sweep,
+/// `meridian pm-sync`) instead of one single poll-loop tick, two of them can land in
+/// the same instant — e.g. opening the planner while a drafting sweep is mid-flight.
+/// Both would otherwise read `pm_sync_state` as stale and fire a real fetch
+/// concurrently, wasting a call for every redundant racer. This only dedups within
+/// ONE process; the Jira OAuth refresh-token race across processes is a separate,
+/// already-solved problem (`meridian-oauth/src/store.rs::lock_provider`, a
+/// cross-process file lock inside the refresh path itself).
+fn sync_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
 
 /// True once at least one PM task is cached. Rows only land in `pm_tasks` after a
 /// provider authenticated and fetched successfully, so a non-zero count is proof
@@ -73,20 +96,74 @@ pub async fn run_pm_force_sync(meridian: &SqlitePool, config: &Config) -> Result
     Ok(())
 }
 
-/// Refreshes PM task caches from all configured providers.
+/// Whether a sync is happening behind a real user action or on a clock. Only Jira
+/// OAuth cares, and the difference is not cosmetic: see [`Trigger::Unattended`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Trigger {
+    /// A human just did something — opened the planner, connected a tracker,
+    /// pressed Sync now, edited a ticket, ran a CLI. The machine is provably awake
+    /// and in use, so spending the rotating refresh token is safe.
+    Attended,
+    /// A clock fired and nobody is necessarily there (the hourly worklog drafting
+    /// sweep). Jira OAuth must NOT refresh here: the refresh is a single-use
+    /// exchange whose lost response kills the grant permanently outside a
+    /// 10-minute window, and a laptop suspending mid-POST is exactly how that
+    /// happens with no one watching. An expired token means skip this pass; the
+    /// next attended request refreshes properly. Providers with static
+    /// credentials (GitHub/Linear/Trello/Azure) are unaffected — they have no
+    /// rotating credential to lose.
+    Unattended,
+}
+
+/// Refreshes PM task caches from all configured providers whose cache has gone
+/// stale, behind a real user action. See [`run_pm_sync_with`] for the shared body
+/// and [`Trigger`] for why the distinction exists.
 #[tracing::instrument(skip_all)]
 pub async fn run_pm_sync(meridian: &SqlitePool, config: &Config) -> Result<()> {
+    run_pm_sync_with(meridian, config, Trigger::Attended).await
+}
+
+/// [`run_pm_sync`] for clock-driven callers: refreshes the ticket cache only if it
+/// can be done without minting a new Jira OAuth token, and quietly keeps the stale
+/// cache otherwise. Used by the hourly worklog drafting sweep.
+#[tracing::instrument(skip_all)]
+pub async fn run_pm_sync_unattended(meridian: &SqlitePool, config: &Config) -> Result<()> {
+    run_pm_sync_with(meridian, config, Trigger::Unattended).await
+}
+
+/// Refreshes PM task caches from all configured providers whose cache has gone stale
+/// (per-provider `refresh_if_stale`) — a cheap no-op when nothing is stale. Called
+/// from every on-demand trigger (the daily plan, worklog drafting, `meridian
+/// pm-sync`), not a timer, so [`sync_lock`] serialises same-process callers that land
+/// in the same instant rather than each racing the staleness check independently.
+#[tracing::instrument(skip(meridian, config))]
+pub async fn run_pm_sync_with(
+    meridian: &SqlitePool,
+    config: &Config,
+    trigger: Trigger,
+) -> Result<()> {
     if config.pm_providers.is_empty() {
         tracing::warn!("no PM providers configured — pm_tasks will stay empty (set JIRA_BASE_URL/GITHUB_TOKEN/LINEAR_API_KEY/AZURE_DEVOPS_PAT)");
         return Ok(());
     }
+
+    let _guard = match sync_lock().try_lock() {
+        Ok(g) => g,
+        Err(_) => {
+            tracing::debug!("run_pm_sync: another sync is already in flight — waiting for it");
+            sync_lock().lock().await
+        }
+    };
+
     let provider_count = config.pm_providers.len();
     tracing::debug!(provider_count, "syncing PM providers");
 
     for provider in &config.pm_providers {
         let name = provider.provider_name();
         let result = match provider {
-            PmProviderConfig::Jira(cfg) => providers::jira::refresh_if_stale(meridian, cfg).await,
+            PmProviderConfig::Jira(cfg) => {
+                providers::jira::refresh_if_stale(meridian, cfg, trigger).await
+            }
             PmProviderConfig::GitHub(cfg) => {
                 providers::github::refresh_if_stale(meridian, cfg).await
             }
@@ -219,5 +296,37 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(queued, 0, "the board hygiene digest producer was removed");
+    }
+
+    /// `run_pm_sync` now fires from several independent on-demand callers instead of
+    /// one poll-loop tick, so two of them can land in the same instant. This proves
+    /// [`sync_lock`] actually serialises concurrent holders rather than being a no-op
+    /// — tested directly against the lock primitive since exercising the full
+    /// `run_pm_sync` path needs a live (or mocked) provider HTTP call this crate has
+    /// no test seam for.
+    #[tokio::test]
+    async fn sync_lock_serialises_concurrent_holders() {
+        let order = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<&str>::new()));
+
+        let first_guard = sync_lock().lock().await;
+        let order_clone = order.clone();
+        let second = tokio::spawn(async move {
+            let _g = sync_lock().lock().await; // must wait for `first_guard` to drop
+            order_clone.lock().await.push("second");
+        });
+
+        // Give the spawned task a chance to actually block on the lock before we
+        // release it — otherwise a fast scheduler could run it after the drop below
+        // and the ordering assertion would prove nothing.
+        tokio::task::yield_now().await;
+        order.lock().await.push("first");
+        drop(first_guard);
+
+        second.await.unwrap();
+        assert_eq!(
+            *order.lock().await,
+            vec!["first", "second"],
+            "the second acquirer must not proceed until the first guard drops"
+        );
     }
 }

--- a/src/intelligence/oauth/jira.rs
+++ b/src/intelligence/oauth/jira.rs
@@ -31,34 +31,101 @@ pub(crate) fn has_basic_auth(jira: &JiraConfig) -> bool {
         && !jira.api_token.trim().is_empty()
 }
 
+/// The Basic-auth context from config. Shared by both resolvers so the two cannot
+/// disagree about which config fields make up a request context — a field added to
+/// [`JiraReqCtx::Basic`] has exactly one place to be filled in.
+fn basic_ctx(jira: &JiraConfig) -> JiraReqCtx {
+    JiraReqCtx::Basic {
+        base_url: jira.base_url.clone(),
+        email: jira.email.clone(),
+        api_token: jira.api_token.clone(),
+    }
+}
+
+/// The OAuth context from a token the caller has already obtained. Deliberately takes
+/// the tokens rather than fetching them: that is the whole difference between the two
+/// resolvers ([`resolve`] may mint a new pair, `resolve_unattended` must not), and
+/// keeping the fetch out of here means neither can acquire one by accident.
+fn oauth_ctx(t: meridian_oauth::store::OAuthTokens) -> JiraReqCtx {
+    JiraReqCtx::OAuth {
+        token: t.access_token,
+        cloud_id: t.cloud_id,
+        site_url: t.site_url,
+    }
+}
+
 /// Decide how to authenticate Jira requests: prefer the static API token when
 /// fully configured, otherwise fall back to a stored OAuth session. API token
 /// beats stored OAuth — a set JIRA_API_TOKEN always wins.
 /// This mirrors the industry standard (gh, Vercel CLI, Stripe CLI all follow
 /// env-var-first) and lets developers use a stable PAT in .env without being
 /// blocked by a stale OAuth session stored in ~/.meridian/oauth/jira.json.
+///
+/// **May MINT a new refresh token, so only call this behind a real user action.**
+/// See [`resolve_unattended`] for the clock-driven counterpart and why the
+/// distinction is load-bearing.
 pub async fn resolve(jira: &JiraConfig) -> Result<JiraReqCtx> {
     if has_basic_auth(jira) {
         tracing::debug!(auth_method = "api_token", "resolving Jira auth");
-        return Ok(JiraReqCtx::Basic {
-            base_url: jira.base_url.clone(),
-            email: jira.email.clone(),
-            api_token: jira.api_token.clone(),
-        });
+        return Ok(basic_ctx(jira));
     }
     if store::exists("jira") {
         tracing::debug!(auth_method = "oauth", "resolving Jira auth");
-        let t = ensure_fresh().await?;
-        return Ok(JiraReqCtx::OAuth {
-            token: t.access_token,
-            cloud_id: t.cloud_id,
-            site_url: t.site_url,
-        });
+        return Ok(oauth_ctx(ensure_fresh().await?));
     }
     bail!(
         "no Jira auth available — run `meridian oauth-login jira`, \
          or set JIRA_BASE_URL / JIRA_EMAIL / JIRA_API_TOKEN"
     )
+}
+
+/// [`resolve`] for callers running on a CLOCK rather than behind a user action:
+/// returns auth only if it can be had without spending the rotating refresh token.
+/// `None` means "skip this pass", never an error.
+///
+/// # Why a separate resolver
+///
+/// Refreshing an Atlassian OAuth token is a single-use exchange: the old refresh
+/// token dies the instant the new one is issued, so a lost response leaves the
+/// grant recoverable only inside a 10-minute window. When that POST is fired by a
+/// timer with nobody at the machine, a closing laptop lid destroys the grant
+/// permanently — which is precisely how a production install lost Jira for five
+/// days (refresh at 18:26:55, 28-minute suspend, retry instant on wake at
+/// 18:55:29 but 18 minutes too late).
+///
+/// So unattended code may USE a valid access token but must never MINT one. This
+/// is the same discipline that makes Claude Code's MCP connections durable against
+/// the identical protocol: it only ever refreshes on the tail of something a human
+/// just asked for.
+///
+/// API-token (basic) auth is returned unconditionally — a static token has no
+/// expiry to race and no rotating credential to lose, so there is nothing to
+/// protect it from.
+///
+/// Deferring is close to free: a sweep that finds an expired token is by
+/// definition running while nobody is using the machine, so there is little new
+/// activity to match, and the next attended request refreshes properly.
+///
+/// # Related
+/// - [`resolve`] — the attended counterpart, which may refresh.
+/// - [`meridian_oauth::jira::current_if_valid`] — the non-minting token read.
+pub fn resolve_unattended(jira: &JiraConfig) -> Option<JiraReqCtx> {
+    if has_basic_auth(jira) {
+        tracing::debug!(
+            auth_method = "api_token",
+            "resolving Jira auth (unattended)"
+        );
+        return Some(basic_ctx(jira));
+    }
+    if !store::exists("jira") {
+        return None;
+    }
+    // `current_if_valid`, never `ensure_fresh` — this is the line that makes the
+    // function unattended-safe, and swapping it would silently reintroduce the
+    // timer-driven refresh that killed a production grant.
+    let t = meridian_oauth::jira::current_if_valid()?;
+    tracing::debug!(auth_method = "oauth", "resolving Jira auth (unattended)");
+    Some(oauth_ctx(t))
 }
 
 #[cfg(test)]

--- a/src/intelligence/providers/jira/refresh.rs
+++ b/src/intelligence/providers/jira/refresh.rs
@@ -25,6 +25,7 @@ use sqlx::SqlitePool;
 
 use crate::config::JiraConfig;
 use crate::intelligence::providers::http::SyncFault;
+use crate::intelligence::Trigger;
 
 use super::{
     backfill_worklogged, discover_start_date_field, fetch, native_terminal, prune, upsert,
@@ -36,7 +37,11 @@ use super::{
 // ---------------------------------------------------------------------------
 
 #[tracing::instrument(skip(pool, jira))]
-pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Option<Vec<String>>> {
+pub async fn refresh_if_stale(
+    pool: &SqlitePool,
+    jira: &JiraConfig,
+    trigger: Trigger,
+) -> Result<Option<Vec<String>>> {
     let threshold = format!("-{SYNC_INTERVAL_MINS} minutes");
     let (is_fresh,): (i64,) = sqlx::query_as(
         "SELECT EXISTS(
@@ -70,66 +75,85 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
     // Resolve auth once per refresh: OAuth (with refresh-before-use) if a token
     // store exists, else static basic auth. A resolve failure means no usable
     // creds — keep the stale cache rather than erroring the whole tick.
-    let ctx = match crate::intelligence::oauth::jira::resolve(jira).await {
-        Ok(ctx) => ctx,
-        Err(e) => {
-            // A refresh that failed only because Atlassian was briefly
-            // unreachable (network blip, timeout, 429, 5xx) does NOT mean the
-            // token is dead — the stored refresh token is still valid and the
-            // next tick will almost certainly succeed. Raising a "Reconnect
-            // Jira / re-run oauth-login" sync error for that transient case is
-            // exactly what made this fault flap on and off at random. Keep the
-            // stale cache and stay quiet; the notice is reserved for a terminal
-            // auth failure the user actually has to act on.
-            // Deliberately NOT `record_sync_failure` like the fetch arm below:
-            // this path needs the auth-method-specific remedy override that the
-            // shared helper has no way to express (basic auth really does want
-            // the `.env` wording). The classification policy is otherwise
-            // identical, so a change to one should be mirrored here.
-            //
-            // `meridian_oauth::is_transient` only recognises a `TokenError` from
-            // the token endpoint and answers `false` for anything else, so a raw
-            // transport failure escaping the refresh would still land here as
-            // terminal. Falling back to `http::classify` closes that hole
-            // without ever making a genuinely dead grant look retryable.
-            let fault = if meridian_oauth::is_transient(&e) {
-                SyncFault::retry(&e)
-            } else {
-                crate::intelligence::providers::http::classify(&e)
-            };
-            match fault {
-                SyncFault::Retry { detail } => {
-                    tracing::warn!(
-                        error = %detail,
-                        "jira auth temporarily unavailable - keeping stale cache, will retry next sync"
-                    );
-                    let _ = crate::intelligence::providers::note_transient_sync_failure(
-                        pool, "jira", &detail,
-                    )
-                    .await;
-                }
-                SyncFault::Report { detail } => {
-                    tracing::warn!(error = %detail, "jira auth unavailable - keeping stale cache");
-                    let msg = format!("Jira auth failed: {detail}");
-                    // Basic-auth (JIRA_API_TOKEN/JIRA_BASE_URL) and OAuth are
-                    // mutually exclusive here - has_basic_auth() mirrors
-                    // resolve()'s own choice - so the remedy must match whichever
-                    // path this failure came from, not always point at .env.
-                    let remedy = if crate::intelligence::oauth::jira::has_basic_auth(jira) {
-                        "Set JIRA_API_TOKEN and JIRA_BASE_URL in .env"
-                    } else {
-                        "Reconnect Jira in Settings - Integrations"
-                    };
-                    let _ = crate::intelligence::providers::stamp_sync_error_with_remedy(
-                        pool,
-                        "jira",
-                        &msg,
-                        Some(remedy),
-                    )
-                    .await;
-                }
+    //
+    // A clock-driven pass must never MINT a Jira OAuth token — spending the
+    // rotating refresh token unattended is what permanently kills a grant when the
+    // machine suspends mid-POST (see `Trigger::Unattended`). An expired token here
+    // means keep the stale cache and let the next attended request refresh; that
+    // is not a failure and must not be recorded as one, or a laptop that was shut
+    // for the night would raise a sync error every morning.
+    let ctx = if trigger == Trigger::Unattended {
+        match crate::intelligence::oauth::jira::resolve_unattended(jira) {
+            Some(ctx) => ctx,
+            None => {
+                tracing::debug!(
+                    "jira token not usable without a refresh - deferring unattended sync"
+                );
+                return Ok(None);
             }
-            return Ok(None);
+        }
+    } else {
+        match crate::intelligence::oauth::jira::resolve(jira).await {
+            Ok(ctx) => ctx,
+            Err(e) => {
+                // A refresh that failed only because Atlassian was briefly
+                // unreachable (network blip, timeout, 429, 5xx) does NOT mean the
+                // token is dead — the stored refresh token is still valid and the
+                // next tick will almost certainly succeed. Raising a "Reconnect
+                // Jira / re-run oauth-login" sync error for that transient case is
+                // exactly what made this fault flap on and off at random. Keep the
+                // stale cache and stay quiet; the notice is reserved for a terminal
+                // auth failure the user actually has to act on.
+                // Deliberately NOT `record_sync_failure` like the fetch arm below:
+                // this path needs the auth-method-specific remedy override that the
+                // shared helper has no way to express (basic auth really does want
+                // the `.env` wording). The classification policy is otherwise
+                // identical, so a change to one should be mirrored here.
+                //
+                // `meridian_oauth::is_transient` only recognises a `TokenError` from
+                // the token endpoint and answers `false` for anything else, so a raw
+                // transport failure escaping the refresh would still land here as
+                // terminal. Falling back to `http::classify` closes that hole
+                // without ever making a genuinely dead grant look retryable.
+                let fault = if meridian_oauth::is_transient(&e) {
+                    SyncFault::retry(&e)
+                } else {
+                    crate::intelligence::providers::http::classify(&e)
+                };
+                match fault {
+                    SyncFault::Retry { detail } => {
+                        tracing::warn!(
+                            error = %detail,
+                            "jira auth temporarily unavailable - keeping stale cache, will retry next sync"
+                        );
+                        let _ = crate::intelligence::providers::note_transient_sync_failure(
+                            pool, "jira", &detail,
+                        )
+                        .await;
+                    }
+                    SyncFault::Report { detail } => {
+                        tracing::warn!(error = %detail, "jira auth unavailable - keeping stale cache");
+                        let msg = format!("Jira auth failed: {detail}");
+                        // Basic-auth (JIRA_API_TOKEN/JIRA_BASE_URL) and OAuth are
+                        // mutually exclusive here - has_basic_auth() mirrors
+                        // resolve()'s own choice - so the remedy must match whichever
+                        // path this failure came from, not always point at .env.
+                        let remedy = if crate::intelligence::oauth::jira::has_basic_auth(jira) {
+                            "Set JIRA_API_TOKEN and JIRA_BASE_URL in .env"
+                        } else {
+                            "Reconnect Jira in Settings - Integrations"
+                        };
+                        let _ = crate::intelligence::providers::stamp_sync_error_with_remedy(
+                            pool,
+                            "jira",
+                            &msg,
+                            Some(remedy),
+                        )
+                        .await;
+                    }
+                }
+                return Ok(None);
+            }
         }
     };
     let auth_method = if jira.api_token.is_empty() {
@@ -225,10 +249,16 @@ pub async fn refresh_if_stale(pool: &SqlitePool, jira: &JiraConfig) -> Result<Op
 /// Clears `pm_sync_state` for this provider so `refresh_if_stale` sees it as
 /// stale, then delegates. The `last_synced_at` is updated inside the delegate,
 /// so subsequent ticks won't double-fetch.
+///
+/// Always [`Trigger::Attended`]: every caller is a direct user action — connecting
+/// a tracker, pressing Sync now, or a `meridian tasks-sync` / `ticket-update` CLI
+/// invocation — so refreshing the OAuth token here is safe and expected. There is
+/// deliberately no unattended force-sync: forcing a fetch while nobody is present
+/// is the combination this whole distinction exists to prevent.
 pub async fn force_refresh(pool: &SqlitePool, jira: &JiraConfig) -> Result<Option<Vec<String>>> {
     sqlx::query("DELETE FROM pm_sync_state WHERE provider = 'jira'")
         .execute(pool)
         .await
         .context("clearing jira sync state for force refresh")?;
-    refresh_if_stale(pool, jira).await
+    refresh_if_stale(pool, jira, Trigger::Attended).await
 }

--- a/src/intelligence/sync_delegate.rs
+++ b/src/intelligence/sync_delegate.rs
@@ -1,0 +1,320 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Producer side of the `pm_sync_requests` outbox for **short-lived CLI processes**:
+//! ask the daemon to sync, rather than syncing here.
+//!
+//! # Why this exists
+//!
+//! An Atlassian OAuth refresh token is single-use and rotating: the old token dies the
+//! instant the new one is issued, so a lost response leaves the grant recoverable only
+//! inside a 10-minute window and permanently dead after it. A credential like that has
+//! exactly one safe writer, and [`crate::intelligence::sync_requests`] makes the daemon
+//! that writer.
+//!
+//! The tray was converted to request-instead-of-sync at the same time, but six CLI
+//! subcommands the tray *spawns* were missed and kept refreshing in their own process:
+//! `plan-task-create` / `plan-task-edit` / `plan-task-done`, `ticket-update`,
+//! `ticket-set-status`, and `worklog-generate`. Every one is user-triggered, so none of
+//! them can recreate the timer-driven "refresh POST in flight when the lid closes"
+//! failure - but each is a second process able to spend the token while the daemon's
+//! watcher is servicing a request. The only thing serialising them was
+//! `meridian-oauth`'s advisory file lock, whose 10 s timeout is shorter than the ~26 s
+//! a refresh can take and which proceeds WITHOUT the lock on timeout. This closes that.
+//!
+//! # Why the in-process fallback stays
+//!
+//! A dev checkout, CI, or a support session with the daemon stopped still needs these
+//! commands to refresh the board. With no daemon running there is no second writer, so
+//! syncing here is safe by the same argument. [`crate::platform::daemon_already_running`]
+//! is the same probe the single-instance guard uses, so the two cannot disagree about
+//! who owns the data dir.
+//!
+//! # Who calls this
+//! - `src/main.rs`'s `tasks-sync` / `pm-sync` / `ticket-update` / `ticket-set-status` /
+//!   `worklog-generate` arms.
+//! - [`crate::plan_tasks`]'s `create` / `edit` / `done` post-write refresh.
+//!
+//! # Related
+//! - [`meridian_core::pm_sync_requests`] - the request/claim/complete API.
+//! - [`crate::intelligence::sync_requests`] - the daemon-side consumer that does the work.
+//! - [`crate::intelligence::Trigger`] - why attendedness is tracked at all.
+
+use std::time::Duration;
+
+use meridian_core::pm_sync_requests::{self, SyncMode, ALL_PROVIDERS};
+use sqlx::SqlitePool;
+
+use crate::config::Config;
+
+/// How often to re-read the request row while waiting. Matched to the daemon watcher's
+/// own 2 s tick rather than being tighter - a faster poll cannot see a result sooner.
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// What happened to a delegated sync.
+///
+/// `Pending` deliberately merges "queued, not waited for" and "waited, budget elapsed":
+/// both mean the daemon owns the work and will finish it, which is the only thing a
+/// caller can act on. Neither is a failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Delegation {
+    /// The sync finished successfully. `count` is the resulting `pm_tasks` total, and is
+    /// present only when the daemon reported it (the in-process path does not tally).
+    Synced { count: Option<i64> },
+    /// The sync was attempted and failed, or the request could not be queued. The string
+    /// is already a flattened error chain, ready to print or log.
+    Failed { error: String },
+    /// Queued for the daemon; no outcome is known yet.
+    Pending,
+}
+
+/// Ask for a sync and wait up to `budget` for the outcome.
+///
+/// Use this when the caller's next step *reads* `pm_tasks` and would behave differently
+/// against a stale board - `plan-task-create` checking whether its new ticket has
+/// mirrored, or `worklog-generate` matching sessions to tickets. Pick a budget that
+/// fits inside the caller's own timeout: a `Pending` return means "carry on with what
+/// is cached", never "fail".
+pub async fn sync_and_wait(
+    pool: &SqlitePool,
+    config: &Config,
+    mode: SyncMode,
+    label: &str,
+    budget: Duration,
+) -> Delegation {
+    delegate(pool, config, mode, label, Some(budget)).await
+}
+
+/// The budget for a post-write refresh (`plan-task-done`, `plan-task-edit`,
+/// `ticket-update`, `ticket-set-status`).
+///
+/// These deliberately WAIT rather than firing and forgetting, because they were
+/// synchronous before delegation and the frontend re-reads the board as soon as the CLI
+/// exits - returning early would show the pre-write value for a second or two and read
+/// as "my change didn't save". The old inline path already paid this latency (its own
+/// HTTP call, up to ~26 s with a token refresh), so waiting is not a new cost.
+pub const POST_WRITE_SYNC_BUDGET: Duration = Duration::from_secs(30);
+
+/// Ask for a post-write refresh and wait for it, using [`POST_WRITE_SYNC_BUDGET`].
+///
+/// A `Pending` return is not a failure: the tracker write already landed and the daemon
+/// will still finish the mirror refresh. Callers log it and carry on.
+pub async fn sync_after_write(pool: &SqlitePool, config: &Config, label: &str) -> Delegation {
+    delegate(
+        pool,
+        config,
+        SyncMode::Force,
+        label,
+        Some(POST_WRITE_SYNC_BUDGET),
+    )
+    .await
+}
+
+/// Shared body: pick the owner, then act.
+///
+/// Only the branch lives here - both halves are separately testable, which the probe
+/// makes necessary: [`crate::platform::daemon_already_running`] talks to the real
+/// single-instance endpoint, so a test that called this function would pass or fail
+/// depending on whether the developer happens to have a daemon running.
+#[tracing::instrument(skip(pool, config), fields(mode = mode.as_str()))]
+async fn delegate(
+    pool: &SqlitePool,
+    config: &Config,
+    mode: SyncMode,
+    label: &str,
+    wait: Option<Duration>,
+) -> Delegation {
+    if crate::platform::daemon_already_running().await {
+        request_and_wait(pool, mode, label, wait).await
+    } else {
+        sync_here(pool, config, mode, label).await
+    }
+}
+
+/// The no-daemon fallback: do the sync in this process.
+async fn sync_here(pool: &SqlitePool, config: &Config, mode: SyncMode, label: &str) -> Delegation {
+    tracing::debug!(label, "no daemon running - syncing in-process");
+    let result = match mode {
+        SyncMode::Force => super::run_pm_force_sync(pool, config).await,
+        SyncMode::Gated => super::run_pm_sync(pool, config).await,
+    };
+    match result {
+        Ok(()) => Delegation::Synced { count: None },
+        Err(e) => Delegation::Failed {
+            error: crate::errors::chain(&e),
+        },
+    }
+}
+
+/// The delegated path: hand the work to the daemon, optionally waiting for its outcome.
+/// `wait: None` returns [`Delegation::Pending`] the moment the request is written.
+async fn request_and_wait(
+    pool: &SqlitePool,
+    mode: SyncMode,
+    label: &str,
+    wait: Option<Duration>,
+) -> Delegation {
+    if let Err(e) = pm_sync_requests::request(pool, ALL_PROVIDERS, mode, label).await {
+        return Delegation::Failed {
+            error: format!(
+                "could not queue the sync request: {}",
+                crate::errors::chain(&e)
+            ),
+        };
+    }
+    tracing::debug!(label, "pm sync requested - the daemon owns tracker auth");
+
+    match wait {
+        Some(budget) => wait_for_outcome(pool, label, budget).await,
+        None => Delegation::Pending,
+    }
+}
+
+/// Poll the request row until the daemon records an outcome, or `budget` elapses.
+///
+/// The row is keyed on the provider (`'*'`), so a concurrent CLI's request can reset it
+/// and this can end up reading a sibling's outcome. That is fine: both asked for the same
+/// thing, and "some sync just completed" is exactly what the caller needs to know. It
+/// cannot read a *stale* outcome, because `request` clears `completed_at`.
+async fn wait_for_outcome(pool: &SqlitePool, label: &str, budget: Duration) -> Delegation {
+    let deadline = std::time::Instant::now() + budget;
+    loop {
+        if std::time::Instant::now() >= deadline {
+            tracing::debug!(
+                label,
+                budget_s = budget.as_secs(),
+                "daemon did not report a sync outcome in time - continuing"
+            );
+            return Delegation::Pending;
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+        match pm_sync_requests::outcome(pool, ALL_PROVIDERS).await {
+            Ok(Some(out)) => {
+                return match out.error {
+                    Some(error) => Delegation::Failed { error },
+                    None => Delegation::Synced {
+                        count: out.synced_count,
+                    },
+                };
+            }
+            Ok(None) => continue,
+            Err(e) => {
+                return Delegation::Failed {
+                    error: format!(
+                        "could not read the sync outcome: {}",
+                        crate::errors::chain(&e)
+                    ),
+                };
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqliteConnectOptions;
+    use std::str::FromStr;
+
+    async fn db() -> SqlitePool {
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+            .unwrap()
+            .create_if_missing(true);
+        let pool = SqlitePool::connect_with(opts).await.unwrap();
+        sqlx::migrate!("src/migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    /// With no providers configured, `run_pm_*_sync` returns early - so the fallback
+    /// path must report success rather than queueing anything. If it ever starts writing
+    /// a request row, a dev checkout would silently stop refreshing: with no daemon
+    /// there is nothing to service it.
+    #[tokio::test]
+    async fn the_fallback_syncs_here_and_queues_nothing() {
+        let pool = db().await;
+        let cfg = Config::from_env();
+
+        let got = sync_here(&pool, &cfg, SyncMode::Force, "test").await;
+
+        assert_eq!(got, Delegation::Synced { count: None });
+        assert!(
+            pm_sync_requests::outcome(&pool, ALL_PROVIDERS)
+                .await
+                .unwrap()
+                .is_none(),
+            "the in-process path must not queue a request"
+        );
+    }
+
+    /// A queued request must be *claimable* by the daemon, carrying the mode and reason
+    /// the producer asked for. If the row were written in a shape `claim` cannot match,
+    /// every delegated sync would silently never happen.
+    #[tokio::test]
+    async fn a_queued_request_is_claimable_by_the_daemon() {
+        let pool = db().await;
+
+        let got = request_and_wait(&pool, SyncMode::Force, "plan-task-done", None).await;
+
+        assert_eq!(got, Delegation::Pending);
+        let claimed = pm_sync_requests::claim(&pool, ALL_PROVIDERS)
+            .await
+            .unwrap()
+            .expect("the daemon must be able to claim the queued request");
+        assert_eq!(claimed.mode, SyncMode::Force);
+        assert_eq!(claimed.reason, "plan-task-done");
+    }
+
+    /// A budget that elapses with no daemon to service the row must read as `Pending`,
+    /// not `Failed`. `plan-task-create` and `worklog-generate` both continue on
+    /// `Pending` and would otherwise log a phantom failure on every slow sync.
+    #[tokio::test]
+    async fn an_elapsed_budget_is_pending_not_failed() {
+        let pool = db().await;
+
+        let got = request_and_wait(
+            &pool,
+            SyncMode::Gated,
+            "worklog-generate",
+            Some(Duration::from_millis(600)),
+        )
+        .await;
+
+        assert_eq!(got, Delegation::Pending);
+    }
+
+    /// A failure the daemon recorded must reach the caller verbatim, so `tasks-sync`
+    /// exits non-zero with the real reason rather than a generic timeout.
+    #[tokio::test]
+    async fn a_recorded_failure_is_reported_to_the_caller() {
+        let pool = db().await;
+        pm_sync_requests::request(&pool, ALL_PROVIDERS, SyncMode::Force, "tasks-sync")
+            .await
+            .unwrap();
+        pm_sync_requests::claim(&pool, ALL_PROVIDERS).await.unwrap();
+        pm_sync_requests::complete(&pool, ALL_PROVIDERS, None, Some("refresh_token is invalid"))
+            .await
+            .unwrap();
+
+        // Re-requesting clears the outcome, so the waiter must be the one to observe it:
+        // drive the wait directly against the already-completed row.
+        let got = wait_for_outcome(&pool, "tasks-sync", Duration::from_secs(5)).await;
+
+        assert_eq!(
+            got,
+            Delegation::Failed {
+                error: "refresh_token is invalid".to_string()
+            }
+        );
+    }
+
+    /// `Pending` is not a failure, and callers branch on that. Pinned because the
+    /// obvious refactor - folding a timeout into `Failed` - would turn "the daemon is
+    /// still working" into a user-visible error on every slow sync.
+    #[test]
+    fn pending_is_distinct_from_failed() {
+        assert_ne!(
+            Delegation::Pending,
+            Delegation::Failed {
+                error: "x".to_string()
+            }
+        );
+    }
+}

--- a/src/intelligence/sync_requests.rs
+++ b/src/intelligence/sync_requests.rs
@@ -1,0 +1,227 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Single-owner PM sync: the daemon-side consumer of the `pm_sync_requests` outbox.
+//!
+//! # Why this task exists
+//!
+//! An Atlassian OAuth refresh token is single-use and rotating: the old token dies
+//! the instant the new one is issued, so a lost response leaves the grant
+//! recoverable only inside a 10-minute window and permanently dead after it. A
+//! credential like that has exactly one safe writer.
+//!
+//! It used to have many. The tray refreshed in-process, the daemon refreshed on its
+//! poll loop, and the tray spawned fresh `meridian pm-sync` / `tasks-sync` processes
+//! that each refreshed too. The advisory file lock meant to serialise them could not:
+//! its 10 s timeout is shorter than the ~26 s a refresh can take, and on timeout the
+//! code proceeded WITHOUT the lock. Two processes could spend the same token, and
+//! only Atlassian's grace window kept that from corrupting state.
+//!
+//! This watcher makes the daemon the sole consumer, so single-ownership is a property
+//! of the architecture rather than of lock discipline. Every other would-be writer -
+//! the tray, and the `tasks-sync` / `pm-sync` / `plan-task-*` / `ticket-update` /
+//! `ticket-set-status` / `worklog-generate` CLIs - now writes a request row instead
+//! (see [`crate::intelligence::sync_delegate`]). The only remaining in-process sync is
+//! the fallback taken when no daemon is running at all, where there is no second
+//! writer to race.
+//!
+//! # Why a separate task instead of the main poll loop
+//!
+//! The poll loop ticks on `POLL_INTERVAL_SECS` (60 s by default). Making a user who
+//! pressed "Sync now" wait up to a minute for the sync to even *begin* would be a
+//! visible regression against the old shell-out, which started immediately. So this
+//! runs its own short cadence ([`WATCH_INTERVAL`]) - a single indexed read against a
+//! local SQLite file, negligible next to the ETL work sharing the process.
+//!
+//! It is deliberately NOT a timer that syncs on its own: it only ever acts on a row
+//! a producer wrote, so every refresh still traces back to a human action. That is
+//! the property that stops a refresh POST being in flight when a laptop lid closes.
+//!
+//! # Who calls this
+//! - [`run_watcher`] is spawned once by `src/main.rs` at daemon startup.
+//! - Producers write rows via [`meridian_core::pm_sync_requests::request`].
+//!
+//! # Related
+//! - [`meridian_core::pm_sync_requests`] - the request/claim/complete API.
+//! - [`crate::intelligence::run_pm_sync`] / [`crate::intelligence::run_pm_force_sync`]
+//!   - the work this dispatches to.
+//! - [`crate::intelligence::Trigger`] - why attendedness is tracked at all.
+
+use std::time::Duration;
+
+use meridian_core::pm_sync_requests::{self, SyncMode, ALL_PROVIDERS};
+use sqlx::SqlitePool;
+use tokio::sync::watch;
+
+use crate::config::Config;
+
+/// How often to look for a pending request. Short enough that "Sync now" feels
+/// immediate, and cheap enough to be irrelevant: one indexed read of a single-row
+/// table on a local file.
+const WATCH_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Drain PM sync requests for the life of the process.
+///
+/// Releases claims stranded by a previous daemon exit once at startup (see
+/// [`pm_sync_requests::reset_stale_claims`]), then loops.
+///
+/// Never propagates an error: a failure to read the table, or a failing sync, must
+/// not take down the daemon or stop future requests being serviced. Outcomes are
+/// recorded on the row so a producer can surface them.
+///
+/// Returns when `shutdown_rx` goes true. The shutdown check is on the SLEEP, not
+/// mid-sync, so a sync already in flight is allowed to finish and record its
+/// outcome rather than being cut off with the row left claimed. A hard kill during a
+/// sync is still possible, and [`pm_sync_requests::reset_stale_claims`] cleans that
+/// up on the next boot.
+#[tracing::instrument(skip(pool, shutdown_rx))]
+pub async fn run_watcher(pool: SqlitePool, mut shutdown_rx: watch::Receiver<bool>) {
+    if let Err(e) = pm_sync_requests::reset_stale_claims(&pool).await {
+        // Non-fatal: the table may not exist yet on a very old DB mid-migration.
+        // A stranded claim self-heals as soon as any producer writes a new request
+        // (which resets `claimed_at`), so this is a latency issue, not a dead end.
+        tracing::warn!(
+            error = %crate::errors::chain(&e),
+            "could not release stale PM sync claims - a pending request may wait for the next producer"
+        );
+    }
+
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep(WATCH_INTERVAL) => service_once(&pool).await,
+            _ = shutdown_rx.changed() => {
+                if *shutdown_rx.borrow() {
+                    tracing::debug!("PM sync request watcher stopping");
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Claim and service at most one pending request. Split from the loop so the
+/// decision logic is reachable without spawning a task.
+async fn service_once(pool: &SqlitePool) {
+    let req = match pm_sync_requests::claim(pool, ALL_PROVIDERS).await {
+        Ok(Some(req)) => req,
+        Ok(None) => return,
+        Err(e) => {
+            // Logged at debug, not warn: on a fresh install this fires every 2 s
+            // until migration 082 has run, and a warn-level line every 2 s would
+            // bury real problems (and, being WARN+, would egress to central
+            // observability on every packaged install).
+            tracing::debug!(
+                error = %crate::errors::chain(&e),
+                "could not read PM sync requests"
+            );
+            return;
+        }
+    };
+
+    // Config is read here rather than captured at spawn time so a settings change
+    // (a newly connected tracker, an edited JQL) is picked up without a restart.
+    // Cheap because this only runs when there is actually work.
+    let cfg = Config::from_env();
+
+    tracing::info!(
+        mode = req.mode.as_str(),
+        reason = %req.reason,
+        "servicing PM sync request"
+    );
+
+    // Both arms are ATTENDED: a row exists only because a producer wrote it in
+    // response to a user action, which is precisely the condition that makes
+    // spending the rotating refresh token safe. There is deliberately no unattended
+    // path through this watcher - the clock-driven worklog sweep calls
+    // `run_pm_sync_unattended` directly instead of requesting.
+    let result = match req.mode {
+        SyncMode::Force => crate::intelligence::run_pm_force_sync(pool, &cfg).await,
+        SyncMode::Gated => crate::intelligence::run_pm_sync(pool, &cfg).await,
+    };
+
+    let (count, error) = match result {
+        Ok(()) => {
+            // The count is read back from `pm_tasks` rather than threaded out of the
+            // sync: `run_pm_sync` fans out over every provider and a per-provider
+            // tally would have to pick one to report. The board total is what "Sync
+            // now" actually wants to show.
+            let n = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM pm_tasks")
+                .fetch_one(pool)
+                .await
+                .ok();
+            tracing::info!(task_count = ?n, "PM sync request completed");
+            (n, None)
+        }
+        Err(e) => {
+            let detail = crate::errors::chain(&e);
+            tracing::warn!(error = %detail, "PM sync request failed");
+            (None, Some(detail))
+        }
+    };
+
+    if let Err(e) = pm_sync_requests::complete(pool, &req.provider, count, error.as_deref()).await {
+        tracing::warn!(
+            error = %crate::errors::chain(&e),
+            "could not record the PM sync outcome - the producer will keep waiting"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqliteConnectOptions;
+    use std::str::FromStr;
+
+    async fn db() -> SqlitePool {
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+            .unwrap()
+            .create_if_missing(true);
+        let pool = SqlitePool::connect_with(opts).await.unwrap();
+        sqlx::migrate!("src/migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    /// An empty table must be a silent no-op. This runs every 2 s forever, so any
+    /// noise or error here would be a permanent log flood.
+    #[tokio::test]
+    async fn service_once_is_quiet_with_no_requests() {
+        let pool = db().await;
+        service_once(&pool).await;
+        assert!(pm_sync_requests::outcome(&pool, ALL_PROVIDERS)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    /// With no PM providers configured, `run_pm_sync` returns `Ok(())` early, so the
+    /// request must still be marked complete rather than left pending forever - a
+    /// producer polling for the outcome would otherwise hang.
+    #[tokio::test]
+    async fn a_request_is_completed_even_with_no_providers_configured() {
+        let pool = db().await;
+        pm_sync_requests::request(&pool, ALL_PROVIDERS, SyncMode::Gated, "test")
+            .await
+            .unwrap();
+
+        service_once(&pool).await;
+
+        let out = pm_sync_requests::outcome(&pool, ALL_PROVIDERS)
+            .await
+            .unwrap()
+            .expect("the request must be completed, not left pending");
+        assert!(out.error.is_none(), "unexpected error: {:?}", out.error);
+    }
+
+    /// The migration must actually create the table the watcher depends on.
+    #[tokio::test]
+    async fn migration_creates_the_requests_table() {
+        let pool = db().await;
+        let exists: i64 = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master
+                            WHERE type = 'table' AND name = 'pm_sync_requests')",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(exists, 1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,9 @@ use anyhow::{Context, Result};
 use meridian::config::Config;
 use meridian::db::meridian::{cleanup_incomplete_runs, setup_db};
 use meridian::etl::run_etl;
-use meridian::intelligence::{run_pm_force_sync, run_pm_sync};
+use meridian::intelligence::sync_delegate::Delegation;
 use meridian::observability;
+use meridian_core::pm_sync_requests::SyncMode;
 use tokio::sync::Notify;
 use tracing::Instrument;
 
@@ -350,23 +351,45 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    // `meridian tasks-sync` — force an immediate sync of all configured PM
-    // providers (Jira, Linear, GitHub), bypassing the 5-minute staleness gate.
-    // Exits 0 on success, non-zero if the DB cannot be opened.
-    if std::env::args().nth(1).as_deref() == Some("tasks-sync") {
+    // `meridian tasks-sync` (force) / `meridian pm-sync` (gated) — the two on-demand
+    // CLI sync entry points. There is no background poller anymore; see
+    // `src/intelligence/mod.rs`'s doc comments for the full trigger list.
+    //
+    // `tasks-sync` bypasses the per-provider staleness gate (the user asked for fresh
+    // data now); `pm-sync` honours it, so it is a cheap no-op on an already-fresh
+    // board. Both DELEGATE to a running daemon rather than syncing here — see
+    // `cli_sync` for why the rotating credential has exactly one safe writer.
+    //
+    // One arm, because the two differ only in mode and label. They were separate
+    // copies of the same fourteen lines, which is how `pm-sync` ended up documented as
+    // the command the tray used "on opening the dashboard" — a trigger that no longer
+    // exists.
+    //
+    // Exit 1 if the DB cannot be opened, or if the sync itself failed. Reporting the
+    // sync failure in the exit code matters: with no daemon running the tray's "Sync
+    // now" shells out to `tasks-sync` and reads a non-zero exit as the failure, so
+    // exiting 0 here would show the user a successful sync that did not happen. A
+    // timeout is NOT a failure (`cli_sync` returns true) — the daemon is still working.
+    let cli_sync_mode = match std::env::args().nth(1).as_deref() {
+        Some("tasks-sync") => Some((SyncMode::Force, "tasks-sync")),
+        Some("pm-sync") => Some((SyncMode::Gated, "pm-sync")),
+        _ => None,
+    };
+    if let Some((mode, label)) = cli_sync_mode {
         let cfg = Config::from_env();
         match setup_db(&cfg.meridian_db_uri()).await {
             Ok(pool) => {
-                if let Err(e) = run_pm_force_sync(&pool, &cfg).await {
-                    eprintln!("tasks-sync: {e}");
-                }
+                let ok = cli_sync(&pool, &cfg, mode, label).await;
                 pool.close().await;
+                if !ok {
+                    std::process::exit(1);
+                }
             }
             Err(e) => {
                 // `{e:#}` prints the full anyhow source chain (e.g. the sqlx
                 // "migration N was previously applied / missing" cause) instead
                 // of just the top-level "failed to run migrations" context.
-                eprintln!("tasks-sync: open db: {e:#}");
+                eprintln!("{label}: open db: {e:#}");
                 std::process::exit(1);
             }
         }
@@ -404,7 +427,7 @@ async fn main() -> Result<()> {
                     meridian::intelligence::ticket_update::ApplyStatus::Applied
                 ) {
                     if let Ok(pool) = setup_db(&cfg.meridian_db_uri()).await {
-                        let _ = run_pm_force_sync(&pool, &cfg).await;
+                        cli_sync_after_write(&pool, &cfg, "ticket-update").await;
                         pool.close().await;
                     }
                 }
@@ -510,7 +533,7 @@ async fn main() -> Result<()> {
                     meridian::intelligence::ticket_update::ApplyStatus::Applied
                 ) {
                     if let Ok(pool) = setup_db(&cfg.meridian_db_uri()).await {
-                        let _ = run_pm_force_sync(&pool, &cfg).await;
+                        cli_sync_after_write(&pool, &cfg, "ticket-set-status").await;
                         pool.close().await;
                     }
                 }
@@ -694,6 +717,32 @@ async fn main() -> Result<()> {
         let obs_guard = observability::init("meridian-rust").ok();
         match setup_db(&cfg.meridian_db_uri()).await {
             Ok(pool) => {
+                // Matching needs current ticket state — a stale board could silently
+                // bind this draft to a closed/renamed ticket. Best-effort: a sync
+                // failure must not block drafting against whatever's cached.
+                //
+                // Delegated to the daemon, the sole owner of the rotating Jira OAuth
+                // token (see `intelligence::sync_delegate`). The wait budget is short
+                // because an LLM call follows inside the tray's 150 s timeout for this
+                // command: better to draft against a slightly stale board than to blow
+                // the timeout and show the user nothing at all.
+                match meridian::intelligence::sync_delegate::sync_and_wait(
+                    &pool,
+                    &cfg,
+                    SyncMode::Gated,
+                    "worklog-generate",
+                    std::time::Duration::from_secs(30),
+                )
+                .await
+                {
+                    Delegation::Synced { .. } => {}
+                    Delegation::Failed { error } => {
+                        tracing::warn!(%error, "worklog-generate: pm sync failed — matching against cached tasks");
+                    }
+                    Delegation::Pending => {
+                        tracing::warn!("worklog-generate: pm sync still running — matching against cached tasks");
+                    }
+                }
                 match meridian::pm_worklog::generate(&pool, &cfg, &day, &task_id).await {
                     Ok(mut draft) => {
                         // A matched draft carries a target_key we can link even
@@ -1256,9 +1305,7 @@ async fn main() -> Result<()> {
     }
 
     // 7c. Run ETL once immediately before entering the loop.
-    //     Re-read config so that any settings.json present at startup takes effect.
     {
-        let cfg = Config::from_env();
         let startup_tick = tracing::info_span!("startup_tick");
         *etl_tick_span.lock().unwrap_or_else(|e| e.into_inner()) = Some(startup_tick.clone());
         let _guard = startup_tick.enter();
@@ -1282,12 +1329,10 @@ async fn main() -> Result<()> {
                 tracing::warn!(error = %meridian::errors::chain(&e), "capture retention sweep failed");
             }
         }
-        if let Err(e) = run_pm_sync(&meridian, &cfg).await {
-            tracing::error!(
-                error = %meridian::errors::chain(&e),
-                "intelligence run failed"
-            );
-        }
+        // No PM sync here anymore — there's no background poller. Syncing is
+        // on-demand now (the daily plan, the match-to-ticket picker, connecting a
+        // tracker, a board write, worklog drafting, `meridian tasks-sync`/`pm-sync`);
+        // see `src/intelligence/mod.rs`'s doc comments for the full set of triggers.
     }
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
@@ -1369,6 +1414,32 @@ async fn main() -> Result<()> {
             if let Err(e) = meridian::embedder::ensure_weights().await {
                 tracing::warn!(error = %meridian::errors::chain(&e), "embedder: weight provisioning failed — distiller stays on lexical-only until this succeeds");
             }
+        });
+    }
+
+    // 7h. PM sync request watcher — the daemon is the SOLE holder of the rotating
+    //     Jira OAuth refresh token, so every other process (the tray, the CLIs) asks
+    //     for a sync by writing a `pm_sync_requests` row instead of refreshing
+    //     itself. This drains those requests.
+    //
+    //     Why single-ownership matters: the refresh is a single-use exchange whose
+    //     lost response kills the grant outside a 10-minute window. Serialising N
+    //     processes with an advisory file lock did not work — a 10 s lock timeout
+    //     guarding a ~26 s operation, and on timeout the code proceeded WITHOUT the
+    //     lock — so two processes could spend the same token and only Atlassian's
+    //     grace window prevented corruption.
+    //
+    //     Deliberately its own task on a short cadence rather than folded into the
+    //     60 s poll loop below: a user pressing "Sync now" must not wait up to a
+    //     minute for the sync to begin. It never syncs on its own initiative — only
+    //     ever on a row a producer wrote, so every refresh still traces to a human
+    //     action, which is what keeps a refresh POST from being in flight when a
+    //     laptop lid closes.
+    {
+        let pool_sync = meridian.clone();
+        let rx_sync = shutdown_rx.clone();
+        tokio::spawn(async move {
+            meridian::intelligence::sync_requests::run_watcher(pool_sync, rx_sync).await;
         });
     }
 
@@ -1506,17 +1577,16 @@ async fn main() -> Result<()> {
                     tracing::debug!(error = %meridian::errors::chain(&e), "notification response consume skipped");
                 }
 
-                // Refresh the PM task cache (pm_tasks) every tick — interval-gated
-                // per provider (~5 min), so this is a cheap no-op most ticks. The
-                // legacy drafting driver that used to trigger this before every
-                // pass was retired when the worklog pipeline moved to the
-                // clock-aligned Python trigger, which never calls this itself —
-                // leaving pm_tasks (and hence a ticket's title on the timeline)
-                // stuck at whatever it was at the last daemon restart. This is
-                // the only thing that keeps it live during normal operation.
-                if let Err(e) = run_pm_sync(&meridian, &cfg).await {
-                    tracing::warn!(error = %meridian::errors::chain(&e), "pm_tasks refresh failed — using cached tasks");
-                }
+                // No PM sync on this tick anymore — there's no background poller.
+                // `pm_tasks` is refreshed on-demand instead: the daily plan and the
+                // match-to-ticket picker (the two screens that decide something from
+                // the whole board), connecting a tracker, any board write, the worklog
+                // drafting sweep (`pm_worklog::auto_generate`), and the manual
+                // `meridian tasks-sync`/`pm-sync` CLI paths. See
+                // `src/intelligence/mod.rs`'s doc comments for the full trigger list
+                // and the reasoning (fewer standing background refreshes also shrinks
+                // how often a Jira OAuth token refresh can straddle a laptop
+                // sleep/wake).
             }
         }
     }
@@ -1547,6 +1617,76 @@ async fn main() -> Result<()> {
     let _ = shipper_shutdown_tx.send(true);
 
     Ok(())
+}
+
+/// Body of the `tasks-sync` / `pm-sync` CLIs: ask the daemon and report what it did.
+///
+/// The delegation itself (and why a CLI must not spend the rotating Jira OAuth token
+/// itself) lives in [`meridian::intelligence::sync_delegate`]; this only maps the
+/// outcome onto stdout/stderr and an exit code, so the user-facing wording stays in
+/// one place next to the other CLI output.
+async fn cli_sync(
+    pool: &meridian::db::SqlitePool,
+    cfg: &Config,
+    mode: SyncMode,
+    label: &str,
+) -> bool {
+    // A generous budget: a cold sync across five providers with a token refresh can
+    // legitimately take a while, and a CLI that gives up early looks like a failure
+    // when the sync is still going. Syncing IS the point of this command, so unlike
+    // the post-write callers it waits.
+    match meridian::intelligence::sync_delegate::sync_and_wait(
+        pool,
+        cfg,
+        mode,
+        label,
+        std::time::Duration::from_secs(120),
+    )
+    .await
+    {
+        Delegation::Synced { count: Some(n) } => {
+            println!("{label}: synced {n} task(s)");
+            true
+        }
+        Delegation::Synced { count: None } => {
+            println!("{label}: synced");
+            true
+        }
+        Delegation::Failed { error } => {
+            eprintln!("{label}: {error}");
+            false
+        }
+        // NOT an error exit: the request is queued and the daemon will service it.
+        // Exiting non-zero here would fail scripts over a slow sync that ultimately
+        // succeeds.
+        Delegation::Pending => {
+            println!("{label}: still running - it will finish in the background");
+            true
+        }
+    }
+}
+
+/// Refresh the board after a CLI write applied to the tracker (`ticket-update`,
+/// `ticket-set-status`).
+///
+/// Waits for the outcome (see `sync_delegate::POST_WRITE_SYNC_BUDGET`): the frontend
+/// re-reads the board as soon as this process exits, so returning before the mirror
+/// caught up would briefly show the pre-write value and read as a lost edit. Failures
+/// and timeouts are logged, never printed - the tracker write already succeeded, so a
+/// sync hiccup must not make the command look like it failed.
+async fn cli_sync_after_write(pool: &meridian::db::SqlitePool, cfg: &Config, label: &str) {
+    match meridian::intelligence::sync_delegate::sync_after_write(pool, cfg, label).await {
+        Delegation::Synced { .. } => {}
+        Delegation::Failed { error } => {
+            tracing::warn!(label, %error, "post-write pm sync failed - the tracker write still landed");
+        }
+        Delegation::Pending => {
+            tracing::warn!(
+                label,
+                "post-write pm sync still running - the tracker write still landed"
+            );
+        }
+    }
 }
 
 /// Runs one ETL pass and maps the outcome onto the notice bus.

--- a/src/migrations/082_pm_sync_requests.sql
+++ b/src/migrations/082_pm_sync_requests.sql
@@ -1,0 +1,68 @@
+-- ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+--
+-- Single-owner PM sync: the request side of the outbox.
+--
+-- WHY THIS EXISTS
+-- An Atlassian OAuth refresh token is single-use and rotating: the old token dies
+-- the instant the new one is issued, so a lost response leaves the grant
+-- recoverable only inside a 10-minute window and unrecoverable after it. That
+-- makes the token a resource with exactly one safe writer.
+--
+-- It had several. The tray refreshed in-process, the daemon refreshed on its poll
+-- loop, and the tray spawned `meridian pm-sync` / `tasks-sync` as fresh processes
+-- that each refreshed too. Mutual exclusion was left to an advisory file lock that
+-- could not actually deliver it: its 10 s timeout is shorter than the ~26 s a
+-- refresh can take (3 attempts x 8 s + backoff), and on failure the code proceeded
+-- WITHOUT the lock rather than backing off. Two processes could therefore spend the
+-- same token, and the only thing preventing corruption was Atlassian's grace window
+-- handing the loser the current pair. Correctness by vendor accident.
+--
+-- So sync becomes a REQUEST rather than an action. Producers (tray window opens,
+-- tracker connect, "Sync now", the CLI) write a row here; the daemon is the sole
+-- consumer and the sole holder of the credential.
+--
+-- COALESCING, NOT A QUEUE
+-- `provider` is the PRIMARY KEY so repeated requests collapse into one pending row
+-- (`ON CONFLICT DO UPDATE`). Opening the dashboard ten times must not queue ten
+-- syncs - it must mean "a sync is wanted", once. `'*'` is the all-providers request
+-- that every current producer writes; per-provider rows are reserved for a future
+-- caller that needs to refresh just one board.
+--
+-- `mode` escalates and never de-escalates while a row is pending: a 'force' request
+-- landing on a pending 'gated' one upgrades it, because a user who just connected a
+-- tracker or pressed "Sync now" must not have their explicit request downgraded by a
+-- passing window focus. The reverse is silently ignored by the producer's UPSERT.
+--
+-- COMPLETION IS REPORTED IN PLACE, NOT DELETED
+-- The daemon stamps `completed_at` plus `error` / `synced_count` rather than removing
+-- the row, so "Sync now" can show a real outcome without the tray needing to hold the
+-- credential or shell out. A serviced row is retained until the next request replaces
+-- it, which also gives `meridian health` a cheap, content-free view of the last sync
+-- attempt.
+
+CREATE TABLE IF NOT EXISTS pm_sync_requests (
+    -- '*' = all configured providers. A specific provider name scopes the request.
+    provider      TEXT    NOT NULL PRIMARY KEY,
+    -- 'gated'  - honour the per-provider staleness window (the cheap common case).
+    -- 'force'  - bypass it; the user explicitly asked (connect, "Sync now", CLI).
+    mode          TEXT    NOT NULL DEFAULT 'gated',
+    -- Free-text producer tag for tracing only (e.g. 'dashboard_open', 'token_connected').
+    -- Never a user-content value: this is read back into logs.
+    reason        TEXT    NOT NULL DEFAULT '',
+    requested_at  TEXT    NOT NULL,
+    -- Set when the daemon starts servicing, so a request in flight is distinguishable
+    -- from one still waiting. Cleared on the next request.
+    claimed_at    TEXT,
+    -- Set when the daemon finishes, success or failure. NULL while pending/in-flight.
+    completed_at  TEXT,
+    -- NULL on success. The failure detail otherwise, for the tray to surface.
+    error         TEXT,
+    -- Tasks refreshed on the last completed pass, for "Sync now" feedback.
+    synced_count  INTEGER
+);
+
+-- No secondary index on purpose. Every hot query (`claim`, `complete`, `outcome`,
+-- `request`) filters on `provider`, which is the PRIMARY KEY, so an index on
+-- (completed_at, claimed_at) would never be chosen. The only query that does not
+-- name a provider is `reset_stale_claims`, which runs once per daemon boot over a
+-- table holding one row per provider - a scan there is free.

--- a/src/plan_tasks/create.rs
+++ b/src/plan_tasks/create.rs
@@ -30,13 +30,22 @@
 //! - [`meridian_core::plan`] — `apply_plan_action("add")`, which puts the key in today.
 
 use anyhow::{Context, Result};
+use meridian_core::pm_sync_requests::SyncMode;
 use meridian_core::task_create::{self, NewTask};
 use serde::Serialize;
 use sqlx::SqlitePool;
+use std::time::Duration;
 use tracing::field::Empty;
 use tracing::Instrument;
 
 use crate::config::Config;
+use crate::intelligence::sync_delegate::Delegation;
+
+/// How long to wait for the post-create sync before falling through to the shadow row.
+/// Must stay comfortably inside the tray's 90 s `WRITE_TIMEOUT` for `plan-task-create`,
+/// since a blown tray timeout looks to the user like a failed create even though the
+/// ticket was filed.
+const POST_CREATE_SYNC_BUDGET: Duration = Duration::from_secs(60);
 
 /// Where a new task should live.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -177,9 +186,30 @@ async fn create_on_tracker(
     tracing::Span::current().record("synced", true);
 
     // Pull the authoritative row in immediately rather than waiting out the 5-minute
-    // sync gate. Best-effort: a failed sync is not a failed create.
-    if let Err(e) = crate::intelligence::run_pm_force_sync(pool, config).await {
-        tracing::warn!(error = %e, "plan_task: post-create sync failed - will shadow the row");
+    // sync gate. Best-effort: a failed sync is not a failed create - it just means the
+    // `task_exists` check below falls through to the shadow row.
+    //
+    // Delegated to the daemon (see `intelligence::sync_delegate`) because this is a
+    // short-lived CLI process and the rotating Jira OAuth token has exactly one safe
+    // writer. Unlike the edit/done paths this WAITS for the outcome: the very next line
+    // reads `pm_tasks`, so returning before the sync landed would shadow every created
+    // ticket. The budget sits inside the tray's 90 s `WRITE_TIMEOUT` for this command.
+    match crate::intelligence::sync_delegate::sync_and_wait(
+        pool,
+        config,
+        SyncMode::Force,
+        "plan-task-create",
+        POST_CREATE_SYNC_BUDGET,
+    )
+    .await
+    {
+        Delegation::Synced { .. } => {}
+        Delegation::Failed { error } => {
+            tracing::warn!(%error, "plan_task: post-create sync failed - will shadow the row");
+        }
+        Delegation::Pending => {
+            tracing::warn!("plan_task: post-create sync still running - will shadow the row");
+        }
     }
 
     if task_create::task_exists(pool, &key).await? {

--- a/src/plan_tasks/done.rs
+++ b/src/plan_tasks/done.rs
@@ -29,6 +29,7 @@ use tracing::field::Empty;
 use tracing::Instrument;
 
 use crate::config::Config;
+use crate::intelligence::sync_delegate::Delegation;
 use crate::intelligence::ticket_update::{self, ApplyStatus};
 use crate::plan_tasks::edit::EditResult;
 
@@ -117,8 +118,20 @@ async fn set_done_on_tracker(
 
     // Best-effort — the tracker has already accepted the transition, so a sync hiccup
     // must not read as a failed toggle.
-    if let Err(e) = crate::intelligence::run_pm_force_sync(pool, config).await {
-        tracing::warn!(error = %e, "plan_task: post-toggle sync failed - the change still landed");
+    //
+    // Delegated to the daemon (`intelligence::sync_delegate`), which is the only process
+    // that may spend the rotating Jira OAuth token. Nothing below reads `pm_tasks`, so
+    // this does not wait for the outcome - the request row is written and the daemon
+    // picks it up within ~2 s, well before the user's next board read.
+    match crate::intelligence::sync_delegate::sync_after_write(pool, config, "plan-task-done").await
+    {
+        Delegation::Synced { .. } => {}
+        Delegation::Failed { error } => {
+            tracing::warn!(%error, "plan_task: post-toggle sync failed - the change still landed");
+        }
+        Delegation::Pending => {
+            tracing::warn!("plan_task: post-toggle sync still running - the change still landed");
+        }
     }
     tracing::Span::current().record("status", "applied");
     tracing::info!(field, "plan_task: tracker task status set");

--- a/src/plan_tasks/edit.rs
+++ b/src/plan_tasks/edit.rs
@@ -32,6 +32,7 @@ use tracing::field::Empty;
 use tracing::Instrument;
 
 use crate::config::Config;
+use crate::intelligence::sync_delegate::Delegation;
 use crate::intelligence::ticket_update::{self, ApplyStatus};
 
 /// The outcome of an edit, serialized to the CLI's one JSON line.
@@ -157,8 +158,20 @@ async fn edit_on_tracker(
         // Reflect the applied write back into our mirror (the `ticket-update` CLI
         // does exactly this after an Applied write). Best-effort — the tracker has
         // already accepted it, so a sync hiccup must not read as a failed edit.
-        if let Err(e) = crate::intelligence::run_pm_force_sync(pool, config).await {
-            tracing::warn!(error = %e, "plan_task: post-edit sync failed - the edit still landed");
+        //
+        // Delegated to the daemon (`intelligence::sync_delegate`), the only process that
+        // may spend the rotating Jira OAuth token. Nothing below reads `pm_tasks`, so the
+        // outcome is not awaited.
+        match crate::intelligence::sync_delegate::sync_after_write(pool, config, "plan-task-edit")
+            .await
+        {
+            Delegation::Synced { .. } => {}
+            Delegation::Failed { error } => {
+                tracing::warn!(%error, "plan_task: post-edit sync failed - the edit still landed");
+            }
+            Delegation::Pending => {
+                tracing::warn!("plan_task: post-edit sync still running - the edit still landed");
+            }
         }
     }
     tracing::Span::current().record("status", "applied");

--- a/src/pm_worklog/auto_generate/mod.rs
+++ b/src/pm_worklog/auto_generate/mod.rs
@@ -1,0 +1,216 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Auto-generate worklog DRAFTS, once a day, at a user-chosen local clock time —
+//! the opt-in behind `settings.worklog_auto_generate_time`.
+//!
+//! This runs the exact same action as the day-task detail panel's "Generate
+//! worklog" button (`pm_worklog::generate`), automatically, for any task past the
+//! fixed [`sweep::QUALIFYING_MINUTES`] threshold that doesn't have a draft yet. It
+//! NEVER approves or posts — approving is always a deliberate human click
+//! (`pm_worklog::approve`, the panel's "Approve & post"). Auto-generate only saves
+//! the user the click that starts the draft; the tracker is never touched without
+//! them.
+//!
+//! Off by default: the field is `None` until the user picks a time from the
+//! Timeline nudge or Settings → Worklogs, so nothing here ever runs unattended for
+//! someone who hasn't said yes.
+//!
+//! # A TRACKER IS NOT REQUIRED — and used to be, wrongly
+//! Both entry points opened with `if config.pm_providers.is_empty() { return }`,
+//! on the premise that "there is nothing to match against, so the sweep would only
+//! fail every call". That premise is false, and stopped being true the moment
+//! personal tasks became first-class: [`crate::pm_worklog::generate`] matches a
+//! PERSONAL (`local`) day-task exactly like a real ticket and, on approve, posts to
+//! that task's own row (`post_to_local_task`) — no tracker anywhere in the path.
+//! Only the PROPOSE branch needs a configured provider, and that branch failing is
+//! already a per-task `warn!` the loop walks past.
+//!
+//! So the gate silently disabled the whole feature for every tracker-less user —
+//! the cohort Meridian now leads with — and Settings mirrored it with a dead-end
+//! card offering nothing. Removed at both ends. Keep it that way: the correct floor
+//! is "does this task have qualifying minutes and no draft yet", which is what the
+//! sweep already checks, not "does this user have Jira".
+//!
+//! # Once a day, from the chosen time onward — not continuously, and self-healing
+//! [`maybe_auto_generate`] is called every clock-aligned wake (HH:03, same as the
+//! rest of the worklog pipeline), but only actually scans once the current local
+//! hour has REACHED the chosen time's hour — so a task crossing the threshold at
+//! 2pm with a 6pm setting waits for 6pm, not the next tick after 2pm.
+//!
+//! Deliberately `>=`, not `==`: if the Mac is asleep, off, or the app isn't
+//! running at exactly 9pm, there is no tick at 9pm to miss — the daemon simply
+//! catches up on its next wake that same day (10pm, or whenever the machine comes
+//! back), because every tick from the chosen hour through local midnight re-runs
+//! the same scan. This is safe to repeat because already-drafted tasks are
+//! skipped (see below) — a caught-up run only ever drafts what genuinely wasn't
+//! drafted yet, it never redoes work. The one thing this does NOT do is reach
+//! back across local midnight: if the whole rest of the day was slept through,
+//! that day's catch-up is skipped, matching this pipeline's standing "no
+//! backfill past today" policy — the manual "Generate worklog" button in the
+//! panel always still works for any past day.
+//!
+//! # Fires once per task, not on every qualifying tick
+//! Once a task has ANY draft (auto- or manually generated), this leaves it alone
+//! for good — it does not keep re-drafting an already-drafted task on a later
+//! tick, whether that's later the same evening (the catch-up case above) or a
+//! future day. If the user keeps working the task past the auto-draft, getting
+//! an up-to-date version is a manual "Regenerate" click in the panel (which
+//! shows when the draft was last generated, via `DayTaskWorklogDraft::
+//! updated_at`) — auto-generate hands off to that rather than looping forever.
+//!
+//! # One task at a time
+//! Tasks are processed in a plain sequential loop, not fanned out — each `generate`
+//! call is a real LLM request, and running them one after another (rather than
+//! concurrently) keeps this predictable and easy to reason about from the trace.
+//!
+//! # Board freshness
+//! [`sweep::draft_qualifying_tasks`] syncs the PM board (gated, ~5 min per provider)
+//! before matching — there is no background poller keeping `pm_tasks` fresh
+//! anymore, so this sweep is one of the few places that has to ask for it itself.
+//!
+//! # Observability
+//! The whole run is one `worklog.auto_generate.run` span (see
+//! [`maybe_auto_generate`]) carrying the gate outcome and per-run counts as
+//! attributes — `gate` names exactly why a run did or didn't scan (`disabled`,
+//! `before_chosen_hour`, `malformed_time`, or `ran`), so "why didn't this fire
+//! tonight" is answerable from the trace alone, not by reading code. Each task
+//! that actually gets drafted (or fails to) gets its own `info!`/`warn!` — real,
+//! individually actionable events — but a task skipped for already having a
+//! draft or not yet qualifying is silent (folded into the summary counts only),
+//! so a quiet evening with nothing to do doesn't spam the log with one line per
+//! task.
+//!
+//! # Who calls this
+//! [`crate::worklog_pipeline::run_loop`], every clock-aligned wake (HH:03), right
+//! after the hourly activity-report pass.
+//!
+//! # Related
+//! - [`crate::pm_worklog::generate`] — the exact function the manual button calls;
+//!   this module never calls [`crate::pm_worklog::approve`].
+//! - [`meridian_core::day_tasks::get_day_tasks`] — the read model this scans;
+//!   `DayTask::minutes` is the deterministic measured total.
+//! - [`meridian_core::day_task_worklogs::get_day_task_worklog`] — the "has this
+//!   task already been drafted" check that makes auto-generate fire exactly once
+//!   per task.
+//! - [`sweep`] — the mechanical per-task loop, split out when this file passed the
+//!   500-line cap.
+
+mod sweep;
+
+use chrono::{Local, Timelike};
+use sqlx::SqlitePool;
+use tracing::field::Empty;
+use tracing::Instrument;
+
+use crate::config::Config;
+use sweep::draft_qualifying_tasks;
+
+/// Parse "HH:MM" into `(hour, minute)`. `None` for anything malformed — the
+/// settings write path (`update_settings`) already rejects a bad value, so this
+/// only has to be defensive against a hand-edited file.
+fn parse_hh_mm(s: &str) -> Option<(u32, u32)> {
+    let (h, m) = s.split_once(':')?;
+    let (h, m) = (h.parse::<u32>().ok()?, m.parse::<u32>().ok()?);
+    (h < 24 && m < 60).then_some((h, m))
+}
+
+/// Once the current local hour has reached the user's chosen hour (today), scan
+/// `day_local`'s day-tasks and auto-generate a worklog DRAFT (never approve,
+/// never post) for any past [`sweep::QUALIFYING_MINUTES`] that doesn't have a draft
+/// yet. A no-op when `worklog_auto_generate_time` is unset, or before that hour.
+/// Safe to call again later the same day (e.g. the machine was asleep at the
+/// chosen time) — see the module docs. Tasks are processed one at a time, in
+/// order — never concurrently.
+#[tracing::instrument(skip(pool, config))]
+pub async fn maybe_auto_generate(pool: &SqlitePool, config: &Config, day_local: &str) {
+    let span = tracing::info_span!(
+        "worklog.auto_generate.run",
+        day = day_local,
+        chosen_time = Empty,
+        gate = Empty,
+        tasks_total = Empty,
+        tasks_qualifying = Empty,
+        tasks_already_drafted = Empty,
+        tasks_drafted = Empty,
+        tasks_failed = Empty,
+    );
+    run(pool, config, day_local).instrument(span).await
+}
+
+async fn run(pool: &SqlitePool, config: &Config, day_local: &str) {
+    let current_span = tracing::Span::current();
+
+    let settings = meridian_core::settings::load_runtime_settings();
+    let Some(chosen_time) = settings.worklog_auto_generate_time else {
+        current_span.record("gate", "disabled");
+        return;
+    };
+    current_span.record("chosen_time", chosen_time.as_str());
+
+    let Some((chosen_hour, _)) = parse_hh_mm(&chosen_time) else {
+        current_span.record("gate", "malformed_time");
+        tracing::warn!(
+            chosen_time,
+            "worklog: auto-generate time is malformed — skipping"
+        );
+        return;
+    };
+    if Local::now().hour() < chosen_hour {
+        current_span.record("gate", "before_chosen_hour");
+        return;
+    }
+    current_span.record("gate", "ran");
+
+    draft_qualifying_tasks(pool, config, day_local, &current_span).await;
+}
+
+/// The "Generate now" path — the same day-task draft sweep as [`maybe_auto_generate`],
+/// but WITHOUT the time-of-day gate, run because the user asked for it on the spot
+/// (the daily-summary screen's "Generate now" button) rather than because the clock
+/// reached their chosen time. Everything else is identical: drafts only, never
+/// approves/posts, and skips any task that already has a draft, so it is safe to run
+/// alongside or before the scheduled pass. Independent of `worklog_auto_generate_time`:
+/// a user who never set a time can still generate on demand.
+#[tracing::instrument(skip(pool, config))]
+pub async fn generate_now(pool: &SqlitePool, config: &Config, day_local: &str) {
+    let span = tracing::info_span!(
+        "worklog.generate_now.run",
+        day = day_local,
+        gate = Empty,
+        tasks_total = Empty,
+        tasks_qualifying = Empty,
+        tasks_already_drafted = Empty,
+        tasks_drafted = Empty,
+        tasks_failed = Empty,
+    );
+    async {
+        let current_span = tracing::Span::current();
+        current_span.record("gate", "ran");
+        draft_qualifying_tasks(pool, config, day_local, &current_span).await;
+    }
+    .instrument(span)
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_hh_mm;
+
+    #[test]
+    fn parses_valid_times() {
+        assert_eq!(parse_hh_mm("00:00"), Some((0, 0)));
+        assert_eq!(parse_hh_mm("18:00"), Some((18, 0)));
+        assert_eq!(parse_hh_mm("23:59"), Some((23, 59)));
+        assert_eq!(parse_hh_mm("09:05"), Some((9, 5)));
+    }
+
+    #[test]
+    fn rejects_out_of_range_or_malformed_values() {
+        assert_eq!(parse_hh_mm("24:00"), None);
+        assert_eq!(parse_hh_mm("18:60"), None);
+        assert_eq!(parse_hh_mm("18"), None);
+        assert_eq!(parse_hh_mm("18:00:00"), None);
+        assert_eq!(parse_hh_mm(""), None);
+        assert_eq!(parse_hh_mm("not-a-time"), None);
+        assert_eq!(parse_hh_mm("ab:cd"), None);
+    }
+}

--- a/src/pm_worklog/auto_generate/sweep.rs
+++ b/src/pm_worklog/auto_generate/sweep.rs
@@ -1,96 +1,11 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
-//! Auto-generate worklog DRAFTS, once a day, at a user-chosen local clock time —
-//! the opt-in behind `settings.worklog_auto_generate_time`.
-//!
-//! This runs the exact same action as the day-task detail panel's "Generate
-//! worklog" button (`pm_worklog::generate`), automatically, for any task past the
-//! fixed [`QUALIFYING_MINUTES`] threshold that doesn't have a draft yet. It NEVER
-//! approves or posts — approving is always a deliberate human click
-//! (`pm_worklog::approve`, the panel's "Approve & post"). Auto-generate only saves
-//! the user the click that starts the draft; the tracker is never touched without
-//! them.
-//!
-//! Off by default: the field is `None` until the user picks a time from the
-//! Timeline nudge or Settings → Worklogs, so nothing here ever runs unattended for
-//! someone who hasn't said yes.
-//!
-//! # A TRACKER IS NOT REQUIRED — and used to be, wrongly
-//! Both entry points opened with `if config.pm_providers.is_empty() { return }`,
-//! on the premise that "there is nothing to match against, so the sweep would only
-//! fail every call". That premise is false, and stopped being true the moment
-//! personal tasks became first-class: [`crate::pm_worklog::generate`] matches a
-//! PERSONAL (`local`) day-task exactly like a real ticket and, on approve, posts to
-//! that task's own row (`post_to_local_task`) — no tracker anywhere in the path.
-//! Only the PROPOSE branch needs a configured provider, and that branch failing is
-//! already a per-task `warn!` the loop walks past.
-//!
-//! So the gate silently disabled the whole feature for every tracker-less user —
-//! the cohort Meridian now leads with — and Settings mirrored it with a dead-end
-//! card offering nothing. Removed at both ends. Keep it that way: the correct floor
-//! is "does this task have qualifying minutes and no draft yet", which is what the
-//! sweep already checks, not "does this user have Jira".
-//!
-//! # Once a day, from the chosen time onward — not continuously, and self-healing
-//! [`maybe_auto_generate`] is called every clock-aligned wake (HH:03, same as the
-//! rest of the worklog pipeline), but only actually scans once the current local
-//! hour has REACHED the chosen time's hour — so a task crossing the threshold at
-//! 2pm with a 6pm setting waits for 6pm, not the next tick after 2pm.
-//!
-//! Deliberately `>=`, not `==`: if the Mac is asleep, off, or the app isn't
-//! running at exactly 9pm, there is no tick at 9pm to miss — the daemon simply
-//! catches up on its next wake that same day (10pm, or whenever the machine comes
-//! back), because every tick from the chosen hour through local midnight re-runs
-//! the same scan. This is safe to repeat because already-drafted tasks are
-//! skipped (see below) — a caught-up run only ever drafts what genuinely wasn't
-//! drafted yet, it never redoes work. The one thing this does NOT do is reach
-//! back across local midnight: if the whole rest of the day was slept through,
-//! that day's catch-up is skipped, matching this pipeline's standing "no
-//! backfill past today" policy — the manual "Generate worklog" button in the
-//! panel always still works for any past day.
-//!
-//! # Fires once per task, not on every qualifying tick
-//! Once a task has ANY draft (auto- or manually generated), this leaves it alone
-//! for good — it does not keep re-drafting an already-drafted task on a later
-//! tick, whether that's later the same evening (the catch-up case above) or a
-//! future day. If the user keeps working the task past the auto-draft, getting
-//! an up-to-date version is a manual "Regenerate" click in the panel (which
-//! shows when the draft was last generated, via `DayTaskWorklogDraft::
-//! updated_at`) — auto-generate hands off to that rather than looping forever.
-//!
-//! # One task at a time
-//! Tasks are processed in a plain sequential loop, not fanned out — each `generate`
-//! call is a real LLM request, and running them one after another (rather than
-//! concurrently) keeps this predictable and easy to reason about from the trace.
-//!
-//! # Observability
-//! The whole run is one `worklog.auto_generate.run` span (see
-//! [`maybe_auto_generate`]) carrying the gate outcome and per-run counts as
-//! attributes — `gate` names exactly why a run did or didn't scan (`disabled`,
-//! `before_chosen_hour`, `malformed_time`, or `ran`), so "why didn't this fire
-//! tonight" is answerable from the trace alone, not by reading code. Each task
-//! that actually gets drafted (or fails to) gets its own `info!`/`warn!` — real,
-//! individually actionable events — but a task skipped for already having a
-//! draft or not yet qualifying is silent (folded into the summary counts only),
-//! so a quiet evening with nothing to do doesn't spam the log with one line per
-//! task.
-//!
-//! # Who calls this
-//! [`crate::worklog_pipeline::run_loop`], every clock-aligned wake (HH:03), right
-//! after the hourly activity-report pass.
-//!
-//! # Related
-//! - [`crate::pm_worklog::generate`] — the exact function the manual button calls;
-//!   this module never calls [`crate::pm_worklog::approve`].
-//! - [`meridian_core::day_tasks::get_day_tasks`] — the read model this scans;
-//!   `DayTask::minutes` is the deterministic measured total.
-//! - [`meridian_core::day_task_worklogs::get_day_task_worklog`] — the "has this
-//!   task already been drafted" check that makes auto-generate fire exactly once
-//!   per task.
+//! The shared sweep body [`super::maybe_auto_generate`] (clock-gated) and
+//! [`super::generate_now`] (on demand) both call: draft a worklog for every
+//! qualifying, not-yet-drafted day-task. Split out of `auto_generate.rs` when that
+//! file passed the repo's 500-line cap — see `auto_generate/mod.rs`'s module doc
+//! for the full feature description; this file is the mechanical loop only.
 
-use chrono::{Local, Timelike};
 use sqlx::SqlitePool;
-use tracing::field::Empty;
-use tracing::Instrument;
 
 use crate::config::Config;
 use crate::pm_worklog;
@@ -98,101 +13,14 @@ use crate::pm_worklog;
 /// Fixed qualifying threshold — a day-task needs more than this many tracked
 /// minutes to be auto-drafted. Not user-configurable: only WHEN Meridian checks
 /// (`worklog_auto_generate_time`) is a choice; WHICH tasks qualify is not.
-const QUALIFYING_MINUTES: i64 = 30;
-
-/// Parse "HH:MM" into `(hour, minute)`. `None` for anything malformed — the
-/// settings write path (`update_settings`) already rejects a bad value, so this
-/// only has to be defensive against a hand-edited file.
-fn parse_hh_mm(s: &str) -> Option<(u32, u32)> {
-    let (h, m) = s.split_once(':')?;
-    let (h, m) = (h.parse::<u32>().ok()?, m.parse::<u32>().ok()?);
-    (h < 24 && m < 60).then_some((h, m))
-}
-
-/// Once the current local hour has reached the user's chosen hour (today), scan
-/// `day_local`'s day-tasks and auto-generate a worklog DRAFT (never approve,
-/// never post) for any past [`QUALIFYING_MINUTES`] that doesn't have a draft yet.
-/// A no-op when `worklog_auto_generate_time` is unset, or before that hour. Safe
-/// to call again later the same day (e.g. the machine was asleep at the chosen
-/// time) — see the module docs. Tasks are processed one at a time, in order —
-/// never concurrently.
-#[tracing::instrument(skip(pool, config))]
-pub async fn maybe_auto_generate(pool: &SqlitePool, config: &Config, day_local: &str) {
-    let span = tracing::info_span!(
-        "worklog.auto_generate.run",
-        day = day_local,
-        chosen_time = Empty,
-        gate = Empty,
-        tasks_total = Empty,
-        tasks_qualifying = Empty,
-        tasks_already_drafted = Empty,
-        tasks_drafted = Empty,
-        tasks_failed = Empty,
-    );
-    run(pool, config, day_local).instrument(span).await
-}
-
-async fn run(pool: &SqlitePool, config: &Config, day_local: &str) {
-    let current_span = tracing::Span::current();
-
-    let settings = meridian_core::settings::load_runtime_settings();
-    let Some(chosen_time) = settings.worklog_auto_generate_time else {
-        current_span.record("gate", "disabled");
-        return;
-    };
-    current_span.record("chosen_time", chosen_time.as_str());
-
-    let Some((chosen_hour, _)) = parse_hh_mm(&chosen_time) else {
-        current_span.record("gate", "malformed_time");
-        tracing::warn!(
-            chosen_time,
-            "worklog: auto-generate time is malformed — skipping"
-        );
-        return;
-    };
-    if Local::now().hour() < chosen_hour {
-        current_span.record("gate", "before_chosen_hour");
-        return;
-    }
-    current_span.record("gate", "ran");
-
-    draft_qualifying_tasks(pool, config, day_local, &current_span).await;
-}
-
-/// The "Generate now" path — the same day-task draft sweep as [`maybe_auto_generate`],
-/// but WITHOUT the time-of-day gate, run because the user asked for it on the spot
-/// (the daily-summary screen's "Generate now" button) rather than because the clock
-/// reached their chosen time. Everything else is identical: drafts only, never
-/// approves/posts, and skips any task that already has a draft, so it is safe to run
-/// alongside or before the scheduled pass. Independent of `worklog_auto_generate_time`:
-/// a user who never set a time can still generate on demand.
-#[tracing::instrument(skip(pool, config))]
-pub async fn generate_now(pool: &SqlitePool, config: &Config, day_local: &str) {
-    let span = tracing::info_span!(
-        "worklog.generate_now.run",
-        day = day_local,
-        gate = Empty,
-        tasks_total = Empty,
-        tasks_qualifying = Empty,
-        tasks_already_drafted = Empty,
-        tasks_drafted = Empty,
-        tasks_failed = Empty,
-    );
-    async {
-        let current_span = tracing::Span::current();
-        current_span.record("gate", "ran");
-        draft_qualifying_tasks(pool, config, day_local, &current_span).await;
-    }
-    .instrument(span)
-    .await
-}
+pub(super) const QUALIFYING_MINUTES: i64 = 30;
 
 /// What one sweep did. Returned rather than only recorded onto the span so the
 /// behaviour is assertable: "did this run at all" and "did it early-return" are
 /// otherwise indistinguishable from outside, which is exactly how a tracker gate
 /// silently disabled the whole feature for solo users once already.
 #[derive(Debug, Default, PartialEq, Eq)]
-struct SweepCounts {
+pub(super) struct SweepCounts {
     total: usize,
     qualifying: u32,
     already_drafted: u32,
@@ -201,19 +29,36 @@ struct SweepCounts {
 }
 
 /// Draft a worklog for every qualifying, not-yet-drafted day-task of `day_local`,
-/// recording per-run counts onto `span` and returning them. The shared body of
-/// [`maybe_auto_generate`] (gated on the clock) and [`generate_now`] (on demand); it
-/// assumes its caller has already decided a run is warranted.
+/// recording per-run counts onto `span`. The shared body of
+/// [`super::maybe_auto_generate`] (gated on the clock) and [`super::generate_now`]
+/// (on demand); it assumes its caller has already decided a run is warranted.
 ///
 /// Deliberately NOT gated on a connected tracker - a personal day-task is matched and
 /// drafted like any ticket, and only the propose branch needs one (it already fails
 /// per-task). See [`neither_sweep_is_gated_on_a_connected_tracker`].
-async fn draft_qualifying_tasks(
+pub(super) async fn draft_qualifying_tasks(
     pool: &SqlitePool,
     config: &Config,
     day_local: &str,
     span: &tracing::Span,
 ) -> SweepCounts {
+    // Matching a day-task against `pm_tasks` wants current ticket state, and there is
+    // no background poller keeping it fresh anymore — so this sweep asks for it.
+    //
+    // UNATTENDED on purpose. This runs on a clock (HH:03), which makes it the one
+    // remaining path that could fire a Jira OAuth refresh with nobody at the machine
+    // — the exact shape that permanently killed a production user's grant when a
+    // refresh POST straddled a 28-minute suspend. `run_pm_sync_unattended` will use a
+    // valid access token but never mint one, so an expired token simply defers to the
+    // next attended request instead of betting the grant. Best-effort either way: a
+    // sync failure must not block drafting against whatever is cached.
+    if let Err(e) = crate::intelligence::run_pm_sync_unattended(pool, config).await {
+        tracing::warn!(
+            day = day_local, error = %e,
+            "worklog: auto-generate pm sync failed — matching against cached tasks"
+        );
+    }
+
     let tasks = match meridian_core::day_tasks::get_day_tasks(pool, day_local).await {
         Ok(resp) => resp.tasks,
         Err(e) => {
@@ -305,7 +150,7 @@ async fn draft_qualifying_tasks(
 
 #[cfg(test)]
 mod tests {
-    use super::{draft_qualifying_tasks, parse_hh_mm, SweepCounts, QUALIFYING_MINUTES};
+    use super::{draft_qualifying_tasks, SweepCounts, QUALIFYING_MINUTES};
     use crate::config::Config;
     use sqlx::sqlite::SqlitePoolOptions;
     use sqlx::SqlitePool;
@@ -449,25 +294,6 @@ mod tests {
         assert_eq!(counts, SweepCounts::default());
     }
 
-    #[test]
-    fn parses_valid_times() {
-        assert_eq!(parse_hh_mm("00:00"), Some((0, 0)));
-        assert_eq!(parse_hh_mm("18:00"), Some((18, 0)));
-        assert_eq!(parse_hh_mm("23:59"), Some((23, 59)));
-        assert_eq!(parse_hh_mm("09:05"), Some((9, 5)));
-    }
-
-    #[test]
-    fn rejects_out_of_range_or_malformed_values() {
-        assert_eq!(parse_hh_mm("24:00"), None);
-        assert_eq!(parse_hh_mm("18:60"), None);
-        assert_eq!(parse_hh_mm("18"), None);
-        assert_eq!(parse_hh_mm("18:00:00"), None);
-        assert_eq!(parse_hh_mm(""), None);
-        assert_eq!(parse_hh_mm("not-a-time"), None);
-        assert_eq!(parse_hh_mm("ab:cd"), None);
-    }
-
     /// Neither entry point may re-acquire a "do they have a tracker" precondition.
     ///
     /// Source-level because the gate was a bare early return with no observable
@@ -477,7 +303,10 @@ mod tests {
     /// ticket); only the propose branch needs one, and it already fails per-task.
     #[test]
     fn neither_sweep_is_gated_on_a_connected_tracker() {
-        let src = include_str!("auto_generate.rs");
+        // Both files: `maybe_auto_generate`/`generate_now` (the entry points) live in
+        // `mod.rs`, the actual per-task loop lives here — a gate could reappear in
+        // either.
+        let src = concat!(include_str!("mod.rs"), "\n", include_str!("sweep.rs"));
         // Comment lines dropped, not just their markers - the module doc above
         // quotes the removed gate verbatim to explain why it went.
         let code: String = src

--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -681,6 +681,11 @@ pub async fn save_integration_token(
         tracing::debug!("daemon reload after token save (non-fatal — will pick up on next start)");
     }
 
+    // First-time (or credential-change) connect — force a sync so the board
+    // populates immediately rather than waiting for the next on-demand trigger.
+    // There's no stale cache to protect here, so gating buys nothing.
+    crate::commands::tasks::trigger_background_pm_force_sync(db_pool.get(), "token_connected");
+
     Ok(serde_json::json!({ "ok": true, "reloaded": reloaded }))
 }
 
@@ -1198,7 +1203,7 @@ pub async fn start_oauth(
     db_pool: State<'_, crate::db_pool::DbPool>,
 ) -> Result<StartOAuthResponse, String> {
     match body.provider.as_str() {
-        "jira" | "trello" => start_oauth_in_process(body.provider),
+        "jira" | "trello" => start_oauth_in_process(body.provider, db_pool.get()),
         "github" => start_oauth_github_device(body.provider, db_pool.inner().clone()).await,
         other => Err(format!("Unknown provider: {other}")),
     }
@@ -1251,7 +1256,10 @@ pub async fn cancel_oauth(body: CancelOAuthBody) -> Result<(), String> {
 /// functions — avoiding `std::env::set_var` on a Tokio worker thread (POSIX
 /// setenv is not thread-safe under concurrent env reads). A per-provider
 /// [`AtomicBool`] prevents two flows from racing to bind the same loopback port.
-fn start_oauth_in_process(provider: String) -> Result<StartOAuthResponse, String> {
+fn start_oauth_in_process(
+    provider: String,
+    db: Option<meridian_core::SqlitePool>,
+) -> Result<StartOAuthResponse, String> {
     // Resolve credentials from .env WITHOUT mutating process env.
     let mode = crate::install::detect_install_mode();
     let dot_env = mode.env_path().map(parse_env).unwrap_or_default();
@@ -1343,7 +1351,12 @@ fn start_oauth_in_process(provider: String) -> Result<StartOAuthResponse, String
         // Always clear the in-flight flag before returning, regardless of outcome.
         in_flight.store(false, Ordering::SeqCst);
         match result {
-            Ok(()) => tracing::info!(provider = %task_provider, "in-process OAuth login succeeded"),
+            Ok(()) => {
+                tracing::info!(provider = %task_provider, "in-process OAuth login succeeded");
+                // First-time connect — force a sync so the board populates
+                // immediately rather than waiting for the next on-demand trigger.
+                crate::commands::tasks::trigger_background_pm_force_sync(db, "oauth_connected");
+            }
             Err(e) => {
                 let msg = format!("{e:#}");
                 tracing::warn!(provider = %task_provider, error = %msg, "in-process OAuth login failed");
@@ -1457,10 +1470,19 @@ async fn start_oauth_github_device(
                     return;
                 }
                 tracing::info!("GitHub device-flow login succeeded");
+                // Grab the DB handle BEFORE `db_pool` is moved into the reload below,
+                // so the sync request can still be written afterwards.
+                let sync_db = db_pool.get();
                 // Best-effort reload so the token takes effect now, not next restart.
                 if let Err(e) = crate::commands::daemon::reload_daemon_with(db_pool).await {
                     tracing::debug!(error = %e, "daemon reload after GitHub connect (non-fatal)");
                 }
+                // First-time connect — force a sync so the board populates
+                // immediately rather than waiting for the next on-demand trigger.
+                crate::commands::tasks::trigger_background_pm_force_sync(
+                    sync_db,
+                    "oauth_connected",
+                );
             }
             Err(e) => {
                 let msg = format!("{e:#}");

--- a/tray/src-tauri/src/commands/tasks.rs
+++ b/tray/src-tauri/src/commands/tasks.rs
@@ -1,29 +1,72 @@
 //ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
-//! Task-board action commands — the ported `/api/tasks/sync` POST.
+//! Task-board action commands — the ported `/api/tasks/sync` POST, plus the
+//! on-demand sync triggers every other tray command fires into.
 //!
-//! Re-syncs the PM board: spawns `meridian tasks-sync`, which pulls the latest
-//! tickets from the connected tracker into `pm_tasks`. Tracker auth lives in the
-//! daemon, so — like every tracker write — this shells out to the CLI rather than
-//! talking to the provider directly; it's a process spawn, so it lives tray-side,
-//! not in meridian-core. (The per-task *read*, `get_tasks`, stays in
-//! [`crate::commands::dashboard`].)
+//! There is no background poller anymore: syncing `pm_tasks` from the connected
+//! tracker happens only at genuine on-demand moments — the manual "Sync now"
+//! button ([`sync_tasks`], force), connecting a tracker
+//! ([`trigger_background_pm_force_sync`], force, fire-and-forget), plan mount and
+//! the match-to-ticket picker ([`request_gated_sync_tasks`], gated, waits for
+//! result).
+//!
+//! # The tray does not sync, it ASKS
+//!
+//! Every function here writes a row to `pm_sync_requests` and the **daemon** does the
+//! work. The tray never holds a tracker credential, and it no longer spawns a
+//! `meridian` process to borrow one either.
+//!
+//! That is not tidiness, it is the fix for a production incident. An Atlassian OAuth
+//! refresh token is single-use and rotating: the old token dies the instant the new
+//! one is issued, so a lost response leaves the grant recoverable only inside a
+//! 10-minute window and permanently dead after it. The credential therefore has
+//! exactly one safe writer — and it used to have several (daemon, tray in-process,
+//! plus a fresh CLI process per trigger). The advisory file lock meant to serialise
+//! them could not: its 10 s timeout is shorter than the ~26 s a refresh can take, and
+//! on timeout the code proceeded WITHOUT the lock. Only Atlassian's grace window kept
+//! that from corrupting state.
+//!
+//! Requesting instead of doing also removed a per-trigger process spawn: opening the
+//! dashboard used to start a whole `meridian pm-sync` process — process init, DB
+//! open, config load — which then usually discovered the staleness gate and did
+//! nothing. It is now one coalescing UPSERT.
+//!
+//! (The per-task *read*, `get_tasks`, stays in [`crate::commands::dashboard`], and
+//! deliberately never triggers a sync itself — it's polled every 30-60s while a panel
+//! is mounted, and wiring a sync to that would silently rebuild the background-timer
+//! problem this replaces.)
 //!
 //! # Who calls this
-//! Registered in `lib.rs`'s `invoke_handler!`; consumed by `TasksView.tsx`'s Sync
-//! button via `ui/lib/bridge.ts::mutate` (success → re-fetch; error → inline msg).
+//! [`sync_tasks`] and [`request_gated_sync_tasks`] are registered in `lib.rs`'s
+//! `invoke_handler!`. `sync_tasks` (force) backs every "Sync now" — the Tasks panel,
+//! the planner's Refresh chip, and the per-provider button in Settings — via
+//! `ui/lib/taskSync.ts::syncTasks`. `request_gated_sync_tasks` backs
+//! `taskSync.ts::requestGatedTaskSync`, called by `PlanView` on mount and
+//! `WorklogTicketPicker` on open.
+//!
+//! [`trigger_background_pm_force_sync`] is a plain Rust fn (not a Tauri command),
+//! called from `commands::integrations`'s connect-success paths.
+//!
+//! Nothing calls a gated sync from a window opener any more: `open_dashboard` and
+//! `tray::open_native_dashboard` used to, and no longer do.
 //!
 //! # Related
-//! - [`crate::install::meridian_bin`] — the shared native-first binary resolver.
-//! - [`crate::commands::parents`] — the other read-side `meridian` CLI shell-out.
+//! - [`meridian_core::pm_sync_requests`] — the request/claim/complete API.
+//! - `src/intelligence/sync_requests.rs` — the daemon-side consumer.
+//! - `src/intelligence/sync_delegate.rs` — the producer side for the `meridian` CLI
+//!   subcommands the tray spawns (`tasks-sync`, `pm-sync`, `plan-task-*`,
+//!   `ticket-update`, `ticket-set-status`, `worklog-generate`), which delegate to the
+//!   same outbox when a daemon is running, for the same reason.
 
-use meridian_core::proc_ext::NoWindow;
+use meridian_core::pm_sync_requests::{self, SyncMode, ALL_PROVIDERS};
+use meridian_core::SqlitePool;
 use serde::Serialize;
 use std::time::Duration;
 
-/// How long `meridian tasks-sync` gets before the command gives up and reports
-/// a timeout. Named so the log field, the user-facing message and the timer can
-/// never disagree — they were three independent literals, and a `30` that drifts
-/// in one place turns a support report into a wrong-duration red herring.
+/// How long [`ask_daemon_to_sync`] waits for the daemon to report an outcome, and the
+/// budget for the no-daemon CLI fallback. Named so the log field, the user-facing
+/// message and the timer can never disagree — they were three independent literals,
+/// and a `30` that drifts in one place turns a support report into a wrong-duration
+/// red herring.
 const SYNC_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Success payload — mirrors the route's `{ ok, detail }` (the CLI's stdout).
@@ -33,83 +76,209 @@ pub struct SyncResult {
     pub detail: String,
 }
 
-/// Re-sync the board from the tracker (the ported /api/tasks/sync POST). Spawns
-/// `meridian tasks-sync` with a `SYNC_TIMEOUT` budget; returns its trimmed stdout as
-/// `detail` on success, or an `Err` carrying stderr (the route's 500 body.error)
-/// on timeout / spawn failure / non-zero exit.
+/// How often [`ask_daemon_to_sync`] re-reads the request row while waiting. The
+/// daemon's watcher ticks every 2 s, so this is matched to that rather than being
+/// tighter — a faster poll would just burn reads without seeing a result any sooner.
+const OUTCOME_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Resolve the tray's DB handle, or an error string suitable for returning straight
+/// to the frontend. `None` means the pool is closed (a repair or a corrupt DB), which
+/// is a real condition rather than a bug — say so plainly instead of unwrapping.
+fn require_pool(
+    pool: &tauri::State<'_, crate::db_pool::DbPool>,
+) -> Result<meridian_core::SqlitePool, String> {
+    pool.get()
+        .ok_or_else(|| "the database is not open - Meridian may be repairing it".to_string())
+}
+
+/// Re-sync the board from the tracker (the ported /api/tasks/sync POST) — always
+/// forces a fetch, bypassing the per-provider staleness gate, because the user
+/// explicitly asked for fresh data right now.
+///
+/// Asks the daemon rather than syncing here. The tray must never hold the tracker
+/// credential: the Jira refresh token is single-use and rotating, so two processes
+/// spending it can permanently kill the grant, and the daemon is the designated sole
+/// owner (see [`meridian_core::pm_sync_requests`]). This writes a `force` request,
+/// then polls the row for the outcome so the button can still report a real result.
 #[tauri::command]
-#[tracing::instrument]
-pub async fn sync_tasks() -> Result<SyncResult, String> {
-    let bin = crate::install::meridian_bin();
-    // The cwd picks the credentials, because dotenvy walks up from it: a release
-    // build lands on the canonical ~/.meridian/.env (AZURE_DEVOPS_PAT, JIRA_URL, …),
-    // a dev build on the checkout's own. Never inherit the tray's cwd — under a
-    // packaged .app that is inside the bundle, and dotenvy finds no .env at all.
-    let cwd = crate::install::cli_cwd()?;
-    // WHICH binary ran, and from where, are the two facts that make a failure here
-    // legible: a stale installed CLI against a DB the dev daemon migrated ahead
-    // exits non-zero with nothing but `status=Some(1)` in the log otherwise.
-    tracing::debug!(bin = %bin, cwd = %cwd.display(), "tasks-sync: spawning");
-    let child = tokio::process::Command::new(&bin)
-        .arg("tasks-sync")
-        .current_dir(&cwd)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        // On timeout below, `tokio::time::timeout` drops the output future; without
-        // this the orphaned `meridian tasks-sync` keeps running (and can still mutate
-        // the board) after the UI reports a failure. The deleted /api/tasks/sync route
-        // called child.kill() on its 30s timer — kill_on_drop preserves that contract.
-        .kill_on_drop(true)
-        .no_window()
-        .output();
-
-    let output = match tokio::time::timeout(SYNC_TIMEOUT, child).await {
-        Err(_) => {
-            // `kill_on_drop` reaps the child here, taking its stderr with it, so
-            // this log is the ONLY record a timeout ever leaves. Emitting a bare
-            // "tasks-sync timed out" (as it did) makes the two cases that matter
-            // indistinguishable in a support bundle: a genuinely slow tracker
-            // sync vs. a `meridian` binary that never got past opening a corrupt
-            // meridian.db. WHICH binary and WHICH cwd is what separates them —
-            // the same two facts the spawn/non-zero arms below already log.
-            tracing::warn!(
-                bin = %bin,
-                cwd = %cwd.display(),
-                timeout_s = SYNC_TIMEOUT.as_secs(),
-                "tasks-sync timed out"
-            );
-            return Err(format!(
-                "tasks-sync timed out after {}s",
-                SYNC_TIMEOUT.as_secs()
-            ));
-        }
-        Ok(Err(e)) => {
-            tracing::warn!(bin = %bin, error = %e, "tasks-sync spawn failed");
-            return Err(format!("spawn error: {e}"));
-        }
-        Ok(Ok(o)) => o,
-    };
-
-    if output.status.success() {
-        let detail = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        tracing::info!("tasks-sync ok");
-        Ok(SyncResult { ok: true, detail })
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        // Log the CLI's own reason, not just the exit code. `status=Some(1)` alone
-        // says nothing — the failure is always explained in stderr, and dropping it
-        // turned a one-line diagnosis into a manual re-run of the subcommand.
-        tracing::warn!(
-            status = ?output.status.code(),
-            bin = %bin,
-            stderr = %stderr,
-            "tasks-sync non-zero"
-        );
-        Err(if stderr.is_empty() {
-            "tasks-sync failed".to_string()
-        } else {
-            stderr
-        })
+#[tracing::instrument(skip(pool))]
+pub async fn sync_tasks(
+    pool: tauri::State<'_, crate::db_pool::DbPool>,
+) -> Result<SyncResult, String> {
+    let db = require_pool(&pool)?;
+    match ask_daemon_to_sync(&db, SyncMode::Force, "sync_now", "tasks-sync").await? {
+        Some(result) => Ok(result),
+        // The user pressed a button and is watching a spinner, so a timeout has to
+        // SAY something — but not "failed": the request is queued and the daemon will
+        // service it. This is the one caller that reports the wait as an error.
+        None => Err(format!(
+            "the sync is still running after {}s - it will finish in the background",
+            SYNC_TIMEOUT.as_secs()
+        )),
     }
+}
+
+/// Frontend-facing: request a **gated** sync and wait for the outcome.
+///
+/// # Only two screens should call this
+///
+/// The board is rendered in many places, but only two of them make a *decision from
+/// the whole task list*, and a stale board there is not a cosmetic lag:
+///
+/// - **The daily plan**, where the user picks the day's tickets. A ticket assigned an
+///   hour ago is simply ABSENT from the list they can pick from, so it cannot enter
+///   the plan at all. (`PlanView`, on mount.)
+/// - **The retarget / match-to-existing-ticket picker**, which lists every open
+///   ticket by definition. (`WorklogTicketPicker`, on open.)
+///
+/// Everything else showing the board is display and self-corrects on the next real
+/// trigger. In particular **worklog drafting does NOT need this**: matching reads the
+/// day's *plan* as its candidate pool, not the board (see
+/// `src/pm_worklog/generate.rs::fetch_plan_candidates` — "Not the board"), so a
+/// fresher board cannot widen the candidate set by even one ticket.
+///
+/// # Gated, and never on a poll
+///
+/// `Gated` rather than `Force` because these fire on mount/open, which recurs: the
+/// daemon applies the per-provider staleness window, so a re-open inside it costs one
+/// coalescing UPSERT instead of a tracker call. `sync_tasks` is the forced variant and
+/// belongs to buttons the user pressed.
+///
+/// **Never wire this to a polled read.** `PlanView` re-loads every 30 s and
+/// `TasksPanel` every 60 s; attaching a sync to those would rebuild the
+/// background-timer problem this whole design removed, relocated into the read path.
+/// Mount and click are one-shot; a poll is not.
+#[tauri::command]
+#[tracing::instrument(skip(pool))]
+pub async fn request_gated_sync_tasks(
+    pool: tauri::State<'_, crate::db_pool::DbPool>,
+) -> Result<SyncResult, String> {
+    let db = require_pool(&pool)?;
+    // A timeout here is NOT an error, unlike [`sync_tasks`]. Nothing is watching a
+    // spinner: the screen already rendered from cache and only wanted fresher rows.
+    // Returning `Err` would make the frontend log a failure for a sync that is simply
+    // still going, which is noise in the telemetry spool rather than information.
+    Ok(
+        ask_daemon_to_sync(&db, SyncMode::Gated, "plan_or_picker", "pm-sync")
+            .await?
+            .unwrap_or(SyncResult {
+                ok: false,
+                detail: "still running in the background".to_string(),
+            }),
+    )
+}
+
+/// Ask the daemon to sync and wait up to [`SYNC_TIMEOUT`] for its outcome.
+///
+/// `Ok(Some(_))` the daemon reported a result; `Ok(None)` the budget elapsed with the
+/// request still queued (not a failure - the daemon will service it); `Err` the sync
+/// itself failed, or the outbox could not be read.
+///
+/// Shared by [`sync_tasks`] and [`request_gated_sync_tasks`], which differ only in
+/// their mode, their tag, their no-daemon fallback subcommand, and what they make of a
+/// timeout. Those four params are the entire difference; everything else - the daemon
+/// probe, the fallback, the request write, the poll loop - was duplicated line for line
+/// between them, which is how the two drifted into having different log messages and
+/// only one of them being `#[instrument]`ed.
+///
+/// `fallback_cli` is the `meridian` subcommand that performs this same sync in its own
+/// process. It is used only when no daemon owns the data dir, where there is no second
+/// writer to race for the rotating credential - the tray still never holds a token
+/// itself. Without it, a queued row would sit unserviced and the user would watch a
+/// spinner time out with the daemon stopped.
+#[tracing::instrument(skip(db), fields(mode = mode.as_str()))]
+async fn ask_daemon_to_sync(
+    db: &SqlitePool,
+    mode: SyncMode,
+    reason: &'static str,
+    fallback_cli: &'static str,
+) -> Result<Option<SyncResult>, String> {
+    if !crate::commands::daemon_control::status().await.running {
+        tracing::debug!(
+            fallback_cli,
+            "no daemon - delegating to the CLI's own fallback"
+        );
+        let out =
+            crate::commands::cli_exec::run_meridian(&[fallback_cli], SYNC_TIMEOUT, fallback_cli)
+                .await?;
+        return Ok(Some(SyncResult {
+            ok: true,
+            detail: out.trim().to_string(),
+        }));
+    }
+
+    pm_sync_requests::request(db, ALL_PROVIDERS, mode, reason)
+        .await
+        .map_err(|e| format!("could not queue the sync: {e}"))?;
+
+    let deadline = tokio::time::Instant::now() + SYNC_TIMEOUT;
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            tracing::warn!(
+                timeout_s = SYNC_TIMEOUT.as_secs() as i64,
+                "daemon did not report a sync outcome in time"
+            );
+            return Ok(None);
+        }
+        tokio::time::sleep(OUTCOME_POLL_INTERVAL).await;
+
+        match pm_sync_requests::outcome(db, ALL_PROVIDERS).await {
+            Ok(Some(out)) => {
+                if let Some(err) = out.error {
+                    tracing::warn!(error = %err, "daemon reported a sync failure");
+                    return Err(err);
+                }
+                let detail = match out.synced_count {
+                    Some(n) => format!("synced {n} task(s)"),
+                    None => "synced".to_string(),
+                };
+                tracing::debug!(detail = %detail, "sync ok");
+                return Ok(Some(SyncResult { ok: true, detail }));
+            }
+            Ok(None) => continue,
+            Err(e) => return Err(format!("could not read the sync outcome: {e}")),
+        }
+    }
+}
+
+/// Fire-and-forget: ask the daemon to **force** a fetch (bypassing the staleness
+/// gate) — for a moment where there is no stale cache to protect, e.g. a tracker was
+/// just connected and the board should populate immediately rather than wait for the
+/// next on-demand trigger.
+///
+/// There is deliberately no `trigger_background_pm_sync` (gated) sibling any more. It
+/// existed for the dashboard window openers, and those were removed: a window opening
+/// is not evidence anyone is about to make a decision from the whole board. The two
+/// screens that genuinely are — the daily plan and the retarget ticket picker — ask
+/// for themselves through [`request_gated_sync_tasks`]. See that command's doc.
+pub(crate) fn trigger_background_pm_force_sync(db: Option<SqlitePool>, reason: &'static str) {
+    request_sync(db, SyncMode::Force, reason);
+}
+
+/// Write a sync request, fire-and-forget.
+///
+/// Unlike [`sync_tasks`] this does NOT fall back to the CLI when no daemon is running.
+/// These fire from window-open and connect-success paths where nothing is waiting on a
+/// result, so a queued row that the next daemon start services is the right outcome -
+/// spawning a process per window open is exactly the cost this replaced.
+///
+/// Takes `Option<SqlitePool>` (i.e. `DbPool::get()`) rather than a pool or an
+/// `AppHandle`, because `None` is a real state and not an error: the pool is closed
+/// while a corrupt DB is being repaired. Callers pass what they already hold, which
+/// is a `DbPool` in the integration paths and app state in the window paths.
+///
+/// Best-effort by design: these fire from window-open and connect-success paths
+/// where a failure must never block the thing the user asked for, and the next
+/// trigger (or their explicit "Sync now") retries anyway.
+fn request_sync(db: Option<SqlitePool>, mode: SyncMode, reason: &'static str) {
+    let Some(db) = db else {
+        tracing::debug!(reason, "pm sync request skipped - database not open");
+        return;
+    };
+    tauri::async_runtime::spawn(async move {
+        match pm_sync_requests::request(&db, ALL_PROVIDERS, mode, reason).await {
+            Ok(()) => tracing::debug!(reason, mode = mode.as_str(), "pm sync requested"),
+            Err(e) => tracing::debug!(reason, error = %e, "pm sync request failed"),
+        }
+    });
 }

--- a/tray/src-tauri/src/commands/tasks.rs
+++ b/tray/src-tauri/src/commands/tasks.rs
@@ -81,6 +81,35 @@ pub struct SyncResult {
 /// tighter — a faster poll would just burn reads without seeing a result any sooner.
 const OUTCOME_POLL_INTERVAL: Duration = Duration::from_millis(500);
 
+/// Turn a failed request-write into something a user can act on.
+///
+/// # Why the missing-table case is special-cased
+///
+/// `pm_sync_requests` arrives in migration 082, and **only the daemon runs migrations**
+/// (the tray opens the file with `create_if_missing(false)` and assumes the daemon made
+/// it). So during an app update there is a window — new tray already running, daemon not
+/// yet restarted onto the new binary — where the table genuinely does not exist yet.
+///
+/// It is seconds long and self-heals the moment the daemon restarts, but a user who
+/// presses "Sync now" inside it would otherwise be shown a raw SQL string:
+/// `could not queue the sync: no such table: pm_sync_requests`. That reads like
+/// database damage for what is in fact a normal, transient update state, and it is the
+/// kind of message that produces a support ticket about a non-problem.
+///
+/// Matched on the message rather than a typed error because sqlx surfaces this as a
+/// `Database` error whose only distinguishing feature IS its text; the match is
+/// deliberately loose (table name plus "no such table") so a reworded sqlite message
+/// degrades to the generic branch rather than mis-reporting something else.
+fn queue_failure_message(e: &anyhow::Error) -> String {
+    let detail = format!("{e:#}");
+    if detail.contains("no such table") && detail.contains("pm_sync_requests") {
+        tracing::warn!("pm_sync_requests missing - the daemon has not applied migration 082 yet");
+        return "Meridian is still finishing an update - try again in a moment".to_string();
+    }
+    tracing::warn!(error = %detail, "could not queue a PM sync request");
+    format!("could not queue the sync: {detail}")
+}
+
 /// Resolve the tray's DB handle, or an error string suitable for returning straight
 /// to the frontend. `None` means the pool is closed (a repair or a corrupt DB), which
 /// is a real condition rather than a bug — say so plainly instead of unwrapping.
@@ -207,9 +236,9 @@ async fn ask_daemon_to_sync(
         }));
     }
 
-    pm_sync_requests::request(db, ALL_PROVIDERS, mode, reason)
-        .await
-        .map_err(|e| format!("could not queue the sync: {e}"))?;
+    if let Err(e) = pm_sync_requests::request(db, ALL_PROVIDERS, mode, reason).await {
+        return Err(queue_failure_message(&e));
+    }
 
     let deadline = tokio::time::Instant::now() + SYNC_TIMEOUT;
     loop {
@@ -281,4 +310,55 @@ fn request_sync(db: Option<SqlitePool>, mode: SyncMode, reason: &'static str) {
             Err(e) => tracing::debug!(reason, error = %e, "pm sync request failed"),
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The update window: `pm_sync_requests` does not exist yet because the daemon
+    /// has not applied migration 082. The user must see a transient-update message,
+    /// never a raw SQL string that reads like database damage.
+    #[test]
+    fn a_missing_requests_table_reads_as_a_pending_update() {
+        let e = anyhow::anyhow!(
+            "error returned from database: (code: 1) no such table: pm_sync_requests"
+        );
+
+        let msg = queue_failure_message(&e);
+
+        assert_eq!(
+            msg,
+            "Meridian is still finishing an update - try again in a moment"
+        );
+        assert!(!msg.contains("no such table"), "must not leak SQL: {msg}");
+    }
+
+    /// Any OTHER write failure keeps its detail. Collapsing every error into the
+    /// friendly update message would hide a real fault (a locked or corrupt DB) behind
+    /// "try again in a moment", which never resolves.
+    #[test]
+    fn other_failures_keep_their_detail() {
+        let e = anyhow::anyhow!("database is locked");
+
+        let msg = queue_failure_message(&e);
+
+        assert!(
+            msg.contains("database is locked"),
+            "detail was dropped: {msg}"
+        );
+    }
+
+    /// A missing table that is NOT ours is somebody else's problem and must not be
+    /// reported as a pending update - that would send the user to wait out an update
+    /// that is already finished while the real fault goes unnamed.
+    #[test]
+    fn a_different_missing_table_is_not_reported_as_an_update() {
+        let e = anyhow::anyhow!("no such table: pm_tasks");
+
+        let msg = queue_failure_message(&e);
+
+        assert!(msg.contains("pm_tasks"), "detail was dropped: {msg}");
+        assert!(!msg.contains("finishing an update"), "misattributed: {msg}");
+    }
 }

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -1358,6 +1358,7 @@ pub fn run() {
             // process / service control (ported /api process routes)
             commands::reload_daemon,
             commands::sync_tasks,
+            commands::request_gated_sync_tasks,
             commands::run_update,
             // tracker connect/disconnect (ported /api/integrations + /api/auth/oauth)
             commands::disconnect_integration,

--- a/ui/components/plan/PlanView.tsx
+++ b/ui/components/plan/PlanView.tsx
@@ -25,7 +25,7 @@ import { dayString } from '@/components/timeline/types'
 import type { PlanResponse, IntegrationsResponse } from '@/lib/api-types'
 import { MAX_PLAN_TASKS } from '@/lib/api-types'
 import { load as bridgeLoad } from '@/lib/bridge'
-import { lastSyncFailure, syncTasks } from '@/lib/taskSync'
+import { lastSyncFailure, requestGatedTaskSync, syncTasks } from '@/lib/taskSync'
 import { availableTrackerNames, connectedTrackers } from '@/lib/integrations'
 import { usePlan, refreshPlan, planAction, pausePlanRefresh } from '@/components/plan/planStore'
 import { isTutorialRunning } from '@/components/tutorial/engine'
@@ -219,14 +219,35 @@ export default function PlanView() {
   useEffect(() => {
     if (autoSyncedRef.current || !trackersLoaded || !data) return
     autoSyncedRef.current = true
-    // Nothing to pull, or something already there to show: the wait is over
-    // before it started.
-    if (trackers.length === 0 || (data.available?.length ?? 0) > 0) { setFirstSyncDone(true); return }
+    // Nothing to pull: the wait is over before it started.
+    if (trackers.length === 0) { setFirstSyncDone(true); return }
+    // A POPULATED board still needs a refresh, just not a blocking one.
+    //
+    // This branch used to return immediately, on the reasoning that there was
+    // "something already there to show". True for the empty-board spinner this
+    // backstop exists for, but it left the planner as the one screen that picks
+    // from the whole task list while never asking for a current copy of it - so a
+    // ticket assigned an hour ago was absent from the list, and the only way to
+    // see it was noticing the Refresh chip. Absent, not stale: it cannot be put in
+    // today's plan at all.
+    //
+    // GATED, unlike the empty branch's forced `handleSync`: this fires on every
+    // planner open, so the per-provider staleness window is what keeps it from
+    // becoming a tracker call each time. Not awaited before `setFirstSyncDone` -
+    // the cached board renders now and the 30 s poll picks the fresher rows up.
+    if ((data.available?.length ?? 0) > 0) {
+      void requestGatedTaskSync().then((ok) => { if (ok) void load(false) })
+      setFirstSyncDone(true)
+      return
+    }
     // Usually this JOINS the sync the connect flow already started - see `handleSync`.
     // It stays as a backstop because plenty of empty-board arrivals never went near a
     // connect: a reopened app, a board that emptied, a sync that failed an hour ago.
     handleSync().finally(() => setFirstSyncDone(true))
-  }, [data, trackers, trackersLoaded, handleSync])
+    // `load` is in the deps because the populated branch above calls it directly.
+    // Re-running is harmless either way: `autoSyncedRef` makes the whole effect
+    // one-shot per mount.
+  }, [data, trackers, trackersLoaded, handleSync, load])
 
   // The drag hold-off is module-global, so a planner closed mid-drag (onDragEnd
   // never fires) would strand every reader's refresh paused for the rest of the

--- a/ui/components/timeline/WorklogTicketPicker.tsx
+++ b/ui/components/timeline/WorklogTicketPicker.tsx
@@ -23,6 +23,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { load } from '@/lib/bridge'
+import { requestGatedTaskSync } from '@/lib/taskSync'
 import type { BoardTicket } from '@/lib/api-types'
 
 /** Rank the board against a query: key first (people type "KAN-3"), then title,
@@ -64,9 +65,22 @@ export function WorklogTicketPicker({ current, busy, onPick, onCancel, title, ex
   useEffect(() => {
     if (tickets) return
     let alive = true
-    load<BoardTicket[]>('/api/board-tickets', 'get_board_tickets')
+    const read = () => load<BoardTicket[]>('/api/board-tickets', 'get_board_tickets')
       .then(r => { if (alive) setFetched(excludeLocal ? r.filter(t => t.provider !== 'local') : r) })
       .catch(() => { if (alive) setError('Could not load your board - try again in a moment.') })
+
+    // Show the cached board immediately, then ask for a refresh and re-read.
+    //
+    // This picker is the ONE surface whose entire purpose is choosing from the whole
+    // board, so a ticket missing from it is not a cosmetic lag - the user cannot
+    // retarget onto a ticket that is not listed, and nothing on screen suggests the
+    // list is incomplete. It had no refresh of its own and relied on whatever some
+    // other screen had happened to fetch.
+    //
+    // Ordered read-then-refresh-then-read on purpose: opening a picker must never
+    // wait on a network round trip. GATED, so opening it repeatedly stays inside the
+    // per-provider staleness window rather than hitting the tracker each time.
+    void read().then(() => requestGatedTaskSync()).then(ok => { if (ok && alive) void read() })
     return () => { alive = false }
   }, [excludeLocal, tickets])
 

--- a/ui/components/timeline/settings/IntegrationsSection.tsx
+++ b/ui/components/timeline/settings/IntegrationsSection.tsx
@@ -64,7 +64,7 @@ export function IntegrationsSection({ integrations, onChanged, gate = false, onD
               Connected to {connected.map(t => t.name).join(', ')}
             </p>
             <p className="text-[11.5px] font-semibold mt-0.5" style={{ color: 'color-mix(in srgb, var(--color-state-approved) 75%, var(--t-muted))' }}>
-              Syncing every hour
+              Kept in sync automatically
             </p>
           </div>
         </div>

--- a/ui/lib/taskSync.ts
+++ b/ui/lib/taskSync.ts
@@ -137,3 +137,59 @@ export function syncTasks(): Promise<boolean> {
 export function pendingTaskSync(): Promise<boolean> | null {
   return inFlight
 }
+
+/**
+ * Refresh the board for a screen that is about to make a decision from the WHOLE
+ * task list, and would behave differently against a stale one.
+ *
+ * # Only two screens should call this
+ *
+ * - **The daily plan**, where the user picks the day's tickets. A stale board here
+ *   is not a cosmetic lag: a ticket assigned an hour ago is simply absent from the
+ *   list they can pick from, so it cannot enter the plan at all. That is the
+ *   candidate-starvation failure, and it is why this exists.
+ * - **The retarget / match-to-existing-ticket picker**, which lists every open
+ *   ticket by definition.
+ *
+ * Worklog drafting deliberately does NOT call this: matching reads the day's *plan*
+ * as its candidate pool, not the board (`fetch_plan_candidates` - "Not the board"),
+ * so a fresher board cannot widen the candidate set by even one ticket.
+ *
+ * # Gated, unlike `syncTasks`
+ *
+ * `syncTasks` FORCES a fetch, which is right for a button the user pressed and wrong
+ * for a mount: a screen the user opens repeatedly would hit the tracker every time.
+ * This goes through `request_gated_sync_tasks`, so the daemon applies the
+ * per-provider staleness window and a re-open inside it costs one local UPSERT.
+ *
+ * **Never call this from a poll.** `PlanView` re-loads every 30 s and `TasksPanel`
+ * every 60 s; wiring it there would rebuild the background-timer problem this whole
+ * design removed, relocated into the read path. Mount and click are one-shot.
+ *
+ * NEVER REJECTS, for the same reason as `syncTasks`: resolves `true` on a completed
+ * sync and `false` on a failure. Callers that only want fresher rows can ignore the
+ * value; nothing on these screens should break because a refresh failed, since the
+ * cached board still renders.
+ *
+ * Deliberately NOT joined to `inFlight`: that promise tracks the *forced* sync, and
+ * a gated request is a different ask. It is cheap enough (one UPSERT when the window
+ * is closed) that sharing state would cost more in surprise than in requests.
+ */
+export function requestGatedTaskSync(): Promise<boolean> {
+  return mutate<{ ok: boolean }>('/api/tasks/sync', 'request_gated_sync_tasks', {})
+    // `ok: false` means the daemon had not reported back inside its budget - the sync
+    // is still running, so there is nothing fresher to re-read YET. Reported as
+    // `false` so callers skip a pointless re-read; it is not a failure and nothing is
+    // logged for it (unlike the `.catch` below).
+    .then((r) => r?.ok !== false)
+    .catch((e) => {
+      // Reported, not surfaced: unlike the Refresh chip there is no UI element
+      // waiting to explain this, and the screen renders fine from cache. It still
+      // has to reach the telemetry spool, or a board that is quietly never
+      // refreshing looks identical to one that is up to date.
+      const reason = syncFailureReason(e)
+      console.error('[meridian] gated tracker sync failed', e)
+      reportUiError(`gated tracker sync failed: ${reason}`)
+      return false
+    })
+}


### PR DESCRIPTION
## Why

A production user lost their Jira grant permanently. A timer-driven OAuth refresh POST fired at 18:26:55, the laptop suspended for 28 minutes mid-request, and the retry — instant on wake at 18:55:29 — landed 18 minutes outside Atlassian's 10-minute reuse-leeway window. Banner: *"Jira sync failing… refresh_token is invalid."*

Two root causes, both structural:

**1. The credential had several writers.** An Atlassian refresh token is single-use and rotating: the old one dies the instant the new one is issued. That makes it a resource with exactly **one** safe writer. It had the daemon's poll loop, the tray in-process, and a fresh `meridian` CLI process per trigger. The advisory file lock meant to serialise them could not — its 10s timeout is shorter than the ~26s a refresh can take, and **on timeout the code proceeded without the lock**. Only Atlassian's grace window prevented corruption.

**2. Refreshes fired on a clock.** The daemon synced every poll tick, so a real Jira fetch happened roughly every 5 minutes forever, whether or not anyone was there. Any suspend could land on one.

## What changed

**An outbox** (`pm_sync_requests`, migration 082). Producers write a coalescing request row; the daemon's watcher is the sole consumer. The tray and the `tasks-sync` / `pm-sync` / `plan-task-*` / `ticket-update` / `ticket-set-status` / `worklog-generate` CLIs all *ask* instead of *doing*. The only remaining in-process sync is the fallback when no daemon is running, where there is no second writer to race.

**An attended/unattended split** (`Trigger`). Unattended code may **use** a valid access token but must never **mint** one. The clock-driven worklog sweep goes through `current_if_valid`, so an expired token defers rather than refreshing — a laptop shut overnight no longer raises a sync error every morning. Every refresh now sits immediately behind a human action.

**The standing timer is gone.** Zero `run_pm_sync` calls remain in the daemon's poll loop.

### Where sync happens now

| Trigger | Mode |
|---|---|
| Connect a tracker (incl. tutorial first-connect), project-picker success | Force |
| "Sync now" — Tasks panel, planner Refresh chip, per-provider in Settings | Force |
| Board write (create / done / edit / ticket-update / set-status) | Force |
| **Daily plan, on mount** | Gated |
| **Retarget ticket picker, on open** | Gated |
| Worklog drafting sweep (HH:03) | Gated, unattended — cannot mint |
| ~~Dashboard window open~~ | **removed** |

Dashboard-open is deliberately *not* a trigger: a window opening is not evidence anyone is about to read the board. It fired where it didn't matter, while the retarget picker — whose entire purpose is choosing from the whole board — had no refresh at all. Worklog drafting needs none either: matching reads the day's **plan** as its candidate pool, not the board (`fetch_plan_candidates` — *"Not the board"*), so a fresher board cannot widen the candidate set by one ticket.

Gated means the per-provider 5-minute window still applies, so opening the planner ten times costs one Jira call.

## Bugs found and fixed while building this

- **A spent `force` escalated every later `gated` request, forever.** The `ON CONFLICT` inherited `force` from the existing row without checking whether it had completed — and the row is kept after completion so "Sync now" can read its result. One tracker connect would have made every planner open bypass the staleness gate and hit Jira, multiplying exactly the refreshes this PR exists to reduce. **This passed 10 existing tests.** Two new tests pin it; the regression test was verified to fail against the old SQL.
- **"Sync now" broke with the daemon stopped** — queued a row nobody would service. Now shells out to the CLI's own no-daemon fallback.
- **`meridian tasks-sync` exited 0 on a failed sync**, so the tray's fallback reported success for a sync that never happened.
- **`sync_freshness` warned purely on elapsed time** — a guaranteed false positive once quiet periods became normal.
- A raw `no such table: pm_sync_requests` could reach the user during the update window (second commit).

## Risk

- **Migration 082 is `CREATE TABLE IF NOT EXISTS`** and nothing else. Additive, idempotent, touches no existing table or row. Only the daemon runs migrations, so there is no concurrent-migrator race.
- **Fails safe:** the watcher logs at `debug` and returns if the table is absent, so a missed migration means PM sync doesn't run — nothing crashes.
- **The Jira error classification and the OAuth refresh itself are untouched** — re-indented into the attended arm, no logic change. The blast radius is *when* a sync fires, not *how*.
- A **downgrade** would break the daemon (sqlx `VersionMissing`), but that is true of all 82 migrations and is not introduced here.

## Verification

Green: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (1091 daemon + 429 tray + 311 core + 50 oauth, 0 failed), `tsc --noEmit`, `bun test` (915 pass / 0 fail), static export build.

## ⚠️ Needs manual verification before merge

**No automated coverage exists for the tray-to-daemon round trip.** Every test here is unit-level against in-memory SQLite; two live processes sharing one SQLCipher WAL file has never been exercised. Three of the bugs above passed every gate and would have surfaced in minutes of clicking — please don't read green CI as proof.

- [ ] "Sync now" with the daemon running, then with it stopped
- [ ] Open the planner twice inside 5 min — expect one Jira call, not two
- [ ] Connect Jira fresh — board populates without pressing Sync now
- [ ] Open the retarget ticket picker — the new trigger fires
- [ ] Migration 082 applies to a real encrypted WAL `meridian.db`
- [ ] Leave it overnight, open next morning — **no sync error** (the whole point)

## Follow-ups (not in scope here)

- Tokens are stored in a plaintext file, not the keychain (#727) — a backup restore still carries a dead grant
- Users whose grant is *already* dead are not healed; they need a one-time reconnect and nothing prompts them
- `store::lock_provider` still proceeds without the lock on timeout — much narrower now, but unfixed
- WAL-checkpoint discipline across the tray/daemon boundary (the #851 corruption cause) deserves its own issue
