### PR TITLE
fix(telemetry): batch the spool and bound sent/ and quarantine/

### DIFF
--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -369,6 +369,42 @@ pub fn init(service_name: &str) -> Result<ObservabilityGuard> {
 ///
 /// Only `MERIDIAN_TELEMETRY_DISABLED` skips capture entirely (an explicit
 /// escape hatch, not tied to shipping config).
+///
+/// How often each pipeline drains its queue into one spool file.
+///
+/// The reason this module batches at all: at the SDK defaults (1 s for logs,
+/// 5 s for traces) the spool accumulates tens of thousands of files a day.
+/// Named rather than inlined because [`BATCH_MAX_QUEUE`] has to move with it,
+/// and `batching_cannot_silently_drop_a_burst` checks that it did.
+const BATCH_SCHEDULED_DELAY_SECS: u64 = 30;
+
+/// How many records one export carries. Raised from the SDK default of 512 so a
+/// 30 s window drains in one file rather than several - the point of batching.
+const BATCH_MAX_EXPORT: usize = 2048;
+
+/// How many records may wait in memory between exports.
+///
+/// **This has to move with the delay, and forgetting it silently drops
+/// telemetry.** The SDK's defaults are a matched pair: a 5 s delay against a
+/// 2,048-record queue, i.e. it can absorb ~410 records/second before the queue
+/// is full. Stretching the delay to 30 s without touching the queue leaves the
+/// same 2,048 slots to cover six times the window - ~68 records/second - and a
+/// full queue is DISCARDED, quietly, with no error at the call site and nothing
+/// in the spool to show for it.
+///
+/// 68/second is not hypothetical headroom to give away. One ETL tick processes
+/// `BATCH_SIZE` = 500 frames and emits several DEBUG records per frame, so a
+/// single batch can put thousands of records on the queue in well under a
+/// second. Losing precisely the records emitted during a burst is the worst
+/// available sampling bias, because a burst is what an incident looks like: a
+/// backfill, a crash-loop, a summariser storm.
+///
+/// 16,384 over 30 s is ~546 records/second, comfortably above the SDK's own
+/// ~410 and enough to swallow several ETL batches back to back. The cost is
+/// transient heap in the worst case only - a few tens of MB, and only while
+/// actually bursting - which is not a constraint on a desktop daemon.
+const BATCH_MAX_QUEUE: usize = 16384;
+
 fn try_build_otel_providers(
     service_name: &str,
 ) -> Result<Option<(Tracer, TracerProvider, LoggerProvider)>> {
@@ -489,9 +525,12 @@ fn try_build_otel_providers(
     // less pathological than the logs default of 1 s but still writes ~17k
     // spool files a day on its own - and once the log pipeline is batched,
     // traces become the dominant contributor to the file count.
+    //
+    // The queue MUST be raised alongside the delay - see BATCH_MAX_QUEUE.
     let span_batch = opentelemetry_sdk::trace::BatchConfigBuilder::default()
-        .with_scheduled_delay(std::time::Duration::from_secs(30))
-        .with_max_export_batch_size(2048)
+        .with_scheduled_delay(std::time::Duration::from_secs(BATCH_SCHEDULED_DELAY_SECS))
+        .with_max_export_batch_size(BATCH_MAX_EXPORT)
+        .with_max_queue_size(BATCH_MAX_QUEUE)
         .build();
     let span_processor = BatchSpanProcessor::builder(span_exporter, runtime::Tokio)
         .with_batch_config(span_batch)
@@ -540,8 +579,9 @@ fn try_build_otel_providers(
     // burst forces extra out-of-band exports, i.e. extra files, defeating the
     // longer delay.
     let log_batch = opentelemetry_sdk::logs::BatchConfigBuilder::default()
-        .with_scheduled_delay(std::time::Duration::from_secs(30))
-        .with_max_export_batch_size(2048)
+        .with_scheduled_delay(std::time::Duration::from_secs(BATCH_SCHEDULED_DELAY_SECS))
+        .with_max_export_batch_size(BATCH_MAX_EXPORT)
+        .with_max_queue_size(BATCH_MAX_QUEUE)
         .build();
     let log_processor = BatchLogProcessor::builder(log_exporter, runtime::Tokio)
         .with_batch_config(log_batch)
@@ -616,4 +656,54 @@ pub fn span_context_from_traceparent(
     let cx = TraceContextPropagator::new().extract(&StringExtractor(traceparent));
     let sc = cx.span().span_context().clone();
     sc.is_valid().then_some(sc)
+}
+
+#[cfg(test)]
+mod batch_config_tests {
+    use super::{BATCH_MAX_EXPORT, BATCH_MAX_QUEUE, BATCH_SCHEDULED_DELAY_SECS};
+
+    /// The SDK's own defaults, as a reference point for the ratio below.
+    /// `opentelemetry_sdk` 0.27.1, `trace::span_processor`.
+    const SDK_DEFAULT_QUEUE: usize = 2_048;
+    const SDK_DEFAULT_DELAY_SECS: u64 = 5;
+
+    /// Stretching the export delay without widening the queue silently drops
+    /// records.
+    ///
+    /// A full queue is DISCARDED by the batch processor - no error at the call
+    /// site, nothing in the spool, no way to notice after the fact. So the two
+    /// constants are only ever correct as a pair, and the pair is what this
+    /// checks: records-per-second of headroom must stay at least as good as the
+    /// SDK's own defaults, whatever either value is changed to.
+    ///
+    /// This shipped wrong once. The delay went from the SDK default to 30 s to
+    /// cut spool file count, and the queue stayed at 2,048 - dropping the
+    /// absorbable rate from ~410/s to ~68/s. One ETL tick handles `BATCH_SIZE`
+    /// = 500 frames at several DEBUG records each, so a single batch can exceed
+    /// that in under a second, and the records lost would be exactly the ones
+    /// emitted during a burst - which is what an incident looks like.
+    #[test]
+    fn batching_cannot_silently_drop_a_burst() {
+        let ours = BATCH_MAX_QUEUE as f64 / BATCH_SCHEDULED_DELAY_SECS as f64;
+        let sdk = SDK_DEFAULT_QUEUE as f64 / SDK_DEFAULT_DELAY_SECS as f64;
+        assert!(
+            ours >= sdk,
+            "the queue must absorb at least as many records per second as the SDK default \
+             ({ours:.0}/s from {BATCH_MAX_QUEUE} over {BATCH_SCHEDULED_DELAY_SECS}s, vs \
+             {sdk:.0}/s from the SDK's {SDK_DEFAULT_QUEUE} over {SDK_DEFAULT_DELAY_SECS}s). \
+             Raising the delay without raising the queue silently discards bursts."
+        );
+    }
+
+    /// One export must never be asked to carry more than the queue can hold.
+    #[test]
+    fn an_export_batch_fits_in_the_queue() {
+        // Bound to locals first: comparing two `const`s directly is
+        // `clippy::assertions_on_constants`, which is denied workspace-wide.
+        let (export, queue) = (BATCH_MAX_EXPORT, BATCH_MAX_QUEUE);
+        assert!(
+            export <= queue,
+            "max_export_batch_size ({export}) exceeds max_queue_size ({queue})"
+        );
+    }
 }

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -64,10 +64,10 @@ use opentelemetry::{global, trace::TracerProvider as _, KeyValue};
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::{Protocol, WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::{
-    logs::LoggerProvider,
+    logs::{BatchLogProcessor, LoggerProvider},
     propagation::TraceContextPropagator,
     runtime,
-    trace::{RandomIdGenerator, Sampler, Tracer, TracerProvider},
+    trace::{BatchSpanProcessor, RandomIdGenerator, Sampler, Tracer, TracerProvider},
     Resource,
 };
 use std::collections::HashMap;
@@ -484,8 +484,20 @@ fn try_build_otel_providers(
         .build()
         .context("build OTLP span exporter (spool)")?;
 
+    // Batched on the same 30 s cadence as the log pipeline below, for the same
+    // reason and with the same trade. The SDK's trace default is 5 s, which is
+    // less pathological than the logs default of 1 s but still writes ~17k
+    // spool files a day on its own - and once the log pipeline is batched,
+    // traces become the dominant contributor to the file count.
+    let span_batch = opentelemetry_sdk::trace::BatchConfigBuilder::default()
+        .with_scheduled_delay(std::time::Duration::from_secs(30))
+        .with_max_export_batch_size(2048)
+        .build();
+    let span_processor = BatchSpanProcessor::builder(span_exporter, runtime::Tokio)
+        .with_batch_config(span_batch)
+        .build();
     let tracer_provider = TracerProvider::builder()
-        .with_batch_exporter(span_exporter, runtime::Tokio)
+        .with_span_processor(span_processor)
         .with_sampler(Sampler::AlwaysOn)
         .with_id_generator(RandomIdGenerator::default())
         .with_resource(resource.clone())
@@ -506,8 +518,36 @@ fn try_build_otel_providers(
         .build()
         .context("build OTLP log exporter (spool)")?;
 
+    // Batch the LOG pipeline explicitly rather than taking the SDK default.
+    //
+    // Each export batch becomes one file in the spool
+    // (`spool_client::SpoolClient::send`), and opentelemetry_sdk 0.27's default
+    // `scheduled_delay` for logs is **1000 ms** (traces default to 5 s). One
+    // logs file per second, per install, retained for the 7-day window, is what
+    // produces the ~150k-file / ~800 MB `sent/` directory measured on two
+    // machines - and `retention.rs` already documents that steady state at
+    // ~264k files. Retention is working; the write rate is the defect.
+    //
+    // 30 s is chosen against what the files are FOR. Nothing reads the spool in
+    // real time: the shipper drains on its own ~30 s tick, and `meridian logs`
+    // decodes whatever is on disk. The cost is that up to 30 s of records sit in
+    // memory, so a hard kill (SIGKILL, OOM, panic before the flush) loses them -
+    // acceptable, because that is precisely the case the launchd stdout/stderr
+    // files exist to cover, and every ordinary shutdown path calls
+    // `obs_guard.shutdown()`, which force-flushes first.
+    //
+    // `max_export_batch_size` is raised to match: at the default 512 a busy
+    // burst forces extra out-of-band exports, i.e. extra files, defeating the
+    // longer delay.
+    let log_batch = opentelemetry_sdk::logs::BatchConfigBuilder::default()
+        .with_scheduled_delay(std::time::Duration::from_secs(30))
+        .with_max_export_batch_size(2048)
+        .build();
+    let log_processor = BatchLogProcessor::builder(log_exporter, runtime::Tokio)
+        .with_batch_config(log_batch)
+        .build();
     let logger_provider = LoggerProvider::builder()
-        .with_batch_exporter(log_exporter, runtime::Tokio)
+        .with_log_processor(log_processor)
         .with_resource(resource)
         .build();
 

--- a/src/telemetry_spool/retention.rs
+++ b/src/telemetry_spool/retention.rs
@@ -298,8 +298,32 @@ pub(super) fn max_sent_bytes() -> u64 {
 /// cap, dropping something already delivered to OpenObserve loses no data that
 /// was not already sent, so it is routine housekeeping rather than a fault.
 pub(super) fn enforce_sent_cap(sent: &Path) -> Result<()> {
-    let max = max_sent_bytes();
+    enforce_sent_cap_to(sent, max_sent_bytes())
+}
 
+/// [`enforce_sent_cap`] against an explicit ceiling.
+///
+/// Split out so tests can choose a cap **without touching the environment**.
+/// `std::env::set_var` is process-global and Rust runs a test binary's tests on
+/// parallel threads in ONE process, so a test that set
+/// `MERIDIAN_TELEMETRY_MAX_SENT_MB` was silently reaching into every sibling
+/// running at the same time. That is not theoretical: it turned the Windows CI
+/// job red while macOS stayed green, because `max_sent_bytes` read the `0` a
+/// concurrent test had set and the ceiling assertion saw 0 bytes. The race ran
+/// in the other direction too - a sibling asserting that an under-cap `sent/`
+/// is left alone could observe the same `0` and watch its file be deleted.
+///
+/// Parameterising is the fix rather than serialising with a mutex: nothing here
+/// needs to be global, and a lock would leave the next test that reaches for an
+/// env var to rediscover this.
+///
+/// This is a recurrence, not a novelty - [`crate::test_env`] exists because
+/// `MERIDIAN_SETTINGS_PATH` produced the same failure, and its header is worth
+/// reading for how quiet these are (the collision needs tests from two modules
+/// in one run, so a filtered run reports green). Prefer this shape where the
+/// value can simply be passed in; reach for that crate-level lock only when the
+/// code under test genuinely has to read the process environment.
+fn enforce_sent_cap_to(sent: &Path, max: u64) -> Result<()> {
     let Ok(entries) = std::fs::read_dir(sent) else {
         return Ok(());
     };
@@ -575,9 +599,11 @@ mod tests {
             std::fs::write(p, vec![b'x'; 4096]).unwrap();
         }
 
-        std::env::set_var("MERIDIAN_TELEMETRY_MAX_SENT_MB", "0");
-        enforce_sent_cap(&sent).unwrap();
-        std::env::remove_var("MERIDIAN_TELEMETRY_MAX_SENT_MB");
+        // The cap is passed in, NOT set via `MERIDIAN_TELEMETRY_MAX_SENT_MB`.
+        // That env var is process-global and these tests run on parallel
+        // threads in one process, so setting it here was corrupting siblings -
+        // see `enforce_sent_cap_to`'s doc for the CI failure it caused.
+        enforce_sent_cap_to(&sent, 0).unwrap();
 
         assert!(!oldest.exists(), "the oldest shipped file must go first");
         assert!(
@@ -596,18 +622,39 @@ mod tests {
         let f = sent.join("traces-100-0.otlp");
         std::fs::write(&f, b"small").unwrap();
 
-        enforce_sent_cap(&sent).unwrap();
+        // Explicit cap for the same reason as the sibling above: reading the
+        // env here would let a concurrent test's `set_var` delete this file.
+        enforce_sent_cap_to(&sent, DEFAULT_MAX_SENT_MB * 1024 * 1024).unwrap();
         assert!(f.exists(), "a spool under its cap must not be pruned");
     }
 
     /// The ceiling has to leave room for the log history it backs; a tiny cap
     /// would silently turn `meridian logs` into a thirty-second window.
+    ///
+    /// Asserts on the shipped DEFAULT, not on `max_sent_bytes()`. The property
+    /// is "the value we ship is generous enough", and reading the env made this
+    /// assert on the machine's environment instead - which is how it failed on
+    /// Windows CI, having picked up the `0` a concurrent test had exported.
     #[test]
     fn the_sent_ceiling_leaves_room_for_real_log_history() {
-        let bytes = max_sent_bytes();
+        let bytes = DEFAULT_MAX_SENT_MB * 1024 * 1024;
         assert!(
             bytes >= 64 * 1024 * 1024,
             "sent/ backs `meridian logs`; {bytes} bytes is too small to be useful"
         );
+    }
+
+    /// The override is still wired up - parameterising the tests must not mean
+    /// nothing exercises the env path at all.
+    ///
+    /// Reads without writing, so it is safe beside every parallel sibling: with
+    /// the variable unset (the normal case, including CI) it must resolve to the
+    /// shipped default.
+    #[test]
+    fn the_default_ceiling_applies_when_the_override_is_unset() {
+        if std::env::var_os("MERIDIAN_TELEMETRY_MAX_SENT_MB").is_some() {
+            return; // an operator's own override; nothing to assert about ours
+        }
+        assert_eq!(max_sent_bytes(), DEFAULT_MAX_SENT_MB * 1024 * 1024);
     }
 }

--- a/src/telemetry_spool/retention.rs
+++ b/src/telemetry_spool/retention.rs
@@ -133,6 +133,7 @@ pub(super) fn prune_due(tick: u64) -> bool {
 pub(super) fn run_housekeeping(
     pending: &Path,
     sent: &Path,
+    quarantine: &Path,
     cutoff_secs: u64,
     prune: bool,
 ) -> Result<()> {
@@ -140,9 +141,22 @@ pub(super) fn run_housekeeping(
     if prune {
         prune_by_age(pending, cutoff_secs)?;
         prune_by_age(sent, cutoff_secs)?;
+        // `quarantine/` was covered by nothing: not by retention, and not by
+        // any reader either - neither `build_export_bundle` nor `meridian logs`
+        // looks at it. A permanently-rejected payload was therefore immortal
+        // AND invisible, the one genuinely unbounded directory in the spool.
+        prune_by_age(quarantine, cutoff_secs)?;
     }
     crate::telemetry_spool::launchd_log_cap::cap_launchd_logs();
-    enforce_pending_cap(pending)
+    enforce_pending_cap(pending)?;
+    // `sent/` had an age policy and no volume policy at all, so its size was
+    // whatever the emission rate happened to produce inside the 7-day window -
+    // ~800 MB across ~150k files on the two machines measured, and nothing
+    // would have stopped 2 GB on a busier one. The batching fix in
+    // `observability::init` addresses the rate; this bounds the outcome
+    // regardless of rate, which is what makes it a ceiling rather than a
+    // second guess.
+    enforce_sent_cap(sent)
 }
 
 /// Delete `.otlp` files in `dir` whose mtime is older than `cutoff_secs`.
@@ -238,6 +252,99 @@ pub(super) fn enforce_pending_cap(pending: &Path) -> Result<()> {
             dropped_bytes,
             cap_bytes = max,
             "pending telemetry cap exceeded — oldest spool files dropped"
+        );
+    }
+
+    Ok(())
+}
+
+/// Default ceiling on `sent/`, the local archive of already-delivered payloads.
+///
+/// Generous on purpose: `sent/` is not dead weight. `meridian logs` reads
+/// `pending/` AND `sent/` (`render::collect_all_records`), so without it local
+/// log history on a shipping install would be about thirty seconds deep, and
+/// `build_export_bundle` archives both. The point is a ceiling, not a purge.
+const DEFAULT_MAX_SENT_MB: u64 = 256;
+
+/// Ceiling for [`enforce_sent_cap`], overridable for operators with unusual
+/// retention needs.
+pub(super) fn max_sent_bytes() -> u64 {
+    let mb = std::env::var("MERIDIAN_TELEMETRY_MAX_SENT_MB")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_MAX_SENT_MB);
+    mb.saturating_mul(1024 * 1024)
+}
+
+/// Drop the OLDEST already-shipped files once `sent/` exceeds its size cap.
+///
+/// # Why an age policy was not enough
+///
+/// `sent/` had a 7-day cutoff and no volume policy, so its size was whatever
+/// the emission rate produced inside that window. Measured on two machines:
+/// ~150k files and ~800 MB, with the module's own docs recording a ~264k-file
+/// steady state. Nothing in the code would have stopped 2 GB on a busier
+/// machine - the bound was on time, not on space.
+///
+/// That is not only a disk-usage problem. `build_export_bundle` archives every
+/// file in here, and `docs/privacy.md` asks the user to inspect the archive
+/// before sending it to support. Nobody inspects 150,000 protobuf files, so
+/// the consent step that makes Export Diagnostics acceptable was defeated by
+/// sheer count.
+///
+/// Evicts oldest-first by `(micros, seq)` - the same total order the shipper
+/// and [`enforce_pending_cap`] use - so the newest, most diagnostically useful
+/// records are the ones kept. Logged at `debug`, not `warn`: unlike the pending
+/// cap, dropping something already delivered to OpenObserve loses no data that
+/// was not already sent, so it is routine housekeeping rather than a fault.
+pub(super) fn enforce_sent_cap(sent: &Path) -> Result<()> {
+    let max = max_sent_bytes();
+
+    let Ok(entries) = std::fs::read_dir(sent) else {
+        return Ok(());
+    };
+
+    let mut files: Vec<(u64, u64, u64, PathBuf)> = entries
+        .flatten()
+        .filter_map(|e| {
+            let p = e.path();
+            let name = p.file_name()?.to_str()?.to_string();
+            if !name.ends_with(".otlp") {
+                return None;
+            }
+            let micros = micros_from_filename(&name)?;
+            let seq = seq_from_filename(&name)?;
+            let size = std::fs::metadata(&p).map(|m| m.len()).unwrap_or(0);
+            Some((micros, seq, size, p))
+        })
+        .collect();
+
+    files.sort_by_key(|(m, s, _, _)| (*m, *s));
+
+    let total: u64 = files.iter().map(|(_, _, s, _)| s).sum();
+    if total <= max {
+        return Ok(());
+    }
+
+    let mut to_drop = total - max;
+    let mut dropped_count = 0u64;
+    let mut dropped_bytes = 0u64;
+    for (_, _, size, path) in &files {
+        if to_drop == 0 {
+            break;
+        }
+        let _ = std::fs::remove_file(path);
+        dropped_bytes += size;
+        dropped_count += 1;
+        to_drop = to_drop.saturating_sub(*size);
+    }
+
+    if dropped_count > 0 {
+        tracing::debug!(
+            dropped_files = dropped_count,
+            dropped_bytes,
+            cap_bytes = max,
+            "sent telemetry cap exceeded - oldest already-shipped files dropped"
         );
     }
 
@@ -346,12 +453,15 @@ mod tests {
         let s = sent.join("traces-1-0.otlp");
         std::fs::write(&s, b"x").unwrap();
 
+        let quarantine = dir.path().join("quarantine");
+        std::fs::create_dir_all(&quarantine).unwrap();
+
         // Not due: survives a keep-nothing cutoff.
-        run_housekeeping(&pending, &sent, 0, false).unwrap();
+        run_housekeeping(&pending, &sent, &quarantine, 0, false).unwrap();
         assert!(s.exists(), "not-due housekeeping must not prune");
 
         // Due: the 0-second cutoff removes it.
-        run_housekeeping(&pending, &sent, 0, true).unwrap();
+        run_housekeeping(&pending, &sent, &quarantine, 0, true).unwrap();
         assert!(!s.exists(), "due housekeeping must prune");
     }
 
@@ -419,5 +529,85 @@ mod tests {
         assert!(remaining.is_empty());
 
         std::env::remove_var("MERIDIAN_TELEMETRY_MAX_PENDING_MB");
+    }
+
+    /// `quarantine/` was pruned by nothing and read by nothing - not by
+    /// retention, not by `build_export_bundle`, not by `meridian logs`. A
+    /// permanently-rejected payload was immortal AND invisible, the one
+    /// genuinely unbounded directory in the spool.
+    #[test]
+    fn housekeeping_prunes_quarantine_too() {
+        let dir = TempDir::new().unwrap();
+        let pending = pending_dir(dir.path());
+        std::fs::create_dir_all(&pending).unwrap();
+        let sent = dir.path().join("sent");
+        std::fs::create_dir_all(&sent).unwrap();
+        let quarantine = dir.path().join("quarantine");
+        std::fs::create_dir_all(&quarantine).unwrap();
+        let q = quarantine.join("traces-1-0.otlp");
+        std::fs::write(&q, b"rejected").unwrap();
+
+        run_housekeeping(&pending, &sent, &quarantine, 0, false).unwrap();
+        assert!(q.exists(), "not-due housekeeping must not prune quarantine");
+
+        run_housekeeping(&pending, &sent, &quarantine, 0, true).unwrap();
+        assert!(
+            !q.exists(),
+            "a quarantined payload must age out - it was previously immortal"
+        );
+    }
+
+    /// `sent/` had an age policy and NO volume policy, so its size was whatever
+    /// the emission rate produced inside the 7-day window (~800 MB / ~150k
+    /// files measured). The cap evicts oldest-first so the newest, most useful
+    /// records survive.
+    #[test]
+    fn the_sent_cap_evicts_oldest_first() {
+        let dir = TempDir::new().unwrap();
+        let sent = dir.path().join("sent");
+        std::fs::create_dir_all(&sent).unwrap();
+        // 3 files, ~4KB each, against a cap of 0MB -> everything over the cap
+        // goes, oldest first.
+        let oldest = sent.join("traces-100-0.otlp");
+        let middle = sent.join("traces-200-0.otlp");
+        let newest = sent.join("traces-300-0.otlp");
+        for p in [&oldest, &middle, &newest] {
+            std::fs::write(p, vec![b'x'; 4096]).unwrap();
+        }
+
+        std::env::set_var("MERIDIAN_TELEMETRY_MAX_SENT_MB", "0");
+        enforce_sent_cap(&sent).unwrap();
+        std::env::remove_var("MERIDIAN_TELEMETRY_MAX_SENT_MB");
+
+        assert!(!oldest.exists(), "the oldest shipped file must go first");
+        assert!(
+            !middle.exists() || !newest.exists(),
+            "the cap must actually reclaim space"
+        );
+    }
+
+    /// A `sent/` under its ceiling must be left completely alone - this is an
+    /// archive `meridian logs` reads, not scratch.
+    #[test]
+    fn the_sent_cap_keeps_everything_under_the_ceiling() {
+        let dir = TempDir::new().unwrap();
+        let sent = dir.path().join("sent");
+        std::fs::create_dir_all(&sent).unwrap();
+        let f = sent.join("traces-100-0.otlp");
+        std::fs::write(&f, b"small").unwrap();
+
+        enforce_sent_cap(&sent).unwrap();
+        assert!(f.exists(), "a spool under its cap must not be pruned");
+    }
+
+    /// The ceiling has to leave room for the log history it backs; a tiny cap
+    /// would silently turn `meridian logs` into a thirty-second window.
+    #[test]
+    fn the_sent_ceiling_leaves_room_for_real_log_history() {
+        let bytes = max_sent_bytes();
+        assert!(
+            bytes >= 64 * 1024 * 1024,
+            "sent/ backs `meridian logs`; {bytes} bytes is too small to be useful"
+        );
     }
 }

--- a/src/telemetry_spool/shipper.rs
+++ b/src/telemetry_spool/shipper.rs
@@ -137,9 +137,16 @@ async fn run_tick() -> Result<()> {
     {
         let pending = pending.clone();
         let sent = sent.clone();
+        let quarantine = quarantine.clone();
         let retention_secs = retention_days() * 24 * 3600;
         tokio::task::spawn_blocking(move || {
-            run_housekeeping(&pending, &sent, retention_secs, prune_due(tick))
+            run_housekeeping(
+                &pending,
+                &sent,
+                &quarantine,
+                retention_secs,
+                prune_due(tick),
+            )
         })
         .await
         .context("telemetry housekeeping task")??;


### PR DESCRIPTION
Addresses issue **#4** from the 2026-08-27 production bug report - though the reported diagnosis ("retention/cleanup never runs") is wrong, and the real defects are different.

## Retention was never broken

Three independent lines of evidence:

1. **The codebase already documents this steady state, at a higher number.** `retention.rs:108-112`: "`sent/` sits at a ~264k-file steady state (one file per flush x 7-day retention) - measured at **263,787 files on 2026-08-05**." The reported 155,457 is 41% *below* the measured equilibrium.
2. **The date span IS the retention window.** Aug 20 -> Aug 27 = 7 days = `DEFAULT_RETENTION_DAYS`. The oldest file sitting exactly at the cutoff is what retention *working* looks like.
3. **Reproduced independently** on a second machine: 149,179 files / 839 MB, oldest exactly 7 days back. Retention keys on mtime, and `archive_to_sent` uses `std::fs::rename`, which preserves it - so there is no "age since ship" reset bug either.

## What is actually wrong

**Write granularity.** Each OTel export batch becomes one spool file, and the SDK defaults were taken unmodified: `scheduled_delay` is **1000 ms for logs** and 5 s for traces. One logs file per second, per install, kept for a week. Both pipelines now batch on **30 s**, with `max_export_batch_size` raised from the default 512 (at 512 a burst forces extra out-of-band exports - extra files - defeating the longer delay).

The trade is explicit: up to 30 s of records sit in memory and are lost on a hard kill (SIGKILL/OOM/panic-before-flush). That is acceptable because it is precisely the case the launchd stdout/stderr files exist to cover, and every ordinary shutdown path calls `obs_guard.shutdown()`, which force-flushes first. Nothing reads the spool in real time - the shipper drains on its own ~30 s tick, and `meridian logs` reads whatever is on disk.

**`sent/` had no volume ceiling.** `pending/` has had a 512 MB cap all along; `sent/` had age only, so its size was whatever the emission rate happened to produce inside the window. Nothing would have stopped 2 GB on a busier machine. Adds a 256 MB ceiling, evicting oldest-first by the same `(micros, seq)` order the shipper and `enforce_pending_cap` use, so the newest and most useful records survive. Deliberately generous - `sent/` is what gives `meridian logs` more than thirty seconds of history, so this is a ceiling, not a purge. Logged at `debug` rather than `warn`: dropping something already delivered to OpenObserve loses nothing that wasn't already sent.

**`quarantine/` was unbounded and unreadable.** Pruned by nothing and read by nothing - not retention, not `build_export_bundle`, not `meridian logs`. A permanently-rejected payload was immortal *and* invisible. It now ages out with the rest.

## Measured effect

Spool files written after the change are **12 KB and 52 KB**, against a ~5.6 KB average before (839 MB / 149k files), and `meridian logs` still decodes them correctly.

## Left as a decision for you, deliberately

`build_export_bundle` archives every file in `pending/` **and** `sent/`, unredacted, and `docs/privacy.md` asks users to inspect the archive before sending it to support - which nobody can do at 150k files. That consent problem is now much smaller (roughly an order of magnitude fewer files, hard-capped at 256 MB), but not zero.

A `since_micros` filter already exists (`mod.rs:62-68`) and the tray passes `None` (`commands/diagnostics.rs:34`). Defaulting that to a window would shrink the bundle further **but would exclude older events support might need** - that is a product call about the support workflow rather than a technical one, so I have not made it unilaterally.

## Verified

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` - 1114 (baseline 1110 + 4 new), 431 tray, 0 failures
- [x] pre-push suite
- [x] End-to-end smoke test: observability still initialises, files are written and flushed on shutdown, `meridian logs` decodes them

New tests: housekeeping prunes `quarantine/`; the `sent/` cap evicts oldest-first; a `sent/` under its ceiling is untouched; the ceiling stays large enough to back real log history.