### PR TITLE
feat(llm): connect any OpenAI-compatible endpoint, local or cloud

### DIFF
--- a/src/llm/openai_compat.rs
+++ b/src/llm/openai_compat.rs
@@ -15,6 +15,11 @@
 //! the standard OpenAI chat-completions protocol; the deltas from a bare call are the
 //! base URL, `Authorization: Bearer`, and [`crate::llm::schema::strictify`] on the way out.
 //!
+//! # Not every endpoint has a key
+//! A self-hosted server (Ollama, LM Studio, llama.cpp, vLLM) typically has no auth, so an
+//! empty `api_key` is a supported configuration and [`with_auth`] then sends NO
+//! `Authorization` header — which is a different thing on the wire from an empty one.
+//!
 //! # Structured output is measured, never assumed
 //! "OpenAI-compatible" endpoints disagree about schemas — measured 2026-07-17, OpenAI
 //! rejects a schema whose `required` omits an optional key while Gemini's compat endpoint
@@ -140,6 +145,26 @@ async fn read_capped_body(mut resp: reqwest::Response) -> Result<String, LlmErro
     Ok(String::from_utf8_lossy(&buf).into_owned())
 }
 
+/// Attach `Authorization: Bearer <key>` — unless the endpoint is KEYLESS, in which case no
+/// auth header is sent at all.
+///
+/// An empty key is a real configuration, not a mistake: a self-hosted OpenAI-compatible
+/// server (Ollama, LM Studio, llama.cpp, vLLM) usually has no auth, and there is nothing to
+/// send it. The distinction matters on the wire — `.bearer_auth("")` sends a well-formed
+/// header with an empty credential, which is NOT the same as sending none, and some servers
+/// reject the former while accepting the latter. Sending nothing is also the honest
+/// description of what the user configured.
+///
+/// Whether an empty key is ALLOWED is decided at the door, in the tray's
+/// `validate_transport_inputs`; by the time a request is built the answer is already yes.
+fn with_auth(rb: reqwest::RequestBuilder, api_key: &str) -> reqwest::RequestBuilder {
+    if api_key.is_empty() {
+        rb
+    } else {
+        rb.bearer_auth(api_key)
+    }
+}
+
 /// Ask an OpenAI-compatible endpoint what models it serves — `GET <base_url>/models`.
 ///
 /// Takes the base URL and key rather than a [`CustomEndpoint`] because the main caller is the
@@ -177,9 +202,7 @@ pub async fn list_models(
         .build()
         .map_err(|e| LlmError::Failed(format!("custom provider client: {e}")))?;
 
-    let resp = client
-        .get(&url)
-        .bearer_auth(api_key)
+    let resp = with_auth(client.get(&url), api_key)
         .send()
         .await
         // As in `complete`: `e` can carry the URL but never the key (reqwest redacts auth).
@@ -262,9 +285,7 @@ impl LlmBackend for OpenAiCompatBackend {
             .build()
             .map_err(|e| LlmError::Failed(format!("custom provider client: {e}")))?;
 
-        let resp = client
-            .post(&url)
-            .bearer_auth(&ep.api_key)
+        let resp = with_auth(client.post(&url), &ep.api_key)
             .json(&body)
             .send()
             .await
@@ -493,6 +514,43 @@ fn classify_error(
         ));
     }
     LlmError::Failed(format!("custom provider {status}: {head}"))
+}
+
+#[cfg(test)]
+mod auth_header_tests {
+    use super::*;
+
+    /// Build a request the way the real call sites do and report its `Authorization` header.
+    fn auth_of(api_key: &str) -> Option<String> {
+        let client = reqwest::Client::new();
+        let req = with_auth(client.get("http://localhost:11434/v1/models"), api_key)
+            .build()
+            .expect("request builds");
+        req.headers()
+            .get(reqwest::header::AUTHORIZATION)
+            .map(|v| v.to_str().unwrap_or_default().to_string())
+    }
+
+    /// A keyless endpoint must send NO `Authorization` header - not an empty one.
+    ///
+    /// The distinction is invisible in the source (`.bearer_auth("")` reads as "no key") and
+    /// very visible on the wire: it sends `Authorization: Bearer `, a well-formed header with
+    /// an empty credential, which some servers reject outright while accepting a request that
+    /// simply carries no auth. This is the whole reason a local model can be connected, so it
+    /// is pinned at the header rather than trusted to the call sites.
+    #[test]
+    fn a_keyless_endpoint_sends_no_authorization_header() {
+        assert_eq!(auth_of(""), None);
+    }
+
+    /// The other half: a key that IS present must still be sent, unchanged.
+    #[test]
+    fn a_key_is_still_sent_as_a_bearer_token() {
+        assert_eq!(
+            auth_of("sk-test-123"),
+            Some("Bearer sk-test-123".to_string())
+        );
+    }
 }
 
 #[cfg(test)]

