### PR TITLE
fix(install): scope the staging stop to the daemon binary, not the database

### DIFF
--- a/src/db/meridian.rs
+++ b/src/db/meridian.rs
@@ -128,6 +128,51 @@ pub async fn setup_db(uri: &str) -> anyhow::Result<SqlitePool> {
     Ok(pool)
 }
 
+/// The migration version in `err` that this binary does not carry, when the
+/// database has been migrated **ahead** of it — otherwise `None`.
+///
+/// # Why this is worth classifying
+///
+/// [`setup_db`] fails for several unrelated reasons and they were all reported
+/// with one sentence naming three of them: a wrong or absent encryption key, a
+/// locked file, corruption. This is a fourth, it is not on that list, and it is
+/// the only one where the database is **perfectly healthy** — the binary is
+/// simply older than the schema. Sending an operator at the database when the
+/// answer is the binary costs hours; it cost several here.
+///
+/// It is also the only one that never resolves on its own. A daemon under
+/// launchd `KeepAlive` retries forever: measured 2026-09-01, a v1.86.0 daemon
+/// carrying 79 migrations against a database at 83 failed **13,306 times over
+/// eight days** (~2,800/day), each attempt opening the database and running
+/// migrations against it.
+///
+/// # What counts
+///
+/// - [`sqlx::migrate::MigrateError::VersionMissing`] — `_sqlx_migrations` has a row for a
+///   migration this build does not carry. This is the observed shape.
+/// - [`sqlx::migrate::MigrateError::VersionTooNew`] — the same condition as sqlx reports it
+///   when it can name the newest applied version.
+///
+/// Deliberately NOT [`sqlx::migrate::MigrateError::VersionMismatch`] (a checksum drift, which
+/// [`reconcile_migration_checksums`] repairs) or [`sqlx::migrate::MigrateError::Dirty`] (a
+/// half-applied migration, which is a genuine repair case). Both are recoverable
+/// in place; neither means the binary is out of date.
+///
+/// `MigrateError` is `#[non_exhaustive]`, so an unrecognised variant falls
+/// through to `None` and keeps the general message. Failing to classify costs a
+/// vaguer log line; misclassifying would tell someone to update a daemon that is
+/// already current.
+pub fn schema_ahead_of_binary(err: &anyhow::Error) -> Option<i64> {
+    use sqlx::migrate::MigrateError;
+    err.chain()
+        .filter_map(|c| c.downcast_ref::<MigrateError>())
+        .find_map(|m| match m {
+            MigrateError::VersionMissing(v) => Some(*v),
+            MigrateError::VersionTooNew(v, _) => Some(*v),
+            _ => None,
+        })
+}
+
 /// Forces the WAL fully into the main database file and truncates it.
 ///
 /// Called from `main.rs`'s shutdown sequence, right before closing the pool.
