### PR TITLE
fix(daemon): bound background-task shutdown and stop dev tray false-installing over itself

### DIFF
--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -595,7 +595,14 @@ pub async fn run_loop(
     // Only rows whose source is in backoff are skipped; other sources continue.
     let mut source_backoff: HashMap<String, std::time::Instant> = HashMap::new();
     loop {
-        let all_backed_off = drain(&pool, &cfg, &mut attempts, &mut source_backoff).await;
+        let all_backed_off = drain(
+            &pool,
+            &cfg,
+            &mut attempts,
+            &mut source_backoff,
+            &shutdown_rx,
+        )
+        .await;
         let wait = if all_backed_off {
             // Nothing could be processed (all pending rows are from backed-off
             // sources). Wait out the backoff period rather than spinning.
@@ -643,6 +650,7 @@ async fn drain(
     cfg: &SummariserConfig,
     attempts: &mut HashMap<i64, u32>,
     source_backoff: &mut HashMap<String, std::time::Instant>,
+    shutdown_rx: &watch::Receiver<bool>,
 ) -> bool {
     // Expire stale backoffs before deciding what to skip.
     let now_instant = std::time::Instant::now();
@@ -671,6 +679,24 @@ async fn drain(
     let mut skipped_backoff = 0u32;
 
     for row in &rows {
+        // Each row shells out to the agent's own CLI (`claude -p` / `codex exec`
+        // / …), which can run for tens of seconds to a couple of minutes — and
+        // this loop runs up to `batch_per_tick` (default 32) of them
+        // sequentially. Without this check, a daemon shutdown mid-batch would
+        // not be observed until the whole batch drained (worst case, tens of
+        // minutes), holding `meridian.db` open long past the tray installer's
+        // 10s `wait_for_db_unheld` budget (`backend_install.rs`) and risking
+        // exactly the double-writer corruption that guard exists to prevent.
+        // Checked between rows, not mid-subprocess-call: the subprocess isn't
+        // cancellation-safe, so bounding exposure to "at most one in-flight
+        // row" is the safe stopping point, not "any point at all".
+        if *shutdown_rx.borrow() {
+            tracing::info!(
+                remaining = rows.len() - summarised as usize - skipped_backoff as usize,
+                "coding-agent summariser: shutdown requested mid-drain — stopping early"
+            );
+            return false;
+        }
         // Skip rows whose agent source is still in rate-limit backoff.
         if source_backoff.contains_key(&row.agent) {
             skipped_backoff += 1;
@@ -944,6 +970,81 @@ mod tests {
             attempts.get(&2),
             Some(&1),
             "row 2's independent failure count must be untouched"
+        );
+    }
+
+    /// THE regression this exists for: `drain()` used to process its whole
+    /// batch (up to `batch_per_tick`, default 32, each shelling out to the
+    /// agent's own CLI) with no shutdown check at all, so a daemon SIGTERM
+    /// mid-batch went unnoticed until every row finished — worst case, tens
+    /// of minutes with `meridian.db` still open. That blew straight through
+    /// the tray installer's 10s `wait_for_db_unheld` budget
+    /// (`backend_install.rs`), which is the guard standing between an update
+    /// and the exact double-writer corruption documented in this repo's
+    /// history.
+    ///
+    /// Pre-signals shutdown BEFORE calling `drain()` (rather than racing a
+    /// real subprocess mid-row, which isn't cancellation-safe) and asserts
+    /// the pending row is untouched — proving the loop bailed before ever
+    /// calling `summarise_one`, not merely that it returned some value.
+    #[tokio::test]
+    async fn drain_stops_before_touching_any_row_once_shutdown_is_signalled() {
+        use crate::coding_agent_session_ingest::db as cdb;
+        use crate::coding_agent_session_ingest::segment::Segment;
+        use sqlx::sqlite::SqliteConnectOptions;
+        use std::str::FromStr;
+
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+            .unwrap()
+            .create_if_missing(true);
+        let pool = SqlitePool::connect_with(opts).await.unwrap();
+        sqlx::migrate!("src/migrations").run(&pool).await.unwrap();
+        db::ensure_summary_source_column(&pool).await.unwrap();
+
+        let seg = Segment {
+            session_uuid: "u1".into(),
+            agent: "claude_code".into(),
+            cwd: Some("/repo".into()),
+            segment_started_at: "2026-05-20T08:00:00.000000+00:00".into(),
+            started_at: "2026-05-20T08:00:00.000000+00:00".into(),
+            ended_at: "2026-05-20T08:30:00.000000+00:00".into(),
+            user_turns: 2,
+            assistant_turns: 2,
+            active_seconds: 300,
+            transcript: "x".repeat(900),
+            is_last: false,
+            title: None,
+        };
+        let id = cdb::upsert_segment(&pool, &seg, true, Some("2026-05-20T09:00:00.000000+00:00"))
+            .await
+            .unwrap()
+            .unwrap();
+
+        let cfg = SummariserConfig::from_env();
+        let mut attempts = HashMap::new();
+        let mut source_backoff = HashMap::new();
+        // Already true when drain() starts — the same state the loop sees
+        // when a SIGTERM lands between two drain() calls, or (with this fix)
+        // between two rows of the same batch.
+        let (_tx, rx) = watch::channel(true);
+
+        let all_backed_off = drain(&pool, &cfg, &mut attempts, &mut source_backoff, &rx).await;
+        assert!(
+            !all_backed_off,
+            "a shutdown bail-out is not a backoff condition"
+        );
+
+        let (method,): (String,) =
+            sqlx::query_as("SELECT task_method FROM app_sessions WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            method,
+            db::TASK_METHOD_PENDING,
+            "the row must be untouched — drain() must bail before calling \
+             summarise_one, not merely stop looping afterward"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1460,6 +1460,12 @@ async fn main() -> Result<()> {
     }
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    // Every task below holds its own clone of the `meridian` pool and must be
+    // known to have actually stopped touching it before shutdown checkpoints
+    // and closes that pool — see the bounded join at the "9. Shutdown" step,
+    // and its doc comment for why a fire-and-forget `tokio::spawn` here isn't
+    // enough on its own.
+    let mut background_tasks: Vec<(&'static str, tokio::task::JoinHandle<()>)> = Vec::new();
 
     // 8a-bis. Coding-agent tasks (both gated — dormant if neither agent is
     //         present). The indexer turns Claude Code / Codex JSONLs into
@@ -1472,18 +1478,26 @@ async fn main() -> Result<()> {
         let pool_idx = meridian.clone();
         let notify_idx = ca_notify.clone();
         let rx_idx = shutdown_rx.clone();
-        tokio::spawn(async move {
-            meridian::coding_agent_session_ingest::indexer::run_loop(pool_idx, notify_idx, rx_idx)
+        background_tasks.push((
+            "coding_agent_indexer",
+            tokio::spawn(async move {
+                meridian::coding_agent_session_ingest::indexer::run_loop(
+                    pool_idx, notify_idx, rx_idx,
+                )
                 .await;
-        });
+            }),
+        ));
         let pool_sum = meridian.clone();
         let rx_sum = shutdown_rx.clone();
-        tokio::spawn(async move {
-            meridian::coding_agent_session_ingest::summariser::run_loop(
-                pool_sum, ca_notify, rx_sum,
-            )
-            .await;
-        });
+        background_tasks.push((
+            "coding_agent_summariser",
+            tokio::spawn(async move {
+                meridian::coding_agent_session_ingest::summariser::run_loop(
+                    pool_sum, ca_notify, rx_sum,
+                )
+                .await;
+            }),
+        ));
     }
 
     // 7d. PM-worklog driver: hour-level pipeline — clock-aligned (HH:03 local), runs
@@ -1493,9 +1507,12 @@ async fn main() -> Result<()> {
         let pool_pm = meridian.clone();
         let db_path_pm = initial_cfg.meridian_db.clone();
         let rx_pm = shutdown_rx.clone();
-        tokio::spawn(async move {
-            meridian::worklog_pipeline::run_loop(pool_pm, db_path_pm, rx_pm).await;
-        });
+        background_tasks.push((
+            "worklog_pipeline",
+            tokio::spawn(async move {
+                meridian::worklog_pipeline::run_loop(pool_pm, db_path_pm, rx_pm).await;
+            }),
+        ));
     }
 
     // 7e. PM-worklog approved-poster: the ~60s sweep that posts worklogs the user
@@ -1505,9 +1522,12 @@ async fn main() -> Result<()> {
     {
         let pool_post = meridian.clone();
         let rx_post = shutdown_rx.clone();
-        tokio::spawn(async move {
-            meridian::pm_worklog::run_post_loop(pool_post, rx_post).await;
-        });
+        background_tasks.push((
+            "pm_worklog_post",
+            tokio::spawn(async move {
+                meridian::pm_worklog::run_post_loop(pool_post, rx_post).await;
+            }),
+        ));
     }
 
     // 7f. Telemetry spool shipper: drains ~/.meridian/telemetry/pending/ to
@@ -1717,6 +1737,60 @@ async fn main() -> Result<()> {
 
     // 9. Shutdown
     tracing::info!(pid = std::process::id() as i64, "shutting down");
+
+    // Wait for every background task to actually stop touching `meridian`
+    // before checkpointing/closing it, instead of just firing the shutdown
+    // signal and hoping. Each task above holds its own clone of this same
+    // pool, and closing it while one is still mid-query races the exact
+    // "held open after stopping the daemon" failure `wait_for_db_unheld`
+    // (`backend_install.rs`) exists to catch during an app update: on macOS
+    // the rename underneath a live writer SUCCEEDS, so two writers end up
+    // sharing one WAL — the root cause of the `code: 11` corruption in this
+    // repo's history. Bounded rather than unconditional: a task that is
+    // stuck on an external subprocess (the coding-agent summariser's `claude
+    // -p` / `codex exec`) must not hang the daemon's own shutdown forever.
+    // The bound is loud on expiry so a future recurrence shows up in
+    // `meridian logs` instead of silently racing the checkpoint below — see
+    // the module doc on `poll::permissions` for why a silent failure mode
+    // here previously cost days to diagnose.
+    const BACKGROUND_TASK_SHUTDOWN_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
+    // Joined CONCURRENTLY, not one after another: these tasks are already
+    // running in parallel, so waiting on them sequentially would let 4 tasks
+    // each burn their own 5s budget and add up to 20s to every shutdown - on
+    // a machine slow enough to need the full budget even once, that's also
+    // long enough to blow past `bootout_agent_and_wait`'s own 15s wait for
+    // the launchd label to clear (`backend_install.rs`), turning a slow but
+    // healthy shutdown into a failed update. `join_all` bounds the total added
+    // latency to one budget's worth, matching how long the slowest task
+    // actually needed.
+    let results = futures::future::join_all(background_tasks.into_iter().map(
+        |(name, handle)| async move {
+            (
+                name,
+                tokio::time::timeout(BACKGROUND_TASK_SHUTDOWN_BUDGET, handle).await,
+            )
+        },
+    ))
+    .await;
+    for (name, outcome) in results {
+        match outcome {
+            Ok(Ok(())) => tracing::debug!(task = name, "background task stopped for shutdown"),
+            Ok(Err(e)) => tracing::warn!(
+                task = name,
+                error = %e, // not-anyhow: tokio::task::JoinError, no chain to walk
+                "background task panicked during shutdown"
+            ),
+            Err(_) => tracing::error!(
+                task = name,
+                budget_s = BACKGROUND_TASK_SHUTDOWN_BUDGET.as_secs(),
+                "background task did not stop within the shutdown budget — \
+                 it may still be holding the database open (e.g. mid an \
+                 external subprocess call); proceeding with checkpoint/close \
+                 anyway rather than hanging shutdown indefinitely"
+            ),
+        }
+    }
+
     meridian::platform::release_endpoint();
     // See `db::meridian::checkpoint_wal`'s doc for why this runs before every
     // close, not just a plain shutdown. Best-effort: a failed checkpoint must

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -485,7 +485,31 @@ pub(crate) async fn ensure_daemon_running(home: &Path) {
 }
 
 /// `Meridian.app/Contents/Resources/backend/` when it exists, else `None`.
+///
+/// Gated on `!cfg!(debug_assertions)` as well as the directory check — a
+/// `tauri dev` / `cargo run` build's `resource_dir()` resolves under
+/// `target/debug/`, and if ANYTHING ever leaves a `backend/` subdirectory
+/// there (a stray artifact from an earlier debug-profile `tauri build`, a
+/// manual test, whatever), `dir.is_dir()` alone can't tell that apart from a
+/// real packaged install. That false positive is not cosmetic:
+/// [`ensure_backend_installed`] would then call [`install`], which on macOS
+/// runs [`stop_daemon_for_migration`] against `meridian.db` — booting out a
+/// launchd agent that was never registered for this run (a no-op) and then
+/// polling `lsof` for up to 10s, which always times out because the actual
+/// holder is the sibling `cargo run` daemon `bootout` can't touch, not the
+/// launchd job it targets. That raises `tray.backend_install_failed`
+/// ("meridian.db is still held open 10s after stopping the daemon") on every
+/// dev-tray launch, with a timestamp that tracks each restart — measured
+/// verbatim on 2026-08-31, traced to exactly one stray directory left over
+/// from an Aug 16 debug build. `debug_assertions` is a compile-time constant
+/// for the running binary's own profile, so this can never be fooled by
+/// what's left lying around on disk the way the directory check alone was.
+/// Matches the same convention already used for the encryption-migration
+/// gate in `lib.rs`'s setup hook.
 fn bundled_backend_dir(app: &tauri::AppHandle) -> Option<PathBuf> {
+    if cfg!(debug_assertions) {
+        return None;
+    }
     let dir = app.path().resource_dir().ok()?.join("backend");
     dir.is_dir().then_some(dir)
 }


### PR DESCRIPTION
## Summary

Two independent fixes, found while chasing a "Meridian couldn't finish installing. meridian.db is still held open 10s after stopping the daemon" notice reported on staging and in dev.

**1. Daemon shutdown could hold `meridian.db` open far past the installer's 10s budget.**
The coding-agent summariser's `drain()` processed up to `batch_per_tick` (32) rows sequentially with no shutdown check between them, and each row shells out to the agent's own CLI (`claude -p` / `codex exec`) for up to ~2 minutes. A SIGTERM mid-batch went unnoticed until the whole batch finished — worst case, tens of minutes with the DB still open, well past `wait_for_db_unheld`'s 10s window in the tray installer, which exists specifically to prevent the double-writer WAL corruption this repo has hit in production before (`code: 11`).
- `summariser::drain()` now checks the shutdown signal between rows.
- `main.rs`'s shutdown sequence now joins all 4 background-task handles (indexer, summariser, worklog pipeline, approved-poster) — concurrently, bounded to one 5s budget total rather than summed per-task — before checkpointing/closing the pool, instead of firing the signal and moving on with no idea whether they'd actually stopped. A task that blows the budget logs loudly (task name + budget) so a future recurrence is diagnosable instead of silently racing the checkpoint.

**2. Dev tray could falsely believe it needed to "install" itself.**
`bundled_backend_dir()` decided "this is a packaged install" purely from whether a `backend/` directory existed under `resource_dir()`. That's true even for a dev/debug tray if a stray directory is ever left there (traced to a leftover from an earlier debug-profile `tauri build`) — which made the dev tray attempt to stage a mismatched binary over itself, `bootout` a launchd agent that was never loaded (no-op), then time out after 10s waiting for its own sibling `cargo run` daemon to release `meridian.db` (which `bootout` can't touch — it isn't launchd-managed). Gated the check on `!cfg!(debug_assertions)`, matching the convention the encryption-migration path in `lib.rs` already uses for the same reason.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (1111 tests in `meridian`, 431 in `meridian-tray`, all passing) — includes a new regression test (`drain_stops_before_touching_any_row_once_shutdown_is_signalled`) that pre-signals shutdown and asserts the pending row is untouched, proving the bail happens before `summarise_one` runs
- [x] `git push` pre-push suite (fmt, clippy, UI build + tests, security audit, full workspace tests) — all green
- [x] Confirmed the dev-tray false-install locally: reproduced the hash mismatch (`target/debug/backend/meridian` vs `~/.meridian/backend-version`), removed the stray directory, confirmed the notice stopped recurring after the code fix