### PR TITLE
fix(summariser): bound rate-limited retries and pace a failing queue

### DIFF
--- a/src/coding_agent_session_ingest/summariser/mod.rs
+++ b/src/coding_agent_session_ingest/summariser/mod.rs
@@ -11,7 +11,11 @@
 // Escalation, in order:
 //   1. the session's OWN agent CLI, `primary_attempts` times
 //   2. a rate limit → stop immediately, back the source off, retry on a later
-//      tick. A quota refills; it is waited out, never routed around.
+//      tick. A quota refills; it is waited out, never routed around — but only
+//      up to MAX_RATE_LIMITED_ROW_ATTEMPTS (~a day of backoff), because this
+//      branch used to be the one outcome that never recorded an attempt, so a
+//      row misclassified as rate-limited retried forever and the queue never
+//      drained. See that constant.
 //   3. otherwise (crashed / not installed / signed out / unusable output) → the
 //      user's globally chosen AI provider, once (`fallback`). Usually the same
 //      CLI, in which case it is skipped without a call.
@@ -565,6 +569,79 @@ pub(crate) fn cap_transcript(transcript: &str, cap: usize) -> String {
 
 // ──────────────────────── Loop ──────────────────────────────────────────────
 
+/// What one [`drain`] pass actually did, so the loop can pace itself.
+///
+/// Replaces a bare `bool` ("were all rows backed off?") that could not
+/// distinguish the three cases the wait needs to tell apart: real progress, a
+/// quota wall, and *work attempted that failed*. The old signal also
+/// miscounted - it compared `skipped_backoff` against the whole batch, so a
+/// single failing row alongside backed-off ones collapsed the 30-minute
+/// rate-limit wait back to the 5-second sweep.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+struct DrainOutcome {
+    /// Rows fetched for consideration this pass.
+    seen: u32,
+    /// Rows summarised and persisted.
+    summarised: u32,
+    /// Rows not attempted because their source is in rate-limit backoff, plus
+    /// rows whose attempt reported a rate limit.
+    skipped_backoff: u32,
+    /// Rows attempted that failed for a non-rate-limit reason.
+    failed: u32,
+    /// Rows not attempted because they have exhausted an attempt cap.
+    skipped_exhausted: u32,
+}
+
+/// Longest the loop will wait when nothing is succeeding.
+///
+/// Bounds the retry storm without letting a transient outage park the queue
+/// for the full rate-limit backoff: a pass that fails is retried within five
+/// minutes, not five seconds.
+const MAX_IDLE_BACKOFF_SECS: u64 = 300;
+
+/// Seconds to wait before the next pass, given what the last one did.
+///
+/// # The fork storm this bounds
+///
+/// Measured in production over ~46 hours: 18,674 forks, one every ~9 seconds,
+/// continuously, while the queue sat flat at 59-61 rows. The shape is a batch
+/// of `batch_per_tick` (32) rows that each fail FAST - two primary attempts,
+/// so 64 spawns - re-attempted every `sweep_interval_secs` (5 s). Nothing in
+/// the loop distinguished "nothing to do" from "everything I tried failed", so
+/// a failing queue was retried at the same cadence as an idle one forever.
+///
+/// Note this is the opposite of the reported diagnosis. A row that *hangs*
+/// produces FEW forks - it sits in `wait_with_output`, not in `spawn` - so a
+/// high fork rate is positive evidence of fast failures, and pacing them is
+/// the fix rather than a timeout change.
+fn next_wait_secs(out: DrainOutcome, cfg: &SummariserConfig, consecutive_idle: u32) -> u64 {
+    // Progress, or nothing pending: keep the responsive cadence. An empty
+    // queue costs nothing to re-check, and the indexer's notify wakes it
+    // sooner anyway.
+    if out.summarised > 0 || out.seen == 0 {
+        return cfg.sweep_interval_secs;
+    }
+    // Everything that could have been worked on is waiting out a quota, and
+    // nothing failed for another reason. Wait out the backoff properly - this
+    // is the case the old `all_backed_off` flag was trying to express.
+    if out.failed == 0 && out.skipped_backoff > 0 {
+        return cfg.rate_limit_backoff_secs;
+    }
+    // Rows were attempted and none succeeded. Back off exponentially from the
+    // normal sweep so a wedged queue costs a fork every few minutes instead of
+    // 64 every few seconds. Capped, so recovery is still prompt.
+    if out.failed > 0 {
+        let factor = 1u64 << consecutive_idle.min(6);
+        return cfg
+            .sweep_interval_secs
+            .saturating_mul(factor)
+            .min(MAX_IDLE_BACKOFF_SECS);
+    }
+    // Everything left is exhausted (dead-lettered or capped) - there is
+    // nothing to retry until new rows seal, and the notify covers that.
+    cfg.sweep_interval_secs
+}
+
 /// The summariser task: drain the queue, then wait for an indexer notify or the
 /// catch-up sweep. Dormant if no coding agent is present. Backs off when the
 /// primary engine is unavailable (a failed row stays pending for a later drain).