@@ -634,6 +679,131 @@ mod tests {
             .run(&pool)
             .await
             .expect("migrate after reconcile must succeed");
+    }
+
+    /// A daemon OLDER than the database must say so, in the error a human reads.
+    ///
+    /// # The condition
+    /// Two daemon builds share one `meridian.db` and the newer one migrates the
+    /// schema forward. The older binary then finds rows in `_sqlx_migrations`
+    /// for migrations it does not carry, and sqlx correctly refuses to run —
+    /// `MigrateError::VersionMissing`. It is correct to refuse: an old binary
+    /// against a new schema would write rows the current code cannot read.
+    ///
+    /// # Why this is a test and not a comment
+    /// Measured on a dev machine 2026-09-01: a v1.86.0 daemon (79 migrations)
+    /// against a database at 83 crash-looped **13,306 times over eight days**
+    /// under launchd `KeepAlive`, at ~2,800/day. Every one of those attempts
+    /// opened the database and tried to migrate it. The only diagnostic it left
+    /// was `error=failed to run migrations` — the outer `.context` with no
+    /// cause — beside a message offering three explanations
+    /// (`wrong/absent encryption key, a locked file, or corruption`), none of
+    /// which was the real one. That sent the investigation at the database
+    /// rather than at the binary.
+    ///
+    /// So this pins the property that actually matters: **the version number
+    /// survives into `errors::chain`**. Without it there is nothing in
+    /// telemetry that distinguishes this from corruption, and it is not
+    /// reproducible on demand — it needs two binaries and a shared database.
+    #[tokio::test]
+    async fn an_applied_migration_the_binary_lacks_names_itself_in_the_error() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("open in-memory db");
+        let migrator = sqlx::migrate!("src/migrations");
+        migrator.run(&pool).await.expect("initial migrate");
+
+        // Stand in for "a newer daemon applied migration 999999 here". The
+        // version is deliberately far above any real one so this never collides
+        // with a migration added later.
+        sqlx::query(
+            "INSERT INTO _sqlx_migrations \
+             (version, description, installed_on, success, checksum, execution_time) \
+             VALUES (999999, 'from a newer daemon', CURRENT_TIMESTAMP, 1, X'00', 0)",
+        )
+        .execute(&pool)
+        .await
+        .expect("insert phantom applied migration");
+
+        // Reconcile must NOT paper over this: it realigns checksums for
+        // migrations this binary HAS, and has nothing to say about one it does
+        // not. Silently deleting the row would let an old daemon run against a
+        // schema it cannot understand, which is the failure sqlx is preventing.
+        reconcile_migration_checksums(&pool, &migrator)
+            .await
+            .expect("reconcile must tolerate an unknown applied migration");
+
+        let err = migrator
+            .run(&pool)
+            .await
+            .context("failed to run migrations")
+            .expect_err("sqlx must refuse to run against a schema ahead of this binary");
+        let rendered = crate::errors::chain(&err);
+
+        assert!(
+            rendered.contains("999999"),
+            "the offending migration version must reach the log - without it the \
+             operator cannot tell this apart from corruption. got: {rendered}"
+        );
+        assert!(
+            rendered.contains("failed to run migrations"),
+            "the outer context must survive too. got: {rendered}"
+        );
+
+        // ...and it must be CLASSIFIED, not just rendered. The log site picks a
+        // different message on this, so a `None` here means an operator is told
+        // to look at their encryption key and their disk for a healthy database.
+        assert_eq!(
+            schema_ahead_of_binary(&err),
+            Some(999_999),
+            "an applied-but-unknown migration must classify as schema-ahead, and \
+             must name the version"
+        );
+    }
+
+    /// The classifier must stay narrow: only "this binary is out of date".
+    ///
+    /// A checksum drift is repaired in place by [`reconcile_migration_checksums`]
+    /// and a plain open failure has nothing to do with versions. Reporting either
+    /// as "your daemon is older than the database" would send someone to update a
+    /// binary that is already current, which is worse than the vague message it
+    /// replaced.
+    #[test]
+    fn only_an_out_of_date_binary_classifies_as_schema_ahead() {
+        use sqlx::migrate::MigrateError;
+
+        for (label, err) in [
+            (
+                "a drifted checksum",
+                anyhow::Error::new(MigrateError::VersionMismatch(7)),
+            ),
+            (
+                "a half-applied migration",
+                anyhow::Error::new(MigrateError::Dirty(7)),
+            ),
+            (
+                "an unrelated open failure",
+                anyhow::anyhow!("file is not a database"),
+            ),
+        ] {
+            assert_eq!(
+                schema_ahead_of_binary(&err.context("failed to run migrations")),
+                None,
+                "{label} must NOT classify as an out-of-date binary"
+            );
+        }
+
+        // And the positive case still classifies through a context layer, which
+        // is how it always arrives from `setup_db`.
+        assert_eq!(
+            schema_ahead_of_binary(
+                &anyhow::Error::new(MigrateError::VersionMissing(84))
+                    .context("failed to run migrations")
+            ),
+            Some(84),
+        );
     }
 
     /// A fresh database (no `_sqlx_migrations` table yet) is a clean no-op.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1259,10 +1259,26 @@ async fn main() -> Result<()> {
             // locked, corruption — is finally diagnosable in central telemetry
             // instead of crash-looping silently. `shutdown` consumes the guard,
             // but we exit immediately after, so the success path still owns it.
