### PR TITLE
fix(release): a revert must be able to cut a release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,7 +7,13 @@
     [
       "@semantic-release/commit-analyzer",
       {
-        "preset": "conventionalcommits"
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          {
+            "type": "revert",
+            "release": "patch"
+          }
+        ]
       }
     ],
     [

--- a/.releaserc.staging.json
+++ b/.releaserc.staging.json
@@ -11,7 +11,13 @@
     [
       "@semantic-release/commit-analyzer",
       {
-        "preset": "conventionalcommits"
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          {
+            "type": "revert",
+            "release": "patch"
+          }
+        ]
       }
     ],
     [


### PR DESCRIPTION
## The problem

#912 reverted #909 and #910 off `pre-main`. A dry run of `Release (prepare)` against the merged result reported:

```
[@semantic-release/commit-analyzer] › ℹ  Analysis of 4 commits complete: no release
```

**The revert was merged and unshippable.** The staging testers stayed on `v1.91.0-staging.3` — the exact build we had just backed out — with no way to reach them.

Two structural reasons, neither a mistake in the revert commits:

1. `git revert` writes `Revert "Merge pull request #910 from Meridiona/..."`, which is not a conventional-commit header, so it carries no type at all.
2. The `conventionalcommits` preset has **no default release rule for `revert`**, so even the well-formed `revert: keep migrations 082 and 083` commit is inert.

## Why this is an oversight rather than a decision

Both configs' `release-notes-generator` **already** declares a section for the `revert` type:

```json
{ "type": "revert", "section": "⏪ Reverts" }
```

So the notes half of the pipeline expects reverts to appear in releases. Only the analyzer half disagreed. The section could never have rendered.

And a revert is the case where shipping is *most* urgent — it is what you reach for when something in production is actively wrong. It should not be the one thing the pipeline treats as unreleasable.

## The change

Adds `releaseRules: [{ type: "revert", release: "patch" }]` to `commit-analyzer` in both `.releaserc.json` (stable) and `.releaserc.staging.json` (staging). Two files, one hunk each, nothing else reformatted.

## Verified, not assumed

Custom `releaseRules` are **additive**, not a replacement. `commit-analyzer` falls through to `DEFAULT_RELEASE_RULES` when no custom rule matches:

```js
// index.js:63-67
// If no custom releaseRules or none matched the commit, try with default releaseRules
if (isUndefined(commitReleaseType)) {
  commitReleaseType = analyzeCommit(DEFAULT_RELEASE_RULES, commit);
}
```

I read this in the installed package rather than trusting the README, because if custom rules *replaced* the defaults this change would silently stop `feat` and `fix` from ever cutting a release — a far worse failure than the one it fixes, and one that would look like "no release" rather than an error.

Both files validated as parseable JSON after the edit.

## What this does not fix

The two `Revert "Merge pull request ..."` commits still carry no type and remain invisible to the analyzer. Only the hand-written `revert:` commit matches the new rule — which is enough to cut the release, but it means a revert PR containing *only* git-generated revert commits would still produce no release.

Making those parse would mean either a `parserOpts.revertPattern` change or a convention that every revert PR carries one hand-written `revert:` commit. I have not done either here; this PR is scoped to unblocking the current one. Worth deciding properly rather than bundling in.

## After merge

`fix(release):` is itself a releasing type, so the next dry run should report `v1.91.0-staging.4` — carrying both this and the revert.