### PR TITLE
fix(telemetry): stop subprocess stderr reaching central OO through the log body

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,7 +385,7 @@ supported way to read logs locally, replacing the old JSONL-tailing UI and the
 old bash `meridian logs` (which used to tail launchd-redirected stdout/stderr
 text).
 
-**Three couplings that silently delete error coverage.** Each has bitten at
+**Four couplings that silently delete error coverage - or cause an egress.** Each has bitten at
 least once; none fails loudly, and none is visible from the call site.
 
 1. **The `EnvFilter` decides what is captured at all — before the spool, before
@@ -420,7 +420,25 @@ least once; none fails loudly, and none is visible from the call site.
    the field was the cheaper half. Likewise a full binary path (`bin`) stays
    denied while `bin_source` — a closed set of literals from
    `install::bin_source` — ships in its place.
-3. **A `u64` field is not shipped as a number.** `tracing-opentelemetry` 0.28's
+3. **The log BODY is not an attribute, and nothing filters it.** The allowlist
+   governs attribute KEYS; the body *is* the record, so it always ships, having
+   passed only `scrub_text`'s URL/email/blob patterns — which know nothing about
+   ticket keys, window titles, or a tracker's error payload. CLAUDE.md has said
+   "structured fields — never format data values into the message string" from
+   the start, and nothing enforced it, so it drifted at three tray call sites
+   that spliced a `meridian` subprocess's stderr into a WARN body. Issue #872
+   measured the result: a real user's ticket key (`ENG-7041`) in central
+   OpenObserve, from a value the allowlist denies as an attribute. It is now
+   enforced — `errors.rs::no_user_data_interpolated_into_a_log_body` walks every
+   workspace source tree and fails the build on a new interpolated WARN+/ERROR
+   body, with `INTERPOLABLE` as the deliberate, justified exemption list. **The
+   corollary when you fix one: move the value to an UNALLOWLISTED attribute
+   rather than deleting it.** Unallowlisted attributes are captured at full
+   fidelity locally (`meridian logs` renders them; export bundles carry the raw
+   spool) and dropped on the ship leg — that is the two-tier design working, and
+   it is why `stderr_tail` costs the engineer debugging their own machine
+   nothing. Deleting the value instead is #867's mistake wearing #872's clothes.
+4. **A `u64` field is not shipped as a number.** `tracing-opentelemetry` 0.28's
    `Visit` impl has no `record_u64`, so `tracing::field::Visit`'s default applies
    and forwards to `record_debug` — which emits a **StringValue**. The field then
    misses the allowlist (nobody lists `timeout_s` as a *string* key) and is

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -78,12 +78,13 @@ For the records that do qualify, every attribute is filtered on your device befo
 - **Text values are dropped unless the attribute name is on an explicit allowlist.** Anything path-like is scrubbed of your home directory; the small free-text subset (error messages, stack traces) is additionally scrubbed of URLs, email addresses, and token-shaped strings, then length-clamped.
 - **Structured values** (byte blobs, arrays, nested maps) are dropped outright.
 - **Span events and links are cleared entirely.**
+- **The message itself is sent** - it is the error, so there is nothing to filter it against. Meridian's own rule is therefore that a message must be a fixed sentence and every runtime value must travel as a named field, where the allowlist above applies to it. That rule is enforced automatically: a build fails if any warning or error message formats a value into its text.
 
 The filter fails closed: a newly added attribute anywhere in the codebase is dropped by default until someone deliberately allowlists it.
 
 ### What is therefore never sent
 
-OCR text, accessibility-tree content, window titles, browser URLs, coding-agent conversation bodies, LLM prompts and completions, ticket contents, file paths, and your local database. These stay on your machine even when error reporting is on. Local logs remain full-fidelity for your own debugging — the stripping applies only to the copy that would be transmitted.
+OCR text, accessibility-tree content, window titles, browser URLs, coding-agent conversation bodies, LLM prompts and completions, ticket keys, ticket contents, file paths, and your local database. These stay on your machine even when error reporting is on. Local logs remain full-fidelity for your own debugging — the stripping applies only to the copy that would be transmitted.
 
 ### How reports are identified
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,10 @@ pub mod health;
 pub mod intelligence;
 pub mod llm;
 pub mod llm_experiment;
+// Test-only lints on log content; see the module header. `#[cfg(test)]` because it
+// has no runtime surface - it exists purely to fail the build.
+#[cfg(test)]
+mod log_hygiene;
 pub mod notices;
 pub mod notification_responses;
 pub mod notifications;

--- a/src/log_hygiene.rs
+++ b/src/log_hygiene.rs
@@ -113,11 +113,7 @@ mod tests {
                     })
                 {
                     if let Ok(src) = std::fs::read_to_string(&p) {
-                        let prod = src
-                            .split_once("\n#[cfg(test)]")
-                            .map_or(src.as_str(), |(a, _)| a)
-                            .to_string();
-                        out.push((p.display().to_string(), prod));
+                        out.push((p.display().to_string(), strip_test_modules(&src)));
                     }
                 }
             }
@@ -139,10 +135,97 @@ mod tests {
         out
     }
 
+    /// Remove `#[cfg(test)] mod … { … }` BLOCKS, brace-balanced, and nothing
+    /// else.
+    ///
+    /// # Why not truncate at the first `#[cfg(test)]`
+    /// That is the older idiom (`errors.rs::no_bare_error_display_in_db_paths`
+    /// still uses it) and it is silently catastrophic for a whole-tree scan:
+    /// everything after the FIRST test module is discarded, including the real
+    /// code below it. Measured on this tree before the change -
+    /// `tray/src-tauri/src/lib.rs` was scanned at 6.6% of its bytes (a test
+    /// module sits at line 150 of 1915), and `intelligence/providers/jira/mod.rs`
+    /// at 2%, because a bare `#[cfg(test)] mod tests;` DECLARATION on line 15
+    /// truncated the file. A declaration points at a separate file, which the
+    /// walk already skips by name, so it must not truncate anything at all.
+    ///
+    /// The scan would still have passed - just over a fraction of the codebase.
+    /// That is the failure mode `SCANNED_TREES`'s file-count assert and
+    /// `MIN_MACRO_SITES` below both exist to make loud.
+    fn strip_test_modules(src: &str) -> String {
+        const MARKER: &str = "#[cfg(test)]";
+        let mut out = String::with_capacity(src.len());
+        let mut rest = src;
+        while let Some(i) = rest.find(MARKER) {
+            let after = &rest[i + MARKER.len()..];
+            // `#[cfg(test)] mod name { … }` - only a BLOCK is stripped. A `;`
+            // declaration, or the attribute on a fn/const/use, is kept.
+            let Some(brace) = after.find('{') else {
+                out.push_str(&rest[..i + MARKER.len()]);
+                rest = after;
+                continue;
+            };
+            let head = &after[..brace];
+            if !head.trim_start().starts_with("mod ") || head.contains(';') {
+                out.push_str(&rest[..i + MARKER.len()]);
+                rest = after;
+                continue;
+            }
+            out.push_str(&rest[..i]);
+            // Balance braces from the module's opening one, ignoring string
+            // literals and line comments (both can contain a stray brace).
+            let body: Vec<char> = after[brace..].chars().collect();
+            let (mut depth, mut k) = (0usize, 0usize);
+            let (mut in_str, mut esc, mut in_comment) = (false, false, false);
+            while k < body.len() {
+                let c = body[k];
+                if in_comment {
+                    if c == '\n' {
+                        in_comment = false;
+                    }
+                } else if in_str {
+                    if esc {
+                        esc = false;
+                    } else if c == '\\' {
+                        esc = true;
+                    } else if c == '"' {
+                        in_str = false;
+                    }
+                } else if c == '"' {
+                    in_str = true;
+                } else if c == '/' && body.get(k + 1) == Some(&'/') {
+                    in_comment = true;
+                } else if c == '{' {
+                    depth += 1;
+                } else if c == '}' {
+                    depth -= 1;
+                    if depth == 0 {
+                        k += 1;
+                        break;
+                    }
+                }
+                k += 1;
+            }
+            let consumed: usize = body[..k].iter().map(|c| c.len_utf8()).sum();
+            rest = &after[brace + consumed..];
+        }
+        out.push_str(rest);
+        out
+    }
+
     /// Every `{ident}` interpolated into the message body of a `tracing::warn!`
     /// or `tracing::error!` in `src`, with its line number.
     fn interpolated_body_idents(src: &str) -> Vec<(usize, String, String)> {
+        scan_bodies(src).1
+    }
+
+    /// [`interpolated_body_idents`] plus the number of WARN+/ERROR macro sites
+    /// the parser REACHED. The count comes out of the same loop on purpose - a
+    /// separate counting fn could drift from the real scan, and then
+    /// `MIN_MACRO_SITES` would be measuring something the guard does not use.
+    fn scan_bodies(src: &str) -> (usize, Vec<(usize, String, String)>) {
         let mut found = Vec::new();
+        let mut reached = 0usize;
         // Matched WITHOUT the `tracing::` prefix on purpose: 14 sites in
         // `etl/` and `capture/` import the macro (`use tracing::warn`) and call
         // it bare, and a scan anchored on the qualified spelling would have read
@@ -168,6 +251,7 @@ mod tests {
                 let Some(open) = src[start..].find('(').map(|i| start + i) else {
                     continue;
                 };
+                reached += 1;
                 // Balance parens, ignoring anything inside a string literal.
                 let (mut depth, mut i) = (0usize, open);
                 let (mut in_str, mut esc) = (false, false);
@@ -208,11 +292,21 @@ mod tests {
                 }
             }
         }