-            tracing::error!(
-                error = %meridian::errors::chain(&e),
-                "daemon startup: failed to open the database — the daemon cannot start (wrong/absent encryption key, a locked file, or corruption)"
-            );
+            //
+            // The "schema ahead of the binary" case is split out because it is
+            // the one failure here where the database is HEALTHY and the general
+            // message actively misleads: it names an encryption key, a lock and
+            // corruption, and the answer is none of those - this build is simply
+            // older than the database. It is also the only one that never clears
+            // on its own, because launchd `KeepAlive` retries a daemon that
+            // cannot possibly succeed. See `db::meridian::schema_ahead_of_binary`
+            // for the 13,306-crash-loop measurement behind both statements.
+            match meridian::db::meridian::schema_ahead_of_binary(&e) {
+                Some(version) => tracing::error!(
+                    error = %meridian::errors::chain(&e),
+                    migration_version = version,
+                    "daemon startup: this daemon is OLDER than meridian.db — the database has migrations this build does not carry, so it cannot start and will keep retrying until the binary is updated. The database itself is fine."
+                ),
+                None => tracing::error!(
+                    error = %meridian::errors::chain(&e),
+                    "daemon startup: failed to open the database — the daemon cannot start (wrong/absent encryption key, a locked file, or corruption)"
+                ),
+            }
             obs_guard.shutdown().await;
             meridian::telemetry_spool::shipper::drain_once().await;
             std::process::exit(1);

--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -270,12 +270,64 @@ pub(crate) async fn stop_daemon_for_migration(db_path: &Path) -> Result<(), Stri
     }
 }
 
+/// Stop the daemon so [`stage_binary`] can overwrite `~/.meridian/bin/meridian`.
+///
+/// # Why this is NOT [`stop_daemon_for_migration`]
+///
+/// It used to be — `install` called that function directly, reusing the
+/// encryption migration's stop rather than writing a second one. The two
+/// operations guard genuinely different things, and sharing one guard gave
+/// staging a precondition it has no way to satisfy:
+///
+/// - **The migration swaps `meridian.db` itself.** Any process holding that
+///   file is a hazard, because the sidecars are addressed by path and a second
+///   writer ends up sharing one journal. "Nothing at all holds the database" is
+///   the correct precondition, and [`wait_for_db_unheld`] is how it is proved.
+/// - **Staging overwrites `~/.meridian/bin/meridian`.** It does not touch the
+///   database. The only file whose holders matter is the *binary*.
+///
+/// Inheriting the database precondition meant any unrelated reader blocked a
+/// daemon UPDATE — and it blocked it in the one way that cannot recover, because
+/// staging is exactly what would have replaced a broken daemon. Measured on a
+/// dev machine 2026-09-01: a stale v1.86.0 daemon crash-looped 13,306 times over
+/// eight days (`failed to run migrations` against a schema three migrations
+/// ahead of it), while every launch's attempt to stage a current binary over it
+/// was declined because the tray's own pool and an MCP server held the database.
+/// The interlock was preventing the repair for the fault it was reporting. A
+/// user running the Meridian MCP server reaches the same state with no dev build
+/// involved: their daemon silently stops updating, permanently.
+///
+/// # What still guards the second-daemon hazard
+///
+/// The comment that justified the database check in `install` was about
+/// [`register_service`] bootstrapping a new daemon beside a live one. That was
+/// written on 2026-08-25, when the daemon's only defence was a check-then-act
+/// endpoint probe. The **atomic single-instance lock** landed the next day
+/// (`meridian::platform::acquire_single_instance_lock`, taken immediately before
+/// `setup_db`), so a second daemon now stands down before it opens the database
+/// at all, however the two are interleaved. The probe additionally catches a
+/// long-running daemon from a build predating the lock. Neither depends on this
+/// function, so narrowing it here gives up nothing.
+#[cfg(target_os = "macos")]
+pub(crate) async fn stop_daemon_for_staging(daemon_bin: &Path) -> Result<(), String> {
+    bootout_agent_and_wait(DAEMON_LABEL).await?;
+    // A bootout only removes the LAUNCHD-managed daemon, and killing a process
+    // does not release its executable mapping instantly. Overwriting a binary
+    // another process is still executing leaves that process running the old
+    // unlinked inode on macOS - silently, unlike Windows' os error 32 - so prove
+    // the file is unmapped rather than inferring it from the bootout returning.
+    wait_for_path_unheld(daemon_bin, "the daemon binary").await
+}
+
 /// Poll until nothing but this process holds `db_path` open (≤10 s), so the
 /// caller can swap the file knowing there is no second writer.
 ///
 /// Deliberately keyed on **the database file**, not on a daemon binary path:
