### PR TITLE
fix(sync): a transient SQLite fault must not fail a queued sync

### DIFF
--- a/src/db/integrity.rs
+++ b/src/db/integrity.rs
@@ -145,6 +145,56 @@ pub fn is_corrupt_sqlx(err: &sqlx::Error) -> bool {
     }
 }
 
+/// SQLite primary result codes that mean "this attempt failed, the database is
+/// fine" - the file was locked, or a read came up short because another process
+/// moved the ground under it.
+///
+/// `SQLITE_IOERR` (10) is the one that matters here and the reason this exists.
+/// Its extended variant `SQLITE_IOERR_SHORT_READ` (522, `10 | (2 << 8)`) is
+/// SQLite asking for a page and being handed fewer bytes than it expected -
+/// which is exactly what a reader sees when the daemon's shutdown
+/// `PRAGMA wal_checkpoint(TRUNCATE)` truncates the WAL underneath it. Measured
+/// on 1.91.0-staging.3: the tray's "Sync now" read of the outbox raced a daemon
+/// reload and surfaced `(code: 522) disk I/O error` to the user, for a sync the
+/// daemon then completed successfully 5 s later.
+///
+/// `SQLITE_BUSY` (5) and `SQLITE_LOCKED` (6) belong to the same class: two
+/// processes write this file, so losing a lock race is a normal event.
+const SQLITE_TRANSIENT: [u32; 3] = [10, 5, 6];
+
+/// True when `err` is SQLite reporting a **retryable** failure - the operation
+/// did not happen, but nothing is wrong with the data.
+///
+/// # Never confuse this with corruption
+///
+/// Corruption (11) and "file is not a database" (26) are deliberately absent.
+/// Those are latching conditions that need an operator, and retrying them just
+/// re-reads damaged pages - the daemon's ETL latch exists for precisely that
+/// reason. This predicate is only for faults where trying again is the correct
+/// and sufficient response.
+///
+/// The low byte is compared rather than the whole code, so extended variants
+/// (`_SHORT_READ`, `_READ`, `_WRITE`, `_FSYNC`, …) are all covered - the same
+/// `primary | (n << 8)` scheme [`is_corrupt_sqlx`] relies on.
+pub fn is_transient_sqlx(err: &sqlx::Error) -> bool {
+    let sqlx::Error::Database(db) = err else {
+        return false;
+    };
+    db.code()
+        .and_then(|c| c.parse::<u32>().ok())
+        .is_some_and(|code| SQLITE_TRANSIENT.contains(&(code & 0xFF)))
+}
+
+/// [`is_transient_sqlx`] over an `anyhow` chain, for callers holding a
+/// `.context(…)`-wrapped error. Same chain-walk rationale as
+/// [`is_corrupt_error`]: the `sqlx::Error` is never the outermost layer by the
+/// time a command sees it.
+pub fn is_transient_error(err: &anyhow::Error) -> bool {
+    err.chain()
+        .filter_map(|c| c.downcast_ref::<sqlx::Error>())
+        .any(is_transient_sqlx)
+}
+
 /// SQLite's `SQLITE_NOTADB` primary result code - "file is not a database".
 ///
 /// This is what a keyed open reports when page 1 itself is unreadable: SQLCipher
@@ -377,6 +427,53 @@ mod tests {
         )
         .context("failed to read first frame batch");
         assert!(is_corrupt_error(&err));
+    }
+
+    /// Guards the `& 0xFF` masking for the transient family. `522`
+    /// (`SQLITE_IOERR_SHORT_READ`) is the measured case - the code the tray was
+    /// shown when a "Sync now" read raced the daemon's shutdown WAL truncate -
+    /// and an equality test against 10 would miss it entirely.
+    #[test]
+    fn transient_codes_match_primary_and_extended() {
+        // IOERR (10) and its extended variants, plus BUSY (5) and LOCKED (6).
+        for code in [10u32, 266, 522, 778, 5, 6, 261] {
+            assert!(
+                SQLITE_TRANSIENT.contains(&(code & 0xFF)),
+                "code {code} must be transient"
+            );
+        }
+        for code in [11u32, 267, 523, 779, 26, 19, 1] {
+            assert!(
+                !SQLITE_TRANSIENT.contains(&(code & 0xFF)),
+                "code {code} must not be transient"
+            );
+        }
+    }
+
+    /// The two classifications must never overlap. A corrupt database routed into
+    /// the retry path would spin re-reading damaged pages instead of latching and
+    /// raising the banner - the exact failure the ETL latch exists to prevent.
+    #[test]
+    fn corruption_is_never_transient() {
+        for code in [11u32, 267, 523, 779] {
+            assert_eq!(code & 0xFF, SQLITE_CORRUPT);
+            assert!(
+                !SQLITE_TRANSIENT.contains(&(code & 0xFF)),
+                "corrupt code {code} must never be retryable"
+            );
+        }
+    }
+
+    /// Unlike [`is_corrupt_error`], the transient predicate has NO message
+    /// fallback: a stringified error is classified as non-transient and therefore
+    /// terminal. That is the safe direction (a real fault surfaces instead of
+    /// being silently retried), and it is pinned so nobody "fixes" the asymmetry
+    /// without weighing it.
+    #[test]
+    fn a_stringified_transient_error_is_not_retried() {
+        let err = anyhow::anyhow!("error returned from database: (code: 522) disk I/O error")
+            .context("reading the PM sync outcome");
+        assert!(!is_transient_error(&err));
     }
 
     #[test]

