### PR TITLE
fix(oauth): make the Jira token exchange survive sleep, and sync PM tasks on demand

### DIFF
--- a/meridian-oauth/src/flow.rs
+++ b/meridian-oauth/src/flow.rs
@@ -255,6 +255,77 @@ fn truncate_body(text: &str) -> String {
     format!("{} (truncated, {} bytes total)", &text[..end], text.len())
 }
 
+/// Wall-clock ceiling for ONE token-endpoint attempt, in seconds.
+///
+/// Sits alongside `reqwest`'s own 8 s `.timeout()` rather than replacing it, and
+/// the two measure different things on purpose.
+const WALL_CLOCK_BUDGET_SECS: i64 = 20;
+
+/// Run `fut`, abandoning it if the WALL CLOCK advances past `budget_secs`.
+///
+/// # Why `reqwest`'s own timeout is not enough
+///
+/// Every `.timeout()` in this codebase - and every `tokio::time` primitive -
+/// measures `Instant`, which on macOS is `mach_absolute_time` and DOES NOT ADVANCE
+/// while the system is asleep. So a request in flight when the lid closes is not
+/// cancelled by its 8 s timeout: it hangs for the entire suspend, and on wake the
+/// retry goes out with a refresh token that the provider rotated (and stopped
+/// honouring) half an hour ago. That is the exact sequence that killed production
+/// grants; see [`crate::refresh_journal`]'s header for the measured case.
+///
+/// The watchdog below still SLEEPS on the monotonic clock - it has to, that is the
+/// only timer available - but every time it wakes it compares the WALL clock. A
+/// suspend freezes both clocks, so nothing fires mid-suspend; the instant the
+/// machine resumes, the first tick sees the wall clock has jumped and gives up
+/// immediately. Abandoning promptly on wake is the whole point: it is what leaves
+/// enough of the provider's reuse grace to replay the spend and recover the grant,
+/// instead of discovering the loss when the window has already closed.
+///
+/// Abandoning is classified TRANSIENT: an unanswered request says nothing about
+/// whether the grant is valid, and treating it as terminal is what turned a
+/// suspend into "re-authenticate".
+async fn with_wall_clock_deadline<F, T>(budget_secs: i64, fut: F) -> Result<T, TokenError>
+where
+    F: std::future::Future<Output = Result<T, TokenError>>,
+{
+    let started = wall_clock_unix();
+    // Boxed so the future can be polled repeatedly across successive `timeout`
+    // slices: `timeout` takes its future by value, but `&mut Pin<Box<F>>` is
+    // itself a future, so borrowing it preserves the in-flight request between
+    // slices instead of restarting it.
+    let mut fut = Box::pin(fut);
+    loop {
+        // The MONOTONIC slice is just a heartbeat, not the deadline. Deliberately
+        // short so that the wall-clock check below runs promptly after a resume.
+        match tokio::time::timeout(Duration::from_millis(500), &mut fut).await {
+            // The request answered. Checked before the clock on purpose: a
+            // response already in hand must never be discarded, because the
+            // refresh token it cost has already been spent.
+            Ok(out) => return out,
+            Err(_) => {
+                let elapsed = wall_clock_unix().saturating_sub(started);
+                if elapsed > budget_secs {
+                    return Err(TokenError::transient(format!(
+                        "token endpoint did not answer within {elapsed}s of wall-clock \
+                         time (a system suspend, or a stalled connection); abandoning \
+                         so the spend can be replayed while the provider still \
+                         honours the previous token"
+                    )));
+                }
+            }
+        }
+    }
+}
+
+/// Wall-clock unix seconds. `0` if the clock is before the epoch, which only
+/// happens on a badly misconfigured machine and would otherwise panic.
+fn wall_clock_unix() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
 /// [`post_token`] with bounded retry-with-backoff for transient failures. Only
 /// [`TokenFailure::Transient`] errors are retried; a terminal rejection returns
 /// immediately so a genuinely dead token isn't hidden behind seconds of backoff.