-/// the hazard is "some process has this file open", and a check that enumerates
-/// known daemon locations misses every writer that isn't at one of them.
+/// for the encryption migration the hazard is "some process has this file open",
+/// and a check that enumerates known daemon locations misses every writer that
+/// isn't at one of them. Staging has the opposite requirement and uses
+/// [`stop_daemon_for_staging`] — see there for why the two must not share a
+/// guard.
 ///
 /// A spawn failure of `lsof` is treated as **still held**, not as clear. Being
 /// unable to prove the file is free is not evidence that it is, and the cost of
@@ -284,10 +336,25 @@ pub(crate) async fn stop_daemon_for_migration(db_path: &Path) -> Result<(), Stri
 /// proceeding corrupts the user's data irrecoverably.
 #[cfg(target_os = "macos")]
 async fn wait_for_db_unheld(db_path: &Path) -> Result<(), String> {
+    wait_for_path_unheld(db_path, "meridian.db").await
+}
+
+/// Poll until nothing but this process holds `path` open (≤10 s).
+///
+/// The shared body of [`wait_for_db_unheld`] and [`stop_daemon_for_staging`].
+/// `subject` names the file in the returned error because that string reaches
+/// the user as the detail of the "Meridian couldn't finish installing" notice,
+/// and "meridian.db is still held open" sent an installation failure chasing a
+/// database problem for weeks.
+///
+/// A spawn failure of `lsof` is an `Err`, never an empty holder list — see
+/// [`wait_for_db_unheld`] for the asymmetry that rule protects.
+#[cfg(target_os = "macos")]
+async fn wait_for_path_unheld(path: &Path, subject: &str) -> Result<(), String> {
     for _ in 0..10 {
         let out = tokio::process::Command::new("lsof")
             .arg("-t")
-            .arg(db_path)
+            .arg(path)
             .output()
             .await
             .map_err(|e| format!("run lsof: {e}"))?;
@@ -297,10 +364,16 @@ async fn wait_for_db_unheld(db_path: &Path) -> Result<(), String> {
         if holders.is_empty() {
             return Ok(());
         }
-        tracing::debug!(holders = ?holders, "backend_install: waiting for db writers to exit");
+        tracing::debug!(
+            holders = ?holders,
+            path = %path.display(),
+            "backend_install: waiting for holders to exit"
+        );
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
-    Err("meridian.db is still held open 10s after stopping the daemon".to_string())
+    Err(format!(
+        "{subject} is still held open 10s after stopping the daemon"
+    ))
 }
 
 /// The pids in `lsof -t` output, excluding our own — i.e. the processes that
@@ -493,15 +566,16 @@ pub(crate) async fn ensure_daemon_running(home: &Path) {
 /// manual test, whatever), `dir.is_dir()` alone can't tell that apart from a
 /// real packaged install. That false positive is not cosmetic:
 /// [`ensure_backend_installed`] would then call [`install`], which on macOS
-/// runs [`stop_daemon_for_migration`] against `meridian.db` — booting out a
-/// launchd agent that was never registered for this run (a no-op) and then
-/// polling `lsof` for up to 10s, which always times out because the actual
-/// holder is the sibling `cargo run` daemon `bootout` can't touch, not the
-/// launchd job it targets. That raises `tray.backend_install_failed`
-/// ("meridian.db is still held open 10s after stopping the daemon") on every
-/// dev-tray launch, with a timestamp that tracks each restart — measured
-/// verbatim on 2026-08-31, traced to exactly one stray directory left over
-/// from an Aug 16 debug build. `debug_assertions` is a compile-time constant
+/// boots out a launchd agent that was never registered for this run (a no-op)
+/// and then polls `lsof` for up to 10s. That raises
+/// `tray.backend_install_failed` on every dev-tray launch, with a timestamp
+/// that tracks each restart — measured verbatim on 2026-08-31, traced to
+/// exactly one stray directory left over from an Aug 16 debug build. (At the
+/// time the poll was [`stop_daemon_for_migration`]'s, waiting on `meridian.db`
+/// and so timing out against the sibling `cargo run` daemon's pool; it is
+/// [`stop_daemon_for_staging`]'s now, waiting only on the staged binary. This
+/// gate is still required — the bootout alone is wrong to perform from a dev
+/// build.) `debug_assertions` is a compile-time constant
 /// for the running binary's own profile, so this can never be fooled by
 /// what's left lying around on disk the way the directory check alone was.
 /// Matches the same convention already used for the encryption-migration
@@ -596,18 +670,22 @@ async fn install(backend: &Path, home: &Path) -> Result<(), String> {
     // NINE MILLISECONDS before anything asked it to stop, and the stop that did
     // arrive came from `register_agent`'s bootout, after the fact.
     //
-    // Reuses the migration path's stop rather than a second implementation:
-    // bootout the launchd job, then prove via `lsof` that NOTHING holds the
-    // database - a dev `cargo run`, a directly-spawned binary and an orphan
-    // from an overlapping install have all been seen here, and a bootout
-    // removes none of them.
+    // Scoped to the DAEMON BINARY, matching Windows. This used to call
+    // `stop_daemon_for_migration` and therefore required that NOTHING held
+    // meridian.db - a precondition staging cannot satisfy and does not need,
+    // because staging overwrites `~/.meridian/bin/meridian` and never touches
+    // the database. Any unrelated reader (the tray's own pool, an MCP server, a
+    // dev build) blocked every daemon update, permanently and unrecoverably.
+    // `stop_daemon_for_staging`'s doc has the measurement and why the atomic
+    // single-instance lock, not this call, is what now guards the second-daemon
+    // hazard described above.
     //
     // Failing here declines the STAGING, exactly as Windows does: the update
     // does not apply, the existing daemon keeps running, and the next launch
     // retries. That is the right asymmetry - a deferred update costs a version,
     // proceeding costs the user's database.
     #[cfg(target_os = "macos")]
-    stop_daemon_for_migration(std::path::Path::new(&crate::install::meridian_db_path())).await?;
+    stop_daemon_for_staging(&daemon_bin).await?;
 
     stage_binary(&backend.join(DAEMON_FILE), &daemon_bin).await?;
 
@@ -1533,7 +1611,7 @@ mod tests {
 
         for (label, needle) in [
             ("windows", "stop_running_daemon_before_stage("),
-            ("macos", "stop_daemon_for_migration("),
+            ("macos", "stop_daemon_for_staging("),
         ] {
             let stop = body.find(needle).unwrap_or_else(|| {
                 panic!(
@@ -1548,6 +1626,98 @@ mod tests {
                  first is what makes the window silent. stop at {stop}, stage at {stage}"
             );
         }
+    }
+
+    /// Staging must wait on the **daemon binary**, never on `meridian.db`.
+    ///
+    /// The two are one keystroke apart (`stop_daemon_for_staging` vs
+    /// `stop_daemon_for_migration`) and both compile, so nothing but this scan
+    /// catches a revert. What it costs is not a style point:
+    /// `stop_daemon_for_migration` requires that NOTHING holds the database,
+    /// which staging can neither satisfy nor needs to — it overwrites
+    /// `~/.meridian/bin/meridian` and never opens the database. Wiring it back
+    /// means any unrelated reader (the tray's own pool, an MCP server, a dev
+    /// build) blocks every daemon UPDATE, and blocks it unrecoverably, because
+    /// staging is the mechanism that would have replaced a broken daemon.
+    /// Measured 2026-09-01: 13,306 crash-loops of a stale v1.86.0 daemon over
+    /// eight days, none of which could be repaired for exactly this reason.
+    ///
+    /// The migration keeps the database-wide wait, and that is correct — it
+    /// swaps the file itself. This asserts only that STAGING does not.
+    #[test]
+    fn staging_waits_on_the_daemon_binary_not_on_the_database() {
+        const SRC: &str = include_str!("backend_install.rs");
+        let prod = SRC
+            .split_once("\n#[cfg(test)]")
+            .map_or(SRC, |(before, _)| before);
+        let body = prod
+            .split_once("async fn install(backend: &Path, home: &Path)")
+            .expect("install() must exist")
+            .1;
+        let end = ["\npub ", "\npub(crate) ", "\nasync fn", "\nfn "]
+            .iter()
+            .filter_map(|m| body.find(m))
+            .min()
+            .unwrap_or(body.len());
+        let body = &body[..end];
+
+        assert!(
+            !body.contains("stop_daemon_for_migration("),
+            "install() must not call stop_daemon_for_migration - that waits for \
+             meridian.db to be unheld, a precondition staging cannot satisfy. Use \
+             stop_daemon_for_staging, which waits on the binary it is about to \
+             overwrite. See that function's doc for the 13,306-crash-loop measurement."
+        );
+        assert!(
+            !body.contains("meridian_db_path("),
+            "install() must not resolve the database path at all - staging does not \
+             touch meridian.db, and reintroducing the path is the first half of \
+             reintroducing the wait"
+        );
+    }
+
+    /// The two stops must stay distinct functions guarding distinct files.
+    ///
+    /// Collapsing them back into one is the shape of the original bug, and it
+    /// would not fail `staging_waits_on_the_daemon_binary_not_on_the_database`
+    /// if the survivor kept the staging name while regaining the database wait.
+    #[test]
+    fn the_migration_stop_still_guards_the_database_and_staging_does_not() {
+        const SRC: &str = include_str!("backend_install.rs");
+        let prod = SRC
+            .split_once("\n#[cfg(test)]")
+            .map_or(SRC, |(before, _)| before);
+
+        let fn_body = |sig: &str| -> String {
+            let after = prod
+                .split_once(sig)
+                .unwrap_or_else(|| panic!("{sig} must exist"))
+                .1;
+            let end = ["\npub ", "\npub(crate) ", "\nasync fn", "\nfn ", "\n///"]
+                .iter()
+                .filter_map(|m| after.find(m))
+                .min()
+                .unwrap_or(after.len());
+            after[..end].to_string()
+        };
+
+        let migration = fn_body("async fn stop_daemon_for_migration(db_path: &Path)");
+        assert!(
+            migration.contains("wait_for_db_unheld("),
+            "stop_daemon_for_migration must keep the database-wide wait - it swaps \
+             meridian.db itself, so any holder is a corruption hazard"
+        );
+
+        let staging = fn_body("async fn stop_daemon_for_staging(daemon_bin: &Path)");
+        assert!(
+            staging.contains("wait_for_path_unheld(daemon_bin"),
+            "stop_daemon_for_staging must wait on the binary it overwrites"
+        );
+        assert!(
+            !staging.contains("wait_for_db_unheld("),
+            "stop_daemon_for_staging must NOT wait on the database - that is the \
+             precondition it exists to stop requiring"
+        );
     }
 
     /// The branch that bootstraps a launchd agent whose `bootout` never cleared


### PR DESCRIPTION
## The bug

Staging the daemon binary required that **nothing held `meridian.db`**. It cannot satisfy that and does not need to: staging overwrites `~/.meridian/bin/meridian` and never opens the database.

The requirement was inherited, not chosen. `install()` reused `stop_daemon_for_migration` rather than writing a second stop, and that function guards the *encryption migration*, which swaps `meridian.db` itself. For that, "nothing holds the database" is genuinely the precondition. Sharing it gave a **binary update** a whole-machine exclusivity precondition.

## Why it matters

It fails in the one way that cannot recover, because staging is exactly what would have replaced a broken daemon.

Measured on a dev machine 2026-09-01:

| | |
|---|---|
| Stale daemon | v1.86.0, staged Aug 16, carries 79 migrations |
| Database | at migration 083 (081 landed Aug 20, 082/083 Aug 26) |
| Failure | `failed to run migrations`, exit 1, relaunched by launchd `KeepAlive` |
| Rate | **13,306 failures over 8 days**, ~2,800/day |
| Why unrepaired | every launch's staging attempt was declined - the tray's own pool and an MCP server held the database |

A livelock: the interlock was preventing the repair for the fault it was reporting. **No dev build is needed to reach it** - a user running the Meridian MCP server holds the database, so their daemon silently stops updating, permanently.

## The fix

`stop_daemon_for_staging` boots out the launchd job and then waits on **the binary it is about to overwrite** - which is what Windows has always done via `stop_running_daemon_before_stage`.

The second-daemon hazard that justified the database check is now the single-instance lock's job. That comment was written **2026-08-25**; `acquire_single_instance_lock` (atomic `flock`, taken immediately before `setup_db`) landed **2026-08-26**. A second daemon now stands down before it opens the database at all, however the two interleave. Verified live: with another daemon holding the socket, the launchd daemon logs *"another meridian daemon already owns this data dir"* and exits **0**.

**The migration keeps the database-wide wait, unchanged.** It swaps the file itself, so every holder really is a hazard there.

## Second change: classify a daemon older than its database

That failure is reported today as `wrong/absent encryption key, a locked file, or corruption` - three causes, none of them the real one, for the only case here where **the database is perfectly healthy**. It is also the only one that never clears on its own. It now says so and names the migration version.

The missing *cause* in the field logs turned out to be a v1.86.0 artifact: that build logged `error = %e`, which drops the anyhow chain. Current code already uses `errors::chain`; a test now pins that the version survives into the rendered error.

## Tests

- `staging_waits_on_the_daemon_binary_not_on_the_database` - `install()` must not call the migration stop, nor resolve the db path at all
- `the_migration_stop_still_guards_the_database_and_staging_does_not` - the two stops stay distinct and guard distinct files
- `an_applied_migration_the_binary_lacks_names_itself_in_the_error` - reproduces the production condition; asserts the version reaches `errors::chain`
- `only_an_out_of_date_binary_classifies_as_schema_ahead` - a drifted checksum and a half-applied migration must **not** classify (both are repairable in place; telling someone to update a current daemon is worse than the vague message)

**Teeth verified.** A full revert of the call site fails to compile (dead code). The subtler regression - `stop_daemon_for_staging` regaining the database wait - was injected and confirmed to fail `the_migration_stop_still_guards_the_database_and_staging_does_not`.

## Gate

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (27 binaries green: 1113 meridian, 433 meridian-tray), plus the full pre-push suite. Also ran `cargo doc` and fixed four intra-doc links this PR introduced.

## Not in scope

- **The shared/exclusive database lock.** `daemon.lock` exists and is a real `flock`, but only the daemon takes it and it has no shared mode, so nothing that *moves* the database file consults it (`encrypt_in_place`, `db::repair`, `repair_boot` still use `lsof` / a socket ping / process-name matching). Extending it is the structural fix; it is a separate change.
- **A crash-looping daemon still has no in-app signal.** The fault bus is DB-backed, and this failure is "the database cannot be opened", so a notice cannot come from the daemon. It needs a tray-side path.