### PR TITLE
fix(tray): quiesce the database pool across a daemon restage

### DIFF
--- a/tray/src-tauri/src/backend_install.rs
+++ b/tray/src-tauri/src/backend_install.rs
@@ -149,16 +149,59 @@ pub async fn ensure_backend_installed(app: &tauri::AppHandle) {
         return;
     }
 
-    // `ensure_backend_installed` runs off the setup hook, after `app.manage(db_pool)`
-    // (see `lib.rs`), so the pool is already there to raise/clear against —
-    // `None` only when the DB itself couldn't be opened, in which case there's
-    // nowhere to write a notice anyway.
-    let pool = app
+    // QUIESCE THE TRAY'S OWN POOL ACROSS THE RESTAGE.
+    //
+    // `install` below stops the running daemon, swaps its binary and bootstraps
+    // a new one. The outgoing daemon checkpoints and RESETS the WAL as it exits.
+    // A connection held across that reset keeps a stale `-shm` index: it still
+    // maps page numbers to WAL frames that have since been recycled for other
+    // pages, so reads AND writes through it silently address the wrong content.
+    //
+    // The tray is a writer here, not a bystander - the capture engine is
+    // appending to `capture_frames`/`capture_ui_events` throughout - so those
+    // misdirected writes deposit one page's bytes into another page's slot.
+    // Measured 2026-09-05: the tray opened the database 100 ms before it sent
+    // the stop signal, held it across the 15:54:23.168 checkpoint, and the
+    // resulting interior pages carried child pointers to pages 90143-90671 in a
+    // database whose highest page ever allocated was 90093 - pointers to space
+    // that has never existed, which is what a page written to the wrong slot
+    // looks like. One WAL file held two salt generations, the fingerprint of a
+    // reset spanned by a live connection. Fifth occurrence since 17 Aug.
+    //
+    // `DbPool::close`/`reopen` has existed since the 24 Aug incident for exactly
+    // this, but only `commands::daemon::reload_daemon` used it; the restage path
+    // - the one an ordinary user hits by installing an update while Meridian is
+    // running - never did.
+    //
+    // Every reader sees `get() == None` for the window and degrades exactly as
+    // it does on a cold start. That includes capture, which drops the handful of
+    // frames produced during the swap. Losing seconds of scratch capture is the
+    // cheap failure; the expensive one is the b-tree.
+    let db_handle = app
         .try_state::<crate::db_pool::DbPool>()
-        .and_then(|s| s.get());
+        .map(|s| s.inner().clone());
+    if let Some(h) = db_handle.as_ref() {
+        h.close().await;
+        tracing::info!("backend_install: closed the tray db pool for the restage");
+    }
 
     tracing::info!(hash = %bundled_hash, "backend_install: installing bundled backend");