--- a/tray/src-tauri/src/commands/tasks/mod.rs
+++ b/tray/src-tauri/src/commands/tasks/mod.rs
@@ -81,6 +81,22 @@ pub struct SyncResult {
 /// tighter — a faster poll would just burn reads without seeing a result any sooner.
 const OUTCOME_POLL_INTERVAL: Duration = Duration::from_millis(500);
 
+/// Attempts [`ask_daemon_to_sync`] makes to WRITE the request row before giving up.
+///
+/// Sized against the thing it is riding out: a daemon reload, during which the tray's
+/// pool is closed and reopened and the daemon truncates the WAL on its way out. That
+/// window is on the order of a second, so 4 attempts spaced [`REQUEST_RETRY_GAP`]
+/// apart covers it with margin while still failing in ~1.2 s if the fault is real.
+///
+/// Only retries faults that mean "not now" - a cycling pool, or a transient SQLite
+/// code. A corrupt database still fails on the first attempt (after one recycle),
+/// because retrying that only re-reads damaged pages.
+const REQUEST_ATTEMPTS: u32 = 4;
+
+/// Gap between [`REQUEST_ATTEMPTS`]. Shorter than the daemon watcher's 2 s tick on
+/// purpose: this is waiting out a pool cycle, not waiting for a sync.
+const REQUEST_RETRY_GAP: Duration = Duration::from_millis(400);
+
 /// Shown when an outbox query fails because `meridian.db` itself is damaged. Points
 /// at the banner rather than repeating the SQLite text, because
 /// [`explain_outbox_failure`] has just raised that banner and it carries both the
@@ -328,13 +344,44 @@ async fn ask_daemon_to_sync(
     let mut attempt = 0;
     let seq = loop {
         attempt += 1;
-        let pool = db
-            .get()
-            .ok_or_else(|| "the database is not open - Meridian may be repairing it".to_string())?;
+        let last_attempt = attempt >= REQUEST_ATTEMPTS;
+
+        // A CLOSED pool is a normal, momentary state, not a fault. Connecting a
+        // tracker reloads the daemon, and `reload_with_pool_cycle` closes this pool
+        // across the signal - so a "Sync now" pressed in that window used to return
+        // "the database is not open - Meridian may be repairing it" instantly, naming
+        // a repair that was not happening. Wait it out instead.
+        let Some(pool) = db.get() else {
+            if last_attempt {
+                return Err("the database is not open - Meridian may be repairing it".to_string());
+            }
+            tracing::debug!(
+                attempt,
+                "pool is cycling - waiting to queue the sync request"
+            );
+            tokio::time::sleep(REQUEST_RETRY_GAP).await;
+            continue;
+        };
+
         match pm_sync_requests::request(&pool, ALL_PROVIDERS, mode, reason).await {
             Ok(seq) => break seq,
             Err(e) => {
                 let rendered = crate::cmd_err!(e, "could not queue a PM sync request");
+
+                // Transient (locked, or a short read against a WAL the daemon is
+                // truncating on its way out): the write simply did not happen and
+                // nothing is wrong with the data. See
+                // `meridian::db::integrity::is_transient_sqlx` for the measured case.
+                if !last_attempt && meridian::db::integrity::is_transient_error(&e) {
+                    tracing::debug!(
+                        attempt,
+                        detail = %rendered,
+                        "transient fault queueing the sync request - retrying"
+                    );
+                    tokio::time::sleep(REQUEST_RETRY_GAP).await;
+                    continue;
+                }
+
                 // Raises the banner and recycles the pool when the fault is a broken
                 // view; returns whether a retry is worth making.
                 let recovered = db.recover_if_corrupt(&e).await;
@@ -395,6 +442,26 @@ async fn ask_daemon_to_sync(
             // written for.
             Err(e) => {
                 let rendered = crate::cmd_err!(e, "could not read the PM sync outcome");
+                // A TRANSIENT fault is not an answer - it is the absence of one, and
+                // the request row is already written, so the only correct response is
+                // to poll again.
+                //
+                // This branch shipped as terminal and that was the bug. Measured on
+                // 1.91.0-staging.3: connecting Jira reloads the daemon, whose shutdown
+                // runs `PRAGMA wal_checkpoint(TRUNCATE)`; a "Sync now" read landing in
+                // that window got `(code: 522) disk I/O error`
+                // (`SQLITE_IOERR_SHORT_READ` - the WAL truncated under the reader) and
+                // the user was shown a red failure. The daemon completed that very sync
+                // 5 s later, with 47 poll turns still left in the budget. Same class of
+                // lie as the outcome-destroying bug this loop was written to fix,
+                // reached from the other side.
+                if meridian::db::integrity::is_transient_error(&e) {
+                    tracing::debug!(
+                        detail = %rendered,
+                        "transient fault reading the sync outcome - retrying"
+                    );
+                    continue;
+                }
                 // Recycle on a broken view here too, then keep waiting rather than
                 // failing: the request row is written and the daemon is servicing it,
                 // so a healed pool on the next poll turn still reports a real result.

--- a/tray/src-tauri/src/commands/tasks/tests.rs
+++ b/tray/src-tauri/src/commands/tasks/tests.rs
@@ -160,3 +160,61 @@ async fn the_fallback_names_the_operation_that_actually_failed() {
     );
     assert!(write.starts_with("could not queue the sync"), "{write}");
 }
+
+/// The whole point of the 1.91.0-staging.3 fix, pinned where it can regress.
+///
+/// `ask_daemon_to_sync` has two SQLite call sites - the request write and the
+/// outcome read - and both used to treat any `Err` as terminal. A daemon reload
+/// truncates the WAL on its way out, so a read landing in that window returned
+/// `(code: 522) disk I/O error` and the user was shown a red failure for a sync
+/// the daemon went on to complete seconds later, with most of the 30 s budget
+/// unspent.
+///
+/// A source scan rather than a behavioural test because provoking a short read
+/// needs two real processes racing a `wal_checkpoint(TRUNCATE)` on a real file -
+/// the one thing an in-memory pool cannot reproduce. Same idiom, and the same
+/// reason, as `ui/__tests__/no-native-dialogs.test.ts`.
+#[test]
+fn transient_faults_are_retried_before_any_terminal_failure() {
+    let src = include_str!("mod.rs");
+
+    let guards: Vec<_> = src
+        .match_indices("is_transient_error")
+        .map(|(i, _)| i)
+        .collect();
+    let terminals: Vec<_> = src
+        .match_indices("explain_outbox_failure(")
+        .map(|(i, _)| i)
+        // Skip the definition itself; only the call sites matter.
+        .filter(|i| !src[..*i].ends_with("async fn "))
+        .collect();
+
+    assert_eq!(
+        guards.len(),
+        2,
+        "both SQLite call sites in ask_daemon_to_sync must classify transient faults"
+    );
+    for terminal in &terminals {
+        assert!(
+            guards.iter().any(|g| g < terminal),
+            "a terminal failure at byte {terminal} is reachable with no transient check before it"
+        );
+    }
+}
+
+/// The retry budget has to outlast the thing it exists to ride out. A daemon
+/// reload closes the tray's pool, signals, and lets the daemon checkpoint and
+/// exit - on the order of a second. A budget shorter than that would turn this
+/// fix into a coin flip.
+#[test]
+fn the_request_retry_budget_covers_a_daemon_reload() {
+    let covered = REQUEST_RETRY_GAP * (REQUEST_ATTEMPTS - 1);
+    assert!(
+        covered >= Duration::from_millis(1200),
+        "retry budget {covered:?} is too short to outlast a daemon reload"
+    );
+    assert!(
+        covered < SYNC_TIMEOUT,
+        "the write retries must fit well inside the overall wait budget"
+    );
+}


### PR DESCRIPTION
## The bug

"Sync now" reported failure for syncs that succeeded, on the machine that had been reproducing the sync issues all along.

Measured on `1.91.0-staging.3`, from that machine's own logs:

```
18:19:02.510  SIGHUP received — reloading (graceful restart) pid=54835
18:19:02.510  shutting down pid=54835              ← daemon truncates the WAL
              ← tray's outcome() read fails, red error shown to the user
18:19:05.600  servicing PM sync request mode=force reason=sync_now seq=17
18:19:08.168  PM sync request completed task_count=Some(4)
```

The user was shown:

> could not read the sync outcome: reading the PM sync outcome: error returned from database: (code: 522) disk I/O error

`522` is `SQLITE_IOERR_SHORT_READ` (`10 | (2 << 8)`) — SQLite asked for a page and was handed fewer bytes than it expected, because the daemon's shutdown `PRAGMA wal_checkpoint(TRUNCATE)` truncated the WAL underneath a live reader. Connecting a tracker reloads the daemon, so a "Sync now" pressed right after connecting lands in that window.

**The daemon did the sync.** It completed 5.6 s later, with 47 poll turns still unspent in the 30 s budget. The failure was entirely in how the tray reacted to a read that didn't land.

## The fix

Once the request row is written, the daemon owns the work. A failed *read* of the outbox is the absence of an answer, not an answer — the only honest terminal states are "the daemon reported a result" or "the budget elapsed, it's still going".

Both SQLite call sites in `ask_daemon_to_sync` treated any `Err` as terminal. The wait loop's own comment already said it should keep polling, and it only did so when `recover_if_corrupt` returned true — which `522` is not.

- **`db::integrity::is_transient_sqlx` / `is_transient_error`** — classify the `IOERR` (10), `BUSY` (5) and `LOCKED` (6) families by low byte, so extended variants like `522` are covered. Deliberately **disjoint from corruption**: retrying a damaged page is precisely what the ETL latch exists to prevent, and `corruption_is_never_transient` pins that. No message fallback either, unlike `is_corrupt_error` — a stringified error stays terminal, which is the safe direction.
- **Wait loop** — retry a transient fault instead of surfacing it.
- **Write path** — retry a transient fault, and treat a momentarily closed pool as the normal state it is. A "Sync now" pressed while `reload_with_pool_cycle` had the pool closed returned *"the database is not open - Meridian may be repairing it"*, naming a repair that was not happening.

Applied to the trace above, the read fails at 18:19:02.5, the loop keeps polling, and the poll at 18:19:08.2 reads `completed_seq=17` and renders **"synced 4 task(s)"**.

## Relationship to #910

#910 fixed outcomes being *destroyed* by an overlapping request (the sequence watermark). That was real and this PR does not touch it — the coalescing is visibly working in the same logs (`seq=10` was absorbed into the `seq=11` sync rather than triggering its own).

But #910 did **not** fix the reported symptom, and I presented it as though it had. This is the actual cause of the timeout and the error text the user kept seeing.

## Explicitly not fixed here

**The tray can still open a connection during the daemon's shutdown checkpoint.** `reload_with_pool_cycle` closes the tray's pool, signals, and reopens *lazily and immediately* — so no connection spans two daemon generations, which is what it was built for. It does nothing to stop a brand-new connection reading while the daemon spends a few hundred ms flushing and truncating. This PR makes that window survivable rather than closed.

Closing it is a change to the reload lifecycle that two production incidents already live in (#851's corruption, and the `ThrottleInterval` outage), so it wants its own PR and its own reasoning.

**One loose end I have not proven.** An earlier failure on the same machine showed the tray handed `seq=9` while the daemon read the same row as `seq=8` two seconds later. I hypothesised a lost commit across the checkpoint. A short read during the `SELECT seq` read-back explains it just as well and requires no data loss, and I could not distinguish the two. Under this fix that case degrades to a neutral "still running in the background" rather than a red error, which is truthful — but I am not claiming a lost write is impossible.

## Testing

- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace` — 1120 + all members, green
- New: `transient_codes_match_primary_and_extended`, `corruption_is_never_transient`, `a_stringified_transient_error_is_not_retried`, `transient_faults_are_retried_before_any_terminal_failure`, `the_request_retry_budget_covers_a_daemon_reload`
- The ordering guard was **verified to fail** with the wait-loop check removed, rather than assumed to work

The ordering guard is a source scan, for the reason `no-native-dialogs.test.ts` is: provoking a short read needs two real processes racing a `wal_checkpoint(TRUNCATE)` on a real file, which an in-memory pool cannot reproduce. **No test here exercises the real race** — the verification that matters is on the staging DMG.

## Manual verification needed on staging

1. Connect Jira, then press **Sync now immediately** — expect a real result, not `(code: 522)` and not "the database is not open"
2. Repeat 5+ times, pressing as fast as possible after connect, since the failure is timing-dependent (it passed 2 of 3 hand-run attempts before)
3. Watch `~/.meridian/bin/meridian logs -f | grep -iE "transient fault|servicing PM sync|did not report"` — a `transient fault ... retrying` line followed by a successful sync is the fix working