--- a/tray/src-tauri/src/commands/custom_llm.rs
+++ b/tray/src-tauri/src/commands/custom_llm.rs
@@ -255,14 +255,27 @@ fn make_id(name: &str, existing: &[CustomLlmProvider]) -> String {
 /// drift — a rule enforced on the add path but not the listing path would be a rule with a
 /// hole in it.
 fn validate_transport_inputs(base_url: &str, api_key: &str) -> Result<(), String> {
-    if api_key.trim().is_empty() {
-        return Err("API key is required".into());
-    }
+    // NO EMPTY-KEY REJECTION, deliberately. A self-hosted OpenAI-compatible server (Ollama,
+    // LM Studio, llama.cpp, vLLM) usually has no auth at all, and there is no key for the
+    // user to invent - requiring one made every local endpoint unconfigurable, which is the
+    // gap this allowance exists to close. A blank key sends no `Authorization` header (see
+    // `openai_compat::with_auth`), so nothing is leaked by permitting it.
+    //
+    // A blank key against an endpoint that DOES require one is not silently accepted either:
+    // it fails at `list_models` or at the probe, both of which run during setup with the user
+    // watching, and both of which report a 401 in the vendor's own words. That is the right
+    // place to find out - unlike a wrong MODEL, which would only surface hours later.
+    //
+    // The reachability rule that was considered and rejected: allowing a blank key only for
+    // loopback/RFC1918 hosts. It would have refused Tailscale (100.64/10), Docker host
+    // aliases and reverse-proxied local models, all of them legitimate, in exchange for
+    // approximately no security - an EMPTY credential discloses nothing wherever it is sent.
     if !base_url.starts_with("http://") && !base_url.starts_with("https://") {
         return Err("base URL must start with http:// or https://".into());
     }
     // The key becomes an Authorization header and the URL becomes a request line: a newline
     // in either is header injection, exactly as `oo_email`/`oo_password` guard against.
+    // Still checked for a BLANK key: blank is allowed, whitespace-with-a-newline is not.
     for (field, v) in [("API key", api_key), ("base URL", base_url)] {
         if v.contains('\n') || v.contains('\r') {
             return Err(format!("{field} contains invalid characters"));
@@ -876,10 +889,31 @@ mod tests {
         assert!(validate("n", "https://x.test/v1", "m", "k").is_ok());
         assert!(validate("", "https://x.test/v1", "m", "k").is_err());
         assert!(validate("n", "https://x.test/v1", "", "k").is_err());
-        assert!(validate("n", "https://x.test/v1", "m", "").is_err());
         assert!(validate("n", "ftp://x.test", "m", "k").is_err());
         assert!(validate("n", "https://x.test/v1", "m", "k\nX-Evil: 1").is_err());
         assert!(validate("n", "https://x.test/v1\r\nHost: evil", "m", "k").is_err());
+    }
+
+    /// A KEYLESS endpoint is a supported configuration, not a half-filled form.
+    ///
+    /// This assertion used to read `is_err()` - "API key is required" - and that single line
+    /// was the whole reason no self-hosted server could be configured: Ollama, LM Studio,
+    /// llama.cpp and vLLM serve the OpenAI protocol with no auth, so there is no key for the
+    /// user to type. Both doors are pinned here because they are separate call sites of the
+    /// shared validator, and the listing one runs FIRST in the setup flow - leaving it strict
+    /// would have failed the flow at "ask the endpoint what it serves", before the add.
+    #[test]
+    fn a_keyless_endpoint_is_allowed_at_both_doors() {
+        assert!(validate("local", "http://localhost:11434/v1", "llama3", "").is_ok());
+        assert!(validate_transport_inputs("http://localhost:1234/v1", "").is_ok());
+        // Plain http is what a local server actually speaks - the scheme check must not have
+        // quietly become https-only while the key rule was being relaxed.
+        assert!(validate_transport_inputs("http://127.0.0.1:8000/v1", "").is_ok());
+        // Blank is allowed; blank-with-a-newline is still header injection.
+        assert!(validate_transport_inputs("http://localhost:11434/v1", " \n ").is_err());
+        // Relaxing the key must not have relaxed anything else on the same path.
+        assert!(validate("local", "localhost:11434", "llama3", "").is_err());
+        assert!(validate("local", "http://localhost:11434/v1", "", "").is_err());
     }
 
     /// One unreadable row must not cost the user every other endpoint.

--- a/ui/__tests__/llm-provider-gate.test.ts
+++ b/ui/__tests__/llm-provider-gate.test.ts
@@ -17,6 +17,7 @@ const uiRoot = import.meta.dir + '/..'
 const gate = readFileSync(`${uiRoot}/components/LlmProviderGate.tsx`, 'utf8')
 const cloudSetup = readFileSync(`${uiRoot}/components/CloudKeySetup.tsx`, 'utf8')
 const picker = readFileSync(`${uiRoot}/components/LlmProviderPicker.tsx`, 'utf8')
+const customSetup = readFileSync(`${uiRoot}/components/CustomEndpointSetup.tsx`, 'utf8')
 
 describe('the subscription gate', () => {
   it('asks about all three subscriptions by name', () => {
@@ -118,20 +119,73 @@ describe('the no-subscription presets', () => {
     expect(presetForVendor('does-not-exist')).toBeUndefined()
   })
 
-  it('is the only way an endpoint gets added', () => {
-    // Gemini / OpenRouter / OpenAI / a free-text endpoint all made the no-subscription path
-    // a configuration exercise for someone who came here to avoid one. Once the preset list
-    // was down to a curated set the add FORM was a questionnaire nobody needed, so it and
-    // its tile went too - this pins that they stay gone.
+  it('is the only way an endpoint gets added ON THE NO-SUBSCRIPTION PATH', () => {
+    // WHAT THIS PINS CHANGED, and the old version would not have noticed.
+    //
+    // It used to scan for three dead identifiers (`AddCustomProvider`, `AddForm`,
+    // `CUSTOM_VENDOR_PRESETS`) to pin that the free-text add form stayed deleted. A form has
+    // since been deliberately restored as `<CustomEndpointSetup>`, for the separate need of
+    // connecting an arbitrary OpenAI-compatible endpoint - and every one of those three
+    // assertions still passed, because none of those words appears in the new file. A test
+    // that cannot fail when the thing it describes is reversed is not protecting anything.
+    //
+    // So it now pins the invariant that actually still holds, which was always the real one:
+    // the GATE - the "I have no subscription" answer - routes to the walkthrough and never to
+    // a form. What made the deleted form wrong was where it stood, not that it existed.
+    const gateBranch = picker.slice(
+      picker.indexOf("gateAnswer === 'free'"),
+      picker.indexOf('const usingHidden'),
+    )
+    expect(gateBranch.length).toBeGreaterThan(0)
+    expect(gateBranch).toContain('<CloudKeySetup')
+    expect(gateBranch).not.toContain('<CustomEndpointSetup')
+
+    // And the form is reachable ONLY behind `!gate`, so a first-run user never meets it.
+    const customTile = picker.slice(
+      picker.indexOf('<CustomEndpointTile'),
+      picker.indexOf('<CustomEndpointTile') + 400,
+    )
+    expect(customTile.length).toBeGreaterThan(0)
+    const beforeTile = picker.slice(0, picker.indexOf('<CustomEndpointTile'))
+    expect(beforeTile.endsWith('{!gate && (\n          ')).toBe(true)
+
+    // The registry write survives on both paths, and neither reimplements it.
     const providers = readFileSync(`${uiRoot}/components/CustomProviders.tsx`, 'utf8')
-    for (const dead of ['AddCustomProvider', 'AddForm', 'CUSTOM_VENDOR_PRESETS']) {
-      expect(providers.includes(dead)).toBe(false)
-      expect(picker.includes(dead)).toBe(false)
-    }
-    // But the registry write itself survives - CloudKeySetup is what calls it now, for
-    // whichever preset it was opened with.
     expect(providers).toContain('add_custom_llm_provider')
     expect(cloudSetup).toContain('onAdd(')
+    expect(customSetup).toContain('onAdd(')
+  })
+
+  it('never asks a self-configured endpoint for a vendor or a rate limit', () => {
+    // The three fields that made the OLD form a questionnaire: an open-ended vendor dropdown
+    // (unanswerable - an OpenAI-compatible URL could be anything), and two hand-typed
+    // rate-limit numbers nobody can know for a server they have never seen. The vendor is a
+    // constant now, and the limits are written as 0/0, which `llm_capacity::assess` reads as
+    // "not known" rather than "unmetered".
+    expect(customSetup).toContain('CUSTOM_ENDPOINT_VENDOR')
+    expect(customSetup).toContain('rpm: 0, rpd: 0')
+    for (const dead of ['CUSTOM_VENDOR_PRESETS', 'customVendorPreset']) {
+      expect(customSetup.includes(dead)).toBe(false)
+    }
+  })
+
+  it('lets a self-configured endpoint have no API key at all', () => {
+    // The single reason a local model (Ollama, LM Studio, llama.cpp, vLLM) can be connected
+    // at all: those servers have no auth, so there is no key to type. Rust permits the blank
+    // one at the door and then sends no Authorization header; the form must say so rather
+    // than leaving the user guessing whether blank is allowed.
+    expect(customSetup).toContain('Leave blank if your server does not need one')
+    // The key must never be a precondition for the model listing either - that call runs
+    // FIRST, so gating it on a key would fail the flow before the add.
+    expect(customSetup).toContain('apiKey: apiKey.trim()')
+  })
+
+  it('tells the user WHICH structured-reply mode an endpoint failed', () => {
+    // A local model that answers fine in prose can still sit below the production gate
+    // (`SchemaRung::JsonSchema` across all four pipeline schemas). "It did not work" would
+    // read as a broken button; naming the measured rung is what makes it actionable.
+    expect(customSetup).toContain('rungLabel(outcome.provider.effective_rung)')
+    expect(customSetup).toContain('production_eligible')
   })
 
   for (const preset of [GROQ, OLLAMA]) {

--- a/ui/__tests__/llm-provider-gate.test.ts
+++ b/ui/__tests__/llm-provider-gate.test.ts
@@ -180,6 +180,32 @@ describe('the no-subscription presets', () => {
     expect(customSetup).toContain('apiKey: apiKey.trim()')
   })
 
+  it('warns that the user pays for their own endpoint, before the key field', () => {
+    // A liability notice nobody reads protects nobody, so this pins BOTH halves:
+    // that the disclaimer is present, and that it is placed above the fields - a cost
+    // warning below the Connect button is read after the decision it exists to inform.
+    expect(customSetup).toContain('we are not responsible for')
+    expect(customSetup).toContain('YOU PAY FOR THIS ENDPOINT')
+    // Concrete, so someone can multiply it against their provider's price. These numbers
+    // are derived from `meridian_core::llm_capacity` (2 x 8 + 7 = 23, probe 16 worst case);
+    // if those constants move, this copy is stale and must move with them.
+    expect(customSetup).toContain('23 requests')
+    expect(customSetup).toContain('16 more')
+    // Above the fields: the warning must come before step 1 in source order.
+    expect(customSetup.indexOf('YOU PAY FOR THIS ENDPOINT'))
+      .toBeLessThan(customSetup.indexOf('title="Where is it?"'))
+  })
+
+  it('keeps the cost warning free of em-dashes', () => {
+    // User-facing app text takes a plain hyphen only, per the repo hard rule. Checked on the
+    // rendered strings rather than the file, so a comment above may still discuss an em-dash.
+    const warning = customSetup.slice(
+      customSetup.indexOf('YOU PAY FOR THIS ENDPOINT'),
+      customSetup.indexOf('title="Where is it?"'),
+    )
+    expect(warning).not.toMatch(/[\u2014\u2013]/)
+  })
+
   it('tells the user WHICH structured-reply mode an endpoint failed', () => {
     // A local model that answers fine in prose can still sit below the production gate
     // (`SchemaRung::JsonSchema` across all four pipeline schemas). "It did not work" would

--- a/ui/components/CustomEndpointSetup.tsx
+++ b/ui/components/CustomEndpointSetup.tsx
@@ -286,7 +286,8 @@ export default function CustomEndpointSetup({ existing, onBack, onAdd, onPick }:
           console, and keep the key safe.
         </p>
         <p style={{ fontSize: 11.5, lineHeight: 1.5, color: 'var(--t-muted)' }}>
-          Your key is stored on this device and is sent only to the address you enter above.
+          Your key is stored on this device and is only ever sent to the base URL you entered
+          above. It is never sent to Meridian, and it is never included in error reports.
         </p>
       </div>
 

--- a/ui/components/CustomEndpointSetup.tsx
+++ b/ui/components/CustomEndpointSetup.tsx
@@ -1,0 +1,433 @@
+//ambient dev tool that watches what you do and updates your PM tickets automatically, boosting developer productivity
+'use client'
+
+// Connect ANY OpenAI-compatible endpoint - a local model or a cloud key - from a base URL.
+//
+// The advanced sibling of <CloudKeySetup>. That one is a walkthrough for someone who said
+// they have no subscription and wants a working key in three clicks; this one is a form for
+// someone who already has an endpoint in mind and needs to describe it. Keeping them apart
+// is deliberate and is the whole reason the deleted add-form's rationale still holds: the
+// no-subscription path never shows this, and the picker only offers it behind `!gate`.
+//
+// # Only what the user can actually tell us
+//
+// Three fields, and no more. The old form's vendor dropdown is gone (the vendor is always
+// `custom` - see `CUSTOM_ENDPOINT_VENDOR`) and so are its two rate-limit boxes: nobody can
+// state the RPM of a server we have never seen, and a guessed number is worse than `0`,
+// which `meridian_core::llm_capacity::assess` reads as "not known" rather than "unmetered".
+//
+// # The API key is optional, and that is the point
+//
+// A local server (Ollama, LM Studio, llama.cpp, vLLM) has no auth, so there is no key to
+// type. Rust permits a blank one at the door (`validate_transport_inputs`) and then sends no
+// `Authorization` header at all (`openai_compat::with_auth`). A blank key against an endpoint
+// that DOES want one fails here, at setup, with the server's own 401 - not hours later.
+//
+// # The model comes from the endpoint, and can still be typed
+//
+// `/models` is asked first, because a mistyped model id is the one error that would not
+// surface until the first real hour. But plenty of OpenAI-compatible servers do not implement
+// `/models` at all, so a failed listing degrades to a text field rather than blocking - the
+// same degradation `openai_compat::list_models` documents for its callers.
+//
+// # Who calls this
+// [`LlmProviderPicker`], for the `custom` vendor tile - never from the gate.
+//
+// # Related
+// - `@/lib/llm-providers` - `CUSTOM_ENDPOINT_VENDOR`, `chatCapableModels`, `rungLabel`
+// - `@/components/CloudKeySetup` - the curated-preset path this deliberately does not merge with
+// - `@/components/CustomProviders` - the registry hook this writes through
+
+import { BackLink } from '@/components/ui/BackLink'
+import { useState } from 'react'
+import { invoke } from '@/lib/bridge'
+import {
+  chatCapableModels, CUSTOM_ENDPOINT_VENDOR, rungLabel, type CustomProviderView,
+  type ProbeOutcome,
+} from '@/lib/llm-providers'
+
+/** The registry write, shared with `<CloudKeySetup>` - `useCustomProviders().add`. */
+type AddFn = (fields: {
+  vendor: string; name: string; base_url: string; model: string
+  api_key: string; rpm: number; rpd: number
+}) => Promise<ProbeOutcome>
+
+type Phase = 'idle' | 'listing' | 'adding' | 'selecting' | 'done'
+
+/** A default name from the URL's host, so the common case needs no thought.
+ *
+ *  Host and port only: two LM Studio instances on different ports are different endpoints and
+ *  must not collide, but the path segment (`/v1`) is noise in a name. Falls back to the raw
+ *  string when `URL` cannot parse it - the field is editable and Rust validates the URL
+ *  properly, so a bad parse here must never block typing. */
+function nameFromUrl(raw: string): string {
+  try {
+    return new URL(raw).host
+  } catch {
+    return raw.replace(/^https?:\/\//, '').split('/')[0] ?? ''
+  }
+}
+
+export default function CustomEndpointSetup({ existing, onBack, onAdd, onPick }: {
+  /** Every endpoint already configured - used ONLY to keep the name unique up front. The
+   *  tray rejects a duplicate name permanently, and it does so AFTER the probe has already
+   *  been paid for, so catching it before the request is the difference between a retryable
+   *  form and a dead end. */
+  existing: CustomProviderView[]
+  onBack: () => void
+  onAdd: AddFn
+  /** Make the freshly added endpoint the live provider. Rejects if the tray refuses. */
+  onPick: (customId: string) => void | Promise<void>
+}) {
+  const [baseUrl, setBaseUrl] = useState('')
+  const [apiKey, setApiKey] = useState('')
+  const [model, setModel] = useState('')
+  const [name, setName] = useState('')
+  const [nameEdited, setNameEdited] = useState(false)
+  const [models, setModels] = useState<string[] | null>(null)
+  const [listError, setListError] = useState<string | null>(null)
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [error, setError] = useState<string | null>(null)
+  // Set once the endpoint EXISTS daemon-side. From here a retry must RE-MEASURE rather than
+  // re-add: the tray refuses a duplicate name forever, so a second add can never succeed and
+  // the screen would be a dead end. Same failure `<CloudKeySetup>` is shaped around.
+  const [addedId, setAddedId] = useState<string | null>(null)
+
+  const busy = phase === 'listing' || phase === 'adding' || phase === 'selecting'
+  const url = baseUrl.trim()
+  const effectiveName = (name.trim() || nameFromUrl(url)).trim()
+  const canList = !busy && !!url
+  // Once the endpoint is SAVED the button must stay live on the fields alone being empty:
+  // the retry path re-measures a row the daemon already holds, so it needs no URL, key or
+  // model from the form. Gating it on the form fields is what made `<CloudKeySetup>`'s
+  // equivalent a dead end after a rate-limited probe.
+  const canConnect = !busy && (addedId !== null || (!!url && !!model.trim() && !!effectiveName))
+
+  /** Ask the endpoint what it serves. Doubles as the first real check that the URL (and the
+   *  key, if the server wants one) work at all - before anything is written to settings. */
+  async function listModels() {
+    if (!canList) return
+    setListError(null)
+    setError(null)
+    setPhase('listing')
+    try {
+      const ids = await invoke<string[]>('list_custom_llm_provider_models', {
+        baseUrl: url,
+        apiKey: apiKey.trim(),
+      })
+      const usable = chatCapableModels(ids)
+      setModels(usable)
+      // Only preselect when there is no ambiguity. Picking the first of many would put a
+      // model in the field the user never chose, and a wrong model fails at the first real
+      // hour rather than here.
+      if (usable.length === 1) setModel(usable[0])
+      if (usable.length === 0) {
+        setListError(
+          ids.length > 0
+            ? 'This endpoint listed only non-chat models (embeddings, speech). Type a model id below if you know one it can chat with.'
+            : 'This endpoint listed no models. Type the model id below.',
+        )
+      }
+    } catch (e) {
+      // NOT fatal. Many OpenAI-compatible servers do not implement /models, and refusing to
+      // continue would make a working endpoint unconfigurable over an optional convenience.
+      setModels([])
+      setListError(
+        `${String(e).replace(/^Error:\s*/, '')} - type the model id below if you know it.`,
+      )
+    } finally {
+      setPhase('idle')
+    }
+  }
+
+  async function connect() {
+    if (busy) return
+    setError(null)
+    try {
+      let outcome: ProbeOutcome
+      if (addedId) {
+        // RETRY, endpoint already saved: re-measure the row rather than create a second one.
+        setPhase('adding')
+        outcome = await invoke<ProbeOutcome>('probe_custom_llm_provider', {
+          id: addedId, refresh: true,
+        })
+      } else {
+        if (!model.trim()) throw new Error('Choose or type a model first.')
+        if (existing.some((p) => p.name.toLowerCase() === effectiveName.toLowerCase())) {
+          throw new Error(`You already have an endpoint named "${effectiveName}". Give this one a different name.`)
+        }
+        setPhase('adding')
+        outcome = await onAdd({
+          vendor: CUSTOM_ENDPOINT_VENDOR,
+          name: effectiveName,
+          base_url: url,
+          model: model.trim(),
+          api_key: apiKey.trim(),
+          // `0/0` is "not known", NOT "unmetered" - see `llm_capacity::assess`. There is no
+          // published limit to read for an endpoint the user brought, and inventing one would
+          // produce a confident verdict about a quota nobody measured.
+          rpm: 0, rpd: 0,
+        })
+        // Recorded BEFORE the eligibility check: the row exists now however that check goes.
+        setAddedId(outcome.provider.id)
+      }
+
+      if (!outcome.provider.production_eligible) {
+        // Say WHICH limitation, not just "failed". The gate wants shape-enforced JSON
+        // (`SchemaRung::JsonSchema` or better) on all four pipeline schemas, and an endpoint
+        // that answers fine in prose can still sit below it - most often a small local model.
+        // Naming the measured rung is what makes this actionable rather than a dead button.
+        const measured = rungLabel(outcome.provider.effective_rung)
+        throw new Error(
+          outcome.incomplete
+            ? `Measuring stopped early: ${outcome.incomplete}. Press Connect again to finish.`
+            : `${outcome.provider.model} answered, but the strongest structured-reply mode it ` +
+              `held across all of Meridian's schemas was "${measured}". Meridian needs enforced ` +
+              `JSON, so it cannot run the pipeline on this model. Try a larger or ` +
+              `instruction-tuned model on the same endpoint - the endpoint is saved, so you ` +
+              `can change its model and re-test from Settings.`,
+        )
+      }
+
+      setPhase('selecting')
+      await onPick(outcome.provider.id)
+      setApiKey('')  // stored daemon-side now, and it never comes back
+      setPhase('done')
+    } catch (e) {
+      setError(String(e).replace(/^Error:\s*/, ''))
+      setPhase('idle')
+    }
+  }
+
+  if (phase === 'done') {
+    return (
+      <div className="flex flex-col mer-pop" style={{ gap: 10, alignItems: 'flex-start' }}>
+        <span className="font-mono self-start" style={{
+          fontSize: 9, letterSpacing: '.1em', color: 'var(--color-state-approved)',
+          border: '1px solid var(--color-state-approved)',
+          background: 'color-mix(in srgb, var(--color-state-approved) 10%, transparent)',
+          borderRadius: 4, padding: '2px 7px',
+        }}>CONNECTED</span>
+        <span style={{ fontSize: 17, fontWeight: 600, color: 'var(--t-title)' }}>
+          You&apos;re set up
+        </span>
+        <p style={{ fontSize: 12, lineHeight: 1.5, color: 'var(--t-muted)', maxWidth: 480 }}>
+          Meridian is using {effectiveName} ({model}) to write your summaries. You can change
+          this any time in Settings.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col" style={{ gap: 14 }}>
+      <BackLink onClick={onBack}>Back</BackLink>
+
+      <div className="flex flex-col" style={{ gap: 5 }}>
+        <span style={{ fontSize: 19, fontWeight: 600, color: 'var(--t-title)', letterSpacing: '-.01em' }}>
+          Connect your own endpoint
+        </span>
+        <p style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--t-muted)', maxWidth: 520 }}>
+          Anything that speaks the OpenAI chat-completions API - Ollama or LM Studio on this
+          machine, a server on your network, or a cloud provider on your own key.
+        </p>
+      </div>
+
+      {/* Stated, not implied. A local endpoint is the reason most people are on this screen,
+          and "does my screen data leave this machine" is the question it raises. The honest
+          answer depends entirely on the URL they type, so this says exactly that rather than
+          borrowing a preset's privacy badge for a server we know nothing about. */}
+      <p style={{
+        fontSize: 11.5, lineHeight: 1.45, color: 'var(--t-muted)',
+        background: 'var(--t-box)', border: '1px solid var(--t-ctrl-border)',
+        borderRadius: 9, padding: '9px 11px', maxWidth: 520,
+      }}>
+        Meridian sends one hour of activity at a time to whatever address you enter here. Point
+        it at a model on this machine and nothing leaves it; point it at a cloud provider and
+        their privacy policy applies, not ours.
+      </p>
+
+      <Step n={1} title="Where is it?"
+        body="The base URL, including the version segment - Meridian adds /chat/completions itself.">
+        <div className="flex flex-col" style={{ gap: 8 }}>
+          <Field
+            label="Base URL"
+            value={baseUrl}
+            onChange={(v) => {
+              setBaseUrl(v)
+              setModels(null)
+              setListError(null)
+              if (!nameEdited) setName('')
+            }}
+            placeholder="http://localhost:11434/v1"
+            disabled={busy}
+            mono
+          />
+          <Field
+            label="API key"
+            hint="Leave blank if your server does not need one - most local models do not."
+            value={apiKey}
+            onChange={setApiKey}
+            placeholder="Optional"
+            disabled={busy}
+            password
+            mono
+          />
+        </div>
+      </Step>
+
+      <Step n={2} title="Which model?"
+        body="Meridian asks the endpoint what it serves. If it does not answer, type the id yourself.">
+        <div className="flex flex-col" style={{ gap: 8 }}>
+          <button
+            onClick={listModels}
+            disabled={!canList}
+            className="self-start"
+            style={{
+              fontSize: 11.5, fontWeight: 600, color: 'var(--t-title)',
+              padding: '6px 11px', borderRadius: 8,
+              background: 'var(--t-ctrl)', border: '1px solid var(--t-ctrl-border)',
+              opacity: canList ? 1 : 0.5,
+              cursor: canList ? 'pointer' : 'default',
+            }}>
+            {phase === 'listing' ? 'Asking the endpoint…' : 'List models'}
+          </button>
+
+          {models && models.length > 0 && (
+            <select
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              disabled={busy}
+              style={{
+                fontSize: 12, padding: '8px 10px', borderRadius: 8, width: '100%',
+                border: '1px solid var(--t-ctrl-border)', background: 'var(--t-ctrl)',
+                color: 'var(--t-title)', cursor: busy ? 'default' : 'pointer',
+              }}>
+              <option value="">Choose a model…</option>
+              {models.map((m) => <option key={m} value={m}>{m}</option>)}
+            </select>
+          )}
+
+          {/* Always available, never only as a fallback: a server may list a hundred models
+              and the user may know exactly which one they want. */}
+          <Field
+            label="Model id"
+            value={model}
+            onChange={setModel}
+            placeholder="llama3.1:8b"
+            disabled={busy}
+            mono
+          />
+
+          {listError && (
+            <p style={{ fontSize: 11, lineHeight: 1.45, color: 'var(--t-muted)' }}>{listError}</p>
+          )}
+        </div>
+      </Step>
+
+      <Step n={3} title="Name it and connect"
+        body="Meridian checks the endpoint can return the structured replies the pipeline needs.">
+        <div className="flex flex-col" style={{ gap: 8 }}>
+          <Field
+            label="Name"
+            value={name}
+            onChange={(v) => { setName(v); setNameEdited(true) }}
+            placeholder={nameFromUrl(url) || 'My endpoint'}
+            disabled={busy}
+          />
+          <button
+            onClick={connect}
+            disabled={!canConnect}
+            className="self-start"
+            style={{
+              fontSize: 12, fontWeight: 700, color: '#fff', padding: '8px 14px',
+              borderRadius: 9, border: 'none',
+              background: 'var(--btn-primary-bg)',
+              opacity: canConnect ? 1 : 0.5,
+              cursor: canConnect ? 'pointer' : 'default',
+            }}>
+            {phase === 'adding' ? 'Testing the endpoint…'
+              : phase === 'selecting' ? 'Almost there…'
+                : addedId ? 'Re-test and connect' : 'Connect'}
+          </button>
+          {/* Named, because this step runs real requests and can sit for a while. */}
+          {phase === 'adding' && (
+            <span style={{ fontSize: 10.5, lineHeight: 1.4, color: 'var(--t-faint)' }}>
+              Checking which replies {model} can give - this takes a few seconds.
+            </span>
+          )}
+          {error && (
+            <p style={{
+              fontSize: 11.5, lineHeight: 1.45, color: 'var(--color-state-pending)',
+              background: 'color-mix(in srgb, var(--color-state-pending) 10%, transparent)',
+              borderRadius: 8, padding: '8px 10px',
+            }}>{error}</p>
+          )}
+        </div>
+      </Step>
+    </div>
+  )
+}
+
+/** A labelled text input. Local to this file: the shape is specific to this form, and the
+ *  repo has no shared field primitive to reach for. */
+function Field({ label, hint, value, onChange, placeholder, disabled, mono, password }: {
+  label: string
+  hint?: string
+  value: string
+  onChange: (v: string) => void
+  placeholder: string
+  disabled: boolean
+  mono?: boolean
+  password?: boolean
+}) {
+  return (
+    <label className="flex flex-col" style={{ gap: 4 }}>
+      <span className="font-mono" style={{
+        fontSize: 9, letterSpacing: '.09em', color: 'var(--t-faint)',
+      }}>{label.toUpperCase()}</span>
+      <input
+        type={password ? 'password' : 'text'}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        spellCheck={false}
+        autoComplete="off"
+        disabled={disabled}
+        style={{
+          fontSize: 12, padding: '8px 10px', borderRadius: 8, width: '100%',
+          border: '1px solid var(--t-ctrl-border)', background: 'var(--t-ctrl)',
+          color: 'var(--t-title)',
+          fontFamily: mono ? 'var(--font-mono, ui-monospace)' : undefined,
+          opacity: disabled ? 0.6 : 1,
+        }}
+      />
+      {hint && (
+        <span style={{ fontSize: 10.5, lineHeight: 1.4, color: 'var(--t-faint)' }}>{hint}</span>
+      )}
+    </label>
+  )
+}
+
+/** One numbered step - the same affordance `<CloudKeySetup>` uses, so the two screens read
+ *  as the same product. Duplicated rather than shared because they are three lines of markup
+ *  and lifting them into a shared module would couple two screens that are deliberately
+ *  diverging. */
+function Step({ n, title, body, children }: {
+  n: number; title: string; body: string; children: React.ReactNode
+}) {
+  return (
+    <div className="flex items-start" style={{ gap: 11 }}>
+      <span className="flex items-center justify-center shrink-0 font-mono" style={{
+        width: 22, height: 22, borderRadius: 999, fontSize: 10.5, fontWeight: 700,
+        background: 'var(--t-box)', border: '1px solid var(--t-ctrl-border)',
+        color: 'var(--t-title)', marginTop: 1,
+      }}>{n}</span>
+      <div className="flex flex-col min-w-0 flex-1" style={{ gap: 5 }}>
+        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--t-title)' }}>{title}</span>
+        <span style={{ fontSize: 11.5, lineHeight: 1.45, color: 'var(--t-muted)' }}>{body}</span>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/ui/components/CustomEndpointSetup.tsx
+++ b/ui/components/CustomEndpointSetup.tsx
@@ -254,6 +254,42 @@ export default function CustomEndpointSetup({ existing, onBack, onAdd, onPick }:
         their privacy policy applies, not ours.
       </p>
 
+      {/* THE MONEY WARNING. Amber, and above the fields rather than below them, because it
+          is only useful before the key is pasted - a cost disclaimer under the Connect button
+          is read after the decision it was meant to inform.
+          Concrete numbers, not "usage may apply": the request count is derived from
+          `meridian_core::llm_capacity` (CALLS_PER_ACTIVE_HOUR 2 x ASSUMED_ACTIVE_HOURS 8 +
+          DISCRETIONARY_CALLS_PER_DAY 7 = 23, plus PROBE_MAX_REQUESTS 16 worst case at setup),
+          so someone can actually multiply it against their provider's per-token price. A
+          warning nobody can act on is a warning nobody reads.
+          Shown for every custom endpoint, including a local one where it costs nothing: we
+          cannot tell from a URL whether it bills, and the honest framing is conditional
+          ("if this endpoint charges") rather than a guess about which kind they typed. */}
+      <div className="flex flex-col" style={{
+        gap: 7, padding: '13px 14px', borderRadius: 11, maxWidth: 520,
+        background: 'color-mix(in srgb, var(--color-state-pending) 9%, transparent)',
+        border: '1px solid color-mix(in srgb, var(--color-state-pending) 32%, transparent)',
+      }}>
+        <span className="font-mono" style={{
+          fontSize: 9, letterSpacing: '.1em', color: 'var(--color-state-pending)',
+        }}>YOU PAY FOR THIS ENDPOINT</span>
+        <p style={{ fontSize: 11.5, lineHeight: 1.5, color: 'var(--t-muted)' }}>
+          If the endpoint you connect charges for use, every request Meridian makes is billed
+          to your key. A normal working day is around 23 requests, plus up to 16 more the
+          first time you connect, and each one carries an hour of your activity - so what it
+          costs depends on your provider's pricing and how busy your days are.
+        </p>
+        <p style={{ fontSize: 11.5, lineHeight: 1.5, color: 'var(--t-muted)' }}>
+          Meridian does not monitor, cap or refund that spend, and we are not responsible for
+          any charges your key incurs - including charges from someone else using it if the
+          key is exposed. Set your own spend limits and usage alerts in your provider's
+          console, and keep the key safe.
+        </p>
+        <p style={{ fontSize: 11.5, lineHeight: 1.5, color: 'var(--t-muted)' }}>
+          Your key is stored on this device and is sent only to the address you enter above.
+        </p>
+      </div>
+
       <Step n={1} title="Where is it?"
         body="The base URL, including the version segment - Meridian adds /chat/completions itself.">
         <div className="flex flex-col" style={{ gap: 8 }}>

--- a/ui/components/CustomEndpointSetup.tsx
+++ b/ui/components/CustomEndpointSetup.tsx
@@ -280,7 +280,7 @@ export default function CustomEndpointSetup({ existing, onBack, onAdd, onPick }:
             hint="Leave blank if your server does not need one - most local models do not."
             value={apiKey}
             onChange={setApiKey}
-            placeholder="Optional"
+            placeholder="Paste your API key"
             disabled={busy}
             password
             mono

--- a/ui/components/CustomEndpointSetup.tsx
+++ b/ui/components/CustomEndpointSetup.tsx
@@ -117,10 +117,17 @@ export default function CustomEndpointSetup({ existing, onBack, onAdd, onPick }:
       })
       const usable = chatCapableModels(ids)
       setModels(usable)
-      // Only preselect when there is no ambiguity. Picking the first of many would put a
-      // model in the field the user never chose, and a wrong model fails at the first real
-      // hour rather than here.
-      if (usable.length === 1) setModel(usable[0])
+      // Only preselect when there is no ambiguity AND the user has not already typed one.
+      // Picking the first of many would put a model in the field the user never chose, and a
+      // wrong model fails at the first real hour rather than here.
+      //
+      // The `!model.trim()` half is the one that is easy to miss: typing an id is the
+      // DOCUMENTED path for a server with no `/models`, so someone may well type
+      // `qwen2.5-coder:7b`, then press List models just to check the URL answers. Without
+      // this guard that press silently replaces what they typed with whatever single id came
+      // back - and a lone survivor of the non-chat filter is exactly the case where the
+      // replacement would be worst.
+      if (usable.length === 1 && !model.trim()) setModel(usable[0])
       if (usable.length === 0) {
         setListError(
           ids.length > 0
@@ -255,6 +262,11 @@ export default function CustomEndpointSetup({ existing, onBack, onAdd, onPick }:
             value={baseUrl}
             onChange={(v) => {
               setBaseUrl(v)
+              // The LISTING is dropped (it described the old address), but a typed model id is
+              // NOT: correcting a typo in the URL must not wipe the id the user just entered.
+              // The dropdown disappears with the listing, so what remains on screen is the
+              // text field showing exactly what will be submitted - no hidden selection can
+              // survive from the previous address.
               setModels(null)
               setListError(null)
               if (!nameEdited) setName('')

--- a/ui/components/LlmProviderPicker.tsx
+++ b/ui/components/LlmProviderPicker.tsx
@@ -26,9 +26,10 @@
 import { BackLink } from '@/components/ui/BackLink'
 import { useCallback, useState } from 'react'
 import {
-  CHOOSER_PROVIDER_IDS, CLOUD_PRESETS, customVariantId, LLM_RANK_FREE, LLM_RANK_SUBSCRIPTION,
-  LLM_RECOMMENDED_NOTE, llmProvider, presetForVendor, type CloudKeyPreset, type CustomProviderView,
-  type LlmProviderId, type LlmRank,
+  CHOOSER_PROVIDER_IDS, CLOUD_PRESETS, CUSTOM_ENDPOINT_DISPLAY, CUSTOM_ENDPOINT_VENDOR,
+  customVariantId, LLM_RANK_CUSTOM, LLM_RANK_FREE, LLM_RANK_SUBSCRIPTION,
+  LLM_RECOMMENDED_NOTE, llmProvider, presetForVendor, type CustomProviderView,
+  type CloudKeyPreset, type LlmProviderId, type LlmRank, type VendorDisplay,
 } from '@/lib/llm-providers'
 import type {
   InstallOutcome, ProviderStatus, ProviderTestOutcome, ProviderTestResult,
@@ -37,6 +38,7 @@ import { CustomVendorLogo, ProviderLogo } from '@/components/LlmProviderLogos'
 import LlmProviderDetail, { phaseFor, type Phase } from '@/components/LlmProviderDetail'
 import LlmProviderGate, { Badge } from '@/components/LlmProviderGate'
 import CloudKeySetup from '@/components/CloudKeySetup'
+import CustomEndpointSetup from '@/components/CustomEndpointSetup'
 
 // Re-exported so the existing `from '@/components/LlmProviderPicker'` imports
 // keep resolving. The definitions now live in api-types.ts, per the repo rule
@@ -280,6 +282,42 @@ export interface LlmProviderPickerProps {
   gate?: boolean
 }
 
+/** The self-configured endpoint's grid tile.
+ *
+ *  Separate from `CloudPresetTile` rather than a `preset`-less mode of it: that one is built
+ *  around a `CloudKeyPreset` it can always name and badge, and this vendor has no preset at
+ *  all. The two do share `vendorPhaseFor`, so a configured endpoint's tile and its card can
+ *  never disagree about whether it is answering - the bug that rule exists to prevent. */
+function CustomEndpointTile({ value, selectedCustomId, status, custom, onOpen }: {
+  value: LlmProviderId
+  selectedCustomId: string | null
+  status: Record<string, ProviderStatus>
+  custom: ReturnType<typeof useCustomProviders>
+  onOpen: () => void
+}) {
+  const rows = custom.providers.filter((p) => p.vendor === CUSTOM_ENDPOINT_VENDOR)
+  const { selectedRow, phase: computedPhase } = vendorPhaseFor(rows, selectedCustomId, status)
+  const selected = value === 'custom' && !!selectedRow
+  // Only a SELECTED row's ladder answers - same rule as `CloudPresetTile`, for the same
+  // reason: an unselected vendor showing a borrowed status reads as a claim about a provider
+  // that is not running.
+  const phase = selected ? computedPhase : phaseFor(false, false, false, undefined, null)
+  return (
+    <ChooserTile
+      id="custom"
+      // The row's own name once one exists - the user named it after their own server, and
+      // "Custom endpoint" would be a worse label than the one they chose.
+      name={selectedRow ? selectedRow.name : CUSTOM_ENDPOINT_DISPLAY.name}
+      rank={LLM_RANK_CUSTOM}
+      selected={selected}
+      subtitle={selectedRow ? `Uses your ${selectedRow.name} endpoint.` : CUSTOM_ENDPOINT_DISPLAY.blurb}
+      phase={phase}
+      logo={<CustomVendorLogo vendor={CUSTOM_ENDPOINT_VENDOR} size={21} />}
+      onOpen={onOpen}
+    />
+  )
+}
+
 export default function LlmProviderPicker({
   value, selectedCustomId, onChange, status, scanning, testingIds, installingIds, signingIds,
   testOne, install, signIn, rescan, gate = false,
@@ -303,6 +341,10 @@ export default function LlmProviderPicker({
   // the main grid's per-vendor tiles - those already know their vendor and skip straight to
   // whichever screen (wizard or registry) that vendor needs, via `openVendor` instead.
   const [pendingPreset, setPendingPreset] = useState<CloudKeyPreset | null>(null)
+  // "Add another" on the self-configured vendor's registry view. A separate flag from
+  // `pendingPreset` because that one carries WHICH preset, and this vendor has none - the
+  // question it answers is only "form or registry view".
+  const [addingCustom, setAddingCustom] = useState(false)
   // A provider the user picked DURING this gated flow. Under the gate nothing is shown as
   // selected on arrival (`value` falls back to Claude whether or not it works), but once
   // they have actually chosen one, coming back to the grid must show which - otherwise the
@@ -358,8 +400,15 @@ export default function LlmProviderPicker({
   // stranded, here's what you're on and where to go" line - otherwise the screen just looks
   // empty where their provider used to be, with no explanation.
   const activeRow = custom.providers.find((p) => p.id === selectedCustomId)
+  //
+  // The `custom` vendor is excluded EXPLICITLY, and this is not a cosmetic exclusion: it is
+  // not in `CLOUD_PRESETS` (it never can be - it has no preset), so without this clause every
+  // self-configured endpoint would match "not an offered preset" and its owner would be told
+  // their working endpoint is discontinued and that Meridian is not sending it any requests.
+  // Both halves of that would be false, and it now has a tile of its own to go back to.
   const usingHiddenCloud =
-    value === 'custom' && !!activeRow && !CLOUD_PRESETS.some((p) => p.vendor === activeRow.vendor)
+    value === 'custom' && !!activeRow && activeRow.vendor !== CUSTOM_ENDPOINT_VENDOR
+    && !CLOUD_PRESETS.some((p) => p.vendor === activeRow.vendor)
 
   // Every preset tile the grid shows: exactly the OFFERED presets (Ollama), full stop.
   //
@@ -389,6 +438,52 @@ export default function LlmProviderPicker({
         onSignIn={() => signIn(openId)}
         onTest={() => testOne(openId)}
         onUse={async () => { await commitAndMark(openId) }}
+      />
+    )
+  }
+
+  // The SELF-CONFIGURED vendor, handled before the preset lookup below because it has no
+  // preset and never will: there is no key URL, sign-up copy or published free-tier limit to
+  // put in one (see `CUSTOM_ENDPOINT_VENDOR`). Falling through would hit the `!preset`
+  // dead-end BackLink and make the tile unopenable.
+  if (openId === 'custom' && openVendor === CUSTOM_ENDPOINT_VENDOR) {
+    const customRows = custom.providers.filter((p) => p.vendor === CUSTOM_ENDPOINT_VENDOR)
+    const backToGrid = () => { setOpenId(null); setOpenVendor(null); setAddingCustom(false) }
+    // Nothing configured yet, or "Add another" pressed: the form owns the screen. `!custom.loading`
+    // so a slow registry read cannot flash the form at someone who already has endpoints.
+    if (addingCustom || (!custom.loading && customRows.length === 0)) {
+      return (
+        <CustomEndpointSetup
+          // EVERY row, not just this vendor's: the tray rejects a duplicate name across the
+          // whole registry, so a check scoped to `custom` rows would miss a clash with an
+          // Ollama or Groq row and fail after the probe was already paid for.
+          existing={custom.providers}
+          onBack={customRows.length > 0 ? () => setAddingCustom(false) : backToGrid}
+          onAdd={custom.add}
+          onPick={(id) => commitAndMark('custom', id)}
+        />
+      )
+    }
+    const { selectedRow, phase: vendorPhase } = vendorPhaseFor(customRows, selectedCustomId ?? null, status)
+    return (
+      <CustomDetail
+        display={CUSTOM_ENDPOINT_DISPLAY}
+        providers={customRows}
+        value={value}
+        selectedCustomId={selectedCustomId ?? null}
+        live={!TILE_NOT_LIVE.includes(vendorPhase.kind)}
+        statusDetail={'message' in vendorPhase ? vendorPhase.message : undefined}
+        custom={custom}
+        onBack={backToGrid}
+        onPick={(id) => commitAndMark('custom', id)}
+        // Always offered, unlike a retired preset: a second endpoint here is a normal thing
+        // to want (a local model and a cloud key, say), and nothing about this vendor can be
+        // discontinued - it is whatever address the user types.
+        onAddAnother={() => setAddingCustom(true)}
+        onVerify={async () => {
+          await testOne(selectedRow ? customVariantId(selectedRow.id) : 'custom')
+          rescan()
+        }}
       />
     )
   }
@@ -447,7 +542,7 @@ export default function LlmProviderPicker({
     const { selectedRow, phase: vendorPhase } = vendorPhaseFor(vendorRows, selectedCustomId ?? null, status)
     return (
       <CustomDetail
-        preset={preset}
+        display={preset}
         providers={vendorRows}
         value={value}
         selectedCustomId={selectedCustomId ?? null}
@@ -561,6 +656,25 @@ export default function LlmProviderPicker({
             onOpen={() => { setOpenId('custom'); setOpenVendor(preset.vendor) }}
           />
         ))}
+        {/* Bring-your-own endpoint - any OpenAI-compatible base URL, local or cloud.
+            BEHIND `!gate`, exactly like the preset tiles above, and that placement is the
+            point rather than an accident of where it fits. The form this restores was
+            deleted for standing on the no-subscription path, where it handed a questionnaire
+            to the one person who came to avoid one; the gate still never shows a form, and
+            still routes "no subscription" straight to `<CloudKeySetup>`. Here it is reached
+            only by someone who came looking for it.
+            Last in the grid, after the recommended providers and the free presets: it is the
+            option that needs the user to already have something, so it should not compete
+            with the ones that do not. */}
+        {!gate && (
+          <CustomEndpointTile
+            value={value}
+            selectedCustomId={selectedCustomId ?? null}
+            status={status}
+            custom={custom}
+            onOpen={() => { setOpenId('custom'); setOpenVendor(CUSTOM_ENDPOINT_VENDOR) }}
+          />
+        )}
       </div>
 
       <p style={{ fontSize: 13.5, lineHeight: 1.5, fontWeight: 500, color: 'var(--t-muted)' }}>
@@ -640,10 +754,17 @@ export default function LlmProviderPicker({
  *  endpoint bills you per call" is advice for a decision this screen no longer offers, and it
  *  was the loudest text on a screen whose actual subject is free. */
 function CustomDetail({
-  preset, providers, value, selectedCustomId, live, statusDetail, custom, onBack, onPick,
+  display, providers, value, selectedCustomId, live, statusDetail, custom, onBack, onPick,
   onAddAnother, onVerify,
 }: {
-  preset: CloudKeyPreset
+  /** Just the name - NOT a whole `CloudKeyPreset`.
+   *
+   *  This used to take the preset, for the two `.name` reads below, and that was what shut a
+   *  self-configured endpoint out of this screen: satisfying the type would have meant
+   *  inventing a key URL, a FREE badge and privacy claims for a server nobody here has seen,
+   *  and invented trust copy is worse than none. Narrowing the prop to what is actually
+   *  rendered lets both kinds of vendor share one registry view. */
+  display: VendorDisplay
   /** This vendor's OWN rows only - pre-filtered by the caller. */
   providers: CustomProviderView[]
   value: LlmProviderId
@@ -670,12 +791,17 @@ function CustomDetail({
 
       <div className="flex flex-col" style={{ gap: 3 }}>
         <span style={{ fontSize: 18, fontWeight: 600, color: 'var(--t-title)', letterSpacing: '-.01em' }}>
-          Your {preset.name} key
+          {display.detailHeading ?? `Your ${display.name} key`}
         </span>
         {/* One line, and it says what the key DOES rather than what a different kind of key
-            might cost. 13px: a subtitle under an 18px heading, not a footnote. */}
+            might cost. 13px: a subtitle under an 18px heading, not a footnote.
+            OVERRIDABLE because the default's second sentence is a CLAIM, not decoration:
+            "Nothing is charged" is true of every curated free-tier preset and false of an
+            endpoint the user brought, which may be a metered cloud key. A self-configured
+            endpoint supplies its own line rather than inheriting a promise about someone
+            else's pricing. */}
         <p style={{ fontSize: 13, lineHeight: 1.5, color: 'var(--t-muted)' }}>
-          Meridian writes your summaries on this key. Nothing is charged.
+          {display.detailBlurb ?? 'Meridian writes your summaries on this key. Nothing is charged.'}
         </p>
       </div>
 
@@ -713,7 +839,7 @@ function CustomDetail({
             strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
             <path d="M8 3v10M3 8h10" />
           </svg>
-          Add another {preset.name} key
+          {display.addAnotherLabel ?? `Add another ${display.name} key`}
         </button>
       )}
     </div>

--- a/ui/lib/llm-providers.ts
+++ b/ui/lib/llm-providers.ts
@@ -408,6 +408,15 @@ export const LLM_RANK_SUBSCRIPTION: LlmRank = {
 }
 export const LLM_RANK_FREE: LlmRank = { badge: 'FREE', note: 'GOOD ACCURACY' }
 
+/** The self-configured endpoint's rank - deliberately NOT `LLM_RANK_FREE`.
+ *
+ *  Both of that badge's claims would be false here. "FREE" is a fact about a curated
+ *  preset's published tier, and an endpoint the user brings may be a metered cloud key;
+ *  "GOOD ACCURACY" is a claim about a model we picked, and here the model is theirs. So this
+ *  states what IS known - whose endpoint it is and where it can live - and claims nothing
+ *  about price or quality that only the user can know. */
+export const LLM_RANK_CUSTOM: LlmRank = { badge: 'YOUR OWN', note: 'LOCAL OR CLOUD' }
+
 export const LLM_GATE_TITLE = 'Do you have a Claude, ChatGPT or Cursor subscription?'
 export const LLM_GATE_BODY =
   'Meridian writes your summaries with an AI engine. It can use a subscription you already pay for, or set you up with a free one.'
@@ -476,11 +485,21 @@ export const USAGE_FOOTPRINT_NOTE =
  * the "+ Add a custom endpoint" tile advertised it on the settings screen as though it were a
  * capability rather than a leftover.
  *
- * The cost, stated plainly: an arbitrary OpenAI-compatible endpoint can no longer be added
- * from the UI - only the two curated presets below can. The registry underneath is
- * untouched - `add_custom_llm_provider` still exists, `<CloudKeySetup>` still calls it, and
- * an endpoint added by an older build (or a third vendor added by hand) still loads, runs
- * and can be selected. Only the way to CREATE one from the UI narrowed to these presets.
+ * The cost that used to be stated here - "an arbitrary OpenAI-compatible endpoint can no
+ * longer be added from the UI" - is PAID BACK by `<CustomEndpointSetup>` and
+ * `CUSTOM_ENDPOINT_DISPLAY` below, without reopening what this note was protecting.
+ *
+ * The two are not the same surface and that is the whole point. What made the old form wrong
+ * was WHERE it stood: on the no-subscription path, handing a questionnaire to the one person
+ * who arrived precisely to avoid one. So the free path still gets `<CloudKeySetup>` and only
+ * that, the gate never offers a form, and the free-key tiles still come from `CLOUD_PRESETS`.
+ * The base-URL form lives on the chooser grid behind `!gate` - the same condition those tiles
+ * already use - where it is reached only by someone who went looking for it.
+ *
+ * It is also not the old form rebuilt. There is no vendor dropdown (the vendor is always
+ * `custom`) and no pair of hand-guessed rate-limit fields; what is left is the three things
+ * only the user can know - base URL, key if their server wants one, and which model - and the
+ * model still comes from the endpoint's own `/models` rather than being typed blind.
  */
 
 /**
@@ -706,6 +725,100 @@ export const ALL_KNOWN_PRESETS: CloudKeyPreset[] = [GROQ, OLLAMA]
  *  Rust before its frontend data lands). See `ALL_KNOWN_PRESETS`. */
 export function presetForVendor(vendor: string): CloudKeyPreset | undefined {
   return ALL_KNOWN_PRESETS.find((p) => p.vendor === vendor)
+}
+
+/**
+ * The vendor string every self-configured endpoint is stored under.
+ *
+ * A single literal, not a per-service value, because there is nothing to choose FROM: the
+ * user brings a URL, and "which vendor is behind it" is a question neither they nor we can
+ * answer usefully (an OpenAI-compatible URL may be Ollama, LM Studio, vLLM, a proxy, or a
+ * service nobody here has heard of). The old form asked it anyway via a dropdown, which is
+ * exactly the field that made it a questionnaire - see the note above `CloudKeyPreset`.
+ *
+ * Deliberately NOT a member of `CLOUD_PRESETS` or `ALL_KNOWN_PRESETS`: it is not a curated
+ * free-key vendor and has no key URL, sign-up copy or published limits to put in one. It is
+ * routed by `vendorDisplay`, and rendering it is `<CustomEndpointSetup>`'s job.
+ */
+export const CUSTOM_ENDPOINT_VENDOR = 'custom'
+
+/** The display half of a vendor - the only fields the registry screens actually render.
+ *
+ *  `CustomDetail` used to take a whole `CloudKeyPreset` for two reads (`.name`, `.vendor`),
+ *  which is why a self-configured endpoint could not use it: satisfying that type would have
+ *  meant inventing a key URL, a free badge and privacy copy for an endpoint that has none,
+ *  and invented trust copy is worse than absent trust copy. */
+export interface VendorDisplay {
+  vendor: string
+  name: string
+  blurb: string
+  /** Heading for the registry screen. Defaults to `Your <name> key`, which is right for a
+   *  curated preset and wrong for a self-configured endpoint that may have no key at all. */
+  detailHeading?: string
+  /** The line under that heading. OVERRIDABLE because the default ends in a claim -
+   *  "Nothing is charged" - that is true of every free-tier preset and false of an endpoint
+   *  the user brought, which may be a metered cloud key. */
+  detailBlurb?: string
+  /** The "add another" control's label. Defaults to `Add another <name> key`. */
+  addAnotherLabel?: string
+}
+
+/** How a self-configured endpoint names itself before the user has named it.
+ *
+ *  No FREE badge and no privacy claims, unlike every `CloudKeyPreset`: what this endpoint
+ *  costs and what it does with the data are facts about a server we know nothing about, and
+ *  the presets can make those claims only because each one links the vendor's own policy. */
+export const CUSTOM_ENDPOINT_DISPLAY: VendorDisplay = {
+  vendor: CUSTOM_ENDPOINT_VENDOR,
+  name: 'Custom endpoint',
+  blurb: 'Any OpenAI-compatible API - a local model or your own cloud key.',
+  // "Your Custom endpoint key" is both clumsy and wrong - a local endpoint has no key - so
+  // all three strings are stated rather than derived from `name`.
+  detailHeading: 'Your endpoints',
+  // No cost claim, in either direction. What this endpoint charges is a fact about a server
+  // we know nothing about, and the presets can only promise "nothing is charged" because
+  // each one names a published free tier.
+  detailBlurb: 'Meridian writes your summaries on the endpoint you connected.',
+  addAnotherLabel: 'Add another endpoint',
+}
+
+/** Name and blurb for `vendor`, whether it is a curated preset or a self-configured endpoint.
+ *
+ *  The single display lookup for every registry surface. `presetForVendor` still answers for
+ *  the preset-only questions (which wizard, which key URL) - this one answers "what do I call
+ *  it on screen", which is the question `custom` can also answer. */
+export function vendorDisplay(vendor: string): VendorDisplay | undefined {
+  if (vendor === CUSTOM_ENDPOINT_VENDOR) return CUSTOM_ENDPOINT_DISPLAY
+  return presetForVendor(vendor)
+}
+
+/**
+ * Model-name fragments that cannot answer a chat completion - speech, embeddings, rerankers,
+ * safety classifiers - filtered out of the model list a self-configured endpoint offers.
+ *
+ * The union of what the presets filter, plus the families a LOCAL server characteristically
+ * serves alongside its chat models (`nomic`, `bge`, `minilm`, `rerank`): a local Ollama or
+ * LM Studio install commonly has an embedding model pulled next to a chat one, and offering
+ * it as a chat model produces an endpoint that fails every hour rather than at setup.
+ *
+ * A FILTER, never a ranking. Unlike a preset there is no `modelPreference` to apply: nobody
+ * here can rank the models on a server they have never seen, so the user chooses and this
+ * only removes what provably cannot work.
+ */
+export const NON_CHAT_MODEL_FRAGMENTS: string[] = [
+  'whisper', 'tts', 'embed', 'embedding', 'bge', 'nomic', 'minilm',
+  'rerank', 'guard', 'prompt-guard', 'moderation', 'clip', 'stable-diffusion',
+]
+
+/** The chat-capable subset of what an endpoint reported, in the endpoint's own order.
+ *
+ *  Order is preserved rather than sorted: a server lists its models in an order it chose, and
+ *  alphabetising it would bury the one the user just pulled under whatever starts with an
+ *  early letter. */
+export function chatCapableModels(available: string[]): string[] {
+  return available.filter(
+    (m) => !NON_CHAT_MODEL_FRAGMENTS.some((bad) => m.toLowerCase().includes(bad)),
+  )
 }
 
 /**


### PR DESCRIPTION
## What

Lets a user point Meridian at **any** OpenAI-compatible server from the UI - Ollama or LM Studio on their own machine, a vLLM box on the network, or a cloud provider on their own key - by entering a base URL and (optionally) an API key.

## Most of this already existed

`OpenAiCompatBackend`, the `CustomLlmProvider` registry, the schema probe, rate limiting and `add_custom_llm_provider` all accept an arbitrary base URL today. Three things blocked the feature:

**1. No UI path.** The free-text form was deliberately deleted, and the reason was good: it stood on the no-subscription gate, handing a questionnaire to the one person who arrived to avoid one. That rationale is preserved rather than reverted - the gate still routes straight to `<CloudKeySetup>`, and the new `<CustomEndpointSetup>` lives behind `!gate`, the same condition the existing cloud tiles already use, so only someone who goes looking for it finds it.

It is also not the old form rebuilt. No vendor dropdown (the vendor is the constant `custom` - an OpenAI-compatible URL could be anything, and asking was unanswerable) and no hand-typed rate-limit fields.

**2. The API key was mandatory** at `validate_transport_inputs`, which made every keyless local server unconfigurable. It also gates `list_custom_llm_provider_models`, so the flow died at "ask the endpoint what it serves", before the add. Blank is now allowed; the newline-injection and `http(s)://` checks are untouched.

**3. `.bearer_auth()` was unconditional**, so a blank key sent `Authorization: Bearer ` - a well-formed header with an empty credential, which is a different thing on the wire from sending none, and some servers reject it. `with_auth` now omits the header entirely.

## The production gate is not weakened

An endpoint still has to measure at `SchemaRung::JsonSchema` or better across all four pipeline schemas before it can be selected. A small local model may well fail that. When it does, the form names the rung it *did* hold and says the endpoint is saved and its model changeable, rather than presenting a dead button.

## Bug found and fixed along the way

`usingHiddenCloud` matches any vendor absent from `CLOUD_PRESETS`. Without an explicit exclusion, every self-configured endpoint would have told its owner their working endpoint was discontinued and that Meridian was not sending it requests - both false.

## A note on the tests

The test pinning "the add form stays gone" **passed unchanged against this feature**. It scanned for three identifiers (`AddCustomProvider`, `AddForm`, `CUSTOM_VENDOR_PRESETS`) that the new file happens not to use, so it would have waved through the exact reversal it existed to catch. It is rewritten to pin the invariant that actually survives - the gate renders the walkthrough, never the form - and I verified it fails when the gate is pointed at the form. The keyless validation change was likewise proven to fail against the old validator before being kept.

## Verification

- `cargo test --workspace` - 1111 + 432 + others, all green; `cargo clippy --workspace --all-targets -D warnings` clean; `cargo fmt` clean
- `bun test` in `ui/` - 918 pass (was 915; +3 new)
- `npm run build` (static export) succeeds
- Full pre-push suite passed
- **Keyless wire behaviour confirmed end to end** against a local stub through the real `list_models`: keyless sent `AUTH=<ABSENT>`, keyed sent `Bearer sk-abc`, both parsed correctly

**Not exercised:** no Ollama/LM Studio instance was running here, so the full "add a local model and watch it clear the schema gate" path has not been walked against a real model. Worth doing on staging.

**Accepted behaviour:** a custom endpoint is stored with `rpm/rpd = 0`, which `llm_capacity::assess` reads as *not known* (never *unmetered*), so its card carries an Unknown capacity notice. That is the same state Ollama Cloud already ships with. Inventing limits for a server nobody has measured would produce a confident verdict about a quota that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