-    if let Err(e) = install(&backend, &home).await {
+    let outcome = install(&backend, &home).await;
+
+    // Reopen BEFORE anything below touches the database. Unconditional on the
+    // install outcome: a failed stage leaves the OLD daemon to be restarted by
+    // `restore_unless_paused`, and the tray needs its pool back either way -
+    // leaving it closed would silently end capture and every dashboard read for
+    // the rest of the session, which is the failure mode `start_capture`'s doc
+    // describes.
+    if let Some(h) = db_handle.as_ref() {
+        h.reopen().await;
+        tracing::info!("backend_install: reopened the tray db pool after the restage");
+    }
+    // Re-read AFTER the reopen - a pool captured before `close` is the shut one.
+    let pool = db_handle.as_ref().and_then(|h| h.get());
+
+    if let Err(e) = outcome {
         tracing::error!(error = %e, "backend_install: install failed — will retry next launch");
         // Previously silent beyond the log line: staging/registration can fail
         // for reasons a user can actually act on (antivirus quarantining the
@@ -1626,6 +1669,69 @@ mod tests {
                  first is what makes the window silent. stop at {stop}, stage at {stage}"
             );
         }
+    }
+
+    /// The tray's pool must be CLOSED before the restage and REOPENED after.
+    ///
+    /// This is the fix for the corruption that has now happened five times on
+    /// one machine (17, 19, 20, 27 Aug and 5 Sep). `install` stops the running
+    /// daemon, and the outgoing daemon checkpoints and RESETS the WAL as it
+    /// goes. A connection held across that reset keeps a stale `-shm` index and
+    /// resolves page numbers to WAL frames that have since been recycled, so
+    /// writes through it land on the wrong pages. The tray is a writer here -
+    /// capture is appending to `capture_frames` throughout - so what it deposits
+    /// is one page's bytes in another page's slot. On 5 Sep that produced
+    /// interior pages pointing at pages 90143-90671 in a database whose highest
+    /// page ever allocated was 90093.
+    ///
+    /// Source-scanned because the ordering IS the behaviour and none of it can
+    /// be exercised in a unit test - it needs a real launchd domain, a real
+    /// daemon and a real WAL reset. The same idiom as the sibling scans here.
+    ///
+    /// Both halves are asserted, and the reopen is not optional politeness: a
+    /// pool left closed silently ends capture and every dashboard read for the
+    /// rest of the session, which would trade a corrupt database for a dead one.
+    #[test]
+    fn the_tray_pool_is_closed_across_the_restage_and_reopened_after() {
+        const SRC: &str = include_str!("backend_install.rs");
+        let prod = SRC
+            .split_once("\n#[cfg(test)]")
+            .map_or(SRC, |(before, _)| before);
+        let body = prod
+            .split_once("pub async fn ensure_backend_installed")
+            .expect("ensure_backend_installed must exist")
+            .1;
+        let end = ["\npub ", "\npub(crate) ", "\nasync fn", "\nfn "]
+            .iter()
+            .filter_map(|m| body.find(m))
+            .min()
+            .unwrap_or(body.len());
+        let body = &body[..end];
+
+        let close = body.find(".close().await").expect(
+            "ensure_backend_installed must close the tray's db pool before staging - a \
+             connection held across the outgoing daemon's WAL reset writes to the wrong \
+             pages, which is the recurring capture-table corruption",
+        );
+        let install = body
+            .find("install(&backend, &home).await")
+            .expect("ensure_backend_installed must call install()");
+        let reopen = body.find(".reopen().await").expect(
+            "ensure_backend_installed must reopen the pool after staging - leaving it \
+             closed ends capture and every dashboard read for the rest of the session",
+        );
+
+        assert!(
+            close < install,
+            "the pool must be closed BEFORE install(), not after - closing afterwards \
+             leaves the connection spanning the daemon restart, which is the whole bug. \
+             close at {close}, install at {install}"
+        );
+        assert!(
+            install < reopen,
+            "the pool must be reopened AFTER install() completes. install at {install}, \
+             reopen at {reopen}"
+        );
     }
 
     /// Staging must wait on the **daemon binary**, never on `meridian.db`.

--- a/tray/src-tauri/src/commands/pause.rs
+++ b/tray/src-tauri/src/commands/pause.rs
@@ -339,8 +339,15 @@ pub(crate) async fn resume_capture(
     }
 
     // Restart the capture engine so screen recording resumes.
+    //
+    // Takes the SWAPPABLE handle from managed state rather than cloning the raw
+    // `pool` this function was given. A raw clone keeps writing to the pool
+    // object `DbPool::close` shut, so capture would be dead from the next daemon
+    // restart onward - see `crate::start_capture`'s doc. `try_state` because a
+    // tray whose database never opened has no handle to manage, and capture
+    // degrades to dropping frames exactly as it already does on a cold start.
     #[cfg(feature = "capture")]