-        found
+        (reached, found)
     }
 
     /// The last `"…"` literal in a macro argument list, unescaped enough to read
-    /// its `{}` placeholders.
+    /// its `{}` placeholders - `tracing`'s own rule for which literal is the
+    /// message.
+    ///
+    /// # Residual, stated
+    /// A message followed by a string-literal ARGUMENT
+    /// (`warn!("dropped {n} for {}", "unknown")`) resolves to the argument, so
+    /// that site's real message goes unscanned. No such site exists in the tree
+    /// today (473 of 493 macro sites parse a message; the other 20 carry no
+    /// literal at all). Scanning every literal instead would false-positive on
+    /// a non-message field value, which is the worse trade for a shape that
+    /// does not occur.
     fn last_string_literal(args: &str) -> Option<String> {
         let chars: Vec<char> = args.chars().collect();
         let (mut i, mut last) = (0usize, None);
@@ -240,10 +334,20 @@ mod tests {
         last
     }
 
-    /// Named `{ident}` captures in a format string. Positional `{}` / `{:?}` are
-    /// out of scope: they take their value from a trailing argument, and
-    /// `no_bare_error_display_in_db_paths` already covers the `%e` case that
-    /// produces in practice.
+    /// What a positional `{}` / `{:?}` is reported as. It has no name to print,
+    /// but it is exactly as dangerous - `warn!("failed for {}", ticket_key)`
+    /// ships the key just as surely as `"failed for {ticket_key}"` does.
+    ///
+    /// It is enforced rather than deferred because there are currently ZERO of
+    /// them in a WARN+/ERROR body across all four trees, so the rule costs
+    /// nothing to hold and `docs/privacy.md` can state it to users without
+    /// qualification. Deferring it to `no_bare_error_display_in_db_paths` (the
+    /// earlier plan) would not have worked: that scan's own doc scopes it to
+    /// five DB files and explicitly leaves ~120 sites elsewhere uncovered.
+    const POSITIONAL: &str = "<positional argument>";
+
+    /// Every placeholder in a format string: named `{ident}` captures by name,
+    /// and positional `{}` / `{:?}` as [`POSITIONAL`].
     fn placeholders(msg: &str) -> Vec<String> {
         let mut out = Vec::new();
         let chars: Vec<char> = msg.chars().collect();
@@ -260,12 +364,15 @@ mod tests {
                     name.push(chars[j]);
                     j += 1;
                 }
-                // Only a NAMED capture: `{x}` or `{x:?}`, not `{}` or `{:?}`.
-                if !name.is_empty()
-                    && !name.starts_with(|c: char| c.is_ascii_digit())
-                    && matches!(chars.get(j), Some('}') | Some(':'))
-                {
+                let closes = matches!(chars.get(j), Some('}') | Some(':'));
+                if !name.is_empty() && !name.starts_with(|c: char| c.is_ascii_digit()) && closes {
+                    // A NAMED capture: `{x}` or `{x:?}`.
                     out.push(name);
+                } else if closes {
+                    // `{}`, `{:?}`, `{0}` - the value comes from a trailing
+                    // argument, which the scan cannot see. Reported all the
+                    // same; see `POSITIONAL`.
+                    out.push(POSITIONAL.to_string());
                 }
                 i = j;
             } else {
@@ -279,11 +386,28 @@ mod tests {
     /// allowlist cannot reach - so nothing runtime-valued may be formatted into
     /// it. See [`INTERPOLABLE`] for the full reasoning and issue #872 for the
     /// leak that prompted this.
+    /// A floor on how many WARN+/ERROR macro sites the parser actually REACHES.
+    ///
+    /// `offenders.is_empty()` passes when the scan finds nothing, so a
+    /// regression in the paren balancing, the literal extraction, or
+    /// [`strip_test_modules`] would turn this guard off without failing it -
+    /// which is precisely how the truncation bug documented on
+    /// `strip_test_modules` hid a 94% coverage loss on one file. The file-count
+    /// assert in [`production_sources`] guards the walk; this guards the parse.
+    ///
+    /// Set well below the real count - 526 today, up from 493 before
+    /// [`strip_test_modules`] replaced the truncation - so ordinary deletions
+    /// don't trip it. Raise it if it ever does; do not lower it.
+    const MIN_MACRO_SITES: usize = 400;
+
     #[test]
     fn no_user_data_interpolated_into_a_log_body() {
         let mut offenders = Vec::new();
+        let mut reached = 0usize;
         for (path, src) in production_sources() {
-            for (line, ident, msg) in interpolated_body_idents(&src) {
+            let (sites, hits) = scan_bodies(&src);
+            reached += sites;
+            for (line, ident, msg) in hits {
                 if !INTERPOLABLE.contains(&ident.as_str()) {
                     offenders.push(format!("{path}:{line} - `{{{ident}}}` in \"{msg}\""));
                 }
@@ -301,6 +425,13 @@ mod tests {
              allowlist can make a deliberate decision about it; if it is genuinely \
              a compile-time literal at every call site, add it to `INTERPOLABLE` \
              with a justification. Offenders: {offenders:#?}"
+        );
+        assert!(
+            reached >= MIN_MACRO_SITES,
+            "the scan reached only {reached} WARN+/ERROR macro sites, below the \
+             {MIN_MACRO_SITES} floor - the parse or the test-module stripping has \
+             regressed and this guard is now passing over a fraction of the \
+             codebase. See MIN_MACRO_SITES."
         );
     }
 
@@ -345,13 +476,39 @@ mod tests {
             interpolated_body_idents(r#"// tracing::warn!("{msg}");"#).is_empty(),
             "a commented-out example was flagged"
         );
+
+        // `strip_test_modules` must remove a test module's BODY and nothing
+        // else. The `mod tests;` case is the one that silently truncated 98% of
+        // `jira/mod.rs` under the old `split_once` idiom.
+        let with_decl = "#[cfg(test)]\nmod tests;\nfn f() { warn!(\"x {y}\"); }";
+        assert!(
+            !interpolated_body_idents(&strip_test_modules(with_decl)).is_empty(),
+            "a `#[cfg(test)] mod tests;` DECLARATION truncated the rest of the file"
+        );
+        let with_block = "fn f() { warn!(\"a {p}\"); }\n#[cfg(test)]\nmod t {\n    warn!(\"b {q}\");\n}\nfn g() { warn!(\"c {r}\"); }";
+        let idents: Vec<String> = interpolated_body_idents(&strip_test_modules(with_block))
+            .into_iter()
+            .map(|(_, i, _)| i)
+            .collect();
+        assert!(
+            idents.contains(&"p".to_string()) && idents.contains(&"r".to_string()),
+            "code around a test module was stripped with it: {idents:?}"
+        );
+        assert!(
+            !idents.contains(&"q".to_string()),
+            "the test module's own body was scanned: {idents:?}"
+        );
         assert!(
             interpolated_body_idents(r#"fn my_error!(x) { "{msg}" }"#).is_empty(),
             "`my_error!` is a different macro and must not be scanned"
         );
+        // A positional placeholder is caught too - it has no name, but
+        // `warn!("failed for {}", ticket_key)` ships the key all the same.
         assert!(
-            interpolated_body_idents(r#"tracing::warn!(n = 1, "dropped {} rows", n);"#).is_empty(),
-            "a positional `{{}}` placeholder is out of scope - see `placeholders`"
+            interpolated_body_idents(r#"tracing::warn!(n = 1, "dropped {} rows", n);"#)
+                .iter()
+                .any(|(_, i, _)| i == POSITIONAL),
+            "a positional `{{}}` placeholder was not flagged - see `POSITIONAL`"
         );
         assert!(
             interpolated_body_idents(r#"tracing::warn!("100{{msg}} percent");"#).is_empty(),

--- a/src/log_hygiene.rs
+++ b/src/log_hygiene.rs
@@ -1,0 +1,361 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+
+//! Build-time lints on what a log record is allowed to CONTAIN.
+//!
+//! # Why this is a module and not a comment in a style guide
+//! `telemetry_spool::redact` filters attributes by key: anything not on
+//! `SAFE_STRING_KEYS` is dropped before the ship leg. The **message body** has
+//! no such gate - it *is* the record, so it always ships, having passed only
+//! `scrub_text`'s URL/email/blob patterns, which know nothing about ticket keys,
+//! window titles, or a tracker's error payload.
+//!
+//! CLAUDE.md has said "structured fields - never format data values into the
+//! message string" since the beginning, and nothing checked it. It drifted at
+//! three tray call sites that spliced a `meridian` subprocess's stderr into a
+//! WARN body, and issue #872 measured the result in central OpenObserve: a real
+//! user's ticket key (`ENG-7041`), from a value the allowlist denies as an
+//! attribute. A rule nothing enforces is a rule that decays, which is the whole
+//! argument for putting it here instead.
+//!
+//! The lint is source-scanning because the defect is invisible at runtime - the
+//! record is emitted, well-formed, and carries exactly what it was told to.
+//! Nothing observes the difference until it is already on someone else's server.
+//!
+//! # Who calls this
+//! Nothing at runtime. `cargo test` runs [`tests::no_user_data_interpolated_into_a_log_body`]
+//! over every workspace source tree, and it fails the build for the whole
+//! workspace, not just this crate.
+//!
+//! # Related
+//! - [`crate::errors`] - the sibling log-hygiene lint, on the opposite failure:
+//!   `no_bare_error_display_in_db_paths` catches a cause being DROPPED, this
+//!   catches user data being ADDED. Both exist because a well-formed log line
+//!   is not a correct one.
+//! - `crate::telemetry_spool::redact` - the attribute-side boundary this one
+//!   complements, and the reason a body needs its own rule at all.
+
+#[cfg(test)]
+mod tests {
+
+    /// The identifiers a WARN+/ERROR **message body** may interpolate.
+    ///
+    /// # Why this is an allowlist and not "don't do that"
+    /// A log body is the one field `telemetry_spool::redact` structurally cannot
+    /// filter. Attributes are dropped unless their key is on
+    /// `SAFE_STRING_KEYS`; the body IS the record, so it always ships. Anything
+    /// interpolated into it egresses verbatim, having passed only `scrub_text`'s
+    /// URL/email/blob patterns - which know nothing about ticket keys, window
+    /// titles, or a tracker's error payload.
+    ///
+    /// Issue #872 measured the consequence: a real user's ticket key
+    /// (`ENG-7041`) in central OpenObserve, spliced in from a `meridian`
+    /// subprocess's stderr by three tray call sites, from a value the allowlist
+    /// denies as an attribute. CLAUDE.md has forbidden this since the beginning
+    /// - "structured fields - never format data values into the message string"
+    /// - and nothing enforced it, so it drifted three times.
+    ///
+    /// # Adding an identifier
+    /// It must be provably a compile-time constant or a closed set of our own
+    /// literals at EVERY call site, and it must earn a justification here. If
+    /// the value is runtime data, it belongs in a structured field instead,
+    /// where the allowlist can make a deliberate decision about it - which is
+    /// the entire point of having one.
+    const INTERPOLABLE: &[&str] = &[
+        // A subcommand/operation label. `&'static str` at every call site
+        // (`"ticket-statuses"`, `"plan-task-draft"`, …) - it names OUR
+        // subcommand, never the user's data.
+        "label",
+        // `catch_setup_panic`'s stage name - a `&str` literal at both call
+        // sites, naming a tray setup step.
+        "what",
+        // A panic payload, from `catch_setup_panic`. Deliberately still in the
+        // body: it is our own `expect`/`panic!` text and it is THE diagnostic
+        // for a startup panic, so moving it to an unallowlisted attribute would
+        // delete it from the fleet's telemetry entirely - #867's mistake, not
+        // #872's. It already ships today and this change does not widen that;
+        // the rename to `panic_msg` exists so the exemption is visible at the
+        // call site rather than riding on the generic name `msg`, which is what
+        // all three #872 sites used.
+        "panic_msg",
+    ];
+
+    /// The source trees this scans. A directory WALK, not an `include_str!`
+    /// list: the defect is a new call site, so a "remember to add your file"
+    /// list would be exactly the shape of hole issue #878 was about. Every
+    /// crate in the workspace that emits telemetry is covered.
+    const SCANNED_TREES: &[&str] = &[
+        "src",
+        "meridian-core/src",
+        "meridian-oauth/src",
+        "tray/src-tauri/src",
+    ];
+
+    /// Collect `(path, production source)` for every `.rs` under `SCANNED_TREES`,
+    /// truncated at the file's test module - a file's own tests legitimately
+    /// contain example log lines, and this scan reads the file it lives in.
+    fn production_sources() -> Vec<(String, String)> {
+        fn walk(dir: &std::path::Path, out: &mut Vec<(String, String)>) {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for e in entries.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk(&p, out);
+                } else if p.extension().is_some_and(|x| x == "rs")
+                    // A dedicated test file (`tests.rs`, `cli_exec_tests.rs`)
+                    // has no in-file `#[cfg(test)]` to truncate at, so the
+                    // marker heuristic below would read all of it as
+                    // production and flag its example log lines.
+                    && !p.file_name().is_some_and(|n| {
+                        let n = n.to_string_lossy();
+                        n == "tests.rs" || n.ends_with("_tests.rs")
+                    })
+                {
+                    if let Ok(src) = std::fs::read_to_string(&p) {
+                        let prod = src
+                            .split_once("\n#[cfg(test)]")
+                            .map_or(src.as_str(), |(a, _)| a)
+                            .to_string();
+                        out.push((p.display().to_string(), prod));
+                    }
+                }
+            }
+        }
+        // Set at COMPILE time to this crate's directory, which is the workspace
+        // root (`members = [".", …]`), so the walk is rooted correctly no matter
+        // where the test binary is invoked from.
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let mut out = Vec::new();
+        for tree in SCANNED_TREES {
+            walk(&root.join(tree), &mut out);
+        }
+        assert!(
+            out.len() > 100,
+            "the source walk found only {} files - SCANNED_TREES is stale or the \
+             layout moved, and a scan that reads nothing passes silently",
+            out.len()
+        );
+        out
+    }
+
+    /// Every `{ident}` interpolated into the message body of a `tracing::warn!`
+    /// or `tracing::error!` in `src`, with its line number.
+    fn interpolated_body_idents(src: &str) -> Vec<(usize, String, String)> {
+        let mut found = Vec::new();
+        // Matched WITHOUT the `tracing::` prefix on purpose: 14 sites in
+        // `etl/` and `capture/` import the macro (`use tracing::warn`) and call
+        // it bare, and a scan anchored on the qualified spelling would have read
+        // as full coverage while silently skipping every one of them.
+        for macro_name in ["warn!", "error!"] {
+            let mut from = 0;
+            while let Some(rel) = src[from..].find(macro_name) {
+                let start = from + rel;
+                from = start + macro_name.len();
+                // Not part of a longer identifier (`some_error!`, `debug_warn!`).
+                if src[..start]
+                    .chars()
+                    .next_back()
+                    .is_some_and(|c| c.is_alphanumeric() || c == '_')
+                {
+                    continue;
+                }
+                // Skip a commented-out example.
+                let line_start = src[..start].rfind('\n').map_or(0, |i| i + 1);
+                if src[line_start..start].trim_start().starts_with("//") {
+                    continue;
+                }
+                let Some(open) = src[start..].find('(').map(|i| start + i) else {
+                    continue;
+                };
+                // Balance parens, ignoring anything inside a string literal.
+                let (mut depth, mut i) = (0usize, open);
+                let (mut in_str, mut esc) = (false, false);
+                let bytes: Vec<char> = src[open..].chars().collect();
+                let mut k = 0usize;
+                while k < bytes.len() {
+                    let c = bytes[k];
+                    if in_str {
+                        if esc {
+                            esc = false;
+                        } else if c == '\\' {
+                            esc = true;
+                        } else if c == '"' {
+                            in_str = false;
+                        }
+                    } else if c == '"' {
+                        in_str = true;
+                    } else if c == '(' {
+                        depth += 1;
+                    } else if c == ')' {
+                        depth -= 1;
+                        if depth == 0 {
+                            break;
+                        }
+                    }
+                    k += 1;
+                }
+                i += k;
+                let args = &src[open + 1..i.min(src.len())];
+                // The message is the LAST top-level string literal in the arg
+                // list - `tracing`'s own rule.
+                let Some(msg) = last_string_literal(args) else {
+                    continue;
+                };
+                let line = src[..start].matches('\n').count() + 1;
+                for ident in placeholders(&msg) {
+                    found.push((line, ident, msg.clone()));
+                }
+            }
+        }
+        found
+    }
+
+    /// The last `"…"` literal in a macro argument list, unescaped enough to read
+    /// its `{}` placeholders.
+    fn last_string_literal(args: &str) -> Option<String> {
+        let chars: Vec<char> = args.chars().collect();
+        let (mut i, mut last) = (0usize, None);
+        while i < chars.len() {
+            if chars[i] == '"' {
+                let mut j = i + 1;
+                let mut buf = String::new();
+                while j < chars.len() {
+                    if chars[j] == '\\' {
+                        j += 2;
+                        continue;
+                    }
+                    if chars[j] == '"' {
+                        break;
+                    }
+                    buf.push(chars[j]);
+                    j += 1;
+                }
+                last = Some(buf);
+                i = j + 1;
+            } else {
+                i += 1;
+            }
+        }
+        last
+    }
+
+    /// Named `{ident}` captures in a format string. Positional `{}` / `{:?}` are
+    /// out of scope: they take their value from a trailing argument, and
+    /// `no_bare_error_display_in_db_paths` already covers the `%e` case that
+    /// produces in practice.
+    fn placeholders(msg: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        let chars: Vec<char> = msg.chars().collect();
+        let mut i = 0usize;
+        while i < chars.len() {
+            if chars[i] == '{' {
+                if chars.get(i + 1) == Some(&'{') {
+                    i += 2;
+                    continue;
+                }
+                let mut j = i + 1;
+                let mut name = String::new();
+                while j < chars.len() && (chars[j].is_alphanumeric() || chars[j] == '_') {
+                    name.push(chars[j]);
+                    j += 1;
+                }
+                // Only a NAMED capture: `{x}` or `{x:?}`, not `{}` or `{:?}`.
+                if !name.is_empty()
+                    && !name.starts_with(|c: char| c.is_ascii_digit())
+                    && matches!(chars.get(j), Some('}') | Some(':'))
+                {
+                    out.push(name);
+                }
+                i = j;
+            } else {
+                i += 1;
+            }
+        }
+        out
+    }
+
+    /// A WARN+ log BODY always ships - it is the one field the redaction
+    /// allowlist cannot reach - so nothing runtime-valued may be formatted into
+    /// it. See [`INTERPOLABLE`] for the full reasoning and issue #872 for the
+    /// leak that prompted this.
+    #[test]
+    fn no_user_data_interpolated_into_a_log_body() {
+        let mut offenders = Vec::new();
+        for (path, src) in production_sources() {
+            for (line, ident, msg) in interpolated_body_idents(&src) {
+                if !INTERPOLABLE.contains(&ident.as_str()) {
+                    offenders.push(format!("{path}:{line} - `{{{ident}}}` in \"{msg}\""));
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "a WARN+/ERROR message body interpolates a value that is not on \
+             `INTERPOLABLE`. The body is the ONE field `telemetry_spool::redact` \
+             cannot filter - attributes are dropped unless allowlisted, but the \
+             body always ships - so whatever this formats in egresses verbatim \
+             to central OpenObserve. Issue #872 measured a real user's ticket key \
+             arriving this way. Put the value in a structured field instead \
+             (`tracing::warn!(some_key = %v, \"static message\")`), where the \
+             allowlist can make a deliberate decision about it; if it is genuinely \
+             a compile-time literal at every call site, add it to `INTERPOLABLE` \
+             with a justification. Offenders: {offenders:#?}"
+        );
+    }
+
+    /// The scan above is only worth having if it actually catches the #872
+    /// shape. Feeds it the pre-fix source verbatim - a scan nobody has seen fail
+    /// is a scan nobody knows works.
+    #[test]
+    fn the_body_scan_catches_the_splice_it_was_written_for() {
+        let pre_fix = r#"
+            tracing::warn!(
+                bin = %bin,
+                code = ?output.status.code(),
+                "{label} non-zero: {msg}"
+            );
+        "#;
+        let hits = interpolated_body_idents(pre_fix);
+        let idents: Vec<&str> = hits.iter().map(|(_, i, _)| i.as_str()).collect();
+        assert!(
+            idents.contains(&"msg"),
+            "the scan missed `{{msg}}`, the exact splice #872 measured: {idents:?}"
+        );
+        assert!(
+            idents.contains(&"label"),
+            "the scan missed `{{label}}` - it must SEE allowlisted idents too, or \
+             the allowlist is doing nothing and a rename would slip through: {idents:?}"
+        );
+
+        assert!(
+            interpolated_body_idents(r#"warn!(error = %e, "gap {kind} misclassified");"#)
+                .iter()
+                .any(|(_, i, _)| i == "kind"),
+            "the scan missed a BARE `warn!(` - 14 sites in etl/ and capture/ \
+             import the macro and call it unqualified"
+        );
+
+        // Things that must NOT trip it.
+        assert!(
+            interpolated_body_idents(r#"tracing::warn!(error = %e, "fetch failed");"#).is_empty(),
+            "a body with no interpolation was flagged"
+        );
+        assert!(
+            interpolated_body_idents(r#"// tracing::warn!("{msg}");"#).is_empty(),
+            "a commented-out example was flagged"
+        );
+        assert!(
+            interpolated_body_idents(r#"fn my_error!(x) { "{msg}" }"#).is_empty(),
+            "`my_error!` is a different macro and must not be scanned"
+        );
+        assert!(
+            interpolated_body_idents(r#"tracing::warn!(n = 1, "dropped {} rows", n);"#).is_empty(),
+            "a positional `{{}}` placeholder is out of scope - see `placeholders`"
+        );
+        assert!(
+            interpolated_body_idents(r#"tracing::warn!("100{{msg}} percent");"#).is_empty(),
+            "an escaped `{{{{`/`}}}}` literal was read as a placeholder"
+        );
+    }
+}

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -1820,6 +1820,89 @@ mod tests {
         }
     }
 
+    /// End-to-end proof of the #872 fix, at the boundary itself rather than at
+    /// the call site: a WARN shaped exactly like the one
+    /// `commands::cli_exec::log_non_zero_exit` now emits must ship its static
+    /// message and exit code, and must NOT ship the subprocess stderr the
+    /// pre-fix version spliced into that message.
+    ///
+    /// The pre-fix half is asserted too, and is the more important one - it is
+    /// what makes this a regression test rather than a restatement. Reverting
+    /// `log_non_zero_exit`'s body to `"{label} non-zero: {stderr}"` puts the
+    /// ticket key back in `body`, where nothing here can filter it, and this
+    /// test then fails on the very next line.
+    #[test]
+    fn a_subprocess_stderr_ships_only_when_it_is_spliced_into_the_body() {
+        const STDERR: &str = "Jira GET transitions for ENG-7041 returned 404 Not Found";
+
+        // The FIXED shape: static body, stderr on an unallowlisted attribute.
+        let mut fixed = log_record(
+            SEVERITY_WARN,
+            vec![
+                str_attr("stderr_tail", STDERR),
+                str_attr("key", "ENG-7041"),
+                str_attr("bin_source", "staged"),
+                int_attr("code", 1),
+                int_attr("stderr_len", STDERR.len() as i64),
+            ],
+        );
+        fixed.body = Some(AnyValue {
+            value: Some(Value::StringValue("ticket-statuses non-zero".into())),
+        });
+        let out = match redact_and_filter("logs", &encode_logs(vec![fixed])) {
+            Redacted::Payload { bytes, .. } => decode_logs(&bytes),
+            Redacted::Empty => panic!("the WARN was filtered out before redaction"),
+            Redacted::Undecodable => panic!("the re-encoded payload did not decode"),
+        };
+        let rec = out.first().expect("the WARN was dropped entirely");
+        let body = match rec.body.as_ref().and_then(|b| b.value.as_ref()) {
+            Some(Value::StringValue(s)) => s.clone(),
+            other => panic!("expected a string body, got {other:?}"),
+        };
+        assert!(
+            !body.contains("ENG-7041"),
+            "the ticket key reached the wire through the body: {body}"
+        );
+        let keys: Vec<&str> = rec.attributes.iter().map(|kv| kv.key.as_str()).collect();
+        assert!(
+            !keys.contains(&"stderr_tail") && !keys.contains(&"key"),
+            "stderr_tail / key are not allowlisted and must not ship: {keys:?}"
+        );
+        // …but the record is still worth having: which subcommand, which
+        // binary, and - restored by this change, having previously been
+        // debug-formatted into `\"Some(1)\"` and dropped - the exit code.
+        assert!(body.contains("ticket-statuses"), "{body}");
+        assert!(keys.contains(&"bin_source"), "{keys:?}");
+        assert!(
+            keys.contains(&"code") && keys.contains(&"stderr_len"),
+            "the numeric diagnostics were dropped: {keys:?}"
+        );
+
+        // The PRE-FIX shape, for contrast: same stderr, spliced into the body.
+        // Nothing in this module can stop it, which is precisely why the guard
+        // had to go at the call site (`errors.rs`).
+        let mut pre_fix = log_record(SEVERITY_WARN, vec![]);
+        pre_fix.body = Some(AnyValue {
+            value: Some(Value::StringValue(format!(
+                "ticket-statuses non-zero: {STDERR}"
+            ))),
+        });
+        let out = match redact_and_filter("logs", &encode_logs(vec![pre_fix])) {
+            Redacted::Payload { bytes, .. } => decode_logs(&bytes),
+            _ => panic!("expected a payload"),
+        };
+        let body = match out[0].body.as_ref().and_then(|b| b.value.as_ref()) {
+            Some(Value::StringValue(s)) => s.clone(),
+            other => panic!("expected a string body, got {other:?}"),
+        };
+        assert!(
+            body.contains("ENG-7041"),
+            "if redaction has started catching ticket keys in the body, this test \
+             and `errors.rs`'s INTERPOLABLE doc are both out of date - the fix \
+             would no longer need to live at the call site. Body was: {body}"
+        );
+    }
+
     /// `health check failed` is a static message carrying no diagnostic payload
     /// of its own — everything that identifies the fault rides on its fields. So
     /// six machines reported a CRITICAL health failure to the backend with no

--- a/src/telemetry_spool/redact.rs
+++ b/src/telemetry_spool/redact.rs
@@ -125,9 +125,19 @@ const SAFE_STRING_KEYS: &[&str] = &[
     // output, so it needs the full scrub, not just a path scrub.
     "error",
     // Which provider/engine a failure came from. Enum-like values from a fixed
-    // internal set (`claude`, `codex`, `anthropic`, `gemini`, …) — they name
-    // OUR components, never the user's data, and without them an LLM or
-    // summariser failure can't be attributed to a backend at all.
+    // internal set — they name OUR components, never the user's data, and
+    // without them an LLM or summariser failure can't be attributed to a
+    // backend at all.
+    //
+    // TWO value domains share this key, and the second is easy to miss: LLM
+    // engines (`claude`, `codex`, `anthropic`, `gemini`, …) AND task trackers
+    // (`jira`, `linear`, `github`, `azure_devops`, `asana`, `trello`), from the
+    // tray's `ticket-parents`/`ticket-update` shell-outs. That second domain
+    // reaches the tray as a plain `String` from the frontend, so
+    // `commands::cli_exec::provider_label` narrows it to those literals or
+    // `"other"` before it is logged. An allowlist entry whose comment does not
+    // describe all of its emitters is the exact shape of #872 - do not add a
+    // third domain here without naming it.
     "provider",
     "engine",
     // ── health checks (`crate::health::Report::log`) ─────────────────────────

--- a/tray/src-tauri/src/commands/cli_exec.rs
+++ b/tray/src-tauri/src/commands/cli_exec.rs
@@ -107,17 +107,89 @@ pub(crate) async fn run_meridian(
         let msg = if stderr.is_empty() {
             format!("{label} exited {:?}", output.status.code())
         } else {
-            stderr
+            stderr.clone()
         };
-        tracing::warn!(
-            bin = %bin,
-            bin_source = crate::install::bin_source(&bin),
-            code = ?output.status.code(),
-            "{label} non-zero: {msg}"
-        );
+        log_non_zero_exit(NonZeroExit {
+            label,
+            bin: Some(bin.as_str()),
+            provider: None,
+            key: None,
+            code: output.status.code(),
+            stderr: &stderr,
+        });
         return Err(msg);
     }
     Ok(stdout)
+}
+
+/// Everything the [`log_non_zero_exit`] WARN reports. A struct rather than six
+/// parameters because clippy caps argument counts at seven and the three call
+/// sites each carry a different subset (see `BlockBounds` in the daemon's ETL
+/// runner for the same convention).
+pub(crate) struct NonZeroExit<'a> {
+    /// The subcommand label, e.g. `ticket-statuses`. A `&'static str` literal at
+    /// every call site - it names OUR subcommand, never the user's data, which
+    /// is why it is the one value interpolated into the message body.
+    pub(crate) label: &'a str,
+    /// The resolved `meridian` binary path, when the caller has one.
+    pub(crate) bin: Option<&'a str>,
+    /// The tracker this call was for (`jira`, `linear`, …), when applicable.
+    pub(crate) provider: Option<&'a str>,
+    /// The ticket key the call was about, when applicable. Local-only - see the
+    /// note on `stderr_tail` in [`log_non_zero_exit`].
+    pub(crate) key: Option<&'a str>,
+    /// The child's exit code, if it exited rather than being signalled.
+    pub(crate) code: Option<i32>,
+    /// The child's full stderr, already trimmed.
+    pub(crate) stderr: &'a str,
+}
+
+/// The ONE place a non-zero `meridian` subprocess exit is logged.
+///
+/// # Why this is not three inline `warn!`s
+/// It used to be: this module, [`crate::commands::parents`] and
+/// [`crate::commands::triage`] each spliced the child's stderr straight into the
+/// message body (`"{label} non-zero: {msg}"`). A log **body** always ships - it
+/// is the record - so it is the one field `telemetry_spool::redact`'s attribute
+/// allowlist cannot reach, and subprocess stderr is unbounded third-party text:
+/// a Jira 404 body, a provider API error, a DB error. Issue #872 measured a real
+/// user's ticket key (`ENG-7041`) in central OpenObserve, arriving through
+/// exactly this splice, from a key the allowlist denies as an attribute.
+///
+/// So the body is now static and the stderr rides on `stderr_tail`, which is
+/// deliberately **not** on `redact::SAFE_STRING_KEYS`. That is the two-tier
+/// design working as intended rather than a diagnostic being thrown away:
+/// unallowlisted attributes are captured at full fidelity locally (`meridian
+/// logs` renders attributes, and export bundles carry the raw spool) and dropped
+/// on the ship leg. The engineer debugging their own machine loses nothing; the
+/// central backend stops receiving the user's content.
+///
+/// `code` is passed as `i64` on purpose. It used to be `code = ?…`, which
+/// debug-formats an `Option` into the string `"Some(1)"` - not a bare number, so
+/// `redact::is_bare_number` could not rescue it and the exit code was dropped
+/// from every shipped record. An `IntValue` is kept unconditionally for any key
+/// ([`meridian::telemetry_spool::redact`]'s first `keep_attribute` arm), so this
+/// change also *restores* a diagnostic the previous form silently lost.
+pub(crate) fn log_non_zero_exit(ctx: NonZeroExit<'_>) {
+    let NonZeroExit {
+        label,
+        bin,
+        provider,
+        key,
+        code,
+        stderr,
+    } = ctx;
+    tracing::warn!(
+        bin = bin.unwrap_or(""),
+        bin_source = bin.map(crate::install::bin_source).unwrap_or(""),
+        provider = provider.unwrap_or(""),
+        key = key.unwrap_or(""),
+        // `-1` for "signalled, no exit code" - `Option` would stringify.
+        code = code.unwrap_or(-1) as i64,
+        stderr_len = stderr.len() as i64,
+        stderr_tail = %tail(stderr, 400),
+        "{label} non-zero"
+    );
 }
 
 /// Spawn `meridian <args…>` detached — no timeout, not awaited. For work that can
@@ -215,135 +287,5 @@ pub(crate) async fn run_meridian_json<T: for<'de> Deserialize<'de>>(
 }
 
 #[cfg(test)]
-mod tests {
-    use std::process::Stdio;
-    use std::time::Duration;
-
-    /// Regression guard: on a timeout, `tokio::time::timeout` drops the
-    /// `.output()` future, and without `kill_on_drop(true)` the spawned
-    /// `meridian <args>` keeps running in the background after the caller has
-    /// already reported failure to the user. For an LLM-backed call like
-    /// `plan-task-draft`, that orphan then competes with the next "Try again"
-    /// click's fresh process for the same provider/DB — a plausible reason a
-    /// draft that missed its 150s budget once keeps missing it on retry.
-    ///
-    /// This can't drive `run_meridian` itself as a real spawn-and-verify test:
-    /// it resolves its binary via `crate::install::meridian_bin()`, and
-    /// overriding that via `MERIDIAN_BIN` would mean `std::env::set_var` on a
-    /// shared test binary — exactly what `integrations.rs`'s "avoiding
-    /// `std::env::set_var` on a Tokio worker thread" note warns off. So this
-    /// is source-scanned, mirroring `tasks.rs::sync_tasks`, the sibling call
-    /// site that already carries this fix. The MECHANISM itself — that
-    /// `kill_on_drop(true)` actually terminates an orphaned child, on this
-    /// platform, with tokio's real process reaping — is verified separately
-    /// below, against a plain `tokio::process::Command` that needs no
-    /// `MERIDIAN_BIN` override at all.
-    #[test]
-    fn run_meridian_kills_the_child_on_timeout() {
-        let src = include_str!("cli_exec.rs");
-        let prod = src.split_once("\n#[cfg(test)]").map_or(src, |(a, _)| a);
-        let spawn = prod
-            .find("tokio::process::Command::new(&bin)")
-            .expect("run_meridian's Command builder moved or was renamed");
-        let output_call = prod[spawn..]
-            .find(".output();")
-            .expect("run_meridian's Command builder no longer ends in .output()");
-        let builder = &prod[spawn..spawn + output_call];
-        assert!(
-            builder.contains(".kill_on_drop(true)"),
-            "run_meridian's spawned child is missing .kill_on_drop(true) — a \
-             timeout will orphan it instead of killing it. Builder was: {builder}"
-        );
-    }
-
-    /// A process that runs far longer than the timeout below, so the timeout
-    /// always wins the race — the exact shape `run_meridian` puts its child
-    /// in. No dependency on `meridian`/`MERIDIAN_BIN`: `sleep`/`ping` are
-    /// present on every macOS and Windows runner this crate's tests run on
-    /// (see `.github/workflows/ci.yml`'s `windows-latest` + `macos-latest`
-    /// `cargo test --workspace` jobs).
-    #[cfg(unix)]
-    fn long_running_command() -> (&'static str, &'static [&'static str]) {
-        ("sleep", &["30"])
-    }
-    #[cfg(windows)]
-    fn long_running_command() -> (&'static str, &'static [&'static str]) {
-        // `timeout.exe` refuses to run with stdin redirected (no console
-        // handle) — `ping` to loopback is the standard "sleep N seconds"
-        // substitute on Windows and needs no real network.
-        ("ping", &["-n", "30", "127.0.0.1"])
-    }
-
-    #[cfg(unix)]
-    fn process_is_alive(pid: u32) -> bool {
-        std::process::Command::new("ps")
-            .args(["-p", &pid.to_string()])
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
-    }
-    #[cfg(windows)]
-    fn process_is_alive(pid: u32) -> bool {
-        // `tasklist` exits 0 either way, printing "No tasks are running..."
-        // when nothing matches — the pid has to actually appear in the
-        // output, not just a success status.
-        std::process::Command::new("tasklist")
-            .args(["/FI", &format!("PID eq {pid}"), "/NH"])
-            .output()
-            .map(|o| String::from_utf8_lossy(&o.stdout).contains(&pid.to_string()))
-            .unwrap_or(false)
-    }
-
-    /// Proves the MECHANISM `run_meridian_kills_the_child_on_timeout` pins the
-    /// wiring for: that `kill_on_drop(true)` on a `tokio::process::Command`
-    /// actually terminates the child once the future racing it is dropped —
-    /// i.e. that this fix does what its own reasoning claims, not just that
-    /// the flag is textually present.
-    #[tokio::test]
-    async fn kill_on_drop_actually_terminates_the_orphaned_child() {
-        let (bin, args) = long_running_command();
-        let child = tokio::process::Command::new(bin)
-            .args(args)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-            .expect("failed to spawn the long-running test process");
-        let pid = child.id().expect("a just-spawned child must have a pid");
-        assert!(
-            process_is_alive(pid),
-            "test bug: process not observed alive right after spawn"
-        );
-
-        {
-            // Mirrors `run_meridian` exactly: race the child's `.output()`
-            // against a timeout far shorter than the process's own runtime.
-            let output_fut = child.wait_with_output();
-            let result = tokio::time::timeout(Duration::from_millis(50), output_fut).await;
-            assert!(
-                result.is_err(),
-                "test bug: the process exited before the timeout could fire"
-            );
-            // `output_fut` (and the `Child` it consumed) drops here — exactly
-            // what happens when `tokio::time::timeout` drops `run_meridian`'s
-            // `.output()` future on a real timeout.
-        }
-
-        // `kill_on_drop`'s kill is fired from `Drop`, not awaited to
-        // completion — poll briefly rather than asserting instantaneously.
-        let mut still_alive = process_is_alive(pid);
-        for _ in 0..20 {
-            if !still_alive {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            still_alive = process_is_alive(pid);
-        }
-        assert!(
-            !still_alive,
-            "child (pid {pid}) is still running ~2s after being dropped — \
-             kill_on_drop did not terminate it"
-        );
-    }
-}
+#[path = "cli_exec_tests.rs"]
+mod tests;

--- a/tray/src-tauri/src/commands/cli_exec.rs
+++ b/tray/src-tauri/src/commands/cli_exec.rs
@@ -170,6 +170,33 @@ pub(crate) struct NonZeroExit<'a> {
 /// from every shipped record. An `IntValue` is kept unconditionally for any key
 /// ([`meridian::telemetry_spool::redact`]'s first `keep_attribute` arm), so this
 /// change also *restores* a diagnostic the previous form silently lost.
+/// Map a tracker name onto a fixed set of literals, or `"other"`.
+///
+/// `provider` is on `redact::SAFE_STRING_KEYS` and therefore SHIPS, justified
+/// there as "enum-like values from a fixed internal set". At this call site the
+/// value arrives from the frontend as a plain `String` (`get_ticket_parents`'s
+/// and `apply_ticket_fix`'s parameters) and nothing between there and here
+/// validates it - so the allowlist's premise would have rested on the frontend
+/// behaving, which is not a property anyone can audit. Normalising here makes it
+/// structurally true instead, the same way `install::bin_source` can only ever
+/// return one of five literals.
+///
+/// Mirrors `meridian_core::canonical_task::Provider::as_str`. A name that falls
+/// through to `"other"` still says a tracker call failed, which is the whole
+/// diagnostic value; it just cannot smuggle a typed string onto the wire.
+fn provider_label(p: &str) -> &'static str {
+    match p {
+        "jira" => "jira",
+        "linear" => "linear",
+        "github" => "github",
+        "azure_devops" => "azure_devops",
+        "asana" => "asana",
+        "trello" => "trello",
+        "" => "",
+        _ => "other",
+    }
+}
+
 pub(crate) fn log_non_zero_exit(ctx: NonZeroExit<'_>) {
     let NonZeroExit {
         label,
@@ -182,7 +209,7 @@ pub(crate) fn log_non_zero_exit(ctx: NonZeroExit<'_>) {
     tracing::warn!(
         bin = bin.unwrap_or(""),
         bin_source = bin.map(crate::install::bin_source).unwrap_or(""),
-        provider = provider.unwrap_or(""),
+        provider = provider.map(provider_label).unwrap_or(""),
         key = key.unwrap_or(""),
         // `-1` for "signalled, no exit code" - `Option` would stringify.
         code = code.unwrap_or(-1) as i64,

--- a/tray/src-tauri/src/commands/cli_exec_tests.rs
+++ b/tray/src-tauri/src/commands/cli_exec_tests.rs
@@ -121,6 +121,55 @@ fn a_non_zero_exit_keeps_subprocess_stderr_out_of_the_message_body() {
     );
 }
 
+/// `provider` SHIPS, so an unrecognised value must not reach the wire verbatim.
+/// It arrives here from the frontend as a plain `String` with nothing
+/// validating it - see `provider_label`.
+#[test]
+fn an_unrecognised_provider_is_narrowed_before_it_ships() {
+    fn shipped_provider(p: &str) -> String {
+        let events = capture(|| {
+            log_non_zero_exit(NonZeroExit {
+                label: "ticket-update",
+                bin: None,
+                provider: Some(p),
+                key: None,
+                code: Some(1),
+                stderr: "boom",
+            })
+        });
+        events[0]
+            .fields
+            .iter()
+            .find(|(k, _)| k == "provider")
+            .map(|(_, v)| v.clone())
+            .expect("provider field missing")
+    }
+
+    let shipped = shipped_provider("acme-internal-tracker-prod");
+    assert!(
+        !shipped.contains("acme-internal-tracker-prod"),
+        "an unvalidated provider name reached an ALLOWLISTED field: {shipped}"
+    );
+    assert!(shipped.contains("other"), "{shipped}");
+
+    // …while every real tracker still reports itself.
+    for p in [
+        "jira",
+        "linear",
+        "github",
+        "azure_devops",
+        "asana",
+        "trello",
+    ] {
+        let shipped = shipped_provider(p);
+        assert!(
+            shipped.contains(p),
+            "`{p}` was narrowed away - provider_label has drifted from \
+             meridian_core::canonical_task::Provider::as_str: {shipped}"
+        );
+    }
+}
+
 /// `stderr_tail` must stay OFF `redact::SAFE_STRING_KEYS`, or moving the
 /// stderr out of the body accomplishes nothing - it would ship under its new
 /// name instead. Pinning it here rather than trusting the reader to

--- a/tray/src-tauri/src/commands/cli_exec_tests.rs
+++ b/tray/src-tauri/src/commands/cli_exec_tests.rs
@@ -1,0 +1,274 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Tests for [`super`] - split out to keep `cli_exec.rs` under the 500-line
+//! rule. Attached with `#[path]` rather than a `cli_exec/` directory so the
+//! `include_str!("cli_exec.rs")` source scan below keeps resolving against the
+//! same directory.
+use super::{log_non_zero_exit, NonZeroExit};
+use std::process::Stdio;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tracing_subscriber::{layer::SubscriberExt, registry, Layer};
+
+/// One captured tracing event: level, message body, and `(field, value)`
+/// pairs. Mirrors `commands::setup`'s recorder, which exists for the same
+/// reason - `telemetry_spool::redact` filters on the EXACT field name, so a
+/// test that only asserted "the stderr is logged somewhere" would pass
+/// whether it landed in the body (always ships) or an unallowlisted
+/// attribute (never ships), which is the entire distinction under test.
+#[derive(Debug)]
+struct CapturedEvent {
+    message: String,
+    fields: Vec<(String, String)>,
+}
+
+struct Recorder(Arc<Mutex<Vec<CapturedEvent>>>);
+
+impl<S: tracing::Subscriber> Layer<S> for Recorder {
+    fn on_event(&self, event: &tracing::Event<'_>, _c: tracing_subscriber::layer::Context<'_, S>) {
+        struct V(Vec<(String, String)>);
+        impl tracing::field::Visit for V {
+            fn record_debug(&mut self, f: &tracing::field::Field, v: &dyn std::fmt::Debug) {
+                self.0.push((f.name().to_string(), format!("{v:?}")));
+            }
+        }
+        let mut v = V(Vec::new());
+        event.record(&mut v);
+        // `tracing` records the formatted message body under the reserved
+        // field name `message`; everything else is a structured attribute.
+        let message =
+            v.0.iter()
+                .find(|(k, _)| k == "message")
+                .map(|(_, val)| val.clone())
+                .unwrap_or_default();
+        let fields = v.0.into_iter().filter(|(k, _)| k != "message").collect();
+        self.0
+            .lock()
+            .unwrap()
+            .push(CapturedEvent { message, fields });
+    }
+}
+
+/// Run `f` under a bare recording subscriber (no `EnvFilter`, so level is
+/// irrelevant) and return what it emitted. Drains through the `Mutex`
+/// rather than `Arc::try_unwrap` - see `commands::setup::capture`'s note on
+/// the Windows CI flake that caused.
+fn capture(f: impl FnOnce()) -> Vec<CapturedEvent> {
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = registry().with(Recorder(Arc::clone(&seen)));
+    tracing::subscriber::with_default(subscriber, f);
+    let events = std::mem::take(&mut *seen.lock().unwrap());
+    events
+}
+
+/// The measured leak from issue #872, verbatim: a real user's ticket key
+/// reached central OpenObserve inside a WARN body, because the tray spliced
+/// the `meridian` subprocess's stderr into the message. `task_key` is denied
+/// as an attribute and pinned so by
+/// `redact::user_scoped_diagnostic_keys_stay_off_the_allowlist` - but the
+/// body is not an attribute, so the allowlist never saw it.
+const MEASURED_STDERR: &str = "Jira GET transitions for ENG-7041 returned 404 Not Found:         {\"errorMessages\":[\"Issue does not exist or you do not have permission to see it.\"]}";
+
+/// The regression this whole change exists for.
+///
+/// Asserts BOTH halves, because either one alone is satisfiable by a bad
+/// fix: the ticket key must not be in the body (or it ships), AND the
+/// stderr must still be captured under `stderr_tail` (or we have repeated
+/// #867 in the opposite direction and deleted the only record the failure
+/// leaves on the engineer's own machine).
+#[test]
+fn a_non_zero_exit_keeps_subprocess_stderr_out_of_the_message_body() {
+    let events = capture(|| {
+        log_non_zero_exit(NonZeroExit {
+            label: "ticket-statuses",
+            bin: Some("/Users/someone/.meridian/bin/meridian"),
+            provider: Some("jira"),
+            key: Some("ENG-7041"),
+            code: Some(1),
+            stderr: MEASURED_STDERR,
+        })
+    });
+    let e = events.first().expect("log_non_zero_exit emitted no event");
+
+    assert!(
+        !e.message.contains("ENG-7041"),
+        "the user's ticket key is in the log BODY, which always ships - \
+             redact's attribute allowlist cannot reach it. Body was: {}",
+        e.message
+    );
+    assert!(
+        !e.message.contains("Issue does not exist"),
+        "the provider's error payload is in the log BODY. Body was: {}",
+        e.message
+    );
+    assert!(
+        e.message.contains("ticket-statuses"),
+        "the body must still name WHICH subcommand failed. Body was: {}",
+        e.message
+    );
+
+    let tail = e
+        .fields
+        .iter()
+        .find(|(k, _)| k == "stderr_tail")
+        .map(|(_, v)| v.as_str())
+        .expect(
+            "stderr is no longer captured at all - it must move to an \
+                 unallowlisted ATTRIBUTE, not disappear",
+        );
+    assert!(
+        tail.contains("ENG-7041"),
+        "stderr_tail lost the diagnostic it exists to carry: {tail}"
+    );
+}
+
+/// `stderr_tail` must stay OFF `redact::SAFE_STRING_KEYS`, or moving the
+/// stderr out of the body accomplishes nothing - it would ship under its new
+/// name instead. Pinning it here rather than trusting the reader to
+/// remember: the fix above is only a fix while this holds.
+#[test]
+fn the_key_the_stderr_moved_to_is_not_allowlisted_for_egress() {
+    let redact = include_str!("../../../../src/telemetry_spool/redact.rs");
+    let allowlist = redact
+        .split_once("const SAFE_STRING_KEYS")
+        .expect("SAFE_STRING_KEYS was renamed - this guard no longer reads it")
+        .1
+        .split_once("\n];")
+        .expect("SAFE_STRING_KEYS list terminator moved")
+        .0;
+    for key in ["stderr_tail", "key", "bin"] {
+        assert!(
+            !allowlist.contains(&format!("\"{key}\"")),
+            "`{key}` was added to redact::SAFE_STRING_KEYS, so the stderr / \
+                 ticket key / home-directory path this module deliberately keeps \
+                 local now egresses. See log_non_zero_exit's doc (#872)."
+        );
+    }
+}
+
+/// Regression guard: on a timeout, `tokio::time::timeout` drops the
+/// `.output()` future, and without `kill_on_drop(true)` the spawned
+/// `meridian <args>` keeps running in the background after the caller has
+/// already reported failure to the user. For an LLM-backed call like
+/// `plan-task-draft`, that orphan then competes with the next "Try again"
+/// click's fresh process for the same provider/DB — a plausible reason a
+/// draft that missed its 150s budget once keeps missing it on retry.
+///
+/// This can't drive `run_meridian` itself as a real spawn-and-verify test:
+/// it resolves its binary via `crate::install::meridian_bin()`, and
+/// overriding that via `MERIDIAN_BIN` would mean `std::env::set_var` on a
+/// shared test binary — exactly what `integrations.rs`'s "avoiding
+/// `std::env::set_var` on a Tokio worker thread" note warns off. So this
+/// is source-scanned, mirroring `tasks.rs::sync_tasks`, the sibling call
+/// site that already carries this fix. The MECHANISM itself — that
+/// `kill_on_drop(true)` actually terminates an orphaned child, on this
+/// platform, with tokio's real process reaping — is verified separately
+/// below, against a plain `tokio::process::Command` that needs no
+/// `MERIDIAN_BIN` override at all.
+#[test]
+fn run_meridian_kills_the_child_on_timeout() {
+    let src = include_str!("cli_exec.rs");
+    let prod = src.split_once("\n#[cfg(test)]").map_or(src, |(a, _)| a);
+    let spawn = prod
+        .find("tokio::process::Command::new(&bin)")
+        .expect("run_meridian's Command builder moved or was renamed");
+    let output_call = prod[spawn..]
+        .find(".output();")
+        .expect("run_meridian's Command builder no longer ends in .output()");
+    let builder = &prod[spawn..spawn + output_call];
+    assert!(
+        builder.contains(".kill_on_drop(true)"),
+        "run_meridian's spawned child is missing .kill_on_drop(true) — a \
+             timeout will orphan it instead of killing it. Builder was: {builder}"
+    );
+}
+
+/// A process that runs far longer than the timeout below, so the timeout
+/// always wins the race — the exact shape `run_meridian` puts its child
+/// in. No dependency on `meridian`/`MERIDIAN_BIN`: `sleep`/`ping` are
+/// present on every macOS and Windows runner this crate's tests run on
+/// (see `.github/workflows/ci.yml`'s `windows-latest` + `macos-latest`
+/// `cargo test --workspace` jobs).
+#[cfg(unix)]
+fn long_running_command() -> (&'static str, &'static [&'static str]) {
+    ("sleep", &["30"])
+}
+#[cfg(windows)]
+fn long_running_command() -> (&'static str, &'static [&'static str]) {
+    // `timeout.exe` refuses to run with stdin redirected (no console
+    // handle) — `ping` to loopback is the standard "sleep N seconds"
+    // substitute on Windows and needs no real network.
+    ("ping", &["-n", "30", "127.0.0.1"])
+}
+
+#[cfg(unix)]
+fn process_is_alive(pid: u32) -> bool {
+    std::process::Command::new("ps")
+        .args(["-p", &pid.to_string()])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+#[cfg(windows)]
+fn process_is_alive(pid: u32) -> bool {
+    // `tasklist` exits 0 either way, printing "No tasks are running..."
+    // when nothing matches — the pid has to actually appear in the
+    // output, not just a success status.
+    std::process::Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}"), "/NH"])
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).contains(&pid.to_string()))
+        .unwrap_or(false)
+}
+
+/// Proves the MECHANISM `run_meridian_kills_the_child_on_timeout` pins the
+/// wiring for: that `kill_on_drop(true)` on a `tokio::process::Command`
+/// actually terminates the child once the future racing it is dropped —
+/// i.e. that this fix does what its own reasoning claims, not just that
+/// the flag is textually present.
+#[tokio::test]
+async fn kill_on_drop_actually_terminates_the_orphaned_child() {
+    let (bin, args) = long_running_command();
+    let child = tokio::process::Command::new(bin)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("failed to spawn the long-running test process");
+    let pid = child.id().expect("a just-spawned child must have a pid");
+    assert!(
+        process_is_alive(pid),
+        "test bug: process not observed alive right after spawn"
+    );
+
+    {
+        // Mirrors `run_meridian` exactly: race the child's `.output()`
+        // against a timeout far shorter than the process's own runtime.
+        let output_fut = child.wait_with_output();
+        let result = tokio::time::timeout(Duration::from_millis(50), output_fut).await;
+        assert!(
+            result.is_err(),
+            "test bug: the process exited before the timeout could fire"
+        );
+        // `output_fut` (and the `Child` it consumed) drops here — exactly
+        // what happens when `tokio::time::timeout` drops `run_meridian`'s
+        // `.output()` future on a real timeout.
+    }
+
+    // `kill_on_drop`'s kill is fired from `Drop`, not awaited to
+    // completion — poll briefly rather than asserting instantaneously.
+    let mut still_alive = process_is_alive(pid);
+    for _ in 0..20 {
+        if !still_alive {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        still_alive = process_is_alive(pid);
+    }
+    assert!(
+        !still_alive,
+        "child (pid {pid}) is still running ~2s after being dropped — \
+             kill_on_drop did not terminate it"
+    );
+}

--- a/tray/src-tauri/src/commands/parents.rs
+++ b/tray/src-tauri/src/commands/parents.rs
@@ -102,9 +102,19 @@ pub async fn get_ticket_parents(provider: String, key: String) -> ParentsRespons
         let msg = if stderr.is_empty() {
             format!("exited {:?}", output.status.code())
         } else {
-            stderr
+            stderr.clone()
         };
-        tracing::warn!(%provider, %key, "ticket-parents non-zero: {msg}");
+        // Static body + `stderr_tail`, NOT `"…non-zero: {msg}"`. The stderr here
+        // is a tracker's error payload and routinely contains the ticket key -
+        // see `cli_exec::log_non_zero_exit` and issue #872.
+        crate::commands::cli_exec::log_non_zero_exit(crate::commands::cli_exec::NonZeroExit {
+            label: "ticket-parents",
+            bin: Some(bin.as_str()),
+            provider: Some(&provider),
+            key: Some(&key),
+            code: output.status.code(),
+            stderr: &stderr,
+        });
         return ParentsResponse::failure(msg);
     }
 

--- a/tray/src-tauri/src/commands/triage.rs
+++ b/tray/src-tauri/src/commands/triage.rs
@@ -260,9 +260,17 @@ pub async fn apply_ticket_fix(body: ApplyBody) -> Result<ApplyResponse, String> 
         let msg = if stderr.is_empty() {
             format!("ticket-update exited {:?}", output.status.code())
         } else {
-            stderr
+            stderr.clone()
         };
-        tracing::warn!("ticket-update non-zero: {msg}");
+        // Static body + `stderr_tail` - see `cli_exec::log_non_zero_exit` (#872).
+        crate::commands::cli_exec::log_non_zero_exit(crate::commands::cli_exec::NonZeroExit {
+            label: "ticket-update",
+            bin: Some(bin.as_str()),
+            provider: Some(&body.provider),
+            key: Some(&body.key),
+            code: output.status.code(),
+            stderr: &stderr,
+        });
         return Err(msg);
     }
 

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -133,8 +133,14 @@ fn catch_setup_panic<T>(what: &str, f: impl FnOnce() -> T + std::panic::UnwindSa
                 .map(|s| s.to_string())
                 .or_else(|| payload.downcast_ref::<String>().cloned())
                 .unwrap_or_else(|| "non-string panic payload".to_string());
+            // `panic_msg`, not `msg`: `errors.rs::no_user_data_interpolated_into_a_log_body`
+            // allows exactly three identifiers into a WARN+ body and this is one of
+            // them, named so the exemption is legible at the call site. A panic
+            // payload is our own `expect`/`panic!` text, not a subprocess's or a
+            // provider's output - the distinction that guard exists to force.
+            let panic_msg = msg;
             tracing::error!(
-                "tray setup panicked during {what}: {msg} — degrading to a disabled state instead of crashing the tray"
+                "tray setup panicked during {what}: {panic_msg} — degrading to a disabled state instead of crashing the tray"
             );
             None
         }


### PR DESCRIPTION
Closes #872.

## The gap

`redact::SAFE_STRING_KEYS` governs attribute **keys**. The message **body** is not an attribute - it *is* the record, so it always ships, having passed only `scrub_text`'s URL / email / blob patterns. Those know nothing about ticket keys, window titles, or a tracker's error payload.

Three tray call sites spliced a `meridian` subprocess's stderr straight into a WARN body. #872 measured the consequence in central OpenObserve:

```
ticket-statuses non-zero: Jira GET transitions for ENG-7041 returned 404 Not Found: …
```

`ENG-7041` is a real user's ticket key. `task_key` is denied as an attribute and pinned so by `user_scoped_diagnostic_keys_stay_off_the_allowlist` - the allowlist simply never saw this one.

## The fix

The stderr moves to `stderr_tail`, deliberately **not** allowlisted. That is the two-tier design working, not a diagnostic being thrown away: unallowlisted attributes are captured at full fidelity locally (`meridian logs` renders attributes; export bundles carry the raw spool) and dropped on the ship leg. The engineer debugging their own machine loses nothing; the central backend stops receiving the user's content.

The shipped record also *gains* something it was silently missing. `code = ?output.status.code()` debug-formats an `Option` into the string `"Some(1)"` - not a bare number, so `is_bare_number` could not rescue it and the exit code was dropped from every shipped record. Passed as `i64` it is kept unconditionally.

Three copies became one helper, `cli_exec::log_non_zero_exit` (`parents.rs` and `triage.rs` were bespoke duplicates).

## What I rejected, and why

An identifier regex over the body (`[A-Z]{2,10}-\d+`, the issue's first option). It is the single most common shape in technical prose - `UTF-8`, `SHA-256`, `RFC-7396`, `CVE-2024-1234`, `x86-64`, `ISO-8601` - so the exclusion list is unbounded and every miss is a **silent** diagnostic loss: #867 re-created in the body. Worse, it would make `scrub_text` *look* like it handles identifiers, so the next body splice goes unexamined.

## Enforced, not just fixed

`src/log_hygiene.rs` walks every workspace source tree and fails the build on a new interpolated WARN+/ERROR body. `INTERPOLABLE` is the exemption list, each entry justified. CLAUDE.md has said *"structured fields - never format data values into the message string"* from the start; nothing checked it, and it drifted three times.

Three things the first version of that lint got wrong, all found by auditing it against the sentence `docs/privacy.md` now makes for it, and all fixed in the second commit:

| Hole | Consequence | Fix |
|---|---|---|
| Truncated each file at its first `#[cfg(test)]` (the idiom inherited from `no_bare_error_display_in_db_paths`) | `tray/src-tauri/src/lib.rs` scanned at **6.6%** of its bytes; `jira/mod.rs` at **2%**, because a bare `#[cfg(test)] mod tests;` *declaration* on line 15 truncated the file | brace-balanced `strip_test_modules`; reachable macro sites **493 → 526** |
| `offenders.is_empty()` passes when the scan finds *nothing* | a parse regression switches the guard off without failing it - exactly how the hole above stayed invisible | `MIN_MACRO_SITES`, counted in the same loop so it cannot drift from the real scan |
| positional `{}` was out of scope, so `warn!("failed for {}", ticket_key)` passed | privacy.md's sentence was false | enforced - there are **zero** positional WARN+ bodies in the tree, so it costs nothing |

It also matches **bare** `warn!(` as well as `tracing::warn!` - 14 sites in `etl/` and `capture/` import the macro, and a scan anchored on the qualified spelling would have read as full coverage while skipping all of them.

## One more allowlist entry that didn't describe its emitters

`provider` is on `SAFE_STRING_KEYS` and ships, justified there as "enum-like values from a fixed internal set (`claude`, `codex`, …)" - LLM engines. But `parents.rs` was already emitting **tracker** names under it, and that value arrives at the tray as an unvalidated `String` from the frontend, so the "fixed set" premise rested on the frontend behaving. `provider_label` now narrows it to the six `canonical_task::Provider` literals or `"other"`, the same shape as `install::bin_source`; the comment names both domains.

## Verification

Every new assertion is mutation-proved, and each mutant was confirmed to **compile** before its failure was counted:

| Mutation | Result |
|---|---|
| Restore `"{label} non-zero: {stderr}"` | `cli_exec` test fails, printing the measured leak verbatim |
| Same, seen from the daemon crate | repo-wide scan fails, naming `cli_exec.rs:182` |
| Drop `stderr_tail` from the log | test fails - the diagnostic must move, not disappear |
| Add `stderr_tail` to `SAFE_STRING_KEYS` | both guards fail, in both crates |
| Raise `MIN_MACRO_SITES` above the real count | reports the true figure (526), confirming the floor measures something |

Also added an end-to-end test at the boundary itself (`redact.rs`): the fixed record ships its static body, `code` and `bin_source` and loses `stderr_tail`/`key`; the pre-fix record ships the ticket key, which is the assertion proving the fix had to live at the call site.

`cargo clippy --workspace --all-targets -D warnings` clean; 27 test suites green.

## Docs

`docs/privacy.md` claimed error reports never contain ticket keys while describing only the attribute filter - it never mentioned that the message itself is sent. Both corrected to the fixed state, and CLAUDE.md gains this as a fourth documented coupling.

## Note on scope

`scrub_text` is shared with the tray's Sentry `before_send`, so panic-message splices are a separate surface this does not touch - stated as residual in the module doc rather than expanded into here. `redact.rs` remains over the 500-line rule (#863). This change kept `cli_exec.rs` and the new lint under it by splitting tests into `cli_exec_tests.rs` and giving the lint its own module rather than growing `errors.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)