@@ -272,7 +343,9 @@ async fn post_token_retrying(
         .map_err(|e| TokenError::transient(format!("building HTTP client: {e}")))?;
     let mut backoff = Duration::from_millis(400);
     for attempt in 1..=TOKEN_POST_ATTEMPTS {
-        match post_token(&client, token_url, body).await {
+        match with_wall_clock_deadline(WALL_CLOCK_BUDGET_SECS, post_token(&client, token_url, body))
+            .await
+        {
             Ok(resp) => return Ok(resp),
             Err(e) if e.is_transient() && attempt < TOKEN_POST_ATTEMPTS => {
                 tracing::warn!(

--- a/meridian-oauth/src/jira/mod.rs
+++ b/meridian-oauth/src/jira/mod.rs
@@ -236,28 +236,55 @@ pub async fn login(client_id: &str, client_secret: &str, port: u16) -> Result<St
     Ok(site_url)
 }
 
-/// Load the stored tokens, refreshing the access token if it's within 120 s of
-/// expiry. Persists the rotated refresh token. Returns ready-to-use tokens.
+/// Load the stored tokens, refreshing the access token if it is within 120 s of
+/// expiry. Returns ready-to-use tokens.
 ///
-/// Refreshes are serialised on TWO levels so the rotating refresh token is never
-/// double-spent: a static mutex within this process, and an advisory FILE lock
-/// ([`store::lock_provider`]) across every Meridian process. After taking the file
-/// lock it RE-LOADS and re-checks expiry — so a process that waited on the lock
-/// adopts the peer's freshly-refreshed token instead of POSTing again with the
-/// now-consumed one (the old single-process-mutex behaviour caused that 401 loop).
+/// # Why this is more than "POST if expired"
+///
+/// Atlassian ROTATES the refresh token on every use, so a refresh has a window in
+/// which the old token is already dead server-side and we do not yet know its
+/// replacement. Losing the response in that window destroyed production users'
+/// grants permanently. Three mechanisms close it, and all three are load-bearing:
+///
+/// 1. **Serialisation.** A static mutex within this process and an advisory FILE
+///    lock across every Meridian process ([`store::lock_provider`]), so the token
+///    is never double-spent. After taking the file lock this RE-LOADS and
+///    re-checks expiry, so a process that waited adopts the peer's fresh token
+///    rather than POSTing with the now-consumed one.
+/// 2. **A durable journal** ([`crate::refresh_journal`]) written and `fsync`ed
+///    BEFORE the POST, and cleared only AFTER the new pair is persisted. That is
+///    what makes a lost response recoverable at all: without it there is no way to
+///    tell "never spent" from "spent, answer lost", and those need opposite
+///    handling.
+/// 3. **A wall-clock deadline** on the POST itself (in [`flow`]), because every
+///    `Instant`-based timeout sleeps straight through a system suspend. Abandoning
+///    promptly on wake is what leaves enough of the provider's reuse grace for the
+///    replay in (2) to succeed.
+///
+/// # What a replay does
+///
+/// If a journal entry survives, the previous spend's outcome is unknown. Atlassian
+/// honours the PREVIOUS refresh token for a short grace period after rotation, so
+/// re-presenting it returns the current pair and recovers the grant. That is only
+/// possible while the grace holds, which is why (3) exists.
 pub async fn ensure_fresh() -> Result<OAuthTokens> {
     let _guard = refresh_lock().lock().await; // intra-process serialisation
 
-    // Fast path: a still-fresh token needs neither a refresh nor the file lock.
+    // Fast path: a still-fresh token with no unresolved spend needs neither a
+    // refresh nor the file lock. The journal check is part of the condition, not
+    // an afterthought - a fresh access token can coexist with a spend whose
+    // outcome was lost, and skipping straight past that would leave the stored
+    // refresh token dead and only discover it an hour later, outside the grace.
     let t = store::load("jira")?;
-    if !t.is_expired(now_unix(), 120) {
+    if !t.is_expired(now_unix(), 120) && crate::refresh_journal::load("jira").is_none() {
         return Ok(t);
     }
 
-    // Slow path: enter the cross-process critical section. A peer (a second daemon,
-    // the tray's in-process refresh) may be rotating the SAME refresh token right
-    // now. Best-effort — if the lock can't be taken we log and proceed rather than
-    // turn the lock itself into a new way for Jira auth to fail.
+    // Slow path: enter the cross-process critical section. A peer (a second
+    // daemon, the tray's in-process refresh) may be rotating the SAME refresh
+    // token right now. Best-effort - if the lock cannot be taken we log and
+    // proceed rather than turn the lock itself into a new way for Jira auth to
+    // fail.
     let _flock = match store::lock_provider("jira").await {
         Ok(g) => Some(g),
         Err(e) => {
@@ -273,17 +300,68 @@ pub async fn ensure_fresh() -> Result<OAuthTokens> {
     // adopt their token instead of refreshing again with the dead one. This
     // double-check is what actually breaks the race.
     let mut t = store::load("jira")?;
-    if !t.is_expired(now_unix(), 120) {
+    let pending = reconcile_journal("jira", &t);
+    if pending.is_none() && !t.is_expired(now_unix(), 120) {
         tracing::debug!("jira token already refreshed by another process — adopting it");
         return Ok(t);
     }
 
-    tracing::debug!("jira OAuth access token expired — refreshing");
-    let resp = flow::refresh(&t.client_id, &spec(), &t.refresh_token)
+    // WHICH token to send. A pending spend means the last attempt's outcome is
+    // unknown and the stored token may already be consumed; the journalled one is
+    // the only thing the provider might still honour, so it is re-presented
+    // verbatim. Otherwise this is an ordinary refresh with the stored token.
+    let (refresh_token, client_id, replaying) = match &pending {
+        Some(spend) => {
+            let age = spend.age_secs(now_unix());
+            if spend.within_replay_window(now_unix()) {
+                tracing::warn!(
+                    age_s = age as f64,
+                    "replaying an unresolved Jira refresh inside the provider's reuse grace"
+                );
+            } else {
+                // Attempted anyway: it costs one HTTP call, and the alternative is
+                // a guaranteed re-authentication. Logged as expected-to-fail so it
+                // does not read as a surprise in a support bundle.
+                tracing::warn!(
+                    age_s = age as f64,
+                    window_s = crate::refresh_journal::REPLAY_WINDOW_SECS as f64,
+                    "replaying an unresolved Jira refresh PAST the reuse grace - \
+                     likely to fail; re-authentication may be required"
+                );
+            }
+            (spend.refresh_token.clone(), spend.client_id.clone(), true)
+        }
+        None => {
+            tracing::debug!("jira OAuth access token expired — refreshing");
+            (t.refresh_token.clone(), t.client_id.clone(), false)
+        }
+    };
+
+    // JOURNAL BEFORE SPENDING. If this write fails the refresh is ABANDONED
+    // rather than attempted: proceeding would spend a rotating token with no
+    // record of having done so, which is precisely the unrecoverable state this
+    // whole path exists to prevent. Refusing costs one stale sync cycle; the
+    // access token in hand is still returned by the error path's caller on the
+    // next attempt.
+    if !replaying {
+        let spend = crate::refresh_journal::PendingSpend {
+            refresh_token: refresh_token.clone(),
+            started_at_unix: now_unix(),
+            client_id: client_id.clone(),
+        };
+        crate::refresh_journal::record_spend("jira", &spend).context(
+            "could not journal the Jira refresh before spending it — refusing to spend a \
+             rotating refresh token without a durable record, since a lost response would \
+             then be unrecoverable. Check permissions on ~/.meridian/oauth/.",
+        )?;
+    }
+
+    let resp = flow::refresh(&client_id, &spec(), &refresh_token)
         .await
         .context(
             "refreshing Jira OAuth token — re-run `meridian oauth-login jira` if this persists",
         )?;
+
     t.access_token = resp.access_token;
     if !resp.refresh_token.is_empty() {
         t.refresh_token = resp.refresh_token; // Atlassian rotates the refresh token
@@ -292,23 +370,59 @@ pub async fn ensure_fresh() -> Result<OAuthTokens> {
     if !resp.scope.is_empty() {
         t.scopes = resp.scope;
     }
-    // Save the rotated tokens. If save fails (disk full, permissions), log a
-    // critical error and return the in-memory tokens anyway — the access token
-    // is valid for ~1h so the current request succeeds. On the next expiry the
-    // stored (now-invalid) refresh token will cause a 401 and the user must
-    // re-authenticate. A critical log surfaces this before it happens.
+
+    // PERSIST FIRST, CLEAR SECOND. A crash between the two is harmless:
+    // `reconcile_journal` compares the journalled token against the stored one,
+    // sees they differ, and clears the journal then. The reverse order would lose
+    // the only record of the spend at exactly the wrong moment.
     match store::save(&t) {
-        Ok(()) => {}
+        Ok(()) => {
+            crate::refresh_journal::clear("jira");
+            if replaying {
+                tracing::info!("recovered the Jira grant by replaying an unresolved refresh");
+            }
+        }
         Err(e) => {
+            // The journal is deliberately LEFT IN PLACE. The new pair is only in
+            // memory, so on the next process the stored refresh token is the old
+            // one and the journal is what says "that one may already be spent" -
+            // deleting it here would throw away the recovery path.
             tracing::error!(
                 error = %e,
-                "CRITICAL: failed to persist rotated Jira refresh token — access token \
-                 valid for ~1h but re-authentication required after expiry. Fix \
-                 permissions at ~/.meridian/oauth/ then re-run `meridian oauth-login jira`."
+                "CRITICAL: failed to persist rotated Jira refresh token — the access token \
+                 is valid for ~1h and the refresh journal has been kept so the next attempt \
+                 can recover. Fix permissions at ~/.meridian/oauth/."
             );
         }
     }
     Ok(t)
+}
+
+/// Decide what an existing journal entry means, and return the spend that still
+/// needs resolving (if any).
+///
+/// The decision is made by COMPARING TOKENS rather than trusting a flag, which is
+/// what makes every crash point recoverable:
+///
+/// * journalled == stored -> the save never landed. The outcome is unknown, so
+///   this spend must be replayed.
+/// * journalled != stored -> the save DID land and we died before clearing. The
+///   stored pair is newer and valid; the journal is stale, so clear it.
+fn reconcile_journal(
+    provider: &str,
+    stored: &OAuthTokens,
+) -> Option<crate::refresh_journal::PendingSpend> {
+    let spend = crate::refresh_journal::load(provider)?;
+    if spend.refresh_token == stored.refresh_token {
+        Some(spend)
+    } else {
+        tracing::debug!(
+            provider,
+            "refresh journal predates the stored token pair — the save landed, clearing it"
+        );
+        crate::refresh_journal::clear(provider);
+        None
+    }
 }
 
 /// Resolved per-request auth context. OAuth and basic auth differ in BOTH the API
@@ -370,50 +484,4 @@ impl JiraReqCtx {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn oauth_ctx() -> JiraReqCtx {
-        JiraReqCtx::OAuth {
-            token: "tok".into(),
-            cloud_id: "cloud-xyz".into(),
-            site_url: "https://acme.atlassian.net".into(),
-        }
-    }
-
-    fn basic_ctx() -> JiraReqCtx {
-        JiraReqCtx::Basic {
-            base_url: "https://acme.atlassian.net/".into(),
-            email: "a@b.com".into(),
-            api_token: "tok".into(),
-        }
-    }
-
-    #[test]
-    fn oauth_api_url_uses_gateway() {
-        assert_eq!(
-            oauth_ctx().api_url("/rest/api/3/search/jql"),
-            "https://api.atlassian.com/ex/jira/cloud-xyz/rest/api/3/search/jql"
-        );
-    }
-
-    #[test]
-    fn basic_api_url_uses_site_and_trims_slash() {
-        assert_eq!(
-            basic_ctx().api_url("/rest/api/3/search/jql"),
-            "https://acme.atlassian.net/rest/api/3/search/jql"
-        );
-    }
-
-    #[test]
-    fn browse_url_uses_site_in_both_modes() {
-        assert_eq!(
-            oauth_ctx().browse_url("KAN-1"),
-            "https://acme.atlassian.net/browse/KAN-1"
-        );
-        assert_eq!(
-            basic_ctx().browse_url("KAN-1"),
-            "https://acme.atlassian.net/browse/KAN-1"
-        );
-    }
-}
+mod tests;

--- a/meridian-oauth/src/jira/tests.rs
+++ b/meridian-oauth/src/jira/tests.rs
@@ -1,0 +1,184 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Tests for [`super`] - the Atlassian 3LO wiring.
+//!
+//! Split into its own file on size (`jira.rs` passed the 500-line rule once the
+//! refresh journal's crash-point cases landed). Nothing here is a pure unit test
+//! of URL building alone: the journal cases below pin the recovery behaviour that
+//! decides whether a lost response destroys a user's grant, so they are the most
+//! load-bearing tests in this crate.
+
+use super::*;
+
+fn tokens(refresh: &str) -> OAuthTokens {
+    OAuthTokens {
+        provider: "jira".into(),
+        client_id: "cid".into(),
+        access_token: "access".into(),
+        refresh_token: refresh.into(),
+        expires_at: 0,
+        scopes: String::new(),
+        cloud_id: String::new(),
+        site_url: String::new(),
+    }
+}
+
+/// Scratch `HOME` so the journal lands in a temp dir. Serialised through the
+/// crate's env guard because `HOME` is process-global and cargo runs tests in
+/// parallel threads.
+struct ScratchHome {
+    dir: std::path::PathBuf,
+    prev: Option<std::ffi::OsString>,
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+impl ScratchHome {
+    fn new(tag: &str) -> Self {
+        let guard = crate::env_test_guard();
+        let dir = std::env::temp_dir().join(format!("meridian_jira_{tag}_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let prev = std::env::var_os("HOME");
+        std::env::set_var("HOME", &dir);
+        Self {
+            dir,
+            prev,
+            _guard: guard,
+        }
+    }
+}
+
+impl Drop for ScratchHome {
+    fn drop(&mut self) {
+        match self.prev.take() {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        std::fs::remove_dir_all(&self.dir).ok();
+    }
+}
+
+fn journal(token: &str) -> crate::refresh_journal::PendingSpend {
+    crate::refresh_journal::PendingSpend {
+        refresh_token: token.into(),
+        started_at_unix: now_unix(),
+        client_id: "cid".into(),
+    }
+}
+
+/// CRASH POINT A: died before `store::save` landed. The journalled token still
+/// matches the stored one, so the spend's outcome is unknown and MUST be
+/// replayed - re-presenting it inside the provider's grace is the only thing
+/// that recovers the grant.
+#[test]
+fn an_unresolved_spend_is_replayed_when_the_save_never_landed() {
+    let _home = ScratchHome::new("unresolved");
+    let stored = tokens("refresh-A");
+    crate::refresh_journal::record_spend("jira", &journal("refresh-A")).unwrap();
+
+    let pending = reconcile_journal("jira", &stored);
+    assert_eq!(
+        pending.map(|p| p.refresh_token),
+        Some("refresh-A".to_string()),
+        "a journal matching the stored token means the outcome is unknown - replay it"
+    );
+}
+
+/// CRASH POINT B: `store::save` landed, then we died before clearing. The
+/// stored pair is NEWER than the journal, so there is nothing to recover and
+/// replaying would spend a live token for no reason. The journal must be
+/// recognised as stale and removed.
+#[test]
+fn a_journal_older_than_the_stored_pair_is_stale_and_cleared() {
+    let _home = ScratchHome::new("stale");
+    let stored = tokens("refresh-B"); // save landed: B replaced A
+    crate::refresh_journal::record_spend("jira", &journal("refresh-A")).unwrap();
+
+    let pending = reconcile_journal("jira", &stored);
+    assert!(
+        pending.is_none(),
+        "the save landed, so nothing needs replaying"
+    );
+    assert!(
+        crate::refresh_journal::load("jira").is_none(),
+        "a stale journal must be cleared, not left to trigger a pointless replay \
+         on every future refresh"
+    );
+}
+
+/// The ordinary case: no journal, nothing to reconcile.
+#[test]
+fn no_journal_means_nothing_to_reconcile() {
+    let _home = ScratchHome::new("none");
+    assert!(reconcile_journal("jira", &tokens("refresh-A")).is_none());
+}
+
+/// A pending spend must defeat the fast path even when the access token is
+/// still fresh.
+///
+/// This is the subtle one, and getting it wrong reintroduces the whole bug: a
+/// valid access token can coexist with a refresh token that was already
+/// consumed server-side. Returning early on "not expired" would leave that
+/// unresolved for up to an hour - long past the provider's reuse grace - and
+/// the recovery would then be impossible rather than merely late.
+#[test]
+fn a_fresh_access_token_does_not_hide_an_unresolved_spend() {
+    let _home = ScratchHome::new("fastpath");
+    let mut fresh = tokens("refresh-A");
+    fresh.expires_at = now_unix() + 3600; // comfortably fresh
+    assert!(
+        !fresh.is_expired(now_unix(), 120),
+        "precondition: the access token must look fresh"
+    );
+
+    crate::refresh_journal::record_spend("jira", &journal("refresh-A")).unwrap();
+    // The fast path's condition, mirrored: freshness alone must NOT be enough.
+    let would_take_fast_path =
+        !fresh.is_expired(now_unix(), 120) && crate::refresh_journal::load("jira").is_none();
+    assert!(
+        !would_take_fast_path,
+        "a fresh access token must not short-circuit past an unresolved refresh spend"
+    );
+}
+
+fn oauth_ctx() -> JiraReqCtx {
+    JiraReqCtx::OAuth {
+        token: "tok".into(),
+        cloud_id: "cloud-xyz".into(),
+        site_url: "https://acme.atlassian.net".into(),
+    }
+}
+
+fn basic_ctx() -> JiraReqCtx {
+    JiraReqCtx::Basic {
+        base_url: "https://acme.atlassian.net/".into(),
+        email: "a@b.com".into(),
+        api_token: "tok".into(),
+    }
+}
+
+#[test]
+fn oauth_api_url_uses_gateway() {
+    assert_eq!(
+        oauth_ctx().api_url("/rest/api/3/search/jql"),
+        "https://api.atlassian.com/ex/jira/cloud-xyz/rest/api/3/search/jql"
+    );
+}
+
+#[test]
+fn basic_api_url_uses_site_and_trims_slash() {
+    assert_eq!(
+        basic_ctx().api_url("/rest/api/3/search/jql"),
+        "https://acme.atlassian.net/rest/api/3/search/jql"
+    );
+}
+
+#[test]
+fn browse_url_uses_site_in_both_modes() {
+    assert_eq!(
+        oauth_ctx().browse_url("KAN-1"),
+        "https://acme.atlassian.net/browse/KAN-1"
+    );
+    assert_eq!(
+        basic_ctx().browse_url("KAN-1"),
+        "https://acme.atlassian.net/browse/KAN-1"
+    );
+}

--- a/meridian-oauth/src/lib.rs
+++ b/meridian-oauth/src/lib.rs
@@ -28,6 +28,7 @@ pub mod flow;
 pub mod github;
 pub mod jira;
 pub mod pkce;
+pub mod refresh_journal;
 pub mod store;
 pub mod trello;
 

--- a/meridian-oauth/src/refresh_journal.rs
+++ b/meridian-oauth/src/refresh_journal.rs
@@ -1,0 +1,338 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Crash-safe and suspend-safe record of a refresh-token spend.
+//!
+//! # The bug this exists to close
+//!
+//! Atlassian ROTATES the refresh token on every use: a successful refresh
+//! returns a new pair and invalidates the one you sent. So the exchange has a
+//! window in which the token has already been consumed server-side and we do not
+//! yet know the replacement. If the response is lost in that window, the grant is
+//! gone forever and the user must re-authenticate by hand.
+//!
+//! Production users hit this repeatedly. The mechanism, measured on one install:
+//! a refresh POST was in flight when the Mac suspended for 28 minutes. Atlassian
+//! rotated the token and replied; the reply went nowhere. `reqwest`'s timeout
+//! could not cancel the request, because that timeout is `Instant`-based and the
+//! monotonic clock does not advance while macOS sleeps. On wake the socket was
+//! dead, and the retry went out with the OLD refresh token - by then 28 minutes
+//! stale, well outside Atlassian's reuse leeway. `invalid_grant`, terminal, grant
+//! dead.
+//!
+//! Nothing in the old code recorded that a spend had been attempted, so there was
+//! no way to distinguish "the token was never consumed" from "it was consumed and
+//! we lost the answer" - and those need opposite handling.
+//!
+//! # The rule that makes recovery possible
+//!
+//! Atlassian permits the PREVIOUS refresh token to be presented again within a
+//! grace period after rotation, returning the current pair rather than an error.
+//! That is the recovery mechanism, and it is time-bounded, so the only thing that
+//! matters is replaying the spend QUICKLY - which is impossible without knowing a
+//! spend happened. Hence this journal.
+//!
+//! # Ordering, which is the whole correctness argument
+//!
+//! 1. Journal the token we are about to spend, and `fsync` it. Only then POST.
+//! 2. On success: persist the new pair, `fsync`, and only THEN clear the journal.
+//! 3. On any indeterminate outcome (transport error, timeout, killed process,
+//!    suspend), the journal survives and the next attempt replays it.
+//!
+//! Steps 1 and 2 are deliberately ordered so that every crash point is
+//! recoverable, and the recovery is decided by COMPARING TOKENS rather than by
+//! trusting a flag:
+//!
+//! * journalled token == stored token -> the save never happened. The outcome is
+//!   unknown; replay with the journalled token.
+//! * journalled token != stored token -> the save DID happen and we died before
+//!   clearing. The stored pair is newer and valid; just clear the journal.
+//!
+//! That comparison is why a crash between step 2's write and its journal-clear is
+//! harmless, and why this needs no "in progress" boolean that could itself be
+//! stale.
+//!
+//! # Why a file and not the database
+//!
+//! The OAuth token store is already a per-provider file (see [`crate::store`]);
+//! the journal belongs beside it. It is also deliberately NOT in `meridian.db`:
+//! two processes write that database, and coordination state living there is what
+//! produced a `SQLITE_IOERR_SHORT_READ` in production when a reader hit it during
+//! the daemon's WAL checkpoint. A `0600` file written temp-then-rename cannot
+//! corrupt a database, needs no migration, and cannot fail a sync.
+//!
+//! # Who calls this
+//! [`crate::jira::ensure_fresh`], under the same locks that serialise the spend
+//! itself ([`crate::store::lock_provider`] plus the in-process mutex).
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// How long after a spend a replay is still worth attempting.
+///
+/// Atlassian's documented reuse grace for a rotated refresh token is 10 minutes.
+/// This is deliberately SHORTER: the clock we compare against is the wall clock,
+/// which can be adjusted by NTP after a wake, and a replay attempted a second
+/// after the real deadline is indistinguishable from a genuinely dead grant. 8
+/// minutes keeps a margin for that skew and for the request's own duration.
+///
+/// Past this window a replay is still attempted ONCE (it costs one HTTP call and
+/// the alternative is a guaranteed re-authentication), but it is expected to fail
+/// and is logged as such rather than as a surprise.
+pub const REPLAY_WINDOW_SECS: i64 = 8 * 60;
+
+/// A refresh-token spend that was started and whose outcome may be unknown.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PendingSpend {
+    /// The refresh token that was sent. Compared against the stored token to
+    /// decide whether the save landed - see the module header.
+    pub refresh_token: String,
+    /// Wall-clock unix seconds at which the POST was issued.
+    ///
+    /// WALL clock, not monotonic, on purpose: the entire point is to measure a
+    /// span that may include a system suspend, and a monotonic clock does not
+    /// advance across one. This is the same property whose absence let the
+    /// original 8-second request timeout sleep through a 28-minute suspend.
+    pub started_at_unix: i64,
+    /// The client id the spend was made with, so a replay reconstructs the exact
+    /// same request even if configuration changed in between.
+    pub client_id: String,
+}
+
+impl PendingSpend {
+    /// Seconds elapsed since the spend was issued, per the wall clock. Clamped at
+    /// zero so a backwards clock adjustment cannot produce a negative age that
+    /// would read as "in the future" and be treated as fresh forever.
+    pub fn age_secs(&self, now_unix: i64) -> i64 {
+        (now_unix - self.started_at_unix).max(0)
+    }
+
+    /// Whether a replay is still inside the window where the provider is expected
+    /// to honour the previous token.
+    pub fn within_replay_window(&self, now_unix: i64) -> bool {
+        self.age_secs(now_unix) <= REPLAY_WINDOW_SECS
+    }
+}
+
+fn journal_path(provider: &str) -> Result<PathBuf> {
+    // Reuses `store`'s provider validation and directory resolution, so a journal
+    // path can never escape the oauth dir and never disagrees with where the
+    // token it describes lives.
+    let token_path = crate::store::path(provider)?;
+    let dir = token_path
+        .parent()
+        .context("resolving the OAuth directory for the refresh journal")?;
+    Ok(dir.join(format!(".{provider}.refresh-journal.json")))
+}
+
+/// Record that `refresh_token` is about to be spent, durably, before the POST.
+///
+/// `fsync`s the file AND its directory before returning. Both matter: without the
+/// file sync the record can be in the page cache only, and without the directory
+/// sync the rename itself can be lost - either way a crash leaves no journal,
+/// which is exactly the state this function exists to prevent.
+pub fn record_spend(provider: &str, spend: &PendingSpend) -> Result<()> {
+    let path = journal_path(provider)?;
+    let dir = path
+        .parent()
+        .context("resolving the OAuth directory for the refresh journal")?;
+    std::fs::create_dir_all(dir)
+        .with_context(|| format!("creating {} for the refresh journal", dir.display()))?;
+    let tmp = dir.join(format!(".{provider}.refresh-journal.tmp"));
+    let json = serde_json::to_vec_pretty(spend).context("serialising the refresh journal")?;
+
+    {
+        use std::io::Write;
+        let mut file = open_private(&tmp)?;
+        file.write_all(&json)
+            .with_context(|| format!("writing {}", tmp.display()))?;
+        file.sync_all()
+            .with_context(|| format!("fsync {}", tmp.display()))?;
+    }
+    std::fs::rename(&tmp, &path)
+        .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
+    sync_dir(dir);
+    Ok(())
+}
+
+/// Read the pending spend, if any. A malformed journal is treated as ABSENT and
+/// removed rather than surfaced as an error: it cannot be acted on, and failing
+/// the refresh over an unreadable side-file would turn a recovery aid into a new
+/// way for auth to break.
+pub fn load(provider: &str) -> Option<PendingSpend> {
+    let path = journal_path(provider).ok()?;
+    let raw = std::fs::read_to_string(&path).ok()?;
+    match serde_json::from_str(&raw) {
+        Ok(spend) => Some(spend),
+        Err(e) => {
+            tracing::warn!(
+                provider,
+                error = %e,
+                "refresh journal is unreadable - discarding it and refreshing normally"
+            );
+            let _ = std::fs::remove_file(&path);
+            None
+        }
+    }
+}
+
+/// Clear the journal once the new pair is durably stored.
+///
+/// Best-effort by design: the new tokens are already persisted at this point, so
+/// a leftover journal is harmless - the next `ensure_fresh` compares its token
+/// against the stored one, sees they differ, and clears it then. Failing the
+/// refresh here would discard a SUCCESSFUL exchange.
+pub fn clear(provider: &str) {
+    if let Ok(path) = journal_path(provider) {
+        match std::fs::remove_file(&path) {
+            Ok(()) => tracing::debug!(provider, "refresh journal cleared"),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => tracing::warn!(
+                provider,
+                error = %e,
+                "could not clear the refresh journal - the next refresh will reconcile it"
+            ),
+        }
+    }
+}
+
+/// Create/truncate a file that only the owner can read. The mode is set AT OPEN
+/// on Unix rather than afterwards, so there is no window in which the file exists
+/// world-readable while holding a refresh token.
+fn open_private(path: &std::path::Path) -> Result<std::fs::File> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    opts.open(path)
+        .with_context(|| format!("creating {}", path.display()))
+}
+
+/// `fsync` a directory so a rename into it is durable. Unix-only and
+/// best-effort: on Windows a directory handle cannot be opened this way, and
+/// there `rename` over an existing file is already ordered by the filesystem.
+fn sync_dir(dir: &std::path::Path) {
+    #[cfg(unix)]
+    if let Ok(handle) = std::fs::File::open(dir) {
+        if let Err(e) = handle.sync_all() {
+            tracing::debug!(dir = %dir.display(), error = %e, "directory fsync failed");
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = dir;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spend(token: &str, started_at_unix: i64) -> PendingSpend {
+        PendingSpend {
+            refresh_token: token.into(),
+            started_at_unix,
+            client_id: "cid".into(),
+        }
+    }
+
+    struct ScratchHome {
+        dir: std::path::PathBuf,
+        prev: Option<std::ffi::OsString>,
+        _guard: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl ScratchHome {
+        fn new(tag: &str) -> Self {
+            let guard = crate::env_test_guard();
+            let dir =
+                std::env::temp_dir().join(format!("meridian_journal_{tag}_{}", std::process::id()));
+            std::fs::create_dir_all(&dir).unwrap();
+            let prev = std::env::var_os("HOME");
+            std::env::set_var("HOME", &dir);
+            Self {
+                dir,
+                prev,
+                _guard: guard,
+            }
+        }
+    }
+
+    impl Drop for ScratchHome {
+        fn drop(&mut self) {
+            match self.prev.take() {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            std::fs::remove_dir_all(&self.dir).ok();
+        }
+    }
+
+    #[test]
+    fn a_recorded_spend_survives_and_round_trips() {
+        let _home = ScratchHome::new("roundtrip");
+        assert!(load("jira").is_none(), "no journal before recording");
+        let s = spend("old-refresh", 1_000);
+        record_spend("jira", &s).unwrap();
+        assert_eq!(load("jira").as_ref(), Some(&s));
+        clear("jira");
+        assert!(
+            load("jira").is_none(),
+            "cleared journal must read as absent"
+        );
+    }
+
+    /// The journal holds a refresh token, so it must never be world-readable -
+    /// same requirement as the token file itself.
+    #[cfg(unix)]
+    #[test]
+    fn the_journal_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let _home = ScratchHome::new("perms");
+        record_spend("jira", &spend("t", 1)).unwrap();
+        let path = journal_path("jira").unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "journal must be 0600, got {mode:o}");
+    }
+
+    /// A garbage journal must not fail the refresh. It is discarded, so the
+    /// caller proceeds with a normal refresh rather than erroring on a side-file.
+    #[test]
+    fn a_corrupt_journal_reads_as_absent_and_is_removed() {
+        let _home = ScratchHome::new("corrupt");
+        record_spend("jira", &spend("t", 1)).unwrap();
+        let path = journal_path("jira").unwrap();
+        std::fs::write(&path, b"{not json").unwrap();
+        assert!(
+            load("jira").is_none(),
+            "a corrupt journal must read as absent"
+        );
+        assert!(
+            !path.exists(),
+            "a corrupt journal must be removed, not left to be re-read forever"
+        );
+    }
+
+    /// The replay window is measured on the WALL clock so it spans a suspend.
+    #[test]
+    fn the_replay_window_is_bounded_and_clamped() {
+        let s = spend("t", 1_000);
+        assert!(
+            s.within_replay_window(1_000),
+            "a spend just issued is in window"
+        );
+        assert!(
+            s.within_replay_window(1_000 + REPLAY_WINDOW_SECS),
+            "the boundary itself is in window"
+        );
+        assert!(
+            !s.within_replay_window(1_000 + REPLAY_WINDOW_SECS + 1),
+            "one second past the window is out"
+        );
+        // A backwards clock jump must not read as "issued in the future", which
+        // would make the spend look permanently fresh and replay forever.
+        assert_eq!(s.age_secs(500), 0, "age is clamped at zero");
+        assert!(s.within_replay_window(500));
+    }
+}

--- a/src/health/jira.rs
+++ b/src/health/jira.rs
@@ -145,8 +145,15 @@ async fn classify_auth(send: reqwest::Result<reqwest::Response>) -> Check {
 /// failure warns and carries the provider's own message; anything else reports
 /// elapsed time as context only, never as a fault.
 async fn sync_freshness(pool: &SqlitePool) -> Check {
-    match sqlx::query_as::<_, (Option<f64>, Option<String>)>(
-        "SELECT (julianday('now') - julianday(last_synced_at)) * 86400.0, last_error
+    // `last_synced_at` is NOT always a real success timestamp: `stamp_sync_error`
+    // inserts the epoch sentinel when it creates a row for a provider that has
+    // never synced. Reporting an age off that renders as "last synced 29799360m
+    // ago", so the sentinel is detected and reported as never-synced instead of
+    // being arithmetic'd into a nonsense duration.
+    match sqlx::query_as::<_, (Option<f64>, Option<String>, Option<String>)>(
+        "SELECT (julianday('now') - julianday(last_synced_at)) * 86400.0,
+                last_error,
+                last_synced_at
          FROM pm_sync_state WHERE provider = 'jira'",
     )
     .fetch_optional(pool)
@@ -155,19 +162,23 @@ async fn sync_freshness(pool: &SqlitePool) -> Check {
         // A recorded failure is the ONLY thing that warns. `last_error` is set by
         // the provider itself, so the text is the real cause rather than this
         // check's guess at one.
-        Ok(Some((_, Some(err)))) if !err.trim().is_empty() => {
+        Ok(Some((_, Some(err), _))) if !err.trim().is_empty() => {
             Check::warn("ticket sync", "L3", format!("last sync failed: {err}")).with_remedy(
                 "check the auth row above; a sync retries on the next on-demand trigger",
             )
         }
+        // The epoch sentinel means "a row exists but no sync ever succeeded".
+        Ok(Some((_, _, Some(stamp)))) if stamp.starts_with("1970") => {
+            Check::info("ticket sync", "L3", "no successful Jira sync recorded yet")
+        }
         // Elapsed time as context. An old cache is normal when nothing asked for a sync.
-        Ok(Some((Some(age), _))) => Check::ok(
+        Ok(Some((Some(age), _, _))) => Check::ok(
             "ticket sync",
             "L3",
             format!("last synced {:.0}m ago, no errors", age / 60.0),
         ),
         // A row with neither a parseable timestamp nor an error: nothing to report.
-        Ok(Some((None, _))) => {
+        Ok(Some((None, _, _))) => {
             Check::info("ticket sync", "L3", "no successful Jira sync recorded yet")
         }
         Ok(None) => Check::info("ticket sync", "L3", "no Jira sync recorded yet"),
@@ -295,6 +306,31 @@ mod tests {
             check.severity,
             Severity::Info,
             "never-synced must be info, got {check:?}"
+        );
+    }
+
+    /// The epoch sentinel must not be rendered as an age.
+    ///
+    /// `stamp_sync_error` inserts `1970-01-01T00:00:00Z` when it creates a row for
+    /// a provider that never synced. Doing the arithmetic on that produced "last
+    /// synced 29799360m ago" - a real string this would have shown a user.
+    #[tokio::test]
+    async fn the_epoch_sentinel_is_not_reported_as_an_age() {
+        let pool = db().await;
+        sqlx::query(
+            "INSERT INTO pm_sync_state (provider, last_synced_at, last_error)
+             VALUES ('jira', '1970-01-01T00:00:00Z', NULL)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let check = sync_freshness(&pool).await;
+        assert_eq!(check.severity, Severity::Info, "got {check:?}");
+        assert!(
+            !check.detail.contains('m'),
+            "the sentinel must not be turned into a minutes figure, got {:?}",
+            check.detail
         );
     }
 }

--- a/src/health/jira.rs
+++ b/src/health/jira.rs
@@ -12,9 +12,6 @@ use crate::intelligence::oauth::{jira as oauth_jira, store as oauth_store};
 use sqlx::SqlitePool;
 use std::time::Duration;
 
-/// Cache older than this (2× the 30-min sync interval) ⇒ fetch likely failing.
-const SYNC_STALE_SECS: f64 = 3600.0;
-
 pub async fn checks(_cfg: &Config, pool: Option<&SqlitePool>) -> Vec<Check> {
     let mut out = Vec::new();
 
@@ -132,28 +129,47 @@ async fn classify_auth(send: reqwest::Result<reqwest::Response>) -> Check {
     }
 }
 
+/// Report whether the last Jira sync FAILED, not whether it was long ago.
+///
+/// This used to warn purely on elapsed time (`age > 3600s` => "fetch may be
+/// failing silently"), which was a reasonable proxy only while a background
+/// timer synced every few minutes no matter what. PM sync is on-demand now (see
+/// [`crate::intelligence::run_pm_sync`]): a machine that was shut all weekend,
+/// or a user who has not opened the dashboard since Friday, has a legitimately
+/// old cache and nothing is wrong. Warning on that is a false alarm nobody can
+/// act on - and a check that cries wolf during normal operation is worse than no
+/// check, because it teaches people to ignore the one that matters.
+///
+/// So the signal is the OUTCOME instead: `pm_sync_state.last_error`, written by
+/// `providers::record_sync_failure` and cleared by `clear_sync_error`. A recorded
+/// failure warns and carries the provider's own message; anything else reports
+/// elapsed time as context only, never as a fault.
 async fn sync_freshness(pool: &SqlitePool) -> Check {
-    match sqlx::query_scalar::<_, Option<f64>>(
-        "SELECT (julianday('now') - julianday(MAX(last_synced_at))) * 86400.0
+    match sqlx::query_as::<_, (Option<f64>, Option<String>)>(
+        "SELECT (julianday('now') - julianday(last_synced_at)) * 86400.0, last_error
          FROM pm_sync_state WHERE provider = 'jira'",
     )
-    .fetch_one(pool)
+    .fetch_optional(pool)
     .await
     {
-        Ok(Some(age)) if age > SYNC_STALE_SECS => Check::warn(
+        // A recorded failure is the ONLY thing that warns. `last_error` is set by
+        // the provider itself, so the text is the real cause rather than this
+        // check's guess at one.
+        Ok(Some((_, Some(err)))) if !err.trim().is_empty() => {
+            Check::warn("ticket sync", "L3", format!("last sync failed: {err}")).with_remedy(
+                "check the auth row above; a sync retries on the next on-demand trigger",
+            )
+        }
+        // Elapsed time as context. An old cache is normal when nothing asked for a sync.
+        Ok(Some((Some(age), _))) => Check::ok(
             "ticket sync",
             "L3",
-            format!(
-                "cache {:.0}m stale — fetch may be failing silently",
-                age / 60.0
-            ),
-        )
-        .with_remedy("check the auth row above; the daemon refreshes every 30m"),
-        Ok(Some(age)) => Check::ok(
-            "ticket sync",
-            "L3",
-            format!("fresh ({:.0}m ago)", age / 60.0),
+            format!("last synced {:.0}m ago, no errors", age / 60.0),
         ),
+        // A row with neither a parseable timestamp nor an error: nothing to report.
+        Ok(Some((None, _))) => {
+            Check::info("ticket sync", "L3", "no successful Jira sync recorded yet")
+        }
         Ok(None) => Check::info("ticket sync", "L3", "no Jira sync recorded yet"),
         Err(e) => Check::warn(
             "ticket sync",
@@ -186,5 +202,99 @@ async fn candidate_count(pool: &SqlitePool) -> Check {
             "L3",
             format!("could not count pm_tasks ({e})"),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::health::Severity;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn db() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("src/migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    /// Seed `pm_sync_state` with a sync `days_ago` in the past and an optional
+    /// recorded error.
+    async fn seed(pool: &SqlitePool, days_ago: f64, last_error: Option<&str>) {
+        sqlx::query(
+            "INSERT INTO pm_sync_state (provider, last_synced_at, last_error)
+             VALUES ('jira', strftime('%Y-%m-%dT%H:%M:%SZ', 'now', ?), ?)",
+        )
+        .bind(format!("-{days_ago} days"))
+        .bind(last_error)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// THE REGRESSION THIS EXISTS FOR. A three-day-old cache with no recorded
+    /// failure is normal once syncing is on-demand - the machine was shut, or
+    /// nobody opened the dashboard. The old elapsed-time rule warned at one hour,
+    /// which would now fire on healthy installs every Monday morning.
+    #[tokio::test]
+    async fn a_long_quiet_period_with_no_error_is_not_a_fault() {
+        let pool = db().await;
+        seed(&pool, 3.0, None).await;
+        let check = sync_freshness(&pool).await;
+        assert_eq!(
+            check.severity,
+            Severity::Ok,
+            "a stale-but-successful sync must not warn, got {check:?}"
+        );
+    }
+
+    /// A recorded failure warns and carries the provider's own message, so the
+    /// user sees the real cause rather than this check's guess at one.
+    #[tokio::test]
+    async fn a_recorded_failure_warns_with_the_providers_own_message() {
+        let pool = db().await;
+        seed(&pool, 0.01, Some("refresh_token is invalid")).await;
+        let check = sync_freshness(&pool).await;
+        assert_eq!(
+            check.severity,
+            Severity::Warn,
+            "a recorded failure must warn"
+        );
+        assert!(
+            check.detail.contains("refresh_token is invalid"),
+            "the provider's message must survive into the detail, got {:?}",
+            check.detail
+        );
+    }
+
+    /// An empty string is not a failure. `clear_sync_error` blanks the column on
+    /// success on some paths, and treating `''` as an error would leave a
+    /// permanent warn on a perfectly healthy install.
+    #[tokio::test]
+    async fn a_blank_last_error_is_not_a_failure() {
+        let pool = db().await;
+        seed(&pool, 0.5, Some("   ")).await;
+        let check = sync_freshness(&pool).await;
+        assert_eq!(
+            check.severity,
+            Severity::Ok,
+            "a blank last_error must not warn, got {check:?}"
+        );
+    }
+
+    /// No row at all - a tracker that has never synced. Informational, never a
+    /// fault: this is every fresh install for its first few minutes.
+    #[tokio::test]
+    async fn never_synced_is_informational() {
+        let pool = db().await;
+        let check = sync_freshness(&pool).await;
+        assert_eq!(
+            check.severity,
+            Severity::Info,
+            "never-synced must be info, got {check:?}"
+        );
     }
 }

--- a/src/intelligence/mod.rs
+++ b/src/intelligence/mod.rs
@@ -3,6 +3,7 @@
 pub mod oauth;
 pub mod providers;
 pub mod session_categorizer;
+pub mod sync_lock;
 pub mod task_triage;
 pub mod ticket_update;
 
@@ -10,6 +11,24 @@ use anyhow::Result;
 use sqlx::SqlitePool;
 
 use crate::config::{Config, PmProviderConfig};
+
+/// Serialises PM sync WITHIN this process, above [`sync_lock`]'s cross-process
+/// file lock.
+///
+/// Both layers are needed and neither subsumes the other: `flock` is held per
+/// open-file-description, so two tasks in ONE process would each open the lock
+/// file and each be granted it. The daemon has two callers that can overlap (a
+/// worklog drafting sweep and a forced sync from `ticket-update`), so without
+/// this the file lock would not dedupe them at all.
+///
+/// A `tokio::sync::Mutex` rather than a `std` one because it is held across the
+/// provider loop's `.await`s.
+static IN_PROCESS_SYNC: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// How long a FORCED sync waits for a gated one to finish before giving up on
+/// the lock. Comfortably inside the tray's 30 s `tasks-sync` budget, so the
+/// caller reports honestly instead of being killed mid-wait.
+const FORCE_LOCK_WAIT: std::time::Duration = std::time::Duration::from_secs(20);
 
 /// True once at least one PM task is cached. Rows only land in `pm_tasks` after a
 /// provider authenticated and fetched successfully, so a non-zero count is proof
@@ -39,6 +58,31 @@ pub async fn run_pm_force_sync(meridian: &SqlitePool, config: &Config) -> Result
     if config.pm_providers.is_empty() {
         return Ok(());
     }
+    let _in_process = IN_PROCESS_SYNC.lock().await;
+    // A forced sync must NOT skip on contention - somebody pressed "Sync now",
+    // or a tracker write just landed and the board is knowingly behind. So wait
+    // for the holder, and if the budget expires proceed anyway: a duplicate
+    // fetch is wasteful, whereas silently doing nothing after an explicit
+    // request is the "sync is still running" dead end users already hit.
+    // Lock evaluation failing is logged and ignored for the same reason - the
+    // dedup lock must never become a new way for a sync to fail.
+    let _cross_process = match sync_lock::acquire_waiting(FORCE_LOCK_WAIT).await {
+        Ok(Some(guard)) => Some(guard),
+        Ok(None) => {
+            tracing::info!(
+                waited_s = FORCE_LOCK_WAIT.as_secs(),
+                "force sync: another sync still holds the lock - proceeding anyway"
+            );
+            None
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %crate::errors::chain(&e),
+                "force sync: could not evaluate the PM sync lock - proceeding without dedup"
+            );
+            None
+        }
+    };
     for provider in &config.pm_providers {
         let name = provider.provider_name();
         let result = match provider {
@@ -80,6 +124,35 @@ pub async fn run_pm_sync(meridian: &SqlitePool, config: &Config) -> Result<()> {
         tracing::warn!("no PM providers configured — pm_tasks will stay empty (set JIRA_BASE_URL/GITHUB_TOKEN/LINEAR_API_KEY/AZURE_DEVOPS_PAT)");
         return Ok(());
     }
+    let _in_process = IN_PROCESS_SYNC.lock().await;
+    // Gated callers SKIP when another sync is in flight: that run is already
+    // fetching the board this one wanted, so a second fetch is pure duplicate
+    // load on the tracker's API. This is the only thing standing between "the
+    // dashboard was opened while a drafting sweep started" and two identical
+    // board fetches.
+    let _cross_process = match sync_lock::try_acquire() {
+        Ok(Some(guard)) => guard,
+        Ok(None) => {
+            tracing::debug!("pm sync already in flight in another process - skipping");
+            return Ok(());
+        }
+        // Never fail a sync because the DEDUP lock was unreadable - degrading to
+        // "no dedup" is strictly better than degrading to "no sync".
+        Err(e) => {
+            tracing::warn!(
+                error = %crate::errors::chain(&e),
+                "could not evaluate the PM sync lock - proceeding without dedup"
+            );
+            return run_pm_sync_providers(meridian, config).await;
+        }
+    };
+    run_pm_sync_providers(meridian, config).await
+}
+
+/// The provider loop itself, split from [`run_pm_sync`] so the locking policy
+/// above has exactly one body to guard and cannot drift from it.
+#[tracing::instrument(skip_all)]
+async fn run_pm_sync_providers(meridian: &SqlitePool, config: &Config) -> Result<()> {
     let provider_count = config.pm_providers.len();
     tracing::debug!(provider_count, "syncing PM providers");
 
@@ -219,5 +292,47 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(queued, 0, "the board hygiene digest producer was removed");
+    }
+
+    /// NO TIMER MAY SYNC THE BOARD. This is a source-level guard because the
+    /// regression it prevents is invisible: a `run_pm_sync` call added back into
+    /// the daemon's poll loop would work perfectly, sync the board, pass every
+    /// test - and start silently destroying users' Jira OAuth grants again.
+    ///
+    /// The mechanism, in one paragraph, because it is not guessable from the call
+    /// site: macOS dark-wakes a sleeping machine every 15-16 minutes. A timer
+    /// resumed, found the access token expired, and POSTed a refresh; Atlassian
+    /// rotated the refresh token and replied; the machine re-suspended before the
+    /// response was read. `reqwest`'s timeout could not cancel it, because the
+    /// timeout is `Instant`-based and the monotonic clock does not advance while
+    /// the system is asleep. The next dark wake retried with the OLD refresh
+    /// token, by then past Atlassian's 10-minute reuse leeway - `invalid_grant`,
+    /// terminal, grant dead forever. The dark-wake interval is LONGER than the
+    /// leeway, which is why no retry policy fixes it and why the only fix is to
+    /// attempt no refresh while nobody is there.
+    ///
+    /// Every legitimate caller is a ONE-SHOT CLI arm, all of which sit before the
+    /// daemon boots. So the rule is positional: nothing after the poll loop
+    /// begins. If this fails, do not silence it - move the trigger to something a
+    /// present user did (see `tray/src-tauri/src/commands/tasks.rs`).
+    #[test]
+    fn the_daemon_poll_loop_never_syncs_pm_tasks() {
+        let main_rs = include_str!("../main.rs");
+        // The loop's own `tokio::select!` is the boundary: CLI arms are all above
+        // it, the daemon's recurring work is all below.
+        let loop_start = main_rs
+            .find("tokio::select! {")
+            .expect("main.rs must still have the poll loop's tokio::select!");
+        let after = &main_rs[loop_start..];
+        let offenders: Vec<&str> = after
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .filter(|l| l.contains("run_pm_sync(") || l.contains("run_pm_force_sync("))
+            .collect();
+        assert!(
+            offenders.is_empty(),
+            "PM sync is back on a timer, which permanently kills Jira OAuth grants \
+             on sleeping machines - see this test's doc comment. Offending lines: {offenders:?}"
+        );
     }
 }

--- a/src/intelligence/providers/mod.rs
+++ b/src/intelligence/providers/mod.rs
@@ -91,167 +91,74 @@ pub async fn stamp_sync_error_with_remedy(
     Ok(())
 }
 
-/// How stale the last SUCCESSFUL sync may get before a run of otherwise-
-/// suppressed transient failures is escalated to a user-facing notice.
+/// How many CONSECUTIVE failed sync attempts a provider gets before its
+/// otherwise-suppressed transient failures escalate to a user-facing notice.
 ///
-/// Comfortably longer than any provider's sync interval, so an ordinary flaky
-/// hour never trips it — but short enough that a persistently blocked provider
-/// surfaces the same working day.
-const TRANSIENT_ESCALATION_HOURS: i64 = 6;
+/// This replaced a "no successful sync in the last 6 hours" rule. That rule was
+/// correct when written: sync ran on a timer every few minutes, so six hours
+/// without a success reliably meant something was broken - its own doc comment
+/// said "comfortably longer than any provider's sync interval".
+///
+/// Sync is on-demand now (see [`crate::intelligence::run_pm_sync`]) and that
+/// premise is gone. A machine that slept all weekend, or a user who has not
+/// opened the dashboard since Friday, has no successful sync for DAYS and nothing
+/// is wrong. Under the old rule the first two failures after any quiet period
+/// escalated, so opening the dashboard on Monday before Wi-Fi associated raised a
+/// red "sync failing" banner on a healthy install - with a body reading "No
+/// successful sync in the last 6 hours" while describing normal use.
+///
+/// Consecutive failures are the honest evidence: a blocked proxy or a dead route
+/// fails EVERY attempt, whereas a wake-time blip fails once or twice then works.
+/// Elapsed quiet carries no signal at all any more.
+const TRANSIENT_ESCALATION_ATTEMPTS: u32 = 4;
 
-/// Record a transient (retryable) sync failure.
+/// Consecutive transient failures per provider, for the CURRENT PROCESS only.
 ///
-/// Normally raises NOTHING — [`http::SyncFault::Retry`] exists precisely so a
-/// network blip stops producing a "check your credentials" banner for
-/// credentials that are fine.
+/// In memory rather than in `pm_sync_state`, deliberately:
 ///
-/// But silence has to be BOUNDED. A provider blocked persistently (corporate
-/// proxy, TLS interception, a firewall rule) is unreachable on every tick
-/// forever, and suppressing that outright would leave the user's board silently
-/// going stale with no signal at all — strictly worse than the misleading banner
-/// this change removes. So the failure escalates to a normal sync notice once
-/// the provider has not synced successfully within
-/// [`TRANSIENT_ESCALATION_HOURS`].
-///
-/// **A provider that has NEVER synced needs its own handling**, because it has
-/// no `pm_sync_state` row at all, so an age test alone would no-op forever on
-/// exactly the installs that most need it — someone who just connected and whose
-/// network blocks the provider outright.
-///
-/// It gets ONE retry rather than escalating on the first failure. Escalating
-/// immediately would reintroduce the very thing this change removes, just with
-/// connectivity wording instead of credentials wording: connect a tracker, have
-/// the first attempt land on an ordinary blip (a DNS hiccup, a proxy handshake,
-/// a laptop still waking up) and a "sync failing" banner appears seconds later.
-/// So the first failure writes the row and stays silent; the next one sees the
-/// row with an epoch `last_synced_at`, which is not recent, and escalates. One
-/// sync interval of grace, and the persistently-blocked case still surfaces.
-///
-/// **This same one-retry grace applies to a provider that has synced
-/// successfully before**, not just a brand-new one - see the `is_sentinel`
-/// branch in [`note_transient_sync_failure`]. Without it, a provider whose
-/// `last_synced_at` goes stale because the DAEMON WAS ASLEEP (laptop closed
-/// overnight, a longer Wi-Fi/VPN drop) rather than because it kept failing
-/// escalates on its very first retry after waking - the exact false-positive
-/// this module exists to remove, just triggered by a gap in *time* instead of
-/// a gap in connectivity. The grace row and this ONE mechanism (the epoch
-/// sentinel) cover both cases identically, so the escalation check cannot tell
-/// them apart and does not need to.
-///
-/// The remedy points at connectivity, NOT credentials: by construction we only
-/// reach here for failures that are not the user's token.
-///
-/// Write the epoch-sentinel grace row for a provider that has never synced.
-///
-/// **Deliberately does NOT write `last_error`** (unlike the escalating write
-/// in [`stamp_sync_error_with_remedy`]): `meridian_core::readers::integrations::sync_errors`
-/// reads `last_error IS NOT NULL` to drive the per-provider "Sync failed"
-/// badge on the Integrations page, independent of whether a system-wide
-/// notice was raised. Setting it here would show that badge during a period
-/// this function is specifically trying to keep quiet - `detail` is still
-/// logged (below) so the attempt is not lost from telemetry, just kept out of
-/// the persisted, user-visible column.
-///
-/// # Why `ON CONFLICT DO NOTHING`
-/// The caller's `has_row` check is a SEPARATE statement from this insert, and
-/// `pm_sync_state.provider` is a PRIMARY KEY - so anything that can run two
-/// sync passes for one provider concurrently can have both observe "no row"
-/// and both insert. That is not hypothetical here: `meridian ticket-update`
-/// opens its OWN pool to the same `meridian.db` and calls
-/// `intelligence::run_pm_force_sync` (`src/main.rs`) while the daemon's poll
-/// loop is running `run_pm_sync` against the same file, so the two racers are
-/// separate PROCESSES and no in-process lock would cover them.
-///
-/// Without the clause the loser gets `UNIQUE constraint failed`, which
-/// [`record_sync_failure`] swallows by design - so the grace row would be
-/// silently lost, the next failure would take the same branch again, and the
-/// escalation clock would never start. That is the exact failure this whole
-/// module exists to prevent, reintroduced by a race.
-///
-/// Doing nothing on conflict is the correct resolution rather than a
-/// compromise: the row the winner wrote carries the same epoch sentinel this
-/// one would have written, so both racers leave the state they intended.
-///
-/// Extracted from [`note_transient_sync_failure`] to give the conflict
-/// behaviour a testable seam - the race itself has no deterministic hook, but
-/// "inserting over an existing row is a no-op, not an error" does.
-async fn insert_grace_row(pool: &SqlitePool, provider: &str, detail: &str) -> Result<()> {
-    tracing::debug!(
-        provider,
-        detail,
-        "grace row: recording the attempt without a user-visible error"
-    );
-    sqlx::query(
-        "INSERT INTO pm_sync_state (provider, last_synced_at, last_error)
-         VALUES (?, '1970-01-01T00:00:00Z', NULL)
-         ON CONFLICT(provider) DO NOTHING",
-    )
-    .bind(provider)
-    .execute(pool)
-    .await
-    .context("recording the first transient failure for a never-synced provider")?;
-    Ok(())
+/// * No migration, and it cannot corrupt a database - the same reasoning that put
+///   the sync dedup lock and the OAuth refresh journal outside `meridian.db`.
+/// * Resetting on restart is the SAFE direction. launchd `KeepAlive` restarts the
+///   daemon on every wake, so a fresh process starts at zero and can never
+///   inherit a stale streak and escalate on its first blip. The cost is that a
+///   persistent block takes a few attempts within one session to surface, which
+///   is the trade we want: quiet by default, loud only on real evidence.
+static TRANSIENT_STREAKS: std::sync::Mutex<Option<std::collections::HashMap<String, u32>>> =
+    std::sync::Mutex::new(None);
+
+/// Increment and return this provider's consecutive-failure count.
+fn bump_transient_streak(provider: &str) -> u32 {
+    let mut guard = TRANSIENT_STREAKS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let map = guard.get_or_insert_with(std::collections::HashMap::new);
+    let counter = map.entry(provider.to_string()).or_insert(0);
+    *counter = counter.saturating_add(1);
+    *counter
 }
 
-/// Downgrade a STALE-BUT-PREVIOUSLY-SUCCESSFUL provider's `last_synced_at` to
-/// the epoch sentinel, marking its one retry of grace as used - WITHOUT
-/// writing `last_error`, for the same reason [`insert_grace_row`] doesn't (see
-/// its doc comment). Mirrors that function's shape but is an UPDATE, not an
-/// INSERT: the row already exists here, carrying a real (if old) past-success
-/// timestamp that this call intentionally overwrites, so the NEXT failure's
-/// `is_sentinel` check reads it identically to a never-synced provider's grace
-/// row and escalates.
-async fn mark_first_stale_failure(pool: &SqlitePool, provider: &str, detail: &str) -> Result<()> {
-    tracing::debug!(
-        provider,
-        detail,
-        "first transient failure since a genuine past success - staying quiet until the next attempt"
-    );
-    // The WHERE clause re-checks, inside the write, the same three conditions
-    // the caller checked in a SEPARATE statement: still stale, not already the
-    // sentinel, and carrying no error.
-    //
-    // For the same reason `insert_grace_row` needs `ON CONFLICT DO NOTHING`:
-    // `meridian ticket-update` opens its own pool to this file and runs
-    // `run_pm_force_sync` while the daemon's poll loop runs `run_pm_sync`, so
-    // the racers are separate PROCESSES and no in-process lock covers them.
-    // That path was guarded for the INSERT and left open for this UPDATE.
-    //
-    // The damage an unconditional write does is not a lost grace tick (both
-    // racers intend the same sentinel) but the opposite: a sync that SUCCEEDS
-    // between the caller's read and this statement has its fresh
-    // `last_synced_at` stamped back to the epoch. The provider then reads as
-    // never-recently-synced, and the next failure escalates a user-visible
-    // notice for a tracker that is working. A single conditional statement is
-    // atomic in SQLite, so the success either lands before this (and the
-    // `last_synced_at` guard makes this a no-op) or after it (and it wins).
-    let updated = sqlx::query(
-        "UPDATE pm_sync_state SET last_synced_at = '1970-01-01T00:00:00Z'
-         WHERE provider = ?
-           AND last_error IS NULL
-           AND last_synced_at != '1970-01-01T00:00:00Z'
-           AND last_synced_at <= strftime('%Y-%m-%dT%H:%M:%SZ', 'now', ?)",
-    )
-    .bind(provider)
-    .bind(format!("-{TRANSIENT_ESCALATION_HOURS} hours"))
-    .execute(pool)
-    .await
-    .context("recording a resumed provider's first quiet failure since its last success")?
-    .rows_affected();
-
-    if updated == 0 {
-        // Something changed under us between the read and the write. Staying
-        // quiet is still the right answer for THIS attempt - the caller already
-        // decided not to escalate - but say so, because the alternative reading
-        // ("the write silently did nothing") is the bug this guard introduces
-        // if it is ever wrong.
-        tracing::debug!(
-            provider,
-            "grace write skipped - the row stopped being a clean stale transition \
-             (a concurrent sync succeeded, or another pass already recorded it)"
-        );
+/// Reset this provider's consecutive-failure count after a successful sync.
+///
+/// A success is the ONLY thing that clears it, which is what makes the count mean
+/// "failures in a row" rather than "failures ever".
+pub(crate) fn reset_transient_streak(provider: &str) {
+    let mut guard = TRANSIENT_STREAKS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(map) = guard.as_mut() {
+        map.remove(provider);
     }
-    Ok(())
+}
+
+/// Test-only: force a provider's streak so escalation can be exercised without
+/// calling the recorder N times.
+#[cfg(test)]
+pub(crate) fn set_transient_streak_for_test(provider: &str, value: u32) {
+    let mut guard = TRANSIENT_STREAKS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let map = guard.get_or_insert_with(std::collections::HashMap::new);
+    map.insert(provider.to_string(), value);
 }
 
 /// Returns whether it escalated.
@@ -264,77 +171,37 @@ pub async fn note_transient_sync_failure(
     provider: &str,
     detail: &str,
 ) -> Result<bool> {
-    let threshold = format!("-{TRANSIENT_ESCALATION_HOURS} hours");
-    let (has_row, recently_synced, is_sentinel, has_error): (i64, i64, i64, i64) = sqlx::query_as(
-        "SELECT
-             EXISTS(SELECT 1 FROM pm_sync_state WHERE provider = ?),
-             EXISTS(
-                 SELECT 1 FROM pm_sync_state
-                 WHERE provider = ?
-                   AND last_synced_at > strftime('%Y-%m-%dT%H:%M:%SZ', 'now', ?)
-             ),
-             EXISTS(
-                 SELECT 1 FROM pm_sync_state
-                 WHERE provider = ? AND last_synced_at = '1970-01-01T00:00:00Z'
-             ),
-             EXISTS(
-                 SELECT 1 FROM pm_sync_state WHERE provider = ? AND last_error IS NOT NULL
-             )",
-    )
-    .bind(provider)
-    .bind(provider)
-    .bind(&threshold)
-    .bind(provider)
-    .bind(provider)
-    .fetch_one(pool)
-    .await
-    .context("checking sync recency for transient-failure escalation")?;
+    let streak = bump_transient_streak(provider);
+    let span = tracing::Span::current();
+    span.record("streak", streak);
 
-    if recently_synced != 0 {
-        tracing::Span::current().record("escalated", false);
-        return Ok(false);
-    }
-
-    if has_row == 0 {
-        // First-ever failure on a provider that has never synced. Record the
-        // attempt so the NEXT one escalates, but raise nothing: a tracker
-        // connected seconds ago that hits one blip must not immediately show a
-        // fault. The epoch sentinel is deliberate - it is not a recent sync, so
-        // the next failure takes the escalation branch below.
-        insert_grace_row(pool, provider, detail).await?;
+    if streak < TRANSIENT_ESCALATION_ATTEMPTS {
+        // Silence, which is the normal outcome. `SyncFault::Retry` exists so a
+        // network blip does not produce a banner for credentials that are fine,
+        // and a wake-time blip is the single most common instance of one.
         tracing::debug!(
             provider,
-            "first transient failure on a never-synced provider - staying quiet until the next attempt"
+            streak,
+            needed = TRANSIENT_ESCALATION_ATTEMPTS,
+            "transient sync failure - staying quiet until the streak is real"
         );
-        tracing::Span::current().record("escalated", false);
+        span.record("escalated", false);
         return Ok(false);
     }
 
-    // Not recently synced, and the provider HAS synced before. Give it the
-    // SAME one retry of grace a never-synced provider gets, unless there is
-    // already something to weigh against staying quiet: `is_sentinel` covers
-    // "the grace tick already ran" (this branch set `last_synced_at` to the
-    // sentinel with no `last_error`, and a SECOND consecutive failure now
-    // finds it), and `has_error` covers "a fault is already recorded here"
-    // (a terminal failure elsewhere already wrote `last_error` and raised its
-    // own notice - nothing is gained by staying quiet on top of that). Only a
-    // row that has synced before, has since gone stale, and carries neither
-    // signal - a clean transition into staleness - gets the grace write.
-    if has_error == 0 && is_sentinel == 0 {
-        mark_first_stale_failure(pool, provider, detail).await?;
-        tracing::Span::current().record("escalated", false);
-        return Ok(false);
-    }
-
+    // Silence has to be BOUNDED. A provider blocked persistently (corporate
+    // proxy, TLS interception, a firewall rule) fails every single attempt
+    // forever, and suppressing that outright would leave the board silently going
+    // stale with no signal at all - strictly worse than a misleading banner.
     tracing::warn!(
         provider,
-        hours = TRANSIENT_ESCALATION_HOURS,
-        "provider unreachable with no recent successful sync - escalating to a notice"
+        streak,
+        "provider unreachable on {streak} consecutive attempts - escalating to a notice"
     );
-    // The title already names the provider, so the body only has to say what is
-    // wrong and carry the cause.
-    let msg =
-        format!("No successful sync in the last {TRANSIENT_ESCALATION_HOURS} hours - {detail}");
+    // The message names the evidence, not a duration. The old wording ("No
+    // successful sync in the last 6 hours") described normal on-demand operation
+    // and so read as a false alarm even when the fault was real.
+    let msg = format!("Unreachable on {streak} consecutive sync attempts - {detail}");
     stamp_sync_error_with_remedy(
         pool,
         provider,
@@ -342,7 +209,7 @@ pub async fn note_transient_sync_failure(
         Some("Check your internet connection, VPN, or proxy settings"),
     )
     .await?;
-    tracing::Span::current().record("escalated", true);
+    span.record("escalated", true);
     Ok(true)
 }
 
@@ -446,6 +313,12 @@ pub async fn record_sync_failure(
 
 /// Clear the last error for a provider after a successful sync.
 pub async fn clear_sync_error(pool: &SqlitePool, provider: &str) -> Result<()> {
+    // A success is the ONLY thing that resets the consecutive-failure streak,
+    // which is what makes that count mean "failures in a row" rather than
+    // "failures ever". Reset FIRST: if the DB write below fails, the streak is
+    // still correct (the sync did succeed), whereas a streak left standing after
+    // a success would escalate on the next single blip.
+    reset_transient_streak(provider);
     sqlx::query("UPDATE pm_sync_state SET last_error = NULL WHERE provider = ?")
         .bind(provider)
         .execute(pool)

--- a/src/intelligence/providers/sync_failure_tests.rs
+++ b/src/intelligence/providers/sync_failure_tests.rs
@@ -44,308 +44,197 @@ async fn notice(pool: &SqlitePool, id: &str) -> Option<(String, String, Option<S
         .unwrap()
 }
 
-/// The whole point of suppressing transient failures: an ordinary blip on a
-/// provider that is otherwise working must raise NOTHING. This is the bug
-/// the user reported - a banner telling them to redo working credentials.
-#[tokio::test]
-async fn a_blip_on_a_healthy_provider_stays_silent() {
-    let pool = make_db().await;
-    set_last_sync(&pool, "github", "-5 minutes").await;
+/// Each test gets its own provider name where the streak matters: the streak
+/// lives in a process-global map, and cargo runs these in parallel threads, so
+/// sharing a name would let one test's failures leak into another's count.
+///
+/// Reset explicitly too, because the map outlives any single test.
+fn fresh_streak(provider: &str) {
+    reset_transient_streak(provider);
+}
 
-    let escalated = note_transient_sync_failure(&pool, "github", "dns error")
+/// A single network blip must stay SILENT. This is the whole reason
+/// `SyncFault::Retry` exists - one DNS hiccup must not produce a "check your
+/// credentials" banner for credentials that are fine.
+#[tokio::test]
+async fn a_single_blip_stays_silent() {
+    let pool = make_db().await;
+    fresh_streak("blip_single");
+    set_last_sync(&pool, "blip_single", "-2 minutes").await;
+
+    let escalated = note_transient_sync_failure(&pool, "blip_single", "dns error")
         .await
         .unwrap();
-
-    assert!(!escalated);
+    assert!(!escalated, "one transient failure must not escalate");
     assert!(
-        notice(&pool, "pm.github").await.is_none(),
-        "a network blip must not raise a user-facing fault"
+        notice(&pool, "pm.blip_single").await.is_none(),
+        "one blip must raise no notice"
     );
 }
 
-/// And the counterweight: silence must be BOUNDED. A provider blocked by a
-/// proxy or firewall fails on every tick forever, and going quiet would
-/// leave the board silently stale - worse than the banner we removed.
+/// THE REGRESSION THIS REWRITE EXISTS FOR.
 ///
-/// The FIRST failure after `last_synced_at` goes stale gets one retry of
-/// grace too (same mechanism a never-synced provider gets - see
-/// `a_provider_resuming_after_a_long_gap_gets_one_retry_before_escalating`),
-/// so this simulates genuine persistence with a SECOND consecutive failure,
-/// matching how `a_never_synced_provider_gets_one_retry_before_escalating`
-/// proves the same property for a brand-new connection.
+/// A machine that has not synced for days is NORMAL once sync is on-demand: it
+/// was shut, or nobody opened the dashboard. The old rule ("no successful sync in
+/// the last 6 hours") treated that as evidence of a fault, so the first couple of
+/// failures after any quiet period escalated - meaning a Monday-morning Wi-Fi
+/// blip raised a red banner on a healthy install.
+///
+/// A long quiet period must now carry NO weight at all.
+#[tokio::test]
+async fn a_blip_after_days_of_quiet_stays_silent() {
+    let pool = make_db().await;
+    fresh_streak("blip_quiet");
+    // Three days since the last success - a shut laptop, not a fault.
+    set_last_sync(&pool, "blip_quiet", "-72 hours").await;
+
+    for attempt in 1..=2 {
+        let escalated = note_transient_sync_failure(&pool, "blip_quiet", "dns error")
+            .await
+            .unwrap();
+        assert!(
+            !escalated,
+            "attempt {attempt} after a long quiet period must not escalate - \
+             elapsed quiet is not evidence of a fault under on-demand sync"
+        );
+    }
+    assert!(
+        notice(&pool, "pm.blip_quiet").await.is_none(),
+        "a wake-time blip must raise no notice however long the machine slept"
+    );
+}
+
+/// Silence still has to be BOUNDED. A provider blocked persistently (corporate
+/// proxy, TLS interception, a firewall rule) fails every single attempt, and
+/// suppressing that outright would leave the board silently going stale with no
+/// signal at all - strictly worse than a misleading banner.
 #[tokio::test]
 async fn a_persistently_unreachable_provider_stops_being_silent() {
     let pool = make_db().await;
-    set_last_sync(&pool, "jira", "-7 hours").await;
+    fresh_streak("blocked");
+    set_last_sync(&pool, "blocked", "-2 minutes").await;
 
-    let first = note_transient_sync_failure(&pool, "jira", "connection timed out")
-        .await
-        .unwrap();
-    assert!(
-        !first,
-        "the first failure after going stale must stay silent"
-    );
-
-    let escalated = note_transient_sync_failure(&pool, "jira", "connection timed out")
-        .await
-        .unwrap();
-
-    assert!(escalated);
-    let (title, detail, remedy) = notice(&pool, "pm.jira").await.expect("notice raised");
-    assert_eq!(title, "Jira sync failing");
-    assert!(
-        detail.contains("connection timed out"),
-        "the cause must survive into the notice: {detail}"
-    );
-    let remedy = remedy.expect("remedy set");
-    assert!(
-        remedy.contains("connection") || remedy.contains("proxy"),
-        "an unreachable provider is a connectivity remedy, not a credentials one: {remedy}"
-    );
-    assert!(
-        !remedy.contains("TOKEN"),
-        "must not tell the user to redo credentials that are fine: {remedy}"
-    );
-}
-
-/// The trap this has to survive: transient failures no longer call
-/// `stamp_sync_error`, so a machine that has NEVER reached the provider has
-/// no `pm_sync_state` row at all, and an age test alone would no-op forever
-/// on exactly the installs that need it most - someone who just connected
-/// behind a blocking proxy.
-///
-/// But it must not escalate on failure #1 either, or connecting a tracker
-/// and hitting one DNS hiccup shows a fault seconds later - the same
-/// false-positive banner this change exists to remove, just with
-/// connectivity wording. One retry, then it surfaces.
-#[tokio::test]
-async fn a_never_synced_provider_gets_one_retry_before_escalating() {
-    let pool = make_db().await;
-
-    let first = note_transient_sync_failure(&pool, "github", "dns error")
-        .await
-        .unwrap();
-    assert!(!first, "the first blip after connecting must stay silent");
-    assert!(
-        notice(&pool, "pm.github").await.is_none(),
-        "no banner seconds after connecting a tracker"
-    );
-
-    let second = note_transient_sync_failure(&pool, "github", "dns error")
-        .await
-        .unwrap();
-    assert!(second, "a second failure means it is not just a blip");
-    assert!(notice(&pool, "pm.github").await.is_some());
-}
-
-/// THE REGRESSION THIS MODULE WAS MISSING: a provider that synced
-/// successfully hours ago - laptop asleep overnight, a longer Wi-Fi/VPN drop,
-/// reconnecting after being away - has `last_synced_at` go stale for a reason
-/// that has NOTHING to do with repeated failed attempts. Before this test
-/// existed, the very first retry after such a gap escalated immediately (zero
-/// grace), while a never-synced provider got one retry first. If the network
-/// is actually back up moments later, the next attempt succeeds and clears
-/// the notice within seconds - a flash-then-clear banner that never should
-/// have shown. This provider must get the SAME one-retry grace a never-synced
-/// provider gets, and the grace attempt must not touch `last_error` either
-/// (see `a_racing_grace_row_insert_is_a_no_op_not_an_error` for the same
-/// guarantee on the never-synced path).
-#[tokio::test]
-async fn a_provider_resuming_after_a_long_gap_gets_one_retry_before_escalating() {
-    let pool = make_db().await;
-    set_last_sync(&pool, "jira", "-9 hours").await;
-
-    let first = note_transient_sync_failure(&pool, "jira", "dns error")
-        .await
-        .unwrap();
-    assert!(
-        !first,
-        "the first failure after a long gap must stay silent, same as a never-synced provider"
-    );
-    assert!(
-        notice(&pool, "pm.jira").await.is_none(),
-        "no banner on the very first retry after waking up"
-    );
-    let (last_error,): (Option<String>,) =
-        sqlx::query_as("SELECT last_error FROM pm_sync_state WHERE provider = 'jira'")
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-    assert_eq!(
-        last_error, None,
-        "the grace attempt must not make the Integrations page show \"Sync failed\""
-    );
-
-    let second = note_transient_sync_failure(&pool, "jira", "dns error")
-        .await
-        .unwrap();
-    assert!(
-        second,
-        "a second consecutive failure means it is not just a blip"
-    );
-    assert!(notice(&pool, "pm.jira").await.is_some());
-}
-
-/// Grace is per-gap, not a one-time allowance for the provider's lifetime: a
-/// genuine intervening success must reset it, or a provider that recovers and
-/// later fails again would skip straight to escalation.
-#[tokio::test]
-async fn a_real_success_between_gaps_resets_the_grace() {
-    let pool = make_db().await;
-    set_last_sync(&pool, "jira", "-9 hours").await;
-
-    assert!(
-        !note_transient_sync_failure(&pool, "jira", "dns error")
-            .await
-            .unwrap(),
-        "first failure after the first gap: grace"
-    );
-
-    // A real success lands - e.g. the network came back for a while.
-    set_last_sync(&pool, "jira", "-0 hours").await;
-
-    // Then a second, later gap starts.
-    set_last_sync(&pool, "jira", "-9 hours").await;
-    assert!(
-        !note_transient_sync_failure(&pool, "jira", "dns error")
-            .await
-            .unwrap(),
-        "first failure after the SECOND gap must get grace again, not skip to escalation"
-    );
-}
-
-/// The grace-row insert races a concurrent one across PROCESSES: `meridian
-/// ticket-update` force-syncs through its own pool on the same `meridian.db`
-/// while the daemon polls. Both can observe "no row" and both insert against
-/// the `provider` PRIMARY KEY.
-///
-/// Without `ON CONFLICT DO NOTHING` the loser gets a UNIQUE violation, which
-/// `record_sync_failure` swallows by design - so the grace row vanishes, the
-/// next failure takes the never-synced branch again, and the escalation clock
-/// never starts. A provider blocked forever would then stay silent forever,
-/// which is the failure mode this module exists to prevent.
-///
-/// The race has no deterministic hook, so this pins the property that makes
-/// the race survivable: inserting over an existing row is a no-op, not an
-/// error, and the first writer's row is left intact.
-#[tokio::test]
-async fn a_racing_grace_row_insert_is_a_no_op_not_an_error() {
-    let pool = make_db().await;
-
-    insert_grace_row(&pool, "github", "first writer")
-        .await
-        .unwrap();
-    insert_grace_row(&pool, "github", "second writer")
-        .await
-        .expect("a concurrent grace-row insert must not error");
-
-    let (count,): (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM pm_sync_state WHERE provider = 'github'")
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-    assert_eq!(count, 1, "the racing insert must not duplicate the row");
-
-    let (last, detail): (String, Option<String>) = sqlx::query_as(
-        "SELECT last_synced_at, last_error FROM pm_sync_state WHERE provider = 'github'",
-    )
-    .fetch_one(&pool)
-    .await
-    .unwrap();
-    assert!(
-        last.starts_with("1970"),
-        "the sentinel must survive the race, or escalation stalls: {last}"
-    );
-    assert_eq!(
-        detail, None,
-        "a grace row must never carry a user-visible last_error, from either writer"
-    );
-}
-
-/// A provider that HAS synced before must still escalate normally after a
-/// grace row lands - i.e. the conflict-tolerant insert did not change the
-/// contract the escalation clock reads.
-#[tokio::test]
-async fn a_grace_row_from_a_race_still_escalates_on_the_next_failure() {
-    let pool = make_db().await;
-    insert_grace_row(&pool, "github", "first writer")
-        .await
-        .unwrap();
-
-    let escalated = note_transient_sync_failure(&pool, "github", "dns error")
+    for attempt in 1..TRANSIENT_ESCALATION_ATTEMPTS {
+        assert!(
+            !note_transient_sync_failure(&pool, "blocked", "connection timed out")
+                .await
+                .unwrap(),
+            "attempt {attempt} is below the threshold and must stay silent"
+        );
+    }
+    let escalated = note_transient_sync_failure(&pool, "blocked", "connection timed out")
         .await
         .unwrap();
     assert!(
         escalated,
-        "the epoch sentinel is not a recent sync, so the next failure must surface"
+        "the {TRANSIENT_ESCALATION_ATTEMPTS}th consecutive failure must escalate"
     );
-    assert!(notice(&pool, "pm.github").await.is_some());
-}
 
-/// The grace is exactly one retry, not an open-ended reprieve: the row the
-/// first failure writes must carry the epoch sentinel, or it would read as
-/// a recent sync and suppress escalation forever.
-#[tokio::test]
-async fn the_first_failure_row_does_not_look_like_a_sync() {
-    let pool = make_db().await;
-    note_transient_sync_failure(&pool, "github", "dns error")
+    let (_, detail, remedy) = notice(&pool, "pm.blocked")
         .await
-        .unwrap();
-
-    let (last,): (String,) =
-        sqlx::query_as("SELECT last_synced_at FROM pm_sync_state WHERE provider = 'github'")
-            .fetch_one(&pool)
-            .await
-            .unwrap();
+        .expect("a notice must exist once the streak is real");
     assert!(
-        last.starts_with("1970"),
-        "the grace row must not count as a sync: {last}"
+        detail.contains("consecutive"),
+        "the message must name the real evidence (consecutive failures), not a \
+         duration that now describes normal operation - got {detail:?}"
+    );
+    assert!(
+        !detail.contains("6 hours"),
+        "the old duration wording must not come back - got {detail:?}"
+    );
+    assert!(
+        remedy.is_some_and(|r| r.to_lowercase().contains("connection")),
+        "a connectivity fault must point at connectivity"
     );
 }
 
-/// A row left by an earlier TERMINAL failure carries the epoch sentinel
-/// (`stamp_sync_error` inserts `1970-01-01`), which is a row but not a
-/// success. It must not be mistaken for one.
+/// A SUCCESS is the only thing that resets the streak. Without this, failures
+/// accumulate across hours of healthy operation and the Nth blip of the day
+/// escalates for no reason.
 #[tokio::test]
-async fn an_epoch_sentinel_row_is_not_a_recent_success() {
+async fn a_success_resets_the_streak() {
     let pool = make_db().await;
-    stamp_sync_error(&pool, "github", "bad credentials")
-        .await
-        .unwrap();
+    fresh_streak("resets");
+    set_last_sync(&pool, "resets", "-2 minutes").await;
 
-    let escalated = note_transient_sync_failure(&pool, "github", "dns error")
-        .await
-        .unwrap();
+    for _ in 1..TRANSIENT_ESCALATION_ATTEMPTS {
+        assert!(!note_transient_sync_failure(&pool, "resets", "blip")
+            .await
+            .unwrap());
+    }
+    // One good sync in between wipes the slate.
+    clear_sync_error(&pool, "resets").await.unwrap();
 
-    assert!(escalated, "an epoch last_synced_at is not a success");
+    assert!(
+        !note_transient_sync_failure(&pool, "resets", "blip")
+            .await
+            .unwrap(),
+        "after a success the count restarts, so this is failure #1 and stays silent"
+    );
+    assert!(
+        notice(&pool, "pm.resets").await.is_none(),
+        "no notice may survive a successful sync"
+    );
 }
 
-/// The window itself, from both sides.
+/// The streak is per provider. A flaky GitHub must not push Jira toward a notice.
 #[tokio::test]
-async fn the_escalation_window_holds_on_both_sides() {
+async fn streaks_do_not_leak_between_providers() {
     let pool = make_db().await;
+    fresh_streak("leak_a");
+    fresh_streak("leak_b");
 
-    set_last_sync(&pool, "jira", "-1 hours").await;
+    for _ in 1..TRANSIENT_ESCALATION_ATTEMPTS {
+        assert!(!note_transient_sync_failure(&pool, "leak_a", "blip")
+            .await
+            .unwrap());
+    }
     assert!(
-        !note_transient_sync_failure(&pool, "jira", "blip")
+        !note_transient_sync_failure(&pool, "leak_b", "blip")
             .await
             .unwrap(),
-        "inside the window must stay silent"
+        "provider b is on its FIRST failure and must be unaffected by a's streak"
     );
+}
 
-    set_last_sync(&pool, "jira", "-7 hours").await;
+/// A never-synced provider (no `pm_sync_state` row at all) follows the same rule.
+///
+/// It used to need its own branch, because an age test on a missing row no-opped
+/// forever - exactly on the installs that most needed it, someone who just
+/// connected and whose network blocks the provider. Counting attempts removes
+/// that special case entirely, and this pins that it really is gone.
+#[tokio::test]
+async fn a_never_synced_provider_escalates_on_the_same_streak() {
+    let pool = make_db().await;
+    fresh_streak("virgin");
+    // Deliberately NO set_last_sync: there is no row.
+
+    for _ in 1..TRANSIENT_ESCALATION_ATTEMPTS {
+        assert!(!note_transient_sync_failure(&pool, "virgin", "dns error")
+            .await
+            .unwrap());
+    }
     assert!(
-        !note_transient_sync_failure(&pool, "jira", "blip")
+        note_transient_sync_failure(&pool, "virgin", "dns error")
             .await
             .unwrap(),
-        "the first failure outside the window still gets one retry of grace"
+        "a provider that never synced must still escalate on a real streak"
     );
+}
+
+/// The test seam exists and drives escalation, so a future test does not have to
+/// know the threshold's value to exercise the loud path.
+#[tokio::test]
+async fn the_streak_can_be_forced_for_tests() {
+    let pool = make_db().await;
+    set_transient_streak_for_test("forced", TRANSIENT_ESCALATION_ATTEMPTS - 1);
     assert!(
-        note_transient_sync_failure(&pool, "jira", "blip")
+        note_transient_sync_failure(&pool, "forced", "blip")
             .await
             .unwrap(),
-        "the second consecutive failure outside the window must escalate"
+        "one more failure on top of a forced near-threshold streak must escalate"
     );
+    reset_transient_streak("forced");
 }
 
 /// The escalation must self-heal: once the provider is reachable again the
@@ -353,10 +242,10 @@ async fn the_escalation_window_holds_on_both_sides() {
 #[tokio::test]
 async fn a_successful_sync_clears_an_escalated_notice() {
     let pool = make_db().await;
-    // Two failures: the first is the never-synced grace attempt.
-    note_transient_sync_failure(&pool, "github", "dns error")
-        .await
-        .unwrap();
+    // Drive the streak to one below the threshold, so the next failure is the
+    // one that escalates. Forced rather than looped so the test does not have to
+    // restate the threshold's value.
+    set_transient_streak_for_test("github", TRANSIENT_ESCALATION_ATTEMPTS - 1);
     note_transient_sync_failure(&pool, "github", "dns error")
         .await
         .unwrap();
@@ -370,16 +259,16 @@ async fn a_successful_sync_clears_an_escalated_notice() {
     );
 }
 
-/// The coupling that makes escalation reachable at all: recording an error
-/// must NEVER write a fresh `last_synced_at`.
+/// Recording an error must NEVER write a fresh `last_synced_at`.
 ///
-/// Every provider gates its whole fetch on that column being recent, and
-/// [`note_transient_sync_failure`] keys its escalation clock on the SAME
-/// column. So stamping `now` here would do two invisible things at once:
-/// suppress the next tick's retry, and reset the escalation clock on every
-/// failure so the threshold is never reached. The provider would go silent
-/// permanently, which is the exact regression this whole change exists to
-/// prevent. `azure_devops` had precisely this bug in its own `stamp_error`.
+/// Every provider gates its whole fetch on that column being recent, so stamping
+/// `now` while recording a FAILURE would suppress the next attempt's retry - the
+/// provider would go quiet permanently, having convinced itself it had just
+/// succeeded. `azure_devops` had precisely this bug in its own `stamp_error`.
+///
+/// This used to also guard the escalation clock, which keyed on the same column.
+/// That clock is gone (escalation counts consecutive attempts now), but the
+/// retry-suppression half is untouched and is the reason this still matters.
 #[tokio::test]
 async fn recording_an_error_never_looks_like_a_successful_sync() {
     let pool = make_db().await;
@@ -397,15 +286,24 @@ async fn recording_an_error_never_looks_like_a_successful_sync() {
         "an error must not be recorded as a sync: {last}"
     );
 
-    // And on a row that already holds a real (old) success, recording a
-    // failure must leave the clock alone rather than pushing it forward.
+    // And on a row that already holds a real (old) success, recording a failure
+    // must leave that timestamp alone rather than pushing it forward.
     set_last_sync(&pool, "github", "-10 hours").await;
-    stamp_sync_error(&pool, "github", "boom").await.unwrap();
-    assert!(
-        note_transient_sync_failure(&pool, "github", "unreachable")
+    let (before,): (String,) =
+        sqlx::query_as("SELECT last_synced_at FROM pm_sync_state WHERE provider = 'github'")
+            .fetch_one(&pool)
             .await
-            .unwrap(),
-        "recording an error must not reset the escalation clock"
+            .unwrap();
+    stamp_sync_error(&pool, "github", "boom").await.unwrap();
+    let (after,): (String,) =
+        sqlx::query_as("SELECT last_synced_at FROM pm_sync_state WHERE provider = 'github'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        before, after,
+        "recording an error must not move last_synced_at - doing so would make the \
+         provider skip its next fetch as though it had just succeeded"
     );
 }
 
@@ -451,12 +349,25 @@ fn status_err(status: u16, body: &str) -> anyhow::Error {
 #[tokio::test]
 async fn a_transient_failure_at_the_catch_all_raises_no_notice() {
     let pool = make_db().await;
-    set_last_sync(&pool, "azure_devops", "-5 minutes").await;
+    // A UNIQUE provider key, not a real provider name. The consecutive-failure
+    // streak lives in a process-global map, and several tests in this file drive
+    // transient failures through `azure_devops`; sharing the key let one test's
+    // failures count toward another's streak under cargo's parallel threads.
+    // Nothing here depends on the name being a real provider - the assertion is
+    // that no notice is raised at all.
+    reset_transient_streak("catchall_transient");
+    set_last_sync(&pool, "catchall_transient", "-5 minutes").await;
 
-    record_sync_failure(&pool, "azure_devops", "wiql", &status_err(503, "down")).await;
+    record_sync_failure(
+        &pool,
+        "catchall_transient",
+        "wiql",
+        &status_err(503, "down"),
+    )
+    .await;
 
     assert!(
-        notice(&pool, "pm.azure_devops").await.is_none(),
+        notice(&pool, "pm.catchall_transient").await.is_none(),
         "a 503 reaching the catch-all must not raise a credentials banner"
     );
 }
@@ -516,14 +427,21 @@ async fn recording_the_same_failure_twice_cannot_degrade_it() {
 #[tokio::test]
 async fn re_reporting_a_transient_failure_still_raises_nothing() {
     let pool = make_db().await;
-    set_last_sync(&pool, "azure_devops", "-5 minutes").await;
+    // A UNIQUE provider key, not a real provider name. The consecutive-failure
+    // streak lives in a process-global map, and several tests in this file drive
+    // transient failures through `azure_devops`; sharing the key let one test's
+    // failures count toward another's streak under cargo's parallel threads.
+    // Nothing here depends on the name being a real provider - the assertion is
+    // that no notice is raised at all.
+    reset_transient_streak("rereport_transient");
+    set_last_sync(&pool, "rereport_transient", "-5 minutes").await;
     let err = status_err(503, "down");
 
-    record_sync_failure(&pool, "azure_devops", "wiql", &err).await;
-    record_sync_failure(&pool, "azure_devops", "refresh", &err).await;
+    record_sync_failure(&pool, "rereport_transient", "wiql", &err).await;
+    record_sync_failure(&pool, "rereport_transient", "refresh", &err).await;
 
     assert!(
-        notice(&pool, "pm.azure_devops").await.is_none(),
+        notice(&pool, "pm.rereport_transient").await.is_none(),
         "a re-reported blip must stay silent"
     );
 }
@@ -596,80 +514,4 @@ async fn every_default_remedy_names_a_place_in_the_app() {
             "{provider} remedy asks for a file edit or a CLI command: {remedy}"
         );
     }
-}
-
-/// The grace write must not clobber a sync that SUCCEEDED under it.
-///
-/// `note_transient_sync_failure` reads the row's state, then writes the epoch
-/// sentinel in a SEPARATE statement. `meridian ticket-update` opens its own
-/// pool to this file and runs `run_pm_force_sync` while the daemon's poll loop
-/// runs `run_pm_sync`, so a success can land between those two - and the write
-/// used to be unconditional, stamping the fresh `last_synced_at` back to the
-/// epoch. The provider then read as never-recently-synced and the NEXT failure
-/// escalated a user-visible notice for a tracker that was working.
-///
-/// Simulating the interleaving directly needs a hook that does not exist, so
-/// this drives the same end state the racer would leave: a row that is fresh
-/// at the moment of the write. The conditional UPDATE must decline it.
-#[tokio::test]
-async fn a_concurrent_successful_sync_is_not_stamped_back_to_the_epoch() {
-    let pool = make_db().await;
-    // The state the winner of the race leaves behind: a genuinely recent sync.
-    set_last_sync(&pool, "jira", "-1 minutes").await;
-
-    mark_first_stale_failure(&pool, "jira", "dns error")
-        .await
-        .unwrap();
-
-    let (last,): (String,) =
-        sqlx::query_as("SELECT last_synced_at FROM pm_sync_state WHERE provider = 'jira'")
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-    assert_ne!(
-        last, "1970-01-01T00:00:00Z",
-        "a successful sync must not be stamped back to the epoch by the grace write"
-    );
-}
-
-/// The grace write still does its job on the case it exists for: a provider
-/// that genuinely went stale, with no error recorded.
-#[tokio::test]
-async fn a_clean_stale_transition_still_gets_its_grace_tick() {
-    let pool = make_db().await;
-    set_last_sync(&pool, "jira", "-7 hours").await;
-
-    mark_first_stale_failure(&pool, "jira", "dns error")
-        .await
-        .unwrap();
-
-    let (last,): (String,) =
-        sqlx::query_as("SELECT last_synced_at FROM pm_sync_state WHERE provider = 'jira'")
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-    assert_eq!(last, "1970-01-01T00:00:00Z");
-}
-
-/// A row that already carries an error is not a clean stale transition, so the
-/// grace write must decline it - the escalation clock is already running.
-#[tokio::test]
-async fn a_row_with_an_error_does_not_get_a_grace_tick() {
-    let pool = make_db().await;
-    set_last_sync(&pool, "jira", "-7 hours").await;
-    sqlx::query("UPDATE pm_sync_state SET last_error = 'boom' WHERE provider = 'jira'")
-        .execute(&pool)
-        .await
-        .unwrap();
-
-    mark_first_stale_failure(&pool, "jira", "dns error")
-        .await
-        .unwrap();
-
-    let (last,): (String,) =
-        sqlx::query_as("SELECT last_synced_at FROM pm_sync_state WHERE provider = 'jira'")
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-    assert_ne!(last, "1970-01-01T00:00:00Z");
 }

--- a/src/intelligence/sync_lock.rs
+++ b/src/intelligence/sync_lock.rs
@@ -1,0 +1,238 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! Cross-process deduplication for PM task sync.
+//!
+//! PM sync is on-demand (see [`crate::intelligence::run_pm_sync`]): the tray
+//! triggers it by spawning `meridian pm-sync` when the user connects a tracker
+//! or opens the dashboard, and the daemon triggers it before a worklog drafting
+//! sweep. Several of those can land within a second of each other - opening the
+//! dashboard while a drafting sweep is starting is the ordinary case, not a
+//! corner one - and each would independently read `pm_sync_state`, independently
+//! decide the cache is stale, and fetch the same board again.
+//!
+//! This is the ONE mechanism that stops that. It is deliberately a **file** lock
+//! and not a table:
+//!
+//! * The reverted `pm_sync_requests` outbox (PRs #909/#910) coordinated the tray
+//!   and the daemon through `meridian.db`, and the tray's read-back of the
+//!   outcome is what failed in production with `SQLITE_IOERR_SHORT_READ` (522) -
+//!   a short read while the daemon truncated the WAL on shutdown. Coordination
+//!   state that lives outside the database cannot fail that way, and needs no
+//!   migration, so shipping it cannot damage anyone's data.
+//! * A crashed holder releases automatically: the lock dies with its fd. No
+//!   stale-row cleanup, no `claimed_at` timestamps to reap.
+//!
+//! # Who calls this
+//! [`crate::intelligence::run_pm_sync`] (gated - skips on contention) and
+//! [`crate::intelligence::run_pm_force_sync`] (forced - waits, then proceeds).
+//!
+//! # Related
+//! - [`meridian_oauth::store::lock_provider`] - the same advisory-file-lock
+//!   pattern, guarding the rotating OAuth refresh token. That one serialises
+//!   *token* writes and is unaffected by this module; a duplicate fetch is
+//!   wasteful, a duplicate token refresh is destructive, so they stay separate
+//!   locks with different contention policies.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+/// Held for the duration of one sync. Releasing is `Drop` (the fd closes), so a
+/// panic or a killed process frees it without any cleanup path.
+#[derive(Debug)]
+pub struct SyncLock {
+    _file: std::fs::File,
+}
+
+/// `~/.meridian/pm-sync.lock`. Alongside the OAuth store's lock files rather
+/// than in a temp dir: a per-user path that survives reboots and is not shared
+/// between accounts on one machine.
+fn lock_path() -> Result<PathBuf> {
+    let home = meridian_core::paths::home_dir()
+        .context("resolving the home directory for the PM sync lock")?;
+    Ok(home.join(".meridian").join("pm-sync.lock"))
+}
+
+/// Open (creating if needed) the lock file. Split out so both acquire paths
+/// share it and neither can drift on flags - `truncate(false)` matters: the file
+/// is a lock, never a payload, and truncating it would be a pointless write on
+/// every sync.
+fn open_lock_file() -> Result<std::fs::File> {
+    let path = lock_path()?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("creating {} for the PM sync lock", dir.display()))?;
+    }
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)
+        .with_context(|| format!("opening PM sync lock {}", path.display()))
+}
+
+/// Try to take the lock without waiting.
+///
+/// `Ok(Some(_))` - acquired, this process owns the sync.
+/// `Ok(None)`   - another process is syncing right now; the caller should SKIP,
+///                because that run is already doing the work this one wanted.
+/// `Err(_)`     - the lock could not be evaluated at all (no home dir,
+///                unwritable `~/.meridian`).
+///
+/// Used by the gated path. Skipping on contention is the whole point: two
+/// concurrent gated syncs would fetch the same board twice.
+pub fn try_acquire() -> Result<Option<SyncLock>> {
+    let file = open_lock_file()?;
+    match file.try_lock() {
+        Ok(()) => Ok(Some(SyncLock { _file: file })),
+        Err(std::fs::TryLockError::WouldBlock) => Ok(None),
+        Err(std::fs::TryLockError::Error(e)) => {
+            Err(anyhow::Error::new(e).context("evaluating the PM sync lock"))
+        }
+    }
+}
+
+/// Wait up to `timeout` for the lock, then give up.
+///
+/// `Ok(Some(_))` - acquired. `Ok(None)` - still held when the budget ran out.
+///
+/// Used by the FORCED path, which must not silently skip: a user pressing "Sync
+/// now" has to get a sync. Waiting is nearly always brief (a gated sync is one
+/// HTTP fetch per provider), and a caller that times out is told so rather than
+/// racing the holder - see [`crate::intelligence::run_pm_force_sync`].
+///
+/// Polls a non-blocking try-lock rather than blocking on `flock`, so the async
+/// executor is never parked - identical reasoning to
+/// [`meridian_oauth::store::lock_provider`].
+pub async fn acquire_waiting(timeout: std::time::Duration) -> Result<Option<SyncLock>> {
+    let step = std::time::Duration::from_millis(100);
+    let mut waited = std::time::Duration::ZERO;
+    loop {
+        if let Some(guard) = try_acquire()? {
+            return Ok(Some(guard));
+        }
+        if waited >= timeout {
+            return Ok(None);
+        }
+        tokio::time::sleep(step).await;
+        waited += step;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serialises the tests below. Both mutate `HOME` (process-global) to point
+    /// `lock_path` at a scratch dir, and cargo runs tests in parallel threads -
+    /// so without this one test's `set_var` lands mid-flight in the other and it
+    /// contends on the WRONG lock file. That is not hypothetical: it is exactly
+    /// how these two first failed. Mirrors `meridian_oauth::env_test_guard`.
+    fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        LOCK.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    /// Point `HOME` at a fresh scratch dir for the duration of a test, restoring
+    /// it afterwards so a failure cannot leak a bogus `HOME` into later tests.
+    struct ScratchHome {
+        dir: std::path::PathBuf,
+        prev: Option<std::ffi::OsString>,
+        _guard: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl ScratchHome {
+        fn new(tag: &str) -> Self {
+            let guard = env_guard();
+            let dir = std::env::temp_dir()
+                .join(format!("meridian_synclock_{tag}_{}", std::process::id()));
+            std::fs::create_dir_all(&dir).unwrap();
+            let prev = std::env::var_os("HOME");
+            std::env::set_var("HOME", &dir);
+            Self {
+                dir,
+                prev,
+                _guard: guard,
+            }
+        }
+    }
+
+    impl Drop for ScratchHome {
+        fn drop(&mut self) {
+            match self.prev.take() {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            std::fs::remove_dir_all(&self.dir).ok();
+        }
+    }
+
+    /// Two acquisitions contend and the second is refused, then succeeds once
+    /// the first is dropped. `flock` is per-open-file-description, so two opens
+    /// in ONE process contend exactly as two processes would - which is what
+    /// makes this testable without spawning anything.
+    #[test]
+    fn a_second_acquire_is_refused_until_the_first_drops() {
+        let _home = ScratchHome::new("basic");
+
+        let held = try_acquire().unwrap();
+        assert!(held.is_some(), "the first acquire must succeed");
+
+        let contended = try_acquire().unwrap();
+        assert!(
+            contended.is_none(),
+            "a gated caller must be refused while another sync holds the lock, \
+             not granted a duplicate"
+        );
+
+        drop(held);
+        let reacquired = try_acquire().unwrap();
+        assert!(
+            reacquired.is_some(),
+            "the lock must be free again once the holder drops it"
+        );
+    }
+
+    /// The waiting path returns `Ok(None)` rather than erroring or hanging when
+    /// the budget expires - the forced caller needs to distinguish "I have the
+    /// lock" from "someone else still does" to report honestly.
+    #[test]
+    fn waiting_gives_up_with_none_when_the_budget_expires() {
+        let _home = ScratchHome::new("waiting");
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        let held = try_acquire().unwrap().expect("first acquire");
+        let timed_out = rt.block_on(acquire_waiting(std::time::Duration::from_millis(250)));
+        assert!(
+            matches!(timed_out, Ok(None)),
+            "a contended wait must expire as Ok(None), got {timed_out:?}"
+        );
+        drop(held);
+    }
+
+    /// The waiting path takes a FREE lock immediately rather than sleeping out
+    /// its budget - the forced path runs on a user's click, so a 20 s wait for
+    /// an uncontended lock would be a visible regression.
+    #[test]
+    fn waiting_acquires_immediately_when_uncontended() {
+        let _home = ScratchHome::new("free");
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        let started = std::time::Instant::now();
+        let got = rt.block_on(acquire_waiting(std::time::Duration::from_secs(20)));
+        assert!(
+            matches!(got, Ok(Some(_))),
+            "an uncontended wait must acquire, got {got:?}"
+        );
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(1),
+            "an uncontended wait must not sleep - took {:?}",
+            started.elapsed()
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -373,6 +373,38 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    // `meridian pm-sync` — the GATED sibling of `tasks-sync`: sync all configured
+    // PM providers, but honour each provider's staleness gate so a fresh cache is
+    // a cheap no-op. This is what every ON-DEMAND trigger spawns (tracker
+    // connected, dashboard opened), which is why it must not be `tasks-sync`:
+    // those triggers can fire repeatedly within seconds and a forced fetch each
+    // time would be exactly the API hammering the timer used to do.
+    //
+    // Exits 0 whether it fetched, skipped as fresh, or skipped because another
+    // sync held the dedup lock — all three are successful outcomes for a
+    // best-effort trigger, and only a DB that cannot be opened is a real failure.
+    if std::env::args().nth(1).as_deref() == Some("pm-sync") {
+        let cfg = Config::from_env();
+        match setup_db(&cfg.meridian_db_uri()).await {
+            Ok(pool) => {
+                if let Err(e) = run_pm_sync(&pool, &cfg).await {
+                    eprintln!("pm-sync: {}", meridian::errors::chain(&e));
+                }
+                // Close the pool explicitly, same as `tasks-sync`: this is a
+                // short-lived process writing the SAME meridian.db the daemon and
+                // tray hold open, and dropping a pool without closing it can
+                // leave the WAL un-checkpointed behind a connection the OS is
+                // still tearing down.
+                pool.close().await;
+            }
+            Err(e) => {
+                eprintln!("pm-sync: open db: {e:#}");
+                std::process::exit(1);
+            }
+        }
+        return Ok(());
+    }
+
     // `meridian ticket-update --provider P --key K --field F --value V` — apply
     // ONE board-hygiene fix to the real tracker (due date, assignee, label, …).
     // Prints a JSON result the UI reads: {"status":"applied"} or
@@ -694,6 +726,18 @@ async fn main() -> Result<()> {
         let obs_guard = observability::init("meridian-rust").ok();
         match setup_db(&cfg.meridian_db_uri()).await {
             Ok(pool) => {
+                // Refresh the board BEFORE matching, now that nothing does it on
+                // a timer. A stale `pm_tasks` is not a cosmetic problem here: it
+                // is what silently binds an hour of work to a ticket that was
+                // closed or reassigned hours ago. Gated (a fresh cache no-ops)
+                // and log-and-continue — drafting from a slightly stale board
+                // beats not drafting at all.
+                if let Err(e) = run_pm_sync(&pool, &cfg).await {
+                    tracing::warn!(
+                        error = %meridian::errors::chain(&e),
+                        "worklog-generate: pre-draft PM sync failed — matching against the cached board"
+                    );
+                }
                 match meridian::pm_worklog::generate(&pool, &cfg, &day, &task_id).await {
                     Ok(mut draft) => {
                         // A matched draft carries a target_key we can link even
@@ -1355,9 +1399,12 @@ async fn main() -> Result<()> {
     }
 
     // 7c. Run ETL once immediately before entering the loop.
-    //     Re-read config so that any settings.json present at startup takes effect.
+    //
+    //     No `Config::from_env()` re-read here any more: it existed only to hand
+    //     a fresh config to the startup PM sync that used to live at the end of
+    //     this block, and nothing else in the block reads it. ETL and the
+    //     retention sweep take the pool alone.
     {
-        let cfg = Config::from_env();
         let startup_tick = tracing::info_span!("startup_tick");
         *etl_tick_span.lock().unwrap_or_else(|e| e.into_inner()) = Some(startup_tick.clone());
         let _guard = startup_tick.enter();
@@ -1381,12 +1428,11 @@ async fn main() -> Result<()> {
                 tracing::warn!(error = %meridian::errors::chain(&e), "capture retention sweep failed");
             }
         }
-        if let Err(e) = run_pm_sync(&meridian, &cfg).await {
-            tracing::error!(
-                error = %meridian::errors::chain(&e),
-                "intelligence run failed"
-            );
-        }
+        // No startup PM sync either, for the same reason as the poll tick above:
+        // launchd `KeepAlive` restarts this process on every wake, so a
+        // sync-on-boot IS a wake-triggered token refresh wearing different
+        // clothes. Nothing at startup needs a fresh board - `pm_tasks_present`
+        // and `daily_plan::maybe_nudge` only check EXISTENCE, not freshness.
     }
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
@@ -1605,17 +1651,38 @@ async fn main() -> Result<()> {
                     tracing::debug!(error = %meridian::errors::chain(&e), "notification response consume skipped");
                 }
 
-                // Refresh the PM task cache (pm_tasks) every tick — interval-gated
-                // per provider (~5 min), so this is a cheap no-op most ticks. The
-                // legacy drafting driver that used to trigger this before every
-                // pass was retired when the worklog pipeline moved to the
-                // clock-aligned Python trigger, which never calls this itself —
-                // leaving pm_tasks (and hence a ticket's title on the timeline)
-                // stuck at whatever it was at the last daemon restart. This is
-                // the only thing that keeps it live during normal operation.
-                if let Err(e) = run_pm_sync(&meridian, &cfg).await {
-                    tracing::warn!(error = %meridian::errors::chain(&e), "pm_tasks refresh failed — using cached tasks");
-                }
+        // ── NO PM SYNC ON THE POLL TICK. ────────────────────────────────────
+        //
+        // This used to call `run_pm_sync` every tick (~60 s), interval-gated per
+        // provider to ~5 min. It was removed because the timer, not the network,
+        // is what was permanently destroying production users' Jira grants.
+        //
+        // macOS dark-wakes a sleeping machine every 15-16 minutes. The daemon
+        // resumed, found the OAuth access token expired, and POSTed a refresh.
+        // Atlassian rotated the refresh token and replied - and the machine
+        // re-suspended before the response was read. `reqwest`'s timeout could
+        // not save it: the timeout is `Instant`-based and the monotonic clock
+        // does not advance while the system is asleep, so the request simply
+        // hung. On the NEXT dark wake, 15-16 minutes later, the socket was dead
+        // and the retry went out with the OLD refresh token - now past
+        // Atlassian's 10-minute reuse leeway. `invalid_grant`, classified
+        // terminal, grant dead forever, user sees "refresh_token is invalid".
+        //
+        // The dark-wake interval being LONGER than the leeway is why no retry
+        // policy can fix this from inside the daemon; see
+        // `~/.claude` notes and `meridian-oauth::jira::ensure_fresh`.
+        //
+        // A sleeping machine has no work to do, so it must attempt no token
+        // refreshes. Nothing here needs `pm_tasks` fresh on a clock either: the
+        // hourly worklog fold never reads it, and the one place that matches
+        // sessions to tickets now syncs for itself
+        // (`pm_worklog::auto_generate::sweep::draft_qualifying_tasks`). The
+        // remaining triggers are all things a PRESENT user did - connecting a
+        // tracker, opening the dashboard, pressing Sync now, a tracker write -
+        // and they live in `tray/src-tauri/src/commands/tasks.rs`.
+        //
+        // Do not reintroduce a timer here. If something needs a fresher board,
+        // give it its own trigger and let `intelligence::sync_lock` dedupe it.
             }
         }
     }

--- a/src/pm_worklog/auto_generate/mod.rs
+++ b/src/pm_worklog/auto_generate/mod.rs
@@ -98,6 +98,34 @@ mod sweep;
 
 use sweep::draft_qualifying_tasks;
 
+/// Whether a sweep may refresh the PM board before matching work to tickets.
+///
+/// Exists because "refresh the board first" is correct for one caller and
+/// actively unsafe for the other, and the difference is not visible from inside
+/// the sweep.
+///
+/// Refreshing the board can trigger an OAuth access-token refresh, and Atlassian
+/// rotates the refresh token on every use - so a refresh whose response is lost
+/// because the machine suspended mid-request destroys the grant permanently (the
+/// full mechanism is in `meridian_oauth::refresh_journal`). launchd `KeepAlive`
+/// restarts the daemon on every wake, which makes the pipeline's STARTUP pass
+/// wake-triggered by construction: exactly the condition where a suspend can land
+/// mid-request. Its clock-aligned tick is different - it fires at the hour the
+/// user chose for their end-of-day pass, when they are far more likely to be
+/// sitting at the machine.
+///
+/// So the startup pass drafts against the cached board ([`RefreshBoard::No`]) and
+/// the chosen-hour tick refreshes first ([`RefreshBoard::Yes`]). A slightly stale
+/// board costs at worst one mis-bound worklog the user can correct; a destroyed
+/// grant costs a manual re-authentication and every sync until they notice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefreshBoard {
+    /// Refresh `pm_tasks` first. For triggers where a user is plausibly present.
+    Yes,
+    /// Draft against whatever is cached. For anything a wake can trigger.
+    No,
+}
+
 /// Fixed qualifying threshold — a day-task needs more than this many tracked
 /// minutes to be auto-drafted. Not user-configurable: only WHEN Meridian checks
 /// (`worklog_auto_generate_time`) is a choice; WHICH tasks qualify is not.
@@ -120,7 +148,12 @@ fn parse_hh_mm(s: &str) -> Option<(u32, u32)> {
 /// time) — see the module docs. Tasks are processed one at a time, in order —
 /// never concurrently.
 #[tracing::instrument(skip(pool, config))]
-pub async fn maybe_auto_generate(pool: &SqlitePool, config: &Config, day_local: &str) {
+pub async fn maybe_auto_generate(
+    pool: &SqlitePool,
+    config: &Config,
+    day_local: &str,
+    refresh: RefreshBoard,
+) {
     let span = tracing::info_span!(
         "worklog.auto_generate.run",
         day = day_local,
@@ -132,10 +165,10 @@ pub async fn maybe_auto_generate(pool: &SqlitePool, config: &Config, day_local: 
         tasks_drafted = Empty,
         tasks_failed = Empty,
     );
-    run(pool, config, day_local).instrument(span).await
+    run(pool, config, day_local, refresh).instrument(span).await
 }
 
-async fn run(pool: &SqlitePool, config: &Config, day_local: &str) {
+async fn run(pool: &SqlitePool, config: &Config, day_local: &str, refresh: RefreshBoard) {
     let current_span = tracing::Span::current();
 
     let settings = meridian_core::settings::load_runtime_settings();
@@ -159,7 +192,7 @@ async fn run(pool: &SqlitePool, config: &Config, day_local: &str) {
     }
     current_span.record("gate", "ran");
 
-    draft_qualifying_tasks(pool, config, day_local, &current_span).await;
+    draft_qualifying_tasks(pool, config, day_local, &current_span, refresh).await;
 }
 
 /// The "Generate now" path — the same day-task draft sweep as [`maybe_auto_generate`],
@@ -184,7 +217,9 @@ pub async fn generate_now(pool: &SqlitePool, config: &Config, day_local: &str) {
     async {
         let current_span = tracing::Span::current();
         current_span.record("gate", "ran");
-        draft_qualifying_tasks(pool, config, day_local, &current_span).await;
+        // On-demand: the user pressed Generate, so they are unambiguously present
+        // and this refresh cannot be a wake-triggered one.
+        draft_qualifying_tasks(pool, config, day_local, &current_span, RefreshBoard::Yes).await;
     }
     .instrument(span)
     .await
@@ -246,6 +281,45 @@ mod tests {
         assert!(
             !code.contains(&gate),
             "the tracker gate is back - it disables auto-generate for every solo user"
+        );
+    }
+
+    /// THE WAKE-TRIGGERED PASS MUST NOT REFRESH THE BOARD.
+    ///
+    /// Source-level, because getting this wrong is silent: the startup pass would
+    /// simply work, refresh the board, and occasionally destroy an Atlassian grant
+    /// when the machine re-suspended mid-token-exchange. launchd `KeepAlive`
+    /// restarts the daemon on every wake, so `run_loop`'s pre-loop
+    /// `end_of_day_pass` IS the wake path - see [`RefreshBoard`].
+    ///
+    /// Pins the pairing rather than the values alone: the startup call must pass
+    /// `No` and the clock-aligned tick must pass `Yes`. A future edit that
+    /// "simplifies" them to one shared argument fails here.
+    #[test]
+    fn the_startup_pass_never_refreshes_and_the_chosen_hour_tick_does() {
+        let src = include_str!("../../worklog_pipeline.rs");
+        let code: String = src
+            .lines()
+            .filter(|l: &&str| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let no_calls = code.matches("RefreshBoard::No").count();
+        let yes_calls = code.matches("RefreshBoard::Yes").count();
+        assert_eq!(
+            no_calls, 1,
+            "exactly one end_of_day_pass call - the wake-triggered startup one - \
+             may pass RefreshBoard::No; found {no_calls}"
+        );
+        assert_eq!(
+            yes_calls, 1,
+            "exactly one end_of_day_pass call - the chosen-hour tick - may pass \
+             RefreshBoard::Yes; found {yes_calls}"
+        );
+        // And no call may omit the decision by defaulting it.
+        assert!(
+            !code.contains("end_of_day_pass(&pool, &full_cfg)."),
+            "every end_of_day_pass call must state its RefreshBoard explicitly"
         );
     }
 }

--- a/src/pm_worklog/auto_generate/mod.rs
+++ b/src/pm_worklog/auto_generate/mod.rs
@@ -93,7 +93,10 @@ use tracing::field::Empty;
 use tracing::Instrument;
 
 use crate::config::Config;
-use crate::pm_worklog;
+
+mod sweep;
+
+use sweep::draft_qualifying_tasks;
 
 /// Fixed qualifying threshold — a day-task needs more than this many tracked
 /// minutes to be auto-drafted. Not user-configurable: only WHEN Meridian checks
@@ -187,267 +190,9 @@ pub async fn generate_now(pool: &SqlitePool, config: &Config, day_local: &str) {
     .await
 }
 
-/// What one sweep did. Returned rather than only recorded onto the span so the
-/// behaviour is assertable: "did this run at all" and "did it early-return" are
-/// otherwise indistinguishable from outside, which is exactly how a tracker gate
-/// silently disabled the whole feature for solo users once already.
-#[derive(Debug, Default, PartialEq, Eq)]
-struct SweepCounts {
-    total: usize,
-    qualifying: u32,
-    already_drafted: u32,
-    drafted: u32,
-    failed: u32,
-}
-
-/// Draft a worklog for every qualifying, not-yet-drafted day-task of `day_local`,
-/// recording per-run counts onto `span` and returning them. The shared body of
-/// [`maybe_auto_generate`] (gated on the clock) and [`generate_now`] (on demand); it
-/// assumes its caller has already decided a run is warranted.
-///
-/// Deliberately NOT gated on a connected tracker - a personal day-task is matched and
-/// drafted like any ticket, and only the propose branch needs one (it already fails
-/// per-task). See [`neither_sweep_is_gated_on_a_connected_tracker`].
-async fn draft_qualifying_tasks(
-    pool: &SqlitePool,
-    config: &Config,
-    day_local: &str,
-    span: &tracing::Span,
-) -> SweepCounts {
-    let tasks = match meridian_core::day_tasks::get_day_tasks(pool, day_local).await {
-        Ok(resp) => resp.tasks,
-        Err(e) => {
-            tracing::warn!(
-                day = day_local, error = %e,
-                "worklog: auto-generate day-task read failed — skipping this run"
-            );
-            return SweepCounts::default();
-        }
-    };
-    span.record("tasks_total", tasks.len());
-    let total = tasks.len();
-
-    let mut qualifying = 0u32;
-    let mut already_drafted = 0u32;
-    let mut drafted = 0u32;
-    let mut failed = 0u32;
-
-    for task in tasks {
-        if task.minutes < QUALIFYING_MINUTES {
-            continue;
-        }
-        qualifying += 1;
-
-        // Already drafted — by an earlier auto-generate run, or by the user
-        // clicking "Generate worklog" themselves. Either way this task is now the
-        // user's to drive (Regenerate in the panel), never auto-generate's again.
-        match meridian_core::day_task_worklogs::get_day_task_worklog(pool, day_local, &task.id)
-            .await
-        {
-            Ok(Some(_)) => {
-                already_drafted += 1;
-                continue;
-            }
-            Ok(None) => {}
-            Err(e) => {
-                failed += 1;
-                tracing::warn!(
-                    day = day_local, task_id = %task.id, error = %e,
-                    "worklog: auto-generate existing-draft check failed — skipping this task this run"
-                );
-                continue;
-            }
-        }
-
-        tracing::info!(
-            day = day_local, task_id = %task.id, minutes = task.minutes,
-            "worklog: threshold crossed — drafting"
-        );
-        match pm_worklog::generate(pool, config, day_local, &task.id).await {
-            Ok(draft) => {
-                drafted += 1;
-                tracing::info!(
-                    day = day_local, task_id = %task.id, state = draft.state,
-                    "worklog: auto-generated (draft only — never posted)"
-                );
-            }
-            Err(e) => {
-                failed += 1;
-                tracing::warn!(
-                    day = day_local, task_id = %task.id, error = %e,
-                    "worklog: auto-generate failed — the user can still generate it manually"
-                );
-            }
-        }
-    }
-
-    span.record("tasks_qualifying", qualifying);
-    span.record("tasks_already_drafted", already_drafted);
-    span.record("tasks_drafted", drafted);
-    span.record("tasks_failed", failed);
-    tracing::info!(
-        day = day_local,
-        qualifying,
-        already_drafted,
-        drafted,
-        failed,
-        "worklog: auto-generate run complete"
-    );
-
-    SweepCounts {
-        total,
-        qualifying,
-        already_drafted,
-        drafted,
-        failed,
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{draft_qualifying_tasks, parse_hh_mm, SweepCounts, QUALIFYING_MINUTES};
-    use crate::config::Config;
-    use sqlx::sqlite::SqlitePoolOptions;
-    use sqlx::SqlitePool;
-
-    const DAY: &str = "2026-08-07";
-
-    /// The two tables the sweep reads: day-tasks to enumerate, worklogs to skip
-    /// ones already drafted. `pm_providers` is a CONFIG field, not a table, so a
-    /// tracker-less user is modelled by the empty `Config` below.
-    async fn seeded() -> SqlitePool {
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect("sqlite::memory:")
-            .await
-            .unwrap();
-        for ddl in [
-            "CREATE TABLE day_tasks (day_local TEXT NOT NULL, task_id TEXT NOT NULL, \
-                title TEXT, summary TEXT, hours_json TEXT, segments_json TEXT, \
-                minutes INTEGER, status TEXT, linked_ticket TEXT, \
-                PRIMARY KEY (day_local, task_id))",
-            // Mirrors `meridian-core/src/readers/day_task_worklogs/tests.rs`'s fixture -
-            // `get_day_task_worklog` reads the targets table too, and a column short of
-            // it the read fails and every task counts as `failed` rather than
-            // `already_drafted`, which would make this test pass for the wrong reason.
-            "CREATE TABLE day_task_worklogs (day_local TEXT NOT NULL, task_id TEXT NOT NULL, \
-                provider TEXT NOT NULL DEFAULT 'local', state TEXT NOT NULL DEFAULT 'drafted', \
-                update_summary TEXT NOT NULL DEFAULT '', update_json TEXT NOT NULL DEFAULT '{}', \
-                reasoning TEXT NOT NULL DEFAULT '', propose_issue_type TEXT, propose_title TEXT, \
-                propose_description TEXT, created_task_key TEXT, last_error TEXT, \
-                create_attempt_at TEXT, drafted_minutes INTEGER, \
-                created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '', \
-                PRIMARY KEY (day_local, task_id))",
-            "CREATE TABLE day_task_worklog_targets (day_local TEXT NOT NULL, \
-                task_id TEXT NOT NULL, task_key TEXT NOT NULL, provider TEXT NOT NULL, \
-                confidence REAL NOT NULL DEFAULT 0, manual INTEGER NOT NULL DEFAULT 0, \
-                position INTEGER NOT NULL DEFAULT 0, posted_comment_id TEXT, browse_url TEXT, \
-                posted_at TEXT, last_error TEXT, post_attempt_at TEXT, \
-                created_at TEXT NOT NULL DEFAULT '', update_json TEXT, \
-                PRIMARY KEY (day_local, task_id, task_key))",
-            "CREATE TABLE pm_tasks (task_key TEXT PRIMARY KEY, title TEXT NOT NULL)",
-        ] {
-            sqlx::query(ddl).execute(&pool).await.unwrap();
-        }
-        pool
-    }
-
-    async fn put_task(pool: &SqlitePool, task_id: &str, minutes: i64) {
-        sqlx::query(
-            "INSERT INTO day_tasks (day_local, task_id, title, minutes) VALUES (?, ?, ?, ?)",
-        )
-        .bind(DAY)
-        .bind(task_id)
-        .bind(format!("Task {task_id}"))
-        .bind(minutes)
-        .execute(pool)
-        .await
-        .unwrap();
-    }
-
-    async fn put_draft(pool: &SqlitePool, task_id: &str) {
-        sqlx::query("INSERT INTO day_task_worklogs (day_local, task_id) VALUES (?, ?)")
-            .bind(DAY)
-            .bind(task_id)
-            .execute(pool)
-            .await
-            .unwrap();
-    }
-
-    /// A user with NO tracker connected - the exact configuration the removed
-    /// gate used to abandon.
-    fn no_tracker_config() -> Config {
-        Config {
-            meridian_db: ":memory:".into(),
-            poll_interval_secs: 60,
-            pm_providers: Vec::new(),
-            jira_update_enabled: false,
-            jira_update_interval_s: 14_400,
-            jira_office_start_hour: 9,
-            jira_office_end_hour: 17,
-            runtime: Default::default(),
-        }
-    }
-
-    /// The functional half of [`neither_sweep_is_gated_on_a_connected_tracker`].
-    ///
-    /// That test greps the source for the gate's return; this one proves the sweep
-    /// actually walks its task list with `pm_providers` empty. The two together
-    /// close the hole: a gate written a DIFFERENT way (a different field, an early
-    /// `return` above the read) would slip past the grep, but not past this.
-    ///
-    /// Every task here is pre-drafted on purpose, so the loop reaches its
-    /// already-drafted branch and returns without ever calling `pm_worklog::generate`
-    /// - no LLM, no network, no CLI spawn. Counting the tasks it CONSIDERED is
-    /// enough: an early return yields zeroes, and nothing else does.
-    #[tokio::test]
-    async fn the_sweep_walks_its_tasks_with_no_tracker_connected() {
-        let pool = seeded().await;
-        put_task(&pool, "T1", QUALIFYING_MINUTES + 5).await;
-        put_task(&pool, "T2", QUALIFYING_MINUTES + 90).await;
-        put_draft(&pool, "T1").await;
-        put_draft(&pool, "T2").await;
-
-        let counts =
-            draft_qualifying_tasks(&pool, &no_tracker_config(), DAY, &tracing::Span::none()).await;
-
-        assert_eq!(
-            counts,
-            SweepCounts {
-                total: 2,
-                qualifying: 2,
-                already_drafted: 2,
-                drafted: 0,
-                failed: 0,
-            },
-            "a tracker-less user's tasks must still be considered"
-        );
-    }
-
-    /// The threshold still applies - "not gated on a tracker" must not become
-    /// "not gated at all".
-    #[tokio::test]
-    async fn short_tasks_are_still_below_the_threshold() {
-        let pool = seeded().await;
-        put_task(&pool, "T1", QUALIFYING_MINUTES - 1).await;
-        put_draft(&pool, "T1").await;
-
-        let counts =
-            draft_qualifying_tasks(&pool, &no_tracker_config(), DAY, &tracing::Span::none()).await;
-
-        assert_eq!(counts.total, 1);
-        assert_eq!(counts.qualifying, 0, "under the threshold, never drafted");
-        assert_eq!(counts.already_drafted, 0);
-    }
-
-    /// A day with nothing on it returns cleanly rather than erroring.
-    #[tokio::test]
-    async fn an_empty_day_sweeps_to_zero() {
-        let pool = seeded().await;
-        let counts =
-            draft_qualifying_tasks(&pool, &no_tracker_config(), DAY, &tracing::Span::none()).await;
-        assert_eq!(counts, SweepCounts::default());
-    }
+    use super::parse_hh_mm;
 
     #[test]
     fn parses_valid_times() {
@@ -474,15 +219,26 @@ mod tests {
     /// output to assert on - it just made the feature silently do nothing for every
     /// tracker-less user, in a build that otherwise looked healthy. Drafting works
     /// without a tracker (a personal day-task is matched and drafted like any
+    /// The tracker gate must not come back, in EITHER half of this module.
+    ///
+    /// Source-level because the gate was a bare early return with no observable
+    /// output to assert on - it just made the feature silently do nothing for every
+    /// tracker-less user, in a build that otherwise looked healthy. Drafting works
+    /// without a tracker (a personal day-task is matched and drafted like any
     /// ticket); only the propose branch needs one, and it already fails per-task.
+    ///
+    /// Scans `mod.rs` AND `sweep.rs`. When this module was one file the scan was
+    /// one `include_str!`; splitting it for the 500-line cap would have quietly
+    /// halved the guard's reach, leaving the sweep itself - the half that
+    /// actually enumerates tasks - uncovered while the test still passed.
     #[test]
     fn neither_sweep_is_gated_on_a_connected_tracker() {
-        let src = include_str!("auto_generate.rs");
+        let src = concat!(include_str!("mod.rs"), "\n", include_str!("sweep.rs"));
         // Comment lines dropped, not just their markers - the module doc above
         // quotes the removed gate verbatim to explain why it went.
         let code: String = src
             .lines()
-            .filter(|l| !l.trim_start().starts_with("//"))
+            .filter(|l: &&str| !l.trim_start().starts_with("//"))
             .collect::<Vec<_>>()
             .join("\n");
         // Assembled, not written out: a literal would match itself on this very line.

--- a/src/pm_worklog/auto_generate/sweep.rs
+++ b/src/pm_worklog/auto_generate/sweep.rs
@@ -1,0 +1,308 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! The auto-generate SWEEP: refresh the board, then draft a worklog for every
+//! qualifying, not-yet-drafted day-task.
+//!
+//! Split out of [`super`] purely for the 500-line file cap; the clock gate that
+//! decides WHEN a sweep runs stays there, and this is WHAT a sweep does. Both of
+//! `super`'s entry points ([`super::maybe_auto_generate`], the daily clock
+//! trigger, and [`super::generate_now`], the on-demand one) funnel through
+//! [`draft_qualifying_tasks`], which is the single place that refreshes
+//! `pm_tasks` before matching - see its body for why that call cannot live in
+//! the two callers instead.
+//!
+//! # Who calls this
+//! [`super::run`] and [`super::generate_now`], via [`draft_qualifying_tasks`].
+//! Nothing outside `auto_generate` may call it - the clock/consent gate is
+//! `super`'s job.
+//!
+//! # Related
+//! - [`crate::intelligence::run_pm_sync`] - the gated board refresh this runs
+//!   first, and [`crate::intelligence::sync_lock`] for why a concurrent sweep
+//!   and dashboard-open do not both fetch.
+//! - [`crate::pm_worklog::generate`] - the per-task draft this loop calls.
+
+use sqlx::SqlitePool;
+
+use crate::config::Config;
+use crate::pm_worklog;
+
+use super::QUALIFYING_MINUTES;
+
+/// What one sweep did. Returned rather than only recorded onto the span so the
+/// behaviour is assertable: "did this run at all" and "did it early-return" are
+/// otherwise indistinguishable from outside, which is exactly how a tracker gate
+/// silently disabled the whole feature for solo users once already.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(super) struct SweepCounts {
+    pub(super) total: usize,
+    pub(super) qualifying: u32,
+    pub(super) already_drafted: u32,
+    pub(super) drafted: u32,
+    pub(super) failed: u32,
+}
+
+/// Draft a worklog for every qualifying, not-yet-drafted day-task of `day_local`,
+/// recording per-run counts onto `span` and returning them. The shared body of
+/// [`maybe_auto_generate`] (gated on the clock) and [`generate_now`] (on demand); it
+/// assumes its caller has already decided a run is warranted.
+///
+/// Deliberately NOT gated on a connected tracker - a personal day-task is matched and
+/// drafted like any ticket, and only the propose branch needs one (it already fails
+/// per-task). See [`neither_sweep_is_gated_on_a_connected_tracker`].
+pub(super) async fn draft_qualifying_tasks(
+    pool: &SqlitePool,
+    config: &Config,
+    day_local: &str,
+    span: &tracing::Span,
+) -> SweepCounts {
+    // Refresh the board before matching work to tickets. Nothing does this on a
+    // timer any more (see `main.rs`'s poll loop), and this is the one consumer
+    // where a stale `pm_tasks` is actively harmful rather than merely cosmetic:
+    // matching against a ticket that was closed or reassigned hours ago writes a
+    // wrong worklog, which is worse than writing none.
+    //
+    // Placed HERE rather than in `maybe_auto_generate` and `generate_now`
+    // separately, so both sweeps get it from one call site and the two can never
+    // disagree about whether a run refreshed first. Gated (a fresh cache is a
+    // no-op) and log-and-continue: a failed sync must not cancel drafting.
+    if let Err(e) = crate::intelligence::run_pm_sync(pool, config).await {
+        tracing::warn!(
+            day = day_local, error = %crate::errors::chain(&e),
+            "worklog: pre-draft PM sync failed — matching against the cached board"
+        );
+    }
+    let tasks = match meridian_core::day_tasks::get_day_tasks(pool, day_local).await {
+        Ok(resp) => resp.tasks,
+        Err(e) => {
+            tracing::warn!(
+                day = day_local, error = %e,
+                "worklog: auto-generate day-task read failed — skipping this run"
+            );
+            return SweepCounts::default();
+        }
+    };
+    span.record("tasks_total", tasks.len());
+    let total = tasks.len();
+
+    let mut qualifying = 0u32;
+    let mut already_drafted = 0u32;
+    let mut drafted = 0u32;
+    let mut failed = 0u32;
+
+    for task in tasks {
+        if task.minutes < QUALIFYING_MINUTES {
+            continue;
+        }
+        qualifying += 1;
+
+        // Already drafted — by an earlier auto-generate run, or by the user
+        // clicking "Generate worklog" themselves. Either way this task is now the
+        // user's to drive (Regenerate in the panel), never auto-generate's again.
+        match meridian_core::day_task_worklogs::get_day_task_worklog(pool, day_local, &task.id)
+            .await
+        {
+            Ok(Some(_)) => {
+                already_drafted += 1;
+                continue;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                failed += 1;
+                tracing::warn!(
+                    day = day_local, task_id = %task.id, error = %e,
+                    "worklog: auto-generate existing-draft check failed — skipping this task this run"
+                );
+                continue;
+            }
+        }
+
+        tracing::info!(
+            day = day_local, task_id = %task.id, minutes = task.minutes,
+            "worklog: threshold crossed — drafting"
+        );
+        match pm_worklog::generate(pool, config, day_local, &task.id).await {
+            Ok(draft) => {
+                drafted += 1;
+                tracing::info!(
+                    day = day_local, task_id = %task.id, state = draft.state,
+                    "worklog: auto-generated (draft only — never posted)"
+                );
+            }
+            Err(e) => {
+                failed += 1;
+                tracing::warn!(
+                    day = day_local, task_id = %task.id, error = %e,
+                    "worklog: auto-generate failed — the user can still generate it manually"
+                );
+            }
+        }
+    }
+
+    span.record("tasks_qualifying", qualifying);
+    span.record("tasks_already_drafted", already_drafted);
+    span.record("tasks_drafted", drafted);
+    span.record("tasks_failed", failed);
+    tracing::info!(
+        day = day_local,
+        qualifying,
+        already_drafted,
+        drafted,
+        failed,
+        "worklog: auto-generate run complete"
+    );
+
+    SweepCounts {
+        total,
+        qualifying,
+        already_drafted,
+        drafted,
+        failed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{draft_qualifying_tasks, SweepCounts, QUALIFYING_MINUTES};
+    use crate::config::Config;
+    use sqlx::sqlite::SqlitePoolOptions;
+    use sqlx::SqlitePool;
+
+    const DAY: &str = "2026-08-07";
+
+    /// The two tables the sweep reads: day-tasks to enumerate, worklogs to skip
+    /// ones already drafted. `pm_providers` is a CONFIG field, not a table, so a
+    /// tracker-less user is modelled by the empty `Config` below.
+    async fn seeded() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        for ddl in [
+            "CREATE TABLE day_tasks (day_local TEXT NOT NULL, task_id TEXT NOT NULL, \
+                title TEXT, summary TEXT, hours_json TEXT, segments_json TEXT, \
+                minutes INTEGER, status TEXT, linked_ticket TEXT, \
+                PRIMARY KEY (day_local, task_id))",
+            // Mirrors `meridian-core/src/readers/day_task_worklogs/tests.rs`'s fixture -
+            // `get_day_task_worklog` reads the targets table too, and a column short of
+            // it the read fails and every task counts as `failed` rather than
+            // `already_drafted`, which would make this test pass for the wrong reason.
+            "CREATE TABLE day_task_worklogs (day_local TEXT NOT NULL, task_id TEXT NOT NULL, \
+                provider TEXT NOT NULL DEFAULT 'local', state TEXT NOT NULL DEFAULT 'drafted', \
+                update_summary TEXT NOT NULL DEFAULT '', update_json TEXT NOT NULL DEFAULT '{}', \
+                reasoning TEXT NOT NULL DEFAULT '', propose_issue_type TEXT, propose_title TEXT, \
+                propose_description TEXT, created_task_key TEXT, last_error TEXT, \
+                create_attempt_at TEXT, drafted_minutes INTEGER, \
+                created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '', \
+                PRIMARY KEY (day_local, task_id))",
+            "CREATE TABLE day_task_worklog_targets (day_local TEXT NOT NULL, \
+                task_id TEXT NOT NULL, task_key TEXT NOT NULL, provider TEXT NOT NULL, \
+                confidence REAL NOT NULL DEFAULT 0, manual INTEGER NOT NULL DEFAULT 0, \
+                position INTEGER NOT NULL DEFAULT 0, posted_comment_id TEXT, browse_url TEXT, \
+                posted_at TEXT, last_error TEXT, post_attempt_at TEXT, \
+                created_at TEXT NOT NULL DEFAULT '', update_json TEXT, \
+                PRIMARY KEY (day_local, task_id, task_key))",
+            "CREATE TABLE pm_tasks (task_key TEXT PRIMARY KEY, title TEXT NOT NULL)",
+        ] {
+            sqlx::query(ddl).execute(&pool).await.unwrap();
+        }
+        pool
+    }
+
+    async fn put_task(pool: &SqlitePool, task_id: &str, minutes: i64) {
+        sqlx::query(
+            "INSERT INTO day_tasks (day_local, task_id, title, minutes) VALUES (?, ?, ?, ?)",
+        )
+        .bind(DAY)
+        .bind(task_id)
+        .bind(format!("Task {task_id}"))
+        .bind(minutes)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn put_draft(pool: &SqlitePool, task_id: &str) {
+        sqlx::query("INSERT INTO day_task_worklogs (day_local, task_id) VALUES (?, ?)")
+            .bind(DAY)
+            .bind(task_id)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    /// A user with NO tracker connected - the exact configuration the removed
+    /// gate used to abandon.
+    fn no_tracker_config() -> Config {
+        Config {
+            meridian_db: ":memory:".into(),
+            poll_interval_secs: 60,
+            pm_providers: Vec::new(),
+            jira_update_enabled: false,
+            jira_update_interval_s: 14_400,
+            jira_office_start_hour: 9,
+            jira_office_end_hour: 17,
+            runtime: Default::default(),
+        }
+    }
+
+    /// The functional half of [`neither_sweep_is_gated_on_a_connected_tracker`].
+    ///
+    /// That test greps the source for the gate's return; this one proves the sweep
+    /// actually walks its task list with `pm_providers` empty. The two together
+    /// close the hole: a gate written a DIFFERENT way (a different field, an early
+    /// `return` above the read) would slip past the grep, but not past this.
+    ///
+    /// Every task here is pre-drafted on purpose, so the loop reaches its
+    /// already-drafted branch and returns without ever calling `pm_worklog::generate`
+    /// - no LLM, no network, no CLI spawn. Counting the tasks it CONSIDERED is
+    /// enough: an early return yields zeroes, and nothing else does.
+    #[tokio::test]
+    async fn the_sweep_walks_its_tasks_with_no_tracker_connected() {
+        let pool = seeded().await;
+        put_task(&pool, "T1", QUALIFYING_MINUTES + 5).await;
+        put_task(&pool, "T2", QUALIFYING_MINUTES + 90).await;
+        put_draft(&pool, "T1").await;
+        put_draft(&pool, "T2").await;
+
+        let counts =
+            draft_qualifying_tasks(&pool, &no_tracker_config(), DAY, &tracing::Span::none()).await;
+
+        assert_eq!(
+            counts,
+            SweepCounts {
+                total: 2,
+                qualifying: 2,
+                already_drafted: 2,
+                drafted: 0,
+                failed: 0,
+            },
+            "a tracker-less user's tasks must still be considered"
+        );
+    }
+
+    /// The threshold still applies - "not gated on a tracker" must not become
+    /// "not gated at all".
+    #[tokio::test]
+    async fn short_tasks_are_still_below_the_threshold() {
+        let pool = seeded().await;
+        put_task(&pool, "T1", QUALIFYING_MINUTES - 1).await;
+        put_draft(&pool, "T1").await;
+
+        let counts =
+            draft_qualifying_tasks(&pool, &no_tracker_config(), DAY, &tracing::Span::none()).await;
+
+        assert_eq!(counts.total, 1);
+        assert_eq!(counts.qualifying, 0, "under the threshold, never drafted");
+        assert_eq!(counts.already_drafted, 0);
+    }
+
+    /// A day with nothing on it returns cleanly rather than erroring.
+    #[tokio::test]
+    async fn an_empty_day_sweeps_to_zero() {
+        let pool = seeded().await;
+        let counts =
+            draft_qualifying_tasks(&pool, &no_tracker_config(), DAY, &tracing::Span::none()).await;
+        assert_eq!(counts, SweepCounts::default());
+    }
+}

--- a/src/pm_worklog/auto_generate/sweep.rs
+++ b/src/pm_worklog/auto_generate/sweep.rs
@@ -54,6 +54,7 @@ pub(super) async fn draft_qualifying_tasks(
     config: &Config,
     day_local: &str,
     span: &tracing::Span,
+    refresh: super::RefreshBoard,
 ) -> SweepCounts {
     // Refresh the board before matching work to tickets. Nothing does this on a
     // timer any more (see `main.rs`'s poll loop), and this is the one consumer
@@ -65,11 +66,23 @@ pub(super) async fn draft_qualifying_tasks(
     // separately, so both sweeps get it from one call site and the two can never
     // disagree about whether a run refreshed first. Gated (a fresh cache is a
     // no-op) and log-and-continue: a failed sync must not cancel drafting.
-    if let Err(e) = crate::intelligence::run_pm_sync(pool, config).await {
-        tracing::warn!(
-            day = day_local, error = %crate::errors::chain(&e),
-            "worklog: pre-draft PM sync failed — matching against the cached board"
-        );
+    match refresh {
+        super::RefreshBoard::Yes => {
+            if let Err(e) = crate::intelligence::run_pm_sync(pool, config).await {
+                tracing::warn!(
+                    day = day_local, error = %crate::errors::chain(&e),
+                    "worklog: pre-draft PM sync failed — matching against the cached board"
+                );
+            }
+        }
+        // Not merely skipped for speed: see `super::RefreshBoard`. A refresh here
+        // can trigger a rotating-OAuth-token exchange, and this caller is
+        // wake-triggered, which is the one condition under which losing that
+        // exchange's response destroys the user's grant.
+        super::RefreshBoard::No => tracing::debug!(
+            day = day_local,
+            "worklog: drafting against the cached board - this pass can be wake-triggered"
+        ),
     }
     let tasks = match meridian_core::day_tasks::get_day_tasks(pool, day_local).await {
         Ok(resp) => resp.tasks,
@@ -265,8 +278,14 @@ mod tests {
         put_draft(&pool, "T1").await;
         put_draft(&pool, "T2").await;
 
-        let counts =
-            draft_qualifying_tasks(&pool, &no_tracker_config(), DAY, &tracing::Span::none()).await;
+        let counts = draft_qualifying_tasks(
+            &pool,
+            &no_tracker_config(),
+            DAY,
+            &tracing::Span::none(),
+            crate::pm_worklog::auto_generate::RefreshBoard::No,
+        )
+        .await;
 
         assert_eq!(
             counts,
@@ -289,8 +308,14 @@ mod tests {
         put_task(&pool, "T1", QUALIFYING_MINUTES - 1).await;
         put_draft(&pool, "T1").await;
 
-        let counts =
-            draft_qualifying_tasks(&pool, &no_tracker_config(), DAY, &tracing::Span::none()).await;
+        let counts = draft_qualifying_tasks(
+            &pool,
+            &no_tracker_config(),
+            DAY,
+            &tracing::Span::none(),
+            crate::pm_worklog::auto_generate::RefreshBoard::No,
+        )
+        .await;
 
         assert_eq!(counts.total, 1);
         assert_eq!(counts.qualifying, 0, "under the threshold, never drafted");
@@ -301,8 +326,14 @@ mod tests {
     #[tokio::test]
     async fn an_empty_day_sweeps_to_zero() {
         let pool = seeded().await;
-        let counts =
-            draft_qualifying_tasks(&pool, &no_tracker_config(), DAY, &tracing::Span::none()).await;
+        let counts = draft_qualifying_tasks(
+            &pool,
+            &no_tracker_config(),
+            DAY,
+            &tracing::Span::none(),
+            crate::pm_worklog::auto_generate::RefreshBoard::No,
+        )
+        .await;
         assert_eq!(counts, SweepCounts::default());
     }
 }

--- a/src/worklog_pipeline.rs
+++ b/src/worklog_pipeline.rs
@@ -30,6 +30,7 @@ use sqlx::SqlitePool;
 use tokio::sync::watch;
 use tracing::Instrument;
 
+use crate::pm_worklog::auto_generate::RefreshBoard;
 use crate::pm_worklog::{ledger, PmWorklogConfig};
 
 // `pub(crate)` where the LLM-Lab replay ([`crate::llm_experiment`]) reuses the request
@@ -516,7 +517,14 @@ pub async fn run_loop(pool: SqlitePool, db_path: String, mut shutdown_rx: watch:
         tracing::info!("worklog-pipeline driver stopped");
         return;
     }
-    end_of_day_pass(&pool, &full_cfg).await;
+    // `RefreshBoard::No` on the STARTUP pass, and this is a data-safety choice
+    // rather than an optimisation. launchd `KeepAlive` restarts the daemon on
+    // every wake, so anything the startup pass does is wake-triggered - and a
+    // board refresh can trigger an OAuth token refresh, which is the operation
+    // that permanently destroys an Atlassian grant if the machine re-suspends
+    // mid-request (see `meridian_oauth::refresh_journal`). Drafting against the
+    // board the user's last dashboard visit left behind is the safe trade.
+    end_of_day_pass(&pool, &full_cfg, RefreshBoard::No).await;
 
     loop {
         let dur = next_worklog_wake();
@@ -526,7 +534,12 @@ pub async fn run_loop(pool: SqlitePool, db_path: String, mut shutdown_rx: watch:
                 if catch_up_pass(&pool, &cfg, &db_path, &mut shutdown_rx).await {
                     break;
                 }
-                end_of_day_pass(&pool, &full_cfg).await;
+                // The clock-aligned tick MAY refresh: it fires at the hour the
+                // user themselves chose for their end-of-day pass, so they are
+                // far more likely to be at the machine, and a fresh board is what
+                // stops an hour of work being bound to a ticket that closed
+                // earlier today.
+                end_of_day_pass(&pool, &full_cfg, RefreshBoard::Yes).await;
             }
         }
     }
@@ -542,9 +555,14 @@ pub async fn run_loop(pool: SqlitePool, db_path: String, mut shutdown_rx: watch:
 /// summary first would score a plan whose matches had not landed yet. Both gate
 /// themselves on `worklog_auto_generate_time`, so on every hour but the chosen one
 /// (through midnight, self-healing) this is a pair of cheap no-ops.
-async fn end_of_day_pass(pool: &SqlitePool, full_cfg: &crate::config::Config) {
+async fn end_of_day_pass(
+    pool: &SqlitePool,
+    full_cfg: &crate::config::Config,
+    refresh: RefreshBoard,
+) {
     let day_local = Local::now().date_naive().format("%Y-%m-%d").to_string();
-    crate::pm_worklog::auto_generate::maybe_auto_generate(pool, full_cfg, &day_local).await;
+    crate::pm_worklog::auto_generate::maybe_auto_generate(pool, full_cfg, &day_local, refresh)
+        .await;
     crate::day_summary::auto::maybe_auto_summarise(pool, &day_local).await;
 }
 

--- a/tray/src-tauri/src/commands/integrations.rs
+++ b/tray/src-tauri/src/commands/integrations.rs
@@ -681,6 +681,17 @@ pub async fn save_integration_token(
         tracing::debug!("daemon reload after token save (non-fatal — will pick up on next start)");
     }
 
+    // POPULATE THE BOARD NOW. Nothing syncs on a timer any more (see
+    // `commands::tasks`'s header for why that timer was destroying OAuth
+    // grants), so without this a freshly connected tracker showed an empty
+    // board until the user happened to reopen the dashboard.
+    //
+    // FORCED, not gated: `pm_sync_state` can say "synced 2 minutes ago" from
+    // a previous account or provider while `pm_tasks` still holds that other
+    // board's tickets, and the staleness gate would wrongly skip. Connecting
+    // is rare and user-initiated, so a guaranteed fetch is the right cost.
+    crate::commands::tasks::trigger_background_pm_force_sync("token_connected");
+
     Ok(serde_json::json!({ "ok": true, "reloaded": reloaded }))
 }
 
@@ -1343,7 +1354,19 @@ fn start_oauth_in_process(provider: String) -> Result<StartOAuthResponse, String
         // Always clear the in-flight flag before returning, regardless of outcome.
         in_flight.store(false, Ordering::SeqCst);
         match result {
-            Ok(()) => tracing::info!(provider = %task_provider, "in-process OAuth login succeeded"),
+            Ok(()) => {
+                tracing::info!(provider = %task_provider, "in-process OAuth login succeeded");
+                // POPULATE THE BOARD NOW. Nothing syncs on a timer any more (see
+                // `commands::tasks`'s header for why that timer was destroying OAuth
+                // grants), so without this a freshly connected tracker showed an empty
+                // board until the user happened to reopen the dashboard.
+                //
+                // FORCED, not gated: `pm_sync_state` can say "synced 2 minutes ago" from
+                // a previous account or provider while `pm_tasks` still holds that other
+                // board's tickets, and the staleness gate would wrongly skip. Connecting
+                // is rare and user-initiated, so a guaranteed fetch is the right cost.
+                crate::commands::tasks::trigger_background_pm_force_sync("oauth_connected");
+            }
             Err(e) => {
                 let msg = format!("{e:#}");
                 tracing::warn!(provider = %task_provider, error = %msg, "in-process OAuth login failed");
@@ -1461,6 +1484,16 @@ async fn start_oauth_github_device(
                 if let Err(e) = crate::commands::daemon::reload_daemon_with(db_pool).await {
                     tracing::debug!(error = %e, "daemon reload after GitHub connect (non-fatal)");
                 }
+                // POPULATE THE BOARD NOW. Nothing syncs on a timer any more (see
+                // `commands::tasks`'s header for why that timer was destroying OAuth
+                // grants), so without this a freshly connected tracker showed an empty
+                // board until the user happened to reopen the dashboard.
+                //
+                // FORCED, not gated: `pm_sync_state` can say "synced 2 minutes ago" from
+                // a previous account or provider while `pm_tasks` still holds that other
+                // board's tickets, and the staleness gate would wrongly skip. Connecting
+                // is rare and user-initiated, so a guaranteed fetch is the right cost.
+                crate::commands::tasks::trigger_background_pm_force_sync("oauth_connected");
             }
             Err(e) => {
                 let msg = format!("{e:#}");

--- a/tray/src-tauri/src/commands/system.rs
+++ b/tray/src-tauri/src/commands/system.rs
@@ -42,6 +42,16 @@ pub async fn open_dashboard(app: tauri::AppHandle) -> Result<(), String> {
         crate::tray::open_wizard_window(&app);
         return Ok(());
     }
+    // ON-DEMAND PM SYNC. The daemon no longer syncs the board on a timer (see
+    // `commands::tasks`'s header for why that timer was killing OAuth grants),
+    // so opening the dashboard is one of the moments that has to ask for a
+    // refresh. Placed AFTER the onboarding gate: a fresh install has no tracker
+    // to sync and the redirect above returns before reaching here.
+    //
+    // Fire-and-forget and gated - the window paints from the cached board
+    // immediately and never waits on the network, and a re-open seconds later
+    // no-ops on the staleness gate rather than re-fetching.
+    crate::commands::tasks::trigger_background_pm_sync("dashboard_open");
     dismiss_popover(&app);
     if let Some(win) = app.get_webview_window("dashboard") {
         let _ = win.show();

--- a/tray/src-tauri/src/commands/tasks.rs
+++ b/tray/src-tauri/src/commands/tasks.rs
@@ -8,13 +8,35 @@
 //! not in meridian-core. (The per-task *read*, `get_tasks`, stays in
 //! [`crate::commands::dashboard`].)
 //!
+//! Also home to the ON-DEMAND sync triggers that replaced the daemon's standing
+//! timer. PM sync used to run on every poll tick forever, which is what put a
+//! rotating-OAuth-token refresh POST in flight during a macOS dark wake: the
+//! machine re-suspended mid-request, the reply was lost, and the retry landed
+//! outside Atlassian's 10-minute reuse leeway, killing the grant permanently.
+//! A sleeping machine has no work to do, so it should attempt no refreshes -
+//! these triggers fire on things a PRESENT user did instead.
+//!
+//! # Why a process spawn and not a table
+//! The reverted `pm_sync_requests` outbox (PRs #909/#910) coordinated the tray
+//! and the daemon through `meridian.db`, and the tray's read-back of the outcome
+//! is what failed in production with `SQLITE_IOERR_SHORT_READ` (522) - a short
+//! read while the daemon truncated the WAL on shutdown. These triggers have no
+//! outcome to read: they spawn `meridian pm-sync` and forget it. There is no
+//! handshake, no new table, and no migration, so shipping them cannot damage a
+//! database or leave a request stuck.
+//!
 //! # Who calls this
 //! Registered in `lib.rs`'s `invoke_handler!`; consumed by `TasksView.tsx`'s Sync
 //! button via `ui/lib/bridge.ts::mutate` (success → re-fetch; error → inline msg).
+//! [`trigger_background_pm_sync`] is called by [`crate::commands::system::open_dashboard`]
+//! and [`crate::tray`]'s menu opener; [`trigger_background_pm_force_sync`] by
+//! [`crate::commands::integrations`] on a successful tracker connect.
 //!
 //! # Related
 //! - [`crate::install::meridian_bin`] — the shared native-first binary resolver.
 //! - [`crate::commands::parents`] — the other read-side `meridian` CLI shell-out.
+//! - `meridian::intelligence::sync_lock` — the cross-process lock that stops two
+//!   near-simultaneous triggers both fetching the same board.
 
 use meridian_core::proc_ext::NoWindow;
 use serde::Serialize;
@@ -40,56 +62,7 @@ pub struct SyncResult {
 #[tauri::command]
 #[tracing::instrument]
 pub async fn sync_tasks() -> Result<SyncResult, String> {
-    let bin = crate::install::meridian_bin();
-    // The cwd picks the credentials, because dotenvy walks up from it: a release
-    // build lands on the canonical ~/.meridian/.env (AZURE_DEVOPS_PAT, JIRA_URL, …),
-    // a dev build on the checkout's own. Never inherit the tray's cwd — under a
-    // packaged .app that is inside the bundle, and dotenvy finds no .env at all.
-    let cwd = crate::install::cli_cwd()?;
-    // WHICH binary ran, and from where, are the two facts that make a failure here
-    // legible: a stale installed CLI against a DB the dev daemon migrated ahead
-    // exits non-zero with nothing but `status=Some(1)` in the log otherwise.
-    tracing::debug!(bin = %bin, cwd = %cwd.display(), "tasks-sync: spawning");
-    let child = tokio::process::Command::new(&bin)
-        .arg("tasks-sync")
-        .current_dir(&cwd)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        // On timeout below, `tokio::time::timeout` drops the output future; without
-        // this the orphaned `meridian tasks-sync` keeps running (and can still mutate
-        // the board) after the UI reports a failure. The deleted /api/tasks/sync route
-        // called child.kill() on its 30s timer — kill_on_drop preserves that contract.
-        .kill_on_drop(true)
-        .no_window()
-        .output();
-
-    let output = match tokio::time::timeout(SYNC_TIMEOUT, child).await {
-        Err(_) => {
-            // `kill_on_drop` reaps the child here, taking its stderr with it, so
-            // this log is the ONLY record a timeout ever leaves. Emitting a bare
-            // "tasks-sync timed out" (as it did) makes the two cases that matter
-            // indistinguishable in a support bundle: a genuinely slow tracker
-            // sync vs. a `meridian` binary that never got past opening a corrupt
-            // meridian.db. WHICH binary and WHICH cwd is what separates them —
-            // the same two facts the spawn/non-zero arms below already log.
-            tracing::warn!(
-                bin = %bin,
-                cwd = %cwd.display(),
-                timeout_s = SYNC_TIMEOUT.as_secs(),
-                "tasks-sync timed out"
-            );
-            return Err(format!(
-                "tasks-sync timed out after {}s",
-                SYNC_TIMEOUT.as_secs()
-            ));
-        }
-        Ok(Err(e)) => {
-            tracing::warn!(bin = %bin, error = %e, "tasks-sync spawn failed");
-            return Err(format!("spawn error: {e}"));
-        }
-        Ok(Ok(o)) => o,
-    };
+    let output = spawn_meridian_cli("tasks-sync", SYNC_TIMEOUT).await?;
 
     if output.status.success() {
         let detail = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -102,7 +75,6 @@ pub async fn sync_tasks() -> Result<SyncResult, String> {
         // turned a one-line diagnosis into a manual re-run of the subcommand.
         tracing::warn!(
             status = ?output.status.code(),
-            bin = %bin,
             stderr = %stderr,
             "tasks-sync non-zero"
         );
@@ -112,4 +84,133 @@ pub async fn sync_tasks() -> Result<SyncResult, String> {
             stderr
         })
     }
+}
+
+/// Budget for a background trigger's `meridian pm-sync`.
+///
+/// Longer than [`SYNC_TIMEOUT`] because nobody is watching a spinner - but still
+/// bounded, and bounded for a specific reason: a `pm-sync` whose HTTP request
+/// straddles a system suspend does NOT time out on its own (`reqwest`'s timeout
+/// is `Instant`-based, and the monotonic clock does not advance while macOS is
+/// asleep), so without a ceiling here an orphan can sit holding the cross-process
+/// sync lock and starve every later trigger.
+const TRIGGER_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Spawn `meridian <subcommand>` and wait for it, with `timeout` and
+/// `kill_on_drop`.
+///
+/// Factored out of [`sync_tasks`] so the button and the background triggers can
+/// never drift on the two things that are easy to get wrong and invisible when
+/// wrong: the cwd (which picks the credentials, because dotenvy walks up from it)
+/// and `kill_on_drop` (without which a timed-out child keeps running and can
+/// still mutate the board after the caller gave up).
+async fn spawn_meridian_cli(
+    subcommand: &str,
+    timeout: Duration,
+) -> Result<std::process::Output, String> {
+    let bin = crate::install::meridian_bin();
+    // The cwd picks the credentials, because dotenvy walks up from it: a release
+    // build lands on the canonical ~/.meridian/.env (AZURE_DEVOPS_PAT, JIRA_URL, …),
+    // a dev build on the checkout's own. Never inherit the tray's cwd — under a
+    // packaged .app that is inside the bundle, and dotenvy finds no .env at all.
+    let cwd = crate::install::cli_cwd()?;
+    // WHICH binary ran, and from where, are the two facts that make a failure here
+    // legible: a stale installed CLI against a DB the dev daemon migrated ahead
+    // exits non-zero with nothing but `status=Some(1)` in the log otherwise.
+    tracing::debug!(subcommand, bin = %bin, cwd = %cwd.display(), "meridian cli: spawning");
+    let child = tokio::process::Command::new(&bin)
+        .arg(subcommand)
+        .current_dir(&cwd)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        // On timeout below, `tokio::time::timeout` drops the output future; without
+        // this the orphaned child keeps running (and can still mutate the board)
+        // after the caller reports a failure.
+        .kill_on_drop(true)
+        .no_window()
+        .output();
+
+    match tokio::time::timeout(timeout, child).await {
+        Err(_) => {
+            // `kill_on_drop` reaps the child here, taking its stderr with it, so
+            // this log is the ONLY record a timeout ever leaves. Emitting a bare
+            // "timed out" makes the two cases that matter indistinguishable in a
+            // support bundle: a genuinely slow tracker sync vs. a `meridian`
+            // binary that never got past opening a corrupt meridian.db.
+            tracing::warn!(
+                subcommand,
+                bin = %bin,
+                cwd = %cwd.display(),
+                timeout_s = timeout.as_secs() as f64,
+                "meridian cli timed out"
+            );
+            Err(format!(
+                "{subcommand} timed out after {}s",
+                timeout.as_secs()
+            ))
+        }
+        Ok(Err(e)) => {
+            tracing::warn!(subcommand, bin = %bin, error = %e, "meridian cli spawn failed");
+            Err(format!("spawn error: {e}"))
+        }
+        Ok(Ok(o)) => Ok(o),
+    }
+}
+
+/// Fire off a GATED background sync and return immediately.
+///
+/// `reason` names the trigger (`"dashboard_open"`, `"token_connected"`, …) and is
+/// logged, so the on-demand schedule is legible in a support bundle - "why did
+/// this install sync at 09:14" has an answer.
+///
+/// Detached on purpose: the caller is opening a window or finishing a settings
+/// save, and must not wait on the network to do it. Every outcome logs at
+/// `debug`/`warn` and NOTHING is surfaced to the UI - a best-effort refresh that
+/// failed is not a thing to interrupt someone with, and the next trigger retries.
+///
+/// Gated, not forced: these fire repeatedly within seconds (open the dashboard,
+/// close it, open it again), and a forced fetch each time would recreate exactly
+/// the API hammering the removed timer was doing.
+pub(crate) fn trigger_background_pm_sync(reason: &'static str) {
+    spawn_trigger("pm-sync", reason);
+}
+
+/// Fire off a FORCED background sync and return immediately.
+///
+/// For the moments where the cache is knowingly wrong and the staleness gate
+/// would wrongly skip: a tracker was just connected, so `pm_sync_state` may say
+/// "synced 2 minutes ago" from a previous account while `pm_tasks` holds another
+/// board's tickets. Same detached, best-effort, never-surfaced discipline as
+/// [`trigger_background_pm_sync`].
+pub(crate) fn trigger_background_pm_force_sync(reason: &'static str) {
+    spawn_trigger("tasks-sync", reason);
+}
+
+/// Shared body of the two triggers: spawn onto the runtime, log the outcome,
+/// surface nothing. One place so the two can never disagree about what
+/// "best-effort" means.
+fn spawn_trigger(subcommand: &'static str, reason: &'static str) {
+    tauri::async_runtime::spawn(async move {
+        match spawn_meridian_cli(subcommand, TRIGGER_TIMEOUT).await {
+            Ok(o) if o.status.success() => {
+                tracing::debug!(subcommand, reason, "background pm sync finished");
+            }
+            Ok(o) => {
+                // WARN, not ERROR: a tracker being briefly unreachable is
+                // ordinary, and the next trigger retries. Carrying stderr means
+                // a real fault (dead grant, bad JQL) is still diagnosable.
+                tracing::warn!(
+                    subcommand,
+                    reason,
+                    status = ?o.status.code(),
+                    stderr = %String::from_utf8_lossy(&o.stderr).trim(),
+                    "background pm sync exited non-zero"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(subcommand, reason, detail = %e, "background pm sync failed");
+            }
+        }
+    });
 }

--- a/tray/src-tauri/src/tray.rs
+++ b/tray/src-tauri/src/tray.rs
@@ -116,6 +116,16 @@ pub(crate) fn open_native_dashboard(app: &tauri::AppHandle) {
         open_wizard_window(app);
         return;
     }
+    // ON-DEMAND PM SYNC. The daemon no longer syncs the board on a timer (see
+    // `commands::tasks`'s header for why that timer was killing OAuth grants),
+    // so opening the dashboard is one of the moments that has to ask for a
+    // refresh. Placed AFTER the onboarding gate: a fresh install has no tracker
+    // to sync and the redirect above returns before reaching here.
+    //
+    // Fire-and-forget and gated - the window paints from the cached board
+    // immediately and never waits on the network, and a re-open seconds later
+    // no-ops on the staleness gate rather than re-fetching.
+    crate::commands::tasks::trigger_background_pm_sync("dashboard_open_menu");
     crate::commands::system::dismiss_popover(app);
     if let Some(win) = app.get_webview_window("dashboard") {
         let _ = win.show();

--- a/ui/components/timeline/settings/IntegrationsSection.tsx
+++ b/ui/components/timeline/settings/IntegrationsSection.tsx
@@ -64,7 +64,7 @@ export function IntegrationsSection({ integrations, onChanged, gate = false, onD
               Connected to {connected.map(t => t.name).join(', ')}
             </p>
             <p className="text-[11.5px] font-semibold mt-0.5" style={{ color: 'color-mix(in srgb, var(--color-state-approved) 75%, var(--t-muted))' }}>
-              Syncing every hour
+              Kept in sync automatically
             </p>
           </div>
         </div>


### PR DESCRIPTION
Two commits. The first removes what made the failure **likely**; the second makes it **recoverable**.

## The bug

Production users kept hitting a permanent `refresh_token is invalid` Jira disconnect.

1. macOS dark-wakes a sleeping machine every **15-16 minutes**.
2. The daemon resumed, found the access token expired, POSTed a refresh.
3. Atlassian **rotated the refresh token** and replied.
4. The machine re-suspended before the response was read. `flow.rs`'s `.timeout(8s)` could not cancel it: the timeout is `Instant`-based and `mach_absolute_time` does not advance while the system sleeps, so the request just hung.
5. Next dark wake: socket dead, retry with the **old** token, now past Atlassian's **10-minute reuse leeway** → `invalid_grant` → terminal → grant dead.

The dark-wake interval is longer than the leeway, so once you're there no retry gets you out.

Underneath that was a design defect: **nothing recorded that a spend had been attempted**, so the code could not distinguish *"never spent"* from *"spent, answer lost"* — and those need opposite handling.

---

## Commit 1 — sync on demand, not on a timer

A sleeping machine has no work to do, so it must attempt no token refreshes.

**Removed:** the every-tick `run_pm_sync` in the daemon poll loop, and the startup pass (launchd `KeepAlive` restarts the daemon on every wake, so sync-on-boot is a wake-triggered refresh in disguise).

**Added**, every one something a *present* user did:

| Trigger | Mode | Why |
|---|---|---|
| `meridian pm-sync` (new CLI) | gated | what the tray spawns |
| Dashboard opened | gated | fires repeatedly; forcing each time would re-create the hammering |
| Tracker connected | **forced** | `pm_sync_state` can say "synced 2m ago" from a previous account while `pm_tasks` holds another board |
| Before the drafting sweep, and `worklog-generate` | gated | the one consumer where a stale board binds work to a closed ticket |

**Not** hung off the dashboard's read commands — `TasksPanel` polls `get_tasks` every 60s and `OverviewPanel` polls `get_plan` every 30s, so a trigger there would have recreated the timer inside the tray.

**Single source of truth:** staleness is still decided in exactly one place per provider (`refresh_if_stale` on `pm_sync_state.last_synced_at`). Dedup is a new `intelligence::sync_lock` — an advisory **file** lock plus an in-process mutex (`flock` is per open-file-description, so two tasks in one process would each be granted it). Gated callers skip on contention, forced callers wait then proceed.

**Why a file lock and not a table:** the reverted `pm_sync_requests` outbox (#909/#910) coordinated tray↔daemon through `meridian.db`, and the tray's read-back of the outcome is what failed in production with `SQLITE_IOERR_SHORT_READ` (522). Here the tray spawns and forgets — no handshake, no outcome to read.

---

## Commit 2 — make the exchange itself crash- and suspend-safe

**1. A durable journal** (`meridian-oauth/src/refresh_journal.rs`). The token about to be spent is written and `fsync`'d (file **and** directory) *before* the POST, cleared only *after* the new pair is persisted. Recovery is decided by **comparing tokens**, not by trusting a flag:

- journalled == stored → the save never landed → **replay**
- journalled != stored → it landed, we died before clearing → journal is stale

That is what makes every crash point recoverable, with no "in progress" boolean that could itself go stale.

**2. A wall-clock deadline** on each token POST. Every `.timeout()` and every tokio timer measures `Instant`, which does not advance during sleep. The watchdog still sleeps monotonically — that is the only timer available — but compares the **wall clock** on each tick, so nothing fires mid-suspend and it gives up immediately on resume. Abandoning promptly is what leaves enough grace to replay.

**3. Replay inside the grace.** Atlassian honours the previous refresh token briefly after rotation, so re-presenting it returns the current pair and recovers the grant. `REPLAY_WINDOW_SECS` is **8 minutes against a documented 10**, leaving margin for NTP skew on wake and the request's own duration.

Two failure modes chosen deliberately:

- Journal write fails → the refresh is **abandoned**, not attempted. Spending a rotating token with no record is the unrecoverable state this exists to prevent.
- `store::save` fails after a good exchange → the journal is **kept**. The new pair is only in memory, so the journal is the only thing that knows the stored token may already be spent.

The fast path now also checks the journal: a valid access token can coexist with a refresh token already consumed server-side, and returning early on "not expired" would leave that unresolved for up to an hour — long past the grace, turning a late recovery into an impossible one.

---

## Two regressions from commit 1, found and fixed in commit 2

**Escalation false-positived on normal quiet periods.** `note_transient_sync_failure` escalated when there had been no successful sync for 6 hours — correct under a timer (its own doc said *"comfortably longer than any provider's sync interval"*), but with on-demand sync a quiet weekend is normal. **Opening the dashboard on Monday before Wi-Fi associated would have raised a red "sync failing" banner on a healthy install**, bodied *"No successful sync in the last 6 hours"* while describing normal use.

It now counts **consecutive failures** (threshold 4), held in memory: no migration, cannot corrupt a database, and resetting on restart is the safe direction — a fresh process after a wake starts at zero. A blocked proxy fails every attempt; a wake blip fails once or twice then works.

That deleted the grace-row/epoch-sentinel mechanism, which also fixed a display bug: `mark_first_stale_failure` stamped `last_synced_at` back to 1970, and the health check would have rendered **"last synced 29799360m ago"**.

**"No polling" was not absolute, and I said it was.** `worklog_pipeline::run_loop` also runs `end_of_day_pass` once at startup, and launchd restarts the daemon on every wake — so commit 1's pre-draft sync made that a wake-triggered token refresh. A `RefreshBoard` enum now splits them: the startup pass drafts against the cached board, the chosen-hour tick (user far more likely present) refreshes first.

---

## DB safety

Both commits, verified:

```
$ git status --short src/migrations/                      # empty
$ git diff | grep -icE '^\+.*(CREATE|ALTER|DROP) TABLE'   # 0
```

No migration, no DDL, no new table. Every piece of new state is a `0600` file written temp-then-rename, deliberately outside `meridian.db`. Nothing reads back a cross-process outcome, so the `522` failure mode cannot recur.

## Tests

- Both journal **crash points**, the corrupt-journal path, `0600` permissions, wall-clock window clamping, and that a fresh access token cannot hide an unresolved spend.
- Escalation: a single blip and a blip after 72h of quiet both stay silent; four consecutive failures escalate with wording naming the evidence rather than a duration; a success resets; streaks do not leak between providers.
- `the_daemon_poll_loop_never_syncs_pm_tasks` and `the_startup_pass_never_refreshes_and_the_chosen_hour_tick_does` — source-level, because the wrong value in either is **silent**: it works, and only destroys grants months later. Both mutation-checked.
- `neither_sweep_is_gated_on_a_connected_tracker` now scans **both** halves of the split `auto_generate` module; splitting for the 500-line cap would otherwise have halved its reach while still passing. Mutation-checked.
- Two pre-existing tests shared a provider name and leaked the streak between parallel threads; they now use unique keys.

Gate: `cargo clippy --workspace --all-targets -D warnings` clean, **1108 Rust tests**, **915 UI tests**, 0 failures.

## Still not immune

A suspend **longer than the reuse grace**, landing inside the exchange, remains unrecoverable — no client-side code fixes that. It now needs a far narrower coincidence. Per the 2026-08-26 investigation, eight avenues are each independently closed and OAuth 3LO cannot be made disconnect-proof with tokens local and no server. **Scoped API tokens are the only structurally immune credential** and are a separate change.

Also left: `sync_failure_tests.rs` is 517 lines, still over the 500 cap (it was 675 before this PR).

## Testing before merge

Per the agreed rollout, on the Mac that has actually been failing:

1. Connect a tracker — the board should populate without pressing Sync now.
2. Leave a Tasks panel open and idle 5+ minutes — **no** `pm-sync` process should spawn beyond the one from opening the window.
3. Sleep the laptop overnight, then open the dashboard before Wi-Fi associates — expect a silent recovery, **no** red banner.
4. `~/.meridian/oauth/` should contain no leftover `.refresh-journal.json` once a sync succeeds.
