### PR TITLE
ci(release): wire OTP worker secrets into release-build.yml

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -459,6 +459,8 @@ jobs:
       MERIDIAN_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
       MERIDIAN_COUNTER_API_KEY: ${{ secrets.COUNTER_API_KEY }}
       MERIDIAN_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_PROD }}
+      MERIDIAN_OTP_API_URL: ${{ vars.MERIDIAN_OTP_API_URL }}
+      MERIDIAN_OTP_CLIENT_TOKEN: ${{ secrets.MERIDIAN_OTP_CLIENT_TOKEN }}
       MERIDIAN_CHANNEL: ${{ needs.prepare.outputs.channel }}
       # Signing + updater material. TAURI_SIGNING_* is consumed at BUNDLE time.
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -857,6 +859,8 @@ jobs:
       MERIDIAN_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
       MERIDIAN_COUNTER_API_KEY: ${{ secrets.COUNTER_API_KEY }}
       MERIDIAN_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_PROD }}
+      MERIDIAN_OTP_API_URL: ${{ vars.MERIDIAN_OTP_API_URL }}
+      MERIDIAN_OTP_CLIENT_TOKEN: ${{ secrets.MERIDIAN_OTP_CLIENT_TOKEN }}
       MERIDIAN_CHANNEL: ${{ needs.prepare.outputs.channel }}
       # The updater's minisign keypair is cross-platform — the SAME key signs
       # the macOS tarball and the Windows installer, and the pubkey baked into


### PR DESCRIPTION
## Summary
- Adds `MERIDIAN_OTP_API_URL` / `MERIDIAN_OTP_CLIENT_TOKEN` to `release-build.yml`'s macOS and Windows job env blocks, alongside the existing Clerk line (left untouched).

## Why
`release-build.yml` is always dispatched with branch = `main` (cache-scoping requirement enforced by the workflow's own guard step), regardless of which tag/tree is actually being built. `pre-main` already merged the OTP-capture replacement for Clerk (#929), whose `tray/src-tauri/src/commands/otp.rs` reads `MERIDIAN_OTP_API_URL`/`MERIDIAN_OTP_CLIENT_TOKEN` via `option_env!`. A staging build compiles that pre-main code but runs *this* workflow file from `main` — so without this change, `option_env!` resolves to `None` and the shipped binary reports `"not_configured"` for every OTP send/verify, confirmed against the actual `v1.91.0-staging.7` build logs.

## Scope
Pure CI plumbing — no application code on `main` changes. `main`'s own build still uses `MERIDIAN_CLERK_PUBLISHABLE_KEY`/Clerk as before; the two new vars are simply unused there until the real Clerk-removal work is promoted from `pre-main`. Landing them now unblocks correctly testing the OTP feature on staging in the meantime.

## Test plan
- [x] `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` (pre-push hook, full suite, passed)
- [x] UI build + UI tests (pre-push hook, passed)
- [ ] Re-run the staging release dispatch (branch = main, tag = a new staging tag) and confirm the macOS/Windows job env dump now includes both vars
- [ ] Confirm OTP send/verify works end-to-end on the resulting staging build without the `~/.meridian/.env` workaround

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated macOS and Windows release builds to include the configuration required for OTP services.
  - Ensured OTP service settings are embedded consistently in both desktop release packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->