-    crate::start_capture(state.clone(), pool.cloned());
+    crate::restart_capture(app, state, "pause resumed");
 
     // Emit immediately so the popover reverts to the picker without waiting for the next tick.
     if let Ok(s) = state.lock() {

--- a/tray/src-tauri/src/lib.rs
+++ b/tray/src-tauri/src/lib.rs
@@ -653,20 +653,28 @@ pub fn run() {
                     // as it was before this span grew a wrapper): the capture
                     // feature is the only later consumer, but the clone itself is
                     // cheap and every build needs a value to return.
-                    let capture_pool = db_pool.clone();
                     // The encryption-state notice below needs a pool handle before
                     // db_pool is moved into managed state.
                     let encryption_notice_pool = db_pool.clone();
-                    // Wrapped so `commands::daemon::reload_daemon` can close and
-                    // reopen it around a daemon restart instead of holding one
-                    // connection across two different daemon process
-                    // generations — see `db_pool::DbPool`'s header for the
-                    // corruption incident this closes off.
-                    app.manage(db_pool::DbPool::new(
+                    // Wrapped so `commands::daemon::reload_daemon` and
+                    // `backend_install::install` can close and reopen it around a
+                    // daemon restart instead of holding one connection across two
+                    // different daemon process generations — see
+                    // `db_pool::DbPool`'s header for the corruption this closes
+                    // off.
+                    let handle = db_pool::DbPool::new(
                         db_pool,
                         db_path.clone(),
                         db_key_hex.clone(),
-                    ));
+                    );
+                    // Capture gets the HANDLE, not a pool clone. A clone would go
+                    // on writing to the pool object that `close()` shut, which is
+                    // both a dead capture engine and the reason quiescing across a
+                    // restage was not previously possible — see `start_capture`.
+                    // Returned from this closure so `app.manage` is guaranteed to
+                    // have run before capture starts.
+                    let capture_pool = handle.clone();
+                    app.manage(handle);
 
                     // Report the repair now that there is a pool to write a notice
                     // with. Deliberately after `app.manage`: the notice is the
@@ -676,7 +684,9 @@ pub fn run() {
                     // never the `db_pool` that was just moved above, and the
                     // pool is already managed by the time this block runs at all.
                     if let Some(outcome) = repair_outcome {
-                        if let Some(p) = capture_pool.clone() {
+                        // `.get()`: `capture_pool` is the swappable handle now, not
+                        // an `Option<SqlitePool>`. Same graceful skip when no pool is open.
+                        if let Some(p) = capture_pool.get() {
                             // Own the strings before the task takes them: the
                             // notice borrows its fields, and `outcome` cannot
                             // outlive this scope. `fault_cleared` decides both
@@ -874,8 +884,7 @@ pub fn run() {
 
                     capture_pool
                 }),
-            )
-            .flatten();
+            );
             // `.manage()` no-ops (returns `false`) when the type is already
             // managed — see `tauri::Manager::manage`'s doc — so this only takes
             // effect on the panic path above, where `app.manage(db_pool)` inside
@@ -1218,7 +1227,14 @@ pub fn run() {
             // isolation, so this matters). Frames → capture_frames (slice 4a),
             // input events → capture_ui_events (slice 3c).
             #[cfg(feature = "capture")]
-            start_capture(app_state.clone(), capture_pool);
+            // `capture_pool` is `None` only when the setup span panicked before it
+            // could build the handle. The fallback `app.manage` above guarantees
+            // one is managed even on that path, so fall through to it rather than
+            // leaving capture dead for the session.
+            match capture_pool {
+                Some(h) => start_capture(app_state.clone(), h),
+                None => restart_capture(app.handle(), &app_state, "setup panic fallback"),
+            }
 
             // Auto-open the setup wizard on first launch (no ~/.meridian/onboarded).
             // The 800 ms delay lets the tray menu settle before the window appears.
@@ -1680,10 +1696,52 @@ fn tray_debug(window: tauri::Window, msg: String) {
 /// # Who calls this
 /// Once from `lib.rs`'s `setup()` on launch, and again from
 /// `commands::pause_for_duration` on resume.
+/// Restart capture using the managed [`db_pool::DbPool`] handle.
+///
+/// Every resume path (pause expiry, disk-space recovery, work-hours start)
+/// wants the same thing, and the one way to get it wrong is to pass a raw
+/// `SqlitePool` clone instead - which is what all three did, and why capture
+/// died silently on the first `DbPool::close`. Centralised so there is one
+/// place to be right.
+///
+/// `try_state` rather than `state`: a tray whose database never opened manages
+/// no handle, and that must warn rather than panic in a poll tick.
+#[cfg(feature = "capture")]
+pub(crate) fn restart_capture(
+    app: &tauri::AppHandle,
+    app_state: &std::sync::Arc<std::sync::Mutex<AppState>>,
+    reason: &'static str,
+) {
+    use tauri::Manager as _;
+    match app.try_state::<db_pool::DbPool>() {
+        Some(h) => start_capture(app_state.clone(), h.inner().clone()),
+        None => tracing::warn!(reason, "no db pool handle managed - capture not restarted"),
+    }
+}
+
+/// `pool` is the SWAPPABLE [`db_pool::DbPool`] handle, not a bare
+/// `Option<SqlitePool>`.
+///
+/// The distinction is the whole point. This used to take a pool clone captured
+/// once at startup and hold it for the tray's entire life. `sqlx::Pool` is
+/// `Arc`-backed and `close()` closes the shared inner pool, so the moment
+/// anything called [`db_pool::DbPool::close`] every write here began failing -
+/// permanently, because the consumers never looked at the handle again and so
+/// never saw the reopened pool. `commands::daemon::reload_daemon` has been
+/// doing exactly that close/reopen since it was written, which means a daemon
+/// reload silently ended capture until the next tray restart.
+///
+/// That also blocked the fix for the recurring corruption: quiescing the pool
+/// across a daemon restage (`backend_install::install`) is the right move, and
+/// with a captured clone it would have traded a corrupt database for a dead
+/// capture engine. Reading `get()` per item makes both safe - a `None` during
+/// the restage window drops that item, which is the same graceful degradation
+/// every reader already has on a cold start, and the next item after `reopen`
+/// lands normally.
 #[cfg(feature = "capture")]
 pub(crate) fn start_capture(
     app_state: std::sync::Arc<std::sync::Mutex<AppState>>,
-    pool: Option<meridian_core::SqlitePool>,
+    pool: db_pool::DbPool,
 ) {
     use capture::{screenpipe::ScreenpipeEngine, CaptureEngine};
 
@@ -1783,7 +1841,8 @@ pub(crate) fn start_capture(
                         );
                         continue;
                     }
-                    let Some(p) = consumer_pool.as_ref() else {
+                    // Re-read the handle per item: see `start_capture`'s doc.
+                    let Some(p) = consumer_pool.get() else {
                         continue;
                     };
                     let row = meridian_core::CaptureFrameInsert {
@@ -1794,8 +1853,8 @@ pub(crate) fn start_capture(
                         text: frame.text,
                         text_source: frame.text_source.as_str().to_string(),
                     };
-                    if let Err(e) = meridian_core::insert_capture_frame(p, &row).await {
-                        tracing::warn!(error = %e, "capture: failed to persist frame");
+                    if let Err(e) = meridian_core::insert_capture_frame(&p, &row).await {
+                        tracing::warn!(error = %meridian::errors::chain(&e), "capture: failed to persist frame");
                     }
                 }
                 capture::CaptureItem::Secondary(sample) => {
@@ -1817,7 +1876,8 @@ pub(crate) fn start_capture(
                         );
                         continue;
                     }
-                    let Some(p) = consumer_pool.as_ref() else {
+                    // Re-read the handle per item: see `start_capture`'s doc.
+                    let Some(p) = consumer_pool.get() else {
                         continue;
                     };
                     let row = meridian_core::CaptureSecondaryScreenInsert {
@@ -1827,8 +1887,8 @@ pub(crate) fn start_capture(
                         window_name: sample.window_name,
                         text: sample.text,
                     };
-                    if let Err(e) = meridian_core::insert_capture_secondary_screen(p, &row).await {
-                        tracing::warn!(error = %e, "capture: failed to persist secondary-screen sample");
+                    if let Err(e) = meridian_core::insert_capture_secondary_screen(&p, &row).await {
+                        tracing::warn!(error = %meridian::errors::chain(&e), "capture: failed to persist secondary-screen sample");
                     }
                 }
             }
@@ -1873,9 +1933,10 @@ pub(crate) fn start_capture(
                     if ui_ignore.lock().unwrap().should_drop_app(ev.app_name.as_deref()) {
                         continue;
                     }
-                    let Some(p) = ui_pool.as_ref() else { continue };
-                    if let Err(e) = meridian_core::insert_capture_ui_event(p, &ev).await {
-                        tracing::warn!(error = %e, "capture: failed to persist ui event");
+                    // Re-read the handle per item: see `start_capture`'s doc.
+                    let Some(p) = ui_pool.get() else { continue };
+                    if let Err(e) = meridian_core::insert_capture_ui_event(&p, &ev).await {
+                        tracing::warn!(error = %meridian::errors::chain(&e), "capture: failed to persist ui event");
                     }
                 }
             }

--- a/tray/src-tauri/src/poll/mod.rs
+++ b/tray/src-tauri/src/poll/mod.rs
@@ -122,7 +122,7 @@ pub async fn run_poll_loop(app: tauri::AppHandle, state: Arc<Mutex<AppState>>) {
         // check_disk_space's doc comment for why writing into a nearly-full
         // disk must stop rather than degrade silently.
         if let Some(pool) = &pool {
-            check_disk_space(&state, pool).await;
+            check_disk_space(&app, &state, pool).await;
         }
         // Work-hours schedule enforcement: auto-pause capture outside the
         // configured window, auto-resume when entering it. Only fires when the
@@ -223,7 +223,11 @@ fn update_tray_icon(app: &tauri::AppHandle, state: &Arc<Mutex<AppState>>) {
 /// timer) is separately gated in [`crate::commands::pause::resume_capture`],
 /// so a still-low disk can't be resumed into from any direction — this
 /// function only owns the disk-low pause's own start/end transition.
-async fn check_disk_space(state: &Arc<Mutex<AppState>>, pool: &meridian_core::SqlitePool) {
+async fn check_disk_space(
+    app: &tauri::AppHandle,
+    state: &Arc<Mutex<AppState>>,
+    pool: &meridian_core::SqlitePool,
+) {
     let low = meridian::health::platform::meridian_data_low_gb().is_some();
 
     let (pause_source, started_at, capture_paused_flag) = {
@@ -348,7 +352,7 @@ async fn check_disk_space(state: &Arc<Mutex<AppState>>, pool: &meridian_core::Sq
             // capturing nothing) rather than a bug worth cross-checking
             // schedule state here too.
             #[cfg(feature = "capture")]
-            crate::start_capture(state.clone(), Some(pool.clone()));
+            crate::restart_capture(app, state, "disk space recovered");
             tracing::info!(duration_s, "disk-space guard: capture resumed");
         }
         _ => {
@@ -446,7 +450,7 @@ async fn check_work_hours(
             }
             // Restart engine so screen recording resumes.
             #[cfg(feature = "capture")]
-            crate::start_capture(state.clone(), Some(pool.clone()));
+            crate::restart_capture(app, state, "work hours started");
             tracing::info!(
                 duration_s,
                 "work-hours: schedule pause ended — capture resumed"


### PR DESCRIPTION
Fifth capture-table corruption on one machine since 17 Aug (17, 19, 20, 27 Aug, 5 Sep). The writer is **the tray's own connection**, held across the restage the tray itself initiates.

## Answering "didn't we already fix this?"

Four adjacent things were fixed, and none of them was this one:

| PR | What it fixed |
|---|---|
| #856 (24 Aug) | The **daemon** checkpoints its WAL on shutdown |
| #918 | Daemon shutdown joins background tasks before that checkpoint |
| #921 | **Recovery** - ETL un-latches; no checkpoint onto a swapped file |
| #926 | The **livelock** - staging waits on the daemon *binary*, not the database |

All daemon-side, detection-side, or recovery-side. `DbPool::close`/`reopen` was built for *this* hazard after the 24 Aug incident — and wired only into `reload_daemon`. The restage path, which is what an ordinary user hits by installing an update while Meridian is running, never used it.

#926 is in the failing build but is not implicated: `parse_lsof_holders` excludes the tray's own pid, so both the old database-wait and the new binary-wait were blind to this connection.

## Mechanism

`install` stops the daemon, swaps the binary, bootstraps a new one. The outgoing daemon checkpoints and **resets** the WAL on the way out. A connection held across that reset keeps a stale `-shm` index — it still maps page numbers to WAL frames since recycled for other pages, so reads *and writes* address the wrong content. The tray is a writer throughout (capture appends to `capture_frames`/`capture_ui_events`), so it deposits one page's bytes into another page's slot.

From the 5 Sep artifacts:

```
tray opened meridian.db      15:54:23.058
daemon SIGTERM               15:54:23.158   (+100 ms)
daemon shutdown checkpoint   15:54:23.168   WAL resets, salt advances
                                            tray connection still open
ETL healthy                  15:54:32
ETL malformed (code 11)      16:00:32
```

```
page_count            90,090
highest page ever     90,093
pointers in damaged interior pages:
  90143  90213  90288  90291  90670  90671   <- never existed
```

A truncated file overshoots by a little. These overshoot by up to 581 pages, so the bytes are not pointers at all — they are another page's content in the wrong slot. One WAL file held **two salt generations**, the fingerprint of a reset spanned by a live connection.

## Why it could not just be wired in

`start_capture` took a raw `Option<SqlitePool>` cloned once at startup. `sqlx::Pool` is `Arc`-backed and `close()` closes the shared inner pool, so calling `DbPool::close` killed every capture write **permanently** — the consumers never looked at the handle again, so they never saw the reopened pool. Wiring the fix in as-is would have traded a corrupt database for a dead capture engine.

**That is a live bug on its own:** `reload_daemon` has been closing and reopening since it was written, so a daemon reload has been silently ending capture until the next tray restart.

So capture takes the swappable handle and calls `get()` per item. `None` during the window drops that item — the same degradation every reader already has on a cold start — and the next item after `reopen` lands normally. Losing seconds of scratch capture is the cheap failure; the b-tree is the expensive one.

The three resume paths (pause expiry, disk-space recovery, work-hours start) all passed raw clones too, and now go through one `restart_capture` helper so there is a single place to be right.

## Also folded in

The report's **P2**: capture write sites logged `error = %e`, which renders only the outermost context and drops the SQLite result code — which is why the mechanism had to be reconstructed from the file rather than read from a log line. They use `errors::chain` now.

## Test

`the_tray_pool_is_closed_across_the_restage_and_reopened_after` pins that close precedes `install()` and reopen follows it. Source-scanned because the ordering *is* the behaviour and exercising it needs a real launchd domain, a real daemon and a real WAL reset.

**Teeth verified:** moving the close after `install()` fails it with the byte offsets named. Both halves are asserted — a pool left closed would end capture and every dashboard read for the session.

## Gate

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` — 2,064 tests green, 444 in `meridian-tray`. `capture` is a default feature, so all of this compiled and linted the changed path.

## Not in scope

- **Per-channel data roots** (report P1b). Production and staging sharing one `~/.meridian`, one staged daemon path and one launchd label is a real second cause and a bigger change.
- **Dev isolation** (P2). Belongs in a checked-in script.
- **Post-restage `quick_check`** (P3). Worth having; separate from the fix.