### PR TITLE
fix: the CodeRabbit findings on #899, all of them in code I wrote

### DIFF
--- a/scripts/deploy-gateway.sh
+++ b/scripts/deploy-gateway.sh
@@ -94,7 +94,16 @@ probe_rejects_unauthenticated() {
 	shift 2
 	local deadline=$((SECONDS + PROBE_TIMEOUT_S)) code verdict
 	while :; do
-		code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "$@" "${url}" || true)"
+		# --noproxy '*': the point of this probe is that THE GATEWAY rejects
+		# the caller. curl honours http_proxy/https_proxy/ALL_PROXY, so on a
+		# machine with a proxy configured an intercepting proxy's own 401
+		# would satisfy the assertion without the request ever reaching the
+		# gateway - a security check passing on someone else's answer.
+		# Verified: with https_proxy pointed at a dead port the probe returns
+		# 000, and --noproxy '*' returns the gateway's real 401. If direct
+		# egress is genuinely impossible here, 000 retries and then FAILS,
+		# which is the intended "fail rather than falsely pass" behaviour.
+		code="$(curl -s --noproxy '*' -o /dev/null -w '%{http_code}' --max-time 15 "$@" "${url}" || true)"
 		verdict="$(classify_probe "${code}")"
 		case "${verdict}" in
 		pass)
@@ -151,6 +160,22 @@ verify_public_endpoints_authenticate() {
 #
 # A deploy now requires exactly zero arguments. Anything unrecognised prints
 # usage and exits 2 without touching the VM.
+# `$#` first: the `case` below only ever inspects `$1`, so without this
+# `--verify-only somethingelse` would silently ignore the extra word, and a
+# single EMPTY argument (`"$SOME_UNSET_VAR"`) would match the `""` arm and
+# deploy. Both are the same class of bug as the one this dispatch was added to
+# fix - an argument that does not mean what it looks like, ending in a
+# production deploy.
+if [ "$#" -gt 1 ]; then
+	echo "deploy-gateway.sh: unexpected extra argument '${2}'" >&2
+	echo "run with --help for usage" >&2
+	exit 2
+fi
+if [ "$#" -eq 1 ] && [ -z "${1}" ]; then
+	echo "deploy-gateway.sh: empty argument - a deploy takes NO arguments" >&2
+	echo "run with --help for usage" >&2
+	exit 2
+fi
 case "${1:-}" in
 --verify-only | --self-test | "") ;;
 -h | --help)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1120,6 +1120,14 @@ async fn main() -> Result<()> {
             endpoint = %meridian::platform::endpoint_display(),
             "another meridian daemon already owns this data dir — exiting (single-instance guard)"
         );
+        // Flush before returning, matching the repair-marker stand-down above.
+        // Without it this WARN dies in the batch processor: `main` returning
+        // does not flush (`ObservabilityGuard` has no Drop — see its docs), so
+        // the record of a stand-down never reached the spool at all. MEASURED,
+        // not theorised: a second daemon was made to lose the race and
+        // `meridian logs` found zero occurrences of its own WARN.
+        obs_guard.shutdown().await;
+        meridian::telemetry_spool::shipper::drain_once().await;
         return Ok(());
     }
 
@@ -1162,6 +1170,11 @@ async fn main() -> Result<()> {
                 pid = std::process::id() as i64,
                 "another meridian daemon holds the single-instance lock for this data dir — exiting (lock)"
             );
+            // See the probe stand-down above. This one matters most: it is the
+            // ONLY evidence that two daemons raced past the probe, and it was
+            // reaching nothing.
+            obs_guard.shutdown().await;
+            meridian::telemetry_spool::shipper::drain_once().await;
             return Ok(());
         }
         // Could not find out. Proceed UNLOCKED rather than refuse to start:
@@ -1229,17 +1242,28 @@ async fn main() -> Result<()> {
     //     would let a daemon that's about to `exit(1)` on a locked or corrupt
     //     database falsely tell the tray's watchdog it's healthy for the
     //     brief window before that failure surfaces. Safe to bind
-    //     unconditionally here: we hold the single-instance lock taken at
+    //     unconditionally here — but read the next paragraph before relying
+    //     on WHY, because the obvious reason is only true most of the time.
+    //
+    //     ON THE `Acquired` PATH we hold the single-instance lock taken at
     //     4a-quater, so no other daemon process reached this line at all. (The
     //     older justification — "the check above established nothing else is
     //     listening, and we're single-threaded up to the poll loop" — was only
     //     ever about THIS process's threads and said nothing about a second
-    //     process. The lock is what actually makes this claim true.)
+    //     process.)
+    //
+    //     ON THE `Unavailable` PATH WE HOLD NO LOCK. That path exists on
+    //     purpose (a lock we could not attempt must not stop the daemon
+    //     starting), and it reaches this line with exactly the pre-lock
+    //     guarantees: the endpoint probe, which is check-then-act. So the
+    //     lock does NOT make the sequence below unreachable in general — only
+    //     on the path where it was actually acquired.
     //
     //     NOTE: `spawn_health_listener` itself unlinks a stale socket and then
-    //     binds, which is its own check-then-act across processes. The lock
-    //     makes that unreachable for two daemons, but the sequence is left
-    //     untouched here on purpose — #862 owns that boundary.
+    //     binds, which is its own check-then-act across processes. Do not
+    //     delete that stale-socket handling on the strength of the lock: on
+    //     the `Unavailable` path it is still the only thing standing there.
+    //     #862 owns that boundary.
     meridian::platform::spawn_health_listener()?;
     tracing::info!(endpoint = %meridian::platform::endpoint_display(), "daemon health endpoint ready");
 
@@ -1643,9 +1667,14 @@ async fn main() -> Result<()> {
             pid = std::process::id() as i64,
             "WAL checkpoint on shutdown complete"
         ),
-        Err(e) => {
-            tracing::warn!(error = %meridian::errors::chain(&e), "WAL checkpoint on shutdown failed - continuing anyway")
-        }
+        // `pid` here too: the whole reason both outcomes are logged is to
+        // attribute a checkpoint to a generation, and a FAILED checkpoint is
+        // the one most worth attributing.
+        Err(e) => tracing::warn!(
+            pid = std::process::id() as i64,
+            error = %meridian::errors::chain(&e),
+            "WAL checkpoint on shutdown failed - continuing anyway"
+        ),
     }
     meridian.close().await;
 
