### PR TITLE
fix(intelligence): keep the escalation streak out of the log body

### DIFF
--- a/src/intelligence/providers/mod.rs
+++ b/src/intelligence/providers/mod.rs
@@ -193,10 +193,19 @@ pub async fn note_transient_sync_failure(
     // proxy, TLS interception, a firewall rule) fails every single attempt
     // forever, and suppressing that outright would leave the board silently going
     // stale with no signal at all - strictly worse than a misleading banner.
+    // The count lives in the `streak` FIELD, not in the message body. The body
+    // is the one thing `telemetry_spool::redact` cannot filter - attributes are
+    // dropped unless allowlisted, but the body always ships verbatim - so
+    // interpolating anything runtime-derived into it is what `log_hygiene`
+    // forbids. `streak` was already a field here; the body merely duplicated
+    // it, so nothing is lost. (It survives the ship leg as a bare number via
+    // `redact::is_bare_number` - see that function for why a `u32` arrives as a
+    // StringValue in the first place.)
     tracing::warn!(
         provider,
         streak,
-        "provider unreachable on {streak} consecutive attempts - escalating to a notice"
+        needed = TRANSIENT_ESCALATION_ATTEMPTS,
+        "provider unreachable on every consecutive sync attempt - escalating to a notice"
     );
     // The message names the evidence, not a duration. The old wording ("No
     // successful sync in the last 6 hours") described normal on-demand operation


### PR DESCRIPTION
## `pre-main` is red

`log_hygiene::tests::no_user_data_interpolated_into_a_log_body` fails on `src/intelligence/providers/mod.rs:196`:

```
"provider unreachable on {streak} consecutive attempts - escalating to a notice"
```

The message body is the one field `telemetry_spool::redact` cannot filter - attributes are dropped unless allowlisted, but the body **always ships verbatim** to central OpenObserve. So anything interpolated there egresses regardless of whether it should.

## The fix is subtraction

`streak` was **already a structured field on the same call**, so the body was only duplicating it. Removing it from the body loses nothing. I added `needed` alongside it so the pair still reads as "n of m" without either number touching the body.

The count still reaches OpenObserve: as a `u32` it arrives as a `StringValue` (tracing-opentelemetry 0.28 has no `record_u64`, so it falls through to `record_debug`), and `redact::is_bare_number` keeps it because the whole value parses as a number.

## Why CI was green on both PRs and red once merged

| | |
|---|---|
| The message | `4a0a2fc4`, on `pre-main` since August |
| The guard that rejects it | #916, `b4f33de7` |

#916's branch predated the message, so its new guard never scanned that line. The violation exists only in the merge, which is the first place the two meet.

**This is the second "green individually, red combined" today** - #923 was the other, and it merged with no Rust CI at all because it was based on a feature branch. Neither is visible until after the merge lands on `pre-main`, which is also the moment it blocks a release. Worth considering a required merge-queue or an up-to-date-branch check, but that is a separate change and not this PR.

## Gate

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (27 binaries green), plus the full pre-push suite.

## Context

This is blocking the staging release cut for `pre-main`. Once this lands I will verify `pre-main` is green and cut `v1.91.0-staging.7`.