### PR TITLE
fix(analytics): stop disabling GeoIP on PostHog events

### DIFF
--- a/tray/src-tauri/src/analytics/mod.rs
+++ b/tray/src-tauri/src/analytics/mod.rs
@@ -16,10 +16,9 @@
 //! Nothing else: a single raw HTTP POST to PostHog's `/i/v0/e/`
 //! capture endpoint, no `posthog-js`, so session replay / autocapture /
 //! surveys / feature flags never activate — that's client-SDK behaviour this
-//! code never touches. `$geoip_disable` is set on every event since the
-//! request originates from the user's own machine, not a backend relay (the
-//! default GeoIP enrichment would otherwise resolve each user's real
-//! location).
+//! code never touches. GeoIP enrichment is left on PostHog's default (no
+//! `$geoip_disable`), so events resolve each user's location from their
+//! request IP.
 //!
 //! **Consent.** Everything here is gated on
 //! [`meridian_core::settings::RuntimeSettings::product_analytics_enabled`]
@@ -208,7 +207,7 @@ fn posthog_api_key() -> String {
 pub(crate) async fn capture(
     event: &str,
     distinct_id: &str,
-    mut properties: serde_json::Map<String, serde_json::Value>,
+    properties: serde_json::Map<String, serde_json::Value>,
 ) -> bool {
     let api_key = posthog_api_key();
     if api_key.is_empty() {
@@ -223,7 +222,6 @@ pub(crate) async fn capture(
         );
         return false;
     }
-    properties.insert("$geoip_disable".to_string(), serde_json::Value::Bool(true));
     let body = serde_json::json!({
         "api_key": api_key,
         "event": event,


### PR DESCRIPTION
## Summary
- Removes the `$geoip_disable: true` property that was set on every PostHog analytics event, so PostHog now resolves user location from the request IP as it does by default.
- Updates the module header comment in `tray/src-tauri/src/analytics/mod.rs` to reflect the new behavior.

## Note
This affects `app_installed`, `app_active`, and `daily_usage` — all identified by the signed-in user's real email (not pseudonymous). Going forward, PostHog will store resolved location alongside each identified user's real email. Nothing retroactive happens to already-sent events.

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -p meridian-tray --lib -- -D warnings` passes clean
- [x] Full pre-push suite (fmt, clippy, ui build/tests, security audit, `cargo test --workspace`) passed