@@ -1755,6 +1784,44 @@ mod startup_order_tests {
     /// `backend_install.rs` (`a_stuck_bootout_is_reported_at_warn`,
     /// `every_early_return_still_restores_the_daemon`) — this scans the
     /// source for the three call sites and asserts their relative order.
+    /// A stand-down must FLUSH before it returns, or its own WARN is lost.
+    ///
+    /// `main` returning does not flush: `ObservabilityGuard` has no `Drop`
+    /// (its docs say to call `shutdown` explicitly), so a record emitted just
+    /// before `return Ok(())` dies in the batch processor.
+    ///
+    /// This was not theoretical. MEASURED before the fix: a second daemon was
+    /// made to lose the lock race and `meridian logs` found ZERO occurrences of
+    /// the WARN the daemon had just printed. On a release build there is no
+    /// stdout mirror either, so the event was invisible everywhere - and that
+    /// WARN is the only evidence that two daemons raced past the endpoint
+    /// probe, which is the entire reason the lock reports it.
+    #[test]
+    fn every_stand_down_flushes_before_returning() {
+        const SRC: &str = include_str!("main.rs");
+        let prod = SRC
+            .split_once("\n#[cfg(test)]")
+            .map_or(SRC, |(before, _)| before);
+
+        for needle in ["exiting (single-instance guard)", "exiting (lock)"] {
+            let at = prod
+                .find(needle)
+                .unwrap_or_else(|| panic!("the {needle} stand-down must exist in main()"));
+            let after = &prod[at..];
+            let ret = after
+                .find("return Ok(());")
+                .unwrap_or_else(|| panic!("the {needle} stand-down must return"));
+            let between = &after[..ret];
+            assert!(
+                between.contains("obs_guard.shutdown().await;"),
+                "the '{needle}' stand-down must flush telemetry before it \
+                 returns - without it the WARN it just emitted never reaches \
+                 the spool and the stand-down is invisible. Found between the \
+                 log and the return: {between:?}"
+            );
+        }
+    }
+
     #[test]
     fn single_instance_lock_precedes_setup_db_and_bind_follows_it() {
         const SRC: &str = include_str!("main.rs");

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -134,7 +134,13 @@ impl ObservabilityGuard {
         }
         if let Some(lp) = self.logger_provider {
             let _ = tokio::task::spawn_blocking(move || {
-                let _ = lp.force_flush();
+                // See `force_flush` for why this reports to stderr rather than
+                // through `tracing`.
+                for r in lp.force_flush() {
+                    if let Err(e) = r {
+                        eprintln!("observability: log force_flush error: {e:?}");
+                    }
+                }
                 let _ = lp.shutdown();
             })
             .await;
@@ -201,7 +207,22 @@ pub async fn force_flush() {
     }
     if let Some(lp) = handles.logger_provider.clone() {
         let _ = tokio::task::spawn_blocking(move || {
-            let _ = lp.force_flush();
+            // Reported, not discarded - the tracer arm above already prints its
+            // error and the logger arm silently swallowed one.
+            //
+            // `eprintln!` rather than `tracing::error!` DELIBERATELY: this is
+            // the code that flushes the telemetry pipeline, so routing its own
+            // failure back into that pipeline is circular. On the quit path the
+            // process exits microseconds later, so a `tracing::error!` here
+            // would land in the very batch that just failed to flush and be
+            // lost - reporting the failure by the one mechanism the failure
+            // proves is broken. stderr is the only sink that does not depend on
+            // what is failing.
+            for r in lp.force_flush() {
+                if let Err(e) = r {
+                    eprintln!("observability: log force_flush error: {e:?}");
+                }
+            }
         })
         .await;
     }

--- a/src/telemetry_spool/render.rs
+++ b/src/telemetry_spool/render.rs
@@ -62,13 +62,23 @@ pub struct RenderedRecord {
 /// EVERY record, which would triple the width of every line with the one thing
 /// a reader already knows (they can see the message).
 ///
-/// Prefix-matched, so `code.filepath`/`code.lineno`/`code.namespace` are all
-/// covered by one entry.
-const UNPRINTED_ATTR_PREFIXES: &[&str] = &["code.", "log.target", "thread.", "busy_ns", "idle_ns"];
+/// Namespaces: every key under them is call-site metadata, so a prefix match
+/// is correct and `code.filepath`/`code.lineno`/`code.namespace` are covered by
+/// one entry.
+const UNPRINTED_ATTR_NAMESPACES: &[&str] = &["code.", "thread."];
+
+/// Whole keys. Deliberately NOT prefixes: these are single field names, and
+/// matching them by prefix would silently swallow an emitter's own field that
+/// merely starts the same way - `log.target_override`, `busy_ns_budget`,
+/// `idle_ns_extra`. Hiding a field the author chose to record is precisely the
+/// bug this rendering exists to fix, so it must not be reintroduced by the
+/// filter meant to reduce noise.
+const UNPRINTED_ATTR_KEYS: &[&str] = &["log.target", "busy_ns", "idle_ns"];
 
 /// Is this a call-site metadata key rather than a value the emitter chose?
 fn is_unprinted_attr(key: &str) -> bool {
-    UNPRINTED_ATTR_PREFIXES.iter().any(|p| key.starts_with(p))
+    UNPRINTED_ATTR_NAMESPACES.iter().any(|p| key.starts_with(p))
+        || UNPRINTED_ATTR_KEYS.contains(&key)
 }
 
 /// Decode one spooled file into [`RenderedRecord`]s. The signal (logs vs
@@ -576,6 +586,36 @@ mod tests {
             "only the emitter's own fields should survive; got {:?}",
             r.attributes
         );
+    }
+
+    /// A near-miss on an exact-match key must NOT be suppressed.
+    ///
+    /// `log.target`, `busy_ns` and `idle_ns` are whole field names, not
+    /// namespaces. When they were prefix-matched alongside `code.`/`thread.`,
+    /// any emitter field that merely started the same way was silently hidden -
+    /// which is the exact failure this rendering was added to fix, reintroduced
+    /// by the filter meant to reduce noise.
+    #[test]
+    fn a_field_that_merely_starts_like_a_metadata_key_still_prints() {
+        for key in ["log.target_override", "busy_ns_budget", "idle_ns_extra"] {
+            assert!(
+                !is_unprinted_attr(key),
+                "{key} is an emitter field, not call-site metadata, and must be \
+                 displayed"
+            );
+        }
+        // ...while the exact keys and the real namespaces stay suppressed.
+        for key in [
+            "log.target",
+            "busy_ns",
+            "idle_ns",
+            "code.filepath",
+            "code.lineno",
+            "thread.id",
+            "thread.name",
+        ] {
+            assert!(is_unprinted_attr(key), "{key} is call-site metadata");
+        }
     }
 
     /// A field declared on a span but never recorded arrives as an empty value.

--- a/tray/src-tauri/src/daemon_lifecycle.rs
+++ b/tray/src-tauri/src/daemon_lifecycle.rs
@@ -86,6 +86,16 @@ use tracing::Instrument;
 /// the next launch reconciles the daemon regardless.
 const QUIT_STOP_BUDGET: Duration = Duration::from_secs(5);
 
+/// How long a quit waits for the telemetry flush before exiting anyway.
+///
+/// Shorter than [`QUIT_STOP_BUDGET`] on purpose: the flush is a local disk
+/// write that normally completes in milliseconds, and the thing it protects is
+/// a diagnostic record, not the user's data. Losing that record is a bad
+/// outcome; a Quit that never completes is a worse one, and `ExitPhase::Stopping`
+/// holds every subsequent `ExitRequested` - so an unbounded wait here leaves
+/// the app with no path out at all.
+pub(crate) const QUIT_FLUSH_BUDGET: Duration = Duration::from_secs(2);
+
 /// Where the app is in its exit sequence.
 ///
 /// The quit path is not atomic - the daemon stop is async and the exit is not -
@@ -942,12 +952,15 @@ mod tests {
         let stop_pos = spawn_body
             .find("stop_for_quit().await")
             .expect("the spawned task must call stop_for_quit");
-        let flush_pos = spawn_body
-            .find("observability::force_flush().await")
-            .expect(
-                "the spawned stop task must flush telemetry before exiting, or \
+        // Matched WITHOUT `.await` attached: the call is wrapped in a
+        // `tokio::time::timeout`, so the await belongs to the timeout rather
+        // than to `force_flush` itself. The over-specific needle failed the
+        // moment that bound was added - the test doing its job, but it was the
+        // needle that needed correcting, not the code.
+        let flush_pos = spawn_body.find("observability::force_flush(").expect(
+            "the spawned stop task must flush telemetry before exiting, or \
                  stop_for_quit's outcome never reaches the spool",
-            );
+        );
         let exit_pos = spawn_body
             .find("handle.exit(")
             .expect("the spawned task must exit the app");
@@ -957,6 +970,18 @@ mod tests {
              handle.exit: before the stop it flushes a verdict that has not \
              been reached yet, and after the exit it does not run at all. \
              Found stop at {stop_pos}, flush at {flush_pos}, exit at {exit_pos}."
+        );
+
+        // And it must be BOUNDED. `force_flush` awaits blocking exporter work
+        // and the spool does synchronous filesystem writes, so an unbounded
+        // await here can hang the quit indefinitely - and `ExitPhase::Stopping`
+        // holds every later `ExitRequested`, leaving the app unquittable with
+        // no way back. That is the failure mode `HeldExitGuard` exists to
+        // prevent, reached again through a different door.
+        assert!(
+            spawn_body[..exit_pos].contains("QUIT_FLUSH_BUDGET"),
+            "the telemetry flush on quit must be bounded by QUIT_FLUSH_BUDGET; \
+             an unbounded await leaves no path out of ExitPhase::Stopping"
         );
     }
 }

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -1483,7 +1483,31 @@ pub fn run() {
                             // corruption report (quit is when the tray and the
                             // daemon are most likely to overlap on meridian.db),
                             // and it was the one guaranteed never to survive.
-                            meridian::observability::force_flush().await;
+                            //
+                            // BOUNDED, for the same reason `stop_for_quit` is:
+                            // a quit that hangs is worse than a record that is
+                            // lost. `force_flush` awaits blocking exporter work
+                            // and the SpoolClient does synchronous filesystem
+                            // writes, so a wedged spool (full disk, a stalled
+                            // network home dir) would otherwise sit here
+                            // forever - and `ExitPhase::Stopping` holds every
+                            // later `ExitRequested`, so the app would be
+                            // permanently unquittable with no way back. That is
+                            // the exact failure mode `HeldExitGuard` exists to
+                            // prevent; an unbounded await here reintroduced it
+                            // by another door.
+                            if tokio::time::timeout(
+                                daemon_lifecycle::QUIT_FLUSH_BUDGET,
+                                meridian::observability::force_flush(),
+                            )
+                            .await
+                            .is_err()
+                            {
+                                tracing::warn!(
+                                    budget_s = daemon_lifecycle::QUIT_FLUSH_BUDGET.as_secs(),
+                                    "flushing telemetry on quit exceeded its budget - exiting anyway"
+                                );
+                            }
                             // Immediately before the exit, so the re-entrant
                             // `ExitRequested` this triggers is the one and only
                             // one allowed through.


### PR DESCRIPTION
Eight findings from CodeRabbit's review of the release PR, every one on code merged today in #902/#903/#907/#908. **Seven fixed, one declined with a reason.** Two of them mattered.

## 1. The stand-down WARN reached nothing

Both `daemon_already_running()` and `LockOutcome::HeldByAnother` `return Ok(())` **before** `obs_guard.shutdown()`. `main` returning does not flush — `ObservabilityGuard` has no `Drop`, deliberately — so the WARN died in the batch processor.

Measured rather than argued:

```
# before: second daemon loses the lock race, prints the WARN to stdout
WARN another meridian daemon holds the single-instance lock … pid=70058
$ meridian logs | grep -c "holds the single-instance lock"
0
```

Zero. And a release build has no stdout mirror either, so the event was invisible everywhere.

That WARN is the **only** evidence that two daemons raced past the endpoint probe. I described it as *"the first direct evidence of how often this happens across the fleet"* — it would have measured nothing. Both stand-downs now flush + drain, matching the repair-marker stand-down 50 lines above that already did. **0 → 1** after the fix.

## 2. The quit flush could hang the app forever

`force_flush()` awaits blocking exporter work, and the `SpoolClient` does synchronous filesystem writes. Unbounded, a wedged spool sits there while `ExitPhase::Stopping` holds every subsequent `ExitRequested` — **the app becomes permanently unquittable with no way back.**

That is precisely the failure `HeldExitGuard` exists to prevent, reached again by another door, in a function whose neighbouring `stop_for_quit` is bounded for the identical stated reason. Now bounded by `QUIT_FLUSH_BUDGET` (2s — shorter than the 5s stop budget, because the flush protects a diagnostic, not user data).

## The rest

| finding | |
|---|---|
| `main.rs` bind comment | Claimed the lock makes a second process unreachable. True on `Acquired`, **false on `Unavailable`**, which proceeds unlocked by design. Corrected, and it now warns against deleting the stale-socket handling on the strength of a lock that path doesn't hold. |
| `main.rs` checkpoint | `pid` on the **failure** warn. The success line had it; the failure line — the one most worth attributing — did not. |
| `render.rs` | `log.target`/`busy_ns`/`idle_ns` were prefix-matched alongside the real `code.`/`thread.` namespaces, so `busy_ns_budget` or `log.target_override` would be silently hidden. That is the exact bug the rendering was added to fix, reintroduced by the noise filter meant to help it. Split into namespaces vs whole keys. |
| `observability` | The logger arm discarded its flush error while the tracer arm printed one. Both report now. |
| `deploy-gateway.sh` | `--noproxy '*'` — curl honours `https_proxy`, so an intercepting proxy's own 401 would satisfy a **security** assertion without the request reaching the gateway. Verified: dead proxy → `000`, `--noproxy` → the real `401`. |
| `deploy-gateway.sh` | Validate `$#`, not just `$1`. `--verify-only extra` ignored the extra word, and a single **empty** argument matched the `""` arm and deployed. |

Two places I diverged from the suggestion, both stated in the code:

- **`eprintln!`, not `tracing::error!`** for flush failures. This is the code that flushes the telemetry pipeline; reporting its failure *through* that pipeline is circular — on the quit path the process exits microseconds later and the record lands in the batch that just failed. Also, `force_flush` returns `Vec<Result<_>>` (one per processor), not a `Result`.
- **Declined: em-dashes in four log bodies.** CLAUDE.md's rule targets user-facing app text — window titles, wizard copy, button labels, notification bodies — and exempts comments/docs. Log bodies use em-dashes throughout: **171 sites already in the tree**. Changing four makes the codebase less consistent, not more. If the rule should cover log messages, that's a tree-wide sweep plus a lint, not four edits inside a release PR. Happy to do that sweep separately if you want it.

## Testing

Every assertion mutation-proved:

| mutation | result |
|---|---|
| flush removed from the lock stand-down | new test fails |
| all-prefix matching restored in `render.rs` | near-match test fails |
| timeout removed from the quit flush | boundedness assertion fails |

The last one is worth calling out: my first attempt **failed to compile** (`dead_code` on the now-unused constant), which reads as "0 failing" — the trap this repo has hit before. I re-ran it with `#[allow(dead_code)]` so the mutant actually built, the test ran, and it failed for the right reason.

`clippy --workspace --all-targets -D warnings` clean; 27 suites green.