@@ -594,15 +671,28 @@ pub async fn run_loop(
     // engine is available again. Keyed on app_name ("Claude Code", "Codex", …).
     // Only rows whose source is in backoff are skipped; other sources continue.
     let mut source_backoff: HashMap<String, std::time::Instant> = HashMap::new();
+    // Separate ledger for consecutive rate-limited reports — see
+    // `MAX_RATE_LIMITED_ROW_ATTEMPTS`.
+    let mut rate_limited_attempts: HashMap<i64, u32> = HashMap::new();
+    // Consecutive passes that attempted work and summarised nothing. Drives
+    // `next_wait_secs`'s exponential backoff so a wedged queue stops re-forking
+    // its whole batch every few seconds.
+    let mut consecutive_idle: u32 = 0;
     loop {
-        let all_backed_off = drain(&pool, &cfg, &mut attempts, &mut source_backoff).await;
-        let wait = if all_backed_off {
-            // Nothing could be processed (all pending rows are from backed-off
-            // sources). Wait out the backoff period rather than spinning.
-            cfg.rate_limit_backoff_secs
+        let out = drain(
+            &pool,
+            &cfg,
+            &mut attempts,
+            &mut rate_limited_attempts,
+            &mut source_backoff,
+        )
+        .await;
+        if out.summarised > 0 || out.failed == 0 {
+            consecutive_idle = 0;
         } else {
-            cfg.sweep_interval_secs
-        };
+            consecutive_idle = consecutive_idle.saturating_add(1);
+        }
+        let wait = next_wait_secs(out, &cfg, consecutive_idle);
         tokio::select! {
             _ = shutdown_rx.changed() => break,
             _ = notify.notified() => {}
@@ -642,8 +732,9 @@ async fn drain(
     pool: &SqlitePool,
     cfg: &SummariserConfig,
     attempts: &mut HashMap<i64, u32>,
+    rate_limited_attempts: &mut HashMap<i64, u32>,
     source_backoff: &mut HashMap<String, std::time::Instant>,
-) -> bool {
+) -> DrainOutcome {
     // Expire stale backoffs before deciding what to skip.
     let now_instant = std::time::Instant::now();
     source_backoff.retain(|_, until| *until > now_instant);
@@ -659,43 +750,82 @@ async fn drain(
         Ok(r) => r,
         Err(e) => {
             tracing::warn!(error = %crate::errors::chain(&e), "summariser: fetch_pending failed");
-            return false;
+            return DrainOutcome::default();
         }
     };
 
     if rows.is_empty() {
-        return false;
+        return DrainOutcome::default();
     }
 
-    let mut summarised = 0u32;
-    let mut skipped_backoff = 0u32;
+    let mut out = DrainOutcome {
+        seen: rows.len() as u32,
+        ..DrainOutcome::default()
+    };
 
     for row in &rows {
         // Skip rows whose agent source is still in rate-limit backoff.
         if source_backoff.contains_key(&row.agent) {
-            skipped_backoff += 1;
+            out.skipped_backoff += 1;
             continue;
         }
 
         let tries = attempts.get(&row.id).copied().unwrap_or(0);
         if tries >= MAX_ROW_ATTEMPTS {
+            out.skipped_exhausted += 1;
             continue; // dead-lettered this daemon lifetime
+        }
+        if rate_limited_attempts.get(&row.id).copied().unwrap_or(0) >= MAX_RATE_LIMITED_ROW_ATTEMPTS
+        {
+            out.skipped_exhausted += 1;
+            continue; // gave up on this row's endless "rate limited" reports
         }
 
         let outcome = summarise_one(pool, row, cfg, true).await;
         if outcome.written {
-            summarised += 1;
+            out.summarised += 1;
             // Row succeeded and moved past pending_summariser — drop its
             // ledger entry via record_attempt so `attempts` only ever holds
             // currently-pending rows that have failed at least once, not
             // every row that ever failed once over the daemon's lifetime.
             record_attempt(attempts, row.id, true);
+            // Same for the rate-limit ledger: a success means whatever quota
+            // was in the way has refilled, so the row starts clean if it is
+            // ever retried.
+            rate_limited_attempts.remove(&row.id);
         } else if outcome.rate_limited {
             // Apply per-source backoff so other sources can still drain.
             let until =
                 std::time::Instant::now() + Duration::from_secs(cfg.rate_limit_backoff_secs);
             source_backoff.insert(row.agent.clone(), until);
-            skipped_backoff += 1;
+            out.skipped_backoff += 1;
+            // Count it. This branch used to be the ONE outcome that never
+            // touched the ledger, which made `MAX_ROW_ATTEMPTS` inapplicable to
+            // it: a row that classified `RateLimited` on every attempt was
+            // retried forever and could never dead-letter. That is not a
+            // theoretical hole - `RATE_LIMIT_MARKERS` matches bare substrings
+            // like "429" and "quota" anywhere in an engine's output, and this
+            // is a developer tool whose transcripts are full of both, so a row
+            // failing for an unrelated reason can be misfiled as rate-limited
+            // and then never terminate.
+            //
+            // Counted against its OWN, much more generous cap rather than
+            // `MAX_ROW_ATTEMPTS`, because the intent behind this branch is
+            // still right: a quota refills, and it should be waited out rather
+            // than routed around. See `MAX_RATE_LIMITED_ROW_ATTEMPTS`.
+            let tries = record_rate_limited_attempt(rate_limited_attempts, row.id);
+            if tries >= MAX_RATE_LIMITED_ROW_ATTEMPTS {
+                if let Err(e) = db::write_dead_letter(pool, row.id).await {
+                    tracing::error!(row_id = row.id, error = %crate::errors::chain(&e), "failed to dead-letter a persistently rate-limited row");
+                }
+                tracing::warn!(
+                    row_id = row.id,
+                    attempts = tries,
+                    "row has reported rate-limited on every attempt for far longer than a \
+                     quota takes to refill - dead-lettering it rather than retrying forever \
+                     (it may be a misclassified failure)"
+                );
+            }
             tracing::warn!(
                 row_id = outcome.row_id,
                 source = %row.agent,
@@ -704,6 +834,7 @@ async fn drain(
             );
         } else {
             // Transient failure. Leave pending for retry; log so it isn't silent.
+            out.failed += 1;
             let tries = record_attempt(attempts, row.id, false)
                 .expect("record_attempt(.., written=false) always returns Some");
             if tries >= MAX_ROW_ATTEMPTS {
@@ -727,13 +858,11 @@ async fn drain(
         }
     }
 
-    if summarised > 0 {
-        tracing::info!(summarised, "summariser drain");
+    if out.summarised > 0 {
+        tracing::info!(summarised = out.summarised, "summariser drain");
     }
 
-    // Signal global backoff only when ALL rows were skipped due to source
-    // backoffs — nothing useful can be done until at least one source recovers.
-    skipped_backoff > 0 && skipped_backoff == rows.len() as u32 && summarised == 0
+    out
 }
 
 /// Updates the per-row failure ledger (`attempts`, see [`MAX_ROW_ATTEMPTS`])
@@ -748,6 +877,28 @@ async fn drain(
 /// On failure (`written = false`) the row's attempt count is incremented and
 /// the new count returned as `Some(tries)`, for the caller to compare against
 /// [`MAX_ROW_ATTEMPTS`].
+/// How many consecutive `RateLimited` outcomes a single row may report before
+/// it is dead-lettered anyway.
+///
+/// Deliberately far larger than [`MAX_ROW_ATTEMPTS`], and paced by
+/// `rate_limit_backoff_secs` (30 minutes by default) rather than the 5-second
+/// sweep - so this is roughly a day of genuinely waiting out a quota before
+/// giving up. A real usage limit refills long inside that; a row still
+/// reporting "rate limited" a day later is almost certainly a misclassified
+/// failure, and the alternative to giving up is retrying it forever.
+const MAX_RATE_LIMITED_ROW_ATTEMPTS: u32 = 48;
+
+/// Increment and return a row's consecutive rate-limited count.
+///
+/// Kept in a ledger separate from [`record_attempt`]'s so the two caps cannot
+/// interfere: a row that fails twice, then hits a genuine quota, must not
+/// arrive at the rate-limit cap carrying unrelated strikes.
+fn record_rate_limited_attempt(attempts: &mut HashMap<i64, u32>, row_id: i64) -> u32 {
+    let tries = attempts.get(&row_id).copied().unwrap_or(0) + 1;
+    attempts.insert(row_id, tries);
+    tries
+}
+
 fn record_attempt(attempts: &mut HashMap<i64, u32>, row_id: i64, written: bool) -> Option<u32> {
     if written {
         attempts.remove(&row_id);
@@ -944,6 +1095,157 @@ mod tests {
             attempts.get(&2),
             Some(&1),
             "row 2's independent failure count must be untouched"
+        );
+    }
+
+    // ── pacing + the rate-limit cap ─────────────────────────────────────────
+
+    fn cfg_for_pacing() -> SummariserConfig {
+        let mut c = SummariserConfig::from_env();
+        c.sweep_interval_secs = 5;
+        c.rate_limit_backoff_secs = 1800;
+        c
+    }
+
+    /// THE fork storm. Measured in production: 18,674 forks over ~46 hours,
+    /// one every ~9 s, while the queue sat flat. A batch of 32 rows that each
+    /// fail fast costs 64 spawns, and it used to be re-attempted every 5 s
+    /// forever because the loop could not tell "nothing to do" from
+    /// "everything I tried failed".
+    #[test]
+    fn a_failing_pass_backs_off_instead_of_re_forking_every_sweep() {
+        let cfg = cfg_for_pacing();
+        let failing = DrainOutcome {
+            seen: 32,
+            failed: 32,
+            ..DrainOutcome::default()
+        };
+        let mut prev = 0;
+        for idle in 1..=6 {
+            let w = next_wait_secs(failing, &cfg, idle);
+            assert!(
+                w > prev,
+                "wait must grow while nothing succeeds (idle={idle} gave {w}, previous {prev})"
+            );
+            prev = w;
+        }
+        assert!(
+            next_wait_secs(failing, &cfg, 1) > cfg.sweep_interval_secs,
+            "the first failing pass must already back off past the normal sweep"
+        );
+        assert_eq!(
+            next_wait_secs(failing, &cfg, 99),
+            MAX_IDLE_BACKOFF_SECS,
+            "backoff must cap so recovery stays prompt"
+        );
+    }
+
+    /// Progress and an empty queue both keep the responsive cadence - backing
+    /// off a working summariser would delay every summary.
+    #[test]
+    fn progress_and_idleness_keep_the_normal_sweep() {
+        let cfg = cfg_for_pacing();
+        let progressing = DrainOutcome {
+            seen: 4,
+            summarised: 4,
+            ..DrainOutcome::default()
+        };
+        assert_eq!(
+            next_wait_secs(progressing, &cfg, 3),
+            cfg.sweep_interval_secs,
+            "a pass that summarised must not inherit an earlier backoff"
+        );
+        assert_eq!(
+            next_wait_secs(DrainOutcome::default(), &cfg, 3),
+            cfg.sweep_interval_secs,
+            "an empty queue is cheap to re-check"
+        );
+    }
+
+    /// A genuine quota wall waits the full backoff rather than spinning.
+    #[test]
+    fn an_entirely_rate_limited_pass_waits_out_the_quota() {
+        let cfg = cfg_for_pacing();
+        let walled = DrainOutcome {
+            seen: 6,
+            skipped_backoff: 6,
+            ..DrainOutcome::default()
+        };
+        assert_eq!(
+            next_wait_secs(walled, &cfg, 0),
+            cfg.rate_limit_backoff_secs,
+            "nothing can proceed until a quota refills - do not spin on it"
+        );
+    }
+
+    /// The old `all_backed_off` flag required `skipped_backoff == rows.len()`,
+    /// so ONE failing row alongside backed-off ones collapsed the 30-minute
+    /// wait back to the 5-second sweep. It must still not spin - but it also
+    /// must not wait out the full quota, because the failing row is real work
+    /// that deserves a retry sooner than that.
+    #[test]
+    fn one_failure_beside_backed_off_rows_neither_spins_nor_stalls() {
+        let cfg = cfg_for_pacing();
+        let mixed = DrainOutcome {
+            seen: 10,
+            skipped_backoff: 9,
+            failed: 1,
+            ..DrainOutcome::default()
+        };
+        let w = next_wait_secs(mixed, &cfg, 1);
+        assert!(
+            w > cfg.sweep_interval_secs,
+            "a mixed pass collapsed back to the bare sweep - this is the spin"
+        );
+        assert!(
+            w < cfg.rate_limit_backoff_secs,
+            "the failing row must be retried well before the quota window elapses"
+        );
+    }
+
+    /// THE immortality bug. The `rate_limited` branch was the one outcome that
+    /// never touched a ledger, so `MAX_ROW_ATTEMPTS` did not apply to it and a
+    /// row misclassified as rate-limited retried forever. `RATE_LIMIT_MARKERS`
+    /// matches bare "429"/"quota" anywhere in an engine's output, and this is a
+    /// developer tool whose transcripts are full of both.
+    #[test]
+    fn a_persistently_rate_limited_row_eventually_terminates() {
+        let mut ledger: HashMap<i64, u32> = HashMap::new();
+        let mut last = 0;
+        for _ in 0..MAX_RATE_LIMITED_ROW_ATTEMPTS {
+            last = record_rate_limited_attempt(&mut ledger, 7);
+        }
+        assert_eq!(
+            last, MAX_RATE_LIMITED_ROW_ATTEMPTS,
+            "consecutive rate-limited reports must be counted, not ignored"
+        );
+    }
+
+    /// The two caps are independent: a row that failed twice and then hits a
+    /// genuine quota must not arrive at the rate-limit cap carrying unrelated
+    /// strikes, and vice versa.
+    #[test]
+    fn the_two_attempt_ledgers_do_not_bleed_into_each_other() {
+        let mut failures: HashMap<i64, u32> = HashMap::new();
+        let mut rate_limits: HashMap<i64, u32> = HashMap::new();
+        record_attempt(&mut failures, 42, false);
+        record_attempt(&mut failures, 42, false);
+        assert_eq!(record_rate_limited_attempt(&mut rate_limits, 42), 1);
+        assert_eq!(failures.get(&42), Some(&2));
+    }
+
+    /// Waiting out a quota must be generous - far longer than the fast-failure
+    /// cap - or a real usage limit would dead-letter a legitimate row.
+    #[test]
+    fn the_rate_limit_cap_is_far_more_patient_than_the_failure_cap() {
+        // Read through locals so this is a value comparison rather than an
+        // assertion on a constant expression (which clippy rejects).
+        let patient: u32 = MAX_RATE_LIMITED_ROW_ATTEMPTS;
+        let strict: u32 = MAX_ROW_ATTEMPTS;
+        assert!(
+            patient > strict.saturating_mul(10),
+            "a refilling quota must be waited out, not treated like a broken row \
+             (rate-limit cap {patient}, failure cap {strict})"
         );
     }
 }


### PR DESCRIPTION
Fixes issue **#3** from the 2026-08-27 production bug report. Two independent defects, and the report's mechanism ("stuck behind sessions that hang/time out") is the opposite of what the evidence shows.

## Why it isn't a hang

A hanging row produces **few** forks by construction - the process waits in `wait_with_output`, not in `spawn`. With `claude_timeout_s = 60` and two attempts, a genuinely hanging Claude row yields ~1 fork per 30 s; a Codex/Cursor row (240 s) ~1 per 60-240 s. The reported rate was **1 per 8.9 s** - 3 to 25x faster than hanging permits. The `Child::kill()` in the thread sample is `kill_on_drop`, which fires on the fast-failure path too.

## Defect A - immortal rows

Of `drain()`'s three outcome branches, `rate_limited` was the only one that never called `record_attempt`. `MAX_ROW_ATTEMPTS = 3` therefore did not apply to it, and such a row retried **forever**.

That matters because `RATE_LIMIT_MARKERS` is a case-insensitive substring scan whose entries include the bare strings `"429"` and `"quota"`, matched against engine output. This is a developer tool; a session spent debugging HTTP 429 handling or a billing quota puts those exact tokens into the transcript. A row failing for an unrelated reason gets misfiled as rate-limited and becomes permanently unkillable.

Consecutive rate-limited reports are now counted against their own cap (`MAX_RATE_LIMITED_ROW_ATTEMPTS = 48`, paced by the 30-minute backoff, so roughly a day of genuinely waiting out a quota) before dead-lettering.

**The classifier is deliberately unchanged.** Narrowing those markers risks *missing* a real limit, which would dead-letter legitimate rows against an exhausted quota - a worse failure than the one being fixed, and unnecessary now that the accounting bounds it either way. The two ledgers are kept separate so a row that failed twice and then hits a real quota doesn't arrive at the rate-limit cap carrying unrelated strikes.

## Defect B - the fork storm

The loop could not distinguish "nothing to do" from "everything I tried failed", so a batch of 32 fast-failing rows (2 spawns each = 64 forks) was re-attempted every `sweep_interval_secs` = 5 s, forever. At ~6 s per failing invocation that is a pass every ~415 s, or 1 fork per 6.5 s - matching the observed 8.9 s within noise, and matching the flat 59->61 queue exactly (a row needs 3 passes, ~21 minutes, to dead-letter).

`drain()` now returns what it actually did, and the wait backs off exponentially (capped at 5 minutes) whenever work was attempted and nothing succeeded.

## Also fixed: the signal that let both run at once

The old `all_backed_off` bool required `skipped_backoff == rows.len()`, so a **single** failing row alongside backed-off ones collapsed the 30-minute rate-limit wait back to the 5-second sweep. That is precisely what allowed Defect A and Defect B to coexist in one batch.

## Known residual, deliberately not fixed here

The attempt ledgers are `HashMap`s on `run_loop`'s stack, so they reset when the process restarts - and launchd `KeepAlive` restarts the daemon on every wake. A row still needs its strikes *within one process lifetime*. Making that durable needs a schema change to `app_sessions`, which I did not want to fold into a behavioural PR touching the same code path. With the backoff in place the residual is bounded (occasional retries, not a storm), and it is a clean follow-up.

## Not a defect

The report also asks for "enough detail per failure (session id, exit code, timeout vs. crash)". That already exists - `mod.rs:401/410/739/746` all carry `row_id` plus a discriminating cause - and goes to the telemetry spool, readable with `meridian logs`. That was a discoverability problem, not missing instrumentation.

## Verified

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` - 1117 (baseline 1110 + 7 new), 431 tray, 0 failures
- [x] pre-push suite

New tests: a failing pass backs off instead of re-forking every sweep, and the backoff caps; progress and idleness keep the normal cadence; an entirely rate-limited pass waits out the quota; one failure beside backed-off rows neither spins nor stalls; a persistently rate-limited row terminates; the two ledgers don't bleed into each other; the rate-limit cap stays far more patient than the failure cap.