### PR TITLE
fix(cli): add the restart subcommand five remedies already recommend

### DIFF
--- a/src/cli_flags.rs
+++ b/src/cli_flags.rs
@@ -256,6 +256,11 @@ pub const SPECS: &[Spec] = &[
                 [--endpoint URL] [--auth BASE64]",
     },
     Spec {
+        name: "restart",
+        flags: &[],
+        usage: "meridian restart   (restarts the background daemon)",
+    },
+    Spec {
         name: "logs",
         flags: &["--min-severity", "--service", "-n", "-f"],
         usage: "meridian logs [--service NAME] [--min-severity LEVEL] [-n N] [-f]",

--- a/src/health/diagnose.rs
+++ b/src/health/diagnose.rs
@@ -97,7 +97,7 @@ pub fn root_causes(report: &Report) -> Vec<Diagnosis> {
                 ("jira", "ticket sync"),
                 ("worklog", "hour ledger"),
             ]),
-            action: "`meridian start` (or `meridian doctor --fix`).".into(),
+            action: "`meridian restart` (or `meridian doctor --fix`).".into(),
         });
     }
 
@@ -194,11 +194,20 @@ pub fn escalation_hint(color: bool) -> String {
     };
     let bold = |s: &str| paint("\x1b[1m", s);
     let dim = |s: &str| paint("\x1b[2m", s);
+    // The `meridian logs` line is here because an operator debugging a stalled
+    // ETL on 2026-08-27 went to the paths in the launchd plist, found
+    // `daemon.log` at 0 bytes, and reported that logging was broken. It is not:
+    // those files are a crash-only safety net by design and every structured
+    // log goes to the telemetry spool, which `meridian logs` decodes. Nothing
+    // told them that, so the one tool that would have shown the fault went
+    // unused for 44.7 hours.
     format!(
-        "\n  {}\n    • {}  {}\n    • {}\n",
+        "\n  {}\n    • {}  {}\n    • {}  {}\n    • {}\n",
         bold("Still stuck?"),
         "meridian doctor --fix",
         dim("attempt automatic + guided repair"),
+        "meridian logs -f",
+        dim("live daemon logs (the files in ~/.meridian/logs are normally empty)"),
         dim("share this output with the team, or run: claude \"debug my meridian doctor output\""),
     )
 }

--- a/src/health/mod.rs
+++ b/src/health/mod.rs
@@ -247,6 +247,22 @@ impl Report {
             _ => paint("\x1b[32m", "  ✓ all systems healthy"),
         };
         out.push_str(&format!("{verdict}\n"));
+        // Where to look next. Reported from production 2026-08-27: an operator
+        // debugging a stalled ETL went to the paths in the launchd plist
+        // (`~/.meridian/logs/daemon.log`), found 0 bytes, and concluded logging
+        // was broken. It is not - those files are a crash-only safety net by
+        // design, and every structured log goes to the telemetry spool, which
+        // `meridian logs` decodes. Nothing anywhere told them that, so the one
+        // tool that would have shown the fault went unused. Printed
+        // unconditionally rather than only on a warning: the times you most
+        // need it are the times `doctor` looks fine and something is still off.
+        out.push_str(&format!(
+            "\n  {}\n",
+            dim(
+                "Logs: meridian logs [-f]   (the files in ~/.meridian/logs are a crash-only \
+                 safety net and are normally empty)"
+            )
+        ));
         out
     }
 

--- a/src/health/platform.rs
+++ b/src/health/platform.rs
@@ -181,9 +181,8 @@ pub fn daemon_service() -> Vec<Check> {
     use crate::platform::ServiceStatus;
     let run_check = match crate::platform::service_status(LABEL_DAEMON) {
         ServiceStatus::Running(pid) => Check::ok("daemon running", "system", format!("pid {pid}")),
-        ServiceStatus::NotRunning => {
-            Check::critical("daemon running", "system", "not loaded").with_remedy("meridian start")
-        }
+        ServiceStatus::NotRunning => Check::critical("daemon running", "system", "not loaded")
+            .with_remedy("meridian restart"),
         // Not "not running" — we have not looked. See ServiceStatus's docs.
         ServiceStatus::Unknown => Check::info(
             "daemon running",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod observability;
 pub mod plan_tasks;
 pub mod platform;
 pub mod pm_worklog;
+pub mod restart;
 pub mod telemetry_spool;
 pub mod uninstall;
 pub mod worklog_pipeline;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1040,6 +1040,30 @@ async fn main() -> Result<()> {
     // bash `meridian logs` (which tailed launchd-redirected stdout/stderr
     // text) now that the OTel spool is the sole log/trace sink — see
     // observability.rs's module doc. No daemon init needed.
+    // `meridian restart` - restart the managed daemon. This subcommand did not
+    //     exist while FIVE places in this same binary told users to run it,
+    //     including the Jira/Trello OAuth handlers' success output and
+    //     `doctor`'s etl-freshness remedy. It works on a source install only
+    //     because that path symlinks `meridian` at `scripts/meridian-cli.sh`,
+    //     whose bash `cmd_restart` has always existed; a DMG install runs this
+    //     binary directly and got `unknown subcommand "restart"`.
+    if std::env::args().nth(1).as_deref() == Some("restart") {
+        let outcome = meridian::restart::run();
+        let text = meridian::restart::describe(&outcome);
+        match outcome {
+            meridian::restart::Outcome::Restarted => {
+                println!("{text}");
+                return Ok(());
+            }
+            // Exit non-zero so a script (or the tray) can tell "restarted" from
+            // "there was nothing to restart" without parsing the message.
+            _ => {
+                eprintln!("{text}");
+                std::process::exit(1);
+            }
+        }
+    }
+
     if std::env::args().nth(1).as_deref() == Some("logs") {
         let args: Vec<String> = std::env::args().collect();
         meridian::telemetry_spool::render::run(&args).await;

--- a/src/restart.rs
+++ b/src/restart.rs
@@ -1,0 +1,250 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+//! `meridian restart` - stop and restart the background daemon.
+//!
+//! # Why this had to exist
+//!
+//! Five places in this binary already told users to run `meridian restart`,
+//! and on a packaged install the command did not exist:
+//!
+//! - `health::daemon`'s `etl freshness` remedy (the one a production user hit
+//!   on 2026-08-27, staring at a stalled ETL while `doctor` recommended a
+//!   command that answered `unknown subcommand "restart"`)
+//! - `main.rs`'s Jira and Trello OAuth handlers, printed on the **success**
+//!   path: "Tokens saved ... run `meridian restart` to pick them up"
+//! - `health::diagnose`'s expired-token remedy
+//! - `health::capture`'s persistent-failure remedy
+//!
+//! It worked for whoever wrote it, which is exactly why it survived: the
+//! **source** install symlinks `~/.local/bin/meridian` at
+//! `scripts/meridian-cli.sh`, whose bash `cmd_restart` has always existed. A
+//! **DMG** install has no wrapper - `~/.meridian/bin/meridian` is this native
+//! binary - so the same advice was a dead end for every packaged user.
+//!
+//! The OAuth case is the damaging one and had nothing to do with `doctor`: a
+//! user connects Jira, is told to run a command that does not exist, doesn't
+//! run it, and their tracker integration silently never picks up the tokens
+//! until something else happens to restart the daemon.
+//!
+//! # Why `kickstart -k` and not `bootout` + `bootstrap`
+//!
+//! `-k` is precisely what kills a running instance, and here that is what was
+//! asked for - unlike the tray's daemon watchdog, where `-k` on a daemon that
+//! was merely slow to answer an 800 ms probe corrupted `meridian.db` on every
+//! macOS install for days (see `tray/src-tauri/src/poll/watchdog.rs`, which
+//! now drops `-k` for exactly that reason).
+//! Two things make it correct in this module and not there: the user typed the
+//! command, and this runs in a **separate short-lived process**, so it is not
+//! the daemon signalling itself.
+//!
+//! `bootout` + `bootstrap` is deliberately NOT used. It is heavier, and the
+//! `launchctl disable` that tends to travel with it has already wedged a plist
+//! in this repo badly enough that `bootstrap` returned EIO and the agent had to
+//! be reinstalled by hand - see `crate::db::repair::marker`'s module docs.
+//! Recovery tooling must not be able to brick the thing it is recovering.
+//!
+//! # Who calls this
+//! `main.rs`'s subcommand dispatch, and every remedy string listed above.
+
+/// The daemon's launchd label on macOS. Must match the plist that
+/// `tray/src-tauri/src/backend_install.rs` renders.
+#[cfg(target_os = "macos")]
+const DAEMON_LABEL: &str = "com.meridiona.daemon";
+
+/// The daemon's Task Scheduler name on Windows. Must match
+/// `backend_install::WINDOWS_TASK_NAME`.
+#[cfg(target_os = "windows")]
+const WINDOWS_TASK_NAME: &str = "Meridian Daemon";
+
+/// What `meridian restart` did.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Outcome {
+    /// The service manager was asked to restart the daemon.
+    Restarted,
+    /// No service is registered for this user - a source/dev checkout, where
+    /// the daemon is run by hand or by `cargo watch`. Reported rather than
+    /// silently "succeeding", because a bare exit 0 here would look like the
+    /// restart happened.
+    NotRegistered,
+    /// The service manager refused.
+    Failed(String),
+}
+
+/// Human-readable result, ready to print. Separated from [`run`] so the
+/// wording is testable without a service manager.
+pub fn describe(outcome: &Outcome) -> String {
+    match outcome {
+        Outcome::Restarted => "Meridian daemon restarted.".to_string(),
+        Outcome::NotRegistered => {
+            // Plain hyphens: user-facing text (see the repo's hard rule).
+            "No Meridian daemon service is registered for your user.\n\
+             This is expected on a source checkout - start it the way you \
+             normally do (for example 'cargo run --bin meridian'), or install \
+             the app to get a managed daemon."
+                .to_string()
+        }
+        Outcome::Failed(why) => format!("Could not restart the Meridian daemon: {why}"),
+    }
+}
+
+/// Restart the managed daemon for the current user.
+pub fn run() -> Outcome {
+    #[cfg(target_os = "macos")]
+    {
+        let target = format!("gui/{}/{}", uid_str(), DAEMON_LABEL);
+        // Ask first, so a source checkout gets an explanation instead of
+        // launchctl's "Could not find service" spelled as a raw error.
+        if !service_is_loaded(&target) {
+            return Outcome::NotRegistered;
+        }
+        match std::process::Command::new("launchctl")
+            .args(["kickstart", "-k", &target])
+            .output()
+        {
+            Ok(o) if o.status.success() => Outcome::Restarted,
+            Ok(o) => Outcome::Failed(format!(
+                "launchctl kickstart exited {}: {}",
+                o.status,
+                String::from_utf8_lossy(&o.stderr).trim()
+            )),
+            Err(e) => Outcome::Failed(format!("could not run launchctl: {e}")),
+        }
+    }
+    #[cfg(target_os = "windows")]
+    {
+        // No atomic restart verb in Task Scheduler: end it, then run it. `/End`
+        // failing is not fatal - the task may simply not have been running -
+        // so only `/Run` decides the outcome.
+        let _ = std::process::Command::new("schtasks")
+            .args(["/End", "/TN", WINDOWS_TASK_NAME])
+            .output();
+        match std::process::Command::new("schtasks")
+            .args(["/Run", "/TN", WINDOWS_TASK_NAME])
+            .output()
+        {
+            Ok(o) if o.status.success() => Outcome::Restarted,
+            // schtasks reports a missing task on stderr with a non-zero exit;
+            // that is the Windows shape of "no service registered".
+            Ok(o) => {
+                let err = String::from_utf8_lossy(&o.stderr).trim().to_string();
+                if err.contains("cannot find the file specified") || err.contains("does not exist")
+                {
+                    Outcome::NotRegistered
+                } else {
+                    Outcome::Failed(format!("schtasks /Run exited {}: {err}", o.status))
+                }
+            }
+            Err(e) => Outcome::Failed(format!("could not run schtasks: {e}")),
+        }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        Outcome::NotRegistered
+    }
+}
+
+/// Whether launchd has the label loaded for this user.
+///
+/// `launchctl print` exits non-zero for a label that is not loaded at all,
+/// which is the source/dev case; it exits 0 both for "loaded and running" and
+/// "loaded but stopped", and `kickstart` is correct for either.
+#[cfg(target_os = "macos")]
+fn service_is_loaded(target: &str) -> bool {
+    std::process::Command::new("launchctl")
+        .args(["print", target])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// The current user's uid as launchd wants it in a `gui/<uid>/<label>` target.
+///
+/// Falls back to `501` (the first console user on macOS) rather than failing:
+/// a wrong uid produces a clean "not registered" message, whereas refusing to
+/// run produces nothing useful at all.
+#[cfg(target_os = "macos")]
+fn uid_str() -> String {
+    std::process::Command::new("id")
+        .arg("-u")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "501".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every message this prints is user-facing app text, so it takes plain
+    /// hyphens only - no em-dash or en-dash (repo hard rule).
+    #[test]
+    fn messages_use_plain_hyphens() {
+        for o in [
+            Outcome::Restarted,
+            Outcome::NotRegistered,
+            Outcome::Failed("boom".into()),
+        ] {
+            let s = describe(&o);
+            for bad in ['\u{2014}', '\u{2013}'] {
+                assert!(
+                    !s.contains(bad),
+                    "{s:?} contains {bad:?} - user-facing text takes a plain hyphen"
+                );
+            }
+        }
+    }
+
+    /// A source checkout must be told what happened rather than getting a
+    /// silent exit 0 that looks like the restart worked.
+    #[test]
+    fn an_unregistered_service_is_explained_not_faked() {
+        let s = describe(&Outcome::NotRegistered);
+        assert!(
+            s.contains("source checkout"),
+            "the dev case must say why there is no service: {s:?}"
+        );
+        assert!(
+            !s.contains("restarted"),
+            "must not imply a restart happened: {s:?}"
+        );
+    }
+
+    /// A failure has to carry the reason - the whole point is that the
+    /// previous behaviour ("unknown subcommand") told the operator nothing.
+    #[test]
+    fn a_failure_names_its_cause() {
+        assert!(
+            describe(&Outcome::Failed("launchctl exited 1".into())).contains("launchctl exited 1")
+        );
+    }
+
+    /// THE regression this module exists for. Every in-binary string that
+    /// tells a user to run `meridian restart` is only correct while the
+    /// subcommand is actually dispatched. Source-scanned because the dispatch
+    /// chain is `if` statements, not data.
+    #[test]
+    fn the_restart_subcommand_is_actually_dispatched() {
+        let main_rs = include_str!("main.rs");
+        assert!(
+            main_rs.contains("nth(1).as_deref() == Some(\"restart\")"),
+            "main.rs no longer dispatches `restart`, but health remedies and the \
+             OAuth success paths still tell users to run it - which is exactly the \
+             dead end reported from production on 2026-08-27"
+        );
+    }
+
+    /// The remedy strings and the subcommand must not drift apart again: if
+    /// something still recommends `meridian restart`, the command must exist
+    /// (asserted above), and if nothing recommends it any more this test
+    /// should be revisited rather than silently passing.
+    #[test]
+    fn something_still_recommends_the_command_this_module_implements() {
+        let health = include_str!("health/daemon.rs");
+        assert!(
+            health.contains("meridian restart"),
+            "health::daemon no longer recommends `meridian restart`; if that was \
+             deliberate, re-check whether this subcommand is still needed"
+        );
+    }
+}


### PR DESCRIPTION
Fixes issues **#2** and the discoverability half of **#5** from the 2026-08-27 production bug report.

> **Stacked on #920** (`fix/cli-reject-unknown-flags`) and targeted at that branch, not `pre-main`. It has to be: #920 adds a source-scan test asserting every dispatched subcommand has a flag-table entry, so adding `restart` on an independent branch would break that test the moment both merged. Retarget to `pre-main` once #920 lands.

## #2 - the remedy that only worked for the people who wrote it

`meridian restart` did not exist in the daemon binary, while **five** places inside it recommended it:

| where | when it fires |
|---|---|
| `health/daemon.rs:91` | `doctor`'s etl-freshness warning - the one the reporter hit |
| `main.rs:188` | **on successful Jira OAuth login** |
| `main.rs:225` | **on successful Trello OAuth login** |
| `health/diagnose.rs:79` | expired-token remedy |
| `health/capture.rs:504` | persistent capture failure |

It survived because a **source** install symlinks `~/.local/bin/meridian` at `scripts/meridian-cli.sh`, whose bash `cmd_restart` has always existed. A **DMG** install runs the native binary and got `unknown subcommand "restart"`.

The two OAuth sites are the ones that actually hurt, and they have nothing to do with `doctor`: a packaged user connects Jira, is told to run a command that doesn't exist, doesn't run it, and **their tracker integration silently never picks up the tokens** until something else restarts the daemon.

Rather than rewrite five strings to say something else, this makes the command they already name real.

### Implementation notes

- macOS `launchctl kickstart -k`; Windows `schtasks /End` then `/Run` (no atomic restart verb exists there).
- **`-k` is correct here and wrong in the tray's watchdog**, which is worth being explicit about given the history: `-k` on a daemon merely slow to answer an 800 ms probe is what corrupted `meridian.db` on every macOS install for days. Two things differ - the user typed the command, and this runs in a separate short-lived process rather than the daemon signalling itself.
- **Deliberately not `bootout` + `bootstrap`.** The `launchctl disable` that travels with it has already wedged a plist in this repo badly enough that `bootstrap` returned EIO and the agent needed a manual reinstall (`db/repair/marker.rs`). Recovery tooling must not be able to brick the thing it recovers.
- A source checkout with no registered service is **told so**, and exits non-zero, rather than getting a silent exit 0 that reads as a successful restart.

### Also found

`health/diagnose.rs:100` and `health/platform.rs:185` recommended **`meridian start`**, which doesn't exist either. `kickstart` covers stopped-and-loaded, so both now say `restart`.

## #5 - discoverability

The empty `daemon.log` is by design (the OTel spool is the sole sink; the launchd files are a crash-only net), and `log_level` is live and hot-reloaded - so the report's diagnosis is wrong. But its underlying complaint is right: **nothing anywhere told the operator that `meridian logs` exists**, so they read 0 bytes, concluded logging was broken, and never ran the one tool that would have shown the fault for 44.7 hours.

`doctor` now surfaces `meridian logs -f` in both render paths, and says the files in `~/.meridian/logs` are normally empty.

## Verified

```
$ meridian restart          # on this machine, no launchd agent registered
No Meridian daemon service is registered for your user.
This is expected on a source checkout - start it the way you normally do ...   # exit 1

$ meridian restart --help
meridian restart   (restarts the background daemon)
```

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` - 1125 (stacked base 1120 + 5 new), 431 tray, 0 failures
- [x] pre-push suite
- [x] `doctor` output inspected for both the corrected remedies and the new logs pointer

New tests include a source-scan guard that fails the build if `restart` stops being dispatched while the remedy strings still recommend it - the exact drift